### PR TITLE
Improve saved package export usability

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getSavedPackageById: vi.fn(),
+	loadPackageManifestBySourceId: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageManifestBySourceId: (...args: Array<unknown>) =>
+		mockModule.loadPackageManifestBySourceId(...args),
+}))
+
+const { getPackageCapability } = await import('./get-package.ts')
+
+// eslint-disable-next-line epic-web/prefer-dispose-in-tests -- this suite resets shared hoisted mocks between tests.
+beforeEach(() => {
+	mockModule.getSavedPackageById.mockReset()
+	mockModule.loadPackageManifestBySourceId.mockReset()
+})
+
+test('getPackageCapability returns ready-to-import package exports', async () => {
+	mockModule.getSavedPackageById.mockResolvedValueOnce({
+		id: 'package-1',
+		userId: 'user-1',
+		name: '@kentcdodds/discord-gateway',
+		kodyId: 'discord-gateway',
+		description: 'Discord helpers',
+		tags: ['discord'],
+		searchText: null,
+		sourceId: 'source-1',
+		hasApp: true,
+		createdAt: '2026-04-25T00:00:00.000Z',
+		updatedAt: '2026-04-26T00:00:00.000Z',
+	})
+	mockModule.loadPackageManifestBySourceId.mockResolvedValueOnce({
+		source: { id: 'source-1' },
+		manifest: {
+			name: '@kentcdodds/discord-gateway',
+			exports: {
+				'.': './src/index.ts',
+				'./post-message': {
+					import: './src/post-message.ts',
+					types: './src/post-message.ts',
+				},
+			},
+			kody: {
+				id: 'discord-gateway',
+				description: 'Discord helpers',
+				tags: ['discord'],
+				app: {
+					entry: './src/operator-app.ts',
+				},
+			},
+		},
+	})
+
+	const result = await getPackageCapability.handler(
+		{ package_id: 'package-1' },
+		{
+			env: { APP_DB: {} } as Env,
+			callerContext: {
+				baseUrl: 'https://heykody.dev',
+				user: {
+					userId: 'user-1',
+					email: 'me@kentcdodds.com',
+					displayName: 'Kent',
+				},
+				homeConnectorId: null,
+				remoteConnectors: null,
+				storageContext: null,
+				repoContext: null,
+			},
+		},
+	)
+
+	expect(result).toEqual({
+		package_id: 'package-1',
+		kody_id: 'discord-gateway',
+		name: '@kentcdodds/discord-gateway',
+		description: 'Discord helpers',
+		tags: ['discord'],
+		has_app: true,
+		source_id: 'source-1',
+		created_at: '2026-04-25T00:00:00.000Z',
+		updated_at: '2026-04-26T00:00:00.000Z',
+		exports: [
+			{
+				subpath: '.',
+				import_specifier: 'kody:@kentcdodds/discord-gateway',
+				runtime_target: 'src/index.ts',
+				types_path: null,
+				description: null,
+				type_definition: null,
+			},
+			{
+				subpath: './post-message',
+				import_specifier: 'kody:@kentcdodds/discord-gateway/post-message',
+				runtime_target: 'src/post-message.ts',
+				types_path: 'src/post-message.ts',
+				description: null,
+				type_definition: null,
+			},
+		],
+	})
+	expect(mockModule.loadPackageManifestBySourceId).toHaveBeenCalledWith({
+		env: { APP_DB: {} },
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceId: 'source-1',
+	})
+})
+

--- a/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
@@ -114,4 +114,3 @@ test('getPackageCapability returns ready-to-import package exports', async () =>
 		sourceId: 'source-1',
 	})
 })
-

--- a/packages/worker/src/mcp/capabilities/packages/get-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.ts
@@ -3,16 +3,10 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { buildPackageSearchProjection } from '#worker/package-registry/manifest.ts'
+import { buildPackageImportSpecifier } from '#worker/package-registry/package-import-specifier.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
 import { packageDetailSchema } from './shared.ts'
-
-function buildPackageImportSpecifier(packageName: string, exportName: string) {
-	if (exportName === '.') {
-		return `kody:${packageName}`
-	}
-	return `kody:${packageName}/${exportName.replace(/^\.\//, '')}`
-}
 
 export const getPackageCapability = defineDomainCapability(
 	capabilityDomainNames.packages,

--- a/packages/worker/src/mcp/capabilities/packages/get-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.ts
@@ -2,23 +2,32 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { buildPackageSearchProjection } from '#worker/package-registry/manifest.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
-import { packageSummarySchema } from './shared.ts'
+import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
+import { packageDetailSchema } from './shared.ts'
+
+function buildPackageImportSpecifier(packageName: string, exportName: string) {
+	if (exportName === '.') {
+		return `kody:${packageName}`
+	}
+	return `kody:${packageName}/${exportName.replace(/^\.\//, '')}`
+}
 
 export const getPackageCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
 		name: 'package_get',
 		description:
-			'Load one saved package metadata record for the signed-in user by package id.',
-		keywords: ['package', 'get', 'read', 'metadata'],
+			'Load one saved package metadata record for the signed-in user, including ready-to-import export specifiers.',
+		keywords: ['package', 'get', 'read', 'metadata', 'exports', 'imports'],
 		readOnly: true,
 		idempotent: true,
 		destructive: false,
 		inputSchema: z.object({
 			package_id: z.string().min(1),
 		}),
-		outputSchema: packageSummarySchema,
+		outputSchema: packageDetailSchema,
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
 			const saved = await getSavedPackageById(ctx.env.APP_DB, {
@@ -28,6 +37,13 @@ export const getPackageCapability = defineDomainCapability(
 			if (!saved) {
 				throw new Error('Saved package not found for this user.')
 			}
+			const loaded = await loadPackageManifestBySourceId({
+				env: ctx.env,
+				baseUrl: ctx.callerContext.baseUrl,
+				userId: user.userId,
+				sourceId: saved.sourceId,
+			})
+			const projection = buildPackageSearchProjection(loaded.manifest)
 			return {
 				package_id: saved.id,
 				kody_id: saved.kodyId,
@@ -38,6 +54,17 @@ export const getPackageCapability = defineDomainCapability(
 				source_id: saved.sourceId,
 				created_at: saved.createdAt,
 				updated_at: saved.updatedAt,
+				exports: projection.exports.map((exportDetail) => ({
+					subpath: exportDetail.subpath,
+					import_specifier: buildPackageImportSpecifier(
+						saved.name,
+						exportDetail.subpath,
+					),
+					runtime_target: exportDetail.runtimeTarget,
+					types_path: exportDetail.typesPath,
+					description: exportDetail.description,
+					type_definition: exportDetail.typeDefinition,
+				})),
 			}
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/packages/get-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.ts
@@ -48,7 +48,7 @@ export const getPackageCapability = defineDomainCapability(
 				source_id: saved.sourceId,
 				created_at: saved.createdAt,
 				updated_at: saved.updatedAt,
-				exports: projection.exports.map((exportDetail) => ({
+				exports: (projection.exports ?? []).map((exportDetail) => ({
 					subpath: exportDetail.subpath,
 					import_specifier: buildPackageImportSpecifier(
 						saved.name,

--- a/packages/worker/src/mcp/capabilities/packages/shared.ts
+++ b/packages/worker/src/mcp/capabilities/packages/shared.ts
@@ -21,3 +21,32 @@ export const packageSummarySchema = z.object({
 	created_at: z.string(),
 	updated_at: z.string(),
 })
+
+export const packageExportSurfaceSchema = z.object({
+	subpath: z
+		.string()
+		.describe('Package export subpath from package.json exports.'),
+	import_specifier: z
+		.string()
+		.describe('Ready-to-use kody: import specifier for this export.'),
+	runtime_target: z
+		.string()
+		.nullable()
+		.describe('Package-relative runtime source path for this export.'),
+	types_path: z
+		.string()
+		.nullable()
+		.describe('Package-relative types source path for this export, when declared.'),
+	description: z
+		.string()
+		.nullable()
+		.describe('Export description parsed from JSDoc when available.'),
+	type_definition: z
+		.string()
+		.nullable()
+		.describe('Primary export type signature parsed from source when available.'),
+})
+
+export const packageDetailSchema = packageSummarySchema.extend({
+	exports: z.array(packageExportSurfaceSchema),
+})

--- a/packages/worker/src/mcp/capabilities/packages/shared.ts
+++ b/packages/worker/src/mcp/capabilities/packages/shared.ts
@@ -36,7 +36,9 @@ export const packageExportSurfaceSchema = z.object({
 	types_path: z
 		.string()
 		.nullable()
-		.describe('Package-relative types source path for this export, when declared.'),
+		.describe(
+			'Package-relative types source path for this export, when declared.',
+		),
 	description: z
 		.string()
 		.nullable()
@@ -44,7 +46,9 @@ export const packageExportSurfaceSchema = z.object({
 	type_definition: z
 		.string()
 		.nullable()
-		.describe('Primary export type signature parsed from source when available.'),
+		.describe(
+			'Primary export type signature parsed from source when available.',
+		),
 })
 
 export const packageDetailSchema = packageSummarySchema.extend({

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -3,6 +3,7 @@ import { type ConnectorConfig } from '#mcp/capabilities/values/connector-shared.
 import { type SecretSearchRow } from '#mcp/secrets/types.ts'
 import { type ValueMetadata } from '#mcp/values/types.ts'
 import { buildPackageReadmeDetail } from '#worker/package-registry/package-readme.ts'
+import { buildPackageImportSpecifier } from '#worker/package-registry/package-import-specifier.ts'
 import {
 	type AuthoredPackageJson,
 	type PackageJobSchedule,
@@ -377,13 +378,6 @@ export type SearchMatch =
 
 function buildPackageHostedUrl(baseUrl: string, kodyId: string) {
 	return `${baseUrl.replace(/\/+$/, '')}/packages/${encodeURIComponent(kodyId)}`
-}
-
-function buildPackageImportSpecifier(packageName: string, exportName: string) {
-	if (exportName === '.') {
-		return `kody:${packageName}`
-	}
-	return `kody:${packageName}/${exportName.replace(/^\.\//, '')}`
 }
 
 function buildEntityRef(id: string, type: SearchEntityType) {

--- a/packages/worker/src/package-registry/package-import-specifier.ts
+++ b/packages/worker/src/package-registry/package-import-specifier.ts
@@ -1,0 +1,9 @@
+export function buildPackageImportSpecifier(
+	packageName: string,
+	exportName: string,
+) {
+	if (exportName === '.') {
+		return `kody:${packageName}`
+	}
+	return `kody:${packageName}/${exportName.replace(/^\.\//, '')}`
+}

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -782,6 +782,11 @@ test('buildKodyModuleBundle resolves transitive imports back to the root package
 			},
 		],
 	})
+	expect(mockModule.getSavedPackageByName).toHaveBeenCalledTimes(1)
+	expect(mockModule.getSavedPackageByName).toHaveBeenCalledWith(
+		{},
+		{ userId: 'user-1', name: '@kentcdodds/journaling' },
+	)
 })
 
 test('buildKodyModuleBundle keeps dependencies for scoped packages with the same leaf', async () => {

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -694,6 +694,96 @@ test('buildKodyModuleBundle requires a published artifact before importing saved
 	)
 })
 
+test('buildKodyModuleBundle resolves transitive imports back to the root package source during rebuilds', async () => {
+	mockModule.createWorker.mockResolvedValue(createBundleResult('root-cycle'))
+	mockModule.getSavedPackageByName.mockResolvedValue(
+		createSavedPackageRecord({
+			name: '@kentcdodds/journaling',
+			kodyId: 'journaling',
+			sourceId: 'journaling-source',
+		}),
+	)
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: {
+			id: 'journaling-source',
+			published_commit: 'journaling-commit',
+		},
+		manifest: {
+			name: '@kentcdodds/journaling',
+			exports: {
+				'./upsert-for-thread': './src/upsert-for-thread.ts',
+			},
+			kody: {
+				id: 'journaling',
+				description: 'Journaling package',
+			},
+		},
+		files: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/journaling',
+				exports: {
+					'./upsert-for-thread': './src/upsert-for-thread.ts',
+				},
+				kody: {
+					id: 'journaling',
+					description: 'Journaling package',
+				},
+			}),
+			'src/upsert-for-thread.ts':
+				'import ensureState from "kody:@kentcdodds/personal-history/state-ensure"\nexport default ensureState\n',
+		},
+	})
+	mockModule.loadPublishedBundleArtifactByIdentity.mockResolvedValue(null)
+
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+
+	await expect(
+		buildKodyModuleBundle({
+			env: {
+				APP_DB: {},
+				REPO_SESSION: {},
+			} as Env,
+			baseUrl: 'https://heykody.dev',
+			userId: 'user-1',
+			sourceFiles: {
+				'package.json': JSON.stringify({
+					name: '@kentcdodds/personal-history',
+					exports: {
+						'.': './src/index.ts',
+						'./state-ensure': './src/state-ensure.ts',
+					},
+					dependencies: {
+						jsonrepair: '3.13.1',
+					},
+					kody: {
+						id: 'personal-history',
+						description: 'Personal history package',
+					},
+				}),
+				'src/index.ts':
+					'import upsert from "kody:@kentcdodds/journaling/upsert-for-thread"\nexport default upsert\n',
+				'src/state-ensure.ts':
+					'export default async function ensureState() { return { ok: true } }\n',
+			},
+			entryPoint: 'src/index.ts',
+		}),
+	).resolves.toEqual({
+		mainModule: 'dist/root-cycle.js',
+		modules: {
+			'dist/root-cycle.js':
+				'export default { async fetch() { return new Response("root-cycle") } }',
+		},
+		dependencies: [
+			{
+				sourceId: 'journaling-source',
+				publishedCommit: 'journaling-commit',
+				kodyId: 'journaling',
+				packageName: '@kentcdodds/journaling',
+			},
+		],
+	})
+})
+
 test('buildKodyModuleBundle keeps dependencies for scoped packages with the same leaf', async () => {
 	mockModule.createWorker.mockResolvedValue(createBundleResult('shared-leaf'))
 	mockModule.getSavedPackageByName.mockImplementation(

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -5,8 +5,10 @@ import {
 import {
 	normalizePackageWorkspacePath,
 	normalizePackageExportKey,
+	parseAuthoredPackageJson,
 	resolvePackageExportPath,
 } from '#worker/package-registry/manifest.ts'
+import { type AuthoredPackageJson } from '#worker/package-registry/types.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
 import {
 	createPublishedPackageCacheKey,
@@ -90,6 +92,10 @@ type RewriteState = {
 	baseUrl: string
 	userId: string
 	files: Record<string, string>
+	rootPackage: {
+		manifest: AuthoredPackageJson
+		prefix: string
+	} | null
 	proxies: Map<string, string>
 	packages: Map<
 		string,
@@ -230,6 +236,19 @@ function createPackageProxyPathSegment(specifier: string) {
 	return encodePathKey(
 		`${parsed.packageName}#${normalizePackageExportKey(parsed.exportName)}`,
 	)
+}
+
+function readRootPackage(sourceFiles: Record<string, string>) {
+	const packageJson = sourceFiles[packageManifestPath]
+	if (!packageJson) return null
+	try {
+		return {
+			manifest: parseAuthoredPackageJson({ content: packageJson }),
+			prefix: rootSourcePrefix,
+		}
+	} catch {
+		return null
+	}
 }
 
 function isBundlerRootConfigPath(path: string) {
@@ -440,26 +459,38 @@ async function ensurePackageProxy(
 	const existing = state.proxies.get(specifier)
 	if (existing) return existing
 	const parsed = parseKodyPackageSpecifier(specifier)
-	const loaded = await ensurePackageLoaded(state, specifier)
 	const absoluteExportPath =
-		(await maybeEnsurePublishedArtifactTarget({
-			state,
-			specifier,
-			loaded,
-		})) ??
-		(() => {
-			assertPublishedSourceCanRebuildWithoutInstallingDeps({
-				sourceFiles: loaded.files,
-				bundleLabel: `Saved package export "${normalizePackageExportKey(
-					parsed.exportName,
-				)}"`,
-			})
-			const exportPath = resolvePackageExportPath({
-				manifest: loaded.manifest,
-				exportName: parsed.exportName,
-			})
-			return joinPath(loaded.prefix, exportPath)
-		})()
+		parsed.packageName === state.rootPackage?.manifest.name
+			? joinPath(
+					state.rootPackage.prefix,
+					resolvePackageExportPath({
+						manifest: state.rootPackage.manifest,
+						exportName: parsed.exportName,
+					}),
+				)
+			: await (async () => {
+					const loaded = await ensurePackageLoaded(state, specifier)
+					return (
+						(await maybeEnsurePublishedArtifactTarget({
+							state,
+							specifier,
+							loaded,
+						})) ??
+						(() => {
+							assertPublishedSourceCanRebuildWithoutInstallingDeps({
+								sourceFiles: loaded.files,
+								bundleLabel: `Saved package export "${normalizePackageExportKey(
+									parsed.exportName,
+								)}"`,
+							})
+							const exportPath = resolvePackageExportPath({
+								manifest: loaded.manifest,
+								exportName: parsed.exportName,
+							})
+							return joinPath(loaded.prefix, exportPath)
+						})()
+					)
+				})()
 	const proxyPath = joinPath(
 		packageImportProxyPrefix,
 		`${createPackageProxyPathSegment(specifier)}.js`,
@@ -603,6 +634,7 @@ async function prepareKodyGraphFiles(input: {
 		baseUrl: input.baseUrl,
 		userId: input.userId,
 		files,
+		rootPackage: readRootPackage(input.sourceFiles),
 		proxies: new Map(),
 		packages: new Map(),
 		dependencies: new Map(),

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -8,8 +8,10 @@ import {
 	parseAuthoredPackageJson,
 	resolvePackageExportPath,
 } from '#worker/package-registry/manifest.ts'
-import { type AuthoredPackageJson } from '#worker/package-registry/types.ts'
-import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+import {
+	type AuthoredPackageJson,
+	type SavedPackageRecord,
+} from '#worker/package-registry/types.ts'
 import {
 	createPublishedPackageCacheKey,
 	createPublishedPackagePromiseCache,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Resolves transitive imports back to the root package source during package rebuilds, unblocking packages that import each other while importable artifacts are being regenerated.
- Adds export surfaces to `package_get`, including ready-to-use `kody:` import specifiers and runtime/type targets.
- Shares package import-specifier formatting across package detail and search formatting.
- Adds regression coverage for package rebuild cycles and `package_get` export details.

### Validation
- `npx vitest run "packages/worker/src/package-runtime/module-graph.node.test.ts" "packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts" "packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts" "packages/worker/src/package-registry/service.node.test.ts"`
- `npx vitest run "packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts" "packages/worker/src/mcp/tools/search.node.test.ts"`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

### Review loop
- Addressed Cursor Bugbot feedback by extracting the duplicate import-specifier helper.
- Addressed CodeRabbit feedback by adding a defensive export fallback and an explicit root-bypass assertion.
- Latest GitHub Actions, Cursor Bugbot, and CodeRabbit checks are green.

### Operational follow-up after deploy
- Republish the packages that currently fail on the root-package artifact cycle: `personal-history`, `journaling`, `discord-personal-history`, `discord-general-chat`, and `discord-gateway`.
- Rerun the cross-package import smoke test to confirm explicit import call arguments win over outer execute params.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dad97834-cd91-4c2d-b4ba-3c462e949ae5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dad97834-cd91-4c2d-b4ba-3c462e949ae5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package queries now return detailed export surfaces including ready-to-use import specifiers, runtime targets, type paths, descriptions, and type definitions.

* **Improvements**
  * Better resolution of package-root exports and transitive package imports to produce more accurate module bundles and dependency records.

* **Tests**
  * Added/updated tests validating package detail responses and module-bundling resolution across package boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->