### PR TITLE
Add opt-in repo job typecheck bypass policy

### DIFF
--- a/packages/worker/migrations/0025-jobs-repo-check-policy.sql
+++ b/packages/worker/migrations/0025-jobs-repo-check-policy.sql
@@ -1,0 +1,2 @@
+ALTER TABLE jobs
+ADD COLUMN repo_check_policy_json TEXT;

--- a/packages/worker/src/jobs/manager-do.ts
+++ b/packages/worker/src/jobs/manager-do.ts
@@ -3,6 +3,7 @@ import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { DurableObject } from 'cloudflare:workers'
 import { buildSentryOptions } from '#worker/sentry-options.ts'
 import { getNextRunnableJob, runDueJobsForUser, runJobNow } from './service.ts'
+import { type JobRepoCheckPolicy } from './types.ts'
 
 const userIdStorageKey = 'user-id'
 
@@ -50,6 +51,7 @@ class JobManagerBase extends DurableObject<Env> {
 		userId: string
 		jobId: string
 		callerContext?: McpCallerContext | null
+		repoCheckPolicyOverride?: JobRepoCheckPolicy | null
 	}) {
 		let result: Awaited<ReturnType<typeof runJobNow>> | undefined
 		let originalError: unknown
@@ -59,6 +61,7 @@ class JobManagerBase extends DurableObject<Env> {
 				userId: input.userId,
 				jobId: input.jobId,
 				callerContext: input.callerContext ?? null,
+				repoCheckPolicyOverride: input.repoCheckPolicyOverride,
 			})
 		} catch (error) {
 			originalError = error
@@ -95,6 +98,7 @@ export function jobManagerRpc(env: Env, userId: string) {
 			userId: string
 			jobId: string
 			callerContext?: McpCallerContext | null
+			repoCheckPolicyOverride?: JobRepoCheckPolicy | null
 		}) => Promise<Awaited<ReturnType<typeof runJobNow>>>
 	}
 }
@@ -110,10 +114,12 @@ export async function runJobNowViaManager(input: {
 	userId: string
 	jobId: string
 	callerContext?: McpCallerContext | null
+	repoCheckPolicyOverride?: JobRepoCheckPolicy | null
 }) {
 	return jobManagerRpc(input.env, input.userId).runNow({
 		userId: input.userId,
 		jobId: input.jobId,
 		callerContext: input.callerContext ?? null,
+		repoCheckPolicyOverride: input.repoCheckPolicyOverride,
 	})
 }

--- a/packages/worker/src/jobs/repo.ts
+++ b/packages/worker/src/jobs/repo.ts
@@ -8,6 +8,7 @@ type JobRowRecord = {
 	code: string | null
 	source_id: string | null
 	published_commit: string | null
+	repo_check_policy_json: string | null
 	storage_id: string | null
 	params_json: string | null
 	schedule_json: string
@@ -41,6 +42,9 @@ function serializeJob(job: JobRecord) {
 		code: job.code,
 		source_id: job.sourceId ?? null,
 		published_commit: job.publishedCommit ?? null,
+		repo_check_policy_json: job.repoCheckPolicy
+			? JSON.stringify(job.repoCheckPolicy)
+			: null,
 		storage_id: job.storageId,
 		params_json: job.params ? JSON.stringify(job.params) : null,
 		schedule_json: JSON.stringify(job.schedule),
@@ -84,6 +88,12 @@ function mapRow(row: Record<string, unknown>): JobRow {
 		sourceId: row['source_id'] == null ? null : String(row['source_id']),
 		publishedCommit:
 			row['published_commit'] == null ? null : String(row['published_commit']),
+		repoCheckPolicy: parseJson<JobRecord['repoCheckPolicy'] | undefined>(
+			row['repo_check_policy_json'] == null
+				? null
+				: String(row['repo_check_policy_json']),
+			undefined,
+		),
 		storageId,
 		params: parseJson<Record<string, unknown> | undefined>(
 			row['params_json'] == null ? null : String(row['params_json']),
@@ -126,6 +136,10 @@ function mapRow(row: Record<string, unknown>): JobRow {
 		code: record.code,
 		source_id: record.sourceId ?? null,
 		published_commit: record.publishedCommit ?? null,
+		repo_check_policy_json:
+			row['repo_check_policy_json'] == null
+				? null
+				: String(row['repo_check_policy_json']),
 		storage_id: record.storageId,
 		params_json: row['params_json'] == null ? null : String(row['params_json']),
 		schedule_json: String(row['schedule_json']),
@@ -165,11 +179,11 @@ export async function insertJobRow(input: {
 	await input.db
 		.prepare(
 			`INSERT INTO jobs (
-				id, user_id, name, code, source_id, published_commit, storage_id, params_json, schedule_json, timezone, enabled,
+				id, user_id, name, code, source_id, published_commit, repo_check_policy_json, storage_id, params_json, schedule_json, timezone, enabled,
 				kill_switch_enabled, caller_context_json, created_at, updated_at,
 				last_run_at, last_run_status, last_run_error, last_duration_ms,
 				next_run_at, run_count, success_count, error_count, run_history_json
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		)
 		.bind(
 			serialized.id,
@@ -178,6 +192,7 @@ export async function insertJobRow(input: {
 			serialized.code,
 			serialized.source_id,
 			serialized.published_commit,
+			serialized.repo_check_policy_json,
 			serialized.storage_id,
 			serialized.params_json,
 			serialized.schedule_json,
@@ -210,7 +225,7 @@ export async function updateJobRow(input: {
 	const result = await input.db
 		.prepare(
 			`UPDATE jobs SET
-				name = ?, code = ?, source_id = ?, published_commit = ?, storage_id = ?, params_json = ?, schedule_json = ?, timezone = ?,
+				name = ?, code = ?, source_id = ?, published_commit = ?, repo_check_policy_json = ?, storage_id = ?, params_json = ?, schedule_json = ?, timezone = ?,
 				enabled = ?, kill_switch_enabled = ?, caller_context_json = ?, updated_at = ?,
 				last_run_at = ?, last_run_status = ?, last_run_error = ?, last_duration_ms = ?,
 				next_run_at = ?, run_count = ?, success_count = ?, error_count = ?, run_history_json = ?
@@ -221,6 +236,7 @@ export async function updateJobRow(input: {
 			serialized.code,
 			serialized.source_id,
 			serialized.published_commit,
+			serialized.repo_check_policy_json,
 			serialized.storage_id,
 			serialized.params_json,
 			serialized.schedule_json,

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -1049,6 +1049,131 @@ test('executeJobOnce bypasses typecheck-only failures when the stored repo polic
 	}
 })
 
+test('executeJobOnce preserves bypass audit logs when execution fails after a typecheck-only bypass', async () => {
+	const env = {
+		APP_DB: createDatabase(),
+		LOADER: {} as WorkerLoader,
+	} as Env
+	const callerContext = createBaseCallerContext()
+	const job: JobRecord = {
+		version: 1,
+		id: 'job-repo-typecheck-bypass-failure',
+		userId: callerContext.user.userId,
+		name: 'Repo-backed bypass failure job',
+		code: null,
+		sourceId: 'source-bypass-failure',
+		publishedCommit: 'commit-bypass-failure',
+		repoCheckPolicy: {
+			allowTypecheckFailures: true,
+		},
+		storageId: 'job:job-repo-typecheck-bypass-failure',
+		schedule: {
+			type: 'once',
+			runAt: '2026-04-17T15:00:00Z',
+		},
+		timezone: 'UTC',
+		enabled: true,
+		killSwitchEnabled: false,
+		createdAt: '2026-04-16T00:00:00.000Z',
+		updatedAt: '2026-04-16T00:00:00.000Z',
+		nextRunAt: '2026-04-17T15:00:00.000Z',
+		runCount: 0,
+		successCount: 0,
+		errorCount: 0,
+		runHistory: [],
+	}
+	const sessionClient = {
+		openSession: vi.fn(async () => ({
+			id: 'job-runtime-job-repo-typecheck-bypass-failure',
+			source_id: 'source-bypass-failure',
+			source_root: '/',
+			base_commit: 'commit-bypass-failure',
+			session_repo_id: 'session-repo-bypass-failure',
+			session_repo_name: 'session-repo-name',
+			session_repo_namespace: 'default',
+			conversation_id: null,
+			last_checkpoint_commit: null,
+			last_check_run_id: null,
+			last_check_tree_hash: null,
+			expires_at: null,
+			created_at: '2026-04-16T00:00:00.000Z',
+			updated_at: '2026-04-16T00:00:00.000Z',
+			published_commit: 'commit-bypass-failure',
+			manifest_path: 'kody.json',
+			entity_type: 'job' as const,
+		})),
+		runChecks: vi.fn(async () => ({
+			ok: false,
+			results: [
+				{
+					kind: 'typecheck' as const,
+					ok: false,
+					message: "src/job.ts:1:28 Cannot find name 'codemode'.",
+				},
+			],
+			manifest: {
+				version: 1,
+				kind: 'job' as const,
+				title: 'Repo-backed bypass failure job',
+				description: 'Runs from repo',
+				entrypoint: 'src/job.ts',
+			},
+			runId: 'check-run-bypass-failure',
+			treeHash: 'tree-hash-bypass-failure',
+			checkedAt: '2026-04-16T00:00:00.000Z',
+		})),
+		readFile: vi.fn(async ({ path }: { path: string }) => ({
+			path,
+			content:
+				path === 'kody.json'
+					? JSON.stringify({
+							version: 1,
+							kind: 'job',
+							title: 'Repo-backed bypass failure job',
+							description: 'Runs from repo',
+							entrypoint: 'src/job.ts',
+						})
+					: 'async () => ({ ok: true, bypassed: true })',
+		})),
+		discardSession: vi.fn(),
+	}
+
+	const repoSessionRpcSpy = vi
+		.spyOn(await import('#worker/repo/repo-session-do.ts'), 'repoSessionRpc')
+		.mockReturnValue(sessionClient as never)
+	const executeSpy = vi.spyOn(
+		await import('#mcp/run-codemode-registry.ts'),
+		'runCodemodeWithRegistry',
+	)
+	const formatJobErrorSpy = vi.spyOn(
+		await import('./schedule.ts'),
+		'formatJobError',
+	)
+
+	try {
+		executeSpy.mockRejectedValueOnce(new Error('Executor import failed'))
+
+		const outcome = await executeJobOnce({
+			env,
+			job,
+			callerContext,
+		})
+
+		expect(outcome.execution).toEqual({
+			ok: false,
+			error: 'Executor import failed',
+			logs: [
+				'Bypassed repo typecheck-only check failures for job "job-repo-typecheck-bypass-failure" (source "source-bypass-failure", check run check-run-bypass-failure).',
+			],
+		})
+		expect(formatJobErrorSpy).toHaveBeenCalled()
+	} finally {
+		repoSessionRpcSpy.mockRestore()
+		executeSpy.mockRestore()
+		formatJobErrorSpy.mockRestore()
+	}
+})
+
 test('executeJobOnce succeeds for repo-backed jobs with repo-session absolute paths and migrated entrypoints', async () => {
 	const env = {
 		APP_DB: createDatabase(),
@@ -1648,3 +1773,4 @@ test('runJobNow can use a one-off repo check policy override without changing th
 		executeSpy.mockRestore()
 	}
 })
+

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -11,24 +11,28 @@ import {
 } from './types.ts'
 
 vi.mock('@cloudflare/worker-bundler', () => ({
-	createFileSystemSnapshot: vi.fn(async (files: AsyncIterable<[string, string]>) => {
-		const snapshotFiles = new Map<string, string>()
-		for await (const [path, content] of files) {
-			snapshotFiles.set(path, content)
-		}
-		return {
-			read(path: string) {
-				return snapshotFiles.get(path) ?? null
-			},
-		}
-	}),
+	createFileSystemSnapshot: vi.fn(
+		async (files: AsyncIterable<[string, string]>) => {
+			const snapshotFiles = new Map<string, string>()
+			for await (const [path, content] of files) {
+				snapshotFiles.set(path, content)
+			}
+			return {
+				read(path: string) {
+					return snapshotFiles.get(path) ?? null
+				},
+			}
+		},
+	),
 }))
 
 vi.mock('@cloudflare/worker-bundler/typescript', () => ({
 	createTypescriptLanguageService: vi.fn(async () => ({
 		languageService: {
 			getSemanticDiagnostics: vi.fn((entryPoint: string) =>
-				entryPoint === 'src/job.ts' ? [] : [{ messageText: `missing ${entryPoint}` }],
+				entryPoint === 'src/job.ts'
+					? []
+					: [{ messageText: `missing ${entryPoint}` }],
 			),
 		},
 	})),
@@ -320,24 +324,25 @@ function createDatabase() {
 									code: params[3],
 									source_id: params[4],
 									published_commit: params[5],
-									storage_id: params[6],
-									params_json: params[7],
-									schedule_json: params[8],
-									timezone: params[9],
-									enabled: params[10],
-									kill_switch_enabled: params[11],
-									caller_context_json: params[12],
-									created_at: params[13],
-									updated_at: params[14],
-									last_run_at: params[15],
-									last_run_status: params[16],
-									last_run_error: params[17],
-									last_duration_ms: params[18],
-									next_run_at: params[19],
-									run_count: params[20],
-									success_count: params[21],
-									error_count: params[22],
-									run_history_json: params[23],
+									repo_check_policy_json: params[6],
+									storage_id: params[7],
+									params_json: params[8],
+									schedule_json: params[9],
+									timezone: params[10],
+									enabled: params[11],
+									kill_switch_enabled: params[12],
+									caller_context_json: params[13],
+									created_at: params[14],
+									updated_at: params[15],
+									last_run_at: params[16],
+									last_run_status: params[17],
+									last_run_error: params[18],
+									last_duration_ms: params[19],
+									next_run_at: params[20],
+									run_count: params[21],
+									success_count: params[22],
+									error_count: params[23],
+									run_history_json: params[24],
 								}
 								upsert(
 									'jobs',
@@ -350,36 +355,37 @@ function createDatabase() {
 							}
 							if (query.startsWith('UPDATE jobs SET')) {
 								const row = {
-									id: params[21],
-									user_id: params[22],
+									id: params[22],
+									user_id: params[23],
 									name: params[0],
 									code: params[1],
 									source_id: params[2],
 									published_commit: params[3],
-									storage_id: params[4],
-									params_json: params[5],
-									schedule_json: params[6],
-									timezone: params[7],
-									enabled: params[8],
-									kill_switch_enabled: params[9],
-									caller_context_json: params[10],
-									updated_at: params[11],
-									last_run_at: params[12],
-									last_run_status: params[13],
-									last_run_error: params[14],
-									last_duration_ms: params[15],
-									next_run_at: params[16],
-									run_count: params[17],
-									success_count: params[18],
-									error_count: params[19],
-									run_history_json: params[20],
+									repo_check_policy_json: params[4],
+									storage_id: params[5],
+									params_json: params[6],
+									schedule_json: params[7],
+									timezone: params[8],
+									enabled: params[9],
+									kill_switch_enabled: params[10],
+									caller_context_json: params[11],
+									updated_at: params[12],
+									last_run_at: params[13],
+									last_run_status: params[14],
+									last_run_error: params[15],
+									last_duration_ms: params[16],
+									next_run_at: params[17],
+									run_count: params[18],
+									success_count: params[19],
+									error_count: params[20],
+									run_history_json: params[21],
 									created_at:
 										selectOne(
 											'jobs',
 											(existing) =>
-												existing['id'] === params[21] &&
-												existing['user_id'] === params[22],
-										)?.['created_at'] ?? params[11],
+												existing['id'] === params[22] &&
+												existing['user_id'] === params[23],
+										)?.['created_at'] ?? params[12],
 								}
 								upsert(
 									'jobs',
@@ -802,6 +808,237 @@ test('executeJobOnce refreshes repo sessions when base commit moves', async () =
 		})
 		expect(sessionClient.readFile).toHaveBeenCalledWith({
 			sessionId: 'job-runtime-job-repo-1',
+			userId: 'user-123',
+			path: 'src/job.ts',
+		})
+		expect(executeSpy).toHaveBeenCalledTimes(1)
+	} finally {
+		repoSessionRpcSpy.mockRestore()
+		executeSpy.mockRestore()
+	}
+})
+
+test('executeJobOnce blocks repo-backed jobs on typecheck failures by default', async () => {
+	const env = {
+		APP_DB: createDatabase(),
+		LOADER: {} as WorkerLoader,
+	} as Env
+	const callerContext = createBaseCallerContext()
+	const job: JobRecord = {
+		version: 1,
+		id: 'job-repo-typecheck-strict',
+		userId: callerContext.user.userId,
+		name: 'Repo-backed strict typecheck job',
+		code: null,
+		sourceId: 'source-strict',
+		publishedCommit: 'commit-strict',
+		storageId: 'job:job-repo-typecheck-strict',
+		schedule: {
+			type: 'once',
+			runAt: '2026-04-17T15:00:00Z',
+		},
+		timezone: 'UTC',
+		enabled: true,
+		killSwitchEnabled: false,
+		createdAt: '2026-04-16T00:00:00.000Z',
+		updatedAt: '2026-04-16T00:00:00.000Z',
+		nextRunAt: '2026-04-17T15:00:00.000Z',
+		runCount: 0,
+		successCount: 0,
+		errorCount: 0,
+		runHistory: [],
+	}
+	const sessionClient = {
+		openSession: vi.fn(async () => ({
+			id: 'job-runtime-job-repo-typecheck-strict',
+			source_id: 'source-strict',
+			source_root: '/',
+			base_commit: 'commit-strict',
+			session_repo_id: 'session-repo-strict',
+			session_repo_name: 'session-repo-name',
+			session_repo_namespace: 'default',
+			conversation_id: null,
+			last_checkpoint_commit: null,
+			last_check_run_id: null,
+			last_check_tree_hash: null,
+			expires_at: null,
+			created_at: '2026-04-16T00:00:00.000Z',
+			updated_at: '2026-04-16T00:00:00.000Z',
+			published_commit: 'commit-strict',
+			manifest_path: 'kody.json',
+			entity_type: 'job' as const,
+		})),
+		runChecks: vi.fn(async () => ({
+			ok: false,
+			results: [
+				{
+					kind: 'typecheck' as const,
+					ok: false,
+					message: "src/job.ts:1:28 Cannot find name 'codemode'.",
+				},
+			],
+			manifest: {
+				version: 1,
+				kind: 'job' as const,
+				title: 'Repo-backed strict typecheck job',
+				description: 'Runs from repo',
+				entrypoint: 'src/job.ts',
+			},
+			runId: 'check-run-strict',
+			treeHash: 'tree-hash-strict',
+			checkedAt: '2026-04-16T00:00:00.000Z',
+		})),
+		readFile: vi.fn(),
+		discardSession: vi.fn(),
+	}
+
+	const repoSessionRpcSpy = vi
+		.spyOn(await import('#worker/repo/repo-session-do.ts'), 'repoSessionRpc')
+		.mockReturnValue(sessionClient as never)
+	const executeSpy = vi.spyOn(
+		await import('#mcp/run-codemode-registry.ts'),
+		'runCodemodeWithRegistry',
+	)
+
+	try {
+		const outcome = await executeJobOnce({
+			env,
+			job,
+			callerContext,
+		})
+
+		expect(outcome.execution).toEqual({
+			ok: false,
+			error: "src/job.ts:1:28 Cannot find name 'codemode'.",
+			logs: [],
+		})
+		expect(sessionClient.readFile).not.toHaveBeenCalled()
+		expect(executeSpy).not.toHaveBeenCalled()
+	} finally {
+		repoSessionRpcSpy.mockRestore()
+		executeSpy.mockRestore()
+	}
+})
+
+test('executeJobOnce bypasses typecheck-only failures when the stored repo policy allows it', async () => {
+	const env = {
+		APP_DB: createDatabase(),
+		LOADER: {} as WorkerLoader,
+	} as Env
+	const callerContext = createBaseCallerContext()
+	const job: JobRecord = {
+		version: 1,
+		id: 'job-repo-typecheck-bypass',
+		userId: callerContext.user.userId,
+		name: 'Repo-backed bypass typecheck job',
+		code: null,
+		sourceId: 'source-bypass',
+		publishedCommit: 'commit-bypass',
+		repoCheckPolicy: {
+			allowTypecheckFailures: true,
+		},
+		storageId: 'job:job-repo-typecheck-bypass',
+		schedule: {
+			type: 'once',
+			runAt: '2026-04-17T15:00:00Z',
+		},
+		timezone: 'UTC',
+		enabled: true,
+		killSwitchEnabled: false,
+		createdAt: '2026-04-16T00:00:00.000Z',
+		updatedAt: '2026-04-16T00:00:00.000Z',
+		nextRunAt: '2026-04-17T15:00:00.000Z',
+		runCount: 0,
+		successCount: 0,
+		errorCount: 0,
+		runHistory: [],
+	}
+	const sessionClient = {
+		openSession: vi.fn(async () => ({
+			id: 'job-runtime-job-repo-typecheck-bypass',
+			source_id: 'source-bypass',
+			source_root: '/',
+			base_commit: 'commit-bypass',
+			session_repo_id: 'session-repo-bypass',
+			session_repo_name: 'session-repo-name',
+			session_repo_namespace: 'default',
+			conversation_id: null,
+			last_checkpoint_commit: null,
+			last_check_run_id: null,
+			last_check_tree_hash: null,
+			expires_at: null,
+			created_at: '2026-04-16T00:00:00.000Z',
+			updated_at: '2026-04-16T00:00:00.000Z',
+			published_commit: 'commit-bypass',
+			manifest_path: 'kody.json',
+			entity_type: 'job' as const,
+		})),
+		runChecks: vi.fn(async () => ({
+			ok: false,
+			results: [
+				{
+					kind: 'typecheck' as const,
+					ok: false,
+					message: "src/job.ts:1:28 Cannot find name 'codemode'.",
+				},
+			],
+			manifest: {
+				version: 1,
+				kind: 'job' as const,
+				title: 'Repo-backed bypass typecheck job',
+				description: 'Runs from repo',
+				entrypoint: 'src/job.ts',
+			},
+			runId: 'check-run-bypass',
+			treeHash: 'tree-hash-bypass',
+			checkedAt: '2026-04-16T00:00:00.000Z',
+		})),
+		readFile: vi.fn(async ({ path }: { path: string }) => ({
+			path,
+			content:
+				path === 'kody.json'
+					? JSON.stringify({
+							version: 1,
+							kind: 'job',
+							title: 'Repo-backed bypass typecheck job',
+							description: 'Runs from repo',
+							entrypoint: 'src/job.ts',
+						})
+					: 'async () => ({ ok: true, bypassed: true })',
+		})),
+		discardSession: vi.fn(),
+	}
+
+	const repoSessionRpcSpy = vi
+		.spyOn(await import('#worker/repo/repo-session-do.ts'), 'repoSessionRpc')
+		.mockReturnValue(sessionClient as never)
+	const executeSpy = vi
+		.spyOn(
+			await import('#mcp/run-codemode-registry.ts'),
+			'runCodemodeWithRegistry',
+		)
+		.mockResolvedValue({
+			result: { ok: true, bypassed: true },
+			logs: ['repo-backed codemode executed'],
+		})
+
+	try {
+		const outcome = await executeJobOnce({
+			env,
+			job,
+			callerContext,
+		})
+
+		expect(outcome.execution).toEqual({
+			ok: true,
+			result: { ok: true, bypassed: true },
+			logs: [
+				'Bypassed repo typecheck-only check failures for job "job-repo-typecheck-bypass" (source "source-bypass", check run check-run-bypass).',
+				'repo-backed codemode executed',
+			],
+		})
+		expect(sessionClient.readFile).toHaveBeenCalledWith({
+			sessionId: 'job-runtime-job-repo-typecheck-bypass',
 			userId: 'user-123',
 			path: 'src/job.ts',
 		})
@@ -1287,6 +1524,127 @@ test('runJobNow deletes vectors for once jobs', async () => {
 		).getJobRowById(db, callerContext.user.userId, jobView.id)
 		expect(row).toBeNull()
 	} finally {
+		executeSpy.mockRestore()
+	}
+})
+
+test('runJobNow can use a one-off repo check policy override without changing the stored job', async () => {
+	const db = createDatabase()
+	const env = {
+		APP_DB: db,
+		LOADER: {} as WorkerLoader,
+	} as Env
+	const callerContext = createBaseCallerContext()
+	const jobView = await createJob({
+		env,
+		callerContext,
+		body: {
+			name: 'Repo-backed run-now override',
+			code: null,
+			sourceId: 'source-run-now-override',
+			publishedCommit: 'commit-run-now-override',
+			schedule: {
+				type: 'interval',
+				every: '15m',
+			},
+		},
+	})
+
+	const sessionClient = {
+		openSession: vi.fn(async () => ({
+			id: `job-runtime-${jobView.id}`,
+			source_id: 'source-run-now-override',
+			source_root: '/',
+			base_commit: 'commit-run-now-override',
+			session_repo_id: 'session-repo-run-now-override',
+			session_repo_name: 'session-repo-name',
+			session_repo_namespace: 'default',
+			conversation_id: null,
+			last_checkpoint_commit: null,
+			last_check_run_id: null,
+			last_check_tree_hash: null,
+			expires_at: null,
+			created_at: '2026-04-16T00:00:00.000Z',
+			updated_at: '2026-04-16T00:00:00.000Z',
+			published_commit: 'commit-run-now-override',
+			manifest_path: 'kody.json',
+			entity_type: 'job' as const,
+		})),
+		runChecks: vi.fn(async () => ({
+			ok: false,
+			results: [
+				{
+					kind: 'typecheck' as const,
+					ok: false,
+					message: "src/job.ts:1:28 Cannot find name 'codemode'.",
+				},
+			],
+			manifest: {
+				version: 1,
+				kind: 'job' as const,
+				title: 'Repo-backed run-now override',
+				description: 'Runs from repo',
+				entrypoint: 'src/job.ts',
+			},
+			runId: 'check-run-run-now-override',
+			treeHash: 'tree-hash-run-now-override',
+			checkedAt: '2026-04-16T00:00:00.000Z',
+		})),
+		readFile: vi.fn(async ({ path }: { path: string }) => ({
+			path,
+			content:
+				path === 'kody.json'
+					? JSON.stringify({
+							version: 1,
+							kind: 'job',
+							title: 'Repo-backed run-now override',
+							description: 'Runs from repo',
+							entrypoint: 'src/job.ts',
+						})
+					: 'async () => ({ ok: true, override: true })',
+		})),
+		discardSession: vi.fn(),
+	}
+
+	const repoSessionRpcSpy = vi
+		.spyOn(await import('#worker/repo/repo-session-do.ts'), 'repoSessionRpc')
+		.mockReturnValue(sessionClient as never)
+	const executeSpy = vi
+		.spyOn(
+			await import('#mcp/run-codemode-registry.ts'),
+			'runCodemodeWithRegistry',
+		)
+		.mockResolvedValue({
+			result: { ok: true, override: true },
+			logs: ['repo-backed codemode executed'],
+		})
+
+	try {
+		const result = await runJobNow({
+			env,
+			userId: callerContext.user.userId,
+			jobId: jobView.id,
+			callerContext,
+			repoCheckPolicyOverride: {
+				allowTypecheckFailures: true,
+			},
+		})
+
+		expect(result.execution).toEqual({
+			ok: true,
+			result: { ok: true, override: true },
+			logs: [
+				`Bypassed repo typecheck-only check failures for job "${jobView.id}" (source "source-run-now-override", check run check-run-run-now-override).`,
+				'repo-backed codemode executed',
+			],
+		})
+		const row = await (
+			await import('./repo.ts')
+		).getJobRowById(db, callerContext.user.userId, jobView.id)
+		expect(row?.record.repoCheckPolicy).toBeUndefined()
+		expect(executeSpy).toHaveBeenCalledTimes(1)
+	} finally {
+		repoSessionRpcSpy.mockRestore()
 		executeSpy.mockRestore()
 	}
 })

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -590,7 +590,7 @@ async function runRepoBackedJob(input: {
 		return {
 			error: `Job manifest "${manifestPath}" was not found in repo session.`,
 			result: null,
-			logs: [],
+			logs: gate.logs,
 		}
 	}
 	let manifest: ReturnType<typeof parseRepoManifest>
@@ -603,14 +603,14 @@ async function runRepoBackedJob(input: {
 		return {
 			error: error instanceof Error ? error.message : String(error),
 			result: null,
-			logs: [],
+			logs: gate.logs,
 		}
 	}
 	if (manifest.kind !== 'job') {
 		return {
 			error: `Repo source "${input.job.sourceId}" is not a job manifest.`,
 			result: null,
-			logs: [],
+			logs: gate.logs,
 		}
 	}
 	const moduleFile = await sessionClient.readFile({
@@ -622,7 +622,7 @@ async function runRepoBackedJob(input: {
 		return {
 			error: `Job entrypoint "${manifest.entrypoint}" was not found in repo session.`,
 			result: null,
-			logs: [],
+			logs: gate.logs,
 		}
 	}
 	if (hasModuleStyleCodemodeEntrypoint(moduleFile.content)) {
@@ -630,7 +630,7 @@ async function runRepoBackedJob(input: {
 			error:
 				'Repo-backed job entrypoints must be execute-compatible async function snippets, not ESM/CommonJS modules.',
 			result: null,
-			logs: [],
+			logs: gate.logs,
 		}
 	}
 	const { runCodemodeWithRegistry } =

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -196,9 +196,11 @@ function resolveUpdatedShape(input: {
 			? input.existing.publishedCommit
 			: input.body.publishedCommit
 	const nextRepoCheckPolicy =
-		input.body.repoCheckPolicy === undefined
-			? input.existing.repoCheckPolicy
-			: normalizeJobRepoCheckPolicy(input.body.repoCheckPolicy)
+		nextSourceId == null
+			? undefined
+			: input.body.repoCheckPolicy === undefined
+				? input.existing.repoCheckPolicy
+				: normalizeJobRepoCheckPolicy(input.body.repoCheckPolicy)
 	if (!nextCode && !nextSourceId) {
 		throw new Error('Jobs require either code or sourceId.')
 	}
@@ -580,6 +582,7 @@ async function runRepoBackedJob(input: {
 			logs: gate.logs,
 		}
 	}
+	const bypassLogs = [...gate.logs]
 	const manifestPath = session.manifest_path?.replace(/^\/+/, '') || 'kody.json'
 	const entrypoint = await sessionClient.readFile({
 		sessionId: session.id,
@@ -590,7 +593,7 @@ async function runRepoBackedJob(input: {
 		return {
 			error: `Job manifest "${manifestPath}" was not found in repo session.`,
 			result: null,
-			logs: gate.logs,
+			logs: bypassLogs,
 		}
 	}
 	let manifest: ReturnType<typeof parseRepoManifest>
@@ -603,14 +606,14 @@ async function runRepoBackedJob(input: {
 		return {
 			error: error instanceof Error ? error.message : String(error),
 			result: null,
-			logs: gate.logs,
+			logs: bypassLogs,
 		}
 	}
 	if (manifest.kind !== 'job') {
 		return {
 			error: `Repo source "${input.job.sourceId}" is not a job manifest.`,
 			result: null,
-			logs: gate.logs,
+			logs: bypassLogs,
 		}
 	}
 	const moduleFile = await sessionClient.readFile({
@@ -622,7 +625,7 @@ async function runRepoBackedJob(input: {
 		return {
 			error: `Job entrypoint "${manifest.entrypoint}" was not found in repo session.`,
 			result: null,
-			logs: gate.logs,
+			logs: bypassLogs,
 		}
 	}
 	if (hasModuleStyleCodemodeEntrypoint(moduleFile.content)) {
@@ -630,42 +633,50 @@ async function runRepoBackedJob(input: {
 			error:
 				'Repo-backed job entrypoints must be execute-compatible async function snippets, not ESM/CommonJS modules.',
 			result: null,
-			logs: gate.logs,
+			logs: bypassLogs,
 		}
 	}
-	const { runCodemodeWithRegistry } =
-		await import('#mcp/run-codemode-registry.ts')
-	const executionResult = await runCodemodeWithRegistry(
-		input.env,
-		{
-			...input.callerContext,
-			repoContext: {
-				sourceId: session.source_id,
-				repoId: null,
-				sessionId: session.id,
-				sessionRepoId: session.session_repo_id,
-				baseCommit: session.base_commit,
-				manifestPath: session.manifest_path,
-				sourceRoot: session.source_root,
-				publishedCommit: session.published_commit,
-				entityKind: session.entity_type,
-				entityId: input.job.id,
+	try {
+		const { runCodemodeWithRegistry } =
+			await import('#mcp/run-codemode-registry.ts')
+		const executionResult = await runCodemodeWithRegistry(
+			input.env,
+			{
+				...input.callerContext,
+				repoContext: {
+					sourceId: session.source_id,
+					repoId: null,
+					sessionId: session.id,
+					sessionRepoId: session.session_repo_id,
+					baseCommit: session.base_commit,
+					manifestPath: session.manifest_path,
+					sourceRoot: session.source_root,
+					publishedCommit: session.published_commit,
+					entityKind: session.entity_type,
+					entityId: input.job.id,
+				},
 			},
-		},
-		moduleFile.content,
-		input.job.params,
-		{
-			executorExports: workerExports,
-			storageTools: {
-				userId: input.callerContext.user.userId,
-				storageId: input.job.storageId,
-				writable: true,
+			moduleFile.content,
+			input.job.params,
+			{
+				executorExports: workerExports,
+				storageTools: {
+					userId: input.callerContext.user.userId,
+					storageId: input.job.storageId,
+					writable: true,
+				},
 			},
-		},
-	)
-	return {
-		...executionResult,
-		logs: [...gate.logs, ...(executionResult.logs ?? [])],
+		)
+		return {
+			...executionResult,
+			logs: [...bypassLogs, ...(executionResult.logs ?? [])],
+		}
+	} catch (error) {
+		return {
+			error: formatJobError(error),
+			result: null,
+			logs: bypassLogs,
+		}
 	}
 }
 

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -25,6 +25,7 @@ import {
 	type JobCreateInput,
 	type JobExecutionOutcome,
 	type JobExecutionResult,
+	type JobRepoCheckPolicy,
 	type JobRecord,
 	type JobUpdateInput,
 	type PersistedJobCallerContext,
@@ -39,9 +40,7 @@ import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 import { buildJobSourceFiles } from '#worker/repo/source-templates.ts'
 
-function hasRepoBackedJobSource(input: {
-	sourceId?: string | null
-}) {
+function hasRepoBackedJobSource(input: { sourceId?: string | null }) {
 	return typeof input.sourceId === 'string' && input.sourceId.length > 0
 }
 
@@ -89,6 +88,68 @@ function normalizeOptionalParams(
 	return params === null || params === undefined ? undefined : params
 }
 
+function normalizeJobRepoCheckPolicy(
+	policy: JobRepoCheckPolicy | null | undefined,
+): JobRepoCheckPolicy | undefined {
+	if (!policy) {
+		return undefined
+	}
+	if (policy.allowTypecheckFailures === true) {
+		return {
+			allowTypecheckFailures: true,
+		}
+	}
+	return undefined
+}
+
+function resolveJobRepoCheckPolicy(input: {
+	stored: JobRepoCheckPolicy | undefined
+	override?: JobRepoCheckPolicy | null
+}) {
+	if (input.override !== undefined) {
+		return normalizeJobRepoCheckPolicy(input.override)
+	}
+	return normalizeJobRepoCheckPolicy(input.stored)
+}
+
+function evaluateRepoCheckGate(input: {
+	result: Awaited<ReturnType<ReturnType<typeof repoSessionRpc>['runChecks']>>
+	policy: JobRepoCheckPolicy | undefined
+	jobId: string
+	sourceId: string
+}) {
+	if (input.result.ok) {
+		return {
+			proceed: true,
+			logs: [] as Array<string>,
+		}
+	}
+	const failingResults = input.result.results.filter((entry) => !entry.ok)
+	const onlyTypecheckFailures =
+		failingResults.length > 0 &&
+		failingResults.every((entry) => entry.kind === 'typecheck')
+	if (input.policy?.allowTypecheckFailures === true && onlyTypecheckFailures) {
+		console.info('[runRepoBackedJob] bypassing repo typecheck failures', {
+			jobId: input.jobId,
+			sourceId: input.sourceId,
+			runId: input.result.runId,
+			treeHash: input.result.treeHash,
+			failingKinds: failingResults.map((entry) => entry.kind),
+		})
+		return {
+			proceed: true,
+			logs: [
+				`Bypassed repo typecheck-only check failures for job "${input.jobId}" (source "${input.sourceId}", check run ${input.result.runId}).`,
+			],
+		}
+	}
+	return {
+		proceed: false,
+		error: failingResults.map((entry) => entry.message).join('\n'),
+		logs: [] as Array<string>,
+	}
+}
+
 function repoSessionNeedsRefresh(session: {
 	base_commit: string | null
 	published_commit: string | null
@@ -105,12 +166,14 @@ function resolveCreateShape(input: JobCreateInput) {
 			code: input.code == null ? null : normalizeJobCode(input.code),
 			sourceId: input.sourceId ?? null,
 			publishedCommit: input.publishedCommit ?? null,
+			repoCheckPolicy: normalizeJobRepoCheckPolicy(input.repoCheckPolicy),
 		}
 	}
 	return {
 		code: normalizeJobCode(input.code ?? ''),
 		sourceId: null,
 		publishedCommit: null,
+		repoCheckPolicy: undefined,
 	}
 }
 
@@ -132,6 +195,10 @@ function resolveUpdatedShape(input: {
 		input.body.publishedCommit === undefined
 			? input.existing.publishedCommit
 			: input.body.publishedCommit
+	const nextRepoCheckPolicy =
+		input.body.repoCheckPolicy === undefined
+			? input.existing.repoCheckPolicy
+			: normalizeJobRepoCheckPolicy(input.body.repoCheckPolicy)
 	if (!nextCode && !nextSourceId) {
 		throw new Error('Jobs require either code or sourceId.')
 	}
@@ -139,6 +206,7 @@ function resolveUpdatedShape(input: {
 		code: nextCode,
 		sourceId: nextSourceId ?? null,
 		publishedCommit: nextPublishedCommit ?? null,
+		repoCheckPolicy: nextRepoCheckPolicy,
 	}
 }
 
@@ -172,6 +240,7 @@ export async function createJob(input: {
 		code: shape.code,
 		sourceId: ensuredSource?.id ?? shape.sourceId ?? null,
 		publishedCommit: shape.publishedCommit ?? null,
+		repoCheckPolicy: shape.repoCheckPolicy,
 		storageId: createJobStorageId(jobId),
 		params: normalizeOptionalParams(input.body.params),
 		schedule,
@@ -301,6 +370,7 @@ export async function updateJob(input: {
 		code: shape.code ?? null,
 		sourceId: ensuredSource?.id ?? shape.sourceId ?? null,
 		publishedCommit: shape.publishedCommit ?? null,
+		repoCheckPolicy: shape.repoCheckPolicy,
 		params:
 			input.body.params === undefined
 				? existing.params
@@ -372,6 +442,7 @@ export async function executeJobOnce(input: {
 	env: Env
 	job: JobRecord
 	callerContext: PersistedJobCallerContext | null
+	repoCheckPolicyOverride?: JobRepoCheckPolicy | null
 }): Promise<JobExecutionOutcome> {
 	const started = new Date()
 	let execution: JobExecutionResult
@@ -402,6 +473,7 @@ export async function executeJobOnce(input: {
 						env: input.env,
 						job: input.job,
 						callerContext: runtimeCallerContext,
+						repoCheckPolicyOverride: input.repoCheckPolicyOverride,
 					})
 				: await runCodemodeWithRegistry(
 						input.env,
@@ -449,6 +521,7 @@ async function runRepoBackedJob(input: {
 	env: Env
 	job: JobRecord
 	callerContext: PersistedJobCallerContext
+	repoCheckPolicyOverride?: JobRepoCheckPolicy | null
 }): Promise<ExecuteResult> {
 	if (!input.job.sourceId) {
 		return {
@@ -491,18 +564,23 @@ async function runRepoBackedJob(input: {
 		sessionId: session.id,
 		userId: input.callerContext.user.userId,
 	})
-	if (!result.ok) {
+	const gate = evaluateRepoCheckGate({
+		result,
+		policy: resolveJobRepoCheckPolicy({
+			stored: input.job.repoCheckPolicy,
+			override: input.repoCheckPolicyOverride,
+		}),
+		jobId: input.job.id,
+		sourceId: input.job.sourceId,
+	})
+	if (!gate.proceed) {
 		return {
-			error: result.results
-				.filter((entry) => !entry.ok)
-				.map((entry) => entry.message)
-				.join('\n'),
+			error: gate.error ?? 'Repo checks failed.',
 			result: null,
-			logs: [],
+			logs: gate.logs,
 		}
 	}
-	const manifestPath =
-		session.manifest_path?.replace(/^\/+/, '') || 'kody.json'
+	const manifestPath = session.manifest_path?.replace(/^\/+/, '') || 'kody.json'
 	const entrypoint = await sessionClient.readFile({
 		sessionId: session.id,
 		userId: input.callerContext.user.userId,
@@ -557,7 +635,7 @@ async function runRepoBackedJob(input: {
 	}
 	const { runCodemodeWithRegistry } =
 		await import('#mcp/run-codemode-registry.ts')
-	return await runCodemodeWithRegistry(
+	const executionResult = await runCodemodeWithRegistry(
 		input.env,
 		{
 			...input.callerContext,
@@ -585,6 +663,10 @@ async function runRepoBackedJob(input: {
 			},
 		},
 	)
+	return {
+		...executionResult,
+		logs: [...gate.logs, ...(executionResult.logs ?? [])],
+	}
 }
 
 export async function runJobNow(input: {
@@ -592,6 +674,7 @@ export async function runJobNow(input: {
 	userId: string
 	jobId: string
 	callerContext?: McpCallerContext | null
+	repoCheckPolicyOverride?: JobRepoCheckPolicy | null
 }) {
 	const row = await getJobRowById(input.env.APP_DB, input.userId, input.jobId)
 	if (!row) {
@@ -604,6 +687,7 @@ export async function runJobNow(input: {
 		env: input.env,
 		job: row.record,
 		callerContext: activeCallerContext,
+		repoCheckPolicyOverride: input.repoCheckPolicyOverride,
 	})
 	const updated =
 		row.record.schedule.type === 'once'

--- a/packages/worker/src/jobs/types.ts
+++ b/packages/worker/src/jobs/types.ts
@@ -27,6 +27,10 @@ export type JobRunHistoryEntry = {
 	error?: string
 }
 
+export type JobRepoCheckPolicy = {
+	allowTypecheckFailures?: boolean
+}
+
 export type JobRecord = {
 	version: 1
 	id: string
@@ -35,6 +39,7 @@ export type JobRecord = {
 	code: string | null
 	sourceId: string | null
 	publishedCommit: string | null
+	repoCheckPolicy?: JobRepoCheckPolicy
 	storageId: string
 	params?: Record<string, unknown>
 	schedule: JobSchedule
@@ -104,6 +109,7 @@ export type JobCreateInput = {
 	code?: string | null
 	sourceId?: string | null
 	publishedCommit?: string | null
+	repoCheckPolicy?: JobRepoCheckPolicy | null
 	params?: Record<string, unknown>
 	schedule: JobSchedule
 	timezone?: string | null
@@ -117,6 +123,7 @@ export type JobUpdateInput = {
 	code?: string | null
 	sourceId?: string | null
 	publishedCommit?: string | null
+	repoCheckPolicy?: JobRepoCheckPolicy | null
 	params?: Record<string, unknown> | null
 	schedule?: JobSchedule
 	timezone?: string | null
@@ -130,6 +137,7 @@ export type JobUpsertInput = {
 	code?: string | null
 	sourceId?: string | null
 	publishedCommit?: string | null
+	repoCheckPolicy?: JobRepoCheckPolicy | null
 	params?: Record<string, unknown> | null
 	schedule?: JobSchedule
 	timezone?: string | null

--- a/packages/worker/src/mcp/capabilities/jobs/job-run-now.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-run-now.node.test.ts
@@ -1,0 +1,79 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	runJobNowViaManager: vi.fn(),
+}))
+
+vi.mock('#worker/jobs/manager-do.ts', () => ({
+	runJobNowViaManager: (...args: Array<unknown>) =>
+		mockModule.runJobNowViaManager(...args),
+}))
+
+const { jobRunNowCapability } = await import('./job-run-now.ts')
+
+test('job_run_now forwards one-off repo check policy overrides', async () => {
+	mockModule.runJobNowViaManager.mockReset()
+	mockModule.runJobNowViaManager.mockResolvedValueOnce({
+		job: {
+			version: 1,
+			id: 'job-1',
+			name: 'Repo-backed run now',
+			code: null,
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			repoCheckPolicy: undefined,
+			storageId: 'job:job-1',
+			schedule: { type: 'interval', every: '15m' },
+			timezone: 'UTC',
+			enabled: true,
+			killSwitchEnabled: false,
+			createdAt: '2026-04-17T00:00:00.000Z',
+			updatedAt: '2026-04-17T00:00:00.000Z',
+			nextRunAt: '2026-04-17T00:15:00.000Z',
+			runCount: 0,
+			successCount: 0,
+			errorCount: 0,
+			runHistory: [],
+			scheduleSummary: 'Runs every 15m',
+		},
+		execution: {
+			ok: true,
+			result: { ok: true },
+			logs: [],
+		},
+	})
+
+	await jobRunNowCapability.handler(
+		{
+			id: 'job-1',
+			repoCheckPolicy: {
+				allowTypecheckFailures: true,
+			},
+		},
+		{
+			env: {} as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				user: { userId: 'user-1', email: 'user@example.com' },
+			}),
+		},
+	)
+
+	expect(mockModule.runJobNowViaManager).toHaveBeenCalledWith({
+		env: {},
+		userId: 'user-1',
+		jobId: 'job-1',
+		callerContext: {
+			baseUrl: 'https://heykody.dev',
+			user: { userId: 'user-1', email: 'user@example.com' },
+			homeConnectorId: null,
+			remoteConnectors: null,
+			storageContext: null,
+			repoContext: null,
+		},
+		repoCheckPolicyOverride: {
+			allowTypecheckFailures: true,
+		},
+	})
+})

--- a/packages/worker/src/mcp/capabilities/jobs/job-run-now.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-run-now.ts
@@ -2,7 +2,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { runJobNowViaManager } from '#worker/jobs/manager-do.ts'
 import {
-	jobIdInputSchema,
+	jobRunNowInputSchema,
 	jobRunNowOutputSchema,
 	requireJobsUser,
 } from './shared.ts'
@@ -17,7 +17,7 @@ export const jobRunNowCapability = defineDomainCapability(
 		readOnly: false,
 		idempotent: false,
 		destructive: false,
-		inputSchema: jobIdInputSchema,
+		inputSchema: jobRunNowInputSchema,
 		outputSchema: jobRunNowOutputSchema,
 		async handler(args, ctx) {
 			const user = requireJobsUser(ctx)
@@ -26,6 +26,7 @@ export const jobRunNowCapability = defineDomainCapability(
 				userId: user.userId,
 				jobId: args.id,
 				callerContext: ctx.callerContext,
+				repoCheckPolicyOverride: args.repoCheckPolicy,
 			})
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/jobs/job-upsert.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-upsert.node.test.ts
@@ -129,9 +129,15 @@ test('job_upsert forwards repo-backed fields on update', async () => {
 			code: null,
 			sourceId: 'source-1',
 			publishedCommit: 'commit-2',
-			repoCheckPolicy: undefined,
 		},
 	})
+	expect(mockModule.updateJob.mock.calls[0]?.[0]).toEqual(
+		expect.not.objectContaining({
+			body: expect.objectContaining({
+				repoCheckPolicy: expect.anything(),
+			}),
+		}),
+	)
 })
 
 test('job_upsert forwards repo check policy on create', async () => {

--- a/packages/worker/src/mcp/capabilities/jobs/job-upsert.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-upsert.node.test.ts
@@ -67,12 +67,13 @@ test('job_upsert forwards repo-backed fields on create', async () => {
 		callerContext: expect.objectContaining({
 			baseUrl: 'https://heykody.dev',
 		}),
-		body: expect.objectContaining({
+		body: {
+			code: null,
 			name: 'Repo-backed create',
 			sourceId: 'source-1',
 			publishedCommit: 'commit-1',
 			schedule: { type: 'interval', every: '15m' },
-		}),
+		},
 	})
 })
 
@@ -128,6 +129,72 @@ test('job_upsert forwards repo-backed fields on update', async () => {
 			code: null,
 			sourceId: 'source-1',
 			publishedCommit: 'commit-2',
+			repoCheckPolicy: undefined,
 		},
+	})
+})
+
+test('job_upsert forwards repo check policy on create', async () => {
+	mockModule.createJob.mockReset()
+	mockModule.updateJob.mockReset()
+	mockModule.syncJobManagerAlarm.mockReset()
+	mockModule.createJob.mockResolvedValueOnce({
+		version: 1,
+		id: 'job-2',
+		name: 'Repo-backed create with policy',
+		code: null,
+		sourceId: 'source-2',
+		publishedCommit: 'commit-2',
+		repoCheckPolicy: {
+			allowTypecheckFailures: true,
+		},
+		storageId: 'job:job-2',
+		schedule: { type: 'interval', every: '15m' },
+		timezone: 'UTC',
+		enabled: true,
+		killSwitchEnabled: false,
+		createdAt: '2026-04-17T00:00:00.000Z',
+		updatedAt: '2026-04-17T00:00:00.000Z',
+		nextRunAt: '2026-04-17T00:15:00.000Z',
+		runCount: 0,
+		successCount: 0,
+		errorCount: 0,
+		runHistory: [],
+		scheduleSummary: 'Runs every 15m',
+	})
+
+	await jobUpsertCapability.handler(
+		{
+			name: 'Repo-backed create with policy',
+			code: null,
+			sourceId: 'source-2',
+			publishedCommit: 'commit-2',
+			repoCheckPolicy: {
+				allowTypecheckFailures: true,
+			},
+			schedule: { type: 'interval', every: '15m' },
+		},
+		{
+			env: {} as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				user: { userId: 'user-1', email: 'user@example.com' },
+			}),
+		},
+	)
+
+	expect(mockModule.createJob).toHaveBeenCalledWith({
+		env: {},
+		callerContext: expect.objectContaining({
+			baseUrl: 'https://heykody.dev',
+		}),
+		body: expect.objectContaining({
+			name: 'Repo-backed create with policy',
+			sourceId: 'source-2',
+			publishedCommit: 'commit-2',
+			repoCheckPolicy: {
+				allowTypecheckFailures: true,
+			},
+		}),
 	})
 })

--- a/packages/worker/src/mcp/capabilities/jobs/job-upsert.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-upsert.ts
@@ -37,6 +37,9 @@ export const jobUpsertCapability = defineDomainCapability(
 								...(args.publishedCommit !== undefined
 									? { publishedCommit: args.publishedCommit }
 									: {}),
+								...(args.repoCheckPolicy !== undefined
+									? { repoCheckPolicy: args.repoCheckPolicy }
+									: {}),
 								...(args.params !== undefined && args.params !== null
 									? { params: args.params }
 									: {}),
@@ -65,6 +68,9 @@ export const jobUpsertCapability = defineDomainCapability(
 									: {}),
 								...(args.publishedCommit !== undefined
 									? { publishedCommit: args.publishedCommit }
+									: {}),
+								...(args.repoCheckPolicy !== undefined
+									? { repoCheckPolicy: args.repoCheckPolicy }
 									: {}),
 								...(args.params !== undefined ? { params: args.params } : {}),
 								...(args.schedule !== undefined

--- a/packages/worker/src/mcp/capabilities/jobs/shared.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/shared.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import {
 	type JobExecutionResult,
+	type JobRepoCheckPolicy,
 	type JobUpsertInput,
 	type JobView,
 } from '#worker/jobs/types.ts'
@@ -40,6 +41,11 @@ export const jobViewSchema = z.object({
 	code: z.string().nullable(),
 	sourceId: z.string().nullable(),
 	publishedCommit: z.string().nullable(),
+	repoCheckPolicy: z
+		.object({
+			allowTypecheckFailures: z.boolean().optional(),
+		})
+		.optional(),
 	storageId: z.string(),
 	params: z.record(z.string(), z.unknown()).optional(),
 	schedule: jobScheduleSchema,
@@ -81,6 +87,17 @@ export const jobIdInputSchema = z.object({
 	id: z.string().min(1).describe('Identifier of the job.'),
 })
 
+export const jobRepoCheckPolicySchema = z
+	.object({
+		allowTypecheckFailures: z
+			.boolean()
+			.optional()
+			.describe(
+				'For repo-backed jobs only, allow execution to continue when Worker-native checks fail only in the typecheck category. Missing manifest, entrypoint, dependency, lint, and smoke checks still block execution.',
+			),
+	})
+	.strict() satisfies z.ZodType<JobRepoCheckPolicy>
+
 export const jobUpsertInputSchema = z
 	.object({
 		id: z
@@ -118,6 +135,12 @@ export const jobUpsertInputSchema = z
 			.optional()
 			.describe(
 				'Published commit pinned for repo-backed job execution. Optional on create; updated automatically when the repo session publish flow promotes changes.',
+			),
+		repoCheckPolicy: jobRepoCheckPolicySchema
+			.nullable()
+			.optional()
+			.describe(
+				'Optional repo-backed execution policy. This is opt-in and does not change publish-time repo checks.',
 			),
 		params: z
 			.record(z.string(), z.unknown())
@@ -166,6 +189,16 @@ export const jobUpsertInputSchema = z
 			})
 		}
 	}) satisfies z.ZodType<JobUpsertInput>
+
+export const jobRunNowInputSchema = z.object({
+	id: z.string().min(1).describe('Identifier of the job.'),
+	repoCheckPolicy: jobRepoCheckPolicySchema
+		.nullable()
+		.optional()
+		.describe(
+			'Optional one-off repo-backed execution policy override for this immediate run only.',
+		),
+})
 
 export const jobExecutionResultSchema = z.discriminatedUnion('ok', [
 	z.object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a per-job `repoCheckPolicy` with `allowTypecheckFailures` for repo-backed job execution
- add a one-off `job_run_now` override using the same policy shape for intentional retries without editing the stored job
- keep default behavior strict and only bypass execution when the failing Worker-native checks are **typecheck-only**
- preserve bypass audit logs even when execution fails after the check gate has already allowed the run to continue

## Motivation
Production repo-backed jobs no longer hit the TS6053 path bug, but they can still be blocked before execution by Worker-native repo checks that report TypeScript semantic errors like `Cannot find name 'codemode'` or `Cannot find name 'storage'`. Those diagnostics are often false blockers for repo-backed jobs because the actual execute runtime injects those helpers before running the codemode snippet.

This change provides an explicit, opt-in escape hatch an agent can send through Kody capabilities when it has reason to believe the runtime will still succeed.

## Behavior
### Default behavior
- unchanged and still strict
- repo-backed job execution still runs repo checks first
- any failing check still blocks execution unless an explicit policy says otherwise

### Opt-in behavior
- `job_upsert` now accepts an optional `repoCheckPolicy`
- `job_run_now` now accepts an optional one-off `repoCheckPolicy` override for that immediate run only
- the initial supported policy is:
  - `allowTypecheckFailures: true`

### What is actually bypassed
Execution proceeds **only** when:
- the job is repo-backed, and
- the policy explicitly enables `allowTypecheckFailures`, and
- every failing repo check is in the `typecheck` category

Execution still stops for other failures, including:
- missing/invalid manifest
- missing entrypoint / bundle failures
- dependency check failures
- lint failures
- smoke failures
- mixed failures that include both typecheck and any other failing category

### Observability
- bypassed runs include an execution log entry describing the bypass
- the worker also emits a structured console info event at the execution fork with job id, source id, check run id, and tree hash
- if the bypassed run later fails during manifest loading or execute runtime startup/execution, the bypass audit log is still preserved in the returned logs

### Important caveat
This is an **execution-time** bypass only. It does **not** relax repo session publish checks or other repo workflows. `repo_run_checks` and publish-time gating remain strict.

## Review follow-up notes
I verified a later round of review comments against the current code rather than applying them blindly.

Applied:
- preserve bypass audit logs when execution fails after the typecheck-only bypass gate
- tighten the `job_upsert` update test so it asserts the repo check policy is omitted rather than forwarded as `undefined`

Not applied:
- clearing stale repo policy when a repo-backed job becomes inline was not actionable in the current implementation, because `updateJob` already forbids changing an assigned `sourceId`, so that transition cannot currently occur

## Validation
- `npm run test -- --run packages/worker/src/jobs/service.node.test.ts packages/worker/src/mcp/capabilities/jobs/job-upsert.node.test.ts packages/worker/src/mcp/capabilities/jobs/job-run-now.node.test.ts`
- `npm run typecheck`
- `npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aff7183b-5afd-4d85-8671-1501d92195cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aff7183b-5afd-4d85-8671-1501d92195cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repository check policies: Jobs now support configurable policies to control how typecheck failures are handled during execution. Policies can allow jobs to continue despite typecheck-only failures.
  * Execution-time policy overrides: Jobs can be run with temporary check policy overrides that take precedence over stored settings for individual executions only, without permanent configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->