### PR TITLE
Fix Kody capability search matching

### DIFF
--- a/packages/worker/src/agent-turn/tools.ts
+++ b/packages/worker/src/agent-turn/tools.ts
@@ -82,7 +82,7 @@ export async function createAgentTurnToolSet(input: {
 							}),
 					}),
 				])
-				const result = searchUnified({
+				const result = await searchUnified({
 					env: input.env,
 					query: args.query,
 					limit: args.limit ?? defaultSearchLimit,

--- a/packages/worker/src/mcp/capabilities/capability-search.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.ts
@@ -336,13 +336,20 @@ export async function searchCapabilities(input: {
 	const matches: Array<CapabilitySearchHit> = ordered.map((id) => {
 		const spec = specs[id]!
 		const base = input.detail ? toDetail(spec) : toSummary(spec)
+		const rawVectorScore = vectorScoreById[id]
+		const vectorScore =
+			rawVectorScore !== undefined && Number.isFinite(rawVectorScore)
+				? rawVectorScore
+				: 0
 		return {
 			...base,
 			fusedScore: fused.get(id) ?? 0,
 			lexicalRank: lexicalRankById.get(id),
 			vectorRank: vectorRankById.get(id),
 			lexicalScore: lexicalScoreById[id] ?? 0,
-			vectorScore: vectorScoreById[id] ?? Number.NEGATIVE_INFINITY,
+			// Keep non-finite scores internal to ranking and expose a stable numeric
+			// value on the public hit shape.
+			vectorScore,
 		}
 	})
 

--- a/packages/worker/src/mcp/capabilities/capability-search.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.ts
@@ -54,7 +54,7 @@ export function cosineSimilarity(
 
 // Keep hybrid lexical+vector scores on the same scale as lexical-only matches.
 export function blendLexicalAndVectorScore(lexical: number, vector: number) {
-	return (lexical + vector) / 2
+	return (lexical + Math.max(0, vector)) / 2
 }
 
 export function buildCapabilityEmbedText(spec: CapabilitySpec): string {
@@ -81,7 +81,7 @@ export function lexicalScore(query: string, doc: string): number {
 }
 
 export function hybridSearchScore(lexical: number, vector: number): number {
-	return (lexical + vector) / 2
+	return blendLexicalAndVectorScore(lexical, vector)
 }
 
 export function normalizeHybridSearchScore(input: {
@@ -137,6 +137,8 @@ export type CapabilitySearchHit = RankedCapabilityHit & {
 	fusedScore: number
 	lexicalRank?: number
 	vectorRank?: number
+	lexicalScore: number
+	vectorScore: number
 }
 
 function toSummary(spec: CapabilitySpec): CapabilitySummaryRow {
@@ -339,6 +341,8 @@ export async function searchCapabilities(input: {
 			fusedScore: fused.get(id) ?? 0,
 			lexicalRank: lexicalRankById.get(id),
 			vectorRank: vectorRankById.get(id),
+			lexicalScore: lexicalScoreById[id] ?? 0,
+			vectorScore: vectorScoreById[id] ?? Number.NEGATIVE_INFINITY,
 		}
 	})
 

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from 'vitest'
 import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
+import { synthesizeRemoteToolDomain } from '#mcp/capabilities/home/index.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
 import { buildConnectorValueName } from '#mcp/capabilities/values/connector-shared.ts'
 import {
 	buildSavedPackageSearchRows,
@@ -11,7 +13,7 @@ import {
 	type PackageSearchRow,
 } from './search.ts'
 
-test('searchUnified ranks mixed search rows through one shared pipeline', () => {
+test('searchUnified ranks mixed search rows through one shared pipeline', async () => {
 	const registry = buildCapabilityRegistry([
 		{
 			name: 'meta',
@@ -109,7 +111,7 @@ test('searchUnified ranks mixed search rows through one shared pipeline', () => 
 		warnings: [],
 	} satisfies OptionalSearchRowsResult
 
-	const result = searchUnified({
+	const result = await searchUnified({
 		env: {} as Env,
 		query: 'alpha\nbeta\ngamma\ndelta\nepsilon',
 		limit: 5,
@@ -288,7 +290,7 @@ test('optional search rows preserve package fallback warnings', async () => {
 	expect(result.warnings).toEqual(['fallback warning'])
 })
 
-test('searchUnified ranks related packages and connectors for operate queries', () => {
+test('searchUnified ranks related packages and connectors for operate queries', async () => {
 	const registry = buildCapabilityRegistry([])
 	const optionalRows = {
 		packageRows: [
@@ -354,7 +356,7 @@ test('searchUnified ranks related packages and connectors for operate queries', 
 		warnings: [],
 	} satisfies OptionalSearchRowsResult
 
-	const result = searchUnified({
+	const result = await searchUnified({
 		env: {} as Env,
 		query: 'play a lofi song on spotify',
 		limit: 5,
@@ -416,9 +418,9 @@ test('buildSavedPackageSearchRows falls back when package source resolution fail
 	expect(result.warnings).toHaveLength(1)
 })
 
-test('search guidance does not pair unrelated package and connector matches', () => {
+test('search guidance does not pair unrelated package and connector matches', async () => {
 	const registry = buildCapabilityRegistry([])
-	const result = searchUnified({
+	const result = await searchUnified({
 		env: {} as Env,
 		query: 'music remote',
 		limit: 5,
@@ -489,6 +491,152 @@ test('search guidance does not pair unrelated package and connector matches', ()
 	)
 	expect(result.guidance).not.toMatch(/connector\s+`github`/)
 	expect(result.guidance).not.toContain('Found saved package')
+})
+
+const runtimeLutronTools = [
+	{
+		name: 'lutron_set_zone_color',
+		title: 'Set Lutron Zone Color',
+		description: 'Set a Lutron lighting zone to a specific color.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				zoneId: { type: 'string' },
+				red: { type: 'number' },
+				green: { type: 'number' },
+				blue: { type: 'number' },
+			},
+			required: ['zoneId', 'red', 'green', 'blue'],
+		},
+	},
+	{
+		name: 'lutron_set_zone_level',
+		title: 'Set Lutron Zone Level',
+		description: 'Set a Lutron lighting zone brightness level.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				zoneId: { type: 'string' },
+				percent: { type: 'number' },
+			},
+			required: ['zoneId', 'percent'],
+		},
+	},
+	{
+		name: 'lutron_set_zone_white_tuning',
+		title: 'Set Lutron Zone White Tuning',
+		description: 'Adjust a tunable white Lutron lighting zone.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				zoneId: { type: 'string' },
+				kelvin: { type: 'number' },
+			},
+			required: ['zoneId', 'kelvin'],
+		},
+	},
+] as const
+
+async function buildHomeRegistryWithLutronCapabilities() {
+	const env = {
+		SENTRY_ENVIRONMENT: 'test',
+		HOME_CONNECTOR_SESSION: {
+			idFromName(name: string) {
+				return name
+			},
+			get() {
+				return {
+					fetch(input: string | URL | Request) {
+						const url = new URL(
+							typeof input === 'string'
+								? input
+								: input instanceof URL
+									? input.toString()
+									: input.url,
+						)
+						if (url.pathname.endsWith('/snapshot')) {
+							return Promise.resolve(
+								Response.json({
+									connectorId: 'default',
+									connectedAt: '2026-03-25T00:00:00.000Z',
+									lastSeenAt: '2026-03-25T00:00:01.000Z',
+									tools: runtimeLutronTools,
+								}),
+							)
+						}
+						throw new Error(`Unexpected fetch to ${url.pathname}`)
+					},
+				}
+			},
+		},
+	} as unknown as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		homeConnectorId: 'default',
+	})
+	const synthesized = await synthesizeRemoteToolDomain(
+		env,
+		{ kind: 'home', instanceId: 'default' },
+		[{ kind: 'home', instanceId: 'default' }],
+	)
+	if (!synthesized) throw new Error('Expected synthesized Lutron home domain')
+	return {
+		env,
+		registry: buildCapabilityRegistry([synthesized.domain]),
+		callerContext,
+	}
+}
+
+test('searchUnified surfaces home_lutron_set_zone_color for literal lutron queries', async () => {
+	const { env, registry } = await buildHomeRegistryWithLutronCapabilities()
+
+	const result = await searchUnified({
+		env,
+		query: 'lutron lights color',
+		limit: 5,
+		registry,
+		optionalRows: {
+			packageRows: [],
+			userSecretRows: [],
+			userValueRows: [],
+		},
+	})
+
+	expect(result.matches[0]).toMatchObject({
+		type: 'capability',
+		name: 'home_lutron_set_zone_color',
+	})
+})
+
+test('searchUnified keeps home_lutron_set_zone_color near the top for intent-like home lighting queries', async () => {
+	const { env, registry } = await buildHomeRegistryWithLutronCapabilities()
+
+	const result = await searchUnified({
+		env,
+		query: 'turn office lights red',
+		limit: 5,
+		registry,
+		optionalRows: {
+			packageRows: [],
+			userSecretRows: [],
+			userValueRows: [],
+		},
+	})
+
+	expect(
+		result.matches
+			.filter(
+				(match): match is Extract<typeof match, { type: 'capability' }> =>
+					match.type === 'capability',
+			)
+			.slice(0, 3),
+	).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				name: 'home_lutron_set_zone_color',
+			}),
+		]),
+	)
 })
 
 test('optional search rows fall back when persisted values lookup fails', async () => {

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -8,12 +8,12 @@ import {
 } from '#mcp/capabilities/values/connector-shared.ts'
 import { getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
 import {
-	buildCapabilityEmbedText,
 	blendLexicalAndVectorScore,
 	cosineSimilarity,
 	deterministicEmbedding,
 	isCapabilitySearchOffline,
 	lexicalScore,
+	searchCapabilities,
 } from '#mcp/capabilities/capability-search.ts'
 import { listUserSecretsForSearch } from '#mcp/secrets/service.ts'
 import { type SecretSearchRow } from '#mcp/secrets/types.ts'
@@ -147,6 +147,10 @@ type SearchGuidanceContext = {
 	intent: SearchIntent
 	matches: Array<SearchMatch>
 }
+
+type SearchCapabilityMatch = Awaited<
+	ReturnType<typeof searchCapabilities>
+>['matches'][number]
 
 type SearchUnifiedResult = {
 	matches: Array<SearchMatch>
@@ -601,42 +605,26 @@ function rerankCandidates(input: {
 		.slice(0, input.limit)
 }
 
-function buildCapabilityCandidates(input: {
+async function buildCapabilityCandidates(input: {
 	query: string
+	env: Env
 	registry: Awaited<ReturnType<typeof getCapabilityRegistryForContext>>
-	queryEmbedding: ReadonlyArray<number>
-}): Array<SearchCandidate> {
-	return Object.values(input.registry.capabilitySpecs)
-		.map((spec) => {
-			const document = buildCapabilityEmbedText(spec)
-			const lexical = lexicalScore(input.query, document)
-			const vector = cosineSimilarity(
-				input.queryEmbedding,
-				deterministicEmbedding(document),
-			)
-			return {
-				match: {
-					type: 'capability' as const,
-					name: spec.name,
-					description: spec.description,
-				},
-				type: 'capability' as const,
-				id: spec.name,
-				title: spec.name,
-				searchFields: [
-					spec.name,
-					spec.domain,
-					spec.description,
-					...(spec.keywords ?? []),
-					...(spec.inputFields ?? []),
-					...(spec.outputFields ?? []),
-				],
-				scoreComponents: buildCandidateBaseScore({
-					lexical,
-					vector,
-				}),
-			}
+}): Promise<Array<SearchCandidate>> {
+	const capabilitySearch = await searchCapabilities({
+		env: input.env,
+		query: input.query,
+		limit: Math.max(1, Object.keys(input.registry.capabilitySpecs).length),
+		detail: false,
+		specs: input.registry.capabilitySpecs,
+	})
+
+	return capabilitySearch.matches
+		.map((match) => {
+			const spec = input.registry.capabilitySpecs[match.name]
+			if (!spec) return null
+			return capabilityMatchToCandidate(match, spec)
 		})
+		.filter((candidate): candidate is SearchCandidate => candidate !== null)
 		.filter((candidate) => candidate.scoreComponents.base > 0)
 }
 
@@ -825,7 +813,37 @@ function buildSecretCandidates(input: {
 		.filter((candidate) => candidate.scoreComponents.base > 0)
 }
 
-export function searchUnified(input: {
+function capabilityMatchToCandidate(
+	match: SearchCapabilityMatch,
+	spec: Awaited<
+		ReturnType<typeof getCapabilityRegistryForContext>
+	>['capabilitySpecs'][string],
+): SearchCandidate {
+	return {
+		match: {
+			type: 'capability',
+			name: spec.name,
+			description: spec.description,
+		},
+		type: 'capability',
+		id: spec.name,
+		title: spec.name,
+		searchFields: [
+			spec.name,
+			spec.domain,
+			spec.description,
+			...(spec.keywords ?? []),
+			...(spec.inputFields ?? []),
+			...(spec.outputFields ?? []),
+		],
+		scoreComponents: buildCandidateBaseScore({
+			lexical: match.lexicalScore,
+			vector: match.vectorScore,
+		}),
+	}
+}
+
+export async function searchUnified(input: {
 	env: Env
 	query: string
 	limit: number
@@ -834,7 +852,7 @@ export function searchUnified(input: {
 		OptionalSearchRowsResult,
 		'packageRows' | 'userSecretRows' | 'userValueRows'
 	>
-}): SearchUnifiedResult {
+}): Promise<SearchUnifiedResult> {
 	const offline = isCapabilitySearchOffline(input.env)
 	const query = input.query.trim()
 	if (!query) {
@@ -881,11 +899,11 @@ export function searchUnified(input: {
 	const candidateGenerationStart = performance.now()
 	const queryEmbedding = deterministicEmbedding(intent.normalizedQuery)
 	const candidates = [
-		...buildCapabilityCandidates({
+		...(await buildCapabilityCandidates({
 			query: intent.normalizedQuery,
+			env: input.env,
 			registry: input.registry,
-			queryEmbedding,
-		}),
+		})),
 		...buildPackageCandidates({
 			query: intent.normalizedQuery,
 			rows: input.optionalRows.packageRows,
@@ -950,7 +968,7 @@ export async function searchPackages(input: {
 	limit: number
 	rows: Array<PackageSearchRow>
 }): Promise<{ matches: Array<SearchMatch>; offline: boolean }> {
-	const result = searchUnified({
+	const result = await searchUnified({
 		env: input.env,
 		query: input.query,
 		limit: input.limit,
@@ -1475,7 +1493,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					}
 				}
 
-				const result = searchUnified({
+				const result = await searchUnified({
 					env: agent.getEnv(),
 					query: args.query!,
 					limit,

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -621,10 +621,13 @@ async function buildCapabilityCandidates(input: {
 	return capabilitySearch.matches
 		.map((match) => {
 			const spec = input.registry.capabilitySpecs[match.name]
-			if (!spec) return null
+			if (!spec || spec.name !== match.name) {
+				throw new Error(
+					`Capability search result "${match.name}" did not map to a registry spec by name.`,
+				)
+			}
 			return capabilityMatchToCandidate(match, spec)
 		})
-		.filter((candidate): candidate is SearchCandidate => candidate !== null)
 		.filter((candidate) => candidate.scoreComponents.base > 0)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- route MCP unified capability results through the shared capability search implementation instead of maintaining a separate capability scorer inside `search.ts`
- clamp negative vector influence in the hybrid lexical/vector blend so literal token matches (for example `lutron`) are not cancelled out
- harden the capability search result boundary by exposing a finite public `vectorScore` and adding a runtime invariant for registry keying during unified capability candidate mapping
- add focused regression coverage for synthesized home Lutron capabilities via natural-language queries like `lutron lights color` and `turn office lights red`

## Root cause
`Kody:search` and `meta_list_capabilities` were reading from the same runtime capability registry, but they were not using the same retrieval path. `meta_list_capabilities` listed the runtime capability correctly, while MCP `search` used a separate lightweight scorer inside `packages/worker/src/mcp/tools/search.ts` instead of the dedicated capability search implementation in `packages/worker/src/mcp/capabilities/capability-search.ts`.

That separate scorer also blended lexical overlap with a raw vector cosine score that could go negative, which meant a real lexical token match could be suppressed rather than boosted.

## Review follow-up
I validated the automated review comments against the actual fix. I accepted and implemented the two comments that represented real risks:
- normalize the public `CapabilitySearchHit.vectorScore` to a finite value while preserving internal ranking sentinels
- fail loudly if unified search can no longer map `searchCapabilities()` hits back to the capability registry

I intentionally did not do the suggested test-helper extraction because it was only optional cleanup and did not affect correctness or the original search goal.

## Testing
- `npm run test -- --run packages/worker/src/mcp/tools/search.node.test.ts packages/worker/src/mcp/capabilities/capability-search.workers.test.ts`
- `npm run typecheck`

## Artifact
<a href="/opt/cursor/artifacts/search-validation-log.txt">Focused validation log</a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f319fa3c-10f0-477e-81a5-67a5c8f67f12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f319fa3c-10f0-477e-81a5-67a5c8f67f12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed search tool to properly await asynchronous search operations, ensuring correct result handling.

* **New Features**
  * Enhanced search results with explicit lexical and vector score metrics for improved transparency.
  * Improved hybrid scoring calculation for more accurate search ranking.

* **Tests**
  * Extended test coverage with new search scenarios and domain-specific test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->