### PR TITLE
Support npm dependencies in saved packages

### DIFF
--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -23,6 +23,32 @@ Use `package.json` as the canonical source of truth for saved package metadata.
 
 The package manifest is `package.json`.
 
+## npm dependencies
+
+Saved packages may declare npm runtime dependencies in
+`package.json#dependencies` when the dependency is compatible with the
+Cloudflare Workers runtime.
+
+Important behavior:
+
+- Kody resolves and bundles saved-package npm dependencies during repo checks
+  and publish-time artifact rebuilds.
+- Published bundle artifacts are what package exports, services, jobs,
+  subscriptions, retrievers, and apps execute at runtime.
+- If a package declares a dependency that the bundler cannot resolve or bundle,
+  repo checks now fail with the underlying bundling error instead of allowing a
+  publish that will only fail later at runtime.
+- Runtime execution does not invent a new dependency policy or ask callers to
+  choose one. Dependency handling is part of the saved-package pipeline itself.
+
+Contributor guidance:
+
+- Prefer Worker-safe ESM packages.
+- Declare runtime dependencies under `dependencies`, not `devDependencies`.
+- When debugging dependency issues, verify both `runRepoChecks(...)` and the
+  published bundle artifact rebuild path, since both must agree on what the
+  saved package can execute.
+
 ## Mental model
 
 Think in terms of:

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -41,6 +41,24 @@ For predictable package resolution, saved packages must use a scoped
 `@kentcdodds/cursor-cloud-agents` must use
 `"kody": { "id": "cursor-cloud-agents" }`.
 
+### npm dependencies
+
+Saved packages may declare runtime npm dependencies in `package.json`
+`dependencies`.
+
+- Kody bundles those dependencies for package exports, package apps, package
+  services, package-owned jobs, and package subscription handlers.
+- Dependency resolution happens during package checks and publish-time artifact
+  rebuilds, not by ad hoc package installs during normal execution.
+- If a declared dependency cannot be resolved or bundled, package checks fail
+  with the bundling error instead of allowing a publish that only fails later at
+  runtime.
+- After changing `dependencies`, republish the package so Kody can rebuild the
+  published runtime bundle artifacts that execution paths use.
+
+Do not rely on `devDependencies` for saved package runtime code. Only
+`dependencies` are treated as part of the runtime package surface.
+
 ## Package exports
 
 `package.json.exports` is the package's callable and importable surface.

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -35,6 +35,7 @@ import {
 } from './types.ts'
 import { createJobStorageId, storageRunnerRpc } from '#worker/storage-runner.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
+import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from '#worker/package-runtime/published-source-dependencies.ts'
 import {
 	normalizePackageWorkspacePath,
 	parseAuthoredPackageJson,
@@ -134,6 +135,12 @@ async function buildPublishedJobBundle(input: {
 	sourceFiles: Record<string, string>
 	entryPoint: string
 }) {
+	assertPublishedSourceCanRebuildWithoutInstallingDeps({
+		sourceFiles: input.sourceFiles,
+		bundleLabel: `Saved package job "${normalizePackageWorkspacePath(
+			input.entryPoint,
+		)}"`,
+	})
 	// Load the worker bundler lazily so registry-only/node test paths that import
 	// jobs/service.ts do not eagerly pull the heavy bundler stack.
 	const { buildKodyModuleBundle } =

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -744,6 +744,94 @@ test('invokePackageExport stores export-not-found responses as terminal failures
 	expect(repoMockModule.runBundledModuleWithRegistry).not.toHaveBeenCalled()
 })
 
+test('invokePackageExport asks for republish when a published artifact is missing for npm-backed source', async () => {
+	const db = createDatabase()
+	seedPackageResolution()
+	repoMockModule.loadPublishedBundleArtifactByIdentity.mockResolvedValue(null)
+	repoMockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: {
+			id: 'source-1',
+			user_id: 'user-123',
+			entity_kind: 'package',
+			entity_id: 'pkg-1',
+			repo_id: 'repo-1',
+			published_commit: 'commit-1',
+			indexed_commit: null,
+			manifest_path: 'package.json',
+			source_root: '/',
+			created_at: '2026-04-27T00:00:00.000Z',
+			updated_at: '2026-04-27T00:00:00.000Z',
+		},
+		manifest: {
+			name: '@kentcdodds/discord-gateway',
+			exports: {
+				'./dispatch-message-created': './src/dispatch-message-created.ts',
+			},
+			kody: {
+				id: 'discord-gateway',
+				description: 'Discord gateway helpers',
+			},
+		},
+		files: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/discord-gateway',
+				dependencies: {
+					kleur: '^4.1.5',
+				},
+				exports: {
+					'./dispatch-message-created': './src/dispatch-message-created.ts',
+				},
+				kody: {
+					id: 'discord-gateway',
+					description: 'Discord gateway helpers',
+				},
+			}),
+			'src/dispatch-message-created.ts':
+				'import kleur from "kleur"\nexport default async function run(){ return kleur.green("ok") }',
+		},
+	})
+
+	const response = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: {
+			packageIdOrKodyId: 'discord-gateway',
+			exportName: 'dispatch-message-created',
+			params: { content: 'hi' },
+			idempotencyKey: 'evt-republish-needed',
+			source: 'discord-gateway',
+		},
+	})
+
+	expect(response.status).toBe(500)
+	expect(response.body).toMatchObject({
+		ok: false,
+		error: {
+			code: 'invocation_failed',
+			message: expect.stringContaining(
+				'no published runtime bundle artifact is available yet',
+			),
+		},
+	})
+	expect(
+		repoMockModule.typecheckPackageEntrypointsFromSourceFiles,
+	).toHaveBeenCalledWith({
+		sourceFiles: expect.objectContaining({
+			'package.json': expect.any(String),
+			'src/dispatch-message-created.ts': expect.any(String),
+		}),
+		entryPoints: [
+			{
+				path: 'src/dispatch-message-created.ts',
+				includeStorage: true,
+			},
+		],
+	})
+	expect(repoMockModule.persistPublishedBundleArtifact).not.toHaveBeenCalled()
+	expect(repoMockModule.runBundledModuleWithRegistry).not.toHaveBeenCalled()
+})
+
 test('invokePackageSubscription uses the normal capability registry with package storage and source metadata intact', async () => {
 	const db = createDatabase()
 	seedPackageResolution()

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -21,6 +21,7 @@ import {
 	loadPublishedBundleArtifactByIdentity,
 	persistPublishedBundleArtifact,
 } from '#worker/package-runtime/published-bundle-artifacts.ts'
+import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from '#worker/package-runtime/published-source-dependencies.ts'
 import {
 	buildPackageSubscriptionArtifactName,
 	normalizePackageSubscriptionTopic,
@@ -274,6 +275,10 @@ async function ensureModuleArtifact(input: {
 	if (!typecheckResult.ok) {
 		throw new Error(typecheckResult.message)
 	}
+	assertPublishedSourceCanRebuildWithoutInstallingDeps({
+		sourceFiles: packageSource.files,
+		bundleLabel: `Saved package export "${resolution.artifactName}"`,
+	})
 	const { buildKodyModuleBundle } =
 		await import('#worker/package-runtime/module-graph.ts')
 	const bundle = await buildKodyModuleBundle({

--- a/packages/worker/src/package-runtime/import-specifiers.ts
+++ b/packages/worker/src/package-runtime/import-specifiers.ts
@@ -1,0 +1,120 @@
+import { parseModuleSource, type ModuleAstNode } from '#worker/module-source.ts'
+
+export type LiteralImportNode = {
+	start: number
+	end: number
+	specifier: string
+}
+
+function readLiteralStringNode(
+	node: unknown,
+): { start: number; end: number; specifier: string } | null {
+	if (node == null || typeof node !== 'object') return null
+	if (!('type' in node)) return null
+	const typedNode = node as {
+		type?: string
+		value?: unknown
+		start?: number
+		end?: number
+		extra?: { rawValue?: unknown }
+	}
+	const literalValue =
+		typeof typedNode.value === 'string'
+			? typedNode.value
+			: typeof typedNode.extra?.rawValue === 'string'
+				? typedNode.extra.rawValue
+				: null
+	if (
+		(typedNode.type === 'Literal' || typedNode.type === 'StringLiteral') &&
+		typeof literalValue === 'string' &&
+		typeof typedNode.start === 'number' &&
+		typeof typedNode.end === 'number'
+	) {
+		return {
+			start: typedNode.start,
+			end: typedNode.end,
+			specifier: literalValue,
+		}
+	}
+	return null
+}
+
+export function collectLiteralImportNodes(
+	source: string,
+): Array<LiteralImportNode> {
+	const nodes: Array<LiteralImportNode> = []
+
+	function visit(node: unknown): void {
+		if (node == null || typeof node !== 'object') return
+		if (Array.isArray(node)) {
+			for (const item of node) visit(item)
+			return
+		}
+		if (!('type' in node)) return
+		const typedNode = node as ModuleAstNode & {
+			source?: { type?: string; value?: unknown; start?: number; end?: number }
+		}
+		if (
+			typedNode.type === 'ImportDeclaration' ||
+			typedNode.type === 'ExportAllDeclaration' ||
+			typedNode.type === 'ExportNamedDeclaration'
+		) {
+			const literalNode = readLiteralStringNode(typedNode.source)
+			if (literalNode) {
+				nodes.push(literalNode)
+			}
+		}
+		if (typedNode.type === 'ImportExpression') {
+			const literalNode = readLiteralStringNode(typedNode.source)
+			if (literalNode) {
+				nodes.push(literalNode)
+			}
+		}
+		for (const value of Object.values(
+			typedNode as unknown as Record<string, unknown>,
+		)) {
+			if (value == null) continue
+			if (typeof value === 'object') {
+				visit(value)
+			}
+		}
+	}
+
+	try {
+		const program = parseModuleSource(source)
+		visit(program)
+	} catch {
+		return []
+	}
+
+	return nodes.sort((left, right) => left.start - right.start)
+}
+
+export function collectLiteralImportSpecifiers(source: string): Array<string> {
+	return collectLiteralImportNodes(source).map((node) => node.specifier)
+}
+
+export function isBarePackageImportSpecifier(specifier: string) {
+	if (
+		specifier.startsWith('.') ||
+		specifier.startsWith('/') ||
+		specifier.startsWith('node:') ||
+		specifier.startsWith('cloudflare:') ||
+		specifier.startsWith('kody:')
+	) {
+		return false
+	}
+	return !/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(specifier)
+}
+
+export function getBarePackageNameFromSpecifier(specifier: string) {
+	if (!isBarePackageImportSpecifier(specifier)) {
+		return null
+	}
+	if (specifier.startsWith('@')) {
+		const [scope, name] = specifier.split('/', 3)
+		if (!scope || !name) return specifier
+		return `${scope}/${name}`
+	}
+	return specifier.split('/', 2)[0] ?? specifier
+}

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -1,4 +1,3 @@
-import { createWorker } from '@cloudflare/worker-bundler'
 import {
 	loadPackageSourceBySourceId,
 	type LoadedPackageSource,
@@ -38,6 +37,17 @@ const packageSourcePrefix = '.__kody_packages__'
 const packageImportProxyPrefix = '.__kody_virtual__/imports'
 const packageAppBundleCache =
 	createPublishedPackagePromiseCache<RuntimeBundle>()
+
+async function createWorkerBundle(input: {
+	files: Record<string, string>
+	entryPoint: string
+}) {
+	// Load the experimental worker bundler lazily so node-unit paths that only
+	// import saved-package runtime helpers do not eagerly evaluate the esbuild
+	// WASM bundle.
+	const { createWorker } = await import('@cloudflare/worker-bundler')
+	return await createWorker(input)
+}
 
 function joinPath(...parts: Array<string>) {
 	return parts
@@ -398,7 +408,7 @@ export async function buildKodyModuleBundle(input: {
 		),
 		paramsJson: 'globalThis.__kodyRuntime?.params ?? null',
 	})
-	const bundle = await createWorker({
+	const bundle = await createWorkerBundle({
 		files,
 		entryPoint: bootstrapPath,
 	})
@@ -485,7 +495,7 @@ export async function buildKodyAppBundle(input: {
 				normalizedEntrypoint,
 			),
 		})
-		const bundle = await createWorker({
+		const bundle = await createWorkerBundle({
 			files,
 			entryPoint: bootstrapPath,
 		})

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -3,7 +3,6 @@ import {
 	loadPackageSourceBySourceId,
 	type LoadedPackageSource,
 } from '#worker/package-registry/source.ts'
-import { parseModuleSource, type ModuleAstNode } from '#worker/module-source.ts'
 import {
 	normalizePackageWorkspacePath,
 	resolvePackageExportPath,
@@ -24,9 +23,16 @@ import {
 	packageSpecifierPrefix,
 	resolveSavedPackageImport,
 } from './package-import-resolution.ts'
+import {
+	collectLiteralImportNodes,
+	collectLiteralImportSpecifiers,
+	isBarePackageImportSpecifier,
+} from './import-specifiers.ts'
 import { type RuntimeBundle } from './runtime-bundle-types.ts'
 
 const runtimeModulePath = '.__kody_virtual__/runtime.js'
+const packageManifestPath = 'package.json'
+const wranglerConfigPaths = ['wrangler.toml', 'wrangler.json', 'wrangler.jsonc']
 const rootSourcePrefix = '.__kody_root__'
 const packageSourcePrefix = '.__kody_packages__'
 const packageImportProxyPrefix = '.__kody_virtual__/imports'
@@ -171,93 +177,72 @@ function sanitizeSpecifier(specifier: string) {
 	return specifier.replace(/[^a-zA-Z0-9/_-]+/g, '-')
 }
 
-function collectLiteralImportNodes(source: string): Array<{
-	start: number
-	end: number
-	specifier: string
-}> {
-	const nodes: Array<{ start: number; end: number; specifier: string }> = []
+function isBundlerRootConfigPath(path: string) {
+	return path === packageManifestPath || wranglerConfigPaths.includes(path)
+}
 
-	function readLiteralStringNode(
-		node: unknown,
-	): { start: number; end: number; specifier: string } | null {
-		if (node == null || typeof node !== 'object') return null
-		if (!('type' in node)) return null
-		const typedNode = node as {
-			type?: string
-			value?: unknown
-			start?: number
-			end?: number
-			extra?: { rawValue?: unknown }
-		}
-		const literalValue =
-			typeof typedNode.value === 'string'
-				? typedNode.value
-				: typeof typedNode.extra?.rawValue === 'string'
-					? typedNode.extra.rawValue
-					: null
-		if (
-			(typedNode.type === 'Literal' || typedNode.type === 'StringLiteral') &&
-			typeof literalValue === 'string' &&
-			typeof typedNode.start === 'number' &&
-			typeof typedNode.end === 'number'
-		) {
-			return {
-				start: typedNode.start,
-				end: typedNode.end,
-				specifier: literalValue,
-			}
-		}
-		return null
-	}
+function isBundlerRootDependencyPath(path: string) {
+	return path === 'node_modules' || path.startsWith('node_modules/')
+}
 
-	function visit(node: unknown): void {
-		if (node == null || typeof node !== 'object') return
-		if (Array.isArray(node)) {
-			for (const item of node) visit(item)
-			return
+function* iterateModuleSourceTexts(
+	modules: WorkerLoaderModules,
+): Generator<[modulePath: string, source: string]> {
+	for (const [modulePath, module] of Object.entries(modules)) {
+		if (typeof module === 'string') {
+			yield [modulePath, module]
+			continue
 		}
-		if (!('type' in node)) return
-		const typedNode = node as ModuleAstNode & {
-			source?: { type?: string; value?: unknown; start?: number; end?: number }
-			start?: number
-			end?: number
-			expression?: unknown
+		if (typeof module.js === 'string') {
+			yield [modulePath, module.js]
 		}
-		if (
-			typedNode.type === 'ImportDeclaration' ||
-			typedNode.type === 'ExportAllDeclaration' ||
-			typedNode.type === 'ExportNamedDeclaration'
-		) {
-			const literalNode = readLiteralStringNode(typedNode.source)
-			if (literalNode) {
-				nodes.push(literalNode)
-			}
+		if (typeof module.cjs === 'string') {
+			yield [modulePath, module.cjs]
 		}
-		if (typedNode.type === 'ImportExpression') {
-			const literalNode = readLiteralStringNode(typedNode.source)
-			if (literalNode) {
-				nodes.push(literalNode)
-			}
-		}
-		for (const value of Object.values(
-			typedNode as unknown as Record<string, unknown>,
-		)) {
-			if (value == null) continue
-			if (typeof value === 'object') {
-				visit(value)
-			}
+		if (typeof module.text === 'string') {
+			yield [modulePath, module.text]
 		}
 	}
+}
 
-	try {
-		const program = parseModuleSource(source)
-		visit(program)
-	} catch {
-		return []
+function collectUnresolvedBareImports(modules: WorkerLoaderModules) {
+	const unresolved = new Map<string, Set<string>>()
+	for (const [modulePath, source] of iterateModuleSourceTexts(modules)) {
+		for (const specifier of collectLiteralImportSpecifiers(source)) {
+			if (!isBarePackageImportSpecifier(specifier)) continue
+			let existing = unresolved.get(modulePath)
+			if (!existing) {
+				existing = new Set()
+				unresolved.set(modulePath, existing)
+			}
+			existing.add(specifier)
+		}
 	}
+	return [...unresolved.entries()].map(([modulePath, specifiers]) => ({
+		modulePath,
+		specifiers: [...specifiers].sort((left, right) =>
+			left.localeCompare(right),
+		),
+	}))
+}
 
-	return nodes.sort((left, right) => left.start - right.start)
+function assertBundleHasNoUnresolvedBareImports(input: {
+	modules: WorkerLoaderModules
+	bundleLabel: string
+}) {
+	const unresolved = collectUnresolvedBareImports(input.modules)
+	if (unresolved.length === 0) return
+	const details = unresolved
+		.map(
+			(entry) =>
+				`${entry.modulePath}: ${entry.specifiers
+					.map((specifier) => `"${specifier}"`)
+					.join(', ')}`,
+		)
+		.join('; ')
+	throw new Error(
+		`${input.bundleLabel} still contains unresolved bare package imports after bundling (${details}). Declare supported runtime dependencies in package.json and ensure checks/publish can resolve them before execution.`,
+	)
 }
 
 function applyReplacements(
@@ -417,6 +402,10 @@ export async function buildKodyModuleBundle(input: {
 		files,
 		entryPoint: bootstrapPath,
 	})
+	assertBundleHasNoUnresolvedBareImports({
+		modules: bundle.modules as WorkerLoaderModules,
+		bundleLabel: `Saved package module "${normalizePackageWorkspacePath(input.entryPoint)}" bundle`,
+	})
 	return {
 		mainModule: bundle.mainModule,
 		modules: bundle.modules as WorkerLoaderModules,
@@ -443,10 +432,21 @@ async function prepareKodyGraphFiles(input: {
 		dependencies: new Map(),
 	}
 	for (const [filePath, content] of Object.entries(input.sourceFiles)) {
-		const normalizedPath = joinPath(
-			rootSourcePrefix,
-			normalizePackageWorkspacePath(filePath),
-		)
+		const normalizedSourcePath = normalizePackageWorkspacePath(filePath)
+		if (
+			isBundlerRootConfigPath(normalizedSourcePath) ||
+			isBundlerRootDependencyPath(normalizedSourcePath)
+		) {
+			files[normalizedSourcePath] = content
+		}
+		if (isBundlerRootDependencyPath(normalizedSourcePath)) {
+			continue
+		}
+		const normalizedPath = joinPath(rootSourcePrefix, normalizedSourcePath)
+		if (normalizedSourcePath === packageManifestPath) {
+			files[normalizedPath] = content
+			continue
+		}
 		files[normalizedPath] = await rewriteKodyImports({
 			state,
 			source: content,
@@ -488,6 +488,10 @@ export async function buildKodyAppBundle(input: {
 		const bundle = await createWorker({
 			files,
 			entryPoint: bootstrapPath,
+		})
+		assertBundleHasNoUnresolvedBareImports({
+			modules: bundle.modules as WorkerLoaderModules,
+			bundleLabel: `Saved package app "${normalizePackageWorkspacePath(input.entryPoint)}" bundle`,
 		})
 		return {
 			mainModule: bundle.mainModule,

--- a/packages/worker/src/package-runtime/module-graph.workers.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.workers.test.ts
@@ -1,0 +1,73 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { runBundledModuleWithRegistry } from '#mcp/run-codemode-registry.ts'
+import { buildKodyModuleBundle } from './module-graph.ts'
+
+test('saved package bundles and executes npm dependencies declared in package.json', async () => {
+	const packageJson = JSON.stringify({
+		name: '@kentcdodds/dependency-package',
+		exports: {
+			'.': './src/index.ts',
+		},
+		dependencies: {
+			kleur: '^4.1.5',
+		},
+		kody: {
+			id: 'dependency-package',
+			description: 'Exercises npm dependency bundling',
+		},
+	})
+
+	const bundle = await buildKodyModuleBundle({
+		env,
+		baseUrl: 'https://kody.dev',
+		userId: 'user-workers-test',
+		sourceFiles: {
+			'package.json': packageJson,
+			'src/index.ts': [
+				"import kleur from 'kleur'",
+				'export default async function run() {',
+				"\treturn { formatted: kleur.green('dependency-ok') }",
+				'}',
+			].join('\n'),
+		},
+		entryPoint: 'src/index.ts',
+	})
+
+	const moduleSources = Object.values(bundle.modules)
+		.map((module) => {
+			if (typeof module === 'string') return module
+			return [module.js, module.cjs, module.text]
+				.filter((value): value is string => typeof value === 'string')
+				.join('\n')
+		})
+		.join('\n')
+	expect(moduleSources).toContain('dependency-ok')
+	expect(moduleSources).not.toContain(`from "kleur"`)
+
+	const result = await runBundledModuleWithRegistry(
+		env,
+		createMcpCallerContext({
+			baseUrl: 'https://kody.dev',
+			user: {
+				userId: 'user-workers-test',
+				email: 'worker@example.com',
+				displayName: 'Worker Test',
+			},
+		}),
+		{
+			mainModule: bundle.mainModule,
+			modules: bundle.modules,
+		},
+		undefined,
+		{
+			skipCapabilityRegistry: true,
+		},
+	)
+
+	expect(result.error).toBeUndefined()
+	expect(result.result).toEqual({
+		formatted: 'dependency-ok',
+	})
+})

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -15,6 +15,7 @@ import {
 	createPublishedBundleArtifact,
 	createPublishedPackageAppBundleCacheKey,
 } from './module-graph.ts'
+import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from './published-source-dependencies.ts'
 import {
 	readPublishedBundleArtifact,
 	writePublishedBundleArtifact,
@@ -897,6 +898,10 @@ export async function buildPackageAppWorker(input: {
 	const bundled =
 		artifact ??
 		(await (async () => {
+			assertPublishedSourceCanRebuildWithoutInstallingDeps({
+				sourceFiles: input.sourceFiles,
+				bundleLabel: `Saved package app "${input.savedPackage.kodyId}"`,
+			})
 			const compiled = await buildKodyAppBundle({
 				env: input.env,
 				baseUrl: input.baseUrl,

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -9,6 +9,7 @@ import {
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 import { buildSentryOptions } from '#worker/sentry-options.ts'
+import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from './published-source-dependencies.ts'
 
 const serviceStateStorageKey = 'package-service-state'
 const packageServiceRetryDelayMs = 5_000
@@ -503,13 +504,19 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		})
 		const bundle =
 			artifact?.artifact ??
-			(await buildKodyModuleBundle({
-				env: this.env,
-				baseUrl: binding.baseUrl,
-				userId: binding.userId,
-				sourceFiles: runtime.loaded.packageSource.files,
-				entryPoint: runtime.loaded.serviceEntry,
-			}))
+			(await (async () => {
+				assertPublishedSourceCanRebuildWithoutInstallingDeps({
+					sourceFiles: runtime.loaded.packageSource.files,
+					bundleLabel: `Saved package service "${binding.serviceName}"`,
+				})
+				return await buildKodyModuleBundle({
+					env: this.env,
+					baseUrl: binding.baseUrl,
+					userId: binding.userId,
+					sourceFiles: runtime.loaded.packageSource.files,
+					entryPoint: runtime.loaded.serviceEntry,
+				})
+			})())
 		const callerContext = createMcpCallerContext({
 			baseUrl: binding.baseUrl,
 			user: {

--- a/packages/worker/src/package-runtime/published-source-dependencies.ts
+++ b/packages/worker/src/package-runtime/published-source-dependencies.ts
@@ -1,0 +1,46 @@
+const packageManifestPath = 'package.json'
+
+function getDeclaredPackageDependencies(sourceFiles: Record<string, string>) {
+	const packageJson = sourceFiles[packageManifestPath]
+	if (!packageJson) return []
+	try {
+		const parsed = JSON.parse(packageJson) as {
+			dependencies?: Record<string, string>
+		}
+		return Object.keys(parsed.dependencies ?? {}).sort((left, right) =>
+			left.localeCompare(right),
+		)
+	} catch {
+		return []
+	}
+}
+
+function getMissingInstalledDependencies(input: {
+	sourceFiles: Record<string, string>
+	dependencies: Array<string>
+}) {
+	return input.dependencies.filter(
+		(dependencyName) =>
+			input.sourceFiles[`node_modules/${dependencyName}/package.json`] == null,
+	)
+}
+
+export function assertPublishedSourceCanRebuildWithoutInstallingDeps(input: {
+	sourceFiles: Record<string, string>
+	bundleLabel: string
+}) {
+	const dependencies = getDeclaredPackageDependencies(input.sourceFiles)
+	if (dependencies.length === 0) return
+	const missingDependencies = getMissingInstalledDependencies({
+		sourceFiles: input.sourceFiles,
+		dependencies,
+	})
+	if (missingDependencies.length === 0) return
+	throw new Error(
+		`${input.bundleLabel} declares npm dependencies (${missingDependencies
+			.map((dependency) => `"${dependency}"`)
+			.join(
+				', ',
+			)}) but no published runtime bundle artifact is available yet. Republish the package so Kody can install dependencies and persist a fresh runtime bundle artifact.`,
+	)
+}

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -1,8 +1,10 @@
-import { expect, test, vi } from 'vitest'
+import { beforeEach, expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
 	createFileSystemSnapshot: vi.fn(),
 	createTypescriptLanguageService: vi.fn(),
+	buildKodyAppBundle: vi.fn(),
+	buildKodyModuleBundle: vi.fn(),
 }))
 
 vi.mock('@cloudflare/worker-bundler', () => ({
@@ -13,6 +15,13 @@ vi.mock('@cloudflare/worker-bundler', () => ({
 vi.mock('@cloudflare/worker-bundler/typescript', () => ({
 	createTypescriptLanguageService: (...args: Array<unknown>) =>
 		mockModule.createTypescriptLanguageService(...args),
+}))
+
+vi.mock('#worker/package-runtime/module-graph.ts', () => ({
+	buildKodyAppBundle: (...args: Array<unknown>) =>
+		mockModule.buildKodyAppBundle(...args),
+	buildKodyModuleBundle: (...args: Array<unknown>) =>
+		mockModule.buildKodyModuleBundle(...args),
 }))
 
 import { runRepoChecks } from './checks.ts'
@@ -30,6 +39,28 @@ function createSnapshotFromFiles(files: Map<string, string>): MockSnapshot {
 		read: vi.fn((path: string) => files.get(path) ?? null),
 	}
 }
+
+beforeEach(() => {
+	mockModule.createFileSystemSnapshot.mockReset()
+	mockModule.createTypescriptLanguageService.mockReset()
+	mockModule.buildKodyAppBundle.mockReset()
+	mockModule.buildKodyModuleBundle.mockReset()
+	mockModule.buildKodyAppBundle.mockResolvedValue({
+		mainModule: 'dist/app.js',
+		modules: {
+			'dist/app.js':
+				'export default { async fetch() { return new Response("ok") } }',
+		},
+		dependencies: [],
+	})
+	mockModule.buildKodyModuleBundle.mockResolvedValue({
+		mainModule: 'dist/module.js',
+		modules: {
+			'dist/module.js': 'export default async function run() { return "ok" }',
+		},
+		dependencies: [],
+	})
+})
 
 async function collectSnapshotFiles(
 	input: AsyncIterable<readonly [string, string]>,
@@ -70,8 +101,6 @@ function createPackageManifest(input: {
 }
 
 test('runRepoChecks normalizes leading slashes in package job entrypoints', async () => {
-	mockModule.createFileSystemSnapshot.mockReset()
-	mockModule.createTypescriptLanguageService.mockReset()
 	const files = new Map<string, string>([
 		[
 			'package.json',
@@ -154,8 +183,6 @@ test('runRepoChecks normalizes leading slashes in package job entrypoints', asyn
 })
 
 test('runRepoChecks strips repo-session workspace prefixes from package snapshot paths', async () => {
-	mockModule.createFileSystemSnapshot.mockReset()
-	mockModule.createTypescriptLanguageService.mockReset()
 	const files = new Map<string, string>([
 		[
 			'/session/package.json',
@@ -235,8 +262,6 @@ test('runRepoChecks strips repo-session workspace prefixes from package snapshot
 })
 
 test('runRepoChecks accepts execute runtime globals for package-owned jobs', async () => {
-	mockModule.createFileSystemSnapshot.mockReset()
-	mockModule.createTypescriptLanguageService.mockReset()
 	const files = new Map<string, string>([
 		[
 			'package.json',
@@ -299,7 +324,7 @@ test('runRepoChecks accepts execute runtime globals for package-owned jobs', asy
 			expect.objectContaining({
 				kind: 'dependencies',
 				ok: true,
-				message: 'package.json found for dependency fingerprinting.',
+				message: 'package.json declares no npm dependencies.',
 			}),
 			expect.objectContaining({
 				kind: 'typecheck',
@@ -315,8 +340,6 @@ test('runRepoChecks accepts execute runtime globals for package-owned jobs', asy
 })
 
 test('runRepoChecks typechecks package exports with execute semantics globals', async () => {
-	mockModule.createFileSystemSnapshot.mockReset()
-	mockModule.createTypescriptLanguageService.mockReset()
 	const files = new Map<string, string>([
 		[
 			'package.json',
@@ -392,8 +415,6 @@ test('runRepoChecks typechecks package exports with execute semantics globals', 
 })
 
 test('runRepoChecks still reports unknown globals for package-owned jobs', async () => {
-	mockModule.createFileSystemSnapshot.mockReset()
-	mockModule.createTypescriptLanguageService.mockReset()
 	const files = new Map<string, string>([
 		[
 			'package.json',
@@ -474,8 +495,6 @@ test('runRepoChecks still reports unknown globals for package-owned jobs', async
 })
 
 test('runRepoChecks typechecks ESM package job entrypoints', async () => {
-	mockModule.createFileSystemSnapshot.mockReset()
-	mockModule.createTypescriptLanguageService.mockReset()
 	const files = new Map<string, string>([
 		[
 			'package.json',
@@ -548,8 +567,6 @@ test('runRepoChecks typechecks ESM package job entrypoints', async () => {
 })
 
 test('runRepoChecks injects a synthetic tsconfig that allows optional .ts imports for package entrypoints', async () => {
-	mockModule.createFileSystemSnapshot.mockReset()
-	mockModule.createTypescriptLanguageService.mockReset()
 	const files = new Map<string, string>([
 		[
 			'package.json',
@@ -629,8 +646,6 @@ test('runRepoChecks injects a synthetic tsconfig that allows optional .ts import
 })
 
 test('runRepoChecks preserves repo tsconfig via extends while enabling optional .ts imports for packages', async () => {
-	mockModule.createFileSystemSnapshot.mockReset()
-	mockModule.createTypescriptLanguageService.mockReset()
 	const repoTsconfig = JSON.stringify({
 		compilerOptions: {
 			module: 'NodeNext',
@@ -709,5 +724,298 @@ test('runRepoChecks preserves repo tsconfig via extends while enabling optional 
 	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
 		'.__kody_repo_module_check__.ts',
 		expect.stringContaining('import userEntrypoint from "./src/index"'),
+	)
+})
+
+test('runRepoChecks reports declared npm dependencies in package.json', async () => {
+	const files = new Map<string, string>([
+		[
+			'package.json',
+			JSON.stringify({
+				name: '@kody/dependency-aware-package',
+				exports: {
+					'.': './src/index.ts',
+				},
+				dependencies: {
+					kleur: '^4.1.5',
+				},
+				kody: {
+					id: 'dependency-aware-package',
+					description: 'Uses npm dependencies',
+				},
+			}),
+		],
+		['src/index.ts', 'export default async () => "ok"\n'],
+	])
+	const snapshot = createSnapshotFromFiles(files)
+	const typeScriptFileSystem: MockTypeScriptFileSystem = {
+		...snapshot,
+		write: vi.fn(),
+	}
+	mockModule.createFileSystemSnapshot.mockResolvedValue(snapshot)
+	mockModule.createTypescriptLanguageService.mockResolvedValue({
+		fileSystem: typeScriptFileSystem,
+		languageService: {
+			getSemanticDiagnostics: vi.fn(() => []),
+		},
+	})
+
+	const result = await runRepoChecks({
+		workspace: {
+			async readFile(path: string) {
+				return files.get(path) ?? null
+			},
+			async glob() {
+				return Array.from(files.keys()).map((path) => ({ path, type: 'file' }))
+			},
+		},
+		manifestPath: 'package.json',
+		sourceRoot: '/',
+	})
+
+	expect(result.ok).toBe(true)
+	expect(result.results).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				kind: 'dependencies',
+				ok: true,
+				message: 'package.json declares 1 npm dependency: "kleur".',
+			}),
+		]),
+	)
+})
+
+test('runRepoChecks fails bundle validation when runtime bundling cannot resolve a declared dependency', async () => {
+	const files = new Map<string, string>([
+		[
+			'package.json',
+			JSON.stringify({
+				name: '@kody/broken-dependency-package',
+				exports: {
+					'.': './src/index.ts',
+				},
+				dependencies: {
+					marked: '^16.3.0',
+				},
+				kody: {
+					id: 'broken-dependency-package',
+					description: 'Fails to bundle npm dependency',
+				},
+			}),
+		],
+		[
+			'src/index.ts',
+			'import { marked } from "marked"\nexport default async () => marked.parse("**ok**")\n',
+		],
+	])
+	const snapshot = createSnapshotFromFiles(files)
+	const typeScriptFileSystem: MockTypeScriptFileSystem = {
+		...snapshot,
+		write: vi.fn(),
+	}
+	mockModule.createFileSystemSnapshot.mockResolvedValue(snapshot)
+	mockModule.createTypescriptLanguageService.mockResolvedValue({
+		fileSystem: typeScriptFileSystem,
+		languageService: {
+			getSemanticDiagnostics: vi.fn(() => []),
+		},
+	})
+	mockModule.buildKodyModuleBundle.mockRejectedValueOnce(
+		new Error('No such module "marked" imported from bundle.js'),
+	)
+
+	const result = await runRepoChecks({
+		workspace: {
+			async readFile(path: string) {
+				return files.get(path) ?? null
+			},
+			async glob() {
+				return Array.from(files.keys()).map((path) => ({ path, type: 'file' }))
+			},
+		},
+		manifestPath: 'package.json',
+		sourceRoot: '/',
+		env: {} as Env,
+		baseUrl: 'https://kody.dev',
+		userId: 'user-123',
+	})
+
+	expect(result.ok).toBe(false)
+	expect(result.results).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				kind: 'bundle',
+				ok: false,
+				message: expect.stringContaining(
+					'No such module "marked" imported from bundle.js',
+				),
+			}),
+		]),
+	)
+	expect(mockModule.buildKodyModuleBundle).toHaveBeenCalledWith(
+		expect.objectContaining({
+			entryPoint: 'src/index.ts',
+			userId: 'user-123',
+		}),
+	)
+})
+
+test('runRepoChecks validates package runtime bundles with npm dependencies', async () => {
+	const files = new Map<string, string>([
+		[
+			'package.json',
+			JSON.stringify({
+				name: '@kody/npm-deps-package',
+				exports: {
+					'.': './src/index.ts',
+				},
+				kody: {
+					id: 'npm-deps-package',
+					description: 'Uses npm dependencies',
+					services: {
+						processor: {
+							entry: './src/service.ts',
+						},
+					},
+				},
+				dependencies: {
+					marked: '18.0.2',
+				},
+			}),
+		],
+		['src/index.ts', 'export default async () => "ok"\n'],
+		[
+			'src/service.ts',
+			'import { marked } from "marked"\nexport default async () => marked.parse("**ok**")\n',
+		],
+	])
+	const snapshot = createSnapshotFromFiles(files)
+	const typeScriptFileSystem: MockTypeScriptFileSystem = {
+		...snapshot,
+		write: vi.fn(),
+	}
+	const getSemanticDiagnostics = vi.fn(() => [])
+	mockModule.createFileSystemSnapshot.mockResolvedValue(snapshot)
+	mockModule.createTypescriptLanguageService.mockResolvedValue({
+		fileSystem: typeScriptFileSystem,
+		languageService: {
+			getSemanticDiagnostics,
+		},
+	})
+
+	const result = await runRepoChecks({
+		workspace: {
+			async readFile(path: string) {
+				return files.get(path) ?? null
+			},
+			async glob() {
+				return Array.from(files.keys()).map((path) => ({ path, type: 'file' }))
+			},
+		},
+		manifestPath: 'package.json',
+		sourceRoot: '/',
+		env: {} as Env,
+		baseUrl: 'https://kody.dev',
+		userId: 'user-123',
+	})
+
+	expect(result.ok).toBe(true)
+	expect(result.results).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				kind: 'dependencies',
+				ok: true,
+				message: 'package.json declares 1 npm dependency: "marked".',
+			}),
+			expect.objectContaining({
+				kind: 'bundle',
+				ok: true,
+				message: 'Bundled 2 package runtime entrypoint(s) successfully.',
+			}),
+		]),
+	)
+	expect(mockModule.buildKodyModuleBundle).toHaveBeenCalledWith(
+		expect.objectContaining({
+			entryPoint: 'src/index.ts',
+			sourceFiles: {
+				'package.json': files.get('package.json'),
+				'src/index.ts': files.get('src/index.ts'),
+				'src/service.ts': files.get('src/service.ts'),
+			},
+		}),
+	)
+	expect(mockModule.buildKodyModuleBundle).toHaveBeenCalledWith(
+		expect.objectContaining({
+			entryPoint: 'src/service.ts',
+		}),
+	)
+})
+
+test('runRepoChecks fails when package runtime bundle cannot resolve npm dependency', async () => {
+	const files = new Map<string, string>([
+		[
+			'package.json',
+			JSON.stringify({
+				name: '@kody/broken-npm-package',
+				exports: {
+					'.': './src/index.ts',
+				},
+				kody: {
+					id: 'broken-npm-package',
+					description: 'Broken npm dependency',
+				},
+				dependencies: {
+					marked: '18.0.2',
+				},
+			}),
+		],
+		[
+			'src/index.ts',
+			'import { marked } from "marked"\nexport default async () => marked.parse("**ok**")\n',
+		],
+	])
+	const snapshot = createSnapshotFromFiles(files)
+	const typeScriptFileSystem: MockTypeScriptFileSystem = {
+		...snapshot,
+		write: vi.fn(),
+	}
+	mockModule.createFileSystemSnapshot.mockResolvedValue(snapshot)
+	mockModule.createTypescriptLanguageService.mockResolvedValue({
+		fileSystem: typeScriptFileSystem,
+		languageService: {
+			getSemanticDiagnostics: vi.fn(() => []),
+		},
+	})
+	mockModule.buildKodyModuleBundle.mockRejectedValueOnce(
+		new Error('Could not resolve version for marked@18.0.2'),
+	)
+
+	const result = await runRepoChecks({
+		workspace: {
+			async readFile(path: string) {
+				return files.get(path) ?? null
+			},
+			async glob() {
+				return Array.from(files.keys()).map((path) => ({ path, type: 'file' }))
+			},
+		},
+		manifestPath: 'package.json',
+		sourceRoot: '/',
+		env: {} as Env,
+		baseUrl: 'https://kody.dev',
+		userId: 'user-123',
+	})
+
+	expect(result.ok).toBe(false)
+	expect(result.results).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				kind: 'bundle',
+				ok: false,
+				message: expect.stringContaining(
+					'src/index.ts: Could not resolve version for marked@18.0.2',
+				),
+			}),
+		]),
 	)
 })

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -1,5 +1,3 @@
-import { createFileSystemSnapshot } from '@cloudflare/worker-bundler'
-import { createTypescriptLanguageService } from '@cloudflare/worker-bundler/typescript'
 import {
 	getPackageAppEntryPath,
 	listPackageServices,
@@ -43,6 +41,24 @@ const executeTypecheckPreludePath = '.__kody_repo_runtime__.d.ts'
 const repoChecksSyntheticTsconfigPath = 'tsconfig.json'
 const repoChecksSyntheticTsconfigExtendsPath =
 	'./.__kody_repo_tsconfig_base__.json'
+
+async function loadWorkerBundlerSnapshotTools() {
+	// Keep worker-bundler lazy so unrelated node tests can import repo/checks
+	// without eagerly loading the experimental bundler and its wasm payload.
+	const { createFileSystemSnapshot } =
+		await import('@cloudflare/worker-bundler')
+	return {
+		createFileSystemSnapshot,
+	}
+}
+
+async function loadWorkerBundlerTypescriptTools() {
+	const { createTypescriptLanguageService } =
+		await import('@cloudflare/worker-bundler/typescript')
+	return {
+		createTypescriptLanguageService,
+	}
+}
 
 type RepoChecksFileSystem = {
 	read(path: string): string | null
@@ -423,6 +439,7 @@ export async function typecheckPackageEntrypointsFromSourceFiles(input: {
 	ok: boolean
 	message: string
 }> {
+	const { createFileSystemSnapshot } = await loadWorkerBundlerSnapshotTools()
 	const snapshot = await createFileSystemSnapshot(
 		(async function* () {
 			for (const [path, content] of Object.entries(input.sourceFiles)) {
@@ -455,6 +472,8 @@ export async function typecheckPackageEntrypointsFromSourceFiles(input: {
 		repoChecksSyntheticTsconfigPath,
 		buildRepoChecksTsconfig(baseTsconfig),
 	)
+	const { createTypescriptLanguageService } =
+		await loadWorkerBundlerTypescriptTools()
 	const { fileSystem, languageService } = await createTypescriptLanguageService(
 		{
 			fileSystem: typecheckFileSystem,
@@ -534,6 +553,7 @@ export async function runRepoChecks(input: {
 		}
 		return collected
 	})()
+	const { createFileSystemSnapshot } = await loadWorkerBundlerSnapshotTools()
 	const snapshot = await createFileSystemSnapshot(
 		(async function* () {
 			for (const [path, content] of snapshotFiles) {
@@ -631,6 +651,8 @@ export async function runRepoChecks(input: {
 		repoChecksSyntheticTsconfigPath,
 		buildRepoChecksTsconfig(baseTsconfig),
 	)
+	const { createTypescriptLanguageService } =
+		await loadWorkerBundlerTypescriptTools()
 	const { fileSystem, languageService } = await createTypescriptLanguageService(
 		{
 			fileSystem: typecheckFileSystem,

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -1,3 +1,5 @@
+import { createFileSystemSnapshot } from '@cloudflare/worker-bundler'
+import { createTypescriptLanguageService } from '@cloudflare/worker-bundler/typescript'
 import {
 	getPackageAppEntryPath,
 	listPackageServices,
@@ -7,6 +9,10 @@ import {
 	resolvePackageExportPath,
 } from '#worker/package-registry/manifest.ts'
 import { type AuthoredPackageJson } from '#worker/package-registry/types.ts'
+import {
+	buildKodyAppBundle,
+	buildKodyModuleBundle,
+} from '#worker/package-runtime/module-graph.ts'
 import { normalizeRepoWorkspacePath } from './manifest.ts'
 import {
 	createRepoCodemodeModuleTypecheckHarness,
@@ -236,13 +242,18 @@ declare const storage: {
 type PackageTypecheckTarget = {
 	path: string
 	includeStorage: boolean
+	bundleKind: 'app' | 'module'
 }
 
 function collectPackageTypecheckTargets(
 	manifest: AuthoredPackageJson,
 ): Array<PackageTypecheckTarget> {
 	const targets = new Map<string, PackageTypecheckTarget>()
-	const remember = (path: string, includeStorage: boolean) => {
+	const remember = (
+		path: string,
+		includeStorage: boolean,
+		bundleKind: PackageTypecheckTarget['bundleKind'],
+	) => {
 		const normalizedPath = normalizePackageWorkspacePath(path)
 		const existing = targets.get(normalizedPath)
 		if (existing) {
@@ -252,11 +263,12 @@ function collectPackageTypecheckTargets(
 		targets.set(normalizedPath, {
 			path: normalizedPath,
 			includeStorage,
+			bundleKind,
 		})
 	}
 	const appEntryPath = getPackageAppEntryPath(manifest)
 	if (appEntryPath) {
-		remember(appEntryPath, false)
+		remember(appEntryPath, false, 'app')
 	}
 	for (const exportName of Object.keys(manifest.exports)) {
 		remember(
@@ -265,18 +277,80 @@ function collectPackageTypecheckTargets(
 				exportName,
 			}),
 			false,
+			'module',
 		)
 	}
 	for (const job of Object.values(manifest.kody.jobs ?? {})) {
-		remember(job.entry, true)
+		remember(job.entry, true, 'module')
 	}
 	for (const service of listPackageServices(manifest)) {
-		remember(service.entry, true)
+		remember(service.entry, true, 'module')
 	}
 	for (const subscription of listPackageSubscriptions(manifest)) {
-		remember(subscription.handler, true)
+		remember(subscription.handler, true, 'module')
 	}
 	return Array.from(targets.values())
+}
+
+function parseDeclaredDependencies(packageJsonContent: string | null) {
+	if (!packageJsonContent) return []
+	try {
+		const parsed = JSON.parse(packageJsonContent) as {
+			dependencies?: Record<string, string>
+		}
+		return Object.keys(parsed.dependencies ?? {}).sort((left, right) =>
+			left.localeCompare(right),
+		)
+	} catch {
+		return []
+	}
+}
+
+function createSourceFilesRecord(snapshotFiles: Map<string, string>) {
+	return Object.fromEntries(snapshotFiles) as Record<string, string>
+}
+
+async function validatePackageBundles(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	sourceFiles: Record<string, string>
+	entryPoints: Array<PackageTypecheckTarget>
+}) {
+	const failures: Array<string> = []
+	for (const target of input.entryPoints) {
+		try {
+			if (target.bundleKind === 'app') {
+				await buildKodyAppBundle({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					userId: input.userId,
+					sourceFiles: input.sourceFiles,
+					entryPoint: target.path,
+					cacheKey: null,
+				})
+			} else {
+				await buildKodyModuleBundle({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					userId: input.userId,
+					sourceFiles: input.sourceFiles,
+					entryPoint: target.path,
+				})
+			}
+		} catch (error) {
+			failures.push(
+				`${target.path}: ${error instanceof Error ? error.message : String(error)}`,
+			)
+		}
+	}
+	return {
+		ok: failures.length === 0,
+		message:
+			failures.length === 0
+				? `Bundled ${input.entryPoints.length} package runtime entrypoint(s) successfully.`
+				: failures.join('\n'),
+	}
 }
 
 function getPackageTypecheckDiagnostics(input: {
@@ -349,8 +423,6 @@ export async function typecheckPackageEntrypointsFromSourceFiles(input: {
 	ok: boolean
 	message: string
 }> {
-	const { createFileSystemSnapshot } =
-		await import('@cloudflare/worker-bundler')
 	const snapshot = await createFileSystemSnapshot(
 		(async function* () {
 			for (const [path, content] of Object.entries(input.sourceFiles)) {
@@ -369,8 +441,6 @@ export async function typecheckPackageEntrypointsFromSourceFiles(input: {
 				.join(', ')}.`,
 		}
 	}
-	const { createTypescriptLanguageService } =
-		await import('@cloudflare/worker-bundler/typescript')
 	const typecheckFileSystem = createRepoChecksFileSystem({
 		fileSystem: snapshot,
 	})
@@ -394,6 +464,7 @@ export async function typecheckPackageEntrypointsFromSourceFiles(input: {
 		targets: input.entryPoints.map((entryPoint) => ({
 			path: entryPoint.path,
 			includeStorage: entryPoint.includeStorage === true,
+			bundleKind: 'module',
 		})),
 		languageService,
 		fileSystem,
@@ -429,6 +500,9 @@ export async function runRepoChecks(input: {
 	}
 	manifestPath: string
 	sourceRoot: string
+	env?: Env
+	baseUrl?: string
+	userId?: string
 }): Promise<RepoCheckRunResult> {
 	const manifestContent = await input.workspace.readFile(input.manifestPath)
 	if (manifestContent == null) {
@@ -450,36 +524,77 @@ export async function runRepoChecks(input: {
 		/\/+$/,
 		'',
 	)
-	const { createFileSystemSnapshot } =
-		await import('@cloudflare/worker-bundler')
-	const snapshot = await createFileSystemSnapshot(
-		workspaceFilesForSnapshot({
+	const snapshotFiles = await (async () => {
+		const collected = new Map<string, string>()
+		for await (const [path, content] of workspaceFilesForSnapshot({
 			workspace: input.workspace,
 			root: sourceRoot,
-		}),
+		})) {
+			collected.set(path, content)
+		}
+		return collected
+	})()
+	const snapshot = await createFileSystemSnapshot(
+		(async function* () {
+			for (const [path, content] of snapshotFiles) {
+				yield [path, content] as const
+			}
+		})(),
 	)
 
 	const packageJson = snapshot.read('package.json')
+	const declaredDependencies = parseDeclaredDependencies(packageJson)
 	results.push({
 		kind: 'dependencies',
 		ok: true,
 		message:
-			packageJson != null
-				? 'package.json found for dependency fingerprinting.'
-				: 'No package.json found in source root; dependency check skipped.',
+			packageJson == null
+				? 'No package.json found in source root; dependency check skipped.'
+				: declaredDependencies.length === 0
+					? 'package.json declares no npm dependencies.'
+					: `package.json declares ${declaredDependencies.length} npm dependenc${
+							declaredDependencies.length === 1 ? 'y' : 'ies'
+						}: ${declaredDependencies.map((dependency) => `"${dependency}"`).join(', ')}.`,
 	})
 
 	const entryPoints = collectPackageTypecheckTargets(manifest)
 	const missingEntryPoints = entryPoints
 		.map((target) => target.path)
 		.filter((path) => snapshot.read(path) == null)
+	const bundleContext =
+		input.env && input.userId
+			? {
+					env: input.env,
+					baseUrl: input.baseUrl ?? input.sourceRoot,
+					userId: input.userId,
+				}
+			: null
+	const bundleCheckResult =
+		missingEntryPoints.length > 0
+			? {
+					ok: false,
+					message: formatBundleCheckMessage({
+						missingEntryPoints,
+						targetCount: entryPoints.length,
+					}),
+				}
+			: bundleContext
+				? await validatePackageBundles({
+						...bundleContext,
+						sourceFiles: createSourceFilesRecord(snapshotFiles),
+						entryPoints,
+					})
+				: {
+						ok: true,
+						message: formatBundleCheckMessage({
+							missingEntryPoints,
+							targetCount: entryPoints.length,
+						}),
+					}
 	results.push({
 		kind: 'bundle',
-		ok: missingEntryPoints.length === 0,
-		message: formatBundleCheckMessage({
-			missingEntryPoints,
-			targetCount: entryPoints.length,
-		}),
+		ok: bundleCheckResult.ok,
+		message: bundleCheckResult.message,
 	})
 
 	if (missingEntryPoints.length > 0) {
@@ -502,8 +617,6 @@ export async function runRepoChecks(input: {
 		}
 	}
 
-	const { createTypescriptLanguageService } =
-		await import('@cloudflare/worker-bundler/typescript')
 	const typecheckFileSystem = createRepoChecksFileSystem({
 		fileSystem: snapshot,
 	})

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -1007,6 +1007,9 @@ class RepoSessionBase extends DurableObject<Env> {
 			workspace: this.workspace,
 			manifestPath,
 			sourceRoot,
+			env: this.env,
+			baseUrl: source.source_root,
+			userId: input.userId,
 		})
 		const runId = crypto.randomUUID()
 		const treeHash = await this.computeTreeHash()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make the saved-package bundler preserve a real root `package.json`/Wrangler config and root-level `node_modules` entries so `@cloudflare/worker-bundler` can resolve declared npm dependencies for package exports, services, apps, jobs, and subscriptions
- make repo-session package checks actually validate dependency-backed runtime bundles instead of only reporting `package.json` presence, so unsupported or unresolved npm imports fail during checks instead of surfacing later at runtime
- fix repo-check path collisions so a file reused as both a package app entry and a module/job/service entry is validated with both bundle kinds instead of silently dropping one validation path
- add a lightweight published-source dependency guard for missing bundle artifacts and lazy-load the worker bundler in package/runtime check paths so npm-backed packages fail with clear republish guidance without breaking unrelated node test discovery
- document saved-package `package.json` dependency support and the publish/check-time resolution model for both users and contributors

## Testing
- `npx vitest run --config vitest.node.config.ts packages/worker/src/repo/checks.node.test.ts packages/worker/src/package-invocations/service.node.test.ts`
- `npx vitest run --config vitest.workers.config.ts packages/worker/src/package-runtime/module-graph.workers.test.ts`
- `npx vitest run --config vitest.node.config.ts packages/worker/src/repo/checks.node.test.ts`
- `npx vitest run --config vitest.workers.config.ts packages/worker/src/package-runtime/module-graph.workers.test.ts`
- `npm run test`
- `npm run test:e2e:run` (via the successful `git push` pre-push hook)

## Notes
- no new user-facing config option was added for dependency installation; saved-package dependency support is built into the checks/publish/runtime pipeline
- runtime safety remains the same: dependency resolution happens through the existing bundling pipeline, not by arbitrary package installation from user code at execution time
- follow-up review fixes removed an unused exported helper and hardened the workers regression assertion for unresolved npm imports
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbd49b30-297f-4032-a878-42194bcfffe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbd49b30-297f-4032-a878-42194bcfffe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
- Added guidance on declaring and using npm dependencies in saved packages

**Improvements**
- Enhanced package validation to detect missing npm dependencies during checks, providing clear error messages before runtime execution
- Declared npm dependencies are now automatically bundled into package runtime artifacts for exports, apps, services, jobs, and subscriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->