### PR TITLE
Clarify repo_run_commands capability discovery guidance

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -107,9 +107,9 @@ Operational notes:
   projections of that repo-backed package rather than a competing second source
   of truth.
 - `repo_run_commands` parses a constrained git-command string and runs it inside
-  the repo session Durable Object. It does not run shell syntax, and package
-  runtime bundles are still loaded from published artifacts rather than a
-  mounted checkout.
+  the repo session Durable Object. It accepts only parsed git command forms,
+  not arbitrary shell syntax, and package runtime bundles are still loaded from
+  published artifacts rather than a mounted checkout.
 
 Production note:
 

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -191,6 +191,9 @@ Retriever implementations should truncate or paginate before returning.
 Package source is edited and published through the repo session capabilities.
 
 - prefer `repo_run_commands` for package changes
+- `repo_run_commands` accepts a newline-separated parsed git-command string, not
+  arbitrary shell; keep agent-facing guidance aligned with the deployed
+  capability schema
 - open repo sessions by package identity when possible
 - for an existing package, treat the repo snapshot as the durable source of
   truth

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -83,9 +83,12 @@ When you need to edit saved source, prefer the repo-backed workflow in
 [Repo-backed editing sessions](./repo-sessions.md). Open by package identity
 instead of internal source ids whenever possible.
 
-For common edit-and-check workflows, `repo_run_commands` accepts a constrained
-git-command string, returns command outputs, and can run checks plus publish in
-one response. Commands are parsed by Kody; they are not arbitrary shell.
+For common edit-and-check workflows, `repo_run_commands` accepts a
+newline-separated parsed git-command string, returns command outputs, and can
+run checks plus publish in one response. Commands are parsed by Kody; they are
+not arbitrary shell, only the documented git forms are supported, and
+`git clone` remains intentionally unsupported because Kody opens repo sessions
+for you.
 
 ## Agent turns
 

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -149,7 +149,7 @@ Use:
 - `package_save` to create or replace a saved package
 - `package_get` and `package_list` to inspect saved packages
 - `repo_run_commands` to edit, check, and publish repo-backed package source
-  after it exists
+  after it exists using parsed, git-only command forms rather than shell
 
 ## Search and discovery
 

--- a/docs/use/repo-sessions.md
+++ b/docs/use/repo-sessions.md
@@ -22,21 +22,26 @@ Commands are parsed, not shell-executed. Unsupported syntax returns a
 line-specific parse error with examples so agents can correct the command
 string.
 
+Only git commands are accepted. Non-git commands and shell syntax such as
+pipes, command substitution, `&&`, or tools like `npm`, `cat`, and `sed` are
+not supported.
+
 Supported commands:
 
-- `git status`
+- `git status [--short]`
 - `git diff`
 - `git apply <<'PATCH' ... PATCH`
 - `git add <path>`
 - `git rm <path>`
 - `git commit -m "message"`
 - `git log [--depth N]`
-- `git branch [name]`
-- `git checkout <ref>` / `git checkout -b <branch>`
+- `git branch [name]` / `git branch -d <name>`
+- `git checkout <ref>` / `git checkout -b <branch> [--force]`
 - `git fetch [remote] [ref]`
 - `git pull [remote] [ref]`
-- `git push [remote] [ref]`
-- `git remote`, `git remote add <name> <url>`, `git remote remove <name>`
+- `git push [remote] [ref] [--force]`
+- `git remote`, `git remote -v`, `git remote add <name> <url>`,
+  `git remote remove <name>`
 
 `git clone` is intentionally unsupported because repo sessions are opened and
 cloned by Kody.

--- a/packages/worker/src/mcp/capabilities/build-capability-registry.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/build-capability-registry.workers.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import { z } from 'zod'
 import { buildCapabilityRegistry } from './build-capability-registry.ts'
+import { builtinDomains } from './builtin-domains.ts'
 import { defineDomain } from './define-domain.ts'
 import { defineDomainCapability } from './define-domain-capability.ts'
 import { capabilityDomainNames } from './domain-metadata.ts'
@@ -99,4 +100,60 @@ test('defineDomain rejects duplicate capability names within one domain', () => 
 			capabilities: [firstCapability, secondCapability],
 		}),
 	).toThrow(/Duplicate capability .* in domain/)
+})
+
+test('repo_run_commands registry spec and tool descriptor expose parsed git-only guidance', () => {
+	const registry = buildCapabilityRegistry(builtinDomains)
+	const capabilitySpec = registry.capabilitySpecs.repo_run_commands
+	const toolDescriptor = registry.capabilityToolDescriptors.repo_run_commands
+	const commandsSchema = capabilitySpec?.inputSchema
+		&& typeof capabilitySpec.inputSchema === 'object'
+		&& 'properties' in capabilitySpec.inputSchema
+		&& capabilitySpec.inputSchema.properties
+		&& typeof capabilitySpec.inputSchema.properties === 'object'
+		&& 'commands' in capabilitySpec.inputSchema.properties
+		? capabilitySpec.inputSchema.properties.commands
+		: null
+
+	expect(capabilitySpec).toBeDefined()
+	expect(capabilitySpec?.description).toContain(
+		'Commands are newline-separated and parsed, not shell-executed.',
+	)
+	expect(capabilitySpec?.description).toContain(
+		'Only supported git command forms are accepted',
+	)
+	expect(toolDescriptor?.description).toBe(capabilitySpec?.description)
+	expect(commandsSchema).toMatchObject({
+		type: 'string',
+		description: expect.stringContaining(
+			'Only git commands are accepted.',
+		),
+	})
+	expect(commandsSchema).toMatchObject({
+		description: expect.stringContaining(
+			'Non-git commands and shell syntax such as pipes (`|`), command substitution (`$()` or backticks), `&&`, or tools like `npm`, `cat`, and `sed` are not supported.',
+		),
+	})
+	expect(commandsSchema).toMatchObject({
+		description: expect.stringContaining(
+			'`git clone` is intentionally unsupported because Kody opens and clones repo sessions for you.',
+		),
+	})
+	expect(commandsSchema).toMatchObject({
+		description: expect.stringContaining('`git status [--short]`'),
+	})
+	expect(commandsSchema).toMatchObject({
+		description: expect.stringContaining(
+			'`git remote, git remote -v, git remote add <name> <url>, git remote remove <name>`',
+		),
+	})
+	expect(capabilitySpec?.inputTypeDefinition).toContain(
+		'Newline-separated commands parsed by Kody; this field is not shell-executed.',
+	)
+	expect(capabilitySpec?.inputTypeDefinition).toContain(
+		'Only git commands are accepted.',
+	)
+	expect(capabilitySpec?.inputTypeDefinition).toContain(
+		'git checkout <ref> / git checkout -b <branch> [--force]',
+	)
 })

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands-text.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands-text.ts
@@ -1,0 +1,42 @@
+export const repoRunCommandsSupportedForms = [
+	'git status [--short]',
+	'git diff',
+	"git apply <<'PATCH' ... PATCH",
+	'git add <path>',
+	'git rm <path>',
+	'git commit -m "message"',
+	'git log [--depth N]',
+	'git branch [name] / git branch -d <name>',
+	'git checkout <ref> / git checkout -b <branch> [--force]',
+	'git fetch [remote] [ref]',
+	'git pull [remote] [ref]',
+	'git push [remote] [ref] [--force]',
+	'git remote, git remote -v, git remote add <name> <url>, git remote remove <name>',
+] as const
+
+export const repoRunCommandsCapabilityDescription = [
+	'Run a parsed git-only workflow in a repo session.',
+	'Commands are newline-separated and parsed, not shell-executed.',
+	'Only supported git command forms are accepted; unsupported syntax returns line-specific parse errors.',
+].join(' ')
+
+export const repoRunCommandsUnsupportedSyntaxDescription = [
+	'Only git commands are accepted.',
+	'Non-git commands and shell syntax such as pipes (`|`), command substitution (`$()` or backticks), `&&`, or tools like `npm`, `cat`, and `sed` are not supported.',
+	'`git clone` is intentionally unsupported because Kody opens and clones repo sessions for you.',
+].join(' ')
+
+export const repoRunCommandsSupportedFormsDescription = [
+	'Supported command forms exactly:',
+	...repoRunCommandsSupportedForms.map((form) => `- \`${form}\``),
+].join('\n')
+
+export const repoRunCommandsCommandsFieldDescription = [
+	'Newline-separated commands parsed by Kody; this field is not shell-executed.',
+	repoRunCommandsUnsupportedSyntaxDescription,
+	repoRunCommandsSupportedFormsDescription,
+].join('\n')
+
+export const repoRunCommandsExecuteSummary = [
+	'commands are newline-separated, parsed, git-only workflows, not shell execution',
+].join(' ')

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
@@ -4,6 +4,7 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { resolveRepoTargetFromSource } from './repo-resolve-target.ts'
+import { repoRunCommandsCapabilityDescription } from './repo-run-commands-text.ts'
 import {
 	normalizeRepoCommandChecks,
 	normalizeRepoCommandPublish,
@@ -41,8 +42,7 @@ export const repoRunCommandsCapability = defineDomainCapability(
 	capabilityDomainNames.repo,
 	{
 		name: 'repo_run_commands',
-		description:
-			'Run a constrained git-command workflow in a repo session. Commands are parsed, not shell-executed; unsupported syntax returns line-specific parse errors.',
+		description: repoRunCommandsCapabilityDescription,
 		keywords: [
 			'repo',
 			'git',

--- a/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { repoRunCommandsCommandsFieldDescription } from './repo-run-commands-text.ts'
 
 export const repoSearchModeSchema = z.enum(['literal', 'regex'])
 export const repoSearchOutputModeSchema = z.enum(['content', 'files'])
@@ -274,9 +275,7 @@ export const repoRunCommandsInputSchema = z
 		commands: z
 			.string()
 			.min(1)
-			.describe(
-				'Newline-separated constrained git commands. Supported commands include git status, git diff, git apply heredoc, git add, git rm, git commit -m, git log, git branch, git checkout, git fetch, git pull, git push, and git remote.',
-			),
+			.describe(repoRunCommandsCommandsFieldDescription),
 		dry_run: z
 			.boolean()
 			.optional()

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -24,6 +24,7 @@ import {
 	formatSurfacedMemoriesMarkdown,
 	surfaceToolMemories,
 } from './memory-tool-context.ts'
+import { repoRunCommandsExecuteSummary } from '#mcp/capabilities/repo/repo-run-commands-text.ts'
 import { finishToolTiming, startToolTiming } from './tool-timing.ts'
 import { prependToolMetadataContent } from './tool-response-content.ts'
 
@@ -38,8 +39,7 @@ call \`search\` with \`entity: "{name}:capability"\` or use
 
 Saved package surface:
 - \`package_save\`, \`package_get\`, \`package_list\`, \`package_delete\`
-- repo-backed package editing with \`repo_run_commands\`; commands are parsed,
-  constrained git workflows, not shell execution
+- repo-backed package editing with \`repo_run_commands\`; ${repoRunCommandsExecuteSummary}
 - cross-package imports with specifiers such as
    \`kody:@scope/my-package/export-name\`
 

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from 'vitest'
+import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
+import { builtinDomains } from '#mcp/capabilities/builtin-domains.ts'
 import {
 	formatEntityDetailMarkdown,
 	formatSearchMarkdown,
@@ -269,6 +271,65 @@ test('capability entity detail keeps type definitions stable and adds schemas on
 	expect(detailWithSchemas.structured).toMatchObject({
 		inputTypeDefinition: detail.structured.inputTypeDefinition,
 		outputTypeDefinition: detail.structured.outputTypeDefinition,
+	})
+})
+
+test('repo_run_commands capability detail surfaces parsed git-only guidance', () => {
+	const registry = buildCapabilityRegistry(builtinDomains)
+	const repoRunCommands = registry.capabilitySpecs.repo_run_commands
+	if (!repoRunCommands) {
+		throw new Error('Expected repo_run_commands capability to exist')
+	}
+
+	const detail = formatEntityDetailMarkdown(
+		{
+			type: 'capability',
+			id: 'repo_run_commands',
+			title: 'repo_run_commands',
+			description: repoRunCommands.description,
+			spec: repoRunCommands,
+		},
+		{ includeSchemas: true },
+	)
+
+	expect(detail.structured).toMatchObject({
+		type: 'capability',
+		inputTypeDefinition: expect.stringContaining(
+			'Commands are newline-separated and parsed, not shell-executed.',
+		),
+	})
+	expect(detail.structured).toMatchObject({
+		inputTypeDefinition: expect.stringContaining(
+			'Only git commands are accepted.',
+		),
+	})
+	expect(detail.structured).toMatchObject({
+		inputTypeDefinition: expect.stringContaining(
+			'git checkout <ref> / git checkout -b <branch> [--force]',
+		),
+	})
+	expect(detail.structured).toMatchObject({
+		inputTypeDefinition: expect.stringContaining(
+			'git remote, git remote -v, git remote add <name> <url>, git remote remove <name>',
+		),
+	})
+	expect(detail.structured).toMatchObject({
+		inputSchema: expect.objectContaining({
+			properties: expect.objectContaining({
+				commands: expect.objectContaining({
+					description: expect.stringContaining('not shell-executed'),
+				}),
+			}),
+		}),
+	})
+	expect(detail.structured).toMatchObject({
+		inputSchema: expect.objectContaining({
+			properties: expect.objectContaining({
+				commands: expect.objectContaining({
+					description: expect.stringContaining('`git clone` is intentionally unsupported'),
+				}),
+			}),
+		}),
 	})
 })
 

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -294,8 +294,14 @@ test('repo_run_commands capability detail surfaces parsed git-only guidance', ()
 
 	expect(detail.structured).toMatchObject({
 		type: 'capability',
-		inputTypeDefinition: expect.stringContaining(
+		description: expect.stringContaining(
 			'Commands are newline-separated and parsed, not shell-executed.',
+		),
+	})
+	expect(detail.structured).toMatchObject({
+		type: 'capability',
+		inputTypeDefinition: expect.stringContaining(
+			'Newline-separated commands parsed by Kody; this field is not shell-executed.',
 		),
 	})
 	expect(detail.structured).toMatchObject({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- centralize the agent-facing `repo_run_commands` capability and commands-field guidance in shared constants
- update the deployed capability description, schema text, execute guidance, and matching docs to spell out parsed git-only command support and unsupported shell forms
- add focused tests covering the generated capability registry/detail surfaces that agents inspect during discovery

## Testing
- `npx vitest run --project node-unit --project workers-unit packages/worker/src/mcp/capabilities/build-capability-registry.workers.test.ts packages/worker/src/mcp/tools/search-format.node.test.ts`
- `npm run typecheck`
- `npx oxlint packages/worker/src/mcp/capabilities/build-capability-registry.workers.test.ts packages/worker/src/mcp/capabilities/repo/repo-run-commands-text.ts packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts packages/worker/src/mcp/capabilities/repo/repo-shared.ts packages/worker/src/mcp/tools/execute.ts packages/worker/src/mcp/tools/search-format.node.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f4ba4cb-9a6d-4cec-9298-946fd028487e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f4ba4cb-9a6d-4cec-9298-946fd028487e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comprehensive guidance clarifying that `repo_run_commands` accepts only parsed git commands and explicitly rejects shell syntax including pipes, command substitution, and non-git tools
  * Expanded details on supported git command forms and variants
  * Clarified that `git clone` remains unsupported

* **Tests**
  * Added test coverage verifying capability specifications enforce git-only command restrictions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->