### PR TITLE
Enable normal capabilities for email package subscriptions

### DIFF
--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -33,6 +33,13 @@ Use the MCP `email` domain:
   stored message id and receipt metadata, then use `email_message_get` or
   `email_attachment_get` (or `import { email } from 'kody:runtime'`) when they
   need bodies or attachment bytes.
+- Subscription handlers run with the normal package runtime context: signed-in
+  package user, package-owned storage `package:<packageId>`, package/repo
+  context, and the standard capability registry subject to the usual secret and
+  capability approval rules. For `email.message.received`, this means handlers
+  can call capabilities such as `agent_chat_turn` and `email_reply` directly,
+  while `import { email } from 'kody:runtime'` remains available as a
+  convenience helper for message lookup, attachment lookup, and replies.
 - Attachments remain metadata-first by default; raw MIME for small messages is
   stored so on-demand attachment lookup can reconstruct bytes locally.
 

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -749,13 +749,13 @@ export default async function run() {
 			replyFrom,
 		])
 		expect(outboundMessages.map((message) => message.processingStatus)).toEqual(
-			['pending', 'pending'],
+			['sent', 'sent'],
 		)
-		expect(outboundMessages.map((message) => message.subject)).toEqual([
-			'Re: Stored mail',
+		expect(outboundMessages.map((message) => message.subject).sort()).toEqual([
 			'Re: Approved sender',
+			'Re: Stored mail',
 		])
-		expect(outboundMessages.map((message) => message.textBody)).toEqual([
+		expect(outboundMessages.map((message) => message.textBody).sort()).toEqual([
 			'Thanks for the email.',
 			'Thanks for the email.',
 		])

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -1,5 +1,5 @@
 import { env } from 'cloudflare:workers'
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import {
 	getEmailDomain,
 	getEmailLocalPart,
@@ -14,11 +14,11 @@ import {
 	getEmailAttachmentById,
 	listEmailMessages,
 	listEmailAttachmentsForMessage,
+	upsertEmailSenderIdentity,
 } from './repo.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
-import {
-	buildPublishedSourceManifestSnapshotKvKey,
-} from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { buildPublishedSourceManifestSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import * as agentTurnApi from '#worker/agent-turn/api.ts'
 
 function createForwardableEmailMessage(input: {
 	from: string
@@ -271,7 +271,8 @@ test('getEmailAttachmentById reconstructs unnamed attachments from raw MIME', as
 				contentType: 'text/plain',
 				contentId: null,
 				disposition: 'attachment',
-				size: new TextEncoder().encode('Attachment without filename\n').byteLength,
+				size: new TextEncoder().encode('Attachment without filename\n')
+					.byteLength,
 				storageKind: 'raw-mime',
 				storageKey: null,
 			},
@@ -300,9 +301,9 @@ test('getEmailAttachmentById reconstructs unnamed attachments from raw MIME', as
 		disposition: 'attachment',
 	})
 	expect(loaded?.contentBase64).toBeTruthy()
-	expect(
-		loaded?.contentBase64 ? atob(loaded.contentBase64) : null,
-	).toBe('Attachment without filename\n')
+	expect(loaded?.contentBase64 ? atob(loaded.contentBase64) : null).toBe(
+		'Attachment without filename\n',
+	)
 })
 
 test('inbound email handler dispatches package subscriptions for stored inbound email', async () => {
@@ -315,6 +316,32 @@ test('inbound email handler dispatches package subscriptions for stored inbound 
 	const packageId = `package-${crypto.randomUUID()}`
 	const bundleKv = new Map<string, string>()
 	const subscriptionCalls: Array<Record<string, unknown>> = []
+	const replyFrom = `package-reply-${crypto.randomUUID()}@example.com`
+	const beginAgentTurnSpy = vi
+		.spyOn(agentTurnApi, 'beginAgentTurn')
+		.mockResolvedValue({
+			ok: true,
+			runId: 'run-subscription-1',
+			conversationId: 'conversation-subscription-1',
+		})
+	const collectAgentTurnEventsSpy = vi
+		.spyOn(agentTurnApi, 'collectAgentTurnEvents')
+		.mockResolvedValue([
+			{
+				type: 'turn_complete',
+				assistantText: 'Thanks for the email.',
+				reasoningText: '',
+				summary: 'Drafted an acknowledgement',
+				continueRecommended: false,
+				needsUserInput: false,
+				stepsUsed: 1,
+				newInformation: true,
+				stopReason: 'completed',
+				finishReason: 'completed',
+				toolCalls: [],
+				conversationId: 'conversation-subscription-1',
+			},
+		])
 
 	const db = env.APP_DB
 	await db
@@ -400,6 +427,14 @@ test('inbound email handler dispatches package subscriptions for stored inbound 
 			ON package_invocations(user_id, token_id, package_id, export_name, idempotency_key)`,
 		)
 		.run()
+	await upsertEmailSenderIdentity({
+		db,
+		userId,
+		email: replyFrom,
+		domain: getEmailDomain(replyFrom),
+		status: 'verified',
+		packageId,
+	})
 
 	const now = new Date().toISOString()
 	await db
@@ -484,13 +519,24 @@ test('inbound email handler dispatches package subscriptions for stored inbound 
 		modules: {
 			'.__kody_virtual__/runtime.js': `
 const runtime = globalThis.__kodyRuntime ?? {};
+export const codemode = runtime.codemode;
 export const email = runtime.email ?? null;
 export const params = runtime.params ?? null;
 `.trim(),
 			'dist/subscription.js': `
-import { email, params } from '../.__kody_virtual__/runtime.js'
+import { codemode, email, params } from '../.__kody_virtual__/runtime.js'
 
 export default async function run() {
+  const agentResult = await codemode.agent_chat_turn({
+    sessionId: 'email-subscription-session',
+    system: 'Write a short acknowledgement for this inbound email.',
+    messages: [
+      {
+        role: 'user',
+        content: 'Reply with a brief acknowledgement.',
+      },
+    ],
+  })
   const result = await email.getMessage(params.message.id)
   const firstAttachment = Array.isArray(params.attachments) ? params.attachments[0] : null
   const attachment = firstAttachment?.id
@@ -499,11 +545,19 @@ export default async function run() {
   const attachmentText = attachment?.content_base64
     ? atob(attachment.content_base64)
     : null
+  const reply = await email.reply({
+    message_id: params.message.id,
+    from: ${JSON.stringify(replyFrom)},
+    text: agentResult?.result?.assistantText ?? 'Fallback reply',
+  })
   return {
     eventType: 'received',
     messageId: result.id,
     textBody: result.text_body,
     attachmentText,
+    agentReplyText: agentResult?.result?.assistantText ?? null,
+    replyMessageId: reply.id,
+    replyDirection: reply.direction,
   }
 }
 `,
@@ -564,6 +618,7 @@ export default async function run() {
 	} as ExecutionContext
 
 	const originalKv = env.BUNDLE_ARTIFACTS_KV
+	const originalEmailBinding = env.EMAIL
 	Object.assign(env, {
 		BUNDLE_ARTIFACTS_KV: {
 			async get(key: string, type?: string) {
@@ -579,6 +634,11 @@ export default async function run() {
 			},
 			async delete() {
 				return undefined
+			},
+		},
+		EMAIL: {
+			async send() {
+				return { messageId: `provider-${crypto.randomUUID()}` }
 			},
 		},
 	})
@@ -643,6 +703,12 @@ export default async function run() {
 		const responses = (invocations.results ?? []).map((row) =>
 			JSON.parse(String(row['response_json'])),
 		) as Array<{ status: number; body: Record<string, unknown> }>
+		const outboundMessages = await listEmailMessages({
+			db: env.APP_DB,
+			userId,
+			direction: 'outbound',
+			limit: 10,
+		})
 		expect(invocations.results?.map((row) => row['export_name'])).toEqual([
 			'subscription:email.message.received',
 			'subscription:email.message.received',
@@ -661,6 +727,8 @@ export default async function run() {
 				eventType: 'received',
 				textBody: 'Stored body.\n',
 				attachmentText: 'Attachment text\n',
+				agentReplyText: 'Thanks for the email.',
+				replyDirection: 'outbound',
 			},
 		})
 		expect(responses[1]?.body).toMatchObject({
@@ -669,11 +737,34 @@ export default async function run() {
 				eventType: 'received',
 				textBody: 'Approved body.\n',
 				attachmentText: null,
+				agentReplyText: 'Thanks for the email.',
+				replyDirection: 'outbound',
 			},
 		})
+		expect(beginAgentTurnSpy).toHaveBeenCalledTimes(2)
+		expect(collectAgentTurnEventsSpy).toHaveBeenCalledTimes(2)
+		expect(outboundMessages).toHaveLength(2)
+		expect(outboundMessages.map((message) => message.fromAddress)).toEqual([
+			replyFrom,
+			replyFrom,
+		])
+		expect(outboundMessages.map((message) => message.processingStatus)).toEqual(
+			['pending', 'pending'],
+		)
+		expect(outboundMessages.map((message) => message.subject)).toEqual([
+			'Re: Stored mail',
+			'Re: Approved sender',
+		])
+		expect(outboundMessages.map((message) => message.textBody)).toEqual([
+			'Thanks for the email.',
+			'Thanks for the email.',
+		])
 	} finally {
+		beginAgentTurnSpy.mockRestore()
+		collectAgentTurnEventsSpy.mockRestore()
 		Object.assign(env, {
 			BUNDLE_ARTIFACTS_KV: originalKv,
+			EMAIL: originalEmailBinding,
 		})
 	}
 })

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -166,10 +166,22 @@ const email = {
     if (!normalizedAttachmentId) {
       throw new Error('email.getAttachment requires a non-empty attachment id.')
     }
-    return await codemode.email_attachment_get({
+    const result = await codemode.email_attachment_get({
       attachment_id: normalizedAttachmentId,
     });
+    if (!result || typeof result !== 'object') {
+      return result;
+    }
+    if ('content_base64' in result) {
+      return result;
+    }
+    return {
+      ...result,
+      content_base64:
+        typeof result.data_base64 === 'string' ? result.data_base64 : null,
+    };
   },
+  reply: async (input) => await codemode.email_reply(input ?? {}),
 };
 	`.trim()
 }
@@ -297,20 +309,35 @@ export async function buildCodemodeFns(
 	const emailTools = options?.emailTools
 	const emailCodemodeTools: AdditionalCodemodeTools = emailTools
 		? {
-				email_message_get: async (args: unknown) => {
-					const messageId =
-						typeof args === 'object' && args !== null && 'message_id' in args
-							? String((args as { message_id: unknown }).message_id ?? '')
-							: ''
-					return await emailTools.getMessage(messageId)
-				},
-				email_attachment_get: async (args: unknown) => {
-					const attachmentId =
-						typeof args === 'object' && args !== null && 'attachment_id' in args
-							? String((args as { attachment_id: unknown }).attachment_id ?? '')
-							: ''
-					return await emailTools.getAttachment(attachmentId)
-				},
+				...(capabilityMap.email_message_get
+					? {}
+					: {
+							email_message_get: async (args: unknown) => {
+								const messageId =
+									typeof args === 'object' &&
+									args !== null &&
+									'message_id' in args
+										? String((args as { message_id: unknown }).message_id ?? '')
+										: ''
+								return await emailTools.getMessage(messageId)
+							},
+						}),
+				...(capabilityMap.email_attachment_get
+					? {}
+					: {
+							email_attachment_get: async (args: unknown) => {
+								const attachmentId =
+									typeof args === 'object' &&
+									args !== null &&
+									'attachment_id' in args
+										? String(
+												(args as { attachment_id: unknown }).attachment_id ??
+													'',
+											)
+										: ''
+								return await emailTools.getAttachment(attachmentId)
+							},
+						}),
 			}
 		: {}
 	assertNoCapabilityCollisions(capabilityMap, emailCodemodeTools)
@@ -487,7 +514,9 @@ export async function runCodemodeWithRegistry(
 	const packageSecretsHelperPrelude = options?.packageContext
 		? createPackageSecretsHelperPrelude()
 		: ''
-	const emailHelperPrelude = options?.emailTools ? createEmailHelperPrelude() : ''
+	const emailHelperPrelude = options?.emailTools
+		? createEmailHelperPrelude()
+		: ''
 	const helperPrelude = [
 		storageHelperPrelude,
 		serviceHelperPrelude,
@@ -632,7 +661,9 @@ export async function runBundledModuleWithRegistry(
 	const packageSecretsHelperPrelude = options?.packageContext
 		? createPackageSecretsHelperPrelude()
 		: ''
-	const emailHelperPrelude = options?.emailTools ? createEmailHelperPrelude() : ''
+	const emailHelperPrelude = options?.emailTools
+		? createEmailHelperPrelude()
+		: ''
 	const wrapped = `async () => {
 ${createExecuteHelperPrelude()}
 ${storageHelperPrelude ? `${storageHelperPrelude}\n` : ''}

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -747,6 +747,65 @@ test('invokePackageExport stores export-not-found responses as terminal failures
 test('invokePackageSubscription uses the normal capability registry with package storage and source metadata intact', async () => {
 	const db = createDatabase()
 	seedPackageResolution()
+	repoMockModule.loadPackageManifestBySourceId.mockResolvedValue({
+		source: {
+			id: 'source-1',
+			user_id: 'user-123',
+			entity_kind: 'package',
+			entity_id: 'pkg-1',
+			repo_id: 'repo-1',
+			published_commit: 'commit-1',
+			indexed_commit: null,
+			manifest_path: 'package.json',
+			source_root: '/',
+			created_at: '2026-04-27T00:00:00.000Z',
+			updated_at: '2026-04-27T00:00:00.000Z',
+		},
+		manifest: {
+			name: '@kentcdodds/discord-gateway',
+			exports: {
+				'./dispatch-message-created': './src/dispatch-message-created.ts',
+			},
+			kody: {
+				id: 'discord-gateway',
+				description: 'Discord gateway helpers',
+				app: {
+					entry: './src/app.ts',
+				},
+				subscriptions: {
+					'email.message.received': {
+						handler: './src/email-message-received.ts',
+					},
+				},
+			},
+		},
+	})
+	repoMockModule.loadPublishedBundleArtifactByIdentity.mockResolvedValue({
+		row: {
+			id: 'artifact-subscription-1',
+		},
+		artifact: {
+			version: 1,
+			kind: 'module',
+			artifactName: 'subscription:email.message.received',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			entryPoint: 'src/email-message-received.ts',
+			mainModule: 'dist/subscription.js',
+			modules: {
+				'dist/subscription.js':
+					'export default async function run(){ return { ok: true } }',
+			},
+			dependencies: [],
+			packageContext: {
+				packageId: 'pkg-1',
+				kodyId: 'discord-gateway',
+				sourceId: 'source-1',
+			},
+			serviceContext: null,
+			createdAt: '2026-04-27T00:00:00.000Z',
+		},
+	})
 	repoMockModule.runBundledModuleWithRegistry.mockResolvedValue({
 		result: { ok: true },
 		logs: [],

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import { invokePackageExport } from './service.ts'
+import { invokePackageExport, invokePackageSubscription } from './service.ts'
 
 const repoMockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
@@ -742,4 +742,84 @@ test('invokePackageExport stores export-not-found responses as terminal failures
 		},
 	})
 	expect(repoMockModule.runBundledModuleWithRegistry).not.toHaveBeenCalled()
+})
+
+test('invokePackageSubscription uses the normal capability registry with package storage and source metadata intact', async () => {
+	const db = createDatabase()
+	seedPackageResolution()
+	repoMockModule.runBundledModuleWithRegistry.mockResolvedValue({
+		result: { ok: true },
+		logs: [],
+	})
+
+	const savedPackage = {
+		id: 'pkg-1',
+		userId: 'user-123',
+		name: '@kentcdodds/discord-gateway',
+		kodyId: 'discord-gateway',
+		description: 'Discord gateway helpers',
+		tags: [],
+		searchText: null,
+		sourceId: 'source-1',
+		hasApp: true,
+		createdAt: '2026-04-27T00:00:00.000Z',
+		updatedAt: '2026-04-27T00:00:00.000Z',
+	}
+
+	const response = await invokePackageSubscription({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		savedPackage,
+		topic: 'email.message.received',
+		params: {
+			event: 'email.message.received',
+			message: { id: 'message-123' },
+		},
+		idempotencyKey: 'email:message-123:pkg-1:email.message.received',
+		source: 'email',
+	})
+
+	expect(response.status).toBe(200)
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({
+			baseUrl: 'https://kody.dev',
+			user: expect.objectContaining({
+				userId: 'user-123',
+				displayName: 'package:discord-gateway',
+			}),
+			storageContext: {
+				sessionId: null,
+				appId: 'pkg-1',
+				storageId: 'package:pkg-1',
+			},
+			repoContext: expect.objectContaining({
+				sourceId: 'source-1',
+			}),
+		}),
+		expect.anything(),
+		{
+			event: 'email.message.received',
+			message: { id: 'message-123' },
+		},
+		expect.objectContaining({
+			storageTools: {
+				userId: 'user-123',
+				storageId: 'package:pkg-1',
+				writable: true,
+			},
+			packageContext: {
+				packageId: 'pkg-1',
+				kodyId: 'discord-gateway',
+				sourceId: 'source-1',
+			},
+		}),
+	)
+	const runOptions =
+		repoMockModule.runBundledModuleWithRegistry.mock.calls[0]?.[4]
+	expect(runOptions).toBeDefined()
+	expect(
+		(runOptions as { skipCapabilityRegistry?: boolean }).skipCapabilityRegistry,
+	).toBeUndefined()
 })

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -464,9 +464,7 @@ function resolveExistingInvocation(input: {
 }
 
 function resolvePackageModuleResolution(input: {
-	manifest: Awaited<
-		ReturnType<typeof loadPackageSourceBySourceId>
-	>['manifest']
+	manifest: Awaited<ReturnType<typeof loadPackageSourceBySourceId>>['manifest']
 	selector: PackageModuleSelector
 }): PackageModuleResolution {
 	switch (input.selector.kind) {
@@ -662,7 +660,6 @@ async function invokeSavedPackageModule(input: {
 			},
 			input.params,
 			{
-				skipCapabilityRegistry: true,
 				storageTools: {
 					userId: input.actor.userId,
 					storageId: buildPackageInvocationStorageId(input.savedPackage.id),
@@ -930,7 +927,8 @@ export async function invokePackageSubscription(input: {
 		return buildJsonErrorResponse({
 			status: 400,
 			code: 'missing_idempotency_key',
-			message: 'Package subscription invocations require a non-empty idempotencyKey.',
+			message:
+				'Package subscription invocations require a non-empty idempotencyKey.',
 		})
 	}
 	return await invokeSavedPackageModule({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- run package subscription handlers with the normal codemode capability registry instead of suppressing builtin capabilities
- keep `kody:runtime` email helpers available for subscription code by making the helper bridge reuse builtin email capabilities and only fall back to subscription-specific shims when needed
- add focused coverage proving `email.message.received` handlers can call `agent_chat_turn` and `email_reply`, and document the runtime context package authors receive

## Testing
- `npm run test -- packages/worker/src/package-invocations/service.node.test.ts packages/worker/src/email/inbound.workers.test.ts`
- `npm run test`
- pre-push hook passed on the final branch state, including the repo unit/workers gate and E2E: `117 passed` tests for `worker:test` and `2 passed` Playwright tests for `worker:test-e2e`

## Notes
- the change keeps the existing package-owned user context, package storage `package:<packageId>`, repo/package context, idempotency behavior, and source/topic audit metadata intact
- Discord export invocations are unchanged because only subscription execution stopped opting out of the capability registry

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cd5b52e-74fc-4fd1-8ec1-c537b8c5d7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cd5b52e-74fc-4fd1-8ec1-c537b8c5d7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

