### PR TITLE
Add parameter support to generated UI executeCode

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -11,6 +11,11 @@ capability call takes one **args** object that matches that capability’s
 **inputSchema** and returns data that matches its **outputSchema** when one
 exists.
 
+**execute** also accepts optional **`params`**. When provided, Kody injects that
+JSON object as **`params`** when invoking your async function, so code like
+**`async (params) => { ... }`** can read structured inputs without manually
+stringifying them into the source.
+
 ## Chaining
 
 Prefer **one execute** when the plan is clear: call several capabilities in a

--- a/docs/use/skills-and-apps.md
+++ b/docs/use/skills-and-apps.md
@@ -30,6 +30,10 @@ Import **`kodyWidget`** from **`@kody/ui-utils`** for helpers, **`executeCode`**
 for low-level server calls, secrets, values, OAuth, and forms. Use generated UI
 when the user must enter sensitive data instead of pasting into chat.
 
+`kodyWidget.executeCode(code, params?)` also accepts optional per-call JSON
+params. Those values are injected as **`params`** inside the async function and
+override saved-app/session params for that execution only.
+
 For third-party OAuth, run **`kody_official_guide`** with **`guide`**
 **`oauth`** first (hosted **`/connect/oauth`**). Use **`guide`**
 **`generated_ui_oauth`** only for OAuth built inside a saved app.

--- a/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
+++ b/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
@@ -180,6 +180,21 @@ test('buildCodemodeCapabilityExecuteCode serializes capability calls safely', ()
 	)
 })
 
+test('kodyWidget public api exposes executeCode helper', () => {
+	const readyState = getOrCreateKodyWidgetReadyStateForTest()
+	readyState.reset()
+	const fakeWidget = {
+		params: {},
+		executeCode: async () => 'ok',
+	} as {
+		params: Record<string, never>
+		executeCode: (code: string, params?: Record<string, unknown>) => Promise<string>
+	}
+	readyState.resolve(fakeWidget)
+
+	expect(typeof kodyWidget.executeCode).toBe('function')
+})
+
 test('getKodyWidget throws until the runtime is ready', () => {
 	const readyState = getOrCreateKodyWidgetReadyStateForTest()
 	readyState.reset()

--- a/packages/worker/client/mcp-apps/kody-ui-utils.ts
+++ b/packages/worker/client/mcp-apps/kody-ui-utils.ts
@@ -320,10 +320,14 @@ export function readSavedAppSourceFromHostToolResult(
 async function executeCodeWithHostTool(
 	hostBridge: ReturnType<typeof createWidgetHostBridge>,
 	code: string,
+	params?: Record<string, unknown>,
 ) {
 	const result = (await hostBridge.callTool({
 		name: 'execute',
-		arguments: { code },
+		arguments: {
+			code,
+			...(params ? { params } : {}),
+		},
 		timeoutMs: 90_000,
 	})) as HostToolResult | null
 	const errorMessage = getHostToolErrorMessage(result)
@@ -369,7 +373,10 @@ type GeneratedUiRuntimeHooks = {
 	requestDisplayMode?: (
 		mode: DisplayMode,
 	) => DisplayMode | null | Promise<DisplayMode | null>
-	executeCode?: (code: string) => unknown | Promise<unknown>
+	executeCode?: (
+		code: string,
+		params?: Record<string, unknown>,
+	) => unknown | Promise<unknown>
 }
 
 type GeneratedUiWindow = Window &
@@ -462,6 +469,7 @@ function getSessionRequestTarget(
 async function executeCodeWithHttp(
 	appSession: AppSessionHttpContext | null | undefined,
 	code: string,
+	params?: Record<string, unknown>,
 ) {
 	const target = getSessionRequestTarget(appSession, 'execute')
 	if (!target) {
@@ -473,7 +481,10 @@ async function executeCodeWithHttp(
 	const { response, payload } = await fetchJsonResponse({
 		url: target.url,
 		method: 'POST',
-		body: { code },
+		body: {
+			code,
+			...(params ? { params } : {}),
+		},
 		token: target.token,
 	})
 	if (!response.ok || !payload || payload.ok !== true) {
@@ -641,12 +652,16 @@ async function initializeRenderedMcpDocument(
 		sendMessage: (text) => hostBridge.sendUserMessageWithFallback(text),
 		openLink: (url) => hostBridge.openLink(url),
 		requestDisplayMode,
-		executeCode: async (code) => {
-			const viaHttp = await executeCodeWithHttp(bootstrap.appSession, code)
+		executeCode: async (code, params) => {
+			const viaHttp = await executeCodeWithHttp(
+				bootstrap.appSession,
+				code,
+				params,
+			)
 			if (viaHttp.handled) {
 				return viaHttp.result
 			}
-			return await executeCodeWithHostTool(hostBridge, code)
+			return await executeCodeWithHostTool(hostBridge, code, params)
 		},
 	})
 	initializeGeneratedUiRuntime()

--- a/packages/worker/client/mcp-apps/kody-widget-runtime.ts
+++ b/packages/worker/client/mcp-apps/kody-widget-runtime.ts
@@ -127,6 +127,7 @@ type MessageLogRefs = {
 
 export type KodyWidgetPublicApi = Record<string, unknown> & {
 	params: JsonRecord
+	executeCode: (code: string, params?: JsonRecord) => Promise<unknown>
 }
 
 type KodyWidgetReadyState = {
@@ -145,7 +146,10 @@ type KodyWindow = Window &
 			requestDisplayMode?: (
 				mode: DisplayMode,
 			) => DisplayMode | null | Promise<DisplayMode | null>
-			executeCode?: (code: string) => unknown | Promise<unknown>
+			executeCode?: (
+				code: string,
+				params?: JsonRecord,
+			) => unknown | Promise<unknown>
 		}
 		__kodyLocalMessageLogRoot?: HTMLElement | null
 		__kodyLocalMessageLogList?: HTMLElement | null
@@ -935,7 +939,7 @@ export function initializeGeneratedUiRuntime() {
 		return { response, payload }
 	}
 
-	async function executeCodeWithHttp(code: string) {
+	async function executeCodeWithHttp(code: string, params?: JsonRecord) {
 		const target = getSessionRequestTarget('execute')
 		if (!target) {
 			throw new Error('Code execution is unavailable in this context.')
@@ -943,7 +947,10 @@ export function initializeGeneratedUiRuntime() {
 		const { response, payload } = await fetchJsonResponse({
 			url: target.url,
 			method: 'POST',
-			body: { code },
+			body: {
+				code,
+				...(params ? { params } : {}),
+			},
 			token: target.token,
 		})
 		if (!response.ok || !payload || payload.ok !== true) {
@@ -1056,16 +1063,16 @@ export function initializeGeneratedUiRuntime() {
 		return null
 	}
 
-	async function executeCodeInCurrentContext(code: string) {
+	async function executeCodeInCurrentContext(code: string, params?: JsonRecord) {
 		if (runtimeMode === 'hosted') {
-			return await executeCodeWithHttp(code)
+			return await executeCodeWithHttp(code, params)
 		}
 		if (runtimeMode === 'mcp') {
 			const hook = getRuntimeHooks().executeCode
 			if (typeof hook === 'function') {
-				return await hook(code)
+				return await hook(code, params)
 			}
-			return await executeCodeWithHttp(code)
+			return await executeCodeWithHttp(code, params)
 		}
 		return null
 	}
@@ -1129,9 +1136,12 @@ export function initializeGeneratedUiRuntime() {
 			}
 			return await requestDisplayMode('fullscreen')
 		},
-		async executeCode(code: string) {
+		async executeCode(code: string, params?: JsonRecord) {
 			if (typeof code !== 'string' || code.length === 0) return null
-			return await executeCodeInCurrentContext(code)
+			if (params != null && !isRecord(params)) {
+				throw new Error('executeCode params must be an object.')
+			}
+			return await executeCodeInCurrentContext(code, params)
 		},
 		async saveSecret(input: any): Promise<SaveSecretResult> {
 			if (!input || typeof input !== 'object') {

--- a/packages/worker/src/mcp/generated-ui-api.ts
+++ b/packages/worker/src/mcp/generated-ui-api.ts
@@ -27,6 +27,7 @@ import {
 
 const executeRequestSchema = z.object({
 	code: z.string().min(1),
+	params: z.record(z.string(), z.unknown()).optional(),
 })
 
 const secretMutationSchema = z.object({
@@ -216,6 +217,13 @@ function createGeneratedUiExecuteHandler(env: Env) {
 			if (!body.success) {
 				return jsonResponse({ error: body.error.message }, 400)
 			}
+			const mergedParams =
+				body.data.params == null
+					? context.params
+					: {
+							...context.params,
+							...body.data.params,
+						}
 			const result = await runCodemodeWithRegistry(
 				env,
 				createMcpCallerContext({
@@ -228,7 +236,7 @@ function createGeneratedUiExecuteHandler(env: Env) {
 					},
 				}),
 				body.data.code,
-				Object.keys(context.params).length > 0 ? context.params : undefined,
+				Object.keys(mergedParams).length > 0 ? mergedParams : undefined,
 				workerExports,
 			)
 			if (result.error) {

--- a/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
@@ -913,6 +913,71 @@ test('generated UI execute supports session storage context', async () => {
 	expect(payload.result?.result?.value).toBe('value')
 })
 
+test('generated UI execute merges per-call params over session params', async () => {
+	await using database = await createTestDatabase()
+	await using server = await startDevServer(database.persistDir)
+	await using mcpClient = await createMcpClient(server.origin, database.user)
+
+	const openResult = await mcpClient.client.callTool({
+		name: 'open_generated_ui',
+		arguments: {
+			code: '<main><h1>Parameterized Execute</h1></main>',
+		},
+	})
+	const openStructured = (openResult as CallToolResult).structuredContent as
+		| {
+				appSession?: {
+					token?: string
+					endpoints?: {
+						execute?: string
+					}
+				} | null
+		  }
+		| undefined
+	const executeEndpoint = openStructured?.appSession?.endpoints?.execute
+	const executeToken = openStructured?.appSession?.token
+	expect(typeof executeEndpoint).toBe('string')
+	expect(typeof executeToken).toBe('string')
+
+	const response = await fetch(executeEndpoint!, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${executeToken}`,
+			'Content-Type': 'application/json',
+			Accept: 'application/json',
+		},
+		body: JSON.stringify({
+			code: `async (params) => ({
+				owner: params.owner,
+				limit: params.limit,
+				nested: params.nested,
+			})`,
+			params: {
+				owner: 'override-owner',
+				limit: 5,
+				nested: { enabled: true },
+			},
+		}),
+	})
+	expect(response.ok).toBe(true)
+	const payload = (await response.json()) as {
+		ok?: boolean
+		result?: {
+			owner?: string
+			limit?: number
+			nested?: {
+				enabled?: boolean
+			}
+		}
+	}
+	expect(payload.ok).toBe(true)
+	expect(payload.result).toEqual({
+		owner: 'override-owner',
+		limit: 5,
+		nested: { enabled: true },
+	})
+})
+
 test('mcp server stores connector configs without resolving secret policies', async () => {
 	await using database = await createTestDatabase()
 	await using server = await startDevServer(database.persistDir)

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -31,6 +31,7 @@ test('registers the execute tool contract', async () => {
 	expect((definition?.description ?? '').length).toBeGreaterThan(0)
 	expect(Object.keys(definition?.inputSchema ?? {})).toEqual([
 		'code',
+		'params',
 		'conversationId',
 		'memoryContext',
 	])

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -75,6 +75,12 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 				code: z
 					.string()
 					.describe('JavaScript async arrow function to execute capabilities.'),
+				params: z
+					.record(z.string(), z.unknown())
+					.optional()
+					.describe(
+						'Optional JSON params injected as `params` when invoking the async function.',
+					),
 				conversationId: conversationIdInputField,
 				memoryContext: memoryContextInputField,
 			},
@@ -82,9 +88,11 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 		},
 		async ({
 			code,
+			params,
 			conversationId,
 		}: {
 			code: string
+			params?: Record<string, unknown>
 			conversationId?: string
 			memoryContext?: z.infer<typeof memoryContextInputField>
 		}) => {
@@ -115,7 +123,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 						env,
 						callerContext,
 						code,
-						undefined,
+						params,
 						agent.getLoopbackExports(),
 					),
 			)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- allow MCP `execute` to accept optional JSON `params` injected as `params` in the async function
- allow generated UI `kodyWidget.executeCode(code, params?)` to forward per-call params through both session HTTP and MCP host-tool execution
- merge per-call generated UI params over session params and cover the behavior with targeted tests

## Testing
- `npm run test -- packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts packages/worker/src/mcp/tools/execute.node.test.ts packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts`
- `npx vitest run --config vitest.mcp-e2e.config.ts packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82c036f6-3f1d-4686-aa3d-89e9836c8898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82c036f6-3f1d-4686-aa3d-89e9836c8898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `execute` and `executeCode` now accept optional `params` argument
  * Parameters are injected as arguments into executed async functions
  * Per-call params override session parameters for that specific execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->