### PR TITLE
fix: stop invalid preview workflow validation

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -454,6 +454,9 @@ jobs:
         github.event.pull_request.head.repo.fork == false) ||
       (github.event_name == 'workflow_dispatch' &&
         inputs.action == 'cleanup')
+    env:
+      PREVIEW_ENVIRONMENT_GITHUB_TOKEN:
+        ${{ secrets.PREVIEW_ENVIRONMENT_GITHUB_TOKEN }}
     steps:
       - name: 📦 Checkout
         uses: actions/checkout@v6.0.2
@@ -571,7 +574,7 @@ jobs:
       - name: ℹ️ Skip GitHub preview environment delete
         if: >-
           always() &&
-          secrets.PREVIEW_ENVIRONMENT_GITHUB_TOKEN == ''
+          env.PREVIEW_ENVIRONMENT_GITHUB_TOKEN == ''
         run: >
           echo "Skipping GitHub preview environment delete;
           PREVIEW_ENVIRONMENT_GITHUB_TOKEN is not configured."
@@ -579,7 +582,7 @@ jobs:
       - name: 🏷️ Delete GitHub preview environment
         if: >-
           always() &&
-          secrets.PREVIEW_ENVIRONMENT_GITHUB_TOKEN != ''
+          env.PREVIEW_ENVIRONMENT_GITHUB_TOKEN != ''
         uses: actions/github-script@v8.0.0
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -587,7 +590,7 @@ jobs:
           INPUT_TARGET: ${{ inputs.target }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         with:
-          github-token: ${{ secrets.PREVIEW_ENVIRONMENT_GITHUB_TOKEN }}
+          github-token: ${{ env.PREVIEW_ENVIRONMENT_GITHUB_TOKEN }}
           script: |
             const eventName = process.env.EVENT_NAME;
             let envName;

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,7 +40,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  environments: write
 
 concurrency:
   group: >-
@@ -569,8 +568,18 @@ jobs:
           set -euo pipefail
           node tools/ci/preview-resources.ts cleanup --worker-name "$APP_WORKER_NAME"
 
+      - name: ℹ️ Skip GitHub preview environment delete
+        if: >-
+          always() &&
+          secrets.PREVIEW_ENVIRONMENT_GITHUB_TOKEN == ''
+        run: >
+          echo "Skipping GitHub preview environment delete;
+          PREVIEW_ENVIRONMENT_GITHUB_TOKEN is not configured."
+
       - name: 🏷️ Delete GitHub preview environment
-        if: always()
+        if: >-
+          always() &&
+          secrets.PREVIEW_ENVIRONMENT_GITHUB_TOKEN != ''
         uses: actions/github-script@v8.0.0
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -578,6 +587,7 @@ jobs:
           INPUT_TARGET: ${{ inputs.target }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         with:
+          github-token: ${{ secrets.PREVIEW_ENVIRONMENT_GITHUB_TOKEN }}
           script: |
             const eventName = process.env.EVENT_NAME;
             let envName;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the unsupported `environments` workflow permission from `preview.yml`
- gate GitHub environment deletion behind an optional `PREVIEW_ENVIRONMENT_GITHUB_TOKEN`
- move secret-based branching through job-level `env` so the workflow remains schema-valid

## Testing
- parse `.github/workflows/preview.yml` as YAML locally
- lint `.github/workflows/preview.yml` with `actionlint`
- push the branch and verify GitHub no longer creates a zero-second failed `push` run for `preview.yml`
- open a draft PR and confirm the preview/validate workflows parse successfully on `pull_request`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-308b9ea8-c529-4517-b5fb-1751f639215f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-308b9ea8-c529-4517-b5fb-1751f639215f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced preview environment cleanup process with conditional execution based on token availability for safer and more reliable environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->