### PR TITLE
Fix account secrets 500 from legacy connector env secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,14 +119,12 @@ jobs:
           AI_GATEWAY_ID: ${{ secrets.AI_GATEWAY_ID }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           CAPABILITY_REINDEX_SECRET: ${{ secrets.CAPABILITY_REINDEX_SECRET }}
-          REMOTE_CONNECTOR_SECRETS: ${{ secrets.REMOTE_CONNECTOR_SECRETS }}
         run: >
           node tools/ci/sync-worker-secrets.ts --env production --config
           "$WRANGLER_CONFIG" --set-from-env COOKIE_SECRET
           --set-from-env-optional SECRET_STORE_KEY --set-from-env AI_GATEWAY_ID
           --set-from-env-optional SENTRY_DSN --set-from-env-optional
           CLOUDFLARE_API_TOKEN --set-from-env-optional CAPABILITY_REINDEX_SECRET
-          --set-from-env-optional REMOTE_CONNECTOR_SECRETS
 
       - name: 🗄️ Apply D1 Migrations
         env:

--- a/docs/contributing/architecture/remote-connectors.md
+++ b/docs/contributing/architecture/remote-connectors.md
@@ -28,9 +28,8 @@ All messages are **JSON objects** with a **`type`** field.
    - **`type`:** `"connector.hello"`
    - **`connectorId`:** string — instance id (for example `default`,
      `living-room`).
-   - **`sharedSecret`:** string — must match the saved shared secret for the
-     connector ref, or the optional environment fallback (see
-     [Environment variables](../environment-variables.md#remote-connector-secrets)).
+   - **`sharedSecret`:** string — must match an enabled shared secret saved for
+     the connector ref in D1.
    - **`connectorKind`:** non-empty string. Lowercase values are normalized.
 
 2. **`connector.heartbeat`**
@@ -141,5 +140,3 @@ Source: `packages/shared/src/chat.ts`,
 
 - [Request lifecycle](./request-lifecycle.md) — where connector routes sit in
   the Worker.
-- [Environment variables](../environment-variables.md#remote-connector-secrets)
-  — secrets and optional JSON map.

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -127,24 +127,6 @@ Optional Worker secrets/vars (see `packages/worker/src/env-schema.ts` and
   local repo create/get/list/token/fork calls do not need the live Artifacts
   REST API.
 
-## Remote connector secrets
-
-See `packages/worker/src/env-schema.ts` and
-`packages/worker/src/remote-connector/resolve-remote-connector-secret.ts`.
-
-- `REMOTE_CONNECTOR_SECRETS` — optional Worker **secret** (JSON string) whose
-  value is a JSON object mapping **`"kind:instanceId"`** keys (trimmed, kind
-  lowercased) to **shared secret strings** for **`connector.hello`**. Kody first
-  checks the encrypted remote connector settings users manage from
-  `/account/remote-connectors`; this environment variable is a generic
-  operational fallback for refs that are not saved in D1 yet. At Worker boot,
-  invalid JSON or malformed keys fail env validation with a clear error. At
-  runtime, if the value is a plain string in a test harness, malformed JSON is
-  logged and ignored for map lookup only.
-
-Authoring guide for outbound WebSocket services:
-[`architecture/remote-connectors.md`](./architecture/remote-connectors.md).
-
 ## Why Zod?
 
 Zod gives type inference for `Env`-driven values and a single runtime gate that

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -127,9 +127,6 @@ Configure these GitHub Actions secrets and variables for workflows:
   paste the DSN; syncs to the Worker as a secret when set in GitHub Actions)
 - `CAPABILITY_REINDEX_SECRET` (optional; triggers post-deploy Vectorize reindex
   when set; synced like other optional secrets)
-- `REMOTE_CONNECTOR_SECRETS` (optional GitHub **secret**; JSON object mapping
-  remote connector `"kind:instanceId"` keys to shared secret strings; synced to
-  the production Worker as a secret when set)
 - `SENTRY_AUTH_TOKEN` (optional GitHub **secret**; Sentry auth token with
   `project:releases` / source map upload permissions — used only by CI to run
   `npm run sentry:upload-sourcemaps` after deploy)
@@ -188,11 +185,6 @@ How to get/set each value:
     `/__maintenance/reindex-capabilities` and `/__maintenance/reindex-skills`
     with `Authorization: Bearer …` to refresh capability and user-skill
     embeddings.
-- `REMOTE_CONNECTOR_SECRETS` (optional)
-  - Store a JSON object as the repository secret `REMOTE_CONNECTOR_SECRETS`.
-    Each key must match the connector kind and instance id, such as
-    `{"home:default":"<shared-secret>"}`. The connector process must use the
-    matching shared secret when it opens its Worker websocket session.
 
 Preview deploys for pull requests create a separate Worker per PR named
 `<app-name>-pr-<number>` (for kody: `kody-pr-123`) plus one Worker per mock

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -178,8 +178,14 @@ export function App(handle: Handle) {
 							<a href="/chat" mix={css(navLinkCss)}>
 								Chat
 							</a>
-							<a href="/account/secrets" mix={css(navLinkCss)}>
+							<a href="/account" mix={css(navLinkCss)}>
 								{sessionEmail}
+							</a>
+							<a href="/account/secrets" mix={css(navLinkCss)}>
+								Secrets
+							</a>
+							<a href="/account/remote-connectors" mix={css(navLinkCss)}>
+								Connectors
 							</a>
 							<form method="post" action="/logout" mix={css({ margin: 0 })}>
 								<button type="submit" mix={css(logOutButtonCss)}>

--- a/packages/worker/public/mcp-apps/kody-ui-utils.css
+++ b/packages/worker/public/mcp-apps/kody-ui-utils.css
@@ -1,176 +1,172 @@
 /* packages/worker/client/mcp-apps/kody-ui-utils.css */
 :root {
-  color-scheme: light dark;
-  --font-body:
-    ui-sans-serif,
-    system-ui,
-    sans-serif;
-  --font-mono:
-    ui-monospace,
-    "SFMono-Regular",
-    "Menlo",
-    "Monaco",
-    "Consolas",
-    monospace;
-  --spacing-1: 0.25rem;
-  --spacing-2: 0.5rem;
-  --spacing-3: 0.75rem;
-  --spacing-4: 1rem;
-  --spacing-6: 1.5rem;
-  --radius-2: 0.5rem;
-  --radius-3: 0.75rem;
-  --shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
-  --color-bg: #ffffff;
-  --color-surface: #f8fafc;
-  --color-fg: #0f172a;
-  --color-muted: #475569;
-  --color-border: #dbe2ea;
-  --color-accent: #2563eb;
-  --color-accent-contrast: #ffffff;
-  --color-code-bg: rgb(15 23 42 / 0.06);
+	color-scheme: light dark;
+	--font-body: ui-sans-serif, system-ui, sans-serif;
+	--font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	--spacing-1: 0.25rem;
+	--spacing-2: 0.5rem;
+	--spacing-3: 0.75rem;
+	--spacing-4: 1rem;
+	--spacing-6: 1.5rem;
+	--radius-2: 0.5rem;
+	--radius-3: 0.75rem;
+	--shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
+	--color-bg: #ffffff;
+	--color-surface: #f8fafc;
+	--color-fg: #0f172a;
+	--color-muted: #475569;
+	--color-border: #dbe2ea;
+	--color-accent: #2563eb;
+	--color-accent-contrast: #ffffff;
+	--color-code-bg: rgb(15 23 42 / 0.06);
 }
 @media (prefers-color-scheme: dark) {
-  :root {
-    --color-bg: #0f172a;
-    --color-surface: #162033;
-    --color-fg: #e5eef8;
-    --color-muted: #a5b4c7;
-    --color-border: #2a3950;
-    --color-accent: #60a5fa;
-    --color-accent-contrast: #0f172a;
-    --color-code-bg: rgb(148 163 184 / 0.16);
-  }
+	:root {
+		--color-bg: #0f172a;
+		--color-surface: #162033;
+		--color-fg: #e5eef8;
+		--color-muted: #a5b4c7;
+		--color-border: #2a3950;
+		--color-accent: #60a5fa;
+		--color-accent-contrast: #0f172a;
+		--color-code-bg: rgb(148 163 184 / 0.16);
+	}
 }
 :where(html) {
-  min-height: 100%;
-  background: var(--color-bg);
-  color: var(--color-fg);
+	min-height: 100%;
+	background: var(--color-bg);
+	color: var(--color-fg);
 }
 :where(body) {
-  min-height: 100%;
-  margin: 0;
-  padding: var(--spacing-4);
-  background: var(--color-bg);
-  color: var(--color-fg);
-  font: 400 14px/1.5 var(--font-body);
+	min-height: 100%;
+	margin: 0;
+	padding: var(--spacing-4);
+	background: var(--color-bg);
+	color: var(--color-fg);
+	font: 400 14px/1.5 var(--font-body);
 }
-:where(body[data-kody-runtime=javascript]) {
-  padding: 0;
+:where(body[data-kody-runtime='javascript']) {
+	padding: 0;
 }
 :where(*, *::before, *::after) {
-  box-sizing: border-box;
+	box-sizing: border-box;
 }
 :where(a) {
-  color: var(--color-accent);
+	color: var(--color-accent);
 }
 :where(p, ul, ol, dl, pre, table, blockquote, fieldset) {
-  margin: 0 0 var(--spacing-4);
+	margin: 0 0 var(--spacing-4);
 }
 :where(h1, h2, h3, h4, h5, h6) {
-  margin: 0 0 var(--spacing-3);
-  line-height: 1.2;
+	margin: 0 0 var(--spacing-3);
+	line-height: 1.2;
 }
 :where(h1) {
-  font-size: 1.875rem;
+	font-size: 1.875rem;
 }
 :where(h2) {
-  font-size: 1.5rem;
+	font-size: 1.5rem;
 }
 :where(h3) {
-  font-size: 1.25rem;
+	font-size: 1.25rem;
 }
 :where(ul, ol) {
-  padding-left: 1.5rem;
+	padding-left: 1.5rem;
 }
 :where(hr) {
-  border: 0;
-  border-top: 1px solid var(--color-border);
-  margin: var(--spacing-6) 0;
+	border: 0;
+	border-top: 1px solid var(--color-border);
+	margin: var(--spacing-6) 0;
 }
 :where(code, kbd, samp) {
-  font-family: var(--font-mono);
-  font-size: 0.95em;
+	font-family: var(--font-mono);
+	font-size: 0.95em;
 }
 :where(code) {
-  background: var(--color-code-bg);
-  border-radius: 0.375rem;
-  padding: 0.1rem 0.35rem;
+	background: var(--color-code-bg);
+	border-radius: 0.375rem;
+	padding: 0.1rem 0.35rem;
 }
 :where(pre) {
-  overflow-x: auto;
-  padding: var(--spacing-3);
-  background: var(--color-code-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-2);
+	overflow-x: auto;
+	padding: var(--spacing-3);
+	background: var(--color-code-bg);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-2);
 }
 :where(pre code) {
-  background: transparent;
-  padding: 0;
+	background: transparent;
+	padding: 0;
 }
 :where(form) {
-  display: grid;
-  gap: var(--spacing-4);
+	display: grid;
+	gap: var(--spacing-4);
 }
 :where(label) {
-  display: grid;
-  gap: var(--spacing-2);
-  font-weight: 600;
+	display: grid;
+	gap: var(--spacing-2);
+	font-weight: 600;
 }
 :where(input, button, textarea, select) {
-  font: inherit;
+	font: inherit;
 }
-:where(input:not([type=checkbox]):not([type=radio]), textarea, select) {
-  width: 100%;
-  padding: var(--spacing-2) var(--spacing-3);
-  background: var(--color-surface);
-  color: var(--color-fg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-2);
-  box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
+:where(input:not([type='checkbox']):not([type='radio']), textarea, select) {
+	width: 100%;
+	padding: var(--spacing-2) var(--spacing-3);
+	background: var(--color-surface);
+	color: var(--color-fg);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-2);
+	box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
 }
 :where(textarea) {
-  min-height: 7rem;
-  resize: vertical;
+	min-height: 7rem;
+	resize: vertical;
 }
-:where(input[type=checkbox], input[type=radio]) {
-  accent-color: var(--color-accent);
+:where(input[type='checkbox'], input[type='radio']) {
+	accent-color: var(--color-accent);
 }
 :where(button) {
-  width: fit-content;
-  padding: var(--spacing-2) var(--spacing-4);
-  background: var(--color-accent);
-  color: var(--color-accent-contrast);
-  border: 1px solid transparent;
-  border-radius: var(--radius-2);
-  box-shadow: var(--shadow-1);
-  cursor: pointer;
+	width: fit-content;
+	padding: var(--spacing-2) var(--spacing-4);
+	background: var(--color-accent);
+	color: var(--color-accent-contrast);
+	border: 1px solid transparent;
+	border-radius: var(--radius-2);
+	box-shadow: var(--shadow-1);
+	cursor: pointer;
 }
 :where(button:disabled, input:disabled, textarea:disabled, select:disabled) {
-  opacity: 0.7;
-  cursor: not-allowed;
+	opacity: 0.7;
+	cursor: not-allowed;
 }
-:where(button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible) {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
+:where(
+	button:focus-visible,
+	input:focus-visible,
+	textarea:focus-visible,
+	select:focus-visible
+) {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
 }
 :where(table) {
-  width: 100%;
-  border-collapse: collapse;
+	width: 100%;
+	border-collapse: collapse;
 }
 :where(th, td) {
-  padding: var(--spacing-2) var(--spacing-3);
-  border: 1px solid var(--color-border);
-  text-align: left;
+	padding: var(--spacing-2) var(--spacing-3);
+	border: 1px solid var(--color-border);
+	text-align: left;
 }
 :where(th) {
-  background: var(--color-surface);
+	background: var(--color-surface);
 }
 :where(blockquote) {
-  margin-left: 0;
-  padding-left: var(--spacing-4);
-  border-left: 3px solid var(--color-border);
-  color: var(--color-muted);
+	margin-left: 0;
+	padding-left: var(--spacing-4);
+	border-left: 3px solid var(--color-border);
+	color: var(--color-muted);
 }
 :where([data-generated-ui-root]) {
-  min-height: 100%;
+	min-height: 100%;
 }

--- a/packages/worker/public/mcp-apps/kody-ui-utils.css
+++ b/packages/worker/public/mcp-apps/kody-ui-utils.css
@@ -1,172 +1,176 @@
 /* packages/worker/client/mcp-apps/kody-ui-utils.css */
 :root {
-	color-scheme: light dark;
-	--font-body: ui-sans-serif, system-ui, sans-serif;
-	--font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-	--spacing-1: 0.25rem;
-	--spacing-2: 0.5rem;
-	--spacing-3: 0.75rem;
-	--spacing-4: 1rem;
-	--spacing-6: 1.5rem;
-	--radius-2: 0.5rem;
-	--radius-3: 0.75rem;
-	--shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
-	--color-bg: #ffffff;
-	--color-surface: #f8fafc;
-	--color-fg: #0f172a;
-	--color-muted: #475569;
-	--color-border: #dbe2ea;
-	--color-accent: #2563eb;
-	--color-accent-contrast: #ffffff;
-	--color-code-bg: rgb(15 23 42 / 0.06);
+  color-scheme: light dark;
+  --font-body:
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+  --font-mono:
+    ui-monospace,
+    "SFMono-Regular",
+    "Menlo",
+    "Monaco",
+    "Consolas",
+    monospace;
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-6: 1.5rem;
+  --radius-2: 0.5rem;
+  --radius-3: 0.75rem;
+  --shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
+  --color-bg: #ffffff;
+  --color-surface: #f8fafc;
+  --color-fg: #0f172a;
+  --color-muted: #475569;
+  --color-border: #dbe2ea;
+  --color-accent: #2563eb;
+  --color-accent-contrast: #ffffff;
+  --color-code-bg: rgb(15 23 42 / 0.06);
 }
 @media (prefers-color-scheme: dark) {
-	:root {
-		--color-bg: #0f172a;
-		--color-surface: #162033;
-		--color-fg: #e5eef8;
-		--color-muted: #a5b4c7;
-		--color-border: #2a3950;
-		--color-accent: #60a5fa;
-		--color-accent-contrast: #0f172a;
-		--color-code-bg: rgb(148 163 184 / 0.16);
-	}
+  :root {
+    --color-bg: #0f172a;
+    --color-surface: #162033;
+    --color-fg: #e5eef8;
+    --color-muted: #a5b4c7;
+    --color-border: #2a3950;
+    --color-accent: #60a5fa;
+    --color-accent-contrast: #0f172a;
+    --color-code-bg: rgb(148 163 184 / 0.16);
+  }
 }
 :where(html) {
-	min-height: 100%;
-	background: var(--color-bg);
-	color: var(--color-fg);
+  min-height: 100%;
+  background: var(--color-bg);
+  color: var(--color-fg);
 }
 :where(body) {
-	min-height: 100%;
-	margin: 0;
-	padding: var(--spacing-4);
-	background: var(--color-bg);
-	color: var(--color-fg);
-	font: 400 14px/1.5 var(--font-body);
+  min-height: 100%;
+  margin: 0;
+  padding: var(--spacing-4);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font: 400 14px/1.5 var(--font-body);
 }
-:where(body[data-kody-runtime='javascript']) {
-	padding: 0;
+:where(body[data-kody-runtime=javascript]) {
+  padding: 0;
 }
 :where(*, *::before, *::after) {
-	box-sizing: border-box;
+  box-sizing: border-box;
 }
 :where(a) {
-	color: var(--color-accent);
+  color: var(--color-accent);
 }
 :where(p, ul, ol, dl, pre, table, blockquote, fieldset) {
-	margin: 0 0 var(--spacing-4);
+  margin: 0 0 var(--spacing-4);
 }
 :where(h1, h2, h3, h4, h5, h6) {
-	margin: 0 0 var(--spacing-3);
-	line-height: 1.2;
+  margin: 0 0 var(--spacing-3);
+  line-height: 1.2;
 }
 :where(h1) {
-	font-size: 1.875rem;
+  font-size: 1.875rem;
 }
 :where(h2) {
-	font-size: 1.5rem;
+  font-size: 1.5rem;
 }
 :where(h3) {
-	font-size: 1.25rem;
+  font-size: 1.25rem;
 }
 :where(ul, ol) {
-	padding-left: 1.5rem;
+  padding-left: 1.5rem;
 }
 :where(hr) {
-	border: 0;
-	border-top: 1px solid var(--color-border);
-	margin: var(--spacing-6) 0;
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  margin: var(--spacing-6) 0;
 }
 :where(code, kbd, samp) {
-	font-family: var(--font-mono);
-	font-size: 0.95em;
+  font-family: var(--font-mono);
+  font-size: 0.95em;
 }
 :where(code) {
-	background: var(--color-code-bg);
-	border-radius: 0.375rem;
-	padding: 0.1rem 0.35rem;
+  background: var(--color-code-bg);
+  border-radius: 0.375rem;
+  padding: 0.1rem 0.35rem;
 }
 :where(pre) {
-	overflow-x: auto;
-	padding: var(--spacing-3);
-	background: var(--color-code-bg);
-	border: 1px solid var(--color-border);
-	border-radius: var(--radius-2);
+  overflow-x: auto;
+  padding: var(--spacing-3);
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
 }
 :where(pre code) {
-	background: transparent;
-	padding: 0;
+  background: transparent;
+  padding: 0;
 }
 :where(form) {
-	display: grid;
-	gap: var(--spacing-4);
+  display: grid;
+  gap: var(--spacing-4);
 }
 :where(label) {
-	display: grid;
-	gap: var(--spacing-2);
-	font-weight: 600;
+  display: grid;
+  gap: var(--spacing-2);
+  font-weight: 600;
 }
 :where(input, button, textarea, select) {
-	font: inherit;
+  font: inherit;
 }
-:where(input:not([type='checkbox']):not([type='radio']), textarea, select) {
-	width: 100%;
-	padding: var(--spacing-2) var(--spacing-3);
-	background: var(--color-surface);
-	color: var(--color-fg);
-	border: 1px solid var(--color-border);
-	border-radius: var(--radius-2);
-	box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
+:where(input:not([type=checkbox]):not([type=radio]), textarea, select) {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--color-surface);
+  color: var(--color-fg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+  box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
 }
 :where(textarea) {
-	min-height: 7rem;
-	resize: vertical;
+  min-height: 7rem;
+  resize: vertical;
 }
-:where(input[type='checkbox'], input[type='radio']) {
-	accent-color: var(--color-accent);
+:where(input[type=checkbox], input[type=radio]) {
+  accent-color: var(--color-accent);
 }
 :where(button) {
-	width: fit-content;
-	padding: var(--spacing-2) var(--spacing-4);
-	background: var(--color-accent);
-	color: var(--color-accent-contrast);
-	border: 1px solid transparent;
-	border-radius: var(--radius-2);
-	box-shadow: var(--shadow-1);
-	cursor: pointer;
+  width: fit-content;
+  padding: var(--spacing-2) var(--spacing-4);
+  background: var(--color-accent);
+  color: var(--color-accent-contrast);
+  border: 1px solid transparent;
+  border-radius: var(--radius-2);
+  box-shadow: var(--shadow-1);
+  cursor: pointer;
 }
 :where(button:disabled, input:disabled, textarea:disabled, select:disabled) {
-	opacity: 0.7;
-	cursor: not-allowed;
+  opacity: 0.7;
+  cursor: not-allowed;
 }
-:where(
-	button:focus-visible,
-	input:focus-visible,
-	textarea:focus-visible,
-	select:focus-visible
-) {
-	outline: 2px solid var(--color-accent);
-	outline-offset: 2px;
+:where(button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible) {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 :where(table) {
-	width: 100%;
-	border-collapse: collapse;
+  width: 100%;
+  border-collapse: collapse;
 }
 :where(th, td) {
-	padding: var(--spacing-2) var(--spacing-3);
-	border: 1px solid var(--color-border);
-	text-align: left;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--color-border);
+  text-align: left;
 }
 :where(th) {
-	background: var(--color-surface);
+  background: var(--color-surface);
 }
 :where(blockquote) {
-	margin-left: 0;
-	padding-left: var(--spacing-4);
-	border-left: 3px solid var(--color-border);
-	color: var(--color-muted);
+  margin-left: 0;
+  padding-left: var(--spacing-4);
+  border-left: 3px solid var(--color-border);
+  color: var(--color-muted);
 }
 :where([data-generated-ui-root]) {
-	min-height: 100%;
+  min-height: 100%;
 }

--- a/packages/worker/src/app/authenticated-user.node.test.ts
+++ b/packages/worker/src/app/authenticated-user.node.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+import { readAuthenticatedAppUser } from './authenticated-user.ts'
+
+test('readAuthenticatedAppUser only requires the session cookie secret from env', async () => {
+	const user = await readAuthenticatedAppUser(
+		new Request('https://example.com/account/secrets.json'),
+		{
+			COOKIE_SECRET: 'LOCAL_TEST_COOKIE_SECRET_32_CHARS_MINIMUM',
+			REMOTE_CONNECTOR_SECRETS: {
+				'custom:alpha': 'alpha-secret',
+			},
+		} as unknown as Env,
+	)
+
+	expect(user).toBeNull()
+})

--- a/packages/worker/src/app/authenticated-user.ts
+++ b/packages/worker/src/app/authenticated-user.ts
@@ -2,7 +2,6 @@ import {
 	readAuthSessionResult,
 	setAuthSessionSecret,
 } from '#app/auth-session.ts'
-import { getEnv } from '#app/env.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { type McpUserContext } from '@kody-internal/shared/chat.ts'
 
@@ -20,8 +19,7 @@ function buildDisplayName(email: string) {
 }
 
 export async function readAuthenticatedAppUser(request: Request, env: Env) {
-	const appEnv = getEnv(env)
-	setAuthSessionSecret(appEnv.COOKIE_SECRET)
+	setAuthSessionSecret(env.COOKIE_SECRET)
 	const { session } = await readAuthSessionResult(request)
 	if (!session) return null
 

--- a/packages/worker/src/app/handler.node.test.ts
+++ b/packages/worker/src/app/handler.node.test.ts
@@ -19,9 +19,9 @@ test('account secrets api ignores legacy remote connector env secrets', async ()
 	const response = await handleRequest(
 		new Request('https://example.com/account/secrets.json'),
 		createEnv({
-			REMOTE_CONNECTOR_SECRETS: JSON.stringify({
+			REMOTE_CONNECTOR_SECRETS: {
 				'custom:alpha': 'alpha-secret',
-			}),
+			},
 		}),
 	)
 

--- a/packages/worker/src/app/handler.node.test.ts
+++ b/packages/worker/src/app/handler.node.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest'
+import { handleRequest } from './handler.ts'
+
+function createEnv(overrides: Record<string, unknown> = {}) {
+	return {
+		COOKIE_SECRET: 'LOCAL_TEST_COOKIE_SECRET_32_CHARS_MINIMUM',
+		SECRET_STORE_KEY: 'LOCAL_TEST_SECRET_STORE_KEY_32_CHARS_MINIMUM',
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {},
+		JOB_MANAGER: {},
+		STORAGE_RUNNER: {},
+		PACKAGE_REALTIME_SESSION: {},
+		PACKAGE_SERVICE_INSTANCE: {},
+		...overrides,
+	} as unknown as Env
+}
+
+test('account secrets api ignores legacy remote connector env secrets', async () => {
+	const response = await handleRequest(
+		new Request('https://example.com/account/secrets.json'),
+		createEnv({
+			REMOTE_CONNECTOR_SECRETS: JSON.stringify({
+				'custom:alpha': 'alpha-secret',
+			}),
+		}),
+	)
+
+	expect(response.status).toBe(401)
+	await expect(response.json()).resolves.toEqual({
+		ok: false,
+		error: 'Unauthorized.',
+	})
+})

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -81,62 +81,6 @@ const optionalAiModeSchema = createSchema<
 	return fail(`Expected one of: ${aiModeValues.join(', ')}`, context.path)
 })
 
-const optionalRemoteConnectorSecretsSchema = createSchema<
-	unknown,
-	Record<string, string> | undefined
->((value, context) => {
-	if (value === undefined) return { value: undefined }
-	if (typeof value !== 'string') return fail('Expected string', context.path)
-
-	const trimmed = value.trim()
-	if (!trimmed) return { value: undefined }
-
-	let parsed: unknown
-	try {
-		parsed = JSON.parse(trimmed) as unknown
-	} catch {
-		return fail(
-			'REMOTE_CONNECTOR_SECRETS must be valid JSON when set.',
-			context.path,
-		)
-	}
-	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-		return fail(
-			'REMOTE_CONNECTOR_SECRETS must be a JSON object mapping "kind:instanceId" keys to secret strings.',
-			context.path,
-		)
-	}
-
-	const out: Record<string, string> = {}
-	for (const [rawKey, rawVal] of Object.entries(parsed)) {
-		const key = rawKey.trim()
-		const colon = key.indexOf(':')
-		if (colon <= 0 || colon === key.length - 1) {
-			return fail(
-				`REMOTE_CONNECTOR_SECRETS has invalid key "${rawKey}" (expected "kind:instanceId").`,
-				context.path,
-			)
-		}
-		const kind = key.slice(0, colon).trim().toLowerCase()
-		const instanceId = key.slice(colon + 1).trim()
-		if (!kind || !instanceId) {
-			return fail(
-				`REMOTE_CONNECTOR_SECRETS has invalid key "${rawKey}" (kind and instanceId must be non-empty).`,
-				context.path,
-			)
-		}
-		const canonicalKey = `${kind}:${instanceId}`
-		if (typeof rawVal !== 'string' || !rawVal.trim()) {
-			return fail(
-				`REMOTE_CONNECTOR_SECRETS value for "${canonicalKey}" must be a non-empty string.`,
-				context.path,
-			)
-		}
-		out[canonicalKey] = rawVal.trim()
-	}
-	return { value: out }
-})
-
 const optionalSentryTracesSampleRateSchema = createSchema<
 	unknown,
 	number | undefined
@@ -266,7 +210,6 @@ export const EnvSchema = object({
 	CLOUDFLARE_API_BASE_URL: optionalUrlStringSchema,
 	CAPABILITY_REINDEX_SECRET: optionalNonEmptyStringSchema,
 	JOB_REINDEX_SECRET: optionalNonEmptyStringSchema,
-	REMOTE_CONNECTOR_SECRETS: optionalRemoteConnectorSecretsSchema,
 })
 
 export type AppEnv = InferOutput<typeof EnvSchema>

--- a/packages/worker/src/remote-connector/resolve-remote-connector-secret.node.test.ts
+++ b/packages/worker/src/remote-connector/resolve-remote-connector-secret.node.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest'
-import { resolveRemoteConnectorSharedSecret } from './resolve-remote-connector-secret.ts'
+import {
+	hasRemoteConnectorSharedSecret,
+	remoteConnectorSharedSecretMatches,
+	resolveRemoteConnectorSharedSecret,
+} from './resolve-remote-connector-secret.ts'
 
 function createEmptyRemoteConnectorSettingsDb() {
 	return {
@@ -11,7 +15,7 @@ function createEmptyRemoteConnectorSettingsDb() {
 	} as unknown as D1Database
 }
 
-test('REMOTE_CONNECTOR_SECRETS resolves by kind and instance', async () => {
+test('remote connector shared secrets are not read from environment variables', async () => {
 	const env = {
 		APP_DB: createEmptyRemoteConnectorSettingsDb(),
 		SECRET_STORE_KEY: 'x'.repeat(32),
@@ -20,35 +24,23 @@ test('REMOTE_CONNECTOR_SECRETS resolves by kind and instance', async () => {
 			'lights:default': 'lights-secret',
 		},
 	} as Env
+
 	await expect(
 		resolveRemoteConnectorSharedSecret('custom', 'alpha', env),
-	).resolves.toBe('alpha-secret')
-	await expect(
-		resolveRemoteConnectorSharedSecret('lights', 'default', env),
-	).resolves.toBe('lights-secret')
-})
-
-test('returns undefined when the map does not contain the connector key', async () => {
-	await expect(
-		resolveRemoteConnectorSharedSecret('custom', 'alpha', {
-			APP_DB: createEmptyRemoteConnectorSettingsDb(),
-			SECRET_STORE_KEY: 'x'.repeat(32),
-			REMOTE_CONNECTOR_SECRETS: {
-				'lights:default': 'lights-secret',
-			},
-		} as Env),
 	).resolves.toBeUndefined()
-})
-
-test('normalizes fallback connector keys generically', async () => {
-	const env = {
-		APP_DB: createEmptyRemoteConnectorSettingsDb(),
-		SECRET_STORE_KEY: 'x'.repeat(32),
-		REMOTE_CONNECTOR_SECRETS: {
-			'roku:living-room': 'roku-secret',
-		},
-	} as Env
 	await expect(
-		resolveRemoteConnectorSharedSecret(' Roku ', ' living-room ', env),
-	).resolves.toBe('roku-secret')
+		remoteConnectorSharedSecretMatches({
+			env,
+			kind: 'custom',
+			instanceId: 'alpha',
+			sharedSecret: 'alpha-secret',
+		}),
+	).resolves.toBe(false)
+	await expect(
+		hasRemoteConnectorSharedSecret({
+			env,
+			kind: 'lights',
+			instanceId: 'default',
+		}),
+	).resolves.toBe(false)
 })

--- a/packages/worker/src/remote-connector/resolve-remote-connector-secret.ts
+++ b/packages/worker/src/remote-connector/resolve-remote-connector-secret.ts
@@ -39,46 +39,6 @@ function timingSafeStringEquals(left: string, right: string) {
 	return isEqual && leftBytes.length === rightBytes.length
 }
 
-function parseSecretsMapFromEnv(value: unknown): Record<string, string> | null {
-	if (!value) return null
-	if (typeof value === 'object' && !Array.isArray(value)) {
-		return value as Record<string, string>
-	}
-	if (typeof value !== 'string') return null
-	const trimmed = value.trim()
-	if (!trimmed) return null
-	try {
-		const parsed = JSON.parse(trimmed) as unknown
-		if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-			return parsed as Record<string, string>
-		}
-	} catch (error) {
-		const detail = error instanceof Error ? error.message : String(error)
-		console.error(
-			`[REMOTE_CONNECTOR_SECRETS] invalid JSON (ignored for map lookup): ${detail}`,
-		)
-	}
-	return null
-}
-
-function resolveRemoteConnectorSharedSecretFromEnv(
-	kind: string,
-	instanceId: string,
-	env: Env,
-): string | undefined {
-	const k = normalizeRemoteConnectorKind(kind)
-	const id = normalizeRemoteConnectorInstanceId(instanceId)
-	const map = parseSecretsMapFromEnv(env.REMOTE_CONNECTOR_SECRETS as unknown)
-	if (map) {
-		const key = `${k}:${id}`
-		const fromMap = map[key]
-		if (typeof fromMap === 'string' && fromMap.trim()) {
-			return fromMap.trim()
-		}
-	}
-	return undefined
-}
-
 async function listStoredSharedSecrets(input: {
 	kind: string
 	instanceId: string
@@ -93,7 +53,7 @@ async function listStoredSharedSecrets(input: {
 	} catch (error) {
 		const detail = error instanceof Error ? error.message : String(error)
 		console.error(
-			`[remote-connectors] failed to read persisted shared secrets for ${normalizeRemoteConnectorKind(input.kind)}:${normalizeRemoteConnectorInstanceId(input.instanceId)} (falling back to env map): ${detail}`,
+			`[remote-connectors] failed to read persisted shared secrets for ${normalizeRemoteConnectorKind(input.kind)}:${normalizeRemoteConnectorInstanceId(input.instanceId)}: ${detail}`,
 		)
 		return []
 	}
@@ -113,7 +73,7 @@ async function storedSharedSecretExists(input: {
 	} catch (error) {
 		const detail = error instanceof Error ? error.message : String(error)
 		console.error(
-			`[remote-connectors] failed to check persisted shared secret for ${normalizeRemoteConnectorKind(input.kind)}:${normalizeRemoteConnectorInstanceId(input.instanceId)} (falling back to env map): ${detail}`,
+			`[remote-connectors] failed to check persisted shared secret for ${normalizeRemoteConnectorKind(input.kind)}:${normalizeRemoteConnectorInstanceId(input.instanceId)}: ${detail}`,
 		)
 		return false
 	}
@@ -129,8 +89,7 @@ export async function resolveRemoteConnectorSharedSecret(
 		instanceId,
 		env,
 	})
-	if (storedSecret) return storedSecret
-	return resolveRemoteConnectorSharedSecretFromEnv(kind, instanceId, env)
+	return storedSecret
 }
 
 export async function remoteConnectorSharedSecretMatches(input: {
@@ -149,15 +108,7 @@ export async function remoteConnectorSharedSecretMatches(input: {
 	if (storedSecretMatches) {
 		return true
 	}
-	const fallbackSecret = resolveRemoteConnectorSharedSecretFromEnv(
-		input.kind,
-		input.instanceId,
-		input.env,
-	)
-	return Boolean(
-		fallbackSecret &&
-		timingSafeStringEquals(input.sharedSecret, fallbackSecret),
-	)
+	return false
 }
 
 export async function hasRemoteConnectorSharedSecret(input: {
@@ -165,12 +116,5 @@ export async function hasRemoteConnectorSharedSecret(input: {
 	instanceId: string
 	env: Env
 }): Promise<boolean> {
-	if (await storedSharedSecretExists(input)) return true
-	return Boolean(
-		resolveRemoteConnectorSharedSecretFromEnv(
-			input.kind,
-			input.instanceId,
-			input.env,
-		),
-	)
+	return storedSharedSecretExists(input)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove `REMOTE_CONNECTOR_SECRETS` parsing and remote connector env-secret fallback so connector hello auth uses D1-backed settings only.
- Stop syncing the legacy connector secret in production deploys and remove docs that describe the env fallback.
- Stop reparsing the full Worker env in `readAuthenticatedAppUser`; it now only requires `COOKIE_SECRET` to configure auth session cookies.
- Add regression tests for object-shaped legacy `REMOTE_CONNECTOR_SECRETS` values and for `/account/secrets.json` returning 401 rather than 500 while unauthenticated.
- Update signed-in nav so the email links to `/account`, with direct `Secrets` and `Connectors` links.
- Keep the PR focused by excluding unrelated generated `kody-ui-utils.css` churn.

## Root cause
`/account/secrets.json` called `readAuthenticatedAppUser()`, which reparsed an already parsed `AppEnv`. The legacy `REMOTE_CONNECTOR_SECRETS` schema transformed the raw JSON string into an object on the first parse, then the second parse rejected that object with `Expected string`, producing a 500 before the route reached secret or D1 logic. The D1 remote connector settings migration was applied and was not the failing query path.

## Verification
- `npm run format && npx vitest run packages/worker/src/app/authenticated-user.node.test.ts packages/worker/src/app/handler.node.test.ts packages/worker/src/remote-connector/resolve-remote-connector-secret.node.test.ts packages/worker/src/remote-connector/settings-service.node.test.ts packages/worker/src/app/handlers/account-secrets.node.test.ts packages/worker/src/app/handlers/account-remote-connectors.node.test.ts`
- `npm run typecheck && npm run build && npm run test`
- Local smoke: unauthenticated `GET /account/secrets.json` returns `401 Unauthorized`, not `500`.
- Browser walkthrough verified Account, Secrets, Connectors, and Chat nav links:

<a href="https://cursor.com/agents/bc-b2fc2245-77be-4490-94f2-5ff5d441dedd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faccount_nav_links_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-ee3ef78c-9386-4e3b-aee7-0080e1b560ac" alt="account_nav_links_walkthrough.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2fc2245-77be-4490-94f2-5ff5d441dedd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2fc2245-77be-4490-94f2-5ff5d441dedd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Connectors" navigation link to the authenticated user menu, providing direct access to connector management.

* **Documentation**
  * Clarified remote connector protocol specifications regarding shared secret requirements.
  * Updated setup and environment variable documentation to reflect current secret configuration methods.

* **Chores**
  * Simplified secret handling for remote connectors to use only persisted storage, removing environment-based fallback configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->