### PR TITLE
Preserve discard session error causes

### DIFF
--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -816,6 +816,7 @@ test('executeJobOnce fails instead of reusing a stale repo session when discard 
 		runHistory: [],
 	}
 
+	const discardFailure = new Error('D1 delete failed')
 	const sessionClient = {
 		openSession: vi.fn(async () => ({
 			id: 'job-runtime-job-repo-discard-failure',

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -675,6 +675,7 @@ test('executeJobOnce refreshes repo sessions when base commit moves', async () =
 		runHistory: [],
 	}
 
+	const discardFailure = new Error('D1 delete failed')
 	const sessionClient = {
 		openSession: vi
 			.fn()
@@ -838,13 +839,17 @@ test('executeJobOnce fails instead of reusing a stale repo session when discard 
 		runChecks: vi.fn(),
 		readFile: vi.fn(),
 		discardSession: vi.fn(async () => {
-			throw new Error('D1 delete failed')
+			throw discardFailure
 		}),
 	}
 
 	const repoSessionRpcSpy = vi
 		.spyOn(await import('#worker/repo/repo-session-do.ts'), 'repoSessionRpc')
 		.mockReturnValue(sessionClient as never)
+	const formatJobErrorSpy = vi.spyOn(
+		await import('./schedule.ts'),
+		'formatJobError',
+	)
 	const executeSpy = vi.spyOn(
 		await import('#mcp/run-codemode-registry.ts'),
 		'runCodemodeWithRegistry',
@@ -866,8 +871,15 @@ test('executeJobOnce fails instead of reusing a stale repo session when discard 
 		expect(sessionClient.openSession).toHaveBeenCalledTimes(1)
 		expect(sessionClient.runChecks).not.toHaveBeenCalled()
 		expect(executeSpy).not.toHaveBeenCalled()
+		expect(formatJobErrorSpy).toHaveBeenCalledTimes(1)
+		expect(formatJobErrorSpy.mock.calls[0]?.[0]).toMatchObject({
+			message:
+				'Failed to discard stale repo session "job-runtime-job-repo-discard-failure" before refreshing to published commit "commit-1".',
+			cause: discardFailure,
+		})
 	} finally {
 		repoSessionRpcSpy.mockRestore()
+		formatJobErrorSpy.mockRestore()
 		executeSpy.mockRestore()
 	}
 })

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -469,9 +469,10 @@ async function runRepoBackedJob(input: {
 				sessionId: session.id,
 				userId: input.callerContext.user.userId,
 			})
-		} catch {
+		} catch (error) {
 			throw new Error(
 				`Failed to discard stale repo session "${session.id}" before refreshing to published commit "${stalePublishedCommit}".`,
+				{ cause: error },
 			)
 		}
 		session = await sessionClient.openSession(openSessionInput)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve the original `discardSession` failure as the `cause` when stale repo session refresh throws
- extend the existing repo-backed job regression test to assert the wrapped error keeps the original cause

## Testing
- `npx vitest run --project node-unit packages/worker/src/jobs/service.node.test.ts -t "executeJobOnce fails instead of reusing a stale repo session when discard fails"`
- `npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64171cb7-183e-4f5d-86a2-11daa007d7df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64171cb7-183e-4f5d-86a2-11daa007d7df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

