### PR TITLE
Improve search discovery signals

### DIFF
--- a/packages/worker/src/agent-turn/tools.ts
+++ b/packages/worker/src/agent-turn/tools.ts
@@ -63,7 +63,7 @@ export async function createAgentTurnToolSet(input: {
 								userId: userId!,
 								records: savedPackages,
 							})
-							return packageRows.rows
+							return packageRows
 						},
 						loadUserSecrets: () =>
 							listUserSecretsForSearch({

--- a/packages/worker/src/agent-turn/tools.ts
+++ b/packages/worker/src/agent-turn/tools.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
 import {
+	buildSavedPackageSearchRows,
 	loadDownRemoteConnectorStatuses,
 	loadOptionalSearchRows,
 	resolveSearchMemoryContext,
@@ -56,19 +57,12 @@ export async function createAgentTurnToolSet(input: {
 								input.env.APP_DB,
 								{ userId: userId! },
 							)
-							return savedPackages.map((savedPackage) => ({
-								record: savedPackage,
-								projection: {
-									name: savedPackage.name,
-									kodyId: savedPackage.kodyId,
-									description: savedPackage.description,
-									tags: savedPackage.tags,
-									searchText: savedPackage.searchText,
-									hasApp: savedPackage.hasApp,
-									exports: [],
-									jobs: [],
-								},
-							}))
+							return await buildSavedPackageSearchRows({
+								env: input.env,
+								baseUrl: input.callerContext.baseUrl,
+								userId: userId!,
+								records: savedPackages,
+							})
 						},
 						loadUserSecrets: () =>
 							listUserSecretsForSearch({
@@ -110,6 +104,7 @@ export async function createAgentTurnToolSet(input: {
 				return {
 					offline: result.offline,
 					warnings: optionalRows.warnings,
+					guidance: result.guidance,
 					memories: memoryToolContext
 						? {
 								surfaced: memoryToolContext.memories,

--- a/packages/worker/src/agent-turn/tools.ts
+++ b/packages/worker/src/agent-turn/tools.ts
@@ -57,12 +57,13 @@ export async function createAgentTurnToolSet(input: {
 								input.env.APP_DB,
 								{ userId: userId! },
 							)
-							return await buildSavedPackageSearchRows({
+							const packageRows = await buildSavedPackageSearchRows({
 								env: input.env,
 								baseUrl: input.callerContext.baseUrl,
 								userId: userId!,
 								records: savedPackages,
 							})
+							return packageRows.rows
 						},
 						loadUserSecrets: () =>
 							listUserSecretsForSearch({

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -21,6 +21,8 @@ test('search markdown and entity detail formatting preserve structured behavior'
 	const markdown = formatSearchMarkdown({
 		baseUrl: 'http://localhost',
 		warnings: [],
+		guidance:
+			'Inspect connector detail with `search({ entity: "github:connector" })` next.',
 		matches: [
 			{
 				type: 'value',
@@ -56,6 +58,8 @@ test('search markdown and entity detail formatting preserve structured behavior'
 
 	expect(markdown).toContain('`user:preferred_repo:value`')
 	expect(markdown).toContain('`https://api.github.com`')
+	expect(markdown).toContain('## Recommended next step')
+	expect(markdown).toContain('`search({ entity: "github:connector" })`')
 
 	expect(
 		toSlimStructuredMatches({
@@ -116,6 +120,8 @@ test('search markdown and entity detail formatting preserve structured behavior'
 			flow: 'confidential',
 			apiBaseUrl: 'https://api.github.com',
 			requiredHosts: ['api.github.com'],
+			nextStep:
+				'Inspect connector detail with search({ entity: "github:connector" }) and then run a minimal authenticated execute smoke test before building or calling integration-backed code.',
 		},
 	])
 

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -20,6 +20,7 @@ export type SearchResultStructuredContent = {
 	matches: Array<SlimSearchMatch>
 	offline: boolean
 	warnings: Array<string>
+	guidance?: string
 	telemetry?: {
 		intent: {
 			task: string
@@ -102,6 +103,7 @@ export type SlimSearchMatch =
 			tags: Array<string>
 			hasApp: boolean
 			hostedUrl: string | null
+			nextStep?: string
 	  }
 	| {
 			type: 'secret'
@@ -133,6 +135,7 @@ export type SlimSearchMatch =
 			flow: string
 			apiBaseUrl: string | null
 			requiredHosts: Array<string>
+			nextStep?: string
 	  }
 
 export type SearchEntityDetailStructured =
@@ -357,6 +360,7 @@ export function formatSearchMarkdown(input: {
 	warnings: Array<string>
 	baseUrl: string
 	includePreamble?: boolean
+	guidance?: string
 	memories?: {
 		surfaced: Array<{
 			category: string | null
@@ -399,6 +403,10 @@ export function formatSearchMarkdown(input: {
 				`- ${String(input.memories.suppressedCount)} additional memory item(s) were suppressed for this conversation.`,
 			)
 		}
+	}
+
+	if (input.guidance?.trim()) {
+		lines.push('', '## Recommended next step', '', input.guidance.trim())
 	}
 
 	for (const match of input.matches) {
@@ -498,6 +506,9 @@ export function toSlimStructuredMatches(input: {
 			}
 		}
 		if (match.type === 'package') {
+			const nextStep = match.hasApp
+				? `Open the app with open_generated_ui({ kody_id: "${match.kodyId}" }) or inspect package detail with search({ entity: "${match.kodyId}:package" }).`
+				: `Inspect package detail with search({ entity: "${match.kodyId}:package" }) to review exports, then import the needed entry from "${buildPackageImportSpecifier(match.kodyId, '.')}".`
 			return {
 				type: 'package',
 				id: match.kodyId,
@@ -514,6 +525,7 @@ export function toSlimStructuredMatches(input: {
 				hostedUrl: match.hasApp
 					? buildPackageHostedUrl(input.baseUrl, match.kodyId)
 					: null,
+				nextStep,
 			}
 		}
 		if (match.type === 'value') {
@@ -541,6 +553,7 @@ export function toSlimStructuredMatches(input: {
 				flow: match.flow,
 				apiBaseUrl: match.apiBaseUrl,
 				requiredHosts: match.requiredHosts,
+				nextStep: `Inspect connector detail with search({ entity: "${match.connectorName}:connector" }) and then run a minimal authenticated execute smoke test before building or calling integration-backed code.`,
 			}
 		}
 		return {

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -237,6 +237,50 @@ test('optional search rows include saved packages when lookup succeeds', async (
 	expect(result.warnings).toEqual([])
 })
 
+test('optional search rows preserve package fallback warnings', async () => {
+	const result = await loadOptionalSearchRows({
+		userId: 'user-123',
+		loadPackages: async () => ({
+			rows: [
+				{
+					record: {
+						id: 'package-123',
+						userId: 'user-123',
+						name: '@kody/observed',
+						kodyId: 'observed-package',
+						description: 'Observed package',
+						tags: ['observed'],
+						searchText: null,
+						sourceId: 'source-package-123',
+						hasApp: true,
+						createdAt: '2026-03-24T00:00:00.000Z',
+						updatedAt: '2026-03-24T00:00:00.000Z',
+					},
+					projection: {
+						name: '@kody/observed',
+						kodyId: 'observed-package',
+						description: 'Observed package',
+						tags: ['observed'],
+						searchText: null,
+						hasApp: true,
+						appEntry: null,
+						exports: [],
+						jobs: [],
+					},
+				},
+			],
+			warnings: ['Saved package "observed-package" fallback metadata was used.'],
+		}),
+		loadUserSecrets: async () => [],
+		loadUserValues: async () => [],
+	})
+
+	expect(result.packageRows).toHaveLength(1)
+	expect(result.warnings).toEqual([
+		'Saved package "observed-package" fallback metadata was used.',
+	])
+})
+
 test('searchUnified uses package exports and connector aliases for operate queries', () => {
 	const registry = buildCapabilityRegistry([])
 	const optionalRows = {

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -325,7 +325,7 @@ test('searchUnified uses package exports and connector aliases for operate queri
 })
 
 test('buildSavedPackageSearchRows falls back when package source resolution fails', async () => {
-	const rows = await buildSavedPackageSearchRows({
+	const result = await buildSavedPackageSearchRows({
 		env: {} as Env,
 		baseUrl: 'http://localhost',
 		userId: 'user-123',
@@ -346,7 +346,7 @@ test('buildSavedPackageSearchRows falls back when package source resolution fail
 		],
 	})
 
-	expect(rows).toEqual([
+	expect(result.rows).toEqual([
 		expect.objectContaining({
 			projection: expect.objectContaining({
 				hasApp: true,
@@ -356,6 +356,74 @@ test('buildSavedPackageSearchRows falls back when package source resolution fail
 			}),
 		}),
 	])
+	expect(result.warnings).toEqual([
+		'Saved package "observed" search metadata is partially unavailable; using fallback metadata from source "missing-source": Saved package source bindings are not available.',
+	])
+})
+
+test('search guidance does not pair unrelated package and connector matches', () => {
+	const registry = buildCapabilityRegistry([])
+	const result = searchUnified({
+		env: {} as Env,
+		query: 'play music on spotify',
+		limit: 5,
+		registry,
+		optionalRows: {
+			packageRows: [
+				{
+					record: {
+						id: 'package-123',
+						userId: 'user-123',
+						name: '@kody/observed',
+						kodyId: 'observed-package',
+						description: 'Observed package with app controls.',
+						tags: ['music'],
+						searchText: 'music remote package',
+						sourceId: 'source-package-123',
+						hasApp: true,
+						createdAt: '2026-03-24T00:00:00.000Z',
+						updatedAt: '2026-03-24T00:00:00.000Z',
+					},
+					projection: {
+						name: '@kody/observed',
+						kodyId: 'observed-package',
+						description: 'Observed package with app controls.',
+						tags: ['music'],
+						searchText: 'music remote package',
+						hasApp: true,
+						appEntry: 'src/app.ts',
+						exports: ['./play'],
+						jobs: [],
+					},
+				},
+			],
+			userSecretRows: [],
+			userValueRows: [
+				{
+					name: buildConnectorValueName('github'),
+					scope: 'user',
+					value: JSON.stringify({
+						tokenUrl: 'https://github.com/login/oauth/access_token',
+						apiBaseUrl: 'https://api.github.com',
+						flow: 'confidential',
+						clientIdValueName: 'github-client-id',
+						clientSecretSecretName: 'github-client-secret',
+						accessTokenSecretName: 'github-access-token',
+						refreshTokenSecretName: 'github-refresh-token',
+						requiredHosts: ['api.github.com'],
+					}),
+					description: 'GitHub OAuth connector config',
+					appId: null,
+					createdAt: '2026-04-20T00:00:00.000Z',
+					updatedAt: '2026-04-20T00:00:00.000Z',
+					ttlMs: null,
+				},
+			],
+			warnings: [],
+		},
+	})
+
+	expect(result.guidance).not.toContain('connector `github`')
 })
 
 test('optional search rows fall back when persisted values lookup fails', async () => {

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -335,7 +335,7 @@ test('searchUnified uses package exports and connector aliases for operate queri
 					refreshTokenSecretName: 'spotify-refresh-token',
 					requiredHosts: ['api.spotify.com'],
 				}),
-				description: 'Spotify OAuth connector config',
+					description: 'Spotify playback and music OAuth connector config',
 				appId: null,
 				createdAt: '2026-04-20T00:00:00.000Z',
 				updatedAt: '2026-04-20T00:00:00.000Z',

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
 import { buildConnectorValueName } from '#mcp/capabilities/values/connector-shared.ts'
 import {
+	buildSavedPackageSearchRows,
 	loadDownHomeConnectorStatus,
 	loadOptionalSearchRows,
 	resolveSearchMemoryContext,
@@ -55,6 +56,7 @@ test('searchUnified ranks mixed search rows through one shared pipeline', () => 
 				tags: ['delta'],
 				searchText: 'epsilon',
 				hasApp: false,
+				appEntry: null,
 				exports: [],
 				jobs: [],
 			},
@@ -219,6 +221,7 @@ test('optional search rows include saved packages when lookup succeeds', async (
 					tags: ['roku'],
 					searchText: null,
 					hasApp: true,
+					appEntry: 'src/app.ts',
 					exports: ['.'],
 					jobs: [],
 				},
@@ -232,6 +235,127 @@ test('optional search rows include saved packages when lookup succeeds', async (
 	expect(result.userSecretRows).toEqual([])
 	expect(result.userValueRows).toEqual([])
 	expect(result.warnings).toEqual([])
+})
+
+test('searchUnified uses package exports and connector aliases for operate queries', () => {
+	const registry = buildCapabilityRegistry([])
+	const optionalRows = {
+		packageRows: [
+			{
+				record: {
+					id: 'spotify-pkg',
+					userId: 'user-1',
+					name: '@kentcdodds/spotify',
+					kodyId: 'spotify',
+					description:
+						'Package-first Spotify playback controls, queue helpers, device management, and a hosted remote app.',
+					tags: ['spotify', 'music', 'playback'],
+					searchText: 'spotify remote playback package music queue player',
+					sourceId: 'source-spotify',
+					hasApp: true,
+					createdAt: '2026-04-20T00:00:00.000Z',
+					updatedAt: '2026-04-20T00:00:00.000Z',
+				},
+				projection: {
+					name: '@kentcdodds/spotify',
+					kodyId: 'spotify',
+					description:
+						'Package-first Spotify playback controls, queue helpers, device management, and a hosted remote app.',
+					tags: ['spotify', 'music', 'playback'],
+					searchText: 'spotify remote playback package music queue player',
+					hasApp: true,
+					appEntry: 'src/app/server.ts',
+					exports: [
+						'./playback-state',
+						'./play-pause',
+						'./transfer-playback',
+						'./add-to-queue',
+						'./playback-controller',
+					],
+					jobs: [],
+				},
+			},
+		],
+		userSecretRows: [],
+		userValueRows: [
+			{
+				name: buildConnectorValueName('spotify'),
+				scope: 'user',
+				value: JSON.stringify({
+					tokenUrl: 'https://accounts.spotify.com/api/token',
+					apiBaseUrl: 'https://api.spotify.com/v1',
+					flow: 'pkce',
+					clientIdValueName: 'spotify-client-id',
+					clientSecretSecretName: null,
+					accessTokenSecretName: 'spotify-access-token',
+					refreshTokenSecretName: 'spotify-refresh-token',
+					requiredHosts: ['api.spotify.com'],
+				}),
+				description: 'Spotify OAuth connector config',
+				appId: null,
+				createdAt: '2026-04-20T00:00:00.000Z',
+				updatedAt: '2026-04-20T00:00:00.000Z',
+				ttlMs: null,
+			},
+		],
+		warnings: [],
+	} satisfies OptionalSearchRowsResult
+
+	const result = searchUnified({
+		env: {} as Env,
+		query: 'play a lofi song on spotify',
+		limit: 5,
+		registry,
+		optionalRows,
+	})
+
+	expect(result.matches).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				type: 'package',
+				kodyId: 'spotify',
+			}),
+			expect.objectContaining({
+				type: 'connector',
+				connectorName: 'spotify',
+			}),
+		]),
+	)
+	expect(result.guidance).toContain('Found saved package `spotify` and connector `spotify`')
+})
+
+test('buildSavedPackageSearchRows falls back when package source resolution fails', async () => {
+	const rows = await buildSavedPackageSearchRows({
+		env: {} as Env,
+		baseUrl: 'http://localhost',
+		userId: 'user-123',
+		records: [
+			{
+				id: 'package-123',
+				userId: 'user-123',
+				name: '@kody/observed',
+				kodyId: 'observed',
+				description: 'Observed package',
+				tags: ['observed'],
+				searchText: 'search text',
+				sourceId: 'missing-source',
+				hasApp: true,
+				createdAt: '2026-03-24T00:00:00.000Z',
+				updatedAt: '2026-03-24T00:00:00.000Z',
+			},
+		],
+	})
+
+	expect(rows).toEqual([
+		expect.objectContaining({
+			projection: expect.objectContaining({
+				hasApp: true,
+				appEntry: null,
+				exports: [],
+				jobs: [],
+			}),
+		}),
+	])
 })
 
 test('optional search rows fall back when persisted values lookup fails', async () => {

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -220,26 +220,17 @@ export async function buildSavedPackageSearchRows(input: {
 	return { rows, warnings }
 }
 
-const wellKnownConnectorAliases: Record<string, Array<string>> = {
-	spotify: [
-		'music',
-		'audio',
-		'playback',
-		'player',
-		'track',
-		'song',
-		'playlist',
-		'album',
-		'artist',
-		'queue',
-		'volume',
-	],
-	github: ['repo', 'repository', 'pull request', 'issue', 'code', 'git'],
-	tesla: ['car', 'vehicle', 'charging', 'climate', 'lock', 'unlock'],
-}
-
-function getConnectorAliases(connectorName: string): Array<string> {
-	return wellKnownConnectorAliases[connectorName.toLowerCase()] ?? []
+function buildPackageRelationTokens(match: Extract<SearchMatch, { type: 'package' }>) {
+	return new Set(
+		extractSearchTokens(
+			[
+				match.kodyId,
+				match.name,
+				match.description,
+				match.tags.join(' '),
+			].join('\n'),
+		),
+	)
 }
 
 function buildConnectorSearchDocument(input: {
@@ -254,7 +245,6 @@ function buildConnectorSearchDocument(input: {
 		input.config.apiBaseUrl ?? '',
 		input.config.flow,
 		...(input.config.requiredHosts ?? []),
-		...getConnectorAliases(input.connectorName),
 	]
 		.filter((value) => value.trim().length > 0)
 		.join('\n')
@@ -264,16 +254,13 @@ function buildRecommendedNextStep(input: SearchGuidanceContext): string | undefi
 	const [topMatch] = input.matches
 	const topPackage = input.matches.find((match) => match.type === 'package')
 	const topConnector = input.matches.find((match) => match.type === 'connector')
+	const packageRelationTokens = topPackage
+		? buildPackageRelationTokens(topPackage)
+		: null
 	const connectorMatchesPackage =
 		topPackage &&
 		topConnector &&
-		(topConnector.connectorName.toLowerCase() === topPackage.kodyId.toLowerCase() ||
-			topPackage.kodyId
-				.toLowerCase()
-				.includes(topConnector.connectorName.toLowerCase()) ||
-			getConnectorAliases(topConnector.connectorName).some((alias) =>
-				topPackage.kodyId.toLowerCase().includes(alias.toLowerCase()),
-			))
+		(packageRelationTokens?.has(topConnector.connectorName.toLowerCase()) ?? false)
 
 	if (connectorMatchesPackage && input.intent.task.name === 'operate') {
 		return `Found saved package \`${topPackage.kodyId}\` and connector \`${topConnector.connectorName}\`. Inspect the package with \`search({ entity: "${topPackage.kodyId}:package" })\`, then use the connector detail or an authenticated \`execute\` smoke test to confirm the integration path before running API-backed actions.`
@@ -350,7 +337,7 @@ function buildSearchableEntityDescriptors(input: {
 				type: 'connector',
 				id: connectorName,
 				title: connectorName,
-				primaryAliases: [connectorName, ...getConnectorAliases(connectorName)],
+				primaryAliases: [connectorName],
 				secondaryAliases: [
 					row.description,
 					config.apiBaseUrl ?? '',
@@ -786,7 +773,6 @@ function buildConnectorCandidates(input: {
 						config.apiBaseUrl ?? '',
 						config.tokenUrl,
 						...(config.requiredHosts ?? []),
-						...getConnectorAliases(connectorName),
 					],
 					scoreComponents: buildCandidateBaseScore({
 						lexical,

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -159,6 +159,8 @@ function buildFallbackPackageSearchProjection(
 		description: record.description,
 		tags: record.tags,
 		searchText: record.searchText,
+		// Preserve the saved-record app signal for discoverability even when manifest
+		// hydration fails and we cannot recover the concrete app entry path.
 		hasApp: record.hasApp,
 		appEntry: null,
 		exports: [],
@@ -166,13 +168,19 @@ function buildFallbackPackageSearchProjection(
 	}
 }
 
+export type BuildSavedPackageSearchRowsResult = {
+	rows: Array<PackageSearchRow>
+	warnings: Array<string>
+}
+
 export async function buildSavedPackageSearchRows(input: {
 	env: Env
 	baseUrl: string
 	userId: string
 	records: Array<Awaited<ReturnType<typeof listSavedPackagesByUserId>>[number]>
-}): Promise<Array<PackageSearchRow>> {
-	return await Promise.all(
+}): Promise<BuildSavedPackageSearchRowsResult> {
+	const warnings: Array<string> = []
+	const rows = await Promise.all(
 		input.records.map(async (record) => {
 			try {
 				const loaded = await loadPackageSourceBySourceId({
@@ -185,7 +193,21 @@ export async function buildSavedPackageSearchRows(input: {
 					record,
 					projection: buildPackageSearchProjection(loaded.manifest),
 				}
-			} catch {
+			} catch (cause) {
+				Sentry.captureException(cause, {
+					tags: {
+						scope: 'search.buildSavedPackageSearchRows',
+					},
+					extra: {
+						kodyId: record.kodyId,
+						sourceId: record.sourceId,
+					},
+				})
+				const message =
+					cause instanceof Error ? cause.message : String(cause)
+				warnings.push(
+					`Saved package "${record.kodyId}" search metadata is partially unavailable; using fallback metadata from source "${record.sourceId}": ${message}`,
+				)
 				return {
 					record,
 					projection: buildFallbackPackageSearchProjection(record),
@@ -193,6 +215,7 @@ export async function buildSavedPackageSearchRows(input: {
 			}
 		}),
 	)
+	return { rows, warnings }
 }
 
 const wellKnownConnectorAliases: Record<string, Array<string>> = {
@@ -239,8 +262,18 @@ function buildRecommendedNextStep(input: SearchGuidanceContext): string | undefi
 	const [topMatch] = input.matches
 	const topPackage = input.matches.find((match) => match.type === 'package')
 	const topConnector = input.matches.find((match) => match.type === 'connector')
+	const connectorMatchesPackage =
+		topPackage &&
+		topConnector &&
+		(topConnector.connectorName.toLowerCase() === topPackage.kodyId.toLowerCase() ||
+			topPackage.kodyId
+				.toLowerCase()
+				.includes(topConnector.connectorName.toLowerCase()) ||
+			getConnectorAliases(topConnector.connectorName).some((alias) =>
+				topPackage.kodyId.toLowerCase().includes(alias.toLowerCase()),
+			))
 
-	if (topPackage && topConnector && input.intent.task.name === 'operate') {
+	if (connectorMatchesPackage && input.intent.task.name === 'operate') {
 		return `Found saved package \`${topPackage.kodyId}\` and connector \`${topConnector.connectorName}\`. Inspect the package with \`search({ entity: "${topPackage.kodyId}:package" })\`, then use the connector detail or an authenticated \`execute\` smoke test to confirm the integration path before running API-backed actions.`
 	}
 	if (topMatch?.type === 'package') {
@@ -705,6 +738,7 @@ function buildValueCandidates(input: {
 function buildConnectorCandidates(input: {
 	query: string
 	rows: Array<ValueMetadata>
+	queryEmbedding: ReadonlyArray<number>
 }): Array<SearchCandidate> {
 	return input.rows
 		.flatMap((row) => {
@@ -724,7 +758,7 @@ function buildConnectorCandidates(input: {
 			})
 			const lexical = lexicalScore(input.query, document)
 			const vector = cosineSimilarity(
-				deterministicEmbedding(input.query),
+				input.queryEmbedding,
 				deterministicEmbedding(document),
 			)
 			return [
@@ -863,6 +897,7 @@ export function searchUnified(input: {
 		...buildConnectorCandidates({
 			query: intent.normalizedQuery,
 			rows: input.optionalRows.userValueRows,
+			queryEmbedding,
 		}),
 		...buildSecretCandidates({
 			query: intent.normalizedQuery,
@@ -1166,12 +1201,13 @@ async function loadSearchRowsAndRegistry(input: {
 						userId: input.userId!,
 					},
 				)
-				return await buildSavedPackageSearchRows({
+				const packageRows = await buildSavedPackageSearchRows({
 					env: input.agent.getEnv(),
 					baseUrl: input.callerContext.baseUrl,
 					userId: input.userId!,
 					records: savedPackages,
 				})
+				return packageRows.rows
 			},
 			loadUserSecrets: () =>
 				listUserSecretsForSearch({

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -617,9 +617,6 @@ function buildPackageCandidates(input: {
 }): Array<SearchCandidate> {
 	return input.rows
 		.map((entry) => {
-			const tags = Array.isArray(entry.projection.tags)
-				? entry.projection.tags
-				: []
 			const exports = Array.isArray(entry.projection.exports)
 				? entry.projection.exports
 				: []

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -30,8 +30,12 @@ import {
 	getSavedPackageByKodyId,
 	listSavedPackagesByUserId,
 } from '#worker/package-registry/repo.ts'
+import {
+	buildPackageSearchDocument,
+	buildPackageSearchProjection,
+	type PackageSearchProjection,
+} from '#worker/package-registry/manifest.ts'
 import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
-import { type buildPackageSearchProjection } from '#worker/package-registry/manifest.ts'
 import {
 	getRemoteConnectorStatus,
 	type HomeConnectorStatus,
@@ -74,7 +78,7 @@ const defaultMaxResponseSize = 4_000
 
 export type PackageSearchRow = {
 	record: Awaited<ReturnType<typeof listSavedPackagesByUserId>>[number]
-	projection: ReturnType<typeof buildPackageSearchProjection>
+	projection: PackageSearchProjection
 }
 
 export type OptionalSearchRowsResult = {
@@ -131,12 +135,126 @@ type SearchPhaseTimings = {
 	formattingMs?: number
 }
 
+type SearchGuidanceContext = {
+	query: string
+	intent: SearchIntent
+	matches: Array<SearchMatch>
+}
+
 type SearchUnifiedResult = {
 	matches: Array<SearchMatch>
 	offline: boolean
 	intent: SearchIntent
 	telemetry: SearchTelemetry
 	phaseTimings: SearchPhaseTimings
+	guidance?: string
+}
+
+function buildFallbackPackageSearchProjection(
+	record: Awaited<ReturnType<typeof listSavedPackagesByUserId>>[number],
+): PackageSearchProjection {
+	return {
+		name: record.name,
+		kodyId: record.kodyId,
+		description: record.description,
+		tags: record.tags,
+		searchText: record.searchText,
+		hasApp: record.hasApp,
+		appEntry: null,
+		exports: [],
+		jobs: [],
+	}
+}
+
+export async function buildSavedPackageSearchRows(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	records: Array<Awaited<ReturnType<typeof listSavedPackagesByUserId>>[number]>
+}): Promise<Array<PackageSearchRow>> {
+	return await Promise.all(
+		input.records.map(async (record) => {
+			try {
+				const loaded = await loadPackageSourceBySourceId({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					userId: input.userId,
+					sourceId: record.sourceId,
+				})
+				return {
+					record,
+					projection: buildPackageSearchProjection(loaded.manifest),
+				}
+			} catch {
+				return {
+					record,
+					projection: buildFallbackPackageSearchProjection(record),
+				}
+			}
+		}),
+	)
+}
+
+const wellKnownConnectorAliases: Record<string, Array<string>> = {
+	spotify: [
+		'music',
+		'audio',
+		'playback',
+		'player',
+		'track',
+		'song',
+		'playlist',
+		'album',
+		'artist',
+		'queue',
+		'volume',
+	],
+	github: ['repo', 'repository', 'pull request', 'issue', 'code', 'git'],
+	tesla: ['car', 'vehicle', 'charging', 'climate', 'lock', 'unlock'],
+}
+
+function getConnectorAliases(connectorName: string): Array<string> {
+	return wellKnownConnectorAliases[connectorName.toLowerCase()] ?? []
+}
+
+function buildConnectorSearchDocument(input: {
+	connectorName: string
+	description: string
+	config: NonNullable<ReturnType<typeof parseConnectorConfig>>
+}): string {
+	return [
+		input.connectorName,
+		input.description,
+		input.config.tokenUrl,
+		input.config.apiBaseUrl ?? '',
+		input.config.flow,
+		...(input.config.requiredHosts ?? []),
+		...getConnectorAliases(input.connectorName),
+	]
+		.filter((value) => value.trim().length > 0)
+		.join('\n')
+}
+
+function buildRecommendedNextStep(input: SearchGuidanceContext): string | undefined {
+	const [topMatch] = input.matches
+	const topPackage = input.matches.find((match) => match.type === 'package')
+	const topConnector = input.matches.find((match) => match.type === 'connector')
+
+	if (topPackage && topConnector && input.intent.task.name === 'operate') {
+		return `Found saved package \`${topPackage.kodyId}\` and connector \`${topConnector.connectorName}\`. Inspect the package with \`search({ entity: "${topPackage.kodyId}:package" })\`, then use the connector detail or an authenticated \`execute\` smoke test to confirm the integration path before running API-backed actions.`
+	}
+	if (topMatch?.type === 'package') {
+		return topMatch.hasApp
+			? `Open the saved app with \`open_generated_ui({ kody_id: "${topMatch.kodyId}" })\` or inspect package detail with \`search({ entity: "${topMatch.kodyId}:package" })\` to review exports and jobs.`
+			: `Inspect package detail with \`search({ entity: "${topMatch.kodyId}:package" })\` to review exports, then import the right entry from \`kody:@${topMatch.kodyId}\` or a subpath export.`
+	}
+	if (topMatch?.type === 'connector') {
+		return `Inspect connector detail with \`search({ entity: "${topMatch.connectorName}:connector" })\` and then run a minimal authenticated \`execute\` smoke test before building or calling integration-backed code.`
+	}
+	if (topMatch?.type === 'capability') {
+		return `Inspect capability detail with \`search({ entity: "${topMatch.name}:capability" })\` to confirm the schema, then call it from \`execute\` via \`codemode.${topMatch.name}(args)\`.`
+	}
+	return undefined
 }
 
 function buildSearchableEntityDescriptors(input: {
@@ -197,14 +315,17 @@ function buildSearchableEntityDescriptors(input: {
 				type: 'connector',
 				id: connectorName,
 				title: connectorName,
-				primaryAliases: [connectorName],
+				primaryAliases: [connectorName, ...getConnectorAliases(connectorName)],
 				secondaryAliases: [
 					row.description,
 					config.apiBaseUrl ?? '',
 					config.tokenUrl,
 					config.flow,
 				],
-				tertiaryAliases: config.requiredHosts ?? [],
+				tertiaryAliases: [
+					...(config.requiredHosts ?? []),
+					...(config.apiBaseUrl ? extractSearchTokens(config.apiBaseUrl) : []),
+				],
 			})
 			continue
 		}
@@ -505,15 +626,7 @@ function buildPackageCandidates(input: {
 			const jobs = Array.isArray(entry.projection.jobs)
 				? entry.projection.jobs
 				: []
-			const document = [
-				entry.projection.kodyId,
-				entry.projection.name,
-				entry.projection.description,
-				tags.join(' '),
-				entry.projection.searchText ?? '',
-				exports.join(' '),
-				jobs.map((job) => job.name).join(' '),
-			].join('\n')
+			const document = buildPackageSearchDocument(entry.projection)
 			const lexical = lexicalScore(input.query, document)
 			const vector = cosineSimilarity(
 				input.queryEmbedding,
@@ -540,7 +653,13 @@ function buildPackageCandidates(input: {
 					entry.record.searchText ?? '',
 					...entry.record.tags,
 					...exports,
-					...jobs.map((job) => job.name),
+					...jobs.flatMap((job) => [
+						job.name,
+						job.entry,
+						job.schedule,
+						job.enabled ? 'enabled' : 'disabled',
+					]),
+					...(entry.projection.appEntry ? [entry.projection.appEntry] : []),
 					...(entry.record.hasApp ? ['app', 'ui', 'remote'] : []),
 				],
 				scoreComponents: buildCandidateBaseScore({
@@ -599,16 +718,17 @@ function buildConnectorCandidates(input: {
 				connectorName,
 			)
 			if (!config) return []
-			const lexical = lexicalScore(
-				input.query,
-				[
-					connectorName,
-					row.description,
-					config.tokenUrl,
-					config.apiBaseUrl ?? '',
-					config.flow,
-					...(config.requiredHosts ?? []),
-				].join('\n'),
+			const document = buildConnectorSearchDocument({
+				connectorName,
+				description:
+					row.description.trim() ||
+					`Saved OAuth connector configuration (${config.flow} flow).`,
+				config,
+			})
+			const lexical = lexicalScore(input.query, document)
+			const vector = cosineSimilarity(
+				deterministicEmbedding(input.query),
+				deterministicEmbedding(document),
 			)
 			return [
 				{
@@ -633,9 +753,11 @@ function buildConnectorCandidates(input: {
 						config.apiBaseUrl ?? '',
 						config.tokenUrl,
 						...(config.requiredHosts ?? []),
+						...getConnectorAliases(connectorName),
 					],
 					scoreComponents: buildCandidateBaseScore({
 						lexical,
+						vector,
 					}),
 				} satisfies SearchCandidate,
 			]
@@ -780,6 +902,11 @@ export function searchUnified(input: {
 			candidateGenerationMs,
 			rerankingMs,
 		},
+		guidance: buildRecommendedNextStep({
+			query,
+			intent,
+			matches,
+		}),
 	}
 }
 
@@ -1042,19 +1169,12 @@ async function loadSearchRowsAndRegistry(input: {
 						userId: input.userId!,
 					},
 				)
-				return savedPackages.map((record) => ({
-					record,
-					projection: {
-						name: record.name,
-						kodyId: record.kodyId,
-						description: record.description,
-						tags: record.tags,
-						searchText: record.searchText,
-						hasApp: record.hasApp,
-						exports: [],
-						jobs: [],
-					},
-				}))
+				return await buildSavedPackageSearchRows({
+					env: input.agent.getEnv(),
+					baseUrl: input.callerContext.baseUrl,
+					userId: input.userId!,
+					records: savedPackages,
+				})
 			},
 			loadUserSecrets: () =>
 				listUserSecretsForSearch({
@@ -1406,6 +1526,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					matches: Array<SearchMatch>
 					offline: boolean
 					warnings: Array<string>
+					guidance?: string
 					memories?: SearchResultStructuredContent['memories']
 					homeConnectorStatus?: {
 						connectorKind: string
@@ -1425,6 +1546,11 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					matches: outcome.result.matches,
 					offline: outcome.result.offline,
 					warnings,
+					...(outcome.result.guidance
+						? {
+								guidance: outcome.result.guidance,
+							}
+						: {}),
 					...(searchMemories
 						? {
 								memories: searchMemories,
@@ -1474,6 +1600,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 						formatSearchMarkdown({
 							matches: value.matches,
 							warnings: value.warnings,
+							guidance: value.guidance,
 							memories: value.memories,
 							baseUrl,
 							includePreamble,
@@ -1495,6 +1622,11 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 				const result: SearchResultStructuredContent = {
 					offline: trimmedPayload.offline,
 					warnings: trimmedPayload.warnings,
+					...(trimmedPayload.guidance
+						? {
+								guidance: trimmedPayload.guidance,
+							}
+						: {}),
 					telemetry: {
 						...outcome.result.telemetry,
 						topResultTypes: trimmedPayload.matches

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -88,6 +88,8 @@ export type OptionalSearchRowsResult = {
 	warnings: Array<string>
 }
 
+type LoadedPackageRows = Array<PackageSearchRow> | BuildSavedPackageSearchRowsResult
+
 export type SearchScoreComponents = {
 	base: number
 	lexical: number
@@ -1121,7 +1123,7 @@ export async function loadDownHomeConnectorStatus(input: {
 
 export async function loadOptionalSearchRows(input: {
 	userId: string | null
-	loadPackages: () => Promise<Array<PackageSearchRow>>
+	loadPackages: () => Promise<LoadedPackageRows>
 	loadUserSecrets: () => Promise<Array<SecretSearchRow>>
 	loadUserValues: () => Promise<Array<ValueMetadata>>
 }): Promise<OptionalSearchRowsResult> {
@@ -1142,9 +1144,15 @@ export async function loadOptionalSearchRows(input: {
 			input.loadUserValues(),
 		])
 
-	const packageRows =
-		packageRowsResult.status === 'fulfilled' ? packageRowsResult.value : []
-	if (packageRowsResult.status === 'rejected') {
+	let packageRows: Array<PackageSearchRow> = []
+	if (packageRowsResult.status === 'fulfilled') {
+		if (Array.isArray(packageRowsResult.value)) {
+			packageRows = packageRowsResult.value
+		} else {
+			packageRows = packageRowsResult.value.rows
+			warnings.push(...packageRowsResult.value.warnings)
+		}
+	} else {
 		const message =
 			packageRowsResult.reason instanceof Error
 				? packageRowsResult.reason.message
@@ -1207,7 +1215,7 @@ async function loadSearchRowsAndRegistry(input: {
 					userId: input.userId!,
 					records: savedPackages,
 				})
-				return packageRows.rows
+				return packageRows
 			},
 			loadUserSecrets: () =>
 				listUserSecretsForSearch({

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -35,7 +35,10 @@ import {
 	buildPackageSearchProjection,
 	type PackageSearchProjection,
 } from '#worker/package-registry/manifest.ts'
-import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
+import {
+	loadPackageManifestBySourceId,
+	loadPackageSourceBySourceId,
+} from '#worker/package-registry/source.ts'
 import {
 	getRemoteConnectorStatus,
 	type HomeConnectorStatus,
@@ -185,7 +188,7 @@ export async function buildSavedPackageSearchRows(input: {
 	const rows = await Promise.all(
 		input.records.map(async (record) => {
 			try {
-				const loaded = await loadPackageSourceBySourceId({
+				const loaded = await loadPackageManifestBySourceId({
 					env: input.env,
 					baseUrl: input.baseUrl,
 					userId: input.userId,

--- a/packages/worker/src/package-registry/embed.ts
+++ b/packages/worker/src/package-registry/embed.ts
@@ -1,41 +1,9 @@
-import { type AuthoredPackageJson, type PackageJobDefinition } from './types.ts'
-
-function formatJobSchedule(job: PackageJobDefinition) {
-	if (job.schedule.type === 'cron') {
-		return `cron ${job.schedule.expression}`
-	}
-	if (job.schedule.type === 'interval') {
-		return `interval ${job.schedule.every}`
-	}
-	return `once ${job.schedule.runAt}`
-}
+import {
+	buildPackageSearchDocument,
+	buildPackageSearchProjection,
+} from './manifest.ts'
+import { type AuthoredPackageJson } from './types.ts'
 
 export function buildSavedPackageEmbedText(manifest: AuthoredPackageJson) {
-	const tags = manifest.kody.tags ?? []
-	const exportLines = Object.entries(manifest.exports).map(
-		([exportName, target]) =>
-			`${exportName} ${
-				typeof target === 'string'
-					? target
-					: [target.import, target.default, target.types]
-							.filter((value): value is string => Boolean(value))
-							.join(' ')
-			}`.trim(),
-	)
-	const jobLines = Object.entries(manifest.kody.jobs ?? {}).map(
-		([jobName, job]) =>
-			`${jobName} ${job.entry} ${formatJobSchedule(job)}`.trim(),
-	)
-	return [
-		`package ${manifest.kody.id}`,
-		manifest.name,
-		manifest.kody.description,
-		tags.join(' '),
-		manifest.kody.searchText ?? '',
-		exportLines.join('\n'),
-		jobLines.join('\n'),
-		manifest.kody.app ? `app ${manifest.kody.app.entry}` : '',
-	]
-		.filter((value) => value.trim().length > 0)
-		.join('\n')
+	return buildPackageSearchDocument(buildPackageSearchProjection(manifest))
 }

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -151,7 +151,11 @@ export function buildPackageSearchDocument(projection: PackageSearchProjection) 
 		projection.searchText ?? '',
 		projection.exports.join('\n'),
 		jobLines.join('\n'),
-		projection.appEntry ? `app ${projection.appEntry}` : '',
+		projection.appEntry
+			? `app ${projection.appEntry}`
+			: projection.hasApp
+				? 'app'
+				: '',
 	]
 		.filter((value) => value.trim().length > 0)
 		.join('\n')

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -91,14 +91,35 @@ export function getPackageTags(manifest: AuthoredPackageJson) {
 	return [...(manifest.kody.tags ?? [])]
 }
 
-export function buildPackageSearchProjection(manifest: AuthoredPackageJson) {
+export type PackageSearchProjection = {
+	name: string
+	kodyId: string
+	description: string
+	tags: Array<string>
+	searchText: string | null
+	hasApp: boolean
+	appEntry: string | null
+	exports: Array<string>
+	jobs: Array<{
+		name: string
+		entry: string
+		schedule: string
+		enabled: boolean
+	}>
+}
+
+export function buildPackageSearchProjection(
+	manifest: AuthoredPackageJson,
+): PackageSearchProjection {
+	const appEntry = getPackageAppEntryPath(manifest)
 	return {
 		name: manifest.name,
 		kodyId: manifest.kody.id,
 		description: manifest.kody.description,
 		tags: getPackageTags(manifest),
 		searchText: manifest.kody.searchText?.trim() || null,
-		hasApp: manifest.kody.app !== undefined,
+		hasApp: appEntry !== null,
+		appEntry,
 		exports: Object.keys(manifest.exports).sort(),
 		jobs: Object.entries(manifest.kody.jobs ?? {})
 			.map(([name, job]) => ({
@@ -114,4 +135,24 @@ export function buildPackageSearchProjection(manifest: AuthoredPackageJson) {
 			}))
 			.sort((left, right) => left.name.localeCompare(right.name)),
 	}
+}
+
+export function buildPackageSearchDocument(projection: PackageSearchProjection) {
+	const jobLines = projection.jobs.map((job) =>
+		[job.name, job.entry, job.schedule, job.enabled ? 'enabled' : 'disabled']
+			.filter((value) => value.length > 0)
+			.join(' '),
+	)
+	return [
+		`package ${projection.kodyId}`,
+		projection.name,
+		projection.description,
+		projection.tags.join(' '),
+		projection.searchText ?? '',
+		projection.exports.join('\n'),
+		jobLines.join('\n'),
+		projection.appEntry ? `app ${projection.appEntry}` : '',
+	]
+		.filter((value) => value.trim().length > 0)
+		.join('\n')
 }

--- a/packages/worker/src/package-registry/source.node.test.ts
+++ b/packages/worker/src/package-registry/source.node.test.ts
@@ -3,6 +3,7 @@ import { expect, test, vi } from 'vitest'
 const mockModule = vi.hoisted(() => ({
 	getEntitySourceById: vi.fn(),
 	loadPublishedEntitySource: vi.fn(),
+	loadPublishedEntityManifest: vi.fn(),
 }))
 
 vi.mock('#worker/repo/entity-sources.ts', () => ({
@@ -13,6 +14,8 @@ vi.mock('#worker/repo/entity-sources.ts', () => ({
 vi.mock('#worker/repo/published-source.ts', () => ({
 	loadPublishedEntitySource: (...args: Array<unknown>) =>
 		mockModule.loadPublishedEntitySource(...args),
+	loadPublishedEntityManifest: (...args: Array<unknown>) =>
+		mockModule.loadPublishedEntityManifest(...args),
 }))
 
 const { loadPackageSourceBySourceId, loadPackageManifestBySourceId } =
@@ -122,6 +125,7 @@ test('loadPackageSourceBySourceId reuses cached published package sources', asyn
 
 test('loadPackageManifestBySourceId reads only the manifest for published sources', async () => {
 	mockModule.getEntitySourceById.mockReset()
+	mockModule.loadPublishedEntityManifest.mockReset()
 	mockModule.loadPublishedEntitySource.mockReset()
 	const bundleKv = {
 		get: vi.fn(async () => null),
@@ -135,27 +139,36 @@ test('loadPackageManifestBySourceId reads only the manifest for published source
 			publishedCommit: 'commit-manifest-only-1',
 		}),
 	)
-	mockModule.loadPublishedEntitySource.mockResolvedValue({
+	mockModule.loadPublishedEntityManifest.mockResolvedValue({
 		source: createPackageSourceRow({
 			id: 'source-manifest-only-1',
 			publishedCommit: 'commit-manifest-only-1',
 		}),
-		files: {
-			'package.json': JSON.stringify({
-				name: '@kentcdodds/example-package',
-				exports: {
-					'.': './index.js',
+		content: JSON.stringify({
+			name: '@kentcdodds/example-package',
+			exports: {
+				'.': './index.js',
+			},
+			kody: {
+				id: 'example-package',
+				description: 'Example package',
+				app: {
+					entry: 'app.js',
 				},
-				kody: {
-					id: 'example-package',
-					description: 'Example package',
-					app: {
-						entry: 'app.js',
-					},
+			},
+		}),
+		manifest: {
+			name: '@kentcdodds/example-package',
+			exports: {
+				'.': './index.js',
+			},
+			kody: {
+				id: 'example-package',
+				description: 'Example package',
+				app: {
+					entry: 'app.js',
 				},
-			}),
-			'app.js': 'export default { async fetch() { return new Response("ok") } }',
-			'index.js': 'export const value = "ok"',
+			},
 		},
 	})
 
@@ -178,7 +191,8 @@ test('loadPackageManifestBySourceId reads only the manifest for published source
 		sourceId: 'source-manifest-only-1',
 	})
 
-	expect(mockModule.loadPublishedEntitySource).toHaveBeenCalledTimes(1)
+	expect(mockModule.loadPublishedEntityManifest).toHaveBeenCalledTimes(1)
+	expect(mockModule.loadPublishedEntitySource).not.toHaveBeenCalled()
 	expect(first).toStrictEqual(second)
 	expect(first.manifest).toMatchObject({
 		name: '@kentcdodds/example-package',

--- a/packages/worker/src/package-registry/source.node.test.ts
+++ b/packages/worker/src/package-registry/source.node.test.ts
@@ -27,7 +27,8 @@ vi.mock('#worker/repo/repo-codemode-execution.ts', () => ({
 		mockModule.loadRepoSourceFilesFromSession(...args),
 }))
 
-const { loadPackageSourceBySourceId } = await import('./source.ts')
+const { loadPackageSourceBySourceId, loadPackageManifestBySourceId } =
+	await import('./source.ts')
 
 function createPackageSourceRow(input: {
 	id: string
@@ -139,6 +140,54 @@ test('loadPackageSourceBySourceId reuses cached published package sources', asyn
 				},
 			},
 		}),
+	})
+})
+
+test('loadPackageManifestBySourceId reads only the manifest for published sources', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.readMockArtifactSnapshot.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+	mockModule.loadRepoSourceFilesFromSession.mockReset()
+
+	const sessionClient = createSessionClient('session-manifest-only-1')
+	mockModule.getEntitySourceById.mockResolvedValue(
+		createPackageSourceRow({
+			id: 'source-manifest-only-1',
+			publishedCommit: 'commit-manifest-only-1',
+		}),
+	)
+	mockModule.readMockArtifactSnapshot.mockResolvedValue(null)
+	mockModule.repoSessionRpc.mockReturnValue(sessionClient as never)
+
+	const first = await loadPackageManifestBySourceId({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceId: 'source-manifest-only-1',
+	})
+	const second = await loadPackageManifestBySourceId({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceId: 'source-manifest-only-1',
+	})
+
+	expect(sessionClient.openSession).toHaveBeenCalledTimes(1)
+	expect(sessionClient.readFile).toHaveBeenCalledTimes(1)
+	expect(mockModule.loadRepoSourceFilesFromSession).not.toHaveBeenCalled()
+	expect(sessionClient.discardSession).toHaveBeenCalledTimes(1)
+	expect(first).toBe(second)
+	expect(first.manifest).toMatchObject({
+		name: '@kentcdodds/example-package',
+		kody: {
+			id: 'example-package',
+		},
 	})
 })
 

--- a/packages/worker/src/package-registry/source.ts
+++ b/packages/worker/src/package-registry/source.ts
@@ -27,6 +27,158 @@ export type LoadedPackageManifest = {
 const packageSourceCache = new PromiseLruCache<LoadedPackageSource>()
 const packageManifestCache = new PromiseLruCache<LoadedPackageManifest>()
 
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
+	if (value && typeof value === 'object') {
+		const objectValue = value as object
+		if (seen.has(objectValue)) {
+			return value
+		}
+		seen.add(objectValue)
+		for (const child of Object.values(value as Record<string, unknown>)) {
+			deepFreeze(child, seen)
+		}
+		Object.freeze(objectValue)
+	}
+	return value
+}
+
+function freezeFiles(files: Record<string, string>) {
+	return Object.freeze({ ...files }) as Record<string, string>
+}
+
+function finalizeLoadedSource(input: {
+	source: EntitySourceRow
+	manifest: AuthoredPackageJson
+	files: Record<string, string>
+}) {
+	return Object.freeze({
+		source: deepFreeze({ ...input.source }),
+		manifest: deepFreeze(structuredClone(input.manifest)),
+		files: freezeFiles(input.files),
+	}) as LoadedPackageSource
+}
+
+function finalizeLoadedManifest(input: {
+	source: EntitySourceRow
+	manifest: AuthoredPackageJson
+}) {
+	return Object.freeze({
+		source: deepFreeze({ ...input.source }),
+		manifest: deepFreeze(structuredClone(input.manifest)),
+	}) as LoadedPackageManifest
+}
+
+function parsePackageManifest(input: {
+	source: EntitySourceRow
+	content: string
+}) {
+	return parseAuthoredPackageJson({
+		content: input.content,
+		manifestPath: input.source.manifest_path,
+	})
+}
+
+async function readManifestFromMockSnapshot(input: {
+	env: Env
+	source: EntitySourceRow
+}): Promise<
+	| {
+			manifest: AuthoredPackageJson
+			manifestContent: string
+			files: Record<string, string>
+	  }
+	| null
+> {
+	const mockArtifactsBaseUrl = input.env.CLOUDFLARE_API_BASE_URL?.trim()
+	if (!mockArtifactsBaseUrl || !input.source.published_commit) {
+		return null
+	}
+	const mockArtifactsUrl = new URL(mockArtifactsBaseUrl)
+	if (!isLoopbackHostname(mockArtifactsUrl.hostname)) {
+		return null
+	}
+	const snapshot = await readMockArtifactSnapshot({
+		env: input.env,
+		repoId: input.source.repo_id,
+		commit: input.source.published_commit,
+	})
+	if (!snapshot) {
+		return null
+	}
+	const manifestContent = snapshot.files[input.source.manifest_path]
+	if (!manifestContent) {
+		throw new Error(
+			`Saved package manifest "${input.source.manifest_path}" was not found in the repo source.`,
+		)
+	}
+	return {
+		manifest: parsePackageManifest({
+			source: input.source,
+			content: manifestContent,
+		}),
+		manifestContent,
+		files: snapshot.files,
+	}
+}
+
+async function withPackageManifestSession<T>(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	source: EntitySourceRow
+	sessionPrefix: string
+	run: (resolved: {
+		session: ReturnType<typeof repoSessionRpc>
+		sessionId: string
+		manifest: AuthoredPackageJson
+		manifestContent: string
+	}) => Promise<T>
+}): Promise<T> {
+	const sessionId = `${input.sessionPrefix}-${input.source.id}-${crypto.randomUUID()}`
+	const session = repoSessionRpc(input.env, sessionId)
+	let openedSessionId: string | null = null
+	try {
+		const opened = await session.openSession({
+			sessionId,
+			sourceId: input.source.id,
+			userId: input.userId,
+			baseUrl: input.baseUrl,
+			sourceRoot: input.source.source_root,
+		})
+		openedSessionId = opened.id
+		const manifestFile = await session.readFile({
+			sessionId: opened.id,
+			userId: input.userId,
+			path: input.source.manifest_path,
+		})
+		if (!manifestFile.content) {
+			throw new Error(
+				`Saved package manifest "${input.source.manifest_path}" was not found in the repo source.`,
+			)
+		}
+		return await input.run({
+			session,
+			sessionId: opened.id,
+			manifest: parsePackageManifest({
+				source: input.source,
+				content: manifestFile.content,
+			}),
+			manifestContent: manifestFile.content,
+		})
+	} finally {
+		if (openedSessionId) {
+			await session
+				.discardSession({
+					sessionId: openedSessionId,
+					userId: input.userId,
+				})
+				.catch(() => {
+					// Best effort only; source resolution should preserve the original error.
+				})
+		}
+	}
+}
+
 function canResolveRepoBackedPackageSource(env: Env) {
 	const anyEnv = env as Env & { APP_DB?: unknown; REPO_SESSION?: unknown }
 	return (
@@ -53,109 +205,38 @@ async function loadPackageSourceUncached(input: {
 	userId: string
 	source: EntitySourceRow
 }): Promise<LoadedPackageSource> {
-	const source = input.source
-	const freezeFiles = (files: Record<string, string>) =>
-		Object.freeze({ ...files }) as Record<string, string>
-	const deepFreeze = <T>(value: T, seen = new WeakSet<object>()): T => {
-		if (value && typeof value === 'object') {
-			const objectValue = value as object
-			if (seen.has(objectValue)) {
-				return value
-			}
-			seen.add(objectValue)
-			for (const child of Object.values(value as Record<string, unknown>)) {
-				deepFreeze(child, seen)
-			}
-			Object.freeze(objectValue)
-		}
-		return value
-	}
-
-	const finalizeLoadedSource = (loaded: {
-		manifest: AuthoredPackageJson
-		files: Record<string, string>
-	}) =>
-		Object.freeze({
-			source: deepFreeze({ ...source }),
-			manifest: deepFreeze(structuredClone(loaded.manifest)),
-			files: freezeFiles(loaded.files),
-		}) as LoadedPackageSource
-
-	const mockArtifactsBaseUrl = input.env.CLOUDFLARE_API_BASE_URL?.trim()
-	if (mockArtifactsBaseUrl && source.published_commit) {
-		const mockArtifactsUrl = new URL(mockArtifactsBaseUrl)
-		if (isLoopbackHostname(mockArtifactsUrl.hostname)) {
-			const snapshot = await readMockArtifactSnapshot({
-				env: input.env,
-				repoId: source.repo_id,
-				commit: source.published_commit,
-			})
-			if (snapshot) {
-				const manifestContent = snapshot.files[source.manifest_path]
-				if (!manifestContent) {
-					throw new Error(
-						`Saved package manifest "${source.manifest_path}" was not found in the repo source.`,
-					)
-				}
-				return finalizeLoadedSource({
-					manifest: parseAuthoredPackageJson({
-						content: manifestContent,
-						manifestPath: source.manifest_path,
-					}),
-					files: snapshot.files,
-				})
-			}
-		}
-	}
-	const sessionId = `package-source-${source.id}-${crypto.randomUUID()}`
-	const session = repoSessionRpc(input.env, sessionId)
-	let openedSessionId: string | null = null
-	try {
-		const opened = await session.openSession({
-			sessionId,
-			sourceId: source.id,
-			userId: input.userId,
-			baseUrl: input.baseUrl,
-			sourceRoot: source.source_root,
-		})
-		openedSessionId = opened.id
-		const manifestFile = await session.readFile({
-			sessionId: opened.id,
-			userId: input.userId,
-			path: source.manifest_path,
-		})
-		if (!manifestFile.content) {
-			throw new Error(
-				`Saved package manifest "${source.manifest_path}" was not found in the repo source.`,
-			)
-		}
-		const manifest = parseAuthoredPackageJson({
-			content: manifestFile.content,
-			manifestPath: source.manifest_path,
-		})
-		const files = await loadRepoSourceFilesFromSession({
-			sessionClient: session,
-			sessionId: opened.id,
-			userId: input.userId,
-			sourceRoot: source.source_root,
-		})
-		files[source.manifest_path] = manifestFile.content
+	const snapshot = await readManifestFromMockSnapshot({
+		env: input.env,
+		source: input.source,
+	})
+	if (snapshot) {
 		return finalizeLoadedSource({
-			manifest,
-			files,
+			source: input.source,
+			manifest: snapshot.manifest,
+			files: snapshot.files,
 		})
-	} finally {
-		if (openedSessionId) {
-			await session
-				.discardSession({
-					sessionId: openedSessionId,
-					userId: input.userId,
-				})
-				.catch(() => {
-					// Best effort only; source resolution should preserve the original error.
-				})
-		}
 	}
+	return await withPackageManifestSession({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		source: input.source,
+		sessionPrefix: 'package-source',
+		run: async ({ session, sessionId, manifest, manifestContent }) => {
+			const files = await loadRepoSourceFilesFromSession({
+				sessionClient: session,
+				sessionId,
+				userId: input.userId,
+				sourceRoot: input.source.source_root,
+			})
+			files[input.source.manifest_path] = manifestContent
+			return finalizeLoadedSource({
+				source: input.source,
+				manifest,
+				files,
+			})
+		},
+	})
 }
 
 async function loadPackageManifestUncached(input: {
@@ -164,95 +245,28 @@ async function loadPackageManifestUncached(input: {
 	userId: string
 	source: EntitySourceRow
 }): Promise<LoadedPackageManifest> {
-	const source = input.source
-	const deepFreeze = <T>(value: T, seen = new WeakSet<object>()): T => {
-		if (value && typeof value === 'object') {
-			const objectValue = value as object
-			if (seen.has(objectValue)) {
-				return value
-			}
-			seen.add(objectValue)
-			for (const child of Object.values(value as Record<string, unknown>)) {
-				deepFreeze(child, seen)
-			}
-			Object.freeze(objectValue)
-		}
-		return value
-	}
-
-	const finalizeLoadedManifest = (loaded: {
-		manifest: AuthoredPackageJson
-	}) =>
-		Object.freeze({
-			source: deepFreeze({ ...source }),
-			manifest: deepFreeze(structuredClone(loaded.manifest)),
-		}) as LoadedPackageManifest
-
-	const mockArtifactsBaseUrl = input.env.CLOUDFLARE_API_BASE_URL?.trim()
-	if (mockArtifactsBaseUrl && source.published_commit) {
-		const mockArtifactsUrl = new URL(mockArtifactsBaseUrl)
-		if (isLoopbackHostname(mockArtifactsUrl.hostname)) {
-			const snapshot = await readMockArtifactSnapshot({
-				env: input.env,
-				repoId: source.repo_id,
-				commit: source.published_commit,
-			})
-			if (snapshot) {
-				const manifestContent = snapshot.files[source.manifest_path]
-				if (!manifestContent) {
-					throw new Error(
-						`Saved package manifest "${source.manifest_path}" was not found in the repo source.`,
-					)
-				}
-				return finalizeLoadedManifest({
-					manifest: parseAuthoredPackageJson({
-						content: manifestContent,
-						manifestPath: source.manifest_path,
-					}),
-				})
-			}
-		}
-	}
-	const sessionId = `package-manifest-${source.id}-${crypto.randomUUID()}`
-	const session = repoSessionRpc(input.env, sessionId)
-	let openedSessionId: string | null = null
-	try {
-		const opened = await session.openSession({
-			sessionId,
-			sourceId: source.id,
-			userId: input.userId,
-			baseUrl: input.baseUrl,
-			sourceRoot: source.source_root,
-		})
-		openedSessionId = opened.id
-		const manifestFile = await session.readFile({
-			sessionId: opened.id,
-			userId: input.userId,
-			path: source.manifest_path,
-		})
-		if (!manifestFile.content) {
-			throw new Error(
-				`Saved package manifest "${source.manifest_path}" was not found in the repo source.`,
-			)
-		}
+	const snapshot = await readManifestFromMockSnapshot({
+		env: input.env,
+		source: input.source,
+	})
+	if (snapshot) {
 		return finalizeLoadedManifest({
-			manifest: parseAuthoredPackageJson({
-				content: manifestFile.content,
-				manifestPath: source.manifest_path,
-			}),
+			source: input.source,
+			manifest: snapshot.manifest,
 		})
-	} finally {
-		if (openedSessionId) {
-			await session
-				.discardSession({
-					sessionId: openedSessionId,
-					userId: input.userId,
-				})
-				.catch(() => {
-					// Best effort only; source resolution should preserve the original error.
-				})
-		}
 	}
+	return await withPackageManifestSession({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		source: input.source,
+		sessionPrefix: 'package-manifest',
+		run: async ({ manifest }) =>
+			finalizeLoadedManifest({
+				source: input.source,
+				manifest,
+			}),
+	})
 }
 
 export async function loadPackageSourceBySourceId(input: {

--- a/packages/worker/src/package-registry/source.ts
+++ b/packages/worker/src/package-registry/source.ts
@@ -19,7 +19,13 @@ export type LoadedPackageSource = {
 	files: Record<string, string>
 }
 
+export type LoadedPackageManifest = {
+	source: EntitySourceRow
+	manifest: AuthoredPackageJson
+}
+
 const packageSourceCache = new PromiseLruCache<LoadedPackageSource>()
+const packageManifestCache = new PromiseLruCache<LoadedPackageManifest>()
 
 function canResolveRepoBackedPackageSource(env: Env) {
 	const anyEnv = env as Env & { APP_DB?: unknown; REPO_SESSION?: unknown }
@@ -152,6 +158,103 @@ async function loadPackageSourceUncached(input: {
 	}
 }
 
+async function loadPackageManifestUncached(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	source: EntitySourceRow
+}): Promise<LoadedPackageManifest> {
+	const source = input.source
+	const deepFreeze = <T>(value: T, seen = new WeakSet<object>()): T => {
+		if (value && typeof value === 'object') {
+			const objectValue = value as object
+			if (seen.has(objectValue)) {
+				return value
+			}
+			seen.add(objectValue)
+			for (const child of Object.values(value as Record<string, unknown>)) {
+				deepFreeze(child, seen)
+			}
+			Object.freeze(objectValue)
+		}
+		return value
+	}
+
+	const finalizeLoadedManifest = (loaded: {
+		manifest: AuthoredPackageJson
+	}) =>
+		Object.freeze({
+			source: deepFreeze({ ...source }),
+			manifest: deepFreeze(structuredClone(loaded.manifest)),
+		}) as LoadedPackageManifest
+
+	const mockArtifactsBaseUrl = input.env.CLOUDFLARE_API_BASE_URL?.trim()
+	if (mockArtifactsBaseUrl && source.published_commit) {
+		const mockArtifactsUrl = new URL(mockArtifactsBaseUrl)
+		if (isLoopbackHostname(mockArtifactsUrl.hostname)) {
+			const snapshot = await readMockArtifactSnapshot({
+				env: input.env,
+				repoId: source.repo_id,
+				commit: source.published_commit,
+			})
+			if (snapshot) {
+				const manifestContent = snapshot.files[source.manifest_path]
+				if (!manifestContent) {
+					throw new Error(
+						`Saved package manifest "${source.manifest_path}" was not found in the repo source.`,
+					)
+				}
+				return finalizeLoadedManifest({
+					manifest: parseAuthoredPackageJson({
+						content: manifestContent,
+						manifestPath: source.manifest_path,
+					}),
+				})
+			}
+		}
+	}
+	const sessionId = `package-manifest-${source.id}-${crypto.randomUUID()}`
+	const session = repoSessionRpc(input.env, sessionId)
+	let openedSessionId: string | null = null
+	try {
+		const opened = await session.openSession({
+			sessionId,
+			sourceId: source.id,
+			userId: input.userId,
+			baseUrl: input.baseUrl,
+			sourceRoot: source.source_root,
+		})
+		openedSessionId = opened.id
+		const manifestFile = await session.readFile({
+			sessionId: opened.id,
+			userId: input.userId,
+			path: source.manifest_path,
+		})
+		if (!manifestFile.content) {
+			throw new Error(
+				`Saved package manifest "${source.manifest_path}" was not found in the repo source.`,
+			)
+		}
+		return finalizeLoadedManifest({
+			manifest: parseAuthoredPackageJson({
+				content: manifestFile.content,
+				manifestPath: source.manifest_path,
+			}),
+		})
+	} finally {
+		if (openedSessionId) {
+			await session
+				.discardSession({
+					sessionId: openedSessionId,
+					userId: input.userId,
+				})
+				.catch(() => {
+					// Best effort only; source resolution should preserve the original error.
+				})
+		}
+	}
+}
+
 export async function loadPackageSourceBySourceId(input: {
 	env: Env
 	baseUrl: string
@@ -187,6 +290,58 @@ export async function loadPackageSourceBySourceId(input: {
 		cacheKey,
 		create: async () =>
 			await loadPackageSourceUncached({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				source,
+			}),
+	})
+}
+
+export async function loadPackageManifestBySourceId(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	sourceId: string
+}): Promise<LoadedPackageManifest> {
+	if (!canResolveRepoBackedPackageSource(input.env)) {
+		throw new Error('Saved package source bindings are not available.')
+	}
+	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
+	if (!source || source.user_id !== input.userId) {
+		throw new Error(`Saved package source "${input.sourceId}" was not found.`)
+	}
+	const cacheKey = createPackageSourceCacheKey({
+		userId: input.userId,
+		source,
+	})
+	if (!cacheKey) {
+		return await loadPackageManifestUncached({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.userId,
+			source,
+		})
+	}
+
+	const cachedSource = packageSourceCache.get(cacheKey)
+	if (cachedSource) {
+		const loadedSource = await cachedSource
+		return Object.freeze({
+			source: loadedSource.source,
+			manifest: loadedSource.manifest,
+		}) as LoadedPackageManifest
+	}
+
+	const cachedManifest = packageManifestCache.get(cacheKey)
+	if (cachedManifest) {
+		return await cachedManifest
+	}
+
+	return await packageManifestCache.getOrCreate({
+		cacheKey,
+		create: async () =>
+			await loadPackageManifestUncached({
 				env: input.env,
 				baseUrl: input.baseUrl,
 				userId: input.userId,

--- a/packages/worker/src/package-registry/source.ts
+++ b/packages/worker/src/package-registry/source.ts
@@ -1,6 +1,9 @@
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
-import { loadPublishedEntitySource } from '#worker/repo/published-source.ts'
+import {
+	loadPublishedEntityManifest,
+	loadPublishedEntitySource,
+} from '#worker/repo/published-source.ts'
 import {
 	createPublishedPackageCacheKey,
 	PromiseLruCache,
@@ -20,6 +23,7 @@ export type LoadedPackageManifest = {
 }
 
 const packageSourceCache = new PromiseLruCache<LoadedPackageSource>()
+const packageManifestCache = new PromiseLruCache<LoadedPackageManifest>()
 
 function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
 	if (value && typeof value === 'object') {
@@ -50,15 +54,6 @@ function finalizeLoadedSource(input: {
 		manifest: deepFreeze(structuredClone(input.manifest)),
 		files: freezeFiles(input.files),
 	}) as LoadedPackageSource
-}
-
-function deriveLoadedManifest(
-	loadedSource: LoadedPackageSource,
-): LoadedPackageManifest {
-	return Object.freeze({
-		source: loadedSource.source,
-		manifest: loadedSource.manifest,
-	}) as LoadedPackageManifest
 }
 
 function parsePackageManifest(input: {
@@ -201,25 +196,38 @@ export async function loadPackageManifestBySourceId(input: {
 		source,
 	})
 	if (!cacheKey) {
-		return deriveLoadedManifest(
-			await loadPackageSourceUncached({
-				env: input.env,
-				baseUrl: input.baseUrl,
-				userId: input.userId,
+		const published = await loadPublishedEntityManifest({
+			env: input.env,
+			userId: input.userId,
+			sourceId: source.id,
+		})
+		return Object.freeze({
+			source,
+			manifest: parsePackageManifest({
 				source,
+				content: published.content,
 			}),
-		)
+		}) as LoadedPackageManifest
 	}
-	return deriveLoadedManifest(
-		await packageSourceCache.getOrCreate({
-			cacheKey,
-			create: async () =>
-				await loadPackageSourceUncached({
-					env: input.env,
-					baseUrl: input.baseUrl,
-					userId: input.userId,
+	const cachedManifest = packageManifestCache.get(cacheKey)
+	if (cachedManifest) {
+		return await cachedManifest
+	}
+	return await packageManifestCache.getOrCreate({
+		cacheKey,
+		create: async () => {
+			const published = await loadPublishedEntityManifest({
+				env: input.env,
+				userId: input.userId,
+				sourceId: source.id,
+			})
+			return Object.freeze({
+				source,
+				manifest: parsePackageManifest({
 					source,
+					content: published.content,
 				}),
-		}),
-	)
+			}) as LoadedPackageManifest
+		},
+	})
 }

--- a/packages/worker/src/package-runtime/published-runtime-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-runtime-artifacts.ts
@@ -2,8 +2,10 @@ import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 
 const sourceSnapshotVersion = 1
+const sourceManifestSnapshotVersion = 1
 const bundleArtifactVersion = 1
 const sourceSnapshotPrefix = 'source-snapshot'
+const sourceManifestSnapshotPrefix = 'source-manifest-snapshot'
 const bundleArtifactPrefix = 'bundle-artifact'
 
 export type BundleArtifactKind = 'app' | 'job' | 'module'
@@ -34,6 +36,15 @@ export type PublishedSourceSnapshot = {
 	manifestPath: string
 	sourceRoot: string
 	files: Record<string, string>
+	createdAt: string
+}
+
+export type PublishedSourceManifestSnapshot = {
+	version: typeof sourceManifestSnapshotVersion
+	sourceId: string
+	publishedCommit: string
+	manifestPath: string
+	manifestContent: string
 	createdAt: string
 }
 
@@ -145,6 +156,13 @@ export function buildPublishedSourceSnapshotKvKey(input: {
 	return `${sourceSnapshotPrefix}:v${sourceSnapshotVersion}:${input.sourceId}:${input.publishedCommit}`
 }
 
+export function buildPublishedSourceManifestSnapshotKvKey(input: {
+	sourceId: string
+	publishedCommit: string
+}) {
+	return `${sourceManifestSnapshotPrefix}:v${sourceManifestSnapshotVersion}:${input.sourceId}:${input.publishedCommit}`
+}
+
 export function buildPublishedBundleArtifactKvKey(input: {
 	sourceId: string
 	publishedCommit: string
@@ -194,7 +212,31 @@ export async function writePublishedSourceSnapshot(input: {
 		sourceId: input.source.id,
 		publishedCommit: input.source.published_commit,
 	})
-	await getBundleArtifactsKv(input.env).put(key, JSON.stringify(snapshot))
+	const manifestContent = input.files[input.source.manifest_path]
+	if (typeof manifestContent !== 'string') {
+		throw new Error(
+			`Published source snapshot is missing manifest "${input.source.manifest_path}".`,
+		)
+	}
+	const manifestKey = buildPublishedSourceManifestSnapshotKvKey({
+		sourceId: input.source.id,
+		publishedCommit: input.source.published_commit,
+	})
+	const manifestSnapshot: PublishedSourceManifestSnapshot = {
+		version: sourceManifestSnapshotVersion,
+		sourceId: input.source.id,
+		publishedCommit: input.source.published_commit,
+		manifestPath: input.source.manifest_path,
+		manifestContent,
+		createdAt: snapshot.createdAt,
+	}
+	await Promise.all([
+		getBundleArtifactsKv(input.env).put(key, JSON.stringify(snapshot)),
+		getBundleArtifactsKv(input.env).put(
+			manifestKey,
+			JSON.stringify(manifestSnapshot),
+		),
+	])
 	return key
 }
 
@@ -234,6 +276,42 @@ export async function loadPublishedSourceSnapshot(input: {
 	})
 }
 
+export async function readPublishedSourceManifestSnapshot(input: {
+	env: Env
+	sourceId: string
+	publishedCommit: string | null
+}) {
+	if (!input.publishedCommit) return null
+	const key = buildPublishedSourceManifestSnapshotKvKey({
+		sourceId: input.sourceId,
+		publishedCommit: input.publishedCommit,
+	})
+	const stored = await getBundleArtifactsKv(input.env).get(key, 'json')
+	if (!stored || typeof stored !== 'object') return null
+	const snapshot = stored as PublishedSourceManifestSnapshot
+	if (
+		snapshot.version !== sourceManifestSnapshotVersion ||
+		snapshot.sourceId !== input.sourceId ||
+		snapshot.publishedCommit !== input.publishedCommit
+	) {
+		return null
+	}
+	return snapshot
+}
+
+export async function loadPublishedSourceManifestSnapshot(input: {
+	env: Env
+	userId: string
+	source: EntitySourceRow
+}) {
+	void input.userId
+	return await readPublishedSourceManifestSnapshot({
+		env: input.env,
+		sourceId: input.source.id,
+		publishedCommit: input.source.published_commit,
+	})
+}
+
 export async function persistPublishedSourceSnapshot(input: {
 	env: Env
 	userId: string
@@ -248,18 +326,50 @@ export async function persistPublishedSourceSnapshot(input: {
 	})
 }
 
+export async function persistPublishedSourceManifestSnapshot(input: {
+	env: Env
+	userId: string
+	source: EntitySourceRow
+	snapshot: Pick<PublishedSourceManifestSnapshot, 'manifestContent'>
+}) {
+	void input.userId
+	if (!input.source.published_commit) return null
+	const manifestSnapshot: PublishedSourceManifestSnapshot = {
+		version: sourceManifestSnapshotVersion,
+		sourceId: input.source.id,
+		publishedCommit: input.source.published_commit,
+		manifestPath: input.source.manifest_path,
+		manifestContent: input.snapshot.manifestContent,
+		createdAt: new Date().toISOString(),
+	}
+	const key = buildPublishedSourceManifestSnapshotKvKey({
+		sourceId: input.source.id,
+		publishedCommit: input.source.published_commit,
+	})
+	await getBundleArtifactsKv(input.env).put(key, JSON.stringify(manifestSnapshot))
+	return key
+}
+
 export async function deletePublishedSourceSnapshot(input: {
 	env: Env
 	sourceId: string
 	publishedCommit: string | null
 }) {
 	if (!input.publishedCommit) return
-	await getBundleArtifactsKv(input.env).delete(
-		buildPublishedSourceSnapshotKvKey({
-			sourceId: input.sourceId,
-			publishedCommit: input.publishedCommit,
-		}),
-	)
+	await Promise.all([
+		getBundleArtifactsKv(input.env).delete(
+			buildPublishedSourceSnapshotKvKey({
+				sourceId: input.sourceId,
+				publishedCommit: input.publishedCommit,
+			}),
+		),
+		getBundleArtifactsKv(input.env).delete(
+			buildPublishedSourceManifestSnapshotKvKey({
+				sourceId: input.sourceId,
+				publishedCommit: input.publishedCommit,
+			}),
+		),
+	])
 }
 
 export async function writePublishedBundleArtifact(input: {

--- a/packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts
+++ b/packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts
@@ -73,7 +73,9 @@ async function startCloudflareMock(token: string) {
 	}
 }
 
-test('Cloudflare mock implements the Artifacts REST workflow used in local dev', async () => {
+test(
+	'Cloudflare mock implements the Artifacts REST workflow used in local dev',
+	async () => {
 	const token = `cloudflare-artifacts-mock-token-${crypto.randomUUID()}`
 	const repoName = `repo-${crypto.randomUUID()}`
 	const forkName = `repo-copy-${crypto.randomUUID()}`
@@ -149,4 +151,6 @@ test('Cloudflare mock implements the Artifacts REST workflow used in local dev',
 		artifactRepoCount?: number
 	}
 	expect(meta.artifactRepoCount).toBe(2)
-})
+	},
+	40_000,
+)

--- a/packages/worker/src/repo/published-source.node.test.ts
+++ b/packages/worker/src/repo/published-source.node.test.ts
@@ -1,0 +1,168 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getEntitySourceById: vi.fn(),
+	readMockArtifactSnapshot: vi.fn(),
+	loadPublishedSourceManifestSnapshot: vi.fn(),
+	persistPublishedSourceManifestSnapshot: vi.fn(),
+	loadPublishedSourceSnapshot: vi.fn(),
+	persistPublishedSourceSnapshot: vi.fn(),
+}))
+
+vi.mock('./entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+}))
+
+vi.mock('./artifacts.ts', () => ({
+	readMockArtifactSnapshot: (...args: Array<unknown>) =>
+		mockModule.readMockArtifactSnapshot(...args),
+}))
+
+vi.mock('#worker/package-runtime/published-runtime-artifacts.ts', () => ({
+	loadPublishedSourceManifestSnapshot: (...args: Array<unknown>) =>
+		mockModule.loadPublishedSourceManifestSnapshot(...args),
+	persistPublishedSourceManifestSnapshot: (...args: Array<unknown>) =>
+		mockModule.persistPublishedSourceManifestSnapshot(...args),
+	loadPublishedSourceSnapshot: (...args: Array<unknown>) =>
+		mockModule.loadPublishedSourceSnapshot(...args),
+	persistPublishedSourceSnapshot: (...args: Array<unknown>) =>
+		mockModule.persistPublishedSourceSnapshot(...args),
+}))
+
+const {
+	loadPublishedEntityManifest,
+	loadPublishedEntitySource,
+} = await import('./published-source.ts')
+
+function createSourceRow() {
+	return {
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package' as const,
+		entity_id: 'package-1',
+		repo_id: 'repo-1',
+		published_commit: 'commit-1',
+		indexed_commit: 'commit-1',
+		manifest_path: 'package.json',
+		source_root: '/',
+		created_at: '2026-04-20T00:00:00.000Z',
+		updated_at: '2026-04-20T00:00:00.000Z',
+	}
+}
+
+test('loadPublishedEntityManifest reads only manifest content from stored snapshots', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.readMockArtifactSnapshot.mockReset()
+	mockModule.loadPublishedSourceManifestSnapshot.mockReset()
+	mockModule.persistPublishedSourceManifestSnapshot.mockReset()
+	mockModule.loadPublishedSourceSnapshot.mockReset()
+	mockModule.persistPublishedSourceSnapshot.mockReset()
+
+	mockModule.getEntitySourceById.mockResolvedValue(createSourceRow())
+	mockModule.loadPublishedSourceManifestSnapshot.mockResolvedValue({
+		version: 1,
+		sourceId: 'source-1',
+		repoId: 'repo-1',
+		entityKind: 'package',
+		entityId: 'package-1',
+		publishedCommit: 'commit-1',
+		manifestPath: 'package.json',
+		manifestContent: JSON.stringify({
+			name: '@kentcdodds/example-package',
+			exports: {
+				'.': './index.js',
+			},
+			kody: {
+				id: 'example-package',
+				description: 'Example package',
+			},
+		}),
+		createdAt: '2026-04-20T00:00:00.000Z',
+	})
+
+	const manifest = await loadPublishedEntityManifest({
+		env: {
+			APP_DB: {},
+			BUNDLE_ARTIFACTS_KV: {},
+		} as Env,
+		userId: 'user-1',
+		sourceId: 'source-1',
+	})
+
+	expect(mockModule.loadPublishedSourceManifestSnapshot).toHaveBeenCalledTimes(1)
+	expect(mockModule.readMockArtifactSnapshot).not.toHaveBeenCalled()
+	expect(
+		mockModule.persistPublishedSourceManifestSnapshot,
+	).not.toHaveBeenCalled()
+	expect(mockModule.persistPublishedSourceSnapshot).not.toHaveBeenCalled()
+	expect(manifest).toMatchObject({
+		source: expect.objectContaining({
+			id: 'source-1',
+		}),
+		manifest: expect.objectContaining({
+			name: '@kentcdodds/example-package',
+			kody: expect.objectContaining({
+				id: 'example-package',
+			}),
+		}),
+	})
+})
+
+test('loadPublishedEntitySource persists fetched snapshots for later reuse', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.readMockArtifactSnapshot.mockReset()
+	mockModule.loadPublishedSourceManifestSnapshot.mockReset()
+	mockModule.persistPublishedSourceManifestSnapshot.mockReset()
+	mockModule.loadPublishedSourceSnapshot.mockReset()
+	mockModule.persistPublishedSourceSnapshot.mockReset()
+
+	mockModule.getEntitySourceById.mockResolvedValue(createSourceRow())
+	mockModule.loadPublishedSourceSnapshot.mockResolvedValue(null)
+	mockModule.readMockArtifactSnapshot.mockResolvedValue({
+		published_commit: 'commit-1',
+		files: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/example-package',
+				exports: {
+					'.': './index.js',
+				},
+				kody: {
+					id: 'example-package',
+					description: 'Example package',
+				},
+			}),
+			'index.js': 'export const value = "ok"',
+		},
+	})
+	mockModule.persistPublishedSourceSnapshot.mockResolvedValue(undefined)
+
+	const source = await loadPublishedEntitySource({
+		env: {
+			APP_DB: {},
+			BUNDLE_ARTIFACTS_KV: {},
+		} as Env,
+		userId: 'user-1',
+		sourceId: 'source-1',
+	})
+
+	expect(mockModule.readMockArtifactSnapshot).toHaveBeenCalledTimes(1)
+	expect(mockModule.persistPublishedSourceSnapshot).toHaveBeenCalledWith({
+		env: {
+			APP_DB: {},
+			BUNDLE_ARTIFACTS_KV: {},
+		},
+		userId: 'user-1',
+		source: expect.objectContaining({
+			id: 'source-1',
+		}),
+		snapshot: expect.objectContaining({
+			files: expect.objectContaining({
+				'package.json': expect.any(String),
+			}),
+		}),
+	})
+	expect(source.files).toMatchObject({
+		'index.js': 'export const value = "ok"',
+	})
+})

--- a/packages/worker/src/repo/published-source.ts
+++ b/packages/worker/src/repo/published-source.ts
@@ -1,13 +1,23 @@
 import { getEntitySourceById } from './entity-sources.ts'
 import { readMockArtifactSnapshot } from './artifacts.ts'
 import {
+	loadPublishedSourceManifestSnapshot,
 	loadPublishedSourceSnapshot,
+	persistPublishedSourceManifestSnapshot,
 	persistPublishedSourceSnapshot,
 } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
+import { type AuthoredPackageJson } from '#worker/package-registry/types.ts'
 
 export type PublishedEntitySource = {
 	source: Awaited<ReturnType<typeof getEntitySourceById>>
 	files: Record<string, string>
+}
+
+export type PublishedEntityManifest = {
+	source: Awaited<ReturnType<typeof getEntitySourceById>>
+	manifest: AuthoredPackageJson
+	content: string
 }
 
 function freezeFiles(files: Record<string, string>) {
@@ -37,6 +47,40 @@ async function loadSourceSnapshotFromArtifacts(input: {
 		)
 	}
 	return snapshot.files
+}
+
+function parsePublishedManifest(input: {
+	source: NonNullable<PublishedEntitySource['source']>
+	content: string
+}) {
+	return parseAuthoredPackageJson({
+		content: input.content,
+		manifestPath: input.source.manifest_path,
+	})
+}
+
+async function loadManifestSnapshotFromArtifacts(input: {
+	env: Env
+	source: NonNullable<PublishedEntitySource['source']>
+}) {
+	const publishedCommit = assertPublishedCommit(input.source)
+	const snapshot = await readMockArtifactSnapshot({
+		env: input.env,
+		repoId: input.source.repo_id,
+		commit: publishedCommit,
+	})
+	if (!snapshot) {
+		throw new Error(
+			`Published snapshot for source "${input.source.id}" at commit "${publishedCommit}" was not found.`,
+		)
+	}
+	const content = snapshot.files[input.source.manifest_path]
+	if (!content) {
+		throw new Error(
+			`Published manifest for source "${input.source.id}" at path "${input.source.manifest_path}" was not found.`,
+		)
+	}
+	return content
 }
 
 export async function loadPublishedEntitySource(input: {
@@ -73,5 +117,46 @@ export async function loadPublishedEntitySource(input: {
 	return {
 		source,
 		files: freezeFiles(files),
+	}
+}
+
+export async function loadPublishedEntityManifest(input: {
+	env: Env
+	userId: string
+	sourceId: string
+}): Promise<PublishedEntityManifest> {
+	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
+	if (!source || source.user_id !== input.userId) {
+		throw new Error(`Published source "${input.sourceId}" was not found.`)
+	}
+	assertPublishedCommit(source)
+	const storedManifest = await loadPublishedSourceManifestSnapshot({
+		env: input.env,
+		userId: input.userId,
+		source,
+	})
+	const content =
+		storedManifest?.manifestContent ??
+		(await loadManifestSnapshotFromArtifacts({
+			env: input.env,
+			source,
+		}))
+	if (!storedManifest) {
+		await persistPublishedSourceManifestSnapshot({
+			env: input.env,
+			userId: input.userId,
+			source,
+			snapshot: {
+				manifestContent: content,
+			},
+		})
+	}
+	return {
+		source,
+		content,
+		manifest: parsePublishedManifest({
+			source,
+			content,
+		}),
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- merge the branch onto the latest `main` and resolve the `packages/worker/src/package-registry/source.ts` conflict by rebasing the search/manifest-only improvements onto `main`'s new published-source architecture
- enrich saved package search rows with manifest-derived exports, jobs, and app entry data across MCP search and agent-turn search
- improve action-oriented discovery with richer package/connector search documents and recommended next-step guidance in search results, while keeping the logic connector-agnostic instead of baking production-only connector aliases into code
- address valid review feedback by surfacing fallback package-search warnings, reusing connector query embeddings, tightening combined package+connector guidance to related matches only, correctly propagating per-package fallback warnings through search loaders, restoring a true manifest-only published-source path for the search hot path, and consolidating duplicate source-loader lifecycle logic where appropriate
- stabilize the failing Cloudflare artifacts mock unit test by aligning its test timeout with the mock startup budget
- extend focused tests to cover richer package projections, Spotify-style discovery behavior, fallback warning behavior, warning propagation, published manifest-only loading, and the merged package-source loader behavior

## Testing
- npm exec vitest run --project node-unit packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts
- npm run test -- --run packages/worker/src/repo/published-source.node.test.ts packages/worker/src/package-registry/source.node.test.ts packages/worker/src/mcp/tools/search.node.test.ts packages/worker/src/mcp/tools/search-format.node.test.ts
- npm run typecheck
- npx oxlint packages/worker/src/repo/published-source.ts packages/worker/src/repo/published-source.node.test.ts packages/worker/src/package-registry/source.ts packages/worker/src/package-registry/source.node.test.ts packages/worker/src/mcp/tools/search.ts packages/worker/src/mcp/tools/search.node.test.ts packages/worker/src/mcp/tools/search-format.node.test.ts packages/worker/src/mcp/tools/search-format.ts packages/worker/src/agent-turn/tools.ts packages/worker/src/package-registry/manifest.ts packages/worker/src/package-registry/embed.ts packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9a48d5a-230b-4468-941e-03625c7a3c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9a48d5a-230b-4468-941e-03625c7a3c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search results now display guidance with "Recommended next step" actions for packages and connectors
  * Enhanced connector search with improved keyword matching and relevance scoring

* **Improvements**
  * Better package search accuracy with improved app entry detection
  * More robust handling of package metadata in search results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->