### PR TITLE
Fix remote connector secrets env revalidation

### DIFF
--- a/packages/worker/src/env-schema.node.test.ts
+++ b/packages/worker/src/env-schema.node.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest'
+import { parseSafe } from 'remix/data-schema'
+import { EnvSchema } from './env-schema.ts'
+
+function createBaseEnv(remoteConnectorSecrets: unknown) {
+	return {
+		COOKIE_SECRET: 'c'.repeat(32),
+		SECRET_STORE_KEY: 's'.repeat(32),
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {},
+		JOB_MANAGER: {},
+		STORAGE_RUNNER: {},
+		PACKAGE_REALTIME_SESSION: {},
+		PACKAGE_SERVICE_INSTANCE: {},
+		REMOTE_CONNECTOR_SECRETS: remoteConnectorSecrets,
+	}
+}
+
+test('REMOTE_CONNECTOR_SECRETS validation is idempotent after parsing JSON', () => {
+	const first = parseSafe(
+		EnvSchema,
+		createBaseEnv(
+			JSON.stringify({
+				'HOME:default': ' home-secret ',
+			}),
+		),
+	)
+
+	expect(first.success).toBe(true)
+	if (!first.success) return
+	expect(first.value.REMOTE_CONNECTOR_SECRETS).toEqual({
+		'home:default': 'home-secret',
+	})
+
+	const second = parseSafe(EnvSchema, first.value)
+
+	expect(second.success).toBe(true)
+	if (!second.success) return
+	expect(second.value.REMOTE_CONNECTOR_SECRETS).toEqual({
+		'home:default': 'home-secret',
+	})
+})

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -85,7 +85,48 @@ const optionalRemoteConnectorSecretsSchema = createSchema<
 	unknown,
 	Record<string, string> | undefined
 >((value, context) => {
+	function validateRecord(parsed: unknown) {
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+			return fail(
+				'REMOTE_CONNECTOR_SECRETS must be a JSON object mapping "kind:instanceId" keys to secret strings.',
+				context.path,
+			)
+		}
+
+		const out: Record<string, string> = {}
+		for (const [rawKey, rawVal] of Object.entries(parsed)) {
+			const key = rawKey.trim()
+			const colon = key.indexOf(':')
+			if (colon <= 0 || colon === key.length - 1) {
+				return fail(
+					`REMOTE_CONNECTOR_SECRETS has invalid key "${rawKey}" (expected "kind:instanceId").`,
+					context.path,
+				)
+			}
+			const kind = key.slice(0, colon).trim().toLowerCase()
+			const instanceId = key.slice(colon + 1).trim()
+			if (!kind || !instanceId) {
+				return fail(
+					`REMOTE_CONNECTOR_SECRETS has invalid key "${rawKey}" (kind and instanceId must be non-empty).`,
+					context.path,
+				)
+			}
+			const canonicalKey = `${kind}:${instanceId}`
+			if (typeof rawVal !== 'string' || !rawVal.trim()) {
+				return fail(
+					`REMOTE_CONNECTOR_SECRETS value for "${canonicalKey}" must be a non-empty string.`,
+					context.path,
+				)
+			}
+			out[canonicalKey] = rawVal.trim()
+		}
+		return { value: out }
+	}
+
 	if (value === undefined) return { value: undefined }
+	if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+		return validateRecord(value)
+	}
 	if (typeof value !== 'string') return fail('Expected string', context.path)
 
 	const trimmed = value.trim()
@@ -100,41 +141,7 @@ const optionalRemoteConnectorSecretsSchema = createSchema<
 			context.path,
 		)
 	}
-	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-		return fail(
-			'REMOTE_CONNECTOR_SECRETS must be a JSON object mapping "kind:instanceId" keys to secret strings.',
-			context.path,
-		)
-	}
-
-	const out: Record<string, string> = {}
-	for (const [rawKey, rawVal] of Object.entries(parsed)) {
-		const key = rawKey.trim()
-		const colon = key.indexOf(':')
-		if (colon <= 0 || colon === key.length - 1) {
-			return fail(
-				`REMOTE_CONNECTOR_SECRETS has invalid key "${rawKey}" (expected "kind:instanceId").`,
-				context.path,
-			)
-		}
-		const kind = key.slice(0, colon).trim().toLowerCase()
-		const instanceId = key.slice(colon + 1).trim()
-		if (!kind || !instanceId) {
-			return fail(
-				`REMOTE_CONNECTOR_SECRETS has invalid key "${rawKey}" (kind and instanceId must be non-empty).`,
-				context.path,
-			)
-		}
-		const canonicalKey = `${kind}:${instanceId}`
-		if (typeof rawVal !== 'string' || !rawVal.trim()) {
-			return fail(
-				`REMOTE_CONNECTOR_SECRETS value for "${canonicalKey}" must be a non-empty string.`,
-				context.path,
-			)
-		}
-		out[canonicalKey] = rawVal.trim()
-	}
-	return { value: out }
+	return validateRecord(parsed)
 })
 
 const optionalSentryTracesSampleRateSchema = createSchema<


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Make `REMOTE_CONNECTOR_SECRETS` env validation accept already-parsed records as well as raw JSON strings.
- Add regression coverage for parsing raw remote connector secrets and then revalidating the parsed `AppEnv`.

## Testing
- `npx vitest run --config vitest.node.config.ts packages/worker/src/env-schema.node.test.ts`
- `npx vitest run --config vitest.node.config.ts packages/worker/src/app/handlers/account-secrets.node.test.ts packages/worker/src/app/handlers/chat-threads.node.test.ts`
- `npm run typecheck`
- `npm run format:check`
- `npx oxlint packages/worker/src/env-schema.ts packages/worker/src/env-schema.node.test.ts`

## Diagnosis
- Cloudflare Workers Observability showed repeated production 500s for `GET /account/secrets.json` with `Invalid environment variables: REMOTE_CONNECTOR_SECRETS: Expected string`.
- The app validates raw Worker env once, transforms `REMOTE_CONNECTOR_SECRETS` into a record, then account secrets auth revalidates that parsed object; the previous schema only accepted strings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5526fabc-a7a2-42c4-87d3-f69c51b2d7f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5526fabc-a7a2-42c4-87d3-f69c51b2d7f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

