### PR TITLE
Remove dead Cloudflare email id handling

### DIFF
--- a/packages/worker/src/app/email/cloudflare-email.node.test.ts
+++ b/packages/worker/src/app/email/cloudflare-email.node.test.ts
@@ -99,8 +99,9 @@ test('sendCloudflareEmail posts to the mock Cloudflare email API', async () => {
 		},
 	)
 
-	expect(sendResult.ok).toBe(true)
-	expect(sendResult.id).toBeUndefined()
+	expect(sendResult).toEqual({
+		ok: true,
+	})
 
 	const response = await fetch(`${mock.origin}/__mocks/messages?token=${token}`)
 	expect(response.status).toBe(200)

--- a/packages/worker/src/app/email/cloudflare-email.ts
+++ b/packages/worker/src/app/email/cloudflare-email.ts
@@ -19,7 +19,6 @@ type CloudflareApiEnvelope = {
 		message?: string
 	}>
 	result?: {
-		messageId?: string
 		delivered?: string[]
 		permanent_bounces?: string[]
 		queued?: string[]
@@ -28,7 +27,6 @@ type CloudflareApiEnvelope = {
 
 type CloudflareSendResult = {
 	ok: boolean
-	id?: string
 	skipped?: boolean
 	error?: string
 }
@@ -122,10 +120,6 @@ async function sendViaCloudflareApi(
 
 	return {
 		ok: true,
-		id:
-			typeof payload?.result?.messageId === 'string'
-				? payload.result.messageId
-				: undefined,
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the unused `messageId` field from the Cloudflare email API envelope type
- stop exposing an `id` field from `sendCloudflareEmail`, since `/email/sending/send` no longer returns one
- tighten the existing email API integration test to assert the exact success shape

## Testing
- `npx vitest run packages/worker/src/app/email/cloudflare-email.node.test.ts`
- `npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee92435a-e775-4a0f-9131-6d79c6801fbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee92435a-e775-4a0f-9131-6d79c6801fbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed message identifier support from Cloudflare email API integration. Email send results no longer include the message ID field, returning only success status instead.

* **Tests**
  * Updated test assertions to reflect removal of message ID from email send results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->