### PR TITLE
Clarify Cursor Cloud agent instructions location

### DIFF
--- a/.cursor/CLOUD.md
+++ b/.cursor/CLOUD.md
@@ -3,6 +3,13 @@
 A full-stack web application starter built on Cloudflare Workers with Remix 3
 (alpha).
 
+## Maintainer note
+
+Cursor Cloud agent definitions/instructions live in this file. When changing
+Kody's Cursor Cloud agent behavior, update `.cursor/CLOUD.md` and keep
+`AGENTS.md` as the brief index. Add deeper guidance in `docs/agents` when
+needed.
+
 ## Quick Reference
 
 | Task             | Command             |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- document that Cursor Cloud agent definitions/instructions live in `.cursor/CLOUD.md`
- remind maintainers to keep `AGENTS.md` brief and add deeper docs under `docs/agents`

## Testing
- not run (docs change)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-878a55a7-9187-4737-8a42-cf7cac801ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-878a55a7-9187-4737-8a42-cf7cac801ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

