### PR TITLE
Fix production deploy after AppRunner removal

### DIFF
--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -46,10 +46,6 @@
 			"new_sqlite_classes": ["RepoSession"],
 			"tag": "v11",
 		},
-		{
-			"deleted_classes": ["AppRunner"],
-			"tag": "v12",
-		},
 	],
 
 	"observability": {

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -46,6 +46,10 @@
 			"new_sqlite_classes": ["RepoSession"],
 			"tag": "v11",
 		},
+		{
+			"deleted_classes": ["AppRunner"],
+			"tag": "v12",
+		},
 	],
 
 	"observability": {

--- a/tools/ci/production-resources.ts
+++ b/tools/ci/production-resources.ts
@@ -315,6 +315,12 @@ async function ensureProductionResources(options: CliOptions) {
 		d1DatabaseName: d1.name,
 		d1DatabaseId: d1.id,
 		oauthKvId: kv.id,
+		extraMigrations: [
+			{
+				deleted_classes: ['AppRunner'],
+				tag: 'v12',
+			},
+		],
 		workerVars: {
 			APP_BASE_URL: process.env.APP_BASE_URL,
 			CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID,

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -5,6 +5,16 @@ import { resolveLocalBinary } from '../node-runtime.ts'
 
 type WranglerEnvName = 'preview' | 'production'
 
+type WranglerMigration = {
+	tag: string
+	deleted_classes?: Array<string>
+	new_sqlite_classes?: Array<string>
+	renamed_classes?: Array<{
+		from: string
+		to: string
+	}>
+}
+
 export type D1DatabaseListEntry = {
 	uuid: string
 	name: string
@@ -242,6 +252,7 @@ export async function writeGeneratedWranglerConfig({
 	d1DatabaseId,
 	oauthKvId,
 	workerVars,
+	extraMigrations,
 }: {
 	baseConfigPath: string
 	outConfigPath: string
@@ -250,6 +261,7 @@ export async function writeGeneratedWranglerConfig({
 	d1DatabaseId: string
 	oauthKvId: string
 	workerVars?: Record<string, string | undefined>
+	extraMigrations?: Array<WranglerMigration>
 }) {
 	const baseText = await readFile(baseConfigPath, 'utf8')
 	const config = parseJsonc<Record<string, unknown>>(baseText)
@@ -333,6 +345,23 @@ export async function writeGeneratedWranglerConfig({
 		}
 	}
 	;(targetEnv as Record<string, unknown>).vars = resolvedVars
+
+	const migrations = config.migrations
+	if (extraMigrations && extraMigrations.length > 0) {
+		if (!Array.isArray(migrations)) {
+			fail(`wrangler config "${baseConfigPath}" is missing top-level "migrations".`)
+		}
+
+		const migrationList = migrations as Array<Record<string, unknown>>
+		for (const extraMigration of extraMigrations) {
+			const alreadyExists = migrationList.some((migration) => {
+				return migration.tag === extraMigration.tag
+			})
+			if (!alreadyExists) {
+				migrationList.push(extraMigration)
+			}
+		}
+	}
 
 	const resolvedOut = path.resolve(outConfigPath)
 	await writeFile(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- keep the base `wrangler.jsonc` migrations unchanged for local, preview, and test environments
- extend the generated Wrangler config helper so production can append one-off top-level migrations
- have the production resource generator append `v12` deleting `AppRunner`, which production history still needs

### Root cause
- PR #221 removed the exported `AppRunner` Durable Object class, and production deploys failed because Cloudflare still had that class in deployed history
- adding the delete migration directly to the shared base config fixed production but broke preview/test environments where `AppRunner` never existed
- the fix is to scope that delete migration to the generated production config only

### Testing
- ✅ `node tools/ci/production-resources.ts ensure --dry-run --out-config packages/worker/wrangler-production.generated.json`
- ✅ `node tools/ci/preview-resources.ts ensure --worker-name kody-pr-227 --dry-run --out-config packages/worker/wrangler-preview.generated.json`
- ✅ `npm run test:mcp && npm run test:e2e:run -- --grep "generated UI shell rerenders inline and saved apps without document rewrites"`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a27770f3-8f19-4dc9-8e7c-423e0d8bc413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a27770f3-8f19-4dc9-8e7c-423e0d8bc413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved production configuration handling for database migrations with enhanced deduplication and version tracking of deprecated components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->