### PR TITLE
Remove secret reveal confirmation flow

### DIFF
--- a/e2e/connect-secret.spec.ts
+++ b/e2e/connect-secret.spec.ts
@@ -47,8 +47,15 @@ test('connect secret shows editable name and scope and saves the edited name', a
 		page.getByRole('heading', { level: 2, name: editedName }),
 	).toBeVisible()
 	await expect(page.getByLabel('Description')).toHaveValue(description)
-	await expect(
-		page.getByPlaceholder('Enter the secret value').first(),
-	).toHaveValue('')
+	const savedSecretInput = page
+		.getByPlaceholder('Enter the secret value')
+		.first()
+	await expect(savedSecretInput).toHaveAttribute('type', 'password')
+	await expect(savedSecretInput).toHaveValue(secretValue)
+	await expect(page.getByText('Reveal current value')).toBeHidden()
+	await expect(page.getByText('Account password')).toBeHidden()
+	await page.getByRole('button', { name: 'Show secret value' }).click()
+	await expect(savedSecretInput).toHaveAttribute('type', 'text')
+	await expect(savedSecretInput).toHaveValue(secretValue)
 	await expect(page.getByPlaceholder('saved package id')).toHaveValue(packageId)
 })

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -66,7 +66,9 @@ type SecretListItem = {
 	ttlMs: number | null
 }
 
-type SecretDetail = SecretListItem
+type SecretDetail = SecretListItem & {
+	value: string
+}
 
 type AccountSecretsPayload = {
 	ok: true
@@ -176,7 +178,7 @@ function createEditorStateFromSecret(secret: SecretDetail): EditorState {
 		scope: secret.scope,
 		appId: secret.appId ?? '',
 		description: secret.description,
-		value: '',
+		value: secret.value,
 		allowedHosts: allowedHosts.length > 0 ? allowedHosts : [''],
 		allowedCapabilities:
 			allowedCapabilities.length > 0 ? allowedCapabilities : [''],
@@ -462,9 +464,6 @@ export function AccountSecretsRoute(handle: Handle) {
 	let loadRequestId = 0
 	let retryTimeout: ReturnType<typeof setTimeout> | null = null
 	let showSecretValue = false
-	let revealState: 'idle' | 'prompting' | 'revealing' | 'revealed' = 'idle'
-	let revealPassword = ''
-	let revealError: string | null = null
 	const deleteSecretCheck = createDoubleCheck(handle)
 	const filterAppCombobox = TypeaheadCombobox(handle)
 	const editorAppCombobox = TypeaheadCombobox(handle)
@@ -494,9 +493,6 @@ export function AccountSecretsRoute(handle: Handle) {
 	function syncEditorState(selection: SelectionState) {
 		deleteSecretCheck.reset()
 		showSecretValue = false
-		revealState = 'idle'
-		revealPassword = ''
-		revealError = null
 		const capabilityPrefill = readCapabilityPrefill(getCurrentHref())
 		if (selection.isCreating) {
 			editorState = applyCapabilityPrefill(
@@ -809,76 +805,6 @@ export function AccountSecretsRoute(handle: Handle) {
 			saveState = 'idle'
 			message =
 				error instanceof Error ? error.message : 'Unable to delete secret.'
-			handle.update()
-		}
-	}
-
-	async function revealSecretValue() {
-		if (!editorState.currentId || revealState === 'revealing') return
-		if (!revealPassword.trim()) {
-			revealError = 'Password is required.'
-			handle.update()
-			return
-		}
-
-		const capturedSecretId = editorState.currentId
-		revealState = 'revealing'
-		revealError = null
-		handle.update()
-
-		try {
-			const response = await fetch('/account/secrets/reveal', {
-				method: 'POST',
-				headers: {
-					Accept: 'application/json',
-					'Content-Type': 'application/json',
-				},
-				credentials: 'include',
-				body: JSON.stringify({
-					secretId: capturedSecretId,
-					password: revealPassword,
-				}),
-			})
-
-			if (
-				editorState.currentId !== capturedSecretId ||
-				revealState !== 'revealing'
-			)
-				return
-
-			if (response.status === 401) {
-				const payload = await readJson<{ error?: string }>(response)
-				revealState = 'prompting'
-				revealError = payload?.error ?? 'Invalid password.'
-				revealPassword = ''
-				handle.update()
-				return
-			}
-
-			const payload = await readJson<{
-				ok?: boolean
-				value?: string
-				error?: string
-			}>(response)
-			if (!response.ok || !payload?.ok || typeof payload.value !== 'string') {
-				throw new Error(payload?.error ?? 'Unable to reveal secret.')
-			}
-
-			editorState = { ...editorState, value: payload.value }
-			revealState = 'revealed'
-			revealPassword = ''
-			revealError = null
-			showSecretValue = true
-			handle.update()
-		} catch (error) {
-			if (
-				editorState.currentId !== capturedSecretId ||
-				revealState !== 'revealing'
-			)
-				return
-			revealState = 'prompting'
-			revealError =
-				error instanceof Error ? error.message : 'Unable to reveal secret.'
 			handle.update()
 		}
 	}
@@ -1545,149 +1471,39 @@ export function AccountSecretsRoute(handle: Handle) {
 										})
 									: null}
 
-							<SecretEditorFields
-								description={editorState.description}
-								onDescriptionChange={(description) => {
-									editorState = {
-										...editorState,
-										description,
-									}
-									handle.update()
-								}}
-								value={editorState.value}
-								onValueChange={(value) => {
-									editorState = {
-										...editorState,
-										value,
-									}
-									handle.update()
-								}}
-								showSecretValue={showSecretValue}
-								onToggleShowSecretValue={() => {
-									showSecretValue = !showSecretValue
-									handle.update()
-								}}
-								allowedHosts={editorState.allowedHosts}
-								onUpdateAllowedHost={updateAllowedHost}
-								onAddAllowedHost={addAllowedHost}
-								onRemoveAllowedHost={removeAllowedHost}
-								allowedCapabilities={editorState.allowedCapabilities}
-								onUpdateAllowedCapability={updateAllowedCapability}
-								onAddAllowedCapability={addAllowedCapability}
-								onRemoveAllowedCapability={removeAllowedCapability}
-								allowedHostsListName="allowed-hosts"
-								allowedCapabilitiesListName="allowed-capabilities"
-							/>
-
-							{editorState.currentId &&
-							revealState !== 'revealed' ? (
-								<div
-									mix={css({
-										display: 'grid',
-										gap: spacing.sm,
-										padding: spacing.md,
-										borderRadius: radius.md,
-										border: `1px solid ${colors.border}`,
-										backgroundColor: colors.background,
-									})}
-								>
-									<span mix={css(fieldLabelCss)}>
-										Reveal current value
-									</span>
-									<p mix={css({ margin: 0, color: colors.textMuted })}>
-										Re-enter your account password to view the stored value.
-									</p>
-									{revealState === 'prompting' ||
-									revealState === 'revealing' ? (
-										<>
-											<input
-												type="password"
-												autoComplete="current-password"
-												placeholder="Account password"
-												aria-label="Account password for reveal"
-												value={revealPassword}
-												disabled={revealState === 'revealing'}
-												mix={[
-													on(
-														'input',
-														(event) => {
-															revealPassword = event.currentTarget.value
-															revealError = null
-															handle.update()
-														},
-													),
-													on('keydown', (event) => {
-														if (event.key === 'Enter') {
-															event.preventDefault()
-															void revealSecretValue()
-														}
-													}),
-													css(inputCss),
-												]}
-											/>
-											{revealError ? (
-												<p
-													role="alert"
-													mix={css({
-														margin: 0,
-														color: colors.error,
-													})}
-												>
-													{revealError}
-												</p>
-											) : null}
-											<div
-												mix={css({
-													display: 'flex',
-													gap: spacing.sm,
-												})}
-											>
-												<button
-													type="button"
-													disabled={revealState === 'revealing'}
-													mix={[
-														on('click', () => void revealSecretValue()),
-														css(primaryButtonCss),
-													]}
-												>
-													{revealState === 'revealing'
-														? 'Verifying...'
-														: 'Confirm'}
-												</button>
-												<button
-													type="button"
-													mix={[
-														on('click', () => {
-															revealState = 'idle'
-															revealPassword = ''
-															revealError = null
-															handle.update()
-														}),
-														css(secondaryButtonCss),
-													]}
-												>
-													Cancel
-												</button>
-											</div>
-										</>
-									) : (
-										<div>
-											<button
-												type="button"
-												mix={[
-													on('click', () => {
-														revealState = 'prompting'
-														handle.update()
-													}),
-													css(secondaryButtonCss),
-												]}
-											>
-												Reveal value
-											</button>
-										</div>
-									)}
-								</div>
-							) : null}
+								<SecretEditorFields
+									description={editorState.description}
+									onDescriptionChange={(description) => {
+										editorState = {
+											...editorState,
+											description,
+										}
+										handle.update()
+									}}
+									value={editorState.value}
+									onValueChange={(value) => {
+										editorState = {
+											...editorState,
+											value,
+										}
+										handle.update()
+									}}
+									showSecretValue={showSecretValue}
+									onToggleShowSecretValue={() => {
+										showSecretValue = !showSecretValue
+										handle.update()
+									}}
+									allowedHosts={editorState.allowedHosts}
+									onUpdateAllowedHost={updateAllowedHost}
+									onAddAllowedHost={addAllowedHost}
+									onRemoveAllowedHost={removeAllowedHost}
+									allowedCapabilities={editorState.allowedCapabilities}
+									onUpdateAllowedCapability={updateAllowedCapability}
+									onAddAllowedCapability={addAllowedCapability}
+									onRemoveAllowedCapability={removeAllowedCapability}
+									allowedHostsListName="allowed-hosts"
+									allowedCapabilitiesListName="allowed-capabilities"
+								/>
 
 								<div mix={css({ display: 'grid', gap: spacing.sm })}>
 									<div mix={css({ display: 'grid', gap: spacing.xs })}>

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -40,10 +40,6 @@ const mockModule = vi.hoisted(() => ({
 	setSecretAllowedCapabilities: vi.fn(async () => undefined),
 	setSecretAllowedPackages: vi.fn(async () => undefined),
 	getValue: vi.fn(async () => null),
-	logAuditEvent: vi.fn(async () => undefined),
-	getRequestIp: vi.fn(() => null),
-	dbFindOne: vi.fn(async () => null),
-	verifyPassword: vi.fn(async () => false),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -108,31 +104,12 @@ vi.mock('#mcp/values/service.ts', () => ({
 	saveValue: (...args: Array<unknown>) => mockModule.saveValue(...args),
 }))
 
-vi.mock('#app/audit-log.ts', () => ({
-	logAuditEvent: (...args: Array<unknown>) =>
-		mockModule.logAuditEvent(...args),
-	getRequestIp: (...args: Array<unknown>) => mockModule.getRequestIp(...args),
-}))
-
-vi.mock('#worker/db.ts', () => ({
-	createDb: () => ({
-		findOne: (...args: Array<unknown>) => mockModule.dbFindOne(...args),
-	}),
-	usersTable: 'users',
-}))
-
-vi.mock('@kody-internal/shared/password-hash.ts', () => ({
-	verifyPassword: (...args: Array<unknown>) =>
-		mockModule.verifyPassword(...args),
-}))
-
 vi.mock('#worker/package-registry/repo.ts', () => ({
 	listSavedPackagesByUserId: (...args: Array<unknown>) =>
 		mockModule.listSavedPackagesByUserId(...args),
 }))
 
-const { createAccountSecretsApiHandler, createAccountSecretRevealHandler } =
-	await import('./account-secrets.ts')
+const { createAccountSecretsApiHandler } = await import('./account-secrets.ts')
 
 function createEnv() {
 	return {
@@ -564,7 +541,7 @@ test('package approval approve deduplicates allowed package ids', async () => {
 	)
 })
 
-test('GET /account/secrets.json keeps selected metadata without decrypted value', async () => {
+test('GET /account/secrets.json includes selected secret value for editing', async () => {
 	mockModule.listSecrets.mockResolvedValueOnce([
 		{
 			name: 'myApiKey',
@@ -581,6 +558,10 @@ test('GET /account/secrets.json keeps selected metadata without decrypted value'
 	])
 	mockModule.listSavedPackagesByUserId.mockResolvedValueOnce([])
 	mockModule.listAppSecretsByAppIds.mockResolvedValueOnce(new Map())
+	mockModule.resolveSecret.mockResolvedValueOnce({
+		found: true,
+		value: 'seeded-secret-value',
+	})
 
 	const handler = createAccountSecretsApiHandler(createEnv())
 	const response = await handler.handler({
@@ -597,95 +578,12 @@ test('GET /account/secrets.json keeps selected metadata without decrypted value'
 	expect(payload.selectedSecret).toBeDefined()
 	expect(payload.selectedSecret.name).toBe('myApiKey')
 	expect(payload.selectedSecret.description).toBe('API key')
-	expect(payload.selectedSecret).not.toHaveProperty('value')
-	expect(mockModule.resolveSecret).not.toHaveBeenCalled()
-})
-
-test('POST /account/secrets/reveal without password returns 401', async () => {
-	const handler = createAccountSecretRevealHandler(createEnv())
-	const response = await handler.handler({
-		request: new Request('https://example.com/account/secrets/reveal', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ secretId: 'user::::myApiKey' }),
-		}),
-	})
-
-	expect(response.status).toBe(401)
-	const payload = await response.json()
-	expect(payload.ok).toBe(false)
-})
-
-test('POST /account/secrets/reveal with wrong password returns 401', async () => {
-	mockModule.dbFindOne.mockResolvedValueOnce({
-		id: 42,
-		email: 'user@example.com',
-		password_hash:
-			'pbkdf2_sha256$100000$0000000000000000$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-	})
-	mockModule.verifyPassword.mockResolvedValueOnce(false)
-
-	const handler = createAccountSecretRevealHandler(createEnv())
-	const response = await handler.handler({
-		request: new Request('https://example.com/account/secrets/reveal', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				secretId: 'user::::myApiKey',
-				password: 'wrong-password',
-			}),
-		}),
-	})
-
-	expect(response.status).toBe(401)
-	const payload = await response.json()
-	expect(payload.ok).toBe(false)
-	expect(payload.error).toBe('Invalid password.')
-	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
+	expect(payload.selectedSecret.value).toBe('seeded-secret-value')
+	expect(mockModule.resolveSecret).toHaveBeenCalledWith(
 		expect.objectContaining({
-			category: 'auth',
-			action: 'secret_reveal',
-			result: 'failure',
-			reason: 'invalid_password',
-		}),
-	)
-})
-
-test('POST /account/secrets/reveal with valid reauth returns plaintext and writes audit log', async () => {
-	mockModule.dbFindOne.mockResolvedValueOnce({
-		id: 42,
-		email: 'user@example.com',
-		password_hash:
-			'pbkdf2_sha256$100000$0000000000000000$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-	})
-	mockModule.verifyPassword.mockResolvedValueOnce(true)
-	mockModule.resolveSecret.mockResolvedValueOnce({
-		found: true,
-		value: 'the-actual-secret-value',
-	})
-
-	const handler = createAccountSecretRevealHandler(createEnv())
-	const response = await handler.handler({
-		request: new Request('https://example.com/account/secrets/reveal', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				secretId: 'user::::myApiKey',
-				password: 'correct-password',
-			}),
-		}),
-	})
-
-	expect(response.status).toBe(200)
-	expect(response.headers.get('Cache-Control')).toBe('no-store')
-	const payload = await response.json()
-	expect(payload.ok).toBe(true)
-	expect(payload.value).toBe('the-actual-secret-value')
-	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
-		expect.objectContaining({
-			category: 'auth',
-			action: 'secret_reveal',
-			result: 'success',
+			name: 'myApiKey',
+			scope: 'user',
+			storageContext: { appId: null, sessionId: null },
 		}),
 	)
 })

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -4,7 +4,6 @@ import {
 	parseAccountSecretId,
 } from '@kody-internal/shared/account-secret-route.ts'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
-import { logAuditEvent, getRequestIp } from '#app/audit-log.ts'
 import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { redirectToLogin } from '#app/auth-redirect.ts'
@@ -33,8 +32,6 @@ import {
 	buildConnectorValueName,
 	normalizeConnectorConfig,
 } from '#mcp/capabilities/values/connector-shared.ts'
-import { createDb, usersTable } from '#worker/db.ts'
-import { verifyPassword } from '@kody-internal/shared/password-hash.ts'
 
 type AccountEditableSecretScope = Extract<SecretScope, 'app' | 'user'>
 
@@ -67,7 +64,9 @@ type AccountSecretListItem = {
 	ttlMs: number | null
 }
 
-type AccountSecretDetail = AccountSecretListItem
+type AccountSecretDetail = AccountSecretListItem & {
+	value: string
+}
 
 type SecretApprovalView = {
 	name: string
@@ -207,105 +206,6 @@ export function createAccountSecretsApiHandler(env: Env) {
 		typeof routes.accountSecretsApi.method,
 		typeof routes.accountSecretsApi.pattern
 	>
-}
-
-export function createAccountSecretRevealHandler(env: Env) {
-	const db = createDb(env.APP_DB)
-
-	return {
-		middleware: [],
-		async handler({ request }: { request: Request }) {
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
-			}
-
-			if (request.method !== 'POST') {
-				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
-			}
-
-			const body = await request.json().catch(() => null)
-			if (!body || typeof body !== 'object') {
-				return jsonResponse({ ok: false, error: 'Invalid request body.' }, 400)
-			}
-
-			const secretId = readString(body, 'secretId')
-			const rawPassword = (body as Record<string, unknown>)['password']
-			const password =
-				typeof rawPassword === 'string' && rawPassword.length > 0
-					? rawPassword
-					: null
-			if (!secretId) {
-				return jsonResponse({ ok: false, error: 'Secret id is required.' }, 400)
-			}
-			if (!password) {
-				return jsonResponse(
-					{ ok: false, error: 'Password is required for reveal.' },
-					401,
-				)
-			}
-
-			const parsed = parseAccountSecretId(secretId)
-			if (!parsed) {
-				return jsonResponse({ ok: false, error: 'Invalid secret id.' }, 400)
-			}
-
-			const userRecord = await db.findOne(usersTable, {
-				where: { id: user.userId },
-			})
-			if (!userRecord) {
-				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
-			}
-			const passwordValid = await verifyPassword(
-				password,
-				userRecord.password_hash,
-			)
-			if (!passwordValid) {
-				void logAuditEvent({
-					category: 'auth',
-					action: 'secret_reveal',
-					result: 'failure',
-					email: user.email,
-					ip: getRequestIp(request) ?? undefined,
-					reason: 'invalid_password',
-				})
-				return jsonResponse(
-					{ ok: false, error: 'Invalid password.' },
-					401,
-				)
-			}
-
-			const resolved = await resolveSecret({
-				env,
-				userId: user.mcpUser.userId,
-				name: parsed.name,
-				scope: parsed.scope,
-				storageContext: getSecretContextForAccountSecret(parsed),
-			})
-			if (!resolved.found || resolved.value == null) {
-				return jsonResponse({ ok: false, error: 'Secret not found.' }, 404)
-			}
-
-			void logAuditEvent({
-				category: 'auth',
-				action: 'secret_reveal',
-				result: 'success',
-				email: user.email,
-				ip: getRequestIp(request) ?? undefined,
-			})
-
-			return new Response(
-				JSON.stringify({ ok: true, value: resolved.value }),
-				{
-					status: 200,
-					headers: {
-						'Cache-Control': 'no-store',
-						'Content-Type': 'application/json; charset=utf-8',
-					},
-				},
-			)
-		},
-	}
 }
 
 async function handleValueGetAction(input: {
@@ -735,7 +635,9 @@ async function buildAccountSecretsPayload(input: {
 		packageApps,
 	})
 	const selectedSecret = input.selectedSecretId
-		? resolveAccountSecretDetail({
+		? await resolveAccountSecretDetail({
+				env: input.env,
+				userId: input.user.mcpUser.userId,
 				secretId: input.selectedSecretId,
 				secrets,
 			})
@@ -896,7 +798,9 @@ async function resolveSecretApprovalView(input: {
 	} satisfies SecretApprovalView
 }
 
-function resolveAccountSecretDetail(input: {
+async function resolveAccountSecretDetail(input: {
+	env: Env
+	userId: string
 	secretId: string
 	secrets: Array<AccountSecretListItem>
 }) {
@@ -904,7 +808,18 @@ function resolveAccountSecretDetail(input: {
 	if (!parsed) return null
 
 	const selected = input.secrets.find((secret) => secret.id === input.secretId)
-	return selected ?? null
+	if (!selected) return null
+	const resolved = await resolveSecret({
+		env: input.env,
+		userId: input.userId,
+		name: parsed.name,
+		scope: parsed.scope,
+		storageContext: getSecretContextForAccountSecret(parsed),
+	})
+	return {
+		...selected,
+		value: resolved.found && resolved.value != null ? resolved.value : '',
+	} satisfies AccountSecretDetail
 }
 
 function toAccountSecretListItem(

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -1,7 +1,6 @@
 import { createRouter } from 'remix/fetch-router'
 import { account } from '#app/handlers/account.ts'
 import {
-	createAccountSecretRevealHandler,
 	createAccountSecretsApiHandler,
 	createAccountSecretsHandler,
 } from '#app/handlers/account-secrets.ts'
@@ -78,9 +77,6 @@ export function createAppRouter(appEnv: AppEnv) {
 				appEnv as unknown as Env,
 			),
 			accountSecretsApiPost: createAccountSecretsApiHandler(
-				appEnv as unknown as Env,
-			),
-			accountSecretsReveal: createAccountSecretRevealHandler(
 				appEnv as unknown as Env,
 			),
 			connectSecret: createConnectSecretHandler(appEnv as unknown as Env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -18,7 +18,6 @@ export const routes = route({
 	accountSecretsApprove: '/account/secrets/approve',
 	accountSecretsApi: '/account/secrets.json',
 	accountSecretsApiPost: post('/account/secrets.json'),
-	accountSecretsReveal: post('/account/secrets/reveal'),
 	chatThreads: '/chat-threads',
 	chatThreadsCreate: post('/chat-threads'),
 	chatThreadsUpdate: post('/chat-threads/update'),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Load selected account secret values into the editor payload.
- Populate the shared password field with the stored secret value and rely on the existing eye icon for reveal/hide.
- Remove the password confirmation reveal route and related UI state.
- Update e2e coverage to assert the saved secret value loads masked and reveals via the eye icon.

### Walkthrough
<a href="https://cursor.com/agents/bc-0ebdcc38-e0df-43d4-b953-510142c7b416/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsecret-value-eye-reveal-b416.webm"><img src="https://cursor.com/artifacts/c/art-86aba42b-8052-457b-b8a0-e2906c042d24" alt="secret-value-eye-reveal-b416.webm" /></a>

### Validation
- `npx vitest run "packages/worker/src/app/handlers/account-secrets.node.test.ts"`
- `npm run typecheck`
- `npm run build:client:web`
- `git diff --check`
- `npx playwright test "e2e/connect-secret.spec.ts" --project=chromium`
- Manual Playwright walkthrough against local preview with seeded `manual-secret-b416` value.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ebdcc38-e0df-43d4-b953-510142c7b416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ebdcc38-e0df-43d4-b953-510142c7b416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

