### PR TITLE
Enforce secret host allowlists

### DIFF
--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -1,0 +1,97 @@
+import { expect, test, vi } from 'vitest'
+import { expandSecretPlaceholders } from '#mcp/fetch-gateway.ts'
+import {
+	parseHostApprovalRequiredBatchMessage,
+} from '#mcp/secrets/errors.ts'
+import * as secretService from '#mcp/secrets/service.ts'
+
+const env = {
+	APP_DB: {} as D1Database,
+	COOKIE_SECRET: 'test-cookie-secret',
+}
+
+const props = {
+	baseUrl: 'https://example.com',
+	userId: 'user-123',
+	storageContext: null,
+}
+
+test('fetch gateway blocks placeholders when allowed hosts are empty', async () => {
+	const resolveSpy = vi
+		.spyOn(secretService, 'resolveSecret')
+		.mockResolvedValue({
+			found: true,
+			value: 'secret-value',
+			scope: 'user',
+			allowedHosts: [],
+			allowedCapabilities: [],
+		})
+	const request = new Request('https://example.com/api', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: 'Bearer {{secret:spotifyRefreshToken|scope=user}}',
+		},
+		body: JSON.stringify({
+			token: '{{secret:spotifyRefreshToken|scope=user}}',
+		}),
+	})
+
+	try {
+		await expandSecretPlaceholders({ request, props, env })
+		throw new Error('Expected host approval error.')
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		expect(message).toContain('Secrets require host approval:')
+		const approvals = parseHostApprovalRequiredBatchMessage(message)
+		expect(approvals).toEqual([
+			expect.objectContaining({
+				secretName: 'spotifyRefreshToken',
+				host: 'example.com',
+				approvalUrl: expect.stringMatching(
+					/\/account\/secrets\/user\/spotifyRefreshToken\?[^#]*allowed-host=example\.com[^#]*request=/,
+				),
+			}),
+		])
+	} finally {
+		resolveSpy.mockRestore()
+	}
+})
+
+test('fetch gateway allows placeholders for approved hosts', async () => {
+	const resolveSpy = vi
+		.spyOn(secretService, 'resolveSecret')
+		.mockResolvedValue({
+			found: true,
+			value: 'secret-value',
+			scope: 'user',
+			allowedHosts: ['example.com'],
+			allowedCapabilities: [],
+		})
+	const request = new Request('https://example.com/api', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: 'Bearer {{secret:spotifyRefreshToken|scope=user}}',
+		},
+		body: JSON.stringify({
+			token: '{{secret:spotifyRefreshToken|scope=user}}',
+		}),
+	})
+
+	try {
+		const transformed = await expandSecretPlaceholders({
+			request,
+			props,
+			env,
+		})
+		expect(transformed.headers.get('Authorization')).toBe(
+			'Bearer secret-value',
+		)
+		expect(await transformed.text()).toBe(
+			JSON.stringify({ token: 'secret-value' }),
+		)
+	} finally {
+		resolveSpy.mockRestore()
+	}
+})

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -46,11 +46,11 @@ export async function expandSecretPlaceholders(input: {
 }) {
 	const headers = new Headers(input.request.headers)
 	const requestBody = await readRequestBody(input.request)
-	const replacements = new Map<string, string>()
 	const resolvedSecrets: Array<{
 		referenced: ReferencedSecret
 		resolved: ResolvedSecret
 	}> = []
+	const replacements = new Map<string, string>()
 	const referencedSecrets = collectReferencedSecrets([
 		input.request.url,
 		...Array.from(headers.values()),
@@ -72,15 +72,19 @@ export async function expandSecretPlaceholders(input: {
 			throw new Error(createMissingSecretMessage(referenced.name))
 		}
 		const placeholder = buildSecretPlaceholder(referenced)
-		replacements.set(placeholder, resolved.value)
+		if (!replacements.has(placeholder)) {
+			replacements.set(placeholder, resolved.value)
+		}
 		resolvedSecrets.push({ referenced, resolved })
 	}
-	const nextUrl = replaceSecretPlaceholders(input.request.url, replacements)
 	let requestedHost = ''
 	if (hasReferencedSecrets) {
-		try {
-			requestedHost = new URL(nextUrl).hostname
-		} catch {
+		const nextUrl = replaceSecretPlaceholders(
+			input.request.url,
+			replacements,
+		)
+		requestedHost = readRequestedHost(nextUrl)
+		if (!requestedHost) {
 			throw new Error(
 				'Unable to resolve the request host after secret expansion.',
 			)
@@ -99,6 +103,7 @@ export async function expandSecretPlaceholders(input: {
 			)
 		}
 	}
+	const nextUrl = replaceSecretPlaceholders(input.request.url, replacements)
 	for (const [key, value] of Array.from(headers.entries())) {
 		headers.set(key, replaceSecretPlaceholders(value, replacements))
 	}
@@ -136,9 +141,9 @@ async function collectHostApprovalEntries(input: {
 }) {
 	const entries = await Promise.all(
 		input.resolvedSecrets.map(async ({ referenced, resolved }) => {
-			const allowedForHost = resolved.allowedHosts.includes(
-				input.normalizedHost,
-			)
+			const allowedForHost =
+				resolved.allowedHosts.length > 0 &&
+				resolved.allowedHosts.includes(input.normalizedHost)
 			if (allowedForHost) return null
 			const approvalToken = await createSecretHostApprovalToken(input.env, {
 				userId: input.props.userId!,
@@ -165,6 +170,14 @@ async function collectHostApprovalEntries(input: {
 	return entries.filter(
 		(entry): entry is NonNullable<typeof entry> => entry != null,
 	)
+}
+
+function readRequestedHost(url: string) {
+	try {
+		return new URL(url).hostname
+	} catch {
+		return ''
+	}
 }
 
 function ensureFetchAllowed(props: FetchGatewayProps) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- enforce deny-all behavior when allowed_hosts is empty in the fetch gateway
- keep host approval errors structured with approval URLs and blocked secret details
- add fetch gateway unit coverage for empty vs allowed host approvals

## Testing
- `npm run test -- --project node-unit packages/worker/src/mcp/fetch-gateway.node.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ca66875-95f9-45d2-8032-cd1978027b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ca66875-95f9-45d2-8032-cd1978027b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for secret placeholder expansion and host approval validation scenarios.

* **Bug Fixes**
  * Improved secret placeholder replacement to preserve existing mappings.
  * Enhanced host approval validation to properly enforce empty allowed hosts check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->