### PR TITLE
repo: make repo_edit_flow edit details opt in

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -49,6 +49,12 @@ When you need to edit saved source, prefer the repo-backed workflow in
 [Repo-backed editing sessions](./repo-sessions.md). Open by package identity
 instead of internal source ids whenever possible.
 
+For common edit-and-check workflows, `repo_edit_flow` returns a self-contained
+result that includes the applied `edits` array. That is convenient for agents
+that want the concrete diff in the same call, but it can be verbose. When
+response size matters more than getting the edit record back immediately, use
+the lower-level repo capabilities described on that page instead.
+
 ## Agent turns
 
 Kody exposes two generic primitives for tool-using chat turns:

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -49,11 +49,10 @@ When you need to edit saved source, prefer the repo-backed workflow in
 [Repo-backed editing sessions](./repo-sessions.md). Open by package identity
 instead of internal source ids whenever possible.
 
-For common edit-and-check workflows, `repo_edit_flow` returns a self-contained
-result that includes the applied `edits` array. That is convenient for agents
-that want the concrete diff in the same call, but it can be verbose. When
-response size matters more than getting the edit record back immediately, use
-the lower-level repo capabilities described on that page instead.
+For common edit-and-check workflows, `repo_edit_flow` returns session, checks,
+and publish detail in one response. The nested `edits.edits` array is omitted by
+default to keep that response smaller, and can be requested explicitly when a
+caller needs the concrete diff in the same call.
 
 ## Agent turns
 

--- a/docs/use/repo-sessions.md
+++ b/docs/use/repo-sessions.md
@@ -7,6 +7,27 @@ publishes.
 Use the repo capabilities when you want to inspect or modify package source
 directly.
 
+## Why `repo_edit_flow` returns `edits`
+
+`repo_edit_flow` returns the applied `edits` array by default.
+
+That response shape favors one-shot agent workflows:
+
+- the caller can inspect exactly what changed without issuing extra read calls
+- checks and publish results can be paired with the concrete file diffs that
+  produced them
+- retries and repair logic can reason over one structured result instead of
+  reconstructing state from a session after the fact
+
+This is especially useful for auditability and for agents that need to explain
+their work immediately after an edit flow finishes.
+
+The tradeoff is response size. Large edit batches can produce a large `edits`
+payload, which may be wasteful for callers that only need session, checks, or
+publish status. When response size matters more than a self-contained result,
+use the lower-level repo capabilities instead of `repo_edit_flow` so you can
+choose when to read file contents or diffs.
+
 ## Preferred workflow
 
 For common edits, prefer **`repo_edit_flow`**.
@@ -61,6 +82,7 @@ session:
 - browse files with `repo_tree` and `repo_read_file`
 - search the workspace with `repo_search`
 - apply multiple edit batches over time
+- avoid returning the full `edits` payload from one convenience workflow
 - run checks separately from publish
 - inspect status with `repo_get_check_status`
 - repair drift with `repo_rebase_session`
@@ -82,4 +104,5 @@ await codemode.repo_edit_flow({
 ```
 
 This returns the session metadata, applied edits, check outcome, and publish
-result in one structured response.
+result in one structured response. The response is intentionally self-contained,
+which is why the `edits` array is included by default.

--- a/docs/use/repo-sessions.md
+++ b/docs/use/repo-sessions.md
@@ -7,26 +7,16 @@ publishes.
 Use the repo capabilities when you want to inspect or modify package source
 directly.
 
-## Why `repo_edit_flow` returns `edits`
+## `edits` payload
 
-`repo_edit_flow` returns the applied `edits` array by default.
+`repo_edit_flow` returns `edits.dry_run` and `edits.total_changed` by default.
 
-That response shape favors one-shot agent workflows:
+The full `edits.edits` array is opt-in through `include_edits: true`.
 
-- the caller can inspect exactly what changed without issuing extra read calls
-- checks and publish results can be paired with the concrete file diffs that
-  produced them
-- retries and repair logic can reason over one structured result instead of
-  reconstructing state from a session after the fact
-
-This is especially useful for auditability and for agents that need to explain
-their work immediately after an edit flow finishes.
-
-The tradeoff is response size. Large edit batches can produce a large `edits`
-payload, which may be wasteful for callers that only need session, checks, or
-publish status. When response size matters more than a self-contained result,
-use the lower-level repo capabilities instead of `repo_edit_flow` so you can
-choose when to read file contents or diffs.
+That keeps the default response small for agent workflows that only need
+session, checks, publish status, or a count of changed files, while still
+allowing callers to request the concrete changed content and diff when they need
+audit or explanation detail.
 
 ## Preferred workflow
 
@@ -82,7 +72,7 @@ session:
 - browse files with `repo_tree` and `repo_read_file`
 - search the workspace with `repo_search`
 - apply multiple edit batches over time
-- avoid returning the full `edits` payload from one convenience workflow
+- inspect file contents or diffs only when you decide to read them
 - run checks separately from publish
 - inspect status with `repo_get_check_status`
 - repair drift with `repo_rebase_session`
@@ -92,6 +82,7 @@ session:
 ```ts
 await codemode.repo_edit_flow({
 	target: { kind: 'package', kody_id: 'triage-github-pr' },
+	include_edits: true,
 	instructions: [
 		{
 			kind: 'replace',
@@ -103,6 +94,6 @@ await codemode.repo_edit_flow({
 })
 ```
 
-This returns the session metadata, applied edits, check outcome, and publish
-result in one structured response. The response is intentionally self-contained,
-which is why the `edits` array is included by default.
+This returns the session metadata, edit summary, check outcome, and publish
+result in one structured response. Set `include_edits: true` when you also want
+the full applied edit list with file content and diffs.

--- a/packages/worker/src/mcp/capabilities/repo/repo-edit-flow.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-edit-flow.ts
@@ -89,7 +89,7 @@ export const repoEditFlowCapability = defineDomainCapability(
 			const editsSummary = {
 				dry_run: edits.dryRun,
 				total_changed: edits.totalChanged,
-				edits: edits.edits,
+				...(args.include_edits ? { edits: edits.edits } : {}),
 			}
 			const buildFlowResponse = async (
 				checks: RepoEditFlowResult['checks'],

--- a/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
@@ -447,6 +447,12 @@ export const repoEditFlowInputSchema = z
 			.describe(
 				'Whether to roll back all edits when one instruction fails. Defaults to true.',
 			),
+		include_edits: z
+			.boolean()
+			.optional()
+			.describe(
+				'Whether to include the full applied edits array in the response. Defaults to false.',
+			),
 		run_checks: z
 			.boolean()
 			.optional()
@@ -577,7 +583,11 @@ export const repoEditFlowPublishSchema = z.union([
 export const repoEditFlowOutputSchema = z.object({
 	session: repoSessionInfoSchema,
 	resolved_target: repoResolvedTargetSchema,
-	edits: repoApplyPatchResultSchema,
+	edits: z.object({
+		dry_run: z.boolean(),
+		total_changed: z.number().int().min(0),
+		edits: repoApplyPatchResultSchema.shape.edits.optional(),
+	}),
 	checks: repoEditFlowChecksSchema,
 	publish: repoEditFlowPublishSchema,
 })

--- a/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
@@ -253,6 +253,10 @@ test('repo_open_session reuses resolved target metadata when resuming an existin
 		createCapabilityContext(),
 	)
 
+	expect(result.edits).toEqual({
+		dry_run: false,
+		total_changed: 1,
+	})
 	expect(result.resolved_target).toEqual({
 		kind: 'package',
 		source_id: 'source-package-1',
@@ -360,6 +364,10 @@ test('repo_edit_flow applies edits, runs checks, and skips publish when checks f
 	expect(rpc.applyEdits).toHaveBeenCalledTimes(1)
 	expect(rpc.runChecks).toHaveBeenCalledTimes(1)
 	expect(rpc.publishSession).not.toHaveBeenCalled()
+	expect(result.edits).toEqual({
+		dry_run: false,
+		total_changed: 1,
+	})
 	expect(result.checks).toEqual({
 		status: 'failed',
 		ok: false,
@@ -389,6 +397,99 @@ test('repo_edit_flow applies edits, runs checks, and skips publish when checks f
 		run_id: 'check-1',
 		tree_hash: 'tree-1',
 		checked_at: '2026-04-18T00:02:00.000Z',
+	})
+})
+
+test('repo_edit_flow includes edit details when include_edits is true', async () => {
+	resetMocks()
+	mockModule.getSavedPackageById
+		.mockResolvedValueOnce(createSavedPackageRow())
+		.mockResolvedValueOnce(createSavedPackageRow())
+	mockModule.getEntitySourceById
+		.mockResolvedValueOnce(createPackageSourceRow())
+		.mockResolvedValueOnce(createPackageSourceRow())
+	const rpc = createRepoRpc()
+	rpc.getSessionInfo.mockResolvedValueOnce({
+		id: 'session-existing',
+		source_id: 'source-package-1',
+		source_root: '/',
+		base_commit: 'commit-package-1',
+		session_repo_id: 'session-repo-1',
+		session_repo_name: 'repo-package-1-session-1',
+		session_repo_namespace: 'default',
+		conversation_id: 'conversation-1',
+		last_checkpoint_commit: 'commit-package-1',
+		last_check_run_id: null,
+		last_check_tree_hash: null,
+		expires_at: null,
+		created_at: '2026-04-18T00:01:00.000Z',
+		updated_at: '2026-04-18T00:02:00.000Z',
+		published_commit: 'commit-package-1',
+		manifest_path: 'package.json',
+		entity_type: 'package',
+	})
+	rpc.getSessionInfo.mockResolvedValueOnce({
+		id: 'session-existing',
+		source_id: 'source-package-1',
+		source_root: '/',
+		base_commit: 'commit-package-1',
+		session_repo_id: 'session-repo-1',
+		session_repo_name: 'repo-package-1-session-1',
+		session_repo_namespace: 'default',
+		conversation_id: 'conversation-1',
+		last_checkpoint_commit: 'commit-package-1',
+		last_check_run_id: null,
+		last_check_tree_hash: null,
+		expires_at: null,
+		created_at: '2026-04-18T00:01:00.000Z',
+		updated_at: '2026-04-18T00:02:00.000Z',
+		published_commit: 'commit-package-1',
+		manifest_path: 'package.json',
+		entity_type: 'package',
+	})
+	rpc.applyEdits.mockResolvedValueOnce({
+		dryRun: false,
+		totalChanged: 1,
+		edits: [
+			{
+				path: 'src/index.ts',
+				changed: true,
+				content: 'export default async function run() { return { ok: true } }',
+				diff: '@@',
+			},
+		],
+	})
+	mockModule.repoSessionRpc.mockReturnValue(rpc)
+
+	const result = await repoEditFlowCapability.handler(
+		{
+			session_id: 'session-existing',
+			instructions: [
+				{
+					kind: 'replace',
+					path: 'src/index.ts',
+					search: 'return { ok: false }',
+					replacement: 'return { ok: true }',
+				},
+			],
+			include_edits: true,
+			run_checks: false,
+			publish: false,
+		},
+		createCapabilityContext(),
+	)
+
+	expect(result.edits).toEqual({
+		dry_run: false,
+		total_changed: 1,
+		edits: [
+			{
+				path: 'src/index.ts',
+				changed: true,
+				content: 'export default async function run() { return { ok: true } }',
+				diff: '@@',
+			},
+		],
 	})
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make `repo_edit_flow` omit the nested `edits.edits` payload by default while still returning `dry_run` and `total_changed`
- add an `include_edits` input flag so callers can explicitly request the full applied edit list when they need content and diffs
- update the repo workflow docs and focused tests to cover the new default and opt-in behavior

## Testing
- ✅ `npm run test -- packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts`
- ✅ `npm run format:check -- packages/worker/src/mcp/capabilities/repo/repo-shared.ts packages/worker/src/mcp/capabilities/repo/repo-edit-flow.ts packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts docs/use/repo-sessions.md docs/use/execute.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-665ff875-a8f0-4192-91eb-e5f109ad8c22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-665ff875-a8f0-4192-91eb-e5f109ad8c22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

