### PR TITLE
Stabilize external saved-package publishing

### DIFF
--- a/packages/worker/src/mcp/capabilities/error-message.ts
+++ b/packages/worker/src/mcp/capabilities/error-message.ts
@@ -1,0 +1,3 @@
+export function getErrorMessage(error: unknown) {
+	return error instanceof Error ? error.message : String(error)
+}

--- a/packages/worker/src/mcp/capabilities/meta/execute.ts
+++ b/packages/worker/src/mcp/capabilities/meta/execute.ts
@@ -6,6 +6,7 @@ import {
 } from '#mcp/executor.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { getErrorMessage } from '#mcp/capabilities/error-message.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import {
 	conversationIdInputField,
@@ -29,10 +30,6 @@ const executeOutputSchema = z.object({
 	errorDetails: z.unknown().optional(),
 	logs: z.array(z.unknown()),
 })
-
-function getErrorMessage(error: unknown) {
-	return error instanceof Error ? error.message : String(error)
-}
 
 export const executeCapability = defineDomainCapability(
 	capabilityDomainNames.meta,

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -1,11 +1,17 @@
 import { beforeEach, expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
+	captureException: vi.fn(),
 	getSavedPackageById: vi.fn(),
 	getSavedPackageByKodyId: vi.fn(),
 	getEntitySourceById: vi.fn(),
 	resolveArtifactSourceHead: vi.fn(),
 	publishFromExternalRef: vi.fn(),
+}))
+
+vi.mock('@sentry/cloudflare', () => ({
+	captureException: (...args: Array<unknown>) =>
+		mockModule.captureException(...args),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -175,6 +181,144 @@ test('passes allow_force through to the publish pipeline', async () => {
 			allowForce: true,
 		}),
 	)
+})
+
+test('retries transient Durable Object resets with a fresh external publish session', async () => {
+	const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-new',
+	})
+	mockModule.publishFromExternalRef
+		.mockRejectedValueOnce(
+			new Error('Durable Object exceeded its CPU time limit and was reset'),
+		)
+		.mockResolvedValueOnce({
+			status: 'published',
+			previous_commit: 'commit-old',
+			published_commit: 'commit-new',
+			manifest: {},
+			checks: [{ kind: 'manifest', ok: true, message: 'ok' }],
+		})
+
+	try {
+		const result = await publishExternalPushCapability.handler(
+			{ package_id: 'package-1' },
+			createContext(),
+		)
+
+		expect(result.status).toBe('published')
+		expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(2)
+		expect(mockModule.publishFromExternalRef).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				sessionId: 'external-publish-source-1',
+			}),
+		)
+		expect(mockModule.publishFromExternalRef).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				sessionId: 'external-publish-source-1-retry-2',
+			}),
+		)
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'package_publish_external_push transient Durable Object reset',
+			),
+		)
+		expect(mockModule.captureException).toHaveBeenCalledWith(
+			expect.any(Error),
+			expect.objectContaining({
+				tags: {
+					scope: 'package_publish_external_push.transient-do-reset',
+				},
+			}),
+		)
+	} finally {
+		warnSpy.mockRestore()
+	}
+})
+
+test('returns already_published when a retry observes that the reset attempt committed', async () => {
+	const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-new',
+	})
+	mockModule.getEntitySourceById
+		.mockResolvedValueOnce({
+			id: 'source-1',
+			user_id: 'user-1',
+			entity_kind: 'package',
+			entity_id: 'package-1',
+			repo_id: 'package-package-1',
+			published_commit: 'commit-old',
+			indexed_commit: null,
+			manifest_path: 'package.json',
+			source_root: '/',
+			last_external_check_at: null,
+			created_at: '2026-05-04T00:00:00.000Z',
+			updated_at: '2026-05-04T00:00:00.000Z',
+		})
+		.mockResolvedValueOnce({
+			id: 'source-1',
+			user_id: 'user-1',
+			entity_kind: 'package',
+			entity_id: 'package-1',
+			repo_id: 'package-package-1',
+			published_commit: 'commit-new',
+			indexed_commit: null,
+			manifest_path: 'package.json',
+			source_root: '/',
+			last_external_check_at: null,
+			created_at: '2026-05-04T00:00:00.000Z',
+			updated_at: '2026-05-04T00:00:00.000Z',
+		})
+	mockModule.publishFromExternalRef.mockRejectedValueOnce(
+		new Error(
+			"Durable Object's isolate exceeded its memory limit and was reset",
+		),
+	)
+
+	try {
+		const result = await publishExternalPushCapability.handler(
+			{ package_id: 'package-1' },
+			createContext(),
+		)
+
+		expect(result).toEqual({
+			status: 'already_published',
+			published_commit: 'commit-new',
+		})
+		expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(1)
+	} finally {
+		warnSpy.mockRestore()
+	}
+})
+
+test('replaces exhausted transient reset attempts with a stable error message', async () => {
+	const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-new',
+	})
+	mockModule.publishFromExternalRef.mockRejectedValue(
+		new Error('Durable Object exceeded its CPU time limit and was reset'),
+	)
+
+	try {
+		await expect(
+			publishExternalPushCapability.handler(
+				{ package_id: 'package-1' },
+				createContext(),
+			),
+		).rejects.toThrow(
+			'package_publish_external_push could not recover after 3 transient Durable Object reset attempts',
+		)
+		expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(3)
+	} finally {
+		warnSpy.mockRestore()
+	}
 })
 
 test('check failure leaves mutation to the shared publish pipeline', async () => {

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -316,6 +316,7 @@ test('replaces exhausted transient reset attempts with a stable error message', 
 			'package_publish_external_push could not recover after 3 transient Durable Object reset attempts',
 		)
 		expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(3)
+		expect(mockModule.captureException).toHaveBeenCalledTimes(3)
 	} finally {
 		warnSpy.mockRestore()
 	}

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/cloudflare'
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { getErrorMessage } from '#mcp/capabilities/error-message.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
@@ -14,10 +15,6 @@ const inputSchema = z.object({
 })
 
 const externalPublishRetryDelaysMs = [100, 500] as const
-
-function getErrorMessage(error: unknown) {
-	return error instanceof Error ? error.message : String(error)
-}
 
 function isTransientDurableObjectResetError(error: unknown) {
 	const message = getErrorMessage(error)

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/cloudflare'
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
@@ -11,6 +12,63 @@ const inputSchema = z.object({
 	kody_id: z.string().min(1).optional(),
 	allow_force: z.boolean().optional().default(false),
 })
+
+const externalPublishRetryDelaysMs = [100, 500] as const
+
+function getErrorMessage(error: unknown) {
+	return error instanceof Error ? error.message : String(error)
+}
+
+function isTransientDurableObjectResetError(error: unknown) {
+	const message = getErrorMessage(error)
+	return (
+		message.includes('Durable Object exceeded its CPU time limit') ||
+		message.includes("Durable Object's isolate exceeded its memory limit") ||
+		message.includes('Durable Object was reset')
+	)
+}
+
+function logExternalPublishRetry(input: {
+	sourceId: string
+	repoId: string
+	packageId: string
+	newCommit: string
+	attempt: number
+	nextDelayMs: number
+	error: unknown
+}) {
+	const errorMessage = getErrorMessage(input.error)
+	console.warn(
+		JSON.stringify({
+			message: 'package_publish_external_push transient Durable Object reset',
+			sourceId: input.sourceId,
+			repoId: input.repoId,
+			packageId: input.packageId,
+			newCommit: input.newCommit,
+			attempt: input.attempt,
+			nextDelayMs: input.nextDelayMs,
+			errorMessage,
+		}),
+	)
+	Sentry.captureException(input.error, {
+		tags: {
+			scope: 'package_publish_external_push.transient-do-reset',
+		},
+		extra: {
+			sourceId: input.sourceId,
+			repoId: input.repoId,
+			packageId: input.packageId,
+			newCommit: input.newCommit,
+			attempt: input.attempt,
+			nextDelayMs: input.nextDelayMs,
+			errorMessage,
+		},
+	})
+}
+
+async function delay(ms: number) {
+	await new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 const checkSchema = z.object({
 	kind: z.enum([
@@ -65,38 +123,79 @@ export const publishExternalPushCapability = defineDomainCapability(
 		outputSchema,
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
-			const { source } = await resolveOwnedPackageSource({
-				db: ctx.env.APP_DB,
-				userId: user.userId,
-				args: {
-					package_id: args.package_id,
-					kody_id: args.kody_id,
-				},
-			})
-			const publishedCommit = source.published_commit
-			const head = await resolveArtifactSourceHead(ctx.env, source.repo_id)
-			const newCommit = head.commit
-			if (!newCommit) {
-				throw new Error(
-					`Artifacts repo "${source.repo_id}" has no published HEAD to reconcile.`,
-				)
+			const maxAttempts = externalPublishRetryDelaysMs.length + 1
+			let lastTransientError: unknown = null
+			for (
+				let attemptIndex = 0;
+				attemptIndex < maxAttempts;
+				attemptIndex += 1
+			) {
+				const attempt = attemptIndex + 1
+				const { packageId, source } = await resolveOwnedPackageSource({
+					db: ctx.env.APP_DB,
+					userId: user.userId,
+					args: {
+						package_id: args.package_id,
+						kody_id: args.kody_id,
+					},
+				})
+				const publishedCommit = source.published_commit
+				const head = await resolveArtifactSourceHead(ctx.env, source.repo_id)
+				const newCommit = head.commit
+				if (!newCommit) {
+					throw new Error(
+						`Artifacts repo "${source.repo_id}" has no published HEAD to reconcile.`,
+					)
+				}
+				if (newCommit === publishedCommit) {
+					return {
+						status: 'already_published',
+						published_commit: publishedCommit,
+					} as const
+				}
+				const sessionId =
+					attemptIndex === 0
+						? `external-publish-${source.id}`
+						: `external-publish-${source.id}-retry-${attempt}`
+				try {
+					return await repoSessionRpc(
+						ctx.env,
+						sessionId,
+					).publishFromExternalRef({
+						sessionId,
+						sourceId: source.id,
+						userId: user.userId,
+						newCommit,
+						expectedHead: newCommit,
+						allowForce: args.allow_force,
+						baseUrl: ctx.callerContext.baseUrl,
+					})
+				} catch (error) {
+					if (!isTransientDurableObjectResetError(error)) {
+						throw error
+					}
+					lastTransientError = error
+					if (attemptIndex >= externalPublishRetryDelaysMs.length) {
+						break
+					}
+					const nextDelayMs = externalPublishRetryDelaysMs[attemptIndex] ?? 0
+					logExternalPublishRetry({
+						sourceId: source.id,
+						repoId: source.repo_id,
+						packageId,
+						newCommit,
+						attempt,
+						nextDelayMs,
+						error,
+					})
+					await delay(nextDelayMs)
+				}
 			}
-			if (newCommit === publishedCommit) {
-				return {
-					status: 'already_published',
-					published_commit: publishedCommit,
-				} as const
-			}
-			const sessionId = `external-publish-${source.id}`
-			return repoSessionRpc(ctx.env, sessionId).publishFromExternalRef({
-				sessionId,
-				sourceId: source.id,
-				userId: user.userId,
-				newCommit,
-				expectedHead: newCommit,
-				allowForce: args.allow_force,
-				baseUrl: ctx.callerContext.baseUrl,
-			})
+			throw new Error(
+				`package_publish_external_push could not recover after ${maxAttempts} transient Durable Object reset attempts: ${getErrorMessage(
+					lastTransientError,
+				)}`,
+			)
 		},
 	},
 )

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -172,10 +172,10 @@ export const publishExternalPushCapability = defineDomainCapability(
 						throw error
 					}
 					lastTransientError = error
-					if (attemptIndex >= externalPublishRetryDelaysMs.length) {
-						break
-					}
-					const nextDelayMs = externalPublishRetryDelaysMs[attemptIndex] ?? 0
+					const willRetry = attemptIndex < externalPublishRetryDelaysMs.length
+					const nextDelayMs = willRetry
+						? (externalPublishRetryDelaysMs[attemptIndex] ?? 0)
+						: 0
 					logExternalPublishRetry({
 						sourceId: source.id,
 						repoId: source.repo_id,
@@ -185,6 +185,9 @@ export const publishExternalPushCapability = defineDomainCapability(
 						nextDelayMs,
 						error,
 					})
+					if (!willRetry) {
+						break
+					}
 					await delay(nextDelayMs)
 				}
 			}

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -129,6 +129,61 @@ function createPackageManifest(input: {
 	})
 }
 
+test('runRepoChecks keeps non-code source files for publish snapshots while excluding git internals', async () => {
+	const files = new Map<string, string>([
+		[
+			'package.json',
+			createPackageManifest({
+				packageName: '@kody/static-assets',
+				kodyId: 'static-assets',
+				description: 'Includes static assets',
+				exports: {
+					'.': './src/index.ts',
+				},
+			}),
+		],
+		['src/index.ts', 'export const ready = true\n'],
+		['styles/app.css', 'body { color: red; }\n'],
+		['public/icon.svg', '<svg />\n'],
+		['.git/config', '[remote "origin"]\n'],
+	])
+	let globPattern = ''
+	let snapshotFiles = new Map<string, string>()
+	const snapshot = createSnapshotFromFiles(snapshotFiles)
+	mockModule.createFileSystemSnapshot.mockImplementation(async (input) => {
+		snapshotFiles = await collectSnapshotFiles(
+			input as AsyncIterable<readonly [string, string]>,
+		)
+		snapshot.read.mockImplementation(
+			(path: string) => snapshotFiles.get(path) ?? null,
+		)
+		return snapshot
+	})
+
+	const result = await runRepoChecks({
+		workspace: {
+			async readFile(path: string) {
+				return files.get(path) ?? null
+			},
+			async glob(pattern: string) {
+				globPattern = pattern
+				return Array.from(files.keys()).map((path) => ({ path, type: 'file' }))
+			},
+		},
+		manifestPath: 'package.json',
+		sourceRoot: '/',
+	})
+
+	expect(globPattern).toBe('**/*')
+	expect(result.sourceFiles).toEqual({
+		'package.json': files.get('package.json'),
+		'src/index.ts': files.get('src/index.ts'),
+		'styles/app.css': files.get('styles/app.css'),
+		'public/icon.svg': files.get('public/icon.svg'),
+	})
+	expect(snapshotFiles.has('.git/config')).toBe(false)
+})
+
 test('runRepoChecks normalizes leading slashes in package job entrypoints', async () => {
 	const files = new Map<string, string>([
 		[

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -157,16 +157,14 @@ async function* workspaceFilesForSnapshot(input: {
 		/\/+$/,
 		'',
 	)
-	const pattern =
-		normalizedRoot === ''
-			? '**/*.{ts,tsx,js,jsx,json}'
-			: `${normalizedRoot}/**/*.{ts,tsx,js,jsx,json}`
+	const pattern = normalizedRoot === '' ? '**/*' : `${normalizedRoot}/**/*`
 	const files = await input.workspace.glob(pattern)
 	for (const file of files) {
 		if (file.type !== 'file') continue
+		const normalizedPath = normalizeRepoWorkspacePath(file.path)
+		if (normalizedPath.split('/').includes('.git')) continue
 		const content = await input.workspace.readFile(file.path)
 		if (content == null) continue
-		const normalizedPath = normalizeRepoWorkspacePath(file.path)
 		const relativePath =
 			normalizedRoot && normalizedPath.startsWith(`${normalizedRoot}/`)
 				? normalizedPath.slice(normalizedRoot.length + 1)

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -39,6 +39,7 @@ export type RepoCheckRunResult = {
 	ok: boolean
 	results: Array<RepoCheckResult>
 	manifest: AuthoredPackageJson
+	sourceFiles: Record<string, string>
 }
 
 const executeTypecheckPreludePath = '.__kody_repo_runtime__.d.ts'
@@ -378,10 +379,6 @@ function parseDeclaredDependencies(packageJsonContent: string | null) {
 	}
 }
 
-function createSourceFilesRecord(snapshotFiles: Map<string, string>) {
-	return Object.fromEntries(snapshotFiles) as Record<string, string>
-}
-
 async function validatePackageBundles(input: {
 	env: Env
 	baseUrl: string
@@ -641,20 +638,20 @@ export async function runRepoChecks(input: {
 		/\/+$/,
 		'',
 	)
-	const snapshotFiles = await (async () => {
-		const collected = new Map<string, string>()
+	const sourceFiles = await (async () => {
+		const collected: Record<string, string> = {}
 		for await (const [path, content] of workspaceFilesForSnapshot({
 			workspace: input.workspace,
 			root: sourceRoot,
 		})) {
-			collected.set(path, content)
+			collected[path] = content
 		}
 		return collected
 	})()
 	const { createFileSystemSnapshot } = await loadWorkerBundlerSnapshotTools()
 	const snapshot = await createFileSystemSnapshot(
 		(async function* () {
-			for (const [path, content] of snapshotFiles) {
+			for (const [path, content] of Object.entries(sourceFiles)) {
 				yield [path, content] as const
 			}
 		})(),
@@ -712,7 +709,7 @@ export async function runRepoChecks(input: {
 			: bundleContext
 				? await validatePackageBundles({
 						...bundleContext,
-						sourceFiles: createSourceFilesRecord(snapshotFiles),
+						sourceFiles,
 						entryPoints: bundleTargets,
 					})
 				: {
@@ -745,6 +742,7 @@ export async function runRepoChecks(input: {
 			ok: results.every((result) => result.ok),
 			results,
 			manifest,
+			sourceFiles,
 		}
 	}
 
@@ -770,6 +768,7 @@ export async function runRepoChecks(input: {
 			ok: results.every((result) => result.ok),
 			results,
 			manifest,
+			sourceFiles,
 		}
 	}
 
@@ -788,6 +787,7 @@ export async function runRepoChecks(input: {
 			ok: results.every((result) => result.ok),
 			results,
 			manifest,
+			sourceFiles,
 		}
 	}
 
@@ -835,5 +835,6 @@ export async function runRepoChecks(input: {
 		ok: results.every((result) => result.ok),
 		results,
 		manifest,
+		sourceFiles,
 	}
 }

--- a/packages/worker/src/repo/external-publish.node.test.ts
+++ b/packages/worker/src/repo/external-publish.node.test.ts
@@ -138,6 +138,44 @@ test('publishes an external fast-forward ref after checks pass', async () => {
 	)
 })
 
+test('finalizes with the source files already collected by checks', async () => {
+	mockModule.getEntitySourceById.mockResolvedValue(source())
+	mockModule.hasPublishedRuntimeArtifacts.mockReturnValue(true)
+	mockModule.runRepoChecks.mockResolvedValue({
+		ok: true,
+		results: [{ kind: 'manifest', ok: true, message: 'ok' }],
+		manifest: {
+			name: '@scope/demo',
+			exports: { '.': './src/index.ts' },
+			kody: { id: 'demo', description: 'Demo' },
+		},
+		sourceFiles: {
+			'package.json': '{"name":"@scope/demo"}',
+			'src/index.ts': 'export default async () => null',
+		},
+	})
+
+	const result = await publishFromExternalRef({
+		env: { APP_DB: {}, BUNDLE_ARTIFACTS_KV: {} as KVNamespace } as Env,
+		sourceId: 'source-1',
+		userId: 'user-1',
+		newCommit: 'commit-new',
+		isFastForward: async () => true,
+		workspace: workspace(),
+		baseUrl: 'https://kody.test',
+	})
+
+	expect(result.status).toBe('published')
+	expect(mockModule.writePublishedSourceSnapshot).toHaveBeenCalledWith(
+		expect.objectContaining({
+			files: {
+				'package.json': '{"name":"@scope/demo"}',
+				'src/index.ts': 'export default async () => null',
+			},
+		}),
+	)
+})
+
 test('returns no-op when commit is already current', async () => {
 	mockModule.getEntitySourceById.mockResolvedValue(source())
 

--- a/packages/worker/src/repo/external-publish.ts
+++ b/packages/worker/src/repo/external-publish.ts
@@ -110,7 +110,7 @@ export async function publishFromExternalRef(input: {
 	isFastForward(input: { previousCommit: string }): Promise<boolean>
 	allowForce?: boolean
 	workspace: RepoPublishWorkspace
-	files: Record<string, string>
+	files?: Record<string, string>
 	baseUrl: string
 	manifestPath?: string
 	sourceRoot?: string
@@ -162,7 +162,7 @@ export async function publishFromExternalRef(input: {
 		env: input.env,
 		source,
 		publishedCommit: input.newCommit,
-		files: input.files,
+		files: input.files ?? checks.sourceFiles,
 		baseUrl: input.baseUrl,
 	})
 	return {

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -107,6 +107,10 @@ const mockModule = vi.hoisted(() => {
 				exports: { '.': './index.ts' },
 				kody: { id: 'demo', description: 'Demo package' },
 			},
+			sourceFiles: {
+				'package.json': '{"name":"@kody/demo"}',
+				'index.ts': 'export const ready = true\n',
+			},
 		})),
 		writePublishedSourceSnapshot: vi.fn(async () => 'snapshot-key'),
 	}
@@ -940,8 +944,12 @@ test('publishFromExternalRef checks fast-forward ancestry through shell git adap
 		{ oid: 'commit-new' },
 		{ oid: 'commit-old' },
 	])
+	mockModule.writePublishedSourceSnapshot.mockClear()
 
-	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
+	const repoSession = new RepoSession(createDurableObjectState(), {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {} as KVNamespace,
+	} as Env)
 
 	const result = await repoSession.publishFromExternalRef({
 		sessionId: 'external-publish-source-1',
@@ -961,6 +969,14 @@ test('publishFromExternalRef checks fast-forward ancestry through shell git adap
 		expect.anything(),
 		expect.objectContaining({
 			publishedCommit: 'commit-new',
+		}),
+	)
+	expect(mockModule.writePublishedSourceSnapshot).toHaveBeenCalledWith(
+		expect.objectContaining({
+			files: {
+				'package.json': '{"name":"@kody/demo"}',
+				'index.ts': 'export const ready = true\n',
+			},
 		}),
 	)
 })

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -951,6 +951,7 @@ test('publishFromExternalRef checks fast-forward ancestry through shell git adap
 	})
 
 	expect(result.status).toBe('published')
+	expect(mockModule.workspaceGlob).not.toHaveBeenCalled()
 	expect(mockModule.git.log).toHaveBeenCalledWith({
 		dir: '/session',
 		ref: 'commit-new',

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -1457,7 +1457,6 @@ class RepoSessionBase extends DurableObject<Env> {
 			ref: input.newCommit,
 			force: true,
 		})
-		const files = await this.collectWorkspaceFiles()
 		return publishExternalRefSource({
 			env: this.env,
 			sourceId: source.id,
@@ -1470,7 +1469,6 @@ class RepoSessionBase extends DurableObject<Env> {
 				}),
 			allowForce: input.allowForce,
 			workspace: this.workspace,
-			files,
 			baseUrl: input.baseUrl ?? source.source_root,
 			manifestPath: resolveRepoWorkspacePath(
 				source.manifest_path,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Walkthrough

- Removed a redundant full workspace materialization from `package_publish_external_push`: the RepoSession DO no longer calls `collectWorkspaceFiles()` before `runRepoChecks`, and publish finalization now reuses the source file snapshot that checks collected.
- Kept that single checks snapshot semantically equivalent to the old publish snapshot by collecting all source files (`**/*`) while excluding `.git` internals, so static assets like CSS/SVG/YAML/etc. remain in published KV snapshots.
- Added bounded internal retry/recovery for transient Durable Object CPU/memory reset signatures in `package_publish_external_push`. Each retry re-resolves the package source and Artifacts HEAD, uses a fresh transient RepoSession DO name, and returns `already_published` if the prior attempt committed before the reset surfaced.
- Added structured warning/Sentry context for every transient reset attempt, including the final exhausted attempt before returning a stable exhausted-retry error.
- Added tests for retry success, committed-before-retry recovery, exhausted reset attempts, source-file reuse, static file preservation, and RepoSession snapshot handoff.
- Centralized the repeated capability error-message helper used by execute and external publish handling.

## Why this helps

The live failures were consistent with pressure inside the publish/check pipeline rather than package checkout size. The path cloned the external HEAD, read the entire workspace into memory, then `runRepoChecks` globbed/read the same tree again and built another snapshot for bundle/typecheck work. Reusing the checks snapshot removes one full source-tree read and one long-lived copy from the RepoSession DO request. The retry path covers remaining transient DO resets with idempotent recovery instead of exposing raw platform reset errors to callers.

## Remaining work

A deeper async publish redesign may still be warranted if bundle/typecheck plus projection rebuilds continue to approach DO limits for packages with many targets or dependencies. The likely next step would be moving check/projection artifact rebuilds into a Workflow/queue with durable run status rather than keeping all phases in the MCP/RepoSession request path.

## Validation

- `npx vitest run --project node-unit packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts packages/worker/src/repo/repo-session-do.node.test.ts packages/worker/src/repo/checks.node.test.ts packages/worker/src/repo/external-publish.node.test.ts packages/worker/src/mcp/capabilities/meta/search-and-execute.node.test.ts` — 52 tests passed
- `npm run typecheck` — passed
- `npm run format:check` — passed
- `npm run lint` — passed with existing unrelated warning in `packages/worker/src/email/inbound.workers.test.ts`
- Previous latest substantial revision: `npm run validate` passed (`format`, `lint`, `typecheck`, unit tests, Playwright E2E, and MCP E2E all exited 0). Full PR CI is re-running after the latest feedback fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a357d7bf-2b9c-4b71-a089-910de0c25210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a357d7bf-2b9c-4b71-a089-910de0c25210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic retry for transient external-publish failures with backoff (up to 3 attempts).

* **Improvements**
  * Better error tracking and structured logging for publish retries and failures.
  * Publish now accepts optional caller files and will use repository-collected source files when absent.
  * Repository snapshotting now includes non-code assets while excluding git internals.

* **Tests**
  * Added tests covering retry behavior, already-published detection, source-file finalization, and snapshot contents.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/427)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->