### PR TITLE
Split initial source bootstrap from repo sessions

### DIFF
--- a/packages/worker/src/mcp/capabilities/meta/meta-save-skill.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-save-skill.node.test.ts
@@ -1,0 +1,185 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	deleteEntitySource: vi.fn(),
+	updateEntitySource: vi.fn(),
+	deleteMcpSkill: vi.fn(),
+	getMcpSkillByName: vi.fn(),
+	insertMcpSkill: vi.fn(),
+	isDuplicateSkillNameError: vi.fn(() => false),
+	updateMcpSkill: vi.fn(),
+	buildSkillEmbedTextFromStoredRow: vi.fn(),
+	prepareSkillPersistence: vi.fn(),
+	upsertSkillVector: vi.fn(),
+	syncArtifactSourceSnapshot: vi.fn(),
+	buildSkillSourceFiles: vi.fn(),
+	ensureEntitySource: vi.fn(),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	deleteEntitySource: (...args: Array<unknown>) =>
+		mockModule.deleteEntitySource(...args),
+	updateEntitySource: (...args: Array<unknown>) =>
+		mockModule.updateEntitySource(...args),
+}))
+
+vi.mock('#mcp/skills/mcp-skills-repo.ts', () => ({
+	deleteMcpSkill: (...args: Array<unknown>) => mockModule.deleteMcpSkill(...args),
+	getMcpSkillByName: (...args: Array<unknown>) =>
+		mockModule.getMcpSkillByName(...args),
+	insertMcpSkill: (...args: Array<unknown>) => mockModule.insertMcpSkill(...args),
+	isDuplicateSkillNameError: (...args: Array<unknown>) =>
+		mockModule.isDuplicateSkillNameError(...args),
+	updateMcpSkill: (...args: Array<unknown>) => mockModule.updateMcpSkill(...args),
+}))
+
+vi.mock('#mcp/skills/skill-mutation.ts', () => ({
+	buildSkillEmbedTextFromStoredRow: (...args: Array<unknown>) =>
+		mockModule.buildSkillEmbedTextFromStoredRow(...args),
+	prepareSkillPersistence: (...args: Array<unknown>) =>
+		mockModule.prepareSkillPersistence(...args),
+}))
+
+vi.mock('#mcp/skills/skill-vectorize.ts', () => ({
+	upsertSkillVector: (...args: Array<unknown>) =>
+		mockModule.upsertSkillVector(...args),
+}))
+
+vi.mock('#worker/repo/source-sync.ts', () => ({
+	syncArtifactSourceSnapshot: (...args: Array<unknown>) =>
+		mockModule.syncArtifactSourceSnapshot(...args),
+}))
+
+vi.mock('#worker/repo/source-templates.ts', () => ({
+	buildSkillSourceFiles: (...args: Array<unknown>) =>
+		mockModule.buildSkillSourceFiles(...args),
+}))
+
+vi.mock('#worker/repo/source-service.ts', () => ({
+	ensureEntitySource: (...args: Array<unknown>) =>
+		mockModule.ensureEntitySource(...args),
+}))
+
+const { metaSaveSkillCapability } = await import('./meta-save-skill.ts')
+
+test('meta_save_skill deletes newly written source references when source sync fails', async () => {
+	mockModule.deleteEntitySource.mockReset()
+	mockModule.updateEntitySource.mockReset()
+	mockModule.deleteMcpSkill.mockReset()
+	mockModule.getMcpSkillByName.mockReset()
+	mockModule.insertMcpSkill.mockReset()
+	mockModule.isDuplicateSkillNameError.mockReset()
+	mockModule.updateMcpSkill.mockReset()
+	mockModule.buildSkillEmbedTextFromStoredRow.mockReset()
+	mockModule.prepareSkillPersistence.mockReset()
+	mockModule.upsertSkillVector.mockReset()
+	mockModule.syncArtifactSourceSnapshot.mockReset()
+	mockModule.buildSkillSourceFiles.mockReset()
+	mockModule.ensureEntitySource.mockReset()
+
+	mockModule.getMcpSkillByName.mockResolvedValue(null)
+	mockModule.isDuplicateSkillNameError.mockReturnValue(false)
+	mockModule.prepareSkillPersistence.mockResolvedValue({
+		merged: ['repo_open_session'],
+		inferencePartial: false,
+		derived: {
+			destructiveDerived: false,
+			readOnlyDerived: false,
+			idempotentDerived: true,
+		},
+		warnings: [],
+		embedText: 'Skill embed text',
+		rowPayload: {
+			name: 'test-skill',
+			title: 'Test skill',
+			description: 'Skill used to test source rollback',
+			collection_name: null,
+			collection_slug: null,
+			keywords: '["repo"]',
+			code: 'async () => "ok"',
+			search_text: null,
+			uses_capabilities: null,
+			parameters: null,
+			inferred_capabilities: '["repo_open_session"]',
+			inference_partial: 0,
+			read_only: 0,
+			idempotent: 1,
+			destructive: 0,
+		},
+	})
+	mockModule.ensureEntitySource.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'skill',
+		entity_id: 'skill-1',
+		repo_id: 'repo-1',
+		published_commit: null,
+		indexed_commit: null,
+		manifest_path: 'kody.json',
+		source_root: '/',
+		created_at: '2026-04-18T00:00:00.000Z',
+		updated_at: '2026-04-18T00:00:00.000Z',
+	})
+	mockModule.buildSkillSourceFiles.mockReturnValue({
+		'kody.json': '{"version":1}',
+		'src/skill.ts': 'async () => "ok"',
+	})
+	mockModule.syncArtifactSourceSnapshot.mockRejectedValue(
+		new Error('bootstrap publish failed'),
+	)
+
+	const db = {} as D1Database
+
+	await expect(
+		metaSaveSkillCapability.handler(
+			{
+				name: 'test-skill',
+				title: 'Test skill',
+				description: 'Skill used to test source rollback',
+				keywords: ['repo'],
+				code: 'async () => "ok"',
+				read_only: false,
+				idempotent: true,
+				destructive: false,
+			},
+			{
+				env: { APP_DB: db } as Env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://heykody.dev',
+					user: { userId: 'user-1', email: 'user@example.com' },
+				}),
+			},
+		),
+	).rejects.toThrow('bootstrap publish failed')
+
+	expect(mockModule.insertMcpSkill).toHaveBeenCalledWith(
+		db,
+		expect.objectContaining({
+			user_id: 'user-1',
+			source_id: 'source-1',
+			name: 'test-skill',
+		}),
+	)
+	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalledWith({
+		env: { APP_DB: db },
+		userId: 'user-1',
+		baseUrl: 'https://heykody.dev',
+		sourceId: 'source-1',
+		files: {
+			'kody.json': '{"version":1}',
+			'src/skill.ts': 'async () => "ok"',
+		},
+	})
+	expect(mockModule.deleteMcpSkill).toHaveBeenCalledWith(
+		db,
+		'user-1',
+		'test-skill',
+	)
+	expect(mockModule.deleteEntitySource).toHaveBeenCalledWith(db, {
+		id: 'source-1',
+		userId: 'user-1',
+	})
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+	expect(mockModule.upsertSkillVector).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/mcp/capabilities/meta/meta-save-skill.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-save-skill.ts
@@ -184,32 +184,74 @@ export const metaSaveSkillCapability = defineDomainCapability(
 				}
 			}
 
-			const syncedPublishedCommit = await syncArtifactSourceSnapshot({
-				env: ctx.env,
-				userId: user.userId,
-				baseUrl: ctx.callerContext.baseUrl,
-				sourceId: source.id,
-				files: buildSkillSourceFiles({
-					title: args.title,
-					description: args.description,
-					keywords: args.keywords,
-					searchText: args.search_text ?? null,
-					collection: prep.rowPayload.collection_name,
-					readOnly: args.read_only,
-					idempotent: args.idempotent,
-					destructive: args.destructive,
-					usesCapabilities: args.uses_capabilities ?? null,
-					parameters: args.parameters ?? null,
-					code: args.code,
-				}),
-			})
-			if (syncedPublishedCommit) {
-				await updateEntitySource(ctx.env.APP_DB, {
-					id: source.id,
+			try {
+				const syncedPublishedCommit = await syncArtifactSourceSnapshot({
+					env: ctx.env,
 					userId: user.userId,
-					publishedCommit: syncedPublishedCommit,
-					indexedCommit: syncedPublishedCommit,
+					baseUrl: ctx.callerContext.baseUrl,
+					sourceId: source.id,
+					files: buildSkillSourceFiles({
+						title: args.title,
+						description: args.description,
+						keywords: args.keywords,
+						searchText: args.search_text ?? null,
+						collection: prep.rowPayload.collection_name,
+						readOnly: args.read_only,
+						idempotent: args.idempotent,
+						destructive: args.destructive,
+						usesCapabilities: args.uses_capabilities ?? null,
+						parameters: args.parameters ?? null,
+						code: args.code,
+					}),
 				})
+				if (syncedPublishedCommit) {
+					await updateEntitySource(ctx.env.APP_DB, {
+						id: source.id,
+						userId: user.userId,
+						publishedCommit: syncedPublishedCommit,
+						indexedCommit: syncedPublishedCommit,
+					})
+				}
+			} catch (cause) {
+				if (existing) {
+					await updateMcpSkill(ctx.env.APP_DB, user.userId, existing.name, {
+						source_id: existing.source_id,
+						name: existing.name,
+						title: existing.title,
+						description: existing.description,
+						collection_name: existing.collection_name,
+						collection_slug: existing.collection_slug,
+						keywords: existing.keywords,
+						code: existing.code,
+						search_text: existing.search_text,
+						uses_capabilities: existing.uses_capabilities,
+						parameters: existing.parameters,
+						inferred_capabilities: existing.inferred_capabilities,
+						inference_partial: existing.inference_partial,
+						read_only: existing.read_only,
+						idempotent: existing.idempotent,
+						destructive: existing.destructive,
+					})
+					await updateEntitySource(ctx.env.APP_DB, {
+						id: source.id,
+						userId: user.userId,
+						publishedCommit: previousPublishedCommit,
+						indexedCommit: previousPublishedCommit,
+					})
+				} else {
+					await Promise.allSettled([
+						deleteMcpSkill(
+							ctx.env.APP_DB,
+							user.userId,
+							prep.rowPayload.name,
+						),
+						deleteEntitySource(ctx.env.APP_DB, {
+							id: source.id,
+							userId: user.userId,
+						}),
+					])
+				}
+				throw cause
 			}
 
 			try {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -291,6 +291,11 @@ class RepoSessionBase extends DurableObject<Env> {
 					`Source "${input.sourceId}" was not found for this user.`,
 				)
 			}
+			if (!source.published_commit) {
+				throw new Error(
+					`Source "${input.sourceId}" has not been published yet. Bootstrap the first publish directly to the source repo before opening a repo session.`,
+				)
+			}
 			const sourceRepo = await resolveArtifactSourceRepo(
 				this.env,
 				source.repo_id,
@@ -751,6 +756,11 @@ class RepoSessionBase extends DurableObject<Env> {
 			input.sessionId,
 			input.userId,
 		)
+		if (!source.published_commit) {
+			throw new Error(
+				`Source "${source.id}" has not been published yet. Bootstrap the first publish directly to the source repo before using repo sessions.`,
+			)
+		}
 		const checkStatus = await this.readCheckStatus()
 		const currentTreeHash = await this.computeTreeHash()
 		if (

--- a/packages/worker/src/repo/source-sync.node.test.ts
+++ b/packages/worker/src/repo/source-sync.node.test.ts
@@ -1,0 +1,340 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getEntitySourceById: vi.fn(),
+	updateEntitySource: vi.fn(),
+	hasArtifactsAccess: vi.fn(() => true),
+	parseArtifactTokenSecret: vi.fn((token: string) =>
+		token.replace(/\?expires=.*$/, ''),
+	),
+	resolveArtifactSourceRepo: vi.fn(),
+	parseRepoManifest: vi.fn(),
+	repoSessionRpc: vi.fn(),
+	createGit: vi.fn(),
+	fsMkdir: vi.fn(),
+	fsWriteFile: vi.fn(),
+}))
+
+vi.mock('./entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+	updateEntitySource: (...args: Array<unknown>) =>
+		mockModule.updateEntitySource(...args),
+}))
+
+vi.mock('./artifacts.ts', () => ({
+	hasArtifactsAccess: (...args: Array<unknown>) =>
+		mockModule.hasArtifactsAccess(...args),
+	parseArtifactTokenSecret: (...args: Array<unknown>) =>
+		mockModule.parseArtifactTokenSecret(...args),
+	resolveArtifactSourceRepo: (...args: Array<unknown>) =>
+		mockModule.resolveArtifactSourceRepo(...args),
+}))
+
+vi.mock('./manifest.ts', () => ({
+	parseRepoManifest: (...args: Array<unknown>) =>
+		mockModule.parseRepoManifest(...args),
+}))
+
+vi.mock('./repo-session-do.ts', () => ({
+	repoSessionRpc: (...args: Array<unknown>) => mockModule.repoSessionRpc(...args),
+}))
+
+vi.mock('@cloudflare/shell', () => ({
+	InMemoryFs: class {
+		mkdir = mockModule.fsMkdir
+		writeFile = mockModule.fsWriteFile
+	},
+}))
+
+vi.mock('@cloudflare/shell/git', () => ({
+	createGit: (...args: Array<unknown>) => mockModule.createGit(...args),
+}))
+
+const { syncArtifactSourceSnapshot } = await import('./source-sync.ts')
+
+function createDb() {
+	return {
+		prepare() {
+			return {}
+		},
+	} as unknown as D1Database
+}
+
+function createSource(
+	overrides: Partial<{
+		published_commit: string | null
+		source_root: string
+	}> = {},
+) {
+	return {
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'skill' as const,
+		entity_id: 'skill-1',
+		repo_id: 'repo-1',
+		published_commit: null,
+		indexed_commit: null,
+		manifest_path: 'kody.json',
+		source_root: '/',
+		created_at: '2026-04-18T00:00:00.000Z',
+		updated_at: '2026-04-18T00:00:00.000Z',
+		...overrides,
+	}
+}
+
+test('syncArtifactSourceSnapshot bootstraps the first publish directly to the source repo', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.updateEntitySource.mockReset()
+	mockModule.hasArtifactsAccess.mockReset()
+	mockModule.parseArtifactTokenSecret.mockReset()
+	mockModule.resolveArtifactSourceRepo.mockReset()
+	mockModule.parseRepoManifest.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+	mockModule.createGit.mockReset()
+	mockModule.fsMkdir.mockReset()
+	mockModule.fsWriteFile.mockReset()
+
+	mockModule.hasArtifactsAccess.mockReturnValue(true)
+	mockModule.parseArtifactTokenSecret.mockImplementation((token: string) =>
+		token.replace(/\?expires=.*$/, ''),
+	)
+	mockModule.getEntitySourceById.mockResolvedValue(createSource())
+	mockModule.parseRepoManifest.mockReturnValue({
+		sourceRoot: 'src',
+	})
+	mockModule.resolveArtifactSourceRepo.mockResolvedValue({
+		info: vi.fn(async () => ({
+			defaultBranch: 'main',
+			remote: 'https://artifacts.example/repos/repo-1.git',
+		})),
+		createToken: vi.fn(async () => ({
+			plaintext: 'art_v1_write?expires=1760000000',
+		})),
+	})
+
+	const gitClient = {
+		init: vi.fn(async () => ({ initialized: '/' })),
+		remote: vi.fn(async () => ({ added: 'origin', url: 'unused' })),
+		add: vi.fn(async () => ({ added: '.' })),
+		commit: vi.fn(async () => ({
+			oid: 'commit-bootstrap',
+			message: 'Bootstrap source source-1',
+		})),
+		push: vi.fn(async () => ({ ok: true, refs: {} })),
+	}
+	mockModule.createGit.mockReturnValue(gitClient)
+	const db = createDb()
+
+	const publishedCommit = await syncArtifactSourceSnapshot({
+		env: {
+			APP_DB: db,
+		} as Env,
+		userId: 'user-1',
+		baseUrl: 'https://heykody.dev',
+		sourceId: 'source-1',
+		files: {
+			'kody.json': JSON.stringify({
+				version: 1,
+				kind: 'skill',
+				title: 'Bootstrap skill',
+				description: 'Publishes directly to the source repo',
+				entrypoint: 'src/skill.ts',
+				sourceRoot: 'src',
+			}),
+			'src/skill.ts': 'export default async () => "ok"',
+		},
+	})
+
+	expect(publishedCommit).toBe('commit-bootstrap')
+	expect(mockModule.repoSessionRpc).not.toHaveBeenCalled()
+	expect(mockModule.resolveArtifactSourceRepo).toHaveBeenCalledWith(
+		expect.objectContaining({ APP_DB: expect.anything() }),
+		'repo-1',
+	)
+	expect(mockModule.fsMkdir).toHaveBeenCalledWith('/src', { recursive: true })
+	expect(mockModule.fsWriteFile).toHaveBeenCalledWith(
+		'/kody.json',
+		expect.any(String),
+	)
+	expect(mockModule.fsWriteFile).toHaveBeenCalledWith(
+		'/src/skill.ts',
+		'export default async () => "ok"',
+	)
+	expect(gitClient.init).toHaveBeenCalledWith({
+		dir: '/',
+		defaultBranch: 'main',
+	})
+	expect(gitClient.remote).toHaveBeenCalledWith({
+		dir: '/',
+		add: {
+			name: 'origin',
+			url: 'https://artifacts.example/repos/repo-1.git',
+		},
+	})
+	expect(gitClient.push).toHaveBeenCalledWith({
+		dir: '/',
+		remote: 'origin',
+		ref: 'main',
+		username: 'x',
+		password: 'art_v1_write',
+	})
+	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(db, {
+		id: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-bootstrap',
+		manifestPath: 'kody.json',
+		sourceRoot: '/src',
+	})
+})
+
+test('syncArtifactSourceSnapshot leaves the source row unchanged when bootstrap push fails', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.updateEntitySource.mockReset()
+	mockModule.hasArtifactsAccess.mockReset()
+	mockModule.parseArtifactTokenSecret.mockReset()
+	mockModule.resolveArtifactSourceRepo.mockReset()
+	mockModule.parseRepoManifest.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+	mockModule.createGit.mockReset()
+	mockModule.fsMkdir.mockReset()
+	mockModule.fsWriteFile.mockReset()
+
+	mockModule.hasArtifactsAccess.mockReturnValue(true)
+	mockModule.parseArtifactTokenSecret.mockImplementation((token: string) =>
+		token.replace(/\?expires=.*$/, ''),
+	)
+	mockModule.getEntitySourceById.mockResolvedValue(createSource())
+	mockModule.parseRepoManifest.mockReturnValue({
+		sourceRoot: '/',
+	})
+	mockModule.resolveArtifactSourceRepo.mockResolvedValue({
+		info: vi.fn(async () => ({
+			defaultBranch: 'main',
+			remote: 'https://artifacts.example/repos/repo-1.git',
+		})),
+		createToken: vi.fn(async () => ({
+			plaintext: 'art_v1_write?expires=1760000000',
+		})),
+	})
+	mockModule.createGit.mockReturnValue({
+		init: vi.fn(async () => ({ initialized: '/' })),
+		remote: vi.fn(async () => ({ added: 'origin', url: 'unused' })),
+		add: vi.fn(async () => ({ added: '.' })),
+		commit: vi.fn(async () => ({
+			oid: 'commit-bootstrap',
+			message: 'Bootstrap source source-1',
+		})),
+		push: vi.fn(async () => {
+			throw new Error('push failed')
+		}),
+	})
+
+	await expect(
+		syncArtifactSourceSnapshot({
+			env: {
+				APP_DB: createDb(),
+			} as Env,
+			userId: 'user-1',
+			baseUrl: 'https://heykody.dev',
+			sourceId: 'source-1',
+			files: {
+				'kody.json': JSON.stringify({
+					version: 1,
+					kind: 'skill',
+					title: 'Bootstrap skill',
+					description: 'Publishes directly to the source repo',
+					entrypoint: 'src/skill.ts',
+				}),
+				'src/skill.ts': 'export default async () => "ok"',
+			},
+		}),
+	).rejects.toThrow('push failed')
+
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+	expect(mockModule.repoSessionRpc).not.toHaveBeenCalled()
+})
+
+test('syncArtifactSourceSnapshot uses repo sessions for already-published sources', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.updateEntitySource.mockReset()
+	mockModule.hasArtifactsAccess.mockReset()
+	mockModule.resolveArtifactSourceRepo.mockReset()
+	mockModule.parseRepoManifest.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+	mockModule.createGit.mockReset()
+
+	mockModule.hasArtifactsAccess.mockReturnValue(true)
+	mockModule.getEntitySourceById.mockResolvedValue(
+		createSource({ published_commit: 'commit-1' }),
+	)
+
+	const sessionClient = {
+		openSession: vi.fn(async () => ({ id: 'session-1' })),
+		applyEdits: vi.fn(async () => ({ dryRun: false, totalChanged: 2, edits: [] })),
+		publishSession: vi.fn(async () => ({
+			status: 'ok' as const,
+			sessionId: 'session-1',
+			publishedCommit: 'commit-2',
+			message: 'Published',
+		})),
+		discardSession: vi.fn(async () => ({
+			ok: true as const,
+			sessionId: 'session-1',
+			deleted: true,
+		})),
+	}
+	mockModule.repoSessionRpc.mockReturnValue(sessionClient)
+
+	const publishedCommit = await syncArtifactSourceSnapshot({
+		env: {
+			APP_DB: createDb(),
+			REPO_SESSION: {},
+		} as Env,
+		userId: 'user-1',
+		baseUrl: 'https://heykody.dev',
+		sourceId: 'source-1',
+		files: {
+			'kody.json': '{"version":1}',
+			'src/skill.ts': 'export default async () => "ok"',
+		},
+	})
+
+	expect(publishedCommit).toBe('commit-2')
+	expect(mockModule.createGit).not.toHaveBeenCalled()
+	expect(mockModule.resolveArtifactSourceRepo).not.toHaveBeenCalled()
+	expect(sessionClient.openSession).toHaveBeenCalledWith({
+		sessionId: expect.stringMatching(/^source-sync-source-1-/),
+		sourceId: 'source-1',
+		userId: 'user-1',
+		baseUrl: 'https://heykody.dev',
+		sourceRoot: '/',
+	})
+	expect(sessionClient.applyEdits).toHaveBeenCalledWith({
+		sessionId: expect.stringMatching(/^source-sync-source-1-/),
+		userId: 'user-1',
+		edits: [
+			{
+				kind: 'write',
+				path: 'kody.json',
+				content: '{"version":1}',
+			},
+			{
+				kind: 'write',
+				path: 'src/skill.ts',
+				content: 'export default async () => "ok"',
+			},
+		],
+		dryRun: false,
+		rollbackOnError: true,
+	})
+	expect(sessionClient.publishSession).toHaveBeenCalledWith({
+		sessionId: expect.stringMatching(/^source-sync-source-1-/),
+		userId: 'user-1',
+		force: true,
+	})
+	expect(sessionClient.discardSession).toHaveBeenCalledWith({
+		sessionId: expect.stringMatching(/^source-sync-source-1-/),
+		userId: 'user-1',
+	})
+})

--- a/packages/worker/src/repo/source-sync.ts
+++ b/packages/worker/src/repo/source-sync.ts
@@ -1,6 +1,14 @@
-import { hasArtifactsAccess } from './artifacts.ts'
-import { getEntitySourceById } from './entity-sources.ts'
+import { InMemoryFs } from '@cloudflare/shell'
+import { createGit } from '@cloudflare/shell/git'
+import {
+	hasArtifactsAccess,
+	parseArtifactTokenSecret,
+	resolveArtifactSourceRepo,
+} from './artifacts.ts'
+import { getEntitySourceById, updateEntitySource } from './entity-sources.ts'
+import { parseRepoManifest } from './manifest.ts'
 import { repoSessionRpc } from './repo-session-do.ts'
+import { type EntitySourceRow } from './types.ts'
 
 type SyncArtifactSourceInput = {
 	env: Env
@@ -10,13 +18,25 @@ type SyncArtifactSourceInput = {
 	files: Record<string, string>
 }
 
-function canSyncArtifactSource(env: Env) {
+const sourceBootstrapWorkspaceRoot = '/'
+const sourceBootstrapCommitAuthor = {
+	name: 'Kody Source Publish',
+	email: 'source-publish@local.invalid',
+}
+
+function canPersistArtifactSource(env: Env) {
 	return (
 		hasArtifactsAccess(env) &&
-		(env as Env & { REPO_SESSION?: DurableObjectNamespace | undefined })
-			.REPO_SESSION != null &&
 		typeof (env as Env & { APP_DB?: D1Database | undefined }).APP_DB?.prepare ===
 			'function'
+	)
+}
+
+function canSyncPublishedArtifactSource(env: Env) {
+	return (
+		canPersistArtifactSource(env) &&
+		(env as Env & { REPO_SESSION?: DurableObjectNamespace | undefined })
+			.REPO_SESSION != null
 	)
 }
 
@@ -24,14 +44,115 @@ function buildSyncSessionId(sourceId: string) {
 	return `source-sync-${sourceId}-${crypto.randomUUID()}`
 }
 
+function normalizeSourceRoot(input: {
+	manifestSourceRoot: string | undefined
+	currentSourceRoot: string
+}) {
+	if (!input.manifestSourceRoot) {
+		return input.currentSourceRoot
+	}
+	return input.manifestSourceRoot.startsWith('/')
+		? input.manifestSourceRoot
+		: `/${input.manifestSourceRoot}`
+}
+
+function toSourceBootstrapPath(path: string) {
+	return path.startsWith('/') ? path : `/${path}`
+}
+
+async function ensureParentDirectory(fs: InMemoryFs, path: string) {
+	const parentPath = path.replace(/\/[^/]+$/, '') || '/'
+	if (parentPath === '/') {
+		return
+	}
+	await fs.mkdir(parentPath, { recursive: true })
+}
+
+async function bootstrapArtifactSourceSnapshot(input: {
+	env: Env
+	source: EntitySourceRow
+	files: Record<string, string>
+}) {
+	const manifestContent = input.files[input.source.manifest_path]
+	if (manifestContent == null) {
+		throw new Error(`Manifest "${input.source.manifest_path}" was not found.`)
+	}
+	const manifest = parseRepoManifest({
+		content: manifestContent,
+		manifestPath: input.source.manifest_path,
+	})
+	const sourceRepo = await resolveArtifactSourceRepo(input.env, input.source.repo_id)
+	const sourceInfo = await sourceRepo.info()
+	if (!sourceInfo?.remote) {
+		throw new Error('Artifact repo remote URL is unavailable.')
+	}
+	const token = await sourceRepo.createToken('write', 3600)
+	const targetBranch = sourceInfo.defaultBranch
+	const fs = new InMemoryFs()
+	const git = createGit(fs, sourceBootstrapWorkspaceRoot)
+	await git.init({
+		dir: sourceBootstrapWorkspaceRoot,
+		defaultBranch: targetBranch,
+	})
+	for (const [path, content] of Object.entries(input.files)) {
+		const workspacePath = toSourceBootstrapPath(path)
+		await ensureParentDirectory(fs, workspacePath)
+		await fs.writeFile(workspacePath, content)
+	}
+	await git.remote({
+		dir: sourceBootstrapWorkspaceRoot,
+		add: {
+			name: 'origin',
+			url: sourceInfo.remote,
+		},
+	})
+	await git.add({
+		dir: sourceBootstrapWorkspaceRoot,
+		filepath: '.',
+	})
+	const commit = await git.commit({
+		dir: sourceBootstrapWorkspaceRoot,
+		message: `Bootstrap source ${input.source.id}`,
+		author: sourceBootstrapCommitAuthor,
+	})
+	await git.push({
+		dir: sourceBootstrapWorkspaceRoot,
+		remote: 'origin',
+		ref: targetBranch,
+		username: 'x',
+		password: parseArtifactTokenSecret(token.plaintext),
+	})
+	await updateEntitySource(input.env.APP_DB, {
+		id: input.source.id,
+		userId: input.source.user_id,
+		publishedCommit: commit.oid,
+		manifestPath: input.source.manifest_path,
+		sourceRoot: normalizeSourceRoot({
+			manifestSourceRoot: manifest.sourceRoot,
+			currentSourceRoot: input.source.source_root,
+		}),
+	})
+	return commit.oid
+}
+
 export async function syncArtifactSourceSnapshot(
 	input: SyncArtifactSourceInput,
 ): Promise<string | null> {
-	if (!input.sourceId || !canSyncArtifactSource(input.env)) {
+	if (!input.sourceId || !canPersistArtifactSource(input.env)) {
 		return null
 	}
 	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
 	if (!source) return null
+	if (!source.published_commit) {
+		return await bootstrapArtifactSourceSnapshot({
+			env: input.env,
+			source,
+			files: input.files,
+		})
+	}
+	if (!canSyncPublishedArtifactSource(input.env)) {
+		return null
+	}
 	const sessionId = buildSyncSessionId(source.id)
 	const session = repoSessionRpc(input.env, sessionId)
 	try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- bootstrap the first publish for repo-backed sources directly to the source repo via Artifacts REST-backed git access instead of immediately opening a forked repo session
- keep repo-session fork/publish workflows for already-published sources only, and fail closed when callers try to open or publish an unpublished source through the session path
- roll back new saved-skill source references when source sync fails so `source_id` values are not left behind after a failed bootstrap/publish
- add focused node tests for direct bootstrap vs session publish behavior and the saved-skill fail-closed rollback path

## Testing
- `npm run test -- packages/worker/src/repo/source-sync.node.test.ts packages/worker/src/repo/source-backfill.node.test.ts packages/worker/src/repo/source-service.node.test.ts packages/worker/src/repo/artifacts.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-save-skill.node.test.ts`
- `npm run typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72594d0a-f09c-4e73-bb05-f83af90683d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72594d0a-f09c-4e73-bb05-f83af90683d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

