### PR TITLE
Fix unified search lexical tie-breakers

### DIFF
--- a/packages/worker/src/mcp/capabilities/unified-search.ts
+++ b/packages/worker/src/mcp/capabilities/unified-search.ts
@@ -127,6 +127,30 @@ function scoreUiArtifactLexicalMatch(
 	return lexicalScore(query, doc) + bonus
 }
 
+type ValueLexicalFields = Pick<
+	ValueMetadata,
+	'name' | 'description' | 'scope' | 'value' | 'appId'
+>
+
+function scoreValueLexicalBonus(
+	normalizedQuery: string,
+	row: ValueLexicalFields,
+): number {
+	let bonus = 0
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.name) * 2
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.description) * 1.5
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.scope) * 0.5
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.appId) * 0.5
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.value) * 1
+	return bonus
+}
+
+function buildValueLexicalDoc(row: ValueLexicalFields): string {
+	return [row.name, row.description, row.scope, row.value, row.appId ?? ''].join(
+		'\n',
+	)
+}
+
 function buildValueUsage(name: string, scope: ValueScope): string {
 	return `Read with value_get: ${JSON.stringify({ name, scope })}. List related persisted config with value_list${scope === 'user' ? '({ scope: "user" })' : '({ ... })'}.`
 }
@@ -137,13 +161,7 @@ function scoreValueLexicalMatch(
 	doc: string,
 ): number {
 	const normalizedQuery = normalizeSearchPhrase(query)
-	let bonus = 0
-	bonus += scoreSkillPhraseMatch(normalizedQuery, row.name) * 2
-	bonus += scoreSkillPhraseMatch(normalizedQuery, row.description) * 1.5
-	bonus += scoreSkillPhraseMatch(normalizedQuery, row.scope) * 0.5
-	bonus += scoreSkillPhraseMatch(normalizedQuery, row.appId) * 0.5
-	bonus += scoreSkillPhraseMatch(normalizedQuery, row.value) * 1
-	return lexicalScore(query, doc) + bonus
+	return lexicalScore(query, doc) + scoreValueLexicalBonus(normalizedQuery, row)
 }
 
 function buildValueEmbedDoc(row: ValueMetadata): string {
@@ -174,20 +192,41 @@ function scoreConnectorLexicalMatch(
 	entry: ConnectorSearchEntry,
 	doc: string,
 ): number {
-	const requiredHosts = entry.config.requiredHosts ?? []
 	const normalizedQuery = normalizeSearchPhrase(query)
+	return (
+		lexicalScore(query, doc) +
+		scoreConnectorLexicalBonus(normalizedQuery, {
+			connectorName: entry.config.name,
+			description: describeConnector(entry.config, entry.row.description),
+			apiBaseUrl: entry.config.apiBaseUrl ?? null,
+			flow: entry.config.flow,
+			tokenUrl: entry.config.tokenUrl,
+			requiredHosts: entry.config.requiredHosts ?? [],
+		})
+	)
+}
+
+type ConnectorLexicalFields = {
+	connectorName: string
+	description: string
+	apiBaseUrl: string | null
+	flow: ConnectorConfig['flow']
+	tokenUrl: string
+	requiredHosts: Array<string>
+}
+
+function scoreConnectorLexicalBonus(
+	normalizedQuery: string,
+	entry: ConnectorLexicalFields,
+): number {
 	let bonus = 0
-	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.config.name) * 2
+	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.connectorName) * 2
+	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.description) * 1.5
+	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.apiBaseUrl) * 1
+	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.tokenUrl) * 0.75
 	bonus +=
-		scoreSkillPhraseMatch(
-			normalizedQuery,
-			describeConnector(entry.config, entry.row.description),
-		) * 1.5
-	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.config.apiBaseUrl) * 1
-	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.config.tokenUrl) * 0.75
-	bonus +=
-		scoreSkillPhraseMatch(normalizedQuery, requiredHosts.join(' ')) * 0.75
-	return lexicalScore(query, doc) + bonus
+		scoreSkillPhraseMatch(normalizedQuery, entry.requiredHosts.join(' ')) * 0.75
+	return bonus
 }
 
 function buildConnectorEmbedDoc(entry: ConnectorSearchEntry): string {
@@ -930,16 +969,26 @@ export async function searchUnified(input: {
 		if (key.startsWith('n:')) {
 			const hit = connectorByName.get(key.slice(2))
 			if (!hit) return 0
-			return lexicalScore(
-				input.query,
-				[
-					hit.connectorName,
-					hit.description,
-					hit.flow,
-					hit.tokenUrl,
-					hit.apiBaseUrl ?? '',
-					hit.requiredHosts.join(' '),
-				].join('\n'),
+			return (
+				lexicalScore(
+					input.query,
+					[
+						hit.connectorName,
+						hit.description,
+						hit.flow,
+						hit.tokenUrl,
+						hit.apiBaseUrl ?? '',
+						hit.requiredHosts.join(' '),
+					].join('\n'),
+				) +
+				scoreConnectorLexicalBonus(normalizeSearchPhrase(input.query), {
+					connectorName: hit.connectorName,
+					description: hit.description,
+					apiBaseUrl: hit.apiBaseUrl,
+					flow: hit.flow,
+					tokenUrl: hit.tokenUrl,
+					requiredHosts: hit.requiredHosts,
+				})
 			)
 		}
 		if (key.startsWith('c:')) {
@@ -981,11 +1030,9 @@ export async function searchUnified(input: {
 		if (key.startsWith('v:')) {
 			const hit = valueById.get(key.slice(2))
 			if (!hit) return 0
-			return lexicalScore(
-				input.query,
-				[hit.name, hit.description, hit.scope, hit.value, hit.appId ?? ''].join(
-					'\n',
-				),
+			return (
+				lexicalScore(input.query, buildValueLexicalDoc(hit)) +
+				scoreValueLexicalBonus(normalizeSearchPhrase(input.query), hit)
 			)
 		}
 		if (key.startsWith('a:')) {

--- a/packages/worker/src/mcp/capabilities/unified-search.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/unified-search.workers.test.ts
@@ -330,6 +330,90 @@ test('search returns value and connector entities as first-class matches', async
 	expect(value.usage).toContain('value_get')
 })
 
+test('exact value and connector phrase matches win cross-entity lexical tiebreaks', async () => {
+	const env = { SENTRY_ENVIRONMENT: 'test' } as Env
+	const specs = {
+		github_helper: {
+			name: 'github_helper',
+			domain: 'coding',
+			description: 'Connector config for GitHub automation.',
+			keywords: ['github', 'connector', 'config'],
+			readOnly: true,
+			idempotent: true,
+			destructive: false,
+			inputFields: ['query'],
+			requiredInputFields: ['query'],
+			outputFields: ['result'],
+			inputSchema: {},
+		},
+	} satisfies Record<string, CapabilitySpec>
+	const valueRow = createValueRow('github_connector', {
+		description: 'Stored user setting',
+		value: 'enabled',
+	})
+
+	const valueResult = await searchUnified({
+		env,
+		baseUrl: 'http://localhost',
+		query: 'github connector',
+		limit: 5,
+		specs,
+		userId: 'user-123',
+		skillRows: [],
+		uiArtifactRows: [],
+		userSecretRows: [
+			{
+				name: 'github-secret',
+				scope: 'user',
+				description: 'Connector token for GitHub',
+				appId: null,
+				updatedAt: '2026-03-20T00:00:00.000Z',
+			},
+		],
+		userValueRows: [valueRow],
+		appSecretsByAppId: new Map(),
+	})
+
+	expect(valueResult.matches[0]).toMatchObject({
+		type: 'value',
+		name: 'github_connector',
+	})
+
+	const connectorRow = createValueRow('_connector:github-connector', {
+		value: JSON.stringify({
+			name: 'github-connector',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			apiBaseUrl: 'https://api.github.com',
+			flow: 'confidential',
+			clientIdValueName: 'github_client_id',
+			clientSecretSecretName: 'github_client_secret',
+			accessTokenSecretName: 'github_access_token',
+			refreshTokenSecretName: 'github_refresh_token',
+			requiredHosts: ['api.github.com'],
+		}),
+		description: 'GitHub connector config',
+	})
+
+	const connectorResult = await searchUnified({
+		env,
+		baseUrl: 'http://localhost',
+		query: 'github connector config',
+		limit: 5,
+		specs,
+		userId: 'user-123',
+		skillRows: [],
+		uiArtifactRows: [],
+		userSecretRows: [],
+		userValueRows: [connectorRow],
+		appSecretsByAppId: new Map(),
+	})
+
+	expect(connectorResult.matches[0]).toMatchObject({
+		type: 'connector',
+		connectorName: 'github-connector',
+	})
+})
+
 test('search skips connector rows whose stored id disagrees with config.name', async () => {
 	const env = { SENTRY_ENVIRONMENT: 'test' } as Env
 	const specs = {} as Record<string, CapabilitySpec>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- reuse weighted phrase-match lexical bonuses for values and connectors during cross-entity unified ranking
- add a regression test covering value and connector exact-phrase matches against equal-ranked entities from other types

## Testing
- not run yet in this pre-testing snapshot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41142f39-bb5c-4aab-92d2-444e9b62b116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41142f39-bb5c-4aab-92d2-444e9b62b116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

