### PR TITLE
Stabilize repo session lookups during scheduled jobs

### DIFF
--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -448,6 +448,74 @@ test('readFile retries the D1 lookup when the persisted cache is missing and the
 	expect(mockModule.getEntitySourceById).toHaveBeenCalledTimes(2)
 })
 
+test('getSessionState prefers fresh D1 reads over cached session and source rows', async () => {
+	// Guards against a regression where the cache, populated by openSession,
+	// would shadow fresh D1 reads and hide updates such as rebaseSession
+	// writing a new base_commit or an external publish updating
+	// source.published_commit. That would cause publishSession's base_moved
+	// check to compare stale values and silently pass when the source has
+	// actually moved.
+	setCommonSessionFixtures()
+	const initialSource = {
+		id: 'source-1',
+		user_id: 'user-1',
+		repo_id: 'source-repo',
+		published_commit: 'commit-initial',
+		manifest_path: 'kody.json',
+		source_root: '/',
+	}
+	const initialSession = {
+		id: 'session-1',
+		user_id: 'user-1',
+		source_id: 'source-1',
+		session_repo_namespace: 'default',
+		session_repo_name: 'session-repo',
+		base_commit: 'commit-initial',
+		last_checkpoint_commit: 'commit-initial',
+	}
+	const movedSession = {
+		...initialSession,
+		base_commit: 'commit-rebased',
+		last_checkpoint_commit: 'commit-rebased',
+	}
+	const movedSource = {
+		...initialSource,
+		published_commit: 'commit-moved',
+	}
+	mockModule.getRepoSessionById
+		.mockResolvedValueOnce(initialSession)
+		.mockResolvedValueOnce(movedSession)
+	mockModule.getEntitySourceById
+		.mockResolvedValueOnce(initialSource)
+		.mockResolvedValueOnce(movedSource)
+	mockModule.workspaceReadFile.mockResolvedValue('hello world')
+
+	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
+	const firstRead = await repoSession.readFile({
+		sessionId: 'session-1',
+		userId: 'user-1',
+		path: 'greeting.txt',
+	})
+	expect(firstRead).toEqual({
+		path: 'greeting.txt',
+		content: 'hello world',
+	})
+
+	const secondRead = await repoSession.readFile({
+		sessionId: 'session-1',
+		userId: 'user-1',
+		path: 'greeting.txt',
+	})
+	expect(secondRead).toEqual({
+		path: 'greeting.txt',
+		content: 'hello world',
+	})
+	// The second readFile hits D1 again rather than short-circuiting on the
+	// in-memory cache, so the updated session and source rows are visible.
+	expect(mockModule.getRepoSessionById).toHaveBeenCalledTimes(2)
+	expect(mockModule.getEntitySourceById).toHaveBeenCalledTimes(2)
+})
+
 test('readFile falls back to cached session state when the session row is not yet readable from D1', async () => {
 	const source = {
 		id: 'source-1',

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -168,7 +168,7 @@ vi.mock('./manifest.ts', () => ({
 		mockModule.parseRepoManifest(...args),
 }))
 
-const { RepoSession } = await import('./repo-session-do.ts')
+const { RepoSession, readWithRetry } = await import('./repo-session-do.ts')
 
 function createDurableObjectState() {
 	const storageState = new Map<string, unknown>()
@@ -446,6 +446,32 @@ test('readFile retries the D1 lookup when the persisted cache is missing and the
 	})
 	expect(mockModule.getRepoSessionById).toHaveBeenCalledTimes(3)
 	expect(mockModule.getEntitySourceById).toHaveBeenCalledTimes(2)
+})
+
+test('readWithRetry distinguishes null from other falsy values', async () => {
+	// readWithRetry treats only null as "missing". Falsy-but-present values
+	// like 0, '', or false must be returned as-is instead of triggering
+	// extra retries and a final null.
+	for (const value of [0, '', false]) {
+		const read = vi.fn(async () => value as unknown as number | string | boolean)
+		const result = await readWithRetry(read, [])
+		expect(result).toBe(value)
+		expect(read).toHaveBeenCalledTimes(1)
+	}
+
+	const nullRead = vi.fn(async () => null)
+	const nullResult = await readWithRetry(nullRead, [0, 0])
+	expect(nullResult).toBeNull()
+	expect(nullRead).toHaveBeenCalledTimes(3)
+
+	let attempts = 0
+	const eventualRead = vi.fn(async () => {
+		attempts += 1
+		return attempts < 3 ? null : ('ok' as const)
+	})
+	const eventualResult = await readWithRetry(eventualRead, [0, 0, 0])
+	expect(eventualResult).toBe('ok')
+	expect(eventualRead).toHaveBeenCalledTimes(3)
 })
 
 test('getSessionState prefers fresh D1 reads over cached session and source rows', async () => {

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -377,6 +377,77 @@ test('openSession strips unsupported characters from derived session repo names'
 	)
 })
 
+test('readFile retries the D1 lookup when the persisted cache is missing and the row is not yet readable', async () => {
+	// This test covers the alarm-driven scheduled-job failure mode where a fresh
+	// DO instance handles a follow-up RPC call before the in-memory cache from
+	// openSession is available, and D1 read replicas have not yet caught up to
+	// the freshly inserted repo session row.
+	const sessionRow = {
+		id: 'job-runtime-session-replica-lag',
+		user_id: 'user-1',
+		source_id: 'source-1',
+		session_repo_id: 'session-repo-1',
+		session_repo_name: 'session-repo-name',
+		session_repo_namespace: 'default',
+		base_commit: 'commit-base',
+		source_root: '/',
+		conversation_id: null,
+		status: 'active' as const,
+		expires_at: null,
+		last_checkpoint_at: null,
+		last_checkpoint_commit: null,
+		last_check_run_id: null,
+		last_check_tree_hash: null,
+		created_at: '2026-04-16T00:00:00.000Z',
+		updated_at: '2026-04-16T00:00:00.000Z',
+	}
+	const source = {
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'job' as const,
+		entity_id: 'job-1',
+		repo_id: 'job-job-1',
+		published_commit: 'commit-base',
+		indexed_commit: null,
+		manifest_path: 'kody.json',
+		source_root: '/',
+		created_at: '2026-04-16T00:00:00.000Z',
+		updated_at: '2026-04-16T00:00:00.000Z',
+	}
+	mockModule.getRepoSessionById
+		.mockResolvedValueOnce(null)
+		.mockResolvedValueOnce(null)
+		.mockResolvedValueOnce(sessionRow)
+	mockModule.getEntitySourceById
+		.mockResolvedValueOnce(null)
+		.mockResolvedValueOnce(source)
+	mockModule.resolveSessionRepo.mockResolvedValue({
+		info: vi.fn(async () => ({
+			remote:
+				'https://acct.artifacts.cloudflare.net/git/default/session-repo-name.git',
+		})),
+		createToken: vi.fn(async () => ({
+			plaintext: 'art_session_secret?expires=1760000200',
+		})),
+	})
+	mockModule.workspaceExists.mockResolvedValue(false)
+	mockModule.workspaceReadFile.mockResolvedValue('{"version":1,"kind":"job"}')
+
+	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
+	const file = await repoSession.readFile({
+		sessionId: 'job-runtime-session-replica-lag',
+		userId: 'user-1',
+		path: 'kody.json',
+	})
+
+	expect(file).toEqual({
+		path: 'kody.json',
+		content: '{"version":1,"kind":"job"}',
+	})
+	expect(mockModule.getRepoSessionById).toHaveBeenCalledTimes(3)
+	expect(mockModule.getEntitySourceById).toHaveBeenCalledTimes(2)
+})
+
 test('readFile falls back to cached session state when the session row is not yet readable from D1', async () => {
 	const source = {
 		id: 'source-1',

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -85,15 +85,16 @@ function getCachedSessionStateStorageKey(sessionId: string) {
 // resorting to global throttling.
 const repoLookupRetryDelaysMs = [50, 100, 200, 400] as const
 
-async function readWithRetry<T>(
+export async function readWithRetry<T>(
 	read: () => Promise<T | null>,
+	delaysMs: ReadonlyArray<number> = repoLookupRetryDelaysMs,
 ): Promise<T | null> {
 	let result = await read()
-	if (result) return result
-	for (const delayMs of repoLookupRetryDelaysMs) {
+	if (result != null) return result
+	for (const delayMs of delaysMs) {
 		await new Promise((resolve) => setTimeout(resolve, delayMs))
 		result = await read()
-		if (result) return result
+		if (result != null) return result
 	}
 	return null
 }

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -207,9 +207,18 @@ class RepoSessionBase extends DurableObject<Env> {
 
 	private async getSessionState(sessionId: string, userId: string) {
 		const cachedState = await this.readCachedSessionState(sessionId)
+		// Prefer fresh reads from D1 so correctness-sensitive flows like
+		// rebaseSession and publishSession always observe the latest
+		// base_commit and published_commit. The cache is only a fallback for
+		// when a D1 read genuinely cannot see a row (e.g. brief replica lag
+		// immediately after openSession inserted it); this keeps scheduled
+		// jobs from throwing "Repo session was not found" while still letting
+		// concurrent mutations through updateRepoSession / updateEntitySource
+		// drive rebase and publish decisions.
 		const sessionRow =
+			(await readRepoSessionWithRetry(this.env.APP_DB, sessionId)) ??
 			cachedState?.sessionRow ??
-			(await readRepoSessionWithRetry(this.env.APP_DB, sessionId))
+			null
 		if (!sessionRow) {
 			throw new Error(`Repo session "${sessionId}" was not found.`)
 		}
@@ -219,13 +228,13 @@ class RepoSessionBase extends DurableObject<Env> {
 			)
 		}
 		const source =
-			cachedState?.source?.id === sessionRow.source_id
+			(await readEntitySourceWithRetry(
+				this.env.APP_DB,
+				sessionRow.source_id,
+			)) ??
+			(cachedState?.source?.id === sessionRow.source_id
 				? cachedState.source
-				: ((await readEntitySourceWithRetry(
-						this.env.APP_DB,
-						sessionRow.source_id,
-					)) ??
-					null)
+				: null)
 		if (!source) {
 			throw new Error(`Source "${sessionRow.source_id}" was not found.`)
 		}

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -78,6 +78,34 @@ function getCachedSessionStateStorageKey(sessionId: string) {
 	return `${cachedSessionStateStorageKeyPrefix}${sessionId}`
 }
 
+// D1 read replicas can lag briefly behind the primary; when we know a row was
+// just inserted (for example, openSession persisted a fresh repo session before
+// returning to the worker), an immediate read from a different request handler
+// may still miss it. A short retry with backoff papers over that lag without
+// resorting to global throttling.
+const repoLookupRetryDelaysMs = [50, 100, 200, 400] as const
+
+async function readWithRetry<T>(
+	read: () => Promise<T | null>,
+): Promise<T | null> {
+	let result = await read()
+	if (result) return result
+	for (const delayMs of repoLookupRetryDelaysMs) {
+		await new Promise((resolve) => setTimeout(resolve, delayMs))
+		result = await read()
+		if (result) return result
+	}
+	return null
+}
+
+async function readRepoSessionWithRetry(db: D1Database, sessionId: string) {
+	return readWithRetry(() => getRepoSessionById(db, sessionId))
+}
+
+async function readEntitySourceWithRetry(db: D1Database, sourceId: string) {
+	return readWithRetry(() => getEntitySourceById(db, sourceId))
+}
+
 function compactArtifactsRepoSuffix(value: string) {
 	const compact = value.replace(/[^a-zA-Z0-9]/g, '')
 	return compact.length > 0 ? compact : 'session'
@@ -136,19 +164,36 @@ class RepoSessionBase extends DurableObject<Env> {
 
 	private initializedSessionId: string | null = null
 
+	// In-memory cache for the active DO instance. This serves as the primary
+	// fallback for follow-up RPC calls on the same sessionId so that even the
+	// shortest replication lag between D1 writes and reads does not surface as
+	// a spurious "Repo session was not found" error during scheduled runs.
+	private readonly inMemorySessionState = new Map<
+		string,
+		CachedRepoSessionState
+	>()
+
 	private async readCachedSessionState(
 		sessionId: string,
 	): Promise<CachedRepoSessionState | null> {
-		return (
+		const inMemory = this.inMemorySessionState.get(sessionId)
+		if (inMemory) {
+			return inMemory
+		}
+		const persisted =
 			(await this.ctx.storage.get<CachedRepoSessionState | null>(
 				getCachedSessionStateStorageKey(sessionId),
 			)) ?? null
-		)
+		if (persisted) {
+			this.inMemorySessionState.set(sessionId, persisted)
+		}
+		return persisted
 	}
 
 	private async writeCachedSessionState(
 		state: CachedRepoSessionState,
 	): Promise<void> {
+		this.inMemorySessionState.set(state.sessionRow.id, state)
 		await this.ctx.storage.put(
 			getCachedSessionStateStorageKey(state.sessionRow.id),
 			state,
@@ -156,15 +201,15 @@ class RepoSessionBase extends DurableObject<Env> {
 	}
 
 	private async clearCachedSessionState(sessionId: string): Promise<void> {
+		this.inMemorySessionState.delete(sessionId)
 		await this.ctx.storage.put(getCachedSessionStateStorageKey(sessionId), null)
 	}
 
 	private async getSessionState(sessionId: string, userId: string) {
 		const cachedState = await this.readCachedSessionState(sessionId)
 		const sessionRow =
-			(await getRepoSessionById(this.env.APP_DB, sessionId)) ??
 			cachedState?.sessionRow ??
-			null
+			(await readRepoSessionWithRetry(this.env.APP_DB, sessionId))
 		if (!sessionRow) {
 			throw new Error(`Repo session "${sessionId}" was not found.`)
 		}
@@ -174,10 +219,13 @@ class RepoSessionBase extends DurableObject<Env> {
 			)
 		}
 		const source =
-			(await getEntitySourceById(this.env.APP_DB, sessionRow.source_id)) ??
-			(cachedState?.source?.id === sessionRow.source_id
+			cachedState?.source?.id === sessionRow.source_id
 				? cachedState.source
-				: null)
+				: ((await readEntitySourceWithRetry(
+						this.env.APP_DB,
+						sessionRow.source_id,
+					)) ??
+					null)
 		if (!source) {
 			throw new Error(`Source "${sessionRow.source_id}" was not found.`)
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Scheduled jobs were intermittently failing with errors like:

```
Repo session "job-runtime-509277e2-ad6c-445c-9ec1-49e2d230ff8a-..." was not found.
```

even though `openSession` had just inserted the row. Direct `job_run_now`
runs did not show the issue, while alarm-driven one-off jobs and recurring
package jobs did.

## Root cause

Two gaps were combining into a real flake in the alarm and recurring
runtime paths:

1. The repo session DO state cache only persisted to Durable Object
   storage. Follow-up RPC calls (e.g. `runChecks`, `readFile`) that
   landed on the same DO instance still went through storage to look up
   the row, and any storage miss fell through to D1.
2. Reads from D1 immediately after a write can hit a lagging read
   replica and return `null` even when the row exists on the primary.
   On these paths, that surfaces as a fatal "Repo session was not
   found" error mid-execution.

The previously shipped DO storage cache helped, but only after at least
one round trip and only when the storage put had landed in time. The
alarm path is more sensitive to this because it does several DO RPC calls
back-to-back from a fresh job runtime sessionId every run.

## Fix

In `packages/worker/src/repo/repo-session-do.ts`:

- Add an in-memory cache (`Map`) on each DO instance for repo session
  state so consecutive RPC calls to the same `sessionId` never have to
  wait on Durable Object storage in the hot path.
- When a D1 lookup misses, retry with a short capped backoff
  (50/100/200/400ms). This papers over brief D1 read-replica lag
  without introducing global throttling.
- Keep the D1-first priority for `getSessionState`:
  `readRepoSessionWithRetry(...) ?? cachedState?.sessionRow` and
  `readEntitySourceWithRetry(...) ?? cachedState?.source`. This keeps
  correctness-sensitive flows like `rebaseSession` and `publishSession`
  seeing the latest `base_commit` and `source.published_commit` even
  when the cache holds older values from earlier in the session, and
  only falls back to the cache when a D1 read genuinely returns null.

The DO storage cache from the earlier fix is still kept as a secondary
layer for cases where the in-memory cache has been evicted (e.g. DO
hibernation between calls).

## Validation

- Added a regression test
  `readFile retries the D1 lookup when the persisted cache is missing
  and the row is not yet readable` that simulates the alarm-driven
  failure mode (cache empty + first two D1 reads return `null`, third
  read returns the row) and verifies that `readFile` recovers via the
  new retry path.
- Added a second regression test
  `getSessionState prefers fresh D1 reads over cached session and
  source rows` that pins D1-first priority: a second `readFile` on the
  same DO instance observes updated `sessionRow` and `source` rows
  instead of short-circuiting on the cache. This guards against
  `publishSession`'s `base_moved` check silently passing on stale data.
- Existing tests in `repo-session-do.node.test.ts`,
  `service.node.test.ts`, and the rest of the jobs/repo suites still
  pass.
- Full `node-unit` suite (84 files / 343 tests) and `workers-unit`
  suite (6 files / 40 tests) pass.
- Typecheck passes; lint reports only the pre-existing warnings on
  unrelated files.

## Notes

- Kept the recently shipped behavior of preserving failed one-off jobs
  for debuggability, so the surface area of this change is narrowly
  focused on lookup stability.
- No public APIs or stored data formats changed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-161a0d7d-2b49-4765-9b4e-f8de6c362e9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-161a0d7d-2b49-4765-9b4e-f8de6c362e9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved system resilience with retry logic and incremental delays for temporary data retrieval issues.
  * Enhanced session management with in-memory caching layer for better reliability.

* **Tests**
  * Added test coverage for scenarios involving temporary data unavailability and cache failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->