### PR TITLE
Fix production APP_BASE_URL binding conflict

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
           COOKIE_SECRET: ${{ secrets.COOKIE_SECRET }}
-          APP_BASE_URL: ${{ vars.APP_BASE_URL }}
           AI_GATEWAY_ID: ${{ secrets.AI_GATEWAY_ID }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL }}
@@ -118,13 +117,38 @@ jobs:
         run: >
           bun tools/ci/sync-worker-secrets.ts --env production --config
           "$WRANGLER_CONFIG" --set-from-env COOKIE_SECRET --set-from-env
-          AI_GATEWAY_ID --set-from-env-optional APP_BASE_URL
-          --set-from-env-optional RESEND_API_KEY --set-from-env-optional
-          RESEND_FROM_EMAIL --set-from-env-optional SENTRY_DSN
-          --set-from-env-optional GITHUB_TOKEN --set-from-env-optional
-          CURSOR_API_KEY --set-from-env-optional CLOUDFLARE_API_BASE_URL
-          --set-from-env-optional CLOUDFLARE_API_TOKEN --set-from-env-optional
-          CAPABILITY_REINDEX_SECRET
+          AI_GATEWAY_ID --set-from-env-optional RESEND_API_KEY
+          --set-from-env-optional RESEND_FROM_EMAIL --set-from-env-optional
+          SENTRY_DSN --set-from-env-optional GITHUB_TOKEN
+          --set-from-env-optional CURSOR_API_KEY --set-from-env-optional
+          CLOUDFLARE_API_BASE_URL --set-from-env-optional CLOUDFLARE_API_TOKEN
+          --set-from-env-optional CAPABILITY_REINDEX_SECRET
+
+      - name: 🧹 Remove legacy APP_BASE_URL secret
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
+        run: |
+          set -euo pipefail
+          output=""
+          set +e
+          output="$(bunx wrangler secret delete APP_BASE_URL --env production --config "$WRANGLER_CONFIG" 2>&1)"
+          exit_code="$?"
+          set -e
+
+          if [ "$exit_code" -eq 0 ]; then
+            echo "$output"
+            exit 0
+          fi
+
+          lower="$(echo "$output" | tr '[:upper:]' '[:lower:]')"
+          if [[ "$lower" == *"not found"* ]] || [[ "$lower" == *"does not exist"* ]]; then
+            echo "Legacy APP_BASE_URL secret not present."
+            exit 0
+          fi
+
+          echo "$output" >&2
+          exit "$exit_code"
 
       - name: 🗄️ Apply D1 Migrations
         env:

--- a/docs/setup-manifest.md
+++ b/docs/setup-manifest.md
@@ -59,7 +59,7 @@ Local development uses `packages/worker/.env`, which Wrangler loads
 automatically:
 
 - `COOKIE_SECRET` (generate with `openssl rand -hex 32`)
- - `APP_BASE_URL` (optional; defaults to request origin, example
+- `APP_BASE_URL` (optional; defaults to request origin, example
   `https://app.example.com`; also sets the canonical public origin used for MCP
   auth metadata, generated UI resources, and email links)
 - `APP_COMMIT_SHA` (optional; set automatically by deploy workflows for
@@ -113,6 +113,9 @@ Configure these GitHub Actions secrets and variables for workflows:
 - `COOKIE_SECRET` (same format as local)
 - `APP_BASE_URL` (optional GitHub Actions **variable**, used by the production
   deploy as the canonical public app origin)
+  - Store this in GitHub Actions **Variables**, not **Secrets**. Production
+    deploy passes it as a Wrangler `--var`, so a legacy Worker secret with the
+    same name must be removed once during migration.
 - `AI_GATEWAY_ID` (required for production deploys that use remote AI inference)
 - `AI_GATEWAY_ID_PREVIEW` (required for preview deploys that use remote AI
   inference)
@@ -155,6 +158,9 @@ How to get/set each value:
 - `APP_BASE_URL` (optional)
   - Use your production app URL (for example `https://app.example.com`).
   - Add only if you want deploy-time health/version checks to use a fixed URL.
+  - If this value previously existed as a Worker secret, delete that legacy
+    `APP_BASE_URL` secret once so Cloudflare can accept the new non-secret var
+    binding.
 - `AI_GATEWAY_ID`
   - Create a Cloudflare AI Gateway in the dashboard and copy its production
     gateway ID.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- stop syncing `APP_BASE_URL` as a production Worker secret
- delete any legacy production `APP_BASE_URL` Worker secret before deploy so the new var binding can succeed
- document that `APP_BASE_URL` must live in GitHub Actions Variables, not Secrets

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a136f00-2608-491b-9201-8240d76b4613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a136f00-2608-491b-9201-8240d76b4613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

