### PR TITLE
fix: prevent sensitive data leakage in handlers (security audit findings 4A + 4B)

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -65,7 +65,28 @@ Password reset handlers are in
 - `POST /password-reset/confirm` verifies token hash and expiry, then updates
   password
 - reset tokens expire after 1 hour
-- when configured, email delivery is done via Resend
+- when configured, email delivery is done via Cloudflare Email API
+- when `CLOUDFLARE_EMAIL_FROM` is unset, the handler logs a diagnostic without
+  the email body or token URL to prevent token leakage in logs
+
+## Account secret reveal
+
+The account secrets API (`packages/worker/src/app/handlers/account-secrets.ts`)
+never returns plaintext secret values in `GET /account/secrets.json`. To view a
+stored value, the client calls a separate reveal endpoint:
+
+- `POST /account/secrets/reveal` with JSON body `{ secretId, password }`
+- Requires an active `kody_session` cookie (same as all account endpoints)
+- Requires the user's current password for reauthentication (verified via
+  PBKDF2 through `@kody-internal/shared/password-hash.ts`)
+- On success, returns `{ ok: true, value }` with `Cache-Control: no-store`
+- On failure (wrong password), returns 401 and writes an audit log entry with
+  `action: 'secret_reveal'`, `result: 'failure'`
+- Successful reveals also emit an audit log entry with
+  `action: 'secret_reveal'`, `result: 'success'`
+
+The UI prompts for the password on each reveal and does not cache the value in
+memory across navigation events.
 
 ## OAuth for MCP
 
@@ -94,3 +115,5 @@ routed from `packages/worker/src/index.ts`.
 - `packages/worker/src/mcp-auth.ts` for MCP token enforcement
 - `packages/worker/src/app/auth-session.ts` for cookie format/signing
 - `packages/worker/src/app/handlers/auth.ts` for app login/signup flow
+- `packages/worker/src/app/handlers/account-secrets.ts` for secret reveal with
+  reauth

--- a/e2e/connect-secret.spec.ts
+++ b/e2e/connect-secret.spec.ts
@@ -49,6 +49,6 @@ test('connect secret shows editable name and scope and saves the edited name', a
 	await expect(page.getByLabel('Description')).toHaveValue(description)
 	await expect(
 		page.getByPlaceholder('Enter the secret value').first(),
-	).toHaveValue(secretValue)
+	).toHaveValue('')
 	await expect(page.getByPlaceholder('saved package id')).toHaveValue(packageId)
 })

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -821,6 +821,7 @@ export function AccountSecretsRoute(handle: Handle) {
 			return
 		}
 
+		const capturedSecretId = editorState.currentId
 		revealState = 'revealing'
 		revealError = null
 		handle.update()
@@ -834,10 +835,12 @@ export function AccountSecretsRoute(handle: Handle) {
 				},
 				credentials: 'include',
 				body: JSON.stringify({
-					secretId: editorState.currentId,
+					secretId: capturedSecretId,
 					password: revealPassword,
 				}),
 			})
+
+			if (editorState.currentId !== capturedSecretId) return
 
 			if (response.status === 401) {
 				const payload = await readJson<{ error?: string }>(response)
@@ -864,6 +867,7 @@ export function AccountSecretsRoute(handle: Handle) {
 			showSecretValue = true
 			handle.update()
 		} catch (error) {
+			if (editorState.currentId !== capturedSecretId) return
 			revealState = 'prompting'
 			revealError =
 				error instanceof Error ? error.message : 'Unable to reveal secret.'
@@ -1592,6 +1596,7 @@ export function AccountSecretsRoute(handle: Handle) {
 												type="password"
 												autoComplete="current-password"
 												placeholder="Account password"
+												aria-label="Account password for reveal"
 												value={revealPassword}
 												disabled={revealState === 'revealing'}
 												mix={[

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -66,9 +66,7 @@ type SecretListItem = {
 	ttlMs: number | null
 }
 
-type SecretDetail = SecretListItem & {
-	value: string
-}
+type SecretDetail = SecretListItem
 
 type AccountSecretsPayload = {
 	ok: true
@@ -178,7 +176,7 @@ function createEditorStateFromSecret(secret: SecretDetail): EditorState {
 		scope: secret.scope,
 		appId: secret.appId ?? '',
 		description: secret.description,
-		value: secret.value,
+		value: '',
 		allowedHosts: allowedHosts.length > 0 ? allowedHosts : [''],
 		allowedCapabilities:
 			allowedCapabilities.length > 0 ? allowedCapabilities : [''],
@@ -464,6 +462,9 @@ export function AccountSecretsRoute(handle: Handle) {
 	let loadRequestId = 0
 	let retryTimeout: ReturnType<typeof setTimeout> | null = null
 	let showSecretValue = false
+	let revealState: 'idle' | 'prompting' | 'revealing' | 'revealed' = 'idle'
+	let revealPassword = ''
+	let revealError: string | null = null
 	const deleteSecretCheck = createDoubleCheck(handle)
 	const filterAppCombobox = TypeaheadCombobox(handle)
 	const editorAppCombobox = TypeaheadCombobox(handle)
@@ -493,6 +494,9 @@ export function AccountSecretsRoute(handle: Handle) {
 	function syncEditorState(selection: SelectionState) {
 		deleteSecretCheck.reset()
 		showSecretValue = false
+		revealState = 'idle'
+		revealPassword = ''
+		revealError = null
 		const capabilityPrefill = readCapabilityPrefill(getCurrentHref())
 		if (selection.isCreating) {
 			editorState = applyCapabilityPrefill(
@@ -805,6 +809,64 @@ export function AccountSecretsRoute(handle: Handle) {
 			saveState = 'idle'
 			message =
 				error instanceof Error ? error.message : 'Unable to delete secret.'
+			handle.update()
+		}
+	}
+
+	async function revealSecretValue() {
+		if (!editorState.currentId || revealState === 'revealing') return
+		if (!revealPassword.trim()) {
+			revealError = 'Password is required.'
+			handle.update()
+			return
+		}
+
+		revealState = 'revealing'
+		revealError = null
+		handle.update()
+
+		try {
+			const response = await fetch('/account/secrets/reveal', {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				credentials: 'include',
+				body: JSON.stringify({
+					secretId: editorState.currentId,
+					password: revealPassword,
+				}),
+			})
+
+			if (response.status === 401) {
+				const payload = await readJson<{ error?: string }>(response)
+				revealState = 'prompting'
+				revealError = payload?.error ?? 'Invalid password.'
+				revealPassword = ''
+				handle.update()
+				return
+			}
+
+			const payload = await readJson<{
+				ok?: boolean
+				value?: string
+				error?: string
+			}>(response)
+			if (!response.ok || !payload?.ok || typeof payload.value !== 'string') {
+				throw new Error(payload?.error ?? 'Unable to reveal secret.')
+			}
+
+			editorState = { ...editorState, value: payload.value }
+			revealState = 'revealed'
+			revealPassword = ''
+			revealError = null
+			showSecretValue = true
+			handle.update()
+		} catch (error) {
+			revealState = 'prompting'
+			revealError =
+				error instanceof Error ? error.message : 'Unable to reveal secret.'
 			handle.update()
 		}
 	}
@@ -1471,39 +1533,148 @@ export function AccountSecretsRoute(handle: Handle) {
 										})
 									: null}
 
-								<SecretEditorFields
-									description={editorState.description}
-									onDescriptionChange={(description) => {
-										editorState = {
-											...editorState,
-											description,
-										}
-										handle.update()
-									}}
-									value={editorState.value}
-									onValueChange={(value) => {
-										editorState = {
-											...editorState,
-											value,
-										}
-										handle.update()
-									}}
-									showSecretValue={showSecretValue}
-									onToggleShowSecretValue={() => {
-										showSecretValue = !showSecretValue
-										handle.update()
-									}}
-									allowedHosts={editorState.allowedHosts}
-									onUpdateAllowedHost={updateAllowedHost}
-									onAddAllowedHost={addAllowedHost}
-									onRemoveAllowedHost={removeAllowedHost}
-									allowedCapabilities={editorState.allowedCapabilities}
-									onUpdateAllowedCapability={updateAllowedCapability}
-									onAddAllowedCapability={addAllowedCapability}
-									onRemoveAllowedCapability={removeAllowedCapability}
-									allowedHostsListName="allowed-hosts"
-									allowedCapabilitiesListName="allowed-capabilities"
-								/>
+							<SecretEditorFields
+								description={editorState.description}
+								onDescriptionChange={(description) => {
+									editorState = {
+										...editorState,
+										description,
+									}
+									handle.update()
+								}}
+								value={editorState.value}
+								onValueChange={(value) => {
+									editorState = {
+										...editorState,
+										value,
+									}
+									handle.update()
+								}}
+								showSecretValue={showSecretValue}
+								onToggleShowSecretValue={() => {
+									showSecretValue = !showSecretValue
+									handle.update()
+								}}
+								allowedHosts={editorState.allowedHosts}
+								onUpdateAllowedHost={updateAllowedHost}
+								onAddAllowedHost={addAllowedHost}
+								onRemoveAllowedHost={removeAllowedHost}
+								allowedCapabilities={editorState.allowedCapabilities}
+								onUpdateAllowedCapability={updateAllowedCapability}
+								onAddAllowedCapability={addAllowedCapability}
+								onRemoveAllowedCapability={removeAllowedCapability}
+								allowedHostsListName="allowed-hosts"
+								allowedCapabilitiesListName="allowed-capabilities"
+							/>
+
+							{editorState.currentId &&
+							revealState !== 'revealed' ? (
+								<div
+									mix={css({
+										display: 'grid',
+										gap: spacing.sm,
+										padding: spacing.md,
+										borderRadius: radius.md,
+										border: `1px solid ${colors.border}`,
+										backgroundColor: colors.background,
+									})}
+								>
+									<span mix={css(fieldLabelCss)}>
+										Reveal current value
+									</span>
+									<p mix={css({ margin: 0, color: colors.textMuted })}>
+										Re-enter your account password to view the stored value.
+									</p>
+									{revealState === 'prompting' ||
+									revealState === 'revealing' ? (
+										<>
+											<input
+												type="password"
+												autoComplete="current-password"
+												placeholder="Account password"
+												value={revealPassword}
+												disabled={revealState === 'revealing'}
+												mix={[
+													on(
+														'input',
+														(event) => {
+															revealPassword = event.currentTarget.value
+															revealError = null
+															handle.update()
+														},
+													),
+													on('keydown', (event) => {
+														if (event.key === 'Enter') {
+															event.preventDefault()
+															void revealSecretValue()
+														}
+													}),
+													css(inputCss),
+												]}
+											/>
+											{revealError ? (
+												<p
+													role="alert"
+													mix={css({
+														margin: 0,
+														color: colors.error,
+													})}
+												>
+													{revealError}
+												</p>
+											) : null}
+											<div
+												mix={css({
+													display: 'flex',
+													gap: spacing.sm,
+												})}
+											>
+												<button
+													type="button"
+													disabled={revealState === 'revealing'}
+													mix={[
+														on('click', () => void revealSecretValue()),
+														css(primaryButtonCss),
+													]}
+												>
+													{revealState === 'revealing'
+														? 'Verifying...'
+														: 'Confirm'}
+												</button>
+												<button
+													type="button"
+													mix={[
+														on('click', () => {
+															revealState = 'idle'
+															revealPassword = ''
+															revealError = null
+															handle.update()
+														}),
+														css(secondaryButtonCss),
+													]}
+												>
+													Cancel
+												</button>
+											</div>
+										</>
+									) : (
+										<div>
+											<button
+												type="button"
+												mix={[
+													on('click', () => {
+														revealState = 'prompting'
+														handle.update()
+													}),
+													css(secondaryButtonCss),
+												]}
+											>
+												Reveal value
+											</button>
+										</div>
+									)}
+								</div>
+							) : null}
 
 								<div mix={css({ display: 'grid', gap: spacing.sm })}>
 									<div mix={css({ display: 'grid', gap: spacing.xs })}>

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -840,7 +840,11 @@ export function AccountSecretsRoute(handle: Handle) {
 				}),
 			})
 
-			if (editorState.currentId !== capturedSecretId) return
+			if (
+				editorState.currentId !== capturedSecretId ||
+				revealState !== 'revealing'
+			)
+				return
 
 			if (response.status === 401) {
 				const payload = await readJson<{ error?: string }>(response)
@@ -867,7 +871,11 @@ export function AccountSecretsRoute(handle: Handle) {
 			showSecretValue = true
 			handle.update()
 		} catch (error) {
-			if (editorState.currentId !== capturedSecretId) return
+			if (
+				editorState.currentId !== capturedSecretId ||
+				revealState !== 'revealing'
+			)
+				return
 			revealState = 'prompting'
 			revealError =
 				error instanceof Error ? error.message : 'Unable to reveal secret.'

--- a/packages/worker/src/app/audit-log.ts
+++ b/packages/worker/src/app/audit-log.ts
@@ -17,6 +17,11 @@ async function hashIdentifier(value: string) {
 	return toHex(new Uint8Array(digest))
 }
 
+export function redactEmailRecipient(email: string) {
+	const at = email.indexOf('@')
+	return at >= 0 ? `***@${email.slice(at + 1)}` : '***'
+}
+
 export function getRequestIp(request: Request) {
 	const forwarded = request.headers.get('x-forwarded-for')
 	const forwardedIp = forwarded?.split(',')[0]?.trim()

--- a/packages/worker/src/app/email/cloudflare-email.node.test.ts
+++ b/packages/worker/src/app/email/cloudflare-email.node.test.ts
@@ -192,9 +192,10 @@ test('sendCloudflareEmail returns skipped when account or token is missing', asy
 		expect(warnSpy).toHaveBeenCalledTimes(1)
 		const [reason, payload] = warnSpy.mock.calls[0]!
 		expect(reason).toBe('cloudflare-email-unconfigured')
-		expect(String(payload)).toContain('secret body')
-		expect(String(payload)).toContain('secret text')
-		expect(String(payload)).toContain('recipient@example.com')
+		expect(String(payload)).not.toContain('secret body')
+		expect(String(payload)).not.toContain('secret text')
+		expect(String(payload)).not.toContain('recipient@example.com')
+		expect(String(payload)).toContain('***@example.com')
 		expect(String(payload)).toContain('Skipped email')
 	} finally {
 		warnSpy.mockRestore()

--- a/packages/worker/src/app/email/cloudflare-email.ts
+++ b/packages/worker/src/app/email/cloudflare-email.ts
@@ -50,23 +50,23 @@ function normalizeEmailPayload(message: OutboundEmail) {
 	return result.value
 }
 
+function redactEmailRecipient(email: string) {
+	const at = email.indexOf('@')
+	return at >= 0 ? `***@${email.slice(at + 1)}` : '***'
+}
+
+function redactRecipients(to: string | Array<string>) {
+	if (Array.isArray(to)) return to.map(redactEmailRecipient)
+	return redactEmailRecipient(to)
+}
+
 function logSkippedEmail(reason: string, message: OutboundEmail) {
-	const headers =
-		message.headers ?
-			Object.fromEntries(
-				Object.keys(message.headers).map((key) => [key, '[REDACTED]']),
-			)
-		:	undefined
 	console.warn(
 		reason,
 		JSON.stringify({
-			to: message.to,
+			to: redactRecipients(message.to),
 			from: message.from,
 			subject: message.subject,
-			html: message.html,
-			text: message.text,
-			replyTo: message.replyTo,
-			headers,
 		}),
 	)
 }

--- a/packages/worker/src/app/email/cloudflare-email.ts
+++ b/packages/worker/src/app/email/cloudflare-email.ts
@@ -3,6 +3,7 @@ import {
 	outboundEmailSchema,
 	type OutboundEmail,
 } from '@kody-internal/shared/outbound-email.ts'
+import { redactEmailRecipient } from '#app/audit-log.ts'
 
 type CloudflareEmailClientConfig = {
 	accountId?: string
@@ -48,11 +49,6 @@ function normalizeEmailPayload(message: OutboundEmail) {
 		throw new Error(`Invalid outbound email payload: ${issueMessage}`)
 	}
 	return result.value
-}
-
-function redactEmailRecipient(email: string) {
-	const at = email.indexOf('@')
-	return at >= 0 ? `***@${email.slice(at + 1)}` : '***'
 }
 
 function redactRecipients(to: string | Array<string>) {

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
-	readAuthenticatedAppUser: async () => ({
+	readAuthenticatedAppUser: vi.fn(async () => ({
 		sessionUserId: '42',
 		userId: 42,
 		email: 'user@example.com',
@@ -12,7 +12,7 @@ const mockModule = vi.hoisted(() => ({
 			email: 'user@example.com',
 			displayName: 'user',
 		},
-	}),
+	})),
 	readAuthSessionResult: async () => ({ session: null, setCookie: null }),
 	getAppBaseUrl: () => 'https://example.com',
 	saveSecret: vi.fn(async () => ({
@@ -40,6 +40,10 @@ const mockModule = vi.hoisted(() => ({
 	setSecretAllowedCapabilities: vi.fn(async () => undefined),
 	setSecretAllowedPackages: vi.fn(async () => undefined),
 	getValue: vi.fn(async () => null),
+	logAuditEvent: vi.fn(async () => undefined),
+	getRequestIp: vi.fn(() => null),
+	dbFindOne: vi.fn(async () => null),
+	verifyPassword: vi.fn(async () => false),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -104,12 +108,31 @@ vi.mock('#mcp/values/service.ts', () => ({
 	saveValue: (...args: Array<unknown>) => mockModule.saveValue(...args),
 }))
 
+vi.mock('#app/audit-log.ts', () => ({
+	logAuditEvent: (...args: Array<unknown>) =>
+		mockModule.logAuditEvent(...args),
+	getRequestIp: (...args: Array<unknown>) => mockModule.getRequestIp(...args),
+}))
+
+vi.mock('#worker/db.ts', () => ({
+	createDb: () => ({
+		findOne: (...args: Array<unknown>) => mockModule.dbFindOne(...args),
+	}),
+	usersTable: 'users',
+}))
+
+vi.mock('@kody-internal/shared/password-hash.ts', () => ({
+	verifyPassword: (...args: Array<unknown>) =>
+		mockModule.verifyPassword(...args),
+}))
+
 vi.mock('#worker/package-registry/repo.ts', () => ({
 	listSavedPackagesByUserId: (...args: Array<unknown>) =>
 		mockModule.listSavedPackagesByUserId(...args),
 }))
 
-const { createAccountSecretsApiHandler } = await import('./account-secrets.ts')
+const { createAccountSecretsApiHandler, createAccountSecretRevealHandler } =
+	await import('./account-secrets.ts')
 
 function createEnv() {
 	return {
@@ -541,6 +564,134 @@ test('package approval approve deduplicates allowed package ids', async () => {
 			name: 'discordBotToken',
 			scope: 'user',
 			allowedPackages: ['pkg-allowed', 'pkg-new'],
+		}),
+	)
+})
+
+test('GET /account/secrets.json does not include value in selectedSecret', async () => {
+	mockModule.listSecrets.mockResolvedValueOnce([
+		{
+			name: 'myApiKey',
+			scope: 'user',
+			description: 'API key',
+			appId: null,
+			allowedHosts: [],
+			allowedCapabilities: [],
+			allowedPackages: [],
+			createdAt: new Date(0).toISOString(),
+			updatedAt: new Date(0).toISOString(),
+			ttlMs: null,
+		},
+	])
+	mockModule.resolveSecret.mockResolvedValueOnce({
+		found: true,
+		value: 'super-secret-value',
+	})
+	mockModule.listSavedPackagesByUserId.mockResolvedValueOnce([])
+	mockModule.listAppSecretsByAppIds.mockResolvedValueOnce(new Map())
+
+	const handler = createAccountSecretsApiHandler(createEnv())
+	const response = await handler.handler({
+		request: new Request(
+			'https://example.com/account/secrets.json?selected=user::::myApiKey',
+			{ method: 'GET' },
+		),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	const payload = await response.json()
+	expect(payload.ok).toBe(true)
+	expect(payload.selectedSecret).toBeDefined()
+	expect(payload.selectedSecret.name).toBe('myApiKey')
+	expect(payload.selectedSecret).not.toHaveProperty('value')
+})
+
+test('POST /account/secrets/reveal without password returns 401', async () => {
+	const handler = createAccountSecretRevealHandler(createEnv())
+	const response = await handler.handler({
+		request: new Request('https://example.com/account/secrets/reveal', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ secretId: 'user::::myApiKey' }),
+		}),
+	})
+
+	expect(response.status).toBe(401)
+	const payload = await response.json()
+	expect(payload.ok).toBe(false)
+})
+
+test('POST /account/secrets/reveal with wrong password returns 401', async () => {
+	mockModule.dbFindOne.mockResolvedValueOnce({
+		id: 42,
+		email: 'user@example.com',
+		password_hash:
+			'pbkdf2_sha256$100000$0000000000000000$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+	})
+	mockModule.verifyPassword.mockResolvedValueOnce(false)
+
+	const handler = createAccountSecretRevealHandler(createEnv())
+	const response = await handler.handler({
+		request: new Request('https://example.com/account/secrets/reveal', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				secretId: 'user::::myApiKey',
+				password: 'wrong-password',
+			}),
+		}),
+	})
+
+	expect(response.status).toBe(401)
+	const payload = await response.json()
+	expect(payload.ok).toBe(false)
+	expect(payload.error).toBe('Invalid password.')
+	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'secret_reveal',
+			result: 'failure',
+			reason: 'invalid_password',
+		}),
+	)
+})
+
+test('POST /account/secrets/reveal with valid reauth returns plaintext and writes audit log', async () => {
+	mockModule.dbFindOne.mockResolvedValueOnce({
+		id: 42,
+		email: 'user@example.com',
+		password_hash:
+			'pbkdf2_sha256$100000$0000000000000000$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+	})
+	mockModule.verifyPassword.mockResolvedValueOnce(true)
+	mockModule.resolveSecret.mockResolvedValueOnce({
+		found: true,
+		value: 'the-actual-secret-value',
+	})
+
+	const handler = createAccountSecretRevealHandler(createEnv())
+	const response = await handler.handler({
+		request: new Request('https://example.com/account/secrets/reveal', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				secretId: 'user::::myApiKey',
+				password: 'correct-password',
+			}),
+		}),
+	})
+
+	expect(response.status).toBe(200)
+	expect(response.headers.get('Cache-Control')).toBe('no-store')
+	const payload = await response.json()
+	expect(payload.ok).toBe(true)
+	expect(payload.value).toBe('the-actual-secret-value')
+	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'secret_reveal',
+			result: 'success',
 		}),
 	)
 })

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -299,10 +299,6 @@ test('host approval view is derived from allowed-host and selected secret', asyn
 			ttlMs: null,
 		},
 	])
-	mockModule.resolveSecret.mockResolvedValueOnce({
-		found: true,
-		value: 'secret-value',
-	})
 	mockModule.listSecrets.mockResolvedValueOnce([
 		{
 			name: 'cloudflareToken',
@@ -583,10 +579,6 @@ test('GET /account/secrets.json does not include value in selectedSecret', async
 			ttlMs: null,
 		},
 	])
-	mockModule.resolveSecret.mockResolvedValueOnce({
-		found: true,
-		value: 'super-secret-value',
-	})
 	mockModule.listSavedPackagesByUserId.mockResolvedValueOnce([])
 	mockModule.listAppSecretsByAppIds.mockResolvedValueOnce(new Map())
 

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -4,6 +4,7 @@ import {
 	parseAccountSecretId,
 } from '@kody-internal/shared/account-secret-route.ts'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
+import { logAuditEvent, getRequestIp } from '#app/audit-log.ts'
 import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { redirectToLogin } from '#app/auth-redirect.ts'
@@ -32,6 +33,8 @@ import {
 	buildConnectorValueName,
 	normalizeConnectorConfig,
 } from '#mcp/capabilities/values/connector-shared.ts'
+import { createDb, usersTable } from '#worker/db.ts'
+import { verifyPassword } from '@kody-internal/shared/password-hash.ts'
 
 type AccountEditableSecretScope = Extract<SecretScope, 'app' | 'user'>
 
@@ -64,9 +67,7 @@ type AccountSecretListItem = {
 	ttlMs: number | null
 }
 
-type AccountSecretDetail = AccountSecretListItem & {
-	value: string
-}
+type AccountSecretDetail = AccountSecretListItem
 
 type SecretApprovalView = {
 	name: string
@@ -206,6 +207,101 @@ export function createAccountSecretsApiHandler(env: Env) {
 		typeof routes.accountSecretsApi.method,
 		typeof routes.accountSecretsApi.pattern
 	>
+}
+
+export function createAccountSecretRevealHandler(env: Env) {
+	const db = createDb(env.APP_DB)
+
+	return {
+		middleware: [],
+		async handler({ request }: { request: Request }) {
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+
+			if (request.method !== 'POST') {
+				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+			}
+
+			const body = await request.json().catch(() => null)
+			if (!body || typeof body !== 'object') {
+				return jsonResponse({ ok: false, error: 'Invalid request body.' }, 400)
+			}
+
+			const secretId = readString(body, 'secretId')
+			const password = readString(body, 'password')
+			if (!secretId) {
+				return jsonResponse({ ok: false, error: 'Secret id is required.' }, 400)
+			}
+			if (!password) {
+				return jsonResponse(
+					{ ok: false, error: 'Password is required for reveal.' },
+					401,
+				)
+			}
+
+			const parsed = parseAccountSecretId(secretId)
+			if (!parsed) {
+				return jsonResponse({ ok: false, error: 'Invalid secret id.' }, 400)
+			}
+
+			const userRecord = await db.findOne(usersTable, {
+				where: { id: user.userId },
+			})
+			if (!userRecord) {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+			const passwordValid = await verifyPassword(
+				password,
+				userRecord.password_hash,
+			)
+			if (!passwordValid) {
+				void logAuditEvent({
+					category: 'auth',
+					action: 'secret_reveal',
+					result: 'failure',
+					email: user.email,
+					ip: getRequestIp(request) ?? undefined,
+					reason: 'invalid_password',
+				})
+				return jsonResponse(
+					{ ok: false, error: 'Invalid password.' },
+					401,
+				)
+			}
+
+			const resolved = await resolveSecret({
+				env,
+				userId: user.mcpUser.userId,
+				name: parsed.name,
+				scope: parsed.scope,
+				storageContext: getSecretContextForAccountSecret(parsed),
+			})
+			if (!resolved.found || resolved.value == null) {
+				return jsonResponse({ ok: false, error: 'Secret not found.' }, 404)
+			}
+
+			void logAuditEvent({
+				category: 'auth',
+				action: 'secret_reveal',
+				result: 'success',
+				email: user.email,
+				ip: getRequestIp(request) ?? undefined,
+			})
+
+			return new Response(
+				JSON.stringify({ ok: true, value: resolved.value }),
+				{
+					status: 200,
+					headers: {
+						'Cache-Control': 'no-store',
+						'Content-Type': 'application/json; charset=utf-8',
+					},
+				},
+			)
+		},
+	}
 }
 
 async function handleValueGetAction(input: {
@@ -819,10 +915,7 @@ async function resolveAccountSecretDetail(input: {
 	})
 	if (!resolved.found || resolved.value == null) return null
 
-	return {
-		...selected,
-		value: resolved.value,
-	} satisfies AccountSecretDetail
+	return { ...selected } satisfies AccountSecretDetail
 }
 
 function toAccountSecretListItem(

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -230,7 +230,11 @@ export function createAccountSecretRevealHandler(env: Env) {
 			}
 
 			const secretId = readString(body, 'secretId')
-			const password = readString(body, 'password')
+			const rawPassword = (body as Record<string, unknown>)['password']
+			const password =
+				typeof rawPassword === 'string' && rawPassword.length > 0
+					? rawPassword
+					: null
 			if (!secretId) {
 				return jsonResponse({ ok: false, error: 'Secret id is required.' }, 400)
 			}

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -731,9 +731,7 @@ async function buildAccountSecretsPayload(input: {
 		packageApps,
 	})
 	const selectedSecret = input.selectedSecretId
-		? await resolveAccountSecretDetail({
-				env: input.env,
-				userId: input.user.mcpUser.userId,
+		? resolveAccountSecretDetail({
 				secretId: input.selectedSecretId,
 				secrets,
 			})
@@ -894,9 +892,7 @@ async function resolveSecretApprovalView(input: {
 	} satisfies SecretApprovalView
 }
 
-async function resolveAccountSecretDetail(input: {
-	env: Env
-	userId: string
+function resolveAccountSecretDetail(input: {
 	secretId: string
 	secrets: Array<AccountSecretListItem>
 }) {
@@ -904,18 +900,7 @@ async function resolveAccountSecretDetail(input: {
 	if (!parsed) return null
 
 	const selected = input.secrets.find((secret) => secret.id === input.secretId)
-	if (!selected) return null
-
-	const resolved = await resolveSecret({
-		env: input.env,
-		userId: input.userId,
-		name: parsed.name,
-		scope: parsed.scope,
-		storageContext: getSecretContextForAccountSecret(parsed),
-	})
-	if (!resolved.found || resolved.value == null) return null
-
-	return { ...selected } satisfies AccountSecretDetail
+	return selected ?? null
 }
 
 function toAccountSecretListItem(
@@ -1104,7 +1089,7 @@ async function handleSaveAction(input: {
 }) {
 	const currentId = readOptionalString(input.body, 'currentId')
 	const name = readString(input.body, 'name')
-	const value = readString(input.body, 'value')
+	let value = readString(input.body, 'value')
 	const scope = readAccountSecretScope(input.body)
 	const description = readOptionalString(input.body, 'description') ?? ''
 	const allowedHosts = normalizeAllowedHosts(
@@ -1120,11 +1105,28 @@ async function handleSaveAction(input: {
 	if (!name) {
 		return jsonResponse({ ok: false, error: 'Secret name is required.' }, 400)
 	}
-	if (!value) {
-		return jsonResponse({ ok: false, error: 'Secret value is required.' }, 400)
-	}
 	if (!scope) {
 		return jsonResponse({ ok: false, error: 'Secret scope is required.' }, 400)
+	}
+
+	if (!value && currentId) {
+		const parsed = parseAccountSecretId(currentId)
+		if (parsed) {
+			const existing = await resolveSecret({
+				env: input.env,
+				userId: input.user.mcpUser.userId,
+				name: parsed.name,
+				scope: parsed.scope,
+				storageContext: getSecretContextForAccountSecret(parsed),
+			})
+			if (existing.found && existing.value != null) {
+				value = existing.value
+			}
+		}
+	}
+
+	if (!value) {
+		return jsonResponse({ ok: false, error: 'Secret value is required.' }, 400)
 	}
 
 	const savedPackages = await listSavedPackagesByUserId(input.env.APP_DB, {

--- a/packages/worker/src/app/handlers/password-reset.node.test.ts
+++ b/packages/worker/src/app/handlers/password-reset.node.test.ts
@@ -21,11 +21,15 @@ vi.mock('#worker/db.ts', () => ({
 	usersTable: {},
 }))
 
-vi.mock('#app/audit-log.ts', () => ({
-	getRequestIp: () => null,
-	logAuditEvent: (...args: Array<unknown>) =>
-		mockModule.logAuditEvent(...args),
-}))
+vi.mock('#app/audit-log.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
+	return {
+		...actual,
+		getRequestIp: () => null,
+		logAuditEvent: (...args: Array<unknown>) =>
+			mockModule.logAuditEvent(...args),
+	}
+})
 
 vi.mock('#app/email/cloudflare-email.ts', () => ({
 	sendCloudflareEmail: (...args: Array<unknown>) =>

--- a/packages/worker/src/app/handlers/password-reset.node.test.ts
+++ b/packages/worker/src/app/handlers/password-reset.node.test.ts
@@ -23,7 +23,8 @@ vi.mock('#worker/db.ts', () => ({
 
 vi.mock('#app/audit-log.ts', () => ({
 	getRequestIp: () => null,
-	logAuditEvent: (...args: Array<unknown>) => mockModule.logAuditEvent(...args),
+	logAuditEvent: (...args: Array<unknown>) =>
+		mockModule.logAuditEvent(...args),
 }))
 
 vi.mock('#app/email/cloudflare-email.ts', () => ({
@@ -54,6 +55,8 @@ function createResetRequest() {
 		body: JSON.stringify({ email: 'user@example.com' }),
 	})
 }
+
+const hexTokenPattern = /[0-9a-f]{64}/i
 
 test('password reset email sender is derived from APP_BASE_URL hostname', async () => {
 	const handler = createPasswordResetRequestHandler(
@@ -101,8 +104,71 @@ test('password reset email is skipped when APP_BASE_URL is not configured', asyn
 		expect(mockModule.sendCloudflareEmail).not.toHaveBeenCalled()
 		expect(warnSpy).toHaveBeenCalledWith(
 			'password-reset-email-sender-unconfigured',
-			expect.stringContaining('Reset your password'),
+			expect.any(String),
 		)
+	} finally {
+		warnSpy.mockRestore()
+	}
+})
+
+test('unconfigured email log does not contain token or raw recipient', async () => {
+	const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	const handler = createPasswordResetRequestHandler(
+		createEnv({ APP_BASE_URL: '' }),
+	)
+
+	try {
+		const response = await handler.handler({
+			request: createResetRequest(),
+			url: new URL('https://request-origin.test/password-reset'),
+			params: {},
+		})
+
+		expect(response.status).toBe(200)
+
+		const warnCalls = warnSpy.mock.calls
+		const emailMissingCall = warnCalls.find(
+			(args) => args[0] === 'password-reset-email-sender-unconfigured',
+		)
+		expect(emailMissingCall).toBeDefined()
+
+		const logPayload = emailMissingCall![1] as string
+		expect(logPayload).not.toContain('token=')
+		expect(logPayload).not.toMatch(hexTokenPattern)
+		expect(logPayload).not.toContain('user@example.com')
+		expect(logPayload).not.toContain('<html')
+		expect(logPayload).not.toContain('reset-password')
+
+		const parsed = JSON.parse(logPayload) as Record<string, unknown>
+		expect(parsed).toHaveProperty('subject')
+		expect(parsed.to).toBe('***@example.com')
+	} finally {
+		warnSpy.mockRestore()
+	}
+})
+
+test('configured email send does not log the token', async () => {
+	const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	const handler = createPasswordResetRequestHandler(
+		createEnv({ APP_BASE_URL: 'https://app.example.com' }),
+	)
+
+	try {
+		const response = await handler.handler({
+			request: createResetRequest(),
+			url: new URL('https://request-origin.test/password-reset'),
+			params: {},
+		})
+
+		expect(response.status).toBe(200)
+		expect(mockModule.sendCloudflareEmail).toHaveBeenCalledTimes(1)
+
+		const warnCalls = warnSpy.mock.calls
+		for (const args of warnCalls) {
+			const joined = args.map(String).join(' ')
+			expect(joined).not.toContain('token=')
+			expect(joined).not.toMatch(hexTokenPattern)
+		}
 	} finally {
 		warnSpy.mockRestore()
 	}

--- a/packages/worker/src/app/handlers/password-reset.ts
+++ b/packages/worker/src/app/handlers/password-reset.ts
@@ -56,17 +56,20 @@ async function hashResetToken(token: string) {
 	return toHex(new Uint8Array(digest))
 }
 
+function redactEmailRecipient(email: string) {
+	const at = email.indexOf('@')
+	return at >= 0 ? `***@${email.slice(at + 1)}` : '***'
+}
+
 function logMissingEmailConfig(payload: {
 	to: string
 	subject: string
-	html: string
 }) {
 	console.warn(
 		'password-reset-email-sender-unconfigured',
 		JSON.stringify({
-			to: payload.to,
+			to: redactEmailRecipient(payload.to),
 			subject: payload.subject,
-			body: payload.html,
 		}),
 	)
 }
@@ -150,7 +153,6 @@ export function createPasswordResetRequestHandler(appEnv: AppEnv) {
 					logMissingEmailConfig({
 						to: normalizedEmail,
 						subject: email.subject,
-						html: email.html,
 					})
 				} else {
 					try {

--- a/packages/worker/src/app/handlers/password-reset.ts
+++ b/packages/worker/src/app/handlers/password-reset.ts
@@ -1,7 +1,11 @@
 import { type BuildAction } from 'remix/fetch-router'
 import { object, parseSafe, string } from 'remix/data-schema'
 import { createDb, passwordResetsTable, usersTable } from '#worker/db.ts'
-import { logAuditEvent, getRequestIp } from '#app/audit-log.ts'
+import {
+	logAuditEvent,
+	getRequestIp,
+	redactEmailRecipient,
+} from '#app/audit-log.ts'
 import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
 import { normalizeEmail } from '#app/normalize-email.ts'
 import { type routes } from '#app/routes.ts'
@@ -54,11 +58,6 @@ async function hashResetToken(token: string) {
 	const data = new TextEncoder().encode(token)
 	const digest = await crypto.subtle.digest('SHA-256', data)
 	return toHex(new Uint8Array(digest))
-}
-
-function redactEmailRecipient(email: string) {
-	const at = email.indexOf('@')
-	return at >= 0 ? `***@${email.slice(at + 1)}` : '***'
 }
 
 function logMissingEmailConfig(payload: {

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -1,6 +1,7 @@
 import { createRouter } from 'remix/fetch-router'
 import { account } from '#app/handlers/account.ts'
 import {
+	createAccountSecretRevealHandler,
 	createAccountSecretsApiHandler,
 	createAccountSecretsHandler,
 } from '#app/handlers/account-secrets.ts'
@@ -77,6 +78,9 @@ export function createAppRouter(appEnv: AppEnv) {
 				appEnv as unknown as Env,
 			),
 			accountSecretsApiPost: createAccountSecretsApiHandler(
+				appEnv as unknown as Env,
+			),
+			accountSecretsReveal: createAccountSecretRevealHandler(
 				appEnv as unknown as Env,
 			),
 			connectSecret: createConnectSecretHandler(appEnv as unknown as Env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -18,6 +18,7 @@ export const routes = route({
 	accountSecretsApprove: '/account/secrets/approve',
 	accountSecretsApi: '/account/secrets.json',
 	accountSecretsApiPost: post('/account/secrets.json'),
+	accountSecretsReveal: post('/account/secrets/reveal'),
 	chatThreads: '/chat-threads',
 	chatThreadsCreate: post('/chat-threads'),
 	chatThreadsUpdate: post('/chat-threads/update'),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two MEDIUM findings from the 2026-05-01 security audit targeting authenticated/handler-level data leaking to incidental observers.

### Finding 4A: Password reset tokens logged when email is misconfigured

**Problem:** When the email sender was unconfigured, `logMissingEmailConfig` wrote the full HTML email body — including the live reset token URL — to `console.warn`. The generic `logSkippedEmail` helper in `cloudflare-email.ts` had the same issue, logging full `html`/`text` bodies when the API was unconfigured.

**Fix:**
- `logMissingEmailConfig` now logs only the email subject and a redacted recipient (`***@domain.com`). The HTML body, reset URL, and raw token are never logged.
- `logSkippedEmail` in `cloudflare-email.ts` is similarly stripped to log only `to` (redacted), `from`, and `subject`. No bodies or token-bearing URLs reach the log.
- `redactEmailRecipient` is shared via `audit-log.ts` to avoid duplication.
- Added `password-reset.node.test.ts` that captures `console.warn` output and asserts the payload contains no `token=`, no 64-hex sequences, no raw email address, and no HTML.
- Updated the existing `cloudflare-email.node.test.ts` assertion to verify the new redacted output.

### Finding 4B: Account secret detail API returned plaintext values

**Problem:** `resolveAccountSecretDetail` returned `{ value: resolved.value }` as part of the `selectedSecret` field in the `GET /account/secrets.json` response, putting plaintext secrets in every authenticated detail fetch.

**Fix:**
- `GET /account/secrets.json` no longer includes `value` in `selectedSecret`. The type `AccountSecretDetail` now equals `AccountSecretListItem` (metadata only).
- `resolveAccountSecretDetail` no longer fetches the secret value from storage — it only confirms the secret exists in the list.
- Metadata-only edits (description, hosts, capabilities, packages) work without revealing the value first: when saving an existing secret with an empty `value`, the handler re-reads the current value from storage.
- Added `POST /account/secrets/reveal` endpoint requiring:
  - Active `kody_session` cookie
  - Password reauthentication (verified with existing PBKDF2 helpers)
  - Returns plaintext once with `Cache-Control: no-store`
  - Writes structured audit log entries for both success and failure
- Updated the account-secrets UI with a "Reveal value" button that prompts for the account password on each reveal, and does not cache the value across navigation.
- Extended `account-secrets.node.test.ts` with 4 new tests:
  - GET does not include `value` in selectedSecret
  - Reveal without password returns 401
  - Reveal with wrong password returns 401 + audit log
  - Reveal with valid reauth returns plaintext + audit log

### Documentation

Updated `docs/contributing/architecture/authentication.md` to document the new reveal flow, correct the email provider reference (Cloudflare Email API, not Resend), and list the reveal handler in the "what to read" section.

### Files changed

| File | Change |
|------|--------|
| `packages/worker/src/app/audit-log.ts` | Add shared `redactEmailRecipient` export |
| `packages/worker/src/app/handlers/password-reset.ts` | Remove body/token from log, import shared redact |
| `packages/worker/src/app/email/cloudflare-email.ts` | Remove body from `logSkippedEmail`, import shared redact |
| `packages/worker/src/app/handlers/account-secrets.ts` | Remove value from detail, add reveal handler, support metadata-only save |
| `packages/worker/src/app/routes.ts` | Add `accountSecretsReveal` route |
| `packages/worker/src/app/router.ts` | Wire up reveal handler |
| `packages/worker/client/routes/account-secrets.tsx` | Add reveal UI flow |
| `packages/worker/src/app/handlers/password-reset.node.test.ts` | New test file |
| `packages/worker/src/app/handlers/account-secrets.node.test.ts` | Extended with reveal tests |
| `packages/worker/src/app/email/cloudflare-email.node.test.ts` | Updated assertion |
| `docs/contributing/architecture/authentication.md` | Document reveal flow |

### Bugbot feedback addressed

- **High**: Metadata-only secret edits (description, hosts, etc.) no longer fail with "Secret value is required" — the handler re-reads the existing value from storage when no new value is submitted.
- **Low**: `redactEmailRecipient` extracted to shared `audit-log.ts` to eliminate duplication.
- **Low**: `resolveAccountSecretDetail` no longer fetches then discards the secret value — it just validates the secret exists in the list.

### Verification

- Rebased on current `main` (includes #319 email sender refactor)
- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm run build` — clean
- `npm test` — 119 test files, 539 tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f2f8cb3-daa1-4aec-8f43-7cad2d99f50c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f2f8cb3-daa1-4aec-8f43-7cad2d99f50c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password-gated reveal workflow for account secrets requiring reauthentication to display sensitive values.
  * New POST /account/secrets/reveal endpoint to securely fetch secret plaintext (no-store caching).

* **Bug Fixes**
  * Secret edit form no longer pre-fills secret values until explicitly revealed.
  * Password-reset warning/logging now redacts recipient and omits email body/token details.

* **Documentation**
  * Updated authentication docs to reflect email delivery and the secrets reveal flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->