### PR TITLE
Fix value_get/value_set envelope outputs

### DIFF
--- a/packages/worker/client/mcp-apps/generated-ui-widget-runtime.ts
+++ b/packages/worker/client/mcp-apps/generated-ui-widget-runtime.ts
@@ -1205,9 +1205,7 @@ export function initializeGeneratedUiRuntime() {
 						...(coerceStorageScope(input.scope) ? { scope: input.scope } : {}),
 					}),
 				)
-				const saved = coerceValueMetadata(
-					isRecord(result) ? result.value : null,
-				)
+				const saved = coerceValueMetadata(result)
 				if (!saved) {
 					return { ok: false, error: 'Unable to save value.' }
 				}
@@ -1276,7 +1274,7 @@ export function initializeGeneratedUiRuntime() {
 					...(coerceStorageScope(input.scope) ? { scope: input.scope } : {}),
 				}),
 			)
-			return coerceValueMetadata(isRecord(result) ? result.value : null)
+			return coerceValueMetadata(result)
 		},
 		async listValues(input: any) {
 			const scope = coerceStorageScope(

--- a/packages/worker/src/mcp/capabilities/values/value-get.ts
+++ b/packages/worker/src/mcp/capabilities/values/value-get.ts
@@ -26,9 +26,7 @@ export const valueGetCapability = defineDomainCapability(
 					'Optional scope filter. When omitted, look up the value in accessible scopes in precedence order.',
 				),
 		}),
-		outputSchema: z.object({
-			value: valueMetadataSchema.nullable(),
-		}),
+		outputSchema: valueMetadataSchema.nullable(),
 		async handler(args, ctx: CapabilityContext) {
 			const user = requireMcpUser(ctx.callerContext)
 			const value = await getValue({
@@ -41,20 +39,18 @@ export const valueGetCapability = defineDomainCapability(
 					appId: ctx.callerContext.storageContext?.appId ?? null,
 				},
 			})
-			return {
-				value: value
-					? {
-							name: value.name,
-							scope: value.scope,
-							value: value.value,
-							description: value.description,
-							app_id: value.appId,
-							created_at: value.createdAt,
-							updated_at: value.updatedAt,
-							ttl_ms: value.ttlMs,
-						}
-					: null,
-			}
+			return value
+				? {
+						name: value.name,
+						scope: value.scope,
+						value: value.value,
+						description: value.description,
+						app_id: value.appId,
+						created_at: value.createdAt,
+						updated_at: value.updatedAt,
+						ttl_ms: value.ttlMs,
+					}
+				: null
 		},
 	},
 )

--- a/packages/worker/src/mcp/capabilities/values/value-set.ts
+++ b/packages/worker/src/mcp/capabilities/values/value-set.ts
@@ -32,9 +32,7 @@ export const valueSetCapability = defineDomainCapability(
 				.default('session')
 				.describe('Storage scope for the value.'),
 		}),
-		outputSchema: z.object({
-			value: valueMetadataSchema,
-		}),
+		outputSchema: valueMetadataSchema,
 		async handler(args, ctx: CapabilityContext) {
 			const user = requireMcpUser(ctx.callerContext)
 			const value = await saveValue({
@@ -50,16 +48,14 @@ export const valueSetCapability = defineDomainCapability(
 				},
 			})
 			return {
-				value: {
-					name: value.name,
-					scope: value.scope,
-					value: value.value,
-					description: value.description,
-					app_id: value.appId,
-					created_at: value.createdAt,
-					updated_at: value.updatedAt,
-					ttl_ms: value.ttlMs,
-				},
+				name: value.name,
+				scope: value.scope,
+				value: value.value,
+				description: value.description,
+				app_id: value.appId,
+				created_at: value.createdAt,
+				updated_at: value.updatedAt,
+				ttl_ms: value.ttlMs,
 			}
 		},
 	},

--- a/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
@@ -1467,8 +1467,8 @@ test('generated ui sessions support secret storage, execute-time resolution, and
 				})
 				const remaining = await codemode.value_list({})
 				return {
-					current: current.value,
-					appOnly: appOnly.value,
+					current,
+					appOnly,
 					listedNames: listed.values.map((value) => value.name + ':' + value.scope + ':' + value.value),
 					deleted: deleted.deleted,
 					remainingNames: remaining.values.map((value) => value.name + ':' + value.scope),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- unwrap value_get/value_set output schemas and return raw value metadata (or null)
- align generated UI widget helpers and MCP e2e flow with unwrapped results

## Testing
- npm run test:mcp

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae9f6802-9b49-474d-bd21-10d4ffcf946a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae9f6802-9b49-474d-bd21-10d4ffcf946a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected value metadata coercion handling in widget runtime for proper result processing.

* **Refactor**
  * Simplified API response structures for value get and set operations by removing unnecessary nesting, improving clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->