### PR TITLE
Address Tesla gateway review feedback

### DIFF
--- a/packages/home-connector/app/router.node.test.ts
+++ b/packages/home-connector/app/router.node.test.ts
@@ -316,6 +316,92 @@ test('venstar setup can save and remove thermostats directly', async () => {
 	}
 })
 
+test('tesla gateway status rejects cross-origin mutations and renders live snapshots', async () => {
+	const dataPath = createTemporaryDataPath()
+	const config = createConfig(dataPath)
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		jellyfish,
+		venstar,
+		teslaGateway,
+	} = createAdapters(config)
+	try {
+		const router = createHomeConnectorRouter(
+			state,
+			config,
+			lutron,
+			samsungTv,
+			sonos,
+			bond,
+			jellyfish,
+			venstar,
+			teslaGateway,
+		)
+
+		const rejectedResponse = await router.fetch(
+			'http://example.test/tesla-gateway/status',
+			{
+				method: 'POST',
+				headers: {
+					'content-type': 'application/x-www-form-urlencoded',
+					origin: 'http://evil.example',
+				},
+				body: 'action=scan',
+			},
+		)
+		expect(rejectedResponse.status).toBe(403)
+
+		await router.fetch('http://example.test/tesla-gateway/status', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/x-www-form-urlencoded',
+				origin: 'http://example.test',
+			},
+			body: 'action=scan',
+		})
+		await router.fetch('http://example.test/tesla-gateway/setup', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/x-www-form-urlencoded',
+				origin: 'http://example.test',
+			},
+			body: new URLSearchParams({
+				action: 'save-credentials',
+				gatewayId: 'tesla-gateway-mock-home-1',
+				password: 'mock-password',
+			}).toString(),
+		})
+		const snapshotResponse = await router.fetch(
+			'http://example.test/tesla-gateway/status',
+			{
+				method: 'POST',
+				headers: {
+					'content-type': 'application/x-www-form-urlencoded',
+					origin: 'http://example.test',
+				},
+				body: new URLSearchParams({
+					action: 'fetch-snapshot',
+					gatewayId: 'tesla-gateway-mock-home-1',
+				}).toString(),
+			},
+		)
+
+		expect(snapshotResponse.status).toBe(200)
+		const html = await snapshotResponse.text()
+		expect(html).toContain('Action result')
+		expect(html).toContain('max_site_export_power_kW')
+		expect(html).toContain('meters')
+	} finally {
+		storage.close()
+		rmSync(dataPath, { recursive: true, force: true })
+	}
+})
+
 test('health route returns ok json', async () => {
 	const config = createConfig()
 	const {

--- a/packages/home-connector/app/tesla-gateway-handlers.ts
+++ b/packages/home-connector/app/tesla-gateway-handlers.ts
@@ -5,6 +5,7 @@ import { type HomeConnectorConfig } from '../src/config.ts'
 import { type createTeslaGatewayAdapter } from '../src/adapters/tesla-gateway/index.ts'
 import {
 	type TeslaGatewayDiscoveryDiagnostics,
+	type TeslaGatewayLiveSnapshot,
 	type TeslaGatewayPublicRecord,
 } from '../src/adapters/tesla-gateway/types.ts'
 import { type HomeConnectorState } from '../src/state.ts'
@@ -43,6 +44,32 @@ async function readPostedFormData(request: Request, fallbackAction: string) {
 	return formData
 }
 
+function validateSameOriginPost(request: Request) {
+	const requestOrigin = new URL(request.url).origin
+	const origin = request.headers.get('origin')
+	if (origin) {
+		if (origin === requestOrigin) return
+		throw new Response('Forbidden', { status: 403 })
+	}
+	const referer = request.headers.get('referer')
+	if (referer && new URL(referer).origin === requestOrigin) return
+	throw new Response('Forbidden', { status: 403 })
+}
+
+function summarizeLiveSnapshot(snapshot: TeslaGatewayLiveSnapshot) {
+	return {
+		gateway: snapshot.gateway,
+		status: snapshot.status,
+		systemStatus: snapshot.systemStatus,
+		gridStatus: snapshot.gridStatus,
+		soe: snapshot.soe,
+		meters: snapshot.meters,
+		operation: snapshot.operation,
+		siteInfo: snapshot.siteInfo,
+		fetchErrors: snapshot.fetchErrors,
+	}
+}
+
 async function handleTeslaGatewayMutation(input: {
 	action: string
 	formData: FormData
@@ -54,6 +81,7 @@ async function handleTeslaGatewayMutation(input: {
 		const gateways = await teslaGateway.scan()
 		return {
 			message: `Scan complete. ${gateways.length} gateway(s) known.`,
+			details: null,
 		}
 	}
 
@@ -62,6 +90,7 @@ async function handleTeslaGatewayMutation(input: {
 		const gateway = await teslaGateway.authenticate(gatewayId)
 		return {
 			message: `Authenticated against ${gateway.host} (${gateway.gatewayId}).`,
+			details: null,
 		}
 	}
 
@@ -74,6 +103,7 @@ async function handleTeslaGatewayMutation(input: {
 				errorCount === 0
 					? `Pulled live snapshot for ${snapshot.gateway.gatewayId}.`
 					: `Pulled snapshot for ${snapshot.gateway.gatewayId} with ${errorCount} per-endpoint error(s).`,
+			details: summarizeLiveSnapshot(snapshot),
 		}
 	}
 
@@ -85,6 +115,7 @@ async function handleTeslaGatewayMutation(input: {
 				info.exportLimitKw === null
 					? `Could not determine an export limit for ${info.gatewayId}.`
 					: `${info.gatewayId} export limit ≈ ${info.exportLimitKw} kW (source: ${info.source}).`,
+			details: null,
 		}
 	}
 
@@ -101,6 +132,7 @@ async function handleTeslaGatewayMutation(input: {
 		})
 		return {
 			message: `Saved credentials for ${gateway.host} (${gateway.gatewayId}).`,
+			details: null,
 		}
 	}
 
@@ -116,6 +148,7 @@ async function handleTeslaGatewayMutation(input: {
 			message: label
 				? `Set label for ${gatewayId} to "${label}".`
 				: `Cleared label for ${gatewayId}.`,
+			details: null,
 		}
 	}
 
@@ -256,6 +289,7 @@ function renderTeslaGatewayPage(input: {
 	includeSetupForm?: boolean
 	scanMessage?: string | null
 	scanError?: string | null
+	resultDetails?: unknown
 }) {
 	const status = input.teslaGateway.getStatus()
 	return render(
@@ -311,6 +345,12 @@ function renderTeslaGatewayPage(input: {
 					: ''}
 				${input.scanError
 					? renderBanner({ tone: 'error', message: input.scanError })
+					: ''}
+				${input.resultDetails
+					? html`<section class="card">
+							<h2>Action result</h2>
+							${renderCodeBlock(formatJson(input.resultDetails))}
+						</section>`
 					: ''}
 				<section class="card">
 					<h2>Configured gateways</h2>
@@ -405,12 +445,13 @@ function buildHandler(input: {
 		middleware: [],
 		async handler({ request }: { request: Request }) {
 			if (request.method === 'POST') {
-				const formData = await readPostedFormData(request, 'scan')
-				const action =
-					typeof formData.get('action') === 'string'
-						? String(formData.get('action'))
-						: 'scan'
 				try {
+					validateSameOriginPost(request)
+					const formData = await readPostedFormData(request, 'scan')
+					const action =
+						typeof formData.get('action') === 'string'
+							? String(formData.get('action'))
+							: 'scan'
 					const result = await handleTeslaGatewayMutation({
 						action,
 						formData,
@@ -423,12 +464,13 @@ function buildHandler(input: {
 						title: input.title,
 						includeSetupForm: input.includeSetupForm,
 						scanMessage: result.message,
+						resultDetails: result.details,
 					})
 				} catch (error) {
+					if (error instanceof Response) return error
 					captureHomeConnectorException(error, {
 						tags: {
 							route: `/tesla-gateway/${input.route}`,
-							action,
 						},
 						contexts: {
 							teslaGateway: {

--- a/packages/home-connector/src/adapters/tesla-gateway/discovery.node.test.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/discovery.node.test.ts
@@ -7,6 +7,7 @@ const {
 	isTeslaCert,
 	probeLooksLikeTesla,
 	ouiFromMac,
+	validateJsonGateway,
 	TESLA_LEADER_OUIS,
 	TESLA_POWERWALL_OUIS,
 } = __testing
@@ -139,4 +140,31 @@ test('decideLeaderStatus uses OUI as the authoritative leader signal', () => {
 			ouiIsPowerwall: false,
 		}),
 	).toBe(false)
+})
+
+test('validateJsonGateway rejects malformed discovery feed entries', () => {
+	expect(
+		validateJsonGateway({
+			gatewayId: 'tesla-gateway-home-1',
+			host: '192.168.1.10',
+			port: 443,
+			role: 'leader',
+			lastSeenAt: '2026-05-01T00:00:00.000Z',
+		}),
+	).toMatchObject({
+		gatewayId: 'tesla-gateway-home-1',
+		host: '192.168.1.10',
+		port: 443,
+		role: 'leader',
+	})
+	expect(
+		validateJsonGateway({ gatewayId: 'missing-host', port: 443 }),
+	).toBeNull()
+	expect(
+		validateJsonGateway({
+			gatewayId: 'bad-port',
+			host: '192.168.1.10',
+			port: '443',
+		}),
+	).toBeNull()
 })

--- a/packages/home-connector/src/adapters/tesla-gateway/discovery.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/discovery.ts
@@ -47,6 +47,7 @@ const DEFAULT_PORT = 443
 const TCP_PROBE_TIMEOUT_MS = 1_000
 const TLS_PROBE_TIMEOUT_MS = 3_000
 const LOGIN_PROBE_TIMEOUT_MS = 4_000
+const JSON_DISCOVERY_TIMEOUT_MS = 5_000
 const SUBNET_MAX_HOSTS = 254
 const TESLA_LEADER_OUIS = new Set(['90:03:71'])
 const TESLA_POWERWALL_OUIS = new Set(['00:d6:cb'])
@@ -357,7 +358,7 @@ async function probeHost(input: {
 }
 
 function buildGatewayId(input: { host: string; macAddress: string | null }) {
-	const base = input.macAddress ?? input.host
+	const base = input.host
 	return `tesla-gateway-${base.replaceAll(/[^a-zA-Z0-9]+/g, '-').toLowerCase()}`
 }
 
@@ -504,13 +505,75 @@ function resolveScanCidrs(config: HomeConnectorConfig): Array<string> {
 	return derivePrivateAutoscanCidrsFromInterfaces(networkInterfaces())
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function nullableString(value: unknown) {
+	return typeof value === 'string' ? value : null
+}
+
+function validateJsonGateway(
+	value: unknown,
+): TeslaGatewayDiscoveredGateway | null {
+	if (!isRecord(value)) return null
+	if (
+		typeof value.gatewayId !== 'string' ||
+		value.gatewayId.trim().length === 0 ||
+		typeof value.host !== 'string' ||
+		value.host.trim().length === 0 ||
+		typeof value.port !== 'number' ||
+		!Number.isInteger(value.port)
+	) {
+		return null
+	}
+	const role =
+		value.role === 'leader' || value.role === 'follower'
+			? value.role
+			: 'unknown'
+	const cert = isRecord(value.cert)
+		? {
+				subjectCommonName: nullableString(value.cert.subjectCommonName),
+				subjectOrganization: nullableString(value.cert.subjectOrganization),
+				subjectOrganizationalUnit: nullableString(
+					value.cert.subjectOrganizationalUnit,
+				),
+				issuerCommonName: nullableString(value.cert.issuerCommonName),
+				issuerOrganization: nullableString(value.cert.issuerOrganization),
+				subjectAltName: nullableString(value.cert.subjectAltName),
+				fingerprint256: nullableString(value.cert.fingerprint256),
+			}
+		: null
+	return {
+		gatewayId: value.gatewayId.trim(),
+		host: value.host.trim(),
+		port: value.port,
+		din: nullableString(value.din),
+		serialNumber: nullableString(value.serialNumber),
+		macAddress: nullableString(value.macAddress),
+		macOui: nullableString(value.macOui),
+		cert,
+		firmwareVersion: nullableString(value.firmwareVersion),
+		role,
+		lastSeenAt:
+			typeof value.lastSeenAt === 'string'
+				? value.lastSeenAt
+				: new Date().toISOString(),
+	}
+}
+
 async function discoverFromJson(
 	discoveryUrl: string,
 ): Promise<TeslaGatewayDiscoveryResult> {
 	const errors: Array<string> = []
 	let payload: Record<string, unknown> | null = null
+	let timeout: ReturnType<typeof setTimeout> | null = null
 	try {
-		const response = await fetch(discoveryUrl)
+		const controller = new AbortController()
+		timeout = setTimeout(() => {
+			controller.abort()
+		}, JSON_DISCOVERY_TIMEOUT_MS)
+		const response = await fetch(discoveryUrl, { signal: controller.signal })
 		if (!response.ok) {
 			errors.push(
 				`Tesla discovery feed returned HTTP ${response.status} for ${discoveryUrl}`,
@@ -519,11 +582,28 @@ async function discoverFromJson(
 			payload = (await response.json()) as Record<string, unknown>
 		}
 	} catch (error) {
-		errors.push(error instanceof Error ? error.message : String(error))
+		errors.push(
+			error instanceof Error && error.name === 'AbortError'
+				? `Tesla discovery feed timed out after ${JSON_DISCOVERY_TIMEOUT_MS}ms for ${discoveryUrl}`
+				: error instanceof Error
+					? error.message
+					: String(error),
+		)
+	} finally {
+		if (timeout) clearTimeout(timeout)
 	}
-	const gateways = Array.isArray(payload?.['gateways'])
-		? (payload['gateways'] as Array<TeslaGatewayDiscoveredGateway>)
+	const rawGateways = Array.isArray(payload?.['gateways'])
+		? payload['gateways']
 		: []
+	const gateways: Array<TeslaGatewayDiscoveredGateway> = []
+	for (const [index, rawGateway] of rawGateways.entries()) {
+		const gateway = validateJsonGateway(rawGateway)
+		if (gateway) {
+			gateways.push(gateway)
+		} else {
+			errors.push(`Tesla discovery feed gateway[${index}] is invalid.`)
+		}
+	}
 	return {
 		gateways,
 		diagnostics: {
@@ -582,6 +662,7 @@ export const __testing = {
 	decideLeaderStatus,
 	expandSlash24,
 	isTeslaCert,
+	validateJsonGateway,
 	probeLooksLikeTesla,
 	ouiFromMac,
 	TESLA_LEADER_OUIS,

--- a/packages/home-connector/src/adapters/tesla-gateway/gateway-client.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/gateway-client.ts
@@ -49,11 +49,6 @@ export type TeslaGatewayCredentials = {
 	password: string
 }
 
-export type TeslaGatewayClientHost = {
-	host: string
-	port?: number
-}
-
 export type TeslaGatewayHttpResponse<T> = {
 	status: number
 	body: T | null

--- a/packages/home-connector/src/adapters/tesla-gateway/index.node.test.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/index.node.test.ts
@@ -82,6 +82,8 @@ test('setCredentials, authenticate, and live snapshot exercise the full happy pa
 	})
 	const authed = await env.adapter.authenticate(gatewayId)
 	expect(authed.hasStoredCredentials).toBe(true)
+	expect(authed.hasCustomCustomerEmailLabel).toBe(true)
+	expect('customerEmailLabel' in authed).toBe(false)
 	expect(authed.lastAuthError).toBeNull()
 	expect(authed.lastAuthenticatedAt).toBeTruthy()
 
@@ -89,23 +91,25 @@ test('setCredentials, authenticate, and live snapshot exercise the full happy pa
 	expect(Object.keys(snapshot.fetchErrors)).toEqual([])
 	expect(snapshot.gateway.din).toMatch(/--GF/)
 	expect(snapshot.gateway.serialNumber).toBeTruthy()
-	expect(snapshot.systemStatus?.solar_real_power_limit).toBe(25_000)
-	expect(snapshot.siteInfo?.max_site_meter_power_ac).toBe(25_000)
+	expect(snapshot.systemStatus?.solar_real_power_limit).toBe(21_000)
+	expect(snapshot.siteInfo?.max_site_export_power_kW).toBe(21)
+	expect(snapshot.siteInfo?.max_site_meter_power_ac).toBe(40_000)
 	expect(snapshot.gridStatus?.grid_status).toBe('SystemGridConnected')
 	expect(snapshot.soe?.percentage).toBeGreaterThanOrEqual(0)
 	expect(snapshot.meters?.solar?.instant_power).toBe(6_700)
 	expect(snapshot.powerwalls?.powerwalls?.length ?? 0).toBe(3)
 })
 
-test('findExportLimit prefers max_site_meter_power_ac and reports source', async () => {
+test('findExportLimit prefers the dedicated export cap field and works when destructured', async () => {
 	using env = makeAdapter()
 	await env.adapter.scan()
 	const gatewayId = 'tesla-gateway-mock-home-1'
 	env.adapter.setCredentials({ gatewayId, password: 'mock-password' })
-	const info = await env.adapter.findExportLimit(gatewayId)
-	expect(info.exportLimitKw).toBe(25)
-	expect(info.exportLimitWatts).toBe(25_000)
-	expect(info.source).toBe('site_info.max_site_meter_power_ac')
+	const { findExportLimit } = env.adapter
+	const info = await findExportLimit(gatewayId)
+	expect(info.exportLimitKw).toBe(21)
+	expect(info.exportLimitWatts).toBe(21_000)
+	expect(info.source).toBe('site_info.max_site_export_power_kW')
 })
 
 test('findAllExportLimits surfaces the configured cap for every gateway', async () => {
@@ -126,7 +130,7 @@ test('findAllExportLimits surfaces the configured cap for every gateway', async 
 	expect(
 		results.find((entry) => entry.gatewayId === 'tesla-gateway-mock-home-1')
 			?.exportLimitKw,
-	).toBe(25)
+	).toBe(21)
 	expect(
 		results.find((entry) => entry.gatewayId === 'tesla-gateway-mock-home-2')
 			?.exportLimitKw,

--- a/packages/home-connector/src/adapters/tesla-gateway/index.node.test.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/index.node.test.ts
@@ -112,6 +112,21 @@ test('findExportLimit prefers the dedicated export cap field and works when dest
 	expect(info.source).toBe('site_info.max_site_export_power_kW')
 })
 
+test('findExportLimit records failed authentication status', async () => {
+	using env = makeAdapter()
+	await env.adapter.scan()
+	const gatewayId = 'tesla-gateway-mock-home-1'
+	env.adapter.setCredentials({ gatewayId, password: 'wrong-password' })
+	await expect(env.adapter.findExportLimit(gatewayId)).rejects.toThrow(
+		/credentials are invalid/i,
+	)
+	const gateway = env.adapter
+		.listGateways()
+		.find((entry) => entry.gatewayId === gatewayId)
+	expect(gateway?.lastAuthError).toBeTruthy()
+	expect(gateway?.lastAuthenticatedAt).toBeNull()
+})
+
 test('findAllExportLimits surfaces the configured cap for every gateway', async () => {
 	using env = makeAdapter()
 	await env.adapter.scan()

--- a/packages/home-connector/src/adapters/tesla-gateway/index.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/index.ts
@@ -193,11 +193,25 @@ async function ensureSession(input: {
 async function safeFetch<T>(input: {
 	label: string
 	fn: () => Promise<T>
+	onUnauthorized?: () => Promise<T>
 	errors: Record<string, string>
 }): Promise<T | null> {
 	try {
 		return await input.fn()
 	} catch (error) {
+		if (
+			input.onUnauthorized &&
+			error instanceof TeslaGatewayHttpError &&
+			(error.status === 401 || error.status === 403)
+		) {
+			try {
+				return await input.onUnauthorized()
+			} catch (retryError) {
+				input.errors[input.label] =
+					retryError instanceof Error ? retryError.message : String(retryError)
+				return null
+			}
+		}
 		input.errors[input.label] =
 			error instanceof Error ? error.message : String(error)
 		return null
@@ -210,13 +224,25 @@ async function fetchLiveFromGateway(input: {
 	gateway: TeslaGatewayPersistedRecord
 }): Promise<TeslaGatewayLiveSnapshot> {
 	const errors: Record<string, string> = {}
-	const session = await ensureSession({
+	let session = await ensureSession({
 		storage: input.storage,
 		connectorId: input.connectorId,
 		gateway: input.gateway,
 	})
 
 	const isMock = isMockTeslaGatewayHost(input.gateway.host)
+	async function retryAfterUnauthorized<T>(
+		fn: (session: TeslaGatewaySession) => Promise<T>,
+	): Promise<T> {
+		dropSession(input.connectorId, input.gateway.gatewayId)
+		const freshSession = await ensureSession({
+			storage: input.storage,
+			connectorId: input.connectorId,
+			gateway: input.gateway,
+		})
+		session = freshSession
+		return await fn(session)
+	}
 	const status = isMock
 		? await safeFetch({
 				label: 'status',
@@ -226,6 +252,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'status',
 				fn: () => getTeslaApiStatus(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaApiStatus),
 				errors,
 			})
 	const systemStatus = isMock
@@ -237,6 +264,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'system_status',
 				fn: () => getTeslaSystemStatus(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaSystemStatus),
 				errors,
 			})
 	const gridStatus = isMock
@@ -248,6 +276,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'grid_status',
 				fn: () => getTeslaGridStatus(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaGridStatus),
 				errors,
 			})
 	const soe = isMock
@@ -259,6 +288,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'soe',
 				fn: () => getTeslaSoe(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaSoe),
 				errors,
 			})
 	const meters = isMock
@@ -270,6 +300,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'meters/aggregates',
 				fn: () => getTeslaMetersAggregates(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaMetersAggregates),
 				errors,
 			})
 	const operation = isMock
@@ -281,6 +312,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'operation',
 				fn: () => getTeslaOperation(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaOperation),
 				errors,
 			})
 	const networks = isMock
@@ -292,6 +324,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'networks',
 				fn: () => getTeslaNetworks(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaNetworks),
 				errors,
 			})
 	const siteInfo = isMock
@@ -303,6 +336,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'site_info',
 				fn: () => getTeslaSiteInfo(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaSiteInfo),
 				errors,
 			})
 	const powerwalls = isMock
@@ -314,6 +348,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'powerwalls',
 				fn: () => getTeslaPowerwalls(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaPowerwalls),
 				errors,
 			})
 	const solarPowerwall = isMock
@@ -325,6 +360,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'solar_powerwall',
 				fn: () => getTeslaSolarPowerwall(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaSolarPowerwall),
 				errors,
 			})
 	const generators = isMock
@@ -336,6 +372,7 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'generators',
 				fn: () => getTeslaGenerators(session),
+				onUnauthorized: () => retryAfterUnauthorized(getTeslaGenerators),
 				errors,
 			})
 	const systemUpdateStatus = isMock
@@ -347,6 +384,8 @@ async function fetchLiveFromGateway(input: {
 		: await safeFetch({
 				label: 'system/update/status',
 				fn: () => getTeslaSystemUpdateStatus(session),
+				onUnauthorized: () =>
+					retryAfterUnauthorized(getTeslaSystemUpdateStatus),
 				errors,
 			})
 
@@ -391,6 +430,7 @@ export type TeslaGatewayExportLimitInfo = {
 	exportLimitWatts: number | null
 	exportLimitKw: number | null
 	source:
+		| 'site_info.max_site_export_power_kW'
 		| 'site_info.max_site_meter_power_ac'
 		| 'system_status.solar_real_power_limit'
 		| 'site_info.max_system_power_kW'
@@ -404,6 +444,16 @@ function pickExportLimit(
 		typeof snapshot.siteInfo?.site_name === 'string'
 			? snapshot.siteInfo.site_name
 			: null
+	if (typeof snapshot.siteInfo?.max_site_export_power_kW === 'number') {
+		const kW = snapshot.siteInfo.max_site_export_power_kW
+		return {
+			gatewayId: snapshot.gateway.gatewayId,
+			siteName,
+			exportLimitWatts: Math.round(kW * 1_000),
+			exportLimitKw: kW,
+			source: 'site_info.max_site_export_power_kW',
+		}
+	}
 	if (typeof snapshot.siteInfo?.max_site_meter_power_ac === 'number') {
 		const watts = snapshot.siteInfo.max_site_meter_power_ac
 		return {
@@ -479,7 +529,14 @@ export function createTeslaGatewayAdapter(input: {
 				config.mocksEnabled && result.gateways.length === 0
 					? listMockTeslaGatewayDiscoveryEntries()
 					: result.gateways
-			upsertDiscoveredTeslaGateways(storage, connectorId, gateways)
+			const discoveryWasFallbackToMocks =
+				config.mocksEnabled && result.gateways.length === 0
+			upsertDiscoveredTeslaGateways(storage, connectorId, gateways, {
+				pruneMissing:
+					discoveryWasFallbackToMocks ||
+					result.diagnostics.errors.length === 0 ||
+					result.gateways.length > 0,
+			})
 			return listGateways()
 		},
 		getStatus() {
@@ -499,14 +556,13 @@ export function createTeslaGatewayAdapter(input: {
 			customerEmailLabel?: string
 		}) {
 			requireTeslaGateway(storage, connectorId, input.gatewayId)
+			const customerEmailLabel = input.customerEmailLabel?.trim()
 			saveTeslaGatewayCredentials({
 				storage,
 				connectorId,
 				gatewayId: input.gatewayId,
 				password: input.password,
-				...(input.customerEmailLabel
-					? { customerEmailLabel: input.customerEmailLabel }
-					: {}),
+				...(customerEmailLabel ? { customerEmailLabel } : {}),
 			})
 			dropSession(connectorId, input.gatewayId)
 			return toPublicTeslaGateway(
@@ -552,7 +608,12 @@ export function createTeslaGatewayAdapter(input: {
 		async findExportLimit(
 			gatewayId: string,
 		): Promise<TeslaGatewayExportLimitInfo> {
-			const snapshot = await this.getLiveSnapshot(gatewayId)
+			const gateway = requireTeslaGateway(storage, connectorId, gatewayId)
+			const snapshot = await fetchLiveFromGateway({
+				storage,
+				connectorId,
+				gateway,
+			})
 			return pickExportLimit(snapshot)
 		},
 		async findAllExportLimits(): Promise<Array<TeslaGatewayExportLimitInfo>> {

--- a/packages/home-connector/src/adapters/tesla-gateway/index.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/index.ts
@@ -609,12 +609,17 @@ export function createTeslaGatewayAdapter(input: {
 			gatewayId: string,
 		): Promise<TeslaGatewayExportLimitInfo> {
 			const gateway = requireTeslaGateway(storage, connectorId, gatewayId)
-			const snapshot = await fetchLiveFromGateway({
-				storage,
-				connectorId,
-				gateway,
-			})
-			return pickExportLimit(snapshot)
+			try {
+				const snapshot = await fetchLiveFromGateway({
+					storage,
+					connectorId,
+					gateway,
+				})
+				return pickExportLimit(snapshot)
+			} catch (error) {
+				applyFailedAuth({ gateway, error })
+				throw error
+			}
 		},
 		async findAllExportLimits(): Promise<Array<TeslaGatewayExportLimitInfo>> {
 			const gateways = listTeslaGateways(storage, connectorId)

--- a/packages/home-connector/src/adapters/tesla-gateway/mock-driver.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/mock-driver.ts
@@ -57,8 +57,11 @@ function buildDefaultGateway(input: {
 	siteName: string
 	macAddress: string
 	exportLimitKw: number
+	systemCapacityKw: number
+	meterLimitKw: number
 }): MockTeslaGatewayState {
 	const exportLimitWatts = input.exportLimitKw * 1_000
+	const meterLimitWatts = input.meterLimitKw * 1_000
 	return {
 		gatewayId: input.gatewayId,
 		host: input.host,
@@ -186,9 +189,10 @@ function buildDefaultGateway(input: {
 			site_name: input.siteName,
 			timezone: 'America/Denver',
 			max_system_energy_kWh: 40.5,
-			max_system_power_kW: 25,
-			max_site_meter_power_ac: exportLimitWatts,
-			min_site_meter_power_ac: -exportLimitWatts,
+			max_system_power_kW: input.systemCapacityKw,
+			max_site_export_power_kW: input.exportLimitKw,
+			max_site_meter_power_ac: meterLimitWatts,
+			min_site_meter_power_ac: -meterLimitWatts,
 			nominal_system_energy_kWh: 40.5,
 			nominal_system_power_kW: 25,
 			panel_max_current: 200,
@@ -273,7 +277,9 @@ function defineDefaultMocks() {
 		serial: 'GF22327600010H',
 		siteName: 'Mock Home 1',
 		macAddress: '90:03:71:11:22:33',
-		exportLimitKw: 25,
+		exportLimitKw: 21,
+		systemCapacityKw: 32,
+		meterLimitKw: 40,
 	})
 	const home2 = buildDefaultGateway({
 		gatewayId: 'tesla-gateway-mock-home-2',
@@ -282,7 +288,9 @@ function defineDefaultMocks() {
 		serial: 'GF22327600011K',
 		siteName: 'Mock Home 2',
 		macAddress: '90:03:71:44:55:66',
-		exportLimitKw: 25,
+		exportLimitKw: 21,
+		systemCapacityKw: 32,
+		meterLimitKw: 40,
 	})
 	mockGateways.set(home1.host, home1)
 	mockGateways.set(home2.host, home2)
@@ -410,7 +418,5 @@ export function setMockTeslaGatewayExportLimitKw(input: {
 	const state = requireMockGateway(input.host)
 	const exportLimitWatts = input.exportLimitKw * 1_000
 	state.systemStatus.solar_real_power_limit = exportLimitWatts
-	state.siteInfo.max_site_meter_power_ac = exportLimitWatts
-	state.siteInfo.min_site_meter_power_ac = -exportLimitWatts
-	state.siteInfo.max_system_power_kW = input.exportLimitKw
+	state.siteInfo.max_site_export_power_kW = input.exportLimitKw
 }

--- a/packages/home-connector/src/adapters/tesla-gateway/repository.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/repository.ts
@@ -133,10 +133,11 @@ function mapRow(
 export function toPublicTeslaGateway(
 	gateway: TeslaGatewayPersistedRecord,
 ): TeslaGatewayPublicRecord {
-	const { password, ...rest } = gateway
+	const { customerEmailLabel, password, ...rest } = gateway
 	return {
 		...rest,
 		hasStoredCredentials: password !== null && password !== '',
+		hasCustomCustomerEmailLabel: customerEmailLabel !== DEFAULT_EMAIL_LABEL,
 	}
 }
 
@@ -327,6 +328,7 @@ export function upsertDiscoveredTeslaGateways(
 	storage: HomeConnectorStorage,
 	connectorId: string,
 	gateways: Array<TeslaGatewayDiscoveredGateway>,
+	options: { pruneMissing?: boolean } = {},
 ) {
 	const now = new Date().toISOString()
 	const upsert = getUpsertGatewayStatement(storage)
@@ -354,8 +356,10 @@ export function upsertDiscoveredTeslaGateways(
 			now,
 		)
 	}
-	const ids = JSON.stringify(gateways.map((gateway) => gateway.gatewayId))
-	getDeleteMissingGatewaysStatement(storage).run(connectorId, ids)
+	if (options.pruneMissing ?? true) {
+		const ids = JSON.stringify(gateways.map((gateway) => gateway.gatewayId))
+		getDeleteMissingGatewaysStatement(storage).run(connectorId, ids)
+	}
 	return listTeslaGateways(storage, connectorId)
 }
 

--- a/packages/home-connector/src/adapters/tesla-gateway/types.ts
+++ b/packages/home-connector/src/adapters/tesla-gateway/types.ts
@@ -88,9 +88,10 @@ export type TeslaGatewayPersistedRecord = TeslaGatewayDiscoveredGateway & {
 
 export type TeslaGatewayPublicRecord = Omit<
 	TeslaGatewayPersistedRecord,
-	'password'
+	'password' | 'customerEmailLabel'
 > & {
 	hasStoredCredentials: boolean
+	hasCustomCustomerEmailLabel: boolean
 }
 
 export type TeslaGatewayLoginResponse = {
@@ -232,6 +233,7 @@ export type TeslaGatewayNetworksResponse = Array<TeslaGatewayNetworkInterface>
 export type TeslaGatewaySiteInfoResponse = {
 	max_system_energy_kWh?: number
 	max_system_power_kW?: number
+	max_site_export_power_kW?: number
 	site_name?: string
 	timezone?: string
 	max_site_meter_power_ac?: number

--- a/packages/home-connector/src/config.ts
+++ b/packages/home-connector/src/config.ts
@@ -206,9 +206,12 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 		explicitJellyfishCidrs.length > 0
 			? explicitJellyfishCidrs
 			: deriveJellyfishAutoscanCidrs()
+	const teslaGatewayDiscoveryUrl =
+		process.env.TESLA_GATEWAY_DISCOVERY_URL?.trim() || null
 	const explicitTeslaCidrs = resolveScanCidrsFromEnv('TESLA_GATEWAY_SCAN_CIDRS')
-	const teslaGatewayScanCidrs =
-		explicitTeslaCidrs.length > 0
+	const teslaGatewayScanCidrs = teslaGatewayDiscoveryUrl
+		? explicitTeslaCidrs
+		: explicitTeslaCidrs.length > 0
 			? explicitTeslaCidrs
 			: derivePrivateAutoscanCidrsFromInterfaces(networkInterfaces())
 	return {
@@ -233,8 +236,7 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 		venstarScanCidrs,
 		jellyfishScanCidrs,
 		teslaGatewayScanCidrs,
-		teslaGatewayDiscoveryUrl:
-			process.env.TESLA_GATEWAY_DISCOVERY_URL?.trim() || null,
+		teslaGatewayDiscoveryUrl,
 		dataPath,
 		dbPath: resolveHomeConnectorDbPath(dataPath),
 		port: Number.isFinite(port) ? port : 4040,

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -147,6 +147,17 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		expect(
 			tools.some((tool) => tool.name === 'venstar_control_thermostat'),
 		).toBe(true)
+		for (const toolName of [
+			'tesla_gateway_scan',
+			'tesla_gateway_list',
+			'tesla_gateway_set_credentials',
+			'tesla_gateway_authenticate',
+			'tesla_gateway_live_snapshot',
+			'tesla_gateway_find_export_limit',
+			'tesla_gateway_find_all_export_limits',
+		]) {
+			expect(tools.some((tool) => tool.name === toolName)).toBe(true)
+		}
 		const bondAuthGuide = await mcp.callTool('bond_authentication_guide')
 		expect(bondAuthGuide.content[0]?.type).toBe('text')
 		expect(bondAuthGuide.structuredContent).toMatchObject({
@@ -254,6 +265,55 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		expect(venstarScan.structuredContent).toMatchObject({
 			discovered: expect.any(Array),
 			diagnostics: expect.anything(),
+		})
+		const teslaScan = await mcp.callTool('tesla_gateway_scan')
+		expect(teslaScan.structuredContent).toMatchObject({
+			gateways: expect.any(Array),
+			diagnostics: expect.anything(),
+		})
+		const teslaGateways = await mcp.callTool('tesla_gateway_list')
+		expect(teslaGateways.structuredContent).toMatchObject({
+			gateways: expect.arrayContaining([
+				expect.objectContaining({
+					gatewayId: 'tesla-gateway-mock-home-1',
+					hasStoredCredentials: false,
+				}),
+			]),
+		})
+		await mcp.callTool('tesla_gateway_set_credentials', {
+			gatewayId: 'tesla-gateway-mock-home-1',
+			password: 'mock-password',
+			customerEmailLabel: '   ',
+		})
+		const teslaExportLimit = await mcp.callTool(
+			'tesla_gateway_find_export_limit',
+			{ gatewayId: 'tesla-gateway-mock-home-1' },
+		)
+		expect(teslaExportLimit.structuredContent).toMatchObject({
+			gatewayId: 'tesla-gateway-mock-home-1',
+			exportLimitKw: 21,
+			source: 'site_info.max_site_export_power_kW',
+		})
+		const teslaAuthedGateways = await mcp.callTool('tesla_gateway_list')
+		expect(teslaAuthedGateways.structuredContent).toMatchObject({
+			gateways: expect.arrayContaining([
+				expect.objectContaining({
+					gatewayId: 'tesla-gateway-mock-home-1',
+					hasStoredCredentials: true,
+					hasCustomCustomerEmailLabel: false,
+				}),
+			]),
+		})
+		const teslaGatewaysAfterCredentials =
+			await mcp.callTool('tesla_gateway_list')
+		expect(teslaGatewaysAfterCredentials.structuredContent).toMatchObject({
+			gateways: expect.arrayContaining([
+				expect.objectContaining({
+					gatewayId: 'tesla-gateway-mock-home-1',
+					hasStoredCredentials: true,
+					hasCustomCustomerEmailLabel: false,
+				}),
+			]),
 		})
 		const addedVenstar = await mcp.callTool('venstar_add_thermostat', {
 			ip: '192.168.10.41',

--- a/packages/home-connector/src/mcp/server.ts
+++ b/packages/home-connector/src/mcp/server.ts
@@ -2872,12 +2872,14 @@ export function createHomeConnectorMcpServer(input: {
 			),
 		},
 		async (args) => {
+			const customerEmailLabel =
+				typeof args['customerEmailLabel'] === 'string'
+					? args['customerEmailLabel'].trim()
+					: ''
 			const gateway = teslaGateway.setCredentials({
 				gatewayId: String(args['gatewayId'] ?? ''),
 				password: String(args['password'] ?? ''),
-				...(typeof args['customerEmailLabel'] === 'string'
-					? { customerEmailLabel: args['customerEmailLabel'] }
-					: {}),
+				...(customerEmailLabel ? { customerEmailLabel } : {}),
 			})
 			return structuredTextResult(
 				`Saved Tesla gateway credentials for ${gateway.gatewayId}.`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Harden Tesla gateway discovery, authentication retry, export-limit detection, and public record redaction.
- Add same-origin validation and live snapshot rendering to the Tesla gateway admin routes.
- Ensure `findExportLimit` records failed authentication status like adjacent live/auth methods.
- Expand focused adapter, discovery, MCP, and router tests for the reviewed behavior.

## Testing

- `npm run test -- packages/home-connector/app/router.node.test.ts packages/home-connector/src/adapters/tesla-gateway/index.node.test.ts packages/home-connector/src/adapters/tesla-gateway/discovery.node.test.ts packages/home-connector/src/mcp/server.node.test.ts`
- `npm run test -- packages/home-connector/src/adapters/tesla-gateway/index.node.test.ts`
- `npm run typecheck`
- `npm run lint`
- Local HTTP smoke test against `http://localhost:4040/tesla-gateway/*` with mock Tesla gateway discovery and credentials.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79653bf4-fb1d-4745-92af-855d01e45064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79653bf4-fb1d-4745-92af-855d01e45064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

