### PR TITLE
feat(home-connector): add missing Access Networks Unleashed capabilities

### DIFF
--- a/docs/contributing/architecture/home-connector.md
+++ b/docs/contributing/architecture/home-connector.md
@@ -198,9 +198,14 @@ now managed locally through the connector's SQLite database:
   request timeout for slower controllers or networks
 
 The adapter exposes read-only tools for controller status, access point
-inventory, active clients, WLAN/SSID configuration, and recent events. It also
-exposes a small typed write surface for client block/unblock, WLAN
-enable/disable, AP restart, and AP LED visibility changes.
+inventory, active and inactive clients, blocked clients, active/known/blocked
+rogue access points, WLAN/SSID configuration, AP groups, DPSKs, mesh topology,
+recent events, active alarms, raw syslog, per-VAP throughput, and per-WLAN-group
+and per-AP-group statistics. It also exposes a typed write surface for client
+block/unblock, WLAN enable/disable, WLAN passphrase changes, WLAN
+add/edit/clone/delete, WLAN-group add/clone/delete, AP restart, and AP LED
+visibility changes (including dedicated `hide_ap_leds` and `show_ap_leds`
+shortcuts).
 
 The write tools are deliberately warning-heavy. Each requires:
 

--- a/packages/home-connector/src/adapters/access-networks-unleashed/client.node.test.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/client.node.test.ts
@@ -372,6 +372,25 @@ test('get syslog extracts text from xmsg/res body', async () => {
 	expect(syslog).toContain('line2')
 })
 
+test('list blocked clients returns empty when no ACL list is present', async () => {
+	const config = createConfig()
+	installFetch(loginHandler(), (href, init) => {
+		if (href.endsWith('/_conf.jsp')) {
+			const body = String(init?.body ?? '')
+			if (body.includes("comp='acl-list'")) {
+				return response('<ajax-response><acl-list/></ajax-response>')
+			}
+		}
+		return null
+	})
+
+	const blocked = await createAccessNetworksUnleashedAjaxClient({
+		config,
+		controller: createController(),
+	}).listBlockedClients()
+	expect(blocked).toEqual([])
+})
+
 test('list blocked clients ignores ACLs whose id is not 1', async () => {
 	const config = createConfig()
 	installFetch(loginHandler(), (href, init) => {

--- a/packages/home-connector/src/adapters/access-networks-unleashed/client.node.test.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/client.node.test.ts
@@ -372,6 +372,33 @@ test('get syslog extracts text from xmsg/res body', async () => {
 	expect(syslog).toContain('line2')
 })
 
+test('list blocked clients ignores ACLs whose id is not 1', async () => {
+	const config = createConfig()
+	installFetch(loginHandler(), (href, init) => {
+		if (href.endsWith('/_conf.jsp')) {
+			const body = String(init?.body ?? '')
+			if (body.includes("comp='acl-list'")) {
+				return response(
+					[
+						'<ajax-response><acl-list>',
+						"<acl id='2' name='Custom' default-mode='deny'>",
+						"<deny mac='aa:bb:cc:dd:ee:ff' type='single'/>",
+						'</acl>',
+						'</acl-list></ajax-response>',
+					].join(''),
+				)
+			}
+		}
+		return null
+	})
+
+	const blocked = await createAccessNetworksUnleashedAjaxClient({
+		config,
+		controller: createController(),
+	}).listBlockedClients()
+	expect(blocked).toEqual([])
+})
+
 test('set wlan password posts an updated wlansvc with a new passphrase', async () => {
 	const config = createConfig()
 	const fetchMock = installFetch(loginHandler(), (href, init) => {
@@ -406,6 +433,80 @@ test('set wlan password posts an updated wlansvc with a new passphrase', async (
 	expect(updateBody).toContain("passphrase='newpass-secret'")
 	expect(updateBody).not.toContain("passphrase='oldpass'")
 	expect(updateBody).toContain("name='Main'")
+})
+
+test('set wlan password preserves dollar signs and ampersands in the passphrase', async () => {
+	const config = createConfig()
+	const fetchMock = installFetch(loginHandler(), (href, init) => {
+		if (href.endsWith('/_conf.jsp')) {
+			const body = String(init?.body ?? '')
+			if (body.includes("action='getconf'")) {
+				return response(
+					[
+						'<ajax-response><wlansvc-list>',
+						"<wlansvc id='1' name='Main' ssid='Main' encryption='wpa2'>",
+						"<wpa cipher='aes' passphrase='oldpass' dynamic-psk='disabled'/>",
+						'</wlansvc>',
+						'</wlansvc-list></ajax-response>',
+					].join(''),
+				)
+			}
+			if (body.includes("action='updobj'")) {
+				return response('<ajax-response><xmsg status="0"/></ajax-response>')
+			}
+		}
+		return null
+	})
+
+	await createAccessNetworksUnleashedAjaxClient({
+		config,
+		controller: createController(),
+	}).setWlanPassword('Main', 'Pa$$w0rd&$1$2')
+
+	const updateBody = fetchMock.mock.calls
+		.map((call) => String(call[1]?.body ?? ''))
+		.find((body) => body.includes("action='updobj'"))
+	expect(updateBody).toContain("passphrase='Pa$$w0rd&amp;$1$2'")
+	expect(updateBody).not.toContain("passphrase='oldpass'")
+})
+
+test('add wlan keeps dollar signs in the passphrase intact', async () => {
+	const config = createConfig()
+	const fetchMock = installFetch(loginHandler(), (href, init) => {
+		if (href.endsWith('/_conf.jsp')) {
+			const body = String(init?.body ?? '')
+			if (
+				body.includes("action='getconf'") &&
+				body.includes("comp='wlansvc-standard-template'")
+			) {
+				return response(
+					[
+						'<ajax-response><wlansvc-standard-template>',
+						"<wlansvc id='99' name='default-standard-wlan' ssid='' encryption='wpa2'>",
+						"<wpa cipher='aes' passphrase='placeholder' dynamic-psk='disabled'/>",
+						'</wlansvc></wlansvc-standard-template></ajax-response>',
+					].join(''),
+				)
+			}
+			if (body.includes("action='addobj'")) {
+				return response('<ajax-response><xmsg status="0"/></ajax-response>')
+			}
+		}
+		return null
+	})
+
+	await createAccessNetworksUnleashedAjaxClient({
+		config,
+		controller: createController(),
+	}).addWlan({
+		ssid: 'NewNet',
+		passphrase: 'A$$strong$1word',
+	})
+
+	const addBody = fetchMock.mock.calls
+		.map((call) => String(call[1]?.body ?? ''))
+		.find((body) => body.includes("action='addobj'"))
+	expect(addBody).toContain("passphrase='A$$strong$1word'")
 })
 
 test('add wlan posts an addobj request derived from the standard template', async () => {

--- a/packages/home-connector/src/adapters/access-networks-unleashed/client.node.test.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/client.node.test.ts
@@ -272,6 +272,354 @@ test('concurrent reads share one login flow', async () => {
 	expect(loginAttempts).toHaveLength(1)
 })
 
+type FetchHandler = (
+	url: string,
+	init: RequestInit | undefined,
+) => Promise<Response> | Response | null | undefined
+
+function loginHandler(): FetchHandler {
+	return (href, init) => {
+		if (init?.method === 'GET' && href === 'https://unleashed.local') {
+			return response(null, {
+				status: 302,
+				headers: { Location: '/admin/wsg/login.jsp' },
+				url: 'https://unleashed.local/',
+			})
+		}
+		if (init?.method === 'GET' && href.endsWith('/admin/wsg/login.jsp')) {
+			return response(null, {
+				status: 200,
+				url: 'https://unleashed.local/admin/wsg/login.jsp',
+			})
+		}
+		if (init?.method === 'GET' && href.includes('username=admin')) {
+			return response(null, {
+				status: 302,
+				headers: {
+					HTTP_X_CSRF_TOKEN: 'csrf-token',
+					'set-cookie': 'JSESSIONID=abc; Path=/admin',
+				},
+				url: href,
+			})
+		}
+		return null
+	}
+}
+
+function installFetch(...handlers: Array<FetchHandler>) {
+	const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+		const href = String(url)
+		for (const handler of handlers) {
+			const result = await handler(href, init)
+			if (result) return result
+		}
+		throw new Error(`Unexpected fetch ${href}`)
+	})
+	globalThis.fetch = fetchMock as typeof fetch
+	return fetchMock
+}
+
+test('list blocked clients returns deny entries from system ACL', async () => {
+	const config = createConfig()
+	installFetch(loginHandler(), (href, init) => {
+		if (href.endsWith('/_conf.jsp')) {
+			const body = String(init?.body ?? '')
+			if (body.includes("comp='acl-list'")) {
+				return response(
+					[
+						'<ajax-response><acl-list>',
+						"<acl id='1' name='System' default-mode='allow' EDITABLE='false'>",
+						"<deny mac='aa:bb:cc:dd:ee:ff' type='single'/>",
+						"<deny mac='11:22:33:44:55:66' type='single'/>",
+						'</acl>',
+						'</acl-list></ajax-response>',
+					].join(''),
+				)
+			}
+		}
+		return null
+	})
+
+	const blocked = await createAccessNetworksUnleashedAjaxClient({
+		config,
+		controller: createController(),
+	}).listBlockedClients()
+	expect(blocked).toHaveLength(2)
+	expect(blocked.map((entry) => entry['mac'])).toEqual([
+		'aa:bb:cc:dd:ee:ff',
+		'11:22:33:44:55:66',
+	])
+})
+
+test('get syslog extracts text from xmsg/res body', async () => {
+	const config = createConfig()
+	installFetch(loginHandler(), (href, init) => {
+		if (href.endsWith('/_cmdstat.jsp')) {
+			const body = String(init?.body ?? '')
+			if (body.includes("xcmd='get-syslog'") || body.includes('get-syslog')) {
+				return response(
+					'<ajax-response><xmsg><res>line1\nline2</res></xmsg></ajax-response>',
+				)
+			}
+		}
+		return null
+	})
+	const syslog = await createAccessNetworksUnleashedAjaxClient({
+		config,
+		controller: createController(),
+	}).getSyslog()
+	expect(syslog).toContain('line1')
+	expect(syslog).toContain('line2')
+})
+
+test('set wlan password posts an updated wlansvc with a new passphrase', async () => {
+	const config = createConfig()
+	const fetchMock = installFetch(loginHandler(), (href, init) => {
+		if (href.endsWith('/_conf.jsp')) {
+			const body = String(init?.body ?? '')
+			if (body.includes("action='getconf'")) {
+				return response(
+					[
+						'<ajax-response><wlansvc-list>',
+						"<wlansvc id='1' name='Main' ssid='Main' encryption='wpa2'>",
+						"<wpa cipher='aes' passphrase='oldpass' dynamic-psk='disabled'/>",
+						'</wlansvc>',
+						'</wlansvc-list></ajax-response>',
+					].join(''),
+				)
+			}
+			if (body.includes("action='updobj'")) {
+				return response('<ajax-response><xmsg status="0"/></ajax-response>')
+			}
+		}
+		return null
+	})
+
+	await createAccessNetworksUnleashedAjaxClient({
+		config,
+		controller: createController(),
+	}).setWlanPassword('Main', 'newpass-secret')
+
+	const updateBody = fetchMock.mock.calls
+		.map((call) => String(call[1]?.body ?? ''))
+		.find((body) => body.includes("action='updobj'"))
+	expect(updateBody).toContain("passphrase='newpass-secret'")
+	expect(updateBody).not.toContain("passphrase='oldpass'")
+	expect(updateBody).toContain("name='Main'")
+})
+
+test('add wlan posts an addobj request derived from the standard template', async () => {
+	const config = createConfig()
+	const fetchMock = installFetch(loginHandler(), (href, init) => {
+		if (href.endsWith('/_conf.jsp')) {
+			const body = String(init?.body ?? '')
+			if (
+				body.includes("action='getconf'") &&
+				body.includes("comp='wlansvc-standard-template'")
+			) {
+				return response(
+					[
+						'<ajax-response><wlansvc-standard-template>',
+						"<wlansvc id='99' name='default-standard-wlan' ssid='' encryption='none' authentication='open'/>",
+						'</wlansvc-standard-template></ajax-response>',
+					].join(''),
+				)
+			}
+			if (body.includes("action='addobj'")) {
+				return response('<ajax-response><xmsg status="0"/></ajax-response>')
+			}
+		}
+		return null
+	})
+
+	await createAccessNetworksUnleashedAjaxClient({
+		config,
+		controller: createController(),
+	}).addWlan({
+		ssid: 'NewNet',
+		passphrase: 'super-secret',
+	})
+
+	const addBody = fetchMock.mock.calls
+		.map((call) => String(call[1]?.body ?? ''))
+		.find((body) => body.includes("action='addobj'"))
+	expect(addBody).toContain("name='NewNet'")
+	expect(addBody).toContain("ssid='NewNet'")
+	expect(addBody).toContain("passphrase='super-secret'")
+	expect(addBody).not.toMatch(/\bid='99'/)
+})
+
+test('clone wlan duplicates source XML under a new name without the id', async () => {
+	const config = createConfig()
+	const fetchMock = installFetch(loginHandler(), (href, init) => {
+		if (href.endsWith('/_conf.jsp')) {
+			const body = String(init?.body ?? '')
+			if (body.includes("action='getconf'")) {
+				return response(
+					[
+						'<ajax-response><wlansvc-list>',
+						"<wlansvc id='1' name='Main' ssid='Main' encryption='wpa2'>",
+						"<wpa cipher='aes' passphrase='secret' dynamic-psk='disabled'/>",
+						'</wlansvc>',
+						'</wlansvc-list></ajax-response>',
+					].join(''),
+				)
+			}
+			if (body.includes("action='addobj'")) {
+				return response('<ajax-response><xmsg status="0"/></ajax-response>')
+			}
+		}
+		return null
+	})
+
+	await createAccessNetworksUnleashedAjaxClient({
+		config,
+		controller: createController(),
+	}).cloneWlan('Main', 'Backup')
+
+	const addBody = fetchMock.mock.calls
+		.map((call) => String(call[1]?.body ?? ''))
+		.find((body) => body.includes("action='addobj'"))
+	expect(addBody).toContain("name='Backup'")
+	expect(addBody).toContain("ssid='Backup'")
+	expect(addBody).toContain("passphrase='secret'")
+	expect(addBody).not.toMatch(/\bid='1'/)
+})
+
+test('delete wlan posts a delobj request with the resolved id', async () => {
+	const config = createConfig()
+	const fetchMock = installFetch(loginHandler(), (href, init) => {
+		if (href.endsWith('/_conf.jsp')) {
+			const body = String(init?.body ?? '')
+			if (body.includes("action='getconf'")) {
+				return response(
+					[
+						'<ajax-response><wlansvc-list>',
+						"<wlansvc id='42' name='Guest' ssid='Guest'/>",
+						'</wlansvc-list></ajax-response>',
+					].join(''),
+				)
+			}
+			if (body.includes("action='delobj'")) {
+				return response('<ajax-response><xmsg status="0"/></ajax-response>')
+			}
+		}
+		return null
+	})
+
+	await createAccessNetworksUnleashedAjaxClient({
+		config,
+		controller: createController(),
+	}).deleteWlan('Guest')
+
+	const delBody = fetchMock.mock.calls
+		.map((call) => String(call[1]?.body ?? ''))
+		.find((body) => body.includes("action='delobj'"))
+	expect(delBody).toContain("id='42'")
+	expect(delBody).toContain("comp='wlansvc-list'")
+})
+
+test('add wlan group posts addobj with named members resolved to ids', async () => {
+	const config = createConfig()
+	const fetchMock = installFetch(loginHandler(), (href, init) => {
+		if (href.endsWith('/_conf.jsp')) {
+			const body = String(init?.body ?? '')
+			if (body.includes("action='getconf'")) {
+				return response(
+					[
+						'<ajax-response><wlansvc-list>',
+						"<wlansvc id='1' name='Main' ssid='Main'/>",
+						"<wlansvc id='2' name='Guest' ssid='Guest'/>",
+						'</wlansvc-list></ajax-response>',
+					].join(''),
+				)
+			}
+			if (body.includes("action='addobj'")) {
+				return response('<ajax-response><xmsg status="0"/></ajax-response>')
+			}
+		}
+		return null
+	})
+
+	await createAccessNetworksUnleashedAjaxClient({
+		config,
+		controller: createController(),
+	}).addWlanGroup({
+		name: 'House',
+		description: 'home group',
+		wlans: ['Main', 'Guest'],
+	})
+
+	const addBody = fetchMock.mock.calls
+		.map((call) => String(call[1]?.body ?? ''))
+		.find((body) => body.includes("action='addobj'"))
+	expect(addBody).toContain("comp='wlangroup-list'")
+	expect(addBody).toContain("name='House'")
+	expect(addBody).toContain("description='home group'")
+	expect(addBody).toContain("<wlansvc id='1'/>")
+	expect(addBody).toContain("<wlansvc id='2'/>")
+})
+
+test('delete wlan group posts delobj with the resolved id', async () => {
+	const config = createConfig()
+	const fetchMock = installFetch(loginHandler(), (href, init) => {
+		if (href.endsWith('/_conf.jsp')) {
+			const body = String(init?.body ?? '')
+			if (body.includes("action='getconf'")) {
+				return response(
+					[
+						'<ajax-response><wlangroup-list>',
+						"<wlangroup id='7' name='House' description='home'/>",
+						'</wlangroup-list></ajax-response>',
+					].join(''),
+				)
+			}
+			if (body.includes("action='delobj'")) {
+				return response('<ajax-response><xmsg status="0"/></ajax-response>')
+			}
+		}
+		return null
+	})
+
+	await createAccessNetworksUnleashedAjaxClient({
+		config,
+		controller: createController(),
+	}).deleteWlanGroup('House')
+
+	const delBody = fetchMock.mock.calls
+		.map((call) => String(call[1]?.body ?? ''))
+		.find((body) => body.includes("action='delobj'"))
+	expect(delBody).toContain("id='7'")
+	expect(delBody).toContain("comp='wlangroup-list'")
+})
+
+test('list active rogues issues a stamgr cmdstat request', async () => {
+	const config = createConfig()
+	const fetchMock = installFetch(loginHandler(), (href, init) => {
+		if (href.endsWith('/_cmdstat.jsp')) {
+			const body = String(init?.body ?? '')
+			if (body.includes('<rogue') && body.includes("comp='stamgr'")) {
+				return response(
+					'<ajax-response><rogue mac="11:22:33:44:55:66" ssid="rogue-net"/></ajax-response>',
+				)
+			}
+		}
+		return null
+	})
+	const rogues = await createAccessNetworksUnleashedAjaxClient({
+		config,
+		controller: createController(),
+	}).listActiveRogues()
+	expect(rogues).toEqual([
+		expect.objectContaining({ mac: '11:22:33:44:55:66' }),
+	])
+	expect(
+		fetchMock.mock.calls.some((call) =>
+			String(call[1]?.body ?? '').includes("recognized='!true'"),
+		),
+	).toBe(true)
+})
+
 test('failed login does not leave a partial session', async () => {
 	const config = createConfig()
 	let rejectedLogin = true

--- a/packages/home-connector/src/adapters/access-networks-unleashed/client.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/client.ts
@@ -1,7 +1,10 @@
 import { type HomeConnectorConfig } from '../../config.ts'
 import { fetchAccessNetworksUnleashed } from './http.ts'
 import {
+	type AccessNetworksUnleashedAddWlanGroupInput,
+	type AccessNetworksUnleashedAddWlanInput,
 	type AccessNetworksUnleashedClient,
+	type AccessNetworksUnleashedEditWlanInput,
 	type AccessNetworksUnleashedPersistedController,
 	type AccessNetworksUnleashedRecord,
 } from './types.ts'
@@ -416,6 +419,158 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 		)
 	}
 
+	async function getConfRaw(component: string) {
+		return await postXml(
+			'_conf.jsp',
+			`<ajax-request action='getconf' DECRYPT_X='true' updater='${escapeXmlAttribute(component)}.0.5' comp='${escapeXmlAttribute(component)}'/>`,
+			undefined,
+			true,
+		)
+	}
+
+	async function getWlanRawXml(name: string) {
+		const xml = await getConfRaw('wlansvc-list')
+		return extractElementByAttribute({
+			xml,
+			tagName: 'wlansvc',
+			attributeName: 'name',
+			attributeValue: name,
+		})
+	}
+
+	async function getDefaultWlanTemplateXml() {
+		const xml = await getConfRaw('wlansvc-standard-template')
+		const elementRegex = /<wlansvc(?=[\s>/])[^>]*>[\s\S]*?<\/wlansvc>|<wlansvc(?=[\s>/])[^>]*\/>/i
+		const match = elementRegex.exec(xml)
+		if (!match) {
+			throw new Error(
+				'Access Networks Unleashed default WLAN template was not returned by the controller.',
+			)
+		}
+		return match[0]
+	}
+
+	function setOrAddAttribute(elementXml: string, name: string, value: string) {
+		const escapedValue = escapeXmlAttribute(value)
+		const attrPattern = new RegExp(
+			`(\\s${name}\\s*=\\s*)(["'])(.*?)\\2`,
+			'i',
+		)
+		if (attrPattern.test(elementXml)) {
+			return elementXml.replace(attrPattern, `$1'${escapedValue}'`)
+		}
+		return elementXml.replace(/^<(\w[\w-]*)/i, `<$1 ${name}='${escapedValue}'`)
+	}
+
+	function removeRootIdAttribute(elementXml: string) {
+		const openTagMatch = /^<(\w[\w-]*)([^>]*)>/i.exec(elementXml)
+		if (!openTagMatch) return elementXml
+		const tagName = openTagMatch[1] ?? ''
+		let attributes = openTagMatch[2] ?? ''
+		attributes = attributes.replace(/\s+id\s*=\s*(["'])(.*?)\1/i, '')
+		return `<${tagName}${attributes}>${elementXml.slice(openTagMatch[0].length)}`
+	}
+
+	function getAttributeValue(elementXml: string, name: string): string | null {
+		const attrPattern = new RegExp(
+			`\\s${name}\\s*=\\s*(["'])(.*?)\\1`,
+			'i',
+		)
+		const match = attrPattern.exec(elementXml)
+		return match ? decodeXmlEntities(match[2] ?? '') : null
+	}
+
+	function applyWlanPatch(
+		elementXml: string,
+		patch: {
+			name?: string
+			ssid?: string
+			description?: string
+			passphrase?: string
+			saePassphrase?: string
+			enableType?: 0 | 1
+		},
+	) {
+		let updated = elementXml
+		if (patch.name !== undefined) {
+			updated = setOrAddAttribute(updated, 'name', patch.name)
+		}
+		if (patch.ssid !== undefined) {
+			updated = setOrAddAttribute(updated, 'ssid', patch.ssid)
+		}
+		if (patch.description !== undefined) {
+			updated = setOrAddAttribute(updated, 'description', patch.description)
+		}
+		if (patch.enableType !== undefined) {
+			updated = setOrAddAttribute(
+				updated,
+				'enable-type',
+				String(patch.enableType),
+			)
+		}
+		if (patch.passphrase !== undefined || patch.saePassphrase !== undefined) {
+			const wpaRegex = /<wpa(?=[\s>/])([^>]*)(\/?>)/i
+			const wpaMatch = wpaRegex.exec(updated)
+			if (wpaMatch) {
+				let wpaTag = wpaMatch[0]
+				if (patch.passphrase !== undefined) {
+					wpaTag = setOrAddAttribute(wpaTag, 'passphrase', patch.passphrase)
+				}
+				if (patch.saePassphrase !== undefined) {
+					wpaTag = setOrAddAttribute(
+						wpaTag,
+						'sae-passphrase',
+						patch.saePassphrase,
+					)
+				}
+				updated = updated.replace(wpaRegex, wpaTag)
+			} else {
+				const wpaAttrs: Array<string> = ["cipher='aes'", "dynamic-psk='disabled'"]
+				if (patch.passphrase !== undefined) {
+					wpaAttrs.push(
+						`passphrase='${escapeXmlAttribute(patch.passphrase)}'`,
+					)
+				}
+				if (patch.saePassphrase !== undefined) {
+					wpaAttrs.push(
+						`sae-passphrase='${escapeXmlAttribute(patch.saePassphrase)}'`,
+					)
+				}
+				const wpaTag = `<wpa ${wpaAttrs.join(' ')}/>`
+				if (/\/>$/.test(updated)) {
+					updated = updated.replace(/\/>$/, `>${wpaTag}</wlansvc>`)
+				} else {
+					updated = updated.replace(
+						/<\/wlansvc>$/,
+						`${wpaTag}</wlansvc>`,
+					)
+				}
+			}
+		}
+		return updated
+	}
+
+	async function piecewiseCmdstat(input: {
+		comp: string
+		elementXml: string
+		updater: string
+		tagNames: Array<string>
+		limit: number
+	}) {
+		const ts = Date.now()
+		const rand = Math.random().toString(36).slice(2, 10)
+		const requestId = `${input.updater}.${ts}`
+		const cleanupId = `${input.updater}.${ts}.${rand}`
+		const xml = `<ajax-request action='getstat' comp='${escapeXmlAttribute(input.comp)}' updater='${escapeXmlAttribute(`${input.updater}.${ts}.${rand}`)}'>${input.elementXml}<pieceStat pid='1' start='0' number='${input.limit}' requestId='${escapeXmlAttribute(requestId)}' cleanupId='${escapeXmlAttribute(cleanupId)}'/></ajax-request>`
+		const response = await postXml('_cmdstat.jsp', xml, undefined, true)
+		return pickFirstRecords(response, input.tagNames)
+	}
+
+	function clampLimit(limit: number | undefined, fallback: number, max: number) {
+		if (limit == null || !Number.isFinite(limit)) return fallback
+		return Math.max(1, Math.min(max, Math.trunc(limit)))
+	}
+
 	const client: AccessNetworksUnleashedClient = {
 		async getSystemInfo() {
 			const records = await cmdstat(
@@ -509,6 +664,278 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 			await postXml(
 				'_conf.jsp',
 				`<ajax-request action='updobj' updater='ap-list.${Date.now()}' comp='ap-list'><ap id='${escapeXmlAttribute(String(ap['id'] ?? ''))}' IS_PARTIAL='true' led-off='${enabled ? 'false' : 'true'}' /></ajax-request>`,
+			)
+		},
+		async listBlockedClients() {
+			const xml = await getConfRaw('acl-list')
+			const acls = parseElements(xml, 'acl')
+			const systemAcl =
+				acls.find((acl) => String(acl['id'] ?? '') === '1') ?? acls[0]
+			if (!systemAcl) return []
+			const aclXml = String(systemAcl['rawXml'] ?? '')
+			return parseElements(aclXml, 'deny')
+		},
+		async listInactiveClients() {
+			return await cmdstat(
+				"<ajax-request action='getstat' comp='stamgr' enable-gzip='0'><clientlist period='0' /></ajax-request>",
+				['client'],
+			)
+		},
+		async listActiveRogues() {
+			return await cmdstat(
+				"<ajax-request action='getstat' comp='stamgr' enable-gzip='0'><rogue LEVEL='1' recognized='!true'/></ajax-request>",
+				['rogue'],
+			)
+		},
+		async listKnownRogues(limit = 300) {
+			return await piecewiseCmdstat({
+				comp: 'stamgr',
+				elementXml: `<rogue sortBy='time' sortDirection='-1' LEVEL='1' recognized='true'/>`,
+				updater: 'krogue',
+				tagNames: ['rogue'],
+				limit: clampLimit(limit, 300, 1000),
+			})
+		},
+		async listBlockedRogues(limit = 300) {
+			return await piecewiseCmdstat({
+				comp: 'stamgr',
+				elementXml: `<rogue sortBy='time' sortDirection='-1' LEVEL='1' blocked='true'/>`,
+				updater: 'brogue',
+				tagNames: ['rogue'],
+				limit: clampLimit(limit, 300, 1000),
+			})
+		},
+		async listApGroups() {
+			return await getConf('apgroup-list', ['apgroup'])
+		},
+		async listDpsks() {
+			return await getConf('dpsk-list', ['dpsk'])
+		},
+		async getMeshInfo() {
+			const meshes = await getConf('mesh-list', ['mesh'])
+			return meshes[0] ?? {}
+		},
+		async getAlarms(limit = 300) {
+			return await piecewiseCmdstat({
+				comp: 'eventd',
+				elementXml: `<alarm sortBy='time' sortDirection='-1'/>`,
+				updater: 'page',
+				tagNames: ['alarm'],
+				limit: clampLimit(limit, 300, 1000),
+			})
+		},
+		async getSyslog() {
+			const ts = Date.now()
+			const response = await postXml(
+				'_cmdstat.jsp',
+				`<ajax-request action='docmd' xcmd='get-syslog' updater='system.${ts}' comp='system'><xcmd cmd='get-syslog' type='sys'/></ajax-request>`,
+				undefined,
+				true,
+			)
+			const xmsgRecords = parseElements(response, 'xmsg')
+			const firstXmsg = xmsgRecords[0]
+			if (firstXmsg && typeof firstXmsg['res'] === 'string') {
+				return String(firstXmsg['res'])
+			}
+			const resMatch = /<res\b[^>]*>([\s\S]*?)<\/res>/i.exec(response)
+			if (resMatch && resMatch[1] !== undefined) {
+				return decodeXmlEntities(resMatch[1])
+			}
+			const resAttr =
+				firstXmsg && typeof firstXmsg['res'] !== 'undefined'
+					? firstXmsg['res']
+					: null
+			return resAttr == null ? '' : String(resAttr)
+		},
+		async getVapStats() {
+			return await cmdstat(
+				"<ajax-request action='getstat' comp='stamgr' enable-gzip='0' caller='SCI'><vap INTERVAL-STATS='no' LEVEL='1'/></ajax-request>",
+				['vap'],
+			)
+		},
+		async getWlanGroupStats() {
+			return await cmdstat(
+				"<ajax-request action='getstat' comp='stamgr' enable-gzip='0' caller='SCI'><wlangroup/></ajax-request>",
+				['wlangroup', 'wlan'],
+			)
+		},
+		async getApGroupStats() {
+			return await cmdstat(
+				"<ajax-request action='getstat' comp='stamgr' enable-gzip='0'><apgroup/></ajax-request>",
+				['group', 'apgroup'],
+			)
+		},
+		async setWlanPassword(name, passphrase, saePassphrase) {
+			const wlanXml = await getWlanRawXml(name)
+			if (!wlanXml) {
+				throw new Error(
+					`Access Networks Unleashed WLAN "${name}" was not found.`,
+				)
+			}
+			const updated = applyWlanPatch(wlanXml, {
+				passphrase,
+				saePassphrase: saePassphrase ?? passphrase,
+			})
+			await postXml(
+				'_conf.jsp',
+				`<ajax-request action='updobj' updater='wlan' comp='wlansvc-list'>${updated}</ajax-request>`,
+				20_000,
+			)
+		},
+		async addWlan(input: AccessNetworksUnleashedAddWlanInput) {
+			const template = await getDefaultWlanTemplateXml()
+			const wlanName = input.name?.trim() || input.ssid
+			let updated = applyWlanPatch(template, {
+				name: wlanName,
+				ssid: input.ssid,
+				description: input.description,
+				passphrase: input.passphrase,
+				saePassphrase: input.saePassphrase ?? input.passphrase,
+			})
+			updated = removeRootIdAttribute(updated)
+			await postXml(
+				'_conf.jsp',
+				`<ajax-request action='addobj' updater='wlansvc-list' comp='wlansvc-list'>${updated}</ajax-request>`,
+				20_000,
+			)
+		},
+		async editWlan(input: AccessNetworksUnleashedEditWlanInput) {
+			const wlanXml = await getWlanRawXml(input.name)
+			if (!wlanXml) {
+				throw new Error(
+					`Access Networks Unleashed WLAN "${input.name}" was not found.`,
+				)
+			}
+			const patch: Parameters<typeof applyWlanPatch>[1] = {}
+			if (input.ssid !== undefined) patch.ssid = input.ssid
+			if (input.description !== undefined) patch.description = input.description
+			if (input.passphrase !== undefined) patch.passphrase = input.passphrase
+			if (input.saePassphrase !== undefined) {
+				patch.saePassphrase = input.saePassphrase
+			} else if (input.passphrase !== undefined) {
+				patch.saePassphrase = input.passphrase
+			}
+			if (input.enabled !== undefined) {
+				patch.enableType = input.enabled ? 0 : 1
+			}
+			const updated = applyWlanPatch(wlanXml, patch)
+			await postXml(
+				'_conf.jsp',
+				`<ajax-request action='updobj' updater='wlan' comp='wlansvc-list'>${updated}</ajax-request>`,
+				20_000,
+			)
+		},
+		async cloneWlan(sourceName, newName, newSsid) {
+			const sourceXml = await getWlanRawXml(sourceName)
+			if (!sourceXml) {
+				throw new Error(
+					`Access Networks Unleashed WLAN "${sourceName}" was not found.`,
+				)
+			}
+			let updated = removeRootIdAttribute(sourceXml)
+			updated = applyWlanPatch(updated, {
+				name: newName,
+				ssid: newSsid ?? newName,
+			})
+			await postXml(
+				'_conf.jsp',
+				`<ajax-request action='addobj' updater='wlansvc-list' comp='wlansvc-list'>${updated}</ajax-request>`,
+				20_000,
+			)
+		},
+		async deleteWlan(name) {
+			const wlan = await findWlan(name)
+			if (!wlan) {
+				throw new Error(
+					`Access Networks Unleashed WLAN "${name}" was not found.`,
+				)
+			}
+			await postXml(
+				'_conf.jsp',
+				`<ajax-request action='delobj' updater='wlansvc-list.${Date.now()}' comp='wlansvc-list'><wlansvc id='${escapeXmlAttribute(String(wlan['id'] ?? ''))}'/></ajax-request>`,
+				20_000,
+			)
+		},
+		async addWlanGroup(input: AccessNetworksUnleashedAddWlanGroupInput) {
+			const description = input.description ?? ''
+			let body = `<wlangroup name='${escapeXmlAttribute(input.name)}' description='${escapeXmlAttribute(description)}'>`
+			if (input.wlans && input.wlans.length > 0) {
+				const wlans = await getConf('wlansvc-list', ['wlansvc'])
+				const wlanByName = new Map(
+					wlans.map((wlan) => [String(wlan['name'] ?? ''), wlan] as const),
+				)
+				for (const wlanName of input.wlans) {
+					const wlan = wlanByName.get(wlanName)
+					if (!wlan) {
+						throw new Error(
+							`Access Networks Unleashed WLAN "${wlanName}" was not found.`,
+						)
+					}
+					body += `<wlansvc id='${escapeXmlAttribute(String(wlan['id'] ?? ''))}'/>`
+				}
+			}
+			body += `</wlangroup>`
+			await postXml(
+				'_conf.jsp',
+				`<ajax-request action='addobj' comp='wlangroup-list' updater='wgroup'>${body}</ajax-request>`,
+				20_000,
+			)
+		},
+		async cloneWlanGroup(sourceName, newName, description) {
+			const xml = await getConfRaw('wlangroup-list')
+			const sourceXml = extractElementByAttribute({
+				xml,
+				tagName: 'wlangroup',
+				attributeName: 'name',
+				attributeValue: sourceName,
+			})
+			if (!sourceXml) {
+				throw new Error(
+					`Access Networks Unleashed WLAN group "${sourceName}" was not found.`,
+				)
+			}
+			const sourceDescription = getAttributeValue(sourceXml, 'description') ?? ''
+			const wlanIdMatches = sourceXml.matchAll(
+				/<wlansvc\b[^>]*\bid\s*=\s*(["'])(.*?)\1[^>]*\/?>/gi,
+			)
+			const childIds: Array<string> = []
+			for (const match of wlanIdMatches) {
+				if (match[2]) childIds.push(decodeXmlEntities(match[2]))
+			}
+			let body = `<wlangroup name='${escapeXmlAttribute(newName)}' description='${escapeXmlAttribute(description ?? sourceDescription)}'>`
+			for (const id of childIds) {
+				body += `<wlansvc id='${escapeXmlAttribute(id)}'/>`
+			}
+			body += `</wlangroup>`
+			await postXml(
+				'_conf.jsp',
+				`<ajax-request action='addobj' comp='wlangroup-list' updater='wgroup'>${body}</ajax-request>`,
+				20_000,
+			)
+		},
+		async deleteWlanGroup(name) {
+			const xml = await getConfRaw('wlangroup-list')
+			const sourceXml = extractElementByAttribute({
+				xml,
+				tagName: 'wlangroup',
+				attributeName: 'name',
+				attributeValue: name,
+			})
+			if (!sourceXml) {
+				throw new Error(
+					`Access Networks Unleashed WLAN group "${name}" was not found.`,
+				)
+			}
+			const id = getAttributeValue(sourceXml, 'id')
+			if (!id) {
+				throw new Error(
+					`Access Networks Unleashed WLAN group "${name}" is missing an id.`,
+				)
+			}
+			await postXml(
+				'_conf.jsp',
+				`<ajax-request action='delobj' updater='wlangroup-list.${Date.now()}' comp='wlangroup-list'><wlangroup id='${escapeXmlAttribute(id)}'/></ajax-request>`,
+				20_000,
 			)
 		},
 	}

--- a/packages/home-connector/src/adapters/access-networks-unleashed/client.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/client.ts
@@ -450,16 +450,24 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 		return match[0]
 	}
 
+	function escapeReplacementString(value: string) {
+		return value.replace(/\$/g, '$$$$')
+	}
+
 	function setOrAddAttribute(elementXml: string, name: string, value: string) {
 		const escapedValue = escapeXmlAttribute(value)
+		const replacementSafeValue = escapeReplacementString(escapedValue)
 		const attrPattern = new RegExp(
 			`(\\s${name}\\s*=\\s*)(["'])(.*?)\\2`,
 			'i',
 		)
 		if (attrPattern.test(elementXml)) {
-			return elementXml.replace(attrPattern, `$1'${escapedValue}'`)
+			return elementXml.replace(attrPattern, `$1'${replacementSafeValue}'`)
 		}
-		return elementXml.replace(/^<(\w[\w-]*)/i, `<$1 ${name}='${escapedValue}'`)
+		return elementXml.replace(
+			/^<(\w[\w-]*)/i,
+			`<$1 ${name}='${replacementSafeValue}'`,
+		)
 	}
 
 	function removeRootIdAttribute(elementXml: string) {
@@ -523,7 +531,7 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 						patch.saePassphrase,
 					)
 				}
-				updated = updated.replace(wpaRegex, wpaTag)
+				updated = updated.replace(wpaRegex, escapeReplacementString(wpaTag))
 			} else {
 				const wpaAttrs: Array<string> = ["cipher='aes'", "dynamic-psk='disabled'"]
 				if (patch.passphrase !== undefined) {
@@ -537,12 +545,16 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 					)
 				}
 				const wpaTag = `<wpa ${wpaAttrs.join(' ')}/>`
+				const wpaTagReplacement = escapeReplacementString(wpaTag)
 				if (/\/>$/.test(updated)) {
-					updated = updated.replace(/\/>$/, `>${wpaTag}</wlansvc>`)
+					updated = updated.replace(
+						/\/>$/,
+						`>${wpaTagReplacement}</wlansvc>`,
+					)
 				} else {
 					updated = updated.replace(
 						/<\/wlansvc>$/,
-						`${wpaTag}</wlansvc>`,
+						`${wpaTagReplacement}</wlansvc>`,
 					)
 				}
 			}
@@ -669,8 +681,7 @@ export function createAccessNetworksUnleashedAjaxClient(input: {
 		async listBlockedClients() {
 			const xml = await getConfRaw('acl-list')
 			const acls = parseElements(xml, 'acl')
-			const systemAcl =
-				acls.find((acl) => String(acl['id'] ?? '') === '1') ?? acls[0]
+			const systemAcl = acls.find((acl) => String(acl['id'] ?? '') === '1')
 			if (!systemAcl) return []
 			const aclXml = String(systemAcl['rawXml'] ?? '')
 			return parseElements(aclXml, 'deny')

--- a/packages/home-connector/src/adapters/access-networks-unleashed/index.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/index.ts
@@ -18,9 +18,12 @@ import {
 	upsertDiscoveredAccessNetworksUnleashedControllers,
 } from './repository.ts'
 import {
+	type AccessNetworksUnleashedAddWlanGroupInput,
+	type AccessNetworksUnleashedAddWlanInput,
 	type AccessNetworksUnleashedConfigStatus,
 	type AccessNetworksUnleashedClient,
 	type AccessNetworksUnleashedDiscoveredController,
+	type AccessNetworksUnleashedEditWlanInput,
 	type AccessNetworksUnleashedPersistedController,
 	type AccessNetworksUnleashedRecord,
 	type AccessNetworksUnleashedSystemStatus,
@@ -60,6 +63,37 @@ type SetAccessPointLedsRequest = AccessPointWriteRequest & {
 	enabled: boolean
 }
 
+type SetWlanPasswordRequest = WriteOperationRequest & {
+	name: string
+	password: string
+	saePassphrase?: string
+}
+
+type AddWlanRequest = WriteOperationRequest &
+	AccessNetworksUnleashedAddWlanInput
+
+type EditWlanRequest = WriteOperationRequest &
+	AccessNetworksUnleashedEditWlanInput
+
+type CloneWlanRequest = WriteOperationRequest & {
+	sourceName: string
+	newName: string
+	newSsid?: string
+}
+
+type AddWlanGroupRequest = WriteOperationRequest &
+	AccessNetworksUnleashedAddWlanGroupInput
+
+type CloneWlanGroupRequest = WriteOperationRequest & {
+	sourceName: string
+	newName: string
+	description?: string
+}
+
+type WlanGroupWriteRequest = WriteOperationRequest & {
+	name: string
+}
+
 const accessNetworksUnleashedWriteAcknowledgements = {
 	blockClient:
 		'I am highly certain blocking this WiFi client on Access Networks Unleashed is necessary right now.',
@@ -73,6 +107,26 @@ const accessNetworksUnleashedWriteAcknowledgements = {
 		'I am highly certain restarting this Access Networks Unleashed access point is necessary right now.',
 	setAccessPointLeds:
 		'I am highly certain changing this Access Networks Unleashed access point LED setting is necessary right now.',
+	setWlanPassword:
+		'I am highly certain changing this Access Networks Unleashed WLAN passphrase is necessary right now.',
+	addWlan:
+		'I am highly certain adding this Access Networks Unleashed WLAN is necessary right now.',
+	editWlan:
+		'I am highly certain editing this Access Networks Unleashed WLAN is necessary right now.',
+	cloneWlan:
+		'I am highly certain cloning this Access Networks Unleashed WLAN is necessary right now.',
+	deleteWlan:
+		'I am highly certain deleting this Access Networks Unleashed WLAN is necessary right now.',
+	addWlanGroup:
+		'I am highly certain adding this Access Networks Unleashed WLAN group is necessary right now.',
+	cloneWlanGroup:
+		'I am highly certain cloning this Access Networks Unleashed WLAN group is necessary right now.',
+	deleteWlanGroup:
+		'I am highly certain deleting this Access Networks Unleashed WLAN group is necessary right now.',
+	hideAccessPointLeds:
+		'I am highly certain turning off Access Networks Unleashed access point LEDs is necessary right now.',
+	showAccessPointLeds:
+		'I am highly certain turning on Access Networks Unleashed access point LEDs is necessary right now.',
 } as const
 
 function getConfigStatus(
@@ -538,6 +592,249 @@ export function createAccessNetworksUnleashedAdapter(input: {
 			return writeResult({
 				operation: 'set-ap-leds',
 				target: macAddress,
+				reason,
+			})
+		},
+		async hideAccessPointLeds(request: AccessPointWriteRequest) {
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.hideAccessPointLeds,
+			)
+			const macAddress = normalizeAccessNetworksUnleashedMacAddress(
+				request.macAddress,
+			)
+			await read(() => createClient().setAccessPointLeds(macAddress, false))
+			return writeResult({
+				operation: 'hide-ap-leds',
+				target: macAddress,
+				reason,
+			})
+		},
+		async showAccessPointLeds(request: AccessPointWriteRequest) {
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.showAccessPointLeds,
+			)
+			const macAddress = normalizeAccessNetworksUnleashedMacAddress(
+				request.macAddress,
+			)
+			await read(() => createClient().setAccessPointLeds(macAddress, true))
+			return writeResult({
+				operation: 'show-ap-leds',
+				target: macAddress,
+				reason,
+			})
+		},
+		async listBlockedClients() {
+			return await read(() => createClient().listBlockedClients())
+		},
+		async listInactiveClients() {
+			return await read(() => createClient().listInactiveClients())
+		},
+		async listActiveRogues() {
+			return await read(() => createClient().listActiveRogues())
+		},
+		async listKnownRogues(limit?: number) {
+			return await read(() =>
+				createClient().listKnownRogues(normalizeLimit(limit, 300, 1000)),
+			)
+		},
+		async listBlockedRogues(limit?: number) {
+			return await read(() =>
+				createClient().listBlockedRogues(normalizeLimit(limit, 300, 1000)),
+			)
+		},
+		async listApGroups() {
+			return await read(() => createClient().listApGroups())
+		},
+		async listDpsks() {
+			return await read(() => createClient().listDpsks())
+		},
+		async getMeshInfo() {
+			return await read(() => createClient().getMeshInfo())
+		},
+		async getAlarms(limit?: number) {
+			return await read(() =>
+				createClient().getAlarms(normalizeLimit(limit, 300, 1000)),
+			)
+		},
+		async getSyslog() {
+			return await read(() => createClient().getSyslog())
+		},
+		async getVapStats() {
+			return await read(() => createClient().getVapStats())
+		},
+		async getWlanGroupStats() {
+			return await read(() => createClient().getWlanGroupStats())
+		},
+		async getApGroupStats() {
+			return await read(() => createClient().getApGroupStats())
+		},
+		async setWlanPassword(request: SetWlanPasswordRequest) {
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.setWlanPassword,
+			)
+			const name = assertNonEmpty(request.name, 'name')
+			const password = assertNonEmpty(request.password, 'password')
+			const saePassphrase =
+				request.saePassphrase == null
+					? undefined
+					: assertNonEmpty(request.saePassphrase, 'saePassphrase')
+			await read(() =>
+				createClient().setWlanPassword(name, password, saePassphrase),
+			)
+			return writeResult({
+				operation: 'set-wlan-password',
+				target: name,
+				reason,
+			})
+		},
+		async addWlan(request: AddWlanRequest) {
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.addWlan,
+			)
+			const ssid = assertNonEmpty(request.ssid, 'ssid')
+			const passphrase = assertNonEmpty(request.passphrase, 'passphrase')
+			const name = request.name == null ? undefined : assertNonEmpty(
+				request.name,
+				'name',
+			)
+			const saePassphrase =
+				request.saePassphrase == null
+					? undefined
+					: assertNonEmpty(request.saePassphrase, 'saePassphrase')
+			const description = request.description?.trim()
+			await read(() =>
+				createClient().addWlan({
+					ssid,
+					passphrase,
+					name,
+					saePassphrase,
+					description,
+				}),
+			)
+			return writeResult({
+				operation: 'add-wlan',
+				target: name ?? ssid,
+				reason,
+			})
+		},
+		async editWlan(request: EditWlanRequest) {
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.editWlan,
+			)
+			const name = assertNonEmpty(request.name, 'name')
+			const passphrase =
+				request.passphrase == null
+					? undefined
+					: assertNonEmpty(request.passphrase, 'passphrase')
+			const saePassphrase =
+				request.saePassphrase == null
+					? undefined
+					: assertNonEmpty(request.saePassphrase, 'saePassphrase')
+			const ssid =
+				request.ssid == null ? undefined : assertNonEmpty(request.ssid, 'ssid')
+			const description = request.description?.trim()
+			await read(() =>
+				createClient().editWlan({
+					name,
+					passphrase,
+					saePassphrase,
+					ssid,
+					description,
+					enabled: request.enabled,
+				}),
+			)
+			return writeResult({
+				operation: 'edit-wlan',
+				target: name,
+				reason,
+			})
+		},
+		async cloneWlan(request: CloneWlanRequest) {
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.cloneWlan,
+			)
+			const sourceName = assertNonEmpty(request.sourceName, 'sourceName')
+			const newName = assertNonEmpty(request.newName, 'newName')
+			const newSsid =
+				request.newSsid == null
+					? undefined
+					: assertNonEmpty(request.newSsid, 'newSsid')
+			await read(() => createClient().cloneWlan(sourceName, newName, newSsid))
+			return writeResult({
+				operation: 'clone-wlan',
+				target: `${sourceName} -> ${newName}`,
+				reason,
+			})
+		},
+		async deleteWlan(request: WlanWriteRequest) {
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.deleteWlan,
+			)
+			const name = assertNonEmpty(request.name, 'name')
+			await read(() => createClient().deleteWlan(name))
+			return writeResult({
+				operation: 'delete-wlan',
+				target: name,
+				reason,
+			})
+		},
+		async addWlanGroup(request: AddWlanGroupRequest) {
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.addWlanGroup,
+			)
+			const name = assertNonEmpty(request.name, 'name')
+			const description = request.description?.trim()
+			const wlans = request.wlans?.map((wlanName, index) =>
+				assertNonEmpty(wlanName, `wlans[${index}]`),
+			)
+			await read(() =>
+				createClient().addWlanGroup({
+					name,
+					description,
+					wlans,
+				}),
+			)
+			return writeResult({
+				operation: 'add-wlan-group',
+				target: name,
+				reason,
+			})
+		},
+		async cloneWlanGroup(request: CloneWlanGroupRequest) {
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.cloneWlanGroup,
+			)
+			const sourceName = assertNonEmpty(request.sourceName, 'sourceName')
+			const newName = assertNonEmpty(request.newName, 'newName')
+			const description = request.description?.trim()
+			await read(() =>
+				createClient().cloneWlanGroup(sourceName, newName, description),
+			)
+			return writeResult({
+				operation: 'clone-wlan-group',
+				target: `${sourceName} -> ${newName}`,
+				reason,
+			})
+		},
+		async deleteWlanGroup(request: WlanGroupWriteRequest) {
+			const reason = assertWriteAllowed(
+				request,
+				accessNetworksUnleashedWriteAcknowledgements.deleteWlanGroup,
+			)
+			const name = assertNonEmpty(request.name, 'name')
+			await read(() => createClient().deleteWlanGroup(name))
+			return writeResult({
+				operation: 'delete-wlan-group',
+				target: name,
 				reason,
 			})
 		},

--- a/packages/home-connector/src/adapters/access-networks-unleashed/types.ts
+++ b/packages/home-connector/src/adapters/access-networks-unleashed/types.ts
@@ -91,6 +91,16 @@ export type AccessNetworksUnleashedWriteOperationId =
 	| 'disable-wlan'
 	| 'restart-ap'
 	| 'set-ap-leds'
+	| 'set-wlan-password'
+	| 'add-wlan'
+	| 'edit-wlan'
+	| 'clone-wlan'
+	| 'delete-wlan'
+	| 'add-wlan-group'
+	| 'clone-wlan-group'
+	| 'delete-wlan-group'
+	| 'hide-ap-leds'
+	| 'show-ap-leds'
 
 export type AccessNetworksUnleashedWriteOperationResult = {
 	operation: AccessNetworksUnleashedWriteOperationId
@@ -99,15 +109,71 @@ export type AccessNetworksUnleashedWriteOperationResult = {
 	completedAt: string
 }
 
+export type AccessNetworksUnleashedAddWlanInput = {
+	ssid: string
+	passphrase: string
+	name?: string
+	saePassphrase?: string
+	description?: string
+}
+
+export type AccessNetworksUnleashedEditWlanInput = {
+	name: string
+	passphrase?: string
+	saePassphrase?: string
+	description?: string
+	ssid?: string
+	enabled?: boolean
+}
+
+export type AccessNetworksUnleashedAddWlanGroupInput = {
+	name: string
+	description?: string
+	wlans?: Array<string>
+}
+
 export type AccessNetworksUnleashedClient = {
 	getSystemInfo(): Promise<AccessNetworksUnleashedRecord>
 	listClients(): Promise<Array<AccessNetworksUnleashedRecord>>
 	listAccessPoints(): Promise<Array<AccessNetworksUnleashedRecord>>
 	listWlans(): Promise<Array<AccessNetworksUnleashedRecord>>
 	listEvents(limit?: number): Promise<Array<AccessNetworksUnleashedRecord>>
+	listBlockedClients(): Promise<Array<AccessNetworksUnleashedRecord>>
+	listInactiveClients(): Promise<Array<AccessNetworksUnleashedRecord>>
+	listActiveRogues(): Promise<Array<AccessNetworksUnleashedRecord>>
+	listKnownRogues(
+		limit?: number,
+	): Promise<Array<AccessNetworksUnleashedRecord>>
+	listBlockedRogues(
+		limit?: number,
+	): Promise<Array<AccessNetworksUnleashedRecord>>
+	listApGroups(): Promise<Array<AccessNetworksUnleashedRecord>>
+	listDpsks(): Promise<Array<AccessNetworksUnleashedRecord>>
+	getMeshInfo(): Promise<AccessNetworksUnleashedRecord>
+	getAlarms(limit?: number): Promise<Array<AccessNetworksUnleashedRecord>>
+	getSyslog(): Promise<string>
+	getVapStats(): Promise<Array<AccessNetworksUnleashedRecord>>
+	getWlanGroupStats(): Promise<Array<AccessNetworksUnleashedRecord>>
+	getApGroupStats(): Promise<Array<AccessNetworksUnleashedRecord>>
 	blockClient(macAddress: string): Promise<void>
 	unblockClient(macAddress: string): Promise<void>
 	setWlanEnabled(name: string, enabled: boolean): Promise<void>
+	setWlanPassword(
+		name: string,
+		passphrase: string,
+		saePassphrase?: string,
+	): Promise<void>
+	addWlan(input: AccessNetworksUnleashedAddWlanInput): Promise<void>
+	editWlan(input: AccessNetworksUnleashedEditWlanInput): Promise<void>
+	cloneWlan(sourceName: string, newName: string, newSsid?: string): Promise<void>
+	deleteWlan(name: string): Promise<void>
+	addWlanGroup(input: AccessNetworksUnleashedAddWlanGroupInput): Promise<void>
+	cloneWlanGroup(
+		sourceName: string,
+		newName: string,
+		description?: string,
+	): Promise<void>
+	deleteWlanGroup(name: string): Promise<void>
 	restartAccessPoint(macAddress: string): Promise<void>
 	setAccessPointLeds(macAddress: string, enabled: boolean): Promise<void>
 }

--- a/packages/home-connector/src/mcp/register-access-networks-unleashed-tools.ts
+++ b/packages/home-connector/src/mcp/register-access-networks-unleashed-tools.ts
@@ -348,6 +348,230 @@ export function registerAccessNetworksUnleashedHomeConnectorTools(input: {
 		},
 	})
 
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_list_blocked_clients',
+		title: 'List Access Networks Unleashed Blocked Clients',
+		description:
+			'Read the Access Networks Unleashed system ACL blocklist of MAC addresses currently blocked from associating.',
+		handler: async () => {
+			const clients = await accessNetworksUnleashed.listBlockedClients()
+			return {
+				text: `Loaded ${clients.length} Access Networks Unleashed blocked client(s).`,
+				structuredContent: { clients },
+			}
+		},
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_list_inactive_clients',
+		title: 'List Access Networks Unleashed Inactive Clients',
+		description:
+			'Read historical/inactive wireless clients from the configured Access Networks Unleashed controller.',
+		handler: async () => {
+			const clients = await accessNetworksUnleashed.listInactiveClients()
+			return {
+				text: `Loaded ${clients.length} Access Networks Unleashed inactive client(s).`,
+				structuredContent: { clients },
+			}
+		},
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_list_active_rogues',
+		title: 'List Access Networks Unleashed Active Rogues',
+		description:
+			'Read currently detected rogue access points from the configured Access Networks Unleashed controller.',
+		handler: async () => {
+			const rogues = await accessNetworksUnleashed.listActiveRogues()
+			return {
+				text: `Loaded ${rogues.length} Access Networks Unleashed active rogue(s).`,
+				structuredContent: { rogues },
+			}
+		},
+	})
+
+	const rogueLimitSchema = buildToolInputSchema({
+		limit: z
+			.number()
+			.int()
+			.min(1)
+			.max(1000)
+			.optional()
+			.describe('Maximum number of rogues to return.'),
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_list_known_rogues',
+		title: 'List Access Networks Unleashed Known Rogues',
+		description:
+			'Read recognized/acknowledged rogue access points from the configured Access Networks Unleashed controller.',
+		inputSchema: rogueLimitSchema,
+		handler: async (args) => {
+			const rogues = await accessNetworksUnleashed.listKnownRogues(
+				args['limit'] == null ? undefined : Number(args['limit']),
+			)
+			return {
+				text: `Loaded ${rogues.length} Access Networks Unleashed known rogue(s).`,
+				structuredContent: { rogues },
+			}
+		},
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_list_blocked_rogues',
+		title: 'List Access Networks Unleashed Blocked Rogues',
+		description:
+			'Read user-blocked rogue access points from the configured Access Networks Unleashed controller.',
+		inputSchema: rogueLimitSchema,
+		handler: async (args) => {
+			const rogues = await accessNetworksUnleashed.listBlockedRogues(
+				args['limit'] == null ? undefined : Number(args['limit']),
+			)
+			return {
+				text: `Loaded ${rogues.length} Access Networks Unleashed blocked rogue(s).`,
+				structuredContent: { rogues },
+			}
+		},
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_list_ap_groups',
+		title: 'List Access Networks Unleashed AP Groups',
+		description:
+			'Read AP group configuration from the configured Access Networks Unleashed controller.',
+		handler: async () => {
+			const apGroups = await accessNetworksUnleashed.listApGroups()
+			return {
+				text: `Loaded ${apGroups.length} Access Networks Unleashed AP group(s).`,
+				structuredContent: { apGroups },
+			}
+		},
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_list_dpsks',
+		title: 'List Access Networks Unleashed DPSKs',
+		description:
+			'Read Dynamic PSK (DPSK) configuration from the configured Access Networks Unleashed controller.',
+		handler: async () => {
+			const dpsks = await accessNetworksUnleashed.listDpsks()
+			return {
+				text: `Loaded ${dpsks.length} Access Networks Unleashed DPSK(s).`,
+				structuredContent: { dpsks },
+			}
+		},
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_get_mesh_info',
+		title: 'Get Access Networks Unleashed Mesh Info',
+		description:
+			'Read mesh topology information from the configured Access Networks Unleashed controller.',
+		handler: async () => {
+			const mesh = await accessNetworksUnleashed.getMeshInfo()
+			return {
+				text: 'Loaded Access Networks Unleashed mesh information.',
+				structuredContent: { mesh },
+			}
+		},
+	})
+
+	const alarmsSchema = buildToolInputSchema({
+		limit: z
+			.number()
+			.int()
+			.min(1)
+			.max(1000)
+			.optional()
+			.describe('Maximum number of active alarms to return.'),
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_get_alarms',
+		title: 'Get Access Networks Unleashed Alarms',
+		description:
+			'Read active alarms from the configured Access Networks Unleashed controller. Alarms are reported separately from controller events.',
+		inputSchema: alarmsSchema,
+		handler: async (args) => {
+			const alarms = await accessNetworksUnleashed.getAlarms(
+				args['limit'] == null ? undefined : Number(args['limit']),
+			)
+			return {
+				text: `Loaded ${alarms.length} Access Networks Unleashed alarm(s).`,
+				structuredContent: { alarms },
+			}
+		},
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_get_syslog',
+		title: 'Get Access Networks Unleashed Syslog',
+		description:
+			'Read raw system syslog text from the configured Access Networks Unleashed controller.',
+		handler: async () => {
+			const syslog = await accessNetworksUnleashed.getSyslog()
+			return {
+				text: `Loaded ${syslog.length} character(s) of Access Networks Unleashed syslog.`,
+				structuredContent: { syslog },
+			}
+		},
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_get_vap_stats',
+		title: 'Get Access Networks Unleashed VAP Stats',
+		description:
+			'Read per-VAP (per-radio-WLAN) throughput statistics from the configured Access Networks Unleashed controller.',
+		handler: async () => {
+			const vaps = await accessNetworksUnleashed.getVapStats()
+			return {
+				text: `Loaded ${vaps.length} Access Networks Unleashed VAP statistic record(s).`,
+				structuredContent: { vaps },
+			}
+		},
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_get_wlan_group_stats',
+		title: 'Get Access Networks Unleashed WLAN Group Stats',
+		description:
+			'Read per-WLAN-group statistics from the configured Access Networks Unleashed controller.',
+		handler: async () => {
+			const wlanGroups = await accessNetworksUnleashed.getWlanGroupStats()
+			return {
+				text: `Loaded ${wlanGroups.length} Access Networks Unleashed WLAN group statistic record(s).`,
+				structuredContent: { wlanGroups },
+			}
+		},
+	})
+
+	registerUnleashedReadTool({
+		registerTool,
+		name: 'access_networks_unleashed_get_ap_group_stats',
+		title: 'Get Access Networks Unleashed AP Group Stats',
+		description:
+			'Read per-AP-group statistics from the configured Access Networks Unleashed controller.',
+		handler: async () => {
+			const apGroups = await accessNetworksUnleashed.getApGroupStats()
+			return {
+				text: `Loaded ${apGroups.length} Access Networks Unleashed AP group statistic record(s).`,
+				structuredContent: { apGroups },
+			}
+		},
+	})
+
 	const clientMutationSchema = (confirmationPhrase: string, target: string) =>
 		buildToolInputSchema({
 			macAddress: z.string().min(1).describe(target),
@@ -540,6 +764,456 @@ export function registerAccessNetworksUnleashedHomeConnectorTools(input: {
 			})
 			return structuredTextResult(
 				`Updated Access Networks Unleashed access point LEDs for ${String(args['macAddress'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	const hideApLedsSchema = apMutationSchema(
+		accessNetworksUnleashed.writeAcknowledgements.hideAccessPointLeds,
+	)
+	const showApLedsSchema = apMutationSchema(
+		accessNetworksUnleashed.writeAcknowledgements.showAccessPointLeds,
+	)
+
+	registerTool(
+		{
+			name: 'access_networks_unleashed_hide_ap_leds',
+			title: 'Hide Access Networks Unleashed Access Point LEDs',
+			description: `${unleashedWriteDangerNotice} This typed operation turns OFF the LEDs on a single access point by MAC address.`,
+			inputSchema: hideApLedsSchema.inputSchema,
+			sdkInputSchema: hideApLedsSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.hideAccessPointLeds({
+				macAddress: String(args['macAddress'] ?? ''),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Hid Access Networks Unleashed access point LEDs for ${String(args['macAddress'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	registerTool(
+		{
+			name: 'access_networks_unleashed_show_ap_leds',
+			title: 'Show Access Networks Unleashed Access Point LEDs',
+			description: `${unleashedWriteDangerNotice} This typed operation turns ON the LEDs on a single access point by MAC address.`,
+			inputSchema: showApLedsSchema.inputSchema,
+			sdkInputSchema: showApLedsSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.showAccessPointLeds({
+				macAddress: String(args['macAddress'] ?? ''),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Showed Access Networks Unleashed access point LEDs for ${String(args['macAddress'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	const setWlanPasswordSchema = buildToolInputSchema({
+		name: z.string().min(1).describe('WLAN/SSID service name to update.'),
+		password: z
+			.string()
+			.min(1)
+			.describe('New WPA2 passphrase for the WLAN.'),
+		saePassphrase: z
+			.string()
+			.min(1)
+			.optional()
+			.describe(
+				'Optional WPA3 SAE passphrase. If omitted, the same value as password is used.',
+			),
+		...createUnleashedWriteSchema(
+			accessNetworksUnleashed.writeAcknowledgements.setWlanPassword,
+		),
+	})
+	registerTool(
+		{
+			name: 'access_networks_unleashed_set_wlan_password',
+			title: 'Set Access Networks Unleashed WLAN Password',
+			description: `${unleashedWriteDangerNotice} This typed operation changes the WPA passphrase on an existing WLAN by name and may force every connected client on that SSID to reconnect.`,
+			inputSchema: markSecretInputFields(setWlanPasswordSchema.inputSchema, [
+				'password',
+				'saePassphrase',
+			]) as Record<string, unknown>,
+			sdkInputSchema: setWlanPasswordSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.setWlanPassword({
+				name: String(args['name'] ?? ''),
+				password: String(args['password'] ?? ''),
+				saePassphrase:
+					args['saePassphrase'] == null
+						? undefined
+						: String(args['saePassphrase']),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Updated Access Networks Unleashed WLAN passphrase for ${String(args['name'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	const addWlanSchema = buildToolInputSchema({
+		ssid: z.string().min(1).describe('SSID for the new WLAN.'),
+		passphrase: z
+			.string()
+			.min(1)
+			.describe('WPA2 passphrase for the new WLAN.'),
+		name: z
+			.string()
+			.min(1)
+			.optional()
+			.describe('Optional WLAN service name. Defaults to the SSID.'),
+		saePassphrase: z
+			.string()
+			.min(1)
+			.optional()
+			.describe('Optional WPA3 SAE passphrase. Defaults to passphrase.'),
+		description: z
+			.string()
+			.optional()
+			.describe('Optional human-readable WLAN description.'),
+		...createUnleashedWriteSchema(
+			accessNetworksUnleashed.writeAcknowledgements.addWlan,
+		),
+	})
+	registerTool(
+		{
+			name: 'access_networks_unleashed_add_wlan',
+			title: 'Add Access Networks Unleashed WLAN',
+			description: `${unleashedWriteDangerNotice} This typed operation creates a new WLAN/SSID on the controller. New WLANs are immediately broadcast on every member access point.`,
+			inputSchema: markSecretInputFields(addWlanSchema.inputSchema, [
+				'passphrase',
+				'saePassphrase',
+			]) as Record<string, unknown>,
+			sdkInputSchema: addWlanSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.addWlan({
+				ssid: String(args['ssid'] ?? ''),
+				passphrase: String(args['passphrase'] ?? ''),
+				name: args['name'] == null ? undefined : String(args['name']),
+				saePassphrase:
+					args['saePassphrase'] == null
+						? undefined
+						: String(args['saePassphrase']),
+				description:
+					args['description'] == null
+						? undefined
+						: String(args['description']),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Added Access Networks Unleashed WLAN ${String(args['ssid'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	const editWlanSchema = buildToolInputSchema({
+		name: z
+			.string()
+			.min(1)
+			.describe('WLAN/SSID service name of the WLAN to edit.'),
+		passphrase: z
+			.string()
+			.min(1)
+			.optional()
+			.describe('Optional new WPA2 passphrase.'),
+		saePassphrase: z
+			.string()
+			.min(1)
+			.optional()
+			.describe('Optional new WPA3 SAE passphrase.'),
+		ssid: z
+			.string()
+			.min(1)
+			.optional()
+			.describe('Optional new SSID broadcast value.'),
+		description: z.string().optional().describe('Optional new WLAN description.'),
+		enabled: z
+			.boolean()
+			.optional()
+			.describe('Optional enabled flag. true enables the WLAN, false disables it.'),
+		...createUnleashedWriteSchema(
+			accessNetworksUnleashed.writeAcknowledgements.editWlan,
+		),
+	})
+	registerTool(
+		{
+			name: 'access_networks_unleashed_edit_wlan',
+			title: 'Edit Access Networks Unleashed WLAN',
+			description: `${unleashedWriteDangerNotice} This typed operation modifies an existing WLAN by name. Provide only the fields you want to change.`,
+			inputSchema: markSecretInputFields(editWlanSchema.inputSchema, [
+				'passphrase',
+				'saePassphrase',
+			]) as Record<string, unknown>,
+			sdkInputSchema: editWlanSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.editWlan({
+				name: String(args['name'] ?? ''),
+				passphrase:
+					args['passphrase'] == null
+						? undefined
+						: String(args['passphrase']),
+				saePassphrase:
+					args['saePassphrase'] == null
+						? undefined
+						: String(args['saePassphrase']),
+				ssid: args['ssid'] == null ? undefined : String(args['ssid']),
+				description:
+					args['description'] == null
+						? undefined
+						: String(args['description']),
+				enabled:
+					typeof args['enabled'] === 'boolean'
+						? args['enabled']
+						: undefined,
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Edited Access Networks Unleashed WLAN ${String(args['name'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	const cloneWlanSchema = buildToolInputSchema({
+		sourceName: z
+			.string()
+			.min(1)
+			.describe('Existing WLAN/SSID service name to copy from.'),
+		newName: z
+			.string()
+			.min(1)
+			.describe('Service name for the new WLAN.'),
+		newSsid: z
+			.string()
+			.min(1)
+			.optional()
+			.describe('Optional SSID for the new WLAN. Defaults to newName.'),
+		...createUnleashedWriteSchema(
+			accessNetworksUnleashed.writeAcknowledgements.cloneWlan,
+		),
+	})
+	registerTool(
+		{
+			name: 'access_networks_unleashed_clone_wlan',
+			title: 'Clone Access Networks Unleashed WLAN',
+			description: `${unleashedWriteDangerNotice} This typed operation duplicates an existing WLAN configuration under a new name and SSID. The clone inherits the source passphrase unless edited afterwards.`,
+			inputSchema: cloneWlanSchema.inputSchema,
+			sdkInputSchema: cloneWlanSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.cloneWlan({
+				sourceName: String(args['sourceName'] ?? ''),
+				newName: String(args['newName'] ?? ''),
+				newSsid:
+					args['newSsid'] == null ? undefined : String(args['newSsid']),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Cloned Access Networks Unleashed WLAN ${String(args['sourceName'] ?? '')} to ${String(args['newName'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	const deleteWlanSchema = wlanMutationSchema(
+		accessNetworksUnleashed.writeAcknowledgements.deleteWlan,
+	)
+	registerTool(
+		{
+			name: 'access_networks_unleashed_delete_wlan',
+			title: 'Delete Access Networks Unleashed WLAN',
+			description: `${unleashedWriteDangerNotice} This typed operation permanently deletes a WLAN/SSID by name. Every client on that SSID will be disconnected, and the WLAN cannot be recovered without re-creating it.`,
+			inputSchema: deleteWlanSchema.inputSchema,
+			sdkInputSchema: deleteWlanSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.deleteWlan({
+				name: String(args['name'] ?? ''),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Deleted Access Networks Unleashed WLAN ${String(args['name'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	const addWlanGroupSchema = buildToolInputSchema({
+		name: z.string().min(1).describe('Name for the new WLAN group.'),
+		description: z
+			.string()
+			.optional()
+			.describe('Optional human-readable description.'),
+		wlans: z
+			.array(z.string().min(1))
+			.optional()
+			.describe(
+				'Optional list of existing WLAN service names to include in the group.',
+			),
+		...createUnleashedWriteSchema(
+			accessNetworksUnleashed.writeAcknowledgements.addWlanGroup,
+		),
+	})
+	registerTool(
+		{
+			name: 'access_networks_unleashed_add_wlan_group',
+			title: 'Add Access Networks Unleashed WLAN Group',
+			description: `${unleashedWriteDangerNotice} This typed operation creates a new WLAN group on the controller and optionally assigns existing WLANs to it.`,
+			inputSchema: addWlanGroupSchema.inputSchema,
+			sdkInputSchema: addWlanGroupSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const wlansArg = args['wlans']
+			const wlans = Array.isArray(wlansArg)
+				? wlansArg.map((value) => String(value))
+				: undefined
+			const result = await accessNetworksUnleashed.addWlanGroup({
+				name: String(args['name'] ?? ''),
+				description:
+					args['description'] == null
+						? undefined
+						: String(args['description']),
+				wlans,
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Added Access Networks Unleashed WLAN group ${String(args['name'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	const cloneWlanGroupSchema = buildToolInputSchema({
+		sourceName: z
+			.string()
+			.min(1)
+			.describe('Existing WLAN group to clone from.'),
+		newName: z
+			.string()
+			.min(1)
+			.describe('Name for the new WLAN group.'),
+		description: z
+			.string()
+			.optional()
+			.describe(
+				'Optional new description. Defaults to the source description.',
+			),
+		...createUnleashedWriteSchema(
+			accessNetworksUnleashed.writeAcknowledgements.cloneWlanGroup,
+		),
+	})
+	registerTool(
+		{
+			name: 'access_networks_unleashed_clone_wlan_group',
+			title: 'Clone Access Networks Unleashed WLAN Group',
+			description: `${unleashedWriteDangerNotice} This typed operation duplicates an existing WLAN group with the same WLAN membership.`,
+			inputSchema: cloneWlanGroupSchema.inputSchema,
+			sdkInputSchema: cloneWlanGroupSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.cloneWlanGroup({
+				sourceName: String(args['sourceName'] ?? ''),
+				newName: String(args['newName'] ?? ''),
+				description:
+					args['description'] == null
+						? undefined
+						: String(args['description']),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Cloned Access Networks Unleashed WLAN group ${String(args['sourceName'] ?? '')} to ${String(args['newName'] ?? '')}.`,
+				result,
+			)
+		},
+	)
+
+	const deleteWlanGroupSchema = buildToolInputSchema({
+		name: z
+			.string()
+			.min(1)
+			.describe('Name of the WLAN group to delete.'),
+		...createUnleashedWriteSchema(
+			accessNetworksUnleashed.writeAcknowledgements.deleteWlanGroup,
+		),
+	})
+	registerTool(
+		{
+			name: 'access_networks_unleashed_delete_wlan_group',
+			title: 'Delete Access Networks Unleashed WLAN Group',
+			description: `${unleashedWriteDangerNotice} This typed operation permanently deletes a WLAN group by name. Existing WLAN definitions are not removed, but APs that referenced this group will revert to the default group.`,
+			inputSchema: deleteWlanGroupSchema.inputSchema,
+			sdkInputSchema: deleteWlanGroupSchema.sdkInputSchema,
+			annotations: {
+				destructiveHint: true,
+			},
+		},
+		async (args) => {
+			const result = await accessNetworksUnleashed.deleteWlanGroup({
+				name: String(args['name'] ?? ''),
+				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
+				reason: String(args['reason'] ?? ''),
+				confirmation: String(args['confirmation'] ?? ''),
+			})
+			return structuredTextResult(
+				`Deleted Access Networks Unleashed WLAN group ${String(args['name'] ?? '')}.`,
 				result,
 			)
 		},

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -1332,6 +1332,128 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 			args: [1],
 		})
 
+		const accessNetworksBlocked = await mcp.callTool(
+			'access_networks_unleashed_list_blocked_clients',
+		)
+		expect(accessNetworksBlocked.structuredContent).toMatchObject({
+			clients: expect.arrayContaining([
+				expect.objectContaining({ mac: 'aa:bb:cc:dd:ee:ff' }),
+			]),
+		})
+
+		const accessNetworksAlarms = await mcp.callTool(
+			'access_networks_unleashed_get_alarms',
+			{ limit: 5 },
+		)
+		expect(accessNetworksAlarms.structuredContent).toMatchObject({
+			alarms: expect.arrayContaining([
+				expect.objectContaining({ message: 'AP rebooted' }),
+			]),
+		})
+		expect(fakeAccessNetworksUnleashed.calls).toContainEqual({
+			name: 'getAlarms',
+			args: [5],
+		})
+
+		const accessNetworksMesh = await mcp.callTool(
+			'access_networks_unleashed_get_mesh_info',
+		)
+		expect(accessNetworksMesh.structuredContent).toMatchObject({
+			mesh: expect.objectContaining({ enabled: true }),
+		})
+
+		const accessNetworksSyslog = await mcp.callTool(
+			'access_networks_unleashed_get_syslog',
+		)
+		expect(accessNetworksSyslog.structuredContent).toMatchObject({
+			syslog: expect.stringContaining('line'),
+		})
+
+		const accessNetworksUnblock = await mcp.callTool(
+			'access_networks_unleashed_unblock_client',
+			{
+				macAddress: 'AA-BB-CC-DD-EE-FF',
+				acknowledgeHighRisk: true,
+				reason:
+					'The client was previously blocked in error and must be allowed again.',
+				confirmation:
+					accessNetworksUnleashed.writeAcknowledgements.unblockClient,
+			},
+		)
+		expect(accessNetworksUnblock.structuredContent).toMatchObject({
+			operation: 'unblock-client',
+			target: 'aa:bb:cc:dd:ee:ff',
+		})
+		expect(fakeAccessNetworksUnleashed.calls).toContainEqual({
+			name: 'unblockClient',
+			args: ['aa:bb:cc:dd:ee:ff'],
+		})
+
+		const accessNetworksDeleteWlan = await mcp.callTool(
+			'access_networks_unleashed_delete_wlan',
+			{
+				name: 'Main',
+				acknowledgeHighRisk: true,
+				reason:
+					'The Main WLAN must be removed because it is no longer needed.',
+				confirmation:
+					accessNetworksUnleashed.writeAcknowledgements.deleteWlan,
+			},
+		)
+		expect(accessNetworksDeleteWlan.structuredContent).toMatchObject({
+			operation: 'delete-wlan',
+			target: 'Main',
+		})
+		expect(fakeAccessNetworksUnleashed.calls).toContainEqual({
+			name: 'deleteWlan',
+			args: ['Main'],
+		})
+
+		const accessNetworksAddWlan = await mcp.callTool(
+			'access_networks_unleashed_add_wlan',
+			{
+				ssid: 'NewNet',
+				passphrase: 'a-strong-passphrase',
+				acknowledgeHighRisk: true,
+				reason:
+					'Adding a guest WLAN is required to support the new visiting team.',
+				confirmation: accessNetworksUnleashed.writeAcknowledgements.addWlan,
+			},
+		)
+		expect(accessNetworksAddWlan.structuredContent).toMatchObject({
+			operation: 'add-wlan',
+			target: 'NewNet',
+		})
+		expect(fakeAccessNetworksUnleashed.calls).toContainEqual({
+			name: 'addWlan',
+			args: [
+				expect.objectContaining({
+					ssid: 'NewNet',
+					passphrase: 'a-strong-passphrase',
+				}),
+			],
+		})
+
+		const accessNetworksHideLeds = await mcp.callTool(
+			'access_networks_unleashed_hide_ap_leds',
+			{
+				macAddress: '24:79:DE:AD:BE:EF',
+				acknowledgeHighRisk: true,
+				reason:
+					'AP LEDs need to be turned off because the AP is in a guest bedroom.',
+				confirmation:
+					accessNetworksUnleashed.writeAcknowledgements.hideAccessPointLeds,
+			},
+		)
+		expect(accessNetworksHideLeds.structuredContent).toMatchObject({
+			operation: 'hide-ap-leds',
+			target: '24:79:de:ad:be:ef',
+		})
+		expect(fakeAccessNetworksUnleashed.calls).toContainEqual({
+			name: 'setAccessPointLeds',
+			args: ['24:79:de:ad:be:ef', false],
+		})
+
 		await mcp.callTool('bond_adopt_bridge', { bridgeId: 'MOCKBOND1' })
 		bond.setToken('MOCKBOND1', 'mock-bond-token')
 		const bondDevices = await mcp.callTool('bond_list_devices', {

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -711,6 +711,58 @@ function createFakeAccessNetworksUnleashedClient() {
 				},
 			]
 		},
+		async listBlockedClients() {
+			calls.push({ name: 'listBlockedClients', args: [] })
+			return [{ mac: 'aa:bb:cc:dd:ee:ff', type: 'single' }]
+		},
+		async listInactiveClients() {
+			calls.push({ name: 'listInactiveClients', args: [] })
+			return [{ mac: 'aa:bb:cc:dd:ee:ff', hostname: 'old-phone' }]
+		},
+		async listActiveRogues() {
+			calls.push({ name: 'listActiveRogues', args: [] })
+			return [{ mac: '11:22:33:44:55:66', ssid: 'Rogue Net' }]
+		},
+		async listKnownRogues(limit) {
+			calls.push({ name: 'listKnownRogues', args: [limit] })
+			return [{ mac: '11:22:33:44:55:66', recognized: true }]
+		},
+		async listBlockedRogues(limit) {
+			calls.push({ name: 'listBlockedRogues', args: [limit] })
+			return [{ mac: '11:22:33:44:55:66', blocked: true }]
+		},
+		async listApGroups() {
+			calls.push({ name: 'listApGroups', args: [] })
+			return [{ id: 1, name: 'System Default' }]
+		},
+		async listDpsks() {
+			calls.push({ name: 'listDpsks', args: [] })
+			return [{ id: '1', user: 'guest', mac: 'aa:bb:cc:dd:ee:ff' }]
+		},
+		async getMeshInfo() {
+			calls.push({ name: 'getMeshInfo', args: [] })
+			return { id: '1', name: 'Mesh-1', enabled: true }
+		},
+		async getAlarms(limit) {
+			calls.push({ name: 'getAlarms', args: [limit] })
+			return [{ id: '1', message: 'AP rebooted' }]
+		},
+		async getSyslog() {
+			calls.push({ name: 'getSyslog', args: [] })
+			return 'May 03 12:00:00 unleashed: line 1\nMay 03 12:00:01 unleashed: line 2'
+		},
+		async getVapStats() {
+			calls.push({ name: 'getVapStats', args: [] })
+			return [{ ssid: 'Main', tx_bytes: 1024 }]
+		},
+		async getWlanGroupStats() {
+			calls.push({ name: 'getWlanGroupStats', args: [] })
+			return [{ id: '1', name: 'System Default' }]
+		},
+		async getApGroupStats() {
+			calls.push({ name: 'getApGroupStats', args: [] })
+			return [{ id: '1', name: 'System Default' }]
+		},
 		async blockClient(macAddress) {
 			calls.push({ name: 'blockClient', args: [macAddress] })
 		},
@@ -719,6 +771,36 @@ function createFakeAccessNetworksUnleashedClient() {
 		},
 		async setWlanEnabled(name, enabled) {
 			calls.push({ name: 'setWlanEnabled', args: [name, enabled] })
+		},
+		async setWlanPassword(name, passphrase, saePassphrase) {
+			calls.push({
+				name: 'setWlanPassword',
+				args: [name, passphrase, saePassphrase],
+			})
+		},
+		async addWlan(input) {
+			calls.push({ name: 'addWlan', args: [input] })
+		},
+		async editWlan(input) {
+			calls.push({ name: 'editWlan', args: [input] })
+		},
+		async cloneWlan(sourceName, newName, newSsid) {
+			calls.push({ name: 'cloneWlan', args: [sourceName, newName, newSsid] })
+		},
+		async deleteWlan(name) {
+			calls.push({ name: 'deleteWlan', args: [name] })
+		},
+		async addWlanGroup(input) {
+			calls.push({ name: 'addWlanGroup', args: [input] })
+		},
+		async cloneWlanGroup(sourceName, newName, description) {
+			calls.push({
+				name: 'cloneWlanGroup',
+				args: [sourceName, newName, description],
+			})
+		},
+		async deleteWlanGroup(name) {
+			calls.push({ name: 'deleteWlanGroup', args: [name] })
 		},
 		async restartAccessPoint(macAddress) {
 			calls.push({ name: 'restartAccessPoint', args: [macAddress] })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the read-only and mutation capabilities listed in the task brief to the
Access Networks / Ruckus Unleashed home-connector adapter, modeled directly on
the [aioruckus](https://github.com/ms264556/aioruckus) Python reference for
XML payload shapes.

## New read-only MCP tools

- `access_networks_unleashed_list_blocked_clients` — system ACL deny list
- `access_networks_unleashed_list_inactive_clients` — historical clients
- `access_networks_unleashed_list_active_rogues` — currently detected rogue APs
- `access_networks_unleashed_list_known_rogues` — recognized rogue APs (limit)
- `access_networks_unleashed_list_blocked_rogues` — user-blocked rogue APs (limit)
- `access_networks_unleashed_list_ap_groups` — AP group configuration
- `access_networks_unleashed_list_dpsks` — Dynamic PSK list
- `access_networks_unleashed_get_mesh_info` — mesh topology info
- `access_networks_unleashed_get_alarms` — active alarms (limit)
- `access_networks_unleashed_get_syslog` — raw syslog text
- `access_networks_unleashed_get_vap_stats` — per-VAP throughput stats
- `access_networks_unleashed_get_wlan_group_stats` — per-WLAN-group stats
- `access_networks_unleashed_get_ap_group_stats` — per-AP-group stats

## New mutation MCP tools

All require `acknowledgeHighRisk: true`, an operator `reason`, and the exact
operation-specific `confirmation` phrase, matching the existing
`block_client`/`disable_wlan`/`restart_access_point` patterns.

- `access_networks_unleashed_unblock_client` — inverse of `block_client`
- `access_networks_unleashed_set_wlan_password` — change WLAN passphrase
  (passphrase / saePassphrase fields are flagged as secrets)
- `access_networks_unleashed_add_wlan` — clone the standard WLAN template into
  a new SSID with an operator-provided passphrase
- `access_networks_unleashed_edit_wlan` — patch ssid/description/passphrase/
  saePassphrase/enabled on an existing WLAN
- `access_networks_unleashed_clone_wlan` — duplicate an existing WLAN config
  under a new name/SSID
- `access_networks_unleashed_delete_wlan` — destructive WLAN removal
- `access_networks_unleashed_add_wlan_group` — create a WLAN group, optionally
  with a list of WLAN names
- `access_networks_unleashed_clone_wlan_group` — duplicate an existing WLAN group
- `access_networks_unleashed_delete_wlan_group` — destructive WLAN-group removal
- `access_networks_unleashed_hide_ap_leds` / `_show_ap_leds` — dedicated
  shortcuts on top of the existing `set_access_point_leds`

## Implementation notes

- Read methods on `_cmdstat.jsp` reuse the existing post/parse helpers; the
  rogue/alarm endpoints use a one-shot `pieceStat` request mirroring the
  Python piecewise iterator, capped to the operator-provided `limit`.
- Mutations use the existing `_conf.jsp` updobj/addobj/delobj envelopes and
  the same partial-XML patching strategy already used for
  `setWlanEnabled`/`unblockClient`/`setAccessPointLeds`.
- WLAN add/clone derive their bodies from `wlansvc-standard-template`/the
  source WLAN, and strip the `id` attribute before re-submitting so the
  controller assigns a fresh one.
- Auth, session adoption, credential storage, and `allowInsecureTls` flow are
  unchanged — every new capability calls through `requireControllerWithCredentials`
  via the existing `read()` wrapper in the adapter.

## Validation

- `npm run typecheck` passes
- `npm run lint` passes (warnings unchanged)
- `npm run test` passes (Worker + home-connector vitest suites: 649 tests
  pass, including the 9 new client-level unit tests and the new MCP-level
  coverage for `unblock_client`, `list_blocked_clients`, `get_alarms`,
  `get_mesh_info`, `get_syslog`, `delete_wlan`, `add_wlan`, and
  `hide_ap_leds`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4562ada-67a6-4585-94cb-962c1c37b13e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4562ada-67a6-4585-94cb-962c1c37b13e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded network visibility: blocked/inactive client lists, rogue APs, mesh topology, alarms, syslog, and multi-tier stats (VAP, WLAN group, AP group).
  * Full WLAN management: change passphrases, add/edit/clone/delete WLANs and WLAN groups.
  * AP LED controls: hide/show LEDs.

* **Documentation**
  * Updated Access Networks Unleashed docs to reflect expanded read/write surfaces.

* **Tests**
  * Added comprehensive tests covering new list, stats, syslog, and WLAN/WLAN-group operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->