### PR TITLE
Add connector readiness diagnostics

### DIFF
--- a/packages/worker/src/mcp/capabilities/values/connector-get.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/values/connector-get.node.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	getValue: vi.fn(),
+	listUserSecretsForSearch: vi.fn(),
+}))
+
+vi.mock('#mcp/values/service.ts', () => ({
+	getValue: (...args: Array<unknown>) => mockModule.getValue(...args),
+}))
+
+vi.mock('#mcp/secrets/service.ts', () => ({
+	listUserSecretsForSearch: (...args: Array<unknown>) =>
+		mockModule.listUserSecretsForSearch(...args),
+}))
+
+const { connectorGetCapability } = await import('./connector-get.ts')
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+test('connector_get includes readiness showing missing authenticated prerequisites', async () => {
+	mockModule.getValue.mockImplementation(async (input: {
+		name: string
+	}) => {
+		if (input.name === '_connector:spotify') {
+			return {
+				name: '_connector:spotify',
+				scope: 'user',
+				value: JSON.stringify({
+					name: 'spotify',
+					tokenUrl: 'https://accounts.spotify.com/api/token',
+					apiBaseUrl: 'https://api.spotify.com/v1',
+					flow: 'pkce',
+					clientIdValueName: 'spotify-client-id',
+					clientSecretSecretName: null,
+					accessTokenSecretName: 'spotify-access-token',
+					refreshTokenSecretName: 'spotify-refresh-token',
+					requiredHosts: ['api.spotify.com'],
+				}),
+				description: 'Spotify connector',
+				appId: null,
+				createdAt: '2026-04-21T00:00:00.000Z',
+				updatedAt: '2026-04-21T00:00:00.000Z',
+				ttlMs: null,
+			}
+		}
+		if (input.name === 'spotify-client-id') {
+			return {
+				name: 'spotify-client-id',
+				scope: 'user',
+				value: 'client-id-123',
+				description: 'Spotify client id',
+				appId: null,
+				createdAt: '2026-04-21T00:00:00.000Z',
+				updatedAt: '2026-04-21T00:00:00.000Z',
+				ttlMs: null,
+			}
+		}
+		return null
+	})
+	mockModule.listUserSecretsForSearch.mockResolvedValue([
+		{
+			name: 'spotify-access-token',
+			scope: 'user',
+			description: 'Access token',
+			appId: null,
+			updatedAt: '2026-04-21T00:00:00.000Z',
+		},
+	])
+
+	const result = await connectorGetCapability.handler(
+		{ name: 'spotify' },
+		{
+			env: {} as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://kody.dev',
+				user: { userId: 'user-123' },
+			}),
+		},
+	)
+
+	expect(result.connector).toMatchObject({
+		name: 'spotify',
+		flow: 'pkce',
+	})
+	expect(result.readiness).toEqual({
+		status: 'missing_prerequisites',
+		authenticatedRequestsReady: false,
+		available: {
+			clientIdValue: true,
+			accessTokenSecret: true,
+			refreshTokenSecret: false,
+			clientSecretSecret: null,
+		},
+		missingPrerequisites: [
+			{
+				kind: 'secret',
+				requirement: 'refresh_token',
+				name: 'spotify-refresh-token',
+			},
+		],
+	})
+})
+
+test('connector_get returns null connector and readiness when config is missing', async () => {
+	mockModule.getValue.mockResolvedValue(null)
+
+	const result = await connectorGetCapability.handler(
+		{ name: 'spotify' },
+		{
+			env: {} as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://kody.dev',
+				user: { userId: 'user-123' },
+			}),
+		},
+	)
+
+	expect(result).toEqual({
+		connector: null,
+		readiness: null,
+	})
+	expect(mockModule.listUserSecretsForSearch).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/mcp/capabilities/values/connector-get.ts
+++ b/packages/worker/src/mcp/capabilities/values/connector-get.ts
@@ -2,14 +2,20 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { listUserSecretsForSearch } from '#mcp/secrets/service.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { getValue } from '#mcp/values/service.ts'
 import {
 	buildConnectorValueName,
 	connectorConfigSchema,
+	type ConnectorConfig,
 	parseConnectorConfig,
 	parseConnectorJson,
 } from './connector-shared.ts'
+import {
+	connectorReadinessSchema,
+	getConnectorReadiness,
+} from './connector-readiness.ts'
 
 const inputSchema = z.object({
 	name: z.string().min(1).describe('Connector name to read.'),
@@ -17,6 +23,7 @@ const inputSchema = z.object({
 
 const outputSchema = z.object({
 	connector: connectorConfigSchema.nullable(),
+	readiness: connectorReadinessSchema.nullable(),
 })
 
 export const connectorGetCapability = defineDomainCapability(
@@ -32,27 +39,68 @@ export const connectorGetCapability = defineDomainCapability(
 		outputSchema,
 		async handler(args, ctx: CapabilityContext) {
 			const user = requireMcpUser(ctx.callerContext)
+			const storageContext = {
+				sessionId: ctx.callerContext.storageContext?.sessionId ?? null,
+				appId: ctx.callerContext.storageContext?.appId ?? null,
+				storageId: ctx.callerContext.storageContext?.storageId ?? null,
+			}
 			const value = await getValue({
 				env: ctx.env,
 				userId: user.userId,
 				name: buildConnectorValueName(args.name),
 				scope: 'user',
-				storageContext: {
-					sessionId: ctx.callerContext.storageContext?.sessionId ?? null,
-					appId: ctx.callerContext.storageContext?.appId ?? null,
-					storageId: ctx.callerContext.storageContext?.storageId ?? null,
-				},
+				storageContext,
 			})
 			if (!value) {
-				return { connector: null }
+				return { connector: null, readiness: null }
 			}
 			const parsed = parseConnectorConfig(
 				parseConnectorJson(value.value),
 				args.name,
 			)
+			if (!parsed) {
+				return { connector: null, readiness: null }
+			}
+			const readiness = await loadConnectorReadiness({
+				env: ctx.env,
+				userId: user.userId,
+				connector: parsed,
+				storageContext,
+			})
 			return {
 				connector: parsed,
+				readiness,
 			}
 		},
 	},
 )
+
+async function loadConnectorReadiness(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	connector: ConnectorConfig
+	storageContext: {
+		sessionId: string | null
+		appId: string | null
+		storageId: string | null
+	}
+}) {
+	const [clientIdValue, userSecrets] = await Promise.all([
+		getValue({
+			env: input.env,
+			userId: input.userId,
+			name: input.connector.clientIdValueName,
+			storageContext: input.storageContext,
+		}),
+		listUserSecretsForSearch({
+			env: input.env,
+			userId: input.userId,
+		}),
+	])
+
+	return getConnectorReadiness({
+		connector: input.connector,
+		values: clientIdValue ? [clientIdValue] : [],
+		userSecrets,
+	})
+}

--- a/packages/worker/src/mcp/capabilities/values/connector-readiness.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/values/connector-readiness.node.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from 'vitest'
+import {
+	formatConnectorReadinessSummary,
+	getConnectorReadiness,
+} from './connector-readiness.ts'
+
+const spotifyConnector = {
+	name: 'spotify',
+	tokenUrl: 'https://accounts.spotify.com/api/token',
+	apiBaseUrl: 'https://api.spotify.com/v1',
+	flow: 'pkce' as const,
+	clientIdValueName: 'spotify-client-id',
+	clientSecretSecretName: null,
+	accessTokenSecretName: 'spotify-access-token',
+	refreshTokenSecretName: 'spotify-refresh-token',
+	requiredHosts: ['api.spotify.com'],
+}
+
+test('getConnectorReadiness reports ready when client id and refresh token metadata exist', () => {
+	const readiness = getConnectorReadiness({
+		connector: spotifyConnector,
+		values: [{ name: 'spotify-client-id', value: 'client-id-123' }],
+		userSecrets: [
+			{ name: 'spotify-refresh-token' },
+			{ name: 'spotify-access-token' },
+		],
+	})
+
+	expect(readiness).toEqual({
+		status: 'ready',
+		authenticatedRequestsReady: true,
+		available: {
+			clientIdValue: true,
+			accessTokenSecret: true,
+			refreshTokenSecret: true,
+			clientSecretSecret: null,
+		},
+		missingPrerequisites: [],
+	})
+	expect(formatConnectorReadinessSummary(readiness)).toBe(
+		'Ready for authenticated requests via connector execute helpers.',
+	)
+})
+
+test('getConnectorReadiness reports missing connector prerequisites without exposing secret values', () => {
+	const readiness = getConnectorReadiness({
+		connector: {
+			...spotifyConnector,
+			flow: 'confidential',
+			clientSecretSecretName: 'spotify-client-secret',
+		},
+		values: [],
+		userSecrets: [{ name: 'spotify-access-token' }],
+	})
+
+	expect(readiness.status).toBe('missing_prerequisites')
+	expect(readiness.authenticatedRequestsReady).toBe(false)
+	expect(readiness.available).toEqual({
+		clientIdValue: false,
+		accessTokenSecret: true,
+		refreshTokenSecret: false,
+		clientSecretSecret: false,
+	})
+	expect(readiness.missingPrerequisites).toEqual([
+		{
+			kind: 'value',
+			requirement: 'client_id',
+			name: 'spotify-client-id',
+		},
+		{
+			kind: 'secret',
+			requirement: 'refresh_token',
+			name: 'spotify-refresh-token',
+		},
+		{
+			kind: 'secret',
+			requirement: 'client_secret',
+			name: 'spotify-client-secret',
+		},
+	])
+	expect(formatConnectorReadinessSummary(readiness)).toContain(
+		'Missing prerequisites for authenticated requests:',
+	)
+})

--- a/packages/worker/src/mcp/capabilities/values/connector-readiness.ts
+++ b/packages/worker/src/mcp/capabilities/values/connector-readiness.ts
@@ -1,0 +1,159 @@
+import { z } from 'zod'
+import { type SecretSearchRow } from '#mcp/secrets/types.ts'
+import { type ValueMetadata } from '#mcp/values/types.ts'
+import { type ConnectorConfig } from './connector-shared.ts'
+
+const connectorReadinessStatusValues = [
+	'ready',
+	'missing_prerequisites',
+] as const
+
+const connectorReadinessRequirementValues = [
+	'client_id',
+	'refresh_token',
+	'client_secret',
+] as const
+
+const connectorReadinessMissingKindValues = [
+	'value',
+	'secret',
+	'config',
+] as const
+
+export const connectorReadinessMissingPrerequisiteSchema = z.object({
+	kind: z.enum(connectorReadinessMissingKindValues),
+	requirement: z.enum(connectorReadinessRequirementValues),
+	name: z.string().nullable(),
+})
+
+export const connectorReadinessSchema = z.object({
+	status: z.enum(connectorReadinessStatusValues),
+	authenticatedRequestsReady: z.boolean(),
+	available: z.object({
+		clientIdValue: z.boolean(),
+		accessTokenSecret: z.boolean(),
+		refreshTokenSecret: z.boolean().nullable(),
+		clientSecretSecret: z.boolean().nullable(),
+	}),
+	missingPrerequisites: z.array(connectorReadinessMissingPrerequisiteSchema),
+})
+
+export type ConnectorReadiness = z.infer<typeof connectorReadinessSchema>
+export type ConnectorReadinessMissingPrerequisite = z.infer<
+	typeof connectorReadinessMissingPrerequisiteSchema
+>
+
+export function getConnectorReadiness(input: {
+	connector: ConnectorConfig
+	values: Array<Pick<ValueMetadata, 'name' | 'value'>>
+	userSecrets: Array<Pick<SecretSearchRow, 'name'>>
+}): ConnectorReadiness {
+	const userSecretNames = new Set(
+		input.userSecrets.map((secret) => secret.name.trim()).filter(Boolean),
+	)
+	const clientIdValuePresent = input.values.some(
+		(value) =>
+			value.name === input.connector.clientIdValueName &&
+			value.value.trim().length > 0,
+	)
+	const accessTokenSecretPresent = userSecretNames.has(
+		input.connector.accessTokenSecretName,
+	)
+	const refreshTokenSecretName =
+		input.connector.refreshTokenSecretName?.trim() ?? ''
+	const refreshTokenSecretPresent =
+		refreshTokenSecretName.length > 0
+			? userSecretNames.has(refreshTokenSecretName)
+			: null
+	const clientSecretSecretName =
+		input.connector.clientSecretSecretName?.trim() ?? ''
+	const clientSecretSecretPresent =
+		input.connector.flow === 'confidential'
+			? clientSecretSecretName.length > 0
+				? userSecretNames.has(clientSecretSecretName)
+				: null
+			: null
+	const missingPrerequisites: Array<ConnectorReadinessMissingPrerequisite> = []
+
+	if (!clientIdValuePresent) {
+		missingPrerequisites.push({
+			kind: 'value',
+			requirement: 'client_id',
+			name: input.connector.clientIdValueName,
+		})
+	}
+
+	if (!refreshTokenSecretName) {
+		missingPrerequisites.push({
+			kind: 'config',
+			requirement: 'refresh_token',
+			name: null,
+		})
+	} else if (!refreshTokenSecretPresent) {
+		missingPrerequisites.push({
+			kind: 'secret',
+			requirement: 'refresh_token',
+			name: refreshTokenSecretName,
+		})
+	}
+
+	if (input.connector.flow === 'confidential') {
+		if (!clientSecretSecretName) {
+			missingPrerequisites.push({
+				kind: 'config',
+				requirement: 'client_secret',
+				name: null,
+			})
+		} else if (!clientSecretSecretPresent) {
+			missingPrerequisites.push({
+				kind: 'secret',
+				requirement: 'client_secret',
+				name: clientSecretSecretName,
+			})
+		}
+	}
+
+	const authenticatedRequestsReady = missingPrerequisites.length === 0
+
+	return {
+		status: authenticatedRequestsReady ? 'ready' : 'missing_prerequisites',
+		authenticatedRequestsReady,
+		available: {
+			clientIdValue: clientIdValuePresent,
+			accessTokenSecret: accessTokenSecretPresent,
+			refreshTokenSecret: refreshTokenSecretPresent,
+			clientSecretSecret: clientSecretSecretPresent,
+		},
+		missingPrerequisites,
+	}
+}
+
+export function formatConnectorMissingPrerequisite(
+	prerequisite: ConnectorReadinessMissingPrerequisite,
+) {
+	if (prerequisite.requirement === 'client_id') {
+		return `client ID value \`${prerequisite.name ?? 'unknown'}\` is missing`
+	}
+	if (prerequisite.requirement === 'refresh_token') {
+		if (prerequisite.kind === 'config') {
+			return 'connector config does not define a refresh token secret name'
+		}
+		return `user refresh token secret \`${prerequisite.name ?? 'unknown'}\` is missing`
+	}
+	if (prerequisite.kind === 'config') {
+		return 'connector config does not define a client secret secret name'
+	}
+	return `user client secret \`${prerequisite.name ?? 'unknown'}\` is missing`
+}
+
+export function formatConnectorReadinessSummary(
+	readiness: ConnectorReadiness,
+) {
+	if (readiness.authenticatedRequestsReady) {
+		return 'Ready for authenticated requests via connector execute helpers.'
+	}
+
+	return `Missing prerequisites for authenticated requests: ${readiness.missingPrerequisites
+		.map(formatConnectorMissingPrerequisite)
+		.join('; ')}.`
+}

--- a/packages/worker/src/mcp/execute-modules/codemode-utils.node.test.ts
+++ b/packages/worker/src/mcp/execute-modules/codemode-utils.node.test.ts
@@ -45,7 +45,20 @@ function createCodemode(payload: Record<string, unknown>) {
 		async connector_get(args: CapabilityArgs) {
 			const name = args.name
 			expect(name).toBe('spotify')
-			return { connector: spotifyConnector }
+			return {
+				connector: spotifyConnector,
+				readiness: {
+					status: 'ready' as const,
+					authenticatedRequestsReady: true,
+					available: {
+						clientIdValue: true,
+						accessTokenSecret: false,
+						refreshTokenSecret: true,
+						clientSecretSecret: null,
+					},
+					missingPrerequisites: [],
+				},
+			}
 		},
 		async value_get(args: CapabilityArgs) {
 			const name = args.name
@@ -244,6 +257,49 @@ test('createExecuteHelperPrelude persists rotated refresh token and access token
 	expect(fetchCalls[2]?.headers.get('authorization')).toBe(
 		'Bearer new-access-token',
 	)
+})
+
+test('refreshAccessToken fails early when connector readiness reports missing prerequisites', async () => {
+	const { codemode, fetchStub, fetchCalls } = createCodemode({
+		access_token: 'new-access-token',
+	})
+	const codemodeWithMissingRefreshToken = {
+		...codemode,
+		async connector_get(args: CapabilityArgs) {
+			const result = (await codemode.connector_get(args)) as {
+				connector: typeof spotifyConnector
+			}
+			return {
+				...result,
+				readiness: {
+					status: 'missing_prerequisites' as const,
+					authenticatedRequestsReady: false,
+					available: {
+						clientIdValue: true,
+						accessTokenSecret: false,
+						refreshTokenSecret: false,
+						clientSecretSecret: null,
+					},
+					missingPrerequisites: [
+						{
+							kind: 'secret' as const,
+							requirement: 'refresh_token' as const,
+							name: 'spotifyRefreshToken',
+						},
+					],
+				},
+			}
+		},
+	} satisfies CodemodeNamespace
+
+	await expect(
+		withPatchedFetch(fetchStub, () =>
+			refreshAccessToken(codemodeWithMissingRefreshToken, 'spotify'),
+		),
+	).rejects.toThrow(
+		'Connector "spotify" is not ready for authenticated requests: refresh token secret "spotifyRefreshToken" is missing.',
+	)
+	expect(fetchCalls).toHaveLength(0)
 })
 
 test('getExecuteHelperCapabilityNames includes secret_set for refresh persistence', () => {

--- a/packages/worker/src/mcp/execute-modules/codemode-utils.ts
+++ b/packages/worker/src/mcp/execute-modules/codemode-utils.ts
@@ -21,6 +21,21 @@ type ConnectorConfig = {
 
 type ConnectorGetResult = {
 	connector: ConnectorConfig | null
+	readiness?: {
+		status: 'ready' | 'missing_prerequisites'
+		authenticatedRequestsReady: boolean
+		available: {
+			clientIdValue: boolean
+			accessTokenSecret: boolean
+			refreshTokenSecret: boolean | null
+			clientSecretSecret: boolean | null
+		}
+		missingPrerequisites: Array<{
+			kind: 'value' | 'secret' | 'config'
+			requirement: 'client_id' | 'refresh_token' | 'client_secret'
+			name: string | null
+		}>
+	} | null
 }
 
 type ValueGetResult = {
@@ -49,8 +64,13 @@ export async function refreshAccessToken(
 	codemode: CodemodeNamespace,
 	providerName: string,
 ): Promise<string> {
-	const connector = await readConnectorConfig(codemode, providerName)
-	return refreshAccessTokenWithConnector(codemode, providerName, connector)
+	const connectorResult = await readConnectorConfig(codemode, providerName)
+	return refreshAccessTokenWithConnector(
+		codemode,
+		providerName,
+		connectorResult.connector,
+		connectorResult.readiness,
+	)
 }
 
 export async function createAuthenticatedFetch(
@@ -59,15 +79,19 @@ export async function createAuthenticatedFetch(
 ): Promise<
 	(input: ExecuteRequestInput, init?: RequestInit) => Promise<Response>
 > {
-	const connector = await readConnectorConfig(codemode, providerName)
+	const connectorResult = await readConnectorConfig(codemode, providerName)
 	const accessToken = await refreshAccessTokenWithConnector(
 		codemode,
 		providerName,
-		connector,
+		connectorResult.connector,
+		connectorResult.readiness,
 	)
 
 	return async (input: ExecuteRequestInput, init?: RequestInit) => {
-		const request = new Request(resolveRequestUrl(input, connector), init)
+		const request = new Request(
+			resolveRequestUrl(input, connectorResult.connector),
+			init,
+		)
 		const headers = new Headers(request.headers)
 		headers.set('Authorization', `Bearer ${accessToken}`)
 
@@ -94,7 +118,10 @@ async function readConnectorConfig(
 	if (!connector) {
 		throw new Error(`Connector "${providerName}" was not found.`)
 	}
-	return connector
+	return {
+		connector,
+		readiness: result?.readiness ?? null,
+	}
 }
 
 async function readClientId(
@@ -144,7 +171,9 @@ async function refreshAccessTokenWithConnector(
 	codemode: CodemodeNamespace,
 	providerName: string,
 	connector: ConnectorConfig,
+	readiness: ConnectorGetResult['readiness'],
 ) {
+	assertConnectorReadyForAuthenticatedRequests(providerName, readiness)
 	const clientId = await readClientId(codemode, connector)
 	const refreshTokenSecretName = connector.refreshTokenSecretName?.trim() ?? ''
 	if (!refreshTokenSecretName) {
@@ -190,7 +219,7 @@ async function refreshAccessTokenWithConnector(
 
 	if (!response.ok) {
 		throw new Error(
-			`Token refresh failed for connector "${providerName}" with HTTP ${response.status}.`,
+			buildTokenRefreshFailureMessage(providerName, response.status, readiness),
 		)
 	}
 	if (!payload || typeof payload.access_token !== 'string') {
@@ -220,6 +249,53 @@ async function refreshAccessTokenWithConnector(
 	)
 
 	return payload.access_token
+}
+
+function assertConnectorReadyForAuthenticatedRequests(
+	providerName: string,
+	readiness: ConnectorGetResult['readiness'],
+) {
+	if (!readiness || readiness.authenticatedRequestsReady) {
+		return
+	}
+	const missingSummary = readiness.missingPrerequisites
+		.map(formatMissingPrerequisite)
+		.join('; ')
+	throw new Error(
+		`Connector "${providerName}" is not ready for authenticated requests: ${missingSummary}.`,
+	)
+}
+
+function formatMissingPrerequisite(
+	prerequisite: NonNullable<ConnectorGetResult['readiness']>['missingPrerequisites'][number],
+) {
+	if (prerequisite.requirement === 'client_id') {
+		return `client ID value "${prerequisite.name ?? 'unknown'}" is missing`
+	}
+	if (prerequisite.requirement === 'refresh_token') {
+		if (prerequisite.kind === 'config') {
+			return 'connector config does not define a refresh token secret name'
+		}
+		return `refresh token secret "${prerequisite.name ?? 'unknown'}" is missing`
+	}
+	if (prerequisite.kind === 'config') {
+		return 'connector config does not define a client secret secret name'
+	}
+	return `client secret "${prerequisite.name ?? 'unknown'}" is missing`
+}
+
+function buildTokenRefreshFailureMessage(
+	providerName: string,
+	status: number,
+	readiness: ConnectorGetResult['readiness'],
+) {
+	const details =
+		readiness && readiness.missingPrerequisites.length > 0
+			? ` Readiness check also found missing prerequisites: ${readiness.missingPrerequisites
+					.map(formatMissingPrerequisite)
+					.join('; ')}.`
+			: ''
+	return `Token refresh failed for connector "${providerName}" with HTTP ${status}.${details}`
 }
 
 function buildSecretPlaceholder(
@@ -308,7 +384,52 @@ const __kodyReadConnectorConfig = async (providerName) => {
   if (!connector) {
     throw new Error(\`Connector "\${providerName}" was not found.\`);
   }
-  return connector;
+  return {
+    connector,
+    readiness: result?.readiness ?? null,
+  };
+};
+const __kodyFormatMissingPrerequisite = (prerequisite) => {
+  if (prerequisite.requirement === 'client_id') {
+    return \`client ID value "\${prerequisite.name ?? 'unknown'}" is missing\`;
+  }
+  if (prerequisite.requirement === 'refresh_token') {
+    if (prerequisite.kind === 'config') {
+      return 'connector config does not define a refresh token secret name';
+    }
+    return \`refresh token secret "\${prerequisite.name ?? 'unknown'}" is missing\`;
+  }
+  if (prerequisite.kind === 'config') {
+    return 'connector config does not define a client secret secret name';
+  }
+  return \`client secret "\${prerequisite.name ?? 'unknown'}" is missing\`;
+};
+const __kodyAssertConnectorReadyForAuthenticatedRequests = (
+  providerName,
+  readiness,
+) => {
+  if (!readiness || readiness.authenticatedRequestsReady) {
+    return;
+  }
+  const missingSummary = readiness.missingPrerequisites
+    .map(__kodyFormatMissingPrerequisite)
+    .join('; ');
+  throw new Error(
+    \`Connector "\${providerName}" is not ready for authenticated requests: \${missingSummary}.\`,
+  );
+};
+const __kodyBuildTokenRefreshFailureMessage = (
+  providerName,
+  status,
+  readiness,
+) => {
+  const details =
+    readiness && readiness.missingPrerequisites.length > 0
+      ? \` Readiness check also found missing prerequisites: \${readiness.missingPrerequisites
+          .map(__kodyFormatMissingPrerequisite)
+          .join('; ')}.\`
+      : '';
+  return \`Token refresh failed for connector "\${providerName}" with HTTP \${status}.\${details}\`;
 };
 const __kodyReadClientId = async (connector) => {
   const valueGet = codemode.value_get;
@@ -391,7 +512,12 @@ const __kodyResolveRequestUrl = (input, connector) => {
   return input;
 };
 const __kodyRefreshAccessToken = async (providerName) => {
-  const connector = await __kodyReadConnectorConfig(providerName);
+  const connectorResult = await __kodyReadConnectorConfig(providerName);
+  __kodyAssertConnectorReadyForAuthenticatedRequests(
+    providerName,
+    connectorResult.readiness,
+  );
+  const connector = connectorResult.connector;
   const clientId = await __kodyReadClientId(connector);
   const refreshTokenSecretName = connector.refreshTokenSecretName?.trim() ?? '';
   if (!refreshTokenSecretName) {
@@ -429,7 +555,11 @@ const __kodyRefreshAccessToken = async (providerName) => {
   const payload = await response.json().catch(() => null);
   if (!response.ok) {
     throw new Error(
-      \`Token refresh failed for connector "\${providerName}" with HTTP \${response.status}.\`,
+      __kodyBuildTokenRefreshFailureMessage(
+        providerName,
+        response.status,
+        connectorResult.readiness,
+      ),
     );
   }
   if (!payload || typeof payload.access_token !== 'string') {
@@ -454,7 +584,8 @@ const __kodyRefreshAccessToken = async (providerName) => {
   return payload.access_token;
 };
 const __kodyCreateAuthenticatedFetch = async (providerName) => {
-  const connector = await __kodyReadConnectorConfig(providerName);
+  const connectorResult = await __kodyReadConnectorConfig(providerName);
+  const connector = connectorResult.connector;
   const accessToken = await __kodyRefreshAccessToken(providerName);
   return async (input, init) => {
     const request = new Request(__kodyResolveRequestUrl(input, connector), init);

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -166,13 +166,46 @@ test('search markdown and entity detail formatting preserve structured behavior'
 			refreshTokenSecretName: 'github_refresh_token',
 			requiredHosts: ['api.github.com'],
 		},
+		readiness: {
+			status: 'missing_prerequisites',
+			authenticatedRequestsReady: false,
+			available: {
+				clientIdValue: true,
+				accessTokenSecret: false,
+				refreshTokenSecret: true,
+				clientSecretSecret: false,
+			},
+			missingPrerequisites: [
+				{
+					kind: 'secret',
+					requirement: 'client_secret',
+					name: 'github_client_secret',
+				},
+			],
+		},
 	})
 	expect(connectorDetail.structured).toMatchObject({
 		type: 'connector',
 		flow: 'confidential',
 		apiBaseUrl: 'https://api.github.com',
 		requiredHosts: ['api.github.com'],
+		readiness: {
+			authenticatedRequestsReady: false,
+			missingPrerequisites: [
+				{
+					kind: 'secret',
+					requirement: 'client_secret',
+					name: 'github_client_secret',
+				},
+			],
+		},
 	})
+	expect(connectorDetail.markdown).toContain(
+		'Operational readiness: Missing prerequisites for authenticated requests:',
+	)
+	expect(connectorDetail.markdown).toContain(
+		'user client secret `github_client_secret` is missing',
+	)
 })
 
 test('entity detail formatting includes package app and export metadata', () => {

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -1,5 +1,10 @@
 import { compressSchemaForLlm } from '#mcp/capabilities/schema-compression.ts'
 import { type CapabilitySpec } from '#mcp/capabilities/types.ts'
+import {
+	formatConnectorMissingPrerequisite,
+	formatConnectorReadinessSummary,
+	type ConnectorReadiness,
+} from '#mcp/capabilities/values/connector-readiness.ts'
 import { type ConnectorConfig } from '#mcp/capabilities/values/connector-shared.ts'
 import { type SecretSearchRow } from '#mcp/secrets/types.ts'
 import { type ValueMetadata } from '#mcp/values/types.ts'
@@ -180,6 +185,7 @@ export type SearchEntityDetailStructured =
 			accessTokenSecretName: string
 			refreshTokenSecretName: string | null
 			requiredHosts: Array<string>
+			readiness: ConnectorReadiness
 	  }
 
 export type SearchEntityDetail =
@@ -221,6 +227,7 @@ export type SearchEntityDetail =
 			description: string
 			row: ValueMetadata
 			config: ConnectorConfig
+			readiness: ConnectorReadiness
 	  }
 
 export type SearchMatch =
@@ -698,6 +705,7 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 
 	if (detail.type === 'connector') {
 		const requiredHosts = detail.config.requiredHosts ?? []
+		const readinessSummary = formatConnectorReadinessSummary(detail.readiness)
 		const lines = [
 			`# Connector — \`${detail.config.name}\``,
 			'',
@@ -705,10 +713,12 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 			'',
 			'## Summary',
 			'',
+			`- Authenticated requests ready: ${detail.readiness.authenticatedRequestsReady ? 'yes' : 'no'}`,
 			`- Flow: \`${detail.config.flow}\``,
 			`- Token URL: \`${detail.config.tokenUrl}\``,
 			`- API base URL: ${detail.config.apiBaseUrl ? `\`${detail.config.apiBaseUrl}\`` : 'none'}`,
 			`- Required hosts: ${requiredHosts.length > 0 ? requiredHosts.map((host) => `\`${host}\``).join(', ') : 'none'}`,
+			`- Operational readiness: ${readinessSummary}`,
 			'',
 			'## Read this connector',
 			'',
@@ -721,7 +731,20 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 			`- Client secret secret name: ${detail.config.clientSecretSecretName ? `\`${detail.config.clientSecretSecretName}\`` : 'none'}`,
 			`- Access token secret name: \`${detail.config.accessTokenSecretName}\``,
 			`- Refresh token secret name: ${detail.config.refreshTokenSecretName ? `\`${detail.config.refreshTokenSecretName}\`` : 'none'}`,
+			'',
+			'## Operational readiness details',
+			'',
+			`- Client ID value available: ${formatBoolean(detail.readiness.available.clientIdValue)}`,
+			`- Access token secret already stored: ${formatBoolean(detail.readiness.available.accessTokenSecret)}`,
+			`- Refresh token secret available: ${formatNullableBoolean(detail.readiness.available.refreshTokenSecret)}`,
+			`- Client secret available: ${formatNullableBoolean(detail.readiness.available.clientSecretSecret)}`,
 		]
+		if (detail.readiness.missingPrerequisites.length > 0) {
+			lines.push('', '### Missing prerequisites', '')
+			for (const prerequisite of detail.readiness.missingPrerequisites) {
+				lines.push(`- ${formatConnectorMissingPrerequisite(prerequisite)}`)
+			}
+		}
 		return {
 			markdown: lines.join('\n'),
 			structured: {
@@ -739,6 +762,7 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 				accessTokenSecretName: detail.config.accessTokenSecretName,
 				refreshTokenSecretName: detail.config.refreshTokenSecretName ?? null,
 				requiredHosts,
+				readiness: detail.readiness,
 			} satisfies SearchEntityDetailStructured,
 		}
 	}
@@ -783,4 +807,13 @@ function formatList(items: Array<string>) {
 function formatTtlMs(ttlMs: number | null) {
 	if (ttlMs == null) return 'none'
 	return `\`${ttlMs.toLocaleString()}\``
+}
+
+function formatBoolean(value: boolean) {
+	return value ? 'yes' : 'no'
+}
+
+function formatNullableBoolean(value: boolean | null) {
+	if (value == null) return 'not required'
+	return formatBoolean(value)
 }

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/cloudflare'
 import { type ToolAnnotations } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
+import { getConnectorReadiness } from '#mcp/capabilities/values/connector-readiness.ts'
 import {
 	parseConnectorConfig,
 	parseConnectorJson,
@@ -624,6 +625,11 @@ async function resolveEntityDetail(input: {
 		if (!connector) {
 			throw new Error('Saved connector not found for this user.')
 		}
+		const readiness = getConnectorReadiness({
+			connector: connector.config,
+			values: input.searchRows.userValueRows,
+			userSecrets: input.searchRows.userSecretRows,
+		})
 		return {
 			type: 'connector' as const,
 			id: connector.config.name,
@@ -633,6 +639,7 @@ async function resolveEntityDetail(input: {
 				`Saved OAuth connector configuration (${connector.config.flow} flow).`,
 			row: connector.row,
 			config: connector.config,
+			readiness,
 		}
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a repo-local connector readiness evaluator that reports whether authenticated connector flows have the metadata they need without exposing secret values
- surface connector readiness on `connector_get` and connector search entity details so callers can see missing prerequisites directly
- make execute helper auth failures more actionable by failing early on missing prerequisites and adding readiness context to token refresh failures
- add focused tests for readiness computation, `connector_get`, search formatting/entity detail output, and execute helper preflight behavior

## Testing
- `npx vitest run --project node-unit packages/worker/src/mcp/capabilities/values/connector-readiness.node.test.ts packages/worker/src/mcp/capabilities/values/connector-get.node.test.ts packages/worker/src/mcp/tools/search-format.node.test.ts packages/worker/src/mcp/tools/search.node.test.ts packages/worker/src/mcp/execute-modules/codemode-utils.node.test.ts`
- `npm run typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e01c5ff-1d83-4da9-ad70-d8529c586e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e01c5ff-1d83-4da9-ad70-d8529c586e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

