### PR TITLE
Add direct Artifacts git push primitives for packages

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -111,6 +111,50 @@ Operational notes:
   arbitrary shell syntax, and package runtime bundles are loaded from published
   artifacts rather than a mounted checkout.
 
+### Direct Artifacts git publishes
+
+Saved package source can also be edited through Artifacts git remotes directly.
+`package_get_git_remote` resolves package identity to `entity_sources`, mints a
+short-lived Artifacts repo token, and returns both a plain remote and setup
+commands that pass the token through `http.extraHeader`.
+
+After an external `git push`, `package_publish_external_push` reconciles the
+current Artifacts default-branch HEAD with `entity_sources.published_commit`.
+The RepoSession Durable Object clones that commit, checks that it is a
+fast-forward unless `allow_force` is set, runs `runRepoChecks(...)`, and then
+calls `publishFromExternalRef(...)`.
+
+`publishFromExternalRef(...)` owns the post-receive publish transaction:
+
+- run manifest, dependency, bundle, typecheck, and lint checks before mutation
+- advance `entity_sources.published_commit`
+- write the `PublishedSourceSnapshot` and manifest snapshot to
+  `BUNDLE_ARTIFACTS_KV`
+- roll the D1 commit pointer back if KV snapshot persistence fails
+- rebuild saved package projections, bundle artifacts, vector search entries,
+  retriever manifests, package jobs, and services through
+  `refreshSavedPackageProjection(...)`
+
+The same helper is used by the existing repo-session publish path after it has
+pushed the session commit to the source Artifacts repo.
+
+### Reconcile cron
+
+`packages/worker/src/jobs/reconcile-artifacts-pushes.ts` is a safety net for
+external pushes that were not followed by an explicit
+`package_publish_external_push` call. The Worker scheduled handler runs every
+five minutes (`wrangler.jsonc` `*/5 * * * *`), selects a small batch of stale
+`entity_sources` rows by `last_external_check_at`, resolves the Artifacts
+default-branch HEAD, and calls the same external publish path when HEAD differs
+from `published_commit`.
+
+The reconcile loop is idempotent: if another caller publishes the same commit
+first, the publish path returns `already_published`. Check failures and
+non-fast-forward results leave D1/KV untouched and are counted in the one-line
+metrics log. Once per day during the 03:00 UTC cron window, reconcile also calls
+`revokeStaleArtifactsTokens(...)` for checked repos to clean up expired
+Artifacts tokens.
+
 Production note:
 
 - Released `wrangler` `4.83.0` warns that the documented Artifacts Worker

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -188,15 +188,42 @@ Retriever implementations should truncate or paginate before returning.
 
 ## Repo-backed workflow
 
-Package source is edited and published through the repo session capabilities.
+Package source is edited and published through repo-backed flows.
 
 - prefer `repo_run_commands` for package changes
 - `repo_run_commands` accepts a newline-separated parsed git-command string, not
   arbitrary shell; keep agent-facing guidance aligned with the deployed
   capability schema
+- use `package_get_git_remote` and `package_publish_external_push` when a human
+  or autonomous agent should drive a normal git client directly against the
+  package's Cloudflare Artifacts repo
 - open repo sessions by package identity when possible
 - for an existing package, treat the repo snapshot as the durable source of
   truth
+
+## External Artifacts pushes
+
+Saved package source repos are real Cloudflare Artifacts git repositories.
+`package_get_git_remote` mints a short-lived read or write token for the
+canonical source repo and returns both a plain remote URL and setup commands
+that use `http.extraHeader` for secret-bearing credentials.
+
+After a direct `git push`, `package_publish_external_push` resolves the
+package's default-branch HEAD, opens a transient repo session checkout at that
+commit, and uses `publishFromExternalRef` to run the same package checks before
+advancing `entity_sources.published_commit`. Check failures return the failed
+checks and do not mutate D1, KV snapshots, published bundle artifacts, package
+projections, or vectors. Non-fast-forward external heads are refused unless the
+caller passes `allow_force: true`.
+
+The scheduled reconcile job in
+`packages/worker/src/jobs/reconcile-artifacts-pushes.ts` is a safety net for
+pushed-but-unpublished commits. Every five minutes it scans a small batch of
+stale `entity_sources` rows, compares Artifacts HEAD with `published_commit`,
+and calls the same external publish path when they differ.
+`entity_sources.last_external_check_at` throttles the scan. At 03:00 UTC the job
+also asks each checked repo to revoke expired Artifacts tokens through
+`revokeStaleArtifactsTokens`.
 
 ## Search and discovery
 

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -186,8 +186,11 @@ edit it with a normal git client without round-tripping each file change through
    # edit files
    git add .
    git commit -m "fix: update package behavior"
-   git -c http.extraHeader='Authorization: Bearer art_v1_...' push origin HEAD:main
+   git -c http.extraHeader='Authorization: Bearer art_v1_...' push origin HEAD:<defaultBranch>
    ```
+
+   Use the default branch returned by `package_get_git_remote` for
+   `<defaultBranch>`.
 
 3. Publish the pushed Artifacts HEAD:
 
@@ -198,11 +201,11 @@ edit it with a normal git client without round-tripping each file change through
    ```
 
    Call `package_publish_external_push`. Kody checks the pushed tree server-side
-   before advancing `entity_sources.published_commit`, writing the published
-   source snapshot, rebuilding package bundle artifacts, and refreshing search
+   before recording the new published version, writing the published source
+   snapshot, rebuilding package bundle artifacts, and refreshing search
    projections. If the pushed HEAD is already current, the tool returns
    `already_published`. If checks fail, it returns `checks_failed` with the
-   failed check entries and leaves D1/KV untouched.
+   failed check entries and leaves the underlying storage state unchanged.
 
 Choose the narrowest token scope that fits the task. Use `read` for inspection
 or local diffing, and `write` only when the git client needs to push. Keep TTLs

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -150,6 +150,64 @@ Use:
 - `package_get` and `package_list` to inspect saved packages
 - `repo_run_commands` to edit, check, and publish repo-backed package source
   after it exists using parsed, git-only command forms rather than shell
+- `package_get_git_remote` and `package_publish_external_push` when you want a
+  normal git client to clone, edit, push, and then ask Kody to reconcile the
+  pushed Artifacts HEAD
+
+## Edit a saved package via direct git push
+
+Saved package source is backed by a Cloudflare Artifacts git repository. You can
+edit it with a normal git client without round-tripping each file change through
+`package_save` or `repo_run_commands`.
+
+1. Mint a short-lived remote credential:
+
+   ```json
+   {
+   	"package_id": "pkg_123",
+   	"scope": "write",
+   	"ttl_seconds": 1800
+   }
+   ```
+
+   Call `package_get_git_remote` with either `package_id` or `kody_id`. The
+   result includes the plain remote URL, an authenticated one-line clone URL, an
+   `Authorization: Bearer ...` extra header, and setup commands that use
+   `git -c http.extraHeader=...` so the token does not need to be saved in shell
+   history or `.git/config`.
+
+2. Clone and edit:
+
+   ```bash
+   git -c http.extraHeader='Authorization: Bearer art_v1_...' clone \
+   	https://<account>.artifacts.cloudflare.net/git/default/<repo>.git \
+   	my-package
+   cd my-package
+   # edit files
+   git add .
+   git commit -m "fix: update package behavior"
+   git -c http.extraHeader='Authorization: Bearer art_v1_...' push origin HEAD:main
+   ```
+
+3. Publish the pushed Artifacts HEAD:
+
+   ```json
+   {
+   	"package_id": "pkg_123"
+   }
+   ```
+
+   Call `package_publish_external_push`. Kody checks the pushed tree server-side
+   before advancing `entity_sources.published_commit`, writing the published
+   source snapshot, rebuilding package bundle artifacts, and refreshing search
+   projections. If the pushed HEAD is already current, the tool returns
+   `already_published`. If checks fail, it returns `checks_failed` with the
+   failed check entries and leaves D1/KV untouched.
+
+Choose the narrowest token scope that fits the task. Use `read` for inspection
+or local diffing, and `write` only when the git client needs to push. Keep TTLs
+short for autonomous agents and CI-style helpers; the tool accepts 60 seconds to
+24 hours and defaults to 30 minutes.
 
 ## Search and discovery
 

--- a/packages/worker/migrations/0032-entity-sources-external-check.sql
+++ b/packages/worker/migrations/0032-entity-sources-external-check.sql
@@ -1,0 +1,5 @@
+ALTER TABLE entity_sources
+	ADD COLUMN last_external_check_at TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_entity_sources_external_check
+	ON entity_sources(last_external_check_at);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -364,16 +364,14 @@ const workerHandler = {
 	async scheduled(
 		controller: ScheduledController,
 		env: Env,
-		ctx: ExecutionContext,
+		_ctx: ExecutionContext,
 	) {
 		const baseUrl = env.APP_BASE_URL ?? 'https://kody.local'
-		ctx.waitUntil(
-			reconcileArtifactsPushes({
-				env,
-				baseUrl,
-				now: new Date(controller.scheduledTime),
-			}),
-		)
+		await reconcileArtifactsPushes({
+			env,
+			baseUrl,
+			now: new Date(controller.scheduledTime),
+		})
 	},
 } satisfies ExportedHandler<Env>
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -44,6 +44,7 @@ import { getRequestIp } from '#app/audit-log.ts'
 import { handleCapabilityReindexRequest } from './capability-maintenance.ts'
 import { handleJobReindexRequest } from './job-maintenance.ts'
 import { handleMemoryReindexRequest } from './memory-maintenance.ts'
+import { reconcileArtifactsPushes } from './jobs/reconcile-artifacts-pushes.ts'
 import { CodemodeFetchGateway } from '#mcp/fetch-gateway.ts'
 import {
 	connectorSessionKey,
@@ -359,6 +360,20 @@ const workerHandler = {
 		ctx: ExecutionContext,
 	) {
 		await handleInboundEmail(message, env, ctx)
+	},
+	async scheduled(
+		controller: ScheduledController,
+		env: Env,
+		ctx: ExecutionContext,
+	) {
+		const baseUrl = env.APP_BASE_URL ?? 'https://kody.local'
+		ctx.waitUntil(
+			reconcileArtifactsPushes({
+				env,
+				baseUrl,
+				now: new Date(controller.scheduledTime),
+			}),
+		)
 	},
 } satisfies ExportedHandler<Env>
 

--- a/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
+++ b/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
@@ -87,8 +87,16 @@ test('publishes changed Artifacts HEADs and records reconcile checks', async () 
 		env: { APP_DB: {} } as Env,
 		baseUrl: 'https://kody.test',
 		now: new Date('2026-05-04T02:00:00.000Z'),
+		staleAfterMinutes: 10,
 	})
 
+	expect(mockModule.listEntitySourcesForExternalReconcile).toHaveBeenCalledWith(
+		expect.anything(),
+		{
+			before: '2026-05-04T01:50:00.000Z',
+			limit: 50,
+		},
+	)
 	expect(result).toEqual({
 		checked: 2,
 		published: 1,
@@ -106,6 +114,27 @@ test('publishes changed Artifacts HEADs and records reconcile checks', async () 
 		}),
 	)
 	expect(mockModule.updateEntitySource).toHaveBeenCalledTimes(2)
+})
+
+test('records reconcile checks even when a source fails', async () => {
+	mockModule.listEntitySourcesForExternalReconcile.mockResolvedValue([source()])
+	mockModule.resolveArtifactSourceHead.mockRejectedValueOnce(new Error('boom'))
+
+	const result = await reconcileArtifactsPushes({
+		env: { APP_DB: {} } as Env,
+		baseUrl: 'https://kody.test',
+		now: new Date('2026-05-04T02:00:00.000Z'),
+	})
+
+	expect(result.errors).toBe(1)
+	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
+		expect.anything(),
+		{
+			id: 'source-1',
+			userId: 'user-1',
+			lastExternalCheckAt: '2026-05-04T02:00:00.000Z',
+		},
+	)
 })
 
 test('runs token cleanup during the 03:00 UTC cron window', async () => {

--- a/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
+++ b/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
@@ -137,6 +137,40 @@ test('records reconcile checks even when a source fails', async () => {
 	)
 })
 
+test('continues the batch when recording a failed source check also fails', async () => {
+	mockModule.listEntitySourcesForExternalReconcile.mockResolvedValue([
+		source(),
+		source({
+			id: 'source-2',
+			repo_id: 'repo-2',
+			published_commit: 'commit-current',
+		}),
+	])
+	mockModule.resolveArtifactSourceHead
+		.mockRejectedValueOnce(new Error('boom'))
+		.mockResolvedValueOnce({ branch: 'main', commit: 'commit-current' })
+	mockModule.updateEntitySource
+		.mockRejectedValueOnce(new Error('d1 unavailable'))
+		.mockResolvedValueOnce(true)
+
+	const result = await reconcileArtifactsPushes({
+		env: { APP_DB: {} } as Env,
+		baseUrl: 'https://kody.test',
+		now: new Date('2026-05-04T02:00:00.000Z'),
+	})
+
+	expect(result).toEqual({
+		checked: 2,
+		published: 0,
+		alreadyPublished: 1,
+		checksFailed: 0,
+		notFastForward: 0,
+		errors: 1,
+		tokensRevoked: 0,
+	})
+	expect(mockModule.resolveArtifactSourceHead).toHaveBeenCalledTimes(2)
+})
+
 test('runs token cleanup during the 03:00 UTC cron window', async () => {
 	mockModule.listEntitySourcesForExternalReconcile.mockResolvedValue([source()])
 	mockModule.resolveArtifactSourceHead.mockResolvedValue({

--- a/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
+++ b/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	listEntitySourcesForExternalReconcile: vi.fn(),
+	updateEntitySource: vi.fn(async () => true),
+	resolveArtifactSourceHead: vi.fn(),
+	revokeStaleArtifactsTokens: vi.fn(async () => ({ checked: 0, revoked: 0 })),
+	publishFromExternalRef: vi.fn(),
+	repoSessionRpc: vi.fn(() => ({
+		publishFromExternalRef: mockModule.publishFromExternalRef,
+	})),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	listEntitySourcesForExternalReconcile: (...args: Array<unknown>) =>
+		mockModule.listEntitySourcesForExternalReconcile(...args),
+	updateEntitySource: (...args: Array<unknown>) =>
+		mockModule.updateEntitySource(...args),
+}))
+
+vi.mock('#worker/repo/artifacts.ts', () => ({
+	resolveArtifactSourceHead: (...args: Array<unknown>) =>
+		mockModule.resolveArtifactSourceHead(...args),
+}))
+
+vi.mock('#worker/repo/artifacts-tokens.ts', () => ({
+	revokeStaleArtifactsTokens: (...args: Array<unknown>) =>
+		mockModule.revokeStaleArtifactsTokens(...args),
+}))
+
+vi.mock('#worker/repo/repo-session-do.ts', () => ({
+	repoSessionRpc: (...args: Array<unknown>) =>
+		mockModule.repoSessionRpc(...args),
+}))
+
+const { reconcileArtifactsPushes } =
+	await import('./reconcile-artifacts-pushes.ts')
+
+function source(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'repo-1',
+		published_commit: 'commit-old',
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		created_at: '2026-05-04T00:00:00.000Z',
+		updated_at: '2026-05-04T00:00:00.000Z',
+		...overrides,
+	}
+}
+
+beforeEach(() => {
+	mockModule.listEntitySourcesForExternalReconcile.mockReset()
+	mockModule.updateEntitySource.mockClear()
+	mockModule.resolveArtifactSourceHead.mockReset()
+	mockModule.revokeStaleArtifactsTokens.mockClear()
+	mockModule.publishFromExternalRef.mockReset()
+	mockModule.repoSessionRpc.mockClear()
+})
+
+test('publishes changed Artifacts HEADs and records reconcile checks', async () => {
+	mockModule.listEntitySourcesForExternalReconcile.mockResolvedValue([
+		source(),
+		source({
+			id: 'source-2',
+			repo_id: 'repo-2',
+			published_commit: 'commit-current',
+		}),
+	])
+	mockModule.resolveArtifactSourceHead
+		.mockResolvedValueOnce({ branch: 'main', commit: 'commit-new' })
+		.mockResolvedValueOnce({ branch: 'main', commit: 'commit-current' })
+	mockModule.publishFromExternalRef.mockResolvedValueOnce({
+		status: 'published',
+		published_commit: 'commit-new',
+		previous_commit: 'commit-old',
+		manifest: {},
+		checks: [],
+	})
+
+	const result = await reconcileArtifactsPushes({
+		env: { APP_DB: {} } as Env,
+		baseUrl: 'https://kody.test',
+		now: new Date('2026-05-04T02:00:00.000Z'),
+	})
+
+	expect(result).toEqual({
+		checked: 2,
+		published: 1,
+		alreadyPublished: 1,
+		checksFailed: 0,
+		notFastForward: 0,
+		errors: 0,
+		tokensRevoked: 0,
+	})
+	expect(mockModule.publishFromExternalRef).toHaveBeenCalledWith(
+		expect.objectContaining({
+			sourceId: 'source-1',
+			newCommit: 'commit-new',
+			allowForce: false,
+		}),
+	)
+	expect(mockModule.updateEntitySource).toHaveBeenCalledTimes(2)
+})
+
+test('runs token cleanup during the 03:00 UTC cron window', async () => {
+	mockModule.listEntitySourcesForExternalReconcile.mockResolvedValue([source()])
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-old',
+	})
+	mockModule.revokeStaleArtifactsTokens.mockResolvedValueOnce({
+		checked: 3,
+		revoked: 2,
+	})
+
+	const result = await reconcileArtifactsPushes({
+		env: { APP_DB: {} } as Env,
+		baseUrl: 'https://kody.test',
+		now: new Date('2026-05-04T03:02:00.000Z'),
+	})
+
+	expect(result.tokensRevoked).toBe(2)
+	expect(mockModule.revokeStaleArtifactsTokens).toHaveBeenCalledWith(
+		expect.anything(),
+		'repo-1',
+		{ keepAfter: new Date('2026-05-04T03:02:00.000Z') },
+	)
+})

--- a/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
+++ b/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
@@ -101,9 +101,11 @@ test('publishes changed Artifacts HEADs and records reconcile checks', async () 
 		checked: 2,
 		published: 1,
 		alreadyPublished: 1,
+		missingHead: 0,
 		checksFailed: 0,
 		notFastForward: 0,
 		errors: 0,
+		tokenCleanupErrors: 0,
 		tokensRevoked: 0,
 	})
 	expect(mockModule.publishFromExternalRef).toHaveBeenCalledWith(
@@ -163,9 +165,11 @@ test('continues the batch when recording a failed source check also fails', asyn
 		checked: 2,
 		published: 0,
 		alreadyPublished: 1,
+		missingHead: 0,
 		checksFailed: 0,
 		notFastForward: 0,
 		errors: 1,
+		tokenCleanupErrors: 0,
 		tokensRevoked: 0,
 	})
 	expect(mockModule.resolveArtifactSourceHead).toHaveBeenCalledTimes(2)
@@ -194,4 +198,59 @@ test('runs token cleanup during the 03:00 UTC cron window', async () => {
 		'repo-1',
 		{ keepAfter: new Date('2026-05-04T03:02:00.000Z') },
 	)
+})
+
+test('token cleanup failures do not block source reconciliation', async () => {
+	mockModule.listEntitySourcesForExternalReconcile.mockResolvedValue([source()])
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-new',
+	})
+	mockModule.revokeStaleArtifactsTokens.mockRejectedValueOnce(
+		new Error('cleanup failed'),
+	)
+	mockModule.publishFromExternalRef.mockResolvedValueOnce({
+		status: 'published',
+		published_commit: 'commit-new',
+		previous_commit: 'commit-old',
+		manifest: {},
+		checks: [],
+	})
+
+	const result = await reconcileArtifactsPushes({
+		env: { APP_DB: {} } as Env,
+		baseUrl: 'https://kody.test',
+		now: new Date('2026-05-04T03:02:00.000Z'),
+	})
+
+	expect(result).toEqual(
+		expect.objectContaining({
+			published: 1,
+			errors: 0,
+			tokenCleanupErrors: 1,
+		}),
+	)
+	expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(1)
+})
+
+test('missing Artifacts HEAD is counted separately from already published', async () => {
+	mockModule.listEntitySourcesForExternalReconcile.mockResolvedValue([source()])
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: null,
+	})
+
+	const result = await reconcileArtifactsPushes({
+		env: { APP_DB: {} } as Env,
+		baseUrl: 'https://kody.test',
+		now: new Date('2026-05-04T02:00:00.000Z'),
+	})
+
+	expect(result).toEqual(
+		expect.objectContaining({
+			alreadyPublished: 0,
+			missingHead: 1,
+		}),
+	)
+	expect(mockModule.publishFromExternalRef).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/jobs/reconcile-artifacts-pushes.ts
+++ b/packages/worker/src/jobs/reconcile-artifacts-pushes.ts
@@ -10,9 +10,11 @@ export type ReconcileArtifactsPushesResult = {
 	checked: number
 	published: number
 	alreadyPublished: number
+	missingHead: number
 	checksFailed: number
 	notFastForward: number
 	errors: number
+	tokenCleanupErrors: number
 	tokensRevoked: number
 }
 
@@ -49,9 +51,11 @@ export async function reconcileArtifactsPushes(input: {
 		checked: 0,
 		published: 0,
 		alreadyPublished: 0,
+		missingHead: 0,
 		checksFailed: 0,
 		notFastForward: 0,
 		errors: 0,
+		tokenCleanupErrors: 0,
 		tokensRevoked: 0,
 	}
 	const shouldCleanupTokens = shouldRunDailyTokenCleanup(now)
@@ -60,14 +64,35 @@ export async function reconcileArtifactsPushes(input: {
 		try {
 			const head = await resolveArtifactSourceHead(input.env, source.repo_id)
 			if (shouldCleanupTokens) {
-				const cleanup = await revokeStaleArtifactsTokens(
-					input.env,
-					source.repo_id,
-					{ keepAfter: now },
-				)
-				result.tokensRevoked += cleanup.revoked
+				try {
+					const cleanup = await revokeStaleArtifactsTokens(
+						input.env,
+						source.repo_id,
+						{ keepAfter: now },
+					)
+					result.tokensRevoked += cleanup.revoked
+				} catch (cleanupError) {
+					result.tokenCleanupErrors += 1
+					console.warn('reconcile_artifacts_pushes token cleanup failed', {
+						sourceId: source.id,
+						repoId: source.repo_id,
+						error:
+							cleanupError instanceof Error
+								? cleanupError.message
+								: String(cleanupError),
+					})
+				}
 			}
-			if (!head.commit || head.commit === source.published_commit) {
+			if (!head.commit) {
+				result.missingHead += 1
+				await updateEntitySource(input.env.APP_DB, {
+					id: source.id,
+					userId: source.user_id,
+					lastExternalCheckAt: now.toISOString(),
+				})
+				continue
+			}
+			if (head.commit === source.published_commit) {
 				result.alreadyPublished += 1
 				await updateEntitySource(input.env.APP_DB, {
 					id: source.id,

--- a/packages/worker/src/jobs/reconcile-artifacts-pushes.ts
+++ b/packages/worker/src/jobs/reconcile-artifacts-pushes.ts
@@ -115,11 +115,22 @@ export async function reconcileArtifactsPushes(input: {
 				repoId: source.repo_id,
 				error: error instanceof Error ? error.message : String(error),
 			})
-			await updateEntitySource(input.env.APP_DB, {
-				id: source.id,
-				userId: source.user_id,
-				lastExternalCheckAt: now.toISOString(),
-			})
+			try {
+				await updateEntitySource(input.env.APP_DB, {
+					id: source.id,
+					userId: source.user_id,
+					lastExternalCheckAt: now.toISOString(),
+				})
+			} catch (updateError) {
+				console.warn('reconcile_artifacts_pushes cursor update failed', {
+					sourceId: source.id,
+					repoId: source.repo_id,
+					error:
+						updateError instanceof Error
+							? updateError.message
+							: String(updateError),
+				})
+			}
 		}
 	}
 	console.info('reconcile_artifacts_pushes', result)

--- a/packages/worker/src/jobs/reconcile-artifacts-pushes.ts
+++ b/packages/worker/src/jobs/reconcile-artifacts-pushes.ts
@@ -1,0 +1,121 @@
+import {
+	listEntitySourcesForExternalReconcile,
+	updateEntitySource,
+} from '#worker/repo/entity-sources.ts'
+import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
+import { revokeStaleArtifactsTokens } from '#worker/repo/artifacts-tokens.ts'
+import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
+
+export type ReconcileArtifactsPushesResult = {
+	checked: number
+	published: number
+	alreadyPublished: number
+	checksFailed: number
+	notFastForward: number
+	errors: number
+	tokensRevoked: number
+}
+
+const defaultBatchSize = 50
+const defaultStaleAfterMinutes = 5
+
+function minutesAgoIso(minutes: number) {
+	return new Date(Date.now() - minutes * 60_000).toISOString()
+}
+
+function shouldRunDailyTokenCleanup(now: Date) {
+	return now.getUTCHours() === 3 && now.getUTCMinutes() < 5
+}
+
+export async function reconcileArtifactsPushes(input: {
+	env: Env
+	baseUrl: string
+	batchSize?: number
+	staleAfterMinutes?: number
+	now?: Date
+}): Promise<ReconcileArtifactsPushesResult> {
+	const now = input.now ?? new Date()
+	const sources = await listEntitySourcesForExternalReconcile(
+		input.env.APP_DB,
+		{
+			before: minutesAgoIso(
+				input.staleAfterMinutes ?? defaultStaleAfterMinutes,
+			),
+			limit: input.batchSize ?? defaultBatchSize,
+		},
+	)
+	const result: ReconcileArtifactsPushesResult = {
+		checked: 0,
+		published: 0,
+		alreadyPublished: 0,
+		checksFailed: 0,
+		notFastForward: 0,
+		errors: 0,
+		tokensRevoked: 0,
+	}
+	const shouldCleanupTokens = shouldRunDailyTokenCleanup(now)
+	for (const source of sources) {
+		result.checked += 1
+		try {
+			const head = await resolveArtifactSourceHead(input.env, source.repo_id)
+			if (shouldCleanupTokens) {
+				const cleanup = await revokeStaleArtifactsTokens(
+					input.env,
+					source.repo_id,
+					{ keepAfter: now },
+				)
+				result.tokensRevoked += cleanup.revoked
+			}
+			if (!head.commit || head.commit === source.published_commit) {
+				result.alreadyPublished += 1
+				await updateEntitySource(input.env.APP_DB, {
+					id: source.id,
+					userId: source.user_id,
+					lastExternalCheckAt: now.toISOString(),
+				})
+				continue
+			}
+			const sessionId = `external-reconcile-${source.id}`
+			const publishResult = await repoSessionRpc(
+				input.env,
+				sessionId,
+			).publishFromExternalRef({
+				sessionId,
+				sourceId: source.id,
+				userId: source.user_id,
+				newCommit: head.commit,
+				expectedHead: head.commit,
+				allowForce: false,
+				baseUrl: input.baseUrl,
+			})
+			switch (publishResult.status) {
+				case 'already_published':
+					result.alreadyPublished += 1
+					break
+				case 'published':
+					result.published += 1
+					break
+				case 'checks_failed':
+					result.checksFailed += 1
+					break
+				case 'not_fast_forward':
+					result.notFastForward += 1
+					break
+			}
+			await updateEntitySource(input.env.APP_DB, {
+				id: source.id,
+				userId: source.user_id,
+				lastExternalCheckAt: now.toISOString(),
+			})
+		} catch (error) {
+			result.errors += 1
+			console.warn('reconcile_artifacts_pushes source failed', {
+				sourceId: source.id,
+				repoId: source.repo_id,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+	console.info('reconcile_artifacts_pushes', result)
+	return result
+}

--- a/packages/worker/src/jobs/reconcile-artifacts-pushes.ts
+++ b/packages/worker/src/jobs/reconcile-artifacts-pushes.ts
@@ -19,8 +19,8 @@ export type ReconcileArtifactsPushesResult = {
 const defaultBatchSize = 50
 const defaultStaleAfterMinutes = 5
 
-function minutesAgoIso(minutes: number) {
-	return new Date(Date.now() - minutes * 60_000).toISOString()
+function minutesAgoIso(now: Date, minutes: number) {
+	return new Date(now.getTime() - minutes * 60_000).toISOString()
 }
 
 function shouldRunDailyTokenCleanup(now: Date) {
@@ -39,6 +39,7 @@ export async function reconcileArtifactsPushes(input: {
 		input.env.APP_DB,
 		{
 			before: minutesAgoIso(
+				now,
 				input.staleAfterMinutes ?? defaultStaleAfterMinutes,
 			),
 			limit: input.batchSize ?? defaultBatchSize,
@@ -113,6 +114,11 @@ export async function reconcileArtifactsPushes(input: {
 				sourceId: source.id,
 				repoId: source.repo_id,
 				error: error instanceof Error ? error.message : String(error),
+			})
+			await updateEntitySource(input.env.APP_DB, {
+				id: source.id,
+				userId: source.user_id,
+				lastExternalCheckAt: now.toISOString(),
 			})
 		}
 	}

--- a/packages/worker/src/mcp/capabilities/packages/domain.ts
+++ b/packages/worker/src/mcp/capabilities/packages/domain.ts
@@ -1,9 +1,11 @@
 import { defineDomain } from '../define-domain.ts'
 import { capabilityDomainNames } from '../domain-metadata.ts'
 import { deletePackageCapability } from './delete-package.ts'
+import { getGitRemoteCapability } from './get-git-remote.ts'
 import { getPackageCapability } from './get-package.ts'
 import { listPackagesCapability } from './list-packages.ts'
 import { listPackageSubscriptionsCapability } from './list-package-subscriptions.ts'
+import { publishExternalPushCapability } from './publish-external-push.ts'
 import { savePackageCapability } from './save-package.ts'
 
 export const packagesDomain = defineDomain({
@@ -14,8 +16,10 @@ export const packagesDomain = defineDomain({
 	capabilities: [
 		savePackageCapability,
 		getPackageCapability,
+		getGitRemoteCapability,
 		listPackagesCapability,
 		listPackageSubscriptionsCapability,
+		publishExternalPushCapability,
 		deletePackageCapability,
 	],
 })

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getSavedPackageById: vi.fn(),
+	getSavedPackageByKodyId: vi.fn(),
+	getEntitySourceById: vi.fn(),
+	resolveArtifactSourceRepo: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+	getSavedPackageByKodyId: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageByKodyId(...args),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+}))
+
+vi.mock('#worker/repo/artifacts.ts', async () => {
+	const actual = await vi.importActual('#worker/repo/artifacts.ts')
+	return {
+		...(actual as object),
+		resolveArtifactSourceRepo: (...args: Array<unknown>) =>
+			mockModule.resolveArtifactSourceRepo(...args),
+	}
+})
+
+const { getGitRemoteCapability } = await import('./get-git-remote.ts')
+
+function createContext(userId = 'user-1') {
+	return {
+		env: { APP_DB: {} } as Env,
+		callerContext: {
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId,
+				email: `${userId}@example.com`,
+				displayName: userId,
+			},
+			homeConnectorId: null,
+			remoteConnectors: null,
+			storageContext: null,
+			repoContext: null,
+		},
+	}
+}
+
+function mockPackageSource(sourceUserId = 'user-1') {
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: 'package-1',
+		kodyId: 'unleashed-wifi',
+		name: '@kentcdodds/unleashed-wifi',
+		sourceId: 'source-1',
+	})
+	mockModule.getSavedPackageByKodyId.mockResolvedValue({
+		id: 'package-1',
+		kodyId: 'unleashed-wifi',
+		name: '@kentcdodds/unleashed-wifi',
+		sourceId: 'source-1',
+	})
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: sourceUserId,
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'package-package-1',
+		published_commit: 'commit-1',
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		created_at: '2026-05-04T00:00:00.000Z',
+		updated_at: '2026-05-04T00:00:00.000Z',
+	})
+	const createToken = vi.fn(async (scope: 'read' | 'write', ttl: number) => ({
+		id: 'token-1',
+		plaintext: `art_v1_${scope}_token?expires=${Math.floor(Date.now() / 1000) + ttl}`,
+		scope,
+		expiresAt: new Date(Date.now() + ttl * 1000).toISOString(),
+	}))
+	mockModule.resolveArtifactSourceRepo.mockResolvedValue({
+		info: vi.fn(async () => ({
+			remote:
+				'https://acct.artifacts.cloudflare.net/git/default/package-package-1.git',
+			defaultBranch: 'main',
+		})),
+		createToken,
+	})
+	return { createToken }
+}
+
+beforeEach(() => {
+	for (const fn of Object.values(mockModule)) {
+		fn.mockReset()
+	}
+})
+
+test('returns a write remote token expiring within the requested ttl', async () => {
+	const { createToken } = mockPackageSource()
+	const before = Date.now()
+	const result = await getGitRemoteCapability.handler(
+		{ package_id: 'package-1', ttl_seconds: 1800 },
+		createContext(),
+	)
+	const expiresAt = new Date(result.expires_at).getTime()
+	expect(createToken).toHaveBeenCalledWith('write', 1800)
+	expect(result.scope).toBe('write')
+	expect(expiresAt).toBeGreaterThanOrEqual(before + 1799 * 1000)
+	expect(expiresAt).toBeLessThanOrEqual(Date.now() + 1801 * 1000)
+	expect(result.authenticated_remote).toContain('https://x:art_v1_write_token@')
+	expect(result.git_extra_header).toBe(
+		'Authorization: Bearer art_v1_write_token',
+	)
+	expect(result.setup_commands[0]).toContain('-c http.extraHeader=')
+})
+
+test('rejects a package source owned by another user', async () => {
+	mockPackageSource('other-user')
+	await expect(
+		getGitRemoteCapability.handler(
+			{ package_id: 'package-1' },
+			createContext(),
+		),
+	).rejects.toThrow('Repo source was not found for this user.')
+})
+
+test('rejects an unknown package id', async () => {
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+	await expect(
+		getGitRemoteCapability.handler({ package_id: 'missing' }, createContext()),
+	).rejects.toThrow('Saved package "missing" was not found.')
+})
+
+test('requires exactly one package identity', async () => {
+	await expect(
+		getGitRemoteCapability.handler({}, createContext()),
+	).rejects.toThrow('Provide exactly one of `package_id` or `kody_id`.')
+})
+
+test('honors explicit read scope', async () => {
+	const { createToken } = mockPackageSource()
+	const result = await getGitRemoteCapability.handler(
+		{ kody_id: 'unleashed-wifi', scope: 'read' },
+		createContext(),
+	)
+	expect(createToken).toHaveBeenCalledWith('read', 1800)
+	expect(result.scope).toBe('read')
+})
+
+test('validates ttl bounds', async () => {
+	mockPackageSource()
+	await expect(
+		getGitRemoteCapability.handler(
+			{ package_id: 'package-1', ttl_seconds: 59 },
+			createContext(),
+		),
+	).rejects.toThrow()
+	await expect(
+		getGitRemoteCapability.handler(
+			{ package_id: 'package-1', ttl_seconds: 86_401 },
+			createContext(),
+		),
+	).rejects.toThrow()
+})

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
@@ -115,6 +115,7 @@ test('returns a write remote token expiring within the requested ttl', async () 
 		'Authorization: Bearer art_v1_write_token',
 	)
 	expect(result.setup_commands[0]).toContain('-c http.extraHeader=')
+	expect(result.setup_commands[1]).toBe(`cd 'package-1'`)
 })
 
 test('rejects a package source owned by another user', async () => {

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
@@ -1,0 +1,99 @@
+import { markSecretInputFields } from '@kody-internal/shared/secret-input-schema.ts'
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import {
+	buildArtifactsGitAuth,
+	buildAuthenticatedArtifactsRemote,
+	resolveArtifactSourceRepo,
+} from '#worker/repo/artifacts.ts'
+import { resolveOwnedPackageSource } from './resolve-package-source.ts'
+
+const getGitRemoteInputSchema = z
+	.object({
+		package_id: z.string().min(1).optional(),
+		kody_id: z.string().min(1).optional(),
+		scope: z.enum(['read', 'write']).default('write'),
+		ttl_seconds: z.number().int().min(60).max(86_400).default(1800),
+	})
+	.superRefine((value, ctx) => {
+		const idCount =
+			(value.package_id !== undefined ? 1 : 0) +
+			(value.kody_id !== undefined ? 1 : 0)
+		if (idCount !== 1) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['package_id'],
+				message: 'Provide exactly one of `package_id` or `kody_id`.',
+			})
+		}
+	})
+
+const outputSchema = markSecretInputFields(
+	z.toJSONSchema(
+		z.object({
+			remote: z.string(),
+			authenticated_remote: z.string(),
+			git_extra_header: z.string(),
+			scope: z.enum(['read', 'write']),
+			expires_at: z.string(),
+			setup_commands: z.array(z.string()),
+		}),
+	) as Record<string, unknown>,
+	['authenticated_remote', 'git_extra_header'],
+) as Record<string, unknown>
+
+function shellQuote(value: string) {
+	return `'${value.replaceAll(`'`, `'"'"'`)}'`
+}
+
+export const getGitRemoteCapability = defineDomainCapability(
+	capabilityDomainNames.packages,
+	{
+		name: 'package_get_git_remote',
+		description:
+			'Mint a short-lived Cloudflare Artifacts git remote for directly cloning, pulling, or pushing a saved package source repository.',
+		keywords: ['package', 'git', 'remote', 'artifacts', 'clone', 'push'],
+		readOnly: false,
+		idempotent: false,
+		destructive: false,
+		inputSchema: getGitRemoteInputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const { source } = await resolveOwnedPackageSource({
+				db: ctx.env.APP_DB,
+				userId: user.userId,
+				args: {
+					package_id: args.package_id,
+					kody_id: args.kody_id,
+				},
+			})
+			const repo = await resolveArtifactSourceRepo(ctx.env, source.repo_id)
+			const info = await repo.info()
+			if (!info?.remote) {
+				throw new Error('Artifact repo remote URL is unavailable.')
+			}
+			const token = await repo.createToken(args.scope, args.ttl_seconds)
+			const gitAuth = buildArtifactsGitAuth({ token: token.plaintext })
+			const gitExtraHeader = `Authorization: Bearer ${gitAuth.password}`
+			const cloneDirectory = source.entity_id
+			return {
+				remote: info.remote,
+				authenticated_remote: buildAuthenticatedArtifactsRemote({
+					remote: info.remote,
+					token: token.plaintext,
+				}),
+				git_extra_header: gitExtraHeader,
+				scope: args.scope,
+				expires_at: token.expiresAt,
+				setup_commands: [
+					`git -c http.extraHeader=${shellQuote(gitExtraHeader)} clone ${shellQuote(info.remote)} ${shellQuote(cloneDirectory)}`,
+					`git remote add kody ${shellQuote(info.remote)}`,
+					`git -c http.extraHeader=${shellQuote(gitExtraHeader)} push kody HEAD:${shellQuote(info.defaultBranch ?? 'main')}`,
+				],
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
@@ -4,8 +4,8 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import {
-	buildArtifactsGitAuth,
 	buildAuthenticatedArtifactsRemote,
+	parseArtifactTokenSecret,
 	resolveArtifactSourceRepo,
 } from '#worker/repo/artifacts.ts'
 import { resolveOwnedPackageSource } from './resolve-package-source.ts'
@@ -76,8 +76,7 @@ export const getGitRemoteCapability = defineDomainCapability(
 				throw new Error('Artifact repo remote URL is unavailable.')
 			}
 			const token = await repo.createToken(args.scope, args.ttl_seconds)
-			const gitAuth = buildArtifactsGitAuth({ token: token.plaintext })
-			const gitExtraHeader = `Authorization: Bearer ${gitAuth.password}`
+			const gitExtraHeader = `Authorization: Bearer ${parseArtifactTokenSecret(token.plaintext)}`
 			const cloneDirectory = source.entity_id
 			return {
 				remote: info.remote,

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
@@ -10,25 +10,12 @@ import {
 } from '#worker/repo/artifacts.ts'
 import { resolveOwnedPackageSource } from './resolve-package-source.ts'
 
-const getGitRemoteInputSchema = z
-	.object({
-		package_id: z.string().min(1).optional(),
-		kody_id: z.string().min(1).optional(),
-		scope: z.enum(['read', 'write']).default('write'),
-		ttl_seconds: z.number().int().min(60).max(86_400).default(1800),
-	})
-	.superRefine((value, ctx) => {
-		const idCount =
-			(value.package_id !== undefined ? 1 : 0) +
-			(value.kody_id !== undefined ? 1 : 0)
-		if (idCount !== 1) {
-			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
-				path: ['package_id'],
-				message: 'Provide exactly one of `package_id` or `kody_id`.',
-			})
-		}
-	})
+const getGitRemoteInputSchema = z.object({
+	package_id: z.string().min(1).optional(),
+	kody_id: z.string().min(1).optional(),
+	scope: z.enum(['read', 'write']).default('write'),
+	ttl_seconds: z.number().int().min(60).max(86_400).default(1800),
+})
 
 const outputSchema = markSecretInputFields(
 	z.toJSONSchema(

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
@@ -41,7 +41,7 @@ const outputSchema = markSecretInputFields(
 			setup_commands: z.array(z.string()),
 		}),
 	) as Record<string, unknown>,
-	['authenticated_remote', 'git_extra_header'],
+	['authenticated_remote', 'git_extra_header', 'setup_commands'],
 ) as Record<string, unknown>
 
 function shellQuote(value: string) {
@@ -90,6 +90,7 @@ export const getGitRemoteCapability = defineDomainCapability(
 				expires_at: token.expiresAt,
 				setup_commands: [
 					`git -c http.extraHeader=${shellQuote(gitExtraHeader)} clone ${shellQuote(info.remote)} ${shellQuote(cloneDirectory)}`,
+					`cd ${shellQuote(cloneDirectory)}`,
 					`git remote add kody ${shellQuote(info.remote)}`,
 					`git -c http.extraHeader=${shellQuote(gitExtraHeader)} push kody HEAD:${shellQuote(info.defaultBranch ?? 'main')}`,
 				],

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getSavedPackageById: vi.fn(),
+	getSavedPackageByKodyId: vi.fn(),
+	getEntitySourceById: vi.fn(),
+	resolveArtifactSourceHead: vi.fn(),
+	publishFromExternalRef: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+	getSavedPackageByKodyId: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageByKodyId(...args),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+}))
+
+vi.mock('#worker/repo/artifacts.ts', () => ({
+	resolveArtifactSourceHead: (...args: Array<unknown>) =>
+		mockModule.resolveArtifactSourceHead(...args),
+}))
+
+vi.mock('#worker/repo/repo-session-do.ts', () => ({
+	repoSessionRpc: () => ({
+		publishFromExternalRef: (...args: Array<unknown>) =>
+			mockModule.publishFromExternalRef(...args),
+	}),
+}))
+
+const { publishExternalPushCapability } =
+	await import('./publish-external-push.ts')
+
+beforeEach(() => {
+	for (const value of Object.values(mockModule)) {
+		value.mockReset()
+	}
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: 'package-1',
+		kodyId: 'demo-package',
+		name: '@kentcdodds/demo-package',
+		sourceId: 'source-1',
+	})
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'package-package-1',
+		published_commit: 'commit-old',
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		created_at: '2026-05-04T00:00:00.000Z',
+		updated_at: '2026-05-04T00:00:00.000Z',
+	})
+})
+
+function createContext() {
+	return {
+		env: { APP_DB: {} } as Env,
+		callerContext: {
+			baseUrl: 'https://kody.test',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'User',
+			},
+			homeConnectorId: null,
+			remoteConnectors: null,
+			storageContext: null,
+			repoContext: null,
+		},
+	}
+}
+
+test('publishes a new external Artifacts HEAD', async () => {
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-new',
+	})
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'published',
+		previous_commit: 'commit-old',
+		published_commit: 'commit-new',
+		manifest: {},
+		checks: [{ kind: 'manifest', ok: true, message: 'ok' }],
+	})
+
+	const result = await publishExternalPushCapability.handler(
+		{ package_id: 'package-1' },
+		createContext(),
+	)
+
+	expect(result.status).toBe('published')
+	expect(mockModule.publishFromExternalRef).toHaveBeenCalledWith(
+		expect.objectContaining({
+			sourceId: 'source-1',
+			userId: 'user-1',
+			newCommit: 'commit-new',
+			expectedHead: 'commit-new',
+			allowForce: false,
+		}),
+	)
+})
+
+test('returns already_published when Artifacts HEAD matches D1', async () => {
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-old',
+	})
+
+	const result = await publishExternalPushCapability.handler(
+		{ package_id: 'package-1' },
+		createContext(),
+	)
+
+	expect(result).toEqual({
+		status: 'already_published',
+		published_commit: 'commit-old',
+	})
+	expect(mockModule.publishFromExternalRef).not.toHaveBeenCalled()
+})
+
+test('surfaces not-fast-forward refusal without force', async () => {
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-rewrite',
+	})
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'not_fast_forward',
+		previous_commit: 'commit-old',
+		published_commit: 'commit-rewrite',
+		message: 'The external Artifacts HEAD is not a descendant.',
+	})
+
+	const result = await publishExternalPushCapability.handler(
+		{ package_id: 'package-1' },
+		createContext(),
+	)
+
+	expect(result.status).toBe('not_fast_forward')
+	expect(mockModule.publishFromExternalRef).toHaveBeenCalledWith(
+		expect.objectContaining({
+			allowForce: false,
+		}),
+	)
+})
+
+test('passes allow_force through to the publish pipeline', async () => {
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-rewrite',
+	})
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'published',
+		previous_commit: 'commit-old',
+		published_commit: 'commit-rewrite',
+		manifest: {},
+		checks: [],
+	})
+
+	await publishExternalPushCapability.handler(
+		{ package_id: 'package-1', allow_force: true },
+		createContext(),
+	)
+
+	expect(mockModule.publishFromExternalRef).toHaveBeenCalledWith(
+		expect.objectContaining({
+			allowForce: true,
+		}),
+	)
+})
+
+test('check failure leaves mutation to the shared publish pipeline', async () => {
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-new',
+	})
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'checks_failed',
+		failed_checks: [{ kind: 'typecheck', ok: false, message: 'bad types' }],
+		manifest: {},
+		run_id: 'run-1',
+	})
+
+	const result = await publishExternalPushCapability.handler(
+		{ package_id: 'package-1' },
+		createContext(),
+	)
+
+	expect(result).toEqual({
+		status: 'checks_failed',
+		failed_checks: [{ kind: 'typecheck', ok: false, message: 'bad types' }],
+		manifest: {},
+		run_id: 'run-1',
+	})
+})

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -6,24 +6,11 @@ import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
 import { resolveOwnedPackageSource } from './resolve-package-source.ts'
 
-const inputSchema = z
-	.object({
-		package_id: z.string().min(1).optional(),
-		kody_id: z.string().min(1).optional(),
-		allow_force: z.boolean().optional().default(false),
-	})
-	.superRefine((value, ctx) => {
-		const idCount =
-			(value.package_id !== undefined ? 1 : 0) +
-			(value.kody_id !== undefined ? 1 : 0)
-		if (idCount !== 1) {
-			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
-				path: ['package_id'],
-				message: 'Provide exactly one of `package_id` or `kody_id`.',
-			})
-		}
-	})
+const inputSchema = z.object({
+	package_id: z.string().min(1).optional(),
+	kody_id: z.string().min(1).optional(),
+	allow_force: z.boolean().optional().default(false),
+})
 
 const checkSchema = z.object({
 	kind: z.enum([

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -1,0 +1,115 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
+import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
+import { resolveOwnedPackageSource } from './resolve-package-source.ts'
+
+const inputSchema = z
+	.object({
+		package_id: z.string().min(1).optional(),
+		kody_id: z.string().min(1).optional(),
+		allow_force: z.boolean().optional().default(false),
+	})
+	.superRefine((value, ctx) => {
+		const idCount =
+			(value.package_id !== undefined ? 1 : 0) +
+			(value.kody_id !== undefined ? 1 : 0)
+		if (idCount !== 1) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['package_id'],
+				message: 'Provide exactly one of `package_id` or `kody_id`.',
+			})
+		}
+	})
+
+const checkSchema = z.object({
+	kind: z.enum([
+		'manifest',
+		'dependencies',
+		'bundle',
+		'typecheck',
+		'lint',
+		'smoke',
+	]),
+	ok: z.boolean(),
+	message: z.string(),
+})
+
+const outputSchema = z.discriminatedUnion('status', [
+	z.object({
+		status: z.literal('already_published'),
+		published_commit: z.string().nullable(),
+	}),
+	z.object({
+		status: z.literal('not_fast_forward'),
+		previous_commit: z.string(),
+		published_commit: z.string(),
+		message: z.string(),
+	}),
+	z.object({
+		status: z.literal('checks_failed'),
+		failed_checks: z.array(checkSchema),
+		manifest: z.unknown(),
+		run_id: z.string(),
+	}),
+	z.object({
+		status: z.literal('published'),
+		previous_commit: z.string().nullable(),
+		published_commit: z.string(),
+		manifest: z.unknown(),
+		checks: z.array(checkSchema),
+	}),
+])
+
+export const publishExternalPushCapability = defineDomainCapability(
+	capabilityDomainNames.packages,
+	{
+		name: 'package_publish_external_push',
+		description:
+			'Publish the current Artifacts git HEAD for a saved package after server-side checks pass.',
+		keywords: ['package', 'publish', 'git', 'artifacts', 'external', 'push'],
+		readOnly: false,
+		idempotent: true,
+		destructive: false,
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const { source } = await resolveOwnedPackageSource({
+				db: ctx.env.APP_DB,
+				userId: user.userId,
+				args: {
+					package_id: args.package_id,
+					kody_id: args.kody_id,
+				},
+			})
+			const publishedCommit = source.published_commit
+			const head = await resolveArtifactSourceHead(ctx.env, source.repo_id)
+			const newCommit = head.commit
+			if (!newCommit) {
+				throw new Error(
+					`Artifacts repo "${source.repo_id}" has no published HEAD to reconcile.`,
+				)
+			}
+			if (newCommit === publishedCommit) {
+				return {
+					status: 'already_published',
+					published_commit: publishedCommit,
+				} as const
+			}
+			const sessionId = `external-publish-${source.id}`
+			return repoSessionRpc(ctx.env, sessionId).publishFromExternalRef({
+				sessionId,
+				sourceId: source.id,
+				userId: user.userId,
+				newCommit,
+				expectedHead: newCommit,
+				allowForce: args.allow_force,
+				baseUrl: ctx.callerContext.baseUrl,
+			})
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/packages/resolve-package-source.ts
+++ b/packages/worker/src/mcp/capabilities/packages/resolve-package-source.ts
@@ -1,0 +1,59 @@
+import {
+	getSavedPackageById,
+	getSavedPackageByKodyId,
+} from '#worker/package-registry/repo.ts'
+import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
+import { type EntitySourceRow } from '#worker/repo/types.ts'
+
+export type PackageSourceIdentity = {
+	package_id?: string
+	kody_id?: string
+}
+
+export function requireExactlyOnePackageSourceIdentity(
+	input: PackageSourceIdentity,
+) {
+	const count =
+		(input.package_id !== undefined ? 1 : 0) +
+		(input.kody_id !== undefined ? 1 : 0)
+	if (count !== 1) {
+		throw new Error('Provide exactly one of `package_id` or `kody_id`.')
+	}
+}
+
+export async function resolveOwnedPackageSource(input: {
+	db: D1Database
+	userId: string
+	args: PackageSourceIdentity
+}): Promise<{
+	packageId: string
+	kodyId: string
+	name: string
+	source: EntitySourceRow
+}> {
+	requireExactlyOnePackageSourceIdentity(input.args)
+	const savedPackage =
+		input.args.package_id !== undefined
+			? await getSavedPackageById(input.db, {
+					userId: input.userId,
+					packageId: input.args.package_id,
+				})
+			: await getSavedPackageByKodyId(input.db, {
+					userId: input.userId,
+					kodyId: input.args.kody_id ?? '',
+				})
+	if (!savedPackage) {
+		const missingId = input.args.package_id ?? input.args.kody_id
+		throw new Error(`Saved package "${missingId}" was not found.`)
+	}
+	const source = await getEntitySourceById(input.db, savedPackage.sourceId)
+	if (!source || source.user_id !== input.userId) {
+		throw new Error('Repo source was not found for this user.')
+	}
+	return {
+		packageId: savedPackage.id,
+		kodyId: savedPackage.kodyId,
+		name: savedPackage.name,
+		source,
+	}
+}

--- a/packages/worker/src/mcp/capabilities/packages/resolve-package-source.ts
+++ b/packages/worker/src/mcp/capabilities/packages/resolve-package-source.ts
@@ -10,9 +10,7 @@ export type PackageSourceIdentity = {
 	kody_id?: string
 }
 
-export function requireExactlyOnePackageSourceIdentity(
-	input: PackageSourceIdentity,
-) {
+function requireExactlyOnePackageSourceIdentity(input: PackageSourceIdentity) {
 	const count =
 		(input.package_id !== undefined ? 1 : 0) +
 		(input.kody_id !== undefined ? 1 : 0)

--- a/packages/worker/src/repo/artifacts-tokens.ts
+++ b/packages/worker/src/repo/artifacts-tokens.ts
@@ -23,12 +23,12 @@ export async function revokeStaleArtifactsTokens(
 		}
 		try {
 			await repo.revokeToken(token.id)
+			revoked += 1
 		} catch (error) {
 			if (!(error instanceof CloudflareApiError && error.status === 404)) {
 				throw error
 			}
 		}
-		revoked += 1
 	}
 	return {
 		checked: tokens.length,

--- a/packages/worker/src/repo/artifacts-tokens.ts
+++ b/packages/worker/src/repo/artifacts-tokens.ts
@@ -1,0 +1,30 @@
+import { resolveArtifactSourceRepo } from './artifacts.ts'
+
+export async function revokeStaleArtifactsTokens(
+	env: Env,
+	repoName: string,
+	input: {
+		keepAfter: Date
+	},
+) {
+	const repo = await resolveArtifactSourceRepo(env, repoName)
+	if (!repo.listTokens || !repo.revokeToken) {
+		return {
+			checked: 0,
+			revoked: 0,
+		}
+	}
+	const tokens = await repo.listTokens()
+	let revoked = 0
+	for (const token of tokens) {
+		if (new Date(token.expiresAt) >= input.keepAfter) {
+			continue
+		}
+		await repo.revokeToken(token.id)
+		revoked += 1
+	}
+	return {
+		checked: tokens.length,
+		revoked,
+	}
+}

--- a/packages/worker/src/repo/artifacts-tokens.ts
+++ b/packages/worker/src/repo/artifacts-tokens.ts
@@ -1,3 +1,4 @@
+import { CloudflareApiError } from '#mcp/cloudflare/cloudflare-rest-client.ts'
 import { resolveArtifactSourceRepo } from './artifacts.ts'
 
 export async function revokeStaleArtifactsTokens(
@@ -20,7 +21,13 @@ export async function revokeStaleArtifactsTokens(
 		if (new Date(token.expiresAt) >= input.keepAfter) {
 			continue
 		}
-		await repo.revokeToken(token.id)
+		try {
+			await repo.revokeToken(token.id)
+		} catch (error) {
+			if (!(error instanceof CloudflareApiError && error.status === 404)) {
+				throw error
+			}
+		}
 		revoked += 1
 	}
 	return {

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -239,7 +239,6 @@ function createArtifactsRestBinding(env: Env) {
 			await requestArtifactsEnvelope(client, {
 				method: 'DELETE',
 				path: `${basePath}/tokens/${encodeURIComponent(idOrPlaintext)}`,
-				treat404AsNull: true,
 			})
 		},
 		fork: async (target) => {

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -2,6 +2,8 @@ import {
 	CloudflareApiError,
 	createCloudflareRestClient,
 } from '#mcp/cloudflare/cloudflare-rest-client.ts'
+import git from 'isomorphic-git'
+import http from 'isomorphic-git/http/web'
 import { type EntityKind } from './types.ts'
 
 export type ArtifactToken = {
@@ -9,6 +11,13 @@ export type ArtifactToken = {
 	plaintext: string
 	scope: string
 	expiresAt: string
+}
+
+export type ArtifactStoredToken = {
+	id: string
+	scope: string
+	expiresAt: string
+	createdAt?: string | null
 }
 
 export type ArtifactBootstrapAccess = {
@@ -34,6 +43,8 @@ export type ArtifactRepoInfo = {
 export type ArtifactRepoHandle = {
 	info(): Promise<ArtifactRepoInfo | null>
 	createToken(scope?: 'write' | 'read', ttl?: number): Promise<ArtifactToken>
+	listTokens?(): Promise<Array<ArtifactStoredToken>>
+	revokeToken?(idOrPlaintext: string): Promise<void>
 	fork(target: { name: string; readOnly?: boolean }): Promise<{
 		id: string
 		name: string
@@ -152,6 +163,13 @@ type ArtifactRestCreateTokenResult = {
 	expires_at: string
 }
 
+type ArtifactRestStoredToken = {
+	id: string
+	scope: string
+	expires_at: string
+	created_at?: string | null
+}
+
 type ArtifactRestForkRepoResult = ArtifactRestCreateRepoResult & {
 	objects?: number
 }
@@ -199,6 +217,29 @@ function createArtifactsRestBinding(env: Env) {
 				scope: result.scope,
 				expiresAt: result.expires_at,
 			}
+		},
+		listTokens: async () => {
+			const envelope = await requestArtifactsEnvelope<
+				Array<ArtifactRestStoredToken>
+			>(client, {
+				method: 'GET',
+				path: `${basePath}/tokens`,
+				query: {
+					repo: name,
+				},
+			})
+			return (envelope.result ?? []).map((token) => ({
+				id: token.id,
+				scope: token.scope,
+				expiresAt: token.expires_at,
+				createdAt: token.created_at ?? null,
+			}))
+		},
+		revokeToken: async (idOrPlaintext) => {
+			await requestArtifactsEnvelope(client, {
+				method: 'DELETE',
+				path: `${basePath}/tokens/${encodeURIComponent(idOrPlaintext)}`,
+			})
 		},
 		fork: async (target) => {
 			const result = await requestArtifactsApi<ArtifactRestForkRepoResult>(
@@ -459,6 +500,48 @@ export function buildAuthenticatedArtifactsRemote(input: {
 	return remoteUrl.toString()
 }
 
+export async function listArtifactServerRefs(input: {
+	remote: string
+	token: string
+	prefix?: string
+}) {
+	const auth = buildArtifactsGitAuth({ token: input.token })
+	return git.listServerRefs({
+		http,
+		url: input.remote,
+		prefix: input.prefix,
+		symrefs: true,
+		onAuth() {
+			return auth
+		},
+	})
+}
+
+export async function resolveArtifactDefaultBranchHead(input: {
+	repo: ArtifactRepoHandle
+}) {
+	const info = await input.repo.info()
+	if (!info?.remote) {
+		throw new Error('Artifact repo remote URL is unavailable.')
+	}
+	const token = await input.repo.createToken('read', 300)
+	const refName = `refs/heads/${info.defaultBranch || 'main'}`
+	const refs = await listArtifactServerRefs({
+		remote: info.remote,
+		token: token.plaintext,
+		prefix: refName,
+	})
+	const branchRef = refs.find((ref) => ref.ref === refName)
+	if (!branchRef?.oid) {
+		return null
+	}
+	return {
+		remote: info.remote,
+		defaultBranch: info.defaultBranch || 'main',
+		commit: branchRef.oid,
+	}
+}
+
 export function isLoopbackHostname(hostname: string) {
 	return (
 		hostname === 'localhost' ||
@@ -548,4 +631,27 @@ export async function resolveSessionRepo(
 		)
 	}
 	return result.repo
+}
+
+export async function resolveArtifactSourceHead(env: Env, repoId: string) {
+	const repo = await resolveArtifactSourceRepo(env, repoId)
+	const info = await repo.info()
+	if (!info?.remote) {
+		throw new Error('Artifact repo remote URL is unavailable.')
+	}
+	const token = await repo.createToken('read', 300)
+	const auth = buildArtifactsGitAuth({ token: token.plaintext })
+	const refs = await git.listServerRefs({
+		http,
+		url: info.remote,
+		prefix: `refs/heads/${info.defaultBranch}`,
+		onAuth: () => auth,
+	})
+	const ref = refs.find(
+		(entry) => entry.ref === `refs/heads/${info.defaultBranch}`,
+	)
+	return {
+		branch: info.defaultBranch,
+		commit: ref?.oid ?? null,
+	}
 }

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -239,6 +239,7 @@ function createArtifactsRestBinding(env: Env) {
 			await requestArtifactsEnvelope(client, {
 				method: 'DELETE',
 				path: `${basePath}/tokens/${encodeURIComponent(idOrPlaintext)}`,
+				treat404AsNull: true,
 			})
 		},
 		fork: async (target) => {
@@ -635,23 +636,9 @@ export async function resolveSessionRepo(
 
 export async function resolveArtifactSourceHead(env: Env, repoId: string) {
 	const repo = await resolveArtifactSourceRepo(env, repoId)
-	const info = await repo.info()
-	if (!info?.remote) {
-		throw new Error('Artifact repo remote URL is unavailable.')
-	}
-	const token = await repo.createToken('read', 300)
-	const auth = buildArtifactsGitAuth({ token: token.plaintext })
-	const refs = await git.listServerRefs({
-		http,
-		url: info.remote,
-		prefix: `refs/heads/${info.defaultBranch}`,
-		onAuth: () => auth,
-	})
-	const ref = refs.find(
-		(entry) => entry.ref === `refs/heads/${info.defaultBranch}`,
-	)
+	const ref = await resolveArtifactDefaultBranchHead({ repo })
 	return {
-		branch: info.defaultBranch,
-		commit: ref?.oid ?? null,
+		branch: ref?.defaultBranch ?? 'main',
+		commit: ref?.commit ?? null,
 	}
 }

--- a/packages/worker/src/repo/entity-sources.ts
+++ b/packages/worker/src/repo/entity-sources.ts
@@ -34,8 +34,8 @@ export async function insertEntitySource(
 		.prepare(
 			`INSERT INTO entity_sources (
 				id, user_id, entity_kind, entity_id, repo_id, published_commit, indexed_commit,
-				manifest_path, source_root, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				manifest_path, source_root, last_external_check_at, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		)
 		.bind(
 			row.id,
@@ -47,6 +47,7 @@ export async function insertEntitySource(
 			row.indexed_commit,
 			row.manifest_path,
 			row.source_root,
+			row.last_external_check_at,
 			row.created_at,
 			row.updated_at,
 		)

--- a/packages/worker/src/repo/entity-sources.ts
+++ b/packages/worker/src/repo/entity-sources.ts
@@ -17,6 +17,10 @@ function mapEntitySourceRow(row: Record<string, unknown>): EntitySourceRow {
 			row['indexed_commit'] == null ? null : String(row['indexed_commit']),
 		manifest_path: String(row['manifest_path']),
 		source_root: String(row['source_root']),
+		last_external_check_at:
+			row['last_external_check_at'] == null
+				? null
+				: String(row['last_external_check_at']),
 		created_at: String(row['created_at']),
 		updated_at: String(row['updated_at']),
 	})
@@ -104,6 +108,7 @@ export async function updateEntitySource(
 		indexedCommit?: string | null
 		manifestPath?: string
 		sourceRoot?: string
+		lastExternalCheckAt?: string | null
 	},
 ): Promise<boolean> {
 	const assignments: Array<string> = []
@@ -120,6 +125,9 @@ export async function updateEntitySource(
 		add('indexed_commit', input.indexedCommit)
 	if (input.manifestPath !== undefined) add('manifest_path', input.manifestPath)
 	if (input.sourceRoot !== undefined) add('source_root', input.sourceRoot)
+	if (input.lastExternalCheckAt !== undefined) {
+		add('last_external_check_at', input.lastExternalCheckAt)
+	}
 	add('updated_at', new Date().toISOString())
 	const result = await db
 		.prepare(
@@ -154,6 +162,25 @@ export async function upsertEntitySource(
 		return
 	}
 	await insertEntitySource(db, row)
+}
+
+export async function listEntitySourcesForExternalReconcile(
+	db: D1Database,
+	input: {
+		before: string
+		limit: number
+	},
+): Promise<Array<EntitySourceRow>> {
+	const { results } = await db
+		.prepare(
+			`SELECT * FROM entity_sources
+			WHERE last_external_check_at IS NULL OR last_external_check_at < ?
+			ORDER BY COALESCE(last_external_check_at, created_at) ASC
+			LIMIT ?`,
+		)
+		.bind(input.before, input.limit)
+		.all<Record<string, unknown>>()
+	return (results ?? []).map(mapEntitySourceRow)
 }
 
 export async function deleteEntitySource(

--- a/packages/worker/src/repo/external-publish.node.test.ts
+++ b/packages/worker/src/repo/external-publish.node.test.ts
@@ -90,7 +90,7 @@ test('does not fail publish when package projection refresh fails after commit a
 		sourceId: 'source-1',
 		userId: 'user-1',
 		newCommit: 'commit-new',
-		isFastForward: true,
+		isFastForward: async () => true,
 		workspace: workspace(),
 		files: { 'package.json': '{}' },
 		baseUrl: 'https://kody.test',
@@ -122,7 +122,7 @@ test('publishes an external fast-forward ref after checks pass', async () => {
 		sourceId: 'source-1',
 		userId: 'user-1',
 		newCommit: 'commit-new',
-		isFastForward: true,
+		isFastForward: async () => true,
 		workspace: workspace(),
 		files: { 'package.json': '{}' },
 		baseUrl: 'https://kody.test',
@@ -147,7 +147,7 @@ test('returns no-op when commit is already current', async () => {
 			sourceId: 'source-1',
 			userId: 'user-1',
 			newCommit: 'commit-old',
-			isFastForward: true,
+			isFastForward: async () => true,
 			workspace: workspace(),
 			files: {},
 			baseUrl: 'https://kody.test',
@@ -168,7 +168,7 @@ test('refuses non-fast-forward publish unless allowForce is true', async () => {
 		sourceId: 'source-1',
 		userId: 'user-1',
 		newCommit: 'commit-rewritten',
-		isFastForward: false,
+		isFastForward: async () => false,
 		workspace: workspace(),
 		files: {},
 		baseUrl: 'https://kody.test',
@@ -202,7 +202,7 @@ test('allows non-fast-forward publish when allowForce is true', async () => {
 		sourceId: 'source-1',
 		userId: 'user-1',
 		newCommit: 'commit-rewritten',
-		isFastForward: false,
+		isFastForward: async () => false,
 		allowForce: true,
 		workspace: workspace(),
 		files: { 'package.json': '{}' },
@@ -226,6 +226,33 @@ test('allows non-fast-forward publish when allowForce is true', async () => {
 	)
 })
 
+test('rechecks fast-forward against the latest source row before publishing', async () => {
+	mockModule.getEntitySourceById.mockResolvedValue(
+		source({ published_commit: 'commit-concurrent' }),
+	)
+
+	const result = await publishFromExternalRef({
+		env: { APP_DB: {} } as Env,
+		sourceId: 'source-1',
+		userId: 'user-1',
+		newCommit: 'commit-new',
+		isFastForward: async (previousCommit) => previousCommit === 'commit-old',
+		workspace: workspace(),
+		files: {},
+		baseUrl: 'https://kody.test',
+	})
+
+	expect(result).toEqual({
+		status: 'not_fast_forward',
+		previous_commit: 'commit-concurrent',
+		published_commit: 'commit-new',
+		message:
+			'The external Artifacts HEAD is not a descendant of the current published commit. Retry with allow_force to publish it.',
+	})
+	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+})
+
 test('check failure leaves D1 untouched', async () => {
 	mockModule.getEntitySourceById.mockResolvedValue(source())
 	mockModule.runRepoChecks.mockResolvedValue({
@@ -246,7 +273,7 @@ test('check failure leaves D1 untouched', async () => {
 		sourceId: 'source-1',
 		userId: 'user-1',
 		newCommit: 'commit-new',
-		isFastForward: true,
+		isFastForward: async () => true,
 		workspace: workspace(),
 		files: {},
 		baseUrl: 'https://kody.test',
@@ -287,7 +314,7 @@ test('projection refresh failure does not fail an already-committed publish', as
 		sourceId: 'source-1',
 		userId: 'user-1',
 		newCommit: 'commit-new',
-		isFastForward: true,
+		isFastForward: async () => true,
 		workspace: workspace(),
 		files: { 'package.json': '{}' },
 		baseUrl: 'https://kody.test',

--- a/packages/worker/src/repo/external-publish.node.test.ts
+++ b/packages/worker/src/repo/external-publish.node.test.ts
@@ -70,6 +70,41 @@ beforeEach(() => {
 	mockModule.refreshSavedPackageProjection.mockClear()
 })
 
+test('does not fail publish when package projection refresh fails after commit advance', async () => {
+	mockModule.getEntitySourceById.mockResolvedValue(source())
+	mockModule.runRepoChecks.mockResolvedValue({
+		ok: true,
+		results: [{ kind: 'manifest', ok: true, message: 'ok' }],
+		manifest: {
+			name: '@scope/demo',
+			exports: { '.': './src/index.ts' },
+			kody: { id: 'demo', description: 'Demo' },
+		},
+	})
+	mockModule.refreshSavedPackageProjection.mockRejectedValueOnce(
+		new Error('projection failed'),
+	)
+
+	const result = await publishFromExternalRef({
+		env: { APP_DB: {} } as Env,
+		sourceId: 'source-1',
+		userId: 'user-1',
+		newCommit: 'commit-new',
+		isFastForward: true,
+		workspace: workspace(),
+		files: { 'package.json': '{}' },
+		baseUrl: 'https://kody.test',
+	})
+
+	expect(result.status).toBe('published')
+	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({
+			publishedCommit: 'commit-new',
+		}),
+	)
+})
+
 test('publishes an external fast-forward ref after checks pass', async () => {
 	mockModule.getEntitySourceById.mockResolvedValue(source())
 	mockModule.runRepoChecks.mockResolvedValue({
@@ -188,4 +223,41 @@ test('check failure leaves D1 untouched', async () => {
 		run_id: 'run-1',
 	})
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+})
+
+test('projection refresh failure does not fail an already-committed publish', async () => {
+	mockModule.getEntitySourceById.mockResolvedValue(source())
+	mockModule.hasPublishedRuntimeArtifacts.mockReturnValue(true)
+	mockModule.runRepoChecks.mockResolvedValue({
+		ok: true,
+		results: [{ kind: 'manifest', ok: true, message: 'ok' }],
+		manifest: {
+			name: '@scope/demo',
+			exports: { '.': './src/index.ts' },
+			kody: { id: 'demo', description: 'Demo' },
+		},
+	})
+	mockModule.refreshSavedPackageProjection.mockRejectedValueOnce(
+		new Error('projection unavailable'),
+	)
+
+	const result = await publishFromExternalRef({
+		env: { APP_DB: {}, BUNDLE_ARTIFACTS_KV: {} as KVNamespace } as Env,
+		sourceId: 'source-1',
+		userId: 'user-1',
+		newCommit: 'commit-new',
+		isFastForward: true,
+		workspace: workspace(),
+		files: { 'package.json': '{}' },
+		baseUrl: 'https://kody.test',
+	})
+
+	expect(result.status).toBe('published')
+	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({
+			publishedCommit: 'commit-new',
+		}),
+	)
+	expect(mockModule.writePublishedSourceSnapshot).toHaveBeenCalled()
 })

--- a/packages/worker/src/repo/external-publish.node.test.ts
+++ b/packages/worker/src/repo/external-publish.node.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getEntitySourceById: vi.fn(),
+	updateEntitySource: vi.fn(async () => true),
+	runRepoChecks: vi.fn(),
+	writePublishedSourceSnapshot: vi.fn(async () => 'snapshot-key'),
+	refreshSavedPackageProjection: vi.fn(),
+	hasPublishedRuntimeArtifacts: vi.fn(() => false),
+}))
+
+vi.mock('./entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+	updateEntitySource: (...args: Array<unknown>) =>
+		mockModule.updateEntitySource(...args),
+}))
+
+vi.mock('./checks.ts', () => ({
+	runRepoChecks: (...args: Array<unknown>) => mockModule.runRepoChecks(...args),
+}))
+
+vi.mock('#worker/package-runtime/published-runtime-artifacts.ts', () => ({
+	hasPublishedRuntimeArtifacts: (...args: Array<unknown>) =>
+		mockModule.hasPublishedRuntimeArtifacts(...args),
+	writePublishedSourceSnapshot: (...args: Array<unknown>) =>
+		mockModule.writePublishedSourceSnapshot(...args),
+}))
+
+vi.mock('#worker/package-registry/service.ts', () => ({
+	refreshSavedPackageProjection: (...args: Array<unknown>) =>
+		mockModule.refreshSavedPackageProjection(...args),
+}))
+
+const { publishFromExternalRef } = await import('./external-publish.ts')
+const { finalizePublishedEntitySource } = await import('./external-publish.ts')
+
+function source(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'repo-1',
+		published_commit: 'commit-old',
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		created_at: '2026-05-04T00:00:00.000Z',
+		updated_at: '2026-05-04T00:00:00.000Z',
+		...overrides,
+	}
+}
+
+function workspace() {
+	return {
+		readFile: vi.fn(async () => '{}'),
+		glob: vi.fn(async () => []),
+	}
+}
+
+beforeEach(() => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.updateEntitySource.mockClear()
+	mockModule.runRepoChecks.mockReset()
+	mockModule.writePublishedSourceSnapshot.mockClear()
+	mockModule.writePublishedSourceSnapshot.mockResolvedValue('snapshot-key')
+	mockModule.hasPublishedRuntimeArtifacts.mockReturnValue(false)
+	mockModule.refreshSavedPackageProjection.mockClear()
+})
+
+test('publishes an external fast-forward ref after checks pass', async () => {
+	mockModule.getEntitySourceById.mockResolvedValue(source())
+	mockModule.runRepoChecks.mockResolvedValue({
+		ok: true,
+		results: [{ kind: 'manifest', ok: true, message: 'ok' }],
+		manifest: {
+			name: '@scope/demo',
+			exports: { '.': './src/index.ts' },
+			kody: { id: 'demo', description: 'Demo' },
+		},
+	})
+
+	const result = await publishFromExternalRef({
+		env: { APP_DB: {} } as Env,
+		sourceId: 'source-1',
+		userId: 'user-1',
+		newCommit: 'commit-new',
+		isFastForward: true,
+		workspace: workspace(),
+		files: { 'package.json': '{}' },
+		baseUrl: 'https://kody.test',
+	})
+
+	expect(result.status).toBe('published')
+	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({
+			id: 'source-1',
+			publishedCommit: 'commit-new',
+		}),
+	)
+})
+
+test('returns no-op when commit is already current', async () => {
+	mockModule.getEntitySourceById.mockResolvedValue(source())
+
+	await expect(
+		publishFromExternalRef({
+			env: { APP_DB: {} } as Env,
+			sourceId: 'source-1',
+			userId: 'user-1',
+			newCommit: 'commit-old',
+			isFastForward: true,
+			workspace: workspace(),
+			files: {},
+			baseUrl: 'https://kody.test',
+		}),
+	).resolves.toEqual({
+		status: 'already_published',
+		published_commit: 'commit-old',
+	})
+	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+})
+
+test('refuses non-fast-forward publish unless allowForce is true', async () => {
+	mockModule.getEntitySourceById.mockResolvedValue(source())
+
+	const result = await publishFromExternalRef({
+		env: { APP_DB: {} } as Env,
+		sourceId: 'source-1',
+		userId: 'user-1',
+		newCommit: 'commit-rewritten',
+		isFastForward: false,
+		workspace: workspace(),
+		files: {},
+		baseUrl: 'https://kody.test',
+	})
+
+	expect(result).toEqual({
+		status: 'not_fast_forward',
+		previous_commit: 'commit-old',
+		published_commit: 'commit-rewritten',
+		message:
+			'The external Artifacts HEAD is not a descendant of the current published commit. Retry with allow_force to publish it.',
+	})
+	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+})
+
+test('check failure leaves D1 untouched', async () => {
+	mockModule.getEntitySourceById.mockResolvedValue(source())
+	mockModule.runRepoChecks.mockResolvedValue({
+		ok: false,
+		results: [
+			{ kind: 'manifest', ok: true, message: 'ok' },
+			{ kind: 'typecheck', ok: false, message: 'bad type' },
+		],
+		manifest: {
+			name: '@scope/demo',
+			exports: { '.': './src/index.ts' },
+			kody: { id: 'demo', description: 'Demo' },
+		},
+	})
+
+	const result = await publishFromExternalRef({
+		env: { APP_DB: {} } as Env,
+		sourceId: 'source-1',
+		userId: 'user-1',
+		newCommit: 'commit-new',
+		isFastForward: true,
+		workspace: workspace(),
+		files: {},
+		baseUrl: 'https://kody.test',
+		runId: 'run-1',
+	})
+
+	expect(result).toEqual({
+		status: 'checks_failed',
+		failed_checks: [{ kind: 'typecheck', ok: false, message: 'bad type' }],
+		manifest: {
+			name: '@scope/demo',
+			exports: { '.': './src/index.ts' },
+			kody: { id: 'demo', description: 'Demo' },
+		},
+		run_id: 'run-1',
+	})
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/repo/external-publish.node.test.ts
+++ b/packages/worker/src/repo/external-publish.node.test.ts
@@ -185,6 +185,47 @@ test('refuses non-fast-forward publish unless allowForce is true', async () => {
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
 })
 
+test('allows non-fast-forward publish when allowForce is true', async () => {
+	mockModule.getEntitySourceById.mockResolvedValue(source())
+	mockModule.runRepoChecks.mockResolvedValue({
+		ok: true,
+		results: [{ kind: 'manifest', ok: true, message: 'ok' }],
+		manifest: {
+			name: '@scope/demo',
+			exports: { '.': './src/index.ts' },
+			kody: { id: 'demo', description: 'Demo' },
+		},
+	})
+
+	const result = await publishFromExternalRef({
+		env: { APP_DB: {} } as Env,
+		sourceId: 'source-1',
+		userId: 'user-1',
+		newCommit: 'commit-rewritten',
+		isFastForward: false,
+		allowForce: true,
+		workspace: workspace(),
+		files: { 'package.json': '{}' },
+		baseUrl: 'https://kody.test',
+	})
+
+	expect(result).toEqual(
+		expect.objectContaining({
+			status: 'published',
+			previous_commit: 'commit-old',
+			published_commit: 'commit-rewritten',
+		}),
+	)
+	expect(mockModule.runRepoChecks).toHaveBeenCalledTimes(1)
+	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({
+			id: 'source-1',
+			publishedCommit: 'commit-rewritten',
+		}),
+	)
+})
+
 test('check failure leaves D1 untouched', async () => {
 	mockModule.getEntitySourceById.mockResolvedValue(source())
 	mockModule.runRepoChecks.mockResolvedValue({

--- a/packages/worker/src/repo/external-publish.ts
+++ b/packages/worker/src/repo/external-publish.ts
@@ -107,7 +107,7 @@ export async function publishFromExternalRef(input: {
 	sourceId: string
 	userId: string
 	newCommit: string
-	isFastForward: boolean
+	isFastForward(input: { previousCommit: string }): Promise<boolean>
 	allowForce?: boolean
 	workspace: RepoPublishWorkspace
 	files: Record<string, string>
@@ -126,7 +126,13 @@ export async function publishFromExternalRef(input: {
 			published_commit: source.published_commit,
 		}
 	}
-	if (source.published_commit && !input.allowForce && !input.isFastForward) {
+	if (
+		source.published_commit &&
+		!input.allowForce &&
+		!(await input.isFastForward({
+			previousCommit: source.published_commit,
+		}))
+	) {
 		return {
 			status: 'not_fast_forward',
 			previous_commit: source.published_commit,

--- a/packages/worker/src/repo/external-publish.ts
+++ b/packages/worker/src/repo/external-publish.ts
@@ -1,0 +1,147 @@
+import * as Sentry from '@sentry/cloudflare'
+import { refreshSavedPackageProjection } from '#worker/package-registry/service.ts'
+import {
+	hasPublishedRuntimeArtifacts,
+	writePublishedSourceSnapshot,
+} from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { getEntitySourceById, updateEntitySource } from './entity-sources.ts'
+import { runRepoChecks } from './checks.ts'
+import {
+	type EntitySourceRow,
+	type RepoExternalPublishResult,
+} from './types.ts'
+
+export type RepoPublishWorkspace = {
+	readFile(path: string): Promise<string | null>
+	glob(pattern: string): Promise<Array<{ path: string; type: string }>>
+}
+
+export type FinalizePublishedSourceInput = {
+	env: Env
+	source: EntitySourceRow
+	publishedCommit: string
+	files: Record<string, string>
+	baseUrl?: string
+}
+
+export async function finalizePublishedEntitySource(
+	input: FinalizePublishedSourceInput,
+) {
+	const previousPublishedCommit = input.source.published_commit
+	await updateEntitySource(input.env.APP_DB, {
+		id: input.source.id,
+		userId: input.source.user_id,
+		publishedCommit: input.publishedCommit,
+		manifestPath: input.source.manifest_path,
+		sourceRoot: input.source.source_root,
+	})
+	if (hasPublishedRuntimeArtifacts(input.env)) {
+		try {
+			await writePublishedSourceSnapshot({
+				env: input.env,
+				source: {
+					...input.source,
+					published_commit: input.publishedCommit,
+				},
+				files: input.files,
+			})
+		} catch (snapshotError) {
+			try {
+				await updateEntitySource(input.env.APP_DB, {
+					id: input.source.id,
+					userId: input.source.user_id,
+					publishedCommit: previousPublishedCommit,
+					manifestPath: input.source.manifest_path,
+					sourceRoot: input.source.source_root,
+				})
+			} catch (revertError) {
+				Sentry.captureException(revertError, {
+					tags: {
+						scope: 'repo.publishFromExternalRef.revert-after-snapshot-failure',
+					},
+					extra: {
+						sourceId: input.source.id,
+						previousPublishedCommit,
+						attemptedPublishedCommit: input.publishedCommit,
+					},
+				})
+			}
+			throw snapshotError
+		}
+	}
+	if (input.source.entity_kind === 'package') {
+		await refreshSavedPackageProjection({
+			env: input.env,
+			baseUrl: input.baseUrl ?? input.source.source_root,
+			userId: input.source.user_id,
+			packageId: input.source.entity_id,
+			sourceId: input.source.id,
+		})
+	}
+}
+
+export async function publishFromExternalRef(input: {
+	env: Env
+	sourceId: string
+	userId: string
+	newCommit: string
+	isFastForward: boolean
+	allowForce?: boolean
+	workspace: RepoPublishWorkspace
+	files: Record<string, string>
+	baseUrl: string
+	manifestPath?: string
+	sourceRoot?: string
+	runId?: string
+}): Promise<RepoExternalPublishResult> {
+	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
+	if (!source || source.user_id !== input.userId) {
+		throw new Error('Repo source was not found for this user.')
+	}
+	if (source.published_commit === input.newCommit) {
+		return {
+			status: 'already_published',
+			published_commit: source.published_commit,
+		}
+	}
+	if (source.published_commit && !input.allowForce && !input.isFastForward) {
+		return {
+			status: 'not_fast_forward',
+			previous_commit: source.published_commit,
+			published_commit: input.newCommit,
+			message:
+				'The external Artifacts HEAD is not a descendant of the current published commit. Retry with allow_force to publish it.',
+		}
+	}
+	const checks = await runRepoChecks({
+		workspace: input.workspace,
+		manifestPath: input.manifestPath ?? source.manifest_path,
+		sourceRoot: input.sourceRoot ?? source.source_root,
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+	})
+	const runId = input.runId ?? crypto.randomUUID()
+	if (!checks.ok) {
+		return {
+			status: 'checks_failed',
+			failed_checks: checks.results.filter((check) => !check.ok),
+			manifest: checks.manifest,
+			run_id: runId,
+		}
+	}
+	await finalizePublishedEntitySource({
+		env: input.env,
+		source,
+		publishedCommit: input.newCommit,
+		files: input.files,
+		baseUrl: input.baseUrl,
+	})
+	return {
+		status: 'published',
+		previous_commit: source.published_commit,
+		published_commit: input.newCommit,
+		manifest: checks.manifest,
+		checks: checks.results,
+	}
+}

--- a/packages/worker/src/repo/external-publish.ts
+++ b/packages/worker/src/repo/external-publish.ts
@@ -70,13 +70,35 @@ export async function finalizePublishedEntitySource(
 		}
 	}
 	if (input.source.entity_kind === 'package') {
-		await refreshSavedPackageProjection({
-			env: input.env,
-			baseUrl: input.baseUrl ?? input.source.source_root,
-			userId: input.source.user_id,
-			packageId: input.source.entity_id,
-			sourceId: input.source.id,
-		})
+		try {
+			await refreshSavedPackageProjection({
+				env: input.env,
+				baseUrl: input.baseUrl ?? input.source.source_root,
+				userId: input.source.user_id,
+				packageId: input.source.entity_id,
+				sourceId: input.source.id,
+			})
+		} catch (projectionError) {
+			Sentry.captureException(projectionError, {
+				tags: {
+					scope: 'repo.publishFromExternalRef.refresh-package-projection',
+				},
+				extra: {
+					sourceId: input.source.id,
+					packageId: input.source.entity_id,
+					publishedCommit: input.publishedCommit,
+				},
+			})
+			console.warn('publish_from_external_ref projection refresh failed', {
+				sourceId: input.source.id,
+				packageId: input.source.entity_id,
+				publishedCommit: input.publishedCommit,
+				error:
+					projectionError instanceof Error
+						? projectionError.message
+						: String(projectionError),
+			})
+		}
 	}
 }
 

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -92,6 +92,12 @@ const mockModule = vi.hoisted(() => {
 		updateEntitySource: vi.fn(async () => undefined),
 		resolveSessionRepo: vi.fn(),
 		resolveArtifactSourceRepo: vi.fn(),
+		resolveArtifactDefaultBranchHead: vi.fn(async () => ({
+			defaultBranch: 'main',
+			commit: 'commit-published-new',
+			remote:
+				'https://acct.artifacts.cloudflare.net/git/default/source-repo.git',
+		})),
 		parseRepoManifest: vi.fn(() => ({ sourceRoot: '/' })),
 		runRepoChecks: vi.fn(async () => ({
 			ok: true,
@@ -182,6 +188,8 @@ vi.mock('./artifacts.ts', async () => {
 			mockModule.resolveSessionRepo(...args),
 		resolveArtifactSourceRepo: (...args: Array<unknown>) =>
 			mockModule.resolveArtifactSourceRepo(...args),
+		resolveArtifactDefaultBranchHead: (...args: Array<unknown>) =>
+			mockModule.resolveArtifactDefaultBranchHead(...args),
 	}
 })
 

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -901,6 +901,29 @@ test('readWithRetry distinguishes null from other falsy values', async () => {
 	expect(eventualRead).toHaveBeenCalledTimes(3)
 })
 
+test('publishFromExternalRef rejects stale expected HEAD values', async () => {
+	setCommonSessionFixtures()
+	mockModule.resolveArtifactDefaultBranchHead.mockResolvedValueOnce({
+		defaultBranch: 'main',
+		commit: 'commit-new',
+		remote: 'https://acct.artifacts.cloudflare.net/git/default/source-repo.git',
+	})
+
+	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
+
+	await expect(
+		repoSession.publishFromExternalRef({
+			sessionId: 'external-publish-source-1',
+			sourceId: 'source-1',
+			userId: 'user-1',
+			newCommit: 'commit-stale',
+			expectedHead: 'commit-stale',
+		}),
+	).rejects.toThrow(
+		'Artifacts HEAD changed from "commit-stale" to "commit-new" before publish.',
+	)
+})
+
 test('getSessionState prefers fresh D1 reads over cached session and source rows', async () => {
 	// Guards against a regression where the cache, populated by openSession,
 	// would shadow fresh D1 reads and hide updates such as rebaseSession

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -35,14 +35,11 @@ import {
 import { runRepoChecks } from './checks.ts'
 import { parseRepoManifest } from './manifest.ts'
 import {
-	hasPublishedRuntimeArtifacts,
-	writePublishedSourceSnapshot,
-} from '#worker/package-runtime/published-runtime-artifacts.ts'
-import {
 	type EntityKind,
 	type EntitySourceRow,
 	type RepoSearchMode,
 	type RepoSearchOutputMode,
+	type RepoExternalPublishResult,
 	type RepoSourceBootstrapResult,
 	type RepoSessionApplyEditsResult,
 	type RepoSessionCheckRun,
@@ -54,7 +51,10 @@ import {
 	type RepoSessionSearchResult,
 	type RepoSessionTreeResult,
 } from './types.ts'
-import { refreshSavedPackageProjection } from '#worker/package-registry/service.ts'
+import {
+	finalizePublishedEntitySource,
+	publishFromExternalRef as publishExternalRefSource,
+} from './external-publish.ts'
 import {
 	type RepoGitCommand,
 	type RepoRunCommandsResult,
@@ -446,6 +446,27 @@ class RepoSessionBase extends DurableObject<Env> {
 		return [...new Uint8Array(digest)]
 			.map((byte) => byte.toString(16).padStart(2, '0'))
 			.join('')
+	}
+
+	private async isAncestorCommit(input: {
+		ancestor: string
+		descendant: string
+	}) {
+		if (input.ancestor === input.descendant) {
+			return true
+		}
+		const commits = await this.git.log({
+			dir: repoSessionWorkspacePrefix,
+			depth: 1000,
+		})
+		const commitIds = commits.map((commit) => commit.oid)
+		const descendantIndex = commitIds.indexOf(input.descendant)
+		const ancestorIndex = commitIds.indexOf(input.ancestor)
+		return (
+			descendantIndex >= 0 &&
+			ancestorIndex >= 0 &&
+			ancestorIndex >= descendantIndex
+		)
 	}
 
 	private async writeCheckStatus(status: RepoSessionCheckStatus) {
@@ -1367,69 +1388,14 @@ class RepoSessionBase extends DurableObject<Env> {
 			source.manifest_path,
 			source.entity_kind,
 		)
-		// Persist the workspace snapshot to BUNDLE_ARTIFACTS_KV so downstream
-		// readers like loadPublishedEntitySource can resolve the freshly
-		// published commit without round-tripping to Artifacts. Without this,
-		// refreshSavedPackageProjection below, as well as every package-backed
-		// job run that reaches for the published snapshot, would throw
-		// "Published snapshot for source ... was not found" because no writer
-		// had stored the snapshot under the new commit.
-		//
-		// Collect the workspace files BEFORE advancing D1 so a failure to
-		// materialize the tree never leaves entity_sources.published_commit
-		// pointing at a commit whose snapshot we never wrote.
-		const shouldPersistSnapshot =
-			sessionHeadCommit != null && hasPublishedRuntimeArtifacts(this.env)
-		const snapshotFiles = shouldPersistSnapshot
-			? await this.collectWorkspaceFiles()
-			: null
-		await updateEntitySource(this.env.APP_DB, {
-			id: source.id,
-			userId: source.user_id,
-			publishedCommit: sessionHeadCommit,
-			manifestPath: source.manifest_path,
-			sourceRoot: source.source_root,
+		const snapshotFiles = await this.collectWorkspaceFiles()
+		await finalizePublishedEntitySource({
+			env: this.env,
+			source,
+			publishedCommit: sessionHeadCommit ?? sessionRow.base_commit,
+			files: snapshotFiles,
+			baseUrl: source.source_root,
 		})
-		if (shouldPersistSnapshot && snapshotFiles != null && sessionHeadCommit) {
-			try {
-				await writePublishedSourceSnapshot({
-					env: this.env,
-					source: {
-						...source,
-						published_commit: sessionHeadCommit,
-					},
-					files: snapshotFiles,
-				})
-			} catch (snapshotError) {
-				// Preserve the original KV failure as the thrown error even if
-				// the compensating D1 revert also fails; surfacing the revert
-				// error would mask the real root cause and make the orphaned
-				// D1 row harder to diagnose.
-				try {
-					await updateEntitySource(this.env.APP_DB, {
-						id: source.id,
-						userId: source.user_id,
-						publishedCommit: source.published_commit,
-						manifestPath: source.manifest_path,
-						sourceRoot: source.source_root,
-					})
-				} catch (revertError) {
-					Sentry.captureException(revertError, {
-						tags: {
-							scope:
-								'repo-session.publishSession.revert-after-snapshot-failure',
-						},
-						extra: {
-							sessionId: input.sessionId,
-							sourceId: source.id,
-							previousPublishedCommit: source.published_commit,
-							attemptedPublishedCommit: sessionHeadCommit,
-						},
-					})
-				}
-				throw snapshotError
-			}
-		}
 		await updateRepoSession(this.env.APP_DB, {
 			id: sessionRow.id,
 			userId: sessionRow.user_id,
@@ -1438,21 +1404,77 @@ class RepoSessionBase extends DurableObject<Env> {
 			lastCheckpointCommit: sessionHeadCommit,
 			lastCheckpointAt: nowIso(),
 		})
-		if (source.entity_kind === 'package') {
-			await refreshSavedPackageProjection({
-				env: this.env,
-				baseUrl: source.source_root,
-				userId: source.user_id,
-				packageId: source.entity_id,
-				sourceId: source.id,
-			})
-		}
 		return {
 			status: 'ok',
 			sessionId: sessionRow.id,
 			publishedCommit: sessionHeadCommit ?? sessionRow.base_commit,
 			message: `Published session ${sessionRow.id} to ${source.repo_id}.`,
 		}
+	}
+
+	async publishFromExternalRef(input: {
+		sessionId: string
+		sourceId: string
+		userId: string
+		newCommit: string
+		expectedHead?: string | null
+		allowForce?: boolean
+		baseUrl?: string
+	}): Promise<RepoExternalPublishResult> {
+		const source = await getEntitySourceById(this.env.APP_DB, input.sourceId)
+		if (!source || source.user_id !== input.userId) {
+			throw new Error('Repo source was not found for this user.')
+		}
+		const sourceRepo = await resolveArtifactSourceRepo(this.env, source.repo_id)
+		const sourceInfo = await sourceRepo.info()
+		const sourceAccess = await ensureArtifactRepoRemote({
+			repo: sourceRepo,
+			scope: 'read',
+		})
+		const targetBranch = sourceInfo?.defaultBranch ?? defaultSessionBranch
+		if (input.expectedHead && input.expectedHead !== input.newCommit) {
+			throw new Error(
+				`Artifacts HEAD changed from "${input.expectedHead}" to "${input.newCommit}" before publish.`,
+			)
+		}
+		await this.resetWorkspace()
+		await this.workspace.mkdir(repoSessionWorkspacePrefix, {
+			recursive: true,
+		})
+		await this.git.clone({
+			dir: repoSessionWorkspacePrefix,
+			branch: targetBranch,
+			singleBranch: true,
+			...buildGitCloneAuth({
+				remote: sourceAccess.remote,
+				token: sourceAccess.token,
+			}),
+		})
+		await this.git.checkout({
+			dir: repoSessionWorkspacePrefix,
+			ref: input.newCommit,
+			force: true,
+		})
+		const files = await this.collectWorkspaceFiles()
+		const isFastForward =
+			!source.published_commit ||
+			(await this.isAncestorCommit({
+				ancestor: source.published_commit,
+				descendant: input.newCommit,
+			}))
+		return publishExternalRefSource({
+			env: this.env,
+			sourceId: source.id,
+			userId: input.userId,
+			newCommit: input.newCommit,
+			isFastForward,
+			allowForce: input.allowForce,
+			workspace: this.workspace,
+			files,
+			baseUrl: input.baseUrl ?? source.source_root,
+			manifestPath: source.manifest_path,
+			sourceRoot: source.source_root,
+		})
 	}
 }
 

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -1460,18 +1460,16 @@ class RepoSessionBase extends DurableObject<Env> {
 			force: true,
 		})
 		const files = await this.collectWorkspaceFiles()
-		const isFastForward =
-			!source.published_commit ||
-			(await this.isAncestorCommit({
-				ancestor: source.published_commit,
-				descendant: input.newCommit,
-			}))
 		return publishExternalRefSource({
 			env: this.env,
 			sourceId: source.id,
 			userId: input.userId,
 			newCommit: input.newCommit,
-			isFastForward,
+			isFastForward: async ({ previousCommit }) =>
+				await this.isAncestorCommit({
+					ancestor: previousCommit,
+					descendant: input.newCommit,
+				}),
 			allowForce: input.allowForce,
 			workspace: this.workspace,
 			files,

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -7,6 +7,7 @@ import {
 } from '@cloudflare/shell'
 import { applyPatch, formatPatch, parsePatch } from 'diff'
 import { createGit } from '@cloudflare/shell/git'
+import * as git from 'isomorphic-git'
 import {
 	deleteRepoSession,
 	getRepoSessionById,
@@ -456,18 +457,15 @@ class RepoSessionBase extends DurableObject<Env> {
 		if (input.ancestor === input.descendant) {
 			return true
 		}
-		const commits = await this.git.log({
+		return git.isDescendent({
+			fs: this.fileSystem as unknown as Parameters<
+				typeof git.isDescendent
+			>[0]['fs'],
 			dir: repoSessionWorkspacePrefix,
-			depth: 1000,
+			oid: input.descendant,
+			ancestor: input.ancestor,
+			depth: -1,
 		})
-		const commitIds = commits.map((commit) => commit.oid)
-		const descendantIndex = commitIds.indexOf(input.descendant)
-		const ancestorIndex = commitIds.indexOf(input.ancestor)
-		return (
-			descendantIndex >= 0 &&
-			ancestorIndex >= 0 &&
-			ancestorIndex >= descendantIndex
-		)
 	}
 
 	private async writeCheckStatus(status: RepoSessionCheckStatus) {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -18,6 +18,7 @@ import {
 	type ArtifactRepoInfo,
 	buildArtifactsGitAuth,
 	buildAuthenticatedArtifactsRemote,
+	resolveArtifactDefaultBranchHead,
 	resolveArtifactSourceRepo,
 	resolveSessionRepo,
 } from './artifacts.ts'
@@ -1432,10 +1433,15 @@ class RepoSessionBase extends DurableObject<Env> {
 			scope: 'read',
 		})
 		const targetBranch = sourceInfo?.defaultBranch ?? defaultSessionBranch
-		if (input.expectedHead && input.expectedHead !== input.newCommit) {
-			throw new Error(
-				`Artifacts HEAD changed from "${input.expectedHead}" to "${input.newCommit}" before publish.`,
-			)
+		if (input.expectedHead) {
+			const currentHead = await resolveArtifactDefaultBranchHead({
+				repo: sourceRepo,
+			})
+			if (currentHead?.commit !== input.expectedHead) {
+				throw new Error(
+					`Artifacts HEAD changed from "${input.expectedHead}" to "${currentHead?.commit ?? 'unknown'}" before publish.`,
+				)
+			}
 		}
 		await this.resetWorkspace()
 		await this.workspace.mkdir(repoSessionWorkspacePrefix, {
@@ -1472,8 +1478,14 @@ class RepoSessionBase extends DurableObject<Env> {
 			workspace: this.workspace,
 			files,
 			baseUrl: input.baseUrl ?? source.source_root,
-			manifestPath: source.manifest_path,
-			sourceRoot: source.source_root,
+			manifestPath: resolveRepoWorkspacePath(
+				source.manifest_path,
+				repoSessionWorkspacePrefix,
+			),
+			sourceRoot: resolveRepoWorkspacePath(
+				source.source_root || repoSessionWorkspacePrefix,
+				repoSessionWorkspacePrefix,
+			),
 		})
 	}
 }

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -9,6 +9,7 @@ import {
 	type RepoSessionCheckStatus,
 	type RepoSessionDiscardResult,
 	type RepoSessionEdit,
+	type RepoExternalPublishResult,
 	type RepoSessionInfoResult,
 	type RepoSessionPublishResult,
 	type RepoSessionRebaseResult,
@@ -103,6 +104,15 @@ export type RepoSessionRpc = {
 		userId: string
 		force?: boolean
 	}) => Promise<RepoSessionPublishResult>
+	publishFromExternalRef: (payload: {
+		sessionId: string
+		sourceId: string
+		userId: string
+		newCommit: string
+		expectedHead?: string | null
+		allowForce?: boolean
+		baseUrl?: string
+	}) => Promise<RepoExternalPublishResult>
 }
 
 export function repoSessionRpc(env: Env, sessionId: string): RepoSessionRpc {

--- a/packages/worker/src/repo/source-service.ts
+++ b/packages/worker/src/repo/source-service.ts
@@ -46,6 +46,7 @@ function buildEntitySourceRow(input: {
 			input.manifestPath ??
 			(input.entityKind === 'package' ? 'package.json' : 'kody.json'),
 		source_root: input.sourceRoot ?? '/',
+		last_external_check_at: null,
 		created_at: now,
 		updated_at: now,
 	}

--- a/packages/worker/src/repo/types.ts
+++ b/packages/worker/src/repo/types.ts
@@ -14,6 +14,7 @@ export const entitySourceRowSchema = z.object({
 	indexed_commit: z.string().nullable(),
 	manifest_path: z.string(),
 	source_root: z.string(),
+	last_external_check_at: z.string().nullable(),
 	created_at: z.string(),
 	updated_at: z.string(),
 })
@@ -332,6 +333,31 @@ export type RepoSessionPublishResult =
 			sessionBaseCommit: string
 			currentPublishedCommit: string | null
 			repairHint: 'repo_rebase_session'
+	  }
+
+export type RepoExternalPublishResult =
+	| {
+			status: 'already_published'
+			published_commit: string | null
+	  }
+	| {
+			status: 'not_fast_forward'
+			previous_commit: string
+			published_commit: string
+			message: string
+	  }
+	| {
+			status: 'checks_failed'
+			failed_checks: NonNullable<RepoSessionCheckStatus['results']>
+			manifest: AuthoredPackageJson
+			run_id: string
+	  }
+	| {
+			status: 'published'
+			previous_commit: string | null
+			published_commit: string
+			manifest: AuthoredPackageJson
+			checks: NonNullable<RepoSessionCheckStatus['results']>
 	  }
 
 export type RepoSourceBootstrapResult = {

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -59,6 +59,9 @@
 	"observability": {
 		"enabled": true,
 	},
+	"triggers": {
+		"crons": ["*/5 * * * *"],
+	},
 	"env": {
 		"production": {
 			"ai": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `package_get_git_remote` for short-lived Artifacts git credentials and `package_publish_external_push` for publishing pushed package HEADs
- extract shared external publish reconciliation with checks-before-mutation, D1/KV rollback semantics, and package projection refresh
- add scheduled Artifacts push reconciliation, stale token cleanup, D1 `last_external_check_at`, and user/contributor docs

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12f6e31e-ace2-416c-9150-58550c5150d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12f6e31e-ace2-416c-9150-58550c5150d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit saved packages via direct git‑push workflows with short‑lived repo tokens and an authenticated git-remote helper
  * Manual publish endpoint for pushed commits and an automatic reconciliation job that publishes detected external pushes

* **Documentation**
  * Expanded guides for repo-backed workflows, git-remote publishing, token scopes/TTL, and external-push reconciliation

* **Chores**
  * Added periodic reconciliation cron and daily stale-token revocation

* **Database**
  * Track last external check time for reconciliation

* **Tests**
  * Added coverage for reconcile, token, git-remote, and publish flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->