### PR TITLE
Clean up package migration leftovers

### DIFF
--- a/docs/talks/kody-mcp-runtime/README.md
+++ b/docs/talks/kody-mcp-runtime/README.md
@@ -15,10 +15,10 @@ forms when secrets and approvals matter.
 
 Center the narrative on **Cursor Cloud Agents + GitHub PR observability**:
 
-- A **saved generated UI** (Cursor Agent PR Dashboard) that polls Cursor and
+- A **package app** (Cursor Agent PR Dashboard) that polls Cursor and
   GitHub with secret-backed fetches.
-- **Saved skills** that wrap the same APIs for scripted checks: open PRs from
-  agents, agent status overview, follow-up on an agent.
+- **Saved package exports** that wrap the same APIs for scripted checks: open PRs
+  from agents, agent status overview, follow-up on an agent.
 
 That stack is “personal infrastructure”: not a one-off chat, but software you
 reopen and reuse.

--- a/docs/talks/kody-mcp-runtime/slides.md
+++ b/docs/talks/kody-mcp-runtime/slides.md
@@ -246,7 +246,7 @@ Now the rest of the talk explains how Kody solves those problems.
 <!--
 Map for the rest of the talk: discovery, execution, UI escape hatch.
 
-`search` finds capabilities, saved skills, saved apps, and secret references.
+`search` finds capabilities, saved packages, values, connectors, and secret references.
 `execute` runs an async function in Codemode to compose capability calls.
 `open_generated_ui` opens dynamically generated MCP Apps.
 
@@ -284,7 +284,7 @@ one "write code" tool, not a giant bag of disconnected tool calls.
 - Thin results → **rephrase** or check registry
 
 <!--
-`search` returns ranked hits across capabilities, saved skills, saved apps, and
+`search` returns ranked hits across capabilities, saved packages, values, connectors, and
 secret references. Top hits are what the agent should inspect first. Without
 `search`, `execute` is just guessing names and input shapes.
 
@@ -357,11 +357,11 @@ not "Kody has the smartest model." Use Kody on existing subscriptions instead of
 
 - **MCP server**, not a chat app
 - Any **MCP host** works
-- Compounds in **capabilities, apps, secrets, skills**
+- Compounds in **capabilities, package apps, secrets, package exports**
 
 <!--
-Portability: investment is the runtime layer — capabilities, saved apps,
-secrets, skills — not the current chat client. Bring your own agent, same runtime.
+Portability: investment is the runtime layer — capabilities, package apps,
+secrets, package exports — not the current chat client. Bring your own agent, same runtime.
 -->
 
 ---
@@ -398,7 +398,7 @@ secret; unapproved egress stays blocked.
 
 <!--
 Chat can launch the app; the app becomes durable software. Model generates UI;
-user can save as saved app. UI calls back for secrets, OAuth, approved API access.
+user can save it as a package app. UI calls back for secrets, OAuth, approved API access.
 -->
 
 ---
@@ -425,8 +425,8 @@ enough; generated UI OAuth is the exception, not the default.
 - Experiments → **personal infra**
 
 <!--
-Why it sticks: connected account powers automation and saved apps; OAuth fans out;
-saved app becomes internal tool; capability portable across MCP hosts.
+Why it sticks: connected accounts power automation and package apps; OAuth fans out;
+a package app becomes an internal tool; capabilities stay portable across MCP hosts.
 -->
 
 ---

--- a/e2e/generated-ui-shell.spec.ts
+++ b/e2e/generated-ui-shell.spec.ts
@@ -4,7 +4,7 @@ function escapeHtmlScriptContent(value: string) {
 	return value.replaceAll('</script>', '<\\/script>')
 }
 
-test('generated UI shell rerenders inline and saved apps without document rewrites', async ({
+test('generated UI shell rerenders inline and package apps without document rewrites', async ({
 	page,
 	baseURL,
 }) => {
@@ -33,15 +33,15 @@ test('generated UI shell rerenders inline and saved apps without document rewrit
 		'})',
 		'</script>',
 	].join('\n')
-	const savedHtml = [
+	const packageAppHtml = [
 		'<!doctype html>',
 		'<html lang="en" data-shell-phase="saved">',
 		'<head>',
-		'<title>Saved app</title>',
+		'<title>Package app</title>',
 		'<style>body { font-family: system-ui, sans-serif; }</style>',
 		'</head>',
 		'<body data-shell-body="saved">',
-		'<main id="saved-app"><button id="saved-app-button">Saved app</button></main>',
+		'<main id="package-app"><button id="package-app-button">Package app</button></main>',
 		'<script type="module">',
 		'const result = await window.kodyWidget.executeCode(\'async () => ({ phase: "saved", owner: window.kodyWidget.params.owner })\')',
 		'window.document.body.dataset.savedExecute = JSON.stringify(result)',
@@ -52,7 +52,7 @@ test('generated UI shell rerenders inline and saved apps without document rewrit
 		'</html>',
 	].join('\n')
 	const inlineHtmlJson = escapeHtmlScriptContent(JSON.stringify(inlineHtml))
-	const savedHtmlJson = escapeHtmlScriptContent(JSON.stringify(savedHtml))
+	const packageAppHtmlJson = escapeHtmlScriptContent(JSON.stringify(packageAppHtml))
 
 	await page.setContent(`
 		<!doctype html>
@@ -69,11 +69,11 @@ test('generated UI shell rerenders inline and saved apps without document rewrit
 						renderData: undefined,
 						lastSize: null,
 						toolCalls: [],
-						savedSource: {
-							app_id: 'saved-app-123',
-							title: 'Saved app',
-							description: 'Saved test app',
-							client_code: ${savedHtmlJson},
+						packageAppSource: {
+							app_id: 'package-app-123',
+							title: 'Package app',
+							description: 'Package test app',
+							client_code: ${packageAppHtmlJson},
 							server_code: null,
 							server_code_id: 'server-code-1',
 							parameters: null,
@@ -104,11 +104,11 @@ test('generated UI shell rerenders inline and saved apps without document rewrit
 							}
 							postRenderData()
 						},
-						renderSaved(params) {
+						renderPackageApp(params) {
 							hostState.renderData = {
 								toolOutput: {
 									renderSource: 'saved_package',
-									sourceCode: ${savedHtmlJson},
+									sourceCode: ${packageAppHtmlJson},
 									runtime: 'html',
 									params,
 								},
@@ -233,13 +233,13 @@ test('generated UI shell rerenders inline and saved apps without document rewrit
 		;(
 			window as typeof window & {
 				__generatedUiHostActions: {
-					renderSaved: (params: Record<string, unknown>) => void
+					renderPackageApp: (params: Record<string, unknown>) => void
 				}
 			}
-		).__generatedUiHostActions.renderSaved({ owner: 'beta', count: 2 })
+		).__generatedUiHostActions.renderPackageApp({ owner: 'beta', count: 2 })
 	})
 
-	await expect(frame.getByRole('button', { name: 'Saved app' })).toBeVisible()
+	await expect(frame.getByRole('button', { name: 'Package app' })).toBeVisible()
 	await expect(frame.locator('html')).toHaveAttribute(
 		'data-shell-phase',
 		'saved',

--- a/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
+++ b/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
@@ -13,7 +13,7 @@ const {
 	injectRuntimeStateIntoDocument,
 	kodyWidget,
 	measureRenderedFrameSize,
-	readSavedAppSourceFromHostToolResult,
+	readSavedPackageAppSourceFromHostToolResult,
 	shouldInitializeGeneratedUiRuntimeImmediately,
 } = uiUtils
 
@@ -142,8 +142,8 @@ test('injectRuntimeStateIntoDocument exposes runtime bootstrap globals', () => {
 	expect(result).toContain('window.params =')
 })
 
-test('readSavedAppSourceFromHostToolResult reads a package app source payload', () => {
-	const result = readSavedAppSourceFromHostToolResult({
+test('readSavedPackageAppSourceFromHostToolResult reads a package app source payload', () => {
+	const result = readSavedPackageAppSourceFromHostToolResult({
 		structuredContent: {
 			app_id: 'app-123',
 			client_code: '<main>hello</main>',
@@ -157,8 +157,8 @@ test('readSavedAppSourceFromHostToolResult reads a package app source payload', 
 	})
 })
 
-test('readSavedAppSourceFromHostToolResult preserves host tool errors', () => {
-	const result = readSavedAppSourceFromHostToolResult({
+test('readSavedPackageAppSourceFromHostToolResult preserves host tool errors', () => {
+	const result = readSavedPackageAppSourceFromHostToolResult({
 		isError: true,
 		structuredContent: {
 			error: {

--- a/packages/worker/client/mcp-apps/kody-ui-utils.ts
+++ b/packages/worker/client/mcp-apps/kody-ui-utils.ts
@@ -136,7 +136,7 @@ type HostToolResult = {
 	isError?: boolean
 }
 
-type SavedAppSourceFromHostToolResult =
+type SavedPackageAppSourceFromHostToolResult =
 	| {
 			handled: false
 	  }
@@ -317,9 +317,9 @@ function getHostToolErrorMessage(result: HostToolResult | null) {
 		: 'Code execution failed.'
 }
 
-export function readSavedAppSourceFromHostToolResult(
+export function readSavedPackageAppSourceFromHostToolResult(
 	result: HostToolResult | null,
-): SavedAppSourceFromHostToolResult {
+): SavedPackageAppSourceFromHostToolResult {
 	if (!result) {
 		return {
 			handled: false as const,

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -44,7 +44,7 @@ import {
 
 type SecretScope = 'app' | 'user'
 
-type SavedAppOption = {
+type PackageAppOption = {
 	id: string
 	title: string
 	updatedAt: string
@@ -71,7 +71,7 @@ type SecretDetail = SecretListItem & {
 type AccountSecretsPayload = {
 	ok: true
 	email: string
-	apps: Array<SavedAppOption>
+	apps: Array<PackageAppOption>
 	secrets: Array<SecretListItem>
 	selectedSecret: SecretDetail | null
 	approval: ApprovalView | null
@@ -117,7 +117,7 @@ function formatTimestamp(value: string) {
 	return new Date(value).toLocaleString()
 }
 
-function createEmptyEditorState(apps: Array<SavedAppOption>): EditorState {
+function createEmptyEditorState(apps: Array<PackageAppOption>): EditorState {
 	return {
 		currentId: null,
 		name: '',
@@ -336,7 +336,7 @@ function getDataRefreshKey(href: string) {
 
 function readFilterState(
 	href: string,
-	apps: Array<SavedAppOption>,
+	apps: Array<PackageAppOption>,
 ): SecretFilterState {
 	const url = new URL(href, 'http://localhost')
 	const search = url.searchParams.get('q')?.trim() ?? ''
@@ -393,7 +393,7 @@ function buildAppOptionDescription(updatedAt: string) {
 export function AccountSecretsRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
 	let email = ''
-	let apps: Array<SavedAppOption> = []
+	let apps: Array<PackageAppOption> = []
 	let secrets: Array<SecretListItem> = []
 	let selectedSecret: SecretDetail | null = null
 	let approval: ApprovalView | null = null
@@ -860,7 +860,7 @@ export function AccountSecretsRoute(handle: Handle) {
 						</h1>
 						<p css={{ color: colors.textMuted, margin: 0 }}>
 							Create, update, and delete the secrets available to your account
-							and saved apps.
+							and package apps.
 						</p>
 					</div>
 					<button

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -626,23 +626,23 @@ async function buildAccountSecretsPayload(input: {
 	env: Env
 	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
 	selectedSecretId?: string | null
-	savedApps?: Array<SavedPackageAppOption>
+	packageApps?: Array<SavedPackageAppOption>
 }): Promise<AccountSecretsPayload> {
 	const url = new URL(input.request.url)
 	const approvalToken = url.searchParams.get('request')
 	const requestedApprovalHost = readApprovalHost(url)
 	const requestedCapability = readRequestedCapability(url)
 
-	const savedApps =
-		input.savedApps ??
-		(await listSavedAppsForUser({
+	const packageApps =
+		input.packageApps ??
+		(await listPackageAppsForUser({
 			env: input.env,
 			user: input.user,
 		}))
 	const secrets = await listAccountSecrets({
 		env: input.env,
 		user: input.user,
-		savedApps,
+		packageApps,
 	})
 	const selectedSecret = input.selectedSecretId
 		? await resolveAccountSecretDetail({
@@ -666,14 +666,14 @@ async function buildAccountSecretsPayload(input: {
 	return {
 		ok: true,
 		email: input.user.email,
-		apps: savedApps,
+		apps: packageApps,
 		secrets,
 		selectedSecret,
 		approval,
 	}
 }
 
-async function listSavedAppsForUser(input: {
+async function listPackageAppsForUser(input: {
 	env: Env
 	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
 }) {
@@ -699,9 +699,9 @@ async function listSavedAppsForUser(input: {
 async function listAccountSecrets(input: {
 	env: Env
 	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
-	savedApps: Array<SavedPackageAppOption>
+	packageApps: Array<SavedPackageAppOption>
 }) {
-	const appTitles = new Map(input.savedApps.map((app) => [app.id, app.title]))
+	const appTitles = new Map(input.packageApps.map((app) => [app.id, app.title]))
 	const [userSecrets, appSecrets] = await Promise.all([
 		listSecrets({
 			env: input.env,
@@ -711,7 +711,7 @@ async function listAccountSecrets(input: {
 		listAppSecretsByAppIds({
 			env: input.env,
 			userId: input.user.mcpUser.userId,
-			appIds: input.savedApps.map((app) => app.id),
+			appIds: input.packageApps.map((app) => app.id),
 		}),
 	])
 
@@ -929,14 +929,14 @@ async function handleSaveAction(input: {
 		return jsonResponse({ ok: false, error: 'Secret scope is required.' }, 400)
 	}
 
-	const savedApps = await listSavedAppsForUser({
+	const packageApps = await listPackageAppsForUser({
 		env: input.env,
 		user: input.user,
 	})
 	const appId = readAppIdForScope({
 		body: input.body,
 		scope,
-		savedApps,
+		packageApps,
 	})
 	if (scope === 'app' && !appId) {
 		return jsonResponse(
@@ -948,7 +948,7 @@ async function handleSaveAction(input: {
 	const secrets = await listAccountSecrets({
 		env: input.env,
 		user: input.user,
-		savedApps,
+		packageApps,
 	})
 	const secretById = new Map(secrets.map((secret) => [secret.id, secret]))
 	const currentSecret = currentId ? (secretById.get(currentId) ?? null) : null
@@ -1021,7 +1021,7 @@ async function handleSaveAction(input: {
 			request: input.request,
 			env: input.env,
 			user: input.user,
-			savedApps,
+			packageApps,
 			selectedSecretId: nextId,
 		})
 		return jsonResponse(payload)
@@ -1135,12 +1135,12 @@ function readAccountSecretScope(
 function readAppIdForScope(input: {
 	body: object
 	scope: AccountEditableSecretScope
-	savedApps: Array<SavedPackageAppOption>
+	packageApps: Array<SavedPackageAppOption>
 }) {
 	if (input.scope !== 'app') return null
 	const appId = readString(input.body, 'appId')
 	if (!appId) return null
-	return input.savedApps.some((app) => app.id === appId) ? appId : null
+	return input.packageApps.some((app) => app.id === appId) ? appId : null
 }
 
 function jsonResponse(body: Record<string, unknown>, status = 200) {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -260,10 +260,6 @@ const workerHandler = {
 	fetch(request: Request, env: Env, ctx: ExecutionContext) {
 		const url = new URL(request.url)
 
-		if (url.pathname === '/api/skills/run') {
-			return apiHandler.fetch(request, env, ctx)
-		}
-
 		// OAuthProvider serves this URL first and defaults `resource` to the origin only.
 		// MCP clients must use `<origin>/mcp` as the resource (RFC 8707) to match our
 		// token audience; otherwise authorize stores origin but the token request sends

--- a/packages/worker/src/mcp/cloudflare/cloudflare-rest-client.ts
+++ b/packages/worker/src/mcp/cloudflare/cloudflare-rest-client.ts
@@ -1,7 +1,7 @@
 /**
  * Minimal Cloudflare API v4 HTTP client (Bearer token) for internal Worker-side
  * Cloudflare API calls and tests. User-facing Cloudflare API access is via
- * saved skills and secret-aware `fetch`; see
+ * saved package exports and secret-aware `fetch`; see
  * `docs/contributing/skill-patterns/cloudflare-api-v4.md`.
  *
  * @see https://developers.cloudflare.com/fundamentals/api/how-to/make-api-calls/

--- a/packages/worker/src/mcp/generated-ui-app-session.ts
+++ b/packages/worker/src/mcp/generated-ui-app-session.ts
@@ -101,7 +101,3 @@ export async function verifyGeneratedUiAppSession(
 	}
 	return payload as GeneratedUiAppSessionPayload
 }
-
-export function buildSavedAppBackendBasePath(appId: string) {
-	return `/app/${encodeURIComponent(appId)}`
-}

--- a/packages/worker/src/mcp/secrets/name-guards.ts
+++ b/packages/worker/src/mcp/secrets/name-guards.ts
@@ -1,8 +1,5 @@
 export const skillRunnerSecretNamePrefix = 'skill-runner-token:'
 
-export function buildSkillRunnerSecretName(clientName: string) {
-	return `${skillRunnerSecretNamePrefix}${clientName.trim()}`
-}
 
 export function parseSkillRunnerSecretClientName(secretName: string) {
 	if (!secretName.startsWith(skillRunnerSecretNamePrefix)) return null

--- a/packages/worker/src/mcp/ui-artifacts-embed.node.test.ts
+++ b/packages/worker/src/mcp/ui-artifacts-embed.node.test.ts
@@ -30,7 +30,7 @@ test('buildUiArtifactEmbedText summarizes searchable app metadata and truncates 
 		'mcp app',
 		'ui artifact',
 		'facet backend',
-		'saved app parameters',
+		'package app parameters',
 		'clientId string required Spotify client id',
 		'region string optional Spotify API region default "us"',
 	])

--- a/packages/worker/src/mcp/ui-artifacts-embed.ts
+++ b/packages/worker/src/mcp/ui-artifacts-embed.ts
@@ -18,7 +18,7 @@ export function buildUiArtifactEmbedText(
 	const parameterText =
 		input.parameters && input.parameters.length > 0
 			? [
-					'saved app parameters',
+					'package app parameters',
 					...input.parameters.map((parameter) =>
 						[
 							parameter.name,

--- a/packages/worker/src/repo/source-templates.ts
+++ b/packages/worker/src/repo/source-templates.ts
@@ -90,7 +90,7 @@ export function buildAppSourceFiles(input: {
 			input.serverCode ??
 			`export default {
   async fetch() {
-    return new Response('Saved app backend not configured.', { status: 404 })
+    return new Response('Package app backend not configured.', { status: 404 })
   },
 }`
 		).trim()}\n`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- remove dead package-migration leftovers (`/api/skills/run`, unused `/app/*` helper, unused skill-runner name builder)
- rename remaining saved-app/saved-skill terminology in package-app helpers, account-secrets UI copy, repo templates, and talk docs
- keep the generated UI shell e2e and helper tests aligned with the package-app wording

### Testing
- `npm run typecheck`
- `npm run test -- packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts packages/worker/src/mcp/ui-artifacts-embed.node.test.ts`
- `npm run test:e2e:run -- --grep "generated UI shell rerenders inline and package apps without document rewrites"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7afdbb11-2cb8-422c-92da-797bc393ae69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7afdbb11-2cb8-422c-92da-797bc393ae69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

