### PR TITLE
Add Access Networks Unleashed home connector

### DIFF
--- a/docs/contributing/architecture/home-connector.md
+++ b/docs/contributing/architecture/home-connector.md
@@ -33,6 +33,8 @@ The connector exposes these local-device families:
 - Venstar WiFi thermostat status and control over the local REST API
 - Island router diagnostics over SSH using a typed command allowlist plus a tiny
   opt-in set of high-risk write operations
+- Access Networks Unleashed / RUCKUS Unleashed WiFi controller reads and typed
+  high-risk writes over the local AJAX management interface
 
 All surfaces are registered as MCP tools inside the connector and then exposed
 to the Worker through the existing outbound WebSocket session to
@@ -147,8 +149,8 @@ The adapter does expose:
 - a structured `router_diagnose_host` workflow that combines ping, ARP,
   reservation, interface, and log data for one host
 - a broader but still typed and explicitly allowlisted high-risk write surface
-  for failover selection, DHCP reservations, reboot, interface descriptions,
-  DNS servers, host blocking/unblocking, `clear dhcp-client`, `clear log`, and
+  for failover selection, DHCP reservations, reboot, interface descriptions, DNS
+  servers, host blocking/unblocking, `clear dhcp-client`, `clear log`, and
   `write memory` when all write guardrails pass
 
 The adapter explicitly does not expose:
@@ -174,6 +176,36 @@ SSH transport is conservative:
   host fingerprint
 - the Docker image includes the OpenSSH client utilities needed for `ssh`,
   `ssh-keyscan`, and fingerprint verification
+
+## Access Networks Unleashed WiFi integration
+
+The Access Networks Unleashed adapter lives under
+`packages/home-connector/src/adapters/access-networks-unleashed/` and targets
+controllers reachable from the local connector host through the Unleashed AJAX
+management interface. Configure it with:
+
+- `ACCESS_NETWORKS_UNLEASHED_HOST`
+- `ACCESS_NETWORKS_UNLEASHED_USERNAME`
+- `ACCESS_NETWORKS_UNLEASHED_PASSWORD`
+- `ACCESS_NETWORKS_UNLEASHED_ALLOW_INSECURE_TLS=false` when the controller uses
+  a certificate trusted by the connector host. The default allows self-signed
+  LAN certificates.
+- `ACCESS_NETWORKS_UNLEASHED_REQUEST_TIMEOUT_MS` when the default 8s request
+  timeout is too short.
+
+The adapter exposes read-only tools for controller status, access point
+inventory, active clients, WLAN/SSID configuration, and recent events. It also
+exposes a small typed write surface for client block/unblock, WLAN
+enable/disable, AP restart, and AP LED visibility changes.
+
+The write tools are deliberately warning-heavy. Each requires:
+
+- `acknowledgeHighRisk: true`
+- an operator reason
+- an exact operation-specific confirmation phrase
+
+The adapter does not expose arbitrary Unleashed CLI or arbitrary AJAX payload
+execution.
 
 ## Local persistence
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22870,6 +22870,7 @@
         "multicast-dns": "^7.2.3",
         "multicast-dns-service-types": "^1.1.0",
         "remix": "^3.0.0-beta.0",
+        "undici": "^8.2.0",
         "zod": "^4.3.6"
       }
     },
@@ -23121,6 +23122,15 @@
         "redis": {
           "optional": true
         }
+      }
+    },
+    "packages/home-connector/node_modules/undici": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.2.0.tgz",
+      "integrity": "sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "packages/mock-servers/ai": {

--- a/packages/home-connector/package.json
+++ b/packages/home-connector/package.json
@@ -19,6 +19,7 @@
     "multicast-dns": "^7.2.3",
     "multicast-dns-service-types": "^1.1.0",
     "remix": "^3.0.0-beta.0",
+    "undici": "^8.2.0",
     "zod": "^4.3.6"
   }
 }

--- a/packages/home-connector/src/adapters/access-networks-unleashed/client.node.test.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/client.node.test.ts
@@ -249,3 +249,56 @@ test('concurrent reads share one login flow', async () => {
 	)
 	expect(loginAttempts).toHaveLength(1)
 })
+
+test('failed login does not leave a partial session', async () => {
+	const config = createConfig()
+	let rejectedLogin = true
+	const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+		const href = String(url)
+		if (init?.method === 'HEAD' && href === 'https://unleashed.local') {
+			return response(null, {
+				status: 302,
+				headers: { Location: '/admin/wsg/login.jsp' },
+				url: 'https://unleashed.local/',
+			})
+		}
+		if (init?.method === 'HEAD' && href.includes('username=admin')) {
+			if (rejectedLogin) {
+				rejectedLogin = false
+				return response(null, {
+					status: 200,
+					url: href,
+				})
+			}
+			return response(null, {
+				status: 302,
+				headers: {
+					HTTP_X_CSRF_TOKEN: 'csrf-token',
+					'set-cookie': 'JSESSIONID=abc; Path=/admin',
+				},
+				url: href,
+			})
+		}
+		if (init?.method === 'HEAD' && href.endsWith('/admin/wsg/login.jsp')) {
+			return response(null, {
+				status: 200,
+				url: 'https://unleashed.local/admin/wsg/login.jsp',
+			})
+		}
+		if (href.endsWith('/_cmdstat.jsp')) {
+			return response(
+				'<ajax-response><client mac="aa:bb:cc:dd:ee:ff"/></ajax-response>',
+			)
+		}
+		throw new Error(`Unexpected fetch ${href}`)
+	})
+	globalThis.fetch = fetchMock as typeof fetch
+	const client = createAccessNetworksUnleashedAjaxClient({ config })
+
+	await expect(client.listClients()).rejects.toThrow('login was rejected')
+	await expect(client.listClients()).resolves.toEqual([
+		expect.objectContaining({
+			mac: 'aa:bb:cc:dd:ee:ff',
+		}),
+	])
+})

--- a/packages/home-connector/src/adapters/access-networks-unleashed/client.node.test.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/client.node.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { createAccessNetworksUnleashedAjaxClient } from './client.ts'
+import { loadHomeConnectorConfig } from '../../config.ts'
+
+const originalFetch = globalThis.fetch
+
+function createTemporaryEnv(values: Record<string, string | undefined>) {
+	const previousValues = Object.fromEntries(
+		Object.keys(values).map((key) => [key, process.env[key]]),
+	)
+
+	for (const [key, value] of Object.entries(values)) {
+		if (typeof value === 'undefined') {
+			delete process.env[key]
+			continue
+		}
+		process.env[key] = value
+	}
+
+	return {
+		[Symbol.dispose]: () => {
+			for (const [key, value] of Object.entries(previousValues)) {
+				if (typeof value === 'undefined') {
+					delete process.env[key]
+					continue
+				}
+				process.env[key] = value
+			}
+		},
+	}
+}
+
+function response(
+	body: string | null,
+	init: ResponseInit & { url?: string } = {},
+) {
+	const output = new Response(body, init)
+	Object.defineProperty(output, 'url', {
+		value: init.url ?? 'https://unleashed.local/admin/wsg',
+	})
+	return output
+}
+
+function createConfig() {
+	process.env.HOME_CONNECTOR_ID = 'default'
+	process.env.WORKER_BASE_URL = 'http://localhost:3742'
+	process.env.ACCESS_NETWORKS_UNLEASHED_HOST = 'https://unleashed.local'
+	process.env.ACCESS_NETWORKS_UNLEASHED_USERNAME = 'admin'
+	process.env.ACCESS_NETWORKS_UNLEASHED_PASSWORD = 'password'
+	process.env.ACCESS_NETWORKS_UNLEASHED_ALLOW_INSECURE_TLS = 'true'
+	return loadHomeConnectorConfig()
+}
+
+afterEach(() => {
+	globalThis.fetch = originalFetch
+})
+
+test('unblock client preserves unrelated system ACL XML', async () => {
+	using _env = createTemporaryEnv({})
+	const config = createConfig()
+	const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+		const href = String(url)
+		if (init?.method === 'HEAD' && href === 'https://unleashed.local') {
+			return response(null, {
+				status: 302,
+				headers: { Location: '/admin/wsg/login.jsp' },
+				url: 'https://unleashed.local/',
+			})
+		}
+		if (init?.method === 'HEAD' && href.includes('username=admin')) {
+			return response(null, {
+				status: 302,
+				headers: {
+					HTTP_X_CSRF_TOKEN: 'csrf-token',
+					'set-cookie': 'JSESSIONID=abc; Path=/admin',
+				},
+				url: href,
+			})
+		}
+		if (init?.method === 'HEAD' && href.endsWith('/admin/wsg/login.jsp')) {
+			return response(null, {
+				status: 200,
+				url: 'https://unleashed.local/admin/wsg/login.jsp',
+			})
+		}
+		if (href.endsWith('/_conf.jsp')) {
+			const body = String(init?.body ?? '')
+			if (body.includes("action='getconf'")) {
+				return response(
+					[
+						'<ajax-response><acl-list>',
+						"<acl id='1' name='System' description='Keep me' default-mode='allow' EDITABLE='false' custom='preserve'>",
+						"<deny mac='aa:bb:cc:dd:ee:ff' type='single'/>",
+						"<deny mac='11:22:33:44:55:66' type='single'/>",
+						"<allow mac='77:88:99:aa:bb:cc' type='single'/>",
+						'</acl>',
+						'</acl-list></ajax-response>',
+					].join(''),
+				)
+			}
+			return response('<ajax-response><xmsg status="0"/></ajax-response>')
+		}
+		throw new Error(`Unexpected fetch ${href}`)
+	})
+	globalThis.fetch = fetchMock as typeof fetch
+
+	await createAccessNetworksUnleashedAjaxClient({ config }).unblockClient(
+		'aa:bb:cc:dd:ee:ff',
+	)
+
+	const updateBody = fetchMock.mock.calls
+		.map((call) => String(call[1]?.body ?? ''))
+		.find((body) => body.includes("action='updobj'"))
+	expect(updateBody).toContain("custom='preserve'")
+	expect(updateBody).toContain("<allow mac='77:88:99:aa:bb:cc' type='single'/>")
+	expect(updateBody).toContain("<deny mac='11:22:33:44:55:66' type='single'/>")
+	expect(updateBody).not.toContain("<deny mac='aa:bb:cc:dd:ee:ff'")
+})
+
+test('post XML redirects reset session and stop after one reauthentication', async () => {
+	using _env = createTemporaryEnv({})
+	const config = createConfig()
+	const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+		const href = String(url)
+		if (init?.method === 'HEAD' && href === 'https://unleashed.local') {
+			return response(null, {
+				status: 302,
+				headers: { Location: '/admin/wsg/login.jsp' },
+				url: 'https://unleashed.local/',
+			})
+		}
+		if (init?.method === 'HEAD' && href.includes('username=admin')) {
+			return response(null, {
+				status: 302,
+				headers: {
+					HTTP_X_CSRF_TOKEN: 'csrf-token',
+					'set-cookie': 'JSESSIONID=abc; Path=/admin',
+				},
+				url: href,
+			})
+		}
+		if (init?.method === 'HEAD' && href.endsWith('/admin/wsg/login.jsp')) {
+			return response(null, {
+				status: 200,
+				url: 'https://unleashed.local/admin/wsg/login.jsp',
+			})
+		}
+		if (href.endsWith('/_conf.jsp')) {
+			return response(null, { status: 302 })
+		}
+		throw new Error(`Unexpected fetch ${href}`)
+	})
+	globalThis.fetch = fetchMock as typeof fetch
+
+	await expect(
+		createAccessNetworksUnleashedAjaxClient({ config }).listWlans(),
+	).rejects.toThrow('redirected after reauthentication')
+})

--- a/packages/home-connector/src/adapters/access-networks-unleashed/client.node.test.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/client.node.test.ts
@@ -42,12 +42,14 @@ function response(
 }
 
 function createConfig() {
-	process.env.HOME_CONNECTOR_ID = 'default'
-	process.env.WORKER_BASE_URL = 'http://localhost:3742'
-	process.env.ACCESS_NETWORKS_UNLEASHED_HOST = 'https://unleashed.local'
-	process.env.ACCESS_NETWORKS_UNLEASHED_USERNAME = 'admin'
-	process.env.ACCESS_NETWORKS_UNLEASHED_PASSWORD = 'password'
-	process.env.ACCESS_NETWORKS_UNLEASHED_ALLOW_INSECURE_TLS = 'true'
+	using _env = createTemporaryEnv({
+		HOME_CONNECTOR_ID: 'default',
+		WORKER_BASE_URL: 'http://localhost:3742',
+		ACCESS_NETWORKS_UNLEASHED_HOST: 'https://unleashed.local',
+		ACCESS_NETWORKS_UNLEASHED_USERNAME: 'admin',
+		ACCESS_NETWORKS_UNLEASHED_PASSWORD: 'password',
+		ACCESS_NETWORKS_UNLEASHED_ALLOW_INSECURE_TLS: 'true',
+	})
 	return loadHomeConnectorConfig()
 }
 
@@ -118,7 +120,6 @@ test('unblock client preserves unrelated system ACL XML', async () => {
 })
 
 test('post XML redirects reset session and stop after one reauthentication', async () => {
-	using _env = createTemporaryEnv({})
 	const config = createConfig()
 	const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
 		const href = String(url)
@@ -155,4 +156,96 @@ test('post XML redirects reset session and stop after one reauthentication', asy
 	await expect(
 		createAccessNetworksUnleashedAjaxClient({ config }).listWlans(),
 	).rejects.toThrow('redirected after reauthentication')
+})
+
+test('mutating post XML does not retry after session redirect', async () => {
+	const config = createConfig()
+	const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+		const href = String(url)
+		if (init?.method === 'HEAD' && href === 'https://unleashed.local') {
+			return response(null, {
+				status: 302,
+				headers: { Location: '/admin/wsg/login.jsp' },
+				url: 'https://unleashed.local/',
+			})
+		}
+		if (init?.method === 'HEAD' && href.includes('username=admin')) {
+			return response(null, {
+				status: 302,
+				headers: {
+					HTTP_X_CSRF_TOKEN: 'csrf-token',
+					'set-cookie': 'JSESSIONID=abc; Path=/admin',
+				},
+				url: href,
+			})
+		}
+		if (init?.method === 'HEAD' && href.endsWith('/admin/wsg/login.jsp')) {
+			return response(null, {
+				status: 200,
+				url: 'https://unleashed.local/admin/wsg/login.jsp',
+			})
+		}
+		if (href.endsWith('/_cmdstat.jsp')) {
+			return response(null, { status: 302 })
+		}
+		throw new Error(`Unexpected fetch ${href}`)
+	})
+	globalThis.fetch = fetchMock as typeof fetch
+
+	await expect(
+		createAccessNetworksUnleashedAjaxClient({ config }).restartAccessPoint(
+			'24:79:de:ad:be:ef',
+		),
+	).rejects.toThrow('redirected during a command')
+
+	const loginAttempts = fetchMock.mock.calls.filter((call) =>
+		String(call[0]).includes('username=admin'),
+	)
+	expect(loginAttempts).toHaveLength(1)
+})
+
+test('concurrent reads share one login flow', async () => {
+	const config = createConfig()
+	const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+		const href = String(url)
+		if (init?.method === 'HEAD' && href === 'https://unleashed.local') {
+			return response(null, {
+				status: 302,
+				headers: { Location: '/admin/wsg/login.jsp' },
+				url: 'https://unleashed.local/',
+			})
+		}
+		if (init?.method === 'HEAD' && href.includes('username=admin')) {
+			return response(null, {
+				status: 302,
+				headers: {
+					HTTP_X_CSRF_TOKEN: 'csrf-token',
+					'set-cookie': 'JSESSIONID=abc; Path=/admin',
+				},
+				url: href,
+			})
+		}
+		if (init?.method === 'HEAD' && href.endsWith('/admin/wsg/login.jsp')) {
+			await new Promise((resolve) => setTimeout(resolve, 5))
+			return response(null, {
+				status: 200,
+				url: 'https://unleashed.local/admin/wsg/login.jsp',
+			})
+		}
+		if (href.endsWith('/_cmdstat.jsp')) {
+			return response(
+				'<ajax-response><client mac="aa:bb:cc:dd:ee:ff"/></ajax-response>',
+			)
+		}
+		throw new Error(`Unexpected fetch ${href}`)
+	})
+	globalThis.fetch = fetchMock as typeof fetch
+	const client = createAccessNetworksUnleashedAjaxClient({ config })
+
+	await Promise.all([client.listClients(), client.listClients()])
+
+	const loginAttempts = fetchMock.mock.calls.filter((call) =>
+		String(call[0]).includes('username=admin'),
+	)
+	expect(loginAttempts).toHaveLength(1)
 })

--- a/packages/home-connector/src/adapters/access-networks-unleashed/client.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/client.ts
@@ -226,6 +226,7 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 		cookie: null,
 	}
 	const dispatcher = createDispatcher(config)
+	let loginPromise: Promise<void> | null = null
 
 	function requireConfig() {
 		const host = config.accessNetworksUnleashedHost?.trim()
@@ -315,7 +316,10 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 
 	async function ensureSession() {
 		if (state.baseUrl) return
-		await login()
+		loginPromise ??= login().finally(() => {
+			loginPromise = null
+		})
+		await loginPromise
 	}
 
 	function resetSession() {
@@ -329,6 +333,7 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 		path: string,
 		xml: string,
 		timeoutMs?: number,
+		allowRedirectRetry = false,
 		redirectCount = 0,
 	) {
 		await ensureSession()
@@ -347,15 +352,25 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 			timeoutMs,
 		)
 		if (response.status === 302) {
+			resetSession()
+			if (!allowRedirectRetry) {
+				throw new Error(
+					'Access Networks Unleashed redirected during a command. The session was reset; retry after confirming the command did not already apply.',
+				)
+			}
 			if (redirectCount >= 1) {
-				resetSession()
 				throw new Error(
 					'Access Networks Unleashed redirected after reauthentication.',
 				)
 			}
-			resetSession()
 			await ensureSession()
-			return await postXml(path, xml, timeoutMs, redirectCount + 1)
+			return await postXml(
+				path,
+				xml,
+				timeoutMs,
+				allowRedirectRetry,
+				redirectCount + 1,
+			)
 		}
 		const text = await response.text()
 		if (!response.ok) {
@@ -377,7 +392,7 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 	}
 
 	async function cmdstat(xml: string, tagNames: Array<string>) {
-		const response = await postXml('_cmdstat.jsp', xml)
+		const response = await postXml('_cmdstat.jsp', xml, undefined, true)
 		return pickFirstRecords(response, tagNames)
 	}
 
@@ -385,15 +400,10 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 		const response = await postXml(
 			'_conf.jsp',
 			`<ajax-request action='getconf' DECRYPT_X='true' updater='${escapeXmlAttribute(component)}.0.5' comp='${escapeXmlAttribute(component)}'/>`,
+			undefined,
+			true,
 		)
 		return pickFirstRecords(response, tagNames)
-	}
-
-	async function getConfXml(component: string) {
-		return await postXml(
-			'_conf.jsp',
-			`<ajax-request action='getconf' DECRYPT_X='true' updater='${escapeXmlAttribute(component)}.0.5' comp='${escapeXmlAttribute(component)}'/>`,
-		)
 	}
 
 	async function findWlan(name: string) {
@@ -456,6 +466,8 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 			const aclResponse = await postXml(
 				'_conf.jsp',
 				"<ajax-request action='getconf' DECRYPT_X='true' updater='acl-list.0.5' comp='acl-list'/>",
+				undefined,
+				true,
 			)
 			const rawXml = extractElementByAttribute({
 				xml: aclResponse,

--- a/packages/home-connector/src/adapters/access-networks-unleashed/client.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/client.ts
@@ -269,6 +269,7 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 
 	async function login() {
 		const credentials = requireConfig()
+		let csrfToken: string | null = null
 		const head = await request(credentials.host, { method: 'HEAD' }, 3_000)
 		const location = head.headers.get('location')
 		if (!location) {
@@ -277,8 +278,7 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 			)
 		}
 		const loginUrl = new URL(location, head.url || credentials.host).toString()
-		state.loginUrl = loginUrl
-		state.baseUrl = new URL('.', loginUrl).toString().replace(/\/$/, '')
+		const baseUrl = new URL('.', loginUrl).toString().replace(/\/$/, '')
 		const login = await request(loginUrl, {
 			method: 'HEAD',
 			headers: {
@@ -300,18 +300,18 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 			loginResult.headers.get('HTTP_X_CSRF_TOKEN') ??
 			loginResult.headers.get('x-csrf-token')
 		if (csrfHeader) {
-			state.csrfToken = csrfHeader
-		} else if (state.baseUrl) {
-			const tokenResponse = await request(
-				`${state.baseUrl}/_csrfTokenVar.jsp`,
-				{
-					method: 'GET',
-				},
-			)
+			csrfToken = csrfHeader
+		} else {
+			const tokenResponse = await request(`${baseUrl}/_csrfTokenVar.jsp`, {
+				method: 'GET',
+			})
 			if (tokenResponse.ok) {
-				state.csrfToken = extractCsrfToken(await tokenResponse.text())
+				csrfToken = extractCsrfToken(await tokenResponse.text())
 			}
 		}
+		state.loginUrl = loginUrl
+		state.baseUrl = baseUrl
+		state.csrfToken = csrfToken
 	}
 
 	async function ensureSession() {

--- a/packages/home-connector/src/adapters/access-networks-unleashed/client.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/client.ts
@@ -69,7 +69,7 @@ function parseAttributes(value: string): AccessNetworksUnleashedRecord {
 function parseElements(xml: string, tagName: string) {
 	const records: Array<AccessNetworksUnleashedRecord> = []
 	const elementRegex = new RegExp(
-		`<${tagName}\\b(?<attributes>[^>]*)>(?<body>[\\s\\S]*?)<\\/${tagName}>|<${tagName}\\b(?<selfClosingAttributes>[^>]*)\\/>`,
+		`<${tagName}(?=[\\s>/])(?<attributes>[^>]*)>(?<body>[\\s\\S]*?)<\\/${tagName}>|<${tagName}(?=[\\s>/])(?<selfClosingAttributes>[^>]*)\\/>`,
 		'gi',
 	)
 	for (const match of xml.matchAll(elementRegex)) {
@@ -83,7 +83,7 @@ function parseElements(xml: string, tagName: string) {
 			rawXml?: string
 		}
 		record.rawXml = match[0]
-		const childRegex = /<([:\w-]+)\b[^>]*>([\s\S]*?)<\/\1>/g
+		const childRegex = /<([:\w-]+)(?=[\s>/])[^>]*>([\s\S]*?)<\/\1>/g
 		for (const childMatch of body.matchAll(childRegex)) {
 			const key = normalizeFieldName(childMatch[1] ?? '')
 			if (!key || key in record) continue
@@ -102,6 +102,29 @@ function pickFirstRecords(xml: string, tagNames: Array<string>) {
 		if (records.length > 0) return records
 	}
 	return []
+}
+
+function extractElementByAttribute(input: {
+	xml: string
+	tagName: string
+	attributeName: string
+	attributeValue: string
+}) {
+	const elementRegex = new RegExp(
+		`<${input.tagName}(?=[\\s>/])(?<attributes>[^>]*)>(?<body>[\\s\\S]*?)<\\/${input.tagName}>|<${input.tagName}(?=[\\s>/])(?<selfClosingAttributes>[^>]*)\\/>`,
+		'gi',
+	)
+	for (const match of input.xml.matchAll(elementRegex)) {
+		const attributes =
+			match.groups?.['attributes'] ??
+			match.groups?.['selfClosingAttributes'] ??
+			''
+		const record = parseAttributes(attributes)
+		if (String(record[input.attributeName] ?? '') === input.attributeValue) {
+			return match[0]
+		}
+	}
+	return null
 }
 
 function escapeXmlAttribute(value: string) {
@@ -170,7 +193,7 @@ function createDispatcher(config: HomeConnectorConfig) {
 	if (!config.accessNetworksUnleashedAllowInsecureTls) return undefined
 	return new Agent({
 		connect: {
-			rejectUnauthorized: false,
+			rejectUnauthorized: !config.accessNetworksUnleashedAllowInsecureTls,
 		},
 	})
 }
@@ -295,7 +318,19 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 		await login()
 	}
 
-	async function postXml(path: string, xml: string, timeoutMs?: number) {
+	function resetSession() {
+		state.baseUrl = null
+		state.loginUrl = null
+		state.csrfToken = null
+		state.cookie = null
+	}
+
+	async function postXml(
+		path: string,
+		xml: string,
+		timeoutMs?: number,
+		redirectCount = 0,
+	) {
 		await ensureSession()
 		if (!state.baseUrl)
 			throw new Error('Access Networks Unleashed session has no base URL.')
@@ -312,9 +347,15 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 			timeoutMs,
 		)
 		if (response.status === 302) {
-			state.baseUrl = null
+			if (redirectCount >= 1) {
+				resetSession()
+				throw new Error(
+					'Access Networks Unleashed redirected after reauthentication.',
+				)
+			}
+			resetSession()
 			await ensureSession()
-			return await postXml(path, xml, timeoutMs)
+			return await postXml(path, xml, timeoutMs, redirectCount + 1)
 		}
 		const text = await response.text()
 		if (!response.ok) {
@@ -346,6 +387,13 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 			`<ajax-request action='getconf' DECRYPT_X='true' updater='${escapeXmlAttribute(component)}.0.5' comp='${escapeXmlAttribute(component)}'/>`,
 		)
 		return pickFirstRecords(response, tagNames)
+	}
+
+	async function getConfXml(component: string) {
+		return await postXml(
+			'_conf.jsp',
+			`<ajax-request action='getconf' DECRYPT_X='true' updater='${escapeXmlAttribute(component)}.0.5' comp='${escapeXmlAttribute(component)}'/>`,
+		)
 	}
 
 	async function findWlan(name: string) {
@@ -404,24 +452,28 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 			)
 		},
 		async unblockClient(macAddress) {
-			const mac = escapeXmlAttribute(macAddress.toLowerCase())
-			const aclRecords = await getConf('acl-list', ['acl'])
-			const systemAcl = aclRecords.find(
-				(acl) => String(acl['id'] ?? '') === '1',
+			const mac = macAddress.toLowerCase()
+			const aclResponse = await postXml(
+				'_conf.jsp',
+				"<ajax-request action='getconf' DECRYPT_X='true' updater='acl-list.0.5' comp='acl-list'/>",
 			)
-			const existingDenied = systemAcl
-				? parseElements(String(systemAcl['raw_xml'] ?? ''), 'deny')
-				: []
-			const remaining = existingDenied
-				.filter((deny) => String(deny['mac'] ?? '').toLowerCase() !== mac)
-				.map(
-					(deny) =>
-						`<deny mac='${escapeXmlAttribute(String(deny['mac'] ?? ''))}' type='single'/>`,
-				)
-				.join('')
+			const rawXml = extractElementByAttribute({
+				xml: aclResponse,
+				tagName: 'acl',
+				attributeName: 'id',
+				attributeValue: '1',
+			})
+			if (!rawXml) {
+				throw new Error('Access Networks Unleashed system ACL was not found.')
+			}
+			const updatedAclXml = rawXml.replace(
+				/<deny\b[^>]*\bmac\s*=\s*(["'])(?<mac>.*?)\1[^>]*\/?>/gi,
+				(match, _quote, deniedMac: string) =>
+					deniedMac.toLowerCase() === mac ? '' : match,
+			)
 			await postXml(
 				'_conf.jsp',
-				`<ajax-request action='updobj' comp='acl-list' updater='blocked-clients'><acl id='1' name='System' description='System' default-mode='allow' EDITABLE='false'>${remaining}</acl></ajax-request>`,
+				`<ajax-request action='updobj' comp='acl-list' updater='blocked-clients'>${updatedAclXml}</ajax-request>`,
 			)
 		},
 		async setWlanEnabled(name, enabled) {

--- a/packages/home-connector/src/adapters/access-networks-unleashed/client.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/client.ts
@@ -1,0 +1,460 @@
+import { Agent } from 'undici'
+import { type HomeConnectorConfig } from '../../config.ts'
+import {
+	type AccessNetworksUnleashedClient,
+	type AccessNetworksUnleashedRecord,
+} from './types.ts'
+
+type SessionState = {
+	baseUrl: string | null
+	loginUrl: string | null
+	csrfToken: string | null
+	cookie: string | null
+}
+
+const xmlEntityMap: Record<string, string> = {
+	amp: '&',
+	lt: '<',
+	gt: '>',
+	quot: '"',
+	apos: "'",
+}
+
+function decodeXmlEntities(value: string) {
+	return value.replace(
+		/&(#x?[0-9a-f]+|amp|lt|gt|quot|apos);/gi,
+		(match, entity) => {
+			const normalized = String(entity).toLowerCase()
+			if (normalized.startsWith('#x')) {
+				return String.fromCodePoint(Number.parseInt(normalized.slice(2), 16))
+			}
+			if (normalized.startsWith('#')) {
+				return String.fromCodePoint(Number.parseInt(normalized.slice(1), 10))
+			}
+			return xmlEntityMap[normalized] ?? match
+		},
+	)
+}
+
+function normalizeFieldName(value: string) {
+	return value
+		.trim()
+		.replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+		.replace(/[^a-zA-Z0-9]+/g, '_')
+		.replace(/^_+|_+$/g, '')
+		.toLowerCase()
+}
+
+function parseScalar(value: string): string | number | boolean | null {
+	const trimmed = decodeXmlEntities(value.trim())
+	if (!trimmed) return null
+	if (/^-?\d+$/.test(trimmed)) return Number.parseInt(trimmed, 10)
+	if (/^-?\d+\.\d+$/.test(trimmed)) return Number.parseFloat(trimmed)
+	if (/^(true|enabled|yes)$/i.test(trimmed)) return true
+	if (/^(false|disabled|no)$/i.test(trimmed)) return false
+	return trimmed
+}
+
+function parseAttributes(value: string): AccessNetworksUnleashedRecord {
+	const record: AccessNetworksUnleashedRecord = {}
+	const attributeRegex = /([:\w-]+)\s*=\s*(["'])(.*?)\2/gs
+	for (const match of value.matchAll(attributeRegex)) {
+		const key = normalizeFieldName(match[1] ?? '')
+		if (!key) continue
+		record[key] = parseScalar(match[3] ?? '')
+	}
+	return record
+}
+
+function parseElements(xml: string, tagName: string) {
+	const records: Array<AccessNetworksUnleashedRecord> = []
+	const elementRegex = new RegExp(
+		`<${tagName}\\b(?<attributes>[^>]*)>(?<body>[\\s\\S]*?)<\\/${tagName}>|<${tagName}\\b(?<selfClosingAttributes>[^>]*)\\/>`,
+		'gi',
+	)
+	for (const match of xml.matchAll(elementRegex)) {
+		const groups = match.groups ?? {}
+		const attributes =
+			groups['attributes'] ?? groups['selfClosingAttributes'] ?? ''
+		const body = groups['body'] ?? ''
+		const record = parseAttributes(
+			attributes,
+		) as AccessNetworksUnleashedRecord & {
+			rawXml?: string
+		}
+		record.rawXml = match[0]
+		const childRegex = /<([:\w-]+)\b[^>]*>([\s\S]*?)<\/\1>/g
+		for (const childMatch of body.matchAll(childRegex)) {
+			const key = normalizeFieldName(childMatch[1] ?? '')
+			if (!key || key in record) continue
+			const childBody = childMatch[2] ?? ''
+			if (/<[a-zA-Z]/.test(childBody)) continue
+			record[key] = parseScalar(childBody)
+		}
+		records.push(record)
+	}
+	return records
+}
+
+function pickFirstRecords(xml: string, tagNames: Array<string>) {
+	for (const tagName of tagNames) {
+		const records = parseElements(xml, tagName)
+		if (records.length > 0) return records
+	}
+	return []
+}
+
+function escapeXmlAttribute(value: string) {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&apos;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+}
+
+function normalizeHost(host: string) {
+	const trimmed = host.trim()
+	if (/^https?:\/\//i.test(trimmed)) return trimmed.replace(/\/+$/, '')
+	return `https://${trimmed.replace(/\/+$/, '')}`
+}
+
+export function normalizeAccessNetworksUnleashedMacAddress(value: string) {
+	const cleaned = value
+		.trim()
+		.toLowerCase()
+		.replace(/[^0-9a-f]/g, '')
+	if (cleaned.length !== 12) {
+		throw new Error('macAddress must be a valid 12-hex-digit MAC address.')
+	}
+	const octets = cleaned.match(/.{2}/g)
+	if (!octets) {
+		throw new Error('macAddress must be a valid MAC address.')
+	}
+	return octets.join(':')
+}
+
+function collectCookies(headers: Headers, existing: string | null) {
+	const cookies = new Map<string, string>()
+	if (existing) {
+		for (const cookie of existing.split(';')) {
+			const [name, ...rest] = cookie.trim().split('=')
+			if (name && rest.length > 0) cookies.set(name, rest.join('='))
+		}
+	}
+	const setCookie =
+		typeof headers.getSetCookie === 'function'
+			? headers.getSetCookie()
+			: headers.get('set-cookie')
+				? [headers.get('set-cookie') ?? '']
+				: []
+	for (const cookieHeader of setCookie) {
+		const [cookie] = cookieHeader.split(';')
+		const [name, ...rest] = cookie.trim().split('=')
+		if (name && rest.length > 0) cookies.set(name, rest.join('='))
+	}
+	return [...cookies.entries()]
+		.map(([name, value]) => `${name}=${value}`)
+		.join('; ')
+}
+
+function extractCsrfToken(text: string) {
+	const match =
+		/HTTP_X_CSRF_TOKEN["']?\s*[:=]\s*["']([^"']+)["']/i.exec(text) ??
+		/X-CSRF-Token["']?\s*[:=]\s*["']([^"']+)["']/i.exec(text) ??
+		/([a-zA-Z0-9]{10,})/.exec(text)
+	return match?.[1] ?? null
+}
+
+function createDispatcher(config: HomeConnectorConfig) {
+	if (!config.accessNetworksUnleashedAllowInsecureTls) return undefined
+	return new Agent({
+		connect: {
+			rejectUnauthorized: false,
+		},
+	})
+}
+
+async function fetchWithTimeout(input: {
+	url: string
+	init?: RequestInit
+	timeoutMs: number
+}) {
+	const controller = new AbortController()
+	const timeout = setTimeout(() => controller.abort(), input.timeoutMs)
+	try {
+		return await fetch(input.url, {
+			...input.init,
+			signal: controller.signal,
+		})
+	} finally {
+		clearTimeout(timeout)
+	}
+}
+
+export function createAccessNetworksUnleashedAjaxClient(input: {
+	config: HomeConnectorConfig
+}) {
+	const { config } = input
+	const state: SessionState = {
+		baseUrl: null,
+		loginUrl: null,
+		csrfToken: null,
+		cookie: null,
+	}
+	const dispatcher = createDispatcher(config)
+
+	function requireConfig() {
+		const host = config.accessNetworksUnleashedHost?.trim()
+		const username = config.accessNetworksUnleashedUsername?.trim()
+		const password = config.accessNetworksUnleashedPassword?.trim()
+		if (!host || !username || !password) {
+			throw new Error(
+				'Access Networks Unleashed is not configured. Set ACCESS_NETWORKS_UNLEASHED_HOST, ACCESS_NETWORKS_UNLEASHED_USERNAME, and ACCESS_NETWORKS_UNLEASHED_PASSWORD on the home connector.',
+			)
+		}
+		return {
+			host: normalizeHost(host),
+			username,
+			password,
+		}
+	}
+
+	async function request(
+		url: string,
+		init: RequestInit = {},
+		timeoutMs = config.accessNetworksUnleashedRequestTimeoutMs,
+	) {
+		const headers = new Headers(init.headers)
+		if (state.cookie) headers.set('Cookie', state.cookie)
+		if (state.csrfToken) headers.set('X-CSRF-Token', state.csrfToken)
+		const response = await fetchWithTimeout({
+			url,
+			timeoutMs,
+			init: {
+				...init,
+				headers,
+				redirect: 'manual',
+				// Undici-specific option used only by Node fetch.
+				dispatcher,
+			} as RequestInit,
+		})
+		state.cookie = collectCookies(response.headers, state.cookie)
+		return response
+	}
+
+	async function login() {
+		const credentials = requireConfig()
+		const head = await request(credentials.host, { method: 'HEAD' }, 3_000)
+		const location = head.headers.get('location')
+		if (!location) {
+			throw new Error(
+				'Access Networks Unleashed login did not return an admin redirect.',
+			)
+		}
+		const loginUrl = new URL(location, head.url || credentials.host).toString()
+		state.loginUrl = loginUrl
+		state.baseUrl = new URL('.', loginUrl).toString().replace(/\/$/, '')
+		const login = await request(loginUrl, {
+			method: 'HEAD',
+			headers: {
+				Accept: '*/*',
+			},
+			body: null,
+		})
+		const loginWithParams = new URL(login.url || loginUrl)
+		loginWithParams.searchParams.set('username', credentials.username)
+		loginWithParams.searchParams.set('password', credentials.password)
+		loginWithParams.searchParams.set('ok', 'Log In')
+		const loginResult = await request(loginWithParams.toString(), {
+			method: 'HEAD',
+		})
+		if (loginResult.status === 200) {
+			throw new Error('Access Networks Unleashed login was rejected.')
+		}
+		const csrfHeader =
+			loginResult.headers.get('HTTP_X_CSRF_TOKEN') ??
+			loginResult.headers.get('x-csrf-token')
+		if (csrfHeader) {
+			state.csrfToken = csrfHeader
+		} else if (state.baseUrl) {
+			const tokenResponse = await request(
+				`${state.baseUrl}/_csrfTokenVar.jsp`,
+				{
+					method: 'GET',
+				},
+			)
+			if (tokenResponse.ok) {
+				state.csrfToken = extractCsrfToken(await tokenResponse.text())
+			}
+		}
+	}
+
+	async function ensureSession() {
+		if (state.baseUrl) return
+		await login()
+	}
+
+	async function postXml(path: string, xml: string, timeoutMs?: number) {
+		await ensureSession()
+		if (!state.baseUrl)
+			throw new Error('Access Networks Unleashed session has no base URL.')
+		const response = await request(
+			`${state.baseUrl}/${path.replace(/^\/+/, '')}`,
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'text/xml',
+					Accept: 'text/xml, */*',
+				},
+				body: xml,
+			},
+			timeoutMs,
+		)
+		if (response.status === 302) {
+			state.baseUrl = null
+			await ensureSession()
+			return await postXml(path, xml, timeoutMs)
+		}
+		const text = await response.text()
+		if (!response.ok) {
+			throw new Error(
+				`Access Networks Unleashed request failed with HTTP ${response.status}: ${text.trim()}`,
+			)
+		}
+		if (!text.trim()) {
+			throw new Error('Access Networks Unleashed returned an empty response.')
+		}
+		if (
+			/<xmsg\b[^>]*\b(?:error|status)=["'](?:1|true|error|failed)["']/i.test(
+				text,
+			)
+		) {
+			throw new Error(`Access Networks Unleashed rejected the command: ${text}`)
+		}
+		return text
+	}
+
+	async function cmdstat(xml: string, tagNames: Array<string>) {
+		const response = await postXml('_cmdstat.jsp', xml)
+		return pickFirstRecords(response, tagNames)
+	}
+
+	async function getConf(component: string, tagNames: Array<string>) {
+		const response = await postXml(
+			'_conf.jsp',
+			`<ajax-request action='getconf' DECRYPT_X='true' updater='${escapeXmlAttribute(component)}.0.5' comp='${escapeXmlAttribute(component)}'/>`,
+		)
+		return pickFirstRecords(response, tagNames)
+	}
+
+	async function findWlan(name: string) {
+		const wlans = await getConf('wlansvc-list', ['wlansvc'])
+		return wlans.find((wlan) => String(wlan['name'] ?? '') === name) ?? null
+	}
+
+	async function findAp(macAddress: string) {
+		const normalized = macAddress.toLowerCase()
+		const aps = await getConf('ap-list', ['ap'])
+		return (
+			aps.find(
+				(ap) =>
+					String(ap['mac'] ?? ap['mac_address'] ?? '').toLowerCase() ===
+					normalized,
+			) ?? null
+		)
+	}
+
+	const client: AccessNetworksUnleashedClient = {
+		async getSystemInfo() {
+			const records = await cmdstat(
+				"<ajax-request action='getstat' comp='system'><identity/><sysinfo/><unleashed-network/></ajax-request>",
+				['system', 'identity', 'sysinfo', 'unleashed-network'],
+			)
+			return records[0] ?? {}
+		},
+		async listClients() {
+			return await cmdstat(
+				"<ajax-request action='getstat' comp='stamgr' enable-gzip='0'><client LEVEL='1' /></ajax-request>",
+				['client'],
+			)
+		},
+		async listAccessPoints() {
+			const stats = await cmdstat(
+				"<ajax-request action='getstat' comp='stamgr' enable-gzip='0'><ap LEVEL='1' /></ajax-request>",
+				['ap'],
+			)
+			return stats.length > 0 ? stats : await getConf('ap-list', ['ap'])
+		},
+		async listWlans() {
+			return await getConf('wlansvc-list', ['wlansvc'])
+		},
+		async listEvents(limit = 50) {
+			const records = await cmdstat(
+				"<ajax-request action='getstat' comp='eventd'><xevent /></ajax-request>",
+				['xevent', 'event'],
+			)
+			return records.slice(0, Math.max(1, Math.min(300, Math.trunc(limit))))
+		},
+		async blockClient(macAddress) {
+			const mac = escapeXmlAttribute(macAddress.toLowerCase())
+			await postXml(
+				'_cmdstat.jsp',
+				`<ajax-request action='docmd' xcmd='block' checkAbility='10' comp='stamgr'><xcmd check-ability='10' tag='client' acl-id='1' client='${mac}' cmd='block'><client client='${mac}' acl-id='1' hostname=''></client></xcmd></ajax-request>`,
+			)
+		},
+		async unblockClient(macAddress) {
+			const mac = escapeXmlAttribute(macAddress.toLowerCase())
+			const aclRecords = await getConf('acl-list', ['acl'])
+			const systemAcl = aclRecords.find(
+				(acl) => String(acl['id'] ?? '') === '1',
+			)
+			const existingDenied = systemAcl
+				? parseElements(String(systemAcl['raw_xml'] ?? ''), 'deny')
+				: []
+			const remaining = existingDenied
+				.filter((deny) => String(deny['mac'] ?? '').toLowerCase() !== mac)
+				.map(
+					(deny) =>
+						`<deny mac='${escapeXmlAttribute(String(deny['mac'] ?? ''))}' type='single'/>`,
+				)
+				.join('')
+			await postXml(
+				'_conf.jsp',
+				`<ajax-request action='updobj' comp='acl-list' updater='blocked-clients'><acl id='1' name='System' description='System' default-mode='allow' EDITABLE='false'>${remaining}</acl></ajax-request>`,
+			)
+		},
+		async setWlanEnabled(name, enabled) {
+			const wlan = await findWlan(name)
+			if (!wlan)
+				throw new Error(
+					`Access Networks Unleashed WLAN "${name}" was not found.`,
+				)
+			await postXml(
+				'_conf.jsp',
+				`<ajax-request action='updobj' updater='wlansvc-list.${Date.now()}' comp='wlansvc-list'><wlansvc id='${escapeXmlAttribute(String(wlan['id'] ?? ''))}' name='${escapeXmlAttribute(String(wlan['name'] ?? name))}' enable-type='${enabled ? 0 : 1}' IS_PARTIAL='true'/></ajax-request>`,
+			)
+		},
+		async restartAccessPoint(macAddress) {
+			const mac = escapeXmlAttribute(macAddress.toLowerCase())
+			await postXml(
+				'_cmdstat.jsp',
+				`<ajax-request action='docmd' xcmd='reset' checkAbility='2' updater='stamgr.${Date.now()}' comp='stamgr'><xcmd cmd='reset' ap='${mac}' tag='ap' checkAbility='2'/></ajax-request>`,
+			)
+		},
+		async setAccessPointLeds(macAddress, enabled) {
+			const ap = await findAp(macAddress)
+			if (!ap) {
+				throw new Error(
+					`Access Networks Unleashed access point "${macAddress}" was not found.`,
+				)
+			}
+			await postXml(
+				'_conf.jsp',
+				`<ajax-request action='updobj' updater='ap-list.${Date.now()}' comp='ap-list'><ap id='${escapeXmlAttribute(String(ap['id'] ?? ''))}' IS_PARTIAL='true' led-off='${enabled ? 'false' : 'true'}' /></ajax-request>`,
+			)
+		},
+	}
+
+	return client
+}

--- a/packages/home-connector/src/adapters/access-networks-unleashed/index.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/index.ts
@@ -1,0 +1,283 @@
+import { type HomeConnectorConfig } from '../../config.ts'
+import {
+	createAccessNetworksUnleashedAjaxClient,
+	normalizeAccessNetworksUnleashedMacAddress,
+} from './client.ts'
+import {
+	type AccessNetworksUnleashedClient,
+	type AccessNetworksUnleashedConfigStatus,
+	type AccessNetworksUnleashedRecord,
+	type AccessNetworksUnleashedSystemStatus,
+	type AccessNetworksUnleashedWriteOperationId,
+	type AccessNetworksUnleashedWriteOperationResult,
+} from './types.ts'
+
+type WriteOperationRequest = {
+	acknowledgeHighRisk: boolean
+	reason: string
+	confirmation: string
+}
+
+type ClientWriteRequest = WriteOperationRequest & {
+	macAddress: string
+}
+
+type WlanWriteRequest = WriteOperationRequest & {
+	name: string
+}
+
+type AccessPointWriteRequest = WriteOperationRequest & {
+	macAddress: string
+}
+
+type SetAccessPointLedsRequest = AccessPointWriteRequest & {
+	enabled: boolean
+}
+
+const accessNetworksUnleashedWriteAcknowledgements = {
+	blockClient:
+		'I am highly certain blocking this WiFi client on Access Networks Unleashed is necessary right now.',
+	unblockClient:
+		'I am highly certain unblocking this WiFi client on Access Networks Unleashed is necessary right now.',
+	enableWlan:
+		'I am highly certain enabling this Access Networks Unleashed WLAN is necessary right now.',
+	disableWlan:
+		'I am highly certain disabling this Access Networks Unleashed WLAN is necessary right now.',
+	restartAccessPoint:
+		'I am highly certain restarting this Access Networks Unleashed access point is necessary right now.',
+	setAccessPointLeds:
+		'I am highly certain changing this Access Networks Unleashed access point LED setting is necessary right now.',
+} as const
+
+function getConfigStatus(
+	config: HomeConnectorConfig,
+): AccessNetworksUnleashedConfigStatus {
+	const missingFields: Array<string> = []
+	if (!config.accessNetworksUnleashedHost) {
+		missingFields.push('ACCESS_NETWORKS_UNLEASHED_HOST')
+	}
+	if (!config.accessNetworksUnleashedUsername) {
+		missingFields.push('ACCESS_NETWORKS_UNLEASHED_USERNAME')
+	}
+	if (!config.accessNetworksUnleashedPassword) {
+		missingFields.push('ACCESS_NETWORKS_UNLEASHED_PASSWORD')
+	}
+	return {
+		configured: missingFields.length === 0,
+		host: config.accessNetworksUnleashedHost,
+		usernameConfigured: Boolean(config.accessNetworksUnleashedUsername),
+		passwordConfigured: Boolean(config.accessNetworksUnleashedPassword),
+		allowInsecureTls: config.accessNetworksUnleashedAllowInsecureTls,
+		missingFields,
+	}
+}
+
+function assertConfigured(config: HomeConnectorConfig) {
+	const status = getConfigStatus(config)
+	if (!status.configured) {
+		throw new Error(
+			`Access Networks Unleashed is not configured. Missing: ${status.missingFields.join(', ')}.`,
+		)
+	}
+}
+
+function normalizeLimit(
+	value: number | undefined,
+	fallback: number,
+	max: number,
+) {
+	if (value == null || !Number.isFinite(value)) return fallback
+	return Math.max(1, Math.min(max, Math.trunc(value)))
+}
+
+function assertNonEmpty(value: string, field: string) {
+	const trimmed = value.trim()
+	if (!trimmed) throw new Error(`${field} must not be empty.`)
+	return trimmed
+}
+
+function assertWriteAllowed(
+	request: WriteOperationRequest,
+	expectedConfirmation: string,
+) {
+	if (!request.acknowledgeHighRisk) {
+		throw new Error('acknowledgeHighRisk must be true for this WiFi mutation.')
+	}
+	const reason = request.reason.trim()
+	if (reason.length < 20) {
+		throw new Error('reason must be at least 20 characters.')
+	}
+	if (request.confirmation !== expectedConfirmation) {
+		throw new Error(`confirmation must exactly equal: ${expectedConfirmation}`)
+	}
+	return reason
+}
+
+function writeResult(input: {
+	operation: AccessNetworksUnleashedWriteOperationId
+	target: string
+	reason: string
+}): AccessNetworksUnleashedWriteOperationResult {
+	return {
+		operation: input.operation,
+		target: input.target,
+		reason: input.reason,
+		completedAt: new Date().toISOString(),
+	}
+}
+
+export function createAccessNetworksUnleashedAdapter(input: {
+	config: HomeConnectorConfig
+	client?: AccessNetworksUnleashedClient
+}) {
+	const { config } = input
+	const client =
+		input.client ?? createAccessNetworksUnleashedAjaxClient({ config })
+
+	async function read<T>(operation: () => Promise<T>) {
+		assertConfigured(config)
+		return await operation()
+	}
+
+	return {
+		writeAcknowledgements: accessNetworksUnleashedWriteAcknowledgements,
+		getConfigStatus() {
+			return getConfigStatus(config)
+		},
+		async getStatus(): Promise<AccessNetworksUnleashedSystemStatus> {
+			const configStatus = getConfigStatus(config)
+			if (!configStatus.configured) {
+				return {
+					config: configStatus,
+					system: {},
+					aps: [],
+					wlans: [],
+					clients: [],
+					events: [],
+				}
+			}
+			const [system, aps, wlans, clients, events] = await Promise.all([
+				client.getSystemInfo(),
+				client.listAccessPoints(),
+				client.listWlans(),
+				client.listClients(),
+				client.listEvents(25),
+			])
+			return {
+				config: configStatus,
+				system,
+				aps,
+				wlans,
+				clients,
+				events,
+			}
+		},
+		async getSystemInfo(): Promise<AccessNetworksUnleashedRecord> {
+			return await read(() => client.getSystemInfo())
+		},
+		async listAccessPoints() {
+			return await read(() => client.listAccessPoints())
+		},
+		async listClients() {
+			return await read(() => client.listClients())
+		},
+		async listWlans() {
+			return await read(() => client.listWlans())
+		},
+		async listEvents(limit?: number) {
+			return await read(() => client.listEvents(normalizeLimit(limit, 50, 300)))
+		},
+		async blockClient(request: ClientWriteRequest) {
+			assertConfigured(config)
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.blockClient,
+			)
+			const macAddress = normalizeAccessNetworksUnleashedMacAddress(
+				request.macAddress,
+			)
+			await read(() => client.blockClient(macAddress))
+			return writeResult({
+				operation: 'block-client',
+				target: macAddress,
+				reason,
+			})
+		},
+		async unblockClient(request: ClientWriteRequest) {
+			assertConfigured(config)
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.unblockClient,
+			)
+			const macAddress = normalizeAccessNetworksUnleashedMacAddress(
+				request.macAddress,
+			)
+			await read(() => client.unblockClient(macAddress))
+			return writeResult({
+				operation: 'unblock-client',
+				target: macAddress,
+				reason,
+			})
+		},
+		async enableWlan(request: WlanWriteRequest) {
+			assertConfigured(config)
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.enableWlan,
+			)
+			const name = assertNonEmpty(request.name, 'name')
+			await read(() => client.setWlanEnabled(name, true))
+			return writeResult({
+				operation: 'enable-wlan',
+				target: name,
+				reason,
+			})
+		},
+		async disableWlan(request: WlanWriteRequest) {
+			assertConfigured(config)
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.disableWlan,
+			)
+			const name = assertNonEmpty(request.name, 'name')
+			await read(() => client.setWlanEnabled(name, false))
+			return writeResult({
+				operation: 'disable-wlan',
+				target: name,
+				reason,
+			})
+		},
+		async restartAccessPoint(request: AccessPointWriteRequest) {
+			assertConfigured(config)
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.restartAccessPoint,
+			)
+			const macAddress = normalizeAccessNetworksUnleashedMacAddress(
+				request.macAddress,
+			)
+			await read(() => client.restartAccessPoint(macAddress))
+			return writeResult({
+				operation: 'restart-ap',
+				target: macAddress,
+				reason,
+			})
+		},
+		async setAccessPointLeds(request: SetAccessPointLedsRequest) {
+			assertConfigured(config)
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.setAccessPointLeds,
+			)
+			const macAddress = normalizeAccessNetworksUnleashedMacAddress(
+				request.macAddress,
+			)
+			await read(() => client.setAccessPointLeds(macAddress, request.enabled))
+			return writeResult({
+				operation: 'set-ap-leds',
+				target: macAddress,
+				reason,
+			})
+		},
+	}
+}

--- a/packages/home-connector/src/adapters/access-networks-unleashed/types.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/types.ts
@@ -1,0 +1,50 @@
+export type AccessNetworksUnleashedConfigStatus = {
+	configured: boolean
+	host: string | null
+	usernameConfigured: boolean
+	passwordConfigured: boolean
+	allowInsecureTls: boolean
+	missingFields: Array<string>
+}
+
+export type AccessNetworksUnleashedRecord = Record<
+	string,
+	string | number | boolean | null
+>
+
+export type AccessNetworksUnleashedSystemStatus = {
+	config: AccessNetworksUnleashedConfigStatus
+	system: AccessNetworksUnleashedRecord
+	aps: Array<AccessNetworksUnleashedRecord>
+	wlans: Array<AccessNetworksUnleashedRecord>
+	clients: Array<AccessNetworksUnleashedRecord>
+	events: Array<AccessNetworksUnleashedRecord>
+}
+
+export type AccessNetworksUnleashedWriteOperationId =
+	| 'block-client'
+	| 'unblock-client'
+	| 'enable-wlan'
+	| 'disable-wlan'
+	| 'restart-ap'
+	| 'set-ap-leds'
+
+export type AccessNetworksUnleashedWriteOperationResult = {
+	operation: AccessNetworksUnleashedWriteOperationId
+	target: string
+	reason: string
+	completedAt: string
+}
+
+export type AccessNetworksUnleashedClient = {
+	getSystemInfo(): Promise<AccessNetworksUnleashedRecord>
+	listClients(): Promise<Array<AccessNetworksUnleashedRecord>>
+	listAccessPoints(): Promise<Array<AccessNetworksUnleashedRecord>>
+	listWlans(): Promise<Array<AccessNetworksUnleashedRecord>>
+	listEvents(limit?: number): Promise<Array<AccessNetworksUnleashedRecord>>
+	blockClient(macAddress: string): Promise<void>
+	unblockClient(macAddress: string): Promise<void>
+	setWlanEnabled(name: string, enabled: boolean): Promise<void>
+	restartAccessPoint(macAddress: string): Promise<void>
+	setAccessPointLeds(macAddress: string, enabled: boolean): Promise<void>
+}

--- a/packages/home-connector/src/config.node.test.ts
+++ b/packages/home-connector/src/config.node.test.ts
@@ -202,6 +202,40 @@ test('island router SSH env vars honor explicit port, fingerprint, and timeout',
 	})
 })
 
+test('Access Networks Unleashed insecure TLS is opt-in', () => {
+	using _env = createTemporaryEnv({
+		...requiredConfigEnv,
+		ACCESS_NETWORKS_UNLEASHED_HOST: 'https://unleashed.local',
+		ACCESS_NETWORKS_UNLEASHED_USERNAME: 'admin',
+		ACCESS_NETWORKS_UNLEASHED_PASSWORD: 'password',
+		ACCESS_NETWORKS_UNLEASHED_ALLOW_INSECURE_TLS: undefined,
+	})
+
+	expect(loadHomeConnectorConfig()).toMatchObject({
+		accessNetworksUnleashedHost: 'https://unleashed.local',
+		accessNetworksUnleashedUsername: 'admin',
+		accessNetworksUnleashedPassword: 'password',
+		accessNetworksUnleashedAllowInsecureTls: false,
+		accessNetworksUnleashedRequestTimeoutMs: 8000,
+	})
+})
+
+test('Access Networks Unleashed insecure TLS honors explicit true', () => {
+	using _env = createTemporaryEnv({
+		...requiredConfigEnv,
+		ACCESS_NETWORKS_UNLEASHED_HOST: 'https://unleashed.local',
+		ACCESS_NETWORKS_UNLEASHED_USERNAME: 'admin',
+		ACCESS_NETWORKS_UNLEASHED_PASSWORD: 'password',
+		ACCESS_NETWORKS_UNLEASHED_ALLOW_INSECURE_TLS: 'true',
+		ACCESS_NETWORKS_UNLEASHED_REQUEST_TIMEOUT_MS: '12000',
+	})
+
+	expect(loadHomeConnectorConfig()).toMatchObject({
+		accessNetworksUnleashedAllowInsecureTls: true,
+		accessNetworksUnleashedRequestTimeoutMs: 12000,
+	})
+})
+
 test('invalid island router port falls back to default 22', () => {
 	using _env = createTemporaryEnv({
 		...requiredConfigEnv,

--- a/packages/home-connector/src/config.ts
+++ b/packages/home-connector/src/config.ts
@@ -7,6 +7,11 @@ export type HomeConnectorConfig = {
 	workerSessionUrl: string
 	workerWebSocketUrl: string
 	sharedSecret: string | null
+	accessNetworksUnleashedHost: string | null
+	accessNetworksUnleashedUsername: string | null
+	accessNetworksUnleashedPassword: string | null
+	accessNetworksUnleashedAllowInsecureTls: boolean
+	accessNetworksUnleashedRequestTimeoutMs: number
 	islandRouterHost: string | null
 	islandRouterPort: number
 	islandRouterUsername: string | null
@@ -204,6 +209,10 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 		process.env.ISLAND_ROUTER_COMMAND_TIMEOUT_MS ?? '8000',
 		10,
 	)
+	const accessNetworksUnleashedRequestTimeoutMs = Number.parseInt(
+		process.env.ACCESS_NETWORKS_UNLEASHED_REQUEST_TIMEOUT_MS ?? '8000',
+		10,
+	)
 	const homeConnectorId = process.env.HOME_CONNECTOR_ID?.trim() || 'default'
 	const workerBaseUrl =
 		process.env.WORKER_BASE_URL?.trim() || 'http://localhost:3742'
@@ -229,6 +238,19 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 		workerSessionUrl,
 		workerWebSocketUrl: createWorkerWebSocketUrl(workerSessionUrl),
 		sharedSecret: process.env.HOME_CONNECTOR_SHARED_SECRET?.trim() || null,
+		accessNetworksUnleashedHost:
+			process.env.ACCESS_NETWORKS_UNLEASHED_HOST?.trim() || null,
+		accessNetworksUnleashedUsername:
+			process.env.ACCESS_NETWORKS_UNLEASHED_USERNAME?.trim() || null,
+		accessNetworksUnleashedPassword:
+			process.env.ACCESS_NETWORKS_UNLEASHED_PASSWORD?.trim() || null,
+		accessNetworksUnleashedAllowInsecureTls:
+			process.env.ACCESS_NETWORKS_UNLEASHED_ALLOW_INSECURE_TLS !== 'false',
+		accessNetworksUnleashedRequestTimeoutMs:
+			Number.isFinite(accessNetworksUnleashedRequestTimeoutMs) &&
+			accessNetworksUnleashedRequestTimeoutMs >= 1000
+				? accessNetworksUnleashedRequestTimeoutMs
+				: 8000,
 		islandRouterHost: process.env.ISLAND_ROUTER_HOST?.trim() || null,
 		islandRouterPort:
 			islandRouterPort != null &&

--- a/packages/home-connector/src/config.ts
+++ b/packages/home-connector/src/config.ts
@@ -245,7 +245,7 @@ export function loadHomeConnectorConfig(): HomeConnectorConfig {
 		accessNetworksUnleashedPassword:
 			process.env.ACCESS_NETWORKS_UNLEASHED_PASSWORD?.trim() || null,
 		accessNetworksUnleashedAllowInsecureTls:
-			process.env.ACCESS_NETWORKS_UNLEASHED_ALLOW_INSECURE_TLS !== 'false',
+			process.env.ACCESS_NETWORKS_UNLEASHED_ALLOW_INSECURE_TLS === 'true',
 		accessNetworksUnleashedRequestTimeoutMs:
 			Number.isFinite(accessNetworksUnleashedRequestTimeoutMs) &&
 			accessNetworksUnleashedRequestTimeoutMs >= 1000

--- a/packages/home-connector/src/index.ts
+++ b/packages/home-connector/src/index.ts
@@ -1,10 +1,11 @@
+import { createAccessNetworksUnleashedAdapter } from './adapters/access-networks-unleashed/index.ts'
 import { createBondAdapter } from './adapters/bond/index.ts'
 import { createIslandRouterAdapter } from './adapters/island-router/index.ts'
 import { createJellyfishAdapter } from './adapters/jellyfish/index.ts'
 import { createLutronAdapter } from './adapters/lutron/index.ts'
+import { createSamsungTvAdapter } from './adapters/samsung-tv/index.ts'
 import { createSonosAdapter } from './adapters/sonos/index.ts'
 import { createVenstarAdapter } from './adapters/venstar/index.ts'
-import { createSamsungTvAdapter } from './adapters/samsung-tv/index.ts'
 import { createHomeConnectorMcpServer } from './mcp/server.ts'
 import { loadHomeConnectorConfig } from './config.ts'
 import { createAppState, updateConnectionState } from './state.ts'
@@ -50,6 +51,9 @@ export function createHomeConnectorApp() {
 		storage,
 	})
 	const venstar = createVenstarAdapter({ config, state, storage })
+	const accessNetworksUnleashed = createAccessNetworksUnleashedAdapter({
+		config,
+	})
 	const mcp = createHomeConnectorMcpServer({
 		config,
 		state,
@@ -60,6 +64,7 @@ export function createHomeConnectorApp() {
 		islandRouter,
 		jellyfish,
 		venstar,
+		accessNetworksUnleashed,
 	})
 	const workerConnector = createWorkerConnector({
 		config,
@@ -78,6 +83,7 @@ export function createHomeConnectorApp() {
 		islandRouter,
 		jellyfish,
 		venstar,
+		accessNetworksUnleashed,
 		mcp,
 		workerConnector,
 	}

--- a/packages/home-connector/src/mcp/register-access-networks-unleashed-tools.ts
+++ b/packages/home-connector/src/mcp/register-access-networks-unleashed-tools.ts
@@ -1,0 +1,397 @@
+import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+import { type createAccessNetworksUnleashedAdapter } from '../adapters/access-networks-unleashed/index.ts'
+import {
+	buildToolInputSchema,
+	type ToolInputSchema,
+} from './tool-input-schema.ts'
+
+type AccessNetworksUnleashedToolDescriptor = {
+	name: string
+	title: string
+	description: string
+	inputSchema: Record<string, unknown>
+	annotations?: Record<string, unknown>
+}
+
+type AccessNetworksUnleashedRegisteredToolDescriptor =
+	AccessNetworksUnleashedToolDescriptor & {
+		sdkInputSchema?: ToolInputSchema
+	}
+
+type AccessNetworksUnleashedToolHandler = (
+	args: Record<string, unknown>,
+) => Promise<CallToolResult>
+
+function structuredTextResult(
+	text: string,
+	structuredContent: unknown,
+): CallToolResult {
+	return {
+		content: [
+			{
+				type: 'text',
+				text,
+			},
+		],
+		structuredContent,
+	}
+}
+
+const unleashedWriteDangerNotice =
+	'HIGH RISK: this mutates a live Access Networks Unleashed WiFi system. Use it only when you are highly certain it is necessary and correct because mistakes can disconnect clients, take SSIDs offline, reboot access points, or disrupt local connectivity.'
+
+function createUnleashedWriteSchema(confirmationPhrase: string) {
+	return {
+		acknowledgeHighRisk: z
+			.literal(true)
+			.describe(
+				'Must be true. Set this only when you are highly certain the requested WiFi mutation is necessary and correct.',
+			),
+		reason: z
+			.string()
+			.min(20)
+			.max(500)
+			.describe(
+				'Short operator justification. Be specific about why this mutation is necessary right now.',
+			),
+		confirmation: z
+			.literal(confirmationPhrase)
+			.describe(
+				'Exact confirmation phrase required by the tool. The tool rejects any other value.',
+			),
+	}
+}
+
+function registerUnleashedReadTool(input: {
+	registerTool: (
+		descriptor: AccessNetworksUnleashedRegisteredToolDescriptor,
+		handler: AccessNetworksUnleashedToolHandler,
+	) => void
+	name: string
+	title: string
+	description: string
+	inputSchema?: ReturnType<typeof buildToolInputSchema>
+	handler: (args: Record<string, unknown>) => Promise<{
+		text: string
+		structuredContent: unknown
+	}>
+}) {
+	input.registerTool(
+		{
+			name: input.name,
+			title: input.title,
+			description: input.description,
+			inputSchema: input.inputSchema?.inputSchema ?? {},
+			sdkInputSchema: input.inputSchema?.sdkInputSchema,
+			annotations: {
+				readOnlyHint: true,
+				idempotentHint: true,
+			},
+		},
+		async (args) => {
+			const result = await input.handler(args)
+			return structuredTextResult(result.text, result.structuredContent)
+		},
+	)
+}
+
+export function registerAccessNetworksUnleashedHomeConnectorTools(input: {
+	registerTool: (
+		descriptor: AccessNetworksUnleashedRegisteredToolDescriptor,
+		handler: AccessNetworksUnleashedToolHandler,
+	) => void
+	accessNetworksUnleashed: ReturnType<
+		typeof createAccessNetworksUnleashedAdapter
+	>
+}) {
+	const { registerTool, accessNetworksUnleashed } = input
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_get_status',
+		title: 'Get Access Networks Unleashed Status',
+		description:
+			'Read-only Access Networks Unleashed status summary including configuration readiness, system info, access points, WLANs, active clients, and recent events.',
+		handler: async () => {
+			const status = await accessNetworksUnleashed.getStatus()
+			return {
+				text: status.config.configured
+					? `Access Networks Unleashed status loaded with ${status.aps.length} AP(s), ${status.wlans.length} WLAN(s), and ${status.clients.length} active client(s).`
+					: `Access Networks Unleashed is not fully configured: ${status.config.missingFields.join(', ')}.`,
+				structuredContent: status,
+			}
+		},
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_list_access_points',
+		title: 'List Access Networks Unleashed Access Points',
+		description:
+			'Read access point inventory and statistics from the configured Access Networks Unleashed controller.',
+		handler: async () => {
+			const aps = await accessNetworksUnleashed.listAccessPoints()
+			return {
+				text: `Loaded ${aps.length} Access Networks Unleashed access point(s).`,
+				structuredContent: { aps },
+			}
+		},
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_list_clients',
+		title: 'List Access Networks Unleashed Clients',
+		description:
+			'Read currently active wireless clients from the configured Access Networks Unleashed controller.',
+		handler: async () => {
+			const clients = await accessNetworksUnleashed.listClients()
+			return {
+				text: `Loaded ${clients.length} Access Networks Unleashed active client(s).`,
+				structuredContent: { clients },
+			}
+		},
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_list_wlans',
+		title: 'List Access Networks Unleashed WLANs',
+		description:
+			'Read WLAN/SSID configuration from the configured Access Networks Unleashed controller.',
+		handler: async () => {
+			const wlans = await accessNetworksUnleashed.listWlans()
+			return {
+				text: `Loaded ${wlans.length} Access Networks Unleashed WLAN(s).`,
+				structuredContent: { wlans },
+			}
+		},
+	})
+
+	const eventsSchema = buildToolInputSchema({
+		limit: z
+			.number()
+			.int()
+			.min(1)
+			.max(300)
+			.optional()
+			.describe('Maximum number of recent events to return.'),
+	})
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_list_events',
+		title: 'List Access Networks Unleashed Events',
+		description:
+			'Read recent controller events from the configured Access Networks Unleashed controller.',
+		inputSchema: eventsSchema,
+		handler: async (args) => {
+			const events = await accessNetworksUnleashed.listEvents({
+				limit: args['limit'] == null ? undefined : Number(args['limit']),
+			})
+			return {
+				text: `Loaded ${events.length} Access Networks Unleashed event(s).`,
+				structuredContent: { events },
+			}
+		},
+	})
+
+	const clientMutationSchema = (confirmationPhrase: string, target: string) =>
+		buildToolInputSchema({
+			macAddress: z.string().min(1).describe(target),
+			...createUnleashedWriteSchema(confirmationPhrase),
+		})
+	const blockClientSchema = clientMutationSchema(
+		accessNetworksUnleashed.writeAcknowledgements.blockClient,
+		'Client MAC address to block.',
+	)
+	const unblockClientSchema = clientMutationSchema(
+		accessNetworksUnleashed.writeAcknowledgements.unblockClient,
+		'Client MAC address to unblock.',
+	)
+
+	registerTool(
+		{
+			name: 'access_networks_unleashed_block_client',
+			title: 'Block Access Networks Unleashed Client',
+			description: `${unleashedWriteDangerNotice} This typed operation blocks a wireless client by MAC address.`,
+			inputSchema: blockClientSchema.inputSchema,
+			sdkInputSchema: blockClientSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.blockClient({
+				macAddress: String(args['macAddress'] ?? ''),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Blocked Access Networks Unleashed client ${String(args['macAddress'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'access_networks_unleashed_unblock_client',
+			title: 'Unblock Access Networks Unleashed Client',
+			description: `${unleashedWriteDangerNotice} This typed operation removes a wireless client block by MAC address.`,
+			inputSchema: unblockClientSchema.inputSchema,
+			sdkInputSchema: unblockClientSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.unblockClient({
+				macAddress: String(args['macAddress'] ?? ''),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Unblocked Access Networks Unleashed client ${String(args['macAddress'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	const wlanMutationSchema = (confirmationPhrase: string) =>
+		buildToolInputSchema({
+			name: z.string().min(1).describe('WLAN/SSID service name to mutate.'),
+			...createUnleashedWriteSchema(confirmationPhrase),
+		})
+	const enableWlanSchema = wlanMutationSchema(
+		accessNetworksUnleashed.writeAcknowledgements.enableWlan,
+	)
+	const disableWlanSchema = wlanMutationSchema(
+		accessNetworksUnleashed.writeAcknowledgements.disableWlan,
+	)
+
+	registerTool(
+		{
+			name: 'access_networks_unleashed_enable_wlan',
+			title: 'Enable Access Networks Unleashed WLAN',
+			description: `${unleashedWriteDangerNotice} This typed operation enables a WLAN/SSID by name.`,
+			inputSchema: enableWlanSchema.inputSchema,
+			sdkInputSchema: enableWlanSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.setWlanEnabled({
+				name: String(args['name'] ?? ''),
+				enabled: true,
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Enabled Access Networks Unleashed WLAN ${String(args['name'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'access_networks_unleashed_disable_wlan',
+			title: 'Disable Access Networks Unleashed WLAN',
+			description: `${unleashedWriteDangerNotice} This typed operation disables a WLAN/SSID by name. It can immediately disconnect every client on that SSID.`,
+			inputSchema: disableWlanSchema.inputSchema,
+			sdkInputSchema: disableWlanSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.setWlanEnabled({
+				name: String(args['name'] ?? ''),
+				enabled: false,
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Disabled Access Networks Unleashed WLAN ${String(args['name'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	const apMutationSchema = (confirmationPhrase: string, ledControl = false) =>
+		buildToolInputSchema({
+			macAddress: z.string().min(1).describe('Access point MAC address.'),
+			...(ledControl
+				? {
+						enabled: z
+							.boolean()
+							.describe('True to show AP LEDs, false to turn AP LEDs off.'),
+					}
+				: {}),
+			...createUnleashedWriteSchema(confirmationPhrase),
+		})
+	const restartApSchema = apMutationSchema(
+		accessNetworksUnleashed.writeAcknowledgements.restartAccessPoint,
+	)
+	const setApLedsSchema = apMutationSchema(
+		accessNetworksUnleashed.writeAcknowledgements.setAccessPointLeds,
+		true,
+	)
+
+	registerTool(
+		{
+			name: 'access_networks_unleashed_restart_access_point',
+			title: 'Restart Access Networks Unleashed Access Point',
+			description: `${unleashedWriteDangerNotice} This typed operation reboots an access point by MAC address and can immediately disconnect associated clients.`,
+			inputSchema: restartApSchema.inputSchema,
+			sdkInputSchema: restartApSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.restartAccessPoint({
+				macAddress: String(args['macAddress'] ?? ''),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Restarted Access Networks Unleashed access point ${String(args['macAddress'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'access_networks_unleashed_set_access_point_leds',
+			title: 'Set Access Networks Unleashed Access Point LEDs',
+			description: `${unleashedWriteDangerNotice} This typed operation changes access point LED visibility by MAC address.`,
+			inputSchema: setApLedsSchema.inputSchema,
+			sdkInputSchema: setApLedsSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.setAccessPointLeds({
+				macAddress: String(args['macAddress'] ?? ''),
+				enabled: args['enabled'] === true,
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Updated Access Networks Unleashed access point LEDs for ${String(args['macAddress'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+}

--- a/packages/home-connector/src/mcp/register-access-networks-unleashed-tools.ts
+++ b/packages/home-connector/src/mcp/register-access-networks-unleashed-tools.ts
@@ -284,9 +284,8 @@ export function registerAccessNetworksUnleashedHomeConnectorTools(input: {
 			},
 		},
 		async (args) => {
-			const result = await accessNetworksUnleashed.setWlanEnabled({
+			const result = await accessNetworksUnleashed.enableWlan({
 				name: String(args['name'] ?? ''),
-				enabled: true,
 				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
 				reason: String(args['reason'] ?? ''),
 				confirmation: String(args['confirmation'] ?? ''),
@@ -310,9 +309,8 @@ export function registerAccessNetworksUnleashedHomeConnectorTools(input: {
 			},
 		},
 		async (args) => {
-			const result = await accessNetworksUnleashed.setWlanEnabled({
+			const result = await accessNetworksUnleashed.disableWlan({
 				name: String(args['name'] ?? ''),
-				enabled: false,
 				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
 				reason: String(args['reason'] ?? ''),
 				confirmation: String(args['confirmation'] ?? ''),

--- a/packages/home-connector/src/mcp/register-access-networks-unleashed-tools.ts
+++ b/packages/home-connector/src/mcp/register-access-networks-unleashed-tools.ts
@@ -186,9 +186,9 @@ export function registerAccessNetworksUnleashedHomeConnectorTools(input: {
 			'Read recent controller events from the configured Access Networks Unleashed controller.',
 		inputSchema: eventsSchema,
 		handler: async (args) => {
-			const events = await accessNetworksUnleashed.listEvents({
-				limit: args['limit'] == null ? undefined : Number(args['limit']),
-			})
+			const events = await accessNetworksUnleashed.listEvents(
+				args['limit'] == null ? undefined : Number(args['limit']),
+			)
 			return {
 				text: `Loaded ${events.length} Access Networks Unleashed event(s).`,
 				structuredContent: { events },

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from 'vitest'
 import { installHomeConnectorMockServer } from '../../mocks/test-server.ts'
+import { createAccessNetworksUnleashedAdapter } from '../adapters/access-networks-unleashed/index.ts'
+import { type AccessNetworksUnleashedClient } from '../adapters/access-networks-unleashed/types.ts'
 import { createBondAdapter } from '../adapters/bond/index.ts'
 import { type IslandRouterCommandRequest } from '../adapters/island-router/types.ts'
 import { createIslandRouterAdapter } from '../adapters/island-router/index.ts'
@@ -35,6 +37,9 @@ function createConfig() {
 	process.env.ISLAND_ROUTER_HOST_FINGERPRINT =
 		'SHA256:abcDEF1234567890abcDEF1234567890abcDEF12'
 	process.env.ISLAND_ROUTER_COMMAND_TIMEOUT_MS = '5000'
+	process.env.ACCESS_NETWORKS_UNLEASHED_HOST = 'https://unleashed.local'
+	process.env.ACCESS_NETWORKS_UNLEASHED_USERNAME = 'admin'
+	process.env.ACCESS_NETWORKS_UNLEASHED_PASSWORD = 'password'
 	return loadHomeConnectorConfig()
 }
 
@@ -570,7 +575,11 @@ function createIslandRouterRunner() {
 			case 'set-interface-description':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'interface en0', 'description "LAN uplink"'],
+					commandLines: [
+						'terminal length 0',
+						'interface en0',
+						'description "LAN uplink"',
+					],
 					stdout: 'Interface description updated.',
 					stderr: '',
 					exitCode: 0,
@@ -592,7 +601,10 @@ function createIslandRouterRunner() {
 			case 'block-host':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'firewall block-host 192.168.0.52'],
+					commandLines: [
+						'terminal length 0',
+						'firewall block-host 192.168.0.52',
+					],
 					stdout: 'Host blocked.',
 					stderr: '',
 					exitCode: 0,
@@ -603,7 +615,10 @@ function createIslandRouterRunner() {
 			case 'unblock-host':
 				return {
 					id: request.id,
-					commandLines: ['terminal length 0', 'no firewall block-host 192.168.0.52'],
+					commandLines: [
+						'terminal length 0',
+						'no firewall block-host 192.168.0.52',
+					],
 					stdout: 'Host unblocked.',
 					stderr: '',
 					exitCode: 0,
@@ -654,6 +669,68 @@ function createIslandRouterRunner() {
 	}
 }
 
+function createFakeAccessNetworksUnleashedClient() {
+	const calls: Array<{ name: string; args: Array<unknown> }> = []
+	const client: AccessNetworksUnleashedClient = {
+		async getSystemInfo() {
+			return {
+				name: 'Access Networks Unleashed',
+				version: '200.15.6.212',
+			}
+		},
+		async listClients() {
+			return [
+				{
+					mac: 'aa:bb:cc:dd:ee:ff',
+					hostname: 'phone',
+					wlan: 'Main',
+				},
+			]
+		},
+		async listAccessPoints() {
+			return [
+				{
+					id: 1,
+					mac: '24:79:de:ad:be:ef',
+					name: 'Kitchen AP',
+				},
+			]
+		},
+		async listWlans() {
+			return [
+				{
+					id: 1,
+					name: 'Main',
+					ssid: 'Main',
+				},
+			]
+		},
+		async listEvents() {
+			return [
+				{
+					message: 'client associated',
+				},
+			]
+		},
+		async blockClient(macAddress) {
+			calls.push({ name: 'blockClient', args: [macAddress] })
+		},
+		async unblockClient(macAddress) {
+			calls.push({ name: 'unblockClient', args: [macAddress] })
+		},
+		async setWlanEnabled(name, enabled) {
+			calls.push({ name: 'setWlanEnabled', args: [name, enabled] })
+		},
+		async restartAccessPoint(macAddress) {
+			calls.push({ name: 'restartAccessPoint', args: [macAddress] })
+		},
+		async setAccessPointLeds(macAddress, enabled) {
+			calls.push({ name: 'setAccessPointLeds', args: [macAddress, enabled] })
+		},
+	}
+	return { client, calls }
+}
+
 installHomeConnectorMockServer()
 
 test('mcp server exposes Samsung tools and executes samsung_list_devices', async () => {
@@ -696,6 +773,11 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		storage,
 	})
 	const venstar = createVenstarAdapter({ config, state, storage })
+	const fakeAccessNetworksUnleashed = createFakeAccessNetworksUnleashedClient()
+	const accessNetworksUnleashed = createAccessNetworksUnleashedAdapter({
+		config,
+		client: fakeAccessNetworksUnleashed.client,
+	})
 	await samsungTv.scan()
 	await lutron.scan()
 	await sonos.scan()
@@ -710,6 +792,7 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		islandRouter,
 		jellyfish,
 		venstar,
+		accessNetworksUnleashed,
 	})
 
 	try {
@@ -758,13 +841,15 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		expect(tools.some((tool) => tool.name === 'router_diagnose_host')).toBe(
 			true,
 		)
-		expect(tools.some((tool) => tool.name === 'router_get_wan_config')).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_wan_config')).toBe(
+			true,
+		)
 		expect(
 			tools.some((tool) => tool.name === 'router_get_failover_status'),
 		).toBe(true)
-		expect(
-			tools.some((tool) => tool.name === 'router_get_routing_table'),
-		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_routing_table')).toBe(
+			true,
+		)
 		expect(tools.some((tool) => tool.name === 'router_get_nat_rules')).toBe(
 			true,
 		)
@@ -781,9 +866,9 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		expect(tools.some((tool) => tool.name === 'router_get_qos_config')).toBe(
 			true,
 		)
-		expect(
-			tools.some((tool) => tool.name === 'router_get_traffic_stats'),
-		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_traffic_stats')).toBe(
+			true,
+		)
 		expect(
 			tools.some((tool) => tool.name === 'router_get_active_sessions'),
 		).toBe(true)
@@ -796,15 +881,15 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		expect(tools.some((tool) => tool.name === 'router_get_ntp_config')).toBe(
 			true,
 		)
-		expect(
-			tools.some((tool) => tool.name === 'router_get_syslog_config'),
-		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_syslog_config')).toBe(
+			true,
+		)
 		expect(tools.some((tool) => tool.name === 'router_get_snmp_config')).toBe(
 			true,
 		)
-		expect(
-			tools.some((tool) => tool.name === 'router_get_system_info'),
-		).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_get_system_info')).toBe(
+			true,
+		)
 		expect(
 			tools.some((tool) => tool.name === 'router_get_bandwidth_usage'),
 		).toBe(true)
@@ -830,13 +915,32 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		expect(
 			tools.some((tool) => tool.name === 'router_set_interface_description'),
 		).toBe(true)
-		expect(
-			tools.some((tool) => tool.name === 'router_set_dns_server'),
-		).toBe(true)
-		expect(tools.some((tool) => tool.name === 'router_block_host')).toBe(true)
-		expect(tools.some((tool) => tool.name === 'router_unblock_host')).toBe(
+		expect(tools.some((tool) => tool.name === 'router_set_dns_server')).toBe(
 			true,
 		)
+		expect(tools.some((tool) => tool.name === 'router_block_host')).toBe(true)
+		expect(tools.some((tool) => tool.name === 'router_unblock_host')).toBe(true)
+		expect(
+			tools.some(
+				(tool) => tool.name === 'access_networks_unleashed_get_status',
+			),
+		).toBe(true)
+		expect(
+			tools.some(
+				(tool) => tool.name === 'access_networks_unleashed_list_access_points',
+			),
+		).toBe(true)
+		expect(
+			tools.some(
+				(tool) => tool.name === 'access_networks_unleashed_block_client',
+			),
+		).toBe(true)
+		expect(
+			tools.some(
+				(tool) =>
+					tool.name === 'access_networks_unleashed_restart_access_point',
+			),
+		).toBe(true)
 		expect(
 			tools.some((tool) => tool.name === 'jellyfish_scan_controllers'),
 		).toBe(true)
@@ -994,6 +1098,36 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 			},
 		})
 
+		const accessNetworksStatus = await mcp.callTool(
+			'access_networks_unleashed_get_status',
+		)
+		expect(accessNetworksStatus.structuredContent).toMatchObject({
+			config: {
+				configured: true,
+			},
+			aps: expect.any(Array),
+			wlans: expect.any(Array),
+			clients: expect.any(Array),
+		})
+		const accessNetworksBlock = await mcp.callTool(
+			'access_networks_unleashed_block_client',
+			{
+				macAddress: 'AA-BB-CC-DD-EE-FF',
+				acknowledgeHighRisk: true,
+				reason:
+					'The client was identified as unauthorized and must be blocked now.',
+				confirmation: accessNetworksUnleashed.writeAcknowledgements.blockClient,
+			},
+		)
+		expect(accessNetworksBlock.structuredContent).toMatchObject({
+			operation: 'block-client',
+			target: 'aa:bb:cc:dd:ee:ff',
+		})
+		expect(fakeAccessNetworksUnleashed.calls).toContainEqual({
+			name: 'blockClient',
+			args: ['aa:bb:cc:dd:ee:ff'],
+		})
+
 		await mcp.callTool('bond_adopt_bridge', { bridgeId: 'MOCKBOND1' })
 		bond.setToken('MOCKBOND1', 'mock-bond-token')
 		const bondDevices = await mcp.callTool('bond_list_devices', {
@@ -1121,6 +1255,11 @@ test('mcp server exposes island router write tools when host verification is con
 		storage,
 	})
 	const venstar = createVenstarAdapter({ config, state, storage })
+	const fakeAccessNetworksUnleashed = createFakeAccessNetworksUnleashedClient()
+	const accessNetworksUnleashed = createAccessNetworksUnleashedAdapter({
+		config,
+		client: fakeAccessNetworksUnleashed.client,
+	})
 	const mcp = createHomeConnectorMcpServer({
 		config,
 		state,
@@ -1131,6 +1270,7 @@ test('mcp server exposes island router write tools when host verification is con
 		islandRouter,
 		jellyfish,
 		venstar,
+		accessNetworksUnleashed,
 	})
 
 	try {

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -705,7 +705,8 @@ function createFakeAccessNetworksUnleashedClient() {
 				},
 			]
 		},
-		async listEvents() {
+		async listEvents(limit) {
+			calls.push({ name: 'listEvents', args: [limit] })
 			return [
 				{
 					message: 'client associated',
@@ -1126,6 +1127,11 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		expect(fakeAccessNetworksUnleashed.calls).toContainEqual({
 			name: 'blockClient',
 			args: ['aa:bb:cc:dd:ee:ff'],
+		})
+		await mcp.callTool('access_networks_unleashed_list_events', { limit: 1 })
+		expect(fakeAccessNetworksUnleashed.calls).toContainEqual({
+			name: 'listEvents',
+			args: [1],
 		})
 
 		await mcp.callTool('bond_adopt_bridge', { bridgeId: 'MOCKBOND1' })

--- a/packages/home-connector/src/mcp/server.ts
+++ b/packages/home-connector/src/mcp/server.ts
@@ -3,16 +3,18 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { markSecretInputFields } from '@kody-internal/shared/secret-input-schema.ts'
 import { z } from 'zod'
+import { type createAccessNetworksUnleashedAdapter } from '../adapters/access-networks-unleashed/index.ts'
 import { type createBondAdapter } from '../adapters/bond/index.ts'
 import { type createIslandRouterAdapter } from '../adapters/island-router/index.ts'
 import { type createJellyfishAdapter } from '../adapters/jellyfish/index.ts'
-import { createRokuAdapter } from '../adapters/roku/index.ts'
 import { isLutronProcessorNotFoundError } from '../adapters/lutron/errors.ts'
 import { type createLutronAdapter } from '../adapters/lutron/index.ts'
+import { createRokuAdapter } from '../adapters/roku/index.ts'
 import { type createSonosAdapter } from '../adapters/sonos/index.ts'
 import { type createSamsungTvAdapter } from '../adapters/samsung-tv/index.ts'
 import { type createVenstarAdapter } from '../adapters/venstar/index.ts'
 import { type HomeConnectorConfig } from '../config.ts'
+import { registerAccessNetworksUnleashedHomeConnectorTools } from './register-access-networks-unleashed-tools.ts'
 import { registerBondHomeConnectorTools } from './register-bond-tools.ts'
 import { registerIslandRouterHomeConnectorTools } from './register-island-router-tools.ts'
 import { type HomeConnectorState } from '../state.ts'
@@ -76,6 +78,9 @@ export function createHomeConnectorMcpServer(input: {
 	jellyfish: ReturnType<typeof createJellyfishAdapter>
 	venstar: ReturnType<typeof createVenstarAdapter>
 	islandRouter: ReturnType<typeof createIslandRouterAdapter>
+	accessNetworksUnleashed: ReturnType<
+		typeof createAccessNetworksUnleashedAdapter
+	>
 }): HomeConnectorMcpServer {
 	const roku = createRokuAdapter({
 		config: input.config,
@@ -88,6 +93,7 @@ export function createHomeConnectorMcpServer(input: {
 	const jellyfish = input.jellyfish
 	const venstar = input.venstar
 	const islandRouter = input.islandRouter
+	const accessNetworksUnleashed = input.accessNetworksUnleashed
 
 	const server = new McpServer(
 		{
@@ -96,7 +102,7 @@ export function createHomeConnectorMcpServer(input: {
 		},
 		{
 			instructions:
-				'Home connector MCP server. Tools support Roku, Samsung TV, Lutron, Sonos, Bond (Olibra Bond Bridge / shades, groups, and RF devices), JellyFish Lighting, Venstar WiFi thermostat control, and typed allowlisted Island router SSH operations. Island router support is read-mostly: arbitrary CLI execution is never exposed, and the few opt-in write operations are high risk and must be used only when highly certain. Bond local API tokens are configured only in the admin UI (/bond/setup); use bond_authentication_guide when you need a reminder.',
+				'Home connector MCP server. Tools support Roku, Samsung TV, Lutron, Sonos, Bond (Olibra Bond Bridge / shades, groups, and RF devices), JellyFish Lighting, Venstar WiFi thermostat control, typed allowlisted Island router SSH operations, and Access Networks Unleashed WiFi controller reads/writes. Island router and Access Networks Unleashed write operations are high risk and must be used only when highly certain. Arbitrary CLI execution is never exposed. Bond local API tokens are configured only in the admin UI (/bond/setup); use bond_authentication_guide when you need a reminder.',
 		},
 	)
 
@@ -2799,6 +2805,11 @@ export function createHomeConnectorMcpServer(input: {
 	registerIslandRouterHomeConnectorTools({
 		registerTool,
 		islandRouter,
+	})
+
+	registerAccessNetworksUnleashedHomeConnectorTools({
+		registerTool,
+		accessNetworksUnleashed,
 	})
 
 	return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an Access Networks Unleashed home connector adapter for local AJAX access to controller status, APs, WLANs, clients, and events.
- Expose guarded MCP write tools for blocking/unblocking clients, enabling/disabling WLANs, restarting APs, and toggling AP LEDs.
- Document configuration and high-risk write behavior in the home connector architecture notes.
- Address review feedback by making insecure TLS opt-in, bounding redirect reauthentication, preserving ACL XML on unblock, passing event limits correctly, serializing login, preventing write replay after session redirects, and resetting failed login state.

## Testing
- `npm --prefix packages/home-connector test`
- `npm run typecheck`
- `npm run lint`
- `npx oxfmt --check packages/home-connector/src/adapters/access-networks-unleashed/client.ts packages/home-connector/src/adapters/access-networks-unleashed/client.node.test.ts packages/home-connector/src/adapters/access-networks-unleashed/index.ts packages/home-connector/src/adapters/access-networks-unleashed/types.ts packages/home-connector/src/config.ts packages/home-connector/src/config.node.test.ts packages/home-connector/src/index.ts packages/home-connector/src/mcp/register-access-networks-unleashed-tools.ts packages/home-connector/src/mcp/server.ts packages/home-connector/src/mcp/server.node.test.ts packages/home-connector/package.json package-lock.json docs/contributing/architecture/home-connector.md`

## Notes
- Repository-wide `npm run format:check` still reports unrelated pre-existing formatting issues across 52 files, so changed files were checked directly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0eaa55fe-df5b-4338-8425-d45388d6d035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0eaa55fe-df5b-4338-8425-d45388d6d035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Access Networks Unleashed WiFi adapter with full read and write support
  * Monitor controller system status, access points, connected clients, WLANs, and recent events
  * Control devices: block/unblock clients, enable/disable WLANs, restart access points, and toggle LED visibility
  * Write actions require explicit high-risk acknowledgement and confirmation phrases

* **Documentation**
  * Architecture docs updated with configuration, usage, and safety details
<!-- end of auto-generated comment: release notes by coderabbit.ai -->