### PR TITLE
Remove includeSchemas from search capability detail

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -50,7 +50,7 @@ structured result. Split into multiple **execute** calls only when you need new
 user input, confirmation, or a result that changes the plan.
 
 To read field shapes while coding, use **search** with
-**`entity: "{name}:capability"`** for builtin capability schemas, or inspect the
+**`entity: "{name}:capability"`** for builtin capability type definitions, or inspect the
 relevant saved package with **`entity: "{kody_id}:package"`**.
 
 ## Saved packages

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -26,9 +26,7 @@ small.
 To get **full markdown and call shapes for one hit** (for example a capability’s
 `inputTypeDefinition` / `outputTypeDefinition`), call **search** again with
 **`entity`** set to `"{id}:{type}"` where **`type`** is `capability`, `value`,
-`connector`, `package`, or `secret`. Capability detail omits raw JSON schemas by
-default; pass **`includeSchemas: true`** only when you explicitly need
-`inputSchema` / `outputSchema`.
+`connector`, `package`, or `secret`.
 
 Examples:
 

--- a/packages/worker/src/mcp/capabilities/capability-search.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.ts
@@ -1,4 +1,3 @@
-import { compressSchemaForLlm } from './schema-compression.ts'
 import { type CapabilitySpec } from './types.ts'
 
 type CapabilityVectorizeEnv = { CAPABILITY_VECTOR_INDEX?: VectorizeIndex }
@@ -125,8 +124,6 @@ export type CapabilityDetailRow = CapabilitySummaryRow & {
 	readOnly: boolean
 	idempotent: boolean
 	destructive: boolean
-	inputSchema?: unknown
-	outputSchema?: unknown
 	inputTypeDefinition: string
 	outputTypeDefinition?: string
 	inputFields?: Array<string>
@@ -152,19 +149,7 @@ function toSummary(spec: CapabilitySpec): CapabilitySummaryRow {
 	}
 }
 
-function toDetail(
-	spec: CapabilitySpec,
-	includeSchemas: boolean,
-): CapabilityDetailRow {
-	const inputSchema = includeSchemas
-		? compressSchemaForLlm(spec.inputSchema)
-		: undefined
-	const outputSchema =
-		includeSchemas && 'outputSchema' in spec && spec.outputSchema !== undefined
-			? compressSchemaForLlm(spec.outputSchema, {
-					stripRootObjectType: false,
-				})
-			: undefined
+function toDetail(spec: CapabilitySpec): CapabilityDetailRow {
 	const row: CapabilityDetailRow = {
 		...toSummary(spec),
 		description: spec.description,
@@ -172,8 +157,6 @@ function toDetail(
 		readOnly: spec.readOnly,
 		idempotent: spec.idempotent,
 		destructive: spec.destructive,
-		...(includeSchemas ? { inputSchema } : {}),
-		...(outputSchema ? { outputSchema } : {}),
 		inputTypeDefinition: spec.inputTypeDefinition,
 		...(spec.outputTypeDefinition
 			? { outputTypeDefinition: spec.outputTypeDefinition }
@@ -238,7 +221,6 @@ export async function searchCapabilities(input: {
 	query: string
 	limit: number
 	detail: boolean
-	includeSchemas?: boolean
 	specs: Record<string, CapabilitySpec>
 	/** When set (online only), Vectorize query uses this metadata filter first; falls back to unfiltered if no spec ids match. */
 	vectorMetadataFilter?: VectorizeVectorMetadataFilter
@@ -347,9 +329,7 @@ export async function searchCapabilities(input: {
 
 	const matches: Array<CapabilitySearchHit> = ordered.map((id) => {
 		const spec = specs[id]!
-		const base = input.detail
-			? toDetail(spec, input.includeSchemas === true)
-			: toSummary(spec)
+		const base = input.detail ? toDetail(spec) : toSummary(spec)
 		const rawVectorScore = vectorScoreById[id]
 		const vectorScore =
 			rawVectorScore !== undefined && Number.isFinite(rawVectorScore)

--- a/packages/worker/src/mcp/capabilities/capability-search.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.workers.test.ts
@@ -124,7 +124,7 @@ test('offline search returns provided specs without depending on global ranks', 
 	expect(matches[0]?.vectorRank).toBe(1)
 })
 
-test('detailed capability search includes schemas only when requested', async () => {
+test('detailed capability search returns type definitions without schema fields', async () => {
 	const specs = {
 		kody_official_guide: {
 			name: 'kody_official_guide',
@@ -160,27 +160,12 @@ test('detailed capability search includes schemas only when requested', async ()
 		detail: true,
 		specs,
 	})
-	const { matches } = await searchCapabilities({
-		env,
-		query: 'guide',
-		limit: 1,
-		detail: true,
-		includeSchemas: true,
-		specs,
-	})
 
 	expect(defaultDetail.matches[0]).not.toHaveProperty('inputSchema')
 	expect(defaultDetail.matches[0]).toMatchObject({
 		inputTypeDefinition: expect.stringContaining('KodyOfficialGuideInput'),
 	})
-	expect(matches[0]).toMatchObject({
-		inputSchema: expect.objectContaining({
-			properties: expect.objectContaining({
-				guide: expect.objectContaining({ type: 'string' }),
-			}),
-		}),
-		inputTypeDefinition: expect.stringContaining('KodyOfficialGuideInput'),
-	})
+	expect(defaultDetail.matches[0]).not.toHaveProperty('outputSchema')
 })
 
 test('online search semantically ranks runtime-only capabilities missing from Vectorize', async () => {

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
@@ -87,7 +87,7 @@ function buildHomeConnectorEnv() {
 	} as unknown as Env
 }
 
-test('meta_list_capabilities includes runtime home capabilities and adds schemas only when requested', async () => {
+test('meta_list_capabilities includes runtime home capabilities with type definitions only', async () => {
 	const env = buildHomeConnectorEnv()
 
 	const result = await metaListCapabilitiesCapability.handler(
@@ -129,39 +129,6 @@ test('meta_list_capabilities includes runtime home capabilities and adds schemas
 	expect(listAppsCapability).not.toHaveProperty('outputSchema')
 	expect(activeAppCapability).not.toBeUndefined()
 	expect(activeAppCapability?.domain).toBe('home')
-
-	const resultWithSchemas = await metaListCapabilitiesCapability.handler(
-		{
-			detail: true,
-			includeSchemas: true,
-		},
-		{
-			env,
-			callerContext: createMcpCallerContext({
-				baseUrl: 'https://heykody.dev',
-				homeConnectorId: 'default',
-			}),
-		},
-	)
-
-	const homeCapabilityWithSchemas = resultWithSchemas.capabilities.find(
-		(capability) => capability.name === 'home_roku_press_key',
-	)
-	const listAppsCapabilityWithSchemas = resultWithSchemas.capabilities.find(
-		(capability) => capability.name === 'home_roku_list_apps',
-	)
-	expect(homeCapabilityWithSchemas).toMatchObject({
-		inputSchema: expect.objectContaining({ type: 'object' }),
-	})
-	expect(homeCapabilityWithSchemas?.inputTypeDefinition).toBe(
-		homeCapability?.inputTypeDefinition,
-	)
-	expect(listAppsCapabilityWithSchemas).toMatchObject({
-		outputSchema: expect.objectContaining({ type: 'object' }),
-	})
-	expect(listAppsCapabilityWithSchemas?.outputTypeDefinition).toBe(
-		listAppsCapability?.outputTypeDefinition,
-	)
 })
 
 test('meta_list_capabilities filters by domain', async () => {

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.ts
@@ -88,16 +88,10 @@ export const metaListCapabilitiesCapability = defineDomainCapability(
 				.describe(
 					'Include TypeScript type definitions and full field lists when true. Defaults to false.',
 				),
-			includeSchemas: z
-				.boolean()
-				.optional()
-				.describe(
-					'Only used with detail: true. Include raw JSON schemas in addition to TypeScript type definitions. Defaults to false.',
-				),
 		}),
 		outputSchema,
 		async handler(
-			args: { domain?: string; detail?: boolean; includeSchemas?: boolean },
+			args: { domain?: string; detail?: boolean },
 			ctx: CapabilityContext,
 		) {
 			const { getCapabilityRegistryForContext } =
@@ -118,12 +112,6 @@ export const metaListCapabilitiesCapability = defineDomainCapability(
 								idempotent: spec.idempotent,
 								destructive: spec.destructive,
 								requiredInputFields: spec.requiredInputFields,
-								...(args.includeSchemas === true
-									? { inputSchema: spec.inputSchema }
-									: {}),
-								...(args.includeSchemas === true && spec.outputSchema
-									? { outputSchema: spec.outputSchema }
-									: {}),
 								inputTypeDefinition: spec.inputTypeDefinition,
 								...(spec.outputTypeDefinition
 									? { outputTypeDefinition: spec.outputTypeDefinition }

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -45,7 +45,7 @@ What shows up in \`search\` (before you search)
 
 search
 - \`query\`: natural language; results are ranked (order matters). Optional \`limit\`, \`maxResponseSize\`.
-- \`entity: "{id}:{type}"\` (\`capability\` | \`package\` | \`value\` | \`connector\` | \`secret\`) for one entity’s detail (schemas, usage). If a \`query\` returns no useful hits, rephrase or call \`meta_list_capabilities\` — \`entity\` does not repair an empty ranked list.
+- \`entity: "{id}:{type}"\` (\`capability\` | \`package\` | \`value\` | \`connector\` | \`secret\`) for one entity’s detail (TypeScript call shapes, usage). If a \`query\` returns no useful hits, rephrase or call \`meta_list_capabilities\` — \`entity\` does not repair an empty ranked list.
 - Examples:
   - search({ query: 'saved package for github automation' })
   - search({ query: 'Cloudflare API zones dns workers d1' })

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -33,8 +33,8 @@ const executeTool = {
 	title: 'Execute Capabilities',
 	description: `
 Run one ephemeral ESM module string with a default export. Discover capability
-names with \`search\`; for one capability’s \`inputSchema\` / \`outputSchema\`,
-call \`search\` with \`entity: "{name}:capability"\` or use
+names with \`search\`; for one capability’s TypeScript call shape, call
+\`search\` with \`entity: "{name}:capability"\` or use
 \`meta_list_capabilities\`.
 
 Saved package surface:

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -144,7 +144,7 @@ test('entity detail formatting returns stable structured details for values and 
 	})
 })
 
-test('capability entity detail keeps type definitions stable and adds schemas only when requested', () => {
+test('capability entity detail keeps type definitions stable without schema fields', () => {
 	const detail = formatEntityDetailMarkdown({
 		type: 'capability',
 		id: 'github_create_issue',
@@ -196,60 +196,6 @@ test('capability entity detail keeps type definitions stable and adds schemas on
 				'type GithubCreateIssueOutput = {\n\tissueUrl: string\n}',
 		},
 	})
-	const detailWithSchemas = formatEntityDetailMarkdown(
-		{
-			type: 'capability',
-			id: 'github_create_issue',
-			title: 'github_create_issue',
-			description: 'Create a GitHub issue.',
-			spec: {
-				name: 'github_create_issue',
-				domain: 'coding',
-				description: 'Create a GitHub issue.',
-				keywords: ['github', 'issue'],
-				readOnly: false,
-				idempotent: false,
-				destructive: false,
-				inputFields: ['owner', 'repo', 'title'],
-				requiredInputFields: ['owner', 'repo', 'title'],
-				outputFields: ['issueUrl'],
-				inputSchema: {
-					type: 'object',
-					properties: {
-						owner: {
-							type: 'string',
-							description: 'Repository owner.',
-						},
-						repo: {
-							type: 'string',
-							description: 'Repository name.',
-						},
-						title: {
-							type: 'string',
-							description: 'Issue title.',
-						},
-						body: {
-							type: 'string',
-							description: 'Optional issue body.',
-						},
-					},
-					required: ['owner', 'repo', 'title'],
-				},
-				outputSchema: {
-					type: 'object',
-					properties: {
-						issueUrl: { type: 'string' },
-					},
-					required: ['issueUrl'],
-				},
-				inputTypeDefinition:
-					'type GithubCreateIssueInput = {\n\t/** Repository owner. */\n\towner: string\n\t/** Repository name. */\n\trepo: string\n\t/** Issue title. */\n\ttitle: string\n\t/** Optional issue body. */\n\tbody?: string\n}',
-				outputTypeDefinition:
-					'type GithubCreateIssueOutput = {\n\tissueUrl: string\n}',
-			},
-		},
-		{ includeSchemas: true },
-	)
 
 	expect(detail.structured).toMatchObject({
 		type: 'capability',
@@ -258,20 +204,6 @@ test('capability entity detail keeps type definitions stable and adds schemas on
 	})
 	expect(detail.structured).not.toHaveProperty('inputSchema')
 	expect(detail.structured).not.toHaveProperty('outputSchema')
-
-	expect(detailWithSchemas.structured).toMatchObject({
-		type: 'capability',
-		inputSchema: expect.objectContaining({
-			properties: expect.objectContaining({
-				owner: expect.objectContaining({ type: 'string' }),
-			}),
-		}),
-		outputSchema: expect.objectContaining({ type: 'object' }),
-	})
-	expect(detailWithSchemas.structured).toMatchObject({
-		inputTypeDefinition: detail.structured.inputTypeDefinition,
-		outputTypeDefinition: detail.structured.outputTypeDefinition,
-	})
 })
 
 test('repo_run_commands capability detail keeps the structured capability contract', () => {
@@ -281,16 +213,13 @@ test('repo_run_commands capability detail keeps the structured capability contra
 		throw new Error('Expected repo_run_commands capability to exist')
 	}
 
-	const detail = formatEntityDetailMarkdown(
-		{
-			type: 'capability',
-			id: 'repo_run_commands',
-			title: 'repo_run_commands',
-			description: repoRunCommands.description,
-			spec: repoRunCommands,
-		},
-		{ includeSchemas: true },
-	)
+	const detail = formatEntityDetailMarkdown({
+		type: 'capability',
+		id: 'repo_run_commands',
+		title: 'repo_run_commands',
+		description: repoRunCommands.description,
+		spec: repoRunCommands,
+	})
 
 	expect(detail.structured).toMatchObject({
 		kind: 'entity',
@@ -306,27 +235,8 @@ test('repo_run_commands capability detail keeps the structured capability contra
 		destructive: expect.any(Boolean),
 		inputTypeDefinition: expect.any(String),
 	})
-	expect(detail.structured).toMatchObject({
-		inputSchema: expect.objectContaining({
-			properties: expect.objectContaining({
-				commands: expect.objectContaining({
-					type: 'string',
-				}),
-			}),
-		}),
-	})
-	expect(detail.structured).toMatchObject({
-		outputSchema: expect.objectContaining({
-			type: 'object',
-			properties: expect.objectContaining({
-				session: expect.any(Object),
-				resolved_target: expect.any(Object),
-				commands: expect.any(Object),
-				checks: expect.any(Object),
-				publish: expect.any(Object),
-			}),
-		}),
-	})
+	expect(detail.structured).not.toHaveProperty('inputSchema')
+	expect(detail.structured).not.toHaveProperty('outputSchema')
 })
 
 test('entity detail formatting includes package app, export, and job metadata', () => {

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -1,4 +1,3 @@
-import { compressSchemaForLlm } from '#mcp/capabilities/schema-compression.ts'
 import { type CapabilitySpec } from '#mcp/capabilities/types.ts'
 import { type ConnectorConfig } from '#mcp/capabilities/values/connector-shared.ts'
 import { type SecretSearchRow } from '#mcp/secrets/types.ts'
@@ -181,8 +180,6 @@ export type SearchEntityDetailStructured =
 			readOnly: boolean
 			idempotent: boolean
 			destructive: boolean
-			inputSchema?: unknown
-			outputSchema?: unknown
 			inputTypeDefinition: string
 			outputTypeDefinition?: string
 	  }
@@ -733,10 +730,7 @@ export function toSlimStructuredMatches(input: {
 	})
 }
 
-export function formatEntityDetailMarkdown(
-	detail: SearchEntityDetail,
-	options?: { includeSchemas?: boolean },
-) {
+export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 	if (detail.type === 'capability') {
 		const lines = [
 			`# Capability — \`${detail.spec.name}\``,
@@ -761,32 +755,6 @@ export function formatEntityDetailMarkdown(
 				: []),
 			'```',
 		]
-		const includeSchemas = options?.includeSchemas === true
-		const inputSchema = includeSchemas
-			? compressSchemaForLlm(detail.spec.inputSchema)
-			: undefined
-		const outputSchema =
-			includeSchemas && detail.spec.outputSchema != null
-				? compressSchemaForLlm(detail.spec.outputSchema, {
-						stripRootObjectType: false,
-					})
-				: undefined
-		if (includeSchemas) {
-			lines.push(
-				'',
-				'## Input schema',
-				'',
-				`- \`${JSON.stringify(inputSchema)}\``,
-			)
-		}
-		if (outputSchema !== undefined) {
-			lines.push(
-				'',
-				'## Output schema',
-				'',
-				`- \`${JSON.stringify(outputSchema)}\``,
-			)
-		}
 		return {
 			markdown: lines.join('\n'),
 			structured: {
@@ -801,8 +769,6 @@ export function formatEntityDetailMarkdown(
 				readOnly: detail.spec.readOnly,
 				idempotent: detail.spec.idempotent,
 				destructive: detail.spec.destructive,
-				...(includeSchemas ? { inputSchema } : {}),
-				...(outputSchema !== undefined ? { outputSchema } : {}),
 				inputTypeDefinition: detail.spec.inputTypeDefinition,
 				...(detail.spec.outputTypeDefinition
 					? { outputTypeDefinition: detail.spec.outputTypeDefinition }

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -289,7 +289,7 @@ function buildRecommendedNextStep(
 		return `Inspect connector detail with \`search({ entity: "${topMatch.connectorName}:connector" })\` and then run a minimal authenticated \`execute\` smoke test before building or calling integration-backed code.`
 	}
 	if (topMatch?.type === 'capability') {
-		return `Inspect capability detail with \`search({ entity: "${topMatch.name}:capability" })\` to confirm the TypeScript call shape, then call it from \`execute\` via \`codemode.${topMatch.name}(args)\`. Add \`includeSchemas: true\` only if you explicitly need raw JSON Schema.`
+		return `Inspect capability detail with \`search({ entity: "${topMatch.name}:capability" })\` to confirm the TypeScript call shape, then call it from \`execute\` via \`codemode.${topMatch.name}(args)\`.`
 	}
 	return undefined
 }
@@ -1159,9 +1159,6 @@ If results look incomplete: \`meta_list_capabilities\` (full registry) or
 \`meta_list_remote_connector_status\` / \`meta_get_home_connector_status\` (remote connectors).
 
 Optional **limit** (default 15) and **maxResponseSize** trim low-ranked results.
-Set **includeSchemas: true** on entity detail only when you explicitly need the
-underlying JSON Schema.
-
 Example arguments:
 - \`{ "query": "saved github automation package", "limit": 10 }\`
 - \`{ "query": "preferred org value or saved connector", "limit": 10 }\`
@@ -1505,12 +1502,6 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					.describe(
 						'Max response size in characters before trimming low-ranked results. Defaults to 4000.',
 					),
-				includeSchemas: z
-					.boolean()
-					.optional()
-					.describe(
-						'Only for entity detail: include raw JSON schemas in addition to TypeScript type definitions. Defaults to false.',
-					),
 				conversationId: conversationIdInputField,
 				memoryContext: memoryContextInputField,
 			},
@@ -1521,7 +1512,6 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 			entity?: string
 			limit?: number
 			maxResponseSize?: number
-			includeSchemas?: boolean
 			conversationId?: string
 			memoryContext?: z.infer<typeof memoryContextInputField>
 		}) => {
@@ -1668,9 +1658,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 				)
 
 				if (outcome.mode === 'entity') {
-					const entityResult = formatEntityDetailMarkdown(outcome.detail, {
-						includeSchemas: args.includeSchemas === true,
-					})
+					const entityResult = formatEntityDetailMarkdown(outcome.detail)
 					const timing = finishToolTiming(timingStart)
 					logMcpEvent({
 						category: 'mcp',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove `includeSchemas` from the public search tool, capability-detail formatter, and registry listing capability
- keep capability detail focused on TypeScript type definitions and remove schema-specific guidance/examples
- update tests and user docs to match the simplified contract

## Checks
- `npm run test -- --run packages/worker/src/mcp/tools/search-format.node.test.ts packages/worker/src/mcp/capabilities/capability-search.workers.test.ts packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts`
- `npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd162225-2cdd-4a45-9afd-21fa97227800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd162225-2cdd-4a45-9afd-21fa97227800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

