### PR TITLE
Remove unused discardFailure test variable

### DIFF
--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -674,8 +674,6 @@ test('executeJobOnce refreshes repo sessions when base commit moves', async () =
 		errorCount: 0,
 		runHistory: [],
 	}
-
-	const discardFailure = new Error('D1 delete failed')
 	const sessionClient = {
 		openSession: vi
 			.fn()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the stray `discardFailure` declaration from the successful repo-backed job test in `packages/worker/src/jobs/service.node.test.ts`
- leave the discard-failure test as the only case that defines and throws that error

## Testing
- `npx vitest run --project node-unit packages/worker/src/jobs/service.node.test.ts`
- confirmed the file now has only the discard-failure test references to `discardFailure`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cee8cdf6-08cb-4ecd-b36c-1140e8a0e27b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cee8cdf6-08cb-4ecd-b36c-1140e8a0e27b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

