### PR TITLE
Fix unified search lexical tiebreaks for values and connectors

### DIFF
--- a/packages/worker/src/mcp/capabilities/unified-search.ts
+++ b/packages/worker/src/mcp/capabilities/unified-search.ts
@@ -25,7 +25,10 @@ import {
 	type SecretMetadata,
 	type SecretSearchRow,
 } from '#mcp/secrets/types.ts'
-import { buildValueEntityId, describeValue } from '#mcp/tools/search-entities.ts'
+import {
+	buildValueEntityId,
+	describeValue,
+} from '#mcp/tools/search-entities.ts'
 import {
 	type UiArtifactSearchHit,
 	searchUiArtifactsForUser,
@@ -94,10 +97,7 @@ type ValueLexicalFields = Pick<
 	'name' | 'description' | 'scope' | 'value' | 'appId'
 >
 
-function scoreValuePhraseBonus(
-	query: string,
-	row: ValueLexicalFields,
-): number {
+function scoreValuePhraseBonus(query: string, row: ValueLexicalFields): number {
 	const normalizedQuery = normalizeSearchPhrase(query)
 	let bonus = 0
 	bonus += scoreSkillPhraseMatch(normalizedQuery, row.name) * 2
@@ -1019,9 +1019,16 @@ export async function searchUnified(input: {
 		if (key.startsWith('v:')) {
 			const hit = valueById.get(key.slice(2))
 			if (!hit) return 0
-			const doc = [hit.name, hit.description, hit.scope, hit.value, hit.appId ?? '']
-				.join('\n')
-			return lexicalScore(input.query, doc) + scoreValuePhraseBonus(input.query, hit)
+			const doc = [
+				hit.name,
+				hit.description,
+				hit.scope,
+				hit.value,
+				hit.appId ?? '',
+			].join('\n')
+			return (
+				lexicalScore(input.query, doc) + scoreValuePhraseBonus(input.query, hit)
+			)
 		}
 		if (key.startsWith('a:')) {
 			const hit = uiArtifactById.get(key.slice(2))

--- a/packages/worker/src/mcp/capabilities/unified-search.ts
+++ b/packages/worker/src/mcp/capabilities/unified-search.ts
@@ -89,6 +89,48 @@ function scoreSkillLexicalMatch(
 	return lexicalScore(query, doc) + bonus
 }
 
+type ValueLexicalFields = Pick<
+	ValueMetadata,
+	'name' | 'description' | 'scope' | 'value' | 'appId'
+>
+
+function scoreValuePhraseBonus(
+	query: string,
+	row: ValueLexicalFields,
+): number {
+	const normalizedQuery = normalizeSearchPhrase(query)
+	let bonus = 0
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.name) * 2
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.description) * 1.5
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.scope) * 0.5
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.appId) * 0.5
+	bonus += scoreSkillPhraseMatch(normalizedQuery, row.value) * 1
+	return bonus
+}
+
+type ConnectorLexicalFields = {
+	connectorName: string
+	description: string | null | undefined
+	apiBaseUrl: string | null | undefined
+	tokenUrl: string | null | undefined
+	requiredHosts: ReadonlyArray<string>
+}
+
+function scoreConnectorPhraseBonus(
+	query: string,
+	entry: ConnectorLexicalFields,
+): number {
+	const normalizedQuery = normalizeSearchPhrase(query)
+	let bonus = 0
+	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.connectorName) * 2
+	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.description) * 1.5
+	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.apiBaseUrl) * 1
+	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.tokenUrl) * 0.75
+	bonus +=
+		scoreSkillPhraseMatch(normalizedQuery, entry.requiredHosts.join(' ')) * 0.75
+	return bonus
+}
+
 function scoreCapabilityLexicalMatch(
 	query: string,
 	hit: CapabilitySearchHit,
@@ -136,14 +178,7 @@ function scoreValueLexicalMatch(
 	row: ValueMetadata,
 	doc: string,
 ): number {
-	const normalizedQuery = normalizeSearchPhrase(query)
-	let bonus = 0
-	bonus += scoreSkillPhraseMatch(normalizedQuery, row.name) * 2
-	bonus += scoreSkillPhraseMatch(normalizedQuery, row.description) * 1.5
-	bonus += scoreSkillPhraseMatch(normalizedQuery, row.scope) * 0.5
-	bonus += scoreSkillPhraseMatch(normalizedQuery, row.appId) * 0.5
-	bonus += scoreSkillPhraseMatch(normalizedQuery, row.value) * 1
-	return lexicalScore(query, doc) + bonus
+	return lexicalScore(query, doc) + scoreValuePhraseBonus(query, row)
 }
 
 function buildValueEmbedDoc(row: ValueMetadata): string {
@@ -174,20 +209,16 @@ function scoreConnectorLexicalMatch(
 	entry: ConnectorSearchEntry,
 	doc: string,
 ): number {
-	const requiredHosts = entry.config.requiredHosts ?? []
-	const normalizedQuery = normalizeSearchPhrase(query)
-	let bonus = 0
-	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.config.name) * 2
-	bonus +=
-		scoreSkillPhraseMatch(
-			normalizedQuery,
-			describeConnector(entry.config, entry.row.description),
-		) * 1.5
-	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.config.apiBaseUrl) * 1
-	bonus += scoreSkillPhraseMatch(normalizedQuery, entry.config.tokenUrl) * 0.75
-	bonus +=
-		scoreSkillPhraseMatch(normalizedQuery, requiredHosts.join(' ')) * 0.75
-	return lexicalScore(query, doc) + bonus
+	return (
+		lexicalScore(query, doc) +
+		scoreConnectorPhraseBonus(query, {
+			connectorName: entry.config.name,
+			description: describeConnector(entry.config, entry.row.description),
+			apiBaseUrl: entry.config.apiBaseUrl,
+			tokenUrl: entry.config.tokenUrl,
+			requiredHosts: entry.config.requiredHosts ?? [],
+		})
+	)
 }
 
 function buildConnectorEmbedDoc(entry: ConnectorSearchEntry): string {
@@ -930,16 +961,23 @@ export async function searchUnified(input: {
 		if (key.startsWith('n:')) {
 			const hit = connectorByName.get(key.slice(2))
 			if (!hit) return 0
-			return lexicalScore(
-				input.query,
-				[
-					hit.connectorName,
-					hit.description,
-					hit.flow,
-					hit.tokenUrl,
-					hit.apiBaseUrl ?? '',
-					hit.requiredHosts.join(' '),
-				].join('\n'),
+			const doc = [
+				hit.connectorName,
+				hit.description,
+				hit.flow,
+				hit.tokenUrl,
+				hit.apiBaseUrl ?? '',
+				hit.requiredHosts.join(' '),
+			].join('\n')
+			return (
+				lexicalScore(input.query, doc) +
+				scoreConnectorPhraseBonus(input.query, {
+					connectorName: hit.connectorName,
+					description: hit.description,
+					apiBaseUrl: hit.apiBaseUrl,
+					tokenUrl: hit.tokenUrl,
+					requiredHosts: hit.requiredHosts,
+				})
 			)
 		}
 		if (key.startsWith('c:')) {
@@ -981,12 +1019,9 @@ export async function searchUnified(input: {
 		if (key.startsWith('v:')) {
 			const hit = valueById.get(key.slice(2))
 			if (!hit) return 0
-			return lexicalScore(
-				input.query,
-				[hit.name, hit.description, hit.scope, hit.value, hit.appId ?? ''].join(
-					'\n',
-				),
-			)
+			const doc = [hit.name, hit.description, hit.scope, hit.value, hit.appId ?? '']
+				.join('\n')
+			return lexicalScore(input.query, doc) + scoreValuePhraseBonus(input.query, hit)
 		}
 		if (key.startsWith('a:')) {
 			const hit = uiArtifactById.get(key.slice(2))

--- a/packages/worker/src/mcp/capabilities/unified-search.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/unified-search.workers.test.ts
@@ -364,3 +364,97 @@ test('search skips connector rows whose stored id disagrees with config.name', a
 
 	expect(result.matches.some((match) => match.type === 'connector')).toBe(false)
 })
+
+test('exact value-name matches win cross-entity lexical ties', async () => {
+	const env = { SENTRY_ENVIRONMENT: 'test' } as Env
+	const specs = {
+		preferred_org_lookup: {
+			name: 'preferred_org_lookup',
+			domain: 'meta',
+			description: 'Look up preferred org settings.',
+			keywords: ['preferred', 'org', 'lookup'],
+			readOnly: true,
+			idempotent: true,
+			destructive: false,
+			inputFields: ['name'],
+			requiredInputFields: ['name'],
+			outputFields: ['value'],
+			inputSchema: {},
+		},
+	} satisfies Record<string, CapabilitySpec>
+	const valueRow = createValueRow('preferred_org', {
+		description: 'Stored organization preference',
+		value: 'kentcdodds',
+	})
+
+	const result = await searchUnified({
+		env,
+		baseUrl: 'http://localhost',
+		query: 'preferred org',
+		limit: 5,
+		specs,
+		userId: 'user-123',
+		skillRows: [],
+		uiArtifactRows: [],
+		userSecretRows: [],
+		userValueRows: [valueRow],
+		appSecretsByAppId: new Map(),
+	})
+
+	expect(result.matches[0]).toMatchObject({
+		type: 'value',
+		name: 'preferred_org',
+	})
+})
+
+test('exact connector-name matches win cross-entity lexical ties', async () => {
+	const env = { SENTRY_ENVIRONMENT: 'test' } as Env
+	const specs = {
+		github_connector_lookup: {
+			name: 'github_connector_lookup',
+			domain: 'meta',
+			description: 'Inspect saved GitHub connector details.',
+			keywords: ['github', 'connector', 'lookup'],
+			readOnly: true,
+			idempotent: true,
+			destructive: false,
+			inputFields: ['name'],
+			requiredInputFields: ['name'],
+			outputFields: ['connector'],
+			inputSchema: {},
+		},
+	} satisfies Record<string, CapabilitySpec>
+	const connectorRow = createValueRow('_connector:github', {
+		value: JSON.stringify({
+			name: 'github',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			apiBaseUrl: 'https://api.github.com',
+			flow: 'confidential',
+			clientIdValueName: 'github_client_id',
+			clientSecretSecretName: 'github_client_secret',
+			accessTokenSecretName: 'github_access_token',
+			refreshTokenSecretName: 'github_refresh_token',
+			requiredHosts: ['api.github.com'],
+		}),
+		description: 'GitHub OAuth connector config',
+	})
+
+	const result = await searchUnified({
+		env,
+		baseUrl: 'http://localhost',
+		query: 'github',
+		limit: 5,
+		specs,
+		userId: 'user-123',
+		skillRows: [],
+		uiArtifactRows: [],
+		userSecretRows: [],
+		userValueRows: [connectorRow],
+		appSecretsByAppId: new Map(),
+	})
+
+	expect(result.matches[0]).toMatchObject({
+		type: 'connector',
+		connectorName: 'github',
+	})
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- reuse shared phrase-match bonus helpers for value and connector lexical scoring
- apply those helpers in unified cross-entity lexical tiebreaking
- add regression tests covering exact value-name and connector-name matches against capabilities

## Testing
- red/green targeted workers-unit regression tests for unified search ordering
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01682315-4b91-415d-bf48-1f411a6d6e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01682315-4b91-415d-bf48-1f411a6d6e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved search scoring algorithm organization for enhanced maintainability and code clarity.

* **Tests**
  * Added integration tests validating search result ranking behavior across entity types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->