### PR TITLE
fix(security): shorten generated-UI session blast radius and isolate saved-secret KEK from cookie secret

### DIFF
--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -26,6 +26,7 @@ types, runtime validation, and documentation in sync.
    			32,
    			'COOKIE_SECRET must be at least 32 characters for session signing.',
    		),
+   	SECRET_STORE_KEY: z.string().optional(),
    	THIRD_PARTY_API_KEY: z
    		.string()
    		.min(
@@ -68,6 +69,20 @@ third-party APIs can use stored secrets via `{{secret:name}}` placeholders in
 URLs and headers where the MCP runtime supports them. Host allowlists and
 capability policies apply per secret. There are no GitHub-specific Worker
 environment variables.
+
+## Saved-secret encryption (`SECRET_STORE_KEY`)
+
+Optional Worker secret used to derive the AES-GCM key for encrypting saved
+secrets at rest in D1. When unset, the Worker falls back to `COOKIE_SECRET` for
+backward compatibility.
+
+- **Production deployments should set a dedicated `SECRET_STORE_KEY`** so that
+  rotating the cookie signing key does not brick encrypted secrets.
+- When both keys are configured, decryption first attempts `SECRET_STORE_KEY`.
+  If that fails (legacy data), it retries with `COOKIE_SECRET` and transparently
+  re-encrypts the value under the new key on the next read.
+- See [`docs/contributing/secret-rotation.md`](./secret-rotation.md) for
+  rotation procedures.
 
 ## MCP capability search (Vectorize + Workers AI)
 

--- a/docs/contributing/secret-rotation.md
+++ b/docs/contributing/secret-rotation.md
@@ -1,0 +1,66 @@
+# Secret rotation
+
+Procedures for rotating Worker secrets that protect session integrity and
+saved-secret confidentiality.
+
+## Key inventory
+
+| Secret | Purpose | Impact of rotation |
+| --- | --- | --- |
+| `COOKIE_SECRET` | Signs auth session cookies (Remix `createCookie`) | Invalidates all active browser sessions; users must re-authenticate. |
+| `SECRET_STORE_KEY` | Derives the AES-GCM KEK for saved secrets in D1 | Bricks all saved secrets encrypted under the old key unless a re-encryption migration runs. |
+
+## Decoupling cookie and secret-store keys
+
+Prior to this change, both session signing and saved-secret encryption derived
+from `COOKIE_SECRET`. Rotating that single secret simultaneously logged out
+every user **and** destroyed all encrypted secrets.
+
+Now:
+
+- **Cookie signing** uses `COOKIE_SECRET` only.
+- **Saved-secret encryption** uses `SECRET_STORE_KEY` when set, falling back to
+  `COOKIE_SECRET` for backward compatibility with existing ciphertext.
+
+## Rotating `COOKIE_SECRET`
+
+1. Deploy the new `COOKIE_SECRET` value.
+2. All active browser sessions are invalidated (expected).
+3. Saved secrets remain intact — they are encrypted under `SECRET_STORE_KEY`
+   (or legacy `COOKIE_SECRET`-derived key with automatic fallback).
+
+## Rotating `SECRET_STORE_KEY`
+
+Rotating `SECRET_STORE_KEY` requires a re-encryption migration because AES-GCM
+has no built-in key versioning.
+
+### Procedure
+
+1. **Keep the old key available** — set `COOKIE_SECRET` to the **old**
+   `SECRET_STORE_KEY` value temporarily (or use a dedicated migration env var in
+   a future iteration). The runtime's legacy-fallback path will use
+   `COOKIE_SECRET` to decrypt old ciphertext.
+2. **Deploy** with the new `SECRET_STORE_KEY` and the adjusted `COOKIE_SECRET`.
+3. **Trigger a full read pass** over all secrets so the fallback path decrypts
+   with the old key and transparently re-encrypts under the new key. A future
+   `/__maintenance/reencrypt-secrets` endpoint can automate this; until then,
+   iterating through all secret entries via a one-off script against D1 achieves
+   the same effect.
+4. Once all rows are re-encrypted, **restore `COOKIE_SECRET`** to its normal
+   session-signing value.
+
+### Important notes
+
+- Never delete the old key value until re-encryption is verified complete.
+- The fallback decrypt path only fires when primary decryption fails — it does
+  not add latency to normal reads.
+- Monitor error rates after rotation; a spike in "Unable to decrypt secret
+  value" errors indicates the fallback key is also wrong.
+
+## Generating secure key values
+
+Use a cryptographically random string of at least 32 characters:
+
+```sh
+openssl rand -base64 48
+```

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -31,7 +31,10 @@ Quick notes for getting a local kody environment running.
   [`docs/contributing/d1-legacy-export.md`](./d1-legacy-export.md) and
   `tools/export-d1-remote-to-sqlite.sh`.
 - Copy `packages/worker/.env.example` to `packages/worker/.env` before starting
-  any work, then update secrets as needed.
+  any work, then update secrets as needed. The example includes placeholder
+  values for `COOKIE_SECRET` and `SECRET_STORE_KEY`; production deploys must set
+  distinct secrets for each (see
+  [`docs/contributing/secret-rotation.md`](./secret-rotation.md)).
 - `npm run dev` (starts mock API servers automatically, the main worker, and the
   local home connector; it sets `AI_MODE=mock`, `AI_MOCK_BASE_URL`, and
   `CLOUDFLARE_API_BASE_URL` + `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`

--- a/packages/worker/.env.example
+++ b/packages/worker/.env.example
@@ -4,6 +4,11 @@
 # Required
 COOKIE_SECRET=LOCAL_AND_PREVIEW_COOKIE_SECRET_32_CHARS_MINIMUM
 
+# Saved-secret encryption key (optional; falls back to COOKIE_SECRET when unset).
+# Set a dedicated value in production to decouple secret-store encryption from
+# cookie signing. See docs/contributing/secret-rotation.md.
+SECRET_STORE_KEY=LOCAL_SECRET_STORE_KEY_32_CHARS_MINIMUM_VALUE
+
 # Optional (preview uses request origin by default; password-reset email sends
 # from kody@<APP_BASE_URL hostname> when set)
 APP_BASE_URL=

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -171,6 +171,7 @@ export const EnvSchema = object({
 		(value) => value.length >= 32,
 		'COOKIE_SECRET must be at least 32 characters for session signing.',
 	),
+	SECRET_STORE_KEY: optionalNonEmptyStringSchema,
 	APP_DB: d1DatabaseSchema,
 	BUNDLE_ARTIFACTS_KV: createSchema<unknown, KVNamespace>((value, context) => {
 		if (value) {

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -166,12 +166,29 @@ const optionalSentryTracesSampleRateSchema = createSchema<
 	return fail('Expected number or numeric string', context.path)
 })
 
+const optionalSecretStoreKeySchema = createSchema<unknown, string | undefined>(
+	(value, context) => {
+		if (value === undefined) return { value: undefined }
+		if (typeof value !== 'string') return fail('Expected string', context.path)
+
+		const trimmed = value.trim()
+		if (!trimmed) return { value: undefined }
+		if (trimmed.length < 32) {
+			return fail(
+				'SECRET_STORE_KEY must be at least 32 characters for secure key derivation.',
+				context.path,
+			)
+		}
+		return { value: trimmed }
+	},
+)
+
 export const EnvSchema = object({
 	COOKIE_SECRET: string().refine(
 		(value) => value.length >= 32,
 		'COOKIE_SECRET must be at least 32 characters for session signing.',
 	),
-	SECRET_STORE_KEY: optionalNonEmptyStringSchema,
+	SECRET_STORE_KEY: optionalSecretStoreKeySchema,
 	APP_DB: d1DatabaseSchema,
 	BUNDLE_ARTIFACTS_KV: createSchema<unknown, KVNamespace>((value, context) => {
 		if (value) {

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -41,7 +41,7 @@ export class CodemodeFetchGateway extends WorkerEntrypoint<
 export async function expandSecretPlaceholders(input: {
 	request: Request
 	props: FetchGatewayProps
-	env: Pick<Env, 'APP_DB' | 'COOKIE_SECRET'>
+	env: Pick<Env, 'APP_DB' | 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>
 }) {
 	const headers = new Headers(input.request.headers)
 	const requestBody = await readRequestBody(input.request)

--- a/packages/worker/src/mcp/generated-ui-api.ts
+++ b/packages/worker/src/mcp/generated-ui-api.ts
@@ -16,6 +16,8 @@ import { runCodemodeWithRegistry } from '#mcp/run-codemode-registry.ts'
 import { deleteSecret, listSecrets, saveSecret } from '#mcp/secrets/service.ts'
 import { secretScopeValues } from '#mcp/secrets/types.ts'
 
+const generatedUiAllowedScopes = ['session', 'app'] as const
+
 const executeRequestSchema = z.object({
 	code: z.string().min(1),
 	params: z.record(z.string(), z.unknown()).optional(),
@@ -25,12 +27,12 @@ const secretMutationSchema = z.object({
 	name: z.string().min(1),
 	value: z.string().min(1),
 	description: z.string().optional(),
-	scope: z.enum(secretScopeValues).optional(),
+	scope: z.enum(generatedUiAllowedScopes).optional(),
 })
 
 const secretDeleteSchema = z.object({
 	name: z.string().min(1),
-	scope: z.enum(secretScopeValues).optional(),
+	scope: z.enum(generatedUiAllowedScopes).optional(),
 })
 
 const generatedUiApiRoutes = route({
@@ -51,7 +53,6 @@ type GeneratedUiSessionContext = {
 	user: {
 		userId: string
 		email: string
-		displayName: string
 	}
 }
 
@@ -154,7 +155,11 @@ function createGeneratedUiExecuteHandler(env: Env) {
 				env,
 				createMcpCallerContext({
 					baseUrl: getAppBaseUrl({ env, requestUrl: request.url }),
-					user: context.user,
+					user: {
+						userId: context.user.userId,
+						email: context.user.email,
+						displayName: '',
+					},
 					homeConnectorId: context.homeConnectorId,
 					storageContext: {
 						sessionId: context.sessionId,
@@ -250,9 +255,22 @@ function createGeneratedUiSecretsHandler(env: Env) {
 				return jsonResponse({ error: 'Method not allowed.' }, 405)
 			}
 
-			const body = secretMutationSchema.safeParse(
-				await request.json().catch(() => null),
-			)
+			const rawBody = await request.json().catch(() => null)
+			if (
+				rawBody &&
+				typeof rawBody === 'object' &&
+				'scope' in rawBody &&
+				(rawBody as Record<string, unknown>).scope === 'user'
+			) {
+				return jsonResponse(
+					{
+						error:
+							'User-scoped secret mutations are not permitted from generated UI sessions.',
+					},
+					403,
+				)
+			}
+			const body = secretMutationSchema.safeParse(rawBody)
 			if (!body.success) {
 				return jsonResponse({ error: body.error.message }, 400)
 			}
@@ -313,9 +331,22 @@ function createGeneratedUiDeleteSecretHandler(env: Env) {
 				routeId: getGeneratedUiRouteId(params),
 			})
 			if (context instanceof Response) return context
-			const body = secretDeleteSchema.safeParse(
-				await request.json().catch(() => null),
-			)
+			const rawBody = await request.json().catch(() => null)
+			if (
+				rawBody &&
+				typeof rawBody === 'object' &&
+				'scope' in rawBody &&
+				(rawBody as Record<string, unknown>).scope === 'user'
+			) {
+				return jsonResponse(
+					{
+						error:
+							'User-scoped secret mutations are not permitted from generated UI sessions.',
+					},
+					403,
+				)
+			}
+			const body = secretDeleteSchema.safeParse(rawBody)
 			if (!body.success) {
 				return jsonResponse({ error: body.error.message }, 400)
 			}

--- a/packages/worker/src/mcp/generated-ui-app-session.node.test.ts
+++ b/packages/worker/src/mcp/generated-ui-app-session.node.test.ts
@@ -1,0 +1,92 @@
+import { expect, test, vi } from 'vitest'
+import {
+	createGeneratedUiAppSession,
+	defaultGeneratedUiSessionTtlMs,
+	verifyGeneratedUiAppSession,
+} from './generated-ui-app-session.ts'
+
+const testEnv = {
+	COOKIE_SECRET: 'test-cookie-secret-at-least-32-characters-long!!',
+}
+
+test('default TTL is 15 minutes', () => {
+	expect(defaultGeneratedUiSessionTtlMs).toBe(15 * 60 * 1000)
+})
+
+test('minted session token contains only userId and email in user payload', async () => {
+	const session = await createGeneratedUiAppSession({
+		env: testEnv,
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-123',
+			email: 'user@test.com',
+			displayName: 'Test User',
+		},
+		appId: 'app-1',
+		params: { key: 'val' },
+	})
+	expect(session.sessionId).toBeTruthy()
+	expect(session.token).toBeTruthy()
+
+	const payload = await verifyGeneratedUiAppSession(testEnv, session.token)
+	expect(payload.user).toEqual({ userId: 'user-123', email: 'user@test.com' })
+	expect((payload.user as Record<string, unknown>).displayName).toBeUndefined()
+})
+
+test('session expires after the configured TTL', async () => {
+	const now = Date.now()
+	vi.setSystemTime(now)
+	const session = await createGeneratedUiAppSession({
+		env: testEnv,
+		baseUrl: 'https://example.com',
+		user: { userId: 'u1', email: 'e@x.com', displayName: '' },
+	})
+
+	vi.setSystemTime(now + defaultGeneratedUiSessionTtlMs + 1)
+	await expect(
+		verifyGeneratedUiAppSession(testEnv, session.token),
+	).rejects.toThrow('expired')
+
+	vi.useRealTimers()
+})
+
+test('session is valid just before expiry', async () => {
+	const now = Date.now()
+	vi.setSystemTime(now)
+	const session = await createGeneratedUiAppSession({
+		env: testEnv,
+		baseUrl: 'https://example.com',
+		user: { userId: 'u1', email: 'e@x.com', displayName: '' },
+	})
+
+	vi.setSystemTime(now + defaultGeneratedUiSessionTtlMs - 1000)
+	const payload = await verifyGeneratedUiAppSession(testEnv, session.token)
+	expect(payload.user.userId).toBe('u1')
+
+	vi.useRealTimers()
+})
+
+test('verify rejects token when expectedSessionId does not match', async () => {
+	const session = await createGeneratedUiAppSession({
+		env: testEnv,
+		baseUrl: 'https://example.com',
+		user: { userId: 'u1', email: 'e@x.com', displayName: '' },
+	})
+	await expect(
+		verifyGeneratedUiAppSession(testEnv, session.token, 'wrong-session-id'),
+	).rejects.toThrow('does not match')
+})
+
+test('verify succeeds when expectedSessionId matches', async () => {
+	const session = await createGeneratedUiAppSession({
+		env: testEnv,
+		baseUrl: 'https://example.com',
+		user: { userId: 'u1', email: 'e@x.com', displayName: '' },
+	})
+	const payload = await verifyGeneratedUiAppSession(
+		testEnv,
+		session.token,
+		session.sessionId,
+	)
+	expect(payload.session_id).toBe(session.sessionId)
+})

--- a/packages/worker/src/mcp/generated-ui-app-session.ts
+++ b/packages/worker/src/mcp/generated-ui-app-session.ts
@@ -1,18 +1,22 @@
-import { type McpUserContext } from '@kody-internal/shared/chat.ts'
 import {
 	decryptStringWithPurpose,
 	encryptStringWithPurpose,
 } from '#mcp/secrets/crypto.ts'
 
 const generatedUiSessionPurpose = 'generated-ui-session'
-const defaultGeneratedUiSessionTtlMs = 60 * 60 * 1000
+export const defaultGeneratedUiSessionTtlMs = 15 * 60 * 1000
+
+export type GeneratedUiSessionUser = {
+	userId: string
+	email: string
+}
 
 type GeneratedUiAppSessionPayload = {
 	session_id: string
 	app_id: string | null
 	params: Record<string, unknown>
 	home_connector_id: string | null
-	user: McpUserContext
+	user: GeneratedUiSessionUser
 	iat: number
 	exp: number
 }
@@ -34,7 +38,7 @@ export type GeneratedUiAppSession = {
 export async function createGeneratedUiAppSession(input: {
 	env: Pick<Env, 'COOKIE_SECRET'>
 	baseUrl: string
-	user: McpUserContext
+	user: { userId: string; email: string; displayName?: string }
 	appId?: string | null
 	params?: Record<string, unknown>
 	homeConnectorId?: string | null
@@ -50,7 +54,7 @@ export async function createGeneratedUiAppSession(input: {
 			app_id: input.appId ?? null,
 			params: input.params ?? {},
 			home_connector_id: input.homeConnectorId ?? null,
-			user: input.user,
+			user: { userId: input.user.userId, email: input.user.email },
 			iat: now,
 			exp: expiresAtMs,
 		} satisfies GeneratedUiAppSessionPayload),
@@ -75,6 +79,7 @@ export async function createGeneratedUiAppSession(input: {
 export async function verifyGeneratedUiAppSession(
 	env: Pick<Env, 'COOKIE_SECRET'>,
 	token: string,
+	expectedSessionId?: string,
 ) {
 	const raw = await decryptStringWithPurpose(
 		env,
@@ -85,12 +90,18 @@ export async function verifyGeneratedUiAppSession(
 	if (
 		typeof payload.session_id !== 'string' ||
 		!payload.user ||
-		typeof payload.user.userId !== 'string'
+		typeof payload.user.userId !== 'string' ||
+		typeof payload.user.email !== 'string'
 	) {
 		throw new Error('Invalid generated UI session payload.')
 	}
 	if (typeof payload.exp === 'number' && Date.now() > payload.exp) {
 		throw new Error('Generated UI session has expired.')
+	}
+	if (expectedSessionId && payload.session_id !== expectedSessionId) {
+		throw new Error(
+			'Generated UI session does not match the requested session.',
+		)
 	}
 	if (
 		payload.params == null ||

--- a/packages/worker/src/mcp/secrets/crypto.node.test.ts
+++ b/packages/worker/src/mcp/secrets/crypto.node.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from 'vitest'
+import {
+	decryptSecretValue,
+	encryptSecretValue,
+	encryptStringWithPurpose,
+} from './crypto.ts'
+
+const primaryKey = 'primary-secret-store-key-at-least-32-chars!!'
+const cookieSecret = 'cookie-secret-value-at-least-32-characters!!'
+const altCookieSecret = 'rotated-cookie-secret-at-least-32-characters!'
+
+test('encrypt then decrypt with SECRET_STORE_KEY succeeds', async () => {
+	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
+	const encrypted = await encryptSecretValue(env, 'my-secret-value')
+	const result = await decryptSecretValue(env, encrypted)
+	expect(result.value).toBe('my-secret-value')
+	expect(result.needsReEncrypt).toBe(false)
+})
+
+test('decrypt with correct SECRET_STORE_KEY ignores COOKIE_SECRET value', async () => {
+	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
+	const encrypted = await encryptSecretValue(env, 'test-data')
+
+	const envWithDifferentCookie = {
+		COOKIE_SECRET: altCookieSecret,
+		SECRET_STORE_KEY: primaryKey,
+	}
+	const result = await decryptSecretValue(envWithDifferentCookie, encrypted)
+	expect(result.value).toBe('test-data')
+	expect(result.needsReEncrypt).toBe(false)
+})
+
+test('legacy ciphertext encrypted with COOKIE_SECRET decrypts via fallback', async () => {
+	const legacyEnv = {
+		COOKIE_SECRET: cookieSecret,
+		SECRET_STORE_KEY: undefined,
+	}
+	const legacyCiphertext = await encryptSecretValue(legacyEnv, 'legacy-secret')
+
+	const newEnv = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
+	const result = await decryptSecretValue(newEnv, legacyCiphertext)
+	expect(result.value).toBe('legacy-secret')
+	expect(result.needsReEncrypt).toBe(true)
+})
+
+test('rotating COOKIE_SECRET does not brick secrets when SECRET_STORE_KEY is stable', async () => {
+	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
+	const encrypted = await encryptSecretValue(env, 'important-data')
+
+	const rotatedEnv = {
+		COOKIE_SECRET: altCookieSecret,
+		SECRET_STORE_KEY: primaryKey,
+	}
+	const result = await decryptSecretValue(rotatedEnv, encrypted)
+	expect(result.value).toBe('important-data')
+	expect(result.needsReEncrypt).toBe(false)
+})
+
+test('decryption fails when both keys are wrong', async () => {
+	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
+	const encrypted = await encryptSecretValue(env, 'data')
+
+	const wrongEnv = {
+		COOKIE_SECRET: 'wrong-cookie-secret-32-chars-minimum-value!!!',
+		SECRET_STORE_KEY: 'wrong-store-key-32-chars-minimum-value-here!!',
+	}
+	await expect(decryptSecretValue(wrongEnv, encrypted)).rejects.toThrow(
+		'Unable to decrypt secret value.',
+	)
+})
+
+test('when SECRET_STORE_KEY is unset, encrypt/decrypt uses COOKIE_SECRET', async () => {
+	const env = {
+		COOKIE_SECRET: cookieSecret,
+		SECRET_STORE_KEY: undefined,
+	}
+	const encrypted = await encryptSecretValue(env, 'fallback-test')
+	const result = await decryptSecretValue(env, encrypted)
+	expect(result.value).toBe('fallback-test')
+	expect(result.needsReEncrypt).toBe(false)
+})
+
+test('general-purpose encrypt/decrypt with purpose uses COOKIE_SECRET', async () => {
+	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
+	const encrypted = await encryptStringWithPurpose(
+		env,
+		'test-purpose',
+		'hello',
+	)
+	const { decryptStringWithPurpose } = await import('./crypto.ts')
+	const decrypted = await decryptStringWithPurpose(env, 'test-purpose', encrypted)
+	expect(decrypted).toBe('hello')
+})
+
+test('invalid payload format throws', async () => {
+	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
+	await expect(decryptSecretValue(env, 'no-dot-separator')).rejects.toThrow(
+		'Invalid encrypted secret payload.',
+	)
+})

--- a/packages/worker/src/mcp/secrets/crypto.ts
+++ b/packages/worker/src/mcp/secrets/crypto.ts
@@ -24,10 +24,10 @@ function base64UrlToBytes(value: string) {
 	return Uint8Array.from(binary, (char) => char.charCodeAt(0))
 }
 
-async function deriveEncryptionKey(cookieSecret: string, purpose: string) {
+async function deriveEncryptionKey(secret: string, purpose: string) {
 	const digest = await crypto.subtle.digest(
 		'SHA-256',
-		textEncoder.encode(`${purpose}:${cookieSecret}`),
+		textEncoder.encode(`${purpose}:${secret}`),
 	)
 	return crypto.subtle.importKey('raw', digest, 'AES-GCM', false, [
 		'encrypt',
@@ -77,15 +77,66 @@ export async function decryptStringWithPurpose(
 const secretStorePurpose = 'mcp-secret-store'
 
 export async function encryptSecretValue(
-	env: Pick<Env, 'COOKIE_SECRET'>,
+	env: Pick<Env, 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>,
 	value: string,
 ) {
-	return encryptStringWithPurpose(env, secretStorePurpose, value)
+	const secret = getSecretStoreKey(env)
+	const key = await deriveEncryptionKey(secret, secretStorePurpose)
+	const iv = crypto.getRandomValues(new Uint8Array(ivBytes))
+	const ciphertext = await crypto.subtle.encrypt(
+		{ name: 'AES-GCM', iv },
+		key,
+		textEncoder.encode(value),
+	)
+	return `${bytesToBase64Url(iv)}.${bytesToBase64Url(new Uint8Array(ciphertext))}`
 }
 
 export async function decryptSecretValue(
-	env: Pick<Env, 'COOKIE_SECRET'>,
+	env: Pick<Env, 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>,
 	payload: string,
 ) {
-	return decryptStringWithPurpose(env, secretStorePurpose, payload)
+	const [ivPart, ciphertextPart] = payload.split('.')
+	if (!ivPart || !ciphertextPart) {
+		throw new Error('Invalid encrypted secret payload.')
+	}
+	const iv = base64UrlToBytes(ivPart)
+	const ciphertextBytes = base64UrlToBytes(ciphertextPart)
+
+	const primarySecret = getSecretStoreKey(env)
+	const primaryKey = await deriveEncryptionKey(primarySecret, secretStorePurpose)
+	try {
+		const plaintext = await crypto.subtle.decrypt(
+			{ name: 'AES-GCM', iv },
+			primaryKey,
+			ciphertextBytes,
+		)
+		return { value: textDecoder.decode(plaintext), needsReEncrypt: false }
+	} catch {
+		// Primary key failed — attempt legacy COOKIE_SECRET fallback
+	}
+
+	if (primarySecret === env.COOKIE_SECRET) {
+		throw new Error('Unable to decrypt secret value.')
+	}
+
+	const legacyKey = await deriveEncryptionKey(
+		env.COOKIE_SECRET,
+		secretStorePurpose,
+	)
+	try {
+		const plaintext = await crypto.subtle.decrypt(
+			{ name: 'AES-GCM', iv },
+			legacyKey,
+			ciphertextBytes,
+		)
+		return { value: textDecoder.decode(plaintext), needsReEncrypt: true }
+	} catch {
+		throw new Error('Unable to decrypt secret value.')
+	}
+}
+
+function getSecretStoreKey(
+	env: Pick<Env, 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>,
+): string {
+	return env.SECRET_STORE_KEY ?? env.COOKIE_SECRET
 }

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -199,20 +199,21 @@ export async function resolveSecret(
 			name: input.name,
 		})
 		if (!entry) continue
-		const decrypted = await decryptSecretValue(
-			input.env,
-			entry.encrypted_value,
-		)
+		const decrypted = await decryptSecretValue(input.env, entry.encrypted_value)
 		if (decrypted.needsReEncrypt) {
-			const reEncrypted = await encryptSecretValue(input.env, decrypted.value)
-			await upsertSecretEntry({
-				db: input.env.APP_DB,
-				row: {
-					...entry,
-					encrypted_value: reEncrypted,
-					updated_at: new Date().toISOString(),
-				},
-			})
+			try {
+				const reEncrypted = await encryptSecretValue(input.env, decrypted.value)
+				await upsertSecretEntry({
+					db: input.env.APP_DB,
+					row: {
+						...entry,
+						encrypted_value: reEncrypted,
+						updated_at: new Date().toISOString(),
+					},
+				})
+			} catch {
+				// Best-effort re-encryption; read still succeeds with the decrypted value
+			}
 		}
 		return {
 			found: true,

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -40,7 +40,7 @@ type SecretOwnerContext = {
 }
 
 type SaveSecretInput = SecretOwnerContext & {
-	env: Pick<Env, 'APP_DB' | 'COOKIE_SECRET'>
+	env: Pick<Env, 'APP_DB' | 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>
 	scope: SecretScope
 	name: string
 	value: string
@@ -54,13 +54,13 @@ type ListSecretsInput = SecretOwnerContext & {
 }
 
 type ResolveSecretInput = SecretOwnerContext & {
-	env: Pick<Env, 'APP_DB' | 'COOKIE_SECRET'>
+	env: Pick<Env, 'APP_DB' | 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>
 	name: string
 	scope?: SecretScope | null
 }
 
 type UpdateSecretInput = SecretOwnerContext & {
-	env: Pick<Env, 'APP_DB' | 'COOKIE_SECRET'>
+	env: Pick<Env, 'APP_DB' | 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>
 	name: string
 	scope: SecretScope
 	value?: string | null
@@ -199,9 +199,24 @@ export async function resolveSecret(
 			name: input.name,
 		})
 		if (!entry) continue
+		const decrypted = await decryptSecretValue(
+			input.env,
+			entry.encrypted_value,
+		)
+		if (decrypted.needsReEncrypt) {
+			const reEncrypted = await encryptSecretValue(input.env, decrypted.value)
+			await upsertSecretEntry({
+				db: input.env.APP_DB,
+				row: {
+					...entry,
+					encrypted_value: reEncrypted,
+					updated_at: new Date().toISOString(),
+				},
+			})
+		}
 		return {
 			found: true,
-			value: await decryptSecretValue(input.env, entry.encrypted_value),
+			value: decrypted.value,
 			scope,
 			allowedHosts: parseAllowedHosts(entry.allowed_hosts),
 			allowedCapabilities: parseAllowedCapabilities(entry.allowed_capabilities),

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -330,13 +330,13 @@
 					"binding": "BUNDLE_ARTIFACTS_KV",
 				},
 			],
-		"vars": {
-			"AI_MODE": "mock",
-			"AI_MODEL": "@cf/zai-org/glm-4.7-flash",
-			"SENTRY_ENVIRONMENT": "test",
-			"COOKIE_SECRET": "LOCAL_AND_PREVIEW_COOKIE_SECRET_32_CHARS_MINIMUM",
-			"SECRET_STORE_KEY": "LOCAL_TEST_SECRET_STORE_KEY_32_CHARS_MINIMUM_OK",
-		},
+			"vars": {
+				"AI_MODE": "mock",
+				"AI_MODEL": "@cf/zai-org/glm-4.7-flash",
+				"SENTRY_ENVIRONMENT": "test",
+				"COOKIE_SECRET": "LOCAL_AND_PREVIEW_COOKIE_SECRET_32_CHARS_MINIMUM",
+				"SECRET_STORE_KEY": "LOCAL_TEST_SECRET_STORE_KEY_32_CHARS_MINIMUM_OK",
+			},
 		},
 	},
 }

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -330,12 +330,13 @@
 					"binding": "BUNDLE_ARTIFACTS_KV",
 				},
 			],
-			"vars": {
-				"AI_MODE": "mock",
-				"AI_MODEL": "@cf/zai-org/glm-4.7-flash",
-				"SENTRY_ENVIRONMENT": "test",
-				"COOKIE_SECRET": "LOCAL_AND_PREVIEW_COOKIE_SECRET_32_CHARS_MINIMUM",
-			},
+		"vars": {
+			"AI_MODE": "mock",
+			"AI_MODEL": "@cf/zai-org/glm-4.7-flash",
+			"SENTRY_ENVIRONMENT": "test",
+			"COOKIE_SECRET": "LOCAL_AND_PREVIEW_COOKIE_SECRET_32_CHARS_MINIMUM",
+			"SECRET_STORE_KEY": "LOCAL_TEST_SECRET_STORE_KEY_32_CHARS_MINIMUM_OK",
+		},
 		},
 	},
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses two related findings from the 2026-05-01 security audit (Group 3 — Session and secret-store key isolation).

### Finding 3A: Generated UI bearer sessions are overly powerful

- **Reduced TTL** from 60 minutes to 15 minutes, shrinking the window for token misuse.
- **Narrowed user payload** in encrypted session tokens to `{ userId, email }` only — `displayName` and any other user fields are no longer embedded.
- **Restricted secret mutation scope** in the generated-UI API: `scope: 'user'` is now rejected with HTTP 403. Only `'session'` and `'app'` scopes are permitted for secret create/delete from generated UI sessions.
- **Explicit session-id binding** in the verify path with an optional `expectedSessionId` parameter.

### Finding 3B: Saved-secret encryption reuses `COOKIE_SECRET`

- **Introduced `SECRET_STORE_KEY`** — a new optional Worker secret that derives the AES-GCM key for encrypting saved secrets at rest. Enforces a 32-character minimum (matching `COOKIE_SECRET` constraints).
- **Backward-compatible fallback**: if decryption with `SECRET_STORE_KEY` fails, the runtime retries with the legacy `COOKIE_SECRET`-derived key. On success, it transparently re-encrypts the value under the new key on next read (best-effort — read still succeeds if re-encryption write fails).
- **Rotating `COOKIE_SECRET` no longer destroys saved secrets** when `SECRET_STORE_KEY` is configured separately.

### Documentation

- `docs/contributing/environment-variables.md` — documents `SECRET_STORE_KEY`
- `docs/contributing/setup.md` — mentions `SECRET_STORE_KEY` in local setup
- `docs/contributing/secret-rotation.md` — new rotation runbook for both secrets

### Tests

- `generated-ui-app-session.node.test.ts` — asserts 15-min TTL, narrowed payload, session-id binding
- `crypto.node.test.ts` — encrypt/decrypt with new key, legacy fallback path, COOKIE_SECRET rotation resilience, error cases

All 443 worker unit tests pass. Typecheck, lint, build, and Playwright E2E suite clean. Rebased on current `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81a13726-b0b5-4f13-b36c-eb0bd7de0f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81a13726-b0b5-4f13-b36c-eb0bd7de0f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

