### PR TITLE
Fix local email testing port in docs

### DIFF
--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -46,11 +46,12 @@ Use the MCP `email` domain:
 ## Local inbound testing
 
 Run the worker locally, create an inbox alias, then post raw MIME to Wrangler's
-email test endpoint:
+email test endpoint. The local worker defaults to port `3742` unless you set
+`PORT`:
 
 ```sh
 curl --request POST \
-  'http://localhost:8787/cdn-cgi/handler/email?from=sender@example.com&to=alias@example.com' \
+  'http://localhost:3742/cdn-cgi/handler/email?from=sender@example.com&to=alias@example.com' \
   --data-raw 'From: Sender <sender@example.com>
 To: Alias <alias@example.com>
 Subject: Hello


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update the local inbound email testing curl example to use the worker dev default port, `3742`.
- Note that `PORT` can override the default.

## Testing
- Passed: `npx oxfmt --check docs/use/email-primitives.md`
- Warning: `npm run format:check` currently reports formatting issues in unrelated files; `docs/use/email-primitives.md` is not listed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-744db558-e3f0-43d2-acc6-27500fd776f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-744db558-e3f0-43d2-acc6-27500fd776f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated email testing documentation to provide clarity on the correct localhost port configuration for local inbound testing. The documentation now explicitly specifies the test handler's default port and explains how custom port configuration affects the testing endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->