### PR TITLE
Add Kody job update and delete capabilities

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -71,6 +71,11 @@ module-oriented runtime model:
   **`codemode.job_schedule(...)`** without creating a saved package
 - **`codemode.job_schedule_once(...)`** remains available as a convenience alias
   for one-off schedules
+- **`codemode.job_update(...)`** updates an existing scheduled job by id for
+  safe mutable fields such as name, code, params, schedule, timezone,
+  enabled/disabled state, or kill switch state
+- **`codemode.job_delete(...)`** removes an existing scheduled job by id for the
+  signed-in user
 - **`codemode.job_run_now(...)`** runs an existing scheduled job immediately and
   returns both the updated job state and the execution result for debugging
 

--- a/docs/use/first-steps.md
+++ b/docs/use/first-steps.md
@@ -20,8 +20,8 @@ connector, value, or secret reference, then run work through **execute**.
   scheduled work that should not become a saved package, use the built-in
   `job_schedule` capability. `job_schedule_once` remains available as a one-off
   convenience alias, `job_run_now` can trigger an existing job immediately for
-  debugging or catch-up runs, and `job_update` / `job_delete` let you correct
-  or remove an existing scheduled job by id.
+  debugging or catch-up runs, and `job_update` / `job_delete` let you correct or
+  remove an existing scheduled job by id.
 - **Ask for natural-language goals**, for example: “Search Kody for GitHub pull
   request automation” or “Find a saved package for Cloudflare DNS helpers.”
 - **Do not paste secrets in chat.** Use saved secrets, generated UI, or the

--- a/docs/use/first-steps.md
+++ b/docs/use/first-steps.md
@@ -19,8 +19,9 @@ connector, value, or secret reference, then run work through **execute**.
   declare package-owned jobs, and can optionally expose an app/UI surface. For
   scheduled work that should not become a saved package, use the built-in
   `job_schedule` capability. `job_schedule_once` remains available as a one-off
-  convenience alias, and `job_run_now` can trigger an existing job immediately
-  for debugging or catch-up runs.
+  convenience alias, `job_run_now` can trigger an existing job immediately for
+  debugging or catch-up runs, and `job_update` / `job_delete` let you correct
+  or remove an existing scheduled job by id.
 - **Ask for natural-language goals**, for example: “Search Kody for GitHub pull
   request automation” or “Find a saved package for Cloudflare DNS helpers.”
 - **Do not paste secrets in chat.** Use saved secrets, generated UI, or the

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -136,9 +136,11 @@ package.
 Jobs are part of the package definition.
 
 For repo-backed jobs that are not part of a saved package, use `job_schedule`
-instead. `job_schedule_once` remains available as the one-off shortcut, and
-`job_run_now` can trigger an existing scheduled job immediately for debugging or
-ad hoc runs.
+instead. `job_schedule_once` remains available as the one-off shortcut,
+`job_update` can adjust safe mutable fields such as schedule, timezone, enabled
+state, params, or code, `job_delete` removes an existing scheduled job by id,
+and `job_run_now` can trigger an existing scheduled job immediately for
+debugging or ad hoc runs.
 
 ## Save and edit packages
 

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -137,10 +137,10 @@ Jobs are part of the package definition.
 
 For repo-backed jobs that are not part of a saved package, use `job_schedule`
 instead. `job_schedule_once` remains available as the one-off shortcut,
-`job_update` can adjust safe mutable fields such as schedule, timezone, enabled
-state, params, or code, `job_delete` removes an existing scheduled job by id,
-and `job_run_now` can trigger an existing scheduled job immediately for
-debugging or ad hoc runs.
+`job_update` can rename a job and adjust safe mutable fields such as schedule,
+timezone, enabled state, kill-switch state, params, or code, `job_delete`
+removes an existing scheduled job by id, and `job_run_now` can trigger an
+existing scheduled job immediately for debugging or ad hoc runs.
 
 ## Save and edit packages
 

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -1151,6 +1151,162 @@ test('deleteJob syncs the job manager alarm after removing a job', async () => {
 	})
 })
 
+test('updateJob rejects another user trying to mutate a job by id', async () => {
+	const env = {
+		APP_DB: createDatabase(),
+	} as Env
+	mockRepoPersistence()
+	const ownerCallerContext = createBaseCallerContext()
+	const created = await createJob({
+		env,
+		callerContext: ownerCallerContext,
+		body: {
+			name: 'Owner job',
+			code: 'export default async () => ({ ok: true })',
+			schedule: {
+				type: 'interval',
+				every: '15m',
+			},
+		},
+	})
+	const otherCallerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-999',
+			email: 'other@example.com',
+			displayName: 'Other User',
+		},
+		storageContext: {
+			sessionId: null,
+			appId: 'app-999',
+		},
+	}) as PersistedJobCallerContext
+
+	await expect(
+		updateJob({
+			env,
+			callerContext: otherCallerContext,
+			body: {
+				id: created.id,
+				enabled: false,
+			},
+		}),
+	).rejects.toThrow(`Job "${created.id}" was not found.`)
+
+	const inspection = await getJobInspection({
+		env,
+		userId: ownerCallerContext.user.userId,
+		jobId: created.id,
+	})
+	expect(inspection.job.enabled).toBe(true)
+})
+
+test('deleteJob rejects another user trying to remove a job by id', async () => {
+	const env = {
+		APP_DB: createDatabase(),
+	} as Env
+	mockRepoPersistence()
+	const ownerCallerContext = createBaseCallerContext()
+	const created = await createJob({
+		env,
+		callerContext: ownerCallerContext,
+		body: {
+			name: 'Owner job',
+			code: 'export default async () => ({ ok: true })',
+			schedule: {
+				type: 'interval',
+				every: '15m',
+			},
+		},
+	})
+
+	await expect(
+		deleteJob({
+			env,
+			userId: 'user-999',
+			jobId: created.id,
+		}),
+	).rejects.toThrow(`Job "${created.id}" was not found.`)
+
+	const inspection = await getJobInspection({
+		env,
+		userId: ownerCallerContext.user.userId,
+		jobId: created.id,
+	})
+	expect(inspection.job.id).toBe(created.id)
+})
+
+test('updateJob clears params, updates timezone, and disables a job', async () => {
+	const env = {
+		APP_DB: createDatabase(),
+	} as Env
+	mockRepoPersistence()
+	const callerContext = createBaseCallerContext()
+	const created = await createJob({
+		env,
+		callerContext,
+		body: {
+			name: 'Mutable job',
+			code: 'export default async () => ({ ok: true })',
+			params: {
+				room: 'office',
+			},
+			schedule: {
+				type: 'cron',
+				expression: '0 9 * * 1',
+			},
+			timezone: 'UTC',
+		},
+	})
+
+	const updated = await updateJob({
+		env,
+		callerContext,
+		body: {
+			id: created.id,
+			params: null,
+			timezone: 'America/Denver',
+			enabled: false,
+		},
+	})
+
+	expect(updated.params).toBeUndefined()
+	expect(updated.timezone).toBe('America/Denver')
+	expect(updated.enabled).toBe(false)
+	expect(updated.scheduleSummary).toContain('America/Denver')
+})
+
+test('updateJob rejects empty replacement code', async () => {
+	const env = {
+		APP_DB: createDatabase(),
+	} as Env
+	mockRepoPersistence()
+	const callerContext = createBaseCallerContext()
+	const created = await createJob({
+		env,
+		callerContext,
+		body: {
+			name: 'Code validation job',
+			code: 'export default async () => ({ ok: true })',
+			schedule: {
+				type: 'interval',
+				every: '15m',
+			},
+		},
+	})
+
+	await expect(
+		updateJob({
+			env,
+			callerContext,
+			body: {
+				id: created.id,
+				code: '   ',
+			},
+		}),
+	).rejects.toThrow('Jobs require non-empty code.')
+})
+
 test('inspectJobsForUser returns persisted job fields with alarm debug state', async () => {
 	const env = {
 		APP_DB: createDatabase(),

--- a/packages/worker/src/mcp/capabilities/jobs/domain.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/domain.ts
@@ -1,10 +1,12 @@
 import { defineDomain } from '../define-domain.ts'
 import { capabilityDomainNames } from '../domain-metadata.ts'
+import { jobDeleteCapability } from './job-delete.ts'
 import { jobGetCapability } from './job-get.ts'
 import { jobListCapability } from './job-list.ts'
 import { jobRunNowCapability } from './job-run-now.ts'
 import { jobScheduleCapability } from './job-schedule.ts'
 import { jobScheduleOnceCapability } from './job-schedule-once.ts'
+import { jobUpdateCapability } from './job-update.ts'
 
 export const jobsDomain = defineDomain({
 	name: capabilityDomainNames.jobs,
@@ -16,6 +18,10 @@ export const jobsDomain = defineDomain({
 		'one-off',
 		'interval',
 		'cron',
+		'update',
+		'delete',
+		'disable',
+		'enable',
 		'background',
 		'debug',
 		'inspect',
@@ -27,6 +33,8 @@ export const jobsDomain = defineDomain({
 		jobGetCapability,
 		jobScheduleCapability,
 		jobScheduleOnceCapability,
+		jobUpdateCapability,
+		jobDeleteCapability,
 		jobRunNowCapability,
 	],
 })

--- a/packages/worker/src/mcp/capabilities/jobs/job-delete.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-delete.ts
@@ -13,14 +13,7 @@ export const jobDeleteCapability = defineDomainCapability(
 		name: 'job_delete',
 		description:
 			'Delete an existing scheduled job owned by the signed-in user by id. Use this to remove a mistaken or obsolete schedule entirely.',
-		keywords: [
-			'job',
-			'delete',
-			'remove',
-			'cancel',
-			'unschedule',
-			'cleanup',
-		],
+		keywords: ['job', 'delete', 'remove', 'cancel', 'unschedule', 'cleanup'],
 		readOnly: false,
 		idempotent: false,
 		destructive: true,

--- a/packages/worker/src/mcp/capabilities/jobs/job-delete.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-delete.ts
@@ -1,0 +1,37 @@
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	deleteJobFromArgs,
+	type JobDeleteCapabilityInput,
+	jobDeleteInputSchema,
+	jobDeleteOutputSchema,
+} from './shared.ts'
+
+export const jobDeleteCapability = defineDomainCapability(
+	capabilityDomainNames.jobs,
+	{
+		name: 'job_delete',
+		description:
+			'Delete an existing scheduled job owned by the signed-in user by id. Use this to remove a mistaken or obsolete schedule entirely.',
+		keywords: [
+			'job',
+			'delete',
+			'remove',
+			'cancel',
+			'unschedule',
+			'cleanup',
+		],
+		readOnly: false,
+		idempotent: false,
+		destructive: true,
+		inputSchema: jobDeleteInputSchema,
+		outputSchema: jobDeleteOutputSchema,
+		async handler(args: JobDeleteCapabilityInput, ctx) {
+			return deleteJobFromArgs({
+				env: ctx.env,
+				callerContext: ctx.callerContext,
+				args,
+			})
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts
@@ -753,6 +753,18 @@ test('job capabilities require an authenticated user for scheduling, mutation, a
 		),
 	).rejects.toThrow('Authenticated MCP user is required for this capability.')
 	await expect(
+		jobScheduleOnceCapability.handler(
+			{
+				code: 'export default async () => ({ ok: true })',
+				run_at: '2026-04-20T18:30:00Z',
+			},
+			{
+				env,
+				callerContext,
+			},
+		),
+	).rejects.toThrow('Authenticated MCP user is required for this capability.')
+	await expect(
 		jobDeleteCapability.handler(
 			{
 				id: 'job-123',

--- a/packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts
@@ -4,17 +4,21 @@ import { jobsDomain } from './domain.ts'
 
 const mockModule = vi.hoisted(() => ({
 	createJob: vi.fn(),
+	deleteJob: vi.fn(),
 	getJobInspection: vi.fn(),
 	inspectJobsForUser: vi.fn(),
 	runJobNowViaManager: vi.fn(),
+	updateJob: vi.fn(),
 }))
 
 vi.mock('#worker/jobs/service.ts', () => ({
 	createJob: (...args: Array<unknown>) => mockModule.createJob(...args),
+	deleteJob: (...args: Array<unknown>) => mockModule.deleteJob(...args),
 	getJobInspection: (...args: Array<unknown>) =>
 		mockModule.getJobInspection(...args),
 	inspectJobsForUser: (...args: Array<unknown>) =>
 		mockModule.inspectJobsForUser(...args),
+	updateJob: (...args: Array<unknown>) => mockModule.updateJob(...args),
 }))
 
 vi.mock('#worker/jobs/manager-client.ts', () => ({
@@ -24,15 +28,19 @@ vi.mock('#worker/jobs/manager-client.ts', () => ({
 
 const { jobScheduleCapability } = await import('./job-schedule.ts')
 const { jobScheduleOnceCapability } = await import('./job-schedule-once.ts')
+const { jobDeleteCapability } = await import('./job-delete.ts')
 const { jobGetCapability } = await import('./job-get.ts')
 const { jobListCapability } = await import('./job-list.ts')
 const { jobRunNowCapability } = await import('./job-run-now.ts')
+const { jobUpdateCapability } = await import('./job-update.ts')
 
 function resetMocks() {
 	mockModule.createJob.mockReset()
+	mockModule.deleteJob.mockReset()
 	mockModule.getJobInspection.mockReset()
 	mockModule.inspectJobsForUser.mockReset()
 	mockModule.runJobNowViaManager.mockReset()
+	mockModule.updateJob.mockReset()
 }
 
 test('job_schedule creates a one-off job', async () => {
@@ -114,16 +122,176 @@ test('job_schedule creates a one-off job', async () => {
 	})
 })
 
-test('jobs domain exposes scheduling, inspection, and run-now capabilities', () => {
+test('jobs domain exposes scheduling, inspection, mutation, and run-now capabilities', () => {
 	expect(jobsDomain.capabilities.map((capability) => capability.name)).toEqual(
 		expect.arrayContaining([
 			'job_list',
 			'job_get',
 			'job_schedule',
 			'job_schedule_once',
+			'job_update',
+			'job_delete',
 			'job_run_now',
 		]),
 	)
+})
+
+test('job_update updates safe mutable fields on an existing job', async () => {
+	resetMocks()
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-123',
+			email: 'user@example.com',
+			displayName: 'User Example',
+		},
+	})
+	mockModule.updateJob.mockResolvedValue({
+		id: 'job-123',
+		name: 'Nightly cleanup v2',
+		sourceId: 'source-123',
+		publishedCommit: 'commit-456',
+		storageId: 'job:job-123',
+		params: {
+			room: 'office',
+		},
+		schedule: {
+			type: 'cron',
+			expression: '0 3 * * *',
+		},
+		scheduleSummary: 'Runs on cron "0 3 * * *" in America/Denver',
+		timezone: 'America/Denver',
+		enabled: false,
+		killSwitchEnabled: true,
+		createdAt: '2026-04-20T10:00:00.000Z',
+		updatedAt: '2026-04-20T12:00:00.000Z',
+		nextRunAt: '2026-04-21T09:00:00.000Z',
+		runCount: 2,
+		successCount: 1,
+		errorCount: 1,
+		runHistory: [
+			{
+				startedAt: '2026-04-20T11:00:00.000Z',
+				finishedAt: '2026-04-20T11:01:00.000Z',
+				status: 'error',
+				durationMs: 60000,
+				error: 'Timed out',
+			},
+		],
+	})
+
+	const result = await jobUpdateCapability.handler(
+		{
+			id: 'job-123',
+			name: 'Nightly cleanup v2',
+			code: 'export default async () => ({ ok: true, updated: true })',
+			params: {
+				room: 'office',
+			},
+			schedule: {
+				type: 'cron',
+				expression: '0 3 * * *',
+			},
+			timezone: 'America/Denver',
+			enabled: false,
+			kill_switch_enabled: true,
+		},
+		{
+			env,
+			callerContext,
+		},
+	)
+
+	expect(mockModule.updateJob).toHaveBeenCalledWith({
+		env,
+		callerContext,
+		body: {
+			id: 'job-123',
+			name: 'Nightly cleanup v2',
+			code: 'export default async () => ({ ok: true, updated: true })',
+			params: {
+				room: 'office',
+			},
+			schedule: {
+				type: 'cron',
+				expression: '0 3 * * *',
+			},
+			timezone: 'America/Denver',
+			enabled: false,
+			killSwitchEnabled: true,
+		},
+	})
+	expect(result).toEqual({
+		job_id: 'job-123',
+		name: 'Nightly cleanup v2',
+		source_id: 'source-123',
+		published_commit: 'commit-456',
+		storage_id: 'job:job-123',
+		params: {
+			room: 'office',
+		},
+		schedule: {
+			type: 'cron',
+			expression: '0 3 * * *',
+		},
+		schedule_summary: 'Runs on cron "0 3 * * *" in America/Denver',
+		timezone: 'America/Denver',
+		enabled: false,
+		kill_switch_enabled: true,
+		created_at: '2026-04-20T10:00:00.000Z',
+		updated_at: '2026-04-20T12:00:00.000Z',
+		next_run_at: '2026-04-21T09:00:00.000Z',
+		run_count: 2,
+		success_count: 1,
+		error_count: 1,
+		run_history: [
+			{
+				started_at: '2026-04-20T11:00:00.000Z',
+				finished_at: '2026-04-20T11:01:00.000Z',
+				status: 'error',
+				duration_ms: 60000,
+				error: 'Timed out',
+			},
+		],
+	})
+})
+
+test('job_delete removes an existing job by id for the signed-in user', async () => {
+	resetMocks()
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-123',
+			email: 'user@example.com',
+			displayName: 'User Example',
+		},
+	})
+	mockModule.deleteJob.mockResolvedValue({
+		id: 'job-123',
+		deleted: true,
+	})
+
+	const result = await jobDeleteCapability.handler(
+		{
+			id: 'job-123',
+		},
+		{
+			env,
+			callerContext,
+		},
+	)
+
+	expect(mockModule.deleteJob).toHaveBeenCalledWith({
+		env,
+		userId: 'user-123',
+		jobId: 'job-123',
+	})
+	expect(result).toEqual({
+		job_id: 'job-123',
+		deleted: true,
+	})
 })
 
 test('job_run_now executes an existing job through the job manager', async () => {
@@ -481,7 +649,7 @@ test('job_schedule covers recurring schedules and the one-off helper flow', asyn
 	})
 })
 
-test('job capabilities require an authenticated user for scheduling and run-now flows', async () => {
+test('job capabilities require an authenticated user for scheduling, mutation, and run-now flows', async () => {
 	resetMocks()
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
@@ -504,6 +672,29 @@ test('job capabilities require an authenticated user for scheduling and run-now 
 		),
 	).rejects.toThrow('Authenticated MCP user is required for this capability.')
 	await expect(
+		jobUpdateCapability.handler(
+			{
+				id: 'job-123',
+				enabled: false,
+			},
+			{
+				env,
+				callerContext,
+			},
+		),
+	).rejects.toThrow('Authenticated MCP user is required for this capability.')
+	await expect(
+		jobDeleteCapability.handler(
+			{
+				id: 'job-123',
+			},
+			{
+				env,
+				callerContext,
+			},
+		),
+	).rejects.toThrow('Authenticated MCP user is required for this capability.')
+	await expect(
 		jobRunNowCapability.handler(
 			{
 				id: 'job-123',
@@ -515,7 +706,35 @@ test('job capabilities require an authenticated user for scheduling and run-now 
 		),
 	).rejects.toThrow('Authenticated MCP user is required for this capability.')
 	expect(mockModule.createJob).not.toHaveBeenCalled()
+	expect(mockModule.updateJob).not.toHaveBeenCalled()
+	expect(mockModule.deleteJob).not.toHaveBeenCalled()
 	expect(mockModule.runJobNowViaManager).not.toHaveBeenCalled()
+})
+
+test('job_update rejects requests without any mutable fields', async () => {
+	resetMocks()
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-123',
+			email: 'user@example.com',
+			displayName: 'User Example',
+		},
+	})
+
+	await expect(
+		jobUpdateCapability.handler(
+			{
+				id: 'job-123',
+			},
+			{
+				env,
+				callerContext,
+			},
+		),
+	).rejects.toThrow('Provide at least one mutable field to update.')
+	expect(mockModule.updateJob).not.toHaveBeenCalled()
 })
 
 test('job inspection capabilities expose due-now state, history, and alarm status', async () => {

--- a/packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts
@@ -257,6 +257,75 @@ test('job_update updates safe mutable fields on an existing job', async () => {
 	})
 })
 
+test('job_update maps one-off schedule run_at to runAt in the service payload', async () => {
+	resetMocks()
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-123',
+			email: 'user@example.com',
+			displayName: 'User Example',
+		},
+	})
+	mockModule.updateJob.mockResolvedValue({
+		id: 'job-once',
+		name: 'One-off cleanup',
+		sourceId: 'source-once',
+		publishedCommit: null,
+		storageId: 'job:job-once',
+		schedule: {
+			type: 'once',
+			runAt: '2026-04-22T18:30:00Z',
+		},
+		scheduleSummary: 'Runs once at 2026-04-22T18:30:00Z',
+		timezone: 'UTC',
+		enabled: true,
+		killSwitchEnabled: false,
+		createdAt: '2026-04-20T10:00:00.000Z',
+		updatedAt: '2026-04-20T12:00:00.000Z',
+		nextRunAt: '2026-04-22T18:30:00.000Z',
+		runCount: 0,
+		successCount: 0,
+		errorCount: 0,
+		runHistory: [],
+	})
+
+	await jobUpdateCapability.handler(
+		{
+			id: 'job-once',
+			schedule: {
+				type: 'once',
+				run_at: '2026-04-22T18:30:00Z',
+			},
+		},
+		{
+			env,
+			callerContext,
+		},
+	)
+
+	expect(mockModule.updateJob).toHaveBeenCalledWith({
+		env,
+		callerContext,
+		body: {
+			id: 'job-once',
+			name: undefined,
+			code: undefined,
+			params: undefined,
+			schedule: {
+				type: 'once',
+				runAt: '2026-04-22T18:30:00Z',
+			},
+			timezone: undefined,
+			enabled: undefined,
+			killSwitchEnabled: undefined,
+		},
+	})
+	const call = mockModule.updateJob.mock.calls.at(-1)?.[0]
+	expect(call?.body.schedule).not.toHaveProperty('run_at')
+})
+
 test('job_delete removes an existing job by id for the signed-in user', async () => {
 	resetMocks()
 	const env = {} as Env

--- a/packages/worker/src/mcp/capabilities/jobs/job-update.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-update.ts
@@ -1,0 +1,40 @@
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	type JobUpdateCapabilityInput,
+	jobUpdateInputSchema,
+	jobViewOutputSchema,
+	updateJobFromArgs,
+} from './shared.ts'
+
+export const jobUpdateCapability = defineDomainCapability(
+	capabilityDomainNames.jobs,
+	{
+		name: 'job_update',
+		description:
+			'Update a scheduled job owned by the signed-in user. Supports safe mutable fields such as name, code, params, schedule, timezone, enabled state, and kill-switch state.',
+		keywords: [
+			'job',
+			'update',
+			'edit',
+			'reschedule',
+			'rename',
+			'enable',
+			'disable',
+			'kill switch',
+			'timezone',
+		],
+		readOnly: false,
+		idempotent: false,
+		destructive: false,
+		inputSchema: jobUpdateInputSchema,
+		outputSchema: jobViewOutputSchema,
+		async handler(args: JobUpdateCapabilityInput, ctx) {
+			return updateJobFromArgs({
+				env: ctx.env,
+				callerContext: ctx.callerContext,
+				args,
+			})
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/jobs/shared.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/shared.ts
@@ -232,7 +232,9 @@ export const jobUpdateInputSchema = z
 		id: z
 			.string()
 			.min(1)
-			.describe('Existing job id from job_list output or a prior job response.'),
+			.describe(
+				'Existing job id from job_list output or a prior job response.',
+			),
 		name: z
 			.string()
 			.min(1)

--- a/packages/worker/src/mcp/capabilities/jobs/shared.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/shared.ts
@@ -7,6 +7,7 @@ import {
 	type JobCreateInput,
 	type JobExecutionResult,
 	type JobSchedule,
+	type JobUpdateInput,
 	type JobView,
 } from '#worker/jobs/types.ts'
 
@@ -219,6 +220,74 @@ export const jobRunNowInputSchema = z.object({
 	id: z.string().min(1).describe('Existing job id to execute immediately.'),
 })
 
+export const jobDeleteInputSchema = jobInspectionInputSchema
+
+export const jobDeleteOutputSchema = z.object({
+	job_id: z.string(),
+	deleted: z.literal(true),
+})
+
+export const jobUpdateInputSchema = z
+	.object({
+		id: z
+			.string()
+			.min(1)
+			.describe('Existing job id from job_list output or a prior job response.'),
+		name: z
+			.string()
+			.min(1)
+			.optional()
+			.describe('Optional new human-readable name for the job.'),
+		code: z
+			.string()
+			.min(1)
+			.optional()
+			.describe(
+				'Optional replacement ES module source. It must still default export the job entrypoint.',
+			),
+		params: z
+			.record(z.string(), z.unknown())
+			.nullable()
+			.optional()
+			.describe(
+				'Optional replacement params object. Pass null to clear existing params.',
+			),
+		schedule: scheduledJobScheduleSchema
+			.optional()
+			.describe('Optional replacement schedule for the job.'),
+		timezone: z
+			.string()
+			.min(1)
+			.nullable()
+			.optional()
+			.describe(
+				'Optional timezone label for cron display and schedule calculation. Pass null to reset to UTC.',
+			),
+		enabled: z
+			.boolean()
+			.optional()
+			.describe('Enable or disable the job without deleting it.'),
+		kill_switch_enabled: z
+			.boolean()
+			.optional()
+			.describe(
+				'Force the job off regardless of schedule. This remains visible in job_list and job_get for debugging.',
+			),
+	})
+	.refine(
+		(input) =>
+			input.name !== undefined ||
+			input.code !== undefined ||
+			input.params !== undefined ||
+			input.schedule !== undefined ||
+			input.timezone !== undefined ||
+			input.enabled !== undefined ||
+			input.kill_switch_enabled !== undefined,
+		{
+			message: 'Provide at least one mutable field to update.',
+		},
+	)
+
 export const jobRunNowOutputSchema = z.object({
 	job: jobViewOutputSchema,
 	execution: jobExecutionOutputSchema,
@@ -230,7 +299,9 @@ export const jobRunNowOutputSchema = z.object({
 })
 
 export type JobScheduleCapabilityInput = z.infer<typeof jobScheduleInputSchema>
+export type JobDeleteCapabilityInput = z.infer<typeof jobDeleteInputSchema>
 export type JobRunNowCapabilityInput = z.infer<typeof jobRunNowInputSchema>
+export type JobUpdateCapabilityInput = z.infer<typeof jobUpdateInputSchema>
 
 export function buildJobScheduleSummaryOutput(schedule: JobView['schedule']) {
 	switch (schedule.type) {
@@ -333,6 +404,13 @@ export function buildJobViewOutput(job: JobView) {
 	}
 }
 
+export function buildJobDeleteOutput(input: { id: string; deleted: true }) {
+	return {
+		job_id: input.id,
+		deleted: input.deleted,
+	}
+}
+
 export function buildJobInspectionOutput(
 	job: JobView,
 	input: { now?: Date } = {},
@@ -401,6 +479,22 @@ export function buildJobRunNowOutput(input: {
 	}
 }
 
+export function resolveJobUpdateBody(
+	input: JobUpdateCapabilityInput,
+): JobUpdateInput {
+	return {
+		id: input.id,
+		name: input.name,
+		code: input.code,
+		params: input.params,
+		schedule:
+			input.schedule === undefined ? undefined : toJobSchedule(input.schedule),
+		timezone: input.timezone,
+		enabled: input.enabled,
+		killSwitchEnabled: input.kill_switch_enabled,
+	}
+}
+
 export async function createScheduledJobFromArgs(input: {
 	env: Env
 	callerContext: CapabilityContext['callerContext']
@@ -440,4 +534,47 @@ export async function runJobNowFromArgs(input: {
 		callerContext: input.callerContext,
 	})
 	return buildJobRunNowOutput(result)
+}
+
+export async function updateJobFromArgs(input: {
+	env: Env
+	callerContext: CapabilityContext['callerContext']
+	args: JobUpdateCapabilityInput
+}) {
+	const user = requireMcpUser(input.callerContext)
+	const { updateJob } = await import('#worker/jobs/service.ts')
+	const updated = await updateJob({
+		env: input.env,
+		callerContext: input.callerContext,
+		body: resolveJobUpdateBody(input.args),
+	})
+	logJobSchedulerEvent({
+		event: 'job_updated',
+		userId: user.userId,
+		jobId: updated.id,
+		scheduleType: updated.schedule.type,
+		nextRunAt: updated.nextRunAt,
+	})
+	return buildJobViewOutput(updated)
+}
+
+export async function deleteJobFromArgs(input: {
+	env: Env
+	callerContext: CapabilityContext['callerContext']
+	args: JobDeleteCapabilityInput
+}) {
+	const user = requireMcpUser(input.callerContext)
+	const { deleteJob } = await import('#worker/jobs/service.ts')
+	const result = await deleteJob({
+		env: input.env,
+		userId: user.userId,
+		jobId: input.args.id,
+	})
+	logJobSchedulerEvent({
+		event: 'job_deleted',
+		userId: user.userId,
+		jobId: result.id,
+		reason: 'mcp_capability',
+	})
+	return buildJobDeleteOutput(result)
 }

--- a/packages/worker/src/mcp/jobs-embed.ts
+++ b/packages/worker/src/mcp/jobs-embed.ts
@@ -31,5 +31,5 @@ export function buildJobEmbedText(
 }
 
 export function buildJobUsage(job: Pick<JobView, 'id'>) {
-	return `Inspect with job_get: ${JSON.stringify({ id: job.id })}. List jobs with job_list: {}. Trigger immediately with job_run_now: ${JSON.stringify({ id: job.id })}.`
+	return `Inspect with job_get: ${JSON.stringify({ id: job.id })}. List jobs with job_list: {}. Update with job_update: ${JSON.stringify({ id: job.id, enabled: false })}. Delete with job_delete: ${JSON.stringify({ id: job.id })}. Trigger immediately with job_run_now: ${JSON.stringify({ id: job.id })}.`
 }

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -26,6 +26,8 @@ Conventions
 - \`job_list\` / \`job_get\`: inspect the signed-in user's scheduled jobs, recent run outcomes, and current per-user alarm state when debugging scheduling issues.
 - \`job_schedule\`: schedule a repo-backed job for the signed-in user without creating a saved package first. Supports one-off, interval, and cron schedules.
 - \`job_schedule_once\`: compatibility wrapper for one-off repo-backed jobs when you only need a single run time.
+- \`job_update\`: update an existing scheduled job by id. Supports safe mutable fields such as name, code, params, schedule, timezone, enabled, and kill-switch state.
+- \`job_delete\`: delete one of the signed-in user's scheduled jobs by id.
 - \`job_run_now\`: run an existing scheduled job immediately by id and return the updated job view plus execution result for debugging.
 - Package jobs are schedules owned by a package. For ad hoc work that is not tied to a package, use \`job_schedule\`. Package apps are optional UI surfaces declared by the package, and packages may also declare headless package services for long-lived background runtimes.
 - Package apps can also use Kody-managed realtime websocket sessions through \`session_list\`, \`session_emit\`, and \`session_broadcast\`, and package jobs can emit to those sessions when running under the same package caller context.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `job_update` and `job_delete` to the jobs capability domain and registry metadata
- reuse the existing jobs service mutations so user scoping, vector updates, and alarm sync stay consistent
- document and test the new job mutation flows for discovery and supported behavior

## Behavior
- `job_delete` hard-deletes a scheduled job by id for the signed-in user
- `job_update` supports safe mutable fields only: `name`, `code`, `params`, `schedule`, `timezone`, `enabled`, and `kill_switch_enabled`
- jobs remain user-scoped by id, so another user receives the same not-found behavior as `job_get` / `job_list`
- `job_list` and `job_get` already reflect disabled and kill-switched state, so no separate deletion tombstone was introduced

## Intentionally unsupported
- MCP `job_update` does not expose internal source reassignment or publish metadata fields such as `sourceId`, `publishedCommit`, or `repoCheckPolicy`
- mutation is by job id only; duplicate job names are not used as selectors

## Validation
- `npm run test -- packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts packages/worker/src/jobs/service.node.test.ts`
- `npm run test -- packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts`
- `npm run test -- packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm run format:check -- docs/use/execute.md docs/use/first-steps.md docs/use/packages.md packages/worker/src/mcp/capabilities/jobs/job-delete.ts packages/worker/src/mcp/capabilities/jobs/job-update.ts packages/worker/src/mcp/capabilities/jobs/shared.ts packages/worker/src/mcp/capabilities/jobs/domain.ts packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts packages/worker/src/jobs/service.node.test.ts packages/worker/src/mcp/jobs-embed.ts packages/worker/src/mcp/server-instructions.ts`

## Notes
- follow-up review fix: docs now explicitly mention renaming and kill-switch toggling in `job_update`
- follow-up review fix: capability tests now cover once-schedule input mapping from `run_at` to `runAt`
- follow-up review fix: auth-negative tests now cover `job_schedule_once` alongside `job_schedule`, `job_update`, `job_delete`, and `job_run_now`
- I did not act on the generic CodeRabbit docstring-coverage warning because it is repo-wide/non-specific and not a validated jobs-domain defect for this PR
- `npm run lint -- ...` exits successfully in this repo but still reports unrelated pre-existing warnings from untouched files, so I did not treat those as blockers for this jobs-scoped change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff931a00-e491-41ef-a8dc-fdeca4d82796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff931a00-e491-41ef-a8dc-fdeca4d82796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to update scheduled jobs (schedule, timezone, enabled state, params, or code) and to delete jobs by id.

* **Documentation**
  * Clarified guides and examples for scheduling, one-off runs, updating, deleting, and triggering jobs.

* **Tests**
  * Added tests covering update/delete flows, authorization, validation, and mapping of one-off schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->