### PR TITLE
Add package email event subscriptions

### DIFF
--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -24,8 +24,8 @@ Use the MCP `email` domain:
 - Display names are not trusted. Kody stores envelope sender, parsed `From`, and
   authentication headers separately.
 - Outbound sending requires a verified sender identity.
-- Stored inbound mail is the source of truth.
-- Packages can subscribe to the stored inbound email topic
+- Stored inbound mail is the source of truth. If a user wants email automation,
+  they can publish a package that subscribes to the stored inbound email topic
   `email.message.received` using normal package subscriptions. This is package
   behavior, not a separate Kody-owned email handler or agent-loop primitive.
 - Subscription event payloads are metadata-first. Package handlers receive the

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -13,6 +13,7 @@ Use the MCP `email` domain:
 - `email_sender_identity_verify` verifies an outbound sender identity.
 - `email_send` sends outbound mail from a verified sender identity.
 - `email_reply` replies to a stored inbound message.
+- `email_attachment_get` returns stored attachment bytes by attachment id.
 - `email_message_list` lists stored inbound and outbound messages.
 - `email_message_get` returns parsed bodies, headers, thread metadata, and
   attachment metadata.

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -24,10 +24,16 @@ Use the MCP `email` domain:
 - Display names are not trusted. Kody stores envelope sender, parsed `From`, and
   authentication headers separately.
 - Outbound sending requires a verified sender identity.
-- Inbound package handlers are intentionally disabled in this first slice. Mail
-  is stored first; packages and agent loops decide what to do with it later.
-- Attachments are metadata-only for now; raw MIME for small messages is stored
-  so the first pass can be tested locally.
+- Stored inbound mail is the source of truth.
+- Packages can subscribe to the stored inbound email topic
+  `email.message.received` using normal package subscriptions. This is package
+  behavior, not a separate Kody-owned email handler or agent-loop primitive.
+- Subscription event payloads are metadata-first. Package handlers receive the
+  stored message id and receipt metadata, then use `email_message_get` or
+  `email_attachment_get` (or `import { email } from 'kody:runtime'`) when they
+  need bodies or attachment bytes.
+- Attachments remain metadata-first by default; raw MIME for small messages is
+  stored so on-demand attachment lookup can reconstruct bytes locally.
 
 ## Local inbound testing
 

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -14,10 +14,11 @@ import {
 	insertEmailMessageWithAttachments,
 	touchEmailThread,
 } from './repo.ts'
+import { dispatchInboundEmailSubscriptionEvents } from './package-subscriptions.ts'
 
 export async function handleInboundEmail(
 	message: ForwardableEmailMessage,
-	env: Pick<Env, 'APP_DB'>,
+	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'APP_BASE_URL'>,
 	_ctx?: ExecutionContext,
 ) {
 	const recipient = normalizeEmailAddress(message.to)
@@ -160,4 +161,14 @@ export async function handleInboundEmail(
 			from_address: parsed.headerFrom,
 		},
 	})
+	const dispatchPromise = dispatchInboundEmailSubscriptionEvents({
+		env,
+		userId,
+		message: stored,
+	})
+	if (_ctx) {
+		_ctx.waitUntil(dispatchPromise)
+	} else {
+		await dispatchPromise
+	}
 }

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -169,6 +169,8 @@ export async function handleInboundEmail(
 	if (_ctx) {
 		_ctx.waitUntil(dispatchPromise)
 	} else {
-		await dispatchPromise
+		void dispatchPromise.catch((error) => {
+			console.error('Inbound email package subscription dispatch failed', error)
+		})
 	}
 }

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -13,6 +13,9 @@ import {
 	listEmailMessages,
 } from './repo.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
+import {
+	buildPublishedSourceManifestSnapshotKvKey,
+} from '#worker/package-runtime/published-runtime-artifacts.ts'
 
 function createForwardableEmailMessage(input: {
 	from: string
@@ -207,4 +210,377 @@ test('inbound email handler rejects malformed messages without persisting them',
 		limit: 10,
 	})
 	expect(messages).toEqual([])
+})
+
+test('inbound email handler dispatches package subscriptions for stored inbound email', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const userId = `email-subscription-user-${crypto.randomUUID()}`
+	const address = requireNormalizedEmailAddress(
+		`package-inbox-${crypto.randomUUID()}@example.com`,
+	)
+	const sourceId = `source-${crypto.randomUUID()}`
+	const packageId = `package-${crypto.randomUUID()}`
+	const bundleKv = new Map<string, string>()
+	const subscriptionCalls: Array<Record<string, unknown>> = []
+
+	const db = env.APP_DB
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS saved_packages (
+				id TEXT PRIMARY KEY,
+				user_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				kody_id TEXT NOT NULL,
+				description TEXT NOT NULL,
+				tags_json TEXT NOT NULL DEFAULT '[]',
+				search_text TEXT,
+				source_id TEXT NOT NULL,
+				has_app INTEGER NOT NULL DEFAULT 0,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			)`,
+		)
+		.run()
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS entity_sources (
+				id TEXT PRIMARY KEY,
+				user_id TEXT NOT NULL,
+				entity_kind TEXT NOT NULL,
+				entity_id TEXT NOT NULL,
+				repo_id TEXT NOT NULL,
+				published_commit TEXT,
+				indexed_commit TEXT,
+				manifest_path TEXT NOT NULL,
+				source_root TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			)`,
+		)
+		.run()
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS published_bundle_artifacts (
+				id TEXT PRIMARY KEY,
+				user_id TEXT NOT NULL,
+				source_id TEXT NOT NULL,
+				published_commit TEXT NOT NULL,
+				artifact_kind TEXT NOT NULL,
+				artifact_name TEXT,
+				entry_point TEXT NOT NULL,
+				kv_key TEXT NOT NULL,
+				dependencies_json TEXT NOT NULL DEFAULT '[]',
+				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+			)`,
+		)
+		.run()
+	await db
+		.prepare(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_published_bundle_artifacts_identity
+			ON published_bundle_artifacts(user_id, source_id, artifact_kind, COALESCE(artifact_name, ''), entry_point)`,
+		)
+		.run()
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS package_invocations (
+				id TEXT PRIMARY KEY,
+				user_id TEXT NOT NULL,
+				token_id TEXT NOT NULL,
+				package_id TEXT NOT NULL,
+				package_kody_id TEXT NOT NULL,
+				export_name TEXT NOT NULL,
+				idempotency_key TEXT NOT NULL,
+				request_hash TEXT NOT NULL,
+				source TEXT,
+				topic TEXT,
+				status TEXT NOT NULL,
+				response_json TEXT,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			)`,
+		)
+		.run()
+	await db
+		.prepare(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_package_invocations_key
+			ON package_invocations(user_id, token_id, package_id, export_name, idempotency_key)`,
+		)
+		.run()
+
+	const now = new Date().toISOString()
+	await db
+		.prepare(
+			`INSERT INTO saved_packages (
+				id, user_id, name, kody_id, description, tags_json, search_text, source_id, has_app, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.bind(
+			packageId,
+			userId,
+			'@kentcdodds/package-email-notifier',
+			'package-email-notifier',
+			'Package email notifier',
+			'[]',
+			null,
+			sourceId,
+			0,
+			now,
+			now,
+		)
+		.run()
+	await db
+		.prepare(
+			`INSERT INTO entity_sources (
+				id, user_id, entity_kind, entity_id, repo_id, published_commit, indexed_commit, manifest_path, source_root, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.bind(
+			sourceId,
+			userId,
+			'package',
+			packageId,
+			'repo-1',
+			'commit-1',
+			null,
+			'package.json',
+			'/',
+			now,
+			now,
+		)
+		.run()
+
+	const manifest = {
+		name: '@kentcdodds/package-email-notifier',
+		exports: {
+			'.': './src/index.ts',
+		},
+		kody: {
+			id: 'package-email-notifier',
+			description: 'Package email notifier',
+			subscriptions: {
+				'email.message.received': {
+					handler: './src/email-message-received.ts',
+				},
+			},
+		},
+	}
+	bundleKv.set(
+		buildPublishedSourceManifestSnapshotKvKey({
+			sourceId,
+			publishedCommit: 'commit-1',
+		}),
+		JSON.stringify({
+			version: 1,
+			sourceId,
+			publishedCommit: 'commit-1',
+			manifestPath: 'package.json',
+			manifestContent: JSON.stringify(manifest),
+			createdAt: now,
+		}),
+	)
+
+	const subscriptionArtifact = {
+		version: 1,
+		kind: 'module',
+		artifactName: 'subscription:email.message.received',
+		sourceId,
+		publishedCommit: 'commit-1',
+		entryPoint: 'src/email-message-received.ts',
+		mainModule: 'dist/subscription.js',
+		modules: {
+			'.__kody_virtual__/runtime.js': `
+const runtime = globalThis.__kodyRuntime ?? {};
+export const email = runtime.email ?? null;
+export const params = runtime.params ?? null;
+`.trim(),
+			'dist/subscription.js': `
+import { email, params } from '../.__kody_virtual__/runtime.js'
+
+export default async function run() {
+  const result = await email.getMessage(params.message.id)
+  const firstAttachment = Array.isArray(params.attachments) ? params.attachments[0] : null
+  const attachment = firstAttachment?.id
+    ? await email.getAttachment(firstAttachment.id)
+    : null
+  const attachmentText = attachment?.content_base64
+    ? atob(attachment.content_base64)
+    : null
+  return {
+    eventType: 'received',
+    messageId: result.id,
+    textBody: result.text_body,
+    attachmentText,
+  }
+}
+`,
+		},
+		dependencies: [],
+		packageContext: {
+			packageId,
+			kodyId: 'package-email-notifier',
+			sourceId,
+		},
+		serviceContext: null,
+		createdAt: now,
+	}
+	const artifactJson = JSON.stringify(subscriptionArtifact)
+	const artifactKey = `bundle-artifact:v1:${sourceId}:commit-1:module:subscription:email.message.received:src/email-message-received.ts`
+	bundleKv.set(artifactKey, artifactJson)
+	await db
+		.prepare(
+			`INSERT INTO published_bundle_artifacts (
+				id, user_id, source_id, published_commit, artifact_kind, artifact_name, entry_point, kv_key, dependencies_json, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.bind(
+			`artifact-${crypto.randomUUID()}`,
+			userId,
+			sourceId,
+			'commit-1',
+			'module',
+			'subscription:email.message.received',
+			'src/email-message-received.ts',
+			artifactKey,
+			'[]',
+			now,
+			now,
+		)
+		.run()
+	const inbox = await createEmailInbox({
+		db: env.APP_DB,
+		userId,
+		name: 'Package inbox',
+		description: 'Package-managed inbox',
+		packageId,
+	})
+	await createEmailInboxAddress({
+		db: env.APP_DB,
+		inboxId: inbox.id,
+		userId,
+		address,
+		localPart: getEmailLocalPart(address),
+		domain: getEmailDomain(address),
+	})
+
+	const ctx = {
+		waitUntil(promise: Promise<unknown>) {
+			subscriptionCalls.push({ waitUntil: promise })
+		},
+		passThroughOnException() {},
+	} as ExecutionContext
+
+	const originalKv = env.BUNDLE_ARTIFACTS_KV
+	Object.assign(env, {
+		BUNDLE_ARTIFACTS_KV: {
+			async get(key: string, type?: string) {
+				const value = bundleKv.get(key) ?? null
+				if (value == null) return null
+				if (type === 'json') {
+					return JSON.parse(value) as unknown
+				}
+				return value
+			},
+			async put() {
+				return undefined
+			},
+			async delete() {
+				return undefined
+			},
+		},
+	})
+
+	try {
+		const firstMessage = createForwardableEmailMessage({
+			from: 'stranger@example.net',
+			to: address,
+			raw: [
+				'From: Stranger <stranger@example.net>',
+				`To: ${address}`,
+				'Subject: Stored mail',
+				'Message-ID: <stored@example.net>',
+				'Content-Type: multipart/mixed; boundary="mail-boundary"',
+				'',
+				'--mail-boundary',
+				'Content-Type: text/plain; charset="utf-8"',
+				'',
+				'Stored body.',
+				'--mail-boundary',
+				'Content-Type: text/plain; name="note.txt"',
+				'Content-Disposition: attachment; filename="note.txt"',
+				'',
+				'Attachment text',
+				'--mail-boundary--',
+			].join('\r\n'),
+		})
+		await handleInboundEmail(firstMessage, env, ctx)
+		expect(firstMessage.rejectedReason).toBeNull()
+
+		const secondMessage = createForwardableEmailMessage({
+			from: 'agent@trusted.example',
+			to: address,
+			raw: [
+				'From: Agent <agent@trusted.example>',
+				`To: ${address}`,
+				'Subject: Approved sender',
+				'Message-ID: <approved@trusted.example>',
+				'',
+				'Approved body.',
+			].join('\r\n'),
+		})
+		await handleInboundEmail(secondMessage, env, ctx)
+		expect(secondMessage.rejectedReason).toBeNull()
+
+		for (const entry of subscriptionCalls) {
+			if (entry['waitUntil'] instanceof Promise) {
+				await entry['waitUntil']
+			}
+		}
+
+		const invocations = await db
+			.prepare(
+				`SELECT export_name, topic, source, response_json
+				FROM package_invocations
+				WHERE package_id = ?
+				ORDER BY created_at ASC, id ASC`,
+			)
+			.bind(packageId)
+			.all<Record<string, unknown>>()
+		expect(invocations.results).toHaveLength(2)
+		const responses = (invocations.results ?? []).map((row) =>
+			JSON.parse(String(row['response_json'])),
+		) as Array<{ status: number; body: Record<string, unknown> }>
+		expect(invocations.results?.map((row) => row['export_name'])).toEqual([
+			'subscription:email.message.received',
+			'subscription:email.message.received',
+		])
+		expect(invocations.results?.map((row) => row['topic'])).toEqual([
+			'email.message.received',
+			'email.message.received',
+		])
+		expect(invocations.results?.map((row) => row['source'])).toEqual([
+			'email',
+			'email',
+		])
+		expect(responses[0]?.body).toMatchObject({
+			ok: true,
+			result: {
+				eventType: 'received',
+				textBody: 'Stored body.\n',
+				attachmentText: 'Attachment text\n',
+			},
+		})
+		expect(responses[1]?.body).toMatchObject({
+			ok: true,
+			result: {
+				eventType: 'received',
+				textBody: 'Approved body.\n',
+				attachmentText: null,
+			},
+		})
+	} finally {
+		Object.assign(env, {
+			BUNDLE_ARTIFACTS_KV: originalKv,
+		})
+	}
 })

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -10,7 +10,10 @@ import {
 	createEmailInbox,
 	createEmailInboxAddress,
 	createEmailThread,
+	insertEmailMessageWithAttachments,
+	getEmailAttachmentById,
 	listEmailMessages,
+	listEmailAttachmentsForMessage,
 } from './repo.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
 import {
@@ -210,6 +213,96 @@ test('inbound email handler rejects malformed messages without persisting them',
 		limit: 10,
 	})
 	expect(messages).toEqual([])
+})
+
+test('getEmailAttachmentById reconstructs unnamed attachments from raw MIME', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const userId = `email-attachment-user-${crypto.randomUUID()}`
+	const stored = await insertEmailMessageWithAttachments({
+		db: env.APP_DB,
+		message: {
+			direction: 'inbound',
+			userId,
+			inboxId: null,
+			threadId: null,
+			senderIdentityId: null,
+			fromAddress: 'sender@example.net',
+			envelopeFrom: 'sender@example.net',
+			toAddresses: ['receiver@example.com'],
+			ccAddresses: [],
+			bccAddresses: [],
+			replyToAddresses: [],
+			subject: 'Unnamed attachment',
+			messageIdHeader: '<unnamed-attachment@example.net>',
+			inReplyToHeader: null,
+			references: [],
+			headers: { from: ['Sender <sender@example.net>'] },
+			authResults: null,
+			textBody: 'See attachment.\n',
+			htmlBody: null,
+			rawMime: [
+				'From: Sender <sender@example.net>',
+				'To: Receiver <receiver@example.com>',
+				'Subject: Unnamed attachment',
+				'Message-ID: <unnamed-attachment@example.net>',
+				'Content-Type: multipart/mixed; boundary="mail-boundary"',
+				'',
+				'--mail-boundary',
+				'Content-Type: text/plain; charset="utf-8"',
+				'',
+				'See attachment.',
+				'--mail-boundary',
+				'Content-Type: text/plain',
+				'Content-Disposition: attachment',
+				'',
+				'Attachment without filename',
+				'--mail-boundary--',
+			].join('\r\n'),
+			rawSize: 0,
+			processingStatus: 'stored',
+			providerMessageId: null,
+			error: null,
+			receivedAt: new Date().toISOString(),
+			sentAt: null,
+		},
+		attachments: [
+			{
+				filename: null,
+				contentType: 'text/plain',
+				contentId: null,
+				disposition: 'attachment',
+				size: new TextEncoder().encode('Attachment without filename\n').byteLength,
+				storageKind: 'raw-mime',
+				storageKey: null,
+			},
+		],
+	})
+	const attachments = await listEmailAttachmentsForMessage({
+		db: env.APP_DB,
+		messageId: stored.id,
+	})
+	const attachment = attachments[0]
+	expect(attachment).toBeDefined()
+	if (!attachment) {
+		throw new Error('Expected inserted attachment')
+	}
+
+	const loaded = await getEmailAttachmentById({
+		db: env.APP_DB,
+		userId,
+		attachmentId: attachment.id,
+	})
+
+	expect(loaded).toMatchObject({
+		id: attachment.id,
+		filename: null,
+		contentType: 'text/plain',
+		disposition: 'attachment',
+	})
+	expect(loaded?.contentBase64).toBeTruthy()
+	expect(
+		loaded?.contentBase64 ? atob(loaded.contentBase64) : null,
+	).toBe('Attachment without filename\n')
 })
 
 test('inbound email handler dispatches package subscriptions for stored inbound email', async () => {

--- a/packages/worker/src/email/package-subscriptions.ts
+++ b/packages/worker/src/email/package-subscriptions.ts
@@ -1,0 +1,185 @@
+import { getAppBaseUrl } from '#app/app-base-url.ts'
+import { invokePackageSubscription } from '#worker/package-invocations/service.ts'
+import { listPackageSubscriptions } from '#worker/package-registry/manifest.ts'
+import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
+import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
+import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+import { listEmailAttachmentsForMessage } from './repo.ts'
+import { type EmailAttachmentRecord, type EmailMessageRecord } from './types.ts'
+
+const inboundEmailReceiptTopic = 'email.message.received'
+
+type EmailReceiptSubscriptionEnvelope = {
+	event: typeof inboundEmailReceiptTopic
+	message: {
+		id: string
+		inbox_id: string | null
+		from_address: string | null
+		envelope_from: string | null
+		to_addresses: Array<string>
+		cc_addresses: Array<string>
+		reply_to_addresses: Array<string>
+		subject: string | null
+		message_id_header: string | null
+		in_reply_to_header: string | null
+		references: Array<string>
+		processing_status: EmailMessageRecord['processingStatus']
+		received_at: string | null
+		created_at: string
+	}
+	attachments: Array<{
+		id: string
+		filename: string | null
+		content_type: string | null
+		content_id: string | null
+		disposition: string | null
+		size: number
+		storage_kind: string
+		storage_key: string | null
+		created_at: string
+	}>
+}
+
+type LoadedEmailSubscription = {
+	savedPackage: SavedPackageRecord
+	subscription: ReturnType<typeof listPackageSubscriptions>[number]
+}
+
+function stringArray(values: ReadonlyArray<unknown>) {
+	return values.filter((value): value is string => typeof value === 'string')
+}
+
+function toRuntimeAttachmentMetadata(attachment: EmailAttachmentRecord) {
+	return {
+		id: attachment.id,
+		filename: attachment.filename,
+		content_type: attachment.contentType,
+		content_id: attachment.contentId,
+		disposition: attachment.disposition,
+		size: attachment.size,
+		storage_kind: attachment.storageKind,
+		storage_key: attachment.storageKey,
+		created_at: attachment.createdAt,
+	}
+}
+
+function buildEmailEventPayload(input: {
+	message: EmailMessageRecord
+	attachments: Array<EmailAttachmentRecord>
+}) {
+	return {
+		event: inboundEmailReceiptTopic,
+		message: {
+			id: input.message.id,
+			inbox_id: input.message.inboxId,
+			from_address: input.message.fromAddress,
+			envelope_from: input.message.envelopeFrom,
+			to_addresses: stringArray(input.message.toAddresses),
+			cc_addresses: stringArray(input.message.ccAddresses),
+			reply_to_addresses: stringArray(input.message.replyToAddresses),
+			subject: input.message.subject,
+			message_id_header: input.message.messageIdHeader,
+			in_reply_to_header: input.message.inReplyToHeader,
+			references: stringArray(input.message.references),
+			processing_status: input.message.processingStatus,
+			received_at: input.message.receivedAt,
+			created_at: input.message.createdAt,
+		},
+		attachments: input.attachments.map(toRuntimeAttachmentMetadata),
+	} satisfies EmailReceiptSubscriptionEnvelope
+}
+
+function buildSubscriptionIdempotencyKey(input: {
+	messageId: string
+	packageId: string
+}) {
+	return `email:${input.messageId}:${input.packageId}:${inboundEmailReceiptTopic}`
+}
+
+async function loadMatchingEmailSubscriptions(input: {
+	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV'>
+	baseUrl: string
+	userId: string
+}) {
+	let savedPackages: Array<SavedPackageRecord>
+	try {
+		savedPackages = await listSavedPackagesByUserId(input.env.APP_DB, {
+			userId: input.userId,
+		})
+	} catch (error) {
+		if (
+			error instanceof Error &&
+			error.message.includes('no such table: saved_packages')
+		) {
+			return []
+		}
+		throw error
+	}
+	const settled = await Promise.all(
+		savedPackages.map(async (savedPackage) => {
+			try {
+				const loaded = await loadPackageManifestBySourceId({
+					env: input.env as Env,
+					baseUrl: input.baseUrl,
+					userId: input.userId,
+					sourceId: savedPackage.sourceId,
+				})
+				const subscription = listPackageSubscriptions(loaded.manifest).find(
+					(candidate) => candidate.topic === inboundEmailReceiptTopic,
+				)
+				if (!subscription) return null
+				return { savedPackage, subscription } satisfies LoadedEmailSubscription
+			} catch (error) {
+				console.warn('Failed to load package manifest for email subscription', {
+					sourceId: savedPackage.sourceId,
+					packageId: savedPackage.id,
+					error,
+				})
+				return null
+			}
+		}),
+	)
+	return settled.filter(
+		(entry): entry is LoadedEmailSubscription => entry !== null,
+	)
+}
+
+export async function dispatchInboundEmailSubscriptionEvents(input: {
+	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'APP_BASE_URL'>
+	userId: string
+	message: EmailMessageRecord
+}) {
+	const baseUrl = getAppBaseUrl({
+		env: input.env,
+		requestUrl: 'https://kody.invalid',
+	})
+	const attachments = await listEmailAttachmentsForMessage({
+		db: input.env.APP_DB,
+		messageId: input.message.id,
+	})
+	const subscriptions = await loadMatchingEmailSubscriptions({
+		env: input.env,
+		baseUrl,
+		userId: input.userId,
+	})
+	const eventPayload = buildEmailEventPayload({
+		message: input.message,
+		attachments,
+	})
+	return await Promise.all(
+		subscriptions.map(async ({ savedPackage }) =>
+			await invokePackageSubscription({
+				env: input.env as Env,
+				baseUrl,
+				savedPackage,
+				topic: inboundEmailReceiptTopic,
+				params: eventPayload as Record<string, unknown>,
+				idempotencyKey: buildSubscriptionIdempotencyKey({
+					messageId: input.message.id,
+					packageId: savedPackage.id,
+				}),
+				source: 'email',
+			}),
+		),
+	)
+}

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -941,7 +941,7 @@ export async function getEmailAttachmentById(input: {
 		attachmentEncoding: 'arraybuffer',
 	})
 	const matched = parsed.attachments.find((candidate) => {
-		if (candidate.filename !== attachment.filename) return false
+		if ((candidate.filename ?? null) !== attachment.filename) return false
 		if (candidate.mimeType !== (attachment.contentType ?? candidate.mimeType)) {
 			return false
 		}

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -1,3 +1,4 @@
+import PostalMime from 'postal-mime'
 import {
 	type EmailAttachmentRecord,
 	type EmailDirection,
@@ -14,6 +15,18 @@ function nowIso() {
 	return new Date().toISOString()
 }
 
+function bytesToBase64(bytes: Uint8Array) {
+	let binary = ''
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte)
+	}
+	return btoa(binary)
+}
+
+function normalizeRunChanges(result: D1RunResult) {
+	const changes = result.meta['changes']
+	return typeof changes === 'number' ? changes : Number(changes ?? 0)
+}
 function parseJsonArray(value: string | null) {
 	if (!value) return []
 	try {
@@ -746,6 +759,23 @@ export async function getEmailMessageById(input: {
 	return row ? mapMessageRow(row) : null
 }
 
+export async function getEmailMessageWithAttachmentsById(input: {
+	db: D1Database
+	userId: string
+	messageId: string
+}) {
+	const message = await getEmailMessageById(input)
+	if (!message) return null
+	const attachments = await listEmailAttachmentsForMessage({
+		db: input.db,
+		messageId: message.id,
+	})
+	return {
+		message,
+		attachments,
+	}
+}
+
 export async function getEmailMessageByMessageIdHeader(input: {
 	db: D1Database
 	userId: string
@@ -880,6 +910,71 @@ export async function listEmailAttachmentsForMessage(input: {
 		.bind(input.messageId)
 		.all<Record<string, unknown>>()
 	return (result.results ?? []).map(mapAttachmentRow)
+}
+
+export async function getEmailAttachmentById(input: {
+	db: D1Database
+	userId: string
+	attachmentId: string
+}) {
+	const row = await input.db
+		.prepare(
+			`SELECT attachment.*
+			FROM email_attachments attachment
+			JOIN email_messages message ON message.id = attachment.message_id
+			WHERE attachment.id = ?
+				AND message.user_id = ?
+			LIMIT 1`,
+		)
+		.bind(input.attachmentId, input.userId)
+		.first<Record<string, unknown>>()
+	if (!row) return null
+	const attachment = mapAttachmentRow(row)
+	const message = await getEmailMessageById({
+		db: input.db,
+		userId: input.userId,
+		messageId: attachment.messageId,
+	})
+	if (!message?.rawMime) {
+		return {
+			...attachment,
+			content: null,
+			contentBase64: null,
+		}
+	}
+	const parsed = await PostalMime.parse(message.rawMime, {
+		attachmentEncoding: 'arraybuffer',
+	})
+	const matched = parsed.attachments.find((candidate) => {
+		if (candidate.filename !== attachment.filename) return false
+		if (candidate.mimeType !== (attachment.contentType ?? candidate.mimeType)) {
+			return false
+		}
+		if ((candidate.contentId ?? null) !== attachment.contentId) return false
+		if ((candidate.disposition ?? null) !== attachment.disposition) return false
+		const content = candidate.content
+		const size =
+			typeof content === 'string'
+				? new TextEncoder().encode(content).byteLength
+				: content.byteLength
+		return size === attachment.size
+	})
+	if (!matched) {
+		return {
+			...attachment,
+			content: null,
+			contentBase64: null,
+		}
+	}
+	const bytes =
+		typeof matched.content === 'string'
+			? new TextEncoder().encode(matched.content)
+			: new Uint8Array(matched.content)
+	return {
+		...attachment,
+		content: matched.content,
+		contentBase64: bytesToBase64(bytes),
+	}
 }
 
 export async function insertEmailDeliveryEvent(input: {

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -22,11 +22,6 @@ function bytesToBase64(bytes: Uint8Array) {
 	}
 	return btoa(binary)
 }
-
-function normalizeRunChanges(result: D1RunResult) {
-	const changes = result.meta['changes']
-	return typeof changes === 'number' ? changes : Number(changes ?? 0)
-}
 function parseJsonArray(value: string | null) {
 	if (!value) return []
 	try {

--- a/packages/worker/src/mcp/capabilities/email/domain.ts
+++ b/packages/worker/src/mcp/capabilities/email/domain.ts
@@ -2,6 +2,7 @@ import { defineDomain } from '#mcp/capabilities/define-domain.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { emailInboxCreateCapability } from './email-inbox-create.ts'
 import { emailInboxListCapability } from './email-inbox-list.ts'
+import { emailAttachmentGetCapability } from './email-attachment-get.ts'
 import { emailMessageGetCapability } from './email-message-get.ts'
 import { emailMessageListCapability } from './email-message-list.ts'
 import { emailReplyCapability } from './email-reply.ts'
@@ -16,6 +17,7 @@ export const emailDomain = defineDomain({
 	capabilities: [
 		emailInboxCreateCapability,
 		emailInboxListCapability,
+		emailAttachmentGetCapability,
 		emailMessageListCapability,
 		emailMessageGetCapability,
 		emailSendCapability,

--- a/packages/worker/src/mcp/capabilities/email/email-attachment-get.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-attachment-get.node.test.ts
@@ -1,0 +1,81 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getEmailAttachmentById: vi.fn(),
+}))
+
+vi.mock('#worker/email/repo.ts', () => ({
+	getEmailAttachmentById: (...args: Array<unknown>) =>
+		mockModule.getEmailAttachmentById(...args),
+}))
+
+const { emailAttachmentGetCapability } = await import('./email-attachment-get.ts')
+const { createMcpCallerContext } = await import('#mcp/context.ts')
+
+test('emailAttachmentGetCapability returns attachment content from repo helper', async () => {
+	mockModule.getEmailAttachmentById.mockResolvedValueOnce({
+		id: 'attachment-1',
+		messageId: 'message-1',
+		filename: 'note.txt',
+		contentType: 'text/plain',
+		contentId: null,
+		disposition: 'attachment',
+		size: 12,
+		storageKind: 'raw-mime',
+		storageKey: null,
+		createdAt: '2026-04-30T00:00:00.000Z',
+		contentBase64: 'QXR0YWNobWVudCB0ZXh0',
+	})
+
+	const result = await emailAttachmentGetCapability.handler(
+		{ attachment_id: 'attachment-1' },
+		{
+			env: { APP_DB: {} } as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://example.com',
+				user: {
+					userId: 'user-1',
+					email: 'user@example.com',
+					displayName: 'User Example',
+				},
+			}),
+		},
+	)
+
+	expect(mockModule.getEmailAttachmentById).toHaveBeenCalledWith({
+		db: {},
+		userId: 'user-1',
+		attachmentId: 'attachment-1',
+	})
+	expect(result).toEqual({
+		id: 'attachment-1',
+		message_id: 'message-1',
+		filename: 'note.txt',
+		content_type: 'text/plain',
+		content_id: null,
+		disposition: 'attachment',
+		size: 12,
+		data_base64: 'QXR0YWNobWVudCB0ZXh0',
+	})
+})
+
+test('emailAttachmentGetCapability throws when attachment is missing', async () => {
+	mockModule.getEmailAttachmentById.mockResolvedValueOnce(null)
+
+	await expect(
+		emailAttachmentGetCapability.handler(
+			{ attachment_id: 'missing-attachment' },
+			{
+				env: { APP_DB: {} } as Env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://example.com',
+					user: {
+						userId: 'user-1',
+						email: 'user@example.com',
+						displayName: 'User Example',
+					},
+				}),
+			},
+		),
+	).rejects.toThrow('Email attachment not found: missing-attachment')
+})

--- a/packages/worker/src/mcp/capabilities/email/email-attachment-get.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-attachment-get.ts
@@ -1,20 +1,8 @@
-import PostalMime from 'postal-mime'
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
-import {
-	getEmailAttachmentById,
-	getEmailMessageById,
-} from '#worker/email/repo.ts'
-
-function toBase64(bytes: Uint8Array) {
-	let binary = ''
-	for (const byte of bytes) {
-		binary += String.fromCharCode(byte)
-	}
-	return btoa(binary)
-}
+import { getEmailAttachmentById } from '#worker/email/repo.ts'
 
 const emailAttachmentContentSchema = z.object({
 	id: z.string(),
@@ -51,47 +39,11 @@ export const emailAttachmentGetCapability = defineDomainCapability(
 			if (!attachment) {
 				throw new Error(`Email attachment not found: ${args.attachment_id}`)
 			}
-			const message = await getEmailMessageById({
-				db: ctx.env.APP_DB,
-				userId: user.userId,
-				messageId: attachment.messageId,
-			})
-			if (!message) {
-				throw new Error(`Email message not found for attachment: ${args.attachment_id}`)
-			}
-			if (!message.rawMime) {
+			if (!attachment.contentBase64) {
 				throw new Error(
 					`Email attachment "${args.attachment_id}" is unavailable because the stored message has no raw MIME payload.`,
 				)
 			}
-			const parsed = await PostalMime.parse(message.rawMime, {
-				attachmentEncoding: 'arraybuffer',
-			})
-			const matched = parsed.attachments.find((_candidate, index) => {
-				const candidate = parsed.attachments[index]
-				if (!candidate) return false
-				if (candidate.filename !== attachment.filename) return false
-				if (candidate.mimeType !== (attachment.contentType ?? candidate.mimeType)) {
-					return false
-				}
-				if ((candidate.contentId ?? null) !== attachment.contentId) return false
-				if ((candidate.disposition ?? null) !== attachment.disposition) return false
-				const content = candidate.content
-				const size =
-					typeof content === 'string'
-						? new TextEncoder().encode(content).byteLength
-						: content.byteLength
-				return size === attachment.size
-			})
-			if (!matched) {
-				throw new Error(
-					`Email attachment "${args.attachment_id}" could not be reconstructed from stored raw MIME.`,
-				)
-			}
-			const bytes =
-				typeof matched.content === 'string'
-					? new TextEncoder().encode(matched.content)
-					: new Uint8Array(matched.content)
 			return {
 				id: attachment.id,
 				message_id: attachment.messageId,
@@ -100,7 +52,7 @@ export const emailAttachmentGetCapability = defineDomainCapability(
 				content_id: attachment.contentId,
 				disposition: attachment.disposition,
 				size: attachment.size,
-				data_base64: toBase64(bytes),
+				data_base64: attachment.contentBase64,
 			}
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/email/email-attachment-get.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-attachment-get.ts
@@ -1,0 +1,107 @@
+import PostalMime from 'postal-mime'
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import {
+	getEmailAttachmentById,
+	getEmailMessageById,
+} from '#worker/email/repo.ts'
+
+function toBase64(bytes: Uint8Array) {
+	let binary = ''
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte)
+	}
+	return btoa(binary)
+}
+
+const emailAttachmentContentSchema = z.object({
+	id: z.string(),
+	message_id: z.string(),
+	filename: z.string().nullable(),
+	content_type: z.string().nullable(),
+	content_id: z.string().nullable(),
+	disposition: z.string().nullable(),
+	size: z.number(),
+	data_base64: z.string(),
+})
+
+export const emailAttachmentGetCapability = defineDomainCapability(
+	capabilityDomainNames.email,
+	{
+		name: 'email_attachment_get',
+		description:
+			'Get one stored email attachment by id, returning metadata plus the attachment bytes as base64.',
+		keywords: ['email', 'attachment', 'get', 'download'],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: z.object({
+			attachment_id: z.string().min(1),
+		}),
+		outputSchema: emailAttachmentContentSchema,
+		async handler(args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const attachment = await getEmailAttachmentById({
+				db: ctx.env.APP_DB,
+				userId: user.userId,
+				attachmentId: args.attachment_id,
+			})
+			if (!attachment) {
+				throw new Error(`Email attachment not found: ${args.attachment_id}`)
+			}
+			const message = await getEmailMessageById({
+				db: ctx.env.APP_DB,
+				userId: user.userId,
+				messageId: attachment.messageId,
+			})
+			if (!message) {
+				throw new Error(`Email message not found for attachment: ${args.attachment_id}`)
+			}
+			if (!message.rawMime) {
+				throw new Error(
+					`Email attachment "${args.attachment_id}" is unavailable because the stored message has no raw MIME payload.`,
+				)
+			}
+			const parsed = await PostalMime.parse(message.rawMime, {
+				attachmentEncoding: 'arraybuffer',
+			})
+			const matched = parsed.attachments.find((_candidate, index) => {
+				const candidate = parsed.attachments[index]
+				if (!candidate) return false
+				if (candidate.filename !== attachment.filename) return false
+				if (candidate.mimeType !== (attachment.contentType ?? candidate.mimeType)) {
+					return false
+				}
+				if ((candidate.contentId ?? null) !== attachment.contentId) return false
+				if ((candidate.disposition ?? null) !== attachment.disposition) return false
+				const content = candidate.content
+				const size =
+					typeof content === 'string'
+						? new TextEncoder().encode(content).byteLength
+						: content.byteLength
+				return size === attachment.size
+			})
+			if (!matched) {
+				throw new Error(
+					`Email attachment "${args.attachment_id}" could not be reconstructed from stored raw MIME.`,
+				)
+			}
+			const bytes =
+				typeof matched.content === 'string'
+					? new TextEncoder().encode(matched.content)
+					: new Uint8Array(matched.content)
+			return {
+				id: attachment.id,
+				message_id: attachment.messageId,
+				filename: attachment.filename,
+				content_type: attachment.contentType,
+				content_id: attachment.contentId,
+				disposition: attachment.disposition,
+				size: attachment.size,
+				data_base64: toBase64(bytes),
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/email/email-attachment-get.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-attachment-get.ts
@@ -39,7 +39,7 @@ export const emailAttachmentGetCapability = defineDomainCapability(
 			if (!attachment) {
 				throw new Error(`Email attachment not found: ${args.attachment_id}`)
 			}
-			if (!attachment.contentBase64) {
+			if (attachment.contentBase64 == null) {
 				throw new Error(
 					`Email attachment "${args.attachment_id}" is unavailable because the stored message has no raw MIME payload.`,
 				)

--- a/packages/worker/src/mcp/capabilities/email/email-domain.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-domain.node.test.ts
@@ -22,6 +22,7 @@ test('email domain exposes inbox, message, and send capabilities', () => {
 		[
 			'email_inbox_create',
 			'email_inbox_list',
+			'email_attachment_get',
 			'email_message_list',
 			'email_message_get',
 			'email_send',

--- a/packages/worker/src/mcp/run-codemode-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.node.test.ts
@@ -1088,3 +1088,86 @@ test('runBundledModuleWithRegistry injects service helpers and custom timeout', 
 		getRegistrySpy.mockRestore()
 	}
 })
+
+test('runBundledModuleWithRegistry injects email helpers', async () => {
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+	})
+	const getRegistrySpy = vi
+		.spyOn(
+			await import('#mcp/capabilities/registry.ts'),
+			'getCapabilityRegistryForContext',
+		)
+		.mockResolvedValue({
+			capabilityDomains: [],
+			capabilityDomainDescriptionsByName: {} as Record<string, string>,
+			capabilityHandlers: {},
+			capabilityList: [],
+			capabilityMap: {},
+			capabilitySpecs: {},
+			capabilityToolDescriptors: {},
+		} as Awaited<ReturnType<typeof getCapabilityRegistryForContext>>)
+	let providerFns: Record<string, (args: unknown) => Promise<unknown>> | null = null
+	const createExecuteExecutorSpy = vi
+		.spyOn(await import('#mcp/executor.ts'), 'createExecuteExecutor')
+		.mockReturnValue({
+			async execute(_source, providers) {
+				providerFns = (
+					providers[0] as {
+						fns: Record<string, (args: unknown) => Promise<unknown>>
+					}
+				).fns
+				return {
+					result: 'ok',
+					logs: [],
+				}
+			},
+		} as never)
+
+	try {
+		const result = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			{
+				mainModule: 'entry.js',
+				modules: {
+					'entry.js': 'export default async () => "ok"',
+				},
+			},
+			undefined,
+			{
+				emailTools: {
+					getMessage: async (messageId) => ({ id: messageId, subject: 'Hello' }),
+					getAttachment: async (attachmentId) => ({
+						id: attachmentId,
+						text: 'hello',
+					}),
+				},
+			},
+		)
+
+		expect(result.result).toBe('ok')
+		expect(providerFns).not.toBeNull()
+		await expect(
+			providerFns?.email_message_get({
+				message_id: 'message-1',
+			}),
+		).resolves.toEqual({
+			id: 'message-1',
+			subject: 'Hello',
+		})
+		await expect(
+			providerFns?.email_attachment_get({
+				attachment_id: 'attachment-1',
+			}),
+		).resolves.toEqual({
+			id: 'attachment-1',
+			text: 'hello',
+		})
+	} finally {
+		createExecuteExecutorSpy.mockRestore()
+		getRegistrySpy.mockRestore()
+	}
+})

--- a/packages/worker/src/mcp/run-codemode-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.node.test.ts
@@ -1171,3 +1171,86 @@ test('runBundledModuleWithRegistry injects email helpers', async () => {
 		getRegistrySpy.mockRestore()
 	}
 })
+
+test('runModuleWithRegistry injects email helpers for module syntax', async () => {
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+	})
+	const buildBundleMock = vi.mocked(buildKodyModuleBundle)
+	buildBundleMock.mockClear()
+	const getRegistrySpy = vi
+		.spyOn(
+			await import('#mcp/capabilities/registry.ts'),
+			'getCapabilityRegistryForContext',
+		)
+		.mockResolvedValue({
+			capabilityDomains: [],
+			capabilityDomainDescriptionsByName: {} as Record<string, string>,
+			capabilityHandlers: {},
+			capabilityList: [],
+			capabilityMap: {},
+			capabilitySpecs: {},
+			capabilityToolDescriptors: {},
+		} as Awaited<ReturnType<typeof getCapabilityRegistryForContext>>)
+	let providerFns: Record<string, (args: unknown) => Promise<unknown>> | null = null
+	const createExecuteExecutorSpy = vi
+		.spyOn(await import('#mcp/executor.ts'), 'createExecuteExecutor')
+		.mockReturnValue({
+			async execute(_source, providers) {
+				providerFns = (
+					providers[0] as {
+						fns: Record<string, (args: unknown) => Promise<unknown>>
+					}
+				).fns
+				return {
+					result: { id: 'message-1', subject: 'Hello' },
+					logs: [],
+				}
+			},
+		} as never)
+
+	try {
+		const code = `import { email } from 'kody:runtime'
+
+export default async function run() {
+	return await email.getMessage('message-1')
+}`
+		const result = await runModuleWithRegistry(env, callerContext, code, undefined, {
+			emailTools: {
+				getMessage: async (messageId) => ({ id: messageId, subject: 'Hello' }),
+				getAttachment: async (attachmentId) => ({
+					id: attachmentId,
+					text: 'hello',
+				}),
+			},
+		})
+
+		expect(result.result).toEqual({
+			id: 'message-1',
+			subject: 'Hello',
+		})
+		expect(buildBundleMock).toHaveBeenCalledTimes(1)
+		expect(providerFns).not.toBeNull()
+		await expect(
+			providerFns?.email_message_get({
+				message_id: 'message-1',
+			}),
+		).resolves.toEqual({
+			id: 'message-1',
+			subject: 'Hello',
+		})
+		await expect(
+			providerFns?.email_attachment_get({
+				attachment_id: 'attachment-1',
+			}),
+		).resolves.toEqual({
+			id: 'attachment-1',
+			text: 'hello',
+		})
+	} finally {
+		createExecuteExecutorSpy.mockRestore()
+		getRegistrySpy.mockRestore()
+	}
+})

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -61,6 +61,11 @@ type PackageSecretToolOptions = {
 	has: (alias: string) => Promise<boolean>
 }
 
+type EmailToolOptions = {
+	getMessage: (messageId: string) => Promise<unknown>
+	getAttachment: (attachmentId: string) => Promise<unknown>
+}
+
 function isPackageSecretAvailabilityError(error: unknown) {
 	return (
 		error instanceof Error &&
@@ -144,6 +149,31 @@ const packageSecrets = {
 	`.trim()
 }
 
+function createEmailHelperPrelude() {
+	return `
+const email = {
+  getMessage: async (messageId) => {
+    const normalizedMessageId =
+      typeof messageId === 'string' ? messageId.trim() : '';
+    if (!normalizedMessageId) {
+      throw new Error('email.getMessage requires a non-empty message id.')
+    }
+    return await codemode.email_message_get({ message_id: normalizedMessageId });
+  },
+  getAttachment: async (attachmentId) => {
+    const normalizedAttachmentId =
+      typeof attachmentId === 'string' ? attachmentId.trim() : '';
+    if (!normalizedAttachmentId) {
+      throw new Error('email.getAttachment requires a non-empty attachment id.')
+    }
+    return await codemode.email_attachment_get({
+      attachment_id: normalizedAttachmentId,
+    });
+  },
+};
+	`.trim()
+}
+
 export async function buildCodemodeFns(
 	env: Env,
 	callerContext: McpCallerContext,
@@ -157,12 +187,18 @@ export async function buildCodemodeFns(
 		storageTools?: StorageToolOptions
 		serviceTools?: ServiceToolOptions
 		packageSecretTools?: PackageSecretToolOptions
+		emailTools?: EmailToolOptions
+		skipCapabilityRegistry?: boolean
 	},
 ) {
-	const { capabilityMap } = await getCapabilityRegistryForContext({
-		env,
-		callerContext,
-	})
+	const capabilityMap = options?.skipCapabilityRegistry
+		? {}
+		: (
+				await getCapabilityRegistryForContext({
+					env,
+					callerContext,
+				})
+			).capabilityMap
 	const additionalTools = options?.additionalTools ?? {}
 	const storageTools = options?.storageTools
 	assertNoCapabilityCollisions(capabilityMap, additionalTools)
@@ -258,11 +294,32 @@ export async function buildCodemodeFns(
 			}
 		: {}
 	assertNoCapabilityCollisions(capabilityMap, packageSecretCodemodeTools)
+	const emailTools = options?.emailTools
+	const emailCodemodeTools: AdditionalCodemodeTools = emailTools
+		? {
+				email_message_get: async (args: unknown) => {
+					const messageId =
+						typeof args === 'object' && args !== null && 'message_id' in args
+							? String((args as { message_id: unknown }).message_id ?? '')
+							: ''
+					return await emailTools.getMessage(messageId)
+				},
+				email_attachment_get: async (args: unknown) => {
+					const attachmentId =
+						typeof args === 'object' && args !== null && 'attachment_id' in args
+							? String((args as { attachment_id: unknown }).attachment_id ?? '')
+							: ''
+					return await emailTools.getAttachment(attachmentId)
+				},
+			}
+		: {}
+	assertNoCapabilityCollisions(capabilityMap, emailCodemodeTools)
 	return {
 		...capabilityCodemodeTools,
 		...storageCodemodeTools,
 		...serviceCodemodeTools,
 		...packageSecretCodemodeTools,
+		...emailCodemodeTools,
 		...additionalTools,
 	}
 }
@@ -287,6 +344,8 @@ export async function buildCodemodeProvider(
 		storageTools?: StorageToolOptions
 		serviceTools?: ServiceToolOptions
 		packageSecretTools?: PackageSecretToolOptions
+		emailTools?: EmailToolOptions
+		skipCapabilityRegistry?: boolean
 	},
 ): Promise<ResolvedProvider> {
 	const tools = await buildCodemodeFns(env, callerContext, options)
@@ -362,6 +421,7 @@ export async function runCodemodeWithRegistry(
 			packageId: string
 			kodyId: string
 		} | null
+		emailTools?: EmailToolOptions
 		executorModules?: WorkerLoaderModules
 		executorTimeoutMs?: number | null
 	},
@@ -408,6 +468,7 @@ export async function runCodemodeWithRegistry(
 					packageId: options.packageContext.packageId,
 				})
 			: undefined,
+		emailTools: options?.emailTools,
 	})
 	const wrappedCode =
 		params !== undefined
@@ -426,10 +487,12 @@ export async function runCodemodeWithRegistry(
 	const packageSecretsHelperPrelude = options?.packageContext
 		? createPackageSecretsHelperPrelude()
 		: ''
+	const emailHelperPrelude = options?.emailTools ? createEmailHelperPrelude() : ''
 	const helperPrelude = [
 		storageHelperPrelude,
 		serviceHelperPrelude,
 		packageSecretsHelperPrelude,
+		emailHelperPrelude,
 		options?.helperPrelude ?? '',
 	]
 		.filter((value) => value.trim().length > 0)
@@ -518,6 +581,8 @@ export async function runBundledModuleWithRegistry(
 			serviceName: string
 		} | null
 		serviceTools?: ServiceToolOptions
+		emailTools?: EmailToolOptions
+		skipCapabilityRegistry?: boolean
 		executorTimeoutMs?: number | null
 	},
 ): Promise<ExecuteResult> {
@@ -551,6 +616,8 @@ export async function runBundledModuleWithRegistry(
 					packageId: options.packageContext.packageId,
 				})
 			: undefined,
+		emailTools: options?.emailTools,
+		skipCapabilityRegistry: options?.skipCapabilityRegistry,
 	})
 	const storageHelperPrelude = options?.storageTools
 		? createStorageHelperPrelude({
@@ -564,11 +631,13 @@ export async function runBundledModuleWithRegistry(
 	const packageSecretsHelperPrelude = options?.packageContext
 		? createPackageSecretsHelperPrelude()
 		: ''
+	const emailHelperPrelude = options?.emailTools ? createEmailHelperPrelude() : ''
 	const wrapped = `async () => {
 ${createExecuteHelperPrelude()}
 ${storageHelperPrelude ? `${storageHelperPrelude}\n` : ''}
 ${serviceHelperPrelude ? `${serviceHelperPrelude}\n` : ''}
 ${packageSecretsHelperPrelude ? `${packageSecretsHelperPrelude}\n` : ''}
+${emailHelperPrelude ? `${emailHelperPrelude}\n` : ''}
   const __previousRuntime = globalThis.__kodyRuntime;
   globalThis.__kodyRuntime = {
     codemode,
@@ -581,6 +650,7 @@ ${packageSecretsHelperPrelude ? `${packageSecretsHelperPrelude}\n` : ''}
     serviceContext: ${JSON.stringify(options?.serviceContext ?? null)},
     service: typeof service === 'undefined' ? null : service,
     packageSecrets: typeof packageSecrets === 'undefined' ? null : packageSecrets,
+    email: typeof email === 'undefined' ? null : email,
   };
   try {
     const __kodyModule = await import(${JSON.stringify(`./${bundle.mainModule}`)});

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -532,6 +532,7 @@ export async function runModuleWithRegistry(
 			packageId: string
 			kodyId: string
 		} | null
+		emailTools?: EmailToolOptions
 		executorTimeoutMs?: number | null
 	},
 ): Promise<ExecuteResult> {

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -4,6 +4,7 @@ import { invokePackageExport } from './service.ts'
 const repoMockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
 	getSavedPackageByKodyId: vi.fn(),
+	loadPackageManifestBySourceId: vi.fn(),
 	loadPackageSourceBySourceId: vi.fn(),
 	getEntitySourceById: vi.fn(),
 	loadPublishedBundleArtifactByIdentity: vi.fn(),
@@ -20,6 +21,8 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 }))
 
 vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageManifestBySourceId: (...args: Array<unknown>) =>
+		repoMockModule.loadPackageManifestBySourceId(...args),
 	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
 		repoMockModule.loadPackageSourceBySourceId(...args),
 }))
@@ -198,6 +201,34 @@ function seedPackageResolution() {
 		hasApp: true,
 		createdAt: '2026-04-27T00:00:00.000Z',
 		updatedAt: '2026-04-27T00:00:00.000Z',
+	})
+	repoMockModule.loadPackageManifestBySourceId.mockResolvedValue({
+		source: {
+			id: 'source-1',
+			user_id: 'user-123',
+			entity_kind: 'package',
+			entity_id: 'pkg-1',
+			repo_id: 'repo-1',
+			published_commit: 'commit-1',
+			indexed_commit: null,
+			manifest_path: 'package.json',
+			source_root: '/',
+			created_at: '2026-04-27T00:00:00.000Z',
+			updated_at: '2026-04-27T00:00:00.000Z',
+		},
+		manifest: {
+			name: '@kentcdodds/discord-gateway',
+			exports: {
+				'./dispatch-message-created': './src/dispatch-message-created.ts',
+			},
+			kody: {
+				id: 'discord-gateway',
+				description: 'Discord gateway helpers',
+				app: {
+					entry: './src/app.ts',
+				},
+			},
+		},
 	})
 	repoMockModule.loadPackageSourceBySourceId.mockResolvedValue({
 		source: {

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -566,6 +566,94 @@ test('invokePackageExport rejects reusing an idempotency key for a different pay
 	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
 })
 
+test('invokePackageExport replays responses created with the legacy exportName request hash key', async () => {
+	const db = createDatabase()
+	seedPackageResolution()
+	repoMockModule.runBundledModuleWithRegistry.mockResolvedValue({
+		result: { reply: 'hello discord' },
+		logs: ['dispatched'],
+	})
+
+	const first = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: {
+			packageIdOrKodyId: 'discord-gateway',
+			exportName: 'dispatch-message-created',
+			params: { content: 'hi' },
+			idempotencyKey: 'evt-legacy-hash',
+			source: 'discord-gateway',
+			topic: 'discord.message.created',
+		},
+	})
+	expect(first.status).toBe(200)
+
+	const table = (
+		db as unknown as {
+			prepare: (query: string) => {
+				bind: (...params: Array<unknown>) => {
+					run: () => Promise<{ meta: { changes: number; last_row_id: number } }>
+				}
+			}
+		}
+	).prepare(
+		`UPDATE package_invocations
+		SET request_hash = ?, updated_at = ?
+		WHERE user_id = ? AND token_id = ? AND package_id = ? AND export_name = ? AND idempotency_key = ?`,
+	)
+	const legacyDigest = await crypto.subtle.digest(
+		'SHA-256',
+		new TextEncoder().encode(
+			JSON.stringify({
+				exportName: './dispatch-message-created',
+				packageId: 'pkg-1',
+				params: { content: 'hi' },
+				source: 'discord-gateway',
+				topic: 'discord.message.created',
+			}),
+		),
+	)
+	const legacyHash = Array.from(new Uint8Array(legacyDigest))
+		.map((value) => value.toString(16).padStart(2, '0'))
+		.join('')
+	await table
+		.bind(
+			legacyHash,
+			'2026-04-27T00:00:00.000Z',
+			'user-123',
+			'discord-gateway',
+			'pkg-1',
+			'./dispatch-message-created',
+			'evt-legacy-hash',
+		)
+		.run()
+
+	const replay = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: {
+			packageIdOrKodyId: 'discord-gateway',
+			exportName: 'dispatch-message-created',
+			params: { content: 'hi' },
+			idempotencyKey: 'evt-legacy-hash',
+			source: 'discord-gateway',
+			topic: 'discord.message.created',
+		},
+	})
+
+	expect(replay.status).toBe(200)
+	expect(replay.body).toMatchObject({
+		ok: true,
+		idempotency: {
+			key: 'evt-legacy-hash',
+			replayed: true,
+		},
+	})
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
+})
+
 test('invokePackageExport serializes execution failures without exposing thrown objects', async () => {
 	const db = createDatabase()
 	seedPackageResolution()

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -150,7 +150,7 @@ function markStoredResponseAsReplayed(
 
 async function createRequestHash(input: {
 	packageId: string
-	invocationName: string
+	exportName: string
 	params?: Record<string, unknown>
 	source: string | null
 	topic: string | null
@@ -525,7 +525,7 @@ async function invokeSavedPackageModule(input: {
 }) {
 	const requestHash = await createRequestHash({
 		packageId: input.savedPackage.id,
-		invocationName: input.invocationName,
+		exportName: input.invocationName,
 		params: input.params,
 		source: input.source,
 		topic: input.topic,

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -21,7 +21,10 @@ import {
 	loadPublishedBundleArtifactByIdentity,
 	persistPublishedBundleArtifact,
 } from '#worker/package-runtime/published-bundle-artifacts.ts'
-import { buildPackageSubscriptionArtifactName } from '#worker/package-runtime/subscription-artifacts.ts'
+import {
+	buildPackageSubscriptionArtifactName,
+	normalizePackageSubscriptionTopic,
+} from '#worker/package-runtime/subscription-artifacts.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 import {
@@ -96,14 +99,6 @@ function normalizeExportName(exportName: string) {
 function normalizeNullableString(value: string | null | undefined) {
 	const trimmed = value?.trim()
 	return trimmed && trimmed.length > 0 ? trimmed : null
-}
-
-function normalizeSubscriptionTopic(topic: string) {
-	const trimmed = topic.trim()
-	if (!trimmed) {
-		throw new Error('Package subscription topic must not be empty.')
-	}
-	return trimmed
 }
 
 function buildPackageInvocationStorageId(packageId: string) {
@@ -486,7 +481,7 @@ function resolvePackageModuleResolution(input: {
 			}
 		}
 		case 'subscription': {
-			const topic = normalizeSubscriptionTopic(input.selector.topic)
+			const topic = normalizePackageSubscriptionTopic(input.selector.topic)
 			const handler = input.manifest.kody.subscriptions?.[topic]?.handler
 			if (!handler) {
 				throw new Error(
@@ -930,7 +925,7 @@ export async function invokePackageSubscription(input: {
 	idempotencyKey: string
 	source?: string | null
 }) {
-	const topic = normalizeSubscriptionTopic(input.topic)
+	const topic = normalizePackageSubscriptionTopic(input.topic)
 	const idempotencyKey = input.idempotencyKey.trim()
 	if (!idempotencyKey) {
 		return buildJsonErrorResponse({

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -7,16 +7,28 @@ import {
 	getSavedPackageById,
 	getSavedPackageByKodyId,
 } from '#worker/package-registry/repo.ts'
-import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
+import {
+	loadPackageManifestBySourceId,
+	loadPackageSourceBySourceId,
+} from '#worker/package-registry/source.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
-import { resolvePackageExportPath } from '#worker/package-registry/manifest.ts'
+import {
+	normalizePackageWorkspacePath,
+	resolvePackageExportPath,
+} from '#worker/package-registry/manifest.ts'
 import { typecheckPackageEntrypointsFromSourceFiles } from '#worker/repo/checks.ts'
 import {
 	loadPublishedBundleArtifactByIdentity,
 	persistPublishedBundleArtifact,
 } from '#worker/package-runtime/published-bundle-artifacts.ts'
+import { buildPackageSubscriptionArtifactName } from '#worker/package-runtime/subscription-artifacts.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
+import {
+	getEmailAttachmentById,
+	getEmailMessageById,
+	getEmailMessageWithAttachmentsById,
+} from '#worker/email/repo.ts'
 import {
 	getPackageInvocationByKey,
 	insertPackageInvocationRow,
@@ -46,6 +58,30 @@ export type PackageInvocationRequest = {
 
 export type PackageInvocationResponse = PackageInvocationStoredResponse
 
+type PackageInvocationActor = {
+	tokenId: string
+	userId: string
+	email: string
+	displayName: string
+}
+
+type PackageModuleSelector =
+	| {
+			kind: 'export'
+			exportName: string
+	  }
+	| {
+			kind: 'subscription'
+			topic: string
+	  }
+
+type PackageModuleResolution = {
+	artifactName: string
+	entryPoint: string
+}
+
+const internalEmailSubscriptionTokenId = 'internal:email-subscriptions'
+
 function normalizeExportName(exportName: string) {
 	const trimmed = exportName.trim()
 	if (!trimmed) {
@@ -60,6 +96,14 @@ function normalizeExportName(exportName: string) {
 function normalizeNullableString(value: string | null | undefined) {
 	const trimmed = value?.trim()
 	return trimmed && trimmed.length > 0 ? trimmed : null
+}
+
+function normalizeSubscriptionTopic(topic: string) {
+	const trimmed = topic.trim()
+	if (!trimmed) {
+		throw new Error('Package subscription topic must not be empty.')
+	}
+	return trimmed
 }
 
 function buildPackageInvocationStorageId(packageId: string) {
@@ -111,7 +155,7 @@ function markStoredResponseAsReplayed(
 
 async function createRequestHash(input: {
 	packageId: string
-	exportName: string
+	invocationName: string
 	params?: Record<string, unknown>
 	source: string | null
 	topic: string | null
@@ -190,49 +234,47 @@ function tokenAllowsSource(input: {
 	return sources.includes(input.source)
 }
 
-function isMissingPackageExportError(error: unknown) {
-	return (
-		error instanceof Error &&
-		(error.message.includes('does not define export') ||
-			error.message.includes('does not define a runtime target'))
-	)
-}
-
 async function ensureModuleArtifact(input: {
 	env: Env
 	baseUrl: string
 	savedPackage: SavedPackageRecord
-	exportName: string
+	selector: PackageModuleSelector
 	userId: string
 }) {
-	const packageSource = await loadPackageSourceBySourceId({
+	const packageManifest = await loadPackageManifestBySourceId({
 		env: input.env,
 		baseUrl: input.baseUrl,
 		userId: input.userId,
 		sourceId: input.savedPackage.sourceId,
 	})
-	const entryPoint = resolvePackageExportPath({
-		manifest: packageSource.manifest,
-		exportName: input.exportName,
+	const resolution = resolvePackageModuleResolution({
+		manifest: packageManifest.manifest,
+		selector: input.selector,
 	})
 	const loaded = await loadPublishedBundleArtifactByIdentity({
 		env: input.env,
 		userId: input.userId,
 		sourceId: input.savedPackage.sourceId,
 		kind: 'module',
-		artifactName: input.exportName,
-		entryPoint,
+		artifactName: resolution.artifactName,
+		entryPoint: resolution.entryPoint,
 	})
 	if (loaded?.artifact) {
 		return {
 			artifact: loaded.artifact,
-			source: packageSource.source,
-			entryPoint,
+			source: packageManifest.source,
+			entryPoint: resolution.entryPoint,
 		}
 	}
+	const packageSource = await loadPackageSourceBySourceId({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		sourceId: input.savedPackage.sourceId,
+	})
 	const typecheckResult = await typecheckPackageEntrypointsFromSourceFiles({
 		sourceFiles: packageSource.files,
-		entryPoints: [{ path: entryPoint, includeStorage: true }],
+		entryPoints: [{ path: resolution.entryPoint, includeStorage: true }],
 	})
 	if (!typecheckResult.ok) {
 		throw new Error(typecheckResult.message)
@@ -244,15 +286,15 @@ async function ensureModuleArtifact(input: {
 		baseUrl: input.baseUrl,
 		userId: input.userId,
 		sourceFiles: packageSource.files,
-		entryPoint,
+		entryPoint: resolution.entryPoint,
 	})
 	await persistPublishedBundleArtifact({
 		env: input.env,
 		userId: input.userId,
 		source: packageSource.source,
 		kind: 'module',
-		artifactName: input.exportName,
-		entryPoint,
+		artifactName: resolution.artifactName,
+		entryPoint: resolution.entryPoint,
 		mainModule: bundle.mainModule,
 		modules: bundle.modules,
 		dependencies: bundle.dependencies,
@@ -267,24 +309,28 @@ async function ensureModuleArtifact(input: {
 		userId: input.userId,
 		sourceId: input.savedPackage.sourceId,
 		kind: 'module',
-		artifactName: input.exportName,
-		entryPoint,
+		artifactName: resolution.artifactName,
+		entryPoint: resolution.entryPoint,
 	})
 	if (!rebuilt?.artifact) {
+		const moduleLabel =
+			input.selector.kind === 'export'
+				? `export "${input.selector.exportName}"`
+				: `subscription "${input.selector.topic}"`
 		throw new Error(
-			`Published bundle artifact for export "${input.exportName}" could not be loaded after rebuild.`,
+			`Published bundle artifact for ${moduleLabel} could not be loaded after rebuild.`,
 		)
 	}
 	return {
 		artifact: rebuilt.artifact,
 		source: packageSource.source,
-		entryPoint,
+		entryPoint: resolution.entryPoint,
 	}
 }
 
 function buildExecutionSuccessResponse(input: {
 	savedPackage: SavedPackageRecord
-	exportName: string
+	invocationName: string
 	idempotencyKey: string
 	source: string | null
 	topic: string | null
@@ -300,7 +346,7 @@ function buildExecutionSuccessResponse(input: {
 				id: input.savedPackage.id,
 				kodyId: input.savedPackage.kodyId,
 			},
-			exportName: input.exportName,
+			exportName: input.invocationName,
 			source: input.source,
 			topic: input.topic,
 			idempotency: {
@@ -318,7 +364,7 @@ function buildExecutionSuccessResponse(input: {
 
 function buildExecutionErrorResponse(input: {
 	savedPackage: SavedPackageRecord
-	exportName: string
+	invocationName: string
 	idempotencyKey: string
 	source: string | null
 	topic: string | null
@@ -335,7 +381,7 @@ function buildExecutionErrorResponse(input: {
 				id: input.savedPackage.id,
 				kodyId: input.savedPackage.kodyId,
 			},
-			exportName: input.exportName,
+			exportName: input.invocationName,
 			source: input.source,
 			topic: input.topic,
 			idempotency: {
@@ -422,6 +468,373 @@ function resolveExistingInvocation(input: {
 	})
 }
 
+function resolvePackageModuleResolution(input: {
+	manifest: Awaited<
+		ReturnType<typeof loadPackageSourceBySourceId>
+	>['manifest']
+	selector: PackageModuleSelector
+}): PackageModuleResolution {
+	switch (input.selector.kind) {
+		case 'export': {
+			const exportName = normalizeExportName(input.selector.exportName)
+			return {
+				artifactName: exportName,
+				entryPoint: resolvePackageExportPath({
+					manifest: input.manifest,
+					exportName,
+				}),
+			}
+		}
+		case 'subscription': {
+			const topic = normalizeSubscriptionTopic(input.selector.topic)
+			const handler = input.manifest.kody.subscriptions?.[topic]?.handler
+			if (!handler) {
+				throw new Error(
+					`Package "${input.manifest.kody.id}" does not define subscription "${topic}".`,
+				)
+			}
+			return {
+				artifactName: buildPackageSubscriptionArtifactName(topic),
+				entryPoint: normalizePackageWorkspacePath(handler),
+			}
+		}
+		default: {
+			const selector = input.selector
+			void selector
+			throw new Error('Unhandled package module selector.')
+		}
+	}
+}
+
+function isMissingPackageModuleError(error: unknown) {
+	return (
+		error instanceof Error &&
+		(error.message.includes('does not define export') ||
+			error.message.includes('does not define a runtime target') ||
+			error.message.includes('does not define subscription'))
+	)
+}
+
+async function invokeSavedPackageModule(input: {
+	env: Env
+	baseUrl: string
+	actor: PackageInvocationActor
+	savedPackage: SavedPackageRecord
+	invocationName: string
+	moduleSelector: PackageModuleSelector
+	params?: Record<string, unknown>
+	idempotencyKey: string
+	source: string | null
+	topic: string | null
+	notFoundCode: 'export_not_found' | 'subscription_not_found'
+}) {
+	const requestHash = await createRequestHash({
+		packageId: input.savedPackage.id,
+		invocationName: input.invocationName,
+		params: input.params,
+		source: input.source,
+		topic: input.topic,
+	})
+	let existing: Awaited<ReturnType<typeof getPackageInvocationByKey>>
+	try {
+		existing = await getPackageInvocationByKey({
+			db: input.env.APP_DB,
+			userId: input.actor.userId,
+			tokenId: input.actor.tokenId,
+			packageId: input.savedPackage.id,
+			exportName: input.invocationName,
+			idempotencyKey: input.idempotencyKey,
+		})
+	} catch (error) {
+		console.error('package invocation idempotency lookup failed', error)
+		return buildJsonErrorResponse({
+			status: 500,
+			code: 'idempotency_lookup_failed',
+			message:
+				'Unable to look up the package invocation idempotency record. Please retry.',
+			idempotencyKey: input.idempotencyKey,
+		})
+	}
+	if (existing) {
+		return resolveExistingInvocation({
+			record: existing,
+			requestHash,
+			idempotencyKey: input.idempotencyKey,
+		})
+	}
+
+	const invocationId = crypto.randomUUID()
+	let inserted: boolean
+	try {
+		inserted = await insertPackageInvocationRow({
+			db: input.env.APP_DB,
+			row: {
+				id: invocationId,
+				userId: input.actor.userId,
+				tokenId: input.actor.tokenId,
+				packageId: input.savedPackage.id,
+				packageKodyId: input.savedPackage.kodyId,
+				exportName: input.invocationName,
+				idempotencyKey: input.idempotencyKey,
+				requestHash,
+				source: input.source,
+				topic: input.topic,
+				status: 'in_progress',
+			},
+		})
+	} catch (error) {
+		console.error('package invocation idempotency persistence failed', error)
+		return buildJsonErrorResponse({
+			status: 500,
+			code: 'idempotency_persistence_failed',
+			message:
+				'Unable to persist the package invocation idempotency record. Please retry.',
+			idempotencyKey: input.idempotencyKey,
+		})
+	}
+	if (!inserted) {
+		let current: Awaited<ReturnType<typeof getPackageInvocationByKey>>
+		try {
+			current = await getPackageInvocationByKey({
+				db: input.env.APP_DB,
+				userId: input.actor.userId,
+				tokenId: input.actor.tokenId,
+				packageId: input.savedPackage.id,
+				exportName: input.invocationName,
+				idempotencyKey: input.idempotencyKey,
+			})
+		} catch (error) {
+			console.error('package invocation idempotency lookup failed', error)
+			return buildJsonErrorResponse({
+				status: 500,
+				code: 'idempotency_lookup_failed',
+				message:
+					'Unable to look up the package invocation idempotency record. Please retry.',
+				idempotencyKey: input.idempotencyKey,
+			})
+		}
+		if (!current) {
+			return buildJsonErrorResponse({
+				status: 500,
+				code: 'idempotency_conflict_unresolved',
+				message:
+					'Package invocation idempotency insert conflicted but no existing row was found.',
+				idempotencyKey: input.idempotencyKey,
+			})
+		}
+		return resolveExistingInvocation({
+			record: current,
+			requestHash,
+			idempotencyKey: input.idempotencyKey,
+		})
+	}
+
+	try {
+		const { artifact, source: sourceRow } = await ensureModuleArtifact({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			savedPackage: input.savedPackage,
+			selector: input.moduleSelector,
+			userId: input.actor.userId,
+		})
+		const repoSource =
+			artifact.packageContext?.sourceId != null
+				? await getEntitySourceById(
+						input.env.APP_DB,
+						artifact.packageContext.sourceId,
+					)
+				: sourceRow
+		const callerContext = createMcpCallerContext({
+			baseUrl: input.baseUrl,
+			user: {
+				userId: input.actor.userId,
+				email: input.actor.email,
+				displayName: input.actor.displayName,
+			},
+			storageContext: {
+				sessionId: null,
+				appId: input.savedPackage.id,
+				storageId: buildPackageInvocationStorageId(input.savedPackage.id),
+			},
+			repoContext: repoSource ? createRepoContext(repoSource) : null,
+		})
+		const executionResult = await runBundledModuleWithRegistry(
+			input.env,
+			callerContext,
+			{
+				mainModule: artifact.mainModule,
+				modules: artifact.modules,
+			},
+			input.params,
+			{
+				skipCapabilityRegistry: true,
+				storageTools: {
+					userId: input.actor.userId,
+					storageId: buildPackageInvocationStorageId(input.savedPackage.id),
+					writable: true,
+				},
+				emailTools: {
+					getMessage: async (messageId) => {
+						const loaded = await getEmailMessageWithAttachmentsById({
+							db: input.env.APP_DB,
+							userId: input.actor.userId,
+							messageId,
+						})
+						if (!loaded) {
+							throw new Error(`Email message not found: ${messageId}`)
+						}
+						return {
+							id: loaded.message.id,
+							direction: loaded.message.direction,
+							inbox_id: loaded.message.inboxId,
+							thread_id: loaded.message.threadId,
+							from_address: loaded.message.fromAddress,
+							envelope_from: loaded.message.envelopeFrom,
+							to_addresses: loaded.message.toAddresses,
+							cc_addresses: loaded.message.ccAddresses,
+							bcc_addresses: loaded.message.bccAddresses,
+							reply_to_addresses: loaded.message.replyToAddresses,
+							subject: loaded.message.subject,
+							message_id_header: loaded.message.messageIdHeader,
+							in_reply_to_header: loaded.message.inReplyToHeader,
+							references: loaded.message.references,
+							headers: loaded.message.headers,
+							auth_results: loaded.message.authResults,
+							text_body: loaded.message.textBody,
+							html_body: loaded.message.htmlBody,
+							raw_size: loaded.message.rawSize,
+							policy_decision: loaded.message.policyDecision,
+							processing_status: loaded.message.processingStatus,
+							provider_message_id: loaded.message.providerMessageId,
+							error: loaded.message.error,
+							received_at: loaded.message.receivedAt,
+							sent_at: loaded.message.sentAt,
+							created_at: loaded.message.createdAt,
+							updated_at: loaded.message.updatedAt,
+							attachments: loaded.attachments.map((attachment) => ({
+								id: attachment.id,
+								filename: attachment.filename,
+								content_type: attachment.contentType,
+								content_id: attachment.contentId,
+								disposition: attachment.disposition,
+								size: attachment.size,
+								storage_kind: attachment.storageKind,
+								storage_key: attachment.storageKey,
+								created_at: attachment.createdAt,
+							})),
+						}
+					},
+					getAttachment: async (attachmentId) => {
+						const attachment = await getEmailAttachmentById({
+							db: input.env.APP_DB,
+							userId: input.actor.userId,
+							attachmentId,
+						})
+						if (!attachment) {
+							throw new Error(`Email attachment not found: ${attachmentId}`)
+						}
+						const message = await getEmailMessageById({
+							db: input.env.APP_DB,
+							userId: input.actor.userId,
+							messageId: attachment.messageId,
+						})
+						if (!message) {
+							throw new Error(
+								`Email message not found for attachment: ${attachment.messageId}`,
+							)
+						}
+						return {
+							id: attachment.id,
+							message_id: attachment.messageId,
+							filename: attachment.filename,
+							content_type: attachment.contentType,
+							content_id: attachment.contentId,
+							disposition: attachment.disposition,
+							size: attachment.size,
+							storage_kind: attachment.storageKind,
+							storage_key: attachment.storageKey,
+							created_at: attachment.createdAt,
+							message: {
+								id: message.id,
+								message_id_header: message.messageIdHeader,
+								subject: message.subject,
+							},
+							content: attachment.content,
+							content_base64: attachment.contentBase64,
+						}
+					},
+				},
+				...(artifact.packageContext
+					? { packageContext: artifact.packageContext }
+					: {}),
+			},
+		)
+		const response = executionResult.error
+			? buildExecutionErrorResponse({
+					savedPackage: input.savedPackage,
+					invocationName: input.invocationName,
+					idempotencyKey: input.idempotencyKey,
+					source: input.source,
+					topic: input.topic,
+					error: executionResult.error,
+					logs: executionResult.logs ?? [],
+				})
+			: buildExecutionSuccessResponse({
+					savedPackage: input.savedPackage,
+					invocationName: input.invocationName,
+					idempotencyKey: input.idempotencyKey,
+					source: input.source,
+					topic: input.topic,
+					result: executionResult.result,
+					logs: executionResult.logs ?? [],
+					rawContent: extractRawContent(executionResult.result),
+				})
+		await updatePackageInvocationResult({
+			db: input.env.APP_DB,
+			id: invocationId,
+			userId: input.actor.userId,
+			status: executionResult.error ? 'failed' : 'completed',
+			response,
+		})
+		return response
+	} catch (error) {
+		if (isMissingPackageModuleError(error)) {
+			const response = buildJsonErrorResponse({
+				status: 404,
+				code: input.notFoundCode,
+				message: error instanceof Error ? error.message : String(error),
+				idempotencyKey: input.idempotencyKey,
+			})
+			await updatePackageInvocationResult({
+				db: input.env.APP_DB,
+				id: invocationId,
+				userId: input.actor.userId,
+				status: 'failed',
+				response,
+			}).catch(() => {
+				// Best effort; preserve the original invocation error.
+			})
+			return response
+		}
+		const response = buildJsonErrorResponse({
+			status: 500,
+			code: 'invocation_failed',
+			message: error instanceof Error ? error.message : String(error),
+			idempotencyKey: input.idempotencyKey,
+		})
+		await updatePackageInvocationResult({
+			db: input.env.APP_DB,
+			id: invocationId,
+			userId: input.actor.userId,
+			status: 'failed',
+			response,
+		}).catch(() => {
+			// Best effort; preserve the original invocation error.
+		})
+		return response
+	}
+}
+
 export async function invokePackageExport(input: {
 	env: Env
 	baseUrl: string
@@ -485,217 +898,66 @@ export async function invokePackageExport(input: {
 		})
 	}
 
-	const requestHash = await createRequestHash({
-		packageId: savedPackage.id,
-		exportName,
+	return await invokeSavedPackageModule({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		actor: {
+			tokenId: input.token.tokenId,
+			userId: input.token.userId,
+			email: input.token.email,
+			displayName: input.token.displayName,
+		},
+		savedPackage,
+		invocationName: exportName,
+		moduleSelector: {
+			kind: 'export',
+			exportName,
+		},
 		params: input.request.params,
+		idempotencyKey,
 		source,
 		topic,
+		notFoundCode: 'export_not_found',
 	})
-	let existing: Awaited<ReturnType<typeof getPackageInvocationByKey>>
-	try {
-		existing = await getPackageInvocationByKey({
-			db: input.env.APP_DB,
-			userId: input.token.userId,
-			tokenId: input.token.tokenId,
-			packageId: savedPackage.id,
-			exportName,
-			idempotencyKey,
-		})
-	} catch (error) {
-		console.error('package invocation idempotency lookup failed', error)
-		return buildJsonErrorResponse({
-			status: 500,
-			code: 'idempotency_lookup_failed',
-			message:
-				'Unable to look up the package invocation idempotency record. Please retry.',
-			idempotencyKey,
-		})
-	}
-	if (existing) {
-		return resolveExistingInvocation({
-			record: existing,
-			requestHash,
-			idempotencyKey,
-		})
-	}
+}
 
-	const invocationId = crypto.randomUUID()
-	let inserted: boolean
-	try {
-		inserted = await insertPackageInvocationRow({
-			db: input.env.APP_DB,
-			row: {
-				id: invocationId,
-				userId: input.token.userId,
-				tokenId: input.token.tokenId,
-				packageId: savedPackage.id,
-				packageKodyId: savedPackage.kodyId,
-				exportName,
-				idempotencyKey,
-				requestHash,
-				source,
-				topic,
-				status: 'in_progress',
-			},
-		})
-	} catch (error) {
-		console.error('package invocation idempotency persistence failed', error)
+export async function invokePackageSubscription(input: {
+	env: Env
+	baseUrl: string
+	savedPackage: SavedPackageRecord
+	topic: string
+	params?: Record<string, unknown>
+	idempotencyKey: string
+	source?: string | null
+}) {
+	const topic = normalizeSubscriptionTopic(input.topic)
+	const idempotencyKey = input.idempotencyKey.trim()
+	if (!idempotencyKey) {
 		return buildJsonErrorResponse({
-			status: 500,
-			code: 'idempotency_persistence_failed',
-			message:
-				'Unable to persist the package invocation idempotency record. Please retry.',
-			idempotencyKey,
+			status: 400,
+			code: 'missing_idempotency_key',
+			message: 'Package subscription invocations require a non-empty idempotencyKey.',
 		})
 	}
-	if (!inserted) {
-		let current: Awaited<ReturnType<typeof getPackageInvocationByKey>>
-		try {
-			current = await getPackageInvocationByKey({
-				db: input.env.APP_DB,
-				userId: input.token.userId,
-				tokenId: input.token.tokenId,
-				packageId: savedPackage.id,
-				exportName,
-				idempotencyKey,
-			})
-		} catch (error) {
-			console.error('package invocation idempotency lookup failed', error)
-			return buildJsonErrorResponse({
-				status: 500,
-				code: 'idempotency_lookup_failed',
-				message:
-					'Unable to look up the package invocation idempotency record. Please retry.',
-				idempotencyKey,
-			})
-		}
-		if (!current) {
-			return buildJsonErrorResponse({
-				status: 500,
-				code: 'idempotency_conflict_unresolved',
-				message:
-					'Package invocation idempotency insert conflicted but no existing row was found.',
-				idempotencyKey,
-			})
-		}
-		return resolveExistingInvocation({
-			record: current,
-			requestHash,
-			idempotencyKey,
-		})
-	}
-
-	try {
-		const { artifact, source: sourceRow } = await ensureModuleArtifact({
-			env: input.env,
-			baseUrl: input.baseUrl,
-			savedPackage,
-			exportName,
-			userId: input.token.userId,
-		})
-		const repoSource =
-			artifact.packageContext?.sourceId != null
-				? await getEntitySourceById(
-						input.env.APP_DB,
-						artifact.packageContext.sourceId,
-					)
-				: sourceRow
-		const callerContext = createMcpCallerContext({
-			baseUrl: input.baseUrl,
-			user: {
-				userId: input.token.userId,
-				email: input.token.email,
-				displayName: input.token.displayName,
-			},
-			storageContext: {
-				sessionId: null,
-				appId: savedPackage.id,
-				storageId: buildPackageInvocationStorageId(savedPackage.id),
-			},
-			repoContext: repoSource ? createRepoContext(repoSource) : null,
-		})
-		const executionResult = await runBundledModuleWithRegistry(
-			input.env,
-			callerContext,
-			{
-				mainModule: artifact.mainModule,
-				modules: artifact.modules,
-			},
-			input.request.params,
-			{
-				storageTools: {
-					userId: input.token.userId,
-					storageId: buildPackageInvocationStorageId(savedPackage.id),
-					writable: true,
-				},
-				...(artifact.packageContext
-					? { packageContext: artifact.packageContext }
-					: {}),
-			},
-		)
-		const response = executionResult.error
-			? buildExecutionErrorResponse({
-					savedPackage,
-					exportName,
-					idempotencyKey,
-					source,
-					topic,
-					error: executionResult.error,
-					logs: executionResult.logs ?? [],
-				})
-			: buildExecutionSuccessResponse({
-					savedPackage,
-					exportName,
-					idempotencyKey,
-					source,
-					topic,
-					result: executionResult.result,
-					logs: executionResult.logs ?? [],
-					rawContent: extractRawContent(executionResult.result),
-				})
-		await updatePackageInvocationResult({
-			db: input.env.APP_DB,
-			id: invocationId,
-			userId: input.token.userId,
-			status: executionResult.error ? 'failed' : 'completed',
-			response,
-		})
-		return response
-	} catch (error) {
-		if (isMissingPackageExportError(error)) {
-			const response = buildJsonErrorResponse({
-				status: 404,
-				code: 'export_not_found',
-				message: error instanceof Error ? error.message : String(error),
-				idempotencyKey,
-			})
-			await updatePackageInvocationResult({
-				db: input.env.APP_DB,
-				id: invocationId,
-				userId: input.token.userId,
-				status: 'failed',
-				response,
-			}).catch(() => {
-				// Best effort; preserve the original invocation error.
-			})
-			return response
-		}
-		const response = buildJsonErrorResponse({
-			status: 500,
-			code: 'invocation_failed',
-			message: error instanceof Error ? error.message : String(error),
-			idempotencyKey,
-		})
-		await updatePackageInvocationResult({
-			db: input.env.APP_DB,
-			id: invocationId,
-			userId: input.token.userId,
-			status: 'failed',
-			response,
-		}).catch(() => {
-			// Best effort; preserve the original invocation error.
-		})
-		return response
-	}
+	return await invokeSavedPackageModule({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		actor: {
+			tokenId: internalEmailSubscriptionTokenId,
+			userId: input.savedPackage.userId,
+			email: '',
+			displayName: `package:${input.savedPackage.kodyId}`,
+		},
+		savedPackage: input.savedPackage,
+		invocationName: buildPackageSubscriptionArtifactName(topic),
+		moduleSelector: {
+			kind: 'subscription',
+			topic,
+		},
+		params: input.params,
+		idempotencyKey,
+		source: normalizeNullableString(input.source) ?? 'email',
+		topic,
+		notFoundCode: 'subscription_not_found',
+	})
 }

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -698,7 +698,6 @@ async function invokeSavedPackageModule(input: {
 							text_body: loaded.message.textBody,
 							html_body: loaded.message.htmlBody,
 							raw_size: loaded.message.rawSize,
-							policy_decision: loaded.message.policyDecision,
 							processing_status: loaded.message.processingStatus,
 							provider_message_id: loaded.message.providerMessageId,
 							error: loaded.message.error,

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -250,3 +250,56 @@ test('parseAuthoredPackageJson rejects retriever definitions with no scopes', ()
 		}),
 	).toThrow('Too small')
 })
+
+test('parseAuthoredPackageJson accepts email event subscriptions', () => {
+	const manifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/email-notifier',
+			exports: {
+				'.': './index.ts',
+			},
+			kody: {
+				id: 'email-notifier',
+				description: 'Email notifier package',
+				subscriptions: {
+					'email.message.received': {
+						handler: './src/handle-received-email.ts',
+						description: 'Notify on accepted inbound email',
+						filters: {
+							policy_decisions: ['accepted'],
+						},
+					},
+					'email.message.quarantined': {
+						handler: './src/handle-quarantined-email.ts',
+					},
+				},
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+
+	const projection = buildPackageSearchProjection(manifest)
+
+	expect(projection.subscriptions).toEqual([
+		{
+			topic: 'email.message.quarantined',
+			handler: 'src/handle-quarantined-email.ts',
+			description: null,
+			filters: null,
+		},
+		{
+			topic: 'email.message.received',
+			handler: 'src/handle-received-email.ts',
+			description: 'Notify on accepted inbound email',
+			filters: {
+				policy_decisions: ['accepted'],
+			},
+		},
+	])
+	expect(buildPackageSearchDocument(projection)).toContain(
+		'subscription:email.message.received',
+	)
+	expect(buildPackageSearchDocument(projection)).toContain(
+		'subscription:email.message.quarantined',
+	)
+})

--- a/packages/worker/src/package-registry/types.ts
+++ b/packages/worker/src/package-registry/types.ts
@@ -87,24 +87,6 @@ export type PackageRetrieverDefinition = z.infer<
 	typeof packageRetrieverDefinitionSchema
 >
 
-export const packageEmailInboxDefinitionSchema = z.object({
-	id: z.string().regex(kodyPackageIdPattern),
-})
-
-export const packageEmailHandlerDefinitionSchema = z.object({
-	inbox: z.string().regex(kodyPackageIdPattern),
-	export: z.string().min(1),
-})
-
-export const packageEmailDefinitionSchema = z.object({
-	inboxes: z.array(packageEmailInboxDefinitionSchema).optional(),
-	handlers: z.array(packageEmailHandlerDefinitionSchema).optional(),
-})
-
-export type PackageEmailDefinition = z.infer<
-	typeof packageEmailDefinitionSchema
->
-
 const packageExportConditionSchema = z
 	.object({
 		import: z.string().min(1).optional(),
@@ -151,7 +133,6 @@ export const authoredPackageKodySchema = z.object({
 			packageRetrieverDefinitionSchema,
 		)
 		.optional(),
-	email: packageEmailDefinitionSchema.optional(),
 })
 
 export type AuthoredPackageKody = z.infer<typeof authoredPackageKodySchema>

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
@@ -1,0 +1,151 @@
+import { expect, test, vi } from 'vitest'
+import { rebuildPublishedPackageArtifacts } from './published-bundle-artifacts.ts'
+
+const mockModule = vi.hoisted(() => ({
+	getEntitySourceById: vi.fn(),
+	getPublishedBundleArtifactByIdentity: vi.fn(),
+	insertPublishedBundleArtifactRow: vi.fn(),
+	updatePublishedBundleArtifactRow: vi.fn(),
+	writePublishedBundleArtifact: vi.fn(),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+}))
+
+vi.mock('#worker/repo/published-bundle-artifacts-repo.ts', async () => {
+	const actual =
+		await vi.importActual<
+			typeof import('#worker/repo/published-bundle-artifacts-repo.ts')
+		>('#worker/repo/published-bundle-artifacts-repo.ts')
+	return {
+		...actual,
+		getPublishedBundleArtifactByIdentity: (...args: Array<unknown>) =>
+			mockModule.getPublishedBundleArtifactByIdentity(...args),
+		insertPublishedBundleArtifactRow: (...args: Array<unknown>) =>
+			mockModule.insertPublishedBundleArtifactRow(...args),
+		updatePublishedBundleArtifactRow: (...args: Array<unknown>) =>
+			mockModule.updatePublishedBundleArtifactRow(...args),
+	}
+})
+
+vi.mock('./published-runtime-artifacts.ts', async () => {
+	const actual =
+		await vi.importActual<typeof import('./published-runtime-artifacts.ts')>(
+			'./published-runtime-artifacts.ts',
+		)
+	return {
+		...actual,
+		writePublishedBundleArtifact: (...args: Array<unknown>) =>
+			mockModule.writePublishedBundleArtifact(...args),
+	}
+})
+
+test('rebuildPublishedPackageArtifacts bundles declared subscription handlers', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.getPublishedBundleArtifactByIdentity.mockReset()
+	mockModule.insertPublishedBundleArtifactRow.mockReset()
+	mockModule.updatePublishedBundleArtifactRow.mockReset()
+	mockModule.writePublishedBundleArtifact.mockReset()
+	mockModule.getPublishedBundleArtifactByIdentity.mockResolvedValue(null)
+	mockModule.writePublishedBundleArtifact.mockResolvedValue('kv:key')
+	mockModule.insertPublishedBundleArtifactRow.mockResolvedValue(undefined)
+
+	const buildAppBundle = vi.fn()
+	const buildModuleBundle = vi.fn(async ({ entryPoint }: { entryPoint: string }) => ({
+		mainModule: `dist/${entryPoint.replaceAll('/', '_')}.js`,
+		modules: {
+			[`dist/${entryPoint.replaceAll('/', '_')}.js`]:
+				'export default async function run() { return "ok" }',
+		},
+		dependencies: [],
+	}))
+
+	await rebuildPublishedPackageArtifacts({
+		env: {
+			APP_DB: {},
+			BUNDLE_ARTIFACTS_KV: {
+				get: async () => null,
+				put: async () => undefined,
+				delete: async () => undefined,
+			},
+		} as unknown as Env,
+		userId: 'user-1',
+		source: {
+			id: 'source-1',
+			user_id: 'user-1',
+			entity_kind: 'package',
+			entity_id: 'pkg-1',
+			repo_id: 'repo-1',
+			published_commit: 'commit-1',
+			indexed_commit: null,
+			manifest_path: 'package.json',
+			source_root: '/',
+			created_at: '2026-04-30T00:00:00.000Z',
+			updated_at: '2026-04-30T00:00:00.000Z',
+		},
+		savedPackage: {
+			id: 'pkg-1',
+			userId: 'user-1',
+			name: '@kentcdodds/email-automation',
+			kodyId: 'email-automation',
+			description: 'Email automation package',
+			tags: [],
+			searchText: null,
+			sourceId: 'source-1',
+			hasApp: false,
+			createdAt: '2026-04-30T00:00:00.000Z',
+			updatedAt: '2026-04-30T00:00:00.000Z',
+		},
+		manifest: {
+			name: '@kentcdodds/email-automation',
+			exports: {
+				'.': './src/index.ts',
+			},
+			kody: {
+				id: 'email-automation',
+				description: 'Email automation package',
+				subscriptions: {
+					'email.message.received': {
+						handler: './src/on-email-received.ts',
+					},
+					'email.message.quarantined': {
+						handler: './src/on-email-quarantined.ts',
+					},
+				},
+			},
+		},
+		files: {
+			'package.json': '{}',
+			'src/index.ts': 'export default async function run() { return "ok" }',
+			'src/on-email-received.ts':
+				'export default async function run() { return "received" }',
+			'src/on-email-quarantined.ts':
+				'export default async function run() { return "quarantined" }',
+		},
+		buildAppBundle,
+		buildModuleBundle,
+	})
+
+	expect(buildAppBundle).not.toHaveBeenCalled()
+	expect(buildModuleBundle).toHaveBeenCalledWith({
+		entryPoint: './src/index.ts',
+	})
+	expect(buildModuleBundle).toHaveBeenCalledWith({
+		entryPoint: 'src/on-email-received.ts',
+	})
+	expect(buildModuleBundle).toHaveBeenCalledWith({
+		entryPoint: 'src/on-email-quarantined.ts',
+	})
+	expect(mockModule.insertPublishedBundleArtifactRow).toHaveBeenCalledTimes(3)
+	expect(
+		mockModule.insertPublishedBundleArtifactRow.mock.calls.map(
+			(call) => call[1].artifactName,
+		),
+	).toEqual([
+		'.',
+		'subscription:email.message.quarantined',
+		'subscription:email.message.received',
+	])
+})

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.ts
@@ -1,6 +1,7 @@
 import {
 	getPackageAppEntryPath,
 	listPackageServices,
+	listPackageSubscriptions,
 } from '#worker/package-registry/manifest.ts'
 import {
 	type AuthoredPackageJson,
@@ -32,6 +33,7 @@ import {
 	parseKodyPackageSpecifier,
 	resolveSavedPackageImport,
 } from './package-import-resolution.ts'
+import { buildPackageSubscriptionArtifactName } from './subscription-artifacts.ts'
 
 type DependencyResolutionState = {
 	env: Env
@@ -342,6 +344,27 @@ export async function rebuildPublishedPackageArtifacts(input: {
 			kind: 'module',
 			artifactName: exportName,
 			entryPoint,
+			mainModule: bundle.mainModule,
+			modules: bundle.modules,
+			dependencies: bundle.dependencies ?? fallbackDependencies,
+			packageContext: {
+				packageId: input.savedPackage.id,
+				kodyId: input.savedPackage.kodyId,
+				sourceId: input.savedPackage.sourceId,
+			},
+		})
+	}
+	for (const subscription of listPackageSubscriptions(input.manifest)) {
+		const bundle = await input.buildModuleBundle({
+			entryPoint: subscription.handler,
+		})
+		await persistPublishedBundleArtifact({
+			env: input.env,
+			userId: input.userId,
+			source: input.source,
+			kind: 'module',
+			artifactName: buildPackageSubscriptionArtifactName(subscription.topic),
+			entryPoint: subscription.handler,
 			mainModule: bundle.mainModule,
 			modules: bundle.modules,
 			dependencies: bundle.dependencies ?? fallbackDependencies,

--- a/packages/worker/src/package-runtime/subscription-artifacts.ts
+++ b/packages/worker/src/package-runtime/subscription-artifacts.ts
@@ -1,0 +1,11 @@
+export function normalizePackageSubscriptionTopic(topic: string) {
+	const trimmed = topic.trim()
+	if (!trimmed) {
+		throw new Error('Package subscription topic must not be empty.')
+	}
+	return trimmed
+}
+
+export function buildPackageSubscriptionArtifactName(topic: string) {
+	return `subscription:${normalizePackageSubscriptionTopic(topic)}`
+}

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -1,6 +1,7 @@
 import {
 	getPackageAppEntryPath,
 	listPackageServices,
+	listPackageSubscriptions,
 	normalizePackageWorkspacePath,
 	parseAuthoredPackageJson,
 	resolvePackageExportPath,
@@ -271,6 +272,9 @@ function collectPackageTypecheckTargets(
 	}
 	for (const service of listPackageServices(manifest)) {
 		remember(service.entry, true)
+	}
+	for (const subscription of listPackageSubscriptions(manifest)) {
+		remember(subscription.handler, true)
 	}
 	return Array.from(targets.values())
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- rebase the package email subscription work onto the unified inbound email receipt model from #295
- dispatch package-owned subscriptions after inbound email is stored and audited, using the unified stored receipt topic `email.message.received`
- bundle and publish subscription handlers through the existing package runtime artifact pipeline, with metadata-first event payloads and runtime email lookup helpers for message bodies and attachments
- keep email automation as a normal package subscription pattern rather than introducing a separate Kody-owned email handler primitive
- fix email attachment reconstruction for attachments without filenames by normalizing PostalMime `undefined` values against stored `null` metadata, with focused regression coverage
- preserve existing package export invocation idempotency hashes so pre-subscription export retries still replay correctly after the new subscription work lands
- forward `emailTools` through the module-syntax `runModuleWithRegistry` path so runtime email helpers behave consistently across execute entry styles
- harden inbound subscription dispatch so missing `ExecutionContext` does not let post-storage package-dispatch failures bubble back into the email ingestion path, and allow zero-byte attachments through `email_attachment_get`
- add focused tests for manifest declarations, published bundling, stored-email dispatch, message/attachment lookup, attachment capability behavior, export idempotency compatibility, and module-runtime email helper forwarding

## Validation
- `npx vitest run --project node-unit --project workers-unit packages/worker/src/package-registry/manifest.node.test.ts packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts packages/worker/src/email/inbound.workers.test.ts packages/worker/src/mcp/capabilities/email/email-domain.node.test.ts packages/worker/src/mcp/run-codemode-registry.node.test.ts packages/worker/src/mcp/capabilities/email/email-attachment-get.node.test.ts packages/worker/src/package-invocations/service.node.test.ts`
- `npx vitest run --project workers-unit packages/worker/src/email/inbound.workers.test.ts && npx vitest run --project node-unit packages/worker/src/mcp/capabilities/email/email-attachment-get.node.test.ts`
- `npx vitest run --project node-unit packages/worker/src/package-invocations/service.node.test.ts`
- `npx vitest run --project node-unit packages/worker/src/mcp/run-codemode-registry.node.test.ts`
- `npm run typecheck`
- `npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4df8b024-d113-43ee-b4b2-5ed768efe42b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4df8b024-d113-43ee-b4b2-5ed768efe42b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added email attachment retrieval (on-demand decoded payloads) and codemode/runtime helpers (email.getMessage/email.getAttachment).
  * Enabled package subscriptions for email events (email.message.received) with asynchronous, idempotent dispatch to installed packages.
  * Metadata-first inbound handling: handlers receive message IDs and must fetch full message/attachments.

* **Documentation**
  * Updated email primitives docs to document the new attachment capability and revised safety/processing model.

* **Tests**
  * Added coverage for attachment retrieval, subscription dispatch, and codemode helper injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->