### PR TITLE
Trim meta memory verify payload

### DIFF
--- a/packages/worker/src/mcp/capabilities/meta/meta-memory-verify.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-memory-verify.node.test.ts
@@ -1,0 +1,98 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	verifyMemoryCandidate: vi.fn(),
+}))
+
+vi.mock('#mcp/memory/service.ts', () => ({
+	verifyMemoryCandidate: (...args: Array<unknown>) =>
+		mockModule.verifyMemoryCandidate(...args),
+}))
+
+const { metaMemoryVerifyCapability } = await import('./meta-memory-verify.ts')
+
+test('meta_memory_verify omits candidate details from the serialized response', async () => {
+	mockModule.verifyMemoryCandidate.mockResolvedValueOnce({
+		candidate: {
+			subject: 'Editor theme preference',
+			summary: 'User prefers dark mode in editors.',
+			details: 'Long supporting details that should stay out of verify output.',
+			category: 'preference',
+			tags: ['theme'],
+			source_uris: ['https://docs.example.com/preferences/editor-theme'],
+			dedupe_key: 'pref:editor-theme',
+		},
+		relatedMemories: [
+			{
+				memory: {
+					id: 'memory-1',
+					category: 'preference',
+					status: 'active',
+					subject: 'Preferred editor theme',
+					summary: 'User prefers a dark theme in editors.',
+					details:
+						'Existing stored details should also stay out of verify output.',
+					tags: ['theme', 'dark-mode'],
+					sourceUris: ['https://docs.example.com/preferences/editor-theme'],
+					dedupeKey: 'pref:editor-theme',
+				},
+				score: 0.98,
+			},
+		],
+		suppressedCount: 0,
+	})
+
+	const result = await metaMemoryVerifyCapability.handler(
+		{
+			subject: 'Editor theme preference',
+			summary: 'User prefers dark mode in editors.',
+			details: 'Candidate details still need to reach the verify service.',
+			category: 'preference',
+			tags: ['theme'],
+			source_uris: ['https://docs.example.com/preferences/editor-theme'],
+			dedupe_key: 'pref:editor-theme',
+		},
+		{
+			env: {} as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				user: { userId: 'user-123' },
+			}),
+		},
+	)
+
+	expect(mockModule.verifyMemoryCandidate).toHaveBeenCalledWith(
+		expect.objectContaining({
+			candidate: expect.objectContaining({
+				details: 'Candidate details still need to reach the verify service.',
+			}),
+		}),
+	)
+	expect(result).toEqual({
+		candidate: {
+			subject: 'Editor theme preference',
+			summary: 'User prefers dark mode in editors.',
+			category: 'preference',
+			tags: ['theme'],
+			source_uris: ['https://docs.example.com/preferences/editor-theme'],
+			dedupe_key: 'pref:editor-theme',
+		},
+		related_memories: [
+			{
+				id: 'memory-1',
+				category: 'preference',
+				status: 'active',
+				subject: 'Preferred editor theme',
+				summary: 'User prefers a dark theme in editors.',
+				tags: ['theme', 'dark-mode'],
+				source_uris: ['https://docs.example.com/preferences/editor-theme'],
+				dedupe_key: 'pref:editor-theme',
+				score: 0.98,
+			},
+		],
+		recommended_actions: ['upsert', 'delete', 'upsert_and_delete', 'none'],
+	})
+	expect(result.candidate).not.toHaveProperty('details')
+	expect(result.related_memories[0]).not.toHaveProperty('details')
+})

--- a/packages/worker/src/mcp/capabilities/meta/meta-memory-verify.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-memory-verify.ts
@@ -33,7 +33,6 @@ const outputSchema = z.object({
 	candidate: z.object({
 		subject: z.string(),
 		summary: z.string(),
-		details: z.string(),
 		category: z.string().nullable(),
 		tags: z.array(z.string()),
 		source_uris: z.array(memorySourceUriSchema).optional(),
@@ -77,7 +76,7 @@ export const metaMemoryVerifyCapability = defineDomainCapability(
 					args.include_suppressed_in_conversation ?? false,
 			})
 			return {
-				candidate: result.candidate,
+				candidate: formatCandidate(result.candidate),
 				related_memories: result.relatedMemories.map((match) =>
 					formatMemoryMatch(match.memory, match.score),
 				),
@@ -110,5 +109,23 @@ function formatMemoryMatch(
 		source_uris: match.sourceUris,
 		dedupe_key: match.dedupeKey,
 		score,
+	}
+}
+
+function formatCandidate(candidate: {
+	subject: string
+	summary: string
+	category: string | null
+	tags: Array<string>
+	source_uris: Array<string>
+	dedupe_key: string | null
+}) {
+	return {
+		subject: candidate.subject,
+		summary: candidate.summary,
+		category: candidate.category,
+		tags: candidate.tags,
+		source_uris: candidate.source_uris,
+		dedupe_key: candidate.dedupe_key,
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove `candidate.details` from `meta_memory_verify` output while keeping full candidate details available to the verify service
- add a focused capability test that locks the lean serialized response contract

## Testing
- `npm exec vitest run packages/worker/src/mcp/capabilities/meta/meta-memory-verify.node.test.ts packages/worker/src/mcp/memory/service.node.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86dbbc1c-3aa0-4ff4-b1fc-e1257f2c3c3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86dbbc1c-3aa0-4ff4-b1fc-e1257f2c3c3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for memory verification capability to validate response formatting.

* **Bug Fixes**
  * Updated memory verification responses to exclude internal details from returned candidate and memory objects, ensuring cleaner API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->