### PR TITLE
Fix Cloudflare outbound email send headers

### DIFF
--- a/packages/worker/src/email/outbound.ts
+++ b/packages/worker/src/email/outbound.ts
@@ -9,10 +9,7 @@ import {
 	insertEmailDeliveryEvent,
 	updateEmailMessageDelivery,
 } from './repo.ts'
-import {
-	type EmailMessageRecord,
-	type EmailProcessingStatus,
-} from './types.ts'
+import { type EmailMessageRecord, type EmailProcessingStatus } from './types.ts'
 
 type SendEmailEnv = Pick<
 	Env,
@@ -56,7 +53,7 @@ function normalizeRecipientList(to: string | Array<string>) {
 	return Array.from(new Set(normalized))
 }
 
-function buildHeaders(input: {
+function buildStoredHeaders(input: {
 	messageId: string
 	inReplyTo?: string | null
 	references?: Array<string>
@@ -72,6 +69,19 @@ function buildHeaders(input: {
 	return headers
 }
 
+const cloudflareSendAllowedHeaders = new Set(['in-reply-to', 'references'])
+
+function buildProviderHeaders(headers: Record<string, string>) {
+	return Object.fromEntries(
+		Object.entries(headers).filter(([name]) => {
+			return (
+				name.startsWith('X-') ||
+				cloudflareSendAllowedHeaders.has(name.toLowerCase())
+			)
+		}),
+	)
+}
+
 async function requireStoredEmailMessage(input: {
 	env: SendEmailEnv
 	userId: string
@@ -83,7 +93,9 @@ async function requireStoredEmailMessage(input: {
 		messageId: input.messageId,
 	})
 	if (!stored) {
-		throw new Error(`Email message disappeared after delivery update: ${input.messageId}`)
+		throw new Error(
+			`Email message disappeared after delivery update: ${input.messageId}`,
+		)
 	}
 	return stored
 }
@@ -122,6 +134,10 @@ async function sendViaRestFallback(input: {
 	replyTo?: string | null
 	headers: Record<string, string>
 }) {
+	const html = input.html ?? input.text
+	if (!html) {
+		throw new Error('Email text or HTML body is required.')
+	}
 	const result = await sendCloudflareEmail(
 		{
 			accountId: input.env.CLOUDFLARE_ACCOUNT_ID,
@@ -132,17 +148,15 @@ async function sendViaRestFallback(input: {
 			from: input.from,
 			to: input.to.length === 1 ? input.to[0]! : input.to,
 			subject: input.subject,
-			html: input.html ?? input.text ?? input.subject,
+			html,
 			text: input.text ?? undefined,
 			replyTo: input.replyTo ?? undefined,
-			headers: Object.keys(input.headers).length > 0 ? input.headers : undefined,
+			headers:
+				Object.keys(input.headers).length > 0 ? input.headers : undefined,
 		},
 	)
 	if (!result.ok) {
 		throw new Error(result.error ?? 'Cloudflare email send was skipped.')
-	}
-	if (!input.html && !input.text) {
-		throw new Error('Email text or HTML body is required.')
 	}
 	return result.messageId ?? null
 }
@@ -195,11 +209,12 @@ export async function sendOutboundEmail(
 			})
 	const threadId = existingThreadId ?? thread?.id ?? null
 	const messageIdHeader = `<${crypto.randomUUID()}@kody.local>`
-	const sendHeaders = buildHeaders({
+	const storedHeaders = buildStoredHeaders({
 		messageId: messageIdHeader,
 		inReplyTo: input.inReplyToHeader ?? null,
 		references: input.references ?? [],
 	})
+	const providerHeaders = buildProviderHeaders(storedHeaders)
 	const message = await insertEmailMessage({
 		db: input.env.APP_DB,
 		message: {
@@ -222,7 +237,7 @@ export async function sendOutboundEmail(
 			messageIdHeader,
 			inReplyToHeader: input.inReplyToHeader ?? null,
 			references: input.references ?? [],
-			headers: sendHeaders,
+			headers: storedHeaders,
 			authResults: null,
 			textBody: text,
 			htmlBody: html,
@@ -258,22 +273,22 @@ export async function sendOutboundEmail(
 			replyTo: input.replyTo
 				? (normalizeEmailAddress(input.replyTo) ?? undefined)
 				: undefined,
-			headers: sendHeaders,
+			headers: providerHeaders,
 		})
 		const providerMessageId = bindingResult.sent
 			? bindingResult.messageId
 			: await sendViaRestFallback({
-				env: input.env,
-				from,
-				to,
-				subject,
-				text,
-				html,
-				replyTo: input.replyTo
-					? (normalizeEmailAddress(input.replyTo) ?? undefined)
-					: undefined,
-				headers: sendHeaders,
-			})
+					env: input.env,
+					from,
+					to,
+					subject,
+					text,
+					html,
+					replyTo: input.replyTo
+						? (normalizeEmailAddress(input.replyTo) ?? undefined)
+						: undefined,
+					headers: providerHeaders,
+				})
 		await updateEmailMessageDelivery({
 			db: input.env.APP_DB,
 			messageId: message.id,

--- a/packages/worker/src/email/outbound.workers.test.ts
+++ b/packages/worker/src/email/outbound.workers.test.ts
@@ -13,7 +13,7 @@ test('sendOutboundEmail uses SendEmail binding and stores sent delivery state', 
 	await ensureEmailTestSchema(env.APP_DB)
 	const userId = `email-outbound-user-${crypto.randomUUID()}`
 	const from = `sender-${crypto.randomUUID()}@example.com`
-	const sent: Array<unknown> = []
+	const sent: Array<EmailMessage> = []
 	const sendEnv = {
 		...env,
 		EMAIL: {
@@ -41,6 +41,9 @@ test('sendOutboundEmail uses SendEmail binding and stores sent delivery state', 
 	})
 
 	expect(sent).toHaveLength(1)
+	expect(sent[0]?.headers).toEqual({
+		'X-Kody-Email-Message-Id': result.message.messageIdHeader,
+	})
 	expect(result.status).toBe('sent')
 	expect(result.providerMessageId).toBe('provider-message-123')
 	const stored = await getEmailMessageById({
@@ -53,6 +56,10 @@ test('sendOutboundEmail uses SendEmail binding and stores sent delivery state', 
 		processingStatus: 'sent',
 		providerMessageId: 'provider-message-123',
 		fromAddress: from,
+		headers: {
+			'Message-ID': result.message.messageIdHeader,
+			'X-Kody-Email-Message-Id': result.message.messageIdHeader,
+		},
 	})
 	const listed = await listEmailMessages({
 		db: env.APP_DB,
@@ -173,12 +180,15 @@ test('sendOutboundEmail preserves reply headers and records failed fallback send
 		expect(result.error).toBe('provider down')
 		expect(fetchCalls).toHaveLength(1)
 		expect(fetchCalls[0]?.body).toMatchObject({
+			html: 'Body',
 			replyTo: 'reply@example.com',
 			headers: {
+				'X-Kody-Email-Message-Id': result.message.messageIdHeader,
 				'In-Reply-To': original.message.messageIdHeader,
 				References: '<root@example.com>',
 			},
 		})
+		expect(fetchCalls[0]?.body.headers).not.toHaveProperty('Message-ID')
 		const stored = await getEmailMessageById({
 			db: env.APP_DB,
 			userId,
@@ -187,9 +197,53 @@ test('sendOutboundEmail preserves reply headers and records failed fallback send
 		expect(stored).toMatchObject({
 			processingStatus: 'failed',
 			error: 'provider down',
+			headers: {
+				'Message-ID': result.message.messageIdHeader,
+				'X-Kody-Email-Message-Id': result.message.messageIdHeader,
+				'In-Reply-To': original.message.messageIdHeader,
+				References: '<root@example.com>',
+			},
 		})
 	} finally {
 		globalThis.fetch = originalFetch
 	}
 })
 
+test('sendOutboundEmail rejects blank bodies before REST fallback can synthesize one', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const userId = `email-outbound-empty-body-user-${crypto.randomUUID()}`
+	const from = `sender-${crypto.randomUUID()}@example.com`
+	const originalFetch = globalThis.fetch
+	globalThis.fetch = (async () => {
+		throw new Error('REST fallback should not be called')
+	}) as typeof fetch
+
+	try {
+		await upsertEmailSenderIdentity({
+			db: env.APP_DB,
+			userId,
+			email: from,
+			domain: getEmailDomain(from),
+			status: 'verified',
+		})
+
+		await expect(
+			sendOutboundEmail({
+				env: {
+					...env,
+					EMAIL: undefined as unknown as SendEmail,
+					CLOUDFLARE_ACCOUNT_ID: 'account-123',
+					CLOUDFLARE_API_BASE_URL: 'https://api.cloudflare.test',
+					CLOUDFLARE_API_TOKEN: 'token-123',
+				},
+				userId,
+				from,
+				to: 'recipient@example.com',
+				subject: 'Missing body',
+				text: '   ',
+			}),
+		).rejects.toThrow('Email text or HTML body is required.')
+	} finally {
+		globalThis.fetch = originalFetch
+	}
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- stop passing `Message-ID` through Cloudflare outbound sends while still storing the logical message/thread headers in Kody's email records
- keep provider-safe reply/thread headers (`X-Kody-Email-Message-Id`, `In-Reply-To`, `References`) for binding/REST sends
- remove the REST fallback behavior that substituted the email subject as HTML when no body content was present, preserving validation instead

## Testing
- `npm run test -- packages/worker/src/email/outbound.workers.test.ts packages/worker/src/app/email/cloudflare-email.node.test.ts`
- `npm run typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf487134-9790-4b0d-a6d3-8f4095cf9808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf487134-9790-4b0d-a6d3-8f4095cf9808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

