### PR TITLE
Fix artifacts REST readiness handling

### DIFF
--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -201,6 +201,7 @@ export const EnvSchema = object({
 	CLOUDFLARE_ACCOUNT_ID: optionalNonEmptyStringSchema,
 	CLOUDFLARE_API_TOKEN: optionalNonEmptyStringSchema,
 	CLOUDFLARE_API_BASE_URL: optionalUrlStringSchema,
+	ARTIFACTS_NAMESPACE: optionalNonEmptyStringSchema,
 	CAPABILITY_REINDEX_SECRET: optionalNonEmptyStringSchema,
 	JOB_REINDEX_SECRET: optionalNonEmptyStringSchema,
 	HOME_CONNECTOR_SHARED_SECRET: optionalNonEmptyStringSchema,

--- a/packages/worker/src/mcp/cloudflare/cloudflare-rest-client.ts
+++ b/packages/worker/src/mcp/cloudflare/cloudflare-rest-client.ts
@@ -64,7 +64,7 @@ export class CloudflareRestClient {
 		path: string
 		query?: Record<string, string>
 		body?: unknown
-	}): Promise<{ status: number; body: unknown | null }> {
+	}): Promise<{ status: number; body: unknown | null; headers: Headers }> {
 		assertSafeCloudflareApiV4Path(input.path)
 		const pathPart = input.path.startsWith('/') ? input.path : `/${input.path}`
 		const url = new URL(`${this.baseUrl}${pathPart}`)
@@ -100,11 +100,15 @@ export class CloudflareRestClient {
 		const text = await response.text()
 
 		if (response.status === 204 || !text.trim()) {
-			return { status: response.status, body: null }
+			return { status: response.status, body: null, headers: response.headers }
 		}
 
 		try {
-			return { status: response.status, body: JSON.parse(text) as unknown }
+			return {
+				status: response.status,
+				body: JSON.parse(text) as unknown,
+				headers: response.headers,
+			}
 		} catch {
 			throw new CloudflareApiError(
 				`Cloudflare API returned non-JSON (${response.status}).`,

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -3,6 +3,7 @@ import { afterEach, expect, test, vi } from 'vitest'
 const {
 	getArtifactsBinding,
 	resolveArtifactSourceRepo,
+	resolveSessionRepo,
 } = await import('./artifacts.ts')
 
 afterEach(() => {
@@ -190,7 +191,48 @@ test('artifacts REST client uses fallback API error text when envelope errors ar
 	)
 })
 
-test('artifacts REST client rejects tokens without parseable expiry timestamps', async () => {
+test('artifacts REST client maps 202 repo responses into pending state', async () => {
+	const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+		async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			if (method === 'GET' && url.pathname.endsWith('/repos/repo-1')) {
+				return new Response(
+					JSON.stringify({
+						success: false,
+						result: null,
+						errors: [],
+						messages: [{ code: 1000, message: 'Repo importing. Retry after 7s.' }],
+					}),
+					{
+						status: 202,
+						headers: {
+							'content-type': 'application/json',
+							'retry-after': '7',
+						},
+					},
+				)
+			}
+			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
+		},
+	)
+
+	const env = {
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token-123',
+		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+	} as Env
+
+	const binding = getArtifactsBinding(env)
+
+	await expect(binding.get('repo-1')).resolves.toEqual({
+		status: 'importing',
+		retryAfter: 2,
+	})
+	expect(fetchMock).toHaveBeenCalledTimes(1)
+})
+
+test('artifacts REST client tolerates repo tokens without parseable expiry timestamps', async () => {
 	const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
 		async (input, init) => {
 			const url = new URL(String(input))
@@ -228,8 +270,64 @@ test('artifacts REST client rejects tokens without parseable expiry timestamps',
 
 	const binding = getArtifactsBinding(env)
 
-	await expect(binding.create('repo-1')).rejects.toThrow(
-		'Artifacts token is missing a parseable expires timestamp.',
-	)
+	await expect(binding.create('repo-1')).resolves.toMatchObject({
+		id: 'repo_1',
+		name: 'repo-1',
+		remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+		token: 'art_v1_missing_expiry',
+		expiresAt: null,
+	})
 	expect(fetchMock).toHaveBeenCalledTimes(1)
+})
+
+test('resolveSessionRepo uses the requested namespace override', async () => {
+	const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+		async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			expect(method).toBe('GET')
+			expect(url.pathname).toContain('/artifacts/namespaces/session-ns/repos/repo-1')
+			return new Response(
+				JSON.stringify({
+					success: true,
+					result: {
+						id: 'repo_1',
+						name: 'repo-1',
+						description: null,
+						default_branch: 'main',
+						created_at: '2026-04-17T00:00:00.000Z',
+						updated_at: '2026-04-17T00:00:00.000Z',
+						last_push_at: null,
+						source: null,
+						read_only: false,
+						remote: 'https://acct.artifacts.cloudflare.net/git/session-ns/repo-1.git',
+					},
+					errors: [],
+					messages: [],
+				}),
+				{
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				},
+			)
+		},
+	)
+
+	const env = {
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token-123',
+		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+		ARTIFACTS_NAMESPACE: 'env-default',
+	} as Env
+
+	const repo = await resolveSessionRepo(env, {
+		namespace: 'session-ns',
+		name: 'repo-1',
+	})
+
+	await expect(repo.info()).resolves.toMatchObject({
+		name: 'repo-1',
+		remote: 'https://acct.artifacts.cloudflare.net/git/session-ns/repo-1.git',
+	})
+	expect(fetchMock).toHaveBeenCalledTimes(2)
 })

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -37,7 +37,7 @@ export type ArtifactRepoHandle = {
 		defaultBranch: string
 		remote: string
 		token: string
-		expiresAt: string
+		expiresAt: string | null
 		repo: ArtifactRepoHandle
 	}>
 }
@@ -63,7 +63,7 @@ export type ArtifactNamespaceBinding = {
 		defaultBranch: string
 		remote: string
 		token: string
-		expiresAt: string
+		expiresAt: string | null
 	}>
 	get(name: string): Promise<ArtifactGetRepoResult>
 	list(opts?: { limit?: number; cursor?: string }): Promise<{
@@ -75,8 +75,9 @@ export type ArtifactNamespaceBinding = {
 
 export function getArtifactsBinding(
 	env: Env,
+	namespaceOverride?: string | null,
 ): ArtifactNamespaceBinding & Record<string, unknown> {
-	const restBinding = createArtifactsRestBinding(env)
+	const restBinding = createArtifactsRestBinding(env, namespaceOverride)
 	if (!restBinding) {
 		throw new Error(
 			'Cloudflare Artifacts REST access requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.',
@@ -95,10 +96,10 @@ export function hasArtifactsAccess(env: Env) {
 }
 
 export function getArtifactsNamespace(env: Env) {
-	return (
-		(env as Env & { ARTIFACTS_NAMESPACE?: string | undefined })
-			.ARTIFACTS_NAMESPACE ?? 'default'
-	)
+	const namespace = (
+		env as Env & { ARTIFACTS_NAMESPACE?: string | undefined }
+	).ARTIFACTS_NAMESPACE?.trim()
+	return namespace || 'default'
 }
 
 type ArtifactApiEnvelope<T> = {
@@ -152,22 +153,65 @@ type ArtifactRestForkRepoResult = ArtifactRestCreateRepoResult & {
 	objects?: number
 }
 
-function createArtifactsRestBinding(env: Env) {
+type ArtifactPendingRepoResponse = {
+	status: 'importing' | 'forking'
+	retryAfter: number
+}
+
+type ArtifactPendingStatusPayload = {
+	status?: string
+	retry_after?: number
+	retryAfter?: number
+}
+
+type ArtifactEnvelopeResponse<T> = {
+	status: number
+	headers: Headers
+	envelope: ArtifactApiEnvelope<T>
+}
+
+const defaultArtifactRetryAfterSeconds = 2
+const maxArtifactRetryAfterSeconds = 2
+
+function createArtifactsRestBinding(env: Env, namespaceOverride?: string | null) {
 	const accountId = env.CLOUDFLARE_ACCOUNT_ID?.trim()
 	const apiToken = env.CLOUDFLARE_API_TOKEN?.trim()
 	if (!accountId || !apiToken) {
 		return null
 	}
 	const client = createCloudflareRestClient(env)
-	const namespace = getArtifactsNamespace(env)
+	const namespace = namespaceOverride?.trim() || getArtifactsNamespace(env)
 	const basePath = `/client/v4/accounts/${accountId}/artifacts/namespaces/${namespace}`
+	const getRepo = async (name: string): Promise<ArtifactGetRepoResult> => {
+		const response = await requestArtifactsEnvelope<ArtifactRestRepoInfo>(client, {
+			method: 'GET',
+			path: `${basePath}/repos/${encodeURIComponent(name)}`,
+			treat404AsNull: true,
+		})
+		const pending = parsePendingArtifactRepoResponse(response)
+		if (pending) {
+			return pending
+		}
+		if (response.status === 404 || response.envelope.result == null) {
+			return { status: 'not_found' as const }
+		}
+		return {
+			status: 'ready' as const,
+			repo: repoHandle(name),
+		}
+	}
 	const getRepoInfo = async (name: string): Promise<ArtifactRepoInfo | null> => {
 		const response = await requestArtifactsEnvelope<ArtifactRestRepoInfo>(client, {
 			method: 'GET',
 			path: `${basePath}/repos/${encodeURIComponent(name)}`,
 			treat404AsNull: true,
 		})
-		return response.result ? normalizeArtifactRepoInfo(response.result) : null
+		if (response.status === 202 || response.status === 404) {
+			return null
+		}
+		return response.envelope.result
+			? normalizeArtifactRepoInfo(response.envelope.result)
+			: null
 	}
 	const repoHandle = (name: string): ArtifactRepoHandle => ({
 		info: async () => await getRepoInfo(name),
@@ -244,16 +288,7 @@ function createArtifactsRestBinding(env: Env) {
 				expiresAt: parseArtifactTokenExpiry(result.token),
 			}
 		},
-		get: async (name) => {
-			const info = await getRepoInfo(name)
-			if (!info) {
-				return { status: 'not_found' as const }
-			}
-			return {
-				status: 'ready' as const,
-				repo: repoHandle(name),
-			}
-		},
+		get: getRepo,
 		list: async (opts) => {
 			const query: Record<string, string> = {}
 			if (opts?.limit !== undefined) {
@@ -270,7 +305,7 @@ function createArtifactsRestBinding(env: Env) {
 					query,
 				},
 			)
-			const repos = (envelope.result ?? []).map((repo) => {
+			const repos = (envelope.envelope.result ?? []).map((repo) => {
 				const normalized = normalizeArtifactRepoInfo(repo)
 				return {
 					id: normalized.id,
@@ -286,8 +321,8 @@ function createArtifactsRestBinding(env: Env) {
 			})
 			return {
 				repos,
-				total: envelope.result_info?.total_count ?? repos.length,
-				cursor: envelope.result_info?.cursor,
+				total: envelope.envelope.result_info?.total_count ?? repos.length,
+				cursor: envelope.envelope.result_info?.cursor,
 			}
 		},
 	} satisfies ArtifactNamespaceBinding & Record<string, unknown>
@@ -304,10 +339,10 @@ async function requestArtifactsApi<T>(
 	},
 ) {
 	const envelope = await requestArtifactsEnvelope<T>(client, input)
-	if (envelope.result == null) {
+	if (envelope.envelope.result == null) {
 		throw new Error(`Artifacts API returned no result for ${input.path}.`)
 	}
-	return envelope.result
+	return envelope.envelope.result
 }
 
 async function requestArtifactsEnvelope<T>(
@@ -319,7 +354,7 @@ async function requestArtifactsEnvelope<T>(
 		body?: unknown
 		treat404AsNull?: boolean
 	},
-) {
+): Promise<ArtifactEnvelopeResponse<T>> {
 	try {
 		const response = await client.rawRequest({
 			method: input.method,
@@ -328,21 +363,43 @@ async function requestArtifactsEnvelope<T>(
 			body: input.body,
 		})
 		const envelope = response.body as ArtifactApiEnvelope<T> | null
-		if (!envelope?.success) {
-			const message =
-				envelope?.errors?.[0]?.message ??
-				`Artifacts API request failed (${response.status}).`
-			if (input.treat404AsNull && response.status === 404) {
-				return {
+		if (input.treat404AsNull && response.status === 404) {
+			return {
+				status: response.status,
+				headers: response.headers,
+				envelope: {
 					result: null,
 					success: true,
 					errors: [],
 					messages: [],
-				} satisfies ArtifactApiEnvelope<T>
+				} satisfies ArtifactApiEnvelope<T>,
 			}
+		}
+		if (response.status === 202) {
+			return {
+				status: response.status,
+				headers: response.headers,
+				envelope:
+					envelope ??
+					({
+						result: null,
+						success: true,
+						errors: [],
+						messages: [],
+					} satisfies ArtifactApiEnvelope<T>),
+			}
+		}
+		if (!envelope?.success) {
+			const message =
+				envelope?.errors?.[0]?.message ??
+				`Artifacts API request failed (${response.status}).`
 			throw new Error(message)
 		}
-		return envelope
+		return {
+			status: response.status,
+			headers: response.headers,
+			envelope,
+		}
 	} catch (error) {
 		if (
 			input.treat404AsNull &&
@@ -350,11 +407,15 @@ async function requestArtifactsEnvelope<T>(
 			error.status === 404
 		) {
 			return {
-				result: null,
-				success: true,
-				errors: [],
-				messages: [],
-			} satisfies ArtifactApiEnvelope<T>
+				status: 404,
+				headers: new Headers(),
+				envelope: {
+					result: null,
+					success: true,
+					errors: [],
+					messages: [],
+				} satisfies ArtifactApiEnvelope<T>,
+			}
 		}
 		throw error
 	}
@@ -377,13 +438,13 @@ function normalizeArtifactRepoInfo(repo: ArtifactRestRepoInfo): ArtifactRepoInfo
 
 function parseArtifactTokenExpiry(token: string) {
 	const expiresAtSeconds = Number.parseInt(
-		token.split('?expires=')[1] ?? '',
+		new URLSearchParams(token.split('?')[1] ?? '').get('expires') ?? '',
 		10,
 	)
 	if (Number.isFinite(expiresAtSeconds)) {
 		return new Date(expiresAtSeconds * 1000).toISOString()
 	}
-	throw new Error('Artifacts token is missing a parseable expires timestamp.')
+	return null
 }
 
 function normalizeRepoNamePart(value: string) {
@@ -421,7 +482,7 @@ export function buildSessionRepoId(input: {
 }
 
 export function parseArtifactTokenSecret(token: string) {
-	return token.split('?expires=')[0] ?? token
+	return token.split('?')[0] ?? token
 }
 
 export function buildAuthenticatedArtifactsRemote(input: {
@@ -440,30 +501,96 @@ export function buildAuthenticatedArtifactsRemote(input: {
 
 export async function resolveArtifactSourceRepo(env: Env, repoId: string) {
 	const binding = getArtifactsBinding(env)
-	const result = await binding.get(repoId)
-	if (result.status !== 'ready') {
-		throw new Error(
-			`Artifacts repo "${repoId}" is ${result.status}${
-				'retryAfter' in result ? ` (retry after ${result.retryAfter}s)` : ''
-			}.`,
-		)
-	}
-	return result.repo
+	return await waitForArtifactRepoReady(binding, repoId)
 }
 
 export async function resolveSessionRepo(
 	env: Env,
 	input: { namespace?: string | null; name: string },
 ) {
-	const binding = getArtifactsBinding(env)
-	void input.namespace
-	const result = await binding.get(input.name)
-	if (result.status !== 'ready') {
-		throw new Error(
-			`Artifacts repo "${input.name}" is ${result.status}${
-				'retryAfter' in result ? ` (retry after ${result.retryAfter}s)` : ''
-			}.`,
-		)
+	const binding = getArtifactsBinding(env, input.namespace)
+	return await waitForArtifactRepoReady(binding, input.name)
+}
+
+export async function waitForArtifactRepoReady(
+	binding: ArtifactNamespaceBinding,
+	repoName: string,
+	maxAttempts = 5,
+) {
+	let lastPending: ArtifactPendingRepoResponse | null = null
+	for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+		const result = await binding.get(repoName)
+		if (result.status === 'ready') {
+			return result.repo
+		}
+		if (result.status === 'not_found') {
+			throw new Error(`Artifacts repo "${repoName}" was not found.`)
+		}
+		lastPending = result
+		if (attempt < maxAttempts) {
+			await sleep(result.retryAfter * 1000)
+		}
 	}
-	return result.repo
+	throw new Error(
+		`Artifacts repo "${repoName}" is ${lastPending?.status ?? 'unavailable'}${
+			lastPending ? ` (retry after ${lastPending.retryAfter}s)` : ''
+		}.`,
+	)
+}
+
+function parsePendingArtifactRepoResponse(
+	response: ArtifactEnvelopeResponse<ArtifactRestRepoInfo>,
+) {
+	if (response.status !== 202) {
+		return null
+	}
+	const payload = response.envelope.result as ArtifactPendingStatusPayload | null
+	const status = normalizePendingArtifactStatus(
+		payload?.status ??
+			response.envelope.messages[0]?.message ??
+			response.envelope.errors[0]?.message,
+	)
+	return {
+		status,
+		retryAfter: parseRetryAfterSeconds(response, payload),
+	} satisfies ArtifactPendingRepoResponse
+}
+
+function normalizePendingArtifactStatus(value: string | undefined) {
+	return value?.toLowerCase().includes('fork') ? 'forking' : 'importing'
+}
+
+function parseRetryAfterSeconds(
+	response: ArtifactEnvelopeResponse<unknown>,
+	payload?: ArtifactPendingStatusPayload | null,
+) {
+	const retryAfterHeader = response.headers.get('retry-after')
+	const retryAfterValue =
+		Number.parseInt(retryAfterHeader ?? '', 10) ||
+		payload?.retry_after ||
+		payload?.retryAfter ||
+		parseRetryAfterFromMessages(response.envelope)
+	return clampRetryAfterSeconds(retryAfterValue)
+}
+
+function parseRetryAfterFromMessages(envelope: ArtifactApiEnvelope<unknown>) {
+	const combinedMessages = [
+		...envelope.messages.map((message) => message.message),
+		...envelope.errors.map((error) => error.message),
+	].join(' ')
+	const match = /retry after (\d+)/i.exec(combinedMessages)
+	return match ? Number.parseInt(match[1] ?? '', 10) : undefined
+}
+
+function clampRetryAfterSeconds(value: number | undefined) {
+	if (!value || !Number.isFinite(value) || value < 0) {
+		return defaultArtifactRetryAfterSeconds
+	}
+	return Math.min(Math.max(1, Math.ceil(value)), maxArtifactRetryAfterSeconds)
+}
+
+function sleep(ms: number) {
+	return new Promise<void>((resolve) => {
+		setTimeout(resolve, ms)
+	})
 }

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -1,0 +1,95 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	resolveArtifactSourceRepo: vi.fn(),
+	getArtifactsBinding: vi.fn(),
+}))
+
+vi.mock('./artifacts.ts', async () => {
+	const actual = await vi.importActual<typeof import('./artifacts.ts')>(
+		'./artifacts.ts',
+	)
+	return {
+		...actual,
+		resolveArtifactSourceRepo: (...args: Array<unknown>) =>
+			mockModule.resolveArtifactSourceRepo(...args),
+		getArtifactsBinding: (...args: Array<unknown>) =>
+			mockModule.getArtifactsBinding(...args),
+	}
+})
+
+const { createSessionRepoForSource } = await import('./repo-session-do.ts')
+
+test('createSessionRepoForSource creates a blank session repo for unpublished sources', async () => {
+	mockModule.resolveArtifactSourceRepo.mockReset()
+	mockModule.getArtifactsBinding.mockReset()
+
+	const create = vi.fn(async (name: string) => ({
+		id: 'session-repo-1',
+		name,
+		description: null,
+		defaultBranch: 'main',
+		remote: `https://acct.artifacts.cloudflare.net/git/default/${name}.git`,
+		token: 'art_v1_create?expires=1760000000',
+		expiresAt: '2026-10-09T08:53:20.000Z',
+	}))
+	mockModule.getArtifactsBinding.mockReturnValue({
+		create,
+	} as never)
+
+	await expect(
+		createSessionRepoForSource({
+			env: {} as Env,
+			source: {
+				repo_id: 'app-source-1',
+				published_commit: null,
+			},
+			sessionId: 'session-1',
+		}),
+	).resolves.toMatchObject({
+		sessionRepoId: 'session-repo-1',
+		sessionRepoName: 'app-source-1-session1',
+		baseCommit: null,
+	})
+
+	expect(create).toHaveBeenCalledTimes(1)
+	expect(mockModule.resolveArtifactSourceRepo).not.toHaveBeenCalled()
+})
+
+test('createSessionRepoForSource forks published sources', async () => {
+	mockModule.resolveArtifactSourceRepo.mockReset()
+	mockModule.getArtifactsBinding.mockReset()
+
+	const fork = vi.fn(async (input: { name: string; readOnly?: boolean }) => ({
+		id: 'forked-session-1',
+		name: input.name,
+		description: null,
+		defaultBranch: 'main',
+		remote: `https://acct.artifacts.cloudflare.net/git/default/${input.name}.git`,
+		token: 'art_v1_fork?expires=1760000200',
+		expiresAt: '2026-10-09T08:56:40.000Z',
+		repo: {} as never,
+	}))
+	mockModule.resolveArtifactSourceRepo.mockResolvedValue({
+		fork,
+	} as never)
+
+	await expect(
+		createSessionRepoForSource({
+			env: {} as Env,
+			source: {
+				repo_id: 'skill-source-1',
+				published_commit: 'commit-123',
+			},
+			sessionId: 'session-2',
+		}),
+	).resolves.toMatchObject({
+		sessionRepoId: 'forked-session-1',
+		sessionRepoName: 'skill-source-1-session2',
+		baseCommit: 'commit-123',
+	})
+
+	expect(mockModule.resolveArtifactSourceRepo).toHaveBeenCalledTimes(1)
+	expect(fork).toHaveBeenCalledTimes(1)
+	expect(mockModule.getArtifactsBinding).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -14,6 +14,8 @@ import {
 } from './repo-sessions.ts'
 import {
 	buildAuthenticatedArtifactsRemote,
+	getArtifactsNamespace,
+	parseArtifactTokenSecret,
 	resolveArtifactSourceRepo,
 	resolveSessionRepo,
 } from './artifacts.ts'
@@ -84,7 +86,7 @@ async function ensureArtifactRepoRemote(input: {
 }
 
 function buildGitCloneAuth(input: { remote: string; token: string }) {
-	const tokenSecret = input.token.split('?expires=')[0] ?? input.token
+	const tokenSecret = parseArtifactTokenSecret(input.token)
 	return {
 		url: input.remote,
 		username: 'x',
@@ -310,7 +312,7 @@ class RepoSessionBase extends DurableObject<Env> {
 				source_id: input.sourceId,
 				session_repo_id: forked.id,
 				session_repo_name: forked.name,
-				session_repo_namespace: 'default',
+				session_repo_namespace: getArtifactsNamespace(this.env),
 				base_commit: baseCommit ?? '',
 				source_root: input.sourceRoot ?? source.source_root,
 				conversation_id: input.conversationId ?? null,
@@ -714,7 +716,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			author: sessionCommitAuthor,
 			token: sourceAccess.token,
 			username: 'x',
-			password: sourceAccess.token.split('?expires=')[0] ?? sourceAccess.token,
+			password: parseArtifactTokenSecret(sourceAccess.token),
 		})
 		const headCommit = await this.getHeadCommit()
 		await this.git.push({
@@ -723,8 +725,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			ref: defaultBranch,
 			token: sessionAccess.token,
 			username: 'x',
-			password:
-				sessionAccess.token.split('?expires=')[0] ?? sessionAccess.token,
+			password: parseArtifactTokenSecret(sessionAccess.token),
 		})
 		await updateRepoSession(this.env.APP_DB, {
 			id: sessionRow.id,
@@ -792,8 +793,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			),
 			token: sessionAccess.token,
 			username: 'x',
-			password:
-				sessionAccess.token.split('?expires=')[0] ?? sessionAccess.token,
+			password: parseArtifactTokenSecret(sessionAccess.token),
 		})
 		await this.ensureRemote({
 			name: 'source',
@@ -809,7 +809,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			ref: targetBranch,
 			token: sourceAccess.token,
 			username: 'x',
-			password: sourceAccess.token.split('?expires=')[0] ?? sourceAccess.token,
+			password: parseArtifactTokenSecret(sourceAccess.token),
 		})
 		const manifestContent = await this.workspace.readFile(
 			resolveRepoWorkspacePath(

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -14,6 +14,7 @@ import {
 } from './repo-sessions.ts'
 import {
 	buildAuthenticatedArtifactsRemote,
+	getArtifactsBinding,
 	getArtifactsNamespace,
 	parseArtifactTokenSecret,
 	resolveArtifactSourceRepo,
@@ -92,6 +93,60 @@ function buildGitCloneAuth(input: { remote: string; token: string }) {
 		username: 'x',
 		password: tokenSecret,
 	}
+}
+
+type RepoSessionBootstrapResult = {
+	sessionRepoId: string
+	sessionRepoName: string
+	sessionRepoRemote: string
+	sessionRepoToken: string
+	baseCommit: string | null
+}
+
+export async function createSessionRepoForSource(input: {
+	env: Env
+	source: {
+		repo_id: string
+		published_commit: string | null
+	}
+	sessionId: string
+	defaultBranch?: string | null
+}) {
+	const compactSessionId = input.sessionId.replace(/-/g, '')
+	const repoPrefixLength = Math.max(1, 63 - compactSessionId.length - 1)
+	const sessionRepoName = `${input.source.repo_id.slice(0, repoPrefixLength)}-${compactSessionId}`
+	if (input.source.published_commit) {
+		const sourceRepo = await resolveArtifactSourceRepo(
+			input.env,
+			input.source.repo_id,
+		)
+		const forked = await sourceRepo.fork({
+			name: sessionRepoName,
+			readOnly: false,
+		})
+		return {
+			sessionRepoId: forked.id,
+			sessionRepoName: forked.name,
+			sessionRepoRemote: forked.remote,
+			sessionRepoToken: forked.token,
+			baseCommit: input.source.published_commit,
+		} satisfies RepoSessionBootstrapResult
+	}
+	const created = await getArtifactsBinding(input.env).create(sessionRepoName, {
+		readOnly: false,
+		setDefaultBranch: input.defaultBranch ?? defaultSessionBranch,
+	})
+	return {
+		sessionRepoId: created.id,
+		sessionRepoName: created.name,
+		sessionRepoRemote: created.remote,
+		sessionRepoToken: created.token,
+		baseCommit: null,
+	} satisfies RepoSessionBootstrapResult
+}
+
+export const __test_only__ = {
+	createSessionRepoForSource,
 }
 
 class RepoSessionBase extends DurableObject<Env> {
@@ -293,33 +348,27 @@ class RepoSessionBase extends DurableObject<Env> {
 					`Source "${input.sourceId}" was not found for this user.`,
 				)
 			}
-			const sourceRepo = await resolveArtifactSourceRepo(
-				this.env,
-				source.repo_id,
-			)
-			const baseCommit = source.published_commit
-			const compactSessionId = input.sessionId.replace(/-/g, '')
-			const repoPrefixLength = Math.max(1, 63 - compactSessionId.length - 1)
-			const sessionRepoName = `${source.repo_id.slice(0, repoPrefixLength)}-${compactSessionId}`
-			const forked = await sourceRepo.fork({
-				name: sessionRepoName,
-				readOnly: false,
+			const bootstrap = await createSessionRepoForSource({
+				env: this.env,
+				source,
+				sessionId: input.sessionId,
+				defaultBranch: input.defaultBranch,
 			})
 			const now = nowIso()
 			const newSessionRow: RepoSessionRow = {
 				id: input.sessionId,
 				user_id: input.userId,
 				source_id: input.sourceId,
-				session_repo_id: forked.id,
-				session_repo_name: forked.name,
+				session_repo_id: bootstrap.sessionRepoId,
+				session_repo_name: bootstrap.sessionRepoName,
 				session_repo_namespace: getArtifactsNamespace(this.env),
-				base_commit: baseCommit ?? '',
+				base_commit: bootstrap.baseCommit ?? '',
 				source_root: input.sourceRoot ?? source.source_root,
 				conversation_id: input.conversationId ?? null,
 				status: 'active',
 				expires_at: null,
 				last_checkpoint_at: null,
-				last_checkpoint_commit: baseCommit,
+				last_checkpoint_commit: bootstrap.baseCommit,
 				last_check_run_id: null,
 				last_check_tree_hash: null,
 				created_at: now,
@@ -329,8 +378,8 @@ class RepoSessionBase extends DurableObject<Env> {
 			sessionRow = newSessionRow
 			await this.initialize({
 				sessionId: sessionRow.id,
-				sessionRepoRemote: forked.remote,
-				sessionRepoToken: forked.token,
+				sessionRepoRemote: bootstrap.sessionRepoRemote,
+				sessionRepoToken: bootstrap.sessionRepoToken,
 			})
 		} else {
 			if (sessionRow.user_id !== input.userId) {
@@ -859,4 +908,8 @@ export const RepoSession = Sentry.instrumentDurableObjectWithSentry(
 
 export function repoSessionRpc(env: Env, sessionId: string) {
 	return createRepoSessionRpc(env, sessionId)
+}
+
+export const __testOnly = {
+	createSessionRepoForSource,
 }

--- a/packages/worker/src/repo/source-service.node.test.ts
+++ b/packages/worker/src/repo/source-service.node.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from 'vitest'
 
-const { ensureEntitySource } = await import('./source-service.ts')
+const {
+	createArtifactsRepoIfMissing,
+	ensureEntitySource,
+} = await import('./source-service.ts')
 
 test('ensureEntitySource fails closed when durable persistence is required without Artifacts REST credentials', async () => {
 	const db = {
@@ -30,4 +33,49 @@ test('ensureEntitySource fails closed when durable persistence is required witho
 	).rejects.toThrow(
 		'Repo-backed source persistence requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.',
 	)
+})
+
+test('createArtifactsRepoIfMissing waits for pending repos to become ready after create', async () => {
+	let getCount = 0
+	const readyRepo = {
+		async info() {
+			return null
+		},
+		async createToken() {
+			throw new Error('Not implemented in test')
+		},
+		async fork() {
+			throw new Error('Not implemented in test')
+		},
+	}
+	const binding = {
+		async get(name: string) {
+			getCount += 1
+			if (getCount === 1) {
+				return { status: 'not_found' as const }
+			}
+			if (getCount === 2) {
+				return { status: 'importing' as const, retryAfter: 0 }
+			}
+			return { status: 'ready' as const, repo: readyRepo }
+		},
+		async create(name: string) {
+			return {
+				id: 'repo_1',
+				name,
+				description: null,
+				defaultBranch: 'main',
+				remote: `https://acct.artifacts.cloudflare.net/git/default/${name}.git`,
+				token: 'art_v1_create?expires=1760000000',
+				expiresAt: '2026-10-09T08:53:20.000Z',
+			}
+		},
+		async list() {
+			return { repos: [], total: 0 }
+		},
+	}
+
+	await expect(
+		createArtifactsRepoIfMissing({} as Env, 'repo-1', binding),
+	).resolves.toBe(readyRepo)
 })

--- a/packages/worker/src/repo/source-service.ts
+++ b/packages/worker/src/repo/source-service.ts
@@ -3,6 +3,7 @@ import {
 	getArtifactsBinding,
 	hasArtifactsAccess,
 	type ArtifactNamespaceBinding,
+	waitForArtifactRepoReady,
 } from './artifacts.ts'
 import {
 	getEntitySourceByEntity,
@@ -123,18 +124,10 @@ export async function createArtifactsRepoIfMissing(
 	const existing = await binding.get(repoId)
 	if (existing.status === 'ready') return existing.repo
 	if (existing.status === 'importing' || existing.status === 'forking') {
-		throw new Error(
-			`Artifacts repo "${repoId}" is ${existing.status}. Retry after ${existing.retryAfter}s.`,
-		)
+		return await waitForArtifactRepoReady(binding, repoId)
 	}
 	const created = await binding.create(repoId, { readOnly: false })
-	const getResult = await binding.get(created.name)
-	if (getResult.status !== 'ready') {
-		throw new Error(
-			`Artifacts repo "${created.name}" is ${getResult.status} after create.`,
-		)
-	}
-	return getResult.repo
+	return await waitForArtifactRepoReady(binding, created.name)
 }
 
 export async function setEntityPublishedCommit(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- tolerate Cloudflare Artifacts repos that are briefly pending after create/get instead of assuming immediate readiness
- bootstrap first-publish repo sessions by creating a blank session repo when the source repo has no published commit yet, instead of forking an empty repo
- honor persisted session repo namespaces and share token-secret parsing across repo session git operations
- add focused regressions for pending repo readiness, namespace overrides, tolerant token expiry parsing, and first-publish session bootstrap

## Testing
- `npm run test -- packages/worker/src/repo/artifacts.node.test.ts packages/worker/src/repo/source-service.node.test.ts`
- `npm run test -- packages/worker/src/repo/artifacts.node.test.ts packages/worker/src/repo/source-service.node.test.ts packages/worker/src/repo/repo-session-do.node.test.ts`
- production `repo_backfill_sources` dry run on the connected Kody MCP server
- production `repo_backfill_sources` live run exposed empty-repo fork failures and a separate app-runner 401, which informed the follow-up bootstrap fix
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c6a983a-f8c2-4bc6-9982-edae4a5652e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c6a983a-f8c2-4bc6-9982-edae4a5652e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

