### PR TITLE
Fix preview environment cleanup token and naming

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -565,7 +565,7 @@ jobs:
           node tools/ci/preview-resources.ts cleanup --worker-name "$APP_WORKER_NAME"
 
       - name: 🏷️ Delete GitHub preview environment
-        if: always() && secrets.PREVIEW_ENVIRONMENT_GITHUB_TOKEN != ''
+        if: always()
         uses: actions/github-script@v8.0.0
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -573,7 +573,7 @@ jobs:
           INPUT_TARGET: ${{ inputs.target }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         with:
-          github-token: ${{ secrets.PREVIEW_ENVIRONMENT_GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const eventName = process.env.EVENT_NAME;
             let envName;

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -565,7 +565,7 @@ jobs:
           node tools/ci/preview-resources.ts cleanup --worker-name "$APP_WORKER_NAME"
 
       - name: 🏷️ Delete GitHub preview environment
-        if: always()
+        if: always() && secrets.PREVIEW_ENVIRONMENT_GITHUB_TOKEN != ''
         uses: actions/github-script@v8.0.0
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -573,7 +573,7 @@ jobs:
           INPUT_TARGET: ${{ inputs.target }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.PREVIEW_ENVIRONMENT_GITHUB_TOKEN }}
           script: |
             const eventName = process.env.EVENT_NAME;
             let envName;

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -54,8 +54,7 @@ jobs:
     name: 🔎 Deploy Preview Resources
     timeout-minutes: 4
     environment:
-      name:
-        preview-${{ github.event.pull_request.number || inputs.pr_number ||
+      name: preview-${{ github.event.pull_request.number || inputs.pr_number ||
         github.run_id }}
       url: ${{ steps.deploy_preview.outputs.url }}
     if: >-
@@ -143,8 +142,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ENV: preview
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
-        run:
-          node ./wrangler-env.ts d1 migrations apply APP_DB --remote --config
+        run: node ./wrangler-env.ts d1 migrations apply APP_DB --remote --config
           "$WRANGLER_CONFIG"
 
       - name: 🧪 Deploy preview mock Workers
@@ -344,8 +342,7 @@ jobs:
         if: steps.deploy_preview.outputs.url != ''
         env:
           PREVIEW_URL: ${{ steps.deploy_preview.outputs.url }}
-          PREVIEW_VERSION_URL:
-            '${{ steps.deploy_preview.outputs.version_preview_url }}'
+          PREVIEW_VERSION_URL: "${{ steps.deploy_preview.outputs.version_preview_url }}"
           WORKER_NAME: ${{ steps.deploy_preview.outputs.worker_name }}
           MOCK_SUMMARY: ${{ steps.deploy_mocks.outputs.mock_summary }}
           D1_DATABASE_NAME: ${{ steps.resources.outputs.d1_database_name }}
@@ -380,8 +377,7 @@ jobs:
         uses: actions/github-script@v8.0.0
         env:
           PREVIEW_URL: ${{ steps.deploy_preview.outputs.url }}
-          PREVIEW_VERSION_URL:
-            '${{ steps.deploy_preview.outputs.version_preview_url }}'
+          PREVIEW_VERSION_URL: "${{ steps.deploy_preview.outputs.version_preview_url }}"
           WORKER_NAME: ${{ steps.deploy_preview.outputs.worker_name }}
           MOCK_SUMMARY: ${{ steps.deploy_mocks.outputs.mock_comment_summary }}
           D1_DATABASE_NAME: ${{ steps.resources.outputs.d1_database_name }}
@@ -445,15 +441,15 @@ jobs:
     runs-on: ubuntu-latest
     name: 🧹 Cleanup Preview Resources
     timeout-minutes: 4
+    permissions:
+      contents: read
+      deployments: write
     if: >-
       (github.event_name == 'pull_request' &&
         github.event.action == 'closed' &&
         github.event.pull_request.head.repo.fork == false) ||
       (github.event_name == 'workflow_dispatch' &&
         inputs.action == 'cleanup')
-    env:
-      PREVIEW_ENVIRONMENT_GITHUB_TOKEN:
-        ${{ secrets.PREVIEW_ENVIRONMENT_GITHUB_TOKEN }}
     steps:
       - name: 📦 Checkout
         uses: actions/checkout@v6.0.2
@@ -568,16 +564,8 @@ jobs:
           set -euo pipefail
           node tools/ci/preview-resources.ts cleanup --worker-name "$APP_WORKER_NAME"
 
-      - name: ℹ️ Skip GitHub preview environment delete
-        if: >-
-          always() && env.PREVIEW_ENVIRONMENT_GITHUB_TOKEN == ''
-        run: >
-          echo "Skipping GitHub preview environment delete;
-          PREVIEW_ENVIRONMENT_GITHUB_TOKEN is not configured."
-
       - name: 🏷️ Delete GitHub preview environment
-        if: >-
-          always() && env.PREVIEW_ENVIRONMENT_GITHUB_TOKEN != ''
+        if: always()
         uses: actions/github-script@v8.0.0
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -585,7 +573,7 @@ jobs:
           INPUT_TARGET: ${{ inputs.target }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         with:
-          github-token: ${{ env.PREVIEW_ENVIRONMENT_GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const eventName = process.env.EVENT_NAME;
             let envName;

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -104,6 +104,10 @@ secrets from `packages/worker/.env`.
 
 Configure these GitHub Actions secrets and variables for workflows:
 
+- No dedicated GitHub secret is required for preview-environment cleanup. The
+  preview workflow deletes GitHub preview environments with the built-in
+  `GITHUB_TOKEN` and job-scoped `deployments: write` permission.
+
 - `CLOUDFLARE_API_TOKEN` (Workers deploy + D1 edit access on the correct
   account; also reused for remote AI and Cloudflare API workflows that run with
   account secrets + skills)
@@ -131,6 +135,10 @@ Configure these GitHub Actions secrets and variables for workflows:
 - **Repository variables** `SENTRY_ORG` and `SENTRY_PROJECT` (optional; Sentry
   organization and project **slugs** for source map upload — same values as in
   the Sentry wizard’s `--org` / `--project` flags)
+
+The preview cleanup job deletes the matching GitHub deployment environment with
+the built-in GitHub Actions token. No separate GitHub repository secret is
+required for that step.
 
 How to get/set each value:
 
@@ -215,3 +223,6 @@ Preview deploys for pull requests create a separate Worker per PR named
 `<app-name>-pr-<number>` (for kody: `kody-pr-123`) plus one Worker per mock
 service named `<app-name>-pr-<number>-mock-<service>`. The same
 `CLOUDFLARE_API_TOKEN` must be able to create/update and delete those Workers.
+The preview cleanup job also deletes the matching GitHub environment
+(`preview-<pr-number>`) with the workflow's built-in `GITHUB_TOKEN`, so no
+extra GitHub repository secret is needed for that step.

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -104,10 +104,6 @@ secrets from `packages/worker/.env`.
 
 Configure these GitHub Actions secrets and variables for workflows:
 
-- No dedicated GitHub secret is required for preview-environment cleanup. The
-  preview workflow deletes GitHub preview environments with the built-in
-  `GITHUB_TOKEN` and job-scoped `deployments: write` permission.
-
 - `CLOUDFLARE_API_TOKEN` (Workers deploy + D1 edit access on the correct
   account; also reused for remote AI and Cloudflare API workflows that run with
   account secrets + skills)
@@ -135,10 +131,6 @@ Configure these GitHub Actions secrets and variables for workflows:
 - **Repository variables** `SENTRY_ORG` and `SENTRY_PROJECT` (optional; Sentry
   organization and project **slugs** for source map upload — same values as in
   the Sentry wizard’s `--org` / `--project` flags)
-
-The preview cleanup job deletes the matching GitHub deployment environment with
-the built-in GitHub Actions token. No separate GitHub repository secret is
-required for that step.
 
 How to get/set each value:
 
@@ -223,6 +215,3 @@ Preview deploys for pull requests create a separate Worker per PR named
 `<app-name>-pr-<number>` (for kody: `kody-pr-123`) plus one Worker per mock
 service named `<app-name>-pr-<number>-mock-<service>`. The same
 `CLOUDFLARE_API_TOKEN` must be able to create/update and delete those Workers.
-The preview cleanup job also deletes the matching GitHub environment
-(`preview-<pr-number>`) with the workflow's built-in `GITHUB_TOKEN`, so no
-extra GitHub repository secret is needed for that step.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep the GitHub preview-environment delete step on a dedicated repository secret token after verifying the default workflow token fails against the environment delete API
- make the preview job environment name deterministic for manual branch previews instead of falling back to `github.run_id`
- reuse the cleanup job's resolved preview name when deleting the GitHub environment so branch-targeted cleanup matches the environment created during deploy
- remove the cleanup job's unused `deployments: write` permission

## Verification
- verified the current PR head workflow and checked the failed cleanup run log from run `24606236180`
- confirmed the failure was `403 Resource not accessible by integration` for `DELETE /repos/{owner}/{repo}/environments/{environment_name}` when using `github.token`, with `x-accepted-github-permissions: administration=write`
- confirmed the latest workflow parses as YAML with the local parser
- ran `npx prettier --check ".github/workflows/preview.yml"`

## Reviewer findings assessed
- The token warning was valid for the current PR head because the branch had reverted to `github.token`; I kept the dedicated secret token for environment deletion.
- The branch-preview environment naming warning was also valid; deploy and cleanup now resolve the same environment name deterministically.

Artifact:
- [Workflow cleanup failure log excerpt](https://cursor.com/artifacts/c/art-cd801d9e-1994-4a9e-8336-98a44326ba19)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d88b23d-3b4e-4577-a9c4-2bdc0811427c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d88b23d-3b4e-4577-a9c4-2bdc0811427c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with preview environment naming to ensure reliable deployment tracking.

* **Chores**
  * Improved GitHub Actions workflow configuration for more reliable cleanup and management of preview environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->