### PR TITLE
Share search ranking pipeline

### DIFF
--- a/packages/worker/src/agent-turn/tools.ts
+++ b/packages/worker/src/agent-turn/tools.ts
@@ -1,33 +1,15 @@
 import { tool, type ToolSet } from 'ai'
 import { z } from 'zod'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
-import {
-	parseConnectorConfig,
-	parseConnectorJson,
-	parseConnectorValueName,
-} from '#mcp/capabilities/values/connector-shared.ts'
 import { getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
-import {
-	cosineSimilarity,
-	deterministicEmbedding,
-	hybridSearchScore,
-	isCapabilitySearchOffline,
-	lexicalScore,
-} from '#mcp/capabilities/capability-search.ts'
 import {
 	loadDownRemoteConnectorStatuses,
 	loadOptionalSearchRows,
 	resolveSearchMemoryContext,
+	searchUnified,
 } from '#mcp/tools/search.ts'
 import { loadRelevantMemoriesForTool } from '#mcp/tools/memory-tool-context.ts'
-import {
-	buildValueEntityId,
-	describeValue,
-} from '#mcp/tools/search-entities.ts'
-import {
-	type SearchMatch,
-	toSlimStructuredMatches,
-} from '#mcp/tools/search-format.ts'
+import { toSlimStructuredMatches } from '#mcp/tools/search-format.ts'
 import {
 	listUserSecretsForSearch,
 } from '#mcp/secrets/service.ts'
@@ -107,120 +89,13 @@ export async function createAgentTurnToolSet(input: {
 							}),
 					}),
 				])
-				const query = args.query.trim()
-				const limit = args.limit ?? defaultSearchLimit
-				const queryEmbedding = deterministicEmbedding(query)
-				const capabilityMatches = Object.values(
-					registry.capabilitySpecs,
-				)
-					.map((spec) => ({
-						type: 'capability' as const,
-						name: spec.name,
-						description: spec.description,
-						score: lexicalScore(query, `${spec.name}\n${spec.description}`),
-					}))
-					.filter((match) => match.score > 0)
-				const packageMatches = optionalRows.packageRows
-					.map((entry) => {
-						const doc = [
-							entry.record.name,
-							entry.record.kodyId,
-							entry.record.description,
-							entry.record.tags.join(' '),
-							entry.record.searchText ?? '',
-						].join('\n')
-						const lexical = lexicalScore(query, doc)
-						const vector = cosineSimilarity(
-							queryEmbedding,
-							deterministicEmbedding(doc),
-						)
-						return {
-							type: 'package' as const,
-							packageId: entry.record.id,
-							kodyId: entry.record.kodyId,
-							name: entry.record.name,
-							title: entry.record.name,
-							description: entry.record.description,
-							tags: entry.record.tags,
-							hasApp: entry.record.hasApp,
-							score: hybridSearchScore(lexical, vector),
-						}
-					})
-					.filter((match) => match.score > 0)
-				const valueMatches = optionalRows.userValueRows
-					.flatMap((row) => {
-						if (parseConnectorValueName(row.name)) return []
-						return [
-							{
-								type: 'value' as const,
-								valueId: buildValueEntityId(row),
-								name: row.name,
-								description: describeValue(row),
-								scope: row.scope,
-								appId: row.appId,
-								score: lexicalScore(
-									query,
-									[row.name, row.description, row.scope, row.value].join('\n'),
-								),
-							},
-						]
-					})
-					.filter((match) => match.score > 0)
-				const connectorMatches = optionalRows.userValueRows
-					.flatMap((row) => {
-						const connectorName = parseConnectorValueName(row.name)
-						if (!connectorName) return []
-						const config = parseConnectorConfig(
-							parseConnectorJson(row.value),
-							connectorName,
-						)
-						if (!config) return []
-						return [
-							{
-								type: 'connector' as const,
-								connectorName,
-								title: connectorName,
-								description:
-									row.description.trim() ||
-									`Saved OAuth connector configuration (${config.flow} flow).`,
-								flow: config.flow,
-								apiBaseUrl: config.apiBaseUrl ?? null,
-								requiredHosts: config.requiredHosts ?? [],
-								score: lexicalScore(
-									query,
-									[
-										connectorName,
-										row.description,
-										config.tokenUrl,
-										config.apiBaseUrl ?? '',
-									].join('\n'),
-								),
-							},
-						]
-					})
-					.filter((match) => match.score > 0)
-				const secretMatches = optionalRows.userSecretRows
-					.map((row) => ({
-						type: 'secret' as const,
-						name: row.name,
-						description: row.description,
-						score: lexicalScore(query, `${row.name}\n${row.description}`),
-					}))
-					.filter((match) => match.score > 0)
-				const matches: Array<SearchMatch> = [
-					...capabilityMatches,
-					...packageMatches,
-					...valueMatches,
-					...connectorMatches,
-					...secretMatches,
-				]
-					.sort((left, right) => right.score - left.score)
-					.slice(0, limit)
-					.map(({ score: _score, ...match }) => match)
-				const result = {
-					matches,
-					offline: isCapabilitySearchOffline(input.env),
-				}
+				const result = searchUnified({
+					env: input.env,
+					query: args.query,
+					limit: args.limit ?? defaultSearchLimit,
+					registry,
+					optionalRows,
+				})
 				const remoteConnectorStatuses = await loadDownRemoteConnectorStatuses({
 					env: input.env,
 					callerContext: input.callerContext,

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -1,9 +1,145 @@
 import { expect, test } from 'vitest'
+import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
+import { buildConnectorValueName } from '#mcp/capabilities/values/connector-shared.ts'
 import {
 	loadDownHomeConnectorStatus,
 	loadOptionalSearchRows,
 	resolveSearchMemoryContext,
+	searchUnified,
+	type OptionalSearchRowsResult,
+	type PackageSearchRow,
 } from './search.ts'
+
+test('searchUnified ranks mixed search rows through one shared pipeline', () => {
+	const registry = buildCapabilityRegistry([
+		{
+			name: 'meta',
+			description: 'Meta capabilities',
+			capabilities: [
+				{
+					name: 'alpha beta',
+					domain: 'meta',
+					description: 'gamma helper',
+					keywords: [],
+					readOnly: true,
+					idempotent: true,
+					destructive: false,
+					inputSchema: {
+						type: 'object',
+						properties: {},
+					},
+					handler: async () => null,
+				},
+			],
+		},
+	])
+	const packageRows: Array<PackageSearchRow> = [
+		{
+			record: {
+				id: 'pkg-1',
+				userId: 'user-1',
+				name: 'alpha',
+				kodyId: 'beta',
+				description: 'gamma',
+				tags: ['delta'],
+				searchText: 'epsilon',
+				sourceId: 'source-1',
+				hasApp: false,
+				createdAt: '2026-04-20T00:00:00.000Z',
+				updatedAt: '2026-04-20T00:00:00.000Z',
+			},
+			projection: {
+				name: 'alpha',
+				kodyId: 'beta',
+				description: 'gamma',
+				tags: ['delta'],
+				searchText: 'epsilon',
+				hasApp: false,
+				exports: [],
+				jobs: [],
+			},
+		},
+	]
+	const optionalRows = {
+		packageRows,
+		userSecretRows: [
+			{
+				name: 'alpha-secret',
+				scope: 'user',
+				description: 'beta gamma delta secret',
+				appId: null,
+				updatedAt: '2026-04-20T00:00:00.000Z',
+			},
+		],
+		userValueRows: [
+			{
+				name: 'preferred-alpha',
+				scope: 'user',
+				value: 'beta',
+				description: 'gamma delta',
+				appId: null,
+				createdAt: '2026-04-20T00:00:00.000Z',
+				updatedAt: '2026-04-20T00:00:00.000Z',
+				ttlMs: null,
+			},
+			{
+				name: buildConnectorValueName('github'),
+				scope: 'user',
+				value: JSON.stringify({
+					tokenUrl: 'https://delta.example/token',
+					apiBaseUrl: 'https://epsilon.example/api',
+					flow: 'confidential',
+					clientIdValueName: 'github-client-id',
+					clientSecretSecretName: 'github-client-secret',
+					accessTokenSecretName: 'github-access-token',
+					refreshTokenSecretName: 'github-refresh-token',
+					requiredHosts: ['epsilon.example'],
+				}),
+				description: 'alpha beta gamma connector',
+				appId: null,
+				createdAt: '2026-04-20T00:00:00.000Z',
+				updatedAt: '2026-04-20T00:00:00.000Z',
+				ttlMs: null,
+			},
+		],
+		warnings: [],
+	} satisfies OptionalSearchRowsResult
+
+	const result = searchUnified({
+		env: {} as Env,
+		query: 'alpha\nbeta\ngamma\ndelta\nepsilon',
+		limit: 5,
+		registry,
+		optionalRows,
+	})
+
+	expect(result.offline).toBe(true)
+	expect(result.matches).toHaveLength(5)
+	expect(result.matches[0]).toMatchObject({
+		type: 'package',
+		packageId: 'pkg-1',
+	})
+	expect(result.matches).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				type: 'capability',
+				name: 'alpha beta',
+			}),
+			expect.objectContaining({
+				type: 'value',
+				name: 'preferred-alpha',
+			}),
+			expect.objectContaining({
+				type: 'connector',
+				connectorName: 'github',
+			}),
+			expect.objectContaining({
+				type: 'secret',
+				name: 'alpha-secret',
+			}),
+		]),
+	)
+})
 
 test('search memory context falls back to the query when omitted', () => {
 	expect(

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -115,15 +115,15 @@ test('searchUnified ranks mixed search rows through one shared pipeline', () => 
 
 	expect(result.offline).toBe(true)
 	expect(result.matches).toHaveLength(5)
-	expect(result.matches[0]).toMatchObject({
-		type: 'package',
-		packageId: 'pkg-1',
-	})
 	expect(result.matches).toEqual(
 		expect.arrayContaining([
 			expect.objectContaining({
 				type: 'capability',
 				name: 'alpha beta',
+			}),
+			expect.objectContaining({
+				type: 'package',
+				packageId: 'pkg-1',
 			}),
 			expect.objectContaining({
 				type: 'value',

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -8,11 +8,11 @@ import {
 } from '#mcp/capabilities/values/connector-shared.ts'
 import { getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
 import {
-	deterministicEmbedding,
-	lexicalScore,
 	cosineSimilarity,
+	deterministicEmbedding,
+	hybridSearchScore,
 	isCapabilitySearchOffline,
-	normalizeHybridSearchScore,
+	lexicalScore,
 } from '#mcp/capabilities/capability-search.ts'
 import {
 	listUserSecretsForSearch,
@@ -50,6 +50,7 @@ import {
 	resolveConversationId,
 } from './tool-call-context.ts'
 import {
+	type SearchMatch,
 	type SearchResultStructuredContent,
 	formatEntityDetailMarkdown,
 	formatSearchMarkdown,
@@ -64,13 +65,146 @@ const maxChars = maxTokens * charsPerToken
 const defaultSearchLimit = 15
 const defaultMaxResponseSize = 4_000
 
-type PackageSearchRow = {
+export type PackageSearchRow = {
 	record: Awaited<ReturnType<typeof listSavedPackagesByUserId>>[number]
 	projection: ReturnType<typeof buildPackageSearchProjection>
 }
 
-type SearchMatch =
-	Parameters<typeof toSlimStructuredMatches>[0]['matches'][number]
+export type OptionalSearchRowsResult = {
+	packageRows: Array<PackageSearchRow>
+	userSecretRows: Array<SecretSearchRow>
+	userValueRows: Array<ValueMetadata>
+	warnings: Array<string>
+}
+
+export function searchUnified(input: {
+	env: Env
+	query: string
+	limit: number
+	registry: Awaited<ReturnType<typeof getCapabilityRegistryForContext>>
+	optionalRows: Pick<
+		OptionalSearchRowsResult,
+		'packageRows' | 'userSecretRows' | 'userValueRows'
+	>
+}): { matches: Array<SearchMatch>; offline: boolean } {
+	const offline = isCapabilitySearchOffline(input.env)
+	const query = input.query.trim()
+	if (!query) {
+		return {
+			matches: [],
+			offline,
+		}
+	}
+
+	const limit = Math.max(1, input.limit)
+	const queryEmbedding = deterministicEmbedding(query)
+	const capabilityMatches = Object.values(input.registry.capabilitySpecs)
+		.map((spec) => ({
+			type: 'capability' as const,
+			name: spec.name,
+			description: spec.description,
+			score: lexicalScore(query, `${spec.name}\n${spec.description}`),
+		}))
+		.filter((match) => match.score > 0)
+	const packageMatches = input.optionalRows.packageRows
+		.map((entry) => {
+			const doc = [
+				entry.record.name,
+				entry.record.kodyId,
+				entry.record.description,
+				entry.record.tags.join(' '),
+				entry.record.searchText ?? '',
+			].join('\n')
+			const lexical = lexicalScore(query, doc)
+			const vector = cosineSimilarity(queryEmbedding, deterministicEmbedding(doc))
+			return {
+				type: 'package' as const,
+				packageId: entry.record.id,
+				kodyId: entry.record.kodyId,
+				name: entry.record.name,
+				title: entry.record.name,
+				description: entry.record.description,
+				tags: entry.record.tags,
+				hasApp: entry.record.hasApp,
+				score: hybridSearchScore(lexical, vector),
+			}
+		})
+		.filter((match) => match.score > 0)
+	const valueMatches = input.optionalRows.userValueRows
+		.flatMap((row) => {
+			if (parseConnectorValueName(row.name)) return []
+			return [
+				{
+					type: 'value' as const,
+					valueId: buildValueEntityId(row),
+					name: row.name,
+					description: describeValue(row),
+					scope: row.scope,
+					appId: row.appId,
+					score: lexicalScore(
+						query,
+						[row.name, row.description, row.scope, row.value].join('\n'),
+					),
+				},
+			]
+		})
+		.filter((match) => match.score > 0)
+	const connectorMatches = input.optionalRows.userValueRows
+		.flatMap((row) => {
+			const connectorName = parseConnectorValueName(row.name)
+			if (!connectorName) return []
+			const config = parseConnectorConfig(
+				parseConnectorJson(row.value),
+				connectorName,
+			)
+			if (!config) return []
+			return [
+				{
+					type: 'connector' as const,
+					connectorName,
+					title: connectorName,
+					description:
+						row.description.trim() ||
+						`Saved OAuth connector configuration (${config.flow} flow).`,
+					flow: config.flow,
+					apiBaseUrl: config.apiBaseUrl ?? null,
+					requiredHosts: config.requiredHosts ?? [],
+					score: lexicalScore(
+						query,
+						[
+							connectorName,
+							row.description,
+							config.tokenUrl,
+							config.apiBaseUrl ?? '',
+						].join('\n'),
+					),
+				},
+			]
+		})
+		.filter((match) => match.score > 0)
+	const secretMatches = input.optionalRows.userSecretRows
+		.map((row) => ({
+			type: 'secret' as const,
+			name: row.name,
+			description: row.description,
+			score: lexicalScore(query, `${row.name}\n${row.description}`),
+		}))
+		.filter((match) => match.score > 0)
+
+	return {
+		matches: [
+			...capabilityMatches,
+			...packageMatches,
+			...valueMatches,
+			...connectorMatches,
+			...secretMatches,
+		]
+			.sort((left, right) => right.score - left.score)
+			.slice(0, limit)
+			.map(({ score: _score, ...match }) => match),
+		offline,
+	}
+}
 
 export async function searchPackages(input: {
 	env: Env
@@ -222,13 +356,6 @@ https://github.com/kentcdodds/kody/blob/main/docs/use/search.md
 		openWorldHint: false,
 	} satisfies ToolAnnotations,
 } as const
-
-type OptionalSearchRowsResult = {
-	packageRows: Array<PackageSearchRow>
-	userSecretRows: Array<SecretSearchRow>
-	userValueRows: Array<ValueMetadata>
-	warnings: Array<string>
-}
 
 type SearchRowsAndRegistry = OptionalSearchRowsResult & {
 	registry: Awaited<ReturnType<typeof getCapabilityRegistryForContext>>
@@ -615,124 +742,22 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 							callerContext,
 							userId,
 							entity: args.entity,
-						searchRows,
+							searchRows,
 						}),
 					}
 				}
 
-				const capabilityMatches = Object.values(
-					searchRows.registry.capabilitySpecs,
-				)
-					.map((spec) => ({
-						type: 'capability' as const,
-						name: spec.name,
-						description: spec.description,
-						score: lexicalScore(args.query!, `${spec.name}\n${spec.description}`),
-					}))
-					.filter((match) => match.score > 0)
-				const packageMatches = searchRows.packageRows
-					.map((entry) => {
-						const doc = [
-							entry.record.name,
-							entry.record.kodyId,
-							entry.record.description,
-							entry.record.tags.join(' '),
-							entry.record.searchText ?? '',
-						].join('\n')
-						const lexical = lexicalScore(args.query!, doc)
-						const vector = cosineSimilarity(
-							deterministicEmbedding(args.query!),
-							deterministicEmbedding(doc),
-						)
-						return {
-							type: 'package' as const,
-							packageId: entry.record.id,
-							kodyId: entry.record.kodyId,
-							name: entry.record.name,
-							title: entry.record.name,
-							description: entry.record.description,
-							tags: entry.record.tags,
-							hasApp: entry.record.hasApp,
-							score: normalizeHybridSearchScore({
-								lexical,
-								vector,
-							}),
-						}
-					})
-					.filter((match) => match.score > 0)
-				const valueMatches = searchRows.userValueRows
-					.filter((row) => parseConnectorValueName(row.name) == null)
-					.map((row) => ({
-						type: 'value' as const,
-						valueId: buildValueEntityId(row),
-						name: row.name,
-						description: describeValue(row),
-						scope: row.scope,
-						appId: row.appId,
-						score: lexicalScore(
-							args.query!,
-							[row.name, row.description, row.scope, row.value].join('\n'),
-						),
-					}))
-					.filter((match) => match.score > 0)
-				const connectorMatches = searchRows.userValueRows
-					.flatMap((row) => {
-						const connectorName = parseConnectorValueName(row.name)
-						if (!connectorName) return []
-						const config = parseConnectorConfig(
-							parseConnectorJson(row.value),
-							connectorName,
-						)
-						if (!config) return []
-						return [
-							{
-								type: 'connector' as const,
-								connectorName,
-								title: connectorName,
-								description:
-									row.description.trim() ||
-									`Saved OAuth connector configuration (${config.flow} flow).`,
-								flow: config.flow,
-								apiBaseUrl: config.apiBaseUrl ?? null,
-								requiredHosts: config.requiredHosts ?? [],
-								score: lexicalScore(
-									args.query!,
-									[
-										connectorName,
-										row.description,
-										config.tokenUrl,
-										config.apiBaseUrl ?? '',
-									].join('\n'),
-								),
-							},
-						]
-					})
-					.filter((match) => match.score > 0)
-				const secretMatches = searchRows.userSecretRows
-					.map((row) => ({
-						type: 'secret' as const,
-						name: row.name,
-						description: row.description,
-						score: lexicalScore(args.query!, `${row.name}\n${row.description}`),
-					}))
-					.filter((match) => match.score > 0)
-				const allMatches = [
-					...capabilityMatches,
-					...packageMatches,
-					...valueMatches,
-					...connectorMatches,
-					...secretMatches,
-				]
-					.sort((left, right) => right.score - left.score)
-					.slice(0, limit)
-					.map(({ score: _score, ...match }) => match)
+				const result = searchUnified({
+					env: agent.getEnv(),
+					query: args.query!,
+					limit,
+					registry: searchRows.registry,
+					optionalRows: searchRows,
+				})
 
 				return {
 					mode: 'list' as const,
-					result: {
-						matches: allMatches,
-						offline: isCapabilitySearchOffline(agent.getEnv()),
-					},
+					result,
 				}
 			}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- extract the duplicated search ranking pipeline into `searchUnified` in `packages/worker/src/mcp/tools/search.ts`
- switch both the MCP `search` tool and the `agent-turn` search surface to call that shared helper so ranking cannot silently diverge
- add a focused node-unit regression test that exercises mixed capability/package/value/connector/secret ranking through the shared helper

## Testing
- `npx vitest --config vitest.node.config.ts packages/worker/src/mcp/tools/search.node.test.ts`
- `npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d89a5d1-b7f9-46c3-a09f-594ee5afcd0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d89a5d1-b7f9-46c3-a09f-594ee5afcd0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

