### PR TITLE
Improve saved app backend ergonomics

### DIFF
--- a/docs/guides/generated-ui-oauth.md
+++ b/docs/guides/generated-ui-oauth.md
@@ -56,10 +56,10 @@ of treating it like a secret.
 
 Once the connector or tokens exist and the post-connect smoke test passes,
 prefer to continue with a saved app that uses `serverCode` backend endpoints for
-provider API calls and `clientCode` fetches through
-`kodyWidget.appBackend.basePath`. Keep embedded client-side `executeCode(...)`
-strings for quick prototypes or throwaway experiments, not the default
-integration-backed app structure.
+provider API calls and `clientCode` requests through
+`kodyWidget.appBackend.fetch(...)`. Keep embedded client-side
+`executeCode(...)` strings for quick prototypes or throwaway experiments, not
+the default integration-backed app structure.
 
 ## Recommended capability and tool sequence
 

--- a/docs/guides/integration-backed-app-happy-path.md
+++ b/docs/guides/integration-backed-app-happy-path.md
@@ -19,8 +19,7 @@ quickly.
 4. If the smoke test passes, proceed directly to building the app.
    - Prefer a saved app with `serverCode` backend endpoints such as `/api/state`
      and `/api/action`.
-   - Keep `clientCode` mostly UI plus `fetch(...)` calls to
-     `kodyWidget.appBackend.basePath`.
+   - Keep `clientCode` mostly UI plus `kodyWidget.appBackend.fetch(...)` calls.
 5. Open the saved app and iterate.
    - Save with `ui_save_app`.
    - Reopen with `open_generated_ui({ app_id })`.

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -95,7 +95,7 @@ The ordering is:
 1. auth bootstrap first
 2. smoke test second
 3. save the app with `serverCode` backend routes
-4. keep `clientCode` mostly UI plus fetches to `kodyWidget.appBackend.basePath`
+4. keep `clientCode` mostly UI plus `kodyWidget.appBackend.fetch(...)`
 
 For non-trivial apps, keep provider API calls in `serverCode`, not in embedded
 client-side `executeCode(...)` strings. Those inline snippets are acceptable for
@@ -119,19 +119,18 @@ await codemode.ui_save_app({
 				import { kodyWidget } from '@kody/ui-utils'
 
 				const track = document.querySelector('#track')
-				const basePath = kodyWidget.appBackend?.basePath
-				function requireBackendBasePath() {
-					if (!basePath) {
+				function requireBackend() {
+					if (!kodyWidget.appBackend) {
 						track.textContent = 'Saved app backend is not available.'
 						return null
 					}
-					return basePath
+					return kodyWidget.appBackend
 				}
 
 				async function loadState() {
-					const resolvedBasePath = requireBackendBasePath()
-					if (!resolvedBasePath) return
-					const response = await fetch(\`\${resolvedBasePath}/api/state\`)
+					const backend = requireBackend()
+					if (!backend) return
+					const response = await backend.fetch('/api/state')
 					const payload = await response.json()
 					track.textContent = payload.trackName
 						? \`\${payload.trackName} — \${payload.artistName}\`
@@ -139,9 +138,9 @@ await codemode.ui_save_app({
 				}
 
 				async function runAction(action) {
-					const resolvedBasePath = requireBackendBasePath()
-					if (!resolvedBasePath) return
-					await fetch(\`\${resolvedBasePath}/api/action\`, {
+					const backend = requireBackend()
+					if (!backend) return
+					await backend.fetch('/api/action', {
 						method: 'POST',
 						headers: { 'content-type': 'application/json' },
 						body: JSON.stringify({ action }),

--- a/docs/use/examples/saved-app-counter.md
+++ b/docs/use/examples/saved-app-counter.md
@@ -3,7 +3,7 @@
 This example shows the default saved-app backend structure for non-trivial apps:
 
 - **`clientCode`** is mostly UI plus fetches to
-  **`kodyWidget.appBackend.basePath`**
+  **`kodyWidget.appBackend.fetch(...)`**
 - **`serverCode`** owns storage, validation, and mutations
 - the backend exposes **`GET /api/state`** and **`POST /api/action`**
 
@@ -60,11 +60,11 @@ Save it with **`ui_save_app`**, then reopen it with **`open_generated_ui`**.
 	async function loadState() {
 		try {
 			clearCounterError()
-			const basePath = kodyWidget.appBackend?.basePath
-			if (!basePath) {
+			const appBackend = kodyWidget.appBackend
+			if (!appBackend) {
 				throw new Error('Saved app backend is not available.')
 			}
-			const response = await fetch(`${basePath}/api/state`)
+			const response = await appBackend.fetch('api/state')
 			const payload = await readStatePayload(response)
 			counterValue.textContent = String(payload.count ?? 0)
 		} catch (error) {
@@ -78,11 +78,11 @@ Save it with **`ui_save_app`**, then reopen it with **`open_generated_ui`**.
 	async function runAction(action) {
 		try {
 			clearCounterError()
-			const basePath = kodyWidget.appBackend?.basePath
-			if (!basePath) {
+			const appBackend = kodyWidget.appBackend
+			if (!appBackend) {
 				throw new Error('Saved app backend is not available.')
 			}
-			const response = await fetch(`${basePath}/api/action`, {
+			const response = await appBackend.fetch('api/action', {
 				method: 'POST',
 				headers: { 'content-type': 'application/json' },
 				body: JSON.stringify({ action }),
@@ -165,7 +165,7 @@ export class App extends DurableObject {
   counter storage logic with connector lookups and provider API calls in
   **`serverCode`**.
 - The client talks to its backend indirectly through
-  **`kodyWidget.appBackend.basePath`**.
+  **`kodyWidget.appBackend.fetch(...)`**.
 - The backend cannot make arbitrary outbound network calls. It only gets the
   explicit bridge bindings Kody passes in.
 - Reset the stored counter with **`app_storage_reset({ app_id })`**.

--- a/docs/use/saved-app-backends.md
+++ b/docs/use/saved-app-backends.md
@@ -57,8 +57,8 @@ For non-trivial or integration-backed apps, prefer a saved app with:
 
 - `GET /api/state` for the current UI state
 - `POST /api/action` for validated mutations
-- `clientCode` that stays mostly UI plus fetches through
-  `kodyWidget.appBackend.basePath`
+- `clientCode` that stays mostly UI plus requests through
+  `kodyWidget.appBackend.fetch(...)`
 - `serverCode` that owns storage, provider API calls, and request validation
 
 ## Authoring `serverCode`
@@ -83,22 +83,41 @@ The facet has:
 
 ## The `/app/:appId/*` route
 
-Saved app frontend code can call:
+Saved app frontend code can call its backend through:
 
-- `fetch('/app/<appId>/api/...')`
+- `kodyWidget.appBackend.fetch('api/...', init?)`
 
-The request is authenticated with the same generated UI app session token Kody
-already uses for saved app iframes. Kody also sets an app-scoped HttpOnly cookie
-so ordinary relative `fetch()` calls from the iframe work without custom auth
-code.
+The helper resolves requests under the saved app backend base path and applies
+the same generated UI auth Kody already uses for saved app iframes. When a
+generated UI bearer token is available, the helper forwards it automatically.
+Otherwise, ordinary cookie-backed iframe requests still work through the
+app-scoped HttpOnly cookie.
 
-Inside generated UI code, read the base path from:
+If you need the URL without issuing a request, use:
 
 ```ts
 import { kodyWidget } from '@kody/ui-utils'
 
-const backendBase = kodyWidget.appBackend?.basePath
+const backendUrl = kodyWidget.appBackend?.resolveUrl('api/state')
 ```
+
+The helper still exposes `basePath` for inspection/debugging, but
+`kodyWidget.appBackend.fetch(...)` should be the default public API for saved
+app frontend code.
+
+## Save-time backend validation
+
+`ui_save_app` now validates saved app backends through the same repo-published
+source snapshot and dynamic runner load path used at runtime:
+
+- Kody syncs the repo-backed app source snapshot first.
+- It re-resolves the saved app from that published source.
+- It configures the app runner from the resolved source.
+- It forces the backend facet to load before the save succeeds.
+
+That means backend refactors fail earlier when the published server module
+cannot actually load in the saved app runtime, instead of only surfacing on the
+first real backend request later.
 
 ## `KODY` facet bridge
 
@@ -200,24 +219,24 @@ await codemode.ui_save_app({
 				const refreshButton = document.querySelector('#refresh')
 				const incrementButton = document.querySelector('#increment')
 				const resetButton = document.querySelector('#reset')
-				const backendBase = kodyWidget.appBackend?.basePath
+				const backend = kodyWidget.appBackend
 
-			function requireBackendBase() {
-				if (!backendBase) {
-					output.textContent = 'Backend unavailable'
-					throw new Error('Saved app backend is not available.')
+				function requireBackend() {
+					if (!backend) {
+						output.textContent = 'Backend unavailable'
+						throw new Error('Saved app backend is not available.')
+					}
+					return backend
 				}
-				return backendBase
-			}
 
 				async function refresh() {
-				const response = await fetch(\`\${requireBackendBase()}/api/state\`)
+					const response = await requireBackend().fetch('api/state')
 					const payload = await response.json()
 					output.textContent = String(payload.count)
 				}
 
 				async function runAction(action) {
-				await fetch(\`\${requireBackendBase()}/api/action\`, {
+					await requireBackend().fetch('api/action', {
 						method: 'POST',
 						headers: { 'content-type': 'application/json' },
 						body: JSON.stringify({ action }),

--- a/docs/use/skills-and-apps.md
+++ b/docs/use/skills-and-apps.md
@@ -30,12 +30,13 @@ for lifecycle tasks.
 `<script type="module">...</script>` tags in that HTML.
 
 For non-trivial saved apps, treat **`serverCode`** plus
-**`kodyWidget.appBackend.basePath`** as the default pattern:
+**`kodyWidget.appBackend.fetch(...)`** as the default pattern:
 
 - put provider API calls, persistence, validation, and mutations in
   **`serverCode`**
 - expose backend routes such as **`/api/state`** and **`/api/action`**
-- keep **`clientCode`** mostly UI plus `fetch(...)` calls to the app backend
+- keep **`clientCode`** mostly UI plus `kodyWidget.appBackend.fetch(...)` calls
+  to the app backend
 - reserve embedded **`kodyWidget.executeCode(...)`** strings in client HTML for
   quick prototypes or one-off experiments
 
@@ -82,7 +83,7 @@ override saved-app/session params for that execution only.
 For saved apps with real logic, use **`kodyWidget.appBackend`** as the default
 client-to-backend path:
 
-**`fetch(\`\${kodyWidget.appBackend.basePath}/api/state\`)`**
+**`await kodyWidget.appBackend.fetch('/api/state')`**
 
 That keeps **`clientCode`** focused on UI while **`serverCode`** handles the
 backend contract.

--- a/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
+++ b/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
@@ -17,6 +17,16 @@ const {
 	shouldInitializeGeneratedUiRuntimeImmediately,
 } = uiUtils
 
+function installWindowLocation(href: string) {
+	const currentWindow = globalThis.window as Window | undefined
+	const location = new URL(href)
+	globalThis.window = {
+		...(currentWindow ?? {}),
+		location,
+	} as Window & typeof globalThis
+	globalThis.location = location as Location
+}
+
 test('injectIntoHtmlDocument inserts content into an existing head', () => {
 	const result = injectIntoHtmlDocument(
 		'<!doctype html><html lang="en" class="demo"><head data-shell="true"><title>Demo</title></head><body></body></html>',
@@ -178,6 +188,24 @@ test('kodyWidget public api exposes executeCode helper', () => {
 	expect(typeof kodyWidget.executeCode).toBe('function')
 })
 
+test('kodyWidget public api exposes appBackend helper facade when available', () => {
+	const runtimeState = getKodyWidgetRuntimeStateForTest()
+	runtimeState.reset()
+	runtimeState.install({
+		mode: 'hosted',
+		appBackend: {
+			basePath: '/app/app-123',
+			facetNames: ['main'],
+		},
+	})
+
+	expect(kodyWidget.appBackend).not.toBeNull()
+	expect(kodyWidget.appBackend?.basePath).toBe('/app/app-123')
+	expect(kodyWidget.appBackend?.facetNames).toEqual(['main'])
+	expect(typeof kodyWidget.appBackend?.resolveUrl).toBe('function')
+	expect(typeof kodyWidget.appBackend?.fetch).toBe('function')
+})
+
 test('public module does not export readiness helpers', () => {
 	expect('getKodyWidget' in uiUtils).toBe(false)
 	expect('whenKodyWidgetReady' in uiUtils).toBe(false)
@@ -242,6 +270,144 @@ test('runtime bootstrap updates refresh params and app session without reinit', 
 	})
 
 	expect(kodyWidget.params).toEqual({ owner: 'updated', limit: 3 })
+})
+
+test('appBackend.resolveUrl resolves backend-relative paths safely', () => {
+	installWindowLocation('http://localhost:3000/ui/app-123')
+	const runtimeState = getKodyWidgetRuntimeStateForTest()
+	runtimeState.reset()
+	runtimeState.install({
+		mode: 'hosted',
+		appBackend: {
+			basePath: '/app/app-123',
+			facetNames: ['main'],
+		},
+	})
+
+	expect(kodyWidget.appBackend?.resolveUrl()).toBe('http://localhost:3000/app/app-123')
+	expect(kodyWidget.appBackend?.resolveUrl('api/state')).toBe(
+		'http://localhost:3000/app/app-123/api/state',
+	)
+	expect(kodyWidget.appBackend?.resolveUrl('/api/state')).toBe(
+		'http://localhost:3000/app/app-123/api/state',
+	)
+	expect(kodyWidget.appBackend?.resolveUrl('?view=full')).toBe(
+		'http://localhost:3000/app/app-123?view=full',
+	)
+	expect(
+		kodyWidget.appBackend?.resolveUrl(
+			new URL('http://localhost:3000/app/app-123/api/state'),
+		),
+	).toBe('http://localhost:3000/app/app-123/api/state')
+})
+
+test('appBackend.resolveUrl rejects urls outside the saved app backend path', () => {
+	installWindowLocation('http://localhost:3000/ui/app-123')
+	const runtimeState = getKodyWidgetRuntimeStateForTest()
+	runtimeState.reset()
+	runtimeState.install({
+		mode: 'hosted',
+		appBackend: {
+			basePath: '/app/app-123',
+			facetNames: ['main'],
+		},
+	})
+
+	expect(() =>
+		kodyWidget.appBackend?.resolveUrl('http://localhost:3000/ui/app-123'),
+	).toThrow(
+		/only supports same-origin urls within the saved app backend base path/i,
+	)
+	expect(() =>
+		kodyWidget.appBackend?.resolveUrl('https://example.com/app/app-123/api/state'),
+	).toThrow(/only supports same-origin urls within the saved app backend base path/i)
+})
+
+test('appBackend.fetch adds the generated ui bearer token by default', async () => {
+	installWindowLocation('http://localhost:3000/ui/app-123')
+	const runtimeState = getKodyWidgetRuntimeStateForTest()
+	runtimeState.reset()
+	runtimeState.install({
+		mode: 'hosted',
+		appSession: {
+			token: 'app-session-token',
+			endpoints: {
+				source: 'https://kody.example/ui-api/app-123/source',
+				execute: 'https://kody.example/ui-api/app-123/execute',
+				secrets: 'https://kody.example/ui-api/app-123/secrets',
+				deleteSecret: 'https://kody.example/ui-api/app-123/secrets/delete',
+			},
+		},
+		appBackend: {
+			basePath: '/app/app-123',
+			facetNames: ['main'],
+		},
+	})
+
+	const fetchSpy = vi
+		.spyOn(globalThis, 'fetch')
+		.mockResolvedValue(new Response(JSON.stringify({ ok: true })))
+
+	try {
+		await kodyWidget.appBackend?.fetch('api/state', {
+			method: 'POST',
+			body: JSON.stringify({ action: 'refresh' }),
+		})
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1)
+		const [requestUrl, requestInit] = fetchSpy.mock.calls[0] ?? []
+		expect(requestUrl).toBe('http://localhost:3000/app/app-123/api/state')
+		expect((requestInit as RequestInit | undefined)?.method).toBe('POST')
+		expect((requestInit as RequestInit | undefined)?.credentials).toBe('omit')
+		const headers = new Headers(
+			(requestInit as RequestInit | undefined)?.headers,
+		)
+		expect(headers.get('Authorization')).toBe('Bearer app-session-token')
+	} finally {
+		fetchSpy.mockRestore()
+	}
+})
+
+test('appBackend.fetch preserves explicit authorization headers', async () => {
+	installWindowLocation('http://localhost:3000/ui/app-123')
+	const runtimeState = getKodyWidgetRuntimeStateForTest()
+	runtimeState.reset()
+	runtimeState.install({
+		mode: 'hosted',
+		appSession: {
+			token: 'app-session-token',
+			endpoints: {
+				source: 'https://kody.example/ui-api/app-123/source',
+				execute: 'https://kody.example/ui-api/app-123/execute',
+				secrets: 'https://kody.example/ui-api/app-123/secrets',
+				deleteSecret: 'https://kody.example/ui-api/app-123/secrets/delete',
+			},
+		},
+		appBackend: {
+			basePath: '/app/app-123',
+			facetNames: ['main'],
+		},
+	})
+
+	const fetchSpy = vi
+		.spyOn(globalThis, 'fetch')
+		.mockResolvedValue(new Response(JSON.stringify({ ok: true })))
+
+	try {
+		await kodyWidget.appBackend?.fetch('api/state', {
+			headers: {
+				Authorization: 'Bearer explicit-token',
+			},
+		})
+
+		const [, requestInit] = fetchSpy.mock.calls[0] ?? []
+		const headers = new Headers(
+			(requestInit as RequestInit | undefined)?.headers,
+		)
+		expect(headers.get('Authorization')).toBe('Bearer explicit-token')
+	} finally {
+		fetchSpy.mockRestore()
+	}
 })
 
 test('runtime-backed helpers time out if the runtime never becomes ready', async () => {

--- a/packages/worker/client/mcp-apps/kody-ui-utils.ts
+++ b/packages/worker/client/mcp-apps/kody-ui-utils.ts
@@ -32,7 +32,11 @@ export {
 	type GeneratedUiRuntimeBootstrap,
 	generatedUiRuntimeModuleSpecifier,
 } from './kody-ui-utils-contract.ts'
-export { kodyWidget, type KodyWidgetPublicApi } from './kody-widget-runtime.ts'
+export {
+	kodyWidget,
+	type KodyWidgetAppBackendPublicApi,
+	type KodyWidgetPublicApi,
+} from './kody-widget-runtime.ts'
 
 type RenderMode = 'inline_code' | 'saved_app'
 type AppRuntime = 'html' | 'javascript'

--- a/packages/worker/client/mcp-apps/kody-widget-runtime.ts
+++ b/packages/worker/client/mcp-apps/kody-widget-runtime.ts
@@ -122,14 +122,22 @@ type BuildSecretFormInput = {
 	onSuccess?: (result: SaveSecretsResult, values: FormObject) => unknown
 	onError?: (result: SaveSecretsResult, values: FormObject) => unknown
 }
+type AppBackendRequestPath = string | URL
 type MessageLogRefs = {
 	root: HTMLElement
 	list: HTMLElement
 }
 
+export type KodyWidgetAppBackendPublicApi = {
+	basePath: string
+	facetNames?: Array<string>
+	resolveUrl: (path?: AppBackendRequestPath) => string
+	fetch: (path?: AppBackendRequestPath, init?: RequestInit) => Promise<Response>
+}
+
 export type KodyWidgetPublicApi = Record<string, any> & {
 	params: JsonRecord
-	appBackend: GeneratedUiAppBackendBootstrap | null
+	appBackend: KodyWidgetAppBackendPublicApi | null
 	executeCode: (code: string, params?: JsonRecord) => Promise<unknown>
 }
 
@@ -151,6 +159,7 @@ type KodyWindow = Window &
 		}
 		__kodyLocalMessageLogRoot?: HTMLElement | null
 		__kodyLocalMessageLogList?: HTMLElement | null
+		__kodyWidgetAppBackendFacade?: KodyWidgetAppBackendPublicApi
 		__kodyWidgetRuntimeState?: KodyWidgetRuntimeState
 		kodyWidget?: KodyWidgetPublicApi
 		params?: Record<string, unknown>
@@ -276,6 +285,16 @@ function getOrCreateKodyWidgetFacade() {
 	const widget = createKodyWidgetFacade()
 	kodyWindow.kodyWidget = widget
 	return widget
+}
+
+function getOrCreateAppBackendFacade() {
+	const existingFacade = kodyWindow.__kodyWidgetAppBackendFacade
+	if (existingFacade) {
+		return existingFacade
+	}
+	const facade = createAppBackendFacade()
+	kodyWindow.__kodyWidgetAppBackendFacade = facade
+	return facade
 }
 
 export function getKodyWidgetRuntimeStateForTest() {
@@ -1030,6 +1049,127 @@ async function fetchJsonResponse(input: {
 	return { response, payload }
 }
 
+function trimTrailingSlash(value: string) {
+	return value.endsWith('/') ? value.slice(0, -1) : value
+}
+
+function getRuntimeLocationHref() {
+	const location =
+		(typeof kodyWindow.location?.href === 'string' &&
+		kodyWindow.location.href.length > 0
+			? kodyWindow.location
+			: typeof globalThis.location?.href === 'string' &&
+				  globalThis.location.href.length > 0
+				? globalThis.location
+				: null)
+	if (location) {
+		return location.href
+	}
+	return 'http://localhost/'
+}
+
+function buildAppBackendBaseUrl(basePath: string) {
+	const backendOriginUrl = new URL(basePath, getRuntimeLocationHref())
+	return new URL(`${trimTrailingSlash(backendOriginUrl.pathname)}/`, backendOriginUrl)
+}
+
+function getCurrentAppBackendBootstrap() {
+	return getOrCreateKodyWidgetRuntimeState().appBackend
+}
+
+function requireCurrentAppBackendBootstrap() {
+	const appBackend = getCurrentAppBackendBootstrap()
+	if (!appBackend) {
+		throw new Error('Saved app backend is not available in this context.')
+	}
+	return appBackend
+}
+
+function isAbsoluteUrlString(value: string) {
+	return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value) || value.startsWith('//')
+}
+
+function isWithinAppBackendBasePath(candidate: URL, appBackend: { basePath: string }) {
+	const backendBaseUrl = new URL(appBackend.basePath, getRuntimeLocationHref())
+	const normalizedBasePath = trimTrailingSlash(backendBaseUrl.pathname)
+	const normalizedCandidatePath = trimTrailingSlash(candidate.pathname)
+	return (
+		candidate.origin === backendBaseUrl.origin &&
+		(normalizedCandidatePath === normalizedBasePath ||
+			normalizedCandidatePath.startsWith(`${normalizedBasePath}/`))
+	)
+}
+
+function validateResolvedAppBackendUrl(candidate: URL) {
+	const appBackend = requireCurrentAppBackendBootstrap()
+	if (!isWithinAppBackendBasePath(candidate, appBackend)) {
+		throw new Error(
+			'kodyWidget.appBackend only supports same-origin URLs within the saved app backend base path.',
+		)
+	}
+	return candidate.toString()
+}
+
+function resolveAppBackendRequestUrl(path?: AppBackendRequestPath) {
+	const appBackend = requireCurrentAppBackendBootstrap()
+	const backendOriginUrl = new URL(appBackend.basePath, getRuntimeLocationHref())
+	if (path == null || path === '') {
+		return backendOriginUrl.toString()
+	}
+	if (path instanceof URL) {
+		return validateResolvedAppBackendUrl(path)
+	}
+	if (typeof path !== 'string') {
+		throw new Error(
+			'kodyWidget.appBackend.fetch requires a string path, URL, or no path.',
+		)
+	}
+	if (isAbsoluteUrlString(path)) {
+		return validateResolvedAppBackendUrl(new URL(path, getRuntimeLocationHref()))
+	}
+	if (path.startsWith('?') || path.startsWith('#')) {
+		return new URL(path, backendOriginUrl).toString()
+	}
+	const normalizedPath = path.replace(/^\/+/, '')
+	return new URL(normalizedPath, buildAppBackendBaseUrl(appBackend.basePath)).toString()
+}
+
+async function fetchAppBackendInCurrentContext(
+	path?: AppBackendRequestPath,
+	init?: RequestInit,
+) {
+	await ensureKodyWidgetRuntimeReady()
+	const requestUrl = resolveAppBackendRequestUrl(path)
+	const headers = new Headers(init?.headers)
+	const sessionToken = getOrCreateKodyWidgetRuntimeState().appSession?.token
+	if (sessionToken && !headers.has('Authorization')) {
+		headers.set('Authorization', `Bearer ${sessionToken}`)
+	}
+	return await fetch(requestUrl, {
+		...init,
+		headers,
+		credentials:
+			init?.credentials ?? (headers.has('Authorization') ? 'omit' : 'include'),
+	})
+}
+
+function createAppBackendFacade(): KodyWidgetAppBackendPublicApi {
+	return {
+		get basePath() {
+			return requireCurrentAppBackendBootstrap().basePath
+		},
+		get facetNames() {
+			return requireCurrentAppBackendBootstrap().facetNames
+		},
+		resolveUrl(path?: AppBackendRequestPath) {
+			return resolveAppBackendRequestUrl(path)
+		},
+		async fetch(path?: AppBackendRequestPath, init?: RequestInit) {
+			return await fetchAppBackendInCurrentContext(path, init)
+		},
+	}
+}
+
 function getOAuthStorage(): Storage {
 	try {
 		return window.localStorage
@@ -1278,6 +1418,8 @@ function createKodyWidgetFacade(): KodyWidgetPublicApi {
 		},
 		get appBackend() {
 			return getOrCreateKodyWidgetRuntimeState().appBackend
+				? getOrCreateAppBackendFacade()
+				: null
 		},
 		sendMessage(text: unknown) {
 			return sendMessageInCurrentContext(text)

--- a/packages/worker/client/mcp-apps/kody-widget-runtime.ts
+++ b/packages/worker/client/mcp-apps/kody-widget-runtime.ts
@@ -1055,13 +1055,13 @@ function trimTrailingSlash(value: string) {
 
 function getRuntimeLocationHref() {
 	const location =
-		(typeof kodyWindow.location?.href === 'string' &&
+		typeof kodyWindow.location?.href === 'string' &&
 		kodyWindow.location.href.length > 0
 			? kodyWindow.location
 			: typeof globalThis.location?.href === 'string' &&
 				  globalThis.location.href.length > 0
 				? globalThis.location
-				: null)
+				: null
 	if (location) {
 		return location.href
 	}
@@ -1070,7 +1070,10 @@ function getRuntimeLocationHref() {
 
 function buildAppBackendBaseUrl(basePath: string) {
 	const backendOriginUrl = new URL(basePath, getRuntimeLocationHref())
-	return new URL(`${trimTrailingSlash(backendOriginUrl.pathname)}/`, backendOriginUrl)
+	return new URL(
+		`${trimTrailingSlash(backendOriginUrl.pathname)}/`,
+		backendOriginUrl,
+	)
 }
 
 function getCurrentAppBackendBootstrap() {
@@ -1089,7 +1092,10 @@ function isAbsoluteUrlString(value: string) {
 	return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value) || value.startsWith('//')
 }
 
-function isWithinAppBackendBasePath(candidate: URL, appBackend: { basePath: string }) {
+function isWithinAppBackendBasePath(
+	candidate: URL,
+	appBackend: { basePath: string },
+) {
 	const backendBaseUrl = new URL(appBackend.basePath, getRuntimeLocationHref())
 	const normalizedBasePath = trimTrailingSlash(backendBaseUrl.pathname)
 	const normalizedCandidatePath = trimTrailingSlash(candidate.pathname)
@@ -1112,7 +1118,10 @@ function validateResolvedAppBackendUrl(candidate: URL) {
 
 function resolveAppBackendRequestUrl(path?: AppBackendRequestPath) {
 	const appBackend = requireCurrentAppBackendBootstrap()
-	const backendOriginUrl = new URL(appBackend.basePath, getRuntimeLocationHref())
+	const backendOriginUrl = new URL(
+		appBackend.basePath,
+		getRuntimeLocationHref(),
+	)
 	if (path == null || path === '') {
 		return backendOriginUrl.toString()
 	}
@@ -1125,13 +1134,17 @@ function resolveAppBackendRequestUrl(path?: AppBackendRequestPath) {
 		)
 	}
 	if (isAbsoluteUrlString(path)) {
-		return validateResolvedAppBackendUrl(new URL(path, getRuntimeLocationHref()))
+		return validateResolvedAppBackendUrl(
+			new URL(path, getRuntimeLocationHref()),
+		)
 	}
 	if (path.startsWith('?') || path.startsWith('#')) {
 		return new URL(path, backendOriginUrl).toString()
 	}
 	const normalizedPath = path.replace(/^\/+/, '')
-	return new URL(normalizedPath, buildAppBackendBaseUrl(appBackend.basePath)).toString()
+	return validateResolvedAppBackendUrl(
+		new URL(normalizedPath, buildAppBackendBaseUrl(appBackend.basePath)),
+	)
 }
 
 async function fetchAppBackendInCurrentContext(

--- a/packages/worker/src/mcp/app-runner.ts
+++ b/packages/worker/src/mcp/app-runner.ts
@@ -104,6 +104,7 @@ import * as userModule from './user-app.js'
 const BaseApp = userModule.App
 const reservedFacetMethodNames = new Set([
 	'fetch',
+	'__kody_validate',
 	'__kody_resetStorage',
 	'__kody_exportStorage',
 	'__kody_invokeUserMethod',
@@ -114,6 +115,16 @@ if (typeof BaseApp !== 'function') {
 }
 
 export class ${exportName} extends BaseApp {
+	async __kody_validate() {
+		return {
+			ok: true,
+			className:
+				typeof BaseApp.name === 'string' && BaseApp.name.length > 0
+					? BaseApp.name
+					: 'App',
+		}
+	}
+
 	async __kody_resetStorage() {
 		await this.ctx.storage.deleteAll()
 		return { ok: true }
@@ -505,6 +516,31 @@ class AppRunnerBase extends DurableObject<Env> {
 		}
 	}
 
+	async validateBackend(input: { appId: string; facetName?: string | null }) {
+		const facetName = buildFacetName(input.facetName)
+		const config = await this.readConfig(this.ctx.id.toString())
+		if (!config.serverCode) {
+			return {
+				ok: true,
+				appId: input.appId,
+				facetName,
+				validated: false,
+			}
+		}
+		const facet = await this.getFacetStub(facetName)
+		await (
+			facet as unknown as {
+				__kody_validate: () => Promise<unknown>
+			}
+		).__kody_validate()
+		return {
+			ok: true,
+			appId: input.appId,
+			facetName,
+			validated: true,
+		}
+	}
+
 	async exportStorage(input: {
 		appId: string
 		facetName?: string | null
@@ -857,6 +893,15 @@ export function appRunnerRpc(env: Env, appId: string) {
 			metrics: AppRunnerMetrics
 			storageBytes: number
 		}>
+		validateBackend: (payload: {
+			appId: string
+			facetName?: string | null
+		}) => Promise<{
+			ok: true
+			appId: string
+			facetName: string
+			validated: boolean
+		}>
 		resetStorage: (payload: {
 			appId: string
 			facetName?: string | null
@@ -908,6 +953,17 @@ export async function exportSavedAppRunnerStorage(input: {
 		facetName: input.facetName ?? 'main',
 		pageSize: input.pageSize,
 		startAfter: input.startAfter ?? null,
+	})
+}
+
+export async function validateSavedAppRunner(input: {
+	env: Env
+	appId: string
+	facetName?: string | null
+}) {
+	return await appRunnerRpc(input.env, input.appId).validateBackend({
+		appId: input.appId,
+		facetName: input.facetName ?? 'main',
 	})
 }
 

--- a/packages/worker/src/mcp/capabilities/apps/ui-save-app.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/apps/ui-save-app.node.test.ts
@@ -6,8 +6,9 @@ const mockModule = vi.hoisted(() => ({
 	updateUiArtifact: vi.fn(),
 	insertUiArtifact: vi.fn(),
 	deleteUiArtifact: vi.fn(),
-	configureSavedAppRunner: vi.fn(),
 	deleteSavedAppRunner: vi.fn(),
+	syncSavedAppRunnerFromDb: vi.fn(),
+	validateSavedAppRunner: vi.fn(),
 	upsertUiArtifactVector: vi.fn(),
 	deleteUiArtifactVector: vi.fn(),
 	resolveSavedAppSource: vi.fn(),
@@ -27,10 +28,12 @@ vi.mock('#mcp/ui-artifacts-repo.ts', () => ({
 }))
 
 vi.mock('#mcp/app-runner.ts', () => ({
-	configureSavedAppRunner: (...args: Array<unknown>) =>
-		mockModule.configureSavedAppRunner(...args),
 	deleteSavedAppRunner: (...args: Array<unknown>) =>
 		mockModule.deleteSavedAppRunner(...args),
+	syncSavedAppRunnerFromDb: (...args: Array<unknown>) =>
+		mockModule.syncSavedAppRunnerFromDb(...args),
+	validateSavedAppRunner: (...args: Array<unknown>) =>
+		mockModule.validateSavedAppRunner(...args),
 }))
 
 vi.mock('#mcp/ui-artifacts-vectorize.ts', () => ({
@@ -62,8 +65,9 @@ test('ui_save_app updates preserve backend code unless the caller clears or repl
 	mockModule.updateUiArtifact.mockReset()
 	mockModule.insertUiArtifact.mockReset()
 	mockModule.deleteUiArtifact.mockReset()
-	mockModule.configureSavedAppRunner.mockReset()
 	mockModule.deleteSavedAppRunner.mockReset()
+	mockModule.syncSavedAppRunnerFromDb.mockReset()
+	mockModule.validateSavedAppRunner.mockReset()
 	mockModule.upsertUiArtifactVector.mockReset()
 	mockModule.deleteUiArtifactVector.mockReset()
 	mockModule.resolveSavedAppSource.mockReset()
@@ -115,6 +119,12 @@ test('ui_save_app updates preserve backend code unless the caller clears or repl
 		.mockResolvedValueOnce('server-code-v2')
 		.mockResolvedValueOnce('server-code-v3')
 		.mockResolvedValueOnce('server-code-v4')
+	mockModule.validateSavedAppRunner.mockResolvedValue({
+		ok: true,
+		appId: 'app-1',
+		facetName: 'main',
+		validated: true,
+	})
 	mockModule.resolveSavedAppSource.mockImplementation(async () => ({
 		id: currentApp.id,
 		title: currentApp.title,
@@ -132,8 +142,51 @@ test('ui_save_app updates preserve backend code unless the caller clears or repl
 			(currentApp as typeof currentApp & { resolvedClientCode?: string })
 				.resolvedClientCode ?? '<main><h1>Patchable v1</h1></main>',
 		serverCode:
+			'resolvedServerCode' in
 			(currentApp as typeof currentApp & { resolvedServerCode?: string | null })
-				.resolvedServerCode ?? initialServerCode,
+				? (
+						currentApp as typeof currentApp & {
+							resolvedServerCode?: string | null
+						}
+					).resolvedServerCode ?? null
+				: initialServerCode,
+		serverCodeId:
+			(
+				currentApp as typeof currentApp & {
+					resolvedServerCodeId?: string | null
+				}
+			).resolvedServerCodeId ?? 'server-code-v1',
+		sourceId: currentApp.sourceId,
+		publishedCommit:
+			(currentApp as typeof currentApp & { publishedCommit?: string | null })
+				.publishedCommit ?? 'server-code-v1',
+	}))
+	mockModule.syncSavedAppRunnerFromDb.mockImplementation(async () => ({
+		id: currentApp.id,
+		user_id: currentApp.user_id,
+		title: currentApp.title,
+		description: currentApp.description,
+		hidden: currentApp.hidden,
+		parameters: [
+			{
+				name: 'team',
+				description: 'Team slug',
+				type: 'string',
+				required: true,
+			},
+		],
+		clientCode:
+			(currentApp as typeof currentApp & { resolvedClientCode?: string })
+				.resolvedClientCode ?? '<main><h1>Patchable v1</h1></main>',
+		serverCode:
+			'resolvedServerCode' in
+			(currentApp as typeof currentApp & { resolvedServerCode?: string | null })
+				? (
+						currentApp as typeof currentApp & {
+							resolvedServerCode?: string | null
+						}
+					).resolvedServerCode ?? null
+				: initialServerCode,
 		serverCodeId:
 			(
 				currentApp as typeof currentApp & {
@@ -179,7 +232,7 @@ test('ui_save_app updates preserve backend code unless the caller clears or repl
 						resolvedServerCode?: string | null
 					}
 				).resolvedServerCode =
-					updates['hasServerCode'] === true ? initialServerCode : null
+					updates['hasServerCode'] === true ? replacementServerCode : null
 			}
 			return { ...currentApp }
 		},
@@ -231,13 +284,21 @@ test('ui_save_app updates preserve backend code unless the caller clears or repl
 			hasServerCode: true,
 			hidden: undefined,
 		})
-		expect(mockModule.configureSavedAppRunner.mock.calls[0]?.[0]).toEqual(
+		expect(mockModule.syncSavedAppRunnerFromDb.mock.calls[0]?.[0]).toEqual(
 			expect.objectContaining({
 				appId: 'app-1',
-				serverCode: initialServerCode,
-				serverCodeId: expect.any(String),
+				userId: 'user-1',
+				baseUrl: 'https://heykody.dev',
 			}),
 		)
+		expect(mockModule.validateSavedAppRunner.mock.calls[0]?.[0]).toEqual({
+			env: {
+				APP_DB: appDb,
+				CLOUDFLARE_ACCOUNT_ID: 'acct',
+				CLOUDFLARE_API_TOKEN: 'token',
+			},
+			appId: 'app-1',
+		})
 
 		const clearedResult = await uiSaveAppCapability.handler(
 			{
@@ -277,11 +338,11 @@ test('ui_save_app updates preserve backend code unless the caller clears or repl
 				hasServerCode: false,
 			}),
 		)
-		expect(mockModule.configureSavedAppRunner.mock.calls[1]?.[0]).toEqual(
+		expect(mockModule.syncSavedAppRunnerFromDb.mock.calls[1]?.[0]).toEqual(
 			expect.objectContaining({
 				appId: 'app-1',
-				serverCode: null,
-				serverCodeId: expect.any(String),
+				userId: 'user-1',
+				baseUrl: 'https://heykody.dev',
 			}),
 		)
 
@@ -323,15 +384,211 @@ test('ui_save_app updates preserve backend code unless the caller clears or repl
 				hasServerCode: true,
 			}),
 		)
-		expect(mockModule.configureSavedAppRunner.mock.calls[2]?.[0]).toEqual(
+		expect(mockModule.syncSavedAppRunnerFromDb.mock.calls[2]?.[0]).toEqual(
 			expect.objectContaining({
 				appId: 'app-1',
-				serverCode: replacementServerCode,
-				serverCodeId: expect.any(String),
+				userId: 'user-1',
+				baseUrl: 'https://heykody.dev',
 			}),
 		)
 		expect(mockModule.deleteUiArtifactVector).toHaveBeenCalledTimes(3)
 	} finally {
 		randomUuidSpy.mockRestore()
 	}
+})
+
+test('ui_save_app rolls back create when backend validation fails after source sync', async () => {
+	mockModule.getUiArtifactById.mockReset()
+	mockModule.updateUiArtifact.mockReset()
+	mockModule.insertUiArtifact.mockReset()
+	mockModule.deleteUiArtifact.mockReset()
+	mockModule.deleteSavedAppRunner.mockReset()
+	mockModule.syncSavedAppRunnerFromDb.mockReset()
+	mockModule.validateSavedAppRunner.mockReset()
+	mockModule.upsertUiArtifactVector.mockReset()
+	mockModule.deleteUiArtifactVector.mockReset()
+	mockModule.resolveSavedAppSource.mockReset()
+	mockModule.ensureEntitySource.mockReset()
+	mockModule.syncArtifactSourceSnapshot.mockReset()
+
+	mockModule.ensureEntitySource.mockResolvedValue({
+		id: 'source-app-create',
+		bootstrapAccess: null,
+	})
+	mockModule.syncArtifactSourceSnapshot.mockResolvedValue('server-code-created')
+	mockModule.syncSavedAppRunnerFromDb.mockResolvedValue({
+		id: 'app-create',
+		user_id: 'user-1',
+		title: 'Broken backend',
+		description: 'Should fail during backend validation.',
+		hidden: true,
+		parameters: null,
+		clientCode: '<main>Broken backend</main>',
+		serverCode:
+			'import { DurableObject } from "cloudflare:workers"; export class App extends DurableObject {}',
+		serverCodeId: 'server-code-created',
+		sourceId: 'source-app-create',
+		publishedCommit: 'server-code-created',
+	})
+	mockModule.validateSavedAppRunner.mockRejectedValue(
+		new Error('Saved app backend failed validation.'),
+	)
+
+	const randomUuidSpy = vi.spyOn(crypto, 'randomUUID')
+	randomUuidSpy.mockReturnValueOnce('app-create')
+	try {
+		await expect(
+			uiSaveAppCapability.handler(
+				{
+					title: 'Broken backend',
+					description: 'Should fail during backend validation.',
+					clientCode: '<main>Broken backend</main>',
+					serverCode:
+						'import { DurableObject } from "cloudflare:workers"; export class App extends DurableObject {}',
+				},
+				{
+					env: {
+						APP_DB: {} as D1Database,
+						CLOUDFLARE_ACCOUNT_ID: 'acct',
+						CLOUDFLARE_API_TOKEN: 'token',
+					} as Env,
+					callerContext: createMcpCallerContext({
+						baseUrl: 'https://heykody.dev',
+						user: { userId: 'user-1', email: 'user@example.com' },
+					}),
+				},
+			),
+		).rejects.toThrow('Saved app backend failed validation.')
+
+		expect(mockModule.insertUiArtifact).toHaveBeenCalledTimes(1)
+		expect(mockModule.deleteSavedAppRunner).toHaveBeenCalledWith({
+			env: {
+				APP_DB: {} as D1Database,
+				CLOUDFLARE_ACCOUNT_ID: 'acct',
+				CLOUDFLARE_API_TOKEN: 'token',
+			},
+			appId: 'app-create',
+		})
+		expect(mockModule.deleteUiArtifact).toHaveBeenCalledWith(
+			{} as D1Database,
+			'user-1',
+			'app-create',
+		)
+	} finally {
+		randomUuidSpy.mockRestore()
+	}
+})
+
+test('ui_save_app rolls back updates to the previous runner state when backend validation fails', async () => {
+	mockModule.getUiArtifactById.mockReset()
+	mockModule.updateUiArtifact.mockReset()
+	mockModule.insertUiArtifact.mockReset()
+	mockModule.deleteUiArtifact.mockReset()
+	mockModule.deleteSavedAppRunner.mockReset()
+	mockModule.syncSavedAppRunnerFromDb.mockReset()
+	mockModule.validateSavedAppRunner.mockReset()
+	mockModule.upsertUiArtifactVector.mockReset()
+	mockModule.deleteUiArtifactVector.mockReset()
+	mockModule.resolveSavedAppSource.mockReset()
+	mockModule.ensureEntitySource.mockReset()
+	mockModule.syncArtifactSourceSnapshot.mockReset()
+
+	const existingApp = {
+		id: 'app-update',
+		user_id: 'user-1',
+		title: 'Original title',
+		description: 'Original description',
+		sourceId: 'source-original',
+		hasServerCode: true,
+		parameters: null,
+		hidden: true,
+	}
+	mockModule.getUiArtifactById.mockResolvedValue(existingApp)
+	mockModule.ensureEntitySource.mockResolvedValue({
+		id: 'source-original',
+		bootstrapAccess: null,
+	})
+	mockModule.resolveSavedAppSource.mockResolvedValue({
+		id: 'app-update',
+		title: 'Original title',
+		description: 'Original description',
+		hidden: true,
+		parameters: null,
+		clientCode: '<main>Original</main>',
+		serverCode:
+			'import { DurableObject } from "cloudflare:workers"; export class App extends DurableObject { async fetch() { return new Response("ok") } }',
+		serverCodeId: 'server-code-original',
+		sourceId: 'source-original',
+		publishedCommit: 'server-code-original',
+	})
+	mockModule.syncArtifactSourceSnapshot.mockResolvedValue('server-code-next')
+	mockModule.syncSavedAppRunnerFromDb
+		.mockRejectedValueOnce(new Error('Updated backend failed validation.'))
+		.mockResolvedValueOnce({
+			id: 'app-update',
+			user_id: 'user-1',
+			title: 'Original title',
+			description: 'Original description',
+			hidden: true,
+			parameters: null,
+			clientCode: '<main>Original</main>',
+			serverCode:
+				'import { DurableObject } from "cloudflare:workers"; export class App extends DurableObject { async fetch() { return new Response("ok") } }',
+			serverCodeId: 'server-code-original',
+			sourceId: 'source-original',
+			publishedCommit: 'server-code-original',
+		})
+	mockModule.validateSavedAppRunner.mockResolvedValue({
+		ok: true,
+		appId: 'app-update',
+		facetName: 'main',
+		validated: true,
+	})
+	mockModule.updateUiArtifact.mockResolvedValue(true)
+
+	await expect(
+		uiSaveAppCapability.handler(
+			{
+				app_id: 'app-update',
+				title: 'Broken title',
+			},
+			{
+				env: {
+					APP_DB: {} as D1Database,
+					CLOUDFLARE_ACCOUNT_ID: 'acct',
+					CLOUDFLARE_API_TOKEN: 'token',
+				} as Env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://heykody.dev',
+					user: { userId: 'user-1', email: 'user@example.com' },
+				}),
+			},
+		),
+	).rejects.toThrow('Updated backend failed validation.')
+
+	expect(mockModule.updateUiArtifact.mock.calls[0]?.[3]).toEqual({
+		title: 'Broken title',
+		description: undefined,
+		sourceId: 'source-original',
+		hasServerCode: true,
+		hidden: undefined,
+	})
+	expect(mockModule.updateUiArtifact.mock.calls[1]?.[3]).toEqual({
+		title: 'Original title',
+		description: 'Original description',
+		sourceId: 'source-original',
+		hasServerCode: true,
+		parameters: null,
+		hidden: true,
+	})
+	expect(mockModule.syncSavedAppRunnerFromDb.mock.calls[1]?.[0]).toEqual({
+		env: {
+			APP_DB: {} as D1Database,
+			CLOUDFLARE_ACCOUNT_ID: 'acct',
+			CLOUDFLARE_API_TOKEN: 'token',
+		},
+		appId: 'app-update',
+		userId: 'user-1',
+		baseUrl: 'https://heykody.dev',
+	})
 })

--- a/packages/worker/src/mcp/capabilities/apps/ui-save-app.ts
+++ b/packages/worker/src/mcp/capabilities/apps/ui-save-app.ts
@@ -16,8 +16,9 @@ import {
 	upsertUiArtifactVector,
 } from '#mcp/ui-artifacts-vectorize.ts'
 import {
-	configureSavedAppRunner,
 	deleteSavedAppRunner,
+	syncSavedAppRunnerFromDb,
+	validateSavedAppRunner,
 } from '#mcp/app-runner.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import {
@@ -211,26 +212,57 @@ export const uiSaveAppCapability = defineDomainCapability(
 
 			async function saveAndIndexApp(input: {
 				appId: string
-				title: string
-				description: string
-				clientCode: string
-				serverCode: string | null
-				serverCodeId: string
-				parameters: ReturnType<typeof normalizeUiArtifactParameters>
-				hidden: boolean
 				sourceId: string
 				previousPublishedCommit: string | null
 				existingApp: Awaited<ReturnType<typeof getUiArtifactById>> | null
 			}) {
-				const hasBackend = input.serverCode != null
+				const restoreExistingSavedAppState = async () => {
+					if (!input.existingApp) {
+						return
+					}
+					await Promise.allSettled([
+						updateUiArtifact(ctx.env.APP_DB, user.userId, input.appId, {
+							title: input.existingApp.title,
+							description: input.existingApp.description,
+							sourceId: input.existingApp.sourceId,
+							hasServerCode: input.existingApp.hasServerCode,
+							parameters: input.existingApp.parameters,
+							hidden: input.existingApp.hidden,
+						}),
+						restorePublishedCommit(input.sourceId, input.previousPublishedCommit),
+					])
+					try {
+						await syncSavedAppRunnerFromDb({
+							env: ctx.env,
+							appId: input.appId,
+							userId: user.userId,
+							baseUrl: ctx.callerContext.baseUrl,
+						})
+					} catch {
+						// Preserve the original save failure.
+					}
+				}
+
+				let syncedArtifact: Awaited<ReturnType<typeof syncSavedAppRunnerFromDb>>
+				let syncedParameters:
+					| ReturnType<typeof parseUiArtifactParameters>
+					| undefined
 				try {
-					await configureSavedAppRunner({
+					syncedArtifact = await syncSavedAppRunnerFromDb({
 						env: ctx.env,
 						appId: input.appId,
 						userId: user.userId,
 						baseUrl: ctx.callerContext.baseUrl,
-						serverCode: input.serverCode,
-						serverCodeId: input.serverCodeId,
+					})
+					if (!syncedArtifact) {
+						throw new Error('Saved UI artifact not found for this user.')
+					}
+					syncedParameters = Array.isArray(syncedArtifact.parameters)
+						? syncedArtifact.parameters
+						: parseUiArtifactParameters(syncedArtifact.parameters)
+					await validateSavedAppRunner({
+						env: ctx.env,
+						appId: input.appId,
 					})
 				} catch (cause) {
 					if (!isUpdate) {
@@ -246,38 +278,22 @@ export const uiSaveAppCapability = defineDomainCapability(
 							),
 						])
 					} else if (input.existingApp) {
-						try {
-							await Promise.allSettled([
-								updateUiArtifact(ctx.env.APP_DB, user.userId, input.appId, {
-									title: input.existingApp.title,
-									description: input.existingApp.description,
-									sourceId: input.existingApp.sourceId,
-									hasServerCode: input.existingApp.hasServerCode,
-									parameters: input.existingApp.parameters,
-									hidden: input.existingApp.hidden,
-								}),
-								restorePublishedCommit(
-									input.sourceId,
-									input.previousPublishedCommit,
-								),
-							])
-						} catch {
-							// Preserve the original runner configuration failure.
-						}
+						await restoreExistingSavedAppState()
 					}
 					throw cause
 				}
 
 				try {
-					if (!input.hidden) {
+					const hasBackend = syncedArtifact.serverCode != null
+					if (!syncedArtifact.hidden) {
 						await upsertUiArtifactVector(ctx.env, {
 							appId: input.appId,
 							userId: user.userId,
 							embedText: buildUiArtifactEmbedText({
-								title: input.title,
-								description: input.description,
+								title: syncedArtifact.title,
+								description: syncedArtifact.description,
 								hasServerCode: hasBackend,
-								parameters: input.parameters,
+								parameters: syncedParameters ?? null,
 							}),
 						})
 					} else if (isUpdate) {
@@ -325,11 +341,11 @@ export const uiSaveAppCapability = defineDomainCapability(
 
 				return {
 					app_id: input.appId,
-					server_code_id: input.serverCodeId,
-					has_server_code: hasBackend,
+					server_code_id: syncedArtifact.serverCodeId,
+					has_server_code: syncedArtifact.serverCode != null,
 					hosted_url: buildSavedUiUrl(ctx.callerContext.baseUrl, input.appId),
-					parameters: input.parameters,
-					hidden: input.hidden,
+					parameters: syncedParameters ?? null,
+					hidden: syncedArtifact.hidden,
 				}
 			}
 
@@ -397,9 +413,8 @@ export const uiSaveAppCapability = defineDomainCapability(
 				const previousPublishedCommit = await readPublishedCommit(
 					ensuredSource.id,
 				)
-				let nextPublishedCommit: string | null = null
 				try {
-					nextPublishedCommit = await syncArtifactSourceSnapshot({
+					await syncArtifactSourceSnapshot({
 						env: ctx.env,
 						userId: user.userId,
 						baseUrl: ctx.callerContext.baseUrl,
@@ -431,13 +446,6 @@ export const uiSaveAppCapability = defineDomainCapability(
 				hidden = args.hidden ?? existingApp.hidden
 				return await saveAndIndexApp({
 					appId,
-					title,
-					description,
-					clientCode,
-					serverCode: serverCode ?? null,
-					serverCodeId: nextPublishedCommit ?? ensuredSource.id,
-					parameters,
-					hidden,
 					sourceId: ensuredSource.id,
 					previousPublishedCommit,
 					existingApp,
@@ -470,9 +478,8 @@ export const uiSaveAppCapability = defineDomainCapability(
 				const previousPublishedCommit = await readPublishedCommit(
 					ensuredSource.id,
 				)
-				let nextPublishedCommit: string | null = null
 				try {
-					nextPublishedCommit = await syncArtifactSourceSnapshot({
+					await syncArtifactSourceSnapshot({
 						env: ctx.env,
 						userId: user.userId,
 						baseUrl: ctx.callerContext.baseUrl,
@@ -496,13 +503,6 @@ export const uiSaveAppCapability = defineDomainCapability(
 				}
 				return await saveAndIndexApp({
 					appId,
-					title,
-					description,
-					clientCode,
-					serverCode,
-					serverCodeId: nextPublishedCommit ?? ensuredSource.id,
-					parameters,
-					hidden,
 					sourceId: ensuredSource.id,
 					previousPublishedCommit,
 					existingApp,

--- a/packages/worker/src/mcp/observability.workers.test.ts
+++ b/packages/worker/src/mcp/observability.workers.test.ts
@@ -285,6 +285,12 @@ test('ui_save_app capability logs success for valid invocation', async () => {
 									killSwitchEnabled: false,
 									lastError: null,
 								}),
+								validateBackend: async () => ({
+									ok: true,
+									appId: 'generated-app',
+									facetName: 'main',
+									validated: false,
+								}),
 							}
 						},
 					},
@@ -299,7 +305,7 @@ test('ui_save_app capability logs success for valid invocation', async () => {
 			},
 		)
 		expect(typeof (result as { app_id: string }).app_id).toBe('string')
-		expect((result as { hidden: boolean }).hidden).toBe(true)
+		expect((result as { hidden: boolean }).hidden).toBe(false)
 	} finally {
 		console.info = originalInfo
 	}
@@ -378,6 +384,12 @@ test('ui_save_app logs vector refresh failure for in-place updates and still suc
 									rateLimitPerMinute: 120,
 									killSwitchEnabled: false,
 									lastError: null,
+								}),
+								validateBackend: async () => ({
+									ok: true,
+									appId: 'app-1',
+									facetName: 'main',
+									validated: false,
 								}),
 							}
 						},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a first-class `kodyWidget.appBackend` client API with authenticated `fetch(...)` and `resolveUrl(...)` helpers for saved app backend calls
- validate saved app backends through the repo-backed runner path during `ui_save_app` so backend refactors fail fast when the runtime cannot load them
- update saved app docs and examples to use `kodyWidget.appBackend.fetch(...)` instead of raw `fetch(basePath + ...)`

## Testing
- `npm run test -- packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts`
- `npm run test -- packages/worker/src/mcp/capabilities/apps/ui-save-app.node.test.ts`
- `npm run test:mcp -- packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts`
- `npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5da6d76-bccf-487d-afc2-321e5c3f28f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5da6d76-bccf-487d-afc2-321e5c3f28f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

