### PR TITLE
Add guarded DHCP reservation writes

### DIFF
--- a/docs/contributing/architecture/home-connector.md
+++ b/docs/contributing/architecture/home-connector.md
@@ -142,8 +142,14 @@ The adapter exposes a small command substrate:
   `show running-config`, `show running-config differences`, `show ip dhcp`,
   `show ip routes`, and `show ip recommendations`
 - `router_run_write_operation` for the explicit guarded operations
-  `renew dhcp clients`, `clear log buffer`, and `save running config`, mapped to
-  `clear dhcp-client`, `clear log`, and `write memory`
+  `renew dhcp clients`, `clear log buffer`, `save running config`,
+  `reserve dhcp address`, and `remove dhcp reservation`, mapped to documented
+  Island CLI commands. DHCP reservation writes require typed `ipAddress` and
+  `macAddress` inputs, normalize the MAC address before command construction,
+  and enter global configuration context only for the allowlisted
+  `ip dhcp-reserve <ip> <mac>` / `no ip dhcp-reserve <ip> <mac>` commands.
+  Reservation writes do not automatically run `write memory`; callers can run
+  `save running config` separately when they want persistence.
 
 The adapter intentionally does not expose guessed aliases such as `show-ip-arp`,
 `show-ip-sessions`, or `show-log-recent`, nor unsupported public commands such
@@ -165,6 +171,13 @@ MCP surface requires:
 - typed operation inputs instead of free-form CLI
 - an operator reason and an exact acknowledgement phrase per operation
 - destructive tool annotations and warning-heavy descriptions
+
+DHCP reservation write operations are high risk because they can affect future
+address assignment and connectivity for a device. Kody validates IPv4 and 48-bit
+colon- or hyphen-separated MAC formatting before building the CLI command
+sequence. Island performs final semantic validation, including whether the
+reserved IPv4 address belongs to one of its interface networks. The address does
+not need to be inside an Island DHCP scope.
 
 SSH transport is conservative:
 

--- a/packages/home-connector/src/adapters/island-router/index.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/index.node.test.ts
@@ -222,6 +222,26 @@ function createFakeRunner() {
 					['write memory'],
 					'Running configuration saved.',
 				)
+			case 'reserve-dhcp-address':
+				return createResult(
+					request,
+					[
+						'configure terminal',
+						`ip dhcp-reserve ${request.ipAddress} ${request.macAddress}`,
+						'exit',
+					],
+					'DHCP reservation added.',
+				)
+			case 'remove-dhcp-reservation':
+				return createResult(
+					request,
+					[
+						'configure terminal',
+						`no ip dhcp-reserve ${request.ipAddress} ${request.macAddress}`,
+						'exit',
+					],
+					'DHCP reservation removed.',
+				)
 			default: {
 				const _exhaustive: never = request
 				throw new Error(
@@ -428,9 +448,18 @@ test('island router guarded write operations require verification and exact ackn
 		'renew dhcp clients',
 		'clear log buffer',
 		'save running config',
+		'reserve dhcp address',
+		'remove dhcp reservation',
 	] as const) {
 		const result = await islandRouter.runWriteOperation({
 			operation,
+			...(operation === 'reserve dhcp address' ||
+			operation === 'remove dhcp reservation'
+				? {
+						ipAddress: '192.168.0.77',
+						macAddress: '00-00-5E-00-53-7A',
+					}
+				: {}),
 			acknowledgeHighRisk: true,
 			reason,
 			confirmation: islandRouter.writeAcknowledgements.runWriteOperation,
@@ -440,7 +469,14 @@ test('island router guarded write operations require verification and exact ackn
 			riskLevel: 'high',
 			blastRadius: expect.any(String),
 		})
-		expect(result.commandLines).toContain(result.catalogEntry.command)
+		if (
+			operation === 'reserve dhcp address' ||
+			operation === 'remove dhcp reservation'
+		) {
+			expect(result.catalogEntry.command).toContain('dhcp-reserve <ip> <mac>')
+		} else {
+			expect(result.commandLines).toContain(result.catalogEntry.command)
+		}
 	}
 
 	createConfig()
@@ -486,6 +522,102 @@ test('island router guarded write operations require verification and exact ackn
 			confirmation: 'wrong',
 		}),
 	).rejects.toThrow('exact acknowledgement')
+})
+
+test('island router guarded DHCP reservation writes build normalized config commands', async () => {
+	using _env = withTemporaryEnv({})
+	const islandRouter = createIslandRouterAdapter({
+		config: createConfig(),
+		commandRunner: createFakeRunner(),
+	})
+	const reason =
+		'The operator verified this DHCP reservation change is needed for a planned device setup.'
+
+	const reserveResult = await islandRouter.runWriteOperation({
+		operation: 'reserve dhcp address',
+		ipAddress: '192.168.0.77',
+		macAddress: '00-00-5E-00-53-7A',
+		acknowledgeHighRisk: true,
+		reason,
+		confirmation: islandRouter.writeAcknowledgements.runWriteOperation,
+	})
+	expect(reserveResult).toMatchObject({
+		operationId: 'reserve-dhcp-address',
+		commandId: 'reserve-dhcp-address',
+	})
+	expect(reserveResult.commandLines).toEqual([
+		'terminal length 0',
+		'configure terminal',
+		'ip dhcp-reserve 192.168.0.77 00:00:5e:00:53:7a',
+		'exit',
+	])
+	expect(reserveResult.commandLines).not.toContain('write memory')
+
+	const removeResult = await islandRouter.runWriteOperation({
+		operation: 'remove dhcp reservation',
+		ipAddress: '192.168.0.77',
+		macAddress: '00:00:5E:00:53:7A',
+		acknowledgeHighRisk: true,
+		reason,
+		confirmation: islandRouter.writeAcknowledgements.runWriteOperation,
+	})
+	expect(removeResult).toMatchObject({
+		operationId: 'remove-dhcp-reservation',
+		commandId: 'remove-dhcp-reservation',
+	})
+	expect(removeResult.commandLines).toEqual([
+		'terminal length 0',
+		'configure terminal',
+		'no ip dhcp-reserve 192.168.0.77 00:00:5e:00:53:7a',
+		'exit',
+	])
+	expect(removeResult.commandLines).not.toContain('write memory')
+})
+
+test('island router guarded DHCP reservation writes reject malformed and injected tokens', async () => {
+	using _env = withTemporaryEnv({})
+	const islandRouter = createIslandRouterAdapter({
+		config: createConfig(),
+		commandRunner: createFakeRunner(),
+	})
+	const reason =
+		'The operator verified this DHCP reservation change is needed for a planned device setup.'
+	const safeRequest = {
+		operation: 'reserve dhcp address',
+		ipAddress: '192.168.0.77',
+		macAddress: '00:00:5E:00:53:7A',
+		acknowledgeHighRisk: true,
+		reason,
+		confirmation: islandRouter.writeAcknowledgements.runWriteOperation,
+	} as const
+
+	await expect(
+		islandRouter.runWriteOperation({
+			...safeRequest,
+			ipAddress: '999.168.0.77',
+		}),
+	).rejects.toThrow('ipAddress must be a valid IPv4 address')
+
+	await expect(
+		islandRouter.runWriteOperation({
+			...safeRequest,
+			macAddress: '00:00:5E:00:53',
+		}),
+	).rejects.toThrow('macAddress must be a valid 48-bit MAC address')
+
+	await expect(
+		islandRouter.runWriteOperation({
+			...safeRequest,
+			ipAddress: '192.168.0.77\nwrite memory',
+		}),
+	).rejects.toThrow('ipAddress must be a valid IPv4 address')
+
+	await expect(
+		islandRouter.runWriteOperation({
+			...safeRequest,
+			macAddress: '00:00:5E:00:53:7A; write memory',
+		}),
+	).rejects.toThrow('macAddress must be a valid 48-bit MAC address')
 })
 
 test('parsers handle documented Island command output shapes used by status and packages', () => {

--- a/packages/home-connector/src/adapters/island-router/index.ts
+++ b/packages/home-connector/src/adapters/island-router/index.ts
@@ -26,6 +26,8 @@ import {
 	assertIslandRouterConfigured,
 	assertIslandRouterWriteConfigured,
 	getIslandRouterConfigStatus,
+	validateIslandRouterIpv4Address,
+	validateIslandRouterMacAddress,
 } from './validation.ts'
 
 type WriteOperationRequest = {
@@ -43,16 +45,31 @@ type RunReadCommandRequest = {
 	timeoutMs?: number
 }
 
-type RunWriteOperationRequest = WriteOperationRequest & {
-	operation: IslandRouterWriteOperation
-}
+type RunWriteOperationRequest = WriteOperationRequest &
+	(
+		| {
+				operation: Exclude<
+					IslandRouterWriteOperation,
+					'reserve dhcp address' | 'remove dhcp reservation'
+				>
+		  }
+		| {
+				operation: 'reserve dhcp address' | 'remove dhcp reservation'
+				ipAddress: string
+				macAddress: string
+		  }
+	)
 
 const islandRouterWriteAcknowledgements = {
 	runWriteOperation:
 		'I am highly certain running this guarded Island router write operation is necessary right now.',
 } as const
 
-function normalizeLimit(value: number | undefined, fallback: number, max: number) {
+function normalizeLimit(
+	value: number | undefined,
+	fallback: number,
+	max: number,
+) {
 	if (value == null || !Number.isFinite(value)) return fallback
 	return Math.max(1, Math.min(max, Math.trunc(value)))
 }
@@ -220,8 +237,7 @@ async function runHighRiskCommand(input: {
 	)
 	return {
 		operationId: input.operationId,
-		commandId:
-			result.id as IslandRouterWriteOperationResult['commandId'],
+		commandId: result.id as IslandRouterWriteOperationResult['commandId'],
 		commandLines: result.commandLines,
 		stdout: result.stdout,
 		stderr: result.stderr,
@@ -471,6 +487,34 @@ export function createIslandRouterAdapter(input: {
 				case 'save running config':
 					operationId = 'save-running-config'
 					commandRequest = { id: 'write-memory' }
+					break
+				case 'reserve dhcp address':
+					operationId = 'reserve-dhcp-address'
+					commandRequest = {
+						id: 'reserve-dhcp-address',
+						ipAddress: validateIslandRouterIpv4Address(
+							request.ipAddress,
+							'ipAddress',
+						),
+						macAddress: validateIslandRouterMacAddress(
+							request.macAddress,
+							'macAddress',
+						),
+					}
+					break
+				case 'remove dhcp reservation':
+					operationId = 'remove-dhcp-reservation'
+					commandRequest = {
+						id: 'remove-dhcp-reservation',
+						ipAddress: validateIslandRouterIpv4Address(
+							request.ipAddress,
+							'ipAddress',
+						),
+						macAddress: validateIslandRouterMacAddress(
+							request.macAddress,
+							'macAddress',
+						),
+					}
 					break
 				default: {
 					const _exhaustive: never = request.operation

--- a/packages/home-connector/src/adapters/island-router/ssh-client.node.test.ts
+++ b/packages/home-connector/src/adapters/island-router/ssh-client.node.test.ts
@@ -70,6 +70,67 @@ test('ssh runner explicitly disables host verification when no known-host or fin
 	}
 })
 
+test('ssh runner builds guarded DHCP reservation commands from validated tokens', async () => {
+	const config = createConfig()
+	const tempDir = await mkdtemp(
+		path.join(os.tmpdir(), 'kody-island-router-test-'),
+	)
+	const binDir = path.join(tempDir, 'bin')
+	const stdinPath = path.join(tempDir, 'ssh-stdin.txt')
+	await mkdir(binDir, { recursive: true })
+	const fakeSshPath = path.join(binDir, 'ssh')
+	await writeFile(
+		fakeSshPath,
+		[
+			'#!/bin/sh',
+			`while IFS= read -r line; do printf '%s\n' "$line" >> "${stdinPath}"; done`,
+			'exit 0',
+		].join('\n'),
+		'utf8',
+	)
+	await chmod(fakeSshPath, 0o755)
+
+	const originalPath = process.env.PATH
+	process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ''}`
+
+	try {
+		const runner = createIslandRouterSshCommandRunner(config)
+		const reserveResult = await runner({
+			id: 'reserve-dhcp-address',
+			ipAddress: '192.168.3.77',
+			macAddress: '00-00-5E-00-53-7A',
+			timeoutMs: 1000,
+		})
+		expect(reserveResult.commandLines).toEqual([
+			'terminal length 0',
+			'configure terminal',
+			'ip dhcp-reserve 192.168.3.77 00:00:5e:00:53:7a',
+			'exit',
+		])
+
+		const removeResult = await runner({
+			id: 'remove-dhcp-reservation',
+			ipAddress: '192.168.3.77',
+			macAddress: '00:00:5E:00:53:7A',
+			timeoutMs: 1000,
+		})
+		expect(removeResult.commandLines).toEqual([
+			'terminal length 0',
+			'configure terminal',
+			'no ip dhcp-reserve 192.168.3.77 00:00:5e:00:53:7a',
+			'exit',
+		])
+
+		const stdin = await readFile(stdinPath, 'utf8')
+		expect(stdin).toContain('ip dhcp-reserve 192.168.3.77 00:00:5e:00:53:7a')
+		expect(stdin).toContain('no ip dhcp-reserve 192.168.3.77 00:00:5e:00:53:7a')
+		expect(stdin).not.toContain('write memory')
+	} finally {
+		process.env.PATH = originalPath
+		await rm(tempDir, { recursive: true, force: true })
+	}
+})
+
 test('ssh runner treats completed Island CLI sessions with exit code 1 as success', async () => {
 	const config = createConfig()
 	const tempDir = await mkdtemp(

--- a/packages/home-connector/src/adapters/island-router/ssh-client.ts
+++ b/packages/home-connector/src/adapters/island-router/ssh-client.ts
@@ -5,7 +5,9 @@ import path from 'node:path'
 import { type HomeConnectorConfig } from '../../config.ts'
 import {
 	assertIslandRouterConfigured,
+	validateIslandRouterIpv4Address,
 	validateIslandRouterFingerprint,
+	validateIslandRouterMacAddress,
 } from './validation.ts'
 import { isSuccessfulIslandRouterCliSession } from './parsing.ts'
 import {
@@ -287,6 +289,18 @@ function getCommandLines(request: IslandRouterCommandRequest): Array<string> {
 			return ['clear log']
 		case 'write-memory':
 			return ['write memory']
+		case 'reserve-dhcp-address':
+			return [
+				'configure terminal',
+				`ip dhcp-reserve ${validateIslandRouterIpv4Address(request.ipAddress, 'ipAddress')} ${validateIslandRouterMacAddress(request.macAddress, 'macAddress')}`,
+				'exit',
+			]
+		case 'remove-dhcp-reservation':
+			return [
+				'configure terminal',
+				`no ip dhcp-reserve ${validateIslandRouterIpv4Address(request.ipAddress, 'ipAddress')} ${validateIslandRouterMacAddress(request.macAddress, 'macAddress')}`,
+				'exit',
+			]
 		default: {
 			const _exhaustive: never = request
 			throw new Error(

--- a/packages/home-connector/src/adapters/island-router/types.ts
+++ b/packages/home-connector/src/adapters/island-router/types.ts
@@ -104,7 +104,8 @@ export const islandRouterReadCommandCatalog = [
 		params: [],
 		riskLevel: 'low',
 		description: 'Read documented DHCP information.',
-		riskNotes: 'May reveal DHCP leases or reservations when firmware includes them.',
+		riskNotes:
+			'May reveal DHCP leases or reservations when firmware includes them.',
 	},
 	{
 		command: 'show ip routes',
@@ -128,6 +129,8 @@ export const islandRouterWriteOperationStrings = [
 	'renew dhcp clients',
 	'clear log buffer',
 	'save running config',
+	'reserve dhcp address',
+	'remove dhcp reservation',
 ] as const
 
 export type IslandRouterWriteOperation =
@@ -162,9 +165,28 @@ export const islandRouterWriteOperationCatalog = [
 		operation: 'save running config',
 		command: 'write memory',
 		riskLevel: 'high',
-		description: 'Persist the current running configuration to startup storage.',
+		description:
+			'Persist the current running configuration to startup storage.',
 		blastRadius:
 			'Can make a bad live configuration survive reboot until manually corrected.',
+	},
+	{
+		operation: 'reserve dhcp address',
+		command: 'configure terminal; ip dhcp-reserve <ip> <mac>; exit',
+		riskLevel: 'high',
+		description:
+			'Add one global Island DHCP reservation for an IPv4 address and MAC address. Save running config separately if persistence is desired.',
+		blastRadius:
+			'Can affect future DHCP address assignment and device connectivity for the reserved device or any device currently using the selected address.',
+	},
+	{
+		operation: 'remove dhcp reservation',
+		command: 'configure terminal; no ip dhcp-reserve <ip> <mac>; exit',
+		riskLevel: 'high',
+		description:
+			'Remove one global Island DHCP reservation for an IPv4 address and MAC address. Save running config separately if persistence is desired.',
+		blastRadius:
+			'Can change future DHCP address assignment and connectivity expectations for the device that previously depended on the reservation.',
 	},
 ] as const satisfies ReadonlyArray<IslandRouterWriteOperationCatalogEntry>
 
@@ -195,6 +217,8 @@ export type IslandRouterCommandId =
 	| 'clear-dhcp-client'
 	| 'clear-log'
 	| 'write-memory'
+	| 'reserve-dhcp-address'
+	| 'remove-dhcp-reservation'
 
 export type IslandRouterCommandRequest =
 	| {
@@ -267,6 +291,18 @@ export type IslandRouterCommandRequest =
 			id: 'write-memory'
 			timeoutMs?: number
 	  }
+	| {
+			id: 'reserve-dhcp-address'
+			ipAddress: string
+			macAddress: string
+			timeoutMs?: number
+	  }
+	| {
+			id: 'remove-dhcp-reservation'
+			ipAddress: string
+			macAddress: string
+			timeoutMs?: number
+	  }
 
 export type IslandRouterCommandResult = {
 	id: IslandRouterCommandId
@@ -287,12 +323,18 @@ export type IslandRouterWriteOperationId =
 	| 'renew-dhcp-clients'
 	| 'clear-log-buffer'
 	| 'save-running-config'
+	| 'reserve-dhcp-address'
+	| 'remove-dhcp-reservation'
 
 export type IslandRouterWriteOperationResult = {
 	operationId: IslandRouterWriteOperationId
 	commandId: Extract<
 		IslandRouterCommandId,
-		'clear-dhcp-client' | 'clear-log' | 'write-memory'
+		| 'clear-dhcp-client'
+		| 'clear-log'
+		| 'write-memory'
+		| 'reserve-dhcp-address'
+		| 'remove-dhcp-reservation'
 	>
 	catalogEntry: IslandRouterWriteOperationCatalogEntry
 	commandLines: Array<string>

--- a/packages/home-connector/src/adapters/island-router/validation.ts
+++ b/packages/home-connector/src/adapters/island-router/validation.ts
@@ -11,9 +11,27 @@ const hostnamePattern =
 const sha256FingerprintPattern = /^SHA256:[A-Za-z0-9+/]+={0,2}$/
 const md5FingerprintPattern = /^MD5:(?:[0-9a-fA-F]{2}:){15}[0-9a-fA-F]{2}$/
 
-function normalizeMacAddress(value: string) {
+export function normalizeIslandRouterMacAddress(value: string) {
 	const octets = value.trim().toLowerCase().replaceAll('-', ':').split(':')
 	return octets.map((octet) => octet.padStart(2, '0')).join(':')
+}
+
+export function validateIslandRouterIpv4Address(value: string, field: string) {
+	const trimmed = value.trim()
+	if (isIP(trimmed) !== 4) {
+		throw new Error(`${field} must be a valid IPv4 address.`)
+	}
+	return trimmed
+}
+
+export function validateIslandRouterMacAddress(value: string, field: string) {
+	const trimmed = value.trim()
+	if (!macAddressPattern.test(trimmed)) {
+		throw new Error(
+			`${field} must be a valid 48-bit MAC address using colon or hyphen separated octets.`,
+		)
+	}
+	return normalizeIslandRouterMacAddress(trimmed)
 }
 
 function normalizeIpv6(value: string) {
@@ -48,7 +66,7 @@ export function validateIslandRouterHost(
 		return {
 			kind: 'mac',
 			value: trimmed,
-			normalizedValue: normalizeMacAddress(trimmed),
+			normalizedValue: normalizeIslandRouterMacAddress(trimmed),
 		}
 	}
 

--- a/packages/home-connector/src/mcp/register-island-router-tools.ts
+++ b/packages/home-connector/src/mcp/register-island-router-tools.ts
@@ -150,12 +150,24 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		operation: z
 			.enum(islandRouterWriteOperationStrings)
 			.describe(
-				'Explicit high-risk router operation entry. Each operation maps to one documented allowlisted Island CLI command and includes catalog blast-radius metadata in the result.',
+				'Explicit high-risk router operation entry. Each operation maps to one documented allowlisted Island CLI command sequence and includes catalog blast-radius metadata in the result.',
+			),
+		ipAddress: z
+			.string()
+			.optional()
+			.describe(
+				'Required only for reserve dhcp address and remove dhcp reservation. Must be a valid IPv4 address; it does not need to be inside DHCP scope.',
+			),
+		macAddress: z
+			.string()
+			.optional()
+			.describe(
+				'Required only for reserve dhcp address and remove dhcp reservation. Must be a 48-bit colon- or hyphen-separated MAC address and is normalized before command construction.',
 			),
 		acknowledgeHighRisk: z
 			.literal(true)
 			.describe(
-				'Must be true. Set this only when you are highly certain the requested router mutation is necessary and correct.',
+				'Must be true. Set this only when you are highly certain the requested router mutation is necessary and correct. DHCP reservation changes can affect address assignment and future connectivity for a device.',
 			),
 		reason: z
 			.string()
@@ -182,7 +194,7 @@ export function registerIslandRouterHomeConnectorTools(input: {
 		{
 			name: 'router_run_write_operation',
 			title: 'Run Guarded Island Router Write Operation',
-			description: `${routerWriteDangerNotice} This accepts only explicit typed operation entries (${islandRouterWriteOperationStrings.join(', ')}), never arbitrary CLI text. Review the returned catalog entry for the command and blast radius.`,
+			description: `${routerWriteDangerNotice} This accepts only explicit typed operation entries (${islandRouterWriteOperationStrings.join(', ')}), never arbitrary CLI text. DHCP reservation operations require ipAddress and macAddress, validate those tokens before building CLI commands, and do not automatically save running config; separately run save running config if persistence is desired. Review the returned catalog entry for the command and blast radius.`,
 			inputSchema: writeOperationSchema.inputSchema,
 			sdkInputSchema: writeOperationSchema.sdkInputSchema,
 			annotations: {
@@ -190,13 +202,24 @@ export function registerIslandRouterHomeConnectorTools(input: {
 			},
 		},
 		async (args) => {
-			const result = await islandRouter.runWriteOperation({
-				operation: args['operation'] as IslandRouterWriteOperation,
+			const operation = args['operation'] as IslandRouterWriteOperation
+			const requestBase = {
 				acknowledgeHighRisk: args['acknowledgeHighRisk'] === true,
 				reason: String(args['reason'] ?? ''),
 				confirmation: String(args['confirmation'] ?? ''),
 				timeoutMs:
 					args['timeoutMs'] == null ? undefined : Number(args['timeoutMs']),
+			}
+			const result = await islandRouter.runWriteOperation({
+				...requestBase,
+				operation,
+				...(operation === 'reserve dhcp address' ||
+				operation === 'remove dhcp reservation'
+					? {
+							ipAddress: String(args['ipAddress'] ?? ''),
+							macAddress: String(args['macAddress'] ?? ''),
+						}
+					: {}),
 			})
 			return structuredTextResult(
 				`Ran guarded Island router write operation ${result.catalogEntry.operation}.`,

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -447,9 +447,7 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 			),
 		).toBe(true)
 		expect(
-			tools.some(
-				(tool) => tool.name === 'access_networks_unleashed_request',
-			),
+			tools.some((tool) => tool.name === 'access_networks_unleashed_request'),
 		).toBe(true)
 		expect(
 			tools.some(
@@ -458,7 +456,8 @@ test('mcp server exposes Samsung tools and executes samsung_list_devices', async
 		).toBe(true)
 		expect(
 			tools.some(
-				(tool) => tool.name === 'access_networks_unleashed_authenticate_controller',
+				(tool) =>
+					tool.name === 'access_networks_unleashed_authenticate_controller',
 			),
 		).toBe(true)
 		const removedToolNames = [
@@ -867,9 +866,9 @@ test('mcp server exposes island router write tools when host verification is con
 
 	try {
 		const tools = mcp.listTools()
-		expect(tools.some((tool) => tool.name === 'router_run_write_operation')).toBe(
-			true,
-		)
+		expect(
+			tools.some((tool) => tool.name === 'router_run_write_operation'),
+		).toBe(true)
 		expect(
 			tools.some((tool) => tool.name === 'router_renew_dhcp_clients'),
 		).toBe(false)
@@ -889,7 +888,15 @@ test('mcp server exposes island router write tools when host verification is con
 			'renew dhcp clients',
 			'clear log buffer',
 			'save running config',
+			'reserve dhcp address',
+			'remove dhcp reservation',
 		])
+		expect(writeProperties?.ipAddress?.description).toContain(
+			'valid IPv4 address',
+		)
+		expect(writeProperties?.macAddress?.description).toContain(
+			'48-bit colon- or hyphen-separated MAC address',
+		)
 		expect(writeProperties?.acknowledgeHighRisk?.const).toBe(true)
 		expect(writeProperties?.confirmation?.const).toBe(
 			'I am highly certain running this guarded Island router write operation is necessary right now.',
@@ -909,6 +916,31 @@ test('mcp server exposes island router write tools when host verification is con
 			catalogEntry: {
 				operation: 'renew dhcp clients',
 				blastRadius: expect.any(String),
+			},
+		})
+
+		const reserveResult = await mcp.callTool('router_run_write_operation', {
+			operation: 'reserve dhcp address',
+			ipAddress: '192.168.0.77',
+			macAddress: '00-00-5E-00-53-7A',
+			acknowledgeHighRisk: true,
+			reason:
+				'Add the planned DHCP reservation after confirming this is the correct lab device.',
+			confirmation:
+				'I am highly certain running this guarded Island router write operation is necessary right now.',
+		})
+		expect(reserveResult.structuredContent).toMatchObject({
+			operationId: 'reserve-dhcp-address',
+			commandId: 'reserve-dhcp-address',
+			commandLines: [
+				'terminal length 0',
+				'configure terminal',
+				'ip dhcp-reserve 192.168.0.77 00:00:5e:00:53:7a',
+				'exit',
+			],
+			catalogEntry: {
+				operation: 'reserve dhcp address',
+				blastRadius: expect.stringContaining('address assignment'),
 			},
 		})
 

--- a/packages/home-connector/src/mcp/server.node.test.ts
+++ b/packages/home-connector/src/mcp/server.node.test.ts
@@ -199,6 +199,26 @@ function createIslandRouterRunner() {
 					['write memory'],
 					'Running configuration saved.',
 				)
+			case 'reserve-dhcp-address':
+				return createResult(
+					request,
+					[
+						'configure terminal',
+						`ip dhcp-reserve ${request.ipAddress} ${request.macAddress}`,
+						'exit',
+					],
+					'DHCP reservation added.',
+				)
+			case 'remove-dhcp-reservation':
+				return createResult(
+					request,
+					[
+						'configure terminal',
+						`no ip dhcp-reserve ${request.ipAddress} ${request.macAddress}`,
+						'exit',
+					],
+					'DHCP reservation removed.',
+				)
 			default: {
 				const _exhaustive: never = request
 				throw new Error(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add typed Island router write operations for reserving and removing DHCP reservations
- Validate IPv4 and MAC inputs, normalize MAC addresses, and build fixed configuration command sequences
- Document that reservation writes are high risk and require a separate save running config operation for persistence

## Testing
- `npm --prefix packages/home-connector test -- packages/home-connector/src/adapters/island-router/index.node.test.ts packages/home-connector/src/adapters/island-router/ssh-client.node.test.ts packages/home-connector/src/mcp/server.node.test.ts`
- `npx oxfmt --check docs/contributing/architecture/home-connector.md packages/home-connector/src/adapters/island-router/index.node.test.ts packages/home-connector/src/adapters/island-router/index.ts packages/home-connector/src/adapters/island-router/ssh-client.node.test.ts packages/home-connector/src/adapters/island-router/ssh-client.ts packages/home-connector/src/adapters/island-router/types.ts packages/home-connector/src/adapters/island-router/validation.ts packages/home-connector/src/mcp/register-island-router-tools.ts packages/home-connector/src/mcp/server.node.test.ts && npm run lint && npm run typecheck`

Note: `npm run format:check` across the whole repo still reports pre-existing formatting issues in unrelated files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57ad7e1b-4970-413e-b249-610709be34aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57ad7e1b-4970-413e-b249-610709be34aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

