### PR TITLE
Avoid duplicate home websocket disconnects

### DIFF
--- a/packages/worker/src/home/session.node.test.ts
+++ b/packages/worker/src/home/session.node.test.ts
@@ -314,3 +314,44 @@ test('websocket error clears connected state when the socket is gone', async () 
 		tools: [],
 	})
 })
+
+test('websocket error and close only disconnect once for the same socket', async () => {
+	captureMessageMock.mockReset()
+	const socket = {} as WebSocket
+	const { state, persistedEntries } = createState({
+		storedState: {
+			persisted: {
+				connectorId: 'default',
+				connectorKind: 'home',
+				connectedAt: '2026-04-26T05:00:00.000Z',
+				lastSeenAt: '2026-04-26T05:01:00.000Z',
+			},
+			tools: [{ name: 'bond_shade_set_position' }],
+		},
+		webSockets: [socket],
+	})
+	const session = new HomeConnectorSession(
+		{
+			storage: state.storage,
+			getWebSockets: state.getWebSockets,
+			acceptWebSocket: state.acceptWebSocket,
+			blockConcurrencyWhile: state.blockConcurrencyWhile,
+		} as unknown as DurableObjectState,
+		{} as Env,
+	)
+
+	await waitForRestoreState(state)
+	state.getWebSockets.mockReturnValue([])
+	await session.webSocketError(socket, new Error('abnormal close'))
+	await session.webSocketClose(socket, 1006, 'runtime close', false)
+
+	expect(captureMessageMock).toHaveBeenCalledTimes(1)
+	expect(state.storage.put).toHaveBeenCalledTimes(1)
+	expect(persistedEntries.get('home-connector-session-state')).toMatchObject({
+		persisted: {
+			connectorId: 'default',
+			connectedAt: null,
+		},
+		tools: [],
+	})
+})

--- a/packages/worker/src/home/session.ts
+++ b/packages/worker/src/home/session.ts
@@ -57,6 +57,8 @@ class HomeConnectorSessionBase extends DurableObject<Env> {
 
 	private ingressSessionKeys = new WeakMap<WebSocket, string | null>()
 
+	private disconnectedSockets = new WeakSet<WebSocket>()
+
 	private pendingRequests = new Map<string, PendingRpcRequest>()
 
 	constructor(state: DurableObjectState, env: Env) {
@@ -154,6 +156,29 @@ class HomeConnectorSessionBase extends DurableObject<Env> {
 		reason: string,
 		wasClean: boolean,
 	): Promise<void> {
+		return this.handleDisconnect(ws, { code, reason, wasClean })
+	}
+
+	webSocketError(ws: WebSocket, error: unknown): Promise<void> {
+		return this.handleDisconnect(ws, {
+			code: 1011,
+			reason: error instanceof Error ? error.message : String(error ?? 'error'),
+			wasClean: false,
+		})
+	}
+
+	private async handleDisconnect(
+		ws: WebSocket,
+		close: {
+			code: number
+			reason: string
+			wasClean: boolean
+		},
+	) {
+		if (this.disconnectedSockets.has(ws)) return
+		this.disconnectedSockets.add(ws)
+
+		const { code, reason, wasClean } = close
 		this.stateSnapshot.persisted.lastSeenAt = new Date().toISOString()
 		const activeSockets = this.ctx
 			.getWebSockets(connectorTag)
@@ -176,12 +201,6 @@ class HomeConnectorSessionBase extends DurableObject<Env> {
 			},
 		})
 		return this.persistState()
-	}
-
-	webSocketError(ws: WebSocket, error: unknown): Promise<void> {
-		const reason =
-			error instanceof Error ? error.message : String(error ?? 'error')
-		return this.webSocketClose(ws, 1011, reason, false)
 	}
 
 	async getConnectorId() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Route home connector websocket close and error handlers through a shared disconnect helper.
- Skip duplicate disconnect work for the same websocket so runtime error-then-close dispatch only captures and persists once.
- Add a regression test for Cloudflare dispatching `webSocketError` followed by `webSocketClose`.

## Testing
- `npx vitest run --project node-unit packages/worker/src/home/session.node.test.ts`
- `npm run typecheck`
- `npx oxfmt --check packages/worker/src/home/session.ts packages/worker/src/home/session.node.test.ts`
- `npx oxlint packages/worker/src/home/session.ts packages/worker/src/home/session.node.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ff22bf6-1f20-46c8-8fb5-54eb957ec1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ff22bf6-1f20-46c8-8fb5-54eb957ec1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

