### PR TITLE
Stabilize home connector WebSocket lifecycle

### DIFF
--- a/packages/worker/src/home/session.node.test.ts
+++ b/packages/worker/src/home/session.node.test.ts
@@ -34,6 +34,17 @@ type StoredHomeConnectorSessionState = {
 	tools: Array<{ name: string }>
 }
 
+async function waitForRestoreState(state: DurableObjectState) {
+	const blockConcurrencyWhile = state.blockConcurrencyWhile as unknown as {
+		mock: { results: Array<{ value: Promise<void> | undefined }> }
+	}
+	const blockPromise = blockConcurrencyWhile.mock.results[0]?.value
+	if (!blockPromise) {
+		throw new Error('Expected blockConcurrencyWhile to return restore promise.')
+	}
+	await blockPromise
+}
+
 function createState(
 	input: {
 		storedState?: StoredHomeConnectorSessionState | null
@@ -89,7 +100,7 @@ test('constructor restores persisted state through blockConcurrencyWhile', async
 		} as unknown as DurableObjectState,
 		{} as Env,
 	)
-	await new Promise((resolve) => setTimeout(resolve, 0))
+	await waitForRestoreState(state)
 
 	expect(state.blockConcurrencyWhile).toHaveBeenCalledTimes(1)
 	const response = await session.fetch(
@@ -124,7 +135,7 @@ test('snapshot returns null when persisted connector has no live websocket', asy
 		{} as Env,
 	)
 
-	await new Promise((resolve) => setTimeout(resolve, 0))
+	await waitForRestoreState(state)
 
 	const response = await session.fetch(
 		new Request('https://home-connectors/home/connectors/default/snapshot'),
@@ -156,10 +167,9 @@ test('websocket close clears connectedAt and tools from persisted state', async 
 		{} as Env,
 	)
 
-	await new Promise((resolve) => setTimeout(resolve, 0))
+	await waitForRestoreState(state)
 	state.getWebSockets.mockReturnValue([])
-	session.webSocketClose({} as WebSocket, 1006, 'network', false)
-	await new Promise((resolve) => setTimeout(resolve, 0))
+	await session.webSocketClose({} as WebSocket, 1006, 'network', false)
 
 	expect(captureMessageMock).toHaveBeenCalledWith(
 		'Home connector session websocket closed code=1006 wasClean=false reason=network',
@@ -202,10 +212,9 @@ test('stale websocket close preserves active connection state', async () => {
 		{} as Env,
 	)
 
-	await new Promise((resolve) => setTimeout(resolve, 0))
+	await waitForRestoreState(state)
 	state.getWebSockets.mockReturnValue([activeSocket])
-	session.webSocketClose(staleSocket, 1006, 'stale-socket', false)
-	await new Promise((resolve) => setTimeout(resolve, 0))
+	await session.webSocketClose(staleSocket, 1006, 'stale-socket', false)
 
 	expect(persistedEntries.get('home-connector-session-state')).toMatchObject({
 		persisted: {
@@ -239,7 +248,7 @@ test('websocket heartbeat work is returned so the runtime can wait for persisten
 		} as unknown as DurableObjectState,
 		{} as Env,
 	)
-	await new Promise((resolve) => setTimeout(resolve, 0))
+	await waitForRestoreState(state)
 
 	const handlerWork = session.webSocketMessage(
 		{} as WebSocket,
@@ -287,10 +296,9 @@ test('websocket error clears connected state when the socket is gone', async () 
 		{} as Env,
 	)
 
-	await new Promise((resolve) => setTimeout(resolve, 0))
+	await waitForRestoreState(state)
 	state.getWebSockets.mockReturnValue([])
-	session.webSocketError({} as WebSocket, new Error('abnormal close'))
-	await new Promise((resolve) => setTimeout(resolve, 0))
+	await session.webSocketError({} as WebSocket, new Error('abnormal close'))
 
 	expect(captureMessageMock).toHaveBeenCalledWith(
 		'Home connector session websocket closed code=1011 wasClean=false reason=abnormal close',

--- a/packages/worker/src/home/session.node.test.ts
+++ b/packages/worker/src/home/session.node.test.ts
@@ -24,18 +24,22 @@ vi.mock('cloudflare:workers', () => ({
 
 const { HomeConnectorSession } = await import('./session.ts')
 
-function createState(input: {
-	storedState?: {
-		persisted: {
-			connectorId: string | null
-			connectorKind: string | null
-			connectedAt: string | null
-			lastSeenAt: string | null
-		}
-		tools: Array<{ name: string }>
-	} | null
-	webSockets?: Array<WebSocket>
-} = {}) {
+type StoredHomeConnectorSessionState = {
+	persisted: {
+		connectorId: string | null
+		connectorKind: string | null
+		connectedAt: string | null
+		lastSeenAt: string | null
+	}
+	tools: Array<{ name: string }>
+}
+
+function createState(
+	input: {
+		storedState?: StoredHomeConnectorSessionState | null
+		webSockets?: Array<WebSocket>
+	} = {},
+) {
 	const storedState = input.storedState ?? null
 	const webSockets = input.webSockets ?? []
 	const persistedEntries = new Map<string, unknown>()
@@ -53,10 +57,49 @@ function createState(input: {
 			},
 			getWebSockets: vi.fn(() => webSockets),
 			acceptWebSocket: vi.fn(),
+			blockConcurrencyWhile: vi.fn((callback: () => Promise<void>) =>
+				callback(),
+			),
 		} as unknown as DurableObjectState,
 		persistedEntries,
 	}
 }
+
+test('constructor restores persisted state through blockConcurrencyWhile', async () => {
+	captureMessageMock.mockReset()
+	const { state } = createState({
+		storedState: {
+			persisted: {
+				connectorId: 'default',
+				connectorKind: 'home',
+				connectedAt: '2026-04-26T05:00:00.000Z',
+				lastSeenAt: '2026-04-26T05:01:00.000Z',
+			},
+			tools: [{ name: 'bond_shade_set_position' }],
+		},
+		webSockets: [{} as WebSocket],
+	})
+
+	const session = new HomeConnectorSession(
+		{
+			storage: state.storage,
+			getWebSockets: state.getWebSockets,
+			acceptWebSocket: state.acceptWebSocket,
+			blockConcurrencyWhile: state.blockConcurrencyWhile,
+		} as unknown as DurableObjectState,
+		{} as Env,
+	)
+	await new Promise((resolve) => setTimeout(resolve, 0))
+
+	expect(state.blockConcurrencyWhile).toHaveBeenCalledTimes(1)
+	const response = await session.fetch(
+		new Request('https://home-connectors/home/connectors/default/snapshot'),
+	)
+	expect(await response.json()).toMatchObject({
+		connectorId: 'default',
+		tools: [{ name: 'bond_shade_set_position' }],
+	})
+})
 
 test('snapshot returns null when persisted connector has no live websocket', async () => {
 	captureMessageMock.mockReset()
@@ -76,6 +119,7 @@ test('snapshot returns null when persisted connector has no live websocket', asy
 			storage: state.storage,
 			getWebSockets: state.getWebSockets,
 			acceptWebSocket: state.acceptWebSocket,
+			blockConcurrencyWhile: state.blockConcurrencyWhile,
 		} as unknown as DurableObjectState,
 		{} as Env,
 	)
@@ -107,6 +151,7 @@ test('websocket close clears connectedAt and tools from persisted state', async 
 			storage: state.storage,
 			getWebSockets: state.getWebSockets,
 			acceptWebSocket: state.acceptWebSocket,
+			blockConcurrencyWhile: state.blockConcurrencyWhile,
 		} as unknown as DurableObjectState,
 		{} as Env,
 	)
@@ -152,6 +197,7 @@ test('stale websocket close preserves active connection state', async () => {
 			storage: state.storage,
 			getWebSockets: state.getWebSockets,
 			acceptWebSocket: state.acceptWebSocket,
+			blockConcurrencyWhile: state.blockConcurrencyWhile,
 		} as unknown as DurableObjectState,
 		{} as Env,
 	)
@@ -167,5 +213,96 @@ test('stale websocket close preserves active connection state', async () => {
 			connectedAt: '2026-04-26T05:00:00.000Z',
 		},
 		tools: [{ name: 'bond_shade_set_position' }],
+	})
+})
+
+test('websocket heartbeat work is returned so the runtime can wait for persistence', async () => {
+	captureMessageMock.mockReset()
+	const { state, persistedEntries } = createState({
+		storedState: {
+			persisted: {
+				connectorId: 'default',
+				connectorKind: 'home',
+				connectedAt: '2026-04-26T05:00:00.000Z',
+				lastSeenAt: '2026-04-26T05:01:00.000Z',
+			},
+			tools: [{ name: 'bond_shade_set_position' }],
+		},
+		webSockets: [{} as WebSocket],
+	})
+	const session = new HomeConnectorSession(
+		{
+			storage: state.storage,
+			getWebSockets: state.getWebSockets,
+			acceptWebSocket: state.acceptWebSocket,
+			blockConcurrencyWhile: state.blockConcurrencyWhile,
+		} as unknown as DurableObjectState,
+		{} as Env,
+	)
+	await new Promise((resolve) => setTimeout(resolve, 0))
+
+	const handlerWork = session.webSocketMessage(
+		{} as WebSocket,
+		JSON.stringify({ type: 'connector.heartbeat' }),
+	)
+	expect(handlerWork).toBeInstanceOf(Promise)
+	await handlerWork
+
+	const persisted = persistedEntries.get(
+		'home-connector-session-state',
+	) as StoredHomeConnectorSessionState
+	expect(persisted).toMatchObject({
+		persisted: {
+			connectorId: 'default',
+			connectedAt: '2026-04-26T05:00:00.000Z',
+		},
+		tools: [{ name: 'bond_shade_set_position' }],
+	})
+	expect(
+		(persisted as { persisted: { lastSeenAt: string } }).persisted.lastSeenAt,
+	).not.toBe('2026-04-26T05:01:00.000Z')
+})
+
+test('websocket error clears connected state when the socket is gone', async () => {
+	captureMessageMock.mockReset()
+	const { state, persistedEntries } = createState({
+		storedState: {
+			persisted: {
+				connectorId: 'default',
+				connectorKind: 'home',
+				connectedAt: '2026-04-26T05:00:00.000Z',
+				lastSeenAt: '2026-04-26T05:01:00.000Z',
+			},
+			tools: [{ name: 'bond_shade_set_position' }],
+		},
+		webSockets: [{} as WebSocket],
+	})
+	const session = new HomeConnectorSession(
+		{
+			storage: state.storage,
+			getWebSockets: state.getWebSockets,
+			acceptWebSocket: state.acceptWebSocket,
+			blockConcurrencyWhile: state.blockConcurrencyWhile,
+		} as unknown as DurableObjectState,
+		{} as Env,
+	)
+
+	await new Promise((resolve) => setTimeout(resolve, 0))
+	state.getWebSockets.mockReturnValue([])
+	session.webSocketError({} as WebSocket, new Error('abnormal close'))
+	await new Promise((resolve) => setTimeout(resolve, 0))
+
+	expect(captureMessageMock).toHaveBeenCalledWith(
+		'Home connector session websocket closed code=1011 wasClean=false reason=abnormal close',
+		expect.objectContaining({
+			level: 'warning',
+		}),
+	)
+	expect(persistedEntries.get('home-connector-session-state')).toMatchObject({
+		persisted: {
+			connectorId: 'default',
+			connectedAt: null,
+		},
+		tools: [],
 	})
 })

--- a/packages/worker/src/home/session.ts
+++ b/packages/worker/src/home/session.ts
@@ -61,7 +61,9 @@ class HomeConnectorSessionBase extends DurableObject<Env> {
 
 	constructor(state: DurableObjectState, env: Env) {
 		super(state, env)
-		void this.restoreState()
+		state.blockConcurrencyWhile(async () => {
+			await this.restoreState()
+		})
 	}
 
 	private clearConnectionState() {
@@ -143,7 +145,7 @@ class HomeConnectorSessionBase extends DurableObject<Env> {
 		ws: WebSocket,
 		message: string | ArrayBuffer,
 	): void | Promise<void> {
-		void this.handleWebSocketMessage(ws, message)
+		return this.handleWebSocketMessage(ws, message)
 	}
 
 	webSocketClose(
@@ -151,7 +153,7 @@ class HomeConnectorSessionBase extends DurableObject<Env> {
 		code: number,
 		reason: string,
 		wasClean: boolean,
-	): void {
+	): Promise<void> {
 		this.stateSnapshot.persisted.lastSeenAt = new Date().toISOString()
 		const activeSockets = this.ctx
 			.getWebSockets(connectorTag)
@@ -173,7 +175,13 @@ class HomeConnectorSessionBase extends DurableObject<Env> {
 				connectorId: this.stateSnapshot.persisted.connectorId,
 			},
 		})
-		void this.persistState()
+		return this.persistState()
+	}
+
+	webSocketError(ws: WebSocket, error: unknown): Promise<void> {
+		const reason =
+			error instanceof Error ? error.message : String(error ?? 'error')
+		return this.webSocketClose(ws, 1011, reason, false)
 	}
 
 	async getConnectorId() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Restore home connector Durable Object state inside `blockConcurrencyWhile` so hibernation wakeups cannot serve requests before persisted state is loaded.
- Return WebSocket handler promises for messages, closes, and errors so Cloudflare can keep the event alive until persistence and cleanup complete.
- Add regression tests for wake restore, heartbeat persistence, stale closes, and abnormal WebSocket errors.
- Make the session tests deterministic by awaiting the `blockConcurrencyWhile` restore promise and handler promises instead of fixed event-loop ticks.

## Validation

- `npx vitest run --project node-unit packages/worker/src/home/session.node.test.ts` — 6 tests passed
- Commit hook: `npm run typecheck` — passed
- Push hook: `npm run test` — 115 files / 499 tests passed
- Push hook: `npm run test:e2e:run` — 2 Playwright tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8814e3a-fa02-4784-b80f-621815b67b07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8814e3a-fa02-4784-b80f-621815b67b07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust WebSocket lifecycle: errors now trigger unified close handling, state is persisted on close, and heartbeat messages reliably update last-seen timestamps.
  * Startup now waits for durable state restoration to avoid race conditions and data loss.

* **Tests**
  * Added deterministic tests covering constructor restore, message handling, and error/close scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->