### PR TITLE
execute: add responseLimit and connector/npm ergonomics

### DIFF
--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -54,6 +54,13 @@ with `allowedHosts` when needed.
 Client ID, access token, and refresh token names are derived from a normalized
 slug of `provider`.
 
+## Connector naming convention
+
+Prefer connector names like `<provider>-<purpose>` when multiple accounts may
+exist: `google` for the primary account, `google-business` for a business
+account, or `google-youtube-brand` for a brand identity. Agents should call
+`connector_list` up front when a provider may have multiple accounts connected.
+
 ## Not the same as MCP OAuth
 
 `/connect/oauth` is for outbound provider OAuth.

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -42,6 +42,16 @@ the module's **default export**.
 
 Top-level `await` is acceptable when needed.
 
+## npm packages on Workers
+
+**execute** and saved packages may import npm packages directly when they are
+compatible with the Cloudflare Workers runtime. Prefer existing packages over
+rewriting helpers; useful starting points include `p-retry`, `mailparser`,
+`remark` / `mdast-util-to-markdown`, and `googleapis`.
+
+For runtime details, see Cloudflare's
+[Node.js compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/).
+
 ## Chaining
 
 Prefer **one execute** when the plan is clear: import what you need, call
@@ -214,6 +224,11 @@ The sandbox exposes global **`fetch`** plus secret placeholders in approved
 contexts. OAuth helpers are imported from **`kody:runtime`**:
 
 **`import { refreshAccessToken, createAuthenticatedFetch } from 'kody:runtime'`**
+
+Connector names should usually follow `<provider>-<purpose>` when multiple
+accounts may exist, such as `google`, `google-business`, or
+`google-youtube-brand`. Call **`connector_list`** up front when a provider may
+have multiple accounts connected.
 
 See [Secrets, values, and host approval](./secrets-and-values.md) for
 placeholders, host approval, and **`codemode.secret_list`** / **`secret_set`**.

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -44,7 +44,8 @@ For predictable package resolution, saved packages must use a scoped
 ### npm dependencies
 
 Saved packages may declare runtime npm dependencies in `package.json`
-`dependencies`.
+`dependencies` and import them directly when they are compatible with the
+Cloudflare Workers runtime.
 
 - Kody bundles those dependencies for package exports, package apps, package
   services, package-owned jobs, and package subscription handlers.
@@ -58,6 +59,12 @@ Saved packages may declare runtime npm dependencies in `package.json`
 
 Do not rely on `devDependencies` for saved package runtime code. Only
 `dependencies` are treated as part of the runtime package surface.
+
+See Cloudflare's
+[Node.js compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/)
+for runtime details. Useful starting points include `p-retry`, `mailparser`,
+`remark` / `mdast-util-to-markdown`, and `googleapis`; this list is not
+exhaustive.
 
 ## Package exports
 

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -10,6 +10,7 @@ import {
 	extractRawContent,
 	formatExecutionOutput,
 	getExecutionErrorDetails,
+	limitExecutionResultValue,
 } from './executor.ts'
 
 test('getExecutionErrorDetails returns concrete guidance for capability access denial', () => {
@@ -88,6 +89,25 @@ test('extractRawContent returns null for non-sentinel values', () => {
 	expect(extractRawContent({ result: 'not raw content' })).toBeNull()
 	expect(extractRawContent('plain text')).toBeNull()
 	expect(extractRawContent(null)).toBeNull()
+})
+
+test('limitExecutionResultValue truncates strings on UTF-8 codepoint boundaries', () => {
+	const oneByteLimit = limitExecutionResultValue('éabc', 1)
+	expect(oneByteLimit).toMatchObject({
+		value: '',
+		returnedBytes: 5,
+		truncated: true,
+	})
+
+	const threeByteLimit = limitExecutionResultValue('éabc', 3)
+	expect(threeByteLimit).toMatchObject({
+		value: 'éa',
+		returnedBytes: 5,
+		truncated: true,
+	})
+	expect(
+		new TextEncoder().encode(String(threeByteLimit.value)).byteLength,
+	).toBe(3)
 })
 
 test('getExecutionErrorDetails returns batch capability approvals', () => {

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -339,10 +339,6 @@ export function limitExecutionResultValue(
 	} as const
 }
 
-export function getExecutionReturnedBytes(value: unknown) {
-	return getUtf8ByteLength(stringifyExecutionValueForBytes(value))
-}
-
 export function formatLimitedExecutionOutput(input: {
 	value: unknown
 	truncated: boolean
@@ -364,8 +360,16 @@ function stringifyExecutionValueForOutput(value: unknown) {
 }
 
 function truncateUtf8String(value: string, maxBytes: number) {
-	const encoded = new TextEncoder().encode(value)
-	return new TextDecoder().decode(encoded.slice(0, maxBytes))
+	const encoder = new TextEncoder()
+	let usedBytes = 0
+	let result = ''
+	for (const character of value) {
+		const characterBytes = encoder.encode(character).byteLength
+		if (usedBytes + characterBytes > maxBytes) break
+		result += character
+		usedBytes += characterBytes
+	}
+	return result
 }
 
 function getUtf8ByteLength(value: string) {

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -16,9 +16,7 @@ import {
 
 type WorkerLoopbackExports = Exclude<typeof workerExports, undefined>
 
-const charsPerToken = 4
-const maxTokens = 6_000
-const maxChars = maxTokens * charsPerToken
+export const defaultExecutionResponseLimitBytes = 102_400
 const maxSupportedExecutorTimeoutMs = 2_147_483_647
 
 export function createExecuteExecutor(input: {
@@ -281,7 +279,7 @@ export function formatExecutionOutput(result: ExecuteResult) {
 		if (!details) return `Error: ${errorText}`
 		return `Error: ${errorText}\n\nNext step: ${details.nextStep}`
 	}
-	return truncateExecutionResult(result.result)
+	return stringifyExecutionValueForOutput(result.result)
 }
 
 export function extractRawContent(value: unknown): Array<ContentBlock> | null {
@@ -309,15 +307,73 @@ function extractFirstUrl(message: string) {
 	return null
 }
 
-function truncateExecutionResult(value: unknown) {
-	const text =
+export function limitExecutionResultValue(
+	value: unknown,
+	responseLimitBytes: number,
+) {
+	const serialized = stringifyExecutionValueForBytes(value)
+	const returnedBytes = getUtf8ByteLength(serialized)
+
+	if (returnedBytes <= responseLimitBytes) {
+		return {
+			value,
+			returnedBytes,
+			truncated: false,
+		} as const
+	}
+
+	const note = `Returned value was ${returnedBytes.toLocaleString()} bytes, exceeding responseLimit ${responseLimitBytes.toLocaleString()} bytes; output was truncated. Project fields before returning.`
+	const truncatedValue =
 		typeof value === 'string'
-			? value
-			: (JSON.stringify(value, null, 2) ?? 'undefined')
+			? truncateUtf8String(value, responseLimitBytes)
+			: {
+					truncated: true,
+					type: describeExecutionValue(value),
+				}
 
-	if (text.length <= maxChars) return text
+	return {
+		value: truncatedValue,
+		returnedBytes,
+		truncated: true,
+		note,
+	} as const
+}
 
-	return `${text.slice(0, maxChars)}\n\n--- TRUNCATED ---\nResponse was ~${Math.ceil(
-		text.length / charsPerToken,
-	).toLocaleString()} tokens (limit: ${maxTokens.toLocaleString()}). Use more specific queries to reduce response size.`
+export function getExecutionReturnedBytes(value: unknown) {
+	return getUtf8ByteLength(stringifyExecutionValueForBytes(value))
+}
+
+export function formatLimitedExecutionOutput(input: {
+	value: unknown
+	truncated: boolean
+	note?: string
+}) {
+	const text = stringifyExecutionValueForOutput(input.value)
+	if (!input.truncated) return text
+	return `${text}\n\n--- TRUNCATED ---\n${input.note}`
+}
+
+function stringifyExecutionValueForBytes(value: unknown) {
+	if (typeof value === 'string') return value
+	return JSON.stringify(value) ?? 'undefined'
+}
+
+function stringifyExecutionValueForOutput(value: unknown) {
+	if (typeof value === 'string') return value
+	return JSON.stringify(value, null, 2) ?? 'undefined'
+}
+
+function truncateUtf8String(value: string, maxBytes: number) {
+	const encoded = new TextEncoder().encode(value)
+	return new TextDecoder().decode(encoded.slice(0, maxBytes))
+}
+
+function getUtf8ByteLength(value: string) {
+	return new TextEncoder().encode(value).byteLength
+}
+
+function describeExecutionValue(value: unknown) {
+	if (value === null) return 'null'
+	if (Array.isArray(value)) return 'array'
+	return typeof value
 }

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -58,12 +58,16 @@ async function getExecuteHandler() {
 		code: string
 		storageId?: string
 		writable?: boolean
+		responseLimit?: number
 		conversationId?: string
 	}) => Promise<{
 		content: Array<ContentBlock>
 		structuredContent: {
 			conversationId: string
 			storage?: { id: string }
+			returnedBytes: number
+			truncated?: boolean
+			note?: string
 			timing: {
 				startedAt: string
 				endedAt: string
@@ -96,6 +100,9 @@ test('execute tool passes through raw MCP content blocks in success responses', 
 		},
 		logs: [{ level: 'info', message: 'captured screenshot' }],
 	})
+	const returnedBytes = new TextEncoder().encode(
+		JSON.stringify({ __mcpContent: rawContent }),
+	).byteLength
 
 	const response = await handler({
 		code: 'async () => ({ __mcpContent: [] })',
@@ -117,6 +124,7 @@ test('execute tool passes through raw MCP content blocks in success responses', 
 			endedAt: expect.any(String),
 			durationMs: 42,
 		},
+		returnedBytes,
 		result: null,
 		logs: [{ level: 'info', message: 'captured screenshot' }],
 	})
@@ -153,6 +161,7 @@ test('execute tool keeps serializing normal success results as text', async () =
 			endedAt: expect.any(String),
 			durationMs: 9,
 		},
+		returnedBytes: 11,
 		result: { ok: true },
 		logs: [],
 	})
@@ -200,7 +209,81 @@ test('execute tool binds storage id and writable flag when provided', async () =
 			endedAt: expect.any(String),
 			durationMs: 7,
 		},
+		returnedBytes: 11,
 		result: { ok: true },
+		logs: [],
+	})
+})
+
+test('execute tool truncates returned strings over responseLimit', async () => {
+	const handler = await getExecuteHandler()
+	mockPerformanceSequence(20, 25)
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		result: 'hello world',
+		logs: [],
+	})
+
+	const response = await handler({
+		code: 'async () => "hello world"',
+		responseLimit: 5,
+		conversationId: 'conv-truncated-string',
+	})
+
+	expect(response.isError).toBe(false)
+	expect(response.content).toEqual([
+		{
+			type: 'text',
+			text: 'conversationId: conv-truncated-string',
+		},
+		{
+			type: 'text',
+			text: 'hello\n\n--- TRUNCATED ---\nReturned value was 11 bytes, exceeding responseLimit 5 bytes; output was truncated. Project fields before returning.',
+		},
+	])
+	expect(response.structuredContent).toEqual({
+		conversationId: 'conv-truncated-string',
+		timing: {
+			startedAt: expect.any(String),
+			endedAt: expect.any(String),
+			durationMs: 5,
+		},
+		returnedBytes: 11,
+		truncated: true,
+		note: 'Returned value was 11 bytes, exceeding responseLimit 5 bytes; output was truncated. Project fields before returning.',
+		result: 'hello',
+		logs: [],
+	})
+})
+
+test('execute tool replaces non-string returns over responseLimit with a sentinel', async () => {
+	const handler = await getExecuteHandler()
+	mockPerformanceSequence(30, 40)
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		result: { rows: [{ id: 'message-1', payload: 'abcdef' }] },
+		logs: [],
+	})
+
+	const response = await handler({
+		code: 'async () => ({ rows: [{ id: "message-1", payload: "abcdef" }] })',
+		responseLimit: 10,
+		conversationId: 'conv-truncated-object',
+	})
+
+	expect(response.isError).toBe(false)
+	expect(response.structuredContent).toEqual({
+		conversationId: 'conv-truncated-object',
+		timing: {
+			startedAt: expect.any(String),
+			endedAt: expect.any(String),
+			durationMs: 10,
+		},
+		returnedBytes: 48,
+		truncated: true,
+		note: 'Returned value was 48 bytes, exceeding responseLimit 10 bytes; output was truncated. Project fields before returning.',
+		result: {
+			truncated: true,
+			type: 'object',
+		},
 		logs: [],
 	})
 })
@@ -228,6 +311,7 @@ test('execute tool includes timing metadata in error responses', async () => {
 				durationMs: 15,
 			},
 			error: 'Boom',
+			returnedBytes: 0,
 			logs: [{ level: 'error', message: 'failed' }],
 		}),
 	)

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -2,7 +2,10 @@ import * as Sentry from '@sentry/cloudflare'
 import { type ToolAnnotations } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import {
+	defaultExecutionResponseLimitBytes,
 	extractRawContent,
+	formatLimitedExecutionOutput,
+	limitExecutionResultValue,
 	formatExecutionOutput,
 	getExecutionErrorDetails,
 } from '#mcp/executor.ts'
@@ -32,10 +35,9 @@ const executeTool = {
 	name: 'execute',
 	title: 'Execute Capabilities',
 	description: `
-Run one ephemeral ESM module string with a default export. Discover capability
-names with \`search\`; for one capability’s TypeScript call shape, call
-\`search\` with \`entity: "{name}:capability"\` or use
-\`meta_list_capabilities\`.
+Run one ephemeral ESM module string with a default export. Imports may be arbitrary npm packages compatible with the Cloudflare Workers runtime (e.g. \`p-retry\`, \`mailparser\`, \`remark\`); prefer existing packages over rewriting helpers. Discover capability names with \`search\`; for one capability’s TypeScript call shape, call \`search\` with \`entity: "{name}:capability"\` or use \`meta_list_capabilities\`.
+
+Projection rule: you write the code -- if a call returns a large response, project the fields you need before returning. Never return raw API responses; extract a slim shape (e.g. \`{ id, subject, snippet }\`) or a summary.
 
 Saved package surface:
 - \`package_save\`, \`package_get\`, \`package_list\`, \`package_delete\`
@@ -47,7 +49,7 @@ Sandbox surface:
 - Import runtime helpers from \`kody:runtime\`.
 - \`import { codemode } from 'kody:runtime'\` for builtin capabilities.
 - \`import { storage } from 'kody:runtime'\` for durable storage helpers on the bound \`storageId\`, including \`storage.sql(query, params?)\`.
-- \`import { refreshAccessToken, createAuthenticatedFetch } from 'kody:runtime'\` for OAuth connectors.
+- \`import { refreshAccessToken, createAuthenticatedFetch } from 'kody:runtime'\` for OAuth connectors. Connector \`name\` may be account-specific (e.g. \`google-personal\`, \`google-business\`); call \`connector_list\` first when the task involves a provider that may have multiple accounts connected.
 - \`import { agentChatTurnStream } from 'kody:runtime'\` for streamed agent turns.
 - \`params\` is passed to the module default export; if a shared helper needs it, \`import { params } from 'kody:runtime'\`.
 - \`import { packageContext } from 'kody:runtime'\` in saved package code when you need package metadata; it is \`null\` for ad hoc execute calls.
@@ -95,7 +97,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 				code: z
 					.string()
 					.describe(
-						'Single ESM module string with imports/exports and a default export to execute.',
+						'Single ESM module string with imports/exports and a default export to execute. Imports may be arbitrary npm packages compatible with the Cloudflare Workers runtime; prefer packages over rewriting helpers.',
 					),
 				params: z
 					.record(z.string(), z.unknown())
@@ -116,6 +118,17 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					.describe(
 						'Optional write access toggle for bound storage. Defaults to false for ad hoc execute calls.',
 					),
+				responseLimit: z
+					.number()
+					.int()
+					.min(1)
+					.optional()
+					.describe(
+						`Soft cap on the size of the value returned from your default export. Defaults to ~100 KB. Returns over the cap are truncated and the response includes a note. You write the code -- if you only need a few fields, project before returning. Examples:
+// bad: messages.list().then(j => j) -- returns full Gmail payloads
+// good: messages.list().then(j => j.messages.map(m => ({id: m.id, snippet: m.snippet})))
+// good: aggregate().then(rows => ({count: rows.length, sample: rows.slice(0, 3)}))`,
+					),
 				conversationId: conversationIdInputField,
 				memoryContext: memoryContextInputField,
 			},
@@ -126,6 +139,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 			params,
 			storageId,
 			writable,
+			responseLimit,
 			conversationId,
 			memoryContext,
 		}: {
@@ -133,6 +147,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 			params?: Record<string, unknown>
 			storageId?: string
 			writable?: boolean
+			responseLimit?: number
 			conversationId?: string
 			memoryContext?: z.infer<typeof memoryContextInputField>
 		}) => {
@@ -222,6 +237,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 						conversationId: resolvedConversationId,
 						timing,
 						...(activeStorageId ? { storage: { id: activeStorageId } } : {}),
+						returnedBytes: 0,
 						error: errorMessage,
 						errorDetails,
 						logs: result.logs ?? [],
@@ -243,13 +259,19 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 				sandboxError: false,
 				context: activeStorageId ? { storageId: activeStorageId } : undefined,
 			})
-			const rawContent = extractRawContent(result.result)
+			const limitedResult = limitExecutionResultValue(
+				result.result,
+				responseLimit ?? defaultExecutionResponseLimitBytes,
+			)
+			const rawContent = limitedResult.truncated
+				? null
+				: extractRawContent(limitedResult.value)
 			return {
 				content: prependToolMetadataContent(resolvedConversationId, [
 					...(rawContent ?? [
 						{
 							type: 'text',
-							text: formatExecutionOutput(result),
+							text: formatLimitedExecutionOutput(limitedResult),
 						},
 					]),
 					...formatSurfacedMemoriesMarkdown(surfacedMemories),
@@ -258,7 +280,14 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					conversationId: resolvedConversationId,
 					timing,
 					...(activeStorageId ? { storage: { id: activeStorageId } } : {}),
-					result: rawContent ? null : result.result,
+					returnedBytes: limitedResult.returnedBytes,
+					...(limitedResult.truncated
+						? {
+								truncated: true,
+								note: limitedResult.note,
+							}
+						: {}),
+					result: rawContent ? null : limitedResult.value,
 					logs: result.logs ?? [],
 					...buildMemoryStructuredContent(surfacedMemories),
 				},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add concise execute descriptor guidance for projection, npm-on-Workers imports, and multi-account connector names.
- Add optional `responseLimit` to `execute`, defaulting to ~100 KB, with truncation metadata in the response envelope.
- Include `returnedBytes` on execute responses so agents get continuous feedback about return size.
- Document npm packages compatible with the Cloudflare Workers runtime for execute and saved packages.
- Document the recommended `<provider>-<purpose>` connector naming convention and upfront `connector_list` usage for multi-account providers.
- Address AI-reviewer feedback by truncating strings on UTF-8 codepoint boundaries and removing an unused export.

## Rationale
- Multi-account connector friction is addressed through discoverability: named connectors plus `connector_list` remain the model.
- npm support already existed; docs and descriptors now make direct imports more obvious so agents use vetted packages instead of rewriting helpers.
- Response-size control stays with the agent-authored code: the projection rule, `returnedBytes`, and optional `responseLimit` help agents self-correct toward slim return shapes.

## Verification
- `npm exec vitest -- run "packages/worker/src/mcp/tools/execute.node.test.ts" "packages/worker/src/mcp/executor.node.test.ts"`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- Follow-up fix: `npx oxfmt --no-error-on-unmatched-pattern "packages/worker/src/mcp/executor.ts" "packages/worker/src/mcp/executor.node.test.ts" && npm exec vitest -- run "packages/worker/src/mcp/executor.node.test.ts" "packages/worker/src/mcp/tools/execute.node.test.ts" && npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dbf632d-f5d5-4f66-94aa-2b533b1de144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dbf632d-f5d5-4f66-94aa-2b533b1de144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added connector naming convention guidance for multiple accounts.
  * Added guidance on npm packages for Workers and clarified runtime dependency recommendations.

* **New Features**
  * Execute tool: optional response-size limiting with returned-bytes, truncation flag, and explanatory note in results.

* **Tests**
  * Updated tests to verify response-size limiting, returned-bytes reporting, and UTF-8-safe truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->