### PR TITLE
Require admin token for preview environment cleanup

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -54,7 +54,8 @@ jobs:
     name: 🔎 Deploy Preview Resources
     timeout-minutes: 4
     environment:
-      name: preview-${{ github.event.pull_request.number || inputs.pr_number ||
+      name:
+        preview-${{ github.event.pull_request.number || inputs.pr_number ||
         github.run_id }}
       url: ${{ steps.deploy_preview.outputs.url }}
     if: >-
@@ -142,7 +143,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ENV: preview
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
-        run: node ./wrangler-env.ts d1 migrations apply APP_DB --remote --config
+        run:
+          node ./wrangler-env.ts d1 migrations apply APP_DB --remote --config
           "$WRANGLER_CONFIG"
 
       - name: 🧪 Deploy preview mock Workers
@@ -342,7 +344,8 @@ jobs:
         if: steps.deploy_preview.outputs.url != ''
         env:
           PREVIEW_URL: ${{ steps.deploy_preview.outputs.url }}
-          PREVIEW_VERSION_URL: "${{ steps.deploy_preview.outputs.version_preview_url }}"
+          PREVIEW_VERSION_URL:
+            '${{ steps.deploy_preview.outputs.version_preview_url }}'
           WORKER_NAME: ${{ steps.deploy_preview.outputs.worker_name }}
           MOCK_SUMMARY: ${{ steps.deploy_mocks.outputs.mock_summary }}
           D1_DATABASE_NAME: ${{ steps.resources.outputs.d1_database_name }}
@@ -377,7 +380,8 @@ jobs:
         uses: actions/github-script@v8.0.0
         env:
           PREVIEW_URL: ${{ steps.deploy_preview.outputs.url }}
-          PREVIEW_VERSION_URL: "${{ steps.deploy_preview.outputs.version_preview_url }}"
+          PREVIEW_VERSION_URL:
+            '${{ steps.deploy_preview.outputs.version_preview_url }}'
           WORKER_NAME: ${{ steps.deploy_preview.outputs.worker_name }}
           MOCK_SUMMARY: ${{ steps.deploy_mocks.outputs.mock_comment_summary }}
           D1_DATABASE_NAME: ${{ steps.resources.outputs.d1_database_name }}
@@ -572,10 +576,15 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           INPUT_TARGET: ${{ inputs.target }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          HAS_PREVIEW_ENVIRONMENT_ADMIN_TOKEN:
+            ${{ secrets.PREVIEW_ENVIRONMENT_ADMIN_TOKEN != '' && 'true' ||
+            'false' }}
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.PREVIEW_ENVIRONMENT_ADMIN_TOKEN }}
           script: |
             const eventName = process.env.EVENT_NAME;
+            const hasAdminToken =
+              process.env.HAS_PREVIEW_ENVIRONMENT_ADMIN_TOKEN === "true";
             let envName;
             if (eventName === "pull_request") {
               const n = process.env.PR_NUMBER;
@@ -603,6 +612,12 @@ jobs:
               return;
             }
 
+            if (!hasAdminToken) {
+              throw new Error(
+                "PREVIEW_ENVIRONMENT_ADMIN_TOKEN is required to delete GitHub preview environments. Configure it with repository administration write access.",
+              );
+            }
+
             const { owner, repo } = context.repo;
             try {
               await github.request(
@@ -618,6 +633,14 @@ jobs:
               if (e.status === 404) {
                 core.info(
                   `GitHub environment not found (already deleted): ${envName}`,
+                );
+              } else if (
+                e.status === 403 &&
+                e.response?.headers?.["x-accepted-github-permissions"] ===
+                  "administration=write"
+              ) {
+                throw new Error(
+                  `PREVIEW_ENVIRONMENT_ADMIN_TOKEN cannot delete ${envName}; it must allow repository administration write access.`,
                 );
               } else {
                 throw e;

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -36,10 +36,10 @@ Quick notes for getting a local kody environment running.
   local home connector; it sets `AI_MODE=mock`, `AI_MOCK_BASE_URL`, and
   `CLOUDFLARE_API_BASE_URL` + `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`
   to the local Cloudflare API mock Worker for the internal Cloudflare API client
-  and local email sending. Unless you already set
-  `CLOUDFLARE_EMAIL_FROM`, the launcher also defaults it to `reset@kody.dev`.
-  Set `SKIP_CLOUDFLARE_MOCK=1` to skip the local Cloudflare mock entirely. The
-  home connector receives the resolved worker origin via `WORKER_BASE_URL`. When
+  and local email sending. Unless you already set `CLOUDFLARE_EMAIL_FROM`, the
+  launcher also defaults it to `reset@kody.dev`. Set `SKIP_CLOUDFLARE_MOCK=1` to
+  skip the local Cloudflare mock entirely. The home connector receives the
+  resolved worker origin via `WORKER_BASE_URL`. When
   `HOME_CONNECTOR_SHARED_SECRET` is unset, the launcher generates one and passes
   it to both the worker and the connector so the outbound registration handshake
   succeeds in local development. The main worker and home connector stream logs
@@ -262,6 +262,12 @@ that workflow.
 
 Preview deploys also run `node tools/seed-test-data.ts` after deploy to create
 or verify the shared test account credentials listed above.
+
+Preview cleanup also deletes the matching GitHub environment
+(`preview-<pr-number>`). That API requires repository administration write
+access, so the repo must define a `PREVIEW_ENVIRONMENT_ADMIN_TOKEN` Actions
+secret with a token that has that permission. Cleanup intentionally fails when
+that secret is missing or under-scoped so permission regressions are visible.
 
 The production deploy workflow can also be started manually from GitHub Actions
 via **Run workflow** on `main`. The manual path still verifies that the selected


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- require preview cleanup to use `PREVIEW_ENVIRONMENT_ADMIN_TOKEN` instead of the default workflow token when deleting GitHub environments
- fail the cleanup job explicitly when the admin token is missing or lacks repository administration write access
- document the new preview cleanup secret requirement in contributor setup docs

## Testing
- ✅ `npx oxfmt .github/workflows/preview.yml docs/contributing/setup.md`
- ✅ `node -e "import fs from 'node:fs'; import { parseDocument } from 'yaml'; const doc = parseDocument(fs.readFileSync('.github/workflows/preview.yml','utf8')); if (doc.errors.length) throw doc.errors[0]; console.log('preview workflow YAML OK');"`
- ✅ `git commit -m "Require admin token for preview env cleanup"` (passed Husky pre-commit checks)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f9c5ead-1273-4ce7-b9a5-c4e8b174d748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f9c5ead-1273-4ce7-b9a5-c4e8b174d748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

