### PR TITLE
feat(home-connector): expand Island router allowlisted CLI command set

### DIFF
--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -1432,7 +1432,7 @@ test('island router adapter runs the expanded allowlisted CLI command set with p
 		},
 		{
 			input: {
-				command: 'show-ip-sessions-host',
+				command: 'show-ip-sessions',
 				host: '192.168.0.52',
 				acknowledgeHighRisk: true,
 				reason,
@@ -1453,7 +1453,7 @@ test('island router adapter runs the expanded allowlisted CLI command set with p
 		},
 		{
 			input: {
-				command: 'show-ip-nat-host',
+				command: 'show-ip-nat',
 				host: '192.168.0.52',
 				acknowledgeHighRisk: true,
 				reason,
@@ -1474,7 +1474,7 @@ test('island router adapter runs the expanded allowlisted CLI command set with p
 		},
 		{
 			input: {
-				command: 'show-ip-dhcp-host',
+				command: 'show-ip-dhcp',
 				host: '192.168.0.52',
 				acknowledgeHighRisk: true,
 				reason,
@@ -1495,7 +1495,7 @@ test('island router adapter runs the expanded allowlisted CLI command set with p
 		},
 		{
 			input: {
-				command: 'show-ip-arp-host',
+				command: 'show-ip-arp',
 				host: '00:11:22:33:44:55',
 				acknowledgeHighRisk: true,
 				reason,
@@ -1506,7 +1506,7 @@ test('island router adapter runs the expanded allowlisted CLI command set with p
 		},
 		{
 			input: {
-				command: 'show-ip-arp-host',
+				command: 'show-ip-arp',
 				host: '00-11-22-33-44-55',
 				acknowledgeHighRisk: true,
 				reason,
@@ -1524,16 +1524,6 @@ test('island router adapter runs the expanded allowlisted CLI command set with p
 			},
 			expectedCommandLine: 'show ip counters',
 			expectedCommandId: 'show-ip-counters',
-		},
-		{
-			input: {
-				command: 'show-log',
-				acknowledgeHighRisk: true,
-				reason,
-				confirmation: acknowledgement,
-			},
-			expectedCommandLine: 'show log last',
-			expectedCommandId: 'show-log',
 		},
 		{
 			input: {

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -560,6 +560,145 @@ function createFakeRunner() {
 					timedOut: false,
 					durationMs: 10,
 				}
+			case 'show-log-recent':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.lineCount === undefined
+							? 'show log'
+							: `show log ${request.lineCount}`,
+					],
+					stdout: [
+						'2026-05-02 15:50:00 info net: link state change',
+						'2026-05-02 15:50:01 info net: link state change',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-top':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.limit === undefined
+							? 'show ip top'
+							: `show ip top ${request.limit}`,
+					],
+					stdout: [
+						'IP Address    Bytes In  Bytes Out',
+						'------------  --------  ---------',
+						'192.168.0.52  1200000   2400000',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-host':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						`show ip host ${request.host}`,
+					],
+					stdout: `Host stats for ${request.host}: rx=120 tx=240`,
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-sessions':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.host === undefined
+							? 'show ip sessions'
+							: `show ip sessions ${request.host}`,
+					],
+					stdout: 'Protocol  Source              Destination',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-nat-translations':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.host === undefined
+							? 'show ip nat'
+							: `show ip nat ${request.host}`,
+					],
+					stdout: 'Active NAT translations',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-dhcp':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.host === undefined
+							? 'show ip dhcp'
+							: `show ip dhcp ${request.host}`,
+					],
+					stdout: 'Active DHCP leases',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-arp':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.host === undefined
+							? 'show ip arp'
+							: `show ip arp ${request.host}`,
+					],
+					stdout: 'ARP table contents',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-counters':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ip counters'],
+					stdout: 'Interface counters',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-dns-stats':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ip dns'],
+					stdout: 'DNS stats and cache',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
 			case 'show-interface':
 				return {
 					id: request.id,
@@ -1228,6 +1367,233 @@ test('island router adapter exposes expanded read and high-risk write capabiliti
 	})
 })
 
+test('island router adapter runs the expanded allowlisted CLI command set with proper validation', async () => {
+	using _env = withTemporaryEnv({})
+	const config = createConfig()
+	const recordedRequests: Array<IslandRouterCommandRequest> = []
+	const islandRouter = createIslandRouterAdapter({
+		config,
+		commandRunner: async (request) => {
+			recordedRequests.push(request)
+			return await createFakeRunner()(request)
+		},
+	})
+	const acknowledgement =
+		islandRouter.writeAcknowledgements.runAllowlistedCliCommand
+	const reason =
+		'The typed tools do not surface this raw CLI view and the targeted output is needed for diagnosis.'
+
+	const cases: Array<{
+		input: Parameters<typeof islandRouter.runAllowlistedCliCommand>[0]
+		expectedCommandLine: string
+		expectedCommandId: string
+	}> = [
+		{
+			input: {
+				command: 'show-ip-top',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip top',
+			expectedCommandId: 'show-ip-top',
+		},
+		{
+			input: {
+				command: 'show-ip-top',
+				limit: 5,
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip top 5',
+			expectedCommandId: 'show-ip-top',
+		},
+		{
+			input: {
+				command: 'show-ip-host',
+				host: '192.168.0.52',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip host 192.168.0.52',
+			expectedCommandId: 'show-ip-host',
+		},
+		{
+			input: {
+				command: 'show-ip-sessions',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip sessions',
+			expectedCommandId: 'show-ip-sessions',
+		},
+		{
+			input: {
+				command: 'show-ip-sessions-host',
+				host: '192.168.0.52',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip sessions 192.168.0.52',
+			expectedCommandId: 'show-ip-sessions',
+		},
+		{
+			input: {
+				command: 'show-ip-nat',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip nat',
+			expectedCommandId: 'show-ip-nat-translations',
+		},
+		{
+			input: {
+				command: 'show-ip-nat-host',
+				host: '192.168.0.52',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip nat 192.168.0.52',
+			expectedCommandId: 'show-ip-nat-translations',
+		},
+		{
+			input: {
+				command: 'show-ip-dhcp',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip dhcp',
+			expectedCommandId: 'show-ip-dhcp',
+		},
+		{
+			input: {
+				command: 'show-ip-dhcp-host',
+				host: '192.168.0.52',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip dhcp 192.168.0.52',
+			expectedCommandId: 'show-ip-dhcp',
+		},
+		{
+			input: {
+				command: 'show-ip-arp',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip arp',
+			expectedCommandId: 'show-ip-arp',
+		},
+		{
+			input: {
+				command: 'show-ip-arp-host',
+				host: '00:11:22:33:44:55',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip arp 00:11:22:33:44:55',
+			expectedCommandId: 'show-ip-arp',
+		},
+		{
+			input: {
+				command: 'show-ip-counters',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip counters',
+			expectedCommandId: 'show-ip-counters',
+		},
+		{
+			input: {
+				command: 'show-log',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show log last',
+			expectedCommandId: 'show-log',
+		},
+		{
+			input: {
+				command: 'show-log-recent',
+				lineCount: 25,
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show log 25',
+			expectedCommandId: 'show-log-recent',
+		},
+		{
+			input: {
+				command: 'show-ip-dns-stats',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip dns',
+			expectedCommandId: 'show-ip-dns-stats',
+		},
+	]
+
+	for (const { input, expectedCommandLine, expectedCommandId } of cases) {
+		const result = await islandRouter.runAllowlistedCliCommand(input)
+		expect(result.command).toBe(input.command)
+		expect(result.commandId).toBe(expectedCommandId)
+		expect(result.commandLines).toContain(expectedCommandLine)
+	}
+
+	expect(recordedRequests.length).toBeGreaterThanOrEqual(cases.length)
+
+	await expect(
+		islandRouter.runAllowlistedCliCommand({
+			command: 'show-ip-host',
+			host: '',
+			acknowledgeHighRisk: true,
+			reason,
+			confirmation: acknowledgement,
+		}),
+	).rejects.toThrow('host')
+	await expect(
+		islandRouter.runAllowlistedCliCommand({
+			command: 'show-ip-host',
+			host: 'not a; valid host',
+			acknowledgeHighRisk: true,
+			reason,
+			confirmation: acknowledgement,
+		}),
+	).rejects.toThrow('Host must be')
+	await expect(
+		islandRouter.runAllowlistedCliCommand({
+			command: 'show-ip-top',
+			limit: -1,
+			acknowledgeHighRisk: true,
+			reason,
+			confirmation: acknowledgement,
+		}),
+	).rejects.toThrow('positive integer')
+	await expect(
+		islandRouter.runAllowlistedCliCommand({
+			command: 'show-log-recent',
+			lineCount: 0,
+			acknowledgeHighRisk: true,
+			reason,
+			confirmation: acknowledgement,
+		}),
+	).rejects.toThrow('positive integer')
+})
+
 test('island router adapter rejects write operations without host verification and exact confirmation', async () => {
 	using _env = withTemporaryEnv({})
 	createConfig()
@@ -1584,6 +1950,25 @@ test('island router adapter accepts real CLI transcripts that exit with code 1',
 						'Dodds-Island>exit',
 						'Goodbye',
 					].join('\n'),
+					stderr: '',
+					exitCode: 1,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-log-recent':
+			case 'show-ip-top':
+			case 'show-ip-host':
+			case 'show-ip-sessions':
+			case 'show-ip-nat-translations':
+			case 'show-ip-dhcp':
+			case 'show-ip-arp':
+			case 'show-ip-counters':
+			case 'show-ip-dns-stats':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ip stub'],
+					stdout: '',
 					stderr: '',
 					exitCode: 1,
 					signal: null,

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -1527,6 +1527,16 @@ test('island router adapter runs the expanded allowlisted CLI command set with p
 		{
 			input: {
 				command: 'show-log-recent',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show log',
+			expectedCommandId: 'show-log-recent',
+		},
+		{
+			input: {
+				command: 'show-log-recent',
 				lineCount: 25,
 				acknowledgeHighRisk: true,
 				reason,

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -1506,6 +1506,17 @@ test('island router adapter runs the expanded allowlisted CLI command set with p
 		},
 		{
 			input: {
+				command: 'show-ip-arp-host',
+				host: '00-11-22-33-44-55',
+				acknowledgeHighRisk: true,
+				reason,
+				confirmation: acknowledgement,
+			},
+			expectedCommandLine: 'show ip arp 00:11:22:33:44:55',
+			expectedCommandId: 'show-ip-arp',
+		},
+		{
+			input: {
 				command: 'show-ip-counters',
 				acknowledgeHighRisk: true,
 				reason,

--- a/packages/home-connector/src/adapters/island-router/index.ts
+++ b/packages/home-connector/src/adapters/island-router/index.ts
@@ -1092,46 +1092,31 @@ export function createIslandRouterAdapter(input: {
 					}
 					break
 				case 'show-ip-sessions':
-					commandRequest = { id: 'show-ip-sessions' }
-					break
-				case 'show-ip-sessions-host':
 					commandRequest = {
 						id: 'show-ip-sessions',
-						host: requireHost('host'),
+						host: request.host === undefined ? undefined : requireHost('host'),
 					}
 					break
 				case 'show-ip-nat':
-					commandRequest = { id: 'show-ip-nat-translations' }
-					break
-				case 'show-ip-nat-host':
 					commandRequest = {
 						id: 'show-ip-nat-translations',
-						host: requireHost('host'),
+						host: request.host === undefined ? undefined : requireHost('host'),
 					}
 					break
 				case 'show-ip-dhcp':
-					commandRequest = { id: 'show-ip-dhcp' }
-					break
-				case 'show-ip-dhcp-host':
 					commandRequest = {
 						id: 'show-ip-dhcp',
-						host: requireHost('host'),
+						host: request.host === undefined ? undefined : requireHost('host'),
 					}
 					break
 				case 'show-ip-arp':
-					commandRequest = { id: 'show-ip-arp' }
-					break
-				case 'show-ip-arp-host':
 					commandRequest = {
 						id: 'show-ip-arp',
-						host: requireHost('host'),
+						host: request.host === undefined ? undefined : requireHost('host'),
 					}
 					break
 				case 'show-ip-counters':
 					commandRequest = { id: 'show-ip-counters' }
-					break
-				case 'show-log':
-					commandRequest = { id: 'show-log' }
 					break
 				case 'show-log-recent':
 					commandRequest = {
@@ -1198,15 +1183,10 @@ export function createIslandRouterAdapter(input: {
 				case 'show-ip-top':
 				case 'show-ip-host':
 				case 'show-ip-sessions':
-				case 'show-ip-sessions-host':
 				case 'show-ip-nat':
-				case 'show-ip-nat-host':
 				case 'show-ip-dhcp':
-				case 'show-ip-dhcp-host':
 				case 'show-ip-arp':
-				case 'show-ip-arp-host':
 				case 'show-ip-counters':
-				case 'show-log':
 				case 'show-log-recent':
 				case 'show-ip-dns-stats':
 					parsedResult = parseIslandRouterRawOutput(

--- a/packages/home-connector/src/adapters/island-router/index.ts
+++ b/packages/home-connector/src/adapters/island-router/index.ts
@@ -1032,7 +1032,7 @@ export function createIslandRouterAdapter(input: {
 			const requireHost = (field: string) =>
 				validateIslandRouterHost(
 					assertNonEmpty(request.host ?? '', field),
-				).value
+				).normalizedValue
 			const requirePositiveInteger = (
 				field: string,
 				value: number | undefined,

--- a/packages/home-connector/src/adapters/island-router/index.ts
+++ b/packages/home-connector/src/adapters/island-router/index.ts
@@ -51,6 +51,7 @@ import {
 	parseIslandRouterNtpConfig,
 	parseIslandRouterPingResult,
 	parseIslandRouterQosConfig,
+	parseIslandRouterRawOutput,
 	parseIslandRouterRecentEvents,
 	parseIslandRouterRoutingTable,
 	parseIslandRouterSecurityPolicy,
@@ -111,6 +112,9 @@ type SetWanFailoverRequest = WriteOperationRequest & {
 type RunAllowlistedCliCommandRequest = WriteOperationRequest & {
 	command: IslandRouterAllowlistedCliCommand
 	interfaceName?: string
+	host?: string
+	limit?: number
+	lineCount?: number
 }
 
 type SetDhcpReservationRequest = WriteOperationRequest & {
@@ -1025,6 +1029,26 @@ export function createIslandRouterAdapter(input: {
 			})
 		},
 		async runAllowlistedCliCommand(request: RunAllowlistedCliCommandRequest) {
+			const requireHost = (field: string) =>
+				validateIslandRouterHost(
+					assertNonEmpty(request.host ?? '', field),
+				).value
+			const requirePositiveInteger = (
+				field: string,
+				value: number | undefined,
+			) => {
+				if (value === undefined) {
+					throw new Error(`${field} is required for this command.`)
+				}
+				if (
+					!Number.isFinite(value) ||
+					!Number.isInteger(value) ||
+					value <= 0
+				) {
+					throw new Error(`${field} must be a positive integer.`)
+				}
+				return value
+			}
 			let commandRequest: IslandRouterCommandRequest
 			switch (request.command) {
 				case 'show-version':
@@ -1051,6 +1075,75 @@ export function createIslandRouterAdapter(input: {
 							assertNonEmpty(request.interfaceName ?? '', 'interfaceName'),
 						),
 					}
+					break
+				case 'show-ip-top':
+					commandRequest = {
+						id: 'show-ip-top',
+						limit:
+							request.limit === undefined
+								? undefined
+								: requirePositiveInteger('limit', request.limit),
+					}
+					break
+				case 'show-ip-host':
+					commandRequest = {
+						id: 'show-ip-host',
+						host: requireHost('host'),
+					}
+					break
+				case 'show-ip-sessions':
+					commandRequest = { id: 'show-ip-sessions' }
+					break
+				case 'show-ip-sessions-host':
+					commandRequest = {
+						id: 'show-ip-sessions',
+						host: requireHost('host'),
+					}
+					break
+				case 'show-ip-nat':
+					commandRequest = { id: 'show-ip-nat-translations' }
+					break
+				case 'show-ip-nat-host':
+					commandRequest = {
+						id: 'show-ip-nat-translations',
+						host: requireHost('host'),
+					}
+					break
+				case 'show-ip-dhcp':
+					commandRequest = { id: 'show-ip-dhcp' }
+					break
+				case 'show-ip-dhcp-host':
+					commandRequest = {
+						id: 'show-ip-dhcp',
+						host: requireHost('host'),
+					}
+					break
+				case 'show-ip-arp':
+					commandRequest = { id: 'show-ip-arp' }
+					break
+				case 'show-ip-arp-host':
+					commandRequest = {
+						id: 'show-ip-arp',
+						host: requireHost('host'),
+					}
+					break
+				case 'show-ip-counters':
+					commandRequest = { id: 'show-ip-counters' }
+					break
+				case 'show-log':
+					commandRequest = { id: 'show-log' }
+					break
+				case 'show-log-recent':
+					commandRequest = {
+						id: 'show-log-recent',
+						lineCount:
+							request.lineCount === undefined
+								? undefined
+								: requirePositiveInteger('lineCount', request.lineCount),
+					}
+					break
+				case 'show-ip-dns-stats':
+					commandRequest = { id: 'show-ip-dns-stats' }
 					break
 				default: {
 					const _exhaustive: never = request.command
@@ -1098,6 +1191,25 @@ export function createIslandRouterAdapter(input: {
 				case 'show-interface':
 				case 'show-ip-interface':
 					parsedResult = parseIslandRouterInterfaceDetails(
+						result.stdout,
+						result.commandLines,
+					)
+					break
+				case 'show-ip-top':
+				case 'show-ip-host':
+				case 'show-ip-sessions':
+				case 'show-ip-sessions-host':
+				case 'show-ip-nat':
+				case 'show-ip-nat-host':
+				case 'show-ip-dhcp':
+				case 'show-ip-dhcp-host':
+				case 'show-ip-arp':
+				case 'show-ip-arp-host':
+				case 'show-ip-counters':
+				case 'show-log':
+				case 'show-log-recent':
+				case 'show-ip-dns-stats':
+					parsedResult = parseIslandRouterRawOutput(
 						result.stdout,
 						result.commandLines,
 					)

--- a/packages/home-connector/src/adapters/island-router/parsing.ts
+++ b/packages/home-connector/src/adapters/island-router/parsing.ts
@@ -2273,3 +2273,12 @@ export function parseIslandRouterBandwidthUsage(
 		rawOutput: lines.join('\n'),
 	}
 }
+
+export function parseIslandRouterRawOutput(
+	stdout: string,
+	commandLines: Array<string>,
+) {
+	return {
+		rawOutput: sanitizeIslandRouterOutput(stdout, commandLines).join('\n'),
+	}
+}

--- a/packages/home-connector/src/adapters/island-router/ssh-client.ts
+++ b/packages/home-connector/src/adapters/island-router/ssh-client.ts
@@ -247,6 +247,23 @@ function assertSingleCliLine(value: string, field: string) {
 	return trimmed
 }
 
+function assertPositiveIntegerCliArgument(value: number, field: string) {
+	if (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+		throw new Error(`${field} must be a positive integer.`)
+	}
+	return String(value)
+}
+
+function assertHostCliArgument(value: string, field: string) {
+	const trimmed = assertSingleCliLine(value, field)
+	if (!/^[A-Za-z0-9:.\-]+$/u.test(trimmed)) {
+		throw new Error(
+			`${field} must be a valid IP, MAC, or hostname token (letters, digits, dot, dash, colon).`,
+		)
+	}
+	return trimmed
+}
+
 function escapeCliQuery(value: string) {
 	return assertSingleCliLine(value, 'query')
 		.replaceAll('\\', '\\\\')
@@ -352,6 +369,57 @@ function getCommandLines(request: IslandRouterCommandRequest): Array<string> {
 			return request.query
 				? [`show log last where "${escapeCliQuery(request.query)}"`]
 				: ['show log last']
+		case 'show-log-recent':
+			return request.lineCount === undefined
+				? ['show log']
+				: [
+						`show log ${assertPositiveIntegerCliArgument(
+							request.lineCount,
+							'lineCount',
+						)}`,
+					]
+		case 'show-ip-top':
+			return request.limit === undefined
+				? ['show ip top']
+				: [
+						`show ip top ${assertPositiveIntegerCliArgument(
+							request.limit,
+							'limit',
+						)}`,
+					]
+		case 'show-ip-host':
+			return [`show ip host ${assertHostCliArgument(request.host, 'host')}`]
+		case 'show-ip-sessions':
+			return request.host === undefined
+				? ['show ip sessions']
+				: [
+						`show ip sessions ${assertHostCliArgument(
+							request.host,
+							'host',
+						)}`,
+					]
+		case 'show-ip-nat-translations':
+			return request.host === undefined
+				? ['show ip nat']
+				: [
+						`show ip nat ${assertHostCliArgument(request.host, 'host')}`,
+					]
+		case 'show-ip-dhcp':
+			return request.host === undefined
+				? ['show ip dhcp']
+				: [
+						`show ip dhcp ${assertHostCliArgument(request.host, 'host')}`,
+					]
+		case 'show-ip-arp':
+			return request.host === undefined
+				? ['show ip arp']
+				: [
+						`show ip arp ${assertHostCliArgument(request.host, 'host')}`,
+					]
+		case 'show-ip-counters':
+			return ['show ip counters']
+		case 'show-ip-dns-stats':
+			return ['show ip dns']
 		case 'ping':
 			return [`ping ${assertSingleCliLine(request.host, 'host')}`]
 		case 'force-wan-failover':

--- a/packages/home-connector/src/adapters/island-router/types.ts
+++ b/packages/home-connector/src/adapters/island-router/types.ts
@@ -827,15 +827,10 @@ export type IslandRouterAllowlistedCliCommand =
 	| 'show-ip-top'
 	| 'show-ip-host'
 	| 'show-ip-sessions'
-	| 'show-ip-sessions-host'
 	| 'show-ip-nat'
-	| 'show-ip-nat-host'
 	| 'show-ip-dhcp'
-	| 'show-ip-dhcp-host'
 	| 'show-ip-arp'
-	| 'show-ip-arp-host'
 	| 'show-ip-counters'
-	| 'show-log'
 	| 'show-log-recent'
 	| 'show-ip-dns-stats'
 
@@ -859,7 +854,6 @@ export type IslandRouterAllowlistedCliCommandResult = {
 		| 'show-ip-dhcp'
 		| 'show-ip-arp'
 		| 'show-ip-counters'
-		| 'show-log'
 		| 'show-log-recent'
 		| 'show-ip-dns-stats'
 	>

--- a/packages/home-connector/src/adapters/island-router/types.ts
+++ b/packages/home-connector/src/adapters/island-router/types.ts
@@ -63,6 +63,15 @@ export type IslandRouterCommandId =
 	| 'show-syslog'
 	| 'show-snmp'
 	| 'show-log'
+	| 'show-log-recent'
+	| 'show-ip-top'
+	| 'show-ip-host'
+	| 'show-ip-sessions'
+	| 'show-ip-nat-translations'
+	| 'show-ip-dhcp'
+	| 'show-ip-arp'
+	| 'show-ip-counters'
+	| 'show-ip-dns-stats'
 	| 'ping'
 	| 'force-wan-failover'
 	| 'set-dhcp-reservation'
@@ -246,6 +255,49 @@ export type IslandRouterCommandRequest =
 	| {
 			id: 'show-log'
 			query?: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-log-recent'
+			lineCount?: number
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-top'
+			limit?: number
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-host'
+			host: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-sessions'
+			host?: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-nat-translations'
+			host?: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-dhcp'
+			host?: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-arp'
+			host?: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-counters'
+			timeoutMs?: number
+	  }
+	| {
+			id: 'show-ip-dns-stats'
 			timeoutMs?: number
 	  }
 	| {
@@ -772,6 +824,24 @@ export type IslandRouterAllowlistedCliCommand =
 	| 'show-interface-summary'
 	| 'show-interface'
 	| 'show-ip-interface'
+	| 'show-ip-top'
+	| 'show-ip-host'
+	| 'show-ip-sessions'
+	| 'show-ip-sessions-host'
+	| 'show-ip-nat'
+	| 'show-ip-nat-host'
+	| 'show-ip-dhcp'
+	| 'show-ip-dhcp-host'
+	| 'show-ip-arp'
+	| 'show-ip-arp-host'
+	| 'show-ip-counters'
+	| 'show-log'
+	| 'show-log-recent'
+	| 'show-ip-dns-stats'
+
+export type IslandRouterAllowlistedCliRawResult = {
+	rawOutput: string
+}
 
 export type IslandRouterAllowlistedCliCommandResult = {
 	command: IslandRouterAllowlistedCliCommand
@@ -782,6 +852,16 @@ export type IslandRouterAllowlistedCliCommandResult = {
 		| 'show-interface-summary'
 		| 'show-interface'
 		| 'show-ip-interface'
+		| 'show-ip-top'
+		| 'show-ip-host'
+		| 'show-ip-sessions'
+		| 'show-ip-nat-translations'
+		| 'show-ip-dhcp'
+		| 'show-ip-arp'
+		| 'show-ip-counters'
+		| 'show-log'
+		| 'show-log-recent'
+		| 'show-ip-dns-stats'
 	>
 	commandLines: Array<string>
 	result:
@@ -789,6 +869,7 @@ export type IslandRouterAllowlistedCliCommandResult = {
 		| { clock: string | null }
 		| { interfaces: Array<IslandRouterInterfaceSummary> }
 		| IslandRouterInterfaceDetails
+		| IslandRouterAllowlistedCliRawResult
 	stdout: string
 	stderr: string
 	exitCode: number | null

--- a/packages/home-connector/src/mcp/register-island-router-tools.ts
+++ b/packages/home-connector/src/mcp/register-island-router-tools.ts
@@ -1,6 +1,7 @@
 import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import { type createIslandRouterAdapter } from '../adapters/island-router/index.ts'
+import { type IslandRouterAllowlistedCliCommand } from '../adapters/island-router/types.ts'
 import {
 	buildToolInputSchema,
 	type ToolInputSchema,
@@ -893,6 +894,20 @@ export function registerIslandRouterHomeConnectorTools(input: {
 				'show-interface-summary',
 				'show-interface',
 				'show-ip-interface',
+				'show-ip-top',
+				'show-ip-host',
+				'show-ip-sessions',
+				'show-ip-sessions-host',
+				'show-ip-nat',
+				'show-ip-nat-host',
+				'show-ip-dhcp',
+				'show-ip-dhcp-host',
+				'show-ip-arp',
+				'show-ip-arp-host',
+				'show-ip-counters',
+				'show-log',
+				'show-log-recent',
+				'show-ip-dns-stats',
 			])
 			.describe(
 				'Allowlisted read-only Island router CLI command alias. No arbitrary CLI execution is allowed.',
@@ -903,6 +918,31 @@ export function registerIslandRouterHomeConnectorTools(input: {
 			.optional()
 			.describe(
 				'Required only for interface-scoped commands such as show-interface or show-ip-interface.',
+			),
+		host: z
+			.string()
+			.min(1)
+			.optional()
+			.describe(
+				'Required only for host-scoped commands such as show-ip-host, show-ip-sessions-host, show-ip-nat-host, show-ip-dhcp-host, or show-ip-arp-host. Accepts an IPv4, IPv6, MAC, or hostname.',
+			),
+		limit: z
+			.number()
+			.int()
+			.min(1)
+			.max(1000)
+			.optional()
+			.describe(
+				'Optional positive integer limit for show-ip-top to cap the number of returned hosts.',
+			),
+		lineCount: z
+			.number()
+			.int()
+			.min(1)
+			.max(10_000)
+			.optional()
+			.describe(
+				'Optional positive integer line count for show-log-recent to limit recent log lines.',
 			),
 		acknowledgeHighRisk: z
 			.literal(true)
@@ -943,16 +983,15 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		},
 		async (args) => {
 			const result = await islandRouter.runAllowlistedCliCommand({
-				command: args['command'] as
-					| 'show-version'
-					| 'show-clock'
-					| 'show-interface-summary'
-					| 'show-interface'
-					| 'show-ip-interface',
+				command: args['command'] as IslandRouterAllowlistedCliCommand,
 				interfaceName:
 					args['interfaceName'] == null
 						? undefined
 						: String(args['interfaceName']),
+				host: args['host'] == null ? undefined : String(args['host']),
+				limit: args['limit'] == null ? undefined : Number(args['limit']),
+				lineCount:
+					args['lineCount'] == null ? undefined : Number(args['lineCount']),
 				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
 				reason: String(args['reason'] ?? ''),
 				confirmation: String(args['confirmation'] ?? ''),

--- a/packages/home-connector/src/mcp/register-island-router-tools.ts
+++ b/packages/home-connector/src/mcp/register-island-router-tools.ts
@@ -897,15 +897,10 @@ export function registerIslandRouterHomeConnectorTools(input: {
 				'show-ip-top',
 				'show-ip-host',
 				'show-ip-sessions',
-				'show-ip-sessions-host',
 				'show-ip-nat',
-				'show-ip-nat-host',
 				'show-ip-dhcp',
-				'show-ip-dhcp-host',
 				'show-ip-arp',
-				'show-ip-arp-host',
 				'show-ip-counters',
-				'show-log',
 				'show-log-recent',
 				'show-ip-dns-stats',
 			])
@@ -924,7 +919,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 			.min(1)
 			.optional()
 			.describe(
-				'Required only for host-scoped commands such as show-ip-host, show-ip-sessions-host, show-ip-nat-host, show-ip-dhcp-host, or show-ip-arp-host. Accepts an IPv4, IPv6, MAC, or hostname.',
+				'Optional IPv4, IPv6, MAC, or hostname. Required for show-ip-host. Optional filter for show-ip-sessions, show-ip-nat, show-ip-dhcp, and show-ip-arp.',
 			),
 		limit: z
 			.number()

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -483,6 +483,138 @@ function createIslandRouterRunner() {
 					timedOut: false,
 					durationMs: 10,
 				}
+			case 'show-log-recent':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.lineCount === undefined
+							? 'show log'
+							: `show log ${request.lineCount}`,
+					],
+					stdout: '2026-05-02 15:50:00 info net: link state change',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-top':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.limit === undefined
+							? 'show ip top'
+							: `show ip top ${request.limit}`,
+					],
+					stdout: 'IP Address    Bytes In  Bytes Out',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-host':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						`show ip host ${request.host}`,
+					],
+					stdout: `Host stats for ${request.host}`,
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-sessions':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.host === undefined
+							? 'show ip sessions'
+							: `show ip sessions ${request.host}`,
+					],
+					stdout: 'Active sessions',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-nat-translations':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.host === undefined
+							? 'show ip nat'
+							: `show ip nat ${request.host}`,
+					],
+					stdout: 'NAT translations',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-dhcp':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.host === undefined
+							? 'show ip dhcp'
+							: `show ip dhcp ${request.host}`,
+					],
+					stdout: 'DHCP leases',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-arp':
+				return {
+					id: request.id,
+					commandLines: [
+						'terminal length 0',
+						request.host === undefined
+							? 'show ip arp'
+							: `show ip arp ${request.host}`,
+					],
+					stdout: 'ARP table',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-counters':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ip counters'],
+					stdout: 'IP counters',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
+			case 'show-ip-dns-stats':
+				return {
+					id: request.id,
+					commandLines: ['terminal length 0', 'show ip dns'],
+					stdout: 'DNS stats',
+					stderr: '',
+					exitCode: 0,
+					signal: null,
+					timedOut: false,
+					durationMs: 10,
+				}
 			case 'show-interface':
 				return {
 					id: request.id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the requested per-host traffic, session, NAT, DHCP, ARP, interface, log, and DNS read-only commands to the Island Pro router allowlist used by `home_router_run_allowlisted_cli_command`.

## New allowlisted commands

| MCP `command` value             | Underlying CLI                | Notes |
| ------------------------------- | ----------------------------- | ----- |
| `show-ip-top`                   | `show ip top` / `show ip top N` | Optional positive-integer `limit`. |
| `show-ip-host`                  | `show ip host {ip}`           | `host` required (validated). |
| `show-ip-sessions`              | `show ip sessions`            | – |
| `show-ip-sessions-host`         | `show ip sessions {ip}`       | `host` required. |
| `show-ip-nat`                   | `show ip nat`                 | – |
| `show-ip-nat-host`              | `show ip nat {ip}`            | `host` required. |
| `show-ip-dhcp`                  | `show ip dhcp`                | – |
| `show-ip-dhcp-host`             | `show ip dhcp {ip}`           | `host` required. |
| `show-ip-arp`                   | `show ip arp`                 | – |
| `show-ip-arp-host`              | `show ip arp {ip-or-mac}`     | `host` required. |
| `show-ip-counters`              | `show ip counters`            | – |
| `show-log`                      | `show log last`               | – |
| `show-log-recent`               | `show log` / `show log N`     | Optional positive-integer `lineCount`. |
| `show-ip-dns-stats`             | `show ip dns`                 | – |

Existing aliases (`show-version`, `show-clock`, `show-interface-summary`, `show-interface`, `show-ip-interface`) are unchanged.

## Implementation notes

- `IslandRouterCommandId` / `IslandRouterCommandRequest` gained typed variants for each new SSH command, including the optional `limit`, `lineCount`, and `host` arguments.
- `getCommandLines` in the SSH client emits the new commands. New helpers reject empty / control-character / non-token arguments and require positive integers for numeric arguments, so even though the Island session is a restricted CLI rather than a shell, we still validate inputs before they reach SSH stdin.
- `runAllowlistedCliCommand` in the Island router adapter routes the new aliases through the existing `runHighRiskCommand` path (preserving `acknowledgeHighRisk` / `confirmation` / reason validation). Host arguments are normalized through `validateIslandRouterHost`, and numeric arguments are double-checked at the adapter layer too.
- Output for the new commands is sanitized via the existing CLI sanitizer and surfaced as a raw string under `result.rawOutput` in `IslandRouterAllowlistedCliCommandResult`. The structured result types for `show-version` / `show-clock` / `show-interface-summary` / `show-interface` / `show-ip-interface` are unchanged.
- The MCP `router_run_allowlisted_cli_command` tool gained `host`, `limit`, and `lineCount` fields plus the new enum members in the Zod schema.

## Tests

- All existing fake runners (in `index.node.test.ts`, `server.node.test.ts`, and the "real CLI exit 1" runner) gained cases for the new IDs so the exhaustive `switch` checks keep compiling.
- A new adapter test exercises every new alias, asserts the rendered command line, asserts the routed `commandId`, and verifies that empty / malformed hosts and non-positive integers are rejected.
- `npm test` (home-connector + worker, 654 tests), `npm run typecheck`, and `npm run lint` all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81c6ed83-023f-4e2d-8774-f83d9984063d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81c6ed83-023f-4e2d-8774-f83d9984063d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended Island router diagnostics with additional read-only commands for IP-scoped queries, recent logs, and DNS statistics.
  * Added optional filtering parameters (host, limit, lineCount) with validation and host normalization, and a unified raw-output passthrough for those commands.
* **Tests**
  * Added tests covering command-to-CLI mapping, validation failures (invalid/empty host, non-positive limit or lineCount), and error exit-code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->