### PR TITLE
Fix repo-backed ESM migration imports

### DIFF
--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -486,3 +486,163 @@ test('runRepoChecks typechecks ESM repo-backed job entrypoints', async () => {
 		'.__kody_repo_module_check__.ts',
 	)
 })
+
+test('runRepoChecks injects a synthetic tsconfig that allows optional .ts imports when the repo has no tsconfig', async () => {
+	mockModule.createFileSystemSnapshot.mockReset()
+	mockModule.createTypescriptLanguageService.mockReset()
+	const files = new Map<string, string>([
+		[
+			'kody.json',
+			JSON.stringify({
+				version: 1,
+				kind: 'job',
+				title: 'TS extension import job',
+				description: 'Imports a sibling .ts module',
+				sourceRoot: '/',
+				entrypoint: 'src/job.ts',
+			}),
+		],
+		[
+			'src/job.ts',
+			'export { default } from "./helper.ts"\n',
+		],
+		[
+			'src/helper.ts',
+			'export default async () => ({ ok: true })\n',
+		],
+	])
+	const snapshot = createSnapshotFromFiles(files)
+	const typeScriptFileSystem: MockTypeScriptFileSystem = {
+		...snapshot,
+		write: vi.fn(),
+	}
+	const getSemanticDiagnostics = vi.fn(() => [])
+	mockModule.createFileSystemSnapshot.mockResolvedValue(snapshot)
+	mockModule.createTypescriptLanguageService.mockResolvedValue({
+		fileSystem: typeScriptFileSystem,
+		languageService: {
+			getSemanticDiagnostics,
+		},
+	})
+
+	const result = await runRepoChecks({
+		workspace: {
+			async readFile(path: string) {
+				return files.get(path) ?? null
+			},
+			async glob() {
+				return Array.from(files.keys()).map((path) => ({ path, type: 'file' }))
+			},
+		},
+		manifestPath: 'kody.json',
+		sourceRoot: '/',
+	})
+
+	expect(result.ok).toBe(true)
+	expect(mockModule.createTypescriptLanguageService).toHaveBeenCalledWith({
+		fileSystem: expect.objectContaining({
+			read: expect.any(Function),
+			write: expect.any(Function),
+			delete: expect.any(Function),
+			list: expect.any(Function),
+			flush: expect.any(Function),
+		}),
+	})
+	const typecheckInput = mockModule.createTypescriptLanguageService.mock
+		.calls[0]?.[0] as { fileSystem: MockTypeScriptFileSystem }
+	expect(typecheckInput.fileSystem.read('tsconfig.json')).toBe(
+		JSON.stringify({
+			compilerOptions: {
+				allowImportingTsExtensions: true,
+				noEmit: true,
+			},
+		}),
+	)
+	expect(typecheckInput.fileSystem.read('./.__kody_repo_tsconfig_base__.json')).toBe(
+		null,
+	)
+	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
+		'.__kody_repo_module_check__.ts',
+		expect.stringContaining('import userEntrypoint from "./src/job"'),
+	)
+})
+
+test('runRepoChecks preserves repo tsconfig via extends while enabling optional .ts imports', async () => {
+	mockModule.createFileSystemSnapshot.mockReset()
+	mockModule.createTypescriptLanguageService.mockReset()
+	const repoTsconfig = JSON.stringify({
+		compilerOptions: {
+			module: 'NodeNext',
+			moduleResolution: 'NodeNext',
+			strict: true,
+		},
+	})
+	const files = new Map<string, string>([
+		[
+			'kody.json',
+			JSON.stringify({
+				version: 1,
+				kind: 'job',
+				title: 'TS extension import job',
+				description: 'Preserves repo tsconfig',
+				sourceRoot: '/',
+				entrypoint: 'src/job.ts',
+			}),
+		],
+		['tsconfig.json', repoTsconfig],
+		[
+			'src/job.ts',
+			'export { default } from "./helper.ts"\n',
+		],
+		[
+			'src/helper.ts',
+			'export default async () => ({ ok: true })\n',
+		],
+	])
+	const snapshot = createSnapshotFromFiles(files)
+	const typeScriptFileSystem: MockTypeScriptFileSystem = {
+		...snapshot,
+		write: vi.fn(),
+	}
+	const getSemanticDiagnostics = vi.fn(() => [])
+	mockModule.createFileSystemSnapshot.mockResolvedValue(snapshot)
+	mockModule.createTypescriptLanguageService.mockResolvedValue({
+		fileSystem: typeScriptFileSystem,
+		languageService: {
+			getSemanticDiagnostics,
+		},
+	})
+
+	const result = await runRepoChecks({
+		workspace: {
+			async readFile(path: string) {
+				return files.get(path) ?? null
+			},
+			async glob() {
+				return Array.from(files.keys()).map((path) => ({ path, type: 'file' }))
+			},
+		},
+		manifestPath: 'kody.json',
+		sourceRoot: '/',
+	})
+
+	expect(result.ok).toBe(true)
+	const typecheckInput = mockModule.createTypescriptLanguageService.mock
+		.calls[0]?.[0] as { fileSystem: MockTypeScriptFileSystem }
+	expect(typecheckInput.fileSystem.read('tsconfig.json')).toBe(
+		JSON.stringify({
+			extends: './.__kody_repo_tsconfig_base__.json',
+			compilerOptions: {
+				allowImportingTsExtensions: true,
+				noEmit: true,
+			},
+		}),
+	)
+	expect(
+		typecheckInput.fileSystem.read('.__kody_repo_tsconfig_base__.json'),
+	).toBe(repoTsconfig)
+	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
+		'.__kody_repo_module_check__.ts',
+		expect.stringContaining('import userEntrypoint from "./src/job"'),
+	)
+})

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -480,7 +480,7 @@ test('runRepoChecks typechecks ESM repo-backed job entrypoints', async () => {
 	)
 	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
 		'.__kody_repo_module_check__.ts',
-		expect.stringContaining('import userEntrypoint from "./src/job.ts"'),
+		expect.stringContaining('import userEntrypoint from "./src/job"'),
 	)
 	expect(getSemanticDiagnostics).toHaveBeenCalledWith(
 		'.__kody_repo_module_check__.ts',

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -641,6 +641,9 @@ test('runRepoChecks preserves repo tsconfig via extends while enabling optional 
 	expect(
 		typecheckInput.fileSystem.read('.__kody_repo_tsconfig_base__.json'),
 	).toBe(repoTsconfig)
+	expect(
+		typecheckInput.fileSystem.read('/.__kody_repo_tsconfig_base__.json'),
+	).toBe(repoTsconfig)
 	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
 		'.__kody_repo_module_check__.ts',
 		expect.stringContaining('import userEntrypoint from "./src/job"'),

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -43,34 +43,48 @@ type RepoChecksFileSystem = {
 	flush(): Promise<void>
 }
 
+function normalizeRepoChecksFileSystemPath(path: string) {
+	return path.replace(/^\.?\//, '')
+}
+
 function createRepoChecksFileSystem(input: { fileSystem: RepoChecksFileSystem }) {
 	const overlay = new Map<string, string>()
 	const deleted = new Set<string>()
 
 	return {
 		read(path: string) {
-			if (overlay.has(path)) {
-				return overlay.get(path) ?? null
+			const normalizedPath = normalizeRepoChecksFileSystemPath(path)
+			if (overlay.has(normalizedPath)) {
+				return overlay.get(normalizedPath) ?? null
 			}
-			if (deleted.has(path)) {
+			if (deleted.has(normalizedPath)) {
 				return null
 			}
-			return input.fileSystem.read(path)
+			return input.fileSystem.read(normalizedPath)
 		},
 		write(path: string, content: string) {
-			overlay.set(path, content)
-			deleted.delete(path)
+			const normalizedPath = normalizeRepoChecksFileSystemPath(path)
+			overlay.set(normalizedPath, content)
+			deleted.delete(normalizedPath)
 		},
 		delete(path: string) {
-			overlay.delete(path)
-			deleted.add(path)
+			const normalizedPath = normalizeRepoChecksFileSystemPath(path)
+			overlay.delete(normalizedPath)
+			deleted.add(normalizedPath)
 		},
 		list(prefix?: string) {
+			const normalizedPrefix =
+				prefix === undefined
+					? undefined
+					: normalizeRepoChecksFileSystemPath(prefix)
 			const listed = new Set(
-				input.fileSystem.list(prefix).filter((path) => !deleted.has(path)),
+				input.fileSystem
+					.list(normalizedPrefix)
+					.map((path) => normalizeRepoChecksFileSystemPath(path))
+					.filter((path) => !deleted.has(path)),
 			)
 			for (const path of overlay.keys()) {
-				if (prefix === undefined || path.startsWith(prefix)) {
+				if (normalizedPrefix === undefined || path.startsWith(normalizedPrefix)) {
 					listed.add(path)
 				}
 			}

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -32,6 +32,73 @@ export type RepoCheckRunResult = {
 
 const executeTypecheckPreludePath = '.__kody_repo_runtime__.d.ts'
 const executeSnippetTypecheckHarnessPath = '.__kody_repo_check__.ts'
+const repoChecksSyntheticTsconfigPath = 'tsconfig.json'
+const repoChecksSyntheticTsconfigExtendsPath = './.__kody_repo_tsconfig_base__.json'
+
+type RepoChecksFileSystem = {
+	read(path: string): string | null
+	write(path: string, content: string): void
+	delete(path: string): void
+	list(prefix?: string): Array<string>
+	flush(): Promise<void>
+}
+
+function createRepoChecksFileSystem(input: { fileSystem: RepoChecksFileSystem }) {
+	const overlay = new Map<string, string>()
+	const deleted = new Set<string>()
+
+	return {
+		read(path: string) {
+			if (overlay.has(path)) {
+				return overlay.get(path) ?? null
+			}
+			if (deleted.has(path)) {
+				return null
+			}
+			return input.fileSystem.read(path)
+		},
+		write(path: string, content: string) {
+			overlay.set(path, content)
+			deleted.delete(path)
+		},
+		delete(path: string) {
+			overlay.delete(path)
+			deleted.add(path)
+		},
+		list(prefix?: string) {
+			const listed = new Set(
+				input.fileSystem.list(prefix).filter((path) => !deleted.has(path)),
+			)
+			for (const path of overlay.keys()) {
+				if (prefix === undefined || path.startsWith(prefix)) {
+					listed.add(path)
+				}
+			}
+			return Array.from(listed)
+		},
+		async flush() {},
+	} satisfies RepoChecksFileSystem
+}
+
+function buildRepoChecksTsconfig(
+	baseConfigContent: string | null,
+) {
+	if (baseConfigContent == null) {
+		return JSON.stringify({
+			compilerOptions: {
+				allowImportingTsExtensions: true,
+				noEmit: true,
+			},
+		})
+	}
+	return JSON.stringify({
+		extends: repoChecksSyntheticTsconfigExtendsPath,
+		compilerOptions: {
+			allowImportingTsExtensions: true,
+			noEmit: true,
+		},
+	})
+}
 
 async function* workspaceFilesForSnapshot(input: {
 	workspace: {
@@ -333,8 +400,22 @@ export async function runRepoChecks(input: {
 
 	const { createTypescriptLanguageService } =
 		await import('@cloudflare/worker-bundler/typescript')
-	const { fileSystem, languageService } = await createTypescriptLanguageService({
+	const typecheckFileSystem = createRepoChecksFileSystem({
 		fileSystem: snapshot,
+	})
+	const baseTsconfig = snapshot.read(repoChecksSyntheticTsconfigPath)
+	if (baseTsconfig != null) {
+		typecheckFileSystem.write(
+			repoChecksSyntheticTsconfigExtendsPath.slice('./'.length),
+			baseTsconfig,
+		)
+	}
+	typecheckFileSystem.write(
+		repoChecksSyntheticTsconfigPath,
+		buildRepoChecksTsconfig(baseTsconfig),
+	)
+	const { fileSystem, languageService } = await createTypescriptLanguageService({
+		fileSystem: typecheckFileSystem,
 	})
 	const { fileName, diagnostics, lineOffset } = getRepoTypecheckDiagnostics({
 		manifest,

--- a/packages/worker/src/repo/repo-codemode-execution.node.test.ts
+++ b/packages/worker/src/repo/repo-codemode-execution.node.test.ts
@@ -1,0 +1,51 @@
+import { expect, test, vi } from 'vitest'
+import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
+ 
+const mockModule = vi.hoisted(() => ({
+	createWorker: vi.fn(),
+}))
+ 
+vi.mock('@cloudflare/worker-bundler', () => ({
+	createWorker: (...args: Array<unknown>) => mockModule.createWorker(...args),
+}))
+
+import {
+	buildRepoCodemodeBundle,
+	createRepoCodemodeModuleTypecheckHarness,
+} from './repo-codemode-execution.ts'
+
+test('createRepoCodemodeModuleTypecheckHarness omits TypeScript file extensions from generated imports', () => {
+	const harness = createRepoCodemodeModuleTypecheckHarness({
+		entryPoint: 'src/job.ts',
+	})
+
+	expect(harness).toContain('import userEntrypoint from "./src/job"')
+	expect(harness).not.toContain('./src/job.ts')
+})
+
+test('buildRepoCodemodeBundle emits an extensionless synthetic ESM re-export for TypeScript entrypoints', async () => {
+	mockModule.createWorker.mockReset()
+	mockModule.createWorker.mockResolvedValue({
+		mainModule: 'dist/job.js',
+		modules: {
+			'dist/job.js': 'export default async () => ({ ok: true })\n',
+		} satisfies WorkerLoaderModules,
+	})
+
+	const bundle = await buildRepoCodemodeBundle({
+		sourceFiles: {
+			'src/job.ts': 'export default async () => ({ ok: true })\n',
+		},
+		entryPoint: 'src/job.ts',
+		entryPointSource: 'export default async () => ({ ok: true })\n',
+	})
+
+	expect(bundle.entrypointMode).toBe('module')
+	expect(mockModule.createWorker).toHaveBeenCalledWith({
+		files: {
+			'src/job.ts': 'export default async () => ({ ok: true })\n',
+			'.__kody_repo_user_entry__.ts': 'export { default } from "./src/job";\n',
+		},
+		entryPoint: '.__kody_repo_user_entry__.ts',
+	})
+})

--- a/packages/worker/src/repo/repo-codemode-execution.ts
+++ b/packages/worker/src/repo/repo-codemode-execution.ts
@@ -17,6 +17,7 @@ const repoCodemodeBundleCacheLimit = 50
 const repoCodemodeSourceReadConcurrency = 8
 const repoCodemodeSourceMaxFiles = 250
 const repoCodemodeSourceMaxBytes = 2 * 1024 * 1024
+const repoCodemodeImportExtensionPattern = /\.(?:[cm]?[jt]s|[jt]sx)$/
 const repoCodemodeBundleCache = new Map<
 	string,
 	Promise<{
@@ -49,7 +50,11 @@ export function hasModuleStyleRepoBackedEntrypoint(code: string) {
 }
 
 function createRelativeImportSpecifier(path: string) {
-	return JSON.stringify(`./${path}`)
+	const normalizedPath = normalizeRepoWorkspacePath(path).replace(
+		repoCodemodeImportExtensionPattern,
+		'',
+	)
+	return JSON.stringify(`./${normalizedPath}`)
 }
 
 function toRelativeSourcePath(path: string, sourceRoot: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- stop Kody-generated repo-backed ESM harness and synthetic entrypoint imports from ending in `.ts`
- keep migrated saved job/skill artifacts unchanged while making repo checks and bundling migration-safe
- allow repo-backed typecheck to accept user-authored `.ts` relative imports without making them required by overlaying a synthetic root `tsconfig.json` for repo checks only
- normalize repo-check overlay filesystem paths so TypeScript `extends` resolution works for `./...` and `/...` lookups of the synthetic base tsconfig
- add focused regression coverage for repo checks and repo codemode bundling helpers

## Validation
- `npx vitest run --config vitest.node.config.ts packages/worker/src/repo/checks.node.test.ts packages/worker/src/repo/repo-codemode-execution.node.test.ts`
- `npx vitest run --config vitest.node.config.ts packages/worker/src/jobs/service.node.test.ts -t "ESM repo-backed job entrypoints"`
- `npx vitest run --config vitest.node.config.ts packages/worker/src/mcp/skills/run-saved-skill.node.test.ts`
- `npx vitest run --config vitest.node.config.ts packages/worker/src/repo/checks.node.test.ts`
- `npm run typecheck`
- direct TypeScript proof of optional `.ts` import support:
  - with `allowImportingTsExtensions: true` + `noEmit: true`: both `import "./job.ts"` and `import "./job"` pass
  - without `allowImportingTsExtensions`: `import "./job.ts"` fails with `TS5097`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-887eaee7-8cf1-4ffa-be7f-5729cb3a9932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-887eaee7-8cf1-4ffa-be7f-5729cb3a9932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration and unit tests validating module import formatting and end-to-end codemode bundling behavior.
  * Updated typecheck tests to assert extensionless import paths in generated module-check files.

* **Refactor**
  * Import specifier generation now normalizes paths and strips .ts/.tsx/.js/.jsx extensions for emitted ESM imports/exports.
  * Typecheck flow uses an overlay config mechanism that produces a noEmit TS config with importing-extensions enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->