### PR TITLE
Add generic agent turn primitives

### DIFF
--- a/docs/contributing/mcp-skills.md
+++ b/docs/contributing/mcp-skills.md
@@ -51,6 +51,21 @@ rejected; defaults are applied when provided.
 Example:
 `meta_run_skill({ "name": "github-pr-summary", "params": { "owner": "kentcdodds" } })`
 
+## Agent-turn primitives
+
+Kody also provides generic agent-turn primitives for workflows that need
+tool-using inference:
+
+- **`agentChatTurnStream(...)`** — execute-time async iterable helper for
+  incremental events (reasoning, tool calls, results, final completion)
+- **`agent_chat_turn`** — final-value capability wrapper that runs one bounded
+  tool-using turn to completion
+
+Use these when you need a reusable, generic agent turn inside jobs, execute
+code, or higher-level controllers. Keep channel- or product-specific behavior
+outside core primitives; for example, Discord-specific posting and UX should
+live in saved skills or external workers, not in the generic turn runner.
+
 ## Collections
 
 Skills may include an optional **`collection`** string when saved. This is a

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -11,6 +11,11 @@ capability call takes one **args** object that matches that capability’s
 **inputSchema** and returns data that matches its **outputSchema** when one
 exists.
 
+In addition to **`codemode.<capabilityName>(args)`**, the sandbox may expose
+small built-in helpers for common agent workflows. These helpers are not normal
+MCP capabilities; they are runtime conveniences layered on top of the same
+execute environment.
+
 **execute** also accepts optional **`params`**. When provided, Kody injects that
 JSON object as **`params`** when invoking your async function, so code like
 **`async (params) => { ... }`** can read structured inputs without manually
@@ -31,6 +36,25 @@ To read field shapes while coding, use **search** with
 To run persisted user code by name, use **`meta_run_skill`** with **`name`** and
 optional **`params`**. To inspect source, use **`meta_get_skill`**. You can also
 inline saved skill code into **execute** when that fits the workflow.
+
+## Agent turns
+
+Kody exposes two generic primitives for tool-using chat turns:
+
+- **`agentChatTurnStream(input)`** — an async iterable helper available inside
+  the execute sandbox. Use this when your code needs incremental events such as
+  reasoning deltas, tool call notifications, and a final `turn_complete`
+  message.
+- **`codemode.agent_chat_turn(args)`** — a normal final-value capability
+  wrapper. Use this when you only need the completed result and do not need to
+  process stream events manually.
+
+Typical pattern inside execute:
+
+- use **`agentChatTurnStream(...)`** for interactive controllers that need to
+  forward progress over time
+- use **`codemode.agent_chat_turn(...)`** in jobs or workflows that only need
+  the final answer
 
 ## Jobs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "docs/talks/*"
       ],
       "devDependencies": {
-        "@cloudflare/vitest-pool-workers": "^0.14.5",
-        "@cloudflare/workers-types": "^4.20260413.1",
+        "@cloudflare/vitest-pool-workers": "^0.14.7",
+        "@cloudflare/workers-types": "^4.20260415.1",
         "@epic-web/config": "^1.24.1",
         "@kody-internal/shared": "file:packages/shared",
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -36,7 +36,7 @@
         "set-cookie-parser": "^3.0.1",
         "typescript": "^5.9.3",
         "vitest": "^4.1.1",
-        "wrangler": "^4.82.1"
+        "wrangler": "^4.83.0"
       },
       "engines": {
         "node": "24.x"
@@ -620,16 +620,94 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@cloudflare/ai-chat": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.4.4.tgz",
+      "integrity": "sha512-XYuqT/MPJ9DMgy8PFR1IAgQn8T61kg0ylHgTJFwUB3vBljKgCtfrAxWDMekdu1kTbo1VYdSRfj/v4Cs5xxkKIA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "@ai-sdk/react": "^3.0.0",
+        "agents": ">=0.8.7 <1.0.0",
+        "ai": "^6.0.0",
+        "react": "^19.0.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/codemode": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/codemode/-/codemode-0.3.4.tgz",
+      "integrity": "sha512-GDzPUnEqgp9qBNYvrjoO1iODXtOjWVhbyvVE40TJ/oaYvHsOgsaws4TnIKDM/+JK8uG3S3GAJ2+ixDIEuicIdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "acorn": "^8.16.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.0",
+        "@tanstack/ai": ">=0.8.0 <1.0.0",
+        "ai": "^6.0.0",
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "@tanstack/ai": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@cloudflare/shell": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/shell/-/shell-0.3.2.tgz",
+      "integrity": "sha512-2UYlhp308IxKWutGcdOJ8+QTR2J1sck108JJ0AEDYG/aNaapKSCrm0Rvd3EFAfqAPtzsqtFqDOKU/4LtpCF8dw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@cloudflare/codemode": "^0.3.4",
+        "isomorphic-git": "^1.37.5"
+      }
+    },
+    "node_modules/@cloudflare/think": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/think/-/think-0.2.4.tgz",
+      "integrity": "sha512-yBKEprSFbn6+5H3jR7EE/uBf4lQMGxOd2c6IZpMR5fOuaLJH52fXAoGjis9e0/QfmhPEGcarSSNWoxkpJL1lGA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@cloudflare/codemode": ">=0.0.7 <1.0.0",
+        "@cloudflare/shell": ">=0.2.0 <1.0.0",
+        "agents": ">=0.8.7 <1.0.0",
+        "ai": "^6.0.0",
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/codemode": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@cloudflare/unenv-preset": {
       "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
+      "integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
@@ -643,16 +721,16 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.14.6.tgz",
-      "integrity": "sha512-rJzxgJ1tepQEPrJSpCTzZRtl8eZ0Tvpz3HyOwH8QR6TWLPQiYuiD/p/5aVb8OYBTTAj69fwRTYMR5jIA0R6meg==",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.14.7.tgz",
+      "integrity": "sha512-6LooO25358uPn/7U3LUg5f5pLULncDTShGuOf00TyEn3VIBW2otq92dTNf8ScIR3gV9QDztXNfChc4mqPCSBEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cjs-module-lexer": "^1.2.3",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260410.0",
-        "wrangler": "4.82.2",
+        "miniflare": "4.20260415.0",
+        "wrangler": "4.83.0",
         "zod": "^3.25.76"
       },
       "peerDependencies": {
@@ -1137,9 +1215,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260410.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260410.1.tgz",
-      "integrity": "sha512-0sh6xPmCKUfv/lUklP1dfyeKxCuEZGS0HeduxnucL8ECxSgAdWTOD42h/lQTwZCIiWtyHB+ZNB9hsS2Mlf0tMQ==",
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260415.1.tgz",
+      "integrity": "sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg==",
       "cpu": [
         "x64"
       ],
@@ -1154,9 +1232,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260410.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260410.1.tgz",
-      "integrity": "sha512-r2On29gPvlk/eiH/OpeUT23xoB8W8D1PHr8lul5nyxElLqvh3yNxZUnJWrbcOl+ubfrvw7+jFwgopMe17xyf0g==",
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260415.1.tgz",
+      "integrity": "sha512-+JgSgVA49KyKteHRA1SnonE4Zn5Ei5zdAp5FQMxFmXI8qulZw4Hl7safXxRyK4i9sTO8gl7TFOKO5Q64VPvSDQ==",
       "cpu": [
         "arm64"
       ],
@@ -1171,9 +1249,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260410.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260410.1.tgz",
-      "integrity": "sha512-qWORRcAzPZeHJjrcYBNZTN6Y9l+iZQUz4KBdWbNrM6My4CpNrXS5kErPR373vG//5QPaDGwMXgBqyn9xfzarJQ==",
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260415.1.tgz",
+      "integrity": "sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA==",
       "cpu": [
         "x64"
       ],
@@ -1188,9 +1266,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260410.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260410.1.tgz",
-      "integrity": "sha512-jQfuHL4mnGDFyomSS3JNs9TpTvCu6Vzz2QSNCfJRstMzTICUFLMc4Vp/xKK+M5xkb0PoAu/G0hHx7jrxB2j+OQ==",
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260415.1.tgz",
+      "integrity": "sha512-bR9uITnV19r5NQ14xnypi2xHXu2iQvfYV8cVgx0JouFUmWwTEEAwFVojDdssGq93VHX9hr/pi2IRUZeegbYBog==",
       "cpu": [
         "arm64"
       ],
@@ -1205,9 +1283,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260410.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260410.1.tgz",
-      "integrity": "sha512-h8q/nbheDqpknY7AAOz19MuQkZAR1/bnoZnKipyeUPXt5No+y6HlTtva9Bohx5Fhc1MW2CX2MQVdb55qtkkqZQ==",
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260415.1.tgz",
+      "integrity": "sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ==",
       "cpu": [
         "x64"
       ],
@@ -1222,9 +1300,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260413.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260413.1.tgz",
-      "integrity": "sha512-4FFHIVIk645Wf20eCVfe0eM3ERsEw98DFng76QZf1C1JMgIVlfSV2gZF1EyXxNVwOG0RM/CBlu07+u/Z/0Oq9Q==",
+      "version": "4.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260415.1.tgz",
+      "integrity": "sha512-9sEq9cZzr4s075U/TfjvdSmiX+u2NMOAIcFcCfd24FDtPfR7Iw3SbuQxkcgtpx/Bvg0au9PmQ0ZJfBaIitG0gw==",
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@comark/markdown-it": {
@@ -1330,6 +1408,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1346,6 +1425,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1362,6 +1442,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1378,6 +1459,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1411,6 +1493,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1427,6 +1510,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1443,6 +1527,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1459,6 +1544,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1475,6 +1561,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1491,6 +1578,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1507,6 +1595,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1523,6 +1612,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1539,6 +1629,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1555,6 +1646,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1571,6 +1663,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1587,6 +1680,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1603,6 +1697,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1619,6 +1714,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1635,6 +1731,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1651,6 +1748,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1667,6 +1765,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1683,6 +1782,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1699,6 +1799,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1715,6 +1816,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1731,6 +1833,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2260,9 +2363,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2280,9 +2380,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2300,9 +2397,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2320,9 +2414,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2340,9 +2431,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2360,9 +2448,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2380,9 +2465,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2400,9 +2482,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2420,9 +2499,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2446,9 +2522,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2472,9 +2545,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2498,9 +2568,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2524,9 +2591,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2550,9 +2614,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2576,9 +2637,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2602,9 +2660,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3231,9 +3286,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3248,9 +3300,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3265,9 +3314,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3282,9 +3328,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3916,9 +3959,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3936,9 +3976,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3956,9 +3993,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3976,9 +4010,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3996,9 +4027,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4016,9 +4044,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4036,9 +4061,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4056,9 +4078,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4263,9 +4282,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4283,9 +4299,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4303,9 +4316,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4323,9 +4333,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4343,9 +4350,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4363,9 +4367,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4383,9 +4384,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4403,9 +4401,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5036,9 +5031,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5054,9 +5046,6 @@
       "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5074,9 +5063,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5092,9 +5078,6 @@
       "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5112,9 +5095,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5130,9 +5110,6 @@
       "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7840,9 +7817,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7857,9 +7831,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7874,9 +7845,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7891,9 +7859,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7908,9 +7873,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7925,9 +7887,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7942,9 +7901,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7959,9 +7915,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8596,6 +8549,19 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "license": "MIT",
@@ -8631,6 +8597,198 @@
       "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agents": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.11.0.tgz",
+      "integrity": "sha512-FBjTA0G5ejwYMcizqTkX2ONJFXV1vqMM5P0yqOu6r0dWzTmaW84LKQACMava2HkPO4+nVhesW94+kf1E/a+MDw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/plugin-proposal-decorators": "^7.29.0",
+        "@cfworker/json-schema": "^4.1.1",
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "@rolldown/plugin-babel": "^0.2.3",
+        "cron-schedule": "^6.0.0",
+        "json-schema": "^0.4.0",
+        "json-schema-to-typescript": "^15.0.4",
+        "mimetext": "^3.0.28",
+        "nanoid": "^5.1.7",
+        "partyserver": "^0.4.1",
+        "partysocket": "1.1.16",
+        "picomatch": "^4.0.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "agents": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@ai-sdk/react": "^3.0.0",
+        "@cloudflare/ai-chat": "^0.4.2",
+        "@cloudflare/codemode": "^0.3.4",
+        "@tanstack/ai": "^0.10.2",
+        "@x402/core": "^2.0.0",
+        "@x402/evm": "^2.0.0",
+        "ai": "^6.0.0",
+        "react": "^19.0.0",
+        "viem": ">=2.0.0",
+        "vite": ">=6.0.0 <9.0.0",
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/react": {
+          "optional": true
+        },
+        "@cloudflare/ai-chat": {
+          "optional": true
+        },
+        "@cloudflare/codemode": {
+          "optional": true
+        },
+        "@tanstack/ai": {
+          "optional": true
+        },
+        "@x402/core": {
+          "optional": true
+        },
+        "@x402/evm": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agents/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/agents/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/agents/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/agents/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/agents/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/agents/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/agents/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/agents/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/agents/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/ai": {
@@ -8944,6 +9102,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "dev": true,
@@ -8951,7 +9116,6 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -8986,7 +9150,6 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9044,6 +9207,8 @@
     },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true,
       "license": "MIT"
     },
@@ -9207,7 +9372,6 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -9396,6 +9560,13 @@
       "version": "1.4.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/clean-git-ref": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+      "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -9787,6 +9958,19 @@
       "license": "MIT",
       "dependencies": {
         "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cron-schedule": {
@@ -10409,6 +10593,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
@@ -10454,7 +10654,6 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -10559,6 +10758,13 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/diff3": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+      "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dns-equal": {
       "version": "1.0.0",
@@ -10990,7 +11196,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -11035,6 +11241,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11506,10 +11713,30 @@
       "version": "0.0.4",
       "license": "MIT"
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -11870,7 +12097,6 @@
     },
     "node_modules/for-each": {
       "version": "0.3.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -11964,6 +12190,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12276,7 +12503,6 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -12311,7 +12537,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -12468,7 +12693,6 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12688,7 +12912,6 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13072,7 +13295,6 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -13148,12 +13370,89 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "license": "ISC"
+    },
+    "node_modules/isomorphic-git": {
+      "version": "1.37.5",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.37.5.tgz",
+      "integrity": "sha512-wek54c5uFvd3WsxewLWt6h0GXKWQh0P8rRXns9bN1rHNjcgCb3+0lmyAsP594NeTtQFeCJQVS9b0kjbkD1l5qg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "async-lock": "^1.4.1",
+        "clean-git-ref": "^2.0.1",
+        "crc-32": "^1.2.0",
+        "diff3": "0.0.3",
+        "ignore": "^5.1.4",
+        "minimisted": "^2.0.0",
+        "pako": "^1.0.10",
+        "pify": "^4.0.1",
+        "readable-stream": "^4.0.0",
+        "sha.js": "^2.4.12",
+        "simple-get": "^4.0.1"
+      },
+      "bin": {
+        "isogit": "cli.cjs"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/isomorphic-git/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/isomorphic-git/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/isomorphic-git/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -13203,7 +13502,7 @@
     },
     "node_modules/jiti": {
       "version": "2.6.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -13527,6 +13826,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13547,6 +13847,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13567,6 +13868,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13587,6 +13889,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13607,6 +13910,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13627,9 +13931,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13650,9 +13952,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13673,9 +13973,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13696,9 +13994,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13719,6 +14015,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13739,6 +14036,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15057,17 +15355,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/miniflare": {
-      "version": "4.20260410.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260410.0.tgz",
-      "integrity": "sha512-94LEU8d+XPVGp18eW4+bu1v7Tnq7srhqWMIsrx2jhSkdbTnGqg1I613R0GKY4eygBYl9MbqXEhzK/bczJb6uMg==",
+      "version": "4.20260415.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260415.0.tgz",
+      "integrity": "sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
-        "undici": "7.24.4",
-        "workerd": "1.20260410.1",
+        "undici": "7.24.8",
+        "workerd": "1.20260415.1",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10"
       },
@@ -15079,9 +15390,9 @@
       }
     },
     "node_modules/miniflare/node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15106,6 +15417,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimisted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+      "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
       }
     },
     "node_modules/mlly": {
@@ -15850,7 +16171,6 @@
     },
     "node_modules/pako": {
       "version": "1.0.11",
-      "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
@@ -15870,6 +16190,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/partyserver": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.4.1.tgz",
+      "integrity": "sha512-StSs0oY8RmTxjGNil7VbCG4gnTN+4rYX20fiUIItAxTPpr/5rPDZT6PIvMROkk9M1Gn7GzE1wuQXwhxceaGhXA==",
+      "license": "ISC",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20240729.0"
       }
     },
     "node_modules/partysocket": {
@@ -15987,6 +16319,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "license": "MIT",
@@ -16084,7 +16426,6 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -16378,6 +16719,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -17040,7 +17391,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -17168,7 +17518,6 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -17217,6 +17566,27 @@
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "license": "ISC"
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -17401,6 +17771,53 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "dev": true,
@@ -17524,7 +17941,6 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -17884,6 +18300,21 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "dev": true,
@@ -18051,7 +18482,6 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -18263,6 +18693,8 @@
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19176,7 +19608,6 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -19219,9 +19650,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260410.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260410.1.tgz",
-      "integrity": "sha512-T/GRD6Y5vN9g4CnGmOlfST1w7bj+1IjRFvX0K7CodZPJuPVPNPGhz8Wppah0WdT6A7I8Kad3zgZ2OkDdWtENrg==",
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260415.1.tgz",
+      "integrity": "sha512-phyPjRnx+mQDfkhN9ENPioL1L0SdhYs4S0YmJK/xF9Oga+ykNfdSy1MHnsOj8yqnOV96zcVQMx32dJ0r3pq0jQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -19232,25 +19663,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260410.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260410.1",
-        "@cloudflare/workerd-linux-64": "1.20260410.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260410.1",
-        "@cloudflare/workerd-windows-64": "1.20260410.1"
-      }
-    },
-    "node_modules/workers-ai-provider": {
-      "version": "3.1.8",
-      "license": "MIT",
-      "peerDependencies": {
-        "@ai-sdk/provider": "^3.0.0",
-        "ai": "^6.0.0"
+        "@cloudflare/workerd-darwin-64": "1.20260415.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260415.1",
+        "@cloudflare/workerd-linux-64": "1.20260415.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260415.1",
+        "@cloudflare/workerd-windows-64": "1.20260415.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.82.2",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.82.2.tgz",
-      "integrity": "sha512-SKfW21sTJUkM/Qd8zc9oc8TBkAWHRsXuTxE6XdToC55Ct84pR+IfRdaTjCTuC0dL+KYvauSvSn2rtqS2Ae+Dcw==",
+      "version": "4.83.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.83.0.tgz",
+      "integrity": "sha512-gw5g3LCiuAqVWxaoKY6+quE0HzAUEFb/FV3oAlNkE1ttd4XP3FiV91XDkkzUCcdqxS4WjhQvPhIDBNdhEi8P0A==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -19258,10 +19681,10 @@
         "@cloudflare/unenv-preset": "2.16.0",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260410.0",
+        "miniflare": "4.20260415.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260410.1"
+        "workerd": "1.20260415.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -19274,7 +19697,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260410.1"
+        "@cloudflare/workers-types": "^4.20260415.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -19709,6 +20132,8 @@
     },
     "node_modules/wrangler/node_modules/esbuild": {
       "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -19837,7 +20262,7 @@
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -19981,8 +20406,9 @@
     "packages/worker": {
       "name": "@kody/worker",
       "dependencies": {
-        "@cloudflare/ai-chat": "^0.4.2",
+        "@cloudflare/ai-chat": "^0.4.4",
         "@cloudflare/codemode": "^0.3.4",
+        "@cloudflare/think": "^0.2.4",
         "@cloudflare/workers-oauth-provider": "^0.4.0",
         "@epic-web/invariant": "^1.0.0",
         "@kody-internal/shared": "file:../shared",
@@ -19991,10 +20417,10 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "^10.45.0",
         "acorn": "^8.16.0",
-        "agents": "^0.10.1",
+        "agents": "^0.11.0",
         "croner": "^10.0.1",
         "remix": "3.0.0-alpha.3",
-        "workers-ai-provider": "^3.1.2",
+        "workers-ai-provider": "^3.1.11",
         "zod": "^4.3.6"
       }
     },
@@ -20009,36 +20435,6 @@
         "ai": "^6.0.0",
         "react": "^19.0.0",
         "zod": "^4.0.0"
-      }
-    },
-    "packages/worker/node_modules/@cloudflare/codemode": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@cloudflare/codemode/-/codemode-0.3.4.tgz",
-      "integrity": "sha512-GDzPUnEqgp9qBNYvrjoO1iODXtOjWVhbyvVE40TJ/oaYvHsOgsaws4TnIKDM/+JK8uG3S3GAJ2+ixDIEuicIdw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15",
-        "acorn": "^8.16.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.0",
-        "@tanstack/ai": ">=0.8.0 <1.0.0",
-        "ai": "^6.0.0",
-        "zod": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        },
-        "@tanstack/ai": {
-          "optional": true
-        },
-        "ai": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "packages/worker/node_modules/@cloudflare/workers-oauth-provider": {
@@ -20154,18 +20550,6 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
     },
-    "packages/worker/node_modules/partyserver": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.4.1.tgz",
-      "integrity": "sha512-StSs0oY8RmTxjGNil7VbCG4gnTN+4rYX20fiUIItAxTPpr/5rPDZT6PIvMROkk9M1Gn7GzE1wuQXwhxceaGhXA==",
-      "license": "ISC",
-      "dependencies": {
-        "nanoid": "^5.1.6"
-      },
-      "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20240729.0"
-      }
-    },
     "packages/worker/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -20196,6 +20580,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "packages/worker/node_modules/workers-ai-provider": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/workers-ai-provider/-/workers-ai-provider-3.1.11.tgz",
+      "integrity": "sha512-+J2dfbSs3r/DUEzo2buhBuomTrz/kHd063vqz3qsZjZFmnprlE82TLqWfB1jb+AGBCiygQ1J4EimCLy9ZU7QMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@ai-sdk/provider": "^3.0.0",
+        "ai": "^6.0.0"
       }
     },
     "packages/worker/node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -625,8 +625,6 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.4.4.tgz",
       "integrity": "sha512-XYuqT/MPJ9DMgy8PFR1IAgQn8T61kg0ylHgTJFwUB3vBljKgCtfrAxWDMekdu1kTbo1VYdSRfj/v4Cs5xxkKIA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "peerDependencies": {
         "@ai-sdk/react": "^3.0.0",
         "agents": ">=0.8.7 <1.0.0",
@@ -1353,16 +1351,20 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1370,7 +1372,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1402,13 +1406,12 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1419,13 +1422,12 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1436,13 +1438,12 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1453,13 +1454,12 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1487,13 +1487,12 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1504,13 +1503,12 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1521,13 +1519,12 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1538,13 +1535,12 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1555,13 +1551,12 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1572,13 +1567,12 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1589,13 +1583,12 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1606,13 +1599,12 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1623,13 +1615,12 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1640,13 +1631,12 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1657,13 +1647,12 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1674,13 +1663,12 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1691,13 +1679,12 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1708,13 +1695,12 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1725,13 +1711,12 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1742,13 +1727,12 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1759,13 +1743,12 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1776,13 +1759,12 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1793,13 +1775,12 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1810,13 +1791,12 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1827,13 +1807,12 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1900,7 +1879,9 @@
       "peer": true
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1991,7 +1972,9 @@
       "peer": true
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2108,6 +2091,18 @@
         "@opentelemetry/api": "^1.9.0"
       }
     },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz",
+      "integrity": "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
       "version": "0.212.0",
       "license": "Apache-2.0",
@@ -2123,18 +2118,16 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
-      "version": "0.212.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
+    "node_modules/@fastify/otel/node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
-    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation/node_modules/import-in-the-middle": {
+    "node_modules/@fastify/otel/node_modules/import-in-the-middle": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -2142,10 +2135,6 @@
         "cjs-module-lexer": "^2.2.0",
         "module-details-from-path": "^1.0.4"
       }
-    },
-    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation/node_modules/import-in-the-middle/node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
@@ -3070,7 +3059,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/ext-apps": {
-      "version": "1.3.1",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.6.0.tgz",
+      "integrity": "sha512-j80Hv9kSALu7luR+DtoYERlRaehu6cY2wlHEjG3h36C98bbYzA/nxOEvtGhhKd2ssCwC0BG3+gdh7y3sE5m0tQ==",
       "license": "MIT",
       "workspaces": [
         "examples/*"
@@ -3079,7 +3070,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "zod": "^3.25.0 || ^4.0.0"
@@ -3379,7 +3370,9 @@
       "license": "MIT"
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.9.1",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -3825,8 +3818,547 @@
         "@opentelemetry/api": "^1.1.0"
       }
     },
+    "node_modules/@oven/bun-darwin-aarch64": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.3.12.tgz",
+      "integrity": "sha512-b6CQgT28Jx7uDwMTcGo7WFqUd1+wWTdp8XyPi/4LRcL/R4deKT7cLx/Q2ZCWAiK6ZU7yexoCaIaKun6azjRLVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-darwin-x64": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64/-/bun-darwin-x64-1.3.12.tgz",
+      "integrity": "sha512-//6W21c+GinAMMmxD2hFrFmJH+ZlEwJYbLzAGqp0mLFTli9y74RMtDgI2n9pCupXSpU1Kr1sSylVW9yNbAG9Xg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-darwin-x64-baseline": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.3.12.tgz",
+      "integrity": "sha512-9jKJNOc9ID3BxPBPR4r1Mp1Wqde89Twi5zo2LoEMLMKbqpvEM/WUGdJ0Vv7OX1QPEqVblFO6NMky5yY7rjDI2w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-linux-aarch64": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.3.12.tgz",
+      "integrity": "sha512-eTru6tk3K4Ya3SSkUqq/LbdEjwPqLlfINmIhRORrCExBdB1tQbk+WYYflaymO61fkrjnMAjmLTGqk/K37RMIGA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-aarch64-musl": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64-musl/-/bun-linux-aarch64-musl-1.3.12.tgz",
+      "integrity": "sha512-HWIwFzm5fALd9Lli0CgaKb6xOGqODYyHpUTgkn/IHHuS/f3XDCu71+GgkyvfgCYbPoBSgBOfp5TzhRehPcgxow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-1.3.12.tgz",
+      "integrity": "sha512-H75bcEn46lMDxd+P+R6Q/jlIKl/YO0ZXaalSyWhQHr7qNmFhQt3rOHurFoCxuwQeqFoToh0JpWVyMVzByZqgBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-baseline": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.3.12.tgz",
+      "integrity": "sha512-0y+lUiQsPvSGsyM/10KtxhVAQ20p6/D+vj01l6vo9gHpYUpyc1L9pSgaPa7SC9TuaiGASlM3Cb62bmSKW0E/3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-musl": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl/-/bun-linux-x64-musl-1.3.12.tgz",
+      "integrity": "sha512-Zb7T3JxWlArSe44ATO5mtjLCBCt7kenWPl9CYD+zeqq9kHswMv8Cd3h/9uzdv2PA4Flrq57J5XBSuRdStTCXCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-musl-baseline": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl-baseline/-/bun-linux-x64-musl-baseline-1.3.12.tgz",
+      "integrity": "sha512-jdsnuFD3H0l4AHtf1nInRHYWIMTWqok0aW8WysjzN5Isn6rBTBGK/ZWX6XjdTgDgcuVbVOYHiLUHHrvT9N6psA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-windows-x64": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64/-/bun-windows-x64-1.3.12.tgz",
+      "integrity": "sha512-veSntY7pDLDh4XmxZMwTqxfoEVp0BDdeqCBoWL46/TigtniPtDFSTIWBxa6l/RcGzklUA/uqLqmsK/9cBZAm8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oven/bun-windows-x64-baseline": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.3.12.tgz",
+      "integrity": "sha512-rV21md7QWnu3r/shev7IFMh6hX8BJHwofxESAofUT4yH866oCIbcNbzp6+fxrj4oGD8uisP6WoaTCboijv9yYg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.124.0.tgz",
+      "integrity": "sha512-+R9zCafSL8ovjokdPtorUp3sXrh8zQ2AC2L0ivXNvlLR0WS+5WdPkNVrnENq5UvzagM4Xgl0NPsJKz3Hv9+y8g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.124.0.tgz",
+      "integrity": "sha512-ULHC/gVZ+nP4pd3kNNQTYaQ/e066BW/KuY5qUsvwkVWwOUQGDg+WpfyVOmQ4xfxoue6cMlkKkJ+ntdzfDXpNlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.124.0.tgz",
+      "integrity": "sha512-fGJ2hw7bnbUYn6UvTjp0m4WJ9zXz3cohgcwcgeo7gUZehpPNpvcVEVeIVHNmHnAuAw/ysf4YJR8DA1E+xCA4Lw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.124.0.tgz",
+      "integrity": "sha512-j0+re9pgps5BH2Tk3fm59Hi3QuLP3C4KhqXi6A+wRHHHJWDFR8mc/KI9mBrfk2JRT+15doGo+zv1eN75/9DuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.124.0.tgz",
+      "integrity": "sha512-0k5mS0npnrhKy72UfF51lpOZ2ESoPWn6gdFw+RdeRWcokraDW1O2kSx3laQ+yk7cCEavQdJSpWCYS/GvBbUCXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.124.0.tgz",
+      "integrity": "sha512-P/i4eguRWvAUfGdfhQYg1jpwYkyUV6D3gefIH7HhmRl1Ph6P4IqTIEVcyJr1i/3vr1V5OHU4wonH6/ue/Qzvrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.124.0.tgz",
+      "integrity": "sha512-/ameqFQH5fFP+66Atr8Ynv/2rYe4utcU7L4MoWS5JtrFLVO78g4qDLavyIlJxa6caSwYOvG/eO3c/DXqY5/6Rw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.124.0.tgz",
+      "integrity": "sha512-gNeyEcXTtfrRCbj2EfxWU85Fs0wIX3p44Y3twnvuMfkWlLrb9M1Z25AYNSKjJM+fdAjeeQCjw0on47zFuBYwQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.124.0.tgz",
+      "integrity": "sha512-uvG7v4Tz9S8/PVqY0SP0DLHxo4hZGe+Pv2tGVnwcsjKCCUPjplbrFVvDzXq+kOaEoUkiCY0Kt1hlZ6FDJ1LKNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.124.0.tgz",
+      "integrity": "sha512-t7KZaaUhfp2au0MRpoENEFqwLKYDdptEry6V7pTAVdPEcFG4P6ii8yeGU9m6p5vb+b8WEKmdpGMNXBEYy7iJdw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.124.0.tgz",
+      "integrity": "sha512-eurGGaxHZiIQ+fBSageS8TAkRqZgdOiBeqNrWAqAPup9hXBTmQ0WcBjwsLElf+3jvDL9NhnX0dOgOqPfsjSjdg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.124.0.tgz",
+      "integrity": "sha512-d1V7/ll1i/LhqE/gZy6Wbz6evlk0egh2XKkwMI3epiojtbtUwQSLIER0Y3yDBBocPuWOjJdvmjtEmPTTLXje/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.124.0.tgz",
+      "integrity": "sha512-w1+cBvriUteOpox6ATqCFVkpGL47PFdcfCPGmgUZbd78Fw44U0gQkc+kVGvAOTvGrptMYgwomD1c6OTVvkrpGg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.124.0.tgz",
+      "integrity": "sha512-RRB1evQiXRtMCsQQiAh9U0H3HzguLpE0ytfStuhRgmOj7tqUCOVxkHsvM9geZjAax6NqVRj7VXx32qjjkZPsBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.124.0.tgz",
+      "integrity": "sha512-asVYN0qmSHlCU8H9Q47SmeJ/Z5EG4IWCC+QGxkfFboI5qh15aLlJnHmnrV61MwQRPXGnVC/sC3qKhrUyqGxUqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.124.0.tgz",
+      "integrity": "sha512-nhwuxm6B8pn9lzAzMUfa571L5hCXYwQo8C8cx5aGOuHWCzruR8gPJnRRXGBci+uGaIIQEZDyU/U6HDgrSp/JlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.124.0.tgz",
+      "integrity": "sha512-LWuq4Dl9tff7n+HjJcqoBjDlVCtruc0shgtdtGM+rTUIE9aFxHA/P+wCYR+aWMjN8m9vNaRME/sKXErmhmeKrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.124.0.tgz",
+      "integrity": "sha512-aOh3Lf3AeH0dgzT4yBXcArFZ8VhqNXwZ/xlN0GqBtgVaGoHOOqL2YHlcVIgT+ghsXPVR2PTtYgBiQ1CNK7jp5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.124.0.tgz",
+      "integrity": "sha512-sib5xC0nz/+SCpaETBuHBz4SXS02KuG5HtyOcHsO/SK5ZvLRGhOZx0elDKawjb6adFkD7dQCqpXUS25wY6ELKQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.124.0.tgz",
+      "integrity": "sha512-UgojtjGUgZgAZQYt7SC6VO65OVdxEkRe2q+2vbHJO//18qw3Hrk6UvHGQKldsQKgbVcIBT/YBrt85YberiYIPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -4581,6 +5113,18 @@
         "@opentelemetry/api": "^1.8"
       }
     },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
+      "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
       "version": "0.207.0",
       "license": "Apache-2.0",
@@ -4596,18 +5140,16 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
-      "version": "0.207.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
+    "node_modules/@prisma/instrumentation/node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
-    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation/node_modules/import-in-the-middle": {
+    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -4615,10 +5157,6 @@
         "cjs-module-lexer": "^2.2.0",
         "module-details-from-path": "^1.0.4"
       }
-    },
-    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation/node_modules/import-in-the-middle/node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "license": "MIT"
     },
     "node_modules/@quansync/fs": {
       "version": "1.0.0",
@@ -4676,8 +5214,10 @@
         "@remix-run/route-pattern": "^0.20.0"
       }
     },
-    "node_modules/@remix-run/compression-middleware/node_modules/@remix-run/fetch-router/node_modules/@remix-run/route-pattern": {
+    "node_modules/@remix-run/compression-middleware/node_modules/@remix-run/route-pattern": {
       "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/route-pattern/-/route-pattern-0.20.0.tgz",
+      "integrity": "sha512-TEdJ5eFn40St26oyaRYGI1FWeXDvlEzkbvollM8Xit0qIuDFyFG03Okvvfc1s8KgR9sYULDPjxJIzk6xvIRR9A==",
       "license": "MIT"
     },
     "node_modules/@remix-run/cookie": {
@@ -4833,8 +5373,10 @@
         "@remix-run/route-pattern": "^0.20.0"
       }
     },
-    "node_modules/@remix-run/logger-middleware/node_modules/@remix-run/fetch-router/node_modules/@remix-run/route-pattern": {
+    "node_modules/@remix-run/logger-middleware/node_modules/@remix-run/route-pattern": {
       "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/route-pattern/-/route-pattern-0.20.0.tgz",
+      "integrity": "sha512-TEdJ5eFn40St26oyaRYGI1FWeXDvlEzkbvollM8Xit0qIuDFyFG03Okvvfc1s8KgR9sYULDPjxJIzk6xvIRR9A==",
       "license": "MIT"
     },
     "node_modules/@remix-run/method-override-middleware": {
@@ -4851,8 +5393,10 @@
         "@remix-run/route-pattern": "^0.20.0"
       }
     },
-    "node_modules/@remix-run/method-override-middleware/node_modules/@remix-run/fetch-router/node_modules/@remix-run/route-pattern": {
+    "node_modules/@remix-run/method-override-middleware/node_modules/@remix-run/route-pattern": {
       "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/route-pattern/-/route-pattern-0.20.0.tgz",
+      "integrity": "sha512-TEdJ5eFn40St26oyaRYGI1FWeXDvlEzkbvollM8Xit0qIuDFyFG03Okvvfc1s8KgR9sYULDPjxJIzk6xvIRR9A==",
       "license": "MIT"
     },
     "node_modules/@remix-run/mime": {
@@ -4936,8 +5480,10 @@
         "@remix-run/route-pattern": "^0.20.0"
       }
     },
-    "node_modules/@remix-run/static-middleware/node_modules/@remix-run/fetch-router/node_modules/@remix-run/route-pattern": {
+    "node_modules/@remix-run/static-middleware/node_modules/@remix-run/route-pattern": {
       "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/route-pattern/-/route-pattern-0.20.0.tgz",
+      "integrity": "sha512-TEdJ5eFn40St26oyaRYGI1FWeXDvlEzkbvollM8Xit0qIuDFyFG03Okvvfc1s8KgR9sYULDPjxJIzk6xvIRR9A==",
       "license": "MIT"
     },
     "node_modules/@remix-run/tar-parser": {
@@ -4945,9 +5491,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
       "cpu": [
         "arm64"
       ],
@@ -4961,9 +5507,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
       "cpu": [
         "arm64"
       ],
@@ -4977,9 +5523,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
       "cpu": [
         "x64"
       ],
@@ -4993,9 +5539,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
       "cpu": [
         "x64"
       ],
@@ -5009,9 +5555,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
-      "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
       "cpu": [
         "arm"
       ],
@@ -5025,11 +5571,14 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5041,11 +5590,14 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
-      "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5057,11 +5609,14 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5073,11 +5628,14 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5089,11 +5647,14 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5105,11 +5666,14 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
-      "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5121,9 +5685,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
       "cpu": [
         "arm64"
       ],
@@ -5137,25 +5701,27 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
-      "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5181,9 +5747,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
-      "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
       "cpu": [
         "arm64"
       ],
@@ -5197,9 +5763,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
-      "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
       "cpu": [
         "x64"
       ],
@@ -5243,8 +5809,393 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.11",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@sentry/cli": {
       "version": "3.3.4",
@@ -5576,6 +6527,33 @@
         "node": ">=20"
       }
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@shikijs/markdown-it": {
       "version": "4.0.2",
       "dev": true,
@@ -5594,58 +6572,6 @@
         "markdown-it-async": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@shikijs/markdown-it/node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/markdown-it/node_modules/@shikijs/langs": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/markdown-it/node_modules/@shikijs/themes": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/markdown-it/node_modules/shiki": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "4.0.2",
-        "@shikijs/engine-javascript": "4.0.2",
-        "@shikijs/engine-oniguruma": "4.0.2",
-        "@shikijs/langs": "4.0.2",
-        "@shikijs/themes": "4.0.2",
-        "@shikijs/types": "4.0.2",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@shikijs/monaco": {
@@ -5669,6 +6595,19 @@
         "@shikijs/types": "4.0.2",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
       },
       "engines": {
         "node": ">=20"
@@ -5720,58 +6659,6 @@
         "twoslash": "^0.3.6",
         "twoslash-vue": "^0.3.6",
         "vue": "^3.5.29"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/vitepress-twoslash/node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/vitepress-twoslash/node_modules/@shikijs/langs": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/vitepress-twoslash/node_modules/@shikijs/themes": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/vitepress-twoslash/node_modules/shiki": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "4.0.2",
-        "@shikijs/engine-javascript": "4.0.2",
-        "@shikijs/engine-oniguruma": "4.0.2",
-        "@shikijs/langs": "4.0.2",
-        "@shikijs/themes": "4.0.2",
-        "@shikijs/types": "4.0.2",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
       },
       "engines": {
         "node": ">=20"
@@ -5894,40 +6781,6 @@
         }
       }
     },
-    "node_modules/@slidev/cli/node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@slidev/cli/node_modules/@shikijs/langs": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@slidev/cli/node_modules/@shikijs/themes": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/@slidev/cli/node_modules/ansi-regex": {
       "version": "6.2.2",
       "dev": true,
@@ -6018,24 +6871,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@slidev/cli/node_modules/shiki": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "4.0.2",
-        "@shikijs/engine-javascript": "4.0.2",
-        "@shikijs/engine-oniguruma": "4.0.2",
-        "@shikijs/langs": "4.0.2",
-        "@shikijs/themes": "4.0.2",
-        "@shikijs/types": "4.0.2",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@slidev/cli/node_modules/string-width": {
@@ -6340,58 +7175,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/@slidev/client/node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@slidev/client/node_modules/@shikijs/langs": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@slidev/client/node_modules/@shikijs/themes": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@slidev/client/node_modules/shiki": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "4.0.2",
-        "@shikijs/engine-javascript": "4.0.2",
-        "@shikijs/engine-oniguruma": "4.0.2",
-        "@shikijs/langs": "4.0.2",
-        "@shikijs/themes": "4.0.2",
-        "@shikijs/types": "4.0.2",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/@slidev/parser": {
       "version": "52.14.2",
       "dev": true,
@@ -6474,40 +7257,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/@slidev/types/node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@slidev/types/node_modules/@shikijs/langs": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@slidev/types/node_modules/@shikijs/themes": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/@slidev/types/node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "dev": true,
@@ -6548,24 +7297,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@slidev/types/node_modules/shiki": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "4.0.2",
-        "@shikijs/engine-javascript": "4.0.2",
-        "@shikijs/engine-oniguruma": "4.0.2",
-        "@shikijs/langs": "4.0.2",
-        "@shikijs/themes": "4.0.2",
-        "@shikijs/types": "4.0.2",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@slidev/types/node_modules/unplugin-vue-markdown": {
@@ -7075,10 +7806,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/pg": {
@@ -7413,21 +8146,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/@unocss/cli/node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
     "node_modules/@unocss/config": {
       "version": "66.6.8",
       "dev": true,
@@ -7694,21 +8412,6 @@
       },
       "peerDependencies": {
         "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/@unocss/vite/node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
@@ -8600,11 +9303,10 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.11.0.tgz",
-      "integrity": "sha512-FBjTA0G5ejwYMcizqTkX2ONJFXV1vqMM5P0yqOu6r0dWzTmaW84LKQACMava2HkPO4+nVhesW94+kf1E/a+MDw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.11.1.tgz",
+      "integrity": "sha512-d3TKWVaxErMuhmLbqzZj0F2hdAIU3JmnEE75lF7h8Ulw7zaE0s1GYFf1BCUrZ4MX2Qe1V3OYhOtiqUI1qA54Jg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.29.0",
         "@cfworker/json-schema": "^4.1.1",
@@ -8614,7 +9316,7 @@
         "json-schema": "^0.4.0",
         "json-schema-to-typescript": "^15.0.4",
         "mimetext": "^3.0.28",
-        "nanoid": "^5.1.7",
+        "nanoid": "^5.1.9",
         "partyserver": "^0.4.1",
         "partysocket": "1.1.16",
         "picomatch": "^4.0.4",
@@ -8625,8 +9327,8 @@
       },
       "peerDependencies": {
         "@ai-sdk/react": "^3.0.0",
-        "@cloudflare/ai-chat": "^0.4.2",
-        "@cloudflare/codemode": "^0.3.4",
+        "@cloudflare/ai-chat": ">=0.0.8 <1.0.0",
+        "@cloudflare/codemode": ">=0.0.7 <1.0.0",
         "@tanstack/ai": "^0.10.2",
         "@x402/core": "^2.0.0",
         "@x402/evm": "^2.0.0",
@@ -8668,7 +9370,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8681,7 +9382,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8694,7 +9394,6 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
       "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "string-width": "^7.2.0",
         "strip-ansi": "^7.1.0",
@@ -8708,15 +9407,13 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/agents/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -8734,7 +9431,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.2.2"
       },
@@ -8750,7 +9446,6 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "string-width": "^7.0.0",
@@ -8768,7 +9463,6 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
       "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cliui": "^9.0.1",
         "escalade": "^3.1.1",
@@ -8786,7 +9480,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
@@ -8806,14 +9499,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/ai/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -10390,11 +11075,6 @@
         "d3-path": "1"
       }
     },
-    "node_modules/d3-sankey/node_modules/internmap": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "dev": true,
@@ -10859,7 +11539,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -10880,7 +11562,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -10904,7 +11588,9 @@
       }
     },
     "node_modules/dotenv-expand/node_modules/dotenv": {
-      "version": "16.4.7",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -11195,8 +11881,10 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "dev": true,
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -11206,42 +11894,41 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11426,7 +12113,9 @@
       }
     },
     "node_modules/eslint-plugin-playwright/node_modules/globals": {
-      "version": "17.4.0",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11478,6 +12167,24 @@
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
+    "node_modules/eslint-plugin-react/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-react/node_modules/minimatch": {
       "version": "3.1.5",
       "dev": true,
@@ -11488,20 +12195,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/eslint-plugin-react/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/semver": {
       "version": "6.3.1",
@@ -11570,12 +12263,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/eslint/node_modules/ajv/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/eslint/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
@@ -11583,7 +12270,9 @@
       "peer": true
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -11612,6 +12301,14 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.5",
@@ -11961,6 +12658,23 @@
         "minimatch": "^5.0.1"
       }
     },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/filelist/node_modules/minimatch": {
       "version": "5.1.9",
       "dev": true,
@@ -11971,19 +12685,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/filelist/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -12123,6 +12824,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/form-data/node_modules/mime-types": {
       "version": "2.1.35",
       "dev": true,
@@ -12130,14 +12841,6 @@
       "dependencies": {
         "mime-db": "1.52.0"
       },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types/node_modules/mime-db": {
-      "version": "1.52.0",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -12190,7 +12893,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12609,7 +13311,9 @@
       }
     },
     "node_modules/hookable": {
-      "version": "6.1.0",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12753,7 +13457,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "3.0.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -12804,12 +13510,11 @@
       }
     },
     "node_modules/internmap": {
-      "version": "2.0.3",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
       "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -13502,7 +14207,7 @@
     },
     "node_modules/jiti": {
       "version": "2.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -13826,7 +14531,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13847,7 +14551,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13868,7 +14571,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13889,7 +14591,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13910,7 +14611,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13931,7 +14631,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13952,7 +14651,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13973,7 +14671,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13994,7 +14691,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14015,7 +14711,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14036,7 +14731,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15319,19 +16013,21 @@
         "url": "https://patreon.com/muratgozel"
       }
     },
+    "node_modules/mimetext/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimetext/node_modules/mime-types": {
       "version": "2.1.35",
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimetext/node_modules/mime-types/node_modules/mime-db": {
-      "version": "1.52.0",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -15569,7 +16265,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.1.7",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
+      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
       "funding": [
         {
           "type": "github",
@@ -16021,14 +16719,6 @@
         "@oxc-parser/binding-win32-arm64-msvc": "0.124.0",
         "@oxc-parser/binding-win32-ia32-msvc": "0.124.0",
         "@oxc-parser/binding-win32-x64-msvc": "0.124.0"
-      }
-    },
-    "node_modules/oxc-parser/node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/oxc-walker": {
@@ -17219,11 +17909,13 @@
       "license": "Unlicense"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.11",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.11"
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -17232,21 +17924,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.11",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
     "node_modules/rollup": {
@@ -17318,7 +18010,9 @@
       }
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -17659,6 +18353,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/shiki-magic-move": {
@@ -18249,11 +18963,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -18680,7 +19396,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.1",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18688,7 +19406,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -19106,14 +19826,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.2",
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.11",
+        "rolldown": "1.0.0-rc.15",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -19131,7 +19853,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -20262,7 +20984,7 @@
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -20417,24 +21139,11 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "^10.45.0",
         "acorn": "^8.16.0",
-        "agents": "^0.11.0",
+        "agents": "^0.11.1",
         "croner": "^10.0.1",
         "remix": "3.0.0-alpha.3",
         "workers-ai-provider": "^3.1.11",
         "zod": "^4.3.6"
-      }
-    },
-    "packages/worker/node_modules/@cloudflare/ai-chat": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.4.2.tgz",
-      "integrity": "sha512-XYuS+ItVGV5j9ryrUg7RJXVZHcCHm97g+x4sWzko3TeT83KCQwQQ/4kXDvvY7D7X8gkv81P0tzovCsWXMiYXHQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@ai-sdk/react": "^3.0.0",
-        "agents": "^0.10.1",
-        "ai": "^6.0.0",
-        "react": "^19.0.0",
-        "zod": "^4.0.0"
       }
     },
     "packages/worker/node_modules/@cloudflare/workers-oauth-provider": {
@@ -20442,145 +21151,6 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.4.0.tgz",
       "integrity": "sha512-UtbV8hjC2NloB+Ds6J6v/9HiG8rx8MbdeYGCyFwOACT5vANWzDL6SKo3W5UZymsXiameAgC7jAmtUx4cc+Qpaw==",
       "license": "MIT"
-    },
-    "packages/worker/node_modules/agents": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.10.2.tgz",
-      "integrity": "sha512-zltFKKENDClZgIJB7aRneI8tRpnCbMbP4RGPh4t8OgqKHomxUNZJEqMrjcgwP/0FX1W9GGrrLJVo9Ez2ibHVvA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-proposal-decorators": "^7.29.0",
-        "@cfworker/json-schema": "^4.1.1",
-        "@modelcontextprotocol/sdk": "1.29.0",
-        "@rolldown/plugin-babel": "^0.2.3",
-        "cron-schedule": "^6.0.0",
-        "json-schema": "^0.4.0",
-        "json-schema-to-typescript": "^15.0.4",
-        "mimetext": "^3.0.28",
-        "nanoid": "^5.1.7",
-        "partyserver": "^0.4.1",
-        "partysocket": "1.1.16",
-        "picomatch": "^4.0.4",
-        "yargs": "^18.0.0"
-      },
-      "bin": {
-        "agents": "dist/cli/index.js"
-      },
-      "peerDependencies": {
-        "@ai-sdk/openai": "^3.0.0",
-        "@ai-sdk/react": "^3.0.0",
-        "@cloudflare/ai-chat": "^0.4.2",
-        "@cloudflare/codemode": "^0.3.4",
-        "@x402/core": "^2.0.0",
-        "@x402/evm": "^2.0.0",
-        "ai": "^6.0.0",
-        "react": "^19.0.0",
-        "viem": ">=2.0.0",
-        "vite": ">=6.0.0 <9.0.0",
-        "zod": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@ai-sdk/openai": {
-          "optional": true
-        },
-        "@ai-sdk/react": {
-          "optional": true
-        },
-        "@cloudflare/ai-chat": {
-          "optional": true
-        },
-        "@cloudflare/codemode": {
-          "optional": true
-        },
-        "@x402/core": {
-          "optional": true
-        },
-        "@x402/evm": {
-          "optional": true
-        },
-        "viem": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "packages/worker/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "packages/worker/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "packages/worker/node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "packages/worker/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
-    },
-    "packages/worker/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/worker/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
     },
     "packages/worker/node_modules/workers-ai-provider": {
       "version": "3.1.11",
@@ -20590,49 +21160,6 @@
       "peerDependencies": {
         "@ai-sdk/provider": "^3.0.0",
         "ai": "^6.0.0"
-      }
-    },
-    "packages/worker/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "packages/worker/node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^9.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "packages/worker/node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "license": "ISC",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -60,11 +60,11 @@
     "dev:talks": "npm --prefix docs/talks/kody-mcp-runtime run dev"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.14.7",
+    "@cloudflare/workers-types": "^4.20260415.1",
+    "@epic-web/config": "^1.24.1",
     "@kody-internal/shared": "file:packages/shared",
     "@modelcontextprotocol/sdk": "1.29.0",
-    "@cloudflare/vitest-pool-workers": "^0.14.5",
-    "@cloudflare/workers-types": "^4.20260413.1",
-    "@epic-web/config": "^1.24.1",
     "@playwright/test": "^1.58.2",
     "@sentry/cli": "^3.3.3",
     "@types/node": "^25.5.0",
@@ -81,7 +81,7 @@
     "set-cookie-parser": "^3.0.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.1",
-    "wrangler": "^4.82.1"
+    "wrangler": "^4.83.0"
   },
   "overrides": {
     "@modelcontextprotocol/sdk": "1.29.0"

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -6,8 +6,9 @@
     "./*": "./src/*"
   },
   "dependencies": {
-    "@cloudflare/ai-chat": "^0.4.2",
+    "@cloudflare/ai-chat": "^0.4.4",
     "@cloudflare/codemode": "^0.3.4",
+    "@cloudflare/think": "^0.2.4",
     "@cloudflare/workers-oauth-provider": "^0.4.0",
     "@epic-web/invariant": "^1.0.0",
     "@kody-internal/shared": "file:../shared",
@@ -16,10 +17,10 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "^10.45.0",
     "acorn": "^8.16.0",
-    "agents": "^0.10.1",
+    "agents": "^0.11.0",
     "croner": "^10.0.1",
     "remix": "3.0.0-alpha.3",
-    "workers-ai-provider": "^3.1.2",
+    "workers-ai-provider": "^3.1.11",
     "zod": "^4.3.6"
   },
   "imports": {

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -17,7 +17,7 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "^10.45.0",
     "acorn": "^8.16.0",
-    "agents": "^0.11.0",
+    "agents": "^0.11.1",
     "croner": "^10.0.1",
     "remix": "3.0.0-alpha.3",
     "workers-ai-provider": "^3.1.11",

--- a/packages/worker/src/agent-turn/api.ts
+++ b/packages/worker/src/agent-turn/api.ts
@@ -1,0 +1,67 @@
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import {
+	cancelAgentTurnRun,
+	nextAgentTurnRunEvent,
+	startAgentTurnRun,
+} from './service.ts'
+import { type AgentTurnToolInput, type AgentTurnStreamEvent } from './types.ts'
+
+export async function beginAgentTurn(input: {
+	env: Env
+	callerContext: McpCallerContext
+	turn: AgentTurnToolInput
+}) {
+	return startAgentTurnRun({
+		env: input.env,
+		sessionId: input.turn.sessionId,
+		callerContext: input.callerContext,
+		turn: input.turn,
+	})
+}
+
+export async function collectAgentTurnEvents(input: {
+	env: Env
+	sessionId: string
+	runId: string
+	waitMs?: number
+}) {
+	let cursor = 0
+	const allEvents: Array<AgentTurnStreamEvent> = []
+	let done = false
+	while (!done) {
+		const next = await nextAgentTurnRunEvent({
+			env: input.env,
+			sessionId: input.sessionId,
+			runId: input.runId,
+			cursor,
+			waitMs: input.waitMs,
+		})
+		cursor = next.nextCursor
+		allEvents.push(...(next.events as Array<AgentTurnStreamEvent>))
+		done = next.done
+	}
+	return allEvents
+}
+
+export async function readNextAgentTurnEvents(input: {
+	env: Env
+	sessionId: string
+	runId: string
+	cursor: number
+	waitMs?: number
+}) {
+	const next = await nextAgentTurnRunEvent(input)
+	return {
+		events: next.events as Array<AgentTurnStreamEvent>,
+		nextCursor: next.nextCursor,
+		done: next.done,
+	}
+}
+
+export async function cancelAgentTurn(input: {
+	env: Env
+	sessionId: string
+	runId: string
+}) {
+	return cancelAgentTurnRun(input)
+}

--- a/packages/worker/src/agent-turn/runner-do.node.test.ts
+++ b/packages/worker/src/agent-turn/runner-do.node.test.ts
@@ -1,0 +1,156 @@
+import { expect, test, vi } from 'vitest'
+
+const persistedStateKey = 'agent-turn-runner-state'
+const interruptedOnRestoreMessage =
+	'Agent turn was interrupted when the Durable Object restarted. Start a new run to continue.'
+
+const mockModule = vi.hoisted(() => ({
+	runAgentTurn: vi.fn(),
+}))
+
+vi.mock('@sentry/cloudflare', () => ({
+	instrumentDurableObjectWithSentry: (
+		_getOptions: unknown,
+		durableObjectClass: unknown,
+	) => durableObjectClass,
+}))
+
+vi.mock('cloudflare:workers', () => ({
+	DurableObject: class {
+		protected readonly ctx: DurableObjectState
+		protected readonly env: Env
+
+		constructor(ctx: DurableObjectState, env: Env) {
+			this.ctx = ctx
+			this.env = env
+		}
+	},
+}))
+
+vi.mock('./runner.ts', () => ({
+	runAgentTurn: (...args: Array<unknown>) => mockModule.runAgentTurn(...args),
+}))
+
+const { AgentTurnRunnerBase } = await import('./runner-do.ts')
+
+function createCallerContext() {
+	return {
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+		homeConnectorId: null,
+		remoteConnectors: null,
+		storageContext: null,
+	}
+}
+
+function createState(persistedState: unknown) {
+	const persistedEntries = new Map<string, unknown>([
+		[persistedStateKey, structuredClone(persistedState)],
+	])
+	let blocked = Promise.resolve()
+	const state = {
+		storage: {
+			get: vi.fn(async (key: string) =>
+				structuredClone(persistedEntries.get(key)),
+			),
+			put: vi.fn(async (key: string, value: unknown) => {
+				persistedEntries.set(key, structuredClone(value))
+			}),
+		},
+		blockConcurrencyWhile: vi.fn((callback: () => Promise<unknown>) => {
+			blocked = Promise.resolve().then(callback)
+			return blocked
+		}),
+	}
+	return {
+		state: state as unknown as DurableObjectState,
+		persistedEntries,
+		async waitUntilReady() {
+			await blocked
+		},
+	}
+}
+
+test('restored in-progress runs are finalized as interrupted instead of replayed', async () => {
+	const persistedState = {
+		activeRun: {
+			runId: 'run-123',
+			createdAt: '2026-04-16T00:00:00.000Z',
+			cancelled: false,
+			events: [{ type: 'assistant_delta', text: 'partial output' }],
+			done: false,
+			finalResult: null,
+			input: {
+				callerContext: createCallerContext(),
+				turn: {
+					sessionId: 'session-123',
+					conversationId: 'conversation-123',
+					system: 'system',
+					messages: [{ role: 'user', content: 'hello' }],
+				},
+			},
+		},
+	}
+	const { state, persistedEntries, waitUntilReady } =
+		createState(persistedState)
+
+	const runner = new AgentTurnRunnerBase(state, {} as Env)
+	await waitUntilReady()
+
+	expect(mockModule.runAgentTurn).not.toHaveBeenCalled()
+
+	const response = await runner.fetch(
+		new Request('https://agent-turn.internal/next', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				runId: 'run-123',
+				cursor: 0,
+				waitMs: 0,
+			}),
+		}),
+	)
+
+	expect(await response.json()).toEqual({
+		ok: true,
+		events: [
+			{ type: 'assistant_delta', text: 'partial output' },
+			{
+				type: 'error',
+				message: interruptedOnRestoreMessage,
+				phase: 'restore',
+			},
+		],
+		nextCursor: 2,
+		done: true,
+	})
+
+	expect(persistedEntries.get(persistedStateKey)).toEqual({
+		activeRun: {
+			runId: 'run-123',
+			createdAt: '2026-04-16T00:00:00.000Z',
+			cancelled: false,
+			events: [
+				{ type: 'assistant_delta', text: 'partial output' },
+				{
+					type: 'error',
+					message: interruptedOnRestoreMessage,
+					phase: 'restore',
+				},
+			],
+			done: true,
+			finalResult: null,
+			input: {
+				callerContext: createCallerContext(),
+				turn: {
+					sessionId: 'session-123',
+					conversationId: 'conversation-123',
+					system: 'system',
+					messages: [{ role: 'user', content: 'hello' }],
+				},
+			},
+		},
+	})
+})

--- a/packages/worker/src/agent-turn/runner-do.node.test.ts
+++ b/packages/worker/src/agent-turn/runner-do.node.test.ts
@@ -154,3 +154,78 @@ test('restored in-progress runs are finalized as interrupted instead of replayed
 		},
 	})
 })
+
+test('executeRun suppresses completion rejection when cancellation returns early', async () => {
+	const { state, waitUntilReady } = createState({ activeRun: null })
+	const runner = new AgentTurnRunnerBase(state, {} as Env)
+	await waitUntilReady()
+
+	const callerContext = createCallerContext()
+	const turn = {
+		sessionId: 'session-123',
+		conversationId: 'conversation-123',
+		system: 'system',
+		messages: [{ role: 'user', content: 'hello' }],
+	}
+	let rejectCompletion: ((error: unknown) => void) | null = null
+	const completion = new Promise<never>((_resolve, reject) => {
+		rejectCompletion = reject
+	})
+	const completionWithSpy = completion as Promise<never> & {
+		catch: typeof completion.catch
+	}
+	const originalCatch = completionWithSpy.catch.bind(completionWithSpy)
+	let catchCalls = 0
+	completionWithSpy.catch = ((onRejected) => {
+		catchCalls += 1
+		return originalCatch(onRejected)
+	}) as typeof completion.catch
+
+	mockModule.runAgentTurn.mockResolvedValueOnce({
+		conversationId: 'conversation-123',
+		events: (async function* () {
+			yield { type: 'assistant_delta', text: 'partial output' } as const
+		})(),
+		completion: completionWithSpy,
+	})
+
+	;(
+		runner as unknown as { stateSnapshot: { activeRun: unknown } }
+	).stateSnapshot = {
+		activeRun: {
+			runId: 'run-123',
+			createdAt: '2026-04-16T00:00:00.000Z',
+			cancelled: true,
+			events: [],
+			done: false,
+			finalResult: null,
+			input: {
+				callerContext,
+				turn,
+			},
+		},
+	}
+
+	await (
+		runner as unknown as {
+			executeRun(input: {
+				runId: string
+				callerContext: ReturnType<typeof createCallerContext>
+				turn: typeof turn
+			}): Promise<void>
+		}
+	).executeRun({
+		runId: 'run-123',
+		callerContext,
+		turn,
+	})
+
+	expect(catchCalls).toBe(1)
+	expect(
+		(runner as unknown as { activeAbortController: AbortController | null })
+			.activeAbortController,
+	).toBe(null)
+
+	rejectCompletion?.(new Error('cancelled'))
+	await Promise.resolve()
+})

--- a/packages/worker/src/agent-turn/runner-do.ts
+++ b/packages/worker/src/agent-turn/runner-do.ts
@@ -126,12 +126,32 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 
 		const abortController = new AbortController()
 
-		const { events, completion } = await runAgentTurn({
-			env: this.env,
-			callerContext: input.callerContext,
-			turn: input.turn,
-			abortSignal: abortController.signal,
-		})
+		const recordRunError = async (error: unknown) => {
+			const currentRun = this.stateSnapshot.activeRun
+			if (!currentRun || currentRun.runId !== input.runId) return
+			currentRun.events.push({
+				type: 'error',
+				message: error instanceof Error ? error.message : String(error),
+				phase: 'runner',
+			})
+			currentRun.done = true
+			await this.persistState()
+			this.notifyWaiters()
+		}
+
+		let events: ReturnType<typeof runAgentTurn>['events']
+		let completion: ReturnType<typeof runAgentTurn>['completion']
+		try {
+			;({ events, completion } = await runAgentTurn({
+				env: this.env,
+				callerContext: input.callerContext,
+				turn: input.turn,
+				abortSignal: abortController.signal,
+			}))
+		} catch (error) {
+			await recordRunError(error)
+			return
+		}
 
 		const consume = (async () => {
 			try {
@@ -155,16 +175,7 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 				await this.persistState()
 				this.notifyWaiters()
 			} catch (error) {
-				const currentRun = this.stateSnapshot.activeRun
-				if (!currentRun || currentRun.runId !== input.runId) return
-				currentRun.events.push({
-					type: 'error',
-					message: error instanceof Error ? error.message : String(error),
-					phase: 'runner',
-				})
-				currentRun.done = true
-				await this.persistState()
-				this.notifyWaiters()
+				await recordRunError(error)
 			}
 		})()
 

--- a/packages/worker/src/agent-turn/runner-do.ts
+++ b/packages/worker/src/agent-turn/runner-do.ts
@@ -1,0 +1,227 @@
+import * as Sentry from '@sentry/cloudflare'
+import { DurableObject } from 'cloudflare:workers'
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import {
+	type AgentTurnInput,
+	type AgentTurnResult,
+	type AgentTurnStreamEvent,
+} from './types.ts'
+import { runAgentTurn } from './runner.ts'
+import { buildSentryOptions } from '#worker/sentry-options.ts'
+
+type ActiveRunState = {
+	runId: string
+	createdAt: string
+	cancelled: boolean
+	events: Array<AgentTurnStreamEvent>
+	done: boolean
+	finalResult: AgentTurnResult | null
+}
+
+type PersistedState = {
+	activeRun: ActiveRunState | null
+}
+
+const persistedStateKey = 'agent-turn-runner-state'
+
+type StartRequestBody = {
+	callerContext: McpCallerContext
+	turn: AgentTurnInput
+}
+
+type NextRequestBody = {
+	runId: string
+	cursor: number
+	waitMs: number
+}
+
+type CancelRequestBody = {
+	runId: string
+}
+
+class AgentTurnRunnerBase extends DurableObject<Env> {
+	private stateSnapshot: PersistedState = {
+		activeRun: null,
+	}
+
+	private waiters = new Set<() => void>()
+
+	constructor(state: DurableObjectState, env: Env) {
+		super(state, env)
+		void this.restoreState()
+	}
+
+	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url)
+		if (request.method === 'POST' && url.pathname === '/start') {
+			const body = (await request.json()) as StartRequestBody
+			return this.handleStart(body)
+		}
+		if (request.method === 'POST' && url.pathname === '/next') {
+			const body = (await request.json()) as NextRequestBody
+			return this.handleNext(body)
+		}
+		if (request.method === 'POST' && url.pathname === '/cancel') {
+			const body = (await request.json()) as CancelRequestBody
+			return this.handleCancel(body)
+		}
+		return Response.json({ ok: false, error: 'Not found.' }, { status: 404 })
+	}
+
+	private async restoreState() {
+		const persisted =
+			(await this.ctx.storage.get<PersistedState>(persistedStateKey)) ?? null
+		if (persisted) this.stateSnapshot = persisted
+	}
+
+	private async persistState() {
+		await this.ctx.storage.put(persistedStateKey, this.stateSnapshot)
+	}
+
+	private notifyWaiters() {
+		for (const waiter of this.waiters) waiter()
+		this.waiters.clear()
+	}
+
+	private async handleStart(body: StartRequestBody) {
+		const runId = crypto.randomUUID()
+		const run: ActiveRunState = {
+			runId,
+			createdAt: new Date().toISOString(),
+			cancelled: false,
+			events: [],
+			done: false,
+			finalResult: null,
+		}
+		this.stateSnapshot.activeRun = run
+		await this.persistState()
+
+		void this.executeRun({
+			runId,
+			callerContext: body.callerContext,
+			turn: body.turn,
+		})
+
+		return Response.json({
+			ok: true,
+			runId,
+			conversationId: body.turn.conversationId ?? null,
+		})
+	}
+
+	private async executeRun(input: {
+		runId: string
+		callerContext: McpCallerContext
+		turn: AgentTurnInput
+	}) {
+		const run = this.stateSnapshot.activeRun
+		if (!run || run.runId !== input.runId) return
+
+		const abortController = new AbortController()
+
+		const { events, completion } = await runAgentTurn({
+			env: this.env,
+			callerContext: input.callerContext,
+			turn: input.turn,
+			abortSignal: abortController.signal,
+		})
+
+		const consume = (async () => {
+			try {
+				for await (const event of events) {
+					const currentRun = this.stateSnapshot.activeRun
+					if (!currentRun || currentRun.runId !== input.runId) return
+					if (currentRun.cancelled) {
+						abortController.abort('cancelled')
+						return
+					}
+					currentRun.events.push(event)
+					await this.persistState()
+					this.notifyWaiters()
+				}
+
+				const finalResult = await completion
+				const currentRun = this.stateSnapshot.activeRun
+				if (!currentRun || currentRun.runId !== input.runId) return
+				currentRun.finalResult = finalResult
+				currentRun.done = true
+				await this.persistState()
+				this.notifyWaiters()
+			} catch (error) {
+				const currentRun = this.stateSnapshot.activeRun
+				if (!currentRun || currentRun.runId !== input.runId) return
+				currentRun.events.push({
+					type: 'error',
+					message: error instanceof Error ? error.message : String(error),
+					phase: 'runner',
+				})
+				currentRun.done = true
+				await this.persistState()
+				this.notifyWaiters()
+			}
+		})()
+
+		await consume
+	}
+
+	private async waitForChange(waitMs: number) {
+		if (waitMs <= 0) return
+		await Promise.race([
+			new Promise<void>((resolve) => {
+				this.waiters.add(resolve)
+			}),
+			scheduler.wait(waitMs),
+		])
+	}
+
+	private async handleNext(body: NextRequestBody) {
+		let run = this.stateSnapshot.activeRun
+		if (!run || run.runId !== body.runId) {
+			return Response.json({
+				ok: true,
+				events: [],
+				nextCursor: body.cursor,
+				done: true,
+			})
+		}
+
+		if (body.cursor >= run.events.length && !run.done) {
+			await this.waitForChange(body.waitMs)
+			run = this.stateSnapshot.activeRun
+		}
+
+		if (!run || run.runId !== body.runId) {
+			return Response.json({
+				ok: true,
+				events: [],
+				nextCursor: body.cursor,
+				done: true,
+			})
+		}
+
+		const events = run.events.slice(body.cursor)
+		return Response.json({
+			ok: true,
+			events,
+			nextCursor: body.cursor + events.length,
+			done: run.done,
+		})
+	}
+
+	private async handleCancel(body: CancelRequestBody) {
+		const run = this.stateSnapshot.activeRun
+		if (!run || run.runId !== body.runId) {
+			return Response.json({ ok: true, cancelled: false })
+		}
+		run.cancelled = true
+		run.done = true
+		await this.persistState()
+		this.notifyWaiters()
+		return Response.json({ ok: true, cancelled: true })
+	}
+}
+
+export const AgentTurnRunner = Sentry.instrumentDurableObjectWithSentry(
+	(env: Env) => buildSentryOptions(env),
+	AgentTurnRunnerBase,
+)

--- a/packages/worker/src/agent-turn/runner-do.ts
+++ b/packages/worker/src/agent-turn/runner-do.ts
@@ -6,6 +6,7 @@ import {
 	type AgentTurnResult,
 	type AgentTurnStreamEvent,
 } from './types.ts'
+import { resolveConversationId } from '#mcp/tools/tool-call-context.ts'
 import { runAgentTurn } from './runner.ts'
 import { buildSentryOptions } from '#worker/sentry-options.ts'
 
@@ -48,7 +49,9 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 
 	constructor(state: DurableObjectState, env: Env) {
 		super(state, env)
-		void this.restoreState()
+		state.blockConcurrencyWhile(async () => {
+			await this.restoreState()
+		})
 	}
 
 	async fetch(request: Request): Promise<Response> {
@@ -85,6 +88,7 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 
 	private async handleStart(body: StartRequestBody) {
 		const runId = crypto.randomUUID()
+		const conversationId = resolveConversationId(body.turn.conversationId)
 		const run: ActiveRunState = {
 			runId,
 			createdAt: new Date().toISOString(),
@@ -99,13 +103,16 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 		void this.executeRun({
 			runId,
 			callerContext: body.callerContext,
-			turn: body.turn,
+			turn: {
+				...body.turn,
+				conversationId,
+			},
 		})
 
 		return Response.json({
 			ok: true,
 			runId,
-			conversationId: body.turn.conversationId ?? null,
+			conversationId,
 		})
 	}
 

--- a/packages/worker/src/agent-turn/runner-do.ts
+++ b/packages/worker/src/agent-turn/runner-do.ts
@@ -200,11 +200,18 @@ export class AgentTurnRunnerBase extends DurableObject<Env> {
 		}
 
 		const consume = (async () => {
+			const suppressCompletionRejection = () => {
+				void completion.catch(() => {})
+			}
 			try {
 				for await (const event of events) {
 					const currentRun = this.stateSnapshot.activeRun
-					if (!currentRun || currentRun.runId !== input.runId) return
+					if (!currentRun || currentRun.runId !== input.runId) {
+						suppressCompletionRejection()
+						return
+					}
 					if (currentRun.cancelled) {
+						suppressCompletionRejection()
 						abortController.abort('cancelled')
 						return
 					}
@@ -220,11 +227,12 @@ export class AgentTurnRunnerBase extends DurableObject<Env> {
 				currentRun.done = true
 				await this.persistState()
 				this.notifyWaiters()
+			} catch (error) {
+				await recordRunError(error)
+			} finally {
 				if (this.activeAbortController === abortController) {
 					this.activeAbortController = null
 				}
-			} catch (error) {
-				await recordRunError(error)
 			}
 		})()
 

--- a/packages/worker/src/agent-turn/runner-do.ts
+++ b/packages/worker/src/agent-turn/runner-do.ts
@@ -25,6 +25,8 @@ type PersistedState = {
 }
 
 const persistedStateKey = 'agent-turn-runner-state'
+const interruptedOnRestoreMessage =
+	'Agent turn was interrupted when the Durable Object restarted. Start a new run to continue.'
 
 type StartRequestBody = {
 	callerContext: McpCallerContext
@@ -41,7 +43,23 @@ type CancelRequestBody = {
 	runId: string
 }
 
-class AgentTurnRunnerBase extends DurableObject<Env> {
+function markRunInterruptedOnRestore(run: ActiveRunState): ActiveRunState {
+	return {
+		...run,
+		done: true,
+		finalResult: null,
+		events: [
+			...run.events,
+			{
+				type: 'error',
+				message: interruptedOnRestoreMessage,
+				phase: 'restore',
+			},
+		],
+	}
+}
+
+export class AgentTurnRunnerBase extends DurableObject<Env> {
 	private stateSnapshot: PersistedState = {
 		activeRun: null,
 	}
@@ -78,14 +96,12 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 			(await this.ctx.storage.get<PersistedState>(persistedStateKey)) ?? null
 		if (persisted) this.stateSnapshot = persisted
 		if (this.stateSnapshot.activeRun && !this.stateSnapshot.activeRun.done) {
-			this.stateSnapshot.activeRun.events = []
-			this.stateSnapshot.activeRun.finalResult = null
+			// A restarted DO cannot safely resume in-flight model/tool work without
+			// risking duplicate external side effects, so fail closed instead.
+			this.stateSnapshot.activeRun = markRunInterruptedOnRestore(
+				this.stateSnapshot.activeRun,
+			)
 			await this.persistState()
-			void this.executeRun({
-				runId: this.stateSnapshot.activeRun.runId,
-				callerContext: this.stateSnapshot.activeRun.input.callerContext,
-				turn: this.stateSnapshot.activeRun.input.turn,
-			})
 		}
 	}
 

--- a/packages/worker/src/agent-turn/runner-do.ts
+++ b/packages/worker/src/agent-turn/runner-do.ts
@@ -78,6 +78,9 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 			(await this.ctx.storage.get<PersistedState>(persistedStateKey)) ?? null
 		if (persisted) this.stateSnapshot = persisted
 		if (this.stateSnapshot.activeRun && !this.stateSnapshot.activeRun.done) {
+			this.stateSnapshot.activeRun.events = []
+			this.stateSnapshot.activeRun.finalResult = null
+			await this.persistState()
 			void this.executeRun({
 				runId: this.stateSnapshot.activeRun.runId,
 				callerContext: this.stateSnapshot.activeRun.input.callerContext,

--- a/packages/worker/src/agent-turn/runner-do.ts
+++ b/packages/worker/src/agent-turn/runner-do.ts
@@ -17,6 +17,7 @@ type ActiveRunState = {
 	events: Array<AgentTurnStreamEvent>
 	done: boolean
 	finalResult: AgentTurnResult | null
+	input: StartRequestBody
 }
 
 type PersistedState = {
@@ -46,6 +47,7 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 	}
 
 	private waiters = new Set<() => void>()
+	private activeAbortController: AbortController | null = null
 
 	constructor(state: DurableObjectState, env: Env) {
 		super(state, env)
@@ -75,6 +77,13 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 		const persisted =
 			(await this.ctx.storage.get<PersistedState>(persistedStateKey)) ?? null
 		if (persisted) this.stateSnapshot = persisted
+		if (this.stateSnapshot.activeRun && !this.stateSnapshot.activeRun.done) {
+			void this.executeRun({
+				runId: this.stateSnapshot.activeRun.runId,
+				callerContext: this.stateSnapshot.activeRun.input.callerContext,
+				turn: this.stateSnapshot.activeRun.input.turn,
+			})
+		}
 	}
 
 	private async persistState() {
@@ -87,6 +96,16 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 	}
 
 	private async handleStart(body: StartRequestBody) {
+		const existingRun = this.stateSnapshot.activeRun
+		if (existingRun && !existingRun.done && !existingRun.cancelled) {
+			return Response.json(
+				{
+					ok: false,
+					error: 'An agent turn is already active for this session.',
+				},
+				{ status: 409 },
+			)
+		}
 		const runId = crypto.randomUUID()
 		const conversationId = resolveConversationId(body.turn.conversationId)
 		const run: ActiveRunState = {
@@ -96,17 +115,21 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 			events: [],
 			done: false,
 			finalResult: null,
+			input: {
+				callerContext: body.callerContext,
+				turn: {
+					...body.turn,
+					conversationId,
+				},
+			},
 		}
 		this.stateSnapshot.activeRun = run
 		await this.persistState()
 
 		void this.executeRun({
 			runId,
-			callerContext: body.callerContext,
-			turn: {
-				...body.turn,
-				conversationId,
-			},
+			callerContext: run.input.callerContext,
+			turn: run.input.turn,
 		})
 
 		return Response.json({
@@ -125,6 +148,7 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 		if (!run || run.runId !== input.runId) return
 
 		const abortController = new AbortController()
+		this.activeAbortController = abortController
 
 		const recordRunError = async (error: unknown) => {
 			const currentRun = this.stateSnapshot.activeRun
@@ -137,10 +161,13 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 			currentRun.done = true
 			await this.persistState()
 			this.notifyWaiters()
+			if (this.activeAbortController === abortController) {
+				this.activeAbortController = null
+			}
 		}
 
-		let events: ReturnType<typeof runAgentTurn>['events']
-		let completion: ReturnType<typeof runAgentTurn>['completion']
+		let events: Awaited<ReturnType<typeof runAgentTurn>>['events']
+		let completion: Awaited<ReturnType<typeof runAgentTurn>>['completion']
 		try {
 			;({ events, completion } = await runAgentTurn({
 				env: this.env,
@@ -174,6 +201,9 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 				currentRun.done = true
 				await this.persistState()
 				this.notifyWaiters()
+				if (this.activeAbortController === abortController) {
+					this.activeAbortController = null
+				}
 			} catch (error) {
 				await recordRunError(error)
 			}
@@ -184,12 +214,15 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 
 	private async waitForChange(waitMs: number) {
 		if (waitMs <= 0) return
+		let resolver: (() => void) | null = null
 		await Promise.race([
 			new Promise<void>((resolve) => {
+				resolver = resolve
 				this.waiters.add(resolve)
 			}),
 			scheduler.wait(waitMs),
 		])
+		if (resolver) this.waiters.delete(resolver)
 	}
 
 	private async handleNext(body: NextRequestBody) {
@@ -233,6 +266,7 @@ class AgentTurnRunnerBase extends DurableObject<Env> {
 		}
 		run.cancelled = true
 		run.done = true
+		this.activeAbortController?.abort('cancelled')
 		await this.persistState()
 		this.notifyWaiters()
 		return Response.json({ ok: true, cancelled: true })

--- a/packages/worker/src/agent-turn/runner.node.test.ts
+++ b/packages/worker/src/agent-turn/runner.node.test.ts
@@ -1,0 +1,191 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => {
+	const streamText = vi.fn()
+	const stepCountIs = vi.fn((count: number) => ({
+		type: 'step-count-is',
+		count,
+	}))
+	const createWorkersAI = vi.fn(() =>
+		vi.fn(() => ({ provider: 'workers-ai-model' })),
+	)
+	const createAgentTurnToolSet = vi.fn(async () => ({}))
+
+	return {
+		streamText,
+		stepCountIs,
+		createWorkersAI,
+		createAgentTurnToolSet,
+	}
+})
+
+vi.mock('ai', () => ({
+	streamText: (...args: Array<unknown>) => mockModule.streamText(...args),
+	stepCountIs: (...args: Array<unknown>) => mockModule.stepCountIs(...args),
+}))
+
+vi.mock('workers-ai-provider', () => ({
+	createWorkersAI: (...args: Array<unknown>) =>
+		mockModule.createWorkersAI(...args),
+}))
+
+vi.mock('./tools.ts', () => ({
+	createAgentTurnToolSet: (...args: Array<unknown>) =>
+		mockModule.createAgentTurnToolSet(...args),
+}))
+
+const { runAgentTurn } = await import('./runner.ts')
+
+test('runAgentTurn emits deltas and a final structured result', async () => {
+	mockModule.streamText.mockImplementationOnce(
+		(options: Record<string, unknown>) => {
+			return {
+				async consumeStream() {
+					await (options.onChunk as Function)?.({
+						chunk: { type: 'reasoning-delta', text: 'thinking...' },
+					})
+					await (options.onChunk as Function)?.({
+						chunk: { type: 'text-delta', text: 'Hello' },
+					})
+					await (options.onChunk as Function)?.({
+						chunk: {
+							type: 'tool-call',
+							toolCallId: 'call-1',
+							toolName: 'search',
+							input: { query: 'hello' },
+						},
+					})
+					await (options.onChunk as Function)?.({
+						chunk: {
+							type: 'tool-result',
+							toolCallId: 'call-1',
+							toolName: 'search',
+							output: { result: 'world' },
+						},
+					})
+					await (options.onStepFinish as Function)?.({
+						stepNumber: 0,
+						finishReason: 'stop',
+					})
+					await (options.onFinish as Function)?.({
+						steps: [{ toolCalls: [], toolResults: [] }],
+						finishReason: 'stop',
+					})
+				},
+				text: Promise.resolve('Hello'),
+				reasoningText: Promise.resolve('thinking...'),
+			}
+		},
+	)
+
+	const turn = await runAgentTurn({
+		env: { AI: {}, AI_GATEWAY_ID: 'gateway-id' } as Env,
+		callerContext: {
+			baseUrl: 'https://heykody.dev',
+			user: { userId: 'user-123' },
+			homeConnectorId: null,
+			remoteConnectors: null,
+			storageContext: null,
+		},
+		turn: {
+			system: 'system',
+			messages: [{ role: 'user', content: 'hello' }],
+			sessionId: 'session-1',
+		},
+	})
+
+	const events = []
+	for await (const event of turn.events) {
+		events.push(event)
+	}
+
+	const completion = await turn.completion
+
+	expect(events).toEqual(
+		expect.arrayContaining([
+			{ type: 'reasoning_delta', text: 'thinking...' },
+			{ type: 'assistant_delta', text: 'Hello' },
+			{
+				type: 'tool_call_started',
+				id: 'call-1',
+				toolName: 'search',
+				input: { query: 'hello' },
+			},
+			{
+				type: 'tool_call_finished',
+				id: 'call-1',
+				toolName: 'search',
+				input: { query: 'hello' },
+				output: { result: 'world' },
+			},
+		]),
+	)
+	expect(completion.assistantText).toBe('Hello')
+	expect(completion.reasoningText).toBe('thinking...')
+	expect(completion.stepsUsed).toBe(1)
+	expect(completion.stopReason).toBe('completed')
+	expect(completion.conversationId).toBeTruthy()
+})
+
+test('runAgentTurn marks no_new_information for repeated tool calls', async () => {
+	mockModule.streamText.mockImplementationOnce(
+		(options: Record<string, unknown>) => {
+			return {
+				async consumeStream() {
+					for (const id of ['call-1', 'call-2']) {
+						await (options.onChunk as Function)?.({
+							chunk: {
+								type: 'tool-call',
+								toolCallId: id,
+								toolName: 'search',
+								input: { query: 'same' },
+							},
+						})
+						await (options.onChunk as Function)?.({
+							chunk: {
+								type: 'tool-result',
+								toolCallId: id,
+								toolName: 'search',
+								output: { result: 'same' },
+							},
+						})
+					}
+					await (options.onStepFinish as Function)?.({
+						stepNumber: 1,
+						finishReason: 'tool-calls',
+					})
+					await (options.onFinish as Function)?.({
+						steps: [{}, {}],
+						finishReason: 'tool-calls',
+					})
+				},
+				text: Promise.resolve('Need more work'),
+				reasoningText: Promise.resolve(''),
+			}
+		},
+	)
+
+	const turn = await runAgentTurn({
+		env: { AI: {}, AI_GATEWAY_ID: 'gateway-id' } as Env,
+		callerContext: {
+			baseUrl: 'https://heykody.dev',
+			user: { userId: 'user-123' },
+			homeConnectorId: null,
+			remoteConnectors: null,
+			storageContext: null,
+		},
+		turn: {
+			system: 'system',
+			messages: [{ role: 'user', content: 'hello' }],
+			sessionId: 'session-2',
+		},
+	})
+
+	await turn.events[Symbol.asyncIterator]()
+		.next()
+		.catch(() => {})
+	const completion = await turn.completion
+	expect(completion.newInformation).toBe(false)
+	expect(completion.stopReason).toBe('no_new_information')
+	expect(completion.continueRecommended).toBe(false)
+})

--- a/packages/worker/src/agent-turn/runner.ts
+++ b/packages/worker/src/agent-turn/runner.ts
@@ -1,7 +1,6 @@
-import { streamText, stepCountIs, type ModelMessage } from 'ai'
-import { createWorkersAI } from 'workers-ai-provider'
 import { resolveConversationId } from '#mcp/tools/tool-call-context.ts'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { streamRemoteToolLoop } from '#worker/ai-runtime.ts'
 import {
 	agentTurnInputSchema,
 	type AgentToolTrace,
@@ -13,7 +12,6 @@ import {
 } from './types.ts'
 import { createAgentTurnToolSet } from './tools.ts'
 
-const defaultModel = '@cf/zai-org/glm-4.7-flash'
 const defaultMaxSteps = 8
 
 type QueueEntry<T> =
@@ -74,9 +72,7 @@ function clean(value: unknown) {
 	return String(value ?? '').trim()
 }
 
-function toModelMessages(
-	messages: Array<AgentTurnMessage>,
-): Array<ModelMessage> {
+function toModelMessages(messages: Array<AgentTurnMessage>) {
 	return messages.map((message) => ({
 		role: message.role,
 		content: message.content,
@@ -172,10 +168,6 @@ export async function runAgentTurn(input: {
 	const parsed = agentTurnInputSchema.parse(input.turn)
 	const conversationId = resolveConversationId(parsed.conversationId)
 	const modelMessages = toModelMessages(parsed.messages)
-	const model = createWorkersAI({
-		binding: input.env.AI,
-		gateway: { id: input.env.AI_GATEWAY_ID ?? '' },
-	})(input.env.AI_MODEL ?? defaultModel)
 	const tools = await createAgentTurnToolSet({
 		env: input.env,
 		callerContext: input.callerContext,
@@ -189,12 +181,11 @@ export async function runAgentTurn(input: {
 	let finishReason = 'stop'
 	let stepsUsed = 0
 
-	const result = streamText({
-		model,
+	const result = await streamRemoteToolLoop(input.env, {
 		system: parsed.system,
 		messages: modelMessages,
 		tools,
-		stopWhen: stepCountIs(parsed.maxSteps ?? defaultMaxSteps),
+		maxSteps: parsed.maxSteps ?? defaultMaxSteps,
 		abortSignal: input.abortSignal,
 		onChunk: async ({ chunk }) => {
 			if (chunk.type === 'text-delta') {

--- a/packages/worker/src/agent-turn/runner.ts
+++ b/packages/worker/src/agent-turn/runner.ts
@@ -1,0 +1,311 @@
+import { streamText, stepCountIs, type ModelMessage } from 'ai'
+import { createWorkersAI } from 'workers-ai-provider'
+import { resolveConversationId } from '#mcp/tools/tool-call-context.ts'
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import {
+	agentTurnInputSchema,
+	type AgentToolTrace,
+	type AgentTurnInput,
+	type AgentTurnMessage,
+	type AgentTurnResult,
+	type AgentTurnStopReason,
+	type AgentTurnStreamEvent,
+} from './types.ts'
+import { createAgentTurnToolSet } from './tools.ts'
+
+const defaultModel = '@cf/zai-org/glm-4.7-flash'
+const defaultMaxSteps = 8
+
+type QueueEntry<T> =
+	| { type: 'value'; value: T }
+	| { type: 'error'; error: unknown }
+	| { type: 'done' }
+
+class AsyncEventQueue<T> implements AsyncIterable<T> {
+	private readonly values: Array<QueueEntry<T>> = []
+	private readonly waiters: Array<(entry: QueueEntry<T>) => void> = []
+
+	push(value: T) {
+		this.enqueue({ type: 'value', value })
+	}
+
+	error(error: unknown) {
+		this.enqueue({ type: 'error', error })
+	}
+
+	done() {
+		this.enqueue({ type: 'done' })
+	}
+
+	private enqueue(entry: QueueEntry<T>) {
+		const waiter = this.waiters.shift()
+		if (waiter) {
+			waiter(entry)
+			return
+		}
+		this.values.push(entry)
+	}
+
+	private async nextEntry(): Promise<QueueEntry<T>> {
+		if (this.values.length > 0) {
+			return this.values.shift() as QueueEntry<T>
+		}
+		return new Promise((resolve) => {
+			this.waiters.push(resolve)
+		})
+	}
+
+	async *[Symbol.asyncIterator](): AsyncIterator<T> {
+		while (true) {
+			const entry = await this.nextEntry()
+			if (entry.type === 'value') {
+				yield entry.value
+				continue
+			}
+			if (entry.type === 'error') {
+				throw entry.error
+			}
+			return
+		}
+	}
+}
+
+function clean(value: unknown) {
+	return String(value ?? '').trim()
+}
+
+function toModelMessages(
+	messages: Array<AgentTurnMessage>,
+): Array<ModelMessage> {
+	return messages.map((message) => ({
+		role: message.role,
+		content: message.content,
+	}))
+}
+
+function stringifyToolPayload(value: unknown) {
+	try {
+		return JSON.stringify(value, null, 2)
+	} catch {
+		return String(value)
+	}
+}
+
+function fingerprint(value: unknown) {
+	const text = stringifyToolPayload(value)
+	let hash = 2166136261
+	for (let i = 0; i < text.length; i += 1) {
+		hash ^= text.charCodeAt(i)
+		hash = Math.imul(hash, 16777619)
+	}
+	return hash >>> 0
+}
+
+function hasNewInformation(toolCalls: Array<AgentToolTrace>) {
+	if (toolCalls.length < 2) return true
+	const last = toolCalls[toolCalls.length - 1]
+	const previous = toolCalls[toolCalls.length - 2]
+	if (!last || !previous) return true
+	if (last.toolName !== previous.toolName) return true
+	if (fingerprint(last.input) !== fingerprint(previous.input)) return true
+	if (
+		fingerprint(last.output ?? last.error ?? null) !==
+		fingerprint(previous.output ?? previous.error ?? null)
+	) {
+		return true
+	}
+	return false
+}
+
+function inferNeedsUserInput(input: {
+	assistantText: string
+	finishReason: string
+}) {
+	const text = input.assistantText.toLowerCase()
+	return (
+		text.includes('?') &&
+		(text.includes('could you') ||
+			text.includes('can you clarify') ||
+			text.includes('what do you mean') ||
+			text.includes('which part'))
+	)
+}
+
+function inferContinueRecommended(input: {
+	finishReason: string
+	stepsUsed: number
+	needsUserInput: boolean
+	newInformation: boolean
+	maxSteps: number
+}) {
+	if (input.needsUserInput) return false
+	if (!input.newInformation) return false
+	if (input.finishReason === 'tool-calls') return true
+	return input.stepsUsed >= input.maxSteps
+}
+
+function inferStopReason(input: {
+	continueRecommended: boolean
+	needsUserInput: boolean
+	newInformation: boolean
+	stepsUsed: number
+	maxSteps: number
+	finishReason: string
+}) {
+	if (input.needsUserInput) return 'needs_user' satisfies AgentTurnStopReason
+	if (!input.newInformation)
+		return 'no_new_information' satisfies AgentTurnStopReason
+	if (input.continueRecommended) {
+		return input.stepsUsed >= input.maxSteps
+			? ('budget_exhausted' satisfies AgentTurnStopReason)
+			: ('continue_recommended' satisfies AgentTurnStopReason)
+	}
+	return 'completed' satisfies AgentTurnStopReason
+}
+
+export async function runAgentTurn(input: {
+	env: Env
+	callerContext: McpCallerContext
+	turn: AgentTurnInput
+	abortSignal?: AbortSignal
+}) {
+	const parsed = agentTurnInputSchema.parse(input.turn)
+	const conversationId = resolveConversationId(parsed.conversationId)
+	const modelMessages = toModelMessages(parsed.messages)
+	const model = createWorkersAI({
+		binding: input.env.AI,
+		gateway: { id: input.env.AI_GATEWAY_ID ?? '' },
+	})(input.env.AI_MODEL ?? defaultModel)
+	const tools = await createAgentTurnToolSet({
+		env: input.env,
+		callerContext: input.callerContext,
+		conversationId,
+		memoryContext: parsed.memoryContext,
+	})
+	const queue = new AsyncEventQueue<AgentTurnStreamEvent>()
+	const toolCalls: Array<AgentToolTrace> = []
+	let assistantText = ''
+	let reasoningText = ''
+	let finishReason = 'stop'
+	let stepsUsed = 0
+
+	const result = streamText({
+		model,
+		system: parsed.system,
+		messages: modelMessages,
+		tools,
+		stopWhen: stepCountIs(parsed.maxSteps ?? defaultMaxSteps),
+		abortSignal: input.abortSignal,
+		onChunk: async ({ chunk }) => {
+			if (chunk.type === 'text-delta') {
+				assistantText += chunk.text
+				queue.push({ type: 'assistant_delta', text: chunk.text })
+			}
+			if (chunk.type === 'reasoning-delta') {
+				reasoningText += chunk.text
+				queue.push({ type: 'reasoning_delta', text: chunk.text })
+			}
+			if (chunk.type === 'tool-call') {
+				const trace: AgentToolTrace = {
+					id: chunk.toolCallId,
+					toolName: chunk.toolName,
+					input: chunk.input,
+				}
+				toolCalls.push(trace)
+				queue.push({
+					type: 'tool_call_started',
+					id: chunk.toolCallId,
+					toolName: chunk.toolName,
+					input: chunk.input,
+				})
+			}
+			if (chunk.type === 'tool-result') {
+				const trace = toolCalls.find((entry) => entry.id === chunk.toolCallId)
+				if (trace) {
+					trace.output = chunk.output
+				}
+				queue.push({
+					type: 'tool_call_finished',
+					id: chunk.toolCallId,
+					toolName: chunk.toolName,
+					input: trace?.input ?? null,
+					output: chunk.output,
+				})
+			}
+		},
+		onStepFinish: async (event) => {
+			stepsUsed = event.stepNumber + 1
+			finishReason = event.finishReason
+		},
+		onFinish: async (event) => {
+			stepsUsed = event.steps.length
+			finishReason = event.finishReason
+		},
+		onAbort: async () => {
+			queue.push({
+				type: 'error',
+				message: 'Turn aborted.',
+				phase: 'abort',
+			})
+		},
+	})
+
+	const completion = (async () => {
+		try {
+			await result.consumeStream()
+			const text = clean(await result.text)
+			const reasoning = clean(await result.reasoningText)
+			const lastToolCalls = toolCalls.map((entry) => ({ ...entry }))
+			const newInformation = hasNewInformation(lastToolCalls)
+			const needsUserInput = inferNeedsUserInput({
+				assistantText: text,
+				finishReason,
+			})
+			const continueRecommended = inferContinueRecommended({
+				finishReason,
+				stepsUsed,
+				needsUserInput,
+				newInformation,
+				maxSteps: parsed.maxSteps ?? defaultMaxSteps,
+			})
+			const stopReason = inferStopReason({
+				continueRecommended,
+				needsUserInput,
+				newInformation,
+				stepsUsed,
+				maxSteps: parsed.maxSteps ?? defaultMaxSteps,
+				finishReason,
+			})
+			const finalResult: AgentTurnResult = {
+				assistantText: text,
+				reasoningText: reasoning,
+				summary: null,
+				continueRecommended,
+				needsUserInput,
+				stepsUsed,
+				newInformation,
+				stopReason,
+				finishReason,
+				toolCalls: lastToolCalls,
+				conversationId,
+			}
+			queue.push({
+				type: 'turn_complete',
+				...finalResult,
+			})
+			queue.done()
+			return finalResult
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			queue.push({ type: 'error', message, phase: 'run' })
+			queue.error(error)
+			throw error
+		}
+	})()
+
+	return {
+		conversationId,
+		events: queue,
+		completion,
+	}
+}

--- a/packages/worker/src/agent-turn/service.node.test.ts
+++ b/packages/worker/src/agent-turn/service.node.test.ts
@@ -1,0 +1,48 @@
+import { expect, test, vi } from 'vitest'
+import { startAgentTurnRun } from './service.ts'
+
+function createEnv(response: Response) {
+	const stub = {
+		fetch: vi.fn(async () => response),
+	}
+	return {
+		env: {
+			AGENT_TURN_RUNNER: {
+				idFromName: vi.fn((name: string) => name as unknown as DurableObjectId),
+				get: vi.fn(() => stub),
+			},
+		} as unknown as Env,
+		stub,
+	}
+}
+
+test('startAgentTurnRun preserves structured Durable Object conflict errors', async () => {
+	const { env } = createEnv(
+		Response.json(
+			{
+				ok: false,
+				error: 'An agent turn is already active for this session.',
+			},
+			{ status: 409 },
+		),
+	)
+
+	await expect(
+		startAgentTurnRun({
+			env,
+			sessionId: 'session-123',
+			callerContext: {
+				baseUrl: 'https://heykody.dev',
+				user: { userId: 'user-123' },
+				homeConnectorId: null,
+				remoteConnectors: null,
+				storageContext: null,
+			},
+			turn: {
+				sessionId: 'session-123',
+				system: 'system',
+				messages: [{ role: 'user', content: 'hello' }],
+			},
+		}),
+	).rejects.toThrow('An agent turn is already active for this session.')
+})

--- a/packages/worker/src/agent-turn/service.ts
+++ b/packages/worker/src/agent-turn/service.ts
@@ -39,9 +39,33 @@ function getRunnerStub(env: Env, sessionId: string) {
 	return namespace.get(namespace.idFromName(sessionId))
 }
 
+function readRunnerErrorMessage(body: unknown) {
+	if (typeof body === 'string' && body.length > 0) {
+		return body
+	}
+	if (!body || typeof body !== 'object') {
+		return null
+	}
+	const error = 'error' in body ? body.error : null
+	if (typeof error === 'string' && error.length > 0) {
+		return error
+	}
+	const message = 'message' in body ? body.message : null
+	if (typeof message === 'string' && message.length > 0) {
+		return message
+	}
+	return null
+}
+
 async function readJsonResponse<T>(response: Response): Promise<T> {
 	const body = await response.json().catch(() => null)
-	if (!response.ok || body == null) {
+	if (!response.ok) {
+		throw new Error(
+			readRunnerErrorMessage(body) ??
+				`Agent turn runner request failed with HTTP ${response.status}.`,
+		)
+	}
+	if (body == null) {
 		throw new Error(
 			`Agent turn runner request failed with HTTP ${response.status}.`,
 		)

--- a/packages/worker/src/agent-turn/service.ts
+++ b/packages/worker/src/agent-turn/service.ts
@@ -1,0 +1,117 @@
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { agentTurnInputSchema, type AgentTurnInput } from './types.ts'
+
+const agentTurnRunnerOrigin = 'https://agent-turn.internal'
+const defaultPollWaitMs = 5_000
+
+type AgentTurnRunnerBinding = DurableObjectNamespace
+
+type AgentTurnRunStartResult = {
+	ok: true
+	runId: string
+	conversationId: string
+}
+
+type AgentTurnRunNextResult = {
+	ok: true
+	events: Array<unknown>
+	nextCursor: number
+	done: boolean
+}
+
+type AgentTurnRunCancelResult = {
+	ok: true
+	cancelled: boolean
+}
+
+function getRunnerNamespace(env: Env): AgentTurnRunnerBinding {
+	const namespace = (
+		env as Env & { AGENT_TURN_RUNNER?: AgentTurnRunnerBinding }
+	).AGENT_TURN_RUNNER
+	if (!namespace) {
+		throw new Error('AGENT_TURN_RUNNER binding is not configured.')
+	}
+	return namespace
+}
+
+function getRunnerStub(env: Env, sessionId: string) {
+	const namespace = getRunnerNamespace(env)
+	return namespace.get(namespace.idFromName(sessionId))
+}
+
+async function readJsonResponse<T>(response: Response): Promise<T> {
+	const body = await response.json().catch(() => null)
+	if (!response.ok || body == null) {
+		throw new Error(
+			`Agent turn runner request failed with HTTP ${response.status}.`,
+		)
+	}
+	return body as T
+}
+
+export async function startAgentTurnRun(input: {
+	env: Env
+	sessionId: string
+	callerContext: McpCallerContext
+	turn: AgentTurnInput
+}) {
+	const parsedTurn = agentTurnInputSchema.parse(input.turn)
+	const stub = getRunnerStub(input.env, input.sessionId)
+	const response = await stub.fetch(
+		new Request(`${agentTurnRunnerOrigin}/start`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				callerContext: input.callerContext,
+				turn: parsedTurn,
+			}),
+		}),
+	)
+	return readJsonResponse<AgentTurnRunStartResult>(response)
+}
+
+export async function nextAgentTurnRunEvent(input: {
+	env: Env
+	sessionId: string
+	runId: string
+	cursor: number
+	waitMs?: number
+}) {
+	const stub = getRunnerStub(input.env, input.sessionId)
+	const response = await stub.fetch(
+		new Request(`${agentTurnRunnerOrigin}/next`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				runId: input.runId,
+				cursor: input.cursor,
+				waitMs: input.waitMs ?? defaultPollWaitMs,
+			}),
+		}),
+	)
+	return readJsonResponse<AgentTurnRunNextResult>(response)
+}
+
+export async function cancelAgentTurnRun(input: {
+	env: Env
+	sessionId: string
+	runId: string
+}) {
+	const stub = getRunnerStub(input.env, input.sessionId)
+	const response = await stub.fetch(
+		new Request(`${agentTurnRunnerOrigin}/cancel`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				runId: input.runId,
+			}),
+		}),
+	)
+	return readJsonResponse<AgentTurnRunCancelResult>(response)
+}

--- a/packages/worker/src/agent-turn/tools.ts
+++ b/packages/worker/src/agent-turn/tools.ts
@@ -1,0 +1,168 @@
+import { tool, type ToolSet } from 'ai'
+import { z } from 'zod'
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
+import { searchUnified } from '#mcp/capabilities/unified-search.ts'
+import {
+	loadDownRemoteConnectorStatuses,
+	loadOptionalSearchRows,
+	resolveSearchMemoryContext,
+} from '#mcp/tools/search.ts'
+import { loadRelevantMemoriesForTool } from '#mcp/tools/memory-tool-context.ts'
+import { toSlimStructuredMatches } from '#mcp/tools/search-format.ts'
+import { listAppSecretsByAppIds } from '#mcp/secrets/service.ts'
+import { listMcpSkillsByUserId } from '#mcp/skills/mcp-skills-repo.ts'
+import { slugifySkillCollectionName } from '#mcp/skills/skill-collections.ts'
+import { listUiArtifactsByUserId } from '#mcp/ui-artifacts-repo.ts'
+import { listValues } from '#mcp/values/service.ts'
+import { listUserSecretsForSearch } from '#mcp/secrets/service.ts'
+import { runCodemodeWithRegistry } from '#mcp/run-codemode-registry.ts'
+
+const defaultSearchLimit = 15
+const defaultMaxResponseSize = 4_000
+
+function truncateText(text: string, maxChars = defaultMaxResponseSize) {
+	if (text.length <= maxChars) return text
+	return `${text.slice(0, maxChars)}\n\n[truncated]`
+}
+
+export async function createAgentTurnToolSet(input: {
+	env: Env
+	callerContext: McpCallerContext
+	conversationId: string
+	memoryContext?: {
+		task?: string
+		query?: string
+		entities?: Array<string>
+		constraints?: Array<string>
+	} | null
+}): Promise<ToolSet> {
+	return {
+		search: tool({
+			description:
+				'Search Kody capabilities, saved skills, apps, values, connectors, and secret references using a natural language query.',
+			inputSchema: z.object({
+				query: z.string().min(1),
+				limit: z.number().int().min(1).max(50).optional(),
+				skill_collection: z.string().min(1).optional(),
+			}),
+			execute: async (args) => {
+				const userId = input.callerContext.user?.userId ?? null
+				const registry = await getCapabilityRegistryForContext({
+					env: input.env,
+					callerContext: input.callerContext,
+				})
+				const optionalRows = await loadOptionalSearchRows({
+					userId,
+					loadSkills: () => listMcpSkillsByUserId(input.env.APP_DB, userId!),
+					loadUiArtifacts: () =>
+						listUiArtifactsByUserId(input.env.APP_DB, userId!, {
+							hidden: false,
+						}),
+					loadUserSecrets: () =>
+						listUserSecretsForSearch({
+							env: input.env,
+							userId: userId!,
+						}),
+					loadUserValues: () =>
+						listValues({
+							env: input.env,
+							userId: userId!,
+							storageContext: {
+								sessionId:
+									input.callerContext.storageContext?.sessionId ?? null,
+								appId: input.callerContext.storageContext?.appId ?? null,
+							},
+						}),
+				})
+				const skillCollectionSlug = args.skill_collection?.trim()
+					? slugifySkillCollectionName(args.skill_collection)
+					: undefined
+				const appSecretsByAppId = userId
+					? await listAppSecretsByAppIds({
+							env: input.env,
+							userId,
+							appIds: optionalRows.uiArtifactRows.map((row) => row.id),
+						})
+					: new Map()
+				const result = await searchUnified({
+					baseUrl: input.callerContext.baseUrl,
+					env: input.env,
+					query: args.query,
+					skillCollectionSlug,
+					limit: args.limit ?? defaultSearchLimit,
+					specs: registry.capabilitySpecs,
+					userId,
+					skillRows: optionalRows.skillRows,
+					uiArtifactRows: optionalRows.uiArtifactRows,
+					userSecretRows: optionalRows.userSecretRows,
+					userValueRows: optionalRows.userValueRows,
+					appSecretsByAppId,
+				})
+				const remoteConnectorStatuses = await loadDownRemoteConnectorStatuses({
+					env: input.env,
+					callerContext: input.callerContext,
+				})
+				const memoryToolContext = await loadRelevantMemoriesForTool({
+					env: input.env,
+					callerContext: input.callerContext,
+					conversationId: input.conversationId,
+					memoryContext: resolveSearchMemoryContext({
+						query: args.query,
+						memoryContext: input.memoryContext ?? undefined,
+					}),
+				})
+				return {
+					offline: result.offline,
+					warnings: optionalRows.warnings,
+					memories: memoryToolContext
+						? {
+								surfaced: memoryToolContext.memories,
+								suppressedCount: memoryToolContext.suppressedCount,
+								retrievalQuery: memoryToolContext.retrievalQuery,
+							}
+						: undefined,
+					remoteConnectorStatuses: remoteConnectorStatuses.map((status) => ({
+						connectorKind: status.connectorKind,
+						connectorId: status.connectorId ?? 'unknown',
+						state: status.state,
+						connected: status.connected,
+						toolCount: status.toolCount,
+					})),
+					matches: toSlimStructuredMatches({
+						matches: result.matches,
+						baseUrl: input.callerContext.baseUrl,
+					}),
+				}
+			},
+		}),
+		execute: tool({
+			description:
+				'Run a short async JavaScript function against Kody capabilities via the execute runtime.',
+			inputSchema: z.object({
+				code: z.string().min(1),
+				params: z.record(z.string(), z.unknown()).optional(),
+			}),
+			execute: async (args) => {
+				const result = await runCodemodeWithRegistry(
+					input.env,
+					input.callerContext,
+					args.code,
+					args.params,
+				)
+				if (result.error) {
+					throw result.error
+				}
+				const raw =
+					typeof result.result === 'string'
+						? result.result
+						: JSON.stringify(result.result, null, 2)
+				return {
+					result: result.result,
+					logs: result.logs ?? [],
+					preview: truncateText(raw ?? ''),
+				}
+			},
+		}),
+	} satisfies ToolSet
+}

--- a/packages/worker/src/agent-turn/tools.ts
+++ b/packages/worker/src/agent-turn/tools.ts
@@ -10,12 +10,14 @@ import {
 } from '#mcp/tools/search.ts'
 import { loadRelevantMemoriesForTool } from '#mcp/tools/memory-tool-context.ts'
 import { toSlimStructuredMatches } from '#mcp/tools/search-format.ts'
-import { listAppSecretsByAppIds } from '#mcp/secrets/service.ts'
+import {
+	listAppSecretsByAppIds,
+	listUserSecretsForSearch,
+} from '#mcp/secrets/service.ts'
 import { listMcpSkillsByUserId } from '#mcp/skills/mcp-skills-repo.ts'
 import { slugifySkillCollectionName } from '#mcp/skills/skill-collections.ts'
 import { listUiArtifactsByUserId } from '#mcp/ui-artifacts-repo.ts'
 import { listValues } from '#mcp/values/service.ts'
-import { listUserSecretsForSearch } from '#mcp/secrets/service.ts'
 import { runCodemodeWithRegistry } from '#mcp/run-codemode-registry.ts'
 
 const defaultSearchLimit = 15

--- a/packages/worker/src/agent-turn/types.ts
+++ b/packages/worker/src/agent-turn/types.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod'
+import {
+	conversationIdInputField,
+	memoryContextInputField,
+} from '#mcp/tools/tool-call-context.ts'
+
+export const agentTurnMessageSchema = z.object({
+	role: z.enum(['system', 'user', 'assistant']),
+	content: z.string().min(1),
+})
+
+export const agentTurnInputSchema = z.object({
+	messages: z.array(agentTurnMessageSchema).min(1),
+	system: z.string().min(1).describe('System prompt to use for this turn.'),
+	sessionId: z
+		.string()
+		.min(1)
+		.max(120)
+		.optional()
+		.describe(
+			'Optional stable session identifier used to scope interruption and active-run semantics.',
+		),
+	maxSteps: z
+		.number()
+		.int()
+		.min(1)
+		.max(25)
+		.optional()
+		.describe('Maximum tool-calling steps to allow in this turn.'),
+	conversationId: conversationIdInputField,
+	memoryContext: memoryContextInputField,
+})
+
+export const agentTurnToolInputSchema = agentTurnInputSchema.extend({
+	sessionId: z
+		.string()
+		.min(1)
+		.max(120)
+		.describe('Stable session identifier used to scope the active agent run.'),
+})
+
+export type AgentTurnMessage = z.infer<typeof agentTurnMessageSchema>
+export type AgentTurnInput = z.infer<typeof agentTurnInputSchema>
+export type AgentTurnToolInput = z.infer<typeof agentTurnToolInputSchema>
+
+export type AgentToolTrace = {
+	id: string
+	toolName: string
+	input: unknown
+	output?: unknown
+	error?: string
+}
+
+export type AgentTurnStopReason =
+	| 'completed'
+	| 'needs_user'
+	| 'continue_recommended'
+	| 'budget_exhausted'
+	| 'no_new_information'
+	| 'tool_error'
+	| 'interrupted'
+
+export type AgentTurnResult = {
+	assistantText: string
+	reasoningText: string
+	summary: string | null
+	continueRecommended: boolean
+	needsUserInput: boolean
+	stepsUsed: number
+	newInformation: boolean
+	stopReason: AgentTurnStopReason
+	finishReason: string
+	toolCalls: Array<AgentToolTrace>
+	conversationId: string
+}
+
+export type AgentTurnStreamEvent =
+	| { type: 'assistant_delta'; text: string }
+	| { type: 'reasoning_delta'; text: string }
+	| { type: 'tool_call_started'; id: string; toolName: string; input: unknown }
+	| {
+			type: 'tool_call_finished'
+			id: string
+			toolName: string
+			input: unknown
+			output?: unknown
+			error?: string
+	  }
+	| { type: 'error'; message: string; phase: string }
+	| ({ type: 'turn_complete' } & AgentTurnResult)

--- a/packages/worker/src/ai-runtime.ts
+++ b/packages/worker/src/ai-runtime.ts
@@ -1,8 +1,12 @@
 import {
 	convertToModelMessages,
+	type ModelMessage,
 	stepCountIs,
 	streamText,
+	type StreamTextOnChunkCallback,
 	type StreamTextOnFinishCallback,
+	type StreamTextOnStepFinishCallback,
+	type StreamTextResult,
 	type ToolSet,
 	type UIMessage,
 } from 'ai'
@@ -32,6 +36,22 @@ export type AiRuntimeResult =
 
 export type AiRuntime = {
 	streamChatReply(input: StreamChatReplyInput): Promise<AiRuntimeResult>
+}
+
+export type StreamToolLoopInput = {
+	messages: Array<UIMessage> | Array<ModelMessage>
+	system: string
+	tools: ToolSet
+	toolNames?: Array<string>
+	abortSignal?: AbortSignal
+	onFinish?: StreamTextOnFinishCallback<ToolSet>
+	onChunk?: StreamTextOnChunkCallback<ToolSet>
+	onAbort?: (event: {
+		reason?: string
+		steps: Array<unknown>
+	}) => PromiseLike<void> | void
+	onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>
+	maxSteps?: number
 }
 
 type AIEnabledEnv = Env & {
@@ -76,20 +96,44 @@ function createWorkersAiProvider(env: WorkersAiCredentialsEnv) {
 	})
 }
 
+function isUiMessageArray(
+	messages: Array<UIMessage> | Array<ModelMessage>,
+): messages is Array<UIMessage> {
+	return messages.some((message) => 'parts' in message)
+}
+
+async function toModelMessages(
+	messages: Array<UIMessage> | Array<ModelMessage>,
+): Promise<Array<ModelMessage>> {
+	if (isUiMessageArray(messages)) {
+		return (await convertToModelMessages(messages)) as Array<ModelMessage>
+	}
+	return messages as Array<ModelMessage>
+}
+
+export async function streamRemoteToolLoop(
+	env: WorkersAiCredentialsEnv,
+	input: StreamToolLoopInput,
+): Promise<StreamTextResult<ToolSet, never>> {
+	const workersai = createWorkersAiProvider(env)
+	return streamText({
+		model: workersai(env.AI_MODEL ?? defaultModel),
+		system: input.system,
+		messages: await toModelMessages(input.messages),
+		tools: input.tools,
+		stopWhen: stepCountIs(input.maxSteps ?? remoteToolLoopMaxSteps),
+		abortSignal: input.abortSignal,
+		onFinish: input.onFinish,
+		onChunk: input.onChunk,
+		onAbort: input.onAbort,
+		onStepFinish: input.onStepFinish,
+	})
+}
+
 function createRemoteAiRuntime(env: WorkersAiCredentialsEnv): AiRuntime {
 	return {
 		async streamChatReply(input) {
-			const workersai = createWorkersAiProvider(env)
-
-			const result = streamText({
-				model: workersai(env.AI_MODEL ?? defaultModel),
-				system: input.system,
-				messages: await convertToModelMessages(input.messages),
-				tools: input.tools,
-				stopWhen: stepCountIs(remoteToolLoopMaxSteps),
-				abortSignal: input.abortSignal,
-				onFinish: input.onFinish,
-			})
+			const result = await streamRemoteToolLoop(env, input)
 
 			return {
 				kind: 'response',

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -7,6 +7,7 @@ import { MCP } from './mcp/index.ts'
 import { AppFacetBridge, AppRunner } from './mcp/app-runner.ts'
 import { JobManager } from './jobs/manager-do.ts'
 import { StorageRunner } from './storage-runner.ts'
+import { AgentTurnRunner } from './agent-turn/runner-do.ts'
 import { chatAgentBasePath } from '@kody-internal/shared/chat-routes.ts'
 import { getWorkerSentryOptions } from './sentry-options.ts'
 import { handleRequest } from '#app/handler.ts'
@@ -44,6 +45,7 @@ import {
 
 export {
 	ChatAgent,
+	AgentTurnRunner,
 	CodemodeFetchGateway,
 	HomeConnectorSession,
 	HomeMCP,

--- a/packages/worker/src/mcp/capabilities/meta/domain.ts
+++ b/packages/worker/src/mcp/capabilities/meta/domain.ts
@@ -10,6 +10,12 @@ import { metaGetHomeConnectorStatusCapability } from './meta-get-home-connector-
 import { metaListRemoteConnectorStatusCapability } from './meta-list-remote-connector-status.ts'
 import { metaGetMcpServerInstructionsCapability } from './meta-get-mcp-server-instructions.ts'
 import { metaGetSkillCapability } from './meta-get-skill.ts'
+import {
+	metaAgentChatTurnCapability,
+	metaAgentTurnCancelCapability,
+	metaAgentTurnNextCapability,
+	metaAgentTurnStartCapability,
+} from './meta-agent-turn.ts'
 import { metaListCapabilitiesCapability } from './meta-list-capabilities.ts'
 import { metaListSkillCollectionsCapability } from './meta-list-skill-collections.ts'
 import { metaRunSkillCapability } from './meta-run-skill.ts'
@@ -42,6 +48,10 @@ export const metaDomain = defineDomain({
 		metaMemoryUpsertCapability,
 		metaMemoryDeleteCapability,
 		metaListSkillCollectionsCapability,
+		metaAgentChatTurnCapability,
+		metaAgentTurnStartCapability,
+		metaAgentTurnNextCapability,
+		metaAgentTurnCancelCapability,
 		metaSaveSkillCapability,
 		metaDeleteSkillCapability,
 		metaGetSkillCapability,

--- a/packages/worker/src/mcp/capabilities/meta/meta-agent-turn.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-agent-turn.node.test.ts
@@ -1,0 +1,173 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	beginAgentTurn: vi.fn(),
+	readNextAgentTurnEvents: vi.fn(),
+	collectAgentTurnEvents: vi.fn(),
+	cancelAgentTurn: vi.fn(),
+}))
+
+vi.mock('#worker/agent-turn/api.ts', () => ({
+	beginAgentTurn: (...args: Array<unknown>) =>
+		mockModule.beginAgentTurn(...args),
+	readNextAgentTurnEvents: (...args: Array<unknown>) =>
+		mockModule.readNextAgentTurnEvents(...args),
+	collectAgentTurnEvents: (...args: Array<unknown>) =>
+		mockModule.collectAgentTurnEvents(...args),
+	cancelAgentTurn: (...args: Array<unknown>) =>
+		mockModule.cancelAgentTurn(...args),
+}))
+
+const {
+	metaAgentChatTurnCapability,
+	metaAgentTurnCancelCapability,
+	metaAgentTurnNextCapability,
+	metaAgentTurnStartCapability,
+} = await import('./meta-agent-turn.ts')
+
+const ctx = {
+	env: {} as Env,
+	callerContext: {
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+		homeConnectorId: null,
+		remoteConnectors: null,
+		storageContext: null,
+	},
+} as const
+
+test('agent_turn_start delegates to the runner service', async () => {
+	mockModule.beginAgentTurn.mockResolvedValueOnce({
+		ok: true,
+		runId: 'run-123',
+		conversationId: 'conversation-123',
+	})
+
+	const result = await metaAgentTurnStartCapability.handler(
+		{
+			sessionId: 'session-123',
+			system: 'system',
+			messages: [{ role: 'user', content: 'hello' }],
+		},
+		ctx as never,
+	)
+
+	expect(result).toEqual({
+		ok: true,
+		runId: 'run-123',
+		sessionId: 'session-123',
+		conversationId: 'conversation-123',
+	})
+})
+
+test('agent_turn_next returns incremental events', async () => {
+	mockModule.readNextAgentTurnEvents.mockResolvedValueOnce({
+		events: [{ type: 'assistant_delta', text: 'Hi' }],
+		nextCursor: 1,
+		done: false,
+	})
+
+	const result = await metaAgentTurnNextCapability.handler(
+		{
+			sessionId: 'session-123',
+			runId: 'run-123',
+			cursor: 0,
+		},
+		ctx as never,
+	)
+
+	expect(result).toEqual({
+		ok: true,
+		events: [{ type: 'assistant_delta', text: 'Hi' }],
+		nextCursor: 1,
+		done: false,
+	})
+})
+
+test('agent_turn_cancel forwards cancellation', async () => {
+	mockModule.cancelAgentTurn.mockResolvedValueOnce({
+		ok: true,
+		cancelled: true,
+	})
+
+	const result = await metaAgentTurnCancelCapability.handler(
+		{
+			sessionId: 'session-123',
+			runId: 'run-123',
+		},
+		ctx as never,
+	)
+
+	expect(result).toEqual({
+		ok: true,
+		cancelled: true,
+	})
+})
+
+test('agent_chat_turn collects events and returns final structured result', async () => {
+	mockModule.beginAgentTurn.mockResolvedValueOnce({
+		ok: true,
+		runId: 'run-123',
+		conversationId: 'conversation-123',
+	})
+	mockModule.collectAgentTurnEvents.mockResolvedValueOnce([
+		{ type: 'assistant_delta', text: 'Hi' },
+		{
+			type: 'turn_complete',
+			assistantText: 'Hello world',
+			reasoningText: 'thinking',
+			summary: null,
+			continueRecommended: false,
+			needsUserInput: false,
+			stepsUsed: 1,
+			newInformation: true,
+			stopReason: 'completed',
+			finishReason: 'stop',
+			toolCalls: [],
+			conversationId: 'conversation-123',
+		},
+	])
+
+	const result = await metaAgentChatTurnCapability.handler(
+		{
+			sessionId: 'session-123',
+			system: 'system',
+			messages: [{ role: 'user', content: 'hello' }],
+		},
+		ctx as never,
+	)
+
+	expect(result).toEqual({
+		ok: true,
+		result: {
+			assistantText: 'Hello world',
+			reasoningText: 'thinking',
+			summary: null,
+			continueRecommended: false,
+			needsUserInput: false,
+			stepsUsed: 1,
+			newInformation: true,
+			stopReason: 'completed',
+			finishReason: 'stop',
+			toolCalls: [],
+			conversationId: 'conversation-123',
+		},
+		events: [
+			{ type: 'assistant_delta', text: 'Hi' },
+			{
+				type: 'turn_complete',
+				assistantText: 'Hello world',
+				reasoningText: 'thinking',
+				summary: null,
+				continueRecommended: false,
+				needsUserInput: false,
+				stepsUsed: 1,
+				newInformation: true,
+				stopReason: 'completed',
+				finishReason: 'stop',
+				toolCalls: [],
+				conversationId: 'conversation-123',
+			},
+		],
+	})
+})

--- a/packages/worker/src/mcp/capabilities/meta/meta-agent-turn.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-agent-turn.ts
@@ -1,0 +1,213 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import {
+	beginAgentTurn,
+	cancelAgentTurn,
+	collectAgentTurnEvents,
+	readNextAgentTurnEvents,
+} from '#worker/agent-turn/api.ts'
+import {
+	agentTurnInputSchema,
+	type AgentTurnResult,
+	type AgentTurnStreamEvent,
+	type AgentTurnToolInput,
+} from '#worker/agent-turn/types.ts'
+
+const sessionIdField = z
+	.string()
+	.min(1)
+	.max(120)
+	.describe('Stable session identifier used to scope the active agent run.')
+
+export const metaAgentTurnStartCapability = defineDomainCapability(
+	capabilityDomainNames.meta,
+	{
+		name: 'agent_turn_start',
+		description:
+			'Start a generic tool-using agent turn for a session and return a run id. Pair with agent_turn_next to stream events and agent_turn_cancel to interrupt the active run.',
+		keywords: ['agent', 'turn', 'stream', 'start'],
+		readOnly: false,
+		idempotent: false,
+		destructive: false,
+		inputSchema: agentTurnInputSchema.extend({
+			sessionId: sessionIdField,
+		}),
+		outputSchema: z.object({
+			ok: z.literal(true),
+			runId: z.string(),
+			sessionId: z.string(),
+			conversationId: z.string(),
+		}),
+		async handler(args: AgentTurnToolInput, ctx: CapabilityContext) {
+			const result = await beginAgentTurn({
+				env: ctx.env,
+				callerContext: ctx.callerContext,
+				turn: args,
+			})
+			return {
+				ok: true,
+				runId: result.runId,
+				sessionId: args.sessionId,
+				conversationId: result.conversationId,
+			} as const
+		},
+	},
+)
+
+export const metaAgentTurnNextCapability = defineDomainCapability(
+	capabilityDomainNames.meta,
+	{
+		name: 'agent_turn_next',
+		description:
+			'Read the next batch of streamed events for an active agent turn run.',
+		keywords: ['agent', 'turn', 'stream', 'next'],
+		readOnly: false,
+		idempotent: false,
+		destructive: false,
+		inputSchema: z.object({
+			sessionId: sessionIdField,
+			runId: z.string().min(1),
+			cursor: z.number().int().min(0),
+			waitMs: z.number().int().min(0).max(30000).optional(),
+		}),
+		outputSchema: z.object({
+			ok: z.literal(true),
+			events: z.array(z.unknown()),
+			nextCursor: z.number().int().min(0),
+			done: z.boolean(),
+		}),
+		async handler(args, ctx: CapabilityContext) {
+			const result = await readNextAgentTurnEvents({
+				env: ctx.env,
+				sessionId: args.sessionId,
+				runId: args.runId,
+				cursor: args.cursor,
+				waitMs: args.waitMs,
+			})
+			return {
+				ok: true,
+				events: result.events,
+				nextCursor: result.nextCursor,
+				done: result.done,
+			} as const
+		},
+	},
+)
+
+export const metaAgentTurnCancelCapability = defineDomainCapability(
+	capabilityDomainNames.meta,
+	{
+		name: 'agent_turn_cancel',
+		description: 'Interrupt an active agent turn run for a session.',
+		keywords: ['agent', 'turn', 'cancel', 'interrupt'],
+		readOnly: false,
+		idempotent: false,
+		destructive: false,
+		inputSchema: z.object({
+			sessionId: sessionIdField,
+			runId: z.string().min(1),
+		}),
+		outputSchema: z.object({
+			ok: z.literal(true),
+			cancelled: z.boolean(),
+		}),
+		async handler(args, ctx: CapabilityContext) {
+			const result = await cancelAgentTurn({
+				env: ctx.env,
+				sessionId: args.sessionId,
+				runId: args.runId,
+			})
+			return {
+				ok: true,
+				cancelled: result.cancelled,
+			} as const
+		},
+	},
+)
+
+export const metaAgentChatTurnCapability = defineDomainCapability(
+	capabilityDomainNames.meta,
+	{
+		name: 'agent_chat_turn',
+		description:
+			'Run a full generic tool-using agent turn to completion and return the final structured result.',
+		keywords: ['agent', 'chat', 'turn', 'inference'],
+		readOnly: false,
+		idempotent: false,
+		destructive: false,
+		inputSchema: agentTurnInputSchema.extend({
+			sessionId: sessionIdField,
+			waitMs: z
+				.number()
+				.int()
+				.min(0)
+				.max(30000)
+				.optional()
+				.describe('Optional long-poll wait time between event batches.'),
+		}),
+		outputSchema: z.object({
+			ok: z.boolean(),
+			result: z.unknown().optional(),
+			error: z.string().optional(),
+			events: z.array(z.unknown()).optional(),
+		}),
+		async handler(
+			args: AgentTurnToolInput & { waitMs?: number },
+			ctx: CapabilityContext,
+		) {
+			try {
+				const started = await beginAgentTurn({
+					env: ctx.env,
+					callerContext: ctx.callerContext,
+					turn: args,
+				})
+				const events = (await collectAgentTurnEvents({
+					env: ctx.env,
+					sessionId: args.sessionId,
+					runId: started.runId,
+					waitMs: args.waitMs,
+				})) as Array<AgentTurnStreamEvent>
+				const completion = events.find(
+					(
+						event,
+					): event is Extract<
+						AgentTurnStreamEvent,
+						{ type: 'turn_complete' }
+					> => event.type === 'turn_complete',
+				)
+				if (!completion) {
+					return {
+						ok: false,
+						error: 'Agent turn finished without a turn_complete event.',
+						events,
+					}
+				}
+				const result: AgentTurnResult = {
+					assistantText: completion.assistantText,
+					reasoningText: completion.reasoningText,
+					summary: completion.summary,
+					continueRecommended: completion.continueRecommended,
+					needsUserInput: completion.needsUserInput,
+					stepsUsed: completion.stepsUsed,
+					newInformation: completion.newInformation,
+					stopReason: completion.stopReason,
+					finishReason: completion.finishReason,
+					toolCalls: completion.toolCalls,
+					conversationId: completion.conversationId,
+				}
+				return {
+					ok: true,
+					result,
+					events,
+				}
+			} catch (error) {
+				return {
+					ok: false,
+					error: error instanceof Error ? error.message : String(error),
+				}
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/execute-modules/codemode-utils.node.test.ts
+++ b/packages/worker/src/mcp/execute-modules/codemode-utils.node.test.ts
@@ -22,6 +22,9 @@ type SandboxHelpers = {
 	) => Promise<
 		(input: ExecuteRequestInput, init?: RequestInit) => Promise<Response>
 	>
+	agentChatTurnStream: (
+		input: Record<string, unknown>,
+	) => Promise<AsyncIterable<unknown>>
 }
 
 const spotifyConnector = {
@@ -56,6 +59,49 @@ function createCodemode(payload: Record<string, unknown>) {
 				name: call.name,
 				scope: call.scope,
 			}
+		},
+		async agent_turn_start() {
+			return {
+				ok: true,
+				runId: 'run-123',
+				sessionId: 'session-123',
+				conversationId: 'conversation-123',
+			}
+		},
+		async agent_turn_next(args: CapabilityArgs) {
+			const cursor = Number(args.cursor ?? 0)
+			if (cursor === 0) {
+				return {
+					ok: true,
+					events: [{ type: 'assistant_delta', text: 'Hello' }],
+					nextCursor: 1,
+					done: false,
+				}
+			}
+			return {
+				ok: true,
+				events: [
+					{
+						type: 'turn_complete',
+						assistantText: 'Hello world',
+						reasoningText: '',
+						summary: null,
+						continueRecommended: false,
+						needsUserInput: false,
+						stepsUsed: 1,
+						newInformation: true,
+						stopReason: 'completed',
+						finishReason: 'stop',
+						toolCalls: [],
+						conversationId: 'conversation-123',
+					},
+				],
+				nextCursor: 2,
+				done: true,
+			}
+		},
+		async agent_turn_cancel() {
+			return { ok: true, cancelled: true }
 		},
 	} satisfies CodemodeNamespace
 
@@ -205,5 +251,51 @@ test('getExecuteHelperCapabilityNames includes secret_set for refresh persistenc
 		'connector_get',
 		'value_get',
 		'secret_set',
+		'agent_turn_start',
+		'agent_turn_next',
+		'agent_turn_cancel',
+	])
+})
+
+test('createExecuteHelperPrelude exposes agentChatTurnStream as an async iterable', async () => {
+	const { codemode } = createCodemode({
+		access_token: 'new-access-token',
+		refresh_token: 'new-refresh-token',
+	})
+	const prelude = createExecuteHelperPrelude()
+	const createSandboxHelpers = new Function(
+		'codemode',
+		`${prelude}; return { agentChatTurnStream };`,
+	) as (
+		codemodeNamespace: CodemodeNamespace,
+	) => Pick<SandboxHelpers, 'agentChatTurnStream'>
+
+	const helpers = createSandboxHelpers(codemode)
+	const stream = await helpers.agentChatTurnStream({
+		sessionId: 'session-123',
+		messages: [{ role: 'user', content: 'hello' }],
+		system: 'system',
+	})
+	const events: Array<unknown> = []
+	for await (const event of stream) {
+		events.push(event)
+	}
+
+	expect(events).toEqual([
+		{ type: 'assistant_delta', text: 'Hello' },
+		{
+			type: 'turn_complete',
+			assistantText: 'Hello world',
+			reasoningText: '',
+			summary: null,
+			continueRecommended: false,
+			needsUserInput: false,
+			stepsUsed: 1,
+			newInformation: true,
+			stopReason: 'completed',
+			finishReason: 'stop',
+			toolCalls: [],
+			conversationId: 'conversation-123',
+		},
 	])
 })

--- a/packages/worker/src/mcp/execute-modules/codemode-utils.ts
+++ b/packages/worker/src/mcp/execute-modules/codemode-utils.ts
@@ -503,7 +503,7 @@ const refreshAccessToken = async (providerName) =>
   __kodyRefreshAccessToken(providerName);
 const createAuthenticatedFetch = async (providerName) =>
   __kodyCreateAuthenticatedFetch(providerName);
-const agentChatTurnStream = async (input) =>
+const agentChatTurnStream = (input) =>
   __kodyAgentChatTurnStream(input);
 `.trim()
 }

--- a/packages/worker/src/mcp/execute-modules/codemode-utils.ts
+++ b/packages/worker/src/mcp/execute-modules/codemode-utils.ts
@@ -40,6 +40,9 @@ export const EXECUTE_HELPER_CAPABILITY_NAMES = [
 	'connector_get',
 	'value_get',
 	'secret_set',
+	'agent_turn_start',
+	'agent_turn_next',
+	'agent_turn_cancel',
 ] as const
 
 export async function refreshAccessToken(
@@ -464,9 +467,43 @@ const __kodyCreateAuthenticatedFetch = async (providerName) => {
     );
   };
 };
+const __kodyAgentChatTurnStream = async function* (input) {
+  const start = await codemode.agent_turn_start(input);
+  if (!start || !start.ok || !start.runId || !start.sessionId) {
+    throw new Error('agent_turn_start did not return a valid run id and session id.');
+  }
+  let cursor = 0;
+  let done = false;
+  try {
+    while (!done) {
+      const next = await codemode.agent_turn_next({
+        sessionId: start.sessionId,
+        runId: start.runId,
+        cursor,
+      });
+      const events = Array.isArray(next?.events) ? next.events : [];
+      cursor = typeof next?.nextCursor === 'number' ? next.nextCursor : cursor;
+      for (const event of events) {
+        yield event;
+      }
+      done = next?.done === true;
+    }
+  } finally {
+    if (!done) {
+      try {
+        await codemode.agent_turn_cancel({
+          sessionId: start.sessionId,
+          runId: start.runId,
+        });
+      } catch (error) {}
+    }
+  }
+};
 const refreshAccessToken = async (providerName) =>
   __kodyRefreshAccessToken(providerName);
 const createAuthenticatedFetch = async (providerName) =>
   __kodyCreateAuthenticatedFetch(providerName);
+const agentChatTurnStream = async (input) =>
+  __kodyAgentChatTurnStream(input);
 `.trim()
 }

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -130,3 +130,40 @@ test('fetch gateway expands placeholders in form-urlencoded bodies', async () =>
 		resolveSpy.mockRestore()
 	}
 })
+
+test('fetch gateway resolves path-only URLs against baseUrl', async () => {
+	// Node's Request rejects path-only URLs; workerd allows them for codemode outbound fetch.
+	const request = {
+		url: '/',
+		method: 'GET',
+		headers: new Headers(),
+		redirect: 'follow',
+		credentials: 'same-origin',
+		mode: 'cors',
+		cache: 'default',
+		integrity: '',
+		keepalive: false,
+		signal: undefined,
+		text: async () => '',
+	} as unknown as Request
+	const transformed = await expandSecretPlaceholders({ request, props, env })
+	expect(transformed.url).toBe('https://example.com/')
+})
+
+test('fetch gateway resolves nested path-only URLs against baseUrl', async () => {
+	const request = {
+		url: '/core/log',
+		method: 'GET',
+		headers: new Headers(),
+		redirect: 'follow',
+		credentials: 'same-origin',
+		mode: 'cors',
+		cache: 'default',
+		integrity: '',
+		keepalive: false,
+		signal: undefined,
+		text: async () => '',
+	} as unknown as Request
+	const transformed = await expandSecretPlaceholders({ request, props, env })
+	expect(transformed.url).toBe('https://example.com/core/log')
+})

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -53,6 +53,10 @@ export async function expandSecretPlaceholders(input: {
 		resolved: ResolvedSecret
 	}> = []
 	const replacements = new Map<string, string>()
+	const baseUrl = input.props.baseUrl.trim()
+	if (!baseUrl) {
+		throw new Error('Fetch gateway requires a non-empty baseUrl in props.')
+	}
 	const referencedSecrets = dedupeReferencedSecrets([
 		...collectReferencedSecrets([
 			input.request.url,
@@ -83,7 +87,10 @@ export async function expandSecretPlaceholders(input: {
 	}
 	let requestedHost = ''
 	if (hasReferencedSecrets) {
-		const nextUrl = replaceSecretPlaceholders(input.request.url, replacements)
+		const nextUrl = resolveRequestUrlForFetchGateway(
+			replaceSecretPlaceholders(input.request.url, replacements),
+			baseUrl,
+		)
 		requestedHost = readRequestedHost(nextUrl)
 		if (!requestedHost) {
 			throw new Error(
@@ -104,7 +111,10 @@ export async function expandSecretPlaceholders(input: {
 			)
 		}
 	}
-	const nextUrl = replaceSecretPlaceholders(input.request.url, replacements)
+	const nextUrl = resolveRequestUrlForFetchGateway(
+		replaceSecretPlaceholders(input.request.url, replacements),
+		baseUrl,
+	)
 	for (const [key, value] of Array.from(headers.entries())) {
 		headers.set(key, replaceSecretPlaceholders(value, replacements))
 	}
@@ -132,6 +142,28 @@ export async function expandSecretPlaceholders(input: {
 		keepalive: input.request.keepalive,
 		signal: input.request.signal,
 	})
+}
+
+/**
+ * Codemode / sandboxed fetch may emit path-only URLs (e.g. `/`, `/core/log`).
+ * Workers `Request` requires an absolute URL string; resolve against the app origin.
+ */
+function resolveRequestUrlForFetchGateway(url: string, baseUrl: string) {
+	const trimmed = url.trim()
+	if (!trimmed) {
+		throw new Error('Fetch gateway received an empty request URL.')
+	}
+	try {
+		return new URL(trimmed).toString()
+	} catch {
+		try {
+			return new URL(trimmed, baseUrl).toString()
+		} catch {
+			throw new Error(
+				`Fetch gateway could not resolve request URL "${trimmed}" against baseUrl.`,
+			)
+		}
+	}
 }
 
 async function collectHostApprovalEntries(input: {

--- a/packages/worker/src/mcp/skills/infer-codemode-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/skills/infer-codemode-capabilities.node.test.ts
@@ -52,9 +52,21 @@ test('infers capabilities from execute-time helper names', () => {
 	const src = `async () => {
     const spotifyFetch = await createAuthenticatedFetch('spotify')
     await refreshAccessToken('spotify')
+    const stream = await agentChatTurnStream({
+      sessionId: 'thread-1',
+      system: 'You are helpful.',
+      messages: [{ role: 'user', content: 'Hello' }],
+    })
     return spotifyFetch
   }`
 	const { helperNames, inferencePartial } = inferCodemodeCapabilities(src)
 	expect(inferencePartial).toBe(false)
-	expect(helperNames).toEqual(['connector_get', 'secret_set', 'value_get'])
+	expect(helperNames).toEqual([
+		'agent_turn_cancel',
+		'agent_turn_next',
+		'agent_turn_start',
+		'connector_get',
+		'secret_set',
+		'value_get',
+	])
 })

--- a/packages/worker/src/mcp/skills/infer-codemode-capabilities.ts
+++ b/packages/worker/src/mcp/skills/infer-codemode-capabilities.ts
@@ -3,6 +3,7 @@ import { EXECUTE_HELPER_CAPABILITY_NAMES } from '#mcp/execute-modules/codemode-u
 const executeHelperNames = new Set([
 	'refreshAccessToken',
 	'createAuthenticatedFetch',
+	'agentChatTurnStream',
 ])
 
 export type InferCodemodeCapabilitiesResult = {

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -42,6 +42,10 @@
 			"deleted_classes": ["JobRunner"],
 			"tag": "v9",
 		},
+		{
+			"new_sqlite_classes": ["AgentTurnRunner"],
+			"tag": "v10",
+		},
 	],
 
 	"observability": {
@@ -91,6 +95,10 @@
 					{
 						"class_name": "StorageRunner",
 						"name": "STORAGE_RUNNER",
+					},
+					{
+						"class_name": "AgentTurnRunner",
+						"name": "AGENT_TURN_RUNNER",
 					},
 					{
 						"class_name": "AppRunner",
@@ -167,6 +175,10 @@
 						"name": "STORAGE_RUNNER",
 					},
 					{
+						"class_name": "AgentTurnRunner",
+						"name": "AGENT_TURN_RUNNER",
+					},
+					{
 						"class_name": "AppRunner",
 						"name": "APP_RUNNER",
 					},
@@ -239,6 +251,10 @@
 					{
 						"class_name": "StorageRunner",
 						"name": "STORAGE_RUNNER",
+					},
+					{
+						"class_name": "AgentTurnRunner",
+						"name": "AGENT_TURN_RUNNER",
 					},
 					{
 						"class_name": "AppRunner",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- update the Cloudflare/Agents runtime dependencies and add `@cloudflare/think`
- add a generic `agent-turn` core module with shared types, a model-facing `search`/`execute` toolset, a bounded tool-using turn runner, a runner Durable Object, and service/API helpers
- add meta capabilities for `agent_chat_turn`, `agent_turn_start`, `agent_turn_next`, and `agent_turn_cancel`
- extend the execute/codemode helper surface with `agentChatTurnStream(...)` backed by the new start/next/cancel transport
- harden the runner lifecycle for active-run rejection, persisted resume state, immediate cancellation, and waiter cleanup
- extract a shared lower-level `streamRemoteToolLoop(...)` from the existing chat runtime so the web chat route and agent-turn runner share the same `streamText(...)` tool-loop core
- add focused tests for the core runner, execute helper prelude, and meta capability wrapper
- update docs to describe the new agent-turn primitives and when to use the streaming helper vs the final-value wrapper

### Validation
- `npm run typecheck`
- focused node tests for:
  - `packages/worker/src/agent-turn/runner.node.test.ts`
  - `packages/worker/src/mcp/execute-modules/codemode-utils.node.test.ts`
  - `packages/worker/src/mcp/capabilities/meta/meta-agent-turn.node.test.ts`
  - `packages/worker/src/mcp/skills/infer-codemode-capabilities.node.test.ts`
- broader related node tests for:
  - `packages/worker/src/ai-runtime.node.test.ts`
  - `packages/worker/src/mcp/run-codemode-registry.node.test.ts`
  - `packages/worker/src/mcp/tools/execute.node.test.ts`
  - `packages/worker/src/mcp/tools/search.node.test.ts`
- full `npm test`

### Notes
- this PR intentionally adds only generic Kody primitives; no Discord-specific integration logic is added to Kody core
- the first version of the tool-using agent surface is intentionally scoped to `search` and `execute` as the model-facing tools for the shared turn runner
- the web chat route still preserves its existing UI transport, but now shares the same lower-level remote tool-loop core via `streamRemoteToolLoop(...)`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01680759-d1bf-4f3b-a036-92f4dab21fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01680759-d1bf-4f3b-a036-92f4dab21fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent-turn primitives: a streaming helper for incremental agent events and a wrapper for single-turn completion; new capabilities to start, poll, cancel, and run chat turns to completion, plus a hosted runner for managing runs.

* **Documentation**
  * Added docs describing the agent-turn primitives, usage patterns, and guidance on where UX-specific logic should live.

* **Tests**
  * Added tests for streaming behavior, runner restore/cancel flows, helper integrations, and capability handlers.

* **Chores**
  * Development dependency bumps and deployment/migration bindings for the runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->