### PR TITLE
Fallback search memory context to query

### DIFF
--- a/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
@@ -47,6 +47,55 @@ test('mcp server lists tools and search returns matches', async () => {
 	expect(Array.isArray(structured?.result?.matches)).toBe(true)
 })
 
+test('mcp search uses the query as memory context fallback', async () => {
+	await using database = await createTestDatabase()
+	await using server = await startDevServer(database.persistDir)
+	await using mcpClient = await createMcpClient(server.origin, database.user)
+
+	await mcpClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.meta_memory_upsert({
+					subject: 'User prefers npm over pnpm',
+					summary: 'Always use npm commands in this repository.',
+					category: 'preference',
+					tags: ['package-manager', 'repo-workflow'],
+					verified_by_agent: true,
+					verification_reference: 'verify-search-fallback-1',
+				})
+			}`,
+		},
+	})
+
+	const query = 'npm over pnpm'
+	const searchResult = await mcpClient.client.callTool({
+		name: 'search',
+		arguments: {
+			query,
+		},
+	})
+	const structured = (searchResult as CallToolResult).structuredContent as
+		| {
+				result?: {
+					memories?: {
+						retrievalQuery?: string
+						surfaced?: Array<{ subject?: string }>
+					}
+				}
+		  }
+		| undefined
+
+	expect(structured?.result?.memories?.retrievalQuery).toBe(query)
+	expect(structured?.result?.memories?.surfaced).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				subject: 'User prefers npm over pnpm',
+			}),
+		]),
+	)
+})
+
 test('mcp server saves skills and run_skill works', async () => {
 	await using database = await createTestDatabase()
 	await using server = await startDevServer(database.persistDir)

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -2,7 +2,43 @@ import { expect, test } from 'vitest'
 import {
 	loadDownHomeConnectorStatus,
 	loadOptionalSearchRows,
+	resolveSearchMemoryContext,
 } from './search.ts'
+
+test('search memory context falls back to the query when omitted', () => {
+	expect(
+		resolveSearchMemoryContext({
+			query: 'saved interactive dashboard app',
+		}),
+	).toEqual({
+		query: 'saved interactive dashboard app',
+	})
+})
+
+test('search memory context preserves explicit caller context', () => {
+	expect(
+		resolveSearchMemoryContext({
+			query: 'saved interactive dashboard app',
+			memoryContext: {
+				task: 'Find dashboard app',
+				query: 'saved dashboard app',
+				entities: ['dashboard'],
+			},
+		}),
+	).toEqual({
+		task: 'Find dashboard app',
+		query: 'saved dashboard app',
+		entities: ['dashboard'],
+	})
+})
+
+test('search memory context does not synthesize a fallback for blank queries', () => {
+	expect(
+		resolveSearchMemoryContext({
+			query: '   ',
+		}),
+	).toBeUndefined()
+})
 
 test('optional search rows fall back when saved skills lookup fails', async () => {
 	const result = await loadOptionalSearchRows({

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -63,6 +63,18 @@ const maxChars = maxTokens * charsPerToken
 const defaultSearchLimit = 15
 const defaultMaxResponseSize = 4_000
 
+export function resolveSearchMemoryContext(input: {
+	query?: string
+	memoryContext?: z.infer<typeof memoryContextInputField>
+}) {
+	if (input.memoryContext !== undefined) {
+		return input.memoryContext
+	}
+
+	const query = input.query?.trim() ?? ''
+	return query.length > 0 ? { query } : undefined
+}
+
 function truncateSearchText(text: string): string {
 	if (text.length <= maxChars) return text
 
@@ -683,7 +695,10 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 				env: agent.getEnv(),
 				callerContext,
 				conversationId,
-				memoryContext: args.memoryContext,
+				memoryContext: resolveSearchMemoryContext({
+					query: args.query,
+					memoryContext: args.memoryContext,
+				}),
 			})
 			const searchMemories = memoryToolContext
 				? {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fall back to the search query as `memoryContext.query` when callers omit `memoryContext`
- preserve explicitly provided `memoryContext` values without overriding them
- add focused unit and MCP end-to-end coverage for the fallback behavior

## Testing
- `npx vitest run --project node-unit packages/worker/src/mcp/tools/search.node.test.ts`
- `npm run build:mcp-apps && node tools/prepare-e2e-env.ts && npx vitest run --project mcp-e2e packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts`

## Artifacts
- <a href="/opt/cursor/artifacts/search-memory-context-validation.txt">Validation log</a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6215cd95-fd12-4274-800f-3f3c1a0c901f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6215cd95-fd12-4274-800f-3f3c1a0c901f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

