### PR TITLE
Add timing metadata to MCP tool responses

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -9,9 +9,9 @@ function Kody should invoke.
 Author code as one module string. Import runtime APIs from **`kody:runtime`**
 and export a default function:
 
-- use **`import { codemode } from 'kody:runtime'`** to call builtin
-  capabilities
-- use **`import { refreshAccessToken, createAuthenticatedFetch } from 'kody:runtime'`**
+- use **`import { codemode } from 'kody:runtime'`** to call builtin capabilities
+- use
+  **`import { refreshAccessToken, createAuthenticatedFetch } from 'kody:runtime'`**
   for connector OAuth helpers
 - use **`import { storage } from 'kody:runtime'`** when the execute call is
   bound to a storage id
@@ -26,13 +26,13 @@ Top-level `await` is acceptable when needed.
 ## Chaining
 
 Prefer **one execute** when the plan is clear: import what you need, call
-several capabilities or package exports, branch on results, and return the
-final structured result. Split into multiple **execute** calls only when you
-need new user input, confirmation, or a result that changes the plan.
+several capabilities or package exports, branch on results, and return the final
+structured result. Split into multiple **execute** calls only when you need new
+user input, confirmation, or a result that changes the plan.
 
 To read field shapes while coding, use **search** with
-**`entity: "{name}:capability"`** for builtin capability schemas, or inspect
-the relevant saved package with **`entity: "{kody_id}:package"`**.
+**`entity: "{name}:capability"`** for builtin capability schemas, or inspect the
+relevant saved package with **`entity: "{kody_id}:package"`**.
 
 ## Saved packages
 
@@ -87,6 +87,10 @@ For dedicated inspection, use:
 
 Kody can surface a small number of relevant long-term memories when you pass a
 short **`memoryContext`** with **`conversationId`** on normal MCP tool calls.
+
+Handled **execute** responses also include top-level **`timing`** metadata with
+`startedAt`, `endedAt`, and `durationMs` alongside `conversationId`. Use it for
+basic latency instrumentation around tool runs.
 
 For memory mutations, the workflow is explicit and strict:
 

--- a/docs/use/first-steps.md
+++ b/docs/use/first-steps.md
@@ -1,15 +1,17 @@
 # First steps
 
 Kody exposes **search**, **execute**, and **open generated UI** as the main
-tools. The agent should **search first** to find the right capability,
-package, connector, value, or secret reference, then run work through
-**execute**.
+tools. The agent should **search first** to find the right capability, package,
+connector, value, or secret reference, then run work through **execute**.
 
 ## Habits that help
 
 - **Reuse returned `conversationId` values.** If a prior tool response included
   one, pass it back unchanged on follow-up calls. Otherwise omit the field and
   use the server-generated value the tool returns. Do not make one up locally.
+- **Read `timing` when tool latency matters.** `search` and `execute` return
+  timing metadata with `startedAt`, `endedAt`, and `durationMs` in structured
+  responses.
 - **Pass `memoryContext`** when durable user memory may matter. Kody uses it to
   surface a small set of relevant long-term memories that have not already been
   shown in the same conversation.

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -13,6 +13,10 @@ When a tool call also includes **`memoryContext`**, Kody may attach a small
 number of relevant long-term memories that have not already been surfaced for
 that **`conversationId`**.
 
+Search responses also return top-level **`timing`** metadata with
+**`startedAt`**, **`endedAt`**, and **`durationMs`** so hosts can reason about
+how long the ranked lookup or entity lookup took.
+
 Optional **`limit`** caps how many ranked hits return. Optional
 **`maxResponseSize`** trims low-ranked matches when the response must stay
 small.

--- a/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
@@ -55,10 +55,12 @@ test('authenticated MCP smoke covers core tools, inline UI, and hosted package a
 	const searchStructured = (searchResult as CallToolResult).structuredContent as
 		| {
 				conversationId?: string
+				timing?: { durationMs?: number }
 				result?: { matches?: Array<unknown> }
 		  }
 		| undefined
 	expect(typeof searchStructured?.conversationId).toBe('string')
+	expect(typeof searchStructured?.timing?.durationMs).toBe('number')
 	expect(Array.isArray(searchStructured?.result?.matches)).toBe(true)
 
 	const upsertResult = await mcpClient.client.callTool({
@@ -83,8 +85,12 @@ test('authenticated MCP smoke covers core tools, inline UI, and hosted package a
 		},
 	})
 	const upsertStructured = (upsertResult as CallToolResult).structuredContent as
-		| { result?: { memory?: { id?: string } } }
+		| {
+				timing?: { durationMs?: number }
+				result?: { memory?: { id?: string } }
+		  }
 		| undefined
+	expect(typeof upsertStructured?.timing?.durationMs).toBe('number')
 	expect(typeof upsertStructured?.result?.memory?.id).toBe('string')
 
 	const memorySearchResult = await mcpClient.client.callTool({

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -28,6 +28,15 @@ beforeEach(() => {
 
 const mockPerformanceNow = vi.spyOn(performance, 'now')
 
+function mockPerformanceSequence(...values: Array<number>) {
+	let index = 0
+	mockPerformanceNow.mockImplementation(() => {
+		const value = values[Math.min(index, values.length - 1)] ?? 0
+		index += 1
+		return value
+	})
+}
+
 async function getExecuteHandler() {
 	const registerTool = vi.fn()
 
@@ -76,7 +85,7 @@ test('registers execute tool', async () => {
 
 test('execute tool passes through raw MCP content blocks in success responses', async () => {
 	const handler = await getExecuteHandler()
-	mockPerformanceNow.mockReturnValueOnce(100).mockReturnValueOnce(142)
+	mockPerformanceSequence(100, 142)
 	const rawContent: Array<ContentBlock> = [
 		{
 			type: 'image',
@@ -122,7 +131,7 @@ test('execute tool passes through raw MCP content blocks in success responses', 
 
 test('execute tool keeps serializing normal success results as text', async () => {
 	const handler = await getExecuteHandler()
-	mockPerformanceNow.mockReturnValueOnce(10).mockReturnValueOnce(19)
+	mockPerformanceSequence(10, 19)
 	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
 		result: { ok: true },
 		logs: [],
@@ -158,7 +167,7 @@ test('execute tool keeps serializing normal success results as text', async () =
 
 test('execute tool binds storage id and writable flag when provided', async () => {
 	const handler = await getExecuteHandler()
-	mockPerformanceNow.mockReturnValueOnce(1).mockReturnValueOnce(8)
+	mockPerformanceSequence(1, 8)
 	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
 		result: { ok: true },
 		logs: [],
@@ -205,7 +214,7 @@ test('execute tool binds storage id and writable flag when provided', async () =
 
 test('execute tool includes timing metadata in error responses', async () => {
 	const handler = await getExecuteHandler()
-	mockPerformanceNow.mockReturnValueOnce(50).mockReturnValueOnce(65)
+	mockPerformanceSequence(50, 65)
 	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
 		error: new Error('Boom'),
 		logs: [{ level: 'error', message: 'failed' }],

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -26,6 +26,8 @@ beforeEach(() => {
 	vi.clearAllMocks()
 })
 
+const mockPerformanceNow = vi.spyOn(performance, 'now')
+
 async function getExecuteHandler() {
 	const registerTool = vi.fn()
 
@@ -56,6 +58,11 @@ async function getExecuteHandler() {
 		structuredContent: {
 			conversationId: string
 			storage?: { id: string }
+			timing: {
+				startedAt: string
+				endedAt: string
+				durationMs: number
+			}
 			result: unknown
 			logs: Array<unknown>
 		}
@@ -69,6 +76,7 @@ test('registers execute tool', async () => {
 
 test('execute tool passes through raw MCP content blocks in success responses', async () => {
 	const handler = await getExecuteHandler()
+	mockPerformanceNow.mockReturnValueOnce(100).mockReturnValueOnce(142)
 	const rawContent: Array<ContentBlock> = [
 		{
 			type: 'image',
@@ -102,6 +110,11 @@ test('execute tool passes through raw MCP content blocks in success responses', 
 	])
 	expect(response.structuredContent).toEqual({
 		conversationId: 'conv-123',
+		timing: {
+			startedAt: expect.any(String),
+			endedAt: expect.any(String),
+			durationMs: 42,
+		},
 		result: null,
 		logs: [{ level: 'info', message: 'captured screenshot' }],
 	})
@@ -109,6 +122,7 @@ test('execute tool passes through raw MCP content blocks in success responses', 
 
 test('execute tool keeps serializing normal success results as text', async () => {
 	const handler = await getExecuteHandler()
+	mockPerformanceNow.mockReturnValueOnce(10).mockReturnValueOnce(19)
 	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
 		result: { ok: true },
 		logs: [],
@@ -132,6 +146,11 @@ test('execute tool keeps serializing normal success results as text', async () =
 	])
 	expect(response.structuredContent).toEqual({
 		conversationId: 'conv-456',
+		timing: {
+			startedAt: expect.any(String),
+			endedAt: expect.any(String),
+			durationMs: 9,
+		},
 		result: { ok: true },
 		logs: [],
 	})
@@ -139,6 +158,7 @@ test('execute tool keeps serializing normal success results as text', async () =
 
 test('execute tool binds storage id and writable flag when provided', async () => {
 	const handler = await getExecuteHandler()
+	mockPerformanceNow.mockReturnValueOnce(1).mockReturnValueOnce(8)
 	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
 		result: { ok: true },
 		logs: [],
@@ -173,7 +193,40 @@ test('execute tool binds storage id and writable flag when provided', async () =
 	expect(response.structuredContent).toEqual({
 		conversationId: 'conv-789',
 		storage: { id: 'job:lights-off' },
+		timing: {
+			startedAt: expect.any(String),
+			endedAt: expect.any(String),
+			durationMs: 7,
+		},
 		result: { ok: true },
 		logs: [],
 	})
+})
+
+test('execute tool includes timing metadata in error responses', async () => {
+	const handler = await getExecuteHandler()
+	mockPerformanceNow.mockReturnValueOnce(50).mockReturnValueOnce(65)
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		error: new Error('Boom'),
+		logs: [{ level: 'error', message: 'failed' }],
+	})
+
+	const response = await handler({
+		code: 'async () => { throw new Error("Boom") }',
+		conversationId: 'conv-error',
+	})
+
+	expect(response.isError).toBe(true)
+	expect(response.structuredContent).toEqual(
+		expect.objectContaining({
+			conversationId: 'conv-error',
+			timing: {
+				startedAt: expect.any(String),
+				endedAt: expect.any(String),
+				durationMs: 15,
+			},
+			error: 'Boom',
+			logs: [{ level: 'error', message: 'failed' }],
+		}),
+	)
 })

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -24,6 +24,7 @@ import {
 	formatSurfacedMemoriesMarkdown,
 	surfaceToolMemories,
 } from './memory-tool-context.ts'
+import { finishToolTiming, startToolTiming } from './tool-timing.ts'
 import { prependToolMetadataContent } from './tool-response-content.ts'
 
 const executeTool = {
@@ -133,7 +134,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 			conversationId?: string
 			memoryContext?: z.infer<typeof memoryContextInputField>
 		}) => {
-			const startedAt = performance.now()
+			const timingStart = startToolTiming()
 			const env = agent.getEnv()
 			const baseCallerContext = agent.getCallerContext()
 			const resolvedStorageId = storageId?.trim() || null
@@ -187,7 +188,8 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							: undefined,
 					}),
 			)
-			const durationMs = Math.round(performance.now() - startedAt)
+			const timing = finishToolTiming(timingStart)
+			const durationMs = timing.durationMs
 
 			if (result.error) {
 				const errorDetails = getExecutionErrorDetails(result.error)
@@ -216,6 +218,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					]),
 					structuredContent: {
 						conversationId: resolvedConversationId,
+						timing,
 						...(activeStorageId ? { storage: { id: activeStorageId } } : {}),
 						error: errorMessage,
 						errorDetails,
@@ -251,6 +254,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 				]),
 				structuredContent: {
 					conversationId: resolvedConversationId,
+					timing,
 					...(activeStorageId ? { storage: { id: activeStorageId } } : {}),
 					result: rawContent ? null : result.result,
 					logs: result.logs ?? [],

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -3,7 +3,6 @@ import { type CapabilitySpec } from '#mcp/capabilities/types.ts'
 import { type ConnectorConfig } from '#mcp/capabilities/values/connector-shared.ts'
 import { type SecretSearchRow } from '#mcp/secrets/types.ts'
 import { type ValueMetadata } from '#mcp/values/types.ts'
-import { type ToolTiming } from './tool-timing.ts'
 import {
 	type AuthoredPackageJson,
 	type PackageJobSchedule,
@@ -49,12 +48,6 @@ export type SearchResultStructuredContent = {
 		connected: boolean
 		toolCount: number
 	}>
-}
-
-export type SearchStructuredContent = {
-	conversationId: string
-	timing: ToolTiming
-	result: SearchResultStructuredContent | SearchEntityDetailStructured
 }
 
 export type SlimSearchMatch =

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -3,11 +3,12 @@ import { type CapabilitySpec } from '#mcp/capabilities/types.ts'
 import { type ConnectorConfig } from '#mcp/capabilities/values/connector-shared.ts'
 import { type SecretSearchRow } from '#mcp/secrets/types.ts'
 import { type ValueMetadata } from '#mcp/values/types.ts'
+import { type ToolTiming } from './tool-timing.ts'
 import {
 	type AuthoredPackageJson,
+	type PackageJobSchedule,
 	type SavedPackageRecord,
 } from '#worker/package-registry/types.ts'
-import { type PackageJobSchedule } from '#worker/package-registry/types.ts'
 
 export type SearchEntityType =
 	| 'capability'
@@ -48,6 +49,12 @@ export type SearchResultStructuredContent = {
 		connected: boolean
 		toolCount: number
 	}>
+}
+
+export type SearchStructuredContent = {
+	conversationId: string
+	timing: ToolTiming
+	result: SearchResultStructuredContent | SearchEntityDetailStructured
 }
 
 export type SlimSearchMatch =
@@ -273,7 +280,10 @@ function buildPackageImportSpecifier(kodyId: string, exportName: string) {
 	return `kody:@${kodyId}/${exportName.replace(/^\.\//, '')}`
 }
 
-function formatPackageSchedule(schedule: PackageJobSchedule, timezone?: string) {
+function formatPackageSchedule(
+	schedule: PackageJobSchedule,
+	timezone?: string,
+) {
 	if (schedule.type === 'cron') {
 		return `Runs on cron "${schedule.expression}" in ${timezone?.trim() || 'UTC'}`
 	}
@@ -395,7 +405,9 @@ function formatMatchBlock(match: SearchMatch, baseUrl: string) {
 		]
 	}
 	if (match.type === 'package') {
-		const hostedUrl = match.hasApp ? buildPackageHostedUrl(baseUrl, match.kodyId) : null
+		const hostedUrl = match.hasApp
+			? buildPackageHostedUrl(baseUrl, match.kodyId)
+			: null
 		return [
 			`## Package — ${match.title} (\`${match.kodyId}\`)`,
 			'',
@@ -561,7 +573,9 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 				const typesPath =
 					typeof target === 'string' ? null : (target.types ?? null)
 				const typesSource =
-					typesPath == null ? null : (detail.files[typesPath.replace(/^\.?\//, '')] ?? null)
+					typesPath == null
+						? null
+						: (detail.files[typesPath.replace(/^\.?\//, '')] ?? null)
 				return {
 					subpath: exportName,
 					importSpecifier: buildPackageImportSpecifier(

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -151,3 +151,27 @@ test('search tool includes timing metadata in validation errors', async () => {
 		error: 'Provide either "query" or "entity".',
 	})
 })
+
+test('search tool includes timing metadata in handled errors', async () => {
+	const handler = await getSearchHandler()
+	mockModule.getCapabilityRegistryForContext.mockRejectedValueOnce(
+		new Error('Registry unavailable'),
+	)
+	mockPerformanceNow.mockReturnValueOnce(20).mockReturnValueOnce(35)
+
+	const response = await handler({
+		query: 'search docs',
+		conversationId: 'conv-search-handled-error',
+	})
+
+	expect(response.isError).toBe(true)
+	expect(response.structuredContent).toEqual({
+		conversationId: 'conv-search-handled-error',
+		timing: {
+			startedAt: expect.any(String),
+			endedAt: expect.any(String),
+			durationMs: 15,
+		},
+		error: 'Registry unavailable',
+	})
+})

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getCapabilityRegistryForContext: vi.fn(async () => ({
+		capabilitySpecs: {
+			search_docs: {
+				name: 'search_docs',
+				description: 'Search docs capability',
+				domain: 'meta',
+				requiredInputFields: [],
+				readOnly: true,
+				idempotent: true,
+				destructive: false,
+				inputSchema: { type: 'object', properties: {} },
+			},
+		},
+	})),
+	listSavedPackagesByUserId: vi.fn(async () => []),
+	listUserSecretsForSearch: vi.fn(async () => []),
+	listValues: vi.fn(async () => []),
+	loadRelevantMemoriesForTool: vi.fn(async () => null),
+	getRemoteConnectorStatus: vi.fn(async () => ({
+		connectorKind: 'home',
+		connectorId: 'default',
+		state: 'connected',
+		connected: true,
+		toolCount: 1,
+	})),
+}))
+
+vi.mock('#mcp/capabilities/registry.ts', () => ({
+	getCapabilityRegistryForContext: (...args: Array<unknown>) =>
+		mockModule.getCapabilityRegistryForContext(...args),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageByKodyId: vi.fn(),
+	listSavedPackagesByUserId: (...args: Array<unknown>) =>
+		mockModule.listSavedPackagesByUserId(...args),
+}))
+
+vi.mock('#mcp/secrets/service.ts', () => ({
+	listUserSecretsForSearch: (...args: Array<unknown>) =>
+		mockModule.listUserSecretsForSearch(...args),
+}))
+
+vi.mock('#mcp/values/service.ts', () => ({
+	listValues: (...args: Array<unknown>) => mockModule.listValues(...args),
+}))
+
+vi.mock('./memory-tool-context.ts', async () => {
+	const actual = await vi.importActual('./memory-tool-context.ts')
+	return {
+		...actual,
+		loadRelevantMemoriesForTool: (...args: Array<unknown>) =>
+			mockModule.loadRelevantMemoriesForTool(...args),
+	}
+})
+
+vi.mock('#worker/home/status.ts', () => ({
+	getRemoteConnectorStatus: (...args: Array<unknown>) =>
+		mockModule.getRemoteConnectorStatus(...args),
+}))
+
+const { registerSearchTool } = await import('./search.ts')
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+const mockPerformanceNow = vi.spyOn(performance, 'now')
+
+async function getSearchHandler() {
+	const registerTool = vi.fn()
+
+	await registerSearchTool({
+		server: {
+			registerTool,
+		} as never,
+		getEnv: vi.fn(() => ({})),
+		getCallerContext: vi.fn(() => ({
+			baseUrl: 'https://example.com',
+			user: null,
+			homeConnectorId: 'default',
+			remoteConnectors: null,
+		})),
+	} as never)
+
+	expect(registerTool).toHaveBeenCalledTimes(1)
+	const [name, , handler] = registerTool.mock.calls[0] ?? []
+	expect(name).toBe('search')
+	expect(typeof handler).toBe('function')
+	return handler as (input: {
+		query?: string
+		entity?: string
+		limit?: number
+		conversationId?: string
+	}) => Promise<{
+		structuredContent: {
+			conversationId: string
+			timing: {
+				startedAt: string
+				endedAt: string
+				durationMs: number
+			}
+			error?: string
+			result?: unknown
+		}
+		isError?: boolean
+	}>
+}
+
+test('search tool includes timing metadata in success responses', async () => {
+	const handler = await getSearchHandler()
+	mockPerformanceNow.mockReturnValueOnce(100).mockReturnValueOnce(112)
+
+	const response = await handler({
+		query: 'search docs',
+		conversationId: 'conv-search',
+	})
+
+	expect(response.isError).toBeUndefined()
+	expect(response.structuredContent).toEqual(
+		expect.objectContaining({
+			conversationId: 'conv-search',
+			timing: {
+				startedAt: expect.any(String),
+				endedAt: expect.any(String),
+				durationMs: 12,
+			},
+		}),
+	)
+})
+
+test('search tool includes timing metadata in validation errors', async () => {
+	const handler = await getSearchHandler()
+	mockPerformanceNow.mockReturnValueOnce(5).mockReturnValueOnce(9)
+
+	const response = await handler({
+		conversationId: 'conv-search-error',
+	})
+
+	expect(response.isError).toBe(true)
+	expect(response.structuredContent).toEqual({
+		conversationId: 'conv-search-error',
+		timing: {
+			startedAt: expect.any(String),
+			endedAt: expect.any(String),
+			durationMs: 4,
+		},
+		error: 'Provide either "query" or "entity".',
+	})
+})

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -14,9 +14,7 @@ import {
 	isCapabilitySearchOffline,
 	lexicalScore,
 } from '#mcp/capabilities/capability-search.ts'
-import {
-	listUserSecretsForSearch,
-} from '#mcp/secrets/service.ts'
+import { listUserSecretsForSearch } from '#mcp/secrets/service.ts'
 import { type SecretSearchRow } from '#mcp/secrets/types.ts'
 import { type McpRegistrationAgent } from '#mcp/mcp-registration-agent.ts'
 import { loadRelevantMemoriesForTool } from '#mcp/tools/memory-tool-context.ts'
@@ -32,7 +30,7 @@ import {
 	listSavedPackagesByUserId,
 } from '#worker/package-registry/repo.ts'
 import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
-import { buildPackageSearchProjection } from '#worker/package-registry/manifest.ts'
+import { type buildPackageSearchProjection } from '#worker/package-registry/manifest.ts'
 import {
 	getRemoteConnectorStatus,
 	type HomeConnectorStatus,
@@ -57,6 +55,7 @@ import {
 	parseEntityRef,
 	toSlimStructuredMatches,
 } from './search-format.ts'
+import { finishToolTiming, startToolTiming } from './tool-timing.ts'
 import { prependToolMetadataContent } from './tool-response-content.ts'
 
 const charsPerToken = 4
@@ -116,7 +115,10 @@ export function searchUnified(input: {
 				entry.record.searchText ?? '',
 			].join('\n')
 			const lexical = lexicalScore(query, doc)
-			const vector = cosineSimilarity(queryEmbedding, deterministicEmbedding(doc))
+			const vector = cosineSimilarity(
+				queryEmbedding,
+				deterministicEmbedding(doc),
+			)
 			return {
 				type: 'package' as const,
 				packageId: entry.record.id,
@@ -231,7 +233,10 @@ export async function searchPackages(input: {
 				row.projection.jobs.map((job) => job.name).join(' '),
 			].join('\n')
 			const lexical = lexicalScore(query, document)
-			const vector = cosineSimilarity(queryEmbedding, deterministicEmbedding(document))
+			const vector = cosineSimilarity(
+				queryEmbedding,
+				deterministicEmbedding(document),
+			)
 			return {
 				row,
 				score: lexical + vector,
@@ -311,8 +316,7 @@ function applyMaxResponseSize<TPayload>(
 
 const searchTool = {
 	name: 'search',
-	title:
-		'Search Capabilities, Packages, Values, Connectors, and Secrets',
+	title: 'Search Capabilities, Packages, Values, Connectors, and Secrets',
 	description: `
 Find **built-in capabilities**, **saved packages**, **persisted values**,
 **saved connectors**, and **user secret references** (metadata only)
@@ -423,15 +427,12 @@ export async function loadOptionalSearchRows(input: {
 	}
 
 	const warnings: Array<string> = []
-	const [
-		packageRowsResult,
-		userSecretRowsResult,
-		userValueRowsResult,
-	] = await Promise.allSettled([
-		input.loadPackages(),
-		input.loadUserSecrets(),
-		input.loadUserValues(),
-	])
+	const [packageRowsResult, userSecretRowsResult, userValueRowsResult] =
+		await Promise.allSettled([
+			input.loadPackages(),
+			input.loadUserSecrets(),
+			input.loadUserValues(),
+		])
 
 	const packageRows =
 		packageRowsResult.status === 'fulfilled' ? packageRowsResult.value : []
@@ -697,12 +698,13 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 			conversationId?: string
 			memoryContext?: z.infer<typeof memoryContextInputField>
 		}) => {
-			const startedAt = performance.now()
+			const timingStart = startToolTiming()
 			const conversationId = resolveConversationId(args.conversationId)
 			const callerContext = agent.getCallerContext()
 			const { baseUrl, hasUser } = callerContextFields(callerContext)
 			const userId = callerContext.user?.userId ?? null
 			if (!args.query && !args.entity) {
+				const timing = finishToolTiming(timingStart)
 				return {
 					content: prependToolMetadataContent(conversationId, [
 						{
@@ -712,6 +714,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					]),
 					structuredContent: {
 						conversationId,
+						timing,
 						error: 'Provide either "query" or "entity".',
 					},
 					isError: true,
@@ -764,10 +767,10 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 			let outcome:
 				| {
 						mode: 'list'
-				result: {
-					matches: Array<SearchMatch>
-					offline: boolean
-				}
+						result: {
+							matches: Array<SearchMatch>
+							offline: boolean
+						}
 				  }
 				| {
 						mode: 'entity'
@@ -785,7 +788,8 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					searchSpan,
 				)
 			} catch (cause) {
-				const durationMs = Math.round(performance.now() - startedAt)
+				const timing = finishToolTiming(timingStart)
+				const durationMs = timing.durationMs
 				const error = cause instanceof Error ? cause : new Error(String(cause))
 				const { errorName, errorMessage } = errorFields(error)
 				logMcpEvent({
@@ -807,13 +811,15 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					]),
 					structuredContent: {
 						conversationId,
+						timing,
 						error: error.message,
 					},
 					isError: true,
 				}
 			}
 
-			const durationMs = Math.round(performance.now() - startedAt)
+			const timing = finishToolTiming(timingStart)
+			const durationMs = timing.durationMs
 
 			logMcpEvent({
 				category: 'mcp',
@@ -836,6 +842,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					]),
 					structuredContent: {
 						conversationId,
+						timing,
 						result: entityResult.structured,
 					},
 				}
@@ -979,6 +986,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 				]),
 				structuredContent: {
 					conversationId,
+					timing,
 					result,
 				},
 			}

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -764,20 +764,19 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 				}
 			}
 
-			let outcome:
-				| {
-						mode: 'list'
-						result: {
-							matches: Array<SearchMatch>
-							offline: boolean
-						}
-				  }
-				| {
-						mode: 'entity'
-						detail: Awaited<ReturnType<typeof resolveEntityDetail>>
-				  }
 			try {
-				outcome = await Sentry.startSpan(
+				const outcome:
+					| {
+							mode: 'list'
+							result: {
+								matches: Array<SearchMatch>
+								offline: boolean
+							}
+					  }
+					| {
+							mode: 'entity'
+							detail: Awaited<ReturnType<typeof resolveEntityDetail>>
+					  } = await Sentry.startSpan(
 					{
 						name: 'mcp.tool.search',
 						op: 'mcp.tool',
@@ -787,9 +786,187 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					},
 					searchSpan,
 				)
+
+				if (outcome.mode === 'entity') {
+					const entityResult = formatEntityDetailMarkdown(outcome.detail)
+					const timing = finishToolTiming(timingStart)
+					logMcpEvent({
+						category: 'mcp',
+						tool: 'search',
+						toolName: 'search',
+						outcome: 'success',
+						durationMs: timing.durationMs,
+						baseUrl,
+						hasUser,
+					})
+					return {
+						content: prependToolMetadataContent(conversationId, [
+							{
+								type: 'text',
+								text: truncateSearchText(entityResult.markdown),
+							},
+						]),
+						structuredContent: {
+							conversationId,
+							timing,
+							result: entityResult.structured,
+						},
+					}
+				}
+
+				const normalizedRemoteConnectorStatuses =
+					remoteConnectorDownStatuses.length > 0
+						? remoteConnectorDownStatuses.map(serializeRemoteConnectorStatus)
+						: undefined
+				const normalizedHomeConnectorStatus =
+					remoteConnectorDownStatuses.length === 1 &&
+					remoteConnectorDownStatuses[0]?.connectorKind === 'home'
+						? serializeRemoteConnectorStatus(remoteConnectorDownStatuses[0]!)
+						: undefined
+				const memoryToolContext = await loadRelevantMemoriesForTool({
+					env: agent.getEnv(),
+					callerContext,
+					conversationId,
+					memoryContext: resolveSearchMemoryContext({
+						query: args.query,
+						memoryContext: args.memoryContext,
+					}),
+				})
+				const searchMemories = memoryToolContext
+					? {
+							surfaced: memoryToolContext.memories,
+							suppressedCount: memoryToolContext.suppressedCount,
+							retrievalQuery: memoryToolContext.retrievalQuery,
+						}
+					: undefined
+
+				const payload: {
+					matches: Array<SearchMatch>
+					offline: boolean
+					warnings: Array<string>
+					memories?: SearchResultStructuredContent['memories']
+					homeConnectorStatus?: {
+						connectorKind: string
+						connectorId: string
+						state: string
+						connected: boolean
+						toolCount: number
+					}
+					remoteConnectorStatuses?: Array<{
+						connectorKind: string
+						connectorId: string
+						state: string
+						connected: boolean
+						toolCount: number
+					}>
+				} = {
+					matches: outcome.result.matches,
+					offline: outcome.result.offline,
+					warnings,
+					...(searchMemories
+						? {
+								memories: searchMemories,
+							}
+						: {}),
+					...(normalizedRemoteConnectorStatuses
+						? {
+								remoteConnectorStatuses: normalizedRemoteConnectorStatuses,
+							}
+						: {}),
+					...(normalizedHomeConnectorStatus
+						? {
+								homeConnectorStatus: normalizedHomeConnectorStatus,
+							}
+						: {}),
+				}
+				const statefulAgent = agent as McpRegistrationAgent & {
+					state?: {
+						searchConversationIdsWithPreamble?: Array<string>
+					}
+					setState?: (state: {
+						searchConversationIdsWithPreamble?: Array<string>
+					}) => void
+				}
+				const searchConversationIdsWithPreamble = Array.isArray(
+					statefulAgent.state?.searchConversationIdsWithPreamble,
+				)
+					? (statefulAgent.state?.searchConversationIdsWithPreamble ?? [])
+					: []
+				const includePreamble =
+					!args.conversationId ||
+					!searchConversationIdsWithPreamble.includes(conversationId)
+				if (includePreamble && typeof statefulAgent.setState === 'function') {
+					statefulAgent.setState({
+						...(statefulAgent.state ?? {}),
+						searchConversationIdsWithPreamble: [
+							...searchConversationIdsWithPreamble,
+							conversationId,
+						],
+					})
+				}
+				const { payload: trimmedPayload, serialized } = applyMaxResponseSize(
+					payload,
+					maxResponseSize,
+					(value) =>
+						formatSearchMarkdown({
+							matches: value.matches,
+							warnings: value.warnings,
+							memories: value.memories,
+							baseUrl,
+							includePreamble,
+						}),
+					(value, count) => ({
+						...value,
+						matches: value.matches.slice(0, count),
+					}),
+					(value) => value.matches.length,
+				)
+				const result: SearchResultStructuredContent = {
+					offline: trimmedPayload.offline,
+					warnings: trimmedPayload.warnings,
+					...(trimmedPayload.memories
+						? {
+								memories: trimmedPayload.memories,
+							}
+						: {}),
+					...(trimmedPayload.homeConnectorStatus
+						? { homeConnectorStatus: trimmedPayload.homeConnectorStatus }
+						: {}),
+					...(trimmedPayload.remoteConnectorStatuses
+						? {
+								remoteConnectorStatuses: trimmedPayload.remoteConnectorStatuses,
+							}
+						: {}),
+					matches: toSlimStructuredMatches({
+						matches: trimmedPayload.matches,
+						baseUrl,
+					}),
+				}
+				const timing = finishToolTiming(timingStart)
+				logMcpEvent({
+					category: 'mcp',
+					tool: 'search',
+					toolName: 'search',
+					outcome: 'success',
+					durationMs: timing.durationMs,
+					baseUrl,
+					hasUser,
+				})
+				return {
+					content: prependToolMetadataContent(conversationId, [
+						{
+							type: 'text',
+							text: truncateSearchText(serialized),
+						},
+					]),
+					structuredContent: {
+						conversationId,
+						timing,
+						result,
+					},
+				}
 			} catch (cause) {
 				const timing = finishToolTiming(timingStart)
-				const durationMs = timing.durationMs
 				const error = cause instanceof Error ? cause : new Error(String(cause))
 				const { errorName, errorMessage } = errorFields(error)
 				logMcpEvent({
@@ -797,7 +974,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					tool: 'search',
 					toolName: 'search',
 					outcome: 'failure',
-					durationMs,
+					durationMs: timing.durationMs,
 					baseUrl,
 					hasUser,
 					sandboxError: false,
@@ -816,179 +993,6 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					},
 					isError: true,
 				}
-			}
-
-			const timing = finishToolTiming(timingStart)
-			const durationMs = timing.durationMs
-
-			logMcpEvent({
-				category: 'mcp',
-				tool: 'search',
-				toolName: 'search',
-				outcome: 'success',
-				durationMs,
-				baseUrl,
-				hasUser,
-			})
-
-			if (outcome.mode === 'entity') {
-				const entityResult = formatEntityDetailMarkdown(outcome.detail)
-				return {
-					content: prependToolMetadataContent(conversationId, [
-						{
-							type: 'text',
-							text: truncateSearchText(entityResult.markdown),
-						},
-					]),
-					structuredContent: {
-						conversationId,
-						timing,
-						result: entityResult.structured,
-					},
-				}
-			}
-
-			const normalizedRemoteConnectorStatuses =
-				remoteConnectorDownStatuses.length > 0
-					? remoteConnectorDownStatuses.map(serializeRemoteConnectorStatus)
-					: undefined
-			const normalizedHomeConnectorStatus =
-				remoteConnectorDownStatuses.length === 1 &&
-				remoteConnectorDownStatuses[0]?.connectorKind === 'home'
-					? serializeRemoteConnectorStatus(remoteConnectorDownStatuses[0]!)
-					: undefined
-			const memoryToolContext = await loadRelevantMemoriesForTool({
-				env: agent.getEnv(),
-				callerContext,
-				conversationId,
-				memoryContext: resolveSearchMemoryContext({
-					query: args.query,
-					memoryContext: args.memoryContext,
-				}),
-			})
-			const searchMemories = memoryToolContext
-				? {
-						surfaced: memoryToolContext.memories,
-						suppressedCount: memoryToolContext.suppressedCount,
-						retrievalQuery: memoryToolContext.retrievalQuery,
-					}
-				: undefined
-
-			const payload: {
-				matches: Array<SearchMatch>
-				offline: boolean
-				warnings: Array<string>
-				memories?: SearchResultStructuredContent['memories']
-				homeConnectorStatus?: {
-					connectorKind: string
-					connectorId: string
-					state: string
-					connected: boolean
-					toolCount: number
-				}
-				remoteConnectorStatuses?: Array<{
-					connectorKind: string
-					connectorId: string
-					state: string
-					connected: boolean
-					toolCount: number
-				}>
-			} = {
-				matches: outcome.result.matches,
-				offline: outcome.result.offline,
-				warnings,
-				...(searchMemories
-					? {
-							memories: searchMemories,
-						}
-					: {}),
-				...(normalizedRemoteConnectorStatuses
-					? {
-							remoteConnectorStatuses: normalizedRemoteConnectorStatuses,
-						}
-					: {}),
-				...(normalizedHomeConnectorStatus
-					? {
-							homeConnectorStatus: normalizedHomeConnectorStatus,
-						}
-					: {}),
-			}
-			const statefulAgent = agent as McpRegistrationAgent & {
-				state?: {
-					searchConversationIdsWithPreamble?: Array<string>
-				}
-				setState?: (state: {
-					searchConversationIdsWithPreamble?: Array<string>
-				}) => void
-			}
-			const searchConversationIdsWithPreamble = Array.isArray(
-				statefulAgent.state?.searchConversationIdsWithPreamble,
-			)
-				? (statefulAgent.state?.searchConversationIdsWithPreamble ?? [])
-				: []
-			const includePreamble =
-				!args.conversationId ||
-				!searchConversationIdsWithPreamble.includes(conversationId)
-			if (includePreamble && typeof statefulAgent.setState === 'function') {
-				statefulAgent.setState({
-					...(statefulAgent.state ?? {}),
-					searchConversationIdsWithPreamble: [
-						...searchConversationIdsWithPreamble,
-						conversationId,
-					],
-				})
-			}
-			const { payload: trimmedPayload, serialized } = applyMaxResponseSize(
-				payload,
-				maxResponseSize,
-				(value) =>
-					formatSearchMarkdown({
-						matches: value.matches,
-						warnings: value.warnings,
-						memories: value.memories,
-						baseUrl,
-						includePreamble,
-					}),
-				(value, count) => ({
-					...value,
-					matches: value.matches.slice(0, count),
-				}),
-				(value) => value.matches.length,
-			)
-			const result: SearchResultStructuredContent = {
-				offline: trimmedPayload.offline,
-				warnings: trimmedPayload.warnings,
-				...(trimmedPayload.memories
-					? {
-							memories: trimmedPayload.memories,
-						}
-					: {}),
-				...(trimmedPayload.homeConnectorStatus
-					? { homeConnectorStatus: trimmedPayload.homeConnectorStatus }
-					: {}),
-				...(trimmedPayload.remoteConnectorStatuses
-					? {
-							remoteConnectorStatuses: trimmedPayload.remoteConnectorStatuses,
-						}
-					: {}),
-				matches: toSlimStructuredMatches({
-					matches: trimmedPayload.matches,
-					baseUrl,
-				}),
-			}
-
-			return {
-				content: prependToolMetadataContent(conversationId, [
-					{
-						type: 'text',
-						text: truncateSearchText(serialized),
-					},
-				]),
-				structuredContent: {
-					conversationId,
-					timing,
-					result,
-				},
 			}
 		},
 	)

--- a/packages/worker/src/mcp/tools/tool-timing.ts
+++ b/packages/worker/src/mcp/tools/tool-timing.ts
@@ -17,9 +17,13 @@ export function startToolTiming(): ToolTimingStart {
 }
 
 export function finishToolTiming(start: ToolTimingStart): ToolTiming {
+	const durationMs = Math.max(
+		0,
+		Math.round(performance.now() - start.startedAtMs),
+	)
 	return {
 		startedAt: start.startedAt,
-		endedAt: new Date().toISOString(),
-		durationMs: Math.max(0, Math.round(performance.now() - start.startedAtMs)),
+		endedAt: new Date(Date.parse(start.startedAt) + durationMs).toISOString(),
+		durationMs,
 	}
 }

--- a/packages/worker/src/mcp/tools/tool-timing.ts
+++ b/packages/worker/src/mcp/tools/tool-timing.ts
@@ -1,0 +1,25 @@
+export type ToolTiming = {
+	startedAt: string
+	endedAt: string
+	durationMs: number
+}
+
+type ToolTimingStart = {
+	startedAt: string
+	startedAtMs: number
+}
+
+export function startToolTiming(): ToolTimingStart {
+	return {
+		startedAt: new Date().toISOString(),
+		startedAtMs: performance.now(),
+	}
+}
+
+export function finishToolTiming(start: ToolTimingStart): ToolTiming {
+	return {
+		startedAt: start.startedAt,
+		endedAt: new Date().toISOString(),
+		durationMs: Math.max(0, Math.round(performance.now() - start.startedAtMs)),
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- expose top-level `structuredContent.timing` metadata for `search` and `execute` responses
- reuse a shared timing helper and cover success, handled-error, and transport paths in focused MCP tests
- address valid AI review feedback by removing an unused exported type, tightening `search` success/error timing behavior, and reducing timing-test brittleness

## Testing
- `npm run test -- packages/worker/src/mcp/tools/execute.node.test.ts packages/worker/src/mcp/tools/search.node.test.ts packages/worker/src/mcp/tools/search-handler.node.test.ts`
- `npm run test:mcp`
- `npm run typecheck`
- `npm run format:check -- packages/worker/src/mcp/tools/search.ts packages/worker/src/mcp/tools/search-format.ts packages/worker/src/mcp/tools/tool-timing.ts packages/worker/src/mcp/tools/execute.node.test.ts packages/worker/src/mcp/tools/search-handler.node.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1147c97c-b326-4f03-941f-15d59487855b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1147c97c-b326-4f03-941f-15d59487855b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search and execute responses now include timing metadata (startedAt, endedAt, durationMs) for latency instrumentation.

* **Documentation**
  * Guides updated to document timing metadata and recommend reading it from search/execute results and examples.

* **Tests**
  * Added and extended tests to assert timing metadata is present and correctly computed across success, validation, and error cases.

* **Refactor**
  * Centralized timing measurement used across tools to produce consistent timing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->