### PR TITLE
docs: add raw content blocks guide

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -76,3 +76,9 @@ token.
 
 Readable non-secret configuration uses **`codemode.value_get`** and
 **`codemode.value_list`** (for example data generated UI should persist).
+
+## Returning content blocks
+
+By default, **`execute`** returns text output. To return non-text MCP content
+blocks such as images, return an object with a **`__mcpContent`** array instead;
+see [Raw MCP content blocks](./raw-content-blocks.md).

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -12,6 +12,7 @@ Read in order for a full tour, or jump to a topic.
 - [Search](./search.md)
 - [Execute and workflows](./execute.md) — includes per-user MCP instruction
   overlays
+- [Raw MCP content blocks](./raw-content-blocks.md)
 - [Secrets, values, and host approval](./secrets-and-values.md)
 - [Skills, saved apps, and generated UI](./skills-and-apps.md)
 - [Mutating actions and confirmations](./mutating-actions.md)

--- a/docs/use/raw-content-blocks.md
+++ b/docs/use/raw-content-blocks.md
@@ -1,0 +1,24 @@
+# Raw MCP content blocks
+
+By default, `execute` serializes its return value as a single `text` content
+block. When you need to return a non-text block - most commonly an `image` for
+screenshots or charts - return an object with a `__mcpContent` array instead:
+
+```js
+async () => {
+  // ... fetch or generate image data ...
+  return {
+    __mcpContent: [
+      { type: 'image', data: base64, mimeType: 'image/png' },
+      { type: 'text', text: 'Description of the image' },
+    ],
+  }
+}
+```
+
+The blocks are passed through directly as the MCP tool result content. Agents
+that support vision receive image blocks as real image input, not as an
+embedded base64 string inside text.
+
+Use this only when the return value is genuinely a non-text content block. For
+normal structured data, return plain values and let `execute` serialize them.

--- a/docs/use/raw-content-blocks.md
+++ b/docs/use/raw-content-blocks.md
@@ -5,20 +5,20 @@ block. When you need to return a non-text block - most commonly an `image` for
 screenshots or charts - return an object with a `__mcpContent` array instead:
 
 ```js
-async () => {
-  // ... fetch or generate image data ...
-  return {
-    __mcpContent: [
-      { type: 'image', data: base64, mimeType: 'image/png' },
-      { type: 'text', text: 'Description of the image' },
-    ],
-  }
+;async () => {
+	// ... fetch or generate image data ...
+	return {
+		__mcpContent: [
+			{ type: 'image', data: base64, mimeType: 'image/png' },
+			{ type: 'text', text: 'Description of the image' },
+		],
+	}
 }
 ```
 
 The blocks are passed through directly as the MCP tool result content. Agents
-that support vision receive image blocks as real image input, not as an
-embedded base64 string inside text.
+that support vision receive image blocks as real image input, not as an embedded
+base64 string inside text.
 
 Use this only when the return value is genuinely a non-text content block. For
 normal structured data, return plain values and let `execute` serialize them.

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -62,6 +62,8 @@ Example:
   return { source: page.source, preview: page.markdown.slice(0, 120) };
 }\`
 
+To return non-text MCP content blocks (e.g. images), see: https://github.com/kentcdodds/kody/blob/main/docs/use/raw-content-blocks.md
+
 More context: https://github.com/kentcdodds/kody/blob/main/docs/use/execute.md
 	`.trim(),
 	annotations: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a dedicated `docs/use/raw-content-blocks.md` guide for returning `__mcpContent`
- link the new guide from `docs/use/execute.md` and the usage index
- reference the guide from the `execute` tool description so agents can discover it

## Testing
- `npx oxfmt --check "docs/use/execute.md" "docs/use/index.md" "docs/use/raw-content-blocks.md" "packages/worker/src/mcp/tools/execute.ts"`
- `npm run typecheck`
- GitHub PR/files-changed walkthrough confirming the new guide, execute docs section, usage-index link, execute tool description link, and rendered markdown page
- <a href="https://cursor.com/agents/bc-d1bb1a27-209b-4161-a515-b2bbe61371c1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fraw-content-blocks-docs-preview.mp4"><img src="https://cursor.com/artifacts/c/art-4e23c56f-4465-4065-8c9c-865c3a820689" alt="raw-content-blocks-docs-preview.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1bb1a27-209b-4161-a515-b2bbe61371c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1bb1a27-209b-4161-a515-b2bbe61371c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation on returning non-text MCP content blocks from the execute function, with examples showing how to return images. Vision-capable agents can now consume image content directly as real input rather than embedded base64. Includes guidance on when to use this approach versus returning standard structured data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->