### PR TITLE
Support raw MCP content blocks from execute

### DIFF
--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -1,11 +1,16 @@
 import { expect, test } from 'vitest'
+import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import {
 	createCapabilitySecretAccessDeniedBatchMessage,
 	createCapabilitySecretAccessDeniedMessage,
 	createHostSecretAccessDeniedBatchMessage,
 	createMissingSecretMessage,
 } from '#mcp/secrets/errors.ts'
-import { formatExecutionOutput, getExecutionErrorDetails } from './executor.ts'
+import {
+	extractRawContent,
+	formatExecutionOutput,
+	getExecutionErrorDetails,
+} from './executor.ts'
 
 test('getExecutionErrorDetails returns concrete guidance for capability access denial', () => {
 	const error = new Error(
@@ -57,6 +62,32 @@ test('formatExecutionOutput keeps missing secret guidance intact', () => {
 	expect(formatExecutionOutput(result)).toContain(
 		'Open a generated UI so the user can provide and save this secret',
 	)
+})
+
+test('extractRawContent returns MCP content blocks from sentinel result', () => {
+	const content: Array<ContentBlock> = [
+		{
+			type: 'image',
+			data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB',
+			mimeType: 'image/png',
+		},
+		{
+			type: 'text',
+			text: 'Screenshot of https://example.com',
+		},
+	]
+
+	expect(
+		extractRawContent({
+			__mcpContent: content,
+		}),
+	).toEqual(content)
+})
+
+test('extractRawContent returns null for non-sentinel values', () => {
+	expect(extractRawContent({ result: 'not raw content' })).toBeNull()
+	expect(extractRawContent('plain text')).toBeNull()
+	expect(extractRawContent(null)).toBeNull()
 })
 
 test('getExecutionErrorDetails returns batch capability approvals', () => {

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -1,4 +1,5 @@
 import { DynamicWorkerExecutor, type ExecuteResult } from '@cloudflare/codemode'
+import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { exports as workerExports } from 'cloudflare:workers'
 type WorkerLoopbackExports = Exclude<typeof workerExports, undefined>
 import { type FetchGatewayProps } from '#mcp/fetch-gateway.ts'
@@ -210,6 +211,18 @@ export function formatExecutionOutput(result: ExecuteResult) {
 		return `Error: ${errorText}\n\nNext step: ${details.nextStep}`
 	}
 	return truncateExecutionResult(result.result)
+}
+
+export function extractRawContent(value: unknown): Array<ContentBlock> | null {
+	if (
+		typeof value === 'object' &&
+		value !== null &&
+		'__mcpContent' in value &&
+		Array.isArray((value as { __mcpContent: unknown }).__mcpContent)
+	) {
+		return (value as { __mcpContent: Array<ContentBlock> }).__mcpContent
+	}
+	return null
 }
 
 function stringifyExecutionError(error: unknown) {

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -1,15 +1,43 @@
-import { expect, test, vi } from 'vitest'
-import { registerExecuteTool } from './execute.ts'
+import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
+import { beforeEach, expect, test, vi } from 'vitest'
 
-test('registers execute tool', async () => {
+const mockModule = vi.hoisted(() => ({
+	runCodemodeWithRegistry: vi.fn(),
+	getCapabilityRegistryForContext: vi.fn(async () => ({
+		capabilityHandlers: {
+			page_to_markdown: true,
+		},
+	})),
+}))
+
+vi.mock('#mcp/run-codemode-registry.ts', () => ({
+	runCodemodeWithRegistry: (...args: Array<unknown>) =>
+		mockModule.runCodemodeWithRegistry(...args),
+}))
+
+vi.mock('#mcp/capabilities/registry.ts', () => ({
+	getCapabilityRegistryForContext: (...args: Array<unknown>) =>
+		mockModule.getCapabilityRegistryForContext(...args),
+}))
+
+const { registerExecuteTool } = await import('./execute.ts')
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+async function getExecuteHandler() {
 	const registerTool = vi.fn()
 
 	await registerExecuteTool({
 		server: {
 			registerTool,
 		} as never,
-		getEnv: vi.fn(),
-		getCallerContext: vi.fn(),
+		getEnv: vi.fn(() => ({})),
+		getCallerContext: vi.fn(() => ({
+			baseUrl: 'https://example.com',
+			user: null,
+		})),
 		requireDomain: vi.fn(),
 		getLoopbackExports: vi.fn(),
 	} as never)
@@ -18,4 +46,90 @@ test('registers execute tool', async () => {
 	const [name, , handler] = registerTool.mock.calls[0] ?? []
 	expect(name).toBe('execute')
 	expect(typeof handler).toBe('function')
+	return handler as (input: {
+		code: string
+		conversationId?: string
+	}) => Promise<{
+		content: Array<ContentBlock>
+		structuredContent: {
+			conversationId: string
+			result: unknown
+			logs: Array<unknown>
+		}
+		isError: boolean
+	}>
+}
+
+test('registers execute tool', async () => {
+	await getExecuteHandler()
+})
+
+test('execute tool passes through raw MCP content blocks in success responses', async () => {
+	const handler = await getExecuteHandler()
+	const rawContent: Array<ContentBlock> = [
+		{
+			type: 'image',
+			data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB',
+			mimeType: 'image/png',
+		},
+		{
+			type: 'text',
+			text: 'Screenshot of https://example.com',
+		},
+	]
+	mockModule.runCodemodeWithRegistry.mockResolvedValueOnce({
+		result: {
+			__mcpContent: rawContent,
+		},
+		logs: [{ level: 'info', message: 'captured screenshot' }],
+	})
+
+	const response = await handler({
+		code: 'async () => ({ __mcpContent: [] })',
+		conversationId: 'conv-123',
+	})
+
+	expect(response.isError).toBe(false)
+	expect(response.content).toEqual([
+		{
+			type: 'text',
+			text: 'conversationId: conv-123',
+		},
+		...rawContent,
+	])
+	expect(response.structuredContent).toEqual({
+		conversationId: 'conv-123',
+		result: null,
+		logs: [{ level: 'info', message: 'captured screenshot' }],
+	})
+})
+
+test('execute tool keeps serializing normal success results as text', async () => {
+	const handler = await getExecuteHandler()
+	mockModule.runCodemodeWithRegistry.mockResolvedValueOnce({
+		result: { ok: true },
+		logs: [],
+	})
+
+	const response = await handler({
+		code: 'async () => ({ ok: true })',
+		conversationId: 'conv-456',
+	})
+
+	expect(response.isError).toBe(false)
+	expect(response.content).toEqual([
+		{
+			type: 'text',
+			text: 'conversationId: conv-456',
+		},
+		{
+			type: 'text',
+			text: '{\n  "ok": true\n}',
+		},
+	])
+	expect(response.structuredContent).toEqual({
+		conversationId: 'conv-456',
+		result: { ok: true },
+		logs: [],
+	})
 })

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/cloudflare'
 import { type ToolAnnotations } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import {
+	extractRawContent,
 	formatExecutionOutput,
 	getExecutionErrorDetails,
 } from '#mcp/executor.ts'
@@ -189,17 +190,20 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 				registeredCapabilityCount,
 				sandboxError: false,
 			})
+			const rawContent = extractRawContent(result.result)
 			return {
 				content: prependToolMetadataContent(resolvedConversationId, [
-					{
-						type: 'text',
-						text: formatExecutionOutput(result),
-					},
+					...(rawContent ?? [
+						{
+							type: 'text',
+							text: formatExecutionOutput(result),
+						},
+					]),
 					...formatSurfacedMemoriesMarkdown(surfacedMemories),
 				]),
 				structuredContent: {
 					conversationId: resolvedConversationId,
-					result: result.result,
+					result: rawContent ? null : result.result,
 					logs: result.logs ?? [],
 					...buildMemoryStructuredContent(surfacedMemories),
 				},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an `extractRawContent` helper to detect `__mcpContent` sentinel results from execute sandbox code
- pass raw MCP content blocks through directly in the execute tool success path instead of always serializing to a text block
- keep structured execute results backward compatible by returning `null` for `structuredContent.result` when raw MCP content is emitted

## Testing
- `npm exec -- vitest run --project node-unit packages/worker/src/mcp/executor.node.test.ts packages/worker/src/mcp/tools/execute.node.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a995162c-c9ad-4c3b-9a84-4dc073c43295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a995162c-c9ad-4c3b-9a84-4dc073c43295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native support for preserving raw content blocks from tool executions, enabling improved handling of complex result types.

* **Refactor**
  * Enhanced execution result processing to intelligently handle both formatted and raw content responses, with updated response structure to reflect content availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->