### PR TITLE
Fix storage runner SQL rejection tests

### DIFF
--- a/packages/worker/src/storage-runner.workers.test.ts
+++ b/packages/worker/src/storage-runner.workers.test.ts
@@ -132,24 +132,20 @@ test('storage runner supports raw SQL with explicit writable access', async () =
 
 test('storage runner blocks mutating SQL when writable is false', async () => {
 	const storageId = createExecuteStorageId()
-	const runner = storageRunnerRpc({
-		env,
-		userId: 'user-123',
-		storageId,
-	})
+	const stub = env.STORAGE_RUNNER.get(
+		env.STORAGE_RUNNER.idFromName(JSON.stringify(['user-123', storageId])),
+	)
 
-	try {
-		await runner.sqlQuery({
-			query: 'delete from counters',
-			writable: false,
-		})
-		throw new Error('Expected read-only SQL mutation to fail.')
-	} catch (error) {
-		expect(error).toBeInstanceOf(Error)
-		expect((error as Error).message).toBe(
+	await runInDurableObject(stub, async (instance: StorageRunner) => {
+		await expect(
+			instance.sqlQuery({
+				query: 'delete from counters',
+				writable: false,
+			}),
+		).rejects.toThrow(
 			'Read-only storage.sql only allows a single SELECT, EXPLAIN, or schema PRAGMA statement. Pass writable: true to allow multi-statement or mutating queries.',
 		)
-	}
+	})
 })
 
 test('storage runner blocks multi-statement SQL in read-only mode', async () => {
@@ -165,18 +161,19 @@ test('storage runner blocks multi-statement SQL in read-only mode', async () => 
 		value: 1,
 	})
 
-	try {
-		await runner.sqlQuery({
-			query: 'select 1 as ok; delete from sqlite_schema',
-			writable: false,
-		})
-		throw new Error('Expected multi-statement read-only SQL to fail.')
-	} catch (error) {
-		expect(error).toBeInstanceOf(Error)
-		expect((error as Error).message).toBe(
+	const stub = env.STORAGE_RUNNER.get(
+		env.STORAGE_RUNNER.idFromName(JSON.stringify(['user-123', storageId])),
+	)
+	await runInDurableObject(stub, async (instance: StorageRunner) => {
+		await expect(
+			instance.sqlQuery({
+				query: 'select 1 as ok; delete from sqlite_schema',
+				writable: false,
+			}),
+		).rejects.toThrow(
 			'Read-only storage.sql only allows a single SELECT, EXPLAIN, or schema PRAGMA statement. Pass writable: true to allow multi-statement or mutating queries.',
 		)
-	}
+	})
 
 	await expect(
 		runner.getValue({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Assert storage runner read-only SQL failures inside the Durable Object test instance so expected rejections are observed without worker uncaught-exception logs.

## Testing
- `npx oxfmt --check packages/worker/src/storage-runner.workers.test.ts`
- `npx oxlint packages/worker/src/storage-runner.workers.test.ts`
- `npx vitest run --project workers-unit packages/worker/src/storage-runner.workers.test.ts`
- `npm run test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92f978ab-ad7c-465b-a67a-35a1f5fff120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92f978ab-ad7c-465b-a67a-35a1f5fff120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

