### PR TITLE
Fix production repo-backed source fallback

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -84,3 +84,28 @@ Bindings are configured per environment in `packages/worker/wrangler.jsonc`
 - `JOB_MANAGER` (Durable Objects)
 - `STORAGE_RUNNER` (Durable Objects)
 - `ASSETS` (static assets bucket)
+
+## Repo-backed sources and Artifacts
+
+Repo-backed saved apps, skills, jobs, and repo editing sessions use Cloudflare
+Artifacts repos plus D1 `entity_sources` / `repo_sessions` rows.
+
+- Primary code lives under `packages/worker/src/repo/`.
+- `entity_sources` stores the durable mapping from `(user_id, entity_kind,
+  entity_id)` to the repo identity and last published commit.
+- `repo_sessions` stores mutable editing forks for repo session Durable Objects.
+
+Production note:
+
+- `packages/worker/wrangler.jsonc` declares a top-level `artifacts` binding for
+  `ARTIFACTS`, but released `wrangler` `4.83.0` still warns that this config is
+  unexpected and production deploy logs show no `env.ARTIFACTS` binding in the
+  deployed Worker binding summary.
+- Because of that deploy-time gap, repo source code must not assume the Worker
+  binding exists in production today.
+- `packages/worker/src/repo/artifacts.ts` now treats the Worker binding as the
+  preferred path and falls back to the documented Artifacts REST API when
+  `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` are available.
+- Durable repo-source creation paths (`ensureEntitySource(...,
+  requirePersistence: true)`) fail closed when persistence bindings are
+  unavailable so callers do not write orphaned `source_id` references into D1.

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -97,15 +97,16 @@ Artifacts repos plus D1 `entity_sources` / `repo_sessions` rows.
 
 Production note:
 
-- `packages/worker/wrangler.jsonc` declares a top-level `artifacts` binding for
-  `ARTIFACTS`, but released `wrangler` `4.83.0` still warns that this config is
-  unexpected and production deploy logs show no `env.ARTIFACTS` binding in the
-  deployed Worker binding summary.
-- Because of that deploy-time gap, repo source code must not assume the Worker
-  binding exists in production today.
-- `packages/worker/src/repo/artifacts.ts` now treats the Worker binding as the
-  preferred path and falls back to the documented Artifacts REST API when
-  `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` are available.
+- Released `wrangler` `4.83.0` still warns that the documented Artifacts Worker
+  binding config is unexpected, and production deploy logs show no
+  `env.ARTIFACTS` binding in the deployed Worker binding summary.
+- Because of that deploy-time gap, repo source code uses the documented
+  Artifacts REST API as the single integration path for create/get/token/fork
+  operations.
+- `packages/worker/src/repo/artifacts.ts` builds that REST client from
+  `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, and optional
+  `CLOUDFLARE_API_BASE_URL` / `ARTIFACTS_NAMESPACE`, which also makes local dev
+  mocking straightforward.
 - Durable repo-source creation paths (`ensureEntitySource(...,
   requirePersistence: true)`) fail closed when persistence bindings are
   unavailable so callers do not write orphaned `source_id` references into D1.

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, expect, test, vi } from 'vitest'
+
+const {
+	getArtifactsBinding,
+	resolveArtifactSourceRepo,
+} = await import('./artifacts.ts')
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+test('artifacts REST fallback supports get, create, token, and fork operations', async () => {
+	const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+		async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			if (method === 'GET' && url.pathname.endsWith('/repos/repo-1')) {
+				if (!fetchMock.mock.calls.some((call) => call[0] === input && call !== fetchMock.mock.calls[0])) {
+					return new Response(
+						JSON.stringify({
+							success: false,
+							result: null,
+							errors: [{ code: 1000, message: 'Repo not found' }],
+							messages: [],
+						}),
+						{
+							status: 404,
+							headers: { 'content-type': 'application/json' },
+						},
+					)
+				}
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo_1',
+							name: 'repo-1',
+							description: 'Repo 1',
+							default_branch: 'main',
+							created_at: '2026-04-17T00:00:00.000Z',
+							updated_at: '2026-04-17T00:00:00.000Z',
+							last_push_at: null,
+							source: null,
+							read_only: false,
+							remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			if (method === 'POST' && url.pathname.endsWith('/repos')) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo_1',
+							name: 'repo-1',
+							description: null,
+							default_branch: 'main',
+							remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+							token: 'art_v1_create?expires=1760000000',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			if (method === 'POST' && url.pathname.endsWith('/tokens')) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'tok_1',
+							plaintext: 'art_v1_read?expires=1760000100',
+							scope: 'read',
+							expires_at: '2026-10-09T08:55:00.000Z',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			if (method === 'POST' && url.pathname.endsWith('/repos/repo-1/fork')) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo_2',
+							name: 'repo-copy',
+							description: null,
+							default_branch: 'main',
+							remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-copy.git',
+							token: 'art_v1_fork?expires=1760000200',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
+		},
+	)
+
+	const env = {
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token-123',
+		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+	} as Env
+
+	const binding = getArtifactsBinding(env)
+	await expect(binding.get('repo-1')).resolves.toEqual({ status: 'not_found' })
+	await expect(binding.create('repo-1')).resolves.toMatchObject({
+		id: 'repo_1',
+		name: 'repo-1',
+		defaultBranch: 'main',
+		remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+		token: 'art_v1_create?expires=1760000000',
+	})
+
+	const repo = await resolveArtifactSourceRepo(env, 'repo-1')
+	await expect(repo.info()).resolves.toMatchObject({
+		id: 'repo_1',
+		name: 'repo-1',
+		defaultBranch: 'main',
+		remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+	})
+	await expect(repo.createToken('read', 120)).resolves.toEqual({
+		id: 'tok_1',
+		plaintext: 'art_v1_read?expires=1760000100',
+		scope: 'read',
+		expiresAt: '2026-10-09T08:55:00.000Z',
+	})
+	await expect(repo.fork({ name: 'repo-copy', readOnly: false })).resolves.toMatchObject(
+		{
+			id: 'repo_2',
+			name: 'repo-copy',
+			defaultBranch: 'main',
+			remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-copy.git',
+			token: 'art_v1_fork?expires=1760000200',
+		},
+	)
+
+	expect(fetchMock).toHaveBeenCalledTimes(6)
+})

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -9,7 +9,7 @@ afterEach(() => {
 	vi.restoreAllMocks()
 })
 
-test('artifacts REST fallback supports get, create, token, and fork operations', async () => {
+test('artifacts REST client supports get, create, token, and fork operations', async () => {
 	const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
 		async (input, init) => {
 			const url = new URL(String(input))

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -10,12 +10,14 @@ afterEach(() => {
 })
 
 test('artifacts REST client supports get, create, token, and fork operations', async () => {
+	let getRepo1Count = 0
 	const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
 		async (input, init) => {
 			const url = new URL(String(input))
 			const method = init?.method ?? 'GET'
 			if (method === 'GET' && url.pathname.endsWith('/repos/repo-1')) {
-				if (!fetchMock.mock.calls.some((call) => call[0] === input && call !== fetchMock.mock.calls[0])) {
+				getRepo1Count += 1
+				if (getRepo1Count === 1) {
 					return new Response(
 						JSON.stringify({
 							success: false,
@@ -158,4 +160,76 @@ test('artifacts REST client supports get, create, token, and fork operations', a
 	)
 
 	expect(fetchMock).toHaveBeenCalledTimes(6)
+})
+
+test('artifacts REST client uses fallback API error text when envelope errors are missing', async () => {
+	vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+		new Response(
+			JSON.stringify({
+				success: false,
+				result: null,
+				messages: [],
+			}),
+			{
+				status: 500,
+				headers: { 'content-type': 'application/json' },
+			},
+		),
+	)
+
+	const env = {
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token-123',
+		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+	} as Env
+
+	const binding = getArtifactsBinding(env)
+
+	await expect(binding.get('repo-1')).rejects.toThrow(
+		'Artifacts API request failed (500).',
+	)
+})
+
+test('artifacts REST client rejects tokens without parseable expiry timestamps', async () => {
+	const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+		async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			if (method === 'POST' && url.pathname.endsWith('/repos')) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo_1',
+							name: 'repo-1',
+							description: null,
+							default_branch: 'main',
+							remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+							token: 'art_v1_missing_expiry',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
+		},
+	)
+
+	const env = {
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token-123',
+		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+	} as Env
+
+	const binding = getArtifactsBinding(env)
+
+	await expect(binding.create('repo-1')).rejects.toThrow(
+		'Artifacts token is missing a parseable expires timestamp.',
+	)
+	expect(fetchMock).toHaveBeenCalledTimes(1)
 })

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -86,6 +86,15 @@ export function getArtifactsBinding(
 	return restBinding
 }
 
+export function hasArtifactsAccess(env: Env) {
+	try {
+		void getArtifactsBinding(env)
+		return true
+	} catch {
+		return false
+	}
+}
+
 export function getArtifactsNamespace(env: Env) {
 	return (
 		(env as Env & { ARTIFACTS_NAMESPACE?: string | undefined })

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -77,18 +77,13 @@ export type ArtifactNamespaceBinding = {
 export function getArtifactsBinding(
 	env: Env,
 ): ArtifactNamespaceBinding & Record<string, unknown> {
-	const binding = (env as Env & { ARTIFACTS?: unknown }).ARTIFACTS
-	if (hasArtifactBindingShape(binding)) {
-		return binding as ArtifactNamespaceBinding & Record<string, unknown>
-	}
 	const restBinding = createArtifactsRestBinding(env)
-	if (restBinding) {
-		return restBinding
+	if (!restBinding) {
+		throw new Error(
+			'Cloudflare Artifacts REST access requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.',
+		)
 	}
-	if (!binding) {
-		throw new Error('ARTIFACTS binding is not configured.')
-	}
-	throw new Error('ARTIFACTS binding is not usable in this runtime.')
+	return restBinding
 }
 
 export function getArtifactsNamespace(env: Env) {
@@ -147,22 +142,6 @@ type ArtifactRestCreateTokenResult = {
 
 type ArtifactRestForkRepoResult = ArtifactRestCreateRepoResult & {
 	objects?: number
-}
-
-function hasArtifactBindingShape(value: unknown): value is ArtifactNamespaceBinding {
-	if (!value || typeof value !== 'object') {
-		return false
-	}
-	const binding = value as {
-		create?: unknown
-		get?: unknown
-		list?: unknown
-	}
-	return (
-		typeof binding.create === 'function' &&
-		typeof binding.get === 'function' &&
-		typeof binding.list === 'function'
-	)
 }
 
 function createArtifactsRestBinding(env: Env) {

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -1,3 +1,7 @@
+import {
+	CloudflareApiError,
+	createCloudflareRestClient,
+} from '#mcp/cloudflare/cloudflare-rest-client.ts'
 import { type EntityKind } from './types.ts'
 
 export type ArtifactToken = {
@@ -48,7 +52,11 @@ export type ArtifactGetRepoResult =
 export type ArtifactNamespaceBinding = {
 	create(
 		name: string,
-		opts?: { readOnly?: boolean },
+		opts?: {
+			description?: string
+			readOnly?: boolean
+			setDefaultBranch?: string
+		},
 	): Promise<{
 		id: string
 		name: string
@@ -69,12 +77,18 @@ export type ArtifactNamespaceBinding = {
 export function getArtifactsBinding(
 	env: Env,
 ): ArtifactNamespaceBinding & Record<string, unknown> {
-	const binding = (env as Env & { ARTIFACTS?: ArtifactNamespaceBinding })
-		.ARTIFACTS
+	const binding = (env as Env & { ARTIFACTS?: unknown }).ARTIFACTS
+	if (hasArtifactBindingShape(binding)) {
+		return binding as ArtifactNamespaceBinding & Record<string, unknown>
+	}
+	const restBinding = createArtifactsRestBinding(env)
+	if (restBinding) {
+		return restBinding
+	}
 	if (!binding) {
 		throw new Error('ARTIFACTS binding is not configured.')
 	}
-	return binding
+	throw new Error('ARTIFACTS binding is not usable in this runtime.')
 }
 
 export function getArtifactsNamespace(env: Env) {
@@ -82,6 +96,302 @@ export function getArtifactsNamespace(env: Env) {
 		(env as Env & { ARTIFACTS_NAMESPACE?: string | undefined })
 			.ARTIFACTS_NAMESPACE ?? 'default'
 	)
+}
+
+type ArtifactApiEnvelope<T> = {
+	result: T | null
+	success: boolean
+	errors: Array<{
+		code: number
+		message: string
+	}>
+	messages: Array<{
+		code: number
+		message: string
+	}>
+	result_info?: {
+		cursor?: string
+		count?: number
+		total_count?: number
+	}
+}
+
+type ArtifactRestRepoInfo = {
+	id: string
+	name: string
+	description: string | null
+	default_branch: string
+	created_at: string
+	updated_at: string
+	last_push_at: string | null
+	source: string | null
+	read_only: boolean
+	remote: string
+}
+
+type ArtifactRestCreateRepoResult = {
+	id: string
+	name: string
+	description: string | null
+	default_branch: string
+	remote: string
+	token: string
+}
+
+type ArtifactRestCreateTokenResult = {
+	id: string
+	plaintext: string
+	scope: string
+	expires_at: string
+}
+
+type ArtifactRestForkRepoResult = ArtifactRestCreateRepoResult & {
+	objects?: number
+}
+
+function hasArtifactBindingShape(value: unknown): value is ArtifactNamespaceBinding {
+	if (!value || typeof value !== 'object') {
+		return false
+	}
+	const binding = value as {
+		create?: unknown
+		get?: unknown
+		list?: unknown
+	}
+	return (
+		typeof binding.create === 'function' &&
+		typeof binding.get === 'function' &&
+		typeof binding.list === 'function'
+	)
+}
+
+function createArtifactsRestBinding(env: Env) {
+	const accountId = env.CLOUDFLARE_ACCOUNT_ID?.trim()
+	const apiToken = env.CLOUDFLARE_API_TOKEN?.trim()
+	if (!accountId || !apiToken) {
+		return null
+	}
+	const client = createCloudflareRestClient(env)
+	const namespace = getArtifactsNamespace(env)
+	const basePath = `/client/v4/accounts/${accountId}/artifacts/namespaces/${namespace}`
+	const getRepoInfo = async (name: string): Promise<ArtifactRepoInfo | null> => {
+		const response = await requestArtifactsEnvelope<ArtifactRestRepoInfo>(client, {
+			method: 'GET',
+			path: `${basePath}/repos/${encodeURIComponent(name)}`,
+			treat404AsNull: true,
+		})
+		return response.result ? normalizeArtifactRepoInfo(response.result) : null
+	}
+	const repoHandle = (name: string): ArtifactRepoHandle => ({
+		info: async () => await getRepoInfo(name),
+		createToken: async (scope = 'write', ttl = 3600) => {
+			const result = await requestArtifactsApi<ArtifactRestCreateTokenResult>(
+				client,
+				{
+					method: 'POST',
+					path: `${basePath}/tokens`,
+					body: {
+						repo: name,
+						scope,
+						ttl,
+					},
+				},
+			)
+			return {
+				id: result.id,
+				plaintext: result.plaintext,
+				scope: result.scope,
+				expiresAt: result.expires_at,
+			}
+		},
+		fork: async (target) => {
+			const result = await requestArtifactsApi<ArtifactRestForkRepoResult>(
+				client,
+				{
+					method: 'POST',
+					path: `${basePath}/repos/${encodeURIComponent(name)}/fork`,
+					body: {
+						name: target.name,
+						read_only: target.readOnly ?? false,
+					},
+				},
+			)
+			return {
+				id: result.id,
+				name: result.name,
+				description: result.description,
+				defaultBranch: result.default_branch,
+				remote: result.remote,
+				token: result.token,
+				expiresAt: parseArtifactTokenExpiry(result.token),
+				repo: repoHandle(result.name),
+			}
+		},
+	})
+	return {
+		create: async (name, opts) => {
+			const result = await requestArtifactsApi<ArtifactRestCreateRepoResult>(
+				client,
+				{
+					method: 'POST',
+					path: `${basePath}/repos`,
+					body: {
+						name,
+						...(opts?.description ? { description: opts.description } : {}),
+						...(opts?.setDefaultBranch
+							? { default_branch: opts.setDefaultBranch }
+							: {}),
+						...(opts?.readOnly !== undefined
+							? { read_only: opts.readOnly }
+							: {}),
+					},
+				},
+			)
+			return {
+				id: result.id,
+				name: result.name,
+				description: result.description,
+				defaultBranch: result.default_branch,
+				remote: result.remote,
+				token: result.token,
+				expiresAt: parseArtifactTokenExpiry(result.token),
+			}
+		},
+		get: async (name) => {
+			const info = await getRepoInfo(name)
+			if (!info) {
+				return { status: 'not_found' as const }
+			}
+			return {
+				status: 'ready' as const,
+				repo: repoHandle(name),
+			}
+		},
+		list: async (opts) => {
+			const query: Record<string, string> = {}
+			if (opts?.limit !== undefined) {
+				query['limit'] = String(opts.limit)
+			}
+			if (opts?.cursor) {
+				query['cursor'] = opts.cursor
+			}
+			const envelope = await requestArtifactsEnvelope<Array<ArtifactRestRepoInfo>>(
+				client,
+				{
+					method: 'GET',
+					path: `${basePath}/repos`,
+					query,
+				},
+			)
+			const repos = (envelope.result ?? []).map((repo) => {
+				const normalized = normalizeArtifactRepoInfo(repo)
+				return {
+					id: normalized.id,
+					name: normalized.name,
+					description: normalized.description,
+					defaultBranch: normalized.defaultBranch,
+					createdAt: normalized.createdAt,
+					updatedAt: normalized.updatedAt,
+					lastPushAt: normalized.lastPushAt,
+					source: normalized.source,
+					readOnly: normalized.readOnly,
+				}
+			})
+			return {
+				repos,
+				total: envelope.result_info?.total_count ?? repos.length,
+				cursor: envelope.result_info?.cursor,
+			}
+		},
+	} satisfies ArtifactNamespaceBinding & Record<string, unknown>
+}
+
+async function requestArtifactsApi<T>(
+	client: ReturnType<typeof createCloudflareRestClient>,
+	input: {
+		method: 'GET' | 'POST' | 'DELETE'
+		path: string
+		query?: Record<string, string>
+		body?: unknown
+		treat404AsNull?: boolean
+	},
+) {
+	const envelope = await requestArtifactsEnvelope<T>(client, input)
+	if (envelope.result == null) {
+		throw new Error(`Artifacts API returned no result for ${input.path}.`)
+	}
+	return envelope.result
+}
+
+async function requestArtifactsEnvelope<T>(
+	client: ReturnType<typeof createCloudflareRestClient>,
+	input: {
+		method: 'GET' | 'POST' | 'DELETE'
+		path: string
+		query?: Record<string, string>
+		body?: unknown
+		treat404AsNull?: boolean
+	},
+) {
+	try {
+		const response = await client.rawRequest({
+			method: input.method,
+			path: input.path,
+			query: input.query,
+			body: input.body,
+		})
+		const envelope = response.body as ArtifactApiEnvelope<T> | null
+		if (!envelope?.success) {
+			const message =
+				envelope?.errors[0]?.message ??
+				`Artifacts API request failed (${response.status}).`
+			if (input.treat404AsNull && response.status === 404) {
+				return { ...envelope, result: null } as ArtifactApiEnvelope<T>
+			}
+			throw new Error(message)
+		}
+		return envelope
+	} catch (error) {
+		if (
+			input.treat404AsNull &&
+			error instanceof CloudflareApiError &&
+			error.status === 404
+		) {
+			return {
+				result: null,
+				success: true,
+				errors: [],
+				messages: [],
+			} satisfies ArtifactApiEnvelope<T>
+		}
+		throw error
+	}
+}
+
+function normalizeArtifactRepoInfo(repo: ArtifactRestRepoInfo): ArtifactRepoInfo {
+	return {
+		id: repo.id,
+		name: repo.name,
+		description: repo.description,
+		defaultBranch: repo.default_branch,
+		createdAt: repo.created_at,
+		updatedAt: repo.updated_at,
+		lastPushAt: repo.last_push_at,
+		source: repo.source,
+		readOnly: repo.read_only,
+		remote: repo.remote,
+	}
+}
+
+function parseArtifactTokenExpiry(token: string) {
+	const expiresAtSeconds = Number.parseInt(
+		token.split('?expires=')[1] ?? '',
+		10,
+	)
+	if (Number.isFinite(expiresAtSeconds)) {
+		return new Date(expiresAtSeconds * 1000).toISOString()
+	}
+	return new Date(Date.now() + 3600 * 1000).toISOString()
 }
 
 function normalizeRepoNamePart(value: string) {

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -29,7 +29,6 @@ export type ArtifactRepoHandle = {
 	createToken(scope?: 'write' | 'read', ttl?: number): Promise<ArtifactToken>
 	fork(target: {
 		name: string
-		namespace?: string
 		readOnly?: boolean
 	}): Promise<{
 		id: string
@@ -331,7 +330,7 @@ async function requestArtifactsEnvelope<T>(
 		const envelope = response.body as ArtifactApiEnvelope<T> | null
 		if (!envelope?.success) {
 			const message =
-				envelope?.errors[0]?.message ??
+				envelope?.errors?.[0]?.message ??
 				`Artifacts API request failed (${response.status}).`
 			if (input.treat404AsNull && response.status === 404) {
 				return {
@@ -384,7 +383,7 @@ function parseArtifactTokenExpiry(token: string) {
 	if (Number.isFinite(expiresAtSeconds)) {
 		return new Date(expiresAtSeconds * 1000).toISOString()
 	}
-	return new Date(Date.now() + 3600 * 1000).toISOString()
+	throw new Error('Artifacts token is missing a parseable expires timestamp.')
 }
 
 function normalizeRepoNamePart(value: string) {

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -334,7 +334,12 @@ async function requestArtifactsEnvelope<T>(
 				envelope?.errors[0]?.message ??
 				`Artifacts API request failed (${response.status}).`
 			if (input.treat404AsNull && response.status === 404) {
-				return { ...envelope, result: null } as ArtifactApiEnvelope<T>
+				return {
+					result: null,
+					success: true,
+					errors: [],
+					messages: [],
+				} satisfies ArtifactApiEnvelope<T>
 			}
 			throw new Error(message)
 		}

--- a/packages/worker/src/repo/source-backfill.node.test.ts
+++ b/packages/worker/src/repo/source-backfill.node.test.ts
@@ -1,0 +1,130 @@
+import { expect, test, vi } from 'vitest'
+import { type UiArtifactRow } from '#mcp/ui-artifacts-types.ts'
+
+const mockModule = vi.hoisted(() => ({
+	listUiArtifactsByUserId: vi.fn(),
+	updateUiArtifact: vi.fn(),
+	listMcpSkillsByUserId: vi.fn(),
+	updateMcpSkill: vi.fn(),
+	listJobRowsByUserId: vi.fn(),
+	updateJobRow: vi.fn(),
+	syncSavedAppRunnerFromDb: vi.fn(),
+	reindexUiArtifactVectors: vi.fn(),
+	reindexSkillVectors: vi.fn(),
+	reindexJobVectors: vi.fn(),
+}))
+
+vi.mock('#mcp/ui-artifacts-repo.ts', () => ({
+	listUiArtifactsByUserId: (...args: Array<unknown>) =>
+		mockModule.listUiArtifactsByUserId(...args),
+	updateUiArtifact: (...args: Array<unknown>) =>
+		mockModule.updateUiArtifact(...args),
+}))
+
+vi.mock('#mcp/skills/mcp-skills-repo.ts', () => ({
+	listMcpSkillsByUserId: (...args: Array<unknown>) =>
+		mockModule.listMcpSkillsByUserId(...args),
+	updateMcpSkill: (...args: Array<unknown>) =>
+		mockModule.updateMcpSkill(...args),
+}))
+
+vi.mock('#worker/jobs/repo.ts', () => ({
+	listJobRowsByUserId: (...args: Array<unknown>) =>
+		mockModule.listJobRowsByUserId(...args),
+	updateJobRow: (...args: Array<unknown>) => mockModule.updateJobRow(...args),
+}))
+
+vi.mock('#mcp/app-runner.ts', () => ({
+	syncSavedAppRunnerFromDb: (...args: Array<unknown>) =>
+		mockModule.syncSavedAppRunnerFromDb(...args),
+}))
+
+vi.mock('#mcp/ui-artifact-reindex.ts', () => ({
+	reindexUiArtifactVectors: (...args: Array<unknown>) =>
+		mockModule.reindexUiArtifactVectors(...args),
+}))
+
+vi.mock('#mcp/skills/skill-reindex.ts', () => ({
+	reindexSkillVectors: (...args: Array<unknown>) =>
+		mockModule.reindexSkillVectors(...args),
+}))
+
+vi.mock('#worker/jobs/job-reindex.ts', () => ({
+	reindexJobVectors: (...args: Array<unknown>) =>
+		mockModule.reindexJobVectors(...args),
+}))
+
+const { backfillRepoSources } = await import('./source-backfill.ts')
+
+test('backfill leaves app sourceId unchanged when repo source persistence is unavailable', async () => {
+	mockModule.listUiArtifactsByUserId.mockReset()
+	mockModule.updateUiArtifact.mockReset()
+	mockModule.listMcpSkillsByUserId.mockReset()
+	mockModule.updateMcpSkill.mockReset()
+	mockModule.listJobRowsByUserId.mockReset()
+	mockModule.updateJobRow.mockReset()
+	mockModule.syncSavedAppRunnerFromDb.mockReset()
+	mockModule.reindexUiArtifactVectors.mockReset()
+	mockModule.reindexSkillVectors.mockReset()
+	mockModule.reindexJobVectors.mockReset()
+
+	const appRow: UiArtifactRow = {
+		id: 'app-1',
+		user_id: 'user-1',
+		title: 'Investigate orphaned source ids',
+		description: 'Debug repro app',
+		sourceId: null,
+		clientCode: '<main>Hello</main>',
+		serverCode: null,
+		serverCodeId: 'server-code-1',
+		parameters: null,
+		hidden: true,
+		created_at: '2026-04-17T00:00:00.000Z',
+		updated_at: '2026-04-17T00:00:00.000Z',
+	}
+
+	mockModule.listUiArtifactsByUserId.mockResolvedValue([appRow])
+	mockModule.listMcpSkillsByUserId.mockResolvedValue([])
+	mockModule.listJobRowsByUserId.mockResolvedValue([])
+
+	const db = {
+		prepare() {
+			return {
+				bind() {
+					return {
+						async first() {
+							return null
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+
+	const result = await backfillRepoSources({
+		env: {
+			APP_DB: db,
+		} as Env,
+		userId: 'user-1',
+		baseUrl: 'https://heykody.dev',
+		dryRun: false,
+		includeApps: true,
+		includeSkills: false,
+		includeJobs: false,
+		reindex: false,
+		syncAppRunners: false,
+	})
+
+	expect(result.apps.errors).toBe(1)
+	expect(result.apps.results[0]).toEqual({
+		kind: 'app',
+		id: 'app-1',
+		title: 'Investigate orphaned source ids',
+		status: 'error',
+		reason: 'Repo-backed source persistence requires ARTIFACTS bindings.',
+		sourceId: null,
+		publishedCommit: null,
+	})
+	expect(mockModule.updateUiArtifact).not.toHaveBeenCalled()
+	expect(appRow.sourceId).toBeNull()
+})

--- a/packages/worker/src/repo/source-backfill.node.test.ts
+++ b/packages/worker/src/repo/source-backfill.node.test.ts
@@ -56,7 +56,7 @@ vi.mock('#worker/jobs/job-reindex.ts', () => ({
 
 const { backfillRepoSources } = await import('./source-backfill.ts')
 
-test('backfill leaves app sourceId unchanged when repo source persistence is unavailable', async () => {
+test('backfill leaves app sourceId unchanged when Artifacts REST credentials are unavailable', async () => {
 	mockModule.listUiArtifactsByUserId.mockReset()
 	mockModule.updateUiArtifact.mockReset()
 	mockModule.listMcpSkillsByUserId.mockReset()
@@ -121,7 +121,8 @@ test('backfill leaves app sourceId unchanged when repo source persistence is una
 		id: 'app-1',
 		title: 'Investigate orphaned source ids',
 		status: 'error',
-		reason: 'Repo-backed source persistence requires ARTIFACTS bindings.',
+		reason:
+			'Repo-backed source persistence requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.',
 		sourceId: null,
 		publishedCommit: null,
 	})

--- a/packages/worker/src/repo/source-backfill.ts
+++ b/packages/worker/src/repo/source-backfill.ts
@@ -485,14 +485,6 @@ async function backfillJob(input: {
 			publishedCommit,
 			indexedCommit: publishedCommit,
 		})
-		if (input.row.record.sourceId !== ensuredSource.id) {
-			await updateJobRow({
-				db: input.env.APP_DB,
-				userId: input.userId,
-				job: nextRecord,
-				callerContextJson: input.row.callerContextJson,
-			})
-		}
 		await updateJobRow({
 			db: input.env.APP_DB,
 			userId: input.userId,

--- a/packages/worker/src/repo/source-backfill.ts
+++ b/packages/worker/src/repo/source-backfill.ts
@@ -213,12 +213,8 @@ async function backfillApp(input: {
 			entityKind: 'app',
 			entityId: input.row.id,
 			sourceRoot: '/',
+			requirePersistence: true,
 		})
-		if (input.row.sourceId !== ensuredSource.id) {
-			await updateUiArtifact(input.env.APP_DB, input.userId, input.row.id, {
-				sourceId: ensuredSource.id,
-			})
-		}
 		const publishedCommit = await syncArtifactSourceSnapshot({
 			env: input.env,
 			userId: input.userId,
@@ -242,6 +238,11 @@ async function backfillApp(input: {
 			publishedCommit,
 			indexedCommit: publishedCommit,
 		})
+		if (input.row.sourceId !== ensuredSource.id) {
+			await updateUiArtifact(input.env.APP_DB, input.userId, input.row.id, {
+				sourceId: ensuredSource.id,
+			})
+		}
 		if (input.syncAppRunner) {
 			await syncSavedAppRunnerFromDb({
 				env: input.env,
@@ -319,27 +320,8 @@ async function backfillSkill(input: {
 			entityKind: 'skill',
 			entityId: input.row.id,
 			sourceRoot: '/',
+			requirePersistence: true,
 		})
-		if (input.row.source_id !== ensuredSource.id) {
-			await updateMcpSkill(input.env.APP_DB, input.userId, input.row.name, {
-				name: input.row.name,
-				title: input.row.title,
-				description: input.row.description,
-				source_id: ensuredSource.id,
-				keywords: input.row.keywords,
-				code: input.row.code,
-				search_text: input.row.search_text,
-				uses_capabilities: input.row.uses_capabilities,
-				parameters: input.row.parameters,
-				collection_name: input.row.collection_name,
-				collection_slug: input.row.collection_slug,
-				inferred_capabilities: input.row.inferred_capabilities,
-				inference_partial: input.row.inference_partial,
-				read_only: input.row.read_only,
-				idempotent: input.row.idempotent,
-				destructive: input.row.destructive,
-			})
-		}
 		const publishedCommit = await syncArtifactSourceSnapshot({
 			env: input.env,
 			userId: input.userId,
@@ -370,6 +352,26 @@ async function backfillSkill(input: {
 			publishedCommit,
 			indexedCommit: publishedCommit,
 		})
+		if (input.row.source_id !== ensuredSource.id) {
+			await updateMcpSkill(input.env.APP_DB, input.userId, input.row.name, {
+				name: input.row.name,
+				title: input.row.title,
+				description: input.row.description,
+				source_id: ensuredSource.id,
+				keywords: input.row.keywords,
+				code: input.row.code,
+				search_text: input.row.search_text,
+				uses_capabilities: input.row.uses_capabilities,
+				parameters: input.row.parameters,
+				collection_name: input.row.collection_name,
+				collection_slug: input.row.collection_slug,
+				inferred_capabilities: input.row.inferred_capabilities,
+				inference_partial: input.row.inference_partial,
+				read_only: input.row.read_only,
+				idempotent: input.row.idempotent,
+				destructive: input.row.destructive,
+			})
+		}
 		return {
 			kind: 'skill',
 			id: input.row.id,
@@ -459,18 +461,11 @@ async function backfillJob(input: {
 			entityKind: 'job',
 			entityId: input.row.record.id,
 			sourceRoot: '/',
+			requirePersistence: true,
 		})
 		const nextRecord = {
 			...input.row.record,
 			sourceId: ensuredSource.id,
-		}
-		if (input.row.record.sourceId !== ensuredSource.id) {
-			await updateJobRow({
-				db: input.env.APP_DB,
-				userId: input.userId,
-				job: nextRecord,
-				callerContextJson: input.row.callerContextJson,
-			})
 		}
 		const publishedCommit = await syncArtifactSourceSnapshot({
 			env: input.env,
@@ -490,6 +485,14 @@ async function backfillJob(input: {
 			publishedCommit,
 			indexedCommit: publishedCommit,
 		})
+		if (input.row.record.sourceId !== ensuredSource.id) {
+			await updateJobRow({
+				db: input.env.APP_DB,
+				userId: input.userId,
+				job: nextRecord,
+				callerContextJson: input.row.callerContextJson,
+			})
+		}
 		await updateJobRow({
 			db: input.env.APP_DB,
 			userId: input.userId,

--- a/packages/worker/src/repo/source-service.node.test.ts
+++ b/packages/worker/src/repo/source-service.node.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 
 const { ensureEntitySource } = await import('./source-service.ts')
 
-test('ensureEntitySource fails closed when durable persistence is required without artifacts binding', async () => {
+test('ensureEntitySource fails closed when durable persistence is required without Artifacts REST credentials', async () => {
 	const db = {
 		prepare() {
 			return {
@@ -28,6 +28,6 @@ test('ensureEntitySource fails closed when durable persistence is required witho
 			requirePersistence: true,
 		}),
 	).rejects.toThrow(
-		'Repo-backed source persistence requires ARTIFACTS bindings.',
+		'Repo-backed source persistence requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.',
 	)
 })

--- a/packages/worker/src/repo/source-service.node.test.ts
+++ b/packages/worker/src/repo/source-service.node.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest'
+
+const { ensureEntitySource } = await import('./source-service.ts')
+
+test('ensureEntitySource fails closed when durable persistence is required without artifacts binding', async () => {
+	const db = {
+		prepare() {
+			return {
+				bind() {
+					return {
+						async first() {
+							return null
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+
+	await expect(
+		ensureEntitySource({
+			db,
+			env: { APP_DB: db } as Env,
+			userId: 'user-1',
+			entityKind: 'app',
+			entityId: 'app-1',
+			sourceRoot: '/',
+			requirePersistence: true,
+		}),
+	).rejects.toThrow(
+		'Repo-backed source persistence requires ARTIFACTS bindings.',
+	)
+})

--- a/packages/worker/src/repo/source-service.ts
+++ b/packages/worker/src/repo/source-service.ts
@@ -53,12 +53,19 @@ export async function ensureEntitySource(input: {
 	repoId?: string
 	manifestPath?: string
 	sourceRoot?: string
+	requirePersistence?: boolean
 }) {
-	if (
-		typeof (input.db as D1Database | null | undefined)?.prepare !==
-			'function' ||
-		envHasArtifactsBinding(input.env) === false
-	) {
+	const hasDbPrepare = hasAppDbBinding(input.db)
+	const hasArtifactsBinding = envHasArtifactsBinding(input.env)
+	if (!hasDbPrepare || hasArtifactsBinding === false) {
+		if (input.requirePersistence) {
+			throw new Error(
+				`Repo-backed source persistence requires ${missingPersistenceBindings({
+					hasDbPrepare,
+					hasArtifactsBinding,
+				}).join(' and ')} bindings.`,
+			)
+		}
 		return buildEntitySourceRow({
 			id: input.id,
 			userId: input.userId,
@@ -89,11 +96,31 @@ export async function ensureEntitySource(input: {
 	return row
 }
 
+function hasAppDbBinding(db: D1Database | null | undefined) {
+	return typeof db?.prepare === 'function'
+}
+
 function envHasArtifactsBinding(env: Env) {
-	return (
-		typeof (env as Env & { ARTIFACTS?: unknown }).ARTIFACTS === 'object' &&
-		(env as Env & { ARTIFACTS?: unknown }).ARTIFACTS != null
-	)
+	try {
+		void getArtifactsBinding(env)
+		return true
+	} catch {
+		return false
+	}
+}
+
+function missingPersistenceBindings(input: {
+	hasDbPrepare: boolean
+	hasArtifactsBinding: boolean
+}) {
+	const missing: Array<string> = []
+	if (!input.hasDbPrepare) {
+		missing.push('APP_DB')
+	}
+	if (!input.hasArtifactsBinding) {
+		missing.push('ARTIFACTS')
+	}
+	return missing
 }
 
 export async function createArtifactsRepoIfMissing(

--- a/packages/worker/src/repo/source-service.ts
+++ b/packages/worker/src/repo/source-service.ts
@@ -56,14 +56,14 @@ export async function ensureEntitySource(input: {
 	requirePersistence?: boolean
 }) {
 	const hasDbPrepare = hasAppDbBinding(input.db)
-	const hasArtifactsBinding = envHasArtifactsBinding(input.env)
-	if (!hasDbPrepare || hasArtifactsBinding === false) {
+	const hasArtifactsAccess = hasArtifactsAccessConfig(input.env)
+	if (!hasDbPrepare || hasArtifactsAccess === false) {
 		if (input.requirePersistence) {
 			throw new Error(
-				`Repo-backed source persistence requires ${missingPersistenceBindings({
+				`Repo-backed source persistence requires ${missingPersistenceRequirements({
 					hasDbPrepare,
-					hasArtifactsBinding,
-				}).join(' and ')} bindings.`,
+					hasArtifactsAccess,
+				}).join(' and ')}.`,
 			)
 		}
 		return buildEntitySourceRow({
@@ -100,7 +100,7 @@ function hasAppDbBinding(db: D1Database | null | undefined) {
 	return typeof db?.prepare === 'function'
 }
 
-function envHasArtifactsBinding(env: Env) {
+function hasArtifactsAccessConfig(env: Env) {
 	try {
 		void getArtifactsBinding(env)
 		return true
@@ -109,16 +109,16 @@ function envHasArtifactsBinding(env: Env) {
 	}
 }
 
-function missingPersistenceBindings(input: {
+function missingPersistenceRequirements(input: {
 	hasDbPrepare: boolean
-	hasArtifactsBinding: boolean
+	hasArtifactsAccess: boolean
 }) {
 	const missing: Array<string> = []
 	if (!input.hasDbPrepare) {
 		missing.push('APP_DB')
 	}
-	if (!input.hasArtifactsBinding) {
-		missing.push('ARTIFACTS')
+	if (!input.hasArtifactsAccess) {
+		missing.push('CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN')
 	}
 	return missing
 }

--- a/packages/worker/src/repo/source-service.ts
+++ b/packages/worker/src/repo/source-service.ts
@@ -1,6 +1,7 @@
 import {
 	buildEntityRepoId,
 	getArtifactsBinding,
+	hasArtifactsAccess,
 	type ArtifactNamespaceBinding,
 } from './artifacts.ts'
 import {
@@ -56,13 +57,13 @@ export async function ensureEntitySource(input: {
 	requirePersistence?: boolean
 }) {
 	const hasDbPrepare = hasAppDbBinding(input.db)
-	const hasArtifactsAccess = hasArtifactsAccessConfig(input.env)
-	if (!hasDbPrepare || hasArtifactsAccess === false) {
+	const hasArtifactsAccessResult = hasArtifactsAccess(input.env)
+	if (!hasDbPrepare || hasArtifactsAccessResult === false) {
 		if (input.requirePersistence) {
 			throw new Error(
 				`Repo-backed source persistence requires ${missingPersistenceRequirements({
 					hasDbPrepare,
-					hasArtifactsAccess,
+					hasArtifactsAccess: hasArtifactsAccessResult,
 				}).join(' and ')}.`,
 			)
 		}
@@ -98,15 +99,6 @@ export async function ensureEntitySource(input: {
 
 function hasAppDbBinding(db: D1Database | null | undefined) {
 	return typeof db?.prepare === 'function'
-}
-
-function hasArtifactsAccessConfig(env: Env) {
-	try {
-		void getArtifactsBinding(env)
-		return true
-	} catch {
-		return false
-	}
 }
 
 function missingPersistenceRequirements(input: {

--- a/packages/worker/src/repo/source-sync.ts
+++ b/packages/worker/src/repo/source-sync.ts
@@ -1,4 +1,4 @@
-import { getArtifactsBinding } from './artifacts.ts'
+import { hasArtifactsAccess } from './artifacts.ts'
 import { getEntitySourceById } from './entity-sources.ts'
 import { repoSessionRpc } from './repo-session-do.ts'
 
@@ -68,14 +68,5 @@ export async function syncArtifactSourceSnapshot(
 			.catch(() => {
 				// Best effort only; publish/apply failures should preserve the root cause.
 			})
-	}
-}
-
-function hasArtifactsAccess(env: Env) {
-	try {
-		void getArtifactsBinding(env)
-		return true
-	} catch {
-		return false
 	}
 }

--- a/packages/worker/src/repo/source-sync.ts
+++ b/packages/worker/src/repo/source-sync.ts
@@ -1,5 +1,6 @@
-import { repoSessionRpc } from './repo-session-do.ts'
+import { getArtifactsBinding } from './artifacts.ts'
 import { getEntitySourceById } from './entity-sources.ts'
+import { repoSessionRpc } from './repo-session-do.ts'
 
 type SyncArtifactSourceInput = {
 	env: Env
@@ -11,13 +12,11 @@ type SyncArtifactSourceInput = {
 
 function canSyncArtifactSource(env: Env) {
 	return (
-		typeof (env as Env & { ARTIFACTS?: unknown }).ARTIFACTS === 'object' &&
-		(env as Env & { ARTIFACTS?: unknown }).ARTIFACTS != null &&
-		typeof (env as Env & { REPO_SESSION?: unknown }).REPO_SESSION ===
-			'object' &&
-		(env as Env & { REPO_SESSION?: unknown }).REPO_SESSION != null &&
-		typeof (env as Env & { APP_DB?: unknown }).APP_DB === 'object' &&
-		(env as Env & { APP_DB?: unknown }).APP_DB != null
+		hasArtifactsBinding(env) &&
+		(env as Env & { REPO_SESSION?: DurableObjectNamespace | undefined })
+			.REPO_SESSION != null &&
+		typeof (env as Env & { APP_DB?: D1Database | undefined }).APP_DB?.prepare ===
+			'function'
 	)
 }
 
@@ -28,8 +27,9 @@ function buildSyncSessionId(sourceId: string) {
 export async function syncArtifactSourceSnapshot(
 	input: SyncArtifactSourceInput,
 ): Promise<string | null> {
-	if (!input.sourceId) return null
-	if (!canSyncArtifactSource(input.env)) return null
+	if (!input.sourceId || !canSyncArtifactSource(input.env)) {
+		return null
+	}
 	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
 	if (!source) return null
 	const sessionId = buildSyncSessionId(source.id)
@@ -68,5 +68,14 @@ export async function syncArtifactSourceSnapshot(
 			.catch(() => {
 				// Best effort only; publish/apply failures should preserve the root cause.
 			})
+	}
+}
+
+function hasArtifactsBinding(env: Env) {
+	try {
+		void getArtifactsBinding(env)
+		return true
+	} catch {
+		return false
 	}
 }

--- a/packages/worker/src/repo/source-sync.ts
+++ b/packages/worker/src/repo/source-sync.ts
@@ -12,7 +12,7 @@ type SyncArtifactSourceInput = {
 
 function canSyncArtifactSource(env: Env) {
 	return (
-		hasArtifactsBinding(env) &&
+		hasArtifactsAccess(env) &&
 		(env as Env & { REPO_SESSION?: DurableObjectNamespace | undefined })
 			.REPO_SESSION != null &&
 		typeof (env as Env & { APP_DB?: D1Database | undefined }).APP_DB?.prepare ===
@@ -71,7 +71,7 @@ export async function syncArtifactSourceSnapshot(
 	}
 }
 
-function hasArtifactsBinding(env: Env) {
+function hasArtifactsAccess(env: Env) {
 	try {
 		void getArtifactsBinding(env)
 		return true

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -5,12 +5,6 @@
 	"compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
 	"main": "./src/index.ts",
 	"upload_source_maps": true,
-	"artifacts": [
-		{
-			"binding": "ARTIFACTS",
-			"namespace": "default",
-		},
-	],
 	"migrations": [
 		{
 			"new_sqlite_classes": ["MCP"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- use the Cloudflare Artifacts REST API as the only repo-source transport instead of switching between a Worker binding and a fallback
- fail closed when durable repo-source persistence lacks `APP_DB` or Artifacts REST credentials so backfill/save flows cannot write orphaned `source_id` references into D1
- delay app/skill/job backfill foreign-key writes until repo snapshot publish succeeds
- harden the REST client for malformed API envelopes and malformed token expiry timestamps
- remove the unsupported Wrangler `artifacts` config and document the REST-only production path

### Testing
- ✅ `npm exec vitest run packages/worker/src/repo/artifacts.node.test.ts packages/worker/src/repo/source-service.node.test.ts packages/worker/src/repo/source-backfill.node.test.ts packages/worker/src/mcp/capabilities/repo/repo-backfill-sources.node.test.ts --project node-unit`
- ✅ `npm exec vitest run packages/worker/src/repo/app-source.node.test.ts packages/worker/src/mcp/capabilities/apps/ui-save-app.node.test.ts packages/worker/src/mcp/observability.workers.test.ts --project node-unit --project workers-unit`
- ✅ `npm run typecheck && npm run build`

### Production evidence
- latest production deploy logs show `wrangler 4.83.0` warning that top-level `artifacts` is unexpected and the deployed binding summary omits `env.ARTIFACTS`
- the same deploy syncs `CLOUDFLARE_ACCOUNT_ID` as an env var and `CLOUDFLARE_API_TOKEN` as a Worker secret, which is what the REST-only Artifacts client uses
- live single-user production backfill execution is still blocked from this cloud agent because the seeded production user password is not available here and no production-capable Cloudflare credentials/base URL are exposed in this runtime for direct invocation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0bc5ca7-5d40-439f-ad5a-ad10924b855c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0bc5ca7-5d40-439f-ad5a-ad10924b855c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repo-backed persistence for saved apps, skills, and jobs via the Artifacts REST API; explicit availability check added.

* **Refactor**
  * Artifact operations migrated to REST-backed integration and syncing flows reordered to ensure consistent persistence sequencing.

* **Bug Fixes**
  * Persistence now fails closed when required credentials or DB support are missing to avoid orphaned state.

* **Tests**
  * Added tests covering REST client behavior, backfill logic, and fail-closed persistence handling.

* **Documentation**
  * Architecture docs updated to describe repo-backed sources, sessions, and deployment considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->