### PR TITLE
Fix migrated repo-backed job runtime entrypoint paths

### DIFF
--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -723,7 +723,7 @@ test('executeJobOnce refreshes repo sessions when base commit moves', async () =
 				kind: 'job',
 				title: 'Repo-backed job',
 				description: 'Runs from repo',
-				entrypoint: 'src/job.ts',
+				entrypoint: '/src/job.ts',
 			},
 		})),
 		readFile: vi.fn(async ({ path }: { path: string }) => ({
@@ -735,7 +735,7 @@ test('executeJobOnce refreshes repo sessions when base commit moves', async () =
 							kind: 'job',
 							title: 'Repo-backed job',
 							description: 'Runs from repo',
-							entrypoint: 'src/job.ts',
+							entrypoint: '/src/job.ts',
 						})
 					: 'async () => ({ ok: true, repoBacked: true })',
 		})),
@@ -775,6 +775,11 @@ test('executeJobOnce refreshes repo sessions when base commit moves', async () =
 		expect(sessionClient.discardSession).toHaveBeenCalledWith({
 			sessionId: 'job-runtime-job-repo-1',
 			userId: 'user-123',
+		})
+		expect(sessionClient.readFile).toHaveBeenCalledWith({
+			sessionId: 'job-runtime-job-repo-1',
+			userId: 'user-123',
+			path: 'src/job.ts',
 		})
 		expect(executeSpy).toHaveBeenCalledTimes(1)
 	} finally {

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -31,7 +31,10 @@ import {
 } from './types.ts'
 import { createJobStorageId } from '#worker/storage-runner.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
-import { parseRepoManifest } from '#worker/repo/manifest.ts'
+import {
+	getManifestEntrypointPath,
+	parseRepoManifest,
+} from '#worker/repo/manifest.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 import { buildJobSourceFiles } from '#worker/repo/source-templates.ts'
@@ -533,7 +536,7 @@ async function runRepoBackedJob(input: {
 	const moduleFile = await sessionClient.readFile({
 		sessionId: session.id,
 		userId: input.callerContext.user.userId,
-		path: manifest.entrypoint.replace(/^\/+/, ''),
+		path: getManifestEntrypointPath(manifest),
 	})
 	if (!moduleFile.content) {
 		return {

--- a/packages/worker/src/mcp/skills/run-saved-skill.ts
+++ b/packages/worker/src/mcp/skills/run-saved-skill.ts
@@ -6,6 +6,7 @@ import {
 	applySkillParameters,
 	parseSkillParameters,
 } from '#mcp/skills/skill-parameters.ts'
+import { getManifestEntrypointPath } from '#worker/repo/manifest.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 
 const runFailureHint =
@@ -142,7 +143,7 @@ async function runRepoBackedSkill(input: {
 		const moduleFile = await sessionClient.readFile({
 			sessionId: session.id,
 			userId: input.callerContext.user?.userId ?? '',
-			path: manifest.entrypoint.replace(/^\/+/, ''),
+			path: getManifestEntrypointPath(manifest),
 		})
 		if (!moduleFile.content) {
 			return {

--- a/packages/worker/src/mcp/skills/run-saved-skill.ts
+++ b/packages/worker/src/mcp/skills/run-saved-skill.ts
@@ -6,7 +6,10 @@ import {
 	applySkillParameters,
 	parseSkillParameters,
 } from '#mcp/skills/skill-parameters.ts'
-import { getManifestEntrypointPath } from '#worker/repo/manifest.ts'
+import {
+	getManifestEntrypointPath,
+	parseRepoManifest,
+} from '#worker/repo/manifest.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 
 const runFailureHint =
@@ -128,7 +131,6 @@ async function runRepoBackedSkill(input: {
 				logs: [],
 			}
 		}
-		const { parseRepoManifest } = await import('#worker/repo/manifest.ts')
 		const manifest = parseRepoManifest({
 			content: entrypoint.content,
 			manifestPath,

--- a/packages/worker/src/repo/app-source.ts
+++ b/packages/worker/src/repo/app-source.ts
@@ -5,7 +5,7 @@ import {
 } from '#mcp/ui-artifact-parameters.ts'
 import { type UiArtifactRow } from '#mcp/ui-artifacts-types.ts'
 import { getEntitySourceById } from './entity-sources.ts'
-import { parseRepoManifest } from './manifest.ts'
+import { normalizeRepoWorkspacePath, parseRepoManifest } from './manifest.ts'
 import { type AppManifest } from './types.ts'
 import { repoSessionRpc } from './repo-session-do.ts'
 
@@ -37,13 +37,13 @@ function fallbackFromArtifact(artifact: UiArtifactRow): ResolvedSavedAppSource {
 
 function resolveManifestClientPath(manifest: AppManifest) {
 	if (Array.isArray(manifest.assets) && manifest.assets.length > 0) {
-		return manifest.assets[0]!
+		return normalizeRepoWorkspacePath(manifest.assets[0]!)
 	}
 	if (typeof manifest.client === 'string') {
-		return manifest.client
+		return normalizeRepoWorkspacePath(manifest.client)
 	}
 	if (Array.isArray(manifest.client) && manifest.client.length > 0) {
-		return manifest.client[0]!
+		return normalizeRepoWorkspacePath(manifest.client[0]!)
 	}
 	return 'client.html'
 }
@@ -105,7 +105,7 @@ export async function resolveSavedAppSource(input: {
 			session.readFile({
 				sessionId: opened.id,
 				userId: input.artifact.user_id,
-				path: manifest.server,
+				path: normalizeRepoWorkspacePath(manifest.server),
 			}),
 		])
 		const resolved = {

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -1,7 +1,25 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	createFileSystemSnapshot: vi.fn(),
+	createTypescriptLanguageService: vi.fn(),
+}))
+
+vi.mock('@cloudflare/worker-bundler', () => ({
+	createFileSystemSnapshot: (...args: Array<unknown>) =>
+		mockModule.createFileSystemSnapshot(...args),
+}))
+
+vi.mock('@cloudflare/worker-bundler/typescript', () => ({
+	createTypescriptLanguageService: (...args: Array<unknown>) =>
+		mockModule.createTypescriptLanguageService(...args),
+}))
+
 import { runRepoChecks } from './checks.ts'
 
 test('runRepoChecks normalizes leading slashes in manifest entrypoints', async () => {
+	mockModule.createFileSystemSnapshot.mockReset()
+	mockModule.createTypescriptLanguageService.mockReset()
 	const files = new Map<string, string>([
 		[
 			'kody.json',
@@ -18,7 +36,24 @@ test('runRepoChecks normalizes leading slashes in manifest entrypoints', async (
 			'src/job.ts',
 			'const run = async () => ({ ok: true })\nvoid run\n',
 		],
+		[
+			'package.json',
+			JSON.stringify({
+				name: 'migrated-job',
+				private: true,
+			}),
+		],
 	])
+	const snapshot = {
+		read: vi.fn((path: string) => files.get(path) ?? null),
+	}
+	const getSemanticDiagnostics = vi.fn(() => [])
+	mockModule.createFileSystemSnapshot.mockResolvedValue(snapshot)
+	mockModule.createTypescriptLanguageService.mockResolvedValue({
+		languageService: {
+			getSemanticDiagnostics,
+		},
+	})
 
 	const result = await runRepoChecks({
 		workspace: {
@@ -48,4 +83,6 @@ test('runRepoChecks normalizes leading slashes in manifest entrypoints', async (
 			}),
 		]),
 	)
+	expect(snapshot.read).toHaveBeenCalledWith('src/job.ts')
+	expect(getSemanticDiagnostics).toHaveBeenCalledWith('src/job.ts')
 })

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from 'vitest'
+import { runRepoChecks } from './checks.ts'
+
+test('runRepoChecks normalizes leading slashes in manifest entrypoints', async () => {
+	const files = new Map<string, string>([
+		[
+			'kody.json',
+			JSON.stringify({
+				version: 1,
+				kind: 'job',
+				title: 'Migrated job',
+				description: 'Runs immediately after migration',
+				sourceRoot: '/',
+				entrypoint: '/src/job.ts',
+			}),
+		],
+		[
+			'src/job.ts',
+			'const run = async () => ({ ok: true })\nvoid run\n',
+		],
+	])
+
+	const result = await runRepoChecks({
+		workspace: {
+			async readFile(path: string) {
+				return files.get(path) ?? null
+			},
+			async glob() {
+				return Array.from(files.keys()).map((path) => ({ path, type: 'file' }))
+			},
+		},
+		manifestPath: 'kody.json',
+		sourceRoot: '/',
+	})
+
+	expect(result.ok).toBe(true)
+	expect(result.results).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				kind: 'bundle',
+				ok: true,
+				message: 'Entrypoint "src/job.ts" found for bundling.',
+			}),
+			expect.objectContaining({
+				kind: 'typecheck',
+				ok: true,
+				message: 'No semantic diagnostics for "src/job.ts".',
+			}),
+		]),
+	)
+})

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -1,4 +1,4 @@
-import { parseRepoManifest } from './manifest.ts'
+import { getManifestEntrypointPath, parseRepoManifest } from './manifest.ts'
 import { type RepoManifest } from './types.ts'
 
 export type RepoCheckKind =
@@ -117,8 +117,7 @@ export async function runRepoChecks(input: {
 				: 'No package.json found in source root; dependency check skipped.',
 	})
 
-	const entryPoint =
-		manifest.kind === 'app' ? manifest.server : manifest.entrypoint
+	const entryPoint = getManifestEntrypointPath(manifest)
 	results.push({
 		kind: 'bundle',
 		ok: snapshot.read(entryPoint) != null,

--- a/packages/worker/src/repo/manifest.ts
+++ b/packages/worker/src/repo/manifest.ts
@@ -54,3 +54,13 @@ export function getManifestPath(manifest: RepoManifest) {
 		? manifestPath
 		: defaultManifestPath
 }
+
+export function normalizeRepoWorkspacePath(path: string) {
+	return path.trim().replace(/^\/+/, '')
+}
+
+export function getManifestEntrypointPath(manifest: RepoManifest) {
+	return normalizeRepoWorkspacePath(
+		manifest.kind === 'app' ? manifest.server : manifest.entrypoint,
+	)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- normalize repo-backed manifest entrypoint paths before bundling, typechecking, or reading runtime files so migrated manifests like `/src/job.ts` execute correctly
- cover migrated `/src/job.ts` manifests in repo checks and repo-backed job execution tests so a migrated repo-backed job can run immediately after migration
- align saved skill and saved app repo source reads with the same repo-relative path handling to avoid similar leading-slash regressions

## Testing
- `npm run test -- --run packages/worker/src/repo/checks.node.test.ts packages/worker/src/jobs/service.node.test.ts packages/worker/src/repo/app-source.node.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d460e12c-9065-4b15-ac2d-f708afc2851a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d460e12c-9065-4b15-ac2d-f708afc2851a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent file-path handling so job/skill execution reads manifest-referenced files reliably.

* **Internal Improvements**
  * Centralized and normalized repository manifest path resolution for workspace files.

* **Tests**
  * Added tests verifying normalized paths are used across checks, bundling, and typechecking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->