### PR TITLE
Clarify conversationId reuse guidance

### DIFF
--- a/docs/use/first-steps.md
+++ b/docs/use/first-steps.md
@@ -7,8 +7,9 @@ skill).
 
 ## Habits that help
 
-- **Pass `conversationId` back** on follow-up calls when the tool response
-  includes one. That keeps related calls grouped and can reduce response size.
+- **Reuse returned `conversationId` values.** If a prior tool response included
+  one, pass it back unchanged on follow-up calls. Otherwise omit the field and
+  use the server-generated value the tool returns. Do not make one up locally.
 - **Pass `memoryContext`** when durable user memory may matter. Kody uses it to
   surface a small set of relevant long-term memories that have not already been
   shown in the same conversation.

--- a/docs/use/memory.md
+++ b/docs/use/memory.md
@@ -8,9 +8,10 @@ Kody supports two related memory features:
 
 ## `conversationId`
 
-**`conversationId`** ties related tool calls together. Omit it on the first call
-to receive a server-generated id, then pass the returned id on follow-up calls
-in the same conversation.
+**`conversationId`** ties related tool calls together. If you already have one
+from an earlier tool response in the same conversation, pass it back unchanged.
+Otherwise omit the field so Kody can return a server-generated id, then reuse
+that returned id on follow-up calls. Do not make one up yourself.
 
 Kody uses this id to avoid surfacing the same long-term memory repeatedly in one
 conversation.

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -5,7 +5,7 @@ const domainInstructions = builtinDomains
 	.join('\n')
 
 export const conversationIdGuidance =
-	'The public MCP tools accept optional `conversationId` and `memoryContext` fields. `conversationId` ties related calls together. On the first call, omit it to receive a server-generated ID, or supply your own. Pass the returned `conversationId` on every subsequent call in the same conversation - this enables optimizations like reduced response size. Generated values should be short and random enough to avoid collisions.'
+	'The public MCP tools accept optional `conversationId` and `memoryContext` fields. `conversationId` ties related calls together. If you already have a `conversationId` from an earlier response in the same conversation, pass it back unchanged. Otherwise omit this field to receive a server-generated ID, then reuse the returned `conversationId` on subsequent calls - this enables optimizations like reduced response size. Do not invent your own `conversationId`.'
 
 export function buildBaseMcpServerInstructions(): string {
 	return `

--- a/packages/worker/src/mcp/tools/tool-call-context.ts
+++ b/packages/worker/src/mcp/tools/tool-call-context.ts
@@ -4,7 +4,7 @@ const generatedConversationIdLength = 12
 const conversationIdAlphabet = '0123456789abcdefghjkmnpqrstvwxyz'
 
 const conversationIdDescription =
-	'Optional short conversation identifier. Ties related calls together. On the first call, omit this to receive a server-generated ID, or supply your own. Pass the returned `conversationId` on every subsequent call in the same conversation - this enables optimizations like reduced response size. Generated values should be short and random enough to avoid collisions.'
+	'Optional short conversation identifier. Ties related calls together. If you already have a `conversationId` from an earlier response in the same conversation, pass it back unchanged. Otherwise omit this field to receive a server-generated ID, then reuse the returned `conversationId` on subsequent calls - this enables optimizations like reduced response size. Do not invent your own `conversationId`.'
 
 const memoryContextDescription =
 	'Optional short, structured task context for memory retrieval. Keep it brief and factual rather than hidden reasoning. If durable memory may need to be written or deleted, agents should later run `meta_memory_verify` before mutating memory.'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- clarify shared MCP tool guidance so agents reuse an existing `conversationId` and otherwise omit the field until the server returns one
- update the first-steps and memory docs to explicitly tell agents not to invent their own `conversationId`

## Testing
- `npx oxfmt --check docs/use/first-steps.md docs/use/memory.md packages/worker/src/mcp/server-instructions.ts packages/worker/src/mcp/tools/tool-call-context.ts`
- `npx oxlint packages/worker/src/mcp/server-instructions.ts packages/worker/src/mcp/tools/tool-call-context.ts`
- `npm run typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca32143b-af28-401d-a453-eccd40fb1a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca32143b-af28-401d-a453-eccd40fb1a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

