### PR TITLE
Default Cloudflare email API base URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,14 +118,12 @@ jobs:
           AI_GATEWAY_ID: ${{ secrets.AI_GATEWAY_ID }}
           CLOUDFLARE_EMAIL_FROM: ${{ secrets.CLOUDFLARE_EMAIL_FROM }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          CLOUDFLARE_API_BASE_URL: ${{ secrets.CLOUDFLARE_API_BASE_URL }}
           CAPABILITY_REINDEX_SECRET: ${{ secrets.CAPABILITY_REINDEX_SECRET }}
         run: >
           node tools/ci/sync-worker-secrets.ts --env production --config
           "$WRANGLER_CONFIG" --set-from-env COOKIE_SECRET --set-from-env
           AI_GATEWAY_ID --set-from-env-optional CLOUDFLARE_EMAIL_FROM
-          --set-from-env-optional SENTRY_DSN --set-from-env-optional CLOUDFLARE_API_BASE_URL
-          --set-from-env-optional CLOUDFLARE_API_TOKEN --set-from-env-optional
+          --set-from-env-optional SENTRY_DSN --set-from-env-optional CLOUDFLARE_API_TOKEN --set-from-env-optional
           CAPABILITY_REINDEX_SECRET
 
       - name: 🗄️ Apply D1 Migrations

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -91,17 +91,18 @@ Optional Worker secret:
   dev uses offline search while `WRANGLER_IS_LOCAL_DEV` is set or the binding is
   missing.
 
-## Cloudflare API (Worker + Browser Rendering)
+## Cloudflare API (Worker + Browser Rendering + Email)
 
 Optional Worker secrets/vars (see `packages/worker/src/env-schema.ts` and
 `packages/worker/src/mcp/cloudflare/cloudflare-rest-client.ts`):
 
 - `CLOUDFLARE_API_TOKEN` — Cloudflare API token used by the internal API client
-  (`Authorization: Bearer ...`) for `page_to_markdown` Browser Rendering. User
-  Cloudflare API calls from codemode use saved secrets and secret-aware `fetch`
-  (see `docs/contributing/skill-patterns/cloudflare-api-v4.md`). Local
-  `npm run dev` sets this to the Cloudflare mock token unless `AI_MODE=remote`
-  or `SKIP_CLOUDFLARE_MOCK=1`; when unset and no mock is attached, the billed
+  (`Authorization: Bearer ...`) for `page_to_markdown` Browser Rendering and
+  the Cloudflare Email sender. User Cloudflare API calls from codemode use
+  saved secrets and secret-aware `fetch` (see
+  `docs/contributing/skill-patterns/cloudflare-api-v4.md`). Local `npm run dev`
+  sets this to the Cloudflare mock token unless `AI_MODE=remote` or
+  `SKIP_CLOUDFLARE_MOCK=1`; when unset and no mock is attached, the billed
   `page_to_markdown` Browser Rendering fallback fails fast with a setup hint.
 - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id required by the
   `page_to_markdown` capability when it falls back to Browser Rendering
@@ -109,8 +110,9 @@ Optional Worker secrets/vars (see `packages/worker/src/env-schema.ts` and
   Worker var (not a secret) and should match the account behind
   `CLOUDFLARE_API_TOKEN`.
 - `CLOUDFLARE_API_BASE_URL` — API base URL; defaults to
-  `https://api.cloudflare.com` when unset. Local `npm run dev` sets this to the
-  Cloudflare mock Worker unless `AI_MODE=remote` or `SKIP_CLOUDFLARE_MOCK=1`.
+  `https://api.cloudflare.com` when unset, including for outbound email sending.
+  Local `npm run dev` sets this to the Cloudflare mock Worker unless
+  `AI_MODE=remote` or `SKIP_CLOUDFLARE_MOCK=1`.
 
 ## Home connector bridge
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -89,9 +89,9 @@ automatically:
 - `APP_COMMIT_SHA` (used as the Sentry **release** when present, in addition to
   `/health` versioning)
 - `CLOUDFLARE_API_BASE_URL` (optional; defaults to `https://api.cloudflare.com`.
-  Local `npm run dev` targets the Cloudflare mock unless
-  `SKIP_CLOUDFLARE_MOCK=1`. The internal Cloudflare API client expects paths
-  under `/client/v4/`.)
+  Production email uses the default public API base when this is unset. Local
+  `npm run dev` targets the Cloudflare mock unless `SKIP_CLOUDFLARE_MOCK=1`.
+  The internal Cloudflare API client expects paths under `/client/v4/`.)
 - `CAPABILITY_REINDEX_SECRET` (optional Worker secret; bearer auth for
   `POST /__maintenance/reindex-capabilities`,
   `POST /__maintenance/reindex-skills`, and `POST /__maintenance/reindex-apps`

--- a/packages/worker/.env.example
+++ b/packages/worker/.env.example
@@ -29,7 +29,7 @@ CLOUDFLARE_EMAIL_FROM=reset@kody.dev
 # SENTRY_ORG=your-org-slug
 # SENTRY_PROJECT=your-project-slug
 
-# Cloudflare API / Browser Rendering (optional; `npm run dev` sets a mock URL + token for `page_to_markdown` and internal API client)
+# Cloudflare API / Browser Rendering / Email (optional; defaults to the public Cloudflare API, and `npm run dev` sets a mock URL + token for `page_to_markdown`, local email, and the internal API client)
 # Uses Authorization: Bearer <token> against /client/v4/* endpoints.
 # Reuse `CLOUDFLARE_API_TOKEN` for the live API. In mock mode `npm run dev` injects a local token.
 # page_to_markdown also needs CLOUDFLARE_ACCOUNT_ID when it falls back to Cloudflare Browser Rendering `/markdown`.

--- a/packages/worker/src/app/email/cloudflare-email.node.test.ts
+++ b/packages/worker/src/app/email/cloudflare-email.node.test.ts
@@ -120,7 +120,52 @@ test('sendCloudflareEmail posts to the mock Cloudflare email API', async () => {
 	})
 })
 
-test('sendCloudflareEmail returns skipped when API config is missing', async () => {
+test('sendCloudflareEmail defaults the API base URL when it is unset', async () => {
+	const originalFetch = globalThis.fetch
+	const fetchSpy = vi.fn(async (input: RequestInfo | URL) => {
+		return new Response(
+			JSON.stringify({
+				success: true,
+				result: { messageId: 'email_default_base_url' },
+			}),
+			{
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			},
+		)
+	})
+	globalThis.fetch = fetchSpy as typeof fetch
+
+	try {
+		const result = await sendCloudflareEmail(
+			{
+				accountId: mockAccountId,
+				apiToken: 'test-token',
+			},
+			{
+				to: 'recipient@example.com',
+				from: 'reset@kody.dev',
+				subject: 'Default base URL',
+				html: '<p>body</p>',
+				text: 'body',
+			},
+		)
+
+		expect(result).toEqual({
+			ok: true,
+			id: 'email_default_base_url',
+		})
+		expect(fetchSpy).toHaveBeenCalledTimes(1)
+		const [input] = fetchSpy.mock.calls[0]!
+		expect(String(input)).toBe(
+			`https://api.cloudflare.com/client/v4/accounts/${mockAccountId}/email-service/send`,
+		)
+	} finally {
+		globalThis.fetch = originalFetch
+	}
+})
+
+test('sendCloudflareEmail returns skipped when account or token is missing', async () => {
 	const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
 	try {

--- a/packages/worker/src/app/email/cloudflare-email.ts
+++ b/packages/worker/src/app/email/cloudflare-email.ts
@@ -10,6 +10,8 @@ type CloudflareEmailClientConfig = {
 	apiToken?: string
 }
 
+const defaultCloudflareApiBaseUrl = 'https://api.cloudflare.com'
+
 type CloudflareApiEnvelope = {
 	success: boolean
 	errors?: Array<{
@@ -129,9 +131,11 @@ export async function sendCloudflareEmail(
 	message: OutboundEmail,
 ): Promise<CloudflareSendResult> {
 	const normalized = normalizeEmailPayload(message)
+	const apiBaseUrl =
+		typeof config.apiBaseUrl === 'string' && config.apiBaseUrl.trim().length > 0
+			? config.apiBaseUrl.trim()
+			: defaultCloudflareApiBaseUrl
 	const hasApiConfig =
-		typeof config.apiBaseUrl === 'string' &&
-		config.apiBaseUrl.trim().length > 0 &&
 		typeof config.apiToken === 'string' &&
 		config.apiToken.trim().length > 0 &&
 		typeof config.accountId === 'string' &&
@@ -141,7 +145,7 @@ export async function sendCloudflareEmail(
 		return sendViaCloudflareApi(
 			{
 				accountId: config.accountId!.trim(),
-				apiBaseUrl: config.apiBaseUrl!.trim(),
+				apiBaseUrl,
 				apiToken: config.apiToken!.trim(),
 			},
 			normalized,

--- a/packages/worker/src/app/handlers/password-reset.ts
+++ b/packages/worker/src/app/handlers/password-reset.ts
@@ -149,9 +149,7 @@ export function createPasswordResetRequestHandler(appEnv: AppEnv) {
 						await sendCloudflareEmail(
 							{
 								accountId: appEnv.CLOUDFLARE_ACCOUNT_ID,
-								apiBaseUrl:
-									appEnv.CLOUDFLARE_API_BASE_URL ??
-									'https://api.cloudflare.com',
+								apiBaseUrl: appEnv.CLOUDFLARE_API_BASE_URL,
 								apiToken: appEnv.CLOUDFLARE_API_TOKEN,
 							},
 							{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- default Cloudflare email sending to `https://api.cloudflare.com` when `CLOUDFLARE_API_BASE_URL` is unset
- keep local/mock Cloudflare email behavior working when a custom mock base URL is provided
- remove production deploy secret syncing that implied a custom Cloudflare API base URL was needed for email
- update contributor docs to clarify that production email uses the public Cloudflare API base by default

## Testing
- `npx vitest run packages/worker/src/app/email/cloudflare-email.node.test.ts tools/ci/sync-worker-secrets.node.test.ts`
- `npm run test:e2e:install` (required once in this environment so the push-gate Playwright browser existed)
- `npm run test:push`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27498cea-b098-4663-8ad6-ce0671751c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27498cea-b098-4663-8ad6-ce0671751c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email sending now works with a default Cloudflare API base URL when the configuration variable is not explicitly set.

* **Documentation**
  * Clarified that Cloudflare API credentials support email sending, browser rendering, and worker functionality.
  * Updated configuration documentation to reflect default API base URL behavior.

* **Tests**
  * Updated email tests to verify correct behavior when using default API configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->