### PR TITLE
Make remote connectors discoverable from account navigation

### DIFF
--- a/packages/worker/client/app-session-refresh.node.test.ts
+++ b/packages/worker/client/app-session-refresh.node.test.ts
@@ -72,7 +72,7 @@ test('aborted refresh does not erase a ready authenticated session', async () =>
 	await runNextTask(queuedTasks, false)
 
 	const authenticatedUi = await renderToString(render())
-	expect(authenticatedUi).toContain('href="/account/secrets"')
+	expect(authenticatedUi).toContain('href="/account"')
 	expect(authenticatedUi).toContain(sessionEmail)
 	expect(authenticatedUi).toContain('<form method="post" action="/logout"')
 
@@ -81,7 +81,7 @@ test('aborted refresh does not erase a ready authenticated session', async () =>
 	await runNextTask(queuedTasks, true)
 
 	const uiAfterAbort = await renderToString(render())
-	expect(uiAfterAbort).toContain('href="/account/secrets"')
+	expect(uiAfterAbort).toContain('href="/account"')
 	expect(uiAfterAbort).toContain(sessionEmail)
 	expect(uiAfterAbort).toContain('<form method="post" action="/logout"')
 })

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -178,7 +178,7 @@ export function App(handle: Handle) {
 							<a href="/chat" mix={css(navLinkCss)}>
 								Chat
 							</a>
-							<a href="/account/secrets" mix={css(navLinkCss)}>
+							<a href="/account" mix={css(navLinkCss)}>
 								{sessionEmail}
 							</a>
 							<form method="post" action="/logout" mix={css({ margin: 0 })}>

--- a/packages/worker/client/routes/account-secrets-navigation.node.test.ts
+++ b/packages/worker/client/routes/account-secrets-navigation.node.test.ts
@@ -1,0 +1,26 @@
+import { type Handle } from 'remix/ui'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+
+import { AccountSecretsRoute } from './account-secrets.tsx'
+
+test('secrets management links to remote connector settings', async () => {
+	const handle = {
+		queueTask() {
+			return
+		},
+		async update() {
+			return new AbortController().signal
+		},
+		on() {
+			return
+		},
+	} as unknown as Handle
+
+	const render = AccountSecretsRoute(handle)
+	const html = await renderToString(render())
+
+	expect(html).toContain('href="/account/remote-connectors"')
+	expect(html).toContain('Remote connectors')
+	expect(html).toContain('New secret')
+})

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -986,15 +986,32 @@ export function AccountSecretsRoute(handle: Handle) {
 							and package apps.
 						</p>
 					</div>
-					<button
-						type="button"
-						mix={[
-							on('click', () => navigate(buildNewSecretHref())),
-							css(primaryButtonCss),
-						]}
+					<div
+						mix={css({
+							display: 'flex',
+							gap: spacing.sm,
+							flexWrap: 'wrap',
+						})}
 					>
-						New secret
-					</button>
+						<a
+							href="/account/remote-connectors"
+							mix={css({
+								...secondaryButtonCss,
+								textDecoration: 'none',
+							})}
+						>
+							Remote connectors
+						</a>
+						<button
+							type="button"
+							mix={[
+								on('click', () => navigate(buildNewSecretHref())),
+								css(primaryButtonCss),
+							]}
+						>
+							New secret
+						</button>
+					</div>
 				</header>
 
 				{approvalCard ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Point the signed-in account nav link at the account overview so users can reach both secrets and remote connector settings.
- Add a Remote connectors link beside New secret on the secrets management page.
- Add regression coverage for the account and secrets navigation links.

## Validation
- `npx vitest run --project node-unit packages/worker/client/app-session-refresh.node.test.ts packages/worker/client/routes/account-secrets-navigation.node.test.ts`
- `npx oxfmt --check packages/worker/client/app.tsx packages/worker/client/routes/account-secrets.tsx packages/worker/client/app-session-refresh.node.test.ts packages/worker/client/routes/account-secrets-navigation.node.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm run lint`
- `npm run test`

## Walkthrough
<a href="https://cursor.com/agents/bc-3a148a4b-03e1-4953-bb87-80ea262a8ad7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fremote_connectors_navigation_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-21efe960-8d70-431a-8c24-07fc76db2eae" alt="remote_connectors_navigation_walkthrough.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a148a4b-03e1-4953-bb87-80ea262a8ad7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a148a4b-03e1-4953-bb87-80ea262a8ad7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

