### PR TITLE
Fix secret host approval links

### DIFF
--- a/e2e/account-secrets.spec.ts
+++ b/e2e/account-secrets.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from './playwright-utils.ts'
 
+const e2eCookieSecret = 'LOCAL_AND_PREVIEW_COOKIE_SECRET_32_CHARS_MINIMUM'
+const secretHostApprovalPurpose = 'secret-host-approval'
+
 async function saveSecret(
 	page: Parameters<Parameters<typeof test>[1]>[0]['page'],
 	input: {
@@ -24,6 +27,75 @@ async function saveSecret(
 		headers: { 'Content-Type': 'application/json' },
 	})
 	expect(response.ok()).toBeTruthy()
+}
+
+function bytesToBase64Url(bytes: Uint8Array) {
+	let binary = ''
+	for (const value of bytes) {
+		binary += String.fromCharCode(value)
+	}
+	return btoa(binary)
+		.replaceAll('+', '-')
+		.replaceAll('/', '_')
+		.replaceAll('=', '')
+}
+
+async function deriveEncryptionKey(cookieSecret: string, purpose: string) {
+	const digest = await crypto.subtle.digest(
+		'SHA-256',
+		new TextEncoder().encode(`${purpose}:${cookieSecret}`),
+	)
+	return crypto.subtle.importKey('raw', digest, 'AES-GCM', false, [
+		'encrypt',
+		'decrypt',
+	])
+}
+
+async function encryptStringWithPurpose(purpose: string, value: string) {
+	const key = await deriveEncryptionKey(e2eCookieSecret, purpose)
+	const iv = crypto.getRandomValues(new Uint8Array(12))
+	const ciphertext = await crypto.subtle.encrypt(
+		{
+			name: 'AES-GCM',
+			iv,
+		},
+		key,
+		new TextEncoder().encode(value),
+	)
+	return `${bytesToBase64Url(iv)}.${bytesToBase64Url(
+		new Uint8Array(ciphertext),
+	)}`
+}
+
+async function createHostApprovalToken(input: {
+	userId: string
+	name: string
+	requestedHost: string
+}) {
+	const now = Date.now()
+	const token = await encryptStringWithPurpose(
+		secretHostApprovalPurpose,
+		JSON.stringify({
+			kind: 'host',
+			userId: input.userId,
+			name: input.name,
+			scope: 'user',
+			requestedHost: input.requestedHost,
+			storageContext: null,
+			iat: now,
+			exp: now + 60_000,
+		}),
+	)
+	return `host:${token}`
+}
+
+async function createStableUserIdFromEmail(email: string) {
+	const normalized = email.trim().toLowerCase()
+	const data = new TextEncoder().encode(normalized)
+	const hash = await crypto.subtle.digest('SHA-256', data)
+	return Array.from(new Uint8Array(hash), (byte) =>
+		byte.toString(16).padStart(2, '0'),
+	).join('')
 }
 
 test('switching secrets updates detail view without a full reload', async ({
@@ -110,4 +182,47 @@ test('landing on an approval link shows already added when the host is present',
 	await expect(alreadyAddedNotice).toBeVisible()
 	await expect(alreadyAddedNotice).toContainText('api.cloudflare.com')
 	await expect(page.getByRole('button', { name: 'Approve' })).toHaveCount(0)
+})
+
+test('generated host approval link shows one-click approve and persists host', async ({
+	page,
+	login,
+}) => {
+	const user = await login()
+	const nonce = Date.now().toString(36)
+	const secret = {
+		name: `fly-token-${nonce}`,
+		description: `Fly token ${nonce}`,
+		value: `token-${nonce}`,
+	}
+	await saveSecret(page, secret)
+
+	const requestedHost = 'api.fly.io'
+	const token = await createHostApprovalToken({
+		userId: await createStableUserIdFromEmail(user.email),
+		name: secret.name,
+		requestedHost,
+	})
+	await page.goto(
+		`/account/secrets/user/${secret.name}?allowed-host=${requestedHost}&request=${encodeURIComponent(
+			token,
+		)}`,
+	)
+
+	const approvalCard = page.getByRole('heading', {
+		level: 2,
+		name: 'Approve secret access',
+	})
+	await expect(approvalCard).toBeVisible()
+	await expect(page.getByText(requestedHost)).toBeVisible()
+	await page.getByRole('button', { name: 'Approve' }).click()
+	await expect(page.getByRole('alert')).toContainText(
+		'Approved requested host.',
+	)
+	await expect(page).toHaveURL(
+		new RegExp(`/account/secrets/user/${secret.name}`),
+	)
+	await expect(page.getByPlaceholder('api.example.com').first()).toHaveValue(
+		requestedHost,
+	)
 })

--- a/packages/worker/client/routes/account-approval-shared.ts
+++ b/packages/worker/client/routes/account-approval-shared.ts
@@ -27,8 +27,12 @@ export async function readJson<T>(response: Response) {
 
 export async function submitApprovalRequest<
 	T extends { ok?: boolean; error?: string },
->(action: ApprovalAction, requestToken: string) {
-	const response = await fetch(accountSecretsApiPath, {
+>(
+	action: ApprovalAction,
+	requestToken: string,
+	requestUrl = accountSecretsApiPath,
+) {
+	const response = await fetch(requestUrl, {
 		method: 'POST',
 		headers: {
 			Accept: 'application/json',

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -81,6 +81,7 @@ type AccountSecretsPayload = {
 	secrets: Array<SecretListItem>
 	selectedSecret: SecretDetail | null
 	approval: ApprovalView | null
+	approvalError: string | null
 }
 
 type EditorState = {
@@ -531,6 +532,7 @@ export function AccountSecretsRoute(handle: Handle) {
 		syncEditorState(selection)
 		message =
 			nextMessage ??
+			payload.approvalError ??
 			(selection.selectedSecretId &&
 			!payload.selectedSecret &&
 			!payload.approval
@@ -626,12 +628,16 @@ export function AccountSecretsRoute(handle: Handle) {
 		handle.update()
 
 		try {
+			const selection = getSelectionState(getCurrentHref())
+			const requestUrl = new URL(accountSecretsApiPath, getCurrentHref())
+			if (selection.selectedSecretId) {
+				requestUrl.searchParams.set('selected', selection.selectedSecretId)
+			}
 			const payload = await submitApprovalRequest<
 				AccountSecretsPayload & { error?: string; ok?: boolean }
-			>(action, approval.token)
+			>(action, approval.token, requestUrl.toString())
 			if (!payload) return
 
-			const selection = getSelectionState(getCurrentHref())
 			applyPayload(
 				payload,
 				selection,
@@ -874,7 +880,10 @@ export function AccountSecretsRoute(handle: Handle) {
 	function addAllowedPackage() {
 		editorState = {
 			...editorState,
-			allowedPackages: [...editorState.allowedPackages, createAllowedPackageRow()],
+			allowedPackages: [
+				...editorState.allowedPackages,
+				createAllowedPackageRow(),
+			],
 		}
 		handle.update()
 	}
@@ -1007,8 +1016,7 @@ export function AccountSecretsRoute(handle: Handle) {
 							</h2>
 							{approvalCard.requestedPackageId ? (
 								<p css={{ margin: 0, color: colors.textMuted }}>
-									Allow package{' '}
-									<code>{approvalCard.requestedPackageId}</code>{' '}
+									Allow package <code>{approvalCard.requestedPackageId}</code>{' '}
 									to use secret <code>{approvalCard.name}</code> from the{' '}
 									{getScopeLabel(approvalCard.scope)} scope.
 								</p>

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -222,26 +222,7 @@ test('connect oauth returns direct host approval links for saved token secrets',
 			storageContext: null,
 		}),
 	)
-	expect(mockModule.setSecretAllowedHosts).toHaveBeenNthCalledWith(
-		1,
-		expect.objectContaining({
-			userId: 'stable-user-1',
-			name: 'githubAccessToken',
-			scope: 'user',
-			allowedHosts: ['api.github.com', 'github.com'],
-			storageContext: { sessionId: null, appId: null },
-		}),
-	)
-	expect(mockModule.setSecretAllowedHosts).toHaveBeenNthCalledWith(
-		2,
-		expect.objectContaining({
-			userId: 'stable-user-1',
-			name: 'githubRefreshToken',
-			scope: 'user',
-			allowedHosts: ['api.github.com', 'github.com'],
-			storageContext: { sessionId: null, appId: null },
-		}),
-	)
+	expect(mockModule.setSecretAllowedHosts).not.toHaveBeenCalled()
 })
 
 test('connect oauth omits direct host approval links when hosts are already approved', async () => {

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -31,9 +31,7 @@ import {
 	setSecretAllowedPackages,
 } from '#mcp/secrets/service.ts'
 import { type SecretScope } from '#mcp/secrets/types.ts'
-import {
-	listSavedPackagesByUserId,
-} from '#worker/package-registry/repo.ts'
+import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { type routes } from '#app/routes.ts'
 import { normalizeAllowedCapabilities } from '#mcp/secrets/allowed-capabilities.ts'
 import { normalizeAllowedPackages } from '#mcp/secrets/allowed-packages.ts'
@@ -102,6 +100,7 @@ type AccountSecretsPayload = {
 	secrets: Array<AccountSecretListItem>
 	selectedSecret: AccountSecretDetail | null
 	approval: SecretApprovalView | null
+	approvalError: string | null
 }
 
 type ConnectOauthHostApprovalLink = {
@@ -359,14 +358,6 @@ async function handleConnectOauthAction(input: {
 		description: `${provider} OAuth access token`,
 		storageContext: { sessionId: null, appId: null },
 	})
-	await setSecretAllowedHosts({
-		env: input.env,
-		userId: input.user.mcpUser.userId,
-		name: accessTokenSecretName,
-		scope: 'user',
-		allowedHosts,
-		storageContext: { sessionId: null, appId: null },
-	})
 
 	let refreshSaved = false
 	if (refreshToken && refreshTokenSecretName) {
@@ -377,14 +368,6 @@ async function handleConnectOauthAction(input: {
 			value: refreshToken,
 			scope: 'user',
 			description: `${provider} OAuth refresh token`,
-			storageContext: { sessionId: null, appId: null },
-		})
-		await setSecretAllowedHosts({
-			env: input.env,
-			userId: input.user.mcpUser.userId,
-			name: refreshTokenSecretName,
-			scope: 'user',
-			allowedHosts,
 			storageContext: { sessionId: null, appId: null },
 		})
 		refreshSaved = true
@@ -664,8 +647,7 @@ async function buildAccountSecretsPayload(input: {
 		(await listSavedPackagesByUserId(input.env.APP_DB, {
 			userId: input.user.mcpUser.userId,
 		}))
-	const packageApps =
-		input.packageApps ?? toPackageAppOptions(savedPackages)
+	const packageApps = input.packageApps ?? toPackageAppOptions(savedPackages)
 	const packageLookup = toAllowedPackageLookup(savedPackages)
 	const secrets = await listAccountSecrets({
 		env: input.env,
@@ -681,16 +663,25 @@ async function buildAccountSecretsPayload(input: {
 			})
 		: null
 
-	const approval = approvalToken
-		? await resolveSecretApprovalView({
+	let approval: SecretApprovalView | null = null
+	let approvalError: string | null = null
+	if (approvalToken) {
+		try {
+			approval = await resolveSecretApprovalView({
 				env: input.env,
 				userId: input.user.mcpUser.userId,
 				token: approvalToken,
 				requestedHost: requestedApprovalHost,
 				requestedCapability,
 				requestedPackageId,
-			}).catch(() => null)
-		: null
+			})
+		} catch (error) {
+			approvalError =
+				error instanceof Error
+					? error.message
+					: 'Unable to verify approval request.'
+		}
+	}
 
 	return {
 		ok: true,
@@ -704,6 +695,7 @@ async function buildAccountSecretsPayload(input: {
 		secrets,
 		selectedSecret,
 		approval,
+		approvalError,
 	}
 }
 
@@ -815,8 +807,7 @@ async function resolveSecretApprovalView(input: {
 		scope: approval.scope,
 		requestedHost: approval.kind === 'host' ? approval.requestedHost : '',
 		requestedCapability: input.requestedCapability,
-		requestedPackageId:
-			approval.kind === 'package' ? approval.packageId : null,
+		requestedPackageId: approval.kind === 'package' ? approval.packageId : null,
 		currentAllowedHosts: secret.allowedHosts,
 		currentAllowedPackages: secret.allowedPackages,
 	} satisfies SecretApprovalView
@@ -964,7 +955,8 @@ async function handleApprovalAction(input: {
 					storageContext: approval.storageContext,
 				})
 				const secret = current.find(
-					(item) => item.name === approval.name && item.scope === approval.scope,
+					(item) =>
+						item.name === approval.name && item.scope === approval.scope,
 				)
 				if (!secret) {
 					return jsonResponse({ ok: false, error: 'Secret not found.' }, 404)
@@ -1007,7 +999,10 @@ async function handleApprovalAction(input: {
 				userId: input.user.mcpUser.userId,
 				name: approval.name,
 				scope: approval.scope,
-				allowedHosts: [...secret.allowedHosts, approval.requestedHost],
+				allowedHosts: normalizeAllowedHosts([
+					...secret.allowedHosts,
+					approval.requestedHost,
+				]),
 				storageContext: approval.storageContext,
 			})
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep generated OAuth host approval links explicit by no longer auto-adding requested hosts when saving OAuth token secrets.
- Surface approval-link validation failures in the account secrets UI instead of silently falling back to the editor.
- Preserve the selected secret while submitting approval actions so success lands on the updated secret detail.
- Add e2e coverage for `/account/secrets/user/:secretName?allowed-host=api.fly.io&request=...` showing the approval card, approving, and persisting the host.

## Walkthrough
<a href="https://cursor.com/agents/bc-45936486-481c-4f20-b55d-e044ec4b20c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsecret_host_approval_flow.mp4"><img src="https://cursor.com/artifacts/c/art-43756b6e-b326-4a39-9410-768634357b8c" alt="secret_host_approval_flow.mp4" /></a>

## Validation
- `npm test -- --run packages/worker/src/app/handlers/account-secrets.node.test.ts packages/worker/src/mcp/secrets/host-approval.node.test.ts`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3847 npm run test:e2e:run -- --grep "generated host approval link|approval link shows already added"`
- `npx oxfmt --check e2e/account-secrets.spec.ts packages/worker/client/routes/account-approval-shared.ts packages/worker/client/routes/account-secrets.tsx packages/worker/src/app/handlers/account-secrets.ts packages/worker/src/app/handlers/account-secrets.node.test.ts`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck`

Note: repo-wide `npm run format:check` still reports pre-existing formatting issues in unrelated files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45936486-481c-4f20-b55d-e044ec4b20c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45936486-481c-4f20-b55d-e044ec4b20c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in secret approval workflow with user-facing error messages
  * Corrected OAuth token behavior to prevent unintended host allowance assignments
  * Normalized host allowance lists during approval operations for consistency

* **Tests**
  * Added comprehensive E2E test coverage for secret approval workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->