### PR TITLE
Improve package app error responses

### DIFF
--- a/packages/worker/src/app/handlers/package-app.node.test.ts
+++ b/packages/worker/src/app/handlers/package-app.node.test.ts
@@ -99,14 +99,44 @@ beforeEach(() => {
 	vi.clearAllMocks()
 })
 
-test('handlePackageAppRequest returns a plain 500 when package app runtime setup fails', async () => {
+test('handlePackageAppRequest returns a helpful HTML 500 when package app runtime setup fails', async () => {
 	const response = await handlePackageAppRequest(
 		new Request('https://example.com/packages/example'),
 		{} as Env,
 	)
 
 	expect(response.status).toBe(500)
-	await expect(response.text()).resolves.toBe('Internal Server Error')
+	expect(response.headers.get('content-type')).toContain('text/html')
+	const body = await response.text()
+	expect(body).toContain('Package app could not be prepared')
+	expect(body).toContain(
+		'Kody could not load or prepare this package app runtime',
+	)
+	expect(body).toContain('@kody/example')
+	expect(body).toContain('example')
+})
+
+test('handlePackageAppRequest returns a helpful JSON 500 for API package app requests', async () => {
+	const response = await handlePackageAppRequest(
+		new Request('https://example.com/packages/example/api/data', {
+			headers: { accept: 'application/json' },
+		}),
+		{} as Env,
+	)
+
+	expect(response.status).toBe(500)
+	await expect(response.json()).resolves.toEqual({
+		error: 'Package app could not be prepared',
+		message:
+			'Kody could not load or prepare this package app runtime before your request reached the package code.',
+		next_step:
+			'This has been reported to Kody. Try again shortly, or ask the package owner to republish the package if it keeps happening.',
+		package: {
+			name: '@kody/example',
+			kody_id: 'example',
+		},
+		request_path: '/packages/example/api/data',
+	})
 })
 
 test('handlePackageAppRequest reports package app runtime failures to Sentry', async () => {
@@ -193,6 +223,10 @@ test('handlePackageAppRequest does not report package entrypoint failures to Kod
 	)
 
 	expect(response.status).toBe(500)
+	const body = await response.text()
+	expect(body).toContain('Package app crashed')
+	expect(body).toContain('its own request handler failed')
+	expect(body).toContain('package runtime debug runs')
 	expect(mockModule.captureException).not.toHaveBeenCalled()
 })
 

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -11,6 +11,7 @@ import {
 	createPackageAppCallerContext,
 } from '#worker/package-runtime/package-app.ts'
 import { packageRealtimeSessionRpc } from '#worker/package-runtime/realtime-session.ts'
+import { wantsJson } from '#worker/utils.ts'
 
 function parsePackageAppPath(pathname: string) {
 	const parts = pathname.split('/').filter(Boolean)
@@ -91,11 +92,6 @@ type PackageAppFailureKind =
 	| 'host-setup'
 	| 'package-entrypoint'
 	| 'realtime-connect'
-
-function wantsJson(request: Request) {
-	const accept = request.headers.get('accept')
-	return accept?.includes('application/json') ?? false
-}
 
 function createPackageAppErrorResponse(input: {
 	request: Request

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -1,4 +1,6 @@
 import * as Sentry from '@sentry/cloudflare'
+import { html } from 'remix/html-template'
+import { createHtmlResponse } from 'remix/response/html'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { redirectToLogin } from '#app/auth-redirect.ts'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
@@ -85,6 +87,148 @@ function reportPackageAppFailure(input: {
 	}
 }
 
+type PackageAppFailureKind =
+	| 'host-setup'
+	| 'package-entrypoint'
+	| 'realtime-connect'
+
+function wantsJson(request: Request) {
+	const accept = request.headers.get('accept')
+	return accept?.includes('application/json') ?? false
+}
+
+function createPackageAppErrorResponse(input: {
+	request: Request
+	kind: PackageAppFailureKind
+	kodyId: string
+	packageName: string
+}) {
+	const messages = {
+		'host-setup': {
+			title: 'Package app could not be prepared',
+			summary:
+				'Kody could not load or prepare this package app runtime before your request reached the package code.',
+			nextStep:
+				'This has been reported to Kody. Try again shortly, or ask the package owner to republish the package if it keeps happening.',
+		},
+		'package-entrypoint': {
+			title: 'Package app crashed',
+			summary:
+				'The package app started, but its own request handler failed while processing this request.',
+			nextStep:
+				'Ask the package owner to inspect recent package runtime debug runs for this app.',
+		},
+		'realtime-connect': {
+			title: 'Package realtime connection failed',
+			summary:
+				'Kody could not establish the realtime session for this package app.',
+			nextStep:
+				'This has been reported to Kody. Try reconnecting, or ask the package owner to retry after checking the package app.',
+		},
+	} satisfies Record<
+		PackageAppFailureKind,
+		{ title: string; summary: string; nextStep: string }
+	>
+	const message = messages[input.kind]
+	const requestPath = new URL(input.request.url).pathname
+	const body = {
+		error: message.title,
+		message: message.summary,
+		next_step: message.nextStep,
+		package: {
+			name: input.packageName,
+			kody_id: input.kodyId,
+		},
+		request_path: requestPath,
+	}
+	if (wantsJson(input.request)) {
+		return Response.json(body, { status: 500 })
+	}
+	return createHtmlResponse(
+		html`<!doctype html>
+			<html lang="en">
+				<head>
+					<meta charset="utf-8" />
+					<meta name="viewport" content="width=device-width, initial-scale=1" />
+					<title>${message.title}</title>
+					<style>
+						:root {
+							color-scheme: light dark;
+							font-family:
+								ui-sans-serif,
+								system-ui,
+								-apple-system,
+								BlinkMacSystemFont,
+								'Segoe UI',
+								sans-serif;
+							line-height: 1.5;
+						}
+						body {
+							margin: 0;
+							background: #f8fafc;
+							color: #0f172a;
+						}
+						main {
+							box-sizing: border-box;
+							max-width: 46rem;
+							margin: 0 auto;
+							padding: min(12vh, 6rem) 1.25rem;
+						}
+						.card {
+							border: 1px solid #cbd5e1;
+							border-radius: 1rem;
+							background: white;
+							padding: clamp(1.25rem, 4vw, 2rem);
+							box-shadow: 0 20px 60px rgb(15 23 42 / 0.12);
+						}
+						h1 {
+							margin: 0 0 0.75rem;
+							font-size: clamp(1.75rem, 4vw, 2.75rem);
+							line-height: 1;
+						}
+						dl {
+							display: grid;
+							grid-template-columns: max-content 1fr;
+							gap: 0.35rem 0.75rem;
+							margin: 1.5rem 0 0;
+						}
+						dt {
+							font-weight: 700;
+						}
+						@media (prefers-color-scheme: dark) {
+							body {
+								background: #020617;
+								color: #e2e8f0;
+							}
+							.card {
+								border-color: #334155;
+								background: #0f172a;
+							}
+						}
+					</style>
+				</head>
+				<body>
+					<main>
+						<section class="card" aria-labelledby="package-app-error-title">
+							<h1 id="package-app-error-title">${message.title}</h1>
+							<p>${message.summary}</p>
+							<p>${message.nextStep}</p>
+							<dl>
+								<dt>Package</dt>
+								<dd>${input.packageName}</dd>
+								<dt>Kody ID</dt>
+								<dd><code>${input.kodyId}</code></dd>
+								<dt>Path</dt>
+								<dd><code>${requestPath}</code></dd>
+							</dl>
+						</section>
+					</main>
+				</body>
+			</html>`,
+		{ status: 500 },
+	)
+}
+
 export async function handlePackageAppRequest(
 	request: Request,
 	env: Env,
@@ -138,7 +282,12 @@ export async function handlePackageAppRequest(
 				forwardedPath: forwardedPackageRestPath,
 				realtimePath: packageRealtimeRestPath,
 			})
-			return new Response('Internal Server Error', { status: 500 })
+			return createPackageAppErrorResponse({
+				request,
+				kind: 'realtime-connect',
+				kodyId: savedPackage.kodyId,
+				packageName: savedPackage.name,
+			})
 		}
 	}
 
@@ -195,13 +344,23 @@ export async function handlePackageAppRequest(
 			forwardedPath: forwardedPackageRestPath,
 			realtimePath: packageRealtimeRestPath,
 		})
-		return new Response('Internal Server Error', { status: 500 })
+		return createPackageAppErrorResponse({
+			request,
+			kind: 'host-setup',
+			kodyId: savedPackage.kodyId,
+			packageName: savedPackage.name,
+		})
 	}
 
 	try {
 		return await entrypoint.fetch(forwardedRequest)
 	} catch (error) {
 		console.error('Package app entrypoint failed:', error)
-		return new Response('Internal Server Error', { status: 500 })
+		return createPackageAppErrorResponse({
+			request,
+			kind: 'package-entrypoint',
+			kodyId: savedPackage.kodyId,
+			packageName: savedPackage.name,
+		})
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace generic package app 500 bodies with safe, actionable HTML or JSON responses.
- Distinguish Kody host setup/realtime failures from package entrypoint crashes.
- Keep stack traces/internal error details out of user-facing responses while pointing package owners to runtime debug runs.
- Reuse the shared `wantsJson` helper and add coverage for HTML, JSON, and package-entrypoint failure messaging.

## Validation
- PR checks are green after rebasing on latest `main`: Validate, preview deploy, CodeRabbit, and Cursor Bugbot.
- Pre-push typecheck, unit tests, and E2E passed while pushing the branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56efe8f1-e047-4f20-992f-09ab6447b855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56efe8f1-e047-4f20-992f-09ab6447b855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses when package apps fail: HTML for browser requests and structured JSON for API calls.
  * Responses now include contextual package metadata, clearer titles/summaries, and actionable debug guidance.
  * Failure cases (host setup, realtime connect, entrypoint crash) report distinct, user-facing messages.

* **Tests**
  * Updated tests to assert richer HTML and JSON 500 responses and enhanced crash/debug messaging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/426)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->