### PR TITLE
Refine home connector router tests

### DIFF
--- a/docs/agents/testing-principles.md
+++ b/docs/agents/testing-principles.md
@@ -22,6 +22,9 @@ magic.
   small number of important happy-path journeys.
 - Do not add regression tests for bugs that are unlikely to happen again unless
   the flow is important enough to justify the maintenance cost.
+- Avoid tests that only assert a string blob contains a description or other
+  incidental copy. Favor behavior-focused assertions (structured output,
+  user-visible outcomes, or stable public contracts) instead.
 - Run server/unit tests with `npm run test` (plus targeted Vitest paths when
   needed) to avoid Playwright spec discovery and accidental matches like
   `packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts`.

--- a/packages/home-connector/app/router.node.test.ts
+++ b/packages/home-connector/app/router.node.test.ts
@@ -45,27 +45,25 @@ function createAdapters(config: HomeConnectorConfig) {
 
 installHomeConnectorMockServer()
 
-test('home route renders admin dashboard links and connection info', async () => {
+test('home route toggles worker snapshot link by connector id', async () => {
 	const config = createConfig()
 	const { state, storage, lutron, samsungTv } = createAdapters(config)
 	state.connection.connectorId = 'default'
 	state.connection.workerUrl = 'http://localhost:3742'
-	state.connection.connected = true
-	state.connection.sharedSecret = 'secret'
 	try {
 		const router = createHomeConnectorRouter(state, config, lutron, samsungTv)
-		const response = await router.fetch('http://example.test/')
-		expect(response.status).toBe(200)
-		const html = await response.text()
-		expect(html).toContain('Home connector admin')
-		expect(html).toContain('/roku/status')
-		expect(html).toContain('/roku/setup')
-		expect(html).toContain('/lutron/status')
-		expect(html).toContain('/lutron/setup')
-		expect(html).toContain('/samsung-tv/status')
-		expect(html).toContain('/samsung-tv/setup')
-		expect(html).toContain('/home/connectors/default/snapshot')
-		expect(html).toContain('connected')
+		const responseWithConnector = await router.fetch('http://example.test/')
+		expect(responseWithConnector.status).toBe(200)
+		const htmlWithConnector = await responseWithConnector.text()
+		expect(htmlWithConnector).toContain('Home connector admin')
+		expect(htmlWithConnector).toContain('/home/connectors/default/snapshot')
+
+		state.connection.connectorId = ''
+		const responseWithoutConnector = await router.fetch('http://example.test/')
+		expect(responseWithoutConnector.status).toBe(200)
+		const htmlWithoutConnector = await responseWithoutConnector.text()
+		expect(htmlWithoutConnector).toContain('Home connector admin')
+		expect(htmlWithoutConnector).not.toContain('/home/connectors/default/snapshot')
 	} finally {
 		storage.close()
 	}
@@ -109,7 +107,7 @@ test('roku status route renders connector details', async () => {
 	}
 })
 
-test('roku status route renders last discovery diagnostics', async () => {
+test('roku status route renders discovery diagnostics summary', async () => {
 	const config = createConfig()
 	const { state, storage, lutron, samsungTv } = createAdapters(config)
 	state.rokuDiscoveryDiagnostics = {
@@ -122,25 +120,13 @@ test('roku status route renders last discovery diagnostics', async () => {
 				receivedAt: '2026-03-24T12:00:00.000Z',
 				remoteAddress: '192.168.1.45',
 				remotePort: 1900,
-				raw: 'HTTP/1.1 200 OK\r\nLOCATION: http://192.168.1.45:8060/\r\n',
-				location: 'http://192.168.1.45:8060/',
-				usn: 'uuid:roku:ecp:YH00AA123456',
+				raw: 'HTTP/1.1 200 OK\r\nLOCATION: http://roku.local:8060/\r\n',
+				location: 'http://roku.local:8060/',
+				usn: 'uuid:roku:ecp:ROKU-SAMPLE',
 				server: 'Roku/14.0.0 UPnP/1.0 Roku-ECP/1.0',
 			},
 		],
-		deviceInfoLookups: [
-			{
-				location: 'http://192.168.1.45:8060/',
-				deviceInfoUrl: 'http://192.168.1.45:8060/query/device-info',
-				raw: '<device-info><serial-number>YH00AA123456</serial-number></device-info>',
-				parsed: {
-					name: 'Living Room Roku',
-					serialNumber: 'YH00AA123456',
-					modelName: 'Roku Ultra',
-				},
-				error: null,
-			},
-		],
+		deviceInfoLookups: [],
 	}
 	try {
 		const router = createHomeConnectorRouter(state, config, lutron, samsungTv)
@@ -149,9 +135,8 @@ test('roku status route renders last discovery diagnostics', async () => {
 		const html = await response.text()
 		expect(html).toContain('Discovery diagnostics')
 		expect(html).toContain('Raw SSDP hits')
-		expect(html).toContain('192.168.1.45:1900')
-		expect(html).toContain('http://192.168.1.45:8060/query/device-info')
-		expect(html).toContain('YH00AA123456')
+		expect(html).toContain('http://roku.local:8060/')
+		expect(html).toContain('No device-info payloads were captured')
 	} finally {
 		storage.close()
 	}

--- a/packages/home-connector/app/router.node.test.ts
+++ b/packages/home-connector/app/router.node.test.ts
@@ -63,7 +63,7 @@ test('home route toggles worker snapshot link by connector id', async () => {
 		expect(responseWithoutConnector.status).toBe(200)
 		const htmlWithoutConnector = await responseWithoutConnector.text()
 		expect(htmlWithoutConnector).toContain('Home connector admin')
-		expect(htmlWithoutConnector).not.toContain('/home/connectors/default/snapshot')
+		expect(htmlWithoutConnector).not.toContain('Worker connector snapshot')
 	} finally {
 		storage.close()
 	}

--- a/packages/worker/client/app-session-refresh.node.test.ts
+++ b/packages/worker/client/app-session-refresh.node.test.ts
@@ -81,6 +81,4 @@ test('aborted refresh does not erase a ready authenticated session', async () =>
 	const uiAfterAbort = await renderToString(render())
 	expect(uiAfterAbort).toContain('signed-in@example.com')
 	expect(uiAfterAbort).toContain('Log out')
-	expect(uiAfterAbort).not.toContain('>Login<')
-	expect(uiAfterAbort).not.toContain('>Signup<')
 })

--- a/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
+++ b/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
@@ -13,7 +13,7 @@ import {
 	whenKodyWidgetReady,
 } from './kody-ui-utils.ts'
 
-test('injectIntoHtmlDocument inserts into an existing head without adding an extra bracket', () => {
+test('injectIntoHtmlDocument inserts content into an existing head', () => {
 	const result = injectIntoHtmlDocument(
 		'<!doctype html><html lang="en" class="demo"><head data-shell="true"><title>Demo</title></head><body></body></html>',
 		'<meta name="viewport" content="width=device-width, initial-scale=1" />',
@@ -21,10 +21,9 @@ test('injectIntoHtmlDocument inserts into an existing head without adding an ext
 
 	expect(result).toContain('<html lang="en" class="demo">')
 	expect(result).toContain(
-		'<head data-shell="true">\n<meta name="viewport" content="width=device-width, initial-scale=1" />\n<title>Demo</title>',
+		'<meta name="viewport" content="width=device-width, initial-scale=1" />',
 	)
-	expect(result).not.toContain('<head>>')
-	expect(result).not.toContain('<head data-shell="true">>')
+	expect(result).toContain('<title>Demo</title>')
 })
 
 test('injectIntoHtmlDocument preserves html attributes when injecting a missing head', () => {
@@ -49,7 +48,7 @@ test('injectIntoHtmlDocument preserves existing html attributes untouched', () =
 	)
 })
 
-test('absolutizeHtmlAttributeUrls resolves worker-relative urls without adding a base tag', () => {
+test('absolutizeHtmlAttributeUrls resolves worker-relative urls', () => {
 	const result = absolutizeHtmlAttributeUrls(
 		[
 			'<html><head><link rel="stylesheet" href="/styles.css" /></head><body>',
@@ -77,7 +76,6 @@ test('absolutizeHtmlAttributeUrls resolves worker-relative urls without adding a
 	expect(result).toContain(
 		'srcset="https://kody-production.kentcdodds.workers.dev/logo.png 1x, https://kody-production.kentcdodds.workers.dev/logo@2x.png 2x"',
 	)
-	expect(result).not.toContain('<base ')
 })
 
 test('absolutizeHtmlAttributeUrls leaves hash, data, and javascript urls untouched', () => {
@@ -174,10 +172,12 @@ test('buildCodemodeCapabilityExecuteCode serializes capability calls safely', ()
 		scope: 'app',
 	})
 
-	expect(code).toContain('async () => {')
-	expect(code).toContain('codemode["value_set"]')
-	expect(code).toContain('"name":"workspaceSlug"')
-	expect(code).toContain('"scope":"app"')
+	const [opener, invocation, closer] = code.split('\n')
+	expect(opener).toBe('async () => {')
+	expect(closer).toBe('}')
+	expect(invocation).toBe(
+		'  return await codemode["value_set"]({"name":"workspaceSlug","value":"kody","scope":"app"});',
+	)
 })
 
 test('getKodyWidget throws until the runtime is ready', () => {

--- a/packages/worker/src/app/saved-ui-hosted-html.node.test.ts
+++ b/packages/worker/src/app/saved-ui-hosted-html.node.test.ts
@@ -30,18 +30,44 @@ test('renderHostedSavedUiHtml emits shared runtime assets for html apps', () => 
 		appBaseUrl: 'https://kody.example',
 	})
 
-	expect(result).toContain(
-		'<link rel="stylesheet" href="https://kody.example/mcp-apps/kody-ui-utils.css" />',
+	const stylesheetMatch = result.match(
+		/<link rel="stylesheet" href="([^"]+kody-ui-utils\.css)" \/>/,
 	)
-	expect(result).toContain(
-		'<script type="module" src="https://kody.example/mcp-apps/kody-ui-utils.js"></script>',
+	expect(stylesheetMatch?.[1]).toBe(
+		'https://kody.example/mcp-apps/kody-ui-utils.css',
 	)
-	expect(result).toContain(
-		'<script type="importmap">{"imports":{"@kody/ui-utils":"https://kody.example/mcp-apps/kody-ui-utils.js"}}</script>',
+	const runtimeScriptMatch = result.match(
+		/<script type="module" src="([^"]+kody-ui-utils\.js)"><\/script>/,
 	)
-	expect(result).toContain(
-		'window.__kodyGeneratedUiBootstrap = {"mode":"hosted","appSession":{"token":"token-123","endpoints":{"source":"https://kody.example/ui-api/session-123/source","execute":"https://kody.example/ui-api/session-123/execute","secrets":"https://kody.example/ui-api/session-123/secrets","deleteSecret":"https://kody.example/ui-api/session-123/secrets/delete"}}};',
+	expect(runtimeScriptMatch?.[1]).toBe(
+		'https://kody.example/mcp-apps/kody-ui-utils.js',
 	)
+	const importMapMatch = result.match(
+		/<script type="importmap">([^<]+)<\/script>/,
+	)
+	expect(importMapMatch).not.toBeNull()
+	const importMap = JSON.parse(importMapMatch?.[1] ?? '{}') as {
+		imports?: Record<string, string>
+	}
+	expect(importMap.imports?.['@kody/ui-utils']).toBe(
+		'https://kody.example/mcp-apps/kody-ui-utils.js',
+	)
+	const bootstrapMatch = result.match(
+		/window\.__kodyGeneratedUiBootstrap = ([^;]+);/,
+	)
+	expect(bootstrapMatch).not.toBeNull()
+	const bootstrap = JSON.parse(bootstrapMatch?.[1] ?? '{}') as {
+		mode?: string
+		appSession?: { token?: string; endpoints?: Record<string, string> }
+	}
+	expect(bootstrap.mode).toBe('hosted')
+	expect(bootstrap.appSession?.token).toBe('token-123')
+	expect(bootstrap.appSession?.endpoints).toEqual({
+		source: 'https://kody.example/ui-api/session-123/source',
+		execute: 'https://kody.example/ui-api/session-123/execute',
+		secrets: 'https://kody.example/ui-api/session-123/secrets',
+		deleteSecret: 'https://kody.example/ui-api/session-123/secrets/delete',
+	})
 })
 
 test('renderHostedSavedUiHtml keeps user javascript separate from runtime bootstrap', () => {
@@ -61,14 +87,26 @@ test('renderHostedSavedUiHtml keeps user javascript separate from runtime bootst
 		appBaseUrl: 'https://kody.example',
 	})
 
-	expect(result).toContain(
-		'<script type="module" src="https://kody.example/mcp-apps/kody-ui-utils.js"></script>',
+	const importMapMatch = result.match(
+		/<script type="importmap">([^<]+)<\/script>/,
+	)
+	expect(importMapMatch).not.toBeNull()
+	const importMap = JSON.parse(importMapMatch?.[1] ?? '{}') as {
+		imports?: Record<string, string>
+	}
+	expect(importMap.imports?.['@kody/ui-utils']).toBe(
+		'https://kody.example/mcp-apps/kody-ui-utils.js',
 	)
 	expect(result).toContain(
-		'<script type="importmap">{"imports":{"@kody/ui-utils":"https://kody.example/mcp-apps/kody-ui-utils.js"}}</script>',
+		'<script type="module">\n' +
+			'document.querySelector("[data-generated-ui-root]")?.append("hello")',
 	)
-	expect(result).toContain(
-		'<script type="module">\ndocument.querySelector("[data-generated-ui-root]")?.append("hello")',
+	const bootstrapMatch = result.match(
+		/window\.__kodyGeneratedUiBootstrap = ([^;]+);/,
 	)
-	expect(result).not.toContain('const appSession =')
+	expect(bootstrapMatch).not.toBeNull()
+	const bootstrap = JSON.parse(bootstrapMatch?.[1] ?? '{}') as {
+		appSession?: { token?: string }
+	}
+	expect(bootstrap.appSession?.token).toBe('token-123')
 })

--- a/packages/worker/src/mcp/capabilities/capability-search.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.workers.test.ts
@@ -74,7 +74,10 @@ test('offline search returns provided specs without depending on global ranks', 
 	expect(offline).toBe(true)
 	expect(matches).toHaveLength(1)
 	expect(matches[0]?.name).toBe('generated_ui_oauth_guide')
-	expect(matches[0]?.description).toContain('OAuth callback')
+	expect(matches[0]?.keywords).toEqual(
+		expect.arrayContaining(['oauth', 'redirect uri', 'provider registration']),
+	)
+	expect(matches[0]?.outputFields).toEqual(['title', 'body'])
 	expect(matches[0]?.lexicalRank).toBe(1)
 	expect(matches[0]?.vectorRank).toBe(1)
 })

--- a/packages/worker/src/mcp/capabilities/coding/generated-ui-oauth-guide.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/coding/generated-ui-oauth-guide.node.test.ts
@@ -20,10 +20,10 @@ test('generated_ui_oauth_guide distinguishes PKCE and server-side exchange helpe
 	expect(result.body).toContain(
 		'exchangeOAuthCodeWithSecrets({ tokenUrl, code, redirectUri, clientId, clientSecretSecretName, scope?, extraParams? })',
 	)
+	expect(result.body).toContain('Choosing the exchange helper')
 	expect(result.body).toContain(
 		'prefer `exchangePkceOAuthCode(...)` when the provider supports PKCE',
 	)
 	expect(result.body).toContain('`exchangeOAuthCodeWithSecrets(...)`')
 	expect(result.body).toContain('run server-side')
-	expect(result.body).not.toContain('exchangeOAuthCode({ tokenUrl')
 })

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
@@ -162,7 +162,7 @@ test('meta_list_capabilities includes runtime home capabilities from the connect
 	)
 	expect(homeCapability).not.toBeUndefined()
 	expect(homeCapability?.domain).toBe('home')
-	expect(homeCapability?.description).toContain('Roku')
+	expect(homeCapability?.description).toBeTruthy()
 	expect(homeCapability?.requiredInputFields).toEqual(['deviceId', 'key'])
 	expect(listAppsCapability).not.toBeUndefined()
 	expect(listAppsCapability?.requiredInputFields).toEqual(['deviceId'])

--- a/packages/worker/src/mcp/skills/skill-embed-and-flags.node.test.ts
+++ b/packages/worker/src/mcp/skills/skill-embed-and-flags.node.test.ts
@@ -69,11 +69,29 @@ test('buildSkillEmbedText includes denormalized capability text', () => {
 		parameters,
 		specs: fakeSpecs,
 	})
-	expect(text).toContain('ui_save_app')
-	expect(text).toContain('owner')
-	expect(text).toContain('GitHub automation')
-	expect(text).toContain('github-automation')
-	expect(text.toLowerCase()).toContain('generated ui artifact')
+	const lines = text.split('\n')
+	expect(lines).toEqual(
+		expect.arrayContaining([
+			't',
+			'd',
+			'collection GitHub automation',
+			'github-automation',
+			'k',
+			'meta',
+			'skill',
+			'owner: GitHub repo owner. (string)',
+		]),
+	)
+	const denormalizedLines = lines.slice(lines.indexOf('owner: GitHub repo owner. (string)') + 1)
+	expect(denormalizedLines).toEqual(
+		expect.arrayContaining([
+			'ui_save_app',
+			capabilityDomainNames.apps,
+			'Save a generated UI artifact.',
+			'app ui artifact',
+			'title description keywords source app_id',
+		]),
+	)
 })
 
 test('validateSkillSaveFlags rejects read_only with destructive inferred set', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace brittle UI copy/absence assertions with behavior-focused checks in session refresh, UI utils, saved UI hosting, OAuth guide, and skill embed tests
- parse runtime bootstrap/import map content to validate structured behavior instead of raw HTML string fragments
- verify denormalized skill embed content using stable line structure rather than incidental wording
- update testing guidelines to discourage string-contains-only assertions on incidental copy
- remove description-substring assertions in capability tests, replacing them with structured field checks

## Testing
- npm run test -- packages/worker/client/app-session-refresh.node.test.ts packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts packages/worker/src/app/saved-ui-hosted-html.node.test.ts packages/worker/src/mcp/capabilities/coding/generated-ui-oauth-guide.node.test.ts packages/worker/src/mcp/skills/skill-embed-and-flags.node.test.ts
- npm run test -- packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts packages/worker/src/mcp/capabilities/capability-search.workers.test.ts

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5521f7d-0833-4d06-8d78-da6f490a9064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5521f7d-0833-4d06-8d78-da6f490a9064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidelines to prioritize behavior-focused assertions and structured output validation over content matching in free-form text.

* **Tests**
  * Refactored test assertions across multiple modules to use structured parsing (regex, JSON, line-based decomposition) instead of substring matching, improving test robustness and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->