### PR TITLE
feat: overhaul home connector admin dashboard

### DIFF
--- a/packages/home-connector/app/admin-ui.ts
+++ b/packages/home-connector/app/admin-ui.ts
@@ -1,0 +1,175 @@
+import { html } from 'remix/html-template'
+
+export type StatusTone = 'good' | 'warn' | 'bad' | 'neutral'
+
+export type ActionLink = {
+	href: string
+	label: string
+}
+
+type MetricCardInput = {
+	label: string
+	value: string | number | ReturnType<typeof html>
+	detail?: string | ReturnType<typeof html>
+	tone?: StatusTone
+}
+
+type SummaryMetric = {
+	label: string
+	value: string | number | ReturnType<typeof html>
+}
+
+type SummaryCardInput = {
+	title: string
+	description: string
+	status: string
+	tone: StatusTone
+	metrics: Array<SummaryMetric>
+	primaryLink?: ActionLink
+	secondaryLink?: ActionLink
+	note?: string | ReturnType<typeof html>
+}
+
+type ActionCardInput = {
+	href: string
+	title: string
+	description: string
+	badge?: {
+		label: string
+		tone: StatusTone
+	}
+}
+
+type PageIntroInput = {
+	eyebrow: string
+	title: string
+	description: string | ReturnType<typeof html>
+	actions?: Array<ActionLink>
+}
+
+function getStatusBadgeClassName(tone: StatusTone) {
+	switch (tone) {
+		case 'good':
+			return 'status-badge status-badge-good'
+		case 'warn':
+			return 'status-badge status-badge-warn'
+		case 'bad':
+			return 'status-badge status-badge-bad'
+		case 'neutral':
+			return 'status-badge status-badge-neutral'
+	}
+}
+
+export function renderStatusBadge(input: { label: string; tone: StatusTone }) {
+	return html`<span class="${getStatusBadgeClassName(input.tone)}">
+		${input.label}
+	</span>`
+}
+
+export function renderPageIntro(input: PageIntroInput) {
+	return html`<section class="page-intro">
+		<div class="page-eyebrow">${input.eyebrow}</div>
+		<div class="title-row">
+			<div class="page-header">
+				<h1>${input.title}</h1>
+				<p class="muted">${input.description}</p>
+			</div>
+			${input.actions && input.actions.length > 0
+				? renderInlineLinks(input.actions)
+				: ''}
+		</div>
+	</section>`
+}
+
+export function renderMetricCard(input: MetricCardInput) {
+	return html`<section
+		class="metric-card"
+		data-tone="${input.tone ?? 'neutral'}"
+	>
+		<div class="metric-label">${input.label}</div>
+		<div class="metric-value">${input.value}</div>
+		${input.detail
+			? html`<div class="metric-detail">${input.detail}</div>`
+			: ''}
+	</section>`
+}
+
+export function renderSummaryCard(input: SummaryCardInput) {
+	return html`<section class="summary-card" data-tone="${input.tone}">
+		<div class="summary-card-heading">
+			<div class="page-header">
+				<h2>${input.title}</h2>
+				<p class="summary-card-copy">${input.description}</p>
+			</div>
+			${renderStatusBadge({
+				label: input.status,
+				tone: input.tone,
+			})}
+		</div>
+		<div class="summary-card-metrics">
+			${input.metrics.map(
+				(metric) => html`<div class="summary-card-metric">
+					<div class="summary-metric-label">${metric.label}</div>
+					<div class="summary-metric-value">${metric.value}</div>
+				</div>`,
+			)}
+		</div>
+		${input.primaryLink || input.secondaryLink
+			? html`<div class="inline-links">
+					${input.primaryLink ? renderInlineLink(input.primaryLink) : ''}
+					${input.secondaryLink ? renderInlineLink(input.secondaryLink) : ''}
+				</div>`
+			: ''}
+		${input.note
+			? html`<div class="summary-card-note">${input.note}</div>`
+			: ''}
+	</section>`
+}
+
+export function renderActionCard(input: ActionCardInput) {
+	return html`<a class="action-card" href="${input.href}">
+		<div class="card-heading">
+			<h2>${input.title}</h2>
+			${input.badge ? renderStatusBadge(input.badge) : ''}
+		</div>
+		<p class="action-card-description">${input.description}</p>
+	</a>`
+}
+
+export function renderInlineLink(link: ActionLink) {
+	return html`<a class="inline-link" href="${link.href}">${link.label}</a>`
+}
+
+export function renderInlineLinks(links: Array<ActionLink>) {
+	return html`<div class="inline-links">
+		${links.map((link) => renderInlineLink(link))}
+	</div>`
+}
+
+export function renderEmptyState(message: string | ReturnType<typeof html>) {
+	return html`<div class="empty-state">${message}</div>`
+}
+
+export function renderDataTable(input: {
+	headers: Array<string>
+	rows: Array<Array<string | number | ReturnType<typeof html>>>
+}) {
+	if (input.rows.length === 0) {
+		return renderEmptyState('No rows to display.')
+	}
+
+	return html`<table class="data-table">
+		<thead>
+			<tr>
+				${input.headers.map((header) => html`<th scope="col">${header}</th>`)}
+			</tr>
+		</thead>
+		<tbody>
+			${input.rows.map(
+				(row) => html`<tr>
+					${row.map((value) => html`<td>${value}</td>`)}
+				</tr>`,
+			)}
+		</tbody>
+	</table>`
+}

--- a/packages/home-connector/app/dashboard-handlers.ts
+++ b/packages/home-connector/app/dashboard-handlers.ts
@@ -16,7 +16,10 @@ import { render } from './render.ts'
 import { RootLayout } from './root.ts'
 import { routes } from './routes.ts'
 import { type createBondAdapter } from '../src/adapters/bond/index.ts'
-import { type IslandRouterConfigStatus } from '../src/adapters/island-router/types.ts'
+import {
+	type IslandRouterConfigStatus,
+	type IslandRouterStatus,
+} from '../src/adapters/island-router/types.ts'
 import { type createIslandRouterAdapter } from '../src/adapters/island-router/index.ts'
 import { type createJellyfishAdapter } from '../src/adapters/jellyfish/index.ts'
 import { type createLutronAdapter } from '../src/adapters/lutron/index.ts'
@@ -106,6 +109,10 @@ type DashboardSnapshot = {
 	}
 }
 
+type LoadDashboardSnapshotInput = {
+	islandRouterStatus?: IslandRouterStatus
+}
+
 function getConnectionTone(state: HomeConnectorState): StatusTone {
 	if (!state.connection.connected) return 'bad'
 	if (!state.connection.sharedSecret) return 'warn'
@@ -175,6 +182,7 @@ function getIslandRouterStatusLabel(input: {
 
 async function loadDashboardSnapshot(
 	deps: DashboardDependencies,
+	input: LoadDashboardSnapshotInput = {},
 ): Promise<DashboardSnapshot> {
 	const rokuAdopted = getAdoptedRokuDevices(deps.state)
 	const rokuDiscovered = getDiscoveredRokuDevices(deps.state)
@@ -183,10 +191,14 @@ async function loadDashboardSnapshot(
 	const sonosStatus = deps.sonos.getStatus()
 	const bondStatus = deps.bond.getStatus()
 	const jellyfishStatus = deps.jellyfish.getStatus()
-	const [venstarStatus, islandRouterStatus] = await Promise.all([
+	const venstarDiscoveryStatus = deps.venstar.getStatus()
+	const [venstarStatus, loadedIslandRouterStatus] = await Promise.all([
 		deps.venstar.listThermostatsWithStatus(),
-		deps.islandRouter.getStatus(),
+		input.islandRouterStatus
+			? Promise.resolve(input.islandRouterStatus)
+			: deps.islandRouter.getStatus(),
 	])
+	const islandRouterStatus = loadedIslandRouterStatus
 	const onlineVenstarCount = venstarStatus.filter(
 		(thermostat) => thermostat.info != null,
 	).length
@@ -241,7 +253,7 @@ async function loadDashboardSnapshot(
 			configured: venstarStatus.length,
 			online: onlineVenstarCount,
 			offline: venstarStatus.length - onlineVenstarCount,
-			discovered: deps.venstar.getStatus().discovered.length,
+			discovered: venstarDiscoveryStatus.discovered.length,
 			diagnosticsCaptured: deps.state.venstarDiscoveryDiagnostics != null,
 		},
 		islandRouter: {
@@ -275,7 +287,7 @@ async function loadDashboardSnapshot(
 				samsungStatus.discovered.length +
 				bondStatus.discovered.length +
 				jellyfishStatus.discovered.length +
-				deps.venstar.getStatus().discovered.length,
+				venstarDiscoveryStatus.discovered.length,
 			diagnosticSources: countDiagnosticSources(deps.state),
 		},
 	}
@@ -1177,7 +1189,13 @@ export function createDiagnosticsHandler(deps: DashboardDependencies) {
 					status: snapshot.venstar.diagnosticsCaptured
 						? 'Captured'
 						: 'No captures',
-					tone: snapshot.venstar.offline > 0 ? 'warn' : 'good',
+					tone:
+						snapshot.venstar.offline > 0
+							? 'warn'
+							: snapshot.venstar.diagnosticsCaptured ||
+								  snapshot.venstar.configured > 0
+								? 'good'
+								: 'neutral',
 					details: deps.state.venstarDiscoveryDiagnostics
 						? `Last scan ${deps.state.venstarDiscoveryDiagnostics.scannedAt} with ${deps.state.venstarDiscoveryDiagnostics.infoLookups.length} info lookup(s).`
 						: 'No Venstar diagnostics captured yet.',
@@ -1343,10 +1361,10 @@ export function createIslandRouterStatusHandler(deps: DashboardDependencies) {
 		middleware: [],
 		async handler({ request }: { request: Request }) {
 			const requestedHost = getRequestedHost(request)
-			const [snapshot, routerStatus] = await Promise.all([
-				loadDashboardSnapshot(deps),
-				deps.islandRouter.getStatus(),
-			])
+			const routerStatus = await deps.islandRouter.getStatus()
+			const snapshot = await loadDashboardSnapshot(deps, {
+				islandRouterStatus: routerStatus,
+			})
 
 			let hostDiagnosis: Awaited<
 				ReturnType<ReturnType<typeof createIslandRouterAdapter>['diagnoseHost']>

--- a/packages/home-connector/app/dashboard-handlers.ts
+++ b/packages/home-connector/app/dashboard-handlers.ts
@@ -1,0 +1,1637 @@
+import { type BuildAction } from 'remix/fetch-router'
+import { html } from 'remix/html-template'
+import {
+	renderActionCard,
+	renderDataTable,
+	renderEmptyState,
+	renderInlineLinks,
+	renderMetricCard,
+	renderPageIntro,
+	renderStatusBadge,
+	renderSummaryCard,
+	type StatusTone,
+} from './admin-ui.ts'
+import { formatJson, renderCodeBlock, renderInfoRows } from './handler-utils.ts'
+import { render } from './render.ts'
+import { RootLayout } from './root.ts'
+import { routes } from './routes.ts'
+import { type createBondAdapter } from '../src/adapters/bond/index.ts'
+import { type IslandRouterConfigStatus } from '../src/adapters/island-router/types.ts'
+import { type createIslandRouterAdapter } from '../src/adapters/island-router/index.ts'
+import { type createJellyfishAdapter } from '../src/adapters/jellyfish/index.ts'
+import { type createLutronAdapter } from '../src/adapters/lutron/index.ts'
+import { type createSamsungTvAdapter } from '../src/adapters/samsung-tv/index.ts'
+import { type createSonosAdapter } from '../src/adapters/sonos/index.ts'
+import { type createVenstarAdapter } from '../src/adapters/venstar/index.ts'
+import { type HomeConnectorConfig } from '../src/config.ts'
+import {
+	getAdoptedRokuDevices,
+	getDiscoveredRokuDevices,
+	type HomeConnectorState,
+} from '../src/state.ts'
+
+type DashboardDependencies = {
+	state: HomeConnectorState
+	config: HomeConnectorConfig
+	lutron: ReturnType<typeof createLutronAdapter>
+	samsungTv: ReturnType<typeof createSamsungTvAdapter>
+	sonos: ReturnType<typeof createSonosAdapter>
+	bond: ReturnType<typeof createBondAdapter>
+	islandRouter: ReturnType<typeof createIslandRouterAdapter>
+	jellyfish: ReturnType<typeof createJellyfishAdapter>
+	venstar: ReturnType<typeof createVenstarAdapter>
+}
+
+type DashboardSnapshot = {
+	connectionTone: StatusTone
+	connectionLabel: string
+	connectionIssues: Array<string>
+	workerSnapshotUrl: string | null
+	roku: {
+		adopted: number
+		discovered: number
+		diagnosticsCaptured: boolean
+	}
+	lutron: {
+		processors: number
+		credentials: number
+		diagnosticsCaptured: boolean
+	}
+	sonos: {
+		adopted: number
+		discovered: number
+		audioInputSupported: number
+		diagnosticsCaptured: boolean
+	}
+	samsungTv: {
+		adopted: number
+		discovered: number
+		paired: number
+		diagnosticsCaptured: boolean
+	}
+	bond: {
+		adopted: number
+		discovered: number
+		withToken: number
+		diagnosticsCaptured: boolean
+	}
+	jellyfish: {
+		controllers: number
+		discovered: number
+		diagnosticsCaptured: boolean
+	}
+	venstar: {
+		configured: number
+		online: number
+		offline: number
+		discovered: number
+		diagnosticsCaptured: boolean
+	}
+	islandRouter: {
+		config: IslandRouterConfigStatus
+		connected: boolean
+		interfaceCount: number
+		neighborCount: number
+		errorCount: number
+		versionModel: string | null
+		clock: string | null
+		tone: StatusTone
+		statusLabel: string
+		errors: Array<string>
+	}
+	totals: {
+		managedEndpoints: number
+		unmanagedDiscoveries: number
+		diagnosticSources: number
+	}
+}
+
+function getConnectionTone(state: HomeConnectorState): StatusTone {
+	if (!state.connection.connected) return 'bad'
+	if (!state.connection.sharedSecret) return 'warn'
+	return 'good'
+}
+
+function getConnectionLabel(state: HomeConnectorState) {
+	if (!state.connection.connected) return 'Disconnected'
+	if (!state.connection.sharedSecret) return 'Connected with missing secret'
+	return 'Connected'
+}
+
+function getConnectionIssues(state: HomeConnectorState) {
+	const issues: Array<string> = []
+	if (!state.connection.connected) {
+		issues.push('Worker connector is not currently connected.')
+	}
+	if (!state.connection.sharedSecret) {
+		issues.push(
+			'Shared secret is missing, so authenticated worker sync is degraded.',
+		)
+	}
+	if (state.connection.lastError) {
+		issues.push(`Last connector error: ${state.connection.lastError}`)
+	}
+	return issues
+}
+
+function getWorkerSnapshotUrl(state: HomeConnectorState) {
+	return state.connection.connectorId
+		? `${state.connection.workerUrl}/home/connectors/${encodeURIComponent(state.connection.connectorId)}/snapshot`
+		: null
+}
+
+function countDiagnosticSources(state: HomeConnectorState) {
+	return [
+		state.rokuDiscoveryDiagnostics,
+		state.lutronDiscoveryDiagnostics,
+		state.sonosDiscoveryDiagnostics,
+		state.samsungTvDiscoveryDiagnostics,
+		state.bondDiscoveryDiagnostics,
+		state.jellyfishDiscoveryDiagnostics,
+		state.venstarDiscoveryDiagnostics,
+	].filter(Boolean).length
+}
+
+function getIslandRouterTone(input: {
+	configured: boolean
+	connected: boolean
+	errorCount: number
+}) {
+	if (!input.configured) return 'warn'
+	if (!input.connected || input.errorCount > 0) return 'bad'
+	return 'good'
+}
+
+function getIslandRouterStatusLabel(input: {
+	configured: boolean
+	connected: boolean
+	errorCount: number
+}) {
+	if (!input.configured) return 'Needs configuration'
+	if (!input.connected) return 'Configured but unreachable'
+	if (input.errorCount > 0) return 'Connected with errors'
+	return 'Healthy'
+}
+
+async function loadDashboardSnapshot(
+	deps: DashboardDependencies,
+): Promise<DashboardSnapshot> {
+	const rokuAdopted = getAdoptedRokuDevices(deps.state)
+	const rokuDiscovered = getDiscoveredRokuDevices(deps.state)
+	const lutronStatus = deps.lutron.getStatus()
+	const samsungStatus = deps.samsungTv.getStatus()
+	const sonosStatus = deps.sonos.getStatus()
+	const bondStatus = deps.bond.getStatus()
+	const jellyfishStatus = deps.jellyfish.getStatus()
+	const [venstarStatus, islandRouterStatus] = await Promise.all([
+		deps.venstar.listThermostatsWithStatus(),
+		deps.islandRouter.getStatus(),
+	])
+	const onlineVenstarCount = venstarStatus.filter(
+		(thermostat) => thermostat.info != null,
+	).length
+
+	const connectionIssues = getConnectionIssues(deps.state)
+	const islandRouterTone = getIslandRouterTone({
+		configured: islandRouterStatus.config.configured,
+		connected: islandRouterStatus.connected,
+		errorCount: islandRouterStatus.errors.length,
+	})
+
+	return {
+		connectionTone: getConnectionTone(deps.state),
+		connectionLabel: getConnectionLabel(deps.state),
+		connectionIssues,
+		workerSnapshotUrl: getWorkerSnapshotUrl(deps.state),
+		roku: {
+			adopted: rokuAdopted.length,
+			discovered: rokuDiscovered.length,
+			diagnosticsCaptured: deps.state.rokuDiscoveryDiagnostics != null,
+		},
+		lutron: {
+			processors: lutronStatus.processors.length,
+			credentials: lutronStatus.configuredCredentialsCount,
+			diagnosticsCaptured: deps.state.lutronDiscoveryDiagnostics != null,
+		},
+		sonos: {
+			adopted: sonosStatus.adopted.length,
+			discovered: sonosStatus.discovered.length,
+			audioInputSupported: sonosStatus.audioInputSupportedCount,
+			diagnosticsCaptured: deps.state.sonosDiscoveryDiagnostics != null,
+		},
+		samsungTv: {
+			adopted: samsungStatus.adopted.length,
+			discovered: samsungStatus.discovered.length,
+			paired: samsungStatus.pairedCount,
+			diagnosticsCaptured: deps.state.samsungTvDiscoveryDiagnostics != null,
+		},
+		bond: {
+			adopted: bondStatus.adopted.length,
+			discovered: bondStatus.discovered.length,
+			withToken: bondStatus.bridges.filter((bridge) => bridge.hasStoredToken)
+				.length,
+			diagnosticsCaptured: deps.state.bondDiscoveryDiagnostics != null,
+		},
+		jellyfish: {
+			controllers: jellyfishStatus.controllers.length,
+			discovered: jellyfishStatus.discovered.length,
+			diagnosticsCaptured: deps.state.jellyfishDiscoveryDiagnostics != null,
+		},
+		venstar: {
+			configured: venstarStatus.length,
+			online: onlineVenstarCount,
+			offline: venstarStatus.length - onlineVenstarCount,
+			discovered: deps.venstar.getStatus().discovered.length,
+			diagnosticsCaptured: deps.state.venstarDiscoveryDiagnostics != null,
+		},
+		islandRouter: {
+			config: islandRouterStatus.config,
+			connected: islandRouterStatus.connected,
+			interfaceCount: islandRouterStatus.interfaces.length,
+			neighborCount: islandRouterStatus.neighbors.length,
+			errorCount: islandRouterStatus.errors.length,
+			versionModel: islandRouterStatus.router.version?.model ?? null,
+			clock: islandRouterStatus.router.clock,
+			tone: islandRouterTone,
+			statusLabel: getIslandRouterStatusLabel({
+				configured: islandRouterStatus.config.configured,
+				connected: islandRouterStatus.connected,
+				errorCount: islandRouterStatus.errors.length,
+			}),
+			errors: islandRouterStatus.errors,
+		},
+		totals: {
+			managedEndpoints:
+				rokuAdopted.length +
+				lutronStatus.processors.length +
+				sonosStatus.adopted.length +
+				samsungStatus.adopted.length +
+				bondStatus.adopted.length +
+				jellyfishStatus.controllers.length +
+				venstarStatus.length,
+			unmanagedDiscoveries:
+				rokuDiscovered.length +
+				sonosStatus.discovered.length +
+				samsungStatus.discovered.length +
+				bondStatus.discovered.length +
+				jellyfishStatus.discovered.length +
+				deps.venstar.getStatus().discovered.length,
+			diagnosticSources: countDiagnosticSources(deps.state),
+		},
+	}
+}
+
+function getIntegrationTone(input: {
+	managedCount: number
+	discoveredCount: number
+	diagnosticsCaptured: boolean
+	optionalIssueCount?: number
+}) {
+	const issueCount = input.optionalIssueCount ?? 0
+	if (issueCount > 0) return 'bad'
+	if (input.managedCount > 0) return 'good'
+	if (input.discoveredCount > 0 || input.diagnosticsCaptured) return 'warn'
+	return 'neutral'
+}
+
+function getIntegrationStatusLabel(input: {
+	managedCount: number
+	discoveredCount: number
+	diagnosticsCaptured: boolean
+	managedLabel: string
+}) {
+	if (input.managedCount > 0)
+		return `${input.managedCount} ${input.managedLabel}`
+	if (input.discoveredCount > 0) return `${input.discoveredCount} discovered`
+	if (input.diagnosticsCaptured) return 'Scanned recently'
+	return 'No recent data'
+}
+
+function renderConnectionSummary(
+	state: HomeConnectorState,
+	snapshot: DashboardSnapshot,
+) {
+	return renderSummaryCard({
+		title: 'Connector session',
+		description:
+			'Worker connectivity, identity, sync timing, and shared secret readiness.',
+		status: snapshot.connectionLabel,
+		tone: snapshot.connectionTone,
+		metrics: [
+			{
+				label: 'Connector ID',
+				value: state.connection.connectorId || 'not registered',
+			},
+			{
+				label: 'Last sync',
+				value: state.connection.lastSyncAt ?? 'never',
+			},
+			{
+				label: 'Mocks',
+				value: state.connection.mocksEnabled ? 'enabled' : 'disabled',
+			},
+		],
+		primaryLink: {
+			href: routes.systemStatus.pattern,
+			label: 'Open system status',
+		},
+		secondaryLink: snapshot.workerSnapshotUrl
+			? {
+					href: snapshot.workerSnapshotUrl,
+					label: 'Worker snapshot',
+				}
+			: undefined,
+		note:
+			snapshot.connectionIssues.length > 0
+				? html`<ul class="compact-list">
+						${snapshot.connectionIssues.map((issue) => html`<li>${issue}</li>`)}
+					</ul>`
+				: 'Connection prerequisites look healthy from the local connector state.',
+	})
+}
+
+function renderIntegrationSummaryCards(snapshot: DashboardSnapshot) {
+	return html`<div class="card-grid">
+		${renderSummaryCard({
+			title: 'Roku',
+			description: 'Streaming device discovery and adoption.',
+			status: getIntegrationStatusLabel({
+				managedCount: snapshot.roku.adopted,
+				discoveredCount: snapshot.roku.discovered,
+				diagnosticsCaptured: snapshot.roku.diagnosticsCaptured,
+				managedLabel: 'adopted',
+			}),
+			tone: getIntegrationTone({
+				managedCount: snapshot.roku.adopted,
+				discoveredCount: snapshot.roku.discovered,
+				diagnosticsCaptured: snapshot.roku.diagnosticsCaptured,
+			}),
+			metrics: [
+				{ label: 'Adopted', value: snapshot.roku.adopted },
+				{ label: 'Discovered', value: snapshot.roku.discovered },
+				{
+					label: 'Diagnostics',
+					value: snapshot.roku.diagnosticsCaptured ? 'captured' : 'none',
+				},
+			],
+			primaryLink: {
+				href: routes.rokuStatus.pattern,
+				label: 'Roku status',
+			},
+			secondaryLink: {
+				href: routes.rokuSetup.pattern,
+				label: 'Roku setup',
+			},
+		})}
+		${renderSummaryCard({
+			title: 'Lutron',
+			description: 'Processor discovery and credential attachment.',
+			status: getIntegrationStatusLabel({
+				managedCount: snapshot.lutron.processors,
+				discoveredCount: 0,
+				diagnosticsCaptured: snapshot.lutron.diagnosticsCaptured,
+				managedLabel: 'processors',
+			}),
+			tone:
+				snapshot.lutron.processors > 0 && snapshot.lutron.credentials === 0
+					? 'warn'
+					: getIntegrationTone({
+							managedCount: snapshot.lutron.processors,
+							discoveredCount: 0,
+							diagnosticsCaptured: snapshot.lutron.diagnosticsCaptured,
+						}),
+			metrics: [
+				{ label: 'Processors', value: snapshot.lutron.processors },
+				{ label: 'Credentials', value: snapshot.lutron.credentials },
+				{
+					label: 'Diagnostics',
+					value: snapshot.lutron.diagnosticsCaptured ? 'captured' : 'none',
+				},
+			],
+			primaryLink: {
+				href: routes.lutronStatus.pattern,
+				label: 'Lutron status',
+			},
+			secondaryLink: {
+				href: routes.lutronSetup.pattern,
+				label: 'Lutron setup',
+			},
+		})}
+		${renderSummaryCard({
+			title: 'Sonos',
+			description: 'Grouped players, input support, and adoption.',
+			status: getIntegrationStatusLabel({
+				managedCount: snapshot.sonos.adopted,
+				discoveredCount: snapshot.sonos.discovered,
+				diagnosticsCaptured: snapshot.sonos.diagnosticsCaptured,
+				managedLabel: 'adopted',
+			}),
+			tone: getIntegrationTone({
+				managedCount: snapshot.sonos.adopted,
+				discoveredCount: snapshot.sonos.discovered,
+				diagnosticsCaptured: snapshot.sonos.diagnosticsCaptured,
+			}),
+			metrics: [
+				{ label: 'Adopted', value: snapshot.sonos.adopted },
+				{ label: 'Discovered', value: snapshot.sonos.discovered },
+				{ label: 'Audio input', value: snapshot.sonos.audioInputSupported },
+			],
+			primaryLink: {
+				href: routes.sonosStatus.pattern,
+				label: 'Sonos status',
+			},
+			secondaryLink: {
+				href: routes.sonosSetup.pattern,
+				label: 'Sonos setup',
+			},
+		})}
+		${renderSummaryCard({
+			title: 'Samsung TV',
+			description: 'Discovery, pairing, and adoption of TVs.',
+			status: getIntegrationStatusLabel({
+				managedCount: snapshot.samsungTv.adopted,
+				discoveredCount: snapshot.samsungTv.discovered,
+				diagnosticsCaptured: snapshot.samsungTv.diagnosticsCaptured,
+				managedLabel: 'adopted',
+			}),
+			tone:
+				snapshot.samsungTv.adopted > 0 && snapshot.samsungTv.paired === 0
+					? 'warn'
+					: getIntegrationTone({
+							managedCount: snapshot.samsungTv.adopted,
+							discoveredCount: snapshot.samsungTv.discovered,
+							diagnosticsCaptured: snapshot.samsungTv.diagnosticsCaptured,
+						}),
+			metrics: [
+				{ label: 'Adopted', value: snapshot.samsungTv.adopted },
+				{ label: 'Discovered', value: snapshot.samsungTv.discovered },
+				{ label: 'Paired', value: snapshot.samsungTv.paired },
+			],
+			primaryLink: {
+				href: routes.samsungTvStatus.pattern,
+				label: 'Samsung TV status',
+			},
+			secondaryLink: {
+				href: routes.samsungTvSetup.pattern,
+				label: 'Samsung TV setup',
+			},
+		})}
+		${renderSummaryCard({
+			title: 'Bond',
+			description: 'Bridge adoption and token availability.',
+			status: getIntegrationStatusLabel({
+				managedCount: snapshot.bond.adopted,
+				discoveredCount: snapshot.bond.discovered,
+				diagnosticsCaptured: snapshot.bond.diagnosticsCaptured,
+				managedLabel: 'adopted',
+			}),
+			tone:
+				snapshot.bond.adopted > 0 && snapshot.bond.withToken === 0
+					? 'warn'
+					: getIntegrationTone({
+							managedCount: snapshot.bond.adopted,
+							discoveredCount: snapshot.bond.discovered,
+							diagnosticsCaptured: snapshot.bond.diagnosticsCaptured,
+						}),
+			metrics: [
+				{ label: 'Adopted', value: snapshot.bond.adopted },
+				{ label: 'Discovered', value: snapshot.bond.discovered },
+				{ label: 'With token', value: snapshot.bond.withToken },
+			],
+			primaryLink: {
+				href: routes.bondStatus.pattern,
+				label: 'Bond status',
+			},
+			secondaryLink: {
+				href: routes.bondSetup.pattern,
+				label: 'Bond setup',
+			},
+		})}
+		${renderSummaryCard({
+			title: 'JellyFish',
+			description: 'Lighting controllers, zones, and patterns.',
+			status: getIntegrationStatusLabel({
+				managedCount: snapshot.jellyfish.controllers,
+				discoveredCount: snapshot.jellyfish.discovered,
+				diagnosticsCaptured: snapshot.jellyfish.diagnosticsCaptured,
+				managedLabel: 'controllers',
+			}),
+			tone: getIntegrationTone({
+				managedCount: snapshot.jellyfish.controllers,
+				discoveredCount: snapshot.jellyfish.discovered,
+				diagnosticsCaptured: snapshot.jellyfish.diagnosticsCaptured,
+			}),
+			metrics: [
+				{ label: 'Controllers', value: snapshot.jellyfish.controllers },
+				{ label: 'Discovered', value: snapshot.jellyfish.discovered },
+				{
+					label: 'Diagnostics',
+					value: snapshot.jellyfish.diagnosticsCaptured ? 'captured' : 'none',
+				},
+			],
+			primaryLink: {
+				href: routes.jellyfishStatus.pattern,
+				label: 'JellyFish status',
+			},
+			secondaryLink: {
+				href: routes.jellyfishSetup.pattern,
+				label: 'JellyFish setup',
+			},
+		})}
+		${renderSummaryCard({
+			title: 'Venstar',
+			description: 'Managed thermostats with online and offline state.',
+			status:
+				snapshot.venstar.configured > 0
+					? `${snapshot.venstar.online}/${snapshot.venstar.configured} online`
+					: snapshot.venstar.discovered > 0
+						? `${snapshot.venstar.discovered} discovered`
+						: 'No recent data',
+			tone:
+				snapshot.venstar.configured > 0 && snapshot.venstar.offline > 0
+					? 'warn'
+					: getIntegrationTone({
+							managedCount: snapshot.venstar.configured,
+							discoveredCount: snapshot.venstar.discovered,
+							diagnosticsCaptured: snapshot.venstar.diagnosticsCaptured,
+						}),
+			metrics: [
+				{ label: 'Configured', value: snapshot.venstar.configured },
+				{ label: 'Online', value: snapshot.venstar.online },
+				{ label: 'Discovered', value: snapshot.venstar.discovered },
+			],
+			primaryLink: {
+				href: routes.venstarStatus.pattern,
+				label: 'Venstar status',
+			},
+			secondaryLink: {
+				href: routes.venstarSetup.pattern,
+				label: 'Venstar setup',
+			},
+		})}
+	</div>`
+}
+
+function renderDrillDownActions(snapshot: DashboardSnapshot) {
+	return html`<div class="action-grid">
+		${renderActionCard({
+			href: routes.systemStatus.pattern,
+			title: 'System status',
+			description:
+				'See worker URLs, connector identity, environment-derived configuration, and aggregate counts in one place.',
+			badge: {
+				label: snapshot.connectionLabel,
+				tone: snapshot.connectionTone,
+			},
+		})}
+		${renderActionCard({
+			href: routes.diagnostics.pattern,
+			title: 'Diagnostics',
+			description:
+				'Review discovery recency, configuration gaps, error banners, and JSON payload access paths.',
+			badge: {
+				label:
+					snapshot.totals.diagnosticSources > 0
+						? `${snapshot.totals.diagnosticSources} sources`
+						: 'No captures',
+				tone: snapshot.totals.diagnosticSources > 0 ? 'good' : 'neutral',
+			},
+		})}
+		${renderActionCard({
+			href: routes.islandRouterStatus.pattern,
+			title: 'Island router diagnostics',
+			description:
+				'Inspect SSH configuration readiness, live status, interfaces, neighbor cache, and host-level router diagnosis.',
+			badge: {
+				label: snapshot.islandRouter.statusLabel,
+				tone: snapshot.islandRouter.tone,
+			},
+		})}
+	</div>`
+}
+
+function renderDiagnosticsHighlights(snapshot: DashboardSnapshot) {
+	const highlights: Array<{ label: string; tone: StatusTone; detail: string }> =
+		[]
+
+	if (snapshot.connectionIssues.length > 0) {
+		highlights.push({
+			label: 'Connector issues',
+			tone: snapshot.connectionTone,
+			detail: snapshot.connectionIssues[0] ?? 'Connector issues detected.',
+		})
+	}
+	if (!snapshot.islandRouter.config.configured) {
+		highlights.push({
+			label: 'Island router configuration',
+			tone: 'warn',
+			detail:
+				snapshot.islandRouter.config.missingFields.length > 0
+					? `Missing ${snapshot.islandRouter.config.missingFields.join(', ')}`
+					: (snapshot.islandRouter.config.warnings[0] ??
+						'Island router diagnostics need configuration.'),
+		})
+	}
+	if (snapshot.islandRouter.errors.length > 0) {
+		highlights.push({
+			label: 'Island router errors',
+			tone: 'bad',
+			detail: snapshot.islandRouter.errors[0] ?? 'Router errors present.',
+		})
+	}
+	if (snapshot.bond.adopted > snapshot.bond.withToken) {
+		highlights.push({
+			label: 'Bond tokens',
+			tone: 'warn',
+			detail: `${snapshot.bond.adopted - snapshot.bond.withToken} adopted bridge(s) still need stored tokens.`,
+		})
+	}
+	if (snapshot.samsungTv.adopted > snapshot.samsungTv.paired) {
+		highlights.push({
+			label: 'Samsung pairing',
+			tone: 'warn',
+			detail: `${snapshot.samsungTv.adopted - snapshot.samsungTv.paired} adopted TV(s) are not paired yet.`,
+		})
+	}
+	if (snapshot.venstar.offline > 0) {
+		highlights.push({
+			label: 'Venstar reachability',
+			tone: 'warn',
+			detail: `${snapshot.venstar.offline} configured thermostat(s) are currently offline.`,
+		})
+	}
+
+	if (highlights.length === 0) {
+		return renderEmptyState(
+			'No high-priority warnings surfaced from the current connector and integration snapshots.',
+		)
+	}
+
+	return html`<div class="metric-grid">
+		${highlights.map((item) =>
+			renderMetricCard({
+				label: item.label,
+				value: renderStatusBadge({
+					label: item.tone === 'bad' ? 'attention' : 'review',
+					tone: item.tone,
+				}),
+				detail: item.detail,
+				tone: item.tone,
+			}),
+		)}
+	</div>`
+}
+
+export function createDashboardHandler(deps: DashboardDependencies) {
+	return {
+		middleware: [],
+		async handler() {
+			const snapshot = await loadDashboardSnapshot(deps)
+			return render(
+				RootLayout({
+					title: 'home connector - dashboard',
+					currentPath: routes.home.pattern,
+					body: html`${renderPageIntro({
+							eyebrow: 'Dashboard',
+							title: 'Home connector dashboard',
+							description:
+								'Quick-look operational view for the local admin UI with health, counts, status colors, and direct links into deeper diagnostics.',
+							actions: [
+								{ href: routes.systemStatus.pattern, label: 'System status' },
+								{ href: routes.diagnostics.pattern, label: 'Diagnostics' },
+								{
+									href: routes.islandRouterStatus.pattern,
+									label: 'Island router',
+								},
+							],
+						})}
+						<div class="metric-grid">
+							${renderMetricCard({
+								label: 'Managed endpoints',
+								value: snapshot.totals.managedEndpoints,
+								detail:
+									'Adopted or configured devices/controllers managed by this connector.',
+								tone: snapshot.totals.managedEndpoints > 0 ? 'good' : 'neutral',
+							})}
+							${renderMetricCard({
+								label: 'Unmanaged discoveries',
+								value: snapshot.totals.unmanagedDiscoveries,
+								detail:
+									'Devices found on the network that still need adoption or setup.',
+								tone:
+									snapshot.totals.unmanagedDiscoveries > 0 ? 'warn' : 'good',
+							})}
+							${renderMetricCard({
+								label: 'Diagnostic sources',
+								value: snapshot.totals.diagnosticSources,
+								detail:
+									'Integrations with captured discovery diagnostics in local state.',
+								tone:
+									snapshot.totals.diagnosticSources > 0 ? 'good' : 'neutral',
+							})}
+							${renderMetricCard({
+								label: 'Router quick look',
+								value: snapshot.islandRouter.statusLabel,
+								detail:
+									snapshot.islandRouter.versionModel ??
+									'Island router model not available yet.',
+								tone: snapshot.islandRouter.tone,
+							})}
+						</div>
+						${renderConnectionSummary(deps.state, snapshot)}
+						<section class="section-stack">
+							<div class="card-heading">
+								<h2>Integration quick look</h2>
+								<p class="muted">
+									Green means managed and healthy, yellow means partial setup or
+									discoveries, red means a current problem.
+								</p>
+							</div>
+							${renderIntegrationSummaryCards(snapshot)}
+						</section>
+						<section class="section-stack">
+							<div class="card-heading">
+								<h2>Drill-down pages</h2>
+								<p class="muted">
+									Use these admin pages for deeper context instead of jumping
+									through a bare list of links.
+								</p>
+							</div>
+							${renderDrillDownActions(snapshot)}
+						</section>
+						<section class="card">
+							<div class="card-heading">
+								<h2>Priority diagnostics</h2>
+								<p class="muted">
+									Highlights from the current state that are likely to need
+									action first.
+								</p>
+							</div>
+							${renderDiagnosticsHighlights(snapshot)}
+						</section>`,
+				}),
+			)
+		},
+	} satisfies BuildAction<typeof routes.home.method, typeof routes.home.pattern>
+}
+
+function renderConfigWarningList(configStatus: IslandRouterConfigStatus) {
+	if (
+		configStatus.missingFields.length === 0 &&
+		configStatus.warnings.length === 0
+	) {
+		return renderEmptyState(
+			'No Island router configuration warnings are currently present.',
+		)
+	}
+
+	return html`<ul class="list">
+		${configStatus.missingFields.map(
+			(field) => html`<li>Missing ${field}</li>`,
+		)}
+		${configStatus.warnings.map((warning) => html`<li>${warning}</li>`)}
+	</ul>`
+}
+
+export function createSystemStatusHandler(deps: DashboardDependencies) {
+	return {
+		middleware: [],
+		async handler() {
+			const snapshot = await loadDashboardSnapshot(deps)
+			return render(
+				RootLayout({
+					title: 'home connector - system status',
+					currentPath: routes.systemStatus.pattern,
+					body: html`${renderPageIntro({
+							eyebrow: 'System',
+							title: 'System status',
+							description:
+								'High-level connector identity, network endpoints, environment-derived configuration, and aggregated inventory counts.',
+							actions: [
+								{ href: routes.home.pattern, label: 'Back to dashboard' },
+								{ href: routes.diagnostics.pattern, label: 'Diagnostics' },
+							],
+						})}
+						<div class="metric-grid">
+							${renderMetricCard({
+								label: 'Connection',
+								value: snapshot.connectionLabel,
+								detail: deps.state.connection.lastSyncAt ?? 'No sync yet',
+								tone: snapshot.connectionTone,
+							})}
+							${renderMetricCard({
+								label: 'Worker secret',
+								value: deps.state.connection.sharedSecret
+									? 'configured'
+									: 'missing',
+								detail: 'Used for authenticated worker connector traffic.',
+								tone: deps.state.connection.sharedSecret ? 'good' : 'warn',
+							})}
+							${renderMetricCard({
+								label: 'Mocks',
+								value: deps.state.connection.mocksEnabled
+									? 'enabled'
+									: 'disabled',
+								detail: deps.state.connection.mocksEnabled
+									? 'Local mock services are active.'
+									: 'Using live discovery and device endpoints.',
+								tone: deps.state.connection.mocksEnabled ? 'warn' : 'neutral',
+							})}
+							${renderMetricCard({
+								label: 'Admin port',
+								value: deps.config.port,
+								detail: 'Local HTTP server port for this admin UI.',
+								tone: 'neutral',
+							})}
+						</div>
+						<section class="card-grid">
+							<section class="card">
+								<div class="card-heading">
+									<h2>Connector identity</h2>
+									${renderStatusBadge({
+										label: snapshot.connectionLabel,
+										tone: snapshot.connectionTone,
+									})}
+								</div>
+								${renderInfoRows([
+									{
+										label: 'Connector ID',
+										value: html`<code
+											>${deps.state.connection.connectorId ||
+											'not registered'}</code
+										>`,
+									},
+									{
+										label: 'Worker URL',
+										value: html`<code
+											>${deps.state.connection.workerUrl}</code
+										>`,
+									},
+									{
+										label: 'Worker session URL',
+										value: html`<code>${deps.config.workerSessionUrl}</code>`,
+									},
+									{
+										label: 'Worker WebSocket URL',
+										value: html`<code>${deps.config.workerWebSocketUrl}</code>`,
+									},
+									{
+										label: 'Data path',
+										value: html`<code>${deps.config.dataPath}</code>`,
+									},
+									{
+										label: 'SQLite DB',
+										value: html`<code>${deps.config.dbPath}</code>`,
+									},
+									{
+										label: 'Last connector error',
+										value: deps.state.connection.lastError ?? 'none',
+									},
+								])}
+							</section>
+							<section class="card">
+								<div class="card-heading">
+									<h2>Inventory totals</h2>
+									<p class="muted">Cross-integration device counts.</p>
+								</div>
+								${renderInfoRows([
+									{
+										label: 'Managed endpoints',
+										value: String(snapshot.totals.managedEndpoints),
+									},
+									{
+										label: 'Unmanaged discoveries',
+										value: String(snapshot.totals.unmanagedDiscoveries),
+									},
+									{
+										label: 'Discovery captures',
+										value: String(snapshot.totals.diagnosticSources),
+									},
+									{
+										label: 'Venstar scan CIDRs',
+										value: html`<code
+											>${deps.config.venstarScanCidrs.join(', ') ||
+											'none'}</code
+										>`,
+									},
+									{
+										label: 'JellyFish scan CIDRs',
+										value: html`<code
+											>${deps.config.jellyfishScanCidrs.join(', ') ||
+											'none'}</code
+										>`,
+									},
+								])}
+							</section>
+						</section>
+						<section class="card-grid">
+							<section class="card">
+								<div class="card-heading">
+									<h2>Discovery endpoints</h2>
+									<p class="muted">
+										Configured discovery sources for each integration.
+									</p>
+								</div>
+								${renderInfoRows([
+									{
+										label: 'Roku',
+										value: html`<code>${deps.config.rokuDiscoveryUrl}</code>`,
+									},
+									{
+										label: 'Lutron',
+										value: html`<code>${deps.config.lutronDiscoveryUrl}</code>`,
+									},
+									{
+										label: 'Sonos',
+										value: html`<code>${deps.config.sonosDiscoveryUrl}</code>`,
+									},
+									{
+										label: 'Samsung TV',
+										value: html`<code
+											>${deps.config.samsungTvDiscoveryUrl}</code
+										>`,
+									},
+									{
+										label: 'Bond',
+										value: html`<code>${deps.config.bondDiscoveryUrl}</code>`,
+									},
+									{
+										label: 'JellyFish override',
+										value: deps.config.jellyfishDiscoveryUrl
+											? html`<code>${deps.config.jellyfishDiscoveryUrl}</code>`
+											: 'none',
+									},
+								])}
+							</section>
+							<section class="card">
+								<div class="card-heading">
+									<h2>Island router readiness</h2>
+									${renderStatusBadge({
+										label: snapshot.islandRouter.statusLabel,
+										tone: snapshot.islandRouter.tone,
+									})}
+								</div>
+								${renderInfoRows([
+									{
+										label: 'Host',
+										value: deps.config.islandRouterHost
+											? html`<code>${deps.config.islandRouterHost}</code>`
+											: 'missing',
+									},
+									{
+										label: 'Port',
+										value: String(deps.config.islandRouterPort),
+									},
+									{
+										label: 'Username',
+										value: deps.config.islandRouterUsername ?? 'missing',
+									},
+									{
+										label: 'Verification mode',
+										value: snapshot.islandRouter.config.verificationMode,
+									},
+									{
+										label: 'Timeout',
+										value: `${deps.config.islandRouterCommandTimeoutMs}ms`,
+									},
+								])}
+								${renderConfigWarningList(snapshot.islandRouter.config)}
+							</section>
+						</section>`,
+				}),
+			)
+		},
+	} satisfies BuildAction<
+		typeof routes.systemStatus.method,
+		typeof routes.systemStatus.pattern
+	>
+}
+
+type DiagnosticRow = {
+	name: string
+	status: string
+	tone: StatusTone
+	details: string
+	links: Array<{ href: string; label: string }>
+}
+
+function renderDiagnosticRows(rows: Array<DiagnosticRow>) {
+	return renderDataTable({
+		headers: ['Surface', 'Status', 'Details', 'Links'],
+		rows: rows.map((row) => [
+			row.name,
+			renderStatusBadge({ label: row.status, tone: row.tone }),
+			row.details,
+			renderInlineLinks(row.links),
+		]),
+	})
+}
+
+export function createDiagnosticsHandler(deps: DashboardDependencies) {
+	return {
+		middleware: [],
+		async handler() {
+			const snapshot = await loadDashboardSnapshot(deps)
+			const rows: Array<DiagnosticRow> = [
+				{
+					name: 'Connector session',
+					status: snapshot.connectionLabel,
+					tone: snapshot.connectionTone,
+					details:
+						snapshot.connectionIssues[0] ??
+						'Worker URL, shared secret, and connector identity look consistent.',
+					links: [
+						{ href: routes.systemStatus.pattern, label: 'System status' },
+						{ href: routes.health.pattern, label: 'Health JSON' },
+					],
+				},
+				{
+					name: 'Island router',
+					status: snapshot.islandRouter.statusLabel,
+					tone: snapshot.islandRouter.tone,
+					details:
+						snapshot.islandRouter.errors[0] ??
+						snapshot.islandRouter.config.warnings[0] ??
+						`${snapshot.islandRouter.interfaceCount} interfaces, ${snapshot.islandRouter.neighborCount} neighbors.`,
+					links: [
+						{
+							href: routes.islandRouterStatus.pattern,
+							label: 'Router status',
+						},
+						{
+							href: `${routes.islandRouterStatus.pattern}?host=192.168.1.10`,
+							label: 'Host diagnosis example',
+						},
+					],
+				},
+				{
+					name: 'Roku discovery',
+					status: snapshot.roku.diagnosticsCaptured
+						? 'Captured'
+						: 'No captures',
+					tone: snapshot.roku.diagnosticsCaptured
+						? snapshot.roku.discovered > 0
+							? 'warn'
+							: 'good'
+						: 'neutral',
+					details: deps.state.rokuDiscoveryDiagnostics
+						? `Last scan ${deps.state.rokuDiscoveryDiagnostics.scannedAt} with ${deps.state.rokuDiscoveryDiagnostics.ssdpHits.length} SSDP hits.`
+						: 'No Roku scan diagnostics captured yet.',
+					links: [
+						{ href: routes.rokuStatus.pattern, label: 'Roku status' },
+						{ href: routes.rokuSetup.pattern, label: 'Roku setup' },
+					],
+				},
+				{
+					name: 'Lutron discovery',
+					status: snapshot.lutron.diagnosticsCaptured
+						? 'Captured'
+						: 'No captures',
+					tone: deps.state.lutronDiscoveryDiagnostics?.errors.length
+						? 'bad'
+						: snapshot.lutron.diagnosticsCaptured
+							? 'good'
+							: 'neutral',
+					details: deps.state.lutronDiscoveryDiagnostics
+						? `Last scan ${deps.state.lutronDiscoveryDiagnostics.scannedAt} with ${deps.state.lutronDiscoveryDiagnostics.services.length} services and ${deps.state.lutronDiscoveryDiagnostics.errors.length} error(s).`
+						: 'No Lutron scan diagnostics captured yet.',
+					links: [
+						{ href: routes.lutronStatus.pattern, label: 'Lutron status' },
+						{ href: routes.lutronSetup.pattern, label: 'Lutron setup' },
+					],
+				},
+				{
+					name: 'Sonos discovery',
+					status: snapshot.sonos.diagnosticsCaptured
+						? 'Captured'
+						: 'No captures',
+					tone: snapshot.sonos.diagnosticsCaptured ? 'good' : 'neutral',
+					details: deps.state.sonosDiscoveryDiagnostics
+						? `Last scan ${deps.state.sonosDiscoveryDiagnostics.scannedAt} with ${deps.state.sonosDiscoveryDiagnostics.ssdpHits.length} SSDP hits and ${deps.state.sonosDiscoveryDiagnostics.descriptionLookups.length} description lookups.`
+						: 'No Sonos diagnostics captured yet.',
+					links: [
+						{ href: routes.sonosStatus.pattern, label: 'Sonos status' },
+						{ href: routes.sonosSetup.pattern, label: 'Sonos setup' },
+					],
+				},
+				{
+					name: 'Samsung TV discovery',
+					status: snapshot.samsungTv.diagnosticsCaptured
+						? 'Captured'
+						: 'No captures',
+					tone: snapshot.samsungTv.diagnosticsCaptured ? 'good' : 'neutral',
+					details: deps.state.samsungTvDiscoveryDiagnostics
+						? `Last scan ${deps.state.samsungTvDiscoveryDiagnostics.scannedAt} with ${deps.state.samsungTvDiscoveryDiagnostics.services.length} services and ${deps.state.samsungTvDiscoveryDiagnostics.metadataLookups.length} metadata lookups.`
+						: 'No Samsung TV diagnostics captured yet.',
+					links: [
+						{
+							href: routes.samsungTvStatus.pattern,
+							label: 'Samsung TV status',
+						},
+						{
+							href: routes.samsungTvSetup.pattern,
+							label: 'Samsung TV setup',
+						},
+					],
+				},
+				{
+					name: 'Bond discovery',
+					status: snapshot.bond.diagnosticsCaptured
+						? 'Captured'
+						: 'No captures',
+					tone: deps.state.bondDiscoveryDiagnostics?.errors.length
+						? 'bad'
+						: snapshot.bond.diagnosticsCaptured
+							? 'good'
+							: 'neutral',
+					details: deps.state.bondDiscoveryDiagnostics
+						? `Last scan ${deps.state.bondDiscoveryDiagnostics.scannedAt} with ${deps.state.bondDiscoveryDiagnostics.services.length} services and ${deps.state.bondDiscoveryDiagnostics.errors.length} error(s).`
+						: 'No Bond diagnostics captured yet.',
+					links: [
+						{ href: routes.bondStatus.pattern, label: 'Bond status' },
+						{ href: routes.bondSetup.pattern, label: 'Bond setup' },
+					],
+				},
+				{
+					name: 'JellyFish discovery',
+					status: snapshot.jellyfish.diagnosticsCaptured
+						? 'Captured'
+						: 'No captures',
+					tone: snapshot.jellyfish.diagnosticsCaptured ? 'good' : 'neutral',
+					details: deps.state.jellyfishDiscoveryDiagnostics
+						? `Last scan ${deps.state.jellyfishDiscoveryDiagnostics.scannedAt} via ${deps.state.jellyfishDiscoveryDiagnostics.protocol} with ${deps.state.jellyfishDiscoveryDiagnostics.probeResults.length} probe result(s).`
+						: 'No JellyFish diagnostics captured yet.',
+					links: [
+						{
+							href: routes.jellyfishStatus.pattern,
+							label: 'JellyFish status',
+						},
+						{
+							href: routes.jellyfishSetup.pattern,
+							label: 'JellyFish setup',
+						},
+					],
+				},
+				{
+					name: 'Venstar discovery',
+					status: snapshot.venstar.diagnosticsCaptured
+						? 'Captured'
+						: 'No captures',
+					tone: snapshot.venstar.offline > 0 ? 'warn' : 'good',
+					details: deps.state.venstarDiscoveryDiagnostics
+						? `Last scan ${deps.state.venstarDiscoveryDiagnostics.scannedAt} with ${deps.state.venstarDiscoveryDiagnostics.infoLookups.length} info lookup(s).`
+						: 'No Venstar diagnostics captured yet.',
+					links: [
+						{ href: routes.venstarStatus.pattern, label: 'Venstar status' },
+						{ href: routes.venstarSetup.pattern, label: 'Venstar setup' },
+					],
+				},
+			]
+
+			return render(
+				RootLayout({
+					title: 'home connector - diagnostics',
+					currentPath: routes.diagnostics.pattern,
+					body: html`${renderPageIntro({
+							eyebrow: 'Diagnostics',
+							title: 'Diagnostics overview',
+							description:
+								'Cross-cutting visibility into discovery recency, configuration gaps, and where to drill in for live operational data.',
+							actions: [
+								{ href: routes.home.pattern, label: 'Dashboard' },
+								{
+									href: routes.islandRouterStatus.pattern,
+									label: 'Island router',
+								},
+							],
+						})}
+						<section class="card">
+							<div class="card-heading">
+								<h2>Diagnostics matrix</h2>
+								<p class="muted">
+									Every row links back to the local status/setup pages that own
+									the underlying details.
+								</p>
+							</div>
+							${renderDiagnosticRows(rows)}
+						</section>
+						<section class="card-grid">
+							<section class="card">
+								<div class="card-heading">
+									<h2>Connection raw snapshot</h2>
+									<p class="muted">Current in-memory connector state.</p>
+								</div>
+								${renderCodeBlock(formatJson(deps.state.connection))}
+							</section>
+							<section class="card">
+								<div class="card-heading">
+									<h2>Known discovery fields</h2>
+									<p class="muted">
+										Quick way to confirm which diagnostics collections are
+										populated.
+									</p>
+								</div>
+								${renderInfoRows([
+									{
+										label: 'Roku',
+										value: deps.state.rokuDiscoveryDiagnostics
+											? 'captured'
+											: 'none',
+									},
+									{
+										label: 'Lutron',
+										value: deps.state.lutronDiscoveryDiagnostics
+											? 'captured'
+											: 'none',
+									},
+									{
+										label: 'Sonos',
+										value: deps.state.sonosDiscoveryDiagnostics
+											? 'captured'
+											: 'none',
+									},
+									{
+										label: 'Samsung TV',
+										value: deps.state.samsungTvDiscoveryDiagnostics
+											? 'captured'
+											: 'none',
+									},
+									{
+										label: 'Bond',
+										value: deps.state.bondDiscoveryDiagnostics
+											? 'captured'
+											: 'none',
+									},
+									{
+										label: 'JellyFish',
+										value: deps.state.jellyfishDiscoveryDiagnostics
+											? 'captured'
+											: 'none',
+									},
+									{
+										label: 'Venstar',
+										value: deps.state.venstarDiscoveryDiagnostics
+											? 'captured'
+											: 'none',
+									},
+								])}
+							</section>
+						</section>`,
+				}),
+			)
+		},
+	} satisfies BuildAction<
+		typeof routes.diagnostics.method,
+		typeof routes.diagnostics.pattern
+	>
+}
+
+function renderNeighborTable(
+	neighbors: Awaited<
+		ReturnType<ReturnType<typeof createIslandRouterAdapter>['getStatus']>
+	>['neighbors'],
+) {
+	if (neighbors.length === 0) {
+		return renderEmptyState(
+			'No neighbor entries were returned by the Island router.',
+		)
+	}
+
+	return renderDataTable({
+		headers: ['IP', 'MAC', 'Interface', 'State'],
+		rows: neighbors
+			.slice(0, 25)
+			.map((neighbor) => [
+				neighbor.ipAddress ?? 'unknown',
+				neighbor.macAddress ?? 'unknown',
+				neighbor.interfaceName ?? 'unknown',
+				neighbor.state ?? 'unknown',
+			]),
+	})
+}
+
+function renderInterfaceTable(
+	interfaces: Awaited<
+		ReturnType<ReturnType<typeof createIslandRouterAdapter>['getStatus']>
+	>['interfaces'],
+) {
+	if (interfaces.length === 0) {
+		return renderEmptyState(
+			'No interface summaries were returned by the Island router.',
+		)
+	}
+
+	return renderDataTable({
+		headers: ['Interface', 'Link', 'Speed', 'Duplex', 'Description'],
+		rows: interfaces.map((entry) => [
+			entry.name ?? 'unknown',
+			entry.linkState ?? 'unknown',
+			entry.speed ?? 'unknown',
+			entry.duplex ?? 'unknown',
+			entry.description ?? 'none',
+		]),
+	})
+}
+
+function getRequestedHost(request: Request) {
+	const url = new URL(request.url)
+	return url.searchParams.get('host')?.trim() || ''
+}
+
+export function createIslandRouterStatusHandler(deps: DashboardDependencies) {
+	return {
+		middleware: [],
+		async handler({ request }: { request: Request }) {
+			const requestedHost = getRequestedHost(request)
+			const [snapshot, routerStatus] = await Promise.all([
+				loadDashboardSnapshot(deps),
+				deps.islandRouter.getStatus(),
+			])
+
+			let hostDiagnosis: Awaited<
+				ReturnType<ReturnType<typeof createIslandRouterAdapter>['diagnoseHost']>
+			> | null = null
+			let hostDiagnosisError: string | null = null
+
+			if (requestedHost) {
+				try {
+					hostDiagnosis = await deps.islandRouter.diagnoseHost({
+						host: requestedHost,
+					})
+				} catch (error) {
+					hostDiagnosisError =
+						error instanceof Error ? error.message : String(error)
+				}
+			}
+
+			return render(
+				RootLayout({
+					title: 'home connector - island router status',
+					currentPath: routes.islandRouterStatus.pattern,
+					body: html`${renderPageIntro({
+							eyebrow: 'Island router',
+							title: 'Island router status',
+							description:
+								'Router-state diagnostics surfaced directly in the local admin UI, including SSH readiness, interface summaries, neighbors, and host-level drill-downs.',
+							actions: [
+								{ href: routes.home.pattern, label: 'Dashboard' },
+								{ href: routes.diagnostics.pattern, label: 'Diagnostics' },
+							],
+						})}
+						<div class="metric-grid">
+							${renderMetricCard({
+								label: 'Router health',
+								value: snapshot.islandRouter.statusLabel,
+								detail:
+									snapshot.islandRouter.versionModel ??
+									'Router version not available yet.',
+								tone: snapshot.islandRouter.tone,
+							})}
+							${renderMetricCard({
+								label: 'Verification',
+								value: routerStatus.config.verificationMode,
+								detail: routerStatus.config.configured
+									? 'SSH configuration is complete enough to attempt commands.'
+									: 'Set the missing fields below to enable SSH-backed diagnostics.',
+								tone: routerStatus.config.configured ? 'good' : 'warn',
+							})}
+							${renderMetricCard({
+								label: 'Interfaces',
+								value: routerStatus.interfaces.length,
+								detail: routerStatus.router.clock ?? 'Clock unavailable',
+								tone: routerStatus.interfaces.length > 0 ? 'good' : 'warn',
+							})}
+							${renderMetricCard({
+								label: 'Neighbors',
+								value: routerStatus.neighbors.length,
+								detail: `${routerStatus.errors.length} router error(s)`,
+								tone: routerStatus.errors.length > 0 ? 'bad' : 'good',
+							})}
+						</div>
+						<section class="card-grid">
+							<section class="card">
+								<div class="card-heading">
+									<h2>SSH configuration</h2>
+									${renderStatusBadge({
+										label: snapshot.islandRouter.statusLabel,
+										tone: snapshot.islandRouter.tone,
+									})}
+								</div>
+								${renderInfoRows([
+									{
+										label: 'Host',
+										value: deps.config.islandRouterHost
+											? html`<code>${deps.config.islandRouterHost}</code>`
+											: 'missing',
+									},
+									{
+										label: 'Port',
+										value: String(deps.config.islandRouterPort),
+									},
+									{
+										label: 'Username',
+										value: deps.config.islandRouterUsername ?? 'missing',
+									},
+									{
+										label: 'Private key path',
+										value: deps.config.islandRouterPrivateKeyPath
+											? html`<code
+													>${deps.config.islandRouterPrivateKeyPath}</code
+												>`
+											: 'missing',
+									},
+									{
+										label: 'Known hosts path',
+										value: deps.config.islandRouterKnownHostsPath
+											? html`<code
+													>${deps.config.islandRouterKnownHostsPath}</code
+												>`
+											: 'none',
+									},
+									{
+										label: 'Fingerprint',
+										value: deps.config.islandRouterHostFingerprint
+											? html`<code
+													>${deps.config.islandRouterHostFingerprint}</code
+												>`
+											: 'none',
+									},
+								])}
+								${renderConfigWarningList(routerStatus.config)}
+							</section>
+							<section class="card">
+								<div class="card-heading">
+									<h2>Router snapshot</h2>
+									<p class="muted">
+										Live router metadata returned from SSH commands.
+									</p>
+								</div>
+								${renderInfoRows([
+									{
+										label: 'Connected',
+										value: routerStatus.connected ? 'yes' : 'no',
+									},
+									{
+										label: 'Model',
+										value: routerStatus.router.version?.model ?? 'unknown',
+									},
+									{
+										label: 'Serial number',
+										value:
+											routerStatus.router.version?.serialNumber ?? 'unknown',
+									},
+									{
+										label: 'Firmware',
+										value:
+											routerStatus.router.version?.firmwareVersion ?? 'unknown',
+									},
+									{
+										label: 'Clock',
+										value: routerStatus.router.clock ?? 'unknown',
+									},
+								])}
+								${routerStatus.errors.length > 0
+									? html`<ul class="list">
+											${routerStatus.errors.map(
+												(error) => html`<li>${error}</li>`,
+											)}
+										</ul>`
+									: renderEmptyState(
+											'No router-side errors were reported in the current snapshot.',
+										)}
+							</section>
+						</section>
+						<section class="card">
+							<div class="card-heading">
+								<h2>Host diagnosis</h2>
+								<p class="muted">
+									Pass <code>?host=192.168.1.10</code> or a hostname to run a
+									router-side diagnosis from this page.
+								</p>
+							</div>
+							${requestedHost
+								? hostDiagnosisError
+									? renderEmptyState(
+											`Host diagnosis failed: ${hostDiagnosisError}`,
+										)
+									: hostDiagnosis
+										? html`${renderInfoRows([
+												{
+													label: 'Requested host',
+													value: hostDiagnosis.host.value,
+												},
+												{
+													label: 'Parsed kind',
+													value: hostDiagnosis.host.kind,
+												},
+												{
+													label: 'Ping',
+													value: hostDiagnosis.ping
+														? hostDiagnosis.ping.reachable
+															? 'reachable'
+															: hostDiagnosis.ping.timedOut
+																? 'timed out'
+																: 'no reply'
+														: 'not run',
+												},
+												{
+													label: 'Neighbor match',
+													value:
+														hostDiagnosis.arpEntry?.ipAddress ??
+														hostDiagnosis.arpEntry?.macAddress ??
+														'none',
+												},
+												{
+													label: 'DHCP match',
+													value:
+														hostDiagnosis.dhcpLease?.ipAddress ??
+														hostDiagnosis.dhcpLease?.macAddress ??
+														'none',
+												},
+												{
+													label: 'Recent events',
+													value: String(hostDiagnosis.recentEvents.length),
+												},
+											])}
+											${hostDiagnosis.errors.length > 0
+												? html`<ul class="list">
+														${hostDiagnosis.errors.map(
+															(error) => html`<li>${error}</li>`,
+														)}
+													</ul>`
+												: ''}
+											${hostDiagnosis.ping
+												? html`<section class="card">
+														<h3>Ping raw output</h3>
+														${renderCodeBlock(hostDiagnosis.ping.rawOutput)}
+													</section>`
+												: ''}
+											${hostDiagnosis.recentEvents.length > 0
+												? html`<section class="card">
+														<h3>Recent matching events</h3>
+														${renderDataTable({
+															headers: [
+																'Timestamp',
+																'Level',
+																'Module',
+																'Message',
+															],
+															rows: hostDiagnosis.recentEvents.map((event) => [
+																event.timestamp ?? 'unknown',
+																event.level ?? 'unknown',
+																event.module ?? 'unknown',
+																event.message,
+															]),
+														})}
+													</section>`
+												: ''}
+											${hostDiagnosis.interfaceDetails
+												? html`<section class="card">
+														<h3>Interface details</h3>
+														${renderCodeBlock(
+															hostDiagnosis.interfaceDetails.rawOutput,
+														)}
+													</section>`
+												: ''}`
+										: renderEmptyState(
+												'No host diagnosis data was produced for the requested host.',
+											)
+								: renderEmptyState(
+										'Append a host query parameter to run a router-side diagnosis from this page.',
+									)}
+						</section>
+						<section class="card-grid">
+							<section class="card">
+								<div class="card-heading">
+									<h2>Interface summary</h2>
+									<p class="muted">
+										First-class interface data from the router.
+									</p>
+								</div>
+								${renderInterfaceTable(routerStatus.interfaces)}
+							</section>
+							<section class="card">
+								<div class="card-heading">
+									<h2>Neighbor cache</h2>
+									<p class="muted">Current parsed IP neighbor table.</p>
+								</div>
+								${renderNeighborTable(routerStatus.neighbors)}
+							</section>
+						</section>
+						<section class="card">
+							<div class="card-heading">
+								<h2>Raw status payload</h2>
+								<p class="muted">
+									Useful when comparing the UI output with MCP router tools.
+								</p>
+							</div>
+							${renderCodeBlock(formatJson(routerStatus))}
+						</section>`,
+				}),
+			)
+		},
+	} satisfies BuildAction<
+		typeof routes.islandRouterStatus.method,
+		typeof routes.islandRouterStatus.pattern
+	>
+}

--- a/packages/home-connector/app/dashboard-handlers.ts
+++ b/packages/home-connector/app/dashboard-handlers.ts
@@ -141,6 +141,13 @@ function getConnectionIssues(state: HomeConnectorState) {
 	return issues
 }
 
+function getSafeConnectionSnapshot(state: HomeConnectorState) {
+	return {
+		...state.connection,
+		sharedSecret: state.connection.sharedSecret ? 'configured' : 'missing',
+	}
+}
+
 function getWorkerSnapshotUrl(state: HomeConnectorState) {
 	return state.connection.connectorId
 		? `${state.connection.workerUrl}/home/connectors/${encodeURIComponent(state.connection.connectorId)}/snapshot`
@@ -1239,7 +1246,9 @@ export function createDiagnosticsHandler(deps: DashboardDependencies) {
 									<h2>Connection raw snapshot</h2>
 									<p class="muted">Current in-memory connector state.</p>
 								</div>
-								${renderCodeBlock(formatJson(deps.state.connection))}
+								${renderCodeBlock(
+									formatJson(getSafeConnectionSnapshot(deps.state)),
+								)}
 							</section>
 							<section class="card">
 								<div class="card-heading">

--- a/packages/home-connector/app/root.ts
+++ b/packages/home-connector/app/root.ts
@@ -1,125 +1,211 @@
 import { html } from 'remix/html-template'
+import { routes } from './routes.ts'
+
+type NavigationItem = {
+	href: string
+	label: string
+	description: string
+	matchPaths?: Array<string>
+}
+
+const navigationSections: Array<{
+	label: string
+	items: Array<NavigationItem>
+}> = [
+	{
+		label: 'Overview',
+		items: [
+			{
+				href: routes.home.pattern,
+				label: 'Dashboard',
+				description: 'Health, counts, and quick actions',
+			},
+			{
+				href: routes.systemStatus.pattern,
+				label: 'System status',
+				description: 'Connection, endpoints, config, and inventory',
+			},
+			{
+				href: routes.diagnostics.pattern,
+				label: 'Diagnostics',
+				description: 'Discovery recency, warnings, and drill-downs',
+			},
+			{
+				href: routes.islandRouterStatus.pattern,
+				label: 'Island router',
+				description: 'SSH readiness, interfaces, neighbors, and host diagnosis',
+			},
+			{
+				href: routes.health.pattern,
+				label: 'Health JSON',
+				description: 'Machine-readable local health endpoint',
+			},
+		],
+	},
+	{
+		label: 'Integrations',
+		items: [
+			{
+				href: routes.rokuStatus.pattern,
+				label: 'Roku',
+				description: 'Devices and discovery',
+				matchPaths: [routes.rokuSetup.pattern],
+			},
+			{
+				href: routes.lutronStatus.pattern,
+				label: 'Lutron',
+				description: 'Processors and credentials',
+				matchPaths: [routes.lutronSetup.pattern],
+			},
+			{
+				href: routes.sonosStatus.pattern,
+				label: 'Sonos',
+				description: 'Players and groups',
+				matchPaths: [routes.sonosSetup.pattern],
+			},
+			{
+				href: routes.samsungTvStatus.pattern,
+				label: 'Samsung TV',
+				description: 'Discovery and pairing',
+				matchPaths: [routes.samsungTvSetup.pattern],
+			},
+			{
+				href: routes.bondStatus.pattern,
+				label: 'Bond',
+				description: 'Bridge state and token setup',
+				matchPaths: [routes.bondSetup.pattern],
+			},
+			{
+				href: routes.jellyfishStatus.pattern,
+				label: 'JellyFish',
+				description: 'Controllers, patterns, and zones',
+				matchPaths: [routes.jellyfishSetup.pattern],
+			},
+			{
+				href: routes.venstarStatus.pattern,
+				label: 'Venstar',
+				description: 'Managed thermostats and LAN scans',
+				matchPaths: [routes.venstarSetup.pattern],
+			},
+		],
+	},
+]
+
+function isNavigationItemActive(
+	item: NavigationItem,
+	currentPath: string | undefined,
+) {
+	if (!currentPath) return false
+	return [item.href, ...(item.matchPaths ?? [])].includes(currentPath)
+}
+
+function renderNavigation(currentPath: string | undefined) {
+	return html`${navigationSections.map(
+		(section) => html`<section class="nav-section">
+			<div class="nav-section-title">${section.label}</div>
+			<ul class="nav-list">
+				${section.items.map((item) => {
+					const active = isNavigationItemActive(item, currentPath)
+					return html`<li>
+						<a
+							class="nav-link ${active ? 'nav-link-active' : ''}"
+							href="${item.href}"
+						>
+							<span class="nav-link-label">${item.label}</span>
+							<span class="nav-link-description">${item.description}</span>
+						</a>
+					</li>`
+				})}
+			</ul>
+		</section>`,
+	)}`
+}
 
 const styles = `
 	:root {
 		color-scheme: light dark;
-
-		/* Colors - Light mode (blue and gray) */
 		--color-primary: #2563eb;
 		--color-primary-hover: #1d4ed8;
 		--color-primary-active: #1e40af;
 		--color-on-primary: #ffffff;
-		--color-primary-text: #1e40af;
+		--color-primary-text: #1d4ed8;
 		--color-background: #f8fafc;
-		--color-surface: #f1f5f9;
+		--color-surface: #ffffff;
+		--color-surface-muted: #f1f5f9;
 		--color-text: #0f172a;
 		--color-text-muted: #64748b;
 		--color-border: #cbd5e1;
+		--color-success: #15803d;
+		--color-success-surface: #dcfce7;
+		--color-warning: #b45309;
+		--color-warning-surface: #fef3c7;
 		--color-danger: #dc2626;
-		--color-danger-hover: #b91c1c;
-		--color-on-danger: #ffffff;
-
-		/* Colors - Dark mode (blue and gray) */
-		--color-primary-dark: #3b82f6;
-		--color-primary-hover-dark: #60a5fa;
-		--color-primary-active-dark: #93c5fd;
-		--color-on-primary-dark: #0f172a;
-		--color-primary-text-dark: #60a5fa;
-		--color-background-dark: #0f172a;
-		--color-surface-dark: #1e293b;
-		--color-text-dark: #f8fafc;
-		--color-text-muted-dark: #94a3b8;
-		--color-border-dark: #334155;
-		--color-danger-dark: #f87171;
-		--color-danger-hover-dark: #ef4444;
-		--color-on-danger-dark: #450a0a;
-
-		/* Typography */
+		--color-danger-surface: #fee2e2;
 		--font-family: system-ui, sans-serif;
 		--font-size-xs: 0.75rem;
 		--font-size-sm: 0.875rem;
 		--font-size-base: 1rem;
 		--font-size-lg: 1.25rem;
 		--font-size-xl: 2rem;
-		--font-size-2xl: 3rem;
-		--font-weight-normal: 400;
+		--font-size-2xl: 2.75rem;
 		--font-weight-medium: 500;
 		--font-weight-semibold: 600;
 		--font-weight-bold: 700;
-
-		/* Spacing */
 		--spacing-xs: 0.25rem;
 		--spacing-sm: 0.5rem;
 		--spacing-md: 1rem;
 		--spacing-lg: 1.5rem;
 		--spacing-xl: 2rem;
 		--spacing-2xl: 3rem;
-
-		/* Border radius */
 		--radius-sm: 0.25rem;
 		--radius-md: 0.5rem;
 		--radius-lg: 0.75rem;
 		--radius-xl: 1rem;
 		--radius-full: 999px;
-
-		/* Shadows */
-		--shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-		--shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1),
-			0 2px 4px -2px rgb(0 0 0 / 0.1);
-		--shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1),
-			0 4px 6px -4px rgb(0 0 0 / 0.1);
-		--shadow-sm-dark: 0 1px 2px 0 rgb(255 255 255 / 0.05);
-		--shadow-md-dark: 0 4px 6px -1px rgb(255 255 255 / 0.08),
-			0 2px 4px -2px rgb(255 255 255 / 0.08);
-		--shadow-lg-dark: 0 10px 15px -3px rgb(255 255 255 / 0.1),
-			0 4px 6px -4px rgb(255 255 255 / 0.1);
-
-		/* Transitions */
-		--transition-fast: 0.15s ease;
-		--transition-normal: 0.2s ease;
-
-		/* Responsive spacing - used for page-level padding */
-		--spacing-page: var(--spacing-2xl);
-		--spacing-section: var(--spacing-xl);
-		--spacing-header: var(--spacing-xl);
-	}
-
-	@media (max-width: 1024px) {
-		:root {
-			--spacing-page: var(--spacing-xl);
-			--spacing-section: var(--spacing-lg);
-			--spacing-header: var(--spacing-lg);
-		}
-	}
-
-	@media (max-width: 640px) {
-		:root {
-			--spacing-page: var(--spacing-md);
-			--spacing-section: var(--spacing-md);
-			--spacing-header: var(--spacing-md);
-			--font-size-xl: 1.5rem;
-			--font-size-2xl: 2rem;
-		}
+		--shadow-sm: 0 1px 2px 0 rgb(15 23 42 / 0.06);
+		--shadow-md: 0 18px 40px -24px rgb(15 23 42 / 0.35);
 	}
 
 	@media (prefers-color-scheme: dark) {
 		:root {
-			--color-primary: var(--color-primary-dark);
-			--color-primary-hover: var(--color-primary-hover-dark);
-			--color-primary-active: var(--color-primary-active-dark);
-			--color-on-primary: var(--color-on-primary-dark);
-			--color-primary-text: var(--color-primary-text-dark);
-			--color-background: var(--color-background-dark);
-			--color-surface: var(--color-surface-dark);
-			--color-text: var(--color-text-dark);
-			--color-text-muted: var(--color-text-muted-dark);
-			--color-border: var(--color-border-dark);
-			--color-danger: var(--color-danger-dark);
-			--color-danger-hover: var(--color-danger-hover-dark);
-			--color-on-danger: var(--color-on-danger-dark);
-			--shadow-sm: var(--shadow-sm-dark);
-			--shadow-md: var(--shadow-md-dark);
-			--shadow-lg: var(--shadow-lg-dark);
+			--color-primary: #60a5fa;
+			--color-primary-hover: #93c5fd;
+			--color-primary-active: #bfdbfe;
+			--color-on-primary: #0f172a;
+			--color-primary-text: #93c5fd;
+			--color-background: #020617;
+			--color-surface: #0f172a;
+			--color-surface-muted: #111c31;
+			--color-text: #f8fafc;
+			--color-text-muted: #94a3b8;
+			--color-border: #23304a;
+			--color-success: #4ade80;
+			--color-success-surface: rgb(34 197 94 / 0.12);
+			--color-warning: #fbbf24;
+			--color-warning-surface: rgb(251 191 36 / 0.12);
+			--color-danger: #f87171;
+			--color-danger-surface: rgb(248 113 113 / 0.12);
+			--shadow-sm: 0 1px 2px 0 rgb(2 6 23 / 0.45);
+			--shadow-md: 0 18px 40px -24px rgb(2 6 23 / 0.9);
+		}
+	}
+
+	@media (max-width: 1024px) {
+		:root {
+			--font-size-xl: 1.75rem;
+			--font-size-2xl: 2.25rem;
+		}
+	}
+
+	@media (max-width: 800px) {
+		.layout-shell {
+			grid-template-columns: 1fr !important;
+		}
+
+		.sidebar {
+			position: static !important;
+			border-right: none !important;
+			border-bottom: 1px solid var(--color-border);
 		}
 	}
 
@@ -136,41 +222,38 @@ const styles = `
 	body {
 		margin: 0;
 		min-height: 100vh;
-		padding: var(--spacing-page);
 		font-family: var(--font-family);
 		font-size: var(--font-size-base);
 		line-height: 1.5;
 		color: var(--color-text);
-		background: var(--color-background);
-		transition:
-			background-color var(--transition-normal),
-			color var(--transition-normal);
-	}
-
-	main {
-		width: min(100%, 60rem);
-		margin: 0 auto;
-		display: grid;
-		gap: var(--spacing-lg);
+		background:
+			radial-gradient(circle at top left, rgb(37 99 235 / 0.08), transparent 28%),
+			var(--color-background);
 	}
 
 	h1,
-	h2 {
+	h2,
+	h3 {
 		margin: 0;
+		line-height: 1.15;
 		color: var(--color-text);
-		line-height: 1.2;
 	}
 
 	h1 {
-		font-size: var(--font-size-xl);
+		font-size: var(--font-size-2xl);
 	}
 
 	h2 {
 		font-size: var(--font-size-lg);
 	}
 
+	h3 {
+		font-size: 1rem;
+	}
+
 	p,
-	ul {
+	ul,
+	ol {
 		margin: 0;
 	}
 
@@ -194,63 +277,194 @@ const styles = `
 		font-weight: var(--font-weight-semibold);
 		cursor: pointer;
 		transition:
-			background-color var(--transition-fast),
-			border-color var(--transition-fast);
+			background-color 0.15s ease,
+			border-color 0.15s ease,
+			transform 0.15s ease;
 	}
 
 	button:hover {
 		background: var(--color-primary-hover);
 		border-color: var(--color-primary-hover);
+		transform: translateY(-1px);
 	}
 
 	button:active {
 		background: var(--color-primary-active);
 		border-color: var(--color-primary-active);
+		transform: translateY(0);
+	}
+
+	input,
+	select,
+	textarea {
+		font: inherit;
 	}
 
 	code,
 	pre {
 		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-			"Liberation Mono", "Courier New", monospace;
+			'Liberation Mono', 'Courier New', monospace;
 	}
 
 	code {
 		padding: 0.125rem 0.375rem;
 		border-radius: var(--radius-sm);
 		border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
-		background: color-mix(in srgb, var(--color-surface) 82%, transparent);
+		background: color-mix(in srgb, var(--color-surface-muted) 88%, transparent);
 	}
 
-	.app-shell,
-	.stack {
+	pre {
+		margin: 0;
+		padding: var(--spacing-md);
+		overflow: auto;
+		border-radius: var(--radius-lg);
+		border: 1px solid var(--color-border);
+		background: color-mix(in srgb, var(--color-surface-muted) 88%, transparent);
+	}
+
+	.layout-shell {
 		display: grid;
-		gap: var(--spacing-lg);
+		grid-template-columns: minmax(16rem, 18rem) minmax(0, 1fr);
+		min-height: 100vh;
 	}
 
-	.page-header {
+	.sidebar {
+		position: sticky;
+		top: 0;
+		align-self: start;
+		height: 100vh;
+		padding: var(--spacing-xl);
+		display: grid;
+		align-content: start;
+		gap: var(--spacing-xl);
+		border-right: 1px solid var(--color-border);
+		background: color-mix(in srgb, var(--color-surface) 78%, transparent);
+		backdrop-filter: blur(20px);
+	}
+
+	.sidebar-brand {
 		display: grid;
 		gap: var(--spacing-sm);
 	}
 
-	.card {
+	.sidebar-brand-title {
+		font-size: 1.1rem;
+		font-weight: var(--font-weight-bold);
+	}
+
+	.sidebar-brand-copy {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-sm);
+	}
+
+	.nav-section {
 		display: grid;
-		gap: var(--spacing-md);
-		align-content: start;
-		padding: var(--spacing-lg);
-		background: var(--color-surface);
-		border: 1px solid var(--color-border);
+		gap: var(--spacing-sm);
+	}
+
+	.nav-section-title {
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-bold);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--color-text-muted);
+	}
+
+	.nav-list {
+		list-style: none;
+		padding: 0;
+		display: grid;
+		gap: var(--spacing-xs);
+	}
+
+	.nav-link {
+		display: grid;
+		gap: 0.1rem;
+		padding: 0.75rem 0.875rem;
 		border-radius: var(--radius-lg);
+		text-decoration: none;
+		border: 1px solid transparent;
+		color: inherit;
+		background: transparent;
+	}
+
+	.nav-link:hover {
+		background: color-mix(in srgb, var(--color-surface-muted) 80%, transparent);
+		border-color: color-mix(in srgb, var(--color-border) 65%, transparent);
+		color: inherit;
+	}
+
+	.nav-link-active {
+		background: color-mix(in srgb, var(--color-primary) 10%, var(--color-surface));
+		border-color: color-mix(in srgb, var(--color-primary) 45%, var(--color-border));
+		box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary) 30%, transparent);
+	}
+
+	.nav-link-label {
+		font-weight: var(--font-weight-semibold);
+	}
+
+	.nav-link-description {
+		font-size: var(--font-size-sm);
+		color: var(--color-text-muted);
+	}
+
+	.layout-main {
+		min-width: 0;
+		padding: var(--spacing-xl);
+	}
+
+	.page {
+		width: min(100%, 92rem);
+		margin: 0 auto;
+		display: grid;
+		gap: var(--spacing-lg);
+	}
+
+	.app-shell,
+	.stack,
+	.page-header,
+	.page-intro,
+	.section-stack {
+		display: grid;
+		gap: var(--spacing-lg);
+	}
+
+	.page-intro {
+		padding: clamp(1.25rem, 1.5vw, 1.75rem);
+		border-radius: var(--radius-xl);
+		border: 1px solid color-mix(in srgb, var(--color-primary) 20%, var(--color-border));
+		background:
+			linear-gradient(
+				135deg,
+				color-mix(in srgb, var(--color-primary) 11%, var(--color-surface)),
+				var(--color-surface)
+			);
 		box-shadow: var(--shadow-md);
 	}
 
-	.card-success {
-		border-color: color-mix(in srgb, var(--color-primary) 45%, var(--color-border));
+	.page-eyebrow {
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-bold);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--color-primary-text);
 	}
 
-	.card-error {
-		border-color: var(--color-danger);
+	.title-row,
+	.card-heading,
+	.summary-card-heading,
+	.split-row {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: var(--spacing-sm);
 	}
 
+	.card-grid,
+	.metric-grid,
+	.action-grid,
 	.status-grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
@@ -258,9 +472,167 @@ const styles = `
 		align-items: start;
 	}
 
-	.status-grid > *,
-	.card > * {
+	.metric-grid {
+		grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+	}
+
+	.card {
+		display: grid;
+		gap: var(--spacing-md);
+		align-content: start;
+		padding: var(--spacing-lg);
+		background: color-mix(in srgb, var(--color-surface) 88%, transparent);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-xl);
+		box-shadow: var(--shadow-sm);
 		min-width: 0;
+	}
+
+	.card-success {
+		border-color: color-mix(in srgb, var(--color-success) 40%, var(--color-border));
+		background: color-mix(in srgb, var(--color-success-surface) 55%, var(--color-surface));
+	}
+
+	.card-error {
+		border-color: color-mix(in srgb, var(--color-danger) 55%, var(--color-border));
+		background: color-mix(in srgb, var(--color-danger-surface) 52%, var(--color-surface));
+	}
+
+	.metric-card,
+	.action-card,
+	.summary-card {
+		display: grid;
+		gap: var(--spacing-sm);
+		padding: var(--spacing-lg);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-xl);
+		background: color-mix(in srgb, var(--color-surface) 88%, transparent);
+		box-shadow: var(--shadow-sm);
+		min-width: 0;
+	}
+
+	.metric-card[data-tone='good'],
+	.summary-card[data-tone='good'] {
+		border-color: color-mix(in srgb, var(--color-success) 45%, var(--color-border));
+	}
+
+	.metric-card[data-tone='warn'],
+	.summary-card[data-tone='warn'] {
+		border-color: color-mix(in srgb, var(--color-warning) 45%, var(--color-border));
+	}
+
+	.metric-card[data-tone='bad'],
+	.summary-card[data-tone='bad'] {
+		border-color: color-mix(in srgb, var(--color-danger) 52%, var(--color-border));
+	}
+
+	.metric-label,
+	.summary-metric-label {
+		font-size: var(--font-size-sm);
+		color: var(--color-text-muted);
+	}
+
+	.metric-value {
+		font-size: 1.8rem;
+		font-weight: var(--font-weight-bold);
+		line-height: 1;
+	}
+
+	.metric-detail,
+	.summary-card-copy,
+	.summary-card-note,
+	.action-card-description {
+		font-size: var(--font-size-sm);
+		color: var(--color-text-muted);
+	}
+
+	.status-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: fit-content;
+		padding: 0.25rem 0.65rem;
+		border-radius: var(--radius-full);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-bold);
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		border: 1px solid transparent;
+	}
+
+	.status-badge-good {
+		color: var(--color-success);
+		background: color-mix(in srgb, var(--color-success-surface) 80%, var(--color-surface));
+		border-color: color-mix(in srgb, var(--color-success) 35%, transparent);
+	}
+
+	.status-badge-warn {
+		color: var(--color-warning);
+		background: color-mix(in srgb, var(--color-warning-surface) 82%, var(--color-surface));
+		border-color: color-mix(in srgb, var(--color-warning) 35%, transparent);
+	}
+
+	.status-badge-bad {
+		color: var(--color-danger);
+		background: color-mix(in srgb, var(--color-danger-surface) 80%, var(--color-surface));
+		border-color: color-mix(in srgb, var(--color-danger) 35%, transparent);
+	}
+
+	.status-badge-neutral {
+		color: var(--color-text-muted);
+		background: color-mix(in srgb, var(--color-surface-muted) 84%, var(--color-surface));
+		border-color: color-mix(in srgb, var(--color-border) 75%, transparent);
+	}
+
+	.summary-card-metrics {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(7.5rem, 1fr));
+		gap: var(--spacing-sm);
+	}
+
+	.summary-card-metric {
+		display: grid;
+		gap: 0.15rem;
+		padding: 0.75rem;
+		border-radius: var(--radius-lg);
+		background: color-mix(in srgb, var(--color-surface-muted) 80%, transparent);
+	}
+
+	.summary-metric-value {
+		font-weight: var(--font-weight-bold);
+	}
+
+	.inline-links {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--spacing-sm);
+	}
+
+	.inline-link {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--spacing-xs);
+		padding: 0.5rem 0.75rem;
+		border-radius: var(--radius-full);
+		border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
+		background: color-mix(in srgb, var(--color-surface-muted) 78%, transparent);
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.inline-link:hover {
+		border-color: color-mix(in srgb, var(--color-primary) 45%, var(--color-border));
+		color: inherit;
+	}
+
+	.action-card {
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.action-card:hover {
+		border-color: color-mix(in srgb, var(--color-primary) 40%, var(--color-border));
+		transform: translateY(-1px);
 	}
 
 	.info-list {
@@ -289,11 +661,13 @@ const styles = `
 		word-break: break-word;
 	}
 
-	.list {
+	.list,
+	.compact-list {
 		padding-left: 1.25rem;
 	}
 
-	.list li + li {
+	.list li + li,
+	.compact-list li + li {
 		margin-top: var(--spacing-sm);
 	}
 
@@ -304,7 +678,7 @@ const styles = `
 	.field-stack {
 		display: grid;
 		gap: var(--spacing-md);
-		max-width: 36rem;
+		max-width: 42rem;
 	}
 
 	.field-stack label {
@@ -316,11 +690,10 @@ const styles = `
 	.field-stack input,
 	.field-stack select,
 	.field-stack textarea {
-		font: inherit;
 		padding: var(--spacing-sm) var(--spacing-md);
 		border-radius: var(--radius-md);
 		border: 1px solid var(--color-border);
-		background: var(--color-background);
+		background: color-mix(in srgb, var(--color-surface) 86%, transparent);
 		color: var(--color-text);
 	}
 
@@ -335,11 +708,39 @@ const styles = `
 		gap: var(--spacing-sm);
 		align-items: center;
 	}
+
+	.empty-state {
+		padding: var(--spacing-lg);
+		border-radius: var(--radius-lg);
+		border: 1px dashed color-mix(in srgb, var(--color-border) 85%, transparent);
+		color: var(--color-text-muted);
+		background: color-mix(in srgb, var(--color-surface-muted) 68%, transparent);
+	}
+
+	.data-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: var(--font-size-sm);
+	}
+
+	.data-table th,
+	.data-table td {
+		padding: 0.75rem;
+		text-align: left;
+		vertical-align: top;
+		border-bottom: 1px solid color-mix(in srgb, var(--color-border) 75%, transparent);
+	}
+
+	.data-table th {
+		color: var(--color-text-muted);
+		font-weight: var(--font-weight-semibold);
+	}
 `
 
 export function RootLayout(input: {
 	title: string
 	body: ReturnType<typeof html>
+	currentPath?: string
 }) {
 	return html`<html lang="en">
 		<head>
@@ -351,7 +752,22 @@ export function RootLayout(input: {
 			</style>
 		</head>
 		<body>
-			<main>${input.body}</main>
+			<div class="layout-shell">
+				<aside class="sidebar">
+					<section class="sidebar-brand">
+						<div class="page-eyebrow">Local admin</div>
+						<div class="sidebar-brand-title">home connector</div>
+						<p class="sidebar-brand-copy">
+							Operational dashboard and diagnostics for the connector running on
+							this machine.
+						</p>
+					</section>
+					<nav aria-label="Primary">${renderNavigation(input.currentPath)}</nav>
+				</aside>
+				<div class="layout-main">
+					<main class="page">${input.body}</main>
+				</div>
+			</div>
 		</body>
 	</html>`
 }

--- a/packages/home-connector/app/router.node.test.ts
+++ b/packages/home-connector/app/router.node.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { expect, test } from 'vitest'
 import { installHomeConnectorMockServer } from '../mocks/test-server.ts'
 import { createBondAdapter } from '../src/adapters/bond/index.ts'
+import { createIslandRouterAdapter } from '../src/adapters/island-router/index.ts'
 import { createJellyfishAdapter } from '../src/adapters/jellyfish/index.ts'
 import { createLutronAdapter } from '../src/adapters/lutron/index.ts'
 import { createSamsungTvAdapter } from '../src/adapters/samsung-tv/index.ts'
@@ -22,6 +23,13 @@ function createConfig(dataPath = '/tmp'): HomeConnectorConfig {
 		workerSessionUrl: 'http://localhost:3742/home/connectors/default',
 		workerWebSocketUrl: 'ws://localhost:3742/home/connectors/default',
 		sharedSecret: 'secret',
+		islandRouterHost: null,
+		islandRouterPort: 22,
+		islandRouterUsername: null,
+		islandRouterPrivateKeyPath: null,
+		islandRouterKnownHostsPath: null,
+		islandRouterHostFingerprint: null,
+		islandRouterCommandTimeoutMs: 8000,
 		rokuDiscoveryUrl: 'http://roku.mock.local/discovery',
 		lutronDiscoveryUrl: 'http://lutron.mock.local/discovery',
 		sonosDiscoveryUrl: 'http://sonos.mock.local/discovery',
@@ -69,6 +77,9 @@ function createAdapters(config: HomeConnectorConfig) {
 			state,
 			storage,
 		}),
+		islandRouter: createIslandRouterAdapter({
+			config,
+		}),
 		jellyfish: createJellyfishAdapter({
 			config,
 			state,
@@ -86,8 +97,17 @@ function createTemporaryDataPath() {
 
 test('home route toggles worker snapshot link by connector id', async () => {
 	const config = createConfig()
-	const { state, storage, lutron, sonos, samsungTv, bond, jellyfish, venstar } =
-		createAdapters(config)
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		islandRouter,
+		jellyfish,
+		venstar,
+	} = createAdapters(config)
 	state.connection.connectorId = 'default'
 	state.connection.workerUrl = 'http://localhost:3742'
 	try {
@@ -98,6 +118,7 @@ test('home route toggles worker snapshot link by connector id', async () => {
 			samsungTv,
 			sonos,
 			bond,
+			islandRouter,
 			jellyfish,
 			venstar,
 		)
@@ -113,6 +134,8 @@ test('home route toggles worker snapshot link by connector id', async () => {
 		expect(htmlWithoutConnector).not.toContain(
 			'/home/connectors/default/snapshot',
 		)
+		expect(htmlWithConnector).toContain('Home connector dashboard')
+		expect(htmlWithConnector).toContain('Island router diagnostics')
 	} finally {
 		storage.close()
 	}
@@ -120,8 +143,17 @@ test('home route toggles worker snapshot link by connector id', async () => {
 
 test('venstar status scan shows discovered thermostats', async () => {
 	const config = createConfig()
-	const { state, storage, lutron, sonos, samsungTv, bond, jellyfish, venstar } =
-		createAdapters(config)
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		islandRouter,
+		jellyfish,
+		venstar,
+	} = createAdapters(config)
 	try {
 		const router = createHomeConnectorRouter(
 			state,
@@ -130,6 +162,7 @@ test('venstar status scan shows discovered thermostats', async () => {
 			samsungTv,
 			sonos,
 			bond,
+			islandRouter,
 			jellyfish,
 			venstar,
 		)
@@ -158,8 +191,17 @@ test('venstar status scan shows discovered thermostats', async () => {
 test('venstar status can adopt a discovered thermostat', async () => {
 	const dataPath = createTemporaryDataPath()
 	const config = createConfig(dataPath)
-	const { state, storage, lutron, sonos, samsungTv, bond, jellyfish, venstar } =
-		createAdapters(config)
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		islandRouter,
+		jellyfish,
+		venstar,
+	} = createAdapters(config)
 	try {
 		const router = createHomeConnectorRouter(
 			state,
@@ -168,6 +210,7 @@ test('venstar status can adopt a discovered thermostat', async () => {
 			samsungTv,
 			sonos,
 			bond,
+			islandRouter,
 			jellyfish,
 			venstar,
 		)
@@ -215,8 +258,17 @@ test('venstar status can adopt a discovered thermostat', async () => {
 test('venstar setup can save and remove thermostats directly', async () => {
 	const dataPath = createTemporaryDataPath()
 	const config = createConfig(dataPath)
-	const { state, storage, lutron, sonos, samsungTv, bond, jellyfish, venstar } =
-		createAdapters(config)
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		islandRouter,
+		jellyfish,
+		venstar,
+	} = createAdapters(config)
 	try {
 		venstar.removeThermostat('venstar.mock.local')
 		const router = createHomeConnectorRouter(
@@ -226,6 +278,7 @@ test('venstar setup can save and remove thermostats directly', async () => {
 			samsungTv,
 			sonos,
 			bond,
+			islandRouter,
 			jellyfish,
 			venstar,
 		)
@@ -274,8 +327,17 @@ test('venstar setup can save and remove thermostats directly', async () => {
 
 test('health route returns ok json', async () => {
 	const config = createConfig()
-	const { state, storage, lutron, sonos, samsungTv, bond, jellyfish, venstar } =
-		createAdapters(config)
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		islandRouter,
+		jellyfish,
+		venstar,
+	} = createAdapters(config)
 	try {
 		const router = createHomeConnectorRouter(
 			state,
@@ -284,6 +346,7 @@ test('health route returns ok json', async () => {
 			samsungTv,
 			sonos,
 			bond,
+			islandRouter,
 			jellyfish,
 			venstar,
 		)
@@ -294,6 +357,96 @@ test('health route returns ok json', async () => {
 			service: 'home-connector',
 			connectorId: '',
 		})
+	} finally {
+		storage.close()
+	}
+})
+
+test('system and diagnostics routes render aggregated admin surfaces', async () => {
+	const config = createConfig()
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		islandRouter,
+		jellyfish,
+		venstar,
+	} = createAdapters(config)
+	state.connection.connectorId = 'default'
+	state.connection.workerUrl = 'http://localhost:3742'
+	state.connection.connected = true
+	state.connection.lastSyncAt = '2026-05-02T22:47:00.000Z'
+	try {
+		const router = createHomeConnectorRouter(
+			state,
+			config,
+			lutron,
+			samsungTv,
+			sonos,
+			bond,
+			islandRouter,
+			jellyfish,
+			venstar,
+		)
+		const systemResponse = await router.fetch(
+			'http://example.test/system-status',
+		)
+		expect(systemResponse.status).toBe(200)
+		const systemHtml = await systemResponse.text()
+		expect(systemHtml).toContain('System status')
+		expect(systemHtml).toContain('Connector identity')
+		expect(systemHtml).toContain('Island router readiness')
+
+		const diagnosticsResponse = await router.fetch(
+			'http://example.test/diagnostics',
+		)
+		expect(diagnosticsResponse.status).toBe(200)
+		const diagnosticsHtml = await diagnosticsResponse.text()
+		expect(diagnosticsHtml).toContain('Diagnostics overview')
+		expect(diagnosticsHtml).toContain('Diagnostics matrix')
+		expect(diagnosticsHtml).toContain('Island router')
+	} finally {
+		storage.close()
+	}
+})
+
+test('island router status route renders configuration details and host diagnosis errors', async () => {
+	const config = createConfig()
+	const {
+		state,
+		storage,
+		lutron,
+		sonos,
+		samsungTv,
+		bond,
+		islandRouter,
+		jellyfish,
+		venstar,
+	} = createAdapters(config)
+	try {
+		const router = createHomeConnectorRouter(
+			state,
+			config,
+			lutron,
+			samsungTv,
+			sonos,
+			bond,
+			islandRouter,
+			jellyfish,
+			venstar,
+		)
+		const response = await router.fetch(
+			'http://example.test/island-router/status?host=192.168.1.10',
+		)
+		expect(response.status).toBe(200)
+		const pageHtml = await response.text()
+		expect(pageHtml).toContain('Island router status')
+		expect(pageHtml).toContain('SSH configuration')
+		expect(pageHtml).toContain('Host diagnosis')
+		expect(pageHtml).toContain('Host diagnosis failed')
 	} finally {
 		storage.close()
 	}

--- a/packages/home-connector/app/router.node.test.ts
+++ b/packages/home-connector/app/router.node.test.ts
@@ -379,6 +379,7 @@ test('system and diagnostics routes render aggregated admin surfaces', async () 
 	state.connection.workerUrl = 'http://localhost:3742'
 	state.connection.connected = true
 	state.connection.lastSyncAt = '2026-05-02T22:47:00.000Z'
+	state.connection.sharedSecret = 'top-secret-value'
 	try {
 		const router = createHomeConnectorRouter(
 			state,
@@ -408,6 +409,10 @@ test('system and diagnostics routes render aggregated admin surfaces', async () 
 		expect(diagnosticsHtml).toContain('Diagnostics overview')
 		expect(diagnosticsHtml).toContain('Diagnostics matrix')
 		expect(diagnosticsHtml).toContain('Island router')
+		expect(diagnosticsHtml).toContain(
+			'&quot;sharedSecret&quot;: &quot;configured&quot;',
+		)
+		expect(diagnosticsHtml).not.toContain('top-secret-value')
 	} finally {
 		storage.close()
 	}

--- a/packages/home-connector/app/router.ts
+++ b/packages/home-connector/app/router.ts
@@ -1,6 +1,5 @@
 import { createRouter } from 'remix/fetch-router'
 import {
-	createHomeDashboardHandler,
 	createHealthHandler,
 	createLutronSetupHandler,
 	createLutronStatusHandler,
@@ -9,6 +8,12 @@ import {
 	createSamsungTvSetupHandler,
 	createSamsungTvStatusHandler,
 } from './handlers.ts'
+import {
+	createDashboardHandler,
+	createDiagnosticsHandler,
+	createIslandRouterStatusHandler,
+	createSystemStatusHandler,
+} from './dashboard-handlers.ts'
 import {
 	createBondSetupHandler,
 	createBondStatusHandler,
@@ -34,6 +39,7 @@ import { type createSamsungTvAdapter } from '../src/adapters/samsung-tv/index.ts
 import { type createVenstarAdapter } from '../src/adapters/venstar/index.ts'
 import { type HomeConnectorConfig } from '../src/config.ts'
 import { type HomeConnectorState } from '../src/state.ts'
+import { type createIslandRouterAdapter } from '../src/adapters/island-router/index.ts'
 
 export function createHomeConnectorRouter(
 	state: HomeConnectorState,
@@ -42,6 +48,7 @@ export function createHomeConnectorRouter(
 	samsungTv: ReturnType<typeof createSamsungTvAdapter>,
 	sonos: ReturnType<typeof createSonosAdapter>,
 	bond: ReturnType<typeof createBondAdapter>,
+	islandRouter: ReturnType<typeof createIslandRouterAdapter>,
 	jellyfish: ReturnType<typeof createJellyfishAdapter>,
 	venstar: ReturnType<typeof createVenstarAdapter>,
 ) {
@@ -51,15 +58,50 @@ export function createHomeConnectorRouter(
 
 	router.map(routes, {
 		actions: {
-			home: createHomeDashboardHandler(
+			home: createDashboardHandler({
 				state,
+				config,
 				lutron,
 				samsungTv,
 				sonos,
 				bond,
+				islandRouter,
 				jellyfish,
 				venstar,
-			),
+			}),
+			systemStatus: createSystemStatusHandler({
+				state,
+				config,
+				lutron,
+				samsungTv,
+				sonos,
+				bond,
+				islandRouter,
+				jellyfish,
+				venstar,
+			}),
+			diagnostics: createDiagnosticsHandler({
+				state,
+				config,
+				lutron,
+				samsungTv,
+				sonos,
+				bond,
+				islandRouter,
+				jellyfish,
+				venstar,
+			}),
+			islandRouterStatus: createIslandRouterStatusHandler({
+				state,
+				config,
+				lutron,
+				samsungTv,
+				sonos,
+				bond,
+				islandRouter,
+				jellyfish,
+				venstar,
+			}),
 			health: createHealthHandler(state),
 			lutronStatus: createLutronStatusHandler(state, lutron),
 			lutronSetup: createLutronSetupHandler(state, lutron),

--- a/packages/home-connector/app/routes.ts
+++ b/packages/home-connector/app/routes.ts
@@ -2,6 +2,9 @@ import { route } from 'remix/fetch-router/routes'
 
 export const routes = route({
 	home: '/',
+	systemStatus: '/system-status',
+	diagnostics: '/diagnostics',
+	islandRouterStatus: '/island-router/status',
 	health: '/health',
 	rokuStatus: '/roku/status',
 	rokuSetup: '/roku/setup',

--- a/packages/home-connector/server/index.ts
+++ b/packages/home-connector/server/index.ts
@@ -71,7 +71,7 @@ function installGracefulShutdownHandlers(input: {
 		})
 	})
 
-	process.once('unhandledRejection', (reason, promise) => {
+	process.once('unhandledRejection', (reason, _promise) => {
 		captureHomeConnectorException(reason, {
 			tags: {
 				area: 'process',
@@ -104,6 +104,7 @@ async function main() {
 		connector.samsungTv,
 		connector.sonos,
 		connector.bond,
+		connector.islandRouter,
 		connector.jellyfish,
 		connector.venstar,
 	)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the old home-connector local admin landing page with a richer dashboard and shared admin layout
- add drill-down pages for system status, diagnostics, and Island router state/host diagnosis
- surface clearer quick-look status badges, counts, grouped navigation, and focused router tests for the new routes

## Testing
- `npm --prefix packages/home-connector test`
- `npx oxfmt --check packages/home-connector/app/root.ts packages/home-connector/app/router.node.test.ts packages/home-connector/app/router.ts packages/home-connector/app/routes.ts packages/home-connector/server/index.ts packages/home-connector/app/admin-ui.ts packages/home-connector/app/dashboard-handlers.ts`
- `npx oxlint packages/home-connector/app/root.ts packages/home-connector/app/router.node.test.ts packages/home-connector/app/router.ts packages/home-connector/app/routes.ts packages/home-connector/server/index.ts packages/home-connector/app/admin-ui.ts packages/home-connector/app/dashboard-handlers.ts`
- live Playwright walkthrough against `http://127.0.0.1:4040/`

## Walkthrough
![Home connector dashboard](https://cursor.com/artifacts/c/art-1cc423e0-b73a-4952-986f-dad1b3344874)

![Island router status page](https://cursor.com/artifacts/c/art-ef9f7afa-233f-4874-a394-1f8bcc08a190)

<a href="https://cursor.com/agents/bc-16154b83-421c-4fed-b77d-f85117d6f5f5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome-connector-dashboard-drill-down-demo.mp4"><img src="https://cursor.com/artifacts/c/art-9140737f-08c5-4f40-ab2d-030b8dcafec6" alt="home-connector-dashboard-drill-down-demo.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16154b83-421c-4fed-b77d-f85117d6f5f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16154b83-421c-4fed-b77d-f85117d6f5f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

