### PR TITLE
Report package app failures to Sentry

### DIFF
--- a/packages/worker/src/app/handlers/package-app.node.test.ts
+++ b/packages/worker/src/app/handlers/package-app.node.test.ts
@@ -135,13 +135,17 @@ test('handlePackageAppRequest reports package app runtime failures to Sentry', a
 		'package_app.source_id',
 		'source-1',
 	)
-	expect(mockModule.sentryScope.setTag).toHaveBeenCalledWith(
+	expect(mockModule.sentryScope.setTag).not.toHaveBeenCalledWith(
 		'package_app.forwarded_path',
-		'/report',
+		expect.any(String),
 	)
-	expect(mockModule.sentryScope.setTag).toHaveBeenCalledWith(
+	expect(mockModule.sentryScope.setTag).not.toHaveBeenCalledWith(
+		'package_app.realtime_path',
+		expect.any(String),
+	)
+	expect(mockModule.sentryScope.setTag).not.toHaveBeenCalledWith(
 		'package_app.host_path',
-		'/packages/example/report',
+		expect.any(String),
 	)
 	expect(mockModule.sentryScope.setContext).toHaveBeenCalledWith(
 		'package_app',

--- a/packages/worker/src/app/handlers/package-app.node.test.ts
+++ b/packages/worker/src/app/handlers/package-app.node.test.ts
@@ -120,6 +120,10 @@ test('handlePackageAppRequest reports package app runtime failures to Sentry', a
 	expect(mockModule.captureException).toHaveBeenCalledWith(expect.any(Error))
 	expect(mockModule.sentryScope.setLevel).toHaveBeenCalledWith('error')
 	expect(mockModule.sentryScope.setTag).toHaveBeenCalledWith(
+		'package_app.phase',
+		'host-setup',
+	)
+	expect(mockModule.sentryScope.setTag).toHaveBeenCalledWith(
 		'package_app.kody_id',
 		'example',
 	)
@@ -142,6 +146,7 @@ test('handlePackageAppRequest reports package app runtime failures to Sentry', a
 	expect(mockModule.sentryScope.setContext).toHaveBeenCalledWith(
 		'package_app',
 		expect.objectContaining({
+			phase: 'host-setup',
 			kodyId: 'example',
 			packageId: 'package-1',
 			packageName: '@kody/example',
@@ -150,6 +155,41 @@ test('handlePackageAppRequest reports package app runtime failures to Sentry', a
 			hostPath: '/packages/example/report',
 		}),
 	)
+})
+
+test('handlePackageAppRequest does not report package entrypoint failures to Kody Sentry', async () => {
+	mockModule.loadPackageSourceBySourceId.mockResolvedValueOnce({
+		source: {
+			published_commit: 'commit-1',
+			manifest_path: 'package.json',
+			source_root: '/',
+		},
+		files: {
+			'package.json': JSON.stringify({
+				name: '@kody/example',
+				kody: { id: 'example', app: { entry: 'app.js' } },
+			}),
+			'app.js': 'export default {}',
+		},
+	})
+	mockModule.buildPackageAppWorker.mockResolvedValueOnce({
+		entrypointName: 'entry',
+		stub: {
+			getEntrypoint: () => ({
+				async fetch() {
+					throw new Error('package code failed')
+				},
+			}),
+		},
+	})
+
+	const response = await handlePackageAppRequest(
+		new Request('https://example.com/packages/example'),
+		{} as Env,
+	)
+
+	expect(response.status).toBe(500)
+	expect(mockModule.captureException).not.toHaveBeenCalled()
 })
 
 test('handlePackageAppRequest routes websocket package paths to realtime session manager', async () => {

--- a/packages/worker/src/app/handlers/package-app.node.test.ts
+++ b/packages/worker/src/app/handlers/package-app.node.test.ts
@@ -1,6 +1,16 @@
-import { expect, test, vi } from 'vitest'
+import { beforeEach, expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
+	captureException: vi.fn(),
+	getSentryClient: vi.fn(() => ({
+		getOptions: () => ({ dsn: 'https://dsn' }),
+	})),
+	isSentryInitialized: vi.fn(() => true),
+	sentryScope: {
+		setLevel: vi.fn(),
+		setTag: vi.fn(),
+		setContext: vi.fn(),
+	},
 	readAuthenticatedAppUser: vi.fn(async () => ({
 		email: 'user@example.com',
 		displayName: 'User',
@@ -33,6 +43,16 @@ const mockModule = vi.hoisted(() => ({
 	packageRealtimeConnect: vi.fn(
 		async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
 	),
+}))
+
+vi.mock('@sentry/cloudflare', () => ({
+	isInitialized: (...args: Array<unknown>) =>
+		mockModule.isSentryInitialized(...args),
+	getClient: (...args: Array<unknown>) => mockModule.getSentryClient(...args),
+	withScope: (callback: (scope: typeof mockModule.sentryScope) => void) =>
+		callback(mockModule.sentryScope),
+	captureException: (...args: Array<unknown>) =>
+		mockModule.captureException(...args),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -75,6 +95,10 @@ vi.mock('#worker/package-runtime/realtime-session.ts', () => ({
 
 const { handlePackageAppRequest } = await import('./package-app.ts')
 
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
 test('handlePackageAppRequest returns a plain 500 when package app runtime setup fails', async () => {
 	const response = await handlePackageAppRequest(
 		new Request('https://example.com/packages/example'),
@@ -83,6 +107,49 @@ test('handlePackageAppRequest returns a plain 500 when package app runtime setup
 
 	expect(response.status).toBe(500)
 	await expect(response.text()).resolves.toBe('Internal Server Error')
+})
+
+test('handlePackageAppRequest reports package app runtime failures to Sentry', async () => {
+	const response = await handlePackageAppRequest(
+		new Request('https://example.com/packages/example/report?tab=errors'),
+		{} as Env,
+	)
+
+	expect(response.status).toBe(500)
+	expect(mockModule.captureException).toHaveBeenCalledTimes(1)
+	expect(mockModule.captureException).toHaveBeenCalledWith(expect.any(Error))
+	expect(mockModule.sentryScope.setLevel).toHaveBeenCalledWith('error')
+	expect(mockModule.sentryScope.setTag).toHaveBeenCalledWith(
+		'package_app.kody_id',
+		'example',
+	)
+	expect(mockModule.sentryScope.setTag).toHaveBeenCalledWith(
+		'package_app.package_id',
+		'package-1',
+	)
+	expect(mockModule.sentryScope.setTag).toHaveBeenCalledWith(
+		'package_app.source_id',
+		'source-1',
+	)
+	expect(mockModule.sentryScope.setTag).toHaveBeenCalledWith(
+		'package_app.forwarded_path',
+		'/report',
+	)
+	expect(mockModule.sentryScope.setTag).toHaveBeenCalledWith(
+		'package_app.host_path',
+		'/packages/example/report',
+	)
+	expect(mockModule.sentryScope.setContext).toHaveBeenCalledWith(
+		'package_app',
+		expect.objectContaining({
+			kodyId: 'example',
+			packageId: 'package-1',
+			packageName: '@kody/example',
+			sourceId: 'source-1',
+			forwardedPath: '/report',
+			hostPath: '/packages/example/report',
+		}),
+	)
 })
 
 test('handlePackageAppRequest routes websocket package paths to realtime session manager', async () => {

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -48,6 +48,7 @@ function parsePackageRealtimePath(restPath: string) {
 
 function reportPackageAppFailure(input: {
 	error: unknown
+	phase: 'host-setup' | 'realtime-connect'
 	requestUrl: URL
 	kodyId: string
 	packageId: string
@@ -63,6 +64,7 @@ function reportPackageAppFailure(input: {
 
 		Sentry.withScope((scope) => {
 			scope.setLevel('error')
+			scope.setTag('package_app.phase', input.phase)
 			scope.setTag('package_app.kody_id', input.kodyId)
 			scope.setTag('package_app.package_id', input.packageId)
 			scope.setTag('package_app.source_id', input.sourceId)
@@ -70,6 +72,7 @@ function reportPackageAppFailure(input: {
 			scope.setTag('package_app.realtime_path', input.realtimePath)
 			scope.setTag('package_app.host_path', input.requestUrl.pathname)
 			scope.setContext('package_app', {
+				phase: input.phase,
 				kodyId: input.kodyId,
 				packageId: input.packageId,
 				packageName: input.packageName,
@@ -113,12 +116,10 @@ export async function handlePackageAppRequest(
 	if (!savedPackage || !savedPackage.hasApp) {
 		return new Response('Saved package app not found.', { status: 404 })
 	}
-	try {
-		const baseUrl = getAppBaseUrl({ env, requestUrl: request.url })
-		const packageRealtimePath = parsePackageRealtimePath(
-			packageRealtimeRestPath,
-		)
-		if (packageRealtimePath && request.headers.get('Upgrade') === 'websocket') {
+	const baseUrl = getAppBaseUrl({ env, requestUrl: request.url })
+	const packageRealtimePath = parsePackageRealtimePath(packageRealtimeRestPath)
+	if (packageRealtimePath && request.headers.get('Upgrade') === 'websocket') {
+		try {
 			return await packageRealtimeSessionRpc({
 				env,
 				userId: user.mcpUser.userId,
@@ -127,7 +128,26 @@ export async function handlePackageAppRequest(
 				sourceId: savedPackage.sourceId,
 				baseUrl,
 			}).connect(request, packageRealtimePath.facet)
+		} catch (error) {
+			console.error('Package realtime handler failed:', error)
+			reportPackageAppFailure({
+				error,
+				phase: 'realtime-connect',
+				requestUrl,
+				kodyId: savedPackage.kodyId,
+				packageId: savedPackage.id,
+				packageName: savedPackage.name,
+				sourceId: savedPackage.sourceId,
+				forwardedPath: forwardedPackageRestPath,
+				realtimePath: packageRealtimeRestPath,
+			})
+			return new Response('Internal Server Error', { status: 500 })
 		}
+	}
+
+	let forwardedRequest: Request
+	let entrypoint: { fetch(request: Request): Promise<Response> }
+	try {
 		const packageSource = await loadPackageSourceBySourceId({
 			env,
 			baseUrl,
@@ -161,15 +181,15 @@ export async function handlePackageAppRequest(
 				callerContext,
 			},
 		})
-		const entrypoint = appWorker.stub.getEntrypoint(appWorker.entrypointName)
+		entrypoint = appWorker.stub.getEntrypoint(appWorker.entrypointName)
 		const forwardedUrl = new URL(requestUrl)
 		forwardedUrl.pathname = forwardedPackageRestPath
-		const forwardedRequest = new Request(forwardedUrl.toString(), request)
-		return await entrypoint.fetch(forwardedRequest)
+		forwardedRequest = new Request(forwardedUrl.toString(), request)
 	} catch (error) {
 		console.error('Package app handler failed:', error)
 		reportPackageAppFailure({
 			error,
+			phase: 'host-setup',
 			requestUrl,
 			kodyId: savedPackage.kodyId,
 			packageId: savedPackage.id,
@@ -178,6 +198,13 @@ export async function handlePackageAppRequest(
 			forwardedPath: forwardedPackageRestPath,
 			realtimePath: packageRealtimeRestPath,
 		})
+		return new Response('Internal Server Error', { status: 500 })
+	}
+
+	try {
+		return await entrypoint.fetch(forwardedRequest)
+	} catch (error) {
+		console.error('Package app entrypoint failed:', error)
 		return new Response('Internal Server Error', { status: 500 })
 	}
 }

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/cloudflare'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { redirectToLogin } from '#app/auth-redirect.ts'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
@@ -42,6 +43,45 @@ function parsePackageRealtimePath(restPath: string) {
 		}
 	} catch {
 		return null
+	}
+}
+
+function reportPackageAppFailure(input: {
+	error: unknown
+	requestUrl: URL
+	kodyId: string
+	packageId: string
+	packageName: string
+	sourceId: string
+	forwardedPath: string
+	realtimePath: string
+}) {
+	try {
+		if (!Sentry.isInitialized()) return
+		const client = Sentry.getClient()
+		if (!client?.getOptions().dsn) return
+
+		Sentry.withScope((scope) => {
+			scope.setLevel('error')
+			scope.setTag('package_app.kody_id', input.kodyId)
+			scope.setTag('package_app.package_id', input.packageId)
+			scope.setTag('package_app.source_id', input.sourceId)
+			scope.setTag('package_app.forwarded_path', input.forwardedPath)
+			scope.setTag('package_app.realtime_path', input.realtimePath)
+			scope.setTag('package_app.host_path', input.requestUrl.pathname)
+			scope.setContext('package_app', {
+				kodyId: input.kodyId,
+				packageId: input.packageId,
+				packageName: input.packageName,
+				sourceId: input.sourceId,
+				forwardedPath: input.forwardedPath,
+				realtimePath: input.realtimePath,
+				hostPath: input.requestUrl.pathname,
+			})
+			Sentry.captureException(input.error)
+		})
+	} catch (sentryError) {
+		console.warn('Failed to report package app failure to Sentry.', sentryError)
 	}
 }
 
@@ -128,6 +168,16 @@ export async function handlePackageAppRequest(
 		return await entrypoint.fetch(forwardedRequest)
 	} catch (error) {
 		console.error('Package app handler failed:', error)
+		reportPackageAppFailure({
+			error,
+			requestUrl,
+			kodyId: savedPackage.kodyId,
+			packageId: savedPackage.id,
+			packageName: savedPackage.name,
+			sourceId: savedPackage.sourceId,
+			forwardedPath: forwardedPackageRestPath,
+			realtimePath: packageRealtimeRestPath,
+		})
 		return new Response('Internal Server Error', { status: 500 })
 	}
 }

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -68,9 +68,6 @@ function reportPackageAppFailure(input: {
 			scope.setTag('package_app.kody_id', input.kodyId)
 			scope.setTag('package_app.package_id', input.packageId)
 			scope.setTag('package_app.source_id', input.sourceId)
-			scope.setTag('package_app.forwarded_path', input.forwardedPath)
-			scope.setTag('package_app.realtime_path', input.realtimePath)
-			scope.setTag('package_app.host_path', input.requestUrl.pathname)
 			scope.setContext('package_app', {
 				phase: input.phase,
 				kodyId: input.kodyId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Report only Kody-owned package app host/setup failures to Sentry before returning the existing plain 500 response.
- Attach low-cardinality package id, Kody id, source id, and failure phase as Sentry tags; keep request paths in event context only.
- Keep package entrypoint exceptions out of Kody Sentry so user package code failures do not spam the host project.
- Add node coverage for both boundaries: host setup failures are captured; package entrypoint failures are not.

## Validation
- PR checks are green after rebasing on latest `main`: Validate, preview deploy, CodeRabbit, and Cursor Bugbot.
- Pre-push typecheck, unit tests, and E2E passed while pushing the branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56efe8f1-e047-4f20-992f-09ab6447b855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56efe8f1-e047-4f20-992f-09ab6447b855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for package application operations with improved error tracking across connection and setup phases.

* **Tests**
  * Expanded test coverage for error conditions, including validation of error reporting and handling behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/424)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->