### PR TITLE
Include saved package README content in search responses

### DIFF
--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -216,5 +216,10 @@ short for autonomous agents and CI-style helpers; the tool accepts 60 seconds to
 
 Search returns packages as the saved-entity unit.
 
-Package detail includes nested exports, nested jobs, tags, and app presence.
+Ranked package search hits may include a concise README excerpt when the saved
+package has a root README so agents can learn usage, examples, and maintenance
+notes without separately cloning the package repository.
+
+Exact package detail includes nested exports, nested jobs, tags, app presence,
+and README content when a root README exists.
 Search should not frame exports or jobs as separate top-level saved entities.

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -61,6 +61,11 @@ behavior work without user-scoped data.
 
 Package search hits summarize whether the package has an app surface and, when
 they do, include a direct `open_generated_ui({ kody_id: "..." })` hint.
+When a saved package includes a root `README` file, ranked search hits include a
+short README excerpt so agents can quickly see usage notes, examples, or
+maintenance caveats without separately inspecting the package repo. Exact
+package detail (`entity: "my-package:package"`) includes the README content, or
+a substantial leading section when the README is long.
 Connector hits also include operational details such as the token URL, API base
 URL, required hosts, and related stored value/secret names so common
 setup/debugging work can often proceed without an immediate detail lookup.

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -378,6 +378,15 @@ test('entity detail formatting includes package app, export, and job metadata', 
 		},
 		files: {
 			'package.json': '{}',
+			'README.md': `# Observed package
+
+Use this package to inspect observed UI state.
+
+## Usage
+
+- Open the app for quick checks.
+- Import the root entry for scripted flows.
+`,
 			'src/app.d.ts': `/**
  * Render the observed app.
  */
@@ -420,7 +429,14 @@ export declare function fetch(request: Request): Promise<Response>
 				scheduleSummary: 'Runs every 1d',
 			}),
 		],
+		readme: {
+			path: 'README.md',
+			content: expect.stringContaining('## Usage'),
+			truncated: false,
+		},
 	})
+	expect(packageDetail.markdown).toContain('## README (`README.md`)')
+	expect(packageDetail.markdown).toContain('Use this package to inspect observed UI state.')
 })
 
 test('package search formatting keeps runnable package actions in structured output', () => {
@@ -436,6 +452,12 @@ test('package search formatting keeps runnable package actions in structured out
 				description: 'Saved package for Spotify playback controls.',
 				tags: ['spotify', 'playback'],
 				hasApp: true,
+				readmeSnippet: {
+					path: 'README.md',
+					snippet:
+						'Playback controls, queue helpers, and maintenance notes for the hosted remote.',
+					truncated: false,
+				},
 			},
 		],
 	})
@@ -454,8 +476,43 @@ test('package search formatting keeps runnable package actions in structured out
 		tags: ['spotify', 'playback'],
 		hasApp: true,
 		hostedUrl: 'http://localhost/packages/spotify-playback',
+		readmeSnippet: {
+			path: 'README.md',
+			snippet:
+				'Playback controls, queue helpers, and maintenance notes for the hosted remote.',
+			truncated: false,
+		},
 	})
 	expect(packageMatch?.nextStep).toEqual(expect.any(String))
+})
+
+test('search markdown includes concise package README snippets when available', () => {
+	const markdown = formatSearchMarkdown({
+		baseUrl: 'http://localhost',
+		warnings: [],
+		matches: [
+			{
+				type: 'package',
+				packageId: 'package-123',
+				kodyId: 'observed-package',
+				name: '@kody/observed-package',
+				title: '@kody/observed-package',
+				description: 'Observed package with an app surface.',
+				tags: ['observed'],
+				hasApp: false,
+				readmeSnippet: {
+					path: 'README.md',
+					snippet:
+						'Includes setup instructions, export examples, and maintenance notes.',
+					truncated: true,
+				},
+			},
+		],
+	})
+
+	expect(markdown).toContain(
+		'**README (README.md):** Includes setup instructions, export examples, and maintenance notes\\. _(truncated)_',
+	)
 })
 
 test('search formatting surfaces package retriever results', () => {

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -3,6 +3,7 @@ import { type CapabilitySpec } from '#mcp/capabilities/types.ts'
 import { type ConnectorConfig } from '#mcp/capabilities/values/connector-shared.ts'
 import { type SecretSearchRow } from '#mcp/secrets/types.ts'
 import { type ValueMetadata } from '#mcp/values/types.ts'
+import { buildPackageReadmeDetail } from '#worker/package-registry/package-readme.ts'
 import {
 	type AuthoredPackageJson,
 	type PackageJobSchedule,
@@ -114,6 +115,11 @@ export type SlimSearchMatch =
 			tags: Array<string>
 			hasApp: boolean
 			hostedUrl: string | null
+			readmeSnippet: {
+				path: string
+				snippet: string
+				truncated: boolean
+			} | null
 			nextStep?: string
 	  }
 	| {
@@ -230,6 +236,11 @@ export type SearchEntityDetailStructured =
 				timeoutMs: number | null
 				maxResults: number | null
 			}>
+			readme: {
+				path: string
+				content: string
+				truncated: boolean
+			} | null
 	  }
 	| {
 			kind: 'entity'
@@ -330,6 +341,11 @@ export type SearchMatch =
 			description: string
 			tags: Array<string>
 			hasApp: boolean
+			readmeSnippet?: {
+				path: string
+				snippet: string
+				truncated: boolean
+			} | null
 	  }
 	| {
 			type: 'value'
@@ -572,6 +588,11 @@ function formatMatchBlock(match: SearchMatch, baseUrl: string) {
 			`**Tags:** ${match.tags.length > 0 ? match.tags.map((tag) => `\`${tag}\``).join(', ') : 'none'}`,
 			`**Has app:** ${match.hasApp ? 'yes' : 'no'}`,
 			...(hostedUrl ? [`**Hosted URL:** \`${hostedUrl}\``] : []),
+			...(match.readmeSnippet
+				? [
+						`**README (${match.readmeSnippet.path}):** ${escapeMarkdownText(match.readmeSnippet.snippet)}${match.readmeSnippet.truncated ? ' _(truncated)_' : ''}`,
+					]
+				: []),
 		]
 	}
 	if (match.type === 'value') {
@@ -669,6 +690,13 @@ export function toSlimStructuredMatches(input: {
 				hasApp: match.hasApp,
 				hostedUrl: match.hasApp
 					? buildPackageHostedUrl(input.baseUrl, match.kodyId)
+					: null,
+				readmeSnippet: match.readmeSnippet
+					? {
+							path: match.readmeSnippet.path,
+							snippet: match.readmeSnippet.snippet,
+							truncated: match.readmeSnippet.truncated,
+						}
 					: null,
 				nextStep,
 			}
@@ -847,6 +875,9 @@ export function formatEntityDetailMarkdown(
 			maxResults: retriever.maxResults ?? null,
 		}))
 		const appEntry = detail.manifest.kody.app?.entry ?? null
+		const readme = buildPackageReadmeDetail({
+			files: detail.files,
+		})
 		const lines = [
 			`# Package — \`${detail.record.kodyId}\``,
 			'',
@@ -914,6 +945,17 @@ export function formatEntityDetailMarkdown(
 				)
 			}
 		}
+		if (readme) {
+			lines.push(
+				'',
+				`## README (\`${readme.path}\`)`,
+				'',
+				readme.content,
+				...(readme.truncated
+					? ['', '> README content was truncated for this detail response.']
+					: []),
+			)
+		}
 		return {
 			markdown: lines.join('\n'),
 			structured: {
@@ -936,6 +978,7 @@ export function formatEntityDetailMarkdown(
 				exports: exportDetails,
 				jobs,
 				retrievers,
+				readme,
 			} satisfies SearchEntityDetailStructured,
 		}
 	}

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -3,6 +3,7 @@ import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-regi
 import { buildConnectorValueName } from '#mcp/capabilities/values/connector-shared.ts'
 import {
 	buildSavedPackageSearchRows,
+	enrichSearchMatchesWithPackageReadmes,
 	loadDownHomeConnectorStatus,
 	loadOptionalSearchRows,
 	resolveSearchMemoryContext,
@@ -27,6 +28,10 @@ const sourceMocks = vi.hoisted(() => ({
 	loadPackageSourceBySourceId: vi.fn(),
 }))
 
+const packageRepoMocks = vi.hoisted(() => ({
+	getSavedPackageByKodyId: vi.fn(),
+}))
+
 vi.mock('#worker/package-registry/source.ts', async () => {
 	const actual = await vi.importActual<
 		typeof import('#worker/package-registry/source.ts')
@@ -37,6 +42,17 @@ vi.mock('#worker/package-registry/source.ts', async () => {
 			sourceMocks.loadPackageManifestBySourceId(...args),
 		loadPackageSourceBySourceId: (...args: Array<unknown>) =>
 			sourceMocks.loadPackageSourceBySourceId(...args),
+	}
+})
+
+vi.mock('#worker/package-registry/repo.ts', async () => {
+	const actual = await vi.importActual<
+		typeof import('#worker/package-registry/repo.ts')
+	>('#worker/package-registry/repo.ts')
+	return {
+		...actual,
+		getSavedPackageByKodyId: (...args: Array<unknown>) =>
+			packageRepoMocks.getSavedPackageByKodyId(...args),
 	}
 })
 
@@ -177,6 +193,73 @@ test('searchUnified ranks mixed search rows through one shared pipeline', async 
 				name: 'alpha-secret',
 			}),
 		]),
+	)
+})
+
+test('package README enrichment adds snippets onto ranked package matches', async () => {
+	packageRepoMocks.getSavedPackageByKodyId.mockResolvedValue({
+		id: 'package-spotify',
+		userId: 'user-1',
+		name: '@kody/spotify-playback',
+		kodyId: 'spotify-playback',
+		description: 'Saved package for Spotify playback controls.',
+		tags: ['spotify', 'playback'],
+		searchText: 'spotify playback remote package',
+		sourceId: 'source-spotify',
+		hasApp: true,
+		createdAt: '2026-04-20T00:00:00.000Z',
+		updatedAt: '2026-04-20T00:00:00.000Z',
+	})
+	sourceMocks.loadPackageSourceBySourceId.mockResolvedValue({
+		manifest: {} as never,
+		source: {} as never,
+		files: {
+			'README.md': `# Spotify playback
+
+Playback controls, queue helpers, and maintenance notes for the hosted remote.
+`,
+			'package.json': '{}',
+		},
+	})
+
+	const matches = await enrichSearchMatchesWithPackageReadmes({
+		env: {
+			APP_DB: {},
+		} as Env,
+		baseUrl: 'http://localhost',
+		userId: 'user-1',
+		matches: [
+			{
+				type: 'package',
+				packageId: 'package-spotify',
+				kodyId: 'spotify-playback',
+				name: '@kody/spotify-playback',
+				title: '@kody/spotify-playback',
+				description: 'Saved package for Spotify playback controls.',
+				tags: ['spotify', 'playback'],
+				hasApp: true,
+			},
+		],
+	})
+
+	expect(matches).toEqual([
+		expect.objectContaining({
+			type: 'package',
+			kodyId: 'spotify-playback',
+			readmeSnippet: {
+				path: 'README.md',
+				snippet:
+					'Playback controls, queue helpers, and maintenance notes for the hosted remote.',
+				truncated: false,
+			},
+		}),
+	])
+	expect(sourceMocks.loadPackageSourceBySourceId).toHaveBeenCalledWith(
+		expect.objectContaining({
+			baseUrl: 'http://localhost',
+			userId: 'user-1',
+			sourceId: 'source-spotify',
+		}),
 	)
 })
 

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -35,6 +35,7 @@ import {
 	buildPackageSearchProjection,
 	type PackageSearchProjection,
 } from '#worker/package-registry/manifest.ts'
+import { buildPackageReadmeSnippet } from '#worker/package-registry/package-readme.ts'
 import {
 	loadPackageManifestBySourceId,
 	loadPackageSourceBySourceId,
@@ -1471,6 +1472,56 @@ async function resolveEntityDetail(input: {
 	}
 }
 
+export async function enrichSearchMatchesWithPackageReadmes(input: {
+	env: Env
+	baseUrl: string
+	userId: string | null
+	matches: Array<SearchMatch>
+}): Promise<Array<SearchMatch>> {
+	if (!input.userId) {
+		return input.matches
+	}
+	return await Promise.all(
+		input.matches.map(async (match) => {
+			if (match.type !== 'package') {
+				return match
+			}
+			try {
+				const record = await getSavedPackageByKodyId(input.env.APP_DB, {
+					userId: input.userId!,
+					kodyId: match.kodyId,
+				})
+				if (!record) {
+					return match
+				}
+				const loaded = await loadPackageSourceBySourceId({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					userId: input.userId!,
+					sourceId: record.sourceId,
+				})
+				return {
+					...match,
+					readmeSnippet: buildPackageReadmeSnippet({
+						files: loaded.files,
+					}),
+				} satisfies SearchMatch
+			} catch (cause) {
+				Sentry.captureException(cause, {
+					tags: {
+						scope: 'search.enrichPackageReadmeSnippet',
+					},
+					extra: {
+						kodyId: match.kodyId,
+						packageId: match.packageId,
+					},
+				})
+				return match
+			}
+		}),
+	)
+}
+
 export async function registerSearchTool(agent: McpRegistrationAgent) {
 	agent.server.registerTool(
 		searchTool.name,
@@ -1643,7 +1694,15 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 
 				return {
 					mode: 'list' as const,
-					result,
+					result: {
+						...result,
+						matches: await enrichSearchMatchesWithPackageReadmes({
+							env: agent.getEnv(),
+							baseUrl,
+							userId,
+							matches: result.matches,
+						}),
+					},
 				}
 			}
 

--- a/packages/worker/src/package-registry/package-readme.ts
+++ b/packages/worker/src/package-registry/package-readme.ts
@@ -1,0 +1,135 @@
+const rootReadmeFileNamePattern = /^readme(?:\.[a-z0-9._-]+)?$/i
+const preferredReadmeNames = [
+	'readme.md',
+	'readme.mdx',
+	'readme.markdown',
+	'readme.txt',
+	'readme',
+] as const
+
+export type PackageReadmeSnippet = {
+	path: string
+	snippet: string
+	truncated: boolean
+}
+
+export type PackageReadmeDetail = {
+	path: string
+	content: string
+	truncated: boolean
+}
+
+function normalizeReadmeContent(content: string) {
+	return content.replace(/\r\n/g, '\n').trim()
+}
+
+function stripLeadingTitleHeading(content: string) {
+	return content.replace(/^#\s+[^\n]+\n+/, '').trim()
+}
+
+function collapseWhitespace(value: string) {
+	return value.replace(/\s+/g, ' ').trim()
+}
+
+function toPlainTextSnippet(content: string) {
+	return collapseWhitespace(
+		content
+			.replace(/```[\s\S]*?```/g, ' ')
+			.replace(/`([^`]+)`/g, '$1')
+			.replace(/!\[[^\]]*]\([^)]*\)/g, ' ')
+			.replace(/\[([^\]]+)]\([^)]*\)/g, '$1')
+			.replace(/^>\s?/gm, '')
+			.replace(/^#{1,6}\s+/gm, '')
+			.replace(/^[-*+]\s+/gm, '')
+			.replace(/^\d+\.\s+/gm, ''),
+	)
+}
+
+function trimWithEllipsis(value: string, maxChars: number) {
+	if (value.length <= maxChars) {
+		return {
+			text: value,
+			truncated: false,
+		}
+	}
+	const trimmed = value.slice(0, Math.max(0, maxChars - 1)).trimEnd()
+	return {
+		text: `${trimmed}…`,
+		truncated: true,
+	}
+}
+
+function sortReadmeCandidates(paths: Array<string>) {
+	return [...paths].sort((left, right) => {
+		const normalizedLeft = left.toLowerCase()
+		const normalizedRight = right.toLowerCase()
+		const leftIndex = preferredReadmeNames.indexOf(
+			normalizedLeft as (typeof preferredReadmeNames)[number],
+		)
+		const rightIndex = preferredReadmeNames.indexOf(
+			normalizedRight as (typeof preferredReadmeNames)[number],
+		)
+		const leftRank = leftIndex === -1 ? preferredReadmeNames.length : leftIndex
+		const rightRank =
+			rightIndex === -1 ? preferredReadmeNames.length : rightIndex
+		if (leftRank !== rightRank) {
+			return leftRank - rightRank
+		}
+		return normalizedLeft.localeCompare(normalizedRight)
+	})
+}
+
+function findRootReadmeFile(files: Record<string, string>) {
+	const matches = Object.keys(files).filter(
+		(path) =>
+			!path.includes('/') && rootReadmeFileNamePattern.test(path.trim().toLowerCase()),
+	)
+	const [firstMatch] = sortReadmeCandidates(matches)
+	if (!firstMatch) {
+		return null
+	}
+	const content = normalizeReadmeContent(files[firstMatch] ?? '')
+	if (!content) {
+		return null
+	}
+	return {
+		path: firstMatch,
+		content,
+	}
+}
+
+export function buildPackageReadmeSnippet(input: {
+	files: Record<string, string>
+	maxChars?: number
+}): PackageReadmeSnippet | null {
+	const readme = findRootReadmeFile(input.files)
+	if (!readme) {
+		return null
+	}
+	const plainText = toPlainTextSnippet(stripLeadingTitleHeading(readme.content))
+	if (!plainText) {
+		return null
+	}
+	const trimmed = trimWithEllipsis(plainText, input.maxChars ?? 320)
+	return {
+		path: readme.path,
+		snippet: trimmed.text,
+		truncated: trimmed.truncated,
+	}
+}
+
+export function buildPackageReadmeDetail(input: {
+	files: Record<string, string>
+	maxChars?: number
+}): PackageReadmeDetail | null {
+	const readme = findRootReadmeFile(input.files)
+	if (!readme) {
+		return null
+	}
+	const trimmed = trimWithEllipsis(readme.content, input.maxChars ?? 6_000)
+	return {
+		path: readme.path,
+		content: trimmed.text,
+		truncated: trimmed.truncated,
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- include concise README snippets on saved package search hits when a root README exists
- include a bounded README section in exact `search({ entity: "<kody-id>:package" })` package detail responses
- document the behavior and add focused tests for formatter and search-package enrichment paths

## Validation
- `npm test -- packages/worker/src/mcp/tools/search-format.node.test.ts packages/worker/src/mcp/tools/search.node.test.ts`
- `npm run typecheck -- --pretty false`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c412fdfd-e90d-4558-8613-415789acd826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c412fdfd-e90d-4558-8613-415789acd826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

