### PR TITLE
Tighten home connector publish workflow

### DIFF
--- a/.github/workflows/home-connector-publish.yml
+++ b/.github/workflows/home-connector-publish.yml
@@ -22,6 +22,9 @@ jobs:
     name: ✅ Test Home Connector
     timeout-minutes: 4
     steps:
+      - name: ⚙️ Configure Git defaults
+        run: git config --global init.defaultBranch main
+
       - name: 📦 Checkout
         uses: actions/checkout@v6.0.2
 
@@ -35,6 +38,8 @@ jobs:
         run: npm ci
 
       - name: ✅ Run Home Connector Tests
+        env:
+          NODE_OPTIONS: --disable-warning=ExperimentalWarning
         run: npm --prefix packages/home-connector run test
 
       - name: ✅ Smoke-test Home Connector on Node
@@ -42,6 +47,7 @@ jobs:
         env:
           PORT: 4041
           HOME_CONNECTOR_SHARED_SECRET: ci-home-connector-secret
+          NODE_OPTIONS: --disable-warning=ExperimentalWarning
           WORKER_BASE_URL: http://127.0.0.1:65535
         run: |
           set -euo pipefail
@@ -71,9 +77,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     name: 🐳 Publish Docker image
-    timeout-minutes: 4
+    timeout-minutes: 10
     needs: test
     steps:
+      - name: ⚙️ Configure Git defaults
+        run: git config --global init.defaultBranch main
+
       - name: 📦 Checkout
         uses: actions/checkout@v6.0.2
 

--- a/.github/workflows/home-connector-publish.yml
+++ b/.github/workflows/home-connector-publish.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: publish-home-connector
   cancel-in-progress: true

--- a/.github/workflows/home-connector-publish.yml
+++ b/.github/workflows/home-connector-publish.yml
@@ -12,9 +12,6 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 concurrency:
   group: publish-home-connector
   cancel-in-progress: true
@@ -115,10 +112,10 @@ jobs:
           fi
 
       - name: 🏗️ Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: 🔐 Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Increase the home connector Docker publish job timeout so post-push cleanup does not get cancelled at the 4 minute mark.
- Upgrade Docker setup/login actions to their Node 24 major versions instead of using `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`.
- Configure Git's default init branch before checkout in both jobs to suppress checkout hint output.
- Suppress Node's SQLite ExperimentalWarning for home connector CI test and smoke-test runs.

## Testing
- `NODE_OPTIONS='--disable-warning=ExperimentalWarning' npm --prefix packages/home-connector run test`
- `PORT=4041 HOME_CONNECTOR_SHARED_SECRET=ci-home-connector-secret NODE_OPTIONS='--disable-warning=ExperimentalWarning' WORKER_BASE_URL=http://127.0.0.1:65535 bash -lc '...'`
- `npx oxfmt --check .github/workflows/home-connector-publish.yml`
- `gh api repos/docker/setup-buildx-action/contents/action.yml?ref=v4 --jq '.content' | base64 -d | rg 'runs:|using:' -C 2`
- `gh api repos/docker/login-action/contents/action.yml?ref=v4 --jq '.content' | base64 -d | rg 'runs:|using:' -C 2`

## Notes
- The Node 20 warning came from publish-job check annotations for `docker/login-action@v3` and `docker/setup-buildx-action@v3`, not the raw step logs.
- Both released `v4` action refs declare `runs.using: node24`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a91e75b-98c3-4eb5-83f9-7c512f9f9e37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a91e75b-98c3-4eb5-83f9-7c512f9f9e37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

