### PR TITLE
Preserve schema descriptions in capability type output

### DIFF
--- a/packages/worker/src/mcp/capabilities/capability-search.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.workers.test.ts
@@ -153,6 +153,13 @@ test('detailed capability search includes schemas only when requested', async ()
 		AI: {} as Ai,
 	} as Env
 
+	const defaultDetail = await searchCapabilities({
+		env,
+		query: 'guide',
+		limit: 1,
+		detail: true,
+		specs,
+	})
 	const { matches } = await searchCapabilities({
 		env,
 		query: 'guide',
@@ -162,6 +169,10 @@ test('detailed capability search includes schemas only when requested', async ()
 		specs,
 	})
 
+	expect(defaultDetail.matches[0]).not.toHaveProperty('inputSchema')
+	expect(defaultDetail.matches[0]).toMatchObject({
+		inputTypeDefinition: expect.stringContaining('KodyOfficialGuideInput'),
+	})
 	expect(matches[0]).toMatchObject({
 		inputSchema: expect.objectContaining({
 			properties: expect.objectContaining({

--- a/packages/worker/src/mcp/capabilities/schema-type-definitions.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/schema-type-definitions.node.test.ts
@@ -25,3 +25,45 @@ test('parenthesizes union members when composing allOf intersections', () => {
 		'type IntersectedInput = (string | number) & {\n\tid: string\n}',
 	)
 })
+
+test('preserves JSON Schema descriptions as type comments', () => {
+	const typeDefinition = createSchemaTypeDefinition({
+		typeName: 'CreateIssueInput',
+		jsonSchema: {
+			type: 'object',
+			description: 'Input for creating an issue.',
+			properties: {
+				owner: {
+					type: 'string',
+					description: 'Repository owner.',
+				},
+				repo: {
+					type: 'string',
+					description: 'Repository name.\nMay include dashes.',
+				},
+				body: {
+					type: 'string',
+					description: 'Issue body with a closing marker */ inside.',
+				},
+			},
+			required: ['owner', 'repo'],
+		} as CapabilityJsonSchema,
+	})
+
+	expect(typeDefinition).toBe(
+		[
+			'/** Input for creating an issue. */',
+			'type CreateIssueInput = {',
+			'\t/** Repository owner. */',
+			'\towner: string',
+			'\t/**',
+			'\t * Repository name.',
+			'\t * May include dashes.',
+			'\t */',
+			'\trepo: string',
+			'\t/** Issue body with a closing marker * / inside. */',
+			'\tbody?: string',
+			'}',
+		].join('\n'),
+	)
+})

--- a/packages/worker/src/mcp/capabilities/schema-type-definitions.ts
+++ b/packages/worker/src/mcp/capabilities/schema-type-definitions.ts
@@ -29,7 +29,9 @@ function createJsonSchemaTypeDefinition(
 	schema: CapabilityJsonSchema,
 	typeName: string,
 ) {
-	return `type ${typeName} = ${jsonSchemaToType(schema)}`
+	const description = isRecord(schema) ? readDescription(schema) : undefined
+	const comment = description ? `${formatComment(description)}\n` : ''
+	return `${comment}type ${typeName} = ${jsonSchemaToType(schema)}`
 }
 
 function jsonSchemaToType(schema: unknown): string {
@@ -121,7 +123,15 @@ function objectSchemaToType(schema: Record<string, unknown>) {
 
 	const lines = propertyEntries.map(([name, propertySchema]) => {
 		const optional = required.has(name) ? '' : '?'
-		return `\t${formatPropertyName(name)}${optional}: ${jsonSchemaToType(propertySchema)}`
+		const propertyDescription = isRecord(propertySchema)
+			? readDescription(propertySchema)
+			: undefined
+		return [
+			...(propertyDescription
+				? [formatComment(propertyDescription, { indent: '\t' })]
+				: []),
+			`\t${formatPropertyName(name)}${optional}: ${jsonSchemaToType(propertySchema)}`,
+		].join('\n')
 	})
 	if (isRecord(additionalProperties)) {
 		lines.push(`\t[key: string]: ${jsonSchemaToType(additionalProperties)}`)
@@ -144,6 +154,34 @@ function literalToType(value: unknown): string {
 		default:
 			return value === null ? 'null' : 'unknown'
 	}
+}
+
+function readDescription(schema: Record<string, unknown>) {
+	const description = schema.description
+	return typeof description === 'string' && description.trim()
+		? description.trim()
+		: undefined
+}
+
+function formatComment(
+	description: string,
+	options?: {
+		indent?: string
+	},
+) {
+	const indent = options?.indent ?? ''
+	const lines = description
+		.replaceAll('*/', '* /')
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+	if (lines.length === 1) {
+		return `${indent}/** ${lines[0]} */`
+	}
+	return [
+		`${indent}/**`,
+		...lines.map((line) => `${indent} * ${line}`),
+		`${indent} */`,
+	].join('\n')
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -215,10 +215,22 @@ test('capability entity detail keeps type definitions stable and adds schemas on
 			inputSchema: {
 				type: 'object',
 				properties: {
-					owner: { type: 'string' },
-					repo: { type: 'string' },
-					title: { type: 'string' },
-					body: { type: 'string' },
+					owner: {
+						type: 'string',
+						description: 'Repository owner.',
+					},
+					repo: {
+						type: 'string',
+						description: 'Repository name.',
+					},
+					title: {
+						type: 'string',
+						description: 'Issue title.',
+					},
+					body: {
+						type: 'string',
+						description: 'Optional issue body.',
+					},
 				},
 				required: ['owner', 'repo', 'title'],
 			},
@@ -230,7 +242,7 @@ test('capability entity detail keeps type definitions stable and adds schemas on
 				required: ['issueUrl'],
 			},
 			inputTypeDefinition:
-				'type GithubCreateIssueInput = {\n\towner: string\n\trepo: string\n\ttitle: string\n\tbody?: string\n}',
+				'type GithubCreateIssueInput = {\n\t/** Repository owner. */\n\towner: string\n\t/** Repository name. */\n\trepo: string\n\t/** Issue title. */\n\ttitle: string\n\t/** Optional issue body. */\n\tbody?: string\n}',
 			outputTypeDefinition:
 				'type GithubCreateIssueOutput = {\n\tissueUrl: string\n}',
 		},
@@ -255,10 +267,22 @@ test('capability entity detail keeps type definitions stable and adds schemas on
 				inputSchema: {
 					type: 'object',
 					properties: {
-						owner: { type: 'string' },
-						repo: { type: 'string' },
-						title: { type: 'string' },
-						body: { type: 'string' },
+						owner: {
+							type: 'string',
+							description: 'Repository owner.',
+						},
+						repo: {
+							type: 'string',
+							description: 'Repository name.',
+						},
+						title: {
+							type: 'string',
+							description: 'Issue title.',
+						},
+						body: {
+							type: 'string',
+							description: 'Optional issue body.',
+						},
 					},
 					required: ['owner', 'repo', 'title'],
 				},
@@ -270,7 +294,7 @@ test('capability entity detail keeps type definitions stable and adds schemas on
 					required: ['issueUrl'],
 				},
 				inputTypeDefinition:
-					'type GithubCreateIssueInput = {\n\towner: string\n\trepo: string\n\ttitle: string\n\tbody?: string\n}',
+					'type GithubCreateIssueInput = {\n\t/** Repository owner. */\n\towner: string\n\t/** Repository name. */\n\trepo: string\n\t/** Issue title. */\n\ttitle: string\n\t/** Optional issue body. */\n\tbody?: string\n}',
 				outputTypeDefinition:
 					'type GithubCreateIssueOutput = {\n\tissueUrl: string\n}',
 			},
@@ -280,6 +304,7 @@ test('capability entity detail keeps type definitions stable and adds schemas on
 
 	expect(detail.markdown).not.toContain('## Input schema')
 	expect(detail.markdown).not.toContain('## Output schema')
+	expect(detail.markdown).toContain('/** Repository owner. */\n\towner: string')
 	expect(detail.structured).toMatchObject({
 		type: 'capability',
 		inputTypeDefinition: expect.any(String),
@@ -406,7 +431,9 @@ test('package search formatting keeps runnable package actions in markdown and s
 		],
 	})
 
-	expect(markdown).toContain('open_generated_ui({ kody_id: "spotify-playback" })')
+	expect(markdown).toContain(
+		'open_generated_ui({ kody_id: "spotify-playback" })',
+	)
 	const [packageMatch] = toSlimStructuredMatches({
 		baseUrl: 'http://localhost',
 		matches: [
@@ -537,7 +564,8 @@ test('usage helpers escape dynamic identifiers in generated snippets', () => {
 
 	expect(valueMatch).toMatchObject({
 		type: 'value',
-		usage: 'codemode.value_get({ name: "display\\"name", scope: "user\\"scope" })',
+		usage:
+			'codemode.value_get({ name: "display\\"name", scope: "user\\"scope" })',
 	})
 	expect(connectorMatch).toMatchObject({
 		type: 'connector',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Render JSON Schema `description` fields as JSDoc comments in generated capability TypeScript type definitions.
- Keep capability detail schemas hidden by default while preserving `includeSchemas: true` for raw schema output.
- Add focused tests for description comments, capability search detail defaults, and entity detail formatting.

### Testing
- `npm test -- --run packages/worker/src/mcp/capabilities/schema-type-definitions.node.test.ts packages/worker/src/mcp/capabilities/capability-search.workers.test.ts packages/worker/src/mcp/tools/search-format.node.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npx oxfmt --check packages/worker/src/mcp/capabilities/schema-type-definitions.ts packages/worker/src/mcp/capabilities/schema-type-definitions.node.test.ts packages/worker/src/mcp/capabilities/capability-search.workers.test.ts packages/worker/src/mcp/tools/search-format.node.test.ts`
- `git diff --check`
- Pre-push hook: `npm run test:push`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2631224d-e2eb-49de-a5d4-8a65c2c82a2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2631224d-e2eb-49de-a5d4-8a65c2c82a2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated TypeScript types now include JSDoc documentation comments derived from schema descriptions.
  * Capability search results now support detailed information with improved schema handling.

* **Tests**
  * Added tests for JSDoc comment generation and multi-line description handling.
  * Enhanced capability search and schema output validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->