### PR TITLE
Load remote connector shared secrets in account form

### DIFF
--- a/e2e/remote-connectors.spec.ts
+++ b/e2e/remote-connectors.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from './playwright-utils.ts'
+
+test('remote connector form reloads, reveals, and generates shared secrets', async ({
+	page,
+	login,
+}) => {
+	await login()
+
+	const nonce = Date.now().toString(36)
+	const kind = `remote-${nonce}`
+	const instanceId = `default-${nonce}`
+	const sharedSecret = `shared-secret-${nonce}`
+
+	await page.goto('/account/remote-connectors')
+	await expect(
+		page.getByRole('heading', { level: 1, name: /remote connectors/i }),
+	).toBeVisible()
+	await expect(page.getByRole('button', { name: 'Generate' })).toBeVisible()
+	await expect(page.getByRole('button', { name: 'Copy' })).toHaveCount(0)
+
+	await page.getByLabel('Kind').fill(kind)
+	await page.getByLabel('Instance ID').fill(instanceId)
+	await page.getByRole('textbox', { name: 'Shared secret' }).fill(sharedSecret)
+	const saveResponse = page.waitForResponse(
+		(response) =>
+			response.url().endsWith('/account/remote-connectors.json') &&
+			response.request().method() === 'POST',
+	)
+	await page.getByRole('button', { name: 'Save connector' }).click()
+	expect((await saveResponse).ok()).toBe(true)
+	await expect(page.getByRole('alert')).toContainText(
+		'Created remote connector.',
+	)
+
+	await page.reload()
+	await page
+		.getByRole('button', { name: new RegExp(`${kind}:${instanceId}`) })
+		.click()
+
+	const sharedSecretInput = page.getByRole('textbox', {
+		name: 'Shared secret',
+	})
+	await expect(sharedSecretInput).toHaveAttribute('type', 'password')
+	await expect(sharedSecretInput).toHaveValue(sharedSecret)
+	await expect(page.getByRole('button', { name: 'Copy' })).toHaveCount(0)
+
+	await page.getByRole('button', { name: 'Show shared secret' }).click()
+	await expect(sharedSecretInput).toHaveAttribute('type', 'text')
+	await expect(sharedSecretInput).toHaveValue(sharedSecret)
+
+	await page.getByRole('button', { name: 'Generate' }).click()
+	await expect(sharedSecretInput).not.toHaveValue(sharedSecret)
+	await expect(sharedSecretInput).toHaveAttribute('type', 'text')
+})

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -654,7 +654,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 												type="text"
 												value={editorState.sharedSecret}
 												placeholder="Connector hello shared secret"
-												autoComplete="new-password"
+												autoComplete="off"
 												disabled={isMutating}
 												mix={[
 													on('input', (event) => {
@@ -674,7 +674,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 												type="password"
 												value={editorState.sharedSecret}
 												placeholder="Connector hello shared secret"
-												autoComplete="new-password"
+												autoComplete="off"
 												disabled={isMutating}
 												mix={[
 													on('input', (event) => {

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -30,6 +30,7 @@ type RemoteConnectorListItem = {
 	enabled: boolean
 	attached: boolean
 	hasSharedSecret: boolean
+	sharedSecret: string
 	createdAt: string
 	updatedAt: string
 }
@@ -75,7 +76,7 @@ function createEditorStateFromConnector(
 		instanceId: connector.instanceId,
 		enabled: connector.enabled,
 		attached: connector.attached,
-		sharedSecret: '',
+		sharedSecret: connector.sharedSecret,
 		hasSharedSecret: connector.hasSharedSecret,
 	}
 }
@@ -405,17 +406,6 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 		handle.update()
 	}
 
-	async function copySharedSecret() {
-		if (!editorState.sharedSecret) return
-		try {
-			await navigator.clipboard.writeText(editorState.sharedSecret)
-			message = 'Copied shared secret.'
-		} catch {
-			message = 'Unable to copy shared secret.'
-		}
-		handle.update()
-	}
-
 	return () => {
 		const currentHref =
 			typeof window === 'undefined'
@@ -591,7 +581,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 								<h2 mix={css(cardTitleCss)}>{selectedLabel}</h2>
 								<p mix={css(descriptionCss)}>
 									Connector refs are generic kind and instance ID pairs. The
-									shared secret is never returned by this page after saving.
+									shared secret is loaded into the password field for editing.
 								</p>
 							</div>
 
@@ -663,11 +653,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 												aria-label="Shared secret"
 												type="text"
 												value={editorState.sharedSecret}
-												placeholder={
-													editorState.hasSharedSecret
-														? 'Leave blank to keep the saved secret'
-														: 'Connector hello shared secret'
-												}
+												placeholder="Connector hello shared secret"
 												autoComplete="new-password"
 												disabled={isMutating}
 												mix={[
@@ -687,11 +673,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 												aria-label="Shared secret"
 												type="password"
 												value={editorState.sharedSecret}
-												placeholder={
-													editorState.hasSharedSecret
-														? 'Leave blank to keep the saved secret'
-														: 'Connector hello shared secret'
-												}
+												placeholder="Connector hello shared secret"
 												autoComplete="new-password"
 												disabled={isMutating}
 												mix={[
@@ -739,16 +721,6 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 										]}
 									>
 										Generate
-									</button>
-									<button
-										type="button"
-										disabled={isMutating || !editorState.sharedSecret}
-										mix={[
-											on('click', () => void copySharedSecret()),
-											css(secondaryButtonCss),
-										]}
-									>
-										Copy
 									</button>
 								</div>
 							</div>

--- a/packages/worker/src/app/handlers/account-remote-connectors.node.test.ts
+++ b/packages/worker/src/app/handlers/account-remote-connectors.node.test.ts
@@ -14,7 +14,7 @@ const mockModule = vi.hoisted(() => ({
 		},
 	})),
 	readAuthSessionResult: async () => ({ session: null, setCookie: null }),
-	listRemoteConnectorSettings: vi.fn(async () => [
+	listRemoteConnectorSettingsWithSharedSecrets: vi.fn(async () => [
 		{
 			id: 'connector-1',
 			kind: 'lights',
@@ -22,6 +22,7 @@ const mockModule = vi.hoisted(() => ({
 			enabled: true,
 			attached: true,
 			hasSharedSecret: true,
+			sharedSecret: 'lights-secret',
 			createdAt: new Date(0).toISOString(),
 			updatedAt: new Date(0).toISOString(),
 		},
@@ -62,8 +63,8 @@ vi.mock('#app/render.ts', () => ({
 }))
 
 vi.mock('#worker/remote-connector/settings-service.ts', () => ({
-	listRemoteConnectorSettings: (...args: Array<unknown>) =>
-		mockModule.listRemoteConnectorSettings(...args),
+	listRemoteConnectorSettingsWithSharedSecrets: (...args: Array<unknown>) =>
+		mockModule.listRemoteConnectorSettingsWithSharedSecrets(...args),
 	saveRemoteConnectorSetting: (...args: Array<unknown>) =>
 		mockModule.saveRemoteConnectorSetting(...args),
 	deleteRemoteConnectorSetting: (...args: Array<unknown>) =>
@@ -80,7 +81,7 @@ function createEnv() {
 	} as Env
 }
 
-test('remote connector settings API lists metadata without plaintext secrets', async () => {
+test('remote connector settings API lists settings with plaintext secrets', async () => {
 	const handler = createAccountRemoteConnectorsApiHandler(createEnv())
 	const response = await handler.handler({
 		request: new Request('https://example.com/account/remote-connectors.json'),
@@ -91,7 +92,6 @@ test('remote connector settings API lists metadata without plaintext secrets', a
 	expect(response.headers.get('Cache-Control')).toBe('no-store')
 	const text = await response.text()
 	expect(text).toContain('"hasSharedSecret":true')
-	expect(text).not.toContain('lights-secret')
 	expect(JSON.parse(text)).toEqual({
 		ok: true,
 		email: 'user@example.com',
@@ -103,6 +103,7 @@ test('remote connector settings API lists metadata without plaintext secrets', a
 				enabled: true,
 				attached: true,
 				hasSharedSecret: true,
+				sharedSecret: 'lights-secret',
 				createdAt: new Date(0).toISOString(),
 				updatedAt: new Date(0).toISOString(),
 			},
@@ -110,7 +111,7 @@ test('remote connector settings API lists metadata without plaintext secrets', a
 	})
 })
 
-test('remote connector settings API passes shared secret only to save service', async () => {
+test('remote connector settings API passes submitted secret to save service', async () => {
 	const handler = createAccountRemoteConnectorsApiHandler(createEnv())
 	const response = await handler.handler({
 		request: new Request('https://example.com/account/remote-connectors.json', {
@@ -137,5 +138,22 @@ test('remote connector settings API passes shared secret only to save service', 
 			sharedSecret: 'roku-secret',
 		}),
 	)
-	expect(await response.text()).not.toContain('roku-secret')
+	expect(await response.json()).toEqual({
+		ok: true,
+		email: 'user@example.com',
+		selectedConnectorId: 'connector-1',
+		connectors: [
+			{
+				id: 'connector-1',
+				kind: 'lights',
+				instanceId: 'default',
+				enabled: true,
+				attached: true,
+				hasSharedSecret: true,
+				sharedSecret: 'lights-secret',
+				createdAt: new Date(0).toISOString(),
+				updatedAt: new Date(0).toISOString(),
+			},
+		],
+	})
 })

--- a/packages/worker/src/app/handlers/account-remote-connectors.ts
+++ b/packages/worker/src/app/handlers/account-remote-connectors.ts
@@ -7,7 +7,7 @@ import { render } from '#app/render.ts'
 import { type routes } from '#app/routes.ts'
 import {
 	deleteRemoteConnectorSetting,
-	listRemoteConnectorSettings,
+	listRemoteConnectorSettingsWithSharedSecrets,
 	saveRemoteConnectorSetting,
 } from '#worker/remote-connector/settings-service.ts'
 
@@ -22,6 +22,7 @@ type AccountRemoteConnectorListItem = {
 	enabled: boolean
 	attached: boolean
 	hasSharedSecret: boolean
+	sharedSecret: string
 	createdAt: string
 	updatedAt: string
 }
@@ -156,7 +157,7 @@ async function buildPayload(input: {
 	env: Env
 	user: AuthenticatedUser
 }): Promise<AccountRemoteConnectorsPayload> {
-	const connectors = await listRemoteConnectorSettings({
+	const connectors = await listRemoteConnectorSettingsWithSharedSecrets({
 		env: input.env,
 		userId: input.user.mcpUser.userId,
 	})

--- a/packages/worker/src/remote-connector/settings-service.node.test.ts
+++ b/packages/worker/src/remote-connector/settings-service.node.test.ts
@@ -4,6 +4,7 @@ import {
 	deleteRemoteConnectorSetting,
 	listAttachedRemoteConnectorRefs,
 	listRemoteConnectorSettings,
+	listRemoteConnectorSettingsWithSharedSecrets,
 	saveRemoteConnectorSetting,
 } from './settings-service.ts'
 import { type RemoteConnectorSettingRow } from './settings-types.ts'
@@ -236,6 +237,17 @@ test('remote connector settings are generic and do not echo plaintext secrets', 
 	expect(connectors).toHaveLength(1)
 	expect(connectors[0]).not.toHaveProperty('sharedSecret')
 	expect(JSON.stringify(connectors)).not.toContain('lights-secret')
+	await expect(
+		listRemoteConnectorSettingsWithSharedSecrets({
+			env,
+			userId: 'user-1',
+		}),
+	).resolves.toEqual([
+		{
+			...connectors[0],
+			sharedSecret: 'lights-secret',
+		},
+	])
 	await expect(
 		listAttachedRemoteConnectorRefs({ env, userId: 'user-1' }),
 	).resolves.toEqual([{ kind: 'lights', instanceId: 'default' }])

--- a/packages/worker/src/remote-connector/settings-service.ts
+++ b/packages/worker/src/remote-connector/settings-service.ts
@@ -13,6 +13,7 @@ import {
 import {
 	type RemoteConnectorSettingMetadata,
 	type RemoteConnectorSettingRow,
+	type RemoteConnectorSettingWithSharedSecret,
 } from './settings-types.ts'
 
 type RemoteConnectorSettingsEnv = Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'>
@@ -60,6 +61,24 @@ export async function listRemoteConnectorSettings(input: {
 		userId: input.userId,
 	})
 	return rows.map(toMetadata)
+}
+
+export async function listRemoteConnectorSettingsWithSharedSecrets(input: {
+	env: RemoteConnectorSettingsEnv
+	userId: string
+}): Promise<Array<RemoteConnectorSettingWithSharedSecret>> {
+	const rows = await listRemoteConnectorSettingRows({
+		db: input.env.APP_DB,
+		userId: input.userId,
+	})
+	return Promise.all(
+		rows.map(async (row) => ({
+			...toMetadata(row),
+			sharedSecret: row.encrypted_shared_secret
+				? await decryptSecretValue(input.env, row.encrypted_shared_secret)
+				: '',
+		})),
+	)
 }
 
 export async function listAttachedRemoteConnectorRefs(input: {

--- a/packages/worker/src/remote-connector/settings-types.ts
+++ b/packages/worker/src/remote-connector/settings-types.ts
@@ -20,3 +20,8 @@ export type RemoteConnectorSettingMetadata = {
 	createdAt: string
 	updatedAt: string
 }
+
+export type RemoteConnectorSettingWithSharedSecret =
+	RemoteConnectorSettingMetadata & {
+		sharedSecret: string
+	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Return decrypted remote connector shared secrets from the authenticated account settings API.
- Populate the remote connector form password field from the loaded secret and remove the copy button.
- Disable password-manager autocomplete controls for the connector secret field so no browser copy affordance appears.
- Add server and Playwright coverage for create, reload, reveal, generate, and no-copy behavior.

## Walkthrough
<a href="https://cursor.com/agents/bc-79ec3fed-8c15-427e-9c70-f9909f513e47/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fremote-connectors-secret-form-walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-033a1a77-9acc-4f77-b1dc-2e6dde1d2418" alt="remote-connectors-secret-form-walkthrough.mp4" /></a>
![Remote connector generated secret final state](https://cursor.com/artifacts/c/art-746a4937-e482-413e-b2b7-c6ee9861d513)

## Testing
- `npx vitest run packages/worker/src/app/handlers/account-remote-connectors.node.test.ts packages/worker/src/remote-connector/settings-service.node.test.ts`
- `npm run typecheck`
- `npx playwright test e2e/remote-connectors.spec.ts`
- `npm run lint`
- `git diff --check`
- Manual browser walkthrough at `http://localhost:8787/account/remote-connectors`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79ec3fed-8c15-427e-9c70-f9909f513e47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79ec3fed-8c15-427e-9c70-f9909f513e47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote connector shared secrets now persist and reload when revisiting the remote connectors form, allowing users to edit existing secrets
  * Added password field visibility toggle to reveal or mask shared secrets during editing
  * Added functionality to generate new shared secrets for remote connectors

* **Changes**
  * Removed copy-to-clipboard button for shared secrets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->