### PR TITLE
Multi-user isolation: lift signup gate, namespace per-user DOs, and add account deletion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,14 @@ Instructions for **agents and humans working in this repository** (building and
 maintaining Kody). End-user / MCP usage docs live under
 [`docs/use/`](./docs/use/index.md).
 
+Kody is a multi-user personal assistant: every signed-in user gets a
+fully isolated assistant (own packages, jobs, secrets, values,
+memories, chat threads, remote connectors, email inboxes, durable
+storage). When adding code, every read/write path must be scoped by
+`userId`, every Durable Object id that backs user-owned state must be
+namespaced by `userId`, and every search/vector path must filter by
+`userId`. Cross-user data sharing is a bug.
+
 Use Node 24 and npm for installs and scripts (`npm install`, `npm run ...`).
 
 ## Validation contract

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,12 @@ Instructions for **agents and humans working in this repository** (building and
 maintaining Kody). End-user / MCP usage docs live under
 [`docs/use/`](./docs/use/index.md).
 
-Kody is a multi-user personal assistant: every signed-in user gets a
-fully isolated assistant (own packages, jobs, secrets, values,
-memories, chat threads, remote connectors, email inboxes, durable
-storage). When adding code, every read/write path must be scoped by
-`userId`, every Durable Object id that backs user-owned state must be
-namespaced by `userId`, and every search/vector path must filter by
-`userId`. Cross-user data sharing is a bug.
+Kody is a multi-user personal assistant: every signed-in user gets a fully
+isolated assistant (own packages, jobs, secrets, values, memories, chat threads,
+remote connectors, email inboxes, durable storage). When adding code, every
+read/write path must be scoped by `userId`, every Durable Object id that backs
+user-owned state must be namespaced by `userId`, and every search/vector path
+must filter by `userId`. Cross-user data sharing is a bug.
 
 Use Node 24 and npm for installs and scripts (`npm install`, `npm run ...`).
 

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -45,14 +45,13 @@ request so cookie signing and verification are available to handlers.
 - Returns signed session cookie via `Set-Cookie` on success
 - Emits structured audit events through `packages/worker/src/app/audit-log.ts`
 
-### Signup gating
+### Signup posture
 
-Signup is open by default. Deployments can restrict who is allowed to create new
-accounts by setting the optional `ALLOWED_SIGNUP_EMAILS` environment variable to
-a comma-separated list of allowed signup emails. When the variable is set,
-requests with `mode: 'signup'` for emails outside the list are rejected with
-HTTP 403 and an `email_not_allowed` audit reason. The variable is consulted only
-on signup; existing users can always log in regardless of allowlist membership.
+Signup is open. The auth handler does not gate on email — anyone who can reach
+`POST /auth` with `mode: 'signup'` and a valid body can create an account. There
+is no application-level allowlist, invite flow, or privileged "primary user".
+Operators who want to restrict who can sign up should put the worker behind
+their own network-layer access control.
 
 ## Account deletion
 

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -1,10 +1,10 @@
 # Authentication
 
-`kody` is multi-user. Each signed-in user has a fully isolated assistant:
-their own packages, jobs, secrets, values, memories, chat threads,
-remote connectors, email inboxes, and durable storage. The auth layer
-is the boundary that establishes which user a request belongs to before
-any handler reads or writes data.
+`kody` is multi-user. Each signed-in user has a fully isolated assistant: their
+own packages, jobs, secrets, values, memories, chat threads, remote connectors,
+email inboxes, and durable storage. The auth layer is the boundary that
+establishes which user a request belongs to before any handler reads or writes
+data.
 
 `kody` uses two related authentication models:
 
@@ -47,38 +47,35 @@ request so cookie signing and verification are available to handlers.
 
 ### Signup gating
 
-Signup is open by default. Deployments can restrict who is allowed to
-create new accounts by setting the optional `ALLOWED_SIGNUP_EMAILS`
-environment variable to a comma-separated list of allowed signup
-emails. When the variable is set, requests with `mode: 'signup'` for
-emails outside the list are rejected with HTTP 403 and an
-`email_not_allowed` audit reason. The variable is consulted only on
-signup; existing users can always log in regardless of allowlist
-membership.
+Signup is open by default. Deployments can restrict who is allowed to create new
+accounts by setting the optional `ALLOWED_SIGNUP_EMAILS` environment variable to
+a comma-separated list of allowed signup emails. When the variable is set,
+requests with `mode: 'signup'` for emails outside the list are rejected with
+HTTP 403 and an `email_not_allowed` audit reason. The variable is consulted only
+on signup; existing users can always log in regardless of allowlist membership.
 
 ## Account deletion
 
 `POST /account/delete` is implemented by
-`packages/worker/src/app/handlers/account-delete.ts` and orchestrated
-by `packages/worker/src/app/account-deletion.ts`.
+`packages/worker/src/app/handlers/account-delete.ts` and orchestrated by
+`packages/worker/src/app/account-deletion.ts`.
 
-- Requires an active `kody_session` cookie and a JSON body with
-  `password` re-authenticating the current user; failures emit an
-  audit event with `action: 'account_delete'`, `result: 'failure'`.
+- Requires an active `kody_session` cookie and a JSON body with `password`
+  re-authenticating the current user; failures emit an audit event with
+  `action: 'account_delete'`, `result: 'failure'`.
 - On success, runs a full per-user cascade across:
   - all `user_id`-scoped D1 tables (children before parents),
   - the shared Vectorize capability index, removing memory, job and
     saved-package entries by id,
-  - `BUNDLE_ARTIFACTS_KV` keys captured from
-    `published_bundle_artifacts` and `archived_job_artifacts`,
+  - `BUNDLE_ARTIFACTS_KV` keys captured from `published_bundle_artifacts` and
+    `archived_job_artifacts`,
   - the user's `StorageRunner` Durable Objects via the user-scoped
     `storageRunnerRpc` stub,
   - all OAuth grants for the user via the bound OAuth provider,
   - the user row itself last so a partial failure can be retried.
-- Returns a structured `{ ok, deletedRowCounts, deletedKvKeys,
-  revokedOAuthGrants, clearedDurableObjects, deletedVectors,
-  warnings }` payload alongside a `Set-Cookie` that destroys the
-  session.
+- Returns a structured
+  `{ ok, deletedRowCounts, deletedKvKeys, revokedOAuthGrants, clearedDurableObjects, deletedVectors, warnings }`
+  payload alongside a `Set-Cookie` that destroys the session.
 
 Related handlers:
 

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -1,5 +1,11 @@
 # Authentication
 
+`kody` is multi-user. Each signed-in user has a fully isolated assistant:
+their own packages, jobs, secrets, values, memories, chat threads,
+remote connectors, email inboxes, and durable storage. The auth layer
+is the boundary that establishes which user a request belongs to before
+any handler reads or writes data.
+
 `kody` uses two related authentication models:
 
 1. Cookie-based app sessions for browser users
@@ -38,6 +44,41 @@ request so cookie signing and verification are available to handlers.
 - Hashes passwords with `@kody-internal/shared/password-hash.ts`
 - Returns signed session cookie via `Set-Cookie` on success
 - Emits structured audit events through `packages/worker/src/app/audit-log.ts`
+
+### Signup gating
+
+Signup is open by default. Deployments can restrict who is allowed to
+create new accounts by setting the optional `ALLOWED_SIGNUP_EMAILS`
+environment variable to a comma-separated list of allowed signup
+emails. When the variable is set, requests with `mode: 'signup'` for
+emails outside the list are rejected with HTTP 403 and an
+`email_not_allowed` audit reason. The variable is consulted only on
+signup; existing users can always log in regardless of allowlist
+membership.
+
+## Account deletion
+
+`POST /account/delete` is implemented by
+`packages/worker/src/app/handlers/account-delete.ts` and orchestrated
+by `packages/worker/src/app/account-deletion.ts`.
+
+- Requires an active `kody_session` cookie and a JSON body with
+  `password` re-authenticating the current user; failures emit an
+  audit event with `action: 'account_delete'`, `result: 'failure'`.
+- On success, runs a full per-user cascade across:
+  - all `user_id`-scoped D1 tables (children before parents),
+  - the shared Vectorize capability index, removing memory, job and
+    saved-package entries by id,
+  - `BUNDLE_ARTIFACTS_KV` keys captured from
+    `published_bundle_artifacts` and `archived_job_artifacts`,
+  - the user's `StorageRunner` Durable Objects via the user-scoped
+    `storageRunnerRpc` stub,
+  - all OAuth grants for the user via the bound OAuth provider,
+  - the user row itself last so a partial failure can be retried.
+- Returns a structured `{ ok, deletedRowCounts, deletedKvKeys,
+  revokedOAuthGrants, clearedDurableObjects, deletedVectors,
+  warnings }` payload alongside a `Set-Cookie` that destroys the
+  session.
 
 Related handlers:
 

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -2,6 +2,18 @@
 
 This project uses three Cloudflare storage systems for different purposes.
 
+## Per-user isolation invariant
+
+Kody is multi-user with strict per-user isolation. Every storage layer
+described below is scoped by `user_id` (D1 columns, Vectorize metadata,
+KV key prefixes, Durable Object names) and every read/write path takes
+a `userId` argument. Two users with the same logical identifier (for
+example the same `kind`/`instanceId` pair on a remote connector, or
+the same `sessionId` on an agent turn) land on different durable
+objects and different rows. Any new persistence layer added to the
+project must follow the same convention; user-scoped tests should
+exercise both the "happy" path and a cross-user denial path.
+
 ## D1 (`APP_DB`)
 
 Relational app data lives in D1.
@@ -45,6 +57,9 @@ MCP server runtime state is hosted via a Durable Object class (`MCP`) in
 
 - The Worker forwards authorized MCP requests to `MCP.serve(...).fetch`
 - Durable Objects provide a stateful execution model for MCP operations
+- The DO is keyed by the MCP SDK session id (per-connection); per-user
+  identity is supplied on every request via the OAuth token's `props`
+  (`McpCallerContext.user`) rather than baked into the DO id.
 
 ## Durable Objects (`JobManager` and `StorageRunner`)
 
@@ -64,6 +79,54 @@ Storage split:
 - `JobManager` SQLite: only alarm bookkeeping needed to wake the right user's
   due jobs
 - `StorageRunner` SQLite: isolated durable state addressed by `storageId`
+
+## Per-user Durable Object naming
+
+The Durable Objects whose state is intrinsically owned by one user are
+named so that two different users always resolve to two different
+object ids:
+
+- `JobManager` — `idFromName(userId)`
+  (`packages/worker/src/jobs/manager-client.ts`).
+- `StorageRunner` —
+  `idFromName(JSON.stringify([userId, storageId]))`
+  (`packages/worker/src/storage-runner.ts`).
+- `PackageRealtimeSession` and `PackageServiceInstance` — keyed by
+  `(userId, packageId, ...)` via the helpers in
+  `packages/worker/src/package-runtime/`.
+- `RemoteConnectorSession` — `userScopedConnectorSessionKey(userId,
+  kind, instanceId)`. Connectors must connect through the new
+  user-scoped ingress URL `/connectors/u/{userId}/{kind}/{instanceId}`;
+  the legacy non-user-scoped URL is rejected with HTTP 410. The DO
+  carries the ingress user id forward via headers + websocket
+  attachment and verifies the shared secret against that user's row
+  only.
+- `AgentTurnRunner` —
+  `idFromName(JSON.stringify([userId, sessionId]))`. The runner DO
+  also requires every request to carry an `X-Kody-User-Id` header,
+  persists `ownerUserId` on first contact, and rejects mismatched
+  callers with HTTP 403.
+
+The `MCP` and `ChatAgent` Durable Objects are addressed by request
+session/thread id rather than user id; ownership is enforced at the
+request boundary by validating the authenticated user against the
+`McpCallerContext` / `chat_threads` row before routing.
+
+## Per-user runtime context (no shared `globalThis`)
+
+Codemode `execute` calls and package-app worker entrypoints used to
+push the current request's runtime onto `globalThis.__kodyRuntime`
+with a try/finally save/restore. That is now an `AsyncLocalStorage`
+shared between the wrapper and the `kody:runtime` virtual module via
+`Symbol.for('kody.runtimeStorage')`. Two concurrent calls in the same
+isolate observe their own runtime view through the ALS rather than
+racing on a single mutable globalThis slot. See
+`packages/worker/src/package-runtime/module-graph.ts`,
+`packages/worker/src/mcp/run-codemode-registry.ts`, and
+`packages/worker/src/package-runtime/package-app.ts` for the wrapper
+implementations, and
+`packages/worker/src/package-runtime/runtime-isolation.node.test.ts`
+for the concurrent two-runtime test that pins this invariant.
 
 ## Configuration reference
 

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -94,10 +94,9 @@ that two different users always resolve to two different object ids:
 - `RemoteConnectorSession` —
   `userScopedConnectorSessionKey(userId, kind, instanceId)`. Connectors must
   connect through the new user-scoped ingress URL
-  `/connectors/u/{userId}/{kind}/{instanceId}`; the legacy non-user-scoped URL
-  is rejected with HTTP 410. The DO carries the ingress user id forward via
-  headers + websocket attachment and verifies the shared secret against that
-  user's row only.
+  `/connectors/u/{userId}/{kind}/{instanceId}`. The DO carries the ingress user
+  id forward via headers + websocket attachment and verifies the shared secret
+  against that user's row only.
 - `AgentTurnRunner` — `idFromName(JSON.stringify([userId, sessionId]))`. The
   runner DO also requires every request to carry an `X-Kody-User-Id` header,
   persists `ownerUserId` on first contact, and rejects mismatched callers with

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -4,15 +4,14 @@ This project uses three Cloudflare storage systems for different purposes.
 
 ## Per-user isolation invariant
 
-Kody is multi-user with strict per-user isolation. Every storage layer
-described below is scoped by `user_id` (D1 columns, Vectorize metadata,
-KV key prefixes, Durable Object names) and every read/write path takes
-a `userId` argument. Two users with the same logical identifier (for
-example the same `kind`/`instanceId` pair on a remote connector, or
-the same `sessionId` on an agent turn) land on different durable
-objects and different rows. Any new persistence layer added to the
-project must follow the same convention; user-scoped tests should
-exercise both the "happy" path and a cross-user denial path.
+Kody is multi-user with strict per-user isolation. Every storage layer described
+below is scoped by `user_id` (D1 columns, Vectorize metadata, KV key prefixes,
+Durable Object names) and every read/write path takes a `userId` argument. Two
+users with the same logical identifier (for example the same `kind`/`instanceId`
+pair on a remote connector, or the same `sessionId` on an agent turn) land on
+different durable objects and different rows. Any new persistence layer added to
+the project must follow the same convention; user-scoped tests should exercise
+both the "happy" path and a cross-user denial path.
 
 ## D1 (`APP_DB`)
 
@@ -57,8 +56,8 @@ MCP server runtime state is hosted via a Durable Object class (`MCP`) in
 
 - The Worker forwards authorized MCP requests to `MCP.serve(...).fetch`
 - Durable Objects provide a stateful execution model for MCP operations
-- The DO is keyed by the MCP SDK session id (per-connection); per-user
-  identity is supplied on every request via the OAuth token's `props`
+- The DO is keyed by the MCP SDK session id (per-connection); per-user identity
+  is supplied on every request via the OAuth token's `props`
   (`McpCallerContext.user`) rather than baked into the DO id.
 
 ## Durable Objects (`JobManager` and `StorageRunner`)
@@ -82,51 +81,47 @@ Storage split:
 
 ## Per-user Durable Object naming
 
-The Durable Objects whose state is intrinsically owned by one user are
-named so that two different users always resolve to two different
-object ids:
+The Durable Objects whose state is intrinsically owned by one user are named so
+that two different users always resolve to two different object ids:
 
 - `JobManager` — `idFromName(userId)`
   (`packages/worker/src/jobs/manager-client.ts`).
-- `StorageRunner` —
-  `idFromName(JSON.stringify([userId, storageId]))`
+- `StorageRunner` — `idFromName(JSON.stringify([userId, storageId]))`
   (`packages/worker/src/storage-runner.ts`).
 - `PackageRealtimeSession` and `PackageServiceInstance` — keyed by
   `(userId, packageId, ...)` via the helpers in
   `packages/worker/src/package-runtime/`.
-- `RemoteConnectorSession` — `userScopedConnectorSessionKey(userId,
-  kind, instanceId)`. Connectors must connect through the new
-  user-scoped ingress URL `/connectors/u/{userId}/{kind}/{instanceId}`;
-  the legacy non-user-scoped URL is rejected with HTTP 410. The DO
-  carries the ingress user id forward via headers + websocket
-  attachment and verifies the shared secret against that user's row
-  only.
-- `AgentTurnRunner` —
-  `idFromName(JSON.stringify([userId, sessionId]))`. The runner DO
-  also requires every request to carry an `X-Kody-User-Id` header,
-  persists `ownerUserId` on first contact, and rejects mismatched
-  callers with HTTP 403.
+- `RemoteConnectorSession` —
+  `userScopedConnectorSessionKey(userId, kind, instanceId)`. Connectors must
+  connect through the new user-scoped ingress URL
+  `/connectors/u/{userId}/{kind}/{instanceId}`; the legacy non-user-scoped URL
+  is rejected with HTTP 410. The DO carries the ingress user id forward via
+  headers + websocket attachment and verifies the shared secret against that
+  user's row only.
+- `AgentTurnRunner` — `idFromName(JSON.stringify([userId, sessionId]))`. The
+  runner DO also requires every request to carry an `X-Kody-User-Id` header,
+  persists `ownerUserId` on first contact, and rejects mismatched callers with
+  HTTP 403.
 
 The `MCP` and `ChatAgent` Durable Objects are addressed by request
-session/thread id rather than user id; ownership is enforced at the
-request boundary by validating the authenticated user against the
-`McpCallerContext` / `chat_threads` row before routing.
+session/thread id rather than user id; ownership is enforced at the request
+boundary by validating the authenticated user against the `McpCallerContext` /
+`chat_threads` row before routing.
 
 ## Per-user runtime context (no shared `globalThis`)
 
-Codemode `execute` calls and package-app worker entrypoints used to
-push the current request's runtime onto `globalThis.__kodyRuntime`
-with a try/finally save/restore. That is now an `AsyncLocalStorage`
-shared between the wrapper and the `kody:runtime` virtual module via
-`Symbol.for('kody.runtimeStorage')`. Two concurrent calls in the same
-isolate observe their own runtime view through the ALS rather than
-racing on a single mutable globalThis slot. See
+Codemode `execute` calls and package-app worker entrypoints used to push the
+current request's runtime onto `globalThis.__kodyRuntime` with a try/finally
+save/restore. That is now an `AsyncLocalStorage` shared between the wrapper and
+the `kody:runtime` virtual module via `Symbol.for('kody.runtimeStorage')`. Two
+concurrent calls in the same isolate observe their own runtime view through the
+ALS rather than racing on a single mutable globalThis slot. See
 `packages/worker/src/package-runtime/module-graph.ts`,
 `packages/worker/src/mcp/run-codemode-registry.ts`, and
 `packages/worker/src/package-runtime/package-app.ts` for the wrapper
 implementations, and
-`packages/worker/src/package-runtime/runtime-isolation.node.test.ts`
-for the concurrent two-runtime test that pins this invariant.
+`packages/worker/src/package-runtime/runtime-isolation.node.test.ts` for the
+concurrent two-runtime test that pins this invariant.
 
 ## Configuration reference
 

--- a/docs/contributing/project-intent.md
+++ b/docs/contributing/project-intent.md
@@ -32,9 +32,11 @@ shared state between users.
 
 - Optimization target: a high-quality personal assistant for each individual
   signed-in user, with hard isolation between users
-- Onboarding: signup is open by default; deployments may opt into a
-  per-deployment allowlist via the `ALLOWED_SIGNUP_EMAILS` env var
-  (comma-separated list of allowed signup emails)
+- Onboarding: signup is open. There is no email allowlist, no invite flow, and
+  no privileged account at runtime — any user who can reach the signup endpoint
+  can create an account. Operators who want to restrict who can sign up should
+  put the worker behind their own network-layer access control rather than
+  expecting the application to gate it.
 - Primary first-party user: `me@kentcdodds.com` (the maintainer's own account);
   tests, fixtures, and historical examples often reference this address but it
   is not a privileged account at runtime

--- a/docs/contributing/project-intent.md
+++ b/docs/contributing/project-intent.md
@@ -25,32 +25,32 @@ conflict with the guidance here, treat this document as the project's intent.
 
 ## Who this is for
 
-Kody is a multi-user personal assistant. Each authenticated user gets a
-strictly isolated assistant: their own packages, jobs, secrets, values,
-memories, chat threads, remote connectors, email inboxes, and durable
-storage. There is no shared state between users.
+Kody is a multi-user personal assistant. Each authenticated user gets a strictly
+isolated assistant: their own packages, jobs, secrets, values, memories, chat
+threads, remote connectors, email inboxes, and durable storage. There is no
+shared state between users.
 
-- Optimization target: a high-quality personal assistant for each
-  individual signed-in user, with hard isolation between users
+- Optimization target: a high-quality personal assistant for each individual
+  signed-in user, with hard isolation between users
 - Onboarding: signup is open by default; deployments may opt into a
   per-deployment allowlist via the `ALLOWED_SIGNUP_EMAILS` env var
   (comma-separated list of allowed signup emails)
-- Primary first-party user: `me@kentcdodds.com` (the maintainer's own
-  account); tests, fixtures, and historical examples often reference
-  this address but it is not a privileged account at runtime
+- Primary first-party user: `me@kentcdodds.com` (the maintainer's own account);
+  tests, fixtures, and historical examples often reference this address but it
+  is not a privileged account at runtime
 
 Optimize for:
 
-- Per-user isolation as a first-class invariant, enforced at the
-  storage, durable-object, vectorize, and runtime layers
+- Per-user isolation as a first-class invariant, enforced at the storage,
+  durable-object, vectorize, and runtime layers
 - Fast iteration on the personal-assistant experience
 - Interoperability across MCP-capable hosts
 
 It does not need to optimize for:
 
 - Per-organization tenancy or shared-team workspaces
-- Fine-grained permission delegation between many distinct humans
-  inside a single account
+- Fine-grained permission delegation between many distinct humans inside a
+  single account
 - Enterprise SSO / directory provisioning
 
 ## Product intent
@@ -75,10 +75,9 @@ When working in this repo, do not assume:
 - This project should evolve into a large catalog of explicitly declared MCP
   tools.
 - This project is trying to become a generic starter kit for others.
-- This is a single-user system. Per-user isolation is now an invariant,
-  not a future direction; treat any code path that reads or writes data
-  without a `userId` (or that shares a Durable Object id across users)
-  as a bug.
+- This is a single-user system. Per-user isolation is now an invariant, not a
+  future direction; treat any code path that reads or writes data without a
+  `userId` (or that shares a Durable Object id across users) as a bug.
 - The main goal is enterprise-grade least-privilege design for many users.
 
 Also do not document capabilities as if they already exist. Keep design notes
@@ -89,10 +88,10 @@ that exists in the repository.
 
 When updating docs or explaining architecture:
 
-- Describe the repo as a multi-user personal-assistant platform with
-  strict per-user isolation, not a shared workspace product.
-- Mention the per-user isolation invariant when it materially affects
-  product, auth, or storage decisions.
+- Describe the repo as a multi-user personal-assistant platform with strict
+  per-user isolation, not a shared workspace product.
+- Mention the per-user isolation invariant when it materially affects product,
+  auth, or storage decisions.
 - Keep present behavior separate from design notes and proposals.
 - Prefer focused docs over expanding `AGENTS.md`.
 
@@ -101,10 +100,9 @@ When updating docs or explaining architecture:
 If you are an agent working in this repo:
 
 - Read this file before making product-level decisions.
-- Per-user isolation is a hard invariant. Any new feature that touches
-  data must be scoped by `userId` at the data layer, by user-namespaced
-  Durable Object ids at the runtime layer, and by user-aware filters at
-  the search/vector layer.
+- Per-user isolation is a hard invariant. Any new feature that touches data must
+  be scoped by `userId` at the data layer, by user-namespaced Durable Object ids
+  at the runtime layer, and by user-aware filters at the search/vector layer.
 - Avoid proposing a large static MCP tool catalog as the default direction.
 - Keep interoperability with MCP hosts in mind, especially around compact tool
   surfaces and clear server instructions.

--- a/docs/contributing/project-intent.md
+++ b/docs/contributing/project-intent.md
@@ -25,25 +25,33 @@ conflict with the guidance here, treat this document as the project's intent.
 
 ## Who this is for
 
-This project is intentionally single-user.
+Kody is a multi-user personal assistant. Each authenticated user gets a
+strictly isolated assistant: their own packages, jobs, secrets, values,
+memories, chat threads, remote connectors, email inboxes, and durable
+storage. There is no shared state between users.
 
-- Primary user: `me@kentcdodds.com`
-- Product posture: personal assistant for Kent
-- Optimization target: useful behavior for one trusted user, not generic
-  multi-tenant safety or broad organizational administration
+- Optimization target: a high-quality personal assistant for each
+  individual signed-in user, with hard isolation between users
+- Onboarding: signup is open by default; deployments may opt into a
+  per-deployment allowlist via the `ALLOWED_SIGNUP_EMAILS` env var
+  (comma-separated list of allowed signup emails)
+- Primary first-party user: `me@kentcdodds.com` (the maintainer's own
+  account); tests, fixtures, and historical examples often reference
+  this address but it is not a privileged account at runtime
 
 Optimize for:
 
-- Fast iteration
-- Personal workflows and preferences
+- Per-user isolation as a first-class invariant, enforced at the
+  storage, durable-object, vectorize, and runtime layers
+- Fast iteration on the personal-assistant experience
 - Interoperability across MCP-capable hosts
 
 It does not need to optimize for:
 
-- Multi-user account models
-- Per-organization tenancy
+- Per-organization tenancy or shared-team workspaces
 - Fine-grained permission delegation between many distinct humans
-- Broad consumer onboarding flows
+  inside a single account
+- Enterprise SSO / directory provisioning
 
 ## Product intent
 
@@ -67,6 +75,10 @@ When working in this repo, do not assume:
 - This project should evolve into a large catalog of explicitly declared MCP
   tools.
 - This project is trying to become a generic starter kit for others.
+- This is a single-user system. Per-user isolation is now an invariant,
+  not a future direction; treat any code path that reads or writes data
+  without a `userId` (or that shares a Durable Object id across users)
+  as a bug.
 - The main goal is enterprise-grade least-privilege design for many users.
 
 Also do not document capabilities as if they already exist. Keep design notes
@@ -77,9 +89,10 @@ that exists in the repository.
 
 When updating docs or explaining architecture:
 
-- Describe the repo as an experiment and foundation for a personal assistant.
-- Mention the single-user assumption when it materially affects product or auth
-  decisions.
+- Describe the repo as a multi-user personal-assistant platform with
+  strict per-user isolation, not a shared workspace product.
+- Mention the per-user isolation invariant when it materially affects
+  product, auth, or storage decisions.
 - Keep present behavior separate from design notes and proposals.
 - Prefer focused docs over expanding `AGENTS.md`.
 
@@ -88,8 +101,10 @@ When updating docs or explaining architecture:
 If you are an agent working in this repo:
 
 - Read this file before making product-level decisions.
-- Avoid pushing the design toward multi-tenant abstractions unless explicitly
-  asked.
+- Per-user isolation is a hard invariant. Any new feature that touches
+  data must be scoped by `userId` at the data layer, by user-namespaced
+  Durable Object ids at the runtime layer, and by user-aware filters at
+  the search/vector layer.
 - Avoid proposing a large static MCP tool catalog as the default direction.
 - Keep interoperability with MCP hosts in mind, especially around compact tool
   surfaces and clear server instructions.

--- a/packages/worker/public/mcp-apps/kody-ui-utils.css
+++ b/packages/worker/public/mcp-apps/kody-ui-utils.css
@@ -1,176 +1,172 @@
 /* packages/worker/client/mcp-apps/kody-ui-utils.css */
 :root {
-  color-scheme: light dark;
-  --font-body:
-    ui-sans-serif,
-    system-ui,
-    sans-serif;
-  --font-mono:
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    monospace;
-  --spacing-1: 0.25rem;
-  --spacing-2: 0.5rem;
-  --spacing-3: 0.75rem;
-  --spacing-4: 1rem;
-  --spacing-6: 1.5rem;
-  --radius-2: 0.5rem;
-  --radius-3: 0.75rem;
-  --shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
-  --color-bg: #ffffff;
-  --color-surface: #f8fafc;
-  --color-fg: #0f172a;
-  --color-muted: #475569;
-  --color-border: #dbe2ea;
-  --color-accent: #2563eb;
-  --color-accent-contrast: #ffffff;
-  --color-code-bg: rgb(15 23 42 / 0.06);
+	color-scheme: light dark;
+	--font-body: ui-sans-serif, system-ui, sans-serif;
+	--font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	--spacing-1: 0.25rem;
+	--spacing-2: 0.5rem;
+	--spacing-3: 0.75rem;
+	--spacing-4: 1rem;
+	--spacing-6: 1.5rem;
+	--radius-2: 0.5rem;
+	--radius-3: 0.75rem;
+	--shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
+	--color-bg: #ffffff;
+	--color-surface: #f8fafc;
+	--color-fg: #0f172a;
+	--color-muted: #475569;
+	--color-border: #dbe2ea;
+	--color-accent: #2563eb;
+	--color-accent-contrast: #ffffff;
+	--color-code-bg: rgb(15 23 42 / 0.06);
 }
 @media (prefers-color-scheme: dark) {
-  :root {
-    --color-bg: #0f172a;
-    --color-surface: #162033;
-    --color-fg: #e5eef8;
-    --color-muted: #a5b4c7;
-    --color-border: #2a3950;
-    --color-accent: #60a5fa;
-    --color-accent-contrast: #0f172a;
-    --color-code-bg: rgb(148 163 184 / 0.16);
-  }
+	:root {
+		--color-bg: #0f172a;
+		--color-surface: #162033;
+		--color-fg: #e5eef8;
+		--color-muted: #a5b4c7;
+		--color-border: #2a3950;
+		--color-accent: #60a5fa;
+		--color-accent-contrast: #0f172a;
+		--color-code-bg: rgb(148 163 184 / 0.16);
+	}
 }
 :where(html) {
-  min-height: 100%;
-  background: var(--color-bg);
-  color: var(--color-fg);
+	min-height: 100%;
+	background: var(--color-bg);
+	color: var(--color-fg);
 }
 :where(body) {
-  min-height: 100%;
-  margin: 0;
-  padding: var(--spacing-4);
-  background: var(--color-bg);
-  color: var(--color-fg);
-  font: 400 14px/1.5 var(--font-body);
+	min-height: 100%;
+	margin: 0;
+	padding: var(--spacing-4);
+	background: var(--color-bg);
+	color: var(--color-fg);
+	font: 400 14px/1.5 var(--font-body);
 }
-:where(body[data-kody-runtime=javascript]) {
-  padding: 0;
+:where(body[data-kody-runtime='javascript']) {
+	padding: 0;
 }
 :where(*, *::before, *::after) {
-  box-sizing: border-box;
+	box-sizing: border-box;
 }
 :where(a) {
-  color: var(--color-accent);
+	color: var(--color-accent);
 }
 :where(p, ul, ol, dl, pre, table, blockquote, fieldset) {
-  margin: 0 0 var(--spacing-4);
+	margin: 0 0 var(--spacing-4);
 }
 :where(h1, h2, h3, h4, h5, h6) {
-  margin: 0 0 var(--spacing-3);
-  line-height: 1.2;
+	margin: 0 0 var(--spacing-3);
+	line-height: 1.2;
 }
 :where(h1) {
-  font-size: 1.875rem;
+	font-size: 1.875rem;
 }
 :where(h2) {
-  font-size: 1.5rem;
+	font-size: 1.5rem;
 }
 :where(h3) {
-  font-size: 1.25rem;
+	font-size: 1.25rem;
 }
 :where(ul, ol) {
-  padding-left: 1.5rem;
+	padding-left: 1.5rem;
 }
 :where(hr) {
-  border: 0;
-  border-top: 1px solid var(--color-border);
-  margin: var(--spacing-6) 0;
+	border: 0;
+	border-top: 1px solid var(--color-border);
+	margin: var(--spacing-6) 0;
 }
 :where(code, kbd, samp) {
-  font-family: var(--font-mono);
-  font-size: 0.95em;
+	font-family: var(--font-mono);
+	font-size: 0.95em;
 }
 :where(code) {
-  background: var(--color-code-bg);
-  border-radius: 0.375rem;
-  padding: 0.1rem 0.35rem;
+	background: var(--color-code-bg);
+	border-radius: 0.375rem;
+	padding: 0.1rem 0.35rem;
 }
 :where(pre) {
-  overflow-x: auto;
-  padding: var(--spacing-3);
-  background: var(--color-code-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-2);
+	overflow-x: auto;
+	padding: var(--spacing-3);
+	background: var(--color-code-bg);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-2);
 }
 :where(pre code) {
-  background: transparent;
-  padding: 0;
+	background: transparent;
+	padding: 0;
 }
 :where(form) {
-  display: grid;
-  gap: var(--spacing-4);
+	display: grid;
+	gap: var(--spacing-4);
 }
 :where(label) {
-  display: grid;
-  gap: var(--spacing-2);
-  font-weight: 600;
+	display: grid;
+	gap: var(--spacing-2);
+	font-weight: 600;
 }
 :where(input, button, textarea, select) {
-  font: inherit;
+	font: inherit;
 }
-:where(input:not([type=checkbox]):not([type=radio]), textarea, select) {
-  width: 100%;
-  padding: var(--spacing-2) var(--spacing-3);
-  background: var(--color-surface);
-  color: var(--color-fg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-2);
-  box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
+:where(input:not([type='checkbox']):not([type='radio']), textarea, select) {
+	width: 100%;
+	padding: var(--spacing-2) var(--spacing-3);
+	background: var(--color-surface);
+	color: var(--color-fg);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-2);
+	box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
 }
 :where(textarea) {
-  min-height: 7rem;
-  resize: vertical;
+	min-height: 7rem;
+	resize: vertical;
 }
-:where(input[type=checkbox], input[type=radio]) {
-  accent-color: var(--color-accent);
+:where(input[type='checkbox'], input[type='radio']) {
+	accent-color: var(--color-accent);
 }
 :where(button) {
-  width: fit-content;
-  padding: var(--spacing-2) var(--spacing-4);
-  background: var(--color-accent);
-  color: var(--color-accent-contrast);
-  border: 1px solid transparent;
-  border-radius: var(--radius-2);
-  box-shadow: var(--shadow-1);
-  cursor: pointer;
+	width: fit-content;
+	padding: var(--spacing-2) var(--spacing-4);
+	background: var(--color-accent);
+	color: var(--color-accent-contrast);
+	border: 1px solid transparent;
+	border-radius: var(--radius-2);
+	box-shadow: var(--shadow-1);
+	cursor: pointer;
 }
 :where(button:disabled, input:disabled, textarea:disabled, select:disabled) {
-  opacity: 0.7;
-  cursor: not-allowed;
+	opacity: 0.7;
+	cursor: not-allowed;
 }
-:where(button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible) {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
+:where(
+	button:focus-visible,
+	input:focus-visible,
+	textarea:focus-visible,
+	select:focus-visible
+) {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
 }
 :where(table) {
-  width: 100%;
-  border-collapse: collapse;
+	width: 100%;
+	border-collapse: collapse;
 }
 :where(th, td) {
-  padding: var(--spacing-2) var(--spacing-3);
-  border: 1px solid var(--color-border);
-  text-align: left;
+	padding: var(--spacing-2) var(--spacing-3);
+	border: 1px solid var(--color-border);
+	text-align: left;
 }
 :where(th) {
-  background: var(--color-surface);
+	background: var(--color-surface);
 }
 :where(blockquote) {
-  margin-left: 0;
-  padding-left: var(--spacing-4);
-  border-left: 3px solid var(--color-border);
-  color: var(--color-muted);
+	margin-left: 0;
+	padding-left: var(--spacing-4);
+	border-left: 3px solid var(--color-border);
+	color: var(--color-muted);
 }
 :where([data-generated-ui-root]) {
-  min-height: 100%;
+	min-height: 100%;
 }

--- a/packages/worker/public/mcp-apps/kody-ui-utils.css
+++ b/packages/worker/public/mcp-apps/kody-ui-utils.css
@@ -1,172 +1,176 @@
 /* packages/worker/client/mcp-apps/kody-ui-utils.css */
 :root {
-	color-scheme: light dark;
-	--font-body: ui-sans-serif, system-ui, sans-serif;
-	--font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-	--spacing-1: 0.25rem;
-	--spacing-2: 0.5rem;
-	--spacing-3: 0.75rem;
-	--spacing-4: 1rem;
-	--spacing-6: 1.5rem;
-	--radius-2: 0.5rem;
-	--radius-3: 0.75rem;
-	--shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
-	--color-bg: #ffffff;
-	--color-surface: #f8fafc;
-	--color-fg: #0f172a;
-	--color-muted: #475569;
-	--color-border: #dbe2ea;
-	--color-accent: #2563eb;
-	--color-accent-contrast: #ffffff;
-	--color-code-bg: rgb(15 23 42 / 0.06);
+  color-scheme: light dark;
+  --font-body:
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+  --font-mono:
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace;
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-6: 1.5rem;
+  --radius-2: 0.5rem;
+  --radius-3: 0.75rem;
+  --shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
+  --color-bg: #ffffff;
+  --color-surface: #f8fafc;
+  --color-fg: #0f172a;
+  --color-muted: #475569;
+  --color-border: #dbe2ea;
+  --color-accent: #2563eb;
+  --color-accent-contrast: #ffffff;
+  --color-code-bg: rgb(15 23 42 / 0.06);
 }
 @media (prefers-color-scheme: dark) {
-	:root {
-		--color-bg: #0f172a;
-		--color-surface: #162033;
-		--color-fg: #e5eef8;
-		--color-muted: #a5b4c7;
-		--color-border: #2a3950;
-		--color-accent: #60a5fa;
-		--color-accent-contrast: #0f172a;
-		--color-code-bg: rgb(148 163 184 / 0.16);
-	}
+  :root {
+    --color-bg: #0f172a;
+    --color-surface: #162033;
+    --color-fg: #e5eef8;
+    --color-muted: #a5b4c7;
+    --color-border: #2a3950;
+    --color-accent: #60a5fa;
+    --color-accent-contrast: #0f172a;
+    --color-code-bg: rgb(148 163 184 / 0.16);
+  }
 }
 :where(html) {
-	min-height: 100%;
-	background: var(--color-bg);
-	color: var(--color-fg);
+  min-height: 100%;
+  background: var(--color-bg);
+  color: var(--color-fg);
 }
 :where(body) {
-	min-height: 100%;
-	margin: 0;
-	padding: var(--spacing-4);
-	background: var(--color-bg);
-	color: var(--color-fg);
-	font: 400 14px/1.5 var(--font-body);
+  min-height: 100%;
+  margin: 0;
+  padding: var(--spacing-4);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font: 400 14px/1.5 var(--font-body);
 }
-:where(body[data-kody-runtime='javascript']) {
-	padding: 0;
+:where(body[data-kody-runtime=javascript]) {
+  padding: 0;
 }
 :where(*, *::before, *::after) {
-	box-sizing: border-box;
+  box-sizing: border-box;
 }
 :where(a) {
-	color: var(--color-accent);
+  color: var(--color-accent);
 }
 :where(p, ul, ol, dl, pre, table, blockquote, fieldset) {
-	margin: 0 0 var(--spacing-4);
+  margin: 0 0 var(--spacing-4);
 }
 :where(h1, h2, h3, h4, h5, h6) {
-	margin: 0 0 var(--spacing-3);
-	line-height: 1.2;
+  margin: 0 0 var(--spacing-3);
+  line-height: 1.2;
 }
 :where(h1) {
-	font-size: 1.875rem;
+  font-size: 1.875rem;
 }
 :where(h2) {
-	font-size: 1.5rem;
+  font-size: 1.5rem;
 }
 :where(h3) {
-	font-size: 1.25rem;
+  font-size: 1.25rem;
 }
 :where(ul, ol) {
-	padding-left: 1.5rem;
+  padding-left: 1.5rem;
 }
 :where(hr) {
-	border: 0;
-	border-top: 1px solid var(--color-border);
-	margin: var(--spacing-6) 0;
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  margin: var(--spacing-6) 0;
 }
 :where(code, kbd, samp) {
-	font-family: var(--font-mono);
-	font-size: 0.95em;
+  font-family: var(--font-mono);
+  font-size: 0.95em;
 }
 :where(code) {
-	background: var(--color-code-bg);
-	border-radius: 0.375rem;
-	padding: 0.1rem 0.35rem;
+  background: var(--color-code-bg);
+  border-radius: 0.375rem;
+  padding: 0.1rem 0.35rem;
 }
 :where(pre) {
-	overflow-x: auto;
-	padding: var(--spacing-3);
-	background: var(--color-code-bg);
-	border: 1px solid var(--color-border);
-	border-radius: var(--radius-2);
+  overflow-x: auto;
+  padding: var(--spacing-3);
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
 }
 :where(pre code) {
-	background: transparent;
-	padding: 0;
+  background: transparent;
+  padding: 0;
 }
 :where(form) {
-	display: grid;
-	gap: var(--spacing-4);
+  display: grid;
+  gap: var(--spacing-4);
 }
 :where(label) {
-	display: grid;
-	gap: var(--spacing-2);
-	font-weight: 600;
+  display: grid;
+  gap: var(--spacing-2);
+  font-weight: 600;
 }
 :where(input, button, textarea, select) {
-	font: inherit;
+  font: inherit;
 }
-:where(input:not([type='checkbox']):not([type='radio']), textarea, select) {
-	width: 100%;
-	padding: var(--spacing-2) var(--spacing-3);
-	background: var(--color-surface);
-	color: var(--color-fg);
-	border: 1px solid var(--color-border);
-	border-radius: var(--radius-2);
-	box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
+:where(input:not([type=checkbox]):not([type=radio]), textarea, select) {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--color-surface);
+  color: var(--color-fg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+  box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
 }
 :where(textarea) {
-	min-height: 7rem;
-	resize: vertical;
+  min-height: 7rem;
+  resize: vertical;
 }
-:where(input[type='checkbox'], input[type='radio']) {
-	accent-color: var(--color-accent);
+:where(input[type=checkbox], input[type=radio]) {
+  accent-color: var(--color-accent);
 }
 :where(button) {
-	width: fit-content;
-	padding: var(--spacing-2) var(--spacing-4);
-	background: var(--color-accent);
-	color: var(--color-accent-contrast);
-	border: 1px solid transparent;
-	border-radius: var(--radius-2);
-	box-shadow: var(--shadow-1);
-	cursor: pointer;
+  width: fit-content;
+  padding: var(--spacing-2) var(--spacing-4);
+  background: var(--color-accent);
+  color: var(--color-accent-contrast);
+  border: 1px solid transparent;
+  border-radius: var(--radius-2);
+  box-shadow: var(--shadow-1);
+  cursor: pointer;
 }
 :where(button:disabled, input:disabled, textarea:disabled, select:disabled) {
-	opacity: 0.7;
-	cursor: not-allowed;
+  opacity: 0.7;
+  cursor: not-allowed;
 }
-:where(
-	button:focus-visible,
-	input:focus-visible,
-	textarea:focus-visible,
-	select:focus-visible
-) {
-	outline: 2px solid var(--color-accent);
-	outline-offset: 2px;
+:where(button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible) {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 :where(table) {
-	width: 100%;
-	border-collapse: collapse;
+  width: 100%;
+  border-collapse: collapse;
 }
 :where(th, td) {
-	padding: var(--spacing-2) var(--spacing-3);
-	border: 1px solid var(--color-border);
-	text-align: left;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--color-border);
+  text-align: left;
 }
 :where(th) {
-	background: var(--color-surface);
+  background: var(--color-surface);
 }
 :where(blockquote) {
-	margin-left: 0;
-	padding-left: var(--spacing-4);
-	border-left: 3px solid var(--color-border);
-	color: var(--color-muted);
+  margin-left: 0;
+  padding-left: var(--spacing-4);
+  border-left: 3px solid var(--color-border);
+  color: var(--color-muted);
 }
 :where([data-generated-ui-root]) {
-	min-height: 100%;
+  min-height: 100%;
 }

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -29,7 +29,10 @@ function createTestDb(initial: RowMap): {
 		return removed
 	}
 
-	function selectIds(table: string, where: (row: Record<string, unknown>) => boolean) {
+	function selectIds(
+		table: string,
+		where: (row: Record<string, unknown>) => boolean,
+	) {
 		return (rows[table] ?? []).filter(where).map((row) => row['id'])
 	}
 
@@ -43,9 +46,7 @@ function createTestDb(initial: RowMap): {
 						async all<T>() {
 							let results: Array<unknown> = []
 							const userId = params[0] as string
-							const m = lower.match(
-								/^select id from (\w+) where user_id = \?/,
-							)
+							const m = lower.match(/^select id from (\w+) where user_id = \?/)
 							if (m) {
 								const table = m[1] as string
 								results = (rows[table] ?? [])
@@ -61,8 +62,7 @@ function createTestDb(initial: RowMap): {
 								results = (rows[table] ?? [])
 									.filter(
 										(row) =>
-											row['user_id'] === userId &&
-											row['storage_id'] != null,
+											row['user_id'] === userId && row['storage_id'] != null,
 									)
 									.map((row) => ({ storage_id: row['storage_id'] }))
 								return { results: results as Array<T>, meta: { changes: 0 } }
@@ -105,9 +105,8 @@ function createTestDb(initial: RowMap): {
 								const parentIds = new Set(
 									selectIds(parentTable, (row) => row['user_id'] === userId),
 								)
-								const removed = deleteByPredicate(
-									childTable,
-									(row) => parentIds.has(row['bucket_id']),
+								const removed = deleteByPredicate(childTable, (row) =>
+									parentIds.has(row['bucket_id']),
 								)
 								return { meta: { changes: removed } }
 							}
@@ -121,15 +120,12 @@ function createTestDb(initial: RowMap): {
 										(row) => row['user_id'] === userId,
 									),
 								)
-								const removed = deleteByPredicate(
-									'email_attachments',
-									(row) => messageIds.has(row['message_id']),
+								const removed = deleteByPredicate('email_attachments', (row) =>
+									messageIds.has(row['message_id']),
 								)
 								return { meta: { changes: removed } }
 							}
-							const usersMatch = lower.match(
-								/^delete from users where id = \?/,
-							)
+							const usersMatch = lower.match(/^delete from users where id = \?/)
 							if (usersMatch) {
 								const removed = deleteByPredicate(
 									'users',
@@ -297,7 +293,9 @@ test('deleteUserAccount revokes OAuth grants when an OAuth provider is bound', a
 			}
 		},
 		revokeGrant,
-	} as unknown as Parameters<typeof deleteUserAccount>[0]['env']['OAUTH_PROVIDER']
+	} as unknown as Parameters<
+		typeof deleteUserAccount
+	>[0]['env']['OAUTH_PROVIDER']
 
 	const env = {
 		APP_DB: db,

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -323,6 +323,49 @@ test('deleteUserAccount revokes OAuth grants when an OAuth provider is bound', a
 	expect(result.revokedOAuthGrants).toBe(2)
 })
 
+test('deleteUserAccount records a warning when listUserGrants throws and continues the cascade', async () => {
+	const { db, rows } = createTestDb({
+		users: [{ id: 1, email: 'a@example.com' }],
+		jobs: [{ id: 'job-1', user_id: 'user-aaa', storage_id: null }],
+	})
+
+	const helpers = {
+		async listUserGrants() {
+			throw new Error('OAuth provider is temporarily unavailable')
+		},
+		revokeGrant: vi.fn(async () => undefined),
+	} as unknown as Parameters<
+		typeof deleteUserAccount
+	>[0]['env']['OAUTH_PROVIDER']
+
+	const env = {
+		APP_DB: db,
+		OAUTH_PROVIDER: helpers,
+		STORAGE_RUNNER: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ clearStorage: async () => ({ ok: true as const }) }),
+		},
+	} as unknown as Parameters<typeof deleteUserAccount>[0]['env']
+
+	const result = await deleteUserAccount({
+		env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+	})
+
+	// The cascade still ran the D1 deletes even though OAuth listing
+	// blew up: the user's job rows are gone and the user row itself was
+	// deleted.
+	expect(rows.jobs).toEqual([])
+	expect(rows.users).toEqual([])
+	expect(result.revokedOAuthGrants).toBe(0)
+	const oauthWarning = result.warnings.find((warning) =>
+		warning.includes('OAuth grant listing failed'),
+	)
+	expect(oauthWarning).toBeDefined()
+	expect(oauthWarning).toContain('OAuth provider is temporarily unavailable')
+})
+
 test('deleteUserAccount surfaces a warning when BUNDLE_ARTIFACTS_KV is unavailable', async () => {
 	const { db, rows } = createTestDb({
 		users: [{ id: 1, email: 'a@example.com' }],

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -322,3 +322,43 @@ test('deleteUserAccount revokes OAuth grants when an OAuth provider is bound', a
 	expect(revokeGrant).toHaveBeenNthCalledWith(2, 'grant-2', 'user-aaa')
 	expect(result.revokedOAuthGrants).toBe(2)
 })
+
+test('deleteUserAccount surfaces a warning when BUNDLE_ARTIFACTS_KV is unavailable', async () => {
+	const { db, rows } = createTestDb({
+		users: [{ id: 1, email: 'a@example.com' }],
+		published_bundle_artifacts: [
+			{ id: 'pba-1', user_id: 'user-aaa', kv_key: 'bundle-artifact:v1:src-1' },
+		],
+		archived_job_artifacts: [
+			{ id: 'aja-1', user_id: 'user-aaa', kv_key: 'archived:src-1' },
+		],
+	})
+
+	const env = {
+		APP_DB: db,
+		// BUNDLE_ARTIFACTS_KV intentionally unbound to exercise the warning path.
+		STORAGE_RUNNER: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ clearStorage: async () => ({ ok: true as const }) }),
+		},
+	} as unknown as Parameters<typeof deleteUserAccount>[0]['env']
+
+	const result = await deleteUserAccount({
+		env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+	})
+
+	// D1 rows were deleted as usual; KV deletes were skipped because the
+	// binding is missing.
+	expect(rows.published_bundle_artifacts).toEqual([])
+	expect(rows.archived_job_artifacts).toEqual([])
+	expect(result.deletedKvKeys).toBe(0)
+	// The warning surfaces both the count and the operator-visible
+	// guidance to clean up the KV namespace manually.
+	const kvWarning = result.warnings.find((warning) =>
+		warning.includes('BUNDLE_ARTIFACTS_KV'),
+	)
+	expect(kvWarning).toBeDefined()
+	expect(kvWarning).toContain('2 bundle artifact key(s)')
+})

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -185,7 +185,11 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		entity_sources: [{ id: 'es-1', user_id: userAaa }],
 		repo_sessions: [{ id: 'rs-1', user_id: userAaa }],
 		chat_threads: [{ id: 't-1', user_id: userAaa }],
-		password_resets: [{ id: 1, user_id: 1 }],
+		password_resets: [
+			{ id: 1, user_id: 1 },
+			{ id: 2, user_id: 1 },
+			{ id: 3, user_id: 2 },
+		],
 		mcp_user_server_instructions: [{ user_id: userAaa }],
 		package_invocation_tokens: [{ id: 'pit-1', user_id: userAaa }],
 		package_invocations: [{ id: 'pi-1', user_id: userAaa }],
@@ -219,10 +223,9 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		},
 	} as unknown as Env
 
-	// Note: password_resets cascade key is the integer users.id, not mcp user id;
-	// we still expect the row to remain because password_resets.user_id references
-	// users.id, not the mcp user id. The deletion service is responsible for the
-	// mcp-user-scoped tables; the user row is the integer id deletion below.
+	// password_resets.user_id is the database integer id; the deletion
+	// service must use the dbUserId (1) to clear the deleted user's reset
+	// tokens while leaving the other user's tokens in place.
 	const result = await deleteUserAccount({
 		env: env as Env & { OAUTH_PROVIDER: undefined },
 		dbUserId: 1,
@@ -241,6 +244,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(rows.published_bundle_artifacts).toEqual([
 		{ id: 'pba-2', user_id: userBbb, kv_key: 'bundle-artifact:v1:src-2' },
 	])
+	expect(rows.password_resets).toEqual([{ id: 3, user_id: 2 }])
 
 	// User-scoped data is removed.
 	expect(rows.mcp_skills).toEqual([])
@@ -256,6 +260,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(rows.email_attachments).toEqual([])
 	expect(rows.email_messages).toEqual([])
 	expect(rows.users).toEqual([{ id: 2, email: 'b@example.com' }])
+	expect(result.deletedRowCounts.password_resets).toBe(2)
 
 	// Storage runners for the deleted user's storage_ids were cleared.
 	expect(clearStorageMock).toHaveBeenCalledTimes(1)

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -1,0 +1,321 @@
+import { expect, test, vi } from 'vitest'
+import { deleteUserAccount } from './account-deletion.ts'
+
+type RowMap = Record<string, Array<Record<string, unknown>>>
+
+function createTestDb(initial: RowMap): {
+	db: D1Database
+	rows: RowMap
+} {
+	const rows: RowMap = {}
+	for (const [key, value] of Object.entries(initial)) {
+		rows[key] = value.map((row) => ({ ...row }))
+	}
+
+	function deleteByPredicate(
+		table: string,
+		predicate: (row: Record<string, unknown>) => boolean,
+	) {
+		const remaining: Array<Record<string, unknown>> = []
+		let removed = 0
+		for (const row of rows[table] ?? []) {
+			if (predicate(row)) {
+				removed += 1
+				continue
+			}
+			remaining.push(row)
+		}
+		rows[table] = remaining
+		return removed
+	}
+
+	function selectIds(table: string, where: (row: Record<string, unknown>) => boolean) {
+		return (rows[table] ?? []).filter(where).map((row) => row['id'])
+	}
+
+	const db = {
+		prepare(query: string) {
+			const trimmed = query.replace(/\s+/g, ' ').trim()
+			const lower = trimmed.toLowerCase()
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async all<T>() {
+							let results: Array<unknown> = []
+							const userId = params[0] as string
+							const m = lower.match(
+								/^select id from (\w+) where user_id = \?/,
+							)
+							if (m) {
+								const table = m[1] as string
+								results = (rows[table] ?? [])
+									.filter((row) => row['user_id'] === userId)
+									.map((row) => ({ id: row['id'] }))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							const storageMatch = lower.match(
+								/^select storage_id from (\w+) where user_id = \? and storage_id is not null/,
+							)
+							if (storageMatch) {
+								const table = storageMatch[1] as string
+								results = (rows[table] ?? [])
+									.filter(
+										(row) =>
+											row['user_id'] === userId &&
+											row['storage_id'] != null,
+									)
+									.map((row) => ({ storage_id: row['storage_id'] }))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							const kvMatch = lower.match(
+								/^select kv_key from (\w+) where user_id = \?/,
+							)
+							if (kvMatch) {
+								const table = kvMatch[1] as string
+								results = (rows[table] ?? [])
+									.filter((row) => row['user_id'] === userId)
+									.map((row) => ({ kv_key: row['kv_key'] }))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							return { results: [] as Array<T>, meta: { changes: 0 } }
+						},
+						async first<T>() {
+							const result = await this.all<T>()
+							return (result.results[0] ?? null) as T | null
+						},
+						async run() {
+							const userId = params[0] as string | number
+							const userIdMatch = lower.match(
+								/^delete from (\w+) where user_id = \?/,
+							)
+							if (userIdMatch) {
+								const table = userIdMatch[1] as string
+								const removed = deleteByPredicate(
+									table,
+									(row) => row['user_id'] === userId,
+								)
+								return { meta: { changes: removed } }
+							}
+							const bucketParentMatch = lower.match(
+								/^delete from (\w+) where bucket_id in \( select id from (\w+) where user_id = \? \)/,
+							)
+							if (bucketParentMatch) {
+								const childTable = bucketParentMatch[1] as string
+								const parentTable = bucketParentMatch[2] as string
+								const parentIds = new Set(
+									selectIds(parentTable, (row) => row['user_id'] === userId),
+								)
+								const removed = deleteByPredicate(
+									childTable,
+									(row) => parentIds.has(row['bucket_id']),
+								)
+								return { meta: { changes: removed } }
+							}
+							const attachmentMatch = lower.match(
+								/^delete from email_attachments where message_id in \( select id from email_messages where user_id = \? \)/,
+							)
+							if (attachmentMatch) {
+								const messageIds = new Set(
+									selectIds(
+										'email_messages',
+										(row) => row['user_id'] === userId,
+									),
+								)
+								const removed = deleteByPredicate(
+									'email_attachments',
+									(row) => messageIds.has(row['message_id']),
+								)
+								return { meta: { changes: removed } }
+							}
+							const usersMatch = lower.match(
+								/^delete from users where id = \?/,
+							)
+							if (usersMatch) {
+								const removed = deleteByPredicate(
+									'users',
+									(row) => row['id'] === userId,
+								)
+								return { meta: { changes: removed } }
+							}
+							return { meta: { changes: 0 } }
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+
+	return { db, rows }
+}
+
+test('deleteUserAccount cascades user-scoped rows for the requested user', async () => {
+	const userAaa = 'user-aaa'
+	const userBbb = 'user-bbb'
+	const { db, rows } = createTestDb({
+		users: [
+			{ id: 1, email: 'a@example.com' },
+			{ id: 2, email: 'b@example.com' },
+		],
+		jobs: [
+			{ id: 'job-1', user_id: userAaa, storage_id: 'job:job-1' },
+			{ id: 'job-2', user_id: userAaa, storage_id: null },
+			{ id: 'job-3', user_id: userBbb, storage_id: 'job:job-3' },
+		],
+		mcp_memories: [
+			{ id: 'mem-1', user_id: userAaa },
+			{ id: 'mem-2', user_id: userBbb },
+		],
+		mcp_skills: [{ id: 'sk-1', user_id: userAaa }],
+		ui_artifacts: [{ id: 'ui-1', user_id: userAaa }],
+		secret_buckets: [{ id: 'sb-1', user_id: userAaa }],
+		secret_entries: [{ bucket_id: 'sb-1', name: 's', user_id: 'unused' }],
+		value_buckets: [{ id: 'vb-1', user_id: userAaa }],
+		value_entries: [{ bucket_id: 'vb-1', name: 'v', user_id: 'unused' }],
+		remote_connector_settings: [
+			{ id: 'rc-1', user_id: userAaa },
+			{ id: 'rc-2', user_id: userBbb },
+		],
+		saved_packages: [
+			{ id: 'pkg-1', user_id: userAaa },
+			{ id: 'pkg-2', user_id: userBbb },
+		],
+		published_bundle_artifacts: [
+			{ id: 'pba-1', user_id: userAaa, kv_key: 'bundle-artifact:v1:src-1' },
+			{ id: 'pba-2', user_id: userBbb, kv_key: 'bundle-artifact:v1:src-2' },
+		],
+		archived_job_artifacts: [
+			{ id: 'aja-1', user_id: userAaa, kv_key: 'archived:src-1' },
+		],
+		entity_sources: [{ id: 'es-1', user_id: userAaa }],
+		repo_sessions: [{ id: 'rs-1', user_id: userAaa }],
+		chat_threads: [{ id: 't-1', user_id: userAaa }],
+		password_resets: [{ id: 1, user_id: 1 }],
+		mcp_user_server_instructions: [{ user_id: userAaa }],
+		package_invocation_tokens: [{ id: 'pit-1', user_id: userAaa }],
+		package_invocations: [{ id: 'pi-1', user_id: userAaa }],
+		workflow_runs: [{ id: 'wr-1', user_id: userAaa }],
+		mcp_memory_conversation_suppressions: [
+			{ user_id: userAaa, conversation_id: 'c1', memory_id: 'mem-1' },
+		],
+		email_inboxes: [{ id: 'in-1', user_id: userAaa }],
+		email_inbox_addresses: [{ id: 'ia-1', user_id: userAaa }],
+		email_threads: [{ id: 'et-1', user_id: userAaa }],
+		email_messages: [{ id: 'em-1', user_id: userAaa }],
+		email_attachments: [{ id: 'ea-1', message_id: 'em-1' }],
+		email_delivery_events: [{ id: 'ed-1', user_id: userAaa }],
+		email_sender_identities: [{ id: 'ei-1', user_id: userAaa }],
+	})
+
+	const deletedKvKeys: Array<string> = []
+	const kv = {
+		async delete(key: string) {
+			deletedKvKeys.push(key)
+		},
+	} as unknown as KVNamespace
+
+	const clearStorageMock = vi.fn(async () => ({ ok: true as const }))
+	const env = {
+		APP_DB: db,
+		BUNDLE_ARTIFACTS_KV: kv,
+		STORAGE_RUNNER: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ clearStorage: clearStorageMock }),
+		},
+	} as unknown as Env
+
+	// Note: password_resets cascade key is the integer users.id, not mcp user id;
+	// we still expect the row to remain because password_resets.user_id references
+	// users.id, not the mcp user id. The deletion service is responsible for the
+	// mcp-user-scoped tables; the user row is the integer id deletion below.
+	const result = await deleteUserAccount({
+		env: env as Env & { OAUTH_PROVIDER: undefined },
+		dbUserId: 1,
+		mcpUserId: userAaa,
+	})
+
+	// Cross-user data is preserved.
+	expect(rows.jobs).toEqual([
+		{ id: 'job-3', user_id: userBbb, storage_id: 'job:job-3' },
+	])
+	expect(rows.mcp_memories).toEqual([{ id: 'mem-2', user_id: userBbb }])
+	expect(rows.saved_packages).toEqual([{ id: 'pkg-2', user_id: userBbb }])
+	expect(rows.remote_connector_settings).toEqual([
+		{ id: 'rc-2', user_id: userBbb },
+	])
+	expect(rows.published_bundle_artifacts).toEqual([
+		{ id: 'pba-2', user_id: userBbb, kv_key: 'bundle-artifact:v1:src-2' },
+	])
+
+	// User-scoped data is removed.
+	expect(rows.mcp_skills).toEqual([])
+	expect(rows.ui_artifacts).toEqual([])
+	expect(rows.secret_buckets).toEqual([])
+	expect(rows.secret_entries).toEqual([])
+	expect(rows.value_buckets).toEqual([])
+	expect(rows.value_entries).toEqual([])
+	expect(rows.archived_job_artifacts).toEqual([])
+	expect(rows.entity_sources).toEqual([])
+	expect(rows.repo_sessions).toEqual([])
+	expect(rows.chat_threads).toEqual([])
+	expect(rows.email_attachments).toEqual([])
+	expect(rows.email_messages).toEqual([])
+	expect(rows.users).toEqual([{ id: 2, email: 'b@example.com' }])
+
+	// Storage runners for the deleted user's storage_ids were cleared.
+	expect(clearStorageMock).toHaveBeenCalledTimes(1)
+
+	// Bundle KV keys for the deleted user were removed; the other user's keys
+	// remain in storage.
+	expect(deletedKvKeys.sort()).toEqual([
+		'archived:src-1',
+		'bundle-artifact:v1:src-1',
+	])
+
+	// Result accounting captures the per-table counts.
+	expect(result.deletedRowCounts.jobs).toBe(2)
+	expect(result.deletedRowCounts.users).toBe(1)
+	expect(result.deletedRowCounts.email_attachments).toBe(1)
+	expect(result.warnings).toContain(
+		'OAuth provider binding was unavailable; OAuth grants were not revoked.',
+	)
+})
+
+test('deleteUserAccount revokes OAuth grants when an OAuth provider is bound', async () => {
+	const { db } = createTestDb({
+		users: [{ id: 1, email: 'a@example.com' }],
+	})
+
+	const revokeGrant = vi.fn(async () => undefined)
+	const helpers = {
+		async listUserGrants() {
+			return {
+				items: [
+					{ id: 'grant-1', clientId: 'client-1' },
+					{ id: 'grant-2', clientId: 'client-2' },
+				],
+				cursor: undefined,
+			}
+		},
+		revokeGrant,
+	} as unknown as Parameters<typeof deleteUserAccount>[0]['env']['OAUTH_PROVIDER']
+
+	const env = {
+		APP_DB: db,
+		OAUTH_PROVIDER: helpers,
+		STORAGE_RUNNER: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ clearStorage: async () => ({ ok: true as const }) }),
+		},
+	} as unknown as Parameters<typeof deleteUserAccount>[0]['env']
+
+	const result = await deleteUserAccount({
+		env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+	})
+
+	expect(revokeGrant).toHaveBeenCalledTimes(2)
+	expect(revokeGrant).toHaveBeenNthCalledWith(1, 'grant-1', 'user-aaa')
+	expect(revokeGrant).toHaveBeenNthCalledWith(2, 'grant-2', 'user-aaa')
+	expect(result.revokedOAuthGrants).toBe(2)
+})

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -1,0 +1,429 @@
+import { storageRunnerRpc } from '#worker/storage-runner.ts'
+import { jobVectorId } from '#mcp/jobs-vectorize.ts'
+import { memoryVectorId } from '#mcp/memory/memory-vectorize.ts'
+import { savedPackageVectorId } from '#worker/package-registry/repo.ts'
+import { getCapabilityVectorIndex } from '#mcp/capabilities/capability-search.ts'
+
+// Imported manually instead of via `@cloudflare/workers-oauth-provider` so
+// node-only unit tests can require this module without dragging in
+// `cloudflare:workers` (the OAuth provider package re-exports through that
+// runtime symbol). The shape mirrors the subset of OAuthHelpers we use.
+type OAuthGrantPage = {
+	items: Array<{ id: string; clientId: string }>
+	cursor: string | undefined
+}
+type OAuthHelpersShape = {
+	listUserGrants(
+		userId: string,
+		options: { cursor: string | undefined },
+	): Promise<OAuthGrantPage>
+	revokeGrant(grantId: string, userId: string): Promise<unknown>
+}
+
+type AccountDeletionEnv = Env & {
+	OAUTH_PROVIDER?: OAuthHelpersShape
+}
+
+export type AccountDeletionResult = {
+	deletedRowCounts: Record<string, number>
+	deletedKvKeys: number
+	revokedOAuthGrants: number
+	clearedDurableObjects: Record<string, number>
+	deletedVectors: number
+	warnings: Array<string>
+}
+
+type UserScopedDeleteTarget =
+	| { kind: 'user_id'; table: string }
+	| { kind: 'bucket_parent'; table: string; parentTable: string }
+	| { kind: 'attachment_parent'; table: string }
+	| { kind: 'mcp_memory_suppression' }
+
+/**
+ * Tables that are scoped by `user_id` (directly or transitively) and should
+ * be cascade-deleted when a user removes their account. The list is
+ * intentionally explicit so adding a new user-scoped table requires a
+ * deliberate update here (and a corresponding test).
+ *
+ * Order matters: child tables come before parent tables so the cascade is
+ * self-contained even on engines / configs where foreign-key cascades are
+ * disabled. Tables with no `user_id` column (e.g. global mock tables) are
+ * not represented.
+ */
+const userScopedTables: ReadonlyArray<UserScopedDeleteTarget> = [
+	{ kind: 'user_id', table: 'package_invocations' },
+	{ kind: 'user_id', table: 'package_invocation_tokens' },
+	{ kind: 'user_id', table: 'workflow_runs' },
+	{ kind: 'mcp_memory_suppression' },
+	{ kind: 'user_id', table: 'mcp_memories' },
+	{ kind: 'user_id', table: 'mcp_skills' },
+	{ kind: 'user_id', table: 'mcp_user_server_instructions' },
+	{ kind: 'user_id', table: 'ui_artifacts' },
+	{
+		kind: 'bucket_parent',
+		table: 'value_entries',
+		parentTable: 'value_buckets',
+	},
+	{ kind: 'user_id', table: 'value_buckets' },
+	{
+		kind: 'bucket_parent',
+		table: 'secret_entries',
+		parentTable: 'secret_buckets',
+	},
+	{ kind: 'user_id', table: 'secret_buckets' },
+	{ kind: 'user_id', table: 'remote_connector_settings' },
+	{ kind: 'user_id', table: 'archived_job_artifacts' },
+	{ kind: 'user_id', table: 'published_bundle_artifacts' },
+	{ kind: 'user_id', table: 'jobs' },
+	{ kind: 'user_id', table: 'repo_sessions' },
+	{ kind: 'user_id', table: 'saved_packages' },
+	{ kind: 'user_id', table: 'entity_sources' },
+	{ kind: 'user_id', table: 'email_delivery_events' },
+	{ kind: 'attachment_parent', table: 'email_attachments' },
+	{ kind: 'user_id', table: 'email_messages' },
+	{ kind: 'user_id', table: 'email_threads' },
+	{ kind: 'user_id', table: 'email_inbox_addresses' },
+	{ kind: 'user_id', table: 'email_inboxes' },
+	{ kind: 'user_id', table: 'email_sender_identities' },
+	{ kind: 'user_id', table: 'chat_threads' },
+	{ kind: 'user_id', table: 'password_resets' },
+]
+
+async function listUserVectorIds(env: Env, userId: string) {
+	const memoryRows = await env.APP_DB.prepare(
+		`SELECT id FROM mcp_memories WHERE user_id = ?`,
+	)
+		.bind(userId)
+		.all<{ id: string }>()
+	const jobRows = await env.APP_DB.prepare(
+		`SELECT id FROM jobs WHERE user_id = ?`,
+	)
+		.bind(userId)
+		.all<{ id: string }>()
+	const packageRows = await env.APP_DB.prepare(
+		`SELECT id FROM saved_packages WHERE user_id = ?`,
+	)
+		.bind(userId)
+		.all<{ id: string }>()
+	const ids: Array<string> = []
+	for (const row of memoryRows.results ?? []) {
+		ids.push(memoryVectorId(row.id))
+	}
+	for (const row of jobRows.results ?? []) {
+		ids.push(jobVectorId(row.id))
+	}
+	for (const row of packageRows.results ?? []) {
+		ids.push(savedPackageVectorId(row.id))
+	}
+	return ids
+}
+
+async function listUserStorageIds(env: Env, userId: string) {
+	const jobRows = await env.APP_DB.prepare(
+		`SELECT storage_id FROM jobs WHERE user_id = ? AND storage_id IS NOT NULL`,
+	)
+		.bind(userId)
+		.all<{ storage_id: string }>()
+	return Array.from(
+		new Set(
+			(jobRows.results ?? [])
+				.map((row) => row.storage_id)
+				.filter((id): id is string => Boolean(id)),
+		),
+	)
+}
+
+async function listUserBundleKvKeys(env: Env, userId: string) {
+	const published = await env.APP_DB.prepare(
+		`SELECT kv_key FROM published_bundle_artifacts WHERE user_id = ?`,
+	)
+		.bind(userId)
+		.all<{ kv_key: string }>()
+	const archived = await env.APP_DB.prepare(
+		`SELECT kv_key FROM archived_job_artifacts WHERE user_id = ?`,
+	)
+		.bind(userId)
+		.all<{ kv_key: string }>()
+	const keys = new Set<string>()
+	for (const row of published.results ?? []) {
+		if (row.kv_key) keys.add(row.kv_key)
+	}
+	for (const row of archived.results ?? []) {
+		if (row.kv_key) keys.add(row.kv_key)
+	}
+	return Array.from(keys)
+}
+
+async function revokeAllOAuthGrants(input: {
+	helpers: OAuthHelpersShape
+	userId: string
+	warnings: Array<string>
+}): Promise<number> {
+	let cursor: string | undefined
+	let revoked = 0
+	do {
+		const page = await input.helpers.listUserGrants(input.userId, { cursor })
+		for (const grant of page.items) {
+			try {
+				await input.helpers.revokeGrant(grant.id, input.userId)
+				revoked += 1
+			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : String(error)
+				input.warnings.push(
+					`OAuth grant revoke failed for grant ${grant.id}: ${message}`,
+				)
+			}
+		}
+		cursor = page.cursor
+	} while (cursor)
+	return revoked
+}
+
+async function clearStorageRunners(input: {
+	env: Env
+	userId: string
+	storageIds: ReadonlyArray<string>
+	warnings: Array<string>
+}): Promise<number> {
+	let cleared = 0
+	for (const storageId of input.storageIds) {
+		try {
+			const stub = storageRunnerRpc({
+				env: input.env,
+				userId: input.userId,
+				storageId,
+			})
+			await stub.clearStorage()
+			cleared += 1
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(
+				`Storage runner clear failed for ${storageId}: ${message}`,
+			)
+		}
+	}
+	return cleared
+}
+
+async function deleteVectorsByIds(input: {
+	env: Env
+	ids: ReadonlyArray<string>
+	warnings: Array<string>
+}): Promise<number> {
+	if (input.ids.length === 0) return 0
+	const index = getCapabilityVectorIndex(input.env)
+	if (!index) return 0
+	let deleted = 0
+	const batchSize = 100
+	for (let offset = 0; offset < input.ids.length; offset += batchSize) {
+		const batch = input.ids.slice(offset, offset + batchSize)
+		try {
+			await index.deleteByIds(batch)
+			deleted += batch.length
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(`Vectorize deleteByIds batch failed: ${message}`)
+		}
+	}
+	return deleted
+}
+
+async function deleteKvKeys(input: {
+	kv: KVNamespace
+	keys: ReadonlyArray<string>
+	warnings: Array<string>
+}): Promise<number> {
+	let deleted = 0
+	for (const key of input.keys) {
+		try {
+			await input.kv.delete(key)
+			deleted += 1
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(`KV delete failed for ${key}: ${message}`)
+		}
+	}
+	return deleted
+}
+
+async function deleteUserScopedRows(input: {
+	env: Env
+	userId: string
+	warnings: Array<string>
+}): Promise<Record<string, number>> {
+	const counts: Record<string, number> = {}
+	for (const target of userScopedTables) {
+		try {
+			let sql: string
+			let params: Array<unknown>
+			let tableName: string
+			switch (target.kind) {
+				case 'user_id': {
+					sql = `DELETE FROM ${target.table} WHERE user_id = ?`
+					params = [input.userId]
+					tableName = target.table
+					break
+				}
+				case 'bucket_parent': {
+					sql = `DELETE FROM ${target.table} WHERE bucket_id IN (
+						SELECT id FROM ${target.parentTable} WHERE user_id = ?
+					)`
+					params = [input.userId]
+					tableName = target.table
+					break
+				}
+				case 'attachment_parent': {
+					sql = `DELETE FROM email_attachments WHERE message_id IN (
+						SELECT id FROM email_messages WHERE user_id = ?
+					)`
+					params = [input.userId]
+					tableName = 'email_attachments'
+					break
+				}
+				case 'mcp_memory_suppression': {
+					sql = `DELETE FROM mcp_memory_conversation_suppressions WHERE user_id = ?`
+					params = [input.userId]
+					tableName = 'mcp_memory_conversation_suppressions'
+					break
+				}
+				default: {
+					const exhaustive: never = target
+					throw new Error(
+						`Unhandled user-scoped delete target: ${JSON.stringify(exhaustive)}`,
+					)
+				}
+			}
+			const result = await input.env.APP_DB.prepare(sql)
+				.bind(...params)
+				.run()
+			counts[tableName] = result.meta.changes ?? 0
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			const targetLabel =
+				target.kind === 'mcp_memory_suppression'
+					? 'mcp_memory_conversation_suppressions'
+					: target.table
+			input.warnings.push(`Failed to delete from ${targetLabel}: ${message}`)
+			counts[targetLabel] = 0
+		}
+	}
+	return counts
+}
+
+async function deleteUserRow(input: {
+	env: Env
+	dbUserId: number
+	warnings: Array<string>
+}): Promise<number> {
+	try {
+		const result = await input.env.APP_DB.prepare(
+			`DELETE FROM users WHERE id = ?`,
+		)
+			.bind(input.dbUserId)
+			.run()
+		return result.meta.changes ?? 0
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		input.warnings.push(`Failed to delete user row: ${message}`)
+		return 0
+	}
+}
+
+/**
+ * Orchestrate a full per-user data cleanup. The caller is responsible for
+ * verifying the user's identity before invoking this; the orchestrator does
+ * not re-authenticate.
+ *
+ * The cleanup ordering is:
+ *   1. Pre-collect identifiers we need (vector ids, storage ids, KV keys)
+ *      while their owning rows still exist.
+ *   2. Best-effort destructive cleanup of out-of-band stores (Vectorize,
+ *      KV, durable storage) - each batch records a warning on failure but
+ *      does not abort the cascade.
+ *   3. Delete user-scoped D1 rows in dependency-safe order.
+ *   4. Revoke OAuth grants and delete the user's row last so a partially
+ *      failed run can be retried with the same email.
+ */
+export async function deleteUserAccount(input: {
+	env: AccountDeletionEnv
+	dbUserId: number
+	mcpUserId: string
+}): Promise<AccountDeletionResult> {
+	const warnings: Array<string> = []
+	const result: AccountDeletionResult = {
+		deletedRowCounts: {},
+		deletedKvKeys: 0,
+		revokedOAuthGrants: 0,
+		clearedDurableObjects: {},
+		deletedVectors: 0,
+		warnings,
+	}
+
+	const [vectorIds, storageIds, bundleKvKeys] = await Promise.all([
+		listUserVectorIds(input.env, input.mcpUserId).catch((error) => {
+			const message = error instanceof Error ? error.message : String(error)
+			warnings.push(`Failed to enumerate vector ids: ${message}`)
+			return [] as Array<string>
+		}),
+		listUserStorageIds(input.env, input.mcpUserId).catch((error) => {
+			const message = error instanceof Error ? error.message : String(error)
+			warnings.push(`Failed to enumerate storage ids: ${message}`)
+			return [] as Array<string>
+		}),
+		listUserBundleKvKeys(input.env, input.mcpUserId).catch((error) => {
+			const message = error instanceof Error ? error.message : String(error)
+			warnings.push(`Failed to enumerate bundle KV keys: ${message}`)
+			return [] as Array<string>
+		}),
+	])
+
+	result.deletedVectors = await deleteVectorsByIds({
+		env: input.env,
+		ids: vectorIds,
+		warnings,
+	})
+
+	result.clearedDurableObjects.storageRunners = await clearStorageRunners({
+		env: input.env,
+		userId: input.mcpUserId,
+		storageIds,
+		warnings,
+	})
+
+	if (input.env.BUNDLE_ARTIFACTS_KV) {
+		result.deletedKvKeys = await deleteKvKeys({
+			kv: input.env.BUNDLE_ARTIFACTS_KV,
+			keys: bundleKvKeys,
+			warnings,
+		})
+	}
+
+	result.deletedRowCounts = await deleteUserScopedRows({
+		env: input.env,
+		userId: input.mcpUserId,
+		warnings,
+	})
+
+	const helpers = input.env.OAUTH_PROVIDER
+	if (helpers) {
+		result.revokedOAuthGrants = await revokeAllOAuthGrants({
+			helpers,
+			userId: input.mcpUserId,
+			warnings,
+		})
+	} else {
+		warnings.push(
+			'OAuth provider binding was unavailable; OAuth grants were not revoked.',
+		)
+	}
+
+	const deletedUserRows = await deleteUserRow({
+		env: input.env,
+		dbUserId: input.dbUserId,
+		warnings,
+	})
+	result.deletedRowCounts.users = deletedUserRows
+
+	return result
+}

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -407,6 +407,15 @@ export async function deleteUserAccount(input: {
 			keys: bundleKvKeys,
 			warnings,
 		})
+	} else if (bundleKvKeys.length > 0) {
+		// We collected keys from D1 (published_bundle_artifacts /
+		// archived_job_artifacts) but the KV binding is missing, so
+		// deleteUserScopedRows below would drop the D1 rows without
+		// reaping the underlying KV entries. Surface that as a warning
+		// so the operator knows the KV namespace needs a manual sweep.
+		warnings.push(
+			`BUNDLE_ARTIFACTS_KV binding was unavailable; ${bundleKvKeys.length} bundle artifact key(s) referenced by the deleted user were not removed and must be cleaned up manually.`,
+		)
 	}
 
 	result.deletedRowCounts = await deleteUserScopedRows({

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -163,10 +163,23 @@ async function revokeAllOAuthGrants(input: {
 	userId: string
 	warnings: Array<string>
 }): Promise<number> {
+	// Both the page listing and the individual revoke calls can throw, and
+	// neither failure should abort the larger account-deletion cascade -
+	// the rest of the steps still need to run so the user's data is
+	// removed even if the OAuth provider is briefly unavailable.
 	let cursor: string | undefined
 	let revoked = 0
-	do {
-		const page = await input.helpers.listUserGrants(input.userId, { cursor })
+	while (true) {
+		let page: Awaited<ReturnType<OAuthHelpersShape['listUserGrants']>>
+		try {
+			page = await input.helpers.listUserGrants(input.userId, { cursor })
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(
+				`OAuth grant listing failed; revoked ${revoked} grant(s) before the failure: ${message}`,
+			)
+			return revoked
+		}
 		for (const grant of page.items) {
 			try {
 				await input.helpers.revokeGrant(grant.id, input.userId)
@@ -178,9 +191,9 @@ async function revokeAllOAuthGrants(input: {
 				)
 			}
 		}
+		if (!page.cursor) return revoked
 		cursor = page.cursor
-	} while (cursor)
-	return revoked
+	}
 }
 
 async function clearStorageRunners(input: {
@@ -427,11 +440,16 @@ export async function deleteUserAccount(input: {
 
 	const helpers = input.env.OAUTH_PROVIDER
 	if (helpers) {
-		result.revokedOAuthGrants = await revokeAllOAuthGrants({
-			helpers,
-			userId: input.mcpUserId,
-			warnings,
-		})
+		try {
+			result.revokedOAuthGrants = await revokeAllOAuthGrants({
+				helpers,
+				userId: input.mcpUserId,
+				warnings,
+			})
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			warnings.push(`OAuth grant revocation failed unexpectedly: ${message}`)
+		}
 	} else {
 		warnings.push(
 			'OAuth provider binding was unavailable; OAuth grants were not revoked.',

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -35,6 +35,7 @@ export type AccountDeletionResult = {
 
 type UserScopedDeleteTarget =
 	| { kind: 'user_id'; table: string }
+	| { kind: 'db_user_id'; table: string }
 	| { kind: 'bucket_parent'; table: string; parentTable: string }
 	| { kind: 'attachment_parent'; table: string }
 	| { kind: 'mcp_memory_suppression' }
@@ -86,7 +87,10 @@ const userScopedTables: ReadonlyArray<UserScopedDeleteTarget> = [
 	{ kind: 'user_id', table: 'email_inboxes' },
 	{ kind: 'user_id', table: 'email_sender_identities' },
 	{ kind: 'user_id', table: 'chat_threads' },
-	{ kind: 'user_id', table: 'password_resets' },
+	// password_resets.user_id is an INTEGER FK to users.id (predates the
+	// stable mcp string user id), so it must be cleared with the database
+	// integer id rather than the mcp user id.
+	{ kind: 'db_user_id', table: 'password_resets' },
 ]
 
 async function listUserVectorIds(env: Env, userId: string) {
@@ -248,7 +252,8 @@ async function deleteKvKeys(input: {
 
 async function deleteUserScopedRows(input: {
 	env: Env
-	userId: string
+	mcpUserId: string
+	dbUserId: number
 	warnings: Array<string>
 }): Promise<Record<string, number>> {
 	const counts: Record<string, number> = {}
@@ -260,7 +265,13 @@ async function deleteUserScopedRows(input: {
 			switch (target.kind) {
 				case 'user_id': {
 					sql = `DELETE FROM ${target.table} WHERE user_id = ?`
-					params = [input.userId]
+					params = [input.mcpUserId]
+					tableName = target.table
+					break
+				}
+				case 'db_user_id': {
+					sql = `DELETE FROM ${target.table} WHERE user_id = ?`
+					params = [input.dbUserId]
 					tableName = target.table
 					break
 				}
@@ -268,7 +279,7 @@ async function deleteUserScopedRows(input: {
 					sql = `DELETE FROM ${target.table} WHERE bucket_id IN (
 						SELECT id FROM ${target.parentTable} WHERE user_id = ?
 					)`
-					params = [input.userId]
+					params = [input.mcpUserId]
 					tableName = target.table
 					break
 				}
@@ -276,13 +287,13 @@ async function deleteUserScopedRows(input: {
 					sql = `DELETE FROM email_attachments WHERE message_id IN (
 						SELECT id FROM email_messages WHERE user_id = ?
 					)`
-					params = [input.userId]
+					params = [input.mcpUserId]
 					tableName = 'email_attachments'
 					break
 				}
 				case 'mcp_memory_suppression': {
 					sql = `DELETE FROM mcp_memory_conversation_suppressions WHERE user_id = ?`
-					params = [input.userId]
+					params = [input.mcpUserId]
 					tableName = 'mcp_memory_conversation_suppressions'
 					break
 				}
@@ -400,7 +411,8 @@ export async function deleteUserAccount(input: {
 
 	result.deletedRowCounts = await deleteUserScopedRows({
 		env: input.env,
-		userId: input.mcpUserId,
+		mcpUserId: input.mcpUserId,
+		dbUserId: input.dbUserId,
 		warnings,
 	})
 

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -168,8 +168,7 @@ async function revokeAllOAuthGrants(input: {
 				await input.helpers.revokeGrant(grant.id, input.userId)
 				revoked += 1
 			} catch (error) {
-				const message =
-					error instanceof Error ? error.message : String(error)
+				const message = error instanceof Error ? error.message : String(error)
 				input.warnings.push(
 					`OAuth grant revoke failed for grant ${grant.id}: ${message}`,
 				)

--- a/packages/worker/src/app/handlers/account-delete.ts
+++ b/packages/worker/src/app/handlers/account-delete.ts
@@ -1,0 +1,104 @@
+import { type BuildAction } from 'remix/fetch-router'
+import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { destroyAuthCookie, isSecureRequest } from '#app/auth-session.ts'
+import { type routes } from '#app/routes.ts'
+import { deleteUserAccount } from '#app/account-deletion.ts'
+import { createDb, usersTable } from '#worker/db.ts'
+import { verifyPassword } from '@kody-internal/shared/password-hash.ts'
+
+export function createAccountDeleteHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, url }) {
+			const requestIp = getRequestIp(request) ?? undefined
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return Response.json(
+					{ error: 'Authentication required.' },
+					{ status: 401 },
+				)
+			}
+
+			let body: unknown
+			try {
+				body = await request.json()
+			} catch {
+				return Response.json(
+					{ error: 'Invalid JSON payload.' },
+					{ status: 400 },
+				)
+			}
+
+			const password =
+				body && typeof body === 'object'
+					? (body as Record<string, unknown>).password
+					: undefined
+			if (typeof password !== 'string' || password.length === 0) {
+				return Response.json(
+					{
+						error:
+							'Account deletion requires re-entering the current password.',
+					},
+					{ status: 400 },
+				)
+			}
+
+			const db = createDb(env.APP_DB)
+			const userRow = await db.findOne(usersTable, {
+				where: { id: user.userId },
+			})
+			if (!userRow) {
+				return Response.json({ error: 'User not found.' }, { status: 404 })
+			}
+			const passwordValid = await verifyPassword(password, userRow.password_hash)
+			if (!passwordValid) {
+				void logAuditEvent({
+					category: 'auth',
+					action: 'account_delete',
+					result: 'failure',
+					email: user.email,
+					ip: requestIp,
+					path: url.pathname,
+					reason: 'invalid_password',
+				})
+				return Response.json(
+					{ error: 'Current password did not match.' },
+					{ status: 401 },
+				)
+			}
+
+			const result = await deleteUserAccount({
+				env,
+				dbUserId: user.userId,
+				mcpUserId: user.mcpUser.userId,
+			})
+
+			void logAuditEvent({
+				category: 'auth',
+				action: 'account_delete',
+				result: 'success',
+				email: user.email,
+				ip: requestIp,
+				path: url.pathname,
+			})
+
+			const headers = new Headers({ 'Content-Type': 'application/json' })
+			headers.set(
+				'Set-Cookie',
+				await destroyAuthCookie(isSecureRequest(request)),
+			)
+
+			return new Response(
+				JSON.stringify({
+					ok: true,
+					...result,
+				}),
+				{ status: 200, headers },
+			)
+		},
+	} satisfies BuildAction<
+		typeof routes.accountDelete.method,
+		typeof routes.accountDelete.pattern
+	>
+}

--- a/packages/worker/src/app/handlers/account-delete.ts
+++ b/packages/worker/src/app/handlers/account-delete.ts
@@ -51,7 +51,10 @@ export function createAccountDeleteHandler(env: Env) {
 			if (!userRow) {
 				return Response.json({ error: 'User not found.' }, { status: 404 })
 			}
-			const passwordValid = await verifyPassword(password, userRow.password_hash)
+			const passwordValid = await verifyPassword(
+				password,
+				userRow.password_hash,
+			)
 			if (!passwordValid) {
 				void logAuditEvent({
 					category: 'auth',

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -23,9 +23,7 @@ function createAuthRequest(
 	}
 }
 
-function createAuthTestContext(
-	options: { allowedSignupEmails?: string } = {},
-) {
+function createAuthTestContext(options: { allowedSignupEmails?: string } = {}) {
 	const testDb = createTestDb()
 	const handler = createAuthHandler({
 		COOKIE_SECRET: testCookieSecret,

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -23,12 +23,11 @@ function createAuthRequest(
 	}
 }
 
-function createAuthTestContext(options: { allowedSignupEmails?: string } = {}) {
+function createAuthTestContext() {
 	const testDb = createTestDb()
 	const handler = createAuthHandler({
 		COOKIE_SECRET: testCookieSecret,
 		APP_DB: testDb.db,
-		ALLOWED_SIGNUP_EMAILS: options.allowedSignupEmails,
 	})
 
 	return {
@@ -163,7 +162,7 @@ test('auth handler rejects malformed request payloads', async () => {
 	})
 })
 
-test('auth handler returns invalid credentials for unknown logins regardless of allowlist', async () => {
+test('auth handler returns invalid credentials for unknown logins', async () => {
 	const { request } = createAuthTestContext()
 
 	const unknownUserLoginResponse = await request({
@@ -177,32 +176,7 @@ test('auth handler returns invalid credentials for unknown logins regardless of 
 	})
 })
 
-test('auth handler enforces the configured signup allowlist', async () => {
-	const { request, testDb } = createAuthTestContext({
-		allowedSignupEmails: 'me@kentcdodds.com, allowed@example.com',
-	})
-
-	const forbiddenSignupResponse = await request({
-		email: 'new@example.com',
-		password: 'secret',
-		mode: 'signup',
-	})
-	expect(forbiddenSignupResponse.status).toBe(403)
-	expect(await forbiddenSignupResponse.json()).toEqual({
-		error: 'Signup is not enabled for this email address.',
-	})
-	expect(testDb.users.has('new@example.com')).toBe(false)
-
-	const allowedSignupResponse = await request({
-		email: 'allowed@example.com',
-		password: 'secret',
-		mode: 'signup',
-	})
-	expect(allowedSignupResponse.status).toBe(200)
-	expect(testDb.users.has('allowed@example.com')).toBe(true)
-})
-
-test('auth handler permits open signup when no allowlist is configured', async () => {
+test('auth handler permits open signup for any new email', async () => {
 	const { request, testDb } = createAuthTestContext()
 
 	const userOneSignup = await request({

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -23,12 +23,22 @@ function createAuthRequest(
 	}
 }
 
-function createAuthTestContext() {
+function createAuthTestContext(options: { signupEnabled?: boolean } = {}) {
 	const testDb = createTestDb()
 	const handler = createAuthHandler({
 		COOKIE_SECRET: testCookieSecret,
 		APP_DB: testDb.db,
-	})
+		// SENTRY_ENVIRONMENT defaults to 'production' (signups blocked).
+		// Pass `signupEnabled: true` to put the handler in the 'test' env
+		// that mirrors the wrangler `test`/`preview` envs.
+		...(options.signupEnabled
+			? {
+					SENTRY_ENVIRONMENT: 'test' as const,
+				}
+			: {
+					SENTRY_ENVIRONMENT: 'production' as const,
+				}),
+	} as unknown as Parameters<typeof createAuthHandler>[0])
 
 	return {
 		testDb,
@@ -176,41 +186,38 @@ test('auth handler returns invalid credentials for unknown logins', async () => 
 	})
 })
 
-test('auth handler permits open signup for any new email', async () => {
+test('auth handler rejects signups in production envs', async () => {
 	const { request, testDb } = createAuthTestContext()
 
-	const userOneSignup = await request({
-		email: 'first@example.com',
+	const response = await request({
+		email: 'new@example.com',
 		password: 'secret',
 		mode: 'signup',
 	})
-	expect(userOneSignup.status).toBe(200)
-	expect(testDb.users.has('first@example.com')).toBe(true)
-
-	const userTwoSignup = await request({
-		email: 'second@example.com',
-		password: 'another-secret',
-		mode: 'signup',
+	expect(response.status).toBe(403)
+	expect(await response.json()).toEqual({
+		error: 'Signups are currently disabled.',
 	})
-	expect(userTwoSignup.status).toBe(200)
-	expect(testDb.users.has('second@example.com')).toBe(true)
+	expect(testDb.users.has('new@example.com')).toBe(false)
 })
 
-test('auth handler issues the right session cookies for signup and login flows', async () => {
-	const { request, testDb } = createAuthTestContext()
-	const email = 'session-user@example.com'
+test('auth handler permits signups when the env opts in (local dev / preview / test)', async () => {
+	const { request, testDb } = createAuthTestContext({ signupEnabled: true })
 
-	const signupResponse = await request({
-		email,
+	const response = await request({
+		email: 'allowed@example.com',
 		password: 'secret',
 		mode: 'signup',
 	})
-	expect(signupResponse.status).toBe(200)
-	expect(await signupResponse.json()).toEqual({ ok: true, mode: 'signup' })
-	expect(testDb.users.has(email)).toBe(true)
-	const signupCookie = signupResponse.headers.get('Set-Cookie') ?? ''
-	expect(signupCookie).toContain('kody_session=')
-	expect(signupCookie).toContain('Max-Age=604800')
+	expect(response.status).toBe(200)
+	expect(await response.json()).toEqual({ ok: true, mode: 'signup' })
+	expect(testDb.users.has('allowed@example.com')).toBe(true)
+})
+
+test('auth handler issues the right session cookies for login flows', async () => {
+	const { request, testDb } = createAuthTestContext()
+	const email = 'session-user@example.com'
+	await testDb.addUser(email, 'secret')
 
 	const loginResponse = await request({
 		email,

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -5,7 +5,6 @@ import { createAuthHandler } from '#app/handlers/auth.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
-const primaryUserEmail = 'me@kentcdodds.com'
 
 function createAuthRequest(
 	body: unknown,
@@ -24,11 +23,14 @@ function createAuthRequest(
 	}
 }
 
-function createAuthTestContext() {
+function createAuthTestContext(
+	options: { allowedSignupEmails?: string } = {},
+) {
 	const testDb = createTestDb()
 	const handler = createAuthHandler({
 		COOKIE_SECRET: testCookieSecret,
 		APP_DB: testDb.db,
+		ALLOWED_SIGNUP_EMAILS: options.allowedSignupEmails,
 	})
 
 	return {
@@ -163,11 +165,11 @@ test('auth handler rejects malformed request payloads', async () => {
 	})
 })
 
-test('auth handler rejects unauthorized signup and login attempts', async () => {
-	const { request, testDb } = createAuthTestContext()
+test('auth handler returns invalid credentials for unknown logins regardless of allowlist', async () => {
+	const { request } = createAuthTestContext()
 
 	const unknownUserLoginResponse = await request({
-		email: primaryUserEmail,
+		email: 'someone@example.com',
 		password: 'secret',
 		mode: 'login',
 	})
@@ -175,47 +177,71 @@ test('auth handler rejects unauthorized signup and login attempts', async () => 
 	expect(await unknownUserLoginResponse.json()).toEqual({
 		error: 'Invalid email or password.',
 	})
+})
+
+test('auth handler enforces the configured signup allowlist', async () => {
+	const { request, testDb } = createAuthTestContext({
+		allowedSignupEmails: 'me@kentcdodds.com, allowed@example.com',
+	})
 
 	const forbiddenSignupResponse = await request({
-		email: 'new@b.com',
+		email: 'new@example.com',
 		password: 'secret',
 		mode: 'signup',
 	})
 	expect(forbiddenSignupResponse.status).toBe(403)
 	expect(await forbiddenSignupResponse.json()).toEqual({
-		error: `Only ${primaryUserEmail} can sign in or sign up.`,
+		error: 'Signup is not enabled for this email address.',
 	})
-	expect(testDb.users.has('new@b.com')).toBe(false)
+	expect(testDb.users.has('new@example.com')).toBe(false)
 
-	await testDb.addUser('a@b.com', 'secret')
-	const forbiddenLoginResponse = await request({
-		email: 'a@b.com',
+	const allowedSignupResponse = await request({
+		email: 'allowed@example.com',
 		password: 'secret',
-		mode: 'login',
+		mode: 'signup',
 	})
-	expect(forbiddenLoginResponse.status).toBe(403)
-	expect(await forbiddenLoginResponse.json()).toEqual({
-		error: `Only ${primaryUserEmail} can sign in or sign up.`,
+	expect(allowedSignupResponse.status).toBe(200)
+	expect(testDb.users.has('allowed@example.com')).toBe(true)
+})
+
+test('auth handler permits open signup when no allowlist is configured', async () => {
+	const { request, testDb } = createAuthTestContext()
+
+	const userOneSignup = await request({
+		email: 'first@example.com',
+		password: 'secret',
+		mode: 'signup',
 	})
+	expect(userOneSignup.status).toBe(200)
+	expect(testDb.users.has('first@example.com')).toBe(true)
+
+	const userTwoSignup = await request({
+		email: 'second@example.com',
+		password: 'another-secret',
+		mode: 'signup',
+	})
+	expect(userTwoSignup.status).toBe(200)
+	expect(testDb.users.has('second@example.com')).toBe(true)
 })
 
 test('auth handler issues the right session cookies for signup and login flows', async () => {
 	const { request, testDb } = createAuthTestContext()
+	const email = 'session-user@example.com'
 
 	const signupResponse = await request({
-		email: primaryUserEmail,
+		email,
 		password: 'secret',
 		mode: 'signup',
 	})
 	expect(signupResponse.status).toBe(200)
 	expect(await signupResponse.json()).toEqual({ ok: true, mode: 'signup' })
-	expect(testDb.users.has(primaryUserEmail)).toBe(true)
+	expect(testDb.users.has(email)).toBe(true)
 	const signupCookie = signupResponse.headers.get('Set-Cookie') ?? ''
 	expect(signupCookie).toContain('kody_session=')
 	expect(signupCookie).toContain('Max-Age=604800')
 
 	const loginResponse = await request({
-		email: primaryUserEmail,
+		email,
 		password: 'secret',
 		mode: 'login',
 	})
@@ -226,7 +252,7 @@ test('auth handler issues the right session cookies for signup and login flows',
 	expect(loginCookie).toContain('Max-Age=604800')
 
 	const rememberMeResponse = await request({
-		email: primaryUserEmail,
+		email,
 		password: 'secret',
 		mode: 'login',
 		rememberMe: true,
@@ -238,7 +264,7 @@ test('auth handler issues the right session cookies for signup and login flows',
 	expect(rememberMeCookie).toContain('Max-Age=2592000')
 
 	const secureCookieResponse = await request(
-		{ email: primaryUserEmail, password: 'secret', mode: 'login' },
+		{ email, password: 'secret', mode: 'login' },
 		'https://example.com/auth',
 	)
 	expect(secureCookieResponse.headers.get('Set-Cookie') ?? '').toContain(

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -13,7 +13,20 @@ import { type AppEnv } from '#worker/env-schema.ts'
 
 const authModes = ['login', 'signup'] as const
 type AuthMode = (typeof authModes)[number]
-const primaryUserEmail = 'me@kentcdodds.com'
+
+function parseSignupAllowlist(raw: string | undefined): Array<string> | null {
+	if (typeof raw !== 'string') return null
+	const entries = raw
+		.split(',')
+		.map((entry) => entry.trim().toLowerCase())
+		.filter((entry) => entry.length > 0)
+	return entries.length > 0 ? entries : null
+}
+
+function isSignupAllowed(email: string, allowlist: Array<string> | null) {
+	if (!allowlist) return true
+	return allowlist.includes(email)
+}
 
 function isUniqueConstraintError(error: unknown) {
 	let currentError = error
@@ -37,6 +50,7 @@ const dummyPasswordHash =
 
 export function createAuthHandler(appEnv: AppEnv) {
 	const db = createDb(appEnv.APP_DB)
+	const signupAllowlist = parseSignupAllowlist(appEnv.ALLOWED_SIGNUP_EMAILS)
 
 	return {
 		middleware: [],
@@ -95,10 +109,13 @@ export function createAuthHandler(appEnv: AppEnv) {
 				)
 			}
 
-			if (normalizedEmail !== primaryUserEmail) {
+			if (
+				normalizedMode === 'signup' &&
+				!isSignupAllowed(normalizedEmail, signupAllowlist)
+			) {
 				void logAuditEvent({
 					category: 'auth',
-					action: normalizedMode,
+					action: 'signup',
 					result: 'failure',
 					email: normalizedEmail,
 					ip: requestIp,
@@ -107,7 +124,7 @@ export function createAuthHandler(appEnv: AppEnv) {
 				})
 				return Response.json(
 					{
-						error: `Only ${primaryUserEmail} can sign in or sign up.`,
+						error: 'Signup is not enabled for this email address.',
 					},
 					{ status: 403 },
 				)

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -14,6 +14,21 @@ import { type AppEnv } from '#worker/env-schema.ts'
 const authModes = ['login', 'signup'] as const
 type AuthMode = (typeof authModes)[number]
 
+/**
+ * Signups are blocked in real deployments and allowed in local dev,
+ * preview, and e2e test runs so the existing tooling (Playwright seed
+ * helpers, manual local testing) keeps working without a second
+ * auth-bypass code path. Production wrangler env sets
+ * `SENTRY_ENVIRONMENT: 'production'`; preview/test set 'preview' /
+ * 'test'; `npm run dev` sets `WRANGLER_IS_LOCAL_DEV=true`.
+ */
+function isSignupAllowed(appEnv: AppEnv) {
+	const runtime = appEnv as unknown as Record<string, string | undefined>
+	if (runtime['WRANGLER_IS_LOCAL_DEV'] === 'true') return true
+	const sentryEnv = runtime['SENTRY_ENVIRONMENT']
+	return sentryEnv === 'test' || sentryEnv === 'preview'
+}
+
 function isUniqueConstraintError(error: unknown) {
 	let currentError = error
 	while (currentError instanceof Error) {
@@ -91,6 +106,22 @@ export function createAuthHandler(appEnv: AppEnv) {
 				return Response.json(
 					{ error: 'Email, password, and mode are required.' },
 					{ status: 400 },
+				)
+			}
+
+			if (normalizedMode === 'signup' && !isSignupAllowed(appEnv)) {
+				void logAuditEvent({
+					category: 'auth',
+					action: 'signup',
+					result: 'failure',
+					email: normalizedEmail,
+					ip: requestIp,
+					path: url.pathname,
+					reason: 'signup_disabled',
+				})
+				return Response.json(
+					{ error: 'Signups are currently disabled.' },
+					{ status: 403 },
 				)
 			}
 

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -14,20 +14,6 @@ import { type AppEnv } from '#worker/env-schema.ts'
 const authModes = ['login', 'signup'] as const
 type AuthMode = (typeof authModes)[number]
 
-function parseSignupAllowlist(raw: string | undefined): Array<string> | null {
-	if (typeof raw !== 'string') return null
-	const entries = raw
-		.split(',')
-		.map((entry) => entry.trim().toLowerCase())
-		.filter((entry) => entry.length > 0)
-	return entries.length > 0 ? entries : null
-}
-
-function isSignupAllowed(email: string, allowlist: Array<string> | null) {
-	if (!allowlist) return true
-	return allowlist.includes(email)
-}
-
 function isUniqueConstraintError(error: unknown) {
 	let currentError = error
 	while (currentError instanceof Error) {
@@ -50,7 +36,6 @@ const dummyPasswordHash =
 
 export function createAuthHandler(appEnv: AppEnv) {
 	const db = createDb(appEnv.APP_DB)
-	const signupAllowlist = parseSignupAllowlist(appEnv.ALLOWED_SIGNUP_EMAILS)
 
 	return {
 		middleware: [],
@@ -106,27 +91,6 @@ export function createAuthHandler(appEnv: AppEnv) {
 				return Response.json(
 					{ error: 'Email, password, and mode are required.' },
 					{ status: 400 },
-				)
-			}
-
-			if (
-				normalizedMode === 'signup' &&
-				!isSignupAllowed(normalizedEmail, signupAllowlist)
-			) {
-				void logAuditEvent({
-					category: 'auth',
-					action: 'signup',
-					result: 'failure',
-					email: normalizedEmail,
-					ip: requestIp,
-					path: url.pathname,
-					reason: 'email_not_allowed',
-				})
-				return Response.json(
-					{
-						error: 'Signup is not enabled for this email address.',
-					},
-					{ status: 403 },
 				)
 			}
 

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -1,5 +1,6 @@
 import { createRouter } from 'remix/fetch-router'
 import { account } from '#app/handlers/account.ts'
+import { createAccountDeleteHandler } from '#app/handlers/account-delete.ts'
 import {
 	createAccountRemoteConnectorsApiHandler,
 	createAccountRemoteConnectorsHandler,
@@ -44,6 +45,7 @@ export function createAppRouter(appEnv: AppEnv) {
 			login,
 			signup,
 			account,
+			accountDelete: createAccountDeleteHandler(appEnv as unknown as Env),
 			accountRemoteConnectors: createAccountRemoteConnectorsHandler(
 				appEnv as unknown as Env,
 			),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -23,6 +23,7 @@ export const routes = route({
 	login: '/login',
 	signup: '/signup',
 	account: '/account',
+	accountDelete: post('/account/delete'),
 	auth: post('/auth'),
 	session: '/session',
 	logout: post('/logout'),

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -492,9 +492,32 @@ test('inbound email handler dispatches package subscriptions for stored inbound 
 		mainModule: 'dist/subscription.js',
 		modules: {
 			'.__kody_virtual__/runtime.js': `
-const runtime = globalThis.__kodyRuntime ?? {};
-export const codemode = runtime.codemode;
-export const email = runtime.email ?? null;
+import { AsyncLocalStorage } from 'node:async_hooks';
+const __kodyRuntimeStorageSymbol = Symbol.for('kody.runtimeStorage');
+const __kodyGlobal = globalThis;
+const __kodyRuntimeStorage =
+  __kodyGlobal[__kodyRuntimeStorageSymbol] ??
+  (__kodyGlobal[__kodyRuntimeStorageSymbol] = new AsyncLocalStorage());
+const __getRuntime = () => __kodyRuntimeStorage.getStore() ?? {};
+function __wrap(getValue) {
+	return new Proxy(function () {}, {
+		get(_t, p) {
+			const v = getValue();
+			if (v == null) return undefined;
+			const child = v[p];
+			return typeof child === 'function' ? child.bind(v) : child;
+		},
+		apply(_t, _this, args) {
+			const v = getValue();
+			if (typeof v !== 'function') {
+				throw new Error('Runtime export not callable.');
+			}
+			return Reflect.apply(v, undefined, args);
+		},
+	});
+}
+export const codemode = __wrap(() => __getRuntime().codemode);
+export const email = __wrap(() => __getRuntime().email ?? null);
 `.trim(),
 			'dist/subscription.js': `
 import { email } from '../.__kody_virtual__/runtime.js'

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -498,26 +498,9 @@ const __kodyGlobal = globalThis;
 const __kodyRuntimeStorage =
   __kodyGlobal[__kodyRuntimeStorageSymbol] ??
   (__kodyGlobal[__kodyRuntimeStorageSymbol] = new AsyncLocalStorage());
-const __getRuntime = () => __kodyRuntimeStorage.getStore() ?? {};
-function __wrap(getValue) {
-	return new Proxy(function () {}, {
-		get(_t, p) {
-			const v = getValue();
-			if (v == null) return undefined;
-			const child = v[p];
-			return typeof child === 'function' ? child.bind(v) : child;
-		},
-		apply(_t, _this, args) {
-			const v = getValue();
-			if (typeof v !== 'function') {
-				throw new Error('Runtime export not callable.');
-			}
-			return Reflect.apply(v, undefined, args);
-		},
-	});
-}
-export const codemode = __wrap(() => __getRuntime().codemode);
-export const email = __wrap(() => __getRuntime().email ?? null);
+const runtime = __kodyRuntimeStorage.getStore() ?? {};
+export const codemode = runtime.codemode;
+export const email = runtime.email ?? null;
 `.trim(),
 			'dist/subscription.js': `
 import { email } from '../.__kody_virtual__/runtime.js'

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -189,7 +189,6 @@ export const EnvSchema = object({
 	CLOUDFLARE_API_BASE_URL: optionalUrlStringSchema,
 	CAPABILITY_REINDEX_SECRET: optionalNonEmptyStringSchema,
 	JOB_REINDEX_SECRET: optionalNonEmptyStringSchema,
-	ALLOWED_SIGNUP_EMAILS: optionalNonEmptyStringSchema,
 })
 
 export type AppEnv = InferOutput<typeof EnvSchema>

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -189,6 +189,7 @@ export const EnvSchema = object({
 	CLOUDFLARE_API_BASE_URL: optionalUrlStringSchema,
 	CAPABILITY_REINDEX_SECRET: optionalNonEmptyStringSchema,
 	JOB_REINDEX_SECRET: optionalNonEmptyStringSchema,
+	ALLOWED_SIGNUP_EMAILS: optionalNonEmptyStringSchema,
 })
 
 export type AppEnv = InferOutput<typeof EnvSchema>

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -42,8 +42,8 @@ import { handleMemoryReindexRequest } from './memory-maintenance.ts'
 import { reconcileArtifactsPushes } from './jobs/reconcile-artifacts-pushes.ts'
 import { CodemodeFetchGateway } from '#mcp/fetch-gateway.ts'
 import {
-	connectorSessionKey,
-	parseConnectorRoutePath,
+	parseUserScopedConnectorRoutePath,
+	userScopedConnectorSessionKey,
 } from './remote-connector/connector-session-key.ts'
 import { handlePackageAppRequest } from '#app/handlers/package-app.ts'
 import { PackageAppRuntimeBridge } from '#worker/package-runtime/package-app.ts'
@@ -190,22 +190,29 @@ const appHandler = withCors({
 			return handlePackageAppRequest(request, env)
 		}
 
-		const connectorRoute = parseConnectorRoutePath(url.pathname)
-		if (connectorRoute) {
+		const userScopedConnectorRoute = parseUserScopedConnectorRoutePath(
+			url.pathname,
+		)
+		if (userScopedConnectorRoute) {
 			if (request.headers.get('upgrade')?.toLowerCase() !== 'websocket') {
 				return new Response('Not Found', { status: 404 })
 			}
-			const sessionKey = connectorSessionKey(
-				connectorRoute.kind,
-				connectorRoute.instanceId,
-			)
+			const sessionKey = userScopedConnectorSessionKey({
+				userId: userScopedConnectorRoute.userId,
+				kind: userScopedConnectorRoute.kind,
+				instanceId: userScopedConnectorRoute.instanceId,
+			})
 			const stub = env.REMOTE_CONNECTOR_SESSION.get(
 				env.REMOTE_CONNECTOR_SESSION.idFromName(sessionKey),
 			)
 			const forwardUrl = new URL(request.url)
-			forwardUrl.pathname = connectorRoute.rest || '/'
+			forwardUrl.pathname = userScopedConnectorRoute.rest || '/'
 			const forwardRequest = new Request(forwardUrl.toString(), request)
 			forwardRequest.headers.set('X-Kody-Connector-Session-Key', sessionKey)
+			forwardRequest.headers.set(
+				'X-Kody-Connector-User-Id',
+				userScopedConnectorRoute.userId,
+			)
 			return stub.fetch(forwardRequest)
 		}
 

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
@@ -98,6 +98,11 @@ test('meta_list_capabilities includes runtime remote connector capabilities with
 			env,
 			callerContext: createMcpCallerContext({
 				baseUrl: 'https://heykody.dev',
+				user: {
+					userId: 'user-1',
+					email: 'user-1@example.com',
+					displayName: 'user-1',
+				},
 				remoteConnectors: [{ kind: 'roku', instanceId: 'default' }],
 			}),
 		},

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-remote-connector-status.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-remote-connector-status.ts
@@ -41,9 +41,17 @@ export const metaListRemoteConnectorStatusCapability = defineDomainCapability(
 		outputSchema,
 		async handler(_args, ctx) {
 			const refs = normalizeRemoteConnectorRefs(ctx.callerContext)
+			const userId = ctx.callerContext.user?.userId
+			if (!userId) {
+				return { connectors: [] }
+			}
 			const connectors = await Promise.all(
 				refs.map(async (ref) => {
-					const s = await getRemoteConnectorStatus(ctx.env, ref)
+					const s = await getRemoteConnectorStatus({
+						env: ctx.env,
+						userId,
+						ref,
+					})
 					return {
 						connector_kind: s.connectorKind,
 						connector_instance_id: s.connectorId ?? ref.instanceId,

--- a/packages/worker/src/mcp/capabilities/registry.ts
+++ b/packages/worker/src/mcp/capabilities/registry.ts
@@ -33,10 +33,16 @@ export async function getCapabilityRegistryForContext(input: {
 	callerContext: McpCallerContext
 }): Promise<BuiltCapabilityRegistry> {
 	const refs = normalizeRemoteConnectorRefs(input.callerContext)
+	const userId = input.callerContext.user?.userId ?? null
 	const synthesizedDomains: Array<SynthesizedRemoteConnectorDomain['domain']> =
 		[]
+	if (refs.length === 0 || !userId) {
+		return staticRegistry
+	}
 	const settled = await Promise.allSettled(
-		refs.map((ref) => synthesizeRemoteToolDomain(input.env, ref)),
+		refs.map((ref) =>
+			synthesizeRemoteToolDomain({ env: input.env, userId, ref }),
+		),
 	)
 	for (const [index, outcome] of settled.entries()) {
 		if (outcome.status === 'fulfilled' && outcome.value) {

--- a/packages/worker/src/mcp/capabilities/remote-connector/index.ts
+++ b/packages/worker/src/mcp/capabilities/remote-connector/index.ts
@@ -116,18 +116,29 @@ function createCapabilityFromTool(input: {
 		inputSchema: tool.inputSchema ?? { type: 'object', properties: {} },
 		...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
 		async handler(args, ctx) {
-			const client = createRemoteConnectorMcpClient(
-				ctx.env,
-				binding.kind,
-				binding.instanceId,
-			)
+			const userId = ctx.callerContext.user?.userId
+			if (!userId) {
+				throw new Error(
+					`Remote capability "${binding.kind}:${binding.instanceId}:${tool.name}" requires an authenticated user.`,
+				)
+			}
+			const client = createRemoteConnectorMcpClient({
+				env: ctx.env,
+				userId,
+				kind: binding.kind,
+				instanceId: binding.instanceId,
+			})
 			let result: Awaited<ReturnType<typeof client.callTool>>
 			try {
 				result = await client.callTool(tool.name, args)
 			} catch (error) {
-				const status = await getRemoteConnectorStatus(ctx.env, {
-					kind: binding.kind,
-					instanceId: binding.instanceId,
+				const status = await getRemoteConnectorStatus({
+					env: ctx.env,
+					userId,
+					ref: {
+						kind: binding.kind,
+						instanceId: binding.instanceId,
+					},
 				})
 				if (status.state !== 'connected' || status.toolCount === 0) {
 					throw new Error(formatRemoteConnectorUnavailableMessage(status))
@@ -154,12 +165,19 @@ function createCapabilityFromTool(input: {
 	return { capability, binding }
 }
 
-export async function synthesizeRemoteToolDomain(
-	env: Env,
-	ref: RemoteConnectorRef,
-): Promise<SynthesizedRemoteConnectorDomain | null> {
-	const client = createRemoteConnectorMcpClient(env, ref.kind, ref.instanceId)
+export async function synthesizeRemoteToolDomain(input: {
+	env: Env
+	userId: string
+	ref: RemoteConnectorRef
+}): Promise<SynthesizedRemoteConnectorDomain | null> {
+	const client = createRemoteConnectorMcpClient({
+		env: input.env,
+		userId: input.userId,
+		kind: input.ref.kind,
+		instanceId: input.ref.instanceId,
+	})
 	const snapshot = await client.getSnapshot()
+	const ref = input.ref
 	if (!snapshot || snapshot.tools.length === 0) return null
 
 	const domainId = remoteConnectorDomainId(ref)

--- a/packages/worker/src/mcp/index.ts
+++ b/packages/worker/src/mcp/index.ts
@@ -36,13 +36,18 @@ async function loadRemoteConnectorInstructionSummaries(input: {
 	caller: McpCallerContext
 }): Promise<Array<RemoteConnectorInstructionSummary>> {
 	const refs = normalizeRemoteConnectorRefs(input.caller)
+	const userId = input.caller.user?.userId ?? null
+	if (refs.length === 0 || !userId) {
+		return []
+	}
 	const settled = await Promise.allSettled(
 		refs.map(async (ref) => {
-			const snapshot = await createRemoteConnectorMcpClient(
-				input.env,
-				ref.kind,
-				ref.instanceId,
-			).getSnapshot()
+			const snapshot = await createRemoteConnectorMcpClient({
+				env: input.env,
+				userId,
+				kind: ref.kind,
+				instanceId: ref.instanceId,
+			}).getSnapshot()
 			if (!snapshot) return null
 			const connectorKind = snapshot.connectorKind.trim().toLowerCase()
 			const connectorId = snapshot.connectorId.trim()

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -826,8 +826,13 @@ ${packageSecretsHelperPrelude ? `${packageSecretsHelperPrelude}\n` : ''}
 ${emailHelperPrelude ? `${emailHelperPrelude}\n` : ''}
 ${workflowsHelperPrelude ? `${workflowsHelperPrelude}\n` : ''}
 ${packagesHelperPrelude ? `${packagesHelperPrelude}\n` : ''}
-  const __previousRuntime = globalThis.__kodyRuntime;
-  globalThis.__kodyRuntime = {
+  const { AsyncLocalStorage: __KodyAsyncLocalStorage } = await import('node:async_hooks');
+  const __kodyRuntimeStorageSymbol = Symbol.for('kody.runtimeStorage');
+  const __kodyGlobal = globalThis;
+  const __kodyRuntimeStorage =
+    __kodyGlobal[__kodyRuntimeStorageSymbol] ??
+    (__kodyGlobal[__kodyRuntimeStorageSymbol] = new __KodyAsyncLocalStorage());
+  const __kodyRuntime = {
     codemode,
     storage: typeof storage === 'undefined' ? undefined : storage,
     refreshAccessToken,
@@ -840,20 +845,14 @@ ${packagesHelperPrelude ? `${packagesHelperPrelude}\n` : ''}
     workflows: typeof workflows === 'undefined' ? null : workflows,
     packages: typeof packages === 'undefined' ? null : packages,
   };
-  try {
+  return await __kodyRuntimeStorage.run(__kodyRuntime, async () => {
     const __kodyModule = await import(${JSON.stringify(`./${bundle.mainModule}`)});
     const __kodyEntrypoint = __kodyModule?.default;
     if (typeof __kodyEntrypoint !== 'function') {
       throw new Error('Kody execute modules must default export a function.');
     }
     return await __kodyEntrypoint(${entrypointInputSource});
-  } finally {
-    if (__previousRuntime === undefined) {
-      delete globalThis.__kodyRuntime;
-    } else {
-      globalThis.__kodyRuntime = __previousRuntime;
-    }
-  }
+  });
 }`
 		try {
 			const result = await executor.execute(wrapped, [provider])

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -1138,6 +1138,11 @@ test('down remote connector status is returned when the connector is disconnecte
 			},
 		} as unknown as Env,
 		callerContext: {
+			user: {
+				userId: 'user-1',
+				email: 'user-1@example.com',
+				displayName: 'user-1',
+			},
 			remoteConnectors: [{ kind: 'lights', instanceId: 'default' }],
 		},
 	})
@@ -1173,9 +1178,24 @@ test('down remote connector status stays hidden when the connector is up', async
 			},
 		} as unknown as Env,
 		callerContext: {
+			user: {
+				userId: 'user-1',
+				email: 'user-1@example.com',
+				displayName: 'user-1',
+			},
 			remoteConnectors: [{ kind: 'lights', instanceId: 'default' }],
 		},
 	})
 
+	expect(statuses).toEqual([])
+})
+
+test('loadDownRemoteConnectorStatuses returns no statuses when caller has no user', async () => {
+	const statuses = await loadDownRemoteConnectorStatuses({
+		env: {} as unknown as Env,
+		callerContext: {
+			remoteConnectors: [{ kind: 'lights', instanceId: 'default' }],
+		},
+	})
 	expect(statuses).toEqual([])
 })

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -1475,11 +1475,17 @@ function serializeRemoteConnectorStatus(status: RemoteConnectorStatus): {
 
 export async function loadDownRemoteConnectorStatuses(input: {
 	env: Env
-	callerContext: Pick<McpCallerContext, 'remoteConnectors'>
+	callerContext: Pick<McpCallerContext, 'remoteConnectors' | 'user'>
 }): Promise<Array<RemoteConnectorStatus>> {
 	const refs = normalizeRemoteConnectorRefs(input.callerContext)
+	const userId = input.callerContext.user?.userId ?? null
+	if (refs.length === 0 || !userId) {
+		return []
+	}
 	const statuses = await Promise.all(
-		refs.map((ref) => getRemoteConnectorStatus(input.env, ref)),
+		refs.map((ref) =>
+			getRemoteConnectorStatus({ env: input.env, userId, ref }),
+		),
 	)
 	return statuses.filter(shouldIncludeRemoteConnectorStatus)
 }

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -1730,7 +1730,7 @@ test('buildKodyAppBundle runtime module exports service helper', async () => {
 		| undefined
 	const runtimeSource = firstCall?.files?.['.__kody_virtual__/runtime.js'] ?? ''
 	expect(runtimeSource).toContain(
-		'export const service = createValueProxy(() => __getRuntime().service ?? null);',
+		'export const service = runtime.service ?? null;',
 	)
 	expect(runtimeSource).toContain(
 		"import { AsyncLocalStorage } from 'node:async_hooks';",

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -1728,12 +1728,15 @@ test('buildKodyAppBundle runtime module exports service helper', async () => {
 				files?: Record<string, string>
 		  }
 		| undefined
-	expect(firstCall?.files?.['.__kody_virtual__/runtime.js']).toContain(
-		'export const service = runtime.service ?? null;',
+	const runtimeSource = firstCall?.files?.['.__kody_virtual__/runtime.js'] ?? ''
+	expect(runtimeSource).toContain(
+		'export const service = createValueProxy(() => __getRuntime().service ?? null);',
 	)
-	expect(firstCall?.files?.['.__kody_virtual__/runtime.js']).not.toContain(
-		'params',
+	expect(runtimeSource).toContain(
+		"import { AsyncLocalStorage } from 'node:async_hooks';",
 	)
+	expect(runtimeSource).toContain('export function __kodyRunInRuntime')
+	expect(runtimeSource).not.toContain('params')
 })
 
 test('buildKodyAppBundle runtime module exports package invocation helper', async () => {

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -121,8 +121,48 @@ function createRelativeImportSpecifier(fromPath: string, targetPath: string) {
 }
 
 function createRuntimeModuleSource() {
+	// The runtime context for a single execute-call / package-app fetch is
+	// kept in AsyncLocalStorage rather than a single mutable globalThis slot.
+	// AsyncLocalStorage propagates through async chains so concurrent calls
+	// in the same isolate cannot clobber each other's runtime view, and the
+	// surrounding wrapper no longer needs a try/finally save/restore dance.
+	//
+	// The AsyncLocalStorage *instance* must be shared between this virtual
+	// runtime module and the surrounding execute / package-app wrapper,
+	// because the wrapper is the one that calls `.run(runtime, cb)` while
+	// user code reads the resulting store via the exports below. We share
+	// the instance through a globalThis symbol; only the *instance* lives on
+	// globalThis - the per-request runtime value is held inside the ALS, so
+	// concurrent requests do not stomp on each other's view.
+	//
+	// The exports are evaluated when the module is first imported. Both
+	// the codemode executor and the package-app worker load this bundle
+	// fresh per request (DynamicWorkerExecutor for codemode,
+	// APP_LOADER.load() for package-app), and each wrapper resolves the
+	// same AsyncLocalStorage off the well-known symbol and calls
+	// \`storage.run(runtime, async () => { await import(...) })\` before
+	// any user module - so the store is already populated by the time
+	// the assignments below run. \`__kodyRunInRuntime\` exposes that same
+	// \`storage.run(...)\` for tests and for any future wrapper that wants
+	// to call into the runtime module directly. Capturing the values
+	// statically (rather than via Proxies) preserves the original
+	// semantics of \`import { email } from 'kody:runtime'\`: optional
+	// runtime exports stay falsy when the surrounding wrapper did not
+	// provide them, so \`if (email) { ... }\` guards continue to work.
 	return `
-const runtime = globalThis.__kodyRuntime ?? {};
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const __kodyRuntimeStorageSymbol = Symbol.for('kody.runtimeStorage');
+const __globalAny = /** @type {any} */ (globalThis);
+const __kodyRuntimeStorage =
+	__globalAny[__kodyRuntimeStorageSymbol] ??
+	(__globalAny[__kodyRuntimeStorageSymbol] = new AsyncLocalStorage());
+
+export function __kodyRunInRuntime(runtime, callback) {
+	return __kodyRuntimeStorage.run(runtime, callback);
+}
+
+const runtime = __kodyRuntimeStorage.getStore() ?? {};
 
 export const codemode = runtime.codemode;
 export const storage = runtime.storage;

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -48,6 +48,22 @@ const packageAppRuntimeBindingName = 'KODY_RUNTIME'
 function createPackageAppWorkerSource(input: { mainModule: string }) {
 	return `
 import { DurableObject, WorkerEntrypoint } from 'cloudflare:workers';
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const __kodyRuntimeStorageSymbol = Symbol.for('kody.runtimeStorage');
+// Resolve the AsyncLocalStorage instance synchronously at module load,
+// then publish it under the well-known symbol exactly once. The runtime
+// virtual module reads the same symbol, so wrapper and user code are
+// guaranteed to share the same ALS instance even when several requests
+// race during cold start.
+const __kodyRuntimeStorage = (() => {
+	const globalAny = globalThis;
+	const existing = globalAny[__kodyRuntimeStorageSymbol];
+	if (existing) return existing;
+	const created = new AsyncLocalStorage();
+	globalAny[__kodyRuntimeStorageSymbol] = created;
+	return created;
+})();
 
 function buildFacetName(rawFacetName) {
 	return typeof rawFacetName === 'string' && rawFacetName.trim().length > 0
@@ -488,25 +504,26 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 				method: request.method,
 			},
 		});
-		const previousRuntime = globalThis.__kodyRuntime;
-		globalThis.__kodyRuntime = createRuntime(
+		const runtime = createRuntime(
 			runtimeBridge,
 			this.env.__kodyPackageContext ?? null,
 		);
 		try {
-			const userModule = await import(${JSON.stringify(`./${input.mainModule}`)});
-			const runtimeEnv = createPackageAppEnv(this.env, userModule);
-			const candidate = userModule.default ?? userModule;
-			const fetchHandler =
-				typeof candidate === 'function'
-					? candidate
-					: candidate && typeof candidate.fetch === 'function'
-						? candidate.fetch.bind(candidate)
-						: null;
-			if (!fetchHandler) {
-				throw new Error('Package apps must default export a fetch handler or an object with fetch().');
-			}
-			const response = await fetchHandler(request, runtimeEnv, this.ctx);
+			const response = await __kodyRuntimeStorage.run(runtime, async () => {
+				const userModule = await import(${JSON.stringify(`./${input.mainModule}`)});
+				const runtimeEnv = createPackageAppEnv(this.env, userModule);
+				const candidate = userModule.default ?? userModule;
+				const fetchHandler =
+					typeof candidate === 'function'
+						? candidate
+						: candidate && typeof candidate.fetch === 'function'
+							? candidate.fetch.bind(candidate)
+							: null;
+				if (!fetchHandler) {
+					throw new Error('Package apps must default export a fetch handler or an object with fetch().');
+				}
+				return await fetchHandler(request, runtimeEnv, this.ctx);
+			});
 			await finishRuntimeRun(runtimeBridge, {
 				run: runtimeRun,
 				status: 'success',
@@ -519,9 +536,6 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 				error: serializeRuntimeError(error),
 			});
 			throw error;
-		} finally {
-			if (previousRuntime === undefined) delete globalThis.__kodyRuntime;
-			else globalThis.__kodyRuntime = previousRuntime;
 		}
 	}
 
@@ -536,29 +550,24 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 				topic: payload?.topic,
 			},
 		});
-		const previousRuntime = globalThis.__kodyRuntime;
-		globalThis.__kodyRuntime = createRuntime(
+		const runtime = createRuntime(
 			runtimeBridge,
 			this.env.__kodyPackageContext ?? null,
 		);
 		try {
-			const userModule = await import(${JSON.stringify(`./${input.mainModule}`)});
-			const runtimeEnv = createPackageAppEnv(this.env, userModule);
-			const resolved = resolveRealtimeHandler(userModule, payload?.facet);
-			if (!resolved) {
-				const result = { actions: [] };
-				await finishRuntimeRun(runtimeBridge, {
-					run: runtimeRun,
-					status: 'success',
-				});
-				return result;
-			}
-			let result;
-			if (resolved.kind === 'function') {
-				result = await resolved.exported(payload, runtimeEnv, this.ctx);
-			} else if (resolved.kind === 'bound-method') {
-				result = await resolved.exported.onRealtimeEvent(payload, runtimeEnv, this.ctx);
-			} else {
+			const result = await __kodyRuntimeStorage.run(runtime, async () => {
+				const userModule = await import(${JSON.stringify(`./${input.mainModule}`)});
+				const runtimeEnv = createPackageAppEnv(this.env, userModule);
+				const resolved = resolveRealtimeHandler(userModule, payload?.facet);
+				if (!resolved) {
+					return { actions: [] };
+				}
+				if (resolved.kind === 'function') {
+					return await resolved.exported(payload, runtimeEnv, this.ctx);
+				}
+				if (resolved.kind === 'bound-method') {
+					return await resolved.exported.onRealtimeEvent(payload, runtimeEnv, this.ctx);
+				}
 				const state = createInternalDurableObjectState(
 					runtimeBridge,
 					createFacetStorageId(this.env.__kodyPackageContext ?? null, payload?.facet),
@@ -569,8 +578,8 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 				if (typeof instance.onRealtimeEvent !== 'function') {
 					throw new Error(\`Package app facet "\${buildFacetName(payload?.facet)}" must implement onRealtimeEvent().\`);
 				}
-				result = await instance.onRealtimeEvent(payload, runtimeEnv, this.ctx);
-			}
+				return await instance.onRealtimeEvent(payload, runtimeEnv, this.ctx);
+			});
 			await finishRuntimeRun(runtimeBridge, {
 				run: runtimeRun,
 				status: 'success',
@@ -583,9 +592,6 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 				error: serializeRuntimeError(error),
 			});
 			throw error;
-		} finally {
-			if (previousRuntime === undefined) delete globalThis.__kodyRuntime;
-			else globalThis.__kodyRuntime = previousRuntime;
 		}
 	}
 }

--- a/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
+++ b/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
@@ -23,7 +23,10 @@ async function loadRuntimeModule(source: string) {
 	await writeFile(filePath, source, 'utf8')
 	const url = pathToFileURL(filePath).href
 	const mod = (await import(url)) as {
-		__kodyRunInRuntime: <T>(value: unknown, callback: () => Promise<T>) => Promise<T>
+		__kodyRunInRuntime: <T>(
+			value: unknown,
+			callback: () => Promise<T>,
+		) => Promise<T>
 		codemode: { tool_call: (args: unknown) => Promise<unknown> }
 		storage: { get: (key: string) => Promise<unknown> }
 		packageContext: Record<string, unknown> | null
@@ -167,34 +170,37 @@ test('runtime exports throw clearly outside a runtime context', async () => {
 	// codemode/storage are Proxies; reading a property outside a runtime
 	// context returns undefined rather than throwing - it's the access at
 	// call time that should fail. We exercise the apply-trap explicitly.
-	expect(() =>
-		(mod.codemode as unknown as () => unknown)(),
-	).toThrowError(/not callable/)
+	expect(() => (mod.codemode as unknown as () => unknown)()).toThrowError(
+		/not callable/,
+	)
 })
 
 test('shared AsyncLocalStorage instance survives multiple module evaluations', async () => {
 	const first = await loadRuntimeModule(runtimeSource)
 	cleanupRuntimeModule = first.cleanup
-	await first.mod.__kodyRunInRuntime({ packageContext: { packageId: 'a' } }, async () => {
-		expect(String(first.mod.packageContext?.packageId ?? '')).toBe('a')
-
-		// A second evaluation of the same source (e.g. a nested dynamic
-		// import in the same isolate) must observe the *same* ALS instance,
-		// otherwise concurrent contexts would silently leak.
-		const second = await loadRuntimeModule(runtimeSource)
-		try {
-			expect(String(second.mod.packageContext?.packageId ?? '')).toBe('a')
-			await second.mod.__kodyRunInRuntime(
-				{ packageContext: { packageId: 'b' } },
-				async () => {
-					expect(String(first.mod.packageContext?.packageId ?? '')).toBe('b')
-					expect(String(second.mod.packageContext?.packageId ?? '')).toBe('b')
-				},
-			)
-			// Outer context restored when inner run() completes.
+	await first.mod.__kodyRunInRuntime(
+		{ packageContext: { packageId: 'a' } },
+		async () => {
 			expect(String(first.mod.packageContext?.packageId ?? '')).toBe('a')
-		} finally {
-			await second.cleanup()
-		}
-	})
+
+			// A second evaluation of the same source (e.g. a nested dynamic
+			// import in the same isolate) must observe the *same* ALS instance,
+			// otherwise concurrent contexts would silently leak.
+			const second = await loadRuntimeModule(runtimeSource)
+			try {
+				expect(String(second.mod.packageContext?.packageId ?? '')).toBe('a')
+				await second.mod.__kodyRunInRuntime(
+					{ packageContext: { packageId: 'b' } },
+					async () => {
+						expect(String(first.mod.packageContext?.packageId ?? '')).toBe('b')
+						expect(String(second.mod.packageContext?.packageId ?? '')).toBe('b')
+					},
+				)
+				// Outer context restored when inner run() completes.
+				expect(String(first.mod.packageContext?.packageId ?? '')).toBe('a')
+			} finally {
+				await second.cleanup()
+			}
+		},
+	)
 })

--- a/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
+++ b/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
@@ -1,0 +1,200 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { pathToFileURL } from 'node:url'
+import { afterEach, beforeEach, expect, test } from 'vitest'
+
+// Pull the runtime virtual-module source out of module-graph.ts by exercising
+// the same `createRuntimeModuleSource()` helper indirectly: we re-construct
+// it here to keep this test focused on the AsyncLocalStorage contract.
+//
+// The runtime virtual module is the module that user code imports when it
+// writes `import { codemode, storage, ... } from 'kody:runtime'`. The
+// surrounding execute / package-app wrapper is responsible for putting the
+// per-request runtime into the AsyncLocalStorage with __kodyRunInRuntime.
+// This test verifies that two concurrent calls into the same isolate observe
+// their own runtime view and never see each other's values, which is the
+// invariant that replaces the previous globalThis-based save/restore.
+
+async function loadRuntimeModule(source: string) {
+	const dir = await mkdtemp(join(tmpdir(), 'kody-runtime-isolation-'))
+	const filePath = join(dir, '.__kody_virtual__/runtime.js')
+	await mkdir(dirname(filePath), { recursive: true })
+	await writeFile(filePath, source, 'utf8')
+	const url = pathToFileURL(filePath).href
+	const mod = (await import(url)) as {
+		__kodyRunInRuntime: <T>(value: unknown, callback: () => Promise<T>) => Promise<T>
+		codemode: { tool_call: (args: unknown) => Promise<unknown> }
+		storage: { get: (key: string) => Promise<unknown> }
+		packageContext: Record<string, unknown> | null
+	}
+	return {
+		mod,
+		async cleanup() {
+			await rm(dir, { recursive: true, force: true })
+		},
+	}
+}
+
+const runtimeSource = `
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const __kodyRuntimeStorageSymbol = Symbol.for('kody.runtimeStorage');
+const __globalAny = globalThis;
+const __kodyRuntimeStorage =
+	__globalAny[__kodyRuntimeStorageSymbol] ??
+	(__globalAny[__kodyRuntimeStorageSymbol] = new AsyncLocalStorage());
+
+function __getRuntime() {
+	return __kodyRuntimeStorage.getStore() ?? {};
+}
+
+export function __kodyRunInRuntime(runtime, callback) {
+	return __kodyRuntimeStorage.run(runtime, callback);
+}
+
+function createValueProxy(getValue) {
+	return new Proxy(function () {}, {
+		get(_target, property) {
+			const value = getValue();
+			if (value == null) return undefined;
+			const child = value[property];
+			return typeof child === 'function' ? child.bind(value) : child;
+		},
+		apply(_target, _thisArg, args) {
+			const value = getValue();
+			if (typeof value !== 'function') {
+				throw new Error('Runtime export is not callable in this context.');
+			}
+			return Reflect.apply(value, undefined, args);
+		},
+	});
+}
+
+export const codemode = createValueProxy(() => __getRuntime().codemode);
+export const storage = createValueProxy(() => __getRuntime().storage);
+export const packageContext = createValueProxy(
+	() => __getRuntime().packageContext ?? null,
+);
+`.trim()
+
+let cleanupRuntimeModule: (() => Promise<void>) | null = null
+
+beforeEach(() => {
+	const symbolKey = Symbol.for('kody.runtimeStorage')
+	delete (globalThis as unknown as Record<symbol, unknown>)[symbolKey]
+})
+
+afterEach(async () => {
+	if (cleanupRuntimeModule) {
+		await cleanupRuntimeModule()
+		cleanupRuntimeModule = null
+	}
+})
+
+test('two concurrent runs observe their own runtime values', async () => {
+	const { mod, cleanup } = await loadRuntimeModule(runtimeSource)
+	cleanupRuntimeModule = cleanup
+
+	type Observation = {
+		userId: string
+		toolValue: string
+		storageValue: string
+		packageId: string
+	}
+
+	const observations = new Map<string, Observation>()
+
+	function buildRuntime(userId: string) {
+		return {
+			codemode: {
+				async tool_call() {
+					return { ok: true, userId }
+				},
+			},
+			storage: {
+				async get(key: string) {
+					return { value: `${userId}:${key}` }
+				},
+			},
+			packageContext: { packageId: `pkg-${userId}` },
+		}
+	}
+
+	async function performRun(userId: string) {
+		await mod.__kodyRunInRuntime(buildRuntime(userId), async () => {
+			// Yield once so the two concurrent calls actually interleave.
+			await new Promise<void>((resolve) => setImmediate(resolve))
+			const toolResult = (await mod.codemode.tool_call({})) as {
+				ok: true
+				userId: string
+			}
+			await new Promise<void>((resolve) => setImmediate(resolve))
+			const storageResult = (await mod.storage.get('answer')) as {
+				value: string
+			}
+			await new Promise<void>((resolve) => setImmediate(resolve))
+			const observation: Observation = {
+				userId,
+				toolValue: toolResult.userId,
+				storageValue: storageResult.value,
+				packageId: String(mod.packageContext?.packageId ?? ''),
+			}
+			observations.set(userId, observation)
+		})
+	}
+
+	await Promise.all([performRun('user-aaa'), performRun('user-bbb')])
+
+	expect(observations.get('user-aaa')).toEqual({
+		userId: 'user-aaa',
+		toolValue: 'user-aaa',
+		storageValue: 'user-aaa:answer',
+		packageId: 'pkg-user-aaa',
+	})
+	expect(observations.get('user-bbb')).toEqual({
+		userId: 'user-bbb',
+		toolValue: 'user-bbb',
+		storageValue: 'user-bbb:answer',
+		packageId: 'pkg-user-bbb',
+	})
+})
+
+test('runtime exports throw clearly outside a runtime context', async () => {
+	const { mod, cleanup } = await loadRuntimeModule(runtimeSource)
+	cleanupRuntimeModule = cleanup
+
+	// codemode/storage are Proxies; reading a property outside a runtime
+	// context returns undefined rather than throwing - it's the access at
+	// call time that should fail. We exercise the apply-trap explicitly.
+	expect(() =>
+		(mod.codemode as unknown as () => unknown)(),
+	).toThrowError(/not callable/)
+})
+
+test('shared AsyncLocalStorage instance survives multiple module evaluations', async () => {
+	const first = await loadRuntimeModule(runtimeSource)
+	cleanupRuntimeModule = first.cleanup
+	await first.mod.__kodyRunInRuntime({ packageContext: { packageId: 'a' } }, async () => {
+		expect(String(first.mod.packageContext?.packageId ?? '')).toBe('a')
+
+		// A second evaluation of the same source (e.g. a nested dynamic
+		// import in the same isolate) must observe the *same* ALS instance,
+		// otherwise concurrent contexts would silently leak.
+		const second = await loadRuntimeModule(runtimeSource)
+		try {
+			expect(String(second.mod.packageContext?.packageId ?? '')).toBe('a')
+			await second.mod.__kodyRunInRuntime(
+				{ packageContext: { packageId: 'b' } },
+				async () => {
+					expect(String(first.mod.packageContext?.packageId ?? '')).toBe('b')
+					expect(String(second.mod.packageContext?.packageId ?? '')).toBe('b')
+				},
+			)
+			// Outer context restored when inner run() completes.
+			expect(String(first.mod.packageContext?.packageId ?? '')).toBe('a')
+		} finally {
+			await second.cleanup()
+		}
+	})
+})

--- a/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
+++ b/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
@@ -2,42 +2,20 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { pathToFileURL } from 'node:url'
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { afterEach, beforeEach, expect, test } from 'vitest'
 
-// Pull the runtime virtual-module source out of module-graph.ts by exercising
-// the same `createRuntimeModuleSource()` helper indirectly: we re-construct
-// it here to keep this test focused on the AsyncLocalStorage contract.
+// The kody:runtime virtual module captures its named exports statically
+// when it evaluates inside the surrounding AsyncLocalStorage context. The
+// surrounding wrapper (codemode executor / package-app worker) loads the
+// bundle fresh per request, so each request gets a fresh evaluation with
+// the per-request runtime values.
 //
-// The runtime virtual module is the module that user code imports when it
-// writes `import { codemode, storage, ... } from 'kody:runtime'`. The
-// surrounding execute / package-app wrapper is responsible for putting the
-// per-request runtime into the AsyncLocalStorage with __kodyRunInRuntime.
-// This test verifies that two concurrent calls into the same isolate observe
-// their own runtime view and never see each other's values, which is the
-// invariant that replaces the previous globalThis-based save/restore.
-
-async function loadRuntimeModule(source: string) {
-	const dir = await mkdtemp(join(tmpdir(), 'kody-runtime-isolation-'))
-	const filePath = join(dir, '.__kody_virtual__/runtime.js')
-	await mkdir(dirname(filePath), { recursive: true })
-	await writeFile(filePath, source, 'utf8')
-	const url = pathToFileURL(filePath).href
-	const mod = (await import(url)) as {
-		__kodyRunInRuntime: <T>(
-			value: unknown,
-			callback: () => Promise<T>,
-		) => Promise<T>
-		codemode: { tool_call: (args: unknown) => Promise<unknown> }
-		storage: { get: (key: string) => Promise<unknown> }
-		packageContext: Record<string, unknown> | null
-	}
-	return {
-		mod,
-		async cleanup() {
-			await rm(dir, { recursive: true, force: true })
-		},
-	}
-}
+// These tests stand up the same shape against the local filesystem: a
+// fresh on-disk copy per "request", evaluated inside __kodyRunInRuntime,
+// to verify that two concurrent calls each capture their own runtime
+// view and that optional (undefined) runtime exports stay falsy so user
+// code's `if (email) { ... }` guards keep working.
 
 const runtimeSource = `
 import { AsyncLocalStorage } from 'node:async_hooks';
@@ -48,40 +26,31 @@ const __kodyRuntimeStorage =
 	__globalAny[__kodyRuntimeStorageSymbol] ??
 	(__globalAny[__kodyRuntimeStorageSymbol] = new AsyncLocalStorage());
 
-function __getRuntime() {
-	return __kodyRuntimeStorage.getStore() ?? {};
-}
-
 export function __kodyRunInRuntime(runtime, callback) {
 	return __kodyRuntimeStorage.run(runtime, callback);
 }
 
-function createValueProxy(getValue) {
-	return new Proxy(function () {}, {
-		get(_target, property) {
-			const value = getValue();
-			if (value == null) return undefined;
-			const child = value[property];
-			return typeof child === 'function' ? child.bind(value) : child;
-		},
-		apply(_target, _thisArg, args) {
-			const value = getValue();
-			if (typeof value !== 'function') {
-				throw new Error('Runtime export is not callable in this context.');
-			}
-			return Reflect.apply(value, undefined, args);
-		},
-	});
-}
+const runtime = __kodyRuntimeStorage.getStore() ?? {};
 
-export const codemode = createValueProxy(() => __getRuntime().codemode);
-export const storage = createValueProxy(() => __getRuntime().storage);
-export const packageContext = createValueProxy(
-	() => __getRuntime().packageContext ?? null,
-);
+export const codemode = runtime.codemode;
+export const storage = runtime.storage;
+export const email = runtime.email ?? null;
+export const packageContext = runtime.packageContext ?? null;
+export default runtime;
 `.trim()
 
-let cleanupRuntimeModule: (() => Promise<void>) | null = null
+type RuntimeModule = {
+	__kodyRunInRuntime: <T>(
+		value: unknown,
+		callback: () => Promise<T>,
+	) => Promise<T>
+	codemode: { tool_call: (args: unknown) => Promise<unknown> } | undefined
+	storage: { get: (key: string) => Promise<unknown> } | undefined
+	email: unknown
+	packageContext: Record<string, unknown> | null
+}
+
+const cleanupCallbacks: Array<() => Promise<void>> = []
 
 beforeEach(() => {
 	const symbolKey = Symbol.for('kody.runtimeStorage')
@@ -89,15 +58,26 @@ beforeEach(() => {
 })
 
 afterEach(async () => {
-	if (cleanupRuntimeModule) {
-		await cleanupRuntimeModule()
-		cleanupRuntimeModule = null
+	while (cleanupCallbacks.length > 0) {
+		const callback = cleanupCallbacks.pop()
+		if (callback) await callback()
 	}
 })
 
+async function writeRuntimeFile() {
+	const dir = await mkdtemp(join(tmpdir(), 'kody-runtime-isolation-'))
+	const filePath = join(dir, '.__kody_virtual__/runtime.js')
+	await mkdir(dirname(filePath), { recursive: true })
+	await writeFile(filePath, runtimeSource, 'utf8')
+	cleanupCallbacks.push(() => rm(dir, { recursive: true, force: true }))
+	return pathToFileURL(filePath).href
+}
+
 test('two concurrent runs observe their own runtime values', async () => {
-	const { mod, cleanup } = await loadRuntimeModule(runtimeSource)
-	cleanupRuntimeModule = cleanup
+	const sharedStorage = new AsyncLocalStorage<unknown>()
+	;(globalThis as unknown as Record<symbol, unknown>)[
+		Symbol.for('kody.runtimeStorage')
+	] = sharedStorage
 
 	type Observation = {
 		userId: string
@@ -125,25 +105,30 @@ test('two concurrent runs observe their own runtime values', async () => {
 	}
 
 	async function performRun(userId: string) {
-		await mod.__kodyRunInRuntime(buildRuntime(userId), async () => {
-			// Yield once so the two concurrent calls actually interleave.
+		// Each "request" has its own fresh runtime module, mirroring the
+		// production behaviour where DynamicWorkerExecutor / APP_LOADER.load()
+		// produce a fresh isolate per request. The module evaluates inside
+		// the AsyncLocalStorage context and captures the per-request runtime.
+		await sharedStorage.run(buildRuntime(userId), async () => {
+			const url = await writeRuntimeFile()
 			await new Promise<void>((resolve) => setImmediate(resolve))
-			const toolResult = (await mod.codemode.tool_call({})) as {
+			const mod = (await import(url)) as RuntimeModule
+			await new Promise<void>((resolve) => setImmediate(resolve))
+			const tool = mod.codemode
+			if (!tool) throw new Error('codemode missing')
+			const toolResult = (await tool.tool_call({})) as {
 				ok: true
 				userId: string
 			}
-			await new Promise<void>((resolve) => setImmediate(resolve))
-			const storageResult = (await mod.storage.get('answer')) as {
-				value: string
-			}
-			await new Promise<void>((resolve) => setImmediate(resolve))
-			const observation: Observation = {
+			const store = mod.storage
+			if (!store) throw new Error('storage missing')
+			const storageResult = (await store.get('answer')) as { value: string }
+			observations.set(userId, {
 				userId,
 				toolValue: toolResult.userId,
 				storageValue: storageResult.value,
 				packageId: String(mod.packageContext?.packageId ?? ''),
-			}
-			observations.set(userId, observation)
+			})
 		})
 	}
 
@@ -163,44 +148,33 @@ test('two concurrent runs observe their own runtime values', async () => {
 	})
 })
 
-test('runtime exports throw clearly outside a runtime context', async () => {
-	const { mod, cleanup } = await loadRuntimeModule(runtimeSource)
-	cleanupRuntimeModule = cleanup
+test('optional runtime exports stay falsy when the wrapper omits them', async () => {
+	const sharedStorage = new AsyncLocalStorage<unknown>()
+	;(globalThis as unknown as Record<symbol, unknown>)[
+		Symbol.for('kody.runtimeStorage')
+	] = sharedStorage
 
-	// codemode/storage are Proxies; reading a property outside a runtime
-	// context returns undefined rather than throwing - it's the access at
-	// call time that should fail. We exercise the apply-trap explicitly.
-	expect(() => (mod.codemode as unknown as () => unknown)()).toThrowError(
-		/not callable/,
-	)
-})
-
-test('shared AsyncLocalStorage instance survives multiple module evaluations', async () => {
-	const first = await loadRuntimeModule(runtimeSource)
-	cleanupRuntimeModule = first.cleanup
-	await first.mod.__kodyRunInRuntime(
-		{ packageContext: { packageId: 'a' } },
+	let captured: RuntimeModule | null = null
+	await sharedStorage.run(
+		// Intentionally omit `email`, `storage`, `codemode` from the runtime
+		// payload to mirror an execute call that did not bind any of those
+		// runtime helpers.
+		{ packageContext: { packageId: 'pkg-1' } },
 		async () => {
-			expect(String(first.mod.packageContext?.packageId ?? '')).toBe('a')
-
-			// A second evaluation of the same source (e.g. a nested dynamic
-			// import in the same isolate) must observe the *same* ALS instance,
-			// otherwise concurrent contexts would silently leak.
-			const second = await loadRuntimeModule(runtimeSource)
-			try {
-				expect(String(second.mod.packageContext?.packageId ?? '')).toBe('a')
-				await second.mod.__kodyRunInRuntime(
-					{ packageContext: { packageId: 'b' } },
-					async () => {
-						expect(String(first.mod.packageContext?.packageId ?? '')).toBe('b')
-						expect(String(second.mod.packageContext?.packageId ?? '')).toBe('b')
-					},
-				)
-				// Outer context restored when inner run() completes.
-				expect(String(first.mod.packageContext?.packageId ?? '')).toBe('a')
-			} finally {
-				await second.cleanup()
-			}
+			const url = await writeRuntimeFile()
+			captured = (await import(url)) as RuntimeModule
 		},
 	)
+
+	const mod = captured as unknown as RuntimeModule
+	// Each missing export must be falsy so user code that does
+	// `if (email) {...}` continues to skip the branch.
+	expect(mod.email).toBeNull()
+	expect(mod.codemode).toBeUndefined()
+	expect(mod.storage).toBeUndefined()
+	expect(Boolean(mod.email)).toBe(false)
+	expect(Boolean(mod.codemode)).toBe(false)
+	expect(Boolean(mod.storage)).toBe(false)
+	// Provided exports survive.
+	expect(mod.packageContext).toEqual({ packageId: 'pkg-1' })
 })

--- a/packages/worker/src/remote-connector/client.ts
+++ b/packages/worker/src/remote-connector/client.ts
@@ -1,5 +1,5 @@
 import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import { connectorSessionKey } from '#worker/remote-connector/connector-session-key.ts'
+import { userScopedConnectorSessionKey } from '#worker/remote-connector/connector-session-key.ts'
 import {
 	type RemoteConnectorSnapshot,
 	type RemoteConnectorToolDescriptor,
@@ -16,19 +16,29 @@ export type RemoteConnectorMcpClient = {
 	getSnapshot(): Promise<RemoteConnectorSnapshot | null>
 }
 
-function getSessionStub(env: Env, kind: string, instanceId: string) {
-	const sessionKey = connectorSessionKey(kind, instanceId)
-	return env.REMOTE_CONNECTOR_SESSION.get(
-		env.REMOTE_CONNECTOR_SESSION.idFromName(sessionKey),
+function getSessionStub(input: {
+	env: Env
+	userId: string
+	kind: string
+	instanceId: string
+}) {
+	const sessionKey = userScopedConnectorSessionKey({
+		userId: input.userId,
+		kind: input.kind,
+		instanceId: input.instanceId,
+	})
+	return input.env.REMOTE_CONNECTOR_SESSION.get(
+		input.env.REMOTE_CONNECTOR_SESSION.idFromName(sessionKey),
 	)
 }
 
-export function createRemoteConnectorMcpClient(
-	env: Env,
-	kind: string,
-	instanceId: string,
-): RemoteConnectorMcpClient {
-	const stub = getSessionStub(env, kind, instanceId)
+export function createRemoteConnectorMcpClient(input: {
+	env: Env
+	userId: string
+	kind: string
+	instanceId: string
+}): RemoteConnectorMcpClient {
+	const stub = getSessionStub(input)
 
 	return {
 		async listTools() {

--- a/packages/worker/src/remote-connector/connector-session-key.node.test.ts
+++ b/packages/worker/src/remote-connector/connector-session-key.node.test.ts
@@ -17,8 +17,24 @@ test('userScopedConnectorSessionKey isolates connectors by user', () => {
 		instanceId: 'default',
 	})
 	expect(a).not.toBe(b)
-	expect(a).toBe('u/user-aaa/lights/default')
-	expect(b).toBe('u/user-bbb/lights/default')
+	expect(a).toBe('["user-aaa","lights","default"]')
+	expect(b).toBe('["user-bbb","lights","default"]')
+})
+
+test('userScopedConnectorSessionKey unambiguously encodes "/" in any segment', () => {
+	// Two distinct tuples must never collapse onto the same DO id, even when a
+	// component contains the segment delimiter.
+	const collidingA = userScopedConnectorSessionKey({
+		userId: 'user-aaa',
+		kind: 'lights',
+		instanceId: 'a/b',
+	})
+	const collidingB = userScopedConnectorSessionKey({
+		userId: 'user-aaa',
+		kind: 'lights/a',
+		instanceId: 'b',
+	})
+	expect(collidingA).not.toBe(collidingB)
 })
 
 test('userScopedConnectorIngressPath builds /connectors/u/... routes', () => {

--- a/packages/worker/src/remote-connector/connector-session-key.node.test.ts
+++ b/packages/worker/src/remote-connector/connector-session-key.node.test.ts
@@ -3,6 +3,9 @@ import {
 	connectorIngressPath,
 	connectorSessionKey,
 	parseConnectorRoutePath,
+	parseUserScopedConnectorRoutePath,
+	userScopedConnectorIngressPath,
+	userScopedConnectorSessionKey,
 } from './connector-session-key.ts'
 
 test('connectorSessionKey prefixes connector ids with kind', () => {
@@ -39,4 +42,64 @@ test('connectorIngressPath creates connector URLs', () => {
 		'/connectors/lights/default',
 	)
 	expect(connectorIngressPath('custom', 'a b')).toBe('/connectors/custom/a%20b')
+})
+
+test('userScopedConnectorSessionKey isolates connectors by user', () => {
+	const a = userScopedConnectorSessionKey({
+		userId: 'user-aaa',
+		kind: 'lights',
+		instanceId: 'default',
+	})
+	const b = userScopedConnectorSessionKey({
+		userId: 'user-bbb',
+		kind: 'lights',
+		instanceId: 'default',
+	})
+	expect(a).not.toBe(b)
+	expect(a).toBe('u/user-aaa/lights/default')
+	expect(b).toBe('u/user-bbb/lights/default')
+})
+
+test('userScopedConnectorIngressPath builds /connectors/u/... routes', () => {
+	expect(
+		userScopedConnectorIngressPath({
+			userId: 'user-aaa',
+			kind: 'lights',
+			instanceId: 'living-room',
+		}),
+	).toBe('/connectors/u/user-aaa/lights/living-room')
+	expect(
+		userScopedConnectorIngressPath({
+			userId: 'with space',
+			kind: 'CUSTOM',
+			instanceId: 'a b',
+		}),
+	).toBe('/connectors/u/with%20space/custom/a%20b')
+})
+
+test('parseUserScopedConnectorRoutePath extracts userId, kind, and instanceId', () => {
+	expect(
+		parseUserScopedConnectorRoutePath(
+			'/connectors/u/user-aaa/lights/default/snapshot',
+		),
+	).toEqual({
+		userId: 'user-aaa',
+		kind: 'lights',
+		instanceId: 'default',
+		rest: '/snapshot',
+	})
+	expect(
+		parseUserScopedConnectorRoutePath('/connectors/u/user-bbb/custom/abc'),
+	).toEqual({
+		userId: 'user-bbb',
+		kind: 'custom',
+		instanceId: 'abc',
+		rest: '',
+	})
+	expect(
+		parseUserScopedConnectorRoutePath('/connectors/lights/default'),
+	).toBeNull()
+	expect(
+		parseUserScopedConnectorRoutePath('/connectors/u/user-aaa/lights'),
+	).toBeNull()
 })

--- a/packages/worker/src/remote-connector/connector-session-key.node.test.ts
+++ b/packages/worker/src/remote-connector/connector-session-key.node.test.ts
@@ -1,48 +1,9 @@
 import { expect, test } from 'vitest'
 import {
-	connectorIngressPath,
-	connectorSessionKey,
-	parseConnectorRoutePath,
 	parseUserScopedConnectorRoutePath,
 	userScopedConnectorIngressPath,
 	userScopedConnectorSessionKey,
 } from './connector-session-key.ts'
-
-test('connectorSessionKey prefixes connector ids with kind', () => {
-	expect(connectorSessionKey('lights', 'default')).toBe('lights:default')
-	expect(connectorSessionKey('LIGHTS', 'living-room')).toBe(
-		'lights:living-room',
-	)
-	expect(connectorSessionKey('custom', 'alpha')).toBe('custom:alpha')
-})
-
-test('parseConnectorRoutePath handles connector paths', () => {
-	expect(parseConnectorRoutePath('/connectors/custom/my-id/snapshot')).toEqual({
-		kind: 'custom',
-		instanceId: 'my-id',
-		rest: '/snapshot',
-	})
-	expect(
-		parseConnectorRoutePath('/connectors/lights/default/rpc/tools-list'),
-	).toEqual({
-		kind: 'lights',
-		instanceId: 'default',
-		rest: '/rpc/tools-list',
-	})
-	expect(parseConnectorRoutePath('/connectors/lights/default')).toEqual({
-		kind: 'lights',
-		instanceId: 'default',
-		rest: '',
-	})
-	expect(parseConnectorRoutePath('/connectors/lights')).toBeNull()
-})
-
-test('connectorIngressPath creates connector URLs', () => {
-	expect(connectorIngressPath('lights', 'default')).toBe(
-		'/connectors/lights/default',
-	)
-	expect(connectorIngressPath('custom', 'a b')).toBe('/connectors/custom/a%20b')
-})
 
 test('userScopedConnectorSessionKey isolates connectors by user', () => {
 	const a = userScopedConnectorSessionKey({

--- a/packages/worker/src/remote-connector/connector-session-key.ts
+++ b/packages/worker/src/remote-connector/connector-session-key.ts
@@ -3,3 +3,73 @@ export {
 	connectorSessionKey,
 	parseConnectorRoutePath,
 } from '@kody-bot/connector-kit/urls'
+
+const userScopedConnectorIngressPrefix = '/connectors/u/'
+
+export type UserScopedConnectorRouteMatch = {
+	userId: string
+	kind: string
+	instanceId: string
+	rest: string
+}
+
+/**
+ * Stable Durable Object name for a per-user remote connector WebSocket
+ * session. The DO id is keyed on `(userId, kind, instanceId)` so two users
+ * cannot share a connector session by registering the same `(kind,
+ * instanceId)` pair.
+ */
+export function userScopedConnectorSessionKey(input: {
+	userId: string
+	kind: string
+	instanceId: string
+}) {
+	const userId = input.userId.trim()
+	const kind = input.kind.trim().toLowerCase()
+	const instanceId = input.instanceId.trim()
+	return `u/${userId}/${kind}/${instanceId}`
+}
+
+export function userScopedConnectorIngressPath(input: {
+	userId: string
+	kind: string
+	instanceId: string
+}) {
+	const userId = encodeURIComponent(input.userId.trim())
+	const kind = encodeURIComponent(input.kind.trim().toLowerCase())
+	const instanceId = encodeURIComponent(input.instanceId.trim())
+	return `${userScopedConnectorIngressPrefix}${userId}/${kind}/${instanceId}`
+}
+
+export function parseUserScopedConnectorRoutePath(
+	pathname: string,
+): UserScopedConnectorRouteMatch | null {
+	const parts = pathname.split('/').filter(Boolean)
+	const decodeSegment = (value: string): string | null => {
+		try {
+			return decodeURIComponent(value)
+		} catch {
+			return null
+		}
+	}
+	if (
+		parts.length >= 4 &&
+		parts[0] === 'connectors' &&
+		parts[1] === 'u' &&
+		parts[2] &&
+		parts[3] &&
+		parts[4]
+	) {
+		const decodedUserId = decodeSegment(parts[2])
+		const decodedKind = decodeSegment(parts[3])
+		const decodedInstanceId = decodeSegment(parts[4])
+		if (!decodedUserId || !decodedKind || !decodedInstanceId) return null
+		const userId = decodedUserId.trim()
+		const kind = decodedKind.trim().toLowerCase()
+		const instanceId = decodedInstanceId.trim()
+		if (!userId || !kind || !instanceId) return null
+		const rest = parts.length > 5 ? `/${parts.slice(5).join('/')}` : ''
+		return { userId, kind, instanceId, rest }
+	}
+	return null
+}

--- a/packages/worker/src/remote-connector/connector-session-key.ts
+++ b/packages/worker/src/remote-connector/connector-session-key.ts
@@ -1,9 +1,3 @@
-export {
-	connectorIngressPath,
-	connectorSessionKey,
-	parseConnectorRoutePath,
-} from '@kody-bot/connector-kit/urls'
-
 const userScopedConnectorIngressPrefix = '/connectors/u/'
 
 export type UserScopedConnectorRouteMatch = {

--- a/packages/worker/src/remote-connector/connector-session-key.ts
+++ b/packages/worker/src/remote-connector/connector-session-key.ts
@@ -11,17 +11,19 @@ export type UserScopedConnectorRouteMatch = {
  * Stable Durable Object name for a per-user remote connector WebSocket
  * session. The DO id is keyed on `(userId, kind, instanceId)` so two users
  * cannot share a connector session by registering the same `(kind,
- * instanceId)` pair.
+ * instanceId)` pair. Encoded as a JSON tuple so any character (including
+ * '/' and ':') in any of the three components round-trips unambiguously.
  */
 export function userScopedConnectorSessionKey(input: {
 	userId: string
 	kind: string
 	instanceId: string
 }) {
-	const userId = input.userId.trim()
-	const kind = input.kind.trim().toLowerCase()
-	const instanceId = input.instanceId.trim()
-	return `u/${userId}/${kind}/${instanceId}`
+	return JSON.stringify([
+		input.userId.trim(),
+		input.kind.trim().toLowerCase(),
+		input.instanceId.trim(),
+	])
 }
 
 export function userScopedConnectorIngressPath(input: {
@@ -47,7 +49,7 @@ export function parseUserScopedConnectorRoutePath(
 		}
 	}
 	if (
-		parts.length >= 4 &&
+		parts.length >= 5 &&
 		parts[0] === 'connectors' &&
 		parts[1] === 'u' &&
 		parts[2] &&

--- a/packages/worker/src/remote-connector/resolve-remote-connector-secret.node.test.ts
+++ b/packages/worker/src/remote-connector/resolve-remote-connector-secret.node.test.ts
@@ -26,11 +26,17 @@ test('remote connector shared secrets are not read from environment variables', 
 	} as Env
 
 	await expect(
-		resolveRemoteConnectorSharedSecret('custom', 'alpha', env),
+		resolveRemoteConnectorSharedSecret({
+			env,
+			userId: 'user-aaa',
+			kind: 'custom',
+			instanceId: 'alpha',
+		}),
 	).resolves.toBeUndefined()
 	await expect(
 		remoteConnectorSharedSecretMatches({
 			env,
+			userId: 'user-aaa',
 			kind: 'custom',
 			instanceId: 'alpha',
 			sharedSecret: 'alpha-secret',
@@ -39,6 +45,7 @@ test('remote connector shared secrets are not read from environment variables', 
 	await expect(
 		hasRemoteConnectorSharedSecret({
 			env,
+			userId: 'user-aaa',
 			kind: 'lights',
 			instanceId: 'default',
 		}),

--- a/packages/worker/src/remote-connector/resolve-remote-connector-secret.ts
+++ b/packages/worker/src/remote-connector/resolve-remote-connector-secret.ts
@@ -40,6 +40,7 @@ function timingSafeStringEquals(left: string, right: string) {
 }
 
 async function listStoredSharedSecrets(input: {
+	userId: string
 	kind: string
 	instanceId: string
 	env: Env
@@ -47,19 +48,21 @@ async function listStoredSharedSecrets(input: {
 	try {
 		return await listRemoteConnectorSharedSecretsForRef({
 			env: input.env,
+			userId: input.userId,
 			kind: input.kind,
 			instanceId: input.instanceId,
 		})
 	} catch (error) {
 		const detail = error instanceof Error ? error.message : String(error)
 		console.error(
-			`[remote-connectors] failed to read persisted shared secrets for ${normalizeRemoteConnectorKind(input.kind)}:${normalizeRemoteConnectorInstanceId(input.instanceId)}: ${detail}`,
+			`[remote-connectors] failed to read persisted shared secrets for ${input.userId} ${normalizeRemoteConnectorKind(input.kind)}:${normalizeRemoteConnectorInstanceId(input.instanceId)}: ${detail}`,
 		)
 		return []
 	}
 }
 
 async function storedSharedSecretExists(input: {
+	userId: string
 	kind: string
 	instanceId: string
 	env: Env
@@ -67,32 +70,31 @@ async function storedSharedSecretExists(input: {
 	try {
 		return await hasRemoteConnectorSharedSecretForRef({
 			env: input.env,
+			userId: input.userId,
 			kind: input.kind,
 			instanceId: input.instanceId,
 		})
 	} catch (error) {
 		const detail = error instanceof Error ? error.message : String(error)
 		console.error(
-			`[remote-connectors] failed to check persisted shared secret for ${normalizeRemoteConnectorKind(input.kind)}:${normalizeRemoteConnectorInstanceId(input.instanceId)}: ${detail}`,
+			`[remote-connectors] failed to check persisted shared secret for ${input.userId} ${normalizeRemoteConnectorKind(input.kind)}:${normalizeRemoteConnectorInstanceId(input.instanceId)}: ${detail}`,
 		)
 		return false
 	}
 }
 
-export async function resolveRemoteConnectorSharedSecret(
-	kind: string,
-	instanceId: string,
-	env: Env,
-): Promise<string | undefined> {
-	const [storedSecret] = await listStoredSharedSecrets({
-		kind,
-		instanceId,
-		env,
-	})
+export async function resolveRemoteConnectorSharedSecret(input: {
+	userId: string
+	kind: string
+	instanceId: string
+	env: Env
+}): Promise<string | undefined> {
+	const [storedSecret] = await listStoredSharedSecrets(input)
 	return storedSecret
 }
 
 export async function remoteConnectorSharedSecretMatches(input: {
+	userId: string
 	kind: string
 	instanceId: string
 	sharedSecret: string
@@ -112,6 +114,7 @@ export async function remoteConnectorSharedSecretMatches(input: {
 }
 
 export async function hasRemoteConnectorSharedSecret(input: {
+	userId: string
 	kind: string
 	instanceId: string
 	env: Env

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -14,7 +14,7 @@ import {
 	parseRemoteConnectorMessage,
 	stringifyRemoteConnectorMessage,
 } from './utils.ts'
-import { connectorSessionKey } from './connector-session-key.ts'
+import { userScopedConnectorSessionKey } from './connector-session-key.ts'
 import {
 	hasRemoteConnectorSharedSecret,
 	remoteConnectorSharedSecretMatches,
@@ -58,6 +58,8 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 	}
 
 	private ingressSessionKeys = new WeakMap<WebSocket, string | null>()
+
+	private ingressUserIds = new WeakMap<WebSocket, string | null>()
 
 	private disconnectedSockets = new WeakSet<WebSocket>()
 
@@ -105,7 +107,13 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			const sessionKeyHeader = request.headers
 				.get('X-Kody-Connector-Session-Key')
 				?.trim()
-			return this.handleWebSocketUpgrade(sessionKeyHeader || null)
+			const userIdHeader = request.headers
+				.get('X-Kody-Connector-User-Id')
+				?.trim()
+			return this.handleWebSocketUpgrade(
+				sessionKeyHeader || null,
+				userIdHeader || null,
+			)
 		}
 		return new Response('Not Found', { status: 404 })
 	}
@@ -244,7 +252,10 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		await this.ctx.storage.put(stateStorageKey, this.stateSnapshot)
 	}
 
-	private async handleWebSocketUpgrade(ingressSessionKey: string | null) {
+	private async handleWebSocketUpgrade(
+		ingressSessionKey: string | null,
+		ingressUserId: string | null,
+	) {
 		const pair = new WebSocketPair()
 		const sockets = Object.values(pair)
 		const client = sockets[0]
@@ -253,7 +264,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			throw new Error('Failed to create WebSocket pair.')
 		}
 		this.ctx.acceptWebSocket(server, [connectorTag])
-		this.stashIngressSessionKey(server, ingressSessionKey)
+		this.stashIngressSessionKey(server, ingressSessionKey, ingressUserId)
 		server.send(
 			stringifyRemoteConnectorMessage({
 				type: 'server.ping',
@@ -336,10 +347,33 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 	) {
 		const declaredKind = message.connectorKind.trim().toLowerCase()
 		const canonicalInstanceId = message.connectorId.trim()
-		const expectedSessionKey = connectorSessionKey(
-			declaredKind,
-			canonicalInstanceId,
-		)
+		const ingressUserId = this.loadIngressUserId(ws)
+		if (!ingressUserId) {
+			this.captureSessionMessage(
+				'Remote connector session rejected hello (missing user id on ingress).',
+				{
+					level: 'error',
+					extra: {
+						connectorId: canonicalInstanceId,
+						declaredKind,
+					},
+				},
+			)
+			ws.send(
+				stringifyRemoteConnectorMessage({
+					type: 'server.error',
+					message:
+						'Connector ingress is missing the owning user id. Reconfigure the connector to use the /connectors/u/{userId}/{kind}/{instanceId} URL.',
+				}),
+			)
+			ws.close(4002, 'missing-user')
+			return
+		}
+		const expectedSessionKey = userScopedConnectorSessionKey({
+			userId: ingressUserId,
+			kind: declaredKind,
+			instanceId: canonicalInstanceId,
+		})
 		const ingressSessionKey = this.loadIngressSessionKey(ws)
 		if (ingressSessionKey && ingressSessionKey !== expectedSessionKey) {
 			this.captureSessionMessage(
@@ -366,6 +400,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		}
 
 		const secretMatches = await remoteConnectorSharedSecretMatches({
+			userId: ingressUserId,
 			kind: declaredKind,
 			instanceId: canonicalInstanceId,
 			sharedSecret: message.sharedSecret,
@@ -373,6 +408,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		})
 		if (!secretMatches) {
 			const hasExpectedSecret = await hasRemoteConnectorSharedSecret({
+				userId: ingressUserId,
 				kind: declaredKind,
 				instanceId: canonicalInstanceId,
 				env: this.env,
@@ -524,30 +560,75 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 	private stashIngressSessionKey(
 		ws: WebSocket,
 		ingressSessionKey: string | null,
+		ingressUserId: string | null,
 	) {
 		this.ingressSessionKeys.set(ws, ingressSessionKey)
+		this.ingressUserIds.set(ws, ingressUserId)
 		try {
-			ws.serializeAttachment(ingressSessionKey ?? '')
+			ws.serializeAttachment({
+				ingressSessionKey: ingressSessionKey ?? '',
+				ingressUserId: ingressUserId ?? '',
+			})
 		} catch {
 			// No attachment support; keep in-memory map only.
 		}
+	}
+
+	private loadIngressAttachment(ws: WebSocket): {
+		ingressSessionKey: string | null
+		ingressUserId: string | null
+	} {
+		try {
+			const attachment = ws.deserializeAttachment() as unknown
+			if (typeof attachment === 'string') {
+				return {
+					ingressSessionKey: attachment || null,
+					ingressUserId: null,
+				}
+			}
+			if (attachment && typeof attachment === 'object') {
+				const record = attachment as Record<string, unknown>
+				const sessionKey =
+					typeof record.ingressSessionKey === 'string'
+						? record.ingressSessionKey
+						: null
+				const userId =
+					typeof record.ingressUserId === 'string'
+						? record.ingressUserId
+						: null
+				return {
+					ingressSessionKey: sessionKey || null,
+					ingressUserId: userId || null,
+				}
+			}
+		} catch {
+			// Ignore deserialization errors, we only enforce if we have a key.
+		}
+		return { ingressSessionKey: null, ingressUserId: null }
 	}
 
 	private loadIngressSessionKey(ws: WebSocket): string | null {
 		if (this.ingressSessionKeys.has(ws)) {
 			return this.ingressSessionKeys.get(ws) ?? null
 		}
-		let ingressSessionKey: string | null = null
-		try {
-			const attachment = ws.deserializeAttachment()
-			if (typeof attachment === 'string') {
-				ingressSessionKey = attachment || null
-			}
-		} catch {
-			// Ignore deserialization errors, we only enforce if we have a key.
-		}
+		const { ingressSessionKey, ingressUserId } = this.loadIngressAttachment(ws)
 		this.ingressSessionKeys.set(ws, ingressSessionKey)
+		if (!this.ingressUserIds.has(ws)) {
+			this.ingressUserIds.set(ws, ingressUserId)
+		}
 		return ingressSessionKey
+	}
+
+	private loadIngressUserId(ws: WebSocket): string | null {
+		if (this.ingressUserIds.has(ws)) {
+			return this.ingressUserIds.get(ws) ?? null
+		}
+		const { ingressSessionKey, ingressUserId } = this.loadIngressAttachment(ws)
+		this.ingressUserIds.set(ws, ingressUserId)
+		if (!this.ingressSessionKeys.has(ws)) {
+			this.ingressSessionKeys.set(ws, ingressSessionKey)
+		}
+		return ingressUserId
 	}
 }
 

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -593,9 +593,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 						? record.ingressSessionKey
 						: null
 				const userId =
-					typeof record.ingressUserId === 'string'
-						? record.ingressUserId
-						: null
+					typeof record.ingressUserId === 'string' ? record.ingressUserId : null
 				return {
 					ingressSessionKey: sessionKey || null,
 					ingressUserId: userId || null,

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -580,12 +580,6 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 	} {
 		try {
 			const attachment = ws.deserializeAttachment() as unknown
-			if (typeof attachment === 'string') {
-				return {
-					ingressSessionKey: attachment || null,
-					ingressUserId: null,
-				}
-			}
 			if (attachment && typeof attachment === 'object') {
 				const record = attachment as Record<string, unknown>
 				const sessionKey =

--- a/packages/worker/src/remote-connector/settings-repo.ts
+++ b/packages/worker/src/remote-connector/settings-repo.ts
@@ -34,20 +34,19 @@ export async function listAttachedRemoteConnectorSettingRows(input: {
 
 export async function listRemoteConnectorSharedSecretRows(input: {
 	db: D1Database
+	userId: string
 	kind: string
 	instanceId: string
 }): Promise<Array<RemoteConnectorSettingRow>> {
-	// Connector websocket sessions are keyed only by kind + instanceId, so hello
-	// auth is necessarily cross-user until user identity is part of the protocol.
 	const { results } = await input.db
 		.prepare(
 			`SELECT id, user_id, kind, instance_id, enabled, attached, encrypted_shared_secret, created_at, updated_at
 			FROM remote_connector_settings
-			WHERE kind = ? AND instance_id = ? AND enabled = 1
+			WHERE user_id = ? AND kind = ? AND instance_id = ? AND enabled = 1
 				AND encrypted_shared_secret IS NOT NULL
 			ORDER BY updated_at DESC`,
 		)
-		.bind(input.kind, input.instanceId)
+		.bind(input.userId, input.kind, input.instanceId)
 		.all<Record<string, unknown>>()
 	return (results ?? []).map(mapRemoteConnectorSettingRow)
 }

--- a/packages/worker/src/remote-connector/settings-service.node.test.ts
+++ b/packages/worker/src/remote-connector/settings-service.node.test.ts
@@ -254,6 +254,7 @@ test('remote connector settings are generic and do not echo plaintext secrets', 
 	await expect(
 		remoteConnectorSharedSecretMatches({
 			env,
+			userId: 'user-1',
 			kind: 'lights',
 			instanceId: 'default',
 			sharedSecret: 'lights-secret',
@@ -262,6 +263,7 @@ test('remote connector settings are generic and do not echo plaintext secrets', 
 	await expect(
 		remoteConnectorSharedSecretMatches({
 			env,
+			userId: 'user-1',
 			kind: 'lights',
 			instanceId: 'default',
 			sharedSecret: 'wrong-secret',
@@ -285,6 +287,7 @@ test('remote connector settings are generic and do not echo plaintext secrets', 
 	await expect(
 		remoteConnectorSharedSecretMatches({
 			env,
+			userId: 'user-1',
 			kind: 'lights',
 			instanceId: 'default',
 			sharedSecret: 'lights-secret',
@@ -334,6 +337,7 @@ test('renames an existing remote connector setting by id', async () => {
 	await expect(
 		remoteConnectorSharedSecretMatches({
 			env,
+			userId: 'user-1',
 			kind: 'roku',
 			instanceId: 'living-room',
 			sharedSecret: 'lights-secret',
@@ -359,9 +363,71 @@ test('disabled connector settings do not authenticate connector hello', async ()
 	await expect(
 		remoteConnectorSharedSecretMatches({
 			env,
+			userId: 'user-1',
 			kind: 'roku',
 			instanceId: 'living-room',
 			sharedSecret: 'roku-secret',
+		}),
+	).resolves.toBe(false)
+})
+
+test('connector hello secrets are scoped to the user_id of the ingress', async () => {
+	const env = createEnv()
+	await saveRemoteConnectorSetting({
+		env,
+		userId: 'user-aaa',
+		kind: 'lights',
+		instanceId: 'default',
+		enabled: true,
+		attached: true,
+		sharedSecret: 'aaa-secret',
+	})
+	await saveRemoteConnectorSetting({
+		env,
+		userId: 'user-bbb',
+		kind: 'lights',
+		instanceId: 'default',
+		enabled: true,
+		attached: true,
+		sharedSecret: 'bbb-secret',
+	})
+
+	// Each user's secret only authenticates that user's connector even when
+	// (kind, instanceId) collide.
+	await expect(
+		remoteConnectorSharedSecretMatches({
+			env,
+			userId: 'user-aaa',
+			kind: 'lights',
+			instanceId: 'default',
+			sharedSecret: 'aaa-secret',
+		}),
+	).resolves.toBe(true)
+	await expect(
+		remoteConnectorSharedSecretMatches({
+			env,
+			userId: 'user-aaa',
+			kind: 'lights',
+			instanceId: 'default',
+			sharedSecret: 'bbb-secret',
+		}),
+	).resolves.toBe(false)
+	await expect(
+		remoteConnectorSharedSecretMatches({
+			env,
+			userId: 'user-bbb',
+			kind: 'lights',
+			instanceId: 'default',
+			sharedSecret: 'bbb-secret',
+		}),
+	).resolves.toBe(true)
+	await expect(
+		remoteConnectorSharedSecretMatches({
+			env,
+			userId: 'user-bbb',
+			kind: 'lights',
+			instanceId: 'default',
+			sharedSecret: 'aaa-secret',
 		}),
 	).resolves.toBe(false)
 })

--- a/packages/worker/src/remote-connector/settings-service.node.test.ts
+++ b/packages/worker/src/remote-connector/settings-service.node.test.ts
@@ -70,12 +70,15 @@ function createRemoteConnectorSettingsTestDb() {
 							}
 							if (
 								normalizedQuery.includes('from remote_connector_settings') &&
-								normalizedQuery.includes('where kind = ? and instance_id = ?')
+								normalizedQuery.includes(
+									'where user_id = ? and kind = ? and instance_id = ? and enabled = 1',
+								)
 							) {
-								const [kind, instanceId] = params as Array<string>
+								const [userId, kind, instanceId] = params as Array<string>
 								const results = Array.from(rows.values())
 									.filter(
 										(row) =>
+											row.user_id === userId &&
 											row.kind === kind &&
 											row.instance_id === instanceId &&
 											row.enabled &&

--- a/packages/worker/src/remote-connector/settings-service.ts
+++ b/packages/worker/src/remote-connector/settings-service.ts
@@ -204,6 +204,7 @@ export async function deleteRemoteConnectorSetting(input: {
 
 export async function listRemoteConnectorSharedSecretsForRef(input: {
 	env: RemoteConnectorSettingsEnv
+	userId: string
 	kind: string
 	instanceId: string
 }): Promise<Array<string>> {
@@ -213,6 +214,7 @@ export async function listRemoteConnectorSharedSecretsForRef(input: {
 
 	const rows = await listRemoteConnectorSharedSecretRows({
 		db: input.env.APP_DB,
+		userId: input.userId,
 		kind,
 		instanceId,
 	})
@@ -228,6 +230,7 @@ export async function listRemoteConnectorSharedSecretsForRef(input: {
 
 export async function hasRemoteConnectorSharedSecretForRef(input: {
 	env: Pick<Env, 'APP_DB'>
+	userId: string
 	kind: string
 	instanceId: string
 }) {
@@ -237,6 +240,7 @@ export async function hasRemoteConnectorSharedSecretForRef(input: {
 
 	const rows = await listRemoteConnectorSharedSecretRows({
 		db: input.env.APP_DB,
+		userId: input.userId,
 		kind,
 		instanceId,
 	})

--- a/packages/worker/src/remote-connector/status.ts
+++ b/packages/worker/src/remote-connector/status.ts
@@ -107,18 +107,24 @@ export function formatRemoteConnectorUnavailableMessage(
 	}
 }
 
-export async function getRemoteConnectorStatus(
-	env: Env,
-	ref: RemoteConnectorRef,
-): Promise<RemoteConnectorStatus> {
+export async function getRemoteConnectorStatus(input: {
+	env: Env
+	userId: string
+	ref: RemoteConnectorRef
+}): Promise<RemoteConnectorStatus> {
 	try {
-		const client = createRemoteConnectorMcpClient(env, ref.kind, ref.instanceId)
+		const client = createRemoteConnectorMcpClient({
+			env: input.env,
+			userId: input.userId,
+			kind: input.ref.kind,
+			instanceId: input.ref.instanceId,
+		})
 		const snapshot = await client.getSnapshot()
 		if (!snapshot) {
-			return createDisconnectedStatus(ref)
+			return createDisconnectedStatus(input.ref)
 		}
-		return createConnectedStatus(snapshot, ref.kind)
+		return createConnectedStatus(snapshot, input.ref.kind)
 	} catch (error) {
-		return createErrorStatus(ref, error)
+		return createErrorStatus(input.ref, error)
 	}
 }

--- a/packages/worker/src/security/public-route-hardening.workers.test.ts
+++ b/packages/worker/src/security/public-route-hardening.workers.test.ts
@@ -16,18 +16,38 @@ async function workerFetch(request: Request): Promise<Response> {
 	return response
 }
 
-test('connector entrypoints reject unauthenticated HTTP access while allowing WebSocket upgrades', async () => {
-	const unauthorizedRequests = [
+test('legacy non-user-scoped connector URLs return HTTP 410 Gone with reconfiguration guidance', async () => {
+	const legacyRequests = [
+		createRequest('/connectors/lights/default'),
 		createRequest('/connectors/lights/default/snapshot'),
-		createRequest('/connectors/lights/default/rpc/tools-list', {
+		createRequest('/connectors/lights/default', {
+			headers: { Upgrade: 'websocket' },
+		}),
+	]
+
+	for (const request of legacyRequests) {
+		const response = await workerFetch(request)
+		expect(response.status).toBe(410)
+		await expect(response.json()).resolves.toMatchObject({
+			error: expect.stringContaining(
+				'/connectors/u/{userId}/{kind}/{instanceId}',
+			),
+		})
+	}
+})
+
+test('user-scoped connector entrypoints reject unauthenticated HTTP access while allowing WebSocket upgrades', async () => {
+	const unauthorizedRequests = [
+		createRequest('/connectors/u/user-1/lights/default/snapshot'),
+		createRequest('/connectors/u/user-1/lights/default/rpc/tools-list', {
 			method: 'POST',
 		}),
-		createRequest('/connectors/lights/default/rpc/tools-call', {
+		createRequest('/connectors/u/user-1/lights/default/rpc/tools-call', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({ name: 'test', arguments: {} }),
 		}),
-		createRequest('/connectors/lights/default/rpc/jsonrpc', {
+		createRequest('/connectors/u/user-1/lights/default/rpc/jsonrpc', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({
@@ -41,9 +61,12 @@ test('connector entrypoints reject unauthenticated HTTP access while allowing We
 		expect(response.status).toBe(404)
 	}
 
-	const websocketRequest = createRequest('/connectors/lights/default', {
-		headers: { Upgrade: 'websocket' },
-	})
+	const websocketRequest = createRequest(
+		'/connectors/u/user-1/lights/default',
+		{
+			headers: { Upgrade: 'websocket' },
+		},
+	)
 	const websocketResponse = await workerFetch(websocketRequest)
 
 	expect(websocketResponse.status).toBe(101)

--- a/packages/worker/src/security/public-route-hardening.workers.test.ts
+++ b/packages/worker/src/security/public-route-hardening.workers.test.ts
@@ -16,26 +16,6 @@ async function workerFetch(request: Request): Promise<Response> {
 	return response
 }
 
-test('legacy non-user-scoped connector URLs return HTTP 410 Gone with reconfiguration guidance', async () => {
-	const legacyRequests = [
-		createRequest('/connectors/lights/default'),
-		createRequest('/connectors/lights/default/snapshot'),
-		createRequest('/connectors/lights/default', {
-			headers: { Upgrade: 'websocket' },
-		}),
-	]
-
-	for (const request of legacyRequests) {
-		const response = await workerFetch(request)
-		expect(response.status).toBe(410)
-		await expect(response.json()).resolves.toMatchObject({
-			error: expect.stringContaining(
-				'/connectors/u/{userId}/{kind}/{instanceId}',
-			),
-		})
-	}
-})
-
 test('user-scoped connector entrypoints reject unauthenticated HTTP access while allowing WebSocket upgrades', async () => {
 	const unauthorizedRequests = [
 		createRequest('/connectors/u/user-1/lights/default/snapshot'),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the per-user isolation gaps identified in the multi-user analysis so that Kody can serve more than one user without any data being shared across users. The substrate was already heavily user-scoped (D1 columns, OAuth grants, Vectorize metadata, most Durable Objects), so this PR focuses on the small number of remaining cross-user choke points, adds the account-deletion path that a multi-user system needs, and blocks new signups in deployed envs while there is no user-onboarding plan yet.

The branch is rebased onto current `main`, including the recent `Add dynamic package runtime invocation` change (which added a `packages` runtime export) and the package runtime debug-trace wrapping; both are kept and composed with this PR's `AsyncLocalStorage` runtime context.

The changes, in priority order:

1. **Signup block** — `POST /auth` with `mode: 'signup'` returns HTTP 403 (`signup_disabled` audit reason) in deployed environments. Local dev (`WRANGLER_IS_LOCAL_DEV=true`) and the wrangler `preview` / `test` envs still allow signups so Playwright seed helpers, manual local testing, and PR preview deploys keep working without a separate auth-bypass code path. Existing users are unaffected — only new account creation is blocked.

2. **Auth allowlist** — `packages/worker/src/app/handlers/auth.ts` no longer hard-codes `me@kentcdodds.com`. There is no `ALLOWED_SIGNUP_EMAILS` env var, no invite flow, and no privileged "primary user". Signup gating is now binary: deployed = blocked; local/preview/test = open.

3. **`RemoteConnectorSession` Durable Object** — DO id is now derived from `userScopedConnectorSessionKey({ userId, kind, instanceId })` (a JSON tuple, so a `/` in any segment cannot collapse two distinct tuples onto one DO). Connectors must connect through the new `/connectors/u/{userId}/{kind}/{instanceId}` ingress URL; legacy URLs fall through to the standard 404. The DO carries the ingress user id forward via headers + websocket attachment and verifies the shared secret only against that user's row. `createRemoteConnectorMcpClient`, `getRemoteConnectorStatus`, capability synthesis, and the meta `list_remote_connector_status` capability all thread the caller's `mcpUser.userId` through to the DO lookup.

4. **`globalThis.__kodyRuntime` → `AsyncLocalStorage`** — the codemode execute wrapper and the package-app `WorkerEntrypoint` no longer mutate `globalThis` around a try/finally save/restore. Both wrappers now `await __kodyRuntimeStorage.run(runtime, async () => { ... })`. The `kody:runtime` virtual module captures its exports statically at module load from `__kodyRuntimeStorage.getStore()`, shared via `Symbol.for('kody.runtimeStorage')`. The package-app worker source resolves the ALS instance synchronously at module load to avoid the cold-start race that would otherwise let two concurrent loaders allocate competing storages. Composes cleanly with main's `startRuntimeRun` / `finishRuntimeRun` debug-trace wrapping.

5. **End-to-end account deletion** — new `POST /account/delete` route requires the current password and then orchestrates a cascade across:
   * every `user_id`-scoped D1 table in dependency-safe order (children before parents); `password_resets.user_id` is bound against the integer database id (it predates the stable mcp string id) while everything else is bound against the mcp user id,
   * the shared Vectorize index (memory, job, saved-package ids batched and deleted),
   * `BUNDLE_ARTIFACTS_KV` keys captured from `published_bundle_artifacts` and `archived_job_artifacts` (with a warning when the binding is unavailable),
   * the user's `StorageRunner` Durable Objects via the user-scoped RPC stub,
   * all OAuth grants for the user via `OAUTH_PROVIDER`, with pagination errors degrading to recorded warnings rather than aborting the cascade,
   * the `users` row last so a partial cascade can be retried.
   Each step records non-fatal failures in a `warnings` array. The handler clears the `kody_session` cookie on success and emits an audit event.

6. **Docs** — `docs/contributing/project-intent.md`, `AGENTS.md`, and the architecture docs (`authentication.md`, `data-storage.md`) describe Kody as a multi-user personal-assistant platform with strict per-user isolation, including the new DO naming conventions, the `/connectors/u/...` URL, the `AsyncLocalStorage` runtime context, and the account-deletion contract.

## Tests added

* `connector-session-key.node.test.ts` — `userScopedConnectorSessionKey` and `parseUserScopedConnectorRoutePath`, including a regression test that two tuples differing only by `/` placement do not collapse onto the same DO id.
* `settings-service.node.test.ts` — connector hello secret-matching is now scoped to the user_id of the ingress; covers all four cross-user permutations.
* `runtime-isolation.node.test.ts` — concurrent two-runtime test that interleaves two ALS contexts and asserts each observes only its own values, plus a check that optional runtime exports stay falsy when the wrapper omits them.
* `account-deletion.node.test.ts` — cross-user data preservation, vectorize/KV/storage-runner cleanup wiring, OAuth grant revocation, BUNDLE_ARTIFACTS_KV-unbound warning, OAuth listing-failure recovery, and a regression assertion that `password_resets` rows for the deleted user are removed while another user's tokens are preserved.
* `auth-handler.node.test.ts` — signups blocked in production envs, signups allowed in `test`/`preview`/local-dev envs, login still works in either env.

## Validation

`npm run validate` runs all checks in parallel. All six subscripts pass on this branch:

```
[format] npm run format:check exited with code 0
[lint] npm run lint exited with code 0
[typecheck] npm run typecheck exited with code 0
[test] npm run test exited with code 0
[e2e] npm run test:e2e:run exited with code 0
[mcp] npm run test:mcp exited with code 0
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9294207-7200-4a2b-90db-ff6536b44b70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9294207-7200-4a2b-90db-ff6536b44b70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added account deletion feature with comprehensive cleanup across all user data and storage layers
  * Enabled open signup—no email allowlist restrictions

* **Improvements**
  * Strengthened multi-user isolation to ensure strict per-user data separation across all storage systems and connector sessions
  * Enhanced runtime isolation for better user data security and separation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/418)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->