### PR TITLE
Improve Bond bridge reliability

### DIFF
--- a/packages/home-connector/src/adapters/bond/api-client.ts
+++ b/packages/home-connector/src/adapters/bond/api-client.ts
@@ -1,3 +1,5 @@
+const defaultBondRequestTimeoutMs = 5_000
+
 function buildBondBaseUrl(host: string, port: number) {
 	const trimmed = host.replace(/\.$/, '')
 	const safePort = Number.isFinite(port) && port > 0 ? port : 80
@@ -7,14 +9,29 @@ function buildBondBaseUrl(host: string, port: number) {
 	return `http://${trimmed}:${String(safePort)}`
 }
 
+function createBondRequestTimeoutError(input: {
+	error: unknown
+	path: string
+	timeoutMs: number
+}) {
+	return new Error(
+		`Bond request timed out after ${String(input.timeoutMs)}ms for ${input.path}`,
+		{
+			cause: input.error instanceof Error ? input.error : undefined,
+		},
+	)
+}
+
 export async function bondRequestJson(input: {
 	baseUrl: string
 	path: string
 	method?: string
 	token?: string | null
 	body?: unknown
+	timeoutMs?: number
 }): Promise<unknown> {
 	const method = input.method ?? 'GET'
+	const timeoutMs = input.timeoutMs ?? defaultBondRequestTimeoutMs
 	const headers: Record<string, string> = {
 		Accept: 'application/json',
 	}
@@ -24,14 +41,27 @@ export async function bondRequestJson(input: {
 	if (input.body !== undefined && method !== 'GET' && method !== 'HEAD') {
 		headers['Content-Type'] = 'application/json'
 	}
-	const response = await fetch(`${input.baseUrl}${input.path}`, {
-		method,
-		headers,
-		body:
-			input.body === undefined || method === 'GET' || method === 'HEAD'
-				? undefined
-				: JSON.stringify(input.body),
-	})
+	let response: Response
+	try {
+		response = await fetch(`${input.baseUrl}${input.path}`, {
+			method,
+			headers,
+			signal: AbortSignal.timeout(timeoutMs),
+			body:
+				input.body === undefined || method === 'GET' || method === 'HEAD'
+					? undefined
+					: JSON.stringify(input.body),
+		})
+	} catch (error) {
+		if (error instanceof Error && error.name === 'TimeoutError') {
+			throw createBondRequestTimeoutError({
+				error,
+				path: input.path,
+				timeoutMs,
+			})
+		}
+		throw error
+	}
 	const text = await response.text()
 	let json: unknown = null
 	if (text) {

--- a/packages/home-connector/src/adapters/bond/api-client.ts
+++ b/packages/home-connector/src/adapters/bond/api-client.ts
@@ -42,6 +42,7 @@ export async function bondRequestJson(input: {
 		headers['Content-Type'] = 'application/json'
 	}
 	let response: Response
+	let text: string
 	try {
 		response = await fetch(`${input.baseUrl}${input.path}`, {
 			method,
@@ -52,6 +53,7 @@ export async function bondRequestJson(input: {
 					? undefined
 					: JSON.stringify(input.body),
 		})
+		text = await response.text()
 	} catch (error) {
 		if (error instanceof Error && error.name === 'TimeoutError') {
 			throw createBondRequestTimeoutError({
@@ -62,7 +64,6 @@ export async function bondRequestJson(input: {
 		}
 		throw error
 	}
-	const text = await response.text()
 	let json: unknown = null
 	if (text) {
 		try {

--- a/packages/home-connector/src/adapters/bond/index.node.test.ts
+++ b/packages/home-connector/src/adapters/bond/index.node.test.ts
@@ -3,7 +3,11 @@ import { createAppState } from '../../state.ts'
 import { type HomeConnectorConfig } from '../../config.ts'
 import { createHomeConnectorStorage } from '../../storage/index.ts'
 import { createBondAdapter } from './index.ts'
-import { adoptBondBridge, upsertDiscoveredBondBridges } from './repository.ts'
+import {
+	adoptBondBridge,
+	requireBondBridge,
+	upsertDiscoveredBondBridges,
+} from './repository.ts'
 
 function createConfig(): HomeConnectorConfig {
 	return {
@@ -47,6 +51,15 @@ function createTcpResetFetchError(message = 'read ECONNRESET') {
 	})
 }
 
+function mockJsonResponse(body: Record<string, unknown>) {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: {
+			'Content-Type': 'application/json',
+		},
+	})
+}
+
 test('bond falls back to the discovered IP when the stored .local host stops resolving', async () => {
 	const config = createConfig()
 	const state = createAppState()
@@ -63,12 +76,7 @@ test('bond falls back to the discovered IP when the stored .local host stops res
 			throw createDnsFetchError()
 		}
 		if (url === 'http://10.0.0.22/v2/devices/mockdev1/state') {
-			return new Response(JSON.stringify({ position: 55, _: 's' }), {
-				status: 200,
-				headers: {
-					'Content-Type': 'application/json',
-				},
-			})
+			return mockJsonResponse({ position: 55, _: 's' })
 		}
 		throw new Error(`Unexpected fetch URL: ${url}`)
 	})
@@ -101,11 +109,19 @@ test('bond falls back to the discovered IP when the stored .local host stops res
 		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST1')
 		bond.setToken('BONDTEST1', 'bond-token')
 
+		const before = bond
+			.getStatus()
+			.bridges.find((bridge) => bridge.bridgeId === 'BONDTEST1')
 		const result = await bond.getDeviceState('BONDTEST1', 'mockdev1')
+		const after = bond
+			.getStatus()
+			.bridges.find((bridge) => bridge.bridgeId === 'BONDTEST1')
 
 		expect(result).toMatchObject({
 			position: 55,
 		})
+		expect(before?.lastSeenAt).toBe('2026-04-27T21:00:00.000Z')
+		expect(after?.lastSeenAt).not.toBe(before?.lastSeenAt)
 		expect(fetchMock).toHaveBeenCalledTimes(2)
 		expect(fetchMock.mock.calls[0]?.[0]).toBe(
 			'http://zpgi01117.local/v2/devices/mockdev1/state',
@@ -134,14 +150,7 @@ test('bond retries transient TCP resets with exponential backoff when reading de
 		.fn()
 		.mockRejectedValueOnce(createTcpResetFetchError())
 		.mockRejectedValueOnce(createTcpResetFetchError('socket hang up'))
-		.mockResolvedValueOnce(
-			new Response(JSON.stringify({ position: 21, _: 's' }), {
-				status: 200,
-				headers: {
-					'Content-Type': 'application/json',
-				},
-			}),
-		)
+		.mockResolvedValueOnce(mockJsonResponse({ position: 21, _: 's' }))
 	globalThis.fetch = fetchMock as typeof fetch
 
 	try {
@@ -300,6 +309,299 @@ test('bond leaves non-network Bond API errors unwrapped and does not claim fallb
 		expect(fetchMock.mock.calls[0]?.[0]).toBe(
 			'http://zpgi01117.local/v2/devices/mockdev1/state',
 		)
+	} finally {
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
+test('bond recovers SetPosition when the action response resets but state reaches the requested position', async () => {
+	const config = createConfig()
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	const fetchMock = vi.fn(
+		async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = String(input)
+			if (
+				url === 'http://10.0.0.22/v2/devices/mockdev1' &&
+				init?.method === 'GET'
+			) {
+				return mockJsonResponse({ actions: ['Open', 'SetPosition'] })
+			}
+			if (
+				url === 'http://10.0.0.22/v2/devices/mockdev1/actions/SetPosition' &&
+				init?.method === 'PUT'
+			) {
+				throw createTcpResetFetchError()
+			}
+			if (url === 'http://10.0.0.22/v2/devices/mockdev1/state') {
+				return mockJsonResponse({ position: 40, _: 's' })
+			}
+			throw new Error(`Unexpected fetch URL: ${url}`)
+		},
+	)
+	globalThis.fetch = fetchMock as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST5',
+				bondid: 'BONDTEST5',
+				instanceName: 'Recoverable Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:20:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST5')
+		bond.setToken('BONDTEST5', 'bond-token')
+
+		const result = await bond.shadeSetPosition({
+			bridgeId: 'BONDTEST5',
+			deviceId: 'mockdev1',
+			position: 40,
+		})
+
+		expect(result).toMatchObject({
+			confirmed: true,
+			recoveredFrom: 'transient_action_network_failure',
+			state: { position: 40 },
+		})
+		expect(fetchMock).toHaveBeenCalledTimes(3)
+		expect(fetchMock.mock.calls.map((call) => String(call[0]))).toEqual([
+			'http://10.0.0.22/v2/devices/mockdev1',
+			'http://10.0.0.22/v2/devices/mockdev1/actions/SetPosition',
+			'http://10.0.0.22/v2/devices/mockdev1/state',
+		])
+	} finally {
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
+test('bond still reports SetPosition reset when follow-up state does not match', async () => {
+	const config = createConfig()
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	const fetchMock = vi.fn(
+		async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = String(input)
+			if (
+				url === 'http://10.0.0.22/v2/devices/mockdev1' &&
+				init?.method === 'GET'
+			) {
+				return mockJsonResponse({ actions: ['Open', 'SetPosition'] })
+			}
+			if (
+				url === 'http://10.0.0.22/v2/devices/mockdev1/actions/SetPosition' &&
+				init?.method === 'PUT'
+			) {
+				throw createTcpResetFetchError()
+			}
+			if (url === 'http://10.0.0.22/v2/devices/mockdev1/state') {
+				return mockJsonResponse({ position: 20, _: 's' })
+			}
+			throw new Error(`Unexpected fetch URL: ${url}`)
+		},
+	)
+	globalThis.fetch = fetchMock as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST6',
+				bondid: 'BONDTEST6',
+				instanceName: 'Unrecovered Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:25:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST6')
+		bond.setToken('BONDTEST6', 'bond-token')
+
+		await expect(
+			bond.shadeSetPosition({
+				bridgeId: 'BONDTEST6',
+				deviceId: 'mockdev1',
+				position: 40,
+			}),
+		).rejects.toThrow(
+			'Bond bridge "BONDTEST6" could not be reached while trying to invoke device mockdev1 action SetPosition',
+		)
+		expect(fetchMock).toHaveBeenCalledTimes(3)
+	} finally {
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
+test('bond preserves SetPosition reset when follow-up state read fails', async () => {
+	const config = createConfig()
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	const fetchMock = vi.fn(
+		async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = String(input)
+			if (
+				url === 'http://10.0.0.22/v2/devices/mockdev1' &&
+				init?.method === 'GET'
+			) {
+				return mockJsonResponse({ actions: ['Open', 'SetPosition'] })
+			}
+			if (
+				url === 'http://10.0.0.22/v2/devices/mockdev1/actions/SetPosition' &&
+				init?.method === 'PUT'
+			) {
+				throw createTcpResetFetchError()
+			}
+			if (url === 'http://10.0.0.22/v2/devices/mockdev1/state') {
+				throw createDnsFetchError('getaddrinfo ENOTFOUND 10.0.0.22')
+			}
+			throw new Error(`Unexpected fetch URL: ${url}`)
+		},
+	)
+	globalThis.fetch = fetchMock as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST8',
+				bondid: 'BONDTEST8',
+				instanceName: 'State-Read-Failure Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:35:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST8')
+		bond.setToken('BONDTEST8', 'bond-token')
+
+		await expect(
+			bond.shadeSetPosition({
+				bridgeId: 'BONDTEST8',
+				deviceId: 'mockdev1',
+				position: 40,
+			}),
+		).rejects.toThrow(
+			'Bond bridge "BONDTEST8" could not be reached while trying to invoke device mockdev1 action SetPosition',
+		)
+		expect(fetchMock).toHaveBeenCalledTimes(3)
+	} finally {
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
+test('bond wraps request timeouts as actionable network failures', async () => {
+	const config = createConfig()
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	globalThis.fetch = vi.fn(async () => {
+		throw new DOMException('The operation timed out.', 'TimeoutError')
+	}) as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST7',
+				bondid: 'BONDTEST7',
+				instanceName: 'Timeout Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:30:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST7')
+		bond.setToken('BONDTEST7', 'bond-token')
+
+		await expect(bond.getDeviceState('BONDTEST7', 'mockdev1')).rejects.toThrow(
+			'Bond bridge "BONDTEST7" could not be reached while trying to fetch device mockdev1 state at http://10.0.0.22. Bond request timed out after 5000ms for /v2/devices/mockdev1/state',
+		)
+	} finally {
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
+test('bond does not refresh bridge lastSeenAt after failed requests', async () => {
+	const config = createConfig()
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	globalThis.fetch = vi.fn(async () => {
+		throw createDnsFetchError()
+	}) as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST8',
+				bondid: 'BONDTEST8',
+				instanceName: 'Failed Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:35:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST8')
+		bond.setToken('BONDTEST8', 'bond-token')
+
+		await bond.getDeviceState('BONDTEST8', 'mockdev1').catch(() => null)
+
+		expect(
+			requireBondBridge(storage, config.homeConnectorId, 'BONDTEST8')
+				.lastSeenAt,
+		).toBe('2026-04-27T21:35:00.000Z')
 	} finally {
 		globalThis.fetch = previousFetch
 		storage.close()

--- a/packages/home-connector/src/adapters/bond/index.node.test.ts
+++ b/packages/home-connector/src/adapters/bond/index.node.test.ts
@@ -610,6 +610,47 @@ test('bond wraps response body timeouts as actionable network failures', async (
 	}
 })
 
+test('bond wraps abort errors as actionable network failures', async () => {
+	const config = createConfig()
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	globalThis.fetch = vi.fn(async () => {
+		throw new DOMException('The user aborted a request.', 'AbortError')
+	}) as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST10',
+				bondid: 'BONDTEST10',
+				instanceName: 'Abort Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:45:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST10')
+		bond.setToken('BONDTEST10', 'bond-token')
+
+		await expect(bond.getDeviceState('BONDTEST10', 'mockdev1')).rejects.toThrow(
+			'Bond bridge "BONDTEST10" could not be reached while trying to fetch device mockdev1 state at http://10.0.0.22. The user aborted a request.',
+		)
+	} finally {
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
 test('bond does not refresh bridge lastSeenAt after failed requests', async () => {
 	const config = createConfig()
 	const state = createAppState()

--- a/packages/home-connector/src/adapters/bond/index.node.test.ts
+++ b/packages/home-connector/src/adapters/bond/index.node.test.ts
@@ -564,6 +564,52 @@ test('bond wraps request timeouts as actionable network failures', async () => {
 	}
 })
 
+test('bond wraps response body timeouts as actionable network failures', async () => {
+	const config = createConfig()
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	globalThis.fetch = vi.fn(async () => {
+		return {
+			ok: true,
+			text: async () => {
+				throw new DOMException('The operation timed out.', 'TimeoutError')
+			},
+		} as Response
+	}) as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST9',
+				bondid: 'BONDTEST9',
+				instanceName: 'Body Timeout Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:40:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST9')
+		bond.setToken('BONDTEST9', 'bond-token')
+
+		await expect(bond.getDeviceState('BONDTEST9', 'mockdev1')).rejects.toThrow(
+			'Bond bridge "BONDTEST9" could not be reached while trying to fetch device mockdev1 state at http://10.0.0.22. Bond request timed out after 5000ms for /v2/devices/mockdev1/state',
+		)
+	} finally {
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
 test('bond does not refresh bridge lastSeenAt after failed requests', async () => {
 	const config = createConfig()
 	const state = createAppState()

--- a/packages/home-connector/src/adapters/bond/index.ts
+++ b/packages/home-connector/src/adapters/bond/index.ts
@@ -183,9 +183,12 @@ function isBondNetworkFailure(error: unknown) {
 	if (!(error instanceof Error)) {
 		return false
 	}
+	const errorName = error.name.toLowerCase()
+	if (errorName === 'aborterror' || errorName === 'timeouterror') {
+		return true
+	}
 	const message = error.message.toLowerCase()
 	if (
-		message.includes('aborterror') ||
 		message.includes('bond request timed out') ||
 		message.includes('fetch failed') ||
 		message.includes('enotfound') ||

--- a/packages/home-connector/src/adapters/bond/index.ts
+++ b/packages/home-connector/src/adapters/bond/index.ts
@@ -24,6 +24,7 @@ import {
 	requireBondBridge,
 	saveBondToken,
 	updateBondBridgeConnection,
+	updateBondBridgeLastSeen,
 	upsertDiscoveredBondBridges,
 } from './repository.ts'
 import {
@@ -184,6 +185,8 @@ function isBondNetworkFailure(error: unknown) {
 	}
 	const message = error.message.toLowerCase()
 	if (
+		message.includes('aborterror') ||
+		message.includes('bond request timed out') ||
 		message.includes('fetch failed') ||
 		message.includes('enotfound') ||
 		message.includes('eai_again') ||
@@ -202,7 +205,8 @@ function isBondNetworkFailure(error: unknown) {
 		causeMessage.includes('econnreset') ||
 		causeMessage.includes('ehostunreach') ||
 		causeMessage.includes('etimedout') ||
-		causeMessage.includes('getaddrinfo')
+		causeMessage.includes('getaddrinfo') ||
+		causeMessage.includes('the operation was aborted')
 	)
 }
 
@@ -216,6 +220,28 @@ function isBondTransientNetworkFailure(error: unknown) {
 	return messages.some(
 		(message) =>
 			message.includes('econnreset') || message.includes('socket hang up'),
+	)
+}
+
+function getBondNumericStateValue(state: Record<string, unknown>, key: string) {
+	const rawValue = state[key]
+	if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+		return rawValue
+	}
+	if (typeof rawValue === 'string' && rawValue.trim()) {
+		const parsed = Number(rawValue)
+		return Number.isFinite(parsed) ? parsed : null
+	}
+	return null
+}
+
+function isBondPositionStateReached(
+	state: Record<string, unknown>,
+	position: number,
+) {
+	const statePosition = getBondNumericStateValue(state, 'position')
+	return (
+		statePosition != null && Math.round(statePosition) === Math.round(position)
 	)
 }
 
@@ -340,6 +366,23 @@ export function createBondAdapter(input: {
 }) {
 	const connectorId = input.config.homeConnectorId
 
+	function markBridgeSeen(bridge: BondPersistedBridge) {
+		updateBondBridgeLastSeen({
+			storage: input.storage,
+			connectorId,
+			bridgeId: bridge.bridgeId,
+			lastSeenAt: new Date().toISOString(),
+		})
+	}
+
+	async function withTrackedBondBridgeRequest<T>(
+		requestInput: Parameters<typeof withBondBridgeRequest<T>>[0],
+	) {
+		const result = await withBondBridgeRequest(requestInput)
+		markBridgeSeen(requestInput.bridge)
+		return result
+	}
+
 	function listPublicBridges(): Array<BondPersistedBridge> {
 		return listBondBridges(input.storage, connectorId)
 	}
@@ -429,7 +472,7 @@ export function createBondAdapter(input: {
 		bridge: BondPersistedBridge,
 		token: string,
 	) {
-		return await withBondBridgeRequest({
+		return await withTrackedBondBridgeRequest({
 			bridge,
 			operation: 'list devices',
 			request: async (baseUrl) => {
@@ -493,7 +536,7 @@ export function createBondAdapter(input: {
 		},
 		async fetchBridgeVersion(bridgeId?: string) {
 			const bridge = resolveBridge(bridgeId)
-			return await withBondBridgeRequest({
+			return await withTrackedBondBridgeRequest({
 				bridge,
 				operation: 'fetch bridge version',
 				request: async (baseUrl) => await bondGetSysVersion({ baseUrl }),
@@ -506,7 +549,7 @@ export function createBondAdapter(input: {
 				connectorId,
 				bridge.bridgeId,
 			)
-			const raw = (await withBondBridgeRequest({
+			const raw = (await withTrackedBondBridgeRequest({
 				bridge,
 				operation: 'read token status',
 				request: async (baseUrl) =>
@@ -521,7 +564,7 @@ export function createBondAdapter(input: {
 			const bridge = bridgeId
 				? requireBondBridge(input.storage, connectorId, bridgeId)
 				: resolveBridge()
-			const raw = (await withBondBridgeRequest({
+			const raw = (await withTrackedBondBridgeRequest({
 				bridge,
 				operation: 'retrieve token from bridge',
 				request: async (baseUrl) =>
@@ -558,7 +601,7 @@ export function createBondAdapter(input: {
 		): Promise<Record<string, unknown>> {
 			const bridge = requireAdoptedBridge(bridgeId)
 			const token = requireToken(bridge)
-			return await withBondBridgeRequest({
+			return await withTrackedBondBridgeRequest({
 				bridge,
 				operation: `fetch device ${deviceId}`,
 				request: async (baseUrl) =>
@@ -575,7 +618,7 @@ export function createBondAdapter(input: {
 		): Promise<Record<string, unknown>> {
 			const bridge = requireAdoptedBridge(bridgeId)
 			const token = requireToken(bridge)
-			return await withBondBridgeRequest({
+			return await withTrackedBondBridgeRequest({
 				bridge,
 				operation: `fetch device ${deviceId} state`,
 				maxTransientAttemptsPerBaseUrl: defaultBondTransientAttemptsPerBaseUrl,
@@ -602,7 +645,7 @@ export function createBondAdapter(input: {
 				input.deviceId,
 				input.deviceName,
 			)
-			const doc = await withBondBridgeRequest({
+			const doc = await withTrackedBondBridgeRequest({
 				bridge,
 				operation: `fetch device ${deviceId} before action`,
 				request: async (baseUrl) =>
@@ -624,18 +667,44 @@ export function createBondAdapter(input: {
 					`Device "${deviceId}" does not advertise action "${input.action}".`,
 				)
 			}
-			return await withBondBridgeRequest({
-				bridge,
-				operation: `invoke device ${deviceId} action ${input.action}`,
-				request: async (baseUrl) =>
-					await bondInvokeDeviceAction({
-						baseUrl,
-						token,
-						deviceId,
-						action: input.action,
-						argument: input.argument,
-					}),
-			})
+			const operation = `invoke device ${deviceId} action ${input.action}`
+			try {
+				return await withTrackedBondBridgeRequest({
+					bridge,
+					operation,
+					request: async (baseUrl) =>
+						await bondInvokeDeviceAction({
+							baseUrl,
+							token,
+							deviceId,
+							action: input.action,
+							argument: input.argument,
+						}),
+				})
+			} catch (error) {
+				if (
+					input.action === 'SetPosition' &&
+					typeof input.argument === 'number' &&
+					isBondTransientNetworkFailure(error)
+				) {
+					try {
+						const state = await bondApi.getDeviceState(
+							bridge.bridgeId,
+							deviceId,
+						)
+						if (isBondPositionStateReached(state, input.argument)) {
+							return {
+								confirmed: true,
+								recoveredFrom: 'transient_action_network_failure',
+								state,
+							}
+						}
+					} catch {
+						// Preserve the action failure; the follow-up read is only diagnostic.
+					}
+				}
+				throw error
+			}
 		},
 		async shadeOpen(input: {
 			bridgeId?: string
@@ -690,7 +759,7 @@ export function createBondAdapter(input: {
 		async listGroups(bridgeId?: string) {
 			const bridge = requireAdoptedBridge(bridgeId)
 			const token = requireToken(bridge)
-			return await withBondBridgeRequest({
+			return await withTrackedBondBridgeRequest({
 				bridge,
 				operation: 'list groups',
 				request: async (baseUrl) => {
@@ -705,7 +774,7 @@ export function createBondAdapter(input: {
 		async getGroup(bridgeId: string | undefined, groupId: string) {
 			const bridge = requireAdoptedBridge(bridgeId)
 			const token = requireToken(bridge)
-			return await withBondBridgeRequest({
+			return await withTrackedBondBridgeRequest({
 				bridge,
 				operation: `fetch group ${groupId}`,
 				request: async (baseUrl) =>
@@ -719,7 +788,7 @@ export function createBondAdapter(input: {
 		async getGroupState(bridgeId: string | undefined, groupId: string) {
 			const bridge = requireAdoptedBridge(bridgeId)
 			const token = requireToken(bridge)
-			return await withBondBridgeRequest({
+			return await withTrackedBondBridgeRequest({
 				bridge,
 				operation: `fetch group ${groupId} state`,
 				request: async (baseUrl) =>
@@ -738,7 +807,7 @@ export function createBondAdapter(input: {
 		}) {
 			const bridge = requireAdoptedBridge(input.bridgeId)
 			const token = requireToken(bridge)
-			const doc = await withBondBridgeRequest({
+			const doc = await withTrackedBondBridgeRequest({
 				bridge,
 				operation: `fetch group ${input.groupId} before action`,
 				request: async (baseUrl) =>
@@ -760,7 +829,7 @@ export function createBondAdapter(input: {
 					`Group "${input.groupId}" does not advertise action "${input.action}".`,
 				)
 			}
-			return await withBondBridgeRequest({
+			return await withTrackedBondBridgeRequest({
 				bridge,
 				operation: `invoke group ${input.groupId} action ${input.action}`,
 				request: async (baseUrl) =>

--- a/packages/home-connector/src/adapters/bond/repository.ts
+++ b/packages/home-connector/src/adapters/bond/repository.ts
@@ -297,3 +297,20 @@ export function updateBondBridgeConnection(
 		.run(input.host, port, connectorId, bridgeId)
 	return requireBondBridge(storage, connectorId, bridgeId)
 }
+
+export function updateBondBridgeLastSeen(input: {
+	storage: HomeConnectorStorage
+	connectorId: string
+	bridgeId: string
+	lastSeenAt: string
+}) {
+	input.storage.db
+		.query(
+			`
+		UPDATE bond_bridges
+		SET last_seen_at = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE connector_id = ? AND bridge_id = ?
+	`,
+		)
+		.run(input.lastSeenAt, input.connectorId, input.bridgeId)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add explicit timeouts for Bond API fetches and classify timeout/abort failures as Bond network failures, including timeouts that occur while consuming the response body.
- Refresh Bond bridge `lastSeenAt` after successful API requests so status reflects live reachability, not only discovery.
- Recover `SetPosition` actions after transient network resets when a follow-up state read confirms the requested shade position.
- Add focused Bond adapter tests for timeout wrapping, response body timeout wrapping, raw abort wrapping, `lastSeenAt` freshness, and `SetPosition` recovery/failure paths.

## Testing
- `npm --prefix packages/home-connector test -- src/adapters/bond/index.node.test.ts`
- `npm run format:check -- packages/home-connector/src/adapters/bond/index.ts packages/home-connector/src/adapters/bond/index.node.test.ts`
- `npm run lint -- packages/home-connector/src/adapters/bond/index.ts packages/home-connector/src/adapters/bond/index.node.test.ts` (passes with existing repo warnings outside this change)
- Earlier on this branch: `npm run typecheck` (blocked by existing `postal-mime` worker email errors outside this change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b07086e-030a-4811-a69f-0cfdd31563f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b07086e-030a-4811-a69f-0cfdd31563f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



Resolves KODY-HOME-CONNECTOR-9