### PR TITLE
Start dev mocks in parallel

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -597,6 +597,17 @@ async function attachCloudflareMock(
 	console.log(dim(`Cloudflare mock base URL ${baseUrl}`))
 }
 
+async function attachOptionalMocksInParallel(
+	mockEnv: Record<string, string>,
+	anchorPort: number,
+) {
+	await Promise.all([
+		attachGithubMock(mockEnv, anchorPort),
+		attachCloudflareMock(mockEnv, anchorPort),
+		attachCursorMock(mockEnv, anchorPort),
+	])
+}
+
 async function ensureMockServers() {
 	const previousMockEnvOverrides = { ...mockEnvOverrides }
 	const desiredAiMode = resolveAiMode()
@@ -625,9 +636,7 @@ async function ensureMockServers() {
 			resendForAnchor.port || String(defaultMockPort),
 			10,
 		)
-		await attachGithubMock(mockEnvOverrides, anchorFromReuse)
-		await attachCloudflareMock(mockEnvOverrides, anchorFromReuse)
-		await attachCursorMock(mockEnvOverrides, anchorFromReuse)
+		await attachOptionalMocksInParallel(mockEnvOverrides, anchorFromReuse)
 		return mockEnvOverrides
 	}
 
@@ -703,15 +712,26 @@ async function ensureMockServers() {
 		if (!hasEnvValue(process.env.RESEND_FROM_EMAIL)) {
 			mockEnvOverrides.RESEND_FROM_EMAIL = 'reset@kody.dev'
 		}
-		const didStart = await waitForMockReady(baseUrl, child)
-		if (!didStart) {
-			console.warn(
-				`Mock API worker did not become ready within ${mockReadyTimeoutMs}ms.`,
-			)
-		}
-		console.log(dim(`Mock API worker running at ${baseUrl}`))
-		console.log(dim(`Resend mock base URL ${baseUrl}`))
 	}
+
+	const pendingMockStarts: Array<Promise<void>> = []
+	const resendBaseUrl = mockEnvOverrides.RESEND_API_BASE_URL
+	if (resendBaseUrl && mockResendProcess && !canReuseCachedResendEnv) {
+		pendingMockStarts.push(
+			(async () => {
+				const didStart = await waitForMockReady(resendBaseUrl, mockResendProcess)
+				if (!didStart) {
+					console.warn(
+						`Mock API worker did not become ready within ${mockReadyTimeoutMs}ms.`,
+					)
+				}
+				console.log(dim(`Mock API worker running at ${resendBaseUrl}`))
+				console.log(dim(`Resend mock base URL ${resendBaseUrl}`))
+			})(),
+		)
+	}
+
+	const optionalMocksReady = attachOptionalMocksInParallel(mockEnvOverrides, mockPort)
 
 	if (desiredAiMode === 'mock') {
 		if (canReuseCachedAiEnv) {
@@ -719,47 +739,48 @@ async function ensureMockServers() {
 				previousMockEnvOverrides.AI_MOCK_BASE_URL ?? ''
 			mockEnvOverrides.AI_MOCK_API_KEY =
 				previousMockEnvOverrides.AI_MOCK_API_KEY ?? ''
-			await attachGithubMock(mockEnvOverrides, mockPort)
-			await attachCloudflareMock(mockEnvOverrides, mockPort)
-			await attachCursorMock(mockEnvOverrides, mockPort)
-			return mockEnvOverrides
-		}
-		const aiPort = await getPort({
-			port: Array.from({ length: 10 }, (_, index) => mockPort + 10 + index),
-		})
-		const aiBaseUrl = `http://127.0.0.1:${aiPort}`
-		const aiApiToken = `mock-ai-${randomUUID()}`
-		const aiChild = runNpmScript(
-			'dev:mock-ai',
-			[
-				'--port',
-				String(aiPort),
-				'--ip',
-				'127.0.0.1',
-				'--var',
-				`MOCK_API_TOKEN:${aiApiToken}`,
-			],
-			{},
-			{
-				label: 'dev:mock-ai',
-				mode: 'buffer-on-error',
-			},
-		)
-		mockAiProcess = aiChild
-		aiChild.once('exit', () => {
-			if (mockAiProcess === aiChild) {
-				mockAiProcess = null
-			}
-		})
-		mockEnvOverrides.AI_MOCK_BASE_URL = aiBaseUrl
-		mockEnvOverrides.AI_MOCK_API_KEY = aiApiToken
-		const aiDidStart = await waitForMockReady(aiBaseUrl, aiChild)
-		if (!aiDidStart) {
-			console.warn(
-				`Mock AI worker did not become ready within ${mockReadyTimeoutMs}ms.`,
+		} else {
+			const aiPort = await getPort({
+				port: Array.from({ length: 10 }, (_, index) => mockPort + 10 + index),
+			})
+			const aiBaseUrl = `http://127.0.0.1:${aiPort}`
+			const aiApiToken = `mock-ai-${randomUUID()}`
+			const aiChild = runNpmScript(
+				'dev:mock-ai',
+				[
+					'--port',
+					String(aiPort),
+					'--ip',
+					'127.0.0.1',
+					'--var',
+					`MOCK_API_TOKEN:${aiApiToken}`,
+				],
+				{},
+				{
+					label: 'dev:mock-ai',
+					mode: 'buffer-on-error',
+				},
+			)
+			mockAiProcess = aiChild
+			aiChild.once('exit', () => {
+				if (mockAiProcess === aiChild) {
+					mockAiProcess = null
+				}
+			})
+			mockEnvOverrides.AI_MOCK_BASE_URL = aiBaseUrl
+			mockEnvOverrides.AI_MOCK_API_KEY = aiApiToken
+			pendingMockStarts.push(
+				(async () => {
+					const aiDidStart = await waitForMockReady(aiBaseUrl, aiChild)
+					if (!aiDidStart) {
+						console.warn(
+							`Mock AI worker did not become ready within ${mockReadyTimeoutMs}ms.`,
+						)
+					}
+					console.log(dim(`AI mock base URL ${aiBaseUrl}`))
+				})(),
 			)
 		}
-		console.log(dim(`AI mock base URL ${aiBaseUrl}`))
 	} else {
 		if (mockAiProcess && !mockAiProcess.killed) {
 			await stopChild(mockAiProcess)
@@ -769,9 +790,7 @@ async function ensureMockServers() {
 		mockEnvOverrides.AI_MOCK_API_KEY = ''
 	}
 
-	await attachGithubMock(mockEnvOverrides, mockPort)
-	await attachCloudflareMock(mockEnvOverrides, mockPort)
-	await attachCursorMock(mockEnvOverrides, mockPort)
+	await Promise.all([...pendingMockStarts, optionalMocksReady])
 
 	return mockEnvOverrides
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- start the independent dev mock workers in parallel instead of awaiting GitHub, Cloudflare, and Cursor one-by-one
- preserve existing mock env wiring, readiness checks, and reuse behavior for resend and AI mocks
- wait for the full mock startup batch to be ready before launching the main worker

## Testing
- `npm run dev` and wait for `http://localhost:3742/health` to return `{ "ok": true }`
- query all mock `__mocks/meta` endpoints after startup to confirm every mock is reachable
- inspect the startup log to confirm mock readiness messages now arrive as an overlapping batch rather than a fixed serial sequence

## Evidence
- startup log artifact: `/opt/cursor/artifacts/mock-server-parallel-startup.log`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03b2f0bd-358f-49d7-bd82-7f60e649f5b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03b2f0bd-358f-49d7-bd82-7f60e649f5b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

