### PR TITLE
Fix generated Wrangler migration ordering

### DIFF
--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+
+import { parseJsonc, writeGeneratedWranglerConfig } from './resource-utils.ts'
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url))
+const workerWranglerConfigPath = path.resolve(
+	thisDir,
+	'../../packages/worker/wrangler.jsonc',
+)
+
+test('writeGeneratedWranglerConfig keeps migrations ordered by tag version', async () => {
+	const tempDir = await mkdtemp(path.join(os.tmpdir(), 'kody-resource-utils-'))
+
+	try {
+		const outConfigPath = path.join(tempDir, 'wrangler-production.generated.json')
+		await writeGeneratedWranglerConfig({
+			baseConfigPath: workerWranglerConfigPath,
+			outConfigPath,
+			envName: 'production',
+			d1DatabaseName: 'kody',
+			d1DatabaseId: 'dry-run-kody',
+			oauthKvId: 'dry-run-kody-oauth',
+			bundleArtifactsKvId: 'dry-run-kody-bundle-artifacts',
+			extraMigrations: [
+				{
+					deleted_classes: ['AppRunner'],
+					tag: 'v12',
+				},
+			],
+		})
+
+		const generatedConfigText = await readFile(outConfigPath, 'utf8')
+		const generatedConfig = parseJsonc<{
+			migrations: Array<{ tag: string; new_sqlite_classes?: Array<string> }>
+		}>(generatedConfigText)
+		const migrationTags = generatedConfig.migrations.map((migration) => migration.tag)
+		const v12Index = migrationTags.indexOf('v12')
+		const v13Index = migrationTags.indexOf('v13')
+
+		expect(v12Index).toBeGreaterThanOrEqual(0)
+		expect(v13Index).toBeGreaterThan(v12Index)
+		expect(generatedConfig.migrations[v13Index]?.new_sqlite_classes).toContain(
+			'PackageRealtimeSession',
+		)
+	} finally {
+		await rm(tempDir, { force: true, recursive: true })
+	}
+})

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -244,6 +244,36 @@ export function parseJsonc<T>(source: string): T {
 	return JSON.parse(json) as T
 }
 
+function getMigrationTagVersion(tag: unknown) {
+	if (typeof tag !== 'string') return undefined
+	const match = /^v(\d+)$/.exec(tag)
+	if (!match) return undefined
+	return Number(match[1])
+}
+
+function sortWranglerMigrations(migrations: Array<Record<string, unknown>>) {
+	const orderedMigrations = migrations
+		.map((migration, index) => ({
+			index,
+			migration,
+			version: getMigrationTagVersion(migration.tag),
+		}))
+		.sort((left, right) => {
+			if (
+				left.version === undefined ||
+				right.version === undefined ||
+				left.version === right.version
+			) {
+				return left.index - right.index
+			}
+
+			return left.version - right.version
+		})
+		.map(({ migration }) => migration)
+
+	migrations.splice(0, migrations.length, ...orderedMigrations)
+}
+
 export async function writeGeneratedWranglerConfig({
 	baseConfigPath,
 	outConfigPath,
@@ -384,6 +414,7 @@ export async function writeGeneratedWranglerConfig({
 				migrationList.push(extraMigration)
 			}
 		}
+		sortWranglerMigrations(migrationList)
 	}
 
 	const resolvedOut = path.resolve(outConfigPath)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep generated Wrangler Durable Object migrations sorted by tag version when adding production-only entries
- add a regression test for generated production configs so `v12` stays before `v13`

## Testing
- `npx vitest run --project node-unit tools/ci/resource-utils.node.test.ts`
- `node tools/ci/production-resources.ts ensure --dry-run --out-config packages/worker/wrangler-production.generated.json`
- `cp packages/worker/.env.example packages/worker/.env && npm run build`
- `cp packages/worker/.env.example packages/worker/.env && node --env-file=packages/worker/.env ./wrangler-env.ts deploy --dry-run --outdir .wrangler/sentry-bundle --upload-source-maps --config packages/worker/wrangler-production.generated.json --var APP_COMMIT_SHA:test-sha`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31c91a67-e6d9-4158-9f81-b9896c8999c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31c91a67-e6d9-4158-9f81-b9896c8999c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migrations are now automatically sorted by version number in the generated configuration, ensuring deterministic and correct ordering even when additional migrations are inserted.

* **Tests**
  * Added test coverage verifying that migration ordering is preserved and migration-specific values are correctly populated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->