### PR TITLE
Support named package exports and metadata

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -33,7 +33,8 @@ and export a default function. These helpers are runtime exports:
 - package service runs may also declare **`kody.services.<name>.timeoutMs`** in
   `package.json` when they need a longer executor budget than the default
   package-service timeout
-- use **`import thing from 'kody:@scope/my-package/export-name'`** to reuse a
+- use **`import thing from 'kody:@scope/my-package/export-name'`** or
+  **`import { helper } from 'kody:@scope/my-package/export-name'`** to reuse a
   saved package export by full package name
 
 **execute** also accepts optional **`params`**. Kody passes that JSON object to
@@ -108,22 +109,22 @@ cache-hint form for prompts with a stable prefix:
 
 ```ts
 await codemode.agent_chat_turn({
-  sessionId: 'email-follow-up',
-  system: {
-    content: stableSystemPrompt,
-    cache: 'prefix',
-  },
-  messages: [
-    {
-      role: 'user',
-      content: normalizedThreadContext,
-      cache: 'prefix',
-    },
-    {
-      role: 'user',
-      content: latestInboundEmail,
-    },
-  ],
+	sessionId: 'email-follow-up',
+	system: {
+		content: stableSystemPrompt,
+		cache: 'prefix',
+	},
+	messages: [
+		{
+			role: 'user',
+			content: normalizedThreadContext,
+			cache: 'prefix',
+		},
+		{
+			role: 'user',
+			content: latestInboundEmail,
+		},
+	],
 })
 ```
 

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -47,9 +47,15 @@ For predictable package resolution, saved packages must use a scoped
 
 - Cross-package imports use the full package name such as
   `kody:@scope/my-package/export-name`.
-- Callable exports are exports whose resolved module default export is a
-  function.
+- Exports are normal modules. They may expose a default export, named exports,
+  or both.
+- Direct package invocation calls the resolved module's default export when that
+  export is a function. Importing a package from `execute` or another package
+  can use any named exports that the module provides.
 - Packages may also export non-callable helper modules and values for reuse.
+- Add JSDoc to exported functions and, when helpful, point the export at a
+  `types` file. Package search detail surfaces package descriptions, export
+  descriptions, function signatures, JSDoc, and type definitions.
 
 ## Package apps
 

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -354,8 +354,11 @@ test('entity detail formatting includes package app, export, and job metadata', 
 		},
 		files: {
 			'package.json': '{}',
-			'src/app.d.ts':
-				'export default function fetch(request: Request): Promise<Response>\n',
+			'src/app.d.ts': `/**
+ * Render the observed app.
+ */
+export declare function fetch(request: Request): Promise<Response>
+`,
 		},
 	})
 
@@ -376,7 +379,15 @@ test('entity detail formatting includes package app, export, and job metadata', 
 			expect.objectContaining({
 				subpath: './app',
 				typesSource:
-					'export default function fetch(request: Request): Promise<Response>\n',
+					'/**\n * Render the observed app.\n */\nexport declare function fetch(request: Request): Promise<Response>\n',
+				functions: [
+					{
+						name: 'fetch',
+						description: 'Render the observed app.',
+						typeDefinition:
+							'export declare function fetch(request: Request): Promise<Response>',
+					},
+				],
 			}),
 		],
 		jobs: [
@@ -386,6 +397,10 @@ test('entity detail formatting includes package app, export, and job metadata', 
 			}),
 		],
 	})
+	expect(packageDetail.markdown).toContain('Render the observed app\\.')
+	expect(packageDetail.markdown).toContain(
+		'export declare function fetch(request: Request): Promise<Response>',
+	)
 })
 
 test('package search formatting keeps runnable package actions in markdown and structured output', () => {
@@ -406,7 +421,9 @@ test('package search formatting keeps runnable package actions in markdown and s
 		],
 	})
 
-	expect(markdown).toContain('open_generated_ui({ kody_id: "spotify-playback" })')
+	expect(markdown).toContain(
+		'open_generated_ui({ kody_id: "spotify-playback" })',
+	)
 	const [packageMatch] = toSlimStructuredMatches({
 		baseUrl: 'http://localhost',
 		matches: [
@@ -537,7 +554,8 @@ test('usage helpers escape dynamic identifiers in generated snippets', () => {
 
 	expect(valueMatch).toMatchObject({
 		type: 'value',
-		usage: 'codemode.value_get({ name: "display\\"name", scope: "user\\"scope" })',
+		usage:
+			'codemode.value_get({ name: "display\\"name", scope: "user\\"scope" })',
 	})
 	expect(connectorMatch).toMatchObject({
 		type: 'connector',

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -8,6 +8,7 @@ import {
 	type PackageJobSchedule,
 	type SavedPackageRecord,
 } from '#worker/package-registry/types.ts'
+import { buildPackageSearchProjection } from '#worker/package-registry/manifest.ts'
 import { type PackageRetrieverSurfaceResult } from '#worker/package-retrievers/types.ts'
 import {
 	escapeMarkdownText,
@@ -205,6 +206,13 @@ export type SearchEntityDetailStructured =
 				importSpecifier: string
 				runtimeTarget: string | null
 				typesPath: string | null
+				description: string | null
+				typeDefinition: string | null
+				functions: Array<{
+					name: string
+					description: string | null
+					typeDefinition: string | null
+				}>
 				typesSource: string | null
 			}>
 			jobs: Array<{
@@ -375,6 +383,10 @@ function buildCapabilityUsage(name: string) {
 
 function buildPackageRootImportUsage(packageName: string) {
 	return `import entry from ${JSON.stringify(buildPackageImportSpecifier(packageName, '.'))}`
+}
+
+function formatInlineTypeDefinition(typeDefinition: string) {
+	return typeDefinition.replace(/\s+/g, ' ').trim()
 }
 
 function buildPackageAppUsage(kodyId: string) {
@@ -800,30 +812,21 @@ export function formatEntityDetailMarkdown(
 	}
 
 	if (detail.type === 'package') {
-		const exportDetails = Object.entries(detail.manifest.exports).map(
-			([exportName, target]) => {
-				const runtimeTarget =
-					typeof target === 'string'
-						? target
-						: (target.import ?? target.default ?? null)
-				const typesPath =
-					typeof target === 'string' ? null : (target.types ?? null)
-				const typesSource =
-					typesPath == null
-						? null
-						: (detail.files[typesPath.replace(/^\.?\//, '')] ?? null)
-				return {
-					subpath: exportName,
-					importSpecifier: buildPackageImportSpecifier(
-						detail.record.name,
-						exportName,
-					),
-					runtimeTarget,
-					typesPath,
-					typesSource,
-				}
-			},
+		const exportProjection = buildPackageSearchProjection(
+			detail.manifest,
+			detail.files,
 		)
+		const exportDetails = exportProjection.exports.map((exportDetail) => ({
+			...exportDetail,
+			importSpecifier: buildPackageImportSpecifier(
+				detail.record.name,
+				exportDetail.subpath,
+			),
+			typesSource:
+				exportDetail.typesPath == null
+					? null
+					: (detail.files[exportDetail.typesPath] ?? null),
+		}))
 		const jobs = Object.entries(detail.manifest.kody.jobs ?? {}).map(
 			([jobName, job]) => ({
 				name: jobName,
@@ -874,6 +877,18 @@ export function formatEntityDetailMarkdown(
 				lines.push(
 					`- \`${exportDetail.subpath}\` -> \`${exportDetail.importSpecifier}\`${exportDetail.runtimeTarget ? ` (runtime target: \`${exportDetail.runtimeTarget}\`)` : ''}${exportDetail.typesPath ? ` (types: \`${exportDetail.typesPath}\`)` : ''}`,
 				)
+				for (const exportedFunction of exportDetail.functions) {
+					if (exportedFunction.description) {
+						lines.push(
+							`  - ${escapeMarkdownText(exportedFunction.description)}`,
+						)
+					}
+					if (exportedFunction.typeDefinition) {
+						lines.push(
+							`  - \`${formatInlineTypeDefinition(exportedFunction.typeDefinition)}\``,
+						)
+					}
+				}
 				if (exportDetail.typesSource) {
 					lines.push('', '  Type definitions:', '', '  ```ts')
 					lines.push(

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
 import { synthesizeRemoteToolDomain } from '#mcp/capabilities/home/index.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
@@ -12,6 +12,24 @@ import {
 	type OptionalSearchRowsResult,
 	type PackageSearchRow,
 } from './search.ts'
+
+const sourceMocks = vi.hoisted(() => ({
+	loadPackageManifestBySourceId: vi.fn(),
+	loadPackageSourceBySourceId: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/source.ts', async () => {
+	const actual = await vi.importActual<
+		typeof import('#worker/package-registry/source.ts')
+	>('#worker/package-registry/source.ts')
+	return {
+		...actual,
+		loadPackageManifestBySourceId: (...args: Array<unknown>) =>
+			sourceMocks.loadPackageManifestBySourceId(...args),
+		loadPackageSourceBySourceId: (...args: Array<unknown>) =>
+			sourceMocks.loadPackageSourceBySourceId(...args),
+	}
+})
 
 test('searchUnified ranks mixed search rows through one shared pipeline', async () => {
 	const registry = buildCapabilityRegistry([

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -13,6 +13,17 @@ import {
 	type PackageSearchRow,
 } from './search.ts'
 
+function createPackageExportProjection(subpath: string) {
+	return {
+		subpath,
+		runtimeTarget: null,
+		typesPath: null,
+		description: null,
+		typeDefinition: null,
+		functions: [],
+	}
+}
+
 const sourceMocks = vi.hoisted(() => ({
 	loadPackageManifestBySourceId: vi.fn(),
 	loadPackageSourceBySourceId: vi.fn(),
@@ -347,7 +358,7 @@ test('optional search rows include saved packages when lookup succeeds', async (
 					searchText: null,
 					hasApp: true,
 					appEntry: 'src/app.ts',
-					exports: ['.'],
+					exports: [createPackageExportProjection('.')],
 					jobs: [],
 					services: [],
 					subscriptions: [],
@@ -439,11 +450,11 @@ test('searchUnified ranks related packages and connectors for operate queries', 
 					hasApp: true,
 					appEntry: 'src/app/server.ts',
 					exports: [
-						'./playback-state',
-						'./play-pause',
-						'./transfer-playback',
-						'./add-to-queue',
-						'./playback-controller',
+						createPackageExportProjection('./playback-state'),
+						createPackageExportProjection('./play-pause'),
+						createPackageExportProjection('./transfer-playback'),
+						createPackageExportProjection('./add-to-queue'),
+						createPackageExportProjection('./playback-controller'),
 					],
 					jobs: [],
 					services: [],
@@ -570,7 +581,7 @@ test('search guidance does not pair unrelated package and connector matches', as
 						searchText: 'music remote package',
 						hasApp: true,
 						appEntry: 'src/app.ts',
-						exports: ['./play'],
+						exports: [createPackageExportProjection('./play')],
 						jobs: [],
 						services: [],
 						subscriptions: [],

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -332,20 +332,16 @@ function buildSearchableEntityDescriptors(input: {
 				...entry.record.tags,
 			],
 			tertiaryAliases: [
-				...entry.projection.exports.flatMap((exportDetail) =>
-					typeof exportDetail === 'string'
-						? [exportDetail]
-						: [
-								exportDetail.subpath,
-								exportDetail.description ?? '',
-								exportDetail.typeDefinition ?? '',
-								...(exportDetail.functions ?? []).flatMap((fn) => [
-									fn.name,
-									fn.description ?? '',
-									fn.typeDefinition ?? '',
-								]),
-							],
-				),
+				...entry.projection.exports.flatMap((exportDetail) => [
+					exportDetail.subpath,
+					exportDetail.description ?? '',
+					exportDetail.typeDefinition ?? '',
+					...(exportDetail.functions ?? []).flatMap((fn) => [
+						fn.name,
+						fn.description ?? '',
+						fn.typeDefinition ?? '',
+					]),
+				]),
 				...entry.projection.jobs.map((job) => job.name),
 				...entry.projection.retrievers.flatMap((retriever) => [
 					retriever.key,

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -35,10 +35,7 @@ import {
 	buildPackageSearchProjection,
 	type PackageSearchProjection,
 } from '#worker/package-registry/manifest.ts'
-import {
-	loadPackageManifestBySourceId,
-	loadPackageSourceBySourceId,
-} from '#worker/package-registry/source.ts'
+import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 import {
 	getRemoteConnectorStatus,
 	type HomeConnectorStatus,
@@ -198,7 +195,7 @@ export async function buildSavedPackageSearchRows(input: {
 	const rows = await Promise.all(
 		input.records.map(async (record) => {
 			try {
-				const loaded = await loadPackageManifestBySourceId({
+				const loaded = await loadPackageSourceBySourceId({
 					env: input.env,
 					baseUrl: input.baseUrl,
 					userId: input.userId,
@@ -206,7 +203,10 @@ export async function buildSavedPackageSearchRows(input: {
 				})
 				return {
 					record,
-					projection: buildPackageSearchProjection(loaded.manifest),
+					projection: buildPackageSearchProjection(
+						loaded.manifest,
+						loaded.files,
+					),
 				}
 			} catch (cause) {
 				Sentry.captureException(cause, {
@@ -332,7 +332,20 @@ function buildSearchableEntityDescriptors(input: {
 				...entry.record.tags,
 			],
 			tertiaryAliases: [
-				...entry.projection.exports,
+				...entry.projection.exports.flatMap((exportDetail) =>
+					typeof exportDetail === 'string'
+						? [exportDetail]
+						: [
+								exportDetail.subpath,
+								exportDetail.description ?? '',
+								exportDetail.typeDefinition ?? '',
+								...(exportDetail.functions ?? []).flatMap((fn) => [
+									fn.name,
+									fn.description ?? '',
+									fn.typeDefinition ?? '',
+								]),
+							],
+				),
 				...entry.projection.jobs.map((job) => job.name),
 				...entry.projection.retrievers.flatMap((retriever) => [
 					retriever.key,
@@ -463,6 +476,7 @@ function scoreMatchedTerms(
 	if (matchedTerms.length === 0 || fields.length === 0) return 0
 	const fieldTokens = new Set<string>()
 	for (const field of fields) {
+		if (typeof field !== 'string') continue
 		for (const token of extractSearchTokens(field)) {
 			fieldTokens.add(token)
 		}
@@ -479,7 +493,9 @@ function scoreConstraintBoost(
 	intent: SearchIntent,
 ): number {
 	if (intent.constraints.length === 0) return 0
-	const normalizedFields = fields.map((field) => normalizeSearchText(field))
+	const normalizedFields = fields
+		.filter((field): field is string => typeof field === 'string')
+		.map((field) => normalizeSearchText(field))
 	let score = 0
 	for (const constraint of intent.constraints) {
 		if (
@@ -680,7 +696,18 @@ function buildPackageCandidates(input: {
 					entry.record.description,
 					entry.record.searchText ?? '',
 					...entry.record.tags,
-					...exports,
+					...exports.flatMap((exportDetail) => [
+						exportDetail.subpath,
+						exportDetail.runtimeTarget ?? '',
+						exportDetail.typesPath ?? '',
+						exportDetail.description ?? '',
+						exportDetail.typeDefinition ?? '',
+						...(exportDetail.functions ?? []).flatMap((fn) => [
+							fn.name,
+							fn.description ?? '',
+							fn.typeDefinition ?? '',
+						]),
+					]),
 					...jobs.flatMap((job) => [
 						job.name,
 						job.entry,

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -35,7 +35,10 @@ import {
 	buildPackageSearchProjection,
 	type PackageSearchProjection,
 } from '#worker/package-registry/manifest.ts'
-import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
+import {
+	loadPackageManifestBySourceId,
+	loadPackageSourceBySourceId,
+} from '#worker/package-registry/source.ts'
 import {
 	getRemoteConnectorStatus,
 	type HomeConnectorStatus,
@@ -195,7 +198,7 @@ export async function buildSavedPackageSearchRows(input: {
 	const rows = await Promise.all(
 		input.records.map(async (record) => {
 			try {
-				const loaded = await loadPackageSourceBySourceId({
+				const loaded = await loadPackageManifestBySourceId({
 					env: input.env,
 					baseUrl: input.baseUrl,
 					userId: input.userId,
@@ -203,10 +206,7 @@ export async function buildSavedPackageSearchRows(input: {
 				})
 				return {
 					record,
-					projection: buildPackageSearchProjection(
-						loaded.manifest,
-						loaded.files,
-					),
+					projection: buildPackageSearchProjection(loaded.manifest),
 				}
 			} catch (cause) {
 				Sentry.captureException(cause, {

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -302,7 +302,12 @@ test('buildPackageSearchProjection uses local declaration kind for exported cons
 	})
 
 	const projection = buildPackageSearchProjection(manifest, {
-		'src/index.ts': `export declare const typed: (value: string) => string
+		'src/index.ts': `/**
+ * Package version metadata.
+ */
+export declare const VERSION: string
+
+export declare const typed: (value: string) => string
 
 /**
  * Runtime formatter.

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -224,6 +224,68 @@ test('parseAuthoredPackageJson accepts retriever definitions and includes them i
 	)
 })
 
+test('buildPackageSearchProjection includes exported function signatures and jsdoc', () => {
+	const manifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/weather-tools',
+			exports: {
+				'.': {
+					import: './src/index.ts',
+					types: './src/index.d.ts',
+				},
+			},
+			kody: {
+				id: 'weather-tools',
+				description: 'Weather tools package',
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+
+	const projection = buildPackageSearchProjection(manifest, {
+		'src/index.ts':
+			'export const ignored = "types file should be preferred for metadata"',
+		'src/index.d.ts': `/**
+ * Look up the forecast for a city.
+ */
+export declare function forecast(city: string): Promise<string>
+
+/**
+ * Convert Celsius to Fahrenheit.
+ */
+export declare const celsiusToFahrenheit: (value: number) => number
+`,
+	})
+
+	expect(projection.exports).toEqual([
+		expect.objectContaining({
+			subpath: '.',
+			runtimeTarget: 'src/index.ts',
+			typesPath: 'src/index.d.ts',
+			description: 'Look up the forecast for a city.',
+			functions: [
+				{
+					name: 'forecast',
+					description: 'Look up the forecast for a city.',
+					typeDefinition:
+						'export declare function forecast(city: string): Promise<string>',
+				},
+				{
+					name: 'celsiusToFahrenheit',
+					description: 'Convert Celsius to Fahrenheit.',
+					typeDefinition:
+						'export declare const celsiusToFahrenheit: (value: number) => number',
+				},
+			],
+		}),
+	])
+	const document = buildPackageSearchDocument(projection)
+	expect(document).toContain('Look up the forecast for a city.')
+	expect(document).toContain(
+		'export declare function forecast(city: string): Promise<string>',
+	)
+})
+
 test('parseAuthoredPackageJson rejects retriever definitions with no scopes', () => {
 	expect(() =>
 		parseAuthoredPackageJson({

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -286,6 +286,45 @@ export declare const celsiusToFahrenheit: (value: number) => number
 	)
 })
 
+test('buildPackageSearchProjection uses local declaration kind for exported const signatures', () => {
+	const manifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/mixed-runtime-tools',
+			exports: {
+				'.': './src/index.ts',
+			},
+			kody: {
+				id: 'mixed-runtime-tools',
+				description: 'Mixed runtime tools package',
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+
+	const projection = buildPackageSearchProjection(manifest, {
+		'src/index.ts': `export declare const typed: (value: string) => string
+
+/**
+ * Runtime formatter.
+ */
+export const format = (value: string): string => value.trim()
+`,
+	})
+
+	expect(projection.exports[0]?.functions).toEqual([
+		{
+			name: 'typed',
+			description: null,
+			typeDefinition: 'export declare const typed: (value: string) => string',
+		},
+		{
+			name: 'format',
+			description: 'Runtime formatter.',
+			typeDefinition: 'export function format(value: string): string',
+		},
+	])
+})
+
 test('parseAuthoredPackageJson rejects retriever definitions with no scopes', () => {
 	expect(() =>
 		parseAuthoredPackageJson({

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -368,6 +368,14 @@ function isFunctionDeclaration(node: unknown): node is ModuleAstNode {
 	return type === 'FunctionDeclaration' || type === 'TSDeclareFunction'
 }
 
+function getVariableDeclarationExportKind(
+	declaration: ModuleAstNode,
+): 'export' | 'export declare' {
+	return (declaration as { declare?: unknown }).declare === true
+		? 'export declare'
+		: 'export'
+}
+
 function collectExportedFunctionsFromSource(
 	source: string,
 ): Array<PackageExportFunctionProjection> {
@@ -429,6 +437,7 @@ function collectExportedFunctionsFromSource(
 		const declarations = (declaration as { declarations?: unknown })
 			.declarations
 		if (!Array.isArray(declarations)) continue
+		const exportKind = getVariableDeclarationExportKind(declaration)
 		for (const declarator of (declarations as Array<ModuleAstNode>).filter(
 			isFunctionDeclarator,
 		)) {
@@ -440,9 +449,7 @@ function collectExportedFunctionsFromSource(
 				typeDefinition: getVariableFunctionSignature({
 					source,
 					declarator,
-					exportKind: source.includes('declare const')
-						? 'export declare'
-						: 'export',
+					exportKind,
 				}),
 			})
 		}

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -241,6 +241,7 @@ function getNodeEnd(node: unknown) {
 }
 
 function getNodeType(node: unknown) {
+	if (!node || typeof node !== 'object') return null
 	const type = (node as { type?: unknown }).type
 	return typeof type === 'string' ? type : null
 }
@@ -355,7 +356,10 @@ function isFunctionDeclarator(declarator: ModuleAstNode) {
 	const id = (declarator as { id?: unknown }).id
 	if (!readIdentifierName(id)) return false
 	const typeAnnotation = (id as { typeAnnotation?: unknown }).typeAnnotation
-	if (typeAnnotation) return true
+	const declaredType = (
+		typeAnnotation as { typeAnnotation?: unknown } | undefined
+	)?.typeAnnotation
+	if (getNodeType(declaredType) === 'TSFunctionType') return true
 	const init = (declarator as { init?: unknown }).init
 	return (
 		getNodeType(init) === 'ArrowFunctionExpression' ||

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { parseModuleSource, type ModuleAstNode } from '#worker/module-source.ts'
 import {
 	authoredPackageJsonSchema,
 	type AuthoredPackageJson,
@@ -181,6 +182,21 @@ export function getPackageTags(manifest: AuthoredPackageJson) {
 	return [...(manifest.kody.tags ?? [])]
 }
 
+export type PackageExportFunctionProjection = {
+	name: string
+	description: string | null
+	typeDefinition: string | null
+}
+
+export type PackageExportProjection = {
+	subpath: string
+	runtimeTarget: string | null
+	typesPath: string | null
+	description: string | null
+	typeDefinition: string | null
+	functions: Array<PackageExportFunctionProjection>
+}
+
 export type PackageSearchProjection = {
 	name: string
 	kodyId: string
@@ -189,7 +205,7 @@ export type PackageSearchProjection = {
 	searchText: string | null
 	hasApp: boolean
 	appEntry: string | null
-	exports: Array<string>
+	exports: Array<PackageExportProjection>
 	jobs: Array<{
 		name: string
 		entry: string
@@ -212,8 +228,261 @@ export type PackageSearchProjection = {
 	retrievers: Array<PackageRetrieverManifestEntry>
 }
 
+function getNodeStart(node: unknown) {
+	if (!node || typeof node !== 'object') return null
+	const start = (node as { start?: unknown }).start
+	return typeof start === 'number' ? start : null
+}
+
+function getNodeEnd(node: unknown) {
+	if (!node || typeof node !== 'object') return null
+	const end = (node as { end?: unknown }).end
+	return typeof end === 'number' ? end : null
+}
+
+function getNodeType(node: unknown) {
+	const type = (node as { type?: unknown }).type
+	return typeof type === 'string' ? type : null
+}
+
+function getProgramBody(program: unknown): Array<ModuleAstNode> {
+	const root = program as {
+		program?: { body?: unknown }
+		body?: unknown
+	}
+	const body = root.program?.body ?? root.body
+	return Array.isArray(body) ? (body as Array<ModuleAstNode>) : []
+}
+
+function normalizeJsDocComment(comment: string) {
+	const trimmed = comment.trim()
+	if (!trimmed.startsWith('/**')) return null
+	return trimmed
+		.replace(/^\/\*\*/, '')
+		.replace(/\*\/$/, '')
+		.split('\n')
+		.map((line) => line.replace(/^\s*\*\s?/, '').trimEnd())
+		.join('\n')
+		.trim()
+}
+
+function readLeadingJsDoc(source: string, start: number) {
+	const prefix = source.slice(0, start)
+	const match = prefix.match(/\/\*\*(?:(?!\*\/)[\s\S])*\*\/\s*$/)
+	if (!match) return null
+	return normalizeJsDocComment(match[0] ?? '')
+}
+
+function readIdentifierName(node: unknown) {
+	const name = (node as { name?: unknown }).name
+	return typeof name === 'string' && name.trim() ? name : null
+}
+
+function getFunctionSignature(input: {
+	source: string
+	node: ModuleAstNode
+	exportKeyword: string
+}) {
+	const start = getNodeStart(input.node)
+	if (start == null) return null
+	const bodyStart = getNodeStart((input.node as { body?: unknown }).body)
+	const end = bodyStart ?? getNodeEnd(input.node)
+	if (end == null) return null
+	const signature = input.source
+		.slice(start, end)
+		.trim()
+		.replace(/\s*\{$/, '')
+		.replace(/\s*;\s*$/, '')
+	return `${input.exportKeyword} ${signature}`.replace(/\s+/g, ' ').trim()
+}
+
+function formatParameterList(source: string, params: unknown) {
+	if (!Array.isArray(params)) return ''
+	return params
+		.map((param) => {
+			const start = getNodeStart(param)
+			const end = getNodeEnd(param)
+			return start == null || end == null
+				? null
+				: source.slice(start, end).trim()
+		})
+		.filter((param): param is string => param != null && param.length > 0)
+		.join(', ')
+}
+
+function getReturnType(source: string, node: unknown) {
+	const returnType = (node as { returnType?: unknown }).returnType
+	const start = getNodeStart(returnType)
+	const end = getNodeEnd(returnType)
+	if (start == null || end == null) return 'unknown'
+	return source.slice(start, end).replace(/^:\s*/, '').trim()
+}
+
+function getVariableFunctionSignature(input: {
+	source: string
+	declarator: ModuleAstNode
+	exportKind: 'export' | 'export declare'
+}) {
+	const id = (input.declarator as { id?: unknown }).id
+	const name = readIdentifierName(id)
+	if (!name) return null
+	const typeAnnotation = (id as { typeAnnotation?: unknown }).typeAnnotation
+	const typeStart = getNodeStart(typeAnnotation)
+	const typeEnd = getNodeEnd(typeAnnotation)
+	if (typeStart != null && typeEnd != null) {
+		return `${input.exportKind} const ${name}${input.source.slice(typeStart, typeEnd)}`
+	}
+	const init = (input.declarator as { init?: unknown }).init as
+		| ModuleAstNode
+		| undefined
+	if (
+		getNodeType(init) !== 'ArrowFunctionExpression' &&
+		getNodeType(init) !== 'FunctionExpression'
+	) {
+		return null
+	}
+	const asyncPrefix =
+		(init as { async?: unknown }).async === true ? 'async ' : ''
+	const params = formatParameterList(
+		input.source,
+		(init as { params?: unknown }).params,
+	)
+	const returnType = getReturnType(input.source, init)
+	return `${input.exportKind} ${asyncPrefix}function ${name}(${params}): ${returnType}`
+}
+
+function isFunctionDeclarator(declarator: ModuleAstNode) {
+	const id = (declarator as { id?: unknown }).id
+	if (!readIdentifierName(id)) return false
+	const typeAnnotation = (id as { typeAnnotation?: unknown }).typeAnnotation
+	if (typeAnnotation) return true
+	const init = (declarator as { init?: unknown }).init
+	return (
+		getNodeType(init) === 'ArrowFunctionExpression' ||
+		getNodeType(init) === 'FunctionExpression'
+	)
+}
+
+function isFunctionDeclaration(node: unknown): node is ModuleAstNode {
+	const type = getNodeType(node)
+	return type === 'FunctionDeclaration' || type === 'TSDeclareFunction'
+}
+
+function collectExportedFunctionsFromSource(
+	source: string,
+): Array<PackageExportFunctionProjection> {
+	let body: Array<ModuleAstNode>
+	try {
+		body = getProgramBody(parseModuleSource(source))
+	} catch {
+		return []
+	}
+	const functions: Array<PackageExportFunctionProjection> = []
+	for (const statement of body) {
+		if (statement.type === 'ExportDefaultDeclaration') {
+			const declaration = (statement as { declaration?: unknown })
+				.declaration as ModuleAstNode | undefined
+			if (isFunctionDeclaration(declaration)) {
+				const declarationStart = getNodeStart(declaration)
+				functions.push({
+					name: 'default',
+					description:
+						(declarationStart == null
+							? null
+							: readLeadingJsDoc(source, declarationStart)) ??
+						(getNodeStart(statement) == null
+							? null
+							: readLeadingJsDoc(source, getNodeStart(statement) ?? 0)),
+					typeDefinition: getFunctionSignature({
+						source,
+						node: declaration,
+						exportKeyword: 'export default',
+					}),
+				})
+			}
+			continue
+		}
+		if (statement.type !== 'ExportNamedDeclaration') continue
+		const declaration = (statement as { declaration?: unknown }).declaration as
+			| ModuleAstNode
+			| undefined
+		const statementStart = getNodeStart(statement)
+		const description =
+			statementStart == null ? null : readLeadingJsDoc(source, statementStart)
+		if (isFunctionDeclaration(declaration)) {
+			const name = readIdentifierName((declaration as { id?: unknown }).id)
+			if (!name) continue
+			functions.push({
+				name,
+				description,
+				typeDefinition: getFunctionSignature({
+					source,
+					node: declaration,
+					exportKeyword: 'export',
+				}),
+			})
+			continue
+		}
+		if (!declaration || getNodeType(declaration) !== 'VariableDeclaration') {
+			continue
+		}
+		const declarations = (declaration as { declarations?: unknown })
+			.declarations
+		if (!Array.isArray(declarations)) continue
+		for (const declarator of (declarations as Array<ModuleAstNode>).filter(
+			isFunctionDeclarator,
+		)) {
+			const name = readIdentifierName((declarator as { id?: unknown }).id)
+			if (!name) continue
+			functions.push({
+				name,
+				description,
+				typeDefinition: getVariableFunctionSignature({
+					source,
+					declarator,
+					exportKind: source.includes('declare const')
+						? 'export declare'
+						: 'export',
+				}),
+			})
+		}
+	}
+	return functions
+}
+
+function summarizePackageExport(input: {
+	exportName: string
+	target: PackageExportTarget
+	files?: Record<string, string>
+}): PackageExportProjection {
+	const runtimeTarget = readTargetPath(input.target, 'runtime')
+	const typesPath = readTargetPath(input.target, 'types')
+	const runtimeSource = runtimeTarget
+		? (input.files?.[normalizePackageWorkspacePath(runtimeTarget)] ?? null)
+		: null
+	const typesSource = typesPath
+		? (input.files?.[normalizePackageWorkspacePath(typesPath)] ?? null)
+		: null
+	const functions = collectExportedFunctionsFromSource(
+		typesSource ?? runtimeSource ?? '',
+	)
+	const [firstFunction] = functions
+	return {
+		subpath: normalizePackageExportKey(input.exportName),
+		runtimeTarget: runtimeTarget
+			? normalizePackageWorkspacePath(runtimeTarget)
+			: null,
+		typesPath: typesPath ? normalizePackageWorkspacePath(typesPath) : null,
+		description: firstFunction?.description ?? null,
+		typeDefinition:
+			functions.length === 1 ? (firstFunction?.typeDefinition ?? null) : null,
+		functions,
+	}
+}
+
 export function buildPackageSearchProjection(
 	manifest: AuthoredPackageJson,
+	files?: Record<string, string>,
 ): PackageSearchProjection {
 	const appEntry = getPackageAppEntryPath(manifest)
 	return {
@@ -224,7 +493,11 @@ export function buildPackageSearchProjection(
 		searchText: manifest.kody.searchText?.trim() || null,
 		hasApp: appEntry !== null,
 		appEntry,
-		exports: Object.keys(manifest.exports).sort(),
+		exports: Object.entries(manifest.exports)
+			.map(([exportName, target]) =>
+				summarizePackageExport({ exportName, target, files }),
+			)
+			.sort((left, right) => left.subpath.localeCompare(right.subpath)),
 		jobs: Object.entries(manifest.kody.jobs ?? {})
 			.map(([name, job]) => ({
 				name,
@@ -249,7 +522,10 @@ export function buildPackageSearchDocument(
 ) {
 	const jobLines = projection.jobs.map((job) =>
 		[job.name, job.entry, job.schedule, job.enabled ? 'enabled' : 'disabled']
-			.filter((value) => value.length > 0)
+			.filter(
+				(value): value is string =>
+					typeof value === 'string' && value.length > 0,
+			)
 			.join(' '),
 	)
 	const serviceLines = projection.services.map((service) =>
@@ -284,13 +560,37 @@ export function buildPackageSearchDocument(
 			.filter((value) => value.length > 0)
 			.join(' '),
 	)
+	const exportLines = projection.exports.map((exportDetail) => {
+		const functions = Array.isArray(exportDetail.functions)
+			? exportDetail.functions
+			: []
+		const values = [
+			typeof exportDetail.subpath === 'string' ? exportDetail.subpath : '',
+			typeof exportDetail.runtimeTarget === 'string'
+				? exportDetail.runtimeTarget
+				: '',
+			typeof exportDetail.typesPath === 'string' ? exportDetail.typesPath : '',
+			typeof exportDetail.description === 'string'
+				? exportDetail.description
+				: '',
+			typeof exportDetail.typeDefinition === 'string'
+				? exportDetail.typeDefinition
+				: '',
+			...functions.flatMap((fn) => [
+				typeof fn.name === 'string' ? fn.name : '',
+				typeof fn.description === 'string' ? fn.description : '',
+				typeof fn.typeDefinition === 'string' ? fn.typeDefinition : '',
+			]),
+		]
+		return [...values.filter((value) => value.length > 0)].join(' ')
+	})
 	return [
 		`package ${projection.kodyId}`,
 		projection.name,
 		projection.description,
 		projection.tags.join(' '),
 		projection.searchText ?? '',
-		projection.exports.join('\n'),
+		exportLines.join('\n'),
 		jobLines.join('\n'),
 		serviceLines.join('\n'),
 		subscriptionLines.join('\n'),

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -218,7 +218,7 @@ test('buildKodyModuleBundle resolves scoped package imports by full package name
 	)
 })
 
-test('buildKodyModuleBundle proxies named-only package module exports', async () => {
+test('buildKodyModuleBundle proxies package module default and named exports', async () => {
 	mockModule.createWorker.mockResolvedValue(createBundleResult('named-import'))
 	mockModule.getSavedPackageByName.mockResolvedValue(createSavedPackageRecord())
 	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
@@ -234,7 +234,8 @@ test('buildKodyModuleBundle proxies named-only package module exports', async ()
 			},
 		},
 		files: {
-			'math.js': 'export function add(left, right) { return left + right }',
+			'math.js':
+				'export default function multiply(left, right) { return left * right }\nexport function add(left, right) { return left + right }',
 		},
 	})
 
@@ -258,8 +259,10 @@ test('buildKodyModuleBundle proxies named-only package module exports', async ()
 					description: 'Local package',
 				},
 			}),
-			'index.js':
-				'import { add } from "kody:@kentcdodds/example-package/math"\nexport default () => add(1, 2)\n',
+			'index.js': [
+				'import multiply, { add } from "kody:@kentcdodds/example-package/math"',
+				'export default () => multiply(2, 3) + add(1, 2)',
+			].join('\n'),
 		},
 		entryPoint: 'index.js',
 	})
@@ -273,8 +276,8 @@ test('buildKodyModuleBundle proxies named-only package module exports', async ()
 		path.includes('__kody_virtual__/imports/'),
 	)?.[1]
 	expect(proxy).toContain('export * from')
-	expect(proxy).not.toContain('import __default')
-	expect(proxy).not.toContain('export default')
+	expect(proxy).toContain('import * as __kodyPackageModule')
+	expect(proxy).toContain('export default __kodyPackageModule.default')
 })
 
 test('buildKodyModuleBundle keeps dependencies for scoped packages with the same leaf', async () => {

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -218,6 +218,65 @@ test('buildKodyModuleBundle resolves scoped package imports by full package name
 	)
 })
 
+test('buildKodyModuleBundle proxies named-only package module exports', async () => {
+	mockModule.createWorker.mockResolvedValue(createBundleResult('named-import'))
+	mockModule.getSavedPackageByName.mockResolvedValue(createSavedPackageRecord())
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		...createLoadedPackageSource(),
+		manifest: {
+			name: '@kentcdodds/example-package',
+			exports: {
+				'./math': './math.js',
+			},
+			kody: {
+				id: 'example-package',
+				description: 'Example package',
+			},
+		},
+		files: {
+			'math.js': 'export function add(left, right) { return left + right }',
+		},
+	})
+
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+
+	await buildKodyModuleBundle({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/local-package',
+				exports: {
+					'.': './index.js',
+				},
+				kody: {
+					id: 'local-package',
+					description: 'Local package',
+				},
+			}),
+			'index.js':
+				'import { add } from "kody:@kentcdodds/example-package/math"\nexport default () => add(1, 2)\n',
+		},
+		entryPoint: 'index.js',
+	})
+
+	const firstCall = mockModule.createWorker.mock.calls[0]?.[0] as
+		| {
+				files?: Record<string, string>
+		  }
+		| undefined
+	const proxy = Object.entries(firstCall?.files ?? {}).find(([path]) =>
+		path.includes('__kody_virtual__/imports/'),
+	)?.[1]
+	expect(proxy).toContain('export * from')
+	expect(proxy).not.toContain('import __default')
+	expect(proxy).not.toContain('export default')
+})
+
 test('buildKodyModuleBundle keeps dependencies for scoped packages with the same leaf', async () => {
 	mockModule.createWorker.mockResolvedValue(createBundleResult('shared-leaf'))
 	mockModule.getSavedPackageByName.mockImplementation(

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -162,6 +162,8 @@ export default {
 function createPackageImportProxySource(input: { targetPath: string }) {
 	return `
 export * from ${JSON.stringify(input.targetPath)};
+import * as __kodyPackageModule from ${JSON.stringify(input.targetPath)};
+export default __kodyPackageModule.default;
 `.trim()
 }
 

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -162,8 +162,6 @@ export default {
 function createPackageImportProxySource(input: { targetPath: string }) {
 	return `
 export * from ${JSON.stringify(input.targetPath)};
-import __default from ${JSON.stringify(input.targetPath)};
-export default __default;
 `.trim()
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Allow saved package imports to re-export named module exports while preserving default-import compatibility.
- Add package export metadata extraction for exported function JSDoc and signatures from runtime or `types` files.
- Keep broad package search row loading manifest-only; package entity detail still loads full source for rich export metadata.
- Filter export metadata to actual function declarations/types so non-function typed constants do not pollute function metadata.
- Remove obsolete string-export fallback code now that package search projections use structured export metadata.
- Surface export metadata in package search/detail output and update package/execute docs to clarify package exports vs execute entrypoints.

### Testing
- `npm run test -- packages/worker/src/package-runtime/module-graph.node.test.ts packages/worker/src/package-registry/manifest.node.test.ts packages/worker/src/mcp/tools/search.node.test.ts packages/worker/src/mcp/tools/search-format.node.test.ts`
- `npm run typecheck`
- `npm run format:check -- packages/worker/src/mcp/tools/search.ts packages/worker/src/mcp/tools/search.node.test.ts`
- `npm run test`
- `git push -u origin cursor/package-export-metadata-b4e5` (pre-push ran `npm run test:push`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b90071db-7ba8-4aa3-930b-f30095fbb4e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b90071db-7ba8-4aa3-930b-f30095fbb4e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

