### PR TITLE
Enable Island router write tools by default

### DIFF
--- a/docs/contributing/architecture/home-connector.md
+++ b/docs/contributing/architecture/home-connector.md
@@ -31,8 +31,8 @@ The connector exposes these local-device families:
 - Samsung TV / Frame discovery and control over mDNS, REST, and local WebSocket
   channels
 - Venstar WiFi thermostat status and control over the local REST API
-- Island router diagnostics over SSH using a typed command allowlist plus a
-  tiny opt-in set of high-risk write operations
+- Island router diagnostics over SSH using a typed command allowlist plus a tiny
+  opt-in set of high-risk write operations
 
 All surfaces are registered as MCP tools inside the connector and then exposed
 to the Worker through the existing outbound WebSocket session to
@@ -140,21 +140,19 @@ The adapter does expose:
 - a structured `router_diagnose_host` workflow that combines ping, ARP,
   reservation, interface, and log data for one host
 - a very small typed write allowlist for `clear dhcp-client`, `clear log`, and
-  `write memory` when `ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true` and all
-  write guardrails pass
+  `write memory` when all write guardrails pass
 
 The adapter explicitly does not expose:
 
 - arbitrary shell or CLI command execution over MCP
-- broad or arbitrary mutating router commands such as reboot, config edits,
-  PoE control, bridge resets, factory reset, or network wipe operations
+- broad or arbitrary mutating router commands such as reboot, config edits, PoE
+  control, bridge resets, factory reset, or network wipe operations
 - password-based auth flows through MCP
 
 The write-capable operations are intentionally hard to use because mistakes can
 have severe consequences. Agents must be highly certain before using them. The
 MCP surface requires:
 
-- explicit runtime opt-in (`ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true`)
 - SSH host verification via `known_hosts` or a pinned host fingerprint
 - typed tool-specific inputs instead of free-form CLI
 - an operator reason and an exact acknowledgement phrase per operation

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -75,8 +75,8 @@ environment variables.
 Required Worker secret used to derive the AES-GCM key for encrypting saved
 secrets at rest in D1.
 
-- **Every environment must set `SECRET_STORE_KEY`**, including local dev and
-  CI, so saved secrets can be encrypted and decrypted.
+- **Every environment must set `SECRET_STORE_KEY`**, including local dev and CI,
+  so saved secrets can be encrypted and decrypted.
 - See [`docs/contributing/secret-rotation.md`](./secret-rotation.md) for
   rotation procedures.
 
@@ -235,16 +235,6 @@ Authoring guide for outbound WebSocket services:
   before opening the real session.
 - `ISLAND_ROUTER_COMMAND_TIMEOUT_MS` — optional connector env var. Default
   timeout for Island router SSH commands in milliseconds. Defaults to `8000`.
-- `ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS` — optional connector env var. Defaults
-  to unset/false. When set to `true`, the connector may expose a tiny, typed,
-  allowlisted set of high-risk mutating Island router tools such as renewing all
-  DHCP clients, clearing the in-memory log buffer, and saving the running
-  configuration. Enable this only when you intentionally want those operations,
-  never as a convenience default. The agent must be highly certain before using
-  them because mistakes can have severe consequences. Write operations also
-  require strict SSH host verification via `ISLAND_ROUTER_KNOWN_HOSTS_PATH` or
-  `ISLAND_ROUTER_HOST_FINGERPRINT`; they stay unavailable when verification is
-  disabled.
 
 ## Why Zod?
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -225,9 +225,6 @@ How to get/set each value:
     - `HOME_CONNECTOR_ISLAND_ROUTER_KNOWN_HOSTS_PATH` or
       `HOME_CONNECTOR_ISLAND_ROUTER_HOST_FINGERPRINT`
     - `HOME_CONNECTOR_ISLAND_ROUTER_COMMAND_TIMEOUT_MS`
-    - `HOME_CONNECTOR_ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS` (optional, defaults
-      to disabled; enables a tiny set of high-risk mutating router tools only
-      after explicit opt-in)
   - When enabling Island router diagnostics in Docker, mount the SSH private key
     (and optionally the known-hosts file) read-only into the container and point
     the env vars at those mounted paths.

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -33,7 +33,8 @@ Quick notes for getting a local kody environment running.
 - Copy `packages/worker/.env.example` to `packages/worker/.env` before starting
   any work, then update secrets as needed. The example includes placeholder
   values for `COOKIE_SECRET` and `SECRET_STORE_KEY`; all environments must set
-  both secrets (see [`docs/contributing/secret-rotation.md`](./secret-rotation.md)).
+  both secrets (see
+  [`docs/contributing/secret-rotation.md`](./secret-rotation.md)).
 - `npm run dev` (starts mock API servers automatically, the main worker, and the
   local home connector; it sets `AI_MODE=mock`, `AI_MOCK_BASE_URL`, and
   `CLOUDFLARE_API_BASE_URL` + `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`
@@ -91,28 +92,29 @@ Quick notes for getting a local kody environment running.
     `HOME_CONNECTOR_DATA_PATH` or the full file path with
     `HOME_CONNECTOR_DB_PATH`.
   - Island router SSH diagnostics are optional. Set `ISLAND_ROUTER_HOST`,
-    `ISLAND_ROUTER_USERNAME`, and `ISLAND_ROUTER_PRIVATE_KEY_PATH` to enable
-    the typed read-oriented MCP tools `router_get_status`,
-    `router_ping_host`, `router_get_arp_entry`, `router_get_dhcp_lease`,
-    `router_get_recent_events`, and `router_diagnose_host`.
+    `ISLAND_ROUTER_USERNAME`, and `ISLAND_ROUTER_PRIVATE_KEY_PATH` to enable the
+    typed MCP tools `router_get_status`, `router_ping_host`,
+    `router_get_arp_entry`, `router_get_dhcp_lease`, `router_get_recent_events`,
+    and `router_diagnose_host`.
   - Prefer mounting the private key read-only into the container or host
-    runtime, for example `-v /path/to/id_ed25519:/run/secrets/island-router-key:ro`
-    plus `HOME_CONNECTOR_ISLAND_ROUTER_PRIVATE_KEY_PATH=/run/secrets/island-router-key`
+    runtime, for example
+    `-v /path/to/id_ed25519:/run/secrets/island-router-key:ro` plus
+    `HOME_CONNECTOR_ISLAND_ROUTER_PRIVATE_KEY_PATH=/run/secrets/island-router-key`
     when launching through `npm run dev`, or
-    `ISLAND_ROUTER_PRIVATE_KEY_PATH=/run/secrets/island-router-key` when
-    running `packages/home-connector` directly.
-  - For host verification, set either `ISLAND_ROUTER_KNOWN_HOSTS_PATH` (preferred)
-    or `ISLAND_ROUTER_HOST_FINGERPRINT`. When neither is set, the connector still
-    works but reports a warning because SSH host verification is disabled.
+    `ISLAND_ROUTER_PRIVATE_KEY_PATH=/run/secrets/island-router-key` when running
+    `packages/home-connector` directly.
+  - For host verification, set either `ISLAND_ROUTER_KNOWN_HOSTS_PATH`
+    (preferred) or `ISLAND_ROUTER_HOST_FINGERPRINT`. When neither is set, the
+    connector still works but reports a warning because SSH host verification is
+    disabled.
   - The Island router integration intentionally does not expose arbitrary
     command execution over MCP. It uses a typed allowlist of documented CLI
     commands.
-  - High-risk Island router write tools are disabled by default. To expose the
-    allowlisted mutating tools `router_renew_dhcp_clients`,
-    `router_clear_log_buffer`, and `router_save_running_config`, set
-    `ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true` and configure SSH host
-    verification with `ISLAND_ROUTER_KNOWN_HOSTS_PATH` or
-    `ISLAND_ROUTER_HOST_FINGERPRINT`.
+  - High-risk Island router write tools are available when SSH host verification
+    is configured with `ISLAND_ROUTER_KNOWN_HOSTS_PATH` or
+    `ISLAND_ROUTER_HOST_FINGERPRINT`. The allowlisted mutating tools are
+    `router_renew_dhcp_clients`, `router_clear_log_buffer`, and
+    `router_save_running_config`.
   - These write tools exist for carefully scoped operational recovery only.
     Their tool descriptions intentionally use strong language because mistakes
     can disrupt connectivity, erase diagnostics, or persist a bad router state

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -35,9 +35,7 @@ verify that the home connector runtime has `ISLAND_ROUTER_HOST`,
 `ISLAND_ROUTER_USERNAME`, and `ISLAND_ROUTER_PRIVATE_KEY_PATH` set, and prefer
 either `ISLAND_ROUTER_KNOWN_HOSTS_PATH` or `ISLAND_ROUTER_HOST_FINGERPRINT` for
 host verification. The connector never exposes arbitrary router command
-execution. By default it exposes read-oriented tools such as
-`router_get_status` and `router_diagnose_host`. A few high-risk, typed,
-allowlisted write tools are available only when
-`ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true` and SSH host verification is
-configured. Those write tools require explicit risk acknowledgement and exact
-confirmation phrases because mistakes can have severe consequences.
+execution. It exposes read-oriented tools such as `router_get_status` and
+`router_diagnose_host`, plus a few high-risk, typed, allowlisted write tools.
+Those write tools require SSH host verification, explicit risk acknowledgement,
+and exact confirmation phrases because mistakes can have severe consequences.

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -51,7 +51,6 @@ function createConfig() {
 	process.env.ISLAND_ROUTER_HOST_FINGERPRINT =
 		'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12'
 	process.env.ISLAND_ROUTER_COMMAND_TIMEOUT_MS = '5000'
-	process.env.ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS = 'false'
 	process.env.VENSTAR_SCAN_CIDRS = '192.168.10.40/32'
 	return loadHomeConnectorConfig()
 }
@@ -344,18 +343,15 @@ test('island router adapter marks malformed fingerprint config as not configured
 	)
 })
 
-test('island router adapter exposes write capability status and runs typed write operations only when explicitly enabled', async () => {
+test('island router adapter exposes write capability status and runs typed write operations with verified SSH config', async () => {
 	using _env = withTemporaryEnv({})
-	createConfig()
-	process.env.ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS = 'true'
-	const config = loadHomeConnectorConfig()
+	const config = createConfig()
 	const islandRouter = createIslandRouterAdapter({
 		config,
 		commandRunner: createFakeRunner(),
 	})
 
 	expect(islandRouter.getConfigStatus()).toMatchObject({
-		writeToolsEnabled: true,
 		writeCapabilitiesAvailable: true,
 	})
 
@@ -396,16 +392,17 @@ test('island router adapter exposes write capability status and runs typed write
 	})
 })
 
-test('island router adapter rejects write operations without explicit enablement and exact confirmation', async () => {
+test('island router adapter rejects write operations without host verification and exact confirmation', async () => {
 	using _env = withTemporaryEnv({})
-	const config = createConfig()
+	createConfig()
+	process.env.ISLAND_ROUTER_HOST_FINGERPRINT = ''
+	const config = loadHomeConnectorConfig()
 	const islandRouter = createIslandRouterAdapter({
 		config,
 		commandRunner: createFakeRunner(),
 	})
 
 	expect(islandRouter.getConfigStatus()).toMatchObject({
-		writeToolsEnabled: false,
 		writeCapabilitiesAvailable: false,
 	})
 
@@ -416,9 +413,10 @@ test('island router adapter rejects write operations without explicit enablement
 				'The WAN DHCP lease is stale after an upstream change and must be renewed intentionally.',
 			confirmation: islandRouter.writeAcknowledgements.renewDhcpClients,
 		}),
-	).rejects.toThrow('ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true')
+	).rejects.toThrow('SSH host verification')
 
-	process.env.ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS = 'true'
+	process.env.ISLAND_ROUTER_HOST_FINGERPRINT =
+		'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12'
 	const enabledConfig = loadHomeConnectorConfig()
 	const enabledIslandRouter = createIslandRouterAdapter({
 		config: enabledConfig,

--- a/packages/home-connector/src/adapters/island-router/types.ts
+++ b/packages/home-connector/src/adapters/island-router/types.ts
@@ -16,7 +16,6 @@ export type IslandRouterConfigStatus = {
 	missingFields: Array<string>
 	verificationMode: IslandRouterVerificationMode
 	warnings: Array<string>
-	writeToolsEnabled: boolean
 	writeCapabilitiesAvailable: boolean
 	writeWarnings: Array<string>
 }

--- a/packages/home-connector/src/adapters/island-router/validation.ts
+++ b/packages/home-connector/src/adapters/island-router/validation.ts
@@ -5,19 +5,14 @@ import {
 	type IslandRouterHostIdentity,
 } from './types.ts'
 
-const macAddressPattern =
-	/^(?<octets>[0-9a-fA-F]{2}([:-][0-9a-fA-F]{2}){5})$/
+const macAddressPattern = /^(?<octets>[0-9a-fA-F]{2}([:-][0-9a-fA-F]{2}){5})$/
 const hostnamePattern =
 	/^(?=.{1,253}$)(?!-)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.(?!-)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
 const sha256FingerprintPattern = /^SHA256:[A-Za-z0-9+/]+={0,2}$/
 const md5FingerprintPattern = /^MD5:(?:[0-9a-fA-F]{2}:){15}[0-9a-fA-F]{2}$/
 
 function normalizeMacAddress(value: string) {
-	const octets = value
-		.trim()
-		.toLowerCase()
-		.replaceAll('-', ':')
-		.split(':')
+	const octets = value.trim().toLowerCase().replaceAll('-', ':').split(':')
 	return octets.map((octet) => octet.padStart(2, '0')).join(':')
 }
 
@@ -25,7 +20,9 @@ function normalizeIpv6(value: string) {
 	return value.trim().toLowerCase()
 }
 
-export function validateIslandRouterHost(value: string): IslandRouterHostIdentity {
+export function validateIslandRouterHost(
+	value: string,
+): IslandRouterHostIdentity {
 	const trimmed = value.trim()
 	if (trimmed.length === 0) {
 		throw new Error('Host must not be empty.')
@@ -111,9 +108,7 @@ export function getIslandRouterConfigStatus(
 			validateIslandRouterFingerprint(config.islandRouterHostFingerprint)
 		} catch (error) {
 			verificationConfigValid = false
-			warnings.push(
-				error instanceof Error ? error.message : String(error),
-			)
+			warnings.push(error instanceof Error ? error.message : String(error))
 		}
 	} else {
 		warnings.push(
@@ -126,21 +121,14 @@ export function getIslandRouterConfigStatus(
 		missingFields,
 		verificationMode,
 		warnings,
-		writeToolsEnabled: config.islandRouterWriteOperationsEnabled,
 		writeCapabilitiesAvailable:
-			config.islandRouterWriteOperationsEnabled &&
 			missingFields.length === 0 &&
 			verificationConfigValid &&
 			verificationMode !== 'none',
 		writeWarnings: [
-			...(config.islandRouterWriteOperationsEnabled
-				? []
-				: [
-						'Island router write operations are disabled. Set ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true only if you intentionally want highly restricted mutating router tools.',
-					]),
 			...(verificationMode === 'none'
 				? [
-						'Island router write operations require SSH host verification. Set ISLAND_ROUTER_KNOWN_HOSTS_PATH or ISLAND_ROUTER_HOST_FINGERPRINT before enabling them.',
+						'Island router write operations require SSH host verification. Set ISLAND_ROUTER_KNOWN_HOSTS_PATH or ISLAND_ROUTER_HOST_FINGERPRINT before using them.',
 					]
 				: []),
 			...(verificationConfigValid
@@ -176,11 +164,6 @@ export function assertIslandRouterConfigured(config: HomeConnectorConfig) {
 
 export function assertIslandRouterWriteConfigured(config: HomeConnectorConfig) {
 	const status = assertIslandRouterConfigured(config)
-	if (!config.islandRouterWriteOperationsEnabled) {
-		throw new Error(
-			'Island router write operations are disabled. Set ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS=true only if you intentionally want these high-risk mutating tools.',
-		)
-	}
 	if (status.verificationMode === 'none') {
 		throw new Error(
 			'Island router write operations require SSH host verification. Set ISLAND_ROUTER_KNOWN_HOSTS_PATH or ISLAND_ROUTER_HOST_FINGERPRINT before using them.',

--- a/packages/home-connector/src/config.node.test.ts
+++ b/packages/home-connector/src/config.node.test.ts
@@ -162,7 +162,6 @@ test('island router SSH env vars are loaded with defaults', () => {
 		ISLAND_ROUTER_KNOWN_HOSTS_PATH: '/keys/known_hosts',
 		ISLAND_ROUTER_HOST_FINGERPRINT: undefined,
 		ISLAND_ROUTER_COMMAND_TIMEOUT_MS: undefined,
-		ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS: undefined,
 	})
 
 	const config = loadHomeConnectorConfig()
@@ -174,7 +173,6 @@ test('island router SSH env vars are loaded with defaults', () => {
 		islandRouterKnownHostsPath: '/keys/known_hosts',
 		islandRouterHostFingerprint: null,
 		islandRouterCommandTimeoutMs: 8000,
-		islandRouterWriteOperationsEnabled: false,
 	})
 })
 
@@ -189,7 +187,6 @@ test('island router SSH env vars honor explicit port, fingerprint, and timeout',
 		ISLAND_ROUTER_HOST_FINGERPRINT:
 			'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12',
 		ISLAND_ROUTER_COMMAND_TIMEOUT_MS: '12000',
-		ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS: 'true',
 	})
 
 	const config = loadHomeConnectorConfig()
@@ -202,7 +199,6 @@ test('island router SSH env vars honor explicit port, fingerprint, and timeout',
 		islandRouterHostFingerprint:
 			'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12',
 		islandRouterCommandTimeoutMs: 12000,
-		islandRouterWriteOperationsEnabled: true,
 	})
 })
 

--- a/packages/home-connector/src/config.ts
+++ b/packages/home-connector/src/config.ts
@@ -14,7 +14,6 @@ export type HomeConnectorConfig = {
 	islandRouterKnownHostsPath: string | null
 	islandRouterHostFingerprint: string | null
 	islandRouterCommandTimeoutMs: number
-	islandRouterWriteOperationsEnabled: boolean
 	rokuDiscoveryUrl: string
 	samsungTvDiscoveryUrl: string
 	lutronDiscoveryUrl: string
@@ -249,8 +248,6 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 			islandRouterCommandTimeoutMs >= 1000
 				? islandRouterCommandTimeoutMs
 				: 8000,
-		islandRouterWriteOperationsEnabled:
-			process.env.ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS === 'true',
 		rokuDiscoveryUrl:
 			process.env.ROKU_DISCOVERY_URL?.trim() || 'ssdp://239.255.255.250:1900',
 		samsungTvDiscoveryUrl:

--- a/packages/home-connector/src/mcp/register-island-router-tools.ts
+++ b/packages/home-connector/src/mcp/register-island-router-tools.ts
@@ -22,7 +22,10 @@ type IslandRouterToolHandler = (
 	args: Record<string, unknown>,
 ) => Promise<CallToolResult>
 
-function structuredTextResult(text: string, structuredContent: unknown): CallToolResult {
+function structuredTextResult(
+	text: string,
+	structuredContent: unknown,
+): CallToolResult {
 	return {
 		content: [
 			{
@@ -45,7 +48,6 @@ export function registerIslandRouterHomeConnectorTools(input: {
 	islandRouter: ReturnType<typeof createIslandRouterAdapter>
 }) {
 	const { registerTool, islandRouter } = input
-	const islandRouterConfig = islandRouter.getConfigStatus()
 
 	const hostSchema = buildToolInputSchema({
 		host: z
@@ -282,121 +284,119 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		},
 	)
 
-	if (islandRouterConfig.writeCapabilitiesAvailable) {
-		const createRouterWriteSchema = (confirmationPhrase: string) =>
-			buildToolInputSchema({
-				acknowledgeHighRisk: z
-					.literal(true)
-					.describe(
-						'Must be true. Set this only when you are highly certain the requested router mutation is necessary and correct.',
-					),
-				reason: z
-					.string()
-					.min(20)
-					.max(500)
-					.describe(
-						'Short operator justification. Be specific about why this mutation is necessary right now.',
-					),
-				confirmation: z
-					.literal(confirmationPhrase)
-					.describe(
-						'Exact confirmation phrase required by the tool. The tool rejects any other value.',
-					),
-				timeoutMs: z
-					.number()
-					.int()
-					.min(1000)
-					.max(60_000)
-					.optional()
-					.describe('Optional command timeout in milliseconds.'),
+	const createRouterWriteSchema = (confirmationPhrase: string) =>
+		buildToolInputSchema({
+			acknowledgeHighRisk: z
+				.literal(true)
+				.describe(
+					'Must be true. Set this only when you are highly certain the requested router mutation is necessary and correct.',
+				),
+			reason: z
+				.string()
+				.min(20)
+				.max(500)
+				.describe(
+					'Short operator justification. Be specific about why this mutation is necessary right now.',
+				),
+			confirmation: z
+				.literal(confirmationPhrase)
+				.describe(
+					'Exact confirmation phrase required by the tool. The tool rejects any other value.',
+				),
+			timeoutMs: z
+				.number()
+				.int()
+				.min(1000)
+				.max(60_000)
+				.optional()
+				.describe('Optional command timeout in milliseconds.'),
+		})
+
+	const renewDhcpClientsSchema = createRouterWriteSchema(
+		islandRouter.writeAcknowledgements.renewDhcpClients,
+	)
+	const clearLogBufferSchema = createRouterWriteSchema(
+		islandRouter.writeAcknowledgements.clearLogBuffer,
+	)
+	const saveRunningConfigSchema = createRouterWriteSchema(
+		islandRouter.writeAcknowledgements.saveRunningConfig,
+	)
+
+	registerTool(
+		{
+			name: 'router_renew_dhcp_clients',
+			title: 'Renew DHCP Clients On Island Router',
+			description: `${routerWriteDangerNotice} This typed allowlisted operation runs the documented Island CLI command \`clear dhcp-client\` to request immediate renewal of DHCP-learned addresses. Never use it as a guess or for broad troubleshooting.`,
+			inputSchema: renewDhcpClientsSchema.inputSchema,
+			sdkInputSchema: renewDhcpClientsSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await islandRouter.renewDhcpClients({
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
 			})
+			return structuredTextResult(
+				'Triggered an immediate renewal of DHCP-learned addresses on the Island router.',
+				result,
+			)
+		},
+	)
 
-		const renewDhcpClientsSchema = createRouterWriteSchema(
-			islandRouter.writeAcknowledgements.renewDhcpClients,
-		)
-		const clearLogBufferSchema = createRouterWriteSchema(
-			islandRouter.writeAcknowledgements.clearLogBuffer,
-		)
-		const saveRunningConfigSchema = createRouterWriteSchema(
-			islandRouter.writeAcknowledgements.saveRunningConfig,
-		)
+	registerTool(
+		{
+			name: 'router_clear_log_buffer',
+			title: 'Clear Island Router Log Buffer',
+			description: `${routerWriteDangerNotice} This typed allowlisted operation runs the documented Island CLI command \`clear log\` and permanently removes the in-memory system log buffer. Use it only when you are highly certain existing log data is no longer needed.`,
+			inputSchema: clearLogBufferSchema.inputSchema,
+			sdkInputSchema: clearLogBufferSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await islandRouter.clearLogBuffer({
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return structuredTextResult(
+				'Cleared the Island router in-memory log buffer.',
+				result,
+			)
+		},
+	)
 
-		registerTool(
-			{
-				name: 'router_renew_dhcp_clients',
-				title: 'Renew DHCP Clients On Island Router',
-				description: `${routerWriteDangerNotice} This typed allowlisted operation runs the documented Island CLI command \`clear dhcp-client\` to request immediate renewal of DHCP-learned addresses. Never use it as a guess or for broad troubleshooting.`,
-				inputSchema: renewDhcpClientsSchema.inputSchema,
-				sdkInputSchema: renewDhcpClientsSchema.sdkInputSchema,
-				annotations: {
-					destructiveHint: true,
-				},
+	registerTool(
+		{
+			name: 'router_save_running_config',
+			title: 'Save Island Router Running Config',
+			description: `${routerWriteDangerNotice} This typed allowlisted operation runs the documented Island CLI command \`write memory\` to persist the current running configuration to startup storage. A mistake can permanently preserve a bad router state, so the agent must be highly certain before using it.`,
+			inputSchema: saveRunningConfigSchema.inputSchema,
+			sdkInputSchema: saveRunningConfigSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
 			},
-			async (args) => {
-				const result = await islandRouter.renewDhcpClients({
-					acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
-					reason: String(args['reason'] ?? ''),
-					confirmation: String(args['confirmation'] ?? ''),
-					timeoutMs:
-						args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
-				})
-				return structuredTextResult(
-					'Triggered an immediate renewal of DHCP-learned addresses on the Island router.',
-					result,
-				)
-			},
-		)
-
-		registerTool(
-			{
-				name: 'router_clear_log_buffer',
-				title: 'Clear Island Router Log Buffer',
-				description: `${routerWriteDangerNotice} This typed allowlisted operation runs the documented Island CLI command \`clear log\` and permanently removes the in-memory system log buffer. Use it only when you are highly certain existing log data is no longer needed.`,
-				inputSchema: clearLogBufferSchema.inputSchema,
-				sdkInputSchema: clearLogBufferSchema.sdkInputSchema,
-				annotations: {
-					destructiveHint: true,
-				},
-			},
-			async (args) => {
-				const result = await islandRouter.clearLogBuffer({
-					acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
-					reason: String(args['reason'] ?? ''),
-					confirmation: String(args['confirmation'] ?? ''),
-					timeoutMs:
-						args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
-				})
-				return structuredTextResult(
-					'Cleared the Island router in-memory log buffer.',
-					result,
-				)
-			},
-		)
-
-		registerTool(
-			{
-				name: 'router_save_running_config',
-				title: 'Save Island Router Running Config',
-				description: `${routerWriteDangerNotice} This typed allowlisted operation runs the documented Island CLI command \`write memory\` to persist the current running configuration to startup storage. A mistake can permanently preserve a bad router state, so the agent must be highly certain before using it.`,
-				inputSchema: saveRunningConfigSchema.inputSchema,
-				sdkInputSchema: saveRunningConfigSchema.sdkInputSchema,
-				annotations: {
-					destructiveHint: true,
-				},
-			},
-			async (args) => {
-				const result = await islandRouter.saveRunningConfig({
-					acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
-					reason: String(args['reason'] ?? ''),
-					confirmation: String(args['confirmation'] ?? ''),
-					timeoutMs:
-						args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
-				})
-				return structuredTextResult(
-					'Saved the Island router running configuration to startup storage.',
-					result,
-				)
-			},
-		)
-	}
+		},
+		async (args) => {
+			const result = await islandRouter.saveRunningConfig({
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return structuredTextResult(
+				'Saved the Island router running configuration to startup storage.',
+				result,
+			)
+		},
+	)
 }

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -14,7 +14,7 @@ import { createHomeConnectorMcpServer } from './server.ts'
 import { createAppState } from '../state.ts'
 import { createHomeConnectorStorage } from '../storage/index.ts'
 
-function createConfig(options?: { writeOperationsEnabled?: boolean }) {
+function createConfig() {
 	process.env.MOCKS = 'true'
 	process.env.HOME_CONNECTOR_ID = 'default'
 	process.env.HOME_CONNECTOR_SHARED_SECRET =
@@ -35,17 +35,11 @@ function createConfig(options?: { writeOperationsEnabled?: boolean }) {
 	process.env.ISLAND_ROUTER_HOST_FINGERPRINT =
 		'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12'
 	process.env.ISLAND_ROUTER_COMMAND_TIMEOUT_MS = '5000'
-	process.env.ISLAND_ROUTER_ENABLE_WRITE_OPERATIONS = options
-		?.writeOperationsEnabled
-		? 'true'
-		: 'false'
 	return loadHomeConnectorConfig()
 }
 
 function createIslandRouterRunner() {
-	return async (
-		request: IslandRouterCommandRequest,
-	) => {
+	return async (request: IslandRouterCommandRequest) => {
 		switch (request.id) {
 			case 'show-version':
 				return {
@@ -138,7 +132,10 @@ function createIslandRouterRunner() {
 			case 'show-interface':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', `show interface ${request.interfaceName}`],
+					commandLines: [
+						'terminal length 0',
+						`show interface ${request.interfaceName}`,
+					],
 					stdout: `Interface: ${request.interfaceName}\nLink State: up`,
 					stderr: '',
 					exitCode: 0,
@@ -307,25 +304,27 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		).toBe(true)
 		expect(tools.some((tool) => tool.name === 'router_get_status')).toBe(true)
 		expect(tools.some((tool) => tool.name === 'router_ping_host')).toBe(true)
-		expect(tools.some((tool) => tool.name === 'router_get_arp_entry')).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_arp_entry')).toBe(
+			true,
+		)
 		expect(tools.some((tool) => tool.name === 'router_get_dhcp_lease')).toBe(
 			true,
 		)
-		expect(
-			tools.some((tool) => tool.name === 'router_get_recent_events'),
-		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_recent_events')).toBe(
+			true,
+		)
 		expect(tools.some((tool) => tool.name === 'router_diagnose_host')).toBe(
 			true,
 		)
 		expect(
 			tools.some((tool) => tool.name === 'router_renew_dhcp_clients'),
-		).toBe(false)
-		expect(
-			tools.some((tool) => tool.name === 'router_clear_log_buffer'),
-		).toBe(false)
+		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_clear_log_buffer')).toBe(
+			true,
+		)
 		expect(
 			tools.some((tool) => tool.name === 'router_save_running_config'),
-		).toBe(false)
+		).toBe(true)
 		expect(
 			tools.some((tool) => tool.name === 'jellyfish_scan_controllers'),
 		).toBe(true)
@@ -537,8 +536,8 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 	}
 })
 
-test('mcp server exposes island router write tools only when explicitly enabled', async () => {
-	const config = createConfig({ writeOperationsEnabled: true })
+test('mcp server exposes island router write tools when host verification is configured', async () => {
+	const config = createConfig()
 	const state = createAppState()
 	const storage = createHomeConnectorStorage(config)
 	const samsungTv = createSamsungTvAdapter({
@@ -588,9 +587,9 @@ test('mcp server exposes island router write tools only when explicitly enabled'
 		expect(
 			tools.some((tool) => tool.name === 'router_renew_dhcp_clients'),
 		).toBe(true)
-		expect(
-			tools.some((tool) => tool.name === 'router_clear_log_buffer'),
-		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_clear_log_buffer')).toBe(
+			true,
+		)
 		expect(
 			tools.some((tool) => tool.name === 'router_save_running_config'),
 		).toBe(true)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove the Island router write-operation environment toggle from home connector config.
- Always register the typed Island router write MCP tools while keeping host verification, high-risk acknowledgement, reason, and exact confirmation checks.
- Update tests and docs to reflect that write capabilities have no availability configuration option.

## Testing
- `npm --prefix packages/home-connector test -- --run packages/home-connector/src/config.node.test.ts packages/home-connector/src/adapters/island-router/index.node.test.ts packages/home-connector/src/mcp/server.node.test.ts`
- `npm run typecheck`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e8e65a8-f856-4d7e-8d24-b99316cda116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e8e65a8-f856-4d7e-8d24-b99316cda116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

