### PR TITLE
Remove legacy secret store fallback decryption

### DIFF
--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -26,7 +26,7 @@ types, runtime validation, and documentation in sync.
    			32,
    			'COOKIE_SECRET must be at least 32 characters for session signing.',
    		),
-   	SECRET_STORE_KEY: z.string().optional(),
+   	SECRET_STORE_KEY: z.string().min(32),
    	THIRD_PARTY_API_KEY: z
    		.string()
    		.min(
@@ -72,15 +72,11 @@ environment variables.
 
 ## Saved-secret encryption (`SECRET_STORE_KEY`)
 
-Optional Worker secret used to derive the AES-GCM key for encrypting saved
-secrets at rest in D1. When unset, the Worker falls back to `COOKIE_SECRET` for
-backward compatibility.
+Required Worker secret used to derive the AES-GCM key for encrypting saved
+secrets at rest in D1.
 
-- **Production deployments should set a dedicated `SECRET_STORE_KEY`** so that
-  rotating the cookie signing key does not brick encrypted secrets.
-- When both keys are configured, decryption first attempts `SECRET_STORE_KEY`.
-  If that fails (legacy data), it retries with `COOKIE_SECRET` and transparently
-  re-encrypts the value under the new key on the next read.
+- **Every environment must set `SECRET_STORE_KEY`**, including local dev and
+  CI, so saved secrets can be encrypted and decrypted.
 - See [`docs/contributing/secret-rotation.md`](./secret-rotation.md) for
   rotation procedures.
 

--- a/docs/contributing/secret-rotation.md
+++ b/docs/contributing/secret-rotation.md
@@ -19,8 +19,8 @@ every user **and** destroyed all encrypted secrets.
 Now:
 
 - **Cookie signing** uses `COOKIE_SECRET` only.
-- **Saved-secret encryption** uses `SECRET_STORE_KEY` when set. There is no
-  legacy decryption fallback anymore.
+- **Saved-secret encryption** requires `SECRET_STORE_KEY`. There is no legacy
+  decryption fallback anymore.
 
 ## Rotating `COOKIE_SECRET`
 
@@ -35,9 +35,8 @@ has no built-in key versioning.
 
 ### Procedure
 
-1. **Keep the old key available** alongside the new key (for example, in a
-   secure migration script or a temporary environment variable) so you can
-   decrypt existing ciphertext.
+1. **Keep the old key available** in a secure migration script so you can
+   decrypt existing ciphertext while preparing the re-encryption pass.
 2. **Decrypt all secrets with the old key** and re-encrypt them with the new
    `SECRET_STORE_KEY`. This can be done via a one-off script against D1 or a
    future `/__maintenance/reencrypt-secrets` endpoint.

--- a/docs/contributing/secret-rotation.md
+++ b/docs/contributing/secret-rotation.md
@@ -19,15 +19,14 @@ every user **and** destroyed all encrypted secrets.
 Now:
 
 - **Cookie signing** uses `COOKIE_SECRET` only.
-- **Saved-secret encryption** uses `SECRET_STORE_KEY` when set, falling back to
-  `COOKIE_SECRET` for backward compatibility with existing ciphertext.
+- **Saved-secret encryption** uses `SECRET_STORE_KEY` when set. There is no
+  legacy decryption fallback anymore.
 
 ## Rotating `COOKIE_SECRET`
 
 1. Deploy the new `COOKIE_SECRET` value.
 2. All active browser sessions are invalidated (expected).
-3. Saved secrets remain intact — they are encrypted under `SECRET_STORE_KEY`
-   (or legacy `COOKIE_SECRET`-derived key with automatic fallback).
+3. Saved secrets remain intact — they are encrypted under `SECRET_STORE_KEY`.
 
 ## Rotating `SECRET_STORE_KEY`
 
@@ -36,26 +35,20 @@ has no built-in key versioning.
 
 ### Procedure
 
-1. **Keep the old key available** — set `COOKIE_SECRET` to the **old**
-   `SECRET_STORE_KEY` value temporarily (or use a dedicated migration env var in
-   a future iteration). The runtime's legacy-fallback path will use
-   `COOKIE_SECRET` to decrypt old ciphertext.
-2. **Deploy** with the new `SECRET_STORE_KEY` and the adjusted `COOKIE_SECRET`.
-3. **Trigger a full read pass** over all secrets so the fallback path decrypts
-   with the old key and transparently re-encrypts under the new key. A future
-   `/__maintenance/reencrypt-secrets` endpoint can automate this; until then,
-   iterating through all secret entries via a one-off script against D1 achieves
-   the same effect.
-4. Once all rows are re-encrypted, **restore `COOKIE_SECRET`** to its normal
-   session-signing value.
+1. **Keep the old key available** alongside the new key (for example, in a
+   secure migration script or a temporary environment variable) so you can
+   decrypt existing ciphertext.
+2. **Decrypt all secrets with the old key** and re-encrypt them with the new
+   `SECRET_STORE_KEY`. This can be done via a one-off script against D1 or a
+   future `/__maintenance/reencrypt-secrets` endpoint.
+3. **Deploy** the new `SECRET_STORE_KEY` only after the re-encryption pass is
+   complete and verified.
 
 ### Important notes
 
 - Never delete the old key value until re-encryption is verified complete.
-- The fallback decrypt path only fires when primary decryption fails — it does
-  not add latency to normal reads.
 - Monitor error rates after rotation; a spike in "Unable to decrypt secret
-  value" errors indicates the fallback key is also wrong.
+  value" errors indicates secrets were not re-encrypted with the new key.
 
 ## Generating secure key values
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -69,6 +69,7 @@ Local development uses `packages/worker/.env`, which Wrangler loads
 automatically:
 
 - `COOKIE_SECRET` (generate with `openssl rand -hex 32`)
+- `SECRET_STORE_KEY` (required; generate with `openssl rand -base64 48`)
 - `APP_BASE_URL` (optional; defaults to request origin for most app URLs,
   example `https://app.example.com`; also sets the canonical public origin used
   for MCP auth metadata, generated UI resources, and email links. Password reset
@@ -115,6 +116,7 @@ Configure these GitHub Actions secrets and variables for workflows:
   account; also reused for remote AI and Cloudflare API workflows that run with
   account secrets + package workflows)
 - `COOKIE_SECRET` (same format as local)
+- `SECRET_STORE_KEY` (same format as local; required for deploys)
 - `APP_BASE_URL` (optional GitHub Actions **variable**, used by the production
   deploy as the canonical public app origin, the password-reset email sender
   hostname, and written into the generated Worker `vars` config before deploy)

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -32,9 +32,8 @@ Quick notes for getting a local kody environment running.
   `tools/export-d1-remote-to-sqlite.sh`.
 - Copy `packages/worker/.env.example` to `packages/worker/.env` before starting
   any work, then update secrets as needed. The example includes placeholder
-  values for `COOKIE_SECRET` and `SECRET_STORE_KEY`; production deploys must set
-  distinct secrets for each (see
-  [`docs/contributing/secret-rotation.md`](./secret-rotation.md)).
+  values for `COOKIE_SECRET` and `SECRET_STORE_KEY`; all environments must set
+  both secrets (see [`docs/contributing/secret-rotation.md`](./secret-rotation.md)).
 - `npm run dev` (starts mock API servers automatically, the main worker, and the
   local home connector; it sets `AI_MODE=mock`, `AI_MOCK_BASE_URL`, and
   `CLOUDFLARE_API_BASE_URL` + `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`

--- a/packages/worker/.env.example
+++ b/packages/worker/.env.example
@@ -3,11 +3,11 @@
 
 # Required
 COOKIE_SECRET=LOCAL_AND_PREVIEW_COOKIE_SECRET_32_CHARS_MINIMUM
+SECRET_STORE_KEY=LOCAL_SECRET_STORE_KEY_32_CHARS_MINIMUM_VALUE
 
-# Saved-secret encryption key (optional; falls back to COOKIE_SECRET when unset).
+# Saved-secret encryption key (required).
 # Set a dedicated value in production to decouple secret-store encryption from
 # cookie signing. See docs/contributing/secret-rotation.md.
-SECRET_STORE_KEY=LOCAL_SECRET_STORE_KEY_32_CHARS_MINIMUM_VALUE
 
 # Optional (preview uses request origin by default; password-reset email sends
 # from kody@<APP_BASE_URL hostname> when set)

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -166,29 +166,36 @@ const optionalSentryTracesSampleRateSchema = createSchema<
 	return fail('Expected number or numeric string', context.path)
 })
 
-const optionalSecretStoreKeySchema = createSchema<unknown, string | undefined>(
-	(value, context) => {
-		if (value === undefined) return { value: undefined }
-		if (typeof value !== 'string') return fail('Expected string', context.path)
+const secretStoreKeySchema = createSchema<unknown, string>((value, context) => {
+	if (typeof value !== 'string') {
+		return fail(
+			'Missing SECRET_STORE_KEY binding for saved secret encryption.',
+			context.path,
+		)
+	}
 
-		const trimmed = value.trim()
-		if (!trimmed) return { value: undefined }
-		if (trimmed.length < 32) {
-			return fail(
-				'SECRET_STORE_KEY must be at least 32 characters for secure key derivation.',
-				context.path,
-			)
-		}
-		return { value: trimmed }
-	},
-)
+	const trimmed = value.trim()
+	if (!trimmed) {
+		return fail(
+			'Missing SECRET_STORE_KEY binding for saved secret encryption.',
+			context.path,
+		)
+	}
+	if (trimmed.length < 32) {
+		return fail(
+			'SECRET_STORE_KEY must be at least 32 characters for secure key derivation.',
+			context.path,
+		)
+	}
+	return { value: trimmed }
+})
 
 export const EnvSchema = object({
 	COOKIE_SECRET: string().refine(
 		(value) => value.length >= 32,
 		'COOKIE_SECRET must be at least 32 characters for session signing.',
 	),
-	SECRET_STORE_KEY: optionalSecretStoreKeySchema,
+	SECRET_STORE_KEY: secretStoreKeySchema,
 	APP_DB: d1DatabaseSchema,
 	BUNDLE_ARTIFACTS_KV: createSchema<unknown, KVNamespace>((value, context) => {
 		if (value) {

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -6,6 +6,7 @@ import * as secretService from '#mcp/secrets/service.ts'
 const env = {
 	APP_DB: {} as D1Database,
 	COOKIE_SECRET: 'test-cookie-secret',
+	SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
 }
 
 const props = {

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -41,7 +41,7 @@ export class CodemodeFetchGateway extends WorkerEntrypoint<
 export async function expandSecretPlaceholders(input: {
 	request: Request
 	props: FetchGatewayProps
-	env: Pick<Env, 'APP_DB' | 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>
+	env: Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'>
 }) {
 	const headers = new Headers(input.request.headers)
 	const requestBody = await readRequestBody(input.request)

--- a/packages/worker/src/mcp/secrets/crypto.node.test.ts
+++ b/packages/worker/src/mcp/secrets/crypto.node.test.ts
@@ -13,8 +13,7 @@ test('encrypt then decrypt with SECRET_STORE_KEY succeeds', async () => {
 	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
 	const encrypted = await encryptSecretValue(env, 'my-secret-value')
 	const result = await decryptSecretValue(env, encrypted)
-	expect(result.value).toBe('my-secret-value')
-	expect(result.needsReEncrypt).toBe(false)
+	expect(result).toBe('my-secret-value')
 })
 
 test('decrypt with correct SECRET_STORE_KEY ignores COOKIE_SECRET value', async () => {
@@ -26,21 +25,7 @@ test('decrypt with correct SECRET_STORE_KEY ignores COOKIE_SECRET value', async 
 		SECRET_STORE_KEY: primaryKey,
 	}
 	const result = await decryptSecretValue(envWithDifferentCookie, encrypted)
-	expect(result.value).toBe('test-data')
-	expect(result.needsReEncrypt).toBe(false)
-})
-
-test('legacy ciphertext encrypted with COOKIE_SECRET decrypts via fallback', async () => {
-	const legacyEnv = {
-		COOKIE_SECRET: cookieSecret,
-		SECRET_STORE_KEY: undefined,
-	}
-	const legacyCiphertext = await encryptSecretValue(legacyEnv, 'legacy-secret')
-
-	const newEnv = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
-	const result = await decryptSecretValue(newEnv, legacyCiphertext)
-	expect(result.value).toBe('legacy-secret')
-	expect(result.needsReEncrypt).toBe(true)
+	expect(result).toBe('test-data')
 })
 
 test('rotating COOKIE_SECRET does not brick secrets when SECRET_STORE_KEY is stable', async () => {
@@ -52,17 +37,16 @@ test('rotating COOKIE_SECRET does not brick secrets when SECRET_STORE_KEY is sta
 		SECRET_STORE_KEY: primaryKey,
 	}
 	const result = await decryptSecretValue(rotatedEnv, encrypted)
-	expect(result.value).toBe('important-data')
-	expect(result.needsReEncrypt).toBe(false)
+	expect(result).toBe('important-data')
 })
 
-test('decryption fails when both keys are wrong', async () => {
+test('decryption fails when SECRET_STORE_KEY is wrong', async () => {
 	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
 	const encrypted = await encryptSecretValue(env, 'data')
 
 	const wrongEnv = {
-		COOKIE_SECRET: 'wrong-cookie-secret-32-chars-minimum-value!!!',
 		SECRET_STORE_KEY: 'wrong-store-key-32-chars-minimum-value-here!!',
+		COOKIE_SECRET: cookieSecret,
 	}
 	await expect(decryptSecretValue(wrongEnv, encrypted)).rejects.toThrow(
 		'Unable to decrypt secret value.',
@@ -76,8 +60,7 @@ test('when SECRET_STORE_KEY is unset, encrypt/decrypt uses COOKIE_SECRET', async
 	}
 	const encrypted = await encryptSecretValue(env, 'fallback-test')
 	const result = await decryptSecretValue(env, encrypted)
-	expect(result.value).toBe('fallback-test')
-	expect(result.needsReEncrypt).toBe(false)
+	expect(result).toBe('fallback-test')
 })
 
 test('general-purpose encrypt/decrypt with purpose uses COOKIE_SECRET', async () => {

--- a/packages/worker/src/mcp/secrets/crypto.node.test.ts
+++ b/packages/worker/src/mcp/secrets/crypto.node.test.ts
@@ -7,7 +7,6 @@ import {
 
 const primaryKey = 'primary-secret-store-key-at-least-32-chars!!'
 const cookieSecret = 'cookie-secret-value-at-least-32-characters!!'
-const altCookieSecret = 'rotated-cookie-secret-at-least-32-characters!'
 
 test('encrypt then decrypt with SECRET_STORE_KEY succeeds', async () => {
 	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
@@ -16,28 +15,12 @@ test('encrypt then decrypt with SECRET_STORE_KEY succeeds', async () => {
 	expect(result).toBe('my-secret-value')
 })
 
-test('decrypt with correct SECRET_STORE_KEY ignores COOKIE_SECRET value', async () => {
+test('decrypt with correct SECRET_STORE_KEY succeeds', async () => {
 	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
 	const encrypted = await encryptSecretValue(env, 'test-data')
 
-	const envWithDifferentCookie = {
-		COOKIE_SECRET: altCookieSecret,
-		SECRET_STORE_KEY: primaryKey,
-	}
-	const result = await decryptSecretValue(envWithDifferentCookie, encrypted)
+	const result = await decryptSecretValue(env, encrypted)
 	expect(result).toBe('test-data')
-})
-
-test('rotating COOKIE_SECRET does not brick secrets when SECRET_STORE_KEY is stable', async () => {
-	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: primaryKey }
-	const encrypted = await encryptSecretValue(env, 'important-data')
-
-	const rotatedEnv = {
-		COOKIE_SECRET: altCookieSecret,
-		SECRET_STORE_KEY: primaryKey,
-	}
-	const result = await decryptSecretValue(rotatedEnv, encrypted)
-	expect(result).toBe('important-data')
 })
 
 test('decryption fails when SECRET_STORE_KEY is wrong', async () => {
@@ -51,16 +34,6 @@ test('decryption fails when SECRET_STORE_KEY is wrong', async () => {
 	await expect(decryptSecretValue(wrongEnv, encrypted)).rejects.toThrow(
 		'Unable to decrypt secret value.',
 	)
-})
-
-test('when SECRET_STORE_KEY is unset, encrypt/decrypt uses COOKIE_SECRET', async () => {
-	const env = {
-		COOKIE_SECRET: cookieSecret,
-		SECRET_STORE_KEY: undefined,
-	}
-	const encrypted = await encryptSecretValue(env, 'fallback-test')
-	const result = await decryptSecretValue(env, encrypted)
-	expect(result).toBe('fallback-test')
 })
 
 test('general-purpose encrypt/decrypt with purpose uses COOKIE_SECRET', async () => {

--- a/packages/worker/src/mcp/secrets/crypto.ts
+++ b/packages/worker/src/mcp/secrets/crypto.ts
@@ -77,11 +77,10 @@ export async function decryptStringWithPurpose(
 const secretStorePurpose = 'mcp-secret-store'
 
 export async function encryptSecretValue(
-	env: Pick<Env, 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>,
+	env: Pick<Env, 'SECRET_STORE_KEY'>,
 	value: string,
 ) {
-	const secret = getSecretStoreKey(env)
-	const key = await deriveEncryptionKey(secret, secretStorePurpose)
+	const key = await deriveEncryptionKey(env.SECRET_STORE_KEY, secretStorePurpose)
 	const iv = crypto.getRandomValues(new Uint8Array(ivBytes))
 	const ciphertext = await crypto.subtle.encrypt(
 		{ name: 'AES-GCM', iv },
@@ -92,7 +91,7 @@ export async function encryptSecretValue(
 }
 
 export async function decryptSecretValue(
-	env: Pick<Env, 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>,
+	env: Pick<Env, 'SECRET_STORE_KEY'>,
 	payload: string,
 ) {
 	const [ivPart, ciphertextPart] = payload.split('.')
@@ -102,8 +101,7 @@ export async function decryptSecretValue(
 	const iv = base64UrlToBytes(ivPart)
 	const ciphertextBytes = base64UrlToBytes(ciphertextPart)
 
-	const secret = getSecretStoreKey(env)
-	const key = await deriveEncryptionKey(secret, secretStorePurpose)
+	const key = await deriveEncryptionKey(env.SECRET_STORE_KEY, secretStorePurpose)
 	try {
 		const plaintext = await crypto.subtle.decrypt(
 			{ name: 'AES-GCM', iv },
@@ -114,10 +112,4 @@ export async function decryptSecretValue(
 	} catch {
 		throw new Error('Unable to decrypt secret value.')
 	}
-}
-
-function getSecretStoreKey(
-	env: Pick<Env, 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>,
-): string {
-	return env.SECRET_STORE_KEY ?? env.COOKIE_SECRET
 }

--- a/packages/worker/src/mcp/secrets/crypto.ts
+++ b/packages/worker/src/mcp/secrets/crypto.ts
@@ -98,11 +98,13 @@ export async function decryptSecretValue(
 	if (!ivPart || !ciphertextPart) {
 		throw new Error('Invalid encrypted secret payload.')
 	}
-	const iv = base64UrlToBytes(ivPart)
-	const ciphertextBytes = base64UrlToBytes(ciphertextPart)
-
-	const key = await deriveEncryptionKey(env.SECRET_STORE_KEY, secretStorePurpose)
 	try {
+		const iv = base64UrlToBytes(ivPart)
+		const ciphertextBytes = base64UrlToBytes(ciphertextPart)
+		const key = await deriveEncryptionKey(
+			env.SECRET_STORE_KEY,
+			secretStorePurpose,
+		)
 		const plaintext = await crypto.subtle.decrypt(
 			{ name: 'AES-GCM', iv },
 			key,

--- a/packages/worker/src/mcp/secrets/crypto.ts
+++ b/packages/worker/src/mcp/secrets/crypto.ts
@@ -102,34 +102,15 @@ export async function decryptSecretValue(
 	const iv = base64UrlToBytes(ivPart)
 	const ciphertextBytes = base64UrlToBytes(ciphertextPart)
 
-	const primarySecret = getSecretStoreKey(env)
-	const primaryKey = await deriveEncryptionKey(primarySecret, secretStorePurpose)
+	const secret = getSecretStoreKey(env)
+	const key = await deriveEncryptionKey(secret, secretStorePurpose)
 	try {
 		const plaintext = await crypto.subtle.decrypt(
 			{ name: 'AES-GCM', iv },
-			primaryKey,
+			key,
 			ciphertextBytes,
 		)
-		return { value: textDecoder.decode(plaintext), needsReEncrypt: false }
-	} catch {
-		// Primary key failed — attempt legacy COOKIE_SECRET fallback
-	}
-
-	if (primarySecret === env.COOKIE_SECRET) {
-		throw new Error('Unable to decrypt secret value.')
-	}
-
-	const legacyKey = await deriveEncryptionKey(
-		env.COOKIE_SECRET,
-		secretStorePurpose,
-	)
-	try {
-		const plaintext = await crypto.subtle.decrypt(
-			{ name: 'AES-GCM', iv },
-			legacyKey,
-			ciphertextBytes,
-		)
-		return { value: textDecoder.decode(plaintext), needsReEncrypt: true }
+		return textDecoder.decode(plaintext)
 	} catch {
 		throw new Error('Unable to decrypt secret value.')
 	}

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -40,7 +40,7 @@ type SecretOwnerContext = {
 }
 
 type SaveSecretInput = SecretOwnerContext & {
-	env: Pick<Env, 'APP_DB' | 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>
+	env: Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'>
 	scope: SecretScope
 	name: string
 	value: string
@@ -54,13 +54,13 @@ type ListSecretsInput = SecretOwnerContext & {
 }
 
 type ResolveSecretInput = SecretOwnerContext & {
-	env: Pick<Env, 'APP_DB' | 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>
+	env: Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'>
 	name: string
 	scope?: SecretScope | null
 }
 
 type UpdateSecretInput = SecretOwnerContext & {
-	env: Pick<Env, 'APP_DB' | 'COOKIE_SECRET' | 'SECRET_STORE_KEY'>
+	env: Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'>
 	name: string
 	scope: SecretScope
 	value?: string | null

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -200,24 +200,9 @@ export async function resolveSecret(
 		})
 		if (!entry) continue
 		const decrypted = await decryptSecretValue(input.env, entry.encrypted_value)
-		if (decrypted.needsReEncrypt) {
-			try {
-				const reEncrypted = await encryptSecretValue(input.env, decrypted.value)
-				await upsertSecretEntry({
-					db: input.env.APP_DB,
-					row: {
-						...entry,
-						encrypted_value: reEncrypted,
-						updated_at: new Date().toISOString(),
-					},
-				})
-			} catch {
-				// Best-effort re-encryption; read still succeeds with the decrypted value
-			}
-		}
 		return {
 			found: true,
-			value: decrypted.value,
+			value: decrypted,
 			scope,
 			allowedHosts: parseAllowedHosts(entry.allowed_hosts),
 			allowedCapabilities: parseAllowedCapabilities(entry.allowed_capabilities),

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -107,6 +107,7 @@ function createEnv(
 			delete: async () => undefined,
 		},
 		COOKIE_SECRET: cookieSecretValue,
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
 		JOB_MANAGER: mockJobDoNamespace('job-manager-test-id'),
 		STORAGE_RUNNER: mockJobDoNamespace('storage-runner-test-id'),
 		PACKAGE_REALTIME_SESSION: mockJobDoNamespace(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- require SECRET_STORE_KEY for secret store encryption/decryption
- remove fallback env usage and update schema/types accordingly
- normalize decrypt errors and update test env fixtures
- update docs and env examples to reflect required key

## Testing
- npm run typecheck
- npx vitest run --project node-unit --project workers-unit packages/worker/src/oauth-handlers.workers.test.ts

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-527a8463-a543-48cd-b6a9-2fd08c8d6611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-527a8463-a543-48cd-b6a9-2fd08c8d6611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified secret rotation with stepwise instructions; made SECRET_STORE_KEY required for all environments and tightened notes about preserving old keys and monitoring decryption errors.

* **Bug Fixes**
  * Removed legacy COOKIE_SECRET fallback for saved-secret decryption and stopped automatic re-encryption-on-read.

* **Tests**
  * Updated tests to match simplified decryption behavior and unified decryption error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->