### PR TITLE
Fix Artifacts session repo git auth

### DIFF
--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, expect, test, vi } from 'vitest'
 
 const {
+	buildArtifactsGitAuth,
 	getArtifactsBinding,
+	parseArtifactTokenSecret,
 	resolveArtifactSourceRepo,
 } = await import('./artifacts.ts')
 
@@ -232,4 +234,16 @@ test('artifacts REST client rejects tokens without parseable expiry timestamps',
 		'Artifacts token is missing a parseable expires timestamp.',
 	)
 	expect(fetchMock).toHaveBeenCalledTimes(1)
+})
+
+test('artifacts git auth uses x username and strips expiry from password', () => {
+	expect(parseArtifactTokenSecret('art_v1_secret?expires=1760000100')).toBe(
+		'art_v1_secret',
+	)
+	expect(buildArtifactsGitAuth({ token: 'art_v1_secret?expires=1760000100' })).toEqual(
+		{
+			username: 'x',
+			password: 'art_v1_secret',
+		},
+	)
 })

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -431,17 +431,24 @@ export function parseArtifactTokenSecret(token: string) {
 	return token.split('?expires=')[0] ?? token
 }
 
+export function buildArtifactsGitAuth(input: { token: string }) {
+	return {
+		username: 'x',
+		password: parseArtifactTokenSecret(input.token),
+	}
+}
+
 export function buildAuthenticatedArtifactsRemote(input: {
 	remote: string
 	token: string
 }) {
-	const tokenSecret = parseArtifactTokenSecret(input.token)
 	const remoteUrl = new URL(input.remote)
 	if (remoteUrl.protocol !== 'https:') {
 		throw new Error(`Artifact remote must use https://, got: ${input.remote}`)
 	}
-	remoteUrl.username = 'x'
-	remoteUrl.password = tokenSecret
+	const auth = buildArtifactsGitAuth({ token: input.token })
+	remoteUrl.username = auth.username
+	remoteUrl.password = auth.password
 	return remoteUrl.toString()
 }
 

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -1,0 +1,280 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => {
+	const gitState = {
+		currentBranch: 'main',
+		headCommit: 'commit-head',
+		statusEntries: [] as Array<{ status: string }>,
+		remotes: [] as Array<{ remote: string; url: string }>,
+	}
+
+	const git = {
+		clone: vi.fn(async () => ({ cloned: 'ok', dir: '/session' })),
+		remote: vi.fn(async (opts?: {
+			list?: boolean
+			add?: { name: string; url: string }
+			remove?: string
+		}) => {
+			if (opts?.list) {
+				return gitState.remotes
+			}
+			if (opts?.remove) {
+				gitState.remotes = gitState.remotes.filter(
+					(remote) => remote.remote !== opts.remove,
+				)
+				return { removed: opts.remove }
+			}
+			if (opts?.add) {
+				gitState.remotes = [
+					...gitState.remotes.filter(
+						(remote) => remote.remote !== opts.add?.name,
+					),
+					{ remote: opts.add.name, url: opts.add.url },
+				]
+				return { added: opts.add.name, url: opts.add.url }
+			}
+			return []
+		}),
+		init: vi.fn(async () => ({ initialized: '/session' })),
+		status: vi.fn(async () => gitState.statusEntries),
+		add: vi.fn(async () => ({ added: '.' })),
+		commit: vi.fn(async () => ({ oid: gitState.headCommit, message: 'commit' })),
+		log: vi.fn(async () => [{ oid: gitState.headCommit }]),
+		branch: vi.fn(async () => ({
+			branches: [gitState.currentBranch],
+			current: gitState.currentBranch,
+		})),
+		pull: vi.fn(async () => ({ pulled: true })),
+		push: vi.fn(async () => ({ ok: true, refs: {} })),
+	}
+
+	return {
+		git,
+		gitState,
+		workspaceExists: vi.fn(async (path: string) => path === '/session/.git/config'),
+		workspaceReadFile: vi.fn(async () => '{"version":1,"kind":"app"}'),
+		workspaceWriteFile: vi.fn(async () => undefined),
+		workspaceMkdir: vi.fn(async () => undefined),
+		workspaceRm: vi.fn(async () => undefined),
+		workspaceGlob: vi.fn(async () => []),
+		storageGet: vi.fn(async () => ({
+			runId: 'run-1',
+			treeHash: '',
+			checkedAt: '2026-04-18T00:00:00.000Z',
+			ok: true,
+			results: [],
+		})),
+		storagePut: vi.fn(async () => undefined),
+		getRepoSessionById: vi.fn(),
+		getEntitySourceById: vi.fn(),
+		updateRepoSession: vi.fn(async () => undefined),
+		updateEntitySource: vi.fn(async () => undefined),
+		resolveSessionRepo: vi.fn(),
+		resolveArtifactSourceRepo: vi.fn(),
+		parseRepoManifest: vi.fn(() => ({ sourceRoot: '/' })),
+	}
+})
+
+vi.mock('@cloudflare/shell', () => ({
+	Workspace: class {
+		constructor(_options: unknown) {}
+		exists(path: string) {
+			return mockModule.workspaceExists(path)
+		}
+		readFile(path: string) {
+			return mockModule.workspaceReadFile(path)
+		}
+		writeFile(path: string, content: string) {
+			return mockModule.workspaceWriteFile(path, content)
+		}
+		mkdir(path: string, options: unknown) {
+			return mockModule.workspaceMkdir(path, options)
+		}
+		rm(path: string, options: unknown) {
+			return mockModule.workspaceRm(path, options)
+		}
+		glob(pattern: string) {
+			return mockModule.workspaceGlob(pattern)
+		}
+	},
+	WorkspaceFileSystem: class {
+		constructor(_workspace: unknown) {}
+	},
+	createWorkspaceStateBackend: vi.fn(() => ({
+		planEdits: vi.fn(),
+		applyEditPlan: vi.fn(),
+		walkTree: vi.fn(),
+	})),
+}))
+
+vi.mock('@cloudflare/shell/git', () => ({
+	createGit: vi.fn(() => mockModule.git),
+}))
+
+vi.mock('./repo-sessions.ts', () => ({
+	getRepoSessionById: (...args: Array<unknown>) =>
+		mockModule.getRepoSessionById(...args),
+	insertRepoSession: vi.fn(async () => undefined),
+	updateRepoSession: (...args: Array<unknown>) =>
+		mockModule.updateRepoSession(...args),
+	deleteRepoSession: vi.fn(async () => undefined),
+}))
+
+vi.mock('./entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+	updateEntitySource: (...args: Array<unknown>) =>
+		mockModule.updateEntitySource(...args),
+}))
+
+vi.mock('./artifacts.ts', async () => {
+	const actual = await vi.importActual<typeof import('./artifacts.ts')>(
+		'./artifacts.ts',
+	)
+	return {
+		...actual,
+		resolveSessionRepo: (...args: Array<unknown>) =>
+			mockModule.resolveSessionRepo(...args),
+		resolveArtifactSourceRepo: (...args: Array<unknown>) =>
+			mockModule.resolveArtifactSourceRepo(...args),
+	}
+})
+
+vi.mock('./manifest.ts', () => ({
+	parseRepoManifest: (...args: Array<unknown>) => mockModule.parseRepoManifest(...args),
+}))
+
+const { RepoSession } = await import('./repo-session-do.ts')
+
+function createDurableObjectState() {
+	return {
+		id: { toString: () => 'do-session-1' },
+		storage: {
+			sql: {},
+			get: mockModule.storageGet,
+			put: mockModule.storagePut,
+		},
+	} as unknown as DurableObjectState
+}
+
+function createEnv() {
+	return {
+		APP_DB: {},
+	} as Env
+}
+
+function setCommonSessionFixtures() {
+	mockModule.getRepoSessionById.mockResolvedValue({
+		id: 'session-1',
+		user_id: 'user-1',
+		source_id: 'source-1',
+		session_repo_namespace: 'default',
+		session_repo_name: 'session-repo',
+		base_commit: 'commit-base',
+		last_checkpoint_commit: 'commit-base',
+	})
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		repo_id: 'source-repo',
+		published_commit: 'commit-base',
+		manifest_path: 'kody.json',
+		source_root: '/',
+	})
+	mockModule.resolveSessionRepo.mockResolvedValue({
+		info: vi.fn(async () => ({
+			remote: 'https://acct.artifacts.cloudflare.net/git/default/session-repo.git',
+		})),
+		createToken: vi.fn(async () => ({
+			plaintext: 'art_session_secret?expires=1760000200',
+		})),
+	})
+	mockModule.resolveArtifactSourceRepo.mockResolvedValue({
+		info: vi.fn(async () => ({
+			defaultBranch: 'main',
+			remote: 'https://acct.artifacts.cloudflare.net/git/default/source-repo.git',
+		})),
+		createToken: vi.fn(async () => ({
+			plaintext: 'art_source_secret?expires=1760000100',
+		})),
+	})
+	mockModule.gitState.currentBranch = 'main'
+	mockModule.gitState.headCommit = 'commit-head'
+	mockModule.gitState.statusEntries = []
+	mockModule.gitState.remotes = [
+		{
+			remote: 'origin',
+			url: 'https://acct.artifacts.cloudflare.net/git/default/session-repo.git',
+		},
+	]
+	mockModule.git.pull.mockClear()
+	mockModule.git.push.mockClear()
+	mockModule.updateRepoSession.mockClear()
+	mockModule.updateEntitySource.mockClear()
+}
+
+test('rebaseSession uses Artifacts username/password auth without token override', async () => {
+	setCommonSessionFixtures()
+	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
+
+	await repoSession.rebaseSession({
+		sessionId: 'session-1',
+		userId: 'user-1',
+	})
+
+	expect(mockModule.git.pull).toHaveBeenCalledWith(
+		expect.objectContaining({
+			remote: 'source',
+			ref: 'main',
+			username: 'x',
+			password: 'art_source_secret',
+		}),
+	)
+	expect(mockModule.git.pull).toHaveBeenCalledWith(
+		expect.not.objectContaining({ token: expect.anything() }),
+	)
+	expect(mockModule.git.push).toHaveBeenCalledWith(
+		expect.objectContaining({
+			remote: 'origin',
+			ref: 'main',
+			username: 'x',
+			password: 'art_session_secret',
+		}),
+	)
+	expect(mockModule.git.push).toHaveBeenCalledWith(
+		expect.not.objectContaining({ token: expect.anything() }),
+	)
+})
+
+test('publishSession uses Artifacts username/password auth for both origin and source pushes', async () => {
+	setCommonSessionFixtures()
+	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
+
+	await repoSession.publishSession({
+		sessionId: 'session-1',
+		userId: 'user-1',
+	})
+
+	expect(mockModule.git.push).toHaveBeenCalledTimes(2)
+	expect(mockModule.git.push).toHaveBeenNthCalledWith(
+		1,
+		expect.objectContaining({
+			remote: 'origin',
+			ref: 'main',
+			username: 'x',
+			password: 'art_session_secret',
+		}),
+	)
+	expect(mockModule.git.push).toHaveBeenNthCalledWith(
+		2,
+		expect.objectContaining({
+			remote: 'source',
+			ref: 'main',
+			username: 'x',
+			password: 'art_source_secret',
+		}),
+	)
+	for (const call of mockModule.git.push.mock.calls) {
+		expect(call[0]).not.toHaveProperty('token')
+	}
+})

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -75,6 +75,22 @@ const mockModule = vi.hoisted(() => {
 	}
 })
 
+vi.mock('cloudflare:workers', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('cloudflare:workers')>()
+	return {
+		...actual,
+		DurableObject: class {
+			protected readonly ctx: DurableObjectState
+			protected readonly env: Env
+
+			constructor(ctx: DurableObjectState, env: Env) {
+				this.ctx = ctx
+				this.env = env
+			}
+		},
+	}
+})
+
 vi.mock('@cloudflare/shell', () => ({
 	Workspace: class {
 		constructor(_options: unknown) {}
@@ -253,6 +269,7 @@ test('publishSession uses Artifacts username/password auth for both origin and s
 	await repoSession.publishSession({
 		sessionId: 'session-1',
 		userId: 'user-1',
+		force: true,
 	})
 
 	expect(mockModule.git.push).toHaveBeenCalledTimes(2)

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -15,6 +15,7 @@ import {
 import {
 	type ArtifactBootstrapAccess,
 	type ArtifactRepoInfo,
+	buildArtifactsGitAuth,
 	buildAuthenticatedArtifactsRemote,
 	resolveArtifactSourceRepo,
 	resolveSessionRepo,
@@ -87,11 +88,9 @@ async function ensureArtifactRepoRemote(input: {
 }
 
 function buildGitCloneAuth(input: { remote: string; token: string }) {
-	const tokenSecret = input.token.split('?expires=')[0] ?? input.token
 	return {
 		url: input.remote,
-		username: 'x',
-		password: tokenSecret,
+		...buildArtifactsGitAuth({ token: input.token }),
 	}
 }
 
@@ -592,9 +591,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			dir: repoSessionWorkspacePrefix,
 			remote: 'source',
 			ref: targetBranch,
-			token: sourceAccess.token,
-			username: 'x',
-			password: sourceAccess.token.split('?expires=')[0] ?? sourceAccess.token,
+			...buildArtifactsGitAuth({ token: sourceAccess.token }),
 		})
 		await updateEntitySource(this.env.APP_DB, {
 			id: source.id,
@@ -908,19 +905,14 @@ class RepoSessionBase extends DurableObject<Env> {
 			remote: 'source',
 			ref: defaultBranch,
 			author: sessionCommitAuthor,
-			token: sourceAccess.token,
-			username: 'x',
-			password: sourceAccess.token.split('?expires=')[0] ?? sourceAccess.token,
+			...buildArtifactsGitAuth({ token: sourceAccess.token }),
 		})
 		const headCommit = await this.getHeadCommit()
 		await this.git.push({
 			dir: repoSessionWorkspacePrefix,
 			remote: 'origin',
 			ref: defaultBranch,
-			token: sessionAccess.token,
-			username: 'x',
-			password:
-				sessionAccess.token.split('?expires=')[0] ?? sessionAccess.token,
+			...buildArtifactsGitAuth({ token: sessionAccess.token }),
 		})
 		await updateRepoSession(this.env.APP_DB, {
 			id: sessionRow.id,
@@ -986,10 +978,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			ref: await this.getCurrentBranch(
 				sourceInfo?.defaultBranch ?? defaultSessionBranch,
 			),
-			token: sessionAccess.token,
-			username: 'x',
-			password:
-				sessionAccess.token.split('?expires=')[0] ?? sessionAccess.token,
+			...buildArtifactsGitAuth({ token: sessionAccess.token }),
 		})
 		await this.ensureRemote({
 			name: 'source',
@@ -1003,9 +992,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			dir: repoSessionWorkspacePrefix,
 			remote: 'source',
 			ref: targetBranch,
-			token: sourceAccess.token,
-			username: 'x',
-			password: sourceAccess.token.split('?expires=')[0] ?? sourceAccess.token,
+			...buildArtifactsGitAuth({ token: sourceAccess.token }),
 		})
 		const manifest = await this.readManifestFromWorkspace(source.manifest_path)
 		await updateEntitySource(this.env.APP_DB, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- stop passing Artifacts tokens through `@cloudflare/shell`'s `token` option on repo-session clone/pull/push paths
- centralize Artifacts git credentials in a helper that always uses username `x` with the token secret as the password
- add focused regression tests for the helper and the repo-session publish/rebase git auth flow

## Testing
- `npx vitest run --project node-unit packages/worker/src/repo/artifacts.node.test.ts packages/worker/src/repo/repo-session-do.node.test.ts`
- `npm run typecheck`

## Notes
- I verified in the installed dependency (`node_modules/@cloudflare/shell/dist/git/index.js`) that passing `token` to `push`/`pull` rewrites auth to `username=<token>, password=x-oauth-basic`, which is incompatible with Artifacts' `x:<tokenSecret>` auth shape and explains the 401s on session-repo pushes.
- A live Artifacts git push smoke test was not possible in this environment because `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, and `CLOUDFLARE_API_BASE_URL` are unset here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c70027ae-07c3-4c76-9b32-523b3b4c88d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c70027ae-07c3-4c76-9b32-523b3b4c88d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for artifact token parsing and Git authentication credential construction.
  * Added integration tests verifying Git operations use proper authentication with credentials derived from artifact tokens.

* **Refactor**
  * Consolidated Git authentication logic into a shared helper for consistent credential construction across all Git operations.
  * Simplified Git operations (clone, push, pull) to use unified authentication handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->