### PR TITLE
Fix recurring job repo session reuse

### DIFF
--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -1018,8 +1018,17 @@ test('executeJobOnce refreshes repo sessions when base commit moves', async () =
 			logs: ['repo-backed codemode executed'],
 		})
 		expect(sessionClient.openSession).toHaveBeenCalledTimes(2)
+		const firstOpenSessionId = sessionClient.openSession.mock.calls[0]?.[0]?.sessionId
+		const secondOpenSessionId =
+			sessionClient.openSession.mock.calls[1]?.[0]?.sessionId
+		expect(firstOpenSessionId).toMatch(/^job-runtime-job-repo-1-/)
+		expect(secondOpenSessionId).toBe(firstOpenSessionId)
 		expect(sessionClient.discardSession).toHaveBeenCalledWith({
 			sessionId: 'job-runtime-job-repo-1',
+			userId: 'user-123',
+		})
+		expect(sessionClient.discardSession).toHaveBeenCalledWith({
+			sessionId: firstOpenSessionId,
 			userId: 'user-123',
 		})
 		expect(sessionClient.readFile).toHaveBeenCalledWith({
@@ -1887,7 +1896,10 @@ test('executeJobOnce bundles and runs ESM repo-backed job entrypoints', async ()
 				writable: true,
 			},
 		})
-		expect(sessionClient.discardSession).not.toHaveBeenCalled()
+		expect(sessionClient.discardSession).toHaveBeenCalledWith({
+			sessionId: expect.stringMatching(/^job-runtime-job-repo-module-/),
+			userId: 'user-123',
+		})
 	} finally {
 		repoSessionRpcSpy.mockRestore()
 		executeSpy.mockRestore()

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -1896,8 +1896,10 @@ test('executeJobOnce bundles and runs ESM repo-backed job entrypoints', async ()
 				writable: true,
 			},
 		})
+		const openedSessionId = sessionClient.openSession.mock.calls[0]?.[0]?.sessionId
+		expect(openedSessionId).toMatch(/^job-runtime-job-repo-module-/)
 		expect(sessionClient.discardSession).toHaveBeenCalledWith({
-			sessionId: expect.stringMatching(/^job-runtime-job-repo-module-/),
+			sessionId: openedSessionId,
 			userId: 'user-123',
 		})
 	} finally {

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -503,6 +503,7 @@ async function runRepoBackedJob(input: {
 		baseUrl: input.callerContext.baseUrl,
 		sourceRoot: null,
 	}
+	let bypassLogs: Array<string> = []
 	try {
 		let session = await sessionClient.openSession(openSessionInput)
 		if (repoSessionNeedsRefresh(session)) {
@@ -545,7 +546,7 @@ async function runRepoBackedJob(input: {
 				logs: gate.logs,
 			}
 		}
-		const bypassLogs = [...gate.logs]
+		bypassLogs = [...gate.logs]
 		const manifestPath = session.manifest_path?.replace(/^\/+/, '') || 'kody.json'
 		const entrypoint = await sessionClient.readFile({
 			sessionId: session.id,
@@ -658,18 +659,17 @@ async function runRepoBackedJob(input: {
 		return {
 			error: formatJobError(error),
 			result: null,
-			logs: [],
+			logs: bypassLogs,
 		}
 	} finally {
-		await Promise.resolve(
-			sessionClient.discardSession({
+		try {
+			await sessionClient.discardSession({
 				sessionId,
 				userId: input.callerContext.user.userId,
-			}),
-		)
-			.catch(() => {
-				// Best effort only; preserve the original execution failure.
 			})
+		} catch {
+			// Best effort only; preserve the original execution failure.
+		}
 	}
 }
 

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -158,6 +158,10 @@ function repoSessionNeedsRefresh(session: {
 	)
 }
 
+function createJobRuntimeSessionId(jobId: string) {
+	return `job-runtime-${jobId}-${crypto.randomUUID()}`
+}
+
 function resolveCreateShape(input: JobCreateInput) {
 	return {
 		moduleSource: normalizeJobCode(input.code),
@@ -449,7 +453,10 @@ export async function executeJobOnce(input: {
 			execution = result.error
 				? {
 						ok: false,
-						error: formatJobError(result.error),
+						error:
+							typeof result.error === 'string'
+								? result.error
+								: formatJobError(result.error),
 						logs: result.logs ?? [],
 					}
 				: {
@@ -487,7 +494,7 @@ async function runRepoBackedJob(input: {
 			logs: [],
 		}
 	}
-	const sessionId = `job-runtime-${input.job.id}`
+	const sessionId = createJobRuntimeSessionId(input.job.id)
 	const sessionClient = repoSessionRpc(input.env, sessionId)
 	const openSessionInput = {
 		sessionId,
@@ -496,155 +503,173 @@ async function runRepoBackedJob(input: {
 		baseUrl: input.callerContext.baseUrl,
 		sourceRoot: null,
 	}
-	let session = await sessionClient.openSession(openSessionInput)
-	if (repoSessionNeedsRefresh(session)) {
-		const stalePublishedCommit = session.published_commit
-		try {
-			await sessionClient.discardSession({
-				sessionId: session.id,
-				userId: input.callerContext.user.userId,
-			})
-		} catch (error) {
-			throw new Error(
-				`Failed to discard stale repo session "${session.id}" before refreshing to published commit "${stalePublishedCommit}".`,
-				{ cause: error },
-			)
-		}
-		session = await sessionClient.openSession(openSessionInput)
+	try {
+		let session = await sessionClient.openSession(openSessionInput)
 		if (repoSessionNeedsRefresh(session)) {
-			throw new Error(
-				`Repo session "${session.id}" still points at base commit "${session.base_commit}" instead of published commit "${session.published_commit}".`,
-			)
+			const stalePublishedCommit = session.published_commit
+			try {
+				await sessionClient.discardSession({
+					sessionId: session.id,
+					userId: input.callerContext.user.userId,
+				})
+			} catch (error) {
+				throw new Error(
+					`Failed to discard stale repo session "${session.id}" before refreshing to published commit "${stalePublishedCommit}".`,
+					{ cause: error },
+				)
+			}
+			session = await sessionClient.openSession(openSessionInput)
+			if (repoSessionNeedsRefresh(session)) {
+				throw new Error(
+					`Repo session "${session.id}" still points at base commit "${session.base_commit}" instead of published commit "${session.published_commit}".`,
+				)
+			}
 		}
-	}
-	const result = await sessionClient.runChecks({
-		sessionId: session.id,
-		userId: input.callerContext.user.userId,
-	})
-	const gate = evaluateRepoCheckGate({
-		result,
-		policy: resolveJobRepoCheckPolicy({
-			stored: input.job.repoCheckPolicy,
-			override: input.repoCheckPolicyOverride,
-		}),
-		jobId: input.job.id,
-		sourceId: input.job.sourceId,
-	})
-	if (!gate.proceed) {
-		return {
-			error: gate.error ?? 'Repo checks failed.',
-			result: null,
-			logs: gate.logs,
-		}
-	}
-	const bypassLogs = [...gate.logs]
-	const manifestPath = session.manifest_path?.replace(/^\/+/, '') || 'kody.json'
-	const entrypoint = await sessionClient.readFile({
-		sessionId: session.id,
-		userId: input.callerContext.user.userId,
-		path: manifestPath,
-	})
-	if (!entrypoint.content) {
-		return {
-			error: `Job manifest "${manifestPath}" was not found in repo session.`,
-			result: null,
-			logs: bypassLogs,
-		}
-	}
-	let manifest: ReturnType<typeof parseRepoManifest>
-	try {
-		manifest = parseRepoManifest({
-			content: entrypoint.content,
-			manifestPath,
-		})
-	} catch (error) {
-		return {
-			error: error instanceof Error ? error.message : String(error),
-			result: null,
-			logs: bypassLogs,
-		}
-	}
-	if (manifest.kind !== 'job') {
-		return {
-			error: `Repo source "${input.job.sourceId}" is not a job manifest.`,
-			result: null,
-			logs: bypassLogs,
-		}
-	}
-	const moduleFile = await sessionClient.readFile({
-		sessionId: session.id,
-		userId: input.callerContext.user.userId,
-		path: getManifestEntrypointPath(manifest),
-	})
-	if (!moduleFile.content) {
-		return {
-			error: `Job entrypoint "${manifest.entrypoint}" was not found in repo session.`,
-			result: null,
-			logs: bypassLogs,
-		}
-	}
-	try {
-		const { runCodemodeWithRegistry } =
-			await import('#mcp/run-codemode-registry.ts')
-		const sourceRoot = getManifestSourceRoot(manifest)
-		const sourceFiles = await loadRepoSourceFilesFromSession({
-			sessionClient,
+		const result = await sessionClient.runChecks({
 			sessionId: session.id,
 			userId: input.callerContext.user.userId,
-			sourceRoot,
 		})
-		const bundled = await buildRepoCodemodeBundle({
-			sourceFiles,
-			entryPoint: getManifestEntrypointPath(manifest),
-			entryPointSource: moduleFile.content,
-			sourceRoot,
-			cacheKey:
-				session.published_commit != null
-					? `${input.job.sourceId}:${session.published_commit}`
-					: null,
-		})
-		const executionResult = await runCodemodeWithRegistry(
-			input.env,
-			{
-				...input.callerContext,
-				repoContext: {
-					sourceId: session.source_id,
-					repoId: null,
-					sessionId: session.id,
-					sessionRepoId: session.session_repo_id,
-					baseCommit: session.base_commit,
-					manifestPath: session.manifest_path,
-					sourceRoot: session.source_root,
-					publishedCommit: session.published_commit,
-					entityKind: session.entity_type,
-					entityId: input.job.id,
-				},
-			},
-			createRepoCodemodeWrapper({
-				mainModule: bundled.mainModule,
-				includeStorage: true,
+		const gate = evaluateRepoCheckGate({
+			result,
+			policy: resolveJobRepoCheckPolicy({
+				stored: input.job.repoCheckPolicy,
+				override: input.repoCheckPolicyOverride,
 			}),
-			input.job.params,
-			{
-				executorExports: workerExports,
-				storageTools: {
-					userId: input.callerContext.user.userId,
-					storageId: input.job.storageId,
-					writable: true,
+			jobId: input.job.id,
+			sourceId: input.job.sourceId,
+		})
+		if (!gate.proceed) {
+			return {
+				error: gate.error ?? 'Repo checks failed.',
+				result: null,
+				logs: gate.logs,
+			}
+		}
+		const bypassLogs = [...gate.logs]
+		const manifestPath = session.manifest_path?.replace(/^\/+/, '') || 'kody.json'
+		const entrypoint = await sessionClient.readFile({
+			sessionId: session.id,
+			userId: input.callerContext.user.userId,
+			path: manifestPath,
+		})
+		if (!entrypoint.content) {
+			return {
+				error: `Job manifest "${manifestPath}" was not found in repo session.`,
+				result: null,
+				logs: bypassLogs,
+			}
+		}
+		let manifest: ReturnType<typeof parseRepoManifest>
+		try {
+			manifest = parseRepoManifest({
+				content: entrypoint.content,
+				manifestPath,
+			})
+		} catch (error) {
+			return {
+				error: error instanceof Error ? error.message : String(error),
+				result: null,
+				logs: bypassLogs,
+			}
+		}
+		if (manifest.kind !== 'job') {
+			return {
+				error: `Repo source "${input.job.sourceId}" is not a job manifest.`,
+				result: null,
+				logs: bypassLogs,
+			}
+		}
+		const moduleFile = await sessionClient.readFile({
+			sessionId: session.id,
+			userId: input.callerContext.user.userId,
+			path: getManifestEntrypointPath(manifest),
+		})
+		if (!moduleFile.content) {
+			return {
+				error: `Job entrypoint "${manifest.entrypoint}" was not found in repo session.`,
+				result: null,
+				logs: bypassLogs,
+			}
+		}
+		try {
+			const { runCodemodeWithRegistry } =
+				await import('#mcp/run-codemode-registry.ts')
+			const sourceRoot = getManifestSourceRoot(manifest)
+			const sourceFiles = await loadRepoSourceFilesFromSession({
+				sessionClient,
+				sessionId: session.id,
+				userId: input.callerContext.user.userId,
+				sourceRoot,
+			})
+			const bundled = await buildRepoCodemodeBundle({
+				sourceFiles,
+				entryPoint: getManifestEntrypointPath(manifest),
+				entryPointSource: moduleFile.content,
+				sourceRoot,
+				cacheKey:
+					session.published_commit != null
+						? `${input.job.sourceId}:${session.published_commit}`
+						: null,
+			})
+			const executionResult = await runCodemodeWithRegistry(
+				input.env,
+				{
+					...input.callerContext,
+					repoContext: {
+						sourceId: session.source_id,
+						repoId: null,
+						sessionId: session.id,
+						sessionRepoId: session.session_repo_id,
+						baseCommit: session.base_commit,
+						manifestPath: session.manifest_path,
+						sourceRoot: session.source_root,
+						publishedCommit: session.published_commit,
+						entityKind: session.entity_type,
+						entityId: input.job.id,
+					},
 				},
-				executorModules: bundled.modules,
-			},
-		)
-		return {
-			...executionResult,
-			logs: [...bypassLogs, ...(executionResult.logs ?? [])],
+				createRepoCodemodeWrapper({
+					mainModule: bundled.mainModule,
+					includeStorage: true,
+				}),
+				input.job.params,
+				{
+					executorExports: workerExports,
+					storageTools: {
+						userId: input.callerContext.user.userId,
+						storageId: input.job.storageId,
+						writable: true,
+					},
+					executorModules: bundled.modules,
+				},
+			)
+			return {
+				...executionResult,
+				logs: [...bypassLogs, ...(executionResult.logs ?? [])],
+			}
+		} catch (error) {
+			return {
+				error: formatJobError(error),
+				result: null,
+				logs: bypassLogs,
+			}
 		}
 	} catch (error) {
 		return {
 			error: formatJobError(error),
 			result: null,
-			logs: bypassLogs,
+			logs: [],
 		}
+	} finally {
+		await Promise.resolve(
+			sessionClient.discardSession({
+				sessionId,
+				userId: input.callerContext.user.userId,
+			}),
+		)
+			.catch(() => {
+				// Best effort only; preserve the original execution failure.
+			})
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix repo-backed recurring job execution to use unique runtime repo session ids
- preserve repo-check bypass audit logs across outer-scope runtime failures
- clean up best-effort session discard handling and tighten cleanup assertions in focused tests

## Validation
- `npx vitest run packages/worker/src/jobs/service.node.test.ts`
- `npm run typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9850f6f8-f660-41ad-ab9e-f4779a69eef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9850f6f8-f660-41ad-ab9e-f4779a69eef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session management and cleanup for job execution to ensure reliable resource cleanup
  * Enhanced error handling for job execution failures with more consistent formatting

* **Tests**
  * Updated tests to verify proper session lifecycle management and cleanup behavior during job execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->