### PR TITLE
docs: clarify job_update source publishing and repo_run_commands ergonomics

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -96,7 +96,10 @@ module-oriented runtime model:
 - **`codemode.job_update(...)`** updates an existing scheduled job by id for
   safe mutable fields such as name, ES module code with a default-exported
   function, params, schedule, timezone, enabled/disabled state, or kill switch
-  state
+  state. Providing `code` republishes the job's repo-backed source so the next
+  run uses the new module; the replacement must default export a function that
+  receives `params` from its first argument (there is no `params` export from
+  `kody:runtime`)
 - **`codemode.job_delete(...)`** removes an existing scheduled job by id for the
   signed-in user
 - **`codemode.job_run_now(...)`** runs an existing scheduled job immediately and

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -149,6 +149,14 @@ kill-switch state, params, or ES module code with a default-exported function,
 `job_delete` removes an existing scheduled job by id, and `job_run_now` can
 trigger an existing scheduled job immediately for debugging or ad hoc runs.
 
+When `job_update` receives a replacement `code` string, Kody publishes a new
+commit on the job's repo-backed source and the next run uses the new module.
+That is usually the easiest way to change the source of a non-package job, since
+there is no `package_get_git_remote` equivalent for non-package job sources. For
+multi-file edits, open the job's `source_id` with `repo_run_commands` instead.
+Job code must default export a function that receives the job `params` as its
+first argument; `kody:runtime` does not export `params`.
+
 ## Save and edit packages
 
 Use:

--- a/docs/use/repo-sessions.md
+++ b/docs/use/repo-sessions.md
@@ -7,9 +7,29 @@ publishes.
 Use the repo capabilities when you want to inspect or modify package source
 directly.
 
-## Preferred workflow
+## When to use repo sessions vs. a local git remote
 
-For package edits, use **`repo_run_commands`**.
+There are two supported ways to edit repo-backed source:
+
+- **Repo sessions** (`repo_open_session`, `repo_run_commands`, and the
+  lower-level `repo_*` capabilities). Use these when you are a tool-only agent
+  without a real filesystem, or when you only need to apply small parsed git
+  workflows. Repo sessions also work for repo-backed scheduled jobs (open by
+  `source_id`), not just saved packages.
+- **A short-lived authenticated git remote** via `package_get_git_remote` plus
+  `package_publish_external_push`. Use this when you have local filesystem and
+  git access and want to clone the repo into a temp directory, edit normally,
+  and push the resulting HEAD back. This path is **saved-package-only**; there
+  is no equivalent helper for non-package repo-backed job source.
+
+For one-file edits to a non-package repo-backed scheduled job, the simplest path
+is usually neither of these: pass a replacement `code` string to
+**`job_update`**, which republishes the job module on its repo-backed source
+without opening a session.
+
+## Preferred workflow for repo sessions
+
+For package edits via repo sessions, use **`repo_run_commands`**.
 
 It combines the usual sequence into one capability:
 
@@ -45,6 +65,24 @@ Supported commands:
 
 `git clone` is intentionally unsupported because repo sessions are opened and
 cloned by Kody.
+
+### `git apply` patch format
+
+`git apply` only accepts heredoc form, and the heredoc body must be a standard
+unified diff. Each file patch must include:
+
+- a `--- a/<path>` line and a `+++ b/<path>` line (use `/dev/null` on either
+  side to create or delete a file)
+- one or more `@@ -<old>,<n> +<new>,<n> @@` hunk markers
+- normal context (` `), removal (`-`), and addition (`+`) lines inside each hunk
+
+Multiple file patches can be stacked back-to-back inside a single heredoc; do
+not separate them with `diff --git` lines or per-file `git apply` invocations.
+Patches are applied with the standard `diff` library, so the heredoc must match
+exactly what an upstream `git diff` would produce. If you only need to edit one
+file, prefer copying the new full file body and writing a clean unified diff
+against the current contents (read it first with `repo_read_file` when in doubt)
+rather than approximating context lines.
 
 ## Opening by package identity
 

--- a/packages/worker/src/mcp/capabilities/jobs/job-update.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-update.ts
@@ -12,7 +12,7 @@ export const jobUpdateCapability = defineDomainCapability(
 	{
 		name: 'job_update',
 		description:
-			'Update a scheduled job owned by the signed-in user. Supports safe mutable fields such as name, code, params, schedule, timezone, enabled state, and kill-switch state.',
+			"Update a scheduled job owned by the signed-in user. Supports safe mutable fields such as name, code, params, schedule, timezone, enabled state, and kill-switch state. When `code` is provided Kody publishes a new commit on the job's repo-backed source, replacing the previously published job module; this is the supported way to change job source for non-package jobs without opening a repo session. The replacement code must default export the job entrypoint (e.g. `export default async function main(input = {}) { ... }`) and read `params` from its first argument; there is no `params` export from `kody:runtime`.",
 		keywords: [
 			'job',
 			'update',

--- a/packages/worker/src/mcp/capabilities/jobs/shared.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/shared.ts
@@ -53,7 +53,7 @@ export const scheduledJobInputBaseSchema = {
 		.string()
 		.min(1)
 		.describe(
-			'ES module source for the job entrypoint. It must default export the function Kody should run later, preferably as `export default async function main(input = {}) { ... }`; legacy async-arrow snippets are not supported.',
+			'ES module source for the job entrypoint. It must default export the function Kody should run later, preferably as `export default async function main(input = {}) { ... }`; legacy async-arrow snippets are not supported. The default export receives the job `params` object as its first argument at run time; there is no `params` export from `kody:runtime`, so do not import params and instead read them from the function argument.',
 		),
 	params: z
 		.record(z.string(), z.unknown())
@@ -246,7 +246,7 @@ export const jobUpdateInputSchema = z
 			.min(1)
 			.optional()
 			.describe(
-				'Optional replacement ES module source. It must still default export the job entrypoint, preferably as `export default async function main(input = {}) { ... }`; legacy async-arrow snippets are not supported.',
+				"Optional replacement ES module source. Providing this publishes a new commit on the job's repo-backed source, replacing the previously published job module. It must still default export the job entrypoint, preferably as `export default async function main(input = {}) { ... }`; legacy async-arrow snippets are not supported. The default export receives `params` as its first argument; there is no `params` export from `kody:runtime`.",
 			),
 		params: z
 			.record(z.string(), z.unknown())

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands-text.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands-text.ts
@@ -16,8 +16,11 @@ export const repoRunCommandsSupportedForms = [
 
 export const repoRunCommandsCapabilityDescription = [
 	'Run a parsed git-only workflow in a Kody-managed repo session for MCP-native edits.',
+	'Use this for tool-only agents without local filesystem/git access; coding agents that can clone locally should prefer `package_get_git_remote` (saved packages only) plus `package_publish_external_push`.',
 	'Commands are newline-separated and parsed, not shell-executed.',
 	'Only supported git command forms are accepted; unsupported syntax returns line-specific parse errors.',
+	'`git apply` requires heredoc form and a standard unified diff body with `--- a/<path>` / `+++ b/<path>` headers and `@@ ... @@` hunk markers; one heredoc may contain multiple file patches stacked back-to-back, and `/dev/null` on either side creates or deletes a file.',
+	'For one-file edits to non-package repo-backed scheduled job source, prefer `job_update` with a replacement `code` string; it republishes the job module without needing a repo session.',
 ].join(' ')
 
 export const repoRunCommandsUnsupportedSyntaxDescription = [
@@ -29,6 +32,7 @@ export const repoRunCommandsUnsupportedSyntaxDescription = [
 export const repoRunCommandsSupportedFormsDescription = [
 	'Supported command forms exactly:',
 	...repoRunCommandsSupportedForms.map((form) => `- \`${form}\``),
+	"`git apply` requires heredoc form (e.g. `<<'PATCH' ... PATCH`) and a standard unified diff body. Each file patch needs `--- a/<path>` and `+++ b/<path>` headers plus `@@ -<old>,<n> +<new>,<n> @@` hunk markers; multiple file patches can be stacked back-to-back inside one heredoc, and `/dev/null` on either side creates or deletes a file.",
 ].join('\n')
 
 export const repoRunCommandsCommandsFieldDescription = [

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -62,7 +62,7 @@ Conventions
 - \`job_list\` / \`job_get\`: inspect the signed-in user's scheduled jobs, recent run outcomes, and current per-user alarm state when debugging scheduling issues.
 - \`job_schedule\`: schedule a repo-backed job for the signed-in user without creating a saved package first. Supports one-off, interval, and cron schedules.
 - \`job_schedule_once\`: compatibility wrapper for one-off repo-backed jobs when you only need a single run time.
-- \`job_update\`: update an existing scheduled job by id. Supports safe mutable fields such as name, code, params, schedule, timezone, enabled, and kill-switch state.
+- \`job_update\`: update an existing scheduled job by id. Supports safe mutable fields such as name, code, params, schedule, timezone, enabled, and kill-switch state. Providing \`code\` publishes a new commit on the job's repo-backed source (the simplest way to change the job module for non-package jobs); the replacement must default export a function and read \`params\` from its first argument, not from \`kody:runtime\`.
 - \`job_delete\`: delete one of the signed-in user's scheduled jobs by id.
 - \`job_run_now\`: run an existing scheduled job immediately by id and return the updated job view plus execution result for debugging.
 - \`workflow_list\`: inspect recent Cloudflare Workflow runs created through \`kody:runtime\` \`workflows.create\`, including inline-code and saved-package export workflows.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

While running a production Kody workflow, an agent hit several generic friction
points that the current docs/tool descriptions did not cover well:

- `storage.sql` returns a result object (not a row array), and the recently
  added doc note was the first place that said so end-to-end.
- `job_update`'s semantics around repo-backed scheduled job source were
  unclear — specifically whether passing `code` actually publishes a new
  commit, and what shape the replacement module must take. There is no
  `params` runtime export, but that was not stated, leading agents to try to
  `import { params } from 'kody:runtime'`.
- `repo_run_commands`'s `git apply` form was underdocumented: the heredoc must
  carry a standard unified diff (with `--- a/<path>` / `+++ b/<path>` headers
  and `@@` hunks). When agents approximated that format, patches failed.
- `package_get_git_remote` exists for clone-edit-push from local filesystem,
  but it is saved-package-only. There was no obvious path for editing
  repo-backed job source short of opening a repo session.

This is a docs/tool-description-only change — no behavior is altered.

## What changed

`job_update`

- Capability description now states that providing `code` publishes a new
  commit on the job's repo-backed source (replacing the previous job module),
  and that this is the supported path to change the source of a non-package
  job without opening a repo session.
- `code` field descriptions on both `job_schedule`'s base schema and
  `job_update`'s replacement schema now state explicitly that the default
  export receives `params` as its first argument and that `kody:runtime`
  does not export `params`.
- Server instructions overlay carries the same `job_update` summary so
  agents see it without round-tripping through `search`.

`repo_run_commands`

- Capability description and the `commands` field's "supported forms" doc
  now spell out the heredoc + unified-diff requirements (`--- a/<path>`,
  `+++ b/<path>`, `@@ ... @@`, `/dev/null` for create/delete, multiple file
  patches stacked back-to-back inside one heredoc).
- Added guidance on when to prefer repo sessions vs.
  `package_get_git_remote` + `package_publish_external_push`, and a note
  steering one-file edits to non-package job source toward `job_update`.

`docs/use/`

- `repo-sessions.md`: new "When to use repo sessions vs. a local git remote"
  section and a `git apply` patch-format subsection.
- `packages.md`: clarifies that `job_update`'s `code` republishes the job
  module and that `kody:runtime` does not export `params`.
- `execute.md`: extends the `codemode.job_update` bullet with the same
  republish + params-from-first-argument note.

## Verifying `storage.sql` doc accuracy

Confirmed against
[`packages/worker/src/storage-runner.ts`](https://github.com/kentcdodds/kody/blob/docs-kody-job-repo-ergonomics/packages/worker/src/storage-runner.ts):
`StorageSqlResult` is exactly
`{ columns: string[]; rows: Array<Record<string, string | number | null>>;
rowCount: number; rowsRead: number; rowsWritten: number }`, and
`cursorToSqlResult` builds it from `cursor.toArray()` plus
`cursor.columnNames`/`cursor.rowsRead`/`cursor.rowsWritten`. The new
`docs/use/execute.md` block and the `execute` tool description's one-liner
both match that shape, so no further refinement was needed there.

## Tests

- Tool-description strings are interpolated, not snapshot-compared, so no
  test updates were required.
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run format` (re-applied) ✅
- Targeted vitest run for the affected capability tests
  (`job-schedule.node.test.ts`, `repo-workflow.node.test.ts`,
  `search-format.node.test.ts`): 33 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b282f2b1-3961-489c-8bc5-07dbcfdf2468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b282f2b1-3961-489c-8bc5-07dbcfdf2468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

