### PR TITLE
Fix repo package export checks

### DIFF
--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -214,6 +214,14 @@ export default __kodyPackageModule.default;
 `.trim()
 }
 
+function createImportableEntrypointSource(input: { modulePath: string }) {
+	return `
+export * from ${JSON.stringify(input.modulePath)};
+import * as userModule from ${JSON.stringify(input.modulePath)};
+export default userModule;
+`.trim()
+}
+
 function encodePathKey(value: string) {
 	return Array.from(new TextEncoder().encode(value), (byte) =>
 		byte.toString(16).padStart(2, '0'),
@@ -537,6 +545,45 @@ export async function buildKodyModuleBundle(input: {
 	assertBundleHasNoUnresolvedBareImports({
 		modules: bundle.modules as WorkerLoaderModules,
 		bundleLabel: `Saved package module "${normalizePackageWorkspacePath(input.entryPoint)}" bundle`,
+	})
+	return {
+		mainModule: bundle.mainModule,
+		modules: bundle.modules as WorkerLoaderModules,
+		dependencies: [...dependencies.values()],
+	}
+}
+
+export async function buildKodyImportableModuleBundle(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	sourceFiles: Record<string, string>
+	entryPoint: string
+}) {
+	const { files, dependencies } = await prepareKodyGraphFiles({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		sourceFiles: input.sourceFiles,
+	})
+	const normalizedEntrypoint = joinPath(
+		rootSourcePrefix,
+		normalizePackageWorkspacePath(input.entryPoint),
+	)
+	const bootstrapPath = joinPath(rootSourcePrefix, '.__kody_import_entry__.js')
+	files[bootstrapPath] = createImportableEntrypointSource({
+		modulePath: createRelativeImportSpecifier(
+			bootstrapPath,
+			normalizedEntrypoint,
+		),
+	})
+	const bundle = await createWorkerBundle({
+		files,
+		entryPoint: bootstrapPath,
+	})
+	assertBundleHasNoUnresolvedBareImports({
+		modules: bundle.modules as WorkerLoaderModules,
+		bundleLabel: `Saved package import "${normalizePackageWorkspacePath(input.entryPoint)}" bundle`,
 	})
 	return {
 		mainModule: bundle.mainModule,

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -4,6 +4,7 @@ const mockModule = vi.hoisted(() => ({
 	createFileSystemSnapshot: vi.fn(),
 	createTypescriptLanguageService: vi.fn(),
 	buildKodyAppBundle: vi.fn(),
+	buildKodyImportableModuleBundle: vi.fn(),
 	buildKodyModuleBundle: vi.fn(),
 }))
 
@@ -20,6 +21,8 @@ vi.mock('@cloudflare/worker-bundler/typescript', () => ({
 vi.mock('#worker/package-runtime/module-graph.ts', () => ({
 	buildKodyAppBundle: (...args: Array<unknown>) =>
 		mockModule.buildKodyAppBundle(...args),
+	buildKodyImportableModuleBundle: (...args: Array<unknown>) =>
+		mockModule.buildKodyImportableModuleBundle(...args),
 	buildKodyModuleBundle: (...args: Array<unknown>) =>
 		mockModule.buildKodyModuleBundle(...args),
 }))
@@ -44,6 +47,7 @@ beforeEach(() => {
 	mockModule.createFileSystemSnapshot.mockReset()
 	mockModule.createTypescriptLanguageService.mockReset()
 	mockModule.buildKodyAppBundle.mockReset()
+	mockModule.buildKodyImportableModuleBundle.mockReset()
 	mockModule.buildKodyModuleBundle.mockReset()
 	mockModule.buildKodyAppBundle.mockResolvedValue({
 		mainModule: 'dist/app.js',
@@ -57,6 +61,13 @@ beforeEach(() => {
 		mainModule: 'dist/module.js',
 		modules: {
 			'dist/module.js': 'export default async function run() { return "ok" }',
+		},
+		dependencies: [],
+	})
+	mockModule.buildKodyImportableModuleBundle.mockResolvedValue({
+		mainModule: 'dist/importable.js',
+		modules: {
+			'dist/importable.js': 'export const ready = true',
 		},
 		dependencies: [],
 	})
@@ -78,6 +89,21 @@ function createPackageManifest(input: {
 	description: string
 	exports?: Record<string, string>
 	jobs?: Record<string, { entry: string; schedule: Record<string, unknown> }>
+	subscriptions?: Record<
+		string,
+		{ handler: string; description?: string; filters?: Record<string, unknown> }
+	>
+	services?: Record<string, { entry: string }>
+	workflows?: Record<string, { export: string; description?: string }>
+	retrievers?: Record<
+		string,
+		{
+			export: string
+			name: string
+			description: string
+			scopes: Array<'search' | 'context'>
+		}
+	>
 	appEntry?: string
 }) {
 	return JSON.stringify({
@@ -96,6 +122,10 @@ function createPackageManifest(input: {
 					}
 				: undefined,
 			jobs: input.jobs,
+			subscriptions: input.subscriptions,
+			services: input.services,
+			workflows: input.workflows,
+			retrievers: input.retrievers,
 		},
 	})
 }
@@ -158,12 +188,13 @@ test('runRepoChecks normalizes leading slashes in package job entrypoints', asyn
 			expect.objectContaining({
 				kind: 'bundle',
 				ok: true,
-				message: 'Resolved 2 package runtime entrypoint(s) for bundling.',
+				message: 'Resolved 2 package target(s) for bundling.',
 			}),
 			expect.objectContaining({
 				kind: 'typecheck',
 				ok: true,
-				message: 'No semantic diagnostics for 2 package runtime entrypoint(s).',
+				message:
+					'No semantic diagnostics for 1 callable package runtime entrypoint(s).',
 			}),
 		]),
 	)
@@ -329,7 +360,8 @@ test('runRepoChecks accepts execute runtime globals for package-owned jobs', asy
 			expect.objectContaining({
 				kind: 'typecheck',
 				ok: true,
-				message: 'No semantic diagnostics for 2 package runtime entrypoint(s).',
+				message:
+					'No semantic diagnostics for 1 callable package runtime entrypoint(s).',
 			}),
 		]),
 	)
@@ -339,29 +371,69 @@ test('runRepoChecks accepts execute runtime globals for package-owned jobs', asy
 	)
 })
 
-test('runRepoChecks typechecks package exports with execute semantics globals', async () => {
+test('runRepoChecks allows named-only helper exports and typechecks callable manifest exports', async () => {
 	const files = new Map<string, string>([
 		[
 			'package.json',
 			createPackageManifest({
-				packageName: '@kody/runtime-globals-export',
-				kodyId: 'runtime-globals-export',
-				description: 'Uses execute globals',
+				packageName: '@kody/helper-and-callable-export',
+				kodyId: 'helper-and-callable-export',
+				description: 'Exports helpers and callable runtime targets',
 				exports: {
 					'.': './src/index.ts',
-					'./run': './src/run.ts',
+					'./helper': './src/helper.ts',
+					'./job': './src/job.ts',
+					'./workflow': './src/workflow.ts',
+					'./search': './src/search.ts',
+					'./subscription': './src/subscription.ts',
+				},
+				jobs: {
+					digest: {
+						entry: 'src/job.ts',
+						schedule: {
+							type: 'once',
+							runAt: '2026-04-17T15:00:00Z',
+						},
+					},
+				},
+				subscriptions: {
+					'email.message.received': {
+						handler: './src/subscription.ts',
+					},
+				},
+				workflows: {
+					refresh: {
+						export: './workflow',
+						description: 'Refreshes derived data.',
+					},
+				},
+				retrievers: {
+					search: {
+						export: './search',
+						name: 'Search',
+						description: 'Searches package records.',
+						scopes: ['search'],
+					},
 				},
 			}),
 		],
 		['src/index.ts', 'export const ready = true\n'],
 		[
-			'src/run.ts',
-			`async (params) => {
+			'src/helper.ts',
+			'export const format = (value: string) => value.trim()\n',
+		],
+		[
+			'src/job.ts',
+			`export default async (params) => {
   const result = await codemode.value_get({ name: 'projectId' })
+  await storage.get('count')
   return { params, result }
 }
 `,
 		],
+		['src/workflow.ts', 'export default async (params) => params\n'],
+		['src/search.ts', 'export default async (params) => ({ results: [] })\n'],
+		['src/subscription.ts', 'export default async (event) => event\n'],
 	])
 	const snapshot = createSnapshotFromFiles(files)
 	const typeScriptFileSystem: MockTypeScriptFileSystem = {
@@ -396,7 +468,8 @@ test('runRepoChecks typechecks package exports with execute semantics globals', 
 			expect.objectContaining({
 				kind: 'typecheck',
 				ok: true,
-				message: 'No semantic diagnostics for 2 package runtime entrypoint(s).',
+				message:
+					'No semantic diagnostics for 4 callable package runtime entrypoint(s).',
 			}),
 		]),
 	)
@@ -406,11 +479,23 @@ test('runRepoChecks typechecks package exports with execute semantics globals', 
 	)
 	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
 		'.__kody_repo_module_check__.ts',
-		expect.stringContaining('declare function __kodyTypecheckModule'),
+		expect.stringContaining('import userEntrypoint from "./src/job"'),
+	)
+	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
+		'.__kody_repo_module_check__.ts',
+		expect.stringContaining('import userEntrypoint from "./src/workflow"'),
+	)
+	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
+		'.__kody_repo_module_check__.ts',
+		expect.stringContaining('import userEntrypoint from "./src/search"'),
+	)
+	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
+		'.__kody_repo_module_check__.ts',
+		expect.stringContaining('import userEntrypoint from "./src/subscription"'),
 	)
 	expect(typeScriptFileSystem.write).not.toHaveBeenCalledWith(
-		'.__kody_repo_runtime__.d.ts',
-		expect.stringContaining('declare const storage'),
+		'.__kody_repo_module_check__.ts',
+		expect.stringContaining('import userEntrypoint from "./src/helper"'),
 	)
 })
 
@@ -553,13 +638,18 @@ test('runRepoChecks typechecks ESM package job entrypoints', async () => {
 			expect.objectContaining({
 				kind: 'typecheck',
 				ok: true,
-				message: 'No semantic diagnostics for 2 package runtime entrypoint(s).',
+				message:
+					'No semantic diagnostics for 1 callable package runtime entrypoint(s).',
 			}),
 		]),
 	)
 	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
 		'.__kody_repo_module_check__.ts',
 		expect.stringContaining('import userEntrypoint from "./src/job"'),
+	)
+	expect(typeScriptFileSystem.write).not.toHaveBeenCalledWith(
+		'.__kody_repo_module_check__.ts',
+		expect.stringContaining('import userEntrypoint from "./src/index"'),
 	)
 	expect(getSemanticDiagnostics).toHaveBeenCalledWith(
 		'.__kody_repo_module_check__.ts',
@@ -640,6 +730,10 @@ test('runRepoChecks injects a synthetic tsconfig that allows optional .ts import
 		typecheckInput.fileSystem.read('./.__kody_repo_tsconfig_base__.json'),
 	).toBe(null)
 	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
+		'.__kody_repo_module_check__.ts',
+		expect.stringContaining('import userEntrypoint from "./src/job"'),
+	)
+	expect(typeScriptFileSystem.write).not.toHaveBeenCalledWith(
 		'.__kody_repo_module_check__.ts',
 		expect.stringContaining('import userEntrypoint from "./src/index"'),
 	)
@@ -722,6 +816,10 @@ test('runRepoChecks preserves repo tsconfig via extends while enabling optional 
 		typecheckInput.fileSystem.read('/.__kody_repo_tsconfig_base__.json'),
 	).toBe(repoTsconfig)
 	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
+		'.__kody_repo_module_check__.ts',
+		expect.stringContaining('import userEntrypoint from "./src/job"'),
+	)
+	expect(typeScriptFileSystem.write).not.toHaveBeenCalledWith(
 		'.__kody_repo_module_check__.ts',
 		expect.stringContaining('import userEntrypoint from "./src/index"'),
 	)
@@ -820,7 +918,7 @@ test('runRepoChecks fails bundle validation when runtime bundling cannot resolve
 			getSemanticDiagnostics: vi.fn(() => []),
 		},
 	})
-	mockModule.buildKodyModuleBundle.mockRejectedValueOnce(
+	mockModule.buildKodyImportableModuleBundle.mockRejectedValueOnce(
 		new Error('No such module "marked" imported from bundle.js'),
 	)
 
@@ -852,12 +950,13 @@ test('runRepoChecks fails bundle validation when runtime bundling cannot resolve
 			}),
 		]),
 	)
-	expect(mockModule.buildKodyModuleBundle).toHaveBeenCalledWith(
+	expect(mockModule.buildKodyImportableModuleBundle).toHaveBeenCalledWith(
 		expect.objectContaining({
 			entryPoint: 'src/index.ts',
 			userId: 'user-123',
 		}),
 	)
+	expect(mockModule.buildKodyModuleBundle).not.toHaveBeenCalled()
 })
 
 test('runRepoChecks validates package runtime bundles with npm dependencies', async () => {
@@ -930,11 +1029,11 @@ test('runRepoChecks validates package runtime bundles with npm dependencies', as
 			expect.objectContaining({
 				kind: 'bundle',
 				ok: true,
-				message: 'Bundled 2 package runtime entrypoint(s) successfully.',
+				message: 'Bundled 2 package target(s) successfully.',
 			}),
 		]),
 	)
-	expect(mockModule.buildKodyModuleBundle).toHaveBeenCalledWith(
+	expect(mockModule.buildKodyImportableModuleBundle).toHaveBeenCalledWith(
 		expect.objectContaining({
 			entryPoint: 'src/index.ts',
 			sourceFiles: {
@@ -986,7 +1085,7 @@ test('runRepoChecks fails when package runtime bundle cannot resolve npm depende
 			getSemanticDiagnostics: vi.fn(() => []),
 		},
 	})
-	mockModule.buildKodyModuleBundle.mockRejectedValueOnce(
+	mockModule.buildKodyImportableModuleBundle.mockRejectedValueOnce(
 		new Error('Could not resolve version for marked@18.0.2'),
 	)
 

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -344,6 +344,7 @@ function collectPackageCallableTypecheckTargets(
 		const normalizedPath = normalizePackageWorkspacePath(path)
 		const existing = targets.get(normalizedPath)
 		if (existing) {
+			// Preserve the widest runtime global surface when one file is reused.
 			existing.includeStorage = existing.includeStorage || includeStorage
 			return
 		}
@@ -427,7 +428,7 @@ async function validatePackageBundles(input: {
 					sourceFiles: input.sourceFiles,
 					entryPoint: target.path,
 				})
-			} else {
+			} else if (target.bundleKind === 'importable') {
 				await buildKodyImportableModuleBundle({
 					env: input.env,
 					baseUrl: input.baseUrl,
@@ -435,6 +436,9 @@ async function validatePackageBundles(input: {
 					sourceFiles: input.sourceFiles,
 					entryPoint: target.path,
 				})
+			} else {
+				const exhaustive: never = target.bundleKind
+				throw new Error(`Unsupported package bundle target kind: ${exhaustive}`)
 			}
 		} catch (error) {
 			failures.push(
@@ -588,7 +592,7 @@ function formatBundleCheckMessage(input: {
 			.join(', ')}.`
 	}
 	if (input.targetCount === 0) {
-		return 'Package defines no app entry, exports, jobs, or services to bundle.'
+		return 'Package defines no app entry, exports, jobs, services, subscriptions, workflows, or retrievers to bundle.'
 	}
 	return `Resolved ${input.targetCount} package target(s) for bundling.`
 }

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -2,6 +2,8 @@ import {
 	getPackageAppEntryPath,
 	listPackageServices,
 	listPackageSubscriptions,
+	listPackageRetrievers,
+	listPackageWorkflows,
 	normalizePackageWorkspacePath,
 	parseAuthoredPackageJson,
 	resolvePackageExportPath,
@@ -9,6 +11,7 @@ import {
 import { type AuthoredPackageJson } from '#worker/package-registry/types.ts'
 import {
 	buildKodyAppBundle,
+	buildKodyImportableModuleBundle,
 	buildKodyModuleBundle,
 } from '#worker/package-runtime/module-graph.ts'
 import { normalizeRepoWorkspacePath } from './manifest.ts'
@@ -255,21 +258,89 @@ declare const storage: {
 `.trim()
 }
 
-type PackageTypecheckTarget = {
+type PackageBundleTarget = {
 	path: string
-	includeStorage: boolean
-	bundleKind: 'app' | 'module'
+	bundleKind: 'app' | 'callable' | 'importable'
 }
 
-function collectPackageTypecheckTargets(
+type PackageCallableTypecheckTarget = {
+	path: string
+	includeStorage: boolean
+}
+
+function buildBundleTargetKey(target: PackageBundleTarget) {
+	return `${target.path}:${target.bundleKind}`
+}
+
+function compareBundleTargets(
+	left: PackageBundleTarget,
+	right: PackageBundleTarget,
+) {
+	return buildBundleTargetKey(left).localeCompare(buildBundleTargetKey(right))
+}
+
+function collectPackageBundleTargets(
 	manifest: AuthoredPackageJson,
-): Array<PackageTypecheckTarget> {
-	const targets = new Map<string, PackageTypecheckTarget>()
+): Array<PackageBundleTarget> {
+	const targets = new Map<string, PackageBundleTarget>()
 	const remember = (
 		path: string,
-		includeStorage: boolean,
-		bundleKind: PackageTypecheckTarget['bundleKind'],
+		bundleKind: PackageBundleTarget['bundleKind'],
 	) => {
+		const normalizedPath = normalizePackageWorkspacePath(path)
+		targets.set(buildBundleTargetKey({ path: normalizedPath, bundleKind }), {
+			path: normalizedPath,
+			bundleKind,
+		})
+	}
+	const appEntryPath = getPackageAppEntryPath(manifest)
+	if (appEntryPath) {
+		remember(appEntryPath, 'app')
+	}
+	for (const exportName of Object.keys(manifest.exports)) {
+		remember(
+			resolvePackageExportPath({
+				manifest,
+				exportName,
+			}),
+			'importable',
+		)
+	}
+	for (const job of Object.values(manifest.kody.jobs ?? {})) {
+		remember(job.entry, 'callable')
+	}
+	for (const service of listPackageServices(manifest)) {
+		remember(service.entry, 'callable')
+	}
+	for (const subscription of listPackageSubscriptions(manifest)) {
+		remember(subscription.handler, 'callable')
+	}
+	for (const workflow of listPackageWorkflows(manifest)) {
+		remember(
+			resolvePackageExportPath({
+				manifest,
+				exportName: workflow.exportName,
+			}),
+			'callable',
+		)
+	}
+	for (const retriever of listPackageRetrievers(manifest)) {
+		remember(
+			resolvePackageExportPath({
+				manifest,
+				exportName: retriever.exportName,
+			}),
+			'callable',
+		)
+	}
+	return Array.from(targets.values()).sort(compareBundleTargets)
+}
+
+function collectPackageCallableTypecheckTargets(
+	manifest: AuthoredPackageJson,
+): Array<PackageCallableTypecheckTarget> {
+	const targets = new Map<string, PackageCallableTypecheckTarget>()
+	const remember = (path: string, includeStorage: boolean) => {
 		const normalizedPath = normalizePackageWorkspacePath(path)
 		const existing = targets.get(normalizedPath)
 		if (existing) {
@@ -279,31 +350,34 @@ function collectPackageTypecheckTargets(
 		targets.set(normalizedPath, {
 			path: normalizedPath,
 			includeStorage,
-			bundleKind,
 		})
 	}
-	const appEntryPath = getPackageAppEntryPath(manifest)
-	if (appEntryPath) {
-		remember(appEntryPath, false, 'app')
+	for (const job of Object.values(manifest.kody.jobs ?? {})) {
+		remember(job.entry, true)
 	}
-	for (const exportName of Object.keys(manifest.exports)) {
+	for (const service of listPackageServices(manifest)) {
+		remember(service.entry, true)
+	}
+	for (const subscription of listPackageSubscriptions(manifest)) {
+		remember(subscription.handler, true)
+	}
+	for (const workflow of listPackageWorkflows(manifest)) {
 		remember(
 			resolvePackageExportPath({
 				manifest,
-				exportName,
+				exportName: workflow.exportName,
 			}),
-			false,
-			'module',
+			true,
 		)
 	}
-	for (const job of Object.values(manifest.kody.jobs ?? {})) {
-		remember(job.entry, true, 'module')
-	}
-	for (const service of listPackageServices(manifest)) {
-		remember(service.entry, true, 'module')
-	}
-	for (const subscription of listPackageSubscriptions(manifest)) {
-		remember(subscription.handler, true, 'module')
+	for (const retriever of listPackageRetrievers(manifest)) {
+		remember(
+			resolvePackageExportPath({
+				manifest,
+				exportName: retriever.exportName,
+			}),
+			true,
+		)
 	}
 	return Array.from(targets.values())
 }
@@ -331,7 +405,7 @@ async function validatePackageBundles(input: {
 	baseUrl: string
 	userId: string
 	sourceFiles: Record<string, string>
-	entryPoints: Array<PackageTypecheckTarget>
+	entryPoints: Array<PackageBundleTarget>
 }) {
 	const failures: Array<string> = []
 	for (const target of input.entryPoints) {
@@ -345,8 +419,16 @@ async function validatePackageBundles(input: {
 					entryPoint: target.path,
 					cacheKey: null,
 				})
-			} else {
+			} else if (target.bundleKind === 'callable') {
 				await buildKodyModuleBundle({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					userId: input.userId,
+					sourceFiles: input.sourceFiles,
+					entryPoint: target.path,
+				})
+			} else {
+				await buildKodyImportableModuleBundle({
 					env: input.env,
 					baseUrl: input.baseUrl,
 					userId: input.userId,
@@ -364,13 +446,13 @@ async function validatePackageBundles(input: {
 		ok: failures.length === 0,
 		message:
 			failures.length === 0
-				? `Bundled ${input.entryPoints.length} package runtime entrypoint(s) successfully.`
+				? `Bundled ${input.entryPoints.length} package target(s) successfully.`
 				: failures.join('\n'),
 	}
 }
 
 function getPackageTypecheckDiagnostics(input: {
-	targets: Array<PackageTypecheckTarget>
+	targets: Array<PackageCallableTypecheckTarget>
 	languageService: {
 		getSemanticDiagnostics(path: string): Array<{
 			messageText: unknown
@@ -483,7 +565,6 @@ export async function typecheckPackageEntrypointsFromSourceFiles(input: {
 		targets: input.entryPoints.map((entryPoint) => ({
 			path: entryPoint.path,
 			includeStorage: entryPoint.includeStorage === true,
-			bundleKind: 'module',
 		})),
 		languageService,
 		fileSystem,
@@ -502,14 +583,14 @@ function formatBundleCheckMessage(input: {
 	targetCount: number
 }) {
 	if (input.missingEntryPoints.length > 0) {
-		return `Package runtime entrypoint(s) missing from the repo session snapshot: ${input.missingEntryPoints
+		return `Package bundle target(s) missing from the repo session snapshot: ${input.missingEntryPoints
 			.map((path) => `"${path}"`)
 			.join(', ')}.`
 	}
 	if (input.targetCount === 0) {
 		return 'Package defines no app entry, exports, jobs, or services to bundle.'
 	}
-	return `Resolved ${input.targetCount} package runtime entrypoint(s) for bundling.`
+	return `Resolved ${input.targetCount} package target(s) for bundling.`
 }
 
 export async function runRepoChecks(input: {
@@ -577,10 +658,23 @@ export async function runRepoChecks(input: {
 						}: ${declaredDependencies.map((dependency) => `"${dependency}"`).join(', ')}.`,
 	})
 
-	const entryPoints = collectPackageTypecheckTargets(manifest)
-	const missingEntryPoints = entryPoints
-		.map((target) => target.path)
-		.filter((path) => snapshot.read(path) == null)
+	const bundleTargets = collectPackageBundleTargets(manifest)
+	const callableTypecheckTargets =
+		collectPackageCallableTypecheckTargets(manifest)
+	const missingBundleTargets = [
+		...new Set(
+			bundleTargets
+				.map((target) => target.path)
+				.filter((path) => snapshot.read(path) == null),
+		),
+	]
+	const missingCallableTypecheckTargets = [
+		...new Set(
+			callableTypecheckTargets
+				.map((target) => target.path)
+				.filter((path) => snapshot.read(path) == null),
+		),
+	]
 	const bundleContext =
 		input.env && input.userId
 			? {
@@ -590,25 +684,25 @@ export async function runRepoChecks(input: {
 				}
 			: null
 	const bundleCheckResult =
-		missingEntryPoints.length > 0
+		missingBundleTargets.length > 0
 			? {
 					ok: false,
 					message: formatBundleCheckMessage({
-						missingEntryPoints,
-						targetCount: entryPoints.length,
+						missingEntryPoints: missingBundleTargets,
+						targetCount: bundleTargets.length,
 					}),
 				}
 			: bundleContext
 				? await validatePackageBundles({
 						...bundleContext,
 						sourceFiles: createSourceFilesRecord(snapshotFiles),
-						entryPoints,
+						entryPoints: bundleTargets,
 					})
 				: {
 						ok: true,
 						message: formatBundleCheckMessage({
-							missingEntryPoints,
-							targetCount: entryPoints.length,
+							missingEntryPoints: missingBundleTargets,
+							targetCount: bundleTargets.length,
 						}),
 					}
 	results.push({
@@ -617,13 +711,31 @@ export async function runRepoChecks(input: {
 		message: bundleCheckResult.message,
 	})
 
-	if (missingEntryPoints.length > 0) {
+	if (missingCallableTypecheckTargets.length > 0) {
 		results.push({
 			kind: 'typecheck',
 			ok: false,
-			message: `Typecheck skipped because package runtime entrypoint(s) are missing from the repo session snapshot: ${missingEntryPoints
+			message: `Typecheck skipped because callable package runtime entrypoint(s) are missing from the repo session snapshot: ${missingCallableTypecheckTargets
 				.map((path) => `"${path}"`)
 				.join(', ')}.`,
+		})
+		results.push({
+			kind: 'lint',
+			ok: true,
+			message: 'Lint placeholder passed for this phase.',
+		})
+		return {
+			ok: results.every((result) => result.ok),
+			results,
+			manifest,
+		}
+	}
+
+	if (callableTypecheckTargets.length === 0) {
+		results.push({
+			kind: 'typecheck',
+			ok: true,
+			message: 'No callable package runtime entrypoint(s) to typecheck.',
 		})
 		results.push({
 			kind: 'lint',
@@ -659,7 +771,7 @@ export async function runRepoChecks(input: {
 		},
 	)
 	const diagnostics = getPackageTypecheckDiagnostics({
-		targets: entryPoints,
+		targets: callableTypecheckTargets,
 		languageService,
 		fileSystem,
 	})
@@ -667,7 +779,7 @@ export async function runRepoChecks(input: {
 		kind: 'typecheck',
 		ok: diagnostics.every((entry) => entry.diagnostics.length === 0),
 		message: diagnostics.every((entry) => entry.diagnostics.length === 0)
-			? `No semantic diagnostics for ${entryPoints.length} package runtime entrypoint(s).`
+			? `No semantic diagnostics for ${callableTypecheckTargets.length} callable package runtime entrypoint(s).`
 			: formatPackageTypecheckDiagnostics(diagnostics).join('\n'),
 	})
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Split repo package bundle targets from callable typecheck targets.
- Allow package exports to be named-only importable modules while still validating they bundle.
- Keep default callable function checks for execute-style runtime targets, including jobs, services, subscriptions, workflows, and retrievers.
- Addressed AI reviewer feedback for exhaustive target handling and updated bundle messaging.

## Test plan
- `npm run test -- packages/worker/src/repo/checks.node.test.ts`
- `npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20af0150-1eec-4166-bd0d-bc59e76f1e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20af0150-1eec-4166-bd0d-bc59e76f1e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for importable module bundles with proper named export re-exporting, enabling modules to be bundled as importable packages.

* **Refactoring**
  * Separated package bundling and typechecking validation into independent target sets with distinct result reporting for improved clarity and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->