### PR TITLE
Fix Island router SSH exit-code 1 handling

### DIFF
--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -581,6 +581,61 @@ test('parser ignores prompt echoes for real neighbor, dhcp, and log transcripts'
 	])
 })
 
+test('real CLI exit-code-1 transcripts remain successful when log output includes not-found text', async () => {
+	using _env = withTemporaryEnv({})
+	const config = createConfig()
+	const islandRouter = createIslandRouterAdapter({
+		config,
+		commandRunner: async (request) => {
+			switch (request.id) {
+				case 'show-log':
+					return {
+						id: request.id,
+						commandLines: [
+							'terminal length 0',
+							request.query
+								? `show log last where "${request.query.replaceAll('"', '\\"')}"`
+								: 'show log last',
+						],
+						stdout: [
+							request.query
+								? `Dodds-Island>show log last where "${request.query.replaceAll('"', '\\"')}"`
+								: 'Dodds-Island>show log last',
+							'2026-05-02 15:50:00 warning arp: ARP entry not found for 192.168.0.52',
+							'2026-05-02 15:50:01 err net: TCP connection timed out while probing uplink',
+							'Dodds-Island>exit',
+							'Goodbye',
+						].join('\n'),
+						stderr: '',
+						exitCode: 1,
+						signal: null,
+						timedOut: false,
+						durationMs: 10,
+					}
+				default:
+					return await createFakeRunner()(request)
+			}
+		},
+	})
+
+	const recentEvents = await islandRouter.getRecentEvents({
+		host: '192.168.0.52',
+	})
+
+	expect(recentEvents).toEqual([
+		expect.objectContaining({
+			level: 'warning',
+			module: 'arp',
+			message: 'warning arp: ARP entry not found for 192.168.0.52',
+		}),
+		expect.objectContaining({
+			level: 'err',
+			module: 'net',
+			message: 'err net: TCP connection timed out while probing uplink',
+		}),
+	])
+})
+
 test('island router adapter accepts real CLI transcripts that exit with code 1', async () => {
 	using _env = withTemporaryEnv({})
 	const config = createConfig()
@@ -603,7 +658,7 @@ test('island router adapter accepts real CLI transcripts that exit with code 1',
 						'Goodbye',
 					].join('\n'),
 					stderr: '',
-					exitCode: 0,
+					exitCode: 1,
 					signal: null,
 					timedOut: false,
 					durationMs: 10,

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -500,6 +500,23 @@ test('parser handles real Island CLI transcript shape with prompt echoes and goo
 	})
 })
 
+test('sanitizeIslandRouterOutput keeps legitimate lines that end with bracketed text', () => {
+	const commandLines = ['terminal length 0', 'show version']
+	const stdout = [
+		'Dodds-Island>show version',
+		'Firmware: v2.0 [beta]',
+		'VLAN [100]',
+		'Dodds-Island>',
+		'Dodds-Island>exit',
+		'Goodbye',
+	].join('\n')
+
+	expect(sanitizeIslandRouterOutput(stdout, commandLines)).toEqual([
+		'Firmware: v2.0 [beta]',
+		'VLAN [100]',
+	])
+})
+
 test('parser ignores prompt echoes for real neighbor, dhcp, and log transcripts', () => {
 	const neighborsTranscript = [
 		'Dodds-Island>show ip neighbors',

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -1,7 +1,14 @@
 import { expect, test } from 'vitest'
 import { loadHomeConnectorConfig } from '../../config.ts'
 import { createIslandRouterAdapter } from './index.ts'
-import { parseIslandRouterInterfaceSummaries } from './parsing.ts'
+import {
+	parseIslandRouterDhcpReservations,
+	parseIslandRouterInterfaceSummaries,
+	parseIslandRouterNeighbors,
+	parseIslandRouterRecentEvents,
+	parseIslandRouterVersion,
+	sanitizeIslandRouterOutput,
+} from './parsing.ts'
 import { type IslandRouterCommandRequest } from './types.ts'
 
 function withTemporaryEnv(values: Record<string, string | undefined>) {
@@ -147,7 +154,10 @@ function createFakeRunner() {
 			case 'show-interface':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', `show interface ${request.interfaceName}`],
+					commandLines: [
+						'terminal length 0',
+						`show interface ${request.interfaceName}`,
+					],
 					stdout: [
 						`Interface: ${request.interfaceName}`,
 						'Link State: up',
@@ -228,7 +238,9 @@ function createFakeRunner() {
 				}
 			default: {
 				const _exhaustive: never = request
-				throw new Error(`Unhandled fake Island router request: ${String(_exhaustive)}`)
+				throw new Error(
+					`Unhandled fake Island router request: ${String(_exhaustive)}`,
+				)
 			}
 		}
 	}
@@ -452,6 +464,319 @@ test('fallback interface summary parsing recognizes up and down link states', ()
 		expect.objectContaining({
 			name: 'en1',
 			linkState: 'down',
+		}),
+	])
+})
+
+test('parser handles real Island CLI transcript shape with prompt echoes and goodbye', () => {
+	const commandLines = ['terminal length 0', 'show version']
+	const stdout = [
+		'Island Pro (IL-0002-01) serial number 08008A020104 Version 3.2.3',
+		'Copyright 2004-2026 PerfTech, Inc.',
+		'',
+		'Dodds-Island>show version',
+		'',
+		'Island Pro (IL-0002-01) serial number 08008A020104 Version 3.2.3',
+		'Copyright 2004-2026 PerfTech, Inc.',
+		'',
+		'Dodds-Island>exit',
+		'Goodbye',
+	].join('\n')
+
+	expect(sanitizeIslandRouterOutput(stdout, commandLines)).toEqual([
+		'Island Pro (IL-0002-01) serial number 08008A020104 Version 3.2.3',
+		'Copyright 2004-2026 PerfTech, Inc.',
+	])
+	expect(parseIslandRouterVersion(stdout, commandLines)).toMatchObject({
+		model: 'Island Pro',
+		serialNumber: '08008A020104',
+		firmwareVersion: '3.2.3',
+		attributes: expect.arrayContaining([
+			expect.objectContaining({
+				key: 'Hardware Model',
+				value: 'IL-0002-01',
+			}),
+		]),
+	})
+})
+
+test('parser ignores prompt echoes for real neighbor, dhcp, and log transcripts', () => {
+	const neighborsTranscript = [
+		'Dodds-Island>show ip neighbors',
+		'IP Address    MAC Address        Interface  State',
+		'------------  -----------------  ---------  ---------',
+		'192.168.0.52  00:11:22:33:44:55  en0        reachable',
+		'Dodds-Island>exit',
+		'Goodbye',
+	].join('\n')
+	const dhcpTranscript = [
+		'Dodds-Island>show ip dhcp-reservations',
+		'IP Address    MAC Address        Host Name  Interface',
+		'------------  -----------------  ---------  ---------',
+		'192.168.0.52  00:11:22:33:44:55  nas-box    en0',
+		'Dodds-Island>exit',
+		'Goodbye',
+	].join('\n')
+	const logTranscript = [
+		'Dodds-Island>show log last where "192.168.0.52"',
+		'2026-05-02 15:50:00 info net: 192.168.0.52 link flap detected on en0',
+		'Dodds-Island>exit',
+		'Goodbye',
+	].join('\n')
+
+	expect(
+		parseIslandRouterNeighbors(neighborsTranscript, [
+			'terminal length 0',
+			'show ip neighbors',
+		]),
+	).toEqual([
+		expect.objectContaining({
+			ipAddress: '192.168.0.52',
+			macAddress: '00:11:22:33:44:55',
+			interfaceName: 'en0',
+			state: 'reachable',
+		}),
+	])
+	expect(
+		parseIslandRouterDhcpReservations(dhcpTranscript, [
+			'terminal length 0',
+			'show ip dhcp-reservations',
+		]),
+	).toEqual([
+		expect.objectContaining({
+			ipAddress: '192.168.0.52',
+			macAddress: '00:11:22:33:44:55',
+			hostName: 'nas-box',
+			interfaceName: 'en0',
+		}),
+	])
+	expect(
+		parseIslandRouterRecentEvents(logTranscript, [
+			'terminal length 0',
+			'show log last where "192.168.0.52"',
+		]),
+	).toEqual([
+		expect.objectContaining({
+			timestamp: '2026-05-02 15:50:00',
+			level: 'info',
+			module: 'net',
+		}),
+	])
+})
+
+test('island router adapter accepts real CLI transcripts that exit with code 1', async () => {
+	using _env = withTemporaryEnv({})
+	const config = createConfig()
+	const realCliExitOneRunner = async (request: IslandRouterCommandRequest) => {
+		switch (request.id) {
+			case 'show-version':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show version'],
+					stdout: [
+						'Island Pro (IL-0002-01) serial number 08008A020104 Version 3.2.3',
+						'Copyright 2004-2026 PerfTech, Inc.',
+						'',
+						'Dodds-Island>show version',
+						'',
+						'Island Pro (IL-0002-01) serial number 08008A020104 Version 3.2.3',
+						'Copyright 2004-2026 PerfTech, Inc.',
+						'',
+						'Dodds-Island>exit',
+						'Goodbye',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-clock':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show clock'],
+					stdout: [
+						'Dodds-Island>show clock',
+						'2026-05-02 15:55:00 PDT',
+						'Dodds-Island>exit',
+						'Goodbye',
+					].join('\n'),
+					stderr: '',
+					exitCode: 1,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-interface-summary':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show interface summary'],
+					stdout: [
+						'Dodds-Island>show interface summary',
+						'Interface  Link   Speed  Duplex  Description',
+						'---------  -----  -----  ------  -----------',
+						'en0        up     1G     full    LAN uplink',
+						'Dodds-Island>exit',
+						'Goodbye',
+					].join('\n'),
+					stderr: '',
+					exitCode: 1,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-neighbors':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ip neighbors'],
+					stdout: [
+						'Dodds-Island>show ip neighbors',
+						'IP Address    MAC Address        Interface  State',
+						'------------  -----------------  ---------  ---------',
+						'192.168.0.52  00:11:22:33:44:55  en0        reachable',
+						'Dodds-Island>exit',
+						'Goodbye',
+					].join('\n'),
+					stderr: '',
+					exitCode: 1,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-dhcp-reservations':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ip dhcp-reservations'],
+					stdout: [
+						'Dodds-Island>show ip dhcp-reservations',
+						'IP Address    MAC Address        Host Name  Interface',
+						'------------  -----------------  ---------  ---------',
+						'192.168.0.52  00:11:22:33:44:55  nas-box    en0',
+						'Dodds-Island>exit',
+						'Goodbye',
+					].join('\n'),
+					stderr: '',
+					exitCode: 1,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-log':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.query
+							? `show log last where "${request.query.replaceAll('"', '\\"')}"`
+							: 'show log last',
+					],
+					stdout: [
+						request.query
+							? `Dodds-Island>show log last where "${request.query.replaceAll('"', '\\"')}"`
+							: 'Dodds-Island>show log last',
+						'2026-05-02 15:50:00 info net: 192.168.0.52 link flap detected on en0',
+						'Dodds-Island>exit',
+						'Goodbye',
+					].join('\n'),
+					stderr: '',
+					exitCode: 1,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-interface':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						`show interface ${request.interfaceName}`,
+					],
+					stdout: [
+						`Dodds-Island>show interface ${request.interfaceName}`,
+						`Interface: ${request.interfaceName}`,
+						'Link State: up',
+						'Dodds-Island>exit',
+						'Goodbye',
+					].join('\n'),
+					stderr: '',
+					exitCode: 1,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-interface':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						`show ip interface ${request.interfaceName}`,
+					],
+					stdout: [
+						`Dodds-Island>show ip interface ${request.interfaceName}`,
+						`Interface: ${request.interfaceName}`,
+						'Address: 192.168.0.1/24',
+						'Dodds-Island>exit',
+						'Goodbye',
+					].join('\n'),
+					stderr: '',
+					exitCode: 1,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'ping':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', `ping ${request.host}`],
+					stdout: [
+						`Dodds-Island>ping ${request.host}`,
+						'64 bytes from 192.168.0.52: icmp_seq=1 ttl=64 time=1.23 ms',
+						'1 packets transmitted, 1 packets received, 0% packet loss',
+						'Dodds-Island>exit',
+						'Goodbye',
+					].join('\n'),
+					stderr: '',
+					exitCode: 1,
+					signal: null,
+					timedOut: false,
+					durationMs: 200,
+				}
+			default: {
+				const _exhaustive: never = request
+				throw new Error(
+					`Unhandled fake Island router request: ${String(_exhaustive)}`,
+				)
+			}
+		}
+	}
+	const islandRouter = createIslandRouterAdapter({
+		config,
+		commandRunner: realCliExitOneRunner,
+	})
+
+	const status = await islandRouter.getStatus()
+	expect(status.connected).toBe(true)
+	expect(status.router.version).toMatchObject({
+		model: 'Island Pro',
+		serialNumber: '08008A020104',
+		firmwareVersion: '3.2.3',
+	})
+
+	const dhcpLease = await islandRouter.getDhcpLease({
+		host: 'nas-box',
+	})
+	expect(dhcpLease.lease).toMatchObject({
+		hostName: 'nas-box',
+		ipAddress: '192.168.0.52',
+	})
+
+	const recentEvents = await islandRouter.getRecentEvents({
+		host: '192.168.0.52',
+	})
+	expect(recentEvents).toEqual([
+		expect.objectContaining({
+			module: 'net',
+			level: 'info',
 		}),
 	])
 })

--- a/packages/home-connector/src/adapters/island-router/index.ts
+++ b/packages/home-connector/src/adapters/island-router/index.ts
@@ -14,6 +14,7 @@ import { createIslandRouterSshCommandRunner } from './ssh-client.ts'
 import {
 	findMatchingDhcpLease,
 	findMatchingNeighbor,
+	didIslandRouterCommandSucceed,
 	parseIslandRouterClock,
 	parseIslandRouterDhcpReservations,
 	parseIslandRouterInterfaceDetails,
@@ -95,7 +96,7 @@ function ensureSuccessfulCommand(
 			`${message} failed because the command exited via ${reason}. ${result.stderr.trim()}`.trim(),
 		)
 	}
-	if (result.exitCode !== 0) {
+	if (!didIslandRouterCommandSucceed(result)) {
 		throw new Error(
 			`${message} failed with exit code ${result.exitCode}. ${result.stderr.trim()}`.trim(),
 		)
@@ -138,20 +139,18 @@ async function maybeGetInterfaceDetails(input: {
 		}),
 	])
 
-	const interfaceDetails =
-		interfaceResult.exitCode === 0 && !interfaceResult.timedOut
-			? parseIslandRouterInterfaceDetails(
-					interfaceResult.stdout,
-					interfaceResult.commandLines,
-				)
-			: null
-	const ipInterfaceDetails =
-		ipInterfaceResult.exitCode === 0 && !ipInterfaceResult.timedOut
-			? parseIslandRouterInterfaceDetails(
-					ipInterfaceResult.stdout,
-					ipInterfaceResult.commandLines,
-				)
-			: null
+	const interfaceDetails = didIslandRouterCommandSucceed(interfaceResult)
+		? parseIslandRouterInterfaceDetails(
+				interfaceResult.stdout,
+				interfaceResult.commandLines,
+			)
+		: null
+	const ipInterfaceDetails = didIslandRouterCommandSucceed(ipInterfaceResult)
+		? parseIslandRouterInterfaceDetails(
+				ipInterfaceResult.stdout,
+				ipInterfaceResult.commandLines,
+			)
+		: null
 
 	return {
 		interfaceDetails,
@@ -166,7 +165,9 @@ function getPreferredInterfaceName(input: {
 	return input.neighbor?.interfaceName ?? input.dhcpLease?.interfaceName ?? null
 }
 
-function dedupeRecentEvents(messages: Array<ReturnType<typeof parseIslandRouterRecentEvents>>) {
+function dedupeRecentEvents(
+	messages: Array<ReturnType<typeof parseIslandRouterRecentEvents>>,
+) {
 	const seen = new Set<string>()
 	const merged = messages.flat()
 	return merged.filter((event) => {
@@ -311,7 +312,7 @@ export function createIslandRouterAdapter(input: {
 				])
 
 			let version = null
-			if (versionResult.exitCode === 0 && !versionResult.timedOut) {
+			if (didIslandRouterCommandSucceed(versionResult)) {
 				version = parseIslandRouterVersion(
 					versionResult.stdout,
 					versionResult.commandLines,
@@ -321,45 +322,42 @@ export function createIslandRouterAdapter(input: {
 			}
 
 			let clock = null
-			if (clockResult.exitCode === 0 && !clockResult.timedOut) {
-				clock = parseIslandRouterClock(clockResult.stdout, clockResult.commandLines)
+			if (didIslandRouterCommandSucceed(clockResult)) {
+				clock = parseIslandRouterClock(
+					clockResult.stdout,
+					clockResult.commandLines,
+				)
 			} else {
 				errors.push('Failed to load Island router clock information.')
 			}
 
-			const interfaces =
-				interfaceResult.exitCode === 0 && !interfaceResult.timedOut
-					? parseIslandRouterInterfaceSummaries(
-							interfaceResult.stdout,
-							interfaceResult.commandLines,
-						)
-					: []
+			const interfaces = didIslandRouterCommandSucceed(interfaceResult)
+				? parseIslandRouterInterfaceSummaries(
+						interfaceResult.stdout,
+						interfaceResult.commandLines,
+					)
+				: []
 			if (interfaces.length === 0) {
 				errors.push('No Island router interface summary data was returned.')
 			}
 
-			const neighbors =
-				neighborResult.exitCode === 0 && !neighborResult.timedOut
-					? parseIslandRouterNeighbors(
-							neighborResult.stdout,
-							neighborResult.commandLines,
-						)
-					: []
-			if (neighborResult.exitCode !== 0 || neighborResult.timedOut) {
+			const neighbors = didIslandRouterCommandSucceed(neighborResult)
+				? parseIslandRouterNeighbors(
+						neighborResult.stdout,
+						neighborResult.commandLines,
+					)
+				: []
+			if (!didIslandRouterCommandSucceed(neighborResult)) {
 				errors.push('Failed to load Island router neighbor cache.')
 			}
 
 			return {
 				config: configStatus,
 				connected:
-					versionResult.exitCode === 0 &&
-					!versionResult.timedOut &&
-					clockResult.exitCode === 0 &&
-					!clockResult.timedOut &&
-					interfaceResult.exitCode === 0 &&
-					!interfaceResult.timedOut &&
-					neighborResult.exitCode === 0 &&
-					!neighborResult.timedOut,
+					didIslandRouterCommandSucceed(versionResult) &&
+					didIslandRouterCommandSucceed(clockResult) &&
+					didIslandRouterCommandSucceed(interfaceResult) &&
+					didIslandRouterCommandSucceed(neighborResult),
 				router: {
 					version,
 					clock,
@@ -373,7 +371,9 @@ export function createIslandRouterAdapter(input: {
 			assertIslandRouterConfigured(config)
 			const host = validateIslandRouterHost(request.host)
 			if (host.kind === 'mac') {
-				throw new Error('router_ping_host requires an IP address or hostname, not a MAC address.')
+				throw new Error(
+					'router_ping_host requires an IP address or hostname, not a MAC address.',
+				)
 			}
 
 			const runner = getRunner()
@@ -438,7 +438,9 @@ export function createIslandRouterAdapter(input: {
 		},
 		async getRecentEvents(request: RecentEventRequest = {}) {
 			assertIslandRouterConfigured(config)
-			const query = request.host ? validateIslandRouterHost(request.host).value : ''
+			const query = request.host
+				? validateIslandRouterHost(request.host).value
+				: ''
 			const limit = normalizeLimit(request.limit, 50, 200)
 			const runner = getRunner()
 			const timeoutMs = normalizeTimeoutMs(config, request.timeoutMs)
@@ -505,38 +507,35 @@ export function createIslandRouterAdapter(input: {
 					}),
 				])
 
-			const neighbors =
-				neighborResult.exitCode === 0 && !neighborResult.timedOut
-					? parseIslandRouterNeighbors(
-							neighborResult.stdout,
-							neighborResult.commandLines,
-						)
-					: []
-			if (neighborResult.exitCode !== 0 || neighborResult.timedOut) {
+			const neighbors = didIslandRouterCommandSucceed(neighborResult)
+				? parseIslandRouterNeighbors(
+						neighborResult.stdout,
+						neighborResult.commandLines,
+					)
+				: []
+			if (!didIslandRouterCommandSucceed(neighborResult)) {
 				errors.push('Failed to read the Island router neighbor cache.')
 			}
 			const arpEntry = findMatchingNeighbor(neighbors, host)
 
-			const leases =
-				dhcpResult.exitCode === 0 && !dhcpResult.timedOut
-					? parseIslandRouterDhcpReservations(
-							dhcpResult.stdout,
-							dhcpResult.commandLines,
-						)
-					: []
-			if (dhcpResult.exitCode !== 0 || dhcpResult.timedOut) {
+			const leases = didIslandRouterCommandSucceed(dhcpResult)
+				? parseIslandRouterDhcpReservations(
+						dhcpResult.stdout,
+						dhcpResult.commandLines,
+					)
+				: []
+			if (!didIslandRouterCommandSucceed(dhcpResult)) {
 				errors.push('Failed to read Island router DHCP reservations.')
 			}
 			const dhcpLease = findMatchingDhcpLease(leases, host)
 
-			const interfaceSummaries =
-				interfaceResult.exitCode === 0 && !interfaceResult.timedOut
-					? parseIslandRouterInterfaceSummaries(
-							interfaceResult.stdout,
-							interfaceResult.commandLines,
-						)
-					: []
-			if (interfaceResult.exitCode !== 0 || interfaceResult.timedOut) {
+			const interfaceSummaries = didIslandRouterCommandSucceed(interfaceResult)
+				? parseIslandRouterInterfaceSummaries(
+						interfaceResult.stdout,
+						interfaceResult.commandLines,
+					)
+				: []
+			if (!didIslandRouterCommandSucceed(interfaceResult)) {
 				errors.push('Failed to read Island router interface summary.')
 			}
 			const preferredInterfaceName = getPreferredInterfaceName({
@@ -549,14 +548,14 @@ export function createIslandRouterAdapter(input: {
 			)
 
 			const recentEventSets = [
-				eventResult.exitCode === 0 && !eventResult.timedOut
+				didIslandRouterCommandSucceed(eventResult)
 					? parseIslandRouterRecentEvents(
 							eventResult.stdout,
 							eventResult.commandLines,
 						)
 					: [],
 			]
-			if (eventResult.exitCode !== 0 || eventResult.timedOut) {
+			if (!didIslandRouterCommandSucceed(eventResult)) {
 				errors.push('Failed to read Island router recent events.')
 			}
 
@@ -570,7 +569,7 @@ export function createIslandRouterAdapter(input: {
 					query: arpEntry.macAddress,
 					timeoutMs,
 				})
-				if (macEventResult.exitCode === 0 && !macEventResult.timedOut) {
+				if (didIslandRouterCommandSucceed(macEventResult)) {
 					recentEventSets.push(
 						parseIslandRouterRecentEvents(
 							macEventResult.stdout,
@@ -579,7 +578,10 @@ export function createIslandRouterAdapter(input: {
 					)
 				}
 			}
-			const recentEvents = dedupeRecentEvents(recentEventSets).slice(0, logLimit)
+			const recentEvents = dedupeRecentEvents(recentEventSets).slice(
+				0,
+				logLimit,
+			)
 
 			const { interfaceDetails, ipInterfaceDetails } =
 				await maybeGetInterfaceDetails({

--- a/packages/home-connector/src/adapters/island-router/parsing.ts
+++ b/packages/home-connector/src/adapters/island-router/parsing.ts
@@ -33,6 +33,7 @@ const islandRouterVersionBannerPattern =
 const islandRouterCliFailurePattern =
 	/\b(?:invalid command|unknown command|syntax error|permission denied|host key verification failed|connection refused|connection timed out|connection closed|no route to host|network is unreachable|could not resolve hostname|not found|not recognized)\b/i
 const islandRouterPromptSuffixPattern = '[>#\\]]'
+const islandRouterPromptOnlyPattern = /^(?:[a-z0-9_.:@-]+[>#]|\[[^\]\r\n]+\])$/i
 
 function normalizeHeaderKey(value: string) {
 	return value
@@ -62,9 +63,14 @@ function isPromptEchoLine(line: string, command: string) {
 function isPromptOnlyLine(line: string) {
 	const trimmed = normalizeWhitespace(line)
 	if (!trimmed) return false
-	return new RegExp(`^[^\\r\\n]+${islandRouterPromptSuffixPattern}$`).test(
-		trimmed,
-	)
+	return islandRouterPromptOnlyPattern.test(trimmed)
+}
+
+function splitSanitizedStdoutLines(stdout: string) {
+	return stdout
+		.replaceAll(/\u001b\[[0-9;]*m/g, '')
+		.split(/\r?\n/)
+		.map((line) => line.replace(/\r/g, ''))
 }
 
 export function sanitizeIslandRouterOutput(
@@ -74,24 +80,12 @@ export function sanitizeIslandRouterOutput(
 	const normalizedCommands = commandLines
 		.map((line) => normalizeWhitespace(line))
 		.filter(Boolean)
-	const firstCommandEchoIndex = stdout
-		.replaceAll(/\u001b\[[0-9;]*m/g, '')
-		.split(/\r?\n/)
-		.map((line) => line.replace(/\r/g, ''))
-		.findIndex((line) =>
-			normalizedCommands.some((command) => isPromptEchoLine(line, command)),
-		)
+	const lines = splitSanitizedStdoutLines(stdout)
+	const firstCommandEchoIndex = lines.findIndex((line) =>
+		normalizedCommands.some((command) => isPromptEchoLine(line, command)),
+	)
 	const relevantOutput =
-		firstCommandEchoIndex >= 0
-			? stdout
-					.replaceAll(/\u001b\[[0-9;]*m/g, '')
-					.split(/\r?\n/)
-					.map((line) => line.replace(/\r/g, ''))
-					.slice(firstCommandEchoIndex)
-			: stdout
-					.replaceAll(/\u001b\[[0-9;]*m/g, '')
-					.split(/\r?\n/)
-					.map((line) => line.replace(/\r/g, ''))
+		firstCommandEchoIndex >= 0 ? lines.slice(firstCommandEchoIndex) : lines
 
 	return relevantOutput.filter((line) => {
 		const trimmed = normalizeWhitespace(line)

--- a/packages/home-connector/src/adapters/island-router/parsing.ts
+++ b/packages/home-connector/src/adapters/island-router/parsing.ts
@@ -22,13 +22,17 @@ const neighborStatePattern =
 	/\b(?:reachable|stale|delay|probe|permanent|failed|incomplete)\b/i
 const timestampPattern =
 	/^(?<timestamp>\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?|\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(?<rest>.*)$/
-const macAddressPattern =
-	/\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b/
+const macAddressPattern = /\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b/
 const ipv4Pattern = /\b\d{1,3}(?:\.\d{1,3}){3}\b/
 const pingReplyPattern =
 	/\bicmp_seq=(?<sequence>\d+)\b.*?\btime=(?<timeMs>\d+(?:\.\d+)?)\s*ms\b/i
 const pingSummaryPattern =
 	/(?<transmitted>\d+)\s+packets transmitted,\s+(?<received>\d+)\s+packets received,\s+(?<packetLoss>\d+(?:\.\d+)?)%\s+packet loss/i
+const islandRouterVersionBannerPattern =
+	/^(?<model>.+?)\s+\((?<hardwareModel>[^)]+)\)\s+serial number\s+(?<serialNumber>\S+)\s+Version\s+(?<firmwareVersion>\S+)$/i
+const islandRouterCliFailurePattern =
+	/\b(?:invalid command|unknown command|syntax error|permission denied|host key verification failed|connection refused|connection timed out|connection closed|no route to host|network is unreachable|could not resolve hostname|not found|not recognized)\b/i
+const islandRouterPromptSuffixPattern = '[>#\\]]'
 
 function normalizeHeaderKey(value: string) {
 	return value
@@ -42,35 +46,135 @@ function normalizeWhitespace(value: string) {
 	return value.replaceAll(/\s+/g, ' ').trim()
 }
 
+function escapeRegExp(value: string) {
+	return value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function isPromptEchoLine(line: string, command: string) {
+	const trimmed = normalizeWhitespace(line)
+	const normalizedCommand = normalizeWhitespace(command)
+	if (!trimmed || !normalizedCommand) return false
+	return new RegExp(
+		`^[^\\r\\n]+${islandRouterPromptSuffixPattern}\\s*${escapeRegExp(normalizedCommand)}$`,
+	).test(trimmed)
+}
+
+function isPromptOnlyLine(line: string) {
+	const trimmed = normalizeWhitespace(line)
+	if (!trimmed) return false
+	return new RegExp(`^[^\\r\\n]+${islandRouterPromptSuffixPattern}$`).test(
+		trimmed,
+	)
+}
+
 export function sanitizeIslandRouterOutput(
 	stdout: string,
 	commandLines: Array<string>,
 ) {
-	const normalizedCommands = new Set(
-		commandLines.map((line) => normalizeWhitespace(line)),
-	)
-
-	return stdout
+	const normalizedCommands = commandLines
+		.map((line) => normalizeWhitespace(line))
+		.filter(Boolean)
+	const firstCommandEchoIndex = stdout
 		.replaceAll(/\u001b\[[0-9;]*m/g, '')
 		.split(/\r?\n/)
 		.map((line) => line.replace(/\r/g, ''))
-		.filter((line) => {
-			const trimmed = normalizeWhitespace(line)
-			if (!trimmed) return false
-			if (trimmed === 'exit') return false
-			if (/^[\w.-]+[>#]$/.test(trimmed)) return false
-			if (normalizedCommands.has(trimmed)) return false
-			for (const command of normalizedCommands) {
-				if (
-					trimmed.endsWith(`> ${command}`) ||
-					trimmed.endsWith(`# ${command}`) ||
-					trimmed.endsWith(`] ${command}`)
-				) {
-					return false
-				}
-			}
-			return true
+		.findIndex((line) =>
+			normalizedCommands.some((command) => isPromptEchoLine(line, command)),
+		)
+	const relevantOutput =
+		firstCommandEchoIndex >= 0
+			? stdout
+					.replaceAll(/\u001b\[[0-9;]*m/g, '')
+					.split(/\r?\n/)
+					.map((line) => line.replace(/\r/g, ''))
+					.slice(firstCommandEchoIndex)
+			: stdout
+					.replaceAll(/\u001b\[[0-9;]*m/g, '')
+					.split(/\r?\n/)
+					.map((line) => line.replace(/\r/g, ''))
+
+	return relevantOutput.filter((line) => {
+		const trimmed = normalizeWhitespace(line)
+		if (!trimmed) return false
+		if (trimmed.toLowerCase() === 'goodbye') return false
+		if (trimmed === 'exit') return false
+		if (isPromptOnlyLine(trimmed)) return false
+		if (normalizedCommands.includes(trimmed)) return false
+		if (isPromptEchoLine(trimmed, 'exit')) return false
+		for (const command of normalizedCommands) {
+			if (isPromptEchoLine(trimmed, command)) return false
+		}
+		return true
+	})
+}
+
+export function isSuccessfulIslandRouterCliSession(input: {
+	stdout: string
+	stderr: string
+	commandLines: Array<string>
+	exitCode: number | null
+	signal: NodeJS.Signals | null
+	timedOut: boolean
+}) {
+	if (input.timedOut || input.signal != null || input.exitCode !== 1) {
+		return false
+	}
+	if (normalizeWhitespace(input.stderr).length > 0) {
+		return false
+	}
+
+	const transcriptLines = input.stdout
+		.split(/\r?\n/)
+		.map((line) => normalizeWhitespace(line))
+		.filter(Boolean)
+	const actionableCommands = input.commandLines.filter(
+		(command) => normalizeWhitespace(command) !== 'terminal length 0',
+	)
+	const sawCommandEcho = actionableCommands.some((command) =>
+		transcriptLines.some((line) => isPromptEchoLine(line, command)),
+	)
+	const sawExitPrompt = transcriptLines.some((line) =>
+		isPromptEchoLine(line, 'exit'),
+	)
+	const sawGoodbye = transcriptLines.some(
+		(line) => line.toLowerCase() === 'goodbye',
+	)
+	const sanitizedOutput = sanitizeIslandRouterOutput(
+		input.stdout,
+		input.commandLines,
+	)
+
+	if (
+		sanitizedOutput.some((line) => islandRouterCliFailurePattern.test(line))
+	) {
+		return false
+	}
+
+	return sawCommandEcho && sawExitPrompt && sawGoodbye
+}
+
+export function didIslandRouterCommandSucceed(input: {
+	stdout: string
+	stderr: string
+	commandLines: Array<string>
+	exitCode: number | null
+	signal: NodeJS.Signals | null
+	timedOut: boolean
+}) {
+	if (input.timedOut || input.signal != null) {
+		return false
+	}
+	return (
+		input.exitCode === 0 ||
+		isSuccessfulIslandRouterCliSession({
+			stdout: input.stdout,
+			stderr: input.stderr,
+			commandLines: input.commandLines,
+			exitCode: input.exitCode,
+			signal: input.signal,
+			timedOut: input.timedOut,
 		})
+	)
 }
 
 function splitTableColumns(line: string) {
@@ -107,7 +211,10 @@ function parseTextTable(lines: Array<string>): Array<ParsedTableRow> {
 		const columns = splitTableColumns(line)
 		if (columns.length < 2) continue
 		const fields = Object.fromEntries(
-			headers.map((header, columnIndex) => [header, columns[columnIndex] ?? '']),
+			headers.map((header, columnIndex) => [
+				header,
+				columns[columnIndex] ?? '',
+			]),
 		)
 		rows.push({
 			rawLine: line,
@@ -176,15 +283,55 @@ export function parseIslandRouterVersion(
 	const fieldMap = Object.fromEntries(
 		attributes.map((entry) => [normalizeHeaderKey(entry.key), entry.value]),
 	)
+	let bannerMatch: RegExpExecArray | null = null
+	for (const line of lines) {
+		const match = islandRouterVersionBannerPattern.exec(
+			normalizeWhitespace(line),
+		)
+		if (match?.groups) {
+			bannerMatch = match
+			break
+		}
+	}
+	const fallbackAttributes =
+		bannerMatch?.groups == null
+			? []
+			: [
+					{
+						key: 'Model',
+						value: bannerMatch.groups['model']?.trim() ?? '',
+					},
+					{
+						key: 'Hardware Model',
+						value: bannerMatch.groups['hardwareModel']?.trim() ?? '',
+					},
+					{
+						key: 'Serial Number',
+						value: bannerMatch.groups['serialNumber']?.trim() ?? '',
+					},
+					{
+						key: 'Firmware Version',
+						value: bannerMatch.groups['firmwareVersion']?.trim() ?? '',
+					},
+				].filter((entry) => entry.value.length > 0)
 	return {
-		model: findField(fieldMap, ['model', 'hardware_model']),
-		serialNumber: findField(fieldMap, ['serial_number', 'serial']),
-		firmwareVersion: findField(fieldMap, [
-			'firmware_version',
-			'software_version',
-			'version',
-		]),
-		attributes,
+		model:
+			findField(fieldMap, ['model', 'hardware_model']) ??
+			bannerMatch?.groups['model']?.trim() ??
+			null,
+		serialNumber:
+			findField(fieldMap, ['serial_number', 'serial']) ??
+			bannerMatch?.groups['serialNumber']?.trim() ??
+			null,
+		firmwareVersion:
+			findField(fieldMap, [
+				'firmware_version',
+				'software_version',
+				'version',
+			]) ??
+			bannerMatch?.groups['firmwareVersion']?.trim() ??
+			null,
+		attributes: attributes.length > 0 ? attributes : fallbackAttributes,
 		rawOutput: lines.join('\n'),
 	}
 }
@@ -262,8 +409,11 @@ export function parseIslandRouterNeighbors(
 		return table.map((row) => ({
 			ipAddress: findField(row.fields, ['ip', 'address', 'ip_address']),
 			macAddress:
-				findField(row.fields, ['mac', 'lladdr', 'link_layer_address'])?.toLowerCase() ??
-				null,
+				findField(row.fields, [
+					'mac',
+					'lladdr',
+					'link_layer_address',
+				])?.toLowerCase() ?? null,
 			interfaceName: findField(row.fields, ['interface', 'iface', 'device']),
 			state: findField(row.fields, ['state', 'status'])?.toLowerCase() ?? null,
 			rawLine: row.rawLine,
@@ -298,7 +448,8 @@ export function parseIslandRouterDhcpReservations(
 		return table.map((row) => ({
 			ipAddress: findField(row.fields, ['ip', 'address', 'ip_address']),
 			macAddress:
-				findField(row.fields, ['mac', 'hardware_address'])?.toLowerCase() ?? null,
+				findField(row.fields, ['mac', 'hardware_address'])?.toLowerCase() ??
+				null,
 			hostName: findField(row.fields, ['host', 'hostname', 'name']),
 			interfaceName: findField(row.fields, ['interface', 'iface']),
 			leaseType: 'reservation',
@@ -381,9 +532,7 @@ export function parseIslandRouterPingResult(input: {
 	const replies = parsePingReplies(lines)
 	const summaryLine =
 		lines.find((line) => pingSummaryPattern.test(line)) ??
-		input.stderr
-			.split(/\r?\n/)
-			.find((line) => pingSummaryPattern.test(line)) ??
+		input.stderr.split(/\r?\n/).find((line) => pingSummaryPattern.test(line)) ??
 		''
 	const summaryMatch = pingSummaryPattern.exec(summaryLine)
 	const transmitted = summaryMatch?.groups?.['transmitted']

--- a/packages/home-connector/src/adapters/island-router/parsing.ts
+++ b/packages/home-connector/src/adapters/island-router/parsing.ts
@@ -31,7 +31,7 @@ const pingSummaryPattern =
 const islandRouterVersionBannerPattern =
 	/^(?<model>.+?)\s+\((?<hardwareModel>[^)]+)\)\s+serial number\s+(?<serialNumber>\S+)\s+Version\s+(?<firmwareVersion>\S+)$/i
 const islandRouterCliFailurePattern =
-	/\b(?:invalid command|unknown command|syntax error|permission denied|host key verification failed|connection refused|connection timed out|connection closed|no route to host|network is unreachable|could not resolve hostname|not found|not recognized)\b/i
+	/\b(?:invalid command|unknown command|unrecognized command|syntax error|permission denied|host key verification failed|connection refused|no route to host|network is unreachable|could not resolve hostname|command not found|not recognized as an internal or external command)\b/i
 const islandRouterPromptSuffixPattern = '[>#\\]]'
 const islandRouterPromptOnlyPattern = /^(?:[a-z0-9_.:@-]+[>#]|\[[^\]\r\n]+\])$/i
 

--- a/packages/home-connector/src/adapters/island-router/ssh-client.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/ssh-client.node.test.ts
@@ -1,4 +1,11 @@
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import {
+	chmod,
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	writeFile,
+} from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { expect, test } from 'vitest'
@@ -25,7 +32,9 @@ function createConfig() {
 
 test('ssh runner explicitly disables host verification when no known-host or fingerprint is configured', async () => {
 	const config = createConfig()
-	const tempDir = await mkdtemp(path.join(os.tmpdir(), 'kody-island-router-test-'))
+	const tempDir = await mkdtemp(
+		path.join(os.tmpdir(), 'kody-island-router-test-'),
+	)
 	const binDir = path.join(tempDir, 'bin')
 	const argsPath = path.join(tempDir, 'ssh-args.txt')
 	await mkdir(binDir, { recursive: true })
@@ -55,6 +64,94 @@ test('ssh runner explicitly disables host verification when no known-host or fin
 		expect(args).toContain('StrictHostKeyChecking=no')
 		expect(args).toContain('UserKnownHostsFile=/dev/null')
 		expect(args).toContain('GlobalKnownHostsFile=/dev/null')
+	} finally {
+		process.env.PATH = originalPath
+		await rm(tempDir, { recursive: true, force: true })
+	}
+})
+
+test('ssh runner treats completed Island CLI sessions with exit code 1 as success', async () => {
+	const config = createConfig()
+	const tempDir = await mkdtemp(
+		path.join(os.tmpdir(), 'kody-island-router-test-'),
+	)
+	const binDir = path.join(tempDir, 'bin')
+	await mkdir(binDir, { recursive: true })
+	const fakeSshPath = path.join(binDir, 'ssh')
+	await writeFile(
+		fakeSshPath,
+		[
+			'#!/bin/sh',
+			'while IFS= read -r _line; do :; done',
+			"printf '%s\n' 'Island Pro (IL-0002-01) serial number 08008A020104 Version 3.2.3'",
+			"printf '%s\n' 'Copyright 2004-2026 PerfTech, Inc.'",
+			"printf '%s\n' ''",
+			"printf '%s\n' 'Dodds-Island>show version'",
+			"printf '%s\n' ''",
+			"printf '%s\n' 'Island Pro (IL-0002-01) serial number 08008A020104 Version 3.2.3'",
+			"printf '%s\n' 'Copyright 2004-2026 PerfTech, Inc.'",
+			"printf '%s\n' ''",
+			"printf '%s\n' 'Dodds-Island>exit'",
+			"printf '%s\n' 'Goodbye'",
+			'exit 1',
+		].join('\n'),
+		'utf8',
+	)
+	await chmod(fakeSshPath, 0o755)
+
+	const originalPath = process.env.PATH
+	process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ''}`
+
+	try {
+		const runner = createIslandRouterSshCommandRunner(config)
+		const result = await runner({
+			id: 'show-version',
+			timeoutMs: 1000,
+		})
+		expect(result.exitCode).toBe(0)
+		expect(result.signal).toBeNull()
+		expect(result.timedOut).toBe(false)
+		expect(result.stdout).toContain('Dodds-Island>show version')
+		expect(result.stdout).toContain('Goodbye')
+	} finally {
+		process.env.PATH = originalPath
+		await rm(tempDir, { recursive: true, force: true })
+	}
+})
+
+test('ssh runner keeps genuine exit-code-1 failures detectable', async () => {
+	const config = createConfig()
+	const tempDir = await mkdtemp(
+		path.join(os.tmpdir(), 'kody-island-router-test-'),
+	)
+	const binDir = path.join(tempDir, 'bin')
+	await mkdir(binDir, { recursive: true })
+	const fakeSshPath = path.join(binDir, 'ssh')
+	await writeFile(
+		fakeSshPath,
+		[
+			'#!/bin/sh',
+			'while IFS= read -r _line; do :; done',
+			"printf '%s\n' 'Permission denied'",
+			'exit 1',
+		].join('\n'),
+		'utf8',
+	)
+	await chmod(fakeSshPath, 0o755)
+
+	const originalPath = process.env.PATH
+	process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ''}`
+
+	try {
+		const runner = createIslandRouterSshCommandRunner(config)
+		const result = await runner({
+			id: 'show-version',
+			timeoutMs: 1000,
+		})
+		expect(result.exitCode).toBe(1)
+		expect(result.signal).toBeNull()
+		expect(result.timedOut).toBe(false)
+		expect(result.stdout).toContain('Permission denied')
 	} finally {
 		process.env.PATH = originalPath
 		await rm(tempDir, { recursive: true, force: true })

--- a/packages/home-connector/src/adapters/island-router/ssh-client.ts
+++ b/packages/home-connector/src/adapters/island-router/ssh-client.ts
@@ -7,6 +7,7 @@ import {
 	assertIslandRouterConfigured,
 	validateIslandRouterFingerprint,
 } from './validation.ts'
+import { isSuccessfulIslandRouterCliSession } from './parsing.ts'
 import {
 	type IslandRouterCommandRequest,
 	type IslandRouterCommandResult,
@@ -26,17 +27,18 @@ type HostVerification = {
 }
 
 function onceProcessExit(child: ChildProcess) {
-	return new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>(
-		(resolve, reject) => {
-			child.once('error', reject)
-			child.once('close', (exitCode, signal) => {
-				resolve({
-					exitCode,
-					signal,
-				})
+	return new Promise<{
+		exitCode: number | null
+		signal: NodeJS.Signals | null
+	}>((resolve, reject) => {
+		child.once('error', reject)
+		child.once('close', (exitCode, signal) => {
+			resolve({
+				exitCode,
+				signal,
 			})
-		},
-	)
+		})
+	})
 }
 
 async function runLocalCommand(input: {
@@ -211,7 +213,10 @@ async function resolveHostVerification(
 	}
 }
 
-function createSshArgs(config: HomeConnectorConfig, verificationArgs: Array<string>) {
+function createSshArgs(
+	config: HomeConnectorConfig,
+	verificationArgs: Array<string>,
+) {
 	return [
 		'-T',
 		'-p',
@@ -282,7 +287,9 @@ function getCommandLines(request: IslandRouterCommandRequest): Array<string> {
 			return ['write memory']
 		default: {
 			const _exhaustive: never = request
-			throw new Error(`Unhandled Island router command request: ${String(_exhaustive)}`)
+			throw new Error(
+				`Unhandled Island router command request: ${String(_exhaustive)}`,
+			)
 		}
 	}
 }
@@ -293,7 +300,9 @@ function writeCommandLines(child: ChildProcess, commandLines: Array<string>) {
 	}
 }
 
-export function createIslandRouterSshCommandRunner(config: HomeConnectorConfig) {
+export function createIslandRouterSshCommandRunner(
+	config: HomeConnectorConfig,
+) {
 	assertIslandRouterConfigured(config)
 	let verificationPromise: Promise<HostVerification> | null = null
 	let cleanupRegistered = false
@@ -397,7 +406,16 @@ export function createIslandRouterSshCommandRunner(config: HomeConnectorConfig) 
 			commandLines,
 			stdout,
 			stderr,
-			exitCode: result.exitCode,
+			exitCode: isSuccessfulIslandRouterCliSession({
+				stdout,
+				stderr,
+				commandLines,
+				exitCode: result.exitCode,
+				signal: result.signal,
+				timedOut,
+			})
+				? 0
+				: result.exitCode,
 			signal: result.signal,
 			timedOut,
 			durationMs: Date.now() - start,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- treat completed Island router CLI SSH sessions as successful even when the underlying `ssh` process exits with code 1 in the observed NAS/container environment
- keep genuine failures detectable by requiring the Island-specific success shape (no stderr, no signal/timeout, echoed command prompt, `exit`, `Goodbye`, and no explicit CLI failure output)
- harden Island router transcript parsing for real prompt echoes like `Dodds-Island>show version`, strip `Goodbye`, parse the observed one-line version banner format, and tighten prompt-only filtering so legitimate bracketed output lines such as `Firmware: v2.0 [beta]` or `VLAN [100]` are preserved
- narrow CLI failure detection so valid `show log` output containing phrases like `ARP entry not found` or `connection timed out` no longer causes false failures in the exit-code-1 environment
- deduplicate stdout normalization inside `sanitizeIslandRouterOutput` so the transcript cleanup path stays consistent
- add targeted regression tests for transport-level exit-code normalization, real transcript parsing, bracketed-output preservation, and log-output false-positive prevention

## Testing
- `npm exec -- vitest run --project node-unit "packages/home-connector/src/adapters/island-router/ssh-client.node.test.ts" "packages/home-connector/src/adapters/island-router/index.node.test.ts"`
- `npm exec -- tsc --noEmit --allowImportingTsExtensions --moduleResolution bundler --module ESNext --target ES2023 --lib ES2023,DOM --types node --verbatimModuleSyntax --moduleDetection force --skipLibCheck packages/home-connector/src/adapters/island-router/index.ts packages/home-connector/src/adapters/island-router/parsing.ts packages/home-connector/src/adapters/island-router/ssh-client.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-768308d9-0f75-48c8-b202-8d054a6fbeeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-768308d9-0f75-48c8-b202-8d054a6fbeeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Island Router command success detection for more reliable status and DHCP lease queries.
  * Enhanced CLI output parsing to properly handle prompt echoes and edge cases in router responses.
  * Better version information extraction from router CLI output.

* **Tests**
  * Expanded test coverage for edge cases and integration scenarios with the Island Router adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->