### PR TITLE
Improve Bond home-connector network failure handling

### DIFF
--- a/packages/home-connector/src/adapters/bond/index.node.test.ts
+++ b/packages/home-connector/src/adapters/bond/index.node.test.ts
@@ -1,0 +1,165 @@
+import { expect, test, vi } from 'vitest'
+import { createAppState } from '../../state.ts'
+import { type HomeConnectorConfig } from '../../config.ts'
+import { createHomeConnectorStorage } from '../../storage/index.ts'
+import { createBondAdapter } from './index.ts'
+import { adoptBondBridge, upsertDiscoveredBondBridges } from './repository.ts'
+
+function createConfig(): HomeConnectorConfig {
+	return {
+		homeConnectorId: 'default',
+		workerBaseUrl: 'http://localhost:3742',
+		workerSessionUrl: 'http://localhost:3742/home/connectors/default',
+		workerWebSocketUrl: 'ws://localhost:3742/home/connectors/default',
+		sharedSecret: 'secret',
+		rokuDiscoveryUrl: 'http://roku.mock.local/discovery',
+		lutronDiscoveryUrl: 'http://lutron.mock.local/discovery',
+		sonosDiscoveryUrl: 'http://sonos.mock.local/discovery',
+		samsungTvDiscoveryUrl: 'http://samsung-tv.mock.local/discovery',
+		bondDiscoveryUrl: 'http://bond.mock.local/discovery',
+		jellyfishDiscoveryUrl: 'http://jellyfish.mock.local/discovery',
+		venstarScanCidrs: ['192.168.10.40/32'],
+		jellyfishScanCidrs: ['192.168.10.93/32'],
+		dataPath: '/tmp',
+		dbPath: ':memory:',
+		port: 4040,
+		mocksEnabled: false,
+	}
+}
+
+function createDnsFetchError(message = 'getaddrinfo ENOTFOUND zpgi01117.local') {
+	const error = new TypeError('fetch failed')
+	Object.defineProperty(error, 'cause', {
+		value: {
+			code: 'ENOTFOUND',
+			errno: -3008,
+			syscall: 'getaddrinfo',
+			hostname: 'zpgi01117.local',
+			message,
+		},
+		enumerable: true,
+		configurable: true,
+	})
+	return error
+}
+
+test('bond falls back to the discovered IP when the stored .local host stops resolving', async () => {
+	const config = createConfig()
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		const url = String(input)
+		if (url === 'http://zpgi01117.local/v2/devices/mockdev1/state') {
+			throw createDnsFetchError()
+		}
+		if (url === 'http://10.0.0.22/v2/devices/mockdev1/state') {
+			return new Response(JSON.stringify({ position: 55, _: 's' }), {
+				status: 200,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+			})
+		}
+		throw new Error(`Unexpected fetch URL: ${url}`)
+	})
+	globalThis.fetch = fetchMock as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST1',
+				bondid: 'BONDTEST1',
+				instanceName: 'Office Bond',
+				host: 'zpgi01117.local',
+				port: 80,
+				address: '10.0.0.22',
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:00:00.000Z',
+				rawDiscovery: {
+					mdns: {
+						host: 'zpgi01117.local.',
+						addresses: ['10.0.0.22'],
+					},
+					version: {
+						model: 'BD-TEST',
+						fwVer: 'v1.0.0',
+					},
+				},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST1')
+		bond.setToken('BONDTEST1', 'bond-token')
+
+		const result = await bond.getDeviceState('BONDTEST1', 'mockdev1')
+
+		expect(result).toMatchObject({
+			position: 55,
+		})
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+		expect(fetchMock.mock.calls[0]?.[0]).toBe(
+			'http://zpgi01117.local/v2/devices/mockdev1/state',
+		)
+		expect(fetchMock.mock.calls[1]?.[0]).toBe(
+			'http://10.0.0.22/v2/devices/mockdev1/state',
+		)
+	} finally {
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
+test('bond surfaces actionable guidance when a .local bridge host cannot be resolved and no IP fallback exists', async () => {
+	const config = createConfig()
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	globalThis.fetch = vi.fn(async () => {
+		throw createDnsFetchError()
+	}) as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST2',
+				bondid: 'BONDTEST2',
+				instanceName: 'Bedroom Bond',
+				host: 'zpgi01117.local',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:05:00.000Z',
+				rawDiscovery: {
+					mdns: {
+						host: 'zpgi01117.local.',
+						addresses: [],
+					},
+				},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST2')
+		bond.setToken('BONDTEST2', 'bond-token')
+
+		await expect(bond.getDeviceState('BONDTEST2', 'mockdev1')).rejects.toThrow(
+			'Bond bridge "BONDTEST2" could not be reached while trying to fetch device mockdev1 state at http://zpgi01117.local',
+		)
+		await expect(bond.getDeviceState('BONDTEST2', 'mockdev1')).rejects.toThrow(
+			'If this connector runs in a NAS/container without mDNS, update the bridge host to a stable IP',
+		)
+	} finally {
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})

--- a/packages/home-connector/src/adapters/bond/index.node.test.ts
+++ b/packages/home-connector/src/adapters/bond/index.node.test.ts
@@ -28,19 +28,15 @@ function createConfig(): HomeConnectorConfig {
 }
 
 function createDnsFetchError(message = 'getaddrinfo ENOTFOUND zpgi01117.local') {
-	const error = new TypeError('fetch failed')
-	Object.defineProperty(error, 'cause', {
-		value: {
+	return new TypeError('fetch failed', {
+		cause: {
 			code: 'ENOTFOUND',
 			errno: -3008,
 			syscall: 'getaddrinfo',
 			hostname: 'zpgi01117.local',
 			message,
 		},
-		enumerable: true,
-		configurable: true,
 	})
-	return error
 }
 
 test('bond falls back to the discovered IP when the stored .local host stops resolving', async () => {
@@ -152,11 +148,76 @@ test('bond surfaces actionable guidance when a .local bridge host cannot be reso
 		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST2')
 		bond.setToken('BONDTEST2', 'bond-token')
 
-		await expect(bond.getDeviceState('BONDTEST2', 'mockdev1')).rejects.toThrow(
+		const error = await bond
+			.getDeviceState('BONDTEST2', 'mockdev1')
+			.catch((caughtError: unknown) => caughtError)
+
+		expect(error).toBeInstanceOf(Error)
+		expect((error as Error).message).toContain(
 			'Bond bridge "BONDTEST2" could not be reached while trying to fetch device mockdev1 state at http://zpgi01117.local',
 		)
-		await expect(bond.getDeviceState('BONDTEST2', 'mockdev1')).rejects.toThrow(
+		expect((error as Error).message).toContain(
 			'If this connector runs in a NAS/container without mDNS, update the bridge host to a stable IP',
+		)
+	} finally {
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
+test('bond leaves non-network Bond API errors unwrapped and does not claim fallback URLs were tried', async () => {
+	const config = createConfig()
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		const url = String(input)
+		if (url === 'http://zpgi01117.local/v2/devices/mockdev1/state') {
+			return new Response(JSON.stringify({ message: 'unauthorized' }), {
+				status: 401,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+			})
+		}
+		if (url === 'http://10.0.0.22/v2/devices/mockdev1/state') {
+			throw new Error('Fallback URL should not have been called')
+		}
+		throw new Error(`Unexpected fetch URL: ${url}`)
+	})
+	globalThis.fetch = fetchMock as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST3',
+				bondid: 'BONDTEST3',
+				instanceName: 'Kitchen Bond',
+				host: 'zpgi01117.local',
+				port: 80,
+				address: '10.0.0.22',
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:10:00.000Z',
+				rawDiscovery: {
+					address: '10.0.0.22',
+				},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST3')
+		bond.setToken('BONDTEST3', 'bond-token')
+
+		await expect(bond.getDeviceState('BONDTEST3', 'mockdev1')).rejects.toThrow(
+			'Bond HTTP 401 for /v2/devices/mockdev1/state: unauthorized',
+		)
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+		expect(fetchMock.mock.calls[0]?.[0]).toBe(
+			'http://zpgi01117.local/v2/devices/mockdev1/state',
 		)
 	} finally {
 		globalThis.fetch = previousFetch

--- a/packages/home-connector/src/adapters/bond/index.ts
+++ b/packages/home-connector/src/adapters/bond/index.ts
@@ -31,6 +31,9 @@ import {
 	type BondGroupSummary,
 	type BondPersistedBridge,
 } from './types.ts'
+import {
+	type HomeConnectorErrorCaptureContext,
+} from '../../sentry.ts'
 
 function normalizeQuery(value: string) {
 	return value.trim().toLowerCase()
@@ -93,6 +96,172 @@ function stripTokenFields(payload: Record<string, unknown>) {
 	return copy
 }
 
+function getBridgeDiscoveredAddress(bridge: BondPersistedBridge) {
+	const rawAddress = bridge.rawDiscovery?.['address']
+	if (typeof rawAddress === 'string' && rawAddress.trim()) {
+		return rawAddress.trim()
+	}
+	const mdns = bridge.rawDiscovery?.['mdns']
+	if (mdns && typeof mdns === 'object' && !Array.isArray(mdns)) {
+		const mdnsRecord = mdns as Record<string, unknown>
+		const mdnsAddress = mdnsRecord['address']
+		if (typeof mdnsAddress === 'string' && mdnsAddress.trim()) {
+			return mdnsAddress.trim()
+		}
+		const mdnsAddresses = mdnsRecord['addresses']
+		if (Array.isArray(mdnsAddresses)) {
+			const firstAddress = mdnsAddresses.find(
+				(entry) => typeof entry === 'string' && entry.trim(),
+			)
+			if (typeof firstAddress === 'string') {
+				return firstAddress.trim()
+			}
+		}
+	}
+	return null
+}
+
+function getBondBridgeConnectionContext(bridge: BondPersistedBridge) {
+	const discoveredAddress = getBridgeDiscoveredAddress(bridge)
+	return {
+		bridgeId: bridge.bridgeId,
+		instanceName: bridge.instanceName,
+		host: bridge.host,
+		port: bridge.port,
+		discoveredAddress,
+		adopted: bridge.adopted,
+		hasStoredToken: bridge.hasStoredToken,
+		lastSeenAt: bridge.lastSeenAt,
+	}
+}
+
+function createBondBaseUrlCandidates(bridge: BondPersistedBridge) {
+	const primary = buildBondBaseUrl(bridge.host, bridge.port)
+	const discoveredAddress = getBridgeDiscoveredAddress(bridge)
+	if (!discoveredAddress) {
+		return [primary]
+	}
+	const fallback = buildBondBaseUrl(discoveredAddress, bridge.port)
+	return fallback === primary ? [primary] : [primary, fallback]
+}
+
+function isBondNetworkFailure(error: unknown) {
+	if (!(error instanceof Error)) {
+		return false
+	}
+	const message = error.message.toLowerCase()
+	if (
+		message.includes('fetch failed') ||
+		message.includes('enotfound') ||
+		message.includes('eai_again') ||
+		message.includes('econnrefused') ||
+		message.includes('ehostunreach') ||
+		message.includes('etimedout')
+	) {
+		return true
+	}
+	const causeMessage =
+		error.cause instanceof Error
+			? error.cause.message.toLowerCase()
+			: typeof error.cause === 'string'
+				? error.cause.toLowerCase()
+				: error.cause && typeof error.cause === 'object'
+					? String((error.cause as { message?: unknown }).message ?? '')
+							.toLowerCase()
+				: ''
+	return (
+		causeMessage.includes('enotfound') ||
+		causeMessage.includes('eai_again') ||
+		causeMessage.includes('econnrefused') ||
+		causeMessage.includes('ehostunreach') ||
+		causeMessage.includes('etimedout') ||
+		causeMessage.includes('getaddrinfo')
+	)
+}
+
+function formatBondFailureReason(error: unknown) {
+	if (error instanceof Error) {
+		const causeMessage =
+			error.cause instanceof Error
+				? error.cause.message
+				: typeof error.cause === 'string'
+					? error.cause
+					: error.cause && typeof error.cause === 'object'
+						? String((error.cause as { message?: unknown }).message ?? '')
+					: null
+		return causeMessage ? `${error.message}; cause=${causeMessage}` : error.message
+	}
+	return String(error)
+}
+
+function createBondActionableError(input: {
+	bridge: BondPersistedBridge
+	operation: string
+	error: unknown
+	baseUrlsTried: Array<string>
+}) {
+	const connection = getBondBridgeConnectionContext(input.bridge)
+	const guidance = connection.host.endsWith('.local')
+		? ' The stored Bond host ends in .local, so this usually means the container cannot resolve mDNS on the LAN. If this connector runs in a NAS/container without mDNS, update the bridge host to a stable IP with bond_update_bridge_connection or restore mDNS/DNS visibility for the container.'
+		: ' Verify the bridge host/IP is still reachable from the home-connector container and update it with bond_update_bridge_connection if it changed.'
+	const errorMessage = `Bond bridge "${input.bridge.bridgeId}" could not be reached while trying to ${input.operation} at ${input.baseUrlsTried.join(', ')}. ${formatBondFailureReason(input.error)}.${guidance}`
+	const wrappedError = new Error(errorMessage, {
+		cause: input.error instanceof Error ? input.error : undefined,
+	}) as Error & {
+		homeConnectorCaptureContext?: HomeConnectorErrorCaptureContext
+	}
+	wrappedError.name = 'BondRequestError'
+	wrappedError.homeConnectorCaptureContext = {
+		tags: {
+			connector_vendor: 'bond',
+			bond_bridge_id: input.bridge.bridgeId,
+			bond_network_failure: isBondNetworkFailure(input.error) ? 'true' : 'false',
+			bond_host_is_local: input.bridge.host.endsWith('.local') ? 'true' : 'false',
+		},
+		contexts: {
+			bond_bridge: {
+				...connection,
+				baseUrlsTried: input.baseUrlsTried,
+				operation: input.operation,
+			},
+		},
+		extra: {
+			bondOperation: input.operation,
+			bondBaseUrlsTried: input.baseUrlsTried,
+			bondFailureReason: formatBondFailureReason(input.error),
+		},
+	}
+	return wrappedError
+}
+
+async function withBondBridgeRequest<T>(input: {
+	bridge: BondPersistedBridge
+	operation: string
+	request: (baseUrl: string) => Promise<T>
+}) {
+	const baseUrls = createBondBaseUrlCandidates(input.bridge)
+	let lastError: unknown = null
+	for (let index = 0; index < baseUrls.length; index += 1) {
+		const baseUrl = baseUrls[index]!
+		try {
+			return await input.request(baseUrl)
+		} catch (error) {
+			lastError = error
+			const canRetryWithFallback =
+				index === 0 && baseUrls.length > 1 && isBondNetworkFailure(error)
+			if (!canRetryWithFallback) {
+				break
+			}
+		}
+	}
+	throw createBondActionableError({
+		bridge: input.bridge,
+		operation: input.operation,
+		error: lastError,
+		baseUrlsTried: baseUrls,
+	})
+}
+
 export function createBondAdapter(input: {
 	config: HomeConnectorConfig
 	state: HomeConnectorState
@@ -146,10 +315,6 @@ export function createBondAdapter(input: {
 		return token
 	}
 
-	function bridgeBaseUrl(bridge: BondPersistedBridge) {
-		return buildBondBaseUrl(bridge.host, bridge.port)
-	}
-
 	async function resolveDeviceId(
 		bridge: BondPersistedBridge,
 		token: string,
@@ -193,13 +358,18 @@ export function createBondAdapter(input: {
 		bridge: BondPersistedBridge,
 		token: string,
 	) {
-		const baseUrl = bridgeBaseUrl(bridge)
-		const ids = await bondListDeviceIds({ baseUrl, token })
-		const docs = await mapPool(ids, 8, async (id) => {
-			const doc = await bondGetDevice({ baseUrl, token, deviceId: id })
-			return summarizeDevice(id, doc)
+		return await withBondBridgeRequest({
+			bridge,
+			operation: 'list devices',
+			request: async (baseUrl) => {
+				const ids = await bondListDeviceIds({ baseUrl, token })
+				const docs = await mapPool(ids, 8, async (id) => {
+					const doc = await bondGetDevice({ baseUrl, token, deviceId: id })
+					return summarizeDevice(id, doc)
+				})
+				return docs
+			},
 		})
-		return docs
 	}
 
 	const bondApi = {
@@ -252,8 +422,10 @@ export function createBondAdapter(input: {
 		},
 		async fetchBridgeVersion(bridgeId?: string) {
 			const bridge = resolveBridge(bridgeId)
-			return await bondGetSysVersion({
-				baseUrl: bridgeBaseUrl(bridge),
+			return await withBondBridgeRequest({
+				bridge,
+				operation: 'fetch bridge version',
+				request: async (baseUrl) => await bondGetSysVersion({ baseUrl }),
 			})
 		},
 		async getTokenStatus(bridgeId?: string) {
@@ -263,9 +435,14 @@ export function createBondAdapter(input: {
 				connectorId,
 				bridge.bridgeId,
 			)
-			const raw = (await bondGetTokenStatus({
-				baseUrl: bridgeBaseUrl(bridge),
-				token: existing,
+			const raw = (await withBondBridgeRequest({
+				bridge,
+				operation: 'read token status',
+				request: async (baseUrl) =>
+					await bondGetTokenStatus({
+						baseUrl,
+						token: existing,
+					}),
 			})) as Record<string, unknown>
 			return stripTokenFields(raw)
 		},
@@ -273,9 +450,14 @@ export function createBondAdapter(input: {
 			const bridge = bridgeId
 				? requireBondBridge(input.storage, connectorId, bridgeId)
 				: resolveBridge()
-			const raw = (await bondGetTokenStatus({
-				baseUrl: bridgeBaseUrl(bridge),
-				token: null,
+			const raw = (await withBondBridgeRequest({
+				bridge,
+				operation: 'retrieve token from bridge',
+				request: async (baseUrl) =>
+					await bondGetTokenStatus({
+						baseUrl,
+						token: null,
+					}),
 			})) as Record<string, unknown>
 			const token =
 				typeof raw['token'] === 'string' ? (raw['token'] as string) : null
@@ -305,10 +487,15 @@ export function createBondAdapter(input: {
 		): Promise<Record<string, unknown>> {
 			const bridge = requireAdoptedBridge(bridgeId)
 			const token = requireToken(bridge)
-			return await bondGetDevice({
-				baseUrl: bridgeBaseUrl(bridge),
-				token,
-				deviceId,
+			return await withBondBridgeRequest({
+				bridge,
+				operation: `fetch device ${deviceId}`,
+				request: async (baseUrl) =>
+					await bondGetDevice({
+						baseUrl,
+						token,
+						deviceId,
+					}),
 			})
 		},
 		async getDeviceState(
@@ -317,10 +504,15 @@ export function createBondAdapter(input: {
 		): Promise<Record<string, unknown>> {
 			const bridge = requireAdoptedBridge(bridgeId)
 			const token = requireToken(bridge)
-			return await bondGetDeviceState({
-				baseUrl: bridgeBaseUrl(bridge),
-				token,
-				deviceId,
+			return await withBondBridgeRequest({
+				bridge,
+				operation: `fetch device ${deviceId} state`,
+				request: async (baseUrl) =>
+					await bondGetDeviceState({
+						baseUrl,
+						token,
+						deviceId,
+					}),
 			})
 		},
 		async invokeDeviceAction(input: {
@@ -338,10 +530,15 @@ export function createBondAdapter(input: {
 				input.deviceId,
 				input.deviceName,
 			)
-			const doc = await bondGetDevice({
-				baseUrl: bridgeBaseUrl(bridge),
-				token,
-				deviceId,
+			const doc = await withBondBridgeRequest({
+				bridge,
+				operation: `fetch device ${deviceId} before action`,
+				request: async (baseUrl) =>
+					await bondGetDevice({
+						baseUrl,
+						token,
+						deviceId,
+					}),
 			})
 			const rawActions = doc['actions']
 			if (!Array.isArray(rawActions) || rawActions.length === 0) {
@@ -355,12 +552,17 @@ export function createBondAdapter(input: {
 					`Device "${deviceId}" does not advertise action "${input.action}".`,
 				)
 			}
-			return await bondInvokeDeviceAction({
-				baseUrl: bridgeBaseUrl(bridge),
-				token,
-				deviceId,
-				action: input.action,
-				argument: input.argument,
+			return await withBondBridgeRequest({
+				bridge,
+				operation: `invoke device ${deviceId} action ${input.action}`,
+				request: async (baseUrl) =>
+					await bondInvokeDeviceAction({
+						baseUrl,
+						token,
+						deviceId,
+						action: input.action,
+						argument: input.argument,
+					}),
 			})
 		},
 		async shadeOpen(input: {
@@ -416,29 +618,44 @@ export function createBondAdapter(input: {
 		async listGroups(bridgeId?: string) {
 			const bridge = requireAdoptedBridge(bridgeId)
 			const token = requireToken(bridge)
-			const baseUrl = bridgeBaseUrl(bridge)
-			const ids = await bondListGroupIds({ baseUrl, token })
-			return await mapPool(ids, 6, async (groupId) => {
-				const doc = await bondGetGroup({ baseUrl, token, groupId })
-				return summarizeGroup(groupId, doc)
+			return await withBondBridgeRequest({
+				bridge,
+				operation: 'list groups',
+				request: async (baseUrl) => {
+					const ids = await bondListGroupIds({ baseUrl, token })
+					return await mapPool(ids, 6, async (groupId) => {
+						const doc = await bondGetGroup({ baseUrl, token, groupId })
+						return summarizeGroup(groupId, doc)
+					})
+				},
 			})
 		},
 		async getGroup(bridgeId: string | undefined, groupId: string) {
 			const bridge = requireAdoptedBridge(bridgeId)
 			const token = requireToken(bridge)
-			return await bondGetGroup({
-				baseUrl: bridgeBaseUrl(bridge),
-				token,
-				groupId,
+			return await withBondBridgeRequest({
+				bridge,
+				operation: `fetch group ${groupId}`,
+				request: async (baseUrl) =>
+					await bondGetGroup({
+						baseUrl,
+						token,
+						groupId,
+					}),
 			})
 		},
 		async getGroupState(bridgeId: string | undefined, groupId: string) {
 			const bridge = requireAdoptedBridge(bridgeId)
 			const token = requireToken(bridge)
-			return await bondGetGroupState({
-				baseUrl: bridgeBaseUrl(bridge),
-				token,
-				groupId,
+			return await withBondBridgeRequest({
+				bridge,
+				operation: `fetch group ${groupId} state`,
+				request: async (baseUrl) =>
+					await bondGetGroupState({
+						baseUrl,
+						token,
+						groupId,
+					}),
 			})
 		},
 		async invokeGroupAction(input: {
@@ -449,11 +666,15 @@ export function createBondAdapter(input: {
 		}) {
 			const bridge = requireAdoptedBridge(input.bridgeId)
 			const token = requireToken(bridge)
-			const baseUrl = bridgeBaseUrl(bridge)
-			const doc = await bondGetGroup({
-				baseUrl,
-				token,
-				groupId: input.groupId,
+			const doc = await withBondBridgeRequest({
+				bridge,
+				operation: `fetch group ${input.groupId} before action`,
+				request: async (baseUrl) =>
+					await bondGetGroup({
+						baseUrl,
+						token,
+						groupId: input.groupId,
+					}),
 			})
 			const rawActions = doc['actions']
 			if (!Array.isArray(rawActions) || rawActions.length === 0) {
@@ -467,12 +688,17 @@ export function createBondAdapter(input: {
 					`Group "${input.groupId}" does not advertise action "${input.action}".`,
 				)
 			}
-			return await bondInvokeGroupAction({
-				baseUrl,
-				token,
-				groupId: input.groupId,
-				action: input.action,
-				argument: input.argument,
+			return await withBondBridgeRequest({
+				bridge,
+				operation: `invoke group ${input.groupId} action ${input.action}`,
+				request: async (baseUrl) =>
+					await bondInvokeGroupAction({
+						baseUrl,
+						token,
+						groupId: input.groupId,
+						action: input.action,
+						argument: input.argument,
+					}),
 			})
 		},
 	}

--- a/packages/home-connector/src/adapters/bond/index.ts
+++ b/packages/home-connector/src/adapters/bond/index.ts
@@ -31,9 +31,7 @@ import {
 	type BondGroupSummary,
 	type BondPersistedBridge,
 } from './types.ts'
-import {
-	type HomeConnectorErrorCaptureContext,
-} from '../../sentry.ts'
+import { type HomeConnectorErrorCaptureContext } from '../../sentry.ts'
 
 function normalizeQuery(value: string) {
 	return value.trim().toLowerCase()
@@ -145,6 +143,26 @@ function createBondBaseUrlCandidates(bridge: BondPersistedBridge) {
 	return fallback === primary ? [primary] : [primary, fallback]
 }
 
+function getErrorCauseMessage(error: Error): string | null {
+	const cause = error.cause
+	if (cause instanceof Error) {
+		return cause.message
+	}
+	if (typeof cause === 'string') {
+		return cause
+	}
+	if (cause && typeof cause === 'object') {
+		const message = (cause as { message?: unknown }).message
+		if (typeof message === 'string' && message.trim()) {
+			return message
+		}
+		if (message != null) {
+			return String(message)
+		}
+	}
+	return null
+}
+
 function isBondNetworkFailure(error: unknown) {
 	if (!(error instanceof Error)) {
 		return false
@@ -160,15 +178,7 @@ function isBondNetworkFailure(error: unknown) {
 	) {
 		return true
 	}
-	const causeMessage =
-		error.cause instanceof Error
-			? error.cause.message.toLowerCase()
-			: typeof error.cause === 'string'
-				? error.cause.toLowerCase()
-				: error.cause && typeof error.cause === 'object'
-					? String((error.cause as { message?: unknown }).message ?? '')
-							.toLowerCase()
-				: ''
+	const causeMessage = (getErrorCauseMessage(error) ?? '').toLowerCase()
 	return (
 		causeMessage.includes('enotfound') ||
 		causeMessage.includes('eai_again') ||
@@ -181,14 +191,7 @@ function isBondNetworkFailure(error: unknown) {
 
 function formatBondFailureReason(error: unknown) {
 	if (error instanceof Error) {
-		const causeMessage =
-			error.cause instanceof Error
-				? error.cause.message
-				: typeof error.cause === 'string'
-					? error.cause
-					: error.cause && typeof error.cause === 'object'
-						? String((error.cause as { message?: unknown }).message ?? '')
-					: null
+		const causeMessage = getErrorCauseMessage(error)
 		return causeMessage ? `${error.message}; cause=${causeMessage}` : error.message
 	}
 	return String(error)
@@ -201,10 +204,11 @@ function createBondActionableError(input: {
 	baseUrlsTried: Array<string>
 }) {
 	const connection = getBondBridgeConnectionContext(input.bridge)
+	const failureReason = formatBondFailureReason(input.error)
 	const guidance = connection.host.endsWith('.local')
 		? ' The stored Bond host ends in .local, so this usually means the container cannot resolve mDNS on the LAN. If this connector runs in a NAS/container without mDNS, update the bridge host to a stable IP with bond_update_bridge_connection or restore mDNS/DNS visibility for the container.'
 		: ' Verify the bridge host/IP is still reachable from the home-connector container and update it with bond_update_bridge_connection if it changed.'
-	const errorMessage = `Bond bridge "${input.bridge.bridgeId}" could not be reached while trying to ${input.operation} at ${input.baseUrlsTried.join(', ')}. ${formatBondFailureReason(input.error)}.${guidance}`
+	const errorMessage = `Bond bridge "${input.bridge.bridgeId}" could not be reached while trying to ${input.operation} at ${input.baseUrlsTried.join(', ')}. ${failureReason}.${guidance}`
 	const wrappedError = new Error(errorMessage, {
 		cause: input.error instanceof Error ? input.error : undefined,
 	}) as Error & {
@@ -228,7 +232,7 @@ function createBondActionableError(input: {
 		extra: {
 			bondOperation: input.operation,
 			bondBaseUrlsTried: input.baseUrlsTried,
-			bondFailureReason: formatBondFailureReason(input.error),
+			bondFailureReason: failureReason,
 		},
 	}
 	return wrappedError
@@ -240,15 +244,20 @@ async function withBondBridgeRequest<T>(input: {
 	request: (baseUrl: string) => Promise<T>
 }) {
 	const baseUrls = createBondBaseUrlCandidates(input.bridge)
+	const attemptedBaseUrls: Array<string> = []
 	let lastError: unknown = null
 	for (let index = 0; index < baseUrls.length; index += 1) {
 		const baseUrl = baseUrls[index]!
+		attemptedBaseUrls.push(baseUrl)
 		try {
 			return await input.request(baseUrl)
 		} catch (error) {
 			lastError = error
+			if (!isBondNetworkFailure(error)) {
+				throw error
+			}
 			const canRetryWithFallback =
-				index === 0 && baseUrls.length > 1 && isBondNetworkFailure(error)
+				index === 0 && baseUrls.length > 1
 			if (!canRetryWithFallback) {
 				break
 			}
@@ -258,7 +267,7 @@ async function withBondBridgeRequest<T>(input: {
 		bridge: input.bridge,
 		operation: input.operation,
 		error: lastError,
-		baseUrlsTried: baseUrls,
+		baseUrlsTried: attemptedBaseUrls,
 	})
 }
 

--- a/packages/home-connector/src/sentry.node.test.ts
+++ b/packages/home-connector/src/sentry.node.test.ts
@@ -2,6 +2,8 @@ import { expect, test, vi } from 'vitest'
 
 const sentryMock = vi.hoisted(() => ({
 	addBreadcrumb: vi.fn(),
+	captureException: vi.fn(),
+	captureMessage: vi.fn(),
 	close: vi.fn(),
 	flush: vi.fn(),
 	init: vi.fn(),
@@ -15,8 +17,10 @@ vi.mock('@sentry/node', () => sentryMock)
 const {
 	buildHomeConnectorSentryOptions,
 	addHomeConnectorSentryBreadcrumb,
+	captureHomeConnectorException,
 	closeHomeConnectorSentry,
 	flushHomeConnectorSentry,
+	getHomeConnectorErrorCaptureContext,
 	initializeHomeConnectorSentry,
 } = await import('./sentry.ts')
 
@@ -124,4 +128,114 @@ test('addHomeConnectorSentryBreadcrumb is a no-op when Sentry is disabled', () =
 	})
 
 	expect(sentryMock.addBreadcrumb).not.toHaveBeenCalled()
+})
+
+test('getHomeConnectorErrorCaptureContext returns a cloned capture context', () => {
+	const error = new Error('boom') as Error & {
+		homeConnectorCaptureContext?: {
+			tags?: Record<string, string>
+			contexts?: Record<string, Record<string, unknown>>
+			extra?: Record<string, unknown>
+		}
+	}
+	error.homeConnectorCaptureContext = {
+		tags: {
+			connector_family: 'bond',
+		},
+		contexts: {
+			bond: {
+				bridgeId: 'bond-1',
+			},
+		},
+		extra: {
+			durationMs: 48,
+		},
+	}
+
+	const captureContext = getHomeConnectorErrorCaptureContext(error)
+	expect(captureContext).toEqual({
+		tags: {
+			connector_family: 'bond',
+		},
+		contexts: {
+			bond: {
+				bridgeId: 'bond-1',
+			},
+		},
+		extra: {
+			durationMs: 48,
+		},
+	})
+	expect(captureContext.tags).not.toBe(error.homeConnectorCaptureContext.tags)
+	expect(captureContext.contexts).not.toBe(
+		error.homeConnectorCaptureContext.contexts,
+	)
+	expect(captureContext.extra).not.toBe(error.homeConnectorCaptureContext.extra)
+})
+
+test('captureHomeConnectorException merges error capture context', () => {
+	sentryMock.isEnabled.mockReturnValue(true)
+	sentryMock.captureException.mockReset()
+	const error = new Error('boom') as Error & {
+		homeConnectorCaptureContext?: {
+			tags?: Record<string, string>
+			contexts?: Record<string, Record<string, unknown>>
+			extra?: Record<string, unknown>
+		}
+	}
+	error.homeConnectorCaptureContext = {
+		tags: {
+			connector_family: 'bond',
+			connector_tool_name: 'bond_get_device_state',
+		},
+		contexts: {
+			bond: {
+				bridgeId: 'bond-1',
+				host: 'bridge.local',
+			},
+		},
+		extra: {
+			requestId: 'abc123',
+		},
+	}
+
+	captureHomeConnectorException(error, {
+		tags: {
+			connector_event: 'tool_call.failure',
+		},
+		contexts: {
+			mcp_request: {
+				method: 'tools/call',
+			},
+		},
+		extra: {
+			durationMs: 48,
+		},
+	})
+
+	expect(sentryMock.captureException).toHaveBeenCalledTimes(1)
+	const [capturedError, captureContext] =
+		sentryMock.captureException.mock.calls[0] ?? []
+	expect(capturedError).toBe(error)
+	expect(captureContext).toEqual({
+		tags: {
+			service: 'home-connector',
+			connector_family: 'bond',
+			connector_tool_name: 'bond_get_device_state',
+			connector_event: 'tool_call.failure',
+		},
+		contexts: {
+			bond: {
+				bridgeId: 'bond-1',
+				host: 'bridge.local',
+			},
+			mcp_request: {
+				method: 'tools/call',
+			},
+		},
+		extra: {
+			requestId: 'abc123',
+			durationMs: 48,
+		},
+	})
 })

--- a/packages/home-connector/src/sentry.node.test.ts
+++ b/packages/home-connector/src/sentry.node.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
 
 const sentryMock = vi.hoisted(() => ({
 	addBreadcrumb: vi.fn(),
@@ -13,6 +13,10 @@ const sentryMock = vi.hoisted(() => ({
 }))
 
 vi.mock('@sentry/node', () => sentryMock)
+
+afterEach(() => {
+	sentryMock.isEnabled.mockReturnValue(false)
+})
 
 const {
 	buildHomeConnectorSentryOptions,
@@ -169,6 +173,9 @@ test('getHomeConnectorErrorCaptureContext returns a cloned capture context', () 
 	expect(captureContext.tags).not.toBe(error.homeConnectorCaptureContext.tags)
 	expect(captureContext.contexts).not.toBe(
 		error.homeConnectorCaptureContext.contexts,
+	)
+	expect(captureContext.contexts?.bond).not.toBe(
+		error.homeConnectorCaptureContext.contexts?.bond,
 	)
 	expect(captureContext.extra).not.toBe(error.homeConnectorCaptureContext.extra)
 })

--- a/packages/home-connector/src/sentry.ts
+++ b/packages/home-connector/src/sentry.ts
@@ -1,9 +1,11 @@
 import * as Sentry from '@sentry/node'
 
 type EnvRecord = Record<string, string | undefined>
+type SentryContextValue = Record<string, unknown> | undefined
+type SentryContextMap = Record<string, SentryContextValue>
 export type HomeConnectorErrorCaptureContext = {
 	tags?: Record<string, string>
-	contexts?: Record<string, Record<string, unknown>>
+	contexts?: SentryContextMap
 	extra?: Record<string, unknown>
 }
 
@@ -34,18 +36,22 @@ function normalizeError(error: unknown) {
 }
 
 function mergeContextRecords(
-	base: Record<string, Record<string, unknown>> | undefined,
-	override: Record<string, Record<string, unknown>> | undefined,
+	base: SentryContextMap | undefined,
+	override: SentryContextMap | undefined,
 ) {
 	if (!base && !override) return undefined
-	const merged: Record<string, Record<string, unknown>> = {
-		...(base ?? {}),
+	const merged: SentryContextMap = {}
+	for (const [key, value] of Object.entries(base ?? {})) {
+		merged[key] = value ? { ...value } : undefined
 	}
 	for (const [key, value] of Object.entries(override ?? {})) {
-		merged[key] = {
-			...(merged[key] ?? {}),
-			...value,
-		}
+		merged[key] =
+			value === undefined
+				? undefined
+				: {
+						...(merged[key] ?? {}),
+						...value,
+					}
 	}
 	return merged
 }
@@ -66,7 +72,14 @@ export function getHomeConnectorErrorCaptureContext(
 	return {
 		...(captureContext.tags ? { tags: { ...captureContext.tags } } : {}),
 		...(captureContext.contexts
-			? { contexts: { ...captureContext.contexts } }
+			? {
+					contexts: Object.fromEntries(
+						Object.entries(captureContext.contexts).map(([key, value]) => [
+							key,
+							value ? { ...value } : undefined,
+						]),
+					),
+				}
 			: {}),
 		...(captureContext.extra ? { extra: { ...captureContext.extra } } : {}),
 	}
@@ -143,9 +156,7 @@ export function captureHomeConnectorException(
 		},
 		contexts: mergeContextRecords(
 			derivedCaptureContext.contexts,
-			captureContext.contexts as
-				| Record<string, Record<string, unknown>>
-				| undefined,
+			captureContext.contexts as SentryContextMap | undefined,
 		),
 		extra: {
 			...(derivedCaptureContext.extra ?? {}),

--- a/packages/home-connector/src/sentry.ts
+++ b/packages/home-connector/src/sentry.ts
@@ -1,6 +1,15 @@
 import * as Sentry from '@sentry/node'
 
 type EnvRecord = Record<string, string | undefined>
+export type HomeConnectorErrorCaptureContext = {
+	tags?: Record<string, string>
+	contexts?: Record<string, Record<string, unknown>>
+	extra?: Record<string, unknown>
+}
+
+type HomeConnectorErrorWithCaptureContext = {
+	homeConnectorCaptureContext?: HomeConnectorErrorCaptureContext
+}
 
 const defaultTracesSampleRate = 1.0
 
@@ -22,6 +31,45 @@ function parseSentryTracesSampleRate(value: string | undefined) {
 
 function normalizeError(error: unknown) {
 	return error instanceof Error ? error : new Error(String(error))
+}
+
+function mergeContextRecords(
+	base: Record<string, Record<string, unknown>> | undefined,
+	override: Record<string, Record<string, unknown>> | undefined,
+) {
+	if (!base && !override) return undefined
+	const merged: Record<string, Record<string, unknown>> = {
+		...(base ?? {}),
+	}
+	for (const [key, value] of Object.entries(override ?? {})) {
+		merged[key] = {
+			...(merged[key] ?? {}),
+			...value,
+		}
+	}
+	return merged
+}
+
+export function getHomeConnectorErrorCaptureContext(
+	error: unknown,
+): HomeConnectorErrorCaptureContext {
+	if (!error || typeof error !== 'object') {
+		return {}
+	}
+
+	const captureContext = (error as HomeConnectorErrorWithCaptureContext)
+		.homeConnectorCaptureContext
+	if (!captureContext) {
+		return {}
+	}
+
+	return {
+		...(captureContext.tags ? { tags: { ...captureContext.tags } } : {}),
+		...(captureContext.contexts
+			? { contexts: { ...captureContext.contexts } }
+			: {}),
+		...(captureContext.extra ? { extra: { ...captureContext.extra } } : {}),
+	}
 }
 
 export function buildHomeConnectorSentryOptions(env: EnvRecord = process.env) {
@@ -83,11 +131,25 @@ export function captureHomeConnectorException(
 		return
 	}
 
+	const derivedCaptureContext = getHomeConnectorErrorCaptureContext(error)
+
 	Sentry.captureException(normalizeError(error), {
+		...derivedCaptureContext,
 		...captureContext,
 		tags: {
 			service: 'home-connector',
+			...(derivedCaptureContext.tags ?? {}),
 			...(captureContext.tags ?? {}),
+		},
+		contexts: mergeContextRecords(
+			derivedCaptureContext.contexts,
+			captureContext.contexts as
+				| Record<string, Record<string, unknown>>
+				| undefined,
+		),
+		extra: {
+			...(derivedCaptureContext.extra ?? {}),
+			...(captureContext.extra ?? {}),
 		},
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- wrap Bond bridge requests so `.local`/network fetch failures surface actionable bridge context instead of a generic `TypeError: fetch failed`
- retry once against the discovered Bond IPv4 address when the stored host fails with a DNS/network-style fetch error
- keep non-network Bond API failures unwrapped so HTTP/auth errors are not mislabeled as mDNS reachability problems
- add focused tests for the fallback path, untried URL reporting, non-network error handling, and merged Sentry capture context

## Likely root cause
The repeated production failures most likely come from the home-connector storing a Bond bridge hostname that ends in `.local` and then trying to fetch Bond endpoints from inside a NAS/container that cannot resolve mDNS on the LAN. In that case Node fetch throws `TypeError: fetch failed` with an underlying `getaddrinfo ENOTFOUND ...local`, which matches the production/NAS logs.

## Operator guidance
If Bond failures mention a `.local` host or `ENOTFOUND`, the immediate operator action is:
1. confirm whether the container has mDNS/DNS visibility to the LAN
2. if not, update the stored Bond bridge connection to a stable IP via `bond_update_bridge_connection`
3. otherwise restore container/network mDNS reachability

This change makes those failures much more actionable in Sentry/logs, uses the last discovered IPv4 address as a safe fallback when it is available, and avoids pointing operators at mDNS when the real issue is an HTTP-level Bond response.

## Testing
- `npm test -- --run src/adapters/bond/index.node.test.ts src/sentry.node.test.ts`
- `npm run typecheck`

## Artifacts
- <a href="/opt/cursor/artifacts/bond-test-evidence.html">Focused test evidence</a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8d40303-421c-4dac-9ce8-20d1463eb8d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8d40303-421c-4dac-9ce8-20d1463eb8d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bond bridge connectivity now automatically falls back to discovered IPs when mDNS (.local) resolution fails, and shows clearer, actionable error messages for connection failures.
  * Improved error reporting to preserve HTTP/status details when non-network errors occur.

* **Improvements**
  * Enhanced error capture merging so diagnostic context (tags, contexts, extra) is combined and includes service identification.

* **Tests**
  * Added tests covering Bond adapter connectivity/fallback and improved error capture behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->