### PR TITLE
Align Island router read commands to the live Island CLI

### DIFF
--- a/docs/contributing/architecture/home-connector.md
+++ b/docs/contributing/architecture/home-connector.md
@@ -137,9 +137,12 @@ The adapter does expose:
 - ARP / neighbor-cache inspection with `show ip neighbors`
 - DHCP reservation inspection with `show ip dhcp-reservations`
 - recent-event lookups with `show log`
-- structured WAN, failover, routing, NAT, VLAN, DNS, user, firewall/security,
+- structured WAN/failover, routing, NAT, VLAN, DNS, user, firewall/security,
   QoS, traffic, session, VPN, DHCP-server, NTP, syslog, SNMP, and
-  bandwidth-usage reads from a typed SSH CLI allowlist
+  system/bandwidth reads from a typed SSH CLI allowlist that now prefers the
+  Island-documented `show running-config`, `show stats`, `show hardware`,
+  `show vpns`, `show ip sockets`, and `show ntp status|associations` families
+  over unsupported guessed top-level subcommands
 - a structured `router_diagnose_host` workflow that combines ping, ARP,
   reservation, interface, and log data for one host
 - a broader but still typed and explicitly allowlisted high-risk write surface

--- a/docs/contributing/architecture/home-connector.md
+++ b/docs/contributing/architecture/home-connector.md
@@ -140,9 +140,10 @@ The adapter does expose:
 - structured WAN/failover, routing, NAT, VLAN, DNS, user, firewall/security,
   QoS, traffic, session, VPN, DHCP-server, NTP, syslog, SNMP, and
   system/bandwidth reads from a typed SSH CLI allowlist that now prefers the
-  Island-documented `show running-config`, `show stats`, `show hardware`,
-  `show vpns`, `show ip sockets`, and `show ntp status|associations` families
-  over unsupported guessed top-level subcommands
+  Island-documented `show system`/`show stats`, `show hardware`,
+  `show running-config`, `show vpns`, `show ip sockets`, and
+  `show ntp status|associations` families over unsupported guessed top-level
+  subcommands
 - a structured `router_diagnose_host` workflow that combines ping, ARP,
   reservation, interface, and log data for one host
 - a broader but still typed and explicitly allowlisted high-risk write surface

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -96,7 +96,13 @@ Quick notes for getting a local kody environment running.
     typed MCP tools for router status, host diagnosis, WAN/failover state,
     routing/NAT/session inspection, VLAN/DNS/DHCP policy inspection, VPN/NTP/
     syslog/SNMP/system-health reads, and the other typed read-only router
-    diagnostics exposed by the home connector.
+    diagnostics exposed by the home connector. The current read surface is
+    intentionally aligned to CLI families verified against live Island Pro
+    firmware: config-style reads primarily source from `show running-config`,
+    connection/state reads use commands such as `show ip neighbors`,
+    `show ip routes`, `show ip sockets`, and `show vpns`, while NTP uses
+    `show ntp status` plus `show ntp associations`, and system-health summaries
+    use `show stats` plus `show hardware`.
   - Prefer mounting the private key read-only into the container or host
     runtime, for example
     `-v /path/to/id_ed25519:/run/secrets/island-router-key:ro` plus

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -41,3 +41,19 @@ VPN, DHCP server, NTP, syslog, SNMP, system info, and bandwidth usage) plus a
 set of high-risk, typed, allowlisted write tools. Those write tools require SSH
 host verification, explicit risk acknowledgement, and exact confirmation
 phrases because mistakes can have severe consequences.
+
+Several of the typed read tools are intentionally derived from the documented
+Island CLI families instead of guessed one-off `show` commands:
+
+- WAN, failover, NAT, VLAN, DNS, DHCP server, syslog, and SNMP reads are
+  derived from `show running-config`.
+- VPN reads are derived from `show vpns`.
+- Active-session reads are derived from `show ip sockets`.
+- NTP reads are derived from `show ntp status` and
+  `show ntp associations`.
+- System-health and bandwidth-style summaries are derived from `show stats`
+  plus `show hardware` when available.
+
+If a router command returns Island help, usage, or unknown-command output, the
+connector now treats that as unsupported or inconclusive output instead of
+trying to parse it as structured data.

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -1101,7 +1101,7 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 		temperatureCelsius: 54,
 		attributes: expect.arrayContaining([
 			expect.objectContaining({
-				key: 'Platform',
+				key: 'Platform Type',
 				value: 'Island Pro',
 			}),
 		]),

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -938,7 +938,7 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 
 	const failover = await islandRouter.getFailoverStatus()
 	expect(failover).toMatchObject({
-		activeInterfaceName: 'en1',
+		activeInterfaceName: null,
 		activeIspName: null,
 		policy: 'random',
 	})
@@ -1099,6 +1099,12 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 		cpuUsagePercent: 17,
 		memoryUsagePercent: 42,
 		temperatureCelsius: 54,
+		attributes: expect.arrayContaining([
+			expect.objectContaining({
+				key: 'Platform',
+				value: 'Island Pro',
+			}),
+		]),
 	})
 
 	const bandwidthUsage = await islandRouter.getBandwidthUsage()

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -87,12 +87,92 @@ function createFakeRunner() {
 			case 'show-system':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'show system'],
+					commandLines: ['terminal length 0', 'show stats'],
 					stdout: [
 						'Uptime: 5 days 2 hours',
 						'CPU Usage: 17%',
 						'Memory Usage: 42%',
 						'Temperature: 54 C',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-hardware':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show hardware'],
+					stdout: [
+						'Platform Type: Island Pro',
+						'CPU Type: ARM64',
+						'Memory Size: 8 GB',
+						'Power Supply Status: ok',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-stats':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show stats'],
+					stdout: [
+						'Uptime: 5 days 2 hours',
+						'CPU Usage: 17%',
+						'Memory Usage: 42%',
+						'Temperature: 54 C',
+						'Interface  RX Bytes  TX Bytes  RX Packets  TX Packets  RX Errors  TX Errors  Utilization',
+						'---------  --------  --------  ----------  ----------  ---------  ---------  -----------',
+						'en0        1200000   2400000   1000        1500        0          1          37%',
+						'en1        100       200       1           2           0          0          1%',
+						'Interface  RX Rate   TX Rate   Total Rate',
+						'---------  --------  --------  ----------',
+						'en0        12 Mbps   2 Mbps    14 Mbps',
+						'en1        150 Mbps  20 Mbps   170 Mbps',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-running-config':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show running-config'],
+					stdout: [
+						'ip dns mode recursive',
+						'ip dns local-only off',
+						'ip dns server 1.1.1.1',
+						'ip dns server 8.8.8.8',
+						'ip load-sharing random',
+						'ip dhcp-reserve 192.168.0.52 00:11:22:33:44:55',
+						'syslog 192.168.0.60',
+						'syslog port 514',
+						'syslog protocol udp',
+						'syslog facility local0',
+						'snmp community public ro 192.168.0.0/24',
+						'snmp trap-target 192.168.0.61 version 2c community public',
+						'vpn peer name office-ipsec',
+						'interface en0',
+						'ip address 192.168.0.1/24',
+						'ip dhcp-server on',
+						'ip dhcp-scope 50-199',
+						'ip dhcp-lease 1800',
+						'interface en1',
+						'ip autoconfig wan',
+						'ip priority 1',
+						'ip nat4 on',
+						'interface en2',
+						'ip autoconfig wan',
+						'ip priority 2',
+						'interface vlan10',
+						'parent en0',
+						'ip address 192.168.10.1/24',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -119,8 +199,12 @@ function createFakeRunner() {
 			case 'show-interface-statistics':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'show interface statistics'],
+					commandLines: ['terminal length 0', 'show stats'],
 					stdout: [
+						'Uptime: 5 days 2 hours',
+						'CPU Usage: 17%',
+						'Memory Usage: 42%',
+						'Temperature: 54 C',
 						'Interface  RX Bytes  TX Bytes  RX Packets  TX Packets  RX Errors  TX Errors  Utilization',
 						'---------  --------  --------  ----------  ----------  ---------  ---------  -----------',
 						'en0        1200000   2400000   1000        1500        0          1          37%',
@@ -135,12 +219,16 @@ function createFakeRunner() {
 			case 'show-bandwidth-usage':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'show bandwidth-usage'],
+					commandLines: ['terminal length 0', 'show stats'],
 					stdout: [
-						'Subject            Interface  RX Rate   TX Rate   Total Rate',
-						'-----------------  ---------  --------  --------  ----------',
-						'192.168.0.52       en0        12 Mbps   2 Mbps    14 Mbps',
-						'WAN aggregate      en1        150 Mbps  20 Mbps   170 Mbps',
+						'Uptime: 5 days 2 hours',
+						'CPU Usage: 17%',
+						'Memory Usage: 42%',
+						'Temperature: 54 C',
+						'Interface  RX Rate   TX Rate   Total Rate',
+						'---------  --------  --------  ----------',
+						'en0        12 Mbps   2 Mbps    14 Mbps',
+						'en1        150 Mbps  20 Mbps   170 Mbps',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -151,12 +239,16 @@ function createFakeRunner() {
 			case 'show-wan':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'show wan'],
+					commandLines: ['terminal length 0', 'show running-config'],
 					stdout: [
-						'ISP          Interface  IP Address     Gateway       Type   Role    Priority  Status',
-						'-----------  ---------  -------------  ------------  -----  ------  --------  ------',
-						'Fiber        en1        203.0.113.10   203.0.113.1   DHCP   active  1         up',
-						'LTE Backup   en2        198.51.100.22  198.51.100.1  DHCP   standby   2         up',
+						'ip load-sharing random',
+						'interface en1',
+						'ip autoconfig wan',
+						'ip priority 1',
+						'ip nat4 on',
+						'interface en2',
+						'ip autoconfig wan',
+						'ip priority 2',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -167,15 +259,15 @@ function createFakeRunner() {
 			case 'show-wan-failover':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'show wan failover'],
+					commandLines: ['terminal length 0', 'show running-config'],
 					stdout: [
-						'Active Interface: en1',
-						'Active ISP: Fiber',
-						'Policy: priority',
-						'Interface  ISP         Health  Role     Priority  Monitor',
-						'---------  ----------  ------  -------  --------  ----------------',
-						'en1        Fiber       up      active   1         8.8.8.8',
-						'en2        LTE Backup up      standby  2         1.1.1.1',
+						'ip load-sharing random',
+						'interface en1',
+						'ip autoconfig wan',
+						'ip priority 1',
+						'interface en2',
+						'ip autoconfig wan',
+						'ip priority 2',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -186,14 +278,15 @@ function createFakeRunner() {
 			case 'show-multi-wan':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'show multi-wan'],
+					commandLines: ['terminal length 0', 'show running-config'],
 					stdout: [
-						'Active Interface: en1',
-						'Policy: priority',
-						'Interface  ISP         Status   Priority',
-						'---------  ----------  -------  --------',
-						'en1        Fiber       active   1',
-						'en2        LTE Backup standby  2',
+						'ip load-sharing random',
+						'interface en1',
+						'ip autoconfig wan',
+						'ip priority 1',
+						'interface en2',
+						'ip autoconfig wan',
+						'ip priority 2',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -237,14 +330,11 @@ function createFakeRunner() {
 			case 'show-ip-nat':
 				return {
 					id: request.id,
-					commandLines: [
-						'terminal length 0',
-						request.id === 'show-nat' ? 'show nat' : 'show ip nat',
-					],
+					commandLines: ['terminal length 0', 'show running-config'],
 					stdout: [
-						'Rule  Type         Protocol  Interface  External         Internal         Enabled  Description',
-						'----  -----------  --------  ---------  ---------------  ---------------  -------  -----------',
-						'1     port-forward  tcp       en1        203.0.113.10:80  192.168.0.52:80  yes      NAS web',
+						'interface en1',
+						'ip autoconfig wan',
+						'ip nat4 on',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -255,11 +345,11 @@ function createFakeRunner() {
 			case 'show-sessions':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'show sessions'],
+					commandLines: ['terminal length 0', 'show ip sockets'],
 					stdout: [
-						'Protocol  Source                Destination           Translated            State        Interface',
-						'--------  --------------------  --------------------  --------------------  -----------  ---------',
-						'tcp       192.168.0.52:51514    93.184.216.34:443     203.0.113.10:51514   established  en1',
+						'Protocol  Local Address         Foreign Address       State',
+						'--------  --------------------  --------------------  -----------',
+						'tcp       192.168.0.52:51514    93.184.216.34:443     established',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -270,11 +360,11 @@ function createFakeRunner() {
 			case 'show-vlan':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'show vlan'],
+					commandLines: ['terminal length 0', 'show running-config'],
 					stdout: [
-						'VLAN  Name    Interface  Members     Status  Address',
-						'----  ------  ---------  ----------  ------  -------------',
-						'10    Main    vlan10     en0,en3     up      192.168.0.1/24',
+						'interface vlan10',
+						'parent en0',
+						'ip address 192.168.10.1/24',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -286,18 +376,12 @@ function createFakeRunner() {
 			case 'show-ip-dns':
 				return {
 					id: request.id,
-					commandLines: [
-						'terminal length 0',
-						request.id === 'show-dns' ? 'show dns' : 'show ip dns',
-					],
+					commandLines: ['terminal length 0', 'show running-config'],
 					stdout: [
-						'Mode: forwarding',
-						'Search Domains: home.arpa, lan',
-						'Server  Role       Source',
-						'------  ---------  --------',
-						'1.1.1.1  upstream   static',
-						'8.8.8.8  upstream   dhcp',
-						'host=nas.home.arpa value=192.168.0.52 enabled=yes',
+						'ip dns mode recursive',
+						'ip dns local-only off',
+						'ip dns server 1.1.1.1',
+						'ip dns server 8.8.8.8',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -330,18 +414,9 @@ function createFakeRunner() {
 			case 'show-firewall':
 				return {
 					id: request.id,
-					commandLines: [
-						'terminal length 0',
-						request.id === 'show-security-policy'
-							? 'show security-policy'
-							: request.id === 'show-protection'
-								? 'show protection'
-								: 'show firewall',
-					],
+					commandLines: ['terminal length 0', 'show running-config'],
 					stdout: [
-						'Rule  Name         Action  Source         Destination    Service  Enabled',
-						'----  -----------  ------  -------------  -------------  -------  -------',
-						'10    block-guest  deny    192.168.0.99   any            any      yes',
+						'firewall block-host 192.168.0.99',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -353,14 +428,9 @@ function createFakeRunner() {
 			case 'show-traffic-policy':
 				return {
 					id: request.id,
-					commandLines: [
-						'terminal length 0',
-						request.id === 'show-qos' ? 'show qos' : 'show traffic-policy',
-					],
+					commandLines: ['terminal length 0', 'show running-config'],
 					stdout: [
-						'Policy   Interface  Class      Priority  Bandwidth  Enabled',
-						'-------  ---------  ---------  --------  ---------  -------',
-						'wan-qos  en1        voice      high      10 Mbps    yes',
+						'qos wan-qos interface en1 bandwidth 10 Mbps priority high',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -371,20 +441,14 @@ function createFakeRunner() {
 			case 'show-vpn':
 			case 'show-ipsec':
 			case 'show-gre':
+			case 'show-vpns':
 				return {
 					id: request.id,
-					commandLines: [
-						'terminal length 0',
-						request.id === 'show-vpn'
-							? 'show vpn'
-							: request.id === 'show-ipsec'
-								? 'show ipsec'
-								: 'show gre',
-					],
+					commandLines: ['terminal length 0', 'show vpns'],
 					stdout: [
-						'Tunnel      Type   Local          Remote         Status  Interface',
-						'----------  -----  -------------  -------------  ------  ---------',
-						'office-ipsec  ipsec  203.0.113.10   198.51.100.20  up      tun0',
+						'Name          Type   Local Endpoint  Remote Endpoint  Status  Interface',
+						'------------  -----  --------------  ---------------  ------  ---------',
+						'office-ipsec  vpn    203.0.113.10    198.51.100.20   up      wg7',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -410,13 +474,14 @@ function createFakeRunner() {
 			case 'show-dhcp-server':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'show dhcp-server'],
+					commandLines: ['terminal length 0', 'show running-config'],
 					stdout: [
-						'Pool  Interface  Network         Range Start    Range End      Gateway       DNS',
-						'----  ---------  --------------  -------------  -------------  ------------  --------',
-						'main  en0        192.168.0.0/24  192.168.0.50   192.168.0.199  192.168.0.1   1.1.1.1,8.8.8.8',
-						'Option 6 value=1.1.1.1,8.8.8.8',
-						'192.168.0.52  00:11:22:33:44:55  nas-box    en0',
+						'ip dhcp-reserve 192.168.0.52 00:11:22:33:44:55',
+						'interface en0',
+						'ip address 192.168.0.1/24',
+						'ip dhcp-server on',
+						'ip dhcp-scope 50-199',
+						'ip dhcp-lease 1800',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -425,14 +490,20 @@ function createFakeRunner() {
 					durationMs: 10,
 				}
 			case 'show-ntp':
+			case 'show-ntp-status':
+			case 'show-ntp-associations':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'show ntp'],
+					commandLines: [
+						'terminal length 0',
+						request.id === 'show-ntp-associations'
+							? 'show ntp associations'
+							: 'show ntp status',
+					],
 					stdout: [
-						'Timezone: America/Denver',
-						'Server         Status  Source',
-						'-------------  ------  ------',
-						'162.159.200.1  synced  static',
+						...(request.id === 'show-ntp-status'
+							? ['Clock State: synchronized', 'Server: 162.159.200.1']
+							: ['Server         Status  Source', '-------------  ------  ------', '162.159.200.1  synced  configured']),
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -443,11 +514,12 @@ function createFakeRunner() {
 			case 'show-syslog':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'show syslog'],
+					commandLines: ['terminal length 0', 'show running-config'],
 					stdout: [
-						'Host            Port  Protocol  Facility  Enabled',
-						'--------------  ----  --------  --------  -------',
-						'192.168.0.60    514   udp       local0    yes',
+						'syslog 192.168.0.60',
+						'syslog port 514',
+						'syslog protocol udp',
+						'syslog facility local0',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -458,11 +530,10 @@ function createFakeRunner() {
 			case 'show-snmp':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'show snmp'],
+					commandLines: ['terminal length 0', 'show running-config'],
 					stdout: [
-						'Enabled: yes',
-						'community=public access=ro source=192.168.0.0/24',
-						'trap target=192.168.0.61 version=2c community=public',
+						'snmp community public ro 192.168.0.0/24',
+						'snmp trap-target 192.168.0.61 version 2c community public',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,
@@ -859,9 +930,8 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 		expect.arrayContaining([
 			expect.objectContaining({
 				interfaceName: 'en1',
-				ispName: 'Fiber',
 				connectionType: 'dhcp',
-				role: 'active',
+				failoverPriority: 1,
 			}),
 		]),
 	)
@@ -869,8 +939,8 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 	const failover = await islandRouter.getFailoverStatus()
 	expect(failover).toMatchObject({
 		activeInterfaceName: 'en1',
-		activeIspName: 'Fiber',
-		policy: 'priority',
+		activeIspName: null,
+		policy: 'random',
 	})
 
 	const routingTable = await islandRouter.getRoutingTable()
@@ -889,8 +959,9 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 		expect.arrayContaining([
 			expect.objectContaining({
 				ruleId: '1',
-				externalAddress: '203.0.113.10',
-				internalAddress: '192.168.0.52',
+				interfaceName: 'en1',
+				type: 'nat4',
+				enabled: true,
 			}),
 		]),
 	)
@@ -907,8 +978,8 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 
 	const dnsConfig = await islandRouter.getDnsConfig()
 	expect(dnsConfig).toMatchObject({
-		mode: 'forwarding',
-		searchDomains: ['home.arpa', 'lan'],
+		mode: 'recursive',
+		searchDomains: [],
 		servers: expect.arrayContaining([
 			expect.objectContaining({
 					address: '1.1.1.1',
@@ -929,7 +1000,7 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 	expect(securityPolicy.rules).toEqual(
 		expect.arrayContaining([
 			expect.objectContaining({
-				action: 'deny',
+				action: 'block',
 			}),
 		]),
 	)
@@ -939,7 +1010,8 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 		expect.arrayContaining([
 			expect.objectContaining({
 				policyName: 'wan-qos',
-				className: 'voice',
+				interfaceName: 'en1',
+				bandwidth: '10 Mbps',
 			}),
 		]),
 	)
@@ -971,7 +1043,8 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 		expect.arrayContaining([
 			expect.objectContaining({
 				tunnelName: 'office-ipsec',
-				type: 'ipsec',
+				type: 'vpn',
+				status: 'up',
 			}),
 		]),
 	)
@@ -980,7 +1053,8 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 	expect(dhcpServerConfig).toMatchObject({
 		pools: expect.arrayContaining([
 			expect.objectContaining({
-				poolName: 'main',
+				poolName: 'en0',
+				interfaceName: 'en0',
 			}),
 		]),
 		reservations: expect.arrayContaining([
@@ -1031,7 +1105,7 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 	expect(bandwidthUsage.entries).toEqual(
 		expect.arrayContaining([
 			expect.objectContaining({
-				subject: '192.168.0.52',
+				subject: 'en0',
 				rxRate: '12 Mbps',
 			}),
 		]),

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -501,7 +501,7 @@ function createFakeRunner() {
 							: 'show ntp status',
 					],
 					stdout: [
-						...(request.id === 'show-ntp-status'
+						...(request.id === 'show-ntp' || request.id === 'show-ntp-status'
 							? ['Clock State: synchronized', 'Server: 162.159.200.1']
 							: ['Server         Status  Source', '-------------  ------  ------', '162.159.200.1  synced  configured']),
 					].join('\n'),

--- a/packages/home-connector/src/adapters/island-router/index.ts
+++ b/packages/home-connector/src/adapters/island-router/index.ts
@@ -807,10 +807,6 @@ export function createIslandRouterAdapter(input: {
 						id: 'show-wan-failover',
 						timeoutMs: request.timeoutMs,
 					},
-					{
-						id: 'show-multi-wan',
-						timeoutMs: request.timeoutMs,
-					},
 				],
 				message: 'Island router failover status lookup',
 				parser: parseIslandRouterFailoverStatus,
@@ -833,10 +829,6 @@ export function createIslandRouterAdapter(input: {
 						id: 'show-nat',
 						timeoutMs: request.timeoutMs,
 					},
-					{
-						id: 'show-ip-nat',
-						timeoutMs: request.timeoutMs,
-					},
 				],
 				message: 'Island router NAT rule lookup',
 				parser: parseIslandRouterNatRules,
@@ -857,10 +849,6 @@ export function createIslandRouterAdapter(input: {
 				requests: [
 					{
 						id: 'show-dns',
-						timeoutMs: request.timeoutMs,
-					},
-					{
-						id: 'show-ip-dns',
 						timeoutMs: request.timeoutMs,
 					},
 				],
@@ -891,14 +879,6 @@ export function createIslandRouterAdapter(input: {
 						id: 'show-security-policy',
 						timeoutMs: request.timeoutMs,
 					},
-					{
-						id: 'show-protection',
-						timeoutMs: request.timeoutMs,
-					},
-					{
-						id: 'show-firewall',
-						timeoutMs: request.timeoutMs,
-					},
 				],
 				message: 'Island router security policy lookup',
 				parser: parseIslandRouterSecurityPolicy,
@@ -909,10 +889,6 @@ export function createIslandRouterAdapter(input: {
 				requests: [
 					{
 						id: 'show-qos',
-						timeoutMs: request.timeoutMs,
-					},
-					{
-						id: 'show-traffic-policy',
 						timeoutMs: request.timeoutMs,
 					},
 				],
@@ -947,14 +923,6 @@ export function createIslandRouterAdapter(input: {
 						id: 'show-vpn',
 						timeoutMs: request.timeoutMs,
 					},
-					{
-						id: 'show-ipsec',
-						timeoutMs: request.timeoutMs,
-					},
-					{
-						id: 'show-gre',
-						timeoutMs: request.timeoutMs,
-					},
 				],
 				message: 'Island router VPN configuration lookup',
 				parser: parseIslandRouterVpnConfig,
@@ -977,14 +945,20 @@ export function createIslandRouterAdapter(input: {
 			})
 		},
 		async getNtpConfig(request: ReadRequest = {}) {
-			return await executeReadCommand(
-				{
-					id: 'show-ntp',
-					timeoutMs: request.timeoutMs,
-				},
-				'Island router NTP configuration lookup',
-				parseIslandRouterNtpConfig,
-			)
+			return await executeCompoundReadCommand({
+				requests: [
+					{
+						id: 'show-ntp-status',
+						timeoutMs: request.timeoutMs,
+					},
+					{
+						id: 'show-ntp-associations',
+						timeoutMs: request.timeoutMs,
+					},
+				],
+				message: 'Island router NTP configuration lookup',
+				parser: parseIslandRouterNtpConfig,
+			})
 		},
 		async getSyslogConfig(request: ReadRequest = {}) {
 			return await executeReadCommand(
@@ -1007,14 +981,20 @@ export function createIslandRouterAdapter(input: {
 			)
 		},
 		async getSystemInfo(request: ReadRequest = {}) {
-			return await executeReadCommand(
-				{
-					id: 'show-system',
-					timeoutMs: request.timeoutMs,
-				},
-				'Island router system info lookup',
-				parseIslandRouterSystemInfo,
-			)
+			return await executeCompoundReadCommand({
+				requests: [
+					{
+						id: 'show-system',
+						timeoutMs: request.timeoutMs,
+					},
+					{
+						id: 'show-hardware',
+						timeoutMs: request.timeoutMs,
+					},
+				],
+				message: 'Island router system info lookup',
+				parser: parseIslandRouterSystemInfo,
+			})
 		},
 		async getBandwidthUsage(request: ReadRequest = {}) {
 			return await executeReadCommand(

--- a/packages/home-connector/src/adapters/island-router/parsing.ts
+++ b/packages/home-connector/src/adapters/island-router/parsing.ts
@@ -76,7 +76,7 @@ const pingSummaryPattern =
 const islandRouterVersionBannerPattern =
 	/^(?<model>.+?)\s+\((?<hardwareModel>[^)]+)\)\s+serial number\s+(?<serialNumber>\S+)\s+Version\s+(?<firmwareVersion>\S+)$/i
 const islandRouterCliFailurePattern =
-	/\b(?:invalid command|unknown command|unrecognized command|syntax error|permission denied|host key verification failed|connection refused|no route to host|network is unreachable|could not resolve hostname|command not found|not recognized as an internal or external command)\b/i
+	/\b(?:invalid command|unknown command|unrecognized command|syntax error|permission denied|host key verification failed|connection refused|no route to host|network is unreachable|could not resolve hostname|command not found|not recognized as an internal or external command|ambiguous command|incomplete command|requires additional parameters?)\b|(?:"[^"]+"|\S+)\s+is unknown\.\s+Try "\?"/i
 const islandRouterPromptSuffixPattern = '[>#\\]]'
 const islandRouterPromptOnlyPattern = /^(?:[a-z0-9_.:@-]+[>#]|\[[^\]\r\n]+\])$/i
 const ipv6Pattern = /\b(?:[0-9a-fA-F]{0,4}:){2,}[0-9a-fA-F]{0,4}\b/
@@ -90,6 +90,12 @@ const uptimePattern =
 	/\b\d+\s+(?:day|days|hour|hours|minute|minutes|second|seconds)\b/i
 const enabledPattern = /\b(?:enabled|on|up|true|yes|allow|active)\b/i
 const disabledPattern = /\b(?:disabled|off|down|false|no|deny|inactive)\b/i
+const islandRouterHelpHeadingPattern =
+	/^(?:syntax|syntax description|defaults|usage guidelines|examples|related commands)$/i
+const islandRouterHelpSyntaxLinePattern =
+	/^(?:show|help|interface|ip|syslog|snmp|vpn|ntp|qos|traffic-policy|firewall|protection|reload|write|clear|ping)\b.*(?:<[^>]+>|\[[^\]]+\]|\|)/i
+const islandRouterHelpHintPattern =
+	/(?:type "\?"|context-sensitive help|display .* information\.?$)/i
 
 function normalizeHeaderKey(value: string) {
 	return value
@@ -129,6 +135,27 @@ function splitSanitizedStdoutLines(stdout: string) {
 		.map((line) => line.replace(/\r/g, ''))
 }
 
+function isIslandRouterHelpOrUsageOutput(lines: Array<string>) {
+	if (lines.length === 0) return false
+	if (
+		lines.some((line) =>
+			islandRouterHelpHeadingPattern.test(normalizeWhitespace(line)),
+		)
+	) {
+		return true
+	}
+	const syntaxLikeCount = lines.filter((line) =>
+		islandRouterHelpSyntaxLinePattern.test(normalizeWhitespace(line)),
+	).length
+	const hintLikeCount = lines.filter((line) =>
+		islandRouterHelpHintPattern.test(line),
+	).length
+	return (
+		syntaxLikeCount > 0 &&
+		syntaxLikeCount + hintLikeCount >= Math.max(1, Math.ceil(lines.length / 2))
+	)
+}
+
 export function sanitizeIslandRouterOutput(
 	stdout: string,
 	commandLines: Array<string>,
@@ -143,7 +170,7 @@ export function sanitizeIslandRouterOutput(
 	const relevantOutput =
 		firstCommandEchoIndex >= 0 ? lines.slice(firstCommandEchoIndex) : lines
 
-	return relevantOutput.filter((line) => {
+	const sanitized = relevantOutput.filter((line) => {
 		const trimmed = normalizeWhitespace(line)
 		if (!trimmed) return false
 		if (trimmed.toLowerCase() === 'goodbye') return false
@@ -156,6 +183,7 @@ export function sanitizeIslandRouterOutput(
 		}
 		return true
 	})
+	return isIslandRouterHelpOrUsageOutput(sanitized) ? [] : sanitized
 }
 
 export function isSuccessfulIslandRouterCliSession(input: {
@@ -805,11 +833,522 @@ function selectRowsOrFallback(lines: Array<string>) {
 	}))
 }
 
+function commandLinesContain(
+	commandLines: Array<string>,
+	expectedCommand: string,
+) {
+	const expected = normalizeWhitespace(expectedCommand)
+	return commandLines.some(
+		(command) => normalizeWhitespace(command) === expected,
+	)
+}
+
+type RunningConfigInterfaceContext = {
+	interfaceName: string
+	lines: Array<string>
+}
+
+function parseRunningConfigContexts(lines: Array<string>) {
+	const globals: Array<string> = []
+	const interfaces: Array<RunningConfigInterfaceContext> = []
+	let currentInterface: RunningConfigInterfaceContext | null = null
+
+	for (const line of lines) {
+		const normalized = normalizeWhitespace(line)
+		const interfaceMatch = /^interface\s+(?<name>\S+)$/i.exec(normalized)
+		if (interfaceMatch?.groups?.['name']) {
+			currentInterface = {
+				interfaceName: interfaceMatch.groups['name'],
+				lines: [],
+			}
+			interfaces.push(currentInterface)
+			continue
+		}
+		if (/^(?:end|exit)$/i.test(normalized)) {
+			currentInterface = null
+			continue
+		}
+		if (currentInterface) {
+			currentInterface.lines.push(normalized)
+		} else {
+			globals.push(normalized)
+		}
+	}
+
+	return {
+		globals,
+		interfaces,
+	}
+}
+
+function getLinesBeforeFirstTable(lines: Array<string>) {
+	for (let index = 0; index < lines.length - 1; index += 1) {
+		const columns = splitTableColumns(lines[index] ?? '')
+		const next = lines[index + 1] ?? ''
+		if (
+			columns.length >= 2 &&
+			/^-{3,}(?:\s+-{3,})*$/.test(next.trim())
+		) {
+			return lines.slice(0, index)
+		}
+	}
+	return lines
+}
+
+function getInterfaceConfigLine(
+	context: RunningConfigInterfaceContext,
+	pattern: RegExp,
+) {
+	return context.lines.find((line) => pattern.test(line)) ?? null
+}
+
+function parseRunningConfigWanInterfaces(lines: Array<string>) {
+	const { interfaces } = parseRunningConfigContexts(lines)
+	return interfaces.flatMap((context) => {
+		const autoconfig = getInterfaceConfigLine(
+			context,
+			/^ip autoconfig (?:wan|static-wan|full)\b/i,
+		)
+		const dhcpClient = getInterfaceConfigLine(
+			context,
+			/^ip dhcp-client (?:on|off)\b/i,
+		)
+		const priority = getInterfaceConfigLine(context, /^ip priority \d+\b/i)
+		const looksLikeWan =
+			autoconfig != null ||
+			dhcpClient != null ||
+			priority != null ||
+			/^wan\d+$/i.test(context.interfaceName)
+		if (!looksLikeWan) return []
+
+		const addressLine = getInterfaceConfigLine(
+			context,
+			/^ip address\s+\S+/i,
+		)
+		const connectionType =
+			autoconfig == null
+				? normalizeConnectionType(dhcpClient ?? addressLine ?? '')
+				: /\bstatic-wan\b/i.test(autoconfig)
+					? 'static'
+					: /\bwan\b/i.test(autoconfig)
+						? 'dhcp'
+						: normalizeConnectionType(autoconfig)
+		return [
+			{
+				ispName: null,
+				interfaceName: context.interfaceName,
+				ipAddress:
+					addressLine?.match(/^ip address\s+(?<address>\S+)/i)?.groups?.[
+						'address'
+					] ?? null,
+				gateway: null,
+				connectionType,
+				role: 'unknown' as const,
+				failoverPriority: parseInteger(
+					priority?.match(/^ip priority (?<priority>\d+)$/i)?.groups?.[
+						'priority'
+					] ?? null,
+				),
+				linkState: null,
+				rawLine: [
+					`interface ${context.interfaceName}`,
+					...context.lines,
+				].join(' '),
+				fields: {
+					interface: context.interfaceName,
+					autoconfig:
+						autoconfig?.replace(/^ip autoconfig\s+/i, '') ?? '',
+					priority:
+						priority?.match(/^ip priority (?<priority>\d+)$/i)?.groups?.[
+							'priority'
+						] ?? '',
+				},
+			} satisfies IslandRouterWanInterfaceConfig,
+		]
+	})
+}
+
+function parseRunningConfigFailover(
+	lines: Array<string>,
+): IslandRouterFailoverStatus {
+	const { globals } = parseRunningConfigContexts(lines)
+	const wans = parseRunningConfigWanInterfaces(lines).sort((left, right) => {
+		const leftPriority = left.failoverPriority ?? Number.POSITIVE_INFINITY
+		const rightPriority = right.failoverPriority ?? Number.POSITIVE_INFINITY
+		return leftPriority - rightPriority
+	})
+	const preferredInterfaceName = wans[0]?.interfaceName ?? null
+	const policy =
+		globals
+			.find((line) => /^ip load-sharing /i.test(line))
+			?.replace(/^ip load-sharing\s+/i, '')
+			.trim() ??
+		(wans.length > 0 ? 'priority' : null)
+	const healthChecks = wans.map((wan) => ({
+		interfaceName: wan.interfaceName,
+		ispName: wan.ispName,
+		state: null,
+		role:
+			wan.interfaceName != null && wan.interfaceName === preferredInterfaceName
+				? ('active' as const)
+				: ('standby' as const),
+		failoverPriority: wan.failoverPriority,
+		monitor: null,
+		rawLine: wan.rawLine,
+		fields: wan.fields,
+	}))
+	return {
+		activeInterfaceName: preferredInterfaceName,
+		activeIspName:
+			wans.find((wan) => wan.interfaceName === preferredInterfaceName)?.ispName ??
+			null,
+		policy,
+		healthChecks,
+		rawOutput: lines.join('\n'),
+	}
+}
+
+function parseRunningConfigDns(
+	lines: Array<string>,
+): IslandRouterDnsConfig {
+	const attributes: Array<{ key: string; value: string }> = []
+	const servers: Array<IslandRouterDnsServer> = []
+	for (const line of lines) {
+		const dnsModeMatch = /^ip dns mode (?<mode>.+)$/i.exec(line)
+		if (dnsModeMatch?.groups?.['mode']) {
+			attributes.push({
+				key: 'Mode',
+				value: dnsModeMatch.groups['mode'],
+			})
+			continue
+		}
+		const localOnlyMatch = /^ip dns local-only (?<value>\S+)$/i.exec(line)
+		if (localOnlyMatch?.groups?.['value']) {
+			attributes.push({
+				key: 'Local Only',
+				value: localOnlyMatch.groups['value'],
+			})
+			continue
+		}
+		const serverMatch =
+			/^ip (?:(?:name-server)|(?:dns server)) (?<server>\S+)$/i.exec(line)
+		if (serverMatch?.groups?.['server']) {
+			servers.push({
+				address: serverMatch.groups['server'],
+				role: 'upstream',
+				source: 'running-config',
+				rawLine: line,
+				fields: {},
+			})
+		}
+	}
+	return {
+		mode:
+			attributes.find((attribute) => attribute.key === 'Mode')?.value ?? null,
+		searchDomains: [],
+		servers,
+		overrides: [],
+		attributes,
+		rawOutput: lines.join('\n'),
+	}
+}
+
+function parseRunningConfigSecurityPolicy(
+	lines: Array<string>,
+): IslandRouterSecurityPolicy {
+	return {
+		rules: lines.flatMap((line, index) => {
+			if (!/^(?:firewall|protection|security-policy)\b/i.test(line)) return []
+			return [
+				{
+					ruleId: String(index + 1),
+					name: line.split(/\s+/).slice(0, 2).join(' '),
+					action:
+						line.match(/\b(allow|deny|drop|reject|block)\b/i)?.[1]?.toLowerCase() ??
+						null,
+					source: null,
+					destination: null,
+					service: null,
+					enabled: !/^no\s+/i.test(line),
+					rawLine: line,
+					fields: {},
+				} satisfies IslandRouterSecurityPolicyRule,
+			]
+		}),
+		rawOutput: lines.join('\n'),
+	}
+}
+
+function parseRunningConfigQos(
+	lines: Array<string>,
+): IslandRouterQosConfig {
+	return {
+		policies: lines.flatMap((line) => {
+			if (!/^(?:qos|traffic-policy)\b/i.test(line)) return []
+			return [
+				{
+					policyName: line.split(/\s+/)[1] ?? null,
+					interfaceName: extractInterfaceName(line),
+					className: null,
+					priority:
+						line.match(/\b(high|medium|low|\d+)\b/i)?.[1]?.toLowerCase() ?? null,
+					bandwidth: extractRate(line),
+					enabled: !/^no\s+/i.test(line),
+					rawLine: line,
+					fields: {},
+				} satisfies IslandRouterQosPolicyEntry,
+			]
+		}),
+		rawOutput: lines.join('\n'),
+	}
+}
+
+function parseRunningConfigNatRules(
+	lines: Array<string>,
+): IslandRouterNatRules {
+	const { interfaces } = parseRunningConfigContexts(lines)
+	return {
+		rules: interfaces.flatMap((context, index) => {
+			const natLine = context.lines.find((line) => /^ip nat[46] on$/i.test(line))
+			if (!natLine) return []
+			return [
+				{
+					ruleId: String(index + 1),
+					type: natLine.match(/\bnat(?<version>[46])\b/i)?.groups?.['version']
+						? `nat${natLine.match(/\bnat(?<version>[46])\b/i)?.groups?.['version']}`
+						: 'nat',
+					protocol: null,
+					interfaceName: context.interfaceName,
+					externalAddress: null,
+					externalPort: null,
+					internalAddress: null,
+					internalPort: null,
+					enabled: true,
+					description: null,
+					rawLine: [`interface ${context.interfaceName}`, natLine].join(' '),
+					fields: {},
+				} satisfies IslandRouterNatRule,
+			]
+		}),
+	}
+}
+
+function parseRunningConfigDhcpServer(
+	lines: Array<string>,
+): IslandRouterDhcpServerConfig {
+	const { globals, interfaces } = parseRunningConfigContexts(lines)
+	const pools: Array<IslandRouterDhcpServerPool> = []
+	const options: Array<IslandRouterDhcpServerOption> = []
+	const reservations: Array<IslandRouterDhcpLease> = []
+
+	for (const context of interfaces) {
+		const dhcpEnabled = getInterfaceConfigLine(
+			context,
+			/^ip dhcp-server on$/i,
+		)
+		if (!dhcpEnabled) continue
+		const addressLine = getInterfaceConfigLine(
+			context,
+			/^ip address (?<address>\S+)$/i,
+		)
+		const scopeLine = getInterfaceConfigLine(
+			context,
+			/^ip dhcp-scope (?<range>.+)$/i,
+		)
+		const leaseLine = getInterfaceConfigLine(
+			context,
+			/^ip dhcp-lease (?<seconds>\d+)$/i,
+		)
+		pools.push({
+			poolName: context.interfaceName,
+			interfaceName: context.interfaceName,
+			network: addressLine?.match(/^ip address (?<address>\S+)$/i)?.groups?.[
+				'address'
+			] ?? null,
+			rangeStart:
+				scopeLine?.match(/^ip dhcp-scope (?<start>\d+)(?:-(?<end>\d*))?$/i)
+					?.groups?.['start'] ?? null,
+			rangeEnd:
+				scopeLine?.match(/^ip dhcp-scope (?<start>\d+)(?:-(?<end>\d*))?$/i)
+					?.groups?.['end'] ?? null,
+			gateway:
+				addressLine?.match(/^ip address (?<address>\S+)$/i)?.groups?.['address'] ??
+				null,
+			dnsServers: [],
+			rawLine: [`interface ${context.interfaceName}`, ...context.lines].join(' '),
+			fields: {},
+		})
+		if (leaseLine) {
+			options.push({
+				poolName: context.interfaceName,
+				option: 'lease-time',
+				value:
+					leaseLine.match(/^ip dhcp-lease (?<seconds>\d+)$/i)?.groups?.[
+						'seconds'
+					] ?? null,
+				rawLine: leaseLine,
+				fields: {},
+			})
+		}
+	}
+
+	for (const line of globals) {
+		const reserveMatch =
+			/^ip dhcp-reserve (?<ip>\S+) (?<mac>[0-9a-f:]+)$/i.exec(line)
+		if (!reserveMatch?.groups) continue
+		reservations.push({
+			ipAddress: reserveMatch.groups['ip'] ?? null,
+			macAddress: reserveMatch.groups['mac']?.toLowerCase() ?? null,
+			hostName: null,
+			interfaceName: null,
+			leaseType: 'reservation',
+			rawLine: line,
+			fields: {},
+		})
+	}
+
+	return {
+		pools,
+		options,
+		reservations,
+		rawOutput: lines.join('\n'),
+	}
+}
+
+function parseRunningConfigVlans(lines: Array<string>): IslandRouterVlanConfig {
+	const { interfaces } = parseRunningConfigContexts(lines)
+	return {
+		vlans: interfaces.flatMap((context) => {
+			const vlanMatch = /^vlan(?<id>\d+)$/i.exec(context.interfaceName)
+			if (!vlanMatch?.groups?.['id']) return []
+			const addressLine = getInterfaceConfigLine(
+				context,
+				/^ip address (?<address>\S+)$/i,
+			)
+			const parentLine = getInterfaceConfigLine(context, /^parent (?<parent>\S+)$/i)
+			return [
+				{
+					vlanId: Number.parseInt(vlanMatch.groups['id'], 10),
+					name: context.interfaceName,
+					interfaceName: context.interfaceName,
+					memberInterfaces: splitValueList(
+						parentLine?.match(/^parent (?<parent>\S+)$/i)?.groups?.['parent'] ?? null,
+					),
+					status: null,
+					ipAddress:
+						addressLine?.match(/^ip address (?<address>\S+)$/i)?.groups?.['address'] ??
+						null,
+					rawLine: [`interface ${context.interfaceName}`, ...context.lines].join(' '),
+					fields: {},
+				} satisfies IslandRouterVlanConfigEntry,
+			]
+		}),
+	}
+}
+
+function parseRunningConfigSyslog(
+	lines: Array<string>,
+): IslandRouterSyslogConfig {
+	const hostLines: Array<string> = []
+	let defaultPort: number | null = null
+	let defaultProtocol: string | null = null
+	let defaultFacility: string | null = null
+
+	for (const line of lines) {
+		const portMatch = /^syslog port (?<port>\d+)$/i.exec(line)
+		if (portMatch?.groups?.['port']) {
+			defaultPort = Number.parseInt(portMatch.groups['port'], 10)
+			continue
+		}
+		const protocolMatch = /^syslog protocol (?<protocol>\S+)$/i.exec(line)
+		if (protocolMatch?.groups?.['protocol']) {
+			defaultProtocol = protocolMatch.groups['protocol'].toLowerCase()
+			continue
+		}
+		const facilityMatch = /^syslog facility (?<facility>\S+)$/i.exec(line)
+		if (facilityMatch?.groups?.['facility']) {
+			defaultFacility = facilityMatch.groups['facility']
+			continue
+		}
+		const hostMatch =
+			/^syslog (?<host>(?!protocol\b|level\b|facility\b|port\b)\S+)$/i.exec(line)
+		if (hostMatch?.groups?.['host']) {
+			hostLines.push(line)
+		}
+	}
+
+	return {
+		targets: hostLines.map((line) => ({
+			host:
+				/^syslog (?<host>(?!protocol\b|level\b|facility\b|port\b)\S+)$/i.exec(line)
+					?.groups?.['host'] ?? null,
+			port: defaultPort,
+			protocol: defaultProtocol,
+			facility: defaultFacility,
+			enabled: true,
+			rawLine: line,
+			fields: {},
+		})),
+		attributes: [],
+		rawOutput: lines.join('\n'),
+	}
+}
+
+function parseRunningConfigSnmp(
+	lines: Array<string>,
+): IslandRouterSnmpConfig {
+	const communities: Array<IslandRouterSnmpCommunity> = []
+	const trapTargets: Array<IslandRouterSnmpTrapTarget> = []
+
+	for (const line of lines) {
+		const communityMatch =
+			/^snmp community (?<community>\S+)(?:\s+(?<access>\S+))?(?:\s+(?<source>\S+))?$/i.exec(
+				line,
+			)
+		if (communityMatch?.groups?.['community']) {
+			communities.push({
+				community: communityMatch.groups['community'],
+				access: communityMatch.groups['access'] ?? null,
+				source: communityMatch.groups['source'] ?? null,
+				rawLine: line,
+				fields: {},
+			})
+			continue
+		}
+		const trapMatch =
+			/^snmp trap(?:-target)? (?<host>\S+)(?:.*\bversion (?<version>\S+))?(?:.*\bcommunity (?<community>\S+))?$/i.exec(
+				line,
+			)
+		if (trapMatch?.groups?.['host']) {
+			trapTargets.push({
+				host: trapMatch.groups['host'],
+				version: trapMatch.groups['version'] ?? null,
+				community: trapMatch.groups['community'] ?? null,
+				rawLine: line,
+				fields: {},
+			})
+		}
+	}
+
+	return {
+		enabled: communities.length > 0 || trapTargets.length > 0 ? true : null,
+		communities,
+		trapTargets,
+		attributes: [],
+		rawOutput: lines.join('\n'),
+	}
+}
+
 export function parseIslandRouterWanConfig(
 	stdout: string,
 	commandLines: Array<string>,
 ): IslandRouterWanConfig {
 	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	if (commandLinesContain(commandLines, 'show running-config')) {
+		return {
+			wans: parseRunningConfigWanInterfaces(lines),
+		}
+	}
 	const rows = selectRowsOrFallback(lines)
 	return {
 		wans: rows.flatMap((row) => {
@@ -854,6 +1393,9 @@ export function parseIslandRouterFailoverStatus(
 	commandLines: Array<string>,
 ): IslandRouterFailoverStatus {
 	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	if (commandLinesContain(commandLines, 'show running-config')) {
+		return parseRunningConfigFailover(lines)
+	}
 	const fieldMap = buildFieldMapFromAttributes(lines)
 	const rows = selectRowsOrFallback(lines)
 	const healthChecks = rows.flatMap((row) => {
@@ -942,6 +1484,9 @@ export function parseIslandRouterNatRules(
 	commandLines: Array<string>,
 ): IslandRouterNatRules {
 	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	if (commandLinesContain(commandLines, 'show running-config')) {
+		return parseRunningConfigNatRules(lines)
+	}
 	const rows = selectRowsOrFallback(lines)
 	return {
 		rules: rows.flatMap((row) => {
@@ -994,6 +1539,9 @@ export function parseIslandRouterVlanConfig(
 	commandLines: Array<string>,
 ): IslandRouterVlanConfig {
 	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	if (commandLinesContain(commandLines, 'show running-config')) {
+		return parseRunningConfigVlans(lines)
+	}
 	const rows = selectRowsOrFallback(lines)
 	return {
 		vlans: rows.flatMap((row) => {
@@ -1028,6 +1576,9 @@ export function parseIslandRouterDnsConfig(
 	commandLines: Array<string>,
 ): IslandRouterDnsConfig {
 	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	if (commandLinesContain(commandLines, 'show running-config')) {
+		return parseRunningConfigDns(lines)
+	}
 	const attributes = parseKeyValueLines(lines)
 	const fieldMap = Object.fromEntries(
 		attributes.map((entry) => [normalizeHeaderKey(entry.key), entry.value]),
@@ -1120,6 +1671,9 @@ export function parseIslandRouterSecurityPolicy(
 	commandLines: Array<string>,
 ): IslandRouterSecurityPolicy {
 	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	if (commandLinesContain(commandLines, 'show running-config')) {
+		return parseRunningConfigSecurityPolicy(lines)
+	}
 	const rows = selectRowsOrFallback(lines)
 	return {
 		rules: rows.flatMap((row) => {
@@ -1159,6 +1713,9 @@ export function parseIslandRouterQosConfig(
 	commandLines: Array<string>,
 ): IslandRouterQosConfig {
 	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	if (commandLinesContain(commandLines, 'show running-config')) {
+		return parseRunningConfigQos(lines)
+	}
 	const rows = selectRowsOrFallback(lines)
 	return {
 		policies: rows.flatMap((row) => {
@@ -1239,12 +1796,25 @@ export function parseIslandRouterActiveSessions(
 	return {
 		sessions: rows.flatMap((row) => {
 			const source = parseHostPort(
-				findField(row.fields, ['source', 'src', 'source_address']) ??
+				findField(row.fields, [
+					'source',
+					'src',
+					'source_address',
+					'local',
+					'local_address',
+				]) ??
 					row.rawLine.match(/\bsrc[:= ]+([^\s,]+)/i)?.[1] ??
 					null,
 			)
 			const destination = parseHostPort(
-				findField(row.fields, ['destination', 'dest', 'dst']) ??
+				findField(row.fields, [
+					'destination',
+					'dest',
+					'dst',
+					'foreign',
+					'foreign_address',
+					'remote',
+				]) ??
 					row.rawLine.match(/\bdst[:= ]+([^\s,]+)/i)?.[1] ??
 					null,
 			)
@@ -1291,7 +1861,14 @@ export function parseIslandRouterVpnConfig(
 			const localEndpoint =
 				findField(row.fields, ['local', 'local_endpoint']) ??
 				extractIpAddress(row.rawLine)
+			const status = findField(row.fields, ['status', 'state'])
+			const interfaceName =
+				findField(row.fields, ['interface', 'iface']) ??
+				extractInterfaceName(row.rawLine)
 			if (!tunnelName && !localEndpoint && !/ipsec|vpn|gre/i.test(row.rawLine)) {
+				return []
+			}
+			if (!localEndpoint && !status && !interfaceName) {
 				return []
 			}
 			const remoteMatch = row.rawLine.match(/\bto\s+([^\s,]+)/i)?.[1] ?? null
@@ -1306,10 +1883,8 @@ export function parseIslandRouterVpnConfig(
 					remoteEndpoint:
 						findField(row.fields, ['remote', 'peer', 'remote_endpoint']) ??
 						remoteMatch,
-					status: findField(row.fields, ['status', 'state']),
-					interfaceName:
-						findField(row.fields, ['interface', 'iface']) ??
-						extractInterfaceName(row.rawLine),
+					status,
+					interfaceName,
 					rawLine: row.rawLine,
 					fields: row.fields,
 				} satisfies IslandRouterVpnTunnel,
@@ -1324,6 +1899,12 @@ export function parseIslandRouterDhcpServerConfig(
 	commandLines: Array<string>,
 ): IslandRouterDhcpServerConfig {
 	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	if (commandLinesContain(commandLines, 'show running-config')) {
+		const base = parseRunningConfigDhcpServer(getLinesBeforeFirstTable(lines))
+		return {
+			...base,
+		}
+	}
 	const rows = selectRowsOrFallback(lines)
 	const pools: Array<IslandRouterDhcpServerPool> = []
 	const options: Array<IslandRouterDhcpServerOption> = []
@@ -1402,23 +1983,38 @@ export function parseIslandRouterNtpConfig(
 		attributes.map((entry) => [normalizeHeaderKey(entry.key), entry.value]),
 	)
 	const rows = selectRowsOrFallback(lines)
+	const parsedServers = rows.flatMap((row) => {
+		const server =
+			findField(row.fields, ['server', 'address', 'host']) ??
+			extractIpAddress(row.rawLine)
+		if (!server) return []
+		return [
+			{
+				server,
+				status: findField(row.fields, ['status', 'state']),
+				source: findField(row.fields, ['source', 'type']),
+				rawLine: row.rawLine,
+				fields: row.fields,
+			} satisfies IslandRouterNtpServer,
+		]
+	})
+	const fallbackServer = findField(fieldMap, ['server'])
 	return {
 		timezone: findField(fieldMap, ['timezone', 'tz']),
-		servers: rows.flatMap((row) => {
-			const server =
-				findField(row.fields, ['server', 'address', 'host']) ??
-				extractIpAddress(row.rawLine)
-			if (!server) return []
-			return [
-				{
-					server,
-					status: findField(row.fields, ['status', 'state']),
-					source: findField(row.fields, ['source', 'type']),
-					rawLine: row.rawLine,
-					fields: row.fields,
-				} satisfies IslandRouterNtpServer,
-			]
-		}),
+		servers:
+			parsedServers.length > 0
+				? parsedServers
+				: fallbackServer == null
+					? []
+					: [
+							{
+								server: fallbackServer,
+								status: findField(fieldMap, ['clock_state', 'status', 'state']),
+								source: 'status',
+								rawLine: `Server: ${fallbackServer}`,
+								fields: {},
+							} satisfies IslandRouterNtpServer,
+						],
 		attributes,
 		rawOutput: lines.join('\n'),
 	}
@@ -1429,6 +2025,9 @@ export function parseIslandRouterSyslogConfig(
 	commandLines: Array<string>,
 ): IslandRouterSyslogConfig {
 	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	if (commandLinesContain(commandLines, 'show running-config')) {
+		return parseRunningConfigSyslog(lines)
+	}
 	const attributes = parseKeyValueLines(lines)
 	const rows = selectRowsOrFallback(lines)
 	return {
@@ -1465,6 +2064,9 @@ export function parseIslandRouterSnmpConfig(
 	commandLines: Array<string>,
 ): IslandRouterSnmpConfig {
 	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
+	if (commandLinesContain(commandLines, 'show running-config')) {
+		return parseRunningConfigSnmp(lines)
+	}
 	const attributes = parseKeyValueLines(lines)
 	const fieldMap = Object.fromEntries(
 		attributes.map((entry) => [normalizeHeaderKey(entry.key), entry.value]),
@@ -1557,14 +2159,18 @@ export function parseIslandRouterBandwidthUsage(
 			const txRate =
 				findField(row.fields, ['tx_rate', 'upload', 'out']) ??
 				null
-			if (!subject && !rxRate && !txRate) return []
+			const totalRate = findField(
+				row.fields,
+				['total_rate', 'rate', 'throughput'],
+			)
+			if (!rxRate && !txRate && !totalRate) return []
 			return [
 				{
 					subject,
 					interfaceName,
 					rxRate,
 					txRate,
-					totalRate: findField(row.fields, ['total_rate', 'rate', 'throughput']),
+					totalRate,
 					rawLine: row.rawLine,
 					fields: row.fields,
 				} satisfies IslandRouterBandwidthUsageEntry,

--- a/packages/home-connector/src/adapters/island-router/parsing.ts
+++ b/packages/home-connector/src/adapters/island-router/parsing.ts
@@ -312,6 +312,91 @@ function parseTextTable(lines: Array<string>): Array<ParsedTableRow> {
 	return rows
 }
 
+function parseTextTables(lines: Array<string>): Array<ParsedTable> {
+	const tables: Array<ParsedTable> = []
+	let index = 0
+
+	while (index < lines.length - 1) {
+		const line = lines[index] ?? ''
+		const columns = splitTableColumns(line)
+		const next = lines[index + 1] ?? ''
+		if (
+			columns.length < 2 ||
+			!/^-{3,}(?:\s+-{3,})*$/.test(next.trim())
+		) {
+			index += 1
+			continue
+		}
+
+		const headers = columns.map(normalizeHeaderKey)
+		const rows: Array<ParsedTableRow> = []
+		index += 2
+
+		while (index < lines.length) {
+			const currentLine = lines[index] ?? ''
+			const currentColumns = splitTableColumns(currentLine)
+			const upcomingLine = lines[index + 1] ?? ''
+			if (
+				currentColumns.length >= 2 &&
+				!/^-{3,}(?:\s+-{3,})*$/.test(currentLine.trim()) &&
+				/^-{3,}(?:\s+-{3,})*$/.test(upcomingLine.trim())
+			) {
+				break
+			}
+			if (!currentLine.trim()) {
+				index += 1
+				continue
+			}
+			if (/^-{3,}(?:\s+-{3,})*$/.test(currentLine.trim())) {
+				index += 1
+				continue
+			}
+			if (currentColumns.length < 2) {
+				index += 1
+				continue
+			}
+			if (
+				currentColumns.length === headers.length &&
+				currentColumns.every(
+					(column, columnIndex) =>
+						normalizeHeaderKey(column) === (headers[columnIndex] ?? ''),
+				)
+			) {
+				index += 1
+				continue
+			}
+			rows.push({
+				rawLine: currentLine,
+				fields: Object.fromEntries(
+					headers.map((header, columnIndex) => [
+						header,
+						currentColumns[columnIndex] ?? '',
+					]),
+				),
+			})
+			index += 1
+		}
+
+		tables.push({
+			headers,
+			rows,
+		})
+	}
+
+	return tables
+}
+
+function findTextTableRows(
+	lines: Array<string>,
+	requiredHeaders: Array<string>,
+): Array<ParsedTableRow> {
+	return (
+		parseTextTables(lines).find((table) =>
+			requiredHeaders.every((header) => table.headers.includes(header)),
+		)?.rows ?? []
+	)
+}
+
 function parseKeyValueLines(lines: Array<string>) {
 	return lines.flatMap((line) => {
 		const match = /^(?<key>[^:]+):\s*(?<value>.+)$/.exec(line)
@@ -1107,8 +1192,11 @@ function parseRunningConfigNatRules(
 	lines: Array<string>,
 ): IslandRouterNatRules {
 	const { interfaces } = parseRunningConfigContexts(lines)
+	const natInterfaces = interfaces.filter((context) =>
+		context.lines.some((line) => /^ip nat[46] on$/i.test(line)),
+	)
 	return {
-		rules: interfaces.flatMap((context, index) => {
+		rules: natInterfaces.flatMap((context, index) => {
 			const natLine = context.lines.find((line) => /^ip nat[46] on$/i.test(line))
 			if (!natLine) return []
 			return [
@@ -1752,7 +1840,9 @@ export function parseIslandRouterTrafficStats(
 	commandLines: Array<string>,
 ): IslandRouterTrafficStats {
 	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
-	const rows = selectRowsOrFallback(lines)
+	const rows = commandLinesContain(commandLines, 'show stats')
+		? findTextTableRows(lines, ['interface', 'rx_bytes', 'tx_bytes'])
+		: selectRowsOrFallback(lines)
 	return {
 		interfaces: rows.flatMap((row) => {
 			const interfaceName =
@@ -2143,7 +2233,9 @@ export function parseIslandRouterBandwidthUsage(
 	commandLines: Array<string>,
 ): IslandRouterBandwidthUsage {
 	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
-	const rows = selectRowsOrFallback(lines)
+	const rows = commandLinesContain(commandLines, 'show stats')
+		? findTextTableRows(lines, ['interface', 'rx_rate', 'tx_rate'])
+		: selectRowsOrFallback(lines)
 	return {
 		entries: rows.flatMap((row) => {
 			const interfaceName =

--- a/packages/home-connector/src/adapters/island-router/parsing.ts
+++ b/packages/home-connector/src/adapters/island-router/parsing.ts
@@ -1073,20 +1073,15 @@ function parseRunningConfigFailover(
 		interfaceName: wan.interfaceName,
 		ispName: wan.ispName,
 		state: null,
-		role:
-			wan.interfaceName != null && wan.interfaceName === preferredInterfaceName
-				? ('active' as const)
-				: ('standby' as const),
+		role: 'unknown' as const,
 		failoverPriority: wan.failoverPriority,
 		monitor: null,
 		rawLine: wan.rawLine,
 		fields: wan.fields,
 	}))
 	return {
-		activeInterfaceName: preferredInterfaceName,
-		activeIspName:
-			wans.find((wan) => wan.interfaceName === preferredInterfaceName)?.ispName ??
-			null,
+		activeInterfaceName: null,
+		activeIspName: null,
 		policy,
 		healthChecks,
 		rawOutput: lines.join('\n'),
@@ -1991,8 +1986,15 @@ export function parseIslandRouterDhcpServerConfig(
 	const lines = sanitizeIslandRouterOutput(stdout, commandLines)
 	if (commandLinesContain(commandLines, 'show running-config')) {
 		const base = parseRunningConfigDhcpServer(getLinesBeforeFirstTable(lines))
+		const reservationLines = lines.slice(getLinesBeforeFirstTable(lines).length)
+		const reservations = parseIslandRouterDhcpReservations(
+			reservationLines.join('\n'),
+			['show ip dhcp-reservations'],
+		)
 		return {
 			...base,
+			reservations:
+				reservations.length > 0 ? reservations : base.reservations,
 		}
 	}
 	const rows = selectRowsOrFallback(lines)

--- a/packages/home-connector/src/adapters/island-router/ssh-client.ts
+++ b/packages/home-connector/src/adapters/island-router/ssh-client.ts
@@ -266,23 +266,25 @@ function getCommandLines(request: IslandRouterCommandRequest): Array<string> {
 		case 'show-clock':
 			return ['show clock']
 		case 'show-system':
-			return ['show system']
+			return ['show stats']
+		case 'show-hardware':
+			return ['show hardware']
+		case 'show-stats':
+			return ['show stats']
+		case 'show-running-config':
+			return ['show running-config']
 		case 'show-interface-summary':
 			return ['show interface summary']
 		case 'show-interface-statistics':
-			return ['show interface statistics']
+			return ['show stats']
 		case 'show-bandwidth-usage':
-			// Best-effort guess; public docs were not found for realtime bandwidth usage.
-			return ['show bandwidth-usage']
+			return ['show stats']
 		case 'show-wan':
-			// Best-effort guess; public docs were not found for WAN summary inspection.
-			return ['show wan']
+			return ['show running-config']
 		case 'show-wan-failover':
-			// Best-effort guess; public docs were not found for WAN failover status.
-			return ['show wan failover']
+			return ['show running-config']
 		case 'show-multi-wan':
-			// Best-effort guess; public docs were not found for multi-WAN state.
-			return ['show multi-wan']
+			return ['show running-config']
 		case 'show-interface':
 			return [
 				`show interface ${assertSingleCliLine(request.interfaceName, 'interfaceName')}`,
@@ -294,68 +296,58 @@ function getCommandLines(request: IslandRouterCommandRequest): Array<string> {
 		case 'show-ip-routes':
 			return ['show ip routes']
 		case 'show-nat':
-			// Best-effort guess; public docs were not found for NAT inspection.
-			return ['show nat']
+			return ['show running-config']
 		case 'show-ip-nat':
-			// Best-effort guess; public docs were not found for IP NAT inspection.
-			return ['show ip nat']
+			return ['show running-config']
 		case 'show-sessions':
-			// Best-effort guess; public docs were not found for session table inspection.
-			return ['show sessions']
+			return ['show ip sockets']
 		case 'show-vlan':
-			// Best-effort guess; public docs were not found for VLAN inspection.
-			return ['show vlan']
+			return ['show running-config']
 		case 'show-dns':
-			// Best-effort guess; public docs were not found for DNS inspection.
-			return ['show dns']
+			return ['show running-config']
 		case 'show-ip-dns':
-			// Best-effort guess; public docs were not found for IP DNS inspection.
-			return ['show ip dns']
+			return ['show running-config']
 		case 'show-users':
 			return ['show users']
 		case 'show-user':
 			// Best-effort guess; public docs were not found for per-user detail output.
 			return ['show user']
 		case 'show-security-policy':
-			// Best-effort guess; public docs were not found for security policy inspection.
-			return ['show security-policy']
+			return ['show running-config']
 		case 'show-protection':
-			// Best-effort guess; public docs were not found for protection inspection.
-			return ['show protection']
+			return ['show running-config']
 		case 'show-firewall':
-			// Best-effort guess; public docs were not found for firewall inspection.
-			return ['show firewall']
+			return ['show running-config']
 		case 'show-qos':
-			// Best-effort guess; public docs were not found for QoS inspection.
-			return ['show qos']
+			return ['show running-config']
 		case 'show-traffic-policy':
-			// Best-effort guess; public docs were not found for traffic policy inspection.
-			return ['show traffic-policy']
+			return ['show running-config']
 		case 'show-vpn':
-			// Best-effort guess; public docs were not found for VPN inspection.
-			return ['show vpn']
+			return ['show vpns']
+		case 'show-vpns':
+			return ['show vpns']
 		case 'show-ipsec':
-			// Best-effort guess; public docs were not found for IPsec inspection.
-			return ['show ipsec']
+			return ['show vpns']
 		case 'show-gre':
-			// Best-effort guess; public docs were not found for GRE inspection.
-			return ['show gre']
+			return ['show vpns']
 		case 'show-ip-neighbors':
 			return ['show ip neighbors']
+		case 'show-ip-sockets':
+			return ['show ip sockets']
 		case 'show-ip-dhcp-reservations':
 			return ['show ip dhcp-reservations']
 		case 'show-dhcp-server':
-			// Best-effort guess; public docs were not found for DHCP server inspection.
-			return ['show dhcp-server']
+			return ['show running-config']
 		case 'show-ntp':
-			// Best-effort guess; public docs were not found for NTP inspection.
-			return ['show ntp']
+			return ['show ntp status']
+		case 'show-ntp-status':
+			return ['show ntp status']
+		case 'show-ntp-associations':
+			return ['show ntp associations']
 		case 'show-syslog':
-			// Best-effort guess; public docs were not found for syslog inspection.
-			return ['show syslog']
+			return ['show running-config']
 		case 'show-snmp':
-			// Best-effort guess; public docs were not found for SNMP inspection.
-			return ['show snmp']
+			return ['show running-config']
 		case 'show-log':
 			return request.query
 				? [`show log last where "${escapeCliQuery(request.query)}"`]

--- a/packages/home-connector/src/adapters/island-router/types.ts
+++ b/packages/home-connector/src/adapters/island-router/types.ts
@@ -24,6 +24,9 @@ export type IslandRouterCommandId =
 	| 'show-version'
 	| 'show-clock'
 	| 'show-system'
+	| 'show-hardware'
+	| 'show-stats'
+	| 'show-running-config'
 	| 'show-interface-summary'
 	| 'show-interface'
 	| 'show-ip-interface'
@@ -47,12 +50,16 @@ export type IslandRouterCommandId =
 	| 'show-qos'
 	| 'show-traffic-policy'
 	| 'show-vpn'
+	| 'show-vpns'
 	| 'show-ipsec'
 	| 'show-gre'
 	| 'show-ip-neighbors'
+	| 'show-ip-sockets'
 	| 'show-ip-dhcp-reservations'
 	| 'show-dhcp-server'
 	| 'show-ntp'
+	| 'show-ntp-status'
+	| 'show-ntp-associations'
 	| 'show-syslog'
 	| 'show-snmp'
 	| 'show-log'
@@ -80,6 +87,18 @@ export type IslandRouterCommandRequest =
 	  }
 	| {
 			id: 'show-system'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-hardware'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-stats'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-running-config'
 			timeoutMs?: number
 	  }
 	| {
@@ -177,6 +196,10 @@ export type IslandRouterCommandRequest =
 			timeoutMs?: number
 	  }
 	| {
+			id: 'show-vpns'
+			timeoutMs?: number
+	  }
+	| {
 			id: 'show-ipsec'
 			timeoutMs?: number
 	  }
@@ -189,6 +212,10 @@ export type IslandRouterCommandRequest =
 			timeoutMs?: number
 	  }
 	| {
+			id: 'show-ip-sockets'
+			timeoutMs?: number
+	  }
+	| {
 			id: 'show-ip-dhcp-reservations'
 			timeoutMs?: number
 	  }
@@ -198,6 +225,14 @@ export type IslandRouterCommandRequest =
 	  }
 	| {
 			id: 'show-ntp'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ntp-status'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ntp-associations'
 			timeoutMs?: number
 	  }
 	| {

--- a/packages/home-connector/src/mcp/register-island-router-tools.ts
+++ b/packages/home-connector/src/mcp/register-island-router-tools.ts
@@ -370,7 +370,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_wan_config',
 		title: 'Get Island Router WAN Config',
 		description:
-			'Read WAN interface configuration for all WAN ports, including ISP/provider labels, addressing, failover role, and priority.',
+			'Read WAN interface configuration inferred from the Island running configuration, including detected WAN interfaces, addressing, and failover priority when present.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getWanConfig({
@@ -392,7 +392,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_failover_status',
 		title: 'Get Island Router Failover Status',
 		description:
-			'Read multi-WAN failover status including the active ISP/interface, health state per WAN, and failover policy.',
+			'Read multi-WAN preference and failover intent inferred from the Island running configuration, including interface priority and load-sharing policy when present.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getFailoverStatus({
@@ -434,7 +434,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_nat_rules',
 		title: 'Get Island Router NAT Rules',
 		description:
-			'Read Island router NAT and port-forwarding rules from the typed allowlisted CLI views.',
+			'Read Island router NAT-related configuration from supported CLI views, including interface NAT enablement when present.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getNatRules({
@@ -456,7 +456,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_vlan_config',
 		title: 'Get Island Router VLAN Config',
 		description:
-			'Read Island router VLAN definitions, interface assignments, and parsed addressing details when present.',
+			'Read Island router VLAN definitions inferred from supported CLI views, including interface assignments and parsed addressing details when present.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getVlanConfig({
@@ -478,7 +478,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_dns_config',
 		title: 'Get Island Router DNS Config',
 		description:
-			'Read Island router DNS server configuration and parsed local DNS override records when present.',
+			'Read Island router DNS resolver configuration from supported CLI views, including DNS mode and configured upstream resolvers when present.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getDnsConfig({
@@ -519,7 +519,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_security_policy',
 		title: 'Get Island Router Security Policy',
 		description:
-			'Read Island router firewall, protection, or security-policy rules from the typed allowlisted CLI views.',
+			'Read Island router firewall, protection, or security-policy configuration from supported CLI views.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getSecurityPolicy({
@@ -541,7 +541,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_qos_config',
 		title: 'Get Island Router QoS Config',
 		description:
-			'Read Island router QoS or traffic-shaping policy configuration from the typed allowlisted CLI views.',
+			'Read Island router QoS or traffic-shaping configuration from supported CLI views.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getQosConfig({
@@ -563,7 +563,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_traffic_stats',
 		title: 'Get Island Router Traffic Stats',
 		description:
-			'Read per-interface Island router traffic statistics including bytes, packets, errors, and utilization when present.',
+			'Read Island router packet-processing or interface traffic statistics from supported diagnostic CLI views when present.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getTrafficStats({
@@ -585,7 +585,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_active_sessions',
 		title: 'Get Island Router Active Sessions',
 		description:
-			'Read the Island router active session or connection-state table, including parsed protocol and endpoint tuples.',
+			'Read the Island router active control-plane socket table from the supported `show ip sockets` CLI view, including parsed protocol and endpoint tuples.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getActiveSessions({
@@ -607,7 +607,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_vpn_config',
 		title: 'Get Island Router VPN Config',
 		description:
-			'Read Island router VPN or tunnel configuration (such as IPSec or GRE) from the typed allowlisted CLI views.',
+			'Read Island router VPN configuration from the supported `show vpns` CLI view, including tunnel status and statistics when present.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getVpnConfig({
@@ -629,7 +629,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_dhcp_server_config',
 		title: 'Get Island Router DHCP Server Config',
 		description:
-			'Read Island router DHCP server pools, options, and static reservation configuration.',
+			'Read Island router DHCP server configuration from supported CLI views, including interface DHCP server state, lease settings, and static reservations when present.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getDhcpServerConfig({
@@ -648,7 +648,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_ntp_config',
 		title: 'Get Island Router NTP Config',
 		description:
-			'Read Island router NTP or time-sync configuration including parsed upstream servers when present.',
+			'Read Island router NTP status and peer information from the supported `show ntp status` and `show ntp associations` CLI views.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getNtpConfig({
@@ -670,7 +670,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_syslog_config',
 		title: 'Get Island Router Syslog Config',
 		description:
-			'Read Island router remote syslog target configuration when present.',
+			'Read Island router remote syslog configuration inferred from supported CLI views when present.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getSyslogConfig({
@@ -692,7 +692,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_snmp_config',
 		title: 'Get Island Router SNMP Config',
 		description:
-			'Read Island router SNMP community and trap-target configuration when present.',
+			'Read Island router SNMP configuration inferred from supported CLI views when present.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getSnmpConfig({
@@ -711,7 +711,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_system_info',
 		title: 'Get Island Router System Info',
 		description:
-			'Read Island router system-health information such as uptime, CPU usage, memory usage, and temperature when available.',
+			'Read Island router system-health and hardware summary information from the supported `show stats` and `show hardware` CLI views when available.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getSystemInfo({
@@ -732,7 +732,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		name: 'router_get_bandwidth_usage',
 		title: 'Get Island Router Bandwidth Usage',
 		description:
-			'Read Island router real-time or historical bandwidth usage entries when the CLI exposes them.',
+			'Read Island router throughput-related summary entries from supported diagnostic CLI views when available.',
 		inputSchema: readTimeoutSchema,
 		handler: async (args) => {
 			const result = await islandRouter.getBandwidthUsage({

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -70,12 +70,28 @@ function createIslandRouterRunner() {
 			case 'show-system':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'show system'],
+					commandLines: ['terminal length 0', 'show stats'],
 					stdout: [
 						'Uptime: 4 days 03 hours',
 						'CPU Usage: 17%',
 						'Memory Usage: 41%',
 						'Temperature: 46 C',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-hardware':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show hardware'],
+					stdout: [
+						'Platform Type: Island Pro',
+						'CPU Type: ARM64',
+						'Memory Size: 8 GB',
+						'Power Supply Status: ok',
 					].join('\n'),
 					stderr: '',
 					exitCode: 0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- align Island router read-only command mappings to documented/live-supported CLI families instead of unsupported guessed top-level subcommands
- parse config-derived reads from `show running-config`, use `show vpns`, `show ip sockets`, `show ntp status|associations`, and `show stats`/`show hardware` where appropriate
- harden output sanitization so Island help/usage/unknown-command text is treated as unsupported or inconclusive output instead of structured data

## Testing
- `npm run test -- packages/home-connector/src/adapters/island-router/index.node.test.ts packages/home-connector/src/mcp/server.node.test.ts`

## Notes
- read tools now prefer live-aligned families for WAN/failover, DNS, NAT, VLAN, DHCP server, syslog, SNMP, VPN, sessions, NTP, and system/bandwidth summaries
- docs were updated to describe the narrower, more accurate command sources and parsing behavior
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e35f80b-1f32-41d6-9a4a-857e6dcc7a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e35f80b-1f32-41d6-9a4a-857e6dcc7a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified supported Island router CLI commands for diagnostics (`show running-config`, `show stats`, `show ntp status`, etc.).
  * Added guidance on handling unsupported or invalid command responses.

* **Bug Fixes**
  * Improved error detection and help/usage output handling.

* **Refactor**
  * Enhanced command routing to use documented CLI commands.
  * Updated parsing logic for more reliable configuration and status extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->