### PR TITLE
Add package realtime websocket primitive

### DIFF
--- a/packages/worker/src/app/handlers/package-app.node.test.ts
+++ b/packages/worker/src/app/handlers/package-app.node.test.ts
@@ -30,6 +30,9 @@ const mockModule = vi.hoisted(() => ({
 	}),
 	createPackageAppCallerContext: vi.fn(),
 	buildPackageAppWorker: vi.fn(),
+	packageRealtimeConnect: vi.fn(
+		async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+	),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -63,6 +66,12 @@ vi.mock('#worker/package-runtime/package-app.ts', () => ({
 		mockModule.buildPackageAppWorker(...args),
 }))
 
+vi.mock('#worker/package-runtime/realtime-session.ts', () => ({
+	packageRealtimeSessionRpc: (..._args: Array<unknown>) => ({
+		connect: (...args: Array<unknown>) => mockModule.packageRealtimeConnect(...args),
+	}),
+}))
+
 const { handlePackageAppRequest } = await import('./package-app.ts')
 
 test('handlePackageAppRequest returns a plain 500 when package app runtime setup fails', async () => {
@@ -73,4 +82,19 @@ test('handlePackageAppRequest returns a plain 500 when package app runtime setup
 
 	expect(response.status).toBe(500)
 	await expect(response.text()).resolves.toBe('Internal Server Error')
+})
+
+test('handlePackageAppRequest routes websocket package paths to realtime session manager', async () => {
+	const request = new Request('https://example.com/packages/example/ws/chat', {
+		headers: {
+			Upgrade: 'websocket',
+		},
+	})
+
+	const response = await handlePackageAppRequest(request, {} as Env)
+
+	expect(response.status).toBe(200)
+	expect(mockModule.packageRealtimeConnect).toHaveBeenCalledTimes(1)
+	expect(mockModule.packageRealtimeConnect).toHaveBeenCalledWith(request, 'chat')
+	expect(mockModule.buildPackageAppWorker).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/app/handlers/package-app.node.test.ts
+++ b/packages/worker/src/app/handlers/package-app.node.test.ts
@@ -113,3 +113,41 @@ test('handlePackageAppRequest routes websocket paths to realtime session manager
 	expect(mockModule.packageRealtimeConnect).toHaveBeenCalledWith(request, 'chat')
 	expect(mockModule.buildPackageAppWorker).not.toHaveBeenCalled()
 })
+
+test('handlePackageAppRequest preserves root forwarding for non-websocket explicitKodyId requests', async () => {
+	mockModule.loadPackageSourceBySourceId.mockResolvedValueOnce({
+		source: {
+			published_commit: 'commit-1',
+			manifest_path: 'package.json',
+			source_root: '/',
+		},
+		files: {
+			'package.json': JSON.stringify({
+				name: '@kody/example',
+				kody: { id: 'example', app: { entry: 'app.js' } },
+			}),
+			'app.js': 'export default {}',
+		},
+	})
+	const entrypointFetch = vi.fn(async (forwardedRequest: Request) => {
+		return Response.json({ pathname: new URL(forwardedRequest.url).pathname })
+	})
+	mockModule.buildPackageAppWorker.mockResolvedValueOnce({
+		entrypointName: 'entry',
+		stub: {
+			getEntrypoint: () => ({
+				fetch: entrypointFetch,
+			}),
+		},
+	})
+
+	const response = await handlePackageAppRequest(
+		new Request('https://example.com/custom/path'),
+		{} as Env,
+		'example',
+	)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toEqual({ pathname: '/' })
+	expect(entrypointFetch).toHaveBeenCalledTimes(1)
+})

--- a/packages/worker/src/app/handlers/package-app.node.test.ts
+++ b/packages/worker/src/app/handlers/package-app.node.test.ts
@@ -98,3 +98,18 @@ test('handlePackageAppRequest routes websocket package paths to realtime session
 	expect(mockModule.packageRealtimeConnect).toHaveBeenCalledWith(request, 'chat')
 	expect(mockModule.buildPackageAppWorker).not.toHaveBeenCalled()
 })
+
+test('handlePackageAppRequest routes websocket paths to realtime session manager when explicitKodyId is provided', async () => {
+	const request = new Request('https://example.com/ws/chat', {
+		headers: {
+			Upgrade: 'websocket',
+		},
+	})
+
+	const response = await handlePackageAppRequest(request, {} as Env, 'example')
+
+	expect(response.status).toBe(200)
+	expect(mockModule.packageRealtimeConnect).toHaveBeenCalledTimes(1)
+	expect(mockModule.packageRealtimeConnect).toHaveBeenCalledWith(request, 'chat')
+	expect(mockModule.buildPackageAppWorker).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -56,8 +56,10 @@ export async function handlePackageAppRequest(
 	if (!kodyId) {
 		return new Response('Saved package app not found.', { status: 404 })
 	}
-	const packageRestPath =
+	const packageRealtimeRestPath =
 		packagePath?.kodyId === kodyId ? packagePath.restPath : requestUrl.pathname || '/'
+	const forwardedPackageRestPath =
+		packagePath?.kodyId === kodyId ? packagePath.restPath : '/'
 	const user = await readAuthenticatedAppUser(request, env)
 	if (!user) {
 		return redirectToLogin(request)
@@ -71,7 +73,7 @@ export async function handlePackageAppRequest(
 	}
 	try {
 		const baseUrl = getAppBaseUrl({ env, requestUrl: request.url })
-		const packageRealtimePath = parsePackageRealtimePath(packageRestPath)
+		const packageRealtimePath = parsePackageRealtimePath(packageRealtimeRestPath)
 		if (packageRealtimePath && request.headers.get('Upgrade') === 'websocket') {
 			return await packageRealtimeSessionRpc({
 				env,
@@ -117,7 +119,7 @@ export async function handlePackageAppRequest(
 		})
 		const entrypoint = appWorker.stub.getEntrypoint(appWorker.entrypointName)
 		const forwardedUrl = new URL(requestUrl)
-		forwardedUrl.pathname = packageRestPath
+		forwardedUrl.pathname = forwardedPackageRestPath
 		const forwardedRequest = new Request(forwardedUrl.toString(), request)
 		return await entrypoint.fetch(forwardedRequest)
 	} catch (error) {

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -50,11 +50,14 @@ export async function handlePackageAppRequest(
 	env: Env,
 	explicitKodyId?: string | null,
 ) {
-	const packagePath = parsePackageAppPath(new URL(request.url).pathname)
+	const requestUrl = new URL(request.url)
+	const packagePath = parsePackageAppPath(requestUrl.pathname)
 	const kodyId = explicitKodyId?.trim() || packagePath?.kodyId || null
 	if (!kodyId) {
 		return new Response('Saved package app not found.', { status: 404 })
 	}
+	const packageRestPath =
+		packagePath?.kodyId === kodyId ? packagePath.restPath : requestUrl.pathname || '/'
 	const user = await readAuthenticatedAppUser(request, env)
 	if (!user) {
 		return redirectToLogin(request)
@@ -68,9 +71,7 @@ export async function handlePackageAppRequest(
 	}
 	try {
 		const baseUrl = getAppBaseUrl({ env, requestUrl: request.url })
-		const packageRealtimePath = parsePackageRealtimePath(
-			packagePath?.restPath ?? '/',
-		)
+		const packageRealtimePath = parsePackageRealtimePath(packageRestPath)
 		if (packageRealtimePath && request.headers.get('Upgrade') === 'websocket') {
 			return await packageRealtimeSessionRpc({
 				env,
@@ -115,13 +116,8 @@ export async function handlePackageAppRequest(
 			},
 		})
 		const entrypoint = appWorker.stub.getEntrypoint(appWorker.entrypointName)
-		const forwardedUrl = new URL(request.url)
-		const resolvedPackagePath = parsePackageAppPath(forwardedUrl.pathname)
-		if (!resolvedPackagePath || resolvedPackagePath.kodyId !== kodyId) {
-			forwardedUrl.pathname = '/'
-		} else {
-			forwardedUrl.pathname = resolvedPackagePath.restPath
-		}
+		const forwardedUrl = new URL(requestUrl)
+		forwardedUrl.pathname = packageRestPath
 		const forwardedRequest = new Request(forwardedUrl.toString(), request)
 		return await entrypoint.fetch(forwardedRequest)
 	} catch (error) {

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -7,6 +7,7 @@ import {
 	buildPackageAppWorker,
 	createPackageAppCallerContext,
 } from '#worker/package-runtime/package-app.ts'
+import { packageRealtimeSessionRpc } from '#worker/package-runtime/realtime-session.ts'
 
 function parsePackageAppPath(pathname: string) {
 	const parts = pathname.split('/').filter(Boolean)
@@ -22,6 +23,25 @@ function parsePackageAppPath(pathname: string) {
 	return {
 		kodyId,
 		restPath: parts.length > 2 ? `/${parts.slice(2).join('/')}` : '/',
+	}
+}
+
+function parsePackageRealtimePath(restPath: string) {
+	const parts = restPath.split('/').filter(Boolean)
+	if (parts[0] !== 'ws') return null
+	if (parts.length > 2) return null
+	const rawFacet = parts[1]?.trim() ?? ''
+	if (!rawFacet) {
+		return {
+			facet: null,
+		}
+	}
+	try {
+		return {
+			facet: decodeURIComponent(rawFacet),
+		}
+	} catch {
+		return null
 	}
 }
 
@@ -48,6 +68,19 @@ export async function handlePackageAppRequest(
 	}
 	try {
 		const baseUrl = getAppBaseUrl({ env, requestUrl: request.url })
+		const packageRealtimePath = parsePackageRealtimePath(
+			packagePath?.restPath ?? '/',
+		)
+		if (packageRealtimePath && request.headers.get('Upgrade') === 'websocket') {
+			return await packageRealtimeSessionRpc({
+				env,
+				userId: user.mcpUser.userId,
+				packageId: savedPackage.id,
+				kodyId: savedPackage.kodyId,
+				sourceId: savedPackage.sourceId,
+				baseUrl,
+			}).connect(request, packageRealtimePath.facet)
+		}
 		const packageSource = await loadPackageSourceBySourceId({
 			env,
 			baseUrl,

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -198,12 +198,15 @@ export const EnvSchema = object({
 	),
 	PACKAGE_REALTIME_SESSION: createSchema<
 		unknown,
-		DurableObjectNamespace | undefined
-	>((value) => {
+		DurableObjectNamespace
+	>((value, context) => {
 		if (value) {
 			return { value: value as DurableObjectNamespace }
 		}
-		return { value: undefined }
+		return fail(
+			'Missing PACKAGE_REALTIME_SESSION binding for package realtime websocket sessions.',
+			context.path,
+		)
 	}),
 	APP_BASE_URL: optionalUrlStringSchema,
 	APP_COMMIT_SHA: optionalCommitShaSchema,

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -196,6 +196,17 @@ export const EnvSchema = object({
 			)
 		},
 	),
+	PACKAGE_REALTIME_SESSION: createSchema<unknown, DurableObjectNamespace>(
+		(value, context) => {
+			if (value) {
+				return { value: value as DurableObjectNamespace }
+			}
+			return fail(
+				'Missing PACKAGE_REALTIME_SESSION binding for package realtime sessions.',
+				context.path,
+			)
+		},
+	),
 	APP_BASE_URL: optionalUrlStringSchema,
 	APP_COMMIT_SHA: optionalCommitShaSchema,
 	CLOUDFLARE_EMAIL_FROM: optionalNonEmptyStringSchema,

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -196,17 +196,15 @@ export const EnvSchema = object({
 			)
 		},
 	),
-	PACKAGE_REALTIME_SESSION: createSchema<unknown, DurableObjectNamespace>(
-		(value, context) => {
-			if (value) {
-				return { value: value as DurableObjectNamespace }
-			}
-			return fail(
-				'Missing PACKAGE_REALTIME_SESSION binding for package realtime sessions.',
-				context.path,
-			)
-		},
-	),
+	PACKAGE_REALTIME_SESSION: createSchema<
+		unknown,
+		DurableObjectNamespace | undefined
+	>((value) => {
+		if (value) {
+			return { value: value as DurableObjectNamespace }
+		}
+		return { value: undefined }
+	}),
 	APP_BASE_URL: optionalUrlStringSchema,
 	APP_COMMIT_SHA: optionalCommitShaSchema,
 	CLOUDFLARE_EMAIL_FROM: optionalNonEmptyStringSchema,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -8,6 +8,7 @@ import { JobManager } from './jobs/manager-do.ts'
 import { StorageRunner } from './storage-runner.ts'
 import { AgentTurnRunner } from './agent-turn/runner-do.ts'
 import { RepoSession } from './repo/repo-session-do.ts'
+import { PackageRealtimeSession } from '#worker/package-runtime/realtime-session.ts'
 import { chatAgentBasePath } from '@kody-internal/shared/chat-routes.ts'
 import { getWorkerSentryOptions } from './sentry-options.ts'
 import { handleRequest } from '#app/handler.ts'
@@ -52,6 +53,7 @@ export {
 	HomeMCP,
 	MCP,
 	JobManager,
+	PackageRealtimeSession,
 	PackageAppRuntimeBridge,
 	StorageRunner,
 }

--- a/packages/worker/src/mcp/capabilities/apps/apps-domain.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/apps/apps-domain.node.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest'
+
+test('builtin capability domains include apps realtime capabilities', async () => {
+	const { builtinDomains } = await import('#mcp/capabilities/builtin-domains.ts')
+	const appsDomain = builtinDomains.find((domain) => domain.name === 'apps')
+	expect(appsDomain).toBeTruthy()
+	expect(appsDomain?.capabilities.map((capability) => capability.name)).toEqual(
+		expect.arrayContaining([
+			'session_emit',
+			'session_broadcast',
+			'session_list',
+		]),
+	)
+})

--- a/packages/worker/src/mcp/capabilities/apps/domain.ts
+++ b/packages/worker/src/mcp/capabilities/apps/domain.ts
@@ -1,0 +1,17 @@
+import { defineDomain } from '../define-domain.ts'
+import { capabilityDomainNames } from '../domain-metadata.ts'
+import { sessionBroadcastCapability } from './session-broadcast.ts'
+import { sessionEmitCapability } from './session-emit.ts'
+import { sessionListCapability } from './session-list.ts'
+
+export const appsDomain = defineDomain({
+	name: capabilityDomainNames.apps,
+	description:
+		'Hosted app runtime capabilities such as realtime session inspection and websocket event delivery for package apps.',
+	keywords: ['app', 'package app', 'realtime', 'websocket', 'session'],
+	capabilities: [
+		sessionEmitCapability,
+		sessionBroadcastCapability,
+		sessionListCapability,
+	],
+})

--- a/packages/worker/src/mcp/capabilities/apps/session-broadcast.ts
+++ b/packages/worker/src/mcp/capabilities/apps/session-broadcast.ts
@@ -1,19 +1,10 @@
-import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { requirePackageRealtimeContext } from './shared.ts'
-
-const inputSchema = z.object({
-	data: z.unknown(),
-	topic: z.string().min(1).optional(),
-	facet: z.string().min(1).optional(),
-	package_id: z.string().min(1).optional(),
-})
-
-const outputSchema = z.object({
-	delivered_count: z.number(),
-	session_ids: z.array(z.string()),
-})
+import {
+	requirePackageRealtimeContext,
+	sessionBroadcastInputSchema,
+	sessionBroadcastOutputSchema,
+} from './shared.ts'
 
 export const sessionBroadcastCapability = defineDomainCapability(
 	capabilityDomainNames.apps,
@@ -25,8 +16,8 @@ export const sessionBroadcastCapability = defineDomainCapability(
 		readOnly: false,
 		idempotent: false,
 		destructive: false,
-		inputSchema,
-		outputSchema,
+		inputSchema: sessionBroadcastInputSchema,
+		outputSchema: sessionBroadcastOutputSchema,
 		async handler(args, ctx) {
 			const realtime = await requirePackageRealtimeContext({
 				env: ctx.env,

--- a/packages/worker/src/mcp/capabilities/apps/session-broadcast.ts
+++ b/packages/worker/src/mcp/capabilities/apps/session-broadcast.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requirePackageRealtimeContext } from './shared.ts'
+
+const inputSchema = z.object({
+	data: z.unknown(),
+	topic: z.string().min(1).optional(),
+	facet: z.string().min(1).optional(),
+	package_id: z.string().min(1).optional(),
+})
+
+const outputSchema = z.object({
+	delivered_count: z.number(),
+	session_ids: z.array(z.string()),
+})
+
+export const sessionBroadcastCapability = defineDomainCapability(
+	capabilityDomainNames.apps,
+	{
+		name: 'session_broadcast',
+		description:
+			'Broadcast a realtime websocket event to connected package app sessions, optionally scoped by facet or topic.',
+		keywords: ['apps', 'websocket', 'realtime', 'session', 'broadcast'],
+		readOnly: false,
+		idempotent: false,
+		destructive: false,
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			const realtime = await requirePackageRealtimeContext({
+				env: ctx.env,
+				callerContext: ctx.callerContext,
+				explicitPackageId: args.package_id,
+			})
+			const result = await realtime.realtime.broadcast({
+				data: args.data,
+				topic: args.topic ?? null,
+				facet: args.facet ?? null,
+			})
+			const normalizedResult =
+				result && typeof result === 'object'
+					? (result as {
+							deliveredCount?: number
+							sessionIds?: Array<unknown>
+						})
+					: null
+			return {
+				delivered_count:
+					typeof normalizedResult?.deliveredCount === 'number'
+						? normalizedResult.deliveredCount
+						: 0,
+				session_ids: Array.isArray(normalizedResult?.sessionIds)
+					? normalizedResult.sessionIds.filter(
+							(value): value is string =>
+								typeof value === 'string' && value.trim().length > 0,
+						)
+					: [],
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/apps/session-emit.ts
+++ b/packages/worker/src/mcp/capabilities/apps/session-emit.ts
@@ -1,0 +1,37 @@
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	requirePackageRealtimeContext,
+	sessionEmitInputSchema,
+	sessionEmitOutputSchema,
+} from './shared.ts'
+
+export const sessionEmitCapability = defineDomainCapability(
+	capabilityDomainNames.apps,
+	{
+		name: 'session_emit',
+		description:
+			'Send one websocket event to one active package realtime session.',
+		keywords: ['session', 'websocket', 'emit', 'realtime', 'app'],
+		readOnly: false,
+		idempotent: false,
+		destructive: false,
+		inputSchema: sessionEmitInputSchema,
+		outputSchema: sessionEmitOutputSchema,
+		async handler(args, ctx) {
+			const realtimeContext = await requirePackageRealtimeContext({
+				env: ctx.env,
+				callerContext: ctx.callerContext,
+				explicitPackageId: args.package_id,
+			})
+			const result = await realtimeContext.realtime.emit(
+				args.session_id,
+				args.data,
+			)
+			return {
+				delivered: result?.delivered === true,
+				...(typeof result?.reason === 'string' ? { reason: result.reason } : {}),
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/apps/session-list.ts
+++ b/packages/worker/src/mcp/capabilities/apps/session-list.ts
@@ -1,0 +1,50 @@
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requirePackageRealtimeContext, packageRealtimeSessionRecordSchema } from './shared.ts'
+import { z } from 'zod'
+
+const inputSchema = z.object({
+	facet: z.string().min(1).optional(),
+	topic: z.string().min(1).optional(),
+	package_id: z.string().min(1).optional(),
+})
+
+const outputSchema = z.object({
+	package_id: z.string(),
+	kody_id: z.string(),
+	sessions: z.array(packageRealtimeSessionRecordSchema),
+})
+
+export const sessionListCapability = defineDomainCapability(
+	capabilityDomainNames.apps,
+	{
+		name: 'session_list',
+		description:
+			'List active websocket sessions for a package app, optionally filtered by facet or subscribed topic.',
+		keywords: ['app', 'websocket', 'session', 'list', 'facet', 'topic'],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			const realtimeContext = await requirePackageRealtimeContext({
+				env: ctx.env,
+				callerContext: ctx.callerContext,
+				explicitPackageId: args.package_id,
+			})
+			const result = await realtimeContext.realtime.listSessions({
+				facet: args.facet ?? null,
+				topic: args.topic ?? null,
+			})
+			const sessions = Array.isArray(result?.sessions)
+				? result.sessions
+				: []
+			return {
+				package_id: realtimeContext.savedPackage.id,
+				kody_id: realtimeContext.savedPackage.kodyId,
+				sessions,
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/apps/shared.ts
+++ b/packages/worker/src/mcp/capabilities/apps/shared.ts
@@ -11,21 +11,6 @@ export const packageRealtimeSessionRecordSchema = z.object({
 	last_seen_at: z.string(),
 })
 
-export const packageRealtimeTargetSchema = z.object({
-	package_id: z
-		.string()
-		.min(1)
-		.optional()
-		.describe(
-			'Optional saved package id. Defaults to the caller package app/job when available.',
-		),
-	facet: z
-		.string()
-		.min(1)
-		.optional()
-		.describe('Optional facet name. Defaults to "main".'),
-})
-
 export const sessionEmitInputSchema = z.object({
 	session_id: z.string().min(1),
 	data: z.unknown(),
@@ -45,9 +30,6 @@ export const sessionBroadcastInputSchema = z.object({
 })
 
 export const sessionBroadcastOutputSchema = z.object({
-	ok: z.literal(true),
-	package_id: z.string(),
-	kody_id: z.string(),
 	delivered_count: z.number(),
 	session_ids: z.array(z.string()),
 })

--- a/packages/worker/src/mcp/capabilities/apps/shared.ts
+++ b/packages/worker/src/mcp/capabilities/apps/shared.ts
@@ -1,0 +1,124 @@
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { z } from 'zod'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { getSavedPackageById } from '#worker/package-registry/repo.ts'
+
+export const packageRealtimeSessionRecordSchema = z.object({
+	session_id: z.string(),
+	facet: z.string(),
+	topics: z.array(z.string()),
+	connected_at: z.string(),
+	last_seen_at: z.string(),
+})
+
+export const packageRealtimeTargetSchema = z.object({
+	package_id: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			'Optional saved package id. Defaults to the caller package app/job when available.',
+		),
+	facet: z
+		.string()
+		.min(1)
+		.optional()
+		.describe('Optional facet name. Defaults to "main".'),
+})
+
+export const sessionEmitInputSchema = z.object({
+	session_id: z.string().min(1),
+	data: z.unknown(),
+	package_id: z.string().min(1).optional(),
+})
+
+export const sessionEmitOutputSchema = z.object({
+	delivered: z.boolean(),
+	reason: z.string().optional(),
+})
+
+export const sessionBroadcastInputSchema = z.object({
+	data: z.unknown(),
+	topic: z.string().min(1).optional(),
+	facet: z.string().min(1).optional(),
+	package_id: z.string().min(1).optional(),
+})
+
+export const sessionBroadcastOutputSchema = z.object({
+	ok: z.literal(true),
+	package_id: z.string(),
+	kody_id: z.string(),
+	delivered_count: z.number(),
+	session_ids: z.array(z.string()),
+})
+
+export type PackageRealtimeContext = {
+	user: ReturnType<typeof requireMcpUser>
+	savedPackage: NonNullable<
+		Awaited<ReturnType<typeof getSavedPackageById>>
+	>
+	realtime: Awaited<ReturnType<typeof createPackageRealtimeClient>>
+}
+
+function resolvePackageId(
+	callerContext: McpCallerContext,
+	explicitPackageId?: string | null,
+) {
+	const normalizedExplicit =
+		typeof explicitPackageId === 'string' ? explicitPackageId.trim() : ''
+	if (normalizedExplicit) {
+		return normalizedExplicit
+	}
+	const appId = callerContext.storageContext?.appId?.trim() || ''
+	if (appId) {
+		return appId
+	}
+	throw new Error(
+		'Package realtime APIs require package app or package job caller context.',
+	)
+}
+
+export async function requirePackageRealtimeContext(input: {
+	env: Env
+	callerContext: McpCallerContext
+	explicitPackageId?: string | null
+}): Promise<PackageRealtimeContext> {
+	const user = requireMcpUser(input.callerContext)
+	const packageId = resolvePackageId(
+		input.callerContext,
+		input.explicitPackageId,
+	)
+	const savedPackage = await getSavedPackageById(input.env.APP_DB, {
+		userId: user.userId,
+		packageId,
+	})
+	if (!savedPackage || !savedPackage.hasApp) {
+		throw new Error('Saved package app was not found for realtime operations.')
+	}
+	return {
+		user,
+		savedPackage,
+		realtime: await createPackageRealtimeClient({
+			env: input.env,
+			userId: user.userId,
+			packageId: savedPackage.id,
+			kodyId: savedPackage.kodyId,
+			sourceId: savedPackage.sourceId,
+			baseUrl: input.callerContext.baseUrl,
+		}),
+	}
+}
+
+async function createPackageRealtimeClient(input: {
+	env: Env
+	userId: string
+	packageId: string
+	kodyId: string
+	sourceId: string
+	baseUrl: string
+}) {
+	const { packageRealtimeSessionRpc } = await import(
+		'#worker/package-runtime/realtime-session.ts'
+	)
+	return packageRealtimeSessionRpc(input)
+}

--- a/packages/worker/src/mcp/capabilities/builtin-domains.ts
+++ b/packages/worker/src/mcp/capabilities/builtin-domains.ts
@@ -1,3 +1,4 @@
+import { appsDomain } from './apps/domain.ts'
 import { codingDomain } from './coding/domain.ts'
 import { jobsDomain } from './jobs/domain.ts'
 import { metaDomain } from './meta/domain.ts'
@@ -16,6 +17,7 @@ import { valuesDomain } from './values/domain.ts'
  * (Workers typically snapshot capabilities at deploy time).
  */
 export const builtinDomains = [
+	appsDomain,
 	codingDomain,
 	jobsDomain,
 	metaDomain,

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -28,6 +28,7 @@ Conventions
 - \`job_schedule_once\`: compatibility wrapper for one-off repo-backed jobs when you only need a single run time.
 - \`job_run_now\`: run an existing scheduled job immediately by id and return the updated job view plus execution result for debugging.
 - Package jobs are schedules owned by a package. For ad hoc work that is not tied to a package, use \`job_schedule\`. Package apps are optional UI surfaces declared by the package, not a separate top-level primitive.
+- Package apps can also use Kody-managed realtime websocket sessions through \`session_list\`, \`session_emit\`, and \`session_broadcast\`, and package jobs can emit to those sessions when running under the same package caller context.
 - Memory writes are verify-first: always run \`meta_memory_verify\` before \`meta_memory_upsert\` or \`meta_memory_delete\`. Kody retrieves related memories; the consuming agent decides whether to upsert, delete, both, or do nothing. \`meta_memory_upsert\` creates a new memory when \`memory_id\` is omitted and updates an existing memory when \`memory_id\` is provided.
 - User-specific MCP instructions: \`meta_get_mcp_server_instructions\` / \`meta_set_mcp_server_instructions\` (signed-in users). Updates apply to **new** MCP sessions (reconnect to refresh what the host shows).
 

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -109,6 +109,7 @@ function createEnv(
 		COOKIE_SECRET: cookieSecretValue,
 		JOB_MANAGER: mockJobDoNamespace('job-manager-test-id'),
 		STORAGE_RUNNER: mockJobDoNamespace('storage-runner-test-id'),
+		PACKAGE_REALTIME_SESSION: mockJobDoNamespace('package-realtime-session-test-id'),
 	} as unknown as Env
 }
 

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -20,6 +20,7 @@ import {
 	writePublishedBundleArtifact,
 } from './published-runtime-artifacts.ts'
 import { storageRunnerRpc } from '#worker/storage-runner.ts'
+import { packageRealtimeSessionRpc } from './realtime-session.ts'
 
 const packageAppEntrypointName = 'PackageAppWorker'
 const packageAppRuntimeBindingName = 'KODY_RUNTIME'
@@ -27,6 +28,30 @@ const packageAppRuntimeBindingName = 'KODY_RUNTIME'
 function createPackageAppWorkerSource(input: { mainModule: string }) {
 	return `
 import { DurableObject, WorkerEntrypoint } from 'cloudflare:workers';
+
+function buildFacetName(rawFacetName) {
+	return typeof rawFacetName === 'string' && rawFacetName.trim().length > 0
+		? rawFacetName.trim()
+		: 'main';
+}
+
+function fnv1a32(input) {
+	let hash = 2166136261;
+	for (let i = 0; i < input.length; i += 1) {
+		hash ^= input.charCodeAt(i);
+		hash = Math.imul(hash, 16777619);
+	}
+	return hash >>> 0;
+}
+
+function buildFacetClassExportName(rawFacetName) {
+	const canonicalName = buildFacetName(rawFacetName);
+	const sanitizedFacetName = canonicalName.replace(/[^a-zA-Z0-9_]/g, '_');
+	const hashSuffix = fnv1a32(canonicalName).toString(16).padStart(8, '0');
+	return canonicalName === 'main'
+		? 'App'
+		: \`App_\${sanitizedFacetName}_\${hashSuffix}\`;
+}
 
 function createCodemodeProxy(runtimeBridge) {
 	return new Proxy({}, {
@@ -129,6 +154,33 @@ function createAgentChatTurnStream(runtimeBridge) {
 			}
 		}
 	}
+}
+
+function createRealtimeProxy(runtimeBridge) {
+	return {
+		emit: async (sessionId, data) =>
+			await runtimeBridge.realtimeEmit({
+				sessionId,
+				data,
+			}),
+		broadcast: async (input = {}) =>
+			await runtimeBridge.realtimeBroadcast({
+				data: input.data,
+				topic: input.topic,
+				facet: input.facet,
+			}),
+		listSessions: async (input = {}) =>
+			await runtimeBridge.realtimeListSessions({
+				topic: input.topic,
+				facet: input.facet,
+			}),
+		disconnect: async (sessionId, input = {}) =>
+			await runtimeBridge.realtimeDisconnect({
+				sessionId,
+				code: input.code,
+				reason: input.reason,
+			}),
+	};
 }
 
 function createAuthenticatedFetchHelper(runtimeBridge) {
@@ -263,8 +315,44 @@ function createRuntime(runtimeBridge, params, packageContext) {
 			await runtimeBridge.refreshAccessToken(providerName),
 		createAuthenticatedFetch: createAuthenticatedFetchHelper(runtimeBridge),
 		agentChatTurnStream: createAgentChatTurnStream(runtimeBridge),
+		realtime: createRealtimeProxy(runtimeBridge),
 		packageContext,
 	};
+}
+
+function createFacetStorageId(packageContext, facetName) {
+	const packageId = packageContext?.packageId ?? 'package';
+	return \`\${packageId}:facet:\${buildFacetName(facetName)}\`;
+}
+
+function resolveRealtimeHandler(userModule, facetName) {
+	const facetExportName = buildFacetClassExportName(facetName);
+	if (typeof userModule[facetExportName] === 'function') {
+		return {
+			kind: 'class',
+			exported: userModule[facetExportName],
+		};
+	}
+	if (typeof userModule.handleRealtimeEvent === 'function') {
+		return {
+			kind: 'function',
+			exported: userModule.handleRealtimeEvent,
+		};
+	}
+	const candidate = userModule.default ?? userModule;
+	if (candidate && typeof candidate.onRealtimeEvent === 'function') {
+		return {
+			kind: 'bound-method',
+			exported: candidate,
+		};
+	}
+	if (typeof candidate === 'function' && typeof candidate.prototype?.onRealtimeEvent === 'function') {
+		return {
+			kind: 'class',
+			exported: candidate,
+		};
+	}
+	return null;
 }
 
 export class ${packageAppEntrypointName} extends WorkerEntrypoint {
@@ -294,6 +382,43 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 			else globalThis.__kodyRuntime = previousRuntime;
 		}
 	}
+
+	async handleRealtimeEvent(payload) {
+		const previousRuntime = globalThis.__kodyRuntime;
+		globalThis.__kodyRuntime = createRuntime(
+			this.env.${packageAppRuntimeBindingName},
+			this.env.__kodyRuntimeParams ?? null,
+			this.env.__kodyPackageContext ?? null,
+		);
+		try {
+			const userModule = await import(${JSON.stringify(`./${input.mainModule}`)});
+			const runtimeEnv = createPackageAppEnv(this.env, userModule);
+			const resolved = resolveRealtimeHandler(userModule, payload?.facet);
+			if (!resolved) {
+				return { actions: [] };
+			}
+			if (resolved.kind === 'function') {
+				return await resolved.exported(payload, runtimeEnv, this.ctx);
+			}
+			if (resolved.kind === 'bound-method') {
+				return await resolved.exported.onRealtimeEvent(payload, runtimeEnv, this.ctx);
+			}
+			const state = createInternalDurableObjectState(
+				this.env.${packageAppRuntimeBindingName},
+				createFacetStorageId(this.env.__kodyPackageContext ?? null, payload?.facet),
+			);
+			const instance = Object.create(resolved.exported.prototype);
+			instance.ctx = state;
+			instance.env = runtimeEnv;
+			if (typeof instance.onRealtimeEvent !== 'function') {
+				throw new Error(\`Package app facet "\${buildFacetName(payload?.facet)}" must implement onRealtimeEvent().\`);
+			}
+			return await instance.onRealtimeEvent(payload, runtimeEnv, this.ctx);
+		} finally {
+			if (previousRuntime === undefined) delete globalThis.__kodyRuntime;
+			else globalThis.__kodyRuntime = previousRuntime;
+		}
+	}
 }
 `.trim()
 }
@@ -305,6 +430,7 @@ type PackageAppRuntimeBridgeProps = {
 	displayName: string
 	packageId: string
 	kodyId: string
+	sourceId: string
 }
 
 export class PackageAppRuntimeBridge extends WorkerEntrypoint<
@@ -332,6 +458,17 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 			env: this.env,
 			userId: this.ctx.props.userId,
 			storageId,
+		})
+	}
+
+	private getRealtimeSessionRpc() {
+		return packageRealtimeSessionRpc({
+			env: this.env,
+			userId: this.ctx.props.userId,
+			packageId: this.ctx.props.packageId,
+			kodyId: this.ctx.props.kodyId,
+			sourceId: this.ctx.props.sourceId,
+			baseUrl: this.ctx.props.baseUrl,
 		})
 	}
 
@@ -498,6 +635,39 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 			body: input.request.body,
 		})
 	}
+
+	async realtimeEmit(input: {
+		sessionId: string
+		data: unknown
+	}) {
+		return await this.getRealtimeSessionRpc().emit(input.sessionId, input.data)
+	}
+
+	async realtimeBroadcast(input: {
+		data: unknown
+		topic?: string | null
+		facet?: string | null
+	}) {
+		return await this.getRealtimeSessionRpc().broadcast(input)
+	}
+
+	async realtimeListSessions(input?: {
+		topic?: string | null
+		facet?: string | null
+	}) {
+		return await this.getRealtimeSessionRpc().listSessions(input)
+	}
+
+	async realtimeDisconnect(input: {
+		sessionId: string
+		code?: number | null
+		reason?: string | null
+	}) {
+		return await this.getRealtimeSessionRpc().disconnect(input.sessionId, {
+			code: input.code ?? undefined,
+			reason: input.reason ?? undefined,
+		})
+	}
 }
 
 export async function buildPackageAppWorker(input: {
@@ -611,6 +781,7 @@ export async function buildPackageAppWorker(input: {
 							`package:${input.savedPackage.id}`,
 						packageId: input.savedPackage.id,
 						kodyId: input.savedPackage.kodyId,
+						sourceId: input.savedPackage.sourceId,
 					},
 				}),
 				__kodyRuntimeParams: input.params ?? null,

--- a/packages/worker/src/package-runtime/realtime-session.node.test.ts
+++ b/packages/worker/src/package-runtime/realtime-session.node.test.ts
@@ -126,6 +126,19 @@ test('resolvePackageAppWorkerCacheKey falls back to current source state when pu
 
 test('resolvePackageAppWorkerCacheKey can skip source refresh and reuse cached binding identity', async () => {
 	mockModule.getEntitySourceById.mockReset()
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'repo-1',
+		published_commit: 'commit-2',
+		indexed_commit: 'commit-2',
+		manifest_path: 'package.json',
+		source_root: '/',
+		created_at: '2026-04-20T00:00:00.000Z',
+		updated_at: '2026-04-20T00:00:00.000Z',
+	})
 
 	const cacheKey = await resolvePackageAppWorkerCacheKey({
 		env: {
@@ -138,8 +151,6 @@ test('resolvePackageAppWorkerCacheKey can skip source refresh and reuse cached b
 			sourceId: 'source-1',
 			baseUrl: 'https://example.com',
 		},
-		publishedCommit: 'commit-2',
-		skipSourceRefresh: true,
 	})
 
 	expect(cacheKey).toBe(
@@ -151,7 +162,7 @@ test('resolvePackageAppWorkerCacheKey can skip source refresh and reuse cached b
 			'commit-2',
 		]),
 	)
-	expect(mockModule.getEntitySourceById).not.toHaveBeenCalled()
+	expect(mockModule.getEntitySourceById).toHaveBeenCalledTimes(1)
 })
 
 test('PackageRealtimeSession is exported for runtime consumers', () => {

--- a/packages/worker/src/package-runtime/realtime-session.node.test.ts
+++ b/packages/worker/src/package-runtime/realtime-session.node.test.ts
@@ -124,6 +124,36 @@ test('resolvePackageAppWorkerCacheKey falls back to current source state when pu
 	)
 })
 
+test('resolvePackageAppWorkerCacheKey can skip source refresh and reuse cached binding identity', async () => {
+	mockModule.getEntitySourceById.mockReset()
+
+	const cacheKey = await resolvePackageAppWorkerCacheKey({
+		env: {
+			APP_DB: {} as D1Database,
+		} as Env,
+		binding: {
+			userId: 'user-1',
+			packageId: 'package-1',
+			kodyId: 'example',
+			sourceId: 'source-1',
+			baseUrl: 'https://example.com',
+		},
+		publishedCommit: 'commit-2',
+		skipSourceRefresh: true,
+	})
+
+	expect(cacheKey).toBe(
+		JSON.stringify([
+			'user-1',
+			'package-1',
+			'source-1',
+			'https://example.com',
+			'commit-2',
+		]),
+	)
+	expect(mockModule.getEntitySourceById).not.toHaveBeenCalled()
+})
+
 test('PackageRealtimeSession is exported for runtime consumers', () => {
 	expect(PackageRealtimeSession).toBeDefined()
 })

--- a/packages/worker/src/package-runtime/realtime-session.node.test.ts
+++ b/packages/worker/src/package-runtime/realtime-session.node.test.ts
@@ -1,12 +1,41 @@
 import { expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
+	buildPackageAppWorker: vi.fn(),
+	createMcpCallerContext: vi.fn(),
+	buildFacetName: vi.fn((value?: string | null) => value ?? 'default'),
+	getSavedPackageById: vi.fn(),
 	getEntitySourceById: vi.fn(),
+	loadPackageSourceBySourceId: vi.fn(),
+}))
+
+vi.mock('#mcp/context.ts', () => ({
+	createMcpCallerContext: (...args: Array<unknown>) =>
+		mockModule.createMcpCallerContext(...args),
+}))
+
+vi.mock('#mcp/app-runner-facet-names.ts', () => ({
+	buildFacetName: (...args: Array<unknown>) => mockModule.buildFacetName(...args),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
 }))
 
 vi.mock('#worker/repo/entity-sources.ts', () => ({
 	getEntitySourceById: (...args: Array<unknown>) =>
 		mockModule.getEntitySourceById(...args),
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
+		mockModule.loadPackageSourceBySourceId(...args),
+}))
+
+vi.mock('./package-app.ts', () => ({
+	buildPackageAppWorker: (...args: Array<unknown>) =>
+		mockModule.buildPackageAppWorker(...args),
 }))
 
 const {

--- a/packages/worker/src/package-runtime/realtime-session.node.test.ts
+++ b/packages/worker/src/package-runtime/realtime-session.node.test.ts
@@ -1,0 +1,100 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getEntitySourceById: vi.fn(),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+}))
+
+const {
+	PackageRealtimeSession,
+	resolvePackageAppWorkerCacheKey,
+} = await import('./realtime-session.ts')
+
+test('resolvePackageAppWorkerCacheKey includes latest published commit when available', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'repo-1',
+		published_commit: 'commit-2',
+		indexed_commit: 'commit-2',
+		manifest_path: 'package.json',
+		source_root: '/',
+		created_at: '2026-04-20T00:00:00.000Z',
+		updated_at: '2026-04-20T00:00:00.000Z',
+	})
+
+	const cacheKey = await resolvePackageAppWorkerCacheKey({
+		env: {
+			APP_DB: {} as D1Database,
+		} as Env,
+		binding: {
+			userId: 'user-1',
+			packageId: 'package-1',
+			kodyId: 'example',
+			sourceId: 'source-1',
+			baseUrl: 'https://example.com',
+		},
+	})
+
+	expect(cacheKey).toBe(
+		JSON.stringify([
+			'user-1',
+			'package-1',
+			'source-1',
+			'https://example.com',
+			'commit-2',
+		]),
+	)
+	expect(mockModule.getEntitySourceById).toHaveBeenCalledWith({}, 'source-1')
+})
+
+test('resolvePackageAppWorkerCacheKey falls back to current source state when published commit is unavailable', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'repo-1',
+		published_commit: null,
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		created_at: '2026-04-20T00:00:00.000Z',
+		updated_at: '2026-04-20T00:00:00.000Z',
+	})
+
+	const cacheKey = await resolvePackageAppWorkerCacheKey({
+		env: {
+			APP_DB: {} as D1Database,
+		} as Env,
+		binding: {
+			userId: 'user-1',
+			packageId: 'package-1',
+			kodyId: 'example',
+			sourceId: 'source-1',
+			baseUrl: 'https://example.com',
+		},
+	})
+
+	expect(cacheKey).toBe(
+		JSON.stringify([
+			'user-1',
+			'package-1',
+			'source-1',
+			'https://example.com',
+			null,
+		]),
+	)
+})
+
+test('PackageRealtimeSession is exported for runtime consumers', () => {
+	expect(PackageRealtimeSession).toBeDefined()
+})

--- a/packages/worker/src/package-runtime/realtime-session.node.test.ts
+++ b/packages/worker/src/package-runtime/realtime-session.node.test.ts
@@ -3,7 +3,7 @@ import { expect, test, vi } from 'vitest'
 const mockModule = vi.hoisted(() => ({
 	buildPackageAppWorker: vi.fn(),
 	createMcpCallerContext: vi.fn(),
-	buildFacetName: vi.fn((value?: string | null) => value ?? 'default'),
+	buildFacetName: vi.fn((value?: string | null) => value?.trim() || 'main'),
 	getSavedPackageById: vi.fn(),
 	getEntitySourceById: vi.fn(),
 	loadPackageSourceBySourceId: vi.fn(),

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -677,6 +677,14 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		})
 	}
 
+	webSocketError(ws: WebSocket, error: unknown): void | Promise<void> {
+		return this.handleDisconnect(ws, {
+			code: 1011,
+			reason: error instanceof Error ? error.message : String(error ?? 'error'),
+			wasClean: false,
+		})
+	}
+
 	private async handleWebSocketMessage(
 		ws: WebSocket,
 		message: string | ArrayBuffer,

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -9,6 +9,9 @@ import { buildPackageAppWorker } from './package-app.ts'
 const sessionStateStorageKey = 'package-realtime-state'
 const sessionTagPrefix = 'session:'
 const facetTagPrefix = 'facet:'
+// Refresh source-version lookups periodically so long-lived sessions can pick up
+// publishes without paying a D1 round trip on every websocket event.
+const packageAppWorkerCacheKeyRefreshMs = 5_000
 
 type PersistedPackageRealtimeSession = {
 	id: string
@@ -278,6 +281,17 @@ function createSessionOutput(
 	}
 }
 
+function createPackageAppWorkerBindingIdentity(
+	binding: PackageRealtimeBindingState,
+) {
+	return JSON.stringify([
+		binding.userId,
+		binding.packageId,
+		binding.sourceId,
+		binding.baseUrl,
+	])
+}
+
 async function resolvePackageAppWorker(input: {
 	env: Env
 	binding: PackageRealtimeBindingState
@@ -350,6 +364,13 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 	private stateSnapshot: PackageRealtimeState = createInitialState()
 	private sessionIds = new WeakMap<WebSocket, string | null>()
 	private cachedAppWorkerKey: string | null = null
+	private cachedAppWorkerKeyLookup:
+		| {
+				bindingIdentity: string
+				cacheKey: string
+				expiresAt: number
+		  }
+		| null = null
 	private cachedAppWorkerPromise: Promise<
 		Awaited<ReturnType<typeof buildPackageAppWorker>>
 	> | null = null
@@ -403,10 +424,7 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 	}
 
 	private async getCachedPackageAppWorker(binding: PackageRealtimeBindingState) {
-		const cacheKey = await resolvePackageAppWorkerCacheKey({
-			env: this.env,
-			binding,
-		})
+		const cacheKey = await this.getResolvedPackageAppWorkerCacheKey(binding)
 		if (this.cachedAppWorkerKey !== cacheKey || !this.cachedAppWorkerPromise) {
 			this.cachedAppWorkerKey = cacheKey
 			this.cachedAppWorkerPromise = resolvePackageAppWorker({
@@ -421,6 +439,31 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 			})
 		}
 		return await this.cachedAppWorkerPromise
+	}
+
+	private async getResolvedPackageAppWorkerCacheKey(
+		binding: PackageRealtimeBindingState,
+	) {
+		const bindingIdentity = createPackageAppWorkerBindingIdentity(binding)
+		const cachedLookup = this.cachedAppWorkerKeyLookup
+		const now = Date.now()
+		if (
+			cachedLookup &&
+			cachedLookup.bindingIdentity === bindingIdentity &&
+			cachedLookup.expiresAt > now
+		) {
+			return cachedLookup.cacheKey
+		}
+		const cacheKey = await resolvePackageAppWorkerCacheKey({
+			env: this.env,
+			binding,
+		})
+		this.cachedAppWorkerKeyLookup = {
+			bindingIdentity,
+			cacheKey,
+			expiresAt: now + packageAppWorkerCacheKeyRefreshMs,
+		}
+		return cacheKey
 	}
 
 	private stashSessionId(ws: WebSocket, sessionId: string) {
@@ -582,7 +625,11 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 				case 'close': {
 					const socket = this.getSocketBySessionId(sessionId)
 					if (socket) {
-						socket.close(action.code ?? 1000, action.reason ?? 'closed')
+						try {
+							socket.close(action.code ?? 1000, action.reason ?? 'closed')
+						} catch {
+							// Ignore duplicate close attempts on sockets that are already closing.
+						}
 					}
 					break
 				}

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -392,6 +392,12 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 			this.cachedAppWorkerPromise = resolvePackageAppWorker({
 				env: this.env,
 				binding,
+			}).catch((error) => {
+				if (this.cachedAppWorkerKey === cacheKey) {
+					this.cachedAppWorkerKey = null
+					this.cachedAppWorkerPromise = null
+				}
+				throw error
 			})
 		}
 		return await this.cachedAppWorkerPromise

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -38,6 +38,14 @@ type PackageRealtimeSessionRecord = {
 	lastSeenAt: string
 }
 
+type PackageRealtimeSessionOutput = {
+	session_id: string
+	facet: string
+	topics: Array<string>
+	connected_at: string
+	last_seen_at: string
+}
+
 export type PackageRealtimeEmitResult = {
 	delivered: boolean
 	reason?: string
@@ -49,13 +57,7 @@ export type PackageRealtimeBroadcastResult = {
 }
 
 export type PackageRealtimeListResult = {
-	sessions: Array<{
-		session_id: string
-		facet: string
-		topics: Array<string>
-		connected_at: string
-		last_seen_at: string
-	}>
+	sessions: Array<PackageRealtimeSessionOutput>
 }
 
 type PackageRealtimeEventRequestInfo = {
@@ -263,6 +265,18 @@ function createSessionRecord(
 	}
 }
 
+function createSessionOutput(
+	session: PersistedPackageRealtimeSession,
+): PackageRealtimeSessionOutput {
+	return {
+		session_id: session.id,
+		facet: session.facet,
+		topics: [...session.topics],
+		connected_at: session.connectedAt,
+		last_seen_at: session.lastSeenAt,
+	}
+}
+
 async function resolvePackageAppWorker(input: {
 	env: Env
 	binding: PackageRealtimeBindingState
@@ -320,7 +334,9 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env)
-		void this.restoreState()
+		this.ctx.blockConcurrencyWhile(async () => {
+			await this.restoreState()
+		})
 	}
 
 	private async restoreState() {
@@ -393,7 +409,7 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 	private listSessions(input?: {
 		facet?: string | null
 		topic?: string | null
-	}): Array<PackageRealtimeSessionRecord> {
+	}): Array<PackageRealtimeSessionOutput> {
 		const facet = buildFacetName(input?.facet)
 		const topic = pickString(input?.topic)
 		return Object.values(this.stateSnapshot.sessions)
@@ -402,7 +418,7 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 				if (topic && !session.topics.includes(topic)) return false
 				return this.getSocketBySessionId(session.id) != null
 			})
-			.map(createSessionRecord)
+			.map(createSessionOutput)
 	}
 
 	private async emitToSession(sessionId: string, data: unknown) {
@@ -429,14 +445,17 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		})
 		let deliveredCount = 0
 		for (const session of sessions) {
-			const delivered = await this.emitToSession(session.id, input.data)
+			const delivered = await this.emitToSession(
+				session.session_id,
+				input.data,
+			)
 			if (delivered.delivered) {
 				deliveredCount += 1
 			}
 		}
 		return {
 			deliveredCount,
-			sessionIds: sessions.map((session) => session.id),
+			sessionIds: sessions.map((session) => session.session_id),
 		}
 	}
 
@@ -469,8 +488,9 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 	private async applyHookActions(
 		sessionId: string,
 		actions: Array<PackageRealtimeAction>,
+		sessionOverride?: PersistedPackageRealtimeSession | null,
 	) {
-		const session = this.stateSnapshot.sessions[sessionId]
+		const session = sessionOverride ?? this.stateSnapshot.sessions[sessionId]
 		if (!session) return
 		let shouldPersist = false
 		for (const action of actions) {
@@ -514,7 +534,7 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 				}
 			}
 		}
-		if (shouldPersist) {
+		if (shouldPersist && this.stateSnapshot.sessions[sessionId]) {
 			this.stateSnapshot.sessions[sessionId] = session
 			await this.persistState()
 		}
@@ -686,7 +706,7 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 				close,
 			},
 		})
-		await this.applyHookActions(sessionId, actions)
+		await this.applyHookActions(sessionId, actions, session)
 	}
 }
 

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -743,7 +743,11 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 			await this.initializeBinding(body.binding)
 			const socket = this.getSocketBySessionId(body.sessionId)
 			if (socket) {
-				socket.close(body.code ?? 1000, body.reason ?? 'closed')
+				try {
+					socket.close(body.code ?? 1000, body.reason ?? 'closed')
+				} catch {
+					// Ignore duplicate close attempts on sockets that are already closing.
+				}
 			}
 			return Response.json({ ok: true })
 		}

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -331,6 +331,10 @@ async function resolvePackageAppWorker(input: {
 export class PackageRealtimeSession extends DurableObject<Env> {
 	private stateSnapshot: PackageRealtimeState = createInitialState()
 	private sessionIds = new WeakMap<WebSocket, string | null>()
+	private cachedAppWorkerKey: string | null = null
+	private cachedAppWorkerPromise: Promise<
+		Awaited<ReturnType<typeof buildPackageAppWorker>>
+	> | null = null
 
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env)
@@ -374,6 +378,23 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 			}
 			await this.persistState()
 		}
+	}
+
+	private async getCachedPackageAppWorker(binding: PackageRealtimeBindingState) {
+		const cacheKey = JSON.stringify([
+			binding.userId,
+			binding.packageId,
+			binding.sourceId,
+			binding.baseUrl,
+		])
+		if (this.cachedAppWorkerKey !== cacheKey || !this.cachedAppWorkerPromise) {
+			this.cachedAppWorkerKey = cacheKey
+			this.cachedAppWorkerPromise = resolvePackageAppWorker({
+				env: this.env,
+				binding,
+			})
+		}
+		return await this.cachedAppWorkerPromise
 	}
 
 	private stashSessionId(ws: WebSocket, sessionId: string) {
@@ -463,10 +484,7 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		binding: PackageRealtimeBindingState
 		payload: PackageRealtimeHookInput
 	}) {
-		const appWorker = await resolvePackageAppWorker({
-			env: this.env,
-			binding: input.binding,
-		})
+		const appWorker = await this.getCachedPackageAppWorker(input.binding)
 		const entrypoint = appWorker.stub.getEntrypoint(appWorker.entrypointName) as {
 			handleRealtimeEvent?: (
 				payload: PackageRealtimeHookInput & PackageRealtimeHookContext,

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -643,7 +643,7 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		ws: WebSocket,
 		message: string | ArrayBuffer,
 	): void | Promise<void> {
-		void this.handleWebSocketMessage(ws, message)
+		return this.handleWebSocketMessage(ws, message)
 	}
 
 	webSocketClose(
@@ -651,8 +651,8 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		_code: number,
 		reason: string,
 		wasClean: boolean,
-	): void {
-		void this.handleDisconnect(ws, {
+	): void | Promise<void> {
+		return this.handleDisconnect(ws, {
 			code: _code,
 			reason,
 			wasClean,

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -1,0 +1,837 @@
+import { DurableObject } from 'cloudflare:workers'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { buildFacetName } from '#mcp/app-runner-facet-names.ts'
+import { getSavedPackageById } from '#worker/package-registry/repo.ts'
+import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
+import { buildPackageAppWorker } from './package-app.ts'
+
+const sessionStateStorageKey = 'package-realtime-state'
+const sessionTagPrefix = 'session:'
+const facetTagPrefix = 'facet:'
+
+type PersistedPackageRealtimeSession = {
+	id: string
+	facet: string
+	connectedAt: string
+	lastSeenAt: string
+	topics: Array<string>
+}
+
+type PackageRealtimeBindingState = {
+	userId: string
+	packageId: string
+	kodyId: string
+	sourceId: string
+	baseUrl: string
+}
+
+type PackageRealtimeState = {
+	binding: PackageRealtimeBindingState | null
+	sessions: Record<string, PersistedPackageRealtimeSession>
+}
+
+type PackageRealtimeSessionRecord = {
+	id: string
+	facet: string
+	topics: Array<string>
+	connectedAt: string
+	lastSeenAt: string
+}
+
+export type PackageRealtimeEmitResult = {
+	delivered: boolean
+	reason?: string
+}
+
+export type PackageRealtimeBroadcastResult = {
+	deliveredCount: number
+	sessionIds: Array<string>
+}
+
+export type PackageRealtimeListResult = {
+	sessions: Array<{
+		session_id: string
+		facet: string
+		topics: Array<string>
+		connected_at: string
+		last_seen_at: string
+	}>
+}
+
+type PackageRealtimeEventRequestInfo = {
+	url: string
+	method: string
+	headers: Record<string, string>
+}
+
+type PackageRealtimeIncomingMessage =
+	| {
+			kind: 'text'
+			text: string
+			json: unknown | null
+	  }
+	| {
+			kind: 'binary'
+			text: string | null
+			json: unknown | null
+	  }
+
+type PackageRealtimeAction =
+	| {
+			type: 'send'
+			data: unknown
+	  }
+	| {
+			type: 'subscribe'
+			topic: string
+	  }
+	| {
+			type: 'unsubscribe'
+			topic: string
+	  }
+	| {
+			type: 'emit'
+			sessionId: string
+			data: unknown
+	  }
+	| {
+			type: 'broadcast'
+			data: unknown
+			topic?: string | null
+			facet?: string | null
+	  }
+	| {
+			type: 'close'
+			code?: number | null
+			reason?: string | null
+	  }
+
+type PackageRealtimeHookResult =
+	| {
+			actions?: Array<PackageRealtimeAction> | null
+	  }
+	| Array<PackageRealtimeAction>
+	| null
+	| undefined
+
+type PackageRealtimeHookInput = {
+	event: 'connect' | 'message' | 'disconnect'
+	facet: string
+	session: PackageRealtimeSessionRecord
+	request?: PackageRealtimeEventRequestInfo | null
+	message?: PackageRealtimeIncomingMessage | null
+	close?: {
+		code: number
+		reason: string
+		wasClean: boolean
+	} | null
+}
+
+type PackageRealtimeHookContext = {
+	userId: string
+	packageId: string
+	kodyId: string
+	baseUrl: string
+}
+
+type PackageRealtimeConnectPayload = {
+	binding: PackageRealtimeBindingState
+	facet?: string | null
+	request: PackageRealtimeEventRequestInfo
+}
+
+type PackageRealtimeEmitPayload = {
+	binding: PackageRealtimeBindingState
+	sessionId: string
+	data: unknown
+}
+
+type PackageRealtimeBroadcastPayload = {
+	binding: PackageRealtimeBindingState
+	data: unknown
+	topic?: string | null
+	facet?: string | null
+}
+
+type PackageRealtimeListPayload = {
+	binding: PackageRealtimeBindingState
+	facet?: string | null
+	topic?: string | null
+}
+
+function createInitialState(): PackageRealtimeState {
+	return {
+		binding: null,
+		sessions: {},
+	}
+}
+
+function sessionTag(sessionId: string) {
+	return `${sessionTagPrefix}${sessionId}`
+}
+
+function facetTag(facet: string) {
+	return `${facetTagPrefix}${facet}`
+}
+
+function pickString(...values: Array<unknown>) {
+	for (const value of values) {
+		if (typeof value === 'string' && value.trim().length > 0) {
+			return value.trim()
+		}
+	}
+	return null
+}
+
+function toPlainHeaders(headers: Headers) {
+	return Object.fromEntries(headers.entries())
+}
+
+function serializeOutboundMessage(value: unknown) {
+	if (typeof value === 'string') {
+		return value
+	}
+	return JSON.stringify(value)
+}
+
+function decodeInboundMessage(
+	message: string | ArrayBuffer,
+): PackageRealtimeIncomingMessage {
+	if (typeof message === 'string') {
+		try {
+			return {
+				kind: 'text',
+				text: message,
+				json: JSON.parse(message),
+			}
+		} catch {
+			return {
+				kind: 'text',
+				text: message,
+				json: null,
+			}
+		}
+	}
+	const text = (() => {
+		try {
+			return new TextDecoder().decode(message)
+		} catch {
+			return null
+		}
+	})()
+	if (text == null) {
+		return {
+			kind: 'binary',
+			text: null,
+			json: null,
+		}
+	}
+	try {
+		return {
+			kind: 'binary',
+			text,
+			json: JSON.parse(text),
+		}
+	} catch {
+		return {
+			kind: 'binary',
+			text,
+			json: null,
+		}
+	}
+}
+
+function normalizeHookActions(result: PackageRealtimeHookResult) {
+	if (Array.isArray(result)) {
+		return result
+	}
+	if (!result || typeof result !== 'object') {
+		return []
+	}
+	return Array.isArray(result.actions) ? result.actions : []
+}
+
+function createSessionRecord(
+	session: PersistedPackageRealtimeSession,
+): PackageRealtimeSessionRecord {
+	return {
+		id: session.id,
+		facet: session.facet,
+		topics: [...session.topics],
+		connectedAt: session.connectedAt,
+		lastSeenAt: session.lastSeenAt,
+	}
+}
+
+async function resolvePackageAppWorker(input: {
+	env: Env
+	binding: PackageRealtimeBindingState
+}) {
+	const savedPackage = await getSavedPackageById(input.env.APP_DB, {
+		userId: input.binding.userId,
+		packageId: input.binding.packageId,
+	})
+	if (!savedPackage || !savedPackage.hasApp) {
+		throw new Error('Saved package app was not found.')
+	}
+	const packageSource = await loadPackageSourceBySourceId({
+		env: input.env,
+		baseUrl: input.binding.baseUrl,
+		userId: input.binding.userId,
+		sourceId: input.binding.sourceId,
+	})
+	const callerContext = createMcpCallerContext({
+		baseUrl: input.binding.baseUrl,
+		user: {
+			userId: input.binding.userId,
+			email: '',
+			displayName: `package:${input.binding.packageId}`,
+		},
+		storageContext: {
+			sessionId: null,
+			appId: input.binding.packageId,
+			storageId: input.binding.packageId,
+		},
+		repoContext: null,
+	})
+	return await buildPackageAppWorker({
+		env: input.env,
+		baseUrl: input.binding.baseUrl,
+		userId: input.binding.userId,
+		savedPackage: {
+			id: savedPackage.id,
+			kodyId: savedPackage.kodyId,
+			name: savedPackage.name,
+			sourceId: savedPackage.sourceId,
+			publishedCommit: packageSource.source.published_commit,
+			manifestPath: packageSource.source.manifest_path,
+			sourceRoot: packageSource.source.source_root,
+		},
+		sourceFiles: packageSource.files,
+		runtime: {
+			callerContext,
+		},
+	})
+}
+
+export class PackageRealtimeSession extends DurableObject<Env> {
+	private stateSnapshot: PackageRealtimeState = createInitialState()
+	private sessionIds = new WeakMap<WebSocket, string | null>()
+
+	constructor(ctx: DurableObjectState, env: Env) {
+		super(ctx, env)
+		void this.restoreState()
+	}
+
+	private async restoreState() {
+		const stored =
+			await this.ctx.storage.get<PackageRealtimeState>(sessionStateStorageKey)
+		if (!stored) return
+		this.stateSnapshot = {
+			binding: stored.binding ?? null,
+			sessions: stored.sessions ?? {},
+		}
+	}
+
+	private async persistState() {
+		await this.ctx.storage.put(sessionStateStorageKey, this.stateSnapshot)
+	}
+
+	private async initializeBinding(binding: PackageRealtimeBindingState) {
+		if (!this.stateSnapshot.binding) {
+			this.stateSnapshot.binding = binding
+			await this.persistState()
+			return
+		}
+		const existing = this.stateSnapshot.binding
+		if (
+			existing.userId !== binding.userId ||
+			existing.packageId !== binding.packageId ||
+			existing.sourceId !== binding.sourceId
+		) {
+			throw new Error('Realtime session binding mismatch.')
+		}
+		if (existing.baseUrl !== binding.baseUrl) {
+			this.stateSnapshot.binding = {
+				...existing,
+				baseUrl: binding.baseUrl,
+			}
+			await this.persistState()
+		}
+	}
+
+	private stashSessionId(ws: WebSocket, sessionId: string) {
+		this.sessionIds.set(ws, sessionId)
+		try {
+			ws.serializeAttachment(sessionId)
+		} catch {
+			// Best effort; keep in-memory map for local runtimes without attachments.
+		}
+	}
+
+	private loadSessionId(ws: WebSocket) {
+		if (this.sessionIds.has(ws)) {
+			return this.sessionIds.get(ws) ?? null
+		}
+		let sessionId: string | null = null
+		try {
+			const attachment = ws.deserializeAttachment()
+			if (typeof attachment === 'string' && attachment.trim().length > 0) {
+				sessionId = attachment.trim()
+			}
+		} catch {
+			// Ignore missing attachment support.
+		}
+		this.sessionIds.set(ws, sessionId)
+		return sessionId
+	}
+
+	private getSocketBySessionId(sessionId: string) {
+		return this.ctx.getWebSockets(sessionTag(sessionId))[0] ?? null
+	}
+
+	private listSessions(input?: {
+		facet?: string | null
+		topic?: string | null
+	}): Array<PackageRealtimeSessionRecord> {
+		const facet = buildFacetName(input?.facet)
+		const topic = pickString(input?.topic)
+		return Object.values(this.stateSnapshot.sessions)
+			.filter((session) => {
+				if (input?.facet != null && session.facet !== facet) return false
+				if (topic && !session.topics.includes(topic)) return false
+				return this.getSocketBySessionId(session.id) != null
+			})
+			.map(createSessionRecord)
+	}
+
+	private async emitToSession(sessionId: string, data: unknown) {
+		const socket = this.getSocketBySessionId(sessionId)
+		if (!socket) {
+			if (this.stateSnapshot.sessions[sessionId]) {
+				delete this.stateSnapshot.sessions[sessionId]
+				await this.persistState()
+			}
+			return { delivered: false, reason: 'session_not_connected' as const }
+		}
+		socket.send(serializeOutboundMessage(data))
+		return { delivered: true as const }
+	}
+
+	private async broadcast(input: {
+		facet?: string | null
+		topic?: string | null
+		data: unknown
+	}) {
+		const sessions = this.listSessions({
+			facet: input.facet,
+			topic: input.topic,
+		})
+		let deliveredCount = 0
+		for (const session of sessions) {
+			const delivered = await this.emitToSession(session.id, input.data)
+			if (delivered.delivered) {
+				deliveredCount += 1
+			}
+		}
+		return {
+			deliveredCount,
+			sessionIds: sessions.map((session) => session.id),
+		}
+	}
+
+	private async resolveRealtimeHookResult(input: {
+		binding: PackageRealtimeBindingState
+		payload: PackageRealtimeHookInput
+	}) {
+		const appWorker = await resolvePackageAppWorker({
+			env: this.env,
+			binding: input.binding,
+		})
+		const entrypoint = appWorker.stub.getEntrypoint(appWorker.entrypointName) as {
+			handleRealtimeEvent?: (
+				payload: PackageRealtimeHookInput & PackageRealtimeHookContext,
+			) => Promise<PackageRealtimeHookResult>
+		}
+		if (typeof entrypoint.handleRealtimeEvent !== 'function') {
+			return []
+		}
+		const result = await entrypoint.handleRealtimeEvent({
+			...input.payload,
+			userId: input.binding.userId,
+			packageId: input.binding.packageId,
+			kodyId: input.binding.kodyId,
+			baseUrl: input.binding.baseUrl,
+		})
+		return normalizeHookActions(result)
+	}
+
+	private async applyHookActions(
+		sessionId: string,
+		actions: Array<PackageRealtimeAction>,
+	) {
+		const session = this.stateSnapshot.sessions[sessionId]
+		if (!session) return
+		let shouldPersist = false
+		for (const action of actions) {
+			if (!action || typeof action !== 'object' || !('type' in action)) continue
+			switch (action.type) {
+				case 'send':
+					await this.emitToSession(sessionId, action.data)
+					break
+				case 'subscribe': {
+					const topic = pickString(action.topic)
+					if (!topic || session.topics.includes(topic)) break
+					session.topics.push(topic)
+					shouldPersist = true
+					break
+				}
+				case 'unsubscribe': {
+					const topic = pickString(action.topic)
+					if (!topic) break
+					const nextTopics = session.topics.filter((value) => value !== topic)
+					if (nextTopics.length === session.topics.length) break
+					session.topics = nextTopics
+					shouldPersist = true
+					break
+				}
+				case 'emit':
+					await this.emitToSession(action.sessionId, action.data)
+					break
+				case 'broadcast':
+					await this.broadcast({
+						facet: action.facet,
+						topic: action.topic,
+						data: action.data,
+					})
+					break
+				case 'close': {
+					const socket = this.getSocketBySessionId(sessionId)
+					if (socket) {
+						socket.close(action.code ?? 1000, action.reason ?? 'closed')
+					}
+					break
+				}
+			}
+		}
+		if (shouldPersist) {
+			this.stateSnapshot.sessions[sessionId] = session
+			await this.persistState()
+		}
+	}
+
+	private async handleConnectRequest(payload: PackageRealtimeConnectPayload) {
+		await this.initializeBinding(payload.binding)
+		const facet = buildFacetName(payload.facet)
+		const pair = new WebSocketPair()
+		const sockets = Object.values(pair)
+		const client = sockets[0]
+		const server = sockets[1]
+		if (!client || !server) {
+			throw new Error('Failed to create WebSocket pair.')
+		}
+		const sessionId = crypto.randomUUID()
+		const now = new Date().toISOString()
+		this.ctx.acceptWebSocket(server, [sessionTag(sessionId), facetTag(facet)])
+		this.stashSessionId(server, sessionId)
+		this.stateSnapshot.sessions[sessionId] = {
+			id: sessionId,
+			facet,
+			connectedAt: now,
+			lastSeenAt: now,
+			topics: [],
+		}
+		await this.persistState()
+		const actions = await this.resolveRealtimeHookResult({
+			binding: payload.binding,
+			payload: {
+				event: 'connect',
+				facet,
+				session: createSessionRecord(this.stateSnapshot.sessions[sessionId]),
+				request: payload.request,
+			},
+		})
+		await this.applyHookActions(sessionId, actions)
+		return new Response(null, {
+			status: 101,
+			webSocket: client,
+		})
+	}
+
+	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url)
+		if (request.headers.get('Upgrade') === 'websocket') {
+			const body = (await request.json()) as PackageRealtimeConnectPayload
+			return await this.handleConnectRequest(body)
+		}
+
+		if (request.method === 'POST' && url.pathname.endsWith('/sessions')) {
+			const body = (await request.json().catch(() => null)) as
+				| PackageRealtimeListPayload
+				| null
+			if (!body) {
+				return Response.json({ sessions: [] })
+			}
+			await this.initializeBinding(body.binding)
+			return Response.json({
+				sessions: this.listSessions({
+					facet: body.facet,
+					topic: body.topic,
+				}),
+			})
+		}
+
+		if (request.method === 'POST' && url.pathname.endsWith('/emit')) {
+			const body = (await request.json()) as PackageRealtimeEmitPayload
+			await this.initializeBinding(body.binding)
+			return Response.json(
+				await this.emitToSession(body.sessionId, body.data),
+			)
+		}
+
+		if (request.method === 'POST' && url.pathname.endsWith('/broadcast')) {
+			const body = (await request.json()) as PackageRealtimeBroadcastPayload
+			await this.initializeBinding(body.binding)
+			return Response.json(
+				await this.broadcast({
+					facet: body.facet,
+					topic: body.topic,
+					data: body.data,
+				}),
+			)
+		}
+
+		if (request.method === 'POST' && url.pathname.endsWith('/disconnect')) {
+			const body = (await request.json()) as {
+				binding: PackageRealtimeBindingState
+				sessionId: string
+				code?: number | null
+				reason?: string | null
+			}
+			await this.initializeBinding(body.binding)
+			const socket = this.getSocketBySessionId(body.sessionId)
+			if (socket) {
+				socket.close(body.code ?? 1000, body.reason ?? 'closed')
+			}
+			return Response.json({ ok: true })
+		}
+
+		return new Response('Not found', { status: 404 })
+	}
+
+	webSocketMessage(
+		ws: WebSocket,
+		message: string | ArrayBuffer,
+	): void | Promise<void> {
+		void this.handleWebSocketMessage(ws, message)
+	}
+
+	webSocketClose(
+		ws: WebSocket,
+		_code: number,
+		reason: string,
+		wasClean: boolean,
+	): void {
+		void this.handleDisconnect(ws, {
+			code: _code,
+			reason,
+			wasClean,
+		})
+	}
+
+	private async handleWebSocketMessage(
+		ws: WebSocket,
+		message: string | ArrayBuffer,
+	) {
+		const sessionId = this.loadSessionId(ws)
+		if (!sessionId) return
+		const session = this.stateSnapshot.sessions[sessionId]
+		const binding = this.stateSnapshot.binding
+		if (!session || !binding) return
+		session.lastSeenAt = new Date().toISOString()
+		await this.persistState()
+		const actions = await this.resolveRealtimeHookResult({
+			binding,
+			payload: {
+				event: 'message',
+				facet: session.facet,
+				session: createSessionRecord(session),
+				message: decodeInboundMessage(message),
+			},
+		})
+		await this.applyHookActions(sessionId, actions)
+	}
+
+	private async handleDisconnect(
+		ws: WebSocket,
+		close: {
+			code: number
+			reason: string
+			wasClean: boolean
+		},
+	) {
+		const sessionId = this.loadSessionId(ws)
+		if (!sessionId) return
+		const session = this.stateSnapshot.sessions[sessionId]
+		const binding = this.stateSnapshot.binding
+		delete this.stateSnapshot.sessions[sessionId]
+		await this.persistState()
+		if (!session || !binding) return
+		const actions = await this.resolveRealtimeHookResult({
+			binding,
+			payload: {
+				event: 'disconnect',
+				facet: session.facet,
+				session: createSessionRecord(session),
+				close,
+			},
+		})
+		await this.applyHookActions(sessionId, actions)
+	}
+}
+
+type PackageRealtimeSessionRpc = {
+	fetch: (request: Request) => Promise<Response>
+}
+
+function buildRealtimeSessionName(input: {
+	userId: string
+	packageId: string
+}) {
+	return JSON.stringify([input.userId, input.packageId])
+}
+
+function getPackageRealtimeNamespace(env: Env) {
+	return env.PACKAGE_REALTIME_SESSION
+}
+
+function getPackageRealtimeStub(input: {
+	env: Env
+	userId: string
+	packageId: string
+}): PackageRealtimeSessionRpc {
+	const namespace = getPackageRealtimeNamespace(input.env)
+	if (!namespace) {
+		throw new Error('Missing PACKAGE_REALTIME_SESSION binding.')
+	}
+	const id = namespace.idFromName(
+		buildRealtimeSessionName({
+			userId: input.userId,
+			packageId: input.packageId,
+		}),
+	)
+	return namespace.get(id) as unknown as PackageRealtimeSessionRpc
+}
+
+export function packageRealtimeSessionRpc(input: {
+	env: Env
+	userId: string
+	packageId: string
+	kodyId: string
+	sourceId: string
+	baseUrl: string
+}) {
+	const binding: PackageRealtimeBindingState = {
+		userId: input.userId,
+		packageId: input.packageId,
+		kodyId: input.kodyId,
+		sourceId: input.sourceId,
+		baseUrl: input.baseUrl,
+	}
+	const stub = getPackageRealtimeStub(input)
+	return {
+		async connect(request: Request, facet?: string | null) {
+			const forwardedRequest = new Request(request.url, {
+				method: 'POST',
+				headers: request.headers,
+				body: JSON.stringify({
+					binding,
+					facet,
+					request: {
+						url: request.url,
+						method: request.method,
+						headers: toPlainHeaders(request.headers),
+					},
+				} satisfies PackageRealtimeConnectPayload),
+			})
+			forwardedRequest.headers.set('Upgrade', 'websocket')
+			return await stub.fetch(forwardedRequest)
+		},
+		async emit(
+			sessionId: string,
+			data: unknown,
+		): Promise<PackageRealtimeEmitResult> {
+			const response = await stub.fetch(
+				new Request('https://package-realtime.invalid/session/emit', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({
+						binding,
+						sessionId,
+						data,
+					} satisfies PackageRealtimeEmitPayload),
+				}),
+			)
+			return (await response.json()) as PackageRealtimeEmitResult
+		},
+		async broadcast(input2: {
+			data: unknown
+			topic?: string | null
+			facet?: string | null
+		}): Promise<PackageRealtimeBroadcastResult> {
+			const response = await stub.fetch(
+				new Request('https://package-realtime.invalid/session/broadcast', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({
+						binding,
+						data: input2.data,
+						topic: input2.topic,
+						facet: input2.facet,
+					} satisfies PackageRealtimeBroadcastPayload),
+				}),
+			)
+			return (await response.json()) as PackageRealtimeBroadcastResult
+		},
+		async listSessions(input2?: {
+			topic?: string | null
+			facet?: string | null
+		}): Promise<PackageRealtimeListResult> {
+			const response = await stub.fetch(
+				new Request('https://package-realtime.invalid/session/sessions', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({
+						binding,
+						topic: input2?.topic,
+						facet: input2?.facet,
+					} satisfies PackageRealtimeListPayload),
+				}),
+			)
+			return (await response.json()) as PackageRealtimeListResult
+		},
+		async disconnect(sessionId: string, input2?: { code?: number; reason?: string }) {
+			const response = await stub.fetch(
+				new Request('https://package-realtime.invalid/session/disconnect', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({
+						binding,
+						sessionId,
+						code: input2?.code,
+						reason: input2?.reason,
+					}),
+				}),
+			)
+			return await response.json()
+		},
+	}
+}

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -371,10 +371,14 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		) {
 			throw new Error('Realtime session binding mismatch.')
 		}
-		if (existing.baseUrl !== binding.baseUrl) {
+		if (
+			existing.baseUrl !== binding.baseUrl ||
+			existing.kodyId !== binding.kodyId
+		) {
 			this.stateSnapshot.binding = {
 				...existing,
 				baseUrl: binding.baseUrl,
+				kodyId: binding.kodyId,
 			}
 			await this.persistState()
 		}
@@ -586,16 +590,27 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 			topics: [],
 		}
 		await this.persistState()
-		const actions = await this.resolveRealtimeHookResult({
-			binding: payload.binding,
-			payload: {
-				event: 'connect',
-				facet,
-				session: createSessionRecord(this.stateSnapshot.sessions[sessionId]),
-				request: payload.request,
-			},
-		})
-		await this.applyHookActions(sessionId, actions)
+		try {
+			const actions = await this.resolveRealtimeHookResult({
+				binding: payload.binding,
+				payload: {
+					event: 'connect',
+					facet,
+					session: createSessionRecord(this.stateSnapshot.sessions[sessionId]),
+					request: payload.request,
+				},
+			})
+			await this.applyHookActions(sessionId, actions)
+		} catch (error) {
+			delete this.stateSnapshot.sessions[sessionId]
+			await this.persistState()
+			try {
+				server.close(1011, 'connect hook failed')
+			} catch {
+				// Best effort cleanup for failed upgrade setup.
+			}
+			throw error
+		}
 		return new Response(null, {
 			status: 101,
 			webSocket: client,

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -477,7 +477,15 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 			}
 			return { delivered: false, reason: 'session_not_connected' as const }
 		}
-		socket.send(serializeOutboundMessage(data))
+		try {
+			socket.send(serializeOutboundMessage(data))
+		} catch {
+			if (this.stateSnapshot.sessions[sessionId]) {
+				delete this.stateSnapshot.sessions[sessionId]
+				await this.persistState()
+			}
+			return { delivered: false, reason: 'session_not_connected' as const }
+		}
 		return { delivered: true as const }
 	}
 

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -491,6 +491,7 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 			topic: input.topic,
 		})
 		let deliveredCount = 0
+		const sessionIds: Array<string> = []
 		for (const session of sessions) {
 			const delivered = await this.emitToSession(
 				session.session_id,
@@ -498,11 +499,12 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 			)
 			if (delivered.delivered) {
 				deliveredCount += 1
+				sessionIds.push(session.session_id)
 			}
 		}
 		return {
 			deliveredCount,
-			sessionIds: sessions.map((session) => session.session_id),
+			sessionIds,
 		}
 	}
 

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -2,6 +2,7 @@ import { DurableObject } from 'cloudflare:workers'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { buildFacetName } from '#mcp/app-runner-facet-names.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
+import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 import { buildPackageAppWorker } from './package-app.ts'
 
@@ -328,6 +329,23 @@ async function resolvePackageAppWorker(input: {
 	})
 }
 
+export async function resolvePackageAppWorkerCacheKey(input: {
+	env: Pick<Env, 'APP_DB'>
+	binding: PackageRealtimeBindingState
+}) {
+	const source = await getEntitySourceById(input.env.APP_DB, input.binding.sourceId)
+	if (!source || source.user_id !== input.binding.userId) {
+		throw new Error('Saved package source was not found.')
+	}
+	return JSON.stringify([
+		input.binding.userId,
+		input.binding.packageId,
+		input.binding.sourceId,
+		input.binding.baseUrl,
+		source.published_commit ?? null,
+	])
+}
+
 export class PackageRealtimeSession extends DurableObject<Env> {
 	private stateSnapshot: PackageRealtimeState = createInitialState()
 	private sessionIds = new WeakMap<WebSocket, string | null>()
@@ -385,12 +403,10 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 	}
 
 	private async getCachedPackageAppWorker(binding: PackageRealtimeBindingState) {
-		const cacheKey = JSON.stringify([
-			binding.userId,
-			binding.packageId,
-			binding.sourceId,
-			binding.baseUrl,
-		])
+		const cacheKey = await resolvePackageAppWorkerCacheKey({
+			env: this.env,
+			binding,
+		})
 		if (this.cachedAppWorkerKey !== cacheKey || !this.cachedAppWorkerPromise) {
 			this.cachedAppWorkerKey = cacheKey
 			this.cachedAppWorkerPromise = resolvePackageAppWorker({

--- a/packages/worker/src/package-runtime/realtime-session.workers.test.ts
+++ b/packages/worker/src/package-runtime/realtime-session.workers.test.ts
@@ -154,3 +154,44 @@ test('package realtime session broadcast skips sessions whose send throws', asyn
 		})
 	})
 })
+
+test('package realtime session close action swallows socket close errors', async () => {
+	const binding = createBinding()
+	const stub = env.PACKAGE_REALTIME_SESSION.get(
+		env.PACKAGE_REALTIME_SESSION.idFromName(
+			JSON.stringify([binding.userId, binding.packageId]),
+		),
+	)
+
+	await runInDurableObject(stub, async (instance: PackageRealtimeSession) => {
+		const anyInstance = instance as unknown as {
+			stateSnapshot: {
+				sessions: Record<string, { id: string; topics: Array<string> }>
+			}
+			getSocketBySessionId: (sessionId: string) => { close: () => void }
+			applyHookActions: (
+				sessionId: string,
+				actions: Array<{ type: 'close'; code?: number; reason?: string }>,
+			) => Promise<void>
+		}
+
+		anyInstance.stateSnapshot = {
+			sessions: {
+				'session-1': { id: 'session-1', topics: [] },
+			},
+		}
+		anyInstance.getSocketBySessionId = () => ({
+			close: () => {
+				throw new Error('socket already closing')
+			},
+		})
+
+		await expect(
+			anyInstance.applyHookActions('session-1', [
+				{
+					type: 'close',
+				},
+			]),
+		).resolves.toBeUndefined()
+	})
+})

--- a/packages/worker/src/package-runtime/realtime-session.workers.test.ts
+++ b/packages/worker/src/package-runtime/realtime-session.workers.test.ts
@@ -195,3 +195,49 @@ test('package realtime session close action swallows socket close errors', async
 		).resolves.toBeUndefined()
 	})
 })
+
+test('package realtime disconnect endpoint swallows socket close errors', async () => {
+	const binding = createBinding()
+	const stub = env.PACKAGE_REALTIME_SESSION.get(
+		env.PACKAGE_REALTIME_SESSION.idFromName(
+			JSON.stringify([binding.userId, binding.packageId]),
+		),
+	)
+
+	await runInDurableObject(stub, async (instance: PackageRealtimeSession) => {
+		const anyInstance = instance as unknown as {
+			initializeBinding: (bindingState: unknown) => Promise<void>
+			getSocketBySessionId: (sessionId: string) => { close: () => void }
+			fetch: (request: Request) => Promise<Response>
+		}
+
+		anyInstance.initializeBinding = async () => undefined
+		anyInstance.getSocketBySessionId = () => ({
+			close: () => {
+				throw new Error('socket already closing')
+			},
+		})
+
+		const response = await anyInstance.fetch(
+			new Request('https://package-realtime.invalid/session/disconnect', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					binding: {
+						userId: 'user-1',
+						packageId: 'package-1',
+						kodyId: 'example',
+						sourceId: 'source-1',
+						baseUrl: 'https://example.com',
+					},
+					sessionId: 'session-1',
+				}),
+			}),
+		)
+
+		expect(response.status).toBe(200)
+		await expect(response.json()).resolves.toEqual({ ok: true })
+	})
+})

--- a/packages/worker/src/package-runtime/realtime-session.workers.test.ts
+++ b/packages/worker/src/package-runtime/realtime-session.workers.test.ts
@@ -98,3 +98,59 @@ test('package realtime session broadcast only returns delivered session ids', as
 		})
 	})
 })
+
+test('package realtime session broadcast skips sessions whose send throws', async () => {
+	const binding = createBinding()
+	const stub = env.PACKAGE_REALTIME_SESSION.get(
+		env.PACKAGE_REALTIME_SESSION.idFromName(
+			JSON.stringify([binding.userId, binding.packageId]),
+		),
+	)
+
+	await runInDurableObject(stub, async (instance: PackageRealtimeSession) => {
+		const anyInstance = instance as unknown as {
+			listSessions: (input?: {
+				facet?: string | null
+				topic?: string | null
+			}) => Array<{ session_id: string }>
+			getSocketBySessionId: (sessionId: string) => { send: (data: string) => void }
+			stateSnapshot: {
+				sessions: Record<string, { id: string }>
+			}
+			persistState: () => Promise<void>
+			broadcast: (input: {
+				facet?: string | null
+				topic?: string | null
+				data: unknown
+			}) => Promise<{ deliveredCount: number; sessionIds: Array<string> }>
+		}
+
+		anyInstance.listSessions = () => [
+			{ session_id: 'session-1' },
+			{ session_id: 'session-2' },
+		]
+		anyInstance.stateSnapshot = {
+			sessions: {
+				'session-1': { id: 'session-1' },
+				'session-2': { id: 'session-2' },
+			},
+		}
+		anyInstance.persistState = async () => undefined
+		anyInstance.getSocketBySessionId = (sessionId) => ({
+			send: () => {
+				if (sessionId === 'session-2') {
+					throw new Error('socket closing')
+				}
+			},
+		}
+
+		await expect(
+			anyInstance.broadcast({
+				data: { type: 'broadcast' },
+			}),
+		).resolves.toEqual({
+			deliveredCount: 1,
+			sessionIds: ['session-1'],
+		})
+	})
+})

--- a/packages/worker/src/package-runtime/realtime-session.workers.test.ts
+++ b/packages/worker/src/package-runtime/realtime-session.workers.test.ts
@@ -1,0 +1,56 @@
+import { env } from 'cloudflare:workers'
+import { runInDurableObject } from 'cloudflare:test'
+import { expect, test } from 'vitest'
+import { packageRealtimeSessionRpc, PackageRealtimeSession } from './realtime-session.ts'
+
+function createBinding(overrides?: Partial<{
+	userId: string
+	packageId: string
+	kodyId: string
+	sourceId: string
+	baseUrl: string
+}>) {
+	return {
+		env,
+		userId: overrides?.userId ?? 'user-1',
+		packageId: overrides?.packageId ?? 'package-1',
+		kodyId: overrides?.kodyId ?? 'example',
+		sourceId: overrides?.sourceId ?? 'source-1',
+		baseUrl: overrides?.baseUrl ?? 'https://example.com',
+	}
+}
+
+test('package realtime session DO can list, emit, and broadcast with no active sessions', async () => {
+	const rpc = packageRealtimeSessionRpc(createBinding())
+
+	await expect(rpc.listSessions()).resolves.toEqual({ sessions: [] })
+	await expect(
+		rpc.emit('missing-session', { type: 'hello' }),
+	).resolves.toEqual({
+		delivered: false,
+		reason: 'session_not_connected',
+	})
+	await expect(
+		rpc.broadcast({ data: { type: 'broadcast' } }),
+	).resolves.toEqual({
+		deliveredCount: 0,
+		sessionIds: [],
+	})
+})
+
+test('package realtime session DO is addressable as a durable object', async () => {
+	const binding = createBinding()
+	const stub = env.PACKAGE_REALTIME_SESSION.get(
+		env.PACKAGE_REALTIME_SESSION.idFromName(
+			JSON.stringify([binding.userId, binding.packageId]),
+		),
+	)
+
+	await runInDurableObject(
+		stub,
+		async (instance: PackageRealtimeSession, state) => {
+			expect(instance).toBeInstanceOf(PackageRealtimeSession)
+			expect(state.storage.sql.databaseSize).toBeGreaterThanOrEqual(0)
+		},
+	)
+})

--- a/packages/worker/src/package-runtime/realtime-session.workers.test.ts
+++ b/packages/worker/src/package-runtime/realtime-session.workers.test.ts
@@ -142,7 +142,7 @@ test('package realtime session broadcast skips sessions whose send throws', asyn
 					throw new Error('socket closing')
 				}
 			},
-		}
+		})
 
 		await expect(
 			anyInstance.broadcast({

--- a/packages/worker/src/package-runtime/realtime-session.workers.test.ts
+++ b/packages/worker/src/package-runtime/realtime-session.workers.test.ts
@@ -54,3 +54,47 @@ test('package realtime session DO is addressable as a durable object', async () 
 		},
 	)
 })
+
+test('package realtime session broadcast only returns delivered session ids', async () => {
+	const binding = createBinding()
+	const stub = env.PACKAGE_REALTIME_SESSION.get(
+		env.PACKAGE_REALTIME_SESSION.idFromName(
+			JSON.stringify([binding.userId, binding.packageId]),
+		),
+	)
+
+	await runInDurableObject(stub, async (instance: PackageRealtimeSession) => {
+		const anyInstance = instance as unknown as {
+			listSessions: (input?: {
+				facet?: string | null
+				topic?: string | null
+			}) => Array<{ session_id: string }>
+			emitToSession: (
+				sessionId: string,
+				data: unknown,
+			) => Promise<{ delivered: boolean }>
+			broadcast: (input: {
+				facet?: string | null
+				topic?: string | null
+				data: unknown
+			}) => Promise<{ deliveredCount: number; sessionIds: Array<string> }>
+		}
+
+		anyInstance.listSessions = () => [
+			{ session_id: 'session-1' },
+			{ session_id: 'session-2' },
+		]
+		anyInstance.emitToSession = async (sessionId) => ({
+			delivered: sessionId === 'session-1',
+		})
+
+		await expect(
+			anyInstance.broadcast({
+				data: { type: 'broadcast' },
+			}),
+		).resolves.toEqual({
+			deliveredCount: 1,
+			sessionIds: ['session-1'],
+		})
+	})
+})

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -46,6 +46,10 @@
 			"new_sqlite_classes": ["RepoSession"],
 			"tag": "v11",
 		},
+		{
+			"new_sqlite_classes": ["PackageRealtimeSession"],
+			"tag": "v12",
+		},
 	],
 
 	"observability": {
@@ -103,6 +107,10 @@
 					{
 						"class_name": "RepoSession",
 						"name": "REPO_SESSION",
+					},
+					{
+						"class_name": "PackageRealtimeSession",
+						"name": "PACKAGE_REALTIME_SESSION",
 					},
 				],
 			},
@@ -185,6 +193,10 @@
 						"class_name": "RepoSession",
 						"name": "REPO_SESSION",
 					},
+					{
+						"class_name": "PackageRealtimeSession",
+						"name": "PACKAGE_REALTIME_SESSION",
+					},
 				],
 			},
 			"d1_databases": [
@@ -265,6 +277,10 @@
 					{
 						"class_name": "RepoSession",
 						"name": "REPO_SESSION",
+					},
+					{
+						"class_name": "PackageRealtimeSession",
+						"name": "PACKAGE_REALTIME_SESSION",
 					},
 				],
 			},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Add a Kody-owned package realtime websocket/session primitive that package apps and package jobs can both use.

### What changed
- add a new `PackageRealtimeSession` Durable Object to own websocket sessions per user/package
- route `/packages/:id/ws/:facet?` through `handlePackageAppRequest` into the session manager
- expose package-facing realtime APIs through package runtime (`kody:runtime.realtime`) and new app capabilities:
  - `session_emit`
  - `session_broadcast`
  - `session_list`
- allow package app code to handle realtime lifecycle events via `handleRealtimeEvent(...)` / facet class `onRealtimeEvent(...)`
- register the new DO binding in worker env + Wrangler config
- add focused tests for the apps domain, package app websocket route delegation, and realtime session DO

## Testing
- `npm run test -- packages/worker/src/package-runtime/realtime-session.workers.test.ts packages/worker/src/mcp/capabilities/apps/apps-domain.node.test.ts`
- `npm run test -- packages/worker/src/package-runtime/realtime-session.workers.test.ts packages/worker/src/mcp/capabilities/apps/apps-domain.node.test.ts packages/worker/src/mcp/capabilities/build-capability-registry.workers.test.ts`
- `npm run test -- packages/worker/src/app/handlers/package-app.node.test.ts packages/worker/src/package-runtime/realtime-session.workers.test.ts packages/worker/src/mcp/capabilities/apps/apps-domain.node.test.ts`
- `npx nx run worker:typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-199533ac-10f9-4166-835f-2b8d6be8ec49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-199533ac-10f9-4166-835f-2b8d6be8ec49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time WebSocket support for package apps: connect, emit, broadcast, list sessions, and graceful disconnects; runtime hooks for handling realtime events.

* **MCP Capabilities**
  * New "apps" capabilities: session_emit, session_broadcast, session_list.

* **Tests**
  * Added tests for realtime RPC, Durable Object/session behavior, routing, and MCP domain capabilities.

* **Documentation**
  * MCP server guidance updated to document realtime session usage.

* **Chores**
  * Durable Object binding and env schema added to persist realtime session state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->