### PR TITLE
Add package runtime debug traces

### DIFF
--- a/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
+++ b/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
@@ -201,7 +201,9 @@ test('buildCodemodeCapabilityExecuteCode runs the intended capability with the o
 		},
 	})
 
-	await expect(new Script(`(${code})()`).runInContext(context)).resolves.toBe('ok')
+	await expect(new Script(`(${code})()`).runInContext(context)).resolves.toBe(
+		'ok',
+	)
 	expect(calls).toEqual([
 		{
 			capability: 'value_set',

--- a/packages/worker/migrations/0037-package-runtime-debug.sql
+++ b/packages/worker/migrations/0037-package-runtime-debug.sql
@@ -1,0 +1,68 @@
+CREATE TABLE IF NOT EXISTS package_runtime_runs (
+	id TEXT PRIMARY KEY,
+	user_id TEXT NOT NULL,
+	package_id TEXT NOT NULL,
+	package_kody_id TEXT NOT NULL,
+	source_id TEXT,
+	published_commit TEXT,
+	surface TEXT NOT NULL CHECK (
+		surface IN (
+			'export',
+			'subscription',
+			'app_fetch',
+			'app_realtime',
+			'service',
+			'job',
+			'workflow',
+			'retriever'
+		)
+	),
+	name TEXT,
+	status TEXT NOT NULL CHECK (status IN ('running', 'success', 'error')),
+	started_at TEXT NOT NULL,
+	finished_at TEXT,
+	duration_ms INTEGER,
+	error_name TEXT,
+	error_message TEXT,
+	storage_id TEXT,
+	job_id TEXT,
+	workflow_id TEXT,
+	invocation_id TEXT,
+	session_id TEXT,
+	idempotency_key TEXT,
+	parent_run_id TEXT,
+	metadata_json TEXT NOT NULL DEFAULT '{}',
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_package_runtime_runs_user_started
+ON package_runtime_runs(user_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_package_runtime_runs_package_started
+ON package_runtime_runs(user_id, package_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_package_runtime_runs_surface_started
+ON package_runtime_runs(user_id, surface, started_at DESC);
+
+CREATE TABLE IF NOT EXISTS package_runtime_logs (
+	id TEXT PRIMARY KEY,
+	run_id TEXT NOT NULL,
+	user_id TEXT NOT NULL,
+	package_id TEXT NOT NULL,
+	timestamp TEXT NOT NULL,
+	sequence INTEGER NOT NULL,
+	level TEXT NOT NULL CHECK (level IN ('debug', 'info', 'log', 'warn', 'error')),
+	message TEXT NOT NULL,
+	fields_json TEXT,
+	created_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_package_runtime_logs_run_sequence
+ON package_runtime_logs(run_id, sequence);
+
+CREATE INDEX IF NOT EXISTS idx_package_runtime_logs_run
+ON package_runtime_logs(run_id, timestamp, sequence);
+
+CREATE INDEX IF NOT EXISTS idx_package_runtime_logs_user_package_created
+ON package_runtime_logs(user_id, package_id, created_at DESC);

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -458,7 +458,8 @@ async function executePublishedJobArtifact(input: {
 						kodyId: input.artifact.packageContext.kodyId,
 						sourceId:
 							input.artifact.packageContext.sourceId ?? input.job.sourceId,
-						publishedCommit: source?.published_commit ?? input.job.publishedCommit,
+						publishedCommit:
+							source?.published_commit ?? input.job.publishedCommit,
 						surface: 'job',
 						name: input.job.name,
 						storageId: input.job.storageId,

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -452,6 +452,19 @@ async function executePublishedJobArtifact(input: {
 			...(input.artifact.packageContext
 				? { packageContext: input.artifact.packageContext }
 				: {}),
+			runtimeDebug: input.artifact.packageContext
+				? {
+						packageId: input.artifact.packageContext.packageId,
+						kodyId: input.artifact.packageContext.kodyId,
+						sourceId:
+							input.artifact.packageContext.sourceId ?? input.job.sourceId,
+						publishedCommit: source?.published_commit ?? input.job.publishedCommit,
+						surface: 'job',
+						name: input.job.name,
+						storageId: input.job.storageId,
+						jobId: input.job.id,
+					}
+				: null,
 		},
 	).then((result) => ({
 		...result,

--- a/packages/worker/src/mcp/capabilities/packages/domain.ts
+++ b/packages/worker/src/mcp/capabilities/packages/domain.ts
@@ -5,6 +5,8 @@ import { getGitRemoteCapability } from './get-git-remote.ts'
 import { getPackageCapability } from './get-package.ts'
 import { listPackagesCapability } from './list-packages.ts'
 import { listPackageSubscriptionsCapability } from './list-package-subscriptions.ts'
+import { packageDebugGetRunCapability } from './package-debug-get-run.ts'
+import { packageDebugListRunsCapability } from './package-debug-list-runs.ts'
 import { publishExternalPushCapability } from './publish-external-push.ts'
 import { savePackageCapability } from './save-package.ts'
 
@@ -19,6 +21,8 @@ export const packagesDomain = defineDomain({
 		getGitRemoteCapability,
 		listPackagesCapability,
 		listPackageSubscriptionsCapability,
+		packageDebugListRunsCapability,
+		packageDebugGetRunCapability,
 		publishExternalPushCapability,
 		deletePackageCapability,
 	],

--- a/packages/worker/src/mcp/capabilities/packages/package-debug-get-run.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-debug-get-run.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { getPackageRuntimeRun } from '#worker/package-runtime/package-runtime-debug.ts'
+import {
+	formatPackageRuntimeLog,
+	formatPackageRuntimeRun,
+	packageRuntimeLogSchema,
+	packageRuntimeRunSchema,
+} from './package-debug-shared.ts'
+
+const inputSchema = z.object({
+	run_id: z.string().min(1),
+})
+
+const outputSchema = z.object({
+	run: packageRuntimeRunSchema,
+	logs: z.array(packageRuntimeLogSchema),
+})
+
+export const packageDebugGetRunCapability = defineDomainCapability(
+	capabilityDomainNames.packages,
+	{
+		name: 'package_debug_get_run',
+		description:
+			'Load a retained package runtime run with its captured logs and normalized error details.',
+		keywords: ['package', 'debug', 'logs', 'run', 'trace', 'error'],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const result = await getPackageRuntimeRun({
+				env: ctx.env,
+				userId: user.userId,
+				runId: args.run_id,
+			})
+			if (!result) {
+				throw new Error(`Package runtime run "${args.run_id}" was not found.`)
+			}
+			return {
+				run: formatPackageRuntimeRun(result.run),
+				logs: result.logs.map(formatPackageRuntimeLog),
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/packages/package-debug-list-runs.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-debug-list-runs.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { listPackageRuntimeRuns } from '#worker/package-runtime/package-runtime-debug.ts'
+import {
+	formatPackageRuntimeRun,
+	packageRuntimeRunSchema,
+	packageRuntimeSurfaceSchema,
+} from './package-debug-shared.ts'
+
+const inputSchema = z.object({
+	package_id: z.string().min(1).optional(),
+	surface: packageRuntimeSurfaceSchema.optional(),
+	limit: z.number().int().positive().max(100).optional(),
+})
+
+const outputSchema = z.object({
+	runs: z.array(packageRuntimeRunSchema),
+})
+
+export const packageDebugListRunsCapability = defineDomainCapability(
+	capabilityDomainNames.packages,
+	{
+		name: 'package_debug_list_runs',
+		description:
+			'List recent retained runtime runs for live package exports, apps, services, jobs, workflows, subscriptions, and retrievers.',
+		keywords: [
+			'package',
+			'debug',
+			'logs',
+			'runs',
+			'observability',
+			'trace',
+		],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const packageId =
+				args.package_id ?? ctx.callerContext.storageContext?.appId ?? null
+			const runs = await listPackageRuntimeRuns({
+				env: ctx.env,
+				userId: user.userId,
+				packageId,
+				surface: args.surface ?? null,
+				limit: args.limit ?? 25,
+			})
+			return {
+				runs: runs.map(formatPackageRuntimeRun),
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/packages/package-debug-list-runs.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-debug-list-runs.ts
@@ -25,14 +25,7 @@ export const packageDebugListRunsCapability = defineDomainCapability(
 		name: 'package_debug_list_runs',
 		description:
 			'List recent retained runtime runs for live package exports, apps, services, jobs, workflows, subscriptions, and retrievers.',
-		keywords: [
-			'package',
-			'debug',
-			'logs',
-			'runs',
-			'observability',
-			'trace',
-		],
+		keywords: ['package', 'debug', 'logs', 'runs', 'observability', 'trace'],
 		readOnly: true,
 		idempotent: true,
 		destructive: false,

--- a/packages/worker/src/mcp/capabilities/packages/package-debug-shared.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-debug-shared.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod'
+import {
+	type PackageRuntimeLogRecord,
+	type PackageRuntimeRunRecord,
+	packageRuntimeLogLevelValues,
+	packageRuntimeStatusValues,
+	packageRuntimeSurfaceValues,
+} from '#worker/package-runtime/package-runtime-debug.ts'
+
+export const packageRuntimeSurfaceSchema = z.enum(packageRuntimeSurfaceValues)
+
+export const packageRuntimeRunSchema = z.object({
+	id: z.string(),
+	user_id: z.string(),
+	package_id: z.string(),
+	kody_id: z.string(),
+	source_id: z.string().nullable(),
+	published_commit: z.string().nullable(),
+	surface: packageRuntimeSurfaceSchema,
+	name: z.string().nullable(),
+	status: z.enum(packageRuntimeStatusValues),
+	started_at: z.string(),
+	finished_at: z.string().nullable(),
+	duration_ms: z.number().int().nonnegative().nullable(),
+	error_name: z.string().nullable(),
+	error_message: z.string().nullable(),
+	storage_id: z.string().nullable(),
+	job_id: z.string().nullable(),
+	workflow_id: z.string().nullable(),
+	invocation_id: z.string().nullable(),
+	session_id: z.string().nullable(),
+	idempotency_key: z.string().nullable(),
+	parent_run_id: z.string().nullable(),
+	metadata: z.record(z.string(), z.unknown()),
+	created_at: z.string(),
+	updated_at: z.string(),
+})
+
+export const packageRuntimeLogSchema = z.object({
+	id: z.string(),
+	run_id: z.string(),
+	user_id: z.string(),
+	package_id: z.string(),
+	timestamp: z.string(),
+	sequence: z.number().int().nonnegative(),
+	level: z.enum(packageRuntimeLogLevelValues),
+	message: z.string(),
+	fields: z.record(z.string(), z.unknown()).nullable(),
+	created_at: z.string(),
+})
+
+export function formatPackageRuntimeRun(
+	run: PackageRuntimeRunRecord,
+): z.infer<typeof packageRuntimeRunSchema> {
+	return {
+		id: run.id,
+		user_id: run.userId,
+		package_id: run.packageId,
+		kody_id: run.kodyId,
+		source_id: run.sourceId,
+		published_commit: run.publishedCommit,
+		surface: run.surface,
+		name: run.name,
+		status: run.status,
+		started_at: run.startedAt,
+		finished_at: run.finishedAt,
+		duration_ms: run.durationMs,
+		error_name: run.errorName,
+		error_message: run.errorMessage,
+		storage_id: run.storageId,
+		job_id: run.jobId,
+		workflow_id: run.workflowId,
+		invocation_id: run.invocationId,
+		session_id: run.sessionId,
+		idempotency_key: run.idempotencyKey,
+		parent_run_id: run.parentRunId,
+		metadata: run.metadata,
+		created_at: run.createdAt,
+		updated_at: run.updatedAt,
+	}
+}
+
+export function formatPackageRuntimeLog(
+	log: PackageRuntimeLogRecord,
+): z.infer<typeof packageRuntimeLogSchema> {
+	return {
+		id: log.id,
+		run_id: log.runId,
+		user_id: log.userId,
+		package_id: log.packageId,
+		timestamp: log.timestamp,
+		sequence: log.sequence,
+		level: log.level,
+		message: log.message,
+		fields: log.fields,
+		created_at: log.createdAt,
+	}
+}

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -667,6 +667,16 @@ export async function runModuleWithRegistry(
 	)
 }
 
+async function finishPackageRuntimeRunBestEffort(
+	input: Parameters<typeof finishPackageRuntimeRun>[0],
+) {
+	try {
+		await finishPackageRuntimeRun(input)
+	} catch (error) {
+		console.warn('package-runtime-debug-finish-unhandled', error)
+	}
+}
+
 export async function runBundledModuleWithRegistry(
 	env: Env,
 	callerContext: McpCallerContext,
@@ -809,7 +819,7 @@ ${workflowsHelperPrelude ? `${workflowsHelperPrelude}\n` : ''}
 			const result = await executor.execute(wrapped, [provider])
 			const sanitizedResult = secretRedactor.sanitizeExecuteResult(result)
 			if (!result.error) {
-				await finishPackageRuntimeRun({
+				await finishPackageRuntimeRunBestEffort({
 					env,
 					handle: runtimeDebugRun,
 					status: 'success',
@@ -829,7 +839,7 @@ ${workflowsHelperPrelude ? `${workflowsHelperPrelude}\n` : ''}
 						error: secretRedactor.redactErrorMessage(batchMessage),
 					}
 				: sanitizedResult
-			await finishPackageRuntimeRun({
+			await finishPackageRuntimeRunBestEffort({
 				env,
 				handle: runtimeDebugRun,
 				status: 'error',
@@ -852,7 +862,7 @@ ${workflowsHelperPrelude ? `${workflowsHelperPrelude}\n` : ''}
 		}
 	} catch (error) {
 		if (!runtimeDebugFinished) {
-			await finishPackageRuntimeRun({
+			await finishPackageRuntimeRunBestEffort({
 				env,
 				handle: runtimeDebugRun,
 				status: 'error',

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -604,45 +604,18 @@ ${helperPrelude ? `${helperPrelude}\n` : ''}
   const __kodyUserCode = (${normalized});
   return await __kodyUserCode();
 }`
-	try {
-		const result = await executor.execute(wrapped, [provider])
-		const sanitizedResult = secretRedactor.sanitizeExecuteResult(result)
-		if (!result.error) {
-			await finishPackageRuntimeRun({
-				env,
-				handle: runtimeDebugRun,
-				status: 'success',
-				logs: sanitizedResult.logs ?? [],
-			})
-			return sanitizedResult
-		}
-		const batchMessage = await rewriteCapabilitySecretError({
-			error: result.error,
-			env,
-			callerContext,
-		})
-		const finalResult = batchMessage
-			? {
-					...sanitizedResult,
-					error: secretRedactor.redactErrorMessage(batchMessage),
-				}
-			: sanitizedResult
-		await finishPackageRuntimeRun({
-			env,
-			handle: runtimeDebugRun,
-			status: 'error',
-			logs: finalResult.logs ?? [],
-			error: finalResult.error,
-		})
-		return finalResult
-	} catch (error) {
-		await finishPackageRuntimeRun({
-			env,
-			handle: runtimeDebugRun,
-			status: 'error',
-			error,
-		})
-		throw error
+	const result = await executor.execute(wrapped, [provider])
+	const sanitizedResult = secretRedactor.sanitizeExecuteResult(result)
+	if (!result.error) return sanitizedResult
+	const batchMessage = await rewriteCapabilitySecretError({
+		error: result.error,
+		env,
+		callerContext,
+	})
+	if (!batchMessage) return sanitizedResult
+	return {
+		...sanitizedResult,
+		error: secretRedactor.redactErrorMessage(batchMessage),
 	}
 }
 
@@ -728,7 +701,8 @@ export async function runBundledModuleWithRegistry(
 				storageId:
 					options.runtimeDebug.storageId ??
 					options.storageTools?.storageId ??
-					normalizedStorageContext.storageId,
+					normalizedStorageContext?.storageId ??
+					null,
 			}
 		: null
 	const runtimeDebugRun = await beginPackageRuntimeRun({
@@ -829,18 +803,45 @@ ${workflowsHelperPrelude ? `${workflowsHelperPrelude}\n` : ''}
     }
   }
 }`
-	const result = await executor.execute(wrapped, [provider])
-	const sanitizedResult = secretRedactor.sanitizeExecuteResult(result)
-	if (!result.error) return sanitizedResult
-	const batchMessage = await rewriteCapabilitySecretError({
-		error: result.error,
-		env,
-		callerContext,
-	})
-	if (!batchMessage) return sanitizedResult
-	return {
-		...sanitizedResult,
-		error: secretRedactor.redactErrorMessage(batchMessage),
+	try {
+		const result = await executor.execute(wrapped, [provider])
+		const sanitizedResult = secretRedactor.sanitizeExecuteResult(result)
+		if (!result.error) {
+			await finishPackageRuntimeRun({
+				env,
+				handle: runtimeDebugRun,
+				status: 'success',
+				logs: sanitizedResult.logs ?? [],
+			})
+			return sanitizedResult
+		}
+		const batchMessage = await rewriteCapabilitySecretError({
+			error: result.error,
+			env,
+			callerContext,
+		})
+		const finalResult = batchMessage
+			? {
+					...sanitizedResult,
+					error: secretRedactor.redactErrorMessage(batchMessage),
+				}
+			: sanitizedResult
+		await finishPackageRuntimeRun({
+			env,
+			handle: runtimeDebugRun,
+			status: 'error',
+			logs: finalResult.logs ?? [],
+			error: finalResult.error,
+		})
+		return finalResult
+	} catch (error) {
+		await finishPackageRuntimeRun({
+			env,
+			handle: runtimeDebugRun,
+			status: 'error',
+			error,
+		})
+		throw error
 	}
 }
 async function rewriteCapabilitySecretError(input: {

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -850,7 +850,7 @@ ${workflowsHelperPrelude ? `${workflowsHelperPrelude}\n` : ''}
 			return finalResult
 		} catch (error) {
 			if (!runtimeDebugFinished) {
-				await finishPackageRuntimeRun({
+				await finishPackageRuntimeRunBestEffort({
 					env,
 					handle: runtimeDebugRun,
 					status: 'error',

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -1,4 +1,5 @@
 import {
+	normalizeCode,
 	resolveProvider,
 	type ExecuteResult,
 	type ResolvedProvider,
@@ -6,6 +7,7 @@ import {
 } from '@cloudflare/codemode'
 import { exports as workerExports } from 'cloudflare:workers'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { createExecuteExecutor } from '#mcp/executor.ts'
 import {
 	getAdditionalPropertiesSchema,
 	getArrayItemSchema,
@@ -32,6 +34,11 @@ import {
 	stripCodeFences,
 } from '#worker/module-source.ts'
 import { buildKodyModuleBundle } from '#worker/package-runtime/module-graph.ts'
+import {
+	beginPackageRuntimeRun,
+	finishPackageRuntimeRun,
+	type PackageRuntimeDebugContext,
+} from '#worker/package-runtime/package-runtime-debug.ts'
 import {
 	createDynamicCallableWorkflow,
 	type PackageWorkflowCreateInput,
@@ -521,8 +528,6 @@ export async function runCodemodeWithRegistry(
 			executorTimeoutMs: options?.executorTimeoutMs,
 		})
 	}
-	const { createExecuteExecutor } = await import('#mcp/executor.ts')
-	const { normalizeCode } = await import('@cloudflare/codemode')
 	const secretRedactor = createExecutionSecretRedactor()
 	const normalizedStorageContext = normalizeStorageContext(
 		callerContext.storageContext ?? null,
@@ -599,18 +604,45 @@ ${helperPrelude ? `${helperPrelude}\n` : ''}
   const __kodyUserCode = (${normalized});
   return await __kodyUserCode();
 }`
-	const result = await executor.execute(wrapped, [provider])
-	const sanitizedResult = secretRedactor.sanitizeExecuteResult(result)
-	if (!result.error) return sanitizedResult
-	const batchMessage = await rewriteCapabilitySecretError({
-		error: result.error,
-		env,
-		callerContext,
-	})
-	if (!batchMessage) return sanitizedResult
-	return {
-		...sanitizedResult,
-		error: secretRedactor.redactErrorMessage(batchMessage),
+	try {
+		const result = await executor.execute(wrapped, [provider])
+		const sanitizedResult = secretRedactor.sanitizeExecuteResult(result)
+		if (!result.error) {
+			await finishPackageRuntimeRun({
+				env,
+				handle: runtimeDebugRun,
+				status: 'success',
+				logs: sanitizedResult.logs ?? [],
+			})
+			return sanitizedResult
+		}
+		const batchMessage = await rewriteCapabilitySecretError({
+			error: result.error,
+			env,
+			callerContext,
+		})
+		const finalResult = batchMessage
+			? {
+					...sanitizedResult,
+					error: secretRedactor.redactErrorMessage(batchMessage),
+				}
+			: sanitizedResult
+		await finishPackageRuntimeRun({
+			env,
+			handle: runtimeDebugRun,
+			status: 'error',
+			logs: finalResult.logs ?? [],
+			error: finalResult.error,
+		})
+		return finalResult
+	} catch (error) {
+		await finishPackageRuntimeRun({
+			env,
+			handle: runtimeDebugRun,
+			status: 'error',
+			error,
+		})
+		throw error
 	}
 }
 
@@ -683,13 +715,27 @@ export async function runBundledModuleWithRegistry(
 		workflowTools?: PackageWorkflowTools
 		skipCapabilityRegistry?: boolean
 		executorTimeoutMs?: number | null
+		runtimeDebug?: PackageRuntimeDebugContext | null
 	},
 ): Promise<ExecuteResult> {
-	const { createExecuteExecutor } = await import('#mcp/executor.ts')
 	const secretRedactor = createExecutionSecretRedactor()
 	const normalizedStorageContext = normalizeStorageContext(
 		callerContext.storageContext ?? null,
 	)
+	const runtimeDebugContext = options?.runtimeDebug
+		? {
+				...options.runtimeDebug,
+				storageId:
+					options.runtimeDebug.storageId ??
+					options.storageTools?.storageId ??
+					normalizedStorageContext.storageId,
+			}
+		: null
+	const runtimeDebugRun = await beginPackageRuntimeRun({
+		env,
+		userId: callerContext.user?.userId ?? null,
+		context: runtimeDebugContext,
+	})
 	const executor = createExecuteExecutor({
 		env,
 		exports: options?.executorExports ?? workerExports,

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -710,64 +710,66 @@ export async function runBundledModuleWithRegistry(
 		userId: callerContext.user?.userId ?? null,
 		context: runtimeDebugContext,
 	})
-	const executor = createExecuteExecutor({
-		env,
-		exports: options?.executorExports ?? workerExports,
-		timeoutMs: options?.executorTimeoutMs,
-		gatewayProps: {
-			baseUrl: callerContext.baseUrl,
-			userId: callerContext.user?.userId ?? null,
-			storageContext: normalizedStorageContext,
-		},
-		modules: bundle.modules,
-	})
-	const workflowTools =
-		options?.workflowTools ??
-		createWorkflowTools({
+	let runtimeDebugFinished = false
+	try {
+		const executor = createExecuteExecutor({
 			env,
-			callerContext,
-			packageContext: options?.packageContext ?? null,
+			exports: options?.executorExports ?? workerExports,
+			timeoutMs: options?.executorTimeoutMs,
+			gatewayProps: {
+				baseUrl: callerContext.baseUrl,
+				userId: callerContext.user?.userId ?? null,
+				storageContext: normalizedStorageContext,
+			},
+			modules: bundle.modules,
 		})
-	const provider = await buildCodemodeProvider(env, callerContext, {
-		trackSecretInputValue: (value) => {
-			secretRedactor.track(value)
-		},
-		additionalTools: options?.additionalTools,
-		storageTools: options?.storageTools,
-		serviceTools: options?.serviceTools,
-		packageSecretTools: options?.packageContext
-			? createPackageSecretTools({
-					env,
-					callerContext,
-					packageId: options.packageContext.packageId,
-				})
-			: undefined,
-		emailTools: options?.emailTools,
-		workflowTools,
-		skipCapabilityRegistry: options?.skipCapabilityRegistry,
-	})
-	const storageHelperPrelude = options?.storageTools
-		? createStorageHelperPrelude({
-				storageId: options.storageTools.storageId,
-				writable: options.storageTools.writable,
+		const workflowTools =
+			options?.workflowTools ??
+			createWorkflowTools({
+				env,
+				callerContext,
+				packageContext: options?.packageContext ?? null,
 			})
-		: ''
-	const serviceHelperPrelude = options?.serviceTools
-		? createServiceHelperPrelude()
-		: ''
-	const packageSecretsHelperPrelude = options?.packageContext
-		? createPackageSecretsHelperPrelude()
-		: ''
-	const emailHelperPrelude = options?.emailTools
-		? createEmailHelperPrelude()
-		: ''
-	const workflowsHelperPrelude = workflowTools
-		? createWorkflowsHelperPrelude()
-		: ''
-	const entrypointInputJson = JSON.stringify(params)
-	const entrypointInputSource =
-		entrypointInputJson === undefined ? 'undefined' : entrypointInputJson
-	const wrapped = `async () => {
+		const provider = await buildCodemodeProvider(env, callerContext, {
+			trackSecretInputValue: (value) => {
+				secretRedactor.track(value)
+			},
+			additionalTools: options?.additionalTools,
+			storageTools: options?.storageTools,
+			serviceTools: options?.serviceTools,
+			packageSecretTools: options?.packageContext
+				? createPackageSecretTools({
+						env,
+						callerContext,
+						packageId: options.packageContext.packageId,
+					})
+				: undefined,
+			emailTools: options?.emailTools,
+			workflowTools,
+			skipCapabilityRegistry: options?.skipCapabilityRegistry,
+		})
+		const storageHelperPrelude = options?.storageTools
+			? createStorageHelperPrelude({
+					storageId: options.storageTools.storageId,
+					writable: options.storageTools.writable,
+				})
+			: ''
+		const serviceHelperPrelude = options?.serviceTools
+			? createServiceHelperPrelude()
+			: ''
+		const packageSecretsHelperPrelude = options?.packageContext
+			? createPackageSecretsHelperPrelude()
+			: ''
+		const emailHelperPrelude = options?.emailTools
+			? createEmailHelperPrelude()
+			: ''
+		const workflowsHelperPrelude = workflowTools
+			? createWorkflowsHelperPrelude()
+			: ''
+		const entrypointInputJson = JSON.stringify(params)
+		const entrypointInputSource =
+			entrypointInputJson === undefined ? 'undefined' : entrypointInputJson
+		const wrapped = `async () => {
 ${createExecuteHelperPrelude()}
 ${storageHelperPrelude ? `${storageHelperPrelude}\n` : ''}
 ${serviceHelperPrelude ? `${serviceHelperPrelude}\n` : ''}
@@ -803,44 +805,60 @@ ${workflowsHelperPrelude ? `${workflowsHelperPrelude}\n` : ''}
     }
   }
 }`
-	try {
-		const result = await executor.execute(wrapped, [provider])
-		const sanitizedResult = secretRedactor.sanitizeExecuteResult(result)
-		if (!result.error) {
+		try {
+			const result = await executor.execute(wrapped, [provider])
+			const sanitizedResult = secretRedactor.sanitizeExecuteResult(result)
+			if (!result.error) {
+				await finishPackageRuntimeRun({
+					env,
+					handle: runtimeDebugRun,
+					status: 'success',
+					logs: sanitizedResult.logs ?? [],
+				})
+				runtimeDebugFinished = true
+				return sanitizedResult
+			}
+			const batchMessage = await rewriteCapabilitySecretError({
+				error: result.error,
+				env,
+				callerContext,
+			})
+			const finalResult = batchMessage
+				? {
+						...sanitizedResult,
+						error: secretRedactor.redactErrorMessage(batchMessage),
+					}
+				: sanitizedResult
 			await finishPackageRuntimeRun({
 				env,
 				handle: runtimeDebugRun,
-				status: 'success',
-				logs: sanitizedResult.logs ?? [],
+				status: 'error',
+				logs: finalResult.logs ?? [],
+				error: finalResult.error,
 			})
-			return sanitizedResult
+			runtimeDebugFinished = true
+			return finalResult
+		} catch (error) {
+			if (!runtimeDebugFinished) {
+				await finishPackageRuntimeRun({
+					env,
+					handle: runtimeDebugRun,
+					status: 'error',
+					error,
+				})
+				runtimeDebugFinished = true
+			}
+			throw error
 		}
-		const batchMessage = await rewriteCapabilitySecretError({
-			error: result.error,
-			env,
-			callerContext,
-		})
-		const finalResult = batchMessage
-			? {
-					...sanitizedResult,
-					error: secretRedactor.redactErrorMessage(batchMessage),
-				}
-			: sanitizedResult
-		await finishPackageRuntimeRun({
-			env,
-			handle: runtimeDebugRun,
-			status: 'error',
-			logs: finalResult.logs ?? [],
-			error: finalResult.error,
-		})
-		return finalResult
 	} catch (error) {
-		await finishPackageRuntimeRun({
-			env,
-			handle: runtimeDebugRun,
-			status: 'error',
-			error,
-		})
+		if (!runtimeDebugFinished) {
+			await finishPackageRuntimeRun({
+				env,
+				handle: runtimeDebugRun,
+				status: 'error',
+				error,
+			})
+		}
 		throw error
 	}
 }

--- a/packages/worker/src/mcp/server-instructions.node.test.ts
+++ b/packages/worker/src/mcp/server-instructions.node.test.ts
@@ -32,7 +32,9 @@ test('surfaces remote connector identifiers and compacts long descriptions', () 
 
 	expect(shortConnectorLine).toContain('`home/default` (`remote:home:default`)')
 	expect(shortConnectorLine).toContain(shortDescription)
-	expect(longConnectorLine).toContain('`tools/default` (`remote:tools:default`)')
+	expect(longConnectorLine).toContain(
+		'`tools/default` (`remote:tools:default`)',
+	)
 	expect(longConnectorLine).toContain('...')
 	expect(longConnectorLine).not.toContain(longDescription)
 	expect(longConnectorDescription.length).toBeLessThanOrEqual(240)

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -3,6 +3,7 @@ import { toHex } from '@kody-internal/shared/hex.ts'
 import { extractRawContent, getExecutionErrorDetails } from '#mcp/executor.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { runBundledModuleWithRegistry } from '#mcp/run-codemode-registry.ts'
+import { type PackageRuntimeSurface } from '#worker/package-runtime/package-runtime-debug.ts'
 import {
 	getSavedPackageById,
 	getSavedPackageByKodyId,
@@ -513,6 +514,49 @@ function isMissingPackageModuleError(error: unknown) {
 	)
 }
 
+function resolveInvocationRuntimeSurface(input: {
+	selector: PackageModuleSelector
+	source: string | null
+}): PackageRuntimeSurface {
+	if (input.source === 'package-workflow') return 'workflow'
+	switch (input.selector.kind) {
+		case 'export':
+			return 'export'
+		case 'subscription':
+			return 'subscription'
+		default: {
+			const selector: never = input.selector
+			void selector
+			throw new Error('Unhandled package module selector.')
+		}
+	}
+}
+
+function resolveInvocationRuntimeName(input: {
+	surface: PackageRuntimeSurface
+	invocationName: string
+	topic: string | null
+}) {
+	switch (input.surface) {
+		case 'workflow':
+		case 'subscription':
+			return input.topic ?? input.invocationName
+		case 'export':
+			return input.invocationName
+		case 'app_fetch':
+		case 'app_realtime':
+		case 'service':
+		case 'job':
+		case 'retriever':
+			return input.invocationName
+		default: {
+			const surface: never = input.surface
+			void surface
+			throw new Error('Unhandled package runtime surface.')
+		}
+	}
+}
+
 async function invokeSavedPackageModule(input: {
 	env: Env
 	baseUrl: string
@@ -656,6 +700,10 @@ async function invokeSavedPackageModule(input: {
 			},
 			repoContext: repoSource ? createRepoContext(repoSource) : null,
 		})
+		const runtimeSurface = resolveInvocationRuntimeSurface({
+			selector: input.moduleSelector,
+			source: input.source,
+		})
 		const executionResult = await runBundledModuleWithRegistry(
 			input.env,
 			callerContext,
@@ -669,6 +717,25 @@ async function invokeSavedPackageModule(input: {
 					userId: input.actor.userId,
 					storageId: buildPackageInvocationStorageId(input.savedPackage.id),
 					writable: true,
+				},
+				runtimeDebug: {
+					packageId: input.savedPackage.id,
+					kodyId: input.savedPackage.kodyId,
+					sourceId: input.savedPackage.sourceId,
+					publishedCommit: repoSource?.published_commit ?? null,
+					surface: runtimeSurface,
+					name: resolveInvocationRuntimeName({
+						surface: runtimeSurface,
+						invocationName: input.invocationName,
+						topic: input.topic,
+					}),
+					invocationId,
+					idempotencyKey: input.idempotencyKey,
+					metadata: {
+						exportName: input.invocationName,
+						source: input.source,
+						topic: input.topic,
+					},
 				},
 				emailTools: {
 					getMessage: async (messageId) => {

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -22,6 +22,7 @@ import {
 	loadPublishedBundleArtifactByIdentity,
 	persistPublishedBundleArtifact,
 } from '#worker/package-runtime/published-bundle-artifacts.ts'
+import { packageWorkflowInvocationSource } from '#worker/package-runtime/package-invocation-sources.ts'
 import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from '#worker/package-runtime/published-source-dependencies.ts'
 import {
 	buildPackageSubscriptionArtifactName,
@@ -518,7 +519,7 @@ function resolveInvocationRuntimeSurface(input: {
 	selector: PackageModuleSelector
 	source: string | null
 }): PackageRuntimeSurface {
-	if (input.source === 'package-workflow') return 'workflow'
+	if (input.source === packageWorkflowInvocationSource) return 'workflow'
 	switch (input.selector.kind) {
 		case 'export':
 			return 'export'

--- a/packages/worker/src/package-retrievers/service.ts
+++ b/packages/worker/src/package-retrievers/service.ts
@@ -160,6 +160,20 @@ async function invokeRetriever(input: {
 			packageContext: {
 				packageId: input.entry.packageId,
 				kodyId: input.entry.kodyId,
+				sourceId: input.entry.sourceId,
+			},
+			runtimeDebug: {
+				packageId: input.entry.packageId,
+				kodyId: input.entry.kodyId,
+				sourceId: input.entry.sourceId,
+				publishedCommit: source.published_commit,
+				surface: 'retriever',
+				name: input.entry.retrieverKey,
+				storageId: buildPackageRetrieverStorageId(input.entry.packageId),
+				metadata: {
+					scope: input.scope,
+					limit,
+				},
 			},
 			executorTimeoutMs: clampTimeout(input.entry.timeoutMs, input.scope),
 		},

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -646,6 +646,7 @@ type PackageAppRuntimeBridgeProps = {
 	packageId: string
 	kodyId: string
 	sourceId: string
+	publishedCommit: string | null
 }
 
 export class PackageAppRuntimeBridge extends WorkerEntrypoint<
@@ -712,6 +713,7 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 				packageId: this.ctx.props.packageId,
 				kodyId: this.ctx.props.kodyId,
 				sourceId: this.ctx.props.sourceId,
+				publishedCommit: this.ctx.props.publishedCommit,
 				surface: input.surface,
 				name: input.name,
 				sessionId: input.sessionId,
@@ -1140,12 +1142,14 @@ export async function buildPackageAppWorker(input: {
 						packageId: input.savedPackage.id,
 						kodyId: input.savedPackage.kodyId,
 						sourceId: input.savedPackage.sourceId,
+						publishedCommit: input.savedPackage.publishedCommit,
 					},
 				}),
 				__kodyPackageContext: {
 					packageId: input.savedPackage.id,
 					kodyId: input.savedPackage.kodyId,
 					sourceId: input.savedPackage.sourceId,
+					publishedCommit: input.savedPackage.publishedCommit,
 				},
 			},
 			globalOutbound: workerExports?.CodemodeFetchGateway

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -35,6 +35,12 @@ import {
 	isPackageSecretAccessUnavailableError,
 	resolvePackageMountedSecret,
 } from '#mcp/secrets/package-access.ts'
+import {
+	beginPackageRuntimeRun,
+	finishPackageRuntimeRun,
+	type PackageRuntimeRunHandle,
+	type PackageRuntimeStatus,
+} from './package-runtime-debug.ts'
 
 const packageAppEntrypointName = 'PackageAppWorker'
 const packageAppRuntimeBindingName = 'KODY_RUNTIME'
@@ -470,6 +476,24 @@ function createFacetStorageId(packageContext, facetName) {
 	return \`\${packageId}:facet:\${buildFacetName(facetName)}\`;
 }
 
+function serializeRuntimeError(error) {
+	return {
+		name: error && typeof error.name === 'string' ? error.name : 'Error',
+		message:
+			error && typeof error.message === 'string'
+				? error.message
+				: String(error),
+	};
+}
+
+async function startRuntimeRun(runtimeBridge, input) {
+	return await runtimeBridge.packageRuntimeRunStart(input).catch(() => null);
+}
+
+async function finishRuntimeRun(runtimeBridge, input) {
+	await runtimeBridge.packageRuntimeRunFinish(input).catch(() => {});
+}
+
 function resolveRealtimeHandler(userModule, facetName) {
 	const facetExportName = buildFacetClassExportName(facetName);
 	if (typeof userModule[facetExportName] === 'function') {
@@ -502,9 +526,17 @@ function resolveRealtimeHandler(userModule, facetName) {
 
 export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 	async fetch(request) {
+		const runtimeBridge = this.env.${packageAppRuntimeBindingName};
+		const runtimeRun = await startRuntimeRun(runtimeBridge, {
+			surface: 'app_fetch',
+			name: new URL(request.url).pathname,
+			metadata: {
+				method: request.method,
+			},
+		});
 		const previousRuntime = globalThis.__kodyRuntime;
 		globalThis.__kodyRuntime = createRuntime(
-			this.env.${packageAppRuntimeBindingName},
+			runtimeBridge,
 			this.env.__kodyPackageContext ?? null,
 		);
 		try {
@@ -520,7 +552,19 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 			if (!fetchHandler) {
 				throw new Error('Package apps must default export a fetch handler or an object with fetch().');
 			}
-			return await fetchHandler(request, runtimeEnv, this.ctx);
+			const response = await fetchHandler(request, runtimeEnv, this.ctx);
+			await finishRuntimeRun(runtimeBridge, {
+				run: runtimeRun,
+				status: 'success',
+			});
+			return response;
+		} catch (error) {
+			await finishRuntimeRun(runtimeBridge, {
+				run: runtimeRun,
+				status: 'error',
+				error: serializeRuntimeError(error),
+			});
+			throw error;
 		} finally {
 			if (previousRuntime === undefined) delete globalThis.__kodyRuntime;
 			else globalThis.__kodyRuntime = previousRuntime;
@@ -528,9 +572,19 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 	}
 
 	async handleRealtimeEvent(payload) {
+		const runtimeBridge = this.env.${packageAppRuntimeBindingName};
+		const runtimeRun = await startRuntimeRun(runtimeBridge, {
+			surface: 'app_realtime',
+			name: buildFacetName(payload?.facet),
+			sessionId: payload?.sessionId,
+			metadata: {
+				facet: payload?.facet,
+				topic: payload?.topic,
+			},
+		});
 		const previousRuntime = globalThis.__kodyRuntime;
 		globalThis.__kodyRuntime = createRuntime(
-			this.env.${packageAppRuntimeBindingName},
+			runtimeBridge,
 			this.env.__kodyPackageContext ?? null,
 		);
 		try {
@@ -538,25 +592,43 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 			const runtimeEnv = createPackageAppEnv(this.env, userModule);
 			const resolved = resolveRealtimeHandler(userModule, payload?.facet);
 			if (!resolved) {
-				return { actions: [] };
+				const result = { actions: [] };
+				await finishRuntimeRun(runtimeBridge, {
+					run: runtimeRun,
+					status: 'success',
+				});
+				return result;
 			}
+			let result;
 			if (resolved.kind === 'function') {
-				return await resolved.exported(payload, runtimeEnv, this.ctx);
+				result = await resolved.exported(payload, runtimeEnv, this.ctx);
+			} else if (resolved.kind === 'bound-method') {
+				result = await resolved.exported.onRealtimeEvent(payload, runtimeEnv, this.ctx);
+			} else {
+				const state = createInternalDurableObjectState(
+					runtimeBridge,
+					createFacetStorageId(this.env.__kodyPackageContext ?? null, payload?.facet),
+				);
+				const instance = Object.create(resolved.exported.prototype);
+				instance.ctx = state;
+				instance.env = runtimeEnv;
+				if (typeof instance.onRealtimeEvent !== 'function') {
+					throw new Error(\`Package app facet "\${buildFacetName(payload?.facet)}" must implement onRealtimeEvent().\`);
+				}
+				result = await instance.onRealtimeEvent(payload, runtimeEnv, this.ctx);
 			}
-			if (resolved.kind === 'bound-method') {
-				return await resolved.exported.onRealtimeEvent(payload, runtimeEnv, this.ctx);
-			}
-			const state = createInternalDurableObjectState(
-				this.env.${packageAppRuntimeBindingName},
-				createFacetStorageId(this.env.__kodyPackageContext ?? null, payload?.facet),
-			);
-			const instance = Object.create(resolved.exported.prototype);
-			instance.ctx = state;
-			instance.env = runtimeEnv;
-			if (typeof instance.onRealtimeEvent !== 'function') {
-				throw new Error(\`Package app facet "\${buildFacetName(payload?.facet)}" must implement onRealtimeEvent().\`);
-			}
-			return await instance.onRealtimeEvent(payload, runtimeEnv, this.ctx);
+			await finishRuntimeRun(runtimeBridge, {
+				run: runtimeRun,
+				status: 'success',
+			});
+			return result;
+		} catch (error) {
+			await finishRuntimeRun(runtimeBridge, {
+				run: runtimeRun,
+				status: 'error',
+				error: serializeRuntimeError(error),
+			});
+			throw error;
 		} finally {
 			if (previousRuntime === undefined) delete globalThis.__kodyRuntime;
 			else globalThis.__kodyRuntime = previousRuntime;
@@ -625,6 +697,43 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 			baseUrl: this.ctx.props.baseUrl,
 			serviceName,
 		})
+	}
+
+	async packageRuntimeRunStart(input: {
+		surface: 'app_fetch' | 'app_realtime'
+		name?: string | null
+		sessionId?: string | null
+		metadata?: Record<string, unknown> | null
+	}): Promise<PackageRuntimeRunHandle | null> {
+		return await beginPackageRuntimeRun({
+			env: this.env,
+			userId: this.ctx.props.userId,
+			context: {
+				packageId: this.ctx.props.packageId,
+				kodyId: this.ctx.props.kodyId,
+				sourceId: this.ctx.props.sourceId,
+				surface: input.surface,
+				name: input.name,
+				sessionId: input.sessionId,
+				metadata: input.metadata,
+			},
+		})
+	}
+
+	async packageRuntimeRunFinish(input: {
+		run: PackageRuntimeRunHandle | null
+		status: Exclude<PackageRuntimeStatus, 'running'>
+		error?: unknown
+		logs?: Array<string>
+	}) {
+		await finishPackageRuntimeRun({
+			env: this.env,
+			handle: input.run,
+			status: input.status,
+			error: input.error,
+			logs: input.logs,
+		})
+		return { ok: true }
 	}
 
 	async callCapability(input: { name: string; args?: unknown }) {

--- a/packages/worker/src/package-runtime/package-invocation-sources.ts
+++ b/packages/worker/src/package-runtime/package-invocation-sources.ts
@@ -1,0 +1,1 @@
+export const packageWorkflowInvocationSource = 'package-workflow'

--- a/packages/worker/src/package-runtime/package-runtime-debug.node.test.ts
+++ b/packages/worker/src/package-runtime/package-runtime-debug.node.test.ts
@@ -24,8 +24,9 @@ function createDebugDatabase() {
 		return rows
 			.toSorted(
 				(left, right) =>
-					String(right['started_at']).localeCompare(String(left['started_at'])) ||
-					String(right['id']).localeCompare(String(left['id'])),
+					String(right['started_at']).localeCompare(
+						String(left['started_at']),
+					) || String(right['id']).localeCompare(String(left['id'])),
 			)
 			.slice(0, limit)
 	}
@@ -63,7 +64,9 @@ function createDebugDatabase() {
 									updated_at: params[18],
 								})
 							}
-							if (query.includes('INSERT OR REPLACE INTO package_runtime_logs')) {
+							if (
+								query.includes('INSERT OR REPLACE INTO package_runtime_logs')
+							) {
 								logs.push({
 									id: params[0],
 									run_id: params[1],

--- a/packages/worker/src/package-runtime/package-runtime-debug.node.test.ts
+++ b/packages/worker/src/package-runtime/package-runtime-debug.node.test.ts
@@ -6,7 +6,7 @@ import {
 	listPackageRuntimeRuns,
 } from './package-runtime-debug.ts'
 
-function createDebugDatabase() {
+function createDebugDatabase(options: { failLogInsert?: boolean } = {}) {
 	const runs: Array<Record<string, unknown>> = []
 	const logs: Array<Record<string, unknown>> = []
 	const selectRows = (query: string, params: Array<unknown>) => {
@@ -67,6 +67,9 @@ function createDebugDatabase() {
 							if (
 								query.includes('INSERT OR REPLACE INTO package_runtime_logs')
 							) {
+								if (options.failLogInsert) {
+									throw new Error('log insert failed')
+								}
 								logs.push({
 									id: params[0],
 									run_id: params[1],
@@ -247,5 +250,43 @@ describe('package runtime debug persistence', () => {
 			16 * 1024,
 		)
 		expect(message.endsWith('... [truncated]')).toBe(true)
+	})
+
+	test('updates run status when log persistence fails', async () => {
+		const env = {
+			APP_DB: createDebugDatabase({ failLogInsert: true }),
+		} as Env
+		const run = await beginPackageRuntimeRun({
+			env,
+			userId: 'user-1',
+			context: {
+				packageId: 'pkg-1',
+				kodyId: 'calendar-agent',
+				surface: 'export',
+				name: './sync',
+			},
+		})
+
+		await finishPackageRuntimeRun({
+			env,
+			handle: run,
+			status: 'success',
+			logs: ['log write will fail'],
+		})
+
+		const listed = await listPackageRuntimeRuns({
+			env,
+			userId: 'user-1',
+		})
+		expect(listed[0]).toMatchObject({
+			status: 'success',
+			name: './sync',
+		})
+		const loaded = await getPackageRuntimeRun({
+			env,
+			userId: 'user-1',
+			runId: run?.id ?? '',
+		})
+		expect(loaded?.logs).toEqual([])
 	})
 })

--- a/packages/worker/src/package-runtime/package-runtime-debug.node.test.ts
+++ b/packages/worker/src/package-runtime/package-runtime-debug.node.test.ts
@@ -289,4 +289,72 @@ describe('package runtime debug persistence', () => {
 		})
 		expect(loaded?.logs).toEqual([])
 	})
+
+	test('keeps truncated metadata parseable', async () => {
+		const env = { APP_DB: createDebugDatabase() } as Env
+		const run = await beginPackageRuntimeRun({
+			env,
+			userId: 'user-1',
+			context: {
+				packageId: 'pkg-1',
+				kodyId: 'calendar-agent',
+				surface: 'export',
+				name: './sync',
+				metadata: {
+					payload: 'x'.repeat(50_000),
+				},
+			},
+		})
+
+		await finishPackageRuntimeRun({
+			env,
+			handle: run,
+			status: 'success',
+		})
+
+		const listed = await listPackageRuntimeRuns({
+			env,
+			userId: 'user-1',
+		})
+		expect(listed[0]?.metadata).toMatchObject({
+			__truncated__: true,
+		})
+		expect(typeof listed[0]?.metadata['preview']).toBe('string')
+	})
+
+	test('retains the newest log entries when log count exceeds the cap', async () => {
+		const env = { APP_DB: createDebugDatabase() } as Env
+		const run = await beginPackageRuntimeRun({
+			env,
+			userId: 'user-1',
+			context: {
+				packageId: 'pkg-1',
+				kodyId: 'calendar-agent',
+				surface: 'export',
+				name: './sync',
+			},
+		})
+
+		await finishPackageRuntimeRun({
+			env,
+			handle: run,
+			status: 'success',
+			logs: Array.from({ length: 205 }, (_, index) => `line-${index}`),
+		})
+
+		const loaded = await getPackageRuntimeRun({
+			env,
+			userId: 'user-1',
+			runId: run?.id ?? '',
+		})
+		expect(loaded?.logs).toHaveLength(200)
+		expect(loaded?.logs[0]).toMatchObject({
+			sequence: 0,
+			message: 'line-5',
+		})
+		expect(loaded?.logs.at(-1)).toMatchObject({
+			sequence: 199,
+			message: 'line-204',
+		})
+	})
 })

--- a/packages/worker/src/package-runtime/package-runtime-debug.node.test.ts
+++ b/packages/worker/src/package-runtime/package-runtime-debug.node.test.ts
@@ -216,4 +216,36 @@ describe('package runtime debug persistence', () => {
 			errorMessage: 'boom',
 		})
 	})
+
+	test('truncates large UTF-8 log entries within the byte limit', async () => {
+		const env = { APP_DB: createDebugDatabase() } as Env
+		const run = await beginPackageRuntimeRun({
+			env,
+			userId: 'user-1',
+			context: {
+				packageId: 'pkg-1',
+				kodyId: 'calendar-agent',
+				surface: 'export',
+				name: './sync',
+			},
+		})
+
+		await finishPackageRuntimeRun({
+			env,
+			handle: run,
+			status: 'success',
+			logs: ['😀'.repeat(20_000)],
+		})
+
+		const loaded = await getPackageRuntimeRun({
+			env,
+			userId: 'user-1',
+			runId: run?.id ?? '',
+		})
+		const message = loaded?.logs[0]?.message ?? ''
+		expect(new TextEncoder().encode(message).length).toBeLessThanOrEqual(
+			16 * 1024,
+		)
+		expect(message.endsWith('... [truncated]')).toBe(true)
+	})
 })

--- a/packages/worker/src/package-runtime/package-runtime-debug.node.test.ts
+++ b/packages/worker/src/package-runtime/package-runtime-debug.node.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from 'vitest'
+import {
+	beginPackageRuntimeRun,
+	finishPackageRuntimeRun,
+	getPackageRuntimeRun,
+	listPackageRuntimeRuns,
+} from './package-runtime-debug.ts'
+
+function createDebugDatabase() {
+	const runs: Array<Record<string, unknown>> = []
+	const logs: Array<Record<string, unknown>> = []
+	const selectRows = (query: string, params: Array<unknown>) => {
+		let rows = runs.filter((row) => row['user_id'] === params[0])
+		let offset = 1
+		if (query.includes('package_id = ?')) {
+			rows = rows.filter((row) => row['package_id'] === params[offset])
+			offset += 1
+		}
+		if (query.includes('surface = ?')) {
+			rows = rows.filter((row) => row['surface'] === params[offset])
+			offset += 1
+		}
+		const limit = Number(params[offset]) || 25
+		return rows
+			.toSorted(
+				(left, right) =>
+					String(right['started_at']).localeCompare(String(left['started_at'])) ||
+					String(right['id']).localeCompare(String(left['id'])),
+			)
+			.slice(0, limit)
+	}
+	const db = {
+		prepare(query: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async run() {
+							if (query.includes('INSERT INTO package_runtime_runs')) {
+								runs.push({
+									id: params[0],
+									user_id: params[1],
+									package_id: params[2],
+									package_kody_id: params[3],
+									source_id: params[4],
+									published_commit: params[5],
+									surface: params[6],
+									name: params[7],
+									status: 'running',
+									started_at: params[8],
+									finished_at: null,
+									duration_ms: null,
+									error_name: null,
+									error_message: null,
+									storage_id: params[9],
+									job_id: params[10],
+									workflow_id: params[11],
+									invocation_id: params[12],
+									session_id: params[13],
+									idempotency_key: params[14],
+									parent_run_id: params[15],
+									metadata_json: params[16],
+									created_at: params[17],
+									updated_at: params[18],
+								})
+							}
+							if (query.includes('INSERT OR REPLACE INTO package_runtime_logs')) {
+								logs.push({
+									id: params[0],
+									run_id: params[1],
+									user_id: params[2],
+									package_id: params[3],
+									timestamp: params[4],
+									sequence: params[5],
+									level: params[6],
+									message: params[7],
+									fields_json: null,
+									created_at: params[8],
+								})
+							}
+							if (query.includes('UPDATE package_runtime_runs')) {
+								const row = runs.find(
+									(candidate) =>
+										candidate['id'] === params[6] &&
+										candidate['user_id'] === params[7],
+								)
+								if (row) {
+									row['status'] = params[0]
+									row['finished_at'] = params[1]
+									row['duration_ms'] = params[2]
+									row['error_name'] = params[3]
+									row['error_message'] = params[4]
+									row['updated_at'] = params[5]
+								}
+							}
+							return { meta: { changes: 1 } }
+						},
+						async all<T = Record<string, unknown>>() {
+							if (query.includes('FROM package_runtime_logs')) {
+								return {
+									results: logs
+										.filter(
+											(row) =>
+												row['run_id'] === params[0] &&
+												row['user_id'] === params[1],
+										)
+										.toSorted(
+											(left, right) =>
+												Number(left['sequence']) - Number(right['sequence']),
+										) as Array<T>,
+								}
+							}
+							return {
+								results: selectRows(query, params) as Array<T>,
+							}
+						},
+						async first<T = Record<string, unknown>>() {
+							const row = runs.find(
+								(candidate) =>
+									candidate['id'] === params[0] &&
+									candidate['user_id'] === params[1],
+							)
+							return (row ?? null) as T | null
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+	return db
+}
+
+describe('package runtime debug persistence', () => {
+	test('records, lists, and loads retained package runtime logs', async () => {
+		const env = { APP_DB: createDebugDatabase() } as Env
+		const run = await beginPackageRuntimeRun({
+			env,
+			userId: 'user-1',
+			context: {
+				packageId: 'pkg-1',
+				kodyId: 'calendar-agent',
+				sourceId: 'source-1',
+				publishedCommit: 'abc123',
+				surface: 'export',
+				name: './sync',
+				storageId: 'package:pkg-1',
+				invocationId: 'invoke-1',
+				idempotencyKey: 'key-1',
+				metadata: { topic: 'manual' },
+			},
+		})
+
+		await finishPackageRuntimeRun({
+			env,
+			handle: run,
+			status: 'success',
+			logs: ['starting sync', 'finished sync'],
+		})
+
+		const listed = await listPackageRuntimeRuns({
+			env,
+			userId: 'user-1',
+			packageId: 'pkg-1',
+			surface: 'export',
+		})
+		expect(listed).toHaveLength(1)
+		expect(listed[0]).toMatchObject({
+			packageId: 'pkg-1',
+			kodyId: 'calendar-agent',
+			surface: 'export',
+			status: 'success',
+			name: './sync',
+			metadata: { topic: 'manual' },
+		})
+
+		const loaded = await getPackageRuntimeRun({
+			env,
+			userId: 'user-1',
+			runId: listed[0]?.id ?? '',
+		})
+		expect(loaded?.logs.map((log) => log.message)).toEqual([
+			'starting sync',
+			'finished sync',
+		])
+	})
+
+	test('records normalized error details', async () => {
+		const env = { APP_DB: createDebugDatabase() } as Env
+		const run = await beginPackageRuntimeRun({
+			env,
+			userId: 'user-1',
+			context: {
+				packageId: 'pkg-1',
+				kodyId: 'calendar-agent',
+				surface: 'service',
+				name: 'daemon',
+			},
+		})
+
+		await finishPackageRuntimeRun({
+			env,
+			handle: run,
+			status: 'error',
+			error: { name: 'ServiceError', message: 'boom' },
+		})
+
+		const listed = await listPackageRuntimeRuns({
+			env,
+			userId: 'user-1',
+		})
+		expect(listed[0]).toMatchObject({
+			status: 'error',
+			errorName: 'ServiceError',
+			errorMessage: 'boom',
+		})
+	})
+})

--- a/packages/worker/src/package-runtime/package-runtime-debug.ts
+++ b/packages/worker/src/package-runtime/package-runtime-debug.ts
@@ -137,7 +137,21 @@ function toJsonSafeValue(value: unknown): unknown {
 }
 
 function serializeJson(value: unknown, maxBytes = maxPersistedJsonBytes) {
-	return truncateUtf8(JSON.stringify(toJsonSafeValue(value)), maxBytes)
+	const json = JSON.stringify(toJsonSafeValue(value))
+	if (textEncoder.encode(json).length <= maxBytes) return json
+	let preview = truncateUtf8(json, Math.max(0, maxBytes - 128))
+	let wrapped = JSON.stringify({
+		__truncated__: true,
+		preview,
+	})
+	while (textEncoder.encode(wrapped).length > maxBytes && preview.length > 0) {
+		preview = preview.slice(0, Math.floor(preview.length * 0.8))
+		wrapped = JSON.stringify({
+			__truncated__: true,
+			preview,
+		})
+	}
+	return wrapped
 }
 
 function parseJsonRecord(value: unknown): Record<string, unknown> {
@@ -229,13 +243,11 @@ function getErrorFields(error: unknown) {
 }
 
 function normalizeLogs(logs: Array<string> | undefined) {
-	return (logs ?? [])
-		.slice(0, maxPersistedLogEntries)
-		.map((message, index) => ({
-			sequence: index,
-			level: 'log' as const,
-			message: truncateUtf8(String(message), maxPersistedTextBytes),
-		}))
+	return (logs ?? []).slice(-maxPersistedLogEntries).map((message, index) => ({
+		sequence: index,
+		level: 'log' as const,
+		message: truncateUtf8(String(message), maxPersistedTextBytes),
+	}))
 }
 
 export async function beginPackageRuntimeRun(input: {

--- a/packages/worker/src/package-runtime/package-runtime-debug.ts
+++ b/packages/worker/src/package-runtime/package-runtime-debug.ts
@@ -290,10 +290,11 @@ export async function finishPackageRuntimeRun(input: {
 }) {
 	const db = dbFromEnv(input.env)
 	if (!db || !input.handle) return
+	const handle = input.handle
 	const finishedAt = new Date().toISOString()
 	const durationMs = Math.max(
 		0,
-		finishedAt ? Date.parse(finishedAt) - Date.parse(input.handle.startedAt) : 0,
+		Date.parse(finishedAt) - Date.parse(handle.startedAt),
 	)
 	const { errorName, errorMessage } = getErrorFields(input.error)
 	const logs = normalizeLogs(input.logs)
@@ -308,10 +309,10 @@ export async function finishPackageRuntimeRun(input: {
 						) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
 					)
 					.bind(
-						`${input.handle.id}:${log.sequence}`,
-						input.handle.id,
-						input.handle.userId,
-						input.handle.packageId,
+						`${handle.id}:${log.sequence}`,
+						handle.id,
+						handle.userId,
+						handle.packageId,
 						finishedAt,
 						log.sequence,
 						log.level,
@@ -340,8 +341,8 @@ export async function finishPackageRuntimeRun(input: {
 				errorName,
 				errorMessage,
 				finishedAt,
-				input.handle.id,
-				input.handle.userId,
+				handle.id,
+				handle.userId,
 			)
 			.run()
 	} catch (error) {

--- a/packages/worker/src/package-runtime/package-runtime-debug.ts
+++ b/packages/worker/src/package-runtime/package-runtime-debug.ts
@@ -112,14 +112,20 @@ function normalizeOptionalString(value: string | null | undefined) {
 function truncateUtf8(value: string, maxBytes: number) {
 	if (textEncoder.encode(value).length <= maxBytes) return value
 	const suffix = '... [truncated]'
-	let truncated = value
-	while (
-		truncated.length > 0 &&
-		textEncoder.encode(`${truncated}${suffix}`).length > maxBytes
-	) {
-		truncated = truncated.slice(0, Math.max(0, truncated.length - 256))
+	let low = 0
+	let high = value.length
+	let best = ''
+	while (low <= high) {
+		const midpoint = Math.floor((low + high) / 2)
+		const candidate = `${value.slice(0, midpoint)}${suffix}`
+		if (textEncoder.encode(candidate).length <= maxBytes) {
+			best = candidate
+			low = midpoint + 1
+		} else {
+			high = midpoint - 1
+		}
 	}
-	return `${truncated}${suffix}`
+	return best
 }
 
 function toJsonSafeValue(value: unknown): unknown {

--- a/packages/worker/src/package-runtime/package-runtime-debug.ts
+++ b/packages/worker/src/package-runtime/package-runtime-debug.ts
@@ -309,8 +309,8 @@ export async function finishPackageRuntimeRun(input: {
 	)
 	const { errorName, errorMessage } = getErrorFields(input.error)
 	const logs = normalizeLogs(input.logs)
-	try {
-		if (logs.length > 0) {
+	if (logs.length > 0) {
+		try {
 			const statements = logs.map((log) =>
 				db
 					.prepare(
@@ -337,7 +337,11 @@ export async function finishPackageRuntimeRun(input: {
 			} else {
 				await Promise.all(statements.map((statement) => statement.run()))
 			}
+		} catch (error) {
+			console.warn('package-runtime-debug-logs-failed', error)
 		}
+	}
+	try {
 		await db
 			.prepare(
 				`UPDATE package_runtime_runs
@@ -357,7 +361,7 @@ export async function finishPackageRuntimeRun(input: {
 			)
 			.run()
 	} catch (error) {
-		console.warn('package-runtime-debug-finish-failed', error)
+		console.warn('package-runtime-debug-status-failed', error)
 	}
 }
 

--- a/packages/worker/src/package-runtime/package-runtime-debug.ts
+++ b/packages/worker/src/package-runtime/package-runtime-debug.ts
@@ -27,7 +27,8 @@ export const packageRuntimeLogLevelValues = [
 	'error',
 ] as const
 
-export type PackageRuntimeLogLevel = (typeof packageRuntimeLogLevelValues)[number]
+export type PackageRuntimeLogLevel =
+	(typeof packageRuntimeLogLevelValues)[number]
 
 export type PackageRuntimeDebugContext = {
 	packageId: string
@@ -137,7 +138,8 @@ function parseJsonRecord(value: unknown): Record<string, unknown> {
 	if (typeof value !== 'string' || value.length === 0) return {}
 	try {
 		const parsed = JSON.parse(value) as unknown
-		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+			return {}
 		return parsed as Record<string, unknown>
 	} catch {
 		return {}
@@ -189,7 +191,8 @@ function mapLogRow(row: Record<string, unknown>): PackageRuntimeLogRecord {
 		sequence: Number(row['sequence']) || 0,
 		level: String(row['level']) as PackageRuntimeLogLevel,
 		message: String(row['message']),
-		fields: row['fields_json'] == null ? null : parseJsonRecord(row['fields_json']),
+		fields:
+			row['fields_json'] == null ? null : parseJsonRecord(row['fields_json']),
 		createdAt: String(row['created_at']),
 	}
 }
@@ -220,11 +223,13 @@ function getErrorFields(error: unknown) {
 }
 
 function normalizeLogs(logs: Array<string> | undefined) {
-	return (logs ?? []).slice(0, maxPersistedLogEntries).map((message, index) => ({
-		sequence: index,
-		level: 'log' as const,
-		message: truncateUtf8(String(message), maxPersistedTextBytes),
-	}))
+	return (logs ?? [])
+		.slice(0, maxPersistedLogEntries)
+		.map((message, index) => ({
+			sequence: index,
+			level: 'log' as const,
+			message: truncateUtf8(String(message), maxPersistedTextBytes),
+		}))
 }
 
 export async function beginPackageRuntimeRun(input: {

--- a/packages/worker/src/package-runtime/package-runtime-debug.ts
+++ b/packages/worker/src/package-runtime/package-runtime-debug.ts
@@ -1,0 +1,420 @@
+export const packageRuntimeSurfaceValues = [
+	'export',
+	'subscription',
+	'app_fetch',
+	'app_realtime',
+	'service',
+	'job',
+	'workflow',
+	'retriever',
+] as const
+
+export type PackageRuntimeSurface = (typeof packageRuntimeSurfaceValues)[number]
+
+export const packageRuntimeStatusValues = [
+	'running',
+	'success',
+	'error',
+] as const
+
+export type PackageRuntimeStatus = (typeof packageRuntimeStatusValues)[number]
+
+export const packageRuntimeLogLevelValues = [
+	'debug',
+	'info',
+	'log',
+	'warn',
+	'error',
+] as const
+
+export type PackageRuntimeLogLevel = (typeof packageRuntimeLogLevelValues)[number]
+
+export type PackageRuntimeDebugContext = {
+	packageId: string
+	kodyId: string
+	sourceId?: string | null
+	publishedCommit?: string | null
+	surface: PackageRuntimeSurface
+	name?: string | null
+	storageId?: string | null
+	jobId?: string | null
+	workflowId?: string | null
+	invocationId?: string | null
+	sessionId?: string | null
+	idempotencyKey?: string | null
+	parentRunId?: string | null
+	metadata?: Record<string, unknown> | null
+}
+
+export type PackageRuntimeRunHandle = {
+	id: string
+	userId: string
+	packageId: string
+	startedAt: string
+}
+
+export type PackageRuntimeRunRecord = {
+	id: string
+	userId: string
+	packageId: string
+	kodyId: string
+	sourceId: string | null
+	publishedCommit: string | null
+	surface: PackageRuntimeSurface
+	name: string | null
+	status: PackageRuntimeStatus
+	startedAt: string
+	finishedAt: string | null
+	durationMs: number | null
+	errorName: string | null
+	errorMessage: string | null
+	storageId: string | null
+	jobId: string | null
+	workflowId: string | null
+	invocationId: string | null
+	sessionId: string | null
+	idempotencyKey: string | null
+	parentRunId: string | null
+	metadata: Record<string, unknown>
+	createdAt: string
+	updatedAt: string
+}
+
+export type PackageRuntimeLogRecord = {
+	id: string
+	runId: string
+	userId: string
+	packageId: string
+	timestamp: string
+	sequence: number
+	level: PackageRuntimeLogLevel
+	message: string
+	fields: Record<string, unknown> | null
+	createdAt: string
+}
+
+const maxPersistedLogEntries = 200
+const maxPersistedTextBytes = 16 * 1024
+const maxPersistedJsonBytes = 32 * 1024
+const textEncoder = new TextEncoder()
+
+function dbFromEnv(env: Env): D1Database | null {
+	const maybeDb = (env as Partial<Env>).APP_DB
+	return maybeDb ?? null
+}
+
+function normalizeOptionalString(value: string | null | undefined) {
+	const trimmed = value?.trim()
+	return trimmed && trimmed.length > 0 ? trimmed : null
+}
+
+function truncateUtf8(value: string, maxBytes: number) {
+	if (textEncoder.encode(value).length <= maxBytes) return value
+	const suffix = '... [truncated]'
+	let truncated = value
+	while (
+		truncated.length > 0 &&
+		textEncoder.encode(`${truncated}${suffix}`).length > maxBytes
+	) {
+		truncated = truncated.slice(0, Math.max(0, truncated.length - 256))
+	}
+	return `${truncated}${suffix}`
+}
+
+function toJsonSafeValue(value: unknown): unknown {
+	try {
+		return JSON.parse(JSON.stringify(value)) as unknown
+	} catch {
+		return value instanceof Error ? value.message : String(value)
+	}
+}
+
+function serializeJson(value: unknown, maxBytes = maxPersistedJsonBytes) {
+	return truncateUtf8(JSON.stringify(toJsonSafeValue(value)), maxBytes)
+}
+
+function parseJsonRecord(value: unknown): Record<string, unknown> {
+	if (typeof value !== 'string' || value.length === 0) return {}
+	try {
+		const parsed = JSON.parse(value) as unknown
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+		return parsed as Record<string, unknown>
+	} catch {
+		return {}
+	}
+}
+
+function mapRunRow(row: Record<string, unknown>): PackageRuntimeRunRecord {
+	return {
+		id: String(row['id']),
+		userId: String(row['user_id']),
+		packageId: String(row['package_id']),
+		kodyId: String(row['package_kody_id']),
+		sourceId: row['source_id'] == null ? null : String(row['source_id']),
+		publishedCommit:
+			row['published_commit'] == null ? null : String(row['published_commit']),
+		surface: String(row['surface']) as PackageRuntimeSurface,
+		name: row['name'] == null ? null : String(row['name']),
+		status: String(row['status']) as PackageRuntimeStatus,
+		startedAt: String(row['started_at']),
+		finishedAt: row['finished_at'] == null ? null : String(row['finished_at']),
+		durationMs:
+			row['duration_ms'] == null ? null : Number(row['duration_ms']) || 0,
+		errorName: row['error_name'] == null ? null : String(row['error_name']),
+		errorMessage:
+			row['error_message'] == null ? null : String(row['error_message']),
+		storageId: row['storage_id'] == null ? null : String(row['storage_id']),
+		jobId: row['job_id'] == null ? null : String(row['job_id']),
+		workflowId: row['workflow_id'] == null ? null : String(row['workflow_id']),
+		invocationId:
+			row['invocation_id'] == null ? null : String(row['invocation_id']),
+		sessionId: row['session_id'] == null ? null : String(row['session_id']),
+		idempotencyKey:
+			row['idempotency_key'] == null ? null : String(row['idempotency_key']),
+		parentRunId:
+			row['parent_run_id'] == null ? null : String(row['parent_run_id']),
+		metadata: parseJsonRecord(row['metadata_json']),
+		createdAt: String(row['created_at']),
+		updatedAt: String(row['updated_at']),
+	}
+}
+
+function mapLogRow(row: Record<string, unknown>): PackageRuntimeLogRecord {
+	return {
+		id: String(row['id']),
+		runId: String(row['run_id']),
+		userId: String(row['user_id']),
+		packageId: String(row['package_id']),
+		timestamp: String(row['timestamp']),
+		sequence: Number(row['sequence']) || 0,
+		level: String(row['level']) as PackageRuntimeLogLevel,
+		message: String(row['message']),
+		fields: row['fields_json'] == null ? null : parseJsonRecord(row['fields_json']),
+		createdAt: String(row['created_at']),
+	}
+}
+
+function getErrorFields(error: unknown) {
+	if (!error) return { errorName: null, errorMessage: null }
+	if (error instanceof Error) {
+		return {
+			errorName: error.name,
+			errorMessage: truncateUtf8(error.message, maxPersistedTextBytes),
+		}
+	}
+	if (typeof error === 'object' && error !== null) {
+		const record = error as Record<string, unknown>
+		const message = record['message']
+		if (typeof message === 'string') {
+			const name = record['name']
+			return {
+				errorName: typeof name === 'string' ? name : 'Error',
+				errorMessage: truncateUtf8(message, maxPersistedTextBytes),
+			}
+		}
+	}
+	return {
+		errorName: 'Unknown',
+		errorMessage: truncateUtf8(String(error), maxPersistedTextBytes),
+	}
+}
+
+function normalizeLogs(logs: Array<string> | undefined) {
+	return (logs ?? []).slice(0, maxPersistedLogEntries).map((message, index) => ({
+		sequence: index,
+		level: 'log' as const,
+		message: truncateUtf8(String(message), maxPersistedTextBytes),
+	}))
+}
+
+export async function beginPackageRuntimeRun(input: {
+	env: Env
+	userId?: string | null
+	context?: PackageRuntimeDebugContext | null
+}): Promise<PackageRuntimeRunHandle | null> {
+	const db = dbFromEnv(input.env)
+	const userId = normalizeOptionalString(input.userId ?? undefined)
+	const context = input.context
+	if (!db || !userId || !context) return null
+	const packageId = normalizeOptionalString(context.packageId)
+	const kodyId = normalizeOptionalString(context.kodyId)
+	if (!packageId || !kodyId) return null
+	const id = crypto.randomUUID()
+	const now = new Date().toISOString()
+	try {
+		await db
+			.prepare(
+				`INSERT INTO package_runtime_runs (
+					id, user_id, package_id, package_kody_id, source_id, published_commit,
+					surface, name, status, started_at, finished_at, duration_ms,
+					error_name, error_message, storage_id, job_id, workflow_id,
+					invocation_id, session_id, idempotency_key, parent_run_id,
+					metadata_json, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, NULL, NULL, NULL, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			)
+			.bind(
+				id,
+				userId,
+				packageId,
+				kodyId,
+				normalizeOptionalString(context.sourceId),
+				normalizeOptionalString(context.publishedCommit),
+				context.surface,
+				normalizeOptionalString(context.name),
+				now,
+				normalizeOptionalString(context.storageId),
+				normalizeOptionalString(context.jobId),
+				normalizeOptionalString(context.workflowId),
+				normalizeOptionalString(context.invocationId),
+				normalizeOptionalString(context.sessionId),
+				normalizeOptionalString(context.idempotencyKey),
+				normalizeOptionalString(context.parentRunId),
+				serializeJson(context.metadata ?? {}),
+				now,
+				now,
+			)
+			.run()
+		return { id, userId, packageId, startedAt: now }
+	} catch (error) {
+		console.warn('package-runtime-debug-start-failed', error)
+		return null
+	}
+}
+
+export async function finishPackageRuntimeRun(input: {
+	env: Env
+	handle: PackageRuntimeRunHandle | null
+	status: Exclude<PackageRuntimeStatus, 'running'>
+	logs?: Array<string>
+	error?: unknown
+}) {
+	const db = dbFromEnv(input.env)
+	if (!db || !input.handle) return
+	const finishedAt = new Date().toISOString()
+	const durationMs = Math.max(
+		0,
+		finishedAt ? Date.parse(finishedAt) - Date.parse(input.handle.startedAt) : 0,
+	)
+	const { errorName, errorMessage } = getErrorFields(input.error)
+	const logs = normalizeLogs(input.logs)
+	try {
+		if (logs.length > 0) {
+			const statements = logs.map((log) =>
+				db
+					.prepare(
+						`INSERT OR REPLACE INTO package_runtime_logs (
+							id, run_id, user_id, package_id, timestamp, sequence, level,
+							message, fields_json, created_at
+						) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
+					)
+					.bind(
+						`${input.handle.id}:${log.sequence}`,
+						input.handle.id,
+						input.handle.userId,
+						input.handle.packageId,
+						finishedAt,
+						log.sequence,
+						log.level,
+						log.message,
+						finishedAt,
+					),
+			)
+			const dbWithBatch = db as D1Database & { batch?: D1Database['batch'] }
+			if (dbWithBatch.batch) {
+				await dbWithBatch.batch(statements)
+			} else {
+				await Promise.all(statements.map((statement) => statement.run()))
+			}
+		}
+		await db
+			.prepare(
+				`UPDATE package_runtime_runs
+				SET status = ?, finished_at = ?, duration_ms = ?,
+					error_name = ?, error_message = ?, updated_at = ?
+				WHERE id = ? AND user_id = ?`,
+			)
+			.bind(
+				input.status,
+				finishedAt,
+				durationMs,
+				errorName,
+				errorMessage,
+				finishedAt,
+				input.handle.id,
+				input.handle.userId,
+			)
+			.run()
+	} catch (error) {
+		console.warn('package-runtime-debug-finish-failed', error)
+	}
+}
+
+export async function listPackageRuntimeRuns(input: {
+	env: Env
+	userId: string
+	packageId?: string | null
+	surface?: PackageRuntimeSurface | null
+	limit?: number | null
+}): Promise<Array<PackageRuntimeRunRecord>> {
+	const db = dbFromEnv(input.env)
+	if (!db) return []
+	const clauses = ['user_id = ?']
+	const params: Array<string | number> = [input.userId]
+	const packageId = normalizeOptionalString(input.packageId)
+	if (packageId) {
+		clauses.push('package_id = ?')
+		params.push(packageId)
+	}
+	if (input.surface) {
+		clauses.push('surface = ?')
+		params.push(input.surface)
+	}
+	const limit = Math.min(Math.max(input.limit ?? 25, 1), 100)
+	params.push(limit)
+	const result = await db
+		.prepare(
+			`SELECT *
+			FROM package_runtime_runs
+			WHERE ${clauses.join(' AND ')}
+			ORDER BY started_at DESC, id DESC
+			LIMIT ?`,
+		)
+		.bind(...params)
+		.all<Record<string, unknown>>()
+	return (result.results ?? []).map(mapRunRow)
+}
+
+export async function getPackageRuntimeRun(input: {
+	env: Env
+	userId: string
+	runId: string
+}): Promise<{
+	run: PackageRuntimeRunRecord
+	logs: Array<PackageRuntimeLogRecord>
+} | null> {
+	const db = dbFromEnv(input.env)
+	if (!db) return null
+	const runRow = await db
+		.prepare(
+			`SELECT *
+			FROM package_runtime_runs
+			WHERE id = ? AND user_id = ?
+			LIMIT 1`,
+		)
+		.bind(input.runId, input.userId)
+		.first<Record<string, unknown>>()
+	if (!runRow) return null
+	const logsResult = await db
+		.prepare(
+			`SELECT *
+			FROM package_runtime_logs
+			WHERE run_id = ? AND user_id = ?
+			ORDER BY sequence ASC`,
+		)
+		.bind(input.runId, input.userId)
+		.all<Record<string, unknown>>()
+	return {
+		run: mapRunRow(runRow),
+		logs: (logsResult.results ?? []).map(mapLogRow),
+	}
+}

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -558,7 +558,8 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 					packageId: binding.packageId,
 					kodyId: binding.kodyId,
 					sourceId: binding.sourceId,
-					publishedCommit: null,
+					publishedCommit:
+						runtime.loaded.packageSource.source.published_commit ?? null,
 					surface: 'service',
 					name: binding.serviceName,
 					storageId: runtime.storageId,

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -554,6 +554,18 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 					storageId: runtime.storageId,
 					writable: true,
 				},
+				runtimeDebug: {
+					packageId: binding.packageId,
+					kodyId: binding.kodyId,
+					sourceId: binding.sourceId,
+					publishedCommit: null,
+					surface: 'service',
+					name: binding.serviceName,
+					storageId: runtime.storageId,
+					metadata: {
+						mode: runtime.loaded.serviceDefinition?.mode ?? 'bounded',
+					},
+				},
 				executorTimeoutMs: runtime.executorTimeoutMs,
 			},
 		)

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -6,6 +6,7 @@ import {
 } from 'cloudflare:workers'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
 import { invokePackageExport } from '#worker/package-invocations/service.ts'
+import { packageWorkflowInvocationSource } from './package-invocation-sources.ts'
 import {
 	getSavedPackageById,
 	getSavedPackageByKodyId,
@@ -974,14 +975,14 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 				packageIds: [payload.packageId],
 				packageKodyIds: [payload.kodyId],
 				exportNames: [payload.exportName],
-				sources: ['package-workflow'],
+				sources: [packageWorkflowInvocationSource],
 			},
 			request: {
 				packageIdOrKodyId: payload.packageId,
 				exportName: payload.exportName,
 				params: payload.params,
 				idempotencyKey: payload.idempotencyKey,
-				source: 'package-workflow',
+				source: packageWorkflowInvocationSource,
 				topic: payload.workflowName,
 			},
 		})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add retained package runtime run/log tables and persistence helpers.
- Add package debug MCP capabilities to list recent runs and fetch run logs.
- Instrument live package execution surfaces including exports, workflows, subscriptions, jobs, services, apps, and retrievers.
- Optimize UTF-8 truncation, keep truncated metadata parseable, retain newest logs, and make debug finalization best-effort across setup/log/execution failure paths.
- Rebase on latest main and apply formatter changes required by the rebased tree.

## Testing
- `npx vitest run packages/worker/src/package-runtime/package-runtime-debug.node.test.ts --config vitest.node.config.ts`
- `npm run typecheck`
- `npm run format:check`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50999553-f644-4155-929d-0dcd27859d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50999553-f644-4155-929d-0dcd27859d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added package runtime debugging: list and inspect recent package executions with status, timing, errors, and ordered logs
  * Runtime debug context included across jobs, services, retrievers, invocations, and app runtime paths
  * Query runtime data by package, surface, and recency

* **Chores**
  * Persisted runtime metadata and logs to support debugging and history

* **Tests**
  * Added tests for persistence, log truncation, error normalization, and log retention behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/423)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->