### PR TITLE
Handle stale OAuth client reset recovery

### DIFF
--- a/packages/shared/src/oauth-messages.ts
+++ b/packages/shared/src/oauth-messages.ts
@@ -1,5 +1,2 @@
-export const invalidRedirectUriMessage =
-	'Invalid redirect URI. The redirect URI provided does not match any registered URI for this client.'
-
 export const invalidClientIdMismatchMessage =
 	'Invalid client. The clientId provided does not match to this client.'

--- a/packages/shared/src/oauth-messages.ts
+++ b/packages/shared/src/oauth-messages.ts
@@ -1,2 +1,14 @@
 export const invalidRedirectUriMessage =
 	'Invalid redirect URI. The redirect URI provided does not match any registered URI for this client.'
+
+export const invalidClientIdMismatchMessage =
+	'Invalid client. The clientId provided does not match to this client.'
+
+export function canResetStoredClientForMessage(
+	message: string | null | undefined,
+) {
+	return (
+		message === invalidRedirectUriMessage ||
+		message === invalidClientIdMismatchMessage
+	)
+}

--- a/packages/shared/src/oauth-messages.ts
+++ b/packages/shared/src/oauth-messages.ts
@@ -3,12 +3,3 @@ export const invalidRedirectUriMessage =
 
 export const invalidClientIdMismatchMessage =
 	'Invalid client. The clientId provided does not match to this client.'
-
-export function canResetStoredClientForMessage(
-	message: string | null | undefined,
-) {
-	return (
-		message === invalidRedirectUriMessage ||
-		message === invalidClientIdMismatchMessage
-	)
-}

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -224,6 +224,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 			(canResetStoredClientForMessage(queryError) ||
 				canResetStoredClientForMessage(message?.text)) &&
 			!resetCompleted
+		const showAuthorizeForm = !resetCompleted
 		const actionsDisabled =
 			status !== 'ready' || Boolean(submittingDecision) || isSessionLoading
 		const resetClientDisabled =
@@ -266,7 +267,11 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 						>
 							Signed in as {sessionEmail}
 						</p>
-						<p css={descriptionCss}>Approve to continue with this account.</p>
+						<p css={descriptionCss}>
+							{resetCompleted
+								? 'Start the connection again from your client to continue with this account.'
+								: 'Approve to continue with this account.'}
+						</p>
 					</section>
 				) : null}
 				{status === 'loading' ? (
@@ -304,59 +309,61 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 						) : null}
 					</section>
 				) : null}
-				<form
-					css={{
-						...cardCss,
-						opacity: formReady ? 1 : 0.7,
-					}}
-					on={{ submit: handleSubmit }}
-				>
-					{!isLoggedIn && isSessionReady ? (
-						<>
-							<label css={fieldCss}>
-								<span css={fieldLabelCss}>Email</span>
-								<input
-									type="email"
-									name="email"
-									required
-									autoComplete="email"
-									placeholder="you@example.com"
-									disabled={actionsDisabled}
-									css={inputCss}
-								/>
-							</label>
-							<label css={fieldCss}>
-								<span css={fieldLabelCss}>Password</span>
-								<input
-									type="password"
-									name="password"
-									required
-									autoComplete="current-password"
-									placeholder="Enter your password"
-									disabled={actionsDisabled}
-									css={inputCss}
-								/>
-							</label>
-						</>
-					) : null}
-					<div css={{ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' }}>
-						<button
-							type="submit"
-							disabled={actionsDisabled}
-							css={primaryButtonCss}
-						>
-							{authorizeLabel}
-						</button>
-						<button
-							type="button"
-							disabled={actionsDisabled}
-							on={{ click: () => submitDecision('deny') }}
-							css={secondaryButtonCss}
-						>
-							Deny
-						</button>
-					</div>
-				</form>
+				{showAuthorizeForm ? (
+					<form
+						css={{
+							...cardCss,
+							opacity: formReady ? 1 : 0.7,
+						}}
+						on={{ submit: handleSubmit }}
+					>
+						{!isLoggedIn && isSessionReady ? (
+							<>
+								<label css={fieldCss}>
+									<span css={fieldLabelCss}>Email</span>
+									<input
+										type="email"
+										name="email"
+										required
+										autoComplete="email"
+										placeholder="you@example.com"
+										disabled={actionsDisabled}
+										css={inputCss}
+									/>
+								</label>
+								<label css={fieldCss}>
+									<span css={fieldLabelCss}>Password</span>
+									<input
+										type="password"
+										name="password"
+										required
+										autoComplete="current-password"
+										placeholder="Enter your password"
+										disabled={actionsDisabled}
+										css={inputCss}
+									/>
+								</label>
+							</>
+						) : null}
+						<div css={{ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' }}>
+							<button
+								type="submit"
+								disabled={actionsDisabled}
+								css={primaryButtonCss}
+							>
+								{authorizeLabel}
+							</button>
+							<button
+								type="button"
+								disabled={actionsDisabled}
+								on={{ click: () => submitDecision('deny') }}
+								css={secondaryButtonCss}
+							>
+								Deny
+							</button>
+						</div>
+					</form>
+				) : null}
 				<a href="/" css={mutedLinkCss}>
 					Back home
 				</a>

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -64,6 +64,15 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		return error ? `Authorization error: ${error}` : null
 	}
 
+	function readResetErrorDescription() {
+		const queryError = readQueryError()
+		if (canResetStoredClientForMessage(queryError)) {
+			return queryError
+		}
+		const messageText = message?.text
+		return canResetStoredClientForMessage(messageText) ? messageText : null
+	}
+
 	async function loadInfo() {
 		status = 'loading'
 
@@ -147,7 +156,18 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 				body.set('email', email)
 				body.set('password', password)
 			}
-			const response = await fetch(window.location.href, {
+			let submitUrl = window.location.href
+			if (decision === 'reset-client') {
+				const resetErrorDescription = readResetErrorDescription()
+				if (resetErrorDescription) {
+					const url = new URL(submitUrl)
+					if (!url.searchParams.get('error_description')) {
+						url.searchParams.set('error_description', resetErrorDescription)
+						submitUrl = url.toString()
+					}
+				}
+			}
+			const response = await fetch(submitUrl, {
 				method: 'POST',
 				headers: {
 					Accept: 'application/json',
@@ -214,16 +234,13 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		const scopes = info?.scopes ?? []
 		const scopeLabel =
 			scopes.length > 0 ? scopes.join(', ') : 'No scopes requested.'
-		const queryError = readQueryError()
+		const resetErrorDescription = readResetErrorDescription()
 		const sessionEmail = session?.email ?? ''
 		const isSessionReady = sessionStatus === 'ready'
 		const isSessionLoading =
 			sessionStatus === 'loading' || sessionStatus === 'idle'
 		const isLoggedIn = isSessionReady && Boolean(sessionEmail)
-		const showResetClientCard =
-			(canResetStoredClientForMessage(queryError) ||
-				canResetStoredClientForMessage(message?.text)) &&
-			!resetCompleted
+		const showResetClientCard = Boolean(resetErrorDescription) && !resetCompleted
 		const showAuthorizeForm = !resetCompleted
 		const actionsDisabled =
 			status !== 'ready' || Boolean(submittingDecision) || isSessionLoading

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -24,7 +24,7 @@ import {
 	sectionTitleCss,
 	stackedPageCss,
 } from '#client/styles/style-primitives.ts'
-import { invalidRedirectUriMessage } from '@kody-internal/shared/oauth-messages.ts'
+import { canResetStoredClientForMessage } from '@kody-internal/shared/oauth-messages.ts'
 
 type OAuthAuthorizeInfo = {
 	client: { id: string; name: string }
@@ -34,10 +34,6 @@ type OAuthAuthorizeInfo = {
 type OAuthAuthorizeStatus = 'idle' | 'loading' | 'ready' | 'error'
 type OAuthAuthorizeMessage = { type: 'error' | 'info'; text: string }
 type OAuthAuthorizeDecision = 'approve' | 'deny' | 'reset-client'
-
-function isInvalidRedirectUriMessage(message: string | null | undefined) {
-	return message === invalidRedirectUriMessage
-}
 
 function getSearchParams() {
 	return typeof window === 'undefined'
@@ -225,8 +221,8 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 			sessionStatus === 'loading' || sessionStatus === 'idle'
 		const isLoggedIn = isSessionReady && Boolean(sessionEmail)
 		const showResetClientCard =
-			(isInvalidRedirectUriMessage(queryError) ||
-				isInvalidRedirectUriMessage(message?.text)) &&
+			(canResetStoredClientForMessage(queryError) ||
+				canResetStoredClientForMessage(message?.text)) &&
 			!resetCompleted
 		const actionsDisabled =
 			status !== 'ready' || Boolean(submittingDecision) || isSessionLoading

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -24,7 +24,6 @@ import {
 	sectionTitleCss,
 	stackedPageCss,
 } from '#client/styles/style-primitives.ts'
-import { canResetStoredClientForMessage } from '@kody-internal/shared/oauth-messages.ts'
 
 type OAuthAuthorizeInfo = {
 	client: { id: string; name: string }
@@ -50,6 +49,8 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 	let session: SessionInfo | null = null
 	let sessionStatus: SessionStatus = 'idle'
 	let resetCompleted = false
+	let allowClientReset = false
+	let activeInfoRequestId = 0
 
 	function setMessage(next: OAuthAuthorizeMessage | null) {
 		message = next
@@ -64,23 +65,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		return error ? `Authorization error: ${error}` : null
 	}
 
-	function readResetErrorDescription() {
-		const queryError = readQueryError()
-		if (canResetStoredClientForMessage(queryError)) {
-			return queryError
-		}
-		const messageText = message?.text
-		return canResetStoredClientForMessage(messageText) ? messageText : null
-	}
-
-	async function loadInfo() {
-		status = 'loading'
-
-		const queryError = readQueryError()
-		if (queryError) {
-			message = { type: 'error', text: queryError }
-		}
-
+	async function loadInfo(requestId: number) {
 		try {
 			const query = typeof window === 'undefined' ? '' : window.location.search
 			const response = await fetch(`/oauth/authorize-info${query}`, {
@@ -88,6 +73,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 				credentials: 'include',
 			})
 			const payload = await response.json().catch(() => null)
+			if (requestId !== activeInfoRequestId) return
 			if (!response.ok || !payload?.ok) {
 				const errorText =
 					typeof payload?.error === 'string'
@@ -95,6 +81,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 						: 'Unable to load authorization details.'
 				info = null
 				status = 'error'
+				allowClientReset = payload?.allowClientReset === true
 				message = { type: 'error', text: errorText }
 				handle.update()
 				return
@@ -104,13 +91,14 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 				scopes: payload.scopes,
 			}
 			status = 'ready'
-			if (!queryError) {
-				message = null
-			}
+			allowClientReset = false
+			message = null
 			handle.update()
 		} catch {
+			if (requestId !== activeInfoRequestId) return
 			info = null
 			status = 'error'
+			allowClientReset = false
 			message = {
 				type: 'error',
 				text: 'Unable to load authorization details.',
@@ -156,16 +144,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 				body.set('email', email)
 				body.set('password', password)
 			}
-			let submitUrl = window.location.href
-			if (decision === 'reset-client') {
-				const resetErrorDescription = readResetErrorDescription()
-				if (resetErrorDescription) {
-					const url = new URL(submitUrl)
-					url.searchParams.set('error_description', resetErrorDescription)
-					submitUrl = url.toString()
-				}
-			}
-			const response = await fetch(submitUrl, {
+			const response = await fetch(window.location.href, {
 				method: 'POST',
 				headers: {
 					Accept: 'application/json',
@@ -222,7 +201,14 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 			typeof window === 'undefined' ? '' : window.location.search
 		if (currentSearch !== lastSearch) {
 			lastSearch = currentSearch
-			void loadInfo()
+			resetCompleted = false
+			allowClientReset = false
+			info = null
+			status = 'loading'
+			const queryError = readQueryError()
+			message = queryError ? { type: 'error', text: queryError } : null
+			activeInfoRequestId += 1
+			void loadInfo(activeInfoRequestId)
 		}
 		if (sessionStatus === 'idle') {
 			void loadSession()
@@ -232,13 +218,12 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		const scopes = info?.scopes ?? []
 		const scopeLabel =
 			scopes.length > 0 ? scopes.join(', ') : 'No scopes requested.'
-		const resetErrorDescription = readResetErrorDescription()
 		const sessionEmail = session?.email ?? ''
 		const isSessionReady = sessionStatus === 'ready'
 		const isSessionLoading =
 			sessionStatus === 'loading' || sessionStatus === 'idle'
 		const isLoggedIn = isSessionReady && Boolean(sessionEmail)
-		const showResetClientCard = Boolean(resetErrorDescription) && !resetCompleted
+		const showResetClientCard = allowClientReset && !resetCompleted
 		const showAuthorizeForm = !resetCompleted
 		const actionsDisabled =
 			status !== 'ready' || Boolean(submittingDecision) || isSessionLoading

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -161,10 +161,8 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 				const resetErrorDescription = readResetErrorDescription()
 				if (resetErrorDescription) {
 					const url = new URL(submitUrl)
-					if (!url.searchParams.get('error_description')) {
-						url.searchParams.set('error_description', resetErrorDescription)
-						submitUrl = url.toString()
-					}
+					url.searchParams.set('error_description', resetErrorDescription)
+					submitUrl = url.toString()
 				}
 			}
 			const response = await fetch(submitUrl, {

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -14,6 +14,7 @@ import { render } from '#app/render.ts'
 import { createDb, usersTable } from './db.ts'
 import { wantsJson } from './utils.ts'
 import { verifyPassword } from '@kody-internal/shared/password-hash.ts'
+import { canResetStoredClientForMessage } from '@kody-internal/shared/oauth-messages.ts'
 
 export const oauthPaths = {
 	authorize: '/oauth/authorize',
@@ -89,6 +90,13 @@ async function resolveAuthRequest(helpers: OAuthHelpers, request: Request) {
 function readClientIdFromAuthorizeRequest(request: Request) {
 	const clientId = new URL(request.url).searchParams.get('client_id')?.trim()
 	return clientId ? clientId : null
+}
+
+function readAuthorizeErrorDescription(request: Request) {
+	const errorDescription = new URL(request.url).searchParams
+		.get('error_description')
+		?.trim()
+	return errorDescription ? errorDescription : null
 }
 
 function isLoopbackHostname(hostname: string) {
@@ -182,10 +190,13 @@ async function handleResetClientRequest(
 		helpers,
 		request,
 	)
-	if (!redirectUriMismatch) {
+	const queryErrorDescription = readAuthorizeErrorDescription(request)
+	const canResetStoredClient =
+		redirectUriMismatch || canResetStoredClientForMessage(queryErrorDescription)
+	if (!canResetStoredClient) {
 		return respondAuthorizeError(
 			request,
-			'Stored client cleanup is only available for redirect URI mismatches.',
+			'Stored client cleanup is only available for stale or mismatched client registrations.',
 			400,
 			'invalid_request',
 		)

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -2,8 +2,10 @@ import {
 	type AuthRequest,
 	type OAuthHelpers,
 } from '@cloudflare/workers-oauth-provider'
+import { createCookie } from '@remix-run/cookie'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
 import {
+	isSecureRequest,
 	readAuthSessionResult,
 	setAuthSessionSecret,
 } from '#app/auth-session.ts'
@@ -14,6 +16,7 @@ import { render } from '#app/render.ts'
 import { createDb, usersTable } from './db.ts'
 import { wantsJson } from './utils.ts'
 import { verifyPassword } from '@kody-internal/shared/password-hash.ts'
+import { invalidClientIdMismatchMessage } from '@kody-internal/shared/oauth-messages.ts'
 
 export const oauthPaths = {
 	authorize: '/oauth/authorize',
@@ -40,20 +43,30 @@ type OAuthContext = ExecutionContext & {
 	props?: OAuthProps
 }
 
+type OAuthClientResetVerification = {
+	clientId: string
+	reason: 'invalid-client-id-mismatch'
+}
+
 function renderSpaShell(status = 200) {
 	return render(Layout({}), { status })
 }
 
 const dummyPasswordHash =
 	'pbkdf2_sha256$100000$00000000000000000000000000000000$0000000000000000000000000000000000000000000000000000000000000000'
+const oauthClientResetVerificationCookieName = 'kody_oauth_client_reset'
+const oauthClientResetVerificationMaxAgeSeconds = 60 * 5
+
+let oauthClientResetVerificationCookie: ReturnType<typeof createCookie> | null =
+	null
+let oauthClientResetVerificationCookieSecret: string | null = null
 
 function jsonResponse(data: unknown, init?: ResponseInit) {
+	const headers = new Headers(init?.headers)
+	headers.set('Content-Type', 'application/json')
 	return new Response(JSON.stringify(data), {
 		...init,
-		headers: {
-			'Content-Type': 'application/json',
-			...init?.headers,
-		},
+		headers,
 	})
 }
 
@@ -63,6 +76,109 @@ function getOAuthHelpers(env: Env) {
 		throw new Error('OAuth provider helpers are not available.')
 	}
 	return helpers
+}
+
+function getOAuthClientResetVerificationCookie(secret: string) {
+	if (
+		oauthClientResetVerificationCookie &&
+		oauthClientResetVerificationCookieSecret === secret
+	) {
+		return oauthClientResetVerificationCookie
+	}
+
+	oauthClientResetVerificationCookieSecret = secret
+	oauthClientResetVerificationCookie = createCookie(
+		oauthClientResetVerificationCookieName,
+		{
+			httpOnly: true,
+			sameSite: 'Lax',
+			path: oauthPaths.authorize,
+			maxAge: oauthClientResetVerificationMaxAgeSeconds,
+			secrets: [secret],
+		},
+	)
+	return oauthClientResetVerificationCookie
+}
+
+function isOAuthClientResetVerification(
+	value: unknown,
+): value is OAuthClientResetVerification {
+	if (!value || typeof value !== 'object') return false
+	const record = value as Record<string, unknown>
+	return (
+		typeof record.clientId === 'string' &&
+		record.clientId.length > 0 &&
+		record.reason === 'invalid-client-id-mismatch'
+	)
+}
+
+function requestHasOAuthClientResetVerificationCookie(request: Request) {
+	const cookieHeader = request.headers.get('Cookie')
+	return (
+		cookieHeader?.includes(`${oauthClientResetVerificationCookieName}=`) ??
+		false
+	)
+}
+
+async function createOAuthClientResetVerificationCookie(
+	request: Request,
+	env: Env,
+	verification: OAuthClientResetVerification,
+) {
+	const appEnv = getEnv(env)
+	return getOAuthClientResetVerificationCookie(appEnv.COOKIE_SECRET).serialize(
+		JSON.stringify(verification),
+		{
+			secure: isSecureRequest(request),
+		},
+	)
+}
+
+async function destroyOAuthClientResetVerificationCookie(
+	request: Request,
+	env: Env,
+) {
+	const appEnv = getEnv(env)
+	return getOAuthClientResetVerificationCookie(appEnv.COOKIE_SECRET).serialize(
+		'',
+		{
+			secure: isSecureRequest(request),
+			maxAge: 0,
+			expires: new Date(0),
+		},
+	)
+}
+
+async function readOAuthClientResetVerification(
+	request: Request,
+	env: Env,
+): Promise<OAuthClientResetVerification | null> {
+	const cookieHeader = request.headers.get('Cookie')
+	if (!cookieHeader) return null
+
+	const appEnv = getEnv(env)
+	const stored = await getOAuthClientResetVerificationCookie(
+		appEnv.COOKIE_SECRET,
+	).parse(cookieHeader)
+	if (!stored || typeof stored !== 'string') return null
+
+	try {
+		const parsed = JSON.parse(stored)
+		return isOAuthClientResetVerification(parsed) ? parsed : null
+	} catch {
+		return null
+	}
+}
+
+function createSetCookieHeaders(cookies: Array<string | null | undefined>) {
+	const headers = new Headers()
+	let hasCookie = false
+	for (const cookie of cookies) {
+		if (!cookie) continue
+		headers.append('Set-Cookie', cookie)
+		hasCookie = true
+	}
+	return hasCookie ? headers : undefined
 }
 
 async function resolveAuthRequest(helpers: OAuthHelpers, request: Request) {
@@ -172,32 +288,92 @@ function resolveScopes(requestedScopes: Array<string>) {
 	return requestedScopes
 }
 
+async function resolveAuthorizeInfoResetState(
+	request: Request,
+	env: Env,
+	helpers: OAuthHelpers,
+	errorMessage: string,
+) {
+	const shouldClearVerificationCookie =
+		requestHasOAuthClientResetVerificationCookie(request)
+	const redirectUriMismatch = await requestHasRedirectUriMismatch(
+		helpers,
+		request,
+	)
+	if (redirectUriMismatch) {
+		return {
+			allowClientReset: true,
+			setCookie: shouldClearVerificationCookie
+				? await destroyOAuthClientResetVerificationCookie(request, env)
+				: null,
+		}
+	}
+
+	if (errorMessage === invalidClientIdMismatchMessage) {
+		const clientId = readClientIdFromAuthorizeRequest(request)
+		if (clientId) {
+			return {
+				allowClientReset: true,
+				setCookie: await createOAuthClientResetVerificationCookie(
+					request,
+					env,
+					{
+						clientId,
+						reason: 'invalid-client-id-mismatch',
+					},
+				),
+			}
+		}
+	}
+
+	return {
+		allowClientReset: false,
+		setCookie: shouldClearVerificationCookie
+			? await destroyOAuthClientResetVerificationCookie(request, env)
+			: null,
+	}
+}
+
 async function handleResetClientRequest(
 	request: Request,
 	env: Env,
 	helpers: OAuthHelpers,
 	requestIp?: string,
 ) {
+	const clientId = readClientIdFromAuthorizeRequest(request)
+	const hasResetVerificationCookie =
+		requestHasOAuthClientResetVerificationCookie(request)
+	const verifiedClientReset = await readOAuthClientResetVerification(
+		request,
+		env,
+	)
+	const clearResetVerificationCookie = hasResetVerificationCookie
+		? await destroyOAuthClientResetVerificationCookie(request, env)
+		: null
 	const redirectUriMismatch = await requestHasRedirectUriMismatch(
 		helpers,
 		request,
 	)
-	if (!redirectUriMismatch) {
+	const canResetStoredClient =
+		redirectUriMismatch ||
+		(clientId !== null && verifiedClientReset?.clientId === clientId)
+	if (!canResetStoredClient) {
 		return respondAuthorizeError(
 			request,
 			'Stored client cleanup is only available for stale or mismatched client registrations.',
 			400,
 			'invalid_request',
+			createSetCookieHeaders([clearResetVerificationCookie]),
 		)
 	}
 
-	const clientId = readClientIdFromAuthorizeRequest(request)
 	if (!clientId) {
 		return respondAuthorizeError(
 			request,
 			'Missing client ID for stored client cleanup.',
 			400,
 			'invalid_request',
+			createSetCookieHeaders([clearResetVerificationCookie]),
 		)
 	}
 
@@ -219,6 +395,7 @@ async function handleResetClientRequest(
 			'Sign in before deleting stored client records.',
 			401,
 			'unauthorized',
+			createSetCookieHeaders([clearResetVerificationCookie]),
 		)
 	}
 
@@ -243,13 +420,12 @@ async function handleResetClientRequest(
 				message:
 					'Deleted the stored client records for this connection. Start the connection again from your client to create a fresh trusted client.',
 			},
-			setCookie
-				? {
-						headers: {
-							'Set-Cookie': setCookie,
-						},
-					}
-				: undefined,
+			{
+				headers: createSetCookieHeaders([
+					clearResetVerificationCookie,
+					setCookie,
+				]),
+			},
 		)
 	} catch (error) {
 		void logAuditEvent({
@@ -266,6 +442,7 @@ async function handleResetClientRequest(
 			'Unable to delete stored client records right now.',
 			500,
 			'server_error',
+			createSetCookieHeaders([clearResetVerificationCookie]),
 		)
 	}
 }
@@ -284,11 +461,17 @@ function createAuthorizeErrorRedirect(
 	request: Request,
 	error: string,
 	description: string,
+	headersInit?: HeadersInit,
 ) {
 	const redirectUrl = new URL(request.url)
 	redirectUrl.searchParams.set('error', error)
 	redirectUrl.searchParams.set('error_description', description)
-	return Response.redirect(redirectUrl.toString(), 303)
+	const headers = new Headers(headersInit)
+	headers.set('Location', redirectUrl.toString())
+	return new Response(null, {
+		status: 303,
+		headers,
+	})
 }
 
 function respondAuthorizeError(
@@ -296,10 +479,14 @@ function respondAuthorizeError(
 	message: string,
 	status = 400,
 	errorCode = 'invalid_request',
+	headers?: HeadersInit,
 ) {
 	return wantsJson(request)
-		? jsonResponse({ ok: false, error: message, code: errorCode }, { status })
-		: createAuthorizeErrorRedirect(request, errorCode, message)
+		? jsonResponse(
+				{ ok: false, error: message, code: errorCode },
+				{ status, headers },
+			)
+		: createAuthorizeErrorRedirect(request, errorCode, message, headers)
 }
 
 async function resolveSessionEmail(request: Request, env: Env) {
@@ -327,26 +514,51 @@ export async function handleAuthorizeInfo(
 	const helpers = getOAuthHelpers(env)
 	const resolution = await resolveAuthRequest(helpers, request)
 	if ('error' in resolution) {
-		return jsonResponse({ ok: false, error: resolution.error }, { status: 400 })
-	}
-
-	const { authRequest, client } = resolution
-	const resolvedScopes = resolveScopes(authRequest.scope)
-	if (!Array.isArray(resolvedScopes)) {
+		const { allowClientReset, setCookie } =
+			await resolveAuthorizeInfoResetState(
+				request,
+				env,
+				helpers,
+				resolution.error ?? 'Unable to parse OAuth request.',
+			)
 		return jsonResponse(
-			{ ok: false, error: resolvedScopes.error },
-			{ status: 400 },
+			{ ok: false, error: resolution.error, allowClientReset },
+			{
+				status: 400,
+				headers: createSetCookieHeaders([setCookie]),
+			},
 		)
 	}
 
-	return jsonResponse({
-		ok: true,
-		client: {
-			id: client.clientId,
-			name: client.clientName ?? client.clientId,
+	const { authRequest, client } = resolution
+	const clearResetVerificationCookie =
+		requestHasOAuthClientResetVerificationCookie(request)
+			? await destroyOAuthClientResetVerificationCookie(request, env)
+			: null
+	const resolvedScopes = resolveScopes(authRequest.scope)
+	if (!Array.isArray(resolvedScopes)) {
+		return jsonResponse(
+			{ ok: false, error: resolvedScopes.error, allowClientReset: false },
+			{
+				status: 400,
+				headers: createSetCookieHeaders([clearResetVerificationCookie]),
+			},
+		)
+	}
+
+	return jsonResponse(
+		{
+			ok: true,
+			client: {
+				id: client.clientId,
+				name: client.clientName ?? client.clientId,
+			},
+			scopes: resolvedScopes,
 		},
-		scopes: resolvedScopes,
-	})
+		{
+			headers: createSetCookieHeaders([clearResetVerificationCookie]),
+		},
+	)
 }
 
 export async function handleAuthorizeRequest(
@@ -473,13 +685,9 @@ export async function handleAuthorizeRequest(
 		if (wantsJson(request)) {
 			return jsonResponse(
 				{ ok: true, redirectTo },
-				setCookie
-					? {
-							headers: {
-								'Set-Cookie': setCookie,
-							},
-						}
-					: undefined,
+				{
+					headers: createSetCookieHeaders([setCookie]),
+				},
 			)
 		}
 

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -56,6 +56,7 @@ const dummyPasswordHash =
 	'pbkdf2_sha256$100000$00000000000000000000000000000000$0000000000000000000000000000000000000000000000000000000000000000'
 const oauthClientResetVerificationCookieName = 'kody_oauth_client_reset'
 const oauthClientResetVerificationMaxAgeSeconds = 60 * 5
+const oauthClientResetVerificationCookiePath = '/oauth'
 
 let oauthClientResetVerificationCookie: ReturnType<typeof createCookie> | null =
 	null
@@ -92,7 +93,7 @@ function getOAuthClientResetVerificationCookie(secret: string) {
 		{
 			httpOnly: true,
 			sameSite: 'Lax',
-			path: oauthPaths.authorize,
+			path: oauthClientResetVerificationCookiePath,
 			maxAge: oauthClientResetVerificationMaxAgeSeconds,
 			secrets: [secret],
 		},

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -14,7 +14,6 @@ import { render } from '#app/render.ts'
 import { createDb, usersTable } from './db.ts'
 import { wantsJson } from './utils.ts'
 import { verifyPassword } from '@kody-internal/shared/password-hash.ts'
-import { canResetStoredClientForMessage } from '@kody-internal/shared/oauth-messages.ts'
 
 export const oauthPaths = {
 	authorize: '/oauth/authorize',
@@ -90,13 +89,6 @@ async function resolveAuthRequest(helpers: OAuthHelpers, request: Request) {
 function readClientIdFromAuthorizeRequest(request: Request) {
 	const clientId = new URL(request.url).searchParams.get('client_id')?.trim()
 	return clientId ? clientId : null
-}
-
-function readAuthorizeErrorDescription(request: Request) {
-	const errorDescription = new URL(request.url).searchParams
-		.get('error_description')
-		?.trim()
-	return errorDescription ? errorDescription : null
 }
 
 function isLoopbackHostname(hostname: string) {
@@ -190,10 +182,7 @@ async function handleResetClientRequest(
 		helpers,
 		request,
 	)
-	const queryErrorDescription = readAuthorizeErrorDescription(request)
-	const canResetStoredClient =
-		redirectUriMismatch || canResetStoredClientForMessage(queryErrorDescription)
-	if (!canResetStoredClient) {
+	if (!redirectUriMismatch) {
 		return respondAuthorizeError(
 			request,
 			'Stored client cleanup is only available for stale or mismatched client registrations.',

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -173,9 +173,9 @@ test('authorize info marks invalid client mismatch as resettable', async () => {
 		error: invalidClientIdMismatchMessage,
 		allowClientReset: true,
 	})
-	expect(response.headers.get('Set-Cookie')).toContain(
-		'kody_oauth_client_reset=',
-	)
+	const setCookie = response.headers.get('Set-Cookie') ?? ''
+	expect(setCookie).toContain('kody_oauth_client_reset=')
+	expect(setCookie).toContain('Path=/oauth')
 })
 
 test('authorize denies access and redirects with error', async () => {

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -120,6 +120,10 @@ function createFormRequest(
 	})
 }
 
+function getCookiePair(setCookie: string) {
+	return setCookie.split(';', 1)[0] ?? setCookie
+}
+
 test('authorize page returns SPA shell', async () => {
 	const response = await handleAuthorizeRequest(
 		new Request('https://example.com/oauth/authorize'),
@@ -147,6 +151,31 @@ test('authorize info returns client and scopes', async () => {
 		client: { id: baseClient.clientId, name: baseClient.clientName },
 		scopes: baseAuthRequest.scope,
 	})
+})
+
+test('authorize info marks invalid client mismatch as resettable', async () => {
+	const response = await handleAuthorizeInfo(
+		new Request(
+			`https://example.com/oauth/authorize-info?response_type=code&client_id=client-123&redirect_uri=${encodeURIComponent('https://example.com/callback')}&error_description=${encodeURIComponent(invalidClientIdMismatchMessage)}`,
+		),
+		createEnv(
+			createHelpers({
+				parseAuthRequest: async () => {
+					throw new Error(invalidClientIdMismatchMessage)
+				},
+			}),
+		),
+	)
+
+	expect(response.status).toBe(400)
+	await expect(response.json()).resolves.toEqual({
+		ok: false,
+		error: invalidClientIdMismatchMessage,
+		allowClientReset: true,
+	})
+	expect(response.headers.get('Set-Cookie')).toContain(
+		'kody_oauth_client_reset=',
+	)
 })
 
 test('authorize denies access and redirects with error', async () => {
@@ -338,6 +367,9 @@ test('reset client deletes stale client registrations after invalid client misma
 	const deletedClientIds = new Array<string>()
 	const userId = await createStableUserIdFromEmail('user@example.com')
 	const helpers = createHelpers({
+		parseAuthRequest: async () => {
+			throw new Error(invalidClientIdMismatchMessage)
+		},
 		listUserGrants: async (requestedUserId) => {
 			expect(requestedUserId).toBe(userId)
 			return {
@@ -374,6 +406,14 @@ test('reset client deletes stale client registrations after invalid client misma
 		{ id: 'session-id', email: 'user@example.com', rememberMe: false },
 		false,
 	)
+	const authorizeInfoResponse = await handleAuthorizeInfo(
+		new Request(
+			`https://example.com/oauth/authorize-info?response_type=code&client_id=client-123&redirect_uri=${encodeURIComponent('https://example.com/callback')}&error_description=${encodeURIComponent(invalidClientIdMismatchMessage)}`,
+		),
+		createEnv(helpers),
+	)
+	const resetVerificationCookie =
+		authorizeInfoResponse.headers.get('Set-Cookie') ?? ''
 
 	const response = await handleAuthorizeRequest(
 		new Request(
@@ -382,13 +422,39 @@ test('reset client deletes stale client registrations after invalid client misma
 				method: 'POST',
 				headers: {
 					Accept: 'application/json',
-					Cookie: cookie,
+					Cookie: `${getCookiePair(cookie)}; ${getCookiePair(resetVerificationCookie)}`,
 					'Content-Type': 'application/x-www-form-urlencoded',
 				},
 				body: new URLSearchParams({ decision: 'reset-client' }),
 			},
 		),
 		createEnv(helpers),
+	)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toEqual({
+		ok: true,
+		message:
+			'Deleted the stored client records for this connection. Start the connection again from your client to create a fresh trusted client.',
+	})
+	expect(revokedGrantIds).toEqual(['grant-1', 'grant-2'])
+	expect(deletedClientIds).toEqual(['client-123'])
+})
+
+test('reset client rejects invalid client mismatch without verification cookie', async () => {
+	const response = await handleAuthorizeRequest(
+		new Request(
+			`https://example.com/oauth/authorize?client_id=client-123&redirect_uri=${encodeURIComponent('https://example.com/callback')}&error_description=${encodeURIComponent(invalidClientIdMismatchMessage)}`,
+			{
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams({ decision: 'reset-client' }),
+			},
+		),
+		createEnv(createHelpers()),
 	)
 
 	expect(response.status).toBe(400)
@@ -398,8 +464,6 @@ test('reset client deletes stale client registrations after invalid client misma
 			'Stored client cleanup is only available for stale or mismatched client registrations.',
 		code: 'invalid_request',
 	})
-	expect(revokedGrantIds).toEqual([])
-	expect(deletedClientIds).toEqual([])
 })
 
 test('reset client is rejected when the request is not a redirect mismatch', async () => {

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@cloudflare/workers-oauth-provider'
 import { createAuthCookie, setAuthSessionSecret } from '#app/auth-session.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
+import { invalidClientIdMismatchMessage } from '@kody-internal/shared/oauth-messages.ts'
 import {
 	handleAuthorizeInfo,
 	handleAuthorizeRequest,
@@ -332,6 +333,74 @@ test('reset client deletes matching grants and client registration', async () =>
 	expect(deletedClientIds).toEqual(['client-123'])
 })
 
+test('reset client deletes stale client registrations after invalid client mismatch', async () => {
+	const revokedGrantIds = new Array<string>()
+	const deletedClientIds = new Array<string>()
+	const userId = await createStableUserIdFromEmail('user@example.com')
+	const helpers = createHelpers({
+		listUserGrants: async (requestedUserId) => {
+			expect(requestedUserId).toBe(userId)
+			return {
+				items: [
+					{
+						id: 'grant-1',
+						clientId: 'client-123',
+						userId,
+						scope: ['profile'],
+						metadata: {},
+						createdAt: 0,
+					},
+					{
+						id: 'grant-2',
+						clientId: 'client-123',
+						userId,
+						scope: ['email'],
+						metadata: {},
+						createdAt: 0,
+					},
+				],
+			}
+		},
+		revokeGrant: async (grantId, requestedUserId) => {
+			expect(requestedUserId).toBe(userId)
+			revokedGrantIds.push(grantId)
+		},
+		deleteClient: async (clientId) => {
+			deletedClientIds.push(clientId)
+		},
+	})
+	setAuthSessionSecret(cookieSecret)
+	const cookie = await createAuthCookie(
+		{ id: 'session-id', email: 'user@example.com', rememberMe: false },
+		false,
+	)
+
+	const response = await handleAuthorizeRequest(
+		new Request(
+			`https://example.com/oauth/authorize?client_id=client-123&redirect_uri=${encodeURIComponent('https://example.com/callback')}&error_description=${encodeURIComponent(invalidClientIdMismatchMessage)}`,
+			{
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					Cookie: cookie,
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams({ decision: 'reset-client' }),
+			},
+		),
+		createEnv(helpers),
+	)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toEqual({
+		ok: true,
+		message:
+			'Deleted the stored client records for this connection. Start the connection again from your client to create a fresh trusted client.',
+	})
+	expect(revokedGrantIds).toEqual(['grant-1', 'grant-2'])
+	expect(deletedClientIds).toEqual(['client-123'])
+})
+
 test('reset client is rejected when the request is not a redirect mismatch', async () => {
 	const response = await handleAuthorizeRequest(
 		new Request(
@@ -352,7 +421,7 @@ test('reset client is rejected when the request is not a redirect mismatch', asy
 	await expect(response.json()).resolves.toEqual({
 		ok: false,
 		error:
-			'Stored client cleanup is only available for redirect URI mismatches.',
+			'Stored client cleanup is only available for stale or mismatched client registrations.',
 		code: 'invalid_request',
 	})
 })

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -391,14 +391,15 @@ test('reset client deletes stale client registrations after invalid client misma
 		createEnv(helpers),
 	)
 
-	expect(response.status).toBe(200)
+	expect(response.status).toBe(400)
 	await expect(response.json()).resolves.toEqual({
-		ok: true,
-		message:
-			'Deleted the stored client records for this connection. Start the connection again from your client to create a fresh trusted client.',
+		ok: false,
+		error:
+			'Stored client cleanup is only available for stale or mismatched client registrations.',
+		code: 'invalid_request',
 	})
-	expect(revokedGrantIds).toEqual(['grant-1', 'grant-2'])
-	expect(deletedClientIds).toEqual(['client-123'])
+	expect(revokedGrantIds).toEqual([])
+	expect(deletedClientIds).toEqual([])
 })
 
 test('reset client is rejected when the request is not a redirect mismatch', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- verify the latest AI review comments against the current code and keep only the valid fixes
- scope the signed OAuth reset-verification cookie to `/oauth` so browsers send it to both `/oauth/authorize` and `/oauth/authorize-info`, allowing cleanup logic to actually run
- remove the now-unused `invalidRedirectUriMessage` export after confirming it no longer has any callers
- keep the previously hardened invalid-client reset verification flow and Remix route-state reset behavior intact

## Walkthrough
<a href="https://cursor.com/agents/bc-ba948616-e592-4cbc-8b8c-a825ff975962/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foauth-review-followup-demo.mp4"><img src="https://cursor.com/artifacts/c/art-eb7731f9-942c-47c6-a6f5-57f4cbb25ffb" alt="oauth-review-followup-demo.mp4" /></a>
![Successful stale-client reset with form hidden](https://cursor.com/artifacts/c/art-1ba2a136-3baf-4660-8da4-b8b1c3d82014)
![Fresh authorize query resets route state](https://cursor.com/artifacts/c/art-eb55a614-f2ae-44eb-a445-893671c4b6c4)

## Testing
- `npx vitest run --project workers-unit packages/worker/src/oauth-handlers.workers.test.ts`
- `npm run typecheck`
- `npm run build`
- browser-like `curl` cookie-jar verification proving the signed reset cookie is issued with `Path=/oauth` and sent back to `/oauth/authorize-info`
- previous live worker/browser verification for the hardened invalid-client reset flow and query-change route reset behavior

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba948616-e592-4cbc-8b8c-a825ff975962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba948616-e592-4cbc-8b8c-a825ff975962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved OAuth error handling to detect client ID mismatches and offer a verified "Reset stored connection" flow; authorization form and follow-up messaging update after reset.

* **Tests**
  * Added coverage for the client-mismatch reset path and updated expectations for non-resettable rejection messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->