### PR TITLE
Fix saved package export artifact imports

### DIFF
--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -67,7 +67,7 @@ export function normalizePackageWorkspacePath(path: string) {
 	return path.trim().replace(/^\.?\//, '')
 }
 
-function normalizePackageExportKey(exportName: string) {
+export function normalizePackageExportKey(exportName: string) {
 	const trimmed = exportName.trim()
 	if (!trimmed) {
 		throw new Error('Package export name must not be empty.')

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, expect, test, vi } from 'vitest'
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
+import type * as PublishedBundleArtifactsModule from './published-bundle-artifacts.ts'
 
 const mockModule = vi.hoisted(() => ({
 	createWorker: vi.fn(),
@@ -26,9 +27,9 @@ vi.mock('#worker/package-registry/source.ts', () => ({
 }))
 
 vi.mock('./published-bundle-artifacts.ts', async () => {
-	const actual = await vi.importActual<
-		typeof import('./published-bundle-artifacts.ts')
-	>('./published-bundle-artifacts.ts')
+	const actual = await vi.importActual<typeof PublishedBundleArtifactsModule>(
+		'./published-bundle-artifacts.ts',
+	)
 	return {
 		...actual,
 		loadPublishedBundleArtifactByIdentity: (...args: Array<unknown>) =>

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -224,9 +224,6 @@ test('buildKodyModuleBundle resolves scoped package imports by full package name
 	expect(firstCall?.files?.['.__kody_root__/index.js']).toContain(
 		'__kody_virtual__/imports/',
 	)
-	expect(firstCall?.files?.['.__kody_root__/index.js']).toContain(
-		'kentcdodds/example-package/follow-up-on-pr-agent.js',
-	)
 	expect(firstCall?.files?.['.__kody_root__/index.js']).not.toContain(
 		'kody:@kentcdodds/example-package/follow-up-on-pr-agent',
 	)
@@ -415,6 +412,160 @@ test('buildKodyModuleBundle prefers published export artifacts for saved package
 	)
 	expect(proxyEntry?.[1]).toContain('.__published_bundle__')
 	expect(proxyEntry?.[1]).not.toContain('src/html.ts')
+})
+
+test('buildKodyModuleBundle keeps distinct proxy and artifact paths for exports whose names only differ by punctuation', async () => {
+	mockModule.createWorker.mockResolvedValue(
+		createBundleResult('published-artifact-collision-safe'),
+	)
+	mockModule.getSavedPackageByName.mockResolvedValue(createSavedPackageRecord())
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: {
+			id: 'source-1',
+			published_commit: 'commit-1',
+		},
+		manifest: {
+			name: '@kentcdodds/example-package',
+			exports: {
+				'./foo.bar': './src/foo-dot.ts',
+				'./foo-bar': './src/foo-dash.ts',
+			},
+			kody: {
+				id: 'example-package',
+				description: 'Example package',
+			},
+		},
+		files: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/example-package',
+				exports: {
+					'./foo.bar': './src/foo-dot.ts',
+					'./foo-bar': './src/foo-dash.ts',
+				},
+				dependencies: {
+					marked: '18.0.2',
+				},
+				kody: {
+					id: 'example-package',
+					description: 'Example package',
+				},
+			}),
+			'src/foo-dot.ts':
+				'import { marked } from "marked"\nexport default async function fooDot() { return marked.parse("**dot**") }',
+			'src/foo-dash.ts':
+				'import { marked } from "marked"\nexport default async function fooDash() { return marked.parse("**dash**") }',
+		},
+	})
+	mockModule.loadPublishedBundleArtifactByIdentity.mockImplementation(
+		async (input: { artifactName?: string | null }) => {
+			if (input.artifactName === './foo.bar') {
+				return {
+					row: {
+						id: 'artifact-dot',
+					},
+					artifact: {
+						version: 1,
+						kind: 'module',
+						artifactName: './foo.bar',
+						sourceId: 'source-1',
+						publishedCommit: 'commit-1',
+						entryPoint: 'src/foo-dot.ts',
+						mainModule: 'dist/foo-dot.js',
+						modules: {
+							'dist/foo-dot.js': 'export default "dot"',
+						},
+						dependencies: [],
+						packageContext: {
+							packageId: 'pkg-1',
+							kodyId: 'example-package',
+							sourceId: 'source-1',
+						},
+						serviceContext: null,
+						createdAt: '2026-05-01T00:00:00.000Z',
+					},
+				}
+			}
+			if (input.artifactName === './foo-bar') {
+				return {
+					row: {
+						id: 'artifact-dash',
+					},
+					artifact: {
+						version: 1,
+						kind: 'module',
+						artifactName: './foo-bar',
+						sourceId: 'source-1',
+						publishedCommit: 'commit-1',
+						entryPoint: 'src/foo-dash.ts',
+						mainModule: 'dist/foo-dash.js',
+						modules: {
+							'dist/foo-dash.js': 'export default "dash"',
+						},
+						dependencies: [],
+						packageContext: {
+							packageId: 'pkg-1',
+							kodyId: 'example-package',
+							sourceId: 'source-1',
+						},
+						serviceContext: null,
+						createdAt: '2026-05-01T00:00:00.000Z',
+					},
+				}
+			}
+			return null
+		},
+	)
+
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+
+	await buildKodyModuleBundle({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/local-package',
+				exports: {
+					'.': './index.js',
+				},
+				kody: {
+					id: 'local-package',
+					description: 'Local package',
+				},
+			}),
+			'index.js': [
+				'import fooDot from "kody:@kentcdodds/example-package/foo.bar"',
+				'import fooDash from "kody:@kentcdodds/example-package/foo-bar"',
+				'export default [fooDot, fooDash]',
+			].join('\n'),
+		},
+		entryPoint: 'index.js',
+	})
+
+	const firstCall = mockModule.createWorker.mock.calls[0]?.[0] as
+		| {
+				files?: Record<string, string>
+		  }
+		| undefined
+	const publishedBundlePaths = Object.keys(firstCall?.files ?? {}).filter(
+		(path) => path.includes('.__published_bundle__'),
+	)
+	expect(
+		publishedBundlePaths.filter((path) => path.endsWith('/dist/foo-dot.js')),
+	).toHaveLength(1)
+	expect(
+		publishedBundlePaths.filter((path) => path.endsWith('/dist/foo-dash.js')),
+	).toHaveLength(1)
+	expect(new Set(publishedBundlePaths).size).toBe(publishedBundlePaths.length)
+
+	const proxyPaths = Object.keys(firstCall?.files ?? {}).filter((path) =>
+		path.includes('__kody_virtual__/imports/'),
+	)
+	expect(proxyPaths).toHaveLength(2)
+	expect(new Set(proxyPaths).size).toBe(2)
 })
 
 test('buildKodyModuleBundle requires a published artifact before importing saved package exports with npm dependencies', async () => {

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -6,6 +6,7 @@ const mockModule = vi.hoisted(() => ({
 	getSavedPackageByKodyId: vi.fn(),
 	getSavedPackageByName: vi.fn(),
 	loadPackageSourceBySourceId: vi.fn(),
+	loadPublishedBundleArtifactByIdentity: vi.fn(),
 }))
 
 vi.mock('@cloudflare/worker-bundler', () => ({
@@ -24,6 +25,17 @@ vi.mock('#worker/package-registry/source.ts', () => ({
 		mockModule.loadPackageSourceBySourceId(...args),
 }))
 
+vi.mock('./published-bundle-artifacts.ts', async () => {
+	const actual = await vi.importActual<
+		typeof import('./published-bundle-artifacts.ts')
+	>('./published-bundle-artifacts.ts')
+	return {
+		...actual,
+		loadPublishedBundleArtifactByIdentity: (...args: Array<unknown>) =>
+			mockModule.loadPublishedBundleArtifactByIdentity(...args),
+	}
+})
+
 const { buildKodyAppBundle, createPublishedPackageAppBundleCacheKey } =
 	await import('./module-graph.ts')
 
@@ -32,6 +44,7 @@ beforeEach(() => {
 	mockModule.getSavedPackageByName.mockReset()
 	mockModule.getSavedPackageByKodyId.mockReset()
 	mockModule.loadPackageSourceBySourceId.mockReset()
+	mockModule.loadPublishedBundleArtifactByIdentity.mockReset()
 })
 
 function createBundleResult(suffix: string) {
@@ -280,6 +293,200 @@ test('buildKodyModuleBundle proxies package module default and named exports', a
 	expect(proxy).toContain('export default __kodyPackageModule.default')
 })
 
+test('buildKodyModuleBundle prefers published export artifacts for saved package imports', async () => {
+	mockModule.createWorker.mockResolvedValue(
+		createBundleResult('published-artifact'),
+	)
+	mockModule.getSavedPackageByName.mockResolvedValue(createSavedPackageRecord())
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: {
+			id: 'source-1',
+			published_commit: 'commit-1',
+		},
+		manifest: {
+			name: '@kentcdodds/example-package',
+			exports: {
+				'./html': './src/html.ts',
+			},
+			kody: {
+				id: 'example-package',
+				description: 'Example package',
+			},
+		},
+		files: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/example-package',
+				exports: {
+					'./html': './src/html.ts',
+				},
+				dependencies: {
+					marked: '18.0.2',
+				},
+				kody: {
+					id: 'example-package',
+					description: 'Example package',
+				},
+			}),
+			'src/html.ts':
+				'import { marked } from "marked"\nexport default async function render() { return marked.parse("**ok**") }',
+		},
+	})
+	mockModule.loadPublishedBundleArtifactByIdentity.mockResolvedValue({
+		row: {
+			id: 'artifact-1',
+		},
+		artifact: {
+			version: 1,
+			kind: 'module',
+			artifactName: './html',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			entryPoint: 'src/html.ts',
+			mainModule: 'dist/html.js',
+			modules: {
+				'dist/html.js':
+					'export default async function render() { return "<p><strong>ok</strong></p>" }',
+			},
+			dependencies: [
+				{
+					sourceId: 'source-1',
+					publishedCommit: 'commit-1',
+					kodyId: 'example-package',
+					packageName: '@kentcdodds/example-package',
+				},
+			],
+			packageContext: {
+				packageId: 'pkg-1',
+				kodyId: 'example-package',
+				sourceId: 'source-1',
+			},
+			serviceContext: null,
+			createdAt: '2026-05-01T00:00:00.000Z',
+		},
+	})
+
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+
+	const result = await buildKodyModuleBundle({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/local-package',
+				exports: {
+					'.': './index.js',
+				},
+				kody: {
+					id: 'local-package',
+					description: 'Local package',
+				},
+			}),
+			'index.js':
+				'import render from "kody:@kentcdodds/example-package/html"\nexport default render\n',
+		},
+		entryPoint: 'index.js',
+	})
+
+	expect(result.dependencies).toEqual([
+		{
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			kodyId: 'example-package',
+			packageName: '@kentcdodds/example-package',
+		},
+	])
+	const firstCall = mockModule.createWorker.mock.calls[0]?.[0] as
+		| {
+				files?: Record<string, string>
+		  }
+		| undefined
+	const artifactEntry = Object.entries(firstCall?.files ?? {}).find(
+		([path]) =>
+			path.includes('.__published_bundle__') && path.endsWith('/dist/html.js'),
+	)
+	expect(artifactEntry?.[1]).toContain('<p><strong>ok</strong></p>')
+	const proxyEntry = Object.entries(firstCall?.files ?? {}).find(([path]) =>
+		path.includes('__kody_virtual__/imports/'),
+	)
+	expect(proxyEntry?.[1]).toContain('.__published_bundle__')
+	expect(proxyEntry?.[1]).not.toContain('src/html.ts')
+})
+
+test('buildKodyModuleBundle requires a published artifact before importing saved package exports with npm dependencies', async () => {
+	mockModule.createWorker.mockResolvedValue(
+		createBundleResult('missing-artifact'),
+	)
+	mockModule.getSavedPackageByName.mockResolvedValue(createSavedPackageRecord())
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: {
+			id: 'source-1',
+			published_commit: 'commit-1',
+		},
+		manifest: {
+			name: '@kentcdodds/example-package',
+			exports: {
+				'./html': './src/html.ts',
+			},
+			kody: {
+				id: 'example-package',
+				description: 'Example package',
+			},
+		},
+		files: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/example-package',
+				exports: {
+					'./html': './src/html.ts',
+				},
+				dependencies: {
+					marked: '18.0.2',
+				},
+				kody: {
+					id: 'example-package',
+					description: 'Example package',
+				},
+			}),
+			'src/html.ts':
+				'import { marked } from "marked"\nexport default async function render() { return marked.parse("**ok**") }',
+		},
+	})
+	mockModule.loadPublishedBundleArtifactByIdentity.mockResolvedValue(null)
+
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+
+	await expect(
+		buildKodyModuleBundle({
+			env: {
+				APP_DB: {},
+				REPO_SESSION: {},
+			} as Env,
+			baseUrl: 'https://heykody.dev',
+			userId: 'user-1',
+			sourceFiles: {
+				'package.json': JSON.stringify({
+					name: '@kentcdodds/local-package',
+					exports: {
+						'.': './index.js',
+					},
+					kody: {
+						id: 'local-package',
+						description: 'Local package',
+					},
+				}),
+				'index.js':
+					'import render from "kody:@kentcdodds/example-package/html"\nexport default render\n',
+			},
+			entryPoint: 'index.js',
+		}),
+	).rejects.toThrow(
+		'no published runtime bundle artifact is available yet. Republish the package so Kody can install dependencies and persist a fresh runtime bundle artifact.',
+	)
+})
+
 test('buildKodyModuleBundle keeps dependencies for scoped packages with the same leaf', async () => {
 	mockModule.createWorker.mockResolvedValue(createBundleResult('shared-leaf'))
 	mockModule.getSavedPackageByName.mockImplementation(
@@ -350,11 +557,13 @@ test('buildKodyModuleBundle keeps dependencies for scoped packages with the same
 			sourceId: 'source-alice',
 			publishedCommit: 'commit-source-alice',
 			kodyId: 'shared-package',
+			packageName: '@alice/shared-package',
 		},
 		{
 			sourceId: 'source-bob',
 			publishedCommit: 'commit-source-bob',
 			kodyId: 'shared-package',
+			packageName: '@bob/shared-package',
 		},
 	])
 })

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -213,8 +213,17 @@ export default __kodyPackageModule.default;
 `.trim()
 }
 
-function sanitizeSpecifier(specifier: string) {
-	return specifier.replace(/[^a-zA-Z0-9/_-]+/g, '-')
+function encodePathKey(value: string) {
+	return Array.from(new TextEncoder().encode(value), (byte) =>
+		byte.toString(16).padStart(2, '0'),
+	).join('')
+}
+
+function createPackageProxyPathSegment(specifier: string) {
+	const parsed = parseKodyPackageSpecifier(specifier)
+	return encodePathKey(
+		`${parsed.packageName}#${normalizePackageExportKey(parsed.exportName)}`,
+	)
 }
 
 function isBundlerRootConfigPath(path: string) {
@@ -338,7 +347,7 @@ async function maybeEnsurePublishedArtifactTarget(input: {
 	const artifactPrefix = joinPath(
 		input.loaded.prefix,
 		'.__published_bundle__',
-		sanitizeSpecifier(exportName),
+		encodePathKey(exportName),
 	)
 	for (const [modulePath, module] of Object.entries(
 		artifact.artifact.modules,
@@ -447,7 +456,7 @@ async function ensurePackageProxy(
 		})()
 	const proxyPath = joinPath(
 		packageImportProxyPrefix,
-		`${sanitizeSpecifier(specifier)}.js`,
+		`${createPackageProxyPathSegment(specifier)}.js`,
 	)
 	const proxyTarget = createRelativeImportSpecifier(
 		proxyPath,

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -4,6 +4,7 @@ import {
 } from '#worker/package-registry/source.ts'
 import {
 	normalizePackageWorkspacePath,
+	normalizePackageExportKey,
 	resolvePackageExportPath,
 } from '#worker/package-registry/manifest.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
@@ -107,7 +108,14 @@ function rememberDependency(
 	state: RewriteState,
 	dependency: BundleArtifactDependency,
 ) {
-	state.dependencies.set(createDependencyKey(dependency), dependency)
+	const key = createDependencyKey(dependency)
+	const existing = state.dependencies.get(key)
+	state.dependencies.set(
+		key,
+		existing?.packageName && !dependency.packageName
+			? { ...dependency, packageName: existing.packageName }
+			: dependency,
+	)
 }
 
 function rememberDependencies(
@@ -207,17 +215,6 @@ export default __kodyPackageModule.default;
 
 function sanitizeSpecifier(specifier: string) {
 	return specifier.replace(/[^a-zA-Z0-9/_-]+/g, '-')
-}
-
-function normalizeExportArtifactName(exportName: string) {
-	const trimmed = exportName.trim()
-	if (!trimmed) {
-		throw new Error('Package export name must not be empty.')
-	}
-	if (trimmed === '.' || trimmed === './') {
-		return '.'
-	}
-	return trimmed.startsWith('./') ? trimmed : `./${trimmed}`
 }
 
 function isBundlerRootConfigPath(path: string) {
@@ -321,7 +318,7 @@ async function maybeEnsurePublishedArtifactTarget(input: {
 		return null
 	}
 	const parsed = parseKodyPackageSpecifier(input.specifier)
-	const exportName = normalizeExportArtifactName(parsed.exportName)
+	const exportName = normalizePackageExportKey(parsed.exportName)
 	const entryPoint = resolvePackageExportPath({
 		manifest: input.loaded.manifest,
 		exportName,
@@ -438,7 +435,7 @@ async function ensurePackageProxy(
 		(() => {
 			assertPublishedSourceCanRebuildWithoutInstallingDeps({
 				sourceFiles: loaded.files,
-				bundleLabel: `Saved package export "${normalizeExportArtifactName(
+				bundleLabel: `Saved package export "${normalizePackageExportKey(
 					parsed.exportName,
 				)}"`,
 			})

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -22,6 +22,8 @@ import {
 	packageSpecifierPrefix,
 	resolveSavedPackageImport,
 } from './package-import-resolution.ts'
+import { loadPublishedBundleArtifactByIdentity } from './published-bundle-artifacts.ts'
+import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from './published-source-dependencies.ts'
 import {
 	collectLiteralImportNodes,
 	collectLiteralImportSpecifiers,
@@ -95,6 +97,26 @@ type RewriteState = {
 		LoadedPackageSource & { row: SavedPackageRecord; prefix: string }
 	>
 	dependencies: Map<string, BundleArtifactDependency>
+}
+
+function createDependencyKey(dependency: BundleArtifactDependency) {
+	return `${dependency.sourceId}:${dependency.publishedCommit}:${dependency.kodyId}`
+}
+
+function rememberDependency(
+	state: RewriteState,
+	dependency: BundleArtifactDependency,
+) {
+	state.dependencies.set(createDependencyKey(dependency), dependency)
+}
+
+function rememberDependencies(
+	state: RewriteState,
+	dependencies: Array<BundleArtifactDependency>,
+) {
+	for (const dependency of dependencies) {
+		rememberDependency(state, dependency)
+	}
 }
 
 function createRelativeImportSpecifier(fromPath: string, targetPath: string) {
@@ -187,6 +209,17 @@ function sanitizeSpecifier(specifier: string) {
 	return specifier.replace(/[^a-zA-Z0-9/_-]+/g, '-')
 }
 
+function normalizeExportArtifactName(exportName: string) {
+	const trimmed = exportName.trim()
+	if (!trimmed) {
+		throw new Error('Package export name must not be empty.')
+	}
+	if (trimmed === '.' || trimmed === './') {
+		return '.'
+	}
+	return trimmed.startsWith('./') ? trimmed : `./${trimmed}`
+}
+
 function isBundlerRootConfigPath(path: string) {
 	return path === packageManifestPath || wranglerConfigPaths.includes(path)
 }
@@ -255,6 +288,73 @@ function assertBundleHasNoUnresolvedBareImports(input: {
 	)
 }
 
+function materializeArtifactModuleSource(input: {
+	modulePath: string
+	module: WorkerLoaderModules[string]
+}): string {
+	if (typeof input.module === 'string') {
+		return input.module
+	}
+	if (typeof input.module.js === 'string') {
+		return input.module.js
+	}
+	if (typeof input.module.cjs === 'string') {
+		return input.module.cjs
+	}
+	if (typeof input.module.text === 'string') {
+		return input.module.text
+	}
+	if (input.module.json !== undefined) {
+		return JSON.stringify(input.module.json)
+	}
+	throw new Error(
+		`Saved package published bundle module "${input.modulePath}" uses an unsupported artifact module shape for import composition.`,
+	)
+}
+
+async function maybeEnsurePublishedArtifactTarget(input: {
+	state: RewriteState
+	specifier: string
+	loaded: LoadedPackageSource & { row: SavedPackageRecord; prefix: string }
+}): Promise<string | null> {
+	if (!input.loaded.source.published_commit) {
+		return null
+	}
+	const parsed = parseKodyPackageSpecifier(input.specifier)
+	const exportName = normalizeExportArtifactName(parsed.exportName)
+	const entryPoint = resolvePackageExportPath({
+		manifest: input.loaded.manifest,
+		exportName,
+	})
+	const artifact = await loadPublishedBundleArtifactByIdentity({
+		env: input.state.env,
+		userId: input.state.userId,
+		sourceId: input.loaded.row.sourceId,
+		kind: 'module',
+		artifactName: exportName,
+		entryPoint,
+	})
+	if (!artifact?.artifact) {
+		return null
+	}
+	rememberDependencies(input.state, artifact.artifact.dependencies)
+	const artifactPrefix = joinPath(
+		input.loaded.prefix,
+		'.__published_bundle__',
+		sanitizeSpecifier(exportName),
+	)
+	for (const [modulePath, module] of Object.entries(
+		artifact.artifact.modules,
+	)) {
+		input.state.files[joinPath(artifactPrefix, modulePath)] =
+			materializeArtifactModuleSource({
+				modulePath,
+				module,
+			})
+	}
+	return joinPath(artifactPrefix, artifact.artifact.mainModule)
+}
+
 function applyReplacements(
 	source: string,
 	replacements: Array<RewriteReplacement>,
@@ -302,10 +402,11 @@ async function ensurePackageLoaded(
 	}
 	state.packages.set(packageKey, entry)
 	if (loaded.source.published_commit) {
-		state.dependencies.set(packageKey, {
+		rememberDependency(state, {
 			sourceId: loaded.source.id,
 			publishedCommit: loaded.source.published_commit,
 			kodyId: row.kodyId,
+			packageName: row.name,
 		})
 	}
 	for (const [filePath, content] of Object.entries(loaded.files)) {
@@ -328,11 +429,25 @@ async function ensurePackageProxy(
 	if (existing) return existing
 	const parsed = parseKodyPackageSpecifier(specifier)
 	const loaded = await ensurePackageLoaded(state, specifier)
-	const exportPath = resolvePackageExportPath({
-		manifest: loaded.manifest,
-		exportName: parsed.exportName,
-	})
-	const absoluteExportPath = joinPath(loaded.prefix, exportPath)
+	const absoluteExportPath =
+		(await maybeEnsurePublishedArtifactTarget({
+			state,
+			specifier,
+			loaded,
+		})) ??
+		(() => {
+			assertPublishedSourceCanRebuildWithoutInstallingDeps({
+				sourceFiles: loaded.files,
+				bundleLabel: `Saved package export "${normalizeExportArtifactName(
+					parsed.exportName,
+				)}"`,
+			})
+			const exportPath = resolvePackageExportPath({
+				manifest: loaded.manifest,
+				exportName: parsed.exportName,
+			})
+			return joinPath(loaded.prefix, exportPath)
+		})()
 	const proxyPath = joinPath(
 		packageImportProxyPrefix,
 		`${sanitizeSpecifier(specifier)}.js`,

--- a/packages/worker/src/package-runtime/module-graph.workers.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.workers.test.ts
@@ -4,70 +4,74 @@ import { createMcpCallerContext } from '#mcp/context.ts'
 import { runBundledModuleWithRegistry } from '#mcp/run-codemode-registry.ts'
 import { buildKodyModuleBundle } from './module-graph.ts'
 
-test('saved package bundles and executes npm dependencies declared in package.json', async () => {
-	const packageJson = JSON.stringify({
-		name: '@kentcdodds/dependency-package',
-		exports: {
-			'.': './src/index.ts',
-		},
-		dependencies: {
-			kleur: '^4.1.5',
-		},
-		kody: {
-			id: 'dependency-package',
-			description: 'Exercises npm dependency bundling',
-		},
-	})
-
-	const bundle = await buildKodyModuleBundle({
-		env,
-		baseUrl: 'https://kody.dev',
-		userId: 'user-workers-test',
-		sourceFiles: {
-			'package.json': packageJson,
-			'src/index.ts': [
-				"import kleur from 'kleur'",
-				'export default async function run() {',
-				"\treturn { formatted: kleur.green('dependency-ok') }",
-				'}',
-			].join('\n'),
-		},
-		entryPoint: 'src/index.ts',
-	})
-
-	const moduleSources = Object.values(bundle.modules)
-		.map((module) => {
-			if (typeof module === 'string') return module
-			return [module.js, module.cjs, module.text]
-				.filter((value): value is string => typeof value === 'string')
-				.join('\n')
-		})
-		.join('\n')
-	expect(moduleSources).toContain('dependency-ok')
-	expect(moduleSources).not.toContain(`from "kleur"`)
-
-	const result = await runBundledModuleWithRegistry(
-		env,
-		createMcpCallerContext({
-			baseUrl: 'https://kody.dev',
-			user: {
-				userId: 'user-workers-test',
-				email: 'worker@example.com',
-				displayName: 'Worker Test',
+test(
+	'saved package bundles and executes npm dependencies declared in package.json',
+	{ timeout: 20_000 },
+	async () => {
+		const packageJson = JSON.stringify({
+			name: '@kentcdodds/dependency-package',
+			exports: {
+				'.': './src/index.ts',
 			},
-		}),
-		{
-			mainModule: bundle.mainModule,
-			modules: bundle.modules,
-		},
-		undefined,
-		{
-			skipCapabilityRegistry: true,
-		},
-	)
+			dependencies: {
+				kleur: '^4.1.5',
+			},
+			kody: {
+				id: 'dependency-package',
+				description: 'Exercises npm dependency bundling',
+			},
+		})
 
-	expect(result.error).toBeUndefined()
-	expect(result.result).toEqual({
-		formatted: 'dependency-ok',
-	})
-})
+		const bundle = await buildKodyModuleBundle({
+			env,
+			baseUrl: 'https://kody.dev',
+			userId: 'user-workers-test',
+			sourceFiles: {
+				'package.json': packageJson,
+				'src/index.ts': [
+					"import kleur from 'kleur'",
+					'export default async function run() {',
+					"\treturn { formatted: kleur.green('dependency-ok') }",
+					'}',
+				].join('\n'),
+			},
+			entryPoint: 'src/index.ts',
+		})
+
+		const moduleSources = Object.values(bundle.modules)
+			.map((module) => {
+				if (typeof module === 'string') return module
+				return [module.js, module.cjs, module.text]
+					.filter((value): value is string => typeof value === 'string')
+					.join('\n')
+			})
+			.join('\n')
+		expect(moduleSources).toContain('dependency-ok')
+		expect(moduleSources).not.toContain(`from "kleur"`)
+
+		const result = await runBundledModuleWithRegistry(
+			env,
+			createMcpCallerContext({
+				baseUrl: 'https://kody.dev',
+				user: {
+					userId: 'user-workers-test',
+					email: 'worker@example.com',
+					displayName: 'Worker Test',
+				},
+			}),
+			{
+				mainModule: bundle.mainModule,
+				modules: bundle.modules,
+			},
+			undefined,
+			{
+				skipCapabilityRegistry: true,
+			},
+		)
+
+		expect(result.error).toBeUndefined()
+		expect(result.result).toEqual({
+			formatted: 'dependency-ok',
+		})
+	},
+)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make `kody:@scope/package/export` imports prefer published module bundle artifacts during execute/runtime composition
- keep raw published source as a fallback only when it can rebuild without ad hoc dependency installs, preserving the republish guidance for dependency-backed packages
- address review feedback by reusing the manifest export-key normalizer, preserving `packageName` when dependency records are replayed, and switching the test mock to a top-level type import
- replace lossy sanitized export/specifier path keys with collision-safe encoded keys for published artifact materialization and proxy modules so distinct exports cannot overwrite each other

## Testing
- `npx vitest run --config vitest.node.config.ts packages/worker/src/repo/checks.node.test.ts packages/worker/src/package-runtime/module-graph.node.test.ts packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts`
- `npx vitest run --config vitest.workers.config.ts packages/worker/src/package-runtime/module-graph.workers.test.ts`
- `git push -u origin cursor/kody-saved-package-dependencies-75c5` (pre-push hook ran `npm run test && npm run test:e2e:run` successfully)
- Validation log artifact: <a href="/opt/cursor/artifacts/saved_package_dependency_test_log.txt">saved_package_dependency_test_log.txt</a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89e90820-8984-4e06-8c4c-5bd79066bb1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89e90820-8984-4e06-8c4c-5bd79066bb1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compose imports from pre-published module artifacts and fall back to original package exports when artifacts aren’t available.
  * Expose a package export normalization helper for reuse across the runtime.

* **Tests**
  * Added coverage for embedding published bundles, dependency tracking, and explicit error behavior when artifacts are unavailable.
  * Adjusted test timeouts and assertions to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->