### PR TITLE
Fix saved package importable default exports

### DIFF
--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -1,3 +1,7 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { pathToFileURL } from 'node:url'
 import { beforeEach, expect, test, vi } from 'vitest'
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
 import type * as PublishedBundleArtifactsModule from './published-bundle-artifacts.ts'
@@ -92,6 +96,25 @@ function createBundleInput(input?: {
 		},
 		entryPoint: input?.entryPoint ?? 'app.js',
 		cacheKey: input?.cacheKey,
+	}
+}
+
+async function createTemporaryModuleGraph(files: Record<string, string>) {
+	const root = await mkdtemp(join(tmpdir(), 'kody-module-graph-'))
+	for (const [filePath, source] of Object.entries(files)) {
+		const destination = join(root, filePath)
+		await mkdir(dirname(destination), { recursive: true })
+		await writeFile(destination, source, 'utf8')
+	}
+	return {
+		async importModule(modulePath: string) {
+			const moduleUrl = pathToFileURL(join(root, modulePath))
+			moduleUrl.searchParams.set('cache', crypto.randomUUID())
+			return await import(moduleUrl.href)
+		},
+		async cleanup() {
+			await rm(root, { recursive: true, force: true })
+		},
 	}
 }
 
@@ -467,6 +490,159 @@ test('buildKodyModuleBundle prefers published importable export artifacts for sa
 	)
 	expect(proxyEntry?.[1]).toContain('.__published_bundle__')
 	expect(proxyEntry?.[1]).not.toContain('src/html.ts')
+})
+
+test('buildKodyModuleBundle imports published importable defaults as callable default exports', async () => {
+	mockModule.createWorker.mockImplementation(
+		async (input: { files: Record<string, string>; entryPoint: string }) => ({
+			mainModule: input.entryPoint,
+			modules: input.files,
+			dependencies: [],
+		}),
+	)
+	mockModule.getSavedPackageByName.mockResolvedValue(createSavedPackageRecord())
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: {
+			id: 'source-1',
+			published_commit: 'commit-1',
+		},
+		manifest: {
+			name: '@kentcdodds/example-package',
+			exports: {
+				'./callable': './src/callable.js',
+			},
+			kody: {
+				id: 'example-package',
+				description: 'Example package',
+			},
+		},
+		files: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/example-package',
+				exports: {
+					'./callable': './src/callable.js',
+				},
+				kody: {
+					id: 'example-package',
+					description: 'Example package',
+				},
+			}),
+			'src/callable.js': [
+				'export const marker = "provider"',
+				'export default function callable(input = {}) {',
+				'\treturn { ok: true, value: input.value }',
+				'}',
+			].join('\n'),
+		},
+	})
+
+	const { buildKodyImportableModuleBundle, buildKodyModuleBundle } =
+		await import('./module-graph.ts')
+	const importableBundle = await buildKodyImportableModuleBundle({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/example-package',
+				exports: {
+					'./callable': './src/callable.js',
+				},
+				kody: {
+					id: 'example-package',
+					description: 'Example package',
+				},
+			}),
+			'src/callable.js': [
+				'export const marker = "provider"',
+				'export default function callable(input = {}) {',
+				'\treturn { ok: true, value: input.value }',
+				'}',
+			].join('\n'),
+		},
+		entryPoint: 'src/callable.js',
+	})
+	mockModule.loadPublishedBundleArtifactByIdentity.mockImplementation(
+		async (input: { kind: string }) =>
+			input.kind === 'importable-module'
+				? {
+						row: {
+							id: 'artifact-1',
+						},
+						artifact: {
+							version: 1,
+							kind: 'importable-module',
+							artifactName: './callable',
+							sourceId: 'source-1',
+							publishedCommit: 'commit-1',
+							entryPoint: 'src/callable.js',
+							mainModule: importableBundle.mainModule,
+							modules: importableBundle.modules,
+							dependencies: [],
+							packageContext: {
+								packageId: 'pkg-1',
+								kodyId: 'example-package',
+								sourceId: 'source-1',
+							},
+							serviceContext: null,
+							createdAt: '2026-05-01T00:00:00.000Z',
+						},
+					}
+				: null,
+	)
+
+	await buildKodyModuleBundle({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/local-package',
+				exports: {
+					'.': './index.js',
+				},
+				kody: {
+					id: 'local-package',
+					description: 'Local package',
+				},
+			}),
+			'index.js': [
+				'import callable from "kody:@kentcdodds/example-package/callable"',
+				'export default callable',
+			].join('\n'),
+		},
+		entryPoint: 'index.js',
+	})
+
+	const consumerCall = mockModule.createWorker.mock.calls.at(-1)?.[0] as
+		| {
+				files?: Record<string, string>
+		  }
+		| undefined
+	const proxyEntry = Object.entries(consumerCall?.files ?? {}).find(([path]) =>
+		path.includes('__kody_virtual__/imports/'),
+	)
+	expect(proxyEntry).toBeDefined()
+	const moduleGraph = await createTemporaryModuleGraph(
+		consumerCall?.files ?? {},
+	)
+	try {
+		const proxyModule = await moduleGraph.importModule(proxyEntry?.[0] ?? '')
+		expect(proxyModule.marker).toBe('provider')
+		expect(typeof proxyModule.default).toBe('function')
+		expect(proxyModule.default({ value: 'from-published-artifact' })).toEqual({
+			ok: true,
+			value: 'from-published-artifact',
+		})
+	} finally {
+		await moduleGraph.cleanup()
+	}
 })
 
 test('buildKodyModuleBundle keeps distinct proxy and artifact paths for exports whose names only differ by punctuation', async () => {

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -106,6 +106,11 @@ async function createTemporaryModuleGraph(files: Record<string, string>) {
 		await mkdir(dirname(destination), { recursive: true })
 		await writeFile(destination, source, 'utf8')
 	}
+	await writeFile(
+		join(root, 'package.json'),
+		JSON.stringify({ type: 'module' }),
+		'utf8',
+	)
 	return {
 		async importModule(modulePath: string) {
 			const moduleUrl = pathToFileURL(join(root, modulePath))

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -163,9 +163,7 @@ export default runtime;
 `.trim()
 }
 
-function createExecuteEntrypointSource(input: {
-	modulePath: string
-}) {
+function createExecuteEntrypointSource(input: { modulePath: string }) {
 	return `
 import userEntrypoint from ${JSON.stringify(input.modulePath)};
 
@@ -221,7 +219,7 @@ function createImportableEntrypointSource(input: { modulePath: string }) {
 	return `
 export * from ${JSON.stringify(input.modulePath)};
 import * as userModule from ${JSON.stringify(input.modulePath)};
-export default userModule;
+export default userModule.default;
 `.trim()
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix importable saved package bundle bootstraps to default-export the underlying module default instead of the module namespace.
- Add a regression covering a published importable artifact consumed through a cross-package import.
- Ensure the temp module graph used by the regression is loaded as ESM.

## Testing
- `npx vitest run --project node-unit packages/worker/src/package-runtime/module-graph.node.test.ts`
- `npm run test`
- `npm run typecheck`
- `npm run lint`
- `npx oxfmt --check packages/worker/src/package-runtime/module-graph.ts packages/worker/src/package-runtime/module-graph.node.test.ts`
- CI on commit `70ab56725890faca1fe4b628c0c6f2a3b2d85d9c` passed: Unit Tests, Typecheck, MCP E2E, E2E, Lint, Deploy Preview Resources, Cursor Bugbot, and CodeRabbit.

## Notes
- Addressed CodeRabbit's valid ESM temp graph review comment in commit `70ab567`.
- `npm run format:check` currently reports unrelated pre-existing format issues in `docs/contributing/packages-and-manifests.md` and `packages/worker/src/mcp/run-codemode-registry.node.test.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96f58ae3-0aa9-4bf8-b91b-8f0ce727c51b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96f58ae3-0aa9-4bf8-b91b-8f0ce727c51b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of default exports in importable modules so callable defaults are exposed and forward input correctly.

* **Tests**
  * Added end-to-end tests validating generated proxy modules expose markers and callable default semantics, including lifecycle cleanup of temporary module artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->