### PR TITLE
Gate generic remote connector capabilities by trust

### DIFF
--- a/docs/contributing/architecture/remote-connectors.md
+++ b/docs/contributing/architecture/remote-connectors.md
@@ -95,14 +95,42 @@ External connector authors only need the **WebSocket**.
 For capabilities to be synthesized from a connector, the MCP session must list
 that connector:
 
-- **`remoteConnectors`:** optional array of `{ kind, instanceId }`. When present
-  (including empty), it fully defines the set of remote connectors for that
-  session.
+- **`remoteConnectors`:** optional array of `{ kind, instanceId, trusted? }`.
+  When present (including empty), it fully defines the set of remote connectors
+  for that session.
 - **`homeConnectorId`:** when `remoteConnectors` is omitted, a non-null value
   maps to `{ kind: "home", instanceId: homeConnectorId }`.
 
 Source: `packages/shared/src/chat.ts`,
 `packages/shared/src/remote-connectors.ts`.
+
+## Discovery, status, and execution trust
+
+There are three separate gates:
+
+1. **Wire authentication:** the connector process must connect to the expected
+   WebSocket URL and pass the shared secret for its `{ kind, instanceId }`.
+2. **Session attachment:** the MCP caller context must include the connector
+   reference. If the caller does not attach it, the Worker does not poll or
+   report that connector for the session.
+3. **Capability execution trust:** attached connectors are only synthesized into
+   executable `search` / `execute` capabilities when their effective
+   **`trusted`** flag is true.
+
+Trust defaults are intentionally conservative:
+
+- `homeConnectorId` and attached `kind: "home"` refs are trusted by default for
+  backward compatibility with the shipped home connector.
+- Non-home connector kinds default to **untrusted**. They can still be attached
+  and reported by `meta_list_remote_connector_status`, but their tools are not
+  surfaced as executable capabilities until the caller marks that ref
+  `trusted: true`.
+
+This is not a full third-party authorization model. It is a session-level
+declaration that the caller is willing to let Kody invoke tools discovered from
+that remote MCP process. Shared secrets authenticate the socket; the `trusted`
+flag decides whether discovered tools are executable through Kody's capability
+registry.
 
 ## Capability naming (search / execute)
 
@@ -125,8 +153,8 @@ Source: `packages/shared/src/chat.ts`,
 4. **Heartbeats** if the service stays connected for a long time.
 5. **Operator config:** Worker `REMOTE_CONNECTOR_SECRETS` and/or
    `HOME_CONNECTOR_SHARED_SECRET` for `home`; MCP clients must pass
-   **`remoteConnectors`** / **`homeConnectorId`** so the registry merges your
-   domain.
+   **`remoteConnectors`** / **`homeConnectorId`**. Non-home refs must also set
+   `trusted: true` before Kody synthesizes executable capabilities.
 
 ## Reference implementation
 

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -32,6 +32,16 @@ const remoteConnectorInstanceIdFieldSchema = createSchema<unknown, string>(
 	},
 )
 
+const remoteConnectorTrustedFieldSchema = createSchema<
+	unknown,
+	boolean | undefined
+>((value, context) => {
+	if (value === undefined) return { value: undefined }
+	if (value === null) return { value: undefined }
+	if (typeof value !== 'boolean') return fail('Expected boolean', context.path)
+	return { value }
+})
+
 export const aiModeValues = ['mock', 'remote'] as const
 export type AiMode = (typeof aiModeValues)[number]
 
@@ -63,6 +73,7 @@ export const mcpRepoContextSchema = object({
 const remoteConnectorRefSchema = object({
 	kind: remoteConnectorKindFieldSchema,
 	instanceId: remoteConnectorInstanceIdFieldSchema,
+	trusted: optional(remoteConnectorTrustedFieldSchema),
 })
 
 export const mcpCallerContextSchema = object({

--- a/packages/shared/src/remote-connectors.ts
+++ b/packages/shared/src/remote-connectors.ts
@@ -6,6 +6,18 @@ type McpCallerContext = InferOutput<typeof mcpCallerContextSchema>
 export type RemoteConnectorRef = {
 	kind: string
 	instanceId: string
+	/**
+	 * Whether tools from this connector may be synthesized into executable
+	 * capabilities. `home` defaults to trusted for backward compatibility; other
+	 * connector kinds default to status-only until explicitly trusted.
+	 */
+	trusted?: boolean
+}
+
+export type NormalizedRemoteConnectorRef = {
+	kind: string
+	instanceId: string
+	trusted: boolean
 }
 
 function normalizeKind(kind: string): string {
@@ -16,6 +28,14 @@ function normalizeInstanceId(instanceId: string): string {
 	return instanceId.trim()
 }
 
+function defaultTrustedForKind(kind: string): boolean {
+	return normalizeKind(kind) === 'home'
+}
+
+export function isRemoteConnectorTrusted(ref: RemoteConnectorRef): boolean {
+	return ref.trusted ?? defaultTrustedForKind(ref.kind)
+}
+
 /**
  * Effective remote connectors for MCP execution, in order.
  * When `remoteConnectors` is set (including empty), it wins.
@@ -23,21 +43,25 @@ function normalizeInstanceId(instanceId: string): string {
  */
 export function normalizeRemoteConnectorRefs(
 	context: Pick<McpCallerContext, 'homeConnectorId' | 'remoteConnectors'>,
-): Array<RemoteConnectorRef> {
+): Array<NormalizedRemoteConnectorRef> {
 	if (
 		context.remoteConnectors !== undefined &&
 		context.remoteConnectors !== null
 	) {
 		return context.remoteConnectors
-			.map((ref) => ({
-				kind: normalizeKind(ref.kind),
-				instanceId: normalizeInstanceId(ref.instanceId),
-			}))
+			.map((ref) => {
+				const kind = normalizeKind(ref.kind)
+				return {
+					kind,
+					instanceId: normalizeInstanceId(ref.instanceId),
+					trusted: ref.trusted ?? defaultTrustedForKind(kind),
+				}
+			})
 			.filter((ref) => ref.kind.length > 0 && ref.instanceId.length > 0)
 	}
 	const hid = context.homeConnectorId?.trim()
 	if (!hid) {
 		return []
 	}
-	return [{ kind: 'home', instanceId: hid }]
+	return [{ kind: 'home', instanceId: hid, trusted: true }]
 }

--- a/packages/worker/src/agent-turn/tools.ts
+++ b/packages/worker/src/agent-turn/tools.ts
@@ -166,6 +166,7 @@ export async function createAgentTurnToolSet(input: {
 						state: status.state,
 						connected: status.connected,
 						toolCount: status.toolCount,
+						trusted: status.trusted,
 					})),
 					matches: toSlimStructuredMatches({
 						matches: result.matches,

--- a/packages/worker/src/home/mcp-bridge.ts
+++ b/packages/worker/src/home/mcp-bridge.ts
@@ -1,0 +1,70 @@
+import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { createHomeMcpClient } from '#worker/home/client.ts'
+import {
+	formatHomeConnectorUnavailableMessage,
+	getHomeConnectorStatus,
+} from '#worker/home/status.ts'
+import { type HomeToolDescriptor } from '#worker/home/types.ts'
+import { type McpServerProps } from '#worker/mcp/context.ts'
+import {
+	type NormalizedRemoteConnectorRef,
+	normalizeRemoteConnectorRefs,
+} from '@kody-internal/shared/remote-connectors.ts'
+
+export type HomeMcpBridge = {
+	getCallerContext(): McpServerProps
+	getEnv(): Env
+	requireDomain(): string
+	getHomeClient(): Promise<ReturnType<typeof createHomeMcpClient>>
+}
+
+export function resolveHomeBridgeRef(
+	callerContext: McpServerProps,
+): NormalizedRemoteConnectorRef | null {
+	const refs = normalizeRemoteConnectorRefs(callerContext)
+	const home = refs.find((r) => r.kind === 'home')
+	return home ?? null
+}
+
+export async function createHomeToolErrorResult(
+	agent: HomeMcpBridge,
+	error: unknown,
+): Promise<CallToolResult> {
+	const callerContext = agent.getCallerContext()
+	const homeRef = resolveHomeBridgeRef(callerContext)
+	const status = await getHomeConnectorStatus(agent.getEnv(), homeRef)
+	const fallbackMessage =
+		error instanceof Error ? error.message : 'Unknown home connector error.'
+	const message =
+		status.state === 'connected' && status.trusted
+			? `Home connector request failed: ${fallbackMessage}`
+			: formatHomeConnectorUnavailableMessage(status)
+
+	return {
+		content: [
+			{
+				type: 'text',
+				text: message,
+			},
+		],
+		structuredContent: {
+			error: message,
+			homeConnectorStatus: status,
+		},
+		isError: true,
+	}
+}
+
+export function createHomeToolSummaryText(tools: Array<HomeToolDescriptor>) {
+	if (tools.length === 0) {
+		return 'No home connector tools are available.'
+	}
+
+	return tools
+		.map((tool) => {
+			const title = tool.title?.trim() || tool.name
+			const description = tool.description?.trim() || 'No description.'
+			return `- ${title} (\`${tool.name}\`): ${description}`
+		})
+		.join('\n')
+}

--- a/packages/worker/src/home/mcp.node.test.ts
+++ b/packages/worker/src/home/mcp.node.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import {
+	createHomeToolErrorResult,
+	resolveHomeBridgeRef,
+} from './mcp-bridge.ts'
+
+test('resolveHomeBridgeRef preserves explicit distrust', () => {
+	const ref = resolveHomeBridgeRef(
+		createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			remoteConnectors: [
+				{ kind: 'home', instanceId: 'default', trusted: false },
+			],
+		}),
+	)
+
+	expect(ref).toEqual({
+		kind: 'home',
+		instanceId: 'default',
+		trusted: false,
+	})
+})
+
+test('home bridge trust errors use unavailable status message', async () => {
+	const result = await createHomeToolErrorResult(
+		{
+			getCallerContext() {
+				return createMcpCallerContext({
+					baseUrl: 'https://heykody.dev',
+					remoteConnectors: [
+						{ kind: 'home', instanceId: 'default', trusted: false },
+					],
+				})
+			},
+			getEnv() {
+				return {
+					HOME_CONNECTOR_SESSION: {
+						idFromName(name: string) {
+							return name
+						},
+						get() {
+							return {
+								getSnapshot() {
+									return Promise.resolve({
+										connectorId: 'default',
+										connectedAt: '2026-05-05T00:00:00.000Z',
+										lastSeenAt: '2026-05-05T00:00:01.000Z',
+										tools: [{ name: 'roku_press_key' }],
+									})
+								},
+							}
+						},
+					},
+				} as unknown as Env
+			},
+			requireDomain() {
+				return 'https://heykody.dev'
+			},
+			async getHomeClient() {
+				throw new Error('not used')
+			},
+		},
+		new Error('Home connector is not trusted for this session.'),
+	)
+
+	expect(result.isError).toBe(true)
+	expect(result.structuredContent).toMatchObject({
+		homeConnectorStatus: {
+			trusted: false,
+			state: 'connected',
+		},
+	})
+	expect(result.content[0]).toMatchObject({
+		text: expect.stringContaining('not trusted'),
+	})
+})

--- a/packages/worker/src/home/mcp.ts
+++ b/packages/worker/src/home/mcp.ts
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/cloudflare'
 import { invariant } from '@epic-web/invariant'
-import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker-provider.js'
 import { McpAgent } from 'agents/mcp'
@@ -8,15 +7,14 @@ import { z } from 'zod'
 import { buildSentryOptions } from '#worker/sentry-options.ts'
 import { createHomeMcpClient } from '#worker/home/client.ts'
 import {
-	formatHomeConnectorUnavailableMessage,
-	getHomeConnectorStatus,
-} from '#worker/home/status.ts'
-import { type HomeToolDescriptor } from '#worker/home/types.ts'
+	createHomeToolErrorResult,
+	createHomeToolSummaryText,
+	resolveHomeBridgeRef,
+} from '#worker/home/mcp-bridge.ts'
 import {
 	parseMcpCallerContext,
 	type McpServerProps,
 } from '#worker/mcp/context.ts'
-import { normalizeRemoteConnectorRefs } from '@kody-internal/shared/remote-connectors.ts'
 
 export type HomeMcpState = {}
 export type HomeMcpProps = McpServerProps
@@ -41,57 +39,6 @@ type HomeMcpBridge = {
 	getEnv(): Env
 	requireDomain(): string
 	getHomeClient(): Promise<ReturnType<typeof createHomeMcpClient>>
-}
-
-function resolveHomeBridgeInstanceId(
-	callerContext: McpServerProps,
-): string | null {
-	const refs = normalizeRemoteConnectorRefs(callerContext)
-	const home = refs.find((r) => r.kind === 'home')
-	return home?.instanceId ?? null
-}
-
-async function createHomeToolErrorResult(
-	agent: HomeMcpBridge,
-	error: unknown,
-): Promise<CallToolResult> {
-	const callerContext = agent.getCallerContext()
-	const homeInstanceId = resolveHomeBridgeInstanceId(callerContext)
-	const status = await getHomeConnectorStatus(agent.getEnv(), homeInstanceId)
-	const fallbackMessage =
-		error instanceof Error ? error.message : 'Unknown home connector error.'
-	const message =
-		status.state === 'connected'
-			? `Home connector request failed: ${fallbackMessage}`
-			: formatHomeConnectorUnavailableMessage(status)
-
-	return {
-		content: [
-			{
-				type: 'text',
-				text: message,
-			},
-		],
-		structuredContent: {
-			error: message,
-			homeConnectorStatus: status,
-		},
-		isError: true,
-	}
-}
-
-function createHomeToolSummaryText(tools: Array<HomeToolDescriptor>) {
-	if (tools.length === 0) {
-		return 'No home connector tools are available.'
-	}
-
-	return tools
-		.map((tool) => {
-			const title = tool.title?.trim() || tool.name
-			const description = tool.description?.trim() || 'No description.'
-			return `- ${title} (\`${tool.name}\`): ${description}`
-		})
-		.join('\n')
 }
 
 async function registerBridgeTools(agent: HomeMcpBridge) {
@@ -183,14 +130,19 @@ class HomeMCPBase extends McpAgent<Env, HomeMcpState, HomeMcpProps> {
 	}
 
 	async getHomeClient() {
-		const homeInstanceId = resolveHomeBridgeInstanceId(this.getCallerContext())
-		if (!homeInstanceId) {
+		const homeRef = resolveHomeBridgeRef(this.getCallerContext())
+		if (!homeRef) {
 			throw new Error(
 				'No home connector is associated with this MCP caller context.',
 			)
 		}
+		if (!homeRef.trusted) {
+			throw new Error(
+				'Home connector is not trusted for capability execution in this session.',
+			)
+		}
 
-		return createHomeMcpClient(this.env, homeInstanceId)
+		return createHomeMcpClient(this.env, homeRef.instanceId)
 	}
 }
 

--- a/packages/worker/src/home/status.ts
+++ b/packages/worker/src/home/status.ts
@@ -172,14 +172,16 @@ export async function getRemoteConnectorStatus(
 
 export async function getHomeConnectorStatus(
 	env: Env,
-	connectorId: string | null,
+	connector: string | RemoteConnectorRef | null,
 ): Promise<HomeConnectorStatus> {
-	if (!connectorId) {
+	if (!connector) {
 		return createUnavailableStatus()
 	}
 
-	return getRemoteConnectorStatus(env, {
-		kind: 'home',
-		instanceId: connectorId,
-	})
+	const ref =
+		typeof connector === 'string'
+			? { kind: 'home', instanceId: connector }
+			: { ...connector, kind: 'home' }
+
+	return getRemoteConnectorStatus(env, ref)
 }

--- a/packages/worker/src/home/status.ts
+++ b/packages/worker/src/home/status.ts
@@ -1,4 +1,7 @@
-import { type RemoteConnectorRef } from '@kody-internal/shared/remote-connectors.ts'
+import {
+	isRemoteConnectorTrusted,
+	type RemoteConnectorRef,
+} from '@kody-internal/shared/remote-connectors.ts'
 import { createRemoteConnectorMcpClient } from './client.ts'
 import { type HomeConnectorSnapshot } from './types.ts'
 
@@ -6,6 +9,7 @@ export type HomeConnectorStatus = {
 	state: 'connected' | 'disconnected' | 'unavailable' | 'error'
 	connectorKind: string
 	connectorId: string | null
+	trusted: boolean
 	connected: boolean
 	connectedAt: string | null
 	lastSeenAt: string | null
@@ -24,22 +28,29 @@ function connectorLabel(kind: string, connectorId: string) {
 
 function createConnectedStatus(
 	snapshot: HomeConnectorSnapshot,
-	kind: string,
+	ref: RemoteConnectorRef,
 ): HomeConnectorStatus {
 	const resolvedKind =
-		(snapshot.connectorKind ?? kind).trim().toLowerCase() || 'home'
+		(snapshot.connectorKind ?? ref.kind).trim().toLowerCase() || 'home'
 	const toolCount = snapshot.tools.length
 	const label = connectorLabel(resolvedKind, snapshot.connectorId)
+	const trusted = isRemoteConnectorTrusted({
+		...ref,
+		kind: resolvedKind,
+	})
 	return {
 		state: 'connected',
 		connectorKind: resolvedKind,
 		connectorId: snapshot.connectorId,
+		trusted,
 		connected: true,
 		connectedAt: snapshot.connectedAt,
 		lastSeenAt: snapshot.lastSeenAt,
 		toolCount,
 		message:
-			toolCount > 0
+			!trusted && toolCount > 0
+				? `The ${label} is connected and exposing ${toolCount} tool${toolCount === 1 ? '' : 's'}, but it is not trusted for capability execution in this session.`
+				: toolCount > 0
 				? `The ${label} is connected and exposing ${toolCount} tool${toolCount === 1 ? '' : 's'}.`
 				: `The ${label} is connected, but it has not exposed any tools yet.`,
 		error: null,
@@ -55,6 +66,7 @@ function createDisconnectedStatus(
 		state: 'disconnected',
 		connectorKind: k,
 		connectorId: ref.instanceId,
+		trusted: isRemoteConnectorTrusted(ref),
 		connected: false,
 		connectedAt: null,
 		lastSeenAt: null,
@@ -69,6 +81,7 @@ function createUnavailableStatus(): HomeConnectorStatus {
 		state: 'unavailable',
 		connectorKind: 'home',
 		connectorId: null,
+		trusted: true,
 		connected: false,
 		connectedAt: null,
 		lastSeenAt: null,
@@ -89,6 +102,7 @@ function createErrorStatus(
 		state: 'error',
 		connectorKind: k,
 		connectorId: ref.instanceId,
+		trusted: isRemoteConnectorTrusted(ref),
 		connected: false,
 		connectedAt: null,
 		lastSeenAt: null,
@@ -110,6 +124,9 @@ export function formatRemoteConnectorUnavailableMessage(
 	const isHome = status.connectorKind === 'home'
 	switch (status.state) {
 		case 'connected':
+			if (!status.trusted) {
+				return `${status.message} Ask the user whether this connector should be trusted before searching or using its capabilities.`
+			}
 			if (status.toolCount > 0) {
 				return status.message
 			}
@@ -147,7 +164,7 @@ export async function getRemoteConnectorStatus(
 		if (!snapshot) {
 			return createDisconnectedStatus(ref)
 		}
-		return createConnectedStatus(snapshot, ref.kind)
+		return createConnectedStatus(snapshot, ref)
 	} catch (error) {
 		return createErrorStatus(ref, error)
 	}

--- a/packages/worker/src/mcp/capabilities/home/index.ts
+++ b/packages/worker/src/mcp/capabilities/home/index.ts
@@ -1,4 +1,7 @@
-import { type RemoteConnectorRef } from '@kody-internal/shared/remote-connectors.ts'
+import {
+	isRemoteConnectorTrusted,
+	type RemoteConnectorRef,
+} from '@kody-internal/shared/remote-connectors.ts'
 import { defineCapability } from '#mcp/capabilities/define-capability.ts'
 import { defineDomain } from '#mcp/capabilities/define-domain.ts'
 import { type CapabilityDomain } from '#mcp/capabilities/domain-metadata.ts'
@@ -159,6 +162,8 @@ export async function synthesizeRemoteToolDomain(
 	ref: RemoteConnectorRef,
 	allRefs: ReadonlyArray<RemoteConnectorRef>,
 ): Promise<SynthesizedRemoteConnectorDomain | null> {
+	if (!isRemoteConnectorTrusted(ref)) return null
+
 	const client = createRemoteConnectorMcpClient(env, ref.kind, ref.instanceId)
 	const snapshot = await client.getSnapshot()
 	if (!snapshot || snapshot.tools.length === 0) return null

--- a/packages/worker/src/mcp/capabilities/home/index.ts
+++ b/packages/worker/src/mcp/capabilities/home/index.ts
@@ -164,18 +164,19 @@ export async function synthesizeRemoteToolDomain(
 ): Promise<SynthesizedRemoteConnectorDomain | null> {
 	if (!isRemoteConnectorTrusted(ref)) return null
 
+	const trustedRefs = allRefs.filter(isRemoteConnectorTrusted)
 	const client = createRemoteConnectorMcpClient(env, ref.kind, ref.instanceId)
 	const snapshot = await client.getSnapshot()
 	if (!snapshot || snapshot.tools.length === 0) return null
 
 	const domainId = remoteConnectorDomainId(ref)
-	const capabilityPrefix = remoteConnectorCapabilityPrefix(ref, allRefs)
+	const capabilityPrefix = remoteConnectorCapabilityPrefix(ref, trustedRefs)
 	const k = ref.kind.trim().toLowerCase()
 	const isOnlyBuiltinHomeDomain =
 		k === 'home' &&
-		allRefs.length === 1 &&
-		allRefs[0]?.kind === 'home' &&
-		allRefs[0]?.instanceId.trim() === 'default'
+		trustedRefs.length === 1 &&
+		trustedRefs[0]?.kind === 'home' &&
+		trustedRefs[0]?.instanceId.trim() === 'default'
 
 	const domainIdForCapabilities: CapabilityDomain = isOnlyBuiltinHomeDomain
 		? 'home'

--- a/packages/worker/src/mcp/capabilities/home/remote-tool-domain.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/home/remote-tool-domain.node.test.ts
@@ -1,0 +1,76 @@
+import { type HomeConnectorSnapshot } from '#worker/home/types.ts'
+import { expect, test } from 'vitest'
+import { synthesizeRemoteToolDomain } from './index.ts'
+
+function createEnvWithSnapshot(snapshot: HomeConnectorSnapshot) {
+	return {
+		HOME_CONNECTOR_SESSION: {
+			idFromName(name: string) {
+				return name
+			},
+			get() {
+				return {
+					async getSnapshot() {
+						return snapshot
+					},
+				}
+			},
+		},
+	} as unknown as Env
+}
+
+function stubSnapshot(): HomeConnectorSnapshot {
+	return {
+		connectorKind: 'github',
+		connectorId: 'work',
+		connectedAt: '2026-05-05T00:00:00.000Z',
+		lastSeenAt: '2026-05-05T00:00:01.000Z',
+		tools: [
+			{
+				name: 'list_repos',
+				description: 'List repositories.',
+				inputSchema: { type: 'object', properties: {} },
+				annotations: { readOnlyHint: true },
+			},
+		],
+	}
+}
+
+test('does not synthesize capabilities for untrusted generic connectors', async () => {
+	const ref = { kind: 'github', instanceId: 'work', trusted: false }
+
+	const domain = await synthesizeRemoteToolDomain(
+		createEnvWithSnapshot(stubSnapshot()),
+		ref,
+		[ref],
+	)
+
+	expect(domain).toBeNull()
+})
+
+test('synthesizes distinct capability names for trusted generic connectors', async () => {
+	const ref = { kind: 'github', instanceId: 'work', trusted: true }
+
+	const domain = await synthesizeRemoteToolDomain(
+		createEnvWithSnapshot(stubSnapshot()),
+		ref,
+		[ref],
+	)
+
+	expect(domain?.domain.name).toBe('remote:github:work')
+	expect(domain?.domain.capabilities).toEqual([
+		expect.objectContaining({
+			name: 'github_work_list_repos',
+			domain: 'remote:github:work',
+			readOnly: true,
+			destructive: false,
+		}),
+	])
+	expect(domain?.bindings).toMatchObject({
+		github_work_list_repos: {
+			kind: 'github',
+			instanceId: 'work',
+			mcpToolName: 'list_repos',
+		},
+	})
+})

--- a/packages/worker/src/mcp/capabilities/home/remote-tool-domain.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/home/remote-tool-domain.node.test.ts
@@ -74,3 +74,34 @@ test('synthesizes distinct capability names for trusted generic connectors', asy
 		},
 	})
 })
+
+test('keeps legacy home naming when only executable connector is home default', async () => {
+	const ref = { kind: 'home', instanceId: 'default', trusted: true }
+	const untrustedRef = { kind: 'github', instanceId: 'work', trusted: false }
+	const snapshot: HomeConnectorSnapshot = {
+		connectorId: 'default',
+		connectedAt: '2026-05-05T00:00:00.000Z',
+		lastSeenAt: '2026-05-05T00:00:01.000Z',
+		tools: [
+			{
+				name: 'roku_press_key',
+				description: 'Press a Roku key.',
+				inputSchema: { type: 'object', properties: {} },
+			},
+		],
+	}
+
+	const domain = await synthesizeRemoteToolDomain(
+		createEnvWithSnapshot(snapshot),
+		ref,
+		[ref, untrustedRef],
+	)
+
+	expect(domain?.domain.name).toBe('home')
+	expect(domain?.domain.capabilities).toEqual([
+		expect.objectContaining({
+			name: 'home_roku_press_key',
+			domain: 'home',
+		}),
+	])
+})

--- a/packages/worker/src/mcp/capabilities/meta/meta-get-home-connector-status.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-get-home-connector-status.node.test.ts
@@ -82,3 +82,45 @@ test('meta_get_home_connector_status reports a disconnected connector', async ()
 	expect(result.message).toEqual(expect.any(String))
 	expect(result.message.length).toBeGreaterThan(0)
 })
+
+test('meta_get_home_connector_status preserves explicit home distrust', async () => {
+	const result = await metaGetHomeConnectorStatusCapability.handler(
+		{},
+		{
+			env: {
+				HOME_CONNECTOR_SESSION: {
+					idFromName(name: string) {
+						return name
+					},
+					get() {
+						return {
+							getSnapshot() {
+								return Promise.resolve({
+									connectorId: 'default',
+									connectedAt: '2026-03-25T00:00:00.000Z',
+									lastSeenAt: '2026-03-25T00:00:01.000Z',
+									tools: [{ name: 'roku_press_key' }],
+								})
+							},
+						}
+					},
+				},
+			} as unknown as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				remoteConnectors: [
+					{ kind: 'home', instanceId: 'default', trusted: false },
+				],
+			}),
+		},
+	)
+
+	expect(result).toMatchObject({
+		status: 'connected',
+		connected: true,
+		connector_id: 'default',
+		trusted: false,
+		tool_count: 1,
+	})
+	expect(result.message).toContain('not trusted')
+})

--- a/packages/worker/src/mcp/capabilities/meta/meta-get-home-connector-status.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-get-home-connector-status.ts
@@ -8,6 +8,7 @@ const outputSchema = z.object({
 	status: z.enum(['connected', 'disconnected', 'unavailable', 'error']),
 	connected: z.boolean(),
 	connector_id: z.string().nullable(),
+	trusted: z.boolean(),
 	connected_at: z.string().nullable(),
 	last_seen_at: z.string().nullable(),
 	tool_count: z.number().int().nonnegative(),
@@ -39,14 +40,12 @@ export const metaGetHomeConnectorStatusCapability = defineDomainCapability(
 		async handler(_args, ctx) {
 			const refs = normalizeRemoteConnectorRefs(ctx.callerContext)
 			const homeRef = refs.find((r) => r.kind === 'home')
-			const status = await getHomeConnectorStatus(
-				ctx.env,
-				homeRef?.instanceId ?? null,
-			)
+			const status = await getHomeConnectorStatus(ctx.env, homeRef ?? null)
 			return {
 				status: status.state,
 				connected: status.connected,
 				connector_id: status.connectorId,
+				trusted: status.trusted,
 				connected_at: status.connectedAt,
 				last_seen_at: status.lastSeenAt,
 				tool_count: status.toolCount,

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-remote-connector-status.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-remote-connector-status.node.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { metaListRemoteConnectorStatusCapability } from './meta-list-remote-connector-status.ts'
+
+function createEnvWithSnapshots(
+	snapshots: Record<
+		string,
+		{
+			connectorKind?: string
+			connectorId: string
+			connectedAt: string
+			lastSeenAt: string
+			tools: Array<{ name: string }>
+		} | null
+	>,
+) {
+	return {
+		HOME_CONNECTOR_SESSION: {
+			idFromName(name: string) {
+				return name
+			},
+			get(id: string) {
+				return {
+					getSnapshot() {
+						return Promise.resolve(snapshots[id] ?? null)
+					},
+				}
+			},
+		},
+	} as unknown as Env
+}
+
+test('meta_list_remote_connector_status reports trust for attached connectors', async () => {
+	const result = await metaListRemoteConnectorStatusCapability.handler(
+		{},
+		{
+			env: createEnvWithSnapshots({
+				'calendar:primary': {
+					connectorKind: 'calendar',
+					connectorId: 'primary',
+					connectedAt: '2026-05-05T00:00:00.000Z',
+					lastSeenAt: '2026-05-05T00:00:01.000Z',
+					tools: [{ name: 'events_list' }],
+				},
+				default: {
+					connectorId: 'default',
+					connectedAt: '2026-05-05T00:00:00.000Z',
+					lastSeenAt: '2026-05-05T00:00:01.000Z',
+					tools: [{ name: 'roku_press_key' }],
+				},
+			}),
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				remoteConnectors: [
+					{ kind: 'calendar', instanceId: 'primary' },
+					{ kind: 'home', instanceId: 'default' },
+				],
+			}),
+		},
+	)
+
+	expect(result.connectors).toEqual([
+		expect.objectContaining({
+			connector_kind: 'calendar',
+			connector_instance_id: 'primary',
+			trusted: false,
+			status: 'connected',
+			tool_count: 1,
+		}),
+		expect.objectContaining({
+			connector_kind: 'home',
+			connector_instance_id: 'default',
+			trusted: true,
+			status: 'connected',
+			tool_count: 1,
+		}),
+	])
+	expect(result.connectors[0]?.message).toContain('not trusted')
+})

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-remote-connector-status.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-remote-connector-status.ts
@@ -7,6 +7,7 @@ import { normalizeRemoteConnectorRefs } from '@kody-internal/shared/remote-conne
 const connectorStatusSchema = z.object({
 	connector_kind: z.string(),
 	connector_instance_id: z.string(),
+	trusted: z.boolean(),
 	status: z.enum(['connected', 'disconnected', 'unavailable', 'error']),
 	connected: z.boolean(),
 	connected_at: z.string().nullable(),
@@ -48,6 +49,7 @@ export const metaListRemoteConnectorStatusCapability = defineDomainCapability(
 					return {
 						connector_kind: s.connectorKind,
 						connector_instance_id: s.connectorId ?? ref.instanceId,
+						trusted: s.trusted,
 						status: s.state,
 						connected: s.connected,
 						connected_at: s.connectedAt,

--- a/packages/worker/src/mcp/capabilities/registry.ts
+++ b/packages/worker/src/mcp/capabilities/registry.ts
@@ -33,10 +33,13 @@ export async function getCapabilityRegistryForContext(input: {
 	callerContext: McpCallerContext
 }): Promise<BuiltCapabilityRegistry> {
 	const refs = normalizeRemoteConnectorRefs(input.callerContext)
+	const trustedRefs = refs.filter((ref) => ref.trusted)
 	const synthesizedDomains: Array<SynthesizedRemoteConnectorDomain['domain']> =
 		[]
 	const settled = await Promise.allSettled(
-		refs.map((ref) => synthesizeRemoteToolDomain(input.env, ref, refs)),
+		trustedRefs.map((ref) =>
+			synthesizeRemoteToolDomain(input.env, ref, trustedRefs),
+		),
 	)
 	for (const [index, outcome] of settled.entries()) {
 		if (outcome.status === 'fulfilled' && outcome.value) {
@@ -44,7 +47,7 @@ export async function getCapabilityRegistryForContext(input: {
 			continue
 		}
 		if (outcome.status === 'rejected') {
-			const ref = refs[index]
+			const ref = trustedRefs[index]
 			console.error(
 				`[getCapabilityRegistryForContext] synthesizeRemoteToolDomain failed for ${ref?.kind ?? '?'}:${ref?.instanceId ?? '?'}`,
 				outcome.reason,

--- a/packages/worker/src/mcp/context.node.test.ts
+++ b/packages/worker/src/mcp/context.node.test.ts
@@ -45,3 +45,18 @@ test('parseMcpCallerContext validates caller context shape', () => {
 	expect(parsed.remoteConnectors ?? null).toBeNull()
 	expect(parsed.repoContext ?? null).toBeNull()
 })
+
+test('parseMcpCallerContext accepts remote connector trust flag', () => {
+	const parsed = parseMcpCallerContext({
+		baseUrl: 'https://example.com',
+		remoteConnectors: [
+			{ kind: 'generic', instanceId: 'alpha', trusted: true },
+			{ kind: 'other', instanceId: 'beta' },
+		],
+	})
+
+	expect(parsed.remoteConnectors).toEqual([
+		{ kind: 'generic', instanceId: 'alpha', trusted: true },
+		{ kind: 'other', instanceId: 'beta' },
+	])
+})

--- a/packages/worker/src/mcp/context.ts
+++ b/packages/worker/src/mcp/context.ts
@@ -22,7 +22,12 @@ export function createMcpCallerContext(input: {
 		baseUrl: input.baseUrl,
 		user: input.user ?? null,
 		homeConnectorId: input.homeConnectorId ?? null,
-		remoteConnectors: input.remoteConnectors ?? null,
+		remoteConnectors:
+			input.remoteConnectors?.map((ref) => ({
+				kind: ref.kind,
+				instanceId: ref.instanceId,
+				trusted: ref.trusted,
+			})) ?? null,
 		storageContext: input.storageContext ?? null,
 		repoContext: input.repoContext ?? null,
 	}

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -88,6 +88,7 @@ export type SearchResultStructuredContent = {
 		state: string
 		connected: boolean
 		toolCount: number
+		trusted: boolean
 	}>
 }
 

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -1184,7 +1184,7 @@ type SearchRowsAndRegistry = OptionalSearchRowsResult & {
 }
 
 function shouldIncludeRemoteConnectorStatus(status: HomeConnectorStatus) {
-	return status.state !== 'connected' || status.toolCount === 0
+	return !status.trusted || status.state !== 'connected' || status.toolCount === 0
 }
 
 function serializeRemoteConnectorStatus(status: HomeConnectorStatus): {
@@ -1193,6 +1193,7 @@ function serializeRemoteConnectorStatus(status: HomeConnectorStatus): {
 	state: string
 	connected: boolean
 	toolCount: number
+	trusted: boolean
 } {
 	return {
 		connectorKind: status.connectorKind,
@@ -1200,6 +1201,7 @@ function serializeRemoteConnectorStatus(status: HomeConnectorStatus): {
 		state: status.state,
 		connected: status.connected,
 		toolCount: status.toolCount,
+		trusted: status.trusted,
 	}
 }
 
@@ -1725,6 +1727,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 						state: string
 						connected: boolean
 						toolCount: number
+						trusted: boolean
 					}
 					remoteConnectorStatuses?: Array<{
 						connectorKind: string
@@ -1732,6 +1735,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 						state: string
 						connected: boolean
 						toolCount: number
+						trusted: boolean
 					}>
 				} = {
 					matches: outcome.result.matches,

--- a/packages/worker/src/remote-connector/remote-connectors-shared.node.test.ts
+++ b/packages/worker/src/remote-connector/remote-connectors-shared.node.test.ts
@@ -7,7 +7,7 @@ test('normalizeRemoteConnectorRefs maps homeConnectorId when remoteConnectors un
 			homeConnectorId: 'living-room',
 			remoteConnectors: undefined,
 		}),
-	).toEqual([{ kind: 'home', instanceId: 'living-room' }])
+	).toEqual([{ kind: 'home', instanceId: 'living-room', trusted: true }])
 })
 
 test('normalizeRemoteConnectorRefs uses remoteConnectors when provided', () => {
@@ -16,12 +16,14 @@ test('normalizeRemoteConnectorRefs uses remoteConnectors when provided', () => {
 			homeConnectorId: 'ignored',
 			remoteConnectors: [
 				{ kind: 'Home', instanceId: '  a  ' },
-				{ kind: 'custom', instanceId: 'x' },
+				{ kind: 'custom', instanceId: 'x', trusted: true },
+				{ kind: 'other', instanceId: 'y' },
 			],
 		}),
 	).toEqual([
-		{ kind: 'home', instanceId: 'a' },
-		{ kind: 'custom', instanceId: 'x' },
+		{ kind: 'home', instanceId: 'a', trusted: true },
+		{ kind: 'custom', instanceId: 'x', trusted: true },
+		{ kind: 'other', instanceId: 'y', trusted: false },
 	])
 })
 

--- a/packages/worker/src/remote-connector/remote-domain-id.node.test.ts
+++ b/packages/worker/src/remote-connector/remote-domain-id.node.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from 'vitest'
+import {
+	remoteConnectorCapabilityPrefix,
+	remoteConnectorDomainId,
+} from './remote-domain-id.ts'
+
+test('remote connector domain ids slug instance ids and preserve kind', () => {
+	expect(
+		remoteConnectorDomainId({
+			kind: 'calendar',
+			instanceId: 'Work Calendar!',
+			trusted: true,
+		}),
+	).toBe('remote:calendar:Work_Calendar')
+})
+
+test('capability prefix keeps only default home connector on legacy prefix', () => {
+	const ref = { kind: 'home', instanceId: 'default', trusted: true }
+
+	expect(remoteConnectorCapabilityPrefix(ref, [ref])).toBe('home')
+	expect(
+		remoteConnectorCapabilityPrefix(ref, [
+			ref,
+			{ kind: 'calendar', instanceId: 'work', trusted: true },
+		]),
+	).toBe('home_default')
+})
+
+test('capability prefix scopes generic connectors by kind and instance', () => {
+	expect(
+		remoteConnectorCapabilityPrefix(
+			{ kind: 'calendar', instanceId: 'Work Calendar!', trusted: true },
+			[{ kind: 'calendar', instanceId: 'Work Calendar!', trusted: true }],
+		),
+	).toBe('calendar_Work_Calendar')
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add an explicit `trusted` flag to remote connector refs, with home connectors trusted by default and non-home connectors status-only unless opted in.
- Gate generic remote connector capability synthesis on trust while preserving status/discovery reporting.
- Document the remote connector model and add focused tests for trust, naming, status, and caller-context parsing.
- Keep untrusted/status-only refs out of executable connector naming decisions and preserve explicit home distrust in status reporting.
- Apply the same trust gate to the internal raw home MCP bridge.

## Tests

- `npx vitest run --project node-unit packages/worker/src/remote-connector/remote-connectors-shared.node.test.ts packages/worker/src/remote-connector/remote-domain-id.node.test.ts packages/worker/src/mcp/capabilities/home/remote-tool-domain.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-list-remote-connector-status.node.test.ts packages/worker/src/mcp/context.node.test.ts`
- `npx vitest run --project node-unit packages/worker/src/home/mcp.node.test.ts packages/worker/src/mcp/capabilities/home/remote-tool-domain.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-get-home-connector-status.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-list-remote-connector-status.node.test.ts packages/worker/src/remote-connector/remote-connectors-shared.node.test.ts packages/worker/src/remote-connector/remote-domain-id.node.test.ts packages/worker/src/mcp/context.node.test.ts`
- `npm run typecheck`
- `npm run test`

Closes #122
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e446805e-e1ea-4ab7-894f-7f3ae83a6c18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e446805e-e1ea-4ab7-894f-7f3ae83a6c18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

