### PR TITLE
Handle invalid Island Router API paths as tool errors

### DIFF
--- a/packages/home-connector/src/mcp/register-island-router-api-tools.node.test.ts
+++ b/packages/home-connector/src/mcp/register-island-router-api-tools.node.test.ts
@@ -124,4 +124,25 @@ test('registers Island Router API proxy tools and handlers call the adapter', as
 			confirmation: islandRouterApiWriteConfirmation,
 		}),
 	])
+	expect(
+		await tools.get('island_router_api_request')?.handler({
+			method: 'GET',
+			path: '/filters',
+		}),
+	).toMatchObject({
+		isError: true,
+		content: [
+			{
+				type: 'text',
+				text: 'Island Router API path must begin with /api/.',
+			},
+		],
+		structuredContent: {
+			error: {
+				code: 'island_router_api_invalid_path',
+				message: 'Island Router API path must begin with /api/.',
+			},
+		},
+	})
+	expect(calls).toHaveLength(1)
 })

--- a/packages/home-connector/src/mcp/register-island-router-api-tools.ts
+++ b/packages/home-connector/src/mcp/register-island-router-api-tools.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import {
 	islandRouterApiWriteConfirmation,
 	type createIslandRouterApiAdapter,
+	validateIslandRouterApiPath,
 } from '../adapters/island-router-api/index.ts'
 import {
 	buildToolInputSchema,
@@ -38,6 +39,29 @@ function structuredTextResult(
 			},
 		],
 		structuredContent,
+	}
+}
+
+function structuredErrorResult(
+	code: string,
+	message: string,
+	structuredContent: Record<string, unknown> = {},
+): CallToolResult {
+	return {
+		isError: true,
+		content: [
+			{
+				type: 'text',
+				text: message,
+			},
+		],
+		structuredContent: {
+			error: {
+				code,
+				message,
+				...structuredContent,
+			},
+		},
 	}
 }
 
@@ -163,8 +187,13 @@ Proxies an authenticated JSON HTTP request from the home connector host to my.is
 		},
 		async (args) => {
 			const path = String(args['path'] ?? '')
-			if (!path.startsWith('/api/')) {
-				throw new Error('path must begin with /api/.')
+			try {
+				validateIslandRouterApiPath(path)
+			} catch (error) {
+				return structuredErrorResult(
+					'island_router_api_invalid_path',
+					error instanceof Error ? error.message : String(error),
+				)
 			}
 			const result = await islandRouterApi.request({
 				method: args['method'] as 'GET' | 'POST' | 'PUT' | 'DELETE',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Handle invalid `island_router_api_request` paths as MCP tool error results instead of thrown exceptions.
- Reuse the adapter path validator so websocket-routed calls get the same validation messages without reporting expected caller input errors to Sentry.
- Add regression coverage that invalid paths do not call the underlying Island Router adapter.

## Sentry
- Investigated `KODY-HOME-CONNECTOR-1D` (`Error: path must begin with /api/.`) via the Kody `@kentcdodds/sentry-utils` package.
- The event was a handled production error from `island_router_api_request` with only `method,path` arguments and stack frames at `register-island-router-api-tools.ts` and `server.ts`.

## Verification
- `npm run test -- --run packages/home-connector/src/mcp/register-island-router-api-tools.node.test.ts packages/home-connector/src/adapters/island-router-api/index.node.test.ts`
- `npm --prefix packages/home-connector run test`
- `npx oxfmt --check "packages/home-connector/src/mcp/register-island-router-api-tools.ts" "packages/home-connector/src/mcp/register-island-router-api-tools.node.test.ts"`
- `npx oxlint "packages/home-connector/src/mcp/register-island-router-api-tools.ts" "packages/home-connector/src/mcp/register-island-router-api-tools.node.test.ts"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-654ebf41-98f8-4c67-b98b-07633299efa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-654ebf41-98f8-4c67-b98b-07633299efa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved path validation for Island Router API with consistent, structured error responses for invalid paths.

* **Tests**
  * Added test coverage validating path validation requirements and error response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->