### PR TITLE
Workflows runtime: fix idempotencyKey dedupe and normalize exportName storage

### DIFF
--- a/packages/worker/migrations/0036-workflow-runs-idempotency-index.sql
+++ b/packages/worker/migrations/0036-workflow-runs-idempotency-index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS workflow_runs_user_idempotency_idx
+ON workflow_runs(user_id, idempotency_key);

--- a/packages/worker/migrations/0036-workflow-runs-idempotency-index.sql
+++ b/packages/worker/migrations/0036-workflow-runs-idempotency-index.sql
@@ -1,2 +1,2 @@
 CREATE INDEX IF NOT EXISTS workflow_runs_user_idempotency_idx
-ON workflow_runs(user_id, idempotency_key);
+ON workflow_runs(user_id, idempotency_key, created_at);

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -120,6 +120,25 @@ function createWorkflowRunsDatabase(options?: {
 									savedPackage['kody_id'] === params[0]
 								return userMatches && idMatches ? savedPackage : null
 							}
+							if (
+								query.includes('FROM workflow_runs') &&
+								query.includes('idempotency_key = ?')
+							) {
+								const userId = params[0]
+								const idempotencyKey = params[1]
+								const matches = [...workflowRuns.values()]
+									.filter(
+										(row) =>
+											row['user_id'] === userId &&
+											row['idempotency_key'] === idempotencyKey,
+									)
+									.sort((left, right) =>
+										String(left['created_at']).localeCompare(
+											String(right['created_at']),
+										),
+									)
+								return matches[0] ?? null
+							}
 							return null
 						},
 						async all() {
@@ -614,6 +633,183 @@ test('createDynamicCallableWorkflow verifies package ownership before queueing p
 	).rejects.toThrow(
 		'workflows.create requires exactly one of exportName or code.',
 	)
+})
+
+test('createDynamicCallableWorkflow dedupes by (user_id, idempotency_key) across runAt changes and runs the workflow only once', async () => {
+	const binding = createStatefulWorkflowBinding()
+	const db = createWorkflowRunsDatabase()
+	const env = {
+		APP_DB: db,
+		DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+	} as Env
+
+	const first = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		body: {
+			packageId: 'pkg-1',
+			exportName: './workflow-run-event',
+			runAt: '2026-05-08T19:30:00.000Z',
+			idempotencyKey: 'idempotency-repro',
+			params: { date: '2026-05-08', key: 'noop' },
+		},
+	})
+
+	const second = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		body: {
+			packageId: 'pkg-1',
+			exportName: './workflow-run-event',
+			runAt: '2026-05-08T19:31:00.000Z',
+			idempotencyKey: 'idempotency-repro',
+			params: { date: '2026-05-08', key: 'noop' },
+		},
+	})
+
+	expect(second.id).toBe(first.id)
+	expect(second).toMatchObject({
+		ok: true,
+		id: first.id,
+		source_type: 'package',
+		package_id: 'pkg-1',
+		export_name: './workflow-run-event',
+		run_at: first.run_at,
+	})
+	expect(binding.create).toHaveBeenCalledTimes(1)
+	expect(binding.instances.size).toBe(1)
+	expect(db.workflowRuns.size).toBe(1)
+	const stored = [...db.workflowRuns.values()]
+	expect(stored).toHaveLength(1)
+	expect(stored[0]).toMatchObject({
+		idempotency_key: 'idempotency-repro',
+		run_at: '2026-05-08T19:30:00.000Z',
+	})
+})
+
+test('createDynamicCallableWorkflow scopes idempotency dedupe per user', async () => {
+	const binding = createStatefulWorkflowBinding()
+	const db = createWorkflowRunsDatabase({
+		savedPackage: {
+			id: 'pkg-1',
+			user_id: 'user-2',
+			name: 'Shade automation',
+			kody_id: 'shade-automation',
+			description: 'Shade automation package',
+			tags_json: '[]',
+			search_text: null,
+			source_id: 'source-1',
+			has_app: 0,
+			created_at: '2026-05-03T00:00:00.000Z',
+			updated_at: '2026-05-03T00:00:00.000Z',
+		},
+	})
+	const env = {
+		APP_DB: db,
+		DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+	} as Env
+
+	const userOne = await createDynamicCallableWorkflow({
+		env: {
+			APP_DB: createWorkflowRunsDatabase(),
+			DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+		} as Env,
+		userId: 'user-1',
+		body: {
+			packageId: 'pkg-1',
+			exportName: './workflow-run-event',
+			runAt: '2026-05-08T19:30:00.000Z',
+			idempotencyKey: 'shared-key',
+		},
+	})
+	const userTwo = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-2',
+		body: {
+			packageId: 'pkg-1',
+			exportName: './workflow-run-event',
+			runAt: '2026-05-08T19:30:00.000Z',
+			idempotencyKey: 'shared-key',
+		},
+	})
+
+	expect(userOne.id).not.toBe(userTwo.id)
+	expect(binding.create).toHaveBeenCalledTimes(2)
+})
+
+test('createDynamicCallableWorkflow dedupes even when the prior run terminated with an error', async () => {
+	const binding = createStatefulWorkflowBinding()
+	const db = createWorkflowRunsDatabase()
+	const env = {
+		APP_DB: db,
+		DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+	} as Env
+
+	const first = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		body: {
+			packageId: 'pkg-1',
+			exportName: './workflow-run-event',
+			runAt: '2026-05-08T19:30:00.000Z',
+			idempotencyKey: 'terminal-key',
+		},
+	})
+	const stored = db.workflowRuns.get(first.id)
+	if (!stored) throw new Error('Expected stored workflow row.')
+	stored['status'] = 'errored'
+
+	const replay = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		body: {
+			packageId: 'pkg-1',
+			exportName: './workflow-run-event',
+			runAt: '2026-05-08T19:31:00.000Z',
+			idempotencyKey: 'terminal-key',
+		},
+	})
+
+	expect(replay.id).toBe(first.id)
+	expect(replay.status).toBe('errored')
+	expect(binding.create).toHaveBeenCalledTimes(1)
+})
+
+test('createDynamicCallableWorkflow normalizes exportName: FQN, relative, and bare forms store without doubled "./"', async () => {
+	for (const form of [
+		'kody:@kentcdodds/shade-automation/workflow-run-event',
+		'./workflow-run-event',
+		'workflow-run-event',
+	]) {
+		const binding = createStatefulWorkflowBinding()
+		const db = createWorkflowRunsDatabase()
+		const env = {
+			APP_DB: db,
+			DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+		} as Env
+		const created = await createDynamicCallableWorkflow({
+			env,
+			userId: 'user-1',
+			body: {
+				packageId: 'pkg-1',
+				exportName: form,
+				runAt: '2026-05-08T19:30:00.000Z',
+				idempotencyKey: `key-${form}`,
+			},
+		})
+		const expectedExportName = form.startsWith('kody:')
+			? form
+			: form.startsWith('./')
+				? form
+				: `./${form}`
+		expect(created.export_name, `create result for ${form}`).toBe(
+			expectedExportName,
+		)
+		expect(
+			db.workflowRuns.get(created.id)?.['export_name'],
+			`stored row for ${form}`,
+		).toBe(expectedExportName)
+	}
 })
 
 test('createDynamicCallableWorkflow enforces the per-user concurrent workflow limit', async () => {

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -221,9 +221,10 @@ function normalizeNonEmptyString(value: string, fieldName: string) {
 	return trimmed
 }
 
-function normalizeWorkflowExportName(exportName: string) {
+export function normalizeWorkflowExportName(exportName: string) {
 	const trimmed = normalizeNonEmptyString(exportName, 'exportName')
 	if (trimmed === '.' || trimmed === './') return '.'
+	if (trimmed.startsWith('kody:')) return trimmed
 	return trimmed.startsWith('./') ? trimmed : `./${trimmed}`
 }
 
@@ -523,6 +524,43 @@ function createPackageWorkflowCreateResult(input: {
 	})
 }
 
+function createWorkflowCreateResultFromRow(
+	row: WorkflowRunInspection,
+): PackageWorkflowCreateResult {
+	return {
+		ok: true,
+		id: row.id,
+		workflow_name: row.workflowName,
+		source_type: row.sourceType,
+		package_id: row.sourceType === 'package' ? row.packageId : null,
+		export_name: row.sourceType === 'package' ? row.exportName : null,
+		run_at: row.runAt,
+		plan_date: row.planDate,
+		...(row.status ? { status: row.status } : {}),
+	}
+}
+
+async function findWorkflowRunByIdempotencyKey(input: {
+	db: D1Database
+	userId: string
+	idempotencyKey: string
+}): Promise<WorkflowRunInspection | null> {
+	const trimmedKey = input.idempotencyKey.trim()
+	if (!trimmedKey) return null
+	const result = await input.db
+		.prepare(
+			`SELECT *
+			FROM workflow_runs
+			WHERE user_id = ? AND idempotency_key = ?
+			ORDER BY created_at ASC
+			LIMIT 1`,
+		)
+		.bind(input.userId, trimmedKey)
+		.first<Record<string, unknown>>()
+	if (!result) return null
+	return mapWorkflowRunRow(result)
+}
+
 async function createInlineWorkflowInstanceId(input: {
 	userId: string
 	workflowName: string
@@ -736,6 +774,25 @@ export async function createPackageWorkflowInstance(input: {
 	return createPackageWorkflowCreateResult({ summary, payload })
 }
 
+function assertWorkflowCreateBodyShape(body: PackageWorkflowCreateInput): {
+	code: string | null
+	exportName: string | null
+} {
+	const record = body as PackageWorkflowCreateInput & Record<string, unknown>
+	const code =
+		typeof record.code === 'string' && record.code.trim() ? record.code : null
+	const exportName =
+		typeof record.exportName === 'string' && record.exportName.trim()
+			? record.exportName
+			: null
+	if ((code ? 1 : 0) + (exportName ? 1 : 0) !== 1) {
+		throw new Error(
+			'workflows.create requires exactly one of exportName or code.',
+		)
+	}
+	return { code, exportName }
+}
+
 async function resolveWorkflowPayload(input: {
 	env: Pick<Env, 'APP_DB'>
 	userId: string
@@ -748,17 +805,7 @@ async function resolveWorkflowPayload(input: {
 }): Promise<DynamicCallableWorkflowPayload> {
 	const body = input.body as PackageWorkflowCreateInput &
 		Record<string, unknown>
-	const code =
-		typeof body.code === 'string' && body.code.trim() ? body.code : null
-	const exportName =
-		typeof body.exportName === 'string' && body.exportName.trim()
-			? body.exportName
-			: null
-	if ((code ? 1 : 0) + (exportName ? 1 : 0) !== 1) {
-		throw new Error(
-			'workflows.create requires exactly one of exportName or code.',
-		)
-	}
+	const { code, exportName } = assertWorkflowCreateBodyShape(input.body)
 	if (code) {
 		return createInlineWorkflowPayload({
 			userId: input.userId,
@@ -816,6 +863,21 @@ export async function createDynamicCallableWorkflow(input: {
 }): Promise<PackageWorkflowCreateResult> {
 	if (!input.env.DYNAMIC_CALLABLE_WORKFLOWS) {
 		throw new Error('Missing DYNAMIC_CALLABLE_WORKFLOWS binding.')
+	}
+	assertWorkflowCreateBodyShape(input.body)
+	const idempotencyKeyInput =
+		typeof input.body.idempotencyKey === 'string'
+			? input.body.idempotencyKey.trim()
+			: ''
+	if (input.env.APP_DB && idempotencyKeyInput) {
+		const existingRun = await findWorkflowRunByIdempotencyKey({
+			db: input.env.APP_DB,
+			userId: input.userId,
+			idempotencyKey: idempotencyKeyInput,
+		})
+		if (existingRun) {
+			return createWorkflowCreateResultFromRow(existingRun)
+		}
 	}
 	const payload = await resolveWorkflowPayload(input)
 	const id = await createDynamicCallableWorkflowInstanceId(payload)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two follow-up fixes for the dynamic Workflows runtime introduced in
[#401](https://github.com/kentcdodds/kody/pull/401).

## Bug 1: `idempotencyKey` dedupe

### Repro (before)

```ts
import { workflows } from 'kody:runtime'

export default async function main() {
  const idempotencyKey = 'idempotency-repro-' + Date.now()
  const a = await workflows.create({
    runAt: new Date(Date.now() + 90_000).toISOString(),
    idempotencyKey,
    packageId: SHADE_PACKAGE_ID,
    exportName: 'kody:@kentcdodds/shade-automation/workflow-run-event',
    params: { date: '2026-05-08', key: 'noop', actions: [], dryRun: true },
  })
  const b = await workflows.create({
    runAt: new Date(Date.now() + 120_000).toISOString(),
    idempotencyKey,
    packageId: SHADE_PACKAGE_ID,
    exportName: 'kody:@kentcdodds/shade-automation/workflow-run-event',
    params: { date: '2026-05-08', key: 'noop', actions: [], dryRun: true },
  })
  return { sameId: a.id === b.id, a, b }
}
```

Before this PR, the two calls returned different IDs and both
workflows ran (`sameId: false`). The deterministic instance ID dedupe
in `createDynamicCallableWorkflowInstanceId` mixes `runAt` into the
hash, so two calls with identical `idempotencyKey` but different
`runAt` produce different IDs and bypass the binding-level dedupe.

### Fix

`createDynamicCallableWorkflow` now consults `workflow_runs` by
`(user_id, idempotency_key)` _before_ allocating a workflow id or
invoking the binding. If a row exists, we return the existing
descriptor in the same shape as a fresh create response, with
`status` reflecting the stored row's current status (including
terminal `errored`/`terminated` rows — callers can use a different
`idempotencyKey` if they want to retry). When `idempotencyKey` is
empty/missing, no implicit dedupe happens.

A new migration adds an index on `(user_id, idempotency_key)` to
keep the lookup cheap. No data migration; existing duplicate rows
are left as-is.

### Regression test

`createDynamicCallableWorkflow dedupes by (user_id, idempotency_key)
across runAt changes and runs the workflow only once` exercises the
exact scenario from the repro: two `create` calls with the same key
but different `runAt`. Asserts identical `id`, `binding.create`
called once, and a single `workflow_runs` row.

Two more regression tests cover the per-user scope (different users
with the same key are not collided) and the terminal-status edge case
(prior `errored` row still dedupes, returning `status: 'errored'`
instead of silently re-spawning).

## Bug 2: `exportName` normalization

### Repro (before)

Calling `workflows.create({ exportName: 'kody:@kentcdodds/...' })`
stored the row with `export_name: './kody:@kentcdodds/...'` (note the
stray leading `./`). The runtime invocation still resolved
correctly, but `workflow_list` output was confusing.

### Fix

`normalizeWorkflowExportName` now treats fully-qualified
`kody:`-prefixed import specifiers as canonical and stores them
as-is. `./relative` and bare `relative` forms are still normalized
to `./relative`. The stored `export_name` and the value returned
in the create response use the canonical, single-form
representation.

No data migration for the existing rows that already have the
doubled `./kody:` prefix (per the task instructions; downstream
resolution still works on those rows).

### Regression test

`createDynamicCallableWorkflow normalizes exportName: FQN, relative,
and bare forms store without doubled "./"` calls `create` with each
of the three input forms and asserts both the response and the
stored row carry the canonical export name with no doubled prefix.

## Test output

```
 ✓ createDynamicCallableWorkflow dedupes by (user_id, idempotency_key) across runAt changes and runs the workflow only once
 ✓ createDynamicCallableWorkflow scopes idempotency dedupe per user
 ✓ createDynamicCallableWorkflow dedupes even when the prior run terminated with an error
 ✓ createDynamicCallableWorkflow normalizes exportName: FQN, relative, and bare forms store without doubled "./"

 Test Files  1 passed (1)
      Tests  17 passed (17)
```

## Non-goals / explicit guarantees

- Public `workflows.create(...)` input shape is unchanged.
- Existing `workflow_runs` rows are not touched.
- `workflow_list` output schema is unchanged.
- All existing package callers
  (shade-automation `daily-plan`, github-activity `weekly-discord`,
  social-intelligence `daily-social-intelligence`, morning-briefing
  `daily-morning-briefing`, email-received-subscriber subscription
  handlers) continue to work without source changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2d93468-a2b1-4ce5-bd6b-d00965ea1d89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2d93468-a2b1-4ce5-bd6b-d00965ea1d89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows now support idempotency: repeated requests with the same idempotency key reuse existing runs (scoped per user) and preserve prior run status.
  * Improved export-name normalization for consistent handling of different naming formats.

* **Performance**
  * Database index added for faster idempotency lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->