### PR TITLE
Improve saved skill search discoverability

### DIFF
--- a/packages/worker/src/mcp/capabilities/unified-search.ts
+++ b/packages/worker/src/mcp/capabilities/unified-search.ts
@@ -582,11 +582,15 @@ export async function searchUnified(input: {
 		}
 		return 0
 	}
+	const lexicalScoreByKey = new Map(
+		allKeys.map((key) => [key, getUnifiedLexicalScore(key)] as const),
+	)
 	const sortedKeys = [...allKeys]
 		.sort((a, b) => {
 			const fusedDiff = (fusedCross.get(b) ?? 0) - (fusedCross.get(a) ?? 0)
 			if (fusedDiff !== 0) return fusedDiff
-			const lexicalDiff = getUnifiedLexicalScore(b) - getUnifiedLexicalScore(a)
+			const lexicalDiff =
+				(lexicalScoreByKey.get(b) ?? 0) - (lexicalScoreByKey.get(a) ?? 0)
 			if (lexicalDiff !== 0) return lexicalDiff
 			const entityDiff = getEntityScore(b) - getEntityScore(a)
 			if (entityDiff !== 0) return entityDiff

--- a/packages/worker/src/mcp/capabilities/unified-search.ts
+++ b/packages/worker/src/mcp/capabilities/unified-search.ts
@@ -40,6 +40,83 @@ function buildSkillUsage(skillName: string): string {
 	return `Run with meta_run_skill: ${runArgs}. Optionally include "params": { ... }. To inspect code, call meta_get_skill then execute.`
 }
 
+function normalizeSearchPhrase(value: string | null | undefined): string {
+	return (value ?? '')
+		.toLowerCase()
+		.replace(/[-_]+/g, ' ')
+		.replace(/[^a-z0-9\s]+/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim()
+}
+
+function scoreSkillPhraseMatch(
+	normalizedQuery: string,
+	value: string | null | undefined,
+): number {
+	const normalizedValue = normalizeSearchPhrase(value)
+	if (!normalizedQuery || !normalizedValue) return 0
+	if (normalizedValue === normalizedQuery) return 1.5
+	if (normalizedValue.includes(normalizedQuery)) return 1
+	return 0
+}
+
+function scoreSkillLexicalMatch(
+	query: string,
+	row: McpSkillRow,
+	doc: string,
+	keywords: ReadonlyArray<string>,
+): number {
+	const normalizedQuery = normalizeSearchPhrase(query)
+	let bonus = 0
+
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.name) * 2
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.title) * 1.5
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.description) * 1.25
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.search_text) * 1
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.collection_name) * 0.25
+	for (const keyword of keywords) {
+		bonus += scoreSkillPhraseMatch(normalizedQuery, keyword) * 0.5
+	}
+
+	return lexicalScore(query, doc) + bonus
+}
+
+function scoreCapabilityLexicalMatch(
+	query: string,
+	hit: CapabilitySearchHit,
+): number {
+	const normalizedQuery = normalizeSearchPhrase(query)
+	const doc = [hit.name, hit.domain, hit.description].join('\n')
+	let bonus = 0
+	bonus += scoreSkillPhraseMatch(normalizedQuery, hit.name) * 1.5
+	bonus += scoreSkillPhraseMatch(normalizedQuery, hit.description) * 1
+	return lexicalScore(query, doc) + bonus
+}
+
+function scoreSecretLexicalMatch(query: string, hit: SecretSearchHit): number {
+	const normalizedQuery = normalizeSearchPhrase(query)
+	const doc = [hit.name, hit.description].join('\n')
+	let bonus = 0
+	bonus += scoreSkillPhraseMatch(normalizedQuery, hit.name) * 1.5
+	bonus += scoreSkillPhraseMatch(normalizedQuery, hit.description) * 1
+	return lexicalScore(query, doc) + bonus
+}
+
+function scoreUiArtifactLexicalMatch(
+	query: string,
+	hit: UiArtifactSearchHit,
+): number {
+	const normalizedQuery = normalizeSearchPhrase(query)
+	const parameterText = (hit.parameters ?? [])
+		.map((parameter) => `${parameter.name} ${parameter.description}`)
+		.join('\n')
+	const doc = [hit.title, hit.description, hit.runtime, parameterText].join('\n')
+	let bonus = 0
+	bonus += scoreSkillPhraseMatch(normalizedQuery, hit.title) * 1.5
+	bonus += scoreSkillPhraseMatch(normalizedQuery, hit.description) * 1
+	return lexicalScore(query, doc) + bonus
+}
+
 function skillRowEmbedDoc(
 	row: McpSkillRow,
 	specs: Record<string, CapabilitySpec>,
@@ -56,6 +133,7 @@ function skillRowEmbedDoc(
 		inferred = []
 	}
 	return buildSkillEmbedText({
+		skillName: row.name,
 		title: row.title,
 		description: row.description,
 		collectionName: row.collection_name,
@@ -188,9 +266,21 @@ async function searchSkillsForUser(input: {
 			(row) => [row.id, skillRowEmbedDoc(row, input.specs)] as const,
 		),
 	)
+	const keywordsById = Object.fromEntries(
+		filteredRows.map((row) => [row.id, parseJsonStringArray(row.keywords)] as const),
+	)
+	const lexicalScoreById = Object.fromEntries(
+		ids.map((id) => {
+			const row = idSet.get(id)!
+			return [
+				id,
+				scoreSkillLexicalMatch(q, row, docsById[id]!, keywordsById[id] ?? []),
+			] as const
+		}),
+	)
 
 	const lexicalOrder = sortIdsByScore(ids, (id) =>
-		lexicalScore(q, docsById[id]!),
+		lexicalScoreById[id]!,
 	)
 
 	let vectorOrder: Array<string>
@@ -262,10 +352,18 @@ async function searchSkillsForUser(input: {
 		[lexicalOrder, vectorOrder],
 		CAPABILITY_SEARCH_RRF_K,
 	)
-	const ordered = sortIdsByScore(ids, (id) => fused.get(id) ?? 0).slice(
-		0,
-		Math.max(1, Math.min(input.limit, ids.length)),
-	)
+	const ordered = [...ids]
+		.sort((a, b) => {
+			const fusedDiff = (fused.get(b) ?? 0) - (fused.get(a) ?? 0)
+			if (fusedDiff !== 0) return fusedDiff
+			const lexicalDiff = lexicalScoreById[b]! - lexicalScoreById[a]!
+			if (lexicalDiff !== 0) return lexicalDiff
+			return (
+				(vectorRankById.get(a) ?? Number.MAX_SAFE_INTEGER) -
+				(vectorRankById.get(b) ?? Number.MAX_SAFE_INTEGER)
+			)
+		})
+		.slice(0, Math.max(1, Math.min(input.limit, ids.length)))
 
 	const matches = ordered.map((id) => {
 		const row = idSet.get(id)!
@@ -355,10 +453,11 @@ export async function searchUnified(input: {
 	const builtinFilter: VectorizeVectorMetadataFilter = {
 		kind: { $eq: 'builtin' },
 	}
+	const candidateLimit = Math.min(100, Math.max(input.limit * 3, 25))
 	const capResult = await searchCapabilities({
 		env: input.env,
 		query: input.query,
-		limit: input.limit,
+		limit: candidateLimit,
 		detail: false,
 		specs: input.specs,
 		vectorMetadataFilter: isCapabilitySearchOffline(input.env)
@@ -387,13 +486,13 @@ export async function searchUnified(input: {
 	if (input.userId) {
 		secretResult = await searchSecretsForUser({
 			query: input.query,
-			limit: input.limit,
+			limit: candidateLimit,
 			rows: input.userSecretRows,
 		})
 		skillResult = await searchSkillsForUser({
 			env: input.env,
 			query: input.query,
-			limit: input.limit,
+			limit: candidateLimit,
 			specs: input.specs,
 			userId: input.userId,
 			collectionSlug: input.skillCollectionSlug,
@@ -403,28 +502,12 @@ export async function searchUnified(input: {
 			baseUrl: input.baseUrl,
 			env: input.env,
 			query: input.query,
-			limit: input.limit,
+			limit: candidateLimit,
 			userId: input.userId,
 			rows: input.uiArtifactRows,
 			appSecretsByAppId: input.appSecretsByAppId,
 		})
 	}
-
-	const capKeys = capResult.matches.map((m) => `c:${m.name}`)
-	const skillKeys = skillResult.matches.map((m) => `s:${m.skillName}`)
-	const secretKeys = secretResult.matches.map((m) => `u:${m.name}`)
-	const uiArtifactKeys = uiArtifactResult.matches.map((m) => `a:${m.appId}`)
-	const fusedCross = reciprocalRankFusion(
-		[capKeys, skillKeys, secretKeys, uiArtifactKeys],
-		CAPABILITY_SEARCH_RRF_K,
-	)
-	const allKeys = [
-		...new Set([...capKeys, ...skillKeys, ...secretKeys, ...uiArtifactKeys]),
-	]
-	const sortedKeys = sortIdsByScore(
-		allKeys,
-		(k) => fusedCross.get(k) ?? 0,
-	).slice(0, Math.max(1, input.limit))
 
 	const capByName = new Map(capResult.matches.map((m) => [m.name, m] as const))
 	const skillByName = new Map(
@@ -436,6 +519,80 @@ export async function searchUnified(input: {
 	const uiArtifactById = new Map(
 		uiArtifactResult.matches.map((m) => [m.appId, m] as const),
 	)
+	const capKeys = capResult.matches.map((m) => `c:${m.name}`)
+	const skillKeys = skillResult.matches.map((m) => `s:${m.skillName}`)
+	const secretKeys = secretResult.matches.map((m) => `u:${m.name}`)
+	const uiArtifactKeys = uiArtifactResult.matches.map((m) => `a:${m.appId}`)
+	const fusedCross = reciprocalRankFusion(
+		[capKeys, skillKeys, secretKeys, uiArtifactKeys],
+		CAPABILITY_SEARCH_RRF_K,
+	)
+	const allKeys = [
+		...new Set([...capKeys, ...skillKeys, ...secretKeys, ...uiArtifactKeys]),
+	]
+	function getEntityScore(key: string): number {
+		if (key.startsWith('c:')) {
+			return capByName.get(key.slice(2))?.fusedScore ?? 0
+		}
+		if (key.startsWith('s:')) {
+			return skillByName.get(key.slice(2))?.fusedScore ?? 0
+		}
+		if (key.startsWith('u:')) {
+			return secretByName.get(key.slice(2))?.fusedScore ?? 0
+		}
+		if (key.startsWith('a:')) {
+			return uiArtifactById.get(key.slice(2))?.fusedScore ?? 0
+		}
+		return 0
+	}
+	function getUnifiedLexicalScore(key: string): number {
+		if (key.startsWith('c:')) {
+			const hit = capByName.get(key.slice(2))
+			return hit ? scoreCapabilityLexicalMatch(input.query, hit) : 0
+		}
+		if (key.startsWith('s:')) {
+			const hit = skillByName.get(key.slice(2))
+			if (!hit) return 0
+			return (
+				lexicalScore(input.query, [
+					hit.skillName,
+					hit.title,
+					hit.description,
+					hit.collection ?? '',
+					hit.keywords.join(' '),
+				].join('\n')) +
+				scoreSkillPhraseMatch(normalizeSearchPhrase(input.query), hit.skillName) *
+					2 +
+				scoreSkillPhraseMatch(normalizeSearchPhrase(input.query), hit.title) *
+					1.5 +
+				scoreSkillPhraseMatch(
+					normalizeSearchPhrase(input.query),
+					hit.description,
+				) *
+					1.25
+			)
+		}
+		if (key.startsWith('u:')) {
+			const hit = secretByName.get(key.slice(2))
+			return hit ? scoreSecretLexicalMatch(input.query, hit) : 0
+		}
+		if (key.startsWith('a:')) {
+			const hit = uiArtifactById.get(key.slice(2))
+			return hit ? scoreUiArtifactLexicalMatch(input.query, hit) : 0
+		}
+		return 0
+	}
+	const sortedKeys = [...allKeys]
+		.sort((a, b) => {
+			const fusedDiff = (fusedCross.get(b) ?? 0) - (fusedCross.get(a) ?? 0)
+			if (fusedDiff !== 0) return fusedDiff
+			const lexicalDiff = getUnifiedLexicalScore(b) - getUnifiedLexicalScore(a)
+			if (lexicalDiff !== 0) return lexicalDiff
+			const entityDiff = getEntityScore(b) - getEntityScore(a)
+			if (entityDiff !== 0) return entityDiff
+			return a.localeCompare(b)
+		})
+		.slice(0, Math.max(1, input.limit))
 
 	const matches: Array<UnifiedSearchMatch> = []
 	for (const key of sortedKeys) {

--- a/packages/worker/src/mcp/capabilities/unified-search.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/unified-search.workers.test.ts
@@ -120,6 +120,80 @@ test('skill collection filter narrows saved skill matches', async () => {
 	expect(skill.collection).toBe('GitHub Workflows')
 })
 
+test('skill name and description matches survive cross-entity ranking', async () => {
+	const env = { SENTRY_ENVIRONMENT: 'test' } as Env
+	const specs = {
+		launch_agent: {
+			name: 'launch_agent',
+			domain: 'coding',
+			description: 'Launch an agent for generic coding work.',
+			keywords: ['launch', 'agent', 'coding'],
+			readOnly: true,
+			idempotent: true,
+			destructive: false,
+			inputFields: ['task'],
+			requiredInputFields: ['task'],
+			outputFields: ['agentId'],
+			inputSchema: {},
+		},
+		cursor_docs: {
+			name: 'cursor_docs',
+			domain: 'coding',
+			description: 'Look up Cursor product documentation.',
+			keywords: ['cursor', 'docs'],
+			readOnly: true,
+			idempotent: true,
+			destructive: false,
+			inputFields: ['query'],
+			requiredInputFields: ['query'],
+			outputFields: ['results'],
+			inputSchema: {},
+		},
+		cursor_agent_status: {
+			name: 'cursor_agent_status',
+			domain: 'coding',
+			description: 'Inspect the status of an existing Cursor agent.',
+			keywords: ['cursor', 'agent', 'status'],
+			readOnly: true,
+			idempotent: true,
+			destructive: false,
+			inputFields: ['agentId'],
+			requiredInputFields: ['agentId'],
+			outputFields: ['status'],
+			inputSchema: {},
+		},
+	} satisfies Record<string, CapabilitySpec>
+	const skillRow: McpSkillRow = {
+		...createSkillRow('launch-cursor-cloud-agent'),
+		name: 'launch-cursor-cloud-agent',
+		title: 'Launch Cursor Cloud Agent',
+		description: 'Launch a Cursor Cloud Agent for an autonomous coding task.',
+		collection_name: 'Cursor',
+		collection_slug: 'cursor',
+		keywords: JSON.stringify(['cursor', 'cloud', 'agent', 'launch']),
+		search_text: 'launch cursor cloud agent autonomous coding task',
+	}
+
+	const result = await searchUnified({
+		env,
+		baseUrl: 'http://localhost',
+		query: 'launch Cursor Cloud agent',
+		limit: 5,
+		specs,
+		userId: 'user-123',
+		skillRows: [skillRow],
+		uiArtifactRows: [],
+		userSecretRows: [],
+		appSecretsByAppId: new Map(),
+	})
+
+	expect(result.matches[0]).toMatchObject({
+		type: 'skill',
+		skillName: 'launch-cursor-cloud-agent',
+		title: 'Launch Cursor Cloud Agent',
+	})
+})
+
 test('search can return standalone user secrets and nest app secrets on apps', async () => {
 	const env = { SENTRY_ENVIRONMENT: 'test' } as Env
 	const specs = {} as Record<string, CapabilitySpec>

--- a/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
@@ -311,6 +311,74 @@ test('mcp server saves and browses skill collections', async () => {
 	)
 })
 
+test('mcp search surfaces strongly matching saved skills without collection filters', async () => {
+	await using database = await createTestDatabase()
+	await using server = await startDevServer(database.persistDir)
+	await using mcpClient = await createMcpClient(server.origin, database.user)
+
+	const saveResult = await mcpClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.meta_save_skill({
+					name: 'launch-cursor-cloud-agent',
+					title: 'Launch Cursor Cloud Agent',
+					description: 'Launch a Cursor Cloud Agent for autonomous coding tasks.',
+					collection: 'Cursor',
+					keywords: ['cursor', 'cloud', 'agent', 'launch'],
+					code: 'async () => ({ ok: true })',
+					search_text: 'launch cursor cloud agent autonomous coding task',
+					read_only: true,
+					idempotent: true,
+					destructive: false,
+				})
+			}`,
+		},
+	})
+	const saveStructured = (saveResult as CallToolResult).structuredContent as
+		| {
+				result?: {
+					name?: string
+				}
+		  }
+		| undefined
+	expect(saveStructured?.result?.name).toBe('launch-cursor-cloud-agent')
+
+	for (const query of ['launch Cursor Cloud agent', 'Cursor Cloud agent']) {
+		const searchResult = await mcpClient.client.callTool({
+			name: 'search',
+			arguments: {
+				query,
+				limit: 10,
+				maxResponseSize: 20_000,
+			},
+		})
+		const searchText = getTextContent((searchResult as CallToolResult).content)
+		const searchStructured = (searchResult as CallToolResult)
+			.structuredContent as
+			| {
+					result?: {
+						matches?: Array<{
+							type?: string
+							id?: string
+							name?: string
+							title?: string
+						}>
+					}
+			  }
+			| undefined
+
+		expect(searchText).toContain('Launch Cursor Cloud Agent')
+		expect(searchStructured?.result?.matches?.some((match) => {
+			return (
+				match.type === 'skill' &&
+				match.id === 'launch-cursor-cloud-agent' &&
+				match.name === 'launch-cursor-cloud-agent'
+			)
+		})).toBe(true)
+	}
+})
+
 test('mcp server executes user code against codemode and tracks execute context', async () => {
 	await using database = await createTestDatabase()
 	await using server = await startDevServer(database.persistDir)

--- a/packages/worker/src/mcp/skills/skill-embed-and-flags.node.test.ts
+++ b/packages/worker/src/mcp/skills/skill-embed-and-flags.node.test.ts
@@ -59,6 +59,7 @@ test('buildSkillEmbedText keeps inferred capability names lightweight', () => {
 		},
 	]
 	const text = buildSkillEmbedText({
+		skillName: 'launch-cursor-cloud-agent',
 		title: 't',
 		description: 'd',
 		collectionName: 'GitHub automation',
@@ -72,6 +73,8 @@ test('buildSkillEmbedText keeps inferred capability names lightweight', () => {
 	const lines = text.split('\n')
 	expect(lines).toEqual(
 		expect.arrayContaining([
+			'name launch-cursor-cloud-agent',
+			'launch cursor cloud agent',
 			't',
 			'd',
 			'collection GitHub automation',

--- a/packages/worker/src/mcp/skills/skill-embed-and-flags.ts
+++ b/packages/worker/src/mcp/skills/skill-embed-and-flags.ts
@@ -26,6 +26,7 @@ export function mergeInferredCapabilityNames(input: {
 
 export function buildSkillEmbedText(
 	input: {
+		skillName?: string | null
 		title: string
 		description: string
 		collectionName?: string | null
@@ -38,7 +39,15 @@ export function buildSkillEmbedText(
 	},
 	maxChars: number = defaultSkillEmbedMaxChars,
 ): string {
+	const normalizedSkillName = input.skillName?.trim()
+	const humanizedSkillName = normalizedSkillName?.replace(/[-_]+/g, ' ')
 	const baseParts = [
+		...(normalizedSkillName
+			? [
+					`name ${normalizedSkillName}`,
+					...(humanizedSkillName ? [humanizedSkillName] : []),
+				]
+			: []),
 		input.title,
 		input.description,
 		...(input.collectionName

--- a/packages/worker/src/mcp/skills/skill-mutation.ts
+++ b/packages/worker/src/mcp/skills/skill-mutation.ts
@@ -41,6 +41,7 @@ export async function buildSkillEmbedTextFromStoredRow(
 		inferred = []
 	}
 	return buildSkillEmbedText({
+		skillName: row.name,
 		title: row.title,
 		description: row.description,
 		collectionName: row.collection_name,
@@ -135,6 +136,7 @@ export async function prepareSkillPersistence(
 	const collection = parseSkillCollection(args.collection)
 	const skillName = normalizeSkillName(args.name)
 	const embedText = buildSkillEmbedText({
+		skillName,
 		title: args.title,
 		description: args.description,
 		collectionName: collection?.name ?? null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- improve saved-skill search relevance by indexing canonical skill names alongside titles and descriptions
- strengthen saved-skill lexical ranking and cross-entity tie-breaking for natural-language queries
- add regressions covering `launch-cursor-cloud-agent` discoverability without `skill_collection`

## Testing
- `npm run test -- packages/worker/src/mcp/skills/skill-embed-and-flags.node.test.ts packages/worker/src/mcp/capabilities/unified-search.workers.test.ts`
- `npm run test:mcp -- packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts`
- Validation artifact: `/opt/cursor/artifacts/search-ranking-validation.txt`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04c19e2f-633a-40c5-8b28-88f94fd33942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04c19e2f-633a-40c5-8b28-88f94fd33942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced unified search ranking with phrase normalization, per-entity lexical scoring, and refined tie-breaking for more relevant results
  * Improved cross-entity result ordering and bounded candidate selection for consistent rankings
  * Skill names are now included in embed text and factored into search relevance

* **Tests**
  * Added unit and e2e tests validating strong skill matching across unified search
  * Updated skill embed text validation tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->