### PR TITLE
Fix saved app facet exec and partial update semantics

### DIFF
--- a/docs/use/saved-app-backends.md
+++ b/docs/use/saved-app-backends.md
@@ -160,6 +160,10 @@ export class App extends DurableObject {
 }
 ```
 
+`app.call(...)` rejects reserved method names such as `fetch` and any name that
+starts with `__kody_`. Only user-defined public methods on the saved app class
+may be invoked through this bridge.
+
 For raw SQLite inspection, use **`app_storage_export`** instead of
 `app_server_exec`.
 

--- a/docs/use/saved-app-backends.md
+++ b/docs/use/saved-app-backends.md
@@ -17,17 +17,25 @@ Object Facet** and gives it an isolated SQLite database.
 ```json
 {
 	"app_id": "app-123",
+	"title": "Counter app",
+	"description": "Saved app with a backend counter",
 	"clientCode": "<main>...</main>",
-	"serverCode": "import { DurableObject } from 'cloudflare:workers'; ...",
-	"serverCodeId": "uuid"
+	"serverCode": "import { DurableObject } from 'cloudflare:workers'; ..."
 }
 ```
 
 `clientCode` supports **HTML only**. If the app needs browser-side logic,
 include it inside `<script type="module">...</script>` tags in the HTML.
 
-`serverCodeId` rotates on every save so Cloudflare's Dynamic Worker loader does
-not reuse stale code.
+When **creating** a saved app, `title`, `description`, and `clientCode` are
+required.
+
+When **updating** an existing saved app with `app_id`, omitted fields preserve
+their current saved values:
+
+- omit `serverCode` to keep the current backend
+- pass **`serverCode: null`** to clear the backend explicitly
+- `server_code_id` only rotates when the saved backend actually changes
 
 ## Read shape
 
@@ -111,6 +119,48 @@ Kody now exposes saved app backend lifecycle operations:
 
 Facet names default to `main`. Kody reserves named facets such as `jobs` and
 `cache` for future multi-facet saved apps.
+
+## `app_server_exec` contract
+
+`app_server_exec` does **not** eval source inside the running facet. Instead,
+Kody compiles the provided `code` into a **throwaway Dynamic Worker** and binds
+the saved app facet as an RPC stub.
+
+Inside the snippet body you can access:
+
+- **`app`** (alias **`appStub`**) — RPC stub for the saved app `App` class
+- **`params`** — optional JSON input passed through the capability
+
+Example:
+
+```ts
+await codemode.app_server_exec({
+	app_id: 'app-123',
+	params: { amount: 2 },
+	code: `
+		return await app.incrementBy(params.amount ?? 1)
+	`,
+})
+```
+
+That means the saved app must expose explicit RPC methods on its exported `App`
+class:
+
+```ts
+import { DurableObject } from 'cloudflare:workers'
+
+export class App extends DurableObject {
+	async incrementBy(amount = 1) {
+		const current = Number((await this.ctx.storage.get('count')) ?? 0)
+		const next = current + Number(amount)
+		await this.ctx.storage.put('count', next)
+		return { count: next }
+	}
+}
+```
+
+For raw SQLite inspection, use **`app_storage_export`** instead of
+`app_server_exec`.
 
 ## Example: counter app
 

--- a/docs/use/saved-app-backends.md
+++ b/docs/use/saved-app-backends.md
@@ -124,11 +124,12 @@ Facet names default to `main`. Kody reserves named facets such as `jobs` and
 
 `app_server_exec` does **not** eval source inside the running facet. Instead,
 Kody compiles the provided `code` into a **throwaway Dynamic Worker** and binds
-the saved app facet as an RPC stub.
+an explicit RPC bridge for the saved app facet.
 
 Inside the snippet body you can access:
 
-- **`app`** (alias **`appStub`**) — RPC stub for the saved app `App` class
+- **`app`** — explicit bridge with `app.call(methodName, ...args)` for invoking
+  public RPC methods on the saved app `App` class
 - **`params`** — optional JSON input passed through the capability
 
 Example:
@@ -138,7 +139,7 @@ await codemode.app_server_exec({
 	app_id: 'app-123',
 	params: { amount: 2 },
 	code: `
-		return await app.incrementBy(params.amount ?? 1)
+		return await app.call('incrementBy', params.amount ?? 1)
 	`,
 })
 ```

--- a/docs/use/skills-and-apps.md
+++ b/docs/use/skills-and-apps.md
@@ -24,8 +24,9 @@ Optional **collection** groups related skills. Use **meta_get_skill**,
 `clientCode` supports **HTML only**. Put browser-side logic inside
 `<script type="module">...</script>` tags in that HTML.
 
-`clientCode` supports **HTML only**. Put browser logic inside
-`<script type="module">...</script>` tags in that HTML.
+When updating an existing saved app with `app_id`, omitted fields preserve the
+current saved value. Omit `serverCode` to keep the existing backend, or pass
+`serverCode: null` to clear it explicitly.
 
 Reopen with **open_generated_ui** using **`app_id`**, or discover apps via
 **search**.
@@ -41,7 +42,8 @@ Use these lifecycle capabilities when you need backend maintenance:
 
 - **`app_storage_reset`**
 - **`app_storage_export`**
-- **`app_server_exec`**
+- **`app_server_exec`** — compiles a throwaway exec worker with `app` /
+  `appStub` RPC access to the saved app facet
 - **`app_delete`**
 
 See [Saved app backends](./saved-app-backends.md) for the route contract, RPC

--- a/docs/use/skills-and-apps.md
+++ b/docs/use/skills-and-apps.md
@@ -42,8 +42,8 @@ Use these lifecycle capabilities when you need backend maintenance:
 
 - **`app_storage_reset`**
 - **`app_storage_export`**
-- **`app_server_exec`** — compiles a throwaway exec worker with `app` /
-  `appStub` RPC access to the saved app facet
+- **`app_server_exec`** — compiles a throwaway exec worker with an explicit
+  `app.call(methodName, ...args)` RPC bridge to the saved app facet
 - **`app_delete`**
 
 See [Saved app backends](./saved-app-backends.md) for the route contract, RPC

--- a/packages/worker/src/mcp/app-runner.ts
+++ b/packages/worker/src/mcp/app-runner.ts
@@ -102,6 +102,12 @@ function createFacetWrapperModule(input: { facetName: string }) {
 import * as userModule from './user-app.js'
 
 const BaseApp = userModule.App
+const reservedFacetMethodNames = new Set([
+	'fetch',
+	'__kody_resetStorage',
+	'__kody_exportStorage',
+	'__kody_invokeUserMethod',
+])
 
 if (typeof BaseApp !== 'function') {
 	throw new Error('Saved app server code must export class App extends DurableObject.')
@@ -148,6 +154,32 @@ export class ${exportName} extends BaseApp {
 			nextStartAfter: truncated ? nextStartAfter : null,
 			pageSize,
 		}
+	}
+
+	async __kody_invokeUserMethod(methodName, args) {
+		if (typeof methodName !== 'string' || !methodName.trim()) {
+			throw new Error('Saved app RPC method name must be a non-empty string.')
+		}
+		const normalizedMethodName = methodName.trim()
+		if (
+			reservedFacetMethodNames.has(normalizedMethodName) ||
+			normalizedMethodName.startsWith('__kody_')
+		) {
+			throw new Error(
+				\`Saved app RPC method "\${normalizedMethodName}" is not allowed.\`,
+			)
+		}
+		const method = Reflect.get(this, normalizedMethodName)
+		if (typeof method !== 'function') {
+			throw new Error(
+				\`Saved app RPC method "\${normalizedMethodName}" was not found.\`,
+			)
+		}
+		return await Reflect.apply(
+			method,
+			this,
+			Array.isArray(args) ? args : [],
+		)
 	}
 }
 `.trim()
@@ -678,13 +710,14 @@ class AppRunnerBase extends DurableObject<Env> {
 		args?: Array<unknown>
 	}) {
 		const facet = await this.getFacetStub(buildFacetName(input.facetName))
-		const method = Reflect.get(facet, input.methodName)
-		if (typeof method !== 'function') {
-			throw new Error(
-				`Saved app RPC method "${input.methodName}" was not found.`,
-			)
-		}
-		return await Reflect.apply(method, facet, input.args ?? [])
+		return await (
+			facet as unknown as {
+				__kody_invokeUserMethod: (
+					methodName: string,
+					args?: Array<unknown>,
+				) => Promise<unknown>
+			}
+		).__kody_invokeUserMethod(input.methodName, input.args ?? [])
 	}
 
 	private async applyRateLimit() {

--- a/packages/worker/src/mcp/app-runner.ts
+++ b/packages/worker/src/mcp/app-runner.ts
@@ -161,8 +161,11 @@ import { WorkerEntrypoint } from 'cloudflare:workers'
 
 export class ${savedAppExecEntrypointName} extends WorkerEntrypoint {
 	async run(params) {
-		const app = this.env.APP
-		const appStub = app
+		const app = {
+			call: (methodName, ...args) => {
+				return this.env.APP.callAppRpc(methodName, args)
+			},
+		}
 		${input.code}
 	}
 }
@@ -190,6 +193,16 @@ function jsonResponse(body: Record<string, unknown>, status = 200) {
 }
 
 export class AppFacetBridge extends WorkerEntrypoint<Env, FacetBridgeProps> {
+	async callAppRpc(methodName: string, args: Array<unknown> = []) {
+		const runner = appRunnerRpc(this.env, this.ctx.props.appId)
+		return await runner.callFacetRpc({
+			appId: this.ctx.props.appId,
+			facetName: this.ctx.props.facetName,
+			methodName,
+			args,
+		})
+	}
+
 	async fetchWithResolvedSecrets(input: {
 		url: string
 		method?: string
@@ -492,7 +505,8 @@ class AppRunnerBase extends DurableObject<Env> {
 		params?: Record<string, unknown>
 	}) {
 		const facetName = buildFacetName(input.facetName)
-		const facet = await this.getFacetStub(facetName)
+		await this.getFacetStub(facetName)
+		const config = await this.readConfig(this.ctx.id.toString())
 		const execWorker = this.env.APP_LOADER.load({
 			compatibilityDate: '2026-04-13',
 			compatibilityFlags: ['nodejs_compat', 'global_fetch_strictly_public'],
@@ -503,7 +517,14 @@ class AppRunnerBase extends DurableObject<Env> {
 				}),
 			},
 			env: {
-				APP: facet,
+				APP: this.ctx.exports.AppFacetBridge({
+					props: {
+						appId: input.appId,
+						userId: config.userId,
+						baseUrl: config.baseUrl || 'http://internal.invalid',
+						facetName,
+					},
+				}),
 			},
 			globalOutbound: null,
 		}).getEntrypoint(savedAppExecEntrypointName) as unknown as {
@@ -648,6 +669,26 @@ class AppRunnerBase extends DurableObject<Env> {
 				),
 			}
 		})
+	}
+
+	async getFacetRpcStub(input: { appId: string; facetName?: string | null }) {
+		return await this.getFacetStub(buildFacetName(input.facetName))
+	}
+
+	async callFacetRpc(input: {
+		appId: string
+		facetName?: string | null
+		methodName: string
+		args?: Array<unknown>
+	}) {
+		const facet = await this.getFacetStub(buildFacetName(input.facetName))
+		const method = Reflect.get(facet, input.methodName)
+		if (typeof method !== 'function') {
+			throw new Error(
+				`Saved app RPC method "${input.methodName}" was not found.`,
+			)
+		}
+		return await Reflect.apply(method, facet, input.args ?? [])
 	}
 
 	private async applyRateLimit() {
@@ -811,6 +852,16 @@ export function appRunnerRpc(env: Env, appId: string) {
 			facetName: string
 			result: unknown
 		}>
+		getFacetRpcStub: (payload: {
+			appId: string
+			facetName?: string | null
+		}) => Promise<Record<string, unknown>>
+		callFacetRpc: (payload: {
+			appId: string
+			facetName?: string | null
+			methodName: string
+			args?: Array<unknown>
+		}) => Promise<unknown>
 		deleteApp: (payload: {
 			appId: string
 			facetNames?: Array<string> | null

--- a/packages/worker/src/mcp/app-runner.ts
+++ b/packages/worker/src/mcp/app-runner.ts
@@ -96,10 +96,7 @@ function defaultRateWindow(now: number): AppRunnerRateWindow {
 	}
 }
 
-function createFacetWrapperModule(input: {
-	facetName: string
-	serverCode: string
-}) {
+function createFacetWrapperModule(input: { facetName: string }) {
 	const exportName = buildFacetClassExportName(input.facetName)
 	return `
 import * as userModule from './user-app.js'
@@ -152,13 +149,21 @@ export class ${exportName} extends BaseApp {
 			pageSize,
 		}
 	}
+}
+`.trim()
+}
 
-	async __kody_exec(code, params) {
-		if (typeof code !== 'string' || !code.trim()) {
-			throw new Error('Facet exec requires non-empty code.')
-		}
-		const runner = new Function('facet', 'params', code)
-		return await runner(this, params ?? {})
+const savedAppExecEntrypointName = 'SavedAppExecWorker'
+
+function createSavedAppExecWorkerModule(input: { code: string }) {
+	return `
+import { WorkerEntrypoint } from 'cloudflare:workers'
+
+export class ${savedAppExecEntrypointName} extends WorkerEntrypoint {
+	async run(params) {
+		const app = this.env.APP
+		const appStub = app
+		${input.code}
 	}
 }
 `.trim()
@@ -488,14 +493,23 @@ class AppRunnerBase extends DurableObject<Env> {
 	}) {
 		const facetName = buildFacetName(input.facetName)
 		const facet = await this.getFacetStub(facetName)
-		const result = await (
-			facet as unknown as {
-				__kody_exec: (
-					code: string,
-					params?: Record<string, unknown>,
-				) => Promise<unknown>
-			}
-		).__kody_exec(input.code, input.params)
+		const execWorker = this.env.APP_LOADER.load({
+			compatibilityDate: '2026-04-13',
+			compatibilityFlags: ['nodejs_compat', 'global_fetch_strictly_public'],
+			mainModule: 'exec-entry.js',
+			modules: {
+				'exec-entry.js': createSavedAppExecWorkerModule({
+					code: input.code,
+				}),
+			},
+			env: {
+				APP: facet,
+			},
+			globalOutbound: null,
+		}).getEntrypoint(savedAppExecEntrypointName) as unknown as {
+			run: (params?: Record<string, unknown>) => Promise<unknown>
+		}
+		const result = await execWorker.run(input.params)
 		return {
 			ok: true,
 			appId: input.appId,
@@ -611,7 +625,6 @@ class AppRunnerBase extends DurableObject<Env> {
 					modules: {
 						'facet-entry.js': createFacetWrapperModule({
 							facetName,
-							serverCode: config.serverCode!,
 						}),
 						'user-app.js': config.serverCode!,
 					},

--- a/packages/worker/src/mcp/app-runner.ts
+++ b/packages/worker/src/mcp/app-runner.ts
@@ -530,7 +530,7 @@ class AppRunnerBase extends DurableObject<Env> {
 		}).getEntrypoint(savedAppExecEntrypointName) as unknown as {
 			run: (params?: Record<string, unknown>) => Promise<unknown>
 		}
-		const result = await execWorker.run(input.params)
+		const result = await execWorker.run(input.params ?? {})
 		return {
 			ok: true,
 			appId: input.appId,
@@ -669,10 +669,6 @@ class AppRunnerBase extends DurableObject<Env> {
 				),
 			}
 		})
-	}
-
-	async getFacetRpcStub(input: { appId: string; facetName?: string | null }) {
-		return await this.getFacetStub(buildFacetName(input.facetName))
 	}
 
 	async callFacetRpc(input: {
@@ -852,10 +848,6 @@ export function appRunnerRpc(env: Env, appId: string) {
 			facetName: string
 			result: unknown
 		}>
-		getFacetRpcStub: (payload: {
-			appId: string
-			facetName?: string | null
-		}) => Promise<Record<string, unknown>>
 		callFacetRpc: (payload: {
 			appId: string
 			facetName?: string | null

--- a/packages/worker/src/mcp/capabilities/apps/app-server-exec.ts
+++ b/packages/worker/src/mcp/capabilities/apps/app-server-exec.ts
@@ -14,7 +14,7 @@ const inputSchema = z.object({
 		.string()
 		.min(1)
 		.describe(
-			'One-off JavaScript function body compiled into a throwaway Dynamic Worker. The body receives `app.call(methodName, ...args)` for explicit RPC calls into the saved app facet plus `params` for JSON inputs.',
+			'One-off JavaScript function body compiled into a throwaway Dynamic Worker. The body receives `app.call(methodName, ...args)` for validated RPC calls into saved app methods plus `params` for JSON inputs. Reserved framework methods such as `fetch` and `__kody_*` are rejected.',
 		),
 	facet_name: z
 		.string()
@@ -39,7 +39,7 @@ export const appServerExecCapability = defineDomainCapability(
 	{
 		name: 'app_server_exec',
 		description:
-			'Compile and run one-off JavaScript in a throwaway Dynamic Worker with an explicit RPC bridge to a saved app facet. Use this for debugging, repair tasks, or data migrations that call methods the saved app App class already exposes.',
+			'Compile and run one-off JavaScript in a throwaway Dynamic Worker with an explicit RPC bridge to a saved app facet. Use this for debugging, repair tasks, or data migrations that call validated user-defined methods on the saved app App class.',
 		keywords: ['app', 'server', 'facet', 'debug', 'migration', 'exec'],
 		readOnly: false,
 		idempotent: false,

--- a/packages/worker/src/mcp/capabilities/apps/app-server-exec.ts
+++ b/packages/worker/src/mcp/capabilities/apps/app-server-exec.ts
@@ -14,7 +14,7 @@ const inputSchema = z.object({
 		.string()
 		.min(1)
 		.describe(
-			'One-off JavaScript function body compiled into a throwaway Dynamic Worker. The body receives `app` (alias `appStub`) as an RPC stub to the saved app facet plus `params` for JSON inputs.',
+			'One-off JavaScript function body compiled into a throwaway Dynamic Worker. The body receives `app.call(methodName, ...args)` for explicit RPC calls into the saved app facet plus `params` for JSON inputs.',
 		),
 	facet_name: z
 		.string()
@@ -39,7 +39,7 @@ export const appServerExecCapability = defineDomainCapability(
 	{
 		name: 'app_server_exec',
 		description:
-			'Compile and run one-off JavaScript in a throwaway Dynamic Worker with an explicit RPC stub to a saved app facet. Use this for debugging, repair tasks, or data migrations that call methods the saved app App class already exposes.',
+			'Compile and run one-off JavaScript in a throwaway Dynamic Worker with an explicit RPC bridge to a saved app facet. Use this for debugging, repair tasks, or data migrations that call methods the saved app App class already exposes.',
 		keywords: ['app', 'server', 'facet', 'debug', 'migration', 'exec'],
 		readOnly: false,
 		idempotent: false,

--- a/packages/worker/src/mcp/capabilities/apps/app-server-exec.ts
+++ b/packages/worker/src/mcp/capabilities/apps/app-server-exec.ts
@@ -14,7 +14,7 @@ const inputSchema = z.object({
 		.string()
 		.min(1)
 		.describe(
-			'One-off JavaScript source to execute inside the saved app facet instance for debugging or migrations.',
+			'One-off JavaScript function body compiled into a throwaway Dynamic Worker. The body receives `app` (alias `appStub`) as an RPC stub to the saved app facet plus `params` for JSON inputs.',
 		),
 	facet_name: z
 		.string()
@@ -39,7 +39,7 @@ export const appServerExecCapability = defineDomainCapability(
 	{
 		name: 'app_server_exec',
 		description:
-			'Execute one-off JavaScript inside a saved app Durable Object facet for debugging, repair tasks, or data migrations scoped to that app.',
+			'Compile and run one-off JavaScript in a throwaway Dynamic Worker with an explicit RPC stub to a saved app facet. Use this for debugging, repair tasks, or data migrations that call methods the saved app App class already exposes.',
 		keywords: ['app', 'server', 'facet', 'debug', 'migration', 'exec'],
 		readOnly: false,
 		idempotent: false,

--- a/packages/worker/src/mcp/capabilities/apps/ui-save-app.ts
+++ b/packages/worker/src/mcp/capabilities/apps/ui-save-app.ts
@@ -23,48 +23,85 @@ import { hasUiArtifactServerCode } from '#mcp/ui-artifacts-types.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import {
 	normalizeUiArtifactParameters,
+	parseUiArtifactParameters,
 	uiArtifactParameterSchema,
 } from '#mcp/ui-artifact-parameters.ts'
 
-const inputSchema = z.object({
-	app_id: z
-		.string()
-		.min(1)
-		.optional()
-		.describe(
-			'Optional saved UI artifact id to update in place. Omit to create a new saved app.',
-		),
-	title: z.string().min(1).describe('Short title for the saved UI artifact.'),
-	description: z
-		.string()
-		.min(1)
-		.describe('What the saved app does and when it is useful.'),
-	clientCode: z
-		.string()
-		.min(1)
-		.describe(
-			'HTML source for the generic MCP UI shell. Provide a self-contained HTML document or fragment. If the app needs browser-side logic, include it with `<script type="module">...</script>` inside the HTML.',
-		),
-	serverCode: z
-		.string()
-		.min(1)
-		.optional()
-		.describe(
-			'Optional Durable Object server code for this saved app. The code must export `class App extends DurableObject` and can use its own isolated facet SQLite storage.',
-		),
-	parameters: z
-		.array(uiArtifactParameterSchema)
-		.optional()
-		.describe(
-			'Optional parameter definitions for reusable saved apps. Resolved values are exposed at runtime on the imported `kodyWidget.params` helper from `@kody/ui-utils`.',
-		),
-	hidden: z
-		.boolean()
-		.optional()
-		.describe(
-			'Whether this saved app should stay hidden from search results. Defaults to true so one-off apps stay private unless explicitly made discoverable.',
-		),
-})
+const inputSchema = z
+	.object({
+		app_id: z
+			.string()
+			.min(1)
+			.optional()
+			.describe(
+				'Optional saved UI artifact id to update in place. Omit to create a new saved app. When app_id is provided, omitted fields preserve the existing saved value.',
+			),
+		title: z
+			.string()
+			.min(1)
+			.optional()
+			.describe(
+				'Short title for the saved UI artifact. Required when creating a new saved app.',
+			),
+		description: z
+			.string()
+			.min(1)
+			.optional()
+			.describe('What the saved app does and when it is useful.'),
+		clientCode: z
+			.string()
+			.min(1)
+			.optional()
+			.describe(
+				'HTML source for the generic MCP UI shell. Provide a self-contained HTML document or fragment. If the app needs browser-side logic, include it with `<script type="module">...</script>` inside the HTML. Required when creating a new saved app.',
+			),
+		serverCode: z
+			.string()
+			.min(1)
+			.nullable()
+			.optional()
+			.describe(
+				'Optional Durable Object server code for this saved app. The code must export `class App extends DurableObject` and can use its own isolated facet SQLite storage. Omit this field on updates to preserve the current backend, or pass null to clear it explicitly.',
+			),
+		parameters: z
+			.array(uiArtifactParameterSchema)
+			.optional()
+			.describe(
+				'Optional parameter definitions for reusable saved apps. Resolved values are exposed at runtime on the imported `kodyWidget.params` helper from `@kody/ui-utils`.',
+			),
+		hidden: z
+			.boolean()
+			.optional()
+			.describe(
+				'Whether this saved app should stay hidden from search results. Defaults to true so one-off apps stay private unless explicitly made discoverable.',
+			),
+	})
+	.superRefine((value, ctx) => {
+		if (value.app_id !== undefined) {
+			return
+		}
+		if (value.title === undefined) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['title'],
+				message: 'title is required when creating a saved app.',
+			})
+		}
+		if (value.description === undefined) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['description'],
+				message: 'description is required when creating a saved app.',
+			})
+		}
+		if (value.clientCode === undefined) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['clientCode'],
+				message: 'clientCode is required when creating a saved app.',
+			})
+		}
+	})
 
 const outputSchema = z.object({
 	app_id: z.string(),
@@ -80,7 +117,7 @@ export const uiSaveAppCapability = defineDomainCapability(
 	{
 		name: 'ui_save_app',
 		description:
-			'Create or replace a saved UI artifact for the signed-in user so it can be reopened later by app_id without sending the source back through the model context. If the saved app depends on a third-party integration, load `kody_official_guide` with `guide: "integration_bootstrap"` first and verify the required connector/secret plus a minimal authenticated smoke test before treating the downstream app as complete.',
+			'Create a saved UI artifact or partially update an existing one for the signed-in user so it can be reopened later by app_id without sending the source back through the model context. When updating, omitted fields preserve the existing saved value. If the saved app depends on a third-party integration, load `kody_official_guide` with `guide: "integration_bootstrap"` first and verify the required connector/secret plus a minimal authenticated smoke test before treating the downstream app as complete.',
 		keywords: ['ui', 'app', 'artifact', 'save', 'persist', 'update', 'mcp app'],
 		readOnly: false,
 		idempotent: false,
@@ -91,29 +128,29 @@ export const uiSaveAppCapability = defineDomainCapability(
 			const user = requireMcpUser(ctx.callerContext)
 			const isUpdate = args.app_id !== undefined
 			const appId = args.app_id ?? crypto.randomUUID()
-			const nextServerCode = args.serverCode ?? null
-			const parameters = normalizeUiArtifactParameters(args.parameters)
-			const serializedParameters = parameters
-				? JSON.stringify(parameters)
-				: null
 			let hidden: boolean
 			let existingApp: Awaited<ReturnType<typeof getUiArtifactById>> | null =
 				null
 
 			async function saveAndIndexApp(input: {
 				appId: string
+				title: string
+				description: string
+				clientCode: string
+				serverCode: string | null
 				serverCodeId: string
+				parameters: ReturnType<typeof normalizeUiArtifactParameters>
 				hidden: boolean
 				existingApp: Awaited<ReturnType<typeof getUiArtifactById>> | null
 			}) {
-				const hasBackend = hasUiArtifactServerCode(nextServerCode)
+				const hasBackend = hasUiArtifactServerCode(input.serverCode)
 				try {
 					await configureSavedAppRunner({
 						env: ctx.env,
 						appId: input.appId,
 						userId: user.userId,
 						baseUrl: ctx.callerContext.baseUrl,
-						serverCode: nextServerCode,
+						serverCode: input.serverCode,
 						serverCodeId: input.serverCodeId,
 					})
 				} catch (cause) {
@@ -149,10 +186,10 @@ export const uiSaveAppCapability = defineDomainCapability(
 							appId: input.appId,
 							userId: user.userId,
 							embedText: buildUiArtifactEmbedText({
-								title: args.title,
-								description: args.description,
+								title: input.title,
+								description: input.description,
 								hasServerCode: hasBackend,
-								parameters,
+								parameters: input.parameters,
 							}),
 						})
 					} else if (isUpdate) {
@@ -199,7 +236,7 @@ export const uiSaveAppCapability = defineDomainCapability(
 					server_code_id: input.serverCodeId,
 					has_server_code: hasBackend,
 					hosted_url: buildSavedUiUrl(ctx.callerContext.baseUrl, input.appId),
-					parameters,
+					parameters: input.parameters,
 					hidden: input.hidden,
 				}
 			}
@@ -213,23 +250,43 @@ export const uiSaveAppCapability = defineDomainCapability(
 				if (!existingApp) {
 					throw new Error('Saved UI artifact not found for this user.')
 				}
-				const serverCodeChanged = nextServerCode !== existingApp.serverCode
+				const title = args.title ?? existingApp.title
+				const description = args.description ?? existingApp.description
+				const clientCode = args.clientCode ?? existingApp.clientCode
+				const serverCode =
+					args.serverCode === undefined
+						? existingApp.serverCode
+						: args.serverCode
+				const parameters =
+					args.parameters === undefined
+						? parseUiArtifactParameters(existingApp.parameters)
+						: normalizeUiArtifactParameters(args.parameters)
+				const serializedParameters =
+					args.parameters === undefined
+						? existingApp.parameters
+						: parameters
+							? JSON.stringify(parameters)
+							: null
+				const serverCodeChanged = serverCode !== existingApp.serverCode
 				const serverCodeId = serverCodeChanged
 					? crypto.randomUUID()
 					: existingApp.serverCodeId
+				const updates: Parameters<typeof updateUiArtifact>[3] = {
+					title: args.title,
+					description: args.description,
+					clientCode: args.clientCode,
+					parameters: serializedParameters,
+					hidden: args.hidden,
+				}
+				if (args.serverCode !== undefined) {
+					updates.serverCode = serverCode
+					updates.serverCodeId = serverCodeId
+				}
 				const updated = await updateUiArtifact(
 					ctx.env.APP_DB,
 					user.userId,
 					appId,
-					{
-						title: args.title,
-						description: args.description,
-						clientCode: args.clientCode,
-						serverCode: nextServerCode,
-						serverCodeId,
-						parameters: serializedParameters,
-						hidden: args.hidden,
-					},
+					updates,
 				)
 				if (!updated) {
 					throw new Error('Saved UI artifact not found for this user.')
@@ -237,21 +294,34 @@ export const uiSaveAppCapability = defineDomainCapability(
 				hidden = args.hidden ?? existingApp.hidden
 				return await saveAndIndexApp({
 					appId,
+					title,
+					description,
+					clientCode,
+					serverCode,
 					serverCodeId,
+					parameters,
 					hidden,
 					existingApp,
 				})
 			} else {
+				const title = args.title!
+				const description = args.description!
+				const clientCode = args.clientCode!
+				const serverCode = args.serverCode ?? null
+				const parameters = normalizeUiArtifactParameters(args.parameters)
+				const serializedParameters = parameters
+					? JSON.stringify(parameters)
+					: null
 				const serverCodeId = crypto.randomUUID()
 				hidden = args.hidden ?? true
 				const now = new Date().toISOString()
 				await insertUiArtifact(ctx.env.APP_DB, {
 					id: appId,
 					user_id: user.userId,
-					title: args.title,
-					description: args.description,
-					clientCode: args.clientCode,
-					serverCode: nextServerCode,
+					title,
+					description,
+					clientCode,
+					serverCode,
 					serverCodeId,
 					parameters: serializedParameters,
 					hidden,
@@ -260,7 +330,12 @@ export const uiSaveAppCapability = defineDomainCapability(
 				})
 				return await saveAndIndexApp({
 					appId,
+					title,
+					description,
+					clientCode,
+					serverCode,
 					serverCodeId,
+					parameters,
 					hidden,
 					existingApp,
 				})

--- a/packages/worker/src/mcp/capabilities/apps/ui-save-app.ts
+++ b/packages/worker/src/mcp/capabilities/apps/ui-save-app.ts
@@ -263,7 +263,7 @@ export const uiSaveAppCapability = defineDomainCapability(
 						: normalizeUiArtifactParameters(args.parameters)
 				const serializedParameters =
 					args.parameters === undefined
-						? existingApp.parameters
+						? undefined
 						: parameters
 							? JSON.stringify(parameters)
 							: null
@@ -275,8 +275,10 @@ export const uiSaveAppCapability = defineDomainCapability(
 					title: args.title,
 					description: args.description,
 					clientCode: args.clientCode,
-					parameters: serializedParameters,
 					hidden: args.hidden,
+				}
+				if (args.parameters !== undefined) {
+					updates.parameters = serializedParameters
 				}
 				if (args.serverCode !== undefined) {
 					updates.serverCode = serverCode

--- a/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
@@ -413,3 +413,349 @@ test('saved apps with server code expose isolated backend storage', async () => 
 	)
 	expect(unauthenticatedResponse.status).toBe(401)
 })
+
+test('app_server_exec runs snippets in a throwaway worker with app RPC access', async () => {
+	await using database = await createTestDatabase()
+	await using server = await startDevServer(database.persistDir)
+	await using mcpClient = await createMcpClient(server.origin, database.user)
+
+	const serverCode = `
+		import { DurableObject } from 'cloudflare:workers'
+
+		export class App extends DurableObject {
+			async incrementBy(amount = 1) {
+				const current = Number((await this.ctx.storage.get('count')) ?? 0)
+				const next = current + Number(amount)
+				await this.ctx.storage.put('count', next)
+				return { count: next }
+			}
+		}
+	`
+
+	const saveResult = await mcpClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.ui_save_app({
+					title: 'Facet Exec App',
+					description: 'Saved app used to verify app_server_exec.',
+					clientCode: '<main><h1>Facet Exec App</h1></main>',
+					serverCode: ${JSON.stringify(serverCode)},
+					hidden: true,
+				})
+			}`,
+		},
+	})
+	const saveStructured = (saveResult as CallToolResult).structuredContent as
+		| { result?: { app_id?: string } }
+		| undefined
+	const savedAppId = saveStructured?.result?.app_id
+	expect(typeof savedAppId).toBe('string')
+
+	const trivialExecResult = await mcpClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.app_server_exec({
+					app_id: ${JSON.stringify(savedAppId)},
+					code: ${JSON.stringify(`return { hello: 'world' }`)},
+				})
+			}`,
+		},
+	})
+	const trivialExecStructured = (trivialExecResult as CallToolResult)
+		.structuredContent as
+		| {
+				result?: {
+					ok?: boolean
+					app_id?: string
+					facet_name?: string
+					result?: { hello?: string }
+				}
+		  }
+		| undefined
+	expect(trivialExecStructured?.result).toEqual({
+		ok: true,
+		app_id: savedAppId,
+		facet_name: 'main',
+		result: { hello: 'world' },
+	})
+
+	const rpcExecResult = await mcpClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.app_server_exec({
+					app_id: ${JSON.stringify(savedAppId)},
+					params: { amount: 3 },
+					code: ${JSON.stringify(`return await app.incrementBy(params.amount ?? 1)`)},
+				})
+			}`,
+		},
+	})
+	const rpcExecStructured = (rpcExecResult as CallToolResult)
+		.structuredContent as
+		| {
+				result?: {
+					result?: { count?: number }
+				}
+		  }
+		| undefined
+	expect(rpcExecStructured?.result?.result).toEqual({ count: 3 })
+
+	const exportResult = await mcpClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.app_storage_export({
+					app_id: ${JSON.stringify(savedAppId)},
+				})
+			}`,
+		},
+	})
+	const exportStructured = (exportResult as CallToolResult).structuredContent as
+		| {
+				result?: {
+					export?: {
+						entries?: Array<{ key?: string; value?: unknown }>
+					}
+				}
+		  }
+		| undefined
+	expect(exportStructured?.result?.export?.entries).toEqual([
+		{ key: 'count', value: 3 },
+	])
+})
+
+test('ui_save_app preserves omitted backend code and requires explicit clearing', async () => {
+	await using database = await createTestDatabase()
+	await using server = await startDevServer(database.persistDir)
+	await using mcpClient = await createMcpClient(server.origin, database.user)
+
+	const initialServerCode = `
+		import { DurableObject } from 'cloudflare:workers'
+
+		export class App extends DurableObject {
+			async readVersion() {
+				return 'v1'
+			}
+		}
+	`
+	const replacementServerCode = `
+		import { DurableObject } from 'cloudflare:workers'
+
+		export class App extends DurableObject {
+			async readVersion() {
+				return 'v2'
+			}
+		}
+	`
+
+	const saveResult = await mcpClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.ui_save_app({
+					title: 'Patchable App',
+					description: 'Saved app used to verify partial ui_save_app updates.',
+					clientCode: '<main><h1>Patchable v1</h1></main>',
+					serverCode: ${JSON.stringify(initialServerCode)},
+					hidden: true,
+				})
+			}`,
+		},
+	})
+	const saveStructured = (saveResult as CallToolResult).structuredContent as
+		| {
+				result?: {
+					app_id?: string
+					server_code_id?: string
+					has_server_code?: boolean
+				}
+		  }
+		| undefined
+	const savedAppId = saveStructured?.result?.app_id
+	const initialServerCodeId = saveStructured?.result?.server_code_id
+	expect(typeof savedAppId).toBe('string')
+	expect(typeof initialServerCodeId).toBe('string')
+	expect(saveStructured?.result?.has_server_code).toBe(true)
+
+	const clientOnlyUpdateResult = await mcpClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.ui_save_app({
+					app_id: ${JSON.stringify(savedAppId)},
+					clientCode: '<main><h1>Patchable v2</h1></main>',
+				})
+			}`,
+		},
+	})
+	const clientOnlyUpdateStructured = (clientOnlyUpdateResult as CallToolResult)
+		.structuredContent as
+		| {
+				result?: {
+					server_code_id?: string
+					has_server_code?: boolean
+				}
+		  }
+		| undefined
+	expect(clientOnlyUpdateStructured?.result?.server_code_id).toBe(
+		initialServerCodeId,
+	)
+	expect(clientOnlyUpdateStructured?.result?.has_server_code).toBe(true)
+
+	const preservedSourceResult = await mcpClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.ui_load_app_source({
+					app_id: ${JSON.stringify(savedAppId)},
+				})
+			}`,
+		},
+	})
+	const preservedSourceStructured = (preservedSourceResult as CallToolResult)
+		.structuredContent as
+		| {
+				result?: {
+					app_id?: string
+					title?: string
+					description?: string
+					client_code?: string
+					server_code?: string | null
+					server_code_id?: string
+					parameters?: null
+					hidden?: boolean
+				}
+		  }
+		| undefined
+	expect(preservedSourceStructured?.result).toEqual(
+		expect.objectContaining({
+			app_id: savedAppId,
+			title: 'Patchable App',
+			description: 'Saved app used to verify partial ui_save_app updates.',
+			client_code: '<main><h1>Patchable v2</h1></main>',
+			server_code: initialServerCode,
+			server_code_id: initialServerCodeId,
+			parameters: null,
+			hidden: true,
+		}),
+	)
+
+	const clearServerCodeResult = await mcpClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.ui_save_app({
+					app_id: ${JSON.stringify(savedAppId)},
+					serverCode: null,
+				})
+			}`,
+		},
+	})
+	const clearServerCodeStructured = (clearServerCodeResult as CallToolResult)
+		.structuredContent as
+		| {
+				result?: {
+					server_code_id?: string
+					has_server_code?: boolean
+				}
+		  }
+		| undefined
+	const clearedServerCodeId = clearServerCodeStructured?.result?.server_code_id
+	expect(typeof clearedServerCodeId).toBe('string')
+	expect(clearedServerCodeId).not.toBe(initialServerCodeId)
+	expect(clearServerCodeStructured?.result?.has_server_code).toBe(false)
+
+	const clearedSourceResult = await mcpClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.ui_load_app_source({
+					app_id: ${JSON.stringify(savedAppId)},
+				})
+			}`,
+		},
+	})
+	const clearedSourceStructured = (clearedSourceResult as CallToolResult)
+		.structuredContent as
+		| {
+				result?: {
+					app_id?: string
+					client_code?: string
+					server_code?: string | null
+					server_code_id?: string
+					hidden?: boolean
+				}
+		  }
+		| undefined
+	expect(clearedSourceStructured?.result).toEqual(
+		expect.objectContaining({
+			app_id: savedAppId,
+			client_code: '<main><h1>Patchable v2</h1></main>',
+			server_code: null,
+			server_code_id: clearedServerCodeId,
+			hidden: true,
+		}),
+	)
+
+	const replaceServerCodeResult = await mcpClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.ui_save_app({
+					app_id: ${JSON.stringify(savedAppId)},
+					serverCode: ${JSON.stringify(replacementServerCode)},
+				})
+			}`,
+		},
+	})
+	const replaceServerCodeStructured = (
+		replaceServerCodeResult as CallToolResult
+	).structuredContent as
+		| {
+				result?: {
+					server_code_id?: string
+					has_server_code?: boolean
+				}
+		  }
+		| undefined
+	const replacementServerCodeId =
+		replaceServerCodeStructured?.result?.server_code_id
+	expect(typeof replacementServerCodeId).toBe('string')
+	expect(replacementServerCodeId).not.toBe(clearedServerCodeId)
+	expect(replaceServerCodeStructured?.result?.has_server_code).toBe(true)
+
+	const replacedSourceResult = await mcpClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.ui_load_app_source({
+					app_id: ${JSON.stringify(savedAppId)},
+				})
+			}`,
+		},
+	})
+	const replacedSourceStructured = (replacedSourceResult as CallToolResult)
+		.structuredContent as
+		| {
+				result?: {
+					app_id?: string
+					client_code?: string
+					server_code?: string | null
+					server_code_id?: string
+					hidden?: boolean
+				}
+		  }
+		| undefined
+	expect(replacedSourceStructured?.result).toEqual(
+		expect.objectContaining({
+			app_id: savedAppId,
+			client_code: '<main><h1>Patchable v2</h1></main>',
+			server_code: replacementServerCode,
+			server_code_id: replacementServerCodeId,
+			hidden: true,
+		}),
+	)
+})

--- a/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
@@ -503,6 +503,33 @@ test('app_server_exec runs snippets in a throwaway worker with app RPC access', 
 		| undefined
 	expect(rpcExecStructured?.result?.result).toEqual({ count: 3 })
 
+	await using forbiddenExecClient = await createMcpClient(
+		server.origin,
+		database.user,
+	)
+
+	const forbiddenExecResult = await forbiddenExecClient.client.callTool({
+		name: 'execute',
+		arguments: {
+			code: `async () => {
+				return await codemode.app_server_exec({
+					app_id: ${JSON.stringify(savedAppId)},
+					code: ${JSON.stringify(`return await app.call("__kody_resetStorage")`)},
+				})
+			}`,
+		},
+	})
+	const forbiddenExecStructured = (forbiddenExecResult as CallToolResult)
+		.structuredContent as
+		| {
+				error?: string
+		  }
+		| undefined
+	expect(forbiddenExecResult.isError).toBe(true)
+	expect(forbiddenExecStructured?.error).toContain(
+		'Saved app RPC method "__kody_resetStorage" is not allowed.',
+	)
+
 	await using exportClient = await createMcpClient(server.origin, database.user)
 
 	const exportResult = await exportClient.client.callTool({
@@ -548,6 +575,14 @@ test('ui_save_app preserves omitted backend code and requires explicit clearing'
 					description: 'Saved app used to verify partial ui_save_app updates.',
 					clientCode: '<main><h1>Patchable v1</h1></main>',
 					serverCode: ${JSON.stringify(initialServerCode)},
+					parameters: [
+						{
+							name: 'team',
+							description: 'Team slug',
+							type: 'string',
+							required: true,
+						},
+					],
 					hidden: true,
 				})
 			}`,
@@ -618,7 +653,12 @@ test('ui_save_app preserves omitted backend code and requires explicit clearing'
 					client_code?: string
 					server_code?: string | null
 					server_code_id?: string
-					parameters?: null
+					parameters?: Array<{
+						name?: string
+						description?: string
+						type?: string
+						required?: boolean
+					}> | null
 					hidden?: boolean
 				}
 		  }
@@ -631,7 +671,14 @@ test('ui_save_app preserves omitted backend code and requires explicit clearing'
 			client_code: '<main><h1>Patchable v2</h1></main>',
 			server_code: initialServerCode,
 			server_code_id: initialServerCodeId,
-			parameters: null,
+			parameters: [
+				{
+					name: 'team',
+					description: 'Team slug',
+					type: 'string',
+					required: true,
+				},
+			],
 			hidden: true,
 		}),
 	)

--- a/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
@@ -419,18 +419,8 @@ test('app_server_exec runs snippets in a throwaway worker with app RPC access', 
 	await using server = await startDevServer(database.persistDir)
 	await using mcpClient = await createMcpClient(server.origin, database.user)
 
-	const serverCode = `
-		import { DurableObject } from 'cloudflare:workers'
-
-		export class App extends DurableObject {
-			async incrementBy(amount = 1) {
-				const current = Number((await this.ctx.storage.get('count')) ?? 0)
-				const next = current + Number(amount)
-				await this.ctx.storage.put('count', next)
-				return { count: next }
-			}
-		}
-	`
+	const serverCode =
+		'import { DurableObject } from "cloudflare:workers"; export class App extends DurableObject { async incrementBy(amount = 1) { const current = Number((await this.ctx.storage.get("count")) ?? 0); const next = current + Number(amount); await this.ctx.storage.put("count", next); return { count: next } } }'
 
 	const saveResult = await mcpClient.client.callTool({
 		name: 'execute',
@@ -452,7 +442,12 @@ test('app_server_exec runs snippets in a throwaway worker with app RPC access', 
 	const savedAppId = saveStructured?.result?.app_id
 	expect(typeof savedAppId).toBe('string')
 
-	const trivialExecResult = await mcpClient.client.callTool({
+	await using trivialExecClient = await createMcpClient(
+		server.origin,
+		database.user,
+	)
+
+	const trivialExecResult = await trivialExecClient.client.callTool({
 		name: 'execute',
 		arguments: {
 			code: `async () => {
@@ -481,14 +476,19 @@ test('app_server_exec runs snippets in a throwaway worker with app RPC access', 
 		result: { hello: 'world' },
 	})
 
-	const rpcExecResult = await mcpClient.client.callTool({
+	await using rpcExecClient = await createMcpClient(
+		server.origin,
+		database.user,
+	)
+
+	const rpcExecResult = await rpcExecClient.client.callTool({
 		name: 'execute',
 		arguments: {
 			code: `async () => {
 				return await codemode.app_server_exec({
 					app_id: ${JSON.stringify(savedAppId)},
 					params: { amount: 3 },
-					code: ${JSON.stringify(`return await app.incrementBy(params.amount ?? 1)`)},
+					code: ${JSON.stringify(`return await app.call("incrementBy", params.amount ?? 1)`)},
 				})
 			}`,
 		},
@@ -503,7 +503,9 @@ test('app_server_exec runs snippets in a throwaway worker with app RPC access', 
 		| undefined
 	expect(rpcExecStructured?.result?.result).toEqual({ count: 3 })
 
-	const exportResult = await mcpClient.client.callTool({
+	await using exportClient = await createMcpClient(server.origin, database.user)
+
+	const exportResult = await exportClient.client.callTool({
 		name: 'execute',
 		arguments: {
 			code: `async () => {
@@ -532,24 +534,10 @@ test('ui_save_app preserves omitted backend code and requires explicit clearing'
 	await using server = await startDevServer(database.persistDir)
 	await using mcpClient = await createMcpClient(server.origin, database.user)
 
-	const initialServerCode = `
-		import { DurableObject } from 'cloudflare:workers'
-
-		export class App extends DurableObject {
-			async readVersion() {
-				return 'v1'
-			}
-		}
-	`
-	const replacementServerCode = `
-		import { DurableObject } from 'cloudflare:workers'
-
-		export class App extends DurableObject {
-			async readVersion() {
-				return 'v2'
-			}
-		}
-	`
+	const initialServerCode =
+		'import { DurableObject } from "cloudflare:workers"; export class App extends DurableObject { async readVersion() { return "v1" } }'
+	const replacementServerCode =
+		'import { DurableObject } from "cloudflare:workers"; export class App extends DurableObject { async readVersion() { return "v2" } }'
 
 	const saveResult = await mcpClient.client.callTool({
 		name: 'execute',
@@ -605,7 +593,12 @@ test('ui_save_app preserves omitted backend code and requires explicit clearing'
 	)
 	expect(clientOnlyUpdateStructured?.result?.has_server_code).toBe(true)
 
-	const preservedSourceResult = await mcpClient.client.callTool({
+	await using preservedSourceClient = await createMcpClient(
+		server.origin,
+		database.user,
+	)
+
+	const preservedSourceResult = await preservedSourceClient.client.callTool({
 		name: 'execute',
 		arguments: {
 			code: `async () => {
@@ -668,7 +661,12 @@ test('ui_save_app preserves omitted backend code and requires explicit clearing'
 	expect(clearedServerCodeId).not.toBe(initialServerCodeId)
 	expect(clearServerCodeStructured?.result?.has_server_code).toBe(false)
 
-	const clearedSourceResult = await mcpClient.client.callTool({
+	await using clearedSourceClient = await createMcpClient(
+		server.origin,
+		database.user,
+	)
+
+	const clearedSourceResult = await clearedSourceClient.client.callTool({
 		name: 'execute',
 		arguments: {
 			code: `async () => {
@@ -727,7 +725,12 @@ test('ui_save_app preserves omitted backend code and requires explicit clearing'
 	expect(replacementServerCodeId).not.toBe(clearedServerCodeId)
 	expect(replaceServerCodeStructured?.result?.has_server_code).toBe(true)
 
-	const replacedSourceResult = await mcpClient.client.callTool({
+	await using replacedSourceClient = await createMcpClient(
+		server.origin,
+		database.user,
+	)
+
+	const replacedSourceResult = await replacedSourceClient.client.callTool({
 		name: 'execute',
 		arguments: {
 			code: `async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- move `app_server_exec` off in-facet string eval and into a throwaway Dynamic Worker loaded via `APP_LOADER`
- preserve existing saved-app fields on `ui_save_app` updates unless the caller explicitly changes them
- harden exec method dispatch and add saved-app regression coverage/docs for the stricter contract

## Design note
`app_server_exec` no longer attempts to evaluate arbitrary source inside the running saved-app facet. The supervisor wraps the snippet in a synthetic WorkerEntrypoint module, loads it through the Dynamic Worker Loader API, and exposes an explicit `app.call(methodName, ...args)` bridge. That bridge now routes through a dedicated facet RPC wrapper that rejects reserved names such as `fetch` and `__kody_*` before dispatching to user-defined methods on the saved app's exported `App` class. For raw storage inspection, users should use `app_storage_export`.

## Testing
- repeated targeted MCP E2E runs for `packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts`
- covered `app_server_exec` trivial execution, explicit RPC calls, and reserved-method rejection
- covered `ui_save_app` preserve / clear / rotate backend semantics across fresh MCP sessions
- covered that omitted `parameters` do not overwrite existing saved parameter definitions
- captured passing output artifact: <a href="/opt/cursor/artifacts/saved-app-regression-test-output.txt">saved-app-regression-test-output.txt</a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d859ee71-b369-421d-bf43-055534d32508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d859ee71-b369-421d-bf43-055534d32508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Saved apps support partial updates—omitted fields preserve existing values.
  * Backend can be explicitly cleared with serverCode: null.
  * Backend exec runs in a throwaway worker and exposes app.call(methodName, ...args) for validated RPC.

* **Documentation**
  * Clarified saved-app update semantics, serverCode handling, and app_server_exec execution model and restrictions (reserved method names).

* **Tests**
  * Added end-to-end tests for exec worker RPCs and partial app update behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->