### PR TITLE
Cache published package sources for package apps

### DIFF
--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -72,6 +72,9 @@ export async function handlePackageAppRequest(
 				kodyId: savedPackage.kodyId,
 				name: savedPackage.name,
 				sourceId: savedPackage.sourceId,
+				publishedCommit: packageSource.source.published_commit,
+				manifestPath: packageSource.source.manifest_path,
+				sourceRoot: packageSource.source.source_root,
 			},
 			sourceFiles: packageSource.files,
 			runtime: {

--- a/packages/worker/src/package-registry/published-package-cache.ts
+++ b/packages/worker/src/package-registry/published-package-cache.ts
@@ -78,8 +78,11 @@ export class PromiseLruCache<T> {
 		if (cached) {
 			return cached
 		}
-		const pending = input.create().catch((error) => {
-			this.delete(input.cacheKey)
+		let pending: Promise<T>
+		pending = input.create().catch((error) => {
+			if (this.cache.get(input.cacheKey)?.pending === pending) {
+				this.delete(input.cacheKey)
+			}
 			throw error
 		})
 		this.set(input.cacheKey, pending)

--- a/packages/worker/src/package-registry/published-package-cache.ts
+++ b/packages/worker/src/package-registry/published-package-cache.ts
@@ -1,0 +1,106 @@
+type PublishedPackageCacheSource = {
+	id: string
+	published_commit: string | null
+	manifest_path: string
+	source_root: string
+}
+
+export const publishedPackageCacheLimit = 50
+export const publishedPackageCacheTtlMs = 5 * 60 * 1000
+
+export function createPublishedPackageCacheKey(input: {
+	userId: string
+	source: PublishedPackageCacheSource
+	entryPoint?: string | null
+}) {
+	if (!input.source.published_commit) {
+		return null
+	}
+
+	return JSON.stringify([
+		input.userId,
+		input.source.id,
+		input.source.published_commit,
+		input.source.manifest_path,
+		input.source.source_root,
+		input.entryPoint?.trim() || null,
+	])
+}
+
+export class PromiseLruCache<T> {
+	private readonly cache = new Map<
+		string,
+		{
+			expiresAt: number
+			pending: Promise<T>
+		}
+	>()
+
+	constructor(input?: {
+		ttlMs?: number
+		limit?: number
+	}) {
+		this.ttlMs = input?.ttlMs ?? publishedPackageCacheTtlMs
+		this.limit = input?.limit ?? publishedPackageCacheLimit
+	}
+
+	private readonly ttlMs: number
+	private readonly limit: number
+
+	get(key: string) {
+		const cached = this.cache.get(key)
+		if (!cached) {
+			return null
+		}
+		if (cached.expiresAt <= Date.now()) {
+			this.cache.delete(key)
+			return null
+		}
+		this.cache.delete(key)
+		this.cache.set(key, cached)
+		return cached.pending
+	}
+
+	set(key: string, pending: Promise<T>) {
+		this.cache.set(key, {
+			expiresAt: Date.now() + this.ttlMs,
+			pending,
+		})
+		this.enforceLimit()
+		return pending
+	}
+
+	getOrCreate(input: {
+		cacheKey: string
+		create: () => Promise<T>
+	}) {
+		const cached = this.get(input.cacheKey)
+		if (cached) {
+			return cached
+		}
+		const pending = input.create().catch((error) => {
+			this.delete(input.cacheKey)
+			throw error
+		})
+		this.set(input.cacheKey, pending)
+		return pending
+	}
+
+	delete(key: string) {
+		this.cache.delete(key)
+	}
+
+	private enforceLimit() {
+		while (this.cache.size > this.limit) {
+			const oldestKey = this.cache.keys().next().value
+			if (oldestKey === undefined) {
+				break
+			}
+			this.cache.delete(oldestKey)
+		}
+	}
+}
+
+export function createPublishedPackagePromiseCache<T>() {
+	return new PromiseLruCache<T>()
+}

--- a/packages/worker/src/package-registry/source.node.test.ts
+++ b/packages/worker/src/package-registry/source.node.test.ts
@@ -119,6 +119,10 @@ test('loadPackageSourceBySourceId reuses cached published package sources', asyn
 	expect(mockModule.loadRepoSourceFilesFromSession).toHaveBeenCalledTimes(1)
 	expect(sessionClient.discardSession).toHaveBeenCalledTimes(1)
 	expect(first).toBe(second)
+	expect(Object.isFrozen(first)).toBe(true)
+	expect(Object.isFrozen(first.source)).toBe(true)
+	expect(Object.isFrozen(first.manifest)).toBe(true)
+	expect(Object.isFrozen(first.files)).toBe(true)
 	expect(first.files).toEqual({
 		'app.js': 'export default { async fetch() { return new Response("ok") } }',
 		'index.js': 'export const value = "ok"',
@@ -236,4 +240,58 @@ test('loadPackageSourceBySourceId shares the same in-flight published source loa
 	expect(mockModule.loadRepoSourceFilesFromSession).toHaveBeenCalledTimes(1)
 	expect(sessionClient.discardSession).toHaveBeenCalledTimes(1)
 	expect(first).toBe(second)
+})
+
+test('loadPackageSourceBySourceId evicts failed published source loads before retrying', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.readMockArtifactSnapshot.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+	mockModule.loadRepoSourceFilesFromSession.mockReset()
+
+	const firstSessionClient = createSessionClient('session-published-failure-1')
+	const secondSessionClient = createSessionClient('session-published-failure-2')
+
+	mockModule.getEntitySourceById.mockResolvedValue(
+		createPackageSourceRow({
+			id: 'source-published-failure',
+			publishedCommit: 'commit-failure-1',
+		}),
+	)
+	mockModule.readMockArtifactSnapshot.mockResolvedValue(null)
+	mockModule.repoSessionRpc
+		.mockReturnValueOnce(firstSessionClient as never)
+		.mockReturnValueOnce(secondSessionClient as never)
+	mockModule.loadRepoSourceFilesFromSession
+		.mockRejectedValueOnce(new Error('repo load failed'))
+		.mockResolvedValueOnce({
+			'app.js': 'export default { async fetch() { return new Response("ok") } }',
+			'index.js': 'export const value = "ok"',
+		})
+
+	const input = {
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceId: 'source-published-failure',
+	}
+
+	await expect(loadPackageSourceBySourceId(input)).rejects.toThrow(
+		'repo load failed',
+	)
+	await expect(loadPackageSourceBySourceId(input)).resolves.toMatchObject({
+		files: {
+			'app.js':
+				'export default { async fetch() { return new Response("ok") } }',
+			'index.js': 'export const value = "ok"',
+		},
+	})
+
+	expect(firstSessionClient.openSession).toHaveBeenCalledTimes(1)
+	expect(firstSessionClient.discardSession).toHaveBeenCalledTimes(1)
+	expect(secondSessionClient.openSession).toHaveBeenCalledTimes(1)
+	expect(secondSessionClient.discardSession).toHaveBeenCalledTimes(1)
+	expect(mockModule.loadRepoSourceFilesFromSession).toHaveBeenCalledTimes(2)
 })

--- a/packages/worker/src/package-registry/source.node.test.ts
+++ b/packages/worker/src/package-registry/source.node.test.ts
@@ -1,0 +1,239 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getEntitySourceById: vi.fn(),
+	readMockArtifactSnapshot: vi.fn(),
+	repoSessionRpc: vi.fn(),
+	loadRepoSourceFilesFromSession: vi.fn(),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+}))
+
+vi.mock('#worker/repo/artifacts.ts', () => ({
+	isLoopbackHostname: () => false,
+	readMockArtifactSnapshot: (...args: Array<unknown>) =>
+		mockModule.readMockArtifactSnapshot(...args),
+}))
+
+vi.mock('#worker/repo/repo-session-do.ts', () => ({
+	repoSessionRpc: (...args: Array<unknown>) => mockModule.repoSessionRpc(...args),
+}))
+
+vi.mock('#worker/repo/repo-codemode-execution.ts', () => ({
+	loadRepoSourceFilesFromSession: (...args: Array<unknown>) =>
+		mockModule.loadRepoSourceFilesFromSession(...args),
+}))
+
+const { loadPackageSourceBySourceId } = await import('./source.ts')
+
+function createPackageSourceRow(input: {
+	id: string
+	publishedCommit: string | null
+}) {
+	return {
+		id: input.id,
+		user_id: 'user-1',
+		entity_kind: 'package' as const,
+		entity_id: `package-${input.id}`,
+		repo_id: `repo-${input.id}`,
+		published_commit: input.publishedCommit,
+		indexed_commit: input.publishedCommit,
+		manifest_path: 'package.json',
+		source_root: '/',
+		created_at: '2026-04-20T00:00:00.000Z',
+		updated_at: '2026-04-20T00:00:00.000Z',
+	}
+}
+
+function createSessionClient(sessionId: string) {
+	return {
+		openSession: vi.fn(async () => ({
+			id: sessionId,
+		})),
+		readFile: vi.fn(async () => ({
+			content: JSON.stringify({
+				name: '@kentcdodds/example-package',
+				exports: {
+					'.': './index.js',
+				},
+				kody: {
+					id: 'example-package',
+					description: 'Example package',
+					app: {
+						entry: 'app.js',
+					},
+				},
+			}),
+		})),
+		discardSession: vi.fn(async () => ({
+			ok: true as const,
+			sessionId,
+			deleted: true,
+		})),
+	}
+}
+
+test('loadPackageSourceBySourceId reuses cached published package sources', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.readMockArtifactSnapshot.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+	mockModule.loadRepoSourceFilesFromSession.mockReset()
+
+	const sessionClient = createSessionClient('session-published-1')
+	mockModule.getEntitySourceById.mockResolvedValue(
+		createPackageSourceRow({
+			id: 'source-published-1',
+			publishedCommit: 'commit-1',
+		}),
+	)
+	mockModule.readMockArtifactSnapshot.mockResolvedValue(null)
+	mockModule.repoSessionRpc.mockReturnValue(sessionClient as never)
+	mockModule.loadRepoSourceFilesFromSession.mockResolvedValue({
+		'app.js': 'export default { async fetch() { return new Response("ok") } }',
+		'index.js': 'export const value = "ok"',
+	})
+
+	const first = await loadPackageSourceBySourceId({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceId: 'source-published-1',
+	})
+	const second = await loadPackageSourceBySourceId({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceId: 'source-published-1',
+	})
+
+	expect(sessionClient.openSession).toHaveBeenCalledTimes(1)
+	expect(mockModule.loadRepoSourceFilesFromSession).toHaveBeenCalledTimes(1)
+	expect(sessionClient.discardSession).toHaveBeenCalledTimes(1)
+	expect(first).toBe(second)
+	expect(first.files).toEqual({
+		'app.js': 'export default { async fetch() { return new Response("ok") } }',
+		'index.js': 'export const value = "ok"',
+		'package.json': JSON.stringify({
+			name: '@kentcdodds/example-package',
+			exports: {
+				'.': './index.js',
+			},
+			kody: {
+				id: 'example-package',
+				description: 'Example package',
+				app: {
+					entry: 'app.js',
+				},
+			},
+		}),
+	})
+})
+
+test('loadPackageSourceBySourceId does not cache unpublished sources', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.readMockArtifactSnapshot.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+	mockModule.loadRepoSourceFilesFromSession.mockReset()
+
+	const sessionClient = createSessionClient('session-unpublished-1')
+	mockModule.getEntitySourceById.mockResolvedValue(
+		createPackageSourceRow({
+			id: 'source-unpublished-1',
+			publishedCommit: null,
+		}),
+	)
+	mockModule.readMockArtifactSnapshot.mockResolvedValue(null)
+	mockModule.repoSessionRpc.mockReturnValue(sessionClient as never)
+	mockModule.loadRepoSourceFilesFromSession.mockResolvedValue({
+		'app.js': 'export default { async fetch() { return new Response("ok") } }',
+		'index.js': 'export const value = "ok"',
+	})
+
+	await loadPackageSourceBySourceId({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceId: 'source-unpublished-1',
+	})
+	await loadPackageSourceBySourceId({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceId: 'source-unpublished-1',
+	})
+
+	expect(sessionClient.openSession).toHaveBeenCalledTimes(2)
+	expect(mockModule.loadRepoSourceFilesFromSession).toHaveBeenCalledTimes(2)
+	expect(sessionClient.discardSession).toHaveBeenCalledTimes(2)
+})
+
+test('loadPackageSourceBySourceId shares the same in-flight published source load', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.readMockArtifactSnapshot.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+	mockModule.loadRepoSourceFilesFromSession.mockReset()
+
+	const sessionClient = createSessionClient('session-published-concurrent')
+	let resolveFiles: ((files: Record<string, string>) => void) | null = null
+	const filesPromise = new Promise<Record<string, string>>((resolve) => {
+		resolveFiles = resolve
+	})
+
+	mockModule.getEntitySourceById.mockResolvedValue(
+		createPackageSourceRow({
+			id: 'source-published-concurrent',
+			publishedCommit: 'commit-concurrent-1',
+		}),
+	)
+	mockModule.readMockArtifactSnapshot.mockResolvedValue(null)
+	mockModule.repoSessionRpc.mockReturnValue(sessionClient as never)
+	mockModule.loadRepoSourceFilesFromSession.mockImplementation(
+		async () => await filesPromise,
+	)
+
+	const firstPromise = loadPackageSourceBySourceId({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceId: 'source-published-concurrent',
+	})
+	const secondPromise = loadPackageSourceBySourceId({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceId: 'source-published-concurrent',
+	})
+
+	resolveFiles?.({
+		'app.js': 'export default { async fetch() { return new Response("ok") } }',
+		'index.js': 'export const value = "ok"',
+	})
+
+	const [first, second] = await Promise.all([firstPromise, secondPromise])
+
+	expect(sessionClient.openSession).toHaveBeenCalledTimes(1)
+	expect(mockModule.loadRepoSourceFilesFromSession).toHaveBeenCalledTimes(1)
+	expect(sessionClient.discardSession).toHaveBeenCalledTimes(1)
+	expect(first).toBe(second)
+})

--- a/packages/worker/src/package-registry/source.ts
+++ b/packages/worker/src/package-registry/source.ts
@@ -15,6 +15,17 @@ export type LoadedPackageSource = {
 	files: Record<string, string>
 }
 
+const packageSourceCacheLimit = 50
+const packageSourceCacheTtlMs = 5 * 60 * 1000
+
+const packageSourceCache = new Map<
+	string,
+	{
+		expiresAt: number
+		pending: Promise<LoadedPackageSource>
+	}
+>()
+
 function canResolveRepoBackedPackageSource(env: Env) {
 	const anyEnv = env as Env & { APP_DB?: unknown; REPO_SESSION?: unknown }
 	return (
@@ -25,19 +36,79 @@ function canResolveRepoBackedPackageSource(env: Env) {
 	)
 }
 
-export async function loadPackageSourceBySourceId(input: {
+function createPackageSourceCacheKey(input: {
+	userId: string
+	source: EntitySourceRow
+}) {
+	if (!input.source.published_commit) {
+		return null
+	}
+
+	return JSON.stringify([
+		input.userId,
+		input.source.id,
+		input.source.published_commit,
+		input.source.manifest_path,
+		input.source.source_root,
+	])
+}
+
+function enforcePackageSourceCacheLimit() {
+	while (packageSourceCache.size > packageSourceCacheLimit) {
+		const oldestKey = packageSourceCache.keys().next().value
+		if (oldestKey === undefined) {
+			break
+		}
+		packageSourceCache.delete(oldestKey)
+	}
+}
+
+function getCachedPackageSource(cacheKey: string) {
+	const cached = packageSourceCache.get(cacheKey)
+	if (!cached) {
+		return null
+	}
+	if (cached.expiresAt <= Date.now()) {
+		packageSourceCache.delete(cacheKey)
+		return null
+	}
+	packageSourceCache.delete(cacheKey)
+	packageSourceCache.set(cacheKey, cached)
+	return cached.pending
+}
+
+function setCachedPackageSource(
+	cacheKey: string,
+	pending: Promise<LoadedPackageSource>,
+) {
+	packageSourceCache.set(cacheKey, {
+		expiresAt: Date.now() + packageSourceCacheTtlMs,
+		pending,
+	})
+	enforcePackageSourceCacheLimit()
+	return pending
+}
+
+async function loadPackageSourceUncached(input: {
 	env: Env
 	baseUrl: string
 	userId: string
-	sourceId: string
+	source: EntitySourceRow
 }): Promise<LoadedPackageSource> {
-	if (!canResolveRepoBackedPackageSource(input.env)) {
-		throw new Error('Saved package source bindings are not available.')
-	}
-	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
-	if (!source || source.user_id !== input.userId) {
-		throw new Error(`Saved package source "${input.sourceId}" was not found.`)
-	}
+	const source = input.source
+	const freezeFiles = (files: Record<string, string>) =>
+		Object.freeze({ ...files }) as Record<string, string>
+
+	const finalizeLoadedSource = (loaded: {
+		manifest: AuthoredPackageJson
+		files: Record<string, string>
+	}) =>
+		Object.freeze({
+			source,
+			manifest: loaded.manifest,
+			files: freezeFiles(loaded.files),
+		}) as LoadedPackageSource
+
 	const mockArtifactsBaseUrl = input.env.CLOUDFLARE_API_BASE_URL?.trim()
 	if (mockArtifactsBaseUrl && source.published_commit) {
 		const mockArtifactsUrl = new URL(mockArtifactsBaseUrl)
@@ -54,14 +125,13 @@ export async function loadPackageSourceBySourceId(input: {
 						`Saved package manifest "${source.manifest_path}" was not found in the repo source.`,
 					)
 				}
-				return {
-					source,
+				return finalizeLoadedSource({
 					manifest: parseAuthoredPackageJson({
 						content: manifestContent,
 						manifestPath: source.manifest_path,
 					}),
 					files: snapshot.files,
-				}
+				})
 			}
 		}
 	}
@@ -98,11 +168,10 @@ export async function loadPackageSourceBySourceId(input: {
 			sourceRoot: source.source_root,
 		})
 		files[source.manifest_path] = manifestFile.content
-		return {
-			source,
+		return finalizeLoadedSource({
 			manifest,
 			files,
-		}
+		})
 	} finally {
 		if (openedSessionId) {
 			await session
@@ -115,4 +184,48 @@ export async function loadPackageSourceBySourceId(input: {
 				})
 		}
 	}
+}
+
+export async function loadPackageSourceBySourceId(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	sourceId: string
+}): Promise<LoadedPackageSource> {
+	if (!canResolveRepoBackedPackageSource(input.env)) {
+		throw new Error('Saved package source bindings are not available.')
+	}
+	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
+	if (!source || source.user_id !== input.userId) {
+		throw new Error(`Saved package source "${input.sourceId}" was not found.`)
+	}
+	const cacheKey = createPackageSourceCacheKey({
+		userId: input.userId,
+		source,
+	})
+	if (!cacheKey) {
+		return await loadPackageSourceUncached({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.userId,
+			source,
+		})
+	}
+
+	const cached = getCachedPackageSource(cacheKey)
+	if (cached) {
+		return await cached
+	}
+
+	const pending = loadPackageSourceUncached({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		source,
+	}).catch((error) => {
+		packageSourceCache.delete(cacheKey)
+		throw error
+	})
+
+	return await setCachedPackageSource(cacheKey, pending)
 }

--- a/packages/worker/src/package-registry/source.ts
+++ b/packages/worker/src/package-registry/source.ts
@@ -50,14 +50,28 @@ async function loadPackageSourceUncached(input: {
 	const source = input.source
 	const freezeFiles = (files: Record<string, string>) =>
 		Object.freeze({ ...files }) as Record<string, string>
+	const deepFreeze = <T>(value: T, seen = new WeakSet<object>()): T => {
+		if (value && typeof value === 'object') {
+			const objectValue = value as object
+			if (seen.has(objectValue)) {
+				return value
+			}
+			seen.add(objectValue)
+			for (const child of Object.values(value as Record<string, unknown>)) {
+				deepFreeze(child, seen)
+			}
+			Object.freeze(objectValue)
+		}
+		return value
+	}
 
 	const finalizeLoadedSource = (loaded: {
 		manifest: AuthoredPackageJson
 		files: Record<string, string>
 	}) =>
 		Object.freeze({
-			source,
-			manifest: loaded.manifest,
+			source: deepFreeze({ ...source }),
+			manifest: deepFreeze(structuredClone(loaded.manifest)),
 			files: freezeFiles(loaded.files),
 		}) as LoadedPackageSource
 

--- a/packages/worker/src/package-registry/source.ts
+++ b/packages/worker/src/package-registry/source.ts
@@ -6,6 +6,10 @@ import {
 } from '#worker/repo/artifacts.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { loadRepoSourceFilesFromSession } from '#worker/repo/repo-codemode-execution.ts'
+import {
+	createPublishedPackageCacheKey,
+	PromiseLruCache,
+} from './published-package-cache.ts'
 import { parseAuthoredPackageJson } from './manifest.ts'
 import { type AuthoredPackageJson } from './types.ts'
 
@@ -15,16 +19,7 @@ export type LoadedPackageSource = {
 	files: Record<string, string>
 }
 
-const packageSourceCacheLimit = 50
-const packageSourceCacheTtlMs = 5 * 60 * 1000
-
-const packageSourceCache = new Map<
-	string,
-	{
-		expiresAt: number
-		pending: Promise<LoadedPackageSource>
-	}
->()
+const packageSourceCache = new PromiseLruCache<LoadedPackageSource>()
 
 function canResolveRepoBackedPackageSource(env: Env) {
 	const anyEnv = env as Env & { APP_DB?: unknown; REPO_SESSION?: unknown }
@@ -40,53 +35,10 @@ function createPackageSourceCacheKey(input: {
 	userId: string
 	source: EntitySourceRow
 }) {
-	if (!input.source.published_commit) {
-		return null
-	}
-
-	return JSON.stringify([
-		input.userId,
-		input.source.id,
-		input.source.published_commit,
-		input.source.manifest_path,
-		input.source.source_root,
-	])
-}
-
-function enforcePackageSourceCacheLimit() {
-	while (packageSourceCache.size > packageSourceCacheLimit) {
-		const oldestKey = packageSourceCache.keys().next().value
-		if (oldestKey === undefined) {
-			break
-		}
-		packageSourceCache.delete(oldestKey)
-	}
-}
-
-function getCachedPackageSource(cacheKey: string) {
-	const cached = packageSourceCache.get(cacheKey)
-	if (!cached) {
-		return null
-	}
-	if (cached.expiresAt <= Date.now()) {
-		packageSourceCache.delete(cacheKey)
-		return null
-	}
-	packageSourceCache.delete(cacheKey)
-	packageSourceCache.set(cacheKey, cached)
-	return cached.pending
-}
-
-function setCachedPackageSource(
-	cacheKey: string,
-	pending: Promise<LoadedPackageSource>,
-) {
-	packageSourceCache.set(cacheKey, {
-		expiresAt: Date.now() + packageSourceCacheTtlMs,
-		pending,
+	return createPublishedPackageCacheKey({
+		userId: input.userId,
+		source: input.source,
 	})
-	enforcePackageSourceCacheLimit()
-	return pending
 }
 
 async function loadPackageSourceUncached(input: {
@@ -212,20 +164,19 @@ export async function loadPackageSourceBySourceId(input: {
 		})
 	}
 
-	const cached = getCachedPackageSource(cacheKey)
+	const cached = packageSourceCache.get(cacheKey)
 	if (cached) {
 		return await cached
 	}
 
-	const pending = loadPackageSourceUncached({
-		env: input.env,
-		baseUrl: input.baseUrl,
-		userId: input.userId,
-		source,
-	}).catch((error) => {
-		packageSourceCache.delete(cacheKey)
-		throw error
+	return await packageSourceCache.getOrCreate({
+		cacheKey,
+		create: async () =>
+			await loadPackageSourceUncached({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				source,
+			}),
 	})
-
-	return await setCachedPackageSource(cacheKey, pending)
 }

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -1,0 +1,229 @@
+import { expect, test, vi } from 'vitest'
+import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
+
+const mockModule = vi.hoisted(() => ({
+	createWorker: vi.fn(),
+}))
+
+vi.mock('@cloudflare/worker-bundler', () => ({
+	createWorker: (...args: Array<unknown>) => mockModule.createWorker(...args),
+}))
+
+const {
+	buildKodyAppBundle,
+	createPublishedPackageAppBundleCacheKey,
+} = await import('./module-graph.ts')
+
+function createBundleResult(suffix: string) {
+	return {
+		mainModule: `dist/${suffix}.js`,
+		modules: {
+			[`dist/${suffix}.js`]: `export default { async fetch() { return new Response(${JSON.stringify(
+				suffix,
+			)}) } }`,
+		} satisfies WorkerLoaderModules,
+	}
+}
+
+function createBundleInput(input?: {
+	cacheKey?: string | null
+	entryPoint?: string
+}) {
+	return {
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/example-package',
+				exports: {
+					'.': './index.js',
+				},
+				kody: {
+					id: 'example-package',
+					description: 'Example package',
+					app: {
+						entry: input?.entryPoint ?? 'app.js',
+					},
+				},
+			}),
+			'app.js':
+				'export default { async fetch() { return new Response("app") } }',
+			'index.js': 'export const value = "ok"',
+		},
+		entryPoint: input?.entryPoint ?? 'app.js',
+		cacheKey: input?.cacheKey,
+	}
+}
+
+test('buildKodyAppBundle reuses cached published package app bundles', async () => {
+	mockModule.createWorker.mockReset()
+	mockModule.createWorker.mockResolvedValue(createBundleResult('warm-cache'))
+
+	const cacheKey = createPublishedPackageAppBundleCacheKey({
+		userId: 'user-1',
+		source: {
+			id: 'source-1',
+			published_commit: 'commit-1',
+			manifest_path: 'package.json',
+			source_root: '/',
+		},
+		entryPoint: 'app.js',
+	})
+
+	const first = await buildKodyAppBundle(
+		createBundleInput({
+			cacheKey,
+		}),
+	)
+	const second = await buildKodyAppBundle(
+		createBundleInput({
+			cacheKey,
+		}),
+	)
+
+	expect(mockModule.createWorker).toHaveBeenCalledTimes(1)
+	expect(first).toBe(second)
+})
+
+test('buildKodyAppBundle does not cache unpublished package app bundles', async () => {
+	mockModule.createWorker.mockReset()
+	mockModule.createWorker
+		.mockResolvedValueOnce(createBundleResult('uncached-first'))
+		.mockResolvedValueOnce(createBundleResult('uncached-second'))
+
+	await buildKodyAppBundle(
+		createBundleInput({
+			cacheKey: null,
+		}),
+	)
+	await buildKodyAppBundle(
+		createBundleInput({
+			cacheKey: null,
+		}),
+	)
+
+	expect(mockModule.createWorker).toHaveBeenCalledTimes(2)
+})
+
+test('buildKodyAppBundle shares the same in-flight published bundle build', async () => {
+	mockModule.createWorker.mockReset()
+	let resolveBundle:
+		| ((value: { mainModule: string; modules: WorkerLoaderModules }) => void)
+		| null = null
+	const bundlePromise = new Promise<{
+		mainModule: string
+		modules: WorkerLoaderModules
+	}>((resolve) => {
+		resolveBundle = resolve
+	})
+	mockModule.createWorker.mockImplementation(async () => await bundlePromise)
+
+	const cacheKey = createPublishedPackageAppBundleCacheKey({
+		userId: 'user-1',
+		source: {
+			id: 'source-concurrent',
+			published_commit: 'commit-concurrent-1',
+			manifest_path: 'package.json',
+			source_root: '/',
+		},
+		entryPoint: 'app.js',
+	})
+
+	const firstPromise = buildKodyAppBundle(
+		createBundleInput({
+			cacheKey,
+		}),
+	)
+	const secondPromise = buildKodyAppBundle(
+		createBundleInput({
+			cacheKey,
+		}),
+	)
+
+	resolveBundle?.(createBundleResult('shared-in-flight'))
+
+	const [first, second] = await Promise.all([firstPromise, secondPromise])
+
+	expect(mockModule.createWorker).toHaveBeenCalledTimes(1)
+	expect(first).toBe(second)
+})
+
+test('buildKodyAppBundle evicts rejected published bundle builds before retrying', async () => {
+	mockModule.createWorker.mockReset()
+	mockModule.createWorker
+		.mockRejectedValueOnce(new Error('bundle failed'))
+		.mockResolvedValueOnce(createBundleResult('retry-success'))
+
+	const cacheKey = createPublishedPackageAppBundleCacheKey({
+		userId: 'user-1',
+		source: {
+			id: 'source-failure',
+			published_commit: 'commit-failure-1',
+			manifest_path: 'package.json',
+			source_root: '/',
+		},
+		entryPoint: 'app.js',
+	})
+
+	await expect(
+		buildKodyAppBundle(
+			createBundleInput({
+				cacheKey,
+			}),
+		),
+	).rejects.toThrow('bundle failed')
+
+	const retried = await buildKodyAppBundle(
+		createBundleInput({
+			cacheKey,
+		}),
+	)
+
+	expect(mockModule.createWorker).toHaveBeenCalledTimes(2)
+	expect(retried).toEqual(createBundleResult('retry-success'))
+})
+
+test('buildKodyAppBundle keeps separate cache entries for different app entrypoints', async () => {
+	mockModule.createWorker.mockReset()
+	mockModule.createWorker
+		.mockResolvedValueOnce(createBundleResult('entry-app'))
+		.mockResolvedValueOnce(createBundleResult('entry-admin'))
+
+	const source = {
+		id: 'source-shared',
+		published_commit: 'commit-shared-1',
+		manifest_path: 'package.json',
+		source_root: '/',
+	}
+
+	const appEntryCacheKey = createPublishedPackageAppBundleCacheKey({
+		userId: 'user-1',
+		source,
+		entryPoint: 'app.js',
+	})
+	const adminEntryCacheKey = createPublishedPackageAppBundleCacheKey({
+		userId: 'user-1',
+		source,
+		entryPoint: 'admin.js',
+	})
+
+	const appBundle = await buildKodyAppBundle(
+		createBundleInput({
+			cacheKey: appEntryCacheKey,
+			entryPoint: 'app.js',
+		}),
+	)
+	const adminBundle = await buildKodyAppBundle(
+		createBundleInput({
+			cacheKey: adminEntryCacheKey,
+			entryPoint: 'admin.js',
+		}),
+	)
+
+	expect(mockModule.createWorker).toHaveBeenCalledTimes(2)
+	expect(appBundle).not.toBe(adminBundle)
+})

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -10,6 +10,10 @@ import {
 	resolvePackageExportPath,
 } from '#worker/package-registry/manifest.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+import {
+	createPublishedPackageCacheKey,
+	createPublishedPackagePromiseCache,
+} from '#worker/package-registry/published-package-cache.ts'
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
 
 const runtimeModulePath = '.__kody_virtual__/runtime.js'
@@ -17,6 +21,10 @@ const rootSourcePrefix = '.__kody_root__'
 const packageSourcePrefix = '.__kody_packages__'
 const packageImportProxyPrefix = '.__kody_virtual__/imports'
 const packageSpecifierPrefix = 'kody:@'
+const packageAppBundleCache = createPublishedPackagePromiseCache<{
+	mainModule: string
+	modules: WorkerLoaderModules
+}>()
 
 function joinPath(...parts: Array<string>) {
 	return parts
@@ -454,30 +462,60 @@ export async function buildKodyAppBundle(input: {
 	userId: string
 	sourceFiles: Record<string, string>
 	entryPoint: string
+	cacheKey?: string | null
 }) {
-	const files = await prepareKodyGraphFiles({
-		env: input.env,
-		baseUrl: input.baseUrl,
-		userId: input.userId,
-		sourceFiles: input.sourceFiles,
-	})
-	const normalizedEntrypoint = joinPath(
-		rootSourcePrefix,
-		normalizePackageWorkspacePath(input.entryPoint),
-	)
-	const bootstrapPath = joinPath(rootSourcePrefix, '.__kody_app_entry__.js')
-	files[bootstrapPath] = createAppEntrypointSource({
-		modulePath: createRelativeImportSpecifier(
-			bootstrapPath,
-			normalizedEntrypoint,
-		),
-	})
-	const bundle = await createWorker({
-		files,
-		entryPoint: bootstrapPath,
-	})
-	return {
-		mainModule: bundle.mainModule,
-		modules: bundle.modules as WorkerLoaderModules,
+	const buildBundle = async () => {
+		const files = await prepareKodyGraphFiles({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.userId,
+			sourceFiles: input.sourceFiles,
+		})
+		const normalizedEntrypoint = joinPath(
+			rootSourcePrefix,
+			normalizePackageWorkspacePath(input.entryPoint),
+		)
+		const bootstrapPath = joinPath(rootSourcePrefix, '.__kody_app_entry__.js')
+		files[bootstrapPath] = createAppEntrypointSource({
+			modulePath: createRelativeImportSpecifier(
+				bootstrapPath,
+				normalizedEntrypoint,
+			),
+		})
+		const bundle = await createWorker({
+			files,
+			entryPoint: bootstrapPath,
+		})
+		return {
+			mainModule: bundle.mainModule,
+			modules: bundle.modules as WorkerLoaderModules,
+		}
 	}
+
+	const cacheKey = input.cacheKey?.trim() || null
+	if (!cacheKey) {
+		return await buildBundle()
+	}
+
+	return await packageAppBundleCache.getOrCreate({
+		cacheKey,
+		create: buildBundle,
+	})
+}
+
+export function createPublishedPackageAppBundleCacheKey(input: {
+	userId: string
+	source: {
+		id: string
+		published_commit: string | null
+		manifest_path: string
+		source_root: string
+	}
+	entryPoint: string
+}) {
+	return createPublishedPackageCacheKey({
+		userId: input.userId,
+		source: input.source,
+		entryPoint: input.entryPoint,
+	})
 }

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -10,7 +10,10 @@ import {
 	createAuthenticatedFetch,
 	refreshAccessToken,
 } from '#mcp/execute-modules/codemode-utils.ts'
-import { buildKodyAppBundle } from './module-graph.ts'
+import {
+	buildKodyAppBundle,
+	createPublishedPackageAppBundleCacheKey,
+} from './module-graph.ts'
 import { storageRunnerRpc } from '#worker/storage-runner.ts'
 
 const packageAppEntrypointName = 'PackageAppWorker'
@@ -501,6 +504,9 @@ export async function buildPackageAppWorker(input: {
 		kodyId: string
 		name: string
 		sourceId: string
+		publishedCommit: string | null
+		manifestPath: string
+		sourceRoot: string
 	}
 	sourceFiles: Record<string, string>
 	params?: Record<string, unknown>
@@ -528,6 +534,16 @@ export async function buildPackageAppWorker(input: {
 		userId: input.userId,
 		sourceFiles: input.sourceFiles,
 		entryPoint: appEntry,
+		cacheKey: createPublishedPackageAppBundleCacheKey({
+			userId: input.userId,
+			source: {
+				id: input.savedPackage.sourceId,
+				published_commit: input.savedPackage.publishedCommit,
+				manifest_path: input.savedPackage.manifestPath,
+				source_root: input.savedPackage.sourceRoot,
+			},
+			entryPoint: appEntry,
+		}),
 	})
 	const mainModule = 'package-app-entry.js'
 	const modules = {
@@ -537,6 +553,9 @@ export async function buildPackageAppWorker(input: {
 		}),
 	}
 	return {
+		// Keep the loader stub per-request because the bound runtime bridge props are
+		// caller-specific (user/package context) and we do not want to risk leaking
+		// request-scoped bindings through a reused stub.
 		stub: input.env.APP_LOADER.load({
 			compatibilityDate: '2026-04-13',
 			compatibilityFlags: ['nodejs_compat', 'global_fetch_strictly_public'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- cache published package source loads in `loadPackageSourceBySourceId` so hosted package apps stop reopening a repo session on every request
- add a second cache layer for published package app bundles so `prepareKodyGraphFiles` + `createWorker(...)` only run once per source/version/entrypoint in an isolate
- keep `APP_LOADER.load(...)` per request because the bound runtime bridge props are caller-specific and reusing a stub risks leaking request-scoped bindings
- harden the shared promise cache so a rejected stale promise cannot delete a newer same-key cache entry
- freeze cached package source payloads more thoroughly and add a source-cache failure-eviction regression test
- add focused tests for warm reuse, uncached unpublished sources, concurrent in-flight sharing, failure eviction, and distinct app entrypoints

## Root cause
Production MCP timings pointed to repo-backed source resolution as the first dominant cost, and Kent reported package apps still felt sluggish after that because every request was still paying for a full package-app esbuild pass.

Production datapoints from the Kody MCP server:
- unauthenticated `GET /packages/tron-mortgage-calculator` redirected in about 862ms
- opening the repo session for `tron-mortgage-calculator` took about 3372ms even though the package only had 13 files / ~40KB
- opening repo sessions for two other real package apps also took about 4.6s-5.3s

This PR now addresses both layers:
1. source cache for published repo-backed package sources
2. bundle cache for published package app module payloads, keyed by `userId + sourceId + published_commit + manifest_path + source_root + entryPoint`

## Notes
- unpublished/live-edited sources still skip both caches and always reload/rebundle
- both caches share the same 5 minute TTL, 50 entry cap, touch-on-read LRU ordering, in-flight promise sharing, and failure eviction semantics
- the bundle cache only stores `{ mainModule, modules }`; request-specific loader env/bindings are rebuilt each time
- cached source payloads are cloned/frozen before reuse so warm-cache callers cannot mutate shared nested state

## Testing
- `npm exec vitest run packages/worker/src/package-registry/source.node.test.ts`
- `npm exec vitest run packages/worker/src/package-registry/source.node.test.ts packages/worker/src/package-runtime/module-graph.node.test.ts packages/worker/src/app/handlers/package-app.node.test.ts`
- `npm run typecheck`
- production MCP timing probes via `repo_open_session` / `repo_discard_session` and hosted package URLs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd89eeac-4483-472b-ba74-9bc32f5ec63e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd89eeac-4483-472b-ba74-9bc32f5ec63e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * In-memory caching for published package sources (5‑minute TTL) with in‑flight deduplication; returned package data is now immutable to prevent accidental mutation.
  * App bundling for published packages is now cached by package metadata, deduplicating concurrent builds and retrying evicted failures.

* **Tests**
  * Added tests validating caching, in‑flight deduplication, eviction/retry behavior, and bundling cache separation by entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->