### PR TITLE
Add repo-backed source backfill capability

### DIFF
--- a/packages/worker/src/mcp/capabilities/jobs/job-upsert.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-upsert.node.test.ts
@@ -1,0 +1,133 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	createJob: vi.fn(),
+	updateJob: vi.fn(),
+	syncJobManagerAlarm: vi.fn(),
+}))
+
+vi.mock('#worker/jobs/service.ts', () => ({
+	createJob: (...args: Array<unknown>) => mockModule.createJob(...args),
+	updateJob: (...args: Array<unknown>) => mockModule.updateJob(...args),
+}))
+
+vi.mock('#worker/jobs/manager-do.ts', () => ({
+	syncJobManagerAlarm: (...args: Array<unknown>) =>
+		mockModule.syncJobManagerAlarm(...args),
+}))
+
+const { jobUpsertCapability } = await import('./job-upsert.ts')
+
+test('job_upsert forwards repo-backed fields on create', async () => {
+	mockModule.createJob.mockReset()
+	mockModule.updateJob.mockReset()
+	mockModule.syncJobManagerAlarm.mockReset()
+	mockModule.createJob.mockResolvedValueOnce({
+		version: 1,
+		id: 'job-1',
+		name: 'Repo-backed create',
+		code: null,
+		sourceId: 'source-1',
+		publishedCommit: 'commit-1',
+		storageId: 'job:job-1',
+		schedule: { type: 'interval', every: '15m' },
+		timezone: 'UTC',
+		enabled: true,
+		killSwitchEnabled: false,
+		createdAt: '2026-04-17T00:00:00.000Z',
+		updatedAt: '2026-04-17T00:00:00.000Z',
+		nextRunAt: '2026-04-17T00:15:00.000Z',
+		runCount: 0,
+		successCount: 0,
+		errorCount: 0,
+		runHistory: [],
+		scheduleSummary: 'Runs every 15m',
+	})
+
+	await jobUpsertCapability.handler(
+		{
+			name: 'Repo-backed create',
+			code: null,
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			schedule: { type: 'interval', every: '15m' },
+		},
+		{
+			env: {} as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				user: { userId: 'user-1', email: 'user@example.com' },
+			}),
+		},
+	)
+
+	expect(mockModule.createJob).toHaveBeenCalledWith({
+		env: {},
+		callerContext: expect.objectContaining({
+			baseUrl: 'https://heykody.dev',
+		}),
+		body: expect.objectContaining({
+			name: 'Repo-backed create',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			schedule: { type: 'interval', every: '15m' },
+		}),
+	})
+})
+
+test('job_upsert forwards repo-backed fields on update', async () => {
+	mockModule.createJob.mockReset()
+	mockModule.updateJob.mockReset()
+	mockModule.syncJobManagerAlarm.mockReset()
+	mockModule.updateJob.mockResolvedValueOnce({
+		version: 1,
+		id: 'job-1',
+		name: 'Repo-backed update',
+		code: null,
+		sourceId: 'source-1',
+		publishedCommit: 'commit-2',
+		storageId: 'job:job-1',
+		schedule: { type: 'interval', every: '15m' },
+		timezone: 'UTC',
+		enabled: true,
+		killSwitchEnabled: false,
+		createdAt: '2026-04-17T00:00:00.000Z',
+		updatedAt: '2026-04-17T00:05:00.000Z',
+		nextRunAt: '2026-04-17T00:15:00.000Z',
+		runCount: 0,
+		successCount: 0,
+		errorCount: 0,
+		runHistory: [],
+		scheduleSummary: 'Runs every 15m',
+	})
+
+	await jobUpsertCapability.handler(
+		{
+			id: 'job-1',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-2',
+			code: null,
+		},
+		{
+			env: {} as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				user: { userId: 'user-1', email: 'user@example.com' },
+			}),
+		},
+	)
+
+	expect(mockModule.updateJob).toHaveBeenCalledWith({
+		env: {},
+		callerContext: expect.objectContaining({
+			baseUrl: 'https://heykody.dev',
+		}),
+		body: {
+			id: 'job-1',
+			code: null,
+			sourceId: 'source-1',
+			publishedCommit: 'commit-2',
+		},
+	})
+})

--- a/packages/worker/src/mcp/capabilities/jobs/job-upsert.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-upsert.ts
@@ -31,6 +31,12 @@ export const jobUpsertCapability = defineDomainCapability(
 							body: {
 								name: args.name ?? '',
 								code: args.code ?? '',
+								...(args.sourceId !== undefined
+									? { sourceId: args.sourceId }
+									: {}),
+								...(args.publishedCommit !== undefined
+									? { publishedCommit: args.publishedCommit }
+									: {}),
 								...(args.params !== undefined && args.params !== null
 									? { params: args.params }
 									: {}),
@@ -53,6 +59,13 @@ export const jobUpsertCapability = defineDomainCapability(
 								id: args.id,
 								...(args.name !== undefined ? { name: args.name } : {}),
 								...(typeof args.code === 'string' ? { code: args.code } : {}),
+								...(args.code === null ? { code: null } : {}),
+								...(args.sourceId !== undefined
+									? { sourceId: args.sourceId }
+									: {}),
+								...(args.publishedCommit !== undefined
+									? { publishedCommit: args.publishedCommit }
+									: {}),
 								...(args.params !== undefined ? { params: args.params } : {}),
 								...(args.schedule !== undefined
 									? { schedule: args.schedule }

--- a/packages/worker/src/mcp/capabilities/jobs/job-upsert.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-upsert.ts
@@ -30,7 +30,7 @@ export const jobUpsertCapability = defineDomainCapability(
 							callerContext: ctx.callerContext,
 							body: {
 								name: args.name ?? '',
-								code: args.code ?? '',
+								code: args.code === undefined ? '' : args.code,
 								...(args.sourceId !== undefined
 									? { sourceId: args.sourceId }
 									: {}),

--- a/packages/worker/src/mcp/capabilities/repo/domain.ts
+++ b/packages/worker/src/mcp/capabilities/repo/domain.ts
@@ -1,6 +1,7 @@
 import { defineDomain } from '#mcp/capabilities/define-domain.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { repoApplyPatchCapability } from './repo-apply-patch.ts'
+import { repoBackfillSourcesCapability } from './repo-backfill-sources.ts'
 import { repoDiscardSessionCapability } from './repo-discard-session.ts'
 import { repoGetCheckStatusCapability } from './repo-get-check-status.ts'
 import { repoGetSessionCapability } from './repo-get-session.ts'
@@ -19,6 +20,7 @@ export const repoDomain = defineDomain({
 		'Repo-backed source sessions for opening entity workspaces, reading files, applying edits, and searching code inside live session overlays.',
 	keywords: ['repo', 'artifact', 'session', 'workspace', 'edit', 'search'],
 	capabilities: [
+		repoBackfillSourcesCapability,
 		repoOpenSessionCapability,
 		repoGetSessionCapability,
 		repoTreeCapability,

--- a/packages/worker/src/mcp/capabilities/repo/index.ts
+++ b/packages/worker/src/mcp/capabilities/repo/index.ts
@@ -2,6 +2,7 @@ import { repoDomain } from './domain.ts'
 
 export { repoDomain } from './domain.ts'
 export { repoApplyPatchCapability } from './repo-apply-patch.ts'
+export { repoBackfillSourcesCapability } from './repo-backfill-sources.ts'
 export { repoDiscardSessionCapability } from './repo-discard-session.ts'
 export { repoGetCheckStatusCapability } from './repo-get-check-status.ts'
 export { repoGetSessionCapability } from './repo-get-session.ts'

--- a/packages/worker/src/mcp/capabilities/repo/repo-backfill-sources.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-backfill-sources.node.test.ts
@@ -1,0 +1,89 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	backfillRepoSources: vi.fn(),
+}))
+
+vi.mock('#worker/repo/source-backfill.ts', () => ({
+	backfillRepoSources: (...args: Array<unknown>) =>
+		mockModule.backfillRepoSources(...args),
+}))
+
+const { repoBackfillSourcesCapability } = await import('./repo-backfill-sources.ts')
+
+test('repo_backfill_sources requires an authenticated user', async () => {
+	await expect(
+		repoBackfillSourcesCapability.handler(
+			{},
+			{
+				env: {} as Env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://heykody.dev',
+				}),
+			},
+		),
+	).rejects.toThrow('repo_backfill_sources requires an authenticated user.')
+})
+
+test('repo_backfill_sources delegates to the backfill service', async () => {
+	mockModule.backfillRepoSources.mockReset()
+	mockModule.backfillRepoSources.mockResolvedValueOnce({
+		dryRun: false,
+		apps: { total: 1, planned: 0, migrated: 1, skipped: 0, errors: 0, results: [] },
+		skills: {
+			total: 2,
+			planned: 0,
+			migrated: 2,
+			skipped: 0,
+			errors: 0,
+			results: [],
+		},
+		jobs: { total: 1, planned: 0, migrated: 1, skipped: 0, errors: 0, results: [] },
+		reindex: { apps: 1, skills: 2, jobs: 1 },
+	})
+
+	const result = await repoBackfillSourcesCapability.handler(
+		{
+			dry_run: false,
+			include_apps: true,
+			include_skills: true,
+			include_jobs: true,
+			reindex: true,
+			sync_app_runners: true,
+		},
+		{
+			env: {} as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				user: { userId: 'user-123', email: 'user@example.com' },
+			}),
+		},
+	)
+
+	expect(mockModule.backfillRepoSources).toHaveBeenCalledWith({
+		env: {},
+		userId: 'user-123',
+		baseUrl: 'https://heykody.dev',
+		dryRun: false,
+		includeApps: true,
+		includeSkills: true,
+		includeJobs: true,
+		reindex: true,
+		syncAppRunners: true,
+	})
+	expect(result).toEqual({
+		dryRun: false,
+		apps: { total: 1, planned: 0, migrated: 1, skipped: 0, errors: 0, results: [] },
+		skills: {
+			total: 2,
+			planned: 0,
+			migrated: 2,
+			skipped: 0,
+			errors: 0,
+			results: [],
+		},
+		jobs: { total: 1, planned: 0, migrated: 1, skipped: 0, errors: 0, results: [] },
+		reindex: { apps: 1, skills: 2, jobs: 1 },
+	})
+})

--- a/packages/worker/src/mcp/capabilities/repo/repo-backfill-sources.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-backfill-sources.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { backfillRepoSources } from '#worker/repo/source-backfill.ts'
+
+const entityResultSchema = z.object({
+	kind: z.enum(['app', 'skill', 'job']),
+	id: z.string(),
+	title: z.string(),
+	status: z.enum(['planned', 'migrated', 'skipped', 'error']),
+	reason: z.string().nullable(),
+	sourceId: z.string().nullable(),
+	publishedCommit: z.string().nullable(),
+})
+
+const groupResultSchema = z.object({
+	total: z.number().int().nonnegative(),
+	planned: z.number().int().nonnegative(),
+	migrated: z.number().int().nonnegative(),
+	skipped: z.number().int().nonnegative(),
+	errors: z.number().int().nonnegative(),
+	results: z.array(entityResultSchema),
+})
+
+export const repoBackfillSourcesCapability = defineDomainCapability(
+	capabilityDomainNames.repo,
+	{
+		name: 'repo_backfill_sources',
+		description:
+			'Backfill legacy inline saved apps, skills, and jobs into repo-backed sources for the signed-in user. Safe to re-run: already-published repo sources are skipped instead of overwritten.',
+		keywords: [
+			'repo',
+			'backfill',
+			'migration',
+			'source',
+			'apps',
+			'skills',
+			'jobs',
+		],
+		readOnly: false,
+		idempotent: false,
+		destructive: false,
+		inputSchema: z.object({
+			dry_run: z
+				.boolean()
+				.optional()
+				.describe(
+					'Preview the migration plan without mutating D1 rows, syncing artifact repos, or reindexing search. Defaults to true.',
+				),
+			include_apps: z
+				.boolean()
+				.optional()
+				.describe('Whether to include saved apps in the backfill. Defaults to true.'),
+			include_skills: z
+				.boolean()
+				.optional()
+				.describe('Whether to include saved skills in the backfill. Defaults to true.'),
+			include_jobs: z
+				.boolean()
+				.optional()
+				.describe('Whether to include saved jobs in the backfill. Defaults to true.'),
+			reindex: z
+				.boolean()
+				.optional()
+				.describe(
+					'Whether to rebuild search/vector projections after a real backfill. Ignored during dry_run. Defaults to true.',
+				),
+			sync_app_runners: z
+				.boolean()
+				.optional()
+				.describe(
+					'Whether to refresh saved app runners from the newly published repo-backed source after app backfill. Ignored during dry_run. Defaults to true.',
+				),
+		}),
+		outputSchema: z.object({
+			dryRun: z.boolean(),
+			apps: groupResultSchema,
+			skills: groupResultSchema,
+			jobs: groupResultSchema,
+			reindex: z
+				.object({
+					apps: z.number().int().nonnegative(),
+					skills: z.number().int().nonnegative(),
+					jobs: z.number().int().nonnegative(),
+				})
+				.nullable(),
+		}),
+		async handler(args, ctx: CapabilityContext) {
+			const user = ctx.callerContext.user
+			if (!user) {
+				throw new Error('repo_backfill_sources requires an authenticated user.')
+			}
+			return await backfillRepoSources({
+				env: ctx.env,
+				userId: user.userId,
+				baseUrl: ctx.callerContext.baseUrl,
+				dryRun: args.dry_run,
+				includeApps: args.include_apps,
+				includeSkills: args.include_skills,
+				includeJobs: args.include_jobs,
+				reindex: args.reindex,
+				syncAppRunners: args.sync_app_runners,
+			})
+		},
+	},
+)

--- a/packages/worker/src/repo/source-backfill.ts
+++ b/packages/worker/src/repo/source-backfill.ts
@@ -161,6 +161,26 @@ async function backfillApp(input: {
 			sourceId: input.row.sourceId,
 		})
 		if (existingSource?.published_commit) {
+			if (!input.dryRun && input.syncAppRunner) {
+				try {
+					await syncSavedAppRunnerFromDb({
+						env: input.env,
+						appId: input.row.id,
+						userId: input.userId,
+						baseUrl: input.baseUrl,
+					})
+				} catch (error) {
+					return {
+						kind: 'app',
+						id: input.row.id,
+						title: input.row.title,
+						status: 'error',
+						reason: formatBackfillError(error),
+						sourceId: existingSource.id,
+						publishedCommit: existingSource.published_commit,
+					}
+				}
+			}
 			return {
 				kind: 'app',
 				id: input.row.id,

--- a/packages/worker/src/repo/source-backfill.ts
+++ b/packages/worker/src/repo/source-backfill.ts
@@ -236,6 +236,12 @@ async function backfillApp(input: {
 		if (!publishedCommit) {
 			throw new Error('App backfill could not publish a repo-backed source snapshot.')
 		}
+		await updateEntitySource(input.env.APP_DB, {
+			id: ensuredSource.id,
+			userId: input.userId,
+			publishedCommit,
+			indexedCommit: publishedCommit,
+		})
 		if (input.syncAppRunner) {
 			await syncSavedAppRunnerFromDb({
 				env: input.env,
@@ -478,6 +484,12 @@ async function backfillJob(input: {
 		if (!publishedCommit) {
 			throw new Error('Job backfill could not publish a repo-backed source snapshot.')
 		}
+		await updateEntitySource(input.env.APP_DB, {
+			id: ensuredSource.id,
+			userId: input.userId,
+			publishedCommit,
+			indexedCommit: publishedCommit,
+		})
 		await updateJobRow({
 			db: input.env.APP_DB,
 			userId: input.userId,

--- a/packages/worker/src/repo/source-backfill.ts
+++ b/packages/worker/src/repo/source-backfill.ts
@@ -1,0 +1,527 @@
+import { syncSavedAppRunnerFromDb } from '#mcp/app-runner.ts'
+import { parseUiArtifactParameters } from '#mcp/ui-artifact-parameters.ts'
+import {
+	listUiArtifactsByUserId,
+	updateUiArtifact,
+} from '#mcp/ui-artifacts-repo.ts'
+import { type UiArtifactRow } from '#mcp/ui-artifacts-types.ts'
+import {
+	listMcpSkillsByUserId,
+	updateMcpSkill,
+} from '#mcp/skills/mcp-skills-repo.ts'
+import { type McpSkillRow } from '#mcp/skills/mcp-skills-types.ts'
+import { parseSkillParameters } from '#mcp/skills/skill-parameters.ts'
+import { reindexSkillVectors } from '#mcp/skills/skill-reindex.ts'
+import { reindexUiArtifactVectors } from '#mcp/ui-artifact-reindex.ts'
+import { reindexJobVectors } from '#worker/jobs/job-reindex.ts'
+import { listJobRowsByUserId, type JobRow, updateJobRow } from '#worker/jobs/repo.ts'
+import { toJobView } from '#worker/jobs/schedule.ts'
+import {
+	getEntitySourceByEntity,
+	getEntitySourceById,
+	updateEntitySource,
+} from './entity-sources.ts'
+import { buildAppSourceFiles, buildJobSourceFiles, buildSkillSourceFiles } from './source-templates.ts'
+import { ensureEntitySource } from './source-service.ts'
+import { syncArtifactSourceSnapshot } from './source-sync.ts'
+
+type BackfillStatus = 'planned' | 'migrated' | 'skipped' | 'error'
+type BackfillEntityKind = 'app' | 'skill' | 'job'
+
+export type SourceBackfillEntityResult = {
+	kind: BackfillEntityKind
+	id: string
+	title: string
+	status: BackfillStatus
+	reason: string | null
+	sourceId: string | null
+	publishedCommit: string | null
+}
+
+type SourceBackfillGroupResult = {
+	total: number
+	planned: number
+	migrated: number
+	skipped: number
+	errors: number
+	results: Array<SourceBackfillEntityResult>
+}
+
+export type SourceBackfillSummary = {
+	dryRun: boolean
+	apps: SourceBackfillGroupResult
+	skills: SourceBackfillGroupResult
+	jobs: SourceBackfillGroupResult
+	reindex: null | {
+		apps: number
+		skills: number
+		jobs: number
+	}
+}
+
+export async function backfillRepoSources(input: {
+	env: Env
+	userId: string
+	baseUrl: string
+	dryRun?: boolean
+	includeApps?: boolean
+	includeSkills?: boolean
+	includeJobs?: boolean
+	reindex?: boolean
+	syncAppRunners?: boolean
+}) {
+	const dryRun = input.dryRun ?? true
+	const appRows = input.includeApps === false ? [] : await listUiArtifactsByUserId(input.env.APP_DB, input.userId)
+	const skillRows =
+		input.includeSkills === false
+			? []
+			: await listMcpSkillsByUserId(input.env.APP_DB, input.userId)
+	const jobRows =
+		input.includeJobs === false
+			? []
+			: await listJobRowsByUserId(input.env.APP_DB, input.userId)
+
+	const apps = await backfillGroup(appRows, (row) =>
+		backfillApp({
+			row,
+			env: input.env,
+			userId: input.userId,
+			baseUrl: input.baseUrl,
+			dryRun,
+			syncAppRunner: input.syncAppRunners ?? true,
+		}),
+	)
+	const skills = await backfillGroup(skillRows, (row) =>
+		backfillSkill({
+			row,
+			env: input.env,
+			userId: input.userId,
+			baseUrl: input.baseUrl,
+			dryRun,
+		}),
+	)
+	const jobs = await backfillGroup(jobRows, (row) =>
+		backfillJob({
+			row,
+			env: input.env,
+			userId: input.userId,
+			baseUrl: input.baseUrl,
+			dryRun,
+		}),
+	)
+
+	const shouldReindex = !dryRun && (input.reindex ?? true)
+	const reindex =
+		shouldReindex === false
+			? null
+			: {
+					apps: (await reindexUiArtifactVectors(input.env)).upserted,
+					skills: (await reindexSkillVectors(input.env)).upserted,
+					jobs: (await reindexJobVectors(input.env)).upserted,
+				}
+
+	return {
+		dryRun,
+		apps,
+		skills,
+		jobs,
+		reindex,
+	} satisfies SourceBackfillSummary
+}
+
+async function backfillGroup<T>(
+	rows: Array<T>,
+	run: (row: T) => Promise<SourceBackfillEntityResult>,
+): Promise<SourceBackfillGroupResult> {
+	const results = await Promise.all(rows.map((row) => run(row)))
+	return {
+		total: results.length,
+		planned: results.filter((result) => result.status === 'planned').length,
+		migrated: results.filter((result) => result.status === 'migrated').length,
+		skipped: results.filter((result) => result.status === 'skipped').length,
+		errors: results.filter((result) => result.status === 'error').length,
+		results,
+	}
+}
+
+async function backfillApp(input: {
+	row: UiArtifactRow
+	env: Env
+	userId: string
+	baseUrl: string
+	dryRun: boolean
+	syncAppRunner: boolean
+}): Promise<SourceBackfillEntityResult> {
+	try {
+		const existingSource = await getExistingEntitySource({
+			db: input.env.APP_DB,
+			userId: input.userId,
+			entityKind: 'app',
+			entityId: input.row.id,
+			sourceId: input.row.sourceId,
+		})
+		if (existingSource?.published_commit) {
+			return {
+				kind: 'app',
+				id: input.row.id,
+				title: input.row.title,
+				status: 'skipped',
+				reason: 'Repo-backed source already published.',
+				sourceId: existingSource.id,
+				publishedCommit: existingSource.published_commit,
+			}
+		}
+
+		const parameters = parseUiArtifactParameters(input.row.parameters)
+		if (input.dryRun) {
+			return {
+				kind: 'app',
+				id: input.row.id,
+				title: input.row.title,
+				status: 'planned',
+				reason: 'Would create and publish a repo-backed source snapshot.',
+				sourceId: existingSource?.id ?? input.row.sourceId,
+				publishedCommit: existingSource?.published_commit ?? null,
+			}
+		}
+
+		const ensuredSource = await ensureEntitySource({
+			db: input.env.APP_DB,
+			env: input.env,
+			id: input.row.sourceId ?? undefined,
+			userId: input.userId,
+			entityKind: 'app',
+			entityId: input.row.id,
+			sourceRoot: '/',
+		})
+		if (input.row.sourceId !== ensuredSource.id) {
+			await updateUiArtifact(input.env.APP_DB, input.userId, input.row.id, {
+				sourceId: ensuredSource.id,
+			})
+		}
+		const publishedCommit = await syncArtifactSourceSnapshot({
+			env: input.env,
+			userId: input.userId,
+			baseUrl: input.baseUrl,
+			sourceId: ensuredSource.id,
+			files: buildAppSourceFiles({
+				title: input.row.title,
+				description: input.row.description,
+				parameters,
+				hidden: input.row.hidden,
+				clientCode: input.row.clientCode,
+				serverCode: input.row.serverCode,
+			}),
+		})
+		if (!publishedCommit) {
+			throw new Error('App backfill could not publish a repo-backed source snapshot.')
+		}
+		if (input.syncAppRunner) {
+			await syncSavedAppRunnerFromDb({
+				env: input.env,
+				appId: input.row.id,
+				userId: input.userId,
+				baseUrl: input.baseUrl,
+			})
+		}
+		return {
+			kind: 'app',
+			id: input.row.id,
+			title: input.row.title,
+			status: 'migrated',
+			reason: 'Published repo-backed source snapshot from legacy inline app source.',
+			sourceId: ensuredSource.id,
+			publishedCommit,
+		}
+	} catch (error) {
+		return {
+			kind: 'app',
+			id: input.row.id,
+			title: input.row.title,
+			status: 'error',
+			reason: formatBackfillError(error),
+			sourceId: input.row.sourceId,
+			publishedCommit: null,
+		}
+	}
+}
+
+async function backfillSkill(input: {
+	row: McpSkillRow
+	env: Env
+	userId: string
+	baseUrl: string
+	dryRun: boolean
+}): Promise<SourceBackfillEntityResult> {
+	try {
+		const existingSource = await getExistingEntitySource({
+			db: input.env.APP_DB,
+			userId: input.userId,
+			entityKind: 'skill',
+			entityId: input.row.id,
+			sourceId: input.row.source_id,
+		})
+		if (existingSource?.published_commit) {
+			return {
+				kind: 'skill',
+				id: input.row.id,
+				title: input.row.title,
+				status: 'skipped',
+				reason: 'Repo-backed source already published.',
+				sourceId: existingSource.id,
+				publishedCommit: existingSource.published_commit,
+			}
+		}
+
+		if (input.dryRun) {
+			return {
+				kind: 'skill',
+				id: input.row.id,
+				title: input.row.title,
+				status: 'planned',
+				reason: 'Would create and publish a repo-backed source snapshot.',
+				sourceId: existingSource?.id ?? input.row.source_id,
+				publishedCommit: existingSource?.published_commit ?? null,
+			}
+		}
+
+		const ensuredSource = await ensureEntitySource({
+			db: input.env.APP_DB,
+			env: input.env,
+			id: input.row.source_id ?? undefined,
+			userId: input.userId,
+			entityKind: 'skill',
+			entityId: input.row.id,
+			sourceRoot: '/',
+		})
+		if (input.row.source_id !== ensuredSource.id) {
+			await updateMcpSkill(input.env.APP_DB, input.userId, input.row.name, {
+				name: input.row.name,
+				title: input.row.title,
+				description: input.row.description,
+				source_id: ensuredSource.id,
+				keywords: input.row.keywords,
+				code: input.row.code,
+				search_text: input.row.search_text,
+				uses_capabilities: input.row.uses_capabilities,
+				parameters: input.row.parameters,
+				collection_name: input.row.collection_name,
+				collection_slug: input.row.collection_slug,
+				inferred_capabilities: input.row.inferred_capabilities,
+				inference_partial: input.row.inference_partial,
+				read_only: input.row.read_only,
+				idempotent: input.row.idempotent,
+				destructive: input.row.destructive,
+			})
+		}
+		const publishedCommit = await syncArtifactSourceSnapshot({
+			env: input.env,
+			userId: input.userId,
+			baseUrl: input.baseUrl,
+			sourceId: ensuredSource.id,
+			files: buildSkillSourceFiles({
+				title: input.row.title,
+				description: input.row.description,
+				keywords: parseJsonStringArray(input.row.keywords),
+				searchText: input.row.search_text,
+				collection: input.row.collection_name,
+				readOnly: input.row.read_only === 1,
+				idempotent: input.row.idempotent === 1,
+				destructive: input.row.destructive === 1,
+				usesCapabilities: parseOptionalJsonStringArray(
+					input.row.uses_capabilities,
+				),
+				parameters: parseSkillParameters(input.row.parameters),
+				code: input.row.code,
+			}),
+		})
+		if (!publishedCommit) {
+			throw new Error('Skill backfill could not publish a repo-backed source snapshot.')
+		}
+		await updateEntitySource(input.env.APP_DB, {
+			id: ensuredSource.id,
+			userId: input.userId,
+			publishedCommit,
+			indexedCommit: publishedCommit,
+		})
+		return {
+			kind: 'skill',
+			id: input.row.id,
+			title: input.row.title,
+			status: 'migrated',
+			reason: 'Published repo-backed source snapshot from legacy inline skill source.',
+			sourceId: ensuredSource.id,
+			publishedCommit,
+		}
+	} catch (error) {
+		return {
+			kind: 'skill',
+			id: input.row.id,
+			title: input.row.title,
+			status: 'error',
+			reason: formatBackfillError(error),
+			sourceId: input.row.source_id,
+			publishedCommit: null,
+		}
+	}
+}
+
+async function backfillJob(input: {
+	row: JobRow
+	env: Env
+	userId: string
+	baseUrl: string
+	dryRun: boolean
+}): Promise<SourceBackfillEntityResult> {
+	try {
+		const existingSource = await getExistingEntitySource({
+			db: input.env.APP_DB,
+			userId: input.userId,
+			entityKind: 'job',
+			entityId: input.row.record.id,
+			sourceId: input.row.record.sourceId,
+		})
+		if (existingSource?.published_commit) {
+			if (
+				!input.dryRun &&
+				input.row.record.publishedCommit !== existingSource.published_commit
+			) {
+				await updateJobRow({
+					db: input.env.APP_DB,
+					userId: input.userId,
+					job: {
+						...input.row.record,
+						sourceId: existingSource.id,
+						publishedCommit: existingSource.published_commit,
+					},
+					callerContextJson: input.row.callerContextJson,
+				})
+			}
+			return {
+				kind: 'job',
+				id: input.row.record.id,
+				title: input.row.record.name,
+				status: 'skipped',
+				reason: 'Repo-backed source already published.',
+				sourceId: existingSource.id,
+				publishedCommit: existingSource.published_commit,
+			}
+		}
+		if (!input.row.record.code?.trim()) {
+			throw new Error(
+				'Job has no inline code available for backfill and no published repo source to preserve.',
+			)
+		}
+
+		if (input.dryRun) {
+			return {
+				kind: 'job',
+				id: input.row.record.id,
+				title: input.row.record.name,
+				status: 'planned',
+				reason: 'Would create and publish a repo-backed source snapshot.',
+				sourceId: existingSource?.id ?? input.row.record.sourceId,
+				publishedCommit: existingSource?.published_commit ?? null,
+			}
+		}
+
+		const ensuredSource = await ensureEntitySource({
+			db: input.env.APP_DB,
+			env: input.env,
+			id: input.row.record.sourceId ?? undefined,
+			userId: input.userId,
+			entityKind: 'job',
+			entityId: input.row.record.id,
+			sourceRoot: '/',
+		})
+		const nextRecord = {
+			...input.row.record,
+			sourceId: ensuredSource.id,
+		}
+		if (input.row.record.sourceId !== ensuredSource.id) {
+			await updateJobRow({
+				db: input.env.APP_DB,
+				userId: input.userId,
+				job: nextRecord,
+				callerContextJson: input.row.callerContextJson,
+			})
+		}
+		const publishedCommit = await syncArtifactSourceSnapshot({
+			env: input.env,
+			userId: input.userId,
+			baseUrl: input.baseUrl,
+			sourceId: ensuredSource.id,
+			files: buildJobSourceFiles({
+				job: toJobView(nextRecord),
+			}),
+		})
+		if (!publishedCommit) {
+			throw new Error('Job backfill could not publish a repo-backed source snapshot.')
+		}
+		await updateJobRow({
+			db: input.env.APP_DB,
+			userId: input.userId,
+			job: {
+				...nextRecord,
+				publishedCommit,
+			},
+			callerContextJson: input.row.callerContextJson,
+		})
+		return {
+			kind: 'job',
+			id: input.row.record.id,
+			title: input.row.record.name,
+			status: 'migrated',
+			reason: 'Published repo-backed source snapshot from legacy inline job code.',
+			sourceId: ensuredSource.id,
+			publishedCommit,
+		}
+	} catch (error) {
+		return {
+			kind: 'job',
+			id: input.row.record.id,
+			title: input.row.record.name,
+			status: 'error',
+			reason: formatBackfillError(error),
+			sourceId: input.row.record.sourceId,
+			publishedCommit: input.row.record.publishedCommit,
+		}
+	}
+}
+
+function parseJsonStringArray(raw: string): Array<string> {
+	try {
+		const parsed = JSON.parse(raw) as unknown
+		return Array.isArray(parsed)
+			? parsed.filter((value): value is string => typeof value === 'string')
+			: []
+	} catch {
+		return []
+	}
+}
+
+function parseOptionalJsonStringArray(raw: string | null): Array<string> | null {
+	return raw == null ? null : parseJsonStringArray(raw)
+}
+
+function formatBackfillError(error: unknown) {
+	if (error instanceof Error) return error.message
+	return String(error)
+}
+
+async function getExistingEntitySource(input: {
+	db: D1Database
+	userId: string
+	entityKind: BackfillEntityKind
+	entityId: string
+	sourceId: string | null
+}) {
+	if (input.sourceId) {
+		return await getEntitySourceById(input.db, input.sourceId)
+	}
+	return await getEntitySourceByEntity(input.db, {
+		userId: input.userId,
+		entityKind: input.entityKind,
+		entityId: input.entityId,
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- add a signed-in-user `repo_backfill_sources` capability that backfills legacy inline saved apps, skills, and jobs into repo-backed sources without overwriting already-published repo truth
- add a reusable repo source backfill service that updates D1 source ids, publishes repo snapshots, refreshes saved app runners, and optionally rebuilds app/skill/job search projections
- wire `job_upsert` to forward `sourceId`, `publishedCommit`, and explicit `code: null` updates so repo-backed jobs remain manageable after migration
- add focused tests for the new backfill capability and the `job_upsert` repo-backed forwarding contract

### Testing
- `npm run test -- --run packages/worker/src/mcp/capabilities/repo/repo-backfill-sources.node.test.ts packages/worker/src/mcp/capabilities/jobs/job-upsert.node.test.ts packages/worker/src/mcp/capabilities/build-capability-registry.workers.test.ts packages/worker/src/jobs/service.node.test.ts`
- `npm run typecheck`

### Notes
- `repo_backfill_sources` is intentionally idempotent at the entity level: if an app, skill, or job already has a published repo-backed source, the backfill reports it as skipped instead of republishing potentially stale D1 fallback source
- the capability defaults to `dry_run: true` so production migration can be previewed safely before the real run
- this PR is the migration path only; legacy D1 source removal is intentionally deferred to a separate cleanup PR after production backfill is complete
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01025a18-17ec-4da3-88ae-9ddee2f174ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01025a18-17ec-4da3-88ae-9ddee2f174ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository source backfill: batch sync of sources for apps, skills, and jobs with dry-run, selective include toggles, optional reindexing, and app-runner sync.
  * Job upsert improvements: better handling of code, explicit support for source ID and published-commit fields (create and update).

* **Tests**
  * Added end-to-end tests covering job create/update forwarding and repository source backfill behaviors, including auth and argument mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->