### PR TITLE
Fix first-publish auth for new repo-backed skills

### DIFF
--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -194,6 +194,7 @@ export async function createJob(input: {
 		userId: callerContext.user.userId,
 		baseUrl: callerContext.baseUrl,
 		sourceId: job.sourceId,
+		bootstrapAccess: ensuredSource?.bootstrapAccess ?? null,
 		files: buildJobSourceFiles({
 			job: toJobView(job),
 		}),
@@ -322,6 +323,7 @@ export async function updateJob(input: {
 		userId: callerContext.user.userId,
 		baseUrl: callerContext.baseUrl,
 		sourceId: updated.sourceId,
+		bootstrapAccess: ensuredSource?.bootstrapAccess ?? null,
 		files: buildJobSourceFiles({
 			job: toJobView(updated),
 		}),

--- a/packages/worker/src/mcp/capabilities/apps/ui-save-app.ts
+++ b/packages/worker/src/mcp/capabilities/apps/ui-save-app.ts
@@ -398,6 +398,7 @@ export const uiSaveAppCapability = defineDomainCapability(
 						userId: user.userId,
 						baseUrl: ctx.callerContext.baseUrl,
 						sourceId: ensuredSource.id,
+						bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
 						files: buildAppSourceFiles({
 							title,
 							description,
@@ -477,6 +478,7 @@ export const uiSaveAppCapability = defineDomainCapability(
 						userId: user.userId,
 						baseUrl: ctx.callerContext.baseUrl,
 						sourceId: ensuredSource.id,
+						bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
 						files: buildAppSourceFiles({
 							title,
 							description,

--- a/packages/worker/src/mcp/capabilities/meta/meta-save-skill.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-save-skill.node.test.ts
@@ -1,0 +1,192 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	getMcpSkillByName: vi.fn(),
+	insertMcpSkill: vi.fn(),
+	updateMcpSkill: vi.fn(),
+	isDuplicateSkillNameError: vi.fn(),
+	prepareSkillPersistence: vi.fn(),
+	ensureEntitySource: vi.fn(),
+	syncArtifactSourceSnapshot: vi.fn(),
+	updateEntitySource: vi.fn(),
+	upsertSkillVector: vi.fn(),
+	deleteEntitySource: vi.fn(),
+	deleteMcpSkill: vi.fn(),
+}))
+
+vi.mock('#mcp/skills/mcp-skills-repo.ts', () => ({
+	getMcpSkillByName: (...args: Array<unknown>) =>
+		mockModule.getMcpSkillByName(...args),
+	insertMcpSkill: (...args: Array<unknown>) => mockModule.insertMcpSkill(...args),
+	updateMcpSkill: (...args: Array<unknown>) => mockModule.updateMcpSkill(...args),
+	isDuplicateSkillNameError: (...args: Array<unknown>) =>
+		mockModule.isDuplicateSkillNameError(...args),
+	deleteMcpSkill: (...args: Array<unknown>) => mockModule.deleteMcpSkill(...args),
+}))
+
+vi.mock('#mcp/skills/skill-mutation.ts', () => ({
+	prepareSkillPersistence: (...args: Array<unknown>) =>
+		mockModule.prepareSkillPersistence(...args),
+	buildSkillEmbedTextFromStoredRow: vi.fn(),
+}))
+
+vi.mock('#worker/repo/source-service.ts', () => ({
+	ensureEntitySource: (...args: Array<unknown>) =>
+		mockModule.ensureEntitySource(...args),
+}))
+
+vi.mock('#worker/repo/source-sync.ts', () => ({
+	syncArtifactSourceSnapshot: (...args: Array<unknown>) =>
+		mockModule.syncArtifactSourceSnapshot(...args),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	updateEntitySource: (...args: Array<unknown>) =>
+		mockModule.updateEntitySource(...args),
+	deleteEntitySource: (...args: Array<unknown>) =>
+		mockModule.deleteEntitySource(...args),
+}))
+
+vi.mock('#mcp/skills/skill-vectorize.ts', () => ({
+	upsertSkillVector: (...args: Array<unknown>) => mockModule.upsertSkillVector(...args),
+}))
+
+const { metaSaveSkillCapability } = await import('./meta-save-skill.ts')
+
+test('meta_save_skill forwards bootstrap access for a brand-new repo-backed skill publish', async () => {
+	mockModule.getMcpSkillByName.mockReset()
+	mockModule.insertMcpSkill.mockReset()
+	mockModule.updateMcpSkill.mockReset()
+	mockModule.isDuplicateSkillNameError.mockReset()
+	mockModule.prepareSkillPersistence.mockReset()
+	mockModule.ensureEntitySource.mockReset()
+	mockModule.syncArtifactSourceSnapshot.mockReset()
+	mockModule.updateEntitySource.mockReset()
+	mockModule.upsertSkillVector.mockReset()
+	mockModule.deleteEntitySource.mockReset()
+	mockModule.deleteMcpSkill.mockReset()
+
+	mockModule.getMcpSkillByName.mockResolvedValue(null)
+	mockModule.prepareSkillPersistence.mockResolvedValue({
+		rowPayload: {
+			name: 'fresh-repo-skill',
+			title: 'Fresh repo skill',
+			description: 'Persists a brand-new repo-backed skill.',
+			collection_name: null,
+			collection_slug: null,
+			keywords: '["repo","skill"]',
+			code: 'async () => ({ ok: true })',
+			search_text: null,
+			uses_capabilities: null,
+			parameters: null,
+			inferred_capabilities: '[]',
+			inference_partial: 0,
+			read_only: 1,
+			idempotent: 1,
+			destructive: 0,
+		},
+		embedText: 'Fresh repo skill',
+		merged: [],
+		inferencePartial: false,
+		derived: {
+			destructiveDerived: false,
+			readOnlyDerived: true,
+			idempotentDerived: true,
+		},
+		warnings: [],
+	})
+	mockModule.ensureEntitySource.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'skill',
+		entity_id: 'skill-1',
+		repo_id: 'skill-skill-1',
+		published_commit: null,
+		indexed_commit: null,
+		manifest_path: 'kody.json',
+		source_root: '/',
+		created_at: '2026-04-18T00:00:00.000Z',
+		updated_at: '2026-04-18T00:00:00.000Z',
+		bootstrapAccess: {
+			defaultBranch: 'main',
+			remote:
+				'https://acct.artifacts.cloudflare.net/git/default/skill-skill-1.git',
+			token: 'art_v1_bootstrap?expires=1760000000',
+			expiresAt: '2026-10-09T08:53:20.000Z',
+		},
+	})
+	mockModule.syncArtifactSourceSnapshot.mockResolvedValue('commit-bootstrap-1')
+	mockModule.upsertSkillVector.mockResolvedValue(undefined)
+	mockModule.insertMcpSkill.mockResolvedValue(undefined)
+	mockModule.updateEntitySource.mockResolvedValue(true)
+
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-1', email: 'user@example.com' },
+	})
+
+	const result = await metaSaveSkillCapability.handler(
+		{
+			name: 'fresh-repo-skill',
+			title: 'Fresh repo skill',
+			description: 'Persists a brand-new repo-backed skill.',
+			keywords: ['repo', 'skill'],
+			code: 'async () => ({ ok: true })',
+			read_only: true,
+			idempotent: true,
+			destructive: false,
+		},
+		{
+			env: { APP_DB: {} } as Env,
+			callerContext,
+		},
+	)
+
+	expect(mockModule.ensureEntitySource).toHaveBeenCalledWith({
+		db: {},
+		env: { APP_DB: {} },
+		userId: 'user-1',
+		entityKind: 'skill',
+		entityId: expect.any(String),
+		sourceRoot: '/',
+	})
+	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalledWith(
+		expect.objectContaining({
+			env: { APP_DB: {} },
+			userId: 'user-1',
+			baseUrl: 'https://heykody.dev',
+			sourceId: 'source-1',
+			bootstrapAccess: {
+				defaultBranch: 'main',
+				remote:
+					'https://acct.artifacts.cloudflare.net/git/default/skill-skill-1.git',
+				token: 'art_v1_bootstrap?expires=1760000000',
+				expiresAt: '2026-10-09T08:53:20.000Z',
+			},
+			files: expect.objectContaining({
+				'kody.json': expect.stringContaining('"kind": "skill"'),
+				'src/skill.ts': 'async () => ({ ok: true })\n',
+			}),
+		}),
+	)
+	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
+		{},
+		expect.objectContaining({
+			id: 'source-1',
+			userId: 'user-1',
+			publishedCommit: 'commit-bootstrap-1',
+			indexedCommit: 'commit-bootstrap-1',
+		}),
+	)
+	expect(result).toEqual({
+		name: 'fresh-repo-skill',
+		collection: null,
+		collection_slug: null,
+		inferred_capabilities: [],
+		inference_partial: false,
+		destructive_derived: false,
+		read_only_derived: true,
+		idempotent_derived: true,
+	})
+})

--- a/packages/worker/src/mcp/capabilities/meta/meta-save-skill.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-save-skill.node.test.ts
@@ -143,14 +143,16 @@ test('meta_save_skill forwards bootstrap access for a brand-new repo-backed skil
 		},
 	)
 
-	expect(mockModule.ensureEntitySource).toHaveBeenCalledWith({
-		db: {},
-		env: { APP_DB: {} },
-		userId: 'user-1',
-		entityKind: 'skill',
-		entityId: expect.any(String),
-		sourceRoot: '/',
-	})
+	expect(mockModule.ensureEntitySource).toHaveBeenCalledWith(
+		expect.objectContaining({
+			db: {},
+			env: { APP_DB: {} },
+			userId: 'user-1',
+			entityKind: 'skill',
+			entityId: expect.any(String),
+			sourceRoot: '/',
+		}),
+	)
 	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalledWith(
 		expect.objectContaining({
 			env: { APP_DB: {} },

--- a/packages/worker/src/mcp/capabilities/meta/meta-save-skill.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-save-skill.node.test.ts
@@ -113,7 +113,7 @@ test('meta_save_skill forwards bootstrap access for a brand-new repo-backed skil
 			remote:
 				'https://acct.artifacts.cloudflare.net/git/default/skill-skill-1.git',
 			token: 'art_v1_bootstrap?expires=1760000000',
-			expiresAt: '2026-10-09T08:53:20.000Z',
+			expiresAt: '2025-10-09T08:53:20.000Z',
 		},
 	})
 	mockModule.syncArtifactSourceSnapshot.mockResolvedValue('commit-bootstrap-1')
@@ -162,7 +162,7 @@ test('meta_save_skill forwards bootstrap access for a brand-new repo-backed skil
 				remote:
 					'https://acct.artifacts.cloudflare.net/git/default/skill-skill-1.git',
 				token: 'art_v1_bootstrap?expires=1760000000',
-				expiresAt: '2026-10-09T08:53:20.000Z',
+				expiresAt: '2025-10-09T08:53:20.000Z',
 			},
 			files: expect.objectContaining({
 				'kody.json': expect.stringContaining('"kind": "skill"'),

--- a/packages/worker/src/mcp/capabilities/meta/meta-save-skill.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-save-skill.ts
@@ -189,6 +189,7 @@ export const metaSaveSkillCapability = defineDomainCapability(
 				userId: user.userId,
 				baseUrl: ctx.callerContext.baseUrl,
 				sourceId: source.id,
+				bootstrapAccess: source.bootstrapAccess ?? null,
 				files: buildSkillSourceFiles({
 					title: args.title,
 					description: args.description,

--- a/packages/worker/src/mcp/skills/run-saved-skill.node.test.ts
+++ b/packages/worker/src/mcp/skills/run-saved-skill.node.test.ts
@@ -1,0 +1,143 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	getMcpSkillByNameInput: vi.fn(),
+	repoSessionRpc: vi.fn(),
+	runCodemodeWithRegistry: vi.fn(),
+}))
+
+vi.mock('#mcp/skills/mcp-skills-repo.ts', () => ({
+	getMcpSkillByNameInput: (...args: Array<unknown>) =>
+		mockModule.getMcpSkillByNameInput(...args),
+}))
+
+vi.mock('#worker/repo/repo-session-do.ts', () => ({
+	repoSessionRpc: (...args: Array<unknown>) => mockModule.repoSessionRpc(...args),
+}))
+
+vi.mock('#mcp/run-codemode-registry.ts', () => ({
+	runCodemodeWithRegistry: (...args: Array<unknown>) =>
+		mockModule.runCodemodeWithRegistry(...args),
+}))
+
+const { runSavedSkill } = await import('./run-saved-skill.ts')
+
+test('runSavedSkill opens a repo session and executes repo-backed skill code immediately after save', async () => {
+	mockModule.getMcpSkillByNameInput.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+	mockModule.runCodemodeWithRegistry.mockReset()
+
+	mockModule.getMcpSkillByNameInput.mockResolvedValue({
+		id: 'skill-1',
+		user_id: 'user-1',
+		name: 'fresh-skill',
+		title: 'Fresh skill',
+		description: 'Runs from repo',
+		collection_name: null,
+		collection_slug: null,
+		source_id: 'source-1',
+		keywords: '[]',
+		code: 'async () => ({ inline: false })',
+		search_text: null,
+		uses_capabilities: null,
+		parameters: null,
+		inferred_capabilities: '[]',
+		inference_partial: 0,
+		read_only: 1,
+		idempotent: 1,
+		destructive: 0,
+		created_at: '2026-04-18T00:00:00.000Z',
+		updated_at: '2026-04-18T00:00:00.000Z',
+	})
+
+	const sessionClient = {
+		openSession: vi.fn(async () => ({
+			id: 'skill-runtime-skill-1-session',
+			source_id: 'source-1',
+			source_root: '/',
+			base_commit: 'commit-1',
+			session_repo_id: 'session-repo-1',
+			session_repo_name: 'session-repo-name',
+			session_repo_namespace: 'default',
+			conversation_id: null,
+			last_checkpoint_commit: null,
+			last_check_run_id: null,
+			last_check_tree_hash: null,
+			expires_at: null,
+			created_at: '2026-04-18T00:00:00.000Z',
+			updated_at: '2026-04-18T00:00:00.000Z',
+			published_commit: 'commit-1',
+			manifest_path: 'kody.json',
+			entity_type: 'skill' as const,
+		})),
+		readFile: vi.fn(async ({ path }: { path: string }) => ({
+			path,
+			content:
+				path === 'kody.json'
+					? JSON.stringify({
+							version: 1,
+							kind: 'skill',
+							title: 'Fresh skill',
+							description: 'Runs from repo',
+							entrypoint: 'skill.ts',
+						})
+					: 'async () => ({ ok: true, repoBacked: true })',
+		})),
+		discardSession: vi.fn(async () => ({
+			ok: true as const,
+			sessionId: 'skill-runtime-skill-1-session',
+			deleted: true,
+		})),
+	}
+	mockModule.repoSessionRpc.mockReturnValue(sessionClient)
+	mockModule.runCodemodeWithRegistry.mockResolvedValue({
+		result: { ok: true, repoBacked: true },
+		logs: ['repo-backed skill executed'],
+	})
+
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-1', email: 'user@example.com' },
+	})
+
+	const result = await runSavedSkill({
+		env: {} as Env,
+		callerContext,
+		name: 'fresh-skill',
+	})
+
+	expect(result).toEqual({
+		ok: true,
+		result: { ok: true, repoBacked: true },
+		logs: ['repo-backed skill executed'],
+	})
+	expect(sessionClient.openSession).toHaveBeenCalledWith({
+		sessionId: expect.stringMatching(/^skill-runtime-skill-1-/),
+		sourceId: 'source-1',
+		userId: 'user-1',
+		baseUrl: 'https://heykody.dev',
+		sourceRoot: '/',
+	})
+	expect(mockModule.runCodemodeWithRegistry).toHaveBeenCalledWith(
+		{} as Env,
+		expect.objectContaining({
+			repoContext: expect.objectContaining({
+				sourceId: 'source-1',
+				sessionId: 'skill-runtime-skill-1-session',
+				publishedCommit: 'commit-1',
+				entityKind: 'skill',
+				entityId: 'skill-1',
+			}),
+		}),
+		'async () => ({ ok: true, repoBacked: true })',
+		undefined,
+		expect.objectContaining({
+			executorExports: expect.any(Object),
+		}),
+	)
+	expect(sessionClient.discardSession).toHaveBeenCalledWith({
+		sessionId: 'skill-runtime-skill-1-session',
+		userId: 'user-1',
+	})
+})

--- a/packages/worker/src/mcp/skills/run-saved-skill.node.test.ts
+++ b/packages/worker/src/mcp/skills/run-saved-skill.node.test.ts
@@ -71,19 +71,40 @@ test('runSavedSkill opens a repo session and executes repo-backed skill code imm
 			manifest_path: 'kody.json',
 			entity_type: 'skill' as const,
 		})),
-		readFile: vi.fn(async ({ path }: { path: string }) => ({
-			path,
-			content:
-				path === 'kody.json'
-					? JSON.stringify({
+		readFile: vi.fn(
+			async (input: {
+				sessionId: string
+				userId: string
+				path: string
+			}) => {
+				expect(input).toEqual(
+					expect.objectContaining({
+						sessionId: 'skill-runtime-skill-1-session',
+						userId: 'user-1',
+						path: expect.any(String),
+					}),
+				)
+				if (input.path === 'kody.json') {
+					return {
+						path: input.path,
+						content: JSON.stringify({
 							version: 1,
 							kind: 'skill',
 							title: 'Fresh skill',
 							description: 'Runs from repo',
 							entrypoint: 'skill.ts',
-						})
-					: 'async () => ({ ok: true, repoBacked: true })',
-		})),
+						}),
+					}
+				}
+				if (input.path === 'skill.ts') {
+					return {
+						path: input.path,
+						content: 'async () => ({ ok: true, repoBacked: true })',
+					}
+				}
+				throw new Error(`Unexpected repo session readFile path: ${input.path}`)
+			},
+		),
 		discardSession: vi.fn(async () => ({
 			ok: true as const,
 			sessionId: 'skill-runtime-skill-1-session',

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -11,6 +11,13 @@ export type ArtifactToken = {
 	expiresAt: string
 }
 
+export type ArtifactBootstrapAccess = {
+	defaultBranch: string
+	remote: string
+	token: string
+	expiresAt: string
+}
+
 export type ArtifactRepoInfo = {
 	id: string
 	name: string

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -13,6 +13,7 @@ import {
 	updateRepoSession,
 } from './repo-sessions.ts'
 import {
+	type ArtifactBootstrapAccess,
 	buildAuthenticatedArtifactsRemote,
 	resolveArtifactSourceRepo,
 	resolveSessionRepo,
@@ -507,6 +508,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		sessionId: string
 		sourceId: string
 		userId: string
+		bootstrapAccess?: ArtifactBootstrapAccess | null
 		edits: Array<{
 			kind: 'write' | 'replace' | 'writeJson'
 			path: string
@@ -540,12 +542,22 @@ class RepoSessionBase extends DurableObject<Env> {
 			)
 		}
 		const sourceRepo = await resolveArtifactSourceRepo(this.env, source.repo_id)
-		const sourceInfo = await sourceRepo.info()
-		const sourceAccess = await ensureArtifactRepoRemote({
-			repo: sourceRepo,
-			scope: 'write',
-		})
-		const targetBranch = sourceInfo?.defaultBranch ?? defaultSessionBranch
+		const sourceInfo = input.bootstrapAccess
+			? null
+			: await sourceRepo.info()
+		const sourceAccess = input.bootstrapAccess
+			? {
+					remote: input.bootstrapAccess.remote,
+					token: input.bootstrapAccess.token,
+				}
+			: await ensureArtifactRepoRemote({
+					repo: sourceRepo,
+					scope: 'write',
+				})
+		const targetBranch =
+			input.bootstrapAccess?.defaultBranch ??
+			sourceInfo?.defaultBranch ??
+			defaultSessionBranch
 		await this.resetWorkspace()
 		await this.workspace.mkdir(repoSessionWorkspacePrefix, {
 			recursive: true,

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -14,6 +14,7 @@ import {
 } from './repo-sessions.ts'
 import {
 	type ArtifactBootstrapAccess,
+	type ArtifactRepoInfo,
 	buildAuthenticatedArtifactsRemote,
 	resolveArtifactSourceRepo,
 	resolveSessionRepo,
@@ -541,19 +542,21 @@ class RepoSessionBase extends DurableObject<Env> {
 				`Source "${source.id}" already has a published commit. Use repo sessions for later edits.`,
 			)
 		}
-		const sourceRepo = await resolveArtifactSourceRepo(this.env, source.repo_id)
-		const sourceInfo = input.bootstrapAccess
-			? null
-			: await sourceRepo.info()
-		const sourceAccess = input.bootstrapAccess
-			? {
-					remote: input.bootstrapAccess.remote,
-					token: input.bootstrapAccess.token,
-				}
-			: await ensureArtifactRepoRemote({
-					repo: sourceRepo,
-					scope: 'write',
-				})
+		let sourceInfo: ArtifactRepoInfo | null = null
+		let sourceAccess: { remote: string; token: string }
+		if (input.bootstrapAccess) {
+			sourceAccess = {
+				remote: input.bootstrapAccess.remote,
+				token: input.bootstrapAccess.token,
+			}
+		} else {
+			const sourceRepo = await resolveArtifactSourceRepo(this.env, source.repo_id)
+			sourceInfo = await sourceRepo.info()
+			sourceAccess = await ensureArtifactRepoRemote({
+				repo: sourceRepo,
+				scope: 'write',
+			})
+		}
 		const targetBranch =
 			input.bootstrapAccess?.defaultBranch ??
 			sourceInfo?.defaultBranch ??

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -1,3 +1,4 @@
+import { type ArtifactBootstrapAccess } from './artifacts.ts'
 import {
 	type RepoSourceBootstrapResult,
 	type RepoSearchMode,
@@ -74,6 +75,7 @@ export type RepoSessionRpc = {
 		sourceId: string
 		userId: string
 		edits: Array<RepoSessionEdit>
+		bootstrapAccess?: ArtifactBootstrapAccess | null
 	}) => Promise<RepoSourceBootstrapResult>
 	runChecks: (payload: {
 		sessionId: string

--- a/packages/worker/src/repo/source-backfill.ts
+++ b/packages/worker/src/repo/source-backfill.ts
@@ -220,6 +220,7 @@ async function backfillApp(input: {
 			userId: input.userId,
 			baseUrl: input.baseUrl,
 			sourceId: ensuredSource.id,
+			bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
 			files: buildAppSourceFiles({
 				title: input.row.title,
 				description: input.row.description,
@@ -327,6 +328,7 @@ async function backfillSkill(input: {
 			userId: input.userId,
 			baseUrl: input.baseUrl,
 			sourceId: ensuredSource.id,
+			bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
 			files: buildSkillSourceFiles({
 				title: input.row.title,
 				description: input.row.description,
@@ -472,6 +474,7 @@ async function backfillJob(input: {
 			userId: input.userId,
 			baseUrl: input.baseUrl,
 			sourceId: ensuredSource.id,
+			bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
 			files: buildJobSourceFiles({
 				job: toJobView(nextRecord),
 			}),

--- a/packages/worker/src/repo/source-service.node.test.ts
+++ b/packages/worker/src/repo/source-service.node.test.ts
@@ -1,6 +1,10 @@
-import { expect, test } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
 
 const { ensureEntitySource } = await import('./source-service.ts')
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
 
 test('ensureEntitySource fails closed when durable persistence is required without Artifacts REST credentials', async () => {
 	const db = {
@@ -30,4 +34,126 @@ test('ensureEntitySource fails closed when durable persistence is required witho
 	).rejects.toThrow(
 		'Repo-backed source persistence requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.',
 	)
+})
+
+test('ensureEntitySource returns bootstrap access for brand-new repos', async () => {
+	const db = {
+		prepare(query: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async first() {
+							if (query.includes('FROM entity_sources')) {
+								return null
+							}
+							return null
+						},
+						async run() {
+							if (query.includes('INSERT INTO entity_sources')) {
+								return { meta: { changes: 1 } }
+							}
+							throw new Error(`Unexpected run query: ${query} ${params.join(',')}`)
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+
+	let getRepoCount = 0
+	const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+		async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			if (
+				method === 'GET' &&
+				url.pathname.endsWith('/repos/skill-skill-1')
+			) {
+				getRepoCount += 1
+				if (getRepoCount === 1) {
+					return new Response(
+						JSON.stringify({
+							success: false,
+							result: null,
+							errors: [{ code: 1000, message: 'Repo not found' }],
+							messages: [],
+						}),
+						{
+							status: 404,
+							headers: { 'content-type': 'application/json' },
+						},
+					)
+				}
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo-1',
+							name: 'skill-skill-1',
+							description: null,
+							default_branch: 'main',
+							created_at: '2026-04-18T00:00:00.000Z',
+							updated_at: '2026-04-18T00:00:00.000Z',
+							last_push_at: null,
+							source: null,
+							read_only: false,
+							remote:
+								'https://acct.artifacts.cloudflare.net/git/default/skill-skill-1.git',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			if (method === 'POST' && url.pathname.endsWith('/repos')) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo-1',
+							name: 'skill-skill-1',
+							description: null,
+							default_branch: 'main',
+							remote: 'https://acct.artifacts.cloudflare.net/git/default/skill-skill-1.git',
+							token: 'art_v1_create?expires=1760000000',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
+		},
+	)
+
+	const source = await ensureEntitySource({
+		db,
+		env: {
+			APP_DB: db,
+			CLOUDFLARE_ACCOUNT_ID: 'acct',
+			CLOUDFLARE_API_TOKEN: 'token-123',
+			CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+		} as Env,
+		userId: 'user-1',
+		entityKind: 'skill',
+		entityId: 'skill-1',
+		sourceRoot: '/',
+	})
+
+	expect(fetchMock).toHaveBeenCalledTimes(3)
+	expect(source.repo_id).toBe('skill-skill-1')
+	expect(source.bootstrapAccess).toEqual({
+		defaultBranch: 'main',
+		remote: 'https://acct.artifacts.cloudflare.net/git/default/skill-skill-1.git',
+		token: 'art_v1_create?expires=1760000000',
+		expiresAt: '2025-10-09T08:53:20.000Z',
+	})
 })

--- a/packages/worker/src/repo/source-service.ts
+++ b/packages/worker/src/repo/source-service.ts
@@ -2,6 +2,7 @@ import {
 	buildEntityRepoId,
 	getArtifactsBinding,
 	hasArtifactsAccess,
+	type ArtifactBootstrapAccess,
 	type ArtifactNamespaceBinding,
 } from './artifacts.ts'
 import {
@@ -10,6 +11,10 @@ import {
 	updateEntitySource,
 } from './entity-sources.ts'
 import { type EntityKind, type EntitySourceRow } from './types.ts'
+
+export type EnsuredEntitySource = EntitySourceRow & {
+	bootstrapAccess?: ArtifactBootstrapAccess | null
+}
 
 function buildEntitySourceRow(input: {
 	id?: string
@@ -55,7 +60,7 @@ export async function ensureEntitySource(input: {
 	manifestPath?: string
 	sourceRoot?: string
 	requirePersistence?: boolean
-}) {
+}): Promise<EnsuredEntitySource> {
 	const hasDbPrepare = hasAppDbBinding(input.db)
 	const hasArtifactsAccessResult = hasArtifactsAccess(input.env)
 	if (!hasDbPrepare || hasArtifactsAccessResult === false) {
@@ -92,9 +97,15 @@ export async function ensureEntitySource(input: {
 		manifestPath: input.manifestPath,
 		sourceRoot: input.sourceRoot,
 	})
-	await createArtifactsRepoIfMissing(input.env, row.repo_id)
+	const bootstrapAccess = await createArtifactsRepoIfMissing(
+		input.env,
+		row.repo_id,
+	)
 	await insertEntitySource(input.db, row)
-	return row
+	return {
+		...row,
+		bootstrapAccess,
+	}
 }
 
 function hasAppDbBinding(db: D1Database | null | undefined) {
@@ -119,9 +130,9 @@ export async function createArtifactsRepoIfMissing(
 	env: Env,
 	repoId: string,
 	binding: ArtifactNamespaceBinding = getArtifactsBinding(env),
-) {
+): Promise<ArtifactBootstrapAccess | null> {
 	const existing = await binding.get(repoId)
-	if (existing.status === 'ready') return existing.repo
+	if (existing.status === 'ready') return null
 	if (existing.status === 'importing' || existing.status === 'forking') {
 		throw new Error(
 			`Artifacts repo "${repoId}" is ${existing.status}. Retry after ${existing.retryAfter}s.`,
@@ -134,7 +145,12 @@ export async function createArtifactsRepoIfMissing(
 			`Artifacts repo "${created.name}" is ${getResult.status} after create.`,
 		)
 	}
-	return getResult.repo
+	return {
+		defaultBranch: created.defaultBranch,
+		remote: created.remote,
+		token: created.token,
+		expiresAt: created.expiresAt,
+	}
 }
 
 export async function setEntityPublishedCommit(input: {

--- a/packages/worker/src/repo/source-sync.node.test.ts
+++ b/packages/worker/src/repo/source-sync.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { type ArtifactBootstrapAccess } from './artifacts.ts'
 
 const mockModule = vi.hoisted(() => ({
 	getEntitySourceById: vi.fn(),
@@ -15,6 +16,13 @@ vi.mock('./repo-session-do.ts', () => ({
 }))
 
 const { syncArtifactSourceSnapshot } = await import('./source-sync.ts')
+
+const bootstrapAccess: ArtifactBootstrapAccess = {
+	defaultBranch: 'main',
+	remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+	token: 'art_v1_bootstrap?expires=1760000000',
+	expiresAt: '2026-10-09T08:53:20.000Z',
+}
 
 test('syncArtifactSourceSnapshot bootstraps unpublished sources directly into the source repo', async () => {
 	mockModule.getEntitySourceById.mockReset()
@@ -88,6 +96,7 @@ test('syncArtifactSourceSnapshot bootstraps unpublished sources directly into th
 				content: '<main>Hello</main>',
 			},
 		],
+		bootstrapAccess: null,
 	})
 	expect(sessionClient.openSession).not.toHaveBeenCalled()
 	expect(sessionClient.applyEdits).not.toHaveBeenCalled()
@@ -190,4 +199,75 @@ test('syncArtifactSourceSnapshot still uses repo sessions for already-published 
 		sessionId: expect.stringMatching(/^source-sync-source-1-/),
 		userId: 'user-1',
 	})
+})
+
+test('syncArtifactSourceSnapshot forwards bootstrap access for the first publish of a new source', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+
+	const sessionClient = {
+		bootstrapSource: vi.fn(async () => ({
+			sessionId: 'source-sync-source-1-session',
+			publishedCommit: 'commit-bootstrap-2',
+			message: 'Bootstrapped source source-1 in app-1.',
+		})),
+		openSession: vi.fn(),
+		applyEdits: vi.fn(),
+		publishSession: vi.fn(),
+		discardSession: vi.fn(async () => ({
+			ok: true as const,
+			sessionId: 'source-sync-source-1-session',
+			deleted: false,
+		})),
+	}
+
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'skill',
+		entity_id: 'skill-1',
+		repo_id: 'skill-1',
+		published_commit: null,
+		indexed_commit: null,
+		manifest_path: 'kody.json',
+		source_root: '/',
+		created_at: '2026-04-18T00:00:00.000Z',
+		updated_at: '2026-04-18T00:00:00.000Z',
+	})
+	mockModule.repoSessionRpc.mockReturnValue(sessionClient as never)
+
+	await syncArtifactSourceSnapshot({
+		env: {
+			APP_DB: {
+				prepare() {
+					return {} as D1PreparedStatement
+				},
+			},
+			REPO_SESSION: {},
+			CLOUDFLARE_ACCOUNT_ID: 'account-1',
+			CLOUDFLARE_API_TOKEN: 'token-1',
+		} as unknown as Env,
+		userId: 'user-1',
+		baseUrl: 'https://heykody.dev',
+		sourceId: 'source-1',
+		bootstrapAccess,
+		files: {
+			'kody.json': '{"version":1,"kind":"skill"}',
+		},
+	})
+
+	expect(sessionClient.bootstrapSource).toHaveBeenCalledWith({
+		sessionId: expect.stringMatching(/^source-sync-source-1-/),
+		sourceId: 'source-1',
+		userId: 'user-1',
+		edits: [
+			{
+				kind: 'write',
+				path: 'kody.json',
+				content: '{"version":1,"kind":"skill"}',
+			},
+		],
+		bootstrapAccess,
+	})
+	expect(sessionClient.openSession).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/repo/source-sync.node.test.ts
+++ b/packages/worker/src/repo/source-sync.node.test.ts
@@ -21,7 +21,7 @@ const bootstrapAccess: ArtifactBootstrapAccess = {
 	defaultBranch: 'main',
 	remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
 	token: 'art_v1_bootstrap?expires=1760000000',
-	expiresAt: '2026-10-09T08:53:20.000Z',
+	expiresAt: '2025-10-09T08:53:20.000Z',
 }
 
 test('syncArtifactSourceSnapshot bootstraps unpublished sources directly into the source repo', async () => {

--- a/packages/worker/src/repo/source-sync.node.test.ts
+++ b/packages/worker/src/repo/source-sync.node.test.ts
@@ -236,7 +236,7 @@ test('syncArtifactSourceSnapshot forwards bootstrap access for the first publish
 	})
 	mockModule.repoSessionRpc.mockReturnValue(sessionClient as never)
 
-	await syncArtifactSourceSnapshot({
+	const publishedCommit = await syncArtifactSourceSnapshot({
 		env: {
 			APP_DB: {
 				prepare() {
@@ -256,6 +256,7 @@ test('syncArtifactSourceSnapshot forwards bootstrap access for the first publish
 		},
 	})
 
+	expect(publishedCommit).toBe('commit-bootstrap-2')
 	expect(sessionClient.bootstrapSource).toHaveBeenCalledWith({
 		sessionId: expect.stringMatching(/^source-sync-source-1-/),
 		sourceId: 'source-1',

--- a/packages/worker/src/repo/source-sync.ts
+++ b/packages/worker/src/repo/source-sync.ts
@@ -1,7 +1,9 @@
-import { hasArtifactsAccess } from './artifacts.ts'
+import {
+	hasArtifactsAccess,
+	type ArtifactBootstrapAccess,
+} from './artifacts.ts'
 import { getEntitySourceById } from './entity-sources.ts'
 import { repoSessionRpc } from './repo-session-do.ts'
-import { type ArtifactBootstrapAccess } from './artifacts.ts'
 
 type SyncArtifactSourceInput = {
 	env: Env

--- a/packages/worker/src/repo/source-sync.ts
+++ b/packages/worker/src/repo/source-sync.ts
@@ -1,6 +1,7 @@
 import { hasArtifactsAccess } from './artifacts.ts'
 import { getEntitySourceById } from './entity-sources.ts'
 import { repoSessionRpc } from './repo-session-do.ts'
+import { type ArtifactBootstrapAccess } from './artifacts.ts'
 
 type SyncArtifactSourceInput = {
 	env: Env
@@ -8,6 +9,7 @@ type SyncArtifactSourceInput = {
 	baseUrl: string
 	sourceId: string | null
 	files: Record<string, string>
+	bootstrapAccess?: ArtifactBootstrapAccess | null
 }
 
 function canSyncArtifactSource(env: Env) {
@@ -46,6 +48,7 @@ export async function syncArtifactSourceSnapshot(
 				sourceId: source.id,
 				userId: input.userId,
 				edits,
+				bootstrapAccess: input.bootstrapAccess ?? null,
 			})
 			return bootstrapResult.publishedCommit
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve the initial Artifacts repo create credentials as bootstrap access when provisioning a new repo-backed source
- thread that bootstrap access through the unpublished-source sync path so the very first publish reuses the create response instead of minting a fresh token immediately
- add focused regression tests for source provisioning, unpublished-source sync, `meta_save_skill`, and immediate repo-backed `runSavedSkill` execution

## Testing
- `npm run test -- --run packages/worker/src/repo/source-service.node.test.ts packages/worker/src/repo/source-sync.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-save-skill.node.test.ts packages/worker/src/mcp/skills/run-saved-skill.node.test.ts`
- `npx vitest run --project node-unit --typecheck packages/worker/src/repo/source-service.node.test.ts packages/worker/src/repo/source-sync.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-save-skill.node.test.ts packages/worker/src/mcp/skills/run-saved-skill.node.test.ts`
- `npx oxlint packages/worker/src/jobs/service.ts packages/worker/src/mcp/capabilities/apps/ui-save-app.ts packages/worker/src/mcp/capabilities/meta/meta-save-skill.ts packages/worker/src/repo/artifacts.ts packages/worker/src/repo/repo-session-do.ts packages/worker/src/repo/repo-session-rpc.ts packages/worker/src/repo/source-backfill.ts packages/worker/src/repo/source-service.ts packages/worker/src/repo/source-sync.ts packages/worker/src/repo/source-service.node.test.ts packages/worker/src/repo/source-sync.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-save-skill.node.test.ts packages/worker/src/mcp/skills/run-saved-skill.node.test.ts`
- `npm run typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6ad50cc-0817-48e9-bb97-4d809b889ab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6ad50cc-0817-48e9-bb97-4d809b889ab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced credential management for artifact repository bootstrap operations, enabling streamlined initialization and improved synchronization during project setup.
  * Enhanced repository session handling to support pre-configured access credentials in bootstrap flows for faster repository configuration.

* **Tests**
  * Added comprehensive test coverage for skill publishing, execution workflows, and save operations.
  * Added validation tests for entity source creation and bootstrap access credential handling across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->