### PR TITLE
Add TypeScript capability schema definitions

### DIFF
--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -24,9 +24,11 @@ small.
 ## Single-entity detail
 
 To get **full markdown and call shapes for one hit** (for example a capability’s
-`inputTypeDefinition` / `outputTypeDefinition` plus `inputSchema` /
-`outputSchema`), call **search** again with **`entity`** set to `"{id}:{type}"`
-where **`type`** is `capability`, `value`, `connector`, `package`, or `secret`.
+`inputTypeDefinition` / `outputTypeDefinition`), call **search** again with
+**`entity`** set to `"{id}:{type}"` where **`type`** is `capability`, `value`,
+`connector`, `package`, or `secret`. Capability detail omits raw JSON schemas by
+default; pass **`includeSchemas: true`** only when you explicitly need
+`inputSchema` / `outputSchema`.
 
 Examples:
 

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -23,10 +23,10 @@ small.
 
 ## Single-entity detail
 
-To get **full markdown and schemas for one hit** (for example a capability’s
-`inputSchema` / `outputSchema`), call **search** again with **`entity`** set to
-`"{id}:{type}"` where **`type`** is `capability`, `value`, `connector`,
-`package`, or `secret`.
+To get **full markdown and call shapes for one hit** (for example a capability’s
+`inputTypeDefinition` / `outputTypeDefinition` plus `inputSchema` /
+`outputSchema`), call **search** again with **`entity`** set to `"{id}:{type}"`
+where **`type`** is `capability`, `value`, `connector`, `package`, or `secret`.
 
 Examples:
 

--- a/packages/worker/src/mcp/capabilities/build-capability-registry.ts
+++ b/packages/worker/src/mcp/capabilities/build-capability-registry.ts
@@ -102,6 +102,10 @@ function createCapabilitySpecs(capabilities: Array<Capability>) {
 					...(capability.outputSchema
 						? { outputSchema: capability.outputSchema }
 						: {}),
+					inputTypeDefinition: capability.inputTypeDefinition,
+					...(capability.outputTypeDefinition
+						? { outputTypeDefinition: capability.outputTypeDefinition }
+						: {}),
 				},
 			] as const,
 	)

--- a/packages/worker/src/mcp/capabilities/capability-search.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.ts
@@ -127,6 +127,8 @@ export type CapabilityDetailRow = CapabilitySummaryRow & {
 	destructive: boolean
 	inputSchema: unknown
 	outputSchema?: unknown
+	inputTypeDefinition: string
+	outputTypeDefinition?: string
 	inputFields?: Array<string>
 	outputFields?: Array<string>
 }
@@ -167,6 +169,10 @@ function toDetail(spec: CapabilitySpec): CapabilityDetailRow {
 		destructive: spec.destructive,
 		inputSchema,
 		...(outputSchema ? { outputSchema } : {}),
+		inputTypeDefinition: spec.inputTypeDefinition,
+		...(spec.outputTypeDefinition
+			? { outputTypeDefinition: spec.outputTypeDefinition }
+			: {}),
 	}
 	if (!spec.inputSchema) {
 		row.inputFields = spec.inputFields

--- a/packages/worker/src/mcp/capabilities/capability-search.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.ts
@@ -125,7 +125,7 @@ export type CapabilityDetailRow = CapabilitySummaryRow & {
 	readOnly: boolean
 	idempotent: boolean
 	destructive: boolean
-	inputSchema: unknown
+	inputSchema?: unknown
 	outputSchema?: unknown
 	inputTypeDefinition: string
 	outputTypeDefinition?: string
@@ -152,10 +152,15 @@ function toSummary(spec: CapabilitySpec): CapabilitySummaryRow {
 	}
 }
 
-function toDetail(spec: CapabilitySpec): CapabilityDetailRow {
-	const inputSchema = compressSchemaForLlm(spec.inputSchema)
+function toDetail(
+	spec: CapabilitySpec,
+	includeSchemas: boolean,
+): CapabilityDetailRow {
+	const inputSchema = includeSchemas
+		? compressSchemaForLlm(spec.inputSchema)
+		: undefined
 	const outputSchema =
-		'outputSchema' in spec && spec.outputSchema !== undefined
+		includeSchemas && 'outputSchema' in spec && spec.outputSchema !== undefined
 			? compressSchemaForLlm(spec.outputSchema, {
 					stripRootObjectType: false,
 				})
@@ -167,7 +172,7 @@ function toDetail(spec: CapabilitySpec): CapabilityDetailRow {
 		readOnly: spec.readOnly,
 		idempotent: spec.idempotent,
 		destructive: spec.destructive,
-		inputSchema,
+		...(includeSchemas ? { inputSchema } : {}),
 		...(outputSchema ? { outputSchema } : {}),
 		inputTypeDefinition: spec.inputTypeDefinition,
 		...(spec.outputTypeDefinition
@@ -233,6 +238,7 @@ export async function searchCapabilities(input: {
 	query: string
 	limit: number
 	detail: boolean
+	includeSchemas?: boolean
 	specs: Record<string, CapabilitySpec>
 	/** When set (online only), Vectorize query uses this metadata filter first; falls back to unfiltered if no spec ids match. */
 	vectorMetadataFilter?: VectorizeVectorMetadataFilter
@@ -341,7 +347,9 @@ export async function searchCapabilities(input: {
 
 	const matches: Array<CapabilitySearchHit> = ordered.map((id) => {
 		const spec = specs[id]!
-		const base = input.detail ? toDetail(spec) : toSummary(spec)
+		const base = input.detail
+			? toDetail(spec, input.includeSchemas === true)
+			: toSummary(spec)
 		const rawVectorScore = vectorScoreById[id]
 		const vectorScore =
 			rawVectorScore !== undefined && Number.isFinite(rawVectorScore)

--- a/packages/worker/src/mcp/capabilities/capability-search.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.workers.test.ts
@@ -119,8 +119,57 @@ test('offline search returns provided specs without depending on global ranks', 
 		expect.arrayContaining(['oauth', 'redirect uri', 'provider registration']),
 	)
 	expect(matches[0]?.outputFields).toEqual(['title', 'body'])
+	expect(matches[0]).not.toHaveProperty('inputSchema')
 	expect(matches[0]?.lexicalRank).toBe(1)
 	expect(matches[0]?.vectorRank).toBe(1)
+})
+
+test('detailed capability search includes schemas only when requested', async () => {
+	const specs = {
+		kody_official_guide: {
+			name: 'kody_official_guide',
+			domain: 'coding',
+			description: 'Load official Kody guides.',
+			keywords: ['guide'],
+			readOnly: true,
+			idempotent: true,
+			destructive: false,
+			inputFields: ['guide'],
+			requiredInputFields: ['guide'],
+			outputFields: [],
+			inputSchema: {
+				type: 'object',
+				properties: {
+					guide: { type: 'string' },
+				},
+				required: ['guide'],
+			},
+			inputTypeDefinition:
+				'type KodyOfficialGuideInput = {\n\tguide: string\n}',
+		},
+	} satisfies Record<string, CapabilitySpec>
+	const env = {
+		SENTRY_ENVIRONMENT: 'test',
+		AI: {} as Ai,
+	} as Env
+
+	const { matches } = await searchCapabilities({
+		env,
+		query: 'guide',
+		limit: 1,
+		detail: true,
+		includeSchemas: true,
+		specs,
+	})
+
+	expect(matches[0]).toMatchObject({
+		inputSchema: expect.objectContaining({
+			properties: expect.objectContaining({
+				guide: expect.objectContaining({ type: 'string' }),
+			}),
+		}),
+		inputTypeDefinition: expect.stringContaining('KodyOfficialGuideInput'),
+	})
 })
 
 test('online search semantically ranks runtime-only capabilities missing from Vectorize', async () => {

--- a/packages/worker/src/mcp/capabilities/capability-search.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.workers.test.ts
@@ -22,6 +22,7 @@ test('buildCapabilityEmbedText folds searchable capability fields into one docum
 		requiredInputFields: ['sourceId'],
 		outputFields: ['deploymentId'],
 		inputSchema: {},
+		inputTypeDefinition: 'type DeployWorkerInput = Record<string, unknown>',
 	} satisfies CapabilitySpec
 
 	expect(buildCapabilityEmbedText(spec)).toBe(
@@ -94,6 +95,8 @@ test('offline search returns provided specs without depending on global ranks', 
 				},
 				required: ['guide'],
 			},
+			inputTypeDefinition:
+				'type KodyOfficialGuideInput = {\n\tguide: "integration_bootstrap" | "secret_backed_integration" | "oauth" | "generated_ui_oauth" | "connect_secret"\n}',
 		},
 	} satisfies Record<string, CapabilitySpec>
 	const env = {
@@ -142,6 +145,8 @@ test('online search semantically ranks runtime-only capabilities missing from Ve
 				},
 				required: ['owner', 'repo'],
 			},
+			inputTypeDefinition:
+				'type GithubEnableIssueNotificationsInput = {\n\towner: string\n\trepo: string\n}',
 		},
 		home_roku_press_key: {
 			name: 'home_roku_press_key',
@@ -163,6 +168,8 @@ test('online search semantically ranks runtime-only capabilities missing from Ve
 				},
 				required: ['deviceId', 'key'],
 			},
+			inputTypeDefinition:
+				'type HomeRokuPressKeyInput = {\n\tdeviceId: string\n\tkey: string\n}',
 		},
 	} satisfies Record<string, CapabilitySpec>
 	const env = {

--- a/packages/worker/src/mcp/capabilities/define-capability.ts
+++ b/packages/worker/src/mcp/capabilities/define-capability.ts
@@ -11,6 +11,10 @@ import {
 	type CapabilitySchemaDefinition,
 	type InferCapabilitySchema,
 } from './types.ts'
+import {
+	createCapabilityTypeName,
+	createSchemaTypeDefinition,
+} from './schema-type-definitions.ts'
 
 // Normalize capability authoring input into the JSON-Schema-based shape
 // consumed by the registry and sandbox search surface.
@@ -23,6 +27,10 @@ export function defineCapability<
 		? createSchemaParser(definition.outputSchema)
 		: null
 	const keywords = mergeKeywords(definition.keywords, definition.tags)
+	const inputSchema = toJsonSchema(definition.inputSchema)
+	const outputSchema = definition.outputSchema
+		? toJsonSchema(definition.outputSchema)
+		: undefined
 
 	return {
 		name: definition.name,
@@ -32,9 +40,19 @@ export function defineCapability<
 		readOnly: definition.readOnly ?? false,
 		idempotent: definition.idempotent ?? false,
 		destructive: definition.destructive ?? false,
-		inputSchema: toJsonSchema(definition.inputSchema),
-		...(definition.outputSchema
-			? { outputSchema: toJsonSchema(definition.outputSchema) }
+		inputSchema,
+		...(outputSchema ? { outputSchema } : {}),
+		inputTypeDefinition: createSchemaTypeDefinition({
+			jsonSchema: inputSchema,
+			typeName: createCapabilityTypeName(definition.name, 'Input'),
+		}),
+		...(definition.outputSchema && outputSchema
+			? {
+					outputTypeDefinition: createSchemaTypeDefinition({
+						jsonSchema: outputSchema,
+						typeName: createCapabilityTypeName(definition.name, 'Output'),
+					}),
+				}
 			: {}),
 		async handler(args, ctx) {
 			const startedAt = performance.now()

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
@@ -134,6 +134,7 @@ test('meta_list_capabilities includes runtime home capabilities from the connect
 			'type HomeRokuPressKeyInput =',
 		),
 	})
+	expect(homeCapability).not.toHaveProperty('inputSchema')
 	expect(listAppsCapability).not.toBeUndefined()
 	expect(listAppsCapability?.domain).toBe('home')
 	expect(listAppsCapability).toMatchObject({
@@ -141,8 +142,66 @@ test('meta_list_capabilities includes runtime home capabilities from the connect
 			'type HomeRokuListAppsOutput =',
 		),
 	})
+	expect(listAppsCapability).not.toHaveProperty('outputSchema')
 	expect(activeAppCapability).not.toBeUndefined()
 	expect(activeAppCapability?.domain).toBe('home')
+})
+
+test('meta_list_capabilities includes schemas only when requested', async () => {
+	const env = {
+		HOME_CONNECTOR_SESSION: {
+			idFromName(name: string) {
+				return name
+			},
+			get() {
+				return {
+					fetch() {
+						return Promise.resolve(
+							Response.json({
+								connectorId: 'default',
+								connectedAt: '2026-03-25T00:00:00.000Z',
+								lastSeenAt: '2026-03-25T00:00:01.000Z',
+								tools: runtimeHomeTools,
+							}),
+						)
+					},
+				}
+			},
+		},
+	} as unknown as Env
+
+	const result = await metaListCapabilitiesCapability.handler(
+		{
+			detail: true,
+			includeSchemas: true,
+		},
+		{
+			env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				homeConnectorId: 'default',
+			}),
+		},
+	)
+
+	const homeCapability = result.capabilities.find(
+		(capability) => capability.name === 'home_roku_press_key',
+	)
+	const listAppsCapability = result.capabilities.find(
+		(capability) => capability.name === 'home_roku_list_apps',
+	)
+	expect(homeCapability).toMatchObject({
+		inputSchema: expect.objectContaining({ type: 'object' }),
+		inputTypeDefinition: expect.stringContaining(
+			'type HomeRokuPressKeyInput =',
+		),
+	})
+	expect(listAppsCapability).toMatchObject({
+		outputSchema: expect.objectContaining({ type: 'object' }),
+		outputTypeDefinition: expect.stringContaining(
+			'type HomeRokuListAppsOutput =',
+		),
+	})
 })
 
 test('meta_list_capabilities filters by domain', async () => {

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
@@ -65,8 +65,8 @@ const runtimeHomeTools = [
 	},
 ] as const
 
-test('meta_list_capabilities includes runtime home capabilities from the connected connector', async () => {
-	const env = {
+function buildHomeConnectorEnv() {
+	return {
 		HOME_CONNECTOR_SESSION: {
 			idFromName(name: string) {
 				return name
@@ -97,6 +97,10 @@ test('meta_list_capabilities includes runtime home capabilities from the connect
 			},
 		},
 	} as unknown as Env
+}
+
+test('meta_list_capabilities includes runtime home capabilities from the connected connector', async () => {
+	const env = buildHomeConnectorEnv()
 
 	const result = await metaListCapabilitiesCapability.handler(
 		{
@@ -148,27 +152,7 @@ test('meta_list_capabilities includes runtime home capabilities from the connect
 })
 
 test('meta_list_capabilities includes schemas only when requested', async () => {
-	const env = {
-		HOME_CONNECTOR_SESSION: {
-			idFromName(name: string) {
-				return name
-			},
-			get() {
-				return {
-					fetch() {
-						return Promise.resolve(
-							Response.json({
-								connectorId: 'default',
-								connectedAt: '2026-03-25T00:00:00.000Z',
-								lastSeenAt: '2026-03-25T00:00:01.000Z',
-								tools: runtimeHomeTools,
-							}),
-						)
-					},
-				}
-			},
-		},
-	} as unknown as Env
+	const env = buildHomeConnectorEnv()
 
 	const result = await metaListCapabilitiesCapability.handler(
 		{

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
@@ -129,8 +129,18 @@ test('meta_list_capabilities includes runtime home capabilities from the connect
 	expect(homeCapability).not.toBeUndefined()
 	expect(homeCapability?.domain).toBe('home')
 	expect(homeCapability?.requiredInputFields).toEqual(['deviceId', 'key'])
+	expect(homeCapability).toMatchObject({
+		inputTypeDefinition: expect.stringContaining(
+			'type HomeRokuPressKeyInput =',
+		),
+	})
 	expect(listAppsCapability).not.toBeUndefined()
 	expect(listAppsCapability?.domain).toBe('home')
+	expect(listAppsCapability).toMatchObject({
+		outputTypeDefinition: expect.stringContaining(
+			'type HomeRokuListAppsOutput =',
+		),
+	})
 	expect(activeAppCapability).not.toBeUndefined()
 	expect(activeAppCapability?.domain).toBe('home')
 })

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.ts
@@ -15,7 +15,7 @@ const capabilitySummarySchema = z.object({
 })
 
 const capabilityDetailSchema = capabilitySummarySchema.extend({
-	inputSchema: z.unknown(),
+	inputSchema: z.unknown().optional(),
 	outputSchema: z.unknown().optional(),
 	inputTypeDefinition: z.string(),
 	outputTypeDefinition: z.string().optional(),
@@ -56,7 +56,7 @@ export const metaListCapabilitiesCapability = defineDomainCapability(
 	{
 		name: 'meta_list_capabilities',
 		description:
-			'List the current runtime capability registry, including dynamic capabilities such as connected home tools. Use this when search seems incomplete and you need the exact capability names and schemas available right now.',
+			'List the current runtime capability registry, including dynamic capabilities such as connected home tools. Use this when search seems incomplete and you need exact capability names and TypeScript call shapes.',
 		keywords: [
 			'capabilities',
 			'list',
@@ -86,12 +86,18 @@ export const metaListCapabilitiesCapability = defineDomainCapability(
 				.boolean()
 				.optional()
 				.describe(
-					'Include schemas and full field lists when true. Defaults to false.',
+					'Include TypeScript type definitions and full field lists when true. Defaults to false.',
+				),
+			includeSchemas: z
+				.boolean()
+				.optional()
+				.describe(
+					'Only used with detail: true. Include raw JSON schemas in addition to TypeScript type definitions. Defaults to false.',
 				),
 		}),
 		outputSchema,
 		async handler(
-			args: { domain?: string; detail?: boolean },
+			args: { domain?: string; detail?: boolean; includeSchemas?: boolean },
 			ctx: CapabilityContext,
 		) {
 			const { getCapabilityRegistryForContext } =
@@ -112,8 +118,10 @@ export const metaListCapabilitiesCapability = defineDomainCapability(
 								idempotent: spec.idempotent,
 								destructive: spec.destructive,
 								requiredInputFields: spec.requiredInputFields,
-								inputSchema: spec.inputSchema,
-								...(spec.outputSchema
+								...(args.includeSchemas === true
+									? { inputSchema: spec.inputSchema }
+									: {}),
+								...(args.includeSchemas === true && spec.outputSchema
 									? { outputSchema: spec.outputSchema }
 									: {}),
 								inputTypeDefinition: spec.inputTypeDefinition,

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.ts
@@ -17,6 +17,8 @@ const capabilitySummarySchema = z.object({
 const capabilityDetailSchema = capabilitySummarySchema.extend({
 	inputSchema: z.unknown(),
 	outputSchema: z.unknown().optional(),
+	inputTypeDefinition: z.string(),
+	outputTypeDefinition: z.string().optional(),
 	inputFields: z.array(z.string()),
 	outputFields: z.array(z.string()),
 })
@@ -24,7 +26,7 @@ const capabilityDetailSchema = capabilitySummarySchema.extend({
 const outputSchema = z.object({
 	total: z.number().int().nonnegative(),
 	capabilities: z.array(
-		z.union([capabilitySummarySchema, capabilityDetailSchema]),
+		z.union([capabilityDetailSchema, capabilitySummarySchema]),
 	),
 })
 
@@ -113,6 +115,10 @@ export const metaListCapabilitiesCapability = defineDomainCapability(
 								inputSchema: spec.inputSchema,
 								...(spec.outputSchema
 									? { outputSchema: spec.outputSchema }
+									: {}),
+								inputTypeDefinition: spec.inputTypeDefinition,
+								...(spec.outputTypeDefinition
+									? { outputTypeDefinition: spec.outputTypeDefinition }
 									: {}),
 								inputFields: spec.inputFields,
 								outputFields: spec.outputFields,

--- a/packages/worker/src/mcp/capabilities/schema-type-definitions.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/schema-type-definitions.node.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'vitest'
+import { createSchemaTypeDefinition } from './schema-type-definitions.ts'
+import { type CapabilityJsonSchema } from './types.ts'
+
+test('parenthesizes union members when composing allOf intersections', () => {
+	const typeDefinition = createSchemaTypeDefinition({
+		typeName: 'IntersectedInput',
+		jsonSchema: {
+			allOf: [
+				{
+					anyOf: [{ type: 'string' }, { type: 'number' }],
+				},
+				{
+					type: 'object',
+					properties: {
+						id: { type: 'string' },
+					},
+					required: ['id'],
+				},
+			],
+		} as CapabilityJsonSchema,
+	})
+
+	expect(typeDefinition).toBe(
+		'type IntersectedInput = (string | number) & {\n\tid: string\n}',
+	)
+})

--- a/packages/worker/src/mcp/capabilities/schema-type-definitions.ts
+++ b/packages/worker/src/mcp/capabilities/schema-type-definitions.ts
@@ -1,0 +1,144 @@
+import { type CapabilityJsonSchema } from './types.ts'
+
+type TypeDefinitionOptions = {
+	jsonSchema: CapabilityJsonSchema
+	typeName: string
+}
+
+export function createCapabilityTypeName(
+	capabilityName: string,
+	suffix: 'Input' | 'Output',
+) {
+	const pascalName = capabilityName
+		.split(/[^a-zA-Z0-9]+/)
+		.filter(Boolean)
+		.map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+		.join('')
+	const safeName = pascalName || 'Capability'
+	return `${/^[A-Za-z_$]/.test(safeName) ? safeName : `Capability${safeName}`}${suffix}`
+}
+
+export function createSchemaTypeDefinition({
+	jsonSchema,
+	typeName,
+}: TypeDefinitionOptions) {
+	return createJsonSchemaTypeDefinition(jsonSchema, typeName)
+}
+
+function createJsonSchemaTypeDefinition(
+	schema: CapabilityJsonSchema,
+	typeName: string,
+) {
+	return `type ${typeName} = ${jsonSchemaToType(schema)}`
+}
+
+function jsonSchemaToType(schema: unknown): string {
+	if (schema === true) return 'unknown'
+	if (schema === false) return 'never'
+	if (!isRecord(schema)) return 'unknown'
+
+	if ('const' in schema) return literalToType(schema.const)
+	if (Array.isArray(schema.enum)) {
+		return (
+			schema.enum.map((value) => literalToType(value)).join(' | ') || 'never'
+		)
+	}
+	if (Array.isArray(schema.anyOf)) {
+		return joinSchemaTypes(schema.anyOf, ' | ')
+	}
+	if (Array.isArray(schema.oneOf)) {
+		return joinSchemaTypes(schema.oneOf, ' | ')
+	}
+	if (Array.isArray(schema.allOf)) {
+		return joinSchemaTypes(schema.allOf, ' & ')
+	}
+	if (Array.isArray(schema.type)) {
+		return schema.type
+			.map((type) => jsonSchemaToType({ ...schema, type }))
+			.join(' | ')
+	}
+
+	switch (schema.type) {
+		case 'string':
+			return 'string'
+		case 'number':
+		case 'integer':
+			return 'number'
+		case 'boolean':
+			return 'boolean'
+		case 'null':
+			return 'null'
+		case 'array':
+			return arraySchemaToType(schema)
+		case 'object':
+			return objectSchemaToType(schema)
+		default:
+			if (isRecord(schema.properties)) return objectSchemaToType(schema)
+			if ('items' in schema) return arraySchemaToType(schema)
+			return 'unknown'
+	}
+}
+
+function joinSchemaTypes(schemas: Array<unknown>, separator: ' | ' | ' & ') {
+	const types = schemas.map((subschema) => jsonSchemaToType(subschema))
+	if (types.length === 0) return 'never'
+	return types.join(separator)
+}
+
+function arraySchemaToType(schema: Record<string, unknown>) {
+	if (Array.isArray(schema.items)) {
+		return `[${schema.items.map((item) => jsonSchemaToType(item)).join(', ')}]`
+	}
+	return `Array<${jsonSchemaToType(schema.items)}>`
+}
+
+function objectSchemaToType(schema: Record<string, unknown>) {
+	const properties = isRecord(schema.properties) ? schema.properties : {}
+	const propertyEntries = Object.entries(properties)
+	const required = new Set(
+		Array.isArray(schema.required)
+			? schema.required.filter(
+					(value): value is string => typeof value === 'string',
+				)
+			: [],
+	)
+	const additionalProperties = schema.additionalProperties
+
+	if (propertyEntries.length === 0) {
+		if (additionalProperties === false) return 'Record<string, never>'
+		if (isRecord(additionalProperties)) {
+			return `Record<string, ${jsonSchemaToType(additionalProperties)}>`
+		}
+		return 'Record<string, unknown>'
+	}
+
+	const lines = propertyEntries.map(([name, propertySchema]) => {
+		const optional = required.has(name) ? '' : '?'
+		return `\t${formatPropertyName(name)}${optional}: ${jsonSchemaToType(propertySchema)}`
+	})
+	if (isRecord(additionalProperties)) {
+		lines.push(`\t[key: string]: ${jsonSchemaToType(additionalProperties)}`)
+	}
+
+	return `{\n${lines.join('\n')}\n}`
+}
+
+function formatPropertyName(name: string) {
+	return /^[A-Za-z_$][\w$]*$/.test(name) ? name : JSON.stringify(name)
+}
+
+function literalToType(value: unknown): string {
+	switch (typeof value) {
+		case 'string':
+			return JSON.stringify(value)
+		case 'number':
+		case 'boolean':
+			return String(value)
+		default:
+			return value === null ? 'null' : 'unknown'
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}

--- a/packages/worker/src/mcp/capabilities/schema-type-definitions.ts
+++ b/packages/worker/src/mcp/capabilities/schema-type-definitions.ts
@@ -80,9 +80,16 @@ function jsonSchemaToType(schema: unknown): string {
 }
 
 function joinSchemaTypes(schemas: Array<unknown>, separator: ' | ' | ' & ') {
-	const types = schemas.map((subschema) => jsonSchemaToType(subschema))
+	const types = schemas.map((subschema) => {
+		const type = jsonSchemaToType(subschema)
+		return separator === ' & ' ? parenthesizeUnion(type) : type
+	})
 	if (types.length === 0) return 'never'
 	return types.join(separator)
+}
+
+function parenthesizeUnion(type: string) {
+	return type.includes(' | ') ? `(${type})` : type
 }
 
 function arraySchemaToType(schema: Record<string, unknown>) {

--- a/packages/worker/src/mcp/capabilities/types.ts
+++ b/packages/worker/src/mcp/capabilities/types.ts
@@ -56,6 +56,8 @@ export type Capability = {
 	destructive: boolean
 	inputSchema: CapabilityJsonSchema
 	outputSchema?: JsonSchemaToolDescriptor['outputSchema']
+	inputTypeDefinition: string
+	outputTypeDefinition?: string
 	handler: (
 		args: Record<string, unknown>,
 		ctx: CapabilityContext,
@@ -75,6 +77,8 @@ export type CapabilitySpec = {
 	outputFields: Array<string>
 	inputSchema: JsonSchemaToolDescriptor['inputSchema']
 	outputSchema?: JsonSchemaToolDescriptor['outputSchema']
+	inputTypeDefinition: string
+	outputTypeDefinition?: string
 }
 
 /** Registry / MCP instruction row derived from a `DomainSpec`. */

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -196,7 +196,7 @@ test('entity detail formatting returns stable structured details for values and 
 	})
 })
 
-test('capability entity detail leads with TypeScript definitions and keeps schemas structured', () => {
+test('capability entity detail defaults to TypeScript definitions without schemas', () => {
 	const detail = formatEntityDetailMarkdown({
 		type: 'capability',
 		id: 'github_create_issue',
@@ -237,16 +237,69 @@ test('capability entity detail leads with TypeScript definitions and keeps schem
 		},
 	})
 
-	expect(detail.markdown.indexOf('## Type definitions')).toBeLessThan(
-		detail.markdown.indexOf('## Input schema'),
-	)
+	expect(detail.markdown).toContain('## Type definitions')
 	expect(detail.markdown).toContain('```ts')
 	expect(detail.markdown).toContain('type GithubCreateIssueInput')
 	expect(detail.markdown).toContain('type GithubCreateIssueOutput')
+	expect(detail.markdown).not.toContain('## Input schema')
+	expect(detail.markdown).not.toContain('## Output schema')
 	expect(detail.structured).toMatchObject({
 		type: 'capability',
 		inputTypeDefinition: expect.stringContaining('GithubCreateIssueInput'),
 		outputTypeDefinition: expect.stringContaining('GithubCreateIssueOutput'),
+	})
+	expect(detail.structured).not.toHaveProperty('inputSchema')
+	expect(detail.structured).not.toHaveProperty('outputSchema')
+})
+
+test('capability entity detail includes schemas only when explicitly requested', () => {
+	const detail = formatEntityDetailMarkdown(
+		{
+			type: 'capability',
+			id: 'github_create_issue',
+			title: 'github_create_issue',
+			description: 'Create a GitHub issue.',
+			spec: {
+				name: 'github_create_issue',
+				domain: 'coding',
+				description: 'Create a GitHub issue.',
+				keywords: ['github', 'issue'],
+				readOnly: false,
+				idempotent: false,
+				destructive: false,
+				inputFields: ['owner', 'repo', 'title'],
+				requiredInputFields: ['owner', 'repo', 'title'],
+				outputFields: ['issueUrl'],
+				inputSchema: {
+					type: 'object',
+					properties: {
+						owner: { type: 'string' },
+						repo: { type: 'string' },
+						title: { type: 'string' },
+						body: { type: 'string' },
+					},
+					required: ['owner', 'repo', 'title'],
+				},
+				outputSchema: {
+					type: 'object',
+					properties: {
+						issueUrl: { type: 'string' },
+					},
+					required: ['issueUrl'],
+				},
+				inputTypeDefinition:
+					'type GithubCreateIssueInput = {\n\towner: string\n\trepo: string\n\ttitle: string\n\tbody?: string\n}',
+				outputTypeDefinition:
+					'type GithubCreateIssueOutput = {\n\tissueUrl: string\n}',
+			},
+		},
+		{ includeSchemas: true },
+	)
+
+	expect(detail.markdown).toContain('## Input schema')
+	expect(detail.markdown).toContain('## Output schema')
+	expect(detail.structured).toMatchObject({
+		type: 'capability',
 		inputSchema: expect.objectContaining({
 			properties: expect.objectContaining({
 				owner: expect.objectContaining({ type: 'string' }),

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -196,6 +196,66 @@ test('entity detail formatting returns stable structured details for values and 
 	})
 })
 
+test('capability entity detail leads with TypeScript definitions and keeps schemas structured', () => {
+	const detail = formatEntityDetailMarkdown({
+		type: 'capability',
+		id: 'github_create_issue',
+		title: 'github_create_issue',
+		description: 'Create a GitHub issue.',
+		spec: {
+			name: 'github_create_issue',
+			domain: 'coding',
+			description: 'Create a GitHub issue.',
+			keywords: ['github', 'issue'],
+			readOnly: false,
+			idempotent: false,
+			destructive: false,
+			inputFields: ['owner', 'repo', 'title'],
+			requiredInputFields: ['owner', 'repo', 'title'],
+			outputFields: ['issueUrl'],
+			inputSchema: {
+				type: 'object',
+				properties: {
+					owner: { type: 'string' },
+					repo: { type: 'string' },
+					title: { type: 'string' },
+					body: { type: 'string' },
+				},
+				required: ['owner', 'repo', 'title'],
+			},
+			outputSchema: {
+				type: 'object',
+				properties: {
+					issueUrl: { type: 'string' },
+				},
+				required: ['issueUrl'],
+			},
+			inputTypeDefinition:
+				'type GithubCreateIssueInput = {\n\towner: string\n\trepo: string\n\ttitle: string\n\tbody?: string\n}',
+			outputTypeDefinition:
+				'type GithubCreateIssueOutput = {\n\tissueUrl: string\n}',
+		},
+	})
+
+	expect(detail.markdown.indexOf('## Type definitions')).toBeLessThan(
+		detail.markdown.indexOf('## Input schema'),
+	)
+	expect(detail.markdown).toContain('```ts')
+	expect(detail.markdown).toContain('type GithubCreateIssueInput')
+	expect(detail.markdown).toContain('type GithubCreateIssueOutput')
+	expect(detail.structured).toMatchObject({
+		type: 'capability',
+		inputTypeDefinition: expect.stringContaining('GithubCreateIssueInput'),
+		outputTypeDefinition: expect.stringContaining('GithubCreateIssueOutput'),
+		inputSchema: expect.objectContaining({
+			properties: expect.objectContaining({
+				owner: expect.objectContaining({ type: 'string' }),
+			}),
+		}),
+		outputSchema: expect.objectContaining({ type: 'object' }),
+	})
+})
+
 test('entity detail formatting includes package app, export, and job metadata', () => {
 	const packageDetail = formatEntityDetailMarkdown({
 		type: 'package',

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -160,6 +160,8 @@ export type SearchEntityDetailStructured =
 			destructive: boolean
 			inputSchema: unknown
 			outputSchema?: unknown
+			inputTypeDefinition: string
+			outputTypeDefinition?: string
 	  }
 	| {
 			kind: 'entity'
@@ -669,6 +671,15 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 			`- Idempotent: ${detail.spec.idempotent ? 'yes' : 'no'}`,
 			`- Destructive: ${detail.spec.destructive ? 'yes' : 'no'}`,
 			'',
+			'## Type definitions',
+			'',
+			'```ts',
+			detail.spec.inputTypeDefinition,
+			...(detail.spec.outputTypeDefinition
+				? ['', detail.spec.outputTypeDefinition]
+				: []),
+			'```',
+			'',
 			'## Input schema',
 			'',
 			`- \`${JSON.stringify(inputSchema)}\``,
@@ -697,6 +708,10 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 				destructive: detail.spec.destructive,
 				inputSchema,
 				...(outputSchema !== undefined ? { outputSchema } : {}),
+				inputTypeDefinition: detail.spec.inputTypeDefinition,
+				...(detail.spec.outputTypeDefinition
+					? { outputTypeDefinition: detail.spec.outputTypeDefinition }
+					: {}),
 			} satisfies SearchEntityDetailStructured,
 		}
 	}

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -158,7 +158,7 @@ export type SearchEntityDetailStructured =
 			readOnly: boolean
 			idempotent: boolean
 			destructive: boolean
-			inputSchema: unknown
+			inputSchema?: unknown
 			outputSchema?: unknown
 			inputTypeDefinition: string
 			outputTypeDefinition?: string
@@ -648,15 +648,11 @@ export function toSlimStructuredMatches(input: {
 	})
 }
 
-export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
+export function formatEntityDetailMarkdown(
+	detail: SearchEntityDetail,
+	options?: { includeSchemas?: boolean },
+) {
 	if (detail.type === 'capability') {
-		const inputSchema = compressSchemaForLlm(detail.spec.inputSchema)
-		const outputSchema =
-			detail.spec.outputSchema == null
-				? undefined
-				: compressSchemaForLlm(detail.spec.outputSchema, {
-						stripRootObjectType: false,
-					})
 		const lines = [
 			`# Capability — \`${detail.spec.name}\``,
 			'',
@@ -679,11 +675,25 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 				? ['', detail.spec.outputTypeDefinition]
 				: []),
 			'```',
-			'',
-			'## Input schema',
-			'',
-			`- \`${JSON.stringify(inputSchema)}\``,
 		]
+		const includeSchemas = options?.includeSchemas === true
+		const inputSchema = includeSchemas
+			? compressSchemaForLlm(detail.spec.inputSchema)
+			: undefined
+		const outputSchema =
+			includeSchemas && detail.spec.outputSchema != null
+				? compressSchemaForLlm(detail.spec.outputSchema, {
+						stripRootObjectType: false,
+					})
+				: undefined
+		if (includeSchemas) {
+			lines.push(
+				'',
+				'## Input schema',
+				'',
+				`- \`${JSON.stringify(inputSchema)}\``,
+			)
+		}
 		if (outputSchema !== undefined) {
 			lines.push(
 				'',
@@ -706,7 +716,7 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 				readOnly: detail.spec.readOnly,
 				idempotent: detail.spec.idempotent,
 				destructive: detail.spec.destructive,
-				inputSchema,
+				...(includeSchemas ? { inputSchema } : {}),
 				...(outputSchema !== undefined ? { outputSchema } : {}),
 				inputTypeDefinition: detail.spec.inputTypeDefinition,
 				...(detail.spec.outputTypeDefinition

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -286,7 +286,7 @@ function buildRecommendedNextStep(
 		return `Inspect connector detail with \`search({ entity: "${topMatch.connectorName}:connector" })\` and then run a minimal authenticated \`execute\` smoke test before building or calling integration-backed code.`
 	}
 	if (topMatch?.type === 'capability') {
-		return `Inspect capability detail with \`search({ entity: "${topMatch.name}:capability" })\` to confirm the schema, then call it from \`execute\` via \`codemode.${topMatch.name}(args)\`.`
+		return `Inspect capability detail with \`search({ entity: "${topMatch.name}:capability" })\` to confirm the TypeScript call shape, then call it from \`execute\` via \`codemode.${topMatch.name}(args)\`. Add \`includeSchemas: true\` only if you explicitly need raw JSON Schema.`
 	}
 	return undefined
 }
@@ -1057,8 +1057,8 @@ returns, rephrase or call \`meta_list_capabilities\`; \`entity\` does not fix an
 empty ranked list.
 
 **entity: "{id}:{type}"** — detail for one hit (\`capability\` | \`value\`
-| \`connector\` | \`package\` | \`secret\`), including schemas for
-capabilities. Types and fields: see response.
+| \`connector\` | \`package\` | \`secret\`). Capability detail includes
+TypeScript call-shape definitions by default.
 
 Packages: \`package_list\`, \`package_get\`, and \`repo_*\` for editing/publishing.
 Open package apps with \`open_generated_ui({ kody_id })\` or use hosted package URLs.
@@ -1071,6 +1071,8 @@ If results look incomplete: \`meta_list_capabilities\` (full registry) or
 \`meta_list_remote_connector_status\` / \`meta_get_home_connector_status\` (remote connectors).
 
 Optional **limit** (default 15) and **maxResponseSize** trim low-ranked results.
+Set **includeSchemas: true** on entity detail only when you explicitly need the
+underlying JSON Schema.
 
 Example arguments:
 - \`{ "query": "saved github automation package", "limit": 10 }\`
@@ -1415,6 +1417,12 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					.describe(
 						'Max response size in characters before trimming low-ranked results. Defaults to 4000.',
 					),
+				includeSchemas: z
+					.boolean()
+					.optional()
+					.describe(
+						'Only for entity detail: include raw JSON schemas in addition to TypeScript type definitions. Defaults to false.',
+					),
 				conversationId: conversationIdInputField,
 				memoryContext: memoryContextInputField,
 			},
@@ -1425,6 +1433,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 			entity?: string
 			limit?: number
 			maxResponseSize?: number
+			includeSchemas?: boolean
 			conversationId?: string
 			memoryContext?: z.infer<typeof memoryContextInputField>
 		}) => {
@@ -1531,7 +1540,9 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 				)
 
 				if (outcome.mode === 'entity') {
-					const entityResult = formatEntityDetailMarkdown(outcome.detail)
+					const entityResult = formatEntityDetailMarkdown(outcome.detail, {
+						includeSchemas: args.includeSchemas === true,
+					})
 					const timing = finishToolTiming(timingStart)
 					logMcpEvent({
 						category: 'mcp',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Generate TypeScript call-shape definitions from normalized capability JSON Schema.
- Surface input/output type definitions by default in capability search detail and detailed capability registry output.
- Keep raw JSON schemas out of default search/meta outputs; callers must pass `includeSchemas: true` to receive `inputSchema` / `outputSchema` alongside type definitions.
- Parenthesize union members when JSON Schema `allOf` composes TypeScript intersections.
- Cover default, opt-in schema, and `allOf` precedence behavior with focused tests.

### Testing
- `npm exec vitest run packages/worker/src/mcp/capabilities/schema-type-definitions.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts packages/worker/src/mcp/tools/search-format.node.test.ts packages/worker/src/mcp/capabilities/capability-search.workers.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npx oxfmt --check packages/worker/src/mcp/capabilities/schema-type-definitions.ts packages/worker/src/mcp/capabilities/schema-type-definitions.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts`
- `npm run build`
- `npm run test`

### Notes
- `npm run format:check` still reports unrelated existing formatting drift outside this change set.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9530b64-3270-4f00-9b4e-18b8d5947a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9530b64-3270-4f00-9b4e-18b8d5947a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capability search & detail now show TypeScript call-shape definitions (input/output) by default for single-entity lookups.
  * Search/detail rendering supports an optional includeSchemas flag to return raw JSON Schemas when explicitly requested.

* **Documentation**
  * Updated docs to explain default type-definition behavior and how to request raw JSON Schemas via includeSchemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->