### PR TITLE
Delete preview deployment records during cleanup

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -573,6 +573,83 @@ jobs:
           set -euo pipefail
           node tools/ci/preview-resources.ts cleanup --worker-name "$APP_WORKER_NAME"
 
+      - name: 🗑️ Delete GitHub preview deployments
+        if: always()
+        uses: actions/github-script@v8.0.0
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          INPUT_TARGET: ${{ inputs.target }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+          script: |
+            const eventName = process.env.EVENT_NAME;
+            let envName;
+            if (eventName === "pull_request") {
+              const n = process.env.PR_NUMBER;
+              if (!n) {
+                core.info("No PR number on event; skipping GitHub deployment delete.");
+                return;
+              }
+              envName = `preview-${n}`;
+            } else if (
+              eventName === "workflow_dispatch" &&
+              process.env.INPUT_TARGET === "pr"
+            ) {
+              const n = process.env.INPUT_PR_NUMBER;
+              if (!n) {
+                core.info(
+                  "Manual cleanup without pr_number; skipping GitHub deployment delete.",
+                );
+                return;
+              }
+              envName = `preview-${n}`;
+            } else {
+              core.info(
+                "Skipping GitHub deployment delete (branch-targeted cleanups use a different naming scheme).",
+              );
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const deployments = await github.paginate(
+              github.rest.repos.listDeployments,
+              {
+                owner,
+                repo,
+                environment: envName,
+                per_page: 100,
+              },
+            );
+
+            for (const deployment of deployments) {
+              try {
+                await github.rest.repos.deleteDeployment({
+                  owner,
+                  repo,
+                  deployment_id: deployment.id,
+                });
+              } catch (error) {
+                if (error.status !== 422) throw error;
+                await github.rest.repos.createDeploymentStatus({
+                  owner,
+                  repo,
+                  deployment_id: deployment.id,
+                  state: "inactive",
+                  description: "Cleaning up closed PR preview deployment.",
+                });
+                await github.rest.repos.deleteDeployment({
+                  owner,
+                  repo,
+                  deployment_id: deployment.id,
+                });
+              }
+            }
+
+            core.notice(
+              `Deleted ${deployments.length} GitHub preview deployment(s) for ${envName}.`,
+            );
+
       - name: 🏷️ Delete GitHub preview environment
         if: always()
         uses: actions/github-script@v8.0.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Delete GitHub `preview-<pr>` deployment records during preview cleanup before deleting the matching environment.
- Preserve the existing Cloudflare Worker/D1/KV cleanup behavior.

### Validation
- Removed stale Cloudflare resources for closed PR previews `190`, `220`, `233`, and `244`.
- Removed 860 stale GitHub preview deployment records and 18 stale GitHub preview environments for closed/merged PRs.
- Verified only open PR previews remain on GitHub and Cloudflare: `290`, `295`, and `296`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e2aaf2b-3252-419f-a598-ed460c61c5df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e2aaf2b-3252-419f-a598-ed460c61c5df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

