### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,40 @@ This file is intentionally brief. Detailed instructions live in focused docs:
   - [docs/contributing/architecture/request-lifecycle.md](./docs/contributing/architecture/request-lifecycle.md)
   - [docs/contributing/architecture/authentication.md](./docs/contributing/architecture/authentication.md)
   - [docs/contributing/architecture/data-storage.md](./docs/contributing/architecture/data-storage.md)
+
+
+## Cursor Cloud specific instructions
+
+| Task | Command |
+| ---------------- | ---------------------- |
+| Start dev server | `npm run dev` |
+| Full validation | `npm run validate` |
+| Lint | `npm run lint` |
+| Format | `npm run format` |
+| Type check | `npm run typecheck` |
+| Build | `npm run build` |
+| E2E tests | `npm run test:e2e:run` |
+
+### Services
+
+- **Dev server**: `npm run dev` starts all services (worker at `localhost:3742`,
+  mock AI, mock Cloudflare API, client bundle watcher, and home connector at
+  `localhost:4040`). No external services required.
+- D1 (SQLite), KV, and Durable Objects are emulated locally by Wrangler.
+
+### Non-obvious caveats
+
+- The seed script needs an explicit config path:
+  `node tools/seed-test-data.ts --local --config packages/worker/wrangler.jsonc`
+  (without `--config` it fails to find the D1 binding).
+- `packages/worker/.env` must exist before `npm run dev`. Copy from
+  `.env.example` if missing: `cp packages/worker/.env.example packages/worker/.env`
+- Migrations: `npm run migrate:local` before first dev run or after schema
+  changes.
+- Test credentials: `me@kentcdodds.com` / `iliketwix` (seeded via
+  `node tools/seed-test-data.ts --local --config packages/worker/wrangler.jsonc`).
+- The MCP endpoint at `/mcp` requires OAuth; unauthenticated requests return 401
+  with proper OAuth metadata. This is expected behavior.
+- The `pre-commit` hook runs `lint-staged` + `typecheck`; the `pre-push` hook
+  runs `npm run test:push` (vitest + Playwright E2E). Disable hooks with
+  `--no-verify` when needed for intermediate commits.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to AGENTS.md with:

- Quick reference command table (dev, validate, lint, format, typecheck, build, e2e)
- Service overview (dev server, D1, KV, DOs all emulated locally)
- Non-obvious caveats discovered during setup:
  - Seed script requires explicit `--config` flag
  - `.env` must exist before `npm run dev`
  - Migration and seed commands for local dev
  - MCP endpoint requires OAuth (401 is expected)
  - Git hook behavior (pre-commit and pre-push)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec5c4578-060e-465a-93e7-a32b9019fc9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec5c4578-060e-465a-93e7-a32b9019fc9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

