### PR TITLE
Fix home connector mobile layout

### DIFF
--- a/packages/home-connector/app/admin-ui.ts
+++ b/packages/home-connector/app/admin-ui.ts
@@ -158,18 +158,20 @@ export function renderDataTable(input: {
 		return renderEmptyState('No rows to display.')
 	}
 
-	return html`<table class="data-table">
-		<thead>
-			<tr>
-				${input.headers.map((header) => html`<th scope="col">${header}</th>`)}
-			</tr>
-		</thead>
-		<tbody>
-			${input.rows.map(
-				(row) => html`<tr>
-					${row.map((value) => html`<td>${value}</td>`)}
-				</tr>`,
-			)}
-		</tbody>
-	</table>`
+	return html`<div class="data-table-scroll">
+		<table class="data-table">
+			<thead>
+				<tr>
+					${input.headers.map((header) => html`<th scope="col">${header}</th>`)}
+				</tr>
+			</thead>
+			<tbody>
+				${input.rows.map(
+					(row) => html`<tr>
+						${row.map((value) => html`<td>${value}</td>`)}
+					</tr>`,
+				)}
+			</tbody>
+		</table>
+	</div>`
 }

--- a/packages/home-connector/app/admin-ui.ts
+++ b/packages/home-connector/app/admin-ui.ts
@@ -153,13 +153,18 @@ export function renderEmptyState(message: string | ReturnType<typeof html>) {
 export function renderDataTable(input: {
 	headers: Array<string>
 	rows: Array<Array<string | number | ReturnType<typeof html>>>
+	className?: 'data-table-diagnostics'
 }) {
 	if (input.rows.length === 0) {
 		return renderEmptyState('No rows to display.')
 	}
 
+	const className = input.className
+		? `data-table ${input.className}`
+		: 'data-table'
+
 	return html`<div class="data-table-scroll">
-		<table class="data-table">
+		<table class="${className}">
 			<thead>
 				<tr>
 					${input.headers.map((header) => html`<th scope="col">${header}</th>`)}

--- a/packages/home-connector/app/dashboard-handlers.ts
+++ b/packages/home-connector/app/dashboard-handlers.ts
@@ -1036,6 +1036,7 @@ type DiagnosticRow = {
 
 function renderDiagnosticRows(rows: Array<DiagnosticRow>) {
 	return renderDataTable({
+		className: 'data-table-diagnostics',
 		headers: ['Surface', 'Status', 'Details', 'Links'],
 		rows: rows.map((row) => [
 			row.name,

--- a/packages/home-connector/app/root.ts
+++ b/packages/home-connector/app/root.ts
@@ -206,6 +206,7 @@ const styles = `
 			position: static !important;
 			height: auto !important;
 			padding: var(--spacing-md) !important;
+			gap: var(--spacing-md) !important;
 			border-right: none !important;
 			border-bottom: 1px solid var(--color-border);
 		}
@@ -216,7 +217,7 @@ const styles = `
 
 		.sidebar nav {
 			display: grid;
-			gap: var(--spacing-md);
+			gap: var(--spacing-sm);
 			overflow-x: auto;
 			padding-bottom: var(--spacing-xs);
 			scrollbar-width: thin;
@@ -232,9 +233,13 @@ const styles = `
 		}
 
 		.nav-link {
-			min-width: 9.5rem;
-			max-width: 13rem;
+			min-width: max-content;
 			height: 100%;
+			padding: 0.625rem 0.75rem !important;
+		}
+
+		.nav-link-description {
+			display: none;
 		}
 
 		.layout-main {

--- a/packages/home-connector/app/root.ts
+++ b/packages/home-connector/app/root.ts
@@ -723,17 +723,46 @@ const styles = `
 
 	.data-table {
 		width: 100%;
+		min-width: 42rem;
 		border-collapse: collapse;
 		font-size: var(--font-size-sm);
 	}
 
 	.data-table th,
 	.data-table td {
+		min-width: 8rem;
 		padding: 0.75rem;
 		text-align: left;
 		vertical-align: top;
 		border-bottom: 1px solid color-mix(in srgb, var(--color-border) 75%, transparent);
-		overflow-wrap: anywhere;
+		overflow-wrap: normal;
+		word-break: normal;
+	}
+
+	.data-table th,
+	.data-table td:first-child,
+	.data-table .inline-link,
+	.data-table .status-badge {
+		white-space: nowrap;
+	}
+
+	.data-table th:nth-child(3),
+	.data-table td:nth-child(3) {
+		min-width: 16rem;
+	}
+
+	.data-table th:nth-child(4),
+	.data-table td:nth-child(4) {
+		min-width: 12rem;
+	}
+
+	.data-table .inline-links {
+		align-items: flex-start;
+		min-width: max-content;
+	}
+
+	.data-table .inline-link {
+		width: auto;
 	}
 
 	.data-table th {
@@ -821,6 +850,11 @@ const styles = `
 		button {
 			justify-content: center;
 			width: 100%;
+		}
+
+		.data-table .inline-link,
+		.data-table button {
+			width: auto;
 		}
 	}
 `

--- a/packages/home-connector/app/root.ts
+++ b/packages/home-connector/app/root.ts
@@ -197,89 +197,6 @@ const styles = `
 		}
 	}
 
-	@media (max-width: 800px) {
-		.layout-shell {
-			grid-template-columns: 1fr !important;
-		}
-
-		.sidebar {
-			position: static !important;
-			height: auto !important;
-			padding: var(--spacing-md) !important;
-			gap: var(--spacing-md) !important;
-			border-right: none !important;
-			border-bottom: 1px solid var(--color-border);
-		}
-
-		.sidebar-brand-copy {
-			display: none;
-		}
-
-		.sidebar nav {
-			display: grid;
-			gap: var(--spacing-sm);
-			overflow-x: auto;
-			padding-bottom: var(--spacing-xs);
-			scrollbar-width: thin;
-		}
-
-		.nav-section {
-			min-width: max-content;
-		}
-
-		.nav-list {
-			display: flex !important;
-			gap: var(--spacing-sm) !important;
-		}
-
-		.nav-link {
-			min-width: max-content;
-			height: 100%;
-			padding: 0.625rem 0.75rem !important;
-		}
-
-		.nav-link-description {
-			display: none;
-		}
-
-		.layout-main {
-			padding: var(--spacing-md) !important;
-			overflow-x: hidden;
-		}
-
-		.page-intro,
-		.card,
-		.metric-card,
-		.action-card,
-		.summary-card {
-			padding: var(--spacing-md) !important;
-		}
-
-		.card-grid,
-		.metric-grid,
-		.action-grid,
-		.status-grid,
-		.summary-card-metrics {
-			grid-template-columns: minmax(0, 1fr) !important;
-		}
-
-		.title-row,
-		.card-heading,
-		.summary-card-heading,
-		.split-row,
-		.inline-links,
-		.form-actions {
-			flex-direction: column;
-			align-items: stretch;
-		}
-
-		.inline-link,
-		button {
-			justify-content: center;
-			width: 100%;
-		}
-	}
-
 	*,
 	*::before,
 	*::after {
@@ -798,11 +715,14 @@ const styles = `
 		background: color-mix(in srgb, var(--color-surface-muted) 68%, transparent);
 	}
 
-	.data-table {
-		display: block;
+	.data-table-scroll {
 		width: 100%;
 		max-width: 100%;
 		overflow-x: auto;
+	}
+
+	.data-table {
+		width: 100%;
 		border-collapse: collapse;
 		font-size: var(--font-size-sm);
 	}
@@ -819,6 +739,89 @@ const styles = `
 	.data-table th {
 		color: var(--color-text-muted);
 		font-weight: var(--font-weight-semibold);
+	}
+
+	@media (max-width: 800px) {
+		.layout-shell {
+			grid-template-columns: 1fr;
+		}
+
+		.sidebar {
+			position: static;
+			height: auto;
+			padding: var(--spacing-md);
+			gap: var(--spacing-md);
+			border-right: none;
+			border-bottom: 1px solid var(--color-border);
+		}
+
+		.sidebar-brand-copy {
+			display: none;
+		}
+
+		.sidebar nav {
+			display: grid;
+			gap: var(--spacing-sm);
+			overflow-x: auto;
+			padding-bottom: var(--spacing-xs);
+			scrollbar-width: thin;
+		}
+
+		.nav-section {
+			min-width: max-content;
+		}
+
+		.nav-list {
+			display: flex;
+			gap: var(--spacing-sm);
+		}
+
+		.nav-link {
+			min-width: max-content;
+			height: 100%;
+			padding: 0.625rem 0.75rem;
+		}
+
+		.nav-link-description {
+			display: none;
+		}
+
+		.layout-main {
+			padding: var(--spacing-md);
+			overflow-x: hidden;
+		}
+
+		.page-intro,
+		.card,
+		.metric-card,
+		.action-card,
+		.summary-card {
+			padding: var(--spacing-md);
+		}
+
+		.card-grid,
+		.metric-grid,
+		.action-grid,
+		.status-grid,
+		.summary-card-metrics {
+			grid-template-columns: minmax(0, 1fr);
+		}
+
+		.title-row,
+		.card-heading,
+		.summary-card-heading,
+		.split-row,
+		.inline-links,
+		.form-actions {
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		.inline-link,
+		button {
+			justify-content: center;
+			width: 100%;
+		}
 	}
 `
 

--- a/packages/home-connector/app/root.ts
+++ b/packages/home-connector/app/root.ts
@@ -746,13 +746,13 @@ const styles = `
 		white-space: nowrap;
 	}
 
-	.data-table th:nth-child(3),
-	.data-table td:nth-child(3) {
+	.data-table-diagnostics th:nth-child(3),
+	.data-table-diagnostics td:nth-child(3) {
 		min-width: 16rem;
 	}
 
-	.data-table th:nth-child(4),
-	.data-table td:nth-child(4) {
+	.data-table-diagnostics th:nth-child(4),
+	.data-table-diagnostics td:nth-child(4) {
 		min-width: 12rem;
 	}
 

--- a/packages/home-connector/app/root.ts
+++ b/packages/home-connector/app/root.ts
@@ -204,8 +204,74 @@ const styles = `
 
 		.sidebar {
 			position: static !important;
+			height: auto !important;
+			padding: var(--spacing-md) !important;
 			border-right: none !important;
 			border-bottom: 1px solid var(--color-border);
+		}
+
+		.sidebar-brand-copy {
+			display: none;
+		}
+
+		.sidebar nav {
+			display: grid;
+			gap: var(--spacing-md);
+			overflow-x: auto;
+			padding-bottom: var(--spacing-xs);
+			scrollbar-width: thin;
+		}
+
+		.nav-section {
+			min-width: max-content;
+		}
+
+		.nav-list {
+			display: flex !important;
+			gap: var(--spacing-sm) !important;
+		}
+
+		.nav-link {
+			min-width: 9.5rem;
+			max-width: 13rem;
+			height: 100%;
+		}
+
+		.layout-main {
+			padding: var(--spacing-md) !important;
+			overflow-x: hidden;
+		}
+
+		.page-intro,
+		.card,
+		.metric-card,
+		.action-card,
+		.summary-card {
+			padding: var(--spacing-md) !important;
+		}
+
+		.card-grid,
+		.metric-grid,
+		.action-grid,
+		.status-grid,
+		.summary-card-metrics {
+			grid-template-columns: minmax(0, 1fr) !important;
+		}
+
+		.title-row,
+		.card-heading,
+		.summary-card-heading,
+		.split-row,
+		.inline-links,
+		.form-actions {
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		.inline-link,
+		button {
+			justify-content: center;
+			width: 100%;
 		}
 	}
 
@@ -217,6 +283,7 @@ const styles = `
 
 	html {
 		background: var(--color-background);
+		overflow-x: hidden;
 	}
 
 	body {
@@ -229,6 +296,7 @@ const styles = `
 		background:
 			radial-gradient(circle at top left, rgb(37 99 235 / 0.08), transparent 28%),
 			var(--color-background);
+		overflow-x: hidden;
 	}
 
 	h1,
@@ -241,6 +309,7 @@ const styles = `
 
 	h1 {
 		font-size: var(--font-size-2xl);
+		overflow-wrap: anywhere;
 	}
 
 	h2 {
@@ -249,6 +318,11 @@ const styles = `
 
 	h3 {
 		font-size: 1rem;
+	}
+
+	p,
+	li {
+		overflow-wrap: anywhere;
 	}
 
 	p,
@@ -415,6 +489,7 @@ const styles = `
 	}
 
 	.page {
+		min-width: 0;
 		width: min(100%, 92rem);
 		margin: 0 auto;
 		display: grid;
@@ -426,6 +501,7 @@ const styles = `
 	.page-header,
 	.page-intro,
 	.section-stack {
+		min-width: 0;
 		display: grid;
 		gap: var(--spacing-lg);
 	}
@@ -718,7 +794,10 @@ const styles = `
 	}
 
 	.data-table {
+		display: block;
 		width: 100%;
+		max-width: 100%;
+		overflow-x: auto;
 		border-collapse: collapse;
 		font-size: var(--font-size-sm);
 	}
@@ -729,6 +808,7 @@ const styles = `
 		text-align: left;
 		vertical-align: top;
 		border-bottom: 1px solid color-mix(in srgb, var(--color-border) 75%, transparent);
+		overflow-wrap: anywhere;
 	}
 
 	.data-table th {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix the home connector admin shell on mobile by shortening the sidebar, using compact horizontally scrollable nav sections, and constraining page overflow.
- Address review feedback by moving mobile overrides after base rules so the cascade applies, and by wrapping tables in a scroll container while preserving native table display and collapsed borders.
- Keep mobile tables readable with wrapper-owned horizontal scrolling, with wider diagnostics-only column sizing scoped to the diagnostics matrix.

## Walkthrough
<a href="https://cursor.com/agents/bc-5e4b62fc-5df2-4fae-a4c5-5062090abbf1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome-connector-mobile-diagnostics-scoped-table.webm"><img src="https://cursor.com/artifacts/c/art-6797f6e9-38d7-4f21-a219-bec312c22767" alt="home-connector-mobile-diagnostics-scoped-table.webm" /></a>
![Mobile diagnostics scoped table layout](https://cursor.com/artifacts/c/art-52274e16-9852-49de-b6c4-c483685e0979)

## Testing
- `npm run format:check -- packages/home-connector/app/admin-ui.ts packages/home-connector/app/dashboard-handlers.ts packages/home-connector/app/root.ts`
- `npm --prefix packages/home-connector run test -- app/router.node.test.ts`
- Playwright computed-style probe confirming `.data-table` remains `display: table`, `border-collapse: collapse`, mobile row alignment computes to `stretch`, and table overflow belongs to `.data-table-scroll`.
- Playwright scoped-width probe confirming diagnostics table opts into `data-table-diagnostics` while generic tables do not inherit diagnostics-only column widths.
- Playwright mobile overflow probe at 393px across `/`, `/system-status`, `/diagnostics`, `/island-router/status`, and all integration status routes.
- Playwright scroll-position probe confirming table scrolling does not change `window.scrollX`, document width, sidebar position, or page position.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e4b62fc-5df2-4fae-a4c5-5062090abbf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e4b62fc-5df2-4fae-a4c5-5062090abbf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

