### PR TITLE
Show editable default fields on connect secret

### DIFF
--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -217,12 +217,12 @@ function readRequestedHost(href: string) {
 
 function normalizeSingleAllowedHost(host: string | null) {
 	if (!host) return null
-	return clientNormalizeAllowedHosts([host])[0] ?? null
+	return normalizeAllowedHosts([host])[0] ?? null
 }
 
 function normalizeSingleAllowedCapability(capability: string | null) {
 	if (!capability) return null
-	return clientNormalizeAllowedCapabilities([capability])[0] ?? null
+	return normalizeAllowedCapabilities([capability])[0] ?? null
 }
 
 function getAlreadyAddedNotice(input: {
@@ -235,12 +235,12 @@ function getAlreadyAddedNotice(input: {
 		readCapabilityPrefill(input.href),
 	)
 	const allowedHosts = input.selectedSecret
-		? clientNormalizeAllowedHosts(coerceStringRows(input.selectedSecret.allowedHosts))
+		? normalizeAllowedHosts(coerceStringRows(input.selectedSecret.allowedHosts))
 		: input.approval
-			? clientNormalizeAllowedHosts(input.approval.currentAllowedHosts)
+			? normalizeAllowedHosts(input.approval.currentAllowedHosts)
 			: []
 	const allowedCapabilities = input.selectedSecret
-		? clientNormalizeAllowedCapabilities(
+		? normalizeAllowedCapabilities(
 				coerceStringRows(input.selectedSecret.allowedCapabilities),
 			)
 		: []

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -25,6 +25,7 @@ import {
 	transitions,
 	typography,
 } from '#client/styles/tokens.ts'
+import { SecretEditorFields } from './secret-editor-fields.tsx'
 
 type SecretScope = 'app' | 'user'
 
@@ -1205,271 +1206,39 @@ export function AccountSecretsRoute(handle: Handle) {
 										})
 									: null}
 
-								<label css={fieldCss}>
-									<span css={fieldLabelCss}>Description</span>
-									<textarea
-										value={editorState.description}
-										rows={3}
-										placeholder="What this secret is used for"
-										on={{
-											input: (event) => {
-												editorState = {
-													...editorState,
-													description: event.currentTarget.value,
-												}
-												handle.update()
-											},
-										}}
-										css={textareaCss}
-									/>
-								</label>
-
-								<label css={fieldCss}>
-									<span css={fieldLabelCss}>Secret value</span>
-									<div
-										css={{
-											position: 'relative',
-											display: 'flex',
-											alignItems: 'center',
-										}}
-									>
-										{showSecretValue ? (
-											<input
-												type="text"
-												required
-												autoComplete="new-password"
-												value={editorState.value}
-												placeholder="Enter the secret value"
-												on={{
-													input: (event) => {
-														editorState = {
-															...editorState,
-															value: event.currentTarget.value,
-														}
-														handle.update()
-													},
-												}}
-												css={{
-													...inputCss,
-													paddingRight: '3rem',
-												}}
-											/>
-										) : (
-											<input
-												type="password"
-												required
-												autoComplete="new-password"
-												value={editorState.value}
-												placeholder="Enter the secret value"
-												on={{
-													input: (event) => {
-														editorState = {
-															...editorState,
-															value: event.currentTarget.value,
-														}
-														handle.update()
-													},
-												}}
-												css={{
-													...inputCss,
-													paddingRight: '3rem',
-												}}
-											/>
-										)}
-										<button
-											type="button"
-											aria-label={
-												showSecretValue
-													? 'Hide secret value'
-													: 'Show secret value'
-											}
-											title={
-												showSecretValue
-													? 'Hide secret value'
-													: 'Show secret value'
-											}
-											on={{
-												click: () => {
-													showSecretValue = !showSecretValue
-													handle.update()
-												},
-											}}
-											css={{
-												position: 'absolute',
-												right: spacing.sm,
-												background: 'none',
-												border: 'none',
-												padding: 0,
-												color: colors.textMuted,
-												cursor: 'pointer',
-												display: 'flex',
-												alignItems: 'center',
-												justifyContent: 'center',
-												'&:hover': {
-													color: colors.text,
-												},
-											}}
-										>
-											{showSecretValue ? (
-												<svg
-													xmlns="http://www.w3.org/2000/svg"
-													width="20"
-													height="20"
-													viewBox="0 0 24 24"
-													fill="none"
-													stroke="currentColor"
-													stroke-width="2"
-													stroke-linecap="round"
-													stroke-linejoin="round"
-												>
-													<path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
-													<path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68" />
-													<path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61" />
-													<line x1="2" x2="22" y1="2" y2="22" />
-												</svg>
-											) : (
-												<svg
-													xmlns="http://www.w3.org/2000/svg"
-													width="20"
-													height="20"
-													viewBox="0 0 24 24"
-													fill="none"
-													stroke="currentColor"
-													stroke-width="2"
-													stroke-linecap="round"
-													stroke-linejoin="round"
-												>
-													<path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
-													<circle cx="12" cy="12" r="3" />
-												</svg>
-											)}
-										</button>
-									</div>
-								</label>
-
-								<div css={{ display: 'grid', gap: spacing.sm }}>
-									<div css={{ display: 'grid', gap: spacing.xs }}>
-										<span css={fieldLabelCss}>Allowed hosts</span>
-										<p css={{ margin: 0, color: colors.textMuted }}>
-											Leave this empty to require explicit host approval before
-											a secret can be used.
-										</p>
-									</div>
-									<div
-										css={{ display: 'grid', gap: spacing.sm }}
-										data-repeat-list="allowed-hosts"
-									>
-										{editorState.allowedHosts.map((host, index) => (
-											<div
-												key={index}
-												css={{
-													display: 'grid',
-													gridTemplateColumns: 'minmax(0, 1fr) auto',
-													gap: spacing.sm,
-													[mq.mobile]: {
-														gridTemplateColumns: '1fr',
-													},
-												}}
-											>
-												<input
-													type="text"
-													value={typeof host === 'string' ? host : ''}
-													placeholder="api.example.com"
-													on={{
-														input: (event) =>
-															updateAllowedHost(
-																index,
-																event.currentTarget.value,
-															),
-													}}
-													css={inputCss}
-												/>
-												<button
-													type="button"
-													on={{ click: () => removeAllowedHost(index) }}
-													css={secondaryButtonCss}
-												>
-													Remove
-												</button>
-											</div>
-										))}
-									</div>
-									<div>
-										<button
-											type="button"
-											on={{ click: addAllowedHost }}
-											css={secondaryButtonCss}
-										>
-											Add host
-										</button>
-									</div>
-								</div>
-
-								<div css={{ display: 'grid', gap: spacing.sm }}>
-									<div css={{ display: 'grid', gap: spacing.xs }}>
-										<span css={fieldLabelCss}>Allowed capabilities</span>
-										<p css={{ margin: 0, color: colors.textMuted }}>
-											Only capabilities listed here can resolve this secret when
-											used with an
-											<code> x-kody-secret </code>
-											input.
-										</p>
-									</div>
-									<div
-										css={{ display: 'grid', gap: spacing.sm }}
-										data-repeat-list="allowed-capabilities"
-									>
-										{editorState.allowedCapabilities.map(
-											(capabilityName, index) => (
-												<div
-													key={index}
-													css={{
-														display: 'grid',
-														gridTemplateColumns: 'minmax(0, 1fr) auto',
-														gap: spacing.sm,
-														[mq.mobile]: {
-															gridTemplateColumns: '1fr',
-														},
-													}}
-												>
-													<input
-														type="text"
-														value={
-															typeof capabilityName === 'string'
-																? capabilityName
-																: ''
-														}
-														placeholder="home_lutron_set_credentials"
-														on={{
-															input: (event) =>
-																updateAllowedCapability(
-																	index,
-																	event.currentTarget.value,
-																),
-														}}
-														css={inputCss}
-													/>
-													<button
-														type="button"
-														on={{ click: () => removeAllowedCapability(index) }}
-														css={secondaryButtonCss}
-													>
-														Remove
-													</button>
-												</div>
-											),
-										)}
-									</div>
-									<div>
-										<button
-											type="button"
-											on={{ click: addAllowedCapability }}
-											css={secondaryButtonCss}
-										>
-											Add capability
-										</button>
-									</div>
-								</div>
+								<SecretEditorFields
+									description={editorState.description}
+									onDescriptionChange={(description) => {
+										editorState = {
+											...editorState,
+											description,
+										}
+										handle.update()
+									}}
+									value={editorState.value}
+									onValueChange={(value) => {
+										editorState = {
+											...editorState,
+											value,
+										}
+										handle.update()
+									}}
+									showSecretValue={showSecretValue}
+									onToggleShowSecretValue={() => {
+										showSecretValue = !showSecretValue
+										handle.update()
+									}}
+									allowedHosts={editorState.allowedHosts}
+									onUpdateAllowedHost={updateAllowedHost}
+									onAddAllowedHost={addAllowedHost}
+									onRemoveAllowedHost={removeAllowedHost}
+									allowedCapabilities={editorState.allowedCapabilities}
+									onUpdateAllowedCapability={updateAllowedCapability}
+									onAddAllowedCapability={addAllowedCapability}
+									onRemoveAllowedCapability={removeAllowedCapability}
+									allowedHostsListName="allowed-hosts"
+									allowedCapabilitiesListName="allowed-capabilities"
+								/>
 
 								{selectedSecret ? (
 									<div
@@ -1599,12 +1368,6 @@ const inputCss = {
 	fontSize: typography.fontSize.base,
 	fontFamily: typography.fontFamily,
 	boxSizing: 'border-box' as const,
-}
-
-const textareaCss = {
-	...inputCss,
-	resize: 'vertical' as const,
-	minHeight: '7rem',
 }
 
 const comboboxListCss = {

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -26,6 +26,10 @@ import {
 	typography,
 } from '#client/styles/tokens.ts'
 import { SecretEditorFields } from './secret-editor-fields.tsx'
+import {
+	normalizeAllowedCapabilities,
+	normalizeAllowedHosts,
+} from './secret-normalization.ts'
 
 type SecretScope = 'app' | 'user'
 
@@ -117,30 +121,6 @@ function createEmptyEditorState(apps: Array<SavedAppOption>): EditorState {
 
 function coerceStringRows(list: Array<unknown>): Array<string> {
 	return list.filter((item): item is string => typeof item === 'string')
-}
-
-/** Matches server `normalizeAllowedHosts` in `#mcp/secrets/allowed-hosts.ts`. */
-function clientNormalizeAllowedHosts(hosts: Array<string>): Array<string> {
-	return Array.from(
-		new Set(
-			hosts
-				.map((host) => host.trim().toLowerCase())
-				.filter((host) => host.length > 0),
-		),
-	).sort()
-}
-
-/** Matches server `normalizeAllowedCapabilities` in `#mcp/secrets/allowed-capabilities.ts`. */
-function clientNormalizeAllowedCapabilities(
-	capabilities: Array<string>,
-): Array<string> {
-	return Array.from(
-		new Set(
-			capabilities
-				.map((value) => value.trim())
-				.filter((value) => value.length > 0),
-		),
-	).sort((left, right) => left.localeCompare(right))
 }
 
 function collectRepeatedTextRows(
@@ -565,10 +545,10 @@ export function AccountSecretsRoute(handle: Handle) {
 		handle.update()
 
 		try {
-			const allowedHosts = clientNormalizeAllowedHosts(
+			const allowedHosts = normalizeAllowedHosts(
 				collectRepeatedTextRows(form, 'allowed-hosts'),
 			)
-			const allowedCapabilities = clientNormalizeAllowedCapabilities(
+			const allowedCapabilities = normalizeAllowedCapabilities(
 				collectRepeatedTextRows(form, 'allowed-capabilities'),
 			)
 			const response = await fetch(accountSecretsApiPath, {

--- a/packages/worker/client/routes/connect-secret.tsx
+++ b/packages/worker/client/routes/connect-secret.tsx
@@ -7,6 +7,7 @@ import {
 	spacing,
 	typography,
 } from '#client/styles/tokens.ts'
+import { SecretEditorFields } from './secret-editor-fields.tsx'
 import { formatConnectorConfigFailureMessage } from './connect-secret-errors.ts'
 
 type StorageScope = 'app' | 'session' | 'user'
@@ -45,9 +46,12 @@ type ConnectSecretParams = {
 type ConnectSecretState = {
 	step: ViewStep
 	error: string
+	description: string
 	secretValue: string
+	allowedHosts: Array<string>
+	allowedCapabilities: Array<string>
+	showSecretValue: boolean
 	existingSecret: SecretMetadata | null
-	updateConfirmed: boolean
 	confirmedReview: boolean
 }
 
@@ -64,9 +68,12 @@ type ConnectSecretSession = {
 const defaultState: ConnectSecretState = {
 	step: 'loading',
 	error: '',
+	description: '',
 	secretValue: '',
+	allowedHosts: [''],
+	allowedCapabilities: [''],
+	showSecretValue: false,
 	existingSecret: null,
-	updateConfirmed: false,
 	confirmedReview: false,
 }
 
@@ -117,6 +124,41 @@ function parseConnectSecretParams(): ConnectSecretParams {
 		dashboardUrl,
 		instructions,
 		connector,
+	}
+}
+
+function toEditableRows(values: Array<string>) {
+	return values.length > 0 ? [...values] : ['']
+}
+
+function normalizeAllowedHostsInput(hosts: Array<string>) {
+	return Array.from(
+		new Set(
+			hosts
+				.map((host) => host.trim().toLowerCase())
+				.filter((host) => host.length > 0),
+		),
+	).sort()
+}
+
+function normalizeAllowedCapabilitiesInput(capabilities: Array<string>) {
+	return Array.from(
+		new Set(
+			capabilities
+				.map((capability) => capability.trim())
+				.filter((capability) => capability.length > 0),
+		),
+	).sort((left, right) => left.localeCompare(right))
+}
+
+function createInitialConnectSecretState(
+	params: ConnectSecretParams,
+): ConnectSecretState {
+	return {
+		...defaultState,
+		description: params.description,
+		allowedHosts: toEditableRows(params.allowedHosts),
+		allowedCapabilities: toEditableRows(params.allowedCapabilities),
 	}
 }
 
@@ -203,22 +245,28 @@ async function listExistingSecret(
 async function saveSecretValue(
 	params: ConnectSecretParams,
 	session: ConnectSecretSession,
-	value: string,
+	input: {
+		value: string
+		description: string
+		allowedHosts: Array<string>
+		allowedCapabilities: Array<string>
+	},
 ) {
-	const response = await fetch(session.endpoints.secrets, {
+	const response = await fetch('/connect/secret.json', {
 		method: 'POST',
 		headers: {
 			Accept: 'application/json',
 			'Content-Type': 'application/json',
-			Authorization: `Bearer ${session.token}`,
 		},
-		credentials: 'omit',
+		credentials: 'include',
 		body: JSON.stringify({
-			action: 'save',
 			name: params.name,
-			value,
-			description: params.description,
 			scope: params.scope,
+			sessionToken: session.token,
+			value: input.value,
+			description: input.description,
+			allowedHosts: input.allowedHosts,
+			allowedCapabilities: input.allowedCapabilities,
 		}),
 	})
 	const payload = (await response.json().catch(() => null)) as {
@@ -233,6 +281,10 @@ async function saveSecretValue(
 async function updateConnectorConfig(
 	params: ConnectSecretParams,
 	session: ConnectSecretSession,
+	input: {
+		allowedHosts: Array<string>
+		allowedCapabilities: Array<string>
+	},
 ) {
 	if (!params.connector) return
 	const response = await fetch('/connect/secret.json', {
@@ -247,8 +299,8 @@ async function updateConnectorConfig(
 			scope: params.scope,
 			sessionToken: session.token,
 			connector: params.connector,
-			allowedHosts: params.allowedHosts,
-			allowedCapabilities: params.allowedCapabilities,
+			allowedHosts: input.allowedHosts,
+			allowedCapabilities: input.allowedCapabilities,
 		}),
 	})
 	const payload = (await response.json().catch(() => null)) as {
@@ -323,12 +375,19 @@ export function ConnectSecretRoute(handle: Handle) {
 			if (version !== initVersion) return
 			if (existing) {
 				setState({
+					...createInitialConnectSecretState(params),
 					step: 'update-confirm',
 					existingSecret: existing,
+					description: existing.description,
+					allowedHosts: toEditableRows(existing.allowed_hosts),
+					allowedCapabilities: toEditableRows(existing.allowed_capabilities),
 				})
 				return
 			}
-			setState({ step: 'input' })
+			setState({
+				...createInitialConnectSecretState(params),
+				step: 'input',
+			})
 		} catch (error) {
 			if (version !== initVersion) return
 			if (isSessionRefreshError(error)) {
@@ -353,6 +412,10 @@ export function ConnectSecretRoute(handle: Handle) {
 			return
 		}
 		const params = parseConnectSecretParams()
+		const normalizedAllowedHosts = normalizeAllowedHostsInput(state.allowedHosts)
+		const normalizedAllowedCapabilities = normalizeAllowedCapabilitiesInput(
+			state.allowedCapabilities,
+		)
 		if (!state.secretValue.trim()) {
 			setState({
 				step: 'error',
@@ -362,7 +425,12 @@ export function ConnectSecretRoute(handle: Handle) {
 		}
 		setState({ step: 'saving', error: '' })
 		try {
-			await saveSecretValue(params, session, state.secretValue)
+			await saveSecretValue(params, session, {
+				value: state.secretValue,
+				description: state.description,
+				allowedHosts: normalizedAllowedHosts,
+				allowedCapabilities: normalizedAllowedCapabilities,
+			})
 		} catch (error) {
 			if (isSessionRefreshError(error)) {
 				startInitialization()
@@ -376,7 +444,10 @@ export function ConnectSecretRoute(handle: Handle) {
 			return
 		}
 		try {
-			await updateConnectorConfig(params, session)
+			await updateConnectorConfig(params, session, {
+				allowedHosts: normalizedAllowedHosts,
+				allowedCapabilities: normalizedAllowedCapabilities,
+			})
 			setState({ step: 'success' })
 		} catch (error) {
 			const secretWasNewlyCreated = state.existingSecret == null
@@ -417,6 +488,53 @@ export function ConnectSecretRoute(handle: Handle) {
 			return
 		}
 		setState({ step: 'input', error: '' })
+	}
+
+	function updateAllowedHost(index: number, value: string) {
+		setState({
+			allowedHosts: state.allowedHosts.map((host, hostIndex) =>
+				hostIndex === index ? value : host,
+			),
+		})
+	}
+
+	function addAllowedHost() {
+		setState({
+			allowedHosts: [...state.allowedHosts, ''],
+		})
+	}
+
+	function removeAllowedHost(index: number) {
+		const nextHosts = state.allowedHosts.filter(
+			(_host, hostIndex) => hostIndex !== index,
+		)
+		setState({
+			allowedHosts: nextHosts.length > 0 ? nextHosts : [''],
+		})
+	}
+
+	function updateAllowedCapability(index: number, value: string) {
+		setState({
+			allowedCapabilities: state.allowedCapabilities.map(
+				(capability, capabilityIndex) =>
+					capabilityIndex === index ? value : capability,
+			),
+		})
+	}
+
+	function addAllowedCapability() {
+		setState({
+			allowedCapabilities: [...state.allowedCapabilities, ''],
+		})
+	}
+
+	function removeAllowedCapability(index: number) {
+		const nextCapabilities = state.allowedCapabilities.filter(
+			(_capability, capabilityIndex) => capabilityIndex !== index,
+		)
+		setState({
+			allowedCapabilities: nextCapabilities.length > 0 ? nextCapabilities : [''],
+		})
 	}
 
 	return () => {
@@ -516,8 +634,7 @@ export function ConnectSecretRoute(handle: Handle) {
 								type="button"
 								css={primaryButtonCss}
 								on={{
-									click: () =>
-										setState({ step: 'input', updateConfirmed: true }),
+									click: () => setState({ step: 'input' }),
 								}}
 							>
 								Update secret
@@ -600,20 +717,25 @@ export function ConnectSecretRoute(handle: Handle) {
 
 						<section css={cardCss}>
 							<h2 css={cardTitleCss}>Enter secret</h2>
-							<label css={{ display: 'grid', gap: spacing.xs }}>
-								<span css={labelCss}>Secret value</span>
-								<input
-									type="password"
-									autoComplete="new-password"
-									value={state.secretValue}
-									placeholder="Paste the secret value"
-									on={{
-										input: (event) =>
-											setState({ secretValue: event.currentTarget.value }),
-									}}
-									css={inputCss}
-								/>
-							</label>
+							<SecretEditorFields
+								description={state.description}
+								onDescriptionChange={(description) => setState({ description })}
+								value={state.secretValue}
+								onValueChange={(secretValue) => setState({ secretValue })}
+								showSecretValue={state.showSecretValue}
+								onToggleShowSecretValue={() =>
+									setState({ showSecretValue: !state.showSecretValue })
+								}
+								allowedHosts={state.allowedHosts}
+								onUpdateAllowedHost={updateAllowedHost}
+								onAddAllowedHost={addAllowedHost}
+								onRemoveAllowedHost={removeAllowedHost}
+								allowedCapabilities={state.allowedCapabilities}
+								onUpdateAllowedCapability={updateAllowedCapability}
+								onAddAllowedCapability={addAllowedCapability}
+								onRemoveAllowedCapability={removeAllowedCapability}
+								valuePlaceholder="Paste the secret value"
+							/>
 						</section>
 
 						{showReview ? (
@@ -634,10 +756,10 @@ export function ConnectSecretRoute(handle: Handle) {
 										<div css={labelCss}>Scope</div>
 										<div>{scopeLabel(params.scope)}</div>
 									</div>
-									{params.description ? (
+									{state.description ? (
 										<div css={{ gridColumn: '1 / -1' }}>
 											<div css={labelCss}>Description</div>
-											<div>{params.description}</div>
+											<div>{state.description}</div>
 										</div>
 									) : null}
 								</div>
@@ -651,8 +773,8 @@ export function ConnectSecretRoute(handle: Handle) {
 									<div>
 										<div css={labelCss}>Hosts to approve</div>
 										<ul css={listCss}>
-											{params.allowedHosts.length > 0 ? (
-												params.allowedHosts.map((host) => (
+											{normalizeAllowedHostsInput(state.allowedHosts).length > 0 ? (
+												normalizeAllowedHostsInput(state.allowedHosts).map((host) => (
 													<li key={host}>{host}</li>
 												))
 											) : (
@@ -663,8 +785,11 @@ export function ConnectSecretRoute(handle: Handle) {
 									<div>
 										<div css={labelCss}>Capabilities to allow</div>
 										<ul css={listCss}>
-											{params.allowedCapabilities.length > 0 ? (
-												params.allowedCapabilities.map((capability) => (
+											{normalizeAllowedCapabilitiesInput(state.allowedCapabilities)
+												.length > 0 ? (
+												normalizeAllowedCapabilitiesInput(
+													state.allowedCapabilities,
+												).map((capability) => (
 													<li key={capability}>{capability}</li>
 												))
 											) : (
@@ -788,16 +913,6 @@ const listCss = {
 	display: 'grid',
 	gap: spacing.xs,
 	color: colors.text,
-}
-
-const inputCss = {
-	padding: spacing.sm,
-	borderRadius: radius.md,
-	border: `1px solid ${colors.border}`,
-	backgroundColor: colors.background,
-	color: colors.text,
-	fontFamily: typography.fontFamily,
-	fontSize: typography.fontSize.base,
 }
 
 const primaryButtonCss = {

--- a/packages/worker/client/routes/connect-secret.tsx
+++ b/packages/worker/client/routes/connect-secret.tsx
@@ -136,6 +136,17 @@ function toEditableRows(values: Array<string> | null | undefined) {
 	return [...values]
 }
 
+function normalizeAllowedForState(input: {
+	allowedHosts: Array<string>
+	allowedCapabilities: Array<string>
+}) {
+	return {
+		normalizedAllowedHosts: normalizeAllowedHosts(input.allowedHosts),
+		normalizedAllowedCapabilities: normalizeAllowedCapabilities(
+			input.allowedCapabilities,
+		),
+	}
+}
 function createInitialConnectSecretState(
 	params: ConnectSecretParams,
 ): ConnectSecretState {
@@ -397,10 +408,8 @@ export function ConnectSecretRoute(handle: Handle) {
 			return
 		}
 		const params = parseConnectSecretParams()
-		const normalizedAllowedHosts = normalizeAllowedHosts(state.allowedHosts)
-		const normalizedAllowedCapabilities = normalizeAllowedCapabilities(
-			state.allowedCapabilities,
-		)
+		const { normalizedAllowedHosts, normalizedAllowedCapabilities } =
+			normalizeAllowedForState(state)
 		if (!state.secretValue.trim()) {
 			setState({
 				step: 'error',
@@ -537,10 +546,8 @@ export function ConnectSecretRoute(handle: Handle) {
 		const params = parseConnectSecretParams()
 		const hasInstructions = Boolean(params.instructions || params.dashboardUrl)
 		const showReview = state.step === 'review' || state.step === 'saving'
-		const normalizedAllowedHosts = normalizeAllowedHosts(state.allowedHosts)
-		const normalizedAllowedCapabilities = normalizeAllowedCapabilities(
-			state.allowedCapabilities,
-		)
+		const { normalizedAllowedHosts, normalizedAllowedCapabilities } =
+			normalizeAllowedForState(state)
 
 		return (
 			<section

--- a/packages/worker/client/routes/connect-secret.tsx
+++ b/packages/worker/client/routes/connect-secret.tsx
@@ -8,6 +8,10 @@ import {
 	typography,
 } from '#client/styles/tokens.ts'
 import { SecretEditorFields } from './secret-editor-fields.tsx'
+import {
+	normalizeAllowedCapabilities,
+	normalizeAllowedHosts,
+} from './secret-normalization.ts'
 import { formatConnectorConfigFailureMessage } from './connect-secret-errors.ts'
 
 type StorageScope = 'app' | 'session' | 'user'
@@ -130,26 +134,6 @@ function parseConnectSecretParams(): ConnectSecretParams {
 function toEditableRows(values: Array<string> | null | undefined) {
 	if (!Array.isArray(values) || values.length === 0) return ['']
 	return [...values]
-}
-
-function normalizeAllowedHostsInput(hosts: Array<string>) {
-	return Array.from(
-		new Set(
-			hosts
-				.map((host) => host.trim().toLowerCase())
-				.filter((host) => host.length > 0),
-		),
-	).sort()
-}
-
-function normalizeAllowedCapabilitiesInput(capabilities: Array<string>) {
-	return Array.from(
-		new Set(
-			capabilities
-				.map((capability) => capability.trim())
-				.filter((capability) => capability.length > 0),
-		),
-	).sort((left, right) => left.localeCompare(right))
 }
 
 function createInitialConnectSecretState(
@@ -413,8 +397,8 @@ export function ConnectSecretRoute(handle: Handle) {
 			return
 		}
 		const params = parseConnectSecretParams()
-		const normalizedAllowedHosts = normalizeAllowedHostsInput(state.allowedHosts)
-		const normalizedAllowedCapabilities = normalizeAllowedCapabilitiesInput(
+		const normalizedAllowedHosts = normalizeAllowedHosts(state.allowedHosts)
+		const normalizedAllowedCapabilities = normalizeAllowedCapabilities(
 			state.allowedCapabilities,
 		)
 		if (!state.secretValue.trim()) {
@@ -778,8 +762,8 @@ export function ConnectSecretRoute(handle: Handle) {
 									<div>
 										<div css={labelCss}>Hosts to approve</div>
 										<ul css={listCss}>
-											{normalizeAllowedHostsInput(state.allowedHosts).length > 0 ? (
-												normalizeAllowedHostsInput(state.allowedHosts).map((host) => (
+											{normalizeAllowedHosts(state.allowedHosts).length > 0 ? (
+												normalizeAllowedHosts(state.allowedHosts).map((host) => (
 													<li key={host}>{host}</li>
 												))
 											) : (
@@ -790,9 +774,9 @@ export function ConnectSecretRoute(handle: Handle) {
 									<div>
 										<div css={labelCss}>Capabilities to allow</div>
 										<ul css={listCss}>
-											{normalizeAllowedCapabilitiesInput(state.allowedCapabilities)
+											{normalizeAllowedCapabilities(state.allowedCapabilities)
 												.length > 0 ? (
-												normalizeAllowedCapabilitiesInput(
+												normalizeAllowedCapabilities(
 													state.allowedCapabilities,
 												).map((capability) => (
 													<li key={capability}>{capability}</li>

--- a/packages/worker/client/routes/connect-secret.tsx
+++ b/packages/worker/client/routes/connect-secret.tsx
@@ -537,6 +537,10 @@ export function ConnectSecretRoute(handle: Handle) {
 		const params = parseConnectSecretParams()
 		const hasInstructions = Boolean(params.instructions || params.dashboardUrl)
 		const showReview = state.step === 'review' || state.step === 'saving'
+		const normalizedAllowedHosts = normalizeAllowedHosts(state.allowedHosts)
+		const normalizedAllowedCapabilities = normalizeAllowedCapabilities(
+			state.allowedCapabilities,
+		)
 
 		return (
 			<section
@@ -762,8 +766,8 @@ export function ConnectSecretRoute(handle: Handle) {
 									<div>
 										<div css={labelCss}>Hosts to approve</div>
 										<ul css={listCss}>
-											{normalizeAllowedHosts(state.allowedHosts).length > 0 ? (
-												normalizeAllowedHosts(state.allowedHosts).map((host) => (
+											{normalizedAllowedHosts.length > 0 ? (
+												normalizedAllowedHosts.map((host) => (
 													<li key={host}>{host}</li>
 												))
 											) : (
@@ -774,11 +778,8 @@ export function ConnectSecretRoute(handle: Handle) {
 									<div>
 										<div css={labelCss}>Capabilities to allow</div>
 										<ul css={listCss}>
-											{normalizeAllowedCapabilities(state.allowedCapabilities)
-												.length > 0 ? (
-												normalizeAllowedCapabilities(
-													state.allowedCapabilities,
-												).map((capability) => (
+											{normalizedAllowedCapabilities.length > 0 ? (
+												normalizedAllowedCapabilities.map((capability) => (
 													<li key={capability}>{capability}</li>
 												))
 											) : (

--- a/packages/worker/client/routes/connect-secret.tsx
+++ b/packages/worker/client/routes/connect-secret.tsx
@@ -127,8 +127,9 @@ function parseConnectSecretParams(): ConnectSecretParams {
 	}
 }
 
-function toEditableRows(values: Array<string>) {
-	return values.length > 0 ? [...values] : ['']
+function toEditableRows(values: Array<string> | null | undefined) {
+	if (!Array.isArray(values) || values.length === 0) return ['']
+	return [...values]
 }
 
 function normalizeAllowedHostsInput(hosts: Array<string>) {
@@ -542,7 +543,11 @@ export function ConnectSecretRoute(handle: Handle) {
 			typeof window === 'undefined' ? '' : window.location.search
 		if (currentSearch !== lastSearch) {
 			lastSearch = currentSearch
-			startInitialization()
+			// Defer: startInitialization calls handle.update(), which must not run during
+			// render (Remix component runtime throws "scheduleUpdate not implemented").
+			handle.queueTask(() => {
+				startInitialization()
+			})
 		}
 
 		const params = parseConnectSecretParams()

--- a/packages/worker/client/routes/secret-editor-fields.tsx
+++ b/packages/worker/client/routes/secret-editor-fields.tsx
@@ -1,0 +1,274 @@
+import { colors, mq, radius, spacing, typography } from '#client/styles/tokens.ts'
+
+type SecretEditorFieldsProps = {
+	description: string
+	onDescriptionChange: (value: string) => void
+	value: string
+	onValueChange: (value: string) => void
+	showSecretValue: boolean
+	onToggleShowSecretValue: () => void
+	allowedHosts: Array<string>
+	onUpdateAllowedHost: (index: number, value: string) => void
+	onAddAllowedHost: () => void
+	onRemoveAllowedHost: (index: number) => void
+	allowedCapabilities: Array<string>
+	onUpdateAllowedCapability: (index: number, value: string) => void
+	onAddAllowedCapability: () => void
+	onRemoveAllowedCapability: (index: number) => void
+	valuePlaceholder?: string
+	allowedHostsListName?: string
+	allowedCapabilitiesListName?: string
+}
+
+export function SecretEditorFields(props: SecretEditorFieldsProps) {
+	return (
+		<>
+			<label css={fieldCss}>
+				<span css={fieldLabelCss}>Description</span>
+				<textarea
+					value={props.description}
+					rows={3}
+					placeholder="What this secret is used for"
+					on={{
+						input: (event) => {
+							props.onDescriptionChange(event.currentTarget.value)
+						},
+					}}
+					css={textareaCss}
+				/>
+			</label>
+
+			<label css={fieldCss}>
+				<span css={fieldLabelCss}>Secret value</span>
+				<div
+					css={{
+						position: 'relative',
+						display: 'flex',
+						alignItems: 'center',
+					}}
+				>
+					<input
+						type={props.showSecretValue ? 'text' : 'password'}
+						required
+						autoComplete="new-password"
+						value={props.value}
+						placeholder={props.valuePlaceholder ?? 'Enter the secret value'}
+						on={{
+							input: (event) => {
+								props.onValueChange(event.currentTarget.value)
+							},
+						}}
+						css={{
+							...inputCss,
+							paddingRight: '3rem',
+						}}
+					/>
+					<button
+						type="button"
+						aria-label={
+							props.showSecretValue ? 'Hide secret value' : 'Show secret value'
+						}
+						title={
+							props.showSecretValue ? 'Hide secret value' : 'Show secret value'
+						}
+						on={{ click: () => props.onToggleShowSecretValue() }}
+						css={iconButtonCss}
+					>
+						{props.showSecretValue ? (
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								width="20"
+								height="20"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							>
+								<path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
+								<path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68" />
+								<path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61" />
+								<line x1="2" x2="22" y1="2" y2="22" />
+							</svg>
+						) : (
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								width="20"
+								height="20"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							>
+								<path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+								<circle cx="12" cy="12" r="3" />
+							</svg>
+						)}
+					</button>
+				</div>
+			</label>
+
+			<div css={{ display: 'grid', gap: spacing.sm }}>
+				<div css={{ display: 'grid', gap: spacing.xs }}>
+					<span css={fieldLabelCss}>Allowed hosts</span>
+					<p css={{ margin: 0, color: colors.textMuted }}>
+						Leave this empty to require explicit host approval before a secret can
+						be used.
+					</p>
+				</div>
+				<div
+					css={{ display: 'grid', gap: spacing.sm }}
+					data-repeat-list={props.allowedHostsListName}
+				>
+					{props.allowedHosts.map((host, index) => (
+						<div key={index} css={repeatedRowCss}>
+							<input
+								type="text"
+								value={typeof host === 'string' ? host : ''}
+								placeholder="api.example.com"
+								on={{
+									input: (event) => {
+										props.onUpdateAllowedHost(index, event.currentTarget.value)
+									},
+								}}
+								css={inputCss}
+							/>
+							<button
+								type="button"
+								on={{ click: () => props.onRemoveAllowedHost(index) }}
+								css={secondaryButtonCss}
+							>
+								Remove
+							</button>
+						</div>
+					))}
+				</div>
+				<div>
+					<button
+						type="button"
+						on={{ click: () => props.onAddAllowedHost() }}
+						css={secondaryButtonCss}
+					>
+						Add host
+					</button>
+				</div>
+			</div>
+
+			<div css={{ display: 'grid', gap: spacing.sm }}>
+				<div css={{ display: 'grid', gap: spacing.xs }}>
+					<span css={fieldLabelCss}>Allowed capabilities</span>
+					<p css={{ margin: 0, color: colors.textMuted }}>
+						Only capabilities listed here can resolve this secret when used with
+						an <code>x-kody-secret</code> input.
+					</p>
+				</div>
+				<div
+					css={{ display: 'grid', gap: spacing.sm }}
+					data-repeat-list={props.allowedCapabilitiesListName}
+				>
+					{props.allowedCapabilities.map((capabilityName, index) => (
+						<div key={index} css={repeatedRowCss}>
+							<input
+								type="text"
+								value={typeof capabilityName === 'string' ? capabilityName : ''}
+								placeholder="home_lutron_set_credentials"
+								on={{
+									input: (event) => {
+										props.onUpdateAllowedCapability(
+											index,
+											event.currentTarget.value,
+										)
+									},
+								}}
+								css={inputCss}
+							/>
+							<button
+								type="button"
+								on={{ click: () => props.onRemoveAllowedCapability(index) }}
+								css={secondaryButtonCss}
+							>
+								Remove
+							</button>
+						</div>
+					))}
+				</div>
+				<div>
+					<button
+						type="button"
+						on={{ click: () => props.onAddAllowedCapability() }}
+						css={secondaryButtonCss}
+					>
+						Add capability
+					</button>
+				</div>
+			</div>
+		</>
+	)
+}
+
+const fieldCss = {
+	display: 'grid',
+	gap: spacing.xs,
+}
+
+const fieldLabelCss = {
+	color: colors.text,
+	fontWeight: typography.fontWeight.medium,
+	fontSize: typography.fontSize.sm,
+}
+
+const inputCss = {
+	width: '100%',
+	padding: spacing.sm,
+	borderRadius: radius.md,
+	border: `1px solid ${colors.border}`,
+	backgroundColor: colors.background,
+	color: colors.text,
+	fontSize: typography.fontSize.base,
+	fontFamily: typography.fontFamily,
+	boxSizing: 'border-box' as const,
+}
+
+const textareaCss = {
+	...inputCss,
+	resize: 'vertical' as const,
+	minHeight: '7rem',
+}
+
+const secondaryButtonCss = {
+	padding: `${spacing.sm} ${spacing.md}`,
+	borderRadius: radius.full,
+	border: `1px solid ${colors.border}`,
+	backgroundColor: 'transparent',
+	color: colors.text,
+	fontWeight: typography.fontWeight.medium,
+	cursor: 'pointer',
+}
+
+const iconButtonCss = {
+	position: 'absolute' as const,
+	right: spacing.sm,
+	background: 'none',
+	border: 'none',
+	padding: 0,
+	color: colors.textMuted,
+	cursor: 'pointer',
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	'&:hover': {
+		color: colors.text,
+	},
+}
+
+const repeatedRowCss = {
+	display: 'grid',
+	gridTemplateColumns: 'minmax(0, 1fr) auto',
+	gap: spacing.sm,
+	[mq.mobile]: {
+		gridTemplateColumns: '1fr',
+	},
+}

--- a/packages/worker/client/routes/secret-editor-fields.tsx
+++ b/packages/worker/client/routes/secret-editor-fields.tsx
@@ -1,3 +1,4 @@
+import { type Handle } from 'remix/component'
 import { colors, mq, radius, spacing, typography } from '#client/styles/tokens.ts'
 
 type SecretEditorFieldsProps = {
@@ -20,8 +21,8 @@ type SecretEditorFieldsProps = {
 	allowedCapabilitiesListName?: string
 }
 
-export function SecretEditorFields(props: SecretEditorFieldsProps) {
-	return (
+export function SecretEditorFields(_handle: Handle) {
+	return (props: SecretEditorFieldsProps) => (
 		<>
 			<label css={fieldCss}>
 				<span css={fieldLabelCss}>Description</span>
@@ -47,22 +48,41 @@ export function SecretEditorFields(props: SecretEditorFieldsProps) {
 						alignItems: 'center',
 					}}
 				>
-					<input
-						type={props.showSecretValue ? 'text' : 'password'}
-						required
-						autoComplete="new-password"
-						value={props.value}
-						placeholder={props.valuePlaceholder ?? 'Enter the secret value'}
-						on={{
-							input: (event) => {
-								props.onValueChange(event.currentTarget.value)
-							},
-						}}
-						css={{
-							...inputCss,
-							paddingRight: '3rem',
-						}}
-					/>
+					{props.showSecretValue ? (
+						<input
+							type="text"
+							required
+							autoComplete="new-password"
+							value={props.value}
+							placeholder={props.valuePlaceholder ?? 'Enter the secret value'}
+							on={{
+								input: (event) => {
+									props.onValueChange(event.currentTarget.value)
+								},
+							}}
+							css={{
+								...inputCss,
+								paddingRight: '3rem',
+							}}
+						/>
+					) : (
+						<input
+							type="password"
+							required
+							autoComplete="new-password"
+							value={props.value}
+							placeholder={props.valuePlaceholder ?? 'Enter the secret value'}
+							on={{
+								input: (event) => {
+									props.onValueChange(event.currentTarget.value)
+								},
+							}}
+							css={{
+								...inputCss,
+								paddingRight: '3rem',
+							}}
+						/>
+					)}
 					<button
 						type="button"
 						aria-label={

--- a/packages/worker/client/routes/secret-normalization.ts
+++ b/packages/worker/client/routes/secret-normalization.ts
@@ -1,0 +1,23 @@
+/** Matches server `normalizeAllowedHosts` in `#mcp/secrets/allowed-hosts.ts`. */
+export function normalizeAllowedHosts(hosts: Array<string>): Array<string> {
+	return Array.from(
+		new Set(
+			hosts
+				.map((host) => host.trim().toLowerCase())
+				.filter((host) => host.length > 0),
+		),
+	).sort()
+}
+
+/** Matches server `normalizeAllowedCapabilities` in `#mcp/secrets/allowed-capabilities.ts`. */
+export function normalizeAllowedCapabilities(
+	capabilities: Array<string>,
+): Array<string> {
+	return Array.from(
+		new Set(
+			capabilities
+				.map((value) => value.trim())
+				.filter((value) => value.length > 0),
+		),
+	).sort((left, right) => left.localeCompare(right))
+}

--- a/packages/worker/src/app/handlers/connect-secret.node.test.ts
+++ b/packages/worker/src/app/handlers/connect-secret.node.test.ts
@@ -37,6 +37,19 @@ const mockModule = vi.hoisted(() => ({
 		allowedHosts: [],
 		allowedCapabilities: [],
 	})),
+	saveSecret: vi.fn(async () => ({
+		name: 'linearApiKey',
+		scope: 'user',
+		description: '',
+		appId: null,
+		allowedHosts: [],
+		allowedCapabilities: [],
+		createdAt: new Date(0).toISOString(),
+		updatedAt: new Date(0).toISOString(),
+		ttlMs: null,
+	})),
+	setSecretAllowedHosts: vi.fn(async () => undefined),
+	setSecretAllowedCapabilities: vi.fn(async () => undefined),
 	saveValue: vi.fn(async () => undefined),
 	getUiArtifactByOwnerIds: async (
 		_db: D1Database,
@@ -92,8 +105,17 @@ vi.mock('#mcp/secrets/allowed-hosts.ts', () => ({
 	normalizeAllowedHosts: (hosts: Array<string>) => hosts,
 }))
 
+vi.mock('#mcp/secrets/allowed-capabilities.ts', () => ({
+	normalizeAllowedCapabilities: (capabilities: Array<string>) => capabilities,
+}))
+
 vi.mock('#mcp/secrets/service.ts', () => ({
 	resolveSecret: (...args: Array<unknown>) => mockModule.resolveSecret(...args),
+	saveSecret: (...args: Array<unknown>) => mockModule.saveSecret(...args),
+	setSecretAllowedHosts: (...args: Array<unknown>) =>
+		mockModule.setSecretAllowedHosts(...args),
+	setSecretAllowedCapabilities: (...args: Array<unknown>) =>
+		mockModule.setSecretAllowedCapabilities(...args),
 }))
 
 vi.mock('#mcp/values/service.ts', () => ({
@@ -226,6 +248,54 @@ test('connect secret POST stores connector binding under dedicated prefix', asyn
 	expect(mockModule.saveValue).not.toHaveBeenCalledWith(
 		expect.objectContaining({
 			name: '_connector:linear',
+		}),
+	)
+})
+
+test('connect secret POST saves secret metadata from editable defaults', async () => {
+	const handler = createConnectSecretApiHandler(createEnv())
+	const response = await handler.action({
+		request: new Request('https://example.com/connect/secret.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'linearApiKey',
+				scope: 'user',
+				sessionToken: 'generated-token',
+				value: 'shh-secret',
+				description: 'Linear API key',
+				allowedHosts: ['API.LINEAR.APP', 'api.linear.app'],
+				allowedCapabilities: ['linear_issue_list'],
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	await expect(readJson(response)).resolves.toEqual({ ok: true })
+	expect(mockModule.saveSecret).toHaveBeenCalledWith(
+		expect.objectContaining({
+			name: 'linearApiKey',
+			value: 'shh-secret',
+			scope: 'user',
+			description: 'Linear API key',
+			storageContext: { sessionId: 'session-1', appId: null },
+		}),
+	)
+	expect(mockModule.setSecretAllowedHosts).toHaveBeenCalledWith(
+		expect.objectContaining({
+			name: 'linearApiKey',
+			scope: 'user',
+			allowedHosts: ['API.LINEAR.APP', 'api.linear.app'],
+			storageContext: { sessionId: 'session-1', appId: null },
+		}),
+	)
+	expect(mockModule.setSecretAllowedCapabilities).toHaveBeenCalledWith(
+		expect.objectContaining({
+			name: 'linearApiKey',
+			scope: 'user',
+			allowedCapabilities: ['linear_issue_list'],
+			storageContext: { sessionId: 'session-1', appId: null },
 		}),
 	)
 })

--- a/packages/worker/src/app/handlers/connect-secret.ts
+++ b/packages/worker/src/app/handlers/connect-secret.ts
@@ -11,8 +11,14 @@ import {
 	verifyGeneratedUiAppSession,
 } from '#mcp/generated-ui-app-session.ts'
 import { capabilityMap } from '#mcp/capabilities/registry.ts'
+import { normalizeAllowedCapabilities } from '#mcp/secrets/allowed-capabilities.ts'
 import { normalizeAllowedHosts } from '#mcp/secrets/allowed-hosts.ts'
-import { resolveSecret } from '#mcp/secrets/service.ts'
+import {
+	resolveSecret,
+	saveSecret,
+	setSecretAllowedCapabilities,
+	setSecretAllowedHosts,
+} from '#mcp/secrets/service.ts'
 import { secretScopeValues, type SecretScope } from '#mcp/secrets/types.ts'
 import { saveValue } from '#mcp/values/service.ts'
 import { getUiArtifactByOwnerIds } from '#mcp/ui-artifacts-repo.ts'
@@ -109,12 +115,22 @@ export function createConnectSecretApiHandler(env: Env) {
 			const name = readString(body, 'name')
 			const scope = readScope(body)
 			const sessionToken = readString(body, 'sessionToken')
+			const value = readOptionalString(body, 'value')
+			const description = readOptionalString(body, 'description') ?? ''
 			const connector = readOptionalString(body, 'connector')
 			const requestedAllowedHosts =
 				readOptionalStringArray(body, 'allowedHosts') ?? []
 			const requestedAllowedCapabilities =
 				readOptionalStringArray(body, 'allowedCapabilities') ?? []
-			const unknownCapabilities = requestedAllowedCapabilities.filter(
+			const normalizedAllowedHosts =
+				requestedAllowedHosts.length > 0
+					? normalizeAllowedHosts(requestedAllowedHosts)
+					: []
+			const normalizedAllowedCapabilities =
+				requestedAllowedCapabilities.length > 0
+					? normalizeAllowedCapabilities(requestedAllowedCapabilities)
+					: []
+			const unknownCapabilities = normalizedAllowedCapabilities.filter(
 				(capability) => !capabilityMap[capability],
 			)
 			if (unknownCapabilities.length > 0) {
@@ -175,6 +191,43 @@ export function createConnectSecretApiHandler(env: Env) {
 			}
 
 			try {
+				if (typeof value === 'string') {
+					if (!value.trim()) {
+						return jsonResponse(
+							{ ok: false, error: 'Secret value is required.' },
+							400,
+						)
+					}
+					await saveSecret({
+						env,
+						userId: user.mcpUser.userId,
+						name,
+						value,
+						scope,
+						description,
+						storageContext,
+						sessionExpiresAt:
+							scope === 'session'
+								? new Date(session.exp).toISOString()
+								: null,
+					})
+					await setSecretAllowedHosts({
+						env,
+						userId: user.mcpUser.userId,
+						name,
+						scope,
+						allowedHosts: normalizedAllowedHosts,
+						storageContext,
+					})
+					await setSecretAllowedCapabilities({
+						env,
+						userId: user.mcpUser.userId,
+						name,
+						scope,
+						allowedCapabilities: normalizedAllowedCapabilities,
+						storageContext,
+					})
+				}
 				if (connector) {
 					const resolved = await resolveSecret({
 						env,
@@ -187,12 +240,12 @@ export function createConnectSecretApiHandler(env: Env) {
 						return jsonResponse({ ok: false, error: 'Secret not found.' }, 404)
 					}
 					const allowedHosts =
-						requestedAllowedHosts.length > 0
-							? normalizeAllowedHosts(requestedAllowedHosts)
+						normalizedAllowedHosts.length > 0
+							? normalizedAllowedHosts
 							: resolved.allowedHosts
 					const allowedCapabilities =
-						requestedAllowedCapabilities.length > 0
-							? requestedAllowedCapabilities
+						normalizedAllowedCapabilities.length > 0
+							? normalizedAllowedCapabilities
 							: resolved.allowedCapabilities
 					await saveValue({
 						env,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- reuse the shared secret editor fields in the connect secret flow and seed editable description, allowed hosts, and allowed capabilities from query params
- save the reviewed secret metadata through `/connect/secret.json` so stored policy matches what the user sees in the form and connector binding
- fix the shared secret editor component to follow the Remix component factory contract so the form renders correctly
- deduplicate connect-secret normalization so save and review share one helper
- merge latest `main` changes and fix account-secrets merge regressions so typecheck and E2E pass together

## Testing
- npm run test -- packages/worker/src/app/handlers/connect-secret.node.test.ts packages/worker/client/routes/connect-secret-errors.node.test.ts
- npm run typecheck
- npm run build
- npm run test:e2e -- e2e/account-secrets.spec.ts
- manual browser walkthrough on `http://localhost:3742/connect/secret?...` confirming editable defaults and normalized review state
- manual browser verification that `/account/secrets/user/manual-secret-check` renders the selected secret detail pane after the merge fix

[connect-secret-query-defaults-demo.mp4](https://cursor.com/agents/bc-884d2f39-295d-463a-b310-c6c0d83603ed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnect-secret-query-defaults-demo.mp4)
[Connect secret editable defaults](https://cursor.com/agents/bc-884d2f39-295d-463a-b310-c6c0d83603ed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnect-secret-defaults.webp)
[Connect secret review state](https://cursor.com/agents/bc-884d2f39-295d-463a-b310-c6c0d83603ed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnect-secret-review.webp)
[Account secrets selected secret detail pane](https://cursor.com/agents/bc-884d2f39-295d-463a-b310-c6c0d83603ed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faccount-secrets-selected-secret.webp)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-884d2f39-295d-463a-b310-c6c0d83603ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-884d2f39-295d-463a-b310-c6c0d83603ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable secret editor UI for description, secret value (show/hide), and dynamic allowed-hosts/capabilities lists.
  * Connect flow now seeds editable description and allowed lists from existing data or query params and shows them in the review step.

* **Bug Fixes**
  * Normalizes and validates host/capability lists and rejects blank secret values to ensure clean persistence.

* **Tests**
  * Added tests to verify secret save and persistence of allowed-host and allowed-capability lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->