### PR TITLE
Fix malformed generated UI HTML injection

### DIFF
--- a/packages/worker/client/mcp-apps/generated-ui-shell.test.ts
+++ b/packages/worker/client/mcp-apps/generated-ui-shell.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'bun:test'
+import { injectIntoHtmlDocument } from './generated-ui-shell.ts'
+
+test('injectIntoHtmlDocument inserts into an existing head without adding an extra bracket', () => {
+	const result = injectIntoHtmlDocument(
+		'<!doctype html><html lang="en" class="demo"><head data-shell="true"><title>Demo</title></head><body></body></html>',
+		'<meta name="viewport" content="width=device-width, initial-scale=1" />',
+		'dark',
+	)
+
+	expect(result).toContain(
+		'<html lang="en" class="demo" data-kody-theme="dark">',
+	)
+	expect(result).toContain(
+		'<head data-shell="true">\n<meta name="viewport" content="width=device-width, initial-scale=1" />\n<title>Demo</title>',
+	)
+	expect(result).not.toContain('<head>>')
+	expect(result).not.toContain('<head data-shell="true">>')
+})
+
+test('injectIntoHtmlDocument preserves html attributes when injecting a missing head', () => {
+	const result = injectIntoHtmlDocument(
+		'<html lang="en" class="demo" data-app="shell"><body><main>Hello</main></body></html>',
+		'<style>body { color: red; }</style>',
+		'light',
+	)
+
+	expect(result).toContain(
+		'<html lang="en" class="demo" data-app="shell" data-kody-theme="light"><head><style>body { color: red; }</style></head><body><main>Hello</main></body></html>',
+	)
+})
+
+test('injectIntoHtmlDocument does not duplicate an existing theme attribute', () => {
+	const result = injectIntoHtmlDocument(
+		'<html lang="en" data-kody-theme="dark"><body></body></html>',
+		'<style>body { color: red; }</style>',
+		'light',
+	)
+
+	expect(result).toContain(
+		'<html lang="en" data-kody-theme="dark"><head><style>body { color: red; }</style></head><body></body></html>',
+	)
+	expect(result).not.toContain('data-kody-theme="light"')
+})

--- a/packages/worker/client/mcp-apps/generated-ui-shell.ts
+++ b/packages/worker/client/mcp-apps/generated-ui-shell.ts
@@ -42,6 +42,56 @@ function coerceTheme(value: unknown): ThemeName | null {
 	return value === 'light' || value === 'dark' ? value : null
 }
 
+function injectThemeAttributeIntoHtmlTag(
+	htmlTag: string,
+	theme: ThemeName | null,
+) {
+	if (!theme || /\bdata-kody-theme\s*=/i.test(htmlTag)) {
+		return htmlTag
+	}
+
+	const closingBracketIndex = htmlTag.lastIndexOf('>')
+	if (closingBracketIndex === -1) {
+		return htmlTag
+	}
+
+	return `${htmlTag.slice(0, closingBracketIndex)} data-kody-theme="${theme}">${htmlTag.slice(closingBracketIndex + 1)}`
+}
+
+export function injectIntoHtmlDocument(
+	code: string,
+	injection: string,
+	theme: ThemeName | null,
+) {
+	if (/<head\b[^>]*>/i.test(code)) {
+		const withTheme = theme
+			? code.replace(
+					/<html\b[^>]*>/i,
+					(match) => injectThemeAttributeIntoHtmlTag(match, theme),
+				)
+			: code
+
+		return withTheme.replace(
+			/<head\b[^>]*>/i,
+			(match) => `${match}\n${injection}\n`,
+		)
+	}
+
+	if (/<html\b[^>]*>/i.test(code)) {
+		return code.replace(
+			/<html\b[^>]*>/i,
+			(match) =>
+				`${injectThemeAttributeIntoHtmlTag(match, theme)}<head>${injection}</head>`,
+		)
+	}
+
+	if (/<\/body>/i.test(code)) {
+		return code.replace(/<\/body>/i, `${injection}\n</body>`)
+	}
+
+	return `${injection}\n${code}`
+}
+
 function getHostToolErrorMessage(result: HostToolResult | null) {
 	if (!result || result.isError !== true) return null
 	const structuredContent = isRecord(result.structuredContent)
@@ -484,29 +534,6 @@ ${code}
 		`.trim()
 	}
 
-	function injectIntoHtmlDocument(code: string) {
-		const theme = coerceTheme(latestRenderData?.theme)
-		const injection = buildHeadInjection(theme)
-		const themeAttribute = theme ? ` data-kody-theme="${theme}"` : ''
-		if (/<head[\s>]/i.test(code)) {
-			return code.replace(/<head([\s>]*)/i, `<head$1>\n${injection}\n`)
-		}
-		if (/<html[\s>]/i.test(code)) {
-			const withTheme =
-				themeAttribute && !/\bdata-kody-theme=/i.test(code)
-					? code.replace(/<html(\s*)/i, `<html${themeAttribute}$1`)
-					: code
-			return withTheme.replace(
-				/<html([\s>])/i,
-				`<html$1><head>${injection}</head>`,
-			)
-		}
-		if (/<\/body>/i.test(code)) {
-			return code.replace(/<\/body>/i, `${injection}\n</body>`)
-		}
-		return `${injection}\n${code}`
-	}
-
 	function setFrameSource(code: string, runtime: AppRuntime) {
 		if (runtime === 'javascript') {
 			const inlineModuleSource = buildInlineModuleSource(code)
@@ -532,8 +559,9 @@ ${inlineModuleSource}
 			return
 		}
 
+		const theme = coerceTheme(latestRenderData?.theme)
 		const htmlSource = /<(?:!doctype|html|head|body)\b/i.test(code)
-			? injectIntoHtmlDocument(code)
+			? injectIntoHtmlDocument(code, buildHeadInjection(theme), theme)
 			: buildHtmlDocumentFromFragment(code)
 		frameElement.srcdoc = htmlSource
 	}
@@ -705,10 +733,12 @@ ${inlineModuleSource}
 	void renderEnvelope(null)
 }
 
-if (document.readyState === 'loading') {
-	document.addEventListener('DOMContentLoaded', initializeGeneratedUiShell, {
+const documentRef = globalThis.document
+
+if (documentRef?.readyState === 'loading') {
+	documentRef.addEventListener('DOMContentLoaded', initializeGeneratedUiShell, {
 		once: true,
 	})
-} else {
+} else if (documentRef) {
 	initializeGeneratedUiShell()
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace partial opening-tag regex rewrites in `injectIntoHtmlDocument` with full-tag replacements
- preserve existing `<html ...>` attributes while injecting a missing `<head>` block
- add regression tests covering malformed `<head>>` output and theme attribute handling

## Testing
- bun test packages/worker/client/mcp-apps/generated-ui-shell.test.ts
- bun run build:mcp-apps
- bun run typecheck
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a141bbae-73f8-4ca2-aec0-ace5ed217b9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a141bbae-73f8-4ca2-aec0-ace5ed217b9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for HTML document injection behavior across multiple scenarios, including structure preservation.

* **Improvements**
  * Enhanced theme attribute injection to prevent duplicates and overwrites.
  * Improved handling of various HTML document formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->