### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,46 @@ This file is intentionally brief. Detailed instructions live in focused docs:
   - [docs/architecture/request-lifecycle.md](./docs/architecture/request-lifecycle.md)
   - [docs/architecture/authentication.md](./docs/architecture/authentication.md)
   - [docs/architecture/data-storage.md](./docs/architecture/data-storage.md)
+
+## Cursor Cloud specific instructions
+
+# kody Cloud Agent Guide
+
+A full-stack web application starter built on Cloudflare Workers with Remix 3
+(alpha).
+
+## Quick Reference
+
+| Task             | Command             |
+| ---------------- | ------------------- |
+| Start dev server | `bun run dev`       |
+| Full validation  | `bun run validate`  |
+| Lint             | `bun run lint`      |
+| Format           | `bun run format`    |
+| Type check       | `bun run typecheck` |
+| Build            | `bun run build`     |
+| E2E tests        | `bun run test:e2e`  |
+
+## Services
+
+- **Dev server**: Runs at `localhost:3742` (Cloudflare Workers local)
+- `bun run dev` starts both the client esbuild watcher and Wrangler worker
+  server
+
+## Architecture
+
+- **Server**: Cloudflare Workers (see `worker/` and `server/`)
+- **Client**: Remix 3 components bundled with esbuild (see `client/`)
+- **Database**: Cloudflare D1 (SQLite, auto-handled locally by Wrangler)
+- **MCP Server**: Available at `/mcp` endpoint when worker runs
+
+## Documentation
+
+- [AGENTS.md](../AGENTS.md) - Agent instructions and verification steps
+- [docs/agents/remix/index.md](../docs/agents/remix/index.md) - Remix package
+  docs
+- [docs/agents/setup.md](../docs/agents/setup.md) - Setup documentation
+- [docs/agents/testing-principles.md](../docs/agents/testing-principles.md) -
+  Testing guidelines
+- [docs/agents/end-to-end-testing.md](../docs/agents/end-to-end-testing.md) -
+  E2E testing guide


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with durable guidance for future cloud agents working in this codebase.

### What's included

- Quick reference table for common dev commands (`bun run dev`, `bun run validate`, etc.)
- Service descriptions (dev server at `localhost:3742`, mock servers auto-started by `bun run dev`)
- Architecture overview (Cloudflare Workers, Remix 3, D1, MCP)
- Links to relevant documentation files

### Environment setup verified

- `bun install` - dependencies installed successfully
- `bun run lint` - 0 warnings, 0 errors
- `bun run typecheck` - clean
- `bun run build` - client + worker build successful
- `bun run dev` - dev server starts at `localhost:3742` with mock API servers
- Login with seeded test account (`me@kentcdodds.com`) and chat feature tested end-to-end
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c209ee6-98ec-45b3-a489-c76732a5a6d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c209ee6-98ec-45b3-a489-c76732a5a6d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

