### PR TITLE
Add prompt caching hints for agent turns

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -101,6 +101,51 @@ Typical pattern inside execute:
 - use **`codemode.agent_chat_turn(...)`** in package jobs or workflows that only
   need the final answer
 
+### Prompt caching for stable prefixes
+
+Agent turns accept the existing string-only prompt shape, plus an optional
+cache-hint form for prompts with a stable prefix:
+
+```ts
+await codemode.agent_chat_turn({
+  sessionId: 'email-follow-up',
+  system: {
+    content: stableSystemPrompt,
+    cache: 'prefix',
+  },
+  messages: [
+    {
+      role: 'user',
+      content: normalizedThreadContext,
+      cache: 'prefix',
+    },
+    {
+      role: 'user',
+      content: latestInboundEmail,
+    },
+  ],
+})
+```
+
+Use `cache: 'prefix'` only on prompt segments that are intentionally stable
+across repeated turns. Kody translates that hint into provider-specific cache
+controls only when the configured model/provider supports prompt caching. For
+other providers, the hint is ignored with no behavior change.
+
+For follow-up email workflows, structure prompts in this order:
+
+1. **Stable system prompt first** - instructions, policy, response style,
+   tool-use guidance
+2. **Stable normalized thread context next** - summarize or normalize the
+   earlier thread so repeated quoted content stays stable
+3. **Current latest email last** - put the newest inbound email content after
+   the cached prefix so only the changing tail invalidates less cached work
+
+Prefer normalizing long quoted threads before passing them into the agent turn
+instead of appending raw mailbox history every time. That keeps the stable
+prefix stable enough to benefit from caching and makes the final changing email
+content easier for the model to prioritize.
+
 ## Storage
 
 Kody supports durable storage binding for execute and scheduled jobs, including

--- a/packages/worker/src/agent-turn/runner.node.test.ts
+++ b/packages/worker/src/agent-turn/runner.node.test.ts
@@ -189,3 +189,86 @@ test('runAgentTurn marks no_new_information for repeated tool calls', async () =
 	expect(completion.stopReason).toBe('no_new_information')
 	expect(completion.continueRecommended).toBe(false)
 })
+
+test('runAgentTurn forwards cache-aware system and message hints to the AI runtime', async () => {
+	mockModule.streamText.mockImplementationOnce(
+		(options: Record<string, unknown>) => {
+			return {
+				async consumeStream() {
+					await (options.onFinish as Function)?.({
+						steps: [],
+						finishReason: 'stop',
+					})
+				},
+				text: Promise.resolve('done'),
+				reasoningText: Promise.resolve(''),
+			}
+		},
+	)
+
+	const turn = await runAgentTurn({
+		env: {
+			AI: {},
+			AI_GATEWAY_ID: 'gateway-id',
+			AI_MODEL: 'anthropic/claude-sonnet-4.5',
+		} as Env,
+		callerContext: {
+			baseUrl: 'https://heykody.dev',
+			user: { userId: 'user-123' },
+			homeConnectorId: null,
+			remoteConnectors: null,
+			storageContext: null,
+		},
+		turn: {
+			system: {
+				content: 'stable system',
+				cache: 'prefix',
+			},
+			messages: [
+				{
+					role: 'user',
+					content: 'normalized thread context',
+					cache: 'prefix',
+				},
+				{
+					role: 'user',
+					content: 'latest inbound email',
+				},
+			],
+			sessionId: 'session-3',
+		},
+	})
+
+	await turn.completion
+
+	expect(mockModule.streamText).toHaveBeenLastCalledWith({
+		model: { provider: 'workers-ai-model' },
+		messages: [
+			{
+				role: 'system',
+				content: 'stable system',
+				providerOptions: {
+					anthropic: { cacheControl: { type: 'ephemeral' } },
+				},
+			},
+			{
+				role: 'user',
+				content: 'normalized thread context',
+				providerOptions: {
+					anthropic: { cacheControl: { type: 'ephemeral' } },
+				},
+			},
+			{
+				role: 'user',
+				content: 'latest inbound email',
+			},
+		],
+		tools: {},
+		abortSignal: undefined,
+		onFinish: expect.any(Function),
+		onChunk: expect.any(Function),
+		onAbort: expect.any(Function),
+		onStepFinish: expect.any(Function),
+		stopWhen: { type: 'step-count-is', count: 8 },
+	})
+})

--- a/packages/worker/src/agent-turn/runner.ts
+++ b/packages/worker/src/agent-turn/runner.ts
@@ -1,6 +1,10 @@
 import { resolveConversationId } from '#mcp/tools/tool-call-context.ts'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
-import { streamRemoteToolLoop } from '#worker/ai-runtime.ts'
+import {
+	streamRemoteToolLoop,
+	type CacheAwareModelMessage,
+	type CacheAwareSystemPrompt,
+} from '#worker/ai-runtime.ts'
 import {
 	agentTurnInputSchema,
 	type AgentToolTrace,
@@ -9,6 +13,7 @@ import {
 	type AgentTurnResult,
 	type AgentTurnStopReason,
 	type AgentTurnStreamEvent,
+	type AgentTurnSystemPrompt,
 } from './types.ts'
 import { createAgentTurnToolSet } from './tools.ts'
 
@@ -72,10 +77,25 @@ function clean(value: unknown) {
 	return String(value ?? '').trim()
 }
 
-function toModelMessages(messages: Array<AgentTurnMessage>) {
+function toSystemPrompt(
+	system: AgentTurnSystemPrompt,
+): CacheAwareSystemPrompt {
+	if (typeof system === 'string') {
+		return system
+	}
+	return {
+		content: system.content,
+		...(system.cache ? { cache: system.cache } : {}),
+	}
+}
+
+function toModelMessages(
+	messages: Array<AgentTurnMessage>,
+): Array<CacheAwareModelMessage> {
 	return messages.map((message) => ({
 		role: message.role,
 		content: message.content,
+		...(message.cache ? { cache: message.cache } : {}),
 	}))
 }
 
@@ -167,6 +187,7 @@ export async function runAgentTurn(input: {
 }) {
 	const parsed = agentTurnInputSchema.parse(input.turn)
 	const conversationId = resolveConversationId(parsed.conversationId)
+	const systemPrompt = toSystemPrompt(parsed.system)
 	const modelMessages = toModelMessages(parsed.messages)
 	const tools = await createAgentTurnToolSet({
 		env: input.env,
@@ -182,7 +203,7 @@ export async function runAgentTurn(input: {
 	let stepsUsed = 0
 
 	const result = await streamRemoteToolLoop(input.env, {
-		system: parsed.system,
+		system: systemPrompt,
 		messages: modelMessages,
 		tools,
 		maxSteps: parsed.maxSteps ?? defaultMaxSteps,

--- a/packages/worker/src/agent-turn/types.ts
+++ b/packages/worker/src/agent-turn/types.ts
@@ -4,14 +4,35 @@ import {
 	memoryContextInputField,
 } from '#mcp/tools/tool-call-context.ts'
 
+export const agentTurnPromptCacheSchema = z.literal('prefix')
+
+export const agentTurnSystemPromptSchema = z.union([
+	z.string().min(1),
+	z.object({
+		content: z.string().min(1),
+		cache: agentTurnPromptCacheSchema
+			.optional()
+			.describe(
+				'Optional hint that the prompt prefix through this system prompt is stable and can be cached when supported.',
+			),
+	}),
+])
+
 export const agentTurnMessageSchema = z.object({
 	role: z.enum(['system', 'user', 'assistant']),
 	content: z.string().min(1),
+	cache: agentTurnPromptCacheSchema
+		.optional()
+		.describe(
+			'Optional hint that the prompt prefix through this message is stable and can be cached when supported.',
+		),
 })
 
 export const agentTurnInputSchema = z.object({
 	messages: z.array(agentTurnMessageSchema).min(1),
-	system: z.string().min(1).describe('System prompt to use for this turn.'),
+	system: agentTurnSystemPromptSchema.describe(
+		'System prompt to use for this turn. Accepts a string or { content, cache: "prefix" }.',
+	),
 	sessionId: z
 		.string()
 		.min(1)
@@ -39,6 +60,8 @@ export const agentTurnToolInputSchema = agentTurnInputSchema.extend({
 		.describe('Stable session identifier used to scope the active agent run.'),
 })
 
+export type AgentTurnPromptCache = z.infer<typeof agentTurnPromptCacheSchema>
+export type AgentTurnSystemPrompt = z.infer<typeof agentTurnSystemPromptSchema>
 export type AgentTurnMessage = z.infer<typeof agentTurnMessageSchema>
 export type AgentTurnInput = z.infer<typeof agentTurnInputSchema>
 export type AgentTurnToolInput = z.infer<typeof agentTurnToolInputSchema>

--- a/packages/worker/src/ai-runtime.node.test.ts
+++ b/packages/worker/src/ai-runtime.node.test.ts
@@ -36,7 +36,7 @@ vi.mock('workers-ai-provider', () => ({
 		mockModule.createWorkersAI(...args),
 }))
 
-const { createAiRuntime } = await import('./ai-runtime.ts')
+const { createAiRuntime, streamRemoteToolLoop } = await import('./ai-runtime.ts')
 
 test('remote ai runtime sets a multi-step stop condition for tool continuation', async () => {
 	const runtime = createAiRuntime({
@@ -83,6 +83,108 @@ test('remote ai runtime sets a multi-step stop condition for tool continuation',
 		stopWhen: { type: 'step-count-is', count: 5 },
 	})
 	expect(mockModule.toUIMessageStreamResponse).toHaveBeenCalledTimes(1)
+})
+
+test('remote tool loop promotes cached system and message prefixes for Anthropic models', async () => {
+	mockModule.streamText.mockClear()
+	mockModule.model.mockClear()
+
+	await streamRemoteToolLoop(
+		{
+			AI_MODE: 'remote',
+			AI_GATEWAY_ID: 'gateway-id',
+			AI_MODEL: 'anthropic/claude-sonnet-4.5',
+			AI: {} as Ai,
+		} as Env,
+		{
+			system: {
+				content: 'stable system prompt',
+				cache: 'prefix',
+			},
+			messages: [
+				{
+					role: 'user',
+					content: 'normalized thread context',
+					cache: 'prefix',
+				},
+				{
+					role: 'user',
+					content: 'latest inbound email',
+				},
+			],
+			tools: {} as never,
+			maxSteps: 3,
+		},
+	)
+
+	expect(mockModule.model).toHaveBeenCalledWith('anthropic/claude-sonnet-4.5')
+	expect(mockModule.streamText).toHaveBeenCalledWith({
+		model: { provider: 'workers-ai-model' },
+		messages: [
+			{
+				role: 'system',
+				content: 'stable system prompt',
+				providerOptions: {
+					anthropic: { cacheControl: { type: 'ephemeral' } },
+				},
+			},
+			{
+				role: 'user',
+				content: 'normalized thread context',
+				providerOptions: {
+					anthropic: { cacheControl: { type: 'ephemeral' } },
+				},
+			},
+			{
+				role: 'user',
+				content: 'latest inbound email',
+			},
+		],
+		tools: {},
+		stopWhen: { type: 'step-count-is', count: 3 },
+	})
+})
+
+test('remote tool loop keeps cache hints inert for unsupported models', async () => {
+	mockModule.streamText.mockClear()
+	mockModule.model.mockClear()
+
+	await streamRemoteToolLoop(
+		{
+			AI_MODE: 'remote',
+			AI_GATEWAY_ID: 'gateway-id',
+			AI_MODEL: '@cf/zai-org/glm-4.7-flash',
+			AI: {} as Ai,
+		} as Env,
+		{
+			system: {
+				content: 'stable system prompt',
+				cache: 'prefix',
+			},
+			messages: [
+				{
+					role: 'user',
+					content: 'normalized thread context',
+					cache: 'prefix',
+				},
+			],
+			tools: {} as never,
+		},
+	)
+
+	expect(mockModule.model).toHaveBeenCalledWith('@cf/zai-org/glm-4.7-flash')
+	expect(mockModule.streamText).toHaveBeenCalledWith({
+		model: { provider: 'workers-ai-model' },
+		system: 'stable system prompt',
+		messages: [
+			{
+				role: 'user',
+				content: 'normalized thread context',
+			},
+		],
+		tools: {},
+		stopWhen: { type: 'step-count-is', count: 5 },
+	})
 })
 
 test('mock ai runtime still returns a local fallback response', async () => {

--- a/packages/worker/src/ai-runtime.ts
+++ b/packages/worker/src/ai-runtime.ts
@@ -34,7 +34,10 @@ export type CacheAwareModelMessage = ModelMessage & {
 	cache?: PromptCacheHint
 }
 
-type ModelMessageProviderOptions = Exclude<ModelMessage['providerOptions'], undefined>
+type ModelMessageProviderOptions = Exclude<
+	ModelMessage['providerOptions'],
+	undefined
+>
 type PromptCachingProvider = 'anthropic'
 
 export type StreamChatReplyInput = {
@@ -122,7 +125,9 @@ async function toModelMessages(
 	messages: Array<UIMessage> | Array<CacheAwareModelMessage>,
 ): Promise<Array<CacheAwareModelMessage>> {
 	if (isUiMessageArray(messages)) {
-		return (await convertToModelMessages(messages)) as Array<CacheAwareModelMessage>
+		return (await convertToModelMessages(
+			messages,
+		)) as Array<CacheAwareModelMessage>
 	}
 	return messages as Array<CacheAwareModelMessage>
 }
@@ -166,13 +171,16 @@ function mergeProviderOptions(
 	if (!currentOptions) return nextOptions
 	if (!nextOptions) return currentOptions
 
-	const mergedEntries = Object.entries(nextOptions).map(([provider, options]) => [
-		provider,
-		{
-			...((currentOptions[provider] as Record<string, unknown> | undefined) ?? {}),
-			...(options as Record<string, unknown>),
-		},
-	])
+	const mergedEntries = Object.entries(nextOptions).map(
+		([provider, options]) => [
+			provider,
+			{
+				...((currentOptions[provider] as Record<string, unknown> | undefined) ??
+					{}),
+				...(options as Record<string, unknown>),
+			},
+		],
+	)
 
 	return {
 		...currentOptions,
@@ -198,11 +206,14 @@ function normalizeModelMessage(
 	}
 }
 
-async function normalizePromptInput(input: StreamToolLoopInput, modelId: string) {
+async function normalizePromptInput(
+	input: StreamToolLoopInput,
+	modelId: string,
+) {
 	const provider = resolvePromptCachingProvider(modelId)
-	const messages = (await toModelMessages(input.messages)).map((message) =>
-		normalizeModelMessage(message, provider),
-	)
+	const messages: Array<ModelMessage> = (
+		await toModelMessages(input.messages)
+	).map((message) => normalizeModelMessage(message, provider))
 
 	if (typeof input.system === 'string') {
 		return {
@@ -218,15 +229,14 @@ async function normalizePromptInput(input: StreamToolLoopInput, modelId: string)
 		}
 	}
 
+	const systemMessage: ModelMessage = {
+		role: 'system',
+		content: input.system.content,
+		providerOptions: getPromptCacheProviderOptions(provider),
+	}
+
 	return {
-		messages: [
-			{
-				role: 'system',
-				content: input.system.content,
-				providerOptions: getPromptCacheProviderOptions(provider),
-			},
-			...messages,
-		],
+		messages: [systemMessage, ...messages],
 	}
 }
 

--- a/packages/worker/src/ai-runtime.ts
+++ b/packages/worker/src/ai-runtime.ts
@@ -21,6 +21,22 @@ import {
 const defaultModel = '@cf/zai-org/glm-4.7-flash'
 const remoteToolLoopMaxSteps = 5
 
+export type PromptCacheHint = 'prefix'
+
+export type CacheAwareSystemPrompt =
+	| string
+	| {
+			content: string
+			cache?: PromptCacheHint
+	  }
+
+export type CacheAwareModelMessage = ModelMessage & {
+	cache?: PromptCacheHint
+}
+
+type ModelMessageProviderOptions = Exclude<ModelMessage['providerOptions'], undefined>
+type PromptCachingProvider = 'anthropic'
+
 export type StreamChatReplyInput = {
 	messages: Array<UIMessage>
 	system: string
@@ -39,8 +55,8 @@ export type AiRuntime = {
 }
 
 export type StreamToolLoopInput = {
-	messages: Array<UIMessage> | Array<ModelMessage>
-	system: string
+	messages: Array<UIMessage> | Array<CacheAwareModelMessage>
+	system: CacheAwareSystemPrompt
 	tools: ToolSet
 	toolNames?: Array<string>
 	abortSignal?: AbortSignal
@@ -97,18 +113,121 @@ function createWorkersAiProvider(env: WorkersAiCredentialsEnv) {
 }
 
 function isUiMessageArray(
-	messages: Array<UIMessage> | Array<ModelMessage>,
+	messages: Array<UIMessage> | Array<CacheAwareModelMessage>,
 ): messages is Array<UIMessage> {
 	return messages.some((message) => 'parts' in message)
 }
 
 async function toModelMessages(
-	messages: Array<UIMessage> | Array<ModelMessage>,
-): Promise<Array<ModelMessage>> {
+	messages: Array<UIMessage> | Array<CacheAwareModelMessage>,
+): Promise<Array<CacheAwareModelMessage>> {
 	if (isUiMessageArray(messages)) {
-		return (await convertToModelMessages(messages)) as Array<ModelMessage>
+		return (await convertToModelMessages(messages)) as Array<CacheAwareModelMessage>
 	}
-	return messages as Array<ModelMessage>
+	return messages as Array<CacheAwareModelMessage>
+}
+
+function resolvePromptCachingProvider(
+	modelId: string,
+): PromptCachingProvider | null {
+	const normalizedModelId = modelId.trim().toLowerCase()
+	if (
+		normalizedModelId.startsWith('anthropic/') ||
+		normalizedModelId.includes('claude')
+	) {
+		return 'anthropic'
+	}
+	return null
+}
+
+function getPromptCacheProviderOptions(
+	provider: PromptCachingProvider,
+): ModelMessageProviderOptions {
+	switch (provider) {
+		case 'anthropic':
+			return {
+				anthropic: {
+					cacheControl: {
+						type: 'ephemeral',
+					},
+				},
+			}
+		default: {
+			const exhaustiveProvider: never = provider
+			return exhaustiveProvider
+		}
+	}
+}
+
+function mergeProviderOptions(
+	currentOptions: ModelMessageProviderOptions | undefined,
+	nextOptions: ModelMessageProviderOptions | undefined,
+) {
+	if (!currentOptions) return nextOptions
+	if (!nextOptions) return currentOptions
+
+	const mergedEntries = Object.entries(nextOptions).map(([provider, options]) => [
+		provider,
+		{
+			...((currentOptions[provider] as Record<string, unknown> | undefined) ?? {}),
+			...(options as Record<string, unknown>),
+		},
+	])
+
+	return {
+		...currentOptions,
+		...Object.fromEntries(mergedEntries),
+	} satisfies ModelMessageProviderOptions
+}
+
+function normalizeModelMessage(
+	message: CacheAwareModelMessage,
+	provider: PromptCachingProvider | null,
+): ModelMessage {
+	const { cache, ...rest } = message
+	if (!provider || cache !== 'prefix') {
+		return rest
+	}
+
+	return {
+		...rest,
+		providerOptions: mergeProviderOptions(
+			rest.providerOptions,
+			getPromptCacheProviderOptions(provider),
+		),
+	}
+}
+
+async function normalizePromptInput(input: StreamToolLoopInput, modelId: string) {
+	const provider = resolvePromptCachingProvider(modelId)
+	const messages = (await toModelMessages(input.messages)).map((message) =>
+		normalizeModelMessage(message, provider),
+	)
+
+	if (typeof input.system === 'string') {
+		return {
+			system: input.system,
+			messages,
+		}
+	}
+
+	if (!provider || input.system.cache !== 'prefix') {
+		return {
+			system: input.system.content,
+			messages,
+		}
+	}
+
+	return {
+		messages: [
+			{
+				role: 'system',
+				content: input.system.content,
+				providerOptions: getPromptCacheProviderOptions(provider),
+			},
+			...messages,
+		],
+	}
 }
 
 export async function streamRemoteToolLoop(
@@ -116,10 +235,12 @@ export async function streamRemoteToolLoop(
 	input: StreamToolLoopInput,
 ): Promise<StreamTextResult<ToolSet, never>> {
 	const workersai = createWorkersAiProvider(env)
+	const modelId = env.AI_MODEL ?? defaultModel
+	const prompt = await normalizePromptInput(input, modelId)
 	return streamText({
-		model: workersai(env.AI_MODEL ?? defaultModel),
-		system: input.system,
-		messages: await toModelMessages(input.messages),
+		model: workersai(modelId),
+		...(prompt.system ? { system: prompt.system } : {}),
+		messages: prompt.messages,
 		tools: input.tools,
 		stopWhen: stepCountIs(input.maxSteps ?? remoteToolLoopMaxSteps),
 		abortSignal: input.abortSignal,

--- a/packages/worker/src/mcp/capabilities/meta/meta-agent-turn.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-agent-turn.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { agentTurnInputSchema } from '#worker/agent-turn/types.ts'
 
 const mockModule = vi.hoisted(() => ({
 	beginAgentTurn: vi.fn(),
@@ -95,6 +96,58 @@ test('agent turn capabilities delegate across start, next, and cancel flows', as
 	})
 })
 
+test('agent turn schema accepts cache-aware prompts while preserving string compatibility', () => {
+	expect(
+		agentTurnInputSchema.parse({
+			sessionId: 'session-123',
+			system: 'plain system prompt',
+			messages: [{ role: 'user', content: 'latest email only' }],
+		}),
+	).toEqual({
+		sessionId: 'session-123',
+		system: 'plain system prompt',
+		messages: [{ role: 'user', content: 'latest email only' }],
+	})
+
+	expect(
+		agentTurnInputSchema.parse({
+			sessionId: 'session-456',
+			system: {
+				content: 'stable system prompt',
+				cache: 'prefix',
+			},
+			messages: [
+				{
+					role: 'user',
+					content: 'normalized prior thread context',
+					cache: 'prefix',
+				},
+				{
+					role: 'user',
+					content: 'latest inbound email',
+				},
+			],
+		}),
+	).toEqual({
+		sessionId: 'session-456',
+		system: {
+			content: 'stable system prompt',
+			cache: 'prefix',
+		},
+		messages: [
+			{
+				role: 'user',
+				content: 'normalized prior thread context',
+				cache: 'prefix',
+			},
+			{
+				role: 'user',
+				content: 'latest inbound email',
+			},
+		],
+	})
+})
+
 test('agent_chat_turn collects events and returns final structured result', async () => {
 	mockModule.beginAgentTurn.mockResolvedValueOnce({
 		ok: true,
@@ -122,8 +175,14 @@ test('agent_chat_turn collects events and returns final structured result', asyn
 	const result = await metaAgentChatTurnCapability.handler(
 		{
 			sessionId: 'session-123',
-			system: 'system',
-			messages: [{ role: 'user', content: 'hello' }],
+			system: {
+				content: 'stable system',
+				cache: 'prefix',
+			},
+			messages: [
+				{ role: 'user', content: 'thread context', cache: 'prefix' },
+				{ role: 'user', content: 'hello' },
+			],
 		},
 		ctx as never,
 	)
@@ -160,5 +219,20 @@ test('agent_chat_turn collects events and returns final structured result', asyn
 				conversationId: 'conversation-123',
 			},
 		],
+	})
+	expect(mockModule.beginAgentTurn).toHaveBeenLastCalledWith({
+		env: ctx.env,
+		callerContext: ctx.callerContext,
+		turn: {
+			sessionId: 'session-123',
+			system: {
+				content: 'stable system',
+				cache: 'prefix',
+			},
+			messages: [
+				{ role: 'user', content: 'thread context', cache: 'prefix' },
+				{ role: 'user', content: 'hello' },
+			],
+		},
 	})
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a prompt-caching-friendly agent turn input shape that keeps existing string-only callers working
- thread cache hints through agent turn normalization into the AI runtime and translate them to provider cache controls only for supported models/providers
- document how package-owned follow-up email workflows should order stable system prompt, stable normalized thread context, and newest email content last
- add focused tests for schema acceptance and cache metadata reaching `streamText` model messages

## Testing
- `npx vitest run packages/worker/src/ai-runtime.node.test.ts packages/worker/src/agent-turn/runner.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-agent-turn.node.test.ts`
- `npm run typecheck`
- Validation artifact: [Prompt caching validation commands](https://cursor.com/artifacts/c/art-a81fea30-3cf2-4ad4-b086-66419c05bed5)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6279e12b-2fd7-4dfc-989e-9f21efe68020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6279e12b-2fd7-4dfc-989e-9f21efe68020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

