### PR TITLE
Allow secret edits without re-entering value

### DIFF
--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -1567,6 +1567,7 @@ export function AccountSecretsRoute(handle: Handle) {
 									showSecretValue = !showSecretValue
 									handle.update()
 								}}
+								valueRequired={!editorState.currentId || showSecretValue}
 								allowedHosts={editorState.allowedHosts}
 								onUpdateAllowedHost={updateAllowedHost}
 								onAddAllowedHost={addAllowedHost}

--- a/packages/worker/client/routes/secret-editor-fields.tsx
+++ b/packages/worker/client/routes/secret-editor-fields.tsx
@@ -16,6 +16,7 @@ type SecretEditorFieldsProps = {
 	onValueChange: (value: string) => void
 	showSecretValue: boolean
 	onToggleShowSecretValue: () => void
+	valueRequired?: boolean
 	allowedHosts: Array<string>
 	onUpdateAllowedHost: (index: number, value: string) => void
 	onAddAllowedHost: () => void
@@ -35,133 +36,136 @@ type SecretEditorFieldsProps = {
 }
 
 export function SecretEditorFields(_handle: Handle) {
-	return (props: SecretEditorFieldsProps) => (
-		<>
-			<label mix={css(fieldCss)}>
-				<span mix={css(fieldLabelCss)}>Description</span>
-				<textarea
-					value={props.description}
-					rows={3}
-					placeholder="What this secret is used for"
-					mix={[
-						on(
-							'input',
+	return (props: SecretEditorFieldsProps) => {
+		const valueRequired = props.valueRequired ?? true
 
-							(event) => {
-								props.onDescriptionChange(event.currentTarget.value)
-							},
-						),
-
-						css(textareaCss),
-					]}
-				/>
-			</label>
-
-			<label mix={css(fieldCss)}>
-				<span mix={css(fieldLabelCss)}>Secret value</span>
-				<div
-					mix={css({
-						position: 'relative',
-						display: 'flex',
-						alignItems: 'center',
-					})}
-				>
-					{props.showSecretValue ? (
-						<input
-							type="text"
-							required
-							autoComplete="new-password"
-							value={props.value}
-							placeholder={props.valuePlaceholder ?? 'Enter the secret value'}
-							mix={[
-								on(
-									'input',
-
-									(event) => {
-										props.onValueChange(event.currentTarget.value)
-									},
-								),
-
-								css({
-									...inputCss,
-									paddingRight: '3rem',
-								}),
-							]}
-						/>
-					) : (
-						<input
-							type="password"
-							required
-							autoComplete="new-password"
-							value={props.value}
-							placeholder={props.valuePlaceholder ?? 'Enter the secret value'}
-							mix={[
-								on(
-									'input',
-
-									(event) => {
-										props.onValueChange(event.currentTarget.value)
-									},
-								),
-
-								css({
-									...inputCss,
-									paddingRight: '3rem',
-								}),
-							]}
-						/>
-					)}
-					<button
-						type="button"
-						aria-label={
-							props.showSecretValue ? 'Hide secret value' : 'Show secret value'
-						}
-						title={
-							props.showSecretValue ? 'Hide secret value' : 'Show secret value'
-						}
+		return (
+			<>
+				<label mix={css(fieldCss)}>
+					<span mix={css(fieldLabelCss)}>Description</span>
+					<textarea
+						value={props.description}
+						rows={3}
+						placeholder="What this secret is used for"
 						mix={[
-							on('click', () => props.onToggleShowSecretValue()),
-							css(iconButtonCss),
+							on(
+								'input',
+
+								(event) => {
+									props.onDescriptionChange(event.currentTarget.value)
+								},
+							),
+
+							css(textareaCss),
 						]}
+					/>
+				</label>
+
+				<label mix={css(fieldCss)}>
+					<span mix={css(fieldLabelCss)}>Secret value</span>
+					<div
+						mix={css({
+							position: 'relative',
+							display: 'flex',
+							alignItems: 'center',
+						})}
 					>
 						{props.showSecretValue ? (
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								width="20"
-								height="20"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-							>
-								<path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
-								<path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68" />
-								<path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61" />
-								<line x1="2" x2="22" y1="2" y2="22" />
-							</svg>
-						) : (
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								width="20"
-								height="20"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-							>
-								<path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
-								<circle cx="12" cy="12" r="3" />
-							</svg>
-						)}
-					</button>
-				</div>
-			</label>
+							<input
+								type="text"
+								required={valueRequired ? true : undefined}
+								autoComplete="new-password"
+								value={props.value}
+								placeholder={props.valuePlaceholder ?? 'Enter the secret value'}
+								mix={[
+									on(
+										'input',
 
-			<div mix={css({ display: 'grid', gap: spacing.sm })}>
+										(event) => {
+											props.onValueChange(event.currentTarget.value)
+										},
+									),
+
+									css({
+										...inputCss,
+										paddingRight: '3rem',
+									}),
+								]}
+							/>
+						) : (
+							<input
+								type="password"
+								required={valueRequired ? true : undefined}
+								autoComplete="new-password"
+								value={props.value}
+								placeholder={props.valuePlaceholder ?? 'Enter the secret value'}
+								mix={[
+									on(
+										'input',
+
+										(event) => {
+											props.onValueChange(event.currentTarget.value)
+										},
+									),
+
+									css({
+										...inputCss,
+										paddingRight: '3rem',
+									}),
+								]}
+							/>
+						)}
+						<button
+							type="button"
+							aria-label={
+								props.showSecretValue ? 'Hide secret value' : 'Show secret value'
+							}
+							title={
+								props.showSecretValue ? 'Hide secret value' : 'Show secret value'
+							}
+							mix={[
+								on('click', () => props.onToggleShowSecretValue()),
+								css(iconButtonCss),
+							]}
+						>
+							{props.showSecretValue ? (
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									width="20"
+									height="20"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
+									<path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
+									<path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68" />
+									<path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61" />
+									<line x1="2" x2="22" y1="2" y2="22" />
+								</svg>
+							) : (
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									width="20"
+									height="20"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
+									<path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+									<circle cx="12" cy="12" r="3" />
+								</svg>
+							)}
+						</button>
+					</div>
+				</label>
+
+				<div mix={css({ display: 'grid', gap: spacing.sm })}>
 				<div mix={css({ display: 'grid', gap: spacing.xs })}>
 					<span mix={css(fieldLabelCss)}>Allowed hosts</span>
 					<p mix={css({ margin: 0, color: colors.textMuted })}>
@@ -218,9 +222,9 @@ export function SecretEditorFields(_handle: Handle) {
 						Add host
 					</button>
 				</div>
-			</div>
+				</div>
 
-			<div mix={css({ display: 'grid', gap: spacing.sm })}>
+				<div mix={css({ display: 'grid', gap: spacing.sm })}>
 				<div mix={css({ display: 'grid', gap: spacing.xs })}>
 					<span mix={css(fieldLabelCss)}>Allowed capabilities</span>
 					<p mix={css({ margin: 0, color: colors.textMuted })}>
@@ -277,13 +281,13 @@ export function SecretEditorFields(_handle: Handle) {
 						Add capability
 					</button>
 				</div>
-			</div>
+				</div>
 
-			{props.allowedPackages &&
-			props.onUpdateAllowedPackage &&
-			props.onAddAllowedPackage &&
-			props.onRemoveAllowedPackage ? (
-				<div mix={css({ display: 'grid', gap: spacing.sm })}>
+				{props.allowedPackages &&
+				props.onUpdateAllowedPackage &&
+				props.onAddAllowedPackage &&
+				props.onRemoveAllowedPackage ? (
+					<div mix={css({ display: 'grid', gap: spacing.sm })}>
 					<div mix={css({ display: 'grid', gap: spacing.xs })}>
 						<span mix={css(fieldLabelCss)}>Allowed packages</span>
 						<p mix={css({ margin: 0, color: colors.textMuted })}>
@@ -340,10 +344,11 @@ export function SecretEditorFields(_handle: Handle) {
 							Add package
 						</button>
 					</div>
-				</div>
-			) : null}
-		</>
-	)
+					</div>
+				) : null}
+			</>
+		)
+	}
 }
 
 const secondaryButtonCss = getSecondaryButtonCss()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- allow account secret edits without forcing secret value entry
- add optional value requirement support for secret editor fields

## Testing
- `npm run typecheck`
- `npx vitest run --project node-unit packages/worker/src/app/handlers/account-secrets.node.test.ts`

## Demo
![Plaintext secret visible](https://cursor.com/artifacts/c/art-c2eb1ba5-327a-49f7-94e4-d171523b34f4)
<a href="https://cursor.com/agents/bc-a9c1aae6-bafd-4eb6-8a03-84fab3928655/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faccount-secrets-reveal-and-remove-host-final.mp4"><img src="https://cursor.com/artifacts/c/art-abfe0ede-4a5c-47a9-8bae-a4ea5781cf0d" alt="account-secrets-reveal-and-remove-host-final.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9c1aae6-bafd-4eb6-8a03-84fab3928655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9c1aae6-bafd-4eb6-8a03-84fab3928655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Secret value field validation is now context-aware—only required when creating a new secret or after choosing to display the secret, providing a more flexible editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->