### PR TITLE
Limit Artifacts reconcile job to package sources

### DIFF
--- a/packages/worker/src/repo/entity-sources.ts
+++ b/packages/worker/src/repo/entity-sources.ts
@@ -175,7 +175,8 @@ export async function listEntitySourcesForExternalReconcile(
 	const { results } = await db
 		.prepare(
 			`SELECT * FROM entity_sources
-			WHERE last_external_check_at IS NULL OR last_external_check_at < ?
+			WHERE entity_kind = 'package'
+				AND (last_external_check_at IS NULL OR last_external_check_at < ?)
 			ORDER BY COALESCE(last_external_check_at, created_at) ASC
 			LIMIT ?`,
 		)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- limit external Artifacts push reconciliation to `entity_kind = 'package'` rows
- avoids scanning non-package source rows that cannot be published through the package external-push flow

## Validation
- `npm run typecheck`
- `npm run lint`
- `npx vitest run packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts --config vitest.node.config.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12f6e31e-ace2-416c-9150-58550c5150d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12f6e31e-ace2-416c-9150-58550c5150d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined external entity reconciliation process to scope checks specifically to package entities, ensuring more accurate and targeted reconciliation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->