### PR TITLE
Fix preview workflow github-token fallback

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -580,7 +580,8 @@ jobs:
             ${{ secrets.PREVIEW_ENVIRONMENT_ADMIN_TOKEN != '' && 'true' ||
             'false' }}
         with:
-          github-token: ${{ secrets.PREVIEW_ENVIRONMENT_ADMIN_TOKEN }}
+          github-token:
+            ${{ secrets.PREVIEW_ENVIRONMENT_ADMIN_TOKEN || github.token }}
           script: |
             const eventName = process.env.EVENT_NAME;
             const hasAdminToken =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make the preview environment cleanup `github-token` fall back to `${{ github.token }}` when `PREVIEW_ENVIRONMENT_ADMIN_TOKEN` is unset
- preserve the existing script-level `hasAdminToken` guard so the workflow now reaches the intended actionable error message instead of failing during action initialization

## Testing
- `git diff --check`
- `python` YAML parse and expression spot-check for the updated `github-token` field
- verified against `actions/github-script@v8.0.0` source that `github-token` is required before the script body runs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b04c2e60-42ff-4841-b5c4-7e15f46be006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b04c2e60-42ff-4841-b5c4-7e15f46be006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced preview deployment process reliability through improved authentication fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->