### PR TITLE
Add Island router SSH diagnostics to home connector

### DIFF
--- a/docs/contributing/architecture/home-connector.md
+++ b/docs/contributing/architecture/home-connector.md
@@ -31,6 +31,7 @@ The connector exposes these local-device families:
 - Samsung TV / Frame discovery and control over mDNS, REST, and local WebSocket
   channels
 - Venstar WiFi thermostat status and control over the local REST API
+- Island router diagnostics over SSH using a read-only command allowlist
 
 All surfaces are registered as MCP tools inside the connector and then exposed
 to the Worker through the existing outbound WebSocket session to
@@ -114,6 +115,41 @@ Discovery is subnet-scan-only. The connector probes `/query/info` across
 `/24` networks from local IPv4 interfaces. This avoids the SSDP multicast
 fragility that showed up on NAS and Docker bridge deployments while keeping the
 user flow aligned with the other managed device integrations.
+
+## Island router diagnostics integration
+
+The Island router adapter lives under
+`packages/home-connector/src/adapters/island-router/` and intentionally limits
+itself to read-only SSH diagnostics from the connector host to the local
+router. It is designed for situations where Kody only has network reachability
+to the router from the NAS or other machine running the home connector.
+
+The adapter does expose:
+
+- router identity/status via `show version`, `show clock`, and
+  `show interface summary`
+- router-side reachability checks with `ping`
+- ARP / neighbor-cache inspection with `show ip neighbors`
+- DHCP reservation inspection with `show ip dhcp-reservations`
+- recent-event lookups with `show log`
+- a structured `router_diagnose_host` workflow that combines ping, ARP,
+  reservation, interface, and log data for one host
+
+The adapter explicitly does not expose:
+
+- arbitrary shell or CLI command execution over MCP
+- any mutating router commands such as reboot, config edits, PoE control,
+  DHCP renewals, or bridge resets
+- password-based auth flows through MCP
+
+SSH transport is conservative:
+
+- public-key authentication only
+- private key path comes from local connector env/runtime config
+- host verification can use either a mounted `known_hosts` file or an expected
+  host fingerprint
+- the Docker image includes the OpenSSH client utilities needed for `ssh`,
+  `ssh-keyscan`, and fingerprint verification
 
 ## Local persistence
 

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -165,8 +165,15 @@ Authoring guide for outbound WebSocket services:
   sets `MOCKS=false` for `packages/home-connector`, and
   `HOME_CONNECTOR_ROKU_DISCOVERY_URL=...` sets `ROKU_DISCOVERY_URL=...`. This
   also applies to `HOME_CONNECTOR_LUTRON_DISCOVERY_URL=...`,
-  `HOME_CONNECTOR_SENTRY_DSN`, `HOME_CONNECTOR_SENTRY_ENVIRONMENT`, and
-  `HOME_CONNECTOR_SENTRY_TRACES_SAMPLE_RATE`.
+  `HOME_CONNECTOR_SENTRY_DSN`, `HOME_CONNECTOR_SENTRY_ENVIRONMENT`,
+  `HOME_CONNECTOR_SENTRY_TRACES_SAMPLE_RATE`,
+  `HOME_CONNECTOR_ISLAND_ROUTER_HOST=...`,
+  `HOME_CONNECTOR_ISLAND_ROUTER_PORT=...`,
+  `HOME_CONNECTOR_ISLAND_ROUTER_USERNAME=...`,
+  `HOME_CONNECTOR_ISLAND_ROUTER_PRIVATE_KEY_PATH=...`,
+  `HOME_CONNECTOR_ISLAND_ROUTER_KNOWN_HOSTS_PATH=...`,
+  `HOME_CONNECTOR_ISLAND_ROUTER_HOST_FINGERPRINT=...`, and
+  `HOME_CONNECTOR_ISLAND_ROUTER_COMMAND_TIMEOUT_MS=...`.
 - `ROKU_DISCOVERY_URL` — optional connector env var. Defaults to
   `ssdp://239.255.255.250:1900`. Mocked connector runs should set an explicit
   value such as `http://roku.mock.local/discovery`.
@@ -211,6 +218,23 @@ Authoring guide for outbound WebSocket services:
   such as Samsung TV metadata/tokens, Lutron processor credentials, Bond bridge
   state, Sonos players, and Venstar managed thermostats across restarts.
   Overrides the derived `HOME_CONNECTOR_DATA_PATH` location.
+- `ISLAND_ROUTER_HOST` — optional connector env var. Hostname or IP address of
+  an Island router reachable from the home-connector host over SSH.
+- `ISLAND_ROUTER_PORT` — optional connector env var. SSH port for the Island
+  router. Defaults to `22`.
+- `ISLAND_ROUTER_USERNAME` — optional connector env var. SSH username for the
+  Island router CLI. Prefer Island's read-only `user` account when possible.
+- `ISLAND_ROUTER_PRIVATE_KEY_PATH` — optional connector env var. Absolute path
+  to a mounted private key file used for SSH public-key authentication. Mount
+  the key read-only into the connector container or host environment.
+- `ISLAND_ROUTER_KNOWN_HOSTS_PATH` — optional connector env var. Absolute path
+  to a read-only `known_hosts` file used for strict SSH host verification.
+- `ISLAND_ROUTER_HOST_FINGERPRINT` — optional connector env var. SSH host key
+  fingerprint (`SHA256:...` or `MD5:...`) used when you cannot mount a
+  `known_hosts` file. The connector verifies the fingerprint with `ssh-keyscan`
+  before opening the real session.
+- `ISLAND_ROUTER_COMMAND_TIMEOUT_MS` — optional connector env var. Default
+  timeout for Island router SSH commands in milliseconds. Defaults to `8000`.
 
 ## Why Zod?
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -217,6 +217,17 @@ How to get/set each value:
     published Docker image)
   - `APP_COMMIT_SHA` is also baked into the published Docker image and used by
     the connector’s Sentry setup as the release identifier
+  - Island router SSH diagnostics (optional, read-only):
+    - `HOME_CONNECTOR_ISLAND_ROUTER_HOST`
+    - `HOME_CONNECTOR_ISLAND_ROUTER_PORT`
+    - `HOME_CONNECTOR_ISLAND_ROUTER_USERNAME`
+    - `HOME_CONNECTOR_ISLAND_ROUTER_PRIVATE_KEY_PATH`
+    - `HOME_CONNECTOR_ISLAND_ROUTER_KNOWN_HOSTS_PATH` or
+      `HOME_CONNECTOR_ISLAND_ROUTER_HOST_FINGERPRINT`
+    - `HOME_CONNECTOR_ISLAND_ROUTER_COMMAND_TIMEOUT_MS`
+  - When enabling Island router diagnostics in Docker, mount the SSH private key
+    (and optionally the known-hosts file) read-only into the container and point
+    the env vars at those mounted paths.
 
 Preview deploys for pull requests create a separate Worker per PR named
 `<app-name>-pr-<number>` (for kody: `kody-pr-123`) plus one Worker per mock

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -90,6 +90,26 @@ Quick notes for getting a local kody environment running.
     `~/.kody/home-connector/home-connector.sqlite`. Override the directory with
     `HOME_CONNECTOR_DATA_PATH` or the full file path with
     `HOME_CONNECTOR_DB_PATH`.
+  - Island router SSH diagnostics are optional and read-only. Set
+    `ISLAND_ROUTER_HOST`, `ISLAND_ROUTER_USERNAME`, and
+    `ISLAND_ROUTER_PRIVATE_KEY_PATH` to enable the MCP tools
+    `router_get_status`, `router_ping_host`, `router_get_arp_entry`,
+    `router_get_dhcp_lease`, `router_get_recent_events`, and
+    `router_diagnose_host`.
+  - Prefer mounting the private key read-only into the container or host
+    runtime, for example `-v /path/to/id_ed25519:/run/secrets/island-router-key:ro`
+    plus `HOME_CONNECTOR_ISLAND_ROUTER_PRIVATE_KEY_PATH=/run/secrets/island-router-key`
+    when launching through `npm run dev`, or
+    `ISLAND_ROUTER_PRIVATE_KEY_PATH=/run/secrets/island-router-key` when
+    running `packages/home-connector` directly.
+  - For host verification, set either `ISLAND_ROUTER_KNOWN_HOSTS_PATH` (preferred)
+    or `ISLAND_ROUTER_HOST_FINGERPRINT`. When neither is set, the connector still
+    works but reports a warning because SSH host verification is disabled.
+  - The Island router integration intentionally does not expose arbitrary command
+    execution or mutating router operations over MCP. It only uses a typed
+    allowlist of read-only CLI commands for status, ping, ARP/neighbor cache,
+    DHCP reservation inspection, interface summaries/details, and recent log
+    lookups.
   - Local operational routes live at `/health`, `/roku/status`, `/roku/setup`,
     `/lutron/status`, `/lutron/setup`, `/samsung-tv/status`, and
     `/samsung-tv/setup`.

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -29,3 +29,11 @@ If home-related tools appear missing, check connector status with
 **`meta_get_home_connector_status`** (first **`home`** connector only) when
 those capabilities are available. For protocol and URL requirements, see
 [Remote connectors](../contributing/architecture/remote-connectors.md).
+
+If Island router diagnostics tools are missing or return configuration errors,
+verify that the home connector runtime has `ISLAND_ROUTER_HOST`,
+`ISLAND_ROUTER_USERNAME`, and `ISLAND_ROUTER_PRIVATE_KEY_PATH` set, and prefer
+either `ISLAND_ROUTER_KNOWN_HOSTS_PATH` or `ISLAND_ROUTER_HOST_FINGERPRINT` for
+host verification. The connector only exposes read-only tools such as
+`router_get_status` and `router_diagnose_host`; it does not support arbitrary
+router command execution or configuration changes.

--- a/packages/home-connector/Dockerfile
+++ b/packages/home-connector/Dockerfile
@@ -14,6 +14,8 @@ ARG APP_COMMIT_SHA=unknown
 
 COPY --from=deps /app /app
 
+RUN apk add --no-cache openssh-client
+
 WORKDIR /app/packages/home-connector
 
 ENV NODE_ENV=production

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -317,6 +317,8 @@ test('fallback interface summary parsing recognizes up and down link states', ()
 })
 
 test('island router adapter forwards explicit timeoutMs to ARP and DHCP lookups', async () => {
+	using _env = withTemporaryEnv({})
+	createConfig()
 	const config = createConfig()
 	const recordedTimeouts: Array<number | undefined> = []
 	const islandRouter = createIslandRouterAdapter({
@@ -338,4 +340,42 @@ test('island router adapter forwards explicit timeoutMs to ARP and DHCP lookups'
 
 	expect(recordedTimeouts).toContain(12_345)
 	expect(recordedTimeouts).toContain(23_456)
+})
+
+test('island router adapter rejects null exit codes for lookup helpers', async () => {
+	using _env = withTemporaryEnv({})
+	const config = createConfig()
+	const nullExitRunner = async (request: IslandRouterCommandRequest) => ({
+		id: request.id,
+		commandLines: [
+			'terminal length 0',
+			request.id === 'show-log' ? 'show log last' : 'show ip neighbors',
+		],
+		stdout: '',
+		stderr: 'signal terminated',
+		exitCode: null,
+		signal: 'SIGTERM' as const,
+		timedOut: false,
+		durationMs: 10,
+	})
+	const islandRouter = createIslandRouterAdapter({
+		config,
+		commandRunner: nullExitRunner,
+	})
+
+	await expect(
+		islandRouter.getArpEntry({
+			host: '192.168.0.52',
+		}),
+	).rejects.toThrow('signal terminated')
+	await expect(
+		islandRouter.getDhcpLease({
+			host: '192.168.0.52',
+		}),
+	).rejects.toThrow('signal terminated')
+	await expect(
+		islandRouter.getRecentEvents({
+			host: '192.168.0.52',
+		}),
+	).rejects.toThrow('signal terminated')
 })

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -1,0 +1,249 @@
+import { expect, test } from 'vitest'
+import { loadHomeConnectorConfig } from '../../config.ts'
+import { createIslandRouterAdapter } from './index.ts'
+import { type IslandRouterCommandRequest } from './types.ts'
+
+function createConfig() {
+	process.env.MOCKS = 'false'
+	process.env.HOME_CONNECTOR_ID = 'default'
+	process.env.HOME_CONNECTOR_SHARED_SECRET =
+		'home-connector-secret-home-connector-secret'
+	process.env.WORKER_BASE_URL = 'http://localhost:3742'
+	process.env.HOME_CONNECTOR_DB_PATH = ':memory:'
+	process.env.ISLAND_ROUTER_HOST = 'router.local'
+	process.env.ISLAND_ROUTER_PORT = '22'
+	process.env.ISLAND_ROUTER_USERNAME = 'user'
+	process.env.ISLAND_ROUTER_PRIVATE_KEY_PATH = '/keys/id_ed25519'
+	process.env.ISLAND_ROUTER_HOST_FINGERPRINT =
+		'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12'
+	process.env.ISLAND_ROUTER_COMMAND_TIMEOUT_MS = '5000'
+	process.env.VENSTAR_SCAN_CIDRS = '192.168.10.40/32'
+	return loadHomeConnectorConfig()
+}
+
+function createFakeRunner() {
+	return async (request: IslandRouterCommandRequest) => {
+		switch (request.id) {
+			case 'show-version':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show version'],
+					stdout: [
+						'Model: Island Pro',
+						'Serial Number: IR-12345',
+						'Firmware Version: 2.3.2',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-clock':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show clock'],
+					stdout: '2026-05-02 15:55:00 PDT',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-interface-summary':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show interface summary'],
+					stdout: [
+						'Interface  Link   Speed  Duplex  Description',
+						'---------  -----  -----  ------  -----------',
+						'en0        up     1G     full    LAN uplink',
+						'en1        down   1G     full    spare port',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-neighbors':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ip neighbors'],
+					stdout: [
+						'IP Address    MAC Address        Interface  State',
+						'------------  -----------------  ---------  ---------',
+						'192.168.0.52  00:11:22:33:44:55  en0        reachable',
+						'192.168.0.1   aa:bb:cc:dd:ee:ff  en0        reachable',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-dhcp-reservations':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ip dhcp-reservations'],
+					stdout: [
+						'IP Address    MAC Address        Host Name  Interface',
+						'------------  -----------------  ---------  ---------',
+						'192.168.0.52  00:11:22:33:44:55  nas-box    en0',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-log':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.query
+							? `show log last where "${request.query.replaceAll('"', '\\"')}"`
+							: 'show log last',
+					],
+					stdout: [
+						'2026-05-02 15:50:00 info net: 192.168.0.52 link flap detected on en0',
+						'2026-05-02 15:50:10 warning dhcp: renewed lease for 192.168.0.52 00:11:22:33:44:55',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-interface':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', `show interface ${request.interfaceName}`],
+					stdout: [
+						`Interface: ${request.interfaceName}`,
+						'Link State: up',
+						'Speed: 1G',
+						'Duplex: full',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-interface':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						`show ip interface ${request.interfaceName}`,
+					],
+					stdout: [
+						`Interface: ${request.interfaceName}`,
+						'Address: 192.168.0.1/24',
+						'DHCP Server: enabled',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'ping':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', `ping ${request.host}`],
+					stdout: [
+						'64 bytes from 192.168.0.52: icmp_seq=1 ttl=64 time=1.23 ms',
+						'64 bytes from 192.168.0.52: icmp_seq=2 ttl=64 time=1.17 ms',
+						'2 packets transmitted, 2 packets received, 0% packet loss',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 200,
+				}
+			default: {
+				const _exhaustive: never = request
+				throw new Error(`Unhandled fake Island router request: ${String(_exhaustive)}`)
+			}
+		}
+	}
+}
+
+test('island router adapter returns status and diagnoses a host from typed SSH output', async () => {
+	const config = createConfig()
+	const islandRouter = createIslandRouterAdapter({
+		config,
+		commandRunner: createFakeRunner(),
+	})
+
+	const status = await islandRouter.getStatus()
+	expect(status.connected).toBe(true)
+	expect(status.router.version).toMatchObject({
+		model: 'Island Pro',
+		serialNumber: 'IR-12345',
+		firmwareVersion: '2.3.2',
+	})
+	expect(status.interfaces).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				name: 'en0',
+				linkState: 'up',
+			}),
+		]),
+	)
+
+	const diagnosis = await islandRouter.diagnoseHost({
+		host: '192.168.0.52',
+		logLimit: 5,
+	})
+	expect(diagnosis.ping).toMatchObject({
+		reachable: true,
+		transmitted: 2,
+		received: 2,
+		packetLossPercent: 0,
+	})
+	expect(diagnosis.arpEntry).toMatchObject({
+		ipAddress: '192.168.0.52',
+		macAddress: '00:11:22:33:44:55',
+		interfaceName: 'en0',
+	})
+	expect(diagnosis.dhcpLease).toMatchObject({
+		ipAddress: '192.168.0.52',
+		macAddress: '00:11:22:33:44:55',
+		hostName: 'nas-box',
+	})
+	expect(diagnosis.interfaceSummary).toMatchObject({
+		name: 'en0',
+		linkState: 'up',
+	})
+	expect(diagnosis.interfaceDetails?.attributes).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				key: 'Link State',
+				value: 'up',
+			}),
+		]),
+	)
+	expect(diagnosis.recentEvents).toHaveLength(2)
+	expect(diagnosis.errors).toEqual([])
+})
+
+test('island router adapter reports incomplete configuration without opening SSH', async () => {
+	process.env.ISLAND_ROUTER_HOST = ''
+	process.env.ISLAND_ROUTER_USERNAME = ''
+	process.env.ISLAND_ROUTER_PRIVATE_KEY_PATH = ''
+	const config = loadHomeConnectorConfig()
+	const islandRouter = createIslandRouterAdapter({
+		config,
+		commandRunner: createFakeRunner(),
+	})
+
+	const status = await islandRouter.getStatus()
+	expect(status.connected).toBe(false)
+	expect(status.config.configured).toBe(false)
+	expect(status.errors[0]).toContain('ISLAND_ROUTER_HOST')
+})

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -315,3 +315,27 @@ test('fallback interface summary parsing recognizes up and down link states', ()
 		}),
 	])
 })
+
+test('island router adapter forwards explicit timeoutMs to ARP and DHCP lookups', async () => {
+	const config = createConfig()
+	const recordedTimeouts: Array<number | undefined> = []
+	const islandRouter = createIslandRouterAdapter({
+		config,
+		commandRunner: async (request) => {
+			recordedTimeouts.push(request.timeoutMs)
+			return await createFakeRunner()(request)
+		},
+	})
+
+	await islandRouter.getArpEntry({
+		host: '192.168.0.52',
+		timeoutMs: 12_345,
+	})
+	await islandRouter.getDhcpLease({
+		host: '192.168.0.52',
+		timeoutMs: 23_456,
+	})
+
+	expect(recordedTimeouts).toContain(12_345)
+	expect(recordedTimeouts).toContain(23_456)
+})

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -4,6 +4,32 @@ import { createIslandRouterAdapter } from './index.ts'
 import { parseIslandRouterInterfaceSummaries } from './parsing.ts'
 import { type IslandRouterCommandRequest } from './types.ts'
 
+function withTemporaryEnv(values: Record<string, string | undefined>) {
+	const previousValues = Object.fromEntries(
+		Object.keys(values).map((key) => [key, process.env[key]]),
+	)
+
+	for (const [key, value] of Object.entries(values)) {
+		if (value === undefined) {
+			delete process.env[key]
+			continue
+		}
+		process.env[key] = value
+	}
+
+	return {
+		[Symbol.dispose]() {
+			for (const [key, value] of Object.entries(previousValues)) {
+				if (value === undefined) {
+					delete process.env[key]
+					continue
+				}
+				process.env[key] = value
+			}
+		},
+	}
+}
+
 function createConfig() {
 	process.env.MOCKS = 'false'
 	process.env.HOME_CONNECTOR_ID = 'default'
@@ -175,6 +201,7 @@ function createFakeRunner() {
 }
 
 test('island router adapter returns status and diagnoses a host from typed SSH output', async () => {
+	using _env = withTemporaryEnv({})
 	const config = createConfig()
 	const islandRouter = createIslandRouterAdapter({
 		config,
@@ -234,6 +261,8 @@ test('island router adapter returns status and diagnoses a host from typed SSH o
 })
 
 test('island router adapter reports incomplete configuration without opening SSH', async () => {
+	using _env = withTemporaryEnv({})
+	createConfig()
 	process.env.ISLAND_ROUTER_HOST = ''
 	process.env.ISLAND_ROUTER_USERNAME = ''
 	process.env.ISLAND_ROUTER_PRIVATE_KEY_PATH = ''
@@ -250,6 +279,8 @@ test('island router adapter reports incomplete configuration without opening SSH
 })
 
 test('island router adapter marks malformed fingerprint config as not configured', async () => {
+	using _env = withTemporaryEnv({})
+	createConfig()
 	process.env.ISLAND_ROUTER_HOST_FINGERPRINT = 'not-a-fingerprint'
 	const config = loadHomeConnectorConfig()
 	const islandRouter = createIslandRouterAdapter({

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import { loadHomeConnectorConfig } from '../../config.ts'
 import { createIslandRouterAdapter } from './index.ts'
+import { parseIslandRouterInterfaceSummaries } from './parsing.ts'
 import { type IslandRouterCommandRequest } from './types.ts'
 
 function createConfig() {
@@ -246,4 +247,40 @@ test('island router adapter reports incomplete configuration without opening SSH
 	expect(status.connected).toBe(false)
 	expect(status.config.configured).toBe(false)
 	expect(status.errors[0]).toContain('ISLAND_ROUTER_HOST')
+})
+
+test('island router adapter marks malformed fingerprint config as not configured', async () => {
+	process.env.ISLAND_ROUTER_HOST_FINGERPRINT = 'not-a-fingerprint'
+	const config = loadHomeConnectorConfig()
+	const islandRouter = createIslandRouterAdapter({
+		config,
+		commandRunner: createFakeRunner(),
+	})
+
+	const status = await islandRouter.getStatus()
+	expect(status.connected).toBe(false)
+	expect(status.config.configured).toBe(false)
+	expect(status.config.warnings).toEqual(
+		expect.arrayContaining([
+			expect.stringContaining('ISLAND_ROUTER_HOST_FINGERPRINT'),
+		]),
+	)
+})
+
+test('fallback interface summary parsing recognizes up and down link states', () => {
+	const summaries = parseIslandRouterInterfaceSummaries(
+		['en0 up 1G full', 'en1 down 1G full'].join('\n'),
+		['show interface summary'],
+	)
+
+	expect(summaries).toEqual([
+		expect.objectContaining({
+			name: 'en0',
+			linkState: 'up',
+		}),
+		expect.objectContaining({
+			name: 'en1',
+			linkState: 'down',
+		}),
+	])
 })

--- a/packages/home-connector/src/adapters/island-router/index.ts
+++ b/packages/home-connector/src/adapters/island-router/index.ts
@@ -1,0 +1,499 @@
+import { type HomeConnectorConfig } from '../../config.ts'
+import {
+	type IslandRouterCommandResult,
+	type IslandRouterCommandRunner,
+	type IslandRouterDhcpLease,
+	type IslandRouterHostDiagnosis,
+	type IslandRouterInterfaceSummary,
+	type IslandRouterNeighborEntry,
+	type IslandRouterStatus,
+} from './types.ts'
+import { createIslandRouterSshCommandRunner } from './ssh-client.ts'
+import {
+	findMatchingDhcpLease,
+	findMatchingNeighbor,
+	parseIslandRouterClock,
+	parseIslandRouterDhcpReservations,
+	parseIslandRouterInterfaceDetails,
+	parseIslandRouterInterfaceSummaries,
+	parseIslandRouterNeighbors,
+	parseIslandRouterPingResult,
+	parseIslandRouterRecentEvents,
+	parseIslandRouterVersion,
+} from './parsing.ts'
+import {
+	assertIslandRouterConfigured,
+	getIslandRouterConfigStatus,
+	validateIslandRouterHost,
+} from './validation.ts'
+
+type PingRequest = {
+	host: string
+	timeoutMs?: number
+}
+
+type RecentEventRequest = {
+	host?: string
+	limit?: number
+	timeoutMs?: number
+}
+
+type DiagnoseHostRequest = {
+	host: string
+	timeoutMs?: number
+	logLimit?: number
+}
+
+function normalizeLimit(value: number | undefined, fallback: number, max: number) {
+	if (value == null || !Number.isFinite(value)) return fallback
+	return Math.max(1, Math.min(max, Math.trunc(value)))
+}
+
+function normalizeTimeoutMs(config: HomeConnectorConfig, timeoutMs?: number) {
+	if (timeoutMs == null || !Number.isFinite(timeoutMs)) {
+		return config.islandRouterCommandTimeoutMs
+	}
+	return Math.max(1000, Math.trunc(timeoutMs))
+}
+
+function ensureSuccessfulCommand(
+	result: IslandRouterCommandResult,
+	message: string,
+) {
+	if (result.timedOut) {
+		throw new Error(`${message} timed out after ${result.durationMs}ms.`)
+	}
+	if (result.exitCode !== 0 && result.exitCode !== null) {
+		throw new Error(
+			`${message} failed with exit code ${result.exitCode}. ${result.stderr.trim()}`.trim(),
+		)
+	}
+	return result
+}
+
+function getPrimaryInterfaceDetails(
+	interfaceName: string | null,
+	interfaceSummaries: Array<IslandRouterInterfaceSummary>,
+) {
+	if (!interfaceName) return null
+	return (
+		interfaceSummaries.find((summary) => summary.name === interfaceName) ?? null
+	)
+}
+
+async function maybeGetInterfaceDetails(input: {
+	runner: IslandRouterCommandRunner
+	interfaceName: string | null
+	timeoutMs: number
+}) {
+	if (!input.interfaceName) {
+		return {
+			interfaceDetails: null,
+			ipInterfaceDetails: null,
+		}
+	}
+
+	const [interfaceResult, ipInterfaceResult] = await Promise.all([
+		input.runner({
+			id: 'show-interface',
+			interfaceName: input.interfaceName,
+			timeoutMs: input.timeoutMs,
+		}),
+		input.runner({
+			id: 'show-ip-interface',
+			interfaceName: input.interfaceName,
+			timeoutMs: input.timeoutMs,
+		}),
+	])
+
+	const interfaceDetails =
+		interfaceResult.exitCode === 0 && !interfaceResult.timedOut
+			? parseIslandRouterInterfaceDetails(
+					interfaceResult.stdout,
+					interfaceResult.commandLines,
+				)
+			: null
+	const ipInterfaceDetails =
+		ipInterfaceResult.exitCode === 0 && !ipInterfaceResult.timedOut
+			? parseIslandRouterInterfaceDetails(
+					ipInterfaceResult.stdout,
+					ipInterfaceResult.commandLines,
+				)
+			: null
+
+	return {
+		interfaceDetails,
+		ipInterfaceDetails,
+	}
+}
+
+function getPreferredInterfaceName(input: {
+	neighbor: IslandRouterNeighborEntry | null
+	dhcpLease: IslandRouterDhcpLease | null
+}) {
+	return input.neighbor?.interfaceName ?? input.dhcpLease?.interfaceName ?? null
+}
+
+function dedupeRecentEvents(messages: Array<ReturnType<typeof parseIslandRouterRecentEvents>>) {
+	const seen = new Set<string>()
+	const merged = messages.flat()
+	return merged.filter((event) => {
+		const key = `${event.timestamp ?? ''}|${event.message}`
+		if (seen.has(key)) return false
+		seen.add(key)
+		return true
+	})
+}
+
+export function createIslandRouterAdapter(input: {
+	config: HomeConnectorConfig
+	commandRunner?: IslandRouterCommandRunner
+}) {
+	const { config } = input
+
+	function getRunner() {
+		return input.commandRunner ?? createIslandRouterSshCommandRunner(config)
+	}
+
+	function getConfigStatus() {
+		return getIslandRouterConfigStatus(config)
+	}
+
+	return {
+		getConfigStatus,
+		async getStatus(): Promise<IslandRouterStatus> {
+			const configStatus = getConfigStatus()
+			if (!configStatus.configured) {
+				return {
+					config: configStatus,
+					connected: false,
+					router: {
+						version: null,
+						clock: null,
+					},
+					interfaces: [],
+					neighbors: [],
+					errors: [
+						`Island router diagnostics are not configured: ${configStatus.missingFields.join(', ')}.`,
+					],
+				}
+			}
+
+			assertIslandRouterConfigured(config)
+			const runner = getRunner()
+			const timeoutMs = normalizeTimeoutMs(config)
+			const errors: Array<string> = []
+
+			const [versionResult, clockResult, interfaceResult, neighborResult] =
+				await Promise.all([
+					runner({
+						id: 'show-version',
+						timeoutMs,
+					}),
+					runner({
+						id: 'show-clock',
+						timeoutMs,
+					}),
+					runner({
+						id: 'show-interface-summary',
+						timeoutMs,
+					}),
+					runner({
+						id: 'show-ip-neighbors',
+						timeoutMs,
+					}),
+				])
+
+			let version = null
+			if (versionResult.exitCode === 0 && !versionResult.timedOut) {
+				version = parseIslandRouterVersion(
+					versionResult.stdout,
+					versionResult.commandLines,
+				)
+			} else {
+				errors.push('Failed to load Island router version information.')
+			}
+
+			let clock = null
+			if (clockResult.exitCode === 0 && !clockResult.timedOut) {
+				clock = parseIslandRouterClock(clockResult.stdout, clockResult.commandLines)
+			} else {
+				errors.push('Failed to load Island router clock information.')
+			}
+
+			const interfaces =
+				interfaceResult.exitCode === 0 && !interfaceResult.timedOut
+					? parseIslandRouterInterfaceSummaries(
+							interfaceResult.stdout,
+							interfaceResult.commandLines,
+						)
+					: []
+			if (interfaces.length === 0) {
+				errors.push('No Island router interface summary data was returned.')
+			}
+
+			const neighbors =
+				neighborResult.exitCode === 0 && !neighborResult.timedOut
+					? parseIslandRouterNeighbors(
+							neighborResult.stdout,
+							neighborResult.commandLines,
+						)
+					: []
+			if (neighborResult.exitCode !== 0 || neighborResult.timedOut) {
+				errors.push('Failed to load Island router neighbor cache.')
+			}
+
+			return {
+				config: configStatus,
+				connected: errors.length < 4,
+				router: {
+					version,
+					clock,
+				},
+				interfaces,
+				neighbors,
+				errors,
+			}
+		},
+		async pingHost(request: PingRequest) {
+			assertIslandRouterConfigured(config)
+			const host = validateIslandRouterHost(request.host)
+			if (host.kind === 'mac') {
+				throw new Error('router_ping_host requires an IP address or hostname, not a MAC address.')
+			}
+
+			const runner = getRunner()
+			const timeoutMs = normalizeTimeoutMs(config, request.timeoutMs)
+			const result = await runner({
+				id: 'ping',
+				host: host.value,
+				timeoutMs,
+				allowTimeout: true,
+			})
+			return parseIslandRouterPingResult({
+				host,
+				stdout: result.stdout,
+				stderr: result.stderr,
+				commandLines: result.commandLines,
+				timedOut: result.timedOut,
+			})
+		},
+		async getArpEntry(host: string) {
+			assertIslandRouterConfigured(config)
+			const identity = validateIslandRouterHost(host)
+			const runner = getRunner()
+			const result = ensureSuccessfulCommand(
+				await runner({
+					id: 'show-ip-neighbors',
+					timeoutMs: normalizeTimeoutMs(config),
+				}),
+				'Island router neighbor lookup',
+			)
+			const entries = parseIslandRouterNeighbors(
+				result.stdout,
+				result.commandLines,
+			)
+			return {
+				host: identity,
+				entry: findMatchingNeighbor(entries, identity),
+				entries,
+			}
+		},
+		async getDhcpLease(host: string) {
+			assertIslandRouterConfigured(config)
+			const identity = validateIslandRouterHost(host)
+			const runner = getRunner()
+			const result = ensureSuccessfulCommand(
+				await runner({
+					id: 'show-ip-dhcp-reservations',
+					timeoutMs: normalizeTimeoutMs(config),
+				}),
+				'Island router DHCP reservation lookup',
+			)
+			const leases = parseIslandRouterDhcpReservations(
+				result.stdout,
+				result.commandLines,
+			)
+			return {
+				host: identity,
+				lease: findMatchingDhcpLease(leases, identity),
+				leases,
+			}
+		},
+		async getRecentEvents(request: RecentEventRequest = {}) {
+			assertIslandRouterConfigured(config)
+			const query = request.host ? validateIslandRouterHost(request.host).value : ''
+			const limit = normalizeLimit(request.limit, 50, 200)
+			const runner = getRunner()
+			const timeoutMs = normalizeTimeoutMs(config, request.timeoutMs)
+			const result = ensureSuccessfulCommand(
+				await runner({
+					id: 'show-log',
+					query: query.length > 0 ? query : undefined,
+					timeoutMs,
+				}),
+				'Island router recent event lookup',
+			)
+			return parseIslandRouterRecentEvents(
+				result.stdout,
+				result.commandLines,
+			).slice(0, limit)
+		},
+		async diagnoseHost(
+			request: DiagnoseHostRequest,
+		): Promise<IslandRouterHostDiagnosis> {
+			assertIslandRouterConfigured(config)
+			const host = validateIslandRouterHost(request.host)
+			const runner = getRunner()
+			const timeoutMs = normalizeTimeoutMs(config, request.timeoutMs)
+			const logLimit = normalizeLimit(request.logLimit, 20, 100)
+			const errors: Array<string> = []
+
+			const pingPromise =
+				host.kind === 'mac'
+					? Promise.resolve(null)
+					: runner({
+							id: 'ping',
+							host: host.value,
+							timeoutMs,
+							allowTimeout: true,
+						}).then((result) =>
+							parseIslandRouterPingResult({
+								host,
+								stdout: result.stdout,
+								stderr: result.stderr,
+								commandLines: result.commandLines,
+								timedOut: result.timedOut,
+							}),
+						)
+
+			const [ping, neighborResult, dhcpResult, interfaceResult, eventResult] =
+				await Promise.all([
+					pingPromise,
+					runner({
+						id: 'show-ip-neighbors',
+						timeoutMs,
+					}),
+					runner({
+						id: 'show-ip-dhcp-reservations',
+						timeoutMs,
+					}),
+					runner({
+						id: 'show-interface-summary',
+						timeoutMs,
+					}),
+					runner({
+						id: 'show-log',
+						query: host.value,
+						timeoutMs,
+					}),
+				])
+
+			const neighbors =
+				neighborResult.exitCode === 0 && !neighborResult.timedOut
+					? parseIslandRouterNeighbors(
+							neighborResult.stdout,
+							neighborResult.commandLines,
+						)
+					: []
+			if (neighborResult.exitCode !== 0 || neighborResult.timedOut) {
+				errors.push('Failed to read the Island router neighbor cache.')
+			}
+			const arpEntry = findMatchingNeighbor(neighbors, host)
+
+			const leases =
+				dhcpResult.exitCode === 0 && !dhcpResult.timedOut
+					? parseIslandRouterDhcpReservations(
+							dhcpResult.stdout,
+							dhcpResult.commandLines,
+						)
+					: []
+			if (dhcpResult.exitCode !== 0 || dhcpResult.timedOut) {
+				errors.push('Failed to read Island router DHCP reservations.')
+			}
+			const dhcpLease = findMatchingDhcpLease(leases, host)
+
+			const interfaceSummaries =
+				interfaceResult.exitCode === 0 && !interfaceResult.timedOut
+					? parseIslandRouterInterfaceSummaries(
+							interfaceResult.stdout,
+							interfaceResult.commandLines,
+						)
+					: []
+			if (interfaceResult.exitCode !== 0 || interfaceResult.timedOut) {
+				errors.push('Failed to read Island router interface summary.')
+			}
+			const preferredInterfaceName = getPreferredInterfaceName({
+				neighbor: arpEntry,
+				dhcpLease,
+			})
+			const interfaceSummary = getPrimaryInterfaceDetails(
+				preferredInterfaceName,
+				interfaceSummaries,
+			)
+
+			const recentEventSets = [
+				eventResult.exitCode === 0 && !eventResult.timedOut
+					? parseIslandRouterRecentEvents(
+							eventResult.stdout,
+							eventResult.commandLines,
+						)
+					: [],
+			]
+			if (eventResult.exitCode !== 0 || eventResult.timedOut) {
+				errors.push('Failed to read Island router recent events.')
+			}
+
+			if (
+				arpEntry?.macAddress &&
+				host.kind !== 'mac' &&
+				arpEntry.macAddress !== host.normalizedValue
+			) {
+				const macEventResult = await runner({
+					id: 'show-log',
+					query: arpEntry.macAddress,
+					timeoutMs,
+				})
+				if (macEventResult.exitCode === 0 && !macEventResult.timedOut) {
+					recentEventSets.push(
+						parseIslandRouterRecentEvents(
+							macEventResult.stdout,
+							macEventResult.commandLines,
+						),
+					)
+				}
+			}
+			const recentEvents = dedupeRecentEvents(recentEventSets).slice(0, logLimit)
+
+			const { interfaceDetails, ipInterfaceDetails } =
+				await maybeGetInterfaceDetails({
+					runner,
+					interfaceName: preferredInterfaceName,
+					timeoutMs,
+				})
+
+			if (!arpEntry) {
+				errors.push(
+					'No matching ARP/neighbor entry was found for the requested host.',
+				)
+			}
+			if (!dhcpLease) {
+				errors.push(
+					'No matching DHCP reservation was found for the requested host.',
+				)
+			}
+
+			return {
+				host,
+				ping,
+				arpEntry,
+				dhcpLease,
+				interfaceSummary,
+				interfaceDetails,
+				ipInterfaceDetails,
+				recentEvents,
+				errors,
+			}
+		},
+	}
+}

--- a/packages/home-connector/src/adapters/island-router/index.ts
+++ b/packages/home-connector/src/adapters/island-router/index.ts
@@ -164,6 +164,10 @@ export function createIslandRouterAdapter(input: {
 		async getStatus(): Promise<IslandRouterStatus> {
 			const configStatus = getConfigStatus()
 			if (!configStatus.configured) {
+				const missingReasons = [
+					...configStatus.missingFields,
+					...configStatus.warnings,
+				].filter(Boolean)
 				return {
 					config: configStatus,
 					connected: false,
@@ -174,7 +178,7 @@ export function createIslandRouterAdapter(input: {
 					interfaces: [],
 					neighbors: [],
 					errors: [
-						`Island router diagnostics are not configured: ${configStatus.missingFields.join(', ')}.`,
+						`Island router diagnostics are not configured: ${missingReasons.join(', ')}.`,
 					],
 				}
 			}
@@ -245,7 +249,15 @@ export function createIslandRouterAdapter(input: {
 
 			return {
 				config: configStatus,
-				connected: errors.length < 4,
+				connected:
+					versionResult.exitCode === 0 &&
+					!versionResult.timedOut &&
+					clockResult.exitCode === 0 &&
+					!clockResult.timedOut &&
+					interfaceResult.exitCode === 0 &&
+					!interfaceResult.timedOut &&
+					neighborResult.exitCode === 0 &&
+					!neighborResult.timedOut,
 				router: {
 					version,
 					clock,

--- a/packages/home-connector/src/adapters/island-router/index.ts
+++ b/packages/home-connector/src/adapters/island-router/index.ts
@@ -68,7 +68,15 @@ function ensureSuccessfulCommand(
 	if (result.timedOut) {
 		throw new Error(`${message} timed out after ${result.durationMs}ms.`)
 	}
-	if (result.exitCode !== 0 && result.exitCode !== null) {
+	if (result.exitCode === null) {
+		const reason = result.signal
+			? `signal ${result.signal}`
+			: 'an unknown termination state'
+		throw new Error(
+			`${message} failed because the command exited via ${reason}. ${result.stderr.trim()}`.trim(),
+		)
+	}
+	if (result.exitCode !== 0) {
 		throw new Error(
 			`${message} failed with exit code ${result.exitCode}. ${result.stderr.trim()}`.trim(),
 		)

--- a/packages/home-connector/src/adapters/island-router/index.ts
+++ b/packages/home-connector/src/adapters/island-router/index.ts
@@ -32,6 +32,11 @@ type PingRequest = {
 	timeoutMs?: number
 }
 
+type HostLookupRequest = {
+	host: string
+	timeoutMs?: number
+}
+
 type RecentEventRequest = {
 	host?: string
 	limit?: number
@@ -150,9 +155,12 @@ export function createIslandRouterAdapter(input: {
 	commandRunner?: IslandRouterCommandRunner
 }) {
 	const { config } = input
+	let cachedRunner: IslandRouterCommandRunner | null = null
 
 	function getRunner() {
-		return input.commandRunner ?? createIslandRouterSshCommandRunner(config)
+		if (input.commandRunner) return input.commandRunner
+		cachedRunner ??= createIslandRouterSshCommandRunner(config)
+		return cachedRunner
 	}
 
 	function getConfigStatus() {
@@ -290,14 +298,15 @@ export function createIslandRouterAdapter(input: {
 				timedOut: result.timedOut,
 			})
 		},
-		async getArpEntry(host: string) {
+		async getArpEntry(request: HostLookupRequest) {
 			assertIslandRouterConfigured(config)
-			const identity = validateIslandRouterHost(host)
+			const identity = validateIslandRouterHost(request.host)
 			const runner = getRunner()
+			const timeoutMs = normalizeTimeoutMs(config, request.timeoutMs)
 			const result = ensureSuccessfulCommand(
 				await runner({
 					id: 'show-ip-neighbors',
-					timeoutMs: normalizeTimeoutMs(config),
+					timeoutMs,
 				}),
 				'Island router neighbor lookup',
 			)
@@ -311,14 +320,15 @@ export function createIslandRouterAdapter(input: {
 				entries,
 			}
 		},
-		async getDhcpLease(host: string) {
+		async getDhcpLease(request: HostLookupRequest) {
 			assertIslandRouterConfigured(config)
-			const identity = validateIslandRouterHost(host)
+			const identity = validateIslandRouterHost(request.host)
 			const runner = getRunner()
+			const timeoutMs = normalizeTimeoutMs(config, request.timeoutMs)
 			const result = ensureSuccessfulCommand(
 				await runner({
 					id: 'show-ip-dhcp-reservations',
-					timeoutMs: normalizeTimeoutMs(config),
+					timeoutMs,
 				}),
 				'Island router DHCP reservation lookup',
 			)

--- a/packages/home-connector/src/adapters/island-router/parsing.ts
+++ b/packages/home-connector/src/adapters/island-router/parsing.ts
@@ -1,0 +1,475 @@
+import {
+	type IslandRouterDhcpLease,
+	type IslandRouterHostIdentity,
+	type IslandRouterInterfaceDetails,
+	type IslandRouterInterfaceSummary,
+	type IslandRouterNeighborEntry,
+	type IslandRouterPingReply,
+	type IslandRouterPingResult,
+	type IslandRouterRecentEvent,
+	type IslandRouterVersionInfo,
+} from './types.ts'
+
+type ParsedTableRow = {
+	rawLine: string
+	fields: Record<string, string>
+}
+
+const interfaceNamePattern =
+	/\b(?:en\d+(?:\.\d+)?|eth\d+(?:\.\d+)?|wan\d+|lan\d+|vlan\d+|bond\d+|br\d+)\b/i
+const neighborStatePattern =
+	/\b(?:reachable|stale|delay|probe|permanent|failed|incomplete)\b/i
+const timestampPattern =
+	/^(?<timestamp>\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?|\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(?<rest>.*)$/
+const macAddressPattern =
+	/\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b/
+const ipv4Pattern = /\b\d{1,3}(?:\.\d{1,3}){3}\b/
+const pingReplyPattern =
+	/\bicmp_seq=(?<sequence>\d+)\b.*?\btime=(?<timeMs>\d+(?:\.\d+)?)\s*ms\b/i
+const pingSummaryPattern =
+	/(?<transmitted>\d+)\s+packets transmitted,\s+(?<received>\d+)\s+packets received,\s+(?<packetLoss>\d+(?:\.\d+)?)%\s+packet loss/i
+
+function normalizeHeaderKey(value: string) {
+	return value
+		.trim()
+		.toLowerCase()
+		.replaceAll(/[^a-z0-9]+/g, '_')
+		.replaceAll(/^_+|_+$/g, '')
+}
+
+function normalizeWhitespace(value: string) {
+	return value.replaceAll(/\s+/g, ' ').trim()
+}
+
+export function sanitizeIslandRouterOutput(
+	stdout: string,
+	commandLines: Array<string>,
+) {
+	const normalizedCommands = new Set(
+		commandLines.map((line) => normalizeWhitespace(line)),
+	)
+
+	return stdout
+		.replaceAll(/\u001b\[[0-9;]*m/g, '')
+		.split(/\r?\n/)
+		.map((line) => line.replace(/\r/g, ''))
+		.filter((line) => {
+			const trimmed = normalizeWhitespace(line)
+			if (!trimmed) return false
+			if (trimmed === 'exit') return false
+			if (/^[\w.-]+[>#]$/.test(trimmed)) return false
+			if (normalizedCommands.has(trimmed)) return false
+			for (const command of normalizedCommands) {
+				if (
+					trimmed.endsWith(`> ${command}`) ||
+					trimmed.endsWith(`# ${command}`) ||
+					trimmed.endsWith(`] ${command}`)
+				) {
+					return false
+				}
+			}
+			return true
+		})
+}
+
+function splitTableColumns(line: string) {
+	return line
+		.trim()
+		.split(/\s{2,}/)
+		.map((part) => part.trim())
+		.filter(Boolean)
+}
+
+function parseTextTable(lines: Array<string>): Array<ParsedTableRow> {
+	let headerIndex = -1
+	let headers: Array<string> = []
+
+	for (let index = 0; index < lines.length; index += 1) {
+		const line = lines[index] ?? ''
+		const columns = splitTableColumns(line)
+		if (columns.length < 2) continue
+		const next = lines[index + 1] ?? ''
+		if (/^-{3,}(?:\s+-{3,})*$/.test(next.trim())) {
+			headerIndex = index
+			headers = columns.map(normalizeHeaderKey)
+			break
+		}
+	}
+
+	if (headerIndex < 0 || headers.length < 2) return []
+
+	const rows: Array<ParsedTableRow> = []
+	for (let index = headerIndex + 2; index < lines.length; index += 1) {
+		const line = lines[index] ?? ''
+		if (!line.trim()) continue
+		if (/^-{3,}(?:\s+-{3,})*$/.test(line.trim())) continue
+		const columns = splitTableColumns(line)
+		if (columns.length < 2) continue
+		const fields = Object.fromEntries(
+			headers.map((header, columnIndex) => [header, columns[columnIndex] ?? '']),
+		)
+		rows.push({
+			rawLine: line,
+			fields,
+		})
+	}
+
+	return rows
+}
+
+function parseKeyValueLines(lines: Array<string>) {
+	return lines.flatMap((line) => {
+		const match = /^(?<key>[^:]+):\s*(?<value>.+)$/.exec(line)
+		if (!match?.groups) return []
+		return [
+			{
+				key: match.groups['key']?.trim() ?? '',
+				value: match.groups['value']?.trim() ?? '',
+			},
+		]
+	})
+}
+
+function findField(
+	fields: Record<string, string>,
+	candidates: Array<string>,
+): string | null {
+	for (const candidate of candidates) {
+		const direct = fields[candidate]
+		if (direct) return direct
+	}
+	const entries = Object.entries(fields)
+	for (const candidate of candidates) {
+		const fuzzy = entries.find(([key]) => key.includes(candidate))
+		if (fuzzy?.[1]) return fuzzy[1]
+	}
+	return null
+}
+
+function extractMacAddress(value: string) {
+	return value.match(macAddressPattern)?.[0]?.toLowerCase() ?? null
+}
+
+function extractIpv4Address(value: string) {
+	return value.match(ipv4Pattern)?.[0] ?? null
+}
+
+function extractInterfaceName(value: string) {
+	return value.match(interfaceNamePattern)?.[0] ?? null
+}
+
+function extractNeighborState(value: string) {
+	return value.match(neighborStatePattern)?.[0]?.toLowerCase() ?? null
+}
+
+export function parseIslandRouterVersion(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterVersionInfo {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const attributes = parseKeyValueLines(lines)
+	const fieldMap = Object.fromEntries(
+		attributes.map((entry) => [normalizeHeaderKey(entry.key), entry.value]),
+	)
+	return {
+		model: findField(fieldMap, ['model', 'hardware_model']),
+		serialNumber: findField(fieldMap, ['serial_number', 'serial']),
+		firmwareVersion: findField(fieldMap, [
+			'firmware_version',
+			'software_version',
+			'version',
+		]),
+		attributes,
+		rawOutput: lines.join('\n'),
+	}
+}
+
+export function parseIslandRouterClock(
+	stdout: string,
+	commandLines: Array<string>,
+) {
+	return sanitizeIslandRouterOutput(stdout, commandLines).join('\n') || null
+}
+
+export function parseIslandRouterInterfaceSummaries(
+	stdout: string,
+	commandLines: Array<string>,
+): Array<IslandRouterInterfaceSummary> {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const table = parseTextTable(lines)
+	if (table.length > 0) {
+		return table.map((row) => ({
+			name: findField(row.fields, ['interface', 'iface', 'name']),
+			linkState: findField(row.fields, ['link', 'status', 'state']),
+			speed: findField(row.fields, ['speed']),
+			duplex: findField(row.fields, ['duplex']),
+			description: findField(row.fields, ['description', 'desc']),
+			rawLine: row.rawLine,
+			fields: row.fields,
+		}))
+	}
+
+	return lines.map((line) => {
+		const normalized = normalizeWhitespace(line)
+		const tokens = normalized.split(' ')
+		return {
+			name: extractInterfaceName(line) ?? tokens[0] ?? null,
+			linkState: extractNeighborState(line) ?? null,
+			speed:
+				tokens.find((token) => /\b\d+(?:g|m|mbps|gbps)\b/i.test(token)) ?? null,
+			duplex:
+				tokens.find((token) => /^(?:full|half)$/i.test(token))?.toLowerCase() ??
+				null,
+			description: null,
+			rawLine: line,
+			fields: {},
+		}
+	})
+}
+
+export function parseIslandRouterInterfaceDetails(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterInterfaceDetails {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const attributes = parseKeyValueLines(lines)
+	const firstLine = lines[0] ?? ''
+	const fieldMap = Object.fromEntries(
+		attributes.map((entry) => [normalizeHeaderKey(entry.key), entry.value]),
+	)
+	return {
+		interfaceName:
+			findField(fieldMap, ['interface', 'name']) ??
+			extractInterfaceName(firstLine) ??
+			null,
+		attributes,
+		rawOutput: lines.join('\n'),
+	}
+}
+
+export function parseIslandRouterNeighbors(
+	stdout: string,
+	commandLines: Array<string>,
+): Array<IslandRouterNeighborEntry> {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const table = parseTextTable(lines)
+	if (table.length > 0) {
+		return table.map((row) => ({
+			ipAddress: findField(row.fields, ['ip', 'address', 'ip_address']),
+			macAddress:
+				findField(row.fields, ['mac', 'lladdr', 'link_layer_address'])?.toLowerCase() ??
+				null,
+			interfaceName: findField(row.fields, ['interface', 'iface', 'device']),
+			state: findField(row.fields, ['state', 'status'])?.toLowerCase() ?? null,
+			rawLine: row.rawLine,
+			fields: row.fields,
+		}))
+	}
+
+	return lines.flatMap((line) => {
+		const ipAddress = extractIpv4Address(line)
+		const macAddress = extractMacAddress(line)
+		if (!ipAddress && !macAddress) return []
+		return [
+			{
+				ipAddress,
+				macAddress,
+				interfaceName: extractInterfaceName(line),
+				state: extractNeighborState(line),
+				rawLine: line,
+				fields: {},
+			},
+		]
+	})
+}
+
+export function parseIslandRouterDhcpReservations(
+	stdout: string,
+	commandLines: Array<string>,
+): Array<IslandRouterDhcpLease> {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const table = parseTextTable(lines)
+	if (table.length > 0) {
+		return table.map((row) => ({
+			ipAddress: findField(row.fields, ['ip', 'address', 'ip_address']),
+			macAddress:
+				findField(row.fields, ['mac', 'hardware_address'])?.toLowerCase() ?? null,
+			hostName: findField(row.fields, ['host', 'hostname', 'name']),
+			interfaceName: findField(row.fields, ['interface', 'iface']),
+			leaseType: 'reservation',
+			rawLine: row.rawLine,
+			fields: row.fields,
+		}))
+	}
+
+	return lines.flatMap((line) => {
+		const ipAddress = extractIpv4Address(line)
+		const macAddress = extractMacAddress(line)
+		if (!ipAddress && !macAddress) return []
+		const hostName = normalizeWhitespace(
+			line
+				.replace(ipAddress ?? '', '')
+				.replace(macAddress ?? '', '')
+				.replace(interfaceNamePattern, '')
+				.trim(),
+		)
+		return [
+			{
+				ipAddress,
+				macAddress,
+				hostName: hostName || null,
+				interfaceName: extractInterfaceName(line),
+				leaseType: 'reservation',
+				rawLine: line,
+				fields: {},
+			},
+		]
+	})
+}
+
+export function parseIslandRouterRecentEvents(
+	stdout: string,
+	commandLines: Array<string>,
+): Array<IslandRouterRecentEvent> {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	return lines.map((line) => {
+		const match = timestampPattern.exec(line)
+		const rest = match?.groups?.['rest']?.trim() ?? line.trim()
+		const levelMatch = rest.match(
+			/\b(?:emerg|alert|crit|err|warning|notice|info|debug)\b/i,
+		)
+		const moduleMatch = rest.match(/\b[a-z][a-z0-9_-]+(?=:)/i)
+		return {
+			timestamp: match?.groups?.['timestamp']?.trim() ?? null,
+			level: levelMatch?.[0]?.toLowerCase() ?? null,
+			module: moduleMatch?.[0] ?? null,
+			message: rest,
+			rawLine: line,
+		}
+	})
+}
+
+function parsePingReplies(lines: Array<string>) {
+	return lines.flatMap((line) => {
+		const match = pingReplyPattern.exec(line)
+		if (!match?.groups) return []
+		const sequenceRaw = match.groups['sequence'] ?? ''
+		const timeMsRaw = match.groups['timeMs'] ?? ''
+		return [
+			{
+				sequence: Number.parseInt(sequenceRaw, 10),
+				timeMs: Number.parseFloat(timeMsRaw),
+				rawLine: line,
+			} satisfies IslandRouterPingReply,
+		]
+	})
+}
+
+export function parseIslandRouterPingResult(input: {
+	host: IslandRouterHostIdentity
+	stdout: string
+	stderr: string
+	commandLines: Array<string>
+	timedOut: boolean
+}): IslandRouterPingResult {
+	const lines = sanitizeIslandRouterOutput(input.stdout, input.commandLines)
+	const replies = parsePingReplies(lines)
+	const summaryLine =
+		lines.find((line) => pingSummaryPattern.test(line)) ??
+		input.stderr
+			.split(/\r?\n/)
+			.find((line) => pingSummaryPattern.test(line)) ??
+		''
+	const summaryMatch = pingSummaryPattern.exec(summaryLine)
+	const transmitted = summaryMatch?.groups?.['transmitted']
+		? Number.parseInt(summaryMatch.groups['transmitted'], 10)
+		: null
+	const received = summaryMatch?.groups?.['received']
+		? Number.parseInt(summaryMatch.groups['received'], 10)
+		: null
+	const packetLossPercent = summaryMatch?.groups?.['packetLoss']
+		? Number.parseFloat(summaryMatch.groups['packetLoss'])
+		: null
+	const reachable =
+		received == null ? (replies.length > 0 ? true : null) : received > 0
+
+	let addressFamily: IslandRouterPingResult['addressFamily']
+	switch (input.host.kind) {
+		case 'ipv4':
+			addressFamily = 'ip'
+			break
+		case 'ipv6':
+			addressFamily = 'ipv6'
+			break
+		case 'hostname':
+			addressFamily = 'auto'
+			break
+		case 'mac':
+			addressFamily = 'auto'
+			break
+		default: {
+			const _exhaustive: never = input.host.kind
+			throw new Error(`Unhandled host kind: ${String(_exhaustive)}`)
+		}
+	}
+
+	return {
+		host: input.host.value,
+		addressFamily,
+		reachable,
+		timedOut: input.timedOut,
+		completed: summaryMatch != null || replies.length > 0,
+		transmitted,
+		received,
+		packetLossPercent,
+		replies,
+		rawOutput: lines.join('\n'),
+		stderr: input.stderr.trim(),
+	}
+}
+
+export function findMatchingNeighbor(
+	entries: Array<IslandRouterNeighborEntry>,
+	host: IslandRouterHostIdentity,
+) {
+	return (
+		entries.find((entry) => {
+			switch (host.kind) {
+				case 'ipv4':
+				case 'ipv6':
+					return entry.ipAddress === host.normalizedValue
+				case 'mac':
+					return entry.macAddress === host.normalizedValue
+				case 'hostname':
+					return entry.rawLine.toLowerCase().includes(host.normalizedValue)
+				default: {
+					const _exhaustive: never = host.kind
+					throw new Error(`Unhandled host kind: ${String(_exhaustive)}`)
+				}
+			}
+		}) ?? null
+	)
+}
+
+export function findMatchingDhcpLease(
+	entries: Array<IslandRouterDhcpLease>,
+	host: IslandRouterHostIdentity,
+) {
+	return (
+		entries.find((entry) => {
+			switch (host.kind) {
+				case 'ipv4':
+				case 'ipv6':
+					return entry.ipAddress === host.normalizedValue
+				case 'mac':
+					return entry.macAddress === host.normalizedValue
+				case 'hostname':
+					return entry.hostName?.toLowerCase() === host.normalizedValue
+				default: {
+					const _exhaustive: never = host.kind
+					throw new Error(`Unhandled host kind: ${String(_exhaustive)}`)
+				}
+			}
+		}) ?? null
+	)
+}

--- a/packages/home-connector/src/adapters/island-router/parsing.ts
+++ b/packages/home-connector/src/adapters/island-router/parsing.ts
@@ -17,6 +17,7 @@ type ParsedTableRow = {
 
 const interfaceNamePattern =
 	/\b(?:en\d+(?:\.\d+)?|eth\d+(?:\.\d+)?|wan\d+|lan\d+|vlan\d+|bond\d+|br\d+)\b/i
+const interfaceLinkStatePattern = /\b(?:up|down)\b/i
 const neighborStatePattern =
 	/\b(?:reachable|stale|delay|probe|permanent|failed|incomplete)\b/i
 const timestampPattern =
@@ -162,6 +163,10 @@ function extractNeighborState(value: string) {
 	return value.match(neighborStatePattern)?.[0]?.toLowerCase() ?? null
 }
 
+function extractInterfaceLinkState(value: string) {
+	return value.match(interfaceLinkStatePattern)?.[0]?.toLowerCase() ?? null
+}
+
 export function parseIslandRouterVersion(
 	stdout: string,
 	commandLines: Array<string>,
@@ -214,7 +219,7 @@ export function parseIslandRouterInterfaceSummaries(
 		const tokens = normalized.split(' ')
 		return {
 			name: extractInterfaceName(line) ?? tokens[0] ?? null,
-			linkState: extractNeighborState(line) ?? null,
+			linkState: extractInterfaceLinkState(line) ?? null,
 			speed:
 				tokens.find((token) => /\b\d+(?:g|m|mbps|gbps)\b/i.test(token)) ?? null,
 			duplex:

--- a/packages/home-connector/src/adapters/island-router/ssh-client.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/ssh-client.node.test.ts
@@ -1,0 +1,62 @@
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+import { loadHomeConnectorConfig } from '../../config.ts'
+import { createIslandRouterSshCommandRunner } from './ssh-client.ts'
+
+function createConfig() {
+	process.env.MOCKS = 'false'
+	process.env.HOME_CONNECTOR_ID = 'default'
+	process.env.HOME_CONNECTOR_SHARED_SECRET =
+		'home-connector-secret-home-connector-secret'
+	process.env.WORKER_BASE_URL = 'http://localhost:3742'
+	process.env.HOME_CONNECTOR_DB_PATH = ':memory:'
+	process.env.ISLAND_ROUTER_HOST = 'router.local'
+	process.env.ISLAND_ROUTER_PORT = '22'
+	process.env.ISLAND_ROUTER_USERNAME = 'user'
+	process.env.ISLAND_ROUTER_PRIVATE_KEY_PATH = '/keys/id_ed25519'
+	process.env.ISLAND_ROUTER_KNOWN_HOSTS_PATH = ''
+	process.env.ISLAND_ROUTER_HOST_FINGERPRINT = ''
+	process.env.ISLAND_ROUTER_COMMAND_TIMEOUT_MS = '5000'
+	process.env.VENSTAR_SCAN_CIDRS = '192.168.10.40/32'
+	return loadHomeConnectorConfig()
+}
+
+test('ssh runner explicitly disables host verification when no known-host or fingerprint is configured', async () => {
+	const config = createConfig()
+	const tempDir = await mkdtemp(path.join(os.tmpdir(), 'kody-island-router-test-'))
+	const binDir = path.join(tempDir, 'bin')
+	const argsPath = path.join(tempDir, 'ssh-args.txt')
+	await mkdir(binDir, { recursive: true })
+	const fakeSshPath = path.join(binDir, 'ssh')
+	await writeFile(
+		fakeSshPath,
+		[
+			'#!/bin/sh',
+			`printf '%s\n' "$@" > "${argsPath}"`,
+			'while IFS= read -r _line; do :; done',
+			'exit 0',
+		].join('\n'),
+		'utf8',
+	)
+	await chmod(fakeSshPath, 0o755)
+
+	const originalPath = process.env.PATH
+	process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ''}`
+
+	try {
+		const runner = createIslandRouterSshCommandRunner(config)
+		await runner({
+			id: 'show-version',
+			timeoutMs: 1000,
+		})
+		const args = await readFile(argsPath, 'utf8')
+		expect(args).toContain('StrictHostKeyChecking=no')
+		expect(args).toContain('UserKnownHostsFile=/dev/null')
+		expect(args).toContain('GlobalKnownHostsFile=/dev/null')
+	} finally {
+		process.env.PATH = originalPath
+		await rm(tempDir, { recursive: true, force: true })
+	}
+})

--- a/packages/home-connector/src/adapters/island-router/ssh-client.ts
+++ b/packages/home-connector/src/adapters/island-router/ssh-client.ts
@@ -78,8 +78,12 @@ async function runLocalCommand(input: {
 		}, 1000).unref()
 	}, input.timeoutMs)
 
-	const result = await onceProcessExit(child)
-	clearTimeout(timeout)
+	let result: Awaited<ReturnType<typeof onceProcessExit>>
+	try {
+		result = await onceProcessExit(child)
+	} finally {
+		clearTimeout(timeout)
+	}
 
 	return {
 		stdout,
@@ -195,14 +199,7 @@ async function resolveHostVerification(
 	}
 
 	return {
-		args: [
-			'-o',
-			'StrictHostKeyChecking=no',
-			'-o',
-			'UserKnownHostsFile=/dev/null',
-			'-o',
-			'GlobalKnownHostsFile=/dev/null',
-		],
+		args: [],
 		cleanup: async () => {},
 	}
 }
@@ -239,7 +236,9 @@ function assertSingleCliLine(value: string, field: string) {
 }
 
 function escapeCliQuery(value: string) {
-	return assertSingleCliLine(value, 'query').replaceAll('"', '\\"')
+	return assertSingleCliLine(value, 'query')
+		.replaceAll('\\', '\\\\')
+		.replaceAll('"', '\\"')
 }
 
 function getCommandLines(request: IslandRouterCommandRequest): Array<string> {
@@ -283,6 +282,31 @@ function writeCommandLines(child: ChildProcess, commandLines: Array<string>) {
 
 export function createIslandRouterSshCommandRunner(config: HomeConnectorConfig) {
 	assertIslandRouterConfigured(config)
+	let verificationPromise: Promise<HostVerification> | null = null
+	let cleanupRegistered = false
+
+	async function getVerification() {
+		if (!verificationPromise) {
+			verificationPromise = resolveHostVerification(
+				config,
+				config.islandRouterCommandTimeoutMs,
+			)
+				.then((verification) => {
+					if (!cleanupRegistered) {
+						cleanupRegistered = true
+						process.once('exit', () => {
+							void verification.cleanup().catch(() => {})
+						})
+					}
+					return verification
+				})
+				.catch((error) => {
+					verificationPromise = null
+					throw error
+				})
+		}
+		return await verificationPromise
+	}
 
 	return async (
 		request: IslandRouterCommandRequest,
@@ -291,79 +315,79 @@ export function createIslandRouterSshCommandRunner(config: HomeConnectorConfig) 
 			request.timeoutMs == null
 				? config.islandRouterCommandTimeoutMs
 				: request.timeoutMs
-		const verification = await resolveHostVerification(config, timeoutMs)
+		const verification = await getVerification()
 		const commandLines = ['terminal length 0', ...getCommandLines(request)]
 		const start = Date.now()
 
-		try {
-			const child = spawn('ssh', createSshArgs(config, verification.args), {
-				stdio: 'pipe',
-			})
+		const child = spawn('ssh', createSshArgs(config, verification.args), {
+			stdio: 'pipe',
+		})
 
-			let stdout = ''
-			let stderr = ''
-			child.stdout?.setEncoding('utf8')
-			child.stdout?.on('data', (chunk: string | Buffer) => {
-				stdout += String(chunk)
-			})
-			child.stderr?.setEncoding('utf8')
-			child.stderr?.on('data', (chunk: string | Buffer) => {
-				stderr += String(chunk)
-			})
+		let stdout = ''
+		let stderr = ''
+		child.stdout?.setEncoding('utf8')
+		child.stdout?.on('data', (chunk: string | Buffer) => {
+			stdout += String(chunk)
+		})
+		child.stderr?.setEncoding('utf8')
+		child.stderr?.on('data', (chunk: string | Buffer) => {
+			stderr += String(chunk)
+		})
 
-			writeCommandLines(child, commandLines)
+		writeCommandLines(child, commandLines)
 
-			let timedOut = false
-			let closed = false
-			child.once('close', () => {
-				closed = true
-			})
-			let timeout: NodeJS.Timeout | null = null
-			if (request.id === 'ping' && request.allowTimeout) {
-				timeout = setTimeout(() => {
-					timedOut = true
-					child.stdin?.write('\u0003')
-					child.stdin?.write('\nexit\n')
-					child.stdin?.end()
-					setTimeout(() => {
-						if (closed) return
-						child.kill('SIGTERM')
-						setTimeout(() => {
-							if (!closed) {
-								child.kill('SIGKILL')
-							}
-						}, 1000).unref()
-					}, 1000).unref()
-				}, timeoutMs)
-			} else {
-				child.stdin?.write('exit\n')
+		let timedOut = false
+		let closed = false
+		child.once('close', () => {
+			closed = true
+		})
+		let timeout: NodeJS.Timeout | null = null
+		if (request.id === 'ping' && request.allowTimeout) {
+			timeout = setTimeout(() => {
+				timedOut = true
+				child.stdin?.write('\u0003')
+				child.stdin?.write('\nexit\n')
 				child.stdin?.end()
-				timeout = setTimeout(() => {
-					timedOut = true
+				setTimeout(() => {
+					if (closed) return
 					child.kill('SIGTERM')
 					setTimeout(() => {
 						if (!closed) {
 							child.kill('SIGKILL')
 						}
 					}, 1000).unref()
-				}, timeoutMs)
-			}
+				}, 1000).unref()
+			}, timeoutMs)
+		} else {
+			child.stdin?.write('exit\n')
+			child.stdin?.end()
+			timeout = setTimeout(() => {
+				timedOut = true
+				child.kill('SIGTERM')
+				setTimeout(() => {
+					if (!closed) {
+						child.kill('SIGKILL')
+					}
+				}, 1000).unref()
+			}, timeoutMs)
+		}
 
-			const result = await onceProcessExit(child)
-			if (timeout) clearTimeout(timeout)
-
-			return {
-				id: request.id,
-				commandLines,
-				stdout,
-				stderr,
-				exitCode: result.exitCode,
-				signal: result.signal,
-				timedOut,
-				durationMs: Date.now() - start,
-			}
+		let result: Awaited<ReturnType<typeof onceProcessExit>>
+		try {
+			result = await onceProcessExit(child)
 		} finally {
-			await verification.cleanup()
+			if (timeout) clearTimeout(timeout)
+		}
+
+		return {
+			id: request.id,
+			commandLines,
+			stdout,
+			stderr,
+			exitCode: result.exitCode,
+			signal: result.signal,
+			timedOut,
+			durationMs: Date.now() - start,
 		}
 	}
 }

--- a/packages/home-connector/src/adapters/island-router/ssh-client.ts
+++ b/packages/home-connector/src/adapters/island-router/ssh-client.ts
@@ -199,7 +199,14 @@ async function resolveHostVerification(
 	}
 
 	return {
-		args: [],
+		args: [
+			'-o',
+			'StrictHostKeyChecking=no',
+			'-o',
+			'UserKnownHostsFile=/dev/null',
+			'-o',
+			'GlobalKnownHostsFile=/dev/null',
+		],
 		cleanup: async () => {},
 	}
 }

--- a/packages/home-connector/src/adapters/island-router/ssh-client.ts
+++ b/packages/home-connector/src/adapters/island-router/ssh-client.ts
@@ -1,0 +1,337 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { type HomeConnectorConfig } from '../../config.ts'
+import {
+	assertIslandRouterConfigured,
+	validateIslandRouterFingerprint,
+} from './validation.ts'
+import {
+	type IslandRouterCommandId,
+	type IslandRouterCommandRequest,
+	type IslandRouterCommandResult,
+} from './types.ts'
+
+type LocalCommandResult = {
+	stdout: string
+	stderr: string
+	exitCode: number | null
+	signal: NodeJS.Signals | null
+	timedOut: boolean
+}
+
+type HostVerification = {
+	args: Array<string>
+	cleanup: () => Promise<void>
+}
+
+function onceProcessExit(child: ChildProcess) {
+	return new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>(
+		(resolve) => {
+			child.once('exit', (exitCode, signal) => {
+				resolve({
+					exitCode,
+					signal,
+				})
+			})
+		},
+	)
+}
+
+async function runLocalCommand(input: {
+	command: string
+	args: Array<string>
+	stdin?: string
+	timeoutMs: number
+}) {
+	const child = spawn(input.command, input.args, {
+		stdio: 'pipe',
+	})
+	let stdout = ''
+	let stderr = ''
+	child.stdout?.setEncoding('utf8')
+	child.stdout?.on('data', (chunk: string | Buffer) => {
+		stdout += String(chunk)
+	})
+	child.stderr?.setEncoding('utf8')
+	child.stderr?.on('data', (chunk: string | Buffer) => {
+		stderr += String(chunk)
+	})
+	if (input.stdin) {
+		child.stdin?.write(input.stdin)
+	}
+	child.stdin?.end()
+
+	let timedOut = false
+	const timeout = setTimeout(() => {
+		timedOut = true
+		child.kill('SIGTERM')
+		setTimeout(() => {
+			if (!child.killed) {
+				child.kill('SIGKILL')
+			}
+		}, 1000).unref()
+	}, input.timeoutMs)
+
+	const result = await onceProcessExit(child)
+	clearTimeout(timeout)
+
+	return {
+		stdout,
+		stderr,
+		exitCode: result.exitCode,
+		signal: result.signal,
+		timedOut,
+	} satisfies LocalCommandResult
+}
+
+function parseFingerprints(output: string) {
+	return output
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.map((line) => {
+			const parts = line.split(/\s+/)
+			return parts[1] ?? null
+		})
+		.filter((value): value is string => Boolean(value))
+}
+
+async function createFingerprintVerifiedKnownHosts(input: {
+	host: string
+	port: number
+	expectedFingerprint: string
+	timeoutMs: number
+}): Promise<HostVerification> {
+	const expectedFingerprint = validateIslandRouterFingerprint(
+		input.expectedFingerprint,
+	)
+	const tempDir = await mkdtemp(path.join(os.tmpdir(), 'kody-island-router-'))
+	const knownHostsPath = path.join(tempDir, 'known_hosts')
+
+	try {
+		const keyscan = await runLocalCommand({
+			command: 'ssh-keyscan',
+			args: ['-p', String(input.port), input.host],
+			timeoutMs: input.timeoutMs,
+		})
+		if (keyscan.timedOut || keyscan.exitCode !== 0 || !keyscan.stdout.trim()) {
+			throw new Error(
+				`ssh-keyscan failed for ${input.host}:${input.port}. ${keyscan.stderr.trim()}`.trim(),
+			)
+		}
+
+		await writeFile(knownHostsPath, keyscan.stdout, 'utf8')
+
+		const hashMode = expectedFingerprint.startsWith('MD5:') ? 'md5' : 'sha256'
+		const keygen = await runLocalCommand({
+			command: 'ssh-keygen',
+			args: ['-lf', knownHostsPath, '-E', hashMode],
+			timeoutMs: input.timeoutMs,
+		})
+		if (keygen.timedOut || keygen.exitCode !== 0 || !keygen.stdout.trim()) {
+			throw new Error(
+				`ssh-keygen failed while validating ${input.host}:${input.port}. ${keygen.stderr.trim()}`.trim(),
+			)
+		}
+
+		const fingerprints = parseFingerprints(keygen.stdout)
+		if (!fingerprints.includes(expectedFingerprint)) {
+			throw new Error(
+				`Island router host fingerprint mismatch. Expected ${expectedFingerprint}, received ${fingerprints.join(', ') || 'none'}.`,
+			)
+		}
+
+		return {
+			args: [
+				'-o',
+				'StrictHostKeyChecking=yes',
+				'-o',
+				`UserKnownHostsFile=${knownHostsPath}`,
+				'-o',
+				'GlobalKnownHostsFile=/dev/null',
+			],
+			cleanup: async () => {
+				await rm(tempDir, { recursive: true, force: true })
+			},
+		}
+	} catch (error) {
+		await rm(tempDir, { recursive: true, force: true }).catch(() => {})
+		throw error
+	}
+}
+
+async function resolveHostVerification(
+	config: HomeConnectorConfig,
+	timeoutMs: number,
+): Promise<HostVerification> {
+	if (config.islandRouterKnownHostsPath) {
+		await stat(config.islandRouterKnownHostsPath)
+		return {
+			args: [
+				'-o',
+				'StrictHostKeyChecking=yes',
+				'-o',
+				`UserKnownHostsFile=${config.islandRouterKnownHostsPath}`,
+				'-o',
+				'GlobalKnownHostsFile=/dev/null',
+			],
+			cleanup: async () => {},
+		}
+	}
+
+	if (config.islandRouterHostFingerprint && config.islandRouterHost) {
+		return await createFingerprintVerifiedKnownHosts({
+			host: config.islandRouterHost,
+			port: config.islandRouterPort,
+			expectedFingerprint: config.islandRouterHostFingerprint,
+			timeoutMs,
+		})
+	}
+
+	return {
+		args: [
+			'-o',
+			'StrictHostKeyChecking=no',
+			'-o',
+			'UserKnownHostsFile=/dev/null',
+			'-o',
+			'GlobalKnownHostsFile=/dev/null',
+		],
+		cleanup: async () => {},
+	}
+}
+
+function createSshArgs(config: HomeConnectorConfig, verificationArgs: Array<string>) {
+	return [
+		'-T',
+		'-p',
+		String(config.islandRouterPort),
+		'-i',
+		config.islandRouterPrivateKeyPath ?? '',
+		'-o',
+		'BatchMode=yes',
+		'-o',
+		'IdentitiesOnly=yes',
+		'-o',
+		'PreferredAuthentications=publickey',
+		'-o',
+		'LogLevel=ERROR',
+		...verificationArgs,
+		`${config.islandRouterUsername}@${config.islandRouterHost}`,
+	]
+}
+
+function escapeCliQuery(value: string) {
+	return value.replaceAll('"', '\\"')
+}
+
+function getCommandLines(request: IslandRouterCommandRequest): Array<string> {
+	switch (request.id) {
+		case 'show-version':
+			return ['show version']
+		case 'show-clock':
+			return ['show clock']
+		case 'show-interface-summary':
+			return ['show interface summary']
+		case 'show-interface':
+			return [`show interface ${request.interfaceName}`]
+		case 'show-ip-interface':
+			return [`show ip interface ${request.interfaceName}`]
+		case 'show-ip-neighbors':
+			return ['show ip neighbors']
+		case 'show-ip-dhcp-reservations':
+			return ['show ip dhcp-reservations']
+		case 'show-log':
+			return request.query
+				? [`show log last where "${escapeCliQuery(request.query)}"`]
+				: ['show log last']
+		case 'ping':
+			return [`ping ${request.host}`]
+		default: {
+			const _exhaustive: never = request
+			throw new Error(`Unhandled Island router command request: ${String(_exhaustive)}`)
+		}
+	}
+}
+
+function writeCommandLines(child: ChildProcess, commandLines: Array<string>) {
+	for (const line of commandLines) {
+		child.stdin?.write(`${line}\n`)
+	}
+}
+
+export function createIslandRouterSshCommandRunner(config: HomeConnectorConfig) {
+	assertIslandRouterConfigured(config)
+
+	return async (
+		request: IslandRouterCommandRequest,
+	): Promise<IslandRouterCommandResult> => {
+		const timeoutMs =
+			request.timeoutMs == null
+				? config.islandRouterCommandTimeoutMs
+				: request.timeoutMs
+		const verification = await resolveHostVerification(config, timeoutMs)
+		const commandLines = ['terminal length 0', ...getCommandLines(request)]
+		const start = Date.now()
+
+		try {
+			const child = spawn('ssh', createSshArgs(config, verification.args), {
+				stdio: 'pipe',
+			})
+
+			let stdout = ''
+			let stderr = ''
+			child.stdout?.setEncoding('utf8')
+			child.stdout?.on('data', (chunk: string | Buffer) => {
+				stdout += String(chunk)
+			})
+			child.stderr?.setEncoding('utf8')
+			child.stderr?.on('data', (chunk: string | Buffer) => {
+				stderr += String(chunk)
+			})
+
+			writeCommandLines(child, commandLines)
+
+			let timedOut = false
+			let timeout: NodeJS.Timeout | null = null
+			if (request.id === 'ping' && request.allowTimeout) {
+				timeout = setTimeout(() => {
+					timedOut = true
+					child.stdin?.write('\u0003')
+					child.stdin?.write('\nexit\n')
+					child.stdin?.end()
+				}, timeoutMs)
+			} else {
+				child.stdin?.write('exit\n')
+				child.stdin?.end()
+				timeout = setTimeout(() => {
+					timedOut = true
+					child.kill('SIGTERM')
+					setTimeout(() => {
+						if (!child.killed) {
+							child.kill('SIGKILL')
+						}
+					}, 1000).unref()
+				}, timeoutMs)
+			}
+
+			const result = await onceProcessExit(child)
+			if (timeout) clearTimeout(timeout)
+
+			return {
+				id: request.id,
+				commandLines,
+				stdout,
+				stderr,
+				exitCode: result.exitCode,
+				signal: result.signal,
+				timedOut,
+				durationMs: Date.now() - start,
+			}
+		} finally {
+			await verification.cleanup()
+		}
+	}
+}

--- a/packages/home-connector/src/adapters/island-router/ssh-client.ts
+++ b/packages/home-connector/src/adapters/island-router/ssh-client.ts
@@ -8,7 +8,6 @@ import {
 	validateIslandRouterFingerprint,
 } from './validation.ts'
 import {
-	type IslandRouterCommandId,
 	type IslandRouterCommandRequest,
 	type IslandRouterCommandResult,
 } from './types.ts'
@@ -28,8 +27,9 @@ type HostVerification = {
 
 function onceProcessExit(child: ChildProcess) {
 	return new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>(
-		(resolve) => {
-			child.once('exit', (exitCode, signal) => {
+		(resolve, reject) => {
+			child.once('error', reject)
+			child.once('close', (exitCode, signal) => {
 				resolve({
 					exitCode,
 					signal,
@@ -64,11 +64,15 @@ async function runLocalCommand(input: {
 	child.stdin?.end()
 
 	let timedOut = false
+	let closed = false
+	child.once('close', () => {
+		closed = true
+	})
 	const timeout = setTimeout(() => {
 		timedOut = true
 		child.kill('SIGTERM')
 		setTimeout(() => {
-			if (!child.killed) {
+			if (!closed) {
 				child.kill('SIGKILL')
 			}
 		}, 1000).unref()
@@ -223,8 +227,19 @@ function createSshArgs(config: HomeConnectorConfig, verificationArgs: Array<stri
 	]
 }
 
+function assertSingleCliLine(value: string, field: string) {
+	const trimmed = value.trim()
+	if (trimmed.length === 0) {
+		throw new Error(`${field} must not be empty.`)
+	}
+	if (/[\u0000-\u001f\u007f]/u.test(trimmed)) {
+		throw new Error(`${field} must not contain control characters.`)
+	}
+	return trimmed
+}
+
 function escapeCliQuery(value: string) {
-	return value.replaceAll('"', '\\"')
+	return assertSingleCliLine(value, 'query').replaceAll('"', '\\"')
 }
 
 function getCommandLines(request: IslandRouterCommandRequest): Array<string> {
@@ -236,9 +251,13 @@ function getCommandLines(request: IslandRouterCommandRequest): Array<string> {
 		case 'show-interface-summary':
 			return ['show interface summary']
 		case 'show-interface':
-			return [`show interface ${request.interfaceName}`]
+			return [
+				`show interface ${assertSingleCliLine(request.interfaceName, 'interfaceName')}`,
+			]
 		case 'show-ip-interface':
-			return [`show ip interface ${request.interfaceName}`]
+			return [
+				`show ip interface ${assertSingleCliLine(request.interfaceName, 'interfaceName')}`,
+			]
 		case 'show-ip-neighbors':
 			return ['show ip neighbors']
 		case 'show-ip-dhcp-reservations':
@@ -248,7 +267,7 @@ function getCommandLines(request: IslandRouterCommandRequest): Array<string> {
 				? [`show log last where "${escapeCliQuery(request.query)}"`]
 				: ['show log last']
 		case 'ping':
-			return [`ping ${request.host}`]
+			return [`ping ${assertSingleCliLine(request.host, 'host')}`]
 		default: {
 			const _exhaustive: never = request
 			throw new Error(`Unhandled Island router command request: ${String(_exhaustive)}`)
@@ -295,6 +314,10 @@ export function createIslandRouterSshCommandRunner(config: HomeConnectorConfig) 
 			writeCommandLines(child, commandLines)
 
 			let timedOut = false
+			let closed = false
+			child.once('close', () => {
+				closed = true
+			})
 			let timeout: NodeJS.Timeout | null = null
 			if (request.id === 'ping' && request.allowTimeout) {
 				timeout = setTimeout(() => {
@@ -302,6 +325,15 @@ export function createIslandRouterSshCommandRunner(config: HomeConnectorConfig) 
 					child.stdin?.write('\u0003')
 					child.stdin?.write('\nexit\n')
 					child.stdin?.end()
+					setTimeout(() => {
+						if (closed) return
+						child.kill('SIGTERM')
+						setTimeout(() => {
+							if (!closed) {
+								child.kill('SIGKILL')
+							}
+						}, 1000).unref()
+					}, 1000).unref()
 				}, timeoutMs)
 			} else {
 				child.stdin?.write('exit\n')
@@ -310,7 +342,7 @@ export function createIslandRouterSshCommandRunner(config: HomeConnectorConfig) 
 					timedOut = true
 					child.kill('SIGTERM')
 					setTimeout(() => {
-						if (!child.killed) {
+						if (!closed) {
 							child.kill('SIGKILL')
 						}
 					}, 1000).unref()

--- a/packages/home-connector/src/adapters/island-router/types.ts
+++ b/packages/home-connector/src/adapters/island-router/types.ts
@@ -1,0 +1,188 @@
+export type IslandRouterHostKind = 'ipv4' | 'ipv6' | 'mac' | 'hostname'
+
+export type IslandRouterHostIdentity = {
+	kind: IslandRouterHostKind
+	value: string
+	normalizedValue: string
+}
+
+export type IslandRouterVerificationMode =
+	| 'known-hosts'
+	| 'fingerprint'
+	| 'none'
+
+export type IslandRouterConfigStatus = {
+	configured: boolean
+	missingFields: Array<string>
+	verificationMode: IslandRouterVerificationMode
+	warnings: Array<string>
+}
+
+export type IslandRouterCommandId =
+	| 'show-version'
+	| 'show-clock'
+	| 'show-interface-summary'
+	| 'show-interface'
+	| 'show-ip-interface'
+	| 'show-ip-neighbors'
+	| 'show-ip-dhcp-reservations'
+	| 'show-log'
+	| 'ping'
+
+export type IslandRouterCommandRequest =
+	| {
+			id: 'show-version'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-clock'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-interface-summary'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-interface'
+			interfaceName: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-interface'
+			interfaceName: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-neighbors'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-dhcp-reservations'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-log'
+			query?: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'ping'
+			host: string
+			timeoutMs?: number
+			allowTimeout?: boolean
+	  }
+
+export type IslandRouterCommandResult = {
+	id: IslandRouterCommandId
+	commandLines: Array<string>
+	stdout: string
+	stderr: string
+	exitCode: number | null
+	signal: NodeJS.Signals | null
+	timedOut: boolean
+	durationMs: number
+}
+
+export type IslandRouterCommandRunner = (
+	request: IslandRouterCommandRequest,
+) => Promise<IslandRouterCommandResult>
+
+export type IslandRouterKeyValue = {
+	key: string
+	value: string
+}
+
+export type IslandRouterInterfaceSummary = {
+	name: string | null
+	linkState: string | null
+	speed: string | null
+	duplex: string | null
+	description: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterInterfaceDetails = {
+	interfaceName: string | null
+	attributes: Array<IslandRouterKeyValue>
+	rawOutput: string
+}
+
+export type IslandRouterNeighborEntry = {
+	ipAddress: string | null
+	macAddress: string | null
+	interfaceName: string | null
+	state: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterDhcpLease = {
+	ipAddress: string | null
+	macAddress: string | null
+	hostName: string | null
+	interfaceName: string | null
+	leaseType: 'reservation' | 'lease' | 'unknown'
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterRecentEvent = {
+	timestamp: string | null
+	level: string | null
+	module: string | null
+	message: string
+	rawLine: string
+}
+
+export type IslandRouterPingReply = {
+	sequence: number | null
+	timeMs: number | null
+	rawLine: string
+}
+
+export type IslandRouterPingResult = {
+	host: string
+	addressFamily: 'auto' | 'ip' | 'ipv6'
+	reachable: boolean | null
+	timedOut: boolean
+	completed: boolean
+	transmitted: number | null
+	received: number | null
+	packetLossPercent: number | null
+	replies: Array<IslandRouterPingReply>
+	rawOutput: string
+	stderr: string
+}
+
+export type IslandRouterVersionInfo = {
+	model: string | null
+	serialNumber: string | null
+	firmwareVersion: string | null
+	attributes: Array<IslandRouterKeyValue>
+	rawOutput: string
+}
+
+export type IslandRouterStatus = {
+	config: IslandRouterConfigStatus
+	connected: boolean
+	router: {
+		version: IslandRouterVersionInfo | null
+		clock: string | null
+	}
+	interfaces: Array<IslandRouterInterfaceSummary>
+	neighbors: Array<IslandRouterNeighborEntry>
+	errors: Array<string>
+}
+
+export type IslandRouterHostDiagnosis = {
+	host: IslandRouterHostIdentity
+	ping: IslandRouterPingResult | null
+	arpEntry: IslandRouterNeighborEntry | null
+	dhcpLease: IslandRouterDhcpLease | null
+	interfaceSummary: IslandRouterInterfaceSummary | null
+	interfaceDetails: IslandRouterInterfaceDetails | null
+	ipInterfaceDetails: IslandRouterInterfaceDetails | null
+	recentEvents: Array<IslandRouterRecentEvent>
+	errors: Array<string>
+}

--- a/packages/home-connector/src/adapters/island-router/validation.ts
+++ b/packages/home-connector/src/adapters/island-router/validation.ts
@@ -95,6 +95,7 @@ export function getIslandRouterConfigStatus(
 	}
 
 	const warnings: Array<string> = []
+	let verificationConfigValid = true
 	let verificationMode: IslandRouterConfigStatus['verificationMode'] = 'none'
 
 	if (config.islandRouterKnownHostsPath) {
@@ -109,6 +110,7 @@ export function getIslandRouterConfigStatus(
 		try {
 			validateIslandRouterFingerprint(config.islandRouterHostFingerprint)
 		} catch (error) {
+			verificationConfigValid = false
 			warnings.push(
 				error instanceof Error ? error.message : String(error),
 			)
@@ -120,7 +122,7 @@ export function getIslandRouterConfigStatus(
 	}
 
 	return {
-		configured: missingFields.length === 0,
+		configured: missingFields.length === 0 && verificationConfigValid,
 		missingFields,
 		verificationMode,
 		warnings,
@@ -129,9 +131,15 @@ export function getIslandRouterConfigStatus(
 
 export function assertIslandRouterConfigured(config: HomeConnectorConfig) {
 	const status = getIslandRouterConfigStatus(config)
-	if (status.missingFields.length > 0) {
+	if (!status.configured) {
+		const details = [
+			...(status.missingFields.length > 0
+				? [`Missing: ${status.missingFields.join(', ')}`]
+				: []),
+			...(status.warnings.length > 0 ? status.warnings : []),
+		].join(' ')
 		throw new Error(
-			`Island router SSH diagnostics are not configured. Missing: ${status.missingFields.join(', ')}.`,
+			`Island router SSH diagnostics are not configured. ${details}`.trim(),
 		)
 	}
 	if (

--- a/packages/home-connector/src/adapters/island-router/validation.ts
+++ b/packages/home-connector/src/adapters/island-router/validation.ts
@@ -1,0 +1,144 @@
+import { isIP } from 'node:net'
+import { type HomeConnectorConfig } from '../../config.ts'
+import {
+	type IslandRouterConfigStatus,
+	type IslandRouterHostIdentity,
+} from './types.ts'
+
+const macAddressPattern =
+	/^(?<octets>[0-9a-fA-F]{2}([:-][0-9a-fA-F]{2}){5})$/
+const hostnamePattern =
+	/^(?=.{1,253}$)(?!-)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.(?!-)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+const sha256FingerprintPattern = /^SHA256:[A-Za-z0-9+/]+={0,2}$/
+const md5FingerprintPattern = /^MD5:(?:[0-9a-fA-F]{2}:){15}[0-9a-fA-F]{2}$/
+
+function normalizeMacAddress(value: string) {
+	const octets = value
+		.trim()
+		.toLowerCase()
+		.replaceAll('-', ':')
+		.split(':')
+	return octets.map((octet) => octet.padStart(2, '0')).join(':')
+}
+
+function normalizeIpv6(value: string) {
+	return value.trim().toLowerCase()
+}
+
+export function validateIslandRouterHost(value: string): IslandRouterHostIdentity {
+	const trimmed = value.trim()
+	if (trimmed.length === 0) {
+		throw new Error('Host must not be empty.')
+	}
+
+	if (isIP(trimmed) === 4) {
+		return {
+			kind: 'ipv4',
+			value: trimmed,
+			normalizedValue: trimmed,
+		}
+	}
+
+	if (isIP(trimmed) === 6) {
+		return {
+			kind: 'ipv6',
+			value: trimmed,
+			normalizedValue: normalizeIpv6(trimmed),
+		}
+	}
+
+	if (macAddressPattern.test(trimmed)) {
+		return {
+			kind: 'mac',
+			value: trimmed,
+			normalizedValue: normalizeMacAddress(trimmed),
+		}
+	}
+
+	if (hostnamePattern.test(trimmed)) {
+		return {
+			kind: 'hostname',
+			value: trimmed,
+			normalizedValue: trimmed.toLowerCase(),
+		}
+	}
+
+	throw new Error(
+		'Host must be a valid IPv4 address, IPv6 address, MAC address, or hostname.',
+	)
+}
+
+export function validateIslandRouterFingerprint(value: string) {
+	const trimmed = value.trim()
+	if (
+		!sha256FingerprintPattern.test(trimmed) &&
+		!md5FingerprintPattern.test(trimmed)
+	) {
+		throw new Error(
+			'ISLAND_ROUTER_HOST_FINGERPRINT must be an SSH SHA256:... or MD5:... fingerprint.',
+		)
+	}
+
+	return trimmed.startsWith('MD5:')
+		? `MD5:${trimmed.slice(4).toLowerCase()}`
+		: trimmed
+}
+
+export function getIslandRouterConfigStatus(
+	config: HomeConnectorConfig,
+): IslandRouterConfigStatus {
+	const missingFields: Array<string> = []
+	if (!config.islandRouterHost) missingFields.push('ISLAND_ROUTER_HOST')
+	if (!config.islandRouterUsername) missingFields.push('ISLAND_ROUTER_USERNAME')
+	if (!config.islandRouterPrivateKeyPath) {
+		missingFields.push('ISLAND_ROUTER_PRIVATE_KEY_PATH')
+	}
+
+	const warnings: Array<string> = []
+	let verificationMode: IslandRouterConfigStatus['verificationMode'] = 'none'
+
+	if (config.islandRouterKnownHostsPath) {
+		verificationMode = 'known-hosts'
+		if (config.islandRouterHostFingerprint) {
+			warnings.push(
+				'ISLAND_ROUTER_KNOWN_HOSTS_PATH is set, so it will be used instead of ISLAND_ROUTER_HOST_FINGERPRINT.',
+			)
+		}
+	} else if (config.islandRouterHostFingerprint) {
+		verificationMode = 'fingerprint'
+		try {
+			validateIslandRouterFingerprint(config.islandRouterHostFingerprint)
+		} catch (error) {
+			warnings.push(
+				error instanceof Error ? error.message : String(error),
+			)
+		}
+	} else {
+		warnings.push(
+			'No Island router host verification was configured. Set ISLAND_ROUTER_KNOWN_HOSTS_PATH or ISLAND_ROUTER_HOST_FINGERPRINT for safer SSH verification.',
+		)
+	}
+
+	return {
+		configured: missingFields.length === 0,
+		missingFields,
+		verificationMode,
+		warnings,
+	}
+}
+
+export function assertIslandRouterConfigured(config: HomeConnectorConfig) {
+	const status = getIslandRouterConfigStatus(config)
+	if (status.missingFields.length > 0) {
+		throw new Error(
+			`Island router SSH diagnostics are not configured. Missing: ${status.missingFields.join(', ')}.`,
+		)
+	}
+	if (
+		config.islandRouterHostFingerprint &&
+		!config.islandRouterKnownHostsPath
+	) {
+		validateIslandRouterFingerprint(config.islandRouterHostFingerprint)
+	}
+	return status
+}

--- a/packages/home-connector/src/config.node.test.ts
+++ b/packages/home-connector/src/config.node.test.ts
@@ -151,3 +151,53 @@ test('HOME_CONNECTOR_DB_PATH overrides the default sqlite location', () => {
 	const config = loadHomeConnectorConfig()
 	expect(config.dbPath).toBe('/tmp/custom-home-connector.sqlite')
 })
+
+test('island router SSH env vars are loaded with defaults', () => {
+	using _env = createTemporaryEnv({
+		...requiredConfigEnv,
+		ISLAND_ROUTER_HOST: 'router.local',
+		ISLAND_ROUTER_USERNAME: 'user',
+		ISLAND_ROUTER_PRIVATE_KEY_PATH: '/keys/id_ed25519',
+		ISLAND_ROUTER_PORT: undefined,
+		ISLAND_ROUTER_KNOWN_HOSTS_PATH: '/keys/known_hosts',
+		ISLAND_ROUTER_HOST_FINGERPRINT: undefined,
+		ISLAND_ROUTER_COMMAND_TIMEOUT_MS: undefined,
+	})
+
+	const config = loadHomeConnectorConfig()
+	expect(config).toMatchObject({
+		islandRouterHost: 'router.local',
+		islandRouterPort: 22,
+		islandRouterUsername: 'user',
+		islandRouterPrivateKeyPath: '/keys/id_ed25519',
+		islandRouterKnownHostsPath: '/keys/known_hosts',
+		islandRouterHostFingerprint: null,
+		islandRouterCommandTimeoutMs: 8000,
+	})
+})
+
+test('island router SSH env vars honor explicit port, fingerprint, and timeout', () => {
+	using _env = createTemporaryEnv({
+		...requiredConfigEnv,
+		ISLAND_ROUTER_HOST: '192.168.0.1',
+		ISLAND_ROUTER_USERNAME: 'readonly',
+		ISLAND_ROUTER_PRIVATE_KEY_PATH: '/keys/id_ed25519',
+		ISLAND_ROUTER_PORT: '2222',
+		ISLAND_ROUTER_KNOWN_HOSTS_PATH: undefined,
+		ISLAND_ROUTER_HOST_FINGERPRINT:
+			'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12',
+		ISLAND_ROUTER_COMMAND_TIMEOUT_MS: '12000',
+	})
+
+	const config = loadHomeConnectorConfig()
+	expect(config).toMatchObject({
+		islandRouterHost: '192.168.0.1',
+		islandRouterPort: 2222,
+		islandRouterUsername: 'readonly',
+		islandRouterPrivateKeyPath: '/keys/id_ed25519',
+		islandRouterKnownHostsPath: null,
+		islandRouterHostFingerprint:
+			'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12',
+		islandRouterCommandTimeoutMs: 12000,
+	})
+})

--- a/packages/home-connector/src/config.node.test.ts
+++ b/packages/home-connector/src/config.node.test.ts
@@ -201,3 +201,16 @@ test('island router SSH env vars honor explicit port, fingerprint, and timeout',
 		islandRouterCommandTimeoutMs: 12000,
 	})
 })
+
+test('invalid island router port falls back to default 22', () => {
+	using _env = createTemporaryEnv({
+		...requiredConfigEnv,
+		ISLAND_ROUTER_HOST: '192.168.0.1',
+		ISLAND_ROUTER_USERNAME: 'readonly',
+		ISLAND_ROUTER_PRIVATE_KEY_PATH: '/keys/id_ed25519',
+		ISLAND_ROUTER_PORT: '22junk',
+	})
+
+	const config = loadHomeConnectorConfig()
+	expect(config.islandRouterPort).toBe(22)
+})

--- a/packages/home-connector/src/config.ts
+++ b/packages/home-connector/src/config.ts
@@ -7,6 +7,13 @@ export type HomeConnectorConfig = {
 	workerSessionUrl: string
 	workerWebSocketUrl: string
 	sharedSecret: string | null
+	islandRouterHost: string | null
+	islandRouterPort: number
+	islandRouterUsername: string | null
+	islandRouterPrivateKeyPath: string | null
+	islandRouterKnownHostsPath: string | null
+	islandRouterHostFingerprint: string | null
+	islandRouterCommandTimeoutMs: number
 	rokuDiscoveryUrl: string
 	samsungTvDiscoveryUrl: string
 	lutronDiscoveryUrl: string
@@ -183,6 +190,14 @@ function deriveJellyfishAutoscanCidrs() {
 
 export function loadHomeConnectorConfig(): HomeConnectorConfig {
 	const port = Number.parseInt(process.env.PORT ?? '4040', 10)
+	const islandRouterPort = Number.parseInt(
+		process.env.ISLAND_ROUTER_PORT ?? '22',
+		10,
+	)
+	const islandRouterCommandTimeoutMs = Number.parseInt(
+		process.env.ISLAND_ROUTER_COMMAND_TIMEOUT_MS ?? '8000',
+		10,
+	)
 	const homeConnectorId = process.env.HOME_CONNECTOR_ID?.trim() || 'default'
 	const workerBaseUrl =
 		process.env.WORKER_BASE_URL?.trim() || 'http://localhost:3742'
@@ -208,6 +223,23 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 		workerSessionUrl,
 		workerWebSocketUrl: createWorkerWebSocketUrl(workerSessionUrl),
 		sharedSecret: process.env.HOME_CONNECTOR_SHARED_SECRET?.trim() || null,
+		islandRouterHost: process.env.ISLAND_ROUTER_HOST?.trim() || null,
+		islandRouterPort:
+			Number.isFinite(islandRouterPort) && islandRouterPort > 0
+				? islandRouterPort
+				: 22,
+		islandRouterUsername: process.env.ISLAND_ROUTER_USERNAME?.trim() || null,
+		islandRouterPrivateKeyPath:
+			process.env.ISLAND_ROUTER_PRIVATE_KEY_PATH?.trim() || null,
+		islandRouterKnownHostsPath:
+			process.env.ISLAND_ROUTER_KNOWN_HOSTS_PATH?.trim() || null,
+		islandRouterHostFingerprint:
+			process.env.ISLAND_ROUTER_HOST_FINGERPRINT?.trim() || null,
+		islandRouterCommandTimeoutMs:
+			Number.isFinite(islandRouterCommandTimeoutMs) &&
+			islandRouterCommandTimeoutMs >= 1000
+				? islandRouterCommandTimeoutMs
+				: 8000,
 		rokuDiscoveryUrl:
 			process.env.ROKU_DISCOVERY_URL?.trim() || 'ssdp://239.255.255.250:1900',
 		samsungTvDiscoveryUrl:

--- a/packages/home-connector/src/config.ts
+++ b/packages/home-connector/src/config.ts
@@ -91,6 +91,15 @@ function resolveNonNegativeIntegerFromEnv(envVar: string, fallback: number) {
 	return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
 }
 
+function parseStrictIntegerEnv(value: string | undefined) {
+	const trimmed = value?.trim()
+	if (!trimmed) return null
+	if (!/^\d+$/.test(trimmed)) return null
+	const parsed = Number(trimmed)
+	if (!Number.isInteger(parsed)) return null
+	return parsed
+}
+
 function isPrivateRfc1918Ipv4(parts: Array<number>) {
 	const [a, b] = parts
 	return (
@@ -190,10 +199,7 @@ function deriveJellyfishAutoscanCidrs() {
 
 export function loadHomeConnectorConfig(): HomeConnectorConfig {
 	const port = Number.parseInt(process.env.PORT ?? '4040', 10)
-	const islandRouterPort = Number.parseInt(
-		process.env.ISLAND_ROUTER_PORT ?? '22',
-		10,
-	)
+	const islandRouterPort = parseStrictIntegerEnv(process.env.ISLAND_ROUTER_PORT)
 	const islandRouterCommandTimeoutMs = Number.parseInt(
 		process.env.ISLAND_ROUTER_COMMAND_TIMEOUT_MS ?? '8000',
 		10,
@@ -225,7 +231,9 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 		sharedSecret: process.env.HOME_CONNECTOR_SHARED_SECRET?.trim() || null,
 		islandRouterHost: process.env.ISLAND_ROUTER_HOST?.trim() || null,
 		islandRouterPort:
-			Number.isFinite(islandRouterPort) && islandRouterPort > 0
+			islandRouterPort != null &&
+			islandRouterPort >= 1 &&
+			islandRouterPort <= 65535
 				? islandRouterPort
 				: 22,
 		islandRouterUsername: process.env.ISLAND_ROUTER_USERNAME?.trim() || null,

--- a/packages/home-connector/src/index.ts
+++ b/packages/home-connector/src/index.ts
@@ -1,4 +1,5 @@
 import { createBondAdapter } from './adapters/bond/index.ts'
+import { createIslandRouterAdapter } from './adapters/island-router/index.ts'
 import { createJellyfishAdapter } from './adapters/jellyfish/index.ts'
 import { createLutronAdapter } from './adapters/lutron/index.ts'
 import { createSonosAdapter } from './adapters/sonos/index.ts'
@@ -40,6 +41,9 @@ export function createHomeConnectorApp() {
 		state,
 		storage,
 	})
+	const islandRouter = createIslandRouterAdapter({
+		config,
+	})
 	const jellyfish = createJellyfishAdapter({
 		config,
 		state,
@@ -53,6 +57,7 @@ export function createHomeConnectorApp() {
 		lutron,
 		sonos,
 		bond,
+		islandRouter,
 		jellyfish,
 		venstar,
 	})
@@ -70,6 +75,7 @@ export function createHomeConnectorApp() {
 		lutron,
 		sonos,
 		bond,
+		islandRouter,
 		jellyfish,
 		venstar,
 		mcp,

--- a/packages/home-connector/src/mcp/register-island-router-tools.ts
+++ b/packages/home-connector/src/mcp/register-island-router-tools.ts
@@ -1,0 +1,272 @@
+import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+import { type createIslandRouterAdapter } from '../adapters/island-router/index.ts'
+import {
+	buildToolInputSchema,
+	type ToolInputSchema,
+} from './tool-input-schema.ts'
+
+type IslandRouterToolDescriptor = {
+	name: string
+	title: string
+	description: string
+	inputSchema: Record<string, unknown>
+	annotations?: Record<string, unknown>
+}
+
+type IslandRouterRegisteredToolDescriptor = IslandRouterToolDescriptor & {
+	sdkInputSchema?: ToolInputSchema
+}
+
+type IslandRouterToolHandler = (
+	args: Record<string, unknown>,
+) => Promise<CallToolResult>
+
+function structuredTextResult(text: string, structuredContent: unknown): CallToolResult {
+	return {
+		content: [
+			{
+				type: 'text',
+				text,
+			},
+		],
+		structuredContent,
+	}
+}
+
+export function registerIslandRouterHomeConnectorTools(input: {
+	registerTool: (
+		descriptor: IslandRouterRegisteredToolDescriptor,
+		handler: IslandRouterToolHandler,
+	) => void
+	islandRouter: ReturnType<typeof createIslandRouterAdapter>
+}) {
+	const { registerTool, islandRouter } = input
+
+	const hostSchema = buildToolInputSchema({
+		host: z
+			.string()
+			.min(1)
+			.describe('IPv4, IPv6, hostname, or MAC address to inspect.'),
+		timeoutMs: z
+			.number()
+			.int()
+			.min(1000)
+			.max(60_000)
+			.optional()
+			.describe('Optional command timeout in milliseconds.'),
+	})
+
+	registerTool(
+		{
+			name: 'router_get_status',
+			title: 'Get Island Router Status',
+			description:
+				'Read-only Island router status snapshot including configuration readiness, version, interface summaries, and the current IP neighbor cache.',
+			inputSchema: {},
+			annotations: {
+				readOnlyHint: true,
+				idempotentHint: true,
+			},
+		},
+		async () => {
+			const status = await islandRouter.getStatus()
+			const interfaceCount = status.interfaces.length
+			const neighborCount = status.neighbors.length
+			return structuredTextResult(
+				status.config.configured
+					? `Island router status loaded with ${interfaceCount} interface(s) and ${neighborCount} neighbor entry/entries.`
+					: `Island router diagnostics are not fully configured: ${status.config.missingFields.join(', ')}.`,
+				status,
+			)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'router_ping_host',
+			title: 'Ping Host From Island Router',
+			description:
+				'Run a read-only router-side ping toward a LAN or remote host and return parsed reachability details.',
+			inputSchema: hostSchema.inputSchema,
+			sdkInputSchema: hostSchema.sdkInputSchema,
+			annotations: {
+				readOnlyHint: true,
+			},
+		},
+		async (args) => {
+			const result = await islandRouter.pingHost({
+				host: String(args['host'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			const summary =
+				result.reachable === true
+					? `Island router ping reached ${result.host}.`
+					: result.reachable === false
+						? `Island router ping did not receive replies from ${result.host}.`
+						: `Island router ping for ${result.host} did not complete cleanly.`
+			return structuredTextResult(summary, result)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'router_get_arp_entry',
+			title: 'Get Island Router ARP Entry',
+			description:
+				'Look up a host in the Island router neighbor cache and return the matching ARP/IP-neighbor entry plus the full parsed cache.',
+			inputSchema: hostSchema.inputSchema,
+			sdkInputSchema: hostSchema.sdkInputSchema,
+			annotations: {
+				readOnlyHint: true,
+				idempotentHint: true,
+			},
+		},
+		async (args) => {
+			const result = await islandRouter.getArpEntry(String(args['host'] ?? ''))
+			return structuredTextResult(
+				result.entry
+					? `Found an Island router neighbor entry for ${result.host.value}.`
+					: `No Island router neighbor entry matched ${result.host.value}.`,
+				result,
+			)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'router_get_dhcp_lease',
+			title: 'Get Island Router DHCP Lease',
+			description:
+				'Look up a host in the Island router DHCP reservation/lease view and return the matching entry plus the full parsed list.',
+			inputSchema: hostSchema.inputSchema,
+			sdkInputSchema: hostSchema.sdkInputSchema,
+			annotations: {
+				readOnlyHint: true,
+				idempotentHint: true,
+			},
+		},
+		async (args) => {
+			const result = await islandRouter.getDhcpLease(String(args['host'] ?? ''))
+			return structuredTextResult(
+				result.lease
+					? `Found an Island router DHCP entry for ${result.host.value}.`
+					: `No Island router DHCP entry matched ${result.host.value}.`,
+				result,
+			)
+		},
+	)
+
+	const recentEventsSchema = buildToolInputSchema({
+		host: z
+			.string()
+			.min(1)
+			.optional()
+			.describe(
+				'Optional IPv4, IPv6, hostname, or MAC address to filter recent events.',
+			),
+		limit: z
+			.number()
+			.int()
+			.min(1)
+			.max(200)
+			.optional()
+			.describe('Maximum number of events to return.'),
+		timeoutMs: z
+			.number()
+			.int()
+			.min(1000)
+			.max(60_000)
+			.optional()
+			.describe('Optional command timeout in milliseconds.'),
+	})
+
+	registerTool(
+		{
+			name: 'router_get_recent_events',
+			title: 'Get Island Router Recent Events',
+			description:
+				'Read recent Island router log entries, optionally filtered by a host/IP/MAC query.',
+			inputSchema: recentEventsSchema.inputSchema,
+			sdkInputSchema: recentEventsSchema.sdkInputSchema,
+			annotations: {
+				readOnlyHint: true,
+				idempotentHint: true,
+			},
+		},
+		async (args) => {
+			const events = await islandRouter.getRecentEvents({
+				host: args['host'] == null ? undefined : String(args['host']),
+				limit: args['limit'] == null ? undefined : Number(args['limit']),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return structuredTextResult(
+				events.length === 0
+					? 'No matching recent Island router events were found.'
+					: `Loaded ${events.length} Island router event(s).`,
+				{ events },
+			)
+		},
+	)
+
+	const diagnoseHostSchema = buildToolInputSchema({
+		host: z
+			.string()
+			.min(1)
+			.describe('IPv4, IPv6, hostname, or MAC address to diagnose.'),
+		logLimit: z
+			.number()
+			.int()
+			.min(1)
+			.max(100)
+			.optional()
+			.describe('Maximum number of recent log entries to include.'),
+		timeoutMs: z
+			.number()
+			.int()
+			.min(1000)
+			.max(60_000)
+			.optional()
+			.describe('Optional command timeout in milliseconds.'),
+	})
+
+	registerTool(
+		{
+			name: 'router_diagnose_host',
+			title: 'Diagnose Host From Island Router',
+			description:
+				'Run a read-only router-side diagnosis for a host and return parsed ping, ARP/neighbor, DHCP, interface, and recent-event data.',
+			inputSchema: diagnoseHostSchema.inputSchema,
+			sdkInputSchema: diagnoseHostSchema.sdkInputSchema,
+			annotations: {
+				readOnlyHint: true,
+			},
+		},
+		async (args) => {
+			const diagnosis = await islandRouter.diagnoseHost({
+				host: String(args['host'] ?? ''),
+				logLimit:
+					args['logLimit'] == null ? undefined : Number(args['logLimit']),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			const summaryParts = [
+				`Diagnosis for ${diagnosis.host.value}.`,
+				diagnosis.ping?.reachable === true
+					? 'Router ping succeeded.'
+					: diagnosis.ping?.reachable === false
+						? 'Router ping did not receive replies.'
+						: 'Router ping was unavailable or inconclusive.',
+				diagnosis.arpEntry
+					? `Neighbor entry found on ${diagnosis.arpEntry.interfaceName ?? 'unknown interface'}.`
+					: 'No neighbor entry found.',
+				diagnosis.dhcpLease
+					? 'DHCP data was found.'
+					: 'No DHCP data was found.',
+			]
+			return structuredTextResult(summaryParts.join(' '), diagnosis)
+		},
+	)
+}

--- a/packages/home-connector/src/mcp/register-island-router-tools.ts
+++ b/packages/home-connector/src/mcp/register-island-router-tools.ts
@@ -124,7 +124,11 @@ export function registerIslandRouterHomeConnectorTools(input: {
 			},
 		},
 		async (args) => {
-			const result = await islandRouter.getArpEntry(String(args['host'] ?? ''))
+			const result = await islandRouter.getArpEntry({
+				host: String(args['host'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
 			return structuredTextResult(
 				result.entry
 					? `Found an Island router neighbor entry for ${result.host.value}.`
@@ -148,7 +152,11 @@ export function registerIslandRouterHomeConnectorTools(input: {
 			},
 		},
 		async (args) => {
-			const result = await islandRouter.getDhcpLease(String(args['host'] ?? ''))
+			const result = await islandRouter.getDhcpLease({
+				host: String(args['host'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
 			return structuredTextResult(
 				result.lease
 					? `Found an Island router DHCP entry for ${result.host.value}.`

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import { installHomeConnectorMockServer } from '../../mocks/test-server.ts'
 import { createBondAdapter } from '../adapters/bond/index.ts'
+import { createIslandRouterAdapter } from '../adapters/island-router/index.ts'
 import { createJellyfishAdapter } from '../adapters/jellyfish/index.ts'
 import { createLutronAdapter } from '../adapters/lutron/index.ts'
 import { createSonosAdapter } from '../adapters/sonos/index.ts'
@@ -26,7 +27,154 @@ function createConfig() {
 	process.env.JELLYFISH_DISCOVERY_URL = 'http://jellyfish.mock.local/discovery'
 	process.env.VENSTAR_SCAN_CIDRS = '192.168.10.40/32,192.168.10.41/32'
 	process.env.HOME_CONNECTOR_DB_PATH = ':memory:'
+	process.env.ISLAND_ROUTER_HOST = 'router.local'
+	process.env.ISLAND_ROUTER_PORT = '22'
+	process.env.ISLAND_ROUTER_USERNAME = 'user'
+	process.env.ISLAND_ROUTER_PRIVATE_KEY_PATH = '/keys/id_ed25519'
+	process.env.ISLAND_ROUTER_HOST_FINGERPRINT =
+		'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12'
+	process.env.ISLAND_ROUTER_COMMAND_TIMEOUT_MS = '5000'
 	return loadHomeConnectorConfig()
+}
+
+function createIslandRouterRunner() {
+	return async (
+		request: import('../adapters/island-router/types.ts').IslandRouterCommandRequest,
+	) => {
+		switch (request.id) {
+			case 'show-version':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show version'],
+					stdout: [
+						'Model: Island Pro',
+						'Serial Number: IR-12345',
+						'Firmware Version: 2.3.2',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-clock':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show clock'],
+					stdout: '2026-05-02 15:55:00 PDT',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-interface-summary':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show interface summary'],
+					stdout: [
+						'Interface  Link   Speed  Duplex  Description',
+						'---------  -----  -----  ------  -----------',
+						'en0        up     1G     full    LAN uplink',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-neighbors':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ip neighbors'],
+					stdout: [
+						'IP Address    MAC Address        Interface  State',
+						'------------  -----------------  ---------  ---------',
+						'192.168.0.52  00:11:22:33:44:55  en0        reachable',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-dhcp-reservations':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ip dhcp-reservations'],
+					stdout: [
+						'IP Address    MAC Address        Host Name  Interface',
+						'------------  -----------------  ---------  ---------',
+						'192.168.0.52  00:11:22:33:44:55  nas-box    en0',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-log':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.query
+							? `show log last where "${request.query.replaceAll('"', '\\"')}"`
+							: 'show log last',
+					],
+					stdout:
+						'2026-05-02 15:50:00 info net: 192.168.0.52 link flap detected on en0',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-interface':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', `show interface ${request.interfaceName}`],
+					stdout: `Interface: ${request.interfaceName}\nLink State: up`,
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-interface':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						`show ip interface ${request.interfaceName}`,
+					],
+					stdout: `Interface: ${request.interfaceName}\nAddress: 192.168.0.1/24`,
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'ping':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', `ping ${request.host}`],
+					stdout:
+						'64 bytes from 192.168.0.52: icmp_seq=1 ttl=64 time=1.23 ms\n1 packets transmitted, 1 packets received, 0% packet loss',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 200,
+				}
+			default: {
+				const _exhaustive: never = request
+				throw new Error(
+					`Unhandled fake Island router MCP request: ${String(_exhaustive)}`,
+				)
+			}
+		}
+	}
 }
 
 installHomeConnectorMockServer()
@@ -61,6 +209,10 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		state,
 		storage,
 	})
+	const islandRouter = createIslandRouterAdapter({
+		config,
+		commandRunner: createIslandRouterRunner(),
+	})
 	const jellyfish = createJellyfishAdapter({
 		config,
 		state,
@@ -78,6 +230,7 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		lutron,
 		sonos,
 		bond,
+		islandRouter,
 		jellyfish,
 		venstar,
 	})
@@ -114,6 +267,18 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		expect(
 			tools.some((tool) => tool.name === 'bond_invoke_device_action'),
 		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_status')).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_ping_host')).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_arp_entry')).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_dhcp_lease')).toBe(
+			true,
+		)
+		expect(
+			tools.some((tool) => tool.name === 'router_get_recent_events'),
+		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_diagnose_host')).toBe(
+			true,
+		)
 		expect(
 			tools.some((tool) => tool.name === 'jellyfish_scan_controllers'),
 		).toBe(true)
@@ -286,6 +451,35 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		})
 		expect(shadeMove.structuredContent).toMatchObject({
 			argument: 50,
+		})
+
+		const routerStatus = await mcp.callTool('router_get_status')
+		expect(routerStatus.structuredContent).toMatchObject({
+			config: {
+				configured: true,
+			},
+			router: {
+				version: {
+					model: 'Island Pro',
+				},
+			},
+		})
+		const routerDiagnosis = await mcp.callTool('router_diagnose_host', {
+			host: '192.168.0.52',
+		})
+		expect(routerDiagnosis.structuredContent).toMatchObject({
+			host: {
+				value: '192.168.0.52',
+			},
+			ping: {
+				reachable: true,
+			},
+			arpEntry: {
+				interfaceName: 'en0',
+			},
+			dhcpLease: {
+				hostName: 'nas-box',
+			},
 		})
 
 		await expect(

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import { installHomeConnectorMockServer } from '../../mocks/test-server.ts'
 import { createBondAdapter } from '../adapters/bond/index.ts'
+import { type IslandRouterCommandRequest } from '../adapters/island-router/types.ts'
 import { createIslandRouterAdapter } from '../adapters/island-router/index.ts'
 import { createJellyfishAdapter } from '../adapters/jellyfish/index.ts'
 import { createLutronAdapter } from '../adapters/lutron/index.ts'
@@ -39,7 +40,7 @@ function createConfig() {
 
 function createIslandRouterRunner() {
 	return async (
-		request: import('../adapters/island-router/types.ts').IslandRouterCommandRequest,
+		request: IslandRouterCommandRequest,
 	) => {
 		switch (request.id) {
 			case 'show-version':

--- a/packages/home-connector/src/mcp/server.ts
+++ b/packages/home-connector/src/mcp/server.ts
@@ -4,6 +4,7 @@ import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { markSecretInputFields } from '@kody-internal/shared/secret-input-schema.ts'
 import { z } from 'zod'
 import { type createBondAdapter } from '../adapters/bond/index.ts'
+import { type createIslandRouterAdapter } from '../adapters/island-router/index.ts'
 import { type createJellyfishAdapter } from '../adapters/jellyfish/index.ts'
 import { createRokuAdapter } from '../adapters/roku/index.ts'
 import { isLutronProcessorNotFoundError } from '../adapters/lutron/errors.ts'
@@ -13,6 +14,7 @@ import { type createSamsungTvAdapter } from '../adapters/samsung-tv/index.ts'
 import { type createVenstarAdapter } from '../adapters/venstar/index.ts'
 import { type HomeConnectorConfig } from '../config.ts'
 import { registerBondHomeConnectorTools } from './register-bond-tools.ts'
+import { registerIslandRouterHomeConnectorTools } from './register-island-router-tools.ts'
 import { type HomeConnectorState } from '../state.ts'
 import {
 	buildToolInputSchema,
@@ -73,6 +75,7 @@ export function createHomeConnectorMcpServer(input: {
 	bond: ReturnType<typeof createBondAdapter>
 	jellyfish: ReturnType<typeof createJellyfishAdapter>
 	venstar: ReturnType<typeof createVenstarAdapter>
+	islandRouter: ReturnType<typeof createIslandRouterAdapter>
 }): HomeConnectorMcpServer {
 	const roku = createRokuAdapter({
 		config: input.config,
@@ -84,6 +87,7 @@ export function createHomeConnectorMcpServer(input: {
 	const bond = input.bond
 	const jellyfish = input.jellyfish
 	const venstar = input.venstar
+	const islandRouter = input.islandRouter
 
 	const server = new McpServer(
 		{
@@ -92,7 +96,7 @@ export function createHomeConnectorMcpServer(input: {
 		},
 		{
 			instructions:
-				'Home connector MCP server. Tools support Roku, Samsung TV, Lutron, Sonos, Bond (Olibra Bond Bridge / shades, groups, and RF devices), JellyFish Lighting, and Venstar WiFi thermostat control and diagnostics. Bond local API tokens are configured only in the admin UI (/bond/setup); use bond_authentication_guide when you need a reminder.',
+				'Home connector MCP server. Tools support Roku, Samsung TV, Lutron, Sonos, Bond (Olibra Bond Bridge / shades, groups, and RF devices), JellyFish Lighting, Venstar WiFi thermostat control, and read-only Island router SSH diagnostics. Bond local API tokens are configured only in the admin UI (/bond/setup); use bond_authentication_guide when you need a reminder.',
 		},
 	)
 
@@ -2790,6 +2794,11 @@ export function createHomeConnectorMcpServer(input: {
 		registerTool,
 		bond,
 		config: input.config,
+	})
+
+	registerIslandRouterHomeConnectorTools({
+		registerTool,
+		islandRouter,
 	})
 
 	return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new read-only `island-router` home-connector adapter that runs a typed allowlist of Island CLI diagnostics over SSH using key auth
- expose `router_get_status`, `router_ping_host`, `router_get_arp_entry`, `router_get_dhcp_lease`, `router_get_recent_events`, and `router_diagnose_host` MCP tools
- document the new runtime env vars, Docker SSH requirements, and read-only key-mount setup for home-connector deployments

## Testing
- `npm --prefix packages/home-connector run test -- packages/home-connector/src/config.node.test.ts packages/home-connector/src/adapters/island-router/index.node.test.ts packages/home-connector/src/mcp/server.node.test.ts`
- `npm run typecheck`

## Verification artifact
- <a href="/opt/cursor/artifacts/island_router_verification.txt">Island router verification transcript</a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff1d0715-72bc-4bfa-af55-7ee38d68a26b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff1d0715-72bc-4bfa-af55-7ee38d68a26b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Island Router SSH diagnostics: read-only allowlisted commands to fetch router status, run host diagnostics, ping, view ARP entries, DHCP leases, interfaces, and recent logs.

* **Documentation**
  * Added setup, environment variable, manifest, and troubleshooting guides explaining configuration, key mounting, host verification options, and read-only scope.

* **Chores**
  * Production image updated to ensure SSH client availability for diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->