### PR TITLE
Fix home connector Node 24 strip-only startup failure

### DIFF
--- a/packages/home-connector/src/adapters/lutron/errors.ts
+++ b/packages/home-connector/src/adapters/lutron/errors.ts
@@ -1,7 +1,10 @@
 export class LutronProcessorNotFoundError extends Error {
-	constructor(readonly processorId: string) {
+	readonly processorId: string
+
+	constructor(processorId: string) {
 		super(`Lutron processor "${processorId}" was not found.`)
 		this.name = 'LutronProcessorNotFoundError'
+		this.processorId = processorId
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the Lutron missing-processor error parameter property with an explicit readonly field assignment
- preserve the typed missing-processor error behavior while avoiding Node 24 strip-only TypeScript syntax
- fix the home-connector CI smoke test failure during the Node startup check used before Docker publish

## Validation
- `npm --prefix packages/home-connector run test`
- `npm run typecheck` *(currently fails for an unrelated pre-existing worker issue in `packages/worker/src/email/parser.ts` about `postal-mime` and an implicit `any`)*
- Node smoke check matching `.github/workflows/home-connector-publish.yml`
- production-entrypoint smoke check matching `packages/home-connector/Dockerfile` CMD

## Artifact
- [Home connector Node 24 validation log](https://cursor.com/artifacts/c/art-7079b695-d60f-49be-90cd-8e618c213df4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29a92bf1-ebf4-4f0e-a5ea-b1505664e764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29a92bf1-ebf4-4f0e-a5ea-b1505664e764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

