### PR TITLE
Fix package workflow identity for recurring runs

### DIFF
--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -140,11 +140,12 @@ payloads in workflow params or metadata. The package export should look up
 current secrets/configuration from normal package runtime helpers when it runs.
 
 Workflow instance ids are deterministic for
-`(userId, packageId, workflowName, idempotencyKey)`, so repeated planners can
-safely attempt to create the same instance without duplicating it. The host
-workflow sleeps until `runAt`, then invokes the saved package export through the
-same package execution path used by package invocations. Workflow instances are
-not search results and are not saved as a new top-level Kody entity.
+`(userId, packageId, workflowName, idempotencyKey, runAt)`, so repeated planners
+can safely attempt to create the same scheduled instance without duplicating it.
+The host workflow sleeps until `runAt`, then invokes the saved package export
+through the same package execution path used by package invocations. Workflow
+instances are not search results and are not saved as a new top-level Kody
+entity.
 
 ## Package-owned retrievers
 
@@ -178,9 +179,10 @@ Example:
 ```
 
 Retriever exports receive their first function argument with `query`, `scope`,
-`memoryContext`, `limit`, and `conversationId`, and return `{ "results": [...] }`
-where each result has `id`, `title`, `summary`, optional `details`, optional
-`score`, optional `source`, optional `url`, and optional `metadata`.
+`memoryContext`, `limit`, and `conversationId`, and return
+`{ "results": [...] }` where each result has `id`, `title`, `summary`, optional
+`details`, optional `score`, optional `source`, optional `url`, and optional
+`metadata`.
 
 The runtime validates retriever output before surfacing it. A retriever may
 return at most 20 results; payloads with more than 20 results are rejected.

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -47,36 +47,77 @@ function createWorkflowBinding(options?: {
 	}
 }
 
-test('createPackageWorkflowInstanceId is stable and scoped to package workflow inputs', async () => {
+function createStatefulWorkflowBinding() {
+	const instances = new Map<string, WorkflowInstanceCreateOptions>()
+	const create = vi.fn(async (input: WorkflowInstanceCreateOptions) => {
+		if (instances.has(input.id)) {
+			throw new Error('Workflow instance already exists')
+		}
+		instances.set(input.id, input)
+		return {
+			id: input.id,
+			status: async () => ({ status: 'queued' }),
+		}
+	})
+	const get = vi.fn(async (id: string) => {
+		if (!instances.has(id)) {
+			throw new Error('workflow instance does not exist')
+		}
+		return {
+			id,
+			status: async () => ({ status: 'waiting' }),
+		}
+	})
+	return {
+		workflow: { get, create } as unknown as Workflow,
+		get,
+		create,
+		instances,
+	}
+}
+
+test('createPackageWorkflowInstanceId is stable and scoped to scheduled package workflow inputs', async () => {
 	const first = await createPackageWorkflowInstanceId({
 		userId: 'user-1',
 		packageId: 'pkg-1',
 		workflowName: 'shade-event',
 		idempotencyKey: 'event-2026-05-03T10:00:00Z',
+		runAt: '2026-05-03T10:00:00.000Z',
 	})
 	const second = await createPackageWorkflowInstanceId({
 		idempotencyKey: 'event-2026-05-03T10:00:00Z',
 		workflowName: 'shade-event',
 		packageId: 'pkg-1',
 		userId: 'user-1',
+		runAt: '2026-05-03T10:00:00.000Z',
 	})
 	const withWhitespace = await createPackageWorkflowInstanceId({
 		userId: ' user-1 ',
 		packageId: ' pkg-1 ',
 		workflowName: ' shade-event ',
 		idempotencyKey: ' event-2026-05-03T10:00:00Z ',
+		runAt: '2026-05-03T10:00:00.000Z',
 	})
 	const differentPackage = await createPackageWorkflowInstanceId({
 		userId: 'user-1',
 		packageId: 'pkg-2',
 		workflowName: 'shade-event',
 		idempotencyKey: 'event-2026-05-03T10:00:00Z',
+		runAt: '2026-05-03T10:00:00.000Z',
+	})
+	const differentRunAt = await createPackageWorkflowInstanceId({
+		userId: 'user-1',
+		packageId: 'pkg-1',
+		workflowName: 'shade-event',
+		idempotencyKey: 'event-2026-05-03T10:00:00Z',
+		runAt: '2026-05-04T10:00:00.000Z',
 	})
 
 	expect(first).toBe(second)
 	expect(first).toBe(withWhitespace)
 	expect(first).toMatch(/^pkgwf-[A-Za-z0-9_-]{43}$/)
 	expect(differentPackage).not.toBe(first)
+	expect(differentRunAt).not.toBe(first)
 })
 
 test('createPackageWorkflowPayload keeps only safe routing metadata and small params', () => {
@@ -176,6 +217,49 @@ test('createPackageWorkflowInstance creates deterministic instance and returns e
 		id: created.id,
 		status: 'waiting',
 	})
+})
+
+test('createPackageWorkflowInstance creates a new instance for a recurring daily workflow run', async () => {
+	const binding = createStatefulWorkflowBinding()
+	const yesterday = await createPackageWorkflowInstance({
+		workflow: binding.workflow,
+		userId: 'user-1',
+		packageId: 'pkg-1',
+		kodyId: 'shade-automation',
+		sourceId: 'source-1',
+		workflowName: 'shade-event',
+		exportName: './workflow-run-event',
+		runAt: '2026-05-06T12:00:00.000Z',
+		idempotencyKey: 'morning-shades-up',
+		params: { roomId: 'primary-bedroom', action: 'open' },
+	})
+	const today = await createPackageWorkflowInstance({
+		workflow: binding.workflow,
+		userId: 'user-1',
+		packageId: 'pkg-1',
+		kodyId: 'shade-automation',
+		sourceId: 'source-1',
+		workflowName: 'shade-event',
+		exportName: './workflow-run-event',
+		runAt: '2026-05-07T12:00:00.000Z',
+		idempotencyKey: 'morning-shades-up',
+		params: { roomId: 'primary-bedroom', action: 'open' },
+	})
+
+	expect(yesterday.id).not.toBe(today.id)
+	expect(binding.create).toHaveBeenCalledTimes(2)
+	expect(
+		[...binding.instances.values()].map((instance) => instance.params),
+	).toEqual([
+		expect.objectContaining({
+			runAt: '2026-05-06T12:00:00.000Z',
+			planDate: '2026-05-06',
+		}),
+		expect.objectContaining({
+			runAt: '2026-05-07T12:00:00.000Z',
+			planDate: '2026-05-07',
+		}),
+	])
 })
 
 test('createPackageWorkflowInstance returns existing instance after duplicate create race', async () => {

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -169,6 +169,7 @@ export async function createPackageWorkflowInstanceId(input: {
 	packageId: string
 	workflowName: string
 	idempotencyKey: string
+	runAt: string | Date
 }) {
 	const canonical = canonicalJsonStringify({
 		userId: normalizeNonEmptyString(input.userId, 'userId'),
@@ -178,6 +179,7 @@ export async function createPackageWorkflowInstanceId(input: {
 			input.idempotencyKey,
 			'idempotencyKey',
 		),
+		runAt: normalizeRunAt(input.runAt),
 	})
 	return `pkgwf-${(await sha256Base64Url(canonical)).slice(0, 43)}`
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Include `runAt` in package workflow instance identity so recurring planned events with the same logical idempotency key create separate scheduled workflow instances.
- Add a regression test covering daily shade workflow runs.
- Update package workflow documentation to describe the identity contract.

## Testing
- `npm run test -- packages/worker/src/package-runtime/package-workflows.node.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format -- --check docs/contributing/packages-and-manifests.md packages/worker/src/package-runtime/package-workflows.ts packages/worker/src/package-runtime/package-workflows.node.test.ts`
- `npm run build`
- `git diff --check HEAD~1 HEAD`

## Notes
- `npm run validate` was attempted; it stopped on existing repository-wide format issues in unrelated files (`README.md`, `docs/contributing/architecture/data-storage.md`, `docs/contributing/architecture/remote-connectors.md`, `docs/contributing/package-invocation-api.md`, `packages/worker/src/mcp/run-codemode-registry.node.test.ts`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e64d2f3-622a-4a7e-ae9f-8b08436f6a90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e64d2f3-622a-4a7e-ae9f-8b08436f6a90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package-owned workflows and retrievers documentation with clarified descriptions.

* **Improvements**
  * Workflow instances now generate distinct IDs based on their scheduled time, ensuring proper handling of recurring workflows with multiple execution times.

* **Tests**
  * Added test coverage for workflow instance ID stability and distinct IDs for recurring scheduled runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->