### PR TITLE
Prefer IP for Lutron LEAP connections

### DIFF
--- a/packages/home-connector/src/adapters/lutron/leap-client.ts
+++ b/packages/home-connector/src/adapters/lutron/leap-client.ts
@@ -207,10 +207,12 @@ function assertSuccessfulResponse(response: LeapResponse, action: string) {
 }
 
 export async function createLutronLeapClient(
-	processor: Pick<LutronPersistedProcessor, 'host' | 'leapPort'>,
+	processor: Pick<LutronPersistedProcessor, 'host' | 'address' | 'leapPort'>,
 ): Promise<LeapClient> {
+	// Prefer the raw IP to avoid .local mDNS lookups in worker runtimes.
+	const connectionHost = processor.address ?? processor.host
 	const socket = await createTlsSocket({
-		host: processor.host,
+		host: connectionHost,
 		port: processor.leapPort,
 	})
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- prefer the discovered IP address when opening Lutron LEAP TLS sockets
- keep mDNS host for identification while avoiding .local resolution failures
- add a short comment explaining the choice

## Testing
- npm run test -- packages/home-connector/src/adapters/lutron/index.test.ts

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d473c8e-14a4-4c05-b9e4-27fef0393d5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d473c8e-14a4-4c05-b9e4-27fef0393d5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lutron LEAP client now supports an alternative connection address, with automatic fallback to the default host when not specified, providing additional flexibility for device endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->