### PR TITLE
Retry transient Bond state read resets

### DIFF
--- a/packages/home-connector/src/adapters/bond/index.node.test.ts
+++ b/packages/home-connector/src/adapters/bond/index.node.test.ts
@@ -119,7 +119,7 @@ test('bond falls back to the discovered IP when the stored .local host stops res
 	}
 })
 
-test('bond retries transient TCP resets when reading device state', async () => {
+test('bond retries transient TCP resets with exponential backoff when reading device state', async () => {
 	const config = createConfig()
 	const state = createAppState()
 	const storage = createHomeConnectorStorage(config)
@@ -129,9 +129,11 @@ test('bond retries transient TCP resets when reading device state', async () => 
 		storage,
 	})
 	const previousFetch = globalThis.fetch
+	vi.useFakeTimers()
 	const fetchMock = vi
 		.fn()
 		.mockRejectedValueOnce(createTcpResetFetchError())
+		.mockRejectedValueOnce(createTcpResetFetchError('socket hang up'))
 		.mockResolvedValueOnce(
 			new Response(JSON.stringify({ position: 21, _: 's' }), {
 				status: 200,
@@ -160,19 +162,31 @@ test('bond retries transient TCP resets when reading device state', async () => 
 		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST4')
 		bond.setToken('BONDTEST4', 'bond-token')
 
-		const result = await bond.getDeviceState('BONDTEST4', 'mockdev1')
+		const resultPromise = bond.getDeviceState('BONDTEST4', 'mockdev1')
+		await vi.advanceTimersByTimeAsync(99)
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+		await vi.advanceTimersByTimeAsync(1)
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+		await vi.advanceTimersByTimeAsync(199)
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+		await vi.advanceTimersByTimeAsync(1)
+		const result = await resultPromise
 
 		expect(result).toMatchObject({
 			position: 21,
 		})
-		expect(fetchMock).toHaveBeenCalledTimes(2)
+		expect(fetchMock).toHaveBeenCalledTimes(3)
 		expect(fetchMock.mock.calls[0]?.[0]).toBe(
 			'http://10.0.0.22/v2/devices/mockdev1/state',
 		)
 		expect(fetchMock.mock.calls[1]?.[0]).toBe(
 			'http://10.0.0.22/v2/devices/mockdev1/state',
 		)
+		expect(fetchMock.mock.calls[2]?.[0]).toBe(
+			'http://10.0.0.22/v2/devices/mockdev1/state',
+		)
 	} finally {
+		vi.useRealTimers()
 		globalThis.fetch = previousFetch
 		storage.close()
 	}

--- a/packages/home-connector/src/adapters/bond/index.node.test.ts
+++ b/packages/home-connector/src/adapters/bond/index.node.test.ts
@@ -27,7 +27,9 @@ function createConfig(): HomeConnectorConfig {
 	}
 }
 
-function createDnsFetchError(message = 'getaddrinfo ENOTFOUND zpgi01117.local') {
+function createDnsFetchError(
+	message = 'getaddrinfo ENOTFOUND zpgi01117.local',
+) {
 	return new TypeError('fetch failed', {
 		cause: {
 			code: 'ENOTFOUND',
@@ -36,6 +38,12 @@ function createDnsFetchError(message = 'getaddrinfo ENOTFOUND zpgi01117.local') 
 			hostname: 'zpgi01117.local',
 			message,
 		},
+	})
+}
+
+function createTcpResetFetchError(message = 'read ECONNRESET') {
+	return new TypeError('fetch failed', {
+		cause: new Error(message),
 	})
 }
 
@@ -101,6 +109,65 @@ test('bond falls back to the discovered IP when the stored .local host stops res
 		expect(fetchMock).toHaveBeenCalledTimes(2)
 		expect(fetchMock.mock.calls[0]?.[0]).toBe(
 			'http://zpgi01117.local/v2/devices/mockdev1/state',
+		)
+		expect(fetchMock.mock.calls[1]?.[0]).toBe(
+			'http://10.0.0.22/v2/devices/mockdev1/state',
+		)
+	} finally {
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
+test('bond retries transient TCP resets when reading device state', async () => {
+	const config = createConfig()
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	const fetchMock = vi
+		.fn()
+		.mockRejectedValueOnce(createTcpResetFetchError())
+		.mockResolvedValueOnce(
+			new Response(JSON.stringify({ position: 21, _: 's' }), {
+				status: 200,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+			}),
+		)
+	globalThis.fetch = fetchMock as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST4',
+				bondid: 'BONDTEST4',
+				instanceName: 'Reset-Prone Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:15:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST4')
+		bond.setToken('BONDTEST4', 'bond-token')
+
+		const result = await bond.getDeviceState('BONDTEST4', 'mockdev1')
+
+		expect(result).toMatchObject({
+			position: 21,
+		})
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+		expect(fetchMock.mock.calls[0]?.[0]).toBe(
+			'http://10.0.0.22/v2/devices/mockdev1/state',
 		)
 		expect(fetchMock.mock.calls[1]?.[0]).toBe(
 			'http://10.0.0.22/v2/devices/mockdev1/state',

--- a/packages/home-connector/src/adapters/bond/index.ts
+++ b/packages/home-connector/src/adapters/bond/index.ts
@@ -33,6 +33,9 @@ import {
 } from './types.ts'
 import { type HomeConnectorErrorCaptureContext } from '../../sentry.ts'
 
+const defaultBondTransientAttemptsPerBaseUrl = 4
+const defaultBondTransientRetryBaseDelayMs = 100
+
 function normalizeQuery(value: string) {
 	return value.trim().toLowerCase()
 }
@@ -216,6 +219,14 @@ function isBondTransientNetworkFailure(error: unknown) {
 	)
 }
 
+function getBondTransientRetryDelayMs(attempt: number) {
+	return defaultBondTransientRetryBaseDelayMs * 2 ** Math.max(0, attempt - 1)
+}
+
+async function wait(ms: number) {
+	await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 function formatBondFailureReason(error: unknown) {
 	if (error instanceof Error) {
 		const causeMessage = getErrorCauseMessage(error)
@@ -303,6 +314,7 @@ async function withBondBridgeRequest<T>(input: {
 					attempt < maxTransientAttemptsPerBaseUrl &&
 					isBondTransientNetworkFailure(error)
 				) {
+					await wait(getBondTransientRetryDelayMs(attempt))
 					continue
 				}
 				break
@@ -566,7 +578,7 @@ export function createBondAdapter(input: {
 			return await withBondBridgeRequest({
 				bridge,
 				operation: `fetch device ${deviceId} state`,
-				maxTransientAttemptsPerBaseUrl: 2,
+				maxTransientAttemptsPerBaseUrl: defaultBondTransientAttemptsPerBaseUrl,
 				request: async (baseUrl) =>
 					await bondGetDeviceState({
 						baseUrl,

--- a/packages/home-connector/src/adapters/bond/index.ts
+++ b/packages/home-connector/src/adapters/bond/index.ts
@@ -163,6 +163,18 @@ function getErrorCauseMessage(error: Error): string | null {
 	return null
 }
 
+function getErrorMessages(error: unknown) {
+	if (!(error instanceof Error)) {
+		return [String(error)]
+	}
+	const messages = [error.message]
+	const causeMessage = getErrorCauseMessage(error)
+	if (causeMessage) {
+		messages.push(causeMessage)
+	}
+	return messages
+}
+
 function isBondNetworkFailure(error: unknown) {
 	if (!(error instanceof Error)) {
 		return false
@@ -173,6 +185,7 @@ function isBondNetworkFailure(error: unknown) {
 		message.includes('enotfound') ||
 		message.includes('eai_again') ||
 		message.includes('econnrefused') ||
+		message.includes('econnreset') ||
 		message.includes('ehostunreach') ||
 		message.includes('etimedout')
 	) {
@@ -183,16 +196,32 @@ function isBondNetworkFailure(error: unknown) {
 		causeMessage.includes('enotfound') ||
 		causeMessage.includes('eai_again') ||
 		causeMessage.includes('econnrefused') ||
+		causeMessage.includes('econnreset') ||
 		causeMessage.includes('ehostunreach') ||
 		causeMessage.includes('etimedout') ||
 		causeMessage.includes('getaddrinfo')
 	)
 }
 
+function isBondTransientNetworkFailure(error: unknown) {
+	if (!isBondNetworkFailure(error)) {
+		return false
+	}
+	const messages = getErrorMessages(error).map((message) =>
+		message.toLowerCase(),
+	)
+	return messages.some(
+		(message) =>
+			message.includes('econnreset') || message.includes('socket hang up'),
+	)
+}
+
 function formatBondFailureReason(error: unknown) {
 	if (error instanceof Error) {
 		const causeMessage = getErrorCauseMessage(error)
-		return causeMessage ? `${error.message}; cause=${causeMessage}` : error.message
+		return causeMessage
+			? `${error.message}; cause=${causeMessage}`
+			: error.message
 	}
 	return String(error)
 }
@@ -219,8 +248,12 @@ function createBondActionableError(input: {
 		tags: {
 			connector_vendor: 'bond',
 			bond_bridge_id: input.bridge.bridgeId,
-			bond_network_failure: isBondNetworkFailure(input.error) ? 'true' : 'false',
-			bond_host_is_local: input.bridge.host.endsWith('.local') ? 'true' : 'false',
+			bond_network_failure: isBondNetworkFailure(input.error)
+				? 'true'
+				: 'false',
+			bond_host_is_local: input.bridge.host.endsWith('.local')
+				? 'true'
+				: 'false',
 		},
 		contexts: {
 			bond_bridge: {
@@ -242,25 +275,42 @@ async function withBondBridgeRequest<T>(input: {
 	bridge: BondPersistedBridge
 	operation: string
 	request: (baseUrl: string) => Promise<T>
+	maxTransientAttemptsPerBaseUrl?: number
 }) {
 	const baseUrls = createBondBaseUrlCandidates(input.bridge)
 	const attemptedBaseUrls: Array<string> = []
 	let lastError: unknown = null
+	const maxTransientAttemptsPerBaseUrl = Math.max(
+		1,
+		Math.floor(input.maxTransientAttemptsPerBaseUrl ?? 1),
+	)
 	for (let index = 0; index < baseUrls.length; index += 1) {
 		const baseUrl = baseUrls[index]!
 		attemptedBaseUrls.push(baseUrl)
-		try {
-			return await input.request(baseUrl)
-		} catch (error) {
-			lastError = error
-			if (!isBondNetworkFailure(error)) {
-				throw error
-			}
-			const canRetryWithFallback =
-				index === 0 && baseUrls.length > 1
-			if (!canRetryWithFallback) {
+		for (
+			let attempt = 1;
+			attempt <= maxTransientAttemptsPerBaseUrl;
+			attempt += 1
+		) {
+			try {
+				return await input.request(baseUrl)
+			} catch (error) {
+				lastError = error
+				if (!isBondNetworkFailure(error)) {
+					throw error
+				}
+				if (
+					attempt < maxTransientAttemptsPerBaseUrl &&
+					isBondTransientNetworkFailure(error)
+				) {
+					continue
+				}
 				break
 			}
+		}
+		const canRetryWithFallback = index === 0 && baseUrls.length > 1
+		if (!canRetryWithFallback) {
+			break
 		}
 	}
 	throw createBondActionableError({
@@ -516,6 +566,7 @@ export function createBondAdapter(input: {
 			return await withBondBridgeRequest({
 				bridge,
 				operation: `fetch device ${deviceId} state`,
+				maxTransientAttemptsPerBaseUrl: 2,
 				request: async (baseUrl) =>
 					await bondGetDeviceState({
 						baseUrl,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update the live Bond bridge connection for `ZPGI01117` from the `.local` host to the discovered stable IP via production Kody MCP.
- Treat `ECONNRESET` as a Bond network failure and retry transient device-state reads with exponential backoff before surfacing an actionable error.
- Add a home connector regression test for reset-prone Bond state reads and the 100ms/200ms retry schedule.

## Testing
- `npm --prefix packages/home-connector run test -- src/adapters/bond/index.node.test.ts`
- `npm --prefix packages/home-connector run test`
- `npm run typecheck`
- `git push -u origin cursor/fix-bond-network-sentry-657a`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27806724-eb54-47d6-83bf-3509d82c657a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27806724-eb54-47d6-83bf-3509d82c657a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

