### PR TITLE
Mitigate Bond bridge request storms

### DIFF
--- a/packages/home-connector/src/adapters/bond/index.node.test.ts
+++ b/packages/home-connector/src/adapters/bond/index.node.test.ts
@@ -809,9 +809,14 @@ test('bond cooldown prevents follow-up requests after network failures', async (
 		expect(globalThis.fetch).toHaveBeenCalledTimes(1)
 		const status = bond.getReliabilityStatus({ bridgeId: 'BONDTEST13' })
 		expect(status.persisted?.lastFailureReason).toContain('fetch failed')
-		expect(status.recentRequestLogs.map((log) => log.status)).toEqual([
-			'cooldown',
-			'failure',
+		expect(
+			status.recentRequestLogs.map((log) => ({
+				status: log.status,
+				baseUrlsTried: log.baseUrlsTried,
+			})),
+		).toEqual([
+			{ status: 'cooldown', baseUrlsTried: [] },
+			{ status: 'failure', baseUrlsTried: ['http://10.0.0.22'] },
 		])
 	} finally {
 		vi.useRealTimers()
@@ -952,6 +957,73 @@ test('bond coalesces duplicate device state reads while one is in flight', async
 	}
 })
 
+test('bond coalesces duplicate queued device state reads until the shared request settles', async () => {
+	const config = {
+		...createConfig(),
+		bondRequestPaceMs: 2_000,
+	}
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	vi.useFakeTimers()
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		const url = String(input)
+		if (url === 'http://10.0.0.22/v2/devices/blocker/state') {
+			return mockJsonResponse({ position: 1, _: 'blocker' })
+		}
+		if (url === 'http://10.0.0.22/v2/devices/queued/state') {
+			return mockJsonResponse({ position: 2, _: 'queued' })
+		}
+		throw new Error(`Unexpected fetch URL: ${url}`)
+	})
+	globalThis.fetch = fetchMock as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST14',
+				bondid: 'BONDTEST14',
+				instanceName: 'Long Queue Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T22:05:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST14')
+		bond.setToken('BONDTEST14', 'bond-token')
+
+		const blocker = bond.getDeviceState('BONDTEST14', 'blocker')
+		await vi.advanceTimersByTimeAsync(0)
+		await expect(blocker).resolves.toMatchObject({ position: 1 })
+
+		const firstQueued = bond.getDeviceState('BONDTEST14', 'queued')
+		await vi.advanceTimersByTimeAsync(1_500)
+		const secondQueued = bond.getDeviceState('BONDTEST14', 'queued')
+		await vi.advanceTimersByTimeAsync(500)
+
+		await expect(firstQueued).resolves.toMatchObject({ position: 2 })
+		await expect(secondQueued).resolves.toMatchObject({ position: 2 })
+		expect(
+			fetchMock.mock.calls.filter((call) =>
+				String(call[0]).endsWith('/v2/devices/queued/state'),
+			),
+		).toHaveLength(1)
+	} finally {
+		vi.useRealTimers()
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
 test('bond enters cooldown after network failure and rejects queued requests', async () => {
 	const config = {
 		...createConfig(),
@@ -1002,9 +1074,14 @@ test('bond enters cooldown after network failure and rejects queued requests', a
 		})
 		expect(status.queue.cooldownUntil).toBeTruthy()
 		expect(status.persisted?.cooldownUntil).toBeTruthy()
-		expect(status.recentRequestLogs.map((log) => log.status)).toEqual([
-			'cooldown',
-			'failure',
+		expect(
+			status.recentRequestLogs.map((log) => ({
+				status: log.status,
+				baseUrlsTried: log.baseUrlsTried,
+			})),
+		).toEqual([
+			{ status: 'cooldown', baseUrlsTried: [] },
+			{ status: 'failure', baseUrlsTried: ['http://10.0.0.22'] },
 		])
 	} finally {
 		vi.useRealTimers()

--- a/packages/home-connector/src/adapters/bond/index.node.test.ts
+++ b/packages/home-connector/src/adapters/bond/index.node.test.ts
@@ -21,6 +21,8 @@ function createConfig(): HomeConnectorConfig {
 		sonosDiscoveryUrl: 'http://sonos.mock.local/discovery',
 		samsungTvDiscoveryUrl: 'http://samsung-tv.mock.local/discovery',
 		bondDiscoveryUrl: 'http://bond.mock.local/discovery',
+		bondRequestPaceMs: 0,
+		bondCircuitBreakerCooldownMs: 0,
 		jellyfishDiscoveryUrl: 'http://jellyfish.mock.local/discovery',
 		venstarScanCidrs: ['192.168.10.40/32'],
 		jellyfishScanCidrs: ['192.168.10.93/32'],
@@ -690,6 +692,322 @@ test('bond does not refresh bridge lastSeenAt after failed requests', async () =
 				.lastSeenAt,
 		).toBe('2026-04-27T21:35:00.000Z')
 	} finally {
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
+test('bond serializes bridge requests and applies configured pacing', async () => {
+	const config = {
+		...createConfig(),
+		bondRequestPaceMs: 250,
+	}
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	vi.useFakeTimers()
+	const testStart = Date.now()
+	const fetchStarts: Array<number> = []
+	globalThis.fetch = vi.fn(async () => {
+		fetchStarts.push(Date.now() - testStart)
+		await new Promise((resolve) => setTimeout(resolve, 10))
+		return mockJsonResponse({ position: fetchStarts.length, _: 's' })
+	}) as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST11',
+				bondid: 'BONDTEST11',
+				instanceName: 'Paced Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:50:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST11')
+		bond.setToken('BONDTEST11', 'bond-token')
+
+		const firstPromise = bond.getDeviceState('BONDTEST11', 'mockdev1')
+		const secondPromise = bond.getDeviceState('BONDTEST11', 'mockdev2')
+		await vi.advanceTimersByTimeAsync(9)
+		expect(fetchStarts).toEqual([0])
+		await vi.advanceTimersByTimeAsync(1)
+		await firstPromise
+		await vi.advanceTimersByTimeAsync(249)
+		expect(fetchStarts).toEqual([0])
+		await vi.advanceTimersByTimeAsync(1)
+		await vi.advanceTimersByTimeAsync(10)
+		await secondPromise
+
+		expect(fetchStarts).toEqual([0, 260])
+		expect(bond.getReliabilityStatus({ bridgeId: 'BONDTEST11' })).toMatchObject({
+			recentRequestLogs: [
+				{ operation: 'fetch device mockdev2 state', status: 'success' },
+				{ operation: 'fetch device mockdev1 state', status: 'success' },
+			],
+		})
+	} finally {
+		vi.useRealTimers()
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
+test('bond cooldown prevents follow-up requests after network failures', async () => {
+	const config = {
+		...createConfig(),
+		bondCircuitBreakerCooldownMs: 60_000,
+	}
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	vi.useFakeTimers()
+	globalThis.fetch = vi.fn(async () => {
+		throw createDnsFetchError('getaddrinfo ENOTFOUND 10.0.0.22')
+	}) as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST13',
+				bondid: 'BONDTEST13',
+				instanceName: 'Cooldown Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T22:00:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST13')
+		bond.setToken('BONDTEST13', 'bond-token')
+
+		await bond.getDeviceState('BONDTEST13', 'mockdev1').catch(() => null)
+		const error = await bond
+			.getDeviceState('BONDTEST13', 'mockdev2')
+			.catch((caughtError: unknown) => caughtError)
+
+		expect(error).toBeInstanceOf(Error)
+		expect((error as Error).name).toBe('BondCircuitBreakerError')
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+		const status = bond.getReliabilityStatus({ bridgeId: 'BONDTEST13' })
+		expect(status.persisted?.lastFailureReason).toContain('fetch failed')
+		expect(status.recentRequestLogs.map((log) => log.status)).toEqual([
+			'cooldown',
+			'failure',
+		])
+	} finally {
+		vi.useRealTimers()
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
+test('bond serializes paced bridge requests and writes request logs', async () => {
+	const config = {
+		...createConfig(),
+		bondRequestPaceMs: 100,
+	}
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	vi.useFakeTimers()
+	const fetchStarts: Array<number> = []
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		fetchStarts.push(Date.now())
+		const url = String(input)
+		if (url === 'http://10.0.0.22/v2/devices/dev1/state') {
+			return mockJsonResponse({ position: 10, _: 's1' })
+		}
+		if (url === 'http://10.0.0.22/v2/devices/dev2/state') {
+			return mockJsonResponse({ position: 20, _: 's2' })
+		}
+		throw new Error(`Unexpected fetch URL: ${url}`)
+	})
+	globalThis.fetch = fetchMock as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST11',
+				bondid: 'BONDTEST11',
+				instanceName: 'Queued Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:50:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST11')
+		bond.setToken('BONDTEST11', 'bond-token')
+
+		const first = bond.getDeviceState('BONDTEST11', 'dev1')
+		const second = bond.getDeviceState('BONDTEST11', 'dev2')
+		await vi.advanceTimersByTimeAsync(0)
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+		await vi.advanceTimersByTimeAsync(99)
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+		await vi.advanceTimersByTimeAsync(1)
+
+		await expect(first).resolves.toMatchObject({ position: 10 })
+		await expect(second).resolves.toMatchObject({ position: 20 })
+		expect(fetchStarts[1]! - fetchStarts[0]!).toBeGreaterThanOrEqual(100)
+		const status = bond.getReliabilityStatus({
+			bridgeId: 'BONDTEST11',
+			limit: 10,
+		})
+		expect(status.recentRequestLogs).toHaveLength(2)
+		expect(status.recentRequestLogs.map((log) => log.status)).toEqual([
+			'success',
+			'success',
+		])
+	} finally {
+		vi.useRealTimers()
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
+test('bond coalesces duplicate device state reads while one is in flight', async () => {
+	const config = createConfig()
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	let resolveFetch: ((response: Response) => void) | null = null
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		const url = String(input)
+		if (url !== 'http://10.0.0.22/v2/devices/mockdev1/state') {
+			throw new Error(`Unexpected fetch URL: ${url}`)
+		}
+		return await new Promise<Response>((resolve) => {
+			resolveFetch = resolve
+		})
+	})
+	globalThis.fetch = fetchMock as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST12',
+				bondid: 'BONDTEST12',
+				instanceName: 'Coalesced Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T21:55:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST12')
+		bond.setToken('BONDTEST12', 'bond-token')
+
+		const first = bond.getDeviceState('BONDTEST12', 'mockdev1')
+		const second = bond.getDeviceState('BONDTEST12', 'mockdev1')
+		await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+		resolveFetch?.(mockJsonResponse({ position: 77, _: 's' }))
+
+		await expect(first).resolves.toMatchObject({ position: 77 })
+		await expect(second).resolves.toMatchObject({ position: 77 })
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+		expect(
+			bond.getReliabilityStatus({
+				bridgeId: 'BONDTEST12',
+			}).recentRequestLogs,
+		).toHaveLength(1)
+	} finally {
+		globalThis.fetch = previousFetch
+		storage.close()
+	}
+})
+
+test('bond enters cooldown after network failure and rejects queued requests', async () => {
+	const config = {
+		...createConfig(),
+		bondCircuitBreakerCooldownMs: 60_000,
+	}
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const previousFetch = globalThis.fetch
+	vi.useFakeTimers()
+	const fetchMock = vi.fn(async () => {
+		throw createDnsFetchError('getaddrinfo ENOTFOUND 10.0.0.22')
+	})
+	globalThis.fetch = fetchMock as typeof fetch
+
+	try {
+		upsertDiscoveredBondBridges(storage, config.homeConnectorId, [
+			{
+				bridgeId: 'BONDTEST13',
+				bondid: 'BONDTEST13',
+				instanceName: 'Cooldown Bond',
+				host: '10.0.0.22',
+				port: 80,
+				address: null,
+				model: 'BD-TEST',
+				fwVer: 'v1.0.0',
+				lastSeenAt: '2026-04-27T22:00:00.000Z',
+				rawDiscovery: {},
+			},
+		])
+		adoptBondBridge(storage, config.homeConnectorId, 'BONDTEST13')
+		bond.setToken('BONDTEST13', 'bond-token')
+
+		await expect(bond.getDeviceState('BONDTEST13', 'dev1')).rejects.toThrow(
+			'Bond bridge "BONDTEST13" could not be reached',
+		)
+		await expect(bond.getDeviceState('BONDTEST13', 'dev2')).rejects.toThrow(
+			'cooling down after a recent network failure',
+		)
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+		const status = bond.getReliabilityStatus({
+			bridgeId: 'BONDTEST13',
+			limit: 10,
+		})
+		expect(status.queue.cooldownUntil).toBeTruthy()
+		expect(status.persisted?.cooldownUntil).toBeTruthy()
+		expect(status.recentRequestLogs.map((log) => log.status)).toEqual([
+			'cooldown',
+			'failure',
+		])
+	} finally {
+		vi.useRealTimers()
 		globalThis.fetch = previousFetch
 		storage.close()
 	}

--- a/packages/home-connector/src/adapters/bond/index.ts
+++ b/packages/home-connector/src/adapters/bond/index.ts
@@ -42,7 +42,6 @@ import { type HomeConnectorErrorCaptureContext } from '../../sentry.ts'
 
 const defaultBondTransientAttemptsPerBaseUrl = 4
 const defaultBondTransientRetryBaseDelayMs = 100
-const defaultBondStateReadCoalesceWindowMs = 1_000
 const bondRequestLogLimit = 200
 
 type BondRequestLogStatus = 'success' | 'failure' | 'cooldown'
@@ -54,7 +53,6 @@ type BondQueueState = {
 }
 
 type BondStateReadCacheEntry = {
-	createdAt: number
 	promise: Promise<Record<string, unknown>>
 }
 
@@ -375,6 +373,7 @@ async function withBondBridgeRequest<T>(input: {
 	operation: string
 	request: (baseUrl: string) => Promise<T>
 	maxTransientAttemptsPerBaseUrl?: number
+	attemptedBaseUrls?: Array<string>
 }) {
 	const baseUrls = createBondBaseUrlCandidates(input.bridge)
 	const attemptedBaseUrls: Array<string> = []
@@ -386,6 +385,7 @@ async function withBondBridgeRequest<T>(input: {
 	for (let index = 0; index < baseUrls.length; index += 1) {
 		const baseUrl = baseUrls[index]!
 		attemptedBaseUrls.push(baseUrl)
+		input.attemptedBaseUrls?.push(baseUrl)
 		for (
 			let attempt = 1;
 			attempt <= maxTransientAttemptsPerBaseUrl;
@@ -542,7 +542,7 @@ export function createBondAdapter(input: {
 		await previousTail.catch(() => undefined)
 		const startedAtMs = Date.now()
 		const startedAt = new Date(startedAtMs).toISOString()
-		const baseUrlsTried = createBondBaseUrlCandidates(requestInput.bridge)
+		const baseUrlsTried: Array<string> = []
 		try {
 			syncPersistedCooldown(requestInput.bridge, queueState)
 			const now = Date.now()
@@ -567,7 +567,10 @@ export function createBondAdapter(input: {
 			if (waitMs > 0) {
 				await wait(waitMs)
 			}
-			const result = await withBondBridgeRequest(requestInput)
+			const result = await withBondBridgeRequest({
+				...requestInput,
+				attemptedBaseUrls: baseUrlsTried,
+			})
 			runBestEffortPersistence('mark bridge seen', () => {
 				markBridgeSeen(requestInput.bridge)
 			})
@@ -746,10 +749,7 @@ export function createBondAdapter(input: {
 	) {
 		const cacheKey = `${bridge.bridgeId}:${deviceId}`
 		const cached = stateReadCache.get(cacheKey)
-		if (
-			cached &&
-			Date.now() - cached.createdAt <= defaultBondStateReadCoalesceWindowMs
-		) {
+		if (cached) {
 			return cached.promise
 		}
 		const promise = withTrackedBondBridgeRequest({
@@ -764,7 +764,6 @@ export function createBondAdapter(input: {
 				}),
 		})
 		stateReadCache.set(cacheKey, {
-			createdAt: Date.now(),
 			promise,
 		})
 		const cleanup = () => {
@@ -840,7 +839,7 @@ export function createBondAdapter(input: {
 				config: {
 					requestPaceMs,
 					circuitBreakerCooldownMs,
-					stateReadCoalesceWindowMs: defaultBondStateReadCoalesceWindowMs,
+					coalescesInFlightStateReads: true,
 				},
 				queue: {
 					nextAvailableAt:

--- a/packages/home-connector/src/adapters/bond/index.ts
+++ b/packages/home-connector/src/adapters/bond/index.ts
@@ -463,6 +463,14 @@ export function createBondAdapter(input: {
 		})
 	}
 
+	function runBestEffortPersistence(description: string, fn: () => void) {
+		try {
+			fn()
+		} catch (error) {
+			console.warn(`Bond reliability persistence failed: ${description}`, error)
+		}
+	}
+
 	function writeRequestLog(inputLog: {
 		bridge: BondPersistedBridge
 		operation: string
@@ -492,6 +500,14 @@ export function createBondAdapter(input: {
 			networkFailure: isBondNetworkFailure(inputLog.error),
 		})
 		pruneRequestLogs(inputLog.bridge.bridgeId)
+	}
+
+	function writeRequestLogBestEffort(
+		inputLog: Parameters<typeof writeRequestLog>[0],
+	) {
+		runBestEffortPersistence('write request log', () => {
+			writeRequestLog(inputLog)
+		})
 	}
 
 	function syncPersistedCooldown(
@@ -536,7 +552,7 @@ export function createBondAdapter(input: {
 					operation: requestInput.operation,
 					cooldownUntil: queueState.cooldownUntil,
 				})
-				writeRequestLog({
+				writeRequestLogBestEffort({
 					bridge: requestInput.bridge,
 					operation: requestInput.operation,
 					status: 'cooldown',
@@ -552,13 +568,17 @@ export function createBondAdapter(input: {
 				await wait(waitMs)
 			}
 			const result = await withBondBridgeRequest(requestInput)
-			markBridgeSeen(requestInput.bridge)
-			clearBondReliabilityCooldown({
-				storage: input.storage,
-				connectorId,
-				bridgeId: requestInput.bridge.bridgeId,
+			runBestEffortPersistence('mark bridge seen', () => {
+				markBridgeSeen(requestInput.bridge)
 			})
-			writeRequestLog({
+			runBestEffortPersistence('clear reliability cooldown', () => {
+				clearBondReliabilityCooldown({
+					storage: input.storage,
+					connectorId,
+					bridgeId: requestInput.bridge.bridgeId,
+				})
+			})
+			writeRequestLogBestEffort({
 				bridge: requestInput.bridge,
 				operation: requestInput.operation,
 				status: 'success',
@@ -578,20 +598,22 @@ export function createBondAdapter(input: {
 					queueState.cooldownUntil,
 					cooldownUntil,
 				)
-				saveBondReliabilityFailure({
-					storage: input.storage,
-					connectorId,
-					bridgeId: requestInput.bridge.bridgeId,
-					cooldownUntil: new Date(queueState.cooldownUntil).toISOString(),
-					failureAt: nowIso(),
-					failureReason: formatBondFailureReason(error),
+				runBestEffortPersistence('save reliability failure', () => {
+					saveBondReliabilityFailure({
+						storage: input.storage,
+						connectorId,
+						bridgeId: requestInput.bridge.bridgeId,
+						cooldownUntil: new Date(queueState.cooldownUntil).toISOString(),
+						failureAt: nowIso(),
+						failureReason: formatBondFailureReason(error),
+					})
 				})
 			}
 			if (
 				!(error instanceof Error) ||
 				error.name !== 'BondCircuitBreakerError'
 			) {
-				writeRequestLog({
+				writeRequestLogBestEffort({
 					bridge: requestInput.bridge,
 					operation: requestInput.operation,
 					status: 'failure',

--- a/packages/home-connector/src/adapters/bond/index.ts
+++ b/packages/home-connector/src/adapters/bond/index.ts
@@ -17,12 +17,18 @@ import {
 import { scanBondBridges } from './discovery.ts'
 import {
 	adoptBondBridge,
+	clearBondReliabilityCooldown,
+	getBondReliabilityState,
 	getBondTokenSecret,
+	insertBondRequestLog,
+	listRecentBondRequestLogs,
 	listBondBridges,
+	pruneBondRequestLogs,
 	pruneNonAdoptedBondBridges,
 	releaseBondBridge,
 	requireBondBridge,
 	saveBondToken,
+	saveBondReliabilityFailure,
 	updateBondBridgeConnection,
 	updateBondBridgeLastSeen,
 	upsertDiscoveredBondBridges,
@@ -36,6 +42,21 @@ import { type HomeConnectorErrorCaptureContext } from '../../sentry.ts'
 
 const defaultBondTransientAttemptsPerBaseUrl = 4
 const defaultBondTransientRetryBaseDelayMs = 100
+const defaultBondStateReadCoalesceWindowMs = 1_000
+const bondRequestLogLimit = 200
+
+type BondRequestLogStatus = 'success' | 'failure' | 'cooldown'
+
+type BondQueueState = {
+	tail: Promise<void>
+	nextAvailableAt: number
+	cooldownUntil: number
+}
+
+type BondStateReadCacheEntry = {
+	createdAt: number
+	promise: Promise<Record<string, unknown>>
+}
 
 function normalizeQuery(value: string) {
 	return value.trim().toLowerCase()
@@ -256,6 +277,10 @@ async function wait(ms: number) {
 	await new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function nowIso() {
+	return new Date().toISOString()
+}
+
 function formatBondFailureReason(error: unknown) {
 	if (error instanceof Error) {
 		const causeMessage = getErrorCauseMessage(error)
@@ -264,6 +289,40 @@ function formatBondFailureReason(error: unknown) {
 			: error.message
 	}
 	return String(error)
+}
+
+function createBondCooldownError(input: {
+	bridge: BondPersistedBridge
+	operation: string
+	cooldownUntil: number
+}) {
+	const cooldownUntilIso = new Date(input.cooldownUntil).toISOString()
+	const error = new Error(
+		`Bond bridge "${input.bridge.bridgeId}" is cooling down after a recent network failure; refusing to ${input.operation} until ${cooldownUntilIso}.`,
+	) as Error & {
+		homeConnectorCaptureContext?: HomeConnectorErrorCaptureContext
+	}
+	error.name = 'BondCircuitBreakerError'
+	error.homeConnectorCaptureContext = {
+		tags: {
+			connector_vendor: 'bond',
+			bond_bridge_id: input.bridge.bridgeId,
+			bond_network_failure: 'true',
+			bond_circuit_breaker: 'true',
+		},
+		contexts: {
+			bond_bridge: {
+				...getBondBridgeConnectionContext(input.bridge),
+				operation: input.operation,
+				cooldownUntil: cooldownUntilIso,
+			},
+		},
+		extra: {
+			bondOperation: input.operation,
+			bondCooldownUntil: cooldownUntilIso,
+		},
+	}
+	return error
 }
 
 function createBondActionableError(input: {
@@ -368,6 +427,23 @@ export function createBondAdapter(input: {
 	storage: HomeConnectorStorage
 }) {
 	const connectorId = input.config.homeConnectorId
+	const requestPaceMs = input.config.bondRequestPaceMs
+	const circuitBreakerCooldownMs = input.config.bondCircuitBreakerCooldownMs
+	const queueStates = new Map<string, BondQueueState>()
+	const stateReadCache = new Map<string, BondStateReadCacheEntry>()
+
+	function getQueueState(bridgeId: string) {
+		let state = queueStates.get(bridgeId)
+		if (!state) {
+			state = {
+				tail: Promise.resolve(),
+				nextAvailableAt: 0,
+				cooldownUntil: 0,
+			}
+			queueStates.set(bridgeId, state)
+		}
+		return state
+	}
 
 	function markBridgeSeen(bridge: BondPersistedBridge) {
 		updateBondBridgeLastSeen({
@@ -378,12 +454,164 @@ export function createBondAdapter(input: {
 		})
 	}
 
+	function pruneRequestLogs(bridgeId: string) {
+		pruneBondRequestLogs({
+			storage: input.storage,
+			connectorId,
+			bridgeId,
+			limit: bondRequestLogLimit,
+		})
+	}
+
+	function writeRequestLog(inputLog: {
+		bridge: BondPersistedBridge
+		operation: string
+		status: BondRequestLogStatus
+		startedAt: string
+		startedAtMs: number
+		baseUrlsTried: Array<string>
+		error?: unknown
+	}) {
+		const finishedAtMs = Date.now()
+		const error =
+			inputLog.error instanceof Error ? inputLog.error : undefined
+		insertBondRequestLog(input.storage, {
+			connectorId,
+			bridgeId: inputLog.bridge.bridgeId,
+			operation: inputLog.operation,
+			status: inputLog.status,
+			startedAt: inputLog.startedAt,
+			finishedAt: nowIso(),
+			durationMs: finishedAtMs - inputLog.startedAtMs,
+			baseUrlsTried: inputLog.baseUrlsTried,
+			errorName: error?.name ?? null,
+			errorMessage:
+				inputLog.error == null
+					? null
+					: formatBondFailureReason(inputLog.error),
+			networkFailure: isBondNetworkFailure(inputLog.error),
+		})
+		pruneRequestLogs(inputLog.bridge.bridgeId)
+	}
+
+	function syncPersistedCooldown(
+		bridge: BondPersistedBridge,
+		queueState: BondQueueState,
+	) {
+		const persisted = getBondReliabilityState(
+			input.storage,
+			connectorId,
+			bridge.bridgeId,
+		)
+		if (!persisted?.cooldownUntil) return
+		const persistedUntil = Date.parse(persisted.cooldownUntil)
+		if (Number.isFinite(persistedUntil) && persistedUntil > Date.now()) {
+			queueState.cooldownUntil = Math.max(
+				queueState.cooldownUntil,
+				persistedUntil,
+			)
+		}
+	}
+
+	async function runQueuedBondBridgeRequest<T>(
+		requestInput: Parameters<typeof withBondBridgeRequest<T>>[0],
+	) {
+		const queueState = getQueueState(requestInput.bridge.bridgeId)
+		const previousTail = queueState.tail
+		let releaseQueue: () => void = () => {}
+		queueState.tail = new Promise<void>((resolve) => {
+			releaseQueue = resolve
+		})
+
+		await previousTail.catch(() => undefined)
+		const startedAtMs = Date.now()
+		const startedAt = new Date(startedAtMs).toISOString()
+		const baseUrlsTried = createBondBaseUrlCandidates(requestInput.bridge)
+		try {
+			syncPersistedCooldown(requestInput.bridge, queueState)
+			const now = Date.now()
+			if (queueState.cooldownUntil > now) {
+				const error = createBondCooldownError({
+					bridge: requestInput.bridge,
+					operation: requestInput.operation,
+					cooldownUntil: queueState.cooldownUntil,
+				})
+				writeRequestLog({
+					bridge: requestInput.bridge,
+					operation: requestInput.operation,
+					status: 'cooldown',
+					startedAt,
+					startedAtMs,
+					baseUrlsTried,
+					error,
+				})
+				throw error
+			}
+			const waitMs = queueState.nextAvailableAt - now
+			if (waitMs > 0) {
+				await wait(waitMs)
+			}
+			const result = await withBondBridgeRequest(requestInput)
+			markBridgeSeen(requestInput.bridge)
+			clearBondReliabilityCooldown({
+				storage: input.storage,
+				connectorId,
+				bridgeId: requestInput.bridge.bridgeId,
+			})
+			writeRequestLog({
+				bridge: requestInput.bridge,
+				operation: requestInput.operation,
+				status: 'success',
+				startedAt,
+				startedAtMs,
+				baseUrlsTried,
+			})
+			return result
+		} catch (error) {
+			if (
+				isBondNetworkFailure(error) &&
+				(!(error instanceof Error) ||
+					error.name !== 'BondCircuitBreakerError')
+			) {
+				const cooldownUntil = Date.now() + circuitBreakerCooldownMs
+				queueState.cooldownUntil = Math.max(
+					queueState.cooldownUntil,
+					cooldownUntil,
+				)
+				saveBondReliabilityFailure({
+					storage: input.storage,
+					connectorId,
+					bridgeId: requestInput.bridge.bridgeId,
+					cooldownUntil: new Date(queueState.cooldownUntil).toISOString(),
+					failureAt: nowIso(),
+					failureReason: formatBondFailureReason(error),
+				})
+			}
+			if (
+				!(error instanceof Error) ||
+				error.name !== 'BondCircuitBreakerError'
+			) {
+				writeRequestLog({
+					bridge: requestInput.bridge,
+					operation: requestInput.operation,
+					status: 'failure',
+					startedAt,
+					startedAtMs,
+					baseUrlsTried,
+					error,
+				})
+			}
+			throw error
+		} finally {
+			queueState.nextAvailableAt = Date.now() + requestPaceMs
+			releaseQueue()
+		}
+	}
+
 	async function withTrackedBondBridgeRequest<T>(
 		requestInput: Parameters<typeof withBondBridgeRequest<T>>[0],
 	) {
-		const result = await withBondBridgeRequest(requestInput)
-		markBridgeSeen(requestInput.bridge)
-		return result
+		return await runQueuedBondBridgeRequest(requestInput)
 	}
 
 	function listPublicBridges(): Array<BondPersistedBridge> {
@@ -489,6 +717,44 @@ export function createBondAdapter(input: {
 		})
 	}
 
+	function readDeviceStateWithCoalescing(
+		bridge: BondPersistedBridge,
+		token: string,
+		deviceId: string,
+	) {
+		const cacheKey = `${bridge.bridgeId}:${deviceId}`
+		const cached = stateReadCache.get(cacheKey)
+		if (
+			cached &&
+			Date.now() - cached.createdAt <= defaultBondStateReadCoalesceWindowMs
+		) {
+			return cached.promise
+		}
+		const promise = withTrackedBondBridgeRequest({
+			bridge,
+			operation: `fetch device ${deviceId} state`,
+			maxTransientAttemptsPerBaseUrl: defaultBondTransientAttemptsPerBaseUrl,
+			request: async (baseUrl) =>
+				await bondGetDeviceState({
+					baseUrl,
+					token,
+					deviceId,
+				}),
+		})
+		stateReadCache.set(cacheKey, {
+			createdAt: Date.now(),
+			promise,
+		})
+		const cleanup = () => {
+			const current = stateReadCache.get(cacheKey)
+			if (current?.promise === promise) {
+				stateReadCache.delete(cacheKey)
+			}
+		}
+		promise.then(cleanup, cleanup)
+		return promise
+	}
+
 	const bondApi = {
 		getStatus() {
 			const bridges = listPublicBridges()
@@ -536,6 +802,46 @@ export function createBondAdapter(input: {
 				bridgeId,
 				connection,
 			)
+		},
+		getReliabilityStatus(inputStatus: {
+			bridgeId?: string
+			limit?: number
+		} = {}) {
+			const bridge = resolveBridge(inputStatus.bridgeId)
+			const queueState = getQueueState(bridge.bridgeId)
+			syncPersistedCooldown(bridge, queueState)
+			const limit =
+				inputStatus.limit == null
+					? 50
+					: Math.max(1, Math.min(200, Math.floor(inputStatus.limit)))
+			return {
+				config: {
+					requestPaceMs,
+					circuitBreakerCooldownMs,
+					stateReadCoalesceWindowMs: defaultBondStateReadCoalesceWindowMs,
+				},
+				queue: {
+					nextAvailableAt:
+						queueState.nextAvailableAt > 0
+							? new Date(queueState.nextAvailableAt).toISOString()
+							: null,
+					cooldownUntil:
+						queueState.cooldownUntil > 0
+							? new Date(queueState.cooldownUntil).toISOString()
+							: null,
+				},
+				persisted: getBondReliabilityState(
+					input.storage,
+					connectorId,
+					bridge.bridgeId,
+				),
+				recentRequestLogs: listRecentBondRequestLogs({
+					storage: input.storage,
+					connectorId,
+					bridgeId: bridge.bridgeId,
+					limit,
+				}),
+			}
 		},
 		async fetchBridgeVersion(bridgeId?: string) {
 			const bridge = resolveBridge(bridgeId)
@@ -621,17 +927,7 @@ export function createBondAdapter(input: {
 		): Promise<Record<string, unknown>> {
 			const bridge = requireAdoptedBridge(bridgeId)
 			const token = requireToken(bridge)
-			return await withTrackedBondBridgeRequest({
-				bridge,
-				operation: `fetch device ${deviceId} state`,
-				maxTransientAttemptsPerBaseUrl: defaultBondTransientAttemptsPerBaseUrl,
-				request: async (baseUrl) =>
-					await bondGetDeviceState({
-						baseUrl,
-						token,
-						deviceId,
-					}),
-			})
+			return await readDeviceStateWithCoalescing(bridge, token, deviceId)
 		},
 		async invokeDeviceAction(input: {
 			bridgeId?: string

--- a/packages/home-connector/src/adapters/bond/repository.ts
+++ b/packages/home-connector/src/adapters/bond/repository.ts
@@ -49,6 +49,18 @@ type BondReliabilityStateRow = {
 	updated_at: string
 }
 
+function parseBondRequestBaseUrls(value: unknown): Array<string> {
+	if (typeof value !== 'string') return []
+	try {
+		const parsed = JSON.parse(value) as unknown
+		return Array.isArray(parsed)
+			? parsed.filter((entry) => typeof entry === 'string')
+			: []
+	} catch {
+		return []
+	}
+}
+
 function mapBondBridgeRow(row: BondBridgeRow): BondPersistedBridge {
 	let rawDiscovery: Record<string, unknown> | null = null
 	if (row.raw_discovery_json) {
@@ -419,10 +431,7 @@ export function listRecentBondRequestLogs(input: {
 		startedAt: String(row['started_at']),
 		finishedAt: String(row['finished_at']),
 		durationMs: Number(row['duration_ms']),
-		baseUrlsTried:
-			typeof row['base_urls_tried_json'] === 'string'
-				? (JSON.parse(row['base_urls_tried_json']) as Array<string>)
-				: [],
+		baseUrlsTried: parseBondRequestBaseUrls(row['base_urls_tried_json']),
 		errorName:
 			typeof row['error_name'] === 'string' ? row['error_name'] : null,
 		errorMessage:

--- a/packages/home-connector/src/adapters/bond/repository.ts
+++ b/packages/home-connector/src/adapters/bond/repository.ts
@@ -1,3 +1,4 @@
+import { type SQLInputValue } from 'node:sqlite'
 import { type HomeConnectorStorage } from '../../storage/index.ts'
 import { type BondDiscoveredBridge, type BondPersistedBridge } from './types.ts'
 
@@ -14,6 +15,38 @@ type BondBridgeRow = {
 	adopted: number
 	last_seen_at: string | null
 	token: string | null
+}
+
+export type BondRequestLogInput = {
+	connectorId: string
+	bridgeId: string
+	operation: string
+	status: 'success' | 'failure' | 'cooldown'
+	startedAt: string
+	finishedAt: string
+	durationMs: number
+	baseUrlsTried: Array<string>
+	errorName?: string | null
+	errorMessage?: string | null
+	networkFailure: boolean
+}
+
+export type BondReliabilityState = {
+	connectorId: string
+	bridgeId: string
+	cooldownUntil: string | null
+	lastFailureAt: string | null
+	lastFailureReason: string | null
+	updatedAt: string
+}
+
+type BondReliabilityStateRow = {
+	connector_id: string
+	bridge_id: string
+	cooldown_until: string | null
+	last_failure_at: string | null
+	last_failure_reason: string | null
+	updated_at: string
 }
 
 function mapBondBridgeRow(row: BondBridgeRow): BondPersistedBridge {
@@ -68,6 +101,19 @@ function selectBondBridgeRows(
 		ORDER BY b.instance_name COLLATE NOCASE, b.bridge_id
 	`)
 	return statement.all(connectorId) as Array<BondBridgeRow>
+}
+
+function mapBondReliabilityStateRow(
+	row: BondReliabilityStateRow,
+): BondReliabilityState {
+	return {
+		connectorId: row.connector_id,
+		bridgeId: row.bridge_id,
+		cooldownUntil: row.cooldown_until,
+		lastFailureAt: row.last_failure_at,
+		lastFailureReason: row.last_failure_reason,
+		updatedAt: row.updated_at,
+	}
 }
 
 function getUpsertBondBridgeStatement(storage: HomeConnectorStorage) {
@@ -132,6 +178,24 @@ function getUpsertBondTokenStatement(storage: HomeConnectorStorage) {
 	`)
 }
 
+function getUpsertBondReliabilityStateStatement(storage: HomeConnectorStorage) {
+	return storage.db.query(`
+		INSERT INTO bond_reliability_state (
+			connector_id,
+			bridge_id,
+			cooldown_until,
+			last_failure_at,
+			last_failure_reason,
+			updated_at
+		) VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(connector_id, bridge_id) DO UPDATE SET
+			cooldown_until = excluded.cooldown_until,
+			last_failure_at = excluded.last_failure_at,
+			last_failure_reason = excluded.last_failure_reason,
+			updated_at = excluded.updated_at
+	`)
+}
+
 export function listBondBridges(
 	storage: HomeConnectorStorage,
 	connectorId: string,
@@ -177,6 +241,196 @@ export function getBondTokenSecret(
 		)
 		.get(connectorId, bridgeId) as { token: string } | undefined
 	return row?.token ?? null
+}
+
+export function insertBondRequestLog(
+	storage: HomeConnectorStorage,
+	input: BondRequestLogInput,
+) {
+	storage.db
+		.query(
+			`
+		INSERT INTO bond_request_logs (
+			connector_id,
+			bridge_id,
+			operation,
+			status,
+			started_at,
+			finished_at,
+			duration_ms,
+			base_urls_tried_json,
+			error_name,
+			error_message,
+			network_failure
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		)
+		.run(
+			input.connectorId,
+			input.bridgeId,
+			input.operation,
+			input.status,
+			input.startedAt,
+			input.finishedAt,
+			Math.max(0, Math.round(input.durationMs)),
+			JSON.stringify(input.baseUrlsTried),
+			input.errorName ?? null,
+			input.errorMessage ?? null,
+			input.networkFailure ? 1 : 0,
+		)
+}
+
+export function pruneBondRequestLogs(input: {
+	storage: HomeConnectorStorage
+	connectorId: string
+	bridgeId: string
+	limit: number
+}) {
+	const limit = Math.max(1, Math.floor(input.limit))
+	input.storage.db
+		.query(
+			`
+		DELETE FROM bond_request_logs
+		WHERE connector_id = ? AND bridge_id = ?
+			AND id NOT IN (
+				SELECT id
+				FROM bond_request_logs
+				WHERE connector_id = ? AND bridge_id = ?
+				ORDER BY started_at DESC, id DESC
+				LIMIT ?
+			)
+	`,
+		)
+		.run(
+			input.connectorId,
+			input.bridgeId,
+			input.connectorId,
+			input.bridgeId,
+			limit,
+		)
+}
+
+export function getBondReliabilityState(
+	storage: HomeConnectorStorage,
+	connectorId: string,
+	bridgeId: string,
+) {
+	const row = storage.db
+		.query(
+			`
+		SELECT
+			connector_id,
+			bridge_id,
+			cooldown_until,
+			last_failure_at,
+			last_failure_reason,
+			updated_at
+		FROM bond_reliability_state
+		WHERE connector_id = ? AND bridge_id = ?
+	`,
+		)
+		.get(connectorId, bridgeId) as BondReliabilityStateRow | undefined
+	return row ? mapBondReliabilityStateRow(row) : null
+}
+
+export function saveBondReliabilityFailure(input: {
+	storage: HomeConnectorStorage
+	connectorId: string
+	bridgeId: string
+	cooldownUntil: string
+	failureAt: string
+	failureReason: string
+}) {
+	getUpsertBondReliabilityStateStatement(input.storage).run(
+		input.connectorId,
+		input.bridgeId,
+		input.cooldownUntil,
+		input.failureAt,
+		input.failureReason,
+		input.failureAt,
+	)
+}
+
+export function clearBondReliabilityCooldown(input: {
+	storage: HomeConnectorStorage
+	connectorId: string
+	bridgeId: string
+}) {
+	const existing = getBondReliabilityState(
+		input.storage,
+		input.connectorId,
+		input.bridgeId,
+	)
+	if (!existing) return
+	getUpsertBondReliabilityStateStatement(input.storage).run(
+		input.connectorId,
+		input.bridgeId,
+		null,
+		existing.lastFailureAt,
+		existing.lastFailureReason,
+		new Date().toISOString(),
+	)
+}
+
+export function listRecentBondRequestLogs(input: {
+	storage: HomeConnectorStorage
+	connectorId: string
+	bridgeId?: string
+	limit?: number
+}) {
+	const limit = Math.max(1, Math.floor(input.limit ?? 100))
+	const params: Array<SQLInputValue> = [input.connectorId]
+	let bridgeFilter = ''
+	if (input.bridgeId) {
+		bridgeFilter = 'AND bridge_id = ?'
+		params.push(input.bridgeId)
+	}
+	params.push(limit)
+	const rows = input.storage.db
+		.query(
+			`
+		SELECT
+			id,
+			connector_id,
+			bridge_id,
+			operation,
+			status,
+			started_at,
+			finished_at,
+			duration_ms,
+			base_urls_tried_json,
+			error_name,
+			error_message,
+			network_failure
+		FROM bond_request_logs
+		WHERE connector_id = ?
+			${bridgeFilter}
+		ORDER BY started_at DESC, id DESC
+		LIMIT ?
+	`,
+		)
+		.all(...params) as Array<Record<string, unknown>>
+	return rows.map((row) => ({
+		id: Number(row['id']),
+		connectorId: String(row['connector_id']),
+		bridgeId: String(row['bridge_id']),
+		operation: String(row['operation']),
+		status: String(row['status']),
+		startedAt: String(row['started_at']),
+		finishedAt: String(row['finished_at']),
+		durationMs: Number(row['duration_ms']),
+		baseUrlsTried:
+			typeof row['base_urls_tried_json'] === 'string'
+				? (JSON.parse(row['base_urls_tried_json']) as Array<string>)
+				: [],
+		errorName:
+			typeof row['error_name'] === 'string' ? row['error_name'] : null,
+		errorMessage:
+			typeof row['error_message'] === 'string'
+				? row['error_message']
+				: null,
+		networkFailure: Boolean(row['network_failure']),
+	}))
 }
 
 export function upsertDiscoveredBondBridges(

--- a/packages/home-connector/src/config.ts
+++ b/packages/home-connector/src/config.ts
@@ -12,6 +12,8 @@ export type HomeConnectorConfig = {
 	lutronDiscoveryUrl: string
 	sonosDiscoveryUrl: string
 	bondDiscoveryUrl: string
+	bondRequestPaceMs: number
+	bondCircuitBreakerCooldownMs: number
 	jellyfishDiscoveryUrl: string | null
 	/**
 	 * Venstar discovery uses direct HTTP probes to `/query/info` across these
@@ -73,6 +75,13 @@ function resolveScanCidrsFromEnv(envVar: string): Array<string> {
 		.split(',')
 		.map((entry) => entry.trim())
 		.filter(Boolean)
+}
+
+function resolveNonNegativeIntegerFromEnv(envVar: string, fallback: number) {
+	const raw = process.env[envVar]?.trim()
+	if (!raw) return fallback
+	const parsed = Number.parseInt(raw, 10)
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
 }
 
 function isPrivateRfc1918Ipv4(parts: Array<number>) {
@@ -211,6 +220,14 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 			'ssdp://239.255.255.250:1900?st=urn:schemas-upnp-org:device:ZonePlayer:1',
 		bondDiscoveryUrl:
 			process.env.BOND_DISCOVERY_URL?.trim() || 'mdns://_bond._tcp.local',
+		bondRequestPaceMs: resolveNonNegativeIntegerFromEnv(
+			'BOND_REQUEST_PACE_MS',
+			500,
+		),
+		bondCircuitBreakerCooldownMs: resolveNonNegativeIntegerFromEnv(
+			'BOND_CIRCUIT_BREAKER_COOLDOWN_MS',
+			60_000,
+		),
 		jellyfishDiscoveryUrl: process.env.JELLYFISH_DISCOVERY_URL?.trim() || null,
 		venstarScanCidrs,
 		jellyfishScanCidrs,

--- a/packages/home-connector/src/mcp/register-bond-tools.ts
+++ b/packages/home-connector/src/mcp/register-bond-tools.ts
@@ -281,6 +281,36 @@ export function registerBondHomeConnectorTools(input: {
 
 	registerTool(
 		{
+			name: 'bond_get_reliability_status',
+			title: 'Get Bond Reliability Status',
+			description:
+				'Read recent Bond request pacing, cooldown, and network-failure logs for troubleshooting bridge reliability.',
+			...bridgeScopedSchema({
+				limit: z.number().int().min(1).max(200).optional(),
+			}),
+			annotations: {
+				readOnlyHint: true,
+			},
+		},
+		async (args) => {
+			const bridgeId =
+				args['bridgeId'] == null ? undefined : String(args['bridgeId'])
+			const limit = args['limit'] == null ? undefined : Number(args['limit'])
+			const status = bond.getReliabilityStatus({ bridgeId, limit })
+			return {
+				content: [
+					{
+						type: 'text' as const,
+						text: `Read Bond reliability status with ${String(status.recentRequestLogs.length)} recent request(s).`,
+					},
+				],
+				structuredContent: status,
+			}
+		},
+	)
+
+	registerTool(
+		{
 			name: 'bond_list_devices',
 			title: 'List Bond Devices',
 			description:

--- a/packages/home-connector/src/storage/index.ts
+++ b/packages/home-connector/src/storage/index.ts
@@ -133,6 +133,41 @@ function initializeSchema(db: SqliteDatabase) {
 				ON DELETE CASCADE
 		);
 
+		CREATE TABLE IF NOT EXISTS bond_request_logs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			connector_id TEXT NOT NULL,
+			bridge_id TEXT NOT NULL,
+			operation TEXT NOT NULL,
+			status TEXT NOT NULL,
+			started_at TEXT NOT NULL,
+			finished_at TEXT NOT NULL,
+			duration_ms INTEGER NOT NULL,
+			base_urls_tried_json TEXT,
+			error_name TEXT,
+			error_message TEXT,
+			network_failure INTEGER NOT NULL DEFAULT 0,
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (connector_id, bridge_id)
+				REFERENCES bond_bridges(connector_id, bridge_id)
+				ON DELETE CASCADE
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_bond_request_logs_bridge_time
+			ON bond_request_logs(connector_id, bridge_id, started_at DESC);
+
+		CREATE TABLE IF NOT EXISTS bond_reliability_state (
+			connector_id TEXT NOT NULL,
+			bridge_id TEXT NOT NULL,
+			cooldown_until TEXT,
+			last_failure_at TEXT,
+			last_failure_reason TEXT,
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY (connector_id, bridge_id),
+			FOREIGN KEY (connector_id, bridge_id)
+				REFERENCES bond_bridges(connector_id, bridge_id)
+				ON DELETE CASCADE
+		);
+
 		CREATE TABLE IF NOT EXISTS jellyfish_controllers (
 			connector_id TEXT NOT NULL,
 			controller_id TEXT NOT NULL,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Serialize Bond bridge HTTP requests per bridge with configurable pacing.
- Coalesce duplicate in-flight device state reads until the shared request settles.
- Add a short circuit-breaker cooldown after Bond network failures.
- Persist recent Bond request logs and reliability state in the home connector SQLite database.
- Expose `bond_get_reliability_status` for troubleshooting recent Bond traffic and cooldown state.
- Harden reliability bookkeeping so logging/storage failures cannot mask the original Bond call result/error.
- Clarify diagnostics so cooldown-rejected requests record no attempted URLs.

### Testing
- `npm --prefix packages/home-connector run test`
- `npm run typecheck`
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72f68e51-1577-4936-bd70-a2d012bf03b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72f68e51-1577-4936-bd70-a2d012bf03b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bond bridge requests are queued and paced and will honor a cooldown after network failures.
  * Device state reads are coalesced to avoid duplicate concurrent calls.
  * A reliability status command exposes queue/cooldown state and recent request logs.

* **Configuration**
  * New environment variables: BOND_REQUEST_PACE_MS (default 500ms) and BOND_CIRCUIT_BREAKER_COOLDOWN_MS (default 60s) to tune behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->