### PR TITLE
Add package-approved secrets, persistent services, and package subscriptions

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -111,8 +111,8 @@ elsewhere, and secret-bearing capability inputs require an authenticated user.
 Those inputs are also treated as write-only for the rest of that execution: once
 plaintext crosses an `x-kody-secret` capability boundary, Kody redacts that
 plaintext from later execute results and logs before returning them to the
-caller. Capability authors should avoid returning or logging secret
-material, but the runtime adds this extra defense-in-depth layer.
+caller. Capability authors should avoid returning or logging secret material,
+but the runtime adds this extra defense-in-depth layer.
 
 When a secret has an `allowed_capabilities` policy, Kody also checks that the
 current capability name is explicitly listed before resolving the placeholder.

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -122,8 +122,8 @@ Production note:
 - During `npm run dev`, those REST calls go to the local Cloudflare mock Worker,
   which implements the Artifacts repo metadata endpoints used by the app
   (`create`, `get`, `list`, `createToken`, and `fork`). The mock only covers the
-  REST control plane; repo session Durable Objects need a Git-capable remote
-  for clone/pull/push flows.
+  REST control plane; repo session Durable Objects need a Git-capable remote for
+  clone/pull/push flows.
 - Durable repo-source creation paths
   (`ensureEntitySource(..., requirePersistence: true)`) fail closed when
   persistence bindings are unavailable so callers do not write orphaned

--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -4,8 +4,8 @@ This folder documents the important runtime architecture for `kody`.
 
 Before making product-level assumptions, read
 [`../project-intent.md`](../project-intent.md). The architecture docs describe
-how the system works, while the intent doc explains what the project
-is trying to become.
+how the system works, while the intent doc explains what the project is trying
+to become.
 
 ## Core docs
 

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -100,8 +100,8 @@ Full page navigations occur for:
 - Allowed methods are `GET, POST, OPTIONS`.
 - Allowed headers include `content-type` and `authorization`.
 
-This keeps cross-origin behavior narrow while allowing same-origin browser
-and API requests.
+This keeps cross-origin behavior narrow while allowing same-origin browser and
+API requests.
 
 ## Observability (Sentry)
 

--- a/docs/contributing/cloudflare-offerings.md
+++ b/docs/contributing/cloudflare-offerings.md
@@ -46,8 +46,8 @@ Recommended baseline permissions for this template (deploy + existing D1/KV):
 Add these permissions when you add the corresponding offering:
 
 - R2: `R2 Storage:Edit`
-- Workers AI: `Workers AI:Read` (for `wrangler ai models`; deploy uses
-  Workers Scripts)
+- Workers AI: `Workers AI:Read` (for `wrangler ai models`; deploy uses Workers
+  Scripts)
 - AI Gateway (only if you want to manage gateways via API): `AI Gateway:Edit`
 
 If you use `npx wrangler secret put ...` in CI, your token must also be able to

--- a/docs/contributing/end-to-end-testing.md
+++ b/docs/contributing/end-to-end-testing.md
@@ -69,8 +69,8 @@ Avoid `page.locator('css')` unless no accessible alternative exists.
   suite starts.
 - `npm run test:e2e:ui` and plain `npx playwright test` assume Playwright
   browsers are already installed.
-- Playwright sets `CLOUDFLARE_ENV=test`; Wrangler loads
-  `packages/worker/.env` values for local secrets.
+- Playwright sets `CLOUDFLARE_ENV=test`; Wrangler loads `packages/worker/.env`
+  values for local secrets.
 - Ensure the `env.test` section in `packages/worker/wrangler.jsonc` includes
   assets, KV, and durable objects since these are not inherited from top-level
   Wrangler config.

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -110,8 +110,8 @@ Optional Worker secrets/vars (see `packages/worker/src/env-schema.ts` and
 - `CLOUDFLARE_API_BASE_URL` — API base URL; defaults to
   `https://api.cloudflare.com` when unset, including for outbound email sending.
   Local `npm run dev` sets this to the Cloudflare mock Worker unless
-  `AI_MODE=remote` or `SKIP_CLOUDFLARE_MOCK=1`. That same local mock
-  serves the Artifacts REST control-plane endpoints used by
+  `AI_MODE=remote` or `SKIP_CLOUDFLARE_MOCK=1`. That same local mock serves the
+  Artifacts REST control-plane endpoints used by
   `packages/worker/src/repo/artifacts.ts` (`repos`, `tokens`, and `fork`), so
   local repo create/get/list/token/fork calls do not need the live Artifacts
   REST API.
@@ -141,9 +141,9 @@ See `packages/worker/src/env-schema.ts` and
   fallback. At Worker boot, invalid JSON or malformed keys fail env validation
   with a clear error. At runtime, if the value is a plain string in a test
   harness, malformed JSON is logged and ignored for map lookup only.
-- For **`kind: home`**, if a key is missing in the map, the worker falls
-  back to **`HOME_CONNECTOR_SHARED_SECRET`**. Non-`home` kinds have **no**
-  legacy fallback; they must appear in the map (or hello is rejected).
+- For **`kind: home`**, if a key is missing in the map, the worker falls back to
+  **`HOME_CONNECTOR_SHARED_SECRET`**. Non-`home` kinds have **no** legacy
+  fallback; they must appear in the map (or hello is rejected).
 
 Authoring guide for outbound WebSocket services:
 [`architecture/remote-connectors.md`](./architecture/remote-connectors.md).

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -9,9 +9,8 @@ Use these steps to run `kody` locally and on Cloudflare Workers.
 
 If you are here to understand the purpose of this repository rather than set it
 up, read [`docs/contributing/project-intent.md`](./project-intent.md) first.
-This repo has some template lineage in its docs and structure, but the
-project intent is to build a personal assistant with an MCP-first
-architecture.
+This repo has some template lineage in its docs and structure, but the project
+intent is to build a personal assistant with an MCP-first architecture.
 
 ## Create the project with degit
 

--- a/docs/contributing/mcp-server-patterns.md
+++ b/docs/contributing/mcp-server-patterns.md
@@ -275,8 +275,8 @@ return {
 - Trunk
 ```
 
-**Example in this repo:** Tools return human-readable markdown in `content`
-and machine-friendly data in `structuredContent`. Tool descriptions should not
+**Example in this repo:** Tools return human-readable markdown in `content` and
+machine-friendly data in `structuredContent`. Tool descriptions should not
 mention these protocol field names.
 
 ---
@@ -433,8 +433,8 @@ Resources provide **read-only data access** with:
 - `media://feeds/{id}` — Individual feed details
 - `media://directories` — Available media directories
 
-**Example in this repo:** Resources are not registered, but this
-pattern is recommended for exposing read-only docs and server metadata.
+**Example in this repo:** Resources are not registered, but this pattern is
+recommended for exposing read-only docs and server metadata.
 
 ---
 
@@ -464,5 +464,5 @@ Available media roots:
 Please ask me some questions to understand what I'm trying to create, then help me set it up.
 ```
 
-**Example in this repo:** Prompts are not registered, but this pattern
-is recommended for guiding multi-step workflows.
+**Example in this repo:** Prompts are not registered, but this pattern is
+recommended for guiding multi-step workflows.

--- a/docs/contributing/mock-api-servers.md
+++ b/docs/contributing/mock-api-servers.md
@@ -18,8 +18,8 @@ Worker package so it can also be deployed alongside the main app.
 
 See `packages/mock-servers/cloudflare/` for a small Cloudflare API v4 subset
 mock used by tests and the internal API client (started by `npm run dev` unless
-`SKIP_CLOUDFLARE_MOCK=1`). It covers the Cloudflare Email REST fallback plus
-the Artifacts REST control-plane endpoints used by
+`SKIP_CLOUDFLARE_MOCK=1`). It covers the Cloudflare Email REST fallback plus the
+Artifacts REST control-plane endpoints used by
 `packages/worker/src/repo/artifacts.ts` (`repos`, `repo info`, `tokens`, and
 `fork`).
 

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -11,8 +11,8 @@ Kody-specific metadata.
 Use `package.json` as the canonical source of truth for saved package metadata.
 
 - `name` — npm-valid scoped package name (`@scope/<leaf>`); the leaf segment
-  must match `kody.id` (for example `@kentcdodds/cursor-cloud-agents` pairs
-  with `kody.id: "cursor-cloud-agents"`)
+  must match `kody.id` (for example `@kentcdodds/cursor-cloud-agents` pairs with
+  `kody.id: "cursor-cloud-agents"`)
 - `exports` — authoritative import/export map
 - `kody.id` — user-scoped Kody package id
 - `kody.description` — package description for search/detail

--- a/docs/contributing/project-intent.md
+++ b/docs/contributing/project-intent.md
@@ -21,9 +21,9 @@ This repository is:
 - The foundation for a personal assistant rather than a general-purpose SaaS
   product.
 
-Some existing docs and code reflect this project's starter/template
-lineage. When those conflict with the direction described here, treat this
-document as the intent for the current project.
+Some existing docs and code reflect this project's starter/template lineage.
+When those conflict with the direction described here, treat this document as
+the intent for the current project.
 
 ## Who this is for
 

--- a/docs/contributing/remix/update.md
+++ b/docs/contributing/remix/update.md
@@ -51,8 +51,8 @@ If a package is added or removed upstream, update
 
 ## 5) Audit export coverage
 
-Confirm `docs/contributing/remix/index.md` package rows cover all
-top-level exports from the installed `remix` package:
+Confirm `docs/contributing/remix/index.md` package rows cover all top-level
+exports from the installed `remix` package:
 
 ```sh
 node -e "const fs=require('fs');const pkg=JSON.parse(fs.readFileSync('node_modules/remix/package.json','utf8'));const top=[...new Set(Object.keys(pkg.exports).filter(k=>k!=='./package.json').map(k=>k.slice(2).split('/')[0]))].sort();const idx=fs.readFileSync('docs/contributing/remix/index.md','utf8');const docs=[...new Set([...idx.matchAll(/^\\|\\s*([a-z0-9-]+)\\s*\\|/gm)].map(m=>m[1]).filter(x=>!['Package','--------------------------'].includes(x)))].sort();const missing=top.filter(x=>!docs.includes(x));console.log(missing.length===0?'No missing package docs in index.':'Missing docs for: '+missing.join(', '));"

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -96,8 +96,8 @@ automatically:
   embeddings in Vectorize. Saved package projections refresh when packages are
   saved or published.)
 
-Tests run with `CLOUDFLARE_ENV=test` (set by Playwright) and read local
-secrets from `packages/worker/.env`.
+Tests run with `CLOUDFLARE_ENV=test` (set by Playwright) and read local secrets
+from `packages/worker/.env`.
 
 ## GitHub Actions configuration
 

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -39,17 +39,17 @@ Quick notes for getting a local kody environment running.
   client, local email sending, and Artifacts REST repo
   create/get/list/token/fork calls. Those REST calls do not hit the live
   Cloudflare Artifacts control plane during normal local development. The mock
-  covers only the REST control plane; repo-session git clone/pull/push
-  flows need a real Git-capable Artifacts remote and are not fully simulated
-  by the local mock. Unless you already set `CLOUDFLARE_EMAIL_FROM`,
-  the launcher also defaults it to `reset@kody.dev`. Set
-  `SKIP_CLOUDFLARE_MOCK=1` to skip the local Cloudflare mock entirely. The home
-  connector receives the resolved worker origin via `WORKER_BASE_URL`. When
-  `HOME_CONNECTOR_SHARED_SECRET` is unset, the launcher generates one and passes
-  it to both the worker and the connector so the outbound registration handshake
-  succeeds in local development. The main worker and home connector stream logs
-  live; the client bundle and background mock workers buffer logs and only print
-  them if that child process exits with an error.)
+  covers only the REST control plane; repo-session git clone/pull/push flows
+  need a real Git-capable Artifacts remote and are not fully simulated by the
+  local mock. Unless you already set `CLOUDFLARE_EMAIL_FROM`, the launcher also
+  defaults it to `reset@kody.dev`. Set `SKIP_CLOUDFLARE_MOCK=1` to skip the
+  local Cloudflare mock entirely. The home connector receives the resolved
+  worker origin via `WORKER_BASE_URL`. When `HOME_CONNECTOR_SHARED_SECRET` is
+  unset, the launcher generates one and passes it to both the worker and the
+  connector so the outbound registration handshake succeeds in local
+  development. The main worker and home connector stream logs live; the client
+  bundle and background mock workers buffer logs and only print them if that
+  child process exits with an error.)
 - The home automation connector lives in `packages/home-connector`.
   - `npm run dev:home-connector` starts the local connector app on Node 24 with
     `node --watch`, so connector code changes automatically restart the local
@@ -98,13 +98,12 @@ Quick notes for getting a local kody environment running.
   - The Samsung TV tool surface intentionally focuses on discovery, pairing,
     remote keys, known-app probing, explicit app launch by app ID, and Art Mode
     control.
-  - Samsung power support is exposed as best-effort `power off` and
-    `power on` actions. Power off uses the local Samsung remote channel and
-    power on uses Wake-on-LAN with the stored TV MAC address. These
-    semantics are model- and firmware-dependent, especially on Frame TVs where
-    the regular power key may be mapped to Art Mode rather than true standby.
-  - Full installed-app enumeration is considered model- and
-    firmware-dependent.
+  - Samsung power support is exposed as best-effort `power off` and `power on`
+    actions. Power off uses the local Samsung remote channel and power on uses
+    Wake-on-LAN with the stored TV MAC address. These semantics are model- and
+    firmware-dependent, especially on Frame TVs where the regular power key may
+    be mapped to Art Mode rather than true standby.
+  - Full installed-app enumeration is considered model- and firmware-dependent.
 - MCP **`search`** uses a deterministic offline ranker in tests and when
   `WRANGLER_IS_LOCAL_DEV` is set (no Vectorize / Workers AI embedding calls
   required for `npm run test` or unauthenticated local runs). Production uses
@@ -150,8 +149,8 @@ Quick notes for getting a local kody environment running.
 - `npm run test:e2e:run` ensures Playwright Chromium is installed before the
   suite starts, so `npm run validate` and `npm run test:push` self-heal on a
   fresh machine.
-- Use `npm run test:e2e:install` when you want to prefetch Playwright
-  browsers ahead of time instead of waiting for the first E2E run.
+- Use `npm run test:e2e:install` when you want to prefetch Playwright browsers
+  ahead of time instead of waiting for the first E2E run.
 - `npm run test:e2e:run` runs the Playwright suite through Nx and depends on a
   cached `worker:prepare-e2e-env` target for `.env` bootstrap plus an uncached
   `worker:prepare-playwright` target that checks the local Chromium install.
@@ -248,9 +247,9 @@ When a PR is closed, the cleanup job deletes the preview Worker(s) and these
 resources as well.
 
 Cloudflare Workers supports version `preview_urls`, but those preview URLs are
-not available for Workers that use Durable Objects. The main app
-Worker binds `MCP_OBJECT`, so app previews continue to use per-PR Worker names.
-Mock Workers do not use Durable Objects, so their Wrangler configs opt into
+not available for Workers that use Durable Objects. The main app Worker binds
+`MCP_OBJECT`, so app previews continue to use per-PR Worker names. Mock Workers
+do not use Durable Objects, so their Wrangler configs opt into
 `preview_urls = true` and the workflow includes mock version preview links when
 Cloudflare returns them.
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -10,7 +10,7 @@ available `guide` ids).
 | [integration-bootstrap.md](./integration-bootstrap.md)                         | **Start here** for third-party integrations that must work before saving a dependent package or package app |
 | [secret-backed-integration.md](./secret-backed-integration.md)                 | Default recipe for non-OAuth integrations that use one or more saved secrets                                |
 | [integration-backed-app-happy-path.md](./integration-backed-app-happy-path.md) | Default package app pattern after integration smoke test passes                                             |
-| [package-service-pattern.md](./package-service-pattern.md)                      | General package-service pattern for native long-lived runtimes inside Kody                                   |
+| [package-service-pattern.md](./package-service-pattern.md)                     | General package-service pattern for native long-lived runtimes inside Kody                                  |
 | [oauth.md](./oauth.md)                                                         | **Start here** for third-party OAuth (`/connect/oauth`, redirect URI, params)                               |
 | [generated-ui-oauth.md](./generated-ui-oauth.md)                               | Edge case: OAuth in a hosted package app (`open_generated_ui` on a saved package)                           |
 | [connect-secret.md](./connect-secret.md)                                       | `/connect/secret` URL parameters and policies                                                               |

--- a/docs/guides/connect-secret.md
+++ b/docs/guides/connect-secret.md
@@ -5,8 +5,8 @@ secret value such as an API key or personal access token. The agent must never
 see the secret value.
 
 If the secret will power a downstream package or package app, load
-`kody_official_guide` with `guide: "integration_bootstrap"` before building
-that package. For the common non-OAuth path after bootstrap, load
+`kody_official_guide` with `guide: "integration_bootstrap"` before building that
+package. For the common non-OAuth path after bootstrap, load
 `kody_official_guide` with `guide: "secret_backed_integration"`. This guide
 covers the secret-collection step only.
 

--- a/docs/guides/integration-bootstrap.md
+++ b/docs/guides/integration-bootstrap.md
@@ -49,7 +49,8 @@ If those conditions are not met, stop and fix the integration first.
 3. If the required connector or secret is missing, **stop**.
    - Surface the exact `/connect/oauth` or `/connect/secret` URL in chat.
    - Wait for the user to confirm they completed the connect flow.
-   - Do not save a downstream auth-dependent package or package app until integration setup is complete.
+   - Do not save a downstream auth-dependent package or package app until
+     integration setup is complete.
 4. After the user confirms setup, run a minimal authenticated smoke test in
    `execute`.
    - Import OAuth helpers explicitly from `kody:runtime`; they are not ambient
@@ -112,8 +113,7 @@ Avoid these common mistakes:
 
 - building a polished UI first and only discovering later that auth is missing
 - saving a package app that assumes a non-existent secret or connector
-- treating a rendered app as success when the first authenticated API call
-  fails
+- treating a rendered app as success when the first authenticated API call fails
 - using `generated_ui_oauth` by default instead of the standard `/connect/oauth`
   path
 - skipping the authenticated smoke test after the user completes setup

--- a/docs/guides/package-service-pattern.md
+++ b/docs/guides/package-service-pattern.md
@@ -22,25 +22,25 @@ Example manifest shape:
 
 ```json
 {
-  "name": "@scope/realtime-supervisor",
-  "exports": {
-    ".": "./src/index.ts",
-    "./format-event": "./src/format-event.ts"
-  },
-  "kody": {
-    "id": "realtime-supervisor",
-    "description": "Native long-lived service package",
-    "app": {
-      "entry": "./src/app.ts"
-    },
-    "services": {
-      "realtime-supervisor": {
-        "entry": "./src/services/realtime-supervisor.ts",
-        "autoStart": true,
-        "timeoutMs": 300000
-      }
-    }
-  }
+	"name": "@scope/realtime-supervisor",
+	"exports": {
+		".": "./src/index.ts",
+		"./format-event": "./src/format-event.ts"
+	},
+	"kody": {
+		"id": "realtime-supervisor",
+		"description": "Native long-lived service package",
+		"app": {
+			"entry": "./src/app.ts"
+		},
+		"services": {
+			"realtime-supervisor": {
+				"entry": "./src/services/realtime-supervisor.ts",
+				"autoStart": true,
+				"timeoutMs": 300000
+			}
+		}
+	}
 }
 ```
 
@@ -102,42 +102,46 @@ Pseudo-code shape:
 import { service, storage } from 'kody:runtime'
 
 async function openSocket(session: unknown) {
-  void session
-  return await new Promise<WebSocket>((resolve, reject) => {
-    const socket = new WebSocket('wss://example.com/stream')
-    socket.addEventListener('open', () => resolve(socket), { once: true })
-    socket.addEventListener('error', () => reject(new Error('Failed to open stream')), {
-      once: true,
-    })
-  })
+	void session
+	return await new Promise<WebSocket>((resolve, reject) => {
+		const socket = new WebSocket('wss://example.com/stream')
+		socket.addEventListener('open', () => resolve(socket), { once: true })
+		socket.addEventListener(
+			'error',
+			() => reject(new Error('Failed to open stream')),
+			{
+				once: true,
+			},
+		)
+	})
 }
 
 export default async function run() {
-  const session = (await storage.get('session-state')) ?? null
-  const socket = await openSocket(session)
+	const session = (await storage.get('session-state')) ?? null
+	const socket = await openSocket(session)
 
-  try {
-    // Authenticate, subscribe, or resume here.
+	try {
+		// Authenticate, subscribe, or resume here.
 
-    while (
-      socket.readyState !== WebSocket.CLOSING &&
-      socket.readyState !== WebSocket.CLOSED
-    ) {
-      if (await service.shouldStop()) {
-        socket.close(1000, 'service stop requested')
-        await service.clearAlarm()
-        return { stopped: true }
-      }
+		while (
+			socket.readyState !== WebSocket.CLOSING &&
+			socket.readyState !== WebSocket.CLOSED
+		) {
+			if (await service.shouldStop()) {
+				socket.close(1000, 'service stop requested')
+				await service.clearAlarm()
+				return { stopped: true }
+			}
 
-      const event = await readNextEvent(socket)
-      await persistRuntimeState(storage, event)
-      await handleRuntimeEvent(event)
-    }
-  } catch (error) {
-    await persistFailure(storage, error)
-    await service.setAlarm(new Date(Date.now() + 5_000))
-    throw error
-  }
+			const event = await readNextEvent(socket)
+			await persistRuntimeState(storage, event)
+			await handleRuntimeEvent(event)
+		}
+	} catch (error) {
+		await persistFailure(storage, error)
+		await service.setAlarm(new Date(Date.now() + 5_000))
+		throw error
+	}
 }
 ```
 

--- a/docs/guides/secret-backed-integration.md
+++ b/docs/guides/secret-backed-integration.md
@@ -100,8 +100,8 @@ Generated UI is the exception when the setup requires something
 - a required transformation step that cannot be represented by saving the raw
   secret plus values directly
 
-Even then, keep the UI focused on setup. The downstream package should wait
-for the post-setup smoke test.
+Even then, keep the UI focused on setup. The downstream package should wait for
+the post-setup smoke test.
 
 ## Recommended chat phrasing
 

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -111,8 +111,9 @@ package-owned jobs and non-package jobs created with `job_schedule` or
 - package service runs also get writable service-owned durable state scoped to
   the declared service name
 - package service runs are background-managed by the service Durable Object, so
-  `service_start` returns immediately with a running state while the service code
-  continues in the background until it finishes, errors, or cooperatively stops
+  `service_start` returns immediately with a running state while the service
+  code continues in the background until it finishes, errors, or cooperatively
+  stops
 - import **`storage`** from **`kody:runtime`**
 - use **`storage.get(...)`**, **`storage.set(...)`**, **`storage.list(...)`**,
   and **`storage.sql(query, params?)`**

--- a/docs/use/first-steps.md
+++ b/docs/use/first-steps.md
@@ -16,11 +16,11 @@ connector, value, or secret reference, then run work through **execute**.
   surface a small set of relevant long-term memories that have not already been
   shown in the same conversation.
 - **Think in packages for reusable saved code.** Packages expose exports,
-  declare package-owned jobs, and can optionally expose an app/UI surface.
-  For scheduled work that should not become a saved package, use the built-in
-  `job_schedule` capability. `job_schedule_once` remains available as a
-  one-off convenience alias, and `job_run_now` can trigger an existing job
-  immediately for debugging or catch-up runs.
+  declare package-owned jobs, and can optionally expose an app/UI surface. For
+  scheduled work that should not become a saved package, use the built-in
+  `job_schedule` capability. `job_schedule_once` remains available as a one-off
+  convenience alias, and `job_run_now` can trigger an existing job immediately
+  for debugging or catch-up runs.
 - **Ask for natural-language goals**, for example: “Search Kody for GitHub pull
   request automation” or “Find a saved package for Cloudflare DNS helpers.”
 - **Do not paste secrets in chat.** Use saved secrets, generated UI, or the

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -102,8 +102,8 @@ Treat package services like package-owned runtime modules:
 
 ## Package-owned jobs
 
-Packages can own jobs, and Kody also supports schedules that are not owned
-by a package.
+Packages can own jobs, and Kody also supports schedules that are not owned by a
+package.
 
 - Define them under `package.json#kody.jobs`
 - Reference package-local entry modules
@@ -111,10 +111,10 @@ by a package.
 
 Jobs are part of the package definition.
 
-For repo-backed jobs that are not part of a saved package, use
-`job_schedule` instead. `job_schedule_once` remains available as the one-off
-shortcut, and `job_run_now` can trigger an existing scheduled job immediately
-for debugging or ad hoc runs.
+For repo-backed jobs that are not part of a saved package, use `job_schedule`
+instead. `job_schedule_once` remains available as the one-off shortcut, and
+`job_run_now` can trigger an existing scheduled job immediately for debugging or
+ad hoc runs.
 
 ## Save and edit packages
 

--- a/docs/use/repo-sessions.md
+++ b/docs/use/repo-sessions.md
@@ -15,8 +15,8 @@ The full `edits.edits` array is opt-in through `include_edits: true`.
 
 That keeps the default response small for agent workflows that only need
 session, checks, publish status, or a count of changed files, while allowing
-callers to request the concrete changed content and diff when they need audit
-or explanation detail.
+callers to request the concrete changed content and diff when they need audit or
+explanation detail.
 
 ## Preferred workflow
 

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -66,6 +66,6 @@ setup/debugging work can often proceed without an immediate detail lookup.
 Long-term memory retrieval also requires a signed-in MCP user.
 
 Use **search** as the default way to discover whether a connector or secret
-already exists before switching to **execute**. Runtime code inside
-**execute** can call **`codemode.secret_list(...)`** when it needs secret
-metadata, but **search** remains the primary discovery path.
+already exists before switching to **execute**. Runtime code inside **execute**
+can call **`codemode.secret_list(...)`** when it needs secret metadata, but
+**search** remains the primary discovery path.

--- a/e2e/account-secrets.spec.ts
+++ b/e2e/account-secrets.spec.ts
@@ -109,7 +109,5 @@ test('landing on an approval link shows already added when the host is present',
 	const alreadyAddedNotice = page.getByRole('status')
 	await expect(alreadyAddedNotice).toBeVisible()
 	await expect(alreadyAddedNotice).toContainText('api.cloudflare.com')
-	await expect(page.getByRole('button', { name: 'Approve host' })).toHaveCount(
-		0,
-	)
+	await expect(page.getByRole('button', { name: 'Approve' })).toHaveCount(0)
 })

--- a/e2e/account-secrets.spec.ts
+++ b/e2e/account-secrets.spec.ts
@@ -110,5 +110,7 @@ test('landing on an approval link shows already added when the host is present',
 	const alreadyAddedNotice = page.getByRole('status')
 	await expect(alreadyAddedNotice).toBeVisible()
 	await expect(alreadyAddedNotice).toContainText('api.cloudflare.com')
-	await expect(page.getByRole('button', { name: 'Approve host' })).toHaveCount(0)
+	await expect(page.getByRole('button', { name: 'Approve host' })).toHaveCount(
+		0,
+	)
 })

--- a/e2e/connect-secret.spec.ts
+++ b/e2e/connect-secret.spec.ts
@@ -24,7 +24,9 @@ test('connect secret shows editable name and scope and saves the edited name', a
 	await page.getByPlaceholder('Paste the secret value').fill(secretValue)
 	await page.getByRole('button', { name: 'Review' }).click()
 
-	await expect(page.getByLabel('I confirm these details are correct.')).toBeVisible()
+	await expect(
+		page.getByLabel('I confirm these details are correct.'),
+	).toBeVisible()
 	await expect(page.getByRole('button', { name: 'Save secret' })).toBeDisabled()
 
 	await page.getByLabel('I confirm these details are correct.').check()

--- a/packages/home-connector/app/router.node.test.ts
+++ b/packages/home-connector/app/router.node.test.ts
@@ -110,7 +110,9 @@ test('home route toggles worker snapshot link by connector id', async () => {
 		const responseWithoutConnector = await router.fetch('http://example.test/')
 		expect(responseWithoutConnector.status).toBe(200)
 		const htmlWithoutConnector = await responseWithoutConnector.text()
-		expect(htmlWithoutConnector).not.toContain('/home/connectors/default/snapshot')
+		expect(htmlWithoutConnector).not.toContain(
+			'/home/connectors/default/snapshot',
+		)
 	} finally {
 		storage.close()
 	}

--- a/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
+++ b/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
@@ -435,7 +435,9 @@ test('buildGeneratedUiRuntimeHeadInjection always bootstraps runtime state and o
 	})
 	expect(defaultHead).toContain('type="importmap"')
 	expect(defaultHead).toContain('window.__kodyGeneratedUiBootstrap')
-	expect(defaultHead).toMatch(/<script type="module" src="[^"]*kody-ui-utils\.js"/)
+	expect(defaultHead).toMatch(
+		/<script type="module" src="[^"]*kody-ui-utils\.js"/,
+	)
 
 	const shellRenderedHead = buildGeneratedUiRuntimeHeadInjection({
 		mode: 'mcp',

--- a/packages/worker/client/routes/account-approval-shared.ts
+++ b/packages/worker/client/routes/account-approval-shared.ts
@@ -11,7 +11,11 @@ export type ApprovalView = {
 	currentAllowedHosts: Array<string>
 	requestedPackageId: string | null
 	requestedPackageKodyId: string | null
-	currentAllowedPackages: Array<string>
+	currentAllowedPackages: Array<{
+		packageId: string
+		kodyId: string
+		name: string
+	}>
 }
 
 export const accountSecretsApiPath = '/account/secrets.json'

--- a/packages/worker/client/routes/account-approval-shared.ts
+++ b/packages/worker/client/routes/account-approval-shared.ts
@@ -11,11 +11,7 @@ export type ApprovalView = {
 	currentAllowedHosts: Array<string>
 	requestedPackageId: string | null
 	requestedPackageKodyId: string | null
-	currentAllowedPackages: Array<{
-		packageId: string
-		kodyId: string
-		name: string
-	}>
+	currentAllowedPackages: Array<string>
 }
 
 export const accountSecretsApiPath = '/account/secrets.json'

--- a/packages/worker/client/routes/account-approval-shared.ts
+++ b/packages/worker/client/routes/account-approval-shared.ts
@@ -9,6 +9,13 @@ export type ApprovalView = {
 	requestedHost: string
 	requestedCapability: string | null
 	currentAllowedHosts: Array<string>
+	requestedPackageId: string | null
+	requestedPackageKodyId: string | null
+	currentAllowedPackages: Array<{
+		packageId: string
+		kodyId: string
+		name: string
+	}>
 }
 
 export const accountSecretsApiPath = '/account/secrets.json'

--- a/packages/worker/client/routes/account-approval-shared.ts
+++ b/packages/worker/client/routes/account-approval-shared.ts
@@ -10,12 +10,7 @@ export type ApprovalView = {
 	requestedCapability: string | null
 	currentAllowedHosts: Array<string>
 	requestedPackageId: string | null
-	requestedPackageKodyId: string | null
-	currentAllowedPackages: Array<{
-		packageId: string
-		kodyId: string
-		name: string
-	}>
+	currentAllowedPackages: Array<string>
 }
 
 export const accountSecretsApiPath = '/account/secrets.json'

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -92,7 +92,7 @@ type EditorState = {
 	value: string
 	allowedHosts: Array<string>
 	allowedCapabilities: Array<string>
-	allowedPackages: Array<string>
+	allowedPackages: Array<{ id: string; value: string }>
 }
 
 type SelectionState = {
@@ -109,6 +109,15 @@ type SecretFilterState = {
 }
 
 const secretsBasePath = '/account/secrets'
+
+let nextAllowedPackageRowId = 0
+
+function createAllowedPackageRow(value = '') {
+	return {
+		id: `allowed-package-${nextAllowedPackageRowId++}`,
+		value,
+	}
+}
 
 function formatRelativeTtl(ttlMs: number | null) {
 	if (ttlMs == null) return 'No expiry'
@@ -134,7 +143,7 @@ function createEmptyEditorState(apps: Array<PackageAppOption>): EditorState {
 		value: '',
 		allowedHosts: [''],
 		allowedCapabilities: [''],
-		allowedPackages: [''],
+		allowedPackages: [createAllowedPackageRow()],
 	}
 }
 
@@ -171,7 +180,10 @@ function createEditorStateFromSecret(secret: SecretDetail): EditorState {
 		allowedHosts: allowedHosts.length > 0 ? allowedHosts : [''],
 		allowedCapabilities:
 			allowedCapabilities.length > 0 ? allowedCapabilities : [''],
-		allowedPackages: allowedPackages.length > 0 ? allowedPackages : [''],
+		allowedPackages:
+			allowedPackages.length > 0
+				? allowedPackages.map((value) => createAllowedPackageRow(value))
+				: [createAllowedPackageRow()],
 	}
 }
 
@@ -251,6 +263,7 @@ function getAlreadyAddedNotice(input: {
 	selectedSecret: SecretDetail | null
 	approval: ApprovalView | null
 }) {
+	const formatPackageId = (packageId: string) => packageId
 	const requestedHost = normalizeSingleAllowedHost(
 		readRequestedHost(input.href),
 	)
@@ -305,7 +318,9 @@ function getAlreadyAddedNotice(input: {
 	const packageAlreadyAdded =
 		requestedPackageId != null && allowedPackageIds.includes(requestedPackageId)
 	if (packageAlreadyAdded) {
-		items.push(`Package ${requestedPackageId} is already in allowed packages.`)
+		items.push(
+			`Package ${formatPackageId(requestedPackageId)} is already in allowed packages.`,
+		)
 	}
 	if (items.length === 0) return null
 	return {
@@ -680,7 +695,7 @@ export function AccountSecretsRoute(handle: Handle) {
 			const allowedPackages = Array.from(
 				new Set(
 					editorState.allowedPackages
-						.map((value) => value.trim())
+						.map((entry) => entry.value.trim())
 						.filter((value) => value.length > 0),
 				),
 			).sort((left, right) => left.localeCompare(right))
@@ -846,11 +861,11 @@ export function AccountSecretsRoute(handle: Handle) {
 		handle.update()
 	}
 
-	function updateAllowedPackage(index: number, value: string) {
+	function updateAllowedPackage(id: string, value: string) {
 		editorState = {
 			...editorState,
-			allowedPackages: editorState.allowedPackages.map((pkg, pkgIndex) =>
-				pkgIndex === index ? value : pkg,
+			allowedPackages: editorState.allowedPackages.map((pkg) =>
+				pkg.id === id ? { ...pkg, value } : pkg,
 			),
 		}
 		handle.update()
@@ -859,18 +874,19 @@ export function AccountSecretsRoute(handle: Handle) {
 	function addAllowedPackage() {
 		editorState = {
 			...editorState,
-			allowedPackages: [...editorState.allowedPackages, ''],
+			allowedPackages: [...editorState.allowedPackages, createAllowedPackageRow()],
 		}
 		handle.update()
 	}
 
-	function removeAllowedPackage(index: number) {
+	function removeAllowedPackage(id: string) {
 		const nextPackages = editorState.allowedPackages.filter(
-			(_pkg, pkgIndex) => pkgIndex !== index,
+			(pkg) => pkg.id !== id,
 		)
 		editorState = {
 			...editorState,
-			allowedPackages: nextPackages.length > 0 ? nextPackages : [''],
+			allowedPackages:
+				nextPackages.length > 0 ? nextPackages : [createAllowedPackageRow()],
 		}
 		handle.update()
 	}
@@ -1447,9 +1463,9 @@ export function AccountSecretsRoute(handle: Handle) {
 										</p>
 									</div>
 									<div css={{ display: 'grid', gap: spacing.sm }}>
-										{editorState.allowedPackages.map((packageId, index) => (
+										{editorState.allowedPackages.map((packageEntry) => (
 											<div
-												key={index}
+												key={packageEntry.id}
 												css={{
 													display: 'grid',
 													gridTemplateColumns: 'minmax(0, 1fr) auto',
@@ -1458,12 +1474,12 @@ export function AccountSecretsRoute(handle: Handle) {
 											>
 												<input
 													type="text"
-													value={typeof packageId === 'string' ? packageId : ''}
+													value={packageEntry.value}
 													placeholder="saved package id"
 													on={{
 														input: (event) => {
 															updateAllowedPackage(
-																index,
+																packageEntry.id,
 																event.currentTarget.value,
 															)
 														},
@@ -1472,7 +1488,9 @@ export function AccountSecretsRoute(handle: Handle) {
 												/>
 												<button
 													type="button"
-													on={{ click: () => removeAllowedPackage(index) }}
+													on={{
+														click: () => removeAllowedPackage(packageEntry.id),
+													}}
 													css={secondaryButtonCss}
 												>
 													Remove

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -59,11 +59,7 @@ type SecretListItem = {
 	appTitle: string | null
 	allowedHosts: Array<string>
 	allowedCapabilities: Array<string>
-	allowedPackages: Array<{
-		packageId: string
-		kodyId: string
-		name: string
-	}>
+	allowedPackages: Array<string>
 	createdAt: string
 	updatedAt: string
 	ttlMs: number | null
@@ -77,6 +73,11 @@ type AccountSecretsPayload = {
 	ok: true
 	email: string
 	apps: Array<PackageAppOption>
+	packages: Array<{
+		id: string
+		kodyId: string
+		name: string
+	}>
 	secrets: Array<SecretListItem>
 	selectedSecret: SecretDetail | null
 	approval: ApprovalView | null
@@ -171,7 +172,7 @@ function createEditorStateFromSecret(secret: SecretDetail): EditorState {
 			allowedCapabilities.length > 0 ? allowedCapabilities : [''],
 		allowedPackages:
 			secret.allowedPackages.length > 0
-				? secret.allowedPackages.map((pkg) => pkg.packageId)
+				? secret.allowedPackages
 				: [''],
 	}
 }
@@ -275,17 +276,17 @@ function getAlreadyAddedNotice(input: {
 	const allowedPackageIds = input.selectedSecret
 		? Array.from(
 				new Set(
-					input.selectedSecret.allowedPackages
-						.map((pkg) => pkg.packageId)
-						.filter((value) => value.length > 0),
+					input.selectedSecret.allowedPackages.filter(
+						(value) => value.length > 0,
+					),
 				),
 			).sort((left, right) => left.localeCompare(right))
 		: input.approval
 			? Array.from(
 					new Set(
-						input.approval.currentAllowedPackages
-							.map((pkg) => pkg.packageId)
-							.filter((value) => value.length > 0),
+						input.approval.currentAllowedPackages.filter(
+							(value) => value.length > 0,
+						),
 					),
 				).sort((left, right) => left.localeCompare(right))
 			: []
@@ -418,7 +419,7 @@ function filterSecrets(
 			secret.scope,
 			...secret.allowedHosts,
 			...secret.allowedCapabilities,
-			...secret.allowedPackages.map((pkg) => pkg.kodyId || pkg.name || pkg.packageId),
+			...secret.allowedPackages,
 		]
 			.join(' ')
 			.toLowerCase()
@@ -428,6 +429,10 @@ function filterSecrets(
 
 function buildAppOptionDescription(updatedAt: string) {
 	return `Updated ${new Date(updatedAt).toLocaleDateString()}`
+}
+
+function formatAllowedPackageLabel(packageId: string) {
+	return packageId
 }
 
 export function AccountSecretsRoute(handle: Handle) {
@@ -981,10 +986,7 @@ export function AccountSecretsRoute(handle: Handle) {
 							{approvalCard.requestedPackageId ? (
 								<p css={{ margin: 0, color: colors.textMuted }}>
 									Allow package{' '}
-									<code>
-										{approvalCard.requestedPackageKodyId ??
-											approvalCard.requestedPackageId}
-									</code>{' '}
+									<code>{approvalCard.requestedPackageId}</code>{' '}
 									to use secret <code>{approvalCard.name}</code> from the{' '}
 									{getScopeLabel(approvalCard.scope)} scope.
 								</p>
@@ -1006,7 +1008,9 @@ export function AccountSecretsRoute(handle: Handle) {
 									Current allowed packages:{' '}
 									{approvalCard.currentAllowedPackages.length > 0
 										? approvalCard.currentAllowedPackages
-												.map((pkg) => pkg.kodyId || pkg.packageId)
+												.map((packageId) =>
+													formatAllowedPackageLabel(packageId),
+												)
 												.join(', ')
 										: 'none'}
 								</p>

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -160,6 +160,7 @@ function collectRepeatedTextRows(
 function createEditorStateFromSecret(secret: SecretDetail): EditorState {
 	const allowedHosts = coerceStringRows(secret.allowedHosts)
 	const allowedCapabilities = coerceStringRows(secret.allowedCapabilities)
+	const allowedPackages = coerceStringRows(secret.allowedPackages)
 	return {
 		currentId: secret.id,
 		name: secret.name,
@@ -170,10 +171,7 @@ function createEditorStateFromSecret(secret: SecretDetail): EditorState {
 		allowedHosts: allowedHosts.length > 0 ? allowedHosts : [''],
 		allowedCapabilities:
 			allowedCapabilities.length > 0 ? allowedCapabilities : [''],
-		allowedPackages:
-			secret.allowedPackages.length > 0
-				? secret.allowedPackages
-				: [''],
+		allowedPackages: allowedPackages.length > 0 ? allowedPackages : [''],
 	}
 }
 
@@ -431,14 +429,11 @@ function buildAppOptionDescription(updatedAt: string) {
 	return `Updated ${new Date(updatedAt).toLocaleDateString()}`
 }
 
-function formatAllowedPackageLabel(packageId: string) {
-	return packageId
-}
-
 export function AccountSecretsRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
 	let email = ''
 	let apps: Array<PackageAppOption> = []
+	let packagesById = new Map<string, { kodyId: string; name: string }>()
 	let secrets: Array<SecretListItem> = []
 	let selectedSecret: SecretDetail | null = null
 	let approval: ApprovalView | null = null
@@ -509,6 +504,12 @@ export function AccountSecretsRoute(handle: Handle) {
 	) {
 		email = payload.email
 		apps = payload.apps
+		packagesById = new Map(
+			payload.packages.map((pkg) => [
+				pkg.id,
+				{ kodyId: pkg.kodyId, name: pkg.name },
+			]),
+		)
 		secrets = payload.secrets
 		selectedSecret = payload.selectedSecret
 		approval = payload.approval
@@ -523,6 +524,11 @@ export function AccountSecretsRoute(handle: Handle) {
 		status = 'ready'
 		submittingApprovalAction = null
 		saveState = 'idle'
+	}
+
+	function formatAllowedPackageLabel(packageId: string) {
+		const meta = packagesById.get(packageId)
+		return meta ? `${meta.name} (${packageId})` : packageId
 	}
 
 	async function loadAccountSecrets() {

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -274,7 +274,7 @@ function getAlreadyAddedNotice(input: {
 	const allowedPackageIds = input.selectedSecret
 		? Array.from(
 				new Set(
-					input.selectedSecret.allowedPackages.filter(
+					coerceStringRows(input.selectedSecret.allowedPackages).filter(
 						(value) => value.length > 0,
 					),
 				),
@@ -282,7 +282,7 @@ function getAlreadyAddedNotice(input: {
 		: input.approval
 			? Array.from(
 					new Set(
-						input.approval.currentAllowedPackages.filter(
+						coerceStringRows(input.approval.currentAllowedPackages).filter(
 							(value) => value.length > 0,
 						),
 					),

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -59,6 +59,11 @@ type SecretListItem = {
 	appTitle: string | null
 	allowedHosts: Array<string>
 	allowedCapabilities: Array<string>
+	allowedPackages: Array<{
+		packageId: string
+		kodyId: string
+		name: string
+	}>
 	createdAt: string
 	updatedAt: string
 	ttlMs: number | null
@@ -86,6 +91,7 @@ type EditorState = {
 	value: string
 	allowedHosts: Array<string>
 	allowedCapabilities: Array<string>
+	allowedPackages: Array<string>
 }
 
 type SelectionState = {
@@ -127,6 +133,7 @@ function createEmptyEditorState(apps: Array<PackageAppOption>): EditorState {
 		value: '',
 		allowedHosts: [''],
 		allowedCapabilities: [''],
+		allowedPackages: [''],
 	}
 }
 
@@ -162,6 +169,10 @@ function createEditorStateFromSecret(secret: SecretDetail): EditorState {
 		allowedHosts: allowedHosts.length > 0 ? allowedHosts : [''],
 		allowedCapabilities:
 			allowedCapabilities.length > 0 ? allowedCapabilities : [''],
+		allowedPackages:
+			secret.allowedPackages.length > 0
+				? secret.allowedPackages.map((pkg) => pkg.packageId)
+				: [''],
 	}
 }
 
@@ -247,6 +258,10 @@ function getAlreadyAddedNotice(input: {
 	const requestedCapability = normalizeSingleAllowedCapability(
 		readCapabilityPrefill(input.href),
 	)
+	const requestedPackageId =
+		new URL(input.href, 'http://localhost').searchParams
+			.get('package_id')
+			?.trim() ?? null
 	const allowedHosts = input.selectedSecret
 		? normalizeAllowedHosts(coerceStringRows(input.selectedSecret.allowedHosts))
 		: input.approval
@@ -257,6 +272,23 @@ function getAlreadyAddedNotice(input: {
 				coerceStringRows(input.selectedSecret.allowedCapabilities),
 			)
 		: []
+	const allowedPackageIds = input.selectedSecret
+		? Array.from(
+				new Set(
+					input.selectedSecret.allowedPackages
+						.map((pkg) => pkg.packageId)
+						.filter((value) => value.length > 0),
+				),
+			).sort((left, right) => left.localeCompare(right))
+		: input.approval
+			? Array.from(
+					new Set(
+						input.approval.currentAllowedPackages
+							.map((pkg) => pkg.packageId)
+							.filter((value) => value.length > 0),
+					),
+				).sort((left, right) => left.localeCompare(right))
+			: []
 	const items: Array<string> = []
 	const hostAlreadyAdded =
 		requestedHost != null && allowedHosts.includes(requestedHost)
@@ -271,10 +303,16 @@ function getAlreadyAddedNotice(input: {
 			`Capability ${requestedCapability} is already in allowed capabilities.`,
 		)
 	}
+	const packageAlreadyAdded =
+		requestedPackageId != null && allowedPackageIds.includes(requestedPackageId)
+	if (packageAlreadyAdded) {
+		items.push(`Package ${requestedPackageId} is already in allowed packages.`)
+	}
 	if (items.length === 0) return null
 	return {
 		items,
 		hostAlreadyAdded,
+		packageAlreadyAdded,
 	}
 }
 
@@ -331,7 +369,8 @@ function getDataRefreshKey(href: string) {
 	const request = url.searchParams.get('request') ?? ''
 	const requestedHost = url.searchParams.get('allowed-host') ?? ''
 	const requestedCapability = url.searchParams.get('capability') ?? ''
-	return `${url.pathname}?request=${request}&allowed-host=${requestedHost}&capability=${requestedCapability}`
+	const requestedPackageId = url.searchParams.get('package_id') ?? ''
+	return `${url.pathname}?request=${request}&allowed-host=${requestedHost}&capability=${requestedCapability}&package_id=${requestedPackageId}`
 }
 
 function readFilterState(
@@ -620,6 +659,13 @@ export function AccountSecretsRoute(handle: Handle) {
 			const allowedCapabilities = normalizeAllowedCapabilities(
 				collectRepeatedTextRows(form, 'allowed-capabilities'),
 			)
+			const allowedPackages = Array.from(
+				new Set(
+					editorState.allowedPackages
+						.map((value) => value.trim())
+						.filter((value) => value.length > 0),
+				),
+			).sort((left, right) => left.localeCompare(right))
 			const response = await fetch(accountSecretsApiPath, {
 				method: 'POST',
 				headers: {
@@ -637,6 +683,7 @@ export function AccountSecretsRoute(handle: Handle) {
 					value: editorState.value,
 					allowedHosts,
 					allowedCapabilities,
+					allowedPackages,
 				}),
 			})
 			if (response.status === 401) {
@@ -781,6 +828,35 @@ export function AccountSecretsRoute(handle: Handle) {
 		handle.update()
 	}
 
+	function updateAllowedPackage(index: number, value: string) {
+		editorState = {
+			...editorState,
+			allowedPackages: editorState.allowedPackages.map((pkg, pkgIndex) =>
+				pkgIndex === index ? value : pkg,
+			),
+		}
+		handle.update()
+	}
+
+	function addAllowedPackage() {
+		editorState = {
+			...editorState,
+			allowedPackages: [...editorState.allowedPackages, ''],
+		}
+		handle.update()
+	}
+
+	function removeAllowedPackage(index: number) {
+		const nextPackages = editorState.allowedPackages.filter(
+			(_pkg, pkgIndex) => pkgIndex !== index,
+		)
+		editorState = {
+			...editorState,
+			allowedPackages: nextPackages.length > 0 ? nextPackages : [''],
+		}
+		handle.update()
+	}
+
 	return () => {
 		const currentHref = getCurrentHref()
 		const selection = getSelectionState(currentHref)
@@ -892,25 +968,48 @@ export function AccountSecretsRoute(handle: Handle) {
 									color: colors.text,
 								}}
 							>
-								Approve host access
+								Approve secret access
 							</h2>
-							<p css={{ margin: 0, color: colors.textMuted }}>
-								Allow <code>{approvalCard.requestedHost}</code> to receive
-								secret <code>{approvalCard.name}</code> from the{' '}
-								{getScopeLabel(approvalCard.scope)} scope.
-							</p>
+							{approvalCard.requestedPackageId ? (
+								<p css={{ margin: 0, color: colors.textMuted }}>
+									Allow package{' '}
+									<code>
+										{approvalCard.requestedPackageKodyId ??
+											approvalCard.requestedPackageId}
+									</code>{' '}
+									to use secret <code>{approvalCard.name}</code> from the{' '}
+									{getScopeLabel(approvalCard.scope)} scope.
+								</p>
+							) : (
+								<p css={{ margin: 0, color: colors.textMuted }}>
+									Allow <code>{approvalCard.requestedHost}</code> to receive
+									secret <code>{approvalCard.name}</code> from the{' '}
+									{getScopeLabel(approvalCard.scope)} scope.
+								</p>
+							)}
 							{approvalCard.requestedCapability ? (
 								<p css={{ margin: 0, color: colors.textMuted }}>
 									Requested capability:{' '}
 									<code>{approvalCard.requestedCapability}</code>
 								</p>
 							) : null}
-							<p css={{ margin: 0, color: colors.textMuted }}>
-								Current allowed hosts:{' '}
-								{approvalCard.currentAllowedHosts.length > 0
-									? approvalCard.currentAllowedHosts.join(', ')
-									: 'none'}
-							</p>
+							{approvalCard.requestedPackageId ? (
+								<p css={{ margin: 0, color: colors.textMuted }}>
+									Current allowed packages:{' '}
+									{approvalCard.currentAllowedPackages.length > 0
+										? approvalCard.currentAllowedPackages
+												.map((pkg) => pkg.kodyId || pkg.packageId)
+												.join(', ')
+										: 'none'}
+								</p>
+							) : (
+								<p css={{ margin: 0, color: colors.textMuted }}>
+									Current allowed hosts:{' '}
+									{approvalCard.currentAllowedHosts.length > 0
+										? approvalCard.currentAllowedHosts.join(', ')
+										: 'none'}
+								</p>
+							)}
 						</div>
 						<div css={{ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' }}>
 							<button
@@ -919,7 +1018,7 @@ export function AccountSecretsRoute(handle: Handle) {
 								on={{ click: () => void submitApproval('approve') }}
 								css={primaryButtonCss}
 							>
-								Approve host
+								Approve
 							</button>
 							<button
 								type="button"
@@ -1321,6 +1420,58 @@ export function AccountSecretsRoute(handle: Handle) {
 									allowedHostsListName="allowed-hosts"
 									allowedCapabilitiesListName="allowed-capabilities"
 								/>
+								<div css={{ display: 'grid', gap: spacing.sm }}>
+									<div css={{ display: 'grid', gap: spacing.xs }}>
+										<span css={fieldLabelCss}>Allowed packages</span>
+										<p css={{ margin: 0, color: colors.textMuted }}>
+											Only listed package ids may read this secret via package
+											secret mounts.
+										</p>
+									</div>
+									<div css={{ display: 'grid', gap: spacing.sm }}>
+										{editorState.allowedPackages.map((packageId, index) => (
+											<div
+												key={index}
+												css={{
+													display: 'grid',
+													gridTemplateColumns: 'minmax(0, 1fr) auto',
+													gap: spacing.sm,
+												}}
+											>
+												<input
+													type="text"
+													value={typeof packageId === 'string' ? packageId : ''}
+													placeholder="saved package id"
+													on={{
+														input: (event) => {
+															updateAllowedPackage(
+																index,
+																event.currentTarget.value,
+															)
+														},
+													}}
+													css={inputCss}
+												/>
+												<button
+													type="button"
+													on={{ click: () => removeAllowedPackage(index) }}
+													css={secondaryButtonCss}
+												>
+													Remove
+												</button>
+											</div>
+										))}
+									</div>
+									<div>
+										<button
+											type="button"
+											on={{ click: () => addAllowedPackage() }}
+											css={secondaryButtonCss}
+										>
+											Add package
+										</button>
+									</div>
+								</div>
 
 								{selectedSecret ? (
 									<div

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -418,6 +418,7 @@ function filterSecrets(
 			secret.scope,
 			...secret.allowedHosts,
 			...secret.allowedCapabilities,
+			...secret.allowedPackages.map((pkg) => pkg.kodyId || pkg.name || pkg.packageId),
 		]
 			.join(' ')
 			.toLowerCase()
@@ -609,8 +610,12 @@ export function AccountSecretsRoute(handle: Handle) {
 				payload,
 				selection,
 				action === 'approve'
-					? 'Approved requested host.'
-					: 'Rejected host approval request.',
+					? approval.requestedPackageId
+						? 'Approved requested package.'
+						: 'Approved requested host.'
+					: approval.requestedPackageId
+						? 'Rejected package approval request.'
+						: 'Rejected host approval request.',
 			)
 			handle.update()
 
@@ -631,6 +636,8 @@ export function AccountSecretsRoute(handle: Handle) {
 				nextUrl.searchParams.delete('request')
 				nextUrl.searchParams.delete('allowed-host')
 				nextUrl.searchParams.delete('capability')
+				nextUrl.searchParams.delete('package_id')
+				nextUrl.searchParams.delete('package')
 				navigate(`${nextUrl.pathname}${nextUrl.search}`)
 				lastLoadedDataKey = getDataRefreshKey(nextUrl.toString())
 			}
@@ -901,7 +908,8 @@ export function AccountSecretsRoute(handle: Handle) {
 		const approvalCard =
 			approval &&
 			!isRefreshingForLocationChange &&
-			!alreadyAddedNotice?.hostAlreadyAdded
+			!alreadyAddedNotice?.hostAlreadyAdded &&
+			!alreadyAddedNotice?.packageAlreadyAdded
 				? approval
 				: null
 

--- a/packages/worker/migrations/0023-secret-allowed-packages.sql
+++ b/packages/worker/migrations/0023-secret-allowed-packages.sql
@@ -1,0 +1,2 @@
+ALTER TABLE secret_entries
+ADD COLUMN allowed_packages TEXT NOT NULL DEFAULT '[]';

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -97,11 +97,13 @@ vi.mock('#mcp/secrets/host-approval.ts', () => ({
 		mockModule.buildSecretHostApprovalUrl(...args),
 	verifySecretHostApprovalToken: (...args: Array<unknown>) =>
 		mockModule.verifySecretHostApprovalToken(...args),
+	secretHostApprovalTokenPrefix: 'host:',
 }))
 
 vi.mock('#mcp/secrets/package-approval.ts', () => ({
 	verifySecretPackageApprovalToken: (...args: Array<unknown>) =>
 		mockModule.verifySecretPackageApprovalToken(...args),
+	secretPackageApprovalTokenPrefix: 'pkg:',
 }))
 
 vi.mock('#mcp/secrets/service.ts', () => ({
@@ -451,7 +453,7 @@ test('malformed package approval token surfaces package-token error without host
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({
 				action: 'approve',
-				requestToken: 'invalid-package-token',
+				requestToken: 'pkg:invalid-package-token',
 			}),
 		}),
 		params: {},

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -47,6 +47,9 @@ const mockModule = vi.hoisted(() => ({
 	verifySecretHostApprovalToken: vi.fn(async () => {
 		throw new Error('not used')
 	}),
+	verifySecretPackageApprovalToken: vi.fn(async () => {
+		throw new Error('not used')
+	}),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -93,6 +96,11 @@ vi.mock('#mcp/secrets/host-approval.ts', () => ({
 		mockModule.buildSecretHostApprovalUrl(...args),
 	verifySecretHostApprovalToken: (...args: Array<unknown>) =>
 		mockModule.verifySecretHostApprovalToken(...args),
+}))
+
+vi.mock('#mcp/secrets/package-approval.ts', () => ({
+	verifySecretPackageApprovalToken: (...args: Array<unknown>) =>
+		mockModule.verifySecretPackageApprovalToken(...args),
 }))
 
 vi.mock('#mcp/secrets/service.ts', () => ({
@@ -309,4 +317,101 @@ test('connect oauth omits direct host approval links when hosts are already appr
 		]),
 	)
 	expect(mockModule.createSecretHostApprovalToken).not.toHaveBeenCalled()
+})
+
+test('account secrets payload preserves app titles and allowed packages', async () => {
+	mockModule.listSavedPackagesByUserId.mockResolvedValue([
+		{
+			id: 'app-123',
+			userId: 'stable-user-1',
+			name: '@kentcdodds/discord-gateway',
+			kodyId: 'discord-gateway',
+			description: 'Discord gateway package',
+			tags: ['discord'],
+			searchText: null,
+			sourceId: 'source-1',
+			hasApp: true,
+			createdAt: new Date(0).toISOString(),
+			updatedAt: new Date(0).toISOString(),
+		},
+		{
+			id: 'pkg-allowed',
+			userId: 'stable-user-1',
+			name: '@kentcdodds/discord-general-chat',
+			kodyId: 'discord-general-chat',
+			description: 'Discord subscriber',
+			tags: ['discord'],
+			searchText: null,
+			sourceId: 'source-2',
+			hasApp: false,
+			createdAt: new Date(0).toISOString(),
+			updatedAt: new Date(0).toISOString(),
+		},
+	])
+	mockModule.listSecrets.mockResolvedValue([
+		{
+			name: 'discordBotToken',
+			scope: 'user',
+			description: 'Discord bot token',
+			appId: null,
+			allowedHosts: [],
+			allowedCapabilities: [],
+			allowedPackages: ['pkg-allowed'],
+			createdAt: new Date(0).toISOString(),
+			updatedAt: new Date(0).toISOString(),
+			ttlMs: null,
+		},
+	])
+	mockModule.listAppSecretsByAppIds.mockResolvedValue(
+		new Map([
+			[
+				'app-123',
+				[
+					{
+						name: 'gatewaySigningSecret',
+						scope: 'app',
+						description: 'Gateway signing secret',
+						appId: 'app-123',
+						allowedHosts: [],
+						allowedCapabilities: [],
+						allowedPackages: [],
+						createdAt: new Date(0).toISOString(),
+						updatedAt: new Date(0).toISOString(),
+						ttlMs: null,
+					},
+				],
+			],
+		]),
+	)
+
+	const handler = createAccountSecretsApiHandler(createEnv())
+	const response = await handler.action({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'GET',
+		}),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toMatchObject({
+		ok: true,
+		secrets: expect.arrayContaining([
+			expect.objectContaining({
+				name: 'discordBotToken',
+				scope: 'user',
+				allowedPackages: [
+					{
+						packageId: 'pkg-allowed',
+						kodyId: 'discord-general-chat',
+						name: '@kentcdodds/discord-general-chat',
+					},
+				],
+			}),
+			expect.objectContaining({
+				name: 'gatewaySigningSecret',
+				scope: 'app',
+				appTitle: '@kentcdodds/discord-gateway',
+			}),
+		]),
+	})
 })

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -320,7 +320,7 @@ test('connect oauth omits direct host approval links when hosts are already appr
 })
 
 test('account secrets payload preserves app titles and allowed packages', async () => {
-	mockModule.listSavedPackagesByUserId.mockResolvedValue([
+	mockModule.listSavedPackagesByUserId.mockResolvedValueOnce([
 		{
 			id: 'app-123',
 			userId: 'stable-user-1',
@@ -348,7 +348,7 @@ test('account secrets payload preserves app titles and allowed packages', async 
 			updatedAt: new Date(0).toISOString(),
 		},
 	])
-	mockModule.listSecrets.mockResolvedValue([
+	mockModule.listSecrets.mockResolvedValueOnce([
 		{
 			name: 'discordBotToken',
 			scope: 'user',
@@ -362,7 +362,7 @@ test('account secrets payload preserves app titles and allowed packages', async 
 			ttlMs: null,
 		},
 	])
-	mockModule.listAppSecretsByAppIds.mockResolvedValue(
+	mockModule.listAppSecretsByAppIds.mockResolvedValueOnce(
 		new Map([
 			[
 				'app-123',

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -43,6 +43,7 @@ const mockModule = vi.hoisted(() => ({
 	resolveSecret: vi.fn(async () => null),
 	deleteSecret: vi.fn(async () => false),
 	setSecretAllowedCapabilities: vi.fn(async () => undefined),
+	setSecretAllowedPackages: vi.fn(async () => undefined),
 	getValue: vi.fn(async () => null),
 	verifySecretHostApprovalToken: vi.fn(async () => {
 		throw new Error('not used')
@@ -114,6 +115,8 @@ vi.mock('#mcp/secrets/service.ts', () => ({
 	deleteSecret: (...args: Array<unknown>) => mockModule.deleteSecret(...args),
 	setSecretAllowedCapabilities: (...args: Array<unknown>) =>
 		mockModule.setSecretAllowedCapabilities(...args),
+	setSecretAllowedPackages: (...args: Array<unknown>) =>
+		mockModule.setSecretAllowedPackages(...args),
 }))
 
 vi.mock('#mcp/values/service.ts', () => ({
@@ -434,4 +437,122 @@ test('package approval expiry surfaces package-token error without host fallback
 		error: 'Secret package approval request has expired.',
 	})
 	expect(mockModule.verifySecretHostApprovalToken).not.toHaveBeenCalled()
+})
+
+test('malformed package approval token surfaces package-token error without host fallback', async () => {
+	mockModule.verifySecretPackageApprovalToken.mockRejectedValueOnce(
+		new Error('Invalid secret package approval request.'),
+	)
+
+	const handler = createAccountSecretsApiHandler(createEnv())
+	const response = await handler.action({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'approve',
+				requestToken: 'invalid-package-token',
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(400)
+	await expect(response.json()).resolves.toMatchObject({
+		ok: false,
+		error: 'Invalid secret package approval request.',
+	})
+	expect(mockModule.verifySecretHostApprovalToken).not.toHaveBeenCalled()
+})
+
+test('package approval reject succeeds even when the secret no longer exists', async () => {
+	mockModule.verifySecretPackageApprovalToken.mockResolvedValueOnce({
+		kind: 'package',
+		userId: 'stable-user-1',
+		name: 'discordBotToken',
+		scope: 'user',
+		packageId: 'pkg-allowed',
+		packageKodyId: 'discord-gateway',
+		storageContext: null,
+		iat: Date.now(),
+		exp: Date.now() + 60_000,
+	})
+	mockModule.listSavedPackagesByUserId.mockResolvedValueOnce([])
+	mockModule.listSecrets.mockResolvedValueOnce([])
+	mockModule.listAppSecretsByAppIds.mockResolvedValueOnce(new Map())
+
+	const handler = createAccountSecretsApiHandler(createEnv())
+	const response = await handler.action({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'reject',
+				requestToken: 'package-token',
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toMatchObject({
+		ok: true,
+		secrets: [],
+	})
+	expect(mockModule.setSecretAllowedHosts).not.toHaveBeenCalled()
+	expect(mockModule.setSecretAllowedCapabilities).not.toHaveBeenCalled()
+})
+
+test('package approval approve deduplicates allowed package ids', async () => {
+	mockModule.verifySecretPackageApprovalToken.mockResolvedValueOnce({
+		kind: 'package',
+		userId: 'stable-user-1',
+		name: 'discordBotToken',
+		scope: 'user',
+		packageId: 'pkg-new',
+		packageKodyId: 'discord-gateway',
+		storageContext: null,
+		iat: Date.now(),
+		exp: Date.now() + 60_000,
+	})
+	mockModule.listSecrets.mockResolvedValueOnce([
+		{
+			name: 'discordBotToken',
+			scope: 'user',
+			description: 'Discord bot token',
+			appId: null,
+			allowedHosts: [],
+			allowedCapabilities: [],
+			allowedPackages: ['pkg-allowed', 'pkg-allowed'],
+			createdAt: new Date(0).toISOString(),
+			updatedAt: new Date(0).toISOString(),
+			ttlMs: null,
+		},
+	])
+	mockModule.listSecrets.mockResolvedValueOnce([])
+	mockModule.listSavedPackagesByUserId.mockResolvedValueOnce([])
+	mockModule.listAppSecretsByAppIds.mockResolvedValueOnce(new Map())
+
+	const handler = createAccountSecretsApiHandler(createEnv())
+	const response = await handler.action({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'approve',
+				requestToken: 'package-token',
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toMatchObject({ ok: true })
+	expect(mockModule.setSecretAllowedPackages).toHaveBeenCalledWith(
+		expect.objectContaining({
+			name: 'discordBotToken',
+			scope: 'user',
+			allowedPackages: ['pkg-allowed', 'pkg-new'],
+		}),
+	)
 })

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -409,3 +409,29 @@ test('account secrets payload preserves app titles and allowed packages', async 
 		]),
 	})
 })
+
+test('package approval expiry surfaces package-token error without host fallback', async () => {
+	mockModule.verifySecretPackageApprovalToken.mockRejectedValueOnce(
+		new Error('Secret package approval request has expired.'),
+	)
+
+	const handler = createAccountSecretsApiHandler(createEnv())
+	const response = await handler.action({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'approve',
+				requestToken: 'expired-package-token',
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(400)
+	await expect(response.json()).resolves.toMatchObject({
+		ok: false,
+		error: 'Secret package approval request has expired.',
+	})
+	expect(mockModule.verifySecretHostApprovalToken).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -399,13 +399,7 @@ test('account secrets payload preserves app titles and allowed packages', async 
 			expect.objectContaining({
 				name: 'discordBotToken',
 				scope: 'user',
-				allowedPackages: [
-					{
-						packageId: 'pkg-allowed',
-						kodyId: 'discord-general-chat',
-						name: '@kentcdodds/discord-general-chat',
-					},
-				],
+				allowedPackages: ['pkg-allowed'],
 			}),
 			expect.objectContaining({
 				name: 'gatewaySigningSecret',

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -47,6 +47,14 @@ type SavedPackageAppOption = {
 	updatedAt: string
 }
 
+type SavedPackageSummary = {
+	id: string
+	kodyId: string
+	name: string
+	hasApp: boolean
+	updatedAt: string
+}
+
 type AccountSecretListItem = {
 	id: string
 	name: string
@@ -639,15 +647,18 @@ async function buildAccountSecretsPayload(input: {
 	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
 	selectedSecretId?: string | null
 	packageApps?: Array<SavedPackageAppOption>
+	savedPackages?: Array<SavedPackageSummary>
 }): Promise<AccountSecretsPayload> {
 	const url = new URL(input.request.url)
 	const approvalToken = url.searchParams.get('request')
 	const requestedApprovalHost = readApprovalHost(url)
 	const requestedCapability = readRequestedCapability(url)
 	const requestedPackageId = readRequestedPackageId(url)
-	const savedPackages = await listSavedPackagesByUserId(input.env.APP_DB, {
-		userId: input.user.mcpUser.userId,
-	})
+	const savedPackages =
+		input.savedPackages ??
+		(await listSavedPackagesByUserId(input.env.APP_DB, {
+			userId: input.user.mcpUser.userId,
+		}))
 	const packageApps =
 		input.packageApps ?? toPackageAppOptions(savedPackages)
 	const packageLookup = toAllowedPackageLookup(savedPackages)
@@ -691,17 +702,6 @@ async function buildAccountSecretsPayload(input: {
 	}
 }
 
-async function listPackageAppsForUser(input: {
-	env: Env
-	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
-}) {
-	return toPackageAppOptions(
-		await listSavedPackagesByUserId(input.env.APP_DB, {
-			userId: input.user.mcpUser.userId,
-		}),
-	)
-}
-
 async function listAccountSecrets(input: {
 	env: Env
 	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
@@ -735,6 +735,31 @@ async function listAccountSecrets(input: {
 	})
 }
 
+type ResolvedSecretApproval =
+	| Awaited<ReturnType<typeof verifySecretHostApprovalToken>>
+	| Awaited<ReturnType<typeof verifySecretPackageApprovalToken>>
+
+function isExpiredPackageApprovalError(error: unknown) {
+	return (
+		error instanceof Error &&
+		error.message === 'Secret package approval request has expired.'
+	)
+}
+
+async function resolveApprovalRequest(
+	env: Env,
+	token: string,
+): Promise<ResolvedSecretApproval> {
+	try {
+		return await verifySecretPackageApprovalToken(env, token)
+	} catch (error) {
+		if (isExpiredPackageApprovalError(error)) {
+			throw error
+		}
+	}
+	return await verifySecretHostApprovalToken(env, token)
+}
+
 async function resolveSecretApprovalView(input: {
 	env: Env
 	userId: string
@@ -743,13 +768,7 @@ async function resolveSecretApprovalView(input: {
 	requestedCapability: string | null
 	requestedPackageId: string | null
 }) {
-	const packageApproval = await verifySecretPackageApprovalToken(
-		input.env,
-		input.token,
-	).catch(() => null)
-	const approval = packageApproval
-		? packageApproval
-		: await verifySecretHostApprovalToken(input.env, input.token)
+	const approval = await resolveApprovalRequest(input.env, input.token)
 	if (approval.userId !== input.userId) {
 		throw new Error('Approval request mismatch.')
 	}
@@ -917,13 +936,7 @@ async function handleApprovalAction(input: {
 	}
 
 	try {
-		const packageApproval = await verifySecretPackageApprovalToken(
-			input.env,
-			token,
-		).catch(() => null)
-		const approval = packageApproval
-			? packageApproval
-			: await verifySecretHostApprovalToken(input.env, token)
+		const approval = await resolveApprovalRequest(input.env, token)
 		if (approval.userId !== input.user.mcpUser.userId) {
 			return jsonResponse(
 				{ ok: false, error: 'Approval request mismatch.' },
@@ -1036,10 +1049,10 @@ async function handleSaveAction(input: {
 		return jsonResponse({ ok: false, error: 'Secret scope is required.' }, 400)
 	}
 
-	const packageApps = await listPackageAppsForUser({
-		env: input.env,
-		user: input.user,
+	const savedPackages = await listSavedPackagesByUserId(input.env.APP_DB, {
+		userId: input.user.mcpUser.userId,
 	})
+	const packageApps = toPackageAppOptions(savedPackages)
 	const appId = readAppIdForScope({
 		body: input.body,
 		scope,
@@ -1140,6 +1153,7 @@ async function handleSaveAction(input: {
 			env: input.env,
 			user: input.user,
 			packageApps,
+			savedPackages,
 			selectedSecretId: nextId,
 		})
 		return jsonResponse(payload)

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -13,9 +13,13 @@ import { type StorageContext } from '#mcp/storage.ts'
 import {
 	buildSecretHostApprovalUrl,
 	createSecretHostApprovalToken,
+	secretHostApprovalTokenPrefix,
 	verifySecretHostApprovalToken,
 } from '#mcp/secrets/host-approval.ts'
-import { verifySecretPackageApprovalToken } from '#mcp/secrets/package-approval.ts'
+import {
+	secretPackageApprovalTokenPrefix,
+	verifySecretPackageApprovalToken,
+} from '#mcp/secrets/package-approval.ts'
 import {
 	deleteSecret,
 	listAppSecretsByAppIds,
@@ -751,13 +755,16 @@ async function resolveApprovalRequest(
 	env: Env,
 	token: string,
 ): Promise<ResolvedSecretApproval> {
+	if (token.startsWith(secretHostApprovalTokenPrefix)) {
+		return await verifySecretHostApprovalToken(env, token)
+	}
+	if (token.startsWith(secretPackageApprovalTokenPrefix)) {
+		return await verifySecretPackageApprovalToken(env, token)
+	}
 	try {
 		return await verifySecretPackageApprovalToken(env, token)
 	} catch (error) {
 		if (isExpiredPackageApprovalError(error)) {
-			throw error
-		}
-		if (error instanceof Error) {
 			throw error
 		}
 	}

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -662,37 +662,22 @@ async function buildAccountSecretsPayload(input: {
 			env: input.env,
 			user: input.user,
 		}))
+	const packageLookup = await buildAllowedPackageLookup({
+		env: input.env,
+		userId: input.user.mcpUser.userId,
+	})
 	const secrets = await listAccountSecrets({
 		env: input.env,
 		user: input.user,
 		packageApps,
+		packageLookup,
 	})
-	const packageLookup = new Map(
-		(
-			await listSavedPackagesByUserId(input.env.APP_DB, {
-				userId: input.user.mcpUser.userId,
-			})
-		).map((savedPackage) => [
-			savedPackage.id,
-			{
-				packageId: savedPackage.id,
-				kodyId: savedPackage.kodyId,
-				name: savedPackage.name,
-			} satisfies AllowedPackageView,
-		]),
-	)
-	const normalizedSecrets = secrets.map((secret) =>
-		normalizeAccountSecretListItem(
-			toAccountSecretListItem(secret, new Map()),
-			packageLookup,
-		),
-	)
 	const selectedSecret = input.selectedSecretId
 		? await resolveAccountSecretDetail({
 				env: input.env,
 				userId: input.user.mcpUser.userId,
 				secretId: input.selectedSecretId,
-				secrets: normalizedSecrets,
+				secrets,
 			})
 		: null
 
@@ -712,7 +697,7 @@ async function buildAccountSecretsPayload(input: {
 		ok: true,
 		email: input.user.email,
 		apps: packageApps,
-		secrets: normalizedSecrets,
+		secrets,
 		selectedSecret,
 		approval,
 	}
@@ -745,6 +730,7 @@ async function listAccountSecrets(input: {
 	env: Env
 	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
 	packageApps: Array<SavedPackageAppOption>
+	packageLookup: Map<string, AllowedPackageView>
 }) {
 	const appTitles = new Map(input.packageApps.map((app) => [app.id, app.title]))
 	const [userSecrets, appSecrets] = await Promise.all([
@@ -761,10 +747,14 @@ async function listAccountSecrets(input: {
 	])
 
 	return [
-		...userSecrets.map((secret) => toAccountSecretListItem(secret, appTitles)),
+		...userSecrets.map((secret) =>
+			toAccountSecretListItem(secret, appTitles, input.packageLookup),
+		),
 		...Array.from(appSecrets.values())
 			.flat()
-			.map((secret) => toAccountSecretListItem(secret, appTitles)),
+			.map((secret) =>
+				toAccountSecretListItem(secret, appTitles, input.packageLookup),
+			),
 	].sort((left, right) => {
 		return (
 			left.name.localeCompare(right.name) ||
@@ -877,6 +867,7 @@ function toAccountSecretListItem(
 		ttlMs: number | null
 	},
 	appTitles: Map<string, string>,
+	packageLookup: Map<string, AllowedPackageView>,
 ) {
 	if (secret.scope === 'session') {
 		throw new Error('Session secrets are not editable from the account page.')
@@ -896,30 +887,11 @@ function toAccountSecretListItem(
 		appTitle: secret.appId ? (appTitles.get(secret.appId) ?? null) : null,
 		allowedHosts: secret.allowedHosts,
 		allowedCapabilities: secret.allowedCapabilities,
-		allowedPackages: [],
+		allowedPackages: mapAllowedPackages(secret.allowedPackages, packageLookup),
 		createdAt: secret.createdAt,
 		updatedAt: secret.updatedAt,
 		ttlMs: secret.ttlMs,
 	} satisfies AccountSecretListItem
-}
-
-function normalizeAccountSecretListItem(
-	secret: Omit<AccountSecretListItem, 'allowedPackages'> & {
-		allowedPackages: Array<string> | Array<AllowedPackageView>
-	},
-	packageLookup: Map<string, AllowedPackageView>,
-): AccountSecretListItem {
-	return {
-		...secret,
-		allowedPackages:
-			secret.allowedPackages.length > 0 &&
-			typeof secret.allowedPackages[0] === 'object'
-				? (secret.allowedPackages as Array<AllowedPackageView>)
-				: mapAllowedPackages(
-						secret.allowedPackages as Array<string>,
-						packageLookup,
-					),
-	}
 }
 
 function mapAllowedPackages(
@@ -936,6 +908,23 @@ function mapAllowedPackages(
 			}
 		)
 	})
+}
+
+async function buildAllowedPackageLookup(input: { env: Env; userId: string }) {
+	return new Map(
+		(
+			await listSavedPackagesByUserId(input.env.APP_DB, {
+				userId: input.userId,
+			})
+		).map((savedPackage) => [
+			savedPackage.id,
+			{
+				packageId: savedPackage.id,
+				kodyId: savedPackage.kodyId,
+				name: savedPackage.name,
+			} satisfies AllowedPackageView,
+		]),
+	)
 }
 
 async function handleApprovalAction(input: {
@@ -1094,6 +1083,20 @@ async function handleSaveAction(input: {
 		env: input.env,
 		user: input.user,
 	})
+	const packageLookup = new Map(
+		(
+			await listSavedPackagesByUserId(input.env.APP_DB, {
+				userId: input.user.mcpUser.userId,
+			})
+		).map((savedPackage) => [
+			savedPackage.id,
+			{
+				packageId: savedPackage.id,
+				kodyId: savedPackage.kodyId,
+				name: savedPackage.name,
+			} satisfies AllowedPackageView,
+		]),
+	)
 	const appId = readAppIdForScope({
 		body: input.body,
 		scope,
@@ -1110,6 +1113,7 @@ async function handleSaveAction(input: {
 		env: input.env,
 		user: input.user,
 		packageApps,
+		packageLookup,
 	})
 	const secretById = new Map(secrets.map((secret) => [secret.id, secret]))
 	const currentSecret = currentId ? (secretById.get(currentId) ?? null) : null

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -645,17 +645,12 @@ async function buildAccountSecretsPayload(input: {
 	const requestedApprovalHost = readApprovalHost(url)
 	const requestedCapability = readRequestedCapability(url)
 	const requestedPackageId = readRequestedPackageId(url)
-
-	const packageApps =
-		input.packageApps ??
-		(await listPackageAppsForUser({
-			env: input.env,
-			user: input.user,
-		}))
-	const packageLookup = await buildAllowedPackageLookup({
-		env: input.env,
+	const savedPackages = await listSavedPackagesByUserId(input.env.APP_DB, {
 		userId: input.user.mcpUser.userId,
 	})
+	const packageApps =
+		input.packageApps ?? toPackageAppOptions(savedPackages)
+	const packageLookup = toAllowedPackageLookup(savedPackages)
 	const secrets = await listAccountSecrets({
 		env: input.env,
 		user: input.user,
@@ -700,23 +695,11 @@ async function listPackageAppsForUser(input: {
 	env: Env
 	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
 }) {
-	return (
+	return toPackageAppOptions(
 		await listSavedPackagesByUserId(input.env.APP_DB, {
 			userId: input.user.mcpUser.userId,
-		})
+		}),
 	)
-		.filter((savedPackage) => savedPackage.hasApp)
-		.map((savedPackage) => ({
-			id: savedPackage.id,
-			title: savedPackage.name,
-			updatedAt: savedPackage.updatedAt,
-		}))
-		.sort((left, right) => {
-			return (
-				right.updatedAt.localeCompare(left.updatedAt) ||
-				left.title.localeCompare(right.title)
-			)
-		})
 }
 
 async function listAccountSecrets(input: {
@@ -771,14 +754,14 @@ async function resolveSecretApprovalView(input: {
 		throw new Error('Approval request mismatch.')
 	}
 	if (
-		'requestedHost' in approval &&
+		approval.kind === 'host' &&
 		input.requestedHost != null &&
 		approval.requestedHost !== normalizeAllowedHosts([input.requestedHost])[0]
 	) {
 		throw new Error('Approval request host mismatch.')
 	}
 	if (
-		'packageId' in approval &&
+		approval.kind === 'package' &&
 		input.requestedPackageId != null &&
 		approval.packageId !== input.requestedPackageId
 	) {
@@ -800,9 +783,10 @@ async function resolveSecretApprovalView(input: {
 		token: input.token,
 		name: approval.name,
 		scope: approval.scope,
-		requestedHost: 'requestedHost' in approval ? approval.requestedHost : '',
+		requestedHost: approval.kind === 'host' ? approval.requestedHost : '',
 		requestedCapability: input.requestedCapability,
-		requestedPackageId: 'packageId' in approval ? approval.packageId : null,
+		requestedPackageId:
+			approval.kind === 'package' ? approval.packageId : null,
 		currentAllowedHosts: secret.allowedHosts,
 		currentAllowedPackages: secret.allowedPackages,
 	} satisfies SecretApprovalView
@@ -875,13 +859,38 @@ function toAccountSecretListItem(
 	} satisfies AccountSecretListItem
 }
 
-async function buildAllowedPackageLookup(input: { env: Env; userId: string }) {
+function toPackageAppOptions(
+	savedPackages: Array<{
+		id: string
+		name: string
+		hasApp: boolean
+		updatedAt: string
+	}>,
+) {
+	return savedPackages
+		.filter((savedPackage) => savedPackage.hasApp)
+		.map((savedPackage) => ({
+			id: savedPackage.id,
+			title: savedPackage.name,
+			updatedAt: savedPackage.updatedAt,
+		}))
+		.sort((left, right) => {
+			return (
+				right.updatedAt.localeCompare(left.updatedAt) ||
+				left.title.localeCompare(right.title)
+			)
+		})
+}
+
+function toAllowedPackageLookup(
+	savedPackages: Array<{
+		id: string
+		kodyId: string
+		name: string
+	}>,
+) {
 	return new Map(
-		(
-			await listSavedPackagesByUserId(input.env.APP_DB, {
-				userId: input.userId,
-			})
-		).map((savedPackage) => [
+		savedPackages.map((savedPackage) => [
 			savedPackage.id,
 			{
 				packageId: savedPackage.id,
@@ -922,7 +931,7 @@ async function handleApprovalAction(input: {
 			)
 		}
 
-		if ('packageId' in approval) {
+		if (approval.kind === 'package') {
 			const current = await listSecrets({
 				env: input.env,
 				userId: input.user.mcpUser.userId,

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -1058,20 +1058,10 @@ async function handleSaveAction(input: {
 		env: input.env,
 		user: input.user,
 	})
-	const packageLookup = new Map(
-		(
-			await listSavedPackagesByUserId(input.env.APP_DB, {
-				userId: input.user.mcpUser.userId,
-			})
-		).map((savedPackage) => [
-			savedPackage.id,
-			{
-				packageId: savedPackage.id,
-				kodyId: savedPackage.kodyId,
-				name: savedPackage.name,
-			} satisfies AllowedPackageView,
-		]),
-	)
+	const packageLookup = await buildAllowedPackageLookup({
+		env: input.env,
+		userId: input.user.mcpUser.userId,
+	})
 	const appId = readAppIdForScope({
 		body: input.body,
 		scope,

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -16,6 +16,11 @@ import {
 	verifySecretHostApprovalToken,
 } from '#mcp/secrets/host-approval.ts'
 import {
+	buildSecretPackageApprovalUrl,
+	createSecretPackageApprovalToken,
+	verifySecretPackageApprovalToken,
+} from '#mcp/secrets/package-approval.ts'
+import {
 	deleteSecret,
 	listAppSecretsByAppIds,
 	listSecrets,
@@ -47,6 +52,12 @@ type SavedPackageAppOption = {
 	updatedAt: string
 }
 
+type AllowedPackageView = {
+	packageId: string
+	kodyId: string
+	name: string
+}
+
 type AccountSecretListItem = {
 	id: string
 	name: string
@@ -56,7 +67,7 @@ type AccountSecretListItem = {
 	appTitle: string | null
 	allowedHosts: Array<string>
 	allowedCapabilities: Array<string>
-	allowedPackages: Array<string>
+	allowedPackages: Array<AllowedPackageView>
 	createdAt: string
 	updatedAt: string
 	ttlMs: number | null
@@ -73,9 +84,9 @@ type SecretApprovalView = {
 	requestedHost: string
 	requestedCapability: string | null
 	requestedPackageId: string | null
-	requestedPackageName: string | null
+	requestedPackageKodyId: string | null
 	currentAllowedHosts: Array<string>
-	currentAllowedPackages: Array<string>
+	currentAllowedPackages: Array<AllowedPackageView>
 }
 
 type AccountSecretsPayload = {
@@ -648,6 +659,7 @@ async function buildAccountSecretsPayload(input: {
 	const approvalToken = url.searchParams.get('request')
 	const requestedApprovalHost = readApprovalHost(url)
 	const requestedCapability = readRequestedCapability(url)
+	const requestedPackageId = readRequestedPackageId(url)
 
 	const packageApps =
 		input.packageApps ??
@@ -660,12 +672,29 @@ async function buildAccountSecretsPayload(input: {
 		user: input.user,
 		packageApps,
 	})
+	const packageLookup = new Map(
+		(
+			await listSavedPackagesByUserId(input.env.APP_DB, {
+				userId: input.user.mcpUser.userId,
+			})
+		).map((savedPackage) => [
+			savedPackage.id,
+			{
+				packageId: savedPackage.id,
+				kodyId: savedPackage.kodyId,
+				name: savedPackage.name,
+			} satisfies AllowedPackageView,
+		]),
+	)
+	const normalizedSecrets = secrets.map((secret) =>
+		normalizeAccountSecretListItem(secret, packageLookup),
+	)
 	const selectedSecret = input.selectedSecretId
 		? await resolveAccountSecretDetail({
 				env: input.env,
 				userId: input.user.mcpUser.userId,
 				secretId: input.selectedSecretId,
-				secrets,
+				secrets: normalizedSecrets,
 			})
 		: null
 
@@ -676,6 +705,8 @@ async function buildAccountSecretsPayload(input: {
 				token: approvalToken,
 				requestedHost: requestedApprovalHost,
 				requestedCapability,
+				requestedPackageId,
+				packageLookup,
 			}).catch(() => null)
 		: null
 
@@ -683,7 +714,7 @@ async function buildAccountSecretsPayload(input: {
 		ok: true,
 		email: input.user.email,
 		apps: packageApps,
-		secrets,
+		secrets: normalizedSecrets,
 		selectedSecret,
 		approval,
 	}
@@ -751,16 +782,32 @@ async function resolveSecretApprovalView(input: {
 	token: string
 	requestedHost: string | null
 	requestedCapability: string | null
+	requestedPackageId: string | null
+	packageLookup: Map<string, AllowedPackageView>
 }) {
-	const approval = await verifySecretHostApprovalToken(input.env, input.token)
+	const packageApproval = await verifySecretPackageApprovalToken(
+		input.env,
+		input.token,
+	).catch(() => null)
+	const approval = packageApproval
+		? packageApproval
+		: await verifySecretHostApprovalToken(input.env, input.token)
 	if (approval.userId !== input.userId) {
 		throw new Error('Approval request mismatch.')
 	}
 	if (
+		'requestedHost' in approval &&
 		input.requestedHost != null &&
 		approval.requestedHost !== normalizeAllowedHosts([input.requestedHost])[0]
 	) {
 		throw new Error('Approval request host mismatch.')
+	}
+	if (
+		'packageId' in approval &&
+		input.requestedPackageId != null &&
+		approval.packageId !== input.requestedPackageId
+	) {
+		throw new Error('Approval request package mismatch.')
 	}
 	const secrets = await listSecrets({
 		env: input.env,
@@ -778,12 +825,16 @@ async function resolveSecretApprovalView(input: {
 		token: input.token,
 		name: approval.name,
 		scope: approval.scope,
-		requestedHost: approval.requestedHost,
+		requestedHost: 'requestedHost' in approval ? approval.requestedHost : '',
 		requestedCapability: input.requestedCapability,
-		requestedPackageId: null,
-		requestedPackageName: null,
+		requestedPackageId: 'packageId' in approval ? approval.packageId : null,
+		requestedPackageKodyId:
+			'packageId' in approval ? approval.kodyId : null,
 		currentAllowedHosts: secret.allowedHosts,
-		currentAllowedPackages: secret.allowedPackages,
+		currentAllowedPackages: mapAllowedPackages(
+			secret.allowedPackages,
+			input.packageLookup,
+		),
 	} satisfies SecretApprovalView
 }
 
@@ -854,6 +905,32 @@ function toAccountSecretListItem(
 	} satisfies AccountSecretListItem
 }
 
+function normalizeAccountSecretListItem(
+	secret: AccountSecretListItem,
+	packageLookup: Map<string, AllowedPackageView>,
+): AccountSecretListItem {
+	return {
+		...secret,
+		allowedPackages: mapAllowedPackages(secret.allowedPackages, packageLookup),
+	}
+}
+
+function mapAllowedPackages(
+	allowedPackageIds: Array<string>,
+	packageLookup: Map<string, AllowedPackageView>,
+) {
+	return allowedPackageIds.map((packageId) => {
+		const savedPackage = packageLookup.get(packageId)
+		return (
+			savedPackage ?? {
+				packageId,
+				kodyId: packageId,
+				name: packageId,
+			}
+		)
+	})
+}
+
 async function handleApprovalAction(input: {
 	request: Request
 	env: Env
@@ -870,12 +947,50 @@ async function handleApprovalAction(input: {
 	}
 
 	try {
-		const approval = await verifySecretHostApprovalToken(input.env, token)
+		const packageApproval = await verifySecretPackageApprovalToken(
+			input.env,
+			token,
+		).catch(() => null)
+		const approval = packageApproval
+			? packageApproval
+			: await verifySecretHostApprovalToken(input.env, token)
 		if (approval.userId !== input.user.mcpUser.userId) {
 			return jsonResponse(
 				{ ok: false, error: 'Approval request mismatch.' },
 				403,
 			)
+		}
+
+		if ('packageId' in approval) {
+			const current = await listSecrets({
+				env: input.env,
+				userId: input.user.mcpUser.userId,
+				scope: approval.scope,
+				storageContext: approval.storageContext,
+			})
+			const secret = current.find(
+				(item) => item.name === approval.name && item.scope === approval.scope,
+			)
+			if (!secret) {
+				return jsonResponse({ ok: false, error: 'Secret not found.' }, 404)
+			}
+			if (input.action === 'approve') {
+				await setSecretAllowedPackages({
+					env: input.env,
+					userId: input.user.mcpUser.userId,
+					name: approval.name,
+					scope: approval.scope,
+					allowedPackages: [...secret.allowedPackages, approval.packageId],
+					storageContext: approval.storageContext,
+				})
+			}
+			const payload = await buildAccountSecretsPayload({
+				request: input.request,
+				env: input.env,
+				user: input.user,
+				selectedSecretId: readSelectedSecretId(input.request),
+			})
+			return jsonResponse(payload)
 		}
 
 		if (input.action === 'approve') {
@@ -928,57 +1043,15 @@ async function handlePackageApprovalAction(input: {
 	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
 	body: object
 }) {
-	const currentId = readString(input.body, 'currentId')
-	const packageId = readString(input.body, 'packageId')
-	if (!currentId || !packageId) {
-		return jsonResponse(
-			{ ok: false, error: 'Secret id and package id are required.' },
-			400,
-		)
-	}
-
-	const secret = parseAccountSecretId(currentId)
-	if (!secret || secret.scope === 'session') {
-		return jsonResponse({ ok: false, error: 'Invalid secret id.' }, 400)
-	}
-
-	const savedPackage = await getSavedPackageById(input.env.APP_DB, {
-		userId: input.user.mcpUser.userId,
-		packageId,
-	})
-	if (!savedPackage) {
-		return jsonResponse({ ok: false, error: 'Package not found.' }, 404)
-	}
-
-	const current = await listSecrets({
-		env: input.env,
-		userId: input.user.mcpUser.userId,
-		scope: secret.scope,
-		storageContext: getSecretContextForAccountSecret(secret),
-	})
-	const currentSecret = current.find(
-		(item) => item.name === secret.name && item.scope === secret.scope,
+	void input
+	return jsonResponse(
+		{
+			ok: false,
+			error:
+				'Package approvals must use the signed approval request flow with a request token.',
+		},
+		400,
 	)
-	if (!currentSecret) {
-		return jsonResponse({ ok: false, error: 'Secret not found.' }, 404)
-	}
-
-	await setSecretAllowedPackages({
-		env: input.env,
-		userId: input.user.mcpUser.userId,
-		name: secret.name,
-		scope: secret.scope,
-		allowedPackages: [...currentSecret.allowedPackages, savedPackage.id],
-		storageContext: getSecretContextForAccountSecret(secret),
-	})
-
-	const payload = await buildAccountSecretsPayload({
-		request: input.request,
-		env: input.env,
-		user: input.user,
-		selectedSecretId: currentId,
-	})
-	return jsonResponse(payload)
 }
 
 async function handleSaveAction(input: {
@@ -998,6 +1071,7 @@ async function handleSaveAction(input: {
 	const allowedCapabilities = normalizeAllowedCapabilities(
 		readStringArray(input.body, 'allowedCapabilities'),
 	)
+	const allowedPackages = readStringArray(input.body, 'allowedPackages')
 
 	if (!name) {
 		return jsonResponse({ ok: false, error: 'Secret name is required.' }, 400)
@@ -1081,6 +1155,17 @@ async function handleSaveAction(input: {
 			name,
 			scope,
 			allowedCapabilities,
+			storageContext: getSecretContextForAccountSecret({
+				scope,
+				appId,
+			}),
+		})
+		await setSecretAllowedPackages({
+			env: input.env,
+			userId: input.user.mcpUser.userId,
+			name,
+			scope,
+			allowedPackages,
 			storageContext: getSecretContextForAccountSecret({
 				scope,
 				appId,
@@ -1173,6 +1258,11 @@ function readSelectedSecretId(request: Request) {
 
 function readApprovalHost(url: URL) {
 	const value = url.searchParams.get('allowed-host')
+	return value?.trim() ? value.trim() : null
+}
+
+function readRequestedPackageId(url: URL) {
+	const value = url.searchParams.get('package_id')
 	return value?.trim() ? value.trim() : null
 }
 

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -15,11 +15,7 @@ import {
 	createSecretHostApprovalToken,
 	verifySecretHostApprovalToken,
 } from '#mcp/secrets/host-approval.ts'
-import {
-	buildSecretPackageApprovalUrl,
-	createSecretPackageApprovalToken,
-	verifySecretPackageApprovalToken,
-} from '#mcp/secrets/package-approval.ts'
+import { verifySecretPackageApprovalToken } from '#mcp/secrets/package-approval.ts'
 import {
 	deleteSecret,
 	listAppSecretsByAppIds,
@@ -32,7 +28,6 @@ import {
 } from '#mcp/secrets/service.ts'
 import { type SecretScope } from '#mcp/secrets/types.ts'
 import {
-	getSavedPackageById,
 	listSavedPackagesByUserId,
 } from '#worker/package-registry/repo.ts'
 import { type routes } from '#app/routes.ts'
@@ -687,7 +682,10 @@ async function buildAccountSecretsPayload(input: {
 		]),
 	)
 	const normalizedSecrets = secrets.map((secret) =>
-		normalizeAccountSecretListItem(secret, packageLookup),
+		normalizeAccountSecretListItem(
+			toAccountSecretListItem(secret, new Map()),
+			packageLookup,
+		),
 	)
 	const selectedSecret = input.selectedSecretId
 		? await resolveAccountSecretDetail({
@@ -829,7 +827,7 @@ async function resolveSecretApprovalView(input: {
 		requestedCapability: input.requestedCapability,
 		requestedPackageId: 'packageId' in approval ? approval.packageId : null,
 		requestedPackageKodyId:
-			'packageId' in approval ? approval.kodyId : null,
+			'packageId' in approval ? approval.packageKodyId : null,
 		currentAllowedHosts: secret.allowedHosts,
 		currentAllowedPackages: mapAllowedPackages(
 			secret.allowedPackages,
@@ -898,7 +896,7 @@ function toAccountSecretListItem(
 		appTitle: secret.appId ? (appTitles.get(secret.appId) ?? null) : null,
 		allowedHosts: secret.allowedHosts,
 		allowedCapabilities: secret.allowedCapabilities,
-		allowedPackages: secret.allowedPackages,
+		allowedPackages: [],
 		createdAt: secret.createdAt,
 		updatedAt: secret.updatedAt,
 		ttlMs: secret.ttlMs,
@@ -906,12 +904,21 @@ function toAccountSecretListItem(
 }
 
 function normalizeAccountSecretListItem(
-	secret: AccountSecretListItem,
+	secret: Omit<AccountSecretListItem, 'allowedPackages'> & {
+		allowedPackages: Array<string> | Array<AllowedPackageView>
+	},
 	packageLookup: Map<string, AllowedPackageView>,
 ): AccountSecretListItem {
 	return {
 		...secret,
-		allowedPackages: mapAllowedPackages(secret.allowedPackages, packageLookup),
+		allowedPackages:
+			secret.allowedPackages.length > 0 &&
+			typeof secret.allowedPackages[0] === 'object'
+				? (secret.allowedPackages as Array<AllowedPackageView>)
+				: mapAllowedPackages(
+						secret.allowedPackages as Array<string>,
+						packageLookup,
+					),
 	}
 }
 

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -32,6 +32,7 @@ import {
 } from '#worker/package-registry/repo.ts'
 import { type routes } from '#app/routes.ts'
 import { normalizeAllowedCapabilities } from '#mcp/secrets/allowed-capabilities.ts'
+import { normalizeAllowedPackages } from '#mcp/secrets/allowed-packages.ts'
 import { normalizeAllowedHosts } from '#mcp/secrets/allowed-hosts.ts'
 import { getValue, saveValue } from '#mcp/values/service.ts'
 import {
@@ -756,6 +757,9 @@ async function resolveApprovalRequest(
 		if (isExpiredPackageApprovalError(error)) {
 			throw error
 		}
+		if (error instanceof Error) {
+			throw error
+		}
 	}
 	return await verifySecretHostApprovalToken(env, token)
 }
@@ -945,25 +949,27 @@ async function handleApprovalAction(input: {
 		}
 
 		if (approval.kind === 'package') {
-			const current = await listSecrets({
-				env: input.env,
-				userId: input.user.mcpUser.userId,
-				scope: approval.scope,
-				storageContext: approval.storageContext,
-			})
-			const secret = current.find(
-				(item) => item.name === approval.name && item.scope === approval.scope,
-			)
-			if (!secret) {
-				return jsonResponse({ ok: false, error: 'Secret not found.' }, 404)
-			}
 			if (input.action === 'approve') {
+				const current = await listSecrets({
+					env: input.env,
+					userId: input.user.mcpUser.userId,
+					scope: approval.scope,
+					storageContext: approval.storageContext,
+				})
+				const secret = current.find(
+					(item) => item.name === approval.name && item.scope === approval.scope,
+				)
+				if (!secret) {
+					return jsonResponse({ ok: false, error: 'Secret not found.' }, 404)
+				}
 				await setSecretAllowedPackages({
 					env: input.env,
 					userId: input.user.mcpUser.userId,
 					name: approval.name,
 					scope: approval.scope,
-					allowedPackages: [...secret.allowedPackages, approval.packageId],
+					allowedPackages: Array.from(
+						new Set([...secret.allowedPackages, approval.packageId]),
+					),
 					storageContext: approval.storageContext,
 				})
 			}
@@ -1037,7 +1043,9 @@ async function handleSaveAction(input: {
 	const allowedCapabilities = normalizeAllowedCapabilities(
 		readStringArray(input.body, 'allowedCapabilities'),
 	)
-	const allowedPackages = readStringArray(input.body, 'allowedPackages')
+	const allowedPackages = normalizeAllowedPackages(
+		readStringArray(input.body, 'allowedPackages'),
+	)
 
 	if (!name) {
 		return jsonResponse({ ok: false, error: 'Secret name is required.' }, 400)

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -23,9 +23,13 @@ import {
 	saveSecret,
 	setSecretAllowedCapabilities,
 	setSecretAllowedHosts,
+	setSecretAllowedPackages,
 } from '#mcp/secrets/service.ts'
 import { type SecretScope } from '#mcp/secrets/types.ts'
-import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
+import {
+	getSavedPackageById,
+	listSavedPackagesByUserId,
+} from '#worker/package-registry/repo.ts'
 import { type routes } from '#app/routes.ts'
 import { normalizeAllowedCapabilities } from '#mcp/secrets/allowed-capabilities.ts'
 import { normalizeAllowedHosts } from '#mcp/secrets/allowed-hosts.ts'
@@ -52,6 +56,7 @@ type AccountSecretListItem = {
 	appTitle: string | null
 	allowedHosts: Array<string>
 	allowedCapabilities: Array<string>
+	allowedPackages: Array<string>
 	createdAt: string
 	updatedAt: string
 	ttlMs: number | null
@@ -67,7 +72,10 @@ type SecretApprovalView = {
 	scope: SecretScope
 	requestedHost: string
 	requestedCapability: string | null
+	requestedPackageId: string | null
+	requestedPackageName: string | null
 	currentAllowedHosts: Array<string>
+	currentAllowedPackages: Array<string>
 }
 
 type AccountSecretsPayload = {
@@ -146,6 +154,14 @@ export function createAccountSecretsApiHandler(env: Env) {
 					env,
 					user,
 					action,
+					body,
+				})
+			}
+			if (action === 'approve_package') {
+				return handlePackageApprovalAction({
+					request,
+					env,
+					user,
 					body,
 				})
 			}
@@ -764,7 +780,10 @@ async function resolveSecretApprovalView(input: {
 		scope: approval.scope,
 		requestedHost: approval.requestedHost,
 		requestedCapability: input.requestedCapability,
+		requestedPackageId: null,
+		requestedPackageName: null,
 		currentAllowedHosts: secret.allowedHosts,
+		currentAllowedPackages: secret.allowedPackages,
 	} satisfies SecretApprovalView
 }
 
@@ -803,6 +822,7 @@ function toAccountSecretListItem(
 		appId: string | null
 		allowedHosts: Array<string>
 		allowedCapabilities: Array<string>
+		allowedPackages: Array<string>
 		createdAt: string
 		updatedAt: string
 		ttlMs: number | null
@@ -827,6 +847,7 @@ function toAccountSecretListItem(
 		appTitle: secret.appId ? (appTitles.get(secret.appId) ?? null) : null,
 		allowedHosts: secret.allowedHosts,
 		allowedCapabilities: secret.allowedCapabilities,
+		allowedPackages: secret.allowedPackages,
 		createdAt: secret.createdAt,
 		updatedAt: secret.updatedAt,
 		ttlMs: secret.ttlMs,
@@ -899,6 +920,65 @@ async function handleApprovalAction(input: {
 			400,
 		)
 	}
+}
+
+async function handlePackageApprovalAction(input: {
+	request: Request
+	env: Env
+	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
+	body: object
+}) {
+	const currentId = readString(input.body, 'currentId')
+	const packageId = readString(input.body, 'packageId')
+	if (!currentId || !packageId) {
+		return jsonResponse(
+			{ ok: false, error: 'Secret id and package id are required.' },
+			400,
+		)
+	}
+
+	const secret = parseAccountSecretId(currentId)
+	if (!secret || secret.scope === 'session') {
+		return jsonResponse({ ok: false, error: 'Invalid secret id.' }, 400)
+	}
+
+	const savedPackage = await getSavedPackageById(input.env.APP_DB, {
+		userId: input.user.mcpUser.userId,
+		packageId,
+	})
+	if (!savedPackage) {
+		return jsonResponse({ ok: false, error: 'Package not found.' }, 404)
+	}
+
+	const current = await listSecrets({
+		env: input.env,
+		userId: input.user.mcpUser.userId,
+		scope: secret.scope,
+		storageContext: getSecretContextForAccountSecret(secret),
+	})
+	const currentSecret = current.find(
+		(item) => item.name === secret.name && item.scope === secret.scope,
+	)
+	if (!currentSecret) {
+		return jsonResponse({ ok: false, error: 'Secret not found.' }, 404)
+	}
+
+	await setSecretAllowedPackages({
+		env: input.env,
+		userId: input.user.mcpUser.userId,
+		name: secret.name,
+		scope: secret.scope,
+		allowedPackages: [...currentSecret.allowedPackages, savedPackage.id],
+		storageContext: getSecretContextForAccountSecret(secret),
+	})
+
+	const payload = await buildAccountSecretsPayload({
+		request: input.request,
+		env: input.env,
+		user: input.user,
+		selectedSecretId: currentId,
+	})
+	return jsonResponse(payload)
 }
 
 async function handleSaveAction(input: {

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -47,12 +47,6 @@ type SavedPackageAppOption = {
 	updatedAt: string
 }
 
-type AllowedPackageView = {
-	packageId: string
-	kodyId: string
-	name: string
-}
-
 type AccountSecretListItem = {
 	id: string
 	name: string
@@ -62,7 +56,7 @@ type AccountSecretListItem = {
 	appTitle: string | null
 	allowedHosts: Array<string>
 	allowedCapabilities: Array<string>
-	allowedPackages: Array<AllowedPackageView>
+	allowedPackages: Array<string>
 	createdAt: string
 	updatedAt: string
 	ttlMs: number | null
@@ -79,15 +73,19 @@ type SecretApprovalView = {
 	requestedHost: string
 	requestedCapability: string | null
 	requestedPackageId: string | null
-	requestedPackageKodyId: string | null
 	currentAllowedHosts: Array<string>
-	currentAllowedPackages: Array<AllowedPackageView>
+	currentAllowedPackages: Array<string>
 }
 
 type AccountSecretsPayload = {
 	ok: true
 	email: string
 	apps: Array<SavedPackageAppOption>
+	packages: Array<{
+		id: string
+		kodyId: string
+		name: string
+	}>
 	secrets: Array<AccountSecretListItem>
 	selectedSecret: AccountSecretDetail | null
 	approval: SecretApprovalView | null
@@ -662,7 +660,6 @@ async function buildAccountSecretsPayload(input: {
 		env: input.env,
 		user: input.user,
 		packageApps,
-		packageLookup,
 	})
 	const selectedSecret = input.selectedSecretId
 		? await resolveAccountSecretDetail({
@@ -681,7 +678,6 @@ async function buildAccountSecretsPayload(input: {
 				requestedHost: requestedApprovalHost,
 				requestedCapability,
 				requestedPackageId,
-				packageLookup,
 			}).catch(() => null)
 		: null
 
@@ -689,6 +685,11 @@ async function buildAccountSecretsPayload(input: {
 		ok: true,
 		email: input.user.email,
 		apps: packageApps,
+		packages: Array.from(packageLookup.values()).map((packageEntry) => ({
+			id: packageEntry.packageId,
+			kodyId: packageEntry.kodyId,
+			name: packageEntry.name,
+		})),
 		secrets,
 		selectedSecret,
 		approval,
@@ -722,7 +723,6 @@ async function listAccountSecrets(input: {
 	env: Env
 	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
 	packageApps: Array<SavedPackageAppOption>
-	packageLookup: Map<string, AllowedPackageView>
 }) {
 	const appTitles = new Map(input.packageApps.map((app) => [app.id, app.title]))
 	const [userSecrets, appSecrets] = await Promise.all([
@@ -739,14 +739,10 @@ async function listAccountSecrets(input: {
 	])
 
 	return [
-		...userSecrets.map((secret) =>
-			toAccountSecretListItem(secret, appTitles, input.packageLookup),
-		),
+		...userSecrets.map((secret) => toAccountSecretListItem(secret, appTitles)),
 		...Array.from(appSecrets.values())
 			.flat()
-			.map((secret) =>
-				toAccountSecretListItem(secret, appTitles, input.packageLookup),
-			),
+			.map((secret) => toAccountSecretListItem(secret, appTitles)),
 	].sort((left, right) => {
 		return (
 			left.name.localeCompare(right.name) ||
@@ -763,7 +759,6 @@ async function resolveSecretApprovalView(input: {
 	requestedHost: string | null
 	requestedCapability: string | null
 	requestedPackageId: string | null
-	packageLookup: Map<string, AllowedPackageView>
 }) {
 	const packageApproval = await verifySecretPackageApprovalToken(
 		input.env,
@@ -808,13 +803,8 @@ async function resolveSecretApprovalView(input: {
 		requestedHost: 'requestedHost' in approval ? approval.requestedHost : '',
 		requestedCapability: input.requestedCapability,
 		requestedPackageId: 'packageId' in approval ? approval.packageId : null,
-		requestedPackageKodyId:
-			'packageId' in approval ? approval.packageKodyId : null,
 		currentAllowedHosts: secret.allowedHosts,
-		currentAllowedPackages: mapAllowedPackages(
-			secret.allowedPackages,
-			input.packageLookup,
-		),
+		currentAllowedPackages: secret.allowedPackages,
 	} satisfies SecretApprovalView
 }
 
@@ -859,7 +849,6 @@ function toAccountSecretListItem(
 		ttlMs: number | null
 	},
 	appTitles: Map<string, string>,
-	packageLookup: Map<string, AllowedPackageView>,
 ) {
 	if (secret.scope === 'session') {
 		throw new Error('Session secrets are not editable from the account page.')
@@ -879,27 +868,11 @@ function toAccountSecretListItem(
 		appTitle: secret.appId ? (appTitles.get(secret.appId) ?? null) : null,
 		allowedHosts: secret.allowedHosts,
 		allowedCapabilities: secret.allowedCapabilities,
-		allowedPackages: mapAllowedPackages(secret.allowedPackages, packageLookup),
+		allowedPackages: secret.allowedPackages,
 		createdAt: secret.createdAt,
 		updatedAt: secret.updatedAt,
 		ttlMs: secret.ttlMs,
 	} satisfies AccountSecretListItem
-}
-
-function mapAllowedPackages(
-	allowedPackageIds: Array<string>,
-	packageLookup: Map<string, AllowedPackageView>,
-) {
-	return allowedPackageIds.map((packageId) => {
-		const savedPackage = packageLookup.get(packageId)
-		return (
-			savedPackage ?? {
-				packageId,
-				kodyId: packageId,
-				name: packageId,
-			}
-		)
-	})
 }
 
 async function buildAllowedPackageLookup(input: { env: Env; userId: string }) {
@@ -914,7 +887,7 @@ async function buildAllowedPackageLookup(input: { env: Env; userId: string }) {
 				packageId: savedPackage.id,
 				kodyId: savedPackage.kodyId,
 				name: savedPackage.name,
-			} satisfies AllowedPackageView,
+			},
 		]),
 	)
 }
@@ -1058,10 +1031,6 @@ async function handleSaveAction(input: {
 		env: input.env,
 		user: input.user,
 	})
-	const packageLookup = await buildAllowedPackageLookup({
-		env: input.env,
-		userId: input.user.mcpUser.userId,
-	})
 	const appId = readAppIdForScope({
 		body: input.body,
 		scope,
@@ -1078,7 +1047,6 @@ async function handleSaveAction(input: {
 		env: input.env,
 		user: input.user,
 		packageApps,
-		packageLookup,
 	})
 	const secretById = new Map(secrets.map((secret) => [secret.id, secret]))
 	const currentSecret = currentId ? (secretById.get(currentId) ?? null) : null

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -163,14 +163,6 @@ export function createAccountSecretsApiHandler(env: Env) {
 					body,
 				})
 			}
-			if (action === 'approve_package') {
-				return handlePackageApprovalAction({
-					request,
-					env,
-					user,
-					body,
-				})
-			}
 			if (action === 'save') {
 				return handleSaveAction({
 					request,
@@ -1031,23 +1023,6 @@ async function handleApprovalAction(input: {
 			400,
 		)
 	}
-}
-
-async function handlePackageApprovalAction(input: {
-	request: Request
-	env: Env
-	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
-	body: object
-}) {
-	void input
-	return jsonResponse(
-		{
-			ok: false,
-			error:
-				'Package approvals must use the signed approval request flow with a request token.',
-		},
-		400,
-	)
 }
 
 async function handleSaveAction(input: {

--- a/packages/worker/src/app/handlers/package-app.node.test.ts
+++ b/packages/worker/src/app/handlers/package-app.node.test.ts
@@ -68,7 +68,8 @@ vi.mock('#worker/package-runtime/package-app.ts', () => ({
 
 vi.mock('#worker/package-runtime/realtime-session.ts', () => ({
 	packageRealtimeSessionRpc: (..._args: Array<unknown>) => ({
-		connect: (...args: Array<unknown>) => mockModule.packageRealtimeConnect(...args),
+		connect: (...args: Array<unknown>) =>
+			mockModule.packageRealtimeConnect(...args),
 	}),
 }))
 
@@ -95,7 +96,10 @@ test('handlePackageAppRequest routes websocket package paths to realtime session
 
 	expect(response.status).toBe(200)
 	expect(mockModule.packageRealtimeConnect).toHaveBeenCalledTimes(1)
-	expect(mockModule.packageRealtimeConnect).toHaveBeenCalledWith(request, 'chat')
+	expect(mockModule.packageRealtimeConnect).toHaveBeenCalledWith(
+		request,
+		'chat',
+	)
 	expect(mockModule.buildPackageAppWorker).not.toHaveBeenCalled()
 })
 
@@ -110,7 +114,10 @@ test('handlePackageAppRequest routes websocket paths to realtime session manager
 
 	expect(response.status).toBe(200)
 	expect(mockModule.packageRealtimeConnect).toHaveBeenCalledTimes(1)
-	expect(mockModule.packageRealtimeConnect).toHaveBeenCalledWith(request, 'chat')
+	expect(mockModule.packageRealtimeConnect).toHaveBeenCalledWith(
+		request,
+		'chat',
+	)
 	expect(mockModule.buildPackageAppWorker).not.toHaveBeenCalled()
 })
 

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -57,7 +57,9 @@ export async function handlePackageAppRequest(
 		return new Response('Saved package app not found.', { status: 404 })
 	}
 	const packageRealtimeRestPath =
-		packagePath?.kodyId === kodyId ? packagePath.restPath : requestUrl.pathname || '/'
+		packagePath?.kodyId === kodyId
+			? packagePath.restPath
+			: requestUrl.pathname || '/'
 	const forwardedPackageRestPath =
 		packagePath?.kodyId === kodyId ? packagePath.restPath : '/'
 	const user = await readAuthenticatedAppUser(request, env)
@@ -73,7 +75,9 @@ export async function handlePackageAppRequest(
 	}
 	try {
 		const baseUrl = getAppBaseUrl({ env, requestUrl: request.url })
-		const packageRealtimePath = parsePackageRealtimePath(packageRealtimeRestPath)
+		const packageRealtimePath = parsePackageRealtimePath(
+			packageRealtimeRestPath,
+		)
 		if (packageRealtimePath && request.headers.get('Upgrade') === 'websocket') {
 			return await packageRealtimeSessionRpc({
 				env,

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -14,6 +14,7 @@ export const routes = route({
 	accountSecretUserDetail: '/account/secrets/user/:secretName',
 	accountSecretAppDetail: '/account/secrets/app/:appId/:secretName',
 	accountSecretSessionDetail: '/account/secrets/session/:sessionId/:secretName',
+	accountSecretPackageDetail: '/account/secrets/package/:packageId/:secretName',
 	accountSecretsApprove: '/account/secrets/approve',
 	accountSecretsApi: '/account/secrets.json',
 	accountSecretsApiPost: post('/account/secrets.json'),

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -196,30 +196,28 @@ export const EnvSchema = object({
 			)
 		},
 	),
-	PACKAGE_REALTIME_SESSION: createSchema<
-		unknown,
-		DurableObjectNamespace
-	>((value, context) => {
-		if (value) {
-			return { value: value as DurableObjectNamespace }
-		}
-		return fail(
-			'Missing PACKAGE_REALTIME_SESSION binding for package realtime websocket sessions.',
-			context.path,
-		)
-	}),
-	PACKAGE_SERVICE_INSTANCE: createSchema<
-		unknown,
-		DurableObjectNamespace
-	>((value, context) => {
-		if (value) {
-			return { value: value as DurableObjectNamespace }
-		}
-		return fail(
-			'Missing PACKAGE_SERVICE_INSTANCE binding for package service runtimes.',
-			context.path,
-		)
-	}),
+	PACKAGE_REALTIME_SESSION: createSchema<unknown, DurableObjectNamespace>(
+		(value, context) => {
+			if (value) {
+				return { value: value as DurableObjectNamespace }
+			}
+			return fail(
+				'Missing PACKAGE_REALTIME_SESSION binding for package realtime websocket sessions.',
+				context.path,
+			)
+		},
+	),
+	PACKAGE_SERVICE_INSTANCE: createSchema<unknown, DurableObjectNamespace>(
+		(value, context) => {
+			if (value) {
+				return { value: value as DurableObjectNamespace }
+			}
+			return fail(
+				'Missing PACKAGE_SERVICE_INSTANCE binding for package service runtimes.',
+				context.path,
+			)
+		},
+	),
 	APP_BASE_URL: optionalUrlStringSchema,
 	APP_COMMIT_SHA: optionalCommitShaSchema,
 	CLOUDFLARE_EMAIL_FROM: optionalNonEmptyStringSchema,

--- a/packages/worker/src/home/mcp.ts
+++ b/packages/worker/src/home/mcp.ts
@@ -101,8 +101,7 @@ async function registerBridgeTools(agent: HomeMcpBridge) {
 		'home_list_tools',
 		{
 			title: 'List Home Connector Tools',
-			description:
-				'List raw tools exposed by the connected home connector.',
+			description: 'List raw tools exposed by the connected home connector.',
 			inputSchema: {},
 		},
 		async () => {

--- a/packages/worker/src/jobs/manager-state.ts
+++ b/packages/worker/src/jobs/manager-state.ts
@@ -1,4 +1,7 @@
-import { type JobManagerDebugState, type JobManagerDebugStatus } from './manager-client.ts'
+import {
+	type JobManagerDebugState,
+	type JobManagerDebugStatus,
+} from './manager-client.ts'
 
 export function resolveJobManagerAlarmState(input: {
 	alarmTimestamp: number | null
@@ -19,8 +22,7 @@ export function resolveJobManagerAlarmState(input: {
 		alarmMs != null &&
 		Number.isFinite(nextRunnableMs) &&
 		alarmMs === nextRunnableMs
-	const alarmInSync =
-		nextRunnableMs == null ? alarmMs == null : timestampsMatch
+	const alarmInSync = nextRunnableMs == null ? alarmMs == null : timestampsMatch
 	const status: JobManagerDebugStatus =
 		nextRunnableMs == null
 			? alarmMs == null

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -33,16 +33,16 @@ import {
 	type JobUpdateInput,
 	type PersistedJobCallerContext,
 } from './types.ts'
-import {
-	createJobStorageId,
-	storageRunnerRpc,
-} from '#worker/storage-runner.ts'
+import { createJobStorageId, storageRunnerRpc } from '#worker/storage-runner.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
 import {
 	normalizePackageWorkspacePath,
 	parseAuthoredPackageJson,
 } from '#worker/package-registry/manifest.ts'
-import { getManifestEntrypointPath, parseRepoManifest } from '#worker/repo/manifest.ts'
+import {
+	getManifestEntrypointPath,
+	parseRepoManifest,
+} from '#worker/repo/manifest.ts'
 import { typecheckPackageEntrypointsFromSourceFiles } from '#worker/repo/checks.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 import { buildJobSourceFiles } from '#worker/repo/source-templates.ts'
@@ -136,9 +136,8 @@ async function buildPublishedJobBundle(input: {
 }) {
 	// Load the worker bundler lazily so registry-only/node test paths that import
 	// jobs/service.ts do not eagerly pull the heavy bundler stack.
-	const { buildKodyModuleBundle } = await import(
-		'#worker/package-runtime/module-graph.ts'
-	)
+	const { buildKodyModuleBundle } =
+		await import('#worker/package-runtime/module-graph.ts')
 	return await buildKodyModuleBundle(input)
 }
 
@@ -153,6 +152,7 @@ async function persistPublishedJobBundleArtifact(input: {
 	packageContext?: {
 		packageId: string
 		kodyId: string
+		sourceId: string
 	} | null
 }) {
 	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
@@ -244,6 +244,7 @@ async function ensurePublishedBundleArtifactForJob(input: {
 	let packageContext: {
 		packageId: string
 		kodyId: string
+		sourceId: string
 	} | null = null
 	if (manifestPath === 'kody.json' || publishedSource.entity_kind === 'job') {
 		const manifest = parseRepoManifest({
@@ -251,7 +252,9 @@ async function ensurePublishedBundleArtifactForJob(input: {
 			manifestPath,
 		})
 		if (manifest.kind !== 'job') {
-			throw new Error(`Repo source "${input.job.sourceId}" is not a job manifest.`)
+			throw new Error(
+				`Repo source "${input.job.sourceId}" is not a job manifest.`,
+			)
 		}
 		entryPoint = getManifestEntrypointPath(manifest)
 	} else {
@@ -269,6 +272,7 @@ async function ensurePublishedBundleArtifactForJob(input: {
 		packageContext = {
 			packageId: source.entity_id,
 			kodyId: manifest.kody.id,
+			sourceId: input.job.sourceId,
 		}
 	}
 	const artifact = await loadPublishedBundleArtifactByIdentity({
@@ -349,6 +353,7 @@ async function rebuildAndExecuteJobArtifact(input: {
 	packageContext?: {
 		packageId: string
 		kodyId: string
+		sourceId: string
 	} | null
 }) {
 	if (!input.job.sourceId) {
@@ -461,17 +466,17 @@ async function archiveSuccessfulOneOffJob(input: {
 	})
 }
 
-async function cleanupArchivedJobArtifacts(input: {
-	env: Env
-	now?: Date
-}) {
+async function cleanupArchivedJobArtifacts(input: { env: Env; now?: Date }) {
 	const due = await listArchivedJobArtifactsDueBefore(
 		input.env.APP_DB,
 		(input.now ?? new Date()).toISOString(),
 	)
 	for (const artifact of due) {
 		try {
-			const source = await getEntitySourceById(input.env.APP_DB, artifact.sourceId)
+			const source = await getEntitySourceById(
+				input.env.APP_DB,
+				artifact.sourceId,
+			)
 			if (source) {
 				await deletePublishedArtifactsForSource({
 					env: input.env,
@@ -1148,6 +1153,7 @@ async function runRepoBackedJob(input: {
 		packageContext: {
 			packageId: source.entity_id ?? input.job.id,
 			kodyId: manifest.kody.id,
+			sourceId: input.job.sourceId,
 		},
 	})
 }

--- a/packages/worker/src/mcp/capabilities/apps/apps-domain.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/apps/apps-domain.node.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from 'vitest'
 
 test('builtin capability domains include apps realtime capabilities', async () => {
-	const { builtinDomains } = await import('#mcp/capabilities/builtin-domains.ts')
+	const { builtinDomains } =
+		await import('#mcp/capabilities/builtin-domains.ts')
 	const appsDomain = builtinDomains.find((domain) => domain.name === 'apps')
 	expect(appsDomain).toBeTruthy()
 	expect(appsDomain?.capabilities.map((capability) => capability.name)).toEqual(

--- a/packages/worker/src/mcp/capabilities/apps/session-emit.ts
+++ b/packages/worker/src/mcp/capabilities/apps/session-emit.ts
@@ -30,7 +30,9 @@ export const sessionEmitCapability = defineDomainCapability(
 			)
 			return {
 				delivered: result?.delivered === true,
-				...(typeof result?.reason === 'string' ? { reason: result.reason } : {}),
+				...(typeof result?.reason === 'string'
+					? { reason: result.reason }
+					: {}),
 			}
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/apps/session-list.ts
+++ b/packages/worker/src/mcp/capabilities/apps/session-list.ts
@@ -1,6 +1,9 @@
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { requirePackageRealtimeContext, packageRealtimeSessionRecordSchema } from './shared.ts'
+import {
+	requirePackageRealtimeContext,
+	packageRealtimeSessionRecordSchema,
+} from './shared.ts'
 import { z } from 'zod'
 
 const inputSchema = z.object({
@@ -37,9 +40,7 @@ export const sessionListCapability = defineDomainCapability(
 				facet: args.facet ?? null,
 				topic: args.topic ?? null,
 			})
-			const sessions = Array.isArray(result?.sessions)
-				? result.sessions
-				: []
+			const sessions = Array.isArray(result?.sessions) ? result.sessions : []
 			return {
 				package_id: realtimeContext.savedPackage.id,
 				kody_id: realtimeContext.savedPackage.kodyId,

--- a/packages/worker/src/mcp/capabilities/apps/shared.ts
+++ b/packages/worker/src/mcp/capabilities/apps/shared.ts
@@ -36,9 +36,7 @@ export const sessionBroadcastOutputSchema = z.object({
 
 export type PackageRealtimeContext = {
 	user: ReturnType<typeof requireMcpUser>
-	savedPackage: NonNullable<
-		Awaited<ReturnType<typeof getSavedPackageById>>
-	>
+	savedPackage: NonNullable<Awaited<ReturnType<typeof getSavedPackageById>>>
 	realtime: Awaited<ReturnType<typeof createPackageRealtimeClient>>
 }
 
@@ -99,8 +97,7 @@ async function createPackageRealtimeClient(input: {
 	sourceId: string
 	baseUrl: string
 }) {
-	const { packageRealtimeSessionRpc } = await import(
-		'#worker/package-runtime/realtime-session.ts'
-	)
+	const { packageRealtimeSessionRpc } =
+		await import('#worker/package-runtime/realtime-session.ts')
 	return packageRealtimeSessionRpc(input)
 }

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -60,9 +60,9 @@ export const kodyOfficialGuideCatalog = {
 	},
 } as const
 
-const guideIds = Object.keys(
-	kodyOfficialGuideCatalog,
-) as Array<keyof typeof kodyOfficialGuideCatalog>
+const guideIds = Object.keys(kodyOfficialGuideCatalog) as Array<
+	keyof typeof kodyOfficialGuideCatalog
+>
 
 function buildRawGithubUrl(file: string): string {
 	const { owner, repo, ref, basePath } = KODY_GUIDES_REPO
@@ -121,12 +121,7 @@ function buildCapabilityDescription(): string {
 }
 
 const guideFieldSchema = z
-	.enum(
-		guideIds as [
-			KodyOfficialGuideId,
-			...Array<KodyOfficialGuideId>,
-		],
-	)
+	.enum(guideIds as [KodyOfficialGuideId, ...Array<KodyOfficialGuideId>])
 	.describe(
 		[
 			'Which guide to load.',

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
@@ -160,4 +160,3 @@ test('meta_list_capabilities filters by domain', async () => {
 		),
 	).toBe(true)
 })
-

--- a/packages/worker/src/mcp/capabilities/packages/domain.ts
+++ b/packages/worker/src/mcp/capabilities/packages/domain.ts
@@ -3,6 +3,7 @@ import { capabilityDomainNames } from '../domain-metadata.ts'
 import { deletePackageCapability } from './delete-package.ts'
 import { getPackageCapability } from './get-package.ts'
 import { listPackagesCapability } from './list-packages.ts'
+import { listPackageSubscriptionsCapability } from './list-package-subscriptions.ts'
 import { savePackageCapability } from './save-package.ts'
 
 export const packagesDomain = defineDomain({
@@ -14,6 +15,7 @@ export const packagesDomain = defineDomain({
 		savePackageCapability,
 		getPackageCapability,
 		listPackagesCapability,
+		listPackageSubscriptionsCapability,
 		deletePackageCapability,
 	],
 })

--- a/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.node.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest'
+import { beforeEach, expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
 	listSavedPackagesByUserId: vi.fn(),
@@ -18,8 +18,13 @@ vi.mock('#worker/package-registry/source.ts', () => ({
 const { listPackageSubscriptionsCapability } =
 	await import('./list-package-subscriptions.ts')
 
+beforeEach(() => {
+	mockModule.listSavedPackagesByUserId.mockReset()
+	mockModule.loadPackageManifestBySourceId.mockReset()
+})
+
 test('listPackageSubscriptionsCapability returns declared subscriptions', async () => {
-	mockModule.listSavedPackagesByUserId.mockResolvedValue([
+	mockModule.listSavedPackagesByUserId.mockResolvedValueOnce([
 		{
 			id: 'package-1',
 			userId: 'user-1',
@@ -48,47 +53,41 @@ test('listPackageSubscriptionsCapability returns declared subscriptions', async 
 		},
 	])
 
-	mockModule.loadPackageManifestBySourceId.mockImplementation(
-		async ({ sourceId }: { sourceId: string }) => {
-			if (sourceId === 'source-1') {
-				return {
-					source: { id: sourceId },
-					manifest: {
-						name: '@kentcdodds/discord-general-chat',
-						exports: {
-							'.': './src/index.ts',
+	mockModule.loadPackageManifestBySourceId.mockImplementationOnce(async () => ({
+		source: { id: 'source-1' },
+		manifest: {
+			name: '@kentcdodds/discord-general-chat',
+			exports: {
+				'.': './src/index.ts',
+			},
+			kody: {
+				id: 'discord-general-chat',
+				description: 'General Discord thread chat subscriber',
+				subscriptions: {
+					'discord.message.created': {
+						handler: './src/handle-discord-message-created.ts',
+						description: 'General chat handler',
+						filters: {
+							channelIds: ['123'],
 						},
-						kody: {
-							id: 'discord-general-chat',
-							description: 'General Discord thread chat subscriber',
-							subscriptions: {
-								'discord.message.created': {
-									handler: './src/handle-discord-message-created.ts',
-									description: 'General chat handler',
-									filters: {
-										channelIds: ['123'],
-									},
-								},
-							},
-						},
-					},
-				}
-			}
-			return {
-				source: { id: sourceId },
-				manifest: {
-					name: '@kentcdodds/other',
-					exports: {
-						'.': './src/index.ts',
-					},
-					kody: {
-						id: 'other',
-						description: 'Other package',
 					},
 				},
-			}
+			},
 		},
-	)
+	}))
+	mockModule.loadPackageManifestBySourceId.mockImplementationOnce(async () => ({
+		source: { id: 'source-2' },
+		manifest: {
+			name: '@kentcdodds/other',
+			exports: {
+				'.': './src/index.ts',
+			},
+			kody: {
+				id: 'other',
+				description: 'Other package',
+			},
+		},
+	}))
 
 	const result = await listPackageSubscriptionsCapability.handler(
 		{ topic: 'discord.message.created' },

--- a/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.node.test.ts
@@ -125,3 +125,206 @@ test('listPackageSubscriptionsCapability returns declared subscriptions', async 
 		],
 	})
 })
+
+test('listPackageSubscriptionsCapability returns all subscriptions sorted without topic filter', async () => {
+	mockModule.listSavedPackagesByUserId.mockResolvedValueOnce([
+		{
+			id: 'package-1',
+			userId: 'user-1',
+			name: '@kentcdodds/z-package',
+			kodyId: 'z-package',
+			description: 'Z package',
+			tags: [],
+			searchText: null,
+			sourceId: 'source-1',
+			hasApp: false,
+			createdAt: '2026-04-25T00:00:00.000Z',
+			updatedAt: '2026-04-25T00:00:00.000Z',
+		},
+		{
+			id: 'package-2',
+			userId: 'user-1',
+			name: '@kentcdodds/a-package',
+			kodyId: 'a-package',
+			description: 'A package',
+			tags: [],
+			searchText: null,
+			sourceId: 'source-2',
+			hasApp: false,
+			createdAt: '2026-04-25T00:00:00.000Z',
+			updatedAt: '2026-04-25T00:00:00.000Z',
+		},
+	])
+	mockModule.loadPackageManifestBySourceId.mockImplementationOnce(async () => ({
+		source: { id: 'source-1' },
+		manifest: {
+			name: '@kentcdodds/z-package',
+			exports: { '.': './src/index.ts' },
+			kody: {
+				id: 'z-package',
+				description: 'Z package',
+				subscriptions: {
+					'discord.reaction.created': {
+						handler: './src/reaction.ts',
+					},
+				},
+			},
+		},
+	}))
+	mockModule.loadPackageManifestBySourceId.mockImplementationOnce(async () => ({
+		source: { id: 'source-2' },
+		manifest: {
+			name: '@kentcdodds/a-package',
+			exports: { '.': './src/index.ts' },
+			kody: {
+				id: 'a-package',
+				description: 'A package',
+				subscriptions: {
+					'discord.message.created': {
+						handler: './src/message.ts',
+						description: 'Message handler',
+						filters: { channelIds: ['123'] },
+					},
+				},
+			},
+		},
+	}))
+
+	const result = await listPackageSubscriptionsCapability.handler(
+		{},
+		{
+			env: { APP_DB: {} } as Env,
+			callerContext: {
+				baseUrl: 'https://heykody.dev',
+				user: {
+					userId: 'user-1',
+					email: 'me@kentcdodds.com',
+					displayName: 'Kent',
+				},
+				homeConnectorId: null,
+				remoteConnectors: null,
+				storageContext: null,
+				repoContext: null,
+			},
+		},
+	)
+
+	expect(result).toEqual({
+		subscriptions: [
+			{
+				package_id: 'package-2',
+				kody_id: 'a-package',
+				name: '@kentcdodds/a-package',
+				topic: 'discord.message.created',
+				handler: './src/message.ts',
+				description: 'Message handler',
+				filters: { channelIds: ['123'] },
+			},
+			{
+				package_id: 'package-1',
+				kody_id: 'z-package',
+				name: '@kentcdodds/z-package',
+				topic: 'discord.reaction.created',
+				handler: './src/reaction.ts',
+				description: null,
+				filters: null,
+			},
+		],
+	})
+})
+
+test('listPackageSubscriptionsCapability skips packages whose manifest load fails', async () => {
+	const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	mockModule.listSavedPackagesByUserId.mockResolvedValueOnce([
+		{
+			id: 'package-1',
+			userId: 'user-1',
+			name: '@kentcdodds/ok-package',
+			kodyId: 'ok-package',
+			description: 'OK package',
+			tags: [],
+			searchText: null,
+			sourceId: 'source-ok',
+			hasApp: false,
+			createdAt: '2026-04-25T00:00:00.000Z',
+			updatedAt: '2026-04-25T00:00:00.000Z',
+		},
+		{
+			id: 'package-2',
+			userId: 'user-1',
+			name: '@kentcdodds/bad-package',
+			kodyId: 'bad-package',
+			description: 'Bad package',
+			tags: [],
+			searchText: null,
+			sourceId: 'source-bad',
+			hasApp: false,
+			createdAt: '2026-04-25T00:00:00.000Z',
+			updatedAt: '2026-04-25T00:00:00.000Z',
+		},
+	])
+	mockModule.loadPackageManifestBySourceId.mockImplementationOnce(async () => ({
+		source: { id: 'source-ok' },
+		manifest: {
+			name: '@kentcdodds/ok-package',
+			exports: { '.': './src/index.ts' },
+			kody: {
+				id: 'ok-package',
+				description: 'OK package',
+				subscriptions: {
+					'discord.message.created': {
+						handler: './src/message.ts',
+					},
+				},
+			},
+		},
+	}))
+	mockModule.loadPackageManifestBySourceId.mockImplementationOnce(async () => {
+		throw new Error('manifest unavailable')
+	})
+
+	try {
+		const result = await listPackageSubscriptionsCapability.handler(
+			{},
+			{
+				env: { APP_DB: {} } as Env,
+				callerContext: {
+					baseUrl: 'https://heykody.dev',
+					user: {
+						userId: 'user-1',
+						email: 'me@kentcdodds.com',
+						displayName: 'Kent',
+					},
+					homeConnectorId: null,
+					remoteConnectors: null,
+					storageContext: null,
+					repoContext: null,
+				},
+			},
+		)
+
+		expect(result).toEqual({
+			subscriptions: [
+				{
+					package_id: 'package-1',
+					kody_id: 'ok-package',
+					name: '@kentcdodds/ok-package',
+					topic: 'discord.message.created',
+					handler: './src/message.ts',
+					description: null,
+					filters: null,
+				},
+			],
+		})
+	expect(warnSpy).toHaveBeenCalledWith(
+		'Failed to load package manifest for subscriptions',
+		{
+			sourceId: 'source-bad',
+			packageId: 'package-2',
+			error: expect.any(Error),
+		},
+	)
+	} finally {
+		warnSpy.mockRestore()
+	}
+})

--- a/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.node.test.ts
@@ -316,14 +316,14 @@ test('listPackageSubscriptionsCapability skips packages whose manifest load fail
 				},
 			],
 		})
-	expect(warnSpy).toHaveBeenCalledWith(
-		'Failed to load package manifest for subscriptions',
-		{
-			sourceId: 'source-bad',
-			packageId: 'package-2',
-			error: expect.any(Error),
-		},
-	)
+		expect(warnSpy).toHaveBeenCalledWith(
+			'Failed to load package manifest for subscriptions',
+			{
+				sourceId: 'source-bad',
+				packageId: 'package-2',
+				error: expect.any(Error),
+			},
+		)
 	} finally {
 		warnSpy.mockRestore()
 	}

--- a/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.node.test.ts
@@ -63,7 +63,6 @@ test('listPackageSubscriptionsCapability returns declared subscriptions', async 
 							description: 'General Discord thread chat subscriber',
 							subscriptions: {
 								'discord.message.created': {
-									topic: 'discord.message.created',
 									handler: './src/handle-discord-message-created.ts',
 									description: 'General chat handler',
 									filters: {

--- a/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.node.test.ts
@@ -1,0 +1,128 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	listSavedPackagesByUserId: vi.fn(),
+	loadPackageManifestBySourceId: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	listSavedPackagesByUserId: (...args: Array<unknown>) =>
+		mockModule.listSavedPackagesByUserId(...args),
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageManifestBySourceId: (...args: Array<unknown>) =>
+		mockModule.loadPackageManifestBySourceId(...args),
+}))
+
+const { listPackageSubscriptionsCapability } =
+	await import('./list-package-subscriptions.ts')
+
+test('listPackageSubscriptionsCapability returns declared subscriptions', async () => {
+	mockModule.listSavedPackagesByUserId.mockResolvedValue([
+		{
+			id: 'package-1',
+			userId: 'user-1',
+			name: '@kentcdodds/discord-general-chat',
+			kodyId: 'discord-general-chat',
+			description: 'General Discord thread chat subscriber',
+			tags: ['discord'],
+			searchText: null,
+			sourceId: 'source-1',
+			hasApp: false,
+			createdAt: '2026-04-25T00:00:00.000Z',
+			updatedAt: '2026-04-25T00:00:00.000Z',
+		},
+		{
+			id: 'package-2',
+			userId: 'user-1',
+			name: '@kentcdodds/other',
+			kodyId: 'other',
+			description: 'Non-subscriber package',
+			tags: [],
+			searchText: null,
+			sourceId: 'source-2',
+			hasApp: false,
+			createdAt: '2026-04-25T00:00:00.000Z',
+			updatedAt: '2026-04-25T00:00:00.000Z',
+		},
+	])
+
+	mockModule.loadPackageManifestBySourceId.mockImplementation(
+		async ({ sourceId }: { sourceId: string }) => {
+			if (sourceId === 'source-1') {
+				return {
+					source: { id: sourceId },
+					manifest: {
+						name: '@kentcdodds/discord-general-chat',
+						exports: {
+							'.': './src/index.ts',
+						},
+						kody: {
+							id: 'discord-general-chat',
+							description: 'General Discord thread chat subscriber',
+							subscriptions: {
+								'discord.message.created': {
+									topic: 'discord.message.created',
+									handler: './src/handle-discord-message-created.ts',
+									description: 'General chat handler',
+									filters: {
+										channelIds: ['123'],
+									},
+								},
+							},
+						},
+					},
+				}
+			}
+			return {
+				source: { id: sourceId },
+				manifest: {
+					name: '@kentcdodds/other',
+					exports: {
+						'.': './src/index.ts',
+					},
+					kody: {
+						id: 'other',
+						description: 'Other package',
+					},
+				},
+			}
+		},
+	)
+
+	const result = await listPackageSubscriptionsCapability.handler(
+		{ topic: 'discord.message.created' },
+		{
+			env: { APP_DB: {} } as Env,
+			callerContext: {
+				baseUrl: 'https://heykody.dev',
+				user: {
+					userId: 'user-1',
+					email: 'me@kentcdodds.com',
+					displayName: 'Kent',
+				},
+				homeConnectorId: null,
+				remoteConnectors: null,
+				storageContext: null,
+				repoContext: null,
+			},
+		},
+	)
+
+	expect(result).toEqual({
+		subscriptions: [
+			{
+				package_id: 'package-1',
+				kody_id: 'discord-general-chat',
+				name: '@kentcdodds/discord-general-chat',
+				topic: 'discord.message.created',
+				handler: './src/handle-discord-message-created.ts',
+				description: 'General chat handler',
+				filters: {
+					channelIds: ['123'],
+				},
+			},
+		],
+	})
+})

--- a/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
@@ -55,7 +55,14 @@ export const listPackageSubscriptionsCapability = defineDomainCapability(
 						baseUrl: ctx.callerContext.baseUrl,
 						userId: user.userId,
 						sourceId: savedPackage.sourceId,
-					}).catch(() => null),
+					}).catch((error) => {
+						console.warn('Failed to load package manifest for subscriptions', {
+							packageId: savedPackage.id,
+							sourceId: savedPackage.sourceId,
+							error,
+						})
+						return null
+					}),
 				})),
 			)
 			const subscriptions: Array<z.infer<typeof packageSubscriptionSchema>> = []

--- a/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
+import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
+
+const packageSubscriptionSchema = z.object({
+	package_id: z.string(),
+	kody_id: z.string(),
+	name: z.string(),
+	topic: z.string(),
+	handler: z.string(),
+	description: z.string().nullable(),
+	filters: z.record(z.string(), z.unknown()).nullable(),
+})
+
+export const listPackageSubscriptionsCapability = defineDomainCapability(
+	capabilityDomainNames.packages,
+	{
+		name: 'package_subscription_list',
+		description:
+			'List manifest-declared package subscriptions for the signed-in user, optionally filtered by topic.',
+		keywords: [
+			'package',
+			'subscription',
+			'event',
+			'handler',
+			'list',
+			'manifest',
+		],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: z.object({
+			topic: z
+				.string()
+				.min(1)
+				.optional()
+				.describe('Optional exact topic filter.'),
+		}),
+		outputSchema: z.object({
+			subscriptions: z.array(packageSubscriptionSchema),
+		}),
+		async handler(args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const packages = await listSavedPackagesByUserId(ctx.env.APP_DB, {
+				userId: user.userId,
+			})
+			const subscriptions = []
+			for (const savedPackage of packages) {
+				const loaded = await loadPackageManifestBySourceId({
+					env: ctx.env,
+					baseUrl: ctx.callerContext.baseUrl,
+					userId: user.userId,
+					sourceId: savedPackage.sourceId,
+				}).catch(() => null)
+				if (!loaded) continue
+				const declared = loaded.manifest.kody.subscriptions ?? {}
+				for (const [topic, definition] of Object.entries(declared)) {
+					if (args.topic && args.topic !== topic) continue
+					subscriptions.push({
+						package_id: savedPackage.id,
+						kody_id: savedPackage.kodyId,
+						name: savedPackage.name,
+						topic,
+						handler: definition.handler,
+						description: definition.description ?? null,
+						filters: definition.filters ?? null,
+					})
+				}
+			}
+			return {
+				subscriptions: subscriptions.sort((left, right) => {
+					return (
+						left.topic.localeCompare(right.topic) ||
+						left.kody_id.localeCompare(right.kody_id)
+					)
+				}),
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
@@ -47,14 +47,19 @@ export const listPackageSubscriptionsCapability = defineDomainCapability(
 			const packages = await listSavedPackagesByUserId(ctx.env.APP_DB, {
 				userId: user.userId,
 			})
-			const subscriptions = []
-			for (const savedPackage of packages) {
-				const loaded = await loadPackageManifestBySourceId({
-					env: ctx.env,
-					baseUrl: ctx.callerContext.baseUrl,
-					userId: user.userId,
-					sourceId: savedPackage.sourceId,
-				}).catch(() => null)
+			const loadedManifests = await Promise.all(
+				packages.map(async (savedPackage) => ({
+					savedPackage,
+					loaded: await loadPackageManifestBySourceId({
+						env: ctx.env,
+						baseUrl: ctx.callerContext.baseUrl,
+						userId: user.userId,
+						sourceId: savedPackage.sourceId,
+					}).catch(() => null),
+				})),
+			)
+			const subscriptions: Array<z.infer<typeof packageSubscriptionSchema>> = []
+			for (const { savedPackage, loaded } of loadedManifests) {
 				if (!loaded) continue
 				const declared = loaded.manifest.kody.subscriptions ?? {}
 				for (const [topic, definition] of Object.entries(declared)) {

--- a/packages/worker/src/mcp/capabilities/secrets/secret-list.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/secret-list.ts
@@ -48,6 +48,7 @@ export const secretListCapability = defineDomainCapability(
 					app_id: secret.appId,
 					allowed_hosts: secret.allowedHosts,
 					allowed_capabilities: secret.allowedCapabilities,
+					allowed_packages: secret.allowedPackages,
 					created_at: secret.createdAt,
 					updated_at: secret.updatedAt,
 					ttl_ms: secret.ttlMs,

--- a/packages/worker/src/mcp/capabilities/secrets/secret-set.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/secret-set.ts
@@ -65,6 +65,7 @@ export const secretSetCapability = defineDomainCapability(
 				app_id: saved.appId,
 				allowed_hosts: saved.allowedHosts,
 				allowed_capabilities: saved.allowedCapabilities,
+				allowed_packages: saved.allowedPackages,
 				created_at: saved.createdAt,
 				updated_at: saved.updatedAt,
 				ttl_ms: saved.ttlMs,

--- a/packages/worker/src/mcp/capabilities/secrets/shared.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/shared.ts
@@ -8,6 +8,7 @@ export const secretMetadataSchema = z.object({
 	app_id: z.string().nullable(),
 	allowed_hosts: z.array(z.string()),
 	allowed_capabilities: z.array(z.string()),
+	allowed_packages: z.array(z.string()),
 	created_at: z.string(),
 	updated_at: z.string(),
 	ttl_ms: z.number().int().nonnegative().nullable(),

--- a/packages/worker/src/mcp/capabilities/services/service-get.ts
+++ b/packages/worker/src/mcp/capabilities/services/service-get.ts
@@ -30,9 +30,7 @@ export const serviceGetCapability = defineDomainCapability(
 				explicitPackageId: args.package_id,
 			})
 			if (!serviceContext.service) {
-				throw new Error(
-					`Package service "${args.service_name}" was not found.`,
-				)
+				throw new Error(`Package service "${args.service_name}" was not found.`)
 			}
 			return normalizePackageServiceStatus(
 				await serviceContext.service.status(),

--- a/packages/worker/src/mcp/capabilities/services/service-list.ts
+++ b/packages/worker/src/mcp/capabilities/services/service-list.ts
@@ -50,6 +50,7 @@ export const serviceListCapability = defineDomainCapability(
 						name: service.name,
 						entry: service.entry,
 						auto_start: service.auto_start,
+						mode: service.mode,
 						timeout_ms: service.timeout_ms ?? null,
 						status,
 					}

--- a/packages/worker/src/mcp/capabilities/services/service-stop.ts
+++ b/packages/worker/src/mcp/capabilities/services/service-stop.ts
@@ -31,9 +31,7 @@ export const serviceStopCapability = defineDomainCapability(
 				explicitPackageId: args.package_id,
 			})
 			if (!serviceContext.service) {
-				throw new Error(
-					`Package service "${args.service_name}" was not found.`,
-				)
+				throw new Error(`Package service "${args.service_name}" was not found.`)
 			}
 			const result = (await serviceContext.service.stop()) as { ok?: unknown }
 			return {

--- a/packages/worker/src/mcp/capabilities/services/services-domain.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/services/services-domain.node.test.ts
@@ -62,7 +62,9 @@ function createCallerContext() {
 }
 
 test('services domain exposes package service lifecycle capabilities', () => {
-	expect(servicesDomain.capabilities.map((capability) => capability.name)).toEqual(
+	expect(
+		servicesDomain.capabilities.map((capability) => capability.name),
+	).toEqual(
 		expect.arrayContaining([
 			'service_list',
 			'service_get',
@@ -97,6 +99,7 @@ test('service_list returns declared package services with live status', async ()
 				name: 'realtime-supervisor',
 				entry: 'services/realtime-supervisor.ts',
 				autoStart: true,
+				mode: 'persistent',
 				timeoutMs: 300000,
 			},
 		],
@@ -155,6 +158,7 @@ test('service_list returns declared package services with live status', async ()
 				name: 'realtime-supervisor',
 				entry: 'services/realtime-supervisor.ts',
 				auto_start: true,
+				mode: 'persistent',
 				status: 'stopped',
 				timeout_ms: 300000,
 			},
@@ -187,6 +191,7 @@ test('service_list marks status as unknown when a service status lookup fails', 
 				name: 'realtime-supervisor',
 				entry: 'services/realtime-supervisor.ts',
 				autoStart: false,
+				mode: 'bounded',
 				timeoutMs: null,
 			},
 		],
@@ -215,6 +220,7 @@ test('service_list marks status as unknown when a service status lookup fails', 
 				name: 'realtime-supervisor',
 				entry: 'services/realtime-supervisor.ts',
 				auto_start: false,
+				mode: 'bounded',
 				status: 'unknown',
 				timeout_ms: null,
 			},

--- a/packages/worker/src/mcp/capabilities/services/shared.ts
+++ b/packages/worker/src/mcp/capabilities/services/shared.ts
@@ -15,11 +15,19 @@ export const packageServiceRecordSchema = z.object({
 	name: z.string(),
 	entry: z.string(),
 	auto_start: z.boolean(),
+	mode: z.enum(['bounded', 'persistent']),
 	timeout_ms: z.number().int().positive().nullable(),
 })
 
 export const packageServiceSummarySchema = packageServiceRecordSchema.extend({
-	status: z.enum(['idle', 'running', 'stopping', 'stopped', 'error', 'unknown']),
+	status: z.enum([
+		'idle',
+		'running',
+		'stopping',
+		'stopped',
+		'error',
+		'unknown',
+	]),
 })
 
 function resolvePackageId(
@@ -56,7 +64,9 @@ export async function requirePackageServiceContext(input: {
 		packageId,
 	})
 	if (!savedPackage) {
-		throw new Error('Saved package was not found for package service operations.')
+		throw new Error(
+			'Saved package was not found for package service operations.',
+		)
 	}
 	const serviceName = input.serviceName?.trim() || ''
 	return {
@@ -111,6 +121,7 @@ export async function listPackageServicesForContext(input: {
 			name: service.name,
 			entry: service.entry,
 			auto_start: service.autoStart,
+			mode: service.mode ?? 'bounded',
 			timeout_ms: service.timeoutMs ?? null,
 		})),
 	}
@@ -119,4 +130,3 @@ export async function listPackageServicesForContext(input: {
 export type PackageServiceStatusRecord = z.infer<
 	typeof packageServiceStatusSchema
 >
-

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -10,6 +10,8 @@ import {
 	parseHostApprovalRequiredBatchMessage,
 	parseHostApprovalRequiredMessage,
 	parseMissingSecretMessage,
+	parsePackageAccessRequiredBatchMessage,
+	parsePackageAccessRequiredMessage,
 } from '#mcp/secrets/errors.ts'
 
 type WorkerLoopbackExports = Exclude<typeof workerExports, undefined>
@@ -90,6 +92,33 @@ export type ExecutionErrorDetails =
 			suggestedAction: {
 				type: 'edit_secret_policy'
 				policyField: 'allowed_capabilities'
+			}
+	  }
+	| {
+			kind: 'secret_package_access_required'
+			message: string
+			nextStep: string
+			secretNames: Array<string>
+			packageName: string
+			approvalUrl: string | null
+			suggestedAction: {
+				type: 'edit_secret_policy'
+				policyField: 'allowed_packages'
+			}
+	  }
+	| {
+			kind: 'secret_package_access_required_batch'
+			message: string
+			nextStep: string
+			missingApprovals: Array<{
+				secretName: string
+				packageId: string
+				kodyId: string | null
+				approvalUrl: string
+			}>
+			suggestedAction: {
+				type: 'edit_secret_policy'
+				policyField: 'allowed_packages'
 			}
 	  }
 	| {
@@ -175,6 +204,38 @@ export function getExecutionErrorDetails(
 			suggestedAction: {
 				type: 'edit_secret_policy',
 				policyField: 'allowed_capabilities',
+			},
+		}
+	}
+
+	const packageAccessBatch = parsePackageAccessRequiredBatchMessage(message)
+	if (packageAccessBatch) {
+		return {
+			kind: 'secret_package_access_required_batch',
+			message,
+			nextStep:
+				'Ask the user whether they want to approve these packages for the listed secrets in the account secrets UI, then retry after approval.',
+			missingApprovals: packageAccessBatch,
+			suggestedAction: {
+				type: 'edit_secret_policy',
+				policyField: 'allowed_packages',
+			},
+		}
+	}
+
+	const packageAccessDetails = parsePackageAccessRequiredMessage(message)
+	if (packageAccessDetails) {
+		return {
+			kind: 'secret_package_access_required',
+			message,
+			nextStep:
+				"Ask the user whether this package should be allowed to use the secret. If they approve, help them add this package to the secret's allowed packages in the account secrets UI, then retry.",
+			secretNames: [packageAccessDetails.secretName],
+			packageName: packageAccessDetails.packageName,
+			approvalUrl: extractFirstUrl(message),
+			suggestedAction: {
+				type: 'edit_secret_policy',
+				policyField: 'allowed_packages',
 			},
 		}
 	}

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -25,7 +25,7 @@ export function createExecuteExecutor(input: {
 	exports?: WorkerLoopbackExports
 	gatewayProps: FetchGatewayProps
 	modules?: WorkerLoaderModules
-	timeoutMs?: number
+	timeoutMs?: number | null
 }) {
 	const loopbackExports = input.exports ?? workerExports
 	if (!loopbackExports?.CodemodeFetchGateway) {
@@ -33,9 +33,13 @@ export function createExecuteExecutor(input: {
 			'CodemodeFetchGateway export is required for execute-time fetch.',
 		)
 	}
+	const timeout =
+		input.timeoutMs === null
+			? Number.MAX_SAFE_INTEGER
+			: (input.timeoutMs ?? 90_000)
 	return new DynamicWorkerExecutor({
 		loader: input.env.LOADER,
-		timeout: input.timeoutMs ?? 90_000,
+		timeout,
 		globalOutbound: loopbackExports.CodemodeFetchGateway({
 			props: input.gatewayProps,
 		}),

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -19,6 +19,7 @@ type WorkerLoopbackExports = Exclude<typeof workerExports, undefined>
 const charsPerToken = 4
 const maxTokens = 6_000
 const maxChars = maxTokens * charsPerToken
+const maxSupportedExecutorTimeoutMs = 2_147_483_647
 
 export function createExecuteExecutor(input: {
 	env: Env
@@ -35,7 +36,7 @@ export function createExecuteExecutor(input: {
 	}
 	const timeout =
 		input.timeoutMs === null
-			? Number.MAX_SAFE_INTEGER
+			? maxSupportedExecutorTimeoutMs
 			: (input.timeoutMs ?? 90_000)
 	return new DynamicWorkerExecutor({
 		loader: input.env.LOADER,

--- a/packages/worker/src/mcp/run-codemode-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.node.test.ts
@@ -850,6 +850,69 @@ export default async function run(): Promise<ModuleOutput> {
 	}
 })
 
+test('runCodemodeWithRegistry forwards package context for module syntax', async () => {
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+		storageContext: {
+			sessionId: null,
+			appId: 'package-123',
+			storageId: 'package-123',
+		},
+	})
+	const buildBundleMock = vi.mocked(buildKodyModuleBundle)
+	buildBundleMock.mockClear()
+	const getRegistrySpy = vi
+		.spyOn(
+			await import('#mcp/capabilities/registry.ts'),
+			'getCapabilityRegistryForContext',
+		)
+		.mockResolvedValue({
+			capabilityDomains: [],
+			capabilityDomainDescriptionsByName: {} as Record<string, string>,
+			capabilityHandlers: {},
+			capabilityList: [],
+			capabilityMap: {},
+			capabilitySpecs: {},
+			capabilityToolDescriptors: {},
+		} as Awaited<ReturnType<typeof getCapabilityRegistryForContext>>)
+	let wrapped = ''
+	const createExecuteExecutorSpy = vi
+		.spyOn(await import('#mcp/executor.ts'), 'createExecuteExecutor')
+		.mockReturnValue({
+			async execute(input) {
+				wrapped = String(input)
+				return {
+					result: 'ok',
+					logs: [],
+				}
+			},
+		} as never)
+
+	try {
+		const code = `import { packageContext } from 'kody:runtime'
+
+export default async function run() {
+	return packageContext?.packageId ?? null
+}`
+		const result = await runCodemodeWithRegistry(env, callerContext, code, undefined, {
+			packageContext: {
+				packageId: 'package-123',
+				kodyId: 'discord-gateway',
+			},
+		})
+
+		expect(result.result).toBe('ok')
+		expect(wrapped).toContain('"packageId":"package-123"')
+		expect(wrapped).toContain('"kodyId":"discord-gateway"')
+		expect(wrapped).toContain('packageSecrets')
+	} finally {
+		createExecuteExecutorSpy.mockRestore()
+		getRegistrySpy.mockRestore()
+	}
+})
+
 test('runCodemodeWithRegistry keeps legacy snippet execution for non-module code', async () => {
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({

--- a/packages/worker/src/mcp/run-codemode-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.node.test.ts
@@ -956,7 +956,10 @@ test('runBundledModuleWithRegistry injects service helpers and custom timeout', 
 				serviceTools: {
 					getStatus: async () => ({ status: 'running' }),
 					shouldStop: async () => false,
-					setAlarm: async () => ({ ok: true, scheduled_at: '2026-04-25T00:00:00.000Z' }),
+					setAlarm: async () => ({
+						ok: true,
+						scheduled_at: '2026-04-25T00:00:00.000Z',
+					}),
 					clearAlarm: async () => ({ ok: true }),
 				},
 				executorTimeoutMs: 300_000,
@@ -965,10 +968,10 @@ test('runBundledModuleWithRegistry injects service helpers and custom timeout', 
 
 		expect(result.result).toBe('ok')
 		expect(wrapped).toContain('const service = {')
-		expect(wrapped).toContain("service_get_status")
-		expect(wrapped).toContain("service_should_stop")
-		expect(wrapped).toContain("service_set_alarm")
-		expect(wrapped).toContain("service_clear_alarm")
+		expect(wrapped).toContain('service_get_status')
+		expect(wrapped).toContain('service_should_stop')
+		expect(wrapped).toContain('service_set_alarm')
+		expect(wrapped).toContain('service_clear_alarm')
 		expect(wrapped).toContain('"serviceName":"realtime-supervisor"')
 	} finally {
 		createExecuteExecutorSpy.mockRestore()

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -20,6 +20,7 @@ import {
 	createCapabilitySecretAccessDeniedBatchMessage,
 	createMissingSecretMessage,
 } from '#mcp/secrets/errors.ts'
+import { resolvePackageMountedSecret } from '#mcp/secrets/package-access.ts'
 import { buildSecretCapabilityApprovalUrl } from '#mcp/secrets/capability-approval-url.ts'
 import { resolveSecret } from '#mcp/secrets/service.ts'
 import { type ReferencedSecret } from '#mcp/secrets/placeholders.ts'
@@ -55,6 +56,11 @@ type ServiceToolOptions = {
 	clearAlarm: () => Promise<{ ok: true }>
 }
 
+type PackageSecretToolOptions = {
+	get: (alias: string) => Promise<string>
+	has: (alias: string) => Promise<boolean>
+}
+
 function createServiceHelperPrelude() {
 	return `
 const service = {
@@ -73,6 +79,29 @@ const service = {
 	`.trim()
 }
 
+function createPackageSecretsHelperPrelude() {
+	return `
+const packageSecrets = {
+  get: async (alias) => {
+    const normalizedAlias = typeof alias === 'string' ? alias.trim() : '';
+    if (!normalizedAlias) {
+      throw new Error('packageSecrets.get requires a non-empty alias.')
+    }
+    const result = await codemode.package_secret_get({ alias: normalizedAlias });
+    return typeof result?.value === 'string' ? result.value : '';
+  },
+  has: async (alias) => {
+    const normalizedAlias = typeof alias === 'string' ? alias.trim() : '';
+    if (!normalizedAlias) {
+      throw new Error('packageSecrets.has requires a non-empty alias.')
+    }
+    const result = await codemode.package_secret_has({ alias: normalizedAlias });
+    return result?.has === true;
+  },
+};
+	`.trim()
+}
+
 export async function buildCodemodeFns(
 	env: Env,
 	callerContext: McpCallerContext,
@@ -85,6 +114,7 @@ export async function buildCodemodeFns(
 		additionalTools?: AdditionalCodemodeTools
 		storageTools?: StorageToolOptions
 		serviceTools?: ServiceToolOptions
+		packageSecretTools?: PackageSecretToolOptions
 	},
 ) {
 	const { capabilityMap } = await getCapabilityRegistryForContext({
@@ -135,8 +165,7 @@ export async function buildCodemodeFns(
 	const serviceTools = options?.serviceTools
 	const serviceCodemodeTools: AdditionalCodemodeTools = serviceTools
 		? {
-				service_get_status: async () =>
-					await serviceTools.getStatus(),
+				service_get_status: async () => await serviceTools.getStatus(),
 				service_should_stop: async () => ({
 					shouldStop: await serviceTools.shouldStop(),
 				}),
@@ -153,19 +182,45 @@ export async function buildCodemodeFns(
 					}
 					const runAt = new Date(runAtString)
 					if (Number.isNaN(runAt.getTime())) {
-						throw new Error('service.setAlarm requires a valid runAt ISO string.')
+						throw new Error(
+							'service.setAlarm requires a valid runAt ISO string.',
+						)
 					}
 					return await serviceTools.setAlarm(runAt)
 				},
-				service_clear_alarm: async () =>
-					await serviceTools.clearAlarm(),
-		  }
+				service_clear_alarm: async () => await serviceTools.clearAlarm(),
+			}
 		: {}
 	assertNoCapabilityCollisions(capabilityMap, serviceCodemodeTools)
+	const packageSecretTools = options?.packageSecretTools
+	const packageSecretCodemodeTools: AdditionalCodemodeTools = packageSecretTools
+		? {
+				package_secret_get: async (args: unknown) => {
+					const alias =
+						typeof args === 'object' && args !== null && 'alias' in args
+							? String((args as { alias: unknown }).alias ?? '')
+							: ''
+					return {
+						value: await packageSecretTools.get(alias),
+					}
+				},
+				package_secret_has: async (args: unknown) => {
+					const alias =
+						typeof args === 'object' && args !== null && 'alias' in args
+							? String((args as { alias: unknown }).alias ?? '')
+							: ''
+					return {
+						has: await packageSecretTools.has(alias),
+					}
+				},
+			}
+		: {}
+	assertNoCapabilityCollisions(capabilityMap, packageSecretCodemodeTools)
 	return {
 		...capabilityCodemodeTools,
 		...storageCodemodeTools,
 		...serviceCodemodeTools,
+		...packageSecretCodemodeTools,
 		...additionalTools,
 	}
 }
@@ -189,6 +244,7 @@ export async function buildCodemodeProvider(
 		additionalTools?: AdditionalCodemodeTools
 		storageTools?: StorageToolOptions
 		serviceTools?: ServiceToolOptions
+		packageSecretTools?: PackageSecretToolOptions
 	},
 ): Promise<ResolvedProvider> {
 	const tools = await buildCodemodeFns(env, callerContext, options)
@@ -260,6 +316,10 @@ export async function runCodemodeWithRegistry(
 		helperPrelude?: string
 		storageTools?: StorageToolOptions
 		serviceTools?: ServiceToolOptions
+		packageContext?: {
+			packageId: string
+			kodyId: string
+		} | null
 		executorModules?: WorkerLoaderModules
 		executorTimeoutMs?: number
 	},
@@ -298,6 +358,32 @@ export async function runCodemodeWithRegistry(
 		additionalTools: options?.additionalTools,
 		storageTools: options?.storageTools,
 		serviceTools: options?.serviceTools,
+		packageSecretTools: options?.packageContext
+			? {
+					get: async (alias: string) =>
+						(
+							await resolvePackageMountedSecret({
+								env,
+								callerContext,
+								packageId: options.packageContext!.packageId,
+								alias,
+							})
+						).value,
+					has: async (alias: string) => {
+						try {
+							await resolvePackageMountedSecret({
+								env,
+								callerContext,
+								packageId: options.packageContext!.packageId,
+								alias,
+							})
+							return true
+						} catch {
+							return false
+						}
+					},
+				}
+			: undefined,
 	})
 	const wrappedCode =
 		params !== undefined
@@ -313,9 +399,13 @@ export async function runCodemodeWithRegistry(
 	const serviceHelperPrelude = options?.serviceTools
 		? createServiceHelperPrelude()
 		: ''
+	const packageSecretsHelperPrelude = options?.packageContext
+		? createPackageSecretsHelperPrelude()
+		: ''
 	const helperPrelude = [
 		storageHelperPrelude,
 		serviceHelperPrelude,
+		packageSecretsHelperPrelude,
 		options?.helperPrelude ?? '',
 	]
 		.filter((value) => value.trim().length > 0)
@@ -423,6 +513,32 @@ export async function runBundledModuleWithRegistry(
 		additionalTools: options?.additionalTools,
 		storageTools: options?.storageTools,
 		serviceTools: options?.serviceTools,
+		packageSecretTools: options?.packageContext
+			? {
+					get: async (alias: string) =>
+						(
+							await resolvePackageMountedSecret({
+								env,
+								callerContext,
+								packageId: options.packageContext!.packageId,
+								alias,
+							})
+						).value,
+					has: async (alias: string) => {
+						try {
+							await resolvePackageMountedSecret({
+								env,
+								callerContext,
+								packageId: options.packageContext!.packageId,
+								alias,
+							})
+							return true
+						} catch {
+							return false
+						}
+					},
+				}
+			: undefined,
 	})
 	const storageHelperPrelude = options?.storageTools
 		? createStorageHelperPrelude({
@@ -433,10 +549,14 @@ export async function runBundledModuleWithRegistry(
 	const serviceHelperPrelude = options?.serviceTools
 		? createServiceHelperPrelude()
 		: ''
+	const packageSecretsHelperPrelude = options?.packageContext
+		? createPackageSecretsHelperPrelude()
+		: ''
 	const wrapped = `async () => {
 ${createExecuteHelperPrelude()}
 ${storageHelperPrelude ? `${storageHelperPrelude}\n` : ''}
 ${serviceHelperPrelude ? `${serviceHelperPrelude}\n` : ''}
+${packageSecretsHelperPrelude ? `${packageSecretsHelperPrelude}\n` : ''}
   const __previousRuntime = globalThis.__kodyRuntime;
   globalThis.__kodyRuntime = {
     codemode,
@@ -448,6 +568,7 @@ ${serviceHelperPrelude ? `${serviceHelperPrelude}\n` : ''}
     packageContext: ${JSON.stringify(options?.packageContext ?? null)},
     serviceContext: ${JSON.stringify(options?.serviceContext ?? null)},
     service: typeof service === 'undefined' ? null : service,
+    packageSecrets: typeof packageSecrets === 'undefined' ? null : packageSecrets,
   };
   try {
     const __kodyModule = await import(${JSON.stringify(`./${bundle.mainModule}`)});

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -61,6 +61,48 @@ type PackageSecretToolOptions = {
 	has: (alias: string) => Promise<boolean>
 }
 
+function isPackageSecretAvailabilityError(error: unknown) {
+	return (
+		error instanceof Error &&
+		(error.message.startsWith('Secret "') ||
+			error.message.startsWith('Package "'))
+	)
+}
+
+function createPackageSecretTools(input: {
+	env: Env
+	callerContext: McpCallerContext
+	packageId: string
+}): PackageSecretToolOptions {
+	return {
+		get: async (alias: string) =>
+			(
+				await resolvePackageMountedSecret({
+					env: input.env,
+					callerContext: input.callerContext,
+					packageId: input.packageId,
+					alias,
+				})
+			).value,
+		has: async (alias: string) => {
+			try {
+				await resolvePackageMountedSecret({
+					env: input.env,
+					callerContext: input.callerContext,
+					packageId: input.packageId,
+					alias,
+				})
+				return true
+			} catch (error) {
+				if (isPackageSecretAvailabilityError(error)) {
+					return false
+				}
+				throw error
+			}
+		},
+	}
+}
+
 function createServiceHelperPrelude() {
 	return `
 const service = {
@@ -359,30 +401,11 @@ export async function runCodemodeWithRegistry(
 		storageTools: options?.storageTools,
 		serviceTools: options?.serviceTools,
 		packageSecretTools: options?.packageContext
-			? {
-					get: async (alias: string) =>
-						(
-							await resolvePackageMountedSecret({
-								env,
-								callerContext,
-								packageId: options.packageContext!.packageId,
-								alias,
-							})
-						).value,
-					has: async (alias: string) => {
-						try {
-							await resolvePackageMountedSecret({
-								env,
-								callerContext,
-								packageId: options.packageContext!.packageId,
-								alias,
-							})
-							return true
-						} catch {
-							return false
-						}
-					},
-				}
+			? createPackageSecretTools({
+					env,
+					callerContext,
+					packageId: options.packageContext.packageId,
+				})
 			: undefined,
 	})
 	const wrappedCode =
@@ -514,30 +537,11 @@ export async function runBundledModuleWithRegistry(
 		storageTools: options?.storageTools,
 		serviceTools: options?.serviceTools,
 		packageSecretTools: options?.packageContext
-			? {
-					get: async (alias: string) =>
-						(
-							await resolvePackageMountedSecret({
-								env,
-								callerContext,
-								packageId: options.packageContext!.packageId,
-								alias,
-							})
-						).value,
-					has: async (alias: string) => {
-						try {
-							await resolvePackageMountedSecret({
-								env,
-								callerContext,
-								packageId: options.packageContext!.packageId,
-								alias,
-							})
-							return true
-						} catch {
-							return false
-						}
-					},
-				}
+			? createPackageSecretTools({
+					env,
+					callerContext,
+					packageId: options.packageContext.packageId,
+				})
 			: undefined,
 	})
 	const storageHelperPrelude = options?.storageTools

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -373,6 +373,7 @@ export async function runCodemodeWithRegistry(
 			additionalTools: options?.additionalTools,
 			storageTools: options?.storageTools,
 			serviceTools: options?.serviceTools,
+			packageContext: options?.packageContext,
 			executorTimeoutMs: options?.executorTimeoutMs,
 		})
 	}
@@ -464,6 +465,10 @@ export async function runModuleWithRegistry(
 		additionalTools?: AdditionalCodemodeTools
 		storageTools?: StorageToolOptions
 		serviceTools?: ServiceToolOptions
+		packageContext?: {
+			packageId: string
+			kodyId: string
+		} | null
 		executorTimeoutMs?: number | null
 	},
 ): Promise<ExecuteResult> {
@@ -486,7 +491,10 @@ export async function runModuleWithRegistry(
 			modules: bundled.modules,
 		},
 		params,
-		options,
+		{
+			...options,
+			packageContext: options?.packageContext ?? null,
+		},
 	)
 }
 

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -321,7 +321,7 @@ export async function runCodemodeWithRegistry(
 			kodyId: string
 		} | null
 		executorModules?: WorkerLoaderModules
-		executorTimeoutMs?: number
+		executorTimeoutMs?: number | null
 	},
 ): Promise<ExecuteResult> {
 	const moduleSource = stripCodeFences(code.trim())
@@ -441,7 +441,7 @@ export async function runModuleWithRegistry(
 		additionalTools?: AdditionalCodemodeTools
 		storageTools?: StorageToolOptions
 		serviceTools?: ServiceToolOptions
-		executorTimeoutMs?: number
+		executorTimeoutMs?: number | null
 	},
 ): Promise<ExecuteResult> {
 	const userId = callerContext.user?.userId ?? ''
@@ -487,7 +487,7 @@ export async function runBundledModuleWithRegistry(
 			serviceName: string
 		} | null
 		serviceTools?: ServiceToolOptions
-		executorTimeoutMs?: number
+		executorTimeoutMs?: number | null
 	},
 ): Promise<ExecuteResult> {
 	const { createExecuteExecutor } = await import('#mcp/executor.ts')

--- a/packages/worker/src/mcp/secrets/allowed-packages.ts
+++ b/packages/worker/src/mcp/secrets/allowed-packages.ts
@@ -1,0 +1,24 @@
+export function normalizeAllowedPackages(input: Array<string>) {
+	return Array.from(
+		new Set(
+			input.map((value) => value.trim()).filter((value) => value.length > 0),
+		),
+	).sort((left, right) => left.localeCompare(right))
+}
+
+export function parseAllowedPackages(value: string | null | undefined) {
+	if (!value) return []
+	try {
+		const parsed = JSON.parse(value)
+		if (!Array.isArray(parsed)) return []
+		return normalizeAllowedPackages(
+			parsed.filter((entry): entry is string => typeof entry === 'string'),
+		)
+	} catch {
+		return []
+	}
+}
+
+export function stringifyAllowedPackages(input: Array<string>) {
+	return JSON.stringify(normalizeAllowedPackages(input))
+}

--- a/packages/worker/src/mcp/secrets/errors.ts
+++ b/packages/worker/src/mcp/secrets/errors.ts
@@ -2,8 +2,11 @@ const hostApprovalRequiredRegex =
 	/^Secret "([^"]+)" is not allowed for host "([^"]+)"/
 const capabilityAccessRequiredRegex =
 	/^Secret "([^"]+)" is not allowed for capability "([^"]+)"/
+const packageAccessRequiredRegex =
+	/^Secret "([^"]+)" is not allowed for package "([^"]+)"/
 const capabilityBatchDeniedPrefix = 'Secrets require capability approval:'
 const hostBatchDeniedPrefix = 'Secrets require host approval:'
+const packageBatchDeniedPrefix = 'Secrets require package approval:'
 const missingSecretRegex = /^Secret "([^"]+)" was not found\.$/
 
 export const fetchSecretAuthRequiredMessage =
@@ -42,6 +45,14 @@ export type HostApprovalEntry = {
 	approvalUrl: string
 }
 
+export type PackageApprovalEntry = {
+	secretName: string
+	packageId: string
+	kodyId: string | null
+	packageName: string | null
+	approvalUrl: string
+}
+
 export function createCapabilitySecretAccessDeniedBatchMessage(
 	entries: Array<CapabilityApprovalEntry>,
 ) {
@@ -54,6 +65,24 @@ export function createHostSecretAccessDeniedBatchMessage(
 ) {
 	const payload = JSON.stringify(entries)
 	return `${hostBatchDeniedPrefix} ${payload}`
+}
+
+export function createPackageSecretAccessDeniedMessage(input: {
+	secretName: string
+	packageName: string
+	approvalUrl?: string | null
+}) {
+	const approvalSuffix = input.approvalUrl
+		? ` Approval link: ${input.approvalUrl}`
+		: ''
+	return `Secret "${input.secretName}" is not allowed for package "${input.packageName}". If this package should be able to use the secret, ask the user whether to approve that package in the account secrets UI, then retry after they approve that policy change.${approvalSuffix}`
+}
+
+export function createPackageSecretAccessDeniedBatchMessage(
+	entries: Array<PackageApprovalEntry>,
+) {
+	const payload = JSON.stringify(entries)
+	return `${packageBatchDeniedPrefix} ${payload}`
 }
 
 export function parseCapabilityAccessRequiredBatchMessage(message: string) {
@@ -114,6 +143,38 @@ export function parseHostApprovalRequiredBatchMessage(message: string) {
 	}
 }
 
+export function parsePackageAccessRequiredBatchMessage(message: string) {
+	if (!message.startsWith(packageBatchDeniedPrefix)) return null
+	const raw = message.slice(packageBatchDeniedPrefix.length).trim()
+	if (!raw) return null
+	try {
+		const parsed = JSON.parse(raw)
+		if (!Array.isArray(parsed)) return null
+		const entries: Array<PackageApprovalEntry> = []
+		for (const entry of parsed) {
+			if (!entry || typeof entry !== 'object') continue
+			if (
+				typeof entry.secretName !== 'string' ||
+				typeof entry.packageId !== 'string' ||
+				typeof entry.approvalUrl !== 'string'
+			) {
+				continue
+			}
+			entries.push({
+				secretName: entry.secretName,
+				packageId: entry.packageId,
+				kodyId: typeof entry.kodyId === 'string' ? entry.kodyId : null,
+				packageName:
+					typeof entry.packageName === 'string' ? entry.packageName : null,
+				approvalUrl: entry.approvalUrl,
+			})
+		}
+		return entries.length > 0 ? entries : null
+	} catch {
+		return null
+	}
+}
+
 export function parseMissingSecretMessage(message: string) {
 	const match = message.match(missingSecretRegex)
 	if (!match?.[1]) return null
@@ -137,6 +198,15 @@ export function parseCapabilityAccessRequiredMessage(message: string) {
 	return {
 		secretName: match[1],
 		capabilityName: match[2],
+	}
+}
+
+export function parsePackageAccessRequiredMessage(message: string) {
+	const match = message.match(packageAccessRequiredRegex)
+	if (!match?.[1] || !match?.[2]) return null
+	return {
+		secretName: match[1],
+		packageName: match[2],
 	}
 }
 

--- a/packages/worker/src/mcp/secrets/host-approval.node.test.ts
+++ b/packages/worker/src/mcp/secrets/host-approval.node.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'vitest'
+import {
+	createSecretHostApprovalToken,
+	verifySecretHostApprovalToken,
+} from './host-approval.ts'
+import { encryptStringWithPurpose } from './crypto.ts'
+
+const env = {
+	COOKIE_SECRET: 'test-cookie-secret',
+} as Pick<Env, 'COOKIE_SECRET'>
+
+test('verifySecretHostApprovalToken accepts legacy tokens without kind', async () => {
+	const now = Date.now()
+	const token = await encryptStringWithPurpose(
+		env,
+		'secret-host-approval',
+		JSON.stringify({
+			userId: 'user-1',
+			name: 'cloudflareToken',
+			scope: 'user',
+			requestedHost: 'API.Cloudflare.com',
+			storageContext: null,
+			iat: now,
+			exp: now + 60_000,
+		}),
+	)
+
+	await expect(verifySecretHostApprovalToken(env, token)).resolves.toEqual({
+		kind: 'host',
+		userId: 'user-1',
+		name: 'cloudflareToken',
+		scope: 'user',
+		requestedHost: 'api.cloudflare.com',
+		storageContext: null,
+		iat: now,
+		exp: now + 60_000,
+	})
+})
+
+test('verifySecretHostApprovalToken still accepts new tokens with kind', async () => {
+	const token = await createSecretHostApprovalToken(env, {
+		userId: 'user-1',
+		name: 'cloudflareToken',
+		scope: 'user',
+		requestedHost: 'api.cloudflare.com',
+		storageContext: null,
+	})
+
+	await expect(verifySecretHostApprovalToken(env, token)).resolves.toMatchObject({
+		kind: 'host',
+		userId: 'user-1',
+		name: 'cloudflareToken',
+		scope: 'user',
+		requestedHost: 'api.cloudflare.com',
+		storageContext: null,
+	})
+})

--- a/packages/worker/src/mcp/secrets/host-approval.node.test.ts
+++ b/packages/worker/src/mcp/secrets/host-approval.node.test.ts
@@ -55,3 +55,47 @@ test('verifySecretHostApprovalToken still accepts new tokens with kind', async (
 		storageContext: null,
 	})
 })
+
+test('verifySecretHostApprovalToken rejects tokens with explicit non-host kind', async () => {
+	const now = Date.now()
+	const token = await encryptStringWithPurpose(
+		env,
+		'secret-host-approval',
+		JSON.stringify({
+			kind: 'package',
+			userId: 'user-1',
+			name: 'cloudflareToken',
+			scope: 'user',
+			requestedHost: 'api.cloudflare.com',
+			storageContext: null,
+			iat: now,
+			exp: now + 60_000,
+		}),
+	)
+
+	await expect(verifySecretHostApprovalToken(env, token)).rejects.toThrow(
+		'Invalid secret host approval request.',
+	)
+})
+
+test('verifySecretHostApprovalToken rejects tokens with explicit non-host kind', async () => {
+	const now = Date.now()
+	const token = await encryptStringWithPurpose(
+		env,
+		'secret-host-approval',
+		JSON.stringify({
+			kind: 'package',
+			userId: 'user-1',
+			name: 'cloudflareToken',
+			scope: 'user',
+			requestedHost: 'api.cloudflare.com',
+			storageContext: null,
+			iat: now,
+			exp: now + 60_000,
+		}),
+	)
+
+	await expect(verifySecretHostApprovalToken(env, token)).rejects.toThrow(
+		'Invalid secret host approval request.',
+	)
+})

--- a/packages/worker/src/mcp/secrets/host-approval.ts
+++ b/packages/worker/src/mcp/secrets/host-approval.ts
@@ -8,6 +8,7 @@ const secretHostApprovalPurpose = 'secret-host-approval'
 const defaultSecretHostApprovalTtlMs = 1000 * 60 * 60 * 24
 
 export type SecretHostApprovalRequest = {
+	kind: 'host'
 	userId: string
 	name: string
 	scope: SecretScope
@@ -34,6 +35,7 @@ export async function createSecretHostApprovalToken(
 		env,
 		secretHostApprovalPurpose,
 		JSON.stringify({
+			kind: 'host',
 			userId: input.userId,
 			name: input.name.trim(),
 			scope: input.scope,
@@ -56,6 +58,7 @@ export async function verifySecretHostApprovalToken(
 	)
 	const parsed = JSON.parse(raw) as Partial<SecretHostApprovalRequest>
 	if (
+		parsed.kind !== 'host' ||
 		typeof parsed.userId !== 'string' ||
 		typeof parsed.name !== 'string' ||
 		typeof parsed.scope !== 'string' ||
@@ -67,6 +70,7 @@ export async function verifySecretHostApprovalToken(
 		throw new Error('Secret host approval request has expired.')
 	}
 	return {
+		kind: 'host',
 		userId: parsed.userId,
 		name: parsed.name.trim(),
 		scope: parsed.scope as SecretScope,

--- a/packages/worker/src/mcp/secrets/host-approval.ts
+++ b/packages/worker/src/mcp/secrets/host-approval.ts
@@ -6,6 +6,7 @@ import { type SecretScope } from './types.ts'
 
 const secretHostApprovalPurpose = 'secret-host-approval'
 const defaultSecretHostApprovalTtlMs = 1000 * 60 * 60 * 24
+export const secretHostApprovalTokenPrefix = 'host:'
 
 export type SecretHostApprovalRequest = {
 	kind: 'host'
@@ -31,7 +32,7 @@ export async function createSecretHostApprovalToken(
 ) {
 	const now = Date.now()
 	const ttlMs = input.ttlMs ?? defaultSecretHostApprovalTtlMs
-	return encryptStringWithPurpose(
+	const token = await encryptStringWithPurpose(
 		env,
 		secretHostApprovalPurpose,
 		JSON.stringify({
@@ -45,16 +46,23 @@ export async function createSecretHostApprovalToken(
 			exp: now + ttlMs,
 		} satisfies SecretHostApprovalRequest),
 	)
+	return `${secretHostApprovalTokenPrefix}${token}`
 }
 
 export async function verifySecretHostApprovalToken(
 	env: Pick<Env, 'COOKIE_SECRET'>,
 	token: string,
 ) {
+	if (token.startsWith('pkg:')) {
+		throw new Error('Invalid secret host approval request.')
+	}
+	const encodedToken = token.startsWith(secretHostApprovalTokenPrefix)
+		? token.slice(secretHostApprovalTokenPrefix.length)
+		: token
 	const raw = await decryptStringWithPurpose(
 		env,
 		secretHostApprovalPurpose,
-		token,
+		encodedToken,
 	)
 	const parsed = JSON.parse(raw) as Partial<SecretHostApprovalRequest>
 	if (

--- a/packages/worker/src/mcp/secrets/host-approval.ts
+++ b/packages/worker/src/mcp/secrets/host-approval.ts
@@ -58,7 +58,7 @@ export async function verifySecretHostApprovalToken(
 	)
 	const parsed = JSON.parse(raw) as Partial<SecretHostApprovalRequest>
 	if (
-		parsed.kind !== 'host' ||
+		(parsed.kind != null && parsed.kind !== 'host') ||
 		typeof parsed.userId !== 'string' ||
 		typeof parsed.name !== 'string' ||
 		typeof parsed.scope !== 'string' ||

--- a/packages/worker/src/mcp/secrets/package-access.node.test.ts
+++ b/packages/worker/src/mcp/secrets/package-access.node.test.ts
@@ -23,6 +23,7 @@ vi.mock('./service.ts', () => ({
 const {
 	buildPackageApprovalErrorForMounts,
 	isPackageSecretAccessUnavailableError,
+	PackageSecretMountError,
 	resolvePackageMountedSecret,
 } = await import('./package-access.ts')
 
@@ -163,7 +164,49 @@ test('package access helpers treat missing approvals consistently', () => {
 	).toContain('Secret "discordBotTokenKentPersonalAutomation" is not allowed')
 	expect(
 		isPackageSecretAccessUnavailableError(
-			new Error('Secret "discordBotTokenKentPersonalAutomation" was not found.'),
+			new PackageSecretMountError('Package "discord-gateway" does not declare secret mount "discordBotToken".'),
 		),
 	).toBe(true)
+})
+
+test('findMissingPackageApprovals reads saved package metadata without loading manifest', async () => {
+	mockModule.getSavedPackageById.mockResolvedValueOnce({
+		id: 'pkg-1',
+		kodyId: 'discord-gateway',
+		name: '@kentcdodds/discord-gateway',
+		sourceId: 'source-1',
+	})
+	mockModule.resolveSecret.mockResolvedValueOnce({
+		found: true,
+		value: 'bot-token',
+		scope: 'user',
+		allowedPackages: [],
+	})
+
+	const { findMissingPackageApprovals } = await import('./package-access.ts')
+	const entries = await findMissingPackageApprovals({
+		env: { APP_DB: {} as D1Database } as Env,
+		baseUrl: 'https://example.com',
+		userId: 'user-1',
+		packageId: 'pkg-1',
+		mounts: {
+			discordBotToken: {
+				name: 'discordBotTokenKentPersonalAutomation',
+				scope: 'user',
+			},
+		},
+		storageContext: {
+			sessionId: null,
+			appId: 'pkg-1',
+			storageId: 'pkg-1',
+		},
+	})
+
+	expect(entries).toHaveLength(1)
+	expect(entries[0]).toMatchObject({
+		secretName: 'discordBotTokenKentPersonalAutomation',
+		packageId: 'pkg-1',
+		kodyId: 'discord-gateway',
+	})
+	expect(mockModule.loadPackageManifestBySourceId).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/mcp/secrets/package-access.node.test.ts
+++ b/packages/worker/src/mcp/secrets/package-access.node.test.ts
@@ -1,0 +1,144 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getSavedPackageById: vi.fn(),
+	loadPackageManifestBySourceId: vi.fn(),
+	resolveSecret: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageManifestBySourceId: (...args: Array<unknown>) =>
+		mockModule.loadPackageManifestBySourceId(...args),
+}))
+
+vi.mock('./service.ts', () => ({
+	resolveSecret: (...args: Array<unknown>) => mockModule.resolveSecret(...args),
+}))
+
+const { resolvePackageMountedSecret } = await import('./package-access.ts')
+
+test('resolvePackageMountedSecret rejects calls without package appId context', async () => {
+	await expect(
+		resolvePackageMountedSecret({
+			env: {} as Env,
+			packageId: 'pkg-1',
+			alias: 'discordBotToken',
+			callerContext: {
+				baseUrl: 'https://example.com',
+				user: { userId: 'user-1', email: 'user@example.com', displayName: 'User' },
+				homeConnectorId: null,
+				remoteConnectors: null,
+				repoContext: null,
+				storageContext: {
+					sessionId: null,
+					appId: null,
+					storageId: 'pkg-1',
+				},
+			},
+		}),
+	).rejects.toThrow(
+		'Package secret access is only available inside server-side package runtime contexts.',
+	)
+})
+
+test('resolvePackageMountedSecret rejects mismatched package appId context', async () => {
+	await expect(
+		resolvePackageMountedSecret({
+			env: {} as Env,
+			packageId: 'pkg-1',
+			alias: 'discordBotToken',
+			callerContext: {
+				baseUrl: 'https://example.com',
+				user: { userId: 'user-1', email: 'user@example.com', displayName: 'User' },
+				homeConnectorId: null,
+				remoteConnectors: null,
+				repoContext: null,
+				storageContext: {
+					sessionId: null,
+					appId: 'pkg-2',
+					storageId: 'pkg-1',
+				},
+			},
+		}),
+	).rejects.toThrow(
+		'Package secret access is only available inside server-side package runtime contexts.',
+	)
+})
+
+test('resolvePackageMountedSecret resolves mounted secret when package appId matches', async () => {
+	mockModule.getSavedPackageById.mockResolvedValueOnce({
+		id: 'pkg-1',
+		kodyId: 'discord-gateway',
+		name: '@kentcdodds/discord-gateway',
+		sourceId: 'source-1',
+	})
+	mockModule.loadPackageManifestBySourceId.mockResolvedValueOnce({
+		manifest: {
+			name: '@kentcdodds/discord-gateway',
+			exports: {
+				'.': './src/index.ts',
+			},
+			kody: {
+				id: 'discord-gateway',
+				description: 'Discord gateway',
+				secretMounts: {
+					discordBotToken: {
+						name: 'discordBotTokenKentPersonalAutomation',
+						scope: 'user',
+					},
+				},
+			},
+		},
+	})
+	mockModule.resolveSecret.mockResolvedValueOnce({
+		found: true,
+		value: 'bot-token',
+		scope: 'user',
+		allowedPackages: ['pkg-1'],
+	})
+
+	await expect(
+		resolvePackageMountedSecret({
+			env: { APP_DB: {} as D1Database } as Env,
+			packageId: 'pkg-1',
+			alias: 'discordBotToken',
+			callerContext: {
+				baseUrl: 'https://example.com',
+				user: { userId: 'user-1', email: 'user@example.com', displayName: 'User' },
+				homeConnectorId: null,
+				remoteConnectors: null,
+				repoContext: null,
+				storageContext: {
+					sessionId: null,
+					appId: 'pkg-1',
+					storageId: 'pkg-1',
+				},
+			},
+		}),
+	).resolves.toMatchObject({
+		alias: 'discordBotToken',
+		name: 'discordBotTokenKentPersonalAutomation',
+		value: 'bot-token',
+		scope: 'user',
+		packageId: 'pkg-1',
+		kodyId: 'discord-gateway',
+	})
+
+	expect(mockModule.resolveSecret).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-1',
+			name: 'discordBotTokenKentPersonalAutomation',
+			scope: 'user',
+			storageContext: {
+				sessionId: null,
+				appId: 'pkg-1',
+				storageId: 'pkg-1',
+			},
+		}),
+	)
+})

--- a/packages/worker/src/mcp/secrets/package-access.node.test.ts
+++ b/packages/worker/src/mcp/secrets/package-access.node.test.ts
@@ -20,7 +20,11 @@ vi.mock('./service.ts', () => ({
 	resolveSecret: (...args: Array<unknown>) => mockModule.resolveSecret(...args),
 }))
 
-const { resolvePackageMountedSecret } = await import('./package-access.ts')
+const {
+	buildPackageApprovalErrorForMounts,
+	isPackageSecretAccessUnavailableError,
+	resolvePackageMountedSecret,
+} = await import('./package-access.ts')
 
 test('resolvePackageMountedSecret rejects calls without package appId context', async () => {
 	await expect(
@@ -141,4 +145,25 @@ test('resolvePackageMountedSecret resolves mounted secret when package appId mat
 			},
 		}),
 	)
+})
+
+test('package access helpers treat missing approvals consistently', () => {
+	expect(buildPackageApprovalErrorForMounts({ entries: [] })).toBeNull()
+	expect(
+		buildPackageApprovalErrorForMounts({
+			entries: [
+				{
+					secretName: 'discordBotTokenKentPersonalAutomation',
+					packageId: 'pkg-1',
+					kodyId: 'discord-gateway',
+					approvalUrl: 'https://example.com/account/secrets/user/discordBotToken',
+				},
+			],
+		}),
+	).toContain('Secret "discordBotTokenKentPersonalAutomation" is not allowed')
+	expect(
+		isPackageSecretAccessUnavailableError(
+			new Error('Secret "discordBotTokenKentPersonalAutomation" was not found.'),
+		),
+	).toBe(true)
 })

--- a/packages/worker/src/mcp/secrets/package-access.ts
+++ b/packages/worker/src/mcp/secrets/package-access.ts
@@ -4,8 +4,6 @@ import {
 	createMissingSecretMessage,
 	createPackageSecretAccessDeniedBatchMessage,
 	createPackageSecretAccessDeniedMessage,
-	parseMissingSecretMessage,
-	parsePackageAccessRequiredMessage,
 } from './errors.ts'
 import { resolveSecret } from './service.ts'
 import { type SecretScope } from './types.ts'
@@ -21,13 +19,14 @@ type SecretMountDefinition = {
 }
 
 export class PackageSecretMountError extends Error {}
+export class PackageSecretMissingError extends Error {}
+export class PackageSecretAccessDeniedError extends Error {}
 
 export function isPackageSecretAccessUnavailableError(error: unknown) {
-	if (error instanceof PackageSecretMountError) return true
-	if (!(error instanceof Error)) return false
 	return (
-		parseMissingSecretMessage(error.message) != null ||
-		parsePackageAccessRequiredMessage(error.message) != null
+		error instanceof PackageSecretMountError ||
+		error instanceof PackageSecretMissingError ||
+		error instanceof PackageSecretAccessDeniedError
 	)
 }
 
@@ -113,7 +112,7 @@ export async function resolvePackageMountedSecret(input: {
 		},
 	})
 	if (!resolved.found || typeof resolved.value !== 'string') {
-		throw new Error(createMissingSecretMessage(mount.name))
+		throw new PackageSecretMissingError(createMissingSecretMessage(mount.name))
 	}
 	if (!resolved.allowedPackages.includes(packageInfo.savedPackage.id)) {
 		const approvalUrl = buildSecretPackageApprovalUrl({
@@ -128,7 +127,7 @@ export async function resolvePackageMountedSecret(input: {
 				storageId: input.callerContext.storageContext?.storageId ?? null,
 			},
 		})
-		throw new Error(
+		throw new PackageSecretAccessDeniedError(
 			createPackageSecretAccessDeniedMessage({
 				secretName: mount.name,
 				packageName: packageInfo.savedPackage.kodyId,
@@ -154,12 +153,13 @@ export async function findMissingPackageApprovals(input: {
 	mounts: Record<string, SecretMountDefinition>
 	storageContext: McpCallerContext['storageContext']
 }) {
-	const packageInfo = await loadPackageSecretMounts({
-		env: input.env,
-		baseUrl: input.baseUrl,
+	const savedPackage = await getSavedPackageById(input.env.APP_DB, {
 		userId: input.userId,
 		packageId: input.packageId,
 	})
+	if (!savedPackage) {
+		throw new Error(`Saved package "${input.packageId}" was not found.`)
+	}
 	const storageContext = {
 		sessionId: input.storageContext?.sessionId ?? null,
 		appId: input.storageContext?.appId ?? null,
@@ -175,19 +175,19 @@ export async function findMissingPackageApprovals(input: {
 				storageContext,
 			})
 			if (!resolved.found) return null
-			if (resolved.allowedPackages.includes(packageInfo.savedPackage.id)) {
+			if (resolved.allowedPackages.includes(savedPackage.id)) {
 				return null
 			}
 			return {
 				secretName: mount.name,
-				packageId: packageInfo.savedPackage.id,
-				kodyId: packageInfo.savedPackage.kodyId,
+				packageId: savedPackage.id,
+				kodyId: savedPackage.kodyId,
 				approvalUrl: buildSecretPackageApprovalUrl({
 					baseUrl: input.baseUrl,
 					name: mount.name,
 					scope: resolved.scope ?? mount.scope ?? 'user',
-					packageId: packageInfo.savedPackage.id,
-					kodyId: packageInfo.savedPackage.kodyId,
+					packageId: savedPackage.id,
+					kodyId: savedPackage.kodyId,
 					storageContext,
 				}),
 			}

--- a/packages/worker/src/mcp/secrets/package-access.ts
+++ b/packages/worker/src/mcp/secrets/package-access.ts
@@ -20,12 +20,14 @@ type SecretMountDefinition = {
 	scope?: SecretScope
 }
 
+export class PackageSecretMountError extends Error {}
+
 export function isPackageSecretAccessUnavailableError(error: unknown) {
+	if (error instanceof PackageSecretMountError) return true
 	if (!(error instanceof Error)) return false
 	return (
 		parseMissingSecretMessage(error.message) != null ||
-		parsePackageAccessRequiredMessage(error.message) != null ||
-		error.message.includes('does not declare secret mount')
+		parsePackageAccessRequiredMessage(error.message) != null
 	)
 }
 
@@ -95,7 +97,7 @@ export async function resolvePackageMountedSecret(input: {
 	})
 	const mount = packageInfo.mounts[input.alias]
 	if (!mount) {
-		throw new Error(
+		throw new PackageSecretMountError(
 			`Package "${packageInfo.savedPackage.kodyId}" does not declare secret mount "${input.alias}".`,
 		)
 	}

--- a/packages/worker/src/mcp/secrets/package-access.ts
+++ b/packages/worker/src/mcp/secrets/package-access.ts
@@ -4,6 +4,8 @@ import {
 	createMissingSecretMessage,
 	createPackageSecretAccessDeniedBatchMessage,
 	createPackageSecretAccessDeniedMessage,
+	parseMissingSecretMessage,
+	parsePackageAccessRequiredMessage,
 } from './errors.ts'
 import { resolveSecret } from './service.ts'
 import { type SecretScope } from './types.ts'
@@ -16,6 +18,15 @@ import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 type SecretMountDefinition = {
 	name: string
 	scope?: SecretScope
+}
+
+export function isPackageSecretAccessUnavailableError(error: unknown) {
+	if (!(error instanceof Error)) return false
+	return (
+		parseMissingSecretMessage(error.message) != null ||
+		parsePackageAccessRequiredMessage(error.message) != null ||
+		error.message.includes('does not declare secret mount')
+	)
 }
 
 export async function loadPackageSecretMounts(input: {
@@ -147,52 +158,52 @@ export async function findMissingPackageApprovals(input: {
 		userId: input.userId,
 		packageId: input.packageId,
 	})
-	const missing = []
-	for (const mount of Object.values(input.mounts)) {
-		const resolved = await resolveSecret({
-			env: input.env,
-			userId: input.userId,
-			name: mount.name,
-			scope: mount.scope,
-			storageContext: {
-				sessionId: input.storageContext?.sessionId ?? null,
-				appId: input.storageContext?.appId ?? null,
-				storageId: input.storageContext?.storageId ?? null,
-			},
-		})
-		if (!resolved.found) continue
-		if (resolved.allowedPackages.includes(packageInfo.savedPackage.id)) continue
-		missing.push({
-			secretName: mount.name,
-			packageId: packageInfo.savedPackage.id,
-			kodyId: packageInfo.savedPackage.kodyId,
-			approvalUrl: buildSecretPackageApprovalUrl({
-				baseUrl: input.baseUrl,
+	const storageContext = {
+		sessionId: input.storageContext?.sessionId ?? null,
+		appId: input.storageContext?.appId ?? null,
+		storageId: input.storageContext?.storageId ?? null,
+	}
+	const entries = await Promise.all(
+		Object.values(input.mounts).map(async (mount) => {
+			const resolved = await resolveSecret({
+				env: input.env,
+				userId: input.userId,
 				name: mount.name,
-				scope: resolved.scope ?? mount.scope ?? 'user',
+				scope: mount.scope,
+				storageContext,
+			})
+			if (!resolved.found) return null
+			if (resolved.allowedPackages.includes(packageInfo.savedPackage.id)) {
+				return null
+			}
+			return {
+				secretName: mount.name,
 				packageId: packageInfo.savedPackage.id,
 				kodyId: packageInfo.savedPackage.kodyId,
-				storageContext: {
-					sessionId: input.storageContext?.sessionId ?? null,
-					appId: input.storageContext?.appId ?? null,
-					storageId: input.storageContext?.storageId ?? null,
-				},
-			}),
-		})
-	}
-	return missing
+				approvalUrl: buildSecretPackageApprovalUrl({
+					baseUrl: input.baseUrl,
+					name: mount.name,
+					scope: resolved.scope ?? mount.scope ?? 'user',
+					packageId: packageInfo.savedPackage.id,
+					kodyId: packageInfo.savedPackage.kodyId,
+					storageContext,
+				}),
+			}
+		}),
+	)
+	return entries.filter((entry) => entry != null)
 }
 
 export function buildPackageApprovalErrorForMounts(input: {
-	secretNames: Array<{
+	entries: Array<{
 		name: string
 		packageId: string
 		kodyId: string
 		approvalUrl: string
 	}>
 }) {
-	if (input.secretNames.length === 1) {
-		const only = input.secretNames[0]
+	if (input.entries.length === 1) {
+		const only = input.entries[0]
 		if (!only) return null
 		return createPackageSecretAccessDeniedMessage({
 			secretName: only.name,
@@ -201,7 +212,7 @@ export function buildPackageApprovalErrorForMounts(input: {
 		})
 	}
 	return createPackageSecretAccessDeniedBatchMessage(
-		input.secretNames.map((entry) => ({
+		input.entries.map((entry) => ({
 			secretName: entry.name,
 			packageId: entry.packageId,
 			kodyId: entry.kodyId,

--- a/packages/worker/src/mcp/secrets/package-access.ts
+++ b/packages/worker/src/mcp/secrets/package-access.ts
@@ -196,24 +196,27 @@ export async function findMissingPackageApprovals(input: {
 
 export function buildPackageApprovalErrorForMounts(input: {
 	entries: Array<{
-		name: string
+		secretName: string
 		packageId: string
 		kodyId: string
 		approvalUrl: string
 	}>
 }) {
+	if (input.entries.length === 0) {
+		return null
+	}
 	if (input.entries.length === 1) {
 		const only = input.entries[0]
 		if (!only) return null
 		return createPackageSecretAccessDeniedMessage({
-			secretName: only.name,
+			secretName: only.secretName,
 			packageName: only.kodyId,
 			approvalUrl: only.approvalUrl,
 		})
 	}
 	return createPackageSecretAccessDeniedBatchMessage(
 		input.entries.map((entry) => ({
-			secretName: entry.name,
+			secretName: entry.secretName,
 			packageId: entry.packageId,
 			kodyId: entry.kodyId,
 			packageName: entry.kodyId,

--- a/packages/worker/src/mcp/secrets/package-access.ts
+++ b/packages/worker/src/mcp/secrets/package-access.ts
@@ -1,0 +1,212 @@
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { buildSecretPackageApprovalUrl } from './package-approval-url.ts'
+import {
+	createMissingSecretMessage,
+	createPackageSecretAccessDeniedBatchMessage,
+	createPackageSecretAccessDeniedMessage,
+} from './errors.ts'
+import { resolveSecret } from './service.ts'
+import { type SecretScope } from './types.ts'
+import {
+	loadPackageManifestBySourceId,
+	type LoadedPackageManifest,
+} from '#worker/package-registry/source.ts'
+import { getSavedPackageById } from '#worker/package-registry/repo.ts'
+
+type SecretMountDefinition = {
+	name: string
+	scope?: SecretScope
+}
+
+export async function loadPackageSecretMounts(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	packageId: string
+}): Promise<{
+	savedPackage: {
+		id: string
+		kodyId: string
+		name: string
+		sourceId: string
+	}
+	manifest: LoadedPackageManifest['manifest']
+	mounts: Record<string, SecretMountDefinition>
+}> {
+	const savedPackage = await getSavedPackageById(input.env.APP_DB, {
+		userId: input.userId,
+		packageId: input.packageId,
+	})
+	if (!savedPackage) {
+		throw new Error(`Saved package "${input.packageId}" was not found.`)
+	}
+	const loaded = await loadPackageManifestBySourceId({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		sourceId: savedPackage.sourceId,
+	})
+	return {
+		savedPackage: {
+			id: savedPackage.id,
+			kodyId: savedPackage.kodyId,
+			name: savedPackage.name,
+			sourceId: savedPackage.sourceId,
+		},
+		manifest: loaded.manifest,
+		mounts: loaded.manifest.kody.secretMounts ?? {},
+	}
+}
+
+export async function resolvePackageMountedSecret(input: {
+	env: Env
+	callerContext: McpCallerContext
+	packageId: string
+	alias: string
+}) {
+	const packageContext = input.callerContext.storageContext?.appId
+	if (!packageContext || packageContext !== input.packageId) {
+		throw new Error(
+			'Package secret access is only available inside server-side package runtime contexts.',
+		)
+	}
+	const userId = input.callerContext.user?.userId
+	if (!userId) {
+		throw new Error(
+			'Package secret access requires an authenticated package caller context.',
+		)
+	}
+	const packageInfo = await loadPackageSecretMounts({
+		env: input.env,
+		baseUrl: input.callerContext.baseUrl,
+		userId,
+		packageId: input.packageId,
+	})
+	const mount = packageInfo.mounts[input.alias]
+	if (!mount) {
+		throw new Error(
+			`Package "${packageInfo.savedPackage.kodyId}" does not declare secret mount "${input.alias}".`,
+		)
+	}
+	const resolved = await resolveSecret({
+		env: input.env,
+		userId,
+		name: mount.name,
+		scope: mount.scope,
+		storageContext: {
+			sessionId: input.callerContext.storageContext?.sessionId ?? null,
+			appId: input.callerContext.storageContext?.appId ?? null,
+			storageId: input.callerContext.storageContext?.storageId ?? null,
+		},
+	})
+	if (!resolved.found || typeof resolved.value !== 'string') {
+		throw new Error(createMissingSecretMessage(mount.name))
+	}
+	if (!resolved.allowedPackages.includes(packageInfo.savedPackage.id)) {
+		const approvalUrl = buildSecretPackageApprovalUrl({
+			baseUrl: input.callerContext.baseUrl,
+			name: mount.name,
+			scope: resolved.scope ?? mount.scope ?? 'user',
+			packageId: packageInfo.savedPackage.id,
+			kodyId: packageInfo.savedPackage.kodyId,
+			storageContext: {
+				sessionId: input.callerContext.storageContext?.sessionId ?? null,
+				appId: input.callerContext.storageContext?.appId ?? null,
+				storageId: input.callerContext.storageContext?.storageId ?? null,
+			},
+		})
+		throw new Error(
+			createPackageSecretAccessDeniedMessage({
+				secretName: mount.name,
+				packageName: packageInfo.savedPackage.kodyId,
+				approvalUrl,
+			}),
+		)
+	}
+	return {
+		alias: input.alias,
+		name: mount.name,
+		value: resolved.value,
+		scope: resolved.scope ?? mount.scope ?? 'user',
+		packageId: packageInfo.savedPackage.id,
+		kodyId: packageInfo.savedPackage.kodyId,
+	}
+}
+
+export async function findMissingPackageApprovals(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	packageId: string
+	mounts: Record<string, SecretMountDefinition>
+	storageContext: McpCallerContext['storageContext']
+}) {
+	const packageInfo = await loadPackageSecretMounts({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		packageId: input.packageId,
+	})
+	const missing = []
+	for (const mount of Object.values(input.mounts)) {
+		const resolved = await resolveSecret({
+			env: input.env,
+			userId: input.userId,
+			name: mount.name,
+			scope: mount.scope,
+			storageContext: {
+				sessionId: input.storageContext?.sessionId ?? null,
+				appId: input.storageContext?.appId ?? null,
+				storageId: input.storageContext?.storageId ?? null,
+			},
+		})
+		if (!resolved.found) continue
+		if (resolved.allowedPackages.includes(packageInfo.savedPackage.id)) continue
+		missing.push({
+			secretName: mount.name,
+			packageId: packageInfo.savedPackage.id,
+			kodyId: packageInfo.savedPackage.kodyId,
+			approvalUrl: buildSecretPackageApprovalUrl({
+				baseUrl: input.baseUrl,
+				name: mount.name,
+				scope: resolved.scope ?? mount.scope ?? 'user',
+				packageId: packageInfo.savedPackage.id,
+				kodyId: packageInfo.savedPackage.kodyId,
+				storageContext: {
+					sessionId: input.storageContext?.sessionId ?? null,
+					appId: input.storageContext?.appId ?? null,
+					storageId: input.storageContext?.storageId ?? null,
+				},
+			}),
+		})
+	}
+	return missing
+}
+
+export function buildPackageApprovalErrorForMounts(input: {
+	secretNames: Array<{
+		name: string
+		packageId: string
+		kodyId: string
+		approvalUrl: string
+	}>
+}) {
+	if (input.secretNames.length === 1) {
+		const only = input.secretNames[0]
+		if (!only) return null
+		return createPackageSecretAccessDeniedMessage({
+			secretName: only.name,
+			packageName: only.kodyId,
+			approvalUrl: only.approvalUrl,
+		})
+	}
+	return createPackageSecretAccessDeniedBatchMessage(
+		input.secretNames.map((entry) => ({
+			secretName: entry.name,
+			packageId: entry.packageId,
+			kodyId: entry.kodyId,
+			packageName: entry.kodyId,
+			approvalUrl: entry.approvalUrl,
+		})),
+	)
+}

--- a/packages/worker/src/mcp/secrets/package-approval-url.ts
+++ b/packages/worker/src/mcp/secrets/package-approval-url.ts
@@ -1,0 +1,25 @@
+import { buildAccountSecretPath } from '@kody-internal/shared/account-secret-route.ts'
+import { type StorageContext } from '#mcp/storage.ts'
+import { type SecretScope } from './types.ts'
+
+export function buildSecretPackageApprovalUrl(input: {
+	baseUrl: string
+	name: string
+	scope: SecretScope
+	packageId: string
+	kodyId: string | null
+	storageContext: StorageContext | null
+}) {
+	const secretPath = buildAccountSecretPath({
+		name: input.name,
+		scope: input.scope,
+		appId: input.storageContext?.appId ?? null,
+		sessionId: input.storageContext?.sessionId ?? null,
+	})
+	const url = new URL(secretPath, input.baseUrl)
+	url.searchParams.set('package_id', input.packageId)
+	if (input.kodyId) {
+		url.searchParams.set('package', input.kodyId)
+	}
+	return url.toString()
+}

--- a/packages/worker/src/mcp/secrets/package-approval-url.ts
+++ b/packages/worker/src/mcp/secrets/package-approval-url.ts
@@ -8,8 +8,17 @@ export function buildSecretPackageApprovalUrl(input: {
 	scope: SecretScope
 	packageId: string
 	kodyId: string | null
+	token?: string | null
 	storageContext: StorageContext | null
 }) {
+	if (input.scope === 'app' && !input.storageContext?.appId) {
+		throw new Error('storageContext.appId is required for app-scope approvals.')
+	}
+	if (input.scope === 'session' && !input.storageContext?.sessionId) {
+		throw new Error(
+			'storageContext.sessionId is required for session-scope approvals.',
+		)
+	}
 	const secretPath = buildAccountSecretPath({
 		name: input.name,
 		scope: input.scope,
@@ -20,6 +29,9 @@ export function buildSecretPackageApprovalUrl(input: {
 	url.searchParams.set('package_id', input.packageId)
 	if (input.kodyId) {
 		url.searchParams.set('package', input.kodyId)
+	}
+	if (input.token) {
+		url.searchParams.set('request', input.token)
 	}
 	return url.toString()
 }

--- a/packages/worker/src/mcp/secrets/package-approval.ts
+++ b/packages/worker/src/mcp/secrets/package-approval.ts
@@ -1,0 +1,108 @@
+import { buildAccountSecretPath } from '@kody-internal/shared/account-secret-route.ts'
+import { type StorageContext } from '#mcp/storage.ts'
+import { decryptStringWithPurpose, encryptStringWithPurpose } from './crypto.ts'
+import { type SecretScope } from './types.ts'
+
+const secretPackageApprovalPurpose = 'secret-package-approval'
+const defaultSecretPackageApprovalTtlMs = 1000 * 60 * 60 * 24
+
+export type SecretPackageApprovalRequest = {
+	userId: string
+	name: string
+	scope: SecretScope
+	packageId: string
+	packageKodyId: string | null
+	storageContext: StorageContext | null
+	iat: number
+	exp: number
+}
+
+export async function createSecretPackageApprovalToken(
+	env: Pick<Env, 'COOKIE_SECRET'>,
+	input: {
+		userId: string
+		name: string
+		scope: SecretScope
+		packageId: string
+		packageKodyId: string | null
+		storageContext: StorageContext | null
+		ttlMs?: number
+	},
+) {
+	const now = Date.now()
+	const ttlMs = input.ttlMs ?? defaultSecretPackageApprovalTtlMs
+	return encryptStringWithPurpose(
+		env,
+		secretPackageApprovalPurpose,
+		JSON.stringify({
+			userId: input.userId,
+			name: input.name.trim(),
+			scope: input.scope,
+			packageId: input.packageId.trim(),
+			packageKodyId: input.packageKodyId?.trim() || null,
+			storageContext: input.storageContext ?? null,
+			iat: now,
+			exp: now + ttlMs,
+		} satisfies SecretPackageApprovalRequest),
+	)
+}
+
+export async function verifySecretPackageApprovalToken(
+	env: Pick<Env, 'COOKIE_SECRET'>,
+	token: string,
+) {
+	const raw = await decryptStringWithPurpose(
+		env,
+		secretPackageApprovalPurpose,
+		token,
+	)
+	const parsed = JSON.parse(raw) as Partial<SecretPackageApprovalRequest>
+	if (
+		typeof parsed.userId !== 'string' ||
+		typeof parsed.name !== 'string' ||
+		typeof parsed.scope !== 'string' ||
+		typeof parsed.packageId !== 'string'
+	) {
+		throw new Error('Invalid secret package approval request.')
+	}
+	if (typeof parsed.exp === 'number' && Date.now() > parsed.exp) {
+		throw new Error('Secret package approval request has expired.')
+	}
+	return {
+		userId: parsed.userId,
+		name: parsed.name.trim(),
+		scope: parsed.scope as SecretScope,
+		packageId: parsed.packageId.trim(),
+		packageKodyId:
+			typeof parsed.packageKodyId === 'string'
+				? (parsed.packageKodyId.trim() || null)
+				: null,
+		storageContext: parsed.storageContext ?? null,
+		iat: typeof parsed.iat === 'number' ? parsed.iat : Date.now(),
+		exp: typeof parsed.exp === 'number' ? parsed.exp : Date.now(),
+	} satisfies SecretPackageApprovalRequest
+}
+
+export function buildSecretPackageApprovalTokenUrl(input: {
+	baseUrl: string
+	token: string
+	name: string
+	scope: SecretScope
+	packageId: string
+	packageKodyId: string | null
+	storageContext: StorageContext | null
+}) {
+	const secretPath = buildAccountSecretPath({
+		name: input.name,
+		scope: input.scope,
+		appId: input.storageContext?.appId ?? null,
+		sessionId: input.storageContext?.sessionId ?? null,
+	})
+	const url = new URL(secretPath, input.baseUrl)
+	url.searchParams.set('package_id', input.packageId)
+	if (input.packageKodyId) {
+		url.searchParams.set('package', input.packageKodyId)
+	}
+	url.searchParams.set('request', input.token)
+	return url.toString()
+}

--- a/packages/worker/src/mcp/secrets/package-approval.ts
+++ b/packages/worker/src/mcp/secrets/package-approval.ts
@@ -7,6 +7,7 @@ const secretPackageApprovalPurpose = 'secret-package-approval'
 const defaultSecretPackageApprovalTtlMs = 1000 * 60 * 60 * 24
 
 export type SecretPackageApprovalRequest = {
+	kind: 'package'
 	userId: string
 	name: string
 	scope: SecretScope
@@ -35,6 +36,7 @@ export async function createSecretPackageApprovalToken(
 		env,
 		secretPackageApprovalPurpose,
 		JSON.stringify({
+			kind: 'package',
 			userId: input.userId,
 			name: input.name.trim(),
 			scope: input.scope,
@@ -58,6 +60,7 @@ export async function verifySecretPackageApprovalToken(
 	)
 	const parsed = JSON.parse(raw) as Partial<SecretPackageApprovalRequest>
 	if (
+		parsed.kind !== 'package' ||
 		typeof parsed.userId !== 'string' ||
 		typeof parsed.name !== 'string' ||
 		typeof parsed.scope !== 'string' ||
@@ -69,6 +72,7 @@ export async function verifySecretPackageApprovalToken(
 		throw new Error('Secret package approval request has expired.')
 	}
 	return {
+		kind: 'package',
 		userId: parsed.userId,
 		name: parsed.name.trim(),
 		scope: parsed.scope as SecretScope,

--- a/packages/worker/src/mcp/secrets/package-approval.ts
+++ b/packages/worker/src/mcp/secrets/package-approval.ts
@@ -32,7 +32,7 @@ export async function createSecretPackageApprovalToken(
 ) {
 	const now = Date.now()
 	const ttlMs = input.ttlMs ?? defaultSecretPackageApprovalTtlMs
-	return encryptStringWithPurpose(
+	const token = await encryptStringWithPurpose(
 		env,
 		secretPackageApprovalPurpose,
 		JSON.stringify({
@@ -47,16 +47,18 @@ export async function createSecretPackageApprovalToken(
 			exp: now + ttlMs,
 		} satisfies SecretPackageApprovalRequest),
 	)
+	return `pkg:${token}`
 }
 
 export async function verifySecretPackageApprovalToken(
 	env: Pick<Env, 'COOKIE_SECRET'>,
 	token: string,
 ) {
+	const encryptedToken = token.startsWith('pkg:') ? token.slice(4) : token
 	const raw = await decryptStringWithPurpose(
 		env,
 		secretPackageApprovalPurpose,
-		token,
+		encryptedToken,
 	)
 	const parsed = JSON.parse(raw) as Partial<SecretPackageApprovalRequest>
 	if (

--- a/packages/worker/src/mcp/secrets/package-approval.ts
+++ b/packages/worker/src/mcp/secrets/package-approval.ts
@@ -5,6 +5,7 @@ import { type SecretScope } from './types.ts'
 
 const secretPackageApprovalPurpose = 'secret-package-approval'
 const defaultSecretPackageApprovalTtlMs = 1000 * 60 * 60 * 24
+export const secretPackageApprovalTokenPrefix = 'pkg:'
 
 export type SecretPackageApprovalRequest = {
 	kind: 'package'
@@ -47,14 +48,16 @@ export async function createSecretPackageApprovalToken(
 			exp: now + ttlMs,
 		} satisfies SecretPackageApprovalRequest),
 	)
-	return `pkg:${token}`
+	return `${secretPackageApprovalTokenPrefix}${token}`
 }
 
 export async function verifySecretPackageApprovalToken(
 	env: Pick<Env, 'COOKIE_SECRET'>,
 	token: string,
 ) {
-	const encryptedToken = token.startsWith('pkg:') ? token.slice(4) : token
+	const encryptedToken = token.startsWith(secretPackageApprovalTokenPrefix)
+		? token.slice(secretPackageApprovalTokenPrefix.length)
+		: token
 	const raw = await decryptStringWithPurpose(
 		env,
 		secretPackageApprovalPurpose,

--- a/packages/worker/src/mcp/secrets/repo.ts
+++ b/packages/worker/src/mcp/secrets/repo.ts
@@ -11,6 +11,7 @@ type SecretMetadataRow = {
 	description: string
 	allowed_hosts: string
 	allowed_capabilities: string
+	allowed_packages: string
 	created_at: string
 	updated_at: string
 	expires_at: string | null
@@ -74,7 +75,7 @@ export async function getSecretEntry(input: {
 }): Promise<SecretEntryRow | null> {
 	const row = await input.db
 		.prepare(
-			`SELECT bucket_id, name, description, encrypted_value, allowed_hosts, allowed_capabilities, created_at, updated_at
+			`SELECT bucket_id, name, description, encrypted_value, allowed_hosts, allowed_capabilities, allowed_packages, created_at, updated_at
 			FROM secret_entries
 			WHERE bucket_id = ? AND name = ?
 			LIMIT 1`,
@@ -95,14 +96,15 @@ export async function upsertSecretEntry(input: {
 	await input.db
 		.prepare(
 			`INSERT INTO secret_entries (
-				bucket_id, name, description, encrypted_value, allowed_hosts, allowed_capabilities, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+				bucket_id, name, description, encrypted_value, allowed_hosts, allowed_capabilities, allowed_packages, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(bucket_id, name)
 			DO UPDATE SET
 				description = excluded.description,
 				encrypted_value = excluded.encrypted_value,
 				allowed_hosts = excluded.allowed_hosts,
 				allowed_capabilities = excluded.allowed_capabilities,
+				allowed_packages = excluded.allowed_packages,
 				updated_at = excluded.updated_at`,
 		)
 		.bind(
@@ -112,6 +114,7 @@ export async function upsertSecretEntry(input: {
 			input.row.encrypted_value,
 			input.row.allowed_hosts,
 			input.row.allowed_capabilities,
+			input.row.allowed_packages,
 			input.row.created_at ?? now,
 			input.row.updated_at ?? now,
 		)
@@ -136,7 +139,7 @@ export async function listSecretMetadataForBucket(input: {
 }): Promise<Array<SecretMetadataRow>> {
 	const { results } = await input.db
 		.prepare(
-			`SELECT ? AS scope, ? AS binding_key, name, description, allowed_hosts, allowed_capabilities, created_at, updated_at, ? AS expires_at
+			`SELECT ? AS scope, ? AS binding_key, name, description, allowed_hosts, allowed_capabilities, allowed_packages, created_at, updated_at, ? AS expires_at
 			FROM secret_entries
 			WHERE bucket_id = ?
 			ORDER BY name ASC`,
@@ -159,7 +162,7 @@ export async function listUserScopeSecretMetadata(input: {
 	const now = input.now ?? new Date().toISOString()
 	const { results } = await input.db
 		.prepare(
-			`SELECT b.scope, b.binding_key, e.name, e.description, e.allowed_hosts, e.allowed_capabilities, e.created_at, e.updated_at, b.expires_at
+			`SELECT b.scope, b.binding_key, e.name, e.description, e.allowed_hosts, e.allowed_capabilities, e.allowed_packages, e.created_at, e.updated_at, b.expires_at
 			FROM secret_buckets b
 			JOIN secret_entries e ON e.bucket_id = b.id
 			WHERE b.user_id = ? AND b.scope = 'user'
@@ -182,7 +185,7 @@ export async function listAppScopeSecretMetadata(input: {
 	const placeholders = input.appIds.map(() => '?').join(', ')
 	const { results } = await input.db
 		.prepare(
-			`SELECT b.scope, b.binding_key, e.name, e.description, e.allowed_hosts, e.allowed_capabilities, e.created_at, e.updated_at, b.expires_at
+			`SELECT b.scope, b.binding_key, e.name, e.description, e.allowed_hosts, e.allowed_capabilities, e.allowed_packages, e.created_at, e.updated_at, b.expires_at
 			FROM secret_buckets b
 			JOIN secret_entries e ON e.bucket_id = b.id
 			WHERE b.user_id = ? AND b.scope = 'app'
@@ -230,6 +233,7 @@ function mapSecretEntryRow(row: Record<string, unknown>): SecretEntryRow {
 		encrypted_value: String(row['encrypted_value']),
 		allowed_hosts: String(row['allowed_hosts']),
 		allowed_capabilities: String(row['allowed_capabilities']),
+		allowed_packages: String(row['allowed_packages']),
 		created_at: String(row['created_at']),
 		updated_at: String(row['updated_at']),
 	}
@@ -243,6 +247,7 @@ function mapSecretMetadataRow(row: Record<string, unknown>): SecretMetadataRow {
 		description: String(row['description']),
 		allowed_hosts: String(row['allowed_hosts']),
 		allowed_capabilities: String(row['allowed_capabilities']),
+		allowed_packages: String(row['allowed_packages']),
 		created_at: String(row['created_at']),
 		updated_at: String(row['updated_at']),
 		expires_at: row['expires_at'] == null ? null : String(row['expires_at']),

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -591,7 +591,6 @@ export async function setSecretAllowedCapabilities(input: {
 			allowed_capabilities: stringifyAllowedCapabilities(
 				input.allowedCapabilities,
 			),
-			allowed_packages: existingEntry.allowed_packages,
 			updated_at: now,
 		},
 	})

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -4,6 +4,11 @@ import {
 	stringifyAllowedCapabilities,
 } from './allowed-capabilities.ts'
 import {
+	normalizeAllowedPackages,
+	parseAllowedPackages,
+	stringifyAllowedPackages,
+} from './allowed-packages.ts'
+import {
 	normalizeAllowedHosts,
 	normalizeHost,
 	parseAllowedHosts,
@@ -74,6 +79,7 @@ export type ResolvedSecret = {
 	scope: SecretScope | null
 	allowedHosts: Array<string>
 	allowedCapabilities: Array<string>
+	allowedPackages: Array<string>
 }
 
 export async function saveSecret(
@@ -111,6 +117,7 @@ export async function saveSecret(
 			encrypted_value: await encryptSecretValue(input.env, value),
 			allowed_hosts: existingEntry?.allowed_hosts ?? '[]',
 			allowed_capabilities: existingEntry?.allowed_capabilities ?? '[]',
+			allowed_packages: existingEntry?.allowed_packages ?? '[]',
 			created_at: existingEntry?.created_at ?? now,
 			updated_at: now,
 		},
@@ -125,6 +132,9 @@ export async function saveSecret(
 			: [],
 		allowedCapabilities: existingEntry
 			? parseAllowedCapabilities(existingEntry.allowed_capabilities)
+			: [],
+		allowedPackages: existingEntry
+			? parseAllowedPackages(existingEntry.allowed_packages)
 			: [],
 		createdAt: existingEntry?.created_at ?? now,
 		updatedAt: now,
@@ -160,6 +170,7 @@ export async function listSecrets(
 				appId: row.scope === 'app' ? row.binding_key : null,
 				allowedHosts: parseAllowedHosts(row.allowed_hosts),
 				allowedCapabilities: parseAllowedCapabilities(row.allowed_capabilities),
+				allowedPackages: parseAllowedPackages(row.allowed_packages),
 				createdAt: row.created_at,
 				updatedAt: row.updated_at,
 				expiresAt: row.expires_at,
@@ -194,6 +205,7 @@ export async function resolveSecret(
 			scope,
 			allowedHosts: parseAllowedHosts(entry.allowed_hosts),
 			allowedCapabilities: parseAllowedCapabilities(entry.allowed_capabilities),
+			allowedPackages: parseAllowedPackages(entry.allowed_packages),
 		}
 	}
 	return {
@@ -202,6 +214,7 @@ export async function resolveSecret(
 		scope: null,
 		allowedHosts: [],
 		allowedCapabilities: [],
+		allowedPackages: [],
 	}
 }
 
@@ -282,6 +295,7 @@ export async function updateSecret(
 				: existingEntry.encrypted_value,
 			allowed_hosts: existingEntry.allowed_hosts,
 			allowed_capabilities: existingEntry.allowed_capabilities,
+			allowed_packages: existingEntry.allowed_packages,
 			created_at: existingEntry.created_at,
 			updated_at: now,
 		},
@@ -295,6 +309,7 @@ export async function updateSecret(
 		allowedCapabilities: parseAllowedCapabilities(
 			existingEntry.allowed_capabilities,
 		),
+		allowedPackages: parseAllowedPackages(existingEntry.allowed_packages),
 		createdAt: existingEntry.created_at,
 		updatedAt: now,
 		expiresAt: bucket.expires_at,
@@ -343,6 +358,7 @@ export async function listAppSecretsByAppIds(input: {
 				appId,
 				allowedHosts: parseAllowedHosts(row.allowed_hosts),
 				allowedCapabilities: parseAllowedCapabilities(row.allowed_capabilities),
+				allowedPackages: parseAllowedPackages(row.allowed_packages),
 				createdAt: row.created_at,
 				updatedAt: row.updated_at,
 				expiresAt: row.expires_at,
@@ -458,6 +474,7 @@ function toSecretMetadata(input: {
 	appId: string | null
 	allowedHosts: Array<string>
 	allowedCapabilities: Array<string>
+	allowedPackages: Array<string>
 	createdAt: string
 	updatedAt: string
 	expiresAt: string | null
@@ -471,6 +488,7 @@ function toSecretMetadata(input: {
 		allowedCapabilities: normalizeAllowedCapabilities(
 			input.allowedCapabilities,
 		),
+		allowedPackages: normalizeAllowedPackages(input.allowedPackages),
 		createdAt: input.createdAt,
 		updatedAt: input.updatedAt,
 		ttlMs:
@@ -528,6 +546,7 @@ export async function setSecretAllowedHosts(input: {
 		allowedCapabilities: parseAllowedCapabilities(
 			existingEntry.allowed_capabilities,
 		),
+		allowedPackages: parseAllowedPackages(existingEntry.allowed_packages),
 		createdAt: existingEntry.created_at,
 		updatedAt: now,
 		expiresAt: bucket.expires_at,
@@ -572,6 +591,7 @@ export async function setSecretAllowedCapabilities(input: {
 			allowed_capabilities: stringifyAllowedCapabilities(
 				input.allowedCapabilities,
 			),
+			allowed_packages: existingEntry.allowed_packages,
 			updated_at: now,
 		},
 	})
@@ -582,6 +602,62 @@ export async function setSecretAllowedCapabilities(input: {
 		appId: input.scope === 'app' ? bucket.binding_key : null,
 		allowedHosts: parseAllowedHosts(existingEntry.allowed_hosts),
 		allowedCapabilities: input.allowedCapabilities,
+		allowedPackages: parseAllowedPackages(existingEntry.allowed_packages),
+		createdAt: existingEntry.created_at,
+		updatedAt: now,
+		expiresAt: bucket.expires_at,
+	})
+}
+
+export async function setSecretAllowedPackages(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	name: string
+	scope: SecretScope
+	allowedPackages: Array<string>
+	storageContext?: StorageContext | null
+}) {
+	const name = input.name.trim()
+	if (!name) {
+		throw new Error('Secret name is required.')
+	}
+	assertSecretNameAllowed(name)
+	const bucket = await getExistingBucketForScope({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		scope: input.scope,
+		storageContext: input.storageContext ?? null,
+	})
+	if (!bucket) {
+		throw new Error('Secret not found for this scope.')
+	}
+	const existingEntry = await getSecretEntry({
+		db: input.env.APP_DB,
+		bucketId: bucket.id,
+		name,
+	})
+	if (!existingEntry) {
+		throw new Error('Secret not found for this scope.')
+	}
+	const now = new Date().toISOString()
+	await upsertSecretEntry({
+		db: input.env.APP_DB,
+		row: {
+			...existingEntry,
+			allowed_packages: stringifyAllowedPackages(input.allowedPackages),
+			updated_at: now,
+		},
+	})
+	return toSecretMetadata({
+		name,
+		scope: input.scope,
+		description: existingEntry.description,
+		appId: input.scope === 'app' ? bucket.binding_key : null,
+		allowedHosts: parseAllowedHosts(existingEntry.allowed_hosts),
+		allowedCapabilities: parseAllowedCapabilities(
+			existingEntry.allowed_capabilities,
+		),
+		allowedPackages: input.allowedPackages,
 		createdAt: existingEntry.created_at,
 		updatedAt: now,
 		expiresAt: bucket.expires_at,

--- a/packages/worker/src/mcp/secrets/types.ts
+++ b/packages/worker/src/mcp/secrets/types.ts
@@ -25,6 +25,7 @@ export type SecretEntryRow = {
 	encrypted_value: string
 	allowed_hosts: string
 	allowed_capabilities: string
+	allowed_packages: string
 	created_at: string
 	updated_at: string
 }
@@ -36,6 +37,7 @@ export type SecretMetadata = {
 	appId: string | null
 	allowedHosts: Array<string>
 	allowedCapabilities: Array<string>
+	allowedPackages: Array<string>
 	createdAt: string
 	updatedAt: string
 	ttlMs: number | null

--- a/packages/worker/src/mcp/tools/open-generated-ui.node.test.ts
+++ b/packages/worker/src/mcp/tools/open-generated-ui.node.test.ts
@@ -8,7 +8,8 @@ const mockModule = vi.hoisted(() => ({
 }))
 
 vi.mock('@modelcontextprotocol/ext-apps/server', () => ({
-	registerAppTool: (...args: Array<unknown>) => mockModule.registerAppTool(...args),
+	registerAppTool: (...args: Array<unknown>) =>
+		mockModule.registerAppTool(...args),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -94,4 +95,3 @@ test('open_generated_ui reopens saved package apps by kody_id', async () => {
 		hostedUrl: 'https://example.com/packages/observed-package',
 	})
 })
-

--- a/packages/worker/src/mcp/tools/open-generated-ui.ts
+++ b/packages/worker/src/mcp/tools/open-generated-ui.ts
@@ -75,13 +75,10 @@ const inputSchema = z
 		conversationId: conversationIdInputField,
 		memoryContext: memoryContextInputField,
 	})
-	.refine(
-		(value) => (value.code ? 1 : 0) + (value.kody_id ? 1 : 0) === 1,
-		{
-			message: 'Provide exactly one of `code` or `kody_id`.',
-			path: ['code'],
-		},
-	)
+	.refine((value) => (value.code ? 1 : 0) + (value.kody_id ? 1 : 0) === 1, {
+		message: 'Provide exactly one of `code` or `kody_id`.',
+		path: ['code'],
+	})
 
 export async function registerOpenGeneratedUiTool(agent: McpRegistrationAgent) {
 	registerAppTool(
@@ -104,8 +101,9 @@ export async function registerOpenGeneratedUiTool(agent: McpRegistrationAgent) {
 			const kodyId = args.kody_id ?? null
 			const title = args.title ?? null
 			const description = args.description ?? null
-			let savedPackage: Awaited<ReturnType<typeof getSavedPackageByKodyId>> | null =
-				null
+			let savedPackage: Awaited<
+				ReturnType<typeof getSavedPackageByKodyId>
+			> | null = null
 			if (kodyId) {
 				if (!callerContext.user) {
 					throw new Error('Authentication required to access saved packages.')

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -17,106 +17,31 @@ test('parseEntityRef accepts value and connector entity types', () => {
 	})
 })
 
-test(
-	'search formatting keeps entity refs in markdown while structured output carries the stable contract',
-	() => {
-		const markdown = formatSearchMarkdown({
-			baseUrl: 'http://localhost',
-			warnings: [],
-			guidance:
-				'Inspect connector detail with `search({ entity: "github:connector" })` next.',
-			matches: [
-				{
-					type: 'value',
-					valueId: 'user:preferred_repo',
-					name: 'preferred_repo',
-					scope: 'user',
-					description: 'Preferred repository owner/name.',
-					value: 'kentcdodds/kody',
-					appId: null,
-					updatedAt: '2026-03-20T00:00:00.000Z',
-					ttlMs: null,
-					usage:
-						'Read with value_get: {"name":"preferred_repo","scope":"user"}.',
-					fusedScore: 1,
-				},
-				{
-					type: 'connector',
-					connectorName: 'github',
-					title: 'github',
-					description: 'GitHub OAuth connector config',
-					flow: 'confidential',
-					tokenUrl: 'https://github.com/login/oauth/access_token',
-					apiBaseUrl: 'https://api.github.com',
-					clientIdValueName: 'github_client_id',
-					clientSecretSecretName: 'github_client_secret',
-					accessTokenSecretName: 'github_access_token',
-					refreshTokenSecretName: 'github_refresh_token',
-					requiredHosts: ['api.github.com'],
-					usage: 'Read with connector_get: {"name":"github"}.',
-					fusedScore: 0.9,
-				},
-			],
-		})
-
-		expect(markdown).toContain('`user:preferred_repo:value`')
-		expect(markdown).toContain('`github:connector`')
-		const structuredMatches = toSlimStructuredMatches({
-			baseUrl: 'http://localhost',
-			matches: [
-				{
-					type: 'value',
-					valueId: 'user:preferred_repo',
-					name: 'preferred_repo',
-					scope: 'user',
-					description: 'Preferred repository owner/name.',
-					value: 'kentcdodds/kody',
-					appId: null,
-					updatedAt: '2026-03-20T00:00:00.000Z',
-					ttlMs: null,
-					usage:
-						'Read with value_get: {"name":"preferred_repo","scope":"user"}.',
-					fusedScore: 1,
-				},
-				{
-					type: 'connector',
-					connectorName: 'github',
-					title: 'github',
-					description: 'GitHub OAuth connector config',
-					flow: 'confidential',
-					tokenUrl: 'https://github.com/login/oauth/access_token',
-					apiBaseUrl: 'https://api.github.com',
-					clientIdValueName: 'github_client_id',
-					clientSecretSecretName: 'github_client_secret',
-					accessTokenSecretName: 'github_access_token',
-					refreshTokenSecretName: 'github_refresh_token',
-					requiredHosts: ['api.github.com'],
-					usage: 'Read with connector_get: {"name":"github"}.',
-					fusedScore: 0.9,
-				},
-			],
-		})
-
-		expect(structuredMatches).toMatchObject([
+test('search formatting keeps entity refs in markdown while structured output carries the stable contract', () => {
+	const markdown = formatSearchMarkdown({
+		baseUrl: 'http://localhost',
+		warnings: [],
+		guidance:
+			'Inspect connector detail with `search({ entity: "github:connector" })` next.',
+		matches: [
 			{
 				type: 'value',
-				id: 'user:preferred_repo',
-				entityRef: 'user:preferred_repo:value',
+				valueId: 'user:preferred_repo',
 				name: 'preferred_repo',
-				title: 'preferred_repo',
-				description: 'Preferred repository owner/name.',
-				usage: 'codemode.value_get({ name: "preferred_repo", scope: "user" })',
 				scope: 'user',
+				description: 'Preferred repository owner/name.',
+				value: 'kentcdodds/kody',
 				appId: null,
+				updatedAt: '2026-03-20T00:00:00.000Z',
+				ttlMs: null,
+				usage: 'Read with value_get: {"name":"preferred_repo","scope":"user"}.',
+				fusedScore: 1,
 			},
 			{
 				type: 'connector',
-				id: 'github',
-				entityRef: 'github:connector',
-				name: 'github',
+				connectorName: 'github',
 				title: 'github',
 				description: 'GitHub OAuth connector config',
-				usage: 'codemode.connector_get({ name: "github" })',
 				flow: 'confidential',
 				tokenUrl: 'https://github.com/login/oauth/access_token',
 				apiBaseUrl: 'https://api.github.com',
@@ -125,16 +50,86 @@ test(
 				accessTokenSecretName: 'github_access_token',
 				refreshTokenSecretName: 'github_refresh_token',
 				requiredHosts: ['api.github.com'],
+				usage: 'Read with connector_get: {"name":"github"}.',
+				fusedScore: 0.9,
 			},
-		])
-		const connectorMatch = structuredMatches[1]
-		expect(connectorMatch).toMatchObject({
+		],
+	})
+
+	expect(markdown).toContain('`user:preferred_repo:value`')
+	expect(markdown).toContain('`github:connector`')
+	const structuredMatches = toSlimStructuredMatches({
+		baseUrl: 'http://localhost',
+		matches: [
+			{
+				type: 'value',
+				valueId: 'user:preferred_repo',
+				name: 'preferred_repo',
+				scope: 'user',
+				description: 'Preferred repository owner/name.',
+				value: 'kentcdodds/kody',
+				appId: null,
+				updatedAt: '2026-03-20T00:00:00.000Z',
+				ttlMs: null,
+				usage: 'Read with value_get: {"name":"preferred_repo","scope":"user"}.',
+				fusedScore: 1,
+			},
+			{
+				type: 'connector',
+				connectorName: 'github',
+				title: 'github',
+				description: 'GitHub OAuth connector config',
+				flow: 'confidential',
+				tokenUrl: 'https://github.com/login/oauth/access_token',
+				apiBaseUrl: 'https://api.github.com',
+				clientIdValueName: 'github_client_id',
+				clientSecretSecretName: 'github_client_secret',
+				accessTokenSecretName: 'github_access_token',
+				refreshTokenSecretName: 'github_refresh_token',
+				requiredHosts: ['api.github.com'],
+				usage: 'Read with connector_get: {"name":"github"}.',
+				fusedScore: 0.9,
+			},
+		],
+	})
+
+	expect(structuredMatches).toMatchObject([
+		{
+			type: 'value',
+			id: 'user:preferred_repo',
+			entityRef: 'user:preferred_repo:value',
+			name: 'preferred_repo',
+			title: 'preferred_repo',
+			description: 'Preferred repository owner/name.',
+			usage: 'codemode.value_get({ name: "preferred_repo", scope: "user" })',
+			scope: 'user',
+			appId: null,
+		},
+		{
 			type: 'connector',
+			id: 'github',
 			entityRef: 'github:connector',
-		})
-		expect(connectorMatch?.nextStep).toContain('github:connector')
-	},
-)
+			name: 'github',
+			title: 'github',
+			description: 'GitHub OAuth connector config',
+			usage: 'codemode.connector_get({ name: "github" })',
+			flow: 'confidential',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			apiBaseUrl: 'https://api.github.com',
+			clientIdValueName: 'github_client_id',
+			clientSecretSecretName: 'github_client_secret',
+			accessTokenSecretName: 'github_access_token',
+			refreshTokenSecretName: 'github_refresh_token',
+			requiredHosts: ['api.github.com'],
+		},
+	])
+	const connectorMatch = structuredMatches[1]
+	expect(connectorMatch).toMatchObject({
+		type: 'connector',
+		entityRef: 'github:connector',
+	})
+	expect(connectorMatch?.nextStep).toContain('github:connector')
+})
 
 test('entity detail formatting returns stable structured details for values and connectors', () => {
 	const valueDetail = formatEntityDetailMarkdown({
@@ -390,5 +385,4 @@ test('search formatting falls back to a safe secret usage placeholder for displa
 
 	expect(markdown).toContain('`secret "name":secret`')
 	expect(markdown).toContain('(secret placeholder unavailable for this name)')
-	},
-)
+})

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -340,7 +340,7 @@ test('searchUnified uses package exports and connector aliases for operate queri
 					refreshTokenSecretName: 'spotify-refresh-token',
 					requiredHosts: ['api.spotify.com'],
 				}),
-					description: 'Spotify playback and music OAuth connector config',
+				description: 'Spotify playback and music OAuth connector config',
 				appId: null,
 				createdAt: '2026-04-20T00:00:00.000Z',
 				updatedAt: '2026-04-20T00:00:00.000Z',
@@ -476,7 +476,9 @@ test('search guidance does not pair unrelated package and connector matches', ()
 	expect(result.guidance).toContain(
 		'search({ entity: "observed-package:package" })',
 	)
-	expect(result.guidance).not.toContain('search({ entity: "github:connector" })')
+	expect(result.guidance).not.toContain(
+		'search({ entity: "github:connector" })',
+	)
 })
 
 test('optional search rows fall back when persisted values lookup fails', async () => {

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -487,9 +487,8 @@ test('search guidance does not pair unrelated package and connector matches', ()
 	expect(result.guidance).toContain(
 		'search({ entity: "observed-package:package" })',
 	)
-	expect(result.guidance).not.toContain(
-		'search({ entity: "github:connector" })',
-	)
+	expect(result.guidance).not.toMatch(/connector\s+`github`/)
+	expect(result.guidance).not.toContain('Found saved package')
 })
 
 test('optional search rows fall back when persisted values lookup fails', async () => {

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -60,7 +60,7 @@ test('searchUnified ranks mixed search rows through one shared pipeline', () => 
 				exports: [],
 				jobs: [],
 				services: [],
-					subscriptions: [],
+				subscriptions: [],
 			},
 		},
 	]
@@ -480,6 +480,10 @@ test('search guidance does not pair unrelated package and connector matches', ()
 		},
 	})
 
+	expect(result.matches[0]).toMatchObject({
+		type: 'package',
+		kodyId: 'observed-package',
+	})
 	expect(result.guidance).toContain(
 		'search({ entity: "observed-package:package" })',
 	)
@@ -487,6 +491,7 @@ test('search guidance does not pair unrelated package and connector matches', ()
 		'search({ entity: "github:connector" })',
 	)
 })
+
 test('optional search rows fall back when persisted values lookup fails', async () => {
 	const result = await loadOptionalSearchRows({
 		userId: 'user-123',

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -420,7 +420,7 @@ test('search guidance does not pair unrelated package and connector matches', ()
 	const registry = buildCapabilityRegistry([])
 	const result = searchUnified({
 		env: {} as Env,
-		query: 'play music on spotify',
+		query: 'music remote',
 		limit: 5,
 		registry,
 		optionalRows: {

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -91,7 +91,9 @@ export type OptionalSearchRowsResult = {
 	warnings: Array<string>
 }
 
-type LoadedPackageRows = Array<PackageSearchRow> | BuildSavedPackageSearchRowsResult
+type LoadedPackageRows =
+	| Array<PackageSearchRow>
+	| BuildSavedPackageSearchRowsResult
 
 export type SearchScoreComponents = {
 	base: number
@@ -171,6 +173,7 @@ function buildFallbackPackageSearchProjection(
 		exports: [],
 		jobs: [],
 		services: [],
+		subscriptions: [],
 	}
 }
 
@@ -209,8 +212,7 @@ export async function buildSavedPackageSearchRows(input: {
 						sourceId: record.sourceId,
 					},
 				})
-				const message =
-					cause instanceof Error ? cause.message : String(cause)
+				const message = cause instanceof Error ? cause.message : String(cause)
 				warnings.push(
 					`Saved package "${record.kodyId}" search metadata is partially unavailable; using fallback metadata from source "${record.sourceId}": ${message}`,
 				)
@@ -224,15 +226,14 @@ export async function buildSavedPackageSearchRows(input: {
 	return { rows, warnings }
 }
 
-function buildPackageRelationTokens(match: Extract<SearchMatch, { type: 'package' }>) {
+function buildPackageRelationTokens(
+	match: Extract<SearchMatch, { type: 'package' }>,
+) {
 	return new Set(
 		extractSearchTokens(
-			[
-				match.kodyId,
-				match.name,
-				match.description,
-				match.tags.join(' '),
-			].join('\n'),
+			[match.kodyId, match.name, match.description, match.tags.join(' ')].join(
+				'\n',
+			),
 		),
 	)
 }
@@ -254,7 +255,9 @@ function buildConnectorSearchDocument(input: {
 		.join('\n')
 }
 
-function buildRecommendedNextStep(input: SearchGuidanceContext): string | undefined {
+function buildRecommendedNextStep(
+	input: SearchGuidanceContext,
+): string | undefined {
 	const [topMatch] = input.matches
 	const topPackage = input.matches.find((match) => match.type === 'package')
 	const topConnector = input.matches.find((match) => match.type === 'connector')
@@ -264,7 +267,8 @@ function buildRecommendedNextStep(input: SearchGuidanceContext): string | undefi
 	const connectorMatchesPackage =
 		topPackage &&
 		topConnector &&
-		(packageRelationTokens?.has(topConnector.connectorName.toLowerCase()) ?? false)
+		(packageRelationTokens?.has(topConnector.connectorName.toLowerCase()) ??
+			false)
 
 	if (connectorMatchesPackage && input.intent.task.name === 'operate') {
 		return `Found saved package \`${topPackage.kodyId}\` and connector \`${topConnector.connectorName}\`. Inspect the package with \`search({ entity: "${topPackage.kodyId}:package" })\`, then use the connector detail or an authenticated \`execute\` smoke test to confirm the integration path before running API-backed actions.`

--- a/packages/worker/src/mcp/ui-artifact-parameters.node.test.ts
+++ b/packages/worker/src/mcp/ui-artifact-parameters.node.test.ts
@@ -4,56 +4,53 @@ import {
 	normalizeUiArtifactParameters,
 } from './ui-artifact-parameters.ts'
 
-test(
-	'ui artifact parameters normalize names, apply defaults, and reject invalid caller input',
-	() => {
-		const defs = normalizeUiArtifactParameters([
-			{
-				name: ' owner ',
-				description: 'Repo owner.',
-				type: 'string',
-				required: true,
-			},
-			{
-				name: 'limit',
-				description: 'Result limit.',
-				type: 'number',
-				default: 5,
-			},
-		])
+test('ui artifact parameters normalize names, apply defaults, and reject invalid caller input', () => {
+	const defs = normalizeUiArtifactParameters([
+		{
+			name: ' owner ',
+			description: 'Repo owner.',
+			type: 'string',
+			required: true,
+		},
+		{
+			name: 'limit',
+			description: 'Result limit.',
+			type: 'number',
+			default: 5,
+		},
+	])
 
-		expect(defs).toEqual([
-			{
-				name: 'owner',
-				description: 'Repo owner.',
-				type: 'string',
-				required: true,
-			},
-			{
-				name: 'limit',
-				description: 'Result limit.',
-				type: 'number',
-				required: false,
-				default: 5,
-			},
-		])
+	expect(defs).toEqual([
+		{
+			name: 'owner',
+			description: 'Repo owner.',
+			type: 'string',
+			required: true,
+		},
+		{
+			name: 'limit',
+			description: 'Result limit.',
+			type: 'number',
+			required: false,
+			default: 5,
+		},
+	])
 
-		expect(() =>
-			applyUiArtifactParameters({ definitions: defs, values: { limit: 2 } }),
-		).toThrow('Missing required package app parameter: owner.')
+	expect(() =>
+		applyUiArtifactParameters({ definitions: defs, values: { limit: 2 } }),
+	).toThrow('Missing required package app parameter: owner.')
 
-		expect(
-			applyUiArtifactParameters({ definitions: defs, values: { owner: 'kody' } }),
-		).toEqual({
-			owner: 'kody',
-			limit: 5,
-		})
+	expect(
+		applyUiArtifactParameters({ definitions: defs, values: { owner: 'kody' } }),
+	).toEqual({
+		owner: 'kody',
+		limit: 5,
+	})
 
-		expect(() =>
-			applyUiArtifactParameters({
-				definitions: defs,
-				values: { owner: 'kody', extra: true },
-			}),
-		).toThrow('Unknown package app parameter(s): extra.')
-	},
-)
+	expect(() =>
+		applyUiArtifactParameters({
+			definitions: defs,
+			values: { owner: 'kody', extra: true },
+		}),
+	).toThrow('Unknown package app parameter(s): extra.')
+})

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -109,8 +109,12 @@ function createEnv(
 		COOKIE_SECRET: cookieSecretValue,
 		JOB_MANAGER: mockJobDoNamespace('job-manager-test-id'),
 		STORAGE_RUNNER: mockJobDoNamespace('storage-runner-test-id'),
-		PACKAGE_REALTIME_SESSION: mockJobDoNamespace('package-realtime-session-test-id'),
-		PACKAGE_SERVICE_INSTANCE: mockJobDoNamespace('package-service-instance-test-id'),
+		PACKAGE_REALTIME_SESSION: mockJobDoNamespace(
+			'package-realtime-session-test-id',
+		),
+		PACKAGE_SERVICE_INSTANCE: mockJobDoNamespace(
+			'package-service-instance-test-id',
+		),
 	} as unknown as Env
 }
 

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -114,3 +114,68 @@ test('parseAuthoredPackageJson rejects service timeoutMs values above the suppor
 		}),
 	).toThrow('expected number to be <=300000')
 })
+
+test('parseAuthoredPackageJson accepts secret mounts and subscriptions', () => {
+	const manifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/discord-gateway',
+			exports: {
+				'.': './index.ts',
+			},
+			kody: {
+				id: 'discord-gateway',
+				description: 'Discord gateway package',
+				secretMounts: {
+					discordBotToken: {
+						name: 'discordBotTokenKentPersonalAutomation',
+						scope: 'user',
+						required: true,
+					},
+				},
+				services: {
+					'gateway-supervisor': {
+						entry: './src/gateway-supervisor.ts',
+						autoStart: true,
+						mode: 'persistent',
+					},
+				},
+				subscriptions: {
+					'discord.message.created': {
+						topic: 'discord.message.created',
+						handler: './src/handle-discord-message-created.ts',
+						description: 'Personal-history subscriber',
+						filters: {
+							channelIds: ['1470913684598423592'],
+						},
+					},
+				},
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+
+	expect(manifest.kody.secretMounts).toEqual({
+		discordBotToken: {
+			name: 'discordBotTokenKentPersonalAutomation',
+			scope: 'user',
+			required: true,
+		},
+	})
+	expect(manifest.kody.services).toEqual({
+		'gateway-supervisor': {
+			entry: './src/gateway-supervisor.ts',
+			autoStart: true,
+			mode: 'persistent',
+		},
+	})
+	expect(manifest.kody.subscriptions).toEqual({
+		'discord.message.created': {
+			topic: 'discord.message.created',
+			handler: './src/handle-discord-message-created.ts',
+			description: 'Personal-history subscriber',
+			filters: {
+				channelIds: ['1470913684598423592'],
+			},
+		},
+	})
+})

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -129,7 +129,6 @@ test('parseAuthoredPackageJson accepts secret mounts and subscriptions', () => {
 					discordBotToken: {
 						name: 'discordBotTokenKentPersonalAutomation',
 						scope: 'user',
-						required: true,
 					},
 				},
 				services: {
@@ -141,7 +140,6 @@ test('parseAuthoredPackageJson accepts secret mounts and subscriptions', () => {
 				},
 				subscriptions: {
 					'discord.message.created': {
-						topic: 'discord.message.created',
 						handler: './src/handle-discord-message-created.ts',
 						description: 'Personal-history subscriber',
 						filters: {
@@ -158,7 +156,6 @@ test('parseAuthoredPackageJson accepts secret mounts and subscriptions', () => {
 		discordBotToken: {
 			name: 'discordBotTokenKentPersonalAutomation',
 			scope: 'user',
-			required: true,
 		},
 	})
 	expect(manifest.kody.services).toEqual({
@@ -170,7 +167,6 @@ test('parseAuthoredPackageJson accepts secret mounts and subscriptions', () => {
 	})
 	expect(manifest.kody.subscriptions).toEqual({
 		'discord.message.created': {
-			topic: 'discord.message.created',
 			handler: './src/handle-discord-message-created.ts',
 			description: 'Personal-history subscriber',
 			filters: {

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -133,9 +133,21 @@ export function listPackageServices(manifest: AuthoredPackageJson) {
 			name,
 			entry: normalizePackageWorkspacePath(service.entry),
 			autoStart: service.autoStart ?? false,
+			mode: service.mode ?? 'bounded',
 			timeoutMs: service.timeoutMs ?? null,
 		}))
 		.sort((left, right) => left.name.localeCompare(right.name))
+}
+
+export function listPackageSubscriptions(manifest: AuthoredPackageJson) {
+	return Object.entries(manifest.kody.subscriptions ?? {})
+		.map(([topic, subscription]) => ({
+			topic,
+			handler: normalizePackageWorkspacePath(subscription.handler),
+			description: subscription.description?.trim() || null,
+			filters: subscription.filters ?? null,
+		}))
+		.sort((left, right) => left.topic.localeCompare(right.topic))
 }
 
 export function getPackageTags(manifest: AuthoredPackageJson) {
@@ -161,7 +173,14 @@ export type PackageSearchProjection = {
 		name: string
 		entry: string
 		autoStart: boolean
+		mode: 'bounded' | 'persistent'
 		timeoutMs: number | null
+	}>
+	subscriptions: Array<{
+		topic: string
+		handler: string
+		description: string | null
+		filters: Record<string, unknown> | null
 	}>
 }
 
@@ -192,10 +211,13 @@ export function buildPackageSearchProjection(
 			}))
 			.sort((left, right) => left.name.localeCompare(right.name)),
 		services: listPackageServices(manifest),
+		subscriptions: listPackageSubscriptions(manifest),
 	}
 }
 
-export function buildPackageSearchDocument(projection: PackageSearchProjection) {
+export function buildPackageSearchDocument(
+	projection: PackageSearchProjection,
+) {
 	const jobLines = projection.jobs.map((job) =>
 		[job.name, job.entry, job.schedule, job.enabled ? 'enabled' : 'disabled']
 			.filter((value) => value.length > 0)
@@ -205,11 +227,22 @@ export function buildPackageSearchDocument(projection: PackageSearchProjection) 
 		[
 			service.name,
 			service.entry,
+			service.mode,
 			service.autoStart ? 'auto-start' : 'manual-start',
 			service.timeoutMs != null ? `timeout-ms:${service.timeoutMs}` : '',
 		]
 			.filter((value) => value.length > 0)
 			.join(' '),
+	)
+	const subscriptionLines = (projection.subscriptions ?? []).map(
+		(subscription) =>
+			[
+				`subscription:${subscription.topic}`,
+				subscription.handler,
+				subscription.description ?? '',
+			]
+				.filter((value) => value.length > 0)
+				.join(' '),
 	)
 	return [
 		`package ${projection.kodyId}`,
@@ -220,6 +253,7 @@ export function buildPackageSearchDocument(projection: PackageSearchProjection) 
 		projection.exports.join('\n'),
 		jobLines.join('\n'),
 		serviceLines.join('\n'),
+		subscriptionLines.join('\n'),
 		projection.appEntry
 			? `app ${projection.appEntry}`
 			: projection.hasApp

--- a/packages/worker/src/package-registry/published-package-cache.ts
+++ b/packages/worker/src/package-registry/published-package-cache.ts
@@ -36,10 +36,7 @@ export class PromiseLruCache<T> {
 		}
 	>()
 
-	constructor(input?: {
-		ttlMs?: number
-		limit?: number
-	}) {
+	constructor(input?: { ttlMs?: number; limit?: number }) {
 		this.ttlMs = input?.ttlMs ?? publishedPackageCacheTtlMs
 		this.limit = input?.limit ?? publishedPackageCacheLimit
 	}
@@ -70,10 +67,7 @@ export class PromiseLruCache<T> {
 		return pending
 	}
 
-	getOrCreate(input: {
-		cacheKey: string
-		create: () => Promise<T>
-	}) {
+	getOrCreate(input: { cacheKey: string; create: () => Promise<T> }) {
 		const cached = this.get(input.cacheKey)
 		if (cached) {
 			return cached

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -228,8 +228,8 @@ test('refreshSavedPackageProjection resyncs the job manager after syncing packag
 		buildAppBundle: expect.any(Function),
 		buildModuleBundle: expect.any(Function),
 	})
-	const savedPackageArg = mockModule.buildPublishedPackageArtifacts.mock.calls[0]?.[0]
-		?.savedPackage as { updatedAt: string } | undefined
+	const savedPackageArg = mockModule.buildPublishedPackageArtifacts.mock
+		.calls[0]?.[0]?.savedPackage as { updatedAt: string } | undefined
 	expect(savedPackageArg?.updatedAt).toMatch(
 		/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
 	)
@@ -263,6 +263,7 @@ test('deleteSavedPackageProjection resyncs the job manager after removing packag
 				name: 'realtime-supervisor',
 				entry: './src/services/realtime-supervisor.ts',
 				autoStart: true,
+				mode: 'persistent',
 				timeoutMs: null,
 			},
 		],
@@ -388,6 +389,7 @@ test('deleteSavedPackageProjection still completes cleanup when service stop thr
 				name: 'realtime-supervisor',
 				entry: 'services/realtime-supervisor.ts',
 				autoStart: true,
+				mode: 'persistent',
 				timeoutMs: null,
 			},
 		],
@@ -406,10 +408,13 @@ test('deleteSavedPackageProjection still completes cleanup when service stop thr
 	})
 
 	expect(mockModule.deleteJobRow).toHaveBeenCalledWith({}, 'user-1', 'job-1')
-	expect(mockModule.deleteSavedPackage).toHaveBeenCalledWith({}, {
-		userId: 'user-1',
-		packageId: 'package-1',
-	})
+	expect(mockModule.deleteSavedPackage).toHaveBeenCalledWith(
+		{},
+		{
+			userId: 'user-1',
+			packageId: 'package-1',
+		},
+	)
 	expect(mockModule.deleteSavedPackageVector).toHaveBeenCalledWith(
 		env,
 		'package-1',

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -18,9 +18,7 @@ import {
 } from './vectorize.ts'
 import { deleteJobRow, listJobRowsByUserId } from '#worker/jobs/repo.ts'
 import { syncJobManagerAlarm } from '#worker/jobs/manager-client.ts'
-import {
-	rebuildPublishedPackageArtifacts,
-} from '#worker/package-runtime/published-bundle-artifacts.ts'
+import { rebuildPublishedPackageArtifacts } from '#worker/package-runtime/published-bundle-artifacts.ts'
 import {
 	listSavedPackageServices,
 	packageServiceRpc,
@@ -114,9 +112,8 @@ export async function refreshSavedPackageProjection(input: {
 		manifest: loaded.manifest,
 		files: loaded.files,
 		buildAppBundle: async ({ entryPoint }) => {
-			const { buildKodyAppBundle } = await import(
-				'#worker/package-runtime/module-graph.ts'
-			)
+			const { buildKodyAppBundle } =
+				await import('#worker/package-runtime/module-graph.ts')
 			return await buildKodyAppBundle({
 				env: input.env,
 				baseUrl: input.baseUrl,
@@ -127,9 +124,8 @@ export async function refreshSavedPackageProjection(input: {
 			})
 		},
 		buildModuleBundle: async ({ entryPoint }) => {
-			const { buildKodyModuleBundle } = await import(
-				'#worker/package-runtime/module-graph.ts'
-			)
+			const { buildKodyModuleBundle } =
+				await import('#worker/package-runtime/module-graph.ts')
 			return await buildKodyModuleBundle({
 				env: input.env,
 				baseUrl: input.baseUrl,

--- a/packages/worker/src/package-registry/source.node.test.ts
+++ b/packages/worker/src/package-registry/source.node.test.ts
@@ -74,7 +74,8 @@ test('loadPackageSourceBySourceId reuses cached published package sources', asyn
 					},
 				},
 			}),
-			'app.js': 'export default { async fetch() { return new Response("ok") } }',
+			'app.js':
+				'export default { async fetch() { return new Response("ok") } }',
 			'index.js': 'export const value = "ok"',
 		},
 	})
@@ -301,7 +302,8 @@ test('loadPackageSourceBySourceId shares the same in-flight published source loa
 					},
 				},
 			}),
-			'app.js': 'export default { async fetch() { return new Response("ok") } }',
+			'app.js':
+				'export default { async fetch() { return new Response("ok") } }',
 			'index.js': 'export const value = "ok"',
 		},
 	})
@@ -348,7 +350,8 @@ test('loadPackageSourceBySourceId evicts failed published source loads before re
 						},
 					},
 				}),
-				'app.js': 'export default { async fetch() { return new Response("ok") } }',
+				'app.js':
+					'export default { async fetch() { return new Response("ok") } }',
 				'index.js': 'export const value = "ok"',
 			},
 		})

--- a/packages/worker/src/package-registry/types.ts
+++ b/packages/worker/src/package-registry/types.ts
@@ -38,7 +38,6 @@ export type PackageAppDefinition = z.infer<typeof packageAppDefinitionSchema>
 export const packageSecretMountDefinitionSchema = z.object({
 	name: z.string().min(1),
 	scope: z.enum(['user', 'app', 'session']).optional(),
-	required: z.boolean().optional(),
 })
 
 export type PackageSecretMountDefinition = z.infer<
@@ -60,7 +59,6 @@ export type PackageServiceDefinition = z.infer<
 >
 
 export const packageSubscriptionDefinitionSchema = z.object({
-	topic: z.string().min(1),
 	handler: z.string().min(1),
 	description: z.string().min(1).optional(),
 	filters: z.record(z.string().min(1), z.unknown()).optional(),

--- a/packages/worker/src/package-registry/types.ts
+++ b/packages/worker/src/package-registry/types.ts
@@ -35,14 +35,39 @@ export const packageAppDefinitionSchema = z.object({
 
 export type PackageAppDefinition = z.infer<typeof packageAppDefinitionSchema>
 
+export const packageSecretMountDefinitionSchema = z.object({
+	name: z.string().min(1),
+	scope: z.enum(['user', 'app', 'session']).optional(),
+	required: z.boolean().optional(),
+})
+
+export type PackageSecretMountDefinition = z.infer<
+	typeof packageSecretMountDefinitionSchema
+>
+
+export const packageServiceModeValues = ['bounded', 'persistent'] as const
+export type PackageServiceMode = (typeof packageServiceModeValues)[number]
+
 export const packageServiceDefinitionSchema = z.object({
 	entry: z.string().min(1),
 	autoStart: z.boolean().optional(),
+	mode: z.enum(packageServiceModeValues).optional(),
 	timeoutMs: z.number().int().positive().max(300_000).optional(),
 })
 
 export type PackageServiceDefinition = z.infer<
 	typeof packageServiceDefinitionSchema
+>
+
+export const packageSubscriptionDefinitionSchema = z.object({
+	topic: z.string().min(1),
+	handler: z.string().min(1),
+	description: z.string().min(1).optional(),
+	filters: z.record(z.string().min(1), z.unknown()).optional(),
+})
+
+export type PackageSubscriptionDefinition = z.infer<
+	typeof packageSubscriptionDefinitionSchema
 >
 
 const packageExportConditionSchema = z
@@ -74,6 +99,12 @@ export const authoredPackageKodySchema = z.object({
 	description: z.string().min(1),
 	tags: z.array(z.string().min(1)).optional(),
 	searchText: z.string().min(1).optional(),
+	secretMounts: z
+		.record(z.string().min(1), packageSecretMountDefinitionSchema)
+		.optional(),
+	subscriptions: z
+		.record(z.string().min(1), packageSubscriptionDefinitionSchema)
+		.optional(),
 	app: packageAppDefinitionSchema.optional(),
 	services: z
 		.record(z.string().min(1), packageServiceDefinitionSchema)

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -24,10 +24,8 @@ vi.mock('#worker/package-registry/source.ts', () => ({
 		mockModule.loadPackageSourceBySourceId(...args),
 }))
 
-const {
-	buildKodyAppBundle,
-	createPublishedPackageAppBundleCacheKey,
-} = await import('./module-graph.ts')
+const { buildKodyAppBundle, createPublishedPackageAppBundleCacheKey } =
+	await import('./module-graph.ts')
 
 beforeEach(() => {
 	mockModule.createWorker.mockReset()
@@ -166,7 +164,9 @@ test('buildKodyModuleBundle resolves scoped package imports by full package name
 		}),
 	)
 	mockModule.getSavedPackageByKodyId.mockResolvedValue(null)
-	mockModule.loadPackageSourceBySourceId.mockResolvedValue(createLoadedPackageSource())
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue(
+		createLoadedPackageSource(),
+	)
 
 	const { buildKodyModuleBundle } = await import('./module-graph.ts')
 
@@ -298,7 +298,9 @@ test('buildKodyModuleBundle keeps dependencies for scoped packages with the same
 })
 
 test('buildKodyModuleBundle keeps virtual package paths distinct for scoped packages with the same leaf', async () => {
-	mockModule.createWorker.mockResolvedValue(createBundleResult('shared-leaf-prefix'))
+	mockModule.createWorker.mockResolvedValue(
+		createBundleResult('shared-leaf-prefix'),
+	)
 	mockModule.getSavedPackageByName.mockImplementation(
 		async (
 			_db: unknown,
@@ -396,7 +398,9 @@ test('buildKodyModuleBundle keeps virtual package paths distinct for scoped pack
 })
 
 test('buildKodyModuleBundle rejects kody id shorthand imports', async () => {
-	mockModule.createWorker.mockResolvedValue(createBundleResult('kody-id-import'))
+	mockModule.createWorker.mockResolvedValue(
+		createBundleResult('kody-id-import'),
+	)
 	mockModule.getSavedPackageByName.mockResolvedValue(null)
 
 	const { buildKodyModuleBundle } = await import('./module-graph.ts')
@@ -633,7 +637,9 @@ export default {
 })
 
 test('buildKodyAppBundle rewrites dynamic kody runtime imports inside TypeScript package apps', async () => {
-	mockModule.createWorker.mockResolvedValue(createBundleResult('ts-dynamic-app'))
+	mockModule.createWorker.mockResolvedValue(
+		createBundleResult('ts-dynamic-app'),
+	)
 
 	await buildKodyAppBundle({
 		env: {
@@ -684,7 +690,9 @@ test('buildKodyAppBundle rewrites dynamic kody runtime imports inside TypeScript
 })
 
 test('buildKodyAppBundle runtime module exports service helper', async () => {
-	mockModule.createWorker.mockResolvedValue(createBundleResult('runtime-service-helper'))
+	mockModule.createWorker.mockResolvedValue(
+		createBundleResult('runtime-service-helper'),
+	)
 
 	await buildKodyAppBundle({
 		env: {

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -3,10 +3,7 @@ import {
 	loadPackageSourceBySourceId,
 	type LoadedPackageSource,
 } from '#worker/package-registry/source.ts'
-import {
-	parseModuleSource,
-	type ModuleAstNode,
-} from '#worker/module-source.ts'
+import { parseModuleSource, type ModuleAstNode } from '#worker/module-source.ts'
 import {
 	normalizePackageWorkspacePath,
 	resolvePackageExportPath,
@@ -33,7 +30,8 @@ const runtimeModulePath = '.__kody_virtual__/runtime.js'
 const rootSourcePrefix = '.__kody_root__'
 const packageSourcePrefix = '.__kody_packages__'
 const packageImportProxyPrefix = '.__kody_virtual__/imports'
-const packageAppBundleCache = createPublishedPackagePromiseCache<RuntimeBundle>()
+const packageAppBundleCache =
+	createPublishedPackagePromiseCache<RuntimeBundle>()
 
 function joinPath(...parts: Array<string>) {
 	return parts
@@ -106,6 +104,7 @@ export const agentChatTurnStream = runtime.agentChatTurnStream;
 export const packageContext = runtime.packageContext ?? null;
 export const serviceContext = runtime.serviceContext ?? null;
 export const service = runtime.service ?? null;
+export const packageSecrets = runtime.packageSecrets ?? null;
 
 export default runtime;
 `.trim()
@@ -225,9 +224,9 @@ function collectLiteralImportNodes(source: string): Array<{
 			expression?: unknown
 		}
 		if (
-			(typedNode.type === 'ImportDeclaration' ||
-				typedNode.type === 'ExportAllDeclaration' ||
-				typedNode.type === 'ExportNamedDeclaration')
+			typedNode.type === 'ImportDeclaration' ||
+			typedNode.type === 'ExportAllDeclaration' ||
+			typedNode.type === 'ExportNamedDeclaration'
 		) {
 			const literalNode = readLiteralStringNode(typedNode.source)
 			if (literalNode) {
@@ -519,6 +518,7 @@ export function createPublishedBundleArtifact(input: {
 	packageContext?: {
 		packageId: string
 		kodyId: string
+		sourceId: string
 	} | null
 	serviceContext?: {
 		serviceName: string

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -26,7 +26,10 @@ import {
 	normalizePackageServiceStatus,
 	packageServiceRpc,
 } from './package-service.ts'
-import { resolvePackageMountedSecret } from '#mcp/secrets/package-access.ts'
+import {
+	isPackageSecretAccessUnavailableError,
+	resolvePackageMountedSecret,
+} from '#mcp/secrets/package-access.ts'
 
 const packageAppEntrypointName = 'PackageAppWorker'
 const packageAppRuntimeBindingName = 'KODY_RUNTIME'
@@ -728,11 +731,7 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 				has: true,
 			}
 		} catch (error) {
-			if (
-				error instanceof Error &&
-				(error.message.startsWith('Secret "') ||
-					error.message.startsWith('Package "'))
-			) {
+			if (isPackageSecretAccessUnavailableError(error)) {
 				return {
 					has: false,
 				}

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -110,7 +110,7 @@ function createStorageProxy(runtimeBridge, storageId) {
 			await runtimeBridge.storageClear({
 				storageId,
 			}),
-	};
+	}
 }
 
 function createAgentChatTurnStream(runtimeBridge) {
@@ -223,7 +223,9 @@ function createPackageSecretsProxy(runtimeBridge) {
 			})
 			if (typeof result?.value !== 'string') {
 				throw new Error(
-					`packageSecretGet returned invalid response for alias "${normalizedAlias}".`,
+					'packageSecretGet returned invalid response for alias "' +
+						normalizedAlias +
+						'".',
 				)
 			}
 			return result.value
@@ -239,7 +241,9 @@ function createPackageSecretsProxy(runtimeBridge) {
 			})
 			if (typeof result?.has !== 'boolean') {
 				throw new Error(
-					`packageSecretHas returned invalid response for alias "${normalizedAlias}".`,
+					'packageSecretHas returned invalid response for alias "' +
+						normalizedAlias +
+						'".',
 				)
 			}
 			return result.has

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -727,10 +727,17 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 			return {
 				has: true,
 			}
-		} catch {
-			return {
-				has: false,
+		} catch (error) {
+			if (
+				error instanceof Error &&
+				(error.message.startsWith('Secret "') ||
+					error.message.startsWith('Package "'))
+			) {
+				return {
+					has: false,
+				}
 			}
+			throw error
 		}
 	}
 
@@ -929,6 +936,7 @@ export async function buildPackageAppWorker(input: {
 				__kodyPackageContext: {
 					packageId: input.savedPackage.id,
 					kodyId: input.savedPackage.kodyId,
+					sourceId: input.savedPackage.sourceId,
 				},
 			},
 			globalOutbound: workerExports?.CodemodeFetchGateway

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -221,7 +221,12 @@ function createPackageSecretsProxy(runtimeBridge) {
 			const result = await runtimeBridge.packageSecretGet({
 				alias: normalizedAlias,
 			})
-			return typeof result?.value === 'string' ? result.value : ''
+			if (typeof result?.value !== 'string') {
+				throw new Error(
+					`packageSecretGet returned invalid response for alias "${normalizedAlias}".`,
+				)
+			}
+			return result.value
 		},
 		has: async (alias) => {
 			const normalizedAlias =
@@ -232,7 +237,12 @@ function createPackageSecretsProxy(runtimeBridge) {
 			const result = await runtimeBridge.packageSecretHas({
 				alias: normalizedAlias,
 			})
-			return result?.has === true
+			if (typeof result?.has !== 'boolean') {
+				throw new Error(
+					`packageSecretHas returned invalid response for alias "${normalizedAlias}".`,
+				)
+			}
+			return result.has
 		},
 	};
 }

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -375,6 +375,21 @@ function createPackageAppEnv(env, userModule) {
 
 function createRuntime(runtimeBridge, params, packageContext) {
 	const packageId = packageContext?.packageId ?? '';
+	const packageSecrets =
+		packageId.length > 0
+			? createPackageSecretsProxy(runtimeBridge)
+			: {
+					get: async () => {
+						throw new Error(
+							'packageSecrets.get requires a package runtime context.',
+						)
+					},
+					has: async () => {
+						throw new Error(
+							'packageSecrets.has requires a package runtime context.',
+						)
+					},
+				}
 	return {
 		codemode: createCodemodeProxy(runtimeBridge),
 		params,
@@ -385,8 +400,7 @@ function createRuntime(runtimeBridge, params, packageContext) {
 		agentChatTurnStream: createAgentChatTurnStream(runtimeBridge),
 		realtime: createRealtimeProxy(runtimeBridge),
 		services: createServicesProxy(runtimeBridge),
-		packageSecrets:
-			packageId.length > 0 ? createPackageSecretsProxy(runtimeBridge) : null,
+		packageSecrets,
 		packageContext,
 	};
 }

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -26,6 +26,7 @@ import {
 	normalizePackageServiceStatus,
 	packageServiceRpc,
 } from './package-service.ts'
+import { resolvePackageMountedSecret } from '#mcp/secrets/package-access.ts'
 
 const packageAppEntrypointName = 'PackageAppWorker'
 const packageAppRuntimeBindingName = 'KODY_RUNTIME'
@@ -206,6 +207,33 @@ function createServicesProxy(runtimeBridge) {
 	};
 }
 
+function createPackageSecretsProxy(runtimeBridge) {
+	return {
+		get: async (alias) => {
+			const normalizedAlias =
+				typeof alias === 'string' ? alias.trim() : ''
+			if (!normalizedAlias) {
+				throw new Error('packageSecrets.get requires a non-empty alias.')
+			}
+			const result = await runtimeBridge.packageSecretGet({
+				alias: normalizedAlias,
+			})
+			return typeof result?.value === 'string' ? result.value : ''
+		},
+		has: async (alias) => {
+			const normalizedAlias =
+				typeof alias === 'string' ? alias.trim() : ''
+			if (!normalizedAlias) {
+				throw new Error('packageSecrets.has requires a non-empty alias.')
+			}
+			const result = await runtimeBridge.packageSecretHas({
+				alias: normalizedAlias,
+			})
+			return result?.has === true
+		},
+	};
+}
+
 function createAuthenticatedFetchHelper(runtimeBridge) {
 	return async function createAuthenticatedFetch(providerName) {
 		return async (input, init) =>
@@ -340,6 +368,8 @@ function createRuntime(runtimeBridge, params, packageContext) {
 		agentChatTurnStream: createAgentChatTurnStream(runtimeBridge),
 		realtime: createRealtimeProxy(runtimeBridge),
 		services: createServicesProxy(runtimeBridge),
+		packageSecrets:
+			packageId.length > 0 ? createPackageSecretsProxy(runtimeBridge) : null,
 		packageContext,
 	};
 }
@@ -672,10 +702,39 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 		})
 	}
 
-	async realtimeEmit(input: {
-		sessionId: string
-		data: unknown
-	}) {
+	async packageSecretGet(input: { alias: string }) {
+		const callerContext = this.createCallerContext(this.ctx.props.packageId)
+		const resolved = await resolvePackageMountedSecret({
+			env: this.env,
+			callerContext,
+			packageId: this.ctx.props.packageId,
+			alias: input.alias,
+		})
+		return {
+			value: resolved.value,
+		}
+	}
+
+	async packageSecretHas(input: { alias: string }) {
+		const callerContext = this.createCallerContext(this.ctx.props.packageId)
+		try {
+			await resolvePackageMountedSecret({
+				env: this.env,
+				callerContext,
+				packageId: this.ctx.props.packageId,
+				alias: input.alias,
+			})
+			return {
+				has: true,
+			}
+		} catch {
+			return {
+				has: false,
+			}
+		}
+	}
+
+	async realtimeEmit(input: { sessionId: string; data: unknown }) {
 		return await this.getRealtimeSessionRpc().emit(input.sessionId, input.data)
 	}
 
@@ -829,6 +888,7 @@ export async function buildPackageAppWorker(input: {
 					packageContext: {
 						packageId: input.savedPackage.id,
 						kodyId: input.savedPackage.kodyId,
+						sourceId: input.savedPackage.sourceId,
 					},
 				}),
 				kvKey,

--- a/packages/worker/src/package-runtime/package-service.node.test.ts
+++ b/packages/worker/src/package-runtime/package-service.node.test.ts
@@ -82,8 +82,9 @@ test('package service runtime refreshes manifest-backed service settings for ala
 	)
 	expect(fileText).toContain("'timeoutMs' in overrides")
 	expect(fileText).toContain("'mode' in overrides")
+	expect(fileText).toContain('const binding =')
 	expect(fileText).toContain(
-		'const binding = loaded?.resolvedBinding ?? this.stateSnapshot.binding ?? input.binding',
+		'loaded?.resolvedBinding ?? this.stateSnapshot.binding ?? input.binding',
 	)
 	expect(fileText).toContain(
 		'loaded = await this.initializeBinding(input.binding, {',
@@ -104,8 +105,9 @@ test('package service runtime schedules auto-start on save path instead of read-
 	expect(fileText).toContain('options?.armAutoStart')
 	expect(fileText).toContain('armAutoStart: true')
 	expect(fileText).toContain("source: 'auto-start'")
+	expect(fileText).toContain('const binding =')
 	expect(fileText).toContain(
-		'const binding = loaded?.resolvedBinding ?? this.stateSnapshot.binding ?? input.binding',
+		'loaded?.resolvedBinding ?? this.stateSnapshot.binding ?? input.binding',
 	)
 	expect(fileText).toContain('options?.armAutoStart &&')
 })

--- a/packages/worker/src/package-runtime/package-service.node.test.ts
+++ b/packages/worker/src/package-runtime/package-service.node.test.ts
@@ -33,13 +33,11 @@ test('package service runtime preserves explicit stop requests after a run ends'
 	expect(fileText).toContain(
 		'const stopRequested = this.stateSnapshot.stopRequested',
 	)
+	expect(fileText).toContain('this.stateSnapshot.stopRequested = false')
+	expect(fileText).toContain('await this.finalizeServiceRun({')
 	expect(fileText).toContain(
-		'this.stateSnapshot.stopRequested = false',
+		'if (stopRequested) {\n\t\t\tawait this.clearAlarm()',
 	)
-	expect(fileText).toContain(
-		'await this.finalizeServiceRun({',
-	)
-	expect(fileText).toContain("if (stopRequested) {\n\t\t\tawait this.clearAlarm()")
 	expect(fileText).toContain('!this.stateSnapshot.stopRequested')
 })
 
@@ -62,9 +60,7 @@ test('package service runtime re-arms auto-start after unplanned exit', async ()
 	expect(fileText).toContain('buildPackageServiceRetryTime()')
 	expect(fileText).toContain('runAt: buildPackageServiceRetryTime(),')
 	expect(fileText).toContain("source: 'auto-start'")
-	expect(fileText).toContain(
-		"this.stateSnapshot.status = 'error'",
-	)
+	expect(fileText).toContain("this.stateSnapshot.status = 'error'")
 	expect(fileText).toContain(
 		'this.stateSnapshot.autoStart &&\n\t\t\t\t!this.stateSnapshot.stopRequested &&\n\t\t\t\t!this.stateSnapshot.nextAlarmAt',
 	)
@@ -75,11 +71,17 @@ test('package service runtime refreshes manifest-backed service settings for ala
 		fs.readFile(new URL('./package-service.ts', import.meta.url), 'utf8'),
 	)
 	expect(fileText).toContain('const loaded = await loadSavedPackageService({')
-	expect(fileText).toContain('this.stateSnapshot.binding = loaded.resolvedBinding')
+	expect(fileText).toContain(
+		'this.stateSnapshot.binding = loaded.resolvedBinding',
+	)
+	expect(fileText).toContain(
+		"this.stateSnapshot.mode = loaded.serviceDefinition?.mode ?? 'bounded'",
+	)
 	expect(fileText).toContain(
 		'this.stateSnapshot.timeoutMs = loaded.serviceDefinition?.timeoutMs ?? null',
 	)
 	expect(fileText).toContain("'timeoutMs' in overrides")
+	expect(fileText).toContain("'mode' in overrides")
 	expect(fileText).toContain(
 		'const binding = loaded?.resolvedBinding ?? this.stateSnapshot.binding ?? input.binding',
 	)
@@ -105,8 +107,24 @@ test('package service runtime schedules auto-start on save path instead of read-
 	expect(fileText).toContain(
 		'const binding = loaded?.resolvedBinding ?? this.stateSnapshot.binding ?? input.binding',
 	)
+	expect(fileText).toContain('options?.armAutoStart &&')
+})
+
+test('package service runtime exposes persistent mode and removes executor timeout for persistent services', async () => {
+	const fileText = await import('node:fs/promises').then((fs) =>
+		fs.readFile(new URL('./package-service.ts', import.meta.url), 'utf8'),
+	)
+	expect(fileText).toContain("mode: 'bounded' | 'persistent'")
 	expect(fileText).toContain(
-		'options?.armAutoStart &&',
+		"this.stateSnapshot.mode = loaded.serviceDefinition?.mode ?? 'bounded'",
+	)
+	expect(fileText).toContain(
+		"mode: loaded.serviceDefinition?.mode ?? 'bounded'",
+	)
+	expect(fileText).toContain("loaded.serviceDefinition?.mode === 'persistent'")
+	expect(fileText).toContain('? (null as unknown as number)')
+	expect(fileText).toContain(
+		': (loaded.serviceDefinition?.timeoutMs ?? 300_000)',
 	)
 })
 

--- a/packages/worker/src/package-runtime/package-service.node.test.ts
+++ b/packages/worker/src/package-runtime/package-service.node.test.ts
@@ -87,6 +87,9 @@ test('package service runtime refreshes manifest-backed service settings for ala
 		'loaded?.resolvedBinding ?? this.stateSnapshot.binding ?? input.binding',
 	)
 	expect(fileText).toContain(
+		"mode: loaded?.serviceDefinition?.mode ?? this.stateSnapshot.mode",
+	)
+	expect(fileText).toContain(
 		'loaded = await this.initializeBinding(input.binding, {',
 	)
 	expect(fileText).toContain('this.buildServiceStatusResponse(')
@@ -124,7 +127,7 @@ test('package service runtime exposes persistent mode and removes executor timeo
 		"mode: loaded.serviceDefinition?.mode ?? 'bounded'",
 	)
 	expect(fileText).toContain("loaded.serviceDefinition?.mode === 'persistent'")
-	expect(fileText).toContain('? (null as unknown as number)')
+	expect(fileText).toContain('? null')
 	expect(fileText).toContain(
 		': (loaded.serviceDefinition?.timeoutMs ?? 300_000)',
 	)

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -25,6 +25,7 @@ export type PackageServiceBindingState = {
 type PackageServiceState = {
 	binding: PackageServiceBindingState | null
 	autoStart: boolean
+	mode: 'bounded' | 'persistent'
 	timeoutMs: number | null
 	stopRequested: boolean
 	currentRunId: string | null
@@ -81,6 +82,7 @@ function createInitialPackageServiceState(): PackageServiceState {
 	return {
 		binding: null,
 		autoStart: false,
+		mode: 'bounded',
 		timeoutMs: null,
 		stopRequested: false,
 		currentRunId: null,
@@ -143,7 +145,9 @@ async function loadSavedPackageService(input: {
 		packageId: input.binding.packageId,
 	})
 	if (!savedPackage) {
-		throw new Error('Saved package was not found for package service operations.')
+		throw new Error(
+			'Saved package was not found for package service operations.',
+		)
 	}
 	const packageSource = await loadPackageSourceBySourceId({
 		env: input.env,
@@ -197,7 +201,8 @@ function buildPackageServiceRetryTime() {
 }
 
 class PackageServiceInstanceBase extends DurableObject<Env> {
-	private stateSnapshot: PackageServiceState = createInitialPackageServiceState()
+	private stateSnapshot: PackageServiceState =
+		createInitialPackageServiceState()
 	private activeRunPromise: Promise<void> | null = null
 
 	constructor(state: DurableObjectState, env: Env) {
@@ -208,8 +213,9 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 	}
 
 	private async restoreState() {
-		const stored =
-			await this.ctx.storage.get<PackageServiceState>(serviceStateStorageKey)
+		const stored = await this.ctx.storage.get<PackageServiceState>(
+			serviceStateStorageKey,
+		)
 		if (!stored) return
 		this.stateSnapshot = stored
 		if (
@@ -314,6 +320,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		binding: PackageServiceBindingState,
 		overrides?: {
 			autoStart?: boolean
+			mode?: 'bounded' | 'persistent'
 			timeoutMs?: number | null
 		},
 	) {
@@ -321,6 +328,10 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 			overrides && 'autoStart' in overrides
 				? overrides.autoStart
 				: this.stateSnapshot.autoStart
+		const mode =
+			overrides && 'mode' in overrides
+				? overrides.mode
+				: this.stateSnapshot.mode
 		const timeoutMs =
 			overrides && 'timeoutMs' in overrides
 				? overrides.timeoutMs
@@ -331,6 +342,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 			service_name: binding.serviceName,
 			status: this.stateSnapshot.status,
 			auto_start: autoStart,
+			mode,
 			timeout_ms: timeoutMs,
 			stop_requested: this.stateSnapshot.stopRequested,
 			active_run_id: this.stateSnapshot.currentRunId,
@@ -366,6 +378,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		if (stopRequested) {
 			await this.clearAlarm()
 		} else if (
+			this.stateSnapshot.mode !== 'persistent' &&
 			this.stateSnapshot.autoStart &&
 			!this.stateSnapshot.nextAlarmAt
 		) {
@@ -393,13 +406,16 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 				input.binding.serviceName,
 			)
 			this.stateSnapshot.binding = loaded.resolvedBinding
-			this.stateSnapshot.autoStart = loaded.serviceDefinition?.autoStart ?? false
+			this.stateSnapshot.autoStart =
+				loaded.serviceDefinition?.autoStart ?? false
+			this.stateSnapshot.mode = loaded.serviceDefinition?.mode ?? 'bounded'
 			this.stateSnapshot.timeoutMs = loaded.serviceDefinition?.timeoutMs ?? null
 			await this.persistState()
 			const result = await this.runService(loaded.resolvedBinding, {
 				getStatus: async () =>
 					this.buildServiceStatusResponse(loaded.resolvedBinding, {
 						autoStart: loaded.serviceDefinition?.autoStart ?? false,
+						mode: loaded.serviceDefinition?.mode ?? 'bounded',
 						timeoutMs: loaded.serviceDefinition?.timeoutMs ?? null,
 					}),
 				shouldStop: async () => this.stateSnapshot.stopRequested,
@@ -408,14 +424,16 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 						runAt,
 						source: 'service',
 					})) as { ok: true; scheduled_at: string },
-				clearAlarm: async () =>
-					(await this.clearAlarm()) as { ok: true },
+				clearAlarm: async () => (await this.clearAlarm()) as { ok: true },
 				packageContext: {
 					packageId: loaded.savedPackage.id,
 					kodyId: loaded.savedPackage.kodyId,
 				},
 				loaded,
-				executorTimeoutMs: loaded.serviceDefinition?.timeoutMs ?? 300_000,
+				executorTimeoutMs:
+					loaded.serviceDefinition?.mode === 'persistent'
+						? (null as unknown as number)
+						: (loaded.serviceDefinition?.timeoutMs ?? 300_000),
 				storageId,
 			})
 			await this.finalizeServiceRun({
@@ -441,9 +459,13 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 	private async runService(
 		binding: PackageServiceBindingState,
 		runtime: {
-			getStatus: () => Promise<ReturnType<PackageServiceInstanceBase['buildServiceStatusResponse']>>
+			getStatus: () => Promise<
+				ReturnType<PackageServiceInstanceBase['buildServiceStatusResponse']>
+			>
 			shouldStop: () => Promise<boolean>
-			setAlarm: (runAt: Date | string) => Promise<{ ok: true; scheduled_at: string }>
+			setAlarm: (
+				runAt: Date | string,
+			) => Promise<{ ok: true; scheduled_at: string }>
 			clearAlarm: () => Promise<{ ok: true }>
 			packageContext: {
 				packageId: string
@@ -454,12 +476,15 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 			storageId: string
 		},
 	) {
-		const [{ runBundledModuleWithRegistry }, { buildKodyModuleBundle }, { loadPublishedBundleArtifactByIdentity }] =
-			await Promise.all([
-				import('#mcp/run-codemode-registry.ts'),
-				import('./module-graph.ts'),
-				import('./published-bundle-artifacts.ts'),
-			])
+		const [
+			{ runBundledModuleWithRegistry },
+			{ buildKodyModuleBundle },
+			{ loadPublishedBundleArtifactByIdentity },
+		] = await Promise.all([
+			import('#mcp/run-codemode-registry.ts'),
+			import('./module-graph.ts'),
+			import('./published-bundle-artifacts.ts'),
+		])
 		const artifact = await loadPublishedBundleArtifactByIdentity({
 			env: this.env,
 			userId: binding.userId,
@@ -546,7 +571,8 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 			return Response.json({
 				ok: true,
 				run_id: this.stateSnapshot.currentRunId,
-				started_at: this.stateSnapshot.lastStartedAt ?? new Date().toISOString(),
+				started_at:
+					this.stateSnapshot.lastStartedAt ?? new Date().toISOString(),
 				status: 'running',
 				already_running: true,
 			} satisfies PackageServiceRunResult)
@@ -586,11 +612,14 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		} catch {
 			loaded = undefined
 		}
-		const binding = loaded?.resolvedBinding ?? this.stateSnapshot.binding ?? input.binding
+		const binding =
+			loaded?.resolvedBinding ?? this.stateSnapshot.binding ?? input.binding
 		return Response.json(
 			this.buildServiceStatusResponse(binding, {
-				autoStart: loaded?.serviceDefinition?.autoStart ?? this.stateSnapshot.autoStart,
-				timeoutMs: loaded?.serviceDefinition?.timeoutMs ?? this.stateSnapshot.timeoutMs,
+				autoStart:
+					loaded?.serviceDefinition?.autoStart ?? this.stateSnapshot.autoStart,
+				timeoutMs:
+					loaded?.serviceDefinition?.timeoutMs ?? this.stateSnapshot.timeoutMs,
 			}),
 		)
 	}
@@ -620,9 +649,9 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 
 	async fetch(request: Request) {
 		const url = new URL(request.url)
-		const body = (await request.json().catch(() => null)) as
-			| { binding?: PackageServiceBindingState }
-			| null
+		const body = (await request.json().catch(() => null)) as {
+			binding?: PackageServiceBindingState
+		} | null
 		const binding = body?.binding
 		if (!binding) {
 			return new Response('Missing package service binding.', { status: 400 })
@@ -653,9 +682,10 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 				binding,
 			})
 			this.stateSnapshot.binding = loaded.resolvedBinding
-			this.stateSnapshot.autoStart = loaded.serviceDefinition?.autoStart ?? false
-			this.stateSnapshot.timeoutMs =
-				loaded.serviceDefinition?.timeoutMs ?? null
+			this.stateSnapshot.autoStart =
+				loaded.serviceDefinition?.autoStart ?? false
+			this.stateSnapshot.mode = loaded.serviceDefinition?.mode ?? 'bounded'
+			this.stateSnapshot.timeoutMs = loaded.serviceDefinition?.timeoutMs ?? null
 			await this.persistState()
 			if (
 				!this.stateSnapshot.stopRequested &&

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -430,6 +430,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 				packageContext: {
 					packageId: loaded.savedPackage.id,
 					kodyId: loaded.savedPackage.kodyId,
+					sourceId: loaded.savedPackage.sourceId,
 				},
 				loaded,
 				executorTimeoutMs:
@@ -472,6 +473,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 			packageContext: {
 				packageId: string
 				kodyId: string
+				sourceId: string
 			}
 			loaded: Awaited<ReturnType<typeof loadSavedPackageService>>
 			executorTimeoutMs: number | null

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -53,6 +53,7 @@ export const packageServiceStatusSchema = z.object({
 	service_name: z.string(),
 	status: z.enum(['idle', 'running', 'stopping', 'stopped', 'error']),
 	auto_start: z.boolean(),
+	mode: z.enum(['bounded', 'persistent']),
 	timeout_ms: z.number().int().positive().nullable(),
 	stop_requested: z.boolean(),
 	active_run_id: z.string().nullable(),
@@ -268,6 +269,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		})
 		this.stateSnapshot.binding = loaded.resolvedBinding
 		this.stateSnapshot.autoStart = loaded.serviceDefinition?.autoStart ?? false
+		this.stateSnapshot.mode = loaded.serviceDefinition?.mode ?? 'bounded'
 		this.stateSnapshot.timeoutMs = loaded.serviceDefinition?.timeoutMs ?? null
 		await this.persistState()
 		if (
@@ -432,7 +434,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 				loaded,
 				executorTimeoutMs:
 					loaded.serviceDefinition?.mode === 'persistent'
-						? (null as unknown as number)
+						? null
 						: (loaded.serviceDefinition?.timeoutMs ?? 300_000),
 				storageId,
 			})
@@ -472,7 +474,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 				kodyId: string
 			}
 			loaded: Awaited<ReturnType<typeof loadSavedPackageService>>
-			executorTimeoutMs: number
+			executorTimeoutMs: number | null
 			storageId: string
 		},
 	) {
@@ -618,6 +620,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 			this.buildServiceStatusResponse(binding, {
 				autoStart:
 					loaded?.serviceDefinition?.autoStart ?? this.stateSnapshot.autoStart,
+				mode: loaded?.serviceDefinition?.mode ?? this.stateSnapshot.mode,
 				timeoutMs:
 					loaded?.serviceDefinition?.timeoutMs ?? this.stateSnapshot.timeoutMs,
 			}),

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -218,7 +218,10 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 			serviceStateStorageKey,
 		)
 		if (!stored) return
-		this.stateSnapshot = stored
+		this.stateSnapshot = {
+			...createInitialPackageServiceState(),
+			...stored,
+		}
 		if (
 			this.stateSnapshot.currentRunId &&
 			(this.stateSnapshot.status === 'running' ||

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -380,8 +380,9 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		if (stopRequested) {
 			await this.clearAlarm()
 		} else if (
-			this.stateSnapshot.mode !== 'persistent' &&
 			this.stateSnapshot.autoStart &&
+			(this.stateSnapshot.mode !== 'persistent' ||
+				input.nextStatus === 'error') &&
 			!this.stateSnapshot.nextAlarmAt
 		) {
 			await this.scheduleAlarm({

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.ts
@@ -80,7 +80,9 @@ async function resolveDependencyForPackage(input: {
 		specifier: parsed,
 	})
 	if (!row) {
-		throw new Error(`Saved package "${parsed.packageName}" was not found for this user.`)
+		throw new Error(
+			`Saved package "${parsed.packageName}" was not found for this user.`,
+		)
 	}
 	const source = await getEntitySourceById(input.state.env.APP_DB, row.sourceId)
 	if (!source?.published_commit) {
@@ -147,8 +149,13 @@ function toDbRowInput(input: {
 	}
 }
 
-export async function persistPublishedBundleArtifact(input: PersistPublishedBundleArtifactInput) {
-	if (!input.source.published_commit || !hasPublishedRuntimeArtifacts(input.env)) {
+export async function persistPublishedBundleArtifact(
+	input: PersistPublishedBundleArtifactInput,
+) {
+	if (
+		!input.source.published_commit ||
+		!hasPublishedRuntimeArtifacts(input.env)
+	) {
 		return null
 	}
 	const artifactName = normalizeArtifactName(input.artifactName)
@@ -174,13 +181,16 @@ export async function persistPublishedBundleArtifact(input: PersistPublishedBund
 		serviceContext: null,
 		createdAt: new Date().toISOString(),
 	}
-	const existing = await getPublishedBundleArtifactByIdentity(input.env.APP_DB, {
-		userId: input.userId,
-		sourceId: input.source.id,
-		artifactKind: input.kind,
-		artifactName,
-		entryPoint,
-	})
+	const existing = await getPublishedBundleArtifactByIdentity(
+		input.env.APP_DB,
+		{
+			userId: input.userId,
+			sourceId: input.source.id,
+			artifactKind: input.kind,
+			artifactName,
+			entryPoint,
+		},
+	)
 	const rowInput = toDbRowInput({
 		userId: input.userId,
 		sourceId: input.source.id,
@@ -256,16 +266,12 @@ export async function rebuildPublishedPackageArtifacts(input: {
 	savedPackage: SavedPackageRecord
 	manifest: AuthoredPackageJson
 	files: Record<string, string>
-	buildAppBundle: (args: {
-		entryPoint: string
-	}) => Promise<{
+	buildAppBundle: (args: { entryPoint: string }) => Promise<{
 		mainModule: string
 		modules: WorkerLoaderModules
 		dependencies?: Array<BundleArtifactDependency>
 	}>
-	buildModuleBundle: (args: {
-		entryPoint: string
-	}) => Promise<{
+	buildModuleBundle: (args: { entryPoint: string }) => Promise<{
 		mainModule: string
 		modules: WorkerLoaderModules
 		dependencies?: Array<BundleArtifactDependency>
@@ -292,6 +298,7 @@ export async function rebuildPublishedPackageArtifacts(input: {
 				packageContext: {
 					packageId: input.savedPackage.id,
 					kodyId: input.savedPackage.kodyId,
+					sourceId: input.savedPackage.sourceId,
 				},
 			})
 		}
@@ -313,6 +320,7 @@ export async function rebuildPublishedPackageArtifacts(input: {
 			packageContext: {
 				packageId: input.savedPackage.id,
 				kodyId: input.savedPackage.kodyId,
+				sourceId: input.savedPackage.sourceId,
 			},
 		})
 	}
@@ -322,7 +330,7 @@ export async function rebuildPublishedPackageArtifacts(input: {
 		const entryPoint =
 			typeof exportTarget === 'string'
 				? exportTarget
-				: exportTarget.import ?? exportTarget.default ?? null
+				: (exportTarget.import ?? exportTarget.default ?? null)
 		if (!entryPoint) continue
 		const bundle = await input.buildModuleBundle({
 			entryPoint,
@@ -340,12 +348,15 @@ export async function rebuildPublishedPackageArtifacts(input: {
 			packageContext: {
 				packageId: input.savedPackage.id,
 				kodyId: input.savedPackage.kodyId,
+				sourceId: input.savedPackage.sourceId,
 			},
 		})
 	}
 	for (const [jobName, jobDefinition] of Object.entries(
 		input.manifest.kody.jobs ?? {},
-	) as Array<[string, NonNullable<AuthoredPackageJson['kody']['jobs']>[string]]>) {
+	) as Array<
+		[string, NonNullable<AuthoredPackageJson['kody']['jobs']>[string]]
+	>) {
 		const bundle = await input.buildModuleBundle({
 			entryPoint: jobDefinition.entry,
 		})
@@ -362,6 +373,7 @@ export async function rebuildPublishedPackageArtifacts(input: {
 			packageContext: {
 				packageId: input.savedPackage.id,
 				kodyId: input.savedPackage.kodyId,
+				sourceId: input.savedPackage.sourceId,
 			},
 		})
 	}

--- a/packages/worker/src/package-runtime/published-runtime-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-runtime-artifacts.ts
@@ -429,6 +429,12 @@ export async function readPublishedBundleArtifact(input: {
 	}
 	return {
 		...artifact,
+		packageContext: artifact.packageContext
+			? {
+					...artifact.packageContext,
+					sourceId: artifact.packageContext.sourceId ?? artifact.sourceId,
+				}
+			: null,
 		serviceContext: artifact.serviceContext ?? null,
 		modules: deserializeWorkerLoaderModules(artifact.modules),
 	} satisfies PublishedBundleArtifact

--- a/packages/worker/src/package-runtime/published-runtime-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-runtime-artifacts.ts
@@ -62,6 +62,7 @@ export type PublishedBundleArtifact = {
 	packageContext: {
 		packageId: string
 		kodyId: string
+		sourceId: string
 	} | null
 	serviceContext: {
 		serviceName: string
@@ -78,7 +79,8 @@ type StoredPublishedBundleArtifact = Omit<
 }
 
 function getBundleArtifactsKv(env: Env) {
-	const kv = (env as Env & { BUNDLE_ARTIFACTS_KV?: KVNamespace }).BUNDLE_ARTIFACTS_KV
+	const kv = (env as Env & { BUNDLE_ARTIFACTS_KV?: KVNamespace })
+		.BUNDLE_ARTIFACTS_KV
 	if (!kv) {
 		throw new Error(
 			'Missing BUNDLE_ARTIFACTS_KV binding for published runtime artifacts.',
@@ -358,7 +360,10 @@ export async function persistPublishedSourceManifestSnapshot(input: {
 		sourceId: input.source.id,
 		publishedCommit: input.source.published_commit,
 	})
-	await getBundleArtifactsKv(input.env).put(key, JSON.stringify(manifestSnapshot))
+	await getBundleArtifactsKv(input.env).put(
+		key,
+		JSON.stringify(manifestSnapshot),
+	)
 	return key
 }
 

--- a/packages/worker/src/package-runtime/realtime-session.node.test.ts
+++ b/packages/worker/src/package-runtime/realtime-session.node.test.ts
@@ -15,7 +15,8 @@ vi.mock('#mcp/context.ts', () => ({
 }))
 
 vi.mock('#mcp/app-runner-facet-names.ts', () => ({
-	buildFacetName: (...args: Array<unknown>) => mockModule.buildFacetName(...args),
+	buildFacetName: (...args: Array<unknown>) =>
+		mockModule.buildFacetName(...args),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -38,10 +39,8 @@ vi.mock('./package-app.ts', () => ({
 		mockModule.buildPackageAppWorker(...args),
 }))
 
-const {
-	PackageRealtimeSession,
-	resolvePackageAppWorkerCacheKey,
-} = await import('./realtime-session.ts')
+const { PackageRealtimeSession, resolvePackageAppWorkerCacheKey } =
+	await import('./realtime-session.ts')
 
 test('resolvePackageAppWorkerCacheKey includes latest published commit when available', async () => {
 	mockModule.getEntitySourceById.mockReset()

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -347,7 +347,10 @@ export async function resolvePackageAppWorkerCacheKey(input: {
 	env: Pick<Env, 'APP_DB'>
 	binding: PackageRealtimeBindingState
 }) {
-	const source = await getEntitySourceById(input.env.APP_DB, input.binding.sourceId)
+	const source = await getEntitySourceById(
+		input.env.APP_DB,
+		input.binding.sourceId,
+	)
 	if (!source || source.user_id !== input.binding.userId) {
 		throw new Error('Saved package source was not found.')
 	}
@@ -364,13 +367,11 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 	private stateSnapshot: PackageRealtimeState = createInitialState()
 	private sessionIds = new WeakMap<WebSocket, string | null>()
 	private cachedAppWorkerKey: string | null = null
-	private cachedAppWorkerKeyLookup:
-		| {
-				bindingIdentity: string
-				cacheKey: string
-				expiresAt: number
-		  }
-		| null = null
+	private cachedAppWorkerKeyLookup: {
+		bindingIdentity: string
+		cacheKey: string
+		expiresAt: number
+	} | null = null
 	private cachedAppWorkerPromise: Promise<
 		Awaited<ReturnType<typeof buildPackageAppWorker>>
 	> | null = null
@@ -383,8 +384,9 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 	}
 
 	private async restoreState() {
-		const stored =
-			await this.ctx.storage.get<PackageRealtimeState>(sessionStateStorageKey)
+		const stored = await this.ctx.storage.get<PackageRealtimeState>(
+			sessionStateStorageKey,
+		)
 		if (!stored) return
 		this.stateSnapshot = {
 			binding: stored.binding ?? null,
@@ -423,7 +425,9 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		}
 	}
 
-	private async getCachedPackageAppWorker(binding: PackageRealtimeBindingState) {
+	private async getCachedPackageAppWorker(
+		binding: PackageRealtimeBindingState,
+	) {
 		const cacheKey = await this.getResolvedPackageAppWorkerCacheKey(binding)
 		if (this.cachedAppWorkerKey !== cacheKey || !this.cachedAppWorkerPromise) {
 			this.cachedAppWorkerKey = cacheKey
@@ -544,10 +548,7 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		let deliveredCount = 0
 		const sessionIds: Array<string> = []
 		for (const session of sessions) {
-			const delivered = await this.emitToSession(
-				session.session_id,
-				input.data,
-			)
+			const delivered = await this.emitToSession(session.session_id, input.data)
 			if (delivered.delivered) {
 				deliveredCount += 1
 				sessionIds.push(session.session_id)
@@ -564,7 +565,9 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		payload: PackageRealtimeHookInput
 	}) {
 		const appWorker = await this.getCachedPackageAppWorker(input.binding)
-		const entrypoint = appWorker.stub.getEntrypoint(appWorker.entrypointName) as {
+		const entrypoint = appWorker.stub.getEntrypoint(
+			appWorker.entrypointName,
+		) as {
 			handleRealtimeEvent?: (
 				payload: PackageRealtimeHookInput & PackageRealtimeHookContext,
 			) => Promise<PackageRealtimeHookResult>
@@ -698,9 +701,9 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		}
 
 		if (request.method === 'POST' && url.pathname.endsWith('/sessions')) {
-			const body = (await request.json().catch(() => null)) as
-				| PackageRealtimeListPayload
-				| null
+			const body = (await request
+				.json()
+				.catch(() => null)) as PackageRealtimeListPayload | null
 			if (!body) {
 				return Response.json({ sessions: [] })
 			}
@@ -716,9 +719,7 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		if (request.method === 'POST' && url.pathname.endsWith('/emit')) {
 			const body = (await request.json()) as PackageRealtimeEmitPayload
 			await this.initializeBinding(body.binding)
-			return Response.json(
-				await this.emitToSession(body.sessionId, body.data),
-			)
+			return Response.json(await this.emitToSession(body.sessionId, body.data))
 		}
 
 		if (request.method === 'POST' && url.pathname.endsWith('/broadcast')) {
@@ -960,7 +961,10 @@ export function packageRealtimeSessionRpc(input: {
 			)
 			return (await response.json()) as PackageRealtimeListResult
 		},
-		async disconnect(sessionId: string, input2?: { code?: number; reason?: string }) {
+		async disconnect(
+			sessionId: string,
+			input2?: { code?: number; reason?: string },
+		) {
 			const response = await stub.fetch(
 				new Request('https://package-realtime.invalid/session/disconnect', {
 					method: 'POST',

--- a/packages/worker/src/package-runtime/realtime-session.workers.test.ts
+++ b/packages/worker/src/package-runtime/realtime-session.workers.test.ts
@@ -1,15 +1,20 @@
 import { env } from 'cloudflare:workers'
 import { runInDurableObject } from 'cloudflare:test'
 import { expect, test } from 'vitest'
-import { packageRealtimeSessionRpc, PackageRealtimeSession } from './realtime-session.ts'
+import {
+	packageRealtimeSessionRpc,
+	PackageRealtimeSession,
+} from './realtime-session.ts'
 
-function createBinding(overrides?: Partial<{
-	userId: string
-	packageId: string
-	kodyId: string
-	sourceId: string
-	baseUrl: string
-}>) {
+function createBinding(
+	overrides?: Partial<{
+		userId: string
+		packageId: string
+		kodyId: string
+		sourceId: string
+		baseUrl: string
+	}>,
+) {
 	return {
 		env,
 		userId: overrides?.userId ?? 'user-1',
@@ -24,18 +29,18 @@ test('package realtime session DO can list, emit, and broadcast with no active s
 	const rpc = packageRealtimeSessionRpc(createBinding())
 
 	await expect(rpc.listSessions()).resolves.toEqual({ sessions: [] })
-	await expect(
-		rpc.emit('missing-session', { type: 'hello' }),
-	).resolves.toEqual({
-		delivered: false,
-		reason: 'session_not_connected',
-	})
-	await expect(
-		rpc.broadcast({ data: { type: 'broadcast' } }),
-	).resolves.toEqual({
-		deliveredCount: 0,
-		sessionIds: [],
-	})
+	await expect(rpc.emit('missing-session', { type: 'hello' })).resolves.toEqual(
+		{
+			delivered: false,
+			reason: 'session_not_connected',
+		},
+	)
+	await expect(rpc.broadcast({ data: { type: 'broadcast' } })).resolves.toEqual(
+		{
+			deliveredCount: 0,
+			sessionIds: [],
+		},
+	)
 })
 
 test('package realtime session DO is addressable as a durable object', async () => {
@@ -113,7 +118,9 @@ test('package realtime session broadcast skips sessions whose send throws', asyn
 				facet?: string | null
 				topic?: string | null
 			}) => Array<{ session_id: string }>
-			getSocketBySessionId: (sessionId: string) => { send: (data: string) => void }
+			getSocketBySessionId: (sessionId: string) => {
+				send: (data: string) => void
+			}
 			stateSnapshot: {
 				sessions: Record<string, { id: string }>
 			}

--- a/packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts
+++ b/packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts
@@ -73,9 +73,7 @@ async function startCloudflareMock(token: string) {
 	}
 }
 
-test(
-	'Cloudflare mock implements the Artifacts REST workflow used in local dev',
-	async () => {
+test('Cloudflare mock implements the Artifacts REST workflow used in local dev', async () => {
 	const token = `cloudflare-artifacts-mock-token-${crypto.randomUUID()}`
 	const repoName = `repo-${crypto.randomUUID()}`
 	const forkName = `repo-copy-${crypto.randomUUID()}`
@@ -151,6 +149,4 @@ test(
 		artifactRepoCount?: number
 	}
 	expect(meta.artifactRepoCount).toBe(2)
-	},
-	40_000,
-)
+}, 40_000)

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -200,6 +200,12 @@ declare function createAuthenticatedFetch(
 declare function agentChatTurnStream(input: KodyCapabilityArgs): AsyncIterable<unknown>;
 declare const packageContext: { packageId: string; kodyId: string } | null;
 declare const serviceContext: { serviceName: string } | null;
+declare const packageSecrets:
+  | {
+      get(alias: string): Promise<string>;
+      has(alias: string): Promise<boolean>;
+    }
+  | null;
 declare const service:
   | {
       getStatus(): Promise<unknown>;
@@ -339,7 +345,8 @@ export async function typecheckPackageEntrypointsFromSourceFiles(input: {
 	ok: boolean
 	message: string
 }> {
-	const { createFileSystemSnapshot } = await import('@cloudflare/worker-bundler')
+	const { createFileSystemSnapshot } =
+		await import('@cloudflare/worker-bundler')
 	const snapshot = await createFileSystemSnapshot(
 		(async function* () {
 			for (const [path, content] of Object.entries(input.sourceFiles)) {
@@ -374,9 +381,11 @@ export async function typecheckPackageEntrypointsFromSourceFiles(input: {
 		repoChecksSyntheticTsconfigPath,
 		buildRepoChecksTsconfig(baseTsconfig),
 	)
-	const { fileSystem, languageService } = await createTypescriptLanguageService({
-		fileSystem: typecheckFileSystem,
-	})
+	const { fileSystem, languageService } = await createTypescriptLanguageService(
+		{
+			fileSystem: typecheckFileSystem,
+		},
+	)
 	const diagnostics = getPackageTypecheckDiagnostics({
 		targets: input.entryPoints.map((entryPoint) => ({
 			path: entryPoint.path,
@@ -535,4 +544,3 @@ export async function runRepoChecks(input: {
 		manifest,
 	}
 }
-

--- a/packages/worker/src/repo/published-source.node.test.ts
+++ b/packages/worker/src/repo/published-source.node.test.ts
@@ -30,10 +30,8 @@ vi.mock('#worker/package-runtime/published-runtime-artifacts.ts', () => ({
 		mockModule.persistPublishedSourceSnapshot(...args),
 }))
 
-const {
-	loadPublishedEntityManifest,
-	loadPublishedEntitySource,
-} = await import('./published-source.ts')
+const { loadPublishedEntityManifest, loadPublishedEntitySource } =
+	await import('./published-source.ts')
 
 function createSourceRow() {
 	return {
@@ -90,7 +88,9 @@ test('loadPublishedEntityManifest reads only manifest content from stored snapsh
 		sourceId: 'source-1',
 	})
 
-	expect(mockModule.loadPublishedSourceManifestSnapshot).toHaveBeenCalledTimes(1)
+	expect(mockModule.loadPublishedSourceManifestSnapshot).toHaveBeenCalledTimes(
+		1,
+	)
 	expect(mockModule.readMockArtifactSnapshot).not.toHaveBeenCalled()
 	expect(
 		mockModule.persistPublishedSourceManifestSnapshot,

--- a/packages/worker/src/repo/published-source.ts
+++ b/packages/worker/src/repo/published-source.ts
@@ -24,7 +24,9 @@ function freezeFiles(files: Record<string, string>) {
 	return Object.freeze({ ...files }) as Record<string, string>
 }
 
-function assertPublishedCommit(source: NonNullable<PublishedEntitySource['source']>) {
+function assertPublishedCommit(
+	source: NonNullable<PublishedEntitySource['source']>,
+) {
 	if (!source.published_commit) {
 		throw new Error(`Source "${source.id}" has no published commit.`)
 	}

--- a/tools/ci/preview-resources.ts
+++ b/tools/ci/preview-resources.ts
@@ -231,9 +231,7 @@ function deleteKvNamespace({
 
 async function ensurePreviewResources(options: CliOptions) {
 	const { d1DatabaseName, oauthKvTitle, bundleArtifactsKvTitle } =
-		buildPreviewResourceNames(
-		options.workerName,
-		)
+		buildPreviewResourceNames(options.workerName)
 	const d1 = ensureD1Database({
 		name: d1DatabaseName,
 		location: options.d1Location,
@@ -273,9 +271,7 @@ async function ensurePreviewResources(options: CliOptions) {
 
 async function cleanupPreviewResources(options: CliOptions) {
 	const { d1DatabaseName, oauthKvTitle, bundleArtifactsKvTitle } =
-		buildPreviewResourceNames(
-		options.workerName,
-		)
+		buildPreviewResourceNames(options.workerName)
 	deleteKvNamespace({ title: bundleArtifactsKvTitle, dryRun: options.dryRun })
 	deleteKvNamespace({ title: oauthKvTitle, dryRun: options.dryRun })
 	deleteD1Database({ name: d1DatabaseName, dryRun: options.dryRun })

--- a/tools/ci/production-resources.ts
+++ b/tools/ci/production-resources.ts
@@ -274,9 +274,7 @@ async function resolveProductionBindings({
 
 	const bundleArtifactsKvEntry = kvNamespaces.find((entry) => {
 		if (!entry || typeof entry !== 'object') return false
-		return (
-			(entry as Record<string, unknown>).binding === 'BUNDLE_ARTIFACTS_KV'
-		)
+		return (entry as Record<string, unknown>).binding === 'BUNDLE_ARTIFACTS_KV'
 	}) as Record<string, unknown> | undefined
 	if (!bundleArtifactsKvEntry) {
 		fail(

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -16,7 +16,10 @@ test('writeGeneratedWranglerConfig keeps migrations ordered by tag version', asy
 	const tempDir = await mkdtemp(path.join(os.tmpdir(), 'kody-resource-utils-'))
 
 	try {
-		const outConfigPath = path.join(tempDir, 'wrangler-production.generated.json')
+		const outConfigPath = path.join(
+			tempDir,
+			'wrangler-production.generated.json',
+		)
 		await writeGeneratedWranglerConfig({
 			baseConfigPath: workerWranglerConfigPath,
 			outConfigPath,
@@ -37,7 +40,9 @@ test('writeGeneratedWranglerConfig keeps migrations ordered by tag version', asy
 		const generatedConfig = parseJsonc<{
 			migrations: Array<{ tag: string; new_sqlite_classes?: Array<string> }>
 		}>(generatedConfigText)
-		const migrationTags = generatedConfig.migrations.map((migration) => migration.tag)
+		const migrationTags = generatedConfig.migrations.map(
+			(migration) => migration.tag,
+		)
 		const v12Index = migrationTags.indexOf('v12')
 		const v13Index = migrationTags.indexOf('v13')
 

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -349,7 +349,10 @@ export async function writeGeneratedWranglerConfig({
 		)
 	}
 
-	const oauthKvEntry = kvNamespaces[oauthKvEntryIndex] as Record<string, unknown>
+	const oauthKvEntry = kvNamespaces[oauthKvEntryIndex] as Record<
+		string,
+		unknown
+	>
 	kvNamespaces[oauthKvEntryIndex] = {
 		...oauthKvEntry,
 		id: oauthKvId,

--- a/tools/mcp-test-support.ts
+++ b/tools/mcp-test-support.ts
@@ -160,7 +160,9 @@ export async function startDevServer(persistDir: string) {
 		}
 	}
 
-	throw new Error('Failed to start MCP test dev servers after multiple retries.')
+	throw new Error(
+		'Failed to start MCP test dev servers after multiple retries.',
+	)
 }
 
 function isPortAlreadyInUseError(error: unknown) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add package-approved secret policy, package-only `packageSecrets`, and account UI support for package secret approvals
- extend package manifests with required `secretMounts`, persistent service mode, and declarative package subscriptions plus subscription discovery
- add core runtime/plumbing changes for persistent package services and package runtime secret access
- merge latest `main`, resolve the resulting test-only conflicts, and address valid PR review feedback around package approval flow, service mode/runtime handling, artifact compatibility, and typed package metadata

## Validation
- `npx vitest run --project node-unit "packages/worker/src/app/handlers/account-secrets.node.test.ts" "packages/worker/src/mcp/secrets/errors.node.test.ts" "packages/worker/src/mcp/secrets/package-access.node.test.ts" "packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.node.test.ts" "packages/worker/src/package-registry/manifest.node.test.ts" "packages/worker/src/package-runtime/package-service.node.test.ts" "packages/worker/src/mcp/run-codemode-registry.node.test.ts"`
- `npx vitest run --project node-unit "packages/worker/src/mcp/tools/search.node.test.ts" "packages/worker/src/package-runtime/package-service.node.test.ts"`
- `npx nx run worker:test-e2e -- e2e/account-secrets.spec.ts`
- `npm run typecheck`
- `npm run test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02642ca3-a2ca-4e8d-8e39-069a8d898b6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02642ca3-a2ca-4e8d-8e39-069a8d898b6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package-level secret allowlists, package-mounted secret access, in-app approval flows, DB migration, and package-scoped approval tokens.
  * Package subscriptions surfaced from manifests and a new listing capability.
  * Service "mode" (bounded | persistent) with adjusted runtime/executor behavior.

* **Documentation**
  * Numerous formatting and readability tweaks across contributing and user guides.

* **Refactor**
  * Execution error details now include package-approval guidance.

* **Tests**
  * Added/updated tests for package secret access, approvals, subscriptions, and related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->