### PR TITLE
Bootstrap first publish directly to source repos

### DIFF
--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -434,6 +434,11 @@ class RepoSessionBase extends DurableObject<Env> {
 				source.repo_id,
 			)
 			const baseCommit = source.published_commit
+			if (!baseCommit) {
+				throw new Error(
+					`Source "${source.id}" has no published commit yet. Bootstrap the source repo before opening a repo session.`,
+				)
+			}
 			const compactSessionId = input.sessionId.replace(/-/g, '')
 			const repoPrefixLength = Math.max(1, 63 - compactSessionId.length - 1)
 			const sessionRepoName = `${source.repo_id.slice(0, repoPrefixLength)}-${compactSessionId}`

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -386,11 +386,6 @@ class RepoSessionBase extends DurableObject<Env> {
 				source.repo_id,
 			)
 			const baseCommit = source.published_commit
-			if (!baseCommit) {
-				throw new Error(
-					`Source "${source.id}" has no published commit yet. Bootstrap the source repo before opening a repo session.`,
-				)
-			}
 			const compactSessionId = input.sessionId.replace(/-/g, '')
 			const repoPrefixLength = Math.max(1, 63 - compactSessionId.length - 1)
 			const sessionRepoName = `${source.repo_id.slice(0, repoPrefixLength)}-${compactSessionId}`

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -33,6 +33,7 @@ import {
 	type RepoApplyPatchResult,
 	type RepoSearchMode,
 	type RepoSearchOutputMode,
+	type RepoSourceBootstrapResult,
 	type RepoSessionApplyEditsResult,
 	type RepoSessionCheckRun,
 	type RepoSessionCheckStatus,
@@ -169,6 +170,18 @@ class RepoSessionBase extends DurableObject<Env> {
 		})
 	}
 
+	private async resetWorkspace() {
+		await this.workspace
+			.rm(repoSessionWorkspacePrefix, {
+				force: true,
+				recursive: true,
+			})
+			.catch(() => {
+				// Best effort only; the session row is the source of truth.
+			})
+		this.initializedSessionId = null
+	}
+
 	private async getCurrentBranch(defaultBranch = defaultSessionBranch) {
 		const branchResult = await this.git.branch({
 			dir: repoSessionWorkspacePrefix,
@@ -271,6 +284,83 @@ class RepoSessionBase extends DurableObject<Env> {
 		this.initializedSessionId = input.sessionId
 	}
 
+	private async applyWorkspaceEdits(input: {
+		edits: Array<{
+			kind: 'write' | 'replace' | 'writeJson'
+			path: string
+			content?: string
+			search?: string
+			replacement?: string
+			value?: unknown
+			options?: {
+				caseSensitive?: boolean
+				regex?: boolean
+				wholeWord?: boolean
+				contextBefore?: number
+				contextAfter?: number
+				maxMatches?: number
+				spaces?: number
+			}
+		}>
+		dryRun?: boolean
+		rollbackOnError?: boolean
+	}): Promise<RepoSessionApplyEditsResult> {
+		const plan = await this.state.planEdits(
+			input.edits.map((edit) => {
+				const path = resolveRepoWorkspacePath(
+					edit.path,
+					repoSessionWorkspacePrefix,
+				)
+				switch (edit.kind) {
+					case 'write':
+						if (typeof edit.content !== 'string') {
+							throw new Error('repo_apply_patch write edits require content.')
+						}
+						return {
+							kind: 'write' as const,
+							path,
+							content: edit.content,
+						}
+					case 'replace':
+						if (typeof edit.search !== 'string') {
+							throw new Error('repo_apply_patch replace edits require search.')
+						}
+						return {
+							kind: 'replace' as const,
+							path,
+							search: edit.search,
+							replacement: edit.replacement ?? '',
+							options: edit.options,
+						}
+					case 'writeJson':
+						return {
+							kind: 'writeJson' as const,
+							path,
+							value: edit.value,
+							options:
+								typeof edit.options?.spaces === 'number'
+									? { spaces: edit.options.spaces }
+									: undefined,
+						}
+				}
+			}),
+		)
+		const result = await this.state.applyEditPlan(plan, {
+			dryRun: input.dryRun,
+			rollbackOnError: input.rollbackOnError,
+		})
+		return {
+			dryRun: result.dryRun,
+			totalChanged: result.totalChanged,
+			edits: result.edits.map((edit) => ({
+				path: toExternalRepoPath(edit.path, repoSessionWorkspacePrefix),
+				changed: edit.changed,
+				content: edit.content,
+				diff: edit.diff,
+			})),
+		}
+	}
+
 	async openSession(input: {
 		sessionId: string
 		sourceId: string
@@ -296,6 +386,11 @@ class RepoSessionBase extends DurableObject<Env> {
 				source.repo_id,
 			)
 			const baseCommit = source.published_commit
+			if (!baseCommit) {
+				throw new Error(
+					`Source "${source.id}" has no published commit yet. Bootstrap the source repo before opening a repo session.`,
+				)
+			}
 			const compactSessionId = input.sessionId.replace(/-/g, '')
 			const repoPrefixLength = Math.max(1, 63 - compactSessionId.length - 1)
 			const sessionRepoName = `${source.repo_id.slice(0, repoPrefixLength)}-${compactSessionId}`
@@ -360,6 +455,111 @@ class RepoSessionBase extends DurableObject<Env> {
 		return toRepoSessionInfoResult(sessionRow, source)
 	}
 
+	async bootstrapSource(input: {
+		sessionId: string
+		sourceId: string
+		userId: string
+		edits: Array<{
+			kind: 'write' | 'replace' | 'writeJson'
+			path: string
+			content?: string
+			search?: string
+			replacement?: string
+			value?: unknown
+			options?: {
+				caseSensitive?: boolean
+				regex?: boolean
+				wholeWord?: boolean
+				contextBefore?: number
+				contextAfter?: number
+				maxMatches?: number
+				spaces?: number
+			}
+		}>
+	}): Promise<RepoSourceBootstrapResult> {
+		const source = await getEntitySourceById(this.env.APP_DB, input.sourceId)
+		if (!source) {
+			throw new Error(`Source "${input.sourceId}" was not found.`)
+		}
+		if (source.user_id !== input.userId) {
+			throw new Error(
+				`Source "${input.sourceId}" was not found for this user.`,
+			)
+		}
+		if (source.published_commit) {
+			throw new Error(
+				`Source "${source.id}" already has a published commit. Use repo sessions for later edits.`,
+			)
+		}
+		const sourceRepo = await resolveArtifactSourceRepo(this.env, source.repo_id)
+		const sourceInfo = await sourceRepo.info()
+		const sourceAccess = await ensureArtifactRepoRemote({
+			repo: sourceRepo,
+			scope: 'write',
+		})
+		const targetBranch = sourceInfo?.defaultBranch ?? defaultSessionBranch
+		await this.resetWorkspace()
+		await this.workspace.mkdir(repoSessionWorkspacePrefix, {
+			recursive: true,
+		})
+		await this.git.init({
+			dir: repoSessionWorkspacePrefix,
+			defaultBranch: targetBranch,
+		})
+		await this.ensureRemote({
+			name: 'source',
+			url: buildAuthenticatedArtifactsRemote({
+				remote: sourceAccess.remote,
+				token: sourceAccess.token,
+			}),
+		})
+		await this.applyWorkspaceEdits({
+			edits: input.edits,
+			dryRun: false,
+			rollbackOnError: true,
+		})
+		const publishedCommit = await this.commitIfDirty(
+			`Bootstrap source repo ${source.id}`,
+		)
+		if (!publishedCommit) {
+			throw new Error(`Source "${source.id}" bootstrap produced no commit.`)
+		}
+		await this.git.push({
+			dir: repoSessionWorkspacePrefix,
+			remote: 'source',
+			ref: targetBranch,
+			token: sourceAccess.token,
+			username: 'x',
+			password: sourceAccess.token.split('?expires=')[0] ?? sourceAccess.token,
+		})
+		const manifestContent = await this.workspace.readFile(
+			resolveRepoWorkspacePath(source.manifest_path, repoSessionWorkspacePrefix),
+		)
+		if (manifestContent == null) {
+			throw new Error(`Manifest "${source.manifest_path}" was not found.`)
+		}
+		const manifest = parseRepoManifest({
+			content: manifestContent,
+			manifestPath: source.manifest_path,
+		})
+		await updateEntitySource(this.env.APP_DB, {
+			id: source.id,
+			userId: source.user_id,
+			publishedCommit,
+			manifestPath: source.manifest_path,
+			sourceRoot: manifest.sourceRoot?.startsWith('/')
+				? manifest.sourceRoot
+				: manifest.sourceRoot
+					? `/${manifest.sourceRoot}`
+					: source.source_root,
+		})
+		return {
+			sessionId: input.sessionId,
+			publishedCommit,
+			message: `Bootstrapped source ${source.id} in ${source.repo_id}.`,
+		}
+	}
+
 	async getSessionInfo(input: { sessionId: string; userId: string }) {
 		const { sessionRow, source } = await this.getSessionState(
 			input.sessionId,
@@ -377,6 +577,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			input.sessionId,
 		)
 		if (!sessionRow) {
+			await this.resetWorkspace()
 			return {
 				ok: true,
 				sessionId: input.sessionId,
@@ -389,14 +590,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			)
 		}
 		await deleteRepoSession(this.env.APP_DB, input.sessionId)
-		try {
-			await this.workspace.rm(repoSessionWorkspacePrefix, {
-				force: true,
-				recursive: true,
-			})
-		} catch {
-			// Best effort only; the session row is the source of truth.
-		}
+		await this.resetWorkspace()
 		return {
 			ok: true,
 			sessionId: input.sessionId,
@@ -569,65 +763,13 @@ class RepoSessionBase extends DurableObject<Env> {
 			input.sessionId,
 			input.userId,
 		)
-		const plan = await this.state.planEdits(
-			input.edits.map((edit) => {
-				const path = resolveRepoWorkspacePath(
-					edit.path,
-					repoSessionWorkspacePrefix,
-				)
-				switch (edit.kind) {
-					case 'write':
-						if (typeof edit.content !== 'string') {
-							throw new Error('repo_apply_patch write edits require content.')
-						}
-						return {
-							kind: 'write' as const,
-							path,
-							content: edit.content,
-						}
-					case 'replace':
-						if (typeof edit.search !== 'string') {
-							throw new Error('repo_apply_patch replace edits require search.')
-						}
-						return {
-							kind: 'replace' as const,
-							path,
-							search: edit.search,
-							replacement: edit.replacement ?? '',
-							options: edit.options,
-						}
-					case 'writeJson':
-						return {
-							kind: 'writeJson' as const,
-							path,
-							value: edit.value,
-							options:
-								typeof edit.options?.spaces === 'number'
-									? { spaces: edit.options.spaces }
-									: undefined,
-						}
-				}
-			}),
-		)
-		const result = await this.state.applyEditPlan(plan, {
-			dryRun: input.dryRun,
-			rollbackOnError: input.rollbackOnError,
-		})
+		const result = await this.applyWorkspaceEdits(input)
 		await updateRepoSession(this.env.APP_DB, {
 			id: input.sessionId,
 			userId: sessionRow.user_id,
 			lastCheckpointAt: nowIso(),
 		})
-		return {
-			dryRun: result.dryRun,
-			totalChanged: result.totalChanged,
-			edits: result.edits.map((edit) => ({
-				path: toExternalRepoPath(edit.path, repoSessionWorkspacePrefix),
-				changed: edit.changed,
-				content: edit.content,
-				diff: edit.diff,
-			})),
-		}
+		return result
 	}
 
 	async runChecks(input: {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -171,15 +171,55 @@ class RepoSessionBase extends DurableObject<Env> {
 	}
 
 	private async resetWorkspace() {
-		await this.workspace
-			.rm(repoSessionWorkspacePrefix, {
+		const gitConfigPath = `${repoSessionWorkspacePrefix}/.git/config`
+		for (let attempt = 0; attempt < 2; attempt += 1) {
+			await this.workspace.rm(repoSessionWorkspacePrefix, {
 				force: true,
 				recursive: true,
 			})
-			.catch(() => {
-				// Best effort only; the session row is the source of truth.
+			const [workspaceExists, gitConfigExists] = await Promise.all([
+				this.workspace.exists(repoSessionWorkspacePrefix),
+				this.workspace.exists(gitConfigPath),
+			])
+			if (!workspaceExists && !gitConfigExists) {
+				this.initializedSessionId = null
+				return
+			}
+		}
+		throw new Error(
+			`Failed to remove repo session workspace "${repoSessionWorkspacePrefix}" cleanly.`,
+		)
+	}
+
+	private async hasExpectedOriginRemote(expectedUrl: string) {
+		try {
+			const remotes = await this.git.remote({
+				dir: repoSessionWorkspacePrefix,
+				list: true,
 			})
-		this.initializedSessionId = null
+			if (!Array.isArray(remotes)) {
+				return false
+			}
+			return remotes.some(
+				(remote) =>
+					remote.remote === 'origin' && remote.url === expectedUrl,
+			)
+		} catch {
+			return false
+		}
+	}
+
+	private async readManifestFromWorkspace(manifestPath: string) {
+		const manifestContent = await this.workspace.readFile(
+			resolveRepoWorkspacePath(manifestPath, repoSessionWorkspacePrefix),
+		)
+		if (manifestContent == null) {
+			throw new Error(`Manifest "${manifestPath}" was not found.`)
+		}
+		return parseRepoManifest({
+			content: manifestContent,
+			manifestPath,
+		})
 	}
 
 	private async getCurrentBranch(defaultBranch = defaultSessionBranch) {
@@ -266,10 +306,18 @@ class RepoSessionBase extends DurableObject<Env> {
 		sessionRepoToken: string
 	}): Promise<void> {
 		if (this.initializedSessionId === input.sessionId) return
-		const hasGitDir = await this.workspace.exists(
-			`${repoSessionWorkspacePrefix}/.git/config`,
-		)
-		if (!hasGitDir) {
+		const gitConfigPath = `${repoSessionWorkspacePrefix}/.git/config`
+		const hasGitDir = await this.workspace.exists(gitConfigPath)
+		if (hasGitDir) {
+			const hasExpectedOrigin = await this.hasExpectedOriginRemote(
+				input.sessionRepoRemote,
+			)
+			if (!hasExpectedOrigin) {
+				await this.resetWorkspace()
+			}
+		}
+		const hasCleanGitDir = await this.workspace.exists(gitConfigPath)
+		if (!hasCleanGitDir) {
 			await this.workspace.mkdir(repoSessionWorkspacePrefix, {
 				recursive: true,
 			})
@@ -519,6 +567,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		if (!publishedCommit) {
 			throw new Error(`Source "${source.id}" bootstrap produced no commit.`)
 		}
+		const manifest = await this.readManifestFromWorkspace(source.manifest_path)
 		await this.git.push({
 			dir: repoSessionWorkspacePrefix,
 			remote: 'source',
@@ -526,16 +575,6 @@ class RepoSessionBase extends DurableObject<Env> {
 			token: sourceAccess.token,
 			username: 'x',
 			password: sourceAccess.token.split('?expires=')[0] ?? sourceAccess.token,
-		})
-		const manifestContent = await this.workspace.readFile(
-			resolveRepoWorkspacePath(source.manifest_path, repoSessionWorkspacePrefix),
-		)
-		if (manifestContent == null) {
-			throw new Error(`Manifest "${source.manifest_path}" was not found.`)
-		}
-		const manifest = parseRepoManifest({
-			content: manifestContent,
-			manifestPath: source.manifest_path,
 		})
 		await updateEntitySource(this.env.APP_DB, {
 			id: source.id,
@@ -948,19 +987,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			username: 'x',
 			password: sourceAccess.token.split('?expires=')[0] ?? sourceAccess.token,
 		})
-		const manifestContent = await this.workspace.readFile(
-			resolveRepoWorkspacePath(
-				source.manifest_path,
-				repoSessionWorkspacePrefix,
-			),
-		)
-		if (manifestContent == null) {
-			throw new Error(`Manifest "${source.manifest_path}" was not found.`)
-		}
-		const manifest = parseRepoManifest({
-			content: manifestContent,
-			manifestPath: source.manifest_path,
-		})
+		const manifest = await this.readManifestFromWorkspace(source.manifest_path)
 		await updateEntitySource(this.env.APP_DB, {
 			id: source.id,
 			userId: source.user_id,

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -1,4 +1,5 @@
 import {
+	type RepoSourceBootstrapResult,
 	type RepoSearchMode,
 	type RepoSearchOutputMode,
 	type RepoSessionApplyEditsResult,
@@ -68,6 +69,12 @@ export type RepoSessionRpc = {
 		dryRun?: boolean
 		rollbackOnError?: boolean
 	}) => Promise<RepoSessionApplyEditsResult>
+	bootstrapSource: (payload: {
+		sessionId: string
+		sourceId: string
+		userId: string
+		edits: Array<RepoSessionEdit>
+	}) => Promise<RepoSourceBootstrapResult>
 	runChecks: (payload: {
 		sessionId: string
 		userId: string

--- a/packages/worker/src/repo/source-sync.node.test.ts
+++ b/packages/worker/src/repo/source-sync.node.test.ts
@@ -1,0 +1,193 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getEntitySourceById: vi.fn(),
+	repoSessionRpc: vi.fn(),
+}))
+
+vi.mock('./entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+}))
+
+vi.mock('./repo-session-do.ts', () => ({
+	repoSessionRpc: (...args: Array<unknown>) => mockModule.repoSessionRpc(...args),
+}))
+
+const { syncArtifactSourceSnapshot } = await import('./source-sync.ts')
+
+test('syncArtifactSourceSnapshot bootstraps unpublished sources directly into the source repo', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+
+	const sessionClient = {
+		bootstrapSource: vi.fn(async () => ({
+			sessionId: 'source-sync-source-1-session',
+			publishedCommit: 'commit-bootstrap-1',
+			message: 'Bootstrapped source source-1 in app-1.',
+		})),
+		openSession: vi.fn(),
+		applyEdits: vi.fn(),
+		publishSession: vi.fn(),
+		discardSession: vi.fn(async () => ({
+			ok: true as const,
+			sessionId: 'source-sync-source-1-session',
+			deleted: false,
+		})),
+	}
+
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'app',
+		entity_id: 'app-1',
+		repo_id: 'app-1',
+		published_commit: null,
+		indexed_commit: null,
+		manifest_path: 'kody.json',
+		source_root: '/',
+		created_at: '2026-04-18T00:00:00.000Z',
+		updated_at: '2026-04-18T00:00:00.000Z',
+	})
+	mockModule.repoSessionRpc.mockReturnValue(sessionClient as never)
+
+	const publishedCommit = await syncArtifactSourceSnapshot({
+		env: {
+			APP_DB: {
+				prepare() {
+					return {} as D1PreparedStatement
+				},
+			},
+			REPO_SESSION: {},
+			CLOUDFLARE_ACCOUNT_ID: 'account-1',
+			CLOUDFLARE_API_TOKEN: 'token-1',
+		} as unknown as Env,
+		userId: 'user-1',
+		baseUrl: 'https://heykody.dev',
+		sourceId: 'source-1',
+		files: {
+			'kody.json': '{"version":1,"kind":"app"}',
+			'client.html': '<main>Hello</main>',
+		},
+	})
+
+	expect(publishedCommit).toBe('commit-bootstrap-1')
+	expect(sessionClient.bootstrapSource).toHaveBeenCalledWith({
+		sessionId: expect.stringMatching(/^source-sync-source-1-/),
+		sourceId: 'source-1',
+		userId: 'user-1',
+		edits: [
+			{
+				kind: 'write',
+				path: 'kody.json',
+				content: '{"version":1,"kind":"app"}',
+			},
+			{
+				kind: 'write',
+				path: 'client.html',
+				content: '<main>Hello</main>',
+			},
+		],
+	})
+	expect(sessionClient.openSession).not.toHaveBeenCalled()
+	expect(sessionClient.applyEdits).not.toHaveBeenCalled()
+	expect(sessionClient.publishSession).not.toHaveBeenCalled()
+	expect(sessionClient.discardSession).toHaveBeenCalledWith({
+		sessionId: expect.stringMatching(/^source-sync-source-1-/),
+		userId: 'user-1',
+	})
+})
+
+test('syncArtifactSourceSnapshot still uses repo sessions for already-published sources', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+
+	const sessionClient = {
+		bootstrapSource: vi.fn(),
+		openSession: vi.fn(async () => ({
+			id: 'source-sync-source-1-session',
+		})),
+		applyEdits: vi.fn(async () => ({
+			dryRun: false,
+			totalChanged: 1,
+			edits: [],
+		})),
+		publishSession: vi.fn(async () => ({
+			status: 'ok' as const,
+			sessionId: 'source-sync-source-1-session',
+			publishedCommit: 'commit-session-2',
+			message: 'Published session source-sync-source-1-session to app-1.',
+		})),
+		discardSession: vi.fn(async () => ({
+			ok: true as const,
+			sessionId: 'source-sync-source-1-session',
+			deleted: true,
+		})),
+	}
+
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'app',
+		entity_id: 'app-1',
+		repo_id: 'app-1',
+		published_commit: 'commit-existing-1',
+		indexed_commit: 'commit-existing-1',
+		manifest_path: 'kody.json',
+		source_root: '/',
+		created_at: '2026-04-18T00:00:00.000Z',
+		updated_at: '2026-04-18T00:00:00.000Z',
+	})
+	mockModule.repoSessionRpc.mockReturnValue(sessionClient as never)
+
+	const publishedCommit = await syncArtifactSourceSnapshot({
+		env: {
+			APP_DB: {
+				prepare() {
+					return {} as D1PreparedStatement
+				},
+			},
+			REPO_SESSION: {},
+			CLOUDFLARE_ACCOUNT_ID: 'account-1',
+			CLOUDFLARE_API_TOKEN: 'token-1',
+		} as unknown as Env,
+		userId: 'user-1',
+		baseUrl: 'https://heykody.dev',
+		sourceId: 'source-1',
+		files: {
+			'kody.json': '{"version":1,"kind":"app"}',
+		},
+	})
+
+	expect(publishedCommit).toBe('commit-session-2')
+	expect(sessionClient.bootstrapSource).not.toHaveBeenCalled()
+	expect(sessionClient.openSession).toHaveBeenCalledWith({
+		sessionId: expect.stringMatching(/^source-sync-source-1-/),
+		sourceId: 'source-1',
+		userId: 'user-1',
+		baseUrl: 'https://heykody.dev',
+		sourceRoot: '/',
+	})
+	expect(sessionClient.applyEdits).toHaveBeenCalledWith({
+		sessionId: expect.stringMatching(/^source-sync-source-1-/),
+		userId: 'user-1',
+		edits: [
+			{
+				kind: 'write',
+				path: 'kody.json',
+				content: '{"version":1,"kind":"app"}',
+			},
+		],
+		dryRun: false,
+		rollbackOnError: true,
+	})
+	expect(sessionClient.publishSession).toHaveBeenCalledWith({
+		sessionId: expect.stringMatching(/^source-sync-source-1-/),
+		userId: 'user-1',
+		force: true,
+	})
+	expect(sessionClient.discardSession).toHaveBeenCalledWith({
+		sessionId: expect.stringMatching(/^source-sync-source-1-/),
+		userId: 'user-1',
+	})
+})

--- a/packages/worker/src/repo/source-sync.ts
+++ b/packages/worker/src/repo/source-sync.ts
@@ -34,7 +34,21 @@ export async function syncArtifactSourceSnapshot(
 	if (!source) return null
 	const sessionId = buildSyncSessionId(source.id)
 	const session = repoSessionRpc(input.env, sessionId)
+	const edits = Object.entries(input.files).map(([path, content]) => ({
+		kind: 'write' as const,
+		path,
+		content,
+	}))
 	try {
+		if (!source.published_commit) {
+			const bootstrapResult = await session.bootstrapSource({
+				sessionId,
+				sourceId: source.id,
+				userId: input.userId,
+				edits,
+			})
+			return bootstrapResult.publishedCommit
+		}
 		await session.openSession({
 			sessionId,
 			sourceId: source.id,
@@ -45,11 +59,7 @@ export async function syncArtifactSourceSnapshot(
 		await session.applyEdits({
 			sessionId,
 			userId: input.userId,
-			edits: Object.entries(input.files).map(([path, content]) => ({
-				kind: 'write' as const,
-				path,
-				content,
-			})),
+			edits,
 			dryRun: false,
 			rollbackOnError: true,
 		})

--- a/packages/worker/src/repo/types.ts
+++ b/packages/worker/src/repo/types.ts
@@ -326,6 +326,12 @@ export type RepoSessionPublishResult =
 			publishedCommit: null
 	  }
 
+export type RepoSourceBootstrapResult = {
+	sessionId: string
+	publishedCommit: string
+	message: string
+}
+
 export type RepoSessionRebaseResult = {
 	ok: true
 	sessionId: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- split first publish from later repo-session edits by routing unpublished sources through a direct source-repo bootstrap path
- keep repo-session fork/export workflows only for sources that already have a published commit
- harden repo session workspace cleanup so stale bootstrap `.git` state cannot be silently reused by later session clones
- validate repo manifests before bootstrap push so bootstrap failures cannot leave a pushed commit with no recorded `published_commit`
- add focused node-unit coverage for unpublished-source bootstrap vs published-source session publish

## Validation
- `npx vitest run --project node-unit "packages/worker/src/repo/source-sync.node.test.ts" "packages/worker/src/repo/source-service.node.test.ts" "packages/worker/src/repo/source-backfill.node.test.ts"`
- `npx vitest run --project node-unit "packages/worker/src/repo/source-sync.node.test.ts" "packages/worker/src/repo/source-service.node.test.ts" "packages/worker/src/repo/source-backfill.node.test.ts" "packages/worker/src/repo/app-source.node.test.ts" "packages/worker/src/jobs/service.node.test.ts"`
- `npx tsc -b --noEmit`

## Notes
- left the pre-existing `package-lock.json` working-tree change untouched
- kept the Artifacts REST transport only; no worker-binding fallback was reintroduced
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee3db9b5-4ecf-4f6a-b2d3-c207eb3766a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee3db9b5-4ecf-4f6a-b2d3-c207eb3766a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a source-bootstrapping API to initialize unpublished repositories, apply edits, commit/push changes, and return publish results.

* **Improvements**
  * Improved workspace lifecycle management, session cleanup, and shared handling of workspace edits with validation and rollback support.

* **Tests**
  * Added tests covering unpublished and published source sync flows to validate bootstrapping and session-based apply/publish behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->