### PR TITLE
Fix external package publish ancestry check

### DIFF
--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -924,6 +924,46 @@ test('publishFromExternalRef rejects stale expected HEAD values', async () => {
 	)
 })
 
+test('publishFromExternalRef checks fast-forward ancestry through shell git adapter', async () => {
+	setCommonSessionFixtures()
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		repo_id: 'source-repo',
+		published_commit: 'commit-old',
+		manifest_path: 'package.json',
+		source_root: '/',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+	})
+	mockModule.git.log.mockResolvedValueOnce([
+		{ oid: 'commit-new' },
+		{ oid: 'commit-old' },
+	])
+
+	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
+
+	const result = await repoSession.publishFromExternalRef({
+		sessionId: 'external-publish-source-1',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		newCommit: 'commit-new',
+	})
+
+	expect(result.status).toBe('published')
+	expect(mockModule.git.log).toHaveBeenCalledWith({
+		dir: '/session',
+		ref: 'commit-new',
+		depth: -1,
+	})
+	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({
+			publishedCommit: 'commit-new',
+		}),
+	)
+})
+
 test('getSessionState prefers fresh D1 reads over cached session and source rows', async () => {
 	// Guards against a regression where the cache, populated by openSession,
 	// would shadow fresh D1 reads and hide updates such as rebaseSession

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -954,7 +954,7 @@ test('publishFromExternalRef checks fast-forward ancestry through shell git adap
 	expect(mockModule.git.log).toHaveBeenCalledWith({
 		dir: '/session',
 		ref: 'commit-new',
-		depth: -1,
+		depth: Number.POSITIVE_INFINITY,
 	})
 	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
 		expect.anything(),

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -7,7 +7,6 @@ import {
 } from '@cloudflare/shell'
 import { applyPatch, formatPatch, parsePatch } from 'diff'
 import { createGit } from '@cloudflare/shell/git'
-import * as git from 'isomorphic-git'
 import {
 	deleteRepoSession,
 	getRepoSessionById,
@@ -457,15 +456,12 @@ class RepoSessionBase extends DurableObject<Env> {
 		if (input.ancestor === input.descendant) {
 			return true
 		}
-		return git.isDescendent({
-			fs: this.fileSystem as unknown as Parameters<
-				typeof git.isDescendent
-			>[0]['fs'],
+		const commits = await this.git.log({
 			dir: repoSessionWorkspacePrefix,
-			oid: input.descendant,
-			ancestor: input.ancestor,
+			ref: input.descendant,
 			depth: -1,
 		})
+		return commits.some((commit) => commit.oid === input.ancestor)
 	}
 
 	private async writeCheckStatus(status: RepoSessionCheckStatus) {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -456,10 +456,12 @@ class RepoSessionBase extends DurableObject<Env> {
 		if (input.ancestor === input.descendant) {
 			return true
 		}
+		// Repo command parsing rejects negative depths; use a positive infinite
+		// depth here to request the complete ancestry chain from the git adapter.
 		const commits = await this.git.log({
 			dir: repoSessionWorkspacePrefix,
 			ref: input.descendant,
-			depth: -1,
+			depth: Number.POSITIVE_INFINITY,
 		})
 		return commits.some((commit) => commit.oid === input.ancestor)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Use the repo session shell git adapter for external publish fast-forward ancestry checks
- Remove the direct `isomorphic-git` filesystem call that could receive an incompatible workspace filesystem shape
- Add a regression test for the external publish fast-forward path
- Use `Number.POSITIVE_INFINITY` for the full-history ancestry walk instead of a negative depth sentinel

## Root cause
`package_publish_external_push` takes the external publish path and checks fast-forward ancestry after cloning/checking out the pushed Artifacts commit. That path called `isomorphic-git.isDescendent` directly with `WorkspaceFileSystem`; in the execute/codemode callback path, isomorphic-git treated that object as a filesystem and attempted to bind missing fs methods, producing `Cannot read properties of undefined (reading 'bind')`. The working `repo_run_commands publish` path stays on the `@cloudflare/shell` git adapter, so it did not hit the incompatible direct fs usage.

## Validation
- `npm test -- packages/worker/src/repo/repo-session-do.node.test.ts packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts`
- `npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa346e2a-96aa-4055-845b-d60cae2026b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa346e2a-96aa-4055-845b-d60cae2026b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test verifying ancestry checking when publishing from an external ref without an expected head (ensures fast‑forward detection).

* **Chores**
  * Improved ancestry-checking logic to treat identical commits as matching and to traverse full commit history for accurate results.
  * Removed an unused Git helper dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->