### PR TITLE
fix(test): bootstrap env for MCP e2e

### DIFF
--- a/docs/agents/mcp-apps-starter-guide.md
+++ b/docs/agents/mcp-apps-starter-guide.md
@@ -222,7 +222,7 @@ token values into widget CSS. If you do this in an MCP App resource, set
 ## Quality checklist before merge
 
 - `bun run format`
-- `bun run test:mcp`
+- `bun run test:mcp` (auto-prepares `packages/worker/.env` from `.env.example` when needed)
 - `bun run validate`
 - `bun run inspect`
 - Confirm docs in `docs/agents` reflect any new workflow or constraints.

--- a/docs/agents/setup.md
+++ b/docs/agents/setup.md
@@ -67,7 +67,9 @@ Quick notes for getting a local kody environment running.
 - `bun run format` applies formatting updates.
 - `bun run test:e2e:install` to install Playwright browsers.
 - `bun run test:e2e` to run Playwright specs.
-- `bun run test:mcp` to run MCP server E2E tests.
+- `bun run test:mcp` to run MCP server E2E tests. Like `test:e2e`, it prepares
+  `packages/worker/.env` from `.env.example` when needed so local and CI runs
+  have the minimum required test env.
 
 ## Documentation maintenance
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:e2e": "bun --no-env-file --env-file=packages/worker/.env tools/prepare-e2e-env.ts && playwright test",
     "test:e2e:ui": "bun --no-env-file --env-file=packages/worker/.env tools/prepare-e2e-env.ts && playwright test --ui",
     "test:e2e:install": "playwright install chromium --with-deps",
-    "test:mcp": "bun run build:mcp-apps && bun --no-env-file --env-file=packages/worker/.env test packages/worker/src/mcp/mcp-server-e2e.test.ts",
+    "test:mcp": "bun --no-env-file --env-file=packages/worker/.env tools/prepare-e2e-env.ts && bun run build:mcp-apps && bun --no-env-file --env-file=packages/worker/.env test packages/worker/src/mcp/mcp-server-e2e.test.ts",
     "nx:graph": "nx graph",
     "nx:show-projects": "nx show projects"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- revert the prior MCP runtime workaround so the app source stays unchanged
- make `bun run test:mcp` prepare `packages/worker/.env` the same way `bun run test:e2e` already does
- document the MCP test bootstrap behavior in the setup and MCP apps docs

## Root cause
- the failing CI/local timeout was caused by `test:mcp` not bootstrapping `packages/worker/.env`
- with no `.env`, MCP startup failed under the test harness and the client timed out waiting for initialization
- this was a test setup problem, not an MCP server runtime bug

## Testing
- `rm -f /workspace/packages/worker/.env && bun run test:mcp`
- `bun run lint`
- `bun run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-918c9a52-f774-4afe-b9ae-550acae9cbc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-918c9a52-f774-4afe-b9ae-550acae9cbc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the MCP test command automatically prepares the environment from example configuration when needed, ensuring consistent test execution across local and CI environments.

* **Tests**
  * Updated the MCP test command to automatically prepare required environment configuration before building and running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->