### PR TITLE
Require package-name imports for saved packages

### DIFF
--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -10,9 +10,9 @@ Kody-specific metadata.
 
 Use `package.json` as the canonical source of truth for saved package metadata.
 
-- `name` — npm-valid package name; for scoped names, the leaf package name must
-  match `kody.id` (for example `@kentcdodds/cursor-cloud-agents` pairs with
-  `kody.id: "cursor-cloud-agents"`)
+- `name` — npm-valid scoped package name (`@scope/<leaf>`); the leaf segment
+  must match `kody.id` (for example `@kentcdodds/cursor-cloud-agents` pairs
+  with `kody.id: "cursor-cloud-agents"`)
 - `exports` — authoritative import/export map
 - `kody.id` — user-scoped Kody package id
 - `kody.description` — package description for search/detail

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -10,7 +10,9 @@ Kody-specific metadata.
 
 Use `package.json` as the canonical source of truth for saved package metadata.
 
-- `name` — npm-valid package name
+- `name` — npm-valid package name; for scoped names, the leaf package name must
+  match `kody.id` (for example `@kentcdodds/cursor-cloud-agents` pairs with
+  `kody.id: "cursor-cloud-agents"`)
 - `exports` — authoritative import/export map
 - `kody.id` — user-scoped Kody package id
 - `kody.description` — package description for search/detail
@@ -35,7 +37,8 @@ The top-level saved identity is the package.
 
 `package.json.exports` is the package's callable/importable surface.
 
-- Cross-package imports use specifiers such as `kody:@my-package/export-name`.
+- Cross-package imports use the full package name, for example
+  `kody:@scope/my-package/export-name`.
 - Callable exports are resolved from package exports, not from a second Kody
   registry.
 - Packages may also export non-callable helper modules and values for reuse.

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -21,8 +21,8 @@ and export a default function. These helpers are runtime exports:
   active execute or job params instead of receiving them as a function argument
 - use **`import { packageContext } from 'kody:runtime'`** inside saved package
   code when you need package metadata; it is **`null`** for ad hoc execute calls
-- use **`import thing from 'kody:@my-package/export-name'`** to reuse a saved
-  package export
+- use **`import thing from 'kody:@scope/my-package/export-name'`** to reuse a
+  saved package export by full package name
 
 **execute** also accepts optional **`params`**. Kody passes that JSON object to
 the module's **default export**.
@@ -46,6 +46,8 @@ Saved packages, scheduled jobs, and one-off **execute** code share the same
 module-oriented runtime model:
 
 - saved packages persist repo-backed source rooted at `package.json`
+- `package.json.name` must end with the same leaf name as `package.json#kody.id`
+  (for example `@scope/my-package` pairs with `kody.id: "my-package"`)
 - package exports are defined by standard `package.json.exports`
 - package-specific metadata lives under `package.json#kody`
 - package jobs are schedules declared under `package.json#kody.jobs`

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -34,11 +34,16 @@ Important fields:
 
 `package.json` is the manifest.
 
+For predictable package resolution, the package name's leaf segment must match
+`kody.id`. For example, `@kentcdodds/cursor-cloud-agents` must use
+`"kody": { "id": "cursor-cloud-agents" }`.
+
 ## Package exports
 
 `package.json.exports` is the package's callable and importable surface.
 
-- Cross-package imports use specifiers such as `kody:@my-package/export-name`.
+- Cross-package imports use the full package name such as
+  `kody:@scope/my-package/export-name`.
 - Callable exports are exports whose resolved module default export is a
   function.
 - Packages may also export non-callable helper modules and values for reuse.

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -34,8 +34,9 @@ Important fields:
 
 `package.json` is the manifest.
 
-For predictable package resolution, the package name's leaf segment must match
-`kody.id`. For example, `@kentcdodds/cursor-cloud-agents` must use
+For predictable package resolution, saved packages must use a scoped
+`package.json.name`, and the leaf segment must match `kody.id`. For example,
+`@kentcdodds/cursor-cloud-agents` must use
 `"kody": { "id": "cursor-cloud-agents" }`.
 
 ## Package exports

--- a/packages/worker/src/mcp/observability.workers.test.ts
+++ b/packages/worker/src/mcp/observability.workers.test.ts
@@ -223,7 +223,7 @@ test('package_save capability logs success for valid invocation', async () => {
 					{
 						path: 'package.json',
 						content: JSON.stringify({
-							name: '@kody/observed',
+							name: '@kody/observed-package',
 							exports: {
 								'.': './src/index.ts',
 							},
@@ -261,7 +261,7 @@ test('package_save capability logs success for valid invocation', async () => {
 												? {
 														id: 'package-1',
 														user_id: 'user-1',
-														name: '@kody/observed',
+														name: '@kody/observed-package',
 														kody_id: 'observed-package',
 														description: 'Observation test package.',
 														tags_json: '[]',
@@ -311,7 +311,7 @@ test('package_save capability logs success for valid invocation', async () => {
 									sourceRoot: '/',
 									files: {
 										'package.json': JSON.stringify({
-											name: '@kody/observed',
+											name: '@kody/observed-package',
 											exports: { '.': './src/index.ts' },
 											kody: {
 												id: 'observed-package',
@@ -367,7 +367,7 @@ test('package_save capability logs success for valid invocation', async () => {
 									content:
 										path === 'package.json'
 											? JSON.stringify({
-													name: '@kody/observed',
+													name: '@kody/observed-package',
 													exports: { '.': './src/index.ts' },
 													kody: {
 														id: 'observed-package',

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -49,7 +49,7 @@ search
 
 execute
 - Single ESM module string with a default export. Import runtime APIs from \`kody:runtime\`. Example: \`import { codemode, refreshAccessToken, createAuthenticatedFetch } from 'kody:runtime'\`. Prefer one \`execute\` when the plan is clear. Full rules for \`fetch\`, placeholders, \`secret_list\` / \`value_get\`, and \`x-kody-secret\`: see the \`execute\` tool description.
-- Cross-package imports use specifiers such as \`kody:@my-package/export-name\`. Package jobs are owned by packages, ad hoc jobs can be scheduled with \`job_schedule\`, and package apps are optional package surfaces.
+- Cross-package imports use specifiers such as \`kody:@scope/my-package/export-name\`. Saved package names should end with the same leaf segment as \`kody.id\`. Package jobs are owned by packages, ad hoc jobs can be scheduled with \`job_schedule\`, and package apps are optional package surfaces.
 - Official how-to guides from the Kody repo: if a requested package or workflow depends on a third-party integration, secrets, or OAuth, call \`kody_official_guide\` with \`guide: "integration_bootstrap"\` before building the package. Then load the relevant setup guide: \`oauth\` for standard third-party OAuth (\`/connect/oauth\`), \`connect_secret\` for secret collection, and \`secret_backed_integration\` for the default non-OAuth secret-backed recipe after bootstrap. If unsure, \`search\` for this capability and load the right guide before implementing.
 - Do not save or present an auth-dependent package as complete until \`search\` shows the required connector or secret reference exists and a minimal authenticated \`execute\` smoke test succeeds.
 

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -40,8 +40,8 @@ Saved package surface:
 - \`package_save\`, \`package_get\`, \`package_list\`, \`package_delete\`
 - repo-backed package editing with \`repo_edit_flow\`, \`repo_open_session\`,
   and \`repo_publish_session\`
-- cross-package imports with specifiers such as
-  \`kody:@my-package/export-name\`
+ - cross-package imports with specifiers such as
+   \`kody:@scope/my-package/export-name\`
 
 Sandbox surface:
 - Import runtime helpers from \`kody:runtime\`.

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -264,7 +264,7 @@ test('entity detail formatting includes package app, export, and job metadata', 
 		exports: [
 			expect.objectContaining({
 				subpath: '.',
-				importSpecifier: 'kody:@observed-package',
+				importSpecifier: 'kody:@kody/observed-package',
 			}),
 			expect.objectContaining({
 				subpath: './app',
@@ -327,7 +327,7 @@ test('package search formatting surfaces entity refs in markdown and import/app 
 			title: '@kody/spotify-playback',
 			description: 'Saved package for Spotify playback controls.',
 			usage: 'open_generated_ui({ kody_id: "spotify-playback" })',
-			rootImportUsage: 'import entry from "kody:@spotify-playback"',
+			rootImportUsage: 'import entry from "kody:@kody/spotify-playback"',
 			openGeneratedUiUsage:
 				'open_generated_ui({ kody_id: "spotify-playback" })',
 			tags: ['spotify', 'playback'],

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -219,7 +219,7 @@ test('entity detail formatting includes package app, export, and job metadata', 
 			updatedAt: '2026-03-20T00:00:00.000Z',
 		},
 		manifest: {
-			name: '@kody/observed',
+			name: '@kody/observed-package',
 			exports: {
 				'.': './src/index.ts',
 				'./app': {
@@ -264,7 +264,7 @@ test('entity detail formatting includes package app, export, and job metadata', 
 		exports: [
 			expect.objectContaining({
 				subpath: '.',
-				importSpecifier: 'kody:@kody/observed-package',
+				importSpecifier: 'kody:@kody/observed',
 			}),
 			expect.objectContaining({
 				subpath: './app',

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -202,13 +202,13 @@ test('entity detail formatting includes package app, export, and job metadata', 
 	const packageDetail = formatEntityDetailMarkdown({
 		type: 'package',
 		id: 'observed-package',
-		title: '@kody/observed',
+		title: '@kody/observed-package',
 		description: 'Observed package with an app surface.',
 		hostedUrl: 'http://localhost/packages/observed-package',
 		record: {
 			id: 'package-123',
 			userId: 'user-123',
-			name: '@kody/observed',
+			name: '@kody/observed-package',
 			kodyId: 'observed-package',
 			description: 'Observed package with an app surface.',
 			tags: ['observed', 'ui'],
@@ -264,7 +264,7 @@ test('entity detail formatting includes package app, export, and job metadata', 
 		exports: [
 			expect.objectContaining({
 				subpath: '.',
-				importSpecifier: 'kody:@kody/observed',
+				importSpecifier: 'kody:@kody/observed-package',
 			}),
 			expect.objectContaining({
 				subpath: './app',

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -322,11 +322,11 @@ function buildPackageHostedUrl(baseUrl: string, kodyId: string) {
 	return `${baseUrl.replace(/\/+$/, '')}/packages/${encodeURIComponent(kodyId)}`
 }
 
-function buildPackageImportSpecifier(kodyId: string, exportName: string) {
+function buildPackageImportSpecifier(packageName: string, exportName: string) {
 	if (exportName === '.') {
-		return `kody:@${kodyId}`
+		return `kody:@${packageName}`
 	}
-	return `kody:@${kodyId}/${exportName.replace(/^\.\//, '')}`
+	return `kody:@${packageName}/${exportName.replace(/^\.\//, '')}`
 }
 
 function buildEntityRef(id: string, type: SearchEntityType) {
@@ -337,8 +337,8 @@ function buildCapabilityUsage(name: string) {
 	return `execute with codemode.${name}(args)`
 }
 
-function buildPackageRootImportUsage(kodyId: string) {
-	return `import entry from ${JSON.stringify(buildPackageImportSpecifier(kodyId, '.'))}`
+function buildPackageRootImportUsage(packageName: string) {
+	return `import entry from ${JSON.stringify(buildPackageImportSpecifier(packageName, '.'))}`
 }
 
 function buildPackageAppUsage(kodyId: string) {
@@ -427,7 +427,7 @@ export function formatSearchMarkdown(input: {
 			'- Built-in capabilities — `execute` with `import { codemode } from "kody:runtime"`',
 			'- Persisted values — `codemode.value_get({ name, scope })` or `codemode.value_list({ scope })`',
 			'- Saved connectors — `codemode.connector_get({ name })` or `codemode.connector_list({})`',
-			'- Saved packages — import from `kody:@package-id/export-name`, edit with `repo_*`, and open package apps with `open_generated_ui({ kody_id })` when the package declares `kody.app`',
+			'- Saved packages — import from `kody:@scope/package-name/export-name`, edit with `repo_*`, and open package apps with `open_generated_ui({ kody_id })` when the package declares `kody.app`',
 			'- Secrets — placeholders in execute-time fetches or `codemode.secret_list` (never paste raw secrets in chat or embed `{{secret:...}}` literally into visible content such as comments, prompts, or issue bodies)',
 		)
 	}
@@ -497,7 +497,7 @@ function formatMatchBlock(match: SearchMatch, baseUrl: string) {
 			? buildPackageHostedUrl(baseUrl, match.kodyId)
 			: null
 		const entityRef = buildEntityRef(match.kodyId, 'package')
-		const rootImportUsage = buildPackageRootImportUsage(match.kodyId)
+		const rootImportUsage = buildPackageRootImportUsage(match.name)
 		const openGeneratedUiUsage = match.hasApp
 			? buildPackageAppUsage(match.kodyId)
 			: null
@@ -576,13 +576,13 @@ export function toSlimStructuredMatches(input: {
 			}
 		}
 		if (match.type === 'package') {
-			const rootImportUsage = buildPackageRootImportUsage(match.kodyId)
+			const rootImportUsage = buildPackageRootImportUsage(match.name)
 			const openGeneratedUiUsage = match.hasApp
 				? buildPackageAppUsage(match.kodyId)
 				: null
 			const nextStep = match.hasApp
 				? `Open the app with open_generated_ui({ kody_id: "${match.kodyId}" }) or inspect package detail with search({ entity: "${match.kodyId}:package" }).`
-				: `Inspect package detail with search({ entity: "${match.kodyId}:package" }) to review exports, then import the needed entry from "${buildPackageImportSpecifier(match.kodyId, '.')}".`
+				: `Inspect package detail with search({ entity: "${match.kodyId}:package" }) to review exports, then import the needed entry from "${buildPackageImportSpecifier(match.name, '.')}".`
 			return {
 				type: 'package',
 				id: match.kodyId,

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -324,9 +324,9 @@ function buildPackageHostedUrl(baseUrl: string, kodyId: string) {
 
 function buildPackageImportSpecifier(packageName: string, exportName: string) {
 	if (exportName === '.') {
-		return `kody:@${packageName}`
+		return `kody:${packageName}`
 	}
-	return `kody:@${packageName}/${exportName.replace(/^\.\//, '')}`
+	return `kody:${packageName}/${exportName.replace(/^\.\//, '')}`
 }
 
 function buildEntityRef(id: string, type: SearchEntityType) {
@@ -717,7 +717,7 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 				return {
 					subpath: exportName,
 					importSpecifier: buildPackageImportSpecifier(
-						detail.record.kodyId,
+						detail.record.name,
 						exportName,
 					),
 					runtimeTarget,
@@ -793,7 +793,7 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 				description: detail.description,
 				usage: detail.record.hasApp
 					? buildPackageAppUsage(detail.record.kodyId)
-					: buildPackageRootImportUsage(detail.record.kodyId),
+					: buildPackageRootImportUsage(detail.record.name),
 				packageId: detail.record.id,
 				kodyId: detail.record.kodyId,
 				name: detail.record.name,

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -39,3 +39,23 @@ test('parseAuthoredPackageJson rejects package names whose leaf does not match k
 		'package.json name "@kentcdodds/cursor-cloud-agents" must use a leaf package name that matches kody.id "follow-up-on-pr-agent"',
 	)
 })
+
+test('parseAuthoredPackageJson rejects unscoped package names', () => {
+	expect(() =>
+		parseAuthoredPackageJson({
+			content: JSON.stringify({
+				name: 'cursor-cloud-agents',
+				exports: {
+					'.': './index.ts',
+				},
+				kody: {
+					id: 'cursor-cloud-agents',
+					description: 'Unscoped package name',
+				},
+			}),
+			manifestPath: 'package.json',
+		}),
+	).toThrow(
+		'package.json name "cursor-cloud-agents" must be a scoped package name like "@scope/cursor-cloud-agents".',
+	)
+})

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from 'vitest'
+import { parseAuthoredPackageJson } from './manifest.ts'
+
+test('parseAuthoredPackageJson accepts package names whose leaf matches kody.id', () => {
+	const manifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/cursor-cloud-agents',
+			exports: {
+				'.': './index.ts',
+			},
+			kody: {
+				id: 'cursor-cloud-agents',
+				description: 'Cursor cloud agents package',
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+
+	expect(manifest.name).toBe('@kentcdodds/cursor-cloud-agents')
+	expect(manifest.kody.id).toBe('cursor-cloud-agents')
+})
+
+test('parseAuthoredPackageJson rejects package names whose leaf does not match kody.id', () => {
+	expect(() =>
+		parseAuthoredPackageJson({
+			content: JSON.stringify({
+				name: '@kentcdodds/cursor-cloud-agents',
+				exports: {
+					'.': './index.ts',
+				},
+				kody: {
+					id: 'follow-up-on-pr-agent',
+					description: 'Mismatched package id',
+				},
+			}),
+			manifestPath: 'package.json',
+		}),
+	).toThrow(
+		'package.json name "@kentcdodds/cursor-cloud-agents" must use a leaf package name that matches kody.id "follow-up-on-pr-agent"',
+	)
+})

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -7,6 +7,16 @@ import {
 
 const packageManifestPath = 'package.json'
 
+function getExpectedKodyName(name: string) {
+	const trimmed = name.trim()
+	if (!trimmed.startsWith('@')) {
+		return trimmed
+	}
+
+	const separator = trimmed.indexOf('/')
+	return separator === -1 ? trimmed : trimmed.slice(separator + 1)
+}
+
 export function parseAuthoredPackageJson(input: {
 	content: string
 	manifestPath?: string
@@ -28,7 +38,16 @@ export function parseAuthoredPackageJson(input: {
 			`Invalid ${input.manifestPath ?? packageManifestPath}:\n${formatted}`,
 		)
 	}
-	return result.data
+
+	const manifest = result.data
+	const expectedKodyId = getExpectedKodyName(manifest.name)
+	if (expectedKodyId !== manifest.kody.id) {
+		throw new Error(
+			`Invalid ${input.manifestPath ?? packageManifestPath}:\npackage.json name "${manifest.name}" must use a leaf package name that matches kody.id "${manifest.kody.id}".`,
+		)
+	}
+
+	return manifest
 }
 
 export function normalizePackageWorkspacePath(path: string) {

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -7,12 +7,18 @@ import {
 
 const packageManifestPath = 'package.json'
 
-function getExpectedKodyName(name: string) {
+function isScopedPackageName(name: string) {
 	const trimmed = name.trim()
 	if (!trimmed.startsWith('@')) {
-		return trimmed
+		return false
 	}
 
+	const separator = trimmed.indexOf('/')
+	return separator > 1 && separator < trimmed.length - 1
+}
+
+function getExpectedKodyName(name: string) {
+	const trimmed = name.trim()
 	const separator = trimmed.indexOf('/')
 	return separator === -1 ? trimmed : trimmed.slice(separator + 1)
 }
@@ -40,6 +46,11 @@ export function parseAuthoredPackageJson(input: {
 	}
 
 	const manifest = result.data
+	if (!isScopedPackageName(manifest.name)) {
+		throw new Error(
+			`Invalid ${input.manifestPath ?? packageManifestPath}:\npackage.json name "${manifest.name}" must be a scoped package name like "@scope/${manifest.kody.id}".`,
+		)
+	}
 	const expectedKodyId = getExpectedKodyName(manifest.name)
 	if (expectedKodyId !== manifest.kody.id) {
 		throw new Error(

--- a/packages/worker/src/package-registry/repo.ts
+++ b/packages/worker/src/package-registry/repo.ts
@@ -178,6 +178,25 @@ export async function getSavedPackageByKodyId(
 	return row ? mapSavedPackageRow(row) : null
 }
 
+export async function getSavedPackageByName(
+	db: D1Database,
+	input: {
+		userId: string
+		name: string
+	},
+): Promise<SavedPackageRecord | null> {
+	const row = await db
+		.prepare(
+			`SELECT id, user_id, name, kody_id, description, tags_json, search_text,
+				source_id, has_app, created_at, updated_at
+			FROM saved_packages
+			WHERE name = ? AND user_id = ?`,
+		)
+		.bind(input.name, input.userId)
+		.first<Record<string, unknown>>()
+	return row ? mapSavedPackageRow(row) : null
+}
+
 export async function listSavedPackagesByUserId(
 	db: D1Database,
 	input: {

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -1,18 +1,40 @@
-import { expect, test, vi } from 'vitest'
+import { beforeEach, expect, test, vi } from 'vitest'
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
 
 const mockModule = vi.hoisted(() => ({
 	createWorker: vi.fn(),
+	getSavedPackageByKodyId: vi.fn(),
+	getSavedPackageByName: vi.fn(),
+	loadPackageSourceBySourceId: vi.fn(),
 }))
 
 vi.mock('@cloudflare/worker-bundler', () => ({
 	createWorker: (...args: Array<unknown>) => mockModule.createWorker(...args),
 }))
 
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageByKodyId: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageByKodyId(...args),
+	getSavedPackageByName: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageByName(...args),
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
+		mockModule.loadPackageSourceBySourceId(...args),
+}))
+
 const {
 	buildKodyAppBundle,
 	createPublishedPackageAppBundleCacheKey,
 } = await import('./module-graph.ts')
+
+beforeEach(() => {
+	mockModule.createWorker.mockReset()
+	mockModule.getSavedPackageByName.mockReset()
+	mockModule.getSavedPackageByKodyId.mockReset()
+	mockModule.loadPackageSourceBySourceId.mockReset()
+})
 
 function createBundleResult(suffix: string) {
 	return {
@@ -60,6 +82,51 @@ function createBundleInput(input?: {
 	}
 }
 
+function createSavedPackageRecord(input?: {
+	name?: string
+	kodyId?: string
+	sourceId?: string
+}) {
+	return {
+		id: 'pkg-1',
+		userId: 'user-1',
+		name: input?.name ?? '@kentcdodds/example-package',
+		kodyId: input?.kodyId ?? 'example-package',
+		description: 'Example package',
+		tags: [],
+		searchText: null,
+		sourceId: input?.sourceId ?? 'source-1',
+		hasApp: false,
+		createdAt: '2026-04-24T00:00:00.000Z',
+		updatedAt: '2026-04-24T00:00:00.000Z',
+	}
+}
+
+function createLoadedPackageSource() {
+	return {
+		source: {
+			id: 'source-1',
+			published_commit: 'commit-1',
+		},
+		manifest: {
+			name: '@kentcdodds/example-package',
+			exports: {
+				'.': './index.js',
+				'./follow-up-on-pr-agent': './follow-up-on-pr-agent.js',
+			},
+			kody: {
+				id: 'example-package',
+				description: 'Example package',
+			},
+		},
+		files: {
+			'index.js': 'export const value = "ok"',
+			'follow-up-on-pr-agent.js':
+				'export default async function followUp() { return "ok" }',
+		},
+	}
+}
+
 test('buildKodyAppBundle reuses cached published package app bundles', async () => {
 	mockModule.createWorker.mockReset()
 	mockModule.createWorker.mockResolvedValue(createBundleResult('warm-cache'))
@@ -90,8 +157,108 @@ test('buildKodyAppBundle reuses cached published package app bundles', async () 
 	expect(first).toBe(second)
 })
 
+test('buildKodyModuleBundle resolves scoped package imports by full package name first', async () => {
+	mockModule.createWorker.mockResolvedValue(createBundleResult('scoped-import'))
+	mockModule.getSavedPackageByName.mockResolvedValue(
+		createSavedPackageRecord({
+			name: '@kentcdodds/example-package',
+			kodyId: 'example-package',
+		}),
+	)
+	mockModule.getSavedPackageByKodyId.mockResolvedValue(null)
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue(createLoadedPackageSource())
+
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+
+	await buildKodyModuleBundle({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/local-package',
+				exports: {
+					'.': './index.js',
+				},
+				kody: {
+					id: 'local-package',
+					description: 'Local package',
+				},
+			}),
+			'index.js':
+				'import followUp from "kody:@kentcdodds/example-package/follow-up-on-pr-agent"\nexport default followUp\n',
+		},
+		entryPoint: 'index.js',
+	})
+
+	expect(mockModule.getSavedPackageByName).toHaveBeenCalledWith(
+		{},
+		{
+			userId: 'user-1',
+			name: '@kentcdodds/example-package',
+		},
+	)
+	expect(mockModule.getSavedPackageByKodyId).toHaveBeenCalledWith(
+		{},
+		{
+			userId: 'user-1',
+			kodyId: 'example-package',
+		},
+	)
+	const firstCall = mockModule.createWorker.mock.calls[0]?.[0] as
+		| {
+				files?: Record<string, string>
+		  }
+		| undefined
+	expect(firstCall?.files?.['.__kody_root__/index.js']).toContain(
+		'./.__kody_virtual__/imports/kody--kentcdodds/example-package/follow-up-on-pr-agent.js',
+	)
+	expect(firstCall?.files?.['.__kody_root__/index.js']).not.toContain(
+		'kody:@kentcdodds/example-package/follow-up-on-pr-agent',
+	)
+})
+
+test('buildKodyModuleBundle rejects kody id shorthand imports', async () => {
+	mockModule.createWorker.mockResolvedValue(createBundleResult('kody-id-import'))
+
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+
+	await expect(
+		buildKodyModuleBundle({
+			env: {
+				APP_DB: {},
+				REPO_SESSION: {},
+			} as Env,
+			baseUrl: 'https://heykody.dev',
+			userId: 'user-1',
+			sourceFiles: {
+				'package.json': JSON.stringify({
+					name: '@kentcdodds/local-package',
+					exports: {
+						'.': './index.js',
+					},
+					kody: {
+						id: 'local-package',
+						description: 'Local package',
+					},
+				}),
+				'index.js':
+					'import followUp from "kody:@example-package/follow-up-on-pr-agent"\nexport default followUp\n',
+			},
+			entryPoint: 'index.js',
+		}),
+	).rejects.toThrow(
+		'Kody package imports must use the full package.json name, for example "kody:@scope/package-name/export".',
+	)
+
+	expect(mockModule.getSavedPackageByName).not.toHaveBeenCalled()
+	expect(mockModule.getSavedPackageByKodyId).not.toHaveBeenCalled()
+})
+
 test('buildKodyAppBundle does not cache unpublished package app bundles', async () => {
-	mockModule.createWorker.mockReset()
 	mockModule.createWorker
 		.mockResolvedValueOnce(createBundleResult('uncached-first'))
 		.mockResolvedValueOnce(createBundleResult('uncached-second'))
@@ -111,7 +278,6 @@ test('buildKodyAppBundle does not cache unpublished package app bundles', async 
 })
 
 test('buildKodyAppBundle shares the same in-flight published bundle build', async () => {
-	mockModule.createWorker.mockReset()
 	let resolveBundle:
 		| ((value: { mainModule: string; modules: WorkerLoaderModules }) => void)
 		| null = null
@@ -154,7 +320,6 @@ test('buildKodyAppBundle shares the same in-flight published bundle build', asyn
 })
 
 test('buildKodyAppBundle evicts rejected published bundle builds before retrying', async () => {
-	mockModule.createWorker.mockReset()
 	mockModule.createWorker
 		.mockRejectedValueOnce(new Error('bundle failed'))
 		.mockResolvedValueOnce(createBundleResult('retry-success'))
@@ -189,7 +354,6 @@ test('buildKodyAppBundle evicts rejected published bundle builds before retrying
 })
 
 test('buildKodyAppBundle keeps separate cache entries for different app entrypoints', async () => {
-	mockModule.createWorker.mockReset()
 	mockModule.createWorker
 		.mockResolvedValueOnce(createBundleResult('entry-app'))
 		.mockResolvedValueOnce(createBundleResult('entry-admin'))
@@ -230,7 +394,6 @@ test('buildKodyAppBundle keeps separate cache entries for different app entrypoi
 })
 
 test('buildKodyAppBundle rewrites kody runtime imports inside TypeScript package apps', async () => {
-	mockModule.createWorker.mockReset()
 	mockModule.createWorker.mockResolvedValue(createBundleResult('ts-app'))
 
 	await buildKodyAppBundle({
@@ -289,7 +452,6 @@ export default {
 })
 
 test('buildKodyAppBundle rewrites dynamic kody runtime imports inside TypeScript package apps', async () => {
-	mockModule.createWorker.mockReset()
 	mockModule.createWorker.mockResolvedValue(createBundleResult('ts-dynamic-app'))
 
 	await buildKodyAppBundle({

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -201,20 +201,17 @@ test('buildKodyModuleBundle resolves scoped package imports by full package name
 			name: '@kentcdodds/example-package',
 		},
 	)
-	expect(mockModule.getSavedPackageByKodyId).toHaveBeenCalledWith(
-		{},
-		{
-			userId: 'user-1',
-			kodyId: 'example-package',
-		},
-	)
+	expect(mockModule.getSavedPackageByKodyId).not.toHaveBeenCalled()
 	const firstCall = mockModule.createWorker.mock.calls[0]?.[0] as
 		| {
 				files?: Record<string, string>
 		  }
 		| undefined
 	expect(firstCall?.files?.['.__kody_root__/index.js']).toContain(
-		'./.__kody_virtual__/imports/kody--kentcdodds/example-package/follow-up-on-pr-agent.js',
+		'__kody_virtual__/imports/',
+	)
+	expect(firstCall?.files?.['.__kody_root__/index.js']).toContain(
+		'kentcdodds/example-package/follow-up-on-pr-agent.js',
 	)
 	expect(firstCall?.files?.['.__kody_root__/index.js']).not.toContain(
 		'kody:@kentcdodds/example-package/follow-up-on-pr-agent',
@@ -223,6 +220,7 @@ test('buildKodyModuleBundle resolves scoped package imports by full package name
 
 test('buildKodyModuleBundle rejects kody id shorthand imports', async () => {
 	mockModule.createWorker.mockResolvedValue(createBundleResult('kody-id-import'))
+	mockModule.getSavedPackageByName.mockResolvedValue(null)
 
 	const { buildKodyModuleBundle } = await import('./module-graph.ts')
 
@@ -251,10 +249,16 @@ test('buildKodyModuleBundle rejects kody id shorthand imports', async () => {
 			entryPoint: 'index.js',
 		}),
 	).rejects.toThrow(
-		'Kody package imports must use the full package.json name, for example "kody:@scope/package-name/export".',
+		'Saved package "@example-package/follow-up-on-pr-agent" was not found for this user.',
 	)
 
-	expect(mockModule.getSavedPackageByName).not.toHaveBeenCalled()
+	expect(mockModule.getSavedPackageByName).toHaveBeenCalledWith(
+		{},
+		{
+			userId: 'user-1',
+			name: '@example-package/follow-up-on-pr-agent',
+		},
+	)
 	expect(mockModule.getSavedPackageByKodyId).not.toHaveBeenCalled()
 })
 

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -297,6 +297,104 @@ test('buildKodyModuleBundle keeps dependencies for scoped packages with the same
 	])
 })
 
+test('buildKodyModuleBundle keeps virtual package paths distinct for scoped packages with the same leaf', async () => {
+	mockModule.createWorker.mockResolvedValue(createBundleResult('shared-leaf-prefix'))
+	mockModule.getSavedPackageByName.mockImplementation(
+		async (
+			_db: unknown,
+			input: {
+				name: string
+			},
+		) => {
+			if (input.name === '@alice/shared-package') {
+				return createSavedPackageRecord({
+					name: '@alice/shared-package',
+					kodyId: 'shared-package',
+					sourceId: 'source-alice',
+				})
+			}
+			if (input.name === '@bob/shared-package') {
+				return createSavedPackageRecord({
+					name: '@bob/shared-package',
+					kodyId: 'shared-package',
+					sourceId: 'source-bob',
+				})
+			}
+			return null
+		},
+	)
+	mockModule.loadPackageSourceBySourceId.mockImplementation(
+		async (input: { sourceId: string }) => {
+			const sourceName =
+				input.sourceId === 'source-alice'
+					? '@alice/shared-package'
+					: '@bob/shared-package'
+			return {
+				source: {
+					id: input.sourceId,
+					published_commit: `commit-${input.sourceId}`,
+				},
+				manifest: {
+					name: sourceName,
+					exports: {
+						'.': './index.js',
+						'./follow-up-on-pr-agent': './follow-up-on-pr-agent.js',
+					},
+					kody: {
+						id: 'shared-package',
+						description: `${sourceName} package`,
+					},
+				},
+				files: {
+					'index.js': `export const source = ${JSON.stringify(sourceName)}`,
+					'follow-up-on-pr-agent.js': `export default ${JSON.stringify(sourceName)}`,
+				},
+			}
+		},
+	)
+
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+
+	await buildKodyModuleBundle({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/local-package',
+				exports: {
+					'.': './index.js',
+				},
+				kody: {
+					id: 'local-package',
+					description: 'Local package',
+				},
+			}),
+			'index.js': [
+				'import aliceFn from "kody:@alice/shared-package/follow-up-on-pr-agent"',
+				'import bobFn from "kody:@bob/shared-package/follow-up-on-pr-agent"',
+				'export default [aliceFn, bobFn]',
+			].join('\n'),
+		},
+		entryPoint: 'index.js',
+	})
+
+	const firstCall = mockModule.createWorker.mock.calls[0]?.[0] as
+		| {
+				files?: Record<string, string>
+		  }
+		| undefined
+	expect(firstCall?.files).toMatchObject({
+		'.__kody_packages__/@alice/shared-package/index.js':
+			'export const source = "@alice/shared-package"',
+		'.__kody_packages__/@bob/shared-package/index.js':
+			'export const source = "@bob/shared-package"',
+	})
+})
+
 test('buildKodyModuleBundle rejects kody id shorthand imports', async () => {
 	mockModule.createWorker.mockResolvedValue(createBundleResult('kody-id-import'))
 	mockModule.getSavedPackageByName.mockResolvedValue(null)

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -1,5 +1,4 @@
 import { createWorker } from '@cloudflare/worker-bundler'
-import { getSavedPackageByKodyId } from '#worker/package-registry/repo.ts'
 import {
 	loadPackageSourceBySourceId,
 	type LoadedPackageSource,
@@ -23,13 +22,17 @@ import {
 	type BundleArtifactKind,
 	type PublishedBundleArtifact,
 } from './published-runtime-artifacts.ts'
+import {
+	parseKodyPackageSpecifier,
+	packageSpecifierPrefix,
+	resolveSavedPackageImport,
+} from './package-import-resolution.ts'
 import { type RuntimeBundle } from './runtime-bundle-types.ts'
 
 const runtimeModulePath = '.__kody_virtual__/runtime.js'
 const rootSourcePrefix = '.__kody_root__'
 const packageSourcePrefix = '.__kody_packages__'
 const packageImportProxyPrefix = '.__kody_virtual__/imports'
-const packageSpecifierPrefix = 'kody:@'
 const packageAppBundleCache = createPublishedPackagePromiseCache<RuntimeBundle>()
 
 function joinPath(...parts: Array<string>) {
@@ -78,11 +81,6 @@ type RewriteState = {
 		LoadedPackageSource & { row: SavedPackageRecord; prefix: string }
 	>
 	dependencies: Map<string, BundleArtifactDependency>
-}
-
-type KodyPackageSpecifier = {
-	kodyId: string
-	exportName: string
 }
 
 function createRelativeImportSpecifier(fromPath: string, targetPath: string) {
@@ -165,24 +163,6 @@ export * from ${JSON.stringify(input.targetPath)};
 import __default from ${JSON.stringify(input.targetPath)};
 export default __default;
 `.trim()
-}
-
-function parsePackageSpecifier(specifier: string): KodyPackageSpecifier {
-	if (!specifier.startsWith(packageSpecifierPrefix)) {
-		throw new Error(`Unsupported Kody package specifier "${specifier}".`)
-	}
-	const trimmed = specifier.slice(packageSpecifierPrefix.length)
-	const separator = trimmed.indexOf('/')
-	if (separator === -1) {
-		return {
-			kodyId: trimmed.trim(),
-			exportName: '.',
-		}
-	}
-	return {
-		kodyId: trimmed.slice(0, separator).trim(),
-		exportName: trimmed.slice(separator + 1).trim(),
-	}
 }
 
 function sanitizeSpecifier(specifier: string) {
@@ -296,16 +276,21 @@ function applyReplacements(
 
 async function ensurePackageLoaded(
 	state: RewriteState,
-	kodyId: string,
+	specifier: string,
 ): Promise<LoadedPackageSource & { row: SavedPackageRecord; prefix: string }> {
-	const existing = state.packages.get(kodyId)
+	const parsed = parseKodyPackageSpecifier(specifier)
+	const packageKey = parsed.packageName
+	const existing = state.packages.get(packageKey)
 	if (existing) return existing
-	const row = await getSavedPackageByKodyId(state.env.APP_DB, {
+	const row = await resolveSavedPackageImport({
+		db: state.env.APP_DB,
 		userId: state.userId,
-		kodyId,
+		specifier: parsed,
 	})
 	if (!row) {
-		throw new Error(`Saved package "${kodyId}" was not found for this user.`)
+		throw new Error(
+			`Saved package "${parsed.packageName}" was not found for this user.`,
+		)
 	}
 	const loaded = await loadPackageSourceBySourceId({
 		env: state.env,
@@ -316,14 +301,14 @@ async function ensurePackageLoaded(
 	const entry = {
 		...loaded,
 		row,
-		prefix: joinPath(packageSourcePrefix, kodyId),
+		prefix: joinPath(packageSourcePrefix, row.kodyId),
 	}
-	state.packages.set(kodyId, entry)
+	state.packages.set(packageKey, entry)
 	if (loaded.source.published_commit) {
-		state.dependencies.set(kodyId, {
+		state.dependencies.set(row.kodyId, {
 			sourceId: loaded.source.id,
 			publishedCommit: loaded.source.published_commit,
-			kodyId,
+			kodyId: row.kodyId,
 		})
 	}
 	for (const [filePath, content] of Object.entries(loaded.files)) {
@@ -344,8 +329,8 @@ async function ensurePackageProxy(
 ): Promise<string> {
 	const existing = state.proxies.get(specifier)
 	if (existing) return existing
-	const parsed = parsePackageSpecifier(specifier)
-	const loaded = await ensurePackageLoaded(state, parsed.kodyId)
+	const parsed = parseKodyPackageSpecifier(specifier)
+	const loaded = await ensurePackageLoaded(state, specifier)
 	const exportPath = resolvePackageExportPath({
 		manifest: loaded.manifest,
 		exportName: parsed.exportName,

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -301,7 +301,7 @@ async function ensurePackageLoaded(
 	const entry = {
 		...loaded,
 		row,
-		prefix: joinPath(packageSourcePrefix, row.kodyId),
+		prefix: joinPath(packageSourcePrefix, packageKey),
 	}
 	state.packages.set(packageKey, entry)
 	if (loaded.source.published_commit) {

--- a/packages/worker/src/package-runtime/package-import-resolution.ts
+++ b/packages/worker/src/package-runtime/package-import-resolution.ts
@@ -1,0 +1,85 @@
+import { getSavedPackageByName } from '#worker/package-registry/repo.ts'
+import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+
+export const packageSpecifierPrefix = 'kody:@'
+
+export type KodyPackageSpecifier = {
+	packageName: string
+	kodyId: string
+	exportName: string
+}
+
+const kodyImportLiteralPattern = /['"](kody:@[^'"]+)['"]/g
+
+function unsupportedSpecifierError(specifier: string) {
+	return new Error(`Unsupported Kody package specifier "${specifier}".`)
+}
+
+export function parseKodyPackageSpecifier(
+	specifier: string,
+): KodyPackageSpecifier {
+	if (!specifier.startsWith(packageSpecifierPrefix)) {
+		throw unsupportedSpecifierError(specifier)
+	}
+
+	const trimmed = specifier.slice(packageSpecifierPrefix.length).trim()
+	if (!trimmed) {
+		throw unsupportedSpecifierError(specifier)
+	}
+
+	const scopeSeparator = trimmed.indexOf('/')
+	if (scopeSeparator <= 1) {
+		throw unsupportedSpecifierError(specifier)
+	}
+
+	const exportSeparator = trimmed.indexOf('/', scopeSeparator + 1)
+	const packageName =
+		exportSeparator === -1
+			? trimmed
+			: trimmed.slice(0, exportSeparator).trim()
+	const kodyId =
+		exportSeparator === -1
+			? trimmed.slice(scopeSeparator + 1).trim()
+			: trimmed.slice(scopeSeparator + 1, exportSeparator).trim()
+
+	if (!packageName || !kodyId) {
+		throw unsupportedSpecifierError(specifier)
+	}
+
+	return {
+		packageName,
+		kodyId,
+		exportName:
+			exportSeparator === -1
+				? '.'
+				: trimmed.slice(exportSeparator + 1).trim() || '.',
+	}
+}
+
+export function collectKodyPackageImportSpecifiers(source: string) {
+	const specifiers: Array<KodyPackageSpecifier> = []
+	for (const match of source.matchAll(kodyImportLiteralPattern)) {
+		const specifier = match[1]?.trim()
+		if (!specifier?.startsWith(packageSpecifierPrefix)) {
+			continue
+		}
+		specifiers.push(parseKodyPackageSpecifier(specifier))
+	}
+	return specifiers
+}
+
+export async function resolveSavedPackageImport(input: {
+	db: D1Database
+	userId: string
+	specifier: string | KodyPackageSpecifier
+}): Promise<SavedPackageRecord | null> {
+	const parsed =
+		typeof input.specifier === 'string'
+			? parseKodyPackageSpecifier(input.specifier)
+			: input.specifier
+
+	return await getSavedPackageByName(input.db, {
+		userId: input.userId,
+		name: parsed.packageName,
+	})
+}

--- a/packages/worker/src/package-runtime/package-import-resolution.ts
+++ b/packages/worker/src/package-runtime/package-import-resolution.ts
@@ -9,8 +9,6 @@ export type KodyPackageSpecifier = {
 	exportName: string
 }
 
-const kodyImportLiteralPattern = /['"](kody:@[^'"]+)['"]/g
-
 function unsupportedSpecifierError(specifier: string) {
 	return new Error(`Unsupported Kody package specifier "${specifier}".`)
 }
@@ -47,18 +45,6 @@ export function parseKodyPackageSpecifier(
 		kodyId,
 		exportName,
 	}
-}
-
-export function collectKodyPackageImportSpecifiers(source: string) {
-	const specifiers: Array<KodyPackageSpecifier> = []
-	for (const match of source.matchAll(kodyImportLiteralPattern)) {
-		const specifier = match[1]?.trim()
-		if (!specifier?.startsWith(packageSpecifierPrefix)) {
-			continue
-		}
-		specifiers.push(parseKodyPackageSpecifier(specifier))
-	}
-	return specifiers
 }
 
 export async function resolveSavedPackageImport(input: {

--- a/packages/worker/src/package-runtime/package-import-resolution.ts
+++ b/packages/worker/src/package-runtime/package-import-resolution.ts
@@ -27,32 +27,25 @@ export function parseKodyPackageSpecifier(
 		throw unsupportedSpecifierError(specifier)
 	}
 
-	const scopeSeparator = trimmed.indexOf('/')
-	if (scopeSeparator <= 1) {
+	const segments = trimmed.split('/').map((segment) => segment.trim())
+	if (segments.length < 2 || segments[0] === '' || segments[1] === '') {
 		throw unsupportedSpecifierError(specifier)
 	}
 
-	const exportSeparator = trimmed.indexOf('/', scopeSeparator + 1)
-	const packageName =
-		exportSeparator === -1
-			? trimmed
-			: trimmed.slice(0, exportSeparator).trim()
-	const kodyId =
-		exportSeparator === -1
-			? trimmed.slice(scopeSeparator + 1).trim()
-			: trimmed.slice(scopeSeparator + 1, exportSeparator).trim()
-
-	if (!packageName || !kodyId) {
+	const scope = segments[0]
+	const packageLeaf = segments[1]
+	if (!scope || !packageLeaf) {
 		throw unsupportedSpecifierError(specifier)
 	}
+
+	const packageName = `@${scope}/${packageLeaf}`
+	const kodyId = packageLeaf
+	const exportName = segments.slice(2).join('/').trim() || '.'
 
 	return {
 		packageName,
 		kodyId,
-		exportName:
-			exportSeparator === -1
-				? '.'
-				: trimmed.slice(exportSeparator + 1).trim() || '.',
+		exportName,
 	}
 }
 

--- a/packages/worker/src/package-runtime/package-import-resolution.ts
+++ b/packages/worker/src/package-runtime/package-import-resolution.ts
@@ -5,7 +5,6 @@ export const packageSpecifierPrefix = 'kody:@'
 
 export type KodyPackageSpecifier = {
 	packageName: string
-	kodyId: string
 	exportName: string
 }
 
@@ -37,12 +36,10 @@ export function parseKodyPackageSpecifier(
 	}
 
 	const packageName = `@${scope}/${packageLeaf}`
-	const kodyId = packageLeaf
 	const exportName = segments.slice(2).join('/').trim() || '.'
 
 	return {
 		packageName,
-		kodyId,
 		exportName,
 	}
 }

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.ts
@@ -1,5 +1,4 @@
 import { getPackageAppEntryPath } from '#worker/package-registry/manifest.ts'
-import { getSavedPackageByKodyId } from '#worker/package-registry/repo.ts'
 import {
 	type AuthoredPackageJson,
 	type SavedPackageRecord,
@@ -26,6 +25,11 @@ import {
 } from '#worker/repo/published-bundle-artifacts-repo.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
+import {
+	parseKodyPackageSpecifier,
+	resolveSavedPackageImport,
+	packageSpecifierPrefix,
+} from './package-import-resolution.ts'
 
 type DependencyResolutionState = {
 	env: Env
@@ -62,28 +66,30 @@ function normalizeEntryPoint(entryPoint: string) {
 
 async function resolveDependencyForPackage(input: {
 	state: DependencyResolutionState
-	kodyId: string
+	specifier: string
 }) {
-	const existing = input.state.visited.has(input.kodyId)
+	const parsed = parseKodyPackageSpecifier(input.specifier)
+	const existing = input.state.visited.has(parsed.packageName)
 	if (existing) return
-	input.state.visited.add(input.kodyId)
-	const row = await getSavedPackageByKodyId(input.state.env.APP_DB, {
+	input.state.visited.add(parsed.packageName)
+	const row = await resolveSavedPackageImport({
+		db: input.state.env.APP_DB,
 		userId: input.state.userId,
-		kodyId: input.kodyId,
+		specifier: parsed,
 	})
 	if (!row) {
-		throw new Error(`Saved package "${input.kodyId}" was not found for this user.`)
+		throw new Error(`Saved package "${parsed.packageName}" was not found for this user.`)
 	}
 	const source = await getEntitySourceById(input.state.env.APP_DB, row.sourceId)
 	if (!source?.published_commit) {
 		throw new Error(
-			`Saved package "${input.kodyId}" source "${row.sourceId}" has no published commit.`,
+			`Saved package "${row.name}" source "${row.sourceId}" has no published commit.`,
 		)
 	}
 	input.state.dependencies.push({
 		sourceId: source.id,
 		publishedCommit: source.published_commit,
-		kodyId: input.kodyId,
+		kodyId: row.kodyId,
 	})
 }
 
@@ -92,7 +98,7 @@ async function collectDependenciesFromFiles(input: {
 	userId: string
 	files: Record<string, string>
 }) {
-	const packageSpecifierPattern = /['"]kody:@([^/'"]+)(?:\/[^'"]*)?['"]/g
+	const packageSpecifierPattern = /['"](kody:@[^'"]+)['"]/g
 	const state: DependencyResolutionState = {
 		env: input.env,
 		userId: input.userId,
@@ -101,11 +107,11 @@ async function collectDependenciesFromFiles(input: {
 	}
 	for (const content of Object.values(input.files)) {
 		for (const match of content.matchAll(packageSpecifierPattern)) {
-			const kodyId = match[1]?.trim()
-			if (!kodyId) continue
+			const specifier = match[1]?.trim()
+			if (!specifier?.startsWith(packageSpecifierPrefix)) continue
 			await resolveDependencyForPackage({
 				state,
-				kodyId,
+				specifier,
 			})
 		}
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- resolve saved-package imports strictly by full `package.json.name` and remove `kody.id` import shorthand support
- enforce that the leaf segment of `package.json.name` matches `kody.id` during manifest parsing so name-based resolution stays deterministic
- update runtime/search guidance and add focused regression tests for scoped imports, shorthand rejection, and manifest validation

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58ab3b4a-d35b-4b65-a72b-346f8f796329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58ab3b4a-d35b-4b65-a72b-346f8f796329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package naming requirements: packages must use scoped names where the leaf portion matches package ID.
  * Updated cross-package import specifiers to use full scoped format (`kody:@scope/package-name/export`).

* **Validation**
  * Enhanced package validation to enforce scoped naming conventions and verify consistency between package name and ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->