### PR TITLE
Add local mock for Artifacts REST control plane

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -107,6 +107,11 @@ Production note:
   `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, and optional
   `CLOUDFLARE_API_BASE_URL` / `ARTIFACTS_NAMESPACE`, which also makes local dev
   mocking straightforward.
+- During `npm run dev`, those REST calls go to the local Cloudflare mock Worker,
+  which now implements the Artifacts repo metadata endpoints used by the app
+  (`create`, `get`, `list`, `createToken`, and `fork`). The mock only covers the
+  REST control plane; repo session Durable Objects still need a Git-capable
+  remote for clone/pull/push flows.
 - Durable repo-source creation paths (`ensureEntitySource(...,
   requirePersistence: true)`) fail closed when persistence bindings are
   unavailable so callers do not write orphaned `source_id` references into D1.

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -110,7 +110,11 @@ Optional Worker secrets/vars (see `packages/worker/src/env-schema.ts` and
 - `CLOUDFLARE_API_BASE_URL` — API base URL; defaults to
   `https://api.cloudflare.com` when unset, including for outbound email sending.
   Local `npm run dev` sets this to the Cloudflare mock Worker unless
-  `AI_MODE=remote` or `SKIP_CLOUDFLARE_MOCK=1`.
+  `AI_MODE=remote` or `SKIP_CLOUDFLARE_MOCK=1`. That same local mock now also
+  serves the Artifacts REST control-plane endpoints used by
+  `packages/worker/src/repo/artifacts.ts` (`repos`, `tokens`, and `fork`), so
+  local repo create/get/list/token/fork calls do not need the live Artifacts
+  REST API.
 
 ## Home connector bridge
 

--- a/docs/contributing/mock-api-servers.md
+++ b/docs/contributing/mock-api-servers.md
@@ -18,7 +18,10 @@ Worker package so it can also be deployed alongside the main app.
 
 See `packages/mock-servers/cloudflare/` for a small Cloudflare API v4 subset
 mock used by tests and the internal API client (started by `npm run dev`
-unless `SKIP_CLOUDFLARE_MOCK=1`).
+unless `SKIP_CLOUDFLARE_MOCK=1`). It now covers the Cloudflare Email REST
+fallback plus the Artifacts REST control-plane endpoints used by
+`packages/worker/src/repo/artifacts.ts` (`repos`, `repo info`, `tokens`, and
+`fork`).
 
 ### Tips
 

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -35,11 +35,16 @@ Quick notes for getting a local kody environment running.
 - `npm run dev` (starts mock API servers automatically, the main worker, and the
   local home connector; it sets `AI_MODE=mock`, `AI_MOCK_BASE_URL`, and
   `CLOUDFLARE_API_BASE_URL` + `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`
-  to the local Cloudflare API mock Worker for the internal Cloudflare API client
-  and local email sending. Unless you already set `CLOUDFLARE_EMAIL_FROM`, the
-  launcher also defaults it to `reset@kody.dev`. Set `SKIP_CLOUDFLARE_MOCK=1` to
-  skip the local Cloudflare mock entirely. The home connector receives the
-  resolved worker origin via `WORKER_BASE_URL`. When
+  to the local Cloudflare API mock Worker for the internal Cloudflare API client,
+  local email sending, and Artifacts REST repo create/get/list/token/fork calls.
+  Those REST calls do not hit the live Cloudflare Artifacts control plane during
+  normal local development. The mock currently covers only the REST control
+  plane; repo-session git clone/pull/push flows still need a real Git-capable
+  Artifacts remote and are not fully simulated by the local mock. Unless you
+  already set `CLOUDFLARE_EMAIL_FROM`, the launcher also defaults it to
+  `reset@kody.dev`. Set `SKIP_CLOUDFLARE_MOCK=1` to skip the local Cloudflare
+  mock entirely. The home connector receives the resolved worker origin via
+  `WORKER_BASE_URL`. When
   `HOME_CONNECTOR_SHARED_SECRET` is unset, the launcher generates one and passes
   it to both the worker and the connector so the outbound registration handshake
   succeeds in local development. The main worker and home connector stream logs

--- a/packages/mock-servers/cloudflare/src/mock-artifacts-do.ts
+++ b/packages/mock-servers/cloudflare/src/mock-artifacts-do.ts
@@ -1,0 +1,319 @@
+type DurableObjectState = {
+	storage: DurableObjectStorage
+}
+
+type DurableObjectEnv = Record<string, never>
+
+type StoredMockArtifactRepo = {
+	id: string
+	name: string
+	description: string | null
+	default_branch: string
+	created_at: string
+	updated_at: string
+	last_push_at: string | null
+	source: string | null
+	read_only: boolean
+	remote: string
+}
+
+type MockArtifactsStorage = {
+	repos: Record<string, StoredMockArtifactRepo>
+}
+
+type MockArtifactsListPayload = {
+	limit: number
+	cursor: string | null
+}
+
+type MockArtifactsGetPayload = {
+	name: string
+}
+
+type MockArtifactsCreatePayload = {
+	name: string
+	description: string | null
+	defaultBranch: string
+	readOnly: boolean
+	remote: string
+}
+
+type MockArtifactsForkPayload = {
+	sourceName: string
+	targetName: string
+	readOnly: boolean
+	remote: string
+}
+
+type MockArtifactsCreateTokenPayload = {
+	repo: string
+	scope: string
+	ttl: number
+}
+
+type MockArtifactsCountPayload = Record<string, never>
+
+type MockArtifactsCommand =
+	| {
+			type: 'list'
+			payload: MockArtifactsListPayload
+	  }
+	| {
+			type: 'get'
+			payload: MockArtifactsGetPayload
+	  }
+	| {
+			type: 'create'
+			payload: MockArtifactsCreatePayload
+	  }
+	| {
+			type: 'fork'
+			payload: MockArtifactsForkPayload
+	  }
+	| {
+			type: 'createToken'
+			payload: MockArtifactsCreateTokenPayload
+	  }
+	| {
+			type: 'count'
+			payload: MockArtifactsCountPayload
+	  }
+
+function assertNever(value: never): never {
+	throw new Error(`Unhandled mock artifacts command: ${String(value)}`)
+}
+
+export class MockCloudflareArtifactsDurableObject {
+	readonly state: DurableObjectState
+
+	constructor(state: DurableObjectState, _env: DurableObjectEnv) {
+		this.state = state
+	}
+
+	async fetch(request: Request): Promise<Response> {
+		let command: MockArtifactsCommand
+		try {
+			command = (await request.json()) as MockArtifactsCommand
+		} catch {
+			return new Response('Invalid JSON payload.', { status: 400 })
+		}
+
+		const storage = await this.readStorage()
+		switch (command.type) {
+			case 'list': {
+				const repos = Object.values(storage.repos).sort((left, right) =>
+					left.name.localeCompare(right.name),
+				)
+				const offset = Math.max(
+					0,
+					Number.parseInt(command.payload.cursor ?? '0', 10) || 0,
+				)
+				const limit = Math.max(1, command.payload.limit)
+				const page = repos.slice(offset, offset + limit)
+				const nextCursor =
+					offset + limit < repos.length ? String(offset + limit) : null
+				return Response.json({
+					repos: page,
+					total: repos.length,
+					cursor: nextCursor,
+				})
+			}
+			case 'get': {
+				return Response.json({
+					repo: storage.repos[command.payload.name] ?? null,
+				})
+			}
+			case 'create': {
+				if (storage.repos[command.payload.name]) {
+					return Response.json({ error: 'repo_exists' })
+				}
+				const now = new Date().toISOString()
+				const repo: StoredMockArtifactRepo = {
+					id: `repo_${crypto.randomUUID()}`,
+					name: command.payload.name,
+					description: command.payload.description,
+					default_branch: command.payload.defaultBranch,
+					created_at: now,
+					updated_at: now,
+					last_push_at: null,
+					source: null,
+					read_only: command.payload.readOnly,
+					remote: command.payload.remote,
+				}
+				storage.repos[repo.name] = repo
+				await this.writeStorage(storage)
+				return Response.json({ repo })
+			}
+			case 'fork': {
+				const source = storage.repos[command.payload.sourceName]
+				if (!source) {
+					return Response.json({ error: 'repo_not_found' })
+				}
+				if (storage.repos[command.payload.targetName]) {
+					return Response.json({ error: 'repo_exists' })
+				}
+				const now = new Date().toISOString()
+				const repo: StoredMockArtifactRepo = {
+					id: `repo_${crypto.randomUUID()}`,
+					name: command.payload.targetName,
+					description: source.description,
+					default_branch: source.default_branch,
+					created_at: now,
+					updated_at: now,
+					last_push_at: null,
+					source: source.name,
+					read_only: command.payload.readOnly,
+					remote: command.payload.remote,
+				}
+				storage.repos[repo.name] = repo
+				await this.writeStorage(storage)
+				return Response.json({ repo })
+			}
+			case 'createToken': {
+				const repo = storage.repos[command.payload.repo]
+				if (!repo) {
+					return Response.json({ error: 'repo_not_found' })
+				}
+				const expiresAtSeconds = Math.floor(Date.now() / 1000) + command.payload.ttl
+				const tokenId = `tok_${crypto.randomUUID()}`
+				return Response.json({
+					token: {
+						id: tokenId,
+						plaintext: `${tokenId}?expires=${expiresAtSeconds}`,
+						scope: command.payload.scope,
+						expires_at: new Date(expiresAtSeconds * 1000).toISOString(),
+					},
+				})
+			}
+			case 'count': {
+				return Response.json({
+					count: Object.keys(storage.repos).length,
+				})
+			}
+			default:
+				return assertNever(command)
+		}
+	}
+
+	private async readStorage(): Promise<MockArtifactsStorage> {
+		const storage = await this.state.storage.get<MockArtifactsStorage>('state')
+		if (!storage) {
+			return { repos: {} }
+		}
+		return {
+			repos:
+				storage.repos && typeof storage.repos === 'object' ? storage.repos : {},
+		}
+	}
+
+	private async writeStorage(storage: MockArtifactsStorage) {
+		await this.state.storage.put('state', storage)
+	}
+}
+
+class MockCloudflareArtifactsState {
+	private stub: DurableObjectStub
+
+	constructor(stub: DurableObjectStub) {
+		this.stub = stub
+	}
+
+	async countRepos() {
+		const response = await this.callState<{ count: number }>({
+			type: 'count',
+			payload: {},
+		})
+		return response.count
+	}
+
+	async listRepos(limit: number, cursor: string | null) {
+		return this.callState<{
+			repos: Array<StoredMockArtifactRepo>
+			total: number
+			cursor: string | null
+		}>({
+			type: 'list',
+			payload: { limit, cursor },
+		})
+	}
+
+	async getRepo(name: string) {
+		const response = await this.callState<{
+			repo: StoredMockArtifactRepo | null
+		}>({
+			type: 'get',
+			payload: { name },
+		})
+		return response.repo
+	}
+
+	async createRepo(input: MockArtifactsCreatePayload) {
+		const response = await this.callState<{
+			repo?: StoredMockArtifactRepo
+			error?: string
+		}>({
+			type: 'create',
+			payload: input,
+		})
+		if (!response.repo) {
+			throw new Error(response.error ?? 'Failed to create mock artifacts repo.')
+		}
+		return response.repo
+	}
+
+	async forkRepo(input: MockArtifactsForkPayload) {
+		const response = await this.callState<{
+			repo?: StoredMockArtifactRepo
+			error?: string
+		}>({
+			type: 'fork',
+			payload: input,
+		})
+		if (!response.repo) {
+			throw new Error(response.error ?? 'Failed to fork mock artifacts repo.')
+		}
+		return response.repo
+	}
+
+	async createToken(input: MockArtifactsCreateTokenPayload) {
+		const response = await this.callState<{
+			token?: {
+				id: string
+				plaintext: string
+				scope: string
+				expires_at: string
+			}
+			error?: string
+		}>({
+			type: 'createToken',
+			payload: input,
+		})
+		if (!response.token) {
+			throw new Error(
+				response.error ?? 'Failed to create mock artifacts token.',
+			)
+		}
+		return response.token
+	}
+
+	private async callState<TResponse>(
+		payload: MockArtifactsCommand,
+	): Promise<TResponse> {
+		const response = await this.stub.fetch('https://mock-cloudflare-artifacts/', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify(payload),
+		})
+		if (!response.ok) {
+			const detail = await response.text()
+			throw new Error(
+				`Mock Cloudflare artifacts state failed (${response.status}): ${detail}`,
+			)
+		}
+		return (await response.json()) as TResponse
+	}
+}
+
+export function createMockCloudflareArtifactsState(stub: DurableObjectStub) {
+	return new MockCloudflareArtifactsState(stub)
+}

--- a/packages/mock-servers/cloudflare/src/worker.ts
+++ b/packages/mock-servers/cloudflare/src/worker.ts
@@ -7,10 +7,12 @@ import {
 	outboundEmailSchema,
 	type OutboundEmail,
 } from '@kody-internal/shared/outbound-email.ts'
+import { createMockCloudflareArtifactsState } from './mock-artifacts-do.ts'
 import { createMockCloudflareEmailState } from './mock-email-messages-do.ts'
 
 type MockCloudflareEnv = {
 	MOCK_API_TOKEN?: string
+	MOCK_CLOUDFLARE_ARTIFACTS_STATE: DurableObjectNamespace
 	MOCK_CLOUDFLARE_EMAIL_STATE: DurableObjectNamespace
 }
 
@@ -41,6 +43,7 @@ const fixtureAccount = {
 	id: 'cf_account_mock_123',
 	name: 'Mock Account',
 }
+const fixtureArtifactsNamespace = 'default'
 
 const fixtureZone: ZoneRecord = {
 	id: 'zone-123',
@@ -94,6 +97,36 @@ const dashboardEndpoints: Array<DashboardEndpoint> = [
 		method: 'POST',
 		path: `/client/v4/accounts/${fixtureAccount.id}/email/sending/send`,
 		description: 'Send an outbound email',
+		requiresAuth: true,
+	},
+	{
+		method: 'GET',
+		path: `/client/v4/accounts/${fixtureAccount.id}/artifacts/namespaces/${fixtureArtifactsNamespace}/repos`,
+		description: 'List Artifacts repos',
+		requiresAuth: true,
+	},
+	{
+		method: 'POST',
+		path: `/client/v4/accounts/${fixtureAccount.id}/artifacts/namespaces/${fixtureArtifactsNamespace}/repos`,
+		description: 'Create an Artifacts repo',
+		requiresAuth: true,
+	},
+	{
+		method: 'GET',
+		path: `/client/v4/accounts/${fixtureAccount.id}/artifacts/namespaces/${fixtureArtifactsNamespace}/repos/example-repo`,
+		description: 'Read Artifacts repo metadata',
+		requiresAuth: true,
+	},
+	{
+		method: 'POST',
+		path: `/client/v4/accounts/${fixtureAccount.id}/artifacts/namespaces/${fixtureArtifactsNamespace}/tokens`,
+		description: 'Create an Artifacts repo token',
+		requiresAuth: true,
+	},
+	{
+		method: 'POST',
+		path: `/client/v4/accounts/${fixtureAccount.id}/artifacts/namespaces/${fixtureArtifactsNamespace}/repos/example-repo/fork`,
+		description: 'Fork an Artifacts repo',
 		requiresAuth: true,
 	},
 	{
@@ -241,6 +274,30 @@ function getMockEmailState(env: MockCloudflareEnv, tokenHash: string) {
 	return createMockCloudflareEmailState(env.MOCK_CLOUDFLARE_EMAIL_STATE.get(id))
 }
 
+function getMockArtifactsState(
+	env: MockCloudflareEnv,
+	input: {
+		tokenHash: string
+		accountId: string
+		namespace: string
+	},
+) {
+	const id = env.MOCK_CLOUDFLARE_ARTIFACTS_STATE.idFromName(
+		`${input.tokenHash}:${input.accountId}:${input.namespace}`,
+	)
+	return createMockCloudflareArtifactsState(
+		env.MOCK_CLOUDFLARE_ARTIFACTS_STATE.get(id),
+	)
+}
+
+function buildMockArtifactsRemote(input: {
+	accountId: string
+	namespace: string
+	repoName: string
+}) {
+	return `https://${input.accountId}.artifacts.mock.local/git/${encodeURIComponent(input.namespace)}/${encodeURIComponent(input.repoName)}.git`
+}
+
 async function readJsonBody(request: Request) {
 	try {
 		const text = await request.text()
@@ -254,6 +311,14 @@ async function readJsonBody(request: Request) {
 async function handleMeta(request: Request, env: MockCloudflareEnv, url: URL) {
 	const authorized = isAuthorized(request, env, url)
 	const tokenHash = authorized ? await getTokenPartition(env) : null
+	const artifactRepoCount =
+		tokenHash == null
+			? null
+			: await getMockArtifactsState(env, {
+					tokenHash,
+					accountId: fixtureAccount.id,
+					namespace: fixtureArtifactsNamespace,
+				}).countRepos()
 	return json({
 		service: 'cloudflare',
 		authorized,
@@ -263,6 +328,7 @@ async function handleMeta(request: Request, env: MockCloudflareEnv, url: URL) {
 		...(tokenHash
 			? {
 					messageCount: await getMockEmailState(env, tokenHash).countMessages(),
+					artifactRepoCount,
 				}
 			: {}),
 	})
@@ -316,6 +382,7 @@ async function handleDashboard(
 		response.json(),
 	)) as {
 		authorized: boolean
+		artifactRepoCount?: number
 		messageCount?: number
 	}
 
@@ -349,6 +416,9 @@ async function handleDashboard(
 
 	const messageCountLine = meta.authorized
 		? `<span class="stat-value">${meta.messageCount ?? 0}</span>`
+		: '<span class="stat-value muted">hidden</span>'
+	const artifactRepoCountLine = meta.authorized
+		? `<span class="stat-value">${meta.artifactRepoCount ?? 0}</span>`
 		: '<span class="stat-value muted">hidden</span>'
 
 	const body = `<!doctype html>
@@ -404,7 +474,7 @@ async function handleDashboard(
 			.container { max-width: 960px; margin: 0 auto; }
 			h1 { margin: 0 0 8px; font-size: 22px; }
 			.subtitle { margin: 0 0 24px; color: var(--muted); }
-			.grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; margin: 16px 0 24px; }
+			.grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; margin: 16px 0 24px; }
 			.card { border: 1px solid var(--border); border-radius: 12px; padding: 16px; background: var(--card-bg); }
 			.stat-label { font-size: 12px; color: var(--muted); margin-bottom: 6px; }
 			.stat-value { font-size: 18px; font-weight: 600; }
@@ -442,6 +512,10 @@ async function handleDashboard(
 				<div class="card">
 					<div class="stat-label">Stored emails</div>
 					<div class="stat-value">${messageCountLine}</div>
+				</div>
+				<div class="card">
+					<div class="stat-label">Artifacts repos</div>
+					<div class="stat-value">${artifactRepoCountLine}</div>
 				</div>
 			</div>
 			<div class="card">
@@ -517,6 +591,215 @@ async function handleEmailSend(
 	)
 }
 
+async function handleArtifactsRepos(
+	request: Request,
+	env: MockCloudflareEnv,
+	input: {
+		accountId: string
+		namespace: string
+		url: URL
+	},
+) {
+	if (input.accountId !== fixtureAccount.id) {
+		return errorEnvelope(404, 1002, 'account not found')
+	}
+	const tokenHash = await getTokenPartition(env)
+	const state = getMockArtifactsState(env, {
+		tokenHash,
+		accountId: input.accountId,
+		namespace: input.namespace,
+	})
+	if (request.method === 'GET') {
+		const limit = Math.min(
+			100,
+			Math.max(
+				1,
+				Number.parseInt(input.url.searchParams.get('limit')?.trim() || '50', 10),
+			),
+		)
+		const cursor = input.url.searchParams.get('cursor')?.trim() || null
+		const result = await state.listRepos(limit, cursor)
+		return envelope(
+			result.repos,
+			{ status: 200 },
+			{
+				count: result.repos.length,
+				total_count: result.total,
+				...(result.cursor ? { cursor: result.cursor } : {}),
+			},
+		)
+	}
+	const body = await readJsonBody(request)
+	if (body === null) {
+		return errorEnvelope(400, 1001, 'invalid JSON body')
+	}
+	const repoName = typeof body.name === 'string' ? body.name.trim() : ''
+	if (!repoName) {
+		return errorEnvelope(400, 1001, 'repo name is required')
+	}
+	const existing = await state.getRepo(repoName)
+	if (existing) {
+		return errorEnvelope(409, 1003, 'repo already exists')
+	}
+	const repo = await state.createRepo({
+		name: repoName,
+		description:
+			typeof body.description === 'string' ? body.description : null,
+		defaultBranch:
+			typeof body.default_branch === 'string' && body.default_branch.trim()
+				? body.default_branch.trim()
+				: 'main',
+		readOnly: body.read_only === true,
+		remote: buildMockArtifactsRemote({
+			accountId: input.accountId,
+			namespace: input.namespace,
+			repoName,
+		}),
+	})
+	const token = await state.createToken({
+		repo: repo.name,
+		scope: 'write',
+		ttl: 3600,
+	})
+	return envelope(
+		{
+			id: repo.id,
+			name: repo.name,
+			description: repo.description,
+			default_branch: repo.default_branch,
+			remote: repo.remote,
+			token: token.plaintext,
+		},
+		{ status: 200 },
+	)
+}
+
+async function handleArtifactsRepoInfo(
+	env: MockCloudflareEnv,
+	input: {
+		accountId: string
+		namespace: string
+		repoName: string
+	},
+) {
+	if (input.accountId !== fixtureAccount.id) {
+		return errorEnvelope(404, 1002, 'account not found')
+	}
+	const tokenHash = await getTokenPartition(env)
+	const state = getMockArtifactsState(env, {
+		tokenHash,
+		accountId: input.accountId,
+		namespace: input.namespace,
+	})
+	const repo = await state.getRepo(input.repoName)
+	if (!repo) {
+		return errorEnvelope(404, 1002, 'repo not found')
+	}
+	return envelope(repo, { status: 200 })
+}
+
+async function handleArtifactsTokens(
+	request: Request,
+	env: MockCloudflareEnv,
+	input: {
+		accountId: string
+		namespace: string
+	},
+) {
+	if (input.accountId !== fixtureAccount.id) {
+		return errorEnvelope(404, 1002, 'account not found')
+	}
+	const body = await readJsonBody(request)
+	if (body === null) {
+		return errorEnvelope(400, 1001, 'invalid JSON body')
+	}
+	const repoName = typeof body.repo === 'string' ? body.repo.trim() : ''
+	if (!repoName) {
+		return errorEnvelope(400, 1001, 'repo is required')
+	}
+	const tokenHash = await getTokenPartition(env)
+	const state = getMockArtifactsState(env, {
+		tokenHash,
+		accountId: input.accountId,
+		namespace: input.namespace,
+	})
+	const repo = await state.getRepo(repoName)
+	if (!repo) {
+		return errorEnvelope(404, 1002, 'repo not found')
+	}
+	const token = await state.createToken({
+		repo: repo.name,
+		scope: typeof body.scope === 'string' ? body.scope : 'write',
+		ttl:
+			typeof body.ttl === 'number' && Number.isFinite(body.ttl)
+				? Math.max(1, Math.floor(body.ttl))
+				: 3600,
+	})
+	return envelope(token, { status: 200 })
+}
+
+async function handleArtifactsFork(
+	request: Request,
+	env: MockCloudflareEnv,
+	input: {
+		accountId: string
+		namespace: string
+		repoName: string
+	},
+) {
+	if (input.accountId !== fixtureAccount.id) {
+		return errorEnvelope(404, 1002, 'account not found')
+	}
+	const body = await readJsonBody(request)
+	if (body === null) {
+		return errorEnvelope(400, 1001, 'invalid JSON body')
+	}
+	const targetName = typeof body.name === 'string' ? body.name.trim() : ''
+	if (!targetName) {
+		return errorEnvelope(400, 1001, 'target repo name is required')
+	}
+	const tokenHash = await getTokenPartition(env)
+	const state = getMockArtifactsState(env, {
+		tokenHash,
+		accountId: input.accountId,
+		namespace: input.namespace,
+	})
+	const source = await state.getRepo(input.repoName)
+	if (!source) {
+		return errorEnvelope(404, 1002, 'repo not found')
+	}
+	const existingTarget = await state.getRepo(targetName)
+	if (existingTarget) {
+		return errorEnvelope(409, 1003, 'repo already exists')
+	}
+	const forked = await state.forkRepo({
+		sourceName: source.name,
+		targetName,
+		readOnly: body.read_only === true,
+		remote: buildMockArtifactsRemote({
+			accountId: input.accountId,
+			namespace: input.namespace,
+			repoName: targetName,
+		}),
+	})
+	const token = await state.createToken({
+		repo: forked.name,
+		scope: 'write',
+		ttl: 3600,
+	})
+	return envelope(
+		{
+			id: forked.id,
+			name: forked.name,
+			description: forked.description,
+			default_branch: forked.default_branch,
+			remote: forked.remote,
+			token: token.plaintext,
+		},
+		{ status: 200 },
+	)
+}
+
 async function routeApi(request: Request, env: MockCloudflareEnv, url: URL) {
 	if (!isAuthorized(request, env, url)) {
 		return errorEnvelope(401, 10000, 'Authentication error')
@@ -569,6 +852,52 @@ async function routeApi(request: Request, env: MockCloudflareEnv, url: URL) {
 	)
 	if (emailMatch && request.method === 'POST') {
 		return handleEmailSend(request, env, emailMatch[1]!)
+	}
+
+	const artifactsReposMatch = url.pathname.match(
+		/^\/client\/v4\/accounts\/([^/]+)\/artifacts\/namespaces\/([^/]+)\/repos\/?$/,
+	)
+	if (
+		artifactsReposMatch &&
+		(request.method === 'GET' || request.method === 'POST')
+	) {
+		return handleArtifactsRepos(request, env, {
+			accountId: artifactsReposMatch[1]!,
+			namespace: decodeURIComponent(artifactsReposMatch[2]!),
+			url,
+		})
+	}
+
+	const artifactsRepoInfoMatch = url.pathname.match(
+		/^\/client\/v4\/accounts\/([^/]+)\/artifacts\/namespaces\/([^/]+)\/repos\/([^/]+)\/?$/,
+	)
+	if (artifactsRepoInfoMatch && request.method === 'GET') {
+		return handleArtifactsRepoInfo(env, {
+			accountId: artifactsRepoInfoMatch[1]!,
+			namespace: decodeURIComponent(artifactsRepoInfoMatch[2]!),
+			repoName: decodeURIComponent(artifactsRepoInfoMatch[3]!),
+		})
+	}
+
+	const artifactsTokensMatch = url.pathname.match(
+		/^\/client\/v4\/accounts\/([^/]+)\/artifacts\/namespaces\/([^/]+)\/tokens\/?$/,
+	)
+	if (artifactsTokensMatch && request.method === 'POST') {
+		return handleArtifactsTokens(request, env, {
+			accountId: artifactsTokensMatch[1]!,
+			namespace: decodeURIComponent(artifactsTokensMatch[2]!),
+		})
+	}
+
+	const artifactsForkMatch = url.pathname.match(
+		/^\/client\/v4\/accounts\/([^/]+)\/artifacts\/namespaces\/([^/]+)\/repos\/([^/]+)\/fork\/?$/,
+	)
+	if (artifactsForkMatch && request.method === 'POST') {
+		return handleArtifactsFork(request, env, {
+			accountId: artifactsForkMatch[1]!,
+			namespace: decodeURIComponent(artifactsForkMatch[2]!),
+			repoName: decodeURIComponent(artifactsForkMatch[3]!),
+		})
 	}
 
 	const dnsListMatch = url.pathname.match(
@@ -657,6 +986,10 @@ export default {
 	},
 } satisfies ExportedHandler<MockCloudflareEnv>
 
+export {
+	MockCloudflareArtifactsDurableObject,
+	createMockCloudflareArtifactsState,
+} from './mock-artifacts-do.ts'
 export {
 	MockCloudflareEmailMessagesDurableObject,
 	createMockCloudflareEmailState,

--- a/packages/mock-servers/cloudflare/wrangler.jsonc
+++ b/packages/mock-servers/cloudflare/wrangler.jsonc
@@ -11,9 +11,17 @@
 			"new_classes": ["MockCloudflareEmailMessagesDurableObject"],
 			"tag": "v1",
 		},
+		{
+			"new_classes": ["MockCloudflareArtifactsDurableObject"],
+			"tag": "v2",
+		},
 	],
 	"durable_objects": {
 		"bindings": [
+			{
+				"class_name": "MockCloudflareArtifactsDurableObject",
+				"name": "MOCK_CLOUDFLARE_ARTIFACTS_STATE",
+			},
 			{
 				"class_name": "MockCloudflareEmailMessagesDurableObject",
 				"name": "MOCK_CLOUDFLARE_EMAIL_STATE",
@@ -25,6 +33,10 @@
 			"durable_objects": {
 				"bindings": [
 					{
+						"class_name": "MockCloudflareArtifactsDurableObject",
+						"name": "MOCK_CLOUDFLARE_ARTIFACTS_STATE",
+					},
+					{
 						"class_name": "MockCloudflareEmailMessagesDurableObject",
 						"name": "MOCK_CLOUDFLARE_EMAIL_STATE",
 					},
@@ -35,6 +47,10 @@
 			"durable_objects": {
 				"bindings": [
 					{
+						"class_name": "MockCloudflareArtifactsDurableObject",
+						"name": "MOCK_CLOUDFLARE_ARTIFACTS_STATE",
+					},
+					{
 						"class_name": "MockCloudflareEmailMessagesDurableObject",
 						"name": "MOCK_CLOUDFLARE_EMAIL_STATE",
 					},
@@ -44,6 +60,10 @@
 		"test": {
 			"durable_objects": {
 				"bindings": [
+					{
+						"class_name": "MockCloudflareArtifactsDurableObject",
+						"name": "MOCK_CLOUDFLARE_ARTIFACTS_STATE",
+					},
 					{
 						"class_name": "MockCloudflareEmailMessagesDurableObject",
 						"name": "MOCK_CLOUDFLARE_EMAIL_STATE",

--- a/packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts
+++ b/packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts
@@ -1,0 +1,152 @@
+import { expect, test } from 'vitest'
+import getPort from 'get-port'
+import { setTimeout as delay } from 'node:timers/promises'
+import {
+	captureOutput,
+	spawnProcess,
+	stopProcess,
+	wranglerBin,
+} from '#mcp/test-process.ts'
+import { getArtifactsBinding } from './artifacts.ts'
+
+const workerConfig = 'packages/mock-servers/cloudflare/wrangler.jsonc'
+const projectRoot = process.cwd()
+const mockAccountId = 'cf_account_mock_123'
+
+async function waitForMock(origin: string) {
+	const deadline = Date.now() + 25_000
+	while (Date.now() < deadline) {
+		try {
+			const response = await fetch(`${origin}/__mocks/meta`)
+			if (response.ok) {
+				await response.body?.cancel()
+				return
+			}
+		} catch {
+			/* retry */
+		}
+		await delay(200)
+	}
+	throw new Error('mock cloudflare timeout')
+}
+
+async function startCloudflareMock(token: string) {
+	const port = await getPort({ host: '127.0.0.1' })
+	const origin = `http://127.0.0.1:${port}`
+	const inspectorPort = await getPort({ host: '127.0.0.1' })
+	const proc = spawnProcess({
+		cmd: [
+			wranglerBin,
+			'dev',
+			'--local',
+			'--config',
+			workerConfig,
+			'--var',
+			`MOCK_API_TOKEN:${token}`,
+			'--port',
+			String(port),
+			'--inspector-port',
+			String(inspectorPort),
+			'--ip',
+			'127.0.0.1',
+			'--show-interactive-dev-session=false',
+			'--log-level',
+			'error',
+		],
+		cwd: projectRoot,
+	})
+	captureOutput(proc.stdout)
+	captureOutput(proc.stderr)
+	const mock = {
+		origin,
+		token,
+		async [Symbol.asyncDispose]() {
+			await stopProcess(proc)
+		},
+	}
+	try {
+		await waitForMock(origin)
+		return mock
+	} catch (error) {
+		await stopProcess(proc)
+		throw error
+	}
+}
+
+test('Cloudflare mock implements the Artifacts REST workflow used in local dev', async () => {
+	const token = `cloudflare-artifacts-mock-token-${crypto.randomUUID()}`
+	const repoName = `repo-${crypto.randomUUID()}`
+	const forkName = `repo-copy-${crypto.randomUUID()}`
+	await using mock = await startCloudflareMock(token)
+	const env = {
+		CLOUDFLARE_ACCOUNT_ID: mockAccountId,
+		CLOUDFLARE_API_TOKEN: mock.token,
+		CLOUDFLARE_API_BASE_URL: mock.origin,
+	} as Env
+
+	const binding = getArtifactsBinding(env)
+	await expect(binding.get(repoName)).resolves.toEqual({ status: 'not_found' })
+
+	const created = await binding.create(repoName, {
+		description: 'Repo 1',
+		readOnly: false,
+	})
+	expect(created).toMatchObject({
+		name: repoName,
+		description: 'Repo 1',
+		defaultBranch: 'main',
+		remote: `https://${mockAccountId}.artifacts.mock.local/git/default/${repoName}.git`,
+	})
+	expect(created.token).toMatch(/\?expires=\d+$/)
+
+	const getResult = await binding.get(repoName)
+	expect(getResult.status).toBe('ready')
+	if (getResult.status !== 'ready') {
+		throw new Error(`Expected ${repoName} to exist in mock artifacts state.`)
+	}
+
+	await expect(getResult.repo.info()).resolves.toMatchObject({
+		name: repoName,
+		description: 'Repo 1',
+		defaultBranch: 'main',
+		source: null,
+		readOnly: false,
+	})
+	await expect(getResult.repo.createToken('read', 120)).resolves.toMatchObject({
+		scope: 'read',
+	})
+
+	const forked = await getResult.repo.fork({
+		name: forkName,
+		readOnly: true,
+	})
+	expect(forked).toMatchObject({
+		name: forkName,
+		defaultBranch: 'main',
+		remote: `https://${mockAccountId}.artifacts.mock.local/git/default/${forkName}.git`,
+	})
+	expect(forked.token).toMatch(/\?expires=\d+$/)
+
+	const listed = await binding.list()
+	expect(listed.total).toBe(2)
+	expect(listed.repos).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				name: repoName,
+				readOnly: false,
+			}),
+			expect.objectContaining({
+				name: forkName,
+				readOnly: true,
+				source: repoName,
+			}),
+		]),
+	)
+
+	const metaResponse = await fetch(`${mock.origin}/__mocks/meta?token=${token}`)
+	expect(metaResponse.status).toBe(200)
+	const meta = (await metaResponse.json()) as {
+		artifactRepoCount?: number
+	}
+	expect(meta.artifactRepoCount).toBe(2)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add Artifacts REST endpoints to the existing Cloudflare mock worker for local development and tests
- persist mock Artifacts repo state in a dedicated Durable Object so create/get/list/token/fork flows behave consistently
- document that local dev uses the mock for Artifacts REST calls while full Git transport is still not simulated

## Testing
- npm run test -- --run packages/worker/src/repo/artifacts.node.test.ts packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts packages/worker/src/mcp/cloudflare/cloudflare-rest-client.node.test.ts packages/worker/src/app/email/cloudflare-email.node.test.ts
- npm run typecheck
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-872f8b4f-4335-41aa-a7c5-dc6a3e778d84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-872f8b4f-4335-41aa-a7c5-dc6a3e778d84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced local development guides to clarify that Artifacts repository operations are mocked during `npm run dev` without contacting live endpoints.

* **New Features**
  * Added comprehensive mock support for Artifacts REST control-plane endpoints (create, list, get, fork, tokens) in local development.

* **Tests**
  * Added integration test for local Artifacts mock functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->