### PR TITLE
Fix repo-backed job TS6053 from repo-session snapshot paths

### DIFF
--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -10,6 +10,30 @@ import {
 	type PersistedJobCallerContext,
 } from './types.ts'
 
+vi.mock('@cloudflare/worker-bundler', () => ({
+	createFileSystemSnapshot: vi.fn(async (files: AsyncIterable<[string, string]>) => {
+		const snapshotFiles = new Map<string, string>()
+		for await (const [path, content] of files) {
+			snapshotFiles.set(path, content)
+		}
+		return {
+			read(path: string) {
+				return snapshotFiles.get(path) ?? null
+			},
+		}
+	}),
+}))
+
+vi.mock('@cloudflare/worker-bundler/typescript', () => ({
+	createTypescriptLanguageService: vi.fn(async () => ({
+		languageService: {
+			getSemanticDiagnostics: vi.fn((entryPoint: string) =>
+				entryPoint === 'src/job.ts' ? [] : [{ messageText: `missing ${entryPoint}` }],
+			),
+		},
+	})),
+}))
+
 function createDatabase() {
 	const tables = new Map<string, Array<Record<string, unknown>>>([
 		['secret_buckets', []],
@@ -778,6 +802,159 @@ test('executeJobOnce refreshes repo sessions when base commit moves', async () =
 		})
 		expect(sessionClient.readFile).toHaveBeenCalledWith({
 			sessionId: 'job-runtime-job-repo-1',
+			userId: 'user-123',
+			path: 'src/job.ts',
+		})
+		expect(executeSpy).toHaveBeenCalledTimes(1)
+	} finally {
+		repoSessionRpcSpy.mockRestore()
+		executeSpy.mockRestore()
+	}
+})
+
+test('executeJobOnce succeeds for repo-backed jobs with repo-session absolute paths and migrated entrypoints', async () => {
+	const env = {
+		APP_DB: createDatabase(),
+		LOADER: {} as WorkerLoader,
+	} as Env
+	const callerContext = createBaseCallerContext()
+	const job: JobRecord = {
+		version: 1,
+		id: 'job-repo-absolute-paths',
+		userId: callerContext.user.userId,
+		name: 'Repo-backed absolute path job',
+		code: null,
+		sourceId: 'source-absolute-paths',
+		publishedCommit: 'commit-absolute',
+		storageId: 'job:job-repo-absolute-paths',
+		schedule: {
+			type: 'once',
+			runAt: '2026-04-17T15:00:00Z',
+		},
+		timezone: 'UTC',
+		enabled: true,
+		killSwitchEnabled: false,
+		createdAt: '2026-04-16T00:00:00.000Z',
+		updatedAt: '2026-04-16T00:00:00.000Z',
+		nextRunAt: '2026-04-17T15:00:00.000Z',
+		runCount: 0,
+		successCount: 0,
+		errorCount: 0,
+		runHistory: [],
+	}
+
+	const sessionClient = {
+		openSession: vi.fn(async () => ({
+			id: 'job-runtime-job-repo-absolute-paths',
+			source_id: 'source-absolute-paths',
+			source_root: '/',
+			base_commit: 'commit-absolute',
+			session_repo_id: 'session-repo-absolute',
+			session_repo_name: 'session-repo-name',
+			session_repo_namespace: 'default',
+			conversation_id: null,
+			last_checkpoint_commit: null,
+			last_check_run_id: null,
+			last_check_tree_hash: null,
+			expires_at: null,
+			created_at: '2026-04-16T00:00:00.000Z',
+			updated_at: '2026-04-16T00:00:00.000Z',
+			published_commit: 'commit-absolute',
+			manifest_path: 'kody.json',
+			entity_type: 'job' as const,
+		})),
+		runChecks: vi.fn(async () => {
+			const { runRepoChecks } = await import('#worker/repo/checks.ts')
+			return runRepoChecks({
+				workspace: {
+					async readFile(path: string) {
+						const file = workspaceFiles.get(path)
+						return file ?? workspaceFiles.get(path.replace(/^\/+/, '')) ?? null
+					},
+					async glob() {
+						return Array.from(workspaceFiles.keys()).map((path) => ({
+							path,
+							type: 'file',
+						}))
+					},
+				},
+				manifestPath: '/session/kody.json',
+				sourceRoot: '/session/',
+			})
+		}),
+		readFile: vi.fn(async ({ path }: { path: string }) => ({
+			path,
+			content:
+				path === 'kody.json'
+					? JSON.stringify({
+							version: 1,
+							kind: 'job',
+							title: 'Repo absolute path job',
+							description: 'Runs from repo session files',
+							sourceRoot: '/',
+							entrypoint: '/src/job.ts',
+						})
+					: 'async () => ({ ok: true, normalized: true })',
+		})),
+		discardSession: vi.fn(async () => ({
+			ok: true as const,
+			sessionId: 'job-runtime-job-repo-absolute-paths',
+			deleted: true,
+		})),
+	}
+	const workspaceFiles = new Map<string, string>([
+		[
+			'/session/kody.json',
+			JSON.stringify({
+				version: 1,
+				kind: 'job',
+				title: 'Repo absolute path job',
+				description: 'Runs from repo session files',
+				sourceRoot: '/',
+				entrypoint: '/src/job.ts',
+			}),
+		],
+		[
+			'/session/src/job.ts',
+			'const run = async () => ({ ok: true })\nvoid run\n',
+		],
+		[
+			'/session/package.json',
+			JSON.stringify({
+				name: 'repo-absolute-path-job',
+				private: true,
+			}),
+		],
+	])
+
+	const repoSessionRpcSpy = vi
+		.spyOn(await import('#worker/repo/repo-session-do.ts'), 'repoSessionRpc')
+		.mockReturnValue(sessionClient as never)
+	const executeSpy = vi
+		.spyOn(
+			await import('#mcp/run-codemode-registry.ts'),
+			'runCodemodeWithRegistry',
+		)
+		.mockResolvedValue({
+			result: { ok: true, normalized: true },
+			logs: ['repo-backed codemode executed'],
+		})
+
+	try {
+		const outcome = await executeJobOnce({
+			env,
+			job,
+			callerContext,
+		})
+
+		expect(outcome.execution).toEqual({
+			ok: true,
+			result: { ok: true, normalized: true },
+			logs: ['repo-backed codemode executed'],
+		})
+		expect(sessionClient.runChecks).toHaveBeenCalledTimes(1)
+		expect(sessionClient.readFile).toHaveBeenCalledWith({
+			sessionId: 'job-runtime-job-repo-absolute-paths',
 			userId: 'user-123',
 			path: 'src/job.ts',
 		})

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -86,3 +86,74 @@ test('runRepoChecks normalizes leading slashes in manifest entrypoints', async (
 	expect(snapshot.read).toHaveBeenCalledWith('src/job.ts')
 	expect(getSemanticDiagnostics).toHaveBeenCalledWith('src/job.ts')
 })
+
+test('runRepoChecks strips repo-session workspace prefixes from snapshot paths', async () => {
+	mockModule.createFileSystemSnapshot.mockReset()
+	mockModule.createTypescriptLanguageService.mockReset()
+	const files = new Map<string, string>([
+		[
+			'/session/kody.json',
+			JSON.stringify({
+				version: 1,
+				kind: 'job',
+				title: 'Session-backed job',
+				description: 'Runs from a repo session workspace',
+				sourceRoot: '/',
+				entrypoint: '/src/job.ts',
+			}),
+		],
+		[
+			'/session/src/job.ts',
+			'const run = async () => ({ ok: true })\nvoid run\n',
+		],
+		[
+			'/session/package.json',
+			JSON.stringify({
+				name: 'session-backed-job',
+				private: true,
+			}),
+		],
+	])
+	let snapshotFiles = new Map<string, string>()
+	const snapshot = {
+		read: vi.fn((path: string) => snapshotFiles.get(path) ?? null),
+	}
+	const getSemanticDiagnostics = vi.fn(() => [])
+	mockModule.createFileSystemSnapshot.mockImplementation(async (input) => {
+		snapshotFiles = new Map<string, string>()
+		for await (const [path, content] of input as AsyncIterable<
+			readonly [string, string]
+		>) {
+			snapshotFiles.set(path, content)
+		}
+		return snapshot
+	})
+	mockModule.createTypescriptLanguageService.mockResolvedValue({
+		languageService: {
+			getSemanticDiagnostics,
+		},
+	})
+
+	const result = await runRepoChecks({
+		workspace: {
+			async readFile(path: string) {
+				return files.get(path) ?? null
+			},
+			async glob() {
+				return Array.from(files.keys()).map((path) => ({ path, type: 'file' }))
+			},
+		},
+		manifestPath: '/session/kody.json',
+		sourceRoot: '/session/',
+	})
+
+	expect(result.ok).toBe(true)
+	expect(Array.from(snapshotFiles.keys())).toEqual([
+		'kody.json',
+		'src/job.ts',
+		'package.json',
+	])
+	expect(snapshot.read).toHaveBeenCalledWith('src/job.ts')
+	expect(snapshot.read).not.toHaveBeenCalledWith('/src/job.ts')
+	expect(getSemanticDiagnostics).toHaveBeenCalledWith('src/job.ts')
+})

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -1,4 +1,8 @@
-import { getManifestEntrypointPath, parseRepoManifest } from './manifest.ts'
+import {
+	getManifestEntrypointPath,
+	normalizeRepoWorkspacePath,
+	parseRepoManifest,
+} from './manifest.ts'
 import { type RepoManifest } from './types.ts'
 
 export type RepoCheckKind =
@@ -28,7 +32,10 @@ async function* workspaceFilesForSnapshot(input: {
 	}
 	root: string
 }) {
-	const normalizedRoot = input.root.replace(/\/+$/, '')
+	const normalizedRoot = normalizeRepoWorkspacePath(input.root).replace(
+		/\/+$/,
+		'',
+	)
 	const pattern =
 		normalizedRoot === ''
 			? '**/*.{ts,tsx,js,jsx,json}'
@@ -38,9 +45,11 @@ async function* workspaceFilesForSnapshot(input: {
 		if (file.type !== 'file') continue
 		const content = await input.workspace.readFile(file.path)
 		if (content == null) continue
-		const relativePath = normalizedRoot
-			? file.path.slice(normalizedRoot.length + 1)
-			: file.path
+		const normalizedPath = normalizeRepoWorkspacePath(file.path)
+		const relativePath =
+			normalizedRoot && normalizedPath.startsWith(`${normalizedRoot}/`)
+				? normalizedPath.slice(normalizedRoot.length + 1)
+				: normalizedPath
 		yield [relativePath, content] as const
 	}
 }
@@ -97,7 +106,10 @@ export async function runRepoChecks(input: {
 		},
 	]
 
-	const sourceRoot = input.sourceRoot.replace(/^\/+/, '').replace(/\/+$/, '')
+	const sourceRoot = normalizeRepoWorkspacePath(input.sourceRoot).replace(
+		/\/+$/,
+		'',
+	)
 	const { createFileSystemSnapshot } =
 		await import('@cloudflare/worker-bundler')
 	const snapshot = await createFileSystemSnapshot(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix repo-session snapshot path normalization in `runRepoChecks` so migrated manifests with `"/src/job.ts"` and repo-session absolute file paths both resolve to `src/job.ts`
- add a repo-check regression for `/session/...` workspace files producing normalized snapshot keys
- add a job execution regression that exercises the `executeJobOnce -> runRepoChecks` path for migrated repo-backed jobs

## Context
Production still reports `TS6053: File '/src/job.ts' not found` for repo-backed jobs even after commit `413721cd9f371a79b6c6ddf2c45b925a5ddc5303` (`Fix migrated repo-backed job runtime entrypoint paths`).

That prior fix normalized manifest entrypoints at several callsites, but `runRepoChecks` could still build a worker-bundler/TypeScript snapshot containing `/src/job.ts` keys when repo-session files arrived as absolute `/session/...` paths. TypeScript was then asked for diagnostics on `src/job.ts`, causing the mismatch.

This PR normalizes the snapshot file keys so repo-session absolute paths and migrated manifest entrypoints converge on the same relative root path before bundler/typecheck work begins.

## Testing
- `npm run test -- --run packages/worker/src/repo/checks.node.test.ts packages/worker/src/jobs/service.node.test.ts`
- `npm run typecheck`

## Notes
- I attempted to inspect real production job records through the connected Kody MCP server, but execute/search calls for capabilities were unauthorized in this session, so validation here is via focused worker tests and typecheck.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5673d3e3-03d3-4bf0-9a7e-e0a9fec9c186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5673d3e3-03d3-4bf0-9a7e-e0a9fec9c186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

