### PR TITLE
Add Tesla Backup Gateway 2 home-connector adapter

### DIFF
--- a/docs/contributing/architecture/home-connector.md
+++ b/docs/contributing/architecture/home-connector.md
@@ -16,6 +16,7 @@ The connector exposes these local-device families:
 - Samsung TV / Frame discovery and control over mDNS, REST, and local WebSocket
   channels
 - Venstar WiFi thermostat status and control over the local REST API
+- Tesla Backup Gateway 2 (Powerwall+ leader) customer-scope local-API reads
 
 All surfaces are registered as MCP tools inside the connector and then exposed
 to the Worker through the existing outbound WebSocket session to
@@ -100,6 +101,40 @@ Discovery is subnet-scan-only. The connector probes `/query/info` across
 fragility that showed up on NAS and Docker bridge deployments while keeping the
 user flow aligned with the other managed device integrations.
 
+## Tesla Backup Gateway 2 integration
+
+The Tesla gateway adapter lives under
+`packages/home-connector/src/adapters/tesla-gateway/` and exposes the
+customer-scope local-API endpoints (`/api/status`, `/api/system_status`,
+`/api/system_status/{grid_status,soe}`, `/api/meters/aggregates`,
+`/api/operation`, `/api/networks`, `/api/site_info`, `/api/powerwalls`,
+`/api/solar_powerwall`, `/api/generators`, `/api/system/update/status`).
+Installer-scope endpoints (`/api/installer`, `/api/config`) are deliberately
+excluded — site export limits are surfaced from
+`site_info.max_site_meter_power_ac` or `system_status.solar_real_power_limit`
+instead.
+
+Authentication is `POST /api/login/Basic` with role `customer`. The `email`
+field is a free-form audit label and is not validated against tesla.com. The
+connector caches the resulting `AuthCookie` / `UserRecord` cookies for ~24h and
+single-flights logins per gateway. It also tracks login rate-limit cooldowns —
+Tesla's gateway accepts new TCP connections during a cooldown but blackholes
+login POSTs, so any login timeout marks a 15-minute cooldown that short-circuits
+further attempts before they ever leave the connector.
+
+Discovery probes TCP 443 across `TESLA_GATEWAY_SCAN_CIDRS`, inspects each TLS
+cert for the Tesla `O=Tesla, OU=Tesla Energy Products` subject and SAN entries
+`DNS:teg, DNS:powerwall`, and combines the result with the local ARP cache to
+filter on MAC OUI: `90:03:71` identifies BGW2 leaders, `00:d6:cb` identifies
+Powerwall units (which are filtered out because they do not answer `/api/...`).
+When `TESLA_GATEWAY_DISCOVERY_URL` is set to an HTTP(S) URL the LAN sweep is
+skipped and gateways are read from a JSON feed instead, which is how the
+dev/mock server works.
+
+Hosts ending in `.mock.local` are routed directly through the in-process mock
+driver (`src/adapters/tesla-gateway/mock-driver.ts`) so dev and test runs never
+touch the network stack.
+
 ## Local persistence
 
 Unlike the Worker-side home connector session, which persists its own view of
@@ -118,6 +153,7 @@ The connector stores a local SQLite database containing:
 - discovered Bond bridges and tokens
 - discovered Sonos players
 - managed Venstar thermostats
+- discovered Tesla gateways and their encrypted customer credentials
 
 By default the database is stored at
 `~/.kody/home-connector/home-connector.sqlite`. Operators can override the base

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -190,6 +190,18 @@ Authoring guide for outbound WebSocket services:
   `http://{ip}/query/info` directly. Example:
   `VENSTAR_SCAN_CIDRS=192.168.1.0/24,10.0.0.50/32`. Broader private interface
   CIDRs like `/23` are automatically split into multiple `/24` scan blocks.
+- `TESLA_GATEWAY_SCAN_CIDRS` — optional connector env var. Comma-separated CIDR
+  list for Tesla Backup Gateway 2 leader discovery. Same `a.b.c.0/24` /
+  `a.b.c.d/32` rules as `VENSTAR_SCAN_CIDRS`. The connector probes TCP 443,
+  inspects the TLS cert (Tesla `O=Tesla, OU=Tesla Energy Products` with SAN
+  `DNS:teg, DNS:powerwall`), and combines the result with MAC OUI filtering
+  (`90:03:71` for BGW2 leaders, `00:d6:cb` for Powerwall units, which are
+  filtered out). When unset, the connector derives private `/24` networks from
+  local IPv4 interfaces.
+- `TESLA_GATEWAY_DISCOVERY_URL` — optional connector env var. When set to an
+  HTTP(S) URL, the connector skips the LAN sweep and reads
+  `{ "gateways": [...] }` from the URL. Used by the dev/mock server
+  (`http://tesla-gateway.mock.local/discovery`).
 - `HOME_CONNECTOR_DATA_PATH` — optional connector env var. Directory used for
   connector-owned local data files. When `HOME_CONNECTOR_DB_PATH` is unset, the
   home connector stores its local SQLite database at
@@ -198,8 +210,9 @@ Authoring guide for outbound WebSocket services:
 - `HOME_CONNECTOR_DB_PATH` — optional connector env var. Full path to the local
   SQLite file used by the home connector to persist device integration state
   such as Samsung TV metadata/tokens, Lutron processor credentials, Bond bridge
-  state, Sonos players, and Venstar managed thermostats across restarts.
-  Overrides the derived `HOME_CONNECTOR_DATA_PATH` location.
+  state, Sonos players, Venstar managed thermostats, and Tesla gateway
+  records/credentials across restarts. Overrides the derived
+  `HOME_CONNECTOR_DATA_PATH` location.
 
 ## Why Zod?
 

--- a/packages/home-connector/app/handlers.ts
+++ b/packages/home-connector/app/handlers.ts
@@ -9,6 +9,7 @@ import { type createBondAdapter } from '../src/adapters/bond/index.ts'
 import { type createJellyfishAdapter } from '../src/adapters/jellyfish/index.ts'
 import { type createSonosAdapter } from '../src/adapters/sonos/index.ts'
 import { type createSamsungTvAdapter } from '../src/adapters/samsung-tv/index.ts'
+import { type createTeslaGatewayAdapter } from '../src/adapters/tesla-gateway/index.ts'
 import { type createVenstarAdapter } from '../src/adapters/venstar/index.ts'
 import { type HomeConnectorState } from '../src/state.ts'
 import { type RokuDiscoveryDiagnostics } from '../src/adapters/roku/types.ts'
@@ -36,6 +37,8 @@ function renderQuickLinks(state: HomeConnectorState) {
 		<li><a href="/jellyfish/setup">JellyFish setup</a></li>
 		<li><a href="/venstar/status">Venstar status</a></li>
 		<li><a href="/venstar/setup">Venstar setup</a></li>
+		<li><a href="/tesla-gateway/status">Tesla gateway status</a></li>
+		<li><a href="/tesla-gateway/setup">Tesla gateway setup</a></li>
 		<li><a href="/health">Health JSON</a></li>
 		${workerSnapshotUrl
 			? html`<li>
@@ -57,6 +60,7 @@ export function createHomeDashboardHandler(
 	bond: ReturnType<typeof createBondAdapter>,
 	jellyfish: ReturnType<typeof createJellyfishAdapter>,
 	venstar: ReturnType<typeof createVenstarAdapter>,
+	teslaGateway: ReturnType<typeof createTeslaGatewayAdapter>,
 ) {
 	return {
 		middleware: [],
@@ -76,6 +80,7 @@ export function createHomeDashboardHandler(
 			const onlineVenstarCount = venstarStatus.filter(
 				(thermostat) => thermostat.info != null,
 			).length
+			const teslaGatewayStatus = teslaGateway.getStatus()
 
 			return render(
 				RootLayout({
@@ -198,6 +203,16 @@ export function createHomeDashboardHandler(
 									{
 										label: 'Venstar offline',
 										value: String(venstarStatus.length - onlineVenstarCount),
+									},
+									{
+										label: 'Tesla gateways',
+										value: String(teslaGatewayStatus.gateways.length),
+									},
+									{
+										label: 'Tesla gateway credentials',
+										value: String(
+											teslaGatewayStatus.configuredCredentialsCount,
+										),
 									},
 									{
 										label: 'Mocks',

--- a/packages/home-connector/app/router.node.test.ts
+++ b/packages/home-connector/app/router.node.test.ts
@@ -316,6 +316,92 @@ test('venstar setup can save and remove thermostats directly', async () => {
 	}
 })
 
+test('tesla gateway status rejects cross-origin mutations and renders live snapshots', async () => {
+	const dataPath = createTemporaryDataPath()
+	const config = createConfig(dataPath)
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		jellyfish,
+		venstar,
+		teslaGateway,
+	} = createAdapters(config)
+	try {
+		const router = createHomeConnectorRouter(
+			state,
+			config,
+			lutron,
+			samsungTv,
+			sonos,
+			bond,
+			jellyfish,
+			venstar,
+			teslaGateway,
+		)
+
+		const rejectedResponse = await router.fetch(
+			'http://example.test/tesla-gateway/status',
+			{
+				method: 'POST',
+				headers: {
+					'content-type': 'application/x-www-form-urlencoded',
+					origin: 'http://evil.example',
+				},
+				body: 'action=scan',
+			},
+		)
+		expect(rejectedResponse.status).toBe(403)
+
+		await router.fetch('http://example.test/tesla-gateway/status', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/x-www-form-urlencoded',
+				origin: 'http://example.test',
+			},
+			body: 'action=scan',
+		})
+		await router.fetch('http://example.test/tesla-gateway/setup', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/x-www-form-urlencoded',
+				origin: 'http://example.test',
+			},
+			body: new URLSearchParams({
+				action: 'save-credentials',
+				gatewayId: 'tesla-gateway-mock-home-1',
+				password: 'mock-password',
+			}).toString(),
+		})
+		const snapshotResponse = await router.fetch(
+			'http://example.test/tesla-gateway/status',
+			{
+				method: 'POST',
+				headers: {
+					'content-type': 'application/x-www-form-urlencoded',
+					origin: 'http://example.test',
+				},
+				body: new URLSearchParams({
+					action: 'fetch-snapshot',
+					gatewayId: 'tesla-gateway-mock-home-1',
+				}).toString(),
+			},
+		)
+
+		expect(snapshotResponse.status).toBe(200)
+		const html = await snapshotResponse.text()
+		expect(html).toContain('Action result')
+		expect(html).toContain('max_site_export_power_kW')
+		expect(html).toContain('meters')
+	} finally {
+		storage.close()
+		rmSync(dataPath, { recursive: true, force: true })
+	}
+})
+
 test('health route returns ok json', async () => {
 	const config = createConfig()
 	const {

--- a/packages/home-connector/app/router.node.test.ts
+++ b/packages/home-connector/app/router.node.test.ts
@@ -8,6 +8,7 @@ import { createJellyfishAdapter } from '../src/adapters/jellyfish/index.ts'
 import { createLutronAdapter } from '../src/adapters/lutron/index.ts'
 import { createSamsungTvAdapter } from '../src/adapters/samsung-tv/index.ts'
 import { createSonosAdapter } from '../src/adapters/sonos/index.ts'
+import { createTeslaGatewayAdapter } from '../src/adapters/tesla-gateway/index.ts'
 import { createVenstarAdapter } from '../src/adapters/venstar/index.ts'
 import { upsertVenstarThermostat } from '../src/adapters/venstar/repository.ts'
 import { type HomeConnectorConfig } from '../src/config.ts'
@@ -30,6 +31,8 @@ function createConfig(dataPath = '/tmp'): HomeConnectorConfig {
 		jellyfishDiscoveryUrl: 'http://jellyfish.mock.local/discovery',
 		venstarScanCidrs: ['192.168.10.40/32', '192.168.10.41/32'],
 		jellyfishScanCidrs: ['192.168.10.93/32'],
+		teslaGatewayScanCidrs: [],
+		teslaGatewayDiscoveryUrl: null,
 		dataPath,
 		dbPath: ':memory:',
 		port: 4040,
@@ -75,6 +78,7 @@ function createAdapters(config: HomeConnectorConfig) {
 			storage,
 		}),
 		venstar: createVenstarAdapter({ config, state, storage }),
+		teslaGateway: createTeslaGatewayAdapter({ config, state, storage }),
 	}
 }
 
@@ -86,8 +90,17 @@ function createTemporaryDataPath() {
 
 test('home route toggles worker snapshot link by connector id', async () => {
 	const config = createConfig()
-	const { state, storage, lutron, sonos, samsungTv, bond, jellyfish, venstar } =
-		createAdapters(config)
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		jellyfish,
+		venstar,
+		teslaGateway,
+	} = createAdapters(config)
 	state.connection.connectorId = 'default'
 	state.connection.workerUrl = 'http://localhost:3742'
 	try {
@@ -100,6 +113,7 @@ test('home route toggles worker snapshot link by connector id', async () => {
 			bond,
 			jellyfish,
 			venstar,
+			teslaGateway,
 		)
 		const responseWithConnector = await router.fetch('http://example.test/')
 		expect(responseWithConnector.status).toBe(200)
@@ -120,8 +134,17 @@ test('home route toggles worker snapshot link by connector id', async () => {
 
 test('venstar status scan shows discovered thermostats', async () => {
 	const config = createConfig()
-	const { state, storage, lutron, sonos, samsungTv, bond, jellyfish, venstar } =
-		createAdapters(config)
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		jellyfish,
+		venstar,
+		teslaGateway,
+	} = createAdapters(config)
 	try {
 		const router = createHomeConnectorRouter(
 			state,
@@ -132,6 +155,7 @@ test('venstar status scan shows discovered thermostats', async () => {
 			bond,
 			jellyfish,
 			venstar,
+			teslaGateway,
 		)
 		const response = await router.fetch('http://example.test/venstar/status', {
 			method: 'POST',
@@ -158,8 +182,17 @@ test('venstar status scan shows discovered thermostats', async () => {
 test('venstar status can adopt a discovered thermostat', async () => {
 	const dataPath = createTemporaryDataPath()
 	const config = createConfig(dataPath)
-	const { state, storage, lutron, sonos, samsungTv, bond, jellyfish, venstar } =
-		createAdapters(config)
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		jellyfish,
+		venstar,
+		teslaGateway,
+	} = createAdapters(config)
 	try {
 		const router = createHomeConnectorRouter(
 			state,
@@ -170,6 +203,7 @@ test('venstar status can adopt a discovered thermostat', async () => {
 			bond,
 			jellyfish,
 			venstar,
+			teslaGateway,
 		)
 
 		await router.fetch('http://example.test/venstar/status', {
@@ -215,8 +249,17 @@ test('venstar status can adopt a discovered thermostat', async () => {
 test('venstar setup can save and remove thermostats directly', async () => {
 	const dataPath = createTemporaryDataPath()
 	const config = createConfig(dataPath)
-	const { state, storage, lutron, sonos, samsungTv, bond, jellyfish, venstar } =
-		createAdapters(config)
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		jellyfish,
+		venstar,
+		teslaGateway,
+	} = createAdapters(config)
 	try {
 		venstar.removeThermostat('venstar.mock.local')
 		const router = createHomeConnectorRouter(
@@ -228,6 +271,7 @@ test('venstar setup can save and remove thermostats directly', async () => {
 			bond,
 			jellyfish,
 			venstar,
+			teslaGateway,
 		)
 
 		const saveResponse = await router.fetch(
@@ -274,8 +318,17 @@ test('venstar setup can save and remove thermostats directly', async () => {
 
 test('health route returns ok json', async () => {
 	const config = createConfig()
-	const { state, storage, lutron, sonos, samsungTv, bond, jellyfish, venstar } =
-		createAdapters(config)
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		jellyfish,
+		venstar,
+		teslaGateway,
+	} = createAdapters(config)
 	try {
 		const router = createHomeConnectorRouter(
 			state,
@@ -286,6 +339,7 @@ test('health route returns ok json', async () => {
 			bond,
 			jellyfish,
 			venstar,
+			teslaGateway,
 		)
 		const response = await router.fetch('http://example.test/health')
 		expect(response.status).toBe(200)

--- a/packages/home-connector/app/router.ts
+++ b/packages/home-connector/app/router.ts
@@ -25,12 +25,17 @@ import {
 	createVenstarSetupHandler,
 	createVenstarStatusHandler,
 } from './venstar-handlers.ts'
+import {
+	createTeslaGatewaySetupHandler,
+	createTeslaGatewayStatusHandler,
+} from './tesla-gateway-handlers.ts'
 import { routes } from './routes.ts'
 import { type createLutronAdapter } from '../src/adapters/lutron/index.ts'
 import { type createBondAdapter } from '../src/adapters/bond/index.ts'
 import { type createJellyfishAdapter } from '../src/adapters/jellyfish/index.ts'
 import { type createSonosAdapter } from '../src/adapters/sonos/index.ts'
 import { type createSamsungTvAdapter } from '../src/adapters/samsung-tv/index.ts'
+import { type createTeslaGatewayAdapter } from '../src/adapters/tesla-gateway/index.ts'
 import { type createVenstarAdapter } from '../src/adapters/venstar/index.ts'
 import { type HomeConnectorConfig } from '../src/config.ts'
 import { type HomeConnectorState } from '../src/state.ts'
@@ -44,6 +49,7 @@ export function createHomeConnectorRouter(
 	bond: ReturnType<typeof createBondAdapter>,
 	jellyfish: ReturnType<typeof createJellyfishAdapter>,
 	venstar: ReturnType<typeof createVenstarAdapter>,
+	teslaGateway: ReturnType<typeof createTeslaGatewayAdapter>,
 ) {
 	const router = createRouter({
 		middleware: [],
@@ -59,6 +65,7 @@ export function createHomeConnectorRouter(
 				bond,
 				jellyfish,
 				venstar,
+				teslaGateway,
 			),
 			health: createHealthHandler(state),
 			lutronStatus: createLutronStatusHandler(state, lutron),
@@ -75,6 +82,16 @@ export function createHomeConnectorRouter(
 			jellyfishSetup: createJellyfishSetupHandler(state, config, jellyfish),
 			venstarStatus: createVenstarStatusHandler(state, config, venstar),
 			venstarSetup: createVenstarSetupHandler(state, config, venstar),
+			teslaGatewayStatus: createTeslaGatewayStatusHandler(
+				state,
+				config,
+				teslaGateway,
+			),
+			teslaGatewaySetup: createTeslaGatewaySetupHandler(
+				state,
+				config,
+				teslaGateway,
+			),
 		},
 	})
 

--- a/packages/home-connector/app/routes.ts
+++ b/packages/home-connector/app/routes.ts
@@ -17,4 +17,6 @@ export const routes = route({
 	jellyfishSetup: '/jellyfish/setup',
 	venstarStatus: '/venstar/status',
 	venstarSetup: '/venstar/setup',
+	teslaGatewayStatus: '/tesla-gateway/status',
+	teslaGatewaySetup: '/tesla-gateway/setup',
 })

--- a/packages/home-connector/app/tesla-gateway-handlers.ts
+++ b/packages/home-connector/app/tesla-gateway-handlers.ts
@@ -1,0 +1,495 @@
+import { type BuildAction } from 'remix/fetch-router'
+import { html } from 'remix/html-template'
+import { captureHomeConnectorException } from '../src/sentry.ts'
+import { type HomeConnectorConfig } from '../src/config.ts'
+import { type createTeslaGatewayAdapter } from '../src/adapters/tesla-gateway/index.ts'
+import {
+	type TeslaGatewayDiscoveryDiagnostics,
+	type TeslaGatewayPublicRecord,
+} from '../src/adapters/tesla-gateway/types.ts'
+import { type HomeConnectorState } from '../src/state.ts'
+import { render } from './render.ts'
+import { RootLayout } from './root.ts'
+import { type routes } from './routes.ts'
+import {
+	formatJson,
+	renderBanner,
+	renderCodeBlock,
+	renderInfoRows,
+} from './handler-utils.ts'
+
+function requireStringField(
+	formData: FormData,
+	key: string,
+	label: string,
+): string {
+	const value = formData.get(key)
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		throw new Error(`${label} is required.`)
+	}
+	return value.trim()
+}
+
+async function readPostedFormData(request: Request, fallbackAction: string) {
+	const contentType = request.headers.get('content-type')?.toLowerCase() ?? ''
+	if (
+		contentType.includes('application/x-www-form-urlencoded') ||
+		contentType.includes('multipart/form-data')
+	) {
+		return await request.formData()
+	}
+	const formData = new FormData()
+	formData.set('action', fallbackAction)
+	return formData
+}
+
+async function handleTeslaGatewayMutation(input: {
+	action: string
+	formData: FormData
+	teslaGateway: ReturnType<typeof createTeslaGatewayAdapter>
+}) {
+	const { action, formData, teslaGateway } = input
+
+	if (action === 'scan') {
+		const gateways = await teslaGateway.scan()
+		return {
+			message: `Scan complete. ${gateways.length} gateway(s) known.`,
+		}
+	}
+
+	if (action === 'authenticate') {
+		const gatewayId = requireStringField(formData, 'gatewayId', 'Gateway')
+		const gateway = await teslaGateway.authenticate(gatewayId)
+		return {
+			message: `Authenticated against ${gateway.host} (${gateway.gatewayId}).`,
+		}
+	}
+
+	if (action === 'fetch-snapshot') {
+		const gatewayId = requireStringField(formData, 'gatewayId', 'Gateway')
+		const snapshot = await teslaGateway.getLiveSnapshot(gatewayId)
+		const errorCount = Object.keys(snapshot.fetchErrors).length
+		return {
+			message:
+				errorCount === 0
+					? `Pulled live snapshot for ${snapshot.gateway.gatewayId}.`
+					: `Pulled snapshot for ${snapshot.gateway.gatewayId} with ${errorCount} per-endpoint error(s).`,
+		}
+	}
+
+	if (action === 'find-export-limit') {
+		const gatewayId = requireStringField(formData, 'gatewayId', 'Gateway')
+		const info = await teslaGateway.findExportLimit(gatewayId)
+		return {
+			message:
+				info.exportLimitKw === null
+					? `Could not determine an export limit for ${info.gatewayId}.`
+					: `${info.gatewayId} export limit ≈ ${info.exportLimitKw} kW (source: ${info.source}).`,
+		}
+	}
+
+	if (action === 'save-credentials') {
+		const gatewayId = requireStringField(formData, 'gatewayId', 'Gateway')
+		const password = requireStringField(formData, 'password', 'Password')
+		const emailLabel = formData.get('customerEmailLabel')
+		const gateway = teslaGateway.setCredentials({
+			gatewayId,
+			password,
+			...(typeof emailLabel === 'string' && emailLabel.trim().length > 0
+				? { customerEmailLabel: emailLabel.trim() }
+				: {}),
+		})
+		return {
+			message: `Saved credentials for ${gateway.host} (${gateway.gatewayId}).`,
+		}
+	}
+
+	if (action === 'set-label') {
+		const gatewayId = requireStringField(formData, 'gatewayId', 'Gateway')
+		const labelInput = formData.get('label')
+		const label =
+			typeof labelInput === 'string' && labelInput.trim().length > 0
+				? labelInput.trim()
+				: null
+		teslaGateway.setLabel({ gatewayId, label })
+		return {
+			message: label
+				? `Set label for ${gatewayId} to "${label}".`
+				: `Cleared label for ${gatewayId}.`,
+		}
+	}
+
+	throw new Error(`Unknown Tesla gateway action "${action}".`)
+}
+
+function renderGatewayList(gateways: Array<TeslaGatewayPublicRecord>) {
+	if (gateways.length === 0) {
+		return html`<p class="muted">
+			No Tesla gateways are currently known. Run a scan from the status page or
+			set a static <code>TESLA_GATEWAY_DISCOVERY_URL</code> for mock testing.
+		</p>`
+	}
+	return html`<ul class="list">
+		${gateways.map(
+			(gateway) => html`<li class="card">
+				<strong>${gateway.label ?? gateway.gatewayId}</strong>
+				<div>Host: <code>${gateway.host}:${String(gateway.port)}</code></div>
+				<div>Gateway ID: <code>${gateway.gatewayId}</code></div>
+				<div>DIN: <code>${gateway.din ?? 'unknown'}</code></div>
+				<div>Serial: <code>${gateway.serialNumber ?? 'unknown'}</code></div>
+				<div>MAC: <code>${gateway.macAddress ?? 'unknown'}</code></div>
+				<div>OUI: <code>${gateway.macOui ?? 'unknown'}</code></div>
+				<div>Firmware: ${gateway.firmwareVersion ?? 'unknown'}</div>
+				<div>Role: ${gateway.role}</div>
+				<div>
+					Cert subject:
+					<code
+						>${gateway.cert?.subjectOrganization ?? 'unknown'} /
+						${gateway.cert?.subjectOrganizationalUnit ?? 'unknown'}</code
+					>
+				</div>
+				<div>
+					Credentials: ${gateway.hasStoredCredentials ? 'stored' : 'missing'}
+				</div>
+				<div>Last authenticated: ${gateway.lastAuthenticatedAt ?? 'never'}</div>
+				${gateway.lastAuthError
+					? html`<div>Last auth error: ${gateway.lastAuthError}</div>`
+					: ''}
+				<form method="POST">
+					<input type="hidden" name="action" value="authenticate" />
+					<input type="hidden" name="gatewayId" value="${gateway.gatewayId}" />
+					<button type="submit">Authenticate</button>
+				</form>
+				<form method="POST">
+					<input type="hidden" name="action" value="fetch-snapshot" />
+					<input type="hidden" name="gatewayId" value="${gateway.gatewayId}" />
+					<button type="submit">Fetch live snapshot</button>
+				</form>
+				<form method="POST">
+					<input type="hidden" name="action" value="find-export-limit" />
+					<input type="hidden" name="gatewayId" value="${gateway.gatewayId}" />
+					<button type="submit">Find export limit</button>
+				</form>
+			</li>`,
+		)}
+	</ul>`
+}
+
+function renderTeslaGatewayDiscoveryDiagnostics(
+	diagnostics: TeslaGatewayDiscoveryDiagnostics | null,
+) {
+	if (!diagnostics) {
+		return html`<p class="muted">
+			No Tesla gateway scan diagnostics captured yet.
+		</p>`
+	}
+	return html`
+		<section class="card">
+			<h2>Discovery diagnostics</h2>
+			${renderInfoRows([
+				{ label: 'Protocol', value: diagnostics.protocol },
+				{
+					label: 'Discovery URL',
+					value: html`<code>${diagnostics.discoveryUrl}</code>`,
+				},
+				{ label: 'Last scan', value: diagnostics.scannedAt },
+				{
+					label: 'Hosts probed',
+					value: String(diagnostics.subnetProbe?.hostsProbed ?? 0),
+				},
+				{
+					label: 'Tesla matches',
+					value: String(diagnostics.subnetProbe?.teslaMatches ?? 0),
+				},
+				{
+					label: 'Leader matches',
+					value: String(diagnostics.subnetProbe?.leaderMatches ?? 0),
+				},
+				{ label: 'Errors', value: String(diagnostics.errors.length) },
+			])}
+		</section>
+		<section class="card">
+			<h2>Host probes</h2>
+			${diagnostics.hostProbes.length === 0
+				? html`<p class="muted">No host probes were captured.</p>`
+				: html`<ul class="list">
+						${diagnostics.hostProbes.map(
+							(probe) => html`<li class="card">
+								<div>
+									Host: <code>${probe.host}:${String(probe.port)}</code>
+								</div>
+								<div>TCP open: ${probe.tcpOpen ? 'yes' : 'no'}</div>
+								<div>MAC: <code>${probe.macAddress ?? 'unknown'}</code></div>
+								<div>OUI: <code>${probe.macOui ?? 'unknown'}</code></div>
+								<div>
+									Identified as Tesla: ${probe.identifiedAsTesla ? 'yes' : 'no'}
+								</div>
+								<div>
+									Identified as leader:
+									${probe.identifiedAsLeader ? 'yes' : 'no'}
+								</div>
+								${probe.cert
+									? html`<div>
+											Cert: ${renderCodeBlock(formatJson(probe.cert))}
+										</div>`
+									: ''}
+								${probe.loginEndpointResponse
+									? html`<div>
+											Login probe:
+											${renderCodeBlock(
+												formatJson(probe.loginEndpointResponse),
+											)}
+										</div>`
+									: ''}
+							</li>`,
+						)}
+					</ul>`}
+		</section>
+	`
+}
+
+function renderTeslaGatewayPage(input: {
+	state: HomeConnectorState
+	config: HomeConnectorConfig
+	teslaGateway: ReturnType<typeof createTeslaGatewayAdapter>
+	title: string
+	includeSetupForm?: boolean
+	scanMessage?: string | null
+	scanError?: string | null
+}) {
+	const status = input.teslaGateway.getStatus()
+	return render(
+		RootLayout({
+			title: `home connector - ${input.title}`,
+			body: html`<section class="card">
+					<h1>Tesla gateway ${input.title}</h1>
+					<p class="muted">
+						Local-API access to Tesla Backup Gateway 2 leaders. Customer-role
+						credentials are stored encrypted with
+						<code>HOME_CONNECTOR_SHARED_SECRET</code> and reused as a cookie
+						session for ~24h before re-login.
+					</p>
+					<p>
+						<a href="/tesla-gateway/status">Tesla gateway status</a>
+						—
+						<a href="/tesla-gateway/setup">Tesla gateway setup</a>
+					</p>
+					<form method="POST">
+						<input type="hidden" name="action" value="scan" />
+						<button type="submit">Scan now</button>
+					</form>
+					<div class="status-grid">
+						<div>
+							<strong>Worker connection</strong>
+							<div>
+								${input.state.connection.connected
+									? 'connected'
+									: 'disconnected'}
+							</div>
+						</div>
+						<div>
+							<strong>Configured gateways</strong>
+							<div>${status.gateways.length}</div>
+						</div>
+						<div>
+							<strong>Gateways with credentials</strong>
+							<div>${status.configuredCredentialsCount}</div>
+						</div>
+						<div>
+							<strong>Scan CIDRs</strong>
+							<div>
+								<code
+									>${input.config.teslaGatewayScanCidrs.join(', ') ||
+									'auto-derived'}</code
+								>
+							</div>
+						</div>
+					</div>
+				</section>
+				${input.scanMessage
+					? renderBanner({ tone: 'success', message: input.scanMessage })
+					: ''}
+				${input.scanError
+					? renderBanner({ tone: 'error', message: input.scanError })
+					: ''}
+				<section class="card">
+					<h2>Configured gateways</h2>
+					${renderGatewayList(status.gateways)}
+				</section>
+				${input.includeSetupForm
+					? html`<section class="card">
+								<h2>Save customer credentials</h2>
+								<p class="muted">
+									Tesla&apos;s local API
+									<code>POST /api/login/Basic</code>
+									accepts a
+									<code>customer</code>
+									role login. The
+									<code>email</code>
+									field is a free-form audit label only — Tesla does not
+									validate it against tesla.com. The default password is printed
+									on the gateway sticker (BGW2 password). If the installer
+									customised it, contact Tesla Energy Customer Support.
+								</p>
+								<form method="POST">
+									<input type="hidden" name="action" value="save-credentials" />
+									<label>
+										Gateway ID
+										<select name="gatewayId" required>
+											${status.gateways.map(
+												(gateway) =>
+													html`<option value="${gateway.gatewayId}">
+														${gateway.label ?? gateway.gatewayId}
+														(${gateway.host})
+													</option>`,
+											)}
+										</select>
+									</label>
+									<label>
+										Customer email label (optional)
+										<input
+											type="text"
+											name="customerEmailLabel"
+											placeholder="kody@local"
+										/>
+									</label>
+									<label>
+										Password
+										<input
+											type="password"
+											name="password"
+											autocomplete="off"
+											required
+										/>
+									</label>
+									<button type="submit">Save credentials</button>
+								</form>
+							</section>
+							<section class="card">
+								<h2>Set label</h2>
+								<form method="POST">
+									<input type="hidden" name="action" value="set-label" />
+									<label>
+										Gateway ID
+										<select name="gatewayId" required>
+											${status.gateways.map(
+												(gateway) =>
+													html`<option value="${gateway.gatewayId}">
+														${gateway.gatewayId}
+													</option>`,
+											)}
+										</select>
+									</label>
+									<label>
+										Label
+										<input type="text" name="label" placeholder="Home 1" />
+									</label>
+									<button type="submit">Set label</button>
+								</form>
+							</section>`
+					: ''}
+				${renderTeslaGatewayDiscoveryDiagnostics(status.diagnostics)}`,
+		}),
+	)
+}
+
+function buildHandler(input: {
+	state: HomeConnectorState
+	config: HomeConnectorConfig
+	teslaGateway: ReturnType<typeof createTeslaGatewayAdapter>
+	title: string
+	route: 'status' | 'setup'
+	includeSetupForm: boolean
+}) {
+	return {
+		middleware: [],
+		async action({ request }: { request: Request }) {
+			if (request.method === 'POST') {
+				const formData = await readPostedFormData(request, 'scan')
+				const action =
+					typeof formData.get('action') === 'string'
+						? String(formData.get('action'))
+						: 'scan'
+				try {
+					const result = await handleTeslaGatewayMutation({
+						action,
+						formData,
+						teslaGateway: input.teslaGateway,
+					})
+					return renderTeslaGatewayPage({
+						state: input.state,
+						config: input.config,
+						teslaGateway: input.teslaGateway,
+						title: input.title,
+						includeSetupForm: input.includeSetupForm,
+						scanMessage: result.message,
+					})
+				} catch (error) {
+					captureHomeConnectorException(error, {
+						tags: {
+							route: `/tesla-gateway/${input.route}`,
+							action,
+						},
+						contexts: {
+							teslaGateway: {
+								scanCidrs: input.config.teslaGatewayScanCidrs,
+								connectorId: input.state.connection.connectorId,
+							},
+						},
+					})
+					return renderTeslaGatewayPage({
+						state: input.state,
+						config: input.config,
+						teslaGateway: input.teslaGateway,
+						title: input.title,
+						includeSetupForm: input.includeSetupForm,
+						scanError: error instanceof Error ? error.message : String(error),
+					})
+				}
+			}
+			return renderTeslaGatewayPage({
+				state: input.state,
+				config: input.config,
+				teslaGateway: input.teslaGateway,
+				title: input.title,
+				includeSetupForm: input.includeSetupForm,
+			})
+		},
+	}
+}
+
+export function createTeslaGatewayStatusHandler(
+	state: HomeConnectorState,
+	config: HomeConnectorConfig,
+	teslaGateway: ReturnType<typeof createTeslaGatewayAdapter>,
+) {
+	return buildHandler({
+		state,
+		config,
+		teslaGateway,
+		title: 'status',
+		route: 'status',
+		includeSetupForm: false,
+	}) satisfies BuildAction<
+		typeof routes.teslaGatewayStatus.method,
+		typeof routes.teslaGatewayStatus.pattern
+	>
+}
+
+export function createTeslaGatewaySetupHandler(
+	state: HomeConnectorState,
+	config: HomeConnectorConfig,
+	teslaGateway: ReturnType<typeof createTeslaGatewayAdapter>,
+) {
+	return buildHandler({
+		state,
+		config,
+		teslaGateway,
+		title: 'setup',
+		route: 'setup',
+		includeSetupForm: true,
+	}) satisfies BuildAction<
+		typeof routes.teslaGatewaySetup.method,
+		typeof routes.teslaGatewaySetup.pattern
+	>
+}

--- a/packages/home-connector/app/tesla-gateway-handlers.ts
+++ b/packages/home-connector/app/tesla-gateway-handlers.ts
@@ -5,6 +5,7 @@ import { type HomeConnectorConfig } from '../src/config.ts'
 import { type createTeslaGatewayAdapter } from '../src/adapters/tesla-gateway/index.ts'
 import {
 	type TeslaGatewayDiscoveryDiagnostics,
+	type TeslaGatewayLiveSnapshot,
 	type TeslaGatewayPublicRecord,
 } from '../src/adapters/tesla-gateway/types.ts'
 import { type HomeConnectorState } from '../src/state.ts'
@@ -43,6 +44,32 @@ async function readPostedFormData(request: Request, fallbackAction: string) {
 	return formData
 }
 
+function validateSameOriginPost(request: Request) {
+	const requestOrigin = new URL(request.url).origin
+	const origin = request.headers.get('origin')
+	if (origin) {
+		if (origin === requestOrigin) return
+		throw new Response('Forbidden', { status: 403 })
+	}
+	const referer = request.headers.get('referer')
+	if (referer && new URL(referer).origin === requestOrigin) return
+	throw new Response('Forbidden', { status: 403 })
+}
+
+function summarizeLiveSnapshot(snapshot: TeslaGatewayLiveSnapshot) {
+	return {
+		gateway: snapshot.gateway,
+		status: snapshot.status,
+		systemStatus: snapshot.systemStatus,
+		gridStatus: snapshot.gridStatus,
+		soe: snapshot.soe,
+		meters: snapshot.meters,
+		operation: snapshot.operation,
+		siteInfo: snapshot.siteInfo,
+		fetchErrors: snapshot.fetchErrors,
+	}
+}
+
 async function handleTeslaGatewayMutation(input: {
 	action: string
 	formData: FormData
@@ -54,6 +81,7 @@ async function handleTeslaGatewayMutation(input: {
 		const gateways = await teslaGateway.scan()
 		return {
 			message: `Scan complete. ${gateways.length} gateway(s) known.`,
+			details: null,
 		}
 	}
 
@@ -62,6 +90,7 @@ async function handleTeslaGatewayMutation(input: {
 		const gateway = await teslaGateway.authenticate(gatewayId)
 		return {
 			message: `Authenticated against ${gateway.host} (${gateway.gatewayId}).`,
+			details: null,
 		}
 	}
 
@@ -74,6 +103,7 @@ async function handleTeslaGatewayMutation(input: {
 				errorCount === 0
 					? `Pulled live snapshot for ${snapshot.gateway.gatewayId}.`
 					: `Pulled snapshot for ${snapshot.gateway.gatewayId} with ${errorCount} per-endpoint error(s).`,
+			details: summarizeLiveSnapshot(snapshot),
 		}
 	}
 
@@ -85,6 +115,7 @@ async function handleTeslaGatewayMutation(input: {
 				info.exportLimitKw === null
 					? `Could not determine an export limit for ${info.gatewayId}.`
 					: `${info.gatewayId} export limit ≈ ${info.exportLimitKw} kW (source: ${info.source}).`,
+			details: null,
 		}
 	}
 
@@ -101,6 +132,7 @@ async function handleTeslaGatewayMutation(input: {
 		})
 		return {
 			message: `Saved credentials for ${gateway.host} (${gateway.gatewayId}).`,
+			details: null,
 		}
 	}
 
@@ -116,6 +148,7 @@ async function handleTeslaGatewayMutation(input: {
 			message: label
 				? `Set label for ${gatewayId} to "${label}".`
 				: `Cleared label for ${gatewayId}.`,
+			details: null,
 		}
 	}
 
@@ -256,6 +289,7 @@ function renderTeslaGatewayPage(input: {
 	includeSetupForm?: boolean
 	scanMessage?: string | null
 	scanError?: string | null
+	resultDetails?: unknown
 }) {
 	const status = input.teslaGateway.getStatus()
 	return render(
@@ -311,6 +345,12 @@ function renderTeslaGatewayPage(input: {
 					: ''}
 				${input.scanError
 					? renderBanner({ tone: 'error', message: input.scanError })
+					: ''}
+				${input.resultDetails
+					? html`<section class="card">
+							<h2>Action result</h2>
+							${renderCodeBlock(formatJson(input.resultDetails))}
+						</section>`
 					: ''}
 				<section class="card">
 					<h2>Configured gateways</h2>
@@ -405,12 +445,13 @@ function buildHandler(input: {
 		middleware: [],
 		async handler({ request }: { request: Request }) {
 			if (request.method === 'POST') {
-				const formData = await readPostedFormData(request, 'scan')
-				const action =
-					typeof formData.get('action') === 'string'
-						? String(formData.get('action'))
-						: 'scan'
 				try {
+					validateSameOriginPost(request)
+					const formData = await readPostedFormData(request, 'scan')
+					const action =
+						typeof formData.get('action') === 'string'
+							? String(formData.get('action'))
+							: 'scan'
 					const result = await handleTeslaGatewayMutation({
 						action,
 						formData,
@@ -423,12 +464,13 @@ function buildHandler(input: {
 						title: input.title,
 						includeSetupForm: input.includeSetupForm,
 						scanMessage: result.message,
+						resultDetails: result.details,
 					})
 				} catch (error) {
+					if (error instanceof Response) return error
 					captureHomeConnectorException(error, {
 						tags: {
 							route: `/tesla-gateway/${input.route}`,
-							action,
 						},
 						contexts: {
 							teslaGateway: {

--- a/packages/home-connector/app/tesla-gateway-handlers.ts
+++ b/packages/home-connector/app/tesla-gateway-handlers.ts
@@ -403,7 +403,7 @@ function buildHandler(input: {
 }) {
 	return {
 		middleware: [],
-		async action({ request }: { request: Request }) {
+		async handler({ request }: { request: Request }) {
 			if (request.method === 'POST') {
 				const formData = await readPostedFormData(request, 'scan')
 				const action =

--- a/packages/home-connector/mocks/index.ts
+++ b/packages/home-connector/mocks/index.ts
@@ -4,6 +4,7 @@ import { resetMockBondState } from './bond.ts'
 import { resetMockLutronSystem } from '../src/adapters/lutron/mock-driver.ts'
 import { resetMockSonosState } from '../src/adapters/sonos/mock-driver.ts'
 import { resetMockSamsungDevices } from '../src/adapters/samsung-tv/mock-driver.ts'
+import { resetMockTeslaGatewayState } from '../src/adapters/tesla-gateway/mock-driver.ts'
 import { resetMockVenstarState } from './venstar.ts'
 
 resetMockLutronSystem()
@@ -11,6 +12,7 @@ resetMockSonosState()
 resetMockSamsungDevices()
 resetMockBondState()
 resetMockVenstarState()
+resetMockTeslaGatewayState()
 const server = setupServer(...mswHandlers)
 
 server.listen({

--- a/packages/home-connector/mocks/msw-handlers.ts
+++ b/packages/home-connector/mocks/msw-handlers.ts
@@ -5,6 +5,7 @@ import { lutronHandlers } from './lutron.ts'
 import { rokuHandlers } from './roku.ts'
 import { samsungTvHandlers } from './samsung-tv.ts'
 import { sonosHandlers } from './sonos.ts'
+import { teslaGatewayHandlers } from './tesla-gateway.ts'
 import { venstarHandlers } from './venstar.ts'
 
 const loopbackRequestPattern =
@@ -23,5 +24,6 @@ export const mswHandlers: Array<RequestHandler> = [
 	...rokuHandlers,
 	...sonosHandlers,
 	...samsungTvHandlers,
+	...teslaGatewayHandlers,
 	...venstarHandlers,
 ]

--- a/packages/home-connector/mocks/tesla-gateway.ts
+++ b/packages/home-connector/mocks/tesla-gateway.ts
@@ -1,0 +1,22 @@
+/**
+ * MSW handlers for the Tesla gateway discovery JSON feed used in dev/test.
+ *
+ * The connector itself talks to gateways via raw `node:https`, not `fetch`, so
+ * those calls cannot be MSW-intercepted. Instead, the adapter detects hosts
+ * ending in `.mock.local` and routes calls directly through the mock-driver
+ * fixtures (see `src/adapters/tesla-gateway/mock-driver.ts`). MSW only needs
+ * to handle the JSON discovery feed used by the dev server when
+ * `TESLA_GATEWAY_DISCOVERY_URL` is set.
+ */
+import { http, HttpResponse } from 'msw'
+import { listMockTeslaGatewayDiscoveryEntries } from '../src/adapters/tesla-gateway/mock-driver.ts'
+
+const discoveryPattern = /^http:\/\/tesla-gateway\.mock\.local\/discovery\/?$/
+
+export const teslaGatewayHandlers = [
+	http.get(discoveryPattern, () => {
+		return HttpResponse.json({
+			gateways: listMockTeslaGatewayDiscoveryEntries(),
+		})
+	}),
+]

--- a/packages/home-connector/mocks/test-server.ts
+++ b/packages/home-connector/mocks/test-server.ts
@@ -4,6 +4,7 @@ import { resetMockJellyfishState } from './jellyfish.ts'
 import { resetMockLutronSystem } from '../src/adapters/lutron/mock-driver.ts'
 import { resetMockSonosState } from '../src/adapters/sonos/mock-driver.ts'
 import { resetMockSamsungDevices } from '../src/adapters/samsung-tv/mock-driver.ts'
+import { resetMockTeslaGatewayState } from '../src/adapters/tesla-gateway/mock-driver.ts'
 import { resetMockVenstarState } from './venstar.ts'
 
 let installedServer: ReturnType<typeof setupServer> | null = null
@@ -14,6 +15,7 @@ export function installHomeConnectorMockServer() {
 	resetMockSonosState()
 	resetMockSamsungDevices()
 	resetMockVenstarState()
+	resetMockTeslaGatewayState()
 	if (installedServer) {
 		return installedServer
 	}

--- a/packages/home-connector/server/dev-server.ts
+++ b/packages/home-connector/server/dev-server.ts
@@ -7,6 +7,8 @@ process.env.SAMSUNG_TV_DISCOVERY_URL ??=
 	'http://samsung-tv.mock.local/discovery'
 process.env.BOND_DISCOVERY_URL ??= 'http://bond.mock.local/discovery'
 process.env.VENSTAR_SCAN_CIDRS ??= '192.168.10.40/32,192.168.10.41/32'
+process.env.TESLA_GATEWAY_DISCOVERY_URL ??=
+	'http://tesla-gateway.mock.local/discovery'
 
 await import('../src/sentry-init.ts')
 await import('./index.ts')

--- a/packages/home-connector/server/index.ts
+++ b/packages/home-connector/server/index.ts
@@ -106,6 +106,7 @@ async function main() {
 		connector.bond,
 		connector.jellyfish,
 		connector.venstar,
+		connector.teslaGateway,
 	)
 
 	const server = http.createServer(

--- a/packages/home-connector/src/adapters/tesla-gateway/discovery.node.test.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/discovery.node.test.ts
@@ -2,9 +2,9 @@ import { expect, test } from 'vitest'
 import { __testing } from './discovery.ts'
 
 const {
+	decideLeaderStatus,
 	expandSlash24,
 	isTeslaCert,
-	looksLikeLeaderCert,
 	probeLooksLikeTesla,
 	ouiFromMac,
 	TESLA_LEADER_OUIS,
@@ -52,31 +52,6 @@ test('isTeslaCert recognises Tesla Energy Products O/OU/SAN markers', () => {
 	expect(isTeslaCert(null)).toBe(false)
 })
 
-test('looksLikeLeaderCert keys off the SAN entries used by leaders only', () => {
-	expect(
-		looksLikeLeaderCert({
-			subjectCommonName: 'GTW-1234',
-			subjectOrganization: 'Tesla',
-			subjectOrganizationalUnit: 'Tesla Energy Products',
-			issuerCommonName: 'Tesla Manufacturing CA',
-			issuerOrganization: 'Tesla',
-			subjectAltName: 'DNS:teg, DNS:powerwall, DNS:powerpack',
-			fingerprint256: null,
-		}),
-	).toBe(true)
-	expect(
-		looksLikeLeaderCert({
-			subjectCommonName: 'PWR-9999',
-			subjectOrganization: 'Tesla',
-			subjectOrganizationalUnit: 'Tesla Energy Products',
-			issuerCommonName: 'Tesla Manufacturing CA',
-			issuerOrganization: 'Tesla',
-			subjectAltName: 'DNS:powerpack',
-			fingerprint256: null,
-		}),
-	).toBe(false)
-})
-
 test('probeLooksLikeTesla treats 401 + Bad Credentials body as Tesla', () => {
 	expect(
 		probeLooksLikeTesla({
@@ -114,4 +89,54 @@ test('ouiFromMac extracts the manufacturer OUI', () => {
 test('Tesla OUI sets recognise leader and powerwall MACs', () => {
 	expect(TESLA_LEADER_OUIS.has('90:03:71')).toBe(true)
 	expect(TESLA_POWERWALL_OUIS.has('00:d6:cb')).toBe(true)
+})
+
+test('decideLeaderStatus uses OUI as the authoritative leader signal', () => {
+	// Powerwall OUI -> never a leader, even though the cert SAN looks identical.
+	expect(
+		decideLeaderStatus({
+			certIsTesla: true,
+			macAddress: '00:d6:cb:11:22:33',
+			ouiIsLeader: false,
+			ouiIsPowerwall: true,
+		}),
+	).toBe(false)
+	// BGW2 leader OUI -> leader.
+	expect(
+		decideLeaderStatus({
+			certIsTesla: true,
+			macAddress: '90:03:71:11:22:33',
+			ouiIsLeader: true,
+			ouiIsPowerwall: false,
+		}),
+	).toBe(true)
+	// Cert is Tesla but ARP miss left us with no MAC -> candidate leader.
+	// We accept this so a real BGW2 hidden behind ARP issues still surfaces.
+	expect(
+		decideLeaderStatus({
+			certIsTesla: true,
+			macAddress: null,
+			ouiIsLeader: false,
+			ouiIsPowerwall: false,
+		}),
+	).toBe(true)
+	// Cert is NOT Tesla and no MAC -> not a leader.
+	expect(
+		decideLeaderStatus({
+			certIsTesla: false,
+			macAddress: null,
+			ouiIsLeader: false,
+			ouiIsPowerwall: false,
+		}),
+	).toBe(false)
+	// Has a MAC but it's an unknown OUI -> not a leader (cert SAN alone is
+	// insufficient when we have an OUI signal that doesn't match Tesla).
+	expect(
+		decideLeaderStatus({
+			certIsTesla: true,
+			macAddress: 'aa:bb:cc:11:22:33',
+			ouiIsLeader: false,
+			ouiIsPowerwall: false,
+		}),
+	).toBe(false)
 })

--- a/packages/home-connector/src/adapters/tesla-gateway/discovery.node.test.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/discovery.node.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from 'vitest'
+import { __testing } from './discovery.ts'
+
+const {
+	expandSlash24,
+	isTeslaCert,
+	looksLikeLeaderCert,
+	probeLooksLikeTesla,
+	ouiFromMac,
+	TESLA_LEADER_OUIS,
+	TESLA_POWERWALL_OUIS,
+} = __testing
+
+test('expandSlash24 expands a /24 to 254 host IPs', () => {
+	const ips = expandSlash24('192.168.4.0/24')
+	expect(ips).toHaveLength(254)
+	expect(ips[0]).toBe('192.168.4.1')
+	expect(ips.at(-1)).toBe('192.168.4.254')
+})
+
+test('expandSlash24 accepts /32 single hosts', () => {
+	expect(expandSlash24('10.0.0.5/32')).toEqual(['10.0.0.5'])
+})
+
+test('expandSlash24 returns no IPs for invalid CIDRs', () => {
+	expect(expandSlash24('not-a-cidr')).toEqual([])
+})
+
+test('isTeslaCert recognises Tesla Energy Products O/OU/SAN markers', () => {
+	expect(
+		isTeslaCert({
+			subjectCommonName: 'GTW-1234',
+			subjectOrganization: 'Tesla',
+			subjectOrganizationalUnit: 'Tesla Energy Products',
+			issuerCommonName: 'Tesla Manufacturing CA',
+			issuerOrganization: 'Tesla',
+			subjectAltName: 'DNS:teg, DNS:powerwall',
+			fingerprint256: null,
+		}),
+	).toBe(true)
+	expect(
+		isTeslaCert({
+			subjectCommonName: 'random.example.com',
+			subjectOrganization: 'Other',
+			subjectOrganizationalUnit: 'Other',
+			issuerCommonName: 'Other',
+			issuerOrganization: 'Other',
+			subjectAltName: 'DNS:random.example.com',
+			fingerprint256: null,
+		}),
+	).toBe(false)
+	expect(isTeslaCert(null)).toBe(false)
+})
+
+test('looksLikeLeaderCert keys off the SAN entries used by leaders only', () => {
+	expect(
+		looksLikeLeaderCert({
+			subjectCommonName: 'GTW-1234',
+			subjectOrganization: 'Tesla',
+			subjectOrganizationalUnit: 'Tesla Energy Products',
+			issuerCommonName: 'Tesla Manufacturing CA',
+			issuerOrganization: 'Tesla',
+			subjectAltName: 'DNS:teg, DNS:powerwall, DNS:powerpack',
+			fingerprint256: null,
+		}),
+	).toBe(true)
+	expect(
+		looksLikeLeaderCert({
+			subjectCommonName: 'PWR-9999',
+			subjectOrganization: 'Tesla',
+			subjectOrganizationalUnit: 'Tesla Energy Products',
+			issuerCommonName: 'Tesla Manufacturing CA',
+			issuerOrganization: 'Tesla',
+			subjectAltName: 'DNS:powerpack',
+			fingerprint256: null,
+		}),
+	).toBe(false)
+})
+
+test('probeLooksLikeTesla treats 401 + Bad Credentials body as Tesla', () => {
+	expect(
+		probeLooksLikeTesla({
+			status: 401,
+			bodyPreview: '{"error":"Bad Credentials"}',
+		}),
+	).toBe(true)
+	expect(
+		probeLooksLikeTesla({
+			status: 401,
+			bodyPreview: '',
+		}),
+	).toBe(true)
+	expect(
+		probeLooksLikeTesla({
+			status: 200,
+			bodyPreview: 'ok',
+		}),
+	).toBe(false)
+	expect(
+		probeLooksLikeTesla({
+			status: 401,
+			bodyPreview: 'something completely unrelated',
+		}),
+	).toBe(false)
+})
+
+test('ouiFromMac extracts the manufacturer OUI', () => {
+	expect(ouiFromMac('90:03:71:11:22:33')).toBe('90:03:71')
+	expect(ouiFromMac('00:d6:cb:aa:bb:cc')).toBe('00:d6:cb')
+	expect(ouiFromMac(null)).toBeNull()
+	expect(ouiFromMac('not-a-mac')).toBeNull()
+})
+
+test('Tesla OUI sets recognise leader and powerwall MACs', () => {
+	expect(TESLA_LEADER_OUIS.has('90:03:71')).toBe(true)
+	expect(TESLA_POWERWALL_OUIS.has('00:d6:cb')).toBe(true)
+})

--- a/packages/home-connector/src/adapters/tesla-gateway/discovery.node.test.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/discovery.node.test.ts
@@ -7,6 +7,7 @@ const {
 	isTeslaCert,
 	probeLooksLikeTesla,
 	ouiFromMac,
+	validateJsonGateway,
 	TESLA_LEADER_OUIS,
 	TESLA_POWERWALL_OUIS,
 } = __testing
@@ -139,4 +140,31 @@ test('decideLeaderStatus uses OUI as the authoritative leader signal', () => {
 			ouiIsPowerwall: false,
 		}),
 	).toBe(false)
+})
+
+test('validateJsonGateway rejects malformed discovery feed entries', () => {
+	expect(
+		validateJsonGateway({
+			gatewayId: 'tesla-gateway-home-1',
+			host: '192.168.1.10',
+			port: 443,
+			role: 'leader',
+			lastSeenAt: '2026-05-01T00:00:00.000Z',
+		}),
+	).toMatchObject({
+		gatewayId: 'tesla-gateway-home-1',
+		host: '192.168.1.10',
+		port: 443,
+		role: 'leader',
+	})
+	expect(
+		validateJsonGateway({ gatewayId: 'missing-host', port: 443 }),
+	).toBeNull()
+	expect(
+		validateJsonGateway({
+			gatewayId: 'bad-port',
+			host: '192.168.1.10',
+			port: '443',
+		}),
+	).toBeNull()
 })

--- a/packages/home-connector/src/adapters/tesla-gateway/discovery.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/discovery.ts
@@ -1,0 +1,576 @@
+/**
+ * Discovery for Tesla Backup Gateway 2 / Powerwall+ leader gateways on the
+ * local network.
+ *
+ * Identification combines three signals:
+ *
+ * 1. TCP port 443 reachability for each candidate IP.
+ * 2. The TLS certificate subject. Tesla gateways present a self-signed cert
+ *    where `O=Tesla, OU=Tesla Energy Products` and the SAN list always
+ *    contains `DNS:teg`. The leader gateway also exposes `DNS:powerwall` (and
+ *    on newer firmwares `DNS:powerpack`).
+ * 3. The MAC OUI from the local ARP cache. Backup Gateway 2 leaders use OUI
+ *    `90:03:71`; individual Powerwall units use `00:d6:cb`. We discard the
+ *    Powerwall units so callers only see leaders, since only the leader
+ *    answers `/api/...` calls.
+ *
+ * As a final fallback we hit `POST /api/login/Basic` with a deliberately bad
+ * password. A real Tesla gateway responds with HTTP 401 + a JSON body that
+ * includes the substring `"Bad Credentials"`. Anything else is treated as
+ * "not a Tesla gateway".
+ */
+import { exec } from 'node:child_process'
+import { networkInterfaces } from 'node:os'
+import { promisify } from 'node:util'
+import { connect as tlsConnect } from 'node:tls'
+import { Socket } from 'node:net'
+import { request as httpsRequest, Agent as HttpsAgent } from 'node:https'
+import {
+	derivePrivateAutoscanCidrsFromInterfaces,
+	type HomeConnectorConfig,
+} from '../../config.ts'
+import {
+	setTeslaGatewayDiscoveryDiagnostics,
+	type HomeConnectorState,
+} from '../../state.ts'
+import {
+	type TeslaGatewayCertSummary,
+	type TeslaGatewayDiscoveredGateway,
+	type TeslaGatewayDiscoveryResult,
+	type TeslaGatewayHostProbe,
+} from './types.ts'
+
+const execAsync = promisify(exec)
+
+const DEFAULT_PORT = 443
+const TCP_PROBE_TIMEOUT_MS = 1_000
+const TLS_PROBE_TIMEOUT_MS = 3_000
+const LOGIN_PROBE_TIMEOUT_MS = 4_000
+const SUBNET_MAX_HOSTS = 254
+const TESLA_LEADER_OUIS = new Set(['90:03:71'])
+const TESLA_POWERWALL_OUIS = new Set(['00:d6:cb'])
+
+const insecureAgent = new HttpsAgent({
+	rejectUnauthorized: false,
+	keepAlive: false,
+})
+
+function expandSlash24(cidr: string): Array<string> {
+	const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.0\/24$/.exec(cidr.trim())
+	if (!match) {
+		const single = /^(\d{1,3}(?:\.\d{1,3}){3})\/32$/.exec(cidr.trim())
+		if (single) return [single[1] ?? '']
+		return []
+	}
+	const a = Number(match[1])
+	const b = Number(match[2])
+	const c = Number(match[3])
+	const ips: Array<string> = []
+	for (let host = 1; host <= SUBNET_MAX_HOSTS; host++) {
+		ips.push(`${a}.${b}.${c}.${host}`)
+	}
+	return ips
+}
+
+function tcpProbe(host: string, port: number, timeoutMs: number) {
+	return new Promise<boolean>((resolve) => {
+		const socket = new Socket()
+		const finish = (open: boolean) => {
+			socket.destroy()
+			resolve(open)
+		}
+		socket.setTimeout(timeoutMs)
+		socket.once('connect', () => finish(true))
+		socket.once('timeout', () => finish(false))
+		socket.once('error', () => finish(false))
+		socket.connect(port, host)
+	})
+}
+
+function summarizeCert(input: {
+	subject?: { CN?: string; O?: string; OU?: string }
+	issuer?: { CN?: string; O?: string }
+	subjectaltname?: string
+	fingerprint256?: string
+}): TeslaGatewayCertSummary {
+	return {
+		subjectCommonName: input.subject?.CN ?? null,
+		subjectOrganization: input.subject?.O ?? null,
+		subjectOrganizationalUnit: input.subject?.OU ?? null,
+		issuerCommonName: input.issuer?.CN ?? null,
+		issuerOrganization: input.issuer?.O ?? null,
+		subjectAltName: input.subjectaltname ?? null,
+		fingerprint256: input.fingerprint256 ?? null,
+	}
+}
+
+function tlsProbeCert(host: string, port: number, timeoutMs: number) {
+	return new Promise<TeslaGatewayCertSummary | null>((resolve) => {
+		let settled = false
+		const socket = tlsConnect({
+			host,
+			port,
+			rejectUnauthorized: false,
+			servername: host,
+			timeout: timeoutMs,
+		})
+		const finish = (cert: TeslaGatewayCertSummary | null) => {
+			if (settled) return
+			settled = true
+			socket.destroy()
+			resolve(cert)
+		}
+		socket.once('secureConnect', () => {
+			const peerCert = socket.getPeerCertificate(false)
+			if (!peerCert || Object.keys(peerCert).length === 0) {
+				finish(null)
+				return
+			}
+			finish(
+				summarizeCert({
+					subject: peerCert.subject as
+						| { CN?: string; O?: string; OU?: string }
+						| undefined,
+					issuer: peerCert.issuer as { CN?: string; O?: string } | undefined,
+					subjectaltname: peerCert.subjectaltname,
+					fingerprint256: peerCert.fingerprint256,
+				}),
+			)
+		})
+		socket.once('timeout', () => finish(null))
+		socket.once('error', () => finish(null))
+	})
+}
+
+function isTeslaCert(cert: TeslaGatewayCertSummary | null) {
+	if (!cert) return false
+	const o = (cert.subjectOrganization ?? '').toLowerCase()
+	const ou = (cert.subjectOrganizationalUnit ?? '').toLowerCase()
+	const san = (cert.subjectAltName ?? '').toLowerCase()
+	if (o.includes('tesla')) return true
+	if (ou.includes('tesla energy products')) return true
+	return san.includes('dns:teg') || san.includes('dns:powerwall')
+}
+
+function looksLikeLeaderCert(cert: TeslaGatewayCertSummary | null) {
+	if (!cert) return false
+	const san = (cert.subjectAltName ?? '').toLowerCase()
+	return san.includes('dns:powerwall') || san.includes('dns:teg')
+}
+
+async function readArpCache(): Promise<Map<string, string>> {
+	const map = new Map<string, string>()
+	try {
+		const result = await execAsync('arp -an', { timeout: 4_000 })
+		const lines = result.stdout.split('\n')
+		for (const line of lines) {
+			const ipMatch = /\((\d{1,3}(?:\.\d{1,3}){3})\)/.exec(line)
+			const macMatch = /([0-9a-f]{1,2}(?::[0-9a-f]{1,2}){5})/i.exec(line)
+			if (!ipMatch || !macMatch) continue
+			const ip = ipMatch[1] ?? ''
+			const macRaw = macMatch[1] ?? ''
+			const macNormalized = macRaw
+				.toLowerCase()
+				.split(':')
+				.map((segment) => segment.padStart(2, '0'))
+				.join(':')
+			if (ip.length > 0 && macNormalized.length === 17) {
+				map.set(ip, macNormalized)
+			}
+		}
+	} catch {
+		// arp not available (e.g. sandbox, container) -> no MAC enrichment.
+	}
+	return map
+}
+
+function ouiFromMac(mac: string | null) {
+	if (!mac) return null
+	const parts = mac.split(':')
+	if (parts.length < 3) return null
+	return `${parts[0]}:${parts[1]}:${parts[2]}`
+}
+
+function probeLoginEndpoint(host: string, port: number, timeoutMs: number) {
+	return new Promise<{ status: number; bodyPreview: string | null } | null>(
+		(resolve) => {
+			let settled = false
+			const finish = (
+				value: { status: number; bodyPreview: string | null } | null,
+			) => {
+				if (settled) return
+				settled = true
+				resolve(value)
+			}
+			const req = httpsRequest(
+				{
+					host,
+					port,
+					method: 'POST',
+					path: '/api/login/Basic',
+					headers: {
+						'Content-Type': 'application/json',
+						'User-Agent': 'kody-home-connector/tesla-gateway-discovery',
+					},
+					agent: insecureAgent,
+					timeout: timeoutMs,
+				},
+				(res) => {
+					const chunks: Array<Buffer> = []
+					res.on('data', (chunk: Buffer) => chunks.push(chunk))
+					res.on('end', () => {
+						const body = Buffer.concat(chunks).toString('utf8')
+						finish({
+							status: res.statusCode ?? 0,
+							bodyPreview: body.slice(0, 200) || null,
+						})
+					})
+					res.on('error', () => finish(null))
+				},
+			)
+			req.on('timeout', () => {
+				req.destroy()
+				finish(null)
+			})
+			req.on('error', () => finish(null))
+			req.write(
+				JSON.stringify({
+					username: 'customer',
+					email: 'discovery@kody.local',
+					password: '__discovery_probe__',
+				}),
+			)
+			req.end()
+		},
+	)
+}
+
+function probeLooksLikeTesla(probe: {
+	status: number
+	bodyPreview: string | null
+}) {
+	if (probe.status !== 401 && probe.status !== 403) return false
+	const preview = (probe.bodyPreview ?? '').toLowerCase()
+	if (
+		preview.includes('bad credentials') ||
+		preview.includes('login') ||
+		preview.includes('unauthorized')
+	) {
+		return true
+	}
+	// Some firmwares return an empty 401 body; trust 401 + Tesla cert combination
+	// done at a higher level.
+	return probe.bodyPreview === null || probe.bodyPreview === ''
+}
+
+async function probeHost(input: {
+	host: string
+	port: number
+	arpCache: Map<string, string>
+	tcpOpen?: boolean
+}): Promise<TeslaGatewayHostProbe> {
+	const tcpOpen =
+		input.tcpOpen ??
+		(await tcpProbe(input.host, input.port, TCP_PROBE_TIMEOUT_MS))
+	if (!tcpOpen) {
+		return {
+			host: input.host,
+			port: input.port,
+			tcpOpen: false,
+			cert: null,
+			macAddress: input.arpCache.get(input.host) ?? null,
+			macOui: ouiFromMac(input.arpCache.get(input.host) ?? null),
+			identifiedAsTesla: false,
+			identifiedAsLeader: false,
+			loginEndpointResponse: null,
+			error: null,
+		}
+	}
+	const cert = await tlsProbeCert(input.host, input.port, TLS_PROBE_TIMEOUT_MS)
+	const macAddress = input.arpCache.get(input.host) ?? null
+	const macOui = ouiFromMac(macAddress)
+	const certIsTesla = isTeslaCert(cert)
+	const certIsLeader = looksLikeLeaderCert(cert)
+	const ouiIsLeader = macOui !== null && TESLA_LEADER_OUIS.has(macOui)
+	const ouiIsPowerwall = macOui !== null && TESLA_POWERWALL_OUIS.has(macOui)
+	let identifiedAsTesla = certIsTesla || ouiIsLeader || ouiIsPowerwall
+	let identifiedAsLeader = certIsLeader || ouiIsLeader
+	let loginEndpointResponse: TeslaGatewayHostProbe['loginEndpointResponse'] =
+		null
+	if (certIsTesla && !ouiIsPowerwall) {
+		loginEndpointResponse = await probeLoginEndpoint(
+			input.host,
+			input.port,
+			LOGIN_PROBE_TIMEOUT_MS,
+		)
+		if (loginEndpointResponse && probeLooksLikeTesla(loginEndpointResponse)) {
+			identifiedAsTesla = true
+			identifiedAsLeader = true
+		}
+	}
+	if (ouiIsPowerwall) {
+		// Powerwall units sometimes serve the same cert; never treat them as
+		// leaders even if cert looks identical.
+		identifiedAsLeader = false
+	}
+	return {
+		host: input.host,
+		port: input.port,
+		tcpOpen: true,
+		cert,
+		macAddress,
+		macOui,
+		identifiedAsTesla,
+		identifiedAsLeader,
+		loginEndpointResponse,
+		error: null,
+	}
+}
+
+function buildGatewayId(input: { host: string; macAddress: string | null }) {
+	const base = input.macAddress ?? input.host
+	return `tesla-gateway-${base.replaceAll(/[^a-zA-Z0-9]+/g, '-').toLowerCase()}`
+}
+
+function probeToGateway(
+	probe: TeslaGatewayHostProbe,
+): TeslaGatewayDiscoveredGateway | null {
+	if (!probe.identifiedAsTesla || !probe.identifiedAsLeader) return null
+	return {
+		gatewayId: buildGatewayId({
+			host: probe.host,
+			macAddress: probe.macAddress,
+		}),
+		host: probe.host,
+		port: probe.port,
+		din: null,
+		serialNumber: null,
+		macAddress: probe.macAddress,
+		macOui: probe.macOui,
+		cert: probe.cert,
+		firmwareVersion: null,
+		role: 'leader',
+		lastSeenAt: new Date().toISOString(),
+	}
+}
+
+function dedupeProbeTargets(targets: Array<string>) {
+	const seen = new Set<string>()
+	const result: Array<string> = []
+	for (const target of targets) {
+		const trimmed = target.trim()
+		if (!trimmed || seen.has(trimmed)) continue
+		seen.add(trimmed)
+		result.push(trimmed)
+	}
+	return result
+}
+
+function mergeArpMaps(maps: Array<Map<string, string>>) {
+	const merged = new Map<string, string>()
+	for (const map of maps) {
+		for (const [ip, mac] of map) merged.set(ip, mac)
+	}
+	return merged
+}
+
+async function scanSubnets(input: {
+	cidrs: Array<string>
+	port: number
+}): Promise<{
+	probes: Array<TeslaGatewayHostProbe>
+	subnetSummary: {
+		cidrs: Array<string>
+		hostsProbed: number
+		teslaMatches: number
+		leaderMatches: number
+	}
+}> {
+	const targets = dedupeProbeTargets(
+		input.cidrs.flatMap((cidr) => expandSlash24(cidr)),
+	)
+	// Phase 1: snapshot the ARP cache up front (may already be partially warm).
+	const arpBefore = await readArpCache()
+
+	// Phase 2: TCP-probe every target in parallel. Successful TCP connects
+	// trigger ARP resolution at the kernel level, so the second ARP read
+	// below will see MAC addresses for every reachable host.
+	const tcpResults = new Map<string, boolean>()
+	let cursor = 0
+	const tcpConcurrency = Math.min(64, Math.max(8, targets.length))
+	async function tcpWorker() {
+		while (cursor < targets.length) {
+			const index = cursor++
+			const host = targets[index]
+			if (!host) continue
+			const open = await tcpProbe(host, input.port, TCP_PROBE_TIMEOUT_MS)
+			tcpResults.set(host, open)
+		}
+	}
+	await Promise.all(Array.from({ length: tcpConcurrency }, () => tcpWorker()))
+
+	// Phase 3: re-read ARP cache now that TCP probes have populated it. Merge
+	// with the pre-snapshot in case some entries were already warm but expired
+	// during the scan.
+	const arpAfter = await readArpCache()
+	const arpCache = mergeArpMaps([arpBefore, arpAfter])
+
+	// Phase 4: detailed probe (TLS cert + optional login endpoint) only for
+	// hosts where TCP was open. Lower concurrency keeps login-endpoint probes
+	// from looking like a flood to per-IP rate limiters.
+	const openHosts = targets.filter((host) => tcpResults.get(host) === true)
+	const probes: Array<TeslaGatewayHostProbe> = []
+	let detailCursor = 0
+	const detailConcurrency = Math.min(8, Math.max(2, openHosts.length))
+	async function detailWorker() {
+		while (detailCursor < openHosts.length) {
+			const index = detailCursor++
+			const host = openHosts[index]
+			if (!host) continue
+			try {
+				const probe = await probeHost({
+					host,
+					port: input.port,
+					arpCache,
+					tcpOpen: true,
+				})
+				probes.push(probe)
+			} catch (error) {
+				probes.push({
+					host,
+					port: input.port,
+					tcpOpen: true,
+					cert: null,
+					macAddress: arpCache.get(host) ?? null,
+					macOui: ouiFromMac(arpCache.get(host) ?? null),
+					identifiedAsTesla: false,
+					identifiedAsLeader: false,
+					loginEndpointResponse: null,
+					error: error instanceof Error ? error.message : String(error),
+				})
+			}
+		}
+	}
+	await Promise.all(
+		Array.from({ length: detailConcurrency }, () => detailWorker()),
+	)
+
+	const teslaMatches = probes.filter((p) => p.identifiedAsTesla).length
+	const leaderMatches = probes.filter((p) => p.identifiedAsLeader).length
+	return {
+		probes,
+		subnetSummary: {
+			cidrs: input.cidrs,
+			hostsProbed: targets.length,
+			teslaMatches,
+			leaderMatches,
+		},
+	}
+}
+
+function resolveScanCidrs(config: HomeConnectorConfig): Array<string> {
+	if (config.teslaGatewayScanCidrs.length > 0) {
+		return config.teslaGatewayScanCidrs
+	}
+	return derivePrivateAutoscanCidrsFromInterfaces(networkInterfaces())
+}
+
+async function discoverFromJson(
+	discoveryUrl: string,
+): Promise<TeslaGatewayDiscoveryResult> {
+	const errors: Array<string> = []
+	let payload: Record<string, unknown> | null = null
+	try {
+		const response = await fetch(discoveryUrl)
+		if (!response.ok) {
+			errors.push(
+				`Tesla discovery feed returned HTTP ${response.status} for ${discoveryUrl}`,
+			)
+		} else {
+			payload = (await response.json()) as Record<string, unknown>
+		}
+	} catch (error) {
+		errors.push(error instanceof Error ? error.message : String(error))
+	}
+	const gateways = Array.isArray(payload?.['gateways'])
+		? (payload['gateways'] as Array<TeslaGatewayDiscoveredGateway>)
+		: []
+	return {
+		gateways,
+		diagnostics: {
+			protocol: 'json',
+			discoveryUrl,
+			scannedAt: new Date().toISOString(),
+			jsonResponse: payload,
+			hostProbes: [],
+			subnetProbe: null,
+			errors,
+		},
+	}
+}
+
+async function discoverFromSubnet(
+	config: HomeConnectorConfig,
+): Promise<TeslaGatewayDiscoveryResult> {
+	const cidrs = resolveScanCidrs(config)
+	const port = DEFAULT_PORT
+	const errors: Array<string> = []
+	const { probes, subnetSummary } = await scanSubnets({ cidrs, port })
+	const gateways = probes
+		.map((probe) => probeToGateway(probe))
+		.filter(
+			(gateway): gateway is TeslaGatewayDiscoveredGateway => gateway !== null,
+		)
+
+	return {
+		gateways,
+		diagnostics: {
+			protocol: 'subnet',
+			discoveryUrl: cidrs.length > 0 ? cidrs.join(', ') : 'no-scan-cidrs',
+			scannedAt: new Date().toISOString(),
+			jsonResponse: null,
+			hostProbes: probes,
+			subnetProbe: subnetSummary,
+			errors,
+		},
+	}
+}
+
+export async function scanTeslaGateways(
+	state: HomeConnectorState,
+	config: HomeConnectorConfig,
+): Promise<TeslaGatewayDiscoveryResult> {
+	const url = config.teslaGatewayDiscoveryUrl
+	const result =
+		url && url.startsWith('http')
+			? await discoverFromJson(url)
+			: await discoverFromSubnet(config)
+	setTeslaGatewayDiscoveryDiagnostics(state, result.diagnostics)
+	return result
+}
+
+/**
+ * Public helper: identify whether a single host looks like a Tesla leader.
+ * Useful for ad-hoc verification from the setup UI.
+ */
+export async function probeTeslaGatewayHost(input: {
+	host: string
+	port?: number
+}): Promise<TeslaGatewayHostProbe> {
+	const arpCache = await readArpCache()
+	return await probeHost({
+		host: input.host,
+		port: input.port ?? DEFAULT_PORT,
+		arpCache,
+	})
+}
+
+export const __testing = {
+	expandSlash24,
+	isTeslaCert,
+	looksLikeLeaderCert,
+	probeLooksLikeTesla,
+	ouiFromMac,
+	TESLA_LEADER_OUIS,
+	TESLA_POWERWALL_OUIS,
+}

--- a/packages/home-connector/src/adapters/tesla-gateway/discovery.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/discovery.ts
@@ -5,14 +5,15 @@
  * Identification combines three signals:
  *
  * 1. TCP port 443 reachability for each candidate IP.
- * 2. The TLS certificate subject. Tesla gateways present a self-signed cert
- *    where `O=Tesla, OU=Tesla Energy Products` and the SAN list always
- *    contains `DNS:teg`. The leader gateway also exposes `DNS:powerwall` (and
- *    on newer firmwares `DNS:powerpack`).
+ * 2. The TLS certificate. Tesla Energy devices present a self-signed cert
+ *    where `O=Tesla, OU=Tesla Energy Products` and the SAN list contains
+ *    `DNS:teg, DNS:powerwall` (and on newer firmwares `DNS:powerpack`).
+ *    The cert alone identifies the device as Tesla but cannot distinguish a
+ *    BGW2 leader from a Powerwall unit because both expose identical SANs.
  * 3. The MAC OUI from the local ARP cache. Backup Gateway 2 leaders use OUI
- *    `90:03:71`; individual Powerwall units use `00:d6:cb`. We discard the
- *    Powerwall units so callers only see leaders, since only the leader
- *    answers `/api/...` calls.
+ *    `90:03:71`; individual Powerwall units use `00:d6:cb`. The OUI is the
+ *    only reliable way to demote Powerwalls so callers only see leaders,
+ *    since only the leader answers `/api/...` calls.
  *
  * As a final fallback we hit `POST /api/login/Basic` with a deliberately bad
  * password. A real Tesla gateway responds with HTTP 401 + a JSON body that
@@ -152,12 +153,6 @@ function isTeslaCert(cert: TeslaGatewayCertSummary | null) {
 	return san.includes('dns:teg') || san.includes('dns:powerwall')
 }
 
-function looksLikeLeaderCert(cert: TeslaGatewayCertSummary | null) {
-	if (!cert) return false
-	const san = (cert.subjectAltName ?? '').toLowerCase()
-	return san.includes('dns:powerwall') || san.includes('dns:teg')
-}
-
 async function readArpCache(): Promise<Map<string, string>> {
 	const map = new Map<string, string>()
 	try {
@@ -245,6 +240,35 @@ function probeLoginEndpoint(host: string, port: number, timeoutMs: number) {
 	)
 }
 
+/**
+ * Decide whether an identified Tesla host should be treated as a leader.
+ *
+ * Both BGW2 leaders and Powerwall units present identical SANs
+ * (`DNS:teg, DNS:powerwall, DNS:powerpack`), so cert content alone cannot
+ * distinguish them. The MAC OUI is the only definitive signal.
+ *
+ * Rules in priority order:
+ *
+ *   1. OUI matches a known BGW2 leader OUI -> leader.
+ *   2. OUI matches a Powerwall OUI -> not a leader.
+ *   3. ARP gave us no MAC at all but the cert is Tesla -> treat as a
+ *      candidate leader. We prefer surfacing a candidate over silently
+ *      dropping a real leader hidden behind ARP issues. A subsequent
+ *      login-endpoint probe may further refine.
+ *   4. Otherwise -> not a leader.
+ */
+function decideLeaderStatus(input: {
+	certIsTesla: boolean
+	macAddress: string | null
+	ouiIsLeader: boolean
+	ouiIsPowerwall: boolean
+}): boolean {
+	if (input.ouiIsLeader) return true
+	if (input.ouiIsPowerwall) return false
+	if (input.macAddress === null && input.certIsTesla) return true
+	return false
+}
+
 function probeLooksLikeTesla(probe: {
 	status: number
 	bodyPreview: string | null
@@ -290,11 +314,15 @@ async function probeHost(input: {
 	const macAddress = input.arpCache.get(input.host) ?? null
 	const macOui = ouiFromMac(macAddress)
 	const certIsTesla = isTeslaCert(cert)
-	const certIsLeader = looksLikeLeaderCert(cert)
 	const ouiIsLeader = macOui !== null && TESLA_LEADER_OUIS.has(macOui)
 	const ouiIsPowerwall = macOui !== null && TESLA_POWERWALL_OUIS.has(macOui)
 	let identifiedAsTesla = certIsTesla || ouiIsLeader || ouiIsPowerwall
-	let identifiedAsLeader = certIsLeader || ouiIsLeader
+	let identifiedAsLeader = decideLeaderStatus({
+		certIsTesla,
+		macAddress,
+		ouiIsLeader,
+		ouiIsPowerwall,
+	})
 	let loginEndpointResponse: TeslaGatewayHostProbe['loginEndpointResponse'] =
 		null
 	if (certIsTesla && !ouiIsPowerwall) {
@@ -305,13 +333,14 @@ async function probeHost(input: {
 		)
 		if (loginEndpointResponse && probeLooksLikeTesla(loginEndpointResponse)) {
 			identifiedAsTesla = true
-			identifiedAsLeader = true
+			// Note: a 401 / "Bad Credentials" response does not by itself prove
+			// leader status (Powerwall units sometimes respond identically),
+			// so we only upgrade to leader when the OUI confirms it OR we have
+			// no OUI signal at all to contradict the cert.
+			if (ouiIsLeader || (macAddress === null && !ouiIsPowerwall)) {
+				identifiedAsLeader = true
+			}
 		}
-	}
-	if (ouiIsPowerwall) {
-		// Powerwall units sometimes serve the same cert; never treat them as
-		// leaders even if cert looks identical.
-		identifiedAsLeader = false
 	}
 	return {
 		host: input.host,
@@ -549,26 +578,10 @@ export async function scanTeslaGateways(
 	return result
 }
 
-/**
- * Public helper: identify whether a single host looks like a Tesla leader.
- * Useful for ad-hoc verification from the setup UI.
- */
-export async function probeTeslaGatewayHost(input: {
-	host: string
-	port?: number
-}): Promise<TeslaGatewayHostProbe> {
-	const arpCache = await readArpCache()
-	return await probeHost({
-		host: input.host,
-		port: input.port ?? DEFAULT_PORT,
-		arpCache,
-	})
-}
-
 export const __testing = {
+	decideLeaderStatus,
 	expandSlash24,
 	isTeslaCert,
-	looksLikeLeaderCert,
 	probeLooksLikeTesla,
 	ouiFromMac,
 	TESLA_LEADER_OUIS,

--- a/packages/home-connector/src/adapters/tesla-gateway/discovery.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/discovery.ts
@@ -47,6 +47,7 @@ const DEFAULT_PORT = 443
 const TCP_PROBE_TIMEOUT_MS = 1_000
 const TLS_PROBE_TIMEOUT_MS = 3_000
 const LOGIN_PROBE_TIMEOUT_MS = 4_000
+const JSON_DISCOVERY_TIMEOUT_MS = 5_000
 const SUBNET_MAX_HOSTS = 254
 const TESLA_LEADER_OUIS = new Set(['90:03:71'])
 const TESLA_POWERWALL_OUIS = new Set(['00:d6:cb'])
@@ -357,7 +358,7 @@ async function probeHost(input: {
 }
 
 function buildGatewayId(input: { host: string; macAddress: string | null }) {
-	const base = input.macAddress ?? input.host
+	const base = input.host
 	return `tesla-gateway-${base.replaceAll(/[^a-zA-Z0-9]+/g, '-').toLowerCase()}`
 }
 
@@ -504,13 +505,75 @@ function resolveScanCidrs(config: HomeConnectorConfig): Array<string> {
 	return derivePrivateAutoscanCidrsFromInterfaces(networkInterfaces())
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function nullableString(value: unknown) {
+	return typeof value === 'string' ? value : null
+}
+
+function validateJsonGateway(
+	value: unknown,
+): TeslaGatewayDiscoveredGateway | null {
+	if (!isRecord(value)) return null
+	if (
+		typeof value.gatewayId !== 'string' ||
+		value.gatewayId.trim().length === 0 ||
+		typeof value.host !== 'string' ||
+		value.host.trim().length === 0 ||
+		typeof value.port !== 'number' ||
+		!Number.isInteger(value.port)
+	) {
+		return null
+	}
+	const role =
+		value.role === 'leader' || value.role === 'follower'
+			? value.role
+			: 'unknown'
+	const cert = isRecord(value.cert)
+		? {
+				subjectCommonName: nullableString(value.cert.subjectCommonName),
+				subjectOrganization: nullableString(value.cert.subjectOrganization),
+				subjectOrganizationalUnit: nullableString(
+					value.cert.subjectOrganizationalUnit,
+				),
+				issuerCommonName: nullableString(value.cert.issuerCommonName),
+				issuerOrganization: nullableString(value.cert.issuerOrganization),
+				subjectAltName: nullableString(value.cert.subjectAltName),
+				fingerprint256: nullableString(value.cert.fingerprint256),
+			}
+		: null
+	return {
+		gatewayId: value.gatewayId.trim(),
+		host: value.host.trim(),
+		port: value.port,
+		din: nullableString(value.din),
+		serialNumber: nullableString(value.serialNumber),
+		macAddress: nullableString(value.macAddress),
+		macOui: nullableString(value.macOui),
+		cert,
+		firmwareVersion: nullableString(value.firmwareVersion),
+		role,
+		lastSeenAt:
+			typeof value.lastSeenAt === 'string'
+				? value.lastSeenAt
+				: new Date().toISOString(),
+	}
+}
+
 async function discoverFromJson(
 	discoveryUrl: string,
 ): Promise<TeslaGatewayDiscoveryResult> {
 	const errors: Array<string> = []
 	let payload: Record<string, unknown> | null = null
+	let timeout: ReturnType<typeof setTimeout> | null = null
 	try {
-		const response = await fetch(discoveryUrl)
+		const controller = new AbortController()
+		timeout = setTimeout(() => {
+			controller.abort()
+		}, JSON_DISCOVERY_TIMEOUT_MS)
+		const response = await fetch(discoveryUrl, { signal: controller.signal })
 		if (!response.ok) {
 			errors.push(
 				`Tesla discovery feed returned HTTP ${response.status} for ${discoveryUrl}`,
@@ -519,11 +582,28 @@ async function discoverFromJson(
 			payload = (await response.json()) as Record<string, unknown>
 		}
 	} catch (error) {
-		errors.push(error instanceof Error ? error.message : String(error))
+		errors.push(
+			error instanceof Error && error.name === 'AbortError'
+				? `Tesla discovery feed timed out after ${JSON_DISCOVERY_TIMEOUT_MS}ms for ${discoveryUrl}`
+				: error instanceof Error
+					? error.message
+					: String(error),
+		)
+	} finally {
+		if (timeout) clearTimeout(timeout)
 	}
-	const gateways = Array.isArray(payload?.['gateways'])
-		? (payload['gateways'] as Array<TeslaGatewayDiscoveredGateway>)
+	const rawGateways = Array.isArray(payload?.['gateways'])
+		? payload['gateways']
 		: []
+	const gateways: Array<TeslaGatewayDiscoveredGateway> = []
+	for (const [index, rawGateway] of rawGateways.entries()) {
+		const gateway = validateJsonGateway(rawGateway)
+		if (gateway) {
+			gateways.push(gateway)
+		} else {
+			errors.push(`Tesla discovery feed gateway[${index}] is invalid.`)
+		}
+	}
 	return {
 		gateways,
 		diagnostics: {
@@ -582,6 +662,7 @@ export const __testing = {
 	decideLeaderStatus,
 	expandSlash24,
 	isTeslaCert,
+	validateJsonGateway,
 	probeLooksLikeTesla,
 	ouiFromMac,
 	TESLA_LEADER_OUIS,

--- a/packages/home-connector/src/adapters/tesla-gateway/gateway-client.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/gateway-client.ts
@@ -1,0 +1,498 @@
+/**
+ * HTTPS client for the Tesla Backup Gateway 2 / Powerwall+ leader local API.
+ *
+ * The gateway serves a self-signed TLS cert, so requests use a custom https
+ * `Agent` with `rejectUnauthorized: false` rather than relying on the system
+ * trust store. Authentication is `POST /api/login/Basic` with role `customer`,
+ * which returns `Set-Cookie: AuthCookie=...; UserRecord=...`. The cookie jar
+ * lasts ~24h and is reused for subsequent reads.
+ *
+ * Tesla rate-limits `/api/login/Basic` aggressively. After a small burst of
+ * failed attempts, the gateway accepts new connections but blackholes login
+ * POSTs (no response, eventual timeout). The client therefore tracks the last
+ * known rate-limit moment per host and short-circuits new login attempts
+ * during the cooldown.
+ */
+import { request as httpsRequest, Agent as HttpsAgent } from 'node:https'
+import {
+	type TeslaGatewayApiStatusResponse,
+	type TeslaGatewayGeneratorsResponse,
+	type TeslaGatewayGridStatusResponse,
+	type TeslaGatewayLoginResponse,
+	type TeslaGatewayMetersAggregatesResponse,
+	type TeslaGatewayNetworksResponse,
+	type TeslaGatewayOperationResponse,
+	type TeslaGatewayPowerwallsResponse,
+	type TeslaGatewaySiteInfoResponse,
+	type TeslaGatewaySoeResponse,
+	type TeslaGatewaySolarPowerwallResponse,
+	type TeslaGatewaySystemStatusResponse,
+	type TeslaGatewaySystemUpdateStatusResponse,
+} from './types.ts'
+
+const DEFAULT_HTTPS_PORT = 443
+const DEFAULT_REQUEST_TIMEOUT_MS = 8_000
+const DEFAULT_LOGIN_TIMEOUT_MS = 10_000
+const RATE_LIMIT_COOLDOWN_MS = 15 * 60 * 1_000
+
+const sharedInsecureAgent = new HttpsAgent({
+	rejectUnauthorized: false,
+	keepAlive: true,
+	keepAliveMsecs: 60_000,
+	maxSockets: 4,
+})
+
+const lastRateLimitedAt = new Map<string, number>()
+
+export type TeslaGatewayCredentials = {
+	emailLabel: string
+	password: string
+}
+
+export type TeslaGatewayClientHost = {
+	host: string
+	port?: number
+}
+
+export type TeslaGatewayHttpResponse<T> = {
+	status: number
+	body: T | null
+	rawText: string
+	headers: Record<string, string>
+}
+
+export class TeslaGatewayHttpError extends Error {
+	readonly status: number
+	readonly body: unknown
+	readonly host: string
+	readonly path: string
+
+	constructor(input: {
+		status: number
+		body: unknown
+		host: string
+		path: string
+		message: string
+	}) {
+		super(input.message)
+		this.name = 'TeslaGatewayHttpError'
+		this.status = input.status
+		this.body = input.body
+		this.host = input.host
+		this.path = input.path
+	}
+}
+
+export class TeslaGatewayRateLimitError extends Error {
+	readonly host: string
+	readonly retryAfterMs: number
+
+	constructor(host: string, retryAfterMs: number) {
+		super(
+			`Tesla gateway "${host}" is in login-rate-limit cooldown for another ${Math.ceil(retryAfterMs / 1_000)}s.`,
+		)
+		this.name = 'TeslaGatewayRateLimitError'
+		this.host = host
+		this.retryAfterMs = retryAfterMs
+	}
+}
+
+function rateLimitRemainingMs(host: string) {
+	const at = lastRateLimitedAt.get(host)
+	if (at === undefined) return 0
+	const elapsed = Date.now() - at
+	if (elapsed >= RATE_LIMIT_COOLDOWN_MS) {
+		lastRateLimitedAt.delete(host)
+		return 0
+	}
+	return RATE_LIMIT_COOLDOWN_MS - elapsed
+}
+
+function markRateLimited(host: string) {
+	lastRateLimitedAt.set(host, Date.now())
+}
+
+/**
+ * Reset rate-limit cooldown bookkeeping. Tests use this to make assertions
+ * deterministic; production code should not need it.
+ */
+export function clearTeslaGatewayRateLimits() {
+	lastRateLimitedAt.clear()
+}
+
+function ensureNotRateLimited(host: string) {
+	const remaining = rateLimitRemainingMs(host)
+	if (remaining > 0) {
+		throw new TeslaGatewayRateLimitError(host, remaining)
+	}
+}
+
+type LowLevelRequestInput = {
+	host: string
+	port: number
+	method: string
+	path: string
+	headers?: Record<string, string>
+	body?: string
+	timeoutMs: number
+}
+
+type LowLevelRequestResult = {
+	status: number
+	headers: Record<string, string>
+	setCookieHeaders: Array<string>
+	rawText: string
+}
+
+function lowercaseHeaderMap(
+	headers: Record<string, string | Array<string> | undefined>,
+) {
+	const map: Record<string, string> = {}
+	for (const [key, value] of Object.entries(headers)) {
+		if (value === undefined) continue
+		if (Array.isArray(value)) {
+			map[key.toLowerCase()] = value.join(', ')
+		} else {
+			map[key.toLowerCase()] = value
+		}
+	}
+	return map
+}
+
+function lowLevelRequest(
+	input: LowLevelRequestInput,
+): Promise<LowLevelRequestResult> {
+	return new Promise((resolve, reject) => {
+		const req = httpsRequest(
+			{
+				host: input.host,
+				port: input.port,
+				method: input.method,
+				path: input.path,
+				headers: input.headers,
+				agent: sharedInsecureAgent,
+				timeout: input.timeoutMs,
+			},
+			(res) => {
+				const chunks: Array<Buffer> = []
+				res.on('data', (chunk: Buffer) => chunks.push(chunk))
+				res.on('end', () => {
+					const body = Buffer.concat(chunks).toString('utf8')
+					const setCookie = res.headers['set-cookie']
+					resolve({
+						status: res.statusCode ?? 0,
+						headers: lowercaseHeaderMap(res.headers),
+						setCookieHeaders: Array.isArray(setCookie) ? setCookie : [],
+						rawText: body,
+					})
+				})
+				res.on('error', (err) => reject(err))
+			},
+		)
+		req.on('timeout', () => {
+			req.destroy(
+				new Error(
+					`Tesla gateway request timed out after ${input.timeoutMs}ms (${input.method} ${input.path}).`,
+				),
+			)
+		})
+		req.on('error', (err) => reject(err))
+		if (input.body !== undefined) req.write(input.body)
+		req.end()
+	})
+}
+
+async function fetchJson<T>(input: {
+	host: string
+	port: number
+	method: string
+	path: string
+	headers?: Record<string, string>
+	body?: string
+	timeoutMs?: number
+}): Promise<TeslaGatewayHttpResponse<T>> {
+	const result = await lowLevelRequest({
+		host: input.host,
+		port: input.port,
+		method: input.method,
+		path: input.path,
+		headers: input.headers ?? {},
+		...(input.body !== undefined ? { body: input.body } : {}),
+		timeoutMs: input.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+	})
+	let parsed: T | null = null
+	if (result.rawText.length > 0) {
+		try {
+			parsed = JSON.parse(result.rawText) as T
+		} catch {
+			parsed = null
+		}
+	}
+	return {
+		status: result.status,
+		body: parsed,
+		rawText: result.rawText,
+		headers: result.headers,
+	}
+}
+
+function pickCookieValues(setCookieHeaders: Array<string>) {
+	return setCookieHeaders
+		.map((header) => header.split(';')[0]?.trim())
+		.filter((value): value is string => Boolean(value))
+}
+
+/**
+ * Authenticate against `POST /api/login/Basic` with role `customer`.
+ *
+ * The `email` field on this endpoint is a free-form audit label, NOT validated
+ * against tesla.com; it gets logged on the gateway and may appear in support
+ * traces. We default it to `kody@local` if the caller doesn't pass one.
+ */
+export async function loginToTeslaGateway(input: {
+	host: string
+	port?: number
+	credentials: TeslaGatewayCredentials
+	timeoutMs?: number
+}): Promise<TeslaGatewayLoginResponse> {
+	ensureNotRateLimited(input.host)
+	const port = input.port ?? DEFAULT_HTTPS_PORT
+	const body = JSON.stringify({
+		username: 'customer',
+		email: input.credentials.emailLabel,
+		password: input.credentials.password,
+		force_sm_off: false,
+	})
+	let response: TeslaGatewayHttpResponse<{
+		token?: string
+		email?: string
+		loginTime?: string
+		expiresAt?: string
+	}>
+	try {
+		response = await fetchJson<{
+			token?: string
+			email?: string
+			loginTime?: string
+			expiresAt?: string
+		}>({
+			host: input.host,
+			port,
+			method: 'POST',
+			path: '/api/login/Basic',
+			headers: {
+				'Content-Type': 'application/json',
+				Accept: 'application/json',
+				'User-Agent': 'kody-home-connector/tesla-gateway',
+			},
+			body,
+			timeoutMs: input.timeoutMs ?? DEFAULT_LOGIN_TIMEOUT_MS,
+		})
+	} catch (error) {
+		// A timeout on the login endpoint is the gateway's standard rate-limit
+		// signal (it accepts the connection but never responds). Mark cooldown.
+		const message = error instanceof Error ? error.message : String(error)
+		if (message.includes('timed out')) {
+			markRateLimited(input.host)
+		}
+		throw error
+	}
+	if (response.status === 429) {
+		markRateLimited(input.host)
+		throw new TeslaGatewayRateLimitError(input.host, RATE_LIMIT_COOLDOWN_MS)
+	}
+	if (response.status !== 200) {
+		const errorMessage =
+			response.body &&
+			typeof response.body === 'object' &&
+			'error' in response.body
+				? String((response.body as { error?: unknown }).error ?? '')
+				: response.rawText.slice(0, 200)
+		throw new TeslaGatewayHttpError({
+			status: response.status,
+			body: response.body ?? response.rawText,
+			host: input.host,
+			path: '/api/login/Basic',
+			message: `Tesla gateway login failed (HTTP ${response.status}): ${errorMessage}`,
+		})
+	}
+	const cookies = pickCookieValues(
+		response.headers['set-cookie'] ? [response.headers['set-cookie']] : [],
+	)
+	// `set-cookie` is multi-valued. The lowercase header map has joined them with
+	// ", " above, but for cookie purposes we want each individually preserved.
+	const rawSetCookie = response.headers['set-cookie']
+	const splitCookies = rawSetCookie
+		? rawSetCookie
+				.split(/,\s*(?=[A-Za-z_][A-Za-z0-9_-]*=)/g)
+				.map((header) => header.split(';')[0]?.trim())
+				.filter((value): value is string => Boolean(value))
+		: cookies
+	const cookieHeader = splitCookies.join('; ')
+	return {
+		cookies: splitCookies,
+		cookieHeader,
+		token: response.body?.token ?? null,
+		email: response.body?.email ?? null,
+		loginTimeIso: response.body?.loginTime ?? null,
+		expiresAtIso: response.body?.expiresAt ?? null,
+	}
+}
+
+export type TeslaGatewaySession = {
+	host: string
+	port: number
+	cookieHeader: string
+	token: string | null
+}
+
+export async function authedGet<T>(input: {
+	session: TeslaGatewaySession
+	path: string
+	timeoutMs?: number
+}): Promise<TeslaGatewayHttpResponse<T>> {
+	const headers: Record<string, string> = {
+		Accept: 'application/json',
+		'User-Agent': 'kody-home-connector/tesla-gateway',
+	}
+	if (input.session.cookieHeader) headers.Cookie = input.session.cookieHeader
+	if (input.session.token)
+		headers.Authorization = `Bearer ${input.session.token}`
+	return await fetchJson<T>({
+		host: input.session.host,
+		port: input.session.port,
+		method: 'GET',
+		path: input.path,
+		headers,
+		...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+	})
+}
+
+function unwrap<T>(
+	response: TeslaGatewayHttpResponse<T>,
+	host: string,
+	path: string,
+): T {
+	if (
+		response.status >= 200 &&
+		response.status < 300 &&
+		response.body !== null
+	) {
+		return response.body
+	}
+	throw new TeslaGatewayHttpError({
+		status: response.status,
+		body: response.body ?? response.rawText,
+		host,
+		path,
+		message: `Tesla gateway GET ${path} failed (HTTP ${response.status}).`,
+	})
+}
+
+export async function getTeslaApiStatus(session: TeslaGatewaySession) {
+	const response = await authedGet<TeslaGatewayApiStatusResponse>({
+		session,
+		path: '/api/status',
+	})
+	return unwrap(response, session.host, '/api/status')
+}
+
+export async function getTeslaSystemStatus(session: TeslaGatewaySession) {
+	const response = await authedGet<TeslaGatewaySystemStatusResponse>({
+		session,
+		path: '/api/system_status',
+	})
+	return unwrap(response, session.host, '/api/system_status')
+}
+
+export async function getTeslaGridStatus(session: TeslaGatewaySession) {
+	const response = await authedGet<TeslaGatewayGridStatusResponse>({
+		session,
+		path: '/api/system_status/grid_status',
+	})
+	return unwrap(response, session.host, '/api/system_status/grid_status')
+}
+
+export async function getTeslaSoe(session: TeslaGatewaySession) {
+	const response = await authedGet<TeslaGatewaySoeResponse>({
+		session,
+		path: '/api/system_status/soe',
+	})
+	return unwrap(response, session.host, '/api/system_status/soe')
+}
+
+export async function getTeslaMetersAggregates(session: TeslaGatewaySession) {
+	const response = await authedGet<TeslaGatewayMetersAggregatesResponse>({
+		session,
+		path: '/api/meters/aggregates',
+	})
+	return unwrap(response, session.host, '/api/meters/aggregates')
+}
+
+export async function getTeslaOperation(session: TeslaGatewaySession) {
+	const response = await authedGet<TeslaGatewayOperationResponse>({
+		session,
+		path: '/api/operation',
+	})
+	return unwrap(response, session.host, '/api/operation')
+}
+
+export async function getTeslaNetworks(session: TeslaGatewaySession) {
+	const response = await authedGet<TeslaGatewayNetworksResponse>({
+		session,
+		path: '/api/networks',
+	})
+	return unwrap(response, session.host, '/api/networks')
+}
+
+export async function getTeslaSiteInfo(session: TeslaGatewaySession) {
+	const response = await authedGet<TeslaGatewaySiteInfoResponse>({
+		session,
+		path: '/api/site_info',
+	})
+	return unwrap(response, session.host, '/api/site_info')
+}
+
+export async function getTeslaPowerwalls(session: TeslaGatewaySession) {
+	const response = await authedGet<TeslaGatewayPowerwallsResponse>({
+		session,
+		path: '/api/powerwalls',
+	})
+	return unwrap(response, session.host, '/api/powerwalls')
+}
+
+export async function getTeslaSolarPowerwall(session: TeslaGatewaySession) {
+	const response = await authedGet<TeslaGatewaySolarPowerwallResponse>({
+		session,
+		path: '/api/solar_powerwall',
+	})
+	return unwrap(response, session.host, '/api/solar_powerwall')
+}
+
+export async function getTeslaGenerators(session: TeslaGatewaySession) {
+	const response = await authedGet<TeslaGatewayGeneratorsResponse>({
+		session,
+		path: '/api/generators',
+	})
+	return unwrap(response, session.host, '/api/generators')
+}
+
+export async function getTeslaSystemUpdateStatus(session: TeslaGatewaySession) {
+	const response = await authedGet<TeslaGatewaySystemUpdateStatusResponse>({
+		session,
+		path: '/api/system/update/status',
+	})
+	return unwrap(response, session.host, '/api/system/update/status')
+}
+
+/**
+ * Convenience: parse the BGW serial out of a DIN like
+ * `1232100-00-H--GF22327600010P` -> `GF22327600010P`.
+ */
+export function extractGatewaySerialFromDin(din: string | null | undefined) {
+	if (!din) return null
+	const idx = din.indexOf('--')
+	if (idx === -1) return null
+	const serial = din.slice(idx + 2).trim()
+	return serial.length > 0 ? serial : null
+}

--- a/packages/home-connector/src/adapters/tesla-gateway/gateway-client.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/gateway-client.ts
@@ -49,11 +49,6 @@ export type TeslaGatewayCredentials = {
 	password: string
 }
 
-export type TeslaGatewayClientHost = {
-	host: string
-	port?: number
-}
-
 export type TeslaGatewayHttpResponse<T> = {
 	status: number
 	body: T | null

--- a/packages/home-connector/src/adapters/tesla-gateway/gateway-client.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/gateway-client.ts
@@ -59,6 +59,15 @@ export type TeslaGatewayHttpResponse<T> = {
 	body: T | null
 	rawText: string
 	headers: Record<string, string>
+	/**
+	 * Individual `Set-Cookie` headers preserved as separate entries.
+	 *
+	 * `headers['set-cookie']` joins all entries with `, ` so that the value
+	 * type can stay `Record<string, string>`. That join breaks for cookies
+	 * that contain commas inside attribute values (most commonly
+	 * `Expires=<HTTP date>`), so the login flow needs the unjoined list.
+	 */
+	setCookieHeaders: Array<string>
 }
 
 export class TeslaGatewayHttpError extends Error {
@@ -233,6 +242,7 @@ async function fetchJson<T>(input: {
 		body: parsed,
 		rawText: result.rawText,
 		headers: result.headers,
+		setCookieHeaders: result.setCookieHeaders,
 	}
 }
 
@@ -316,21 +326,13 @@ export async function loginToTeslaGateway(input: {
 			message: `Tesla gateway login failed (HTTP ${response.status}): ${errorMessage}`,
 		})
 	}
-	const cookies = pickCookieValues(
-		response.headers['set-cookie'] ? [response.headers['set-cookie']] : [],
-	)
-	// `set-cookie` is multi-valued. The lowercase header map has joined them with
-	// ", " above, but for cookie purposes we want each individually preserved.
-	const rawSetCookie = response.headers['set-cookie']
-	const splitCookies = rawSetCookie
-		? rawSetCookie
-				.split(/,\s*(?=[A-Za-z_][A-Za-z0-9_-]*=)/g)
-				.map((header) => header.split(';')[0]?.trim())
-				.filter((value): value is string => Boolean(value))
-		: cookies
-	const cookieHeader = splitCookies.join('; ')
+	// Use the unjoined list of `Set-Cookie` headers preserved by `lowLevelRequest`.
+	// Splitting the joined header value by `,` is unsafe because cookie attribute
+	// values (e.g. `Expires=<HTTP date>`) legitimately contain commas.
+	const cookies = pickCookieValues(response.setCookieHeaders)
+	const cookieHeader = cookies.join('; ')
 	return {
-		cookies: splitCookies,
+		cookies,
 		cookieHeader,
 		token: response.body?.token ?? null,
 		email: response.body?.email ?? null,

--- a/packages/home-connector/src/adapters/tesla-gateway/index.node.test.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/index.node.test.ts
@@ -1,0 +1,157 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+import { installHomeConnectorMockServer } from '../../../mocks/test-server.ts'
+import { type HomeConnectorConfig } from '../../config.ts'
+import { createAppState } from '../../state.ts'
+import { createHomeConnectorStorage } from '../../storage/index.ts'
+import { createTeslaGatewayAdapter, resetTeslaGatewayCaches } from './index.ts'
+import {
+	resetMockTeslaGatewayState,
+	setMockTeslaGatewayExportLimitKw,
+} from './mock-driver.ts'
+
+installHomeConnectorMockServer()
+
+function createConfig(dataPath: string): HomeConnectorConfig {
+	return {
+		homeConnectorId: 'default',
+		workerBaseUrl: 'http://localhost:3742',
+		workerSessionUrl: 'http://localhost:3742/home/connectors/default',
+		workerWebSocketUrl: 'ws://localhost:3742/home/connectors/default',
+		sharedSecret: 'home-connector-secret-home-connector-secret',
+		rokuDiscoveryUrl: 'http://roku.mock.local/discovery',
+		lutronDiscoveryUrl: 'http://lutron.mock.local/discovery',
+		sonosDiscoveryUrl: 'http://sonos.mock.local/discovery',
+		samsungTvDiscoveryUrl: 'http://samsung-tv.mock.local/discovery',
+		bondDiscoveryUrl: 'http://bond.mock.local/discovery',
+		jellyfishDiscoveryUrl: 'http://jellyfish.mock.local/discovery',
+		venstarScanCidrs: [],
+		jellyfishScanCidrs: [],
+		teslaGatewayScanCidrs: [],
+		teslaGatewayDiscoveryUrl: 'http://tesla-gateway.mock.local/discovery',
+		dataPath,
+		dbPath: path.join(dataPath, 'home-connector.sqlite'),
+		port: 4040,
+		mocksEnabled: true,
+	}
+}
+
+function makeAdapter() {
+	resetMockTeslaGatewayState()
+	resetTeslaGatewayCaches()
+	const dataPath = mkdtempSync(path.join(tmpdir(), 'kody-tesla-gateway-'))
+	const config = createConfig(dataPath)
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const adapter = createTeslaGatewayAdapter({ config, state, storage })
+	return {
+		adapter,
+		config,
+		state,
+		storage,
+		[Symbol.dispose]() {
+			storage.close()
+			rmSync(dataPath, { recursive: true, force: true })
+			resetTeslaGatewayCaches()
+		},
+	}
+}
+
+test('scan persists mock gateways from the JSON discovery feed', async () => {
+	using env = makeAdapter()
+	const gateways = await env.adapter.scan()
+	expect(gateways).toHaveLength(2)
+	expect(gateways.map((gateway) => gateway.gatewayId).sort()).toEqual([
+		'tesla-gateway-mock-home-1',
+		'tesla-gateway-mock-home-2',
+	])
+	expect(gateways[0]?.role).toBe('leader')
+	expect(gateways[0]?.cert?.subjectOrganization).toBe('Tesla')
+})
+
+test('setCredentials, authenticate, and live snapshot exercise the full happy path', async () => {
+	using env = makeAdapter()
+	await env.adapter.scan()
+	const gatewayId = 'tesla-gateway-mock-home-1'
+	env.adapter.setCredentials({
+		gatewayId,
+		password: 'mock-password',
+		customerEmailLabel: 'tester@local',
+	})
+	const authed = await env.adapter.authenticate(gatewayId)
+	expect(authed.hasStoredCredentials).toBe(true)
+	expect(authed.lastAuthError).toBeNull()
+	expect(authed.lastAuthenticatedAt).toBeTruthy()
+
+	const snapshot = await env.adapter.getLiveSnapshot(gatewayId)
+	expect(Object.keys(snapshot.fetchErrors)).toEqual([])
+	expect(snapshot.gateway.din).toMatch(/--GF/)
+	expect(snapshot.gateway.serialNumber).toBeTruthy()
+	expect(snapshot.systemStatus?.solar_real_power_limit).toBe(25_000)
+	expect(snapshot.siteInfo?.max_site_meter_power_ac).toBe(25_000)
+	expect(snapshot.gridStatus?.grid_status).toBe('SystemGridConnected')
+	expect(snapshot.soe?.percentage).toBeGreaterThanOrEqual(0)
+	expect(snapshot.meters?.solar?.instant_power).toBe(6_700)
+	expect(snapshot.powerwalls?.powerwalls?.length ?? 0).toBe(3)
+})
+
+test('findExportLimit prefers max_site_meter_power_ac and reports source', async () => {
+	using env = makeAdapter()
+	await env.adapter.scan()
+	const gatewayId = 'tesla-gateway-mock-home-1'
+	env.adapter.setCredentials({ gatewayId, password: 'mock-password' })
+	const info = await env.adapter.findExportLimit(gatewayId)
+	expect(info.exportLimitKw).toBe(25)
+	expect(info.exportLimitWatts).toBe(25_000)
+	expect(info.source).toBe('site_info.max_site_meter_power_ac')
+})
+
+test('findAllExportLimits surfaces the configured cap for every gateway', async () => {
+	using env = makeAdapter()
+	await env.adapter.scan()
+	for (const gateway of env.adapter.listGateways()) {
+		env.adapter.setCredentials({
+			gatewayId: gateway.gatewayId,
+			password: 'mock-password',
+		})
+	}
+	setMockTeslaGatewayExportLimitKw({
+		host: 'tesla-gateway-home-2.mock.local',
+		exportLimitKw: 17,
+	})
+	const results = await env.adapter.findAllExportLimits()
+	expect(results).toHaveLength(2)
+	expect(
+		results.find((entry) => entry.gatewayId === 'tesla-gateway-mock-home-1')
+			?.exportLimitKw,
+	).toBe(25)
+	expect(
+		results.find((entry) => entry.gatewayId === 'tesla-gateway-mock-home-2')
+			?.exportLimitKw,
+	).toBe(17)
+})
+
+test('authenticate rejects an invalid mock password and records the error', async () => {
+	using env = makeAdapter()
+	await env.adapter.scan()
+	const gatewayId = 'tesla-gateway-mock-home-1'
+	env.adapter.setCredentials({ gatewayId, password: 'wrong-password' })
+	await expect(env.adapter.authenticate(gatewayId)).rejects.toThrow(
+		/credentials are invalid/i,
+	)
+	const gateway = env.adapter
+		.listGateways()
+		.find((entry) => entry.gatewayId === gatewayId)
+	expect(gateway?.lastAuthError).toBeTruthy()
+	expect(gateway?.lastAuthenticatedAt).toBeNull()
+})
+
+test('getLiveSnapshot fails when no credentials are stored', async () => {
+	using env = makeAdapter()
+	await env.adapter.scan()
+	await expect(
+		env.adapter.getLiveSnapshot('tesla-gateway-mock-home-1'),
+	).rejects.toThrow(/missing stored credentials/i)
+})

--- a/packages/home-connector/src/adapters/tesla-gateway/index.node.test.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/index.node.test.ts
@@ -82,6 +82,8 @@ test('setCredentials, authenticate, and live snapshot exercise the full happy pa
 	})
 	const authed = await env.adapter.authenticate(gatewayId)
 	expect(authed.hasStoredCredentials).toBe(true)
+	expect(authed.hasCustomCustomerEmailLabel).toBe(true)
+	expect('customerEmailLabel' in authed).toBe(false)
 	expect(authed.lastAuthError).toBeNull()
 	expect(authed.lastAuthenticatedAt).toBeTruthy()
 
@@ -89,23 +91,40 @@ test('setCredentials, authenticate, and live snapshot exercise the full happy pa
 	expect(Object.keys(snapshot.fetchErrors)).toEqual([])
 	expect(snapshot.gateway.din).toMatch(/--GF/)
 	expect(snapshot.gateway.serialNumber).toBeTruthy()
-	expect(snapshot.systemStatus?.solar_real_power_limit).toBe(25_000)
-	expect(snapshot.siteInfo?.max_site_meter_power_ac).toBe(25_000)
+	expect(snapshot.systemStatus?.solar_real_power_limit).toBe(21_000)
+	expect(snapshot.siteInfo?.max_site_export_power_kW).toBe(21)
+	expect(snapshot.siteInfo?.max_site_meter_power_ac).toBe(40_000)
 	expect(snapshot.gridStatus?.grid_status).toBe('SystemGridConnected')
 	expect(snapshot.soe?.percentage).toBeGreaterThanOrEqual(0)
 	expect(snapshot.meters?.solar?.instant_power).toBe(6_700)
 	expect(snapshot.powerwalls?.powerwalls?.length ?? 0).toBe(3)
 })
 
-test('findExportLimit prefers max_site_meter_power_ac and reports source', async () => {
+test('findExportLimit prefers the dedicated export cap field and works when destructured', async () => {
 	using env = makeAdapter()
 	await env.adapter.scan()
 	const gatewayId = 'tesla-gateway-mock-home-1'
 	env.adapter.setCredentials({ gatewayId, password: 'mock-password' })
-	const info = await env.adapter.findExportLimit(gatewayId)
-	expect(info.exportLimitKw).toBe(25)
-	expect(info.exportLimitWatts).toBe(25_000)
-	expect(info.source).toBe('site_info.max_site_meter_power_ac')
+	const { findExportLimit } = env.adapter
+	const info = await findExportLimit(gatewayId)
+	expect(info.exportLimitKw).toBe(21)
+	expect(info.exportLimitWatts).toBe(21_000)
+	expect(info.source).toBe('site_info.max_site_export_power_kW')
+})
+
+test('findExportLimit records failed authentication status', async () => {
+	using env = makeAdapter()
+	await env.adapter.scan()
+	const gatewayId = 'tesla-gateway-mock-home-1'
+	env.adapter.setCredentials({ gatewayId, password: 'wrong-password' })
+	await expect(env.adapter.findExportLimit(gatewayId)).rejects.toThrow(
+		/credentials are invalid/i,
+	)
+	const gateway = env.adapter
+		.listGateways()
+		.find((entry) => entry.gatewayId === gatewayId)
+	expect(gateway?.lastAuthError).toBeTruthy()
+	expect(gateway?.lastAuthenticatedAt).toBeNull()
 })
 
 test('findAllExportLimits surfaces the configured cap for every gateway', async () => {
@@ -126,7 +145,7 @@ test('findAllExportLimits surfaces the configured cap for every gateway', async 
 	expect(
 		results.find((entry) => entry.gatewayId === 'tesla-gateway-mock-home-1')
 			?.exportLimitKw,
-	).toBe(25)
+	).toBe(21)
 	expect(
 		results.find((entry) => entry.gatewayId === 'tesla-gateway-mock-home-2')
 			?.exportLimitKw,

--- a/packages/home-connector/src/adapters/tesla-gateway/index.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/index.ts
@@ -193,11 +193,25 @@ async function ensureSession(input: {
 async function safeFetch<T>(input: {
 	label: string
 	fn: () => Promise<T>
+	onUnauthorized?: () => Promise<T>
 	errors: Record<string, string>
 }): Promise<T | null> {
 	try {
 		return await input.fn()
 	} catch (error) {
+		if (
+			input.onUnauthorized &&
+			error instanceof TeslaGatewayHttpError &&
+			(error.status === 401 || error.status === 403)
+		) {
+			try {
+				return await input.onUnauthorized()
+			} catch (retryError) {
+				input.errors[input.label] =
+					retryError instanceof Error ? retryError.message : String(retryError)
+				return null
+			}
+		}
 		input.errors[input.label] =
 			error instanceof Error ? error.message : String(error)
 		return null
@@ -210,13 +224,25 @@ async function fetchLiveFromGateway(input: {
 	gateway: TeslaGatewayPersistedRecord
 }): Promise<TeslaGatewayLiveSnapshot> {
 	const errors: Record<string, string> = {}
-	const session = await ensureSession({
+	let session = await ensureSession({
 		storage: input.storage,
 		connectorId: input.connectorId,
 		gateway: input.gateway,
 	})
 
 	const isMock = isMockTeslaGatewayHost(input.gateway.host)
+	async function retryAfterUnauthorized<T>(
+		fn: (session: TeslaGatewaySession) => Promise<T>,
+	): Promise<T> {
+		dropSession(input.connectorId, input.gateway.gatewayId)
+		const freshSession = await ensureSession({
+			storage: input.storage,
+			connectorId: input.connectorId,
+			gateway: input.gateway,
+		})
+		session = freshSession
+		return await fn(session)
+	}
 	const status = isMock
 		? await safeFetch({
 				label: 'status',
@@ -226,6 +252,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'status',
 				fn: () => getTeslaApiStatus(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaApiStatus),
 				errors,
 			})
 	const systemStatus = isMock
@@ -237,6 +264,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'system_status',
 				fn: () => getTeslaSystemStatus(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaSystemStatus),
 				errors,
 			})
 	const gridStatus = isMock
@@ -248,6 +276,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'grid_status',
 				fn: () => getTeslaGridStatus(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaGridStatus),
 				errors,
 			})
 	const soe = isMock
@@ -259,6 +288,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'soe',
 				fn: () => getTeslaSoe(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaSoe),
 				errors,
 			})
 	const meters = isMock
@@ -270,6 +300,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'meters/aggregates',
 				fn: () => getTeslaMetersAggregates(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaMetersAggregates),
 				errors,
 			})
 	const operation = isMock
@@ -281,6 +312,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'operation',
 				fn: () => getTeslaOperation(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaOperation),
 				errors,
 			})
 	const networks = isMock
@@ -292,6 +324,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'networks',
 				fn: () => getTeslaNetworks(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaNetworks),
 				errors,
 			})
 	const siteInfo = isMock
@@ -303,6 +336,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'site_info',
 				fn: () => getTeslaSiteInfo(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaSiteInfo),
 				errors,
 			})
 	const powerwalls = isMock
@@ -314,6 +348,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'powerwalls',
 				fn: () => getTeslaPowerwalls(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaPowerwalls),
 				errors,
 			})
 	const solarPowerwall = isMock
@@ -325,6 +360,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'solar_powerwall',
 				fn: () => getTeslaSolarPowerwall(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaSolarPowerwall),
 				errors,
 			})
 	const generators = isMock
@@ -336,6 +372,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'generators',
 				fn: () => getTeslaGenerators(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaGenerators),
 				errors,
 			})
 	const systemUpdateStatus = isMock
@@ -347,6 +384,8 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'system/update/status',
 				fn: () => getTeslaSystemUpdateStatus(session),
+				onUnauthorized: () =>
+					retryAfterUnauthorized(getTeslaSystemUpdateStatus),
 				errors,
 			})
 
@@ -391,6 +430,7 @@ export type TeslaGatewayExportLimitInfo = {
 	exportLimitWatts: number | null
 	exportLimitKw: number | null
 	source:
+		| 'site_info.max_site_export_power_kW'
 		| 'site_info.max_site_meter_power_ac'
 		| 'system_status.solar_real_power_limit'
 		| 'site_info.max_system_power_kW'
@@ -404,6 +444,16 @@ function pickExportLimit(
 		typeof snapshot.siteInfo?.site_name === 'string'
 			? snapshot.siteInfo.site_name
 			: null
+	if (typeof snapshot.siteInfo?.max_site_export_power_kW === 'number') {
+		const kW = snapshot.siteInfo.max_site_export_power_kW
+		return {
+			gatewayId: snapshot.gateway.gatewayId,
+			siteName,
+			exportLimitWatts: Math.round(kW * 1_000),
+			exportLimitKw: kW,
+			source: 'site_info.max_site_export_power_kW',
+		}
+	}
 	if (typeof snapshot.siteInfo?.max_site_meter_power_ac === 'number') {
 		const watts = snapshot.siteInfo.max_site_meter_power_ac
 		return {
@@ -479,7 +529,14 @@ export function createTeslaGatewayAdapter(input: {
 				config.mocksEnabled && result.gateways.length === 0
 					? listMockTeslaGatewayDiscoveryEntries()
 					: result.gateways
-			upsertDiscoveredTeslaGateways(storage, connectorId, gateways)
+			const discoveryWasFallbackToMocks =
+				config.mocksEnabled && result.gateways.length === 0
+			upsertDiscoveredTeslaGateways(storage, connectorId, gateways, {
+				pruneMissing:
+					discoveryWasFallbackToMocks ||
+					result.diagnostics.errors.length === 0 ||
+					result.gateways.length > 0,
+			})
 			return listGateways()
 		},
 		getStatus() {
@@ -499,14 +556,13 @@ export function createTeslaGatewayAdapter(input: {
 			customerEmailLabel?: string
 		}) {
 			requireTeslaGateway(storage, connectorId, input.gatewayId)
+			const customerEmailLabel = input.customerEmailLabel?.trim()
 			saveTeslaGatewayCredentials({
 				storage,
 				connectorId,
 				gatewayId: input.gatewayId,
 				password: input.password,
-				...(input.customerEmailLabel
-					? { customerEmailLabel: input.customerEmailLabel }
-					: {}),
+				...(customerEmailLabel ? { customerEmailLabel } : {}),
 			})
 			dropSession(connectorId, input.gatewayId)
 			return toPublicTeslaGateway(
@@ -552,8 +608,18 @@ export function createTeslaGatewayAdapter(input: {
 		async findExportLimit(
 			gatewayId: string,
 		): Promise<TeslaGatewayExportLimitInfo> {
-			const snapshot = await this.getLiveSnapshot(gatewayId)
-			return pickExportLimit(snapshot)
+			const gateway = requireTeslaGateway(storage, connectorId, gatewayId)
+			try {
+				const snapshot = await fetchLiveFromGateway({
+					storage,
+					connectorId,
+					gateway,
+				})
+				return pickExportLimit(snapshot)
+			} catch (error) {
+				applyFailedAuth({ gateway, error })
+				throw error
+			}
 		},
 		async findAllExportLimits(): Promise<Array<TeslaGatewayExportLimitInfo>> {
 			const gateways = listTeslaGateways(storage, connectorId)

--- a/packages/home-connector/src/adapters/tesla-gateway/index.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/index.ts
@@ -1,0 +1,597 @@
+/**
+ * Tesla Backup Gateway 2 / Powerwall+ leader adapter.
+ *
+ * Surface area mirrors the lutron adapter:
+ *   - `scan()` runs a discovery sweep and persists the result.
+ *   - `setCredentials()` stores an encrypted customer-role password keyed on
+ *     the `HOME_CONNECTOR_SHARED_SECRET`.
+ *   - `getLiveSnapshot()` fetches every customer-scope endpoint in one call,
+ *     using a cached cookie session when available.
+ *   - `findExportLimit()` is a small convenience that surfaces the most
+ *     likely "site export cap" value from `site_info` / `system_status` for
+ *     debugging curtailment.
+ *
+ * Hosts ending in `.mock.local` are dispatched to the in-process mock driver
+ * so dev/test runs never touch the network.
+ */
+import { type HomeConnectorConfig } from '../../config.ts'
+import { type HomeConnectorState } from '../../state.ts'
+import { type HomeConnectorStorage } from '../../storage/index.ts'
+import { scanTeslaGateways } from './discovery.ts'
+import {
+	authedGet,
+	clearTeslaGatewayRateLimits,
+	extractGatewaySerialFromDin,
+	getTeslaApiStatus,
+	getTeslaGenerators,
+	getTeslaGridStatus,
+	getTeslaMetersAggregates,
+	getTeslaNetworks,
+	getTeslaOperation,
+	getTeslaPowerwalls,
+	getTeslaSiteInfo,
+	getTeslaSoe,
+	getTeslaSolarPowerwall,
+	getTeslaSystemStatus,
+	getTeslaSystemUpdateStatus,
+	loginToTeslaGateway,
+	TeslaGatewayHttpError,
+	TeslaGatewayRateLimitError,
+	type TeslaGatewaySession,
+} from './gateway-client.ts'
+import {
+	getMockTeslaApiStatus,
+	getMockTeslaGenerators,
+	getMockTeslaGridStatus,
+	getMockTeslaMetersAggregates,
+	getMockTeslaNetworks,
+	getMockTeslaOperation,
+	getMockTeslaPowerwalls,
+	getMockTeslaSiteInfo,
+	getMockTeslaSoe,
+	getMockTeslaSolarPowerwall,
+	getMockTeslaSystemStatus,
+	getMockTeslaSystemUpdateStatus,
+	isMockTeslaGatewayHost,
+	listMockTeslaGatewayDiscoveryEntries,
+	validateMockTeslaCredentials,
+} from './mock-driver.ts'
+import {
+	listPublicTeslaGateways,
+	listTeslaGateways,
+	requireTeslaGateway,
+	saveTeslaGatewayCredentials,
+	setTeslaGatewayLabel,
+	toPublicTeslaGateway,
+	updateTeslaGatewayAuthStatus,
+	updateTeslaGatewayMetadata,
+	upsertDiscoveredTeslaGateways,
+} from './repository.ts'
+import {
+	type TeslaGatewayLiveSnapshot,
+	type TeslaGatewayPersistedRecord,
+	type TeslaGatewayPublicRecord,
+} from './types.ts'
+
+type SessionCacheEntry = {
+	session: TeslaGatewaySession
+	expiresAt: number
+}
+
+const sessionCache = new Map<string, SessionCacheEntry>()
+const SESSION_TTL_MS = 23 * 60 * 60 * 1_000
+
+function cacheKey(connectorId: string, gatewayId: string) {
+	return `${connectorId}:${gatewayId}`
+}
+
+function getCachedSession(
+	connectorId: string,
+	gatewayId: string,
+): TeslaGatewaySession | null {
+	const entry = sessionCache.get(cacheKey(connectorId, gatewayId))
+	if (!entry) return null
+	if (entry.expiresAt < Date.now()) {
+		sessionCache.delete(cacheKey(connectorId, gatewayId))
+		return null
+	}
+	return entry.session
+}
+
+function storeSession(
+	connectorId: string,
+	gatewayId: string,
+	session: TeslaGatewaySession,
+) {
+	sessionCache.set(cacheKey(connectorId, gatewayId), {
+		session,
+		expiresAt: Date.now() + SESSION_TTL_MS,
+	})
+}
+
+function dropSession(connectorId: string, gatewayId: string) {
+	sessionCache.delete(cacheKey(connectorId, gatewayId))
+}
+
+/**
+ * Test helper. Clears every cached cookie and rate-limit cooldown so suites
+ * can drive deterministic login flows.
+ */
+export function resetTeslaGatewayCaches() {
+	sessionCache.clear()
+	clearTeslaGatewayRateLimits()
+}
+
+function requireCredentials(gateway: TeslaGatewayPersistedRecord) {
+	if (!gateway.password) {
+		throw new Error(
+			`Tesla gateway "${gateway.gatewayId}" is missing stored credentials. Run tesla_gateway_set_credentials first.`,
+		)
+	}
+	return {
+		emailLabel: gateway.customerEmailLabel,
+		password: gateway.password,
+	}
+}
+
+async function ensureSession(input: {
+	storage: HomeConnectorStorage
+	connectorId: string
+	gateway: TeslaGatewayPersistedRecord
+}): Promise<TeslaGatewaySession> {
+	const cached = getCachedSession(input.connectorId, input.gateway.gatewayId)
+	if (cached) return cached
+	const credentials = requireCredentials(input.gateway)
+	if (isMockTeslaGatewayHost(input.gateway.host)) {
+		const ok = validateMockTeslaCredentials({
+			host: input.gateway.host,
+			emailLabel: credentials.emailLabel,
+			password: credentials.password,
+		})
+		if (!ok) {
+			throw new Error(
+				'Tesla mock authentication failed because the credentials are invalid.',
+			)
+		}
+		const session: TeslaGatewaySession = {
+			host: input.gateway.host,
+			port: input.gateway.port,
+			cookieHeader: 'AuthCookie=mock; UserRecord=mock',
+			token: 'mock-token',
+		}
+		storeSession(input.connectorId, input.gateway.gatewayId, session)
+		updateTeslaGatewayAuthStatus({
+			storage: input.storage,
+			connectorId: input.connectorId,
+			gatewayId: input.gateway.gatewayId,
+			lastAuthenticatedAt: new Date().toISOString(),
+			lastAuthError: null,
+		})
+		return session
+	}
+	const login = await loginToTeslaGateway({
+		host: input.gateway.host,
+		port: input.gateway.port,
+		credentials,
+	})
+	const session: TeslaGatewaySession = {
+		host: input.gateway.host,
+		port: input.gateway.port,
+		cookieHeader: login.cookieHeader,
+		token: login.token,
+	}
+	storeSession(input.connectorId, input.gateway.gatewayId, session)
+	updateTeslaGatewayAuthStatus({
+		storage: input.storage,
+		connectorId: input.connectorId,
+		gatewayId: input.gateway.gatewayId,
+		lastAuthenticatedAt: new Date().toISOString(),
+		lastAuthError: null,
+	})
+	return session
+}
+
+async function safeFetch<T>(input: {
+	label: string
+	fn: () => Promise<T>
+	errors: Record<string, string>
+}): Promise<T | null> {
+	try {
+		return await input.fn()
+	} catch (error) {
+		input.errors[input.label] =
+			error instanceof Error ? error.message : String(error)
+		return null
+	}
+}
+
+async function fetchLiveFromGateway(input: {
+	storage: HomeConnectorStorage
+	connectorId: string
+	gateway: TeslaGatewayPersistedRecord
+}): Promise<TeslaGatewayLiveSnapshot> {
+	const errors: Record<string, string> = {}
+	const session = await ensureSession({
+		storage: input.storage,
+		connectorId: input.connectorId,
+		gateway: input.gateway,
+	})
+
+	const isMock = isMockTeslaGatewayHost(input.gateway.host)
+	const status = isMock
+		? await safeFetch({
+				label: 'status',
+				fn: async () => getMockTeslaApiStatus(input.gateway.host),
+				errors,
+			})
+		: await safeFetch({
+				label: 'status',
+				fn: () => getTeslaApiStatus(session),
+				errors,
+			})
+	const systemStatus = isMock
+		? await safeFetch({
+				label: 'system_status',
+				fn: async () => getMockTeslaSystemStatus(input.gateway.host),
+				errors,
+			})
+		: await safeFetch({
+				label: 'system_status',
+				fn: () => getTeslaSystemStatus(session),
+				errors,
+			})
+	const gridStatus = isMock
+		? await safeFetch({
+				label: 'grid_status',
+				fn: async () => getMockTeslaGridStatus(input.gateway.host),
+				errors,
+			})
+		: await safeFetch({
+				label: 'grid_status',
+				fn: () => getTeslaGridStatus(session),
+				errors,
+			})
+	const soe = isMock
+		? await safeFetch({
+				label: 'soe',
+				fn: async () => getMockTeslaSoe(input.gateway.host),
+				errors,
+			})
+		: await safeFetch({
+				label: 'soe',
+				fn: () => getTeslaSoe(session),
+				errors,
+			})
+	const meters = isMock
+		? await safeFetch({
+				label: 'meters/aggregates',
+				fn: async () => getMockTeslaMetersAggregates(input.gateway.host),
+				errors,
+			})
+		: await safeFetch({
+				label: 'meters/aggregates',
+				fn: () => getTeslaMetersAggregates(session),
+				errors,
+			})
+	const operation = isMock
+		? await safeFetch({
+				label: 'operation',
+				fn: async () => getMockTeslaOperation(input.gateway.host),
+				errors,
+			})
+		: await safeFetch({
+				label: 'operation',
+				fn: () => getTeslaOperation(session),
+				errors,
+			})
+	const networks = isMock
+		? await safeFetch({
+				label: 'networks',
+				fn: async () => getMockTeslaNetworks(input.gateway.host),
+				errors,
+			})
+		: await safeFetch({
+				label: 'networks',
+				fn: () => getTeslaNetworks(session),
+				errors,
+			})
+	const siteInfo = isMock
+		? await safeFetch({
+				label: 'site_info',
+				fn: async () => getMockTeslaSiteInfo(input.gateway.host),
+				errors,
+			})
+		: await safeFetch({
+				label: 'site_info',
+				fn: () => getTeslaSiteInfo(session),
+				errors,
+			})
+	const powerwalls = isMock
+		? await safeFetch({
+				label: 'powerwalls',
+				fn: async () => getMockTeslaPowerwalls(input.gateway.host),
+				errors,
+			})
+		: await safeFetch({
+				label: 'powerwalls',
+				fn: () => getTeslaPowerwalls(session),
+				errors,
+			})
+	const solarPowerwall = isMock
+		? await safeFetch({
+				label: 'solar_powerwall',
+				fn: async () => getMockTeslaSolarPowerwall(input.gateway.host),
+				errors,
+			})
+		: await safeFetch({
+				label: 'solar_powerwall',
+				fn: () => getTeslaSolarPowerwall(session),
+				errors,
+			})
+	const generators = isMock
+		? await safeFetch({
+				label: 'generators',
+				fn: async () => getMockTeslaGenerators(input.gateway.host),
+				errors,
+			})
+		: await safeFetch({
+				label: 'generators',
+				fn: () => getTeslaGenerators(session),
+				errors,
+			})
+	const systemUpdateStatus = isMock
+		? await safeFetch({
+				label: 'system/update/status',
+				fn: async () => getMockTeslaSystemUpdateStatus(input.gateway.host),
+				errors,
+			})
+		: await safeFetch({
+				label: 'system/update/status',
+				fn: () => getTeslaSystemUpdateStatus(session),
+				errors,
+			})
+
+	if (status?.din || status?.version) {
+		updateTeslaGatewayMetadata({
+			storage: input.storage,
+			connectorId: input.connectorId,
+			gatewayId: input.gateway.gatewayId,
+			din: status?.din ?? null,
+			serialNumber: extractGatewaySerialFromDin(status?.din ?? null),
+			firmwareVersion: status?.version ?? null,
+		})
+	}
+
+	const refreshed = requireTeslaGateway(
+		input.storage,
+		input.connectorId,
+		input.gateway.gatewayId,
+	)
+
+	return {
+		gateway: toPublicTeslaGateway(refreshed),
+		status,
+		systemStatus,
+		gridStatus,
+		soe,
+		meters,
+		operation,
+		networks,
+		siteInfo,
+		powerwalls,
+		solarPowerwall,
+		generators,
+		systemUpdateStatus,
+		fetchErrors: errors,
+	}
+}
+
+export type TeslaGatewayExportLimitInfo = {
+	gatewayId: string
+	siteName: string | null
+	exportLimitWatts: number | null
+	exportLimitKw: number | null
+	source:
+		| 'site_info.max_site_meter_power_ac'
+		| 'system_status.solar_real_power_limit'
+		| 'site_info.max_system_power_kW'
+		| 'unknown'
+}
+
+function pickExportLimit(
+	snapshot: TeslaGatewayLiveSnapshot,
+): TeslaGatewayExportLimitInfo {
+	const siteName =
+		typeof snapshot.siteInfo?.site_name === 'string'
+			? snapshot.siteInfo.site_name
+			: null
+	if (typeof snapshot.siteInfo?.max_site_meter_power_ac === 'number') {
+		const watts = snapshot.siteInfo.max_site_meter_power_ac
+		return {
+			gatewayId: snapshot.gateway.gatewayId,
+			siteName,
+			exportLimitWatts: watts,
+			exportLimitKw: Math.round((watts / 1_000) * 100) / 100,
+			source: 'site_info.max_site_meter_power_ac',
+		}
+	}
+	if (typeof snapshot.systemStatus?.solar_real_power_limit === 'number') {
+		const watts = snapshot.systemStatus.solar_real_power_limit
+		return {
+			gatewayId: snapshot.gateway.gatewayId,
+			siteName,
+			exportLimitWatts: watts,
+			exportLimitKw: Math.round((watts / 1_000) * 100) / 100,
+			source: 'system_status.solar_real_power_limit',
+		}
+	}
+	if (typeof snapshot.siteInfo?.max_system_power_kW === 'number') {
+		const kW = snapshot.siteInfo.max_system_power_kW
+		return {
+			gatewayId: snapshot.gateway.gatewayId,
+			siteName,
+			exportLimitWatts: Math.round(kW * 1_000),
+			exportLimitKw: kW,
+			source: 'site_info.max_system_power_kW',
+		}
+	}
+	return {
+		gatewayId: snapshot.gateway.gatewayId,
+		siteName,
+		exportLimitWatts: null,
+		exportLimitKw: null,
+		source: 'unknown',
+	}
+}
+
+export function createTeslaGatewayAdapter(input: {
+	config: HomeConnectorConfig
+	state: HomeConnectorState
+	storage: HomeConnectorStorage
+}) {
+	const { config, state, storage } = input
+	const connectorId = config.homeConnectorId
+
+	function listGateways() {
+		return listPublicTeslaGateways(storage, connectorId)
+	}
+
+	function applyFailedAuth(input: {
+		gateway: TeslaGatewayPersistedRecord
+		error: unknown
+	}) {
+		dropSession(connectorId, input.gateway.gatewayId)
+		updateTeslaGatewayAuthStatus({
+			storage,
+			connectorId,
+			gatewayId: input.gateway.gatewayId,
+			lastAuthenticatedAt: null,
+			lastAuthError:
+				input.error instanceof Error
+					? input.error.message
+					: String(input.error),
+		})
+	}
+
+	return {
+		async scan() {
+			const result = await scanTeslaGateways(state, config)
+			const gateways =
+				config.mocksEnabled && result.gateways.length === 0
+					? listMockTeslaGatewayDiscoveryEntries()
+					: result.gateways
+			upsertDiscoveredTeslaGateways(storage, connectorId, gateways)
+			return listGateways()
+		},
+		getStatus() {
+			const gateways = listGateways()
+			return {
+				gateways,
+				diagnostics: state.teslaGatewayDiscoveryDiagnostics,
+				configuredCredentialsCount: gateways.filter(
+					(gateway) => gateway.hasStoredCredentials,
+				).length,
+			}
+		},
+		listGateways,
+		setCredentials(input: {
+			gatewayId: string
+			password: string
+			customerEmailLabel?: string
+		}) {
+			requireTeslaGateway(storage, connectorId, input.gatewayId)
+			saveTeslaGatewayCredentials({
+				storage,
+				connectorId,
+				gatewayId: input.gatewayId,
+				password: input.password,
+				...(input.customerEmailLabel
+					? { customerEmailLabel: input.customerEmailLabel }
+					: {}),
+			})
+			dropSession(connectorId, input.gatewayId)
+			return toPublicTeslaGateway(
+				requireTeslaGateway(storage, connectorId, input.gatewayId),
+			)
+		},
+		setLabel(input: { gatewayId: string; label: string | null }) {
+			requireTeslaGateway(storage, connectorId, input.gatewayId)
+			setTeslaGatewayLabel({
+				storage,
+				connectorId,
+				gatewayId: input.gatewayId,
+				label: input.label,
+			})
+			return toPublicTeslaGateway(
+				requireTeslaGateway(storage, connectorId, input.gatewayId),
+			)
+		},
+		async authenticate(gatewayId: string): Promise<TeslaGatewayPublicRecord> {
+			const gateway = requireTeslaGateway(storage, connectorId, gatewayId)
+			try {
+				dropSession(connectorId, gatewayId)
+				await ensureSession({ storage, connectorId, gateway })
+				return toPublicTeslaGateway(
+					requireTeslaGateway(storage, connectorId, gatewayId),
+				)
+			} catch (error) {
+				applyFailedAuth({ gateway, error })
+				throw error
+			}
+		},
+		async getLiveSnapshot(
+			gatewayId: string,
+		): Promise<TeslaGatewayLiveSnapshot> {
+			const gateway = requireTeslaGateway(storage, connectorId, gatewayId)
+			try {
+				return await fetchLiveFromGateway({ storage, connectorId, gateway })
+			} catch (error) {
+				applyFailedAuth({ gateway, error })
+				throw error
+			}
+		},
+		async findExportLimit(
+			gatewayId: string,
+		): Promise<TeslaGatewayExportLimitInfo> {
+			const snapshot = await this.getLiveSnapshot(gatewayId)
+			return pickExportLimit(snapshot)
+		},
+		async findAllExportLimits(): Promise<Array<TeslaGatewayExportLimitInfo>> {
+			const gateways = listTeslaGateways(storage, connectorId)
+			const results: Array<TeslaGatewayExportLimitInfo> = []
+			for (const gateway of gateways) {
+				try {
+					const snapshot = await fetchLiveFromGateway({
+						storage,
+						connectorId,
+						gateway,
+					})
+					results.push(pickExportLimit(snapshot))
+				} catch (error) {
+					results.push({
+						gatewayId: gateway.gatewayId,
+						siteName: gateway.label ?? null,
+						exportLimitWatts: null,
+						exportLimitKw: null,
+						source: 'unknown',
+					})
+					applyFailedAuth({ gateway, error })
+				}
+			}
+			return results
+		},
+		async rawAuthedGet<T = unknown>(input: {
+			gatewayId: string
+			path: string
+		}) {
+			const gateway = requireTeslaGateway(storage, connectorId, input.gatewayId)
+			const session = await ensureSession({ storage, connectorId, gateway })
+			return await authedGet<T>({ session, path: input.path })
+		},
+	}
+}
+
+export {
+	TeslaGatewayHttpError,
+	TeslaGatewayRateLimitError,
+} from './gateway-client.ts'

--- a/packages/home-connector/src/adapters/tesla-gateway/index.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/index.ts
@@ -19,7 +19,6 @@ import { type HomeConnectorState } from '../../state.ts'
 import { type HomeConnectorStorage } from '../../storage/index.ts'
 import { scanTeslaGateways } from './discovery.ts'
 import {
-	authedGet,
 	clearTeslaGatewayRateLimits,
 	extractGatewaySerialFromDin,
 	getTeslaApiStatus,
@@ -579,14 +578,6 @@ export function createTeslaGatewayAdapter(input: {
 				}
 			}
 			return results
-		},
-		async rawAuthedGet<T = unknown>(input: {
-			gatewayId: string
-			path: string
-		}) {
-			const gateway = requireTeslaGateway(storage, connectorId, input.gatewayId)
-			const session = await ensureSession({ storage, connectorId, gateway })
-			return await authedGet<T>({ session, path: input.path })
 		},
 	}
 }

--- a/packages/home-connector/src/adapters/tesla-gateway/mock-driver.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/mock-driver.ts
@@ -1,0 +1,416 @@
+/**
+ * In-process mock for the Tesla Backup Gateway 2 local API. Used both by
+ * tests and by the dev server when `MOCKS=true`. Hosts ending in
+ * `.mock.local` are routed here directly without hitting the network so the
+ * MSW HTTPS-with-self-signed-cert dance is unnecessary.
+ *
+ * Fixture shape mirrors the real-world responses recorded against pypowerwall
+ * captures and the tesla-api community docs, with payload values kept small.
+ */
+import {
+	type TeslaGatewayApiStatusResponse,
+	type TeslaGatewayDiscoveredGateway,
+	type TeslaGatewayGeneratorsResponse,
+	type TeslaGatewayGridStatusResponse,
+	type TeslaGatewayMetersAggregatesResponse,
+	type TeslaGatewayNetworksResponse,
+	type TeslaGatewayOperationResponse,
+	type TeslaGatewayPowerwallsResponse,
+	type TeslaGatewaySiteInfoResponse,
+	type TeslaGatewaySoeResponse,
+	type TeslaGatewaySolarPowerwallResponse,
+	type TeslaGatewaySystemStatusResponse,
+	type TeslaGatewaySystemUpdateStatusResponse,
+} from './types.ts'
+
+const DEFAULT_PASSWORD = 'mock-password'
+const DEFAULT_EMAIL_LABEL = 'kody@local'
+
+export type MockTeslaGatewayState = {
+	gatewayId: string
+	host: string
+	din: string
+	serialNumber: string
+	siteName: string
+	macAddress: string
+	apiStatus: TeslaGatewayApiStatusResponse
+	systemStatus: TeslaGatewaySystemStatusResponse
+	gridStatus: TeslaGatewayGridStatusResponse
+	soe: TeslaGatewaySoeResponse
+	meters: TeslaGatewayMetersAggregatesResponse
+	operation: TeslaGatewayOperationResponse
+	networks: TeslaGatewayNetworksResponse
+	siteInfo: TeslaGatewaySiteInfoResponse
+	powerwalls: TeslaGatewayPowerwallsResponse
+	solarPowerwall: TeslaGatewaySolarPowerwallResponse
+	generators: TeslaGatewayGeneratorsResponse
+	systemUpdateStatus: TeslaGatewaySystemUpdateStatusResponse
+}
+
+const MOCK_HOST_SUFFIX = '.mock.local'
+
+function buildDefaultGateway(input: {
+	gatewayId: string
+	host: string
+	din: string
+	serial: string
+	siteName: string
+	macAddress: string
+	exportLimitKw: number
+}): MockTeslaGatewayState {
+	const exportLimitWatts = input.exportLimitKw * 1_000
+	return {
+		gatewayId: input.gatewayId,
+		host: input.host,
+		din: input.din,
+		serialNumber: input.serial,
+		siteName: input.siteName,
+		macAddress: input.macAddress,
+		apiStatus: {
+			din: input.din,
+			start_time: '2026-04-15 03:42:11 +0000',
+			up_time_seconds: 1_360_201,
+			is_new: false,
+			version: '24.40.10 5d4d8d1d',
+			git_hash: '5d4d8d1d',
+			commission_count: 1,
+			device_type: 'teg',
+			teg_type: 'leader',
+			sync_type: 'leader',
+			cellular_disabled: true,
+			can_reboot: true,
+		},
+		systemStatus: {
+			command_source: 'Configuration',
+			battery_target_power: 0,
+			battery_target_reactive_power: 0,
+			nominal_full_pack_energy: 40_500,
+			nominal_energy_remaining: 28_350,
+			max_charge_power: 25_000,
+			max_discharge_power: 25_000,
+			max_apparent_power: 25_000,
+			instantaneous_max_discharge_power: 25_000,
+			instantaneous_max_charge_power: 25_000,
+			instantaneous_max_apparent_power: 25_000,
+			hardware_capability_charge_power: 27_000,
+			hardware_capability_discharge_power: 27_000,
+			grid_services_power: 0,
+			system_island_state: 'SystemGridConnected',
+			available_blocks: 3,
+			available_charger_blocks: 3,
+			battery_blocks: [],
+			ffr_power_availability_high: 0,
+			ffr_power_availability_low: 0,
+			grid_faults: [],
+			can_reboot: 'Yes',
+			solar_real_power_limit: exportLimitWatts,
+			score: 999,
+			blocks_controlled: 3,
+			primary: true,
+		},
+		gridStatus: {
+			grid_status: 'SystemGridConnected',
+			grid_services_active: false,
+		},
+		soe: {
+			percentage: 70,
+		},
+		meters: {
+			site: {
+				instant_power: -1_200,
+				instant_reactive_power: 0,
+				instant_apparent_power: 1_200,
+				frequency: 60,
+				energy_exported: 1_234_567,
+				energy_imported: 234_567,
+				instant_average_voltage: 240,
+				instant_average_current: 5,
+				num_meters_aggregated: 1,
+			},
+			battery: {
+				instant_power: -2_000,
+				instant_reactive_power: 0,
+				instant_apparent_power: 2_000,
+				frequency: 60,
+				energy_exported: 5_000_000,
+				energy_imported: 4_500_000,
+				instant_average_voltage: 240,
+				instant_average_current: 8,
+				num_meters_aggregated: 3,
+			},
+			load: {
+				instant_power: 3_500,
+				instant_apparent_power: 3_500,
+				frequency: 60,
+				energy_exported: 0,
+				energy_imported: 9_876_543,
+				instant_average_voltage: 240,
+				instant_average_current: 14,
+				num_meters_aggregated: 1,
+			},
+			solar: {
+				instant_power: 6_700,
+				instant_apparent_power: 6_700,
+				frequency: 60,
+				energy_exported: 12_345_678,
+				energy_imported: 0,
+				instant_average_voltage: 240,
+				instant_average_current: 28,
+				num_meters_aggregated: 1,
+			},
+		},
+		operation: {
+			real_mode: 'self_consumption',
+			backup_reserve_percent: 20,
+		},
+		networks: [
+			{
+				network_name: 'EthType',
+				interface: 'eth0',
+				dhcp: true,
+				enabled: true,
+				active: true,
+				primary: true,
+			},
+			{
+				network_name: 'WifiType',
+				interface: 'wlan0',
+				dhcp: true,
+				enabled: true,
+				active: false,
+				primary: false,
+				signal_strength: -56,
+			},
+		],
+		siteInfo: {
+			site_name: input.siteName,
+			timezone: 'America/Denver',
+			max_system_energy_kWh: 40.5,
+			max_system_power_kW: 25,
+			max_site_meter_power_ac: exportLimitWatts,
+			min_site_meter_power_ac: -exportLimitWatts,
+			nominal_system_energy_kWh: 40.5,
+			nominal_system_power_kW: 25,
+			panel_max_current: 200,
+			grid_code: {
+				grid_code: 'IEEE_1547_2018',
+				grid_voltage_setting: 240,
+				grid_freq_setting: 60,
+				grid_phase_setting: 'Split',
+				country: 'United States',
+				state: 'Utah',
+				distributor: 'Rocky Mountain Power',
+				utility: 'Rocky Mountain Power',
+				region: 'IEEE_1547_2018',
+			},
+			measured_frequency: 60,
+		},
+		powerwalls: {
+			enumerating: false,
+			updating: false,
+			checking_if_offgrid: false,
+			running_phase_detection: false,
+			bubble_shedding: false,
+			grid_qualifying: false,
+			grid_code_validating: false,
+			phase_detection_not_available: false,
+			gateway_din: input.din,
+			powerwalls: [
+				{
+					Type: 'ACPW',
+					PackagePartNumber: '2012170-25-E',
+					PackageSerialNumber: 'TG12247200001A',
+					type: 'ACPW',
+					grid_state: 'Compliant',
+					in_config: true,
+				},
+				{
+					Type: 'ACPW',
+					PackagePartNumber: '2012170-25-E',
+					PackageSerialNumber: 'TG12247200002B',
+					type: 'ACPW',
+					grid_state: 'Compliant',
+					in_config: true,
+				},
+				{
+					Type: 'ACPW',
+					PackagePartNumber: '2012170-25-E',
+					PackageSerialNumber: 'TG12247200003C',
+					type: 'ACPW',
+					grid_state: 'Compliant',
+					in_config: true,
+				},
+			],
+		},
+		solarPowerwall: {
+			pvac_status: { state: 'PVAC_Active' },
+			pvs_status: { state: 'PVS_Active' },
+			pvi_status: { state: 'PVI_Active' },
+			power_status: { real_power_w: 6_700 },
+		},
+		generators: {
+			generators: [],
+		},
+		systemUpdateStatus: {
+			state: 'idle',
+			info: { status: ['<update_failed_or_skipped>'] },
+			current_time: 1_716_000_000,
+			version: '24.40.10 5d4d8d1d',
+			offline_updating: false,
+		},
+	}
+}
+
+const mockGateways: Map<string, MockTeslaGatewayState> = new Map()
+const mockPasswords: Map<string, { emailLabel: string; password: string }> =
+	new Map()
+
+function defineDefaultMocks() {
+	const home1 = buildDefaultGateway({
+		gatewayId: 'tesla-gateway-mock-home-1',
+		host: 'tesla-gateway-home-1.mock.local',
+		din: '1232100-00-H--GF22327600010H',
+		serial: 'GF22327600010H',
+		siteName: 'Mock Home 1',
+		macAddress: '90:03:71:11:22:33',
+		exportLimitKw: 25,
+	})
+	const home2 = buildDefaultGateway({
+		gatewayId: 'tesla-gateway-mock-home-2',
+		host: 'tesla-gateway-home-2.mock.local',
+		din: '1232100-00-H--GF22327600011K',
+		serial: 'GF22327600011K',
+		siteName: 'Mock Home 2',
+		macAddress: '90:03:71:44:55:66',
+		exportLimitKw: 25,
+	})
+	mockGateways.set(home1.host, home1)
+	mockGateways.set(home2.host, home2)
+	mockPasswords.set(home1.host, {
+		emailLabel: DEFAULT_EMAIL_LABEL,
+		password: DEFAULT_PASSWORD,
+	})
+	mockPasswords.set(home2.host, {
+		emailLabel: DEFAULT_EMAIL_LABEL,
+		password: DEFAULT_PASSWORD,
+	})
+}
+
+export function resetMockTeslaGatewayState() {
+	mockGateways.clear()
+	mockPasswords.clear()
+	defineDefaultMocks()
+}
+
+defineDefaultMocks()
+
+export function isMockTeslaGatewayHost(host: string) {
+	return host.endsWith(MOCK_HOST_SUFFIX)
+}
+
+export function listMockTeslaGatewayDiscoveryEntries(): Array<TeslaGatewayDiscoveredGateway> {
+	const now = new Date().toISOString()
+	return [...mockGateways.values()].map((gateway) => ({
+		gatewayId: gateway.gatewayId,
+		host: gateway.host,
+		port: 443,
+		din: gateway.din,
+		serialNumber: gateway.serialNumber,
+		macAddress: gateway.macAddress,
+		macOui: gateway.macAddress.split(':').slice(0, 3).join(':'),
+		cert: {
+			subjectCommonName: 'GTW-' + gateway.serialNumber,
+			subjectOrganization: 'Tesla',
+			subjectOrganizationalUnit: 'Tesla Energy Products',
+			issuerCommonName: 'Tesla Manufacturing CA',
+			issuerOrganization: 'Tesla',
+			subjectAltName: 'DNS:teg, DNS:powerwall, DNS:powerpack',
+			fingerprint256: 'mock-fingerprint',
+		},
+		firmwareVersion: gateway.apiStatus.version ?? null,
+		role: 'leader' as const,
+		lastSeenAt: now,
+	}))
+}
+
+function requireMockGateway(host: string) {
+	const state = mockGateways.get(host)
+	if (!state) {
+		throw new Error(`Unknown mock Tesla gateway host "${host}".`)
+	}
+	return state
+}
+
+export function validateMockTeslaCredentials(input: {
+	host: string
+	emailLabel: string
+	password: string
+}) {
+	const stored = mockPasswords.get(input.host)
+	if (!stored) return false
+	return stored.password === input.password
+}
+
+export function getMockTeslaApiStatus(host: string) {
+	return requireMockGateway(host).apiStatus
+}
+
+export function getMockTeslaSystemStatus(host: string) {
+	return requireMockGateway(host).systemStatus
+}
+
+export function getMockTeslaGridStatus(host: string) {
+	return requireMockGateway(host).gridStatus
+}
+
+export function getMockTeslaSoe(host: string) {
+	return requireMockGateway(host).soe
+}
+
+export function getMockTeslaMetersAggregates(host: string) {
+	return requireMockGateway(host).meters
+}
+
+export function getMockTeslaOperation(host: string) {
+	return requireMockGateway(host).operation
+}
+
+export function getMockTeslaNetworks(host: string) {
+	return requireMockGateway(host).networks
+}
+
+export function getMockTeslaSiteInfo(host: string) {
+	return requireMockGateway(host).siteInfo
+}
+
+export function getMockTeslaPowerwalls(host: string) {
+	return requireMockGateway(host).powerwalls
+}
+
+export function getMockTeslaSolarPowerwall(host: string) {
+	return requireMockGateway(host).solarPowerwall
+}
+
+export function getMockTeslaGenerators(host: string) {
+	return requireMockGateway(host).generators
+}
+
+export function getMockTeslaSystemUpdateStatus(host: string) {
+	return requireMockGateway(host).systemUpdateStatus
+}
+
+/**
+ * Test helper to set the export-limit value on a single mock gateway. Used by
+ * unit tests that assert curtailment detection logic.
+ */
+export function setMockTeslaGatewayExportLimitKw(input: {
+	host: string
+	exportLimitKw: number
+}) {
+	const state = requireMockGateway(input.host)
+	const exportLimitWatts = input.exportLimitKw * 1_000
+	state.systemStatus.solar_real_power_limit = exportLimitWatts
+	state.siteInfo.max_site_meter_power_ac = exportLimitWatts
+	state.siteInfo.min_site_meter_power_ac = -exportLimitWatts
+	state.siteInfo.max_system_power_kW = input.exportLimitKw
+}

--- a/packages/home-connector/src/adapters/tesla-gateway/mock-driver.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/mock-driver.ts
@@ -57,8 +57,11 @@ function buildDefaultGateway(input: {
 	siteName: string
 	macAddress: string
 	exportLimitKw: number
+	systemCapacityKw: number
+	meterLimitKw: number
 }): MockTeslaGatewayState {
 	const exportLimitWatts = input.exportLimitKw * 1_000
+	const meterLimitWatts = input.meterLimitKw * 1_000
 	return {
 		gatewayId: input.gatewayId,
 		host: input.host,
@@ -186,9 +189,10 @@ function buildDefaultGateway(input: {
 			site_name: input.siteName,
 			timezone: 'America/Denver',
 			max_system_energy_kWh: 40.5,
-			max_system_power_kW: 25,
-			max_site_meter_power_ac: exportLimitWatts,
-			min_site_meter_power_ac: -exportLimitWatts,
+			max_system_power_kW: input.systemCapacityKw,
+			max_site_export_power_kW: input.exportLimitKw,
+			max_site_meter_power_ac: meterLimitWatts,
+			min_site_meter_power_ac: -meterLimitWatts,
 			nominal_system_energy_kWh: 40.5,
 			nominal_system_power_kW: 25,
 			panel_max_current: 200,
@@ -273,7 +277,9 @@ function defineDefaultMocks() {
 		serial: 'GF22327600010H',
 		siteName: 'Mock Home 1',
 		macAddress: '90:03:71:11:22:33',
-		exportLimitKw: 25,
+		exportLimitKw: 21,
+		systemCapacityKw: 32,
+		meterLimitKw: 40,
 	})
 	const home2 = buildDefaultGateway({
 		gatewayId: 'tesla-gateway-mock-home-2',
@@ -282,7 +288,9 @@ function defineDefaultMocks() {
 		serial: 'GF22327600011K',
 		siteName: 'Mock Home 2',
 		macAddress: '90:03:71:44:55:66',
-		exportLimitKw: 25,
+		exportLimitKw: 21,
+		systemCapacityKw: 32,
+		meterLimitKw: 40,
 	})
 	mockGateways.set(home1.host, home1)
 	mockGateways.set(home2.host, home2)
@@ -410,7 +418,5 @@ export function setMockTeslaGatewayExportLimitKw(input: {
 	const state = requireMockGateway(input.host)
 	const exportLimitWatts = input.exportLimitKw * 1_000
 	state.systemStatus.solar_real_power_limit = exportLimitWatts
-	state.siteInfo.max_site_meter_power_ac = exportLimitWatts
-	state.siteInfo.min_site_meter_power_ac = -exportLimitWatts
-	state.siteInfo.max_system_power_kW = input.exportLimitKw
+	state.siteInfo.max_site_export_power_kW = input.exportLimitKw
 }

--- a/packages/home-connector/src/adapters/tesla-gateway/repository.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/repository.ts
@@ -133,10 +133,11 @@ function mapRow(
 export function toPublicTeslaGateway(
 	gateway: TeslaGatewayPersistedRecord,
 ): TeslaGatewayPublicRecord {
-	const { password, ...rest } = gateway
+	const { customerEmailLabel, password, ...rest } = gateway
 	return {
 		...rest,
 		hasStoredCredentials: password !== null && password !== '',
+		hasCustomCustomerEmailLabel: customerEmailLabel !== DEFAULT_EMAIL_LABEL,
 	}
 }
 
@@ -327,6 +328,7 @@ export function upsertDiscoveredTeslaGateways(
 	storage: HomeConnectorStorage,
 	connectorId: string,
 	gateways: Array<TeslaGatewayDiscoveredGateway>,
+	options: { pruneMissing?: boolean } = {},
 ) {
 	const now = new Date().toISOString()
 	const upsert = getUpsertGatewayStatement(storage)
@@ -354,8 +356,10 @@ export function upsertDiscoveredTeslaGateways(
 			now,
 		)
 	}
-	const ids = JSON.stringify(gateways.map((gateway) => gateway.gatewayId))
-	getDeleteMissingGatewaysStatement(storage).run(connectorId, ids)
+	if (options.pruneMissing ?? true) {
+		const ids = JSON.stringify(gateways.map((gateway) => gateway.gatewayId))
+		getDeleteMissingGatewaysStatement(storage).run(connectorId, ids)
+	}
 	return listTeslaGateways(storage, connectorId)
 }
 

--- a/packages/home-connector/src/adapters/tesla-gateway/repository.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/repository.ts
@@ -1,0 +1,424 @@
+/**
+ * SQLite persistence for discovered/configured Tesla gateways and their
+ * cached customer credentials. Mirrors the lutron repository pattern: device
+ * rows are upserted on every discovery scan; credentials live in a sibling
+ * table protected by AES-256-GCM keyed off `HOME_CONNECTOR_SHARED_SECRET`.
+ */
+import {
+	createCipheriv,
+	createDecipheriv,
+	createHash,
+	randomBytes,
+} from 'node:crypto'
+import { type HomeConnectorStorage } from '../../storage/index.ts'
+import {
+	type TeslaGatewayDiscoveredGateway,
+	type TeslaGatewayPersistedRecord,
+	type TeslaGatewayPublicRecord,
+} from './types.ts'
+
+type TeslaGatewayRow = {
+	connector_id: string
+	gateway_id: string
+	host: string
+	port: number
+	din: string | null
+	serial_number: string | null
+	mac_address: string | null
+	mac_oui: string | null
+	cert_subject_cn: string | null
+	cert_subject_o: string | null
+	cert_subject_ou: string | null
+	cert_issuer_cn: string | null
+	cert_issuer_o: string | null
+	cert_san: string | null
+	cert_fingerprint_sha256: string | null
+	firmware_version: string | null
+	role: string | null
+	last_seen_at: string | null
+	label: string | null
+	customer_email_label: string | null
+	password: string | null
+	last_authenticated_at: string | null
+	last_auth_error: string | null
+}
+
+const PASSWORD_PREFIX = 'enc:v1:'
+const PASSWORD_AUTH_TAG_BYTES = 16
+const DEFAULT_EMAIL_LABEL = 'kody@local'
+
+function getPasswordKey(sharedSecret: string) {
+	return createHash('sha256').update(sharedSecret).digest()
+}
+
+function encryptPassword(password: string, sharedSecret: string | null) {
+	if (!sharedSecret) {
+		throw new Error(
+			'Cannot store Tesla gateway credentials without HOME_CONNECTOR_SHARED_SECRET.',
+		)
+	}
+	const iv = randomBytes(12)
+	const key = getPasswordKey(sharedSecret)
+	const cipher = createCipheriv('aes-256-gcm', key, iv)
+	const encrypted = Buffer.concat([
+		cipher.update(password, 'utf8'),
+		cipher.final(),
+	])
+	const tag = cipher.getAuthTag()
+	return `${PASSWORD_PREFIX}${iv.toString('base64')}:${tag.toString('base64')}:${encrypted.toString('base64')}`
+}
+
+function decryptPassword(password: string | null, sharedSecret: string | null) {
+	if (!password || !password.startsWith(PASSWORD_PREFIX)) {
+		return password
+	}
+	if (!sharedSecret) return null
+	const payload = password.slice(PASSWORD_PREFIX.length)
+	const [ivBase64, tagBase64, encryptedBase64] = payload.split(':')
+	if (!ivBase64 || !tagBase64 || !encryptedBase64) return null
+	try {
+		const key = getPasswordKey(sharedSecret)
+		const iv = Buffer.from(ivBase64, 'base64')
+		const tag = Buffer.from(tagBase64, 'base64')
+		const encrypted = Buffer.from(encryptedBase64, 'base64')
+		if (iv.length !== 12 || tag.length !== PASSWORD_AUTH_TAG_BYTES) return null
+		const decipher = createDecipheriv('aes-256-gcm', key, iv)
+		decipher.setAuthTag(tag)
+		const decrypted = Buffer.concat([
+			decipher.update(encrypted),
+			decipher.final(),
+		])
+		return decrypted.toString('utf8')
+	} catch {
+		return null
+	}
+}
+
+function mapRow(
+	storage: HomeConnectorStorage,
+	row: TeslaGatewayRow,
+): TeslaGatewayPersistedRecord {
+	return {
+		gatewayId: row.gateway_id,
+		host: row.host,
+		port: row.port,
+		din: row.din,
+		serialNumber: row.serial_number,
+		macAddress: row.mac_address,
+		macOui: row.mac_oui,
+		cert:
+			row.cert_subject_cn || row.cert_subject_o
+				? {
+						subjectCommonName: row.cert_subject_cn,
+						subjectOrganization: row.cert_subject_o,
+						subjectOrganizationalUnit: row.cert_subject_ou,
+						issuerCommonName: row.cert_issuer_cn,
+						issuerOrganization: row.cert_issuer_o,
+						subjectAltName: row.cert_san,
+						fingerprint256: row.cert_fingerprint_sha256,
+					}
+				: null,
+		firmwareVersion: row.firmware_version,
+		role:
+			row.role === 'leader' || row.role === 'follower' ? row.role : 'unknown',
+		lastSeenAt: row.last_seen_at ?? new Date(0).toISOString(),
+		label: row.label,
+		customerEmailLabel: row.customer_email_label ?? DEFAULT_EMAIL_LABEL,
+		password: decryptPassword(row.password, storage.sharedSecret),
+		lastAuthenticatedAt: row.last_authenticated_at,
+		lastAuthError: row.last_auth_error,
+	}
+}
+
+export function toPublicTeslaGateway(
+	gateway: TeslaGatewayPersistedRecord,
+): TeslaGatewayPublicRecord {
+	const { password, ...rest } = gateway
+	return {
+		...rest,
+		hasStoredCredentials: password !== null && password !== '',
+	}
+}
+
+function selectRows(storage: HomeConnectorStorage, connectorId: string) {
+	const statement = storage.db.query(`
+		SELECT
+			gateway.connector_id,
+			gateway.gateway_id,
+			gateway.host,
+			gateway.port,
+			gateway.din,
+			gateway.serial_number,
+			gateway.mac_address,
+			gateway.mac_oui,
+			gateway.cert_subject_cn,
+			gateway.cert_subject_o,
+			gateway.cert_subject_ou,
+			gateway.cert_issuer_cn,
+			gateway.cert_issuer_o,
+			gateway.cert_san,
+			gateway.cert_fingerprint_sha256,
+			gateway.firmware_version,
+			gateway.role,
+			gateway.last_seen_at,
+			gateway.label,
+			credentials.customer_email_label,
+			credentials.password,
+			credentials.last_authenticated_at,
+			credentials.last_auth_error
+		FROM tesla_gateways AS gateway
+		LEFT JOIN tesla_gateway_credentials AS credentials
+			ON credentials.connector_id = gateway.connector_id
+			AND credentials.gateway_id = gateway.gateway_id
+		WHERE gateway.connector_id = ?
+		ORDER BY gateway.label COLLATE NOCASE, gateway.gateway_id
+	`)
+	return statement.all(connectorId) as Array<TeslaGatewayRow>
+}
+
+function getUpsertGatewayStatement(storage: HomeConnectorStorage) {
+	return storage.db.query(`
+		INSERT INTO tesla_gateways (
+			connector_id,
+			gateway_id,
+			host,
+			port,
+			din,
+			serial_number,
+			mac_address,
+			mac_oui,
+			cert_subject_cn,
+			cert_subject_o,
+			cert_subject_ou,
+			cert_issuer_cn,
+			cert_issuer_o,
+			cert_san,
+			cert_fingerprint_sha256,
+			firmware_version,
+			role,
+			last_seen_at,
+			label,
+			updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(connector_id, gateway_id) DO UPDATE SET
+			host = excluded.host,
+			port = excluded.port,
+			din = COALESCE(excluded.din, tesla_gateways.din),
+			serial_number = COALESCE(excluded.serial_number, tesla_gateways.serial_number),
+			mac_address = COALESCE(excluded.mac_address, tesla_gateways.mac_address),
+			mac_oui = COALESCE(excluded.mac_oui, tesla_gateways.mac_oui),
+			cert_subject_cn = excluded.cert_subject_cn,
+			cert_subject_o = excluded.cert_subject_o,
+			cert_subject_ou = excluded.cert_subject_ou,
+			cert_issuer_cn = excluded.cert_issuer_cn,
+			cert_issuer_o = excluded.cert_issuer_o,
+			cert_san = excluded.cert_san,
+			cert_fingerprint_sha256 = excluded.cert_fingerprint_sha256,
+			firmware_version = COALESCE(excluded.firmware_version, tesla_gateways.firmware_version),
+			role = excluded.role,
+			last_seen_at = excluded.last_seen_at,
+			updated_at = excluded.updated_at
+	`)
+}
+
+function getDeleteMissingGatewaysStatement(storage: HomeConnectorStorage) {
+	return storage.db.query(`
+		DELETE FROM tesla_gateways AS gateway
+		WHERE gateway.connector_id = ?
+			AND gateway.gateway_id NOT IN (
+				SELECT value FROM json_each(?)
+			)
+			AND NOT EXISTS (
+				SELECT 1 FROM tesla_gateway_credentials AS credentials
+				WHERE credentials.connector_id = gateway.connector_id
+					AND credentials.gateway_id = gateway.gateway_id
+			)
+	`)
+}
+
+function getUpsertCredentialsStatement(storage: HomeConnectorStorage) {
+	return storage.db.query(`
+		INSERT INTO tesla_gateway_credentials (
+			connector_id,
+			gateway_id,
+			customer_email_label,
+			password,
+			last_authenticated_at,
+			last_auth_error,
+			updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(connector_id, gateway_id) DO UPDATE SET
+			customer_email_label = excluded.customer_email_label,
+			password = excluded.password,
+			last_authenticated_at = excluded.last_authenticated_at,
+			last_auth_error = excluded.last_auth_error,
+			updated_at = excluded.updated_at
+	`)
+}
+
+function getUpdateAuthStatusStatement(storage: HomeConnectorStorage) {
+	return storage.db.query(`
+		UPDATE tesla_gateway_credentials
+		SET last_authenticated_at = ?,
+			last_auth_error = ?,
+			updated_at = CURRENT_TIMESTAMP
+		WHERE connector_id = ? AND gateway_id = ?
+	`)
+}
+
+function getUpdateLabelStatement(storage: HomeConnectorStorage) {
+	return storage.db.query(`
+		UPDATE tesla_gateways
+		SET label = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE connector_id = ? AND gateway_id = ?
+	`)
+}
+
+function getUpdateGatewayMetadataStatement(storage: HomeConnectorStorage) {
+	return storage.db.query(`
+		UPDATE tesla_gateways
+		SET din = COALESCE(?, din),
+			serial_number = COALESCE(?, serial_number),
+			firmware_version = COALESCE(?, firmware_version),
+			updated_at = CURRENT_TIMESTAMP
+		WHERE connector_id = ? AND gateway_id = ?
+	`)
+}
+
+export function listTeslaGateways(
+	storage: HomeConnectorStorage,
+	connectorId: string,
+) {
+	return selectRows(storage, connectorId).map((row) => mapRow(storage, row))
+}
+
+export function listPublicTeslaGateways(
+	storage: HomeConnectorStorage,
+	connectorId: string,
+) {
+	return listTeslaGateways(storage, connectorId).map(toPublicTeslaGateway)
+}
+
+export function getTeslaGateway(
+	storage: HomeConnectorStorage,
+	connectorId: string,
+	gatewayId: string,
+) {
+	return (
+		listTeslaGateways(storage, connectorId).find(
+			(gateway) => gateway.gatewayId === gatewayId,
+		) ?? null
+	)
+}
+
+export function requireTeslaGateway(
+	storage: HomeConnectorStorage,
+	connectorId: string,
+	gatewayId: string,
+) {
+	const gateway = getTeslaGateway(storage, connectorId, gatewayId)
+	if (!gateway) {
+		throw new Error(`Tesla gateway "${gatewayId}" was not found.`)
+	}
+	return gateway
+}
+
+export function upsertDiscoveredTeslaGateways(
+	storage: HomeConnectorStorage,
+	connectorId: string,
+	gateways: Array<TeslaGatewayDiscoveredGateway>,
+) {
+	const now = new Date().toISOString()
+	const upsert = getUpsertGatewayStatement(storage)
+	for (const gateway of gateways) {
+		upsert.run(
+			connectorId,
+			gateway.gatewayId,
+			gateway.host,
+			gateway.port,
+			gateway.din,
+			gateway.serialNumber,
+			gateway.macAddress,
+			gateway.macOui,
+			gateway.cert?.subjectCommonName ?? null,
+			gateway.cert?.subjectOrganization ?? null,
+			gateway.cert?.subjectOrganizationalUnit ?? null,
+			gateway.cert?.issuerCommonName ?? null,
+			gateway.cert?.issuerOrganization ?? null,
+			gateway.cert?.subjectAltName ?? null,
+			gateway.cert?.fingerprint256 ?? null,
+			gateway.firmwareVersion,
+			gateway.role,
+			gateway.lastSeenAt,
+			null,
+			now,
+		)
+	}
+	const ids = JSON.stringify(gateways.map((gateway) => gateway.gatewayId))
+	getDeleteMissingGatewaysStatement(storage).run(connectorId, ids)
+	return listTeslaGateways(storage, connectorId)
+}
+
+export function saveTeslaGatewayCredentials(input: {
+	storage: HomeConnectorStorage
+	connectorId: string
+	gatewayId: string
+	customerEmailLabel?: string
+	password: string
+}) {
+	const now = new Date().toISOString()
+	getUpsertCredentialsStatement(input.storage).run(
+		input.connectorId,
+		input.gatewayId,
+		input.customerEmailLabel ?? DEFAULT_EMAIL_LABEL,
+		encryptPassword(input.password, input.storage.sharedSecret),
+		null,
+		null,
+		now,
+	)
+}
+
+export function updateTeslaGatewayAuthStatus(input: {
+	storage: HomeConnectorStorage
+	connectorId: string
+	gatewayId: string
+	lastAuthenticatedAt: string | null
+	lastAuthError: string | null
+}) {
+	getUpdateAuthStatusStatement(input.storage).run(
+		input.lastAuthenticatedAt,
+		input.lastAuthError,
+		input.connectorId,
+		input.gatewayId,
+	)
+}
+
+export function setTeslaGatewayLabel(input: {
+	storage: HomeConnectorStorage
+	connectorId: string
+	gatewayId: string
+	label: string | null
+}) {
+	getUpdateLabelStatement(input.storage).run(
+		input.label,
+		input.connectorId,
+		input.gatewayId,
+	)
+}
+
+export function updateTeslaGatewayMetadata(input: {
+	storage: HomeConnectorStorage
+	connectorId: string
+	gatewayId: string
+	din?: string | null
+	serialNumber?: string | null
+	firmwareVersion?: string | null
+}) {
+	getUpdateGatewayMetadataStatement(input.storage).run(
+		input.din ?? null,
+		input.serialNumber ?? null,
+		input.firmwareVersion ?? null,
+		input.connectorId,
+		input.gatewayId,
+	)
+}

--- a/packages/home-connector/src/adapters/tesla-gateway/types.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/types.ts
@@ -1,0 +1,332 @@
+/**
+ * Types for the Tesla Backup Gateway 2 (and Powerwall+ leader gateway) local
+ * HTTPS API. Endpoints are exposed at `https://<gateway-ip>/api/...` over a
+ * self-signed TLS cert with subject `O=Tesla, OU=Tesla Energy Products` and a
+ * SAN list including `DNS:teg`, `DNS:powerwall`, and `DNS:powerpack`.
+ *
+ * Customer-scope endpoints accept `username: "customer"` against
+ * `POST /api/login/Basic`. Installer-scope endpoints (`/api/installer`,
+ * `/api/config`) require installer credentials and are not exercised here.
+ */
+
+export type TeslaGatewayDiscoveryProtocol = 'subnet' | 'mdns' | 'json'
+
+export type TeslaGatewayCertSummary = {
+	subjectCommonName: string | null
+	subjectOrganization: string | null
+	subjectOrganizationalUnit: string | null
+	issuerCommonName: string | null
+	issuerOrganization: string | null
+	subjectAltName: string | null
+	fingerprint256: string | null
+}
+
+export type TeslaGatewayHostProbe = {
+	host: string
+	port: number
+	tcpOpen: boolean
+	cert: TeslaGatewayCertSummary | null
+	macAddress: string | null
+	macOui: string | null
+	identifiedAsTesla: boolean
+	identifiedAsLeader: boolean
+	loginEndpointResponse: {
+		status: number
+		bodyPreview: string | null
+	} | null
+	error: string | null
+}
+
+export type TeslaGatewaySubnetProbeSummary = {
+	cidrs: Array<string>
+	hostsProbed: number
+	teslaMatches: number
+	leaderMatches: number
+}
+
+export type TeslaGatewayDiscoveryDiagnostics = {
+	protocol: TeslaGatewayDiscoveryProtocol
+	discoveryUrl: string
+	scannedAt: string
+	jsonResponse: Record<string, unknown> | null
+	hostProbes: Array<TeslaGatewayHostProbe>
+	subnetProbe: TeslaGatewaySubnetProbeSummary | null
+	errors: Array<string>
+}
+
+export type TeslaGatewayDiscoveredGateway = {
+	gatewayId: string
+	host: string
+	port: number
+	/**
+	 * Only present after a successful `customer` login (or a mock fixture). The
+	 * gateway DIN looks like `1232100-00-H--GF22327600010P`, where the segment
+	 * after `--` is the BGW serial.
+	 */
+	din: string | null
+	serialNumber: string | null
+	macAddress: string | null
+	macOui: string | null
+	cert: TeslaGatewayCertSummary | null
+	firmwareVersion: string | null
+	role: 'leader' | 'follower' | 'unknown'
+	lastSeenAt: string
+}
+
+export type TeslaGatewayDiscoveryResult = {
+	gateways: Array<TeslaGatewayDiscoveredGateway>
+	diagnostics: TeslaGatewayDiscoveryDiagnostics
+}
+
+export type TeslaGatewayPersistedRecord = TeslaGatewayDiscoveredGateway & {
+	label: string | null
+	customerEmailLabel: string
+	password: string | null
+	lastAuthenticatedAt: string | null
+	lastAuthError: string | null
+}
+
+export type TeslaGatewayPublicRecord = Omit<
+	TeslaGatewayPersistedRecord,
+	'password'
+> & {
+	hasStoredCredentials: boolean
+}
+
+export type TeslaGatewayLoginResponse = {
+	cookies: Array<string>
+	cookieHeader: string
+	token: string | null
+	email: string | null
+	loginTimeIso: string | null
+	expiresAtIso: string | null
+}
+
+export type TeslaGatewayApiStatusResponse = {
+	din?: string
+	start_time?: string
+	up_time_seconds?: string | number
+	is_new?: boolean
+	version?: string
+	git_hash?: string
+	commission_count?: number
+	device_type?: string
+	teg_type?: string
+	sync_type?: string
+	cellular_disabled?: boolean
+	can_reboot?: boolean
+	[key: string]: unknown
+}
+
+export type TeslaGatewayInverterReport = {
+	device_id?: string
+	din?: string
+	is_active?: boolean
+	power_w?: number
+	[key: string]: unknown
+}
+
+export type TeslaGatewaySystemStatusResponse = {
+	command_source?: string
+	battery_target_power?: number
+	battery_target_reactive_power?: number
+	nominal_full_pack_energy?: number
+	nominal_energy_remaining?: number
+	max_power_energy_remaining?: number
+	max_power_energy_to_be_charged?: number
+	max_charge_power?: number
+	max_discharge_power?: number
+	max_apparent_power?: number
+	instantaneous_max_discharge_power?: number
+	instantaneous_max_charge_power?: number
+	instantaneous_max_apparent_power?: number
+	hardware_capability_charge_power?: number
+	hardware_capability_discharge_power?: number
+	grid_services_power?: number
+	system_island_state?: string
+	available_blocks?: number
+	available_charger_blocks?: number
+	battery_blocks?: Array<Record<string, unknown>>
+	ffr_power_availability_high?: number
+	ffr_power_availability_low?: number
+	load_charge_constraint?: number
+	max_sustained_ramp_rate?: number
+	grid_faults?: Array<Record<string, unknown>>
+	can_reboot?: string
+	smart_inv_delta_p?: number
+	smart_inv_delta_q?: number
+	last_toggle_timestamp?: string
+	solar_real_power_limit?: number
+	score?: number
+	blocks_controlled?: number
+	primary?: boolean
+	auxiliary_load?: number
+	all_enable_lines_high?: boolean
+	inverter_nominal_usable_power?: number
+	expected_energy_remaining?: number
+	[key: string]: unknown
+}
+
+export type TeslaGatewayGridStatusResponse = {
+	grid_status?: string
+	grid_services_active?: boolean
+	[key: string]: unknown
+}
+
+export type TeslaGatewaySoeResponse = {
+	percentage?: number
+	[key: string]: unknown
+}
+
+export type TeslaGatewayMeterAggregate = {
+	last_communication_time?: string
+	instant_power?: number
+	instant_reactive_power?: number
+	instant_apparent_power?: number
+	frequency?: number
+	energy_exported?: number
+	energy_imported?: number
+	instant_average_voltage?: number
+	instant_average_current?: number
+	i_a_current?: number
+	i_b_current?: number
+	i_c_current?: number
+	last_phase_voltage_communication_time?: string
+	last_phase_power_communication_time?: string
+	last_phase_energy_communication_time?: string
+	timeout?: number
+	num_meters_aggregated?: number
+	instant_total_current?: number
+	[key: string]: unknown
+}
+
+export type TeslaGatewayMetersAggregatesResponse = {
+	site?: TeslaGatewayMeterAggregate
+	battery?: TeslaGatewayMeterAggregate
+	load?: TeslaGatewayMeterAggregate
+	solar?: TeslaGatewayMeterAggregate
+	[key: string]: TeslaGatewayMeterAggregate | undefined
+}
+
+export type TeslaGatewayOperationResponse = {
+	real_mode?: string
+	backup_reserve_percent?: number
+	[key: string]: unknown
+}
+
+export type TeslaGatewayNetworkInterface = {
+	network_name?: string
+	interface?: string
+	dhcp?: boolean
+	enabled?: boolean
+	active?: boolean
+	primary?: boolean
+	lastTeslaConnected?: boolean
+	lastInternetConnected?: boolean
+	signal_strength?: number
+	[key: string]: unknown
+}
+
+export type TeslaGatewayNetworksResponse = Array<TeslaGatewayNetworkInterface>
+
+export type TeslaGatewaySiteInfoResponse = {
+	max_system_energy_kWh?: number
+	max_system_power_kW?: number
+	site_name?: string
+	timezone?: string
+	max_site_meter_power_ac?: number
+	min_site_meter_power_ac?: number
+	nominal_system_energy_kWh?: number
+	nominal_system_power_kW?: number
+	panel_max_current?: number
+	grid_code?: {
+		grid_code?: string
+		grid_voltage_setting?: number
+		grid_freq_setting?: number
+		grid_phase_setting?: string
+		country?: string
+		state?: string
+		distributor?: string
+		utility?: string
+		retailer?: string
+		region?: string
+		[key: string]: unknown
+	}
+	measured_frequency?: number
+	[key: string]: unknown
+}
+
+export type TeslaGatewayPowerwallEntry = {
+	Type?: string
+	PackagePartNumber?: string
+	PackageSerialNumber?: string
+	type?: string
+	grid_state?: string
+	commissioning_diagnostic?: Record<string, unknown>
+	update_diagnostic?: Record<string, unknown>
+	bc_type?: string | null
+	in_config?: boolean
+	[key: string]: unknown
+}
+
+export type TeslaGatewayPowerwallsResponse = {
+	enumerating?: boolean
+	updating?: boolean
+	checking_if_offgrid?: boolean
+	running_phase_detection?: boolean
+	phase_detection_last_error?: string
+	bubble_shedding?: boolean
+	on_grid_check_error?: string
+	grid_qualifying?: boolean
+	grid_code_validating?: boolean
+	phase_detection_not_available?: boolean
+	powerwalls?: Array<TeslaGatewayPowerwallEntry>
+	gateway_din?: string
+	sync?: Record<string, unknown>
+	msa?: Record<string, unknown>
+	states?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+export type TeslaGatewaySolarPowerwallResponse = {
+	pvac_status?: Record<string, unknown>
+	pvs_status?: Record<string, unknown>
+	pvi_status?: Record<string, unknown>
+	mppt_status?: Record<string, unknown>
+	power_status?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+export type TeslaGatewayGeneratorsResponse = {
+	generators?: Array<Record<string, unknown>>
+	[key: string]: unknown
+}
+
+export type TeslaGatewaySystemUpdateStatusResponse = {
+	state?: string
+	info?: { status?: Array<string>; [key: string]: unknown }
+	current_time?: number
+	last_status_time?: number
+	version?: string
+	offline_updating?: boolean
+	offline_update_error?: string
+	estimated_bytes_per_second?: number
+	[key: string]: unknown
+}
+
+export type TeslaGatewayLiveSnapshot = {
+	gateway: TeslaGatewayPublicRecord
+	status: TeslaGatewayApiStatusResponse | null
+	systemStatus: TeslaGatewaySystemStatusResponse | null
+	gridStatus: TeslaGatewayGridStatusResponse | null
+	soe: TeslaGatewaySoeResponse | null
+	meters: TeslaGatewayMetersAggregatesResponse | null
+	operation: TeslaGatewayOperationResponse | null
+	networks: TeslaGatewayNetworksResponse | null
+	siteInfo: TeslaGatewaySiteInfoResponse | null
+	powerwalls: TeslaGatewayPowerwallsResponse | null
+	solarPowerwall: TeslaGatewaySolarPowerwallResponse | null
+	generators: TeslaGatewayGeneratorsResponse | null
+	systemUpdateStatus: TeslaGatewaySystemUpdateStatusResponse | null
+	fetchErrors: Record<string, string>
+}

--- a/packages/home-connector/src/adapters/tesla-gateway/types.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/types.ts
@@ -88,9 +88,10 @@ export type TeslaGatewayPersistedRecord = TeslaGatewayDiscoveredGateway & {
 
 export type TeslaGatewayPublicRecord = Omit<
 	TeslaGatewayPersistedRecord,
-	'password'
+	'password' | 'customerEmailLabel'
 > & {
 	hasStoredCredentials: boolean
+	hasCustomCustomerEmailLabel: boolean
 }
 
 export type TeslaGatewayLoginResponse = {
@@ -232,6 +233,7 @@ export type TeslaGatewayNetworksResponse = Array<TeslaGatewayNetworkInterface>
 export type TeslaGatewaySiteInfoResponse = {
 	max_system_energy_kWh?: number
 	max_system_power_kW?: number
+	max_site_export_power_kW?: number
 	site_name?: string
 	timezone?: string
 	max_site_meter_power_ac?: number

--- a/packages/home-connector/src/adapters/venstar/discovery.node.test.ts
+++ b/packages/home-connector/src/adapters/venstar/discovery.node.test.ts
@@ -18,6 +18,8 @@ function createConfig(scanCidrs: Array<string>): HomeConnectorConfig {
 		jellyfishDiscoveryUrl: null,
 		venstarScanCidrs: scanCidrs,
 		jellyfishScanCidrs: ['192.168.10.93/32'],
+		teslaGatewayScanCidrs: [],
+		teslaGatewayDiscoveryUrl: null,
 		dataPath: '/tmp',
 		dbPath: ':memory:',
 		port: 4040,

--- a/packages/home-connector/src/config.ts
+++ b/packages/home-connector/src/config.ts
@@ -25,6 +25,19 @@ export type HomeConnectorConfig = {
 	 * discovery feed.
 	 */
 	jellyfishScanCidrs: Array<string>
+	/**
+	 * Tesla Backup Gateway 2 leaders are discovered by HTTPS port-443 sweeps
+	 * across these CIDRs combined with TLS-cert subject inspection. When unset,
+	 * the connector derives private `/24` networks from local interfaces.
+	 * `TESLA_GATEWAY_SCAN_CIDRS` overrides the derived list.
+	 */
+	teslaGatewayScanCidrs: Array<string>
+	/**
+	 * Optional JSON discovery feed for Tesla gateways. When set to a URL,
+	 * discovery skips the LAN sweep and reads `{ gateways: [...] }` instead.
+	 * Used by the dev/mock server (`http://tesla-gateway.mock.local/discovery`).
+	 */
+	teslaGatewayDiscoveryUrl: string | null
 	dataPath: string
 	dbPath: string
 	port: number
@@ -193,6 +206,11 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 		explicitJellyfishCidrs.length > 0
 			? explicitJellyfishCidrs
 			: deriveJellyfishAutoscanCidrs()
+	const explicitTeslaCidrs = resolveScanCidrsFromEnv('TESLA_GATEWAY_SCAN_CIDRS')
+	const teslaGatewayScanCidrs =
+		explicitTeslaCidrs.length > 0
+			? explicitTeslaCidrs
+			: derivePrivateAutoscanCidrsFromInterfaces(networkInterfaces())
 	return {
 		homeConnectorId,
 		workerBaseUrl,
@@ -214,6 +232,9 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 		jellyfishDiscoveryUrl: process.env.JELLYFISH_DISCOVERY_URL?.trim() || null,
 		venstarScanCidrs,
 		jellyfishScanCidrs,
+		teslaGatewayScanCidrs,
+		teslaGatewayDiscoveryUrl:
+			process.env.TESLA_GATEWAY_DISCOVERY_URL?.trim() || null,
 		dataPath,
 		dbPath: resolveHomeConnectorDbPath(dataPath),
 		port: Number.isFinite(port) ? port : 4040,

--- a/packages/home-connector/src/config.ts
+++ b/packages/home-connector/src/config.ts
@@ -206,9 +206,12 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 		explicitJellyfishCidrs.length > 0
 			? explicitJellyfishCidrs
 			: deriveJellyfishAutoscanCidrs()
+	const teslaGatewayDiscoveryUrl =
+		process.env.TESLA_GATEWAY_DISCOVERY_URL?.trim() || null
 	const explicitTeslaCidrs = resolveScanCidrsFromEnv('TESLA_GATEWAY_SCAN_CIDRS')
-	const teslaGatewayScanCidrs =
-		explicitTeslaCidrs.length > 0
+	const teslaGatewayScanCidrs = teslaGatewayDiscoveryUrl
+		? explicitTeslaCidrs
+		: explicitTeslaCidrs.length > 0
 			? explicitTeslaCidrs
 			: derivePrivateAutoscanCidrsFromInterfaces(networkInterfaces())
 	return {
@@ -233,8 +236,7 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 		venstarScanCidrs,
 		jellyfishScanCidrs,
 		teslaGatewayScanCidrs,
-		teslaGatewayDiscoveryUrl:
-			process.env.TESLA_GATEWAY_DISCOVERY_URL?.trim() || null,
+		teslaGatewayDiscoveryUrl,
 		dataPath,
 		dbPath: resolveHomeConnectorDbPath(dataPath),
 		port: Number.isFinite(port) ? port : 4040,

--- a/packages/home-connector/src/index.ts
+++ b/packages/home-connector/src/index.ts
@@ -2,6 +2,7 @@ import { createBondAdapter } from './adapters/bond/index.ts'
 import { createJellyfishAdapter } from './adapters/jellyfish/index.ts'
 import { createLutronAdapter } from './adapters/lutron/index.ts'
 import { createSonosAdapter } from './adapters/sonos/index.ts'
+import { createTeslaGatewayAdapter } from './adapters/tesla-gateway/index.ts'
 import { createVenstarAdapter } from './adapters/venstar/index.ts'
 import { createSamsungTvAdapter } from './adapters/samsung-tv/index.ts'
 import { createHomeConnectorMcpServer } from './mcp/server.ts'
@@ -46,6 +47,7 @@ export function createHomeConnectorApp() {
 		storage,
 	})
 	const venstar = createVenstarAdapter({ config, state, storage })
+	const teslaGateway = createTeslaGatewayAdapter({ config, state, storage })
 	const mcp = createHomeConnectorMcpServer({
 		config,
 		state,
@@ -55,6 +57,7 @@ export function createHomeConnectorApp() {
 		bond,
 		jellyfish,
 		venstar,
+		teslaGateway,
 	})
 	const workerConnector = createWorkerConnector({
 		config,
@@ -72,6 +75,7 @@ export function createHomeConnectorApp() {
 		bond,
 		jellyfish,
 		venstar,
+		teslaGateway,
 		mcp,
 		workerConnector,
 	}

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -5,6 +5,7 @@ import { createJellyfishAdapter } from '../adapters/jellyfish/index.ts'
 import { createLutronAdapter } from '../adapters/lutron/index.ts'
 import { createSonosAdapter } from '../adapters/sonos/index.ts'
 import { createSamsungTvAdapter } from '../adapters/samsung-tv/index.ts'
+import { createTeslaGatewayAdapter } from '../adapters/tesla-gateway/index.ts'
 import { createVenstarAdapter } from '../adapters/venstar/index.ts'
 import { upsertVenstarThermostat } from '../adapters/venstar/repository.ts'
 import { loadHomeConnectorConfig } from '../config.ts'
@@ -67,6 +68,7 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		storage,
 	})
 	const venstar = createVenstarAdapter({ config, state, storage })
+	const teslaGateway = createTeslaGatewayAdapter({ config, state, storage })
 	await samsungTv.scan()
 	await lutron.scan()
 	await sonos.scan()
@@ -80,6 +82,7 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		bond,
 		jellyfish,
 		venstar,
+		teslaGateway,
 	})
 
 	try {

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -147,6 +147,17 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		expect(
 			tools.some((tool) => tool.name === 'venstar_control_thermostat'),
 		).toBe(true)
+		for (const toolName of [
+			'tesla_gateway_scan',
+			'tesla_gateway_list',
+			'tesla_gateway_set_credentials',
+			'tesla_gateway_authenticate',
+			'tesla_gateway_live_snapshot',
+			'tesla_gateway_find_export_limit',
+			'tesla_gateway_find_all_export_limits',
+		]) {
+			expect(tools.some((tool) => tool.name === toolName)).toBe(true)
+		}
 		const bondAuthGuide = await mcp.callTool('bond_authentication_guide')
 		expect(bondAuthGuide.content[0]?.type).toBe('text')
 		expect(bondAuthGuide.structuredContent).toMatchObject({
@@ -254,6 +265,55 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		expect(venstarScan.structuredContent).toMatchObject({
 			discovered: expect.any(Array),
 			diagnostics: expect.anything(),
+		})
+		const teslaScan = await mcp.callTool('tesla_gateway_scan')
+		expect(teslaScan.structuredContent).toMatchObject({
+			gateways: expect.any(Array),
+			diagnostics: expect.anything(),
+		})
+		const teslaGateways = await mcp.callTool('tesla_gateway_list')
+		expect(teslaGateways.structuredContent).toMatchObject({
+			gateways: expect.arrayContaining([
+				expect.objectContaining({
+					gatewayId: 'tesla-gateway-mock-home-1',
+					hasStoredCredentials: false,
+				}),
+			]),
+		})
+		await mcp.callTool('tesla_gateway_set_credentials', {
+			gatewayId: 'tesla-gateway-mock-home-1',
+			password: 'mock-password',
+			customerEmailLabel: '   ',
+		})
+		const teslaExportLimit = await mcp.callTool(
+			'tesla_gateway_find_export_limit',
+			{ gatewayId: 'tesla-gateway-mock-home-1' },
+		)
+		expect(teslaExportLimit.structuredContent).toMatchObject({
+			gatewayId: 'tesla-gateway-mock-home-1',
+			exportLimitKw: 21,
+			source: 'site_info.max_site_export_power_kW',
+		})
+		const teslaAuthedGateways = await mcp.callTool('tesla_gateway_list')
+		expect(teslaAuthedGateways.structuredContent).toMatchObject({
+			gateways: expect.arrayContaining([
+				expect.objectContaining({
+					gatewayId: 'tesla-gateway-mock-home-1',
+					hasStoredCredentials: true,
+					hasCustomCustomerEmailLabel: false,
+				}),
+			]),
+		})
+		const teslaGatewaysAfterCredentials =
+			await mcp.callTool('tesla_gateway_list')
+		expect(teslaGatewaysAfterCredentials.structuredContent).toMatchObject({
+			gateways: expect.arrayContaining([
+				expect.objectContaining({
+					gatewayId: 'tesla-gateway-mock-home-1',
+					hasStoredCredentials: true,
+					hasCustomCustomerEmailLabel: false,
+				}),
+			]),
 		})
 		const addedVenstar = await mcp.callTool('venstar_add_thermostat', {
 			ip: '192.168.10.41',

--- a/packages/home-connector/src/mcp/server.ts
+++ b/packages/home-connector/src/mcp/server.ts
@@ -10,6 +10,7 @@ import { isLutronProcessorNotFoundError } from '../adapters/lutron/errors.ts'
 import { type createLutronAdapter } from '../adapters/lutron/index.ts'
 import { type createSonosAdapter } from '../adapters/sonos/index.ts'
 import { type createSamsungTvAdapter } from '../adapters/samsung-tv/index.ts'
+import { type createTeslaGatewayAdapter } from '../adapters/tesla-gateway/index.ts'
 import { type createVenstarAdapter } from '../adapters/venstar/index.ts'
 import { type HomeConnectorConfig } from '../config.ts'
 import { registerBondHomeConnectorTools } from './register-bond-tools.ts'
@@ -73,6 +74,7 @@ export function createHomeConnectorMcpServer(input: {
 	bond: ReturnType<typeof createBondAdapter>
 	jellyfish: ReturnType<typeof createJellyfishAdapter>
 	venstar: ReturnType<typeof createVenstarAdapter>
+	teslaGateway: ReturnType<typeof createTeslaGatewayAdapter>
 }): HomeConnectorMcpServer {
 	const roku = createRokuAdapter({
 		config: input.config,
@@ -84,6 +86,7 @@ export function createHomeConnectorMcpServer(input: {
 	const bond = input.bond
 	const jellyfish = input.jellyfish
 	const venstar = input.venstar
+	const teslaGateway = input.teslaGateway
 
 	const server = new McpServer(
 		{
@@ -92,7 +95,7 @@ export function createHomeConnectorMcpServer(input: {
 		},
 		{
 			instructions:
-				'Home connector MCP server. Tools support Roku, Samsung TV, Lutron, Sonos, Bond (Olibra Bond Bridge / shades, groups, and RF devices), JellyFish Lighting, and Venstar WiFi thermostat control and diagnostics. Bond local API tokens are configured only in the admin UI (/bond/setup); use bond_authentication_guide when you need a reminder.',
+				'Home connector MCP server. Tools support Roku, Samsung TV, Lutron, Sonos, Bond (Olibra Bond Bridge / shades, groups, and RF devices), JellyFish Lighting, Venstar WiFi thermostats, and Tesla Backup Gateway 2 (Powerwall+ leader) local-API reads. Bond local API tokens and Tesla gateway customer passwords are saved through the admin UI (/bond/setup, /tesla-gateway/setup); use bond_authentication_guide or tesla_gateway_set_credentials when you need to wire them up.',
 		},
 	)
 
@@ -2791,6 +2794,203 @@ export function createHomeConnectorMcpServer(input: {
 		bond,
 		config: input.config,
 	})
+
+	registerTool(
+		{
+			name: 'tesla_gateway_scan',
+			title: 'Scan Tesla Gateways',
+			description:
+				'Scan the local network for Tesla Backup Gateway 2 (BGW2) leaders, persist any matches, and return the discovery diagnostics. Identifies leaders via TLS cert subject + SAN combined with MAC OUI 90:03:71. Powerwall units (OUI 00:d6:cb) are filtered out so only the leader gateways remain.',
+			inputSchema: {},
+		},
+		async () => {
+			const gateways = await teslaGateway.scan()
+			const status = teslaGateway.getStatus()
+			return structuredTextResult(
+				gateways.length === 0
+					? 'No Tesla gateways were discovered.'
+					: `Discovered ${gateways.length} Tesla gateway(s).`,
+				{
+					gateways,
+					diagnostics: status.diagnostics,
+				},
+			)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'tesla_gateway_list',
+			title: 'List Tesla Gateways',
+			description:
+				'List persisted Tesla gateways with their host, DIN, serial, MAC, and credential status. Does not contact the gateways.',
+			inputSchema: {},
+			annotations: {
+				readOnlyHint: true,
+				idempotentHint: true,
+			},
+		},
+		async () => {
+			const gateways = teslaGateway.listGateways()
+			return structuredTextResult(
+				gateways.length === 0
+					? 'No Tesla gateways are currently known.'
+					: gateways
+							.map(
+								(gateway) =>
+									`- ${gateway.label ?? gateway.gatewayId} (${gateway.host}) credentials=${gateway.hasStoredCredentials ? 'set' : 'missing'}`,
+							)
+							.join('\n'),
+				{ gateways },
+			)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'tesla_gateway_set_credentials',
+			title: 'Save Tesla Gateway Customer Credentials',
+			description:
+				'Save the customer-role local API password (from the gateway sticker, or whatever the installer set) for a discovered gateway. The "email" field on the Tesla local login is just an audit label; pass any value or omit it to use kody@local.',
+			...buildToolInputSchema(
+				markSecretInputFields(
+					z.object({
+						gatewayId: z.string().min(1),
+						password: z
+							.string()
+							.min(1)
+							.describe('Customer-role gateway password.'),
+						customerEmailLabel: z
+							.string()
+							.optional()
+							.describe(
+								'Optional audit label; defaults to "kody@local". The Tesla gateway does not validate this against tesla.com.',
+							),
+					}),
+					['password'],
+				),
+			),
+		},
+		async (args) => {
+			const gateway = teslaGateway.setCredentials({
+				gatewayId: String(args['gatewayId'] ?? ''),
+				password: String(args['password'] ?? ''),
+				...(typeof args['customerEmailLabel'] === 'string'
+					? { customerEmailLabel: args['customerEmailLabel'] }
+					: {}),
+			})
+			return structuredTextResult(
+				`Saved Tesla gateway credentials for ${gateway.gatewayId}.`,
+				{ gateway },
+			)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'tesla_gateway_authenticate',
+			title: 'Authenticate Tesla Gateway',
+			description:
+				'Authenticate against POST /api/login/Basic for a single gateway and cache the resulting session cookie. Returns the public gateway record. Use this to verify a freshly saved password before pulling a live snapshot.',
+			...buildToolInputSchema({
+				gatewayId: z.string().min(1),
+			}),
+		},
+		async (args) => {
+			const gateway = await teslaGateway.authenticate(
+				String(args['gatewayId'] ?? ''),
+			)
+			return structuredTextResult(
+				`Authenticated Tesla gateway ${gateway.gatewayId}.`,
+				{ gateway },
+			)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'tesla_gateway_live_snapshot',
+			title: 'Tesla Gateway Live Snapshot',
+			description:
+				'Fetch every customer-scope endpoint for one gateway in a single call: /api/status, /api/system_status, /api/system_status/grid_status, /api/system_status/soe, /api/meters/aggregates, /api/operation, /api/networks, /api/site_info, /api/powerwalls, /api/solar_powerwall, /api/generators, /api/system/update/status. Errors per endpoint are bucketed under fetchErrors so partial results are still returned.',
+			...buildToolInputSchema({
+				gatewayId: z.string().min(1),
+			}),
+			annotations: {
+				readOnlyHint: true,
+				idempotentHint: true,
+			},
+		},
+		async (args) => {
+			const snapshot = await teslaGateway.getLiveSnapshot(
+				String(args['gatewayId'] ?? ''),
+			)
+			const errorCount = Object.keys(snapshot.fetchErrors).length
+			return structuredTextResult(
+				errorCount === 0
+					? `Loaded full Tesla gateway snapshot for ${snapshot.gateway.gatewayId}.`
+					: `Loaded Tesla gateway snapshot for ${snapshot.gateway.gatewayId} with ${errorCount} per-endpoint error(s).`,
+				snapshot,
+			)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'tesla_gateway_find_export_limit',
+			title: 'Find Tesla Gateway Site Export Limit',
+			description:
+				'Look up the most likely "site export limit" value for one gateway. Prefers site_info.max_site_meter_power_ac, falls back to system_status.solar_real_power_limit, and finally site_info.max_system_power_kW. Useful for confirming a 25 kW (or other) export cap programmed by the installer.',
+			...buildToolInputSchema({
+				gatewayId: z.string().min(1),
+			}),
+			annotations: {
+				readOnlyHint: true,
+				idempotentHint: true,
+			},
+		},
+		async (args) => {
+			const info = await teslaGateway.findExportLimit(
+				String(args['gatewayId'] ?? ''),
+			)
+			return structuredTextResult(
+				info.exportLimitKw === null
+					? `Could not determine a site export limit for ${info.gatewayId}.`
+					: `Site export limit for ${info.gatewayId} appears to be ${info.exportLimitKw} kW (source: ${info.source}).`,
+				info,
+			)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'tesla_gateway_find_all_export_limits',
+			title: 'Find Site Export Limits Across All Gateways',
+			description:
+				'Run findExportLimit across every persisted gateway and return one entry per gateway. Failed gateways are returned with exportLimitKw=null and source="unknown".',
+			inputSchema: {},
+			annotations: {
+				readOnlyHint: true,
+				idempotentHint: true,
+			},
+		},
+		async () => {
+			const results = await teslaGateway.findAllExportLimits()
+			return structuredTextResult(
+				results.length === 0
+					? 'No Tesla gateways are configured.'
+					: results
+							.map(
+								(entry) =>
+									`- ${entry.gatewayId} (${entry.siteName ?? 'no label'}): ${
+										entry.exportLimitKw ?? 'unknown'
+									} kW [${entry.source}]`,
+							)
+							.join('\n'),
+				{ results },
+			)
+		},
+	)
 
 	return {
 		server,

--- a/packages/home-connector/src/mcp/server.ts
+++ b/packages/home-connector/src/mcp/server.ts
@@ -2872,12 +2872,14 @@ export function createHomeConnectorMcpServer(input: {
 			),
 		},
 		async (args) => {
+			const customerEmailLabel =
+				typeof args['customerEmailLabel'] === 'string'
+					? args['customerEmailLabel'].trim()
+					: ''
 			const gateway = teslaGateway.setCredentials({
 				gatewayId: String(args['gatewayId'] ?? ''),
 				password: String(args['password'] ?? ''),
-				...(typeof args['customerEmailLabel'] === 'string'
-					? { customerEmailLabel: args['customerEmailLabel'] }
-					: {}),
+				...(customerEmailLabel ? { customerEmailLabel } : {}),
 			})
 			return structuredTextResult(
 				`Saved Tesla gateway credentials for ${gateway.gatewayId}.`,

--- a/packages/home-connector/src/state.ts
+++ b/packages/home-connector/src/state.ts
@@ -14,6 +14,7 @@ import {
 	type VenstarDiscoveredThermostat,
 	type VenstarDiscoveryDiagnostics,
 } from './adapters/venstar/types.ts'
+import { type TeslaGatewayDiscoveryDiagnostics } from './adapters/tesla-gateway/types.ts'
 
 export type HomeConnectorConnectionState = {
 	workerUrl: string
@@ -37,6 +38,7 @@ export type HomeConnectorState = {
 	jellyfishDiscoveredControllers: Array<JellyfishDiscoveredController>
 	venstarDiscoveryDiagnostics: VenstarDiscoveryDiagnostics | null
 	venstarDiscoveredThermostats: Array<VenstarDiscoveredThermostat>
+	teslaGatewayDiscoveryDiagnostics: TeslaGatewayDiscoveryDiagnostics | null
 }
 
 const initialState: HomeConnectorState = {
@@ -59,6 +61,7 @@ const initialState: HomeConnectorState = {
 	jellyfishDiscoveredControllers: [],
 	venstarDiscoveryDiagnostics: null,
 	venstarDiscoveredThermostats: [],
+	teslaGatewayDiscoveryDiagnostics: null,
 }
 
 export function createAppState(): HomeConnectorState {
@@ -154,6 +157,14 @@ export function setVenstarDiscoveredThermostats(
 ) {
 	state.venstarDiscoveredThermostats = [...thermostats]
 	return state.venstarDiscoveredThermostats
+}
+
+export function setTeslaGatewayDiscoveryDiagnostics(
+	state: HomeConnectorState,
+	diagnostics: TeslaGatewayDiscoveryDiagnostics | null,
+) {
+	state.teslaGatewayDiscoveryDiagnostics = diagnostics
+	return state.teslaGatewayDiscoveryDiagnostics
 }
 
 export function getDiscoveredRokuDevices(state: HomeConnectorState) {

--- a/packages/home-connector/src/storage/index.node.test.ts
+++ b/packages/home-connector/src/storage/index.node.test.ts
@@ -38,6 +38,8 @@ function createConfig(dbPath: string) {
 		jellyfishDiscoveryUrl: 'http://jellyfish.mock.local/discovery',
 		venstarScanCidrs: ['192.168.10.40/32'],
 		jellyfishScanCidrs: ['192.168.10.93/32'],
+		teslaGatewayScanCidrs: [],
+		teslaGatewayDiscoveryUrl: null,
 		dataPath: path.dirname(dbPath),
 		dbPath,
 		port: 4040,

--- a/packages/home-connector/src/storage/index.ts
+++ b/packages/home-connector/src/storage/index.ts
@@ -177,6 +177,44 @@ function initializeSchema(db: SqliteDatabase) {
 			updated_at TEXT NOT NULL,
 			PRIMARY KEY (connector_id, ip)
 		);
+
+		CREATE TABLE IF NOT EXISTS tesla_gateways (
+			connector_id TEXT NOT NULL,
+			gateway_id TEXT NOT NULL,
+			host TEXT NOT NULL,
+			port INTEGER NOT NULL DEFAULT 443,
+			din TEXT,
+			serial_number TEXT,
+			mac_address TEXT,
+			mac_oui TEXT,
+			cert_subject_cn TEXT,
+			cert_subject_o TEXT,
+			cert_subject_ou TEXT,
+			cert_issuer_cn TEXT,
+			cert_issuer_o TEXT,
+			cert_san TEXT,
+			cert_fingerprint_sha256 TEXT,
+			firmware_version TEXT,
+			role TEXT,
+			last_seen_at TEXT,
+			label TEXT,
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY (connector_id, gateway_id)
+		);
+
+		CREATE TABLE IF NOT EXISTS tesla_gateway_credentials (
+			connector_id TEXT NOT NULL,
+			gateway_id TEXT NOT NULL,
+			customer_email_label TEXT NOT NULL,
+			password TEXT NOT NULL,
+			last_authenticated_at TEXT,
+			last_auth_error TEXT,
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY (connector_id, gateway_id),
+			FOREIGN KEY (connector_id, gateway_id)
+				REFERENCES tesla_gateways(connector_id, gateway_id)
+				ON DELETE CASCADE
+		);
 	`)
 }
 

--- a/packages/worker/src/storage-runner.workers.test.ts
+++ b/packages/worker/src/storage-runner.workers.test.ts
@@ -132,24 +132,20 @@ test('storage runner supports raw SQL with explicit writable access', async () =
 
 test('storage runner blocks mutating SQL when writable is false', async () => {
 	const storageId = createExecuteStorageId()
-	const runner = storageRunnerRpc({
-		env,
-		userId: 'user-123',
-		storageId,
-	})
+	const stub = env.STORAGE_RUNNER.get(
+		env.STORAGE_RUNNER.idFromName(JSON.stringify(['user-123', storageId])),
+	)
 
-	try {
-		await runner.sqlQuery({
-			query: 'delete from counters',
-			writable: false,
-		})
-		throw new Error('Expected read-only SQL mutation to fail.')
-	} catch (error) {
-		expect(error).toBeInstanceOf(Error)
-		expect((error as Error).message).toBe(
+	await runInDurableObject(stub, async (instance: StorageRunner) => {
+		await expect(
+			instance.sqlQuery({
+				query: 'delete from counters',
+				writable: false,
+			}),
+		).rejects.toThrow(
 			'Read-only storage.sql only allows a single SELECT, EXPLAIN, or schema PRAGMA statement. Pass writable: true to allow multi-statement or mutating queries.',
 		)
-	}
+	})
 })
 
 test('storage runner blocks multi-statement SQL in read-only mode', async () => {
@@ -165,18 +161,19 @@ test('storage runner blocks multi-statement SQL in read-only mode', async () => 
 		value: 1,
 	})
 
-	try {
-		await runner.sqlQuery({
-			query: 'select 1 as ok; delete from sqlite_schema',
-			writable: false,
-		})
-		throw new Error('Expected multi-statement read-only SQL to fail.')
-	} catch (error) {
-		expect(error).toBeInstanceOf(Error)
-		expect((error as Error).message).toBe(
+	const stub = env.STORAGE_RUNNER.get(
+		env.STORAGE_RUNNER.idFromName(JSON.stringify(['user-123', storageId])),
+	)
+	await runInDurableObject(stub, async (instance: StorageRunner) => {
+		await expect(
+			instance.sqlQuery({
+				query: 'select 1 as ok; delete from sqlite_schema',
+				writable: false,
+			}),
+		).rejects.toThrow(
 			'Read-only storage.sql only allows a single SELECT, EXPLAIN, or schema PRAGMA statement. Pass writable: true to allow multi-statement or mutating queries.',
 		)
-	}
+	})
 
 	await expect(
 		runner.getValue({


### PR DESCRIPTION
## Summary

Adds a `tesla-gateway` adapter to the home connector so Kody can authenticate to local Tesla Backup Gateway 2 (BGW2) leaders, pull the customer-scope endpoints, and surface the programmed site export limit. This unlocks data the cloud Tesla Fleet API doesn't expose — most notably the installer-configured `max_site_export_power_kW` value and per-meter live data.

## What's in the box

- **Adapter** at `packages/home-connector/src/adapters/tesla-gateway/`:
  - `discovery.ts` — phased LAN scan: TCP-probe `:443` → re-read ARP → TLS-cert + bad-credential probe. Identifies BGW2 leaders by `O=Tesla, OU=Tesla Energy Products` cert + MAC OUI `90:03:71`, and demotes Powerwall units (OUI `00:d6:cb`) so callers only see leaders.
  - `gateway-client.ts` — HTTP client with self-signed-TLS handling, `AuthCookie` / `UserRecord` cookie management, and rate-limit awareness (treats `/api/login/Basic` timeouts as cooldown signals).
  - `repository.ts` — SQLite persistence for discovered gateways and AES-256-GCM-encrypted credentials, gated on `HOME_CONNECTOR_SHARED_SECRET`.
  - `mock-driver.ts` — in-process fixtures for two BGW2 leaders with a 25 kW export cap, used whenever a host ends in `.mock.local`.
  - `index.ts` — `scan()`, `setCredentials()`, `authenticate()`, `getLiveSnapshot()`, `findExportLimit()`, `findAllExportLimits()`.
- **MCP tools**: `tesla_gateway_scan`, `tesla_gateway_list`, `tesla_gateway_set_credentials` (password marked `x-kody-secret`), `tesla_gateway_authenticate`, `tesla_gateway_live_snapshot`, `tesla_gateway_find_export_limit`, `tesla_gateway_find_all_export_limits`.
- **UI**: new `/tesla-gateway/status` and `/tesla-gateway/setup` routes; gateway counts surfaced on the home dashboard.
- **Mocks**: MSW handlers for the JSON discovery feed (`http://tesla-gateway.mock.local/discovery`); dev-server wires `TESLA_GATEWAY_DISCOVERY_URL` to it automatically.
- **Storage schema**: new `tesla_gateways` and `tesla_gateway_credentials` tables.
- **Config**: `TESLA_GATEWAY_SCAN_CIDRS` and `TESLA_GATEWAY_DISCOVERY_URL` env vars; documented in `docs/contributing/environment-variables.md`.
- **Architecture docs**: new "Tesla Backup Gateway 2 integration" section in `docs/contributing/architecture/home-connector.md`.

## Why phased discovery

Initial implementation read the kernel ARP cache once up front, before TCP probes ran. On a cold ARP cache, that meant freshly resolved hosts had `macAddress: null` and the OUI heuristic couldn't distinguish BGW2 leaders from Powerwall units. The refactor splits `scanSubnets` into:

1. Snapshot ARP (catches pre-warmed entries)
2. TCP-probe every target in parallel (concurrency 64) — this triggers L2 ARP resolution at the kernel
3. Re-read ARP and merge with the snapshot
4. TLS + login probe at concurrency 8 only on hosts with TCP open (lower concurrency keeps login probes from looking like a flood to per-IP rate limiters)

Verified against a live LAN with 4 Tesla devices: only the actual BGW2 leader (OUI `90:03:71`) is reported as a leader; the 3 Powerwalls (OUI `00:d6:cb`) are correctly demoted despite presenting the same cert SAN.

## Test plan

- [x] `npx vitest run --root . --project node-unit packages/home-connector` — 17 files / 68 tests pass.
- [x] `npx oxlint packages/home-connector docs` — 0 warnings, 0 errors.
- [x] Pre-commit `tsc -b --noEmit` and pre-push `test-e2e` both pass via nx.
- [x] Live LAN scan against the author's network correctly identified one BGW2 leader at `192.168.0.213` and demoted three paired Powerwall units.
- [ ] Live authenticated round-trip — pending Tesla Energy Customer Support reply with the `customer`-role password (or installer-side reset). Adapter behavior validated end-to-end against the mock driver in the meantime.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new network-scanning adapter that stores encrypted customer credentials and talks to a self-signed HTTPS API, increasing risk around local-network probing and secret handling despite being scoped to the home connector.
> 
> **Overview**
> Adds a new `tesla-gateway` home-connector integration that can **discover BGW2 leader gateways** (subnet TCP/TLS/ARP heuristics or a JSON discovery feed), **store customer credentials encrypted**, authenticate with cached cookies + rate-limit cooldown tracking, and fetch a consolidated **live snapshot** of customer-scope `/api/...` endpoints including export-limit detection.
> 
> Wires this into the connector end-to-end: new admin routes (`/tesla-gateway/status` + `/tesla-gateway/setup`) with same-origin POST protection, dashboard counts/links, new MCP tools (`tesla_gateway_*`), dev/test mocks (JSON feed MSW + in-process mock driver), new SQLite tables (`tesla_gateways`, `tesla_gateway_credentials`), config/env support (`TESLA_GATEWAY_SCAN_CIDRS`, `TESLA_GATEWAY_DISCOVERY_URL`), and updates docs/tests accordingly (plus a small Worker `StorageRunner` test refactor to assert errors via a DO instance stub).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc147d5c6d24f867cc42597d48c6e0ec914643ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tesla Backup Gateway 2 and Powerwall+ local API integration with automatic LAN discovery
  * Introduced customer credential storage, authentication, and session management
  * Added live data retrieval for system status, energy metrics, and operation details
  * Implemented export limit detection and management
  * Added admin UI pages for gateway status and configuration
  * Enabled gateway discovery via LAN scanning or external JSON feed

* **Documentation**
  * Updated architecture and environment variable documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->