### PR TITLE
Guard storage codemode helper collisions

### DIFF
--- a/packages/worker/src/mcp/run-codemode-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.node.test.ts
@@ -308,6 +308,107 @@ test('buildCodemodeFns tracks values that crossed secret-marked capability input
 	}
 })
 
+test('buildCodemodeFns rejects storage codemode tools that collide with capabilities', async () => {
+	const env = {
+		STORAGE_RUNNER: {
+			idFromName(name: string) {
+				return name
+			},
+			get() {
+				return {}
+			},
+		},
+	} as unknown as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+	})
+	const getRegistrySpy = vi
+		.spyOn(
+			await import('#mcp/capabilities/registry.ts'),
+			'getCapabilityRegistryForContext',
+		)
+		.mockResolvedValue({
+			capabilityDomains: [],
+			capabilityDomainDescriptionsByName: {} as Record<string, string>,
+			capabilityHandlers: {},
+			capabilityList: [
+				{
+					name: 'storage_get',
+					domain: 'storage',
+					description: 'Capability that collides with a storage helper.',
+					keywords: [],
+					readOnly: true,
+					idempotent: true,
+					destructive: false,
+					inputSchema: {
+						type: 'object',
+						properties: {},
+					},
+					outputSchema: {
+						type: 'object',
+						properties: {},
+					},
+					async handler() {
+						return { ok: true }
+					},
+				},
+			],
+			capabilityMap: {
+				storage_get: {
+					name: 'storage_get',
+					domain: 'storage',
+					description: 'Capability that collides with a storage helper.',
+					keywords: [],
+					readOnly: true,
+					idempotent: true,
+					destructive: false,
+					inputSchema: {
+						type: 'object',
+						properties: {},
+					},
+					outputSchema: {
+						type: 'object',
+						properties: {},
+					},
+					async handler() {
+						return { ok: true }
+					},
+				},
+			},
+			capabilitySpecs: {},
+			capabilityToolDescriptors: {
+				storage_get: {
+					description: 'Capability that collides with a storage helper.',
+					inputSchema: {
+						type: 'object',
+						properties: {},
+					},
+					outputSchema: {
+						type: 'object',
+						properties: {},
+					},
+				},
+			},
+		} as Awaited<ReturnType<typeof getCapabilityRegistryForContext>>)
+
+	try {
+		await expect(
+			buildCodemodeFns(env, callerContext, {
+				storageTools: {
+					userId: 'user-123',
+					storageId: 'exec:test-storage',
+					writable: false,
+				},
+			}),
+		).rejects.toThrow(
+			'Codemode helper "storage_get" collides with a capability.',
+		)
+	} finally {
+		getRegistrySpy.mockRestore()
+	}
+})
+
 test('runCodemodeWithRegistry redacts secret keys and survives cyclic results', async () => {
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -60,12 +60,17 @@ export async function buildCodemodeFns(
 		callerContext,
 	})
 	const additionalTools = options?.additionalTools ?? {}
-	for (const name of Object.keys(additionalTools)) {
-		if (capabilityMap[name]) {
-			throw new Error(`Codemode helper "${name}" collides with a capability.`)
-		}
-	}
 	const storageTools = options?.storageTools
+	assertNoCapabilityCollisions(capabilityMap, additionalTools)
+	const storageCodemodeTools = storageTools
+		? await createStorageCodemodeTools({
+				env,
+				userId: callerContext.user?.userId ?? '',
+				storageId: storageTools.storageId,
+				writable: storageTools.writable,
+			})
+		: {}
+	assertNoCapabilityCollisions(capabilityMap, storageCodemodeTools)
 	return {
 		...Object.fromEntries(
 			Object.values(capabilityMap).map((capability) => [
@@ -96,15 +101,19 @@ export async function buildCodemodeFns(
 				},
 			]),
 		),
-		...(storageTools
-			? await createStorageCodemodeTools({
-					env,
-					userId: callerContext.user?.userId ?? '',
-					storageId: storageTools.storageId,
-					writable: storageTools.writable,
-				})
-			: {}),
+		...storageCodemodeTools,
 		...additionalTools,
+	}
+}
+
+function assertNoCapabilityCollisions(
+	capabilityMap: Record<string, unknown>,
+	tools: AdditionalCodemodeTools,
+) {
+	for (const name of Object.keys(tools)) {
+		if (capabilityMap[name]) {
+			throw new Error(`Codemode helper "${name}" collides with a capability.`)
+		}
 	}
 }
 

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -62,7 +62,36 @@ export async function buildCodemodeFns(
 	const additionalTools = options?.additionalTools ?? {}
 	const storageTools = options?.storageTools
 	assertNoCapabilityCollisions(capabilityMap, additionalTools)
-	const storageCodemodeTools = storageTools
+	const capabilityCodemodeTools = Object.fromEntries(
+		Object.values(capabilityMap).map((capability) => [
+			capability.name,
+			async (args: unknown) => {
+				const resolveSecretValue =
+					options?.resolveSecretValue ??
+					createCapabilityInputSecretResolver(
+						env,
+						callerContext,
+						capability.name,
+					)
+				const resolvedArgs = await resolveCapabilityInputSecrets({
+					schema: capability.inputSchema,
+					value: (args ?? {}) as Record<string, unknown>,
+					resolveSecretValue: (secret) =>
+						resolveSecretValue(secret, capability.name),
+				})
+				collectSecretInputValues({
+					schema: capability.inputSchema,
+					value: resolvedArgs,
+					track: options?.trackSecretInputValue,
+				})
+				return capability.handler(resolvedArgs as Record<string, unknown>, {
+					env,
+					callerContext,
+				})
+			},
+		]),
+	) as AdditionalCodemodeTools
+	const storageCodemodeTools: AdditionalCodemodeTools = storageTools
 		? await createStorageCodemodeTools({
 				env,
 				userId: callerContext.user?.userId ?? '',
@@ -72,35 +101,7 @@ export async function buildCodemodeFns(
 		: {}
 	assertNoCapabilityCollisions(capabilityMap, storageCodemodeTools)
 	return {
-		...Object.fromEntries(
-			Object.values(capabilityMap).map((capability) => [
-				capability.name,
-				async (args: unknown) => {
-					const resolveSecretValue =
-						options?.resolveSecretValue ??
-						createCapabilityInputSecretResolver(
-							env,
-							callerContext,
-							capability.name,
-						)
-					const resolvedArgs = await resolveCapabilityInputSecrets({
-						schema: capability.inputSchema,
-						value: (args ?? {}) as Record<string, unknown>,
-						resolveSecretValue: (secret) =>
-							resolveSecretValue(secret, capability.name),
-					})
-					collectSecretInputValues({
-						schema: capability.inputSchema,
-						value: resolvedArgs,
-						track: options?.trackSecretInputValue,
-					})
-					return capability.handler(resolvedArgs as Record<string, unknown>, {
-						env,
-						callerContext,
-					})
-				},
-			]),
-		),
+		...capabilityCodemodeTools,
 		...storageCodemodeTools,
 		...additionalTools,
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- guard `buildCodemodeFns` against collisions between registered capabilities and built-in storage codemode helpers before the tool maps are merged
- keep the codemode tool map explicitly typed so `buildCodemodeProvider` still exposes callable `execute` functions
- add a node-unit regression test covering a colliding `storage_get` capability
- rebase the branch onto the latest `main`

## Testing
- `npx vitest run --project node-unit "packages/worker/src/mcp/run-codemode-registry.node.test.ts"`
- `npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b572fc2c-eb92-4c9f-b223-53c880b03ff6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b572fc2c-eb92-4c9f-b223-53c880b03ff6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

