### PR TITLE
Enable watch mode for home connector dev server

### DIFF
--- a/docs/agents/setup.md
+++ b/docs/agents/setup.md
@@ -44,7 +44,9 @@ Quick notes for getting a local kody environment running.
   it to both the worker and the connector so the outbound registration handshake
   succeeds in local development.)
 - The home automation connector now lives in `packages/home-connector`.
-  - `npm run dev:home-connector` starts the local connector app on Node 24.
+  - `npm run dev:home-connector` starts the local connector app on Node 24 with
+    `node --watch`, so connector code changes automatically restart the local
+    process.
   - The connector uses the `kentcdodds.com` mock bootstrap shape: only
     `packages/home-connector/index.ts` imports `packages/home-connector/mocks/`
     when `MOCKS=true`.

--- a/packages/home-connector/package.json
+++ b/packages/home-connector/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node server/dev-server.ts",
+    "dev": "node --watch server/dev-server.ts",
     "start": "NODE_ENV=production node --import ./src/sentry-init.ts index.ts",
     "start:mocks": "MOCKS=true ROKU_DISCOVERY_URL=http://roku.mock.local/discovery NODE_ENV=production node --import ./src/sentry-init.ts index.ts",
     "test": "vitest run --root ../.. --project node-unit packages/home-connector/src"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- run the home connector dev script with Node's `--watch` flag
- document that local connector code changes now auto-restart the process
- rebase this branch onto the latest `main`, which now includes `package-lock.json`

## Testing
- `npm --prefix packages/home-connector run test`
- launched `npm run dev:home-connector` with a lightweight fake worker endpoint and confirmed a source edit produced `Restarting 'server/dev-server.ts'` followed by a fresh `home-connector listening` log line

## Branch state
- rebased onto `origin/main` after `chore: restore npm lockfile (#56)`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b78b33a2-2fef-48dc-bd48-be87ec38fc0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b78b33a2-2fef-48dc-bd48-be87ec38fc0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions for the home automation connector to reflect the enhanced local development workflow.

* **Chores**
  * Improved local development by enabling automatic connector restarts when source changes are detected, simplifying iterative testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->