### PR TITLE
Fix read-only storage SQL semicolon parsing

### DIFF
--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -96,8 +96,8 @@ function hasSqlContentAfterSemicolon(query: string, startIndex: number) {
 	let inBlockComment = false
 
 	for (let index = startIndex; index < query.length; index += 1) {
-		const current = query[index]
-		const next = query[index + 1]
+		const current = query.charAt(index)
+		const next = query.charAt(index + 1)
 
 		if (inLineComment) {
 			if (current === '\n') {
@@ -143,8 +143,8 @@ function hasMultipleSqlStatements(query: string) {
 	let inBlockComment = false
 
 	for (let index = 0; index < query.length; index += 1) {
-		const current = query[index]
-		const next = query[index + 1]
+		const current = query.charAt(index)
+		const next = query.charAt(index + 1)
 
 		if (inLineComment) {
 			if (current === '\n') {

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -91,13 +91,159 @@ function normalizeSqlParams(params: Array<unknown> | undefined) {
 	})
 }
 
+function hasSqlContentAfterSemicolon(query: string, startIndex: number) {
+	let inLineComment = false
+	let inBlockComment = false
+
+	for (let index = startIndex; index < query.length; index += 1) {
+		const current = query[index]
+		const next = query[index + 1]
+
+		if (inLineComment) {
+			if (current === '\n') {
+				inLineComment = false
+			}
+			continue
+		}
+
+		if (inBlockComment) {
+			if (current === '*' && next === '/') {
+				inBlockComment = false
+				index += 1
+			}
+			continue
+		}
+
+		if (current === '-' && next === '-') {
+			inLineComment = true
+			index += 1
+			continue
+		}
+
+		if (current === '/' && next === '*') {
+			inBlockComment = true
+			index += 1
+			continue
+		}
+
+		if (!/\s/.test(current)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+function hasMultipleSqlStatements(query: string) {
+	let inSingleQuote = false
+	let inDoubleQuote = false
+	let inBacktickQuote = false
+	let inBracketQuote = false
+	let inLineComment = false
+	let inBlockComment = false
+
+	for (let index = 0; index < query.length; index += 1) {
+		const current = query[index]
+		const next = query[index + 1]
+
+		if (inLineComment) {
+			if (current === '\n') {
+				inLineComment = false
+			}
+			continue
+		}
+
+		if (inBlockComment) {
+			if (current === '*' && next === '/') {
+				inBlockComment = false
+				index += 1
+			}
+			continue
+		}
+
+		if (inSingleQuote) {
+			if (current === "'" && next === "'") {
+				index += 1
+				continue
+			}
+			if (current === "'") {
+				inSingleQuote = false
+			}
+			continue
+		}
+
+		if (inDoubleQuote) {
+			if (current === '"' && next === '"') {
+				index += 1
+				continue
+			}
+			if (current === '"') {
+				inDoubleQuote = false
+			}
+			continue
+		}
+
+		if (inBacktickQuote) {
+			if (current === '`') {
+				inBacktickQuote = false
+			}
+			continue
+		}
+
+		if (inBracketQuote) {
+			if (current === ']') {
+				inBracketQuote = false
+			}
+			continue
+		}
+
+		if (current === '-' && next === '-') {
+			inLineComment = true
+			index += 1
+			continue
+		}
+
+		if (current === '/' && next === '*') {
+			inBlockComment = true
+			index += 1
+			continue
+		}
+
+		if (current === "'") {
+			inSingleQuote = true
+			continue
+		}
+
+		if (current === '"') {
+			inDoubleQuote = true
+			continue
+		}
+
+		if (current === '`') {
+			inBacktickQuote = true
+			continue
+		}
+
+		if (current === '[') {
+			inBracketQuote = true
+			continue
+		}
+
+		if (current === ';' && hasSqlContentAfterSemicolon(query, index + 1)) {
+			return true
+		}
+	}
+
+	return false
+}
+
 function assertSqlAllowed(query: string, writable: boolean | undefined) {
 	const trimmed = query.trim()
 	if (!trimmed) {
 		throw new Error('storage.sql requires a non-empty query.')
 	}
 	if (writable) return trimmed
-	if (trimmed.includes(';')) {
+	if (hasMultipleSqlStatements(trimmed)) {
 		throw new Error(
 			'Read-only storage.sql only allows a single SELECT, EXPLAIN, or schema PRAGMA statement. Pass writable: true to allow multi-statement or mutating queries.',
 		)

--- a/packages/worker/src/storage-runner.workers.test.ts
+++ b/packages/worker/src/storage-runner.workers.test.ts
@@ -187,3 +187,25 @@ test('storage runner blocks multi-statement SQL in read-only mode', async () => 
 		value: 1,
 	})
 })
+
+test('storage runner allows semicolons inside string literals in read-only SQL', async () => {
+	const storageId = createExecuteStorageId()
+	const runner = storageRunnerRpc({
+		env,
+		userId: 'user-123',
+		storageId,
+	})
+
+	await expect(
+		runner.sqlQuery({
+			query: "select 'a;b' as val",
+			writable: false,
+		}),
+	).resolves.toEqual({
+		columns: ['val'],
+		rows: [{ val: 'a;b' }],
+		rowCount: 1,
+		rowsRead: 0,
+		rowsWritten: 0,
+	})
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the read-only SQL semicolon guard with statement-separator detection that ignores semicolons inside literals and comments
- add a worker regression test covering `select 'a;b' as val` in read-only mode
- fix the helper scanner implementation so TypeScript sees the scanned characters as strings and the CI typecheck passes

## Testing
- `npm run typecheck`
- `npx vitest run --project workers-unit packages/worker/src/storage-runner.workers.test.ts`
- `npx oxlint packages/worker/src/storage-runner.ts packages/worker/src/storage-runner.workers.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd142b18-197b-4bda-9090-67cb31afd196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd142b18-197b-4bda-9090-67cb31afd196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

