### PR TITLE
Include referenced package export types

### DIFF
--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -318,15 +318,16 @@ export declare function fetch(request: Request): Promise<Response>
 			}),
 			expect.objectContaining({
 				subpath: './app',
-				typesSource:
-					'/**\n * Render the observed app.\n */\nexport declare function fetch(request: Request): Promise<Response>\n',
+				typesSource: null,
+				referencedTypes: [],
 				functions: [
-					{
+					expect.objectContaining({
 						name: 'fetch',
 						description: 'Render the observed app.',
 						typeDefinition:
 							'export declare function fetch(request: Request): Promise<Response>',
-					},
+						referencedTypes: [],
+					}),
 				],
 			}),
 		],
@@ -346,6 +347,107 @@ export declare function fetch(request: Request): Promise<Response>
 	expect(packageDetail.markdown).toContain(
 		'Use this package to inspect observed UI state.',
 	)
+})
+
+test('package entity detail renders referenced local types without dumping full types source', () => {
+	const packageDetail = formatEntityDetailMarkdown({
+		type: 'package',
+		id: 'cursor-cloud-agents',
+		title: '@kentcdodds/cursor-cloud-agents',
+		description: 'Cursor cloud agents package.',
+		hostedUrl: null,
+		record: {
+			id: 'package-456',
+			userId: 'user-123',
+			name: '@kentcdodds/cursor-cloud-agents',
+			kodyId: 'cursor-cloud-agents',
+			description: 'Cursor cloud agents package.',
+			tags: ['cursor'],
+			searchText: null,
+			sourceId: 'source-package-456',
+			hasApp: false,
+			createdAt: '2026-03-20T00:00:00.000Z',
+			updatedAt: '2026-03-20T00:00:00.000Z',
+		},
+		manifest: {
+			name: '@kentcdodds/cursor-cloud-agents',
+			exports: {
+				'./launch-cursor-cloud-agent': {
+					import: './src/launch-cursor-cloud-agent.ts',
+					types: './src/launch-cursor-cloud-agent.d.ts',
+				},
+			},
+			kody: {
+				id: 'cursor-cloud-agents',
+				description: 'Cursor cloud agents package.',
+				tags: ['cursor'],
+			},
+		},
+		files: {
+			'package.json': '{}',
+			'src/launch-cursor-cloud-agent.d.ts': `type LaunchCursorCloudAgentInput = {
+	prompt: string
+	repository: RepositoryTarget
+	metadata?: Record<string, string>
+}
+
+type RepositoryTarget = {
+	owner: string
+	repo: string
+}
+
+type UnrelatedLocalType = {
+	ignored: boolean
+}
+
+/**
+ * Launch a Cursor Cloud agent.
+ */
+export declare function launch(input: LaunchCursorCloudAgentInput): Promise<Response>
+`,
+		},
+	})
+
+	expect(packageDetail.structured).toMatchObject({
+		type: 'package',
+		exports: [
+			expect.objectContaining({
+				subpath: './launch-cursor-cloud-agent',
+				typesSource: null,
+				referencedTypes: [
+					expect.objectContaining({
+						name: 'LaunchCursorCloudAgentInput',
+						kind: 'type',
+					}),
+					expect.objectContaining({
+						name: 'RepositoryTarget',
+						kind: 'type',
+					}),
+				],
+				functions: [
+					expect.objectContaining({
+						name: 'launch',
+						referencedTypes: [
+							expect.objectContaining({
+								name: 'LaunchCursorCloudAgentInput',
+							}),
+							expect.objectContaining({
+								name: 'RepositoryTarget',
+							}),
+						],
+					}),
+				],
+			}),
+		],
+	})
+	expect(packageDetail.markdown).toContain('Referenced types:')
+	expect(packageDetail.markdown).toContain(
+		'type LaunchCursorCloudAgentInput = {',
+	)
+	expect(packageDetail.markdown).toContain('type RepositoryTarget = {')
+	expect(packageDetail.markdown).not.toContain('UnrelatedLocalType')
+	expect(packageDetail.markdown).not.toContain('type Record')
+	expect(packageDetail.markdown).not.toContain('interface Response')
 })
 
 test('package search formatting keeps runnable package actions in structured output', () => {

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -221,6 +221,8 @@ export type SearchEntityDetailStructured =
 					referencedTypes: Array<PackageReferencedTypeProjection>
 				}>
 				referencedTypes: Array<PackageReferencedTypeProjection>
+				// Full type source is no longer emitted by default; keep the nullable
+				// field for structured-output compatibility with existing clients.
 				typesSource: string | null
 			}>
 			jobs: Array<{

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -8,7 +8,10 @@ import {
 	type PackageJobSchedule,
 	type SavedPackageRecord,
 } from '#worker/package-registry/types.ts'
-import { buildPackageSearchProjection } from '#worker/package-registry/manifest.ts'
+import {
+	buildPackageSearchProjection,
+	type PackageReferencedTypeProjection,
+} from '#worker/package-registry/manifest.ts'
 import { type PackageRetrieverSurfaceResult } from '#worker/package-retrievers/types.ts'
 import {
 	escapeMarkdownText,
@@ -215,7 +218,9 @@ export type SearchEntityDetailStructured =
 					name: string
 					description: string | null
 					typeDefinition: string | null
+					referencedTypes: Array<PackageReferencedTypeProjection>
 				}>
+				referencedTypes: Array<PackageReferencedTypeProjection>
 				typesSource: string | null
 			}>
 			jobs: Array<{
@@ -708,10 +713,7 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 				detail.record.name,
 				exportDetail.subpath,
 			),
-			typesSource:
-				exportDetail.typesPath == null
-					? null
-					: (detail.files[exportDetail.typesPath] ?? null),
+			typesSource: null,
 		}))
 		const jobs = Object.entries(detail.manifest.kody.jobs ?? {}).map(
 			([jobName, job]) => ({
@@ -778,12 +780,17 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 						)
 					}
 				}
-				if (exportDetail.typesSource) {
-					lines.push('', '  Type definitions:', '', '  ```ts')
-					lines.push(
-						...exportDetail.typesSource.split('\n').map((line) => `  ${line}`),
-					)
-					lines.push('  ```')
+				if (exportDetail.referencedTypes.length > 0) {
+					lines.push('  - Referenced types:', '    ```ts')
+					exportDetail.referencedTypes.forEach((referencedType, index) => {
+						if (index > 0) lines.push('    ')
+						lines.push(
+							...referencedType.definition
+								.split('\n')
+								.map((line) => `    ${line}`),
+						)
+					})
+					lines.push('    ```')
 				}
 			}
 		}

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -337,10 +337,18 @@ function buildSearchableEntityDescriptors(input: {
 					exportDetail.subpath,
 					exportDetail.description ?? '',
 					exportDetail.typeDefinition ?? '',
+					...(exportDetail.referencedTypes ?? []).flatMap((referencedType) => [
+						referencedType.name,
+						referencedType.definition,
+					]),
 					...(exportDetail.functions ?? []).flatMap((fn) => [
 						fn.name,
 						fn.description ?? '',
 						fn.typeDefinition ?? '',
+						...(fn.referencedTypes ?? []).flatMap((referencedType) => [
+							referencedType.name,
+							referencedType.definition,
+						]),
 					]),
 				]),
 				...entry.projection.jobs.map((job) => job.name),
@@ -699,10 +707,20 @@ function buildPackageCandidates(input: {
 						exportDetail.typesPath ?? '',
 						exportDetail.description ?? '',
 						exportDetail.typeDefinition ?? '',
+						...(exportDetail.referencedTypes ?? []).flatMap(
+							(referencedType) => [
+								referencedType.name,
+								referencedType.definition,
+							],
+						),
 						...(exportDetail.functions ?? []).flatMap((fn) => [
 							fn.name,
 							fn.description ?? '',
 							fn.typeDefinition ?? '',
+							...(fn.referencedTypes ?? []).flatMap((referencedType) => [
+								referencedType.name,
+								referencedType.definition,
+							]),
 						]),
 					]),
 					...jobs.flatMap((job) => [

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -162,6 +162,17 @@ type SearchUnifiedResult = {
 	guidance?: string
 }
 
+function flattenReferencedTypeFields(
+	referencedTypes:
+		| ReadonlyArray<{ name: string; definition: string }>
+		| undefined,
+): Array<string> {
+	return (referencedTypes ?? []).flatMap((referencedType) => [
+		referencedType.name,
+		referencedType.definition,
+	])
+}
+
 function buildFallbackPackageSearchProjection(
 	record: Awaited<ReturnType<typeof listSavedPackagesByUserId>>[number],
 ): PackageSearchProjection {
@@ -337,18 +348,12 @@ function buildSearchableEntityDescriptors(input: {
 					exportDetail.subpath,
 					exportDetail.description ?? '',
 					exportDetail.typeDefinition ?? '',
-					...(exportDetail.referencedTypes ?? []).flatMap((referencedType) => [
-						referencedType.name,
-						referencedType.definition,
-					]),
+					...flattenReferencedTypeFields(exportDetail.referencedTypes),
 					...(exportDetail.functions ?? []).flatMap((fn) => [
 						fn.name,
 						fn.description ?? '',
 						fn.typeDefinition ?? '',
-						...(fn.referencedTypes ?? []).flatMap((referencedType) => [
-							referencedType.name,
-							referencedType.definition,
-						]),
+						...flattenReferencedTypeFields(fn.referencedTypes),
 					]),
 				]),
 				...entry.projection.jobs.map((job) => job.name),
@@ -707,20 +712,12 @@ function buildPackageCandidates(input: {
 						exportDetail.typesPath ?? '',
 						exportDetail.description ?? '',
 						exportDetail.typeDefinition ?? '',
-						...(exportDetail.referencedTypes ?? []).flatMap(
-							(referencedType) => [
-								referencedType.name,
-								referencedType.definition,
-							],
-						),
+						...flattenReferencedTypeFields(exportDetail.referencedTypes),
 						...(exportDetail.functions ?? []).flatMap((fn) => [
 							fn.name,
 							fn.description ?? '',
 							fn.typeDefinition ?? '',
-							...(fn.referencedTypes ?? []).flatMap((referencedType) => [
-								referencedType.name,
-								referencedType.definition,
-							]),
+							...flattenReferencedTypeFields(fn.referencedTypes),
 						]),
 					]),
 					...jobs.flatMap((job) => [

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -437,17 +437,29 @@ test('buildPackageSearchProjection uses local declaration kind for exported cons
 	})
 
 	const projection = buildPackageSearchProjection(manifest, {
-		'src/index.ts': `/**
+		'src/index.ts': `type GenericBound = {
+	value: string
+}
+
+type RenderedInput = {
+	value: string
+}
+
+/**
  * Package version metadata.
  */
 export declare const VERSION: string
 
 export declare const typed: (value: string) => string
 
+export declare const typedGeneric: <T extends RenderedInput>(input: T) => string
+
 /**
  * Runtime formatter.
  */
 export const format = (value: string): string => value.trim()
+
+export const genericFormat = <T extends GenericBound>(input: T): string => input.value
 `,
 	})
 
@@ -459,10 +471,79 @@ export const format = (value: string): string => value.trim()
 			referencedTypes: [],
 		},
 		{
+			name: 'typedGeneric',
+			description: null,
+			typeDefinition:
+				'export declare const typedGeneric: <T extends RenderedInput>(input: T) => string',
+			referencedTypes: [
+				{
+					name: 'RenderedInput',
+					kind: 'type',
+					definition: `type RenderedInput = {
+	value: string
+}`,
+				},
+			],
+		},
+		{
 			name: 'format',
 			description: 'Runtime formatter.',
 			typeDefinition: 'export function format(value: string): string',
 			referencedTypes: [],
+		},
+		{
+			name: 'genericFormat',
+			description: null,
+			typeDefinition: 'export function genericFormat(input: T): string',
+			referencedTypes: [],
+		},
+	])
+	expect(
+		projection.exports[0]?.referencedTypes.map((type) => type.name),
+	).toEqual(['RenderedInput'])
+})
+
+test('buildPackageSearchProjection skips referenced types that exceed the size budget', () => {
+	const manifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/large-type-tools',
+			exports: {
+				'.': './src/index.ts',
+			},
+			kody: {
+				id: 'large-type-tools',
+				description: 'Large type tools package',
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+	const oversizedFields = Array.from(
+		{ length: 1_500 },
+		(_, index) => `	field${index}: string`,
+	).join('\n')
+
+	const projection = buildPackageSearchProjection(manifest, {
+		'src/index.ts': `type HugeInput = {
+${oversizedFields}
+}
+
+type SmallInput = {
+	value: string
+}
+
+export function run(huge: HugeInput, small: SmallInput): string {
+	return small.value
+}
+`,
+	})
+
+	expect(projection.exports[0]?.referencedTypes).toEqual([
+		{
+			name: 'SmallInput',
+			kind: 'type',
+			definition: `type SmallInput = {
+	value: string
+}`,
 		},
 	])
 })

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -299,16 +299,126 @@ export declare const celsiusToFahrenheit: (value: number) => number
 					description: 'Look up the forecast for a city.',
 					typeDefinition:
 						'export declare function forecast(city: string): Promise<string>',
+					referencedTypes: [],
 				},
 				{
 					name: 'celsiusToFahrenheit',
 					description: 'Convert Celsius to Fahrenheit.',
 					typeDefinition:
 						'export declare const celsiusToFahrenheit: (value: number) => number',
+					referencedTypes: [],
 				},
 			],
+			referencedTypes: [],
 		}),
 	])
+})
+
+test('buildPackageSearchProjection includes only referenced local named types', () => {
+	const manifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/cursor-cloud-agents',
+			exports: {
+				'./launch-cursor-cloud-agent': {
+					import: './src/launch-cursor-cloud-agent.ts',
+					types: './src/launch-cursor-cloud-agent.d.ts',
+				},
+			},
+			kody: {
+				id: 'cursor-cloud-agents',
+				description: 'Cursor cloud agents package',
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+
+	const projection = buildPackageSearchProjection(manifest, {
+		'src/launch-cursor-cloud-agent.d.ts': `type LaunchCursorCloudAgentInput = {
+	prompt: string
+	repository: RepositoryTarget
+	mode?: LaunchMode
+	metadata?: Record<string, string>
+	createdAt?: Date
+}
+
+interface RepositoryTarget {
+	owner: string
+	repo: string
+}
+
+enum LaunchMode {
+	Background = 'background',
+	Interactive = 'interactive',
+}
+
+type UnrelatedLocalType = {
+	ignored: boolean
+}
+
+/**
+ * Launch a Cursor Cloud agent.
+ */
+export declare function launch(input: LaunchCursorCloudAgentInput): Promise<Response>
+`,
+	})
+
+	const [exportDetail] = projection.exports
+	expect(exportDetail).toMatchObject({
+		subpath: './launch-cursor-cloud-agent',
+		functions: [
+			expect.objectContaining({
+				name: 'launch',
+				description: 'Launch a Cursor Cloud agent.',
+				typeDefinition:
+					'export declare function launch(input: LaunchCursorCloudAgentInput): Promise<Response>',
+			}),
+		],
+	})
+	expect(exportDetail?.referencedTypes).toEqual([
+		{
+			name: 'LaunchCursorCloudAgentInput',
+			kind: 'type',
+			definition: `type LaunchCursorCloudAgentInput = {
+	prompt: string
+	repository: RepositoryTarget
+	mode?: LaunchMode
+	metadata?: Record<string, string>
+	createdAt?: Date
+}`,
+		},
+		{
+			name: 'RepositoryTarget',
+			kind: 'interface',
+			definition: `interface RepositoryTarget {
+	owner: string
+	repo: string
+}`,
+		},
+		{
+			name: 'LaunchMode',
+			kind: 'enum',
+			definition: `enum LaunchMode {
+	Background = 'background',
+	Interactive = 'interactive',
+}`,
+		},
+	])
+	expect(exportDetail?.functions[0]?.referencedTypes).toEqual(
+		exportDetail?.referencedTypes,
+	)
+	const referencedTypeText = exportDetail?.referencedTypes
+		.map((type) => type.definition)
+		.join('\n')
+	expect(referencedTypeText).not.toContain('UnrelatedLocalType')
+	expect(referencedTypeText).not.toContain('type Record')
+	expect(referencedTypeText).not.toContain('type Date')
+	expect(referencedTypeText).not.toContain('interface Response')
+
+	const document = buildPackageSearchDocument(projection)
+	expect(document).toContain('LaunchCursorCloudAgentInput')
+	expect(document).toContain('RepositoryTarget')
+	expect(document).toContain('LaunchMode')
+	expect(document).not.toContain('UnrelatedLocalType')
 })
 
 test('buildPackageSearchProjection uses local declaration kind for exported const signatures', () => {
@@ -346,11 +456,13 @@ export const format = (value: string): string => value.trim()
 			name: 'typed',
 			description: null,
 			typeDefinition: 'export declare const typed: (value: string) => string',
+			referencedTypes: [],
 		},
 		{
 			name: 'format',
 			description: 'Runtime formatter.',
 			typeDefinition: 'export function format(value: string): string',
+			referencedTypes: [],
 		},
 	])
 })

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -485,7 +485,10 @@ function collectTypeReferenceNamesFromNodes(nodes: Array<unknown>) {
 	return names
 }
 
-function getFunctionReferenceNodes(node: unknown) {
+function getFunctionReferenceNodes(
+	node: unknown,
+	options: { includeTypeParameters?: boolean } = {},
+) {
 	const functionNode = node as {
 		params?: unknown
 		returnType?: unknown
@@ -493,7 +496,9 @@ function getFunctionReferenceNodes(node: unknown) {
 	}
 	const params = Array.isArray(functionNode.params) ? functionNode.params : []
 	return [
-		functionNode.typeParameters,
+		...((options.includeTypeParameters ?? true)
+			? [functionNode.typeParameters]
+			: []),
 		...params.map(
 			(param) => (param as { typeAnnotation?: unknown }).typeAnnotation,
 		),
@@ -513,7 +518,7 @@ function getVariableFunctionReferenceNodes(declarator: ModuleAstNode) {
 	) {
 		return []
 	}
-	return getFunctionReferenceNodes(init)
+	return getFunctionReferenceNodes(init, { includeTypeParameters: false })
 }
 
 function collectReferencedTypes(input: {
@@ -547,11 +552,9 @@ function collectReferencedTypes(input: {
 		const declaration = input.localTypes.get(next.name)
 		if (!declaration || seen.has(next.name)) continue
 		const nextChars = totalChars + declaration.definition.length
-		if (
-			nextChars > maxReferencedTypeCharsPerExport &&
-			referencedTypes.length > 0
-		) {
-			break
+		if (nextChars > maxReferencedTypeCharsPerExport) {
+			if (maxReferencedTypeCharsPerExport - totalChars <= 0) break
+			continue
 		}
 		seen.add(next.name)
 		totalChars = nextChars
@@ -579,11 +582,9 @@ function mergeReferencedTypes(
 	for (const type of typeGroups.flat()) {
 		if (seen.has(type.name)) continue
 		const nextChars = totalChars + type.definition.length
-		if (
-			nextChars > maxReferencedTypeCharsPerExport &&
-			referencedTypes.length > 0
-		) {
-			break
+		if (nextChars > maxReferencedTypeCharsPerExport) {
+			if (maxReferencedTypeCharsPerExport - totalChars <= 0) break
+			continue
 		}
 		seen.add(type.name)
 		totalChars = nextChars

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -429,7 +429,11 @@ function collectLocalTypeDeclarations(
 
 function readTypeReferenceName(node: unknown): string | null {
 	if (!node || typeof node !== 'object') return null
-	if (getNodeType(node) !== 'Identifier') return null
+	const type = getNodeType(node)
+	if (type === 'TSQualifiedName') {
+		return readTypeReferenceName((node as { left?: unknown }).left)
+	}
+	if (type !== 'Identifier') return null
 	return readIdentifierName(node)
 }
 

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -196,6 +196,13 @@ export type PackageExportFunctionProjection = {
 	name: string
 	description: string | null
 	typeDefinition: string | null
+	referencedTypes: Array<PackageReferencedTypeProjection>
+}
+
+export type PackageReferencedTypeProjection = {
+	name: string
+	kind: 'type' | 'interface' | 'enum'
+	definition: string
 }
 
 export type PackageExportProjection = {
@@ -205,6 +212,7 @@ export type PackageExportProjection = {
 	description: string | null
 	typeDefinition: string | null
 	functions: Array<PackageExportFunctionProjection>
+	referencedTypes: Array<PackageReferencedTypeProjection>
 }
 
 export type PackageSearchProjection = {
@@ -242,6 +250,85 @@ export type PackageSearchProjection = {
 	}>
 	retrievers: Array<PackageRetrieverManifestEntry>
 }
+
+type LocalTypeDeclaration = PackageReferencedTypeProjection & {
+	node: ModuleAstNode
+}
+
+const maxReferencedTypesPerExport = 8
+const maxReferencedTypeCharsPerExport = 12_000
+const maxReferencedTypeDepth = 2
+const builtinTypeNames = new Set([
+	'AbortController',
+	'AbortSignal',
+	'Array',
+	'ArrayBuffer',
+	'Awaited',
+	'Blob',
+	'Boolean',
+	'CallableFunction',
+	'Capitalize',
+	'ConstructorParameters',
+	'Date',
+	'Error',
+	'Event',
+	'EventTarget',
+	'Exclude',
+	'Extract',
+	'File',
+	'FormData',
+	'Function',
+	'Headers',
+	'InstanceType',
+	'Intl',
+	'JSON',
+	'Lowercase',
+	'Map',
+	'Math',
+	'NonNullable',
+	'Number',
+	'Object',
+	'Omit',
+	'OmitThisParameter',
+	'Parameters',
+	'Partial',
+	'Pick',
+	'Promise',
+	'Readonly',
+	'ReadonlyArray',
+	'Record',
+	'RegExp',
+	'Request',
+	'Required',
+	'Response',
+	'ReturnType',
+	'Set',
+	'String',
+	'ThisParameterType',
+	'ThisType',
+	'TransformStream',
+	'URL',
+	'URLSearchParams',
+	'Uncapitalize',
+	'Uppercase',
+	'WeakMap',
+	'WeakSet',
+	'WritableStream',
+	'any',
+	'bigint',
+	'boolean',
+	'false',
+	'never',
+	'null',
+	'number',
+	'object',
+	'string',
+	'symbol',
+	'true',
+	'undefined',
+	'unknown',
+	'void',
+])
 
 function getNodeStart(node: unknown) {
 	if (!node || typeof node !== 'object') return null
@@ -292,6 +379,214 @@ function readLeadingJsDoc(source: string, start: number) {
 function readIdentifierName(node: unknown) {
 	const name = (node as { name?: unknown }).name
 	return typeof name === 'string' && name.trim() ? name : null
+}
+
+function getTypeDeclarationKind(
+	node: ModuleAstNode | undefined,
+): PackageReferencedTypeProjection['kind'] | null {
+	if (!node) return null
+	if (node.type === 'TSTypeAliasDeclaration') return 'type'
+	if (node.type === 'TSInterfaceDeclaration') return 'interface'
+	if (node.type === 'TSEnumDeclaration') return 'enum'
+	return null
+}
+
+function collectLocalTypeDeclarations(
+	source: string,
+	body: Array<ModuleAstNode>,
+) {
+	const declarations = new Map<string, LocalTypeDeclaration>()
+	for (const statement of body) {
+		const declaration =
+			statement.type === 'ExportNamedDeclaration'
+				? ((statement as { declaration?: unknown }).declaration as
+						| ModuleAstNode
+						| undefined)
+				: statement
+		const kind = getTypeDeclarationKind(declaration)
+		if (!kind || !declaration) continue
+		const name = readIdentifierName((declaration as { id?: unknown }).id)
+		if (!name || builtinTypeNames.has(name) || declarations.has(name)) continue
+		const definitionNode =
+			statement.type === 'ExportNamedDeclaration' ? statement : declaration
+		const start = getNodeStart(definitionNode)
+		const end = getNodeEnd(definitionNode)
+		if (start == null || end == null) continue
+		const definition = source
+			.slice(start, end)
+			.trim()
+			.replace(/\s*;\s*$/, '')
+		if (!definition) continue
+		declarations.set(name, {
+			name,
+			kind,
+			definition,
+			node: declaration,
+		})
+	}
+	return declarations
+}
+
+function readTypeReferenceName(node: unknown): string | null {
+	if (!node || typeof node !== 'object') return null
+	if (getNodeType(node) !== 'Identifier') return null
+	return readIdentifierName(node)
+}
+
+function pushUniqueTypeName(names: Array<string>, name: string | null) {
+	if (!name || builtinTypeNames.has(name) || names.includes(name)) return
+	names.push(name)
+}
+
+function collectTypeReferenceNamesFromNodes(nodes: Array<unknown>) {
+	const names: Array<string> = []
+	const seen = new Set<object>()
+	function visit(node: unknown) {
+		if (!node || typeof node !== 'object') return
+		if (seen.has(node)) return
+		seen.add(node)
+		const type = getNodeType(node)
+		if (type === 'TSTypeReference') {
+			pushUniqueTypeName(
+				names,
+				readTypeReferenceName((node as { typeName?: unknown }).typeName),
+			)
+		}
+		if (type === 'TSExpressionWithTypeArguments') {
+			pushUniqueTypeName(
+				names,
+				readTypeReferenceName((node as { expression?: unknown }).expression),
+			)
+		}
+		for (const [key, value] of Object.entries(node)) {
+			if (
+				key === 'loc' ||
+				key === 'start' ||
+				key === 'end' ||
+				key === 'leadingComments' ||
+				key === 'trailingComments' ||
+				key === 'innerComments' ||
+				key === 'extra'
+			) {
+				continue
+			}
+			if (Array.isArray(value)) {
+				for (const item of value) visit(item)
+				continue
+			}
+			visit(value)
+		}
+	}
+	for (const node of nodes) visit(node)
+	return names
+}
+
+function getFunctionReferenceNodes(node: unknown) {
+	const functionNode = node as {
+		params?: unknown
+		returnType?: unknown
+		typeParameters?: unknown
+	}
+	const params = Array.isArray(functionNode.params) ? functionNode.params : []
+	return [
+		functionNode.typeParameters,
+		...params.map(
+			(param) => (param as { typeAnnotation?: unknown }).typeAnnotation,
+		),
+		functionNode.returnType,
+	]
+}
+
+function getVariableFunctionReferenceNodes(declarator: ModuleAstNode) {
+	const id = (declarator as { id?: unknown }).id
+	const typeAnnotation = (id as { typeAnnotation?: unknown } | undefined)
+		?.typeAnnotation
+	if (typeAnnotation) return [typeAnnotation]
+	const init = (declarator as { init?: unknown }).init
+	if (
+		getNodeType(init) !== 'ArrowFunctionExpression' &&
+		getNodeType(init) !== 'FunctionExpression'
+	) {
+		return []
+	}
+	return getFunctionReferenceNodes(init)
+}
+
+function collectReferencedTypes(input: {
+	typeNames: Array<string>
+	localTypes: Map<string, LocalTypeDeclaration>
+}) {
+	const referencedTypes: Array<PackageReferencedTypeProjection> = []
+	const seen = new Set<string>()
+	const queued = new Set<string>()
+	const queue: Array<{ name: string; depth: number }> = []
+	let totalChars = 0
+	function enqueue(name: string, depth: number) {
+		if (
+			builtinTypeNames.has(name) ||
+			queued.has(name) ||
+			seen.has(name) ||
+			!input.localTypes.has(name)
+		) {
+			return
+		}
+		queued.add(name)
+		queue.push({ name, depth })
+	}
+	for (const name of input.typeNames) enqueue(name, 0)
+	while (
+		queue.length > 0 &&
+		referencedTypes.length < maxReferencedTypesPerExport
+	) {
+		const next = queue.shift()
+		if (!next) break
+		const declaration = input.localTypes.get(next.name)
+		if (!declaration || seen.has(next.name)) continue
+		const nextChars = totalChars + declaration.definition.length
+		if (
+			nextChars > maxReferencedTypeCharsPerExport &&
+			referencedTypes.length > 0
+		) {
+			break
+		}
+		seen.add(next.name)
+		totalChars = nextChars
+		referencedTypes.push({
+			name: declaration.name,
+			kind: declaration.kind,
+			definition: declaration.definition,
+		})
+		if (next.depth >= maxReferencedTypeDepth) continue
+		for (const nestedName of collectTypeReferenceNamesFromNodes([
+			declaration.node,
+		])) {
+			enqueue(nestedName, next.depth + 1)
+		}
+	}
+	return referencedTypes
+}
+
+function mergeReferencedTypes(
+	typeGroups: Array<Array<PackageReferencedTypeProjection>>,
+) {
+	const referencedTypes: Array<PackageReferencedTypeProjection> = []
+	const seen = new Set<string>()
+	let totalChars = 0
+	for (const type of typeGroups.flat()) {
+		if (seen.has(type.name)) continue
+		const nextChars = totalChars + type.definition.length
+		if (
+			nextChars > maxReferencedTypeCharsPerExport &&
+			referencedTypes.length > 0
+		) {
+			break
+		}
+		seen.add(type.name)
+		totalChars = nextChars
+		referencedTypes.push(type)
+		if (referencedTypes.length >= maxReferencedTypesPerExport) break
+	}
+	return referencedTypes
 }
 
 function getFunctionSignature(input: {
@@ -395,15 +690,14 @@ function getVariableDeclarationExportKind(
 		: 'export'
 }
 
-function collectExportedFunctionsFromSource(
-	source: string,
-): Array<PackageExportFunctionProjection> {
+function collectExportedFunctionsFromSource(source: string) {
 	let body: Array<ModuleAstNode>
 	try {
 		body = getProgramBody(parseModuleSource(source))
 	} catch {
 		return []
 	}
+	const localTypes = collectLocalTypeDeclarations(source, body)
 	const functions: Array<PackageExportFunctionProjection> = []
 	for (const statement of body) {
 		if (statement.type === 'ExportDefaultDeclaration') {
@@ -411,6 +705,11 @@ function collectExportedFunctionsFromSource(
 				.declaration as ModuleAstNode | undefined
 			if (isFunctionDeclaration(declaration)) {
 				const declarationStart = getNodeStart(declaration)
+				const typeDefinition = getFunctionSignature({
+					source,
+					node: declaration,
+					exportKeyword: 'export default',
+				})
 				functions.push({
 					name: 'default',
 					description:
@@ -420,11 +719,15 @@ function collectExportedFunctionsFromSource(
 						(getNodeStart(statement) == null
 							? null
 							: readLeadingJsDoc(source, getNodeStart(statement) ?? 0)),
-					typeDefinition: getFunctionSignature({
-						source,
-						node: declaration,
-						exportKeyword: 'export default',
-					}),
+					typeDefinition,
+					referencedTypes: typeDefinition
+						? collectReferencedTypes({
+								typeNames: collectTypeReferenceNamesFromNodes(
+									getFunctionReferenceNodes(declaration),
+								),
+								localTypes,
+							})
+						: [],
 				})
 			}
 			continue
@@ -439,14 +742,23 @@ function collectExportedFunctionsFromSource(
 		if (isFunctionDeclaration(declaration)) {
 			const name = readIdentifierName((declaration as { id?: unknown }).id)
 			if (!name) continue
+			const typeDefinition = getFunctionSignature({
+				source,
+				node: declaration,
+				exportKeyword: 'export',
+			})
 			functions.push({
 				name,
 				description,
-				typeDefinition: getFunctionSignature({
-					source,
-					node: declaration,
-					exportKeyword: 'export',
-				}),
+				typeDefinition,
+				referencedTypes: typeDefinition
+					? collectReferencedTypes({
+							typeNames: collectTypeReferenceNamesFromNodes(
+								getFunctionReferenceNodes(declaration),
+							),
+							localTypes,
+						})
+					: [],
 			})
 			continue
 		}
@@ -462,14 +774,23 @@ function collectExportedFunctionsFromSource(
 		)) {
 			const name = readIdentifierName((declarator as { id?: unknown }).id)
 			if (!name) continue
+			const typeDefinition = getVariableFunctionSignature({
+				source,
+				declarator,
+				exportKind,
+			})
 			functions.push({
 				name,
 				description,
-				typeDefinition: getVariableFunctionSignature({
-					source,
-					declarator,
-					exportKind,
-				}),
+				typeDefinition,
+				referencedTypes: typeDefinition
+					? collectReferencedTypes({
+							typeNames: collectTypeReferenceNamesFromNodes(
+								getVariableFunctionReferenceNodes(declarator),
+							),
+							localTypes,
+						})
+					: [],
 			})
 		}
 	}
@@ -503,6 +824,9 @@ function summarizePackageExport(input: {
 		typeDefinition:
 			functions.length === 1 ? (firstFunction?.typeDefinition ?? null) : null,
 		functions,
+		referencedTypes: mergeReferencedTypes(
+			functions.map((fn) => fn.referencedTypes),
+		),
 	}
 }
 
@@ -600,6 +924,9 @@ export function buildPackageSearchDocument(
 		const functions = Array.isArray(exportDetail.functions)
 			? exportDetail.functions
 			: []
+		const referencedTypes = Array.isArray(exportDetail.referencedTypes)
+			? exportDetail.referencedTypes
+			: []
 		const values = [
 			typeof exportDetail.subpath === 'string' ? exportDetail.subpath : '',
 			typeof exportDetail.runtimeTarget === 'string'
@@ -617,6 +944,7 @@ export function buildPackageSearchDocument(
 				typeof fn.description === 'string' ? fn.description : '',
 				typeof fn.typeDefinition === 'string' ? fn.typeDefinition : '',
 			]),
+			...referencedTypes.flatMap((type) => [type.name, type.definition]),
 		]
 		return [...values.filter((value) => value.length > 0)].join(' ')
 	})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Collect top-level local type/interface/enum declarations from each package export metadata source.
- Attach only named local types referenced by displayed export function signatures, including shallow nested local references with size/count caps.
- Render a compact "Referenced types" section in package detail and stop dumping full types files by default.

## Validation
- `npx vitest run --project node-unit packages/worker/src/package-registry/manifest.node.test.ts packages/worker/src/mcp/tools/search-format.node.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f04ab8e0-4915-407e-8fd1-50f40544c4bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f04ab8e0-4915-407e-8fd1-50f40544c4bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search ranking and relevance improved by indexing referenced type names and definitions.
  * Package detail pages now show a "Referenced types" section rendering local type definitions alongside exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->