### PR TITLE
feat: expand Island router SSH capabilities

### DIFF
--- a/docs/contributing/architecture/home-connector.md
+++ b/docs/contributing/architecture/home-connector.md
@@ -131,22 +131,26 @@ connector.
 
 The adapter does expose:
 
-- router identity/status via `show version`, `show clock`, and
+- router identity/status via `show version`, `show clock`, `show system`, and
   `show interface summary`
 - router-side reachability checks with `ping`
 - ARP / neighbor-cache inspection with `show ip neighbors`
 - DHCP reservation inspection with `show ip dhcp-reservations`
 - recent-event lookups with `show log`
+- structured WAN, failover, routing, NAT, VLAN, DNS, user, firewall/security,
+  QoS, traffic, session, VPN, DHCP-server, NTP, syslog, SNMP, and
+  bandwidth-usage reads from a typed SSH CLI allowlist
 - a structured `router_diagnose_host` workflow that combines ping, ARP,
   reservation, interface, and log data for one host
-- a very small typed write allowlist for `clear dhcp-client`, `clear log`, and
+- a broader but still typed and explicitly allowlisted high-risk write surface
+  for failover selection, DHCP reservations, reboot, interface descriptions,
+  DNS servers, host blocking/unblocking, `clear dhcp-client`, `clear log`, and
   `write memory` when all write guardrails pass
 
 The adapter explicitly does not expose:
 
 - arbitrary shell or CLI command execution over MCP
-- broad or arbitrary mutating router commands such as reboot, config edits, PoE
-  control, bridge resets, factory reset, or network wipe operations
+- arbitrary mutating router commands beyond the typed allowlist
 - password-based auth flows through MCP
 
 The write-capable operations are intentionally hard to use because mistakes can

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -93,9 +93,10 @@ Quick notes for getting a local kody environment running.
     `HOME_CONNECTOR_DB_PATH`.
   - Island router SSH diagnostics are optional. Set `ISLAND_ROUTER_HOST`,
     `ISLAND_ROUTER_USERNAME`, and `ISLAND_ROUTER_PRIVATE_KEY_PATH` to enable the
-    typed MCP tools `router_get_status`, `router_ping_host`,
-    `router_get_arp_entry`, `router_get_dhcp_lease`, `router_get_recent_events`,
-    and `router_diagnose_host`.
+    typed MCP tools for router status, host diagnosis, WAN/failover state,
+    routing/NAT/session inspection, VLAN/DNS/DHCP policy inspection, VPN/NTP/
+    syslog/SNMP/system-health reads, and the other typed read-only router
+    diagnostics exposed by the home connector.
   - Prefer mounting the private key read-only into the container or host
     runtime, for example
     `-v /path/to/id_ed25519:/run/secrets/island-router-key:ro` plus
@@ -112,9 +113,11 @@ Quick notes for getting a local kody environment running.
     commands.
   - High-risk Island router write tools are available when SSH host verification
     is configured with `ISLAND_ROUTER_KNOWN_HOSTS_PATH` or
-    `ISLAND_ROUTER_HOST_FINGERPRINT`. The allowlisted mutating tools are
-    `router_renew_dhcp_clients`, `router_clear_log_buffer`, and
-    `router_save_running_config`.
+    `ISLAND_ROUTER_HOST_FINGERPRINT`. The allowlisted mutating tools include
+    targeted operational actions such as WAN failover forcing, DHCP reservation
+    changes, reboot, interface-description changes, DNS-server changes,
+    block/unblock-host actions, DHCP client renewal, log clearing, config save,
+    and a narrowly allowlisted router CLI escape hatch.
   - These write tools exist for carefully scoped operational recovery only.
     Their tool descriptions intentionally use strong language because mistakes
     can disrupt connectivity, erase diagnostics, or persist a bad router state

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -35,7 +35,9 @@ verify that the home connector runtime has `ISLAND_ROUTER_HOST`,
 `ISLAND_ROUTER_USERNAME`, and `ISLAND_ROUTER_PRIVATE_KEY_PATH` set, and prefer
 either `ISLAND_ROUTER_KNOWN_HOSTS_PATH` or `ISLAND_ROUTER_HOST_FINGERPRINT` for
 host verification. The connector never exposes arbitrary router command
-execution. It exposes read-oriented tools such as `router_get_status` and
-`router_diagnose_host`, plus a few high-risk, typed, allowlisted write tools.
-Those write tools require SSH host verification, explicit risk acknowledgement,
-and exact confirmation phrases because mistakes can have severe consequences.
+execution. It exposes a broader typed read surface (status, WAN/failover,
+routing, NAT, VLAN, DNS, users, security policy, QoS, traffic stats, sessions,
+VPN, DHCP server, NTP, syslog, SNMP, system info, and bandwidth usage) plus a
+set of high-risk, typed, allowlisted write tools. Those write tools require SSH
+host verification, explicit risk acknowledgement, and exact confirmation
+phrases because mistakes can have severe consequences.

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -295,8 +295,8 @@ function createFakeRunner() {
 						'Search Domains: home.arpa, lan',
 						'Server  Role       Source',
 						'------  ---------  --------',
-						'1.1.1.1 upstream   static',
-						'8.8.8.8 upstream   dhcp',
+						'1.1.1.1  upstream   static',
+						'8.8.8.8  upstream   dhcp',
 						'host=nas.home.arpa value=192.168.0.52 enabled=yes',
 					].join('\n'),
 					stderr: '',
@@ -911,7 +911,7 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 		searchDomains: ['home.arpa', 'lan'],
 		servers: expect.arrayContaining([
 			expect.objectContaining({
-				address: '1.1.1.1 upstream',
+					address: '1.1.1.1',
 			}),
 		]),
 	})

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -84,6 +84,22 @@ function createFakeRunner() {
 					timedOut: false,
 					durationMs: 10,
 				}
+			case 'show-system':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show system'],
+					stdout: [
+						'Uptime: 5 days 2 hours',
+						'CPU Usage: 17%',
+						'Memory Usage: 42%',
+						'Temperature: 54 C',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
 			case 'show-interface-summary':
 				return {
 					id: request.id,
@@ -93,6 +109,91 @@ function createFakeRunner() {
 						'---------  -----  -----  ------  -----------',
 						'en0        up     1G     full    LAN uplink',
 						'en1        down   1G     full    spare port',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-interface-statistics':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show interface statistics'],
+					stdout: [
+						'Interface  RX Bytes  TX Bytes  RX Packets  TX Packets  RX Errors  TX Errors  Utilization',
+						'---------  --------  --------  ----------  ----------  ---------  ---------  -----------',
+						'en0        1200000   2400000   1000        1500        0          1          37%',
+						'en1        100       200       1           2           0          0          1%',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-bandwidth-usage':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show bandwidth-usage'],
+					stdout: [
+						'Subject            Interface  RX Rate   TX Rate   Total Rate',
+						'-----------------  ---------  --------  --------  ----------',
+						'192.168.0.52       en0        12 Mbps   2 Mbps    14 Mbps',
+						'WAN aggregate      en1        150 Mbps  20 Mbps   170 Mbps',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-wan':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show wan'],
+					stdout: [
+						'ISP          Interface  IP Address     Gateway       Type   Role    Priority  Status',
+						'-----------  ---------  -------------  ------------  -----  ------  --------  ------',
+						'Fiber        en1        203.0.113.10   203.0.113.1   DHCP   active  1         up',
+						'LTE Backup   en2        198.51.100.22  198.51.100.1  DHCP   standby   2         up',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-wan-failover':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show wan failover'],
+					stdout: [
+						'Active Interface: en1',
+						'Active ISP: Fiber',
+						'Policy: priority',
+						'Interface  ISP         Health  Role     Priority  Monitor',
+						'---------  ----------  ------  -------  --------  ----------------',
+						'en1        Fiber       up      active   1         8.8.8.8',
+						'en2        LTE Backup up      standby  2         1.1.1.1',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-multi-wan':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show multi-wan'],
+					stdout: [
+						'Active Interface: en1',
+						'Policy: priority',
+						'Interface  ISP         Status   Priority',
+						'---------  ----------  -------  --------',
+						'en1        Fiber       active   1',
+						'en2        LTE Backup standby  2',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -116,6 +217,181 @@ function createFakeRunner() {
 					timedOut: false,
 					durationMs: 10,
 				}
+			case 'show-ip-routes':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ip routes'],
+					stdout: [
+						'Destination      Gateway       Interface  Protocol  Metric  Selected',
+						'---------------  ------------  ---------  --------  ------  --------',
+						'default          203.0.113.1   en1        static    1       yes',
+						'192.168.0.0/24   0.0.0.0       en0        kernel    0       yes',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-nat':
+			case 'show-ip-nat':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.id === 'show-nat' ? 'show nat' : 'show ip nat',
+					],
+					stdout: [
+						'Rule  Type         Protocol  Interface  External         Internal         Enabled  Description',
+						'----  -----------  --------  ---------  ---------------  ---------------  -------  -----------',
+						'1     port-forward  tcp       en1        203.0.113.10:80  192.168.0.52:80  yes      NAS web',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-sessions':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show sessions'],
+					stdout: [
+						'Protocol  Source                Destination           Translated            State        Interface',
+						'--------  --------------------  --------------------  --------------------  -----------  ---------',
+						'tcp       192.168.0.52:51514    93.184.216.34:443     203.0.113.10:51514   established  en1',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-vlan':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show vlan'],
+					stdout: [
+						'VLAN  Name    Interface  Members     Status  Address',
+						'----  ------  ---------  ----------  ------  -------------',
+						'10    Main    vlan10     en0,en3     up      192.168.0.1/24',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-dns':
+			case 'show-ip-dns':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.id === 'show-dns' ? 'show dns' : 'show ip dns',
+					],
+					stdout: [
+						'Mode: forwarding',
+						'Search Domains: home.arpa, lan',
+						'Server  Role       Source',
+						'------  ---------  --------',
+						'1.1.1.1 upstream   static',
+						'8.8.8.8 upstream   dhcp',
+						'host=nas.home.arpa value=192.168.0.52 enabled=yes',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-users':
+			case 'show-user':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.id === 'show-users' ? 'show users' : 'show user',
+					],
+					stdout: [
+						'Username  Group   Role       Connection  Address        Connected',
+						'--------  ------  ---------  ----------  -------------  ---------',
+						'admin     admins  admin      ssh         192.168.0.20   yes',
+						'user      users   readonly   web         192.168.0.30   yes',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-security-policy':
+			case 'show-protection':
+			case 'show-firewall':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.id === 'show-security-policy'
+							? 'show security-policy'
+							: request.id === 'show-protection'
+								? 'show protection'
+								: 'show firewall',
+					],
+					stdout: [
+						'Rule  Name         Action  Source         Destination    Service  Enabled',
+						'----  -----------  ------  -------------  -------------  -------  -------',
+						'10    block-guest  deny    192.168.0.99   any            any      yes',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-qos':
+			case 'show-traffic-policy':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.id === 'show-qos' ? 'show qos' : 'show traffic-policy',
+					],
+					stdout: [
+						'Policy   Interface  Class      Priority  Bandwidth  Enabled',
+						'-------  ---------  ---------  --------  ---------  -------',
+						'wan-qos  en1        voice      high      10 Mbps    yes',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-vpn':
+			case 'show-ipsec':
+			case 'show-gre':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.id === 'show-vpn'
+							? 'show vpn'
+							: request.id === 'show-ipsec'
+								? 'show ipsec'
+								: 'show gre',
+					],
+					stdout: [
+						'Tunnel      Type   Local          Remote         Status  Interface',
+						'----------  -----  -------------  -------------  ------  ---------',
+						'office-ipsec  ipsec  203.0.113.10   198.51.100.20  up      tun0',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
 			case 'show-ip-dhcp-reservations':
 				return {
 					id: request.id,
@@ -124,6 +400,69 @@ function createFakeRunner() {
 						'IP Address    MAC Address        Host Name  Interface',
 						'------------  -----------------  ---------  ---------',
 						'192.168.0.52  00:11:22:33:44:55  nas-box    en0',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-dhcp-server':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show dhcp-server'],
+					stdout: [
+						'Pool  Interface  Network         Range Start    Range End      Gateway       DNS',
+						'----  ---------  --------------  -------------  -------------  ------------  --------',
+						'main  en0        192.168.0.0/24  192.168.0.50   192.168.0.199  192.168.0.1   1.1.1.1,8.8.8.8',
+						'Option 6 value=1.1.1.1,8.8.8.8',
+						'192.168.0.52  00:11:22:33:44:55  nas-box    en0',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ntp':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ntp'],
+					stdout: [
+						'Timezone: America/Denver',
+						'Server         Status  Source',
+						'-------------  ------  ------',
+						'162.159.200.1  synced  static',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-syslog':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show syslog'],
+					stdout: [
+						'Host            Port  Protocol  Facility  Enabled',
+						'--------------  ----  --------  --------  -------',
+						'192.168.0.60    514   udp       local0    yes',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-snmp':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show snmp'],
+					stdout: [
+						'Enabled: yes',
+						'community=public access=ro source=192.168.0.0/24',
+						'trap target=192.168.0.61 version=2c community=public',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -201,6 +540,121 @@ function createFakeRunner() {
 					signal: null,
 					timedOut: false,
 					durationMs: 200,
+				}
+			case 'force-wan-failover':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						`wan failover force ${request.interfaceName}`,
+					],
+					stdout: `Forced WAN failover to ${request.interfaceName}.`,
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 15,
+				}
+			case 'set-dhcp-reservation':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						`dhcp-server reservation ${request.macAddress} ${request.ipAddress}`,
+					],
+					stdout: `Reservation set for ${request.macAddress}.`,
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 15,
+				}
+			case 'remove-dhcp-reservation':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.ipAddress
+							? `no dhcp-server reservation ${request.macAddress} ${request.ipAddress}`
+							: `no dhcp-server reservation ${request.macAddress}`,
+					],
+					stdout: `Reservation removed for ${request.macAddress}.`,
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 15,
+				}
+			case 'reboot':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'reload'],
+					stdout: 'System reboot scheduled.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 15,
+				}
+			case 'set-interface-description':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						`interface ${request.interfaceName}`,
+						`description "${request.description}"`,
+					],
+					stdout: `Description updated for ${request.interfaceName}.`,
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 15,
+				}
+			case 'set-dns-server':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						...(request.interfaceName
+							? [`interface ${request.interfaceName}`]
+							: []),
+						...request.servers.map((server) => `ip name-server ${server}`),
+					],
+					stdout: `DNS servers updated to ${request.servers.join(', ')}.`,
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 15,
+				}
+			case 'block-host':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						`firewall block host ${request.host}`,
+					],
+					stdout: `Blocked ${request.host}.`,
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 15,
+				}
+			case 'unblock-host':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						`no firewall block host ${request.host}`,
+					],
+					stdout: `Unblocked ${request.host}.`,
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 15,
 				}
 			case 'clear-dhcp-client':
 				return {
@@ -389,6 +843,308 @@ test('island router adapter exposes write capability status and runs typed write
 		operationId: 'save-running-config',
 		commandId: 'write-memory',
 		commandLines: ['terminal length 0', 'write memory'],
+	})
+})
+
+test('island router adapter exposes expanded read and high-risk write capabilities', async () => {
+	using _env = withTemporaryEnv({})
+	const config = createConfig()
+	const islandRouter = createIslandRouterAdapter({
+		config,
+		commandRunner: createFakeRunner(),
+	})
+
+	const wanConfig = await islandRouter.getWanConfig()
+	expect(wanConfig.wans).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				interfaceName: 'en1',
+				ispName: 'Fiber',
+				connectionType: 'dhcp',
+				role: 'active',
+			}),
+		]),
+	)
+
+	const failover = await islandRouter.getFailoverStatus()
+	expect(failover).toMatchObject({
+		activeInterfaceName: 'en1',
+		activeIspName: 'Fiber',
+		policy: 'priority',
+	})
+
+	const routingTable = await islandRouter.getRoutingTable()
+	expect(routingTable.routes).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				destination: 'default',
+				gateway: '203.0.113.1',
+				interfaceName: 'en1',
+			}),
+		]),
+	)
+
+	const natRules = await islandRouter.getNatRules()
+	expect(natRules.rules).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				ruleId: '1',
+				externalAddress: '203.0.113.10',
+				internalAddress: '192.168.0.52',
+			}),
+		]),
+	)
+
+	const vlanConfig = await islandRouter.getVlanConfig()
+	expect(vlanConfig.vlans).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				vlanId: 10,
+				interfaceName: 'vlan10',
+			}),
+		]),
+	)
+
+	const dnsConfig = await islandRouter.getDnsConfig()
+	expect(dnsConfig).toMatchObject({
+		mode: 'forwarding',
+		searchDomains: ['home.arpa', 'lan'],
+		servers: expect.arrayContaining([
+			expect.objectContaining({
+				address: '1.1.1.1 upstream',
+			}),
+		]),
+	})
+
+	const users = await islandRouter.getUsers()
+	expect(users.users).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				username: 'admin',
+			}),
+		]),
+	)
+
+	const securityPolicy = await islandRouter.getSecurityPolicy()
+	expect(securityPolicy.rules).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				action: 'deny',
+			}),
+		]),
+	)
+
+	const qos = await islandRouter.getQosConfig()
+	expect(qos.policies).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				policyName: 'wan-qos',
+				className: 'voice',
+			}),
+		]),
+	)
+
+	const trafficStats = await islandRouter.getTrafficStats()
+	expect(trafficStats.interfaces).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				interfaceName: 'en0',
+				rxBytes: 1_200_000,
+				txBytes: 2_400_000,
+			}),
+		]),
+	)
+
+	const activeSessions = await islandRouter.getActiveSessions()
+	expect(activeSessions.sessions).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				sourceAddress: '192.168.0.52',
+				destinationAddress: '93.184.216.34',
+				destinationPort: 443,
+			}),
+		]),
+	)
+
+	const vpn = await islandRouter.getVpnConfig()
+	expect(vpn.tunnels).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				tunnelName: 'office-ipsec',
+				type: 'ipsec',
+			}),
+		]),
+	)
+
+	const dhcpServerConfig = await islandRouter.getDhcpServerConfig()
+	expect(dhcpServerConfig).toMatchObject({
+		pools: expect.arrayContaining([
+			expect.objectContaining({
+				poolName: 'main',
+			}),
+		]),
+		reservations: expect.arrayContaining([
+			expect.objectContaining({
+				macAddress: '00:11:22:33:44:55',
+			}),
+		]),
+	})
+
+	const ntpConfig = await islandRouter.getNtpConfig()
+	expect(ntpConfig.servers).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				server: '162.159.200.1',
+			}),
+		]),
+	)
+
+	const syslogConfig = await islandRouter.getSyslogConfig()
+	expect(syslogConfig.targets).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				host: '192.168.0.60',
+				port: 514,
+			}),
+		]),
+	)
+
+	const snmpConfig = await islandRouter.getSnmpConfig()
+	expect(snmpConfig).toMatchObject({
+		enabled: true,
+		trapTargets: expect.arrayContaining([
+			expect.objectContaining({
+				host: '192.168.0.61',
+			}),
+		]),
+	})
+
+	const systemInfo = await islandRouter.getSystemInfo()
+	expect(systemInfo).toMatchObject({
+		uptime: expect.stringContaining('days'),
+		cpuUsagePercent: 17,
+		memoryUsagePercent: 42,
+		temperatureCelsius: 54,
+	})
+
+	const bandwidthUsage = await islandRouter.getBandwidthUsage()
+	expect(bandwidthUsage.entries).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				subject: '192.168.0.52',
+				rxRate: '12 Mbps',
+			}),
+		]),
+	)
+
+	const allowlistedCommand = await islandRouter.runAllowlistedCliCommand({
+		command: 'show-version',
+		acknowledgeHighRisk: true,
+		reason:
+			'A targeted allowlisted diagnostic is needed because the typed version tool output must be compared during incident response.',
+		confirmation: islandRouter.writeAcknowledgements.runAllowlistedCliCommand,
+	})
+	expect(allowlistedCommand).toMatchObject({
+		command: 'show-version',
+		commandId: 'show-version',
+		result: {
+			model: 'Island Pro',
+		},
+	})
+
+	const wanFailover = await islandRouter.setWanFailover({
+		interfaceName: 'en1',
+		acknowledgeHighRisk: true,
+		reason:
+			'The primary WAN is degraded and traffic must be forced to the backup interface during a maintenance window.',
+		confirmation: islandRouter.writeAcknowledgements.setWanFailover,
+	})
+	expect(wanFailover).toMatchObject({
+		operationId: 'set-wan-failover',
+		commandId: 'force-wan-failover',
+	})
+
+	const setReservation = await islandRouter.setDhcpReservation({
+		action: 'set',
+		macAddress: '00:11:22:33:44:66',
+		ipAddress: '192.168.0.60',
+		hostName: 'printer',
+		interfaceName: 'en0',
+		acknowledgeHighRisk: true,
+		reason:
+			'The printer requires a fixed IP reservation to restore LAN printing and the intended mapping was validated out of band.',
+		confirmation: islandRouter.writeAcknowledgements.setDhcpReservation,
+	})
+	expect(setReservation).toMatchObject({
+		commandId: 'set-dhcp-reservation',
+	})
+
+	const removeReservation = await islandRouter.setDhcpReservation({
+		action: 'remove',
+		macAddress: '00:11:22:33:44:66',
+		ipAddress: '192.168.0.60',
+		acknowledgeHighRisk: true,
+		reason:
+			'The old reservation must be removed because the device was decommissioned and the address needs to return to the DHCP pool.',
+		confirmation: islandRouter.writeAcknowledgements.setDhcpReservation,
+	})
+	expect(removeReservation).toMatchObject({
+		commandId: 'remove-dhcp-reservation',
+	})
+
+	const rebootResult = await islandRouter.rebootRouter({
+		acknowledgeHighRisk: true,
+		reason:
+			'The router must be rebooted now because configuration drift persists after validated changes and an outage window is active.',
+		confirmation: islandRouter.writeAcknowledgements.reboot,
+	})
+	expect(rebootResult).toMatchObject({
+		commandId: 'reboot',
+	})
+
+	const descriptionResult = await islandRouter.setInterfaceDescription({
+		interfaceName: 'en0',
+		description: 'Main LAN uplink',
+		acknowledgeHighRisk: true,
+		reason:
+			'The interface label needs to be corrected to avoid operator error during maintenance and the updated description is known-good.',
+		confirmation: islandRouter.writeAcknowledgements.setInterfaceDescription,
+	})
+	expect(descriptionResult).toMatchObject({
+		commandId: 'set-interface-description',
+	})
+
+	const dnsServerResult = await islandRouter.setDnsServer({
+		servers: ['1.1.1.1', '8.8.8.8'],
+		acknowledgeHighRisk: true,
+		reason:
+			'The resolver list must be updated intentionally because the upstream DNS providers changed and validation was completed already.',
+		confirmation: islandRouter.writeAcknowledgements.setDnsServer,
+	})
+	expect(dnsServerResult).toMatchObject({
+		commandId: 'set-dns-server',
+	})
+
+	const blockResult = await islandRouter.blockHost({
+		host: '192.168.0.99',
+		acknowledgeHighRisk: true,
+		reason:
+			'A compromised device must be isolated immediately and this IP was confirmed by incident response before enforcement.',
+		confirmation: islandRouter.writeAcknowledgements.blockHost,
+	})
+	expect(blockResult).toMatchObject({
+		commandId: 'block-host',
+	})
+
+	const unblockResult = await islandRouter.unblockHost({
+		host: '192.168.0.99',
+		acknowledgeHighRisk: true,
+		reason:
+			'The device was remediated and network access needs to be restored intentionally after post-incident validation.',
+		confirmation: islandRouter.writeAcknowledgements.unblockHost,
+	})
+	expect(unblockResult).toMatchObject({
+		commandId: 'unblock-host',
 	})
 })
 

--- a/packages/home-connector/src/adapters/island-router/index.ts
+++ b/packages/home-connector/src/adapters/island-router/index.ts
@@ -1,28 +1,68 @@
 import { type HomeConnectorConfig } from '../../config.ts'
 import {
+	type IslandRouterActiveSessions,
+	type IslandRouterAllowlistedCliCommand,
+	type IslandRouterAllowlistedCliCommandResult,
+	type IslandRouterBandwidthUsage,
+	type IslandRouterCommandRequest,
 	type IslandRouterCommandResult,
 	type IslandRouterCommandRunner,
 	type IslandRouterDhcpLease,
+	type IslandRouterDhcpServerConfig,
+	type IslandRouterDnsConfig,
+	type IslandRouterFailoverStatus,
 	type IslandRouterHostDiagnosis,
+	type IslandRouterInterfaceDetails,
 	type IslandRouterInterfaceSummary,
+	type IslandRouterNatRules,
 	type IslandRouterNeighborEntry,
+	type IslandRouterNtpConfig,
+	type IslandRouterQosConfig,
+	type IslandRouterRoutingTable,
+	type IslandRouterSecurityPolicy,
+	type IslandRouterSnmpConfig,
 	type IslandRouterStatus,
+	type IslandRouterSyslogConfig,
+	type IslandRouterSystemInfo,
+	type IslandRouterTrafficStats,
+	type IslandRouterUsers,
+	type IslandRouterVlanConfig,
+	type IslandRouterVpnConfig,
+	type IslandRouterWanConfig,
 	type IslandRouterWriteOperationId,
 	type IslandRouterWriteOperationResult,
 } from './types.ts'
 import { createIslandRouterSshCommandRunner } from './ssh-client.ts'
 import {
+	didIslandRouterCommandSucceed,
 	findMatchingDhcpLease,
 	findMatchingNeighbor,
-	didIslandRouterCommandSucceed,
+	parseIslandRouterActiveSessions,
+	parseIslandRouterBandwidthUsage,
 	parseIslandRouterClock,
 	parseIslandRouterDhcpReservations,
+	parseIslandRouterDhcpServerConfig,
+	parseIslandRouterDnsConfig,
+	parseIslandRouterFailoverStatus,
 	parseIslandRouterInterfaceDetails,
 	parseIslandRouterInterfaceSummaries,
+	parseIslandRouterNatRules,
 	parseIslandRouterNeighbors,
+	parseIslandRouterNtpConfig,
 	parseIslandRouterPingResult,
+	parseIslandRouterQosConfig,
 	parseIslandRouterRecentEvents,
+	parseIslandRouterRoutingTable,
+	parseIslandRouterSecurityPolicy,
+	parseIslandRouterSnmpConfig,
+	parseIslandRouterSyslogConfig,
+	parseIslandRouterSystemInfo,
+	parseIslandRouterTrafficStats,
+	parseIslandRouterUsers,
 	parseIslandRouterVersion,
+	parseIslandRouterVlanConfig,
+	parseIslandRouterVpnConfig,
+	parseIslandRouterWanConfig,
 } from './parsing.ts'
 import {
 	assertIslandRouterConfigured,
@@ -53,6 +93,10 @@ type DiagnoseHostRequest = {
 	logLimit?: number
 }
 
+type ReadRequest = {
+	timeoutMs?: number
+}
+
 type WriteOperationRequest = {
 	timeoutMs?: number
 	acknowledgeHighRisk: boolean
@@ -60,7 +104,54 @@ type WriteOperationRequest = {
 	confirmation: string
 }
 
+type SetWanFailoverRequest = WriteOperationRequest & {
+	interfaceName: string
+}
+
+type RunAllowlistedCliCommandRequest = WriteOperationRequest & {
+	command: IslandRouterAllowlistedCliCommand
+	interfaceName?: string
+}
+
+type SetDhcpReservationRequest = WriteOperationRequest & {
+	action: 'set' | 'remove'
+	macAddress: string
+	ipAddress?: string
+	hostName?: string
+	interfaceName?: string
+}
+
+type SetInterfaceDescriptionRequest = WriteOperationRequest & {
+	interfaceName: string
+	description: string
+}
+
+type SetDnsServerRequest = WriteOperationRequest & {
+	servers: Array<string>
+	interfaceName?: string
+}
+
+type HostWriteRequest = WriteOperationRequest & {
+	host: string
+}
+
 const islandRouterWriteAcknowledgements = {
+	setWanFailover:
+		'I am highly certain forcing Island router WAN failover to a specific interface is necessary right now.',
+	runAllowlistedCliCommand:
+		'I am highly certain running this allowlisted Island router CLI command is necessary right now.',
+	setDhcpReservation:
+		'I am highly certain changing Island router DHCP reservations is necessary right now.',
+	reboot:
+		'I am highly certain rebooting the Island router is necessary right now.',
+	setInterfaceDescription:
+		'I am highly certain changing an Island router interface description is necessary right now.',
+	setDnsServer:
+		'I am highly certain changing Island router DNS server configuration is necessary right now.',
+	blockHost:
+		'I am highly certain blocking this host on the Island router is necessary right now.',
+	unblockHost:
+		'I am highly certain unblocking this host on the Island router is necessary right now.',
 	renewDhcpClients:
 		'I am highly certain renewing all Island router DHCP clients is necessary right now.',
 	clearLogBuffer:
@@ -79,6 +170,50 @@ function normalizeTimeoutMs(config: HomeConnectorConfig, timeoutMs?: number) {
 		return config.islandRouterCommandTimeoutMs
 	}
 	return Math.max(1000, Math.trunc(timeoutMs))
+}
+
+function assertNonEmpty(value: string, field: string) {
+	const trimmed = value.trim()
+	if (trimmed.length === 0) {
+		throw new Error(`${field} must not be empty.`)
+	}
+	return trimmed
+}
+
+function normalizeInterfaceName(value: string) {
+	return assertNonEmpty(value, 'interfaceName')
+}
+
+function normalizeIpv4Address(value: string, field: string) {
+	const host = validateIslandRouterHost(value)
+	if (host.kind !== 'ipv4') {
+		throw new Error(`${field} must be a valid IPv4 address.`)
+	}
+	return host.value
+}
+
+function normalizeMacAddress(value: string) {
+	const host = validateIslandRouterHost(value)
+	if (host.kind !== 'mac') {
+		throw new Error('macAddress must be a valid MAC address.')
+	}
+	return host.normalizedValue
+}
+
+function normalizeDnsServers(servers: Array<string>) {
+	const normalized = servers
+		.map((server) => assertNonEmpty(server, 'servers'))
+		.map((server) => {
+			const host = validateIslandRouterHost(server)
+			if (host.kind === 'mac') {
+				throw new Error('DNS servers must be IP addresses or hostnames, not MAC addresses.')
+			}
+			return host.value
+		})
+	if (normalized.length === 0) {
+		throw new Error('servers must include at least one DNS server.')
+	}
+	return normalized
 }
 
 function ensureSuccessfulCommand(
@@ -199,12 +334,23 @@ function assertWriteReason(reason: string, operationLabel: string) {
 	}
 }
 
-async function runWriteOperation(input: {
+function combineSuccessfulCommandOutputs(
+	results: Array<IslandRouterCommandResult>,
+) {
+	const successful = results.filter((result) => didIslandRouterCommandSucceed(result))
+	return {
+		successful,
+		stdout: successful.map((result) => result.stdout).join('\n'),
+		commandLines: successful.flatMap((result) => result.commandLines),
+	}
+}
+
+async function runHighRiskCommand(input: {
 	config: HomeConnectorConfig
 	runner: IslandRouterCommandRunner
 	timeoutMs?: number
 	operationId: IslandRouterWriteOperationId
-	commandId: 'clear-dhcp-client' | 'clear-log' | 'write-memory'
+	commandRequest: IslandRouterCommandRequest
 	message: string
 	acknowledgeHighRisk: boolean
 	reason: string
@@ -224,16 +370,18 @@ async function runWriteOperation(input: {
 		input.message,
 	)
 	const timeoutMs = normalizeTimeoutMs(input.config, input.timeoutMs)
+	const commandRequest = {
+		...input.commandRequest,
+		timeoutMs,
+	} as IslandRouterCommandRequest
 	const result = ensureSuccessfulCommand(
-		await input.runner({
-			id: input.commandId,
-			timeoutMs,
-		}),
+		await input.runner(commandRequest),
 		input.message,
 	)
 	return {
 		operationId: input.operationId,
-		commandId: input.commandId,
+		commandId:
+			result.id as IslandRouterWriteOperationResult['commandId'],
 		commandLines: result.commandLines,
 		stdout: result.stdout,
 		stderr: result.stderr,
@@ -259,6 +407,43 @@ export function createIslandRouterAdapter(input: {
 
 	function getConfigStatus() {
 		return getIslandRouterConfigStatus(config)
+	}
+
+	async function executeReadCommand<T>(
+		request: IslandRouterCommandRequest,
+		message: string,
+		parser: (stdout: string, commandLines: Array<string>) => T,
+	) {
+		assertIslandRouterConfigured(config)
+		const result = ensureSuccessfulCommand(
+			await getRunner()({
+				...request,
+				timeoutMs: normalizeTimeoutMs(config, request.timeoutMs),
+			} as IslandRouterCommandRequest),
+			message,
+		)
+		return parser(result.stdout, result.commandLines)
+	}
+
+	async function executeCompoundReadCommand<T>(input: {
+		requests: Array<IslandRouterCommandRequest>
+		message: string
+		parser: (stdout: string, commandLines: Array<string>) => T
+	}) {
+		assertIslandRouterConfigured(config)
+		const results = await Promise.all(
+			input.requests.map((request) =>
+				getRunner()({
+					...request,
+					timeoutMs: normalizeTimeoutMs(config, request.timeoutMs),
+				} as IslandRouterCommandRequest),
+			),
+		)
+		const combined = combineSuccessfulCommandOutputs(results)
+		if (combined.successful.length === 0) {
+			throw ensureSuccessfulCommand(results[0]!, input.message)
+		}
+		return input.parser(combined.stdout, combined.commandLines)
 	}
 
 	return {
@@ -376,12 +561,10 @@ export function createIslandRouterAdapter(input: {
 				)
 			}
 
-			const runner = getRunner()
-			const timeoutMs = normalizeTimeoutMs(config, request.timeoutMs)
-			const result = await runner({
+			const result = await getRunner()({
 				id: 'ping',
 				host: host.value,
-				timeoutMs,
+				timeoutMs: normalizeTimeoutMs(config, request.timeoutMs),
 				allowTimeout: true,
 			})
 			return parseIslandRouterPingResult({
@@ -395,12 +578,10 @@ export function createIslandRouterAdapter(input: {
 		async getArpEntry(request: HostLookupRequest) {
 			assertIslandRouterConfigured(config)
 			const identity = validateIslandRouterHost(request.host)
-			const runner = getRunner()
-			const timeoutMs = normalizeTimeoutMs(config, request.timeoutMs)
 			const result = ensureSuccessfulCommand(
-				await runner({
+				await getRunner()({
 					id: 'show-ip-neighbors',
-					timeoutMs,
+					timeoutMs: normalizeTimeoutMs(config, request.timeoutMs),
 				}),
 				'Island router neighbor lookup',
 			)
@@ -417,12 +598,10 @@ export function createIslandRouterAdapter(input: {
 		async getDhcpLease(request: HostLookupRequest) {
 			assertIslandRouterConfigured(config)
 			const identity = validateIslandRouterHost(request.host)
-			const runner = getRunner()
-			const timeoutMs = normalizeTimeoutMs(config, request.timeoutMs)
 			const result = ensureSuccessfulCommand(
-				await runner({
+				await getRunner()({
 					id: 'show-ip-dhcp-reservations',
-					timeoutMs,
+					timeoutMs: normalizeTimeoutMs(config, request.timeoutMs),
 				}),
 				'Island router DHCP reservation lookup',
 			)
@@ -442,13 +621,11 @@ export function createIslandRouterAdapter(input: {
 				? validateIslandRouterHost(request.host).value
 				: ''
 			const limit = normalizeLimit(request.limit, 50, 200)
-			const runner = getRunner()
-			const timeoutMs = normalizeTimeoutMs(config, request.timeoutMs)
 			const result = ensureSuccessfulCommand(
-				await runner({
+				await getRunner()({
 					id: 'show-log',
 					query: query.length > 0 ? query : undefined,
-					timeoutMs,
+					timeoutMs: normalizeTimeoutMs(config, request.timeoutMs),
 				}),
 				'Island router recent event lookup',
 			)
@@ -578,11 +755,11 @@ export function createIslandRouterAdapter(input: {
 					)
 				}
 			}
+
 			const recentEvents = dedupeRecentEvents(recentEventSets).slice(
 				0,
 				logLimit,
 			)
-
 			const { interfaceDetails, ipInterfaceDetails } =
 				await maybeGetInterfaceDetails({
 					runner,
@@ -613,13 +790,502 @@ export function createIslandRouterAdapter(input: {
 				errors,
 			}
 		},
+		async getWanConfig(request: ReadRequest = {}) {
+			return await executeReadCommand(
+				{
+					id: 'show-wan',
+					timeoutMs: request.timeoutMs,
+				},
+				'Island router WAN configuration lookup',
+				parseIslandRouterWanConfig,
+			)
+		},
+		async getFailoverStatus(request: ReadRequest = {}) {
+			return await executeCompoundReadCommand({
+				requests: [
+					{
+						id: 'show-wan-failover',
+						timeoutMs: request.timeoutMs,
+					},
+					{
+						id: 'show-multi-wan',
+						timeoutMs: request.timeoutMs,
+					},
+				],
+				message: 'Island router failover status lookup',
+				parser: parseIslandRouterFailoverStatus,
+			})
+		},
+		async getRoutingTable(request: ReadRequest = {}) {
+			return await executeReadCommand(
+				{
+					id: 'show-ip-routes',
+					timeoutMs: request.timeoutMs,
+				},
+				'Island router routing table lookup',
+				parseIslandRouterRoutingTable,
+			)
+		},
+		async getNatRules(request: ReadRequest = {}) {
+			return await executeCompoundReadCommand({
+				requests: [
+					{
+						id: 'show-nat',
+						timeoutMs: request.timeoutMs,
+					},
+					{
+						id: 'show-ip-nat',
+						timeoutMs: request.timeoutMs,
+					},
+				],
+				message: 'Island router NAT rule lookup',
+				parser: parseIslandRouterNatRules,
+			})
+		},
+		async getVlanConfig(request: ReadRequest = {}) {
+			return await executeReadCommand(
+				{
+					id: 'show-vlan',
+					timeoutMs: request.timeoutMs,
+				},
+				'Island router VLAN configuration lookup',
+				parseIslandRouterVlanConfig,
+			)
+		},
+		async getDnsConfig(request: ReadRequest = {}) {
+			return await executeCompoundReadCommand({
+				requests: [
+					{
+						id: 'show-dns',
+						timeoutMs: request.timeoutMs,
+					},
+					{
+						id: 'show-ip-dns',
+						timeoutMs: request.timeoutMs,
+					},
+				],
+				message: 'Island router DNS configuration lookup',
+				parser: parseIslandRouterDnsConfig,
+			})
+		},
+		async getUsers(request: ReadRequest = {}) {
+			return await executeCompoundReadCommand({
+				requests: [
+					{
+						id: 'show-users',
+						timeoutMs: request.timeoutMs,
+					},
+					{
+						id: 'show-user',
+						timeoutMs: request.timeoutMs,
+					},
+				],
+				message: 'Island router user lookup',
+				parser: parseIslandRouterUsers,
+			})
+		},
+		async getSecurityPolicy(request: ReadRequest = {}) {
+			return await executeCompoundReadCommand({
+				requests: [
+					{
+						id: 'show-security-policy',
+						timeoutMs: request.timeoutMs,
+					},
+					{
+						id: 'show-protection',
+						timeoutMs: request.timeoutMs,
+					},
+					{
+						id: 'show-firewall',
+						timeoutMs: request.timeoutMs,
+					},
+				],
+				message: 'Island router security policy lookup',
+				parser: parseIslandRouterSecurityPolicy,
+			})
+		},
+		async getQosConfig(request: ReadRequest = {}) {
+			return await executeCompoundReadCommand({
+				requests: [
+					{
+						id: 'show-qos',
+						timeoutMs: request.timeoutMs,
+					},
+					{
+						id: 'show-traffic-policy',
+						timeoutMs: request.timeoutMs,
+					},
+				],
+				message: 'Island router QoS configuration lookup',
+				parser: parseIslandRouterQosConfig,
+			})
+		},
+		async getTrafficStats(request: ReadRequest = {}) {
+			return await executeReadCommand(
+				{
+					id: 'show-interface-statistics',
+					timeoutMs: request.timeoutMs,
+				},
+				'Island router traffic statistics lookup',
+				parseIslandRouterTrafficStats,
+			)
+		},
+		async getActiveSessions(request: ReadRequest = {}) {
+			return await executeReadCommand(
+				{
+					id: 'show-sessions',
+					timeoutMs: request.timeoutMs,
+				},
+				'Island router active session lookup',
+				parseIslandRouterActiveSessions,
+			)
+		},
+		async getVpnConfig(request: ReadRequest = {}) {
+			return await executeCompoundReadCommand({
+				requests: [
+					{
+						id: 'show-vpn',
+						timeoutMs: request.timeoutMs,
+					},
+					{
+						id: 'show-ipsec',
+						timeoutMs: request.timeoutMs,
+					},
+					{
+						id: 'show-gre',
+						timeoutMs: request.timeoutMs,
+					},
+				],
+				message: 'Island router VPN configuration lookup',
+				parser: parseIslandRouterVpnConfig,
+			})
+		},
+		async getDhcpServerConfig(request: ReadRequest = {}) {
+			return await executeCompoundReadCommand({
+				requests: [
+					{
+						id: 'show-dhcp-server',
+						timeoutMs: request.timeoutMs,
+					},
+					{
+						id: 'show-ip-dhcp-reservations',
+						timeoutMs: request.timeoutMs,
+					},
+				],
+				message: 'Island router DHCP server lookup',
+				parser: parseIslandRouterDhcpServerConfig,
+			})
+		},
+		async getNtpConfig(request: ReadRequest = {}) {
+			return await executeReadCommand(
+				{
+					id: 'show-ntp',
+					timeoutMs: request.timeoutMs,
+				},
+				'Island router NTP configuration lookup',
+				parseIslandRouterNtpConfig,
+			)
+		},
+		async getSyslogConfig(request: ReadRequest = {}) {
+			return await executeReadCommand(
+				{
+					id: 'show-syslog',
+					timeoutMs: request.timeoutMs,
+				},
+				'Island router syslog configuration lookup',
+				parseIslandRouterSyslogConfig,
+			)
+		},
+		async getSnmpConfig(request: ReadRequest = {}) {
+			return await executeReadCommand(
+				{
+					id: 'show-snmp',
+					timeoutMs: request.timeoutMs,
+				},
+				'Island router SNMP configuration lookup',
+				parseIslandRouterSnmpConfig,
+			)
+		},
+		async getSystemInfo(request: ReadRequest = {}) {
+			return await executeReadCommand(
+				{
+					id: 'show-system',
+					timeoutMs: request.timeoutMs,
+				},
+				'Island router system info lookup',
+				parseIslandRouterSystemInfo,
+			)
+		},
+		async getBandwidthUsage(request: ReadRequest = {}) {
+			return await executeReadCommand(
+				{
+					id: 'show-bandwidth-usage',
+					timeoutMs: request.timeoutMs,
+				},
+				'Island router bandwidth usage lookup',
+				parseIslandRouterBandwidthUsage,
+			)
+		},
+		async setWanFailover(request: SetWanFailoverRequest) {
+			return await runHighRiskCommand({
+				config,
+				runner: getRunner(),
+				timeoutMs: request.timeoutMs,
+				operationId: 'set-wan-failover',
+				commandRequest: {
+					id: 'force-wan-failover',
+					interfaceName: normalizeInterfaceName(request.interfaceName),
+				},
+				message: 'Island router WAN failover change',
+				acknowledgeHighRisk: request.acknowledgeHighRisk,
+				reason: request.reason,
+				confirmation: request.confirmation,
+				expectedAcknowledgement:
+					islandRouterWriteAcknowledgements.setWanFailover,
+			})
+		},
+		async runAllowlistedCliCommand(request: RunAllowlistedCliCommandRequest) {
+			let commandRequest: IslandRouterCommandRequest
+			switch (request.command) {
+				case 'show-version':
+					commandRequest = { id: 'show-version' }
+					break
+				case 'show-clock':
+					commandRequest = { id: 'show-clock' }
+					break
+				case 'show-interface-summary':
+					commandRequest = { id: 'show-interface-summary' }
+					break
+				case 'show-interface':
+					commandRequest = {
+						id: 'show-interface',
+						interfaceName: normalizeInterfaceName(
+							assertNonEmpty(request.interfaceName ?? '', 'interfaceName'),
+						),
+					}
+					break
+				case 'show-ip-interface':
+					commandRequest = {
+						id: 'show-ip-interface',
+						interfaceName: normalizeInterfaceName(
+							assertNonEmpty(request.interfaceName ?? '', 'interfaceName'),
+						),
+					}
+					break
+				default: {
+					const _exhaustive: never = request.command
+					throw new Error(
+						`Unhandled allowlisted CLI command: ${String(_exhaustive)}`,
+					)
+				}
+			}
+
+			const result = await runHighRiskCommand({
+				config,
+				runner: getRunner(),
+				timeoutMs: request.timeoutMs,
+				operationId: 'run-allowlisted-cli-command',
+				commandRequest,
+				message: 'Island router allowlisted CLI command',
+				acknowledgeHighRisk: request.acknowledgeHighRisk,
+				reason: request.reason,
+				confirmation: request.confirmation,
+				expectedAcknowledgement:
+					islandRouterWriteAcknowledgements.runAllowlistedCliCommand,
+			})
+
+			let parsedResult: IslandRouterAllowlistedCliCommandResult['result']
+			switch (request.command) {
+				case 'show-version':
+					parsedResult = parseIslandRouterVersion(
+						result.stdout,
+						result.commandLines,
+					)
+					break
+				case 'show-clock':
+					parsedResult = {
+						clock: parseIslandRouterClock(result.stdout, result.commandLines),
+					}
+					break
+				case 'show-interface-summary':
+					parsedResult = {
+						interfaces: parseIslandRouterInterfaceSummaries(
+							result.stdout,
+							result.commandLines,
+						),
+					}
+					break
+				case 'show-interface':
+				case 'show-ip-interface':
+					parsedResult = parseIslandRouterInterfaceDetails(
+						result.stdout,
+						result.commandLines,
+					)
+					break
+				default: {
+					const _exhaustive: never = request.command
+					throw new Error(
+						`Unhandled allowlisted CLI parser: ${String(_exhaustive)}`,
+					)
+				}
+			}
+
+			return {
+				command: request.command,
+				commandId:
+					result.commandId as IslandRouterAllowlistedCliCommandResult['commandId'],
+				commandLines: result.commandLines,
+				result: parsedResult,
+				stdout: result.stdout,
+				stderr: result.stderr,
+				exitCode: result.exitCode,
+				signal: result.signal,
+				timedOut: result.timedOut,
+				durationMs: result.durationMs,
+			} satisfies IslandRouterAllowlistedCliCommandResult
+		},
+		async setDhcpReservation(request: SetDhcpReservationRequest) {
+			const macAddress = normalizeMacAddress(request.macAddress)
+			const commandRequest: IslandRouterCommandRequest =
+				request.action === 'remove'
+					? {
+							id: 'remove-dhcp-reservation',
+							macAddress,
+							ipAddress:
+								request.ipAddress == null
+									? undefined
+									: normalizeIpv4Address(request.ipAddress, 'ipAddress'),
+						}
+					: {
+							id: 'set-dhcp-reservation',
+							macAddress,
+							ipAddress: normalizeIpv4Address(
+								assertNonEmpty(request.ipAddress ?? '', 'ipAddress'),
+								'ipAddress',
+							),
+							hostName:
+								request.hostName == null
+									? undefined
+									: assertNonEmpty(request.hostName, 'hostName'),
+							interfaceName:
+								request.interfaceName == null
+									? undefined
+									: normalizeInterfaceName(request.interfaceName),
+						}
+			return await runHighRiskCommand({
+				config,
+				runner: getRunner(),
+				timeoutMs: request.timeoutMs,
+				operationId: 'set-dhcp-reservation',
+				commandRequest,
+				message: 'Island router DHCP reservation change',
+				acknowledgeHighRisk: request.acknowledgeHighRisk,
+				reason: request.reason,
+				confirmation: request.confirmation,
+				expectedAcknowledgement:
+					islandRouterWriteAcknowledgements.setDhcpReservation,
+			})
+		},
+		async rebootRouter(request: WriteOperationRequest) {
+			return await runHighRiskCommand({
+				config,
+				runner: getRunner(),
+				timeoutMs: request.timeoutMs,
+				operationId: 'reboot',
+				commandRequest: {
+					id: 'reboot',
+				},
+				message: 'Island router reboot',
+				acknowledgeHighRisk: request.acknowledgeHighRisk,
+				reason: request.reason,
+				confirmation: request.confirmation,
+				expectedAcknowledgement: islandRouterWriteAcknowledgements.reboot,
+			})
+		},
+		async setInterfaceDescription(request: SetInterfaceDescriptionRequest) {
+			return await runHighRiskCommand({
+				config,
+				runner: getRunner(),
+				timeoutMs: request.timeoutMs,
+				operationId: 'set-interface-description',
+				commandRequest: {
+					id: 'set-interface-description',
+					interfaceName: normalizeInterfaceName(request.interfaceName),
+					description: assertNonEmpty(request.description, 'description'),
+				},
+				message: 'Island router interface description change',
+				acknowledgeHighRisk: request.acknowledgeHighRisk,
+				reason: request.reason,
+				confirmation: request.confirmation,
+				expectedAcknowledgement:
+					islandRouterWriteAcknowledgements.setInterfaceDescription,
+			})
+		},
+		async setDnsServer(request: SetDnsServerRequest) {
+			return await runHighRiskCommand({
+				config,
+				runner: getRunner(),
+				timeoutMs: request.timeoutMs,
+				operationId: 'set-dns-server',
+				commandRequest: {
+					id: 'set-dns-server',
+					servers: normalizeDnsServers(request.servers),
+					interfaceName:
+						request.interfaceName == null
+							? undefined
+							: normalizeInterfaceName(request.interfaceName),
+				},
+				message: 'Island router DNS server change',
+				acknowledgeHighRisk: request.acknowledgeHighRisk,
+				reason: request.reason,
+				confirmation: request.confirmation,
+				expectedAcknowledgement:
+					islandRouterWriteAcknowledgements.setDnsServer,
+			})
+		},
+		async blockHost(request: HostWriteRequest) {
+			return await runHighRiskCommand({
+				config,
+				runner: getRunner(),
+				timeoutMs: request.timeoutMs,
+				operationId: 'block-host',
+				commandRequest: {
+					id: 'block-host',
+					host: validateIslandRouterHost(request.host).value,
+				},
+				message: 'Island router host block',
+				acknowledgeHighRisk: request.acknowledgeHighRisk,
+				reason: request.reason,
+				confirmation: request.confirmation,
+				expectedAcknowledgement: islandRouterWriteAcknowledgements.blockHost,
+			})
+		},
+		async unblockHost(request: HostWriteRequest) {
+			return await runHighRiskCommand({
+				config,
+				runner: getRunner(),
+				timeoutMs: request.timeoutMs,
+				operationId: 'unblock-host',
+				commandRequest: {
+					id: 'unblock-host',
+					host: validateIslandRouterHost(request.host).value,
+				},
+				message: 'Island router host unblock',
+				acknowledgeHighRisk: request.acknowledgeHighRisk,
+				reason: request.reason,
+				confirmation: request.confirmation,
+				expectedAcknowledgement: islandRouterWriteAcknowledgements.unblockHost,
+			})
+		},
 		async renewDhcpClients(request: WriteOperationRequest) {
-			return await runWriteOperation({
+			return await runHighRiskCommand({
 				config,
 				runner: getRunner(),
 				timeoutMs: request.timeoutMs,
 				operationId: 'renew-dhcp-clients',
-				commandId: 'clear-dhcp-client',
+				commandRequest: {
+					id: 'clear-dhcp-client',
+				},
 				message: 'Island router DHCP client renewal',
 				acknowledgeHighRisk: request.acknowledgeHighRisk,
 				reason: request.reason,
@@ -629,12 +1295,14 @@ export function createIslandRouterAdapter(input: {
 			})
 		},
 		async clearLogBuffer(request: WriteOperationRequest) {
-			return await runWriteOperation({
+			return await runHighRiskCommand({
 				config,
 				runner: getRunner(),
 				timeoutMs: request.timeoutMs,
 				operationId: 'clear-log-buffer',
-				commandId: 'clear-log',
+				commandRequest: {
+					id: 'clear-log',
+				},
 				message: 'Island router log clear',
 				acknowledgeHighRisk: request.acknowledgeHighRisk,
 				reason: request.reason,
@@ -644,12 +1312,14 @@ export function createIslandRouterAdapter(input: {
 			})
 		},
 		async saveRunningConfig(request: WriteOperationRequest) {
-			return await runWriteOperation({
+			return await runHighRiskCommand({
 				config,
 				runner: getRunner(),
 				timeoutMs: request.timeoutMs,
 				operationId: 'save-running-config',
-				commandId: 'write-memory',
+				commandRequest: {
+					id: 'write-memory',
+				},
 				message: 'Island router configuration save',
 				acknowledgeHighRisk: request.acknowledgeHighRisk,
 				reason: request.reason,

--- a/packages/home-connector/src/adapters/island-router/parsing.ts
+++ b/packages/home-connector/src/adapters/island-router/parsing.ts
@@ -1,18 +1,63 @@
 import {
+	type IslandRouterActiveSession,
+	type IslandRouterActiveSessions,
+	type IslandRouterBandwidthUsage,
+	type IslandRouterBandwidthUsageEntry,
+	type IslandRouterDhcpServerConfig,
+	type IslandRouterDhcpServerOption,
+	type IslandRouterDhcpServerPool,
+	type IslandRouterDnsConfig,
+	type IslandRouterDnsOverride,
+	type IslandRouterDnsServer,
 	type IslandRouterDhcpLease,
+	type IslandRouterFailoverHealthCheck,
+	type IslandRouterFailoverStatus,
 	type IslandRouterHostIdentity,
 	type IslandRouterInterfaceDetails,
 	type IslandRouterInterfaceSummary,
 	type IslandRouterNeighborEntry,
+	type IslandRouterNtpConfig,
+	type IslandRouterNtpServer,
+	type IslandRouterNatRule,
+	type IslandRouterNatRules,
 	type IslandRouterPingReply,
 	type IslandRouterPingResult,
 	type IslandRouterRecentEvent,
+	type IslandRouterRouteEntry,
+	type IslandRouterRoutingTable,
+	type IslandRouterSecurityPolicy,
+	type IslandRouterSecurityPolicyRule,
+	type IslandRouterSnmpCommunity,
+	type IslandRouterSnmpConfig,
+	type IslandRouterSnmpTrapTarget,
+	type IslandRouterSyslogConfig,
+	type IslandRouterSyslogTarget,
+	type IslandRouterSystemInfo,
+	type IslandRouterTrafficStat,
+	type IslandRouterTrafficStats,
+	type IslandRouterUserEntry,
+	type IslandRouterUsers,
 	type IslandRouterVersionInfo,
+	type IslandRouterVlanConfig,
+	type IslandRouterVlanConfigEntry,
+	type IslandRouterVpnConfig,
+	type IslandRouterVpnTunnel,
+	type IslandRouterWanConfig,
+	type IslandRouterWanConnectionType,
+	type IslandRouterWanInterfaceConfig,
+	type IslandRouterWanRole,
+	type IslandRouterQosConfig,
+	type IslandRouterQosPolicyEntry,
 } from './types.ts'
 
 type ParsedTableRow = {
 	rawLine: string
 	fields: Record<string, string>
+}
+
+type ParsedTable = {
+	headers: Array<string>
+	rows: Array<ParsedTableRow>
 }
 
 const interfaceNamePattern =
@@ -34,6 +79,17 @@ const islandRouterCliFailurePattern =
 	/\b(?:invalid command|unknown command|unrecognized command|syntax error|permission denied|host key verification failed|connection refused|no route to host|network is unreachable|could not resolve hostname|command not found|not recognized as an internal or external command)\b/i
 const islandRouterPromptSuffixPattern = '[>#\\]]'
 const islandRouterPromptOnlyPattern = /^(?:[a-z0-9_.:@-]+[>#]|\[[^\]\r\n]+\])$/i
+const ipv6Pattern = /\b(?:[0-9a-fA-F]{0,4}:){2,}[0-9a-fA-F]{0,4}\b/
+const cidrPattern = /\b(?:\d{1,3}(?:\.\d{1,3}){3}\/\d{1,2}|(?:[0-9a-fA-F]{0,4}:){2,}[0-9a-fA-F]{0,4}\/\d{1,3})\b/
+const percentPattern = /(?<value>\d+(?:\.\d+)?)\s*%/
+const numberPattern = /-?\d+(?:\.\d+)?/
+const hostPortPattern =
+	/(?<host>(?:\d{1,3}(?:\.\d{1,3}){3}|(?:[0-9a-fA-F]{0,4}:){2,}[0-9a-fA-F]{0,4}|[a-z0-9_.-]+))(?::(?<port>\d+))?/i
+const rateTokenPattern = /\b\d+(?:\.\d+)?\s*(?:[kmgt]?bps|[kmgt]?b\/s)\b/i
+const uptimePattern =
+	/\b\d+\s+(?:day|days|hour|hours|minute|minutes|second|seconds)\b/i
+const enabledPattern = /\b(?:enabled|on|up|true|yes|allow|active)\b/i
+const disabledPattern = /\b(?:disabled|off|down|false|no|deny|inactive)\b/i
 
 function normalizeHeaderKey(value: string) {
 	return value
@@ -204,6 +260,15 @@ function parseTextTable(lines: Array<string>): Array<ParsedTableRow> {
 		if (/^-{3,}(?:\s+-{3,})*$/.test(line.trim())) continue
 		const columns = splitTableColumns(line)
 		if (columns.length < 2) continue
+		if (
+			columns.length === headers.length &&
+			columns.every(
+				(column, columnIndex) =>
+					normalizeHeaderKey(column) === (headers[columnIndex] ?? ''),
+			)
+		) {
+			continue
+		}
 		const fields = Object.fromEntries(
 			headers.map((header, columnIndex) => [
 				header,
@@ -620,4 +685,891 @@ export function findMatchingDhcpLease(
 			}
 		}) ?? null
 	)
+}
+
+function extractIpv6Address(value: string) {
+	return value.match(ipv6Pattern)?.[0]?.toLowerCase() ?? null
+}
+
+function extractIpAddress(value: string) {
+	return extractIpv4Address(value) ?? extractIpv6Address(value)
+}
+
+function extractCidr(value: string) {
+	return value.match(cidrPattern)?.[0] ?? null
+}
+
+function parseNumber(value: string | null | undefined) {
+	if (!value) return null
+	const normalized = value.replaceAll(',', '')
+	const match = normalized.match(numberPattern)
+	if (!match?.[0]) return null
+	const parsed = Number.parseFloat(match[0])
+	return Number.isFinite(parsed) ? parsed : null
+}
+
+function parseInteger(value: string | null | undefined) {
+	const parsed = parseNumber(value)
+	if (parsed == null) return null
+	return Math.trunc(parsed)
+}
+
+function parsePercent(value: string | null | undefined) {
+	if (!value) return null
+	const match = percentPattern.exec(value)
+	if (!match?.groups?.['value']) return null
+	const parsed = Number.parseFloat(match.groups['value'])
+	return Number.isFinite(parsed) ? parsed : null
+}
+
+function parseEnabledFlag(value: string | null | undefined) {
+	if (!value) return null
+	if (enabledPattern.test(value)) return true
+	if (disabledPattern.test(value)) return false
+	return null
+}
+
+function parseHostPort(value: string | null | undefined) {
+	if (!value) {
+		return {
+			host: null,
+			port: null,
+		}
+	}
+	const match = hostPortPattern.exec(value)
+	return {
+		host: match?.groups?.['host']?.trim() ?? null,
+		port: match?.groups?.['port']
+			? Number.parseInt(match.groups['port'], 10)
+			: null,
+	}
+}
+
+function normalizeConnectionType(
+	value: string | null | undefined,
+): IslandRouterWanConnectionType {
+	if (!value) return 'unknown'
+	const normalized = value.toLowerCase()
+	if (normalized.includes('pppoe')) return 'pppoe'
+	if (normalized.includes('dhcp')) return 'dhcp'
+	if (normalized.includes('static')) return 'static'
+	return 'unknown'
+}
+
+function normalizeWanRole(value: string | null | undefined): IslandRouterWanRole {
+	if (!value) return 'unknown'
+	const normalized = value.toLowerCase()
+	if (
+		normalized.includes('active') ||
+		normalized.includes('primary') ||
+		normalized.includes('selected')
+	) {
+		return 'active'
+	}
+	if (
+		normalized.includes('standby') ||
+		normalized.includes('backup') ||
+		normalized.includes('secondary')
+	) {
+		return 'standby'
+	}
+	return 'unknown'
+}
+
+function splitValueList(value: string | null | undefined) {
+	if (!value) return []
+	return value
+		.split(/[,\s]+/)
+		.map((part) => part.trim())
+		.filter(Boolean)
+}
+
+function extractRate(value: string | null | undefined) {
+	if (!value) return null
+	return value.match(rateTokenPattern)?.[0] ?? null
+}
+
+function buildFieldMapFromAttributes(lines: Array<string>) {
+	const attributes = parseKeyValueLines(lines)
+	return Object.fromEntries(
+		attributes.map((entry) => [normalizeHeaderKey(entry.key), entry.value]),
+	)
+}
+
+function selectRowsOrFallback(lines: Array<string>) {
+	const rows = parseTextTable(lines)
+	if (rows.length > 0) return rows
+	return lines.map((line) => ({
+		rawLine: line,
+		fields: {},
+	}))
+}
+
+export function parseIslandRouterWanConfig(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterWanConfig {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const rows = selectRowsOrFallback(lines)
+	return {
+		wans: rows.flatMap((row) => {
+			const interfaceName =
+				findField(row.fields, ['interface', 'iface', 'port', 'device']) ??
+				extractInterfaceName(row.rawLine)
+			const ipAddress =
+				findField(row.fields, ['ip', 'ip_address', 'address']) ??
+				extractIpAddress(row.rawLine)
+			const gateway = findField(row.fields, ['gateway', 'gw'])
+			if (!interfaceName && !ipAddress && !/wan|isp/i.test(row.rawLine)) {
+				return []
+			}
+			const roleValue =
+				findField(row.fields, ['role', 'state', 'status']) ?? row.rawLine
+			return [
+				{
+					ispName: findField(row.fields, ['isp', 'provider', 'name']),
+					interfaceName,
+					ipAddress,
+					gateway,
+					connectionType: normalizeConnectionType(
+						findField(row.fields, ['type', 'mode']) ?? row.rawLine,
+					),
+					role: normalizeWanRole(roleValue),
+					failoverPriority: parseInteger(
+						findField(row.fields, ['priority', 'failover_priority']),
+					),
+					linkState:
+						findField(row.fields, ['link', 'status', 'state']) ??
+						extractInterfaceLinkState(row.rawLine),
+					rawLine: row.rawLine,
+					fields: row.fields,
+				} satisfies IslandRouterWanInterfaceConfig,
+			]
+		}),
+	}
+}
+
+export function parseIslandRouterFailoverStatus(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterFailoverStatus {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const fieldMap = buildFieldMapFromAttributes(lines)
+	const rows = selectRowsOrFallback(lines)
+	const healthChecks = rows.flatMap((row) => {
+		const interfaceName =
+			findField(row.fields, ['interface', 'iface', 'port', 'device']) ??
+			extractInterfaceName(row.rawLine)
+		if (!interfaceName && !/wan|isp/i.test(row.rawLine)) return []
+		return [
+			{
+				interfaceName,
+				ispName: findField(row.fields, ['isp', 'provider', 'name']),
+				state: findField(row.fields, ['health', 'state', 'status']),
+				role: normalizeWanRole(
+					findField(row.fields, ['role', 'selected', 'active']) ?? row.rawLine,
+				),
+				failoverPriority: parseInteger(
+					findField(row.fields, ['priority', 'failover_priority']),
+				),
+				monitor: findField(row.fields, ['monitor', 'probe', 'health_check']),
+				rawLine: row.rawLine,
+				fields: row.fields,
+			} satisfies IslandRouterFailoverHealthCheck,
+		]
+	})
+	const activeRow =
+		healthChecks.find((entry) => entry.role === 'active') ?? healthChecks[0] ?? null
+	return {
+		activeInterfaceName:
+			findField(fieldMap, ['active_interface', 'active_wan']) ??
+			activeRow?.interfaceName ??
+			null,
+		activeIspName:
+			findField(fieldMap, ['active_isp', 'active_provider']) ??
+			activeRow?.ispName ??
+			null,
+		policy: findField(fieldMap, ['policy', 'failover_policy']),
+		healthChecks,
+		rawOutput: lines.join('\n'),
+	}
+}
+
+export function parseIslandRouterRoutingTable(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterRoutingTable {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const rows = selectRowsOrFallback(lines)
+	return {
+		routes: rows.flatMap((row) => {
+			const destination =
+				findField(row.fields, ['destination', 'network', 'prefix']) ??
+				extractCidr(row.rawLine) ??
+				(/\bdefault\b/i.test(row.rawLine) ? 'default' : null)
+			const gateway =
+				findField(row.fields, ['gateway', 'via', 'next_hop']) ??
+				row.rawLine.match(/\bvia\s+([^\s,]+)/i)?.[1] ??
+				null
+			const interfaceName =
+				findField(row.fields, ['interface', 'iface', 'device']) ??
+				row.rawLine.match(/\bdev\s+([^\s,]+)/i)?.[1] ??
+				extractInterfaceName(row.rawLine)
+			if (!destination && !gateway && !interfaceName) return []
+			return [
+				{
+					destination,
+					gateway,
+					interfaceName,
+					protocol:
+						findField(row.fields, ['protocol', 'proto', 'type']) ??
+						row.rawLine.match(/^(static|kernel|connected|ospf|bgp|rip)\b/i)?.[1] ??
+						null,
+					metric: parseInteger(findField(row.fields, ['metric', 'cost'])),
+					selected:
+						parseEnabledFlag(findField(row.fields, ['selected', 'active'])) ??
+						(row.rawLine.trim().startsWith('*') ? true : null),
+					rawLine: row.rawLine,
+					fields: row.fields,
+				} satisfies IslandRouterRouteEntry,
+			]
+		}),
+	}
+}
+
+export function parseIslandRouterNatRules(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterNatRules {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const rows = selectRowsOrFallback(lines)
+	return {
+		rules: rows.flatMap((row) => {
+			const external = parseHostPort(
+				findField(row.fields, ['external', 'outside', 'public']) ??
+					row.rawLine.match(/\bto\s+([^\s]+)\b/i)?.[1] ??
+					null,
+			)
+			const internal = parseHostPort(
+				findField(row.fields, ['internal', 'inside', 'private', 'target']) ??
+					row.rawLine.match(/\b->\s*([^\s]+)\b/)?.[1] ??
+					null,
+			)
+			if (
+				!external.host &&
+				!internal.host &&
+				!findField(row.fields, ['rule', 'id', 'name'])
+			) {
+				return []
+			}
+			return [
+				{
+					ruleId: findField(row.fields, ['rule', 'id', 'name']),
+					type: findField(row.fields, ['type', 'kind']),
+					protocol:
+						findField(row.fields, ['protocol', 'proto']) ??
+						row.rawLine.match(/\b(tcp|udp|icmp|gre|esp)\b/i)?.[1] ??
+						null,
+					interfaceName:
+						findField(row.fields, ['interface', 'iface', 'wan']) ??
+						extractInterfaceName(row.rawLine),
+					externalAddress: external.host,
+					externalPort: external.port == null ? null : String(external.port),
+					internalAddress: internal.host,
+					internalPort: internal.port == null ? null : String(internal.port),
+					enabled: parseEnabledFlag(
+						findField(row.fields, ['enabled', 'status', 'state']) ?? row.rawLine,
+					),
+					description: findField(row.fields, ['description', 'desc', 'comment']),
+					rawLine: row.rawLine,
+					fields: row.fields,
+				} satisfies IslandRouterNatRule,
+			]
+		}),
+	}
+}
+
+export function parseIslandRouterVlanConfig(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterVlanConfig {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const rows = selectRowsOrFallback(lines)
+	return {
+		vlans: rows.flatMap((row) => {
+			const vlanId =
+				parseInteger(findField(row.fields, ['vlan', 'vlan_id', 'id'])) ??
+				parseInteger(row.rawLine.match(/\bvlan\s*(\d+)\b/i)?.[1] ?? null)
+			const interfaceName =
+				findField(row.fields, ['interface', 'iface']) ??
+				extractInterfaceName(row.rawLine)
+			if (vlanId == null && !interfaceName) return []
+			return [
+				{
+					vlanId,
+					name: findField(row.fields, ['name', 'description', 'desc']),
+					interfaceName,
+					memberInterfaces: splitValueList(
+						findField(row.fields, ['members', 'ports', 'interfaces']),
+					),
+					status: findField(row.fields, ['status', 'state']),
+					ipAddress:
+						findField(row.fields, ['ip', 'address']) ?? extractIpAddress(row.rawLine),
+					rawLine: row.rawLine,
+					fields: row.fields,
+				} satisfies IslandRouterVlanConfigEntry,
+			]
+		}),
+	}
+}
+
+export function parseIslandRouterDnsConfig(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterDnsConfig {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const attributes = parseKeyValueLines(lines)
+	const fieldMap = Object.fromEntries(
+		attributes.map((entry) => [normalizeHeaderKey(entry.key), entry.value]),
+	)
+	const rows = selectRowsOrFallback(lines)
+	const servers: Array<IslandRouterDnsServer> = []
+	const overrides: Array<IslandRouterDnsOverride> = []
+	for (const row of rows) {
+		const address =
+			findField(row.fields, ['server', 'address', 'ip']) ??
+			extractIpAddress(row.rawLine)
+		const host =
+			findField(row.fields, ['host', 'domain', 'name']) ??
+			(/\b[a-z0-9_.-]+\.[a-z]{2,}\b/i.test(row.rawLine)
+				? row.rawLine.match(/\b[a-z0-9_.-]+\.[a-z]{2,}\b/i)?.[0] ?? null
+				: null)
+		if (host && address) {
+			overrides.push({
+				host,
+				recordType: findField(row.fields, ['record', 'type']),
+				value: address,
+				enabled: parseEnabledFlag(
+					findField(row.fields, ['enabled', 'status']) ?? row.rawLine,
+				),
+				rawLine: row.rawLine,
+				fields: row.fields,
+			})
+			continue
+		}
+		if (!address) continue
+		servers.push({
+			address,
+			role: findField(row.fields, ['role', 'type']),
+			source: findField(row.fields, ['source', 'origin']),
+			rawLine: row.rawLine,
+			fields: row.fields,
+		})
+	}
+	return {
+		mode: findField(fieldMap, ['mode', 'dns_mode']),
+		searchDomains: splitValueList(
+			findField(fieldMap, ['search_domain', 'search_domains']),
+		),
+		servers,
+		overrides,
+		attributes,
+		rawOutput: lines.join('\n'),
+	}
+}
+
+export function parseIslandRouterUsers(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterUsers {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const rows = selectRowsOrFallback(lines)
+	return {
+		users: rows.flatMap((row) => {
+			const username =
+				findField(row.fields, ['user', 'username', 'name']) ??
+				row.rawLine.match(/^\s*([a-z0-9_.-]+)/i)?.[1] ??
+				null
+			if (!username) return []
+			return [
+				{
+					username,
+					groupName: findField(row.fields, ['group', 'groups']),
+					role: findField(row.fields, ['role', 'privilege', 'access']),
+					connectionType: findField(
+						row.fields,
+						['connection', 'type', 'transport'],
+					),
+					address:
+						findField(row.fields, ['address', 'ip', 'client']) ??
+						extractIpAddress(row.rawLine),
+					connected: parseEnabledFlag(
+						findField(row.fields, ['connected', 'status']) ?? row.rawLine,
+					),
+					rawLine: row.rawLine,
+					fields: row.fields,
+				} satisfies IslandRouterUserEntry,
+			]
+		}),
+		rawOutput: lines.join('\n'),
+	}
+}
+
+export function parseIslandRouterSecurityPolicy(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterSecurityPolicy {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const rows = selectRowsOrFallback(lines)
+	return {
+		rules: rows.flatMap((row) => {
+			const action =
+				findField(row.fields, ['action', 'policy']) ??
+				row.rawLine.match(/\b(allow|deny|drop|reject|block)\b/i)?.[1] ??
+				null
+			if (!action && !findField(row.fields, ['rule', 'id', 'name'])) return []
+			return [
+				{
+					ruleId: findField(row.fields, ['rule', 'id']),
+					name: findField(row.fields, ['name', 'description']),
+					action,
+					source:
+						findField(row.fields, ['source', 'src']) ??
+						row.rawLine.match(/\bsrc[:= ]+([^\s,]+)/i)?.[1] ??
+						null,
+					destination:
+						findField(row.fields, ['destination', 'dest', 'dst']) ??
+						row.rawLine.match(/\bdst[:= ]+([^\s,]+)/i)?.[1] ??
+						null,
+					service: findField(row.fields, ['service', 'port', 'application']),
+					enabled: parseEnabledFlag(
+						findField(row.fields, ['enabled', 'status']) ?? row.rawLine,
+					),
+					rawLine: row.rawLine,
+					fields: row.fields,
+				} satisfies IslandRouterSecurityPolicyRule,
+			]
+		}),
+		rawOutput: lines.join('\n'),
+	}
+}
+
+export function parseIslandRouterQosConfig(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterQosConfig {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const rows = selectRowsOrFallback(lines)
+	return {
+		policies: rows.flatMap((row) => {
+			const policyName =
+				findField(row.fields, ['policy', 'name']) ??
+				row.rawLine.match(/^\s*([a-z0-9_.-]+)/i)?.[1] ??
+				null
+			if (!policyName && !extractInterfaceName(row.rawLine)) return []
+			return [
+				{
+					policyName,
+					interfaceName:
+						findField(row.fields, ['interface', 'iface']) ??
+						extractInterfaceName(row.rawLine),
+					className: findField(row.fields, ['class', 'queue']),
+					priority: findField(row.fields, ['priority', 'precedence']),
+					bandwidth:
+						findField(row.fields, ['bandwidth', 'rate']) ??
+						extractRate(row.rawLine),
+					enabled: parseEnabledFlag(
+						findField(row.fields, ['enabled', 'status']) ?? row.rawLine,
+					),
+					rawLine: row.rawLine,
+					fields: row.fields,
+				} satisfies IslandRouterQosPolicyEntry,
+			]
+		}),
+		rawOutput: lines.join('\n'),
+	}
+}
+
+export function parseIslandRouterTrafficStats(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterTrafficStats {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const rows = selectRowsOrFallback(lines)
+	return {
+		interfaces: rows.flatMap((row) => {
+			const interfaceName =
+				findField(row.fields, ['interface', 'iface', 'name']) ??
+				extractInterfaceName(row.rawLine)
+			if (!interfaceName) return []
+			return [
+				{
+					interfaceName,
+					rxBytes: parseInteger(findField(row.fields, ['rx_bytes', 'bytes_in'])),
+					txBytes: parseInteger(findField(row.fields, ['tx_bytes', 'bytes_out'])),
+					rxPackets: parseInteger(
+						findField(row.fields, ['rx_packets', 'packets_in']),
+					),
+					txPackets: parseInteger(
+						findField(row.fields, ['tx_packets', 'packets_out']),
+					),
+					rxErrors: parseInteger(
+						findField(row.fields, ['rx_errors', 'errors_in']),
+					),
+					txErrors: parseInteger(
+						findField(row.fields, ['tx_errors', 'errors_out']),
+					),
+					utilizationPercent: parsePercent(
+						findField(row.fields, ['utilization', 'utilization_percent']),
+					),
+					rawLine: row.rawLine,
+					fields: row.fields,
+				} satisfies IslandRouterTrafficStat,
+			]
+		}),
+	}
+}
+
+export function parseIslandRouterActiveSessions(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterActiveSessions {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const rows = selectRowsOrFallback(lines)
+	return {
+		sessions: rows.flatMap((row) => {
+			const source = parseHostPort(
+				findField(row.fields, ['source', 'src', 'source_address']) ??
+					row.rawLine.match(/\bsrc[:= ]+([^\s,]+)/i)?.[1] ??
+					null,
+			)
+			const destination = parseHostPort(
+				findField(row.fields, ['destination', 'dest', 'dst']) ??
+					row.rawLine.match(/\bdst[:= ]+([^\s,]+)/i)?.[1] ??
+					null,
+			)
+			const translated = parseHostPort(
+				findField(row.fields, ['translated', 'nat', 'xlated']) ?? null,
+			)
+			if (!source.host && !destination.host) return []
+			return [
+				{
+					protocol:
+						findField(row.fields, ['protocol', 'proto']) ??
+						row.rawLine.match(/\b(tcp|udp|icmp|gre|esp)\b/i)?.[1] ??
+						null,
+					sourceAddress: source.host,
+					sourcePort: source.port,
+					destinationAddress: destination.host,
+					destinationPort: destination.port,
+					translatedAddress: translated.host,
+					translatedPort: translated.port,
+					state: findField(row.fields, ['state', 'status']),
+					interfaceName:
+						findField(row.fields, ['interface', 'iface']) ??
+						extractInterfaceName(row.rawLine),
+					rawLine: row.rawLine,
+					fields: row.fields,
+				} satisfies IslandRouterActiveSession,
+			]
+		}),
+	}
+}
+
+export function parseIslandRouterVpnConfig(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterVpnConfig {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const rows = selectRowsOrFallback(lines)
+	return {
+		tunnels: rows.flatMap((row) => {
+			const tunnelName =
+				findField(row.fields, ['name', 'tunnel', 'id']) ??
+				row.rawLine.match(/^\s*([a-z0-9_.-]+)/i)?.[1] ??
+				null
+			const localEndpoint =
+				findField(row.fields, ['local', 'local_endpoint']) ??
+				extractIpAddress(row.rawLine)
+			if (!tunnelName && !localEndpoint && !/ipsec|vpn|gre/i.test(row.rawLine)) {
+				return []
+			}
+			const remoteMatch = row.rawLine.match(/\bto\s+([^\s,]+)/i)?.[1] ?? null
+			return [
+				{
+					tunnelName,
+					type:
+						findField(row.fields, ['type', 'protocol']) ??
+						row.rawLine.match(/\b(ipsec|vpn|gre)\b/i)?.[1] ??
+						null,
+					localEndpoint,
+					remoteEndpoint:
+						findField(row.fields, ['remote', 'peer', 'remote_endpoint']) ??
+						remoteMatch,
+					status: findField(row.fields, ['status', 'state']),
+					interfaceName:
+						findField(row.fields, ['interface', 'iface']) ??
+						extractInterfaceName(row.rawLine),
+					rawLine: row.rawLine,
+					fields: row.fields,
+				} satisfies IslandRouterVpnTunnel,
+			]
+		}),
+		rawOutput: lines.join('\n'),
+	}
+}
+
+export function parseIslandRouterDhcpServerConfig(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterDhcpServerConfig {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const rows = selectRowsOrFallback(lines)
+	const pools: Array<IslandRouterDhcpServerPool> = []
+	const options: Array<IslandRouterDhcpServerOption> = []
+	const reservations: Array<IslandRouterDhcpLease> = []
+	for (const row of rows) {
+		const fields = row.fields
+		const rawLower = row.rawLine.toLowerCase()
+		if (findField(fields, ['mac', 'hardware_address']) || macAddressPattern.test(row.rawLine)) {
+			reservations.push({
+				ipAddress:
+					findField(fields, ['ip', 'address']) ?? extractIpv4Address(row.rawLine),
+				macAddress:
+					findField(fields, ['mac', 'hardware_address'])?.toLowerCase() ??
+					extractMacAddress(row.rawLine),
+				hostName: findField(fields, ['host', 'hostname', 'name']),
+				interfaceName:
+					findField(fields, ['interface', 'iface']) ??
+					extractInterfaceName(row.rawLine),
+				leaseType: 'reservation',
+				rawLine: row.rawLine,
+				fields,
+			})
+			continue
+		}
+		if (rawLower.includes('option') || findField(fields, ['option'])) {
+			options.push({
+				poolName: findField(fields, ['pool', 'scope', 'name']),
+				option: findField(fields, ['option', 'code', 'name']),
+				value: findField(fields, ['value', 'setting']),
+				rawLine: row.rawLine,
+				fields,
+			})
+			continue
+		}
+		const poolName = findField(fields, ['pool', 'scope', 'name'])
+		const network =
+			findField(fields, ['network', 'subnet']) ?? extractCidr(row.rawLine)
+		if (!poolName && !network && !rawLower.includes('pool')) continue
+		pools.push({
+			poolName,
+			interfaceName:
+				findField(fields, ['interface', 'iface']) ?? extractInterfaceName(row.rawLine),
+			network,
+			rangeStart:
+				findField(fields, ['range_start', 'start']) ??
+				row.rawLine.match(/\bstart[:= ]+([^\s,]+)/i)?.[1] ??
+				null,
+			rangeEnd:
+				findField(fields, ['range_end', 'end']) ??
+				row.rawLine.match(/\bend[:= ]+([^\s,]+)/i)?.[1] ??
+				null,
+			gateway:
+				findField(fields, ['gateway', 'router']) ??
+				row.rawLine.match(/\bgateway[:= ]+([^\s,]+)/i)?.[1] ??
+				null,
+			dnsServers: splitValueList(findField(fields, ['dns', 'dns_servers'])),
+			rawLine: row.rawLine,
+			fields,
+		})
+	}
+	return {
+		pools,
+		options,
+		reservations,
+		rawOutput: lines.join('\n'),
+	}
+}
+
+export function parseIslandRouterNtpConfig(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterNtpConfig {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const attributes = parseKeyValueLines(lines)
+	const fieldMap = Object.fromEntries(
+		attributes.map((entry) => [normalizeHeaderKey(entry.key), entry.value]),
+	)
+	const rows = selectRowsOrFallback(lines)
+	return {
+		timezone: findField(fieldMap, ['timezone', 'tz']),
+		servers: rows.flatMap((row) => {
+			const server =
+				findField(row.fields, ['server', 'address', 'host']) ??
+				extractIpAddress(row.rawLine)
+			if (!server) return []
+			return [
+				{
+					server,
+					status: findField(row.fields, ['status', 'state']),
+					source: findField(row.fields, ['source', 'type']),
+					rawLine: row.rawLine,
+					fields: row.fields,
+				} satisfies IslandRouterNtpServer,
+			]
+		}),
+		attributes,
+		rawOutput: lines.join('\n'),
+	}
+}
+
+export function parseIslandRouterSyslogConfig(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterSyslogConfig {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const attributes = parseKeyValueLines(lines)
+	const rows = selectRowsOrFallback(lines)
+	return {
+		targets: rows.flatMap((row) => {
+			const hostPort = parseHostPort(
+				findField(row.fields, ['host', 'server', 'target']) ??
+					extractIpAddress(row.rawLine),
+			)
+			if (!hostPort.host) return []
+			return [
+				{
+					host: hostPort.host,
+					port:
+						hostPort.port ??
+						parseInteger(findField(row.fields, ['port'])) ??
+						null,
+					protocol: findField(row.fields, ['protocol', 'transport']),
+					facility: findField(row.fields, ['facility']),
+					enabled: parseEnabledFlag(
+						findField(row.fields, ['enabled', 'status']) ?? row.rawLine,
+					),
+					rawLine: row.rawLine,
+					fields: row.fields,
+				} satisfies IslandRouterSyslogTarget,
+			]
+		}),
+		attributes,
+		rawOutput: lines.join('\n'),
+	}
+}
+
+export function parseIslandRouterSnmpConfig(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterSnmpConfig {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const attributes = parseKeyValueLines(lines)
+	const fieldMap = Object.fromEntries(
+		attributes.map((entry) => [normalizeHeaderKey(entry.key), entry.value]),
+	)
+	const rows = selectRowsOrFallback(lines)
+	const communities: Array<IslandRouterSnmpCommunity> = []
+	const trapTargets: Array<IslandRouterSnmpTrapTarget> = []
+	for (const row of rows) {
+		if (/trap/i.test(row.rawLine) || findField(row.fields, ['trap', 'target'])) {
+			const trapHost = parseHostPort(
+				findField(row.fields, ['host', 'target', 'trap']) ??
+					extractIpAddress(row.rawLine),
+			)
+			if (!trapHost.host) continue
+			trapTargets.push({
+				host: trapHost.host,
+				version: findField(row.fields, ['version']),
+				community: findField(row.fields, ['community']),
+				rawLine: row.rawLine,
+				fields: row.fields,
+			})
+			continue
+		}
+		const community = findField(row.fields, ['community', 'name'])
+		if (!community) continue
+		communities.push({
+			community,
+			access: findField(row.fields, ['access', 'permission']),
+			source: findField(row.fields, ['source', 'host']),
+			rawLine: row.rawLine,
+			fields: row.fields,
+		})
+	}
+	return {
+		enabled:
+			parseEnabledFlag(findField(fieldMap, ['enabled', 'status'])) ??
+			(communities.length > 0 || trapTargets.length > 0 ? true : null),
+		communities,
+		trapTargets,
+		attributes,
+		rawOutput: lines.join('\n'),
+	}
+}
+
+export function parseIslandRouterSystemInfo(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterSystemInfo {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const attributes = parseKeyValueLines(lines)
+	const fieldMap = Object.fromEntries(
+		attributes.map((entry) => [normalizeHeaderKey(entry.key), entry.value]),
+	)
+	const rawOutput = lines.join('\n')
+	return {
+		uptime:
+			findField(fieldMap, ['uptime']) ??
+			rawOutput.match(uptimePattern)?.[0] ??
+			null,
+		cpuUsagePercent: parsePercent(findField(fieldMap, ['cpu', 'cpu_usage'])),
+		memoryUsagePercent: parsePercent(
+			findField(fieldMap, ['memory', 'memory_usage', 'mem_usage']),
+		),
+		temperatureCelsius: parseNumber(
+			findField(fieldMap, ['temperature', 'temp', 'temperature_celsius']),
+		),
+		attributes,
+		rawOutput,
+	}
+}
+
+export function parseIslandRouterBandwidthUsage(
+	stdout: string,
+	commandLines: Array<string>,
+): IslandRouterBandwidthUsage {
+	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	const rows = selectRowsOrFallback(lines)
+	return {
+		entries: rows.flatMap((row) => {
+			const interfaceName =
+				findField(row.fields, ['interface', 'iface']) ??
+				extractInterfaceName(row.rawLine)
+			const subject =
+				findField(row.fields, ['host', 'subject', 'name']) ??
+				interfaceName ??
+				null
+			const rxRate =
+				findField(row.fields, ['rx_rate', 'download', 'in']) ??
+				extractRate(row.rawLine)
+			const txRate =
+				findField(row.fields, ['tx_rate', 'upload', 'out']) ??
+				null
+			if (!subject && !rxRate && !txRate) return []
+			return [
+				{
+					subject,
+					interfaceName,
+					rxRate,
+					txRate,
+					totalRate: findField(row.fields, ['total_rate', 'rate', 'throughput']),
+					rawLine: row.rawLine,
+					fields: row.fields,
+				} satisfies IslandRouterBandwidthUsageEntry,
+			]
+		}),
+		rawOutput: lines.join('\n'),
+	}
 }

--- a/packages/home-connector/src/adapters/island-router/ssh-client.ts
+++ b/packages/home-connector/src/adapters/island-router/ssh-client.ts
@@ -253,14 +253,36 @@ function escapeCliQuery(value: string) {
 		.replaceAll('"', '\\"')
 }
 
+function escapeCliValue(value: string, field: string) {
+	return assertSingleCliLine(value, field)
+		.replaceAll('\\', '\\\\')
+		.replaceAll('"', '\\"')
+}
+
 function getCommandLines(request: IslandRouterCommandRequest): Array<string> {
 	switch (request.id) {
 		case 'show-version':
 			return ['show version']
 		case 'show-clock':
 			return ['show clock']
+		case 'show-system':
+			return ['show system']
 		case 'show-interface-summary':
 			return ['show interface summary']
+		case 'show-interface-statistics':
+			return ['show interface statistics']
+		case 'show-bandwidth-usage':
+			// Best-effort guess; public docs were not found for realtime bandwidth usage.
+			return ['show bandwidth-usage']
+		case 'show-wan':
+			// Best-effort guess; public docs were not found for WAN summary inspection.
+			return ['show wan']
+		case 'show-wan-failover':
+			// Best-effort guess; public docs were not found for WAN failover status.
+			return ['show wan failover']
+		case 'show-multi-wan':
+			// Best-effort guess; public docs were not found for multi-WAN state.
+			return ['show multi-wan']
 		case 'show-interface':
 			return [
 				`show interface ${assertSingleCliLine(request.interfaceName, 'interfaceName')}`,
@@ -269,16 +291,133 @@ function getCommandLines(request: IslandRouterCommandRequest): Array<string> {
 			return [
 				`show ip interface ${assertSingleCliLine(request.interfaceName, 'interfaceName')}`,
 			]
+		case 'show-ip-routes':
+			return ['show ip routes']
+		case 'show-nat':
+			// Best-effort guess; public docs were not found for NAT inspection.
+			return ['show nat']
+		case 'show-ip-nat':
+			// Best-effort guess; public docs were not found for IP NAT inspection.
+			return ['show ip nat']
+		case 'show-sessions':
+			// Best-effort guess; public docs were not found for session table inspection.
+			return ['show sessions']
+		case 'show-vlan':
+			// Best-effort guess; public docs were not found for VLAN inspection.
+			return ['show vlan']
+		case 'show-dns':
+			// Best-effort guess; public docs were not found for DNS inspection.
+			return ['show dns']
+		case 'show-ip-dns':
+			// Best-effort guess; public docs were not found for IP DNS inspection.
+			return ['show ip dns']
+		case 'show-users':
+			return ['show users']
+		case 'show-user':
+			// Best-effort guess; public docs were not found for per-user detail output.
+			return ['show user']
+		case 'show-security-policy':
+			// Best-effort guess; public docs were not found for security policy inspection.
+			return ['show security-policy']
+		case 'show-protection':
+			// Best-effort guess; public docs were not found for protection inspection.
+			return ['show protection']
+		case 'show-firewall':
+			// Best-effort guess; public docs were not found for firewall inspection.
+			return ['show firewall']
+		case 'show-qos':
+			// Best-effort guess; public docs were not found for QoS inspection.
+			return ['show qos']
+		case 'show-traffic-policy':
+			// Best-effort guess; public docs were not found for traffic policy inspection.
+			return ['show traffic-policy']
+		case 'show-vpn':
+			// Best-effort guess; public docs were not found for VPN inspection.
+			return ['show vpn']
+		case 'show-ipsec':
+			// Best-effort guess; public docs were not found for IPsec inspection.
+			return ['show ipsec']
+		case 'show-gre':
+			// Best-effort guess; public docs were not found for GRE inspection.
+			return ['show gre']
 		case 'show-ip-neighbors':
 			return ['show ip neighbors']
 		case 'show-ip-dhcp-reservations':
 			return ['show ip dhcp-reservations']
+		case 'show-dhcp-server':
+			// Best-effort guess; public docs were not found for DHCP server inspection.
+			return ['show dhcp-server']
+		case 'show-ntp':
+			// Best-effort guess; public docs were not found for NTP inspection.
+			return ['show ntp']
+		case 'show-syslog':
+			// Best-effort guess; public docs were not found for syslog inspection.
+			return ['show syslog']
+		case 'show-snmp':
+			// Best-effort guess; public docs were not found for SNMP inspection.
+			return ['show snmp']
 		case 'show-log':
 			return request.query
 				? [`show log last where "${escapeCliQuery(request.query)}"`]
 				: ['show log last']
 		case 'ping':
 			return [`ping ${assertSingleCliLine(request.host, 'host')}`]
+		case 'force-wan-failover':
+			// Best-effort guess; public docs only confirmed priority-based WAN selection,
+			// not an explicit "force now" command.
+			return [
+				`wan failover force ${assertSingleCliLine(request.interfaceName, 'interfaceName')}`,
+			]
+		case 'set-dhcp-reservation': {
+			const command = [
+				'dhcp-server reservation',
+				assertSingleCliLine(request.macAddress, 'macAddress'),
+				assertSingleCliLine(request.ipAddress, 'ipAddress'),
+			]
+			if (request.hostName) {
+				command.push(`host-name "${escapeCliValue(request.hostName, 'hostName')}"`)
+			}
+			if (request.interfaceName) {
+				command.push(
+					`interface ${assertSingleCliLine(request.interfaceName, 'interfaceName')}`,
+				)
+			}
+			return [command.join(' ')]
+		}
+		case 'remove-dhcp-reservation':
+			return [
+				request.ipAddress
+					? `no dhcp-server reservation ${assertSingleCliLine(request.macAddress, 'macAddress')} ${assertSingleCliLine(request.ipAddress, 'ipAddress')}`
+					: `no dhcp-server reservation ${assertSingleCliLine(request.macAddress, 'macAddress')}`,
+			]
+		case 'reboot':
+			return ['reload']
+		case 'set-interface-description':
+			return [
+				`interface ${assertSingleCliLine(request.interfaceName, 'interfaceName')}`,
+				`description "${escapeCliValue(request.description, 'description')}"`,
+			]
+		case 'set-dns-server':
+			return request.interfaceName
+				? [
+						`interface ${assertSingleCliLine(request.interfaceName, 'interfaceName')}`,
+						...request.servers.map(
+							(server) =>
+								`ip name-server ${assertSingleCliLine(server, 'servers')}`,
+						),
+					]
+				: request.servers.map(
+						(server) =>
+							`ip dns server ${assertSingleCliLine(server, 'servers')}`,
+					)
+		case 'block-host':
+			return [
+				`firewall block-host ${assertSingleCliLine(request.host, 'host')}`,
+			]
+		case 'unblock-host':
+			return [
+				`no firewall block-host ${assertSingleCliLine(request.host, 'host')}`,
+			]
 		case 'clear-dhcp-client':
 			return ['clear dhcp-client']
 		case 'clear-log':

--- a/packages/home-connector/src/adapters/island-router/types.ts
+++ b/packages/home-connector/src/adapters/island-router/types.ts
@@ -23,13 +23,48 @@ export type IslandRouterConfigStatus = {
 export type IslandRouterCommandId =
 	| 'show-version'
 	| 'show-clock'
+	| 'show-system'
 	| 'show-interface-summary'
 	| 'show-interface'
 	| 'show-ip-interface'
+	| 'show-interface-statistics'
+	| 'show-bandwidth-usage'
+	| 'show-wan'
+	| 'show-wan-failover'
+	| 'show-multi-wan'
+	| 'show-ip-routes'
+	| 'show-nat'
+	| 'show-ip-nat'
+	| 'show-sessions'
+	| 'show-vlan'
+	| 'show-dns'
+	| 'show-ip-dns'
+	| 'show-users'
+	| 'show-user'
+	| 'show-security-policy'
+	| 'show-protection'
+	| 'show-firewall'
+	| 'show-qos'
+	| 'show-traffic-policy'
+	| 'show-vpn'
+	| 'show-ipsec'
+	| 'show-gre'
 	| 'show-ip-neighbors'
 	| 'show-ip-dhcp-reservations'
+	| 'show-dhcp-server'
+	| 'show-ntp'
+	| 'show-syslog'
+	| 'show-snmp'
 	| 'show-log'
 	| 'ping'
+	| 'force-wan-failover'
+	| 'set-dhcp-reservation'
+	| 'remove-dhcp-reservation'
+	| 'reboot'
+	| 'set-interface-description'
+	| 'set-dns-server'
+	| 'block-host'
+	| 'unblock-host'
 	| 'clear-dhcp-client'
 	| 'clear-log'
 	| 'write-memory'
@@ -44,7 +79,23 @@ export type IslandRouterCommandRequest =
 			timeoutMs?: number
 	  }
 	| {
+			id: 'show-system'
+			timeoutMs?: number
+	  }
+	| {
 			id: 'show-interface-summary'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-wan'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-wan-failover'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-multi-wan'
 			timeoutMs?: number
 	  }
 	| {
@@ -58,11 +109,103 @@ export type IslandRouterCommandRequest =
 			timeoutMs?: number
 	  }
 	| {
+			id: 'show-interface-statistics'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-bandwidth-usage'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-routes'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-nat'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-nat'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-sessions'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-vlan'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-dns'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-dns'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-users'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-user'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-security-policy'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-protection'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-firewall'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-qos'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-traffic-policy'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-vpn'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ipsec'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-gre'
+			timeoutMs?: number
+	  }
+	| {
 			id: 'show-ip-neighbors'
 			timeoutMs?: number
 	  }
 	| {
 			id: 'show-ip-dhcp-reservations'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-dhcp-server'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ntp'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-syslog'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-snmp'
 			timeoutMs?: number
 	  }
 	| {
@@ -75,6 +218,51 @@ export type IslandRouterCommandRequest =
 			host: string
 			timeoutMs?: number
 			allowTimeout?: boolean
+	  }
+	| {
+			id: 'force-wan-failover'
+			interfaceName: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'set-dhcp-reservation'
+			macAddress: string
+			ipAddress: string
+			hostName?: string
+			interfaceName?: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'remove-dhcp-reservation'
+			macAddress: string
+			ipAddress?: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'reboot'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'set-interface-description'
+			interfaceName: string
+			description: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'set-dns-server'
+			servers: Array<string>
+			interfaceName?: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'block-host'
+			host: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'unblock-host'
+			host: string
+			timeoutMs?: number
 	  }
 	| {
 			id: 'clear-dhcp-client'
@@ -105,6 +293,8 @@ export type IslandRouterCommandRunner = (
 ) => Promise<IslandRouterCommandResult>
 
 export type IslandRouterWriteOperationId =
+	| 'set-wan-failover'
+	| 'run-allowlisted-cli-command'
 	| 'renew-dhcp-clients'
 	| 'clear-log-buffer'
 	| 'save-running-config'
@@ -113,7 +303,23 @@ export type IslandRouterWriteOperationResult = {
 	operationId: IslandRouterWriteOperationId
 	commandId: Extract<
 		IslandRouterCommandId,
-		'clear-dhcp-client' | 'clear-log' | 'write-memory'
+		| 'show-version'
+		| 'show-clock'
+		| 'show-system'
+		| 'show-interface-summary'
+		| 'show-interface'
+		| 'show-ip-interface'
+		| 'force-wan-failover'
+		| 'set-dhcp-reservation'
+		| 'remove-dhcp-reservation'
+		| 'reboot'
+		| 'set-interface-description'
+		| 'set-dns-server'
+		| 'block-host'
+		| 'unblock-host'
+		| 'clear-dhcp-client'
+		| 'clear-log'
+		| 'write-memory'
 	>
 	commandLines: Array<string>
 	stdout: string
@@ -198,6 +404,362 @@ export type IslandRouterVersionInfo = {
 	firmwareVersion: string | null
 	attributes: Array<IslandRouterKeyValue>
 	rawOutput: string
+}
+
+export type IslandRouterWanRole = 'active' | 'standby' | 'unknown'
+
+export type IslandRouterWanConnectionType =
+	| 'dhcp'
+	| 'static'
+	| 'pppoe'
+	| 'unknown'
+
+export type IslandRouterWanInterfaceConfig = {
+	ispName: string | null
+	interfaceName: string | null
+	ipAddress: string | null
+	gateway: string | null
+	connectionType: IslandRouterWanConnectionType
+	role: IslandRouterWanRole
+	failoverPriority: number | null
+	linkState: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterWanConfig = {
+	wans: Array<IslandRouterWanInterfaceConfig>
+}
+
+export type IslandRouterFailoverHealthCheck = {
+	interfaceName: string | null
+	ispName: string | null
+	state: string | null
+	role: IslandRouterWanRole
+	failoverPriority: number | null
+	monitor: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterFailoverStatus = {
+	activeInterfaceName: string | null
+	activeIspName: string | null
+	policy: string | null
+	healthChecks: Array<IslandRouterFailoverHealthCheck>
+	rawOutput: string
+}
+
+export type IslandRouterRouteEntry = {
+	destination: string | null
+	gateway: string | null
+	interfaceName: string | null
+	protocol: string | null
+	metric: number | null
+	selected: boolean | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterRoutingTable = {
+	routes: Array<IslandRouterRouteEntry>
+}
+
+export type IslandRouterNatRule = {
+	ruleId: string | null
+	type: string | null
+	protocol: string | null
+	interfaceName: string | null
+	externalAddress: string | null
+	externalPort: string | null
+	internalAddress: string | null
+	internalPort: string | null
+	enabled: boolean | null
+	description: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterNatRules = {
+	rules: Array<IslandRouterNatRule>
+}
+
+export type IslandRouterVlanConfigEntry = {
+	vlanId: number | null
+	name: string | null
+	interfaceName: string | null
+	memberInterfaces: Array<string>
+	status: string | null
+	ipAddress: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterVlanConfig = {
+	vlans: Array<IslandRouterVlanConfigEntry>
+}
+
+export type IslandRouterDnsServer = {
+	address: string | null
+	role: string | null
+	source: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterDnsOverride = {
+	host: string | null
+	recordType: string | null
+	value: string | null
+	enabled: boolean | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterDnsConfig = {
+	mode: string | null
+	searchDomains: Array<string>
+	servers: Array<IslandRouterDnsServer>
+	overrides: Array<IslandRouterDnsOverride>
+	attributes: Array<IslandRouterKeyValue>
+	rawOutput: string
+}
+
+export type IslandRouterUserEntry = {
+	username: string | null
+	groupName: string | null
+	role: string | null
+	connectionType: string | null
+	address: string | null
+	connected: boolean | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterUsers = {
+	users: Array<IslandRouterUserEntry>
+	rawOutput: string
+}
+
+export type IslandRouterSecurityPolicyRule = {
+	ruleId: string | null
+	name: string | null
+	action: string | null
+	source: string | null
+	destination: string | null
+	service: string | null
+	enabled: boolean | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterSecurityPolicy = {
+	rules: Array<IslandRouterSecurityPolicyRule>
+	rawOutput: string
+}
+
+export type IslandRouterQosPolicyEntry = {
+	policyName: string | null
+	interfaceName: string | null
+	className: string | null
+	priority: string | null
+	bandwidth: string | null
+	enabled: boolean | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterQosConfig = {
+	policies: Array<IslandRouterQosPolicyEntry>
+	rawOutput: string
+}
+
+export type IslandRouterTrafficStat = {
+	interfaceName: string | null
+	rxBytes: number | null
+	txBytes: number | null
+	rxPackets: number | null
+	txPackets: number | null
+	rxErrors: number | null
+	txErrors: number | null
+	utilizationPercent: number | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterTrafficStats = {
+	interfaces: Array<IslandRouterTrafficStat>
+}
+
+export type IslandRouterActiveSession = {
+	protocol: string | null
+	sourceAddress: string | null
+	sourcePort: number | null
+	destinationAddress: string | null
+	destinationPort: number | null
+	translatedAddress: string | null
+	translatedPort: number | null
+	state: string | null
+	interfaceName: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterActiveSessions = {
+	sessions: Array<IslandRouterActiveSession>
+}
+
+export type IslandRouterVpnTunnel = {
+	tunnelName: string | null
+	type: string | null
+	localEndpoint: string | null
+	remoteEndpoint: string | null
+	status: string | null
+	interfaceName: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterVpnConfig = {
+	tunnels: Array<IslandRouterVpnTunnel>
+	rawOutput: string
+}
+
+export type IslandRouterDhcpServerPool = {
+	poolName: string | null
+	interfaceName: string | null
+	network: string | null
+	rangeStart: string | null
+	rangeEnd: string | null
+	gateway: string | null
+	dnsServers: Array<string>
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterDhcpServerOption = {
+	poolName: string | null
+	option: string | null
+	value: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterDhcpServerConfig = {
+	pools: Array<IslandRouterDhcpServerPool>
+	options: Array<IslandRouterDhcpServerOption>
+	reservations: Array<IslandRouterDhcpLease>
+	rawOutput: string
+}
+
+export type IslandRouterNtpServer = {
+	server: string | null
+	status: string | null
+	source: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterNtpConfig = {
+	timezone: string | null
+	servers: Array<IslandRouterNtpServer>
+	attributes: Array<IslandRouterKeyValue>
+	rawOutput: string
+}
+
+export type IslandRouterSyslogTarget = {
+	host: string | null
+	port: number | null
+	protocol: string | null
+	facility: string | null
+	enabled: boolean | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterSyslogConfig = {
+	targets: Array<IslandRouterSyslogTarget>
+	attributes: Array<IslandRouterKeyValue>
+	rawOutput: string
+}
+
+export type IslandRouterSnmpCommunity = {
+	community: string | null
+	access: string | null
+	source: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterSnmpTrapTarget = {
+	host: string | null
+	version: string | null
+	community: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterSnmpConfig = {
+	enabled: boolean | null
+	communities: Array<IslandRouterSnmpCommunity>
+	trapTargets: Array<IslandRouterSnmpTrapTarget>
+	attributes: Array<IslandRouterKeyValue>
+	rawOutput: string
+}
+
+export type IslandRouterSystemInfo = {
+	uptime: string | null
+	cpuUsagePercent: number | null
+	memoryUsagePercent: number | null
+	temperatureCelsius: number | null
+	attributes: Array<IslandRouterKeyValue>
+	rawOutput: string
+}
+
+export type IslandRouterBandwidthUsageEntry = {
+	subject: string | null
+	interfaceName: string | null
+	rxRate: string | null
+	txRate: string | null
+	totalRate: string | null
+	rawLine: string
+	fields: Record<string, string>
+}
+
+export type IslandRouterBandwidthUsage = {
+	entries: Array<IslandRouterBandwidthUsageEntry>
+	rawOutput: string
+}
+
+export type IslandRouterAllowlistedCliCommand =
+	| 'show-version'
+	| 'show-clock'
+	| 'show-interface-summary'
+	| 'show-interface'
+	| 'show-ip-interface'
+
+export type IslandRouterAllowlistedCliCommandResult = {
+	command: IslandRouterAllowlistedCliCommand
+	commandId: Extract<
+		IslandRouterCommandId,
+		| 'show-version'
+		| 'show-clock'
+		| 'show-interface-summary'
+		| 'show-interface'
+		| 'show-ip-interface'
+	>
+	commandLines: Array<string>
+	result:
+		| IslandRouterVersionInfo
+		| { clock: string | null }
+		| { interfaces: Array<IslandRouterInterfaceSummary> }
+		| IslandRouterInterfaceDetails
+	stdout: string
+	stderr: string
+	exitCode: number | null
+	signal: NodeJS.Signals | null
+	timedOut: boolean
+	durationMs: number
 }
 
 export type IslandRouterStatus = {

--- a/packages/home-connector/src/mcp/register-island-router-tools.ts
+++ b/packages/home-connector/src/mcp/register-island-router-tools.ts
@@ -40,6 +40,39 @@ function structuredTextResult(
 const routerWriteDangerNotice =
 	'HIGH RISK: this mutates a live router. Use it only when you are highly certain it is necessary and correct because mistakes can disrupt connectivity, destroy diagnostics, or persist a bad state with severe consequences.'
 
+function registerRouterReadTool(input: {
+	registerTool: (
+		descriptor: IslandRouterRegisteredToolDescriptor,
+		handler: IslandRouterToolHandler,
+	) => void
+	name: string
+	title: string
+	description: string
+	inputSchema?: ReturnType<typeof buildToolInputSchema>
+	handler: (args: Record<string, unknown>) => Promise<{
+		text: string
+		structuredContent: unknown
+	}>
+}) {
+	input.registerTool(
+		{
+			name: input.name,
+			title: input.title,
+			description: input.description,
+			inputSchema: input.inputSchema?.inputSchema ?? {},
+			sdkInputSchema: input.inputSchema?.sdkInputSchema,
+			annotations: {
+				readOnlyHint: true,
+				idempotentHint: true,
+			},
+		},
+		async (args) => {
+			const result = await input.handler(args)
+			return structuredTextResult(result.text, result.structuredContent)
+		},
+	)
+}
+
 export function registerIslandRouterHomeConnectorTools(input: {
 	registerTool: (
 		descriptor: IslandRouterRegisteredToolDescriptor,
@@ -322,6 +355,400 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		islandRouter.writeAcknowledgements.saveRunningConfig,
 	)
 
+	const readTimeoutSchema = buildToolInputSchema({
+		timeoutMs: z
+			.number()
+			.int()
+			.min(1000)
+			.max(60_000)
+			.optional()
+			.describe('Optional command timeout in milliseconds.'),
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_wan_config',
+		title: 'Get Island Router WAN Config',
+		description:
+			'Read WAN interface configuration for all WAN ports, including ISP/provider labels, addressing, failover role, and priority.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getWanConfig({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text:
+					result.wans.length === 0
+						? 'No Island router WAN interfaces were parsed.'
+						: `Loaded ${result.wans.length} Island router WAN interface configuration entry/entries.`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_failover_status',
+		title: 'Get Island Router Failover Status',
+		description:
+			'Read multi-WAN failover status including the active ISP/interface, health state per WAN, and failover policy.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getFailoverStatus({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text: result.healthChecks.length === 0
+					? 'No Island router failover health checks were parsed.'
+					: `Loaded Island router failover status with ${result.healthChecks.length} WAN health check entry/entries.`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_routing_table',
+		title: 'Get Island Router Routing Table',
+		description: 'Read the Island router IP routing table.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getRoutingTable({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text:
+					result.routes.length === 0
+						? 'No Island router routes were parsed.'
+						: `Loaded ${result.routes.length} Island router route entry/entries.`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_nat_rules',
+		title: 'Get Island Router NAT Rules',
+		description:
+			'Read Island router NAT and port-forwarding rules from the typed allowlisted CLI views.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getNatRules({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text:
+					result.rules.length === 0
+						? 'No Island router NAT rules were parsed.'
+						: `Loaded ${result.rules.length} Island router NAT rule(s).`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_vlan_config',
+		title: 'Get Island Router VLAN Config',
+		description:
+			'Read Island router VLAN definitions, interface assignments, and parsed addressing details when present.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getVlanConfig({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text:
+					result.vlans.length === 0
+						? 'No Island router VLAN configuration entries were parsed.'
+						: `Loaded ${result.vlans.length} Island router VLAN configuration entry/entries.`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_dns_config',
+		title: 'Get Island Router DNS Config',
+		description:
+			'Read Island router DNS server configuration and parsed local DNS override records when present.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getDnsConfig({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text: `Loaded Island router DNS configuration with ${result.servers.length} server(s) and ${result.overrides.length} override(s).`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_users',
+		title: 'Get Island Router Users',
+		description:
+			'Read Island router local or connected user account information from the CLI user views.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getUsers({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text:
+					result.users.length === 0
+						? 'No Island router users were parsed.'
+						: `Loaded ${result.users.length} Island router user entry/entries.`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_security_policy',
+		title: 'Get Island Router Security Policy',
+		description:
+			'Read Island router firewall, protection, or security-policy rules from the typed allowlisted CLI views.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getSecurityPolicy({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text:
+					result.rules.length === 0
+						? 'No Island router security policy rules were parsed.'
+						: `Loaded ${result.rules.length} Island router security policy rule(s).`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_qos_config',
+		title: 'Get Island Router QoS Config',
+		description:
+			'Read Island router QoS or traffic-shaping policy configuration from the typed allowlisted CLI views.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getQosConfig({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text:
+					result.policies.length === 0
+						? 'No Island router QoS policies were parsed.'
+						: `Loaded ${result.policies.length} Island router QoS policy entry/entries.`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_traffic_stats',
+		title: 'Get Island Router Traffic Stats',
+		description:
+			'Read per-interface Island router traffic statistics including bytes, packets, errors, and utilization when present.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getTrafficStats({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text:
+					result.interfaces.length === 0
+						? 'No Island router traffic statistics were parsed.'
+						: `Loaded traffic statistics for ${result.interfaces.length} Island router interface(s).`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_active_sessions',
+		title: 'Get Island Router Active Sessions',
+		description:
+			'Read the Island router active session or connection-state table, including parsed protocol and endpoint tuples.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getActiveSessions({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text:
+					result.sessions.length === 0
+						? 'No Island router active sessions were parsed.'
+						: `Loaded ${result.sessions.length} Island router active session(s).`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_vpn_config',
+		title: 'Get Island Router VPN Config',
+		description:
+			'Read Island router VPN or tunnel configuration (such as IPSec or GRE) from the typed allowlisted CLI views.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getVpnConfig({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text:
+					result.tunnels.length === 0
+						? 'No Island router VPN tunnels were parsed.'
+						: `Loaded ${result.tunnels.length} Island router VPN or tunnel entry/entries.`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_dhcp_server_config',
+		title: 'Get Island Router DHCP Server Config',
+		description:
+			'Read Island router DHCP server pools, options, and static reservation configuration.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getDhcpServerConfig({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text: `Loaded Island router DHCP server config with ${result.pools.length} pool(s), ${result.options.length} option(s), and ${result.reservations.length} reservation(s).`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_ntp_config',
+		title: 'Get Island Router NTP Config',
+		description:
+			'Read Island router NTP or time-sync configuration including parsed upstream servers when present.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getNtpConfig({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text:
+					result.servers.length === 0
+						? 'No Island router NTP servers were parsed.'
+						: `Loaded ${result.servers.length} Island router NTP server entry/entries.`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_syslog_config',
+		title: 'Get Island Router Syslog Config',
+		description:
+			'Read Island router remote syslog target configuration when present.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getSyslogConfig({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text:
+					result.targets.length === 0
+						? 'No Island router syslog targets were parsed.'
+						: `Loaded ${result.targets.length} Island router syslog target(s).`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_snmp_config',
+		title: 'Get Island Router SNMP Config',
+		description:
+			'Read Island router SNMP community and trap-target configuration when present.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getSnmpConfig({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text: `Loaded Island router SNMP config with ${result.communities.length} community entry/entries and ${result.trapTargets.length} trap target(s).`,
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_system_info',
+		title: 'Get Island Router System Info',
+		description:
+			'Read Island router system-health information such as uptime, CPU usage, memory usage, and temperature when available.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getSystemInfo({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text: result.uptime
+					? `Loaded Island router system info with uptime ${result.uptime}.`
+					: 'Loaded Island router system info.',
+				structuredContent: result,
+			}
+		},
+	})
+
+	registerRouterReadTool({
+		registerTool,
+		name: 'router_get_bandwidth_usage',
+		title: 'Get Island Router Bandwidth Usage',
+		description:
+			'Read Island router real-time or historical bandwidth usage entries when the CLI exposes them.',
+		inputSchema: readTimeoutSchema,
+		handler: async (args) => {
+			const result = await islandRouter.getBandwidthUsage({
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return {
+				text:
+					result.entries.length === 0
+						? 'No Island router bandwidth usage entries were parsed.'
+						: `Loaded ${result.entries.length} Island router bandwidth usage entry/entries.`,
+				structuredContent: result,
+			}
+		},
+	})
+
 	registerTool(
 		{
 			name: 'router_renew_dhcp_clients',
@@ -395,6 +822,476 @@ export function registerIslandRouterHomeConnectorTools(input: {
 			})
 			return structuredTextResult(
 				'Saved the Island router running configuration to startup storage.',
+				result,
+			)
+		},
+	)
+
+	const wanFailoverSchema = buildToolInputSchema({
+		interfaceName: z
+			.string()
+			.min(1)
+			.describe('WAN interface name to force into the active role.'),
+		acknowledgeHighRisk: z
+			.literal(true)
+			.describe(
+				'Must be true. Set this only when you are highly certain the requested router mutation is necessary and correct.',
+			),
+		reason: z
+			.string()
+			.min(20)
+			.max(500)
+			.describe(
+				'Short operator justification. Be specific about why this mutation is necessary right now.',
+			),
+		confirmation: z
+			.literal(islandRouter.writeAcknowledgements.setWanFailover)
+			.describe(
+				'Exact confirmation phrase required by the tool. The tool rejects any other value.',
+			),
+		timeoutMs: z
+			.number()
+			.int()
+			.min(1000)
+			.max(60_000)
+			.optional()
+			.describe('Optional command timeout in milliseconds.'),
+	})
+
+	registerTool(
+		{
+			name: 'router_set_wan_failover',
+			title: 'Force Island Router WAN Failover',
+			description: `${routerWriteDangerNotice} This typed allowlisted operation attempts to force WAN failover to a specific interface. The exact Island CLI command is a best-effort guess because public CLI docs only confirmed priority-based WAN selection, not an explicit manual failover command.`,
+			inputSchema: wanFailoverSchema.inputSchema,
+			sdkInputSchema: wanFailoverSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await islandRouter.setWanFailover({
+				interfaceName: String(args['interfaceName'] ?? ''),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return structuredTextResult(
+				`Forced Island router WAN failover to ${String(args['interfaceName'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	const allowlistedCliSchema = buildToolInputSchema({
+		command: z
+			.enum([
+				'show-version',
+				'show-clock',
+				'show-interface-summary',
+				'show-interface',
+				'show-ip-interface',
+			])
+			.describe(
+				'Allowlisted read-only Island router CLI command alias. No arbitrary CLI execution is allowed.',
+			),
+		interfaceName: z
+			.string()
+			.min(1)
+			.optional()
+			.describe(
+				'Required only for interface-scoped commands such as show-interface or show-ip-interface.',
+			),
+		acknowledgeHighRisk: z
+			.literal(true)
+			.describe(
+				'Must be true. Set this only when you are highly certain the requested router mutation is necessary and correct.',
+			),
+		reason: z
+			.string()
+			.min(20)
+			.max(500)
+			.describe(
+				'Short operator justification. Be specific about why this mutation is necessary right now.',
+			),
+		confirmation: z
+			.literal(islandRouter.writeAcknowledgements.runAllowlistedCliCommand)
+			.describe(
+				'Exact confirmation phrase required by the tool. The tool rejects any other value.',
+			),
+		timeoutMs: z
+			.number()
+			.int()
+			.min(1000)
+			.max(60_000)
+			.optional()
+			.describe('Optional command timeout in milliseconds.'),
+	})
+
+	registerTool(
+		{
+			name: 'router_run_allowlisted_cli_command',
+			title: 'Run Allowlisted Island Router CLI Command',
+			description: `${routerWriteDangerNotice} This typed allowlisted escape hatch runs only a very small set of explicitly enumerated read-only show commands not already covered by a more specific tool. It never accepts arbitrary CLI text.`,
+			inputSchema: allowlistedCliSchema.inputSchema,
+			sdkInputSchema: allowlistedCliSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await islandRouter.runAllowlistedCliCommand({
+				command: args['command'] as
+					| 'show-version'
+					| 'show-clock'
+					| 'show-interface-summary'
+					| 'show-interface'
+					| 'show-ip-interface',
+				interfaceName:
+					args['interfaceName'] == null
+						? undefined
+						: String(args['interfaceName']),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return structuredTextResult(
+				`Ran allowlisted Island router CLI command ${result.command}.`,
+				result,
+			)
+		},
+	)
+
+	const dhcpReservationSchema = buildToolInputSchema({
+		action: z.enum(['set', 'remove']),
+		macAddress: z.string().min(1).describe('Target MAC address for the reservation.'),
+		ipAddress: z
+			.string()
+			.min(1)
+			.optional()
+			.describe('IPv4 address for set, or optional match hint for remove.'),
+		hostName: z
+			.string()
+			.min(1)
+			.optional()
+			.describe('Optional hostname label for set operations.'),
+		interfaceName: z
+			.string()
+			.min(1)
+			.optional()
+			.describe('Optional interface name for set operations.'),
+		acknowledgeHighRisk: z
+			.literal(true)
+			.describe(
+				'Must be true. Set this only when you are highly certain the requested router mutation is necessary and correct.',
+			),
+		reason: z
+			.string()
+			.min(20)
+			.max(500)
+			.describe(
+				'Short operator justification. Be specific about why this mutation is necessary right now.',
+			),
+		confirmation: z
+			.literal(islandRouter.writeAcknowledgements.setDhcpReservation)
+			.describe(
+				'Exact confirmation phrase required by the tool. The tool rejects any other value.',
+			),
+		timeoutMs: z
+			.number()
+			.int()
+			.min(1000)
+			.max(60_000)
+			.optional()
+			.describe('Optional command timeout in milliseconds.'),
+	})
+
+	registerTool(
+		{
+			name: 'router_set_dhcp_reservation',
+			title: 'Change Island Router DHCP Reservation',
+			description: `${routerWriteDangerNotice} This typed allowlisted operation adds, updates, or removes a static DHCP reservation by MAC address and IP. A mistake can strand devices on the wrong address or break expected host mappings.`,
+			inputSchema: dhcpReservationSchema.inputSchema,
+			sdkInputSchema: dhcpReservationSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const action = args['action'] === 'remove' ? 'remove' : 'set'
+			const result = await islandRouter.setDhcpReservation({
+				action,
+				macAddress: String(args['macAddress'] ?? ''),
+				ipAddress:
+					args['ipAddress'] == null ? undefined : String(args['ipAddress']),
+				hostName:
+					args['hostName'] == null ? undefined : String(args['hostName']),
+				interfaceName:
+					args['interfaceName'] == null
+						? undefined
+						: String(args['interfaceName']),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return structuredTextResult(
+				action === 'remove'
+					? 'Removed the requested Island router DHCP reservation.'
+					: 'Set the requested Island router DHCP reservation.',
+				result,
+			)
+		},
+	)
+
+	const rebootSchema = createRouterWriteSchema(
+		islandRouter.writeAcknowledgements.reboot,
+	)
+
+	registerTool(
+		{
+			name: 'router_reboot',
+			title: 'Reboot Island Router',
+			description: `${routerWriteDangerNotice} This typed allowlisted operation reboots the live Island router. It can immediately disrupt all connectivity for the local network and should be used only with extreme certainty.`,
+			inputSchema: rebootSchema.inputSchema,
+			sdkInputSchema: rebootSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await islandRouter.rebootRouter({
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return structuredTextResult('Issued an Island router reboot command.', result)
+		},
+	)
+
+	const interfaceDescriptionSchema = buildToolInputSchema({
+		interfaceName: z.string().min(1).describe('Interface name to relabel.'),
+		description: z.string().min(1).describe('New interface description or label.'),
+		acknowledgeHighRisk: z
+			.literal(true)
+			.describe(
+				'Must be true. Set this only when you are highly certain the requested router mutation is necessary and correct.',
+			),
+		reason: z
+			.string()
+			.min(20)
+			.max(500)
+			.describe(
+				'Short operator justification. Be specific about why this mutation is necessary right now.',
+			),
+		confirmation: z
+			.literal(islandRouter.writeAcknowledgements.setInterfaceDescription)
+			.describe(
+				'Exact confirmation phrase required by the tool. The tool rejects any other value.',
+			),
+		timeoutMs: z
+			.number()
+			.int()
+			.min(1000)
+			.max(60_000)
+			.optional()
+			.describe('Optional command timeout in milliseconds.'),
+	})
+
+	registerTool(
+		{
+			name: 'router_set_interface_description',
+			title: 'Set Island Router Interface Description',
+			description: `${routerWriteDangerNotice} This typed allowlisted operation changes the description or label on a named interface.`,
+			inputSchema: interfaceDescriptionSchema.inputSchema,
+			sdkInputSchema: interfaceDescriptionSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await islandRouter.setInterfaceDescription({
+				interfaceName: String(args['interfaceName'] ?? ''),
+				description: String(args['description'] ?? ''),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return structuredTextResult(
+				`Updated Island router interface description for ${String(args['interfaceName'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	const dnsServerWriteSchema = buildToolInputSchema({
+		servers: z
+			.array(z.string().min(1))
+			.min(1)
+			.describe('DNS server IP addresses or hostnames to configure.'),
+		interfaceName: z
+			.string()
+			.min(1)
+			.optional()
+			.describe('Optional interface name when the DNS change should be scoped.'),
+		acknowledgeHighRisk: z
+			.literal(true)
+			.describe(
+				'Must be true. Set this only when you are highly certain the requested router mutation is necessary and correct.',
+			),
+		reason: z
+			.string()
+			.min(20)
+			.max(500)
+			.describe(
+				'Short operator justification. Be specific about why this mutation is necessary right now.',
+			),
+		confirmation: z
+			.literal(islandRouter.writeAcknowledgements.setDnsServer)
+			.describe(
+				'Exact confirmation phrase required by the tool. The tool rejects any other value.',
+			),
+		timeoutMs: z
+			.number()
+			.int()
+			.min(1000)
+			.max(60_000)
+			.optional()
+			.describe('Optional command timeout in milliseconds.'),
+	})
+
+	registerTool(
+		{
+			name: 'router_set_dns_server',
+			title: 'Set Island Router DNS Server',
+			description: `${routerWriteDangerNotice} This typed allowlisted operation changes the router DNS server configuration for a WAN or LAN context. A mistake can break name resolution across the network.`,
+			inputSchema: dnsServerWriteSchema.inputSchema,
+			sdkInputSchema: dnsServerWriteSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await islandRouter.setDnsServer({
+				servers: Array.isArray(args['servers'])
+					? args['servers'].map((value) => String(value))
+					: [],
+				interfaceName:
+					args['interfaceName'] == null
+						? undefined
+						: String(args['interfaceName']),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return structuredTextResult(
+				'Updated Island router DNS server configuration.',
+				result,
+			)
+		},
+	)
+
+	const hostMutationSchema = (
+		confirmationPhrase: string,
+		hostDescription: string,
+	) =>
+		buildToolInputSchema({
+			host: z.string().min(1).describe(hostDescription),
+			acknowledgeHighRisk: z
+				.literal(true)
+				.describe(
+					'Must be true. Set this only when you are highly certain the requested router mutation is necessary and correct.',
+				),
+			reason: z
+				.string()
+				.min(20)
+				.max(500)
+				.describe(
+					'Short operator justification. Be specific about why this mutation is necessary right now.',
+				),
+			confirmation: z
+				.literal(confirmationPhrase)
+				.describe(
+					'Exact confirmation phrase required by the tool. The tool rejects any other value.',
+				),
+			timeoutMs: z
+				.number()
+				.int()
+				.min(1000)
+				.max(60_000)
+				.optional()
+				.describe('Optional command timeout in milliseconds.'),
+		})
+
+	const blockHostSchema = hostMutationSchema(
+		islandRouter.writeAcknowledgements.blockHost,
+		'IPv4, IPv6, hostname, or MAC address to block.',
+	)
+	const unblockHostSchema = hostMutationSchema(
+		islandRouter.writeAcknowledgements.unblockHost,
+		'IPv4, IPv6, hostname, or MAC address to unblock.',
+	)
+
+	registerTool(
+		{
+			name: 'router_block_host',
+			title: 'Block Host On Island Router',
+			description: `${routerWriteDangerNotice} This typed allowlisted operation attempts to add a host-block rule for the specified IP or MAC address. A mistake can immediately cut off the wrong device from the network.`,
+			inputSchema: blockHostSchema.inputSchema,
+			sdkInputSchema: blockHostSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await islandRouter.blockHost({
+				host: String(args['host'] ?? ''),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return structuredTextResult(
+				`Blocked host ${String(args['host'] ?? '')} on the Island router.`,
+				result,
+			)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'router_unblock_host',
+			title: 'Unblock Host On Island Router',
+			description: `${routerWriteDangerNotice} This typed allowlisted operation attempts to remove a host-block rule for the specified IP or MAC address.`,
+			inputSchema: unblockHostSchema.inputSchema,
+			sdkInputSchema: unblockHostSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await islandRouter.unblockHost({
+				host: String(args['host'] ?? ''),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+				timeoutMs:
+					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			})
+			return structuredTextResult(
+				`Unblocked host ${String(args['host'] ?? '')} on the Island router.`,
 				result,
 			)
 		},

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -67,6 +67,22 @@ function createIslandRouterRunner() {
 					timedOut: false,
 					durationMs: 10,
 				}
+			case 'show-system':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show system'],
+					stdout: [
+						'Uptime: 4 days 03 hours',
+						'CPU Usage: 17%',
+						'Memory Usage: 41%',
+						'Temperature: 46 C',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
 			case 'show-interface-summary':
 				return {
 					id: request.id,
@@ -75,6 +91,88 @@ function createIslandRouterRunner() {
 						'Interface  Link   Speed  Duplex  Description',
 						'---------  -----  -----  ------  -----------',
 						'en0        up     1G     full    LAN uplink',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-interface-statistics':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show interface statistics'],
+					stdout: [
+						'Interface  RX Bytes  TX Bytes  RX Packets  TX Packets  RX Errors  TX Errors  Utilization',
+						'---------  --------  --------  ----------  ----------  ---------  ---------  -----------',
+						'en0        1000      2000      10          20          0          0          12%',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-bandwidth-usage':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show bandwidth-usage'],
+					stdout: [
+						'Interface  RX Rate   TX Rate   Total Rate',
+						'---------  --------  --------  ----------',
+						'en0        12 Mbps   4 Mbps    16 Mbps',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-wan':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show wan'],
+					stdout: [
+						'ISP  Interface  IP Address     Gateway       Type   Role    Priority',
+						'---  ---------  -------------  ------------  -----  ------  --------',
+						'Fiber       en1      203.0.113.10   203.0.113.1   dhcp   active   1',
+						'LTE         en2      198.51.100.10  198.51.100.1  dhcp   standby  2',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-wan-failover':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show wan failover'],
+					stdout: [
+						'Active Interface: en1',
+						'Policy: priority',
+						'Interface  ISP    State    Role    Priority  Monitor',
+						'---------  -----  -------  ------  --------  -------',
+						'en1        Fiber  healthy  active   1         ping',
+						'en2        LTE    healthy  standby  2         ping',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-multi-wan':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show multi-wan'],
+					stdout: [
+						'Active WAN: en1',
+						'Policy: priority',
+						'Interface  ISP    State    Role    Priority  Monitor',
+						'---------  -----  -------  ------  --------  -------',
+						'en1        Fiber  healthy  active   1         ping',
+						'en2        LTE    healthy  standby  2         ping',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -105,6 +203,243 @@ function createIslandRouterRunner() {
 						'IP Address    MAC Address        Host Name  Interface',
 						'------------  -----------------  ---------  ---------',
 						'192.168.0.52  00:11:22:33:44:55  nas-box    en0',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-routes':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ip routes'],
+					stdout: [
+						'Destination      Gateway       Interface  Protocol  Metric',
+						'---------------  ------------  ---------  --------  ------',
+						'default          203.0.113.1   en1        static    1',
+						'192.168.0.0/24   0.0.0.0       en0        kernel    0',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-nat':
+			case 'show-ip-nat':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.id === 'show-nat' ? 'show nat' : 'show ip nat',
+					],
+					stdout: [
+						'Rule  Type        Protocol  Interface  External        Internal         Enabled  Description',
+						'----  ----------  --------  ---------  --------------  ---------------  -------  -----------',
+						'1     port-forward  tcp       en1        203.0.113.10:443  192.168.0.52:443  enabled  NAS HTTPS',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-sessions':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show sessions'],
+					stdout: [
+						'Protocol  Source              Destination         State        Interface',
+						'--------  ------------------  ------------------  -----------  ---------',
+						'tcp       192.168.0.52:54321  1.1.1.1:443         established  en1',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-vlan':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show vlan'],
+					stdout: [
+						'VLAN  Name    Interface  Members      Status  IP Address',
+						'----  ------  ---------  -----------  ------  ----------',
+						'10    IOT     vlan10     en3,en4      up      192.168.10.1',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-dns':
+			case 'show-ip-dns':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.id === 'show-dns' ? 'show dns' : 'show ip dns',
+					],
+					stdout: [
+						'Mode: manual',
+						'Address',
+						'-------',
+						'1.1.1.1',
+						'8.8.8.8',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-users':
+			case 'show-user':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.id === 'show-users' ? 'show users' : 'show user',
+					],
+					stdout: [
+						'Username  Role   Connection  Address',
+						'--------  -----  ----------  -------',
+						'admin     admin  ssh         192.168.0.20',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-security-policy':
+			case 'show-protection':
+			case 'show-firewall':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.id === 'show-security-policy'
+							? 'show security-policy'
+							: request.id === 'show-protection'
+								? 'show protection'
+								: 'show firewall',
+					],
+					stdout: [
+						'Rule  Action  Source        Destination  Service  Enabled',
+						'----  ------  ------------  -----------  -------  -------',
+						'10    allow   192.168.0.0/24 any         any      enabled',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-qos':
+			case 'show-traffic-policy':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.id === 'show-qos' ? 'show qos' : 'show traffic-policy',
+					],
+					stdout: [
+						'Policy  Interface  Class   Priority  Bandwidth  Enabled',
+						'------  ---------  ------  --------  ---------  -------',
+						'video   en1        voice   high      50 Mbps    enabled',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-vpn':
+			case 'show-ipsec':
+			case 'show-gre':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.id === 'show-vpn'
+							? 'show vpn'
+							: request.id === 'show-ipsec'
+								? 'show ipsec'
+								: 'show gre',
+					],
+					stdout: [
+						'Name    Type   Local Endpoint  Remote Endpoint  Status  Interface',
+						'------  -----  --------------  ---------------  ------  ---------',
+						's2s     ipsec  203.0.113.10    203.0.113.20     up      en1',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-dhcp-server':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show dhcp-server'],
+					stdout: [
+						'Pool  Interface  Network         Range Start    Range End      Gateway      DNS Servers',
+						'----  ---------  --------------  -------------  -------------  -----------  ----------------',
+						'LAN   en0        192.168.0.0/24  192.168.0.100  192.168.0.199  192.168.0.1  1.1.1.1,8.8.8.8',
+						'IP Address    MAC Address        Host Name  Interface',
+						'------------  -----------------  ---------  ---------',
+						'192.168.0.52  00:11:22:33:44:55  nas-box    en0',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ntp':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ntp'],
+					stdout: [
+						'Timezone: America/Denver',
+						'Server',
+						'------',
+						'time.cloudflare.com',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-syslog':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show syslog'],
+					stdout: [
+						'Host              Port  Protocol  Facility  Enabled',
+						'----------------  ----  --------  --------  -------',
+						'192.168.0.10      514   udp       local0    enabled',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-snmp':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show snmp'],
+					stdout: [
+						'Enabled: true',
+						'Community  Access  Source',
+						'---------  ------  -------',
+						'public     ro      192.168.0.0/24',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -168,6 +503,97 @@ function createIslandRouterRunner() {
 					signal: null,
 					timedOut: false,
 					durationMs: 200,
+				}
+			case 'force-wan-failover':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						`wan failover force ${request.interfaceName}`,
+					],
+					stdout: `Forced WAN failover to ${request.interfaceName}.`,
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 150,
+				}
+			case 'set-dhcp-reservation':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'dhcp-server reservation'],
+					stdout: 'DHCP reservation updated.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 150,
+				}
+			case 'remove-dhcp-reservation':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'no dhcp-server reservation'],
+					stdout: 'DHCP reservation removed.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 150,
+				}
+			case 'reboot':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'reload'],
+					stdout: 'Reload requested.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 150,
+				}
+			case 'set-interface-description':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'interface en0', 'description "LAN uplink"'],
+					stdout: 'Interface description updated.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 150,
+				}
+			case 'set-dns-server':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'ip name-server 1.1.1.1'],
+					stdout: 'DNS servers updated.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 150,
+				}
+			case 'block-host':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'firewall block-host 192.168.0.52'],
+					stdout: 'Host blocked.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 150,
+				}
+			case 'unblock-host':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'no firewall block-host 192.168.0.52'],
+					stdout: 'Host unblocked.',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 150,
 				}
 			case 'clear-dhcp-client':
 				return {
@@ -316,6 +742,56 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		expect(tools.some((tool) => tool.name === 'router_diagnose_host')).toBe(
 			true,
 		)
+		expect(tools.some((tool) => tool.name === 'router_get_wan_config')).toBe(true)
+		expect(
+			tools.some((tool) => tool.name === 'router_get_failover_status'),
+		).toBe(true)
+		expect(
+			tools.some((tool) => tool.name === 'router_get_routing_table'),
+		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_nat_rules')).toBe(
+			true,
+		)
+		expect(tools.some((tool) => tool.name === 'router_get_vlan_config')).toBe(
+			true,
+		)
+		expect(tools.some((tool) => tool.name === 'router_get_dns_config')).toBe(
+			true,
+		)
+		expect(tools.some((tool) => tool.name === 'router_get_users')).toBe(true)
+		expect(
+			tools.some((tool) => tool.name === 'router_get_security_policy'),
+		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_qos_config')).toBe(
+			true,
+		)
+		expect(
+			tools.some((tool) => tool.name === 'router_get_traffic_stats'),
+		).toBe(true)
+		expect(
+			tools.some((tool) => tool.name === 'router_get_active_sessions'),
+		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_vpn_config')).toBe(
+			true,
+		)
+		expect(
+			tools.some((tool) => tool.name === 'router_get_dhcp_server_config'),
+		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_ntp_config')).toBe(
+			true,
+		)
+		expect(
+			tools.some((tool) => tool.name === 'router_get_syslog_config'),
+		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_snmp_config')).toBe(
+			true,
+		)
+		expect(
+			tools.some((tool) => tool.name === 'router_get_system_info'),
+		).toBe(true)
+		expect(
+			tools.some((tool) => tool.name === 'router_get_bandwidth_usage'),
+		).toBe(true)
 		expect(
 			tools.some((tool) => tool.name === 'router_renew_dhcp_clients'),
 		).toBe(true)
@@ -325,6 +801,26 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		expect(
 			tools.some((tool) => tool.name === 'router_save_running_config'),
 		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_set_wan_failover')).toBe(
+			true,
+		)
+		expect(
+			tools.some((tool) => tool.name === 'router_run_allowlisted_cli_command'),
+		).toBe(true)
+		expect(
+			tools.some((tool) => tool.name === 'router_set_dhcp_reservation'),
+		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_reboot')).toBe(true)
+		expect(
+			tools.some((tool) => tool.name === 'router_set_interface_description'),
+		).toBe(true)
+		expect(
+			tools.some((tool) => tool.name === 'router_set_dns_server'),
+		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_block_host')).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_unblock_host')).toBe(
+			true,
+		)
 		expect(
 			tools.some((tool) => tool.name === 'jellyfish_scan_controllers'),
 		).toBe(true)
@@ -526,6 +1022,45 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 			dhcpLease: {
 				hostName: 'nas-box',
 			},
+		})
+		const wanConfig = await mcp.callTool('router_get_wan_config')
+		expect(wanConfig.structuredContent).toMatchObject({
+			wans: expect.arrayContaining([
+				expect.objectContaining({
+					interfaceName: 'en1',
+					connectionType: 'dhcp',
+				}),
+			]),
+		})
+		const systemInfo = await mcp.callTool('router_get_system_info')
+		expect(systemInfo.structuredContent).toMatchObject({
+			uptime: expect.any(String),
+			cpuUsagePercent: 17,
+		})
+		const activeSessions = await mcp.callTool('router_get_active_sessions')
+		expect(activeSessions.structuredContent).toMatchObject({
+			sessions: expect.arrayContaining([
+				expect.objectContaining({
+					sourceAddress: '192.168.0.52',
+					destinationAddress: '1.1.1.1',
+				}),
+			]),
+		})
+		const allowlistedRouterCommand = await mcp.callTool(
+			'router_run_allowlisted_cli_command',
+			{
+				acknowledgeHighRisk: true,
+				reason:
+					'The typed status tool is not sufficient and the allowlisted interface detail command is needed for diagnosis.',
+				confirmation:
+					'I am highly certain running this allowlisted Island router CLI command is necessary right now.',
+				command: 'show-interface',
+				interfaceName: 'en0',
+			},
+		)
+		expect(allowlistedRouterCommand.structuredContent).toMatchObject({
+			command: 'show-interface',
+			commandId: 'show-interface',
 		})
 
 		await expect(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- expand the Island router adapter, SSH allowlist, and MCP registrations to cover a much broader read surface: WAN/failover, routing, NAT, VLAN, DNS, users, security/QoS, traffic/session state, VPN, DHCP server, NTP, syslog, SNMP, system info, and bandwidth usage
- add additional HIGH RISK typed write operations with the same acknowledgement/host-verification guardrails: WAN failover, allowlisted CLI read escape hatch, DHCP reservations, reboot, interface description, DNS servers, and block/unblock host actions
- update Island router parsing/tests/docs so the new capabilities return structured objects instead of raw CLI text and the broader safety model is documented

## Testing
- `npm run test -- packages/home-connector/src/adapters/island-router/index.node.test.ts packages/home-connector/src/mcp/server.node.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-830e232b-7535-4327-a2de-772bf6ff73dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-830e232b-7535-4327-a2de-772bf6ff73dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

