### PR TITLE
Truncate long secret names

### DIFF
--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -1374,9 +1374,14 @@ export function AccountSecretsRoute(handle: Handle) {
 													{secret.description ? (
 														<span
 															mix={css({
+																display: '-webkit-box',
 																fontSize: typography.fontSize.sm,
 																color: colors.textMuted,
+																overflow: 'hidden',
 																overflowWrap: 'anywhere',
+																textOverflow: 'ellipsis',
+																WebkitBoxOrient: 'vertical',
+																WebkitLineClamp: 2,
 															})}
 														>
 															{secret.description}

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -446,6 +446,13 @@ function buildAppOptionDescription(updatedAt: string) {
 	return `Updated ${new Date(updatedAt).toLocaleDateString()}`
 }
 
+const truncatedTextCss = {
+	minWidth: 0,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+} as const
+
 export function AccountSecretsRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
 	let email = ''
@@ -1277,6 +1284,7 @@ export function AccountSecretsRoute(handle: Handle) {
 								mix={css({
 									maxHeight: 'min(65vh, 48rem)',
 									overflowY: 'auto',
+									overflowX: 'hidden',
 									paddingRight: spacing.xs,
 								})}
 							>
@@ -1292,7 +1300,7 @@ export function AccountSecretsRoute(handle: Handle) {
 									{filteredSecrets.map((secret) => {
 										const isActive = activeSecretId === secret.id
 										return (
-											<li key={secret.id}>
+											<li key={secret.id} mix={css({ minWidth: 0 })}>
 												<button
 													type="button"
 													mix={[
@@ -1304,10 +1312,12 @@ export function AccountSecretsRoute(handle: Handle) {
 
 														css({
 															width: '100%',
+															minWidth: 0,
 															textAlign: 'left',
 															display: 'grid',
 															gap: spacing.xs,
 															padding: spacing.md,
+															overflow: 'hidden',
 															borderRadius: radius.md,
 															border: `1px solid ${
 																isActive ? colors.primary : colors.border
@@ -1328,13 +1338,23 @@ export function AccountSecretsRoute(handle: Handle) {
 															justifyContent: 'space-between',
 															gap: spacing.sm,
 															alignItems: 'baseline',
+															minWidth: 0,
 														})}
 													>
-														<strong>{secret.name}</strong>
+														<strong
+															mix={css({
+																...truncatedTextCss,
+																display: 'block',
+																flex: '1 1 auto',
+															})}
+														>
+															{secret.name}
+														</strong>
 														<span
 															mix={css({
 																fontSize: typography.fontSize.xs,
 																color: colors.textMuted,
+																flex: '0 0 auto',
 															})}
 														>
 															{formatRelativeTtl(secret.ttlMs)}
@@ -1342,6 +1362,8 @@ export function AccountSecretsRoute(handle: Handle) {
 													</div>
 													<span
 														mix={css({
+															...truncatedTextCss,
+															display: 'block',
 															fontSize: typography.fontSize.sm,
 															color: colors.textMuted,
 														})}
@@ -1354,6 +1376,7 @@ export function AccountSecretsRoute(handle: Handle) {
 															mix={css({
 																fontSize: typography.fontSize.sm,
 																color: colors.textMuted,
+																overflowWrap: 'anywhere',
 															})}
 														>
 															{secret.description}

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -1217,7 +1217,10 @@ export function AccountSecretsRoute(handle: Handle) {
 											},
 										),
 
-										css(inputCss),
+										css({
+											...inputCss,
+											paddingRight: spacing.xl,
+										}),
 									]}
 								/>
 							</label>

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -1380,8 +1380,8 @@ export function AccountSecretsRoute(handle: Handle) {
 																overflow: 'hidden',
 																overflowWrap: 'anywhere',
 																textOverflow: 'ellipsis',
-																WebkitBoxOrient: 'vertical',
-																WebkitLineClamp: 2,
+																'-webkit-box-orient': 'vertical',
+																'-webkit-line-clamp': '2',
 															})}
 														>
 															{secret.description}

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -1336,7 +1336,7 @@ export function AccountSecretsRoute(handle: Handle) {
 														mix={css({
 															display: 'flex',
 															justifyContent: 'space-between',
-															gap: spacing.sm,
+															gap: spacing.md,
 															alignItems: 'baseline',
 															minWidth: 0,
 														})}

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -1337,8 +1337,8 @@ export function AccountSecretsRoute(handle: Handle) {
 												>
 													<div
 														mix={css({
-															display: 'flex',
-															justifyContent: 'space-between',
+															display: 'grid',
+															gridTemplateColumns: 'minmax(0, 1fr) auto',
 															gap: spacing.md,
 															alignItems: 'baseline',
 															minWidth: 0,
@@ -1348,7 +1348,6 @@ export function AccountSecretsRoute(handle: Handle) {
 															mix={css({
 																...truncatedTextCss,
 																display: 'block',
-																flex: '1 1 auto',
 															})}
 														>
 															{secret.name}
@@ -1357,7 +1356,6 @@ export function AccountSecretsRoute(handle: Handle) {
 															mix={css({
 																fontSize: typography.fontSize.xs,
 																color: colors.textMuted,
-																flex: '0 0 auto',
 															})}
 														>
 															{formatRelativeTtl(secret.ttlMs)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Truncate long secret names and compact metadata in the account secrets list with CSS-only ellipsis behavior.
- Hide horizontal overflow on the scrollable secrets list while preserving vertical scrolling.
- Clamp long descriptions, keep expiry labels spaced from truncated names, and pad the search field for the native clear control.

### Walkthrough
<a href="https://cursor.com/agents/bc-0764d779-7728-4480-8cc8-2b6b2bcbc814/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsecret-list-final-simple-demo.mp4"><img src="https://cursor.com/artifacts/c/art-74ba4023-d14a-415f-a050-780948ddb254" alt="secret-list-final-simple-demo.mp4" /></a>
![Final account secrets list spacing and truncation](https://cursor.com/artifacts/c/art-47f908fc-486f-4ae3-bb9a-06581bcbdc57)

### Testing
- `npx oxfmt --check packages/worker/client/routes/account-secrets.tsx`
- `npx oxlint packages/worker/client/routes/account-secrets.tsx`
- `npx vitest run packages/worker/client/routes/account-secrets-navigation.node.test.ts --config vitest.node.config.ts`
- `npm run typecheck`
- Browser probes against local dev server seeded long names/descriptions and confirmed no horizontal document scroll, no list overflow, name ellipsis, and description line clamp.
- Manual browser demo verified truncation, clamping, label spacing, and search clear-control spacing.
- PR checks are green: Validate, Preview, Cursor Bugbot, and CodeRabbit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0764d779-7728-4480-8cc8-2b6b2bcbc814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0764d779-7728-4480-8cc8-2b6b2bcbc814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the account secrets list UI with improved text truncation and layout constraints to prevent overflow and ensure secret names and descriptions display consistently across different content lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->