### PR TITLE
Add a jobs capability to run scheduled jobs immediately

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -48,6 +48,8 @@ module-oriented runtime model:
   **`codemode.job_schedule(...)`** without creating a saved package
 - **`codemode.job_schedule_once(...)`** remains available as a convenience alias
   for one-off schedules
+- **`codemode.job_run_now(...)`** runs an existing scheduled job immediately and
+  returns both the updated job state and the execution result for debugging
 
 When you need to edit saved source, prefer the repo-backed workflow in
 [Repo-backed editing sessions](./repo-sessions.md). Open by package identity

--- a/docs/use/first-steps.md
+++ b/docs/use/first-steps.md
@@ -19,7 +19,8 @@ connector, value, or secret reference, then run work through **execute**.
   declare package-owned jobs, and can optionally expose an app/UI surface.
   For scheduled work that should not become a saved package, use the built-in
   `job_schedule` capability. `job_schedule_once` remains available as a
-  one-off convenience alias.
+  one-off convenience alias, and `job_run_now` can trigger an existing job
+  immediately for debugging or catch-up runs.
 - **Ask for natural-language goals**, for example: “Search Kody for GitHub pull
   request automation” or “Find a saved package for Cloudflare DNS helpers.”
 - **Do not paste secrets in chat.** Use saved secrets, generated UI, or the

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -76,7 +76,8 @@ Jobs are part of the package definition.
 
 For repo-backed jobs that are not part of a saved package, use
 `job_schedule` instead. `job_schedule_once` remains available as the one-off
-shortcut.
+shortcut, and `job_run_now` can trigger an existing scheduled job immediately
+for debugging or ad hoc runs.
 
 ## Save and edit packages
 

--- a/packages/worker/src/jobs/manager-client.ts
+++ b/packages/worker/src/jobs/manager-client.ts
@@ -1,5 +1,9 @@
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
-import { type JobRepoCheckPolicy } from './types.ts'
+import {
+	type JobExecutionResult,
+	type JobRepoCheckPolicy,
+	type JobView,
+} from './types.ts'
 
 type JobManagerRpc = {
 	syncAlarm: (payload: { userId: string }) => Promise<{
@@ -12,7 +16,10 @@ type JobManagerRpc = {
 		jobId: string
 		callerContext?: McpCallerContext | null
 		repoCheckPolicyOverride?: JobRepoCheckPolicy | null
-	}) => Promise<unknown>
+	}) => Promise<{
+		job: JobView
+		execution: JobExecutionResult
+	}>
 }
 
 export function jobManagerRpc(env: Env, userId: string): JobManagerRpc | null {

--- a/packages/worker/src/mcp/capabilities/jobs/domain.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/domain.ts
@@ -1,12 +1,26 @@
 import { defineDomain } from '../define-domain.ts'
 import { capabilityDomainNames } from '../domain-metadata.ts'
+import { jobRunNowCapability } from './job-run-now.ts'
 import { jobScheduleCapability } from './job-schedule.ts'
 import { jobScheduleOnceCapability } from './job-schedule-once.ts'
 
 export const jobsDomain = defineDomain({
 	name: capabilityDomainNames.jobs,
 	description:
-		'Schedule repo-backed jobs. Use this for one-off or recurring jobs that should run later without creating a saved package.',
-	keywords: ['job', 'schedule', 'one-off', 'interval', 'cron', 'background'],
-	capabilities: [jobScheduleCapability, jobScheduleOnceCapability],
+		'Schedule repo-backed jobs or trigger an existing job immediately. Use this for one-off or recurring jobs without creating a saved package.',
+	keywords: [
+		'job',
+		'schedule',
+		'one-off',
+		'interval',
+		'cron',
+		'background',
+		'run now',
+		'immediate',
+	],
+	capabilities: [
+		jobScheduleCapability,
+		jobScheduleOnceCapability,
+		jobRunNowCapability,
+	],
 })

--- a/packages/worker/src/mcp/capabilities/jobs/job-run-now.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-run-now.ts
@@ -1,0 +1,40 @@
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	type JobRunNowCapabilityInput,
+	jobRunNowInputSchema,
+	jobRunNowOutputSchema,
+	runJobNowFromArgs,
+} from './shared.ts'
+
+export const jobRunNowCapability = defineDomainCapability(
+	capabilityDomainNames.jobs,
+	{
+		name: 'job_run_now',
+		description:
+			'Run an existing repo-backed job immediately by id using the normal job runtime, then return the updated job state and execution result for debugging.',
+		keywords: [
+			'job',
+			'run',
+			'run now',
+			'immediate',
+			'manual',
+			'execute',
+			'debug',
+			'backfill',
+			'trigger',
+		],
+		readOnly: false,
+		idempotent: false,
+		destructive: false,
+		inputSchema: jobRunNowInputSchema,
+		outputSchema: jobRunNowOutputSchema,
+		async handler(args: JobRunNowCapabilityInput, ctx) {
+			return runJobNowFromArgs({
+				env: ctx.env,
+				callerContext: ctx.callerContext,
+				args,
+			})
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts
@@ -5,6 +5,7 @@ import { jobsDomain } from './domain.ts'
 const mockModule = vi.hoisted(() => ({
 	createJob: vi.fn(),
 	syncJobManagerAlarm: vi.fn(),
+	runJobNowViaManager: vi.fn(),
 }))
 
 vi.mock('#worker/jobs/service.ts', () => ({
@@ -14,14 +15,18 @@ vi.mock('#worker/jobs/service.ts', () => ({
 vi.mock('#worker/jobs/manager-client.ts', () => ({
 	syncJobManagerAlarm: (...args: Array<unknown>) =>
 		mockModule.syncJobManagerAlarm(...args),
+	runJobNowViaManager: (...args: Array<unknown>) =>
+		mockModule.runJobNowViaManager(...args),
 }))
 
 const { jobScheduleCapability } = await import('./job-schedule.ts')
 const { jobScheduleOnceCapability } = await import('./job-schedule-once.ts')
+const { jobRunNowCapability } = await import('./job-run-now.ts')
 
 function resetMocks() {
 	mockModule.createJob.mockReset()
 	mockModule.syncJobManagerAlarm.mockReset()
+	mockModule.runJobNowViaManager.mockReset()
 	mockModule.syncJobManagerAlarm.mockResolvedValue(undefined)
 }
 
@@ -110,8 +115,203 @@ test('job_schedule creates a one-off job and syncs the job manager alarm', async
 
 test('jobs domain exposes recurring and one-off scheduling capabilities', () => {
 	expect(jobsDomain.capabilities.map((capability) => capability.name)).toEqual(
-		expect.arrayContaining(['job_schedule', 'job_schedule_once']),
+		expect.arrayContaining([
+			'job_schedule',
+			'job_schedule_once',
+			'job_run_now',
+		]),
 	)
+})
+
+test('job_run_now executes an existing job through the job manager', async () => {
+	resetMocks()
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-123',
+			email: 'user@example.com',
+			displayName: 'User Example',
+		},
+		storageContext: {
+			sessionId: null,
+			appId: 'app-123',
+		},
+	})
+	mockModule.runJobNowViaManager.mockResolvedValue({
+		job: {
+			id: 'job-123',
+			name: 'Immediate run',
+			sourceId: 'source-123',
+			publishedCommit: 'commit-123',
+			storageId: 'job:job-123',
+			params: {
+				room: 'office',
+			},
+			schedule: {
+				type: 'interval',
+				every: '15m',
+			},
+			scheduleSummary: 'Runs every 15m',
+			timezone: 'UTC',
+			enabled: true,
+			killSwitchEnabled: false,
+			createdAt: '2026-04-20T10:00:00.000Z',
+			updatedAt: '2026-04-20T10:05:00.000Z',
+			lastRunAt: '2026-04-20T10:05:00.000Z',
+			lastRunStatus: 'success',
+			lastDurationMs: 42,
+			nextRunAt: '2026-04-20T10:20:00.000Z',
+			runCount: 1,
+			successCount: 1,
+			errorCount: 0,
+			runHistory: [
+				{
+					startedAt: '2026-04-20T10:05:00.000Z',
+					finishedAt: '2026-04-20T10:05:00.000Z',
+					status: 'success',
+					durationMs: 42,
+				},
+			],
+		},
+		execution: {
+			ok: true,
+			result: { ok: true },
+			logs: ['ran job'],
+		},
+	})
+
+	const result = await jobRunNowCapability.handler(
+		{
+			id: 'job-123',
+		},
+		{
+			env,
+			callerContext,
+		},
+	)
+
+	expect(mockModule.runJobNowViaManager).toHaveBeenCalledWith({
+		env,
+		userId: 'user-123',
+		jobId: 'job-123',
+		callerContext,
+	})
+	expect(result).toEqual({
+		job: {
+			job_id: 'job-123',
+			name: 'Immediate run',
+			source_id: 'source-123',
+			published_commit: 'commit-123',
+			storage_id: 'job:job-123',
+			params: {
+				room: 'office',
+			},
+			schedule: {
+				type: 'interval',
+				every: '15m',
+			},
+			schedule_summary: 'Runs every 15m',
+			timezone: 'UTC',
+			enabled: true,
+			kill_switch_enabled: false,
+			created_at: '2026-04-20T10:00:00.000Z',
+			updated_at: '2026-04-20T10:05:00.000Z',
+			last_run_at: '2026-04-20T10:05:00.000Z',
+			last_run_status: 'success',
+			last_duration_ms: 42,
+			next_run_at: '2026-04-20T10:20:00.000Z',
+			run_count: 1,
+			success_count: 1,
+			error_count: 0,
+			run_history: [
+				{
+					started_at: '2026-04-20T10:05:00.000Z',
+					finished_at: '2026-04-20T10:05:00.000Z',
+					status: 'success',
+					duration_ms: 42,
+				},
+			],
+		},
+		execution: {
+			ok: true,
+			result: { ok: true },
+			logs: ['ran job'],
+		},
+		deleted_after_run: false,
+	})
+})
+
+test('job_run_now reports one-off jobs as deleted after the run', async () => {
+	resetMocks()
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-123',
+			email: 'user@example.com',
+			displayName: 'User Example',
+		},
+	})
+	mockModule.runJobNowViaManager.mockResolvedValue({
+		job: {
+			id: 'job-once',
+			name: 'One-off run',
+			sourceId: 'source-once',
+			publishedCommit: null,
+			storageId: 'job:job-once',
+			schedule: {
+				type: 'once',
+				runAt: '2026-04-20T10:00:00.000Z',
+			},
+			scheduleSummary: 'Runs once at 2026-04-20T10:00:00.000Z',
+			timezone: 'UTC',
+			enabled: true,
+			killSwitchEnabled: false,
+			createdAt: '2026-04-20T09:00:00.000Z',
+			updatedAt: '2026-04-20T10:00:00.000Z',
+			lastRunAt: '2026-04-20T10:00:00.000Z',
+			lastRunStatus: 'error',
+			lastRunError: 'boom',
+			lastDurationMs: 5,
+			nextRunAt: '2026-04-20T10:00:00.000Z',
+			runCount: 1,
+			successCount: 0,
+			errorCount: 1,
+			runHistory: [
+				{
+					startedAt: '2026-04-20T10:00:00.000Z',
+					finishedAt: '2026-04-20T10:00:00.000Z',
+					status: 'error',
+					durationMs: 5,
+					error: 'boom',
+				},
+			],
+		},
+		execution: {
+			ok: false,
+			error: 'boom',
+			logs: ['ran job'],
+		},
+	})
+
+	const result = await jobRunNowCapability.handler(
+		{
+			id: 'job-once',
+		},
+		{
+			env,
+			callerContext,
+		},
+	)
+
+	expect(result.deleted_after_run).toBe(true)
+	expect(result.execution).toEqual({
+		ok: false,
+		error: 'boom',
+		logs: ['ran job'],
+	})
+	expect(result.job.last_run_error).toBe('boom')
 })
 
 test('job_schedule creates a recurring interval job', async () => {
@@ -327,4 +527,24 @@ test('job_schedule requires an authenticated user', async () => {
 	).rejects.toThrow('Authenticated MCP user is required for this capability.')
 	expect(mockModule.createJob).not.toHaveBeenCalled()
 	expect(mockModule.syncJobManagerAlarm).not.toHaveBeenCalled()
+})
+
+test('job_run_now requires an authenticated user', async () => {
+	resetMocks()
+	const env = {} as Env
+
+	await expect(
+		jobRunNowCapability.handler(
+			{
+				id: 'job-123',
+			},
+			{
+				env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://example.com',
+				}),
+			},
+		),
+	).rejects.toThrow('Authenticated MCP user is required for this capability.')
+	expect(mockModule.runJobNowViaManager).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/mcp/capabilities/jobs/shared.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/shared.ts
@@ -207,25 +207,7 @@ export function buildJobScheduleOutput(created: JobView) {
 		name: created.name,
 		source_id: created.sourceId,
 		storage_id: created.storageId,
-		schedule: (() => {
-			switch (created.schedule.type) {
-				case 'once':
-					return {
-						type: 'once' as const,
-						run_at: created.schedule.runAt,
-					}
-				case 'interval':
-					return {
-						type: 'interval' as const,
-						every: created.schedule.every,
-					}
-				case 'cron':
-					return {
-						type: 'cron' as const,
-						expression: created.schedule.expression,
-					}
-			}
-		})(),
+		schedule: buildJobScheduleSummaryOutput(created.schedule),
 		schedule_summary: created.scheduleSummary,
 		created_at: created.createdAt,
 		next_run_at: created.nextRunAt,

--- a/packages/worker/src/mcp/capabilities/jobs/shared.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/shared.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
-import { type JobCreateInput, type JobSchedule, type JobView } from '#worker/jobs/types.ts'
+import {
+	type JobCreateInput,
+	type JobExecutionResult,
+	type JobSchedule,
+	type JobView,
+} from '#worker/jobs/types.ts'
 
 const onceScheduleSchema = z.object({
 	type: z.literal('once'),
@@ -72,6 +77,14 @@ const scheduledJobSummarySchema = z.discriminatedUnion('type', [
 	cronScheduleSchema,
 ])
 
+const runHistoryEntrySchema = z.object({
+	started_at: z.string(),
+	finished_at: z.string(),
+	status: z.enum(['success', 'error']),
+	duration_ms: z.number(),
+	error: z.string().optional(),
+})
+
 export const jobScheduleInputSchema = z.object({
 	...scheduledJobInputBaseSchema,
 	schedule: scheduledJobScheduleSchema,
@@ -98,7 +111,60 @@ export const jobScheduleOutputSchema = z.object({
 	next_run_at: z.string(),
 })
 
+export const jobViewOutputSchema = z.object({
+	job_id: z.string(),
+	name: z.string(),
+	source_id: z.string(),
+	published_commit: z.string().nullable(),
+	storage_id: z.string(),
+	params: z.record(z.string(), z.unknown()).optional(),
+	schedule: scheduledJobSummarySchema,
+	schedule_summary: z.string(),
+	timezone: z.string(),
+	enabled: z.boolean(),
+	kill_switch_enabled: z.boolean(),
+	created_at: z.string(),
+	updated_at: z.string(),
+	last_run_at: z.string().optional(),
+	last_run_status: z.enum(['success', 'error']).optional(),
+	last_run_error: z.string().optional(),
+	last_duration_ms: z.number().optional(),
+	next_run_at: z.string(),
+	run_count: z.number(),
+	success_count: z.number(),
+	error_count: z.number(),
+	run_history: z.array(runHistoryEntrySchema),
+})
+
+export const jobExecutionOutputSchema = z.discriminatedUnion('ok', [
+	z.object({
+		ok: z.literal(true),
+		result: z.unknown().optional(),
+		logs: z.array(z.string()),
+	}),
+	z.object({
+		ok: z.literal(false),
+		error: z.string(),
+		logs: z.array(z.string()),
+	}),
+])
+
+export const jobRunNowInputSchema = z.object({
+	id: z.string().min(1).describe('Existing job id to execute immediately.'),
+})
+
+export const jobRunNowOutputSchema = z.object({
+	job: jobViewOutputSchema,
+	execution: jobExecutionOutputSchema,
+	deleted_after_run: z
+		.boolean()
+		.describe(
+			'Whether the job was deleted after this run, which happens for one-off schedules.',
+		),
+})
+
 export type JobScheduleCapabilityInput = z.infer<typeof jobScheduleInputSchema>
+export type JobRunNowCapabilityInput = z.infer<typeof jobRunNowInputSchema>
 
 export function toJobSchedule(
 	schedule: z.infer<typeof scheduledJobScheduleSchema>,
@@ -166,6 +232,70 @@ export function buildJobScheduleOutput(created: JobView) {
 	}
 }
 
+export function buildJobScheduleSummaryOutput(schedule: JobView['schedule']) {
+	switch (schedule.type) {
+		case 'once':
+			return {
+				type: 'once' as const,
+				run_at: schedule.runAt,
+			}
+		case 'interval':
+			return {
+				type: 'interval' as const,
+				every: schedule.every,
+			}
+		case 'cron':
+			return {
+				type: 'cron' as const,
+				expression: schedule.expression,
+			}
+	}
+}
+
+export function buildJobViewOutput(job: JobView) {
+	return {
+		job_id: job.id,
+		name: job.name,
+		source_id: job.sourceId,
+		published_commit: job.publishedCommit,
+		storage_id: job.storageId,
+		params: job.params,
+		schedule: buildJobScheduleSummaryOutput(job.schedule),
+		schedule_summary: job.scheduleSummary,
+		timezone: job.timezone,
+		enabled: job.enabled,
+		kill_switch_enabled: job.killSwitchEnabled,
+		created_at: job.createdAt,
+		updated_at: job.updatedAt,
+		last_run_at: job.lastRunAt,
+		last_run_status: job.lastRunStatus,
+		last_run_error: job.lastRunError,
+		last_duration_ms: job.lastDurationMs,
+		next_run_at: job.nextRunAt,
+		run_count: job.runCount,
+		success_count: job.successCount,
+		error_count: job.errorCount,
+		run_history: job.runHistory.map((entry) => ({
+			started_at: entry.startedAt,
+			finished_at: entry.finishedAt,
+			status: entry.status,
+			duration_ms: entry.durationMs,
+			error: entry.error,
+		})),
+	}
+}
+
+export function buildJobRunNowOutput(input: {
+	job: JobView
+	execution: JobExecutionResult
+}) {
+	return {
+		job: buildJobViewOutput(input.job),
+		execution: input.execution,
+		deleted_after_run: input.job.schedule.type === 'once',
+	}
+}
+
 export async function createScheduledJobFromArgs(input: {
 	env: Env
 	callerContext: CapabilityContext['callerContext']
@@ -187,4 +317,20 @@ export async function createScheduledJobFromArgs(input: {
 		userId: user.userId,
 	})
 	return buildJobScheduleOutput(created)
+}
+
+export async function runJobNowFromArgs(input: {
+	env: Env
+	callerContext: CapabilityContext['callerContext']
+	args: JobRunNowCapabilityInput
+}) {
+	const user = requireMcpUser(input.callerContext)
+	const { runJobNowViaManager } = await import('#worker/jobs/manager-client.ts')
+	const result = await runJobNowViaManager({
+		env: input.env,
+		userId: user.userId,
+		jobId: input.args.id,
+		callerContext: input.callerContext,
+	})
+	return buildJobRunNowOutput(result)
 }

--- a/packages/worker/src/mcp/jobs-embed.ts
+++ b/packages/worker/src/mcp/jobs-embed.ts
@@ -31,5 +31,5 @@ export function buildJobEmbedText(
 }
 
 export function buildJobUsage(job: Pick<JobView, 'id'>) {
-	return `Inspect with job_get: ${JSON.stringify({ id: job.id })}. Trigger immediately with job_run_now: ${JSON.stringify({ id: job.id })}.`
+	return `Trigger immediately with job_run_now: ${JSON.stringify({ id: job.id })}.`
 }

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -25,6 +25,7 @@ Conventions
 - \`package_get\` / \`package_list\` / \`package_delete\`: inspect or manage saved packages for the signed-in user.
 - \`job_schedule\`: schedule a repo-backed job for the signed-in user without creating a saved package first. Supports one-off, interval, and cron schedules.
 - \`job_schedule_once\`: compatibility wrapper for one-off repo-backed jobs when you only need a single run time.
+- \`job_run_now\`: run an existing scheduled job immediately by id and return the updated job view plus execution result for debugging.
 - Package jobs are schedules owned by a package. For ad hoc work that is not tied to a package, use \`job_schedule\`. Package apps are optional UI surfaces declared by the package, not a separate top-level primitive.
 - Memory writes are verify-first: always run \`meta_memory_verify\` before \`meta_memory_upsert\` or \`meta_memory_delete\`. Kody retrieves related memories; the consuming agent decides whether to upsert, delete, both, or do nothing. \`meta_memory_upsert\` creates a new memory when \`memory_id\` is omitted and updates an existing memory when \`memory_id\` is provided.
 - User-specific MCP instructions: \`meta_get_mcp_server_instructions\` / \`meta_set_mcp_server_instructions\` (signed-in users). Updates apply to **new** MCP sessions (reconnect to refresh what the host shows).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a `job_run_now` jobs-domain capability that executes an existing scheduled job by id through the existing job manager/runtime path
- return the updated job view plus structured execution details for debugging, including whether a one-off job was deleted after the run
- align jobs capability docs/search guidance with the new capability and remove the stale `job_get` hint
- tighten `manager-client.ts` typing so the shared run-now capability path typechecks against the existing durable object contract
- address the valid Bugbot review by reusing the shared schedule output mapper instead of duplicating the schedule-to-output conversion logic

## Testing
- `npm exec vitest -- run packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts`
- `npm run typecheck`
- watched GitHub Actions for the latest push until both `✅ Validate` and `🔎 Preview` completed successfully

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95692ac8-7213-4171-8bab-d64a926af8a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95692ac8-7213-4171-8bab-d64a926af8a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

