### PR TITLE
fix(deps): resolve 4 production vulnerabilities (npm audit --omit=dev)

### DIFF
--- a/docs/contributing/dependency-overrides.md
+++ b/docs/contributing/dependency-overrides.md
@@ -15,7 +15,7 @@ The MCP SDK is pinned to a single version so that all workspaces resolve the
 same copy. Without this override, npm may hoist conflicting versions from
 transitive consumers (`agents`, `@kody/worker`).
 
-### `hono` → `>=4.12.14`
+### `hono` → `>=4.12.14 <5.0.0`
 
 Resolves multiple moderate advisories in hono ≤4.12.13:
 
@@ -33,9 +33,10 @@ Resolves multiple moderate advisories in hono ≤4.12.13:
   incorrect IP matching in `ipRestriction()` for IPv4-mapped IPv6
 
 The transitive consumer is `@modelcontextprotocol/sdk` (declares
-`hono@^4.11.4`), so the override is semver-compatible.
+`hono@^4.11.4`). The upper bound `<5.0.0` keeps the override within the same
+major version to avoid breaking changes.
 
-### `@hono/node-server` → `>=1.19.13`
+### `@hono/node-server` → `>=1.19.13 <2.0.0`
 
 Resolves a moderate advisory in @hono/node-server <1.19.13:
 
@@ -43,9 +44,10 @@ Resolves a moderate advisory in @hono/node-server <1.19.13:
   middleware bypass via repeated slashes in `serveStatic`
 
 The transitive consumer is `@modelcontextprotocol/sdk` (declares
-`@hono/node-server@^1.19.9`), so the override is semver-compatible.
+`@hono/node-server@^1.19.9`). The upper bound `<2.0.0` keeps the override within
+the same major version to avoid breaking changes.
 
-### `postcss` → `>=8.5.10`
+### `postcss` → `>=8.5.10 <9.0.0`
 
 Resolves a moderate advisory in postcss <8.5.10:
 
@@ -53,4 +55,5 @@ Resolves a moderate advisory in postcss <8.5.10:
   via unescaped `</style>` in CSS stringify output
 
 PostCSS is pulled transitively by Vite (via `vitest` in devDependencies and the
-Slidev talk tooling). The override keeps all copies at a safe version.
+Slidev talk tooling). The upper bound `<9.0.0` keeps the override within the
+same major version to avoid breaking changes.

--- a/docs/contributing/dependency-overrides.md
+++ b/docs/contributing/dependency-overrides.md
@@ -1,0 +1,56 @@
+# Dependency overrides
+
+This file documents every `overrides` entry in the root `package.json` and
+explains why it exists. When adding or removing an override, update this file in
+the same commit.
+
+Run `npm run audit:prod` to verify that production dependencies remain free of
+known vulnerabilities.
+
+## Production overrides
+
+### `@modelcontextprotocol/sdk` → `1.29.0`
+
+The MCP SDK is pinned to a single version so that all workspaces resolve the
+same copy. Without this override, npm may hoist conflicting versions from
+transitive consumers (`agents`, `@kody/worker`).
+
+### `hono` → `>=4.12.14`
+
+Resolves multiple moderate advisories in hono ≤4.12.13:
+
+- [GHSA-26pp-8wgv-hjvm](https://github.com/advisories/GHSA-26pp-8wgv-hjvm) —
+  missing validation of cookie name in `setCookie()`
+- [GHSA-r5rp-j6wh-rvv4](https://github.com/advisories/GHSA-r5rp-j6wh-rvv4) —
+  non-breaking space prefix bypass in `getCookie()`
+- [GHSA-xf4j-xp2r-rqqx](https://github.com/advisories/GHSA-xf4j-xp2r-rqqx) —
+  path traversal in `toSSG()`
+- [GHSA-wmmm-f939-6g9c](https://github.com/advisories/GHSA-wmmm-f939-6g9c) —
+  middleware bypass via repeated slashes in `serveStatic`
+- [GHSA-458j-xx4x-4375](https://github.com/advisories/GHSA-458j-xx4x-4375) —
+  HTML injection in hono/jsx SSR
+- [GHSA-xpcf-pg52-r92g](https://github.com/advisories/GHSA-xpcf-pg52-r92g) —
+  incorrect IP matching in `ipRestriction()` for IPv4-mapped IPv6
+
+The transitive consumer is `@modelcontextprotocol/sdk` (declares
+`hono@^4.11.4`), so the override is semver-compatible.
+
+### `@hono/node-server` → `>=1.19.13`
+
+Resolves a moderate advisory in @hono/node-server <1.19.13:
+
+- [GHSA-92pp-h63x-v22m](https://github.com/advisories/GHSA-92pp-h63x-v22m) —
+  middleware bypass via repeated slashes in `serveStatic`
+
+The transitive consumer is `@modelcontextprotocol/sdk` (declares
+`@hono/node-server@^1.19.9`), so the override is semver-compatible.
+
+### `postcss` → `>=8.5.10`
+
+Resolves a moderate advisory in postcss <8.5.10:
+
+- [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) — XSS
+  via unescaped `</style>` in CSS stringify output
+
+PostCSS is pulled transitively by Vite (via `vitest` in devDependencies and the
+Slidev talk tooling). The override keeps all copies at a safe version.

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -283,6 +283,15 @@ If you ever need to do the same operations manually, use:
 - `node tools/ci/preview-resources.ts cleanup --worker-name <name>`
 - `node tools/ci/production-resources.ts ensure --out-config <path>`
 
+## Dependency auditing
+
+- `npm run audit:prod` checks production dependencies for known vulnerabilities
+  (runs `npm audit --omit=dev`). This should return zero high or moderate
+  findings before merging to `main`.
+- See [`docs/contributing/dependency-overrides.md`](./dependency-overrides.md)
+  for any `overrides` entries in the root `package.json` and their
+  justifications.
+
 ## Remix skills
 
 Use [Remix skills](./remix.md) instead of vendoring generated package docs in

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,31 +155,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.9.3",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "license": "MIT",
@@ -1331,9 +1306,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260415.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260415.1.tgz",
-      "integrity": "sha512-9sEq9cZzr4s075U/TfjvdSmiX+u2NMOAIcFcCfd24FDtPfR7Iw3SbuQxkcgtpx/Bvg0au9PmQ0ZJfBaIitG0gw==",
+      "version": "4.20260501.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260501.1.tgz",
+      "integrity": "sha512-B/VX2w3my/sCqxKyWOX7SxUpFC1uD8Gh7I2zbI1d3zA8p7Tx03AFsnuEx8lYLmcd8yONAA93YsAZb1wAaLK83w==",
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@comark/markdown-it": {
@@ -2191,10 +2166,12 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.1.tgz",
+      "integrity": "sha512-jI9yMDyFpqBeSighf/zlXnQG/nl9AyBc6aAgy4XtxJMyt/CNyJpvPfzDD+bCc2zAOmhhqtF6TnmIaY+xV4mIrw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2952,10 +2929,6 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "license": "MIT"
     },
     "node_modules/@kody-internal/shared": {
       "resolved": "packages/shared",
@@ -9327,10 +9300,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "license": "MIT"
-    },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
       "dev": true,
@@ -10861,9 +10830,9 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.11.1.tgz",
-      "integrity": "sha512-d3TKWVaxErMuhmLbqzZj0F2hdAIU3JmnEE75lF7h8Ulw7zaE0s1GYFf1BCUrZ4MX2Qe1V3OYhOtiqUI1qA54Jg==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.11.7.tgz",
+      "integrity": "sha512-Y2VVEewFSjc9rVHZ7Ei4k8TkgT+cri6jEEoox1n2heWqnEojAOUKWFZ2RpN9IdWN7nKHBWMsi6VzP6kXHfbQsw==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.29.0",
@@ -10871,35 +10840,27 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "@rolldown/plugin-babel": "^0.2.3",
         "cron-schedule": "^6.0.0",
-        "json-schema": "^0.4.0",
-        "json-schema-to-typescript": "^15.0.4",
         "mimetext": "^3.0.28",
         "nanoid": "^5.1.9",
-        "partyserver": "^0.4.1",
-        "partysocket": "1.1.16",
-        "picomatch": "^4.0.4",
+        "partyserver": "^0.5.5",
+        "partysocket": "1.1.18",
         "yargs": "^18.0.0"
       },
       "bin": {
         "agents": "dist/cli/index.js"
       },
       "peerDependencies": {
-        "@ai-sdk/react": "^3.0.0",
         "@cloudflare/ai-chat": ">=0.0.8 <1.0.0",
         "@cloudflare/codemode": ">=0.0.7 <1.0.0",
-        "@tanstack/ai": "^0.10.2",
+        "@tanstack/ai": ">=0.10.2 <1.0.0",
         "@x402/core": "^2.0.0",
         "@x402/evm": "^2.0.0",
         "ai": "^6.0.0",
         "react": "^19.0.0",
-        "viem": ">=2.0.0",
         "vite": ">=6.0.0 <9.0.0",
         "zod": "^4.0.0"
       },
       "peerDependenciesMeta": {
-        "@ai-sdk/react": {
-          "optional": true
-        },
         "@cloudflare/ai-chat": {
           "optional": true
         },
@@ -10913,9 +10874,6 @@
           "optional": true
         },
         "@x402/evm": {
-          "optional": true
-        },
-        "viem": {
           "optional": true
         },
         "vite": {
@@ -11174,6 +11132,7 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -13975,6 +13934,8 @@
     },
     "node_modules/event-target-polyfill": {
       "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
+      "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
       "license": "MIT"
     },
     "node_modules/event-target-shim": {
@@ -14867,7 +14828,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.9",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -15263,6 +15226,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15309,6 +15273,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -15879,38 +15844,8 @@
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
-    "node_modules/json-schema-to-typescript": {
-      "version": "15.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^11.5.5",
-        "@types/json-schema": "^7.0.15",
-        "@types/lodash": "^4.17.7",
-        "is-glob": "^4.0.3",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.8",
-        "prettier": "^3.2.5",
-        "tinyglobby": "^0.2.9"
-      },
-      "bin": {
-        "json2ts": "dist/src/cli.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/json-schema-to-typescript/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
+      "license": "(AFL-2.1 OR BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -16513,10 +16448,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -17900,9 +17831,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
       "funding": [
         {
           "type": "github",
@@ -18617,19 +18548,21 @@
       }
     },
     "node_modules/partyserver": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.4.1.tgz",
-      "integrity": "sha512-StSs0oY8RmTxjGNil7VbCG4gnTN+4rYX20fiUIItAxTPpr/5rPDZT6PIvMROkk9M1Gn7GzE1wuQXwhxceaGhXA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.5.5.tgz",
+      "integrity": "sha512-7zub8oV8Od9dY2aXGrgzhX5GLceaWOg7xB5VWXtDcqt2BWVDIOCAgaF0AmBMSu3AXhJHsFdzPnA8SSZdybXMbQ==",
       "license": "ISC",
       "dependencies": {
-        "nanoid": "^5.1.6"
+        "nanoid": "^5.1.9"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20240729.0"
+        "@cloudflare/workers-types": "^4.20260424.1"
       }
     },
     "node_modules/partysocket": {
-      "version": "1.1.16",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.18.tgz",
+      "integrity": "sha512-SyuvH9VavWOSa14v6dYdp3yfSUDII4BQB1+TkGOFBkjfZKjnDBiba4fhdhwBlqGBkqw4ea3gTA1DYhSffX24Wg==",
       "license": "MIT",
       "dependencies": {
         "event-target-polyfill": "^0.0.4"
@@ -18869,7 +18802,9 @@
       "license": "MIT-0"
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "devOptional": true,
       "funding": [
         {
@@ -19025,7 +18960,9 @@
     },
     "node_modules/prettier": {
       "version": "3.8.1",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -23714,7 +23651,7 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "^10.45.0",
         "acorn": "^8.16.0",
-        "agents": "^0.11.1",
+        "agents": ">=0.11.5 <0.11.8",
         "croner": "^10.0.1",
         "postal-mime": "^2.7.4",
         "remix": "^3.0.0-beta.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2165,18 +2165,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@hono/node-server": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.1.tgz",
-      "integrity": "sha512-jI9yMDyFpqBeSighf/zlXnQG/nl9AyBc6aAgy4XtxJMyt/CNyJpvPfzDD+bCc2zAOmhhqtF6TnmIaY+xV4mIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "dev": true,
@@ -3128,6 +3116,18 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@mswjs/interceptors": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "prepare": "husky",
     "nx:graph": "nx graph",
     "nx:show-projects": "nx show projects",
-    "dev:talks": "npm --prefix docs/talks/kody-mcp-runtime run dev"
+    "dev:talks": "npm --prefix docs/talks/kody-mcp-runtime run dev",
+    "audit:prod": "npm audit --omit=dev"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.14.7",
@@ -84,7 +85,10 @@
     "wrangler": "^4.83.0"
   },
   "overrides": {
-    "@modelcontextprotocol/sdk": "1.29.0"
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "hono": ">=4.12.14",
+    "@hono/node-server": ">=1.19.13",
+    "postcss": ">=8.5.10"
   },
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
   },
   "overrides": {
     "@modelcontextprotocol/sdk": "1.29.0",
-    "hono": ">=4.12.14",
-    "@hono/node-server": ">=1.19.13",
-    "postcss": ">=8.5.10"
+    "hono": ">=4.12.14 <5.0.0",
+    "@hono/node-server": ">=1.19.13 <2.0.0",
+    "postcss": ">=8.5.10 <9.0.0"
   },
   "engines": {
     "node": "24.x"

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -20,7 +20,7 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "^10.45.0",
     "acorn": "^8.16.0",
-    "agents": "^0.11.1",
+    "agents": ">=0.11.5 <0.11.8",
     "croner": "^10.0.1",
     "postal-mime": "^2.7.4",
     "remix": "^3.0.0-beta.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves all 4 production-facing vulnerabilities reported by `npm audit --omit=dev` as of 2026-05-01 (1 high, 3 moderate).

## Changes

### Dependency updates

| Package | Change | Resolves |
|---------|--------|----------|
| `agents` | `^0.11.1` → `>=0.11.5 <0.11.8` | Drops `json-schema-to-typescript` → `lodash` and `vite` → `postcss` from production tree |
| `hono` (override) | `>=4.12.14 <5.0.0` | 6 moderate advisories (cookie, SSR, serveStatic, toSSG, ipRestriction) |
| `@hono/node-server` (override) | `>=1.19.13 <2.0.0` | 1 moderate advisory (serveStatic bypass) |
| `postcss` (override) | `>=8.5.10 <9.0.0` | 1 moderate advisory (XSS in stringify) |

All overrides use bounded ranges (`<next-major`) to stay within the semver contract of their direct consumers and avoid unintended major version jumps on future installs.

### Advisories resolved

- **High**: [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc) — lodash `_.template` code injection
- **High**: [GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh) — lodash prototype pollution via `_.unset`/`_.omit`
- **Moderate**: [GHSA-26pp-8wgv-hjvm](https://github.com/advisories/GHSA-26pp-8wgv-hjvm) — hono `setCookie()` validation
- **Moderate**: [GHSA-r5rp-j6wh-rvv4](https://github.com/advisories/GHSA-r5rp-j6wh-rvv4) — hono `getCookie()` bypass
- **Moderate**: [GHSA-xf4j-xp2r-rqqx](https://github.com/advisories/GHSA-xf4j-xp2r-rqqx) — hono `toSSG()` path traversal
- **Moderate**: [GHSA-wmmm-f939-6g9c](https://github.com/advisories/GHSA-wmmm-f939-6g9c) — hono `serveStatic` middleware bypass
- **Moderate**: [GHSA-458j-xx4x-4375](https://github.com/advisories/GHSA-458j-xx4x-4375) — hono/jsx SSR HTML injection
- **Moderate**: [GHSA-xpcf-pg52-r92g](https://github.com/advisories/GHSA-xpcf-pg52-r92g) — hono `ipRestriction()` IPv6
- **Moderate**: [GHSA-92pp-h63x-v22m](https://github.com/advisories/GHSA-92pp-h63x-v22m) — `@hono/node-server` serveStatic bypass
- **Moderate**: [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) — postcss XSS in CSS stringify

### New files & scripts

- `docs/contributing/dependency-overrides.md` — documents each override with justification
- `"audit:prod"` npm script in root `package.json` — runs `npm audit --omit=dev`
- `docs/contributing/setup.md` updated to reference the new script and overrides doc

## Verification

```
$ npm run audit:prod
found 0 vulnerabilities

$ npm run typecheck
Successfully ran target typecheck for project worker

$ npm run test
Test Files  118 passed (118)
     Tests  531 passed (531)
```

## Remaining dev-only vulnerabilities (10 moderate)

These are all in the Slidev/talks toolchain (`@slidev/cli` → `dompurify`, `mermaid` → `uuid`, `axios` → `follow-redirects`) and do not affect production. They require breaking upgrades to Slidev and are tracked but not addressed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-714f7745-bd29-4402-a679-625fb062960a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-714f7745-bd29-4402-a679-625fb062960a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

