### PR TITLE
Clarify package state ownership across package surfaces

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -72,6 +72,31 @@ Storage split:
   due jobs
 - `StorageRunner` SQLite: isolated durable state addressed by `storageId`
 
+### Package state model
+
+For saved packages, use this mental model:
+
+- **package source**: the repo-backed package rooted at `package.json`
+- **package config**: manifest metadata plus app-scoped values/secrets keyed by
+  the saved package id (`appId`)
+- **package storage**: durable `StorageRunner` state addressed by `storageId`
+- **package jobs**: scheduled executions owned by a package; they keep package
+  config scope via `appId`, but run against their own job `storageId`
+- **package actors/runtime internals**: package-app Durable Objects or similar
+  stateful coordination units layered on top of package storage; these are
+  package-owned implementation details rather than separate top-level persisted
+  entities
+
+That means package apps and package jobs do **not** introduce competing config
+namespaces:
+
+- app-scoped values/secrets resolve only from `appId` (the saved package id)
+- `storageId` identifies the active durable state owner for the current run
+- package apps typically use the package id as both `appId` and root
+  `storageId`
+- package jobs keep `appId = <saved package id>` while switching `storageId` to
+  the job-specific durable bucket
+
 ## Configuration reference
 
 Bindings are configured per environment in `packages/worker/wrangler.jsonc`

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -6,6 +6,31 @@ A saved package is a repo-backed module rooted at `package.json`. The standard
 package fields describe the package shape, and `package.json#kody` holds the
 Kody-specific metadata.
 
+## Package state model
+
+Package authors should think in five related but distinct concepts:
+
+1. **Package source** — the repo-backed code and manifest rooted at
+   `package.json`
+2. **Package config** — readable values, secrets, and manifest fields owned by
+   the package id
+3. **Package storage** — durable state in `StorageRunner` addressed by a
+   `storageId`
+4. **Package-owned jobs** — scheduled executions declared by the package
+5. **Package-owned runtime internals** — package-app backends or actor-like
+   coordination units implemented behind the package surface
+
+The important boundary is:
+
+- `kody.id` is the stable authored package identifier in source
+- the saved package id is the durable owner for package config
+- `storageId` is the currently active durable state owner, which may be the
+  package root or a more specific package-owned unit such as a job or internal
+  actor
+
+That means package apps and package jobs are package-owned surfaces, not
+competing top-level persistence models.
+
 ## Source of truth
 
 Use `package.json` as the canonical source of truth for saved package metadata.
@@ -26,7 +51,8 @@ Think in terms of:
 
 - packages
 - package exports
-- package apps
+- package config
+- package storage
 - package-owned jobs
 
 The top-level saved identity is the package.
@@ -52,8 +78,11 @@ Treat package apps like Worker-style modules:
 
 - package app code belongs to the package repo
 - package app entry is declared by `kody.app.entry`
-- Durable Objects / facets are internal implementation details, not the public
-  authoring contract
+- package-root config still belongs to the saved package id
+- package-root storage defaults to the saved package id
+- any internal Durable Objects, facets, or actor-like namespaces are package
+  implementation details layered on top of package storage, not separate saved
+  primitives
 
 ## Package-owned jobs
 
@@ -61,7 +90,10 @@ Jobs belong to packages.
 
 - Define them under `package.json#kody.jobs`
 - Reference package-local entry modules
-- Treat schedule/runtime state as package-owned implementation detail
+- Treat schedule metadata as package-owned configuration
+- Treat each job's `storageId` as job-local durable state
+- Keep package-level values/secrets bound to the saved package id rather than
+  to the job storage bucket
 
 Jobs are not their own top-level saved primitive.
 

--- a/docs/guides/integration-backed-app-happy-path.md
+++ b/docs/guides/integration-backed-app-happy-path.md
@@ -34,8 +34,12 @@ For non-trivial or integration-backed package apps, prefer this split:
   `package.json#kody.app.entry`
 - package exports: reusable modules and callable default exports declared in
   `package.json.exports`
-- internal backend modules / Durable Objects / facets: connector lookups,
-  provider API calls, persistence, validation, and mutations
+- package-root config: values/secrets scoped to the saved package id
+- package storage: durable state addressed by explicit `storageId`s for the
+  active coordination unit
+- internal backend modules / actors / Durable Objects: connector lookups,
+  provider API calls, persistence, validation, mutations, and long-lived
+  coordination
 - inline HTML/code renders: acceptable for quick prototypes or one-off
   experiments, not the default package app pattern
 

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -72,7 +72,11 @@ Typical pattern inside execute:
 
 Kody supports durable storage binding for execute and package-owned jobs.
 
-- bound storage is app- or package-owned durable state
+- the bound `storage` helper always points at one active durable storage owner
+- for package apps, that owner defaults to the package root storage
+- for package-owned jobs, that owner is the job's own durable storage id
+- package-scoped values and secrets are keyed by the saved package id (`appId`),
+  not by whichever `storageId` happens to be active
 - import **`storage`** from **`kody:runtime`**
 - use **`storage.get(...)`**, **`storage.set(...)`**, **`storage.list(...)`**,
   and **`storage.sql(query, params?)`**

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -10,13 +10,31 @@ Kody-specific metadata.
 
 Think in terms of:
 
-- packages
+- package source
 - package exports
-- package apps
+- package config
+- package storage
 - package-owned jobs
+- package apps
+- package-owned runtime internals
 
 Packages are the saved-entity unit across search, execute, repo editing, and UI
 hosting.
+
+The durable package-state model is:
+
+- **package source** — the repo-backed code rooted at `package.json`
+- **package config** — readable/writable package-scoped values, secrets, and
+  manifest metadata keyed by the saved package id
+- **package storage** — durable SQLite/key-value state addressed by a
+  `storageId`
+- **package-owned jobs** — scheduled package entrypoints that run with package
+  config plus their own job storage
+- **package-owned runtime internals** — implementation details such as Durable
+  Objects, actor-like coordination, or namespaces built inside the package
+
+Those are related concepts, but they are not competing top-level primitives.
+The package remains the only saved top-level entity.
 
 ## `package.json`
 
@@ -62,8 +80,11 @@ Treat package apps like Worker-style modules:
 
 - app code lives in the package repo
 - the entry module is declared by `kody.app.entry`
-- internal Durable Objects or facets are implementation details, not the public
-  authoring contract
+- package-root values and secrets remain keyed by the saved package id
+- the default `storage` binding inside the app points at the package root
+  storage bucket
+- internal Durable Objects, actors, or facets are implementation details, not
+  the public authoring contract
 
 ## Package-owned jobs
 
@@ -71,7 +92,8 @@ Jobs belong to packages.
 
 - Define them under `package.json#kody.jobs`
 - Reference package-local entry modules
-- Treat their runtime state as package-owned implementation detail
+- Read package-scoped values and secrets through the package id
+- Treat each job's bound `storageId` as that job run's durable storage owner
 
 Jobs are part of the package definition.
 

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -46,3 +46,20 @@ does not by itself approve new hosts.
 
 Use **values** capabilities for readable non-secret configuration that generated
 UI or workflows should store and read later.
+
+## Package config versus package storage
+
+When a package is involved, Kody keeps two package-related state concepts
+separate:
+
+- **package config** — readable values and secrets scoped by the saved package id
+- **package storage** — durable mutable state bound to the active `storageId`
+
+That means:
+
+- app-scoped values and secrets belong to the package root
+- package apps and package-owned jobs can both read that same package config
+- a package-owned job still executes against its own job storage id for durable
+  runtime state
+- package-internal Durable Objects or similar coordination units should use
+  their own storage ids, not app-scoped values/secrets, for mutable actor state

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -925,6 +925,67 @@ test('executeJobOnce preserves codemode secret and value semantics', async () =>
 	}
 })
 
+test('package-owned jobs keep package app scope while switching runtime storage to the job bucket', async () => {
+	const db = createDatabase()
+	const env = {
+		APP_DB: db,
+	} as Env
+	mockRepoPersistence()
+
+	const manifest = createPackageJobManifest({
+		packageName: '@kody/thread-router',
+		kodyId: 'thread-router',
+		description: 'Routes messages with package-owned state',
+		jobName: 'route-thread',
+	})
+
+	await (
+		await import('./service.ts')
+	).syncPackageJobsForPackage({
+		env,
+		userId: 'user-123',
+		baseUrl: 'https://example.com',
+		packageId: 'package-thread-router',
+		sourceId: 'source-thread-router',
+		manifest,
+	})
+
+	const row = await (
+		await import('./repo.ts')
+	).getJobRowById(
+		db,
+		'user-123',
+		'package-job:package-thread-router:route-thread',
+	)
+	if (!row?.callerContext) {
+		throw new Error('Expected synced package job caller context.')
+	}
+
+	expect(row.callerContext.storageContext).toEqual({
+		sessionId: null,
+		appId: 'package-thread-router',
+		storageId: 'package-thread-router',
+	})
+
+	const runtimeCallerContext = {
+		...row.callerContext,
+		storageContext: {
+			sessionId: row.callerContext.storageContext?.sessionId ?? null,
+			appId: row.callerContext.storageContext?.appId ?? null,
+			storageId: row.record.storageId,
+		},
+	}
+
+	expect(runtimeCallerContext.storageContext).toEqual({
+		sessionId: null,
+		appId: 'package-thread-router',
+		storageId: row.record.storageId,
+	})
+	expect(row.record.storageId).toBe(
+		'job:package-job:package-thread-router:route-thread',
+	)
+})
+
 test('executeJobOnce refreshes repo sessions when base commit moves', async () => {
 	const env = {
 		APP_DB: createDatabase(),

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -37,6 +37,7 @@ import {
 	normalizePackageWorkspacePath,
 	parseAuthoredPackageJson,
 } from '#worker/package-registry/manifest.ts'
+import { createPackageStorageContext } from '#worker/package-runtime/package-state.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 import { buildJobSourceFiles } from '#worker/repo/source-templates.ts'
@@ -179,11 +180,9 @@ function createPackageJobCallerContext(input: {
 			email: '',
 			displayName: `package:${input.packageId}`,
 		},
-		storageContext: {
-			sessionId: null,
-			appId: input.packageId,
-			storageId: null,
-		},
+		storageContext: createPackageStorageContext({
+			packageId: input.packageId,
+		}),
 		repoContext: null,
 	}) as PersistedJobCallerContext
 }
@@ -571,11 +570,11 @@ export async function executeJobOnce(input: {
 		} else {
 			const runtimeCallerContext = {
 				...input.callerContext,
-				storageContext: {
+				storageContext: createPackageStorageContext({
+					packageId: input.callerContext.storageContext?.appId ?? input.job.id,
 					sessionId: input.callerContext.storageContext?.sessionId ?? null,
-					appId: input.callerContext.storageContext?.appId ?? null,
 					storageId: input.job.storageId,
-				},
+				}),
 				repoContext: input.callerContext.repoContext ?? null,
 			}
 			const result = await runRepoBackedJob({

--- a/packages/worker/src/mcp/capabilities/packages/domain.ts
+++ b/packages/worker/src/mcp/capabilities/packages/domain.ts
@@ -8,7 +8,7 @@ import { savePackageCapability } from './save-package.ts'
 export const packagesDomain = defineDomain({
 	name: capabilityDomainNames.packages,
 	description:
-		'Saved packages are the only top-level persisted primitive. A package is a repo-backed module with exports, optional app UI, optional package-owned jobs, and package metadata rooted at package.json.',
+		'Saved packages are the only top-level persisted primitive. A package owns repo-backed source, package-scoped config, optional package storage, optional package-owned jobs, and optional app surfaces rooted at package.json.',
 	keywords: ['package', 'repo', 'package.json', 'exports', 'jobs', 'app'],
 	capabilities: [
 		savePackageCapability,

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -24,6 +24,7 @@ Conventions
 - \`package_save\`: create or replace a repo-backed saved package rooted at \`package.json\`. Standard package exports define the package surface. \`package.json#kody\` contains Kody-specific metadata such as tags, optional app config, and package-owned jobs.
 - \`package_get\` / \`package_list\` / \`package_delete\`: inspect or manage saved packages for the signed-in user.
 - Package jobs are schedules owned by a package, not a separate top-level primitive. Package apps are optional UI surfaces declared by the package, not a separate top-level primitive.
+- Package state model: package source is the repo-backed code, package config is manifest plus app-scoped values/secrets keyed by saved package id, package storage is durable state addressed by \`storageId\`, and package apps/jobs are package-owned ways to execute against that state rather than separate persisted primitives.
 - Memory writes are verify-first: always run \`meta_memory_verify\` before \`meta_memory_upsert\` or \`meta_memory_delete\`. Kody retrieves related memories; the consuming agent decides whether to upsert, delete, both, or do nothing. \`meta_memory_upsert\` creates a new memory when \`memory_id\` is omitted and updates an existing memory when \`memory_id\` is provided.
 - User-specific MCP instructions: \`meta_get_mcp_server_instructions\` / \`meta_set_mcp_server_instructions\` (signed-in users). Updates apply to **new** MCP sessions (reconnect to refresh what the host shows).
 

--- a/packages/worker/src/mcp/storage-bindings.ts
+++ b/packages/worker/src/mcp/storage-bindings.ts
@@ -23,9 +23,7 @@ export function getStorageBindingKey(
 	if (scope === 'user') return ''
 	if (scope === 'app') {
 		const appId = storageContext?.appId?.trim()
-		if (appId) return appId
-		const storageId = storageContext?.storageId?.trim()
-		return storageId || null
+		return appId || null
 	}
 	if (scope === 'session') {
 		const sessionId = storageContext?.sessionId?.trim()

--- a/packages/worker/src/mcp/values/service.node.test.ts
+++ b/packages/worker/src/mcp/values/service.node.test.ts
@@ -276,6 +276,26 @@ test('value service rejects unavailable scoped storage', async () => {
 	).rejects.toThrow('Value scope "app" is unavailable in this context.')
 })
 
+test('value service does not treat arbitrary storage ids as app scope', async () => {
+	const testDb = createValueTestDb()
+	const env = { APP_DB: testDb.db }
+
+	await expect(
+		saveValue({
+			env,
+			userId: 'user-123',
+			scope: 'app',
+			name: 'workspaceSlug',
+			value: 'job-storage',
+			storageContext: {
+				sessionId: null,
+				appId: null,
+				storageId: 'job:job-123',
+			},
+		}),
+	).rejects.toThrow('Value scope "app" is unavailable in this context.')
+})
+
 test('deleteAllAppScopedValues removes all app-scoped values for one app', async () => {
 	const testDb = createValueTestDb()
 	const env = { APP_DB: testDb.db }

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -10,6 +10,7 @@ import {
 	createAuthenticatedFetch,
 	refreshAccessToken,
 } from '#mcp/execute-modules/codemode-utils.ts'
+import { createPackageStorageContext } from './package-state.ts'
 import { buildKodyAppBundle } from './module-graph.ts'
 import { storageRunnerRpc } from '#worker/storage-runner.ts'
 
@@ -311,11 +312,10 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 				email: this.ctx.props.email,
 				displayName: this.ctx.props.displayName,
 			},
-			storageContext: {
-				sessionId: null,
-				appId: this.ctx.props.packageId,
+			storageContext: createPackageStorageContext({
+				packageId: this.ctx.props.packageId,
 				storageId,
-			},
+			}),
 		})
 	}
 
@@ -562,11 +562,9 @@ export async function buildPackageAppWorker(input: {
 						props: {
 							baseUrl: input.baseUrl,
 							userId: input.userId,
-							storageContext: {
-								sessionId: null,
-								appId: input.savedPackage.id,
-								storageId: input.savedPackage.id,
-							},
+							storageContext: createPackageStorageContext({
+								packageId: input.savedPackage.id,
+							}),
 						},
 					})
 				: null,
@@ -592,10 +590,8 @@ export async function createPackageAppCallerContext(input: {
 			displayName:
 				input.user.displayName ?? `package:${input.packageId}`,
 		},
-		storageContext: {
-			sessionId: null,
-			appId: input.packageId,
-			storageId: input.packageId,
-		},
+		storageContext: createPackageStorageContext({
+			packageId: input.packageId,
+		}),
 	})
 }

--- a/packages/worker/src/package-runtime/package-state.ts
+++ b/packages/worker/src/package-runtime/package-state.ts
@@ -1,4 +1,8 @@
 import { type McpStorageContext } from '@kody-internal/shared/chat.ts'
+import { type StorageContext } from '#mcp/storage.ts'
+
+type PackageStorageContext = StorageContext &
+	Required<Pick<McpStorageContext, 'sessionId' | 'appId' | 'storageId'>>
 
 type CreatePackageStorageContextInput = {
 	packageId: string
@@ -8,7 +12,7 @@ type CreatePackageStorageContextInput = {
 
 export function createPackageStorageContext(
 	input: CreatePackageStorageContextInput,
-): McpStorageContext {
+): PackageStorageContext {
 	const packageId = input.packageId.trim()
 	if (!packageId) {
 		throw new Error('Package storage context requires a package id.')

--- a/packages/worker/src/package-runtime/package-state.ts
+++ b/packages/worker/src/package-runtime/package-state.ts
@@ -1,0 +1,21 @@
+import { type McpStorageContext } from '@kody-internal/shared/chat.ts'
+
+type CreatePackageStorageContextInput = {
+	packageId: string
+	storageId?: string | null
+	sessionId?: string | null
+}
+
+export function createPackageStorageContext(
+	input: CreatePackageStorageContextInput,
+): McpStorageContext {
+	const packageId = input.packageId.trim()
+	if (!packageId) {
+		throw new Error('Package storage context requires a package id.')
+	}
+	return {
+		sessionId: input.sessionId ?? null,
+		appId: packageId,
+		storageId: input.storageId?.trim() || packageId,
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- define a single package state model across package source, package config, package storage, package-owned jobs, and package runtime internals
- add a shared package storage-context helper so package apps, package jobs, and hosted package fetch flows carry the same package-root context
- tighten app-scoped values/secrets so package config stays keyed by saved package id instead of falling back to arbitrary active storage ids
- align contributor and user docs with the unified model and add focused regression coverage

## Testing
- `npm run typecheck`
- `npx vitest run --project node-unit packages/worker/src/jobs/service.node.test.ts packages/worker/src/mcp/values/service.node.test.ts packages/worker/src/package-registry/service.node.test.ts packages/worker/src/app/handlers/connect-secret.node.test.ts packages/worker/src/app/handlers/account-secrets.node.test.ts`

Closes #231
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ecaf9f5-956d-4493-bccb-ed99c19aae44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ecaf9f5-956d-4493-bccb-ed99c19aae44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

