### PR TITLE
Add authenticated skill runner endpoint

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+packages/worker/public/mcp-apps/kody-ui-utils.css

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dev:mock-cloudflare": "node --env-file=packages/worker/.env ./wrangler-env.ts dev --local --config packages/mock-servers/cloudflare/wrangler.jsonc",
     "deploy": "node --input-type=module -e \"if (['preview','test'].includes(process.env.CLOUDFLARE_ENV ?? '')) { await import('./tools/prepare-e2e-env.ts'); }\" && npm run build && node --env-file=packages/worker/.env ./wrangler-env.ts deploy --outdir .wrangler/sentry-bundle --upload-source-maps",
     "sentry:upload-sourcemaps": "node tools/sentry-upload-sourcemaps.ts",
-    "build:mcp-apps": "esbuild packages/worker/client/mcp-apps/kody-ui-utils.ts --bundle --format=esm --target=es2022 --outfile=packages/worker/public/mcp-apps/kody-ui-utils.js --platform=browser --banner:js='/* eslint-disable no-undef */' && oxfmt packages/worker/public/mcp-apps/kody-ui-utils.css",
+    "build:mcp-apps": "esbuild packages/worker/client/mcp-apps/kody-ui-utils.ts --bundle --format=esm --target=es2022 --outfile=packages/worker/public/mcp-apps/kody-ui-utils.js --platform=browser --banner:js='/* eslint-disable no-undef */' && oxfmt --ignore-path /dev/null packages/worker/public/mcp-apps/kody-ui-utils.css",
     "build:client:web": "esbuild packages/worker/client/entry.tsx --bundle --format=esm --target=es2022 --outdir=packages/worker/public --entry-names=client-entry --chunk-names=assets/[name] --asset-names=assets/[name] --jsx=automatic --jsx-import-source=remix/component",
     "build:client": "npm run build:client:web && npm run build:mcp-apps",
     "build": "nx run worker:build",

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -300,6 +300,10 @@ const workerHandler = {
 	fetch(request: Request, env: Env, ctx: ExecutionContext) {
 		const url = new URL(request.url)
 
+		if (url.pathname === '/api/skills/run') {
+			return apiHandler.fetch(request, env, ctx)
+		}
+
 		// OAuthProvider serves this URL first and defaults `resource` to the origin only.
 		// MCP clients must use `<origin>/mcp` as the resource (RFC 8707) to match our
 		// token audience; otherwise authorize stores origin but the token request sends

--- a/packages/worker/src/mcp/capabilities/meta/meta-run-skill.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-run-skill.ts
@@ -1,17 +1,8 @@
-import { exports as workerExports } from 'cloudflare:workers'
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
-import { getMcpSkillByNameInput } from '#mcp/skills/mcp-skills-repo.ts'
-import {
-	applySkillParameters,
-	parseSkillParameters,
-} from '#mcp/skills/skill-parameters.ts'
-import { requireMcpUser } from './require-user.ts'
-
-const runFailureHint =
-	'If the saved codemode is wrong, use meta_get_skill to inspect it, then call meta_save_skill again with the same skill name to replace the stored code and metadata.'
+import { runSavedSkill } from '#mcp/skills/run-saved-skill.ts'
 
 const outputSchema = z.object({
 	ok: z.boolean(),
@@ -21,12 +12,6 @@ const outputSchema = z.object({
 	/** Present when ok is false; suggests how to fix stored skill code. */
 	hint: z.string().optional(),
 })
-
-function formatExecutionError(error: unknown): string {
-	if (typeof error === 'string') return error
-	if (error instanceof Error) return error.message
-	return String(error)
-}
 
 export const metaRunSkillCapability = defineDomainCapability(
 	capabilityDomainNames.meta,
@@ -54,45 +39,12 @@ export const metaRunSkillCapability = defineDomainCapability(
 		}),
 		outputSchema,
 		async handler(args, ctx: CapabilityContext) {
-			const user = requireMcpUser(ctx.callerContext)
-			const row = await getMcpSkillByNameInput(
-				ctx.env.APP_DB,
-				user.userId,
-				args.name,
-			)
-			if (!row) {
-				throw new Error('Skill not found for this user.')
-			}
-			const definitions = parseSkillParameters(row.parameters)
-			const params = applySkillParameters({
-				definitions,
-				values: args.params,
+			return runSavedSkill({
+				env: ctx.env,
+				callerContext: ctx.callerContext,
+				name: args.name,
+				params: args.params,
 			})
-			const shouldPassParams = definitions != null || args.params !== undefined
-			const { runCodemodeWithRegistry } =
-				await import('#mcp/run-codemode-registry.ts')
-			const exec = await runCodemodeWithRegistry(
-				ctx.env,
-				ctx.callerContext,
-				row.code,
-				shouldPassParams ? params : undefined,
-				{
-					executorExports: workerExports,
-				},
-			)
-			if (exec.error) {
-				return {
-					ok: false,
-					error: formatExecutionError(exec.error),
-					logs: exec.logs ?? [],
-					hint: runFailureHint,
-				}
-			}
-			return {
-				ok: true,
-				result: exec.result,
-				logs: exec.logs ?? [],
-			}
 		},
 	},
 )

--- a/packages/worker/src/mcp/capabilities/values/domain.ts
+++ b/packages/worker/src/mcp/capabilities/values/domain.ts
@@ -4,6 +4,9 @@ import { connectorDeleteCapability } from './connector-delete.ts'
 import { connectorGetCapability } from './connector-get.ts'
 import { connectorListCapability } from './connector-list.ts'
 import { connectorSaveCapability } from './connector-save.ts'
+import { skillRunnerTokenCreateCapability } from './skill-runner-token-create.ts'
+import { skillRunnerTokenListCapability } from './skill-runner-token-list.ts'
+import { skillRunnerTokenRevokeCapability } from './skill-runner-token-revoke.ts'
 import { valueDeleteCapability } from './value-delete.ts'
 import { valueGetCapability } from './value-get.ts'
 import { valueListCapability } from './value-list.ts'
@@ -12,13 +15,24 @@ import { valueSetCapability } from './value-set.ts'
 export const valuesDomain = defineDomain({
 	name: capabilityDomainNames.values,
 	description:
-		'Readable persisted values for user, app, or session scoped configuration that generated UIs may store and read back later.',
-	keywords: ['value', 'config', 'storage', 'non-secret', 'generated ui'],
+		'Readable persisted values for user, app, or session scoped configuration that generated UIs may store and read back later, plus external skill runner bearer token management.',
+	keywords: [
+		'value',
+		'config',
+		'storage',
+		'non-secret',
+		'generated ui',
+		'skill runner',
+		'token',
+	],
 	capabilities: [
 		valueSetCapability,
 		valueGetCapability,
 		valueListCapability,
 		valueDeleteCapability,
+		skillRunnerTokenCreateCapability,
+		skillRunnerTokenRevokeCapability,
+		skillRunnerTokenListCapability,
 		connectorSaveCapability,
 		connectorGetCapability,
 		connectorListCapability,

--- a/packages/worker/src/mcp/capabilities/values/skill-runner-token-create.ts
+++ b/packages/worker/src/mcp/capabilities/values/skill-runner-token-create.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { createSkillRunnerToken } from '#mcp/values/skill-runner-tokens.ts'
+
+export const skillRunnerTokenCreateCapability = defineDomainCapability(
+	capabilityDomainNames.values,
+	{
+		name: 'skill_runner_token_create',
+		description:
+			'Create or rotate an external bearer token for the signed-in user by client name. The raw token is returned only from this call.',
+		keywords: ['skill', 'runner', 'token', 'bearer', 'create', 'rotate'],
+		readOnly: false,
+		idempotent: false,
+		destructive: false,
+		inputSchema: z.object({
+			clientName: z
+				.string()
+				.min(1)
+				.describe('External client name to store or rotate a token for.'),
+		}),
+		outputSchema: z.object({
+			clientName: z.string(),
+			token: z.string(),
+		}),
+		async handler(args, ctx: CapabilityContext) {
+			const user = requireMcpUser(ctx.callerContext)
+			return {
+				clientName: args.clientName.trim(),
+				token: await createSkillRunnerToken({
+					env: ctx.env,
+					userId: user.userId,
+					clientName: args.clientName,
+				}),
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/values/skill-runner-token-create.ts
+++ b/packages/worker/src/mcp/capabilities/values/skill-runner-token-create.ts
@@ -10,7 +10,7 @@ export const skillRunnerTokenCreateCapability = defineDomainCapability(
 	{
 		name: 'skill_runner_token_create',
 		description:
-			'Create or rotate an external bearer token for the signed-in user by client name. The raw token is returned only from this call.',
+			'Create or rotate an external bearer token for the signed-in user by client name, with a required human-friendly name and optional description. The raw token is returned only from this call.',
 		keywords: ['skill', 'runner', 'token', 'bearer', 'create', 'rotate'],
 		readOnly: false,
 		idempotent: false,
@@ -20,20 +20,37 @@ export const skillRunnerTokenCreateCapability = defineDomainCapability(
 				.string()
 				.min(1)
 				.describe('External client name to store or rotate a token for.'),
+			name: z
+				.string()
+				.min(1)
+				.describe('Required human-friendly label for this token.'),
+			description: z
+				.string()
+				.optional()
+				.describe('Optional description for what this token is used for.'),
 		}),
 		outputSchema: z.object({
 			clientName: z.string(),
+			name: z.string(),
+			description: z.string().nullable(),
+			lastUsedAt: z.string().nullable(),
 			token: z.string(),
 		}),
 		async handler(args, ctx: CapabilityContext) {
 			const user = requireMcpUser(ctx.callerContext)
+			const created = await createSkillRunnerToken({
+				env: ctx.env,
+				userId: user.userId,
+				clientName: args.clientName,
+				name: args.name,
+				description: args.description,
+			})
 			return {
 				clientName: args.clientName.trim(),
-				token: await createSkillRunnerToken({
-					env: ctx.env,
-					userId: user.userId,
-					clientName: args.clientName,
-				}),
+				name: created.name,
+				description: created.description || null,
+				lastUsedAt: created.lastUsedAt,
+				token: created.token,
 			}
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/values/skill-runner-token-list.ts
+++ b/packages/worker/src/mcp/capabilities/values/skill-runner-token-list.ts
@@ -10,14 +10,22 @@ export const skillRunnerTokenListCapability = defineDomainCapability(
 	{
 		name: 'skill_runner_token_list',
 		description:
-			'List external bearer tokens for the signed-in user with token values redacted.',
+			'List external bearer tokens for the signed-in user with token values redacted, including human-friendly names, optional descriptions, and last-used timestamps.',
 		keywords: ['skill', 'runner', 'token', 'bearer', 'list', 'redacted'],
 		readOnly: true,
 		idempotent: true,
 		destructive: false,
 		inputSchema: z.object({}),
 		outputSchema: z.object({
-			tokens: z.record(z.string(), z.string()),
+			tokens: z.array(
+				z.object({
+					clientName: z.string(),
+					name: z.string(),
+					description: z.string().nullable(),
+					lastUsedAt: z.string().nullable(),
+					token: z.string(),
+				}),
+			),
 		}),
 		async handler(_args, ctx: CapabilityContext) {
 			const user = requireMcpUser(ctx.callerContext)

--- a/packages/worker/src/mcp/capabilities/values/skill-runner-token-list.ts
+++ b/packages/worker/src/mcp/capabilities/values/skill-runner-token-list.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { listSkillRunnerTokens } from '#mcp/values/skill-runner-tokens.ts'
+
+export const skillRunnerTokenListCapability = defineDomainCapability(
+	capabilityDomainNames.values,
+	{
+		name: 'skill_runner_token_list',
+		description:
+			'List external bearer tokens for the signed-in user with token values redacted.',
+		keywords: ['skill', 'runner', 'token', 'bearer', 'list', 'redacted'],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: z.object({}),
+		outputSchema: z.object({
+			tokens: z.record(z.string(), z.string()),
+		}),
+		async handler(_args, ctx: CapabilityContext) {
+			const user = requireMcpUser(ctx.callerContext)
+			return {
+				tokens: await listSkillRunnerTokens({
+					env: ctx.env,
+					userId: user.userId,
+				}),
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/values/skill-runner-token-revoke.ts
+++ b/packages/worker/src/mcp/capabilities/values/skill-runner-token-revoke.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { revokeSkillRunnerToken } from '#mcp/values/skill-runner-tokens.ts'
+
+export const skillRunnerTokenRevokeCapability = defineDomainCapability(
+	capabilityDomainNames.values,
+	{
+		name: 'skill_runner_token_revoke',
+		description:
+			'Delete an external bearer token for the signed-in user by client name.',
+		keywords: ['skill', 'runner', 'token', 'bearer', 'revoke', 'delete'],
+		readOnly: false,
+		idempotent: false,
+		destructive: true,
+		inputSchema: z.object({
+			clientName: z
+				.string()
+				.min(1)
+				.describe('External client name whose token should be removed.'),
+		}),
+		outputSchema: z.object({
+			clientName: z.string(),
+			revoked: z.boolean(),
+		}),
+		async handler(args, ctx: CapabilityContext) {
+			const user = requireMcpUser(ctx.callerContext)
+			return {
+				clientName: args.clientName.trim(),
+				revoked: await revokeSkillRunnerToken({
+					env: ctx.env,
+					userId: user.userId,
+					clientName: args.clientName,
+				}),
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/values/value-delete.ts
+++ b/packages/worker/src/mcp/capabilities/values/value-delete.ts
@@ -4,6 +4,7 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { deleteValue } from '#mcp/values/service.ts'
+import { assertValueNameAllowed } from '#mcp/values/value-name-guards.ts'
 import { valueScopeValues } from '#mcp/values/types.ts'
 
 export const valueDeleteCapability = defineDomainCapability(
@@ -27,11 +28,13 @@ export const valueDeleteCapability = defineDomainCapability(
 		}),
 		async handler(args, ctx: CapabilityContext) {
 			const user = requireMcpUser(ctx.callerContext)
+			const name = args.name.trim()
+			assertValueNameAllowed(name)
 			return {
 				deleted: await deleteValue({
 					env: ctx.env,
 					userId: user.userId,
-					name: args.name,
+					name,
 					scope: args.scope,
 					storageContext: {
 						sessionId: ctx.callerContext.storageContext?.sessionId ?? null,

--- a/packages/worker/src/mcp/capabilities/values/value-get.ts
+++ b/packages/worker/src/mcp/capabilities/values/value-get.ts
@@ -3,6 +3,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { assertValueNameAllowed } from '#mcp/values/value-name-guards.ts'
 import { getValue } from '#mcp/values/service.ts'
 import { valueScopeValues } from '#mcp/values/types.ts'
 import { valueMetadataSchema } from './shared.ts'
@@ -29,10 +30,12 @@ export const valueGetCapability = defineDomainCapability(
 		outputSchema: valueMetadataSchema.nullable(),
 		async handler(args, ctx: CapabilityContext) {
 			const user = requireMcpUser(ctx.callerContext)
+			const name = args.name.trim()
+			assertValueNameAllowed(name)
 			const value = await getValue({
 				env: ctx.env,
 				userId: user.userId,
-				name: args.name,
+				name,
 				scope: args.scope ?? null,
 				storageContext: {
 					sessionId: ctx.callerContext.storageContext?.sessionId ?? null,

--- a/packages/worker/src/mcp/capabilities/values/value-list.ts
+++ b/packages/worker/src/mcp/capabilities/values/value-list.ts
@@ -3,6 +3,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { isReservedValueName } from '#mcp/values/value-name-guards.ts'
 import { listValues } from '#mcp/values/service.ts'
 import { valueScopeValues } from '#mcp/values/types.ts'
 import { valueMetadataSchema } from './shared.ts'
@@ -41,16 +42,18 @@ export const valueListCapability = defineDomainCapability(
 				},
 			})
 			return {
-				values: values.map((value) => ({
-					name: value.name,
-					scope: value.scope,
-					value: value.value,
-					description: value.description,
-					app_id: value.appId,
-					created_at: value.createdAt,
-					updated_at: value.updatedAt,
-					ttl_ms: value.ttlMs,
-				})),
+				values: values
+					.filter((value) => !isReservedValueName(value.name))
+					.map((value) => ({
+						name: value.name,
+						scope: value.scope,
+						value: value.value,
+						description: value.description,
+						app_id: value.appId,
+						created_at: value.createdAt,
+						updated_at: value.updatedAt,
+						ttl_ms: value.ttlMs,
+					})),
 			}
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/values/value-set.ts
+++ b/packages/worker/src/mcp/capabilities/values/value-set.ts
@@ -3,6 +3,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { assertValueNameAllowed } from '#mcp/values/value-name-guards.ts'
 import { saveValue } from '#mcp/values/service.ts'
 import { valueScopeValues } from '#mcp/values/types.ts'
 import { valueMetadataSchema } from './shared.ts'
@@ -35,10 +36,12 @@ export const valueSetCapability = defineDomainCapability(
 		outputSchema: valueMetadataSchema,
 		async handler(args, ctx: CapabilityContext) {
 			const user = requireMcpUser(ctx.callerContext)
+			const name = args.name.trim()
+			assertValueNameAllowed(name)
 			const value = await saveValue({
 				env: ctx.env,
 				userId: user.userId,
-				name: args.name,
+				name,
 				value: args.value,
 				scope: args.scope,
 				description: args.description ?? '',

--- a/packages/worker/src/mcp/skills/run-saved-skill.ts
+++ b/packages/worker/src/mcp/skills/run-saved-skill.ts
@@ -5,7 +5,6 @@ import {
 	applySkillParameters,
 	parseSkillParameters,
 } from '#mcp/skills/skill-parameters.ts'
-import { runCodemodeWithRegistry } from '#mcp/run-codemode-registry.ts'
 
 const runFailureHint =
 	'If the saved codemode is wrong, use meta_get_skill to inspect it, then call meta_save_skill again with the same skill name to replace the stored code and metadata.'
@@ -46,6 +45,9 @@ export async function runSavedSkill(input: {
 		values: input.params,
 	})
 	const shouldPassParams = definitions != null || input.params !== undefined
+	const { runCodemodeWithRegistry } = await import(
+		'#mcp/run-codemode-registry.ts'
+	)
 	const exec = await runCodemodeWithRegistry(
 		input.env,
 		input.callerContext,

--- a/packages/worker/src/mcp/skills/run-saved-skill.ts
+++ b/packages/worker/src/mcp/skills/run-saved-skill.ts
@@ -1,0 +1,72 @@
+import { exports as workerExports } from 'cloudflare:workers'
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { getMcpSkillByNameInput } from '#mcp/skills/mcp-skills-repo.ts'
+import {
+	applySkillParameters,
+	parseSkillParameters,
+} from '#mcp/skills/skill-parameters.ts'
+import { runCodemodeWithRegistry } from '#mcp/run-codemode-registry.ts'
+
+const runFailureHint =
+	'If the saved codemode is wrong, use meta_get_skill to inspect it, then call meta_save_skill again with the same skill name to replace the stored code and metadata.'
+
+export type SavedSkillRunResult = {
+	ok: boolean
+	result?: unknown
+	error?: string
+	logs: Array<string>
+	hint?: string
+}
+
+function formatExecutionError(error: unknown): string {
+	if (typeof error === 'string') return error
+	if (error instanceof Error) return error.message
+	return String(error)
+}
+
+export async function runSavedSkill(input: {
+	env: Env
+	callerContext: McpCallerContext
+	name: string
+	params?: Record<string, unknown>
+}): Promise<SavedSkillRunResult> {
+	const userId = input.callerContext.user?.userId
+	if (!userId) {
+		throw new Error('Authenticated MCP user is required for this capability.')
+	}
+
+	const row = await getMcpSkillByNameInput(input.env.APP_DB, userId, input.name)
+	if (!row) {
+		throw new Error('Skill not found for this user.')
+	}
+
+	const definitions = parseSkillParameters(row.parameters)
+	const params = applySkillParameters({
+		definitions,
+		values: input.params,
+	})
+	const shouldPassParams = definitions != null || input.params !== undefined
+	const exec = await runCodemodeWithRegistry(
+		input.env,
+		input.callerContext,
+		row.code,
+		shouldPassParams ? params : undefined,
+		{
+			executorExports: workerExports,
+		},
+	)
+	if (exec.error) {
+		return {
+			ok: false,
+			error: formatExecutionError(exec.error),
+			logs: exec.logs ?? [],
+			hint: runFailureHint,
+		} satisfies SavedSkillRunResult
+	}
+
+	return {
+		ok: true,
+		result: exec.result,
+		logs: exec.logs ?? [],
+	} satisfies SavedSkillRunResult
+}

--- a/packages/worker/src/mcp/skills/run-saved-skill.ts
+++ b/packages/worker/src/mcp/skills/run-saved-skill.ts
@@ -45,9 +45,8 @@ export async function runSavedSkill(input: {
 		values: input.params,
 	})
 	const shouldPassParams = definitions != null || input.params !== undefined
-	const { runCodemodeWithRegistry } = await import(
-		'#mcp/run-codemode-registry.ts'
-	)
+	const { runCodemodeWithRegistry } =
+		await import('#mcp/run-codemode-registry.ts')
 	const exec = await runCodemodeWithRegistry(
 		input.env,
 		input.callerContext,

--- a/packages/worker/src/mcp/skills/run-saved-skill.ts
+++ b/packages/worker/src/mcp/skills/run-saved-skill.ts
@@ -31,12 +31,20 @@ export async function runSavedSkill(input: {
 }): Promise<SavedSkillRunResult> {
 	const userId = input.callerContext.user?.userId
 	if (!userId) {
-		throw new Error('Authenticated MCP user is required for this capability.')
+		return {
+			ok: false,
+			error: 'Authenticated MCP user is required for this capability.',
+			logs: [],
+		} satisfies SavedSkillRunResult
 	}
 
 	const row = await getMcpSkillByNameInput(input.env.APP_DB, userId, input.name)
 	if (!row) {
-		throw new Error('Skill not found for this user.')
+		return {
+			ok: false,
+			error: 'Skill not found for this user.',
+			logs: [],
+		} satisfies SavedSkillRunResult
 	}
 
 	const definitions = parseSkillParameters(row.parameters)

--- a/packages/worker/src/mcp/values/skill-runner-tokens.node.test.ts
+++ b/packages/worker/src/mcp/values/skill-runner-tokens.node.test.ts
@@ -1,0 +1,347 @@
+import { expect, test } from 'vitest'
+import { saveValue } from './service.ts'
+import {
+	createSkillRunnerToken,
+	listSkillRunnerTokens,
+	markSkillRunnerTokenUsed,
+	resolveSkillRunnerUserByToken,
+	revokeSkillRunnerToken,
+	skillRunnerTokensValueName,
+} from './skill-runner-tokens.ts'
+import { type ValueBucketRow, type ValueEntryRow } from './types.ts'
+
+function createValueTestDb() {
+	const buckets = new Map<string, ValueBucketRow>()
+	const entries = new Map<string, ValueEntryRow>()
+
+	function getBucketKey(userId: string, scope: string, bindingKey: string) {
+		return `${userId}:${scope}:${bindingKey}`
+	}
+
+	function getEntryKey(bucketId: string, name: string) {
+		return `${bucketId}:${name}`
+	}
+
+	const db = {
+		prepare(query: string) {
+			const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async first<T>() {
+							if (
+								normalizedQuery.startsWith('select') &&
+								normalizedQuery.includes('from value_buckets')
+							) {
+								const [userId, scope, bindingKey, now] = params as Array<string>
+								const bucket =
+									buckets.get(getBucketKey(userId, scope, bindingKey)) ?? null
+								if (
+									bucket &&
+									(bucket.expires_at == null || bucket.expires_at > now)
+								) {
+									return { ...bucket } as T
+								}
+								return null
+							}
+							if (
+								normalizedQuery.startsWith('select') &&
+								normalizedQuery.includes('from value_entries') &&
+								normalizedQuery.includes('where bucket_id = ? and name = ?')
+							) {
+								const [bucketId, name] = params as Array<string>
+								const entry = entries.get(getEntryKey(bucketId, name)) ?? null
+								return entry ? ({ ...entry } as T) : null
+							}
+							return null
+						},
+						async all<T>() {
+							if (
+								normalizedQuery.startsWith(
+									'select ? as scope, ? as binding_key',
+								) &&
+								normalizedQuery.includes('from value_entries')
+							) {
+								const [scope, bindingKey, expiresAt, bucketId] =
+									params as Array<string | null>
+								const results = Array.from(entries.values())
+									.filter((entry) => entry.bucket_id === bucketId)
+									.sort((left, right) => left.name.localeCompare(right.name))
+									.map((entry) => ({
+										scope,
+										binding_key: bindingKey,
+										name: entry.name,
+										description: entry.description,
+										value: entry.value,
+										created_at: entry.created_at,
+										updated_at: entry.updated_at,
+										expires_at: expiresAt,
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								normalizedQuery.startsWith('select vb.user_id, ve.value') &&
+								normalizedQuery.includes('from value_entries ve inner join')
+							) {
+								const [name, now] = params as Array<string>
+								const results = Array.from(buckets.values())
+									.filter(
+										(bucket) =>
+											bucket.scope === 'user' &&
+											bucket.binding_key === '' &&
+											(bucket.expires_at == null || bucket.expires_at > now),
+									)
+									.flatMap((bucket) => {
+										const entry = entries.get(getEntryKey(bucket.id, name))
+										return entry
+											? [{ user_id: bucket.user_id, value: entry.value }]
+											: []
+									})
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							return { results: [] as Array<T>, meta: { changes: 0 } }
+						},
+						async run() {
+							if (normalizedQuery.startsWith('insert into value_buckets')) {
+								const [
+									id,
+									userId,
+									scope,
+									bindingKey,
+									expiresAt,
+									createdAt,
+									updatedAt,
+								] = params as Array<string | null>
+								const key = getBucketKey(
+									String(userId),
+									String(scope),
+									String(bindingKey),
+								)
+								const existing = buckets.get(key)
+								buckets.set(key, {
+									id: existing?.id ?? String(id),
+									user_id: String(userId),
+									scope: String(scope) as ValueBucketRow['scope'],
+									binding_key: String(bindingKey),
+									expires_at: expiresAt == null ? null : String(expiresAt),
+									created_at: existing?.created_at ?? String(createdAt),
+									updated_at: String(updatedAt),
+								})
+								return { meta: { changes: 1 } }
+							}
+							if (normalizedQuery.startsWith('insert into value_entries')) {
+								const [
+									bucketId,
+									name,
+									description,
+									value,
+									createdAt,
+									updatedAt,
+								] = params as Array<string>
+								const key = getEntryKey(bucketId, name)
+								const existing = entries.get(key)
+								entries.set(key, {
+									bucket_id: bucketId,
+									name,
+									description,
+									value,
+									created_at: existing?.created_at ?? createdAt,
+									updated_at: updatedAt,
+								})
+								return { meta: { changes: 1 } }
+							}
+							if (
+								normalizedQuery.startsWith(
+									'delete from value_buckets where user_id = ? and scope = ? and binding_key = ?',
+								)
+							) {
+								const [userId, scope, bindingKey] = params as Array<string>
+								const bucketKey = getBucketKey(userId, scope, bindingKey)
+								const bucket = buckets.get(bucketKey)
+								if (!bucket) {
+									return { meta: { changes: 0 } }
+								}
+								buckets.delete(bucketKey)
+								for (const [entryKey, entry] of entries) {
+									if (entry.bucket_id === bucket.id) {
+										entries.delete(entryKey)
+									}
+								}
+								return { meta: { changes: 1 } }
+							}
+							if (normalizedQuery.startsWith('delete from value_entries')) {
+								const [bucketId, name] = params as Array<string>
+								const deleted = entries.delete(getEntryKey(bucketId, name))
+								return { meta: { changes: deleted ? 1 : 0 } }
+							}
+							return { meta: { changes: 0 } }
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+
+	function getStoredValue(userId: string, name: string) {
+		const bucket = buckets.get(getBucketKey(userId, 'user', ''))
+		if (!bucket) return null
+		return entries.get(getEntryKey(bucket.id, name))?.value ?? null
+	}
+
+	return { db, getStoredValue }
+}
+
+test('skill runner token store hashes tokens and tracks metadata usage', async () => {
+	const testDb = createValueTestDb()
+	const env = { APP_DB: testDb.db }
+
+	const created = await createSkillRunnerToken({
+		env,
+		userId: 'user-123',
+		clientName: 'kody-discord-gateway',
+		name: 'Discord Gateway',
+		description: 'Receives Discord events and forwards them to Kody.',
+	})
+
+	expect(created).toMatchObject({
+		name: 'Discord Gateway',
+		description: 'Receives Discord events and forwards them to Kody.',
+		lastUsedAt: null,
+		token: expect.stringMatching(/^tok_[0-9a-f]+$/),
+	})
+
+	const storedValue = testDb.getStoredValue(
+		'user-123',
+		skillRunnerTokensValueName,
+	)
+	expect(storedValue).toBeTruthy()
+	expect(storedValue).not.toContain(created.token)
+	const storedPayload = JSON.parse(storedValue ?? '{}') as Record<
+		string,
+		{
+			token?: string
+			name?: string
+			description?: string
+			lastUsedAt?: string | null
+		}
+	>
+	expect(storedPayload['kody-discord-gateway']).toMatchObject({
+		token: expect.stringMatching(/^sha256:/),
+		name: 'Discord Gateway',
+		description: 'Receives Discord events and forwards them to Kody.',
+		lastUsedAt: null,
+	})
+
+	await expect(
+		resolveSkillRunnerUserByToken({
+			env,
+			token: created.token,
+		}),
+	).resolves.toEqual({
+		userId: 'user-123',
+		clientName: 'kody-discord-gateway',
+	})
+
+	await expect(
+		listSkillRunnerTokens({
+			env,
+			userId: 'user-123',
+		}),
+	).resolves.toEqual([
+		{
+			clientName: 'kody-discord-gateway',
+			name: 'Discord Gateway',
+			description: 'Receives Discord events and forwards them to Kody.',
+			lastUsedAt: null,
+			token: 'tok_…',
+		},
+	])
+
+	await expect(
+		markSkillRunnerTokenUsed({
+			env,
+			userId: 'user-123',
+			clientName: 'kody-discord-gateway',
+		}),
+	).resolves.toBe(true)
+
+	const listedAfterUse = await listSkillRunnerTokens({
+		env,
+		userId: 'user-123',
+	})
+	expect(listedAfterUse).toEqual([
+		{
+			clientName: 'kody-discord-gateway',
+			name: 'Discord Gateway',
+			description: 'Receives Discord events and forwards them to Kody.',
+			lastUsedAt: expect.any(String),
+			token: 'tok_…',
+		},
+	])
+
+	await expect(
+		revokeSkillRunnerToken({
+			env,
+			userId: 'user-123',
+			clientName: 'kody-discord-gateway',
+		}),
+	).resolves.toBe(true)
+
+	await expect(
+		listSkillRunnerTokens({
+			env,
+			userId: 'user-123',
+		}),
+	).resolves.toEqual([])
+	await expect(
+		resolveSkillRunnerUserByToken({
+			env,
+			token: created.token,
+		}),
+	).resolves.toBeNull()
+})
+
+test('skill runner token store reads legacy plaintext tokens as metadata entries', async () => {
+	const testDb = createValueTestDb()
+	const env = { APP_DB: testDb.db }
+
+	await saveValue({
+		env,
+		userId: 'legacy-user',
+		name: skillRunnerTokensValueName,
+		value: JSON.stringify({
+			legacyGateway: 'tok_legacy_token',
+		}),
+		scope: 'user',
+		storageContext: {
+			sessionId: null,
+			appId: null,
+			storageId: null,
+		},
+	})
+
+	await expect(
+		listSkillRunnerTokens({
+			env,
+			userId: 'legacy-user',
+		}),
+	).resolves.toEqual([
+		{
+			clientName: 'legacyGateway',
+			name: 'legacyGateway',
+			description: null,
+			lastUsedAt: null,
+			token: 'tok_…',
+		},
+	])
+
+	await expect(
+		resolveSkillRunnerUserByToken({
+			env,
+			token: 'tok_legacy_token',
+		}),
+	).resolves.toEqual({
+		userId: 'legacy-user',
+		clientName: 'legacyGateway',
+	})
+})

--- a/packages/worker/src/mcp/values/skill-runner-tokens.ts
+++ b/packages/worker/src/mcp/values/skill-runner-tokens.ts
@@ -5,6 +5,7 @@ export const skillRunnerTokensValueName = 'skillRunnerTokens'
 
 const skillRunnerTokenBytes = 24
 const skillRunnerTokenPrefix = 'tok_'
+const skillRunnerTokenHashPrefix = 'sha256:'
 const redactedTokenValue = 'tok_…'
 
 export type SkillRunnerTokenMap = Record<string, string>
@@ -72,6 +73,26 @@ function maskToken(_token: string) {
 	return redactedTokenValue
 }
 
+async function hashSkillRunnerToken(token: string) {
+	const encoder = new TextEncoder()
+	const digest = await crypto.subtle.digest('SHA-256', encoder.encode(token))
+	return `${skillRunnerTokenHashPrefix}${toHex(new Uint8Array(digest))}`
+}
+
+function isHashedToken(token: string) {
+	return token.startsWith(skillRunnerTokenHashPrefix)
+}
+
+async function ensureHashedTokenMap(tokenMap: SkillRunnerTokenMap) {
+	const entries = await Promise.all(
+		Object.entries(tokenMap).map(async ([clientName, token]) => [
+			clientName,
+			isHashedToken(token) ? token : await hashSkillRunnerToken(token),
+		]),
+	)
+	return Object.fromEntries(entries) satisfies SkillRunnerTokenMap
+}
+
 function padToLength(buffer: Uint8Array, length: number) {
 	if (buffer.length === length) return buffer
 	const padded = new Uint8Array(length)
@@ -104,12 +125,18 @@ function timingSafeEqual(left: Uint8Array, right: Uint8Array) {
 	return isEqual && left.length === right.length
 }
 
-function includesToken(tokenMap: SkillRunnerTokenMap, token: string) {
+async function includesToken(tokenMap: SkillRunnerTokenMap, token: string) {
 	const encoder = new TextEncoder()
 	const tokenBytes = encoder.encode(token)
+	const hashedToken = await hashSkillRunnerToken(token)
+	const hashedBytes = encoder.encode(hashedToken)
 	let matched = false
 	for (const candidate of Object.values(tokenMap)) {
-		if (timingSafeEqual(tokenBytes, encoder.encode(candidate))) {
+		const candidateBytes = encoder.encode(candidate)
+		const isMatch = isHashedToken(candidate)
+			? timingSafeEqual(hashedBytes, candidateBytes)
+			: timingSafeEqual(tokenBytes, candidateBytes)
+		if (isMatch) {
 			matched = true
 		}
 	}
@@ -165,9 +192,10 @@ export async function createSkillRunnerToken(input: {
 		throw new Error('clientName is required.')
 	}
 
-	const tokens = await getSkillRunnerTokens(input)
+	let tokens = await getSkillRunnerTokens(input)
+	tokens = await ensureHashedTokenMap(tokens)
 	const token = generateSkillRunnerToken()
-	tokens[clientName] = token
+	tokens[clientName] = await hashSkillRunnerToken(token)
 	await writeSkillRunnerTokens({
 		env: input.env,
 		userId: input.userId,
@@ -202,6 +230,7 @@ export async function revokeSkillRunnerToken(input: {
 		return true
 	}
 
+	tokens = await ensureHashedTokenMap(tokens)
 	await writeSkillRunnerTokens({
 		env: input.env,
 		userId: input.userId,
@@ -249,7 +278,7 @@ export async function resolveSkillRunnerUserByToken(input: {
 		if (!userId || !rawValue) continue
 		const tokenMap = tryParseTokenMap(rawValue)
 		if (!tokenMap) continue
-		if (includesToken(tokenMap, token)) {
+		if (await includesToken(tokenMap, token)) {
 			return { userId }
 		}
 	}

--- a/packages/worker/src/mcp/values/skill-runner-tokens.ts
+++ b/packages/worker/src/mcp/values/skill-runner-tokens.ts
@@ -21,10 +21,12 @@ function normalizeTokenMap(raw: unknown) {
 	}
 
 	const entries = Object.entries(raw)
-		.filter(([clientName, token]) => {
-			return clientName.trim().length > 0 && typeof token === 'string'
+		.flatMap(([clientName, token]) => {
+			if (clientName.trim().length === 0 || typeof token !== 'string') {
+				return []
+			}
+			return [[clientName.trim(), token.trim()] as const]
 		})
-		.map(([clientName, token]) => [clientName.trim(), token.trim()] as const)
 		.filter(([, token]) => token.length > 0)
 		.sort(([left], [right]) => left.localeCompare(right))
 

--- a/packages/worker/src/mcp/values/skill-runner-tokens.ts
+++ b/packages/worker/src/mcp/values/skill-runner-tokens.ts
@@ -70,6 +70,50 @@ function maskToken(_token: string) {
 	return redactedTokenValue
 }
 
+function padToLength(buffer: Uint8Array, length: number) {
+	if (buffer.length === length) return buffer
+	const padded = new Uint8Array(length)
+	padded.set(buffer)
+	return padded
+}
+
+function timingSafeEqual(left: Uint8Array, right: Uint8Array) {
+	const maxLength = Math.max(left.length, right.length)
+	const leftPadded = padToLength(left, maxLength)
+	const rightPadded = padToLength(right, maxLength)
+	const subtle = crypto.subtle as SubtleCrypto & {
+		timingSafeEqual?: (
+			a: ArrayBuffer | ArrayBufferView,
+			b: ArrayBuffer | ArrayBufferView,
+		) => boolean
+	}
+	const isEqual =
+		typeof subtle.timingSafeEqual === 'function'
+			? subtle.timingSafeEqual(leftPadded, rightPadded)
+			: (() => {
+					let result = 0
+					for (let index = 0; index < maxLength; index += 1) {
+						const leftValue = leftPadded[index] ?? 0
+						const rightValue = rightPadded[index] ?? 0
+						result |= leftValue ^ rightValue
+					}
+					return result === 0
+				})()
+	return isEqual && left.length === right.length
+}
+
+function includesToken(tokenMap: SkillRunnerTokenMap, token: string) {
+	const encoder = new TextEncoder()
+	const tokenBytes = encoder.encode(token)
+	let matched = false
+	for (const candidate of Object.values(tokenMap)) {
+		if (timingSafeEqual(tokenBytes, encoder.encode(candidate))) {
+			matched = true
+		}
+	}
+	return matched
+}
+
 async function readTokenValue(input: {
 	env: Pick<Env, 'APP_DB'>
 	userId: string
@@ -195,7 +239,7 @@ export async function resolveSkillRunnerUserByToken(input: {
 		if (!userId || !rawValue) continue
 		const tokenMap = tryParseTokenMap(rawValue)
 		if (!tokenMap) continue
-		if (Object.values(tokenMap).includes(token)) {
+		if (includesToken(tokenMap, token)) {
 			return { userId }
 		}
 	}

--- a/packages/worker/src/mcp/values/skill-runner-tokens.ts
+++ b/packages/worker/src/mcp/values/skill-runner-tokens.ts
@@ -220,24 +220,22 @@ export async function resolveSkillRunnerUserByToken(input: {
 	if (!token) return null
 
 	const now = new Date().toISOString()
-	const { results } = await input.env.APP_DB
-		.prepare(
-			`SELECT vb.user_id, ve.value
+	const { results } = await input.env.APP_DB.prepare(
+		`SELECT vb.user_id, ve.value
 			FROM value_entries ve
 			INNER JOIN value_buckets vb ON vb.id = ve.bucket_id
 			WHERE ve.name = ?
 				AND vb.scope = 'user'
 				AND vb.binding_key = ''
 				AND (vb.expires_at IS NULL OR vb.expires_at > ?)`,
-		)
+	)
 		.bind(skillRunnerTokensValueName, now)
 		.all<Record<string, unknown>>()
 
 	for (const row of results ?? []) {
 		const userId =
 			typeof row['user_id'] === 'string' ? row['user_id'].trim() : ''
-		const rawValue =
-			typeof row['value'] === 'string' ? row['value'] : null
+		const rawValue = typeof row['value'] === 'string' ? row['value'] : null
 		if (!userId || !rawValue) continue
 		const tokenMap = tryParseTokenMap(rawValue)
 		if (!tokenMap) continue

--- a/packages/worker/src/mcp/values/skill-runner-tokens.ts
+++ b/packages/worker/src/mcp/values/skill-runner-tokens.ts
@@ -130,6 +130,24 @@ async function readTokenValue(input: {
 	return value?.value ?? null
 }
 
+async function writeSkillRunnerTokens(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	tokens: SkillRunnerTokenMap
+}) {
+	// Token management is low-frequency admin config, so concurrent updates
+	// intentionally use the value store's normal last-write-wins behavior.
+	await saveValue({
+		env: input.env,
+		userId: input.userId,
+		name: skillRunnerTokensValueName,
+		value: JSON.stringify(input.tokens),
+		scope: 'user',
+		description: 'External skill runner bearer tokens by client name',
+		storageContext: createStorageContext(),
+	})
+}
+
 export async function getSkillRunnerTokens(input: {
 	env: Pick<Env, 'APP_DB'>
 	userId: string
@@ -150,14 +168,10 @@ export async function createSkillRunnerToken(input: {
 	const tokens = await getSkillRunnerTokens(input)
 	const token = generateSkillRunnerToken()
 	tokens[clientName] = token
-	await saveValue({
+	await writeSkillRunnerTokens({
 		env: input.env,
 		userId: input.userId,
-		name: skillRunnerTokensValueName,
-		value: JSON.stringify(tokens),
-		scope: 'user',
-		description: 'External skill runner bearer tokens by client name',
-		storageContext: createStorageContext(),
+		tokens,
 	})
 	return token
 }
@@ -188,14 +202,10 @@ export async function revokeSkillRunnerToken(input: {
 		return true
 	}
 
-	await saveValue({
+	await writeSkillRunnerTokens({
 		env: input.env,
 		userId: input.userId,
-		name: skillRunnerTokensValueName,
-		value: JSON.stringify(tokens),
-		scope: 'user',
-		description: 'External skill runner bearer tokens by client name',
-		storageContext: createStorageContext(),
+		tokens,
 	})
 	return true
 }

--- a/packages/worker/src/mcp/values/skill-runner-tokens.ts
+++ b/packages/worker/src/mcp/values/skill-runner-tokens.ts
@@ -8,13 +8,55 @@ const skillRunnerTokenPrefix = 'tok_'
 const skillRunnerTokenHashPrefix = 'sha256:'
 const redactedTokenValue = 'tok_…'
 
-export type SkillRunnerTokenMap = Record<string, string>
+export type SkillRunnerTokenRecord = {
+	token: string
+	name: string
+	description: string
+	lastUsedAt: string | null
+}
+
+export type SkillRunnerTokenStore = Record<string, SkillRunnerTokenRecord>
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return value != null && typeof value === 'object' && !Array.isArray(value)
 }
 
-function normalizeTokenMap(raw: unknown) {
+function normalizeTokenRecord(
+	clientName: string,
+	raw: unknown,
+): SkillRunnerTokenRecord | null {
+	if (typeof raw === 'string') {
+		const token = raw.trim()
+		if (!token) return null
+		return {
+			token,
+			name: clientName,
+			description: '',
+			lastUsedAt: null,
+		}
+	}
+	if (!isRecord(raw)) return null
+	const token = typeof raw['token'] === 'string' ? raw['token'].trim() : ''
+	if (!token) return null
+	const name =
+		typeof raw['name'] === 'string' && raw['name'].trim().length > 0
+			? raw['name'].trim()
+			: clientName
+	const description =
+		typeof raw['description'] === 'string' ? raw['description'].trim() : ''
+	const lastUsedAt =
+		typeof raw['lastUsedAt'] === 'string' && raw['lastUsedAt'].trim().length > 0
+			? raw['lastUsedAt'].trim()
+			: null
+	return {
+		token,
+		name,
+		description,
+		lastUsedAt,
+	}
+}
+
+function normalizeTokenStore(raw: unknown) {
 	if (!isRecord(raw)) {
 		throw new Error(
 			'Persisted skillRunnerTokens value must be a JSON object of clientName to token.',
@@ -22,19 +64,23 @@ function normalizeTokenMap(raw: unknown) {
 	}
 
 	const entries = Object.entries(raw)
-		.flatMap(([clientName, token]) => {
-			if (clientName.trim().length === 0 || typeof token !== 'string') {
-				return []
-			}
-			return [[clientName.trim(), token.trim()] as const]
+		.flatMap(([clientName, rawRecord]) => {
+			const normalizedClientName = clientName.trim()
+			if (!normalizedClientName) return []
+			const normalizedRecord = normalizeTokenRecord(
+				normalizedClientName,
+				rawRecord,
+			)
+			return normalizedRecord == null
+				? []
+				: [[normalizedClientName, normalizedRecord] as const]
 		})
-		.filter(([, token]) => token.length > 0)
 		.sort(([left], [right]) => left.localeCompare(right))
 
-	return Object.fromEntries(entries) satisfies SkillRunnerTokenMap
+	return Object.fromEntries(entries) satisfies SkillRunnerTokenStore
 }
 
-function parseTokenMap(rawValue: string | null): SkillRunnerTokenMap {
+function parseTokenStore(rawValue: string | null): SkillRunnerTokenStore {
 	if (!rawValue) return {}
 	let parsed: unknown
 	try {
@@ -44,12 +90,14 @@ function parseTokenMap(rawValue: string | null): SkillRunnerTokenMap {
 			'Persisted skillRunnerTokens value must be valid JSON containing client tokens.',
 		)
 	}
-	return normalizeTokenMap(parsed)
+	return normalizeTokenStore(parsed)
 }
 
-function tryParseTokenMap(rawValue: string | null): SkillRunnerTokenMap | null {
+function tryParseTokenStore(
+	rawValue: string | null,
+): SkillRunnerTokenStore | null {
 	try {
-		return parseTokenMap(rawValue)
+		return parseTokenStore(rawValue)
 	} catch {
 		return null
 	}
@@ -81,16 +129,6 @@ async function hashSkillRunnerToken(token: string) {
 
 function isHashedToken(token: string) {
 	return token.startsWith(skillRunnerTokenHashPrefix)
-}
-
-async function ensureHashedTokenMap(tokenMap: SkillRunnerTokenMap) {
-	const entries = await Promise.all(
-		Object.entries(tokenMap).map(async ([clientName, token]) => [
-			clientName,
-			isHashedToken(token) ? token : await hashSkillRunnerToken(token),
-		]),
-	)
-	return Object.fromEntries(entries) satisfies SkillRunnerTokenMap
 }
 
 function padToLength(buffer: Uint8Array, length: number) {
@@ -125,22 +163,15 @@ function timingSafeEqual(left: Uint8Array, right: Uint8Array) {
 	return isEqual && left.length === right.length
 }
 
-async function includesToken(tokenMap: SkillRunnerTokenMap, token: string) {
+async function matchesToken(candidateToken: string, token: string) {
 	const encoder = new TextEncoder()
 	const tokenBytes = encoder.encode(token)
 	const hashedToken = await hashSkillRunnerToken(token)
 	const hashedBytes = encoder.encode(hashedToken)
-	let matched = false
-	for (const candidate of Object.values(tokenMap)) {
-		const candidateBytes = encoder.encode(candidate)
-		const isMatch = isHashedToken(candidate)
-			? timingSafeEqual(hashedBytes, candidateBytes)
-			: timingSafeEqual(tokenBytes, candidateBytes)
-		if (isMatch) {
-			matched = true
-		}
-	}
-	return matched
+	const candidateBytes = encoder.encode(candidateToken)
+	return isHashedToken(candidateToken)
+		? timingSafeEqual(hashedBytes, candidateBytes)
+		: timingSafeEqual(tokenBytes, candidateBytes)
 }
 
 async function readTokenValue(input: {
@@ -160,10 +191,11 @@ async function readTokenValue(input: {
 async function writeSkillRunnerTokens(input: {
 	env: Pick<Env, 'APP_DB'>
 	userId: string
-	tokens: SkillRunnerTokenMap
+	tokens: SkillRunnerTokenStore
 }) {
-	// Token management is low-frequency admin config, so concurrent updates
-	// intentionally use the value store's normal last-write-wins behavior.
+	// This store mixes low-frequency admin updates with best-effort usage stamps.
+	// Under concurrent writes, the value store's normal last-write-wins behavior
+	// applies; occasional stale lastUsedAt metadata is acceptable here.
 	await saveValue({
 		env: input.env,
 		userId: input.userId,
@@ -179,29 +211,43 @@ export async function getSkillRunnerTokens(input: {
 	env: Pick<Env, 'APP_DB'>
 	userId: string
 }) {
-	return parseTokenMap(await readTokenValue(input))
+	return parseTokenStore(await readTokenValue(input))
 }
 
 export async function createSkillRunnerToken(input: {
 	env: Pick<Env, 'APP_DB'>
 	userId: string
 	clientName: string
+	name: string
+	description?: string | null
 }) {
 	const clientName = input.clientName.trim()
 	if (!clientName) {
 		throw new Error('clientName is required.')
 	}
+	const name = input.name.trim()
+	if (!name) {
+		throw new Error('name is required.')
+	}
 
-	let tokens = await getSkillRunnerTokens(input)
-	tokens = await ensureHashedTokenMap(tokens)
+	const tokens = await getSkillRunnerTokens(input)
+	const existing = tokens[clientName]
 	const token = generateSkillRunnerToken()
-	tokens[clientName] = await hashSkillRunnerToken(token)
+	tokens[clientName] = {
+		token: await hashSkillRunnerToken(token),
+		name,
+		description: input.description?.trim() ?? existing?.description ?? '',
+		lastUsedAt: existing?.lastUsedAt ?? null,
+	}
 	await writeSkillRunnerTokens({
 		env: input.env,
 		userId: input.userId,
 		tokens,
 	})
-	return token
+	return {
+		...tokens[clientName],
+		token,
+	}
 }
 
 export async function revokeSkillRunnerToken(input: {
@@ -230,7 +276,6 @@ export async function revokeSkillRunnerToken(input: {
 		return true
 	}
 
-	tokens = await ensureHashedTokenMap(tokens)
 	await writeSkillRunnerTokens({
 		env: input.env,
 		userId: input.userId,
@@ -244,11 +289,15 @@ export async function listSkillRunnerTokens(input: {
 	userId: string
 }) {
 	const tokens = await getSkillRunnerTokens(input)
-	return Object.fromEntries(
-		Object.keys(tokens)
-			.sort((left, right) => left.localeCompare(right))
-			.map((clientName) => [clientName, maskToken(tokens[clientName] ?? '')]),
-	) satisfies SkillRunnerTokenMap
+	return Object.entries(tokens)
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([clientName, record]) => ({
+			clientName,
+			name: record.name,
+			description: record.description || null,
+			lastUsedAt: record.lastUsedAt,
+			token: maskToken(record.token),
+		}))
 }
 
 export async function resolveSkillRunnerUserByToken(input: {
@@ -276,12 +325,34 @@ export async function resolveSkillRunnerUserByToken(input: {
 			typeof row['user_id'] === 'string' ? row['user_id'].trim() : ''
 		const rawValue = typeof row['value'] === 'string' ? row['value'] : null
 		if (!userId || !rawValue) continue
-		const tokenMap = tryParseTokenMap(rawValue)
-		if (!tokenMap) continue
-		if (await includesToken(tokenMap, token)) {
-			return { userId }
+		const tokenStore = tryParseTokenStore(rawValue)
+		if (!tokenStore) continue
+		for (const [clientName, record] of Object.entries(tokenStore)) {
+			if (await matchesToken(record.token, token)) {
+				return { userId, clientName }
+			}
 		}
 	}
 
 	return null
+}
+
+export async function markSkillRunnerTokenUsed(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	clientName: string
+}) {
+	const tokens = await getSkillRunnerTokens(input)
+	const existing = tokens[input.clientName]
+	if (!existing) return false
+	tokens[input.clientName] = {
+		...existing,
+		lastUsedAt: new Date().toISOString(),
+	}
+	await writeSkillRunnerTokens({
+		env: input.env,
+		userId: input.userId,
+		tokens,
+	})
+	return true
 }

--- a/packages/worker/src/mcp/values/skill-runner-tokens.ts
+++ b/packages/worker/src/mcp/values/skill-runner-tokens.ts
@@ -1,0 +1,204 @@
+import { toHex } from '@kody-internal/shared/hex.ts'
+import { deleteValue, getValue, saveValue } from './service.ts'
+
+export const skillRunnerTokensValueName = 'skillRunnerTokens'
+
+const skillRunnerTokenBytes = 24
+const skillRunnerTokenPrefix = 'tok_'
+const redactedTokenValue = 'tok_…'
+
+export type SkillRunnerTokenMap = Record<string, string>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizeTokenMap(raw: unknown) {
+	if (!isRecord(raw)) {
+		throw new Error(
+			'Persisted skillRunnerTokens value must be a JSON object of clientName to token.',
+		)
+	}
+
+	const entries = Object.entries(raw)
+		.filter(([clientName, token]) => {
+			return clientName.trim().length > 0 && typeof token === 'string'
+		})
+		.map(([clientName, token]) => [clientName.trim(), token.trim()] as const)
+		.filter(([, token]) => token.length > 0)
+		.sort(([left], [right]) => left.localeCompare(right))
+
+	return Object.fromEntries(entries) satisfies SkillRunnerTokenMap
+}
+
+function parseTokenMap(rawValue: string | null): SkillRunnerTokenMap {
+	if (!rawValue) return {}
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(rawValue)
+	} catch {
+		throw new Error(
+			'Persisted skillRunnerTokens value must be valid JSON containing client tokens.',
+		)
+	}
+	return normalizeTokenMap(parsed)
+}
+
+function tryParseTokenMap(rawValue: string | null): SkillRunnerTokenMap | null {
+	try {
+		return parseTokenMap(rawValue)
+	} catch {
+		return null
+	}
+}
+
+function createStorageContext() {
+	return {
+		sessionId: null,
+		appId: null,
+		storageId: null,
+	}
+}
+
+function generateSkillRunnerToken() {
+	const bytes = new Uint8Array(skillRunnerTokenBytes)
+	crypto.getRandomValues(bytes)
+	return `${skillRunnerTokenPrefix}${toHex(bytes)}`
+}
+
+function maskToken(_token: string) {
+	return redactedTokenValue
+}
+
+async function readTokenValue(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+}) {
+	const value = await getValue({
+		env: input.env,
+		userId: input.userId,
+		name: skillRunnerTokensValueName,
+		scope: 'user',
+		storageContext: createStorageContext(),
+	})
+	return value?.value ?? null
+}
+
+export async function getSkillRunnerTokens(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+}) {
+	return parseTokenMap(await readTokenValue(input))
+}
+
+export async function createSkillRunnerToken(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	clientName: string
+}) {
+	const clientName = input.clientName.trim()
+	if (!clientName) {
+		throw new Error('clientName is required.')
+	}
+
+	const tokens = await getSkillRunnerTokens(input)
+	const token = generateSkillRunnerToken()
+	tokens[clientName] = token
+	await saveValue({
+		env: input.env,
+		userId: input.userId,
+		name: skillRunnerTokensValueName,
+		value: JSON.stringify(tokens),
+		scope: 'user',
+		description: 'External skill runner bearer tokens by client name',
+		storageContext: createStorageContext(),
+	})
+	return token
+}
+
+export async function revokeSkillRunnerToken(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	clientName: string
+}) {
+	const clientName = input.clientName.trim()
+	if (!clientName) {
+		throw new Error('clientName is required.')
+	}
+
+	const tokens = await getSkillRunnerTokens(input)
+	const existed = Object.hasOwn(tokens, clientName)
+	if (!existed) return false
+
+	delete tokens[clientName]
+	if (Object.keys(tokens).length === 0) {
+		await deleteValue({
+			env: input.env,
+			userId: input.userId,
+			name: skillRunnerTokensValueName,
+			scope: 'user',
+			storageContext: createStorageContext(),
+		})
+		return true
+	}
+
+	await saveValue({
+		env: input.env,
+		userId: input.userId,
+		name: skillRunnerTokensValueName,
+		value: JSON.stringify(tokens),
+		scope: 'user',
+		description: 'External skill runner bearer tokens by client name',
+		storageContext: createStorageContext(),
+	})
+	return true
+}
+
+export async function listSkillRunnerTokens(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+}) {
+	const tokens = await getSkillRunnerTokens(input)
+	return Object.fromEntries(
+		Object.keys(tokens)
+			.sort((left, right) => left.localeCompare(right))
+			.map((clientName) => [clientName, maskToken(tokens[clientName] ?? '')]),
+	) satisfies SkillRunnerTokenMap
+}
+
+export async function resolveSkillRunnerUserByToken(input: {
+	env: Pick<Env, 'APP_DB'>
+	token: string
+}) {
+	const token = input.token.trim()
+	if (!token) return null
+
+	const now = new Date().toISOString()
+	const { results } = await input.env.APP_DB
+		.prepare(
+			`SELECT vb.user_id, ve.value
+			FROM value_entries ve
+			INNER JOIN value_buckets vb ON vb.id = ve.bucket_id
+			WHERE ve.name = ?
+				AND vb.scope = 'user'
+				AND vb.binding_key = ''
+				AND (vb.expires_at IS NULL OR vb.expires_at > ?)`,
+		)
+		.bind(skillRunnerTokensValueName, now)
+		.all<Record<string, unknown>>()
+
+	for (const row of results ?? []) {
+		const userId =
+			typeof row['user_id'] === 'string' ? row['user_id'].trim() : ''
+		const rawValue =
+			typeof row['value'] === 'string' ? row['value'] : null
+		if (!userId || !rawValue) continue
+		const tokenMap = tryParseTokenMap(rawValue)
+		if (!tokenMap) continue
+		if (Object.values(tokenMap).includes(token)) {
+			return { userId }
+		}
+	}
+
+	return null
+}

--- a/packages/worker/src/mcp/values/value-name-guards.ts
+++ b/packages/worker/src/mcp/values/value-name-guards.ts
@@ -1,0 +1,13 @@
+import { skillRunnerTokensValueName } from './skill-runner-tokens.ts'
+
+const reservedValueNames = new Set([skillRunnerTokensValueName])
+
+export function isReservedValueName(name: string) {
+	return reservedValueNames.has(name)
+}
+
+export function assertValueNameAllowed(name: string) {
+	if (isReservedValueName(name)) {
+		throw new Error('Value name is reserved for internal use.')
+	}
+}

--- a/packages/worker/src/oauth-handlers-skill-runner.workers.test.ts
+++ b/packages/worker/src/oauth-handlers-skill-runner.workers.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	resolveSkillRunnerUserByToken: vi.fn(),
+	markSkillRunnerTokenUsed: vi.fn(async () => true),
+	runSavedSkill: vi.fn(),
+}))
+
+vi.mock('#mcp/values/skill-runner-tokens.ts', () => ({
+	resolveSkillRunnerUserByToken: (...args: Array<unknown>) =>
+		mockModule.resolveSkillRunnerUserByToken(...args),
+	markSkillRunnerTokenUsed: (...args: Array<unknown>) =>
+		mockModule.markSkillRunnerTokenUsed(...args),
+}))
+
+vi.mock('#mcp/skills/run-saved-skill.ts', () => ({
+	runSavedSkill: (...args: Array<unknown>) => mockModule.runSavedSkill(...args),
+}))
+
+const { apiHandler } = await import('./oauth-handlers.ts')
+
+function createRequest(
+	body: Record<string, unknown>,
+	headers?: Record<string, string>,
+) {
+	return new Request('https://example.com/api/skills/run', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...headers,
+		},
+		body: JSON.stringify(body),
+	})
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+test('api skill runner rejects missing bearer auth', async () => {
+	const response = await apiHandler.fetch(
+		createRequest({ name: 'discord-event-handler', params: {} }),
+		{ APP_DB: {} as D1Database } as Env,
+		{} as ExecutionContext,
+	)
+
+	expect(response.status).toBe(401)
+	await expect(response.json()).resolves.toEqual({
+		ok: false,
+		error: 'Unauthorized.',
+	})
+	expect(mockModule.resolveSkillRunnerUserByToken).not.toHaveBeenCalled()
+	expect(mockModule.runSavedSkill).not.toHaveBeenCalled()
+})
+
+test('api skill runner rejects invalid tokens', async () => {
+	mockModule.resolveSkillRunnerUserByToken.mockResolvedValueOnce(null)
+
+	const response = await apiHandler.fetch(
+		createRequest(
+			{ name: 'discord-event-handler', params: {} },
+			{ Authorization: 'Bearer tok_invalid' },
+		),
+		{ APP_DB: {} as D1Database } as Env,
+		{} as ExecutionContext,
+	)
+
+	expect(response.status).toBe(401)
+	await expect(response.json()).resolves.toEqual({
+		ok: false,
+		error: 'Unauthorized.',
+	})
+	expect(mockModule.markSkillRunnerTokenUsed).not.toHaveBeenCalled()
+	expect(mockModule.runSavedSkill).not.toHaveBeenCalled()
+})
+
+test('api skill runner validates request payloads after auth', async () => {
+	const env = { APP_DB: {} as D1Database } as Env
+	mockModule.resolveSkillRunnerUserByToken.mockResolvedValueOnce({
+		userId: 'user-123',
+		clientName: 'kody-discord-gateway',
+	})
+
+	const response = await apiHandler.fetch(
+		createRequest(
+			{ name: 'discord-event-handler', params: [] },
+			{ Authorization: 'Bearer tok_valid' },
+		),
+		env,
+		{} as ExecutionContext,
+	)
+
+	expect(response.status).toBe(400)
+	await expect(response.json()).resolves.toEqual({
+		ok: false,
+		error: 'Skill params must be a JSON object when provided.',
+	})
+	expect(mockModule.markSkillRunnerTokenUsed).toHaveBeenCalledWith({
+		env,
+		userId: 'user-123',
+		clientName: 'kody-discord-gateway',
+	})
+	expect(mockModule.runSavedSkill).not.toHaveBeenCalled()
+})
+
+test('api skill runner returns successful saved skill results and marks usage', async () => {
+	mockModule.resolveSkillRunnerUserByToken.mockResolvedValueOnce({
+		userId: 'user-123',
+		clientName: 'kody-discord-gateway',
+	})
+	mockModule.runSavedSkill.mockResolvedValueOnce({
+		ok: true,
+		result: { ok: true, echoed: { eventType: 'MESSAGE_CREATE' } },
+		logs: [],
+	})
+	const env = { APP_DB: {} as D1Database } as Env
+
+	const response = await apiHandler.fetch(
+		createRequest(
+			{
+				name: 'discord-event-handler',
+				params: { eventType: 'MESSAGE_CREATE' },
+			},
+			{ Authorization: 'Bearer tok_valid' },
+		),
+		env,
+		{} as ExecutionContext,
+	)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toEqual({
+		ok: true,
+		result: { ok: true, echoed: { eventType: 'MESSAGE_CREATE' } },
+	})
+	expect(mockModule.markSkillRunnerTokenUsed).toHaveBeenCalledWith({
+		env,
+		userId: 'user-123',
+		clientName: 'kody-discord-gateway',
+	})
+	expect(mockModule.runSavedSkill).toHaveBeenCalledWith({
+		env,
+		callerContext: {
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'user-123',
+				email: 'skill-runner@local.invalid',
+				displayName: 'skill-runner',
+			},
+			homeConnectorId: null,
+			remoteConnectors: null,
+			storageContext: null,
+		},
+		name: 'discord-event-handler',
+		params: { eventType: 'MESSAGE_CREATE' },
+	})
+})
+
+test('api skill runner surfaces structured saved skill failures without throwing', async () => {
+	mockModule.resolveSkillRunnerUserByToken.mockResolvedValueOnce({
+		userId: 'user-123',
+		clientName: 'kody-discord-gateway',
+	})
+	mockModule.runSavedSkill.mockResolvedValueOnce({
+		ok: false,
+		error: 'Skill not found for this user.',
+		logs: [],
+	})
+
+	const response = await apiHandler.fetch(
+		createRequest(
+			{
+				name: 'missing-skill',
+				params: {},
+			},
+			{ Authorization: 'Bearer tok_valid' },
+		),
+		{ APP_DB: {} as D1Database } as Env,
+		{} as ExecutionContext,
+	)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toEqual({
+		ok: false,
+		error: 'Skill not found for this user.',
+	})
+})

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -13,6 +13,8 @@ import { getEnv } from '#app/env.ts'
 import { Layout } from '#app/layout.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { render } from '#app/render.ts'
+import { runSavedSkill } from '#mcp/skills/run-saved-skill.ts'
+import { resolveSkillRunnerUserByToken } from '#mcp/values/skill-runner-tokens.ts'
 import { createDb, usersTable } from './db.ts'
 import { wantsJson } from './utils.ts'
 import { verifyPassword } from '@kody-internal/shared/password-hash.ts'
@@ -715,9 +717,110 @@ export function handleOAuthCallback(request: Request): Response {
 	return renderSpaShell(hasError ? 400 : 200)
 }
 
+function readBearerToken(request: Request) {
+	const header = request.headers.get('Authorization')?.trim()
+	if (!header) return null
+	const match = header.match(/^Bearer\s+(.+)$/i)
+	const token = match?.[1]?.trim()
+	return token ? token : null
+}
+
+async function handleSkillRunnerRequest(request: Request, env: Env) {
+	if (request.method !== 'POST') {
+		return jsonResponse({ ok: false, error: 'Method not allowed.' }, { status: 405 })
+	}
+
+	const token = readBearerToken(request)
+	if (!token) {
+		return jsonResponse(
+			{ ok: false, error: 'Unauthorized.' },
+			{
+				status: 401,
+				headers: {
+					'WWW-Authenticate': 'Bearer',
+				},
+			},
+		)
+	}
+
+	const authorizedUser = await resolveSkillRunnerUserByToken({
+		env,
+		token,
+	})
+	if (!authorizedUser) {
+		return jsonResponse(
+			{ ok: false, error: 'Unauthorized.' },
+			{
+				status: 401,
+				headers: {
+					'WWW-Authenticate': 'Bearer',
+				},
+			},
+		)
+	}
+
+	const body = await request.json().catch(() => null)
+	if (!body || typeof body !== 'object' || Array.isArray(body)) {
+		return jsonResponse({ ok: false, error: 'Invalid request body.' }, { status: 400 })
+	}
+	const payload = body as Record<string, unknown>
+
+	const name = typeof payload['name'] === 'string' ? payload['name'].trim() : ''
+	if (!name) {
+		return jsonResponse({ ok: false, error: 'Skill name is required.' }, { status: 400 })
+	}
+
+	const paramsRaw = payload['params']
+	const params =
+		paramsRaw === undefined
+			? undefined
+			: paramsRaw && typeof paramsRaw === 'object' && !Array.isArray(paramsRaw)
+				? (paramsRaw as Record<string, unknown>)
+				: null
+	if (params === null) {
+		return jsonResponse(
+			{ ok: false, error: 'Skill params must be a JSON object when provided.' },
+			{ status: 400 },
+		)
+	}
+
+	try {
+		const result = await runSavedSkill({
+			env,
+			callerContext: {
+				baseUrl: new URL(request.url).origin,
+				user: {
+					userId: authorizedUser.userId,
+					email: 'skill-runner@local.invalid',
+					displayName: 'skill-runner',
+				},
+				homeConnectorId: null,
+				remoteConnectors: null,
+				storageContext: null,
+			},
+			name,
+			params,
+		})
+		return result.ok
+			? jsonResponse({ ok: true, result: result.result })
+			: jsonResponse({
+					ok: false,
+					error: result.error ?? 'Skill execution failed.',
+				})
+	} catch (error) {
+		return jsonResponse({
+			ok: false,
+			error: error instanceof Error ? error.message : 'Skill execution failed.',
+		})
+	}
+}
+
 export const apiHandler = {
-	async fetch(request: Request, _env: unknown, ctx: ExecutionContext) {
+	async fetch(request: Request, env: unknown, ctx: ExecutionContext) {
 		const url = new URL(request.url)
+		if (url.pathname === '/api/skills/run') {
+			return handleSkillRunnerRequest(request, env as Env)
+		}
 		if (url.pathname === '/api/me') {
 			const props = (ctx as OAuthContext).props
 			if (!props) {

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -727,7 +727,10 @@ function readBearerToken(request: Request) {
 
 async function handleSkillRunnerRequest(request: Request, env: Env) {
 	if (request.method !== 'POST') {
-		return jsonResponse({ ok: false, error: 'Method not allowed.' }, { status: 405 })
+		return jsonResponse(
+			{ ok: false, error: 'Method not allowed.' },
+			{ status: 405 },
+		)
 	}
 
 	const token = readBearerToken(request)
@@ -761,13 +764,19 @@ async function handleSkillRunnerRequest(request: Request, env: Env) {
 
 	const body = await request.json().catch(() => null)
 	if (!body || typeof body !== 'object' || Array.isArray(body)) {
-		return jsonResponse({ ok: false, error: 'Invalid request body.' }, { status: 400 })
+		return jsonResponse(
+			{ ok: false, error: 'Invalid request body.' },
+			{ status: 400 },
+		)
 	}
 	const payload = body as Record<string, unknown>
 
 	const name = typeof payload['name'] === 'string' ? payload['name'].trim() : ''
 	if (!name) {
-		return jsonResponse({ ok: false, error: 'Skill name is required.' }, { status: 400 })
+		return jsonResponse(
+			{ ok: false, error: 'Skill name is required.' },
+			{ status: 400 },
+		)
 	}
 
 	const paramsRaw = payload['params']

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -14,7 +14,10 @@ import { Layout } from '#app/layout.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { render } from '#app/render.ts'
 import { runSavedSkill } from '#mcp/skills/run-saved-skill.ts'
-import { resolveSkillRunnerUserByToken } from '#mcp/values/skill-runner-tokens.ts'
+import {
+	markSkillRunnerTokenUsed,
+	resolveSkillRunnerUserByToken,
+} from '#mcp/values/skill-runner-tokens.ts'
 import { createDb, usersTable } from './db.ts'
 import { wantsJson } from './utils.ts'
 import { verifyPassword } from '@kody-internal/shared/password-hash.ts'
@@ -761,6 +764,17 @@ async function handleSkillRunnerRequest(request: Request, env: Env) {
 			},
 		)
 	}
+	await markSkillRunnerTokenUsed({
+		env,
+		userId: authorizedUser.userId,
+		clientName: authorizedUser.clientName,
+	}).catch((error) => {
+		console.error('Failed to update skill runner token usage metadata.', {
+			userId: authorizedUser.userId,
+			clientName: authorizedUser.clientName,
+			error,
+		})
+	})
 
 	const body = await request.json().catch(() => null)
 	if (!body || typeof body !== 'object' || Array.isArray(body)) {
@@ -820,7 +834,8 @@ async function handleSkillRunnerRequest(request: Request, env: Env) {
 		return jsonResponse(
 			{
 				ok: false,
-				error: error instanceof Error ? error.message : 'Skill execution failed.',
+				error:
+					error instanceof Error ? error.message : 'Skill execution failed.',
 			},
 			{ status: 500 },
 		)

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -817,10 +817,13 @@ async function handleSkillRunnerRequest(request: Request, env: Env) {
 					error: result.error ?? 'Skill execution failed.',
 				})
 	} catch (error) {
-		return jsonResponse({
-			ok: false,
-			error: error instanceof Error ? error.message : 'Skill execution failed.',
-		})
+		return jsonResponse(
+			{
+				ok: false,
+				error: error instanceof Error ? error.message : 'Skill execution failed.',
+			},
+			{ status: 500 },
+		)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- rebase the skill runner branch onto the latest `main`, including the changes from merged PR #176
- keep MCP E2E coverage lean by leaving `packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts` as the shared smoke file from `main`
- move skill runner coverage into faster colocated tests: a node test for the token store and a workers test for the `/api/skills/run` handler
- preserve the current branch behavior around hashed skill runner tokens, metadata (`name`, optional `description`), and `lastUsedAt` tracking

## Testing
- `npx vitest run --project node-unit packages/worker/src/mcp/values/skill-runner-tokens.node.test.ts`
- `npx vitest run --project workers-unit packages/worker/src/oauth-handlers-skill-runner.workers.test.ts`
- `npm run typecheck`
- `npm run validate`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2518e6aa-10f6-40e3-9433-78a094b4415c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2518e6aa-10f6-40e3-9433-78a094b4415c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bearer token management for external skill runners: create, list, and revoke tokens.
  * Added an authenticated API endpoint to run saved skills using bearer tokens.

* **Refactor**
  * Centralized saved-skill execution into a shared runner for consistent parameter handling and error formatting.

* **Behavior changes**
  * Normalize and validate value names on get/set/delete; hide reserved internal names from listings.

* **Tests**
  * Added E2E tests covering token lifecycle, auth, and skill execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->