### PR TITLE
feat(repo): add repo_write_file MCP capability for whole-file overwrites

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -132,6 +132,10 @@ Operational notes:
   the repo session Durable Object. It accepts only parsed git command forms, not
   arbitrary shell syntax, and package runtime bundles are loaded from published
   artifacts rather than a mounted checkout.
+- `repo_write_file` exposes the same Durable Object's `applyEdits` write path as
+  a first-class MCP capability for whole-file overwrites. Prefer it over
+  `git apply` heredocs when the agent is replacing an entire file (for example,
+  a single-file job source) instead of patching a hunk with surrounding context.
 
 ### Direct Artifacts git publishes
 

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -196,6 +196,9 @@ Package source is edited and published through repo-backed flows.
 - `repo_run_commands` accepts a newline-separated parsed git-command string, not
   arbitrary shell; keep agent-facing guidance aligned with the deployed
   capability schema
+- prefer `repo_write_file` for whole-file replacements (single-file job sources,
+  freshly generated package modules, one-line config edits) — it avoids the
+  unified-diff context drift that makes `git apply` heredocs brittle
 - use `package_get_git_remote` and `package_publish_external_push` when a human
   or autonomous agent should drive a normal git client directly against the
   package's Cloudflare Artifacts repo

--- a/docs/use/repo-sessions.md
+++ b/docs/use/repo-sessions.md
@@ -79,10 +79,10 @@ unified diff. Each file patch must include:
 Multiple file patches can be stacked back-to-back inside a single heredoc; do
 not separate them with `diff --git` lines or per-file `git apply` invocations.
 Patches are applied with the standard `diff` library, so the heredoc must match
-exactly what an upstream `git diff` would produce. If you only need to edit one
-file, prefer copying the new full file body and writing a clean unified diff
-against the current contents (read it first with `repo_read_file` when in doubt)
-rather than approximating context lines.
+exactly what an upstream `git diff` would produce. If you have the full new file
+body and only need to overwrite a file (rather than apply a true patch with
+context lines), prefer `repo_write_file` (see below) — it sidesteps unified-diff
+context drift entirely.
 
 ## Opening by package identity
 
@@ -122,10 +122,48 @@ session:
 
 - browse files with `repo_tree` and `repo_read_file`
 - search the workspace with `repo_search`
+- overwrite or create files with `repo_write_file` (preferred over `git apply`
+  for whole-file replacements such as single-file job sources or generated
+  package modules)
 - inspect file contents or diffs only when you decide to read them
 - run checks separately from publish
 - inspect status with `repo_get_check_status`
 - repair drift with `repo_rebase_session`
+
+### `repo_write_file` vs `git apply`
+
+`repo_run_commands` accepts `git apply <<'PATCH' ... PATCH` heredocs for true
+unified diffs (see [`git apply` patch format](#git-apply-patch-format)). That
+form is fragile when you do not have the exact surrounding context lines — a
+common situation for AI-authored single-file job sources or freshly generated
+files.
+
+`repo_write_file` overwrites one or more files with full new content and returns
+a per-file diff plus a `changed` flag. Reach for it when:
+
+- replacing the entire body of a job, app server, or skill module
+- writing a freshly generated package file that does not yet exist
+- patching a one-line config when you do not want to hand-craft a diff hunk
+
+It only mutates the live session overlay. Pair it with `repo_run_commands` for
+`git add`/`git commit` and `repo_publish_session` (or `repo_run_commands` with
+`publish: true`) when you are ready to publish.
+
+For non-package repo-backed scheduled job source you can also short-circuit
+sessions entirely by passing a replacement `code` string to `job_update`, which
+republishes the job module without opening a session.
+
+```json
+{
+	"session_id": "session-1",
+	"files": [
+		{
+			"path": "src/index.ts",
+			"content": "export default async function main() { return { ok: true } }\n"
+		}
+	]
+}
+```
 
 ## Example
 

--- a/packages/worker/src/mcp/capabilities/repo/domain.ts
+++ b/packages/worker/src/mcp/capabilities/repo/domain.ts
@@ -11,6 +11,7 @@ import { repoRunChecksCapability } from './repo-run-checks.ts'
 import { repoRunCommandsCapability } from './repo-run-commands.ts'
 import { repoSearchCapability } from './repo-search.ts'
 import { repoTreeCapability } from './repo-tree.ts'
+import { repoWriteFileCapability } from './repo-write-file.ts'
 
 export const repoDomain = defineDomain({
 	name: capabilityDomainNames.repo,
@@ -23,6 +24,7 @@ export const repoDomain = defineDomain({
 		repoGetSessionCapability,
 		repoTreeCapability,
 		repoReadFileCapability,
+		repoWriteFileCapability,
 		repoSearchCapability,
 		repoRunChecksCapability,
 		repoGetCheckStatusCapability,

--- a/packages/worker/src/mcp/capabilities/repo/index.ts
+++ b/packages/worker/src/mcp/capabilities/repo/index.ts
@@ -12,5 +12,6 @@ export { repoRunCommandsCapability } from './repo-run-commands.ts'
 export { repoRunChecksCapability } from './repo-run-checks.ts'
 export { repoSearchCapability } from './repo-search.ts'
 export { repoTreeCapability } from './repo-tree.ts'
+export { repoWriteFileCapability } from './repo-write-file.ts'
 
 export const repoCapabilities = repoDomain.capabilities

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands-text.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands-text.ts
@@ -20,6 +20,7 @@ export const repoRunCommandsCapabilityDescription = [
 	'Commands are newline-separated and parsed, not shell-executed.',
 	'Only supported git command forms are accepted; unsupported syntax returns line-specific parse errors.',
 	'`git apply` requires heredoc form and a standard unified diff body with `--- a/<path>` / `+++ b/<path>` headers and `@@ ... @@` hunk markers; one heredoc may contain multiple file patches stacked back-to-back, and `/dev/null` on either side creates or deletes a file.',
+	'For exact whole-file replacements (especially single-file job sources, freshly generated files, or any edit where you have the full new content), prefer `repo_write_file` over `git apply`; it avoids unified-diff context drift entirely.',
 	'For one-file edits to non-package repo-backed scheduled job source, prefer `job_update` with a replacement `code` string; it republishes the job module without needing a repo session.',
 ].join(' ')
 

--- a/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
@@ -134,6 +134,54 @@ export const repoReadFileOutputSchema = z.object({
 	content: z.string().nullable(),
 })
 
+export const repoWriteFileInputSchema = repoSessionIdSchema.extend({
+	files: z
+		.array(
+			z.object({
+				path: z
+					.string()
+					.min(1)
+					.describe(
+						'Repo-relative file path to write. Existing files are overwritten with the provided content; missing parent directories are created.',
+					),
+				content: z
+					.string()
+					.describe(
+						'Full new file content. Pass the entire file body, not a patch or diff.',
+					),
+			}),
+		)
+		.min(1)
+		.describe(
+			'One or more files to overwrite in the active repo session. Each entry replaces the file at `path` with `content` exactly.',
+		),
+	dry_run: z
+		.boolean()
+		.optional()
+		.describe(
+			'When true, compute the per-file diff without writing the workspace. Useful for previewing changes before committing.',
+		),
+	rollback_on_error: z
+		.boolean()
+		.optional()
+		.describe(
+			'When true (default), all writes are rolled back if any individual write fails. Set to false to keep partial progress.',
+		),
+})
+
+export const repoWriteFileEditSchema = z.object({
+	path: z.string(),
+	changed: z.boolean(),
+	content: z.string(),
+	diff: z.string(),
+})
+
+export const repoWriteFileOutputSchema = z.object({
+	dry_run: z.boolean(),
+	total_changed: z.number().int().min(0),
+	edits: z.array(repoWriteFileEditSchema),
+})
+
 export const repoTreeInputSchema = repoSessionIdSchema.extend({
 	path: z
 		.string()

--- a/packages/worker/src/mcp/capabilities/repo/repo-write-file.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-write-file.node.test.ts
@@ -1,0 +1,198 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	repoSessionRpc: vi.fn(),
+}))
+
+vi.mock('#worker/repo/repo-session-do.ts', () => ({
+	repoSessionRpc: (...args: Array<unknown>) =>
+		mockModule.repoSessionRpc(...args),
+}))
+
+const { repoWriteFileCapability } = await import('./repo-write-file.ts')
+
+function createCapabilityContext() {
+	return {
+		env: { APP_DB: {} } as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: { userId: 'user-1', email: 'user@example.com' },
+		}),
+	}
+}
+
+function createRpc(overrides?: Partial<Record<string, unknown>>) {
+	return {
+		applyEdits: vi.fn(),
+		...overrides,
+	}
+}
+
+function resetMocks() {
+	mockModule.repoSessionRpc.mockReset()
+}
+
+test('repo_write_file forwards write edits to applyEdits and reshapes the response', async () => {
+	resetMocks()
+	const rpc = createRpc()
+	rpc.applyEdits.mockResolvedValueOnce({
+		dryRun: false,
+		totalChanged: 2,
+		edits: [
+			{
+				path: 'src/index.ts',
+				changed: true,
+				content: 'export const value = 1\n',
+				diff: '@@ diff a',
+			},
+			{
+				path: 'README.md',
+				changed: true,
+				content: '# README\n',
+				diff: '@@ diff b',
+			},
+		],
+	})
+	mockModule.repoSessionRpc.mockReturnValue(rpc)
+
+	const result = await repoWriteFileCapability.handler(
+		{
+			session_id: 'session-1',
+			files: [
+				{ path: 'src/index.ts', content: 'export const value = 1\n' },
+				{ path: 'README.md', content: '# README\n' },
+			],
+		},
+		createCapabilityContext(),
+	)
+
+	expect(mockModule.repoSessionRpc).toHaveBeenCalledWith(
+		expect.anything(),
+		'session-1',
+	)
+	expect(rpc.applyEdits).toHaveBeenCalledWith({
+		sessionId: 'session-1',
+		userId: 'user-1',
+		edits: [
+			{
+				kind: 'write',
+				path: 'src/index.ts',
+				content: 'export const value = 1\n',
+			},
+			{ kind: 'write', path: 'README.md', content: '# README\n' },
+		],
+		dryRun: undefined,
+		rollbackOnError: undefined,
+	})
+	expect(result).toEqual({
+		dry_run: false,
+		total_changed: 2,
+		edits: [
+			{
+				path: 'src/index.ts',
+				changed: true,
+				content: 'export const value = 1\n',
+				diff: '@@ diff a',
+			},
+			{
+				path: 'README.md',
+				changed: true,
+				content: '# README\n',
+				diff: '@@ diff b',
+			},
+		],
+	})
+})
+
+test('repo_write_file passes dry_run and rollback_on_error through to applyEdits', async () => {
+	resetMocks()
+	const rpc = createRpc()
+	rpc.applyEdits.mockResolvedValueOnce({
+		dryRun: true,
+		totalChanged: 0,
+		edits: [
+			{
+				path: 'src/index.ts',
+				changed: false,
+				content: 'unchanged\n',
+				diff: '',
+			},
+		],
+	})
+	mockModule.repoSessionRpc.mockReturnValue(rpc)
+
+	const result = await repoWriteFileCapability.handler(
+		{
+			session_id: 'session-1',
+			files: [{ path: 'src/index.ts', content: 'unchanged\n' }],
+			dry_run: true,
+			rollback_on_error: false,
+		},
+		createCapabilityContext(),
+	)
+
+	expect(rpc.applyEdits).toHaveBeenCalledWith(
+		expect.objectContaining({
+			dryRun: true,
+			rollbackOnError: false,
+		}),
+	)
+	expect(result.dry_run).toBe(true)
+	expect(result.total_changed).toBe(0)
+})
+
+test('repo_write_file rejects an empty files array via input schema', async () => {
+	resetMocks()
+	const rpc = createRpc()
+	mockModule.repoSessionRpc.mockReturnValue(rpc)
+	await expect(
+		repoWriteFileCapability.handler(
+			{ session_id: 'session-1', files: [] },
+			createCapabilityContext(),
+		),
+	).rejects.toThrow()
+	expect(rpc.applyEdits).not.toHaveBeenCalled()
+})
+
+test('repo_write_file requires non-empty paths', async () => {
+	resetMocks()
+	const rpc = createRpc()
+	mockModule.repoSessionRpc.mockReturnValue(rpc)
+	await expect(
+		repoWriteFileCapability.handler(
+			{
+				session_id: 'session-1',
+				files: [{ path: '', content: 'hello' }],
+			},
+			createCapabilityContext(),
+		),
+	).rejects.toThrow()
+	expect(rpc.applyEdits).not.toHaveBeenCalled()
+})
+
+test('repo_write_file allows empty content for clearing a file', async () => {
+	resetMocks()
+	const rpc = createRpc()
+	rpc.applyEdits.mockResolvedValueOnce({
+		dryRun: false,
+		totalChanged: 1,
+		edits: [
+			{ path: 'src/index.ts', changed: true, content: '', diff: '@@ cleared' },
+		],
+	})
+	mockModule.repoSessionRpc.mockReturnValue(rpc)
+	const result = await repoWriteFileCapability.handler(
+		{
+			session_id: 'session-1',
+			files: [{ path: 'src/index.ts', content: '' }],
+		},
+		createCapabilityContext(),
+	)
+	expect(rpc.applyEdits).toHaveBeenCalledWith(
+		expect.objectContaining({
+			edits: [{ kind: 'write', path: 'src/index.ts', content: '' }],
+		}),
+	)
+	expect(result.total_changed).toBe(1)
+})

--- a/packages/worker/src/mcp/capabilities/repo/repo-write-file.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-write-file.ts
@@ -1,0 +1,61 @@
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
+import {
+	repoWriteFileInputSchema,
+	repoWriteFileOutputSchema,
+} from './repo-shared.ts'
+
+export const repoWriteFileCapability = defineDomainCapability(
+	capabilityDomainNames.repo,
+	{
+		name: 'repo_write_file',
+		description: [
+			'Overwrite one or more files in the active repo session with exact full-file content.',
+			'Use this for whole-file replacements or for creating new files when crafting a unified diff for `repo_run_commands` `git apply` would be brittle (for example, single-file job sources or generated package modules).',
+			'Each entry replaces the file at `path` with `content` exactly; missing parent directories are created. Returns a per-file diff plus a `changed` flag for callers that want to confirm a write actually mutated the workspace.',
+			'Writes only mutate the live session overlay; they do not commit, run checks, or publish. Pair with `repo_run_commands` for `git add`/`git commit` and with `repo_publish_session` (or `repo_run_commands` with `publish: true`) to publish.',
+		].join(' '),
+		keywords: [
+			'repo',
+			'session',
+			'write',
+			'file',
+			'edit',
+			'replace',
+			'overwrite',
+			'workspace',
+		],
+		readOnly: false,
+		idempotent: false,
+		destructive: true,
+		inputSchema: repoWriteFileInputSchema,
+		outputSchema: repoWriteFileOutputSchema,
+		async handler(args, ctx: CapabilityContext) {
+			const user = requireMcpUser(ctx.callerContext)
+			const result = await repoSessionRpc(ctx.env, args.session_id).applyEdits({
+				sessionId: args.session_id,
+				userId: user.userId,
+				edits: args.files.map((file) => ({
+					kind: 'write' as const,
+					path: file.path,
+					content: file.content,
+				})),
+				dryRun: args.dry_run,
+				rollbackOnError: args.rollback_on_error,
+			})
+			return {
+				dry_run: result.dryRun,
+				total_changed: result.totalChanged,
+				edits: result.edits.map((edit) => ({
+					path: edit.path,
+					changed: edit.changed,
+					content: edit.content,
+					diff: edit.diff,
+				})),
+			}
+		},
+	},
+)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Repo-backed source edits could only flow through `repo_run_commands`'
parsed git command stream, so any change had to be expressed as a unified
diff via `git apply <<'PATCH' ... PATCH`. That works for true patches with
known surrounding context, but it is brittle for whole-file replacements
where the agent already has the full target content:

- single-file job sources where `git apply` patches do not give the agent
  surrounding context lines to anchor against
- freshly generated package modules that do not yet exist on disk
- one-line config flips where hand-crafting a diff hunk is more fragile
  than just writing the file

The `RepoSession` Durable Object already exposes an `applyEdits` RPC with
a `write` edit kind, but no MCP capability surfaced it directly. Agents had
no obvious primitive between `repo_read_file` and `repo_run_commands`.

## What

- New `repo_write_file` MCP capability that wraps the existing
  `RepoSession.applyEdits` RPC for one-or-more `write` edits.
- Accepts `session_id`, `files: [{ path, content }]`, and optional
  `dry_run` / `rollback_on_error`.
- Returns the same per-file `diff` and `changed` shape the underlying RPC
  already produced (snake-cased for MCP output): `{ dry_run, total_changed, edits: [...] }`.
- Registered in the `repo` domain alongside `repo_read_file`.
- Adds unit tests covering the happy path, `dry_run` / `rollback_on_error`
  pass-through, empty-file-array rejection, empty-path rejection, and
  empty-content writes (clearing a file).
- Updates `repo_run_commands`' description plus
  `docs/use/repo-sessions.md`,
  `docs/contributing/packages-and-manifests.md`, and
  `docs/contributing/architecture/data-storage.md` to point agents at
  `repo_write_file` for whole-file replacements.

## Scope notes

The original task listed three possible outcomes in priority order. This
PR delivers option 2 (a focused single-file write capability) rather than
option 1 (a generic temp-dir git remote for every entity kind). Reasoning:

- The DO already has the right primitive — `applyEdits` with `write` kind
  — so wrapping it is a tiny, well-scoped change with deterministic tests.
- A generic git remote per entity kind would have to mint Artifacts
  tokens, plumb new resolver/source paths for skill/app/job entities, and
  introduce a bigger surface area than is reviewable in one focused PR.
- The new capability composes cleanly with existing `repo_run_commands`
  for `git add`/`git commit`/`git push` and with `repo_publish_session`,
  so agents that need a full clone-edit-publish flow can still do it
  through repo sessions without a new git remote.

## Test plan

- `npx vitest run --project node-unit` — 107 files, 520 tests passing
  (includes the new `repo-write-file.node.test.ts`).
- `npx vitest run --project workers-unit` — 12 files, 68 tests passing.
- `npx tsc -b --noEmit` — clean.
- `npx oxlint .` — 0 warnings, 0 errors.
- `npx oxfmt --check` against modified files — clean after formatting.

No production Kody data, saved packages, or live MCP sessions were
touched as part of this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee2877d2-cbf9-4d10-b8d1-a782e7640de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee2877d2-cbf9-4d10-b8d1-a782e7640de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

