### PR TITLE
Attach default home remote connector to MCP caller context

### DIFF
--- a/packages/worker/src/chat-agent-mcp-context.node.test.ts
+++ b/packages/worker/src/chat-agent-mcp-context.node.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'vitest'
+import { createChatMcpCallerContext } from './chat-agent-mcp-context.ts'
+
+test('chat MCP caller context includes the default home remote connector', () => {
+	const callerContext = createChatMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: {
+			userId: 'user-123',
+			email: 'me@kentcdodds.com',
+			displayName: 'Kent',
+		},
+	})
+
+	expect(callerContext).toMatchObject({
+		baseUrl: 'https://heykody.dev',
+		remoteConnectors: [{ kind: 'home', instanceId: 'default' }],
+		user: {
+			userId: 'user-123',
+			email: 'me@kentcdodds.com',
+			displayName: 'Kent',
+		},
+	})
+})

--- a/packages/worker/src/chat-agent-mcp-context.ts
+++ b/packages/worker/src/chat-agent-mcp-context.ts
@@ -1,0 +1,9 @@
+import { type McpUserContext } from '@kody-internal/shared/chat.ts'
+import { createDefaultMcpCallerContext } from './mcp/context.ts'
+
+export function createChatMcpCallerContext(input: {
+	baseUrl: string
+	user: McpUserContext
+}) {
+	return createDefaultMcpCallerContext(input)
+}

--- a/packages/worker/src/chat-agent.ts
+++ b/packages/worker/src/chat-agent.ts
@@ -8,7 +8,7 @@ import {
 import { type Connection, type ConnectionContext } from 'agents'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { createChatThreadsStore } from '#app/chat-threads.ts'
-import { createMcpCallerContext } from './mcp/context.ts'
+import { createChatMcpCallerContext } from './chat-agent-mcp-context.ts'
 import { createAiRuntime, type AiRuntimeResult } from './ai-runtime.ts'
 import { buildSentryOptions } from './sentry-options.ts'
 
@@ -126,7 +126,7 @@ class ChatAgentBase extends AIChatAgent<Env> {
 	private runtimeContext: {
 		appUserId: number
 		baseUrl: string
-		user: ReturnType<typeof createMcpCallerContext>['user']
+		user: ReturnType<typeof createChatMcpCallerContext>['user']
 	} | null = null
 
 	private getRuntimeContext() {
@@ -265,7 +265,7 @@ class ChatAgentBase extends AIChatAgent<Env> {
 		}
 		this.persistRuntimeContext()
 		await this.addMcpServer('kody', this.env.MCP_OBJECT, {
-			props: createMcpCallerContext({
+			props: createChatMcpCallerContext({
 				baseUrl,
 				user: user.mcpUser,
 			}),

--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -3,7 +3,10 @@ import {
 	type TokenSummary,
 } from '@cloudflare/workers-oauth-provider'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
-import { createMcpCallerContext, type McpServerProps } from './mcp/context.ts'
+import {
+	createDefaultMcpCallerContext,
+	type McpServerProps,
+} from './mcp/context.ts'
 import { oauthScopes } from './oauth-handlers.ts'
 
 export const mcpResourcePath = '/mcp'
@@ -110,7 +113,7 @@ export async function handleMcpRequest({
 	}
 
 	const context = ctx as OAuthExecutionContext
-	const props: OAuthContextProps = createMcpCallerContext({
+	const props: OAuthContextProps = createDefaultMcpCallerContext({
 		baseUrl: origin,
 		user: tokenSummary.grant.props ?? null,
 	})

--- a/packages/worker/src/mcp-auth.workers.test.ts
+++ b/packages/worker/src/mcp-auth.workers.test.ts
@@ -197,7 +197,7 @@ test('mcp request forwards when token is valid', async () => {
 	expect(response.status).toBe(200)
 	expect(receivedProps).toMatchObject({
 		baseUrl: 'https://example.com',
-		remoteConnectors: null,
+		remoteConnectors: [{ kind: 'home', instanceId: 'default' }],
 		storageContext: null,
 		user: { userId: 'user' },
 	})

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from 'vitest'
-import { createMcpCallerContext } from '#mcp/context.ts'
+import {
+	createDefaultMcpCallerContext,
+	createMcpCallerContext,
+} from '#mcp/context.ts'
 import { metaListCapabilitiesCapability } from './meta-list-capabilities.ts'
 
 const runtimeRokuTools = [
@@ -87,6 +90,39 @@ function buildRemoteConnectorEnv() {
 	} as unknown as Env
 }
 
+function buildHomeRemoteConnectorEnv() {
+	return {
+		REMOTE_CONNECTOR_SESSION: {
+			idFromName(name: string) {
+				return name
+			},
+			get() {
+				return {
+					getSnapshot() {
+						return Promise.resolve({
+							connectorId: 'default',
+							connectorKind: 'home',
+							connectedAt: '2026-05-07T00:00:00.000Z',
+							lastSeenAt: '2026-05-07T00:00:01.000Z',
+							tools: [
+								{
+									name: 'home_status',
+									title: 'Home Status',
+									description: 'Read the current home connector status.',
+									inputSchema: {
+										type: 'object',
+										properties: {},
+									},
+								},
+							],
+						})
+					},
+				}
+			},
+		},
+	} as unknown as Env
+}
+
 test('meta_list_capabilities includes runtime remote connector capabilities with type definitions only', async () => {
 	const env = buildRemoteConnectorEnv()
 
@@ -129,6 +165,26 @@ test('meta_list_capabilities includes runtime remote connector capabilities with
 	expect(listAppsCapability).not.toHaveProperty('outputSchema')
 	expect(activeAppCapability).not.toBeUndefined()
 	expect(activeAppCapability?.domain).toBe('remote:roku:default')
+})
+
+test('meta_list_capabilities includes capabilities from the default home remote connector', async () => {
+	const result = await metaListCapabilitiesCapability.handler(
+		{
+			detail: true,
+		},
+		{
+			env: buildHomeRemoteConnectorEnv(),
+			callerContext: createDefaultMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+			}),
+		},
+	)
+
+	const homeStatusCapability = result.capabilities.find(
+		(capability) => capability.name === 'home_default_home_status',
+	)
+	expect(homeStatusCapability).not.toBeUndefined()
+	expect(homeStatusCapability?.domain).toBe('remote:home:default')
 })
 
 test('meta_list_capabilities filters by domain', async () => {

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-remote-connector-status.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-remote-connector-status.node.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'vitest'
+import { createDefaultMcpCallerContext } from '#mcp/context.ts'
+import { metaListRemoteConnectorStatusCapability } from './meta-list-remote-connector-status.ts'
+
+function buildRemoteConnectorEnv() {
+	return {
+		REMOTE_CONNECTOR_SESSION: {
+			idFromName(name: string) {
+				return name
+			},
+			get() {
+				return {
+					getSnapshot() {
+						return Promise.resolve({
+							connectorId: 'default',
+							connectorKind: 'home',
+							connectedAt: '2026-05-07T00:00:00.000Z',
+							lastSeenAt: '2026-05-07T00:00:01.000Z',
+							tools: [{ name: 'home_status' }],
+						})
+					},
+				}
+			},
+		},
+	} as unknown as Env
+}
+
+test('meta_list_remote_connector_status sees the default home remote connector', async () => {
+	const result = await metaListRemoteConnectorStatusCapability.handler(
+		{},
+		{
+			env: buildRemoteConnectorEnv(),
+			callerContext: createDefaultMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+			}),
+		},
+	)
+
+	expect(result.connectors).toEqual([
+		expect.objectContaining({
+			connector_kind: 'home',
+			connector_instance_id: 'default',
+			status: 'connected',
+			connected: true,
+			tool_count: 1,
+		}),
+	])
+})

--- a/packages/worker/src/mcp/context.node.test.ts
+++ b/packages/worker/src/mcp/context.node.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from 'vitest'
-import { createMcpCallerContext, parseMcpCallerContext } from './context.ts'
+import {
+	createDefaultMcpCallerContext,
+	createMcpCallerContext,
+	getDefaultMcpRemoteConnectorRefs,
+	parseMcpCallerContext,
+} from './context.ts'
 
 test('createMcpCallerContext normalizes missing user to null', () => {
 	expect(
@@ -13,6 +18,43 @@ test('createMcpCallerContext normalizes missing user to null', () => {
 		storageContext: null,
 		user: null,
 	})
+})
+
+test('createDefaultMcpCallerContext attaches the default home remote connector', () => {
+	expect(
+		createDefaultMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+		}),
+	).toMatchObject({
+		baseUrl: 'https://heykody.dev',
+		remoteConnectors: [{ kind: 'home', instanceId: 'default' }],
+		user: null,
+	})
+})
+
+test('createDefaultMcpCallerContext preserves explicit remote connector refs', () => {
+	expect(
+		createDefaultMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			remoteConnectors: [{ kind: 'lights', instanceId: 'living-room' }],
+		}).remoteConnectors,
+	).toEqual([{ kind: 'lights', instanceId: 'living-room' }])
+
+	expect(
+		createDefaultMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			remoteConnectors: null,
+		}).remoteConnectors,
+	).toBeNull()
+})
+
+test('getDefaultMcpRemoteConnectorRefs returns a fresh ref list', () => {
+	const first = getDefaultMcpRemoteConnectorRefs()
+	const second = getDefaultMcpRemoteConnectorRefs()
+
+	expect(first).toEqual([{ kind: 'home', instanceId: 'default' }])
+	expect(first).not.toBe(second)
+	expect(first[0]).not.toBe(second[0])
 })
 
 test('parseMcpCallerContext validates caller context shape', () => {

--- a/packages/worker/src/mcp/context.ts
+++ b/packages/worker/src/mcp/context.ts
@@ -10,13 +10,21 @@ import { type RemoteConnectorRef } from '@kody-internal/shared/remote-connectors
 
 export type McpServerProps = McpCallerContext
 
-export function createMcpCallerContext(input: {
+type CreateMcpCallerContextInput = {
 	baseUrl: string
 	user?: McpUserContext | null
 	remoteConnectors?: Array<RemoteConnectorRef> | null
 	storageContext?: McpStorageContext | null
 	repoContext?: McpRepoContext | null
-}): McpCallerContext {
+}
+
+const defaultMcpRemoteConnectorRefs = [
+	{ kind: 'home', instanceId: 'default' },
+] satisfies Array<RemoteConnectorRef>
+
+export function createMcpCallerContext(
+	input: CreateMcpCallerContextInput,
+): McpCallerContext {
 	return {
 		baseUrl: input.baseUrl,
 		user: input.user ?? null,
@@ -24,6 +32,22 @@ export function createMcpCallerContext(input: {
 		storageContext: input.storageContext ?? null,
 		repoContext: input.repoContext ?? null,
 	}
+}
+
+export function getDefaultMcpRemoteConnectorRefs(): Array<RemoteConnectorRef> {
+	return defaultMcpRemoteConnectorRefs.map((ref) => ({ ...ref }))
+}
+
+export function createDefaultMcpCallerContext(
+	input: CreateMcpCallerContextInput,
+): McpCallerContext {
+	return createMcpCallerContext({
+		...input,
+		remoteConnectors:
+			input.remoteConnectors === undefined
+				? getDefaultMcpRemoteConnectorRefs()
+				: input.remoteConnectors,
+	})
 }
 
 export function parseMcpCallerContext(value: unknown): McpCallerContext {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a shared default MCP caller-context helper that attaches the generic home remote connector ref (`{ kind: 'home', instanceId: 'default' }`) for normal Kody sessions.
- Uses that helper from both OAuth MCP requests and chat agent MCP server attachment, while leaving explicit caller contexts free to provide or omit their own `remoteConnectors`.
- Adds focused coverage for MCP/chat context attachment plus `meta_list_remote_connector_status` and `meta_list_capabilities` visibility through the default ref.

## Test plan
- `npx vitest run --project node-unit packages/worker/src/mcp/context.node.test.ts packages/worker/src/chat-agent-mcp-context.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-list-remote-connector-status.node.test.ts`
- `npx vitest run --project workers-unit packages/worker/src/mcp-auth.workers.test.ts`
- `npm run format`
- `npm run typecheck`
- `npm run test`
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-936894e0-2772-405f-83fb-f3e4a9759ae3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-936894e0-2772-405f-83fb-f3e4a9759ae3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

