### PR TITLE
Improve package wrapper search ranking

### DIFF
--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest'
 import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
 import { buildConnectorValueName } from '#mcp/capabilities/values/connector-shared.ts'
 import type * as PackageRegistrySource from '#worker/package-registry/source.ts'
+import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
 import {
 	buildSavedPackageSearchRows,
 	loadDownHomeConnectorStatus,
@@ -20,11 +21,12 @@ function createPackageExportProjection(subpath: string) {
 		description: null,
 		typeDefinition: null,
 		functions: [],
+		referencedTypes: [],
 	}
 }
 
 const sourceMocks = vi.hoisted(() => ({
-	loadPackageManifestBySourceId: vi.fn(),
+	loadPackageSourceBySourceId: vi.fn(),
 }))
 
 vi.mock('#worker/package-registry/source.ts', async () => {
@@ -33,8 +35,8 @@ vi.mock('#worker/package-registry/source.ts', async () => {
 	)
 	return {
 		...actual,
-		loadPackageManifestBySourceId: (...args: Array<unknown>) =>
-			sourceMocks.loadPackageManifestBySourceId(...args),
+		loadPackageSourceBySourceId: (...args: Array<unknown>) =>
+			sourceMocks.loadPackageSourceBySourceId(...args),
 	}
 })
 
@@ -510,7 +512,323 @@ test('searchUnified ranks related packages and connectors for operate queries', 
 	})
 })
 
+test('searchUnified prefers safer package wrappers over raw low-level capabilities', async () => {
+	const registry = buildCapabilityRegistry([
+		{
+			name: 'home_access_networks',
+			description: 'Home access network operations',
+			capabilities: [
+				{
+					name: 'home_access_networks_unleashed_request',
+					domain: 'home_access_networks',
+					description:
+						'Raw Unleashed API request for WLAN client disable and block operations. Requires params and an operator reason.',
+					keywords: [
+						'wifi',
+						'wlan',
+						'client',
+						'disable',
+						'block',
+						'unleashed',
+						'params',
+						'reason',
+						'raw',
+						'request',
+					],
+					readOnly: false,
+					idempotent: false,
+					destructive: true,
+					inputSchema: {
+						type: 'object',
+						properties: {
+							params: { type: 'object' },
+							reason: { type: 'string' },
+						},
+					},
+					handler: async () => null,
+				},
+			],
+		},
+	])
+	const result = await searchUnified({
+		env: {} as Env,
+		query: 'wifi disable wlan block client unleashed params reason',
+		limit: 3,
+		registry,
+		optionalRows: {
+			packageRows: [
+				{
+					record: {
+						id: 'unleashed-wifi-pkg',
+						userId: 'user-1',
+						name: '@kentcdodds/unleashed-wifi',
+						kodyId: 'unleashed-wifi',
+						description:
+							'Safer package-first Wi-Fi workflows for Unleashed client controls.',
+						tags: ['wifi', 'unleashed', 'network'],
+						searchText:
+							'Safe wrapper around home_access_networks_unleashed_request for WLAN client disable block operations with confirmation and operator reason.',
+						sourceId: 'source-unleashed-wifi',
+						hasApp: false,
+						createdAt: '2026-04-20T00:00:00.000Z',
+						updatedAt: '2026-04-20T00:00:00.000Z',
+					},
+					projection: {
+						name: '@kentcdodds/unleashed-wifi',
+						kodyId: 'unleashed-wifi',
+						description:
+							'Safer package-first Wi-Fi workflows for Unleashed client controls.',
+						tags: ['wifi', 'unleashed', 'network'],
+						searchText:
+							'Safe wrapper around home_access_networks_unleashed_request for WLAN client disable block operations with confirmation and operator reason.',
+						hasApp: false,
+						appEntry: null,
+						exports: [
+							{
+								subpath: './block-client',
+								runtimeTarget: 'src/block-client.ts',
+								typesPath: 'src/block-client.d.ts',
+								description:
+									'High-level wrapper that renders safe XML payloads for blocking Wi-Fi clients.',
+								typeDefinition:
+									'export declare function blockWifiClient(params: BlockClientParams): Promise<void>',
+								functions: [
+									{
+										name: 'blockWifiClient',
+										description:
+											'Disable or block an Unleashed WLAN client after confirmation.',
+										typeDefinition:
+											'export declare function blockWifiClient(params: BlockClientParams): Promise<void>',
+										referencedTypes: [],
+									},
+								],
+								referencedTypes: [
+									{
+										name: 'BlockClientParams',
+										kind: 'interface',
+										definition:
+											'interface BlockClientParams { clientMac: string; wlan: string; reason: string }',
+									},
+								],
+							},
+						],
+						jobs: [],
+						services: [],
+						workflows: [],
+						subscriptions: [],
+						retrievers: [],
+					},
+				},
+			],
+			userSecretRows: [],
+			userValueRows: [],
+		},
+	})
+
+	expect(result.matches[0]).toMatchObject({
+		type: 'package',
+		kodyId: 'unleashed-wifi',
+	})
+	expect(result.matches).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				type: 'capability',
+				name: 'home_access_networks_unleashed_request',
+			}),
+		]),
+	)
+})
+
+test('searchUnified preserves exact capability matches without a relevant wrapper', async () => {
+	const registry = buildCapabilityRegistry([
+		{
+			name: 'meta',
+			description: 'Meta capabilities',
+			capabilities: [
+				{
+					name: 'meta_memory_verify',
+					domain: 'meta',
+					description:
+						'Verify related long-term memories before updating memory storage.',
+					keywords: ['memory', 'verify', 'storage'],
+					readOnly: true,
+					idempotent: true,
+					destructive: false,
+					inputSchema: {
+						type: 'object',
+						properties: {
+							query: { type: 'string' },
+						},
+					},
+					handler: async () => null,
+				},
+			],
+		},
+	])
+	const result = await searchUnified({
+		env: {} as Env,
+		query: 'meta_memory_verify memory storage',
+		limit: 3,
+		registry,
+		optionalRows: {
+			packageRows: [
+				{
+					record: {
+						id: 'notes-pkg',
+						userId: 'user-1',
+						name: '@kentcdodds/notes-dashboard',
+						kodyId: 'notes-dashboard',
+						description: 'Personal notes dashboard.',
+						tags: ['notes'],
+						searchText: 'notes reminders dashboard',
+						sourceId: 'source-notes',
+						hasApp: true,
+						createdAt: '2026-04-20T00:00:00.000Z',
+						updatedAt: '2026-04-20T00:00:00.000Z',
+					},
+					projection: {
+						name: '@kentcdodds/notes-dashboard',
+						kodyId: 'notes-dashboard',
+						description: 'Personal notes dashboard.',
+						tags: ['notes'],
+						searchText: 'notes reminders dashboard',
+						hasApp: true,
+						appEntry: 'src/app.ts',
+						exports: [],
+						jobs: [],
+						services: [],
+						workflows: [],
+						subscriptions: [],
+						retrievers: [],
+					},
+				},
+			],
+			userSecretRows: [],
+			userValueRows: [],
+		},
+	})
+
+	expect(result.matches[0]).toMatchObject({
+		type: 'capability',
+		name: 'meta_memory_verify',
+	})
+})
+
+test('buildSavedPackageSearchRows hydrates README and export JSDoc search signals', async () => {
+	const manifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/email-received-subscriber',
+			exports: {
+				'./trace-processor': {
+					import: './src/trace-processor.ts',
+					types: './src/trace-processor.d.ts',
+				},
+			},
+			kody: {
+				id: 'email-received-subscriber',
+				description: 'Email received subscriber package',
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+	const files = {
+		'package.json': '{}',
+		'README.md':
+			'# Email received subscriber\n\nPackage-first trace and debug workflow for failed email processor service storage automation.',
+		'src/trace-processor.d.ts': `/**
+ * Trace failed email processor service storage writes.
+ */
+export declare function traceProcessorFailure(messageId: string): Promise<void>
+`,
+	}
+	sourceMocks.loadPackageSourceBySourceId.mockResolvedValueOnce({
+		source: { id: 'source-email' },
+		manifest,
+		files,
+	})
+
+	const rows = await buildSavedPackageSearchRows({
+		env: {} as Env,
+		baseUrl: 'http://localhost',
+		userId: 'user-123',
+		records: [
+			{
+				id: 'email-pkg',
+				userId: 'user-123',
+				name: '@kentcdodds/email-received-subscriber',
+				kodyId: 'email-received-subscriber',
+				description: 'Email received subscriber package',
+				tags: ['email'],
+				searchText: null,
+				sourceId: 'source-email',
+				hasApp: false,
+				createdAt: '2026-04-20T00:00:00.000Z',
+				updatedAt: '2026-04-20T00:00:00.000Z',
+			},
+		],
+	})
+
+	expect(rows.warnings).toEqual([])
+	expect(rows.rows[0]).toMatchObject({
+		readmeSnippet: {
+			path: 'README.md',
+			snippet: expect.stringContaining('trace and debug workflow'),
+			truncated: false,
+		},
+		projection: {
+			exports: [
+				expect.objectContaining({
+					description: 'Trace failed email processor service storage writes.',
+				}),
+			],
+		},
+	})
+
+	const registry = buildCapabilityRegistry([
+		{
+			name: 'email',
+			description: 'Email and storage primitives',
+			capabilities: [
+				{
+					name: 'email_storage_query',
+					domain: 'email',
+					description:
+						'Low-level email service storage query for processor records.',
+					keywords: ['email', 'storage', 'service', 'processor', 'failed'],
+					readOnly: true,
+					idempotent: true,
+					destructive: false,
+					inputSchema: {
+						type: 'object',
+						properties: {},
+					},
+					handler: async () => null,
+				},
+			],
+		},
+	])
+	const result = await searchUnified({
+		env: {} as Env,
+		query: 'email trace failed processor service storage',
+		limit: 3,
+		registry,
+		optionalRows: {
+			packageRows: rows.rows,
+			userSecretRows: [],
+			userValueRows: [],
+		},
+	})
+
+	expect(result.matches[0]).toMatchObject({
+		type: 'package',
+		kodyId: 'email-received-subscriber',
+	})
+})
+
 test('buildSavedPackageSearchRows falls back when package source resolution fails', async () => {
+	sourceMocks.loadPackageSourceBySourceId.mockRejectedValueOnce(
+		new Error('missing-source'),
+	)
 	const result = await buildSavedPackageSearchRows({
 		env: {} as Env,
 		baseUrl: 'http://localhost',

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -36,9 +36,10 @@ import {
 	type PackageSearchProjection,
 } from '#worker/package-registry/manifest.ts'
 import {
-	loadPackageManifestBySourceId,
-	loadPackageSourceBySourceId,
-} from '#worker/package-registry/source.ts'
+	buildPackageReadmeSnippet,
+	type PackageReadmeSnippet,
+} from '#worker/package-registry/package-readme.ts'
+import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 import {
 	getRemoteConnectorStatus,
 	type HomeConnectorStatus,
@@ -83,6 +84,7 @@ const defaultMaxResponseSize = 4_000
 export type PackageSearchRow = {
 	record: Awaited<ReturnType<typeof listSavedPackagesByUserId>>[number]
 	projection: PackageSearchProjection
+	readmeSnippet?: PackageReadmeSnippet | null
 }
 
 export type OptionalSearchRowsResult = {
@@ -104,6 +106,7 @@ export type SearchScoreComponents = {
 	actionMatch: number
 	taskAffinity: number
 	appAvailability: number
+	wrapperWorkflow: number
 	constraint: number
 	final: number
 }
@@ -210,7 +213,7 @@ export async function buildSavedPackageSearchRows(input: {
 	const rows = await Promise.all(
 		input.records.map(async (record) => {
 			try {
-				const loaded = await loadPackageManifestBySourceId({
+				const loaded = await loadPackageSourceBySourceId({
 					env: input.env,
 					baseUrl: input.baseUrl,
 					userId: input.userId,
@@ -218,7 +221,14 @@ export async function buildSavedPackageSearchRows(input: {
 				})
 				return {
 					record,
-					projection: buildPackageSearchProjection(loaded.manifest),
+					projection: buildPackageSearchProjection(
+						loaded.manifest,
+						loaded.files,
+					),
+					readmeSnippet: buildPackageReadmeSnippet({
+						files: loaded.files,
+						maxChars: 1_000,
+					}),
 				}
 			} catch (cause) {
 				Sentry.captureException(cause, {
@@ -333,6 +343,18 @@ function buildSearchableEntityDescriptors(input: {
 	}
 
 	for (const entry of input.optionalRows.packageRows) {
+		const services = Array.isArray(entry.projection.services)
+			? entry.projection.services
+			: []
+		const workflows = Array.isArray(entry.projection.workflows)
+			? entry.projection.workflows
+			: []
+		const subscriptions = Array.isArray(entry.projection.subscriptions)
+			? entry.projection.subscriptions
+			: []
+		const retrievers = Array.isArray(entry.projection.retrievers)
+			? entry.projection.retrievers
+			: []
 		descriptors.push({
 			type: 'package',
 			id: entry.record.kodyId,
@@ -357,11 +379,28 @@ function buildSearchableEntityDescriptors(input: {
 					]),
 				]),
 				...entry.projection.jobs.map((job) => job.name),
-				...entry.projection.retrievers.flatMap((retriever) => [
+				...services.flatMap((service) => [
+					service.name,
+					service.entry,
+					service.mode,
+					service.autoStart ? 'auto-start' : 'manual-start',
+				]),
+				...workflows.flatMap((workflow) => [
+					workflow.name,
+					workflow.exportName,
+					workflow.description ?? '',
+				]),
+				...subscriptions.flatMap((subscription) => [
+					subscription.topic,
+					subscription.handler,
+					subscription.description ?? '',
+				]),
+				...retrievers.flatMap((retriever) => [
 					retriever.key,
 					retriever.name,
 					retriever.description,
 				]),
+				entry.readmeSnippet?.snippet ?? '',
 				...(entry.record.hasApp ? ['app', 'ui', 'remote'] : []),
 			],
 		})
@@ -471,6 +510,7 @@ function buildCandidateBaseScore(input: {
 		actionMatch: 0,
 		taskAffinity: 0,
 		appAvailability: 0,
+		wrapperWorkflow: 0,
 		constraint: 0,
 		final:
 			input.vector === undefined
@@ -519,12 +559,127 @@ function scoreConstraintBoost(
 	return score
 }
 
+const wrapperWorkflowTokenSignals = new Set([
+	'wrap',
+	'wrapper',
+	'wrappers',
+	'wraps',
+	'wrapping',
+	'safe',
+	'safer',
+	'safety',
+	'guardrail',
+	'guardrails',
+	'confirmation',
+	'confirm',
+	'confirmed',
+	'workflow',
+	'workflows',
+	'orchestrate',
+	'orchestrates',
+	'orchestration',
+	'automation',
+	'automations',
+	'helper',
+	'helpers',
+])
+
+const wrapperWorkflowPhraseSignals = [
+	'package first',
+	'high level',
+	'higher level',
+	'safe wrapper',
+	'workflow glue',
+] as const
+
+const packageSurfaceTokenSignals = new Set([
+	'app',
+	'ui',
+	'service',
+	'services',
+	'workflow',
+	'workflows',
+	'subscription',
+	'subscriptions',
+	'retriever',
+	'retrievers',
+	'job',
+	'jobs',
+])
+
+function scorePackageWrapperWorkflowBoost(
+	candidate: SearchCandidate,
+	intent: SearchIntent,
+) {
+	if (candidate.type !== 'package') return 0
+	if (intent.meaningfulTokens.length === 0) return 0
+
+	const fieldText = candidate.searchFields.join('\n')
+	const fieldTokens = new Set(extractSearchTokens(fieldText))
+	const normalizedFieldText = normalizeSearchText(fieldText)
+	const matchedQueryTerms = intent.meaningfulTokens.filter((token) =>
+		fieldTokens.has(token),
+	)
+	const queryCoverage =
+		matchedQueryTerms.length / Math.max(1, intent.meaningfulTokens.length)
+	const actionTermCount = intent.actions.flatMap(
+		(action) => action.matchedTerms,
+	).length
+	const actionCoverage = scoreMatchedTerms(
+		candidate.searchFields,
+		intent.actions.flatMap((action) => action.matchedTerms),
+	)
+
+	const wrapperSignalCount = [...wrapperWorkflowTokenSignals].filter((token) =>
+		fieldTokens.has(token),
+	).length
+	const wrapperPhraseCount = wrapperWorkflowPhraseSignals.filter((phrase) =>
+		normalizedFieldText.includes(phrase),
+	).length
+	const surfaceSignalCount = [...packageSurfaceTokenSignals].filter((token) =>
+		fieldTokens.has(token),
+	).length
+	const hasPackageSurface =
+		surfaceSignalCount > 0 ||
+		('hasApp' in candidate.match && candidate.match.hasApp)
+
+	if (wrapperSignalCount + wrapperPhraseCount === 0 && !hasPackageSurface) {
+		return 0
+	}
+	if (queryCoverage < 0.2 && (actionTermCount === 0 || actionCoverage <= 0)) {
+		return 0
+	}
+
+	const taskWeight =
+		intent.task.name === 'learn'
+			? 0.25
+			: intent.task.name === 'unknown'
+				? 0.75
+				: 1
+	const confidenceWeight = Math.min(
+		1,
+		Math.max(0.35, intent.confidence, intent.task.confidence),
+	)
+	let boost = 0
+	if (wrapperSignalCount > 0) boost += 0.14
+	if (wrapperPhraseCount > 0) boost += 0.1
+	if (hasPackageSurface) boost += 0.1
+	if ('hasApp' in candidate.match && candidate.match.hasApp) boost += 0.04
+	boost += Math.min(0.1, queryCoverage * 0.16)
+	boost += Math.min(0.08, actionCoverage * 0.1)
+	return Math.min(0.42, boost) * confidenceWeight * taskWeight
+}
+
 function scoreTaskAffinity(
 	candidate: SearchCandidate,
 	intent: SearchIntent,
 ): Pick<
 	SearchScoreComponents,
-	'taskAffinity' | 'actionMatch' | 'appAvailability' | 'constraint'
+	| 'taskAffinity'
+	| 'actionMatch'
+	| 'appAvailability'
+	| 'wrapperWorkflow'
+	| 'constraint'
 > {
 	const taskConfidenceWeight = Math.min(
 		1,
@@ -571,6 +726,12 @@ function scoreTaskAffinity(
 			break
 		case 'debug':
 			if (candidate.type === 'connector') taskAffinity += 0.16
+			if (candidate.type === 'package') {
+				taskAffinity += 0.1
+				if ('hasApp' in candidate.match && candidate.match.hasApp) {
+					appAvailability += 0.08
+				}
+			}
 			if (candidate.type === 'capability') taskAffinity += 0.06
 			if (candidate.type === 'value') taskAffinity += 0.04
 			break
@@ -582,6 +743,7 @@ function scoreTaskAffinity(
 		taskAffinity: taskAffinity * taskConfidenceWeight,
 		actionMatch,
 		appAvailability,
+		wrapperWorkflow: scorePackageWrapperWorkflowBoost(candidate, intent),
 		constraint,
 	}
 }
@@ -611,6 +773,7 @@ function rerankCandidates(input: {
 			taskSignals.actionMatch +
 			taskSignals.taskAffinity +
 			taskSignals.appAvailability +
+			taskSignals.wrapperWorkflow +
 			taskSignals.constraint
 
 		return {
@@ -621,6 +784,7 @@ function rerankCandidates(input: {
 				actionMatch: taskSignals.actionMatch,
 				taskAffinity: taskSignals.taskAffinity,
 				appAvailability: taskSignals.appAvailability,
+				wrapperWorkflow: taskSignals.wrapperWorkflow,
 				constraint: taskSignals.constraint,
 				final,
 			},
@@ -680,7 +844,22 @@ function buildPackageCandidates(input: {
 			const retrievers = Array.isArray(entry.projection.retrievers)
 				? entry.projection.retrievers
 				: []
-			const document = buildPackageSearchDocument(entry.projection)
+			const services = Array.isArray(entry.projection.services)
+				? entry.projection.services
+				: []
+			const workflows = Array.isArray(entry.projection.workflows)
+				? entry.projection.workflows
+				: []
+			const subscriptions = Array.isArray(entry.projection.subscriptions)
+				? entry.projection.subscriptions
+				: []
+			const readmeSnippet = entry.readmeSnippet?.snippet ?? ''
+			const document = [
+				buildPackageSearchDocument(entry.projection),
+				readmeSnippet,
+			]
+				.filter((value) => value.trim().length > 0)
+				.join('\n')
 			const lexical = lexicalScore(input.query, document)
 			const vector = cosineSimilarity(
 				input.queryEmbedding,
@@ -696,6 +875,7 @@ function buildPackageCandidates(input: {
 					description: entry.record.description,
 					tags: entry.record.tags,
 					hasApp: entry.record.hasApp,
+					readmeSnippet: entry.readmeSnippet ?? null,
 				},
 				type: 'package' as const,
 				id: entry.record.kodyId,
@@ -726,6 +906,23 @@ function buildPackageCandidates(input: {
 						job.schedule,
 						job.enabled ? 'enabled' : 'disabled',
 					]),
+					...services.flatMap((service) => [
+						service.name,
+						service.entry,
+						service.mode,
+						service.autoStart ? 'auto-start' : 'manual-start',
+						service.timeoutMs != null ? `timeout-ms:${service.timeoutMs}` : '',
+					]),
+					...workflows.flatMap((workflow) => [
+						workflow.name,
+						workflow.exportName,
+						workflow.description ?? '',
+					]),
+					...subscriptions.flatMap((subscription) => [
+						subscription.topic,
+						subscription.handler,
+						subscription.description ?? '',
+					]),
 					...retrievers.flatMap((retriever) => [
 						retriever.key,
 						retriever.name,
@@ -734,6 +931,7 @@ function buildPackageCandidates(input: {
 						...retriever.scopes,
 					]),
 					...(entry.projection.appEntry ? [entry.projection.appEntry] : []),
+					readmeSnippet,
 					...(entry.record.hasApp ? ['app', 'ui', 'remote'] : []),
 				],
 				scoreComponents: buildCandidateBaseScore({

--- a/packages/worker/src/mcp/tools/understand-search-query.ts
+++ b/packages/worker/src/mcp/tools/understand-search-query.ts
@@ -32,6 +32,10 @@ const taskLexicon = {
 		'stop',
 		'run',
 		'launch',
+		'enable',
+		'disable',
+		'block',
+		'unblock',
 		'set',
 		'turn',
 		'skip',
@@ -61,6 +65,8 @@ const taskLexicon = {
 		'inspect',
 		'view',
 		'current',
+		'latest',
+		'summary',
 	],
 	learn: [
 		'what',
@@ -84,6 +90,9 @@ const taskLexicon = {
 		'broken',
 		'troubleshoot',
 		'diagnose',
+		'trace',
+		'traces',
+		'triage',
 	],
 } as const
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- hydrate saved-package search rows from full package source so README snippets and export JSDoc/type metadata contribute to broad search ranking
- add wrapper/workflow ranking signals for saved packages with package-first surfaces, while preserving direct capability matches when no relevant wrapper exists
- broaden package search fields to include services, workflows, subscriptions, retrievers, and README snippets; add intent terms for disable/block/latest/summary/trace/triage

## Tests
- `npm exec vitest -- packages/worker/src/mcp/tools/search.node.test.ts --run`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm exec -- oxfmt --check packages/worker/src/mcp/tools/search.ts packages/worker/src/mcp/tools/search.node.test.ts packages/worker/src/mcp/tools/understand-search-query.ts`

Note: `npm run format:check` still reports pre-existing format issues in unrelated files: `docs/contributing/packages-and-manifests.md`, `packages/worker/src/mcp/run-codemode-registry.node.test.ts`, and `packages/worker/src/package-runtime/module-graph.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e83880a-0e19-43c6-8b96-bf526340a105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e83880a-0e19-43c6-8b96-bf526340a105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

