### PR TITLE
Add allowlisted Island router write tools

### DIFF
--- a/docs/contributing/architecture/home-connector.md
+++ b/docs/contributing/architecture/home-connector.md
@@ -31,7 +31,8 @@ The connector exposes these local-device families:
 - Samsung TV / Frame discovery and control over mDNS, REST, and local WebSocket
   channels
 - Venstar WiFi thermostat status and control over the local REST API
-- Island router diagnostics over SSH using a read-only command allowlist
+- Island router diagnostics over SSH using a typed command allowlist plus a
+  tiny opt-in set of high-risk write operations
 
 All surfaces are registered as MCP tools inside the connector and then exposed
 to the Worker through the existing outbound WebSocket session to
@@ -120,9 +121,13 @@ user flow aligned with the other managed device integrations.
 
 The Island router adapter lives under
 `packages/home-connector/src/adapters/island-router/` and intentionally limits
-itself to read-only SSH diagnostics from the connector host to the local
-router. It is designed for situations where Kody only has network reachability
-to the router from the NAS or other machine running the home connector.
+itself to typed allowlisted SSH operations from the connector host to the local
+router. The default posture is read-only diagnostics. A tiny set of mutating
+operations is available only when the connector runtime explicitly opts in, SSH
+host verification is configured, and the caller supplies strict per-operation
+acknowledgements. It is designed for situations where Kody only has network
+reachability to the router from the NAS or other machine running the home
+connector.
 
 The adapter does expose:
 
@@ -134,13 +139,26 @@ The adapter does expose:
 - recent-event lookups with `show log`
 - a structured `router_diagnose_host` workflow that combines ping, ARP,
   reservation, interface, and log data for one host
+- a very small typed write allowlist for `clear dhcp-client`, `clear log`, and
+  `write memory` when `ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true` and all
+  write guardrails pass
 
 The adapter explicitly does not expose:
 
 - arbitrary shell or CLI command execution over MCP
-- any mutating router commands such as reboot, config edits, PoE control,
-  DHCP renewals, or bridge resets
+- broad or arbitrary mutating router commands such as reboot, config edits,
+  PoE control, bridge resets, factory reset, or network wipe operations
 - password-based auth flows through MCP
+
+The write-capable operations are intentionally hard to use because mistakes can
+have severe consequences. Agents must be highly certain before using them. The
+MCP surface requires:
+
+- explicit runtime opt-in (`ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true`)
+- SSH host verification via `known_hosts` or a pinned host fingerprint
+- typed tool-specific inputs instead of free-form CLI
+- an operator reason and an exact acknowledgement phrase per operation
+- destructive tool annotations and warning-heavy descriptions
 
 SSH transport is conservative:
 

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -235,6 +235,16 @@ Authoring guide for outbound WebSocket services:
   before opening the real session.
 - `ISLAND_ROUTER_COMMAND_TIMEOUT_MS` — optional connector env var. Default
   timeout for Island router SSH commands in milliseconds. Defaults to `8000`.
+- `ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS` — optional connector env var. Defaults
+  to unset/false. When set to `true`, the connector may expose a tiny, typed,
+  allowlisted set of high-risk mutating Island router tools such as renewing all
+  DHCP clients, clearing the in-memory log buffer, and saving the running
+  configuration. Enable this only when you intentionally want those operations,
+  never as a convenience default. The agent must be highly certain before using
+  them because mistakes can have severe consequences. Write operations also
+  require strict SSH host verification via `ISLAND_ROUTER_KNOWN_HOSTS_PATH` or
+  `ISLAND_ROUTER_HOST_FINGERPRINT`; they stay unavailable when verification is
+  disabled.
 
 ## Why Zod?
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -217,7 +217,7 @@ How to get/set each value:
     published Docker image)
   - `APP_COMMIT_SHA` is also baked into the published Docker image and used by
     the connector’s Sentry setup as the release identifier
-  - Island router SSH diagnostics (optional, read-only):
+  - Island router SSH diagnostics (optional, typed allowlist):
     - `HOME_CONNECTOR_ISLAND_ROUTER_HOST`
     - `HOME_CONNECTOR_ISLAND_ROUTER_PORT`
     - `HOME_CONNECTOR_ISLAND_ROUTER_USERNAME`
@@ -225,6 +225,9 @@ How to get/set each value:
     - `HOME_CONNECTOR_ISLAND_ROUTER_KNOWN_HOSTS_PATH` or
       `HOME_CONNECTOR_ISLAND_ROUTER_HOST_FINGERPRINT`
     - `HOME_CONNECTOR_ISLAND_ROUTER_COMMAND_TIMEOUT_MS`
+    - `HOME_CONNECTOR_ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS` (optional, defaults
+      to disabled; enables a tiny set of high-risk mutating router tools only
+      after explicit opt-in)
   - When enabling Island router diagnostics in Docker, mount the SSH private key
     (and optionally the known-hosts file) read-only into the container and point
     the env vars at those mounted paths.

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -90,12 +90,11 @@ Quick notes for getting a local kody environment running.
     `~/.kody/home-connector/home-connector.sqlite`. Override the directory with
     `HOME_CONNECTOR_DATA_PATH` or the full file path with
     `HOME_CONNECTOR_DB_PATH`.
-  - Island router SSH diagnostics are optional and read-only. Set
-    `ISLAND_ROUTER_HOST`, `ISLAND_ROUTER_USERNAME`, and
-    `ISLAND_ROUTER_PRIVATE_KEY_PATH` to enable the MCP tools
-    `router_get_status`, `router_ping_host`, `router_get_arp_entry`,
-    `router_get_dhcp_lease`, `router_get_recent_events`, and
-    `router_diagnose_host`.
+  - Island router SSH diagnostics are optional. Set `ISLAND_ROUTER_HOST`,
+    `ISLAND_ROUTER_USERNAME`, and `ISLAND_ROUTER_PRIVATE_KEY_PATH` to enable
+    the typed read-oriented MCP tools `router_get_status`,
+    `router_ping_host`, `router_get_arp_entry`, `router_get_dhcp_lease`,
+    `router_get_recent_events`, and `router_diagnose_host`.
   - Prefer mounting the private key read-only into the container or host
     runtime, for example `-v /path/to/id_ed25519:/run/secrets/island-router-key:ro`
     plus `HOME_CONNECTOR_ISLAND_ROUTER_PRIVATE_KEY_PATH=/run/secrets/island-router-key`
@@ -105,11 +104,19 @@ Quick notes for getting a local kody environment running.
   - For host verification, set either `ISLAND_ROUTER_KNOWN_HOSTS_PATH` (preferred)
     or `ISLAND_ROUTER_HOST_FINGERPRINT`. When neither is set, the connector still
     works but reports a warning because SSH host verification is disabled.
-  - The Island router integration intentionally does not expose arbitrary command
-    execution or mutating router operations over MCP. It only uses a typed
-    allowlist of read-only CLI commands for status, ping, ARP/neighbor cache,
-    DHCP reservation inspection, interface summaries/details, and recent log
-    lookups.
+  - The Island router integration intentionally does not expose arbitrary
+    command execution over MCP. It uses a typed allowlist of documented CLI
+    commands.
+  - High-risk Island router write tools are disabled by default. To expose the
+    allowlisted mutating tools `router_renew_dhcp_clients`,
+    `router_clear_log_buffer`, and `router_save_running_config`, set
+    `ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true` and configure SSH host
+    verification with `ISLAND_ROUTER_KNOWN_HOSTS_PATH` or
+    `ISLAND_ROUTER_HOST_FINGERPRINT`.
+  - These write tools exist for carefully scoped operational recovery only.
+    Their tool descriptions intentionally use strong language because mistakes
+    can disrupt connectivity, erase diagnostics, or persist a bad router state
+    with severe consequences. Agents must be highly certain before using them.
   - Local operational routes live at `/health`, `/roku/status`, `/roku/setup`,
     `/lutron/status`, `/lutron/setup`, `/samsung-tv/status`, and
     `/samsung-tv/setup`.

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -34,6 +34,10 @@ If Island router diagnostics tools are missing or return configuration errors,
 verify that the home connector runtime has `ISLAND_ROUTER_HOST`,
 `ISLAND_ROUTER_USERNAME`, and `ISLAND_ROUTER_PRIVATE_KEY_PATH` set, and prefer
 either `ISLAND_ROUTER_KNOWN_HOSTS_PATH` or `ISLAND_ROUTER_HOST_FINGERPRINT` for
-host verification. The connector only exposes read-only tools such as
-`router_get_status` and `router_diagnose_host`; it does not support arbitrary
-router command execution or configuration changes.
+host verification. The connector never exposes arbitrary router command
+execution. By default it exposes read-oriented tools such as
+`router_get_status` and `router_diagnose_host`. A few high-risk, typed,
+allowlisted write tools are available only when
+`ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true` and SSH host verification is
+configured. Those write tools require explicit risk acknowledgement and exact
+confirmation phrases because mistakes can have severe consequences.

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -44,6 +44,7 @@ function createConfig() {
 	process.env.ISLAND_ROUTER_HOST_FINGERPRINT =
 		'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12'
 	process.env.ISLAND_ROUTER_COMMAND_TIMEOUT_MS = '5000'
+	process.env.ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS = 'false'
 	process.env.VENSTAR_SCAN_CIDRS = '192.168.10.40/32'
 	return loadHomeConnectorConfig()
 }
@@ -192,6 +193,39 @@ function createFakeRunner() {
 					timedOut: false,
 					durationMs: 200,
 				}
+			case 'clear-dhcp-client':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'clear dhcp-client'],
+					stdout: 'DHCP client renewal requested.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 15,
+				}
+			case 'clear-log':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'clear log'],
+					stdout: 'Log buffer cleared.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 15,
+				}
+			case 'write-memory':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'write memory'],
+					stdout: 'Running configuration saved.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 15,
+				}
 			default: {
 				const _exhaustive: never = request
 				throw new Error(`Unhandled fake Island router request: ${String(_exhaustive)}`)
@@ -296,6 +330,112 @@ test('island router adapter marks malformed fingerprint config as not configured
 			expect.stringContaining('ISLAND_ROUTER_HOST_FINGERPRINT'),
 		]),
 	)
+})
+
+test('island router adapter exposes write capability status and runs typed write operations only when explicitly enabled', async () => {
+	using _env = withTemporaryEnv({})
+	createConfig()
+	process.env.ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS = 'true'
+	const config = loadHomeConnectorConfig()
+	const islandRouter = createIslandRouterAdapter({
+		config,
+		commandRunner: createFakeRunner(),
+	})
+
+	expect(islandRouter.getConfigStatus()).toMatchObject({
+		writeToolsEnabled: true,
+		writeCapabilitiesAvailable: true,
+	})
+
+	const renewResult = await islandRouter.renewDhcpClients({
+		acknowledgeHighRisk: true,
+		reason:
+			'The WAN DHCP lease is stale after an upstream change and must be renewed intentionally.',
+		confirmation: islandRouter.writeAcknowledgements.renewDhcpClients,
+	})
+	expect(renewResult).toMatchObject({
+		operationId: 'renew-dhcp-clients',
+		commandId: 'clear-dhcp-client',
+		commandLines: ['terminal length 0', 'clear dhcp-client'],
+	})
+
+	const clearLogResult = await islandRouter.clearLogBuffer({
+		acknowledgeHighRisk: true,
+		reason:
+			'The current in-memory log spam was already collected and must be cleared before reproducing the issue.',
+		confirmation: islandRouter.writeAcknowledgements.clearLogBuffer,
+	})
+	expect(clearLogResult).toMatchObject({
+		operationId: 'clear-log-buffer',
+		commandId: 'clear-log',
+		commandLines: ['terminal length 0', 'clear log'],
+	})
+
+	const saveConfigResult = await islandRouter.saveRunningConfig({
+		acknowledgeHighRisk: true,
+		reason:
+			'The intended network change was validated manually and now needs to be persisted across reboot.',
+		confirmation: islandRouter.writeAcknowledgements.saveRunningConfig,
+	})
+	expect(saveConfigResult).toMatchObject({
+		operationId: 'save-running-config',
+		commandId: 'write-memory',
+		commandLines: ['terminal length 0', 'write memory'],
+	})
+})
+
+test('island router adapter rejects write operations without explicit enablement and exact confirmation', async () => {
+	using _env = withTemporaryEnv({})
+	const config = createConfig()
+	const islandRouter = createIslandRouterAdapter({
+		config,
+		commandRunner: createFakeRunner(),
+	})
+
+	expect(islandRouter.getConfigStatus()).toMatchObject({
+		writeToolsEnabled: false,
+		writeCapabilitiesAvailable: false,
+	})
+
+	await expect(
+		islandRouter.renewDhcpClients({
+			acknowledgeHighRisk: true,
+			reason:
+				'The WAN DHCP lease is stale after an upstream change and must be renewed intentionally.',
+			confirmation: islandRouter.writeAcknowledgements.renewDhcpClients,
+		}),
+	).rejects.toThrow('ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true')
+
+	process.env.ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS = 'true'
+	const enabledConfig = loadHomeConnectorConfig()
+	const enabledIslandRouter = createIslandRouterAdapter({
+		config: enabledConfig,
+		commandRunner: createFakeRunner(),
+	})
+
+	await expect(
+		enabledIslandRouter.saveRunningConfig({
+			acknowledgeHighRisk: false,
+			reason:
+				'The intended network change was validated manually and now needs to be persisted across reboot.',
+			confirmation: enabledIslandRouter.writeAcknowledgements.saveRunningConfig,
+		}),
+	).rejects.toThrow('acknowledgeHighRisk=true')
+	await expect(
+		enabledIslandRouter.saveRunningConfig({
+			acknowledgeHighRisk: true,
+			reason: 'too short',
+			confirmation: enabledIslandRouter.writeAcknowledgements.saveRunningConfig,
+		}),
+	).rejects.toThrow('specific operator reason')
+	await expect(
+		enabledIslandRouter.saveRunningConfig({
+			acknowledgeHighRisk: true,
+			reason:
+				'The intended network change was validated manually and now needs to be persisted across reboot.',
+			confirmation: 'I think this is probably okay.',
+		}),
+	).rejects.toThrow('exact acknowledgement')
 })
 
 test('fallback interface summary parsing recognizes up and down link states', () => {

--- a/packages/home-connector/src/adapters/island-router/index.ts
+++ b/packages/home-connector/src/adapters/island-router/index.ts
@@ -7,6 +7,8 @@ import {
 	type IslandRouterInterfaceSummary,
 	type IslandRouterNeighborEntry,
 	type IslandRouterStatus,
+	type IslandRouterWriteOperationId,
+	type IslandRouterWriteOperationResult,
 } from './types.ts'
 import { createIslandRouterSshCommandRunner } from './ssh-client.ts'
 import {
@@ -23,6 +25,7 @@ import {
 } from './parsing.ts'
 import {
 	assertIslandRouterConfigured,
+	assertIslandRouterWriteConfigured,
 	getIslandRouterConfigStatus,
 	validateIslandRouterHost,
 } from './validation.ts'
@@ -48,6 +51,22 @@ type DiagnoseHostRequest = {
 	timeoutMs?: number
 	logLimit?: number
 }
+
+type WriteOperationRequest = {
+	timeoutMs?: number
+	acknowledgeHighRisk: boolean
+	reason: string
+	confirmation: string
+}
+
+const islandRouterWriteAcknowledgements = {
+	renewDhcpClients:
+		'I am highly certain renewing all Island router DHCP clients is necessary right now.',
+	clearLogBuffer:
+		'I am highly certain clearing the Island router log buffer is necessary right now.',
+	saveRunningConfig:
+		'I am highly certain saving the Island router running configuration is necessary right now.',
+} as const
 
 function normalizeLimit(value: number | undefined, fallback: number, max: number) {
 	if (value == null || !Number.isFinite(value)) return fallback
@@ -158,6 +177,72 @@ function dedupeRecentEvents(messages: Array<ReturnType<typeof parseIslandRouterR
 	})
 }
 
+function assertWriteAcknowledgement(
+	received: string,
+	expected: string,
+	operationLabel: string,
+) {
+	if (received.trim() !== expected) {
+		throw new Error(
+			`${operationLabel} requires the exact acknowledgement: "${expected}"`,
+		)
+	}
+}
+
+function assertWriteReason(reason: string, operationLabel: string) {
+	const trimmed = reason.trim()
+	if (trimmed.length < 20) {
+		throw new Error(
+			`${operationLabel} requires a specific operator reason of at least 20 characters.`,
+		)
+	}
+}
+
+async function runWriteOperation(input: {
+	config: HomeConnectorConfig
+	runner: IslandRouterCommandRunner
+	timeoutMs?: number
+	operationId: IslandRouterWriteOperationId
+	commandId: 'clear-dhcp-client' | 'clear-log' | 'write-memory'
+	message: string
+	acknowledgeHighRisk: boolean
+	reason: string
+	confirmation: string
+	expectedAcknowledgement: string
+}) {
+	assertIslandRouterWriteConfigured(input.config)
+	if (!input.acknowledgeHighRisk) {
+		throw new Error(
+			`${input.message} requires acknowledgeHighRisk=true because this is a high-risk mutating router operation.`,
+		)
+	}
+	assertWriteReason(input.reason, input.message)
+	assertWriteAcknowledgement(
+		input.confirmation,
+		input.expectedAcknowledgement,
+		input.message,
+	)
+	const timeoutMs = normalizeTimeoutMs(input.config, input.timeoutMs)
+	const result = ensureSuccessfulCommand(
+		await input.runner({
+			id: input.commandId,
+			timeoutMs,
+		}),
+		input.message,
+	)
+	return {
+		operationId: input.operationId,
+		commandId: input.commandId,
+		commandLines: result.commandLines,
+		stdout: result.stdout,
+		stderr: result.stderr,
+		exitCode: result.exitCode,
+		signal: result.signal,
+		timedOut: result.timedOut,
+		durationMs: result.durationMs,
+	} satisfies IslandRouterWriteOperationResult
+}
+
 export function createIslandRouterAdapter(input: {
 	config: HomeConnectorConfig
 	commandRunner?: IslandRouterCommandRunner
@@ -177,6 +262,7 @@ export function createIslandRouterAdapter(input: {
 
 	return {
 		getConfigStatus,
+		writeAcknowledgements: islandRouterWriteAcknowledgements,
 		async getStatus(): Promise<IslandRouterStatus> {
 			const configStatus = getConfigStatus()
 			if (!configStatus.configured) {
@@ -524,6 +610,51 @@ export function createIslandRouterAdapter(input: {
 				recentEvents,
 				errors,
 			}
+		},
+		async renewDhcpClients(request: WriteOperationRequest) {
+			return await runWriteOperation({
+				config,
+				runner: getRunner(),
+				timeoutMs: request.timeoutMs,
+				operationId: 'renew-dhcp-clients',
+				commandId: 'clear-dhcp-client',
+				message: 'Island router DHCP client renewal',
+				acknowledgeHighRisk: request.acknowledgeHighRisk,
+				reason: request.reason,
+				confirmation: request.confirmation,
+				expectedAcknowledgement:
+					islandRouterWriteAcknowledgements.renewDhcpClients,
+			})
+		},
+		async clearLogBuffer(request: WriteOperationRequest) {
+			return await runWriteOperation({
+				config,
+				runner: getRunner(),
+				timeoutMs: request.timeoutMs,
+				operationId: 'clear-log-buffer',
+				commandId: 'clear-log',
+				message: 'Island router log clear',
+				acknowledgeHighRisk: request.acknowledgeHighRisk,
+				reason: request.reason,
+				confirmation: request.confirmation,
+				expectedAcknowledgement:
+					islandRouterWriteAcknowledgements.clearLogBuffer,
+			})
+		},
+		async saveRunningConfig(request: WriteOperationRequest) {
+			return await runWriteOperation({
+				config,
+				runner: getRunner(),
+				timeoutMs: request.timeoutMs,
+				operationId: 'save-running-config',
+				commandId: 'write-memory',
+				message: 'Island router configuration save',
+				acknowledgeHighRisk: request.acknowledgeHighRisk,
+				reason: request.reason,
+				confirmation: request.confirmation,
+				expectedAcknowledgement:
+					islandRouterWriteAcknowledgements.saveRunningConfig,
+			})
 		},
 	}
 }

--- a/packages/home-connector/src/adapters/island-router/ssh-client.ts
+++ b/packages/home-connector/src/adapters/island-router/ssh-client.ts
@@ -274,6 +274,12 @@ function getCommandLines(request: IslandRouterCommandRequest): Array<string> {
 				: ['show log last']
 		case 'ping':
 			return [`ping ${assertSingleCliLine(request.host, 'host')}`]
+		case 'clear-dhcp-client':
+			return ['clear dhcp-client']
+		case 'clear-log':
+			return ['clear log']
+		case 'write-memory':
+			return ['write memory']
 		default: {
 			const _exhaustive: never = request
 			throw new Error(`Unhandled Island router command request: ${String(_exhaustive)}`)

--- a/packages/home-connector/src/adapters/island-router/types.ts
+++ b/packages/home-connector/src/adapters/island-router/types.ts
@@ -16,6 +16,9 @@ export type IslandRouterConfigStatus = {
 	missingFields: Array<string>
 	verificationMode: IslandRouterVerificationMode
 	warnings: Array<string>
+	writeToolsEnabled: boolean
+	writeCapabilitiesAvailable: boolean
+	writeWarnings: Array<string>
 }
 
 export type IslandRouterCommandId =
@@ -28,6 +31,9 @@ export type IslandRouterCommandId =
 	| 'show-ip-dhcp-reservations'
 	| 'show-log'
 	| 'ping'
+	| 'clear-dhcp-client'
+	| 'clear-log'
+	| 'write-memory'
 
 export type IslandRouterCommandRequest =
 	| {
@@ -71,6 +77,18 @@ export type IslandRouterCommandRequest =
 			timeoutMs?: number
 			allowTimeout?: boolean
 	  }
+	| {
+			id: 'clear-dhcp-client'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'clear-log'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'write-memory'
+			timeoutMs?: number
+	  }
 
 export type IslandRouterCommandResult = {
 	id: IslandRouterCommandId
@@ -86,6 +104,26 @@ export type IslandRouterCommandResult = {
 export type IslandRouterCommandRunner = (
 	request: IslandRouterCommandRequest,
 ) => Promise<IslandRouterCommandResult>
+
+export type IslandRouterWriteOperationId =
+	| 'renew-dhcp-clients'
+	| 'clear-log-buffer'
+	| 'save-running-config'
+
+export type IslandRouterWriteOperationResult = {
+	operationId: IslandRouterWriteOperationId
+	commandId: Extract<
+		IslandRouterCommandId,
+		'clear-dhcp-client' | 'clear-log' | 'write-memory'
+	>
+	commandLines: Array<string>
+	stdout: string
+	stderr: string
+	exitCode: number | null
+	signal: NodeJS.Signals | null
+	timedOut: boolean
+	durationMs: number
+}
 
 export type IslandRouterKeyValue = {
 	key: string

--- a/packages/home-connector/src/adapters/island-router/validation.ts
+++ b/packages/home-connector/src/adapters/island-router/validation.ts
@@ -126,6 +126,29 @@ export function getIslandRouterConfigStatus(
 		missingFields,
 		verificationMode,
 		warnings,
+		writeToolsEnabled: config.islandRouterWriteOperationsEnabled,
+		writeCapabilitiesAvailable:
+			config.islandRouterWriteOperationsEnabled &&
+			missingFields.length === 0 &&
+			verificationConfigValid &&
+			verificationMode !== 'none',
+		writeWarnings: [
+			...(config.islandRouterWriteOperationsEnabled
+				? []
+				: [
+						'Island router write operations are disabled. Set ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true only if you intentionally want highly restricted mutating router tools.',
+					]),
+			...(verificationMode === 'none'
+				? [
+						'Island router write operations require SSH host verification. Set ISLAND_ROUTER_KNOWN_HOSTS_PATH or ISLAND_ROUTER_HOST_FINGERPRINT before enabling them.',
+					]
+				: []),
+			...(verificationConfigValid
+				? []
+				: [
+						'Island router write operations remain unavailable until SSH host verification is configured correctly.',
+					]),
+		],
 	}
 }
 
@@ -147,6 +170,27 @@ export function assertIslandRouterConfigured(config: HomeConnectorConfig) {
 		!config.islandRouterKnownHostsPath
 	) {
 		validateIslandRouterFingerprint(config.islandRouterHostFingerprint)
+	}
+	return status
+}
+
+export function assertIslandRouterWriteConfigured(config: HomeConnectorConfig) {
+	const status = assertIslandRouterConfigured(config)
+	if (!config.islandRouterWriteOperationsEnabled) {
+		throw new Error(
+			'Island router write operations are disabled. Set ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true only if you intentionally want these high-risk mutating tools.',
+		)
+	}
+	if (status.verificationMode === 'none') {
+		throw new Error(
+			'Island router write operations require SSH host verification. Set ISLAND_ROUTER_KNOWN_HOSTS_PATH or ISLAND_ROUTER_HOST_FINGERPRINT before using them.',
+		)
+	}
+	if (!status.writeCapabilitiesAvailable) {
+		const details = status.writeWarnings.filter(Boolean).join(' ')
+		throw new Error(
+			`Island router write operations are unavailable. ${details}`.trim(),
+		)
 	}
 	return status
 }

--- a/packages/home-connector/src/config.node.test.ts
+++ b/packages/home-connector/src/config.node.test.ts
@@ -162,6 +162,7 @@ test('island router SSH env vars are loaded with defaults', () => {
 		ISLAND_ROUTER_KNOWN_HOSTS_PATH: '/keys/known_hosts',
 		ISLAND_ROUTER_HOST_FINGERPRINT: undefined,
 		ISLAND_ROUTER_COMMAND_TIMEOUT_MS: undefined,
+		ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS: undefined,
 	})
 
 	const config = loadHomeConnectorConfig()
@@ -173,6 +174,7 @@ test('island router SSH env vars are loaded with defaults', () => {
 		islandRouterKnownHostsPath: '/keys/known_hosts',
 		islandRouterHostFingerprint: null,
 		islandRouterCommandTimeoutMs: 8000,
+		islandRouterWriteOperationsEnabled: false,
 	})
 })
 
@@ -187,6 +189,7 @@ test('island router SSH env vars honor explicit port, fingerprint, and timeout',
 		ISLAND_ROUTER_HOST_FINGERPRINT:
 			'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12',
 		ISLAND_ROUTER_COMMAND_TIMEOUT_MS: '12000',
+		ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS: 'true',
 	})
 
 	const config = loadHomeConnectorConfig()
@@ -199,6 +202,7 @@ test('island router SSH env vars honor explicit port, fingerprint, and timeout',
 		islandRouterHostFingerprint:
 			'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12',
 		islandRouterCommandTimeoutMs: 12000,
+		islandRouterWriteOperationsEnabled: true,
 	})
 })
 

--- a/packages/home-connector/src/config.ts
+++ b/packages/home-connector/src/config.ts
@@ -14,6 +14,7 @@ export type HomeConnectorConfig = {
 	islandRouterKnownHostsPath: string | null
 	islandRouterHostFingerprint: string | null
 	islandRouterCommandTimeoutMs: number
+	islandRouterWriteOperationsEnabled: boolean
 	rokuDiscoveryUrl: string
 	samsungTvDiscoveryUrl: string
 	lutronDiscoveryUrl: string
@@ -248,6 +249,8 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 			islandRouterCommandTimeoutMs >= 1000
 				? islandRouterCommandTimeoutMs
 				: 8000,
+		islandRouterWriteOperationsEnabled:
+			process.env.ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS === 'true',
 		rokuDiscoveryUrl:
 			process.env.ROKU_DISCOVERY_URL?.trim() || 'ssdp://239.255.255.250:1900',
 		samsungTvDiscoveryUrl:

--- a/packages/home-connector/src/mcp/register-island-router-tools.ts
+++ b/packages/home-connector/src/mcp/register-island-router-tools.ts
@@ -34,6 +34,9 @@ function structuredTextResult(text: string, structuredContent: unknown): CallToo
 	}
 }
 
+const routerWriteDangerNotice =
+	'HIGH RISK: this mutates a live router. Use it only when you are highly certain it is necessary and correct because mistakes can disrupt connectivity, destroy diagnostics, or persist a bad state with severe consequences.'
+
 export function registerIslandRouterHomeConnectorTools(input: {
 	registerTool: (
 		descriptor: IslandRouterRegisteredToolDescriptor,
@@ -42,6 +45,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 	islandRouter: ReturnType<typeof createIslandRouterAdapter>
 }) {
 	const { registerTool, islandRouter } = input
+	const islandRouterConfig = islandRouter.getConfigStatus()
 
 	const hostSchema = buildToolInputSchema({
 		host: z
@@ -277,4 +281,122 @@ export function registerIslandRouterHomeConnectorTools(input: {
 			return structuredTextResult(summaryParts.join(' '), diagnosis)
 		},
 	)
+
+	if (islandRouterConfig.writeCapabilitiesAvailable) {
+		const createRouterWriteSchema = (confirmationPhrase: string) =>
+			buildToolInputSchema({
+				acknowledgeHighRisk: z
+					.literal(true)
+					.describe(
+						'Must be true. Set this only when you are highly certain the requested router mutation is necessary and correct.',
+					),
+				reason: z
+					.string()
+					.min(20)
+					.max(500)
+					.describe(
+						'Short operator justification. Be specific about why this mutation is necessary right now.',
+					),
+				confirmation: z
+					.literal(confirmationPhrase)
+					.describe(
+						'Exact confirmation phrase required by the tool. The tool rejects any other value.',
+					),
+				timeoutMs: z
+					.number()
+					.int()
+					.min(1000)
+					.max(60_000)
+					.optional()
+					.describe('Optional command timeout in milliseconds.'),
+			})
+
+		const renewDhcpClientsSchema = createRouterWriteSchema(
+			islandRouter.writeAcknowledgements.renewDhcpClients,
+		)
+		const clearLogBufferSchema = createRouterWriteSchema(
+			islandRouter.writeAcknowledgements.clearLogBuffer,
+		)
+		const saveRunningConfigSchema = createRouterWriteSchema(
+			islandRouter.writeAcknowledgements.saveRunningConfig,
+		)
+
+		registerTool(
+			{
+				name: 'router_renew_dhcp_clients',
+				title: 'Renew DHCP Clients On Island Router',
+				description: `${routerWriteDangerNotice} This typed allowlisted operation runs the documented Island CLI command \`clear dhcp-client\` to request immediate renewal of DHCP-learned addresses. Never use it as a guess or for broad troubleshooting.`,
+				inputSchema: renewDhcpClientsSchema.inputSchema,
+				sdkInputSchema: renewDhcpClientsSchema.sdkInputSchema,
+				annotations: {
+					destructiveHint: true,
+				},
+			},
+			async (args) => {
+				const result = await islandRouter.renewDhcpClients({
+					acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+					reason: String(args['reason'] ?? ''),
+					confirmation: String(args['confirmation'] ?? ''),
+					timeoutMs:
+						args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+				})
+				return structuredTextResult(
+					'Triggered an immediate renewal of DHCP-learned addresses on the Island router.',
+					result,
+				)
+			},
+		)
+
+		registerTool(
+			{
+				name: 'router_clear_log_buffer',
+				title: 'Clear Island Router Log Buffer',
+				description: `${routerWriteDangerNotice} This typed allowlisted operation runs the documented Island CLI command \`clear log\` and permanently removes the in-memory system log buffer. Use it only when you are highly certain existing log data is no longer needed.`,
+				inputSchema: clearLogBufferSchema.inputSchema,
+				sdkInputSchema: clearLogBufferSchema.sdkInputSchema,
+				annotations: {
+					destructiveHint: true,
+				},
+			},
+			async (args) => {
+				const result = await islandRouter.clearLogBuffer({
+					acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+					reason: String(args['reason'] ?? ''),
+					confirmation: String(args['confirmation'] ?? ''),
+					timeoutMs:
+						args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+				})
+				return structuredTextResult(
+					'Cleared the Island router in-memory log buffer.',
+					result,
+				)
+			},
+		)
+
+		registerTool(
+			{
+				name: 'router_save_running_config',
+				title: 'Save Island Router Running Config',
+				description: `${routerWriteDangerNotice} This typed allowlisted operation runs the documented Island CLI command \`write memory\` to persist the current running configuration to startup storage. A mistake can permanently preserve a bad router state, so the agent must be highly certain before using it.`,
+				inputSchema: saveRunningConfigSchema.inputSchema,
+				sdkInputSchema: saveRunningConfigSchema.sdkInputSchema,
+				annotations: {
+					destructiveHint: true,
+				},
+			},
+			async (args) => {
+				const result = await islandRouter.saveRunningConfig({
+					acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+					reason: String(args['reason'] ?? ''),
+					confirmation: String(args['confirmation'] ?? ''),
+					timeoutMs:
+						args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+				})
+				return structuredTextResult(
+					'Saved the Island router running configuration to startup storage.',
+					result,
+				)
+			},
+		)
+	}
 }

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -14,7 +14,7 @@ import { createHomeConnectorMcpServer } from './server.ts'
 import { createAppState } from '../state.ts'
 import { createHomeConnectorStorage } from '../storage/index.ts'
 
-function createConfig() {
+function createConfig(options?: { writeOperationsEnabled?: boolean }) {
 	process.env.MOCKS = 'true'
 	process.env.HOME_CONNECTOR_ID = 'default'
 	process.env.HOME_CONNECTOR_SHARED_SECRET =
@@ -35,6 +35,10 @@ function createConfig() {
 	process.env.ISLAND_ROUTER_HOST_FINGERPRINT =
 		'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12'
 	process.env.ISLAND_ROUTER_COMMAND_TIMEOUT_MS = '5000'
+	process.env.ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS = options
+		?.writeOperationsEnabled
+		? 'true'
+		: 'false'
 	return loadHomeConnectorConfig()
 }
 
@@ -168,6 +172,39 @@ function createIslandRouterRunner() {
 					timedOut: false,
 					durationMs: 200,
 				}
+			case 'clear-dhcp-client':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'clear dhcp-client'],
+					stdout: 'Renewing DHCP-learned addresses.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 150,
+				}
+			case 'clear-log':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'clear log'],
+					stdout: 'System log buffer cleared.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 150,
+				}
+			case 'write-memory':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'write memory'],
+					stdout: 'Running configuration saved.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 150,
+				}
 			default: {
 				const _exhaustive: never = request
 				throw new Error(
@@ -280,6 +317,15 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		expect(tools.some((tool) => tool.name === 'router_diagnose_host')).toBe(
 			true,
 		)
+		expect(
+			tools.some((tool) => tool.name === 'router_renew_dhcp_clients'),
+		).toBe(false)
+		expect(
+			tools.some((tool) => tool.name === 'router_clear_log_buffer'),
+		).toBe(false)
+		expect(
+			tools.some((tool) => tool.name === 'router_save_running_config'),
+		).toBe(false)
 		expect(
 			tools.some((tool) => tool.name === 'jellyfish_scan_controllers'),
 		).toBe(true)
@@ -486,6 +532,103 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		await expect(
 			mcp.callTool('bond_release_bridge', { bridgeId: 'not-a-bridge' }),
 		).rejects.toThrow('not-a-bridge')
+	} finally {
+		storage.close()
+	}
+})
+
+test('mcp server exposes island router write tools only when explicitly enabled', async () => {
+	const config = createConfig({ writeOperationsEnabled: true })
+	const state = createAppState()
+	const storage = createHomeConnectorStorage(config)
+	const samsungTv = createSamsungTvAdapter({
+		config,
+		state,
+		storage,
+	})
+	const lutron = createLutronAdapter({
+		config,
+		state,
+		storage,
+	})
+	const sonos = createSonosAdapter({
+		config,
+		state,
+		storage,
+	})
+	const bond = createBondAdapter({
+		config,
+		state,
+		storage,
+	})
+	const islandRouter = createIslandRouterAdapter({
+		config,
+		commandRunner: createIslandRouterRunner(),
+	})
+	const jellyfish = createJellyfishAdapter({
+		config,
+		state,
+		storage,
+	})
+	const venstar = createVenstarAdapter({ config, state, storage })
+	const mcp = createHomeConnectorMcpServer({
+		config,
+		state,
+		samsungTv,
+		lutron,
+		sonos,
+		bond,
+		islandRouter,
+		jellyfish,
+		venstar,
+	})
+
+	try {
+		const tools = mcp.listTools()
+		expect(
+			tools.some((tool) => tool.name === 'router_renew_dhcp_clients'),
+		).toBe(true)
+		expect(
+			tools.some((tool) => tool.name === 'router_clear_log_buffer'),
+		).toBe(true)
+		expect(
+			tools.some((tool) => tool.name === 'router_save_running_config'),
+		).toBe(true)
+
+		const renewTool = tools.find(
+			(tool) => tool.name === 'router_renew_dhcp_clients',
+		)
+		expect(renewTool).toBeDefined()
+		const renewProperties = (
+			renewTool?.inputSchema as {
+				properties?: Record<string, Record<string, unknown>>
+			}
+		).properties
+		expect(renewProperties?.acknowledgeHighRisk?.const).toBe(true)
+		expect(renewProperties?.confirmation?.const).toBe(
+			'I am highly certain renewing all Island router DHCP clients is necessary right now.',
+		)
+
+		const renewResult = await mcp.callTool('router_renew_dhcp_clients', {
+			acknowledgeHighRisk: true,
+			reason:
+				'The uplink address changed and an immediate DHCP renewal is the explicit recovery step.',
+			confirmation:
+				'I am highly certain renewing all Island router DHCP clients is necessary right now.',
+		})
+		expect(renewResult.structuredContent).toMatchObject({
+			operationId: 'renew-dhcp-clients',
+			commandId: 'clear-dhcp-client',
+		})
+
+		await expect(
+			mcp.callTool('router_save_running_config', {
+				acknowledgeHighRisk: true,
+				reason:
+					'Persist the currently validated maintenance change before the scheduled reboot window.',
+				confirmation: 'wrong',
+			}),
+		).rejects.toThrow('requires the exact acknowledgement')
 	} finally {
 		storage.close()
 	}

--- a/packages/home-connector/src/mcp/server.ts
+++ b/packages/home-connector/src/mcp/server.ts
@@ -96,7 +96,7 @@ export function createHomeConnectorMcpServer(input: {
 		},
 		{
 			instructions:
-				'Home connector MCP server. Tools support Roku, Samsung TV, Lutron, Sonos, Bond (Olibra Bond Bridge / shades, groups, and RF devices), JellyFish Lighting, Venstar WiFi thermostat control, and read-only Island router SSH diagnostics. Bond local API tokens are configured only in the admin UI (/bond/setup); use bond_authentication_guide when you need a reminder.',
+				'Home connector MCP server. Tools support Roku, Samsung TV, Lutron, Sonos, Bond (Olibra Bond Bridge / shades, groups, and RF devices), JellyFish Lighting, Venstar WiFi thermostat control, and typed allowlisted Island router SSH operations. Island router support is read-mostly: arbitrary CLI execution is never exposed, and the few opt-in write operations are high risk and must be used only when highly certain. Bond local API tokens are configured only in the admin UI (/bond/setup); use bond_authentication_guide when you need a reminder.',
 		},
 	)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- extend the Island router integration with a narrow set of typed allowlisted write operations instead of arbitrary command execution
- add strong guardrails for high-risk router mutations, including explicit opt-in config, required SSH host verification, destructive MCP hints, operator reasons, and exact confirmation phrases
- update router tests and docs to reflect the new read-mostly surface and severe-consequence warnings

## Details
- add typed write command ids and adapter methods for `clear dhcp-client`, `clear log`, and `write memory`
- only register the new MCP tools when `ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true` and SSH host verification is configured
- strengthen MCP/server/docs wording so agents are told to use these tools only when highly certain because mistakes can disrupt connectivity, destroy diagnostics, or persist a bad state

## Verification
- `npm run test -- --run src/adapters/island-router/index.node.test.ts src/adapters/island-router/ssh-client.node.test.ts src/mcp/server.node.test.ts src/config.node.test.ts` (in `packages/home-connector`)
- `npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63576bfe-ab44-4383-8aeb-4bb8cd7a0af5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63576bfe-ab44-4383-8aeb-4bb8cd7a0af5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

