### PR TITLE
Fix production deploy blockers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,18 +110,19 @@ jobs:
           set -euo pipefail
           node tools/ci/production-resources.ts ensure --out-config packages/worker/wrangler-production.generated.json | tee -a "$GITHUB_OUTPUT"
 
-      - name: 🔐 Sync Cloudflare Secrets (bulk)
+      - name: 🔐 Sync Cloudflare Secrets
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
+          PRODUCTION_WORKER_NAME:
+            ${{ steps.resources.outputs.production_worker_name }}
           COOKIE_SECRET: ${{ secrets.COOKIE_SECRET }}
           SECRET_STORE_KEY: ${{ secrets.SECRET_STORE_KEY }}
           AI_GATEWAY_ID: ${{ secrets.AI_GATEWAY_ID }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           CAPABILITY_REINDEX_SECRET: ${{ secrets.CAPABILITY_REINDEX_SECRET }}
         run: >
-          node tools/ci/sync-worker-secrets.ts --env production --config
-          "$WRANGLER_CONFIG" --set-from-env COOKIE_SECRET
+          node tools/ci/sync-worker-secrets.ts --name "$PRODUCTION_WORKER_NAME"
+          --put-individually --set-from-env COOKIE_SECRET
           --set-from-env-optional SECRET_STORE_KEY --set-from-env AI_GATEWAY_ID
           --set-from-env-optional SENTRY_DSN --set-from-env-optional
           CLOUDFLARE_API_TOKEN --set-from-env-optional CAPABILITY_REINDEX_SECRET

--- a/docs/contributing/cloudflare-offerings.md
+++ b/docs/contributing/cloudflare-offerings.md
@@ -40,6 +40,10 @@ Cloudflare's API token UI changes over time, but the shape is stable:
 Recommended baseline permissions for this template (deploy + existing D1/KV):
 
 - `Workers Scripts:Edit` (deploy, update, delete preview Workers)
+- `Workers Tail:Read` and Durable Object binding access if the token UI exposes
+  those separately; deploys that bind Durable Objects fail with Cloudflare
+  error `10023` (`durable object bindings require durable object bind
+  permission`) without Durable Object binding access
 - `Workers KV Storage:Edit` (OAuth/session KV)
 - `D1:Edit` (migrations, database operations)
 

--- a/docs/contributing/cloudflare-offerings.md
+++ b/docs/contributing/cloudflare-offerings.md
@@ -41,9 +41,9 @@ Recommended baseline permissions for this template (deploy + existing D1/KV):
 
 - `Workers Scripts:Edit` (deploy, update, delete preview Workers)
 - `Workers Tail:Read` and Durable Object binding access if the token UI exposes
-  those separately; deploys that bind Durable Objects fail with Cloudflare
-  error `10023` (`durable object bindings require durable object bind
-  permission`) without Durable Object binding access
+  those separately; deploys that bind Durable Objects fail with Cloudflare error
+  `10023` (`durable object bindings require durable object bind permission`)
+  without Durable Object binding access
 - `Workers KV Storage:Edit` (OAuth/session KV)
 - `D1:Edit` (migrations, database operations)
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -112,9 +112,9 @@ from `packages/worker/.env`.
 
 Configure these GitHub Actions secrets and variables for workflows:
 
-- `CLOUDFLARE_API_TOKEN` (Workers deploy + Durable Objects bind + D1 edit
-  access on the correct account; also reused for remote AI and Cloudflare API
-  workflows that run with account secrets + package workflows)
+- `CLOUDFLARE_API_TOKEN` (Workers deploy + Durable Objects bind + D1 edit access
+  on the correct account; also reused for remote AI and Cloudflare API workflows
+  that run with account secrets + package workflows)
 - `COOKIE_SECRET` (same format as local)
 - `SECRET_STORE_KEY` (same format as local; required for deploys)
 - `APP_BASE_URL` (optional GitHub Actions **variable**, used by the production

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -112,9 +112,9 @@ from `packages/worker/.env`.
 
 Configure these GitHub Actions secrets and variables for workflows:
 
-- `CLOUDFLARE_API_TOKEN` (Workers deploy + D1 edit access on the correct
-  account; also reused for remote AI and Cloudflare API workflows that run with
-  account secrets + package workflows)
+- `CLOUDFLARE_API_TOKEN` (Workers deploy + Durable Objects bind + D1 edit
+  access on the correct account; also reused for remote AI and Cloudflare API
+  workflows that run with account secrets + package workflows)
 - `COOKIE_SECRET` (same format as local)
 - `SECRET_STORE_KEY` (same format as local; required for deploys)
 - `APP_BASE_URL` (optional GitHub Actions **variable**, used by the production
@@ -144,10 +144,14 @@ How to get/set each value:
 
 - `CLOUDFLARE_API_TOKEN`
   - In Cloudflare Dashboard, create an API Token with permissions to deploy
-    Workers and edit D1 on the target account. This is the same token to reuse
-    for remote AI and Cloudflare API workflows that run with account secrets +
-    skills; when you do, also include the product permissions needed for those
-    APIs.
+    Workers, bind Durable Objects, edit D1, and edit KV on the target account.
+    This is the same token to reuse for remote AI and Cloudflare API workflows
+    that run with account secrets + skills; when you do, also include the
+    product permissions needed for those APIs.
+  - Preview and production Workers both bind Durable Objects. If the token is
+    missing the Durable Objects binding permission, Wrangler fails deploys with
+    Cloudflare error `10023` and text like
+    `durable object bindings require durable object bind permission`.
   - In GitHub: `Settings` → `Secrets and variables` → `Actions` →
     `New repository secret`.
 - `COOKIE_SECRET`
@@ -232,4 +236,5 @@ How to get/set each value:
 Preview deploys for pull requests create a separate Worker per PR named
 `<app-name>-pr-<number>` (for kody: `kody-pr-123`) plus one Worker per mock
 service named `<app-name>-pr-<number>-mock-<service>`. The same
-`CLOUDFLARE_API_TOKEN` must be able to create/update and delete those Workers.
+`CLOUDFLARE_API_TOKEN` must be able to create/update/delete those Workers and
+bind their Durable Objects.

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -131,6 +131,48 @@ test('fetch gateway expands placeholders in form-urlencoded bodies', async () =>
 	}
 })
 
+test('fetch gateway allows absolute placeholder-free requests without props', async () => {
+	const request = new Request('https://api.example.com/status', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({ ok: true }),
+	})
+
+	const transformed = await expandSecretPlaceholders({
+		request,
+		props: undefined,
+		env,
+	})
+
+	expect(transformed.url).toBe('https://api.example.com/status')
+	expect(await transformed.text()).toBe(JSON.stringify({ ok: true }))
+})
+
+test('fetch gateway still requires baseUrl for path-only requests', async () => {
+	// Node's Request rejects path-only URLs; workerd allows them for codemode outbound fetch.
+	const request = {
+		url: '/',
+		method: 'GET',
+		headers: new Headers(),
+		redirect: 'follow',
+		credentials: 'same-origin',
+		mode: 'cors',
+		cache: 'default',
+		integrity: '',
+		keepalive: false,
+		signal: undefined,
+		text: async () => '',
+	} as unknown as Request
+
+	await expect(
+		expandSecretPlaceholders({ request, props: undefined, env }),
+	).rejects.toThrow(
+		'Fetch gateway could not resolve request URL "/" without a baseUrl.',
+	)
+})
+
 test('fetch gateway resolves path-only URLs against baseUrl', async () => {
 	// Node's Request rejects path-only URLs; workerd allows them for codemode outbound fetch.
 	const request = {

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -87,9 +87,15 @@ export async function expandSecretPlaceholders(input: {
 	}
 	let requestedHost = ''
 	if (hasReferencedSecrets) {
+		const secretApprovalBaseUrl = baseUrl
+		if (!secretApprovalBaseUrl) {
+			throw new Error(
+				'Fetch gateway requires a non-empty baseUrl in props when expanding secret placeholders.',
+			)
+		}
 		const nextUrl = resolveRequestUrlForFetchGateway(
 			replaceSecretPlaceholders(input.request.url, replacements),
-			baseUrl,
+			secretApprovalBaseUrl,
 		)
 		requestedHost = readRequestedHost(nextUrl)
 		if (!requestedHost) {
@@ -99,7 +105,7 @@ export async function expandSecretPlaceholders(input: {
 		}
 		const normalizedHost = normalizeHost(requestedHost)
 		const missingApprovals = await collectHostApprovalEntries({
-			baseUrl,
+			baseUrl: secretApprovalBaseUrl,
 			props,
 			requestedHost,
 			normalizedHost,
@@ -148,10 +154,7 @@ export async function expandSecretPlaceholders(input: {
  * Codemode / sandboxed fetch may emit path-only URLs (e.g. `/`, `/core/log`).
  * Workers `Request` requires an absolute URL string; resolve against the app origin.
  */
-function resolveRequestUrlForFetchGateway(
-	url: string,
-	baseUrl: string | null,
-) {
+function resolveRequestUrlForFetchGateway(url: string, baseUrl: string | null) {
 	const trimmed = url.trim()
 	if (!trimmed) {
 		throw new Error('Fetch gateway received an empty request URL.')

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -40,20 +40,18 @@ export class CodemodeFetchGateway extends WorkerEntrypoint<
 
 export async function expandSecretPlaceholders(input: {
 	request: Request
-	props: FetchGatewayProps
+	props: Partial<FetchGatewayProps> | null | undefined
 	env: Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'>
 }) {
 	const headers = new Headers(input.request.headers)
 	const requestBody = await readRequestBody(input.request)
+	const props = input.props ?? {}
 	const resolvedSecrets: Array<{
 		referenced: ReferencedSecret
 		resolved: ResolvedSecret
 	}> = []
 	const replacements = new Map<string, string>()
-	const baseUrl = input.props.baseUrl.trim()
-	if (!baseUrl) {
-		throw new Error('Fetch gateway requires a non-empty baseUrl in props.')
-	}
+	const baseUrl = normalizeFetchGatewayBaseUrl(props.baseUrl)
 	const referencedSecrets = dedupeReferencedSecrets([
 		...collectReferencedSecrets([
 			input.request.url,
@@ -63,15 +61,20 @@ export async function expandSecretPlaceholders(input: {
 	])
 	const hasReferencedSecrets = referencedSecrets.length > 0
 	if (hasReferencedSecrets) {
-		ensureFetchAllowed(input.props)
+		ensureFetchAllowed(props)
+		if (!baseUrl) {
+			throw new Error(
+				'Fetch gateway requires a non-empty baseUrl in props when expanding secret placeholders.',
+			)
+		}
 	}
 	for (const referenced of referencedSecrets) {
 		const resolved = await resolveSecret({
 			env: input.env,
-			userId: input.props.userId!,
+			userId: props.userId!,
 			name: referenced.name,
 			scope: referenced.scope,
-			storageContext: input.props.storageContext,
+			storageContext: props.storageContext ?? null,
 		})
 		if (!resolved.found || typeof resolved.value !== 'string') {
 			throw new Error(createMissingSecretMessage(referenced.name))
@@ -96,7 +99,8 @@ export async function expandSecretPlaceholders(input: {
 		}
 		const normalizedHost = normalizeHost(requestedHost)
 		const missingApprovals = await collectHostApprovalEntries({
-			props: input.props,
+			baseUrl,
+			props,
 			requestedHost,
 			normalizedHost,
 			resolvedSecrets,
@@ -144,7 +148,10 @@ export async function expandSecretPlaceholders(input: {
  * Codemode / sandboxed fetch may emit path-only URLs (e.g. `/`, `/core/log`).
  * Workers `Request` requires an absolute URL string; resolve against the app origin.
  */
-function resolveRequestUrlForFetchGateway(url: string, baseUrl: string) {
+function resolveRequestUrlForFetchGateway(
+	url: string,
+	baseUrl: string | null,
+) {
 	const trimmed = url.trim()
 	if (!trimmed) {
 		throw new Error('Fetch gateway received an empty request URL.')
@@ -152,6 +159,11 @@ function resolveRequestUrlForFetchGateway(url: string, baseUrl: string) {
 	try {
 		return new URL(trimmed).toString()
 	} catch {
+		if (!baseUrl) {
+			throw new Error(
+				`Fetch gateway could not resolve request URL "${trimmed}" without a baseUrl.`,
+			)
+		}
 		try {
 			return new URL(trimmed, baseUrl).toString()
 		} catch {
@@ -162,8 +174,14 @@ function resolveRequestUrlForFetchGateway(url: string, baseUrl: string) {
 	}
 }
 
+function normalizeFetchGatewayBaseUrl(baseUrl: string | null | undefined) {
+	const trimmed = baseUrl?.trim() ?? ''
+	return trimmed || null
+}
+
 async function collectHostApprovalEntries(input: {
-	props: FetchGatewayProps
+	baseUrl: string
+	props: Partial<FetchGatewayProps>
 	requestedHost: string
 	normalizedHost: string
 	resolvedSecrets: Array<{
@@ -178,11 +196,11 @@ async function collectHostApprovalEntries(input: {
 				resolved.allowedHosts.includes(input.normalizedHost)
 			if (allowedForHost) return null
 			const approvalUrl = buildSecretHostApprovalUrl({
-				baseUrl: input.props.baseUrl,
+				baseUrl: input.baseUrl,
 				name: referenced.name,
 				scope: resolved.scope ?? referenced.scope ?? 'user',
 				requestedHost: input.requestedHost,
-				storageContext: input.props.storageContext,
+				storageContext: input.props.storageContext ?? null,
 			})
 			return {
 				secretName: referenced.name,
@@ -204,7 +222,7 @@ function readRequestedHost(url: string) {
 	}
 }
 
-function ensureFetchAllowed(props: FetchGatewayProps) {
+function ensureFetchAllowed(props: Partial<FetchGatewayProps>) {
 	if (!props.userId) {
 		throw new Error(fetchSecretAuthRequiredMessage)
 	}

--- a/tools/ci/production-resources.ts
+++ b/tools/ci/production-resources.ts
@@ -108,6 +108,10 @@ function defaultPackageWorkflowName(workerName: string) {
 	return truncateWithSuffix(workerName, '-package-workflows', 63)
 }
 
+function defaultProductionWorkerName(workerName: string) {
+	return `${workerName}-production`
+}
+
 function ensureD1Database({
 	name,
 	configuredId,
@@ -374,6 +378,9 @@ async function ensureProductionResources(options: CliOptions) {
 
 	// Emit GitHub Actions-friendly outputs (stdout only).
 	console.log(`wrangler_config=${generatedConfigPath}`)
+	console.log(
+		`production_worker_name=${defaultProductionWorkerName(bindings.workerName)}`,
+	)
 	console.log(`d1_database_name=${d1.name}`)
 	console.log(`d1_database_id=${d1.id}`)
 	console.log(`oauth_kv_title=${oauthKv.title}`)

--- a/tools/ci/sync-worker-secrets.node.test.ts
+++ b/tools/ci/sync-worker-secrets.node.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { buildSpawnEnv } from './sync-worker-secrets'
+import { buildSpawnEnv, buildWranglerSecretPutArgs } from './sync-worker-secrets'
 
 const baseOptions = {
 	env: undefined,
@@ -12,6 +12,7 @@ const baseOptions = {
 	generateCookieSecret: false,
 	includeEmpty: false,
 	emptyAsSpace: false,
+	putIndividually: false,
 }
 
 test('buildSpawnEnv removes empty optional vars', () => {
@@ -44,4 +45,46 @@ test('buildSpawnEnv keeps optional vars when set', () => {
 
 	expect(spawnEnv.CLOUDFLARE_API_BASE_URL).toBe('https://api.cloudflare.com')
 	expect(spawnEnv.PATH).toBe('/usr/bin')
+})
+
+test('buildWranglerSecretPutArgs targets a worker by name without env config', () => {
+	const args = buildWranglerSecretPutArgs(
+		{
+			...baseOptions,
+			name: 'kody-production',
+		},
+		'COOKIE_SECRET',
+	)
+
+	expect(args.slice(1)).toEqual([
+		'secret',
+		'put',
+		'COOKIE_SECRET',
+		'--name',
+		'kody-production',
+	])
+})
+
+test('buildWranglerSecretPutArgs includes env and config when provided', () => {
+	const args = buildWranglerSecretPutArgs(
+		{
+			...baseOptions,
+			config: 'packages/worker/wrangler.jsonc',
+			env: 'preview',
+			name: 'kody-preview',
+		},
+		'COOKIE_SECRET',
+	)
+
+	expect(args.slice(1)).toEqual([
+		'secret',
+		'put',
+		'COOKIE_SECRET',
+		'--env',
+		'preview',
+		'--name',
+		'kody-preview',
+		'--config',
+		'packages/worker/wrangler.jsonc',
+	])
 })

--- a/tools/ci/sync-worker-secrets.node.test.ts
+++ b/tools/ci/sync-worker-secrets.node.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from 'vitest'
-import { buildSpawnEnv, buildWranglerSecretPutArgs } from './sync-worker-secrets'
+import {
+	buildSpawnEnv,
+	buildWranglerSecretPutArgs,
+} from './sync-worker-secrets'
 
 const baseOptions = {
 	env: undefined,

--- a/tools/ci/sync-worker-secrets.ts
+++ b/tools/ci/sync-worker-secrets.ts
@@ -16,6 +16,7 @@ export type CliOptions = {
 	generateCookieSecret: boolean
 	includeEmpty: boolean
 	emptyAsSpace: boolean
+	putIndividually: boolean
 }
 
 function fail(message: string): never {
@@ -33,6 +34,7 @@ function parseArgs(argv: Array<string>): CliOptions {
 		generateCookieSecret: false,
 		includeEmpty: false,
 		emptyAsSpace: false,
+		putIndividually: false,
 	}
 
 	for (let index = 0; index < argv.length; index += 1) {
@@ -92,6 +94,10 @@ function parseArgs(argv: Array<string>): CliOptions {
 			}
 			case '--empty-as-space': {
 				options.emptyAsSpace = true
+				break
+			}
+			case '--put-individually': {
+				options.putIndividually = true
 				break
 			}
 			default: {
@@ -234,6 +240,50 @@ function toDotenv(secrets: ReadonlyMap<string, string>) {
 	return `${lines.join('\n')}\n`
 }
 
+export function buildWranglerSecretPutArgs(
+	options: Pick<CliOptions, 'config' | 'env' | 'name'>,
+	key: string,
+) {
+	const wranglerBin = resolveLocalBinary('wrangler')
+	const args = [wranglerBin, 'secret', 'put', key]
+	if (options.env !== undefined) {
+		args.push('--env', options.env)
+	}
+	if (options.name) {
+		args.push('--name', options.name)
+	}
+	if (options.config) {
+		args.push('--config', options.config)
+	}
+	return args
+}
+
+async function runWranglerSecretPut(
+	options: CliOptions,
+	key: string,
+	value: string,
+) {
+	const args = buildWranglerSecretPutArgs(options, key)
+	const spawnEnv = buildSpawnEnv(options)
+	const [command, ...commandArgs] = args
+	if (!command) {
+		fail('Could not resolve wrangler command for secret sync.')
+	}
+
+	const proc = spawn(command, commandArgs, {
+		stdio: ['pipe', 'inherit', 'inherit'],
+		env: spawnEnv,
+	})
+	proc.stdin.end(value)
+	const exitCode = await new Promise<number | null>((resolve, reject) => {
+		proc.once('error', reject)
+		proc.once('exit', (code: number | null) => resolve(code))
+	})
+	if (exitCode !== 0) {
+		process.exit(exitCode ?? 1)
+	}
+}
+
 async function runWranglerSecretBulk(options: CliOptions, dotenvText: string) {
 	const wranglerBin = resolveLocalBinary('wrangler')
 	const args = [wranglerBin, 'secret', 'bulk']
@@ -286,11 +336,17 @@ async function main() {
 		fail('No secrets to sync (empty input).')
 	}
 	const dotenvText = toDotenv(secrets)
-	await runWranglerSecretBulk(options, dotenvText)
+	if (options.putIndividually) {
+		for (const [key, value] of secrets) {
+			await runWranglerSecretPut(options, key, value)
+		}
+	} else {
+		await runWranglerSecretBulk(options, dotenvText)
+	}
 	const envLabel =
 		options.env && options.env.length > 0 ? options.env : 'default'
 	console.log(
-		`Synced ${secrets.size} secret(s) via bulk upload (${envLabel}${options.name ? `, ${options.name}` : ''}).`,
+		`Synced ${secrets.size} secret(s) via ${options.putIndividually ? 'individual uploads' : 'bulk upload'} (${envLabel}${options.name ? `, ${options.name}` : ''}).`,
 	)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- avoid production secret sync uploading the full Worker binding config by targeting the resolved production Worker name with individual `wrangler secret put` calls
- harden the fetch gateway so absolute placeholder-free requests do not crash when WorkerEntrypoint props are absent
- document the Durable Objects API token permission required for production and preview Worker deploys, which is the root cause of the Cloudflare 10023 preview mock deploy failure

## Validation
- `npm test -- --run packages/worker/src/mcp/fetch-gateway.node.test.ts tools/ci/sync-worker-secrets.node.test.ts`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b77d2759-94c7-48cd-b33c-7fab55828ab8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b77d2759-94c7-48cd-b33c-7fab55828ab8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

