### PR TITLE
Hide approved OAuth host links

### DIFF
--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -295,17 +295,20 @@ test('connect oauth omits direct host approval links when hosts are already appr
 	} as never)
 
 	expect(response.status).toBe(200)
-	await expect(response.json()).resolves.toMatchObject({
+	const payload = await response.json()
+	expect(payload).toMatchObject({
 		ok: true,
 		accessTokenSaved: true,
 		refreshTokenSaved: true,
-		allowedHosts: [
-			'auth.tesla.com',
-			'fleet-api.prd.na.vn.cloud.tesla.com',
-			'fleet-auth.prd.vn.cloud.tesla.com',
-		],
 		hostApprovalLinks: [],
 		connectorName: 'Tesla',
 	})
+	expect(payload.allowedHosts).toEqual(
+		expect.arrayContaining([
+			'auth.tesla.com',
+			'fleet-api.prd.na.vn.cloud.tesla.com',
+			'fleet-auth.prd.vn.cloud.tesla.com',
+		]),
+	)
 	expect(mockModule.createSecretHostApprovalToken).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -128,7 +128,6 @@ function createEnv() {
 }
 
 test('connect oauth returns direct host approval links for saved token secrets', async () => {
-	vi.clearAllMocks()
 	const handler = createAccountSecretsApiHandler(createEnv())
 	const response = await handler.action({
 		request: new Request('https://example.com/account/secrets.json', {
@@ -233,7 +232,6 @@ test('connect oauth returns direct host approval links for saved token secrets',
 })
 
 test('connect oauth omits direct host approval links when hosts are already approved', async () => {
-	vi.clearAllMocks()
 	mockModule.listSecrets.mockResolvedValueOnce([
 		{
 			name: 'teslaAccessToken',

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -128,6 +128,7 @@ function createEnv() {
 }
 
 test('connect oauth returns direct host approval links for saved token secrets', async () => {
+	vi.clearAllMocks()
 	const handler = createAccountSecretsApiHandler(createEnv())
 	const response = await handler.action({
 		request: new Request('https://example.com/account/secrets.json', {
@@ -229,4 +230,82 @@ test('connect oauth returns direct host approval links for saved token secrets',
 			storageContext: { sessionId: null, appId: null },
 		}),
 	)
+})
+
+test('connect oauth omits direct host approval links when hosts are already approved', async () => {
+	vi.clearAllMocks()
+	mockModule.listSecrets.mockResolvedValueOnce([
+		{
+			name: 'teslaAccessToken',
+			scope: 'user',
+			description: '',
+			appId: null,
+			allowedHosts: [
+				'auth.tesla.com',
+				'fleet-api.prd.na.vn.cloud.tesla.com',
+				'fleet-auth.prd.vn.cloud.tesla.com',
+			],
+			allowedCapabilities: [],
+			createdAt: new Date(0).toISOString(),
+			updatedAt: new Date(0).toISOString(),
+			ttlMs: null,
+		},
+		{
+			name: 'teslaRefreshToken',
+			scope: 'user',
+			description: '',
+			appId: null,
+			allowedHosts: [
+				'auth.tesla.com',
+				'fleet-api.prd.na.vn.cloud.tesla.com',
+				'fleet-auth.prd.vn.cloud.tesla.com',
+			],
+			allowedCapabilities: [],
+			createdAt: new Date(0).toISOString(),
+			updatedAt: new Date(0).toISOString(),
+			ttlMs: null,
+		},
+	])
+
+	const handler = createAccountSecretsApiHandler(createEnv())
+	const response = await handler.action({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'connect_oauth',
+				provider: 'Tesla',
+				tokenUrl: 'https://auth.tesla.com/oauth2/v3/token',
+				apiBaseUrl: 'https://fleet-api.prd.na.vn.cloud.tesla.com',
+				flow: 'pkce',
+				clientIdValueName: 'tesla-client-id',
+				accessTokenSecretName: 'teslaAccessToken',
+				refreshTokenSecretName: 'teslaRefreshToken',
+				allowedHosts: [
+					'fleet-api.prd.na.vn.cloud.tesla.com',
+					'fleet-auth.prd.vn.cloud.tesla.com',
+				],
+				tokenPayload: {
+					access_token: 'access-token',
+					refresh_token: 'refresh-token',
+				},
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toMatchObject({
+		ok: true,
+		accessTokenSaved: true,
+		refreshTokenSaved: true,
+		allowedHosts: [
+			'auth.tesla.com',
+			'fleet-api.prd.na.vn.cloud.tesla.com',
+			'fleet-auth.prd.vn.cloud.tesla.com',
+		],
+		hostApprovalLinks: [],
+		connectorName: 'Tesla',
+	})
+	expect(mockModule.createSecretHostApprovalToken).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -415,6 +415,15 @@ async function buildConnectOauthHostApprovalLinks(input: {
 		0,
 		maxConnectOauthApprovalSecrets,
 	)
+	const secrets = await listSecrets({
+		env: input.env,
+		userId: input.userId,
+		scope: 'user',
+		storageContext: null,
+	})
+	const approvedHostsBySecretName = new Map(
+		secrets.map((secret) => [secret.name, new Set(secret.allowedHosts)]),
+	)
 	const baseUrl = getAppBaseUrl({
 		env: input.env,
 		requestUrl: input.request.url,
@@ -422,6 +431,9 @@ async function buildConnectOauthHostApprovalLinks(input: {
 	const links = await Promise.all(
 		uniqueSecretNames.flatMap((secretName) =>
 			uniqueHosts.map(async (host) => {
+				if (approvedHostsBySecretName.get(secretName)?.has(host)) {
+					return null
+				}
 				const token = await createSecretHostApprovalToken(input.env, {
 					userId: input.userId,
 					name: secretName,
@@ -444,12 +456,14 @@ async function buildConnectOauthHostApprovalLinks(input: {
 			}),
 		),
 	)
-	return links.sort((left, right) => {
+	return links
+		.filter((link): link is ConnectOauthHostApprovalLink => link !== null)
+		.sort((left, right) => {
 		return (
 			left.secretName.localeCompare(right.secretName) ||
 			left.host.localeCompare(right.host)
 		)
-	})
+		})
 }
 
 async function handleOAuthExchangeAction(input: {

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -315,6 +315,16 @@ async function handleConnectOauthAction(input: {
 		)
 	}
 
+	const approvedHostsBySecretName = new Map(
+		(
+			await listSecrets({
+				env: input.env,
+				userId: input.user.mcpUser.userId,
+				scope: 'user',
+				storageContext: null,
+			})
+		).map((secret) => [secret.name, new Set(secret.allowedHosts)]),
+	)
 	const accessSaved = await saveSecret({
 		env: input.env,
 		userId: input.user.mcpUser.userId,
@@ -381,6 +391,7 @@ async function handleConnectOauthAction(input: {
 			userId: input.user.mcpUser.userId,
 			allowedHosts,
 			secretNames: approvalSecretNames,
+			approvedHostsBySecretName,
 		})
 	} catch (error) {
 		console.error('Failed to build OAuth host approval links.', {
@@ -406,6 +417,7 @@ async function buildConnectOauthHostApprovalLinks(input: {
 	userId: string
 	allowedHosts: Array<string>
 	secretNames: Array<string>
+	approvedHostsBySecretName?: Map<string, Set<string>>
 }) {
 	const uniqueHosts = Array.from(new Set(input.allowedHosts)).slice(
 		0,
@@ -415,15 +427,18 @@ async function buildConnectOauthHostApprovalLinks(input: {
 		0,
 		maxConnectOauthApprovalSecrets,
 	)
-	const secrets = await listSecrets({
-		env: input.env,
-		userId: input.userId,
-		scope: 'user',
-		storageContext: null,
-	})
-	const approvedHostsBySecretName = new Map(
-		secrets.map((secret) => [secret.name, new Set(secret.allowedHosts)]),
-	)
+	const approvedHostsBySecretName =
+		input.approvedHostsBySecretName ??
+		new Map(
+			(
+				await listSecrets({
+					env: input.env,
+					userId: input.userId,
+					scope: 'user',
+					storageContext: null,
+				})
+			).map((secret) => [secret.name, new Set(secret.allowedHosts)]),
+		)
 	const baseUrl = getAppBaseUrl({
 		env: input.env,
 		requestUrl: input.request.url,
@@ -459,10 +474,10 @@ async function buildConnectOauthHostApprovalLinks(input: {
 	return links
 		.filter((link): link is ConnectOauthHostApprovalLink => link !== null)
 		.sort((left, right) => {
-		return (
-			left.secretName.localeCompare(right.secretName) ||
-			left.host.localeCompare(right.host)
-		)
+			return (
+				left.secretName.localeCompare(right.secretName) ||
+				left.host.localeCompare(right.host)
+			)
 		})
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- filter OAuth success host approval links to only show secret/host pairs that are not already approved
- add a regression test covering already-approved Tesla token hosts
- remove redundant `vi.clearAllMocks()` calls now that shared Vitest config already enables `clearMocks: true`

### Testing
- `npm run test -- packages/worker/src/app/handlers/account-secrets.node.test.ts`
- `npm run test -- --skip-nx-cache packages/worker/src/app/handlers/account-secrets.node.test.ts`
- Seed-script manual UI setup was attempted earlier, but local `tools/seed-test-data.ts` currently fails against local Wrangler with `Couldn't find a D1 DB with the name or binding 'APP_DB' in your Wrangler configuration file.`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f626fa41-a4f3-47ef-b4e2-cdbbd0867cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f626fa41-a4f3-47ef-b4e2-cdbbd0867cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stops creating redundant host-approval links for hosts already authorized on a user's tokens, reducing unnecessary approval prompts.

* **Tests**
  * Added a test confirming existing token secrets with approved hosts succeed without producing new approval links and without triggering approval-token creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->