### PR TITLE
Add dynamic package runtime invocation

### DIFF
--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -108,8 +108,9 @@ Idempotency:
 - Callers may pass `idempotencyKey` (or `idempotency_key`) explicitly. This is
   recommended for domain events such as Discord message ids.
 - If omitted during a parent package invocation with its own idempotency key,
-  Kody derives a nested key from the parent key, call order, target, export, and
-  params so retries do not duplicate the same nested dispatch.
+  Kody derives a nested key from the parent key, parent runtime surface/name,
+  call order, target, export, and params so retries do not duplicate the same
+  nested dispatch.
 - If omitted in contexts without a parent invocation key, Kody uses a unique key
   because replay is not implied.
 

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -72,6 +72,62 @@ The top-level saved identity is the package.
   registry.
 - Packages may also export non-callable helper modules and values for reuse.
 
+### Dynamic current-version invocation
+
+Package runtime contexts also expose `packages.invoke` from `kody:runtime`:
+
+```ts
+import { packages } from 'kody:runtime'
+
+await packages.invoke({
+	kodyId: 'discord-general-chat',
+	exportName: './handle-discord-message-created',
+	params: { event },
+})
+```
+
+This path deliberately does not rewrite to a static `kody:@...` import during
+bundle construction. It resolves the target saved package and export at call
+time through the package invocation service, using the current authenticated
+user and package caller context. Package code never handles external
+package-invocation bearer tokens for this flow.
+
+Use dynamic invocation for runtime dispatch surfaces that must pick up the
+target package's current published bundle, such as event subscribers, workflows,
+and agents. Continue to use static `kody:@scope/package/export` imports for
+library-like dependencies where the caller should keep the dependency bundle it
+was published with.
+
+`packages.invoke` returns the target export's unwrapped result. Non-2xx package
+invocation responses reject with an error whose message starts with the
+underlying code, for example `[package_not_found] ...` or
+`[export_not_found] ...`.
+
+Idempotency:
+
+- Callers may pass `idempotencyKey` (or `idempotency_key`) explicitly. This is
+  recommended for domain events such as Discord message ids.
+- If omitted during a parent package invocation with its own idempotency key,
+  Kody derives a nested key from the parent key, call order, target, export, and
+  params so retries do not duplicate the same nested dispatch.
+- If omitted in contexts without a parent invocation key, Kody uses a unique key
+  because replay is not implied.
+
+Security and loop safeguards:
+
+- Resolution is same-user only; package code cannot invoke another user's saved
+  package.
+- `packages.invoke` requires package runtime context, preserving package-owned
+  storage and caller metadata.
+- Nested dynamic package invocations are depth-limited to prevent runaway
+  package-to-package loops.
+
+For the Discord gateway/subscriber pattern, switch dispatchers from statically
+importing subscriber packages to
+`packages.invoke({ kodyId, exportName, params, idempotencyKey })`. Republish
+subscribers independently; the gateway will observe the current published
+subscriber export on its next dispatch without being republished.
+
 ## Package apps
 
 A package app is optional.

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -121,10 +121,10 @@ invocations are depth-limited to prevent runaway loops.
 
 If `idempotencyKey` is omitted, Kody generates one. In package invocations that
 already have a parent idempotency key, the generated key is deterministic for
-the parent key, call order, target, export, and params. In contexts without a
-parent invocation key, Kody uses a unique key, which avoids accidental replay.
-Pass your own `idempotencyKey` when the target operation must dedupe against a
-domain event id.
+the parent key, parent runtime surface/name, call order, target, export, and
+params. In contexts without a parent invocation key, Kody uses a unique key,
+which avoids accidental replay. Pass your own `idempotencyKey` when the target
+operation must dedupe against a domain event id.
 
 For `discord-gateway`, subscriber dispatch should move from static imports such
 as `kody:@kentcdodds/discord-general-chat/handle-discord-message-created` to the

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -82,6 +82,55 @@ exhaustive.
   `types` file. Package search detail surfaces package descriptions, export
   descriptions, function signatures, JSDoc, and type definitions.
 
+### Dynamic package invocation
+
+Package runtime code can invoke another package owned by the same user without
+statically importing it:
+
+```ts
+import { packages } from 'kody:runtime'
+
+const result = await packages.invoke({
+	kodyId: 'discord-general-chat',
+	exportName: './handle-discord-message-created',
+	params: { event },
+})
+```
+
+Use `packages.invoke` for event subscribers, workflow dispatchers, agents, and
+other runtime fan-out where the caller should pick up the target package's
+current published export. The call resolves the target package at runtime, so
+republishing `discord-general-chat` changes what `discord-gateway` observes
+without republishing `discord-gateway`.
+
+Use static `kody:@scope/package/export` imports for library-like dependencies
+where bundling the currently published dependency with the caller is desired.
+
+`packages.invoke` returns the target export's unwrapped return value. If the
+target package, export, or execution fails, the promise rejects with an error
+that includes the package invocation error code in the message.
+
+The primary identifier is `kodyId`; `kody_id`, `packageId`, and `package_id` are
+accepted aliases for compatibility. `exportName` is required, and `export_name`
+is accepted as an alias.
+
+Only package runtime contexts can call `packages.invoke`, and resolution is
+scoped to packages owned by the current authenticated user. Package code does
+not need to mint or pass package-invocation bearer tokens. Nested package
+invocations are depth-limited to prevent runaway loops.
+
+If `idempotencyKey` is omitted, Kody generates one. In package invocations that
+already have a parent idempotency key, the generated key is deterministic for
+the parent key, call order, target, export, and params. In contexts without a
+parent invocation key, Kody uses a unique key, which avoids accidental replay.
+Pass your own `idempotencyKey` when the target operation must dedupe against a
+domain event id.
+
+For `discord-gateway`, subscriber dispatch should move from static imports such
+as `kody:@kentcdodds/discord-general-chat/handle-discord-message-created` to the
+dynamic shape above, using the Discord event id as the explicit `idempotencyKey`
+when available.
+
 ## Package apps
 
 A package app is optional.

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -484,7 +484,6 @@ async function executePublishedJobArtifact(input: {
 			...(packageContext && packageInvokeTools
 				? {
 						packageInvokeTools,
-						packageInvokeDepth: 0,
 					}
 				: {}),
 		},

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -50,7 +50,6 @@ import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 import { buildJobSourceFiles } from '#worker/repo/source-templates.ts'
 import { repoBackedModuleEntrypointExportErrorMessage } from '#worker/repo/repo-codemode-execution.ts'
 import { runBundledModuleWithRegistry } from '#mcp/run-codemode-registry.ts'
-import { createPackageRuntimeInvokeTools } from '#worker/package-invocations/service.ts'
 import {
 	deleteEntitySource,
 	getEntitySourceById,
@@ -450,6 +449,22 @@ async function executePublishedJobArtifact(input: {
 				jobId: input.job.id,
 			}
 		: null
+	const packageInvokeTools = packageContext
+		? await (async () => {
+				// Avoid a top-level jobs -> package-invocations cycle during capability
+				// registry initialization.
+				const { createPackageRuntimeInvokeTools } =
+					await import('#worker/package-invocations/service.ts')
+				return createPackageRuntimeInvokeTools({
+					env: input.env,
+					baseUrl: input.callerContext.baseUrl,
+					callerContext,
+					packageContext,
+					parentRuntimeDebug: runtimeDebug,
+					packageInvokeDepth: 0,
+				})
+			})()
+		: null
 	return await runBundledModuleWithRegistry(
 		input.env,
 		callerContext,
@@ -466,16 +481,9 @@ async function executePublishedJobArtifact(input: {
 			},
 			...(packageContext ? { packageContext } : {}),
 			runtimeDebug,
-			...(packageContext
+			...(packageContext && packageInvokeTools
 				? {
-						packageInvokeTools: createPackageRuntimeInvokeTools({
-							env: input.env,
-							baseUrl: input.callerContext.baseUrl,
-							callerContext,
-							packageContext,
-							parentRuntimeDebug: runtimeDebug,
-							packageInvokeDepth: 0,
-						}),
+						packageInvokeTools,
 						packageInvokeDepth: 0,
 					}
 				: {}),

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -50,6 +50,7 @@ import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 import { buildJobSourceFiles } from '#worker/repo/source-templates.ts'
 import { repoBackedModuleEntrypointExportErrorMessage } from '#worker/repo/repo-codemode-execution.ts'
 import { runBundledModuleWithRegistry } from '#mcp/run-codemode-registry.ts'
+import { createPackageRuntimeInvokeTools } from '#worker/package-invocations/service.ts'
 import {
 	deleteEntitySource,
 	getEntitySourceById,
@@ -419,25 +420,39 @@ async function executePublishedJobArtifact(input: {
 	bypassLogs: Array<string>
 }): Promise<ExecuteResult> {
 	const source = await getEntitySourceById(input.env.APP_DB, input.job.sourceId)
+	const callerContext = {
+		...input.callerContext,
+		repoContext: source
+			? {
+					sourceId: source.id,
+					repoId: source.repo_id,
+					sessionId: null,
+					sessionRepoId: null,
+					baseCommit: source.published_commit,
+					manifestPath: source.manifest_path,
+					sourceRoot: source.source_root,
+					publishedCommit: source.published_commit,
+					entityKind: source.entity_kind,
+					entityId: source.entity_id,
+				}
+			: null,
+	}
+	const packageContext = input.artifact.packageContext ?? null
+	const runtimeDebug = packageContext
+		? {
+				packageId: packageContext.packageId,
+				kodyId: packageContext.kodyId,
+				sourceId: packageContext.sourceId ?? input.job.sourceId,
+				publishedCommit: source?.published_commit ?? input.job.publishedCommit,
+				surface: 'job' as const,
+				name: input.job.name,
+				storageId: input.job.storageId,
+				jobId: input.job.id,
+			}
+		: null
 	return await runBundledModuleWithRegistry(
 		input.env,
-		{
-			...input.callerContext,
-			repoContext: source
-				? {
-						sourceId: source.id,
-						repoId: source.repo_id,
-						sessionId: null,
-						sessionRepoId: null,
-						baseCommit: source.published_commit,
-						manifestPath: source.manifest_path,
-						sourceRoot: source.source_root,
-						publishedCommit: source.published_commit,
-						entityKind: source.entity_kind,
-						entityId: source.entity_id,
-					}
-				: null,
-		},
+		callerContext,
 		{
 			mainModule: input.artifact.mainModule,
 			modules: input.artifact.modules,
@@ -449,23 +464,21 @@ async function executePublishedJobArtifact(input: {
 				storageId: input.job.storageId,
 				writable: true,
 			},
-			...(input.artifact.packageContext
-				? { packageContext: input.artifact.packageContext }
-				: {}),
-			runtimeDebug: input.artifact.packageContext
+			...(packageContext ? { packageContext } : {}),
+			runtimeDebug,
+			...(packageContext
 				? {
-						packageId: input.artifact.packageContext.packageId,
-						kodyId: input.artifact.packageContext.kodyId,
-						sourceId:
-							input.artifact.packageContext.sourceId ?? input.job.sourceId,
-						publishedCommit:
-							source?.published_commit ?? input.job.publishedCommit,
-						surface: 'job',
-						name: input.job.name,
-						storageId: input.job.storageId,
-						jobId: input.job.id,
+						packageInvokeTools: createPackageRuntimeInvokeTools({
+							env: input.env,
+							baseUrl: input.callerContext.baseUrl,
+							callerContext,
+							packageContext,
+							parentRuntimeDebug: runtimeDebug,
+							packageInvokeDepth: 0,
+						}),
+						packageInvokeDepth: 0,
 					}
-				: null,
+				: {}),
 		},
 	).then((result) => ({
 		...result,

--- a/packages/worker/src/mcp/run-codemode-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.node.test.ts
@@ -1458,6 +1458,86 @@ test('runBundledModuleWithRegistry injects workflow helper when custom workflow 
 	}
 })
 
+test('runBundledModuleWithRegistry injects package invocation helper when provided', async () => {
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+	})
+	const getRegistrySpy = vi
+		.spyOn(
+			await import('#mcp/capabilities/registry.ts'),
+			'getCapabilityRegistryForContext',
+		)
+		.mockResolvedValue({
+			capabilityDomains: [],
+			capabilityDomainDescriptionsByName: {} as Record<string, string>,
+			capabilityHandlers: {},
+			capabilityList: [],
+			capabilityMap: {},
+			capabilitySpecs: {},
+			capabilityToolDescriptors: {},
+		} as Awaited<ReturnType<typeof getCapabilityRegistryForContext>>)
+	let providerFns: Record<string, (args: unknown) => Promise<unknown>> | null =
+		null
+	const createExecuteExecutorSpy = vi
+		.spyOn(await import('#mcp/executor.ts'), 'createExecuteExecutor')
+		.mockReturnValue({
+			async execute(wrapped, providers) {
+				expect(wrapped).toContain('const packages = {')
+				expect(wrapped).toContain(
+					"packages: typeof packages === 'undefined' ? null : packages",
+				)
+				providerFns = (
+					providers[0] as {
+						fns: Record<string, (args: unknown) => Promise<unknown>>
+					}
+				).fns
+				return {
+					result: 'ok',
+					logs: [],
+				}
+			},
+		} as never)
+
+	try {
+		const result = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			{
+				mainModule: 'entry.js',
+				modules: {
+					'entry.js': 'export default async () => "ok"',
+				},
+			},
+			undefined,
+			{
+				packageInvokeTools: {
+					invoke: async (input) => ({ ok: true, input }),
+				},
+			},
+		)
+
+		expect(result.result).toBe('ok')
+		expect(providerFns).not.toBeNull()
+		await expect(
+			providerFns?.package_invoke({
+				kodyId: 'discord-general-chat',
+				exportName: './handle-discord-message-created',
+			}),
+		).resolves.toEqual({
+			ok: true,
+			input: {
+				kodyId: 'discord-general-chat',
+				exportName: './handle-discord-message-created',
+			},
+		})
+	} finally {
+		createExecuteExecutorSpy.mockRestore()
+		getRegistrySpy.mockRestore()
+	}
+})
+
 test('runBundledModuleWithRegistry injects default workflow helper for execute and standalone job contexts', async () => {
 	const created: Array<WorkflowInstanceCreateOptions<unknown>> = []
 	const env = {

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -734,7 +734,6 @@ export async function runBundledModuleWithRegistry(
 		skipCapabilityRegistry?: boolean
 		executorTimeoutMs?: number | null
 		runtimeDebug?: PackageRuntimeDebugContext | null
-		packageInvokeDepth?: number
 	},
 ): Promise<ExecuteResult> {
 	const secretRedactor = createExecutionSecretRedactor()

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -77,6 +77,12 @@ type EmailToolOptions = {
 	getAttachment: (attachmentId: string) => Promise<unknown>
 }
 
+export type PackageInvokeInput = Record<string, unknown>
+
+export type PackageInvokeTools = {
+	invoke: (input: PackageInvokeInput) => Promise<unknown>
+}
+
 export type PackageWorkflowTools = {
 	create: (input: PackageWorkflowCreateInput) => Promise<unknown>
 }
@@ -237,6 +243,14 @@ const workflows = {
 	`.trim()
 }
 
+function createPackagesHelperPrelude() {
+	return `
+const packages = {
+  invoke: async (input) => await codemode.package_invoke(input ?? {}),
+};
+	`.trim()
+}
+
 export async function buildCodemodeFns(
 	env: Env,
 	callerContext: McpCallerContext,
@@ -252,6 +266,7 @@ export async function buildCodemodeFns(
 		packageSecretTools?: PackageSecretToolOptions
 		emailTools?: EmailToolOptions
 		workflowTools?: PackageWorkflowTools
+		packageInvokeTools?: PackageInvokeTools
 		skipCapabilityRegistry?: boolean
 	},
 ) {
@@ -401,6 +416,14 @@ export async function buildCodemodeFns(
 			}
 		: {}
 	assertNoCapabilityCollisions(capabilityMap, workflowCodemodeTools)
+	const packageInvokeTools = options?.packageInvokeTools
+	const packageInvokeCodemodeTools: AdditionalCodemodeTools = packageInvokeTools
+		? {
+				package_invoke: async (args: unknown) =>
+					await packageInvokeTools.invoke((args ?? {}) as PackageInvokeInput),
+			}
+		: {}
+	assertNoCapabilityCollisions(capabilityMap, packageInvokeCodemodeTools)
 	return {
 		...capabilityCodemodeTools,
 		...storageCodemodeTools,
@@ -408,6 +431,7 @@ export async function buildCodemodeFns(
 		...packageSecretCodemodeTools,
 		...emailCodemodeTools,
 		...workflowCodemodeTools,
+		...packageInvokeCodemodeTools,
 		...additionalTools,
 	}
 }
@@ -434,6 +458,7 @@ export async function buildCodemodeProvider(
 		packageSecretTools?: PackageSecretToolOptions
 		emailTools?: EmailToolOptions
 		workflowTools?: PackageWorkflowTools
+		packageInvokeTools?: PackageInvokeTools
 		skipCapabilityRegistry?: boolean
 	},
 ): Promise<ResolvedProvider> {
@@ -510,6 +535,7 @@ export async function runCodemodeWithRegistry(
 		emailTools?: EmailToolOptions
 		executorModules?: WorkerLoaderModules
 		executorTimeoutMs?: number | null
+		packageInvokeTools?: PackageInvokeTools
 	},
 ): Promise<ExecuteResult> {
 	const moduleSource = stripCodeFences(code.trim())
@@ -525,6 +551,7 @@ export async function runCodemodeWithRegistry(
 				callerContext,
 				packageContext: options?.packageContext ?? null,
 			}),
+			packageInvokeTools: options?.packageInvokeTools,
 			executorTimeoutMs: options?.executorTimeoutMs,
 		})
 	}
@@ -564,6 +591,7 @@ export async function runCodemodeWithRegistry(
 			: undefined,
 		emailTools: options?.emailTools,
 		workflowTools,
+		packageInvokeTools: options?.packageInvokeTools,
 	})
 	const wrappedCode =
 		params !== undefined
@@ -588,12 +616,16 @@ export async function runCodemodeWithRegistry(
 	const workflowsHelperPrelude = workflowTools
 		? createWorkflowsHelperPrelude()
 		: ''
+	const packagesHelperPrelude = options?.packageInvokeTools
+		? createPackagesHelperPrelude()
+		: ''
 	const helperPrelude = [
 		storageHelperPrelude,
 		serviceHelperPrelude,
 		packageSecretsHelperPrelude,
 		emailHelperPrelude,
 		workflowsHelperPrelude,
+		packagesHelperPrelude,
 		options?.helperPrelude ?? '',
 	]
 		.filter((value) => value.trim().length > 0)
@@ -633,6 +665,7 @@ export async function runModuleWithRegistry(
 		emailTools?: EmailToolOptions
 		workflowTools?: PackageWorkflowTools
 		executorTimeoutMs?: number | null
+		packageInvokeTools?: PackageInvokeTools
 	},
 ): Promise<ExecuteResult> {
 	const userId = callerContext.user?.userId ?? ''
@@ -663,6 +696,7 @@ export async function runModuleWithRegistry(
 					callerContext,
 					packageContext: options?.packageContext ?? null,
 				}),
+			packageInvokeTools: options?.packageInvokeTools,
 		},
 	)
 }
@@ -696,9 +730,11 @@ export async function runBundledModuleWithRegistry(
 		serviceTools?: ServiceToolOptions
 		emailTools?: EmailToolOptions
 		workflowTools?: PackageWorkflowTools
+		packageInvokeTools?: PackageInvokeTools
 		skipCapabilityRegistry?: boolean
 		executorTimeoutMs?: number | null
 		runtimeDebug?: PackageRuntimeDebugContext | null
+		packageInvokeDepth?: number
 	},
 ): Promise<ExecuteResult> {
 	const secretRedactor = createExecutionSecretRedactor()
@@ -756,6 +792,7 @@ export async function runBundledModuleWithRegistry(
 				: undefined,
 			emailTools: options?.emailTools,
 			workflowTools,
+			packageInvokeTools: options?.packageInvokeTools,
 			skipCapabilityRegistry: options?.skipCapabilityRegistry,
 		})
 		const storageHelperPrelude = options?.storageTools
@@ -776,6 +813,9 @@ export async function runBundledModuleWithRegistry(
 		const workflowsHelperPrelude = workflowTools
 			? createWorkflowsHelperPrelude()
 			: ''
+		const packagesHelperPrelude = options?.packageInvokeTools
+			? createPackagesHelperPrelude()
+			: ''
 		const entrypointInputJson = JSON.stringify(params)
 		const entrypointInputSource =
 			entrypointInputJson === undefined ? 'undefined' : entrypointInputJson
@@ -786,6 +826,7 @@ ${serviceHelperPrelude ? `${serviceHelperPrelude}\n` : ''}
 ${packageSecretsHelperPrelude ? `${packageSecretsHelperPrelude}\n` : ''}
 ${emailHelperPrelude ? `${emailHelperPrelude}\n` : ''}
 ${workflowsHelperPrelude ? `${workflowsHelperPrelude}\n` : ''}
+${packagesHelperPrelude ? `${packagesHelperPrelude}\n` : ''}
   const __previousRuntime = globalThis.__kodyRuntime;
   globalThis.__kodyRuntime = {
     codemode,
@@ -798,6 +839,7 @@ ${workflowsHelperPrelude ? `${workflowsHelperPrelude}\n` : ''}
     packageSecrets: typeof packageSecrets === 'undefined' ? null : packageSecrets,
     email: typeof email === 'undefined' ? null : email,
     workflows: typeof workflows === 'undefined' ? null : workflows,
+    packages: typeof packages === 'undefined' ? null : packages,
   };
   try {
     const __kodyModule = await import(${JSON.stringify(`./${bundle.mainModule}`)});

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -1,5 +1,10 @@
 import { expect, test, vi } from 'vitest'
-import { invokePackageExport, invokePackageSubscription } from './service.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import {
+	createPackageRuntimeInvokeTools,
+	invokePackageExport,
+	invokePackageSubscription,
+} from './service.ts'
 
 const repoMockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
@@ -321,6 +326,212 @@ function seedPackageResolution() {
 	repoMockModule.persistPublishedBundleArtifact.mockResolvedValue('kv:key')
 }
 
+function createSavedPackage(input: {
+	id: string
+	sourceId: string
+	name: string
+	kodyId: string
+	description?: string
+}) {
+	return {
+		id: input.id,
+		userId: 'user-123',
+		name: input.name,
+		kodyId: input.kodyId,
+		description: input.description ?? `${input.kodyId} package`,
+		tags: [],
+		searchText: null,
+		sourceId: input.sourceId,
+		hasApp: false,
+		createdAt: '2026-05-10T00:00:00.000Z',
+		updatedAt: '2026-05-10T00:00:00.000Z',
+	}
+}
+
+function createSource(input: { id: string; entityId: string; commit: string }) {
+	return {
+		id: input.id,
+		user_id: 'user-123',
+		entity_kind: 'package',
+		entity_id: input.entityId,
+		repo_id: `repo-${input.id}`,
+		published_commit: input.commit,
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		created_at: '2026-05-10T00:00:00.000Z',
+		updated_at: '2026-05-10T00:00:00.000Z',
+	}
+}
+
+function createManifest(input: {
+	name: string
+	kodyId: string
+	exportName: string
+	entryPoint: string
+}) {
+	return {
+		name: input.name,
+		exports: {
+			[input.exportName]: input.entryPoint,
+		},
+		kody: {
+			id: input.kodyId,
+			description: `${input.kodyId} package`,
+		},
+	}
+}
+
+function createModuleArtifact(input: {
+	sourceId: string
+	publishedCommit: string
+	artifactName: string
+	entryPoint: string
+	mainModule: string
+	packageContext: {
+		packageId: string
+		kodyId: string
+		sourceId: string
+	}
+}) {
+	return {
+		row: {
+			id: `artifact-${input.packageContext.packageId}`,
+		},
+		artifact: {
+			version: 1,
+			kind: 'module',
+			artifactName: input.artifactName,
+			sourceId: input.sourceId,
+			publishedCommit: input.publishedCommit,
+			entryPoint: input.entryPoint,
+			mainModule: input.mainModule,
+			modules: {
+				[input.mainModule]:
+					'export default async function run(){ return { ok: true } }',
+			},
+			dependencies: [],
+			packageContext: input.packageContext,
+			serviceContext: null,
+			createdAt: '2026-05-10T00:00:00.000Z',
+		},
+	}
+}
+
+function seedRuntimeDispatchPackages() {
+	const gateway = createSavedPackage({
+		id: 'pkg-gateway',
+		sourceId: 'source-gateway',
+		name: '@kentcdodds/discord-gateway',
+		kodyId: 'discord-gateway',
+	})
+	const subscriber = createSavedPackage({
+		id: 'pkg-subscriber',
+		sourceId: 'source-subscriber',
+		name: '@kentcdodds/discord-general-chat',
+		kodyId: 'discord-general-chat',
+	})
+	const sources = new Map([
+		[
+			'source-gateway',
+			createSource({
+				id: 'source-gateway',
+				entityId: 'pkg-gateway',
+				commit: 'gateway-commit-1',
+			}),
+		],
+		[
+			'source-subscriber',
+			createSource({
+				id: 'source-subscriber',
+				entityId: 'pkg-subscriber',
+				commit: 'subscriber-commit-1',
+			}),
+		],
+	])
+	const manifests = new Map([
+		[
+			'source-gateway',
+			createManifest({
+				name: gateway.name,
+				kodyId: gateway.kodyId,
+				exportName: './dispatch-message-created',
+				entryPoint: './src/dispatch-message-created.ts',
+			}),
+		],
+		[
+			'source-subscriber',
+			createManifest({
+				name: subscriber.name,
+				kodyId: subscriber.kodyId,
+				exportName: './handle-discord-message-created',
+				entryPoint: './src/handle-discord-message-created.ts',
+			}),
+		],
+	])
+	repoMockModule.getSavedPackageById.mockResolvedValue(null)
+	repoMockModule.getSavedPackageByKodyId.mockImplementation(
+		async (_db: unknown, input: { userId: string; kodyId: string }) => {
+			expect(input.userId).toBe('user-123')
+			if (input.kodyId === gateway.kodyId) return gateway
+			if (input.kodyId === subscriber.kodyId) return subscriber
+			return null
+		},
+	)
+	repoMockModule.loadPackageManifestBySourceId.mockImplementation(
+		async (input: { sourceId: string }) => ({
+			source: sources.get(input.sourceId),
+			manifest: manifests.get(input.sourceId),
+		}),
+	)
+	repoMockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: sources.get('source-gateway'),
+		manifest: manifests.get('source-gateway'),
+		files: {},
+	})
+	repoMockModule.getEntitySourceById.mockImplementation(
+		async (_db: unknown, sourceId: string) => sources.get(sourceId) ?? null,
+	)
+	repoMockModule.loadPublishedBundleArtifactByIdentity.mockImplementation(
+		async (input: {
+			sourceId: string
+			artifactName: string
+			entryPoint: string
+		}) => {
+			if (input.sourceId === 'source-gateway') {
+				return createModuleArtifact({
+					sourceId: 'source-gateway',
+					publishedCommit: 'gateway-commit-1',
+					artifactName: './dispatch-message-created',
+					entryPoint: 'src/dispatch-message-created.ts',
+					mainModule: 'dist/gateway.js',
+					packageContext: {
+						packageId: gateway.id,
+						kodyId: gateway.kodyId,
+						sourceId: gateway.sourceId,
+					},
+				})
+			}
+			if (input.sourceId === 'source-subscriber') {
+				return createModuleArtifact({
+					sourceId: 'source-subscriber',
+					publishedCommit: 'subscriber-commit-1',
+					artifactName: './handle-discord-message-created',
+					entryPoint: 'src/handle-discord-message-created.ts',
+					mainModule: 'dist/subscriber.js',
+					packageContext: {
+						packageId: subscriber.id,
+						kodyId: subscriber.kodyId,
+						sourceId: subscriber.sourceId,
+					},
+				})
+			}
+			return null
+		},
+	)
+	return { gateway, subscriber }
+}
+
 test('invokePackageExport executes a scoped package export successfully', async () => {
 	const db = createDatabase()
 	seedPackageResolution()
@@ -354,6 +565,229 @@ test('invokePackageExport executes a scoped package export successfully', async 
 		logs: ['dispatched'],
 	})
 	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
+})
+
+test('package runtime can dynamically invoke the current published export from another package', async () => {
+	const db = createDatabase()
+	seedRuntimeDispatchPackages()
+	let subscriberVersion = 'v1'
+	repoMockModule.runBundledModuleWithRegistry.mockImplementation(
+		async (
+			_env: unknown,
+			_callerContext: unknown,
+			bundle: { mainModule: string },
+			params: { event?: { id?: string } } | undefined,
+			options: {
+				packageInvokeTools?: {
+					invoke(input: Record<string, unknown>): Promise<unknown>
+				}
+			},
+		) => {
+			if (bundle.mainModule === 'dist/gateway.js') {
+				return {
+					result: await options.packageInvokeTools?.invoke({
+						kodyId: 'discord-general-chat',
+						exportName: './handle-discord-message-created',
+						params: { event: params?.event },
+					}),
+					logs: [],
+				}
+			}
+			if (bundle.mainModule === 'dist/subscriber.js') {
+				return {
+					result: {
+						version: subscriberVersion,
+						eventId: params?.event?.id,
+					},
+					logs: [],
+				}
+			}
+			throw new Error(`Unexpected bundle ${bundle.mainModule}`)
+		},
+	)
+
+	const first = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: {
+			...createToken(),
+			packageKodyIds: ['discord-gateway'],
+			exportNames: ['./dispatch-message-created'],
+		},
+		request: {
+			packageIdOrKodyId: 'discord-gateway',
+			exportName: './dispatch-message-created',
+			params: { event: { id: 'message-1' } },
+			idempotencyKey: 'gateway-message-1',
+		},
+	})
+	subscriberVersion = 'v2'
+	const second = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: {
+			...createToken(),
+			packageKodyIds: ['discord-gateway'],
+			exportNames: ['./dispatch-message-created'],
+		},
+		request: {
+			packageIdOrKodyId: 'discord-gateway',
+			exportName: './dispatch-message-created',
+			params: { event: { id: 'message-2' } },
+			idempotencyKey: 'gateway-message-2',
+		},
+	})
+
+	expect(first.status).toBe(200)
+	expect(first.body).toMatchObject({
+		ok: true,
+		result: {
+			version: 'v1',
+			eventId: 'message-1',
+		},
+	})
+	expect(second.status).toBe(200)
+	expect(second.body).toMatchObject({
+		ok: true,
+		result: {
+			version: 'v2',
+			eventId: 'message-2',
+		},
+	})
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(4)
+	const firstNestedCall =
+		repoMockModule.runBundledModuleWithRegistry.mock.calls[1]
+	expect(firstNestedCall?.[4]).toMatchObject({
+		packageInvokeDepth: 1,
+	})
+})
+
+test('package runtime invocation errors clearly when the target package is missing', async () => {
+	const db = createDatabase()
+	seedRuntimeDispatchPackages()
+	repoMockModule.getSavedPackageByKodyId.mockResolvedValue(null)
+
+	const tools = createPackageRuntimeInvokeTools({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://kody.dev',
+			user: {
+				userId: 'user-123',
+				email: 'me@example.com',
+				displayName: 'Me',
+			},
+		}),
+		packageContext: {
+			packageId: 'pkg-gateway',
+			kodyId: 'discord-gateway',
+			sourceId: 'source-gateway',
+		},
+		parentRuntimeDebug: {
+			packageId: 'pkg-gateway',
+			kodyId: 'discord-gateway',
+			sourceId: 'source-gateway',
+			surface: 'export',
+			name: './dispatch-message-created',
+			idempotencyKey: 'message-1',
+		},
+		packageInvokeDepth: 0,
+	})
+
+	await expect(
+		tools.invoke({
+			kodyId: 'missing-package',
+			exportName: './handle-discord-message-created',
+		}),
+	).rejects.toThrow(
+		'[package_not_found] Saved package "missing-package" was not found for this user.',
+	)
+})
+
+test('package runtime invocation errors clearly when the target export is missing', async () => {
+	const db = createDatabase()
+	seedRuntimeDispatchPackages()
+	const tools = createPackageRuntimeInvokeTools({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://kody.dev',
+			user: {
+				userId: 'user-123',
+				email: 'me@example.com',
+				displayName: 'Me',
+			},
+		}),
+		packageContext: {
+			packageId: 'pkg-gateway',
+			kodyId: 'discord-gateway',
+			sourceId: 'source-gateway',
+		},
+		parentRuntimeDebug: {
+			packageId: 'pkg-gateway',
+			kodyId: 'discord-gateway',
+			sourceId: 'source-gateway',
+			surface: 'export',
+			name: './dispatch-message-created',
+			idempotencyKey: 'message-1',
+		},
+		packageInvokeDepth: 0,
+	})
+
+	await expect(
+		tools.invoke({
+			kodyId: 'discord-general-chat',
+			exportName: './missing-export',
+			params: { event: { id: 'message-1' } },
+		}),
+	).rejects.toThrow('[export_not_found]')
+})
+
+test('package runtime invocation requires package context and enforces loop depth', async () => {
+	const db = createDatabase()
+	seedRuntimeDispatchPackages()
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://kody.dev',
+		user: {
+			userId: 'user-123',
+			email: 'me@example.com',
+			displayName: 'Me',
+		},
+	})
+	const withoutPackageContext = createPackageRuntimeInvokeTools({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		callerContext,
+		packageContext: null,
+		packageInvokeDepth: 0,
+	})
+
+	await expect(
+		withoutPackageContext.invoke({
+			kodyId: 'discord-general-chat',
+			exportName: './handle-discord-message-created',
+		}),
+	).rejects.toThrow('packages.invoke requires a package runtime context.')
+
+	const tooDeep = createPackageRuntimeInvokeTools({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		callerContext,
+		packageContext: {
+			packageId: 'pkg-gateway',
+			kodyId: 'discord-gateway',
+			sourceId: 'source-gateway',
+		},
+		packageInvokeDepth: 8,
+	})
+	await expect(
+		tooDeep.invoke({
+			kodyId: 'discord-general-chat',
+			exportName: './handle-discord-message-created',
+		}),
+	).rejects.toThrow(
+		'packages.invoke exceeded the maximum nested invocation depth (8).',
+	)
 })
 
 test('invokePackageExport replays the stored response for a duplicate idempotency key', async () => {

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -655,11 +655,6 @@ test('package runtime can dynamically invoke the current published export from a
 		},
 	})
 	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(4)
-	const firstNestedCall =
-		repoMockModule.runBundledModuleWithRegistry.mock.calls[1]
-	expect(firstNestedCall?.[4]).toMatchObject({
-		packageInvokeDepth: 1,
-	})
 })
 
 test('package runtime invocation errors clearly when the target package is missing', async () => {

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -751,12 +751,13 @@ test('package runtime auto idempotency keys include parent runtime identity', as
 			_env: unknown,
 			_callerContext: unknown,
 			bundle: { mainModule: string },
-			params: { marker?: string } | undefined,
+			params: { marker?: string; value?: number } | undefined,
 		) => {
 			expect(bundle.mainModule).toBe('dist/subscriber.js')
 			return {
 				result: {
 					marker: params?.marker,
+					value: params?.value,
 				},
 				logs: [],
 			}
@@ -795,16 +796,16 @@ test('package runtime auto idempotency keys include parent runtime identity', as
 	const first = await createToolsForParent('./first-parent').invoke({
 		kodyId: 'discord-general-chat',
 		exportName: './handle-discord-message-created',
-		params: { marker: 'first' },
+		params: { marker: 'same-child-call', value: 1 },
 	})
 	const second = await createToolsForParent('./second-parent').invoke({
 		kodyId: 'discord-general-chat',
 		exportName: './handle-discord-message-created',
-		params: { marker: 'second' },
+		params: { marker: 'same-child-call', value: 1 },
 	})
 
-	expect(first).toEqual({ marker: 'first' })
-	expect(second).toEqual({ marker: 'second' })
+	expect(first).toEqual({ marker: 'same-child-call', value: 1 })
+	expect(second).toEqual({ marker: 'same-child-call', value: 1 })
 	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(2)
 })
 

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -743,6 +743,71 @@ test('package runtime invocation errors clearly when the target export is missin
 	).rejects.toThrow('[export_not_found]')
 })
 
+test('package runtime auto idempotency keys include parent runtime identity', async () => {
+	const db = createDatabase()
+	seedRuntimeDispatchPackages()
+	repoMockModule.runBundledModuleWithRegistry.mockImplementation(
+		async (
+			_env: unknown,
+			_callerContext: unknown,
+			bundle: { mainModule: string },
+			params: { marker?: string } | undefined,
+		) => {
+			expect(bundle.mainModule).toBe('dist/subscriber.js')
+			return {
+				result: {
+					marker: params?.marker,
+				},
+				logs: [],
+			}
+		},
+	)
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://kody.dev',
+		user: {
+			userId: 'user-123',
+			email: 'me@example.com',
+			displayName: 'Me',
+		},
+	})
+	const packageContext = {
+		packageId: 'pkg-gateway',
+		kodyId: 'discord-gateway',
+		sourceId: 'source-gateway',
+	}
+	const createToolsForParent = (name: string) =>
+		createPackageRuntimeInvokeTools({
+			env: createEnv(db),
+			baseUrl: 'https://kody.dev',
+			callerContext,
+			packageContext,
+			parentRuntimeDebug: {
+				packageId: 'pkg-gateway',
+				kodyId: 'discord-gateway',
+				sourceId: 'source-gateway',
+				surface: 'export',
+				name,
+				idempotencyKey: 'shared-domain-event',
+			},
+			packageInvokeDepth: 0,
+		})
+
+	const first = await createToolsForParent('./first-parent').invoke({
+		kodyId: 'discord-general-chat',
+		exportName: './handle-discord-message-created',
+		params: { marker: 'first' },
+	})
+	const second = await createToolsForParent('./second-parent').invoke({
+		kodyId: 'discord-general-chat',
+		exportName: './handle-discord-message-created',
+		params: { marker: 'second' },
+	})
+
+	expect(first).toEqual({ marker: 'first' })
+	expect(second).toEqual({ marker: 'second' })
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(2)
+})
+
 test('package runtime invocation requires package context and enforces loop depth', async () => {
 	const db = createDatabase()
 	seedRuntimeDispatchPackages()

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -2,8 +2,15 @@ import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { toHex } from '@kody-internal/shared/hex.ts'
 import { extractRawContent, getExecutionErrorDetails } from '#mcp/executor.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
-import { runBundledModuleWithRegistry } from '#mcp/run-codemode-registry.ts'
-import { type PackageRuntimeSurface } from '#worker/package-runtime/package-runtime-debug.ts'
+import {
+	runBundledModuleWithRegistry,
+	type PackageInvokeInput,
+	type PackageInvokeTools,
+} from '#mcp/run-codemode-registry.ts'
+import {
+	type PackageRuntimeDebugContext,
+	type PackageRuntimeSurface,
+} from '#worker/package-runtime/package-runtime-debug.ts'
 import {
 	getSavedPackageById,
 	getSavedPackageByKodyId,
@@ -86,7 +93,15 @@ type PackageModuleResolution = {
 	entryPoint: string
 }
 
+type PackageRuntimeContext = {
+	packageId: string
+	kodyId: string
+	sourceId?: string | null
+}
+
 const internalEmailSubscriptionTokenId = 'internal:email-subscriptions'
+const internalPackageRuntimeInvokeTokenId = 'internal:package-runtime'
+const maxPackageRuntimeInvokeDepth = 8
 
 function normalizeExportName(exportName: string) {
 	const trimmed = exportName.trim()
@@ -102,6 +117,64 @@ function normalizeExportName(exportName: string) {
 function normalizeNullableString(value: string | null | undefined) {
 	const trimmed = value?.trim()
 	return trimmed && trimmed.length > 0 ? trimmed : null
+}
+
+function readOptionalString(
+	input: PackageInvokeInput,
+	fieldNames: Array<string>,
+) {
+	for (const fieldName of fieldNames) {
+		const value = input[fieldName]
+		if (typeof value === 'string' && value.trim()) return value.trim()
+	}
+	return null
+}
+
+function readSinglePackageIdentifier(input: PackageInvokeInput) {
+	const candidates = [
+		readOptionalString(input, ['kodyId', 'kody_id']),
+		readOptionalString(input, ['packageId', 'package_id']),
+	].filter((value): value is string => value !== null)
+	const unique = Array.from(new Set(candidates))
+	if (unique.length > 1) {
+		throw new Error(
+			'packages.invoke accepts one package identifier. Use kodyId unless you need the saved package id.',
+		)
+	}
+	const packageIdOrKodyId = unique[0]
+	if (!packageIdOrKodyId) {
+		throw new Error('packages.invoke requires kodyId or packageId.')
+	}
+	return packageIdOrKodyId
+}
+
+function readPackageInvokeParams(input: PackageInvokeInput) {
+	const params = input['params']
+	if (params === undefined || params === null) return undefined
+	if (!params || typeof params !== 'object' || Array.isArray(params)) {
+		throw new Error(
+			'packages.invoke params must be a JSON object when provided.',
+		)
+	}
+	return params as Record<string, unknown>
+}
+
+function parsePackageInvokeInput(input: PackageInvokeInput) {
+	const packageIdOrKodyId = readSinglePackageIdentifier(input)
+	const exportName = readOptionalString(input, ['exportName', 'export_name'])
+	if (!exportName) {
+		throw new Error('packages.invoke requires exportName.')
+	}
+	return {
+		packageIdOrKodyId,
+		exportName,
+		params: readPackageInvokeParams(input),
+		idempotencyKey: readOptionalString(input, [
+			'idempotencyKey',
+			'idempotency_key',
+		]),
+		topic: readOptionalString(input, ['topic']),
+	}
 }
 
 function buildPackageInvocationStorageId(packageId: string) {
@@ -183,6 +256,39 @@ function canonicalizeJsonValue(value: unknown): unknown {
 		)
 	}
 	return value
+}
+
+async function createAutoPackageInvokeIdempotencyKey(input: {
+	callerPackageContext: PackageRuntimeContext
+	parentRuntimeDebug: PackageRuntimeDebugContext | null
+	sequence: number
+	request: ReturnType<typeof parsePackageInvokeInput>
+}) {
+	const parentKey = input.parentRuntimeDebug?.idempotencyKey?.trim()
+	if (!parentKey) {
+		return `pkginvoke:${crypto.randomUUID()}`
+	}
+	const digest = await crypto.subtle.digest(
+		'SHA-256',
+		new TextEncoder().encode(
+			canonicalJsonStringify({
+				callerPackageId: input.callerPackageContext.packageId,
+				parentKey,
+				sequence: input.sequence,
+				packageIdOrKodyId: input.request.packageIdOrKodyId,
+				exportName: normalizeExportName(input.request.exportName),
+				params: input.request.params,
+				topic: input.request.topic,
+			}),
+		),
+	)
+	return [
+		'pkginvoke',
+		input.callerPackageContext.packageId,
+		parentKey,
+		String(input.sequence),
+		toHex(new Uint8Array(digest)).slice(0, 24),
+	].join(':')
 }
 
 async function resolveSavedPackage(input: {
@@ -570,6 +676,7 @@ async function invokeSavedPackageModule(input: {
 	source: string | null
 	topic: string | null
 	notFoundCode: 'export_not_found' | 'subscription_not_found'
+	runtimeInvokeDepth?: number
 }) {
 	const requestHash = await createRequestHash({
 		packageId: input.savedPackage.id,
@@ -705,6 +812,30 @@ async function invokeSavedPackageModule(input: {
 			selector: input.moduleSelector,
 			source: input.source,
 		})
+		const packageContext = artifact.packageContext ?? {
+			packageId: input.savedPackage.id,
+			kodyId: input.savedPackage.kodyId,
+			sourceId: input.savedPackage.sourceId,
+		}
+		const runtimeDebug: PackageRuntimeDebugContext = {
+			packageId: input.savedPackage.id,
+			kodyId: input.savedPackage.kodyId,
+			sourceId: input.savedPackage.sourceId,
+			publishedCommit: repoSource?.published_commit ?? null,
+			surface: runtimeSurface,
+			name: resolveInvocationRuntimeName({
+				surface: runtimeSurface,
+				invocationName: input.invocationName,
+				topic: input.topic,
+			}),
+			invocationId,
+			idempotencyKey: input.idempotencyKey,
+			metadata: {
+				exportName: input.invocationName,
+				source: input.source,
+				topic: input.topic,
+			},
+		}
 		const executionResult = await runBundledModuleWithRegistry(
 			input.env,
 			callerContext,
@@ -719,25 +850,7 @@ async function invokeSavedPackageModule(input: {
 					storageId: buildPackageInvocationStorageId(input.savedPackage.id),
 					writable: true,
 				},
-				runtimeDebug: {
-					packageId: input.savedPackage.id,
-					kodyId: input.savedPackage.kodyId,
-					sourceId: input.savedPackage.sourceId,
-					publishedCommit: repoSource?.published_commit ?? null,
-					surface: runtimeSurface,
-					name: resolveInvocationRuntimeName({
-						surface: runtimeSurface,
-						invocationName: input.invocationName,
-						topic: input.topic,
-					}),
-					invocationId,
-					idempotencyKey: input.idempotencyKey,
-					metadata: {
-						exportName: input.invocationName,
-						source: input.source,
-						topic: input.topic,
-					},
-				},
+				runtimeDebug,
 				emailTools: {
 					getMessage: async (messageId) => {
 						const loaded = await getEmailMessageWithAttachmentsById({
@@ -828,9 +941,16 @@ async function invokeSavedPackageModule(input: {
 						}
 					},
 				},
-				...(artifact.packageContext
-					? { packageContext: artifact.packageContext }
-					: {}),
+				packageContext,
+				packageInvokeTools: createPackageRuntimeInvokeTools({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					callerContext,
+					packageContext,
+					parentRuntimeDebug: runtimeDebug,
+					packageInvokeDepth: input.runtimeInvokeDepth ?? 0,
+				}),
+				packageInvokeDepth: input.runtimeInvokeDepth ?? 0,
 			},
 		)
 		const response = executionResult.error
@@ -899,11 +1019,158 @@ async function invokeSavedPackageModule(input: {
 	}
 }
 
+export function createPackageRuntimeInvokeTools(input: {
+	env: Env
+	baseUrl: string
+	callerContext: ReturnType<typeof createMcpCallerContext>
+	packageContext: PackageRuntimeContext | null
+	parentRuntimeDebug?: PackageRuntimeDebugContext | null
+	packageInvokeDepth?: number
+}): PackageInvokeTools {
+	let autoIdempotencySequence = 0
+	return {
+		invoke: async (rawInput) => {
+			const user = input.callerContext.user
+			if (!user?.userId) {
+				throw new Error('packages.invoke requires an authenticated user.')
+			}
+			if (!input.packageContext) {
+				throw new Error('packages.invoke requires a package runtime context.')
+			}
+			const packageInvokeDepth = input.packageInvokeDepth ?? 0
+			if (packageInvokeDepth >= maxPackageRuntimeInvokeDepth) {
+				throw new Error(
+					`packages.invoke exceeded the maximum nested invocation depth (${maxPackageRuntimeInvokeDepth}).`,
+				)
+			}
+			const request = parsePackageInvokeInput(rawInput)
+			autoIdempotencySequence += 1
+			const idempotencyKey =
+				request.idempotencyKey ??
+				(await createAutoPackageInvokeIdempotencyKey({
+					callerPackageContext: input.packageContext,
+					parentRuntimeDebug: input.parentRuntimeDebug ?? null,
+					sequence: autoIdempotencySequence,
+					request,
+				}))
+			const response = await invokePackageExportForPackageRuntime({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				caller: {
+					userId: user.userId,
+					email: user.email ?? '',
+					displayName: user.displayName ?? '',
+					packageContext: input.packageContext,
+				},
+				request: {
+					packageIdOrKodyId: request.packageIdOrKodyId,
+					exportName: request.exportName,
+					params: request.params,
+					idempotencyKey,
+					source: `package:${input.packageContext.kodyId}`,
+					topic: request.topic,
+				},
+				runtimeInvokeDepth: packageInvokeDepth + 1,
+			})
+			if (response.status >= 200 && response.status < 400) {
+				return response.body['result']
+			}
+			const errorRecord =
+				(response.body['error'] as Record<string, unknown> | undefined) ?? {}
+			const code = String(errorRecord['code'] ?? 'package_invocation_failed')
+			const message = String(
+				errorRecord['message'] ??
+					`Package invocation failed with HTTP ${response.status}.`,
+			)
+			const error = new Error(`[${code}] ${message}`) as Error & {
+				code?: string
+				status?: number
+				response?: PackageInvocationResponse
+			}
+			error.code = code
+			error.status = response.status
+			error.response = response
+			throw error
+		},
+	}
+}
+
+export async function invokePackageExportForPackageRuntime(input: {
+	env: Env
+	baseUrl: string
+	caller: {
+		userId: string
+		email: string
+		displayName: string
+		packageContext: PackageRuntimeContext
+	}
+	request: PackageInvocationRequest
+	runtimeInvokeDepth?: number
+}): Promise<PackageInvocationResponse> {
+	const packageIdOrKodyId = input.request.packageIdOrKodyId.trim()
+	if (!packageIdOrKodyId) {
+		return buildJsonErrorResponse({
+			status: 400,
+			code: 'invalid_package',
+			message: 'Package id or kody id is required.',
+		})
+	}
+	const exportName = normalizeExportName(input.request.exportName)
+	const idempotencyKey = input.request.idempotencyKey.trim()
+	if (!idempotencyKey) {
+		return buildJsonErrorResponse({
+			status: 400,
+			code: 'missing_idempotency_key',
+			message: 'Package invocations require a non-empty idempotencyKey.',
+		})
+	}
+	const savedPackage = await resolveSavedPackage({
+		db: input.env.APP_DB,
+		userId: input.caller.userId,
+		packageIdOrKodyId,
+	})
+	if (!savedPackage) {
+		return buildJsonErrorResponse({
+			status: 404,
+			code: 'package_not_found',
+			message: `Saved package "${packageIdOrKodyId}" was not found for this user.`,
+			idempotencyKey,
+		})
+	}
+	return await invokeSavedPackageModule({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		actor: {
+			tokenId: `${internalPackageRuntimeInvokeTokenId}:${input.caller.packageContext.packageId}`,
+			userId: input.caller.userId,
+			email: input.caller.email,
+			displayName:
+				input.caller.displayName ||
+				`package:${input.caller.packageContext.kodyId}`,
+		},
+		savedPackage,
+		invocationName: exportName,
+		moduleSelector: {
+			kind: 'export',
+			exportName,
+		},
+		params: input.request.params,
+		idempotencyKey,
+		source:
+			normalizeNullableString(input.request.source) ??
+			`package:${input.caller.packageContext.kodyId}`,
+		topic: normalizeNullableString(input.request.topic),
+		notFoundCode: 'export_not_found',
+		runtimeInvokeDepth: input.runtimeInvokeDepth ?? 0,
+	})
+}
+
 export async function invokePackageExport(input: {
 	env: Env
 	baseUrl: string
 	token: PackageInvocationTokenScope
 	request: PackageInvocationRequest
+	runtimeInvokeDepth?: number
 }): Promise<PackageInvocationResponse> {
 	const packageIdOrKodyId = input.request.packageIdOrKodyId.trim()
 	if (!packageIdOrKodyId) {
@@ -982,6 +1249,7 @@ export async function invokePackageExport(input: {
 		source,
 		topic,
 		notFoundCode: 'export_not_found',
+		runtimeInvokeDepth: input.runtimeInvokeDepth ?? 0,
 	})
 }
 

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -274,6 +274,8 @@ async function createAutoPackageInvokeIdempotencyKey(input: {
 			canonicalJsonStringify({
 				callerPackageId: input.callerPackageContext.packageId,
 				parentKey,
+				parentSurface: input.parentRuntimeDebug?.surface ?? null,
+				parentName: input.parentRuntimeDebug?.name ?? null,
 				sequence: input.sequence,
 				packageIdOrKodyId: input.request.packageIdOrKodyId,
 				exportName: normalizeExportName(input.request.exportName),

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -952,7 +952,6 @@ async function invokeSavedPackageModule(input: {
 					parentRuntimeDebug: runtimeDebug,
 					packageInvokeDepth: input.runtimeInvokeDepth ?? 0,
 				}),
-				packageInvokeDepth: input.runtimeInvokeDepth ?? 0,
 			},
 		)
 		const response = executionResult.error
@@ -1097,7 +1096,7 @@ export function createPackageRuntimeInvokeTools(input: {
 	}
 }
 
-export async function invokePackageExportForPackageRuntime(input: {
+async function invokePackageExportForPackageRuntime(input: {
 	env: Env
 	baseUrl: string
 	caller: {

--- a/packages/worker/src/package-retrievers/service.ts
+++ b/packages/worker/src/package-retrievers/service.ts
@@ -189,7 +189,6 @@ async function invokeRetriever(input: {
 				parentRuntimeDebug: runtimeDebug,
 				packageInvokeDepth: 0,
 			}),
-			packageInvokeDepth: 0,
 			executorTimeoutMs: clampTimeout(input.entry.timeoutMs, input.scope),
 		},
 	)

--- a/packages/worker/src/package-retrievers/service.ts
+++ b/packages/worker/src/package-retrievers/service.ts
@@ -5,6 +5,7 @@ import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 import { loadPublishedBundleArtifactByIdentity } from '#worker/package-runtime/published-bundle-artifacts.ts'
+import { createPackageRuntimeInvokeTools } from '#worker/package-invocations/service.ts'
 import {
 	type PackageRetrieverManifestCacheEntry,
 	type PackageRetrieverResult,
@@ -137,6 +138,24 @@ async function invokeRetriever(input: {
 		},
 		repoContext: createRepoContext(source),
 	})
+	const packageContext = {
+		packageId: input.entry.packageId,
+		kodyId: input.entry.kodyId,
+		sourceId: input.entry.sourceId,
+	}
+	const runtimeDebug = {
+		packageId: input.entry.packageId,
+		kodyId: input.entry.kodyId,
+		sourceId: input.entry.sourceId,
+		publishedCommit: source.published_commit,
+		surface: 'retriever' as const,
+		name: input.entry.retrieverKey,
+		storageId: buildPackageRetrieverStorageId(input.entry.packageId),
+		metadata: {
+			scope: input.scope,
+			limit,
+		},
+	}
 	const executionResult = await runBundledModuleWithRegistry(
 		input.env,
 		callerContext,
@@ -157,24 +176,17 @@ async function invokeRetriever(input: {
 				storageId: buildPackageRetrieverStorageId(input.entry.packageId),
 				writable: false,
 			},
-			packageContext: {
-				packageId: input.entry.packageId,
-				kodyId: input.entry.kodyId,
-				sourceId: input.entry.sourceId,
-			},
-			runtimeDebug: {
-				packageId: input.entry.packageId,
-				kodyId: input.entry.kodyId,
-				sourceId: input.entry.sourceId,
-				publishedCommit: source.published_commit,
-				surface: 'retriever',
-				name: input.entry.retrieverKey,
-				storageId: buildPackageRetrieverStorageId(input.entry.packageId),
-				metadata: {
-					scope: input.scope,
-					limit,
-				},
-			},
+			packageContext,
+			runtimeDebug,
+			packageInvokeTools: createPackageRuntimeInvokeTools({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				callerContext,
+				packageContext,
+				parentRuntimeDebug: runtimeDebug,
+				packageInvokeDepth: 0,
+			}),
+			packageInvokeDepth: 0,
 			executorTimeoutMs: clampTimeout(input.entry.timeoutMs, input.scope),
 		},
 	)

--- a/packages/worker/src/package-retrievers/service.ts
+++ b/packages/worker/src/package-retrievers/service.ts
@@ -5,7 +5,6 @@ import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 import { loadPublishedBundleArtifactByIdentity } from '#worker/package-runtime/published-bundle-artifacts.ts'
-import { createPackageRuntimeInvokeTools } from '#worker/package-invocations/service.ts'
 import {
 	type PackageRetrieverManifestCacheEntry,
 	type PackageRetrieverResult,
@@ -156,6 +155,10 @@ async function invokeRetriever(input: {
 			limit,
 		},
 	}
+	// Avoid a top-level package-retrievers -> package-invocations cycle during
+	// capability registry initialization.
+	const { createPackageRuntimeInvokeTools } =
+		await import('#worker/package-invocations/service.ts')
 	const executionResult = await runBundledModuleWithRegistry(
 		input.env,
 		callerContext,

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -1493,3 +1493,51 @@ test('buildKodyAppBundle runtime module exports service helper', async () => {
 		'params',
 	)
 })
+
+test('buildKodyAppBundle runtime module exports package invocation helper', async () => {
+	mockModule.createWorker.mockResolvedValue(
+		createBundleResult('runtime-packages-helper'),
+	)
+
+	await buildKodyAppBundle({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/example-package',
+				exports: {
+					'.': './index.ts',
+				},
+				kody: {
+					id: 'example-package',
+					description: 'Example package',
+					app: {
+						entry: 'app.ts',
+					},
+				},
+			}),
+			'app.ts': `export default {
+	async fetch() {
+		return Response.json({ ok: true })
+	},
+}
+`,
+			'index.ts': 'export const value = "ok"',
+		},
+		entryPoint: 'app.ts',
+		cacheKey: null,
+	})
+
+	const firstCall = mockModule.createWorker.mock.calls.at(-1)?.[0] as
+		| {
+				files?: Record<string, string>
+		  }
+		| undefined
+	expect(firstCall?.files?.['.__kody_virtual__/runtime.js']).toContain(
+		'export const packages = runtime.packages ?? null;',
+	)
+})

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -157,6 +157,7 @@ export const service = runtime.service ?? null;
 export const packageSecrets = runtime.packageSecrets ?? null;
 export const email = runtime.email ?? null;
 export const workflows = runtime.workflows ?? null;
+export const packages = runtime.packages ?? null;
 
 export default runtime;
 `.trim()

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -41,6 +41,7 @@ import {
 	type PackageRuntimeRunHandle,
 	type PackageRuntimeStatus,
 } from './package-runtime-debug.ts'
+import { createPackageRuntimeInvokeTools } from '#worker/package-invocations/service.ts'
 
 const packageAppEntrypointName = 'PackageAppWorker'
 const packageAppRuntimeBindingName = 'KODY_RUNTIME'
@@ -265,6 +266,12 @@ function createWorkflowsProxy(runtimeBridge) {
 	};
 }
 
+function createPackagesProxy(runtimeBridge) {
+	return {
+		invoke: async (input) => await runtimeBridge.packageInvoke(input ?? {}),
+	};
+}
+
 function createAuthenticatedFetchHelper(runtimeBridge) {
 	return async function createAuthenticatedFetch(providerName) {
 		return async (input, init) =>
@@ -414,6 +421,7 @@ function createRuntime(runtimeBridge, packageContext) {
 		services: createServicesProxy(runtimeBridge),
 		packageSecrets,
 		workflows: createWorkflowsProxy(runtimeBridge),
+		packages: createPackagesProxy(runtimeBridge),
 		packageContext,
 	};
 }
@@ -970,6 +978,23 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 			},
 			body: input as PackageWorkflowCreateInput,
 		})
+	}
+
+	async packageInvoke(input: Record<string, unknown>) {
+		const packageContext = {
+			packageId: this.ctx.props.packageId,
+			kodyId: this.ctx.props.kodyId,
+			sourceId: this.ctx.props.sourceId,
+		}
+		const tools = createPackageRuntimeInvokeTools({
+			env: this.env,
+			baseUrl: this.ctx.props.baseUrl,
+			callerContext: this.createCallerContext(this.ctx.props.packageId),
+			packageContext,
+			parentRuntimeDebug: null,
+			packageInvokeDepth: 0,
+		})
+		return await tools.invoke(input)
 	}
 }
 

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -41,7 +41,6 @@ import {
 	type PackageRuntimeRunHandle,
 	type PackageRuntimeStatus,
 } from './package-runtime-debug.ts'
-import { createPackageRuntimeInvokeTools } from '#worker/package-invocations/service.ts'
 
 const packageAppEntrypointName = 'PackageAppWorker'
 const packageAppRuntimeBindingName = 'KODY_RUNTIME'
@@ -981,6 +980,10 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 	}
 
 	async packageInvoke(input: Record<string, unknown>) {
+		// Avoid a top-level package-app -> package-invocations cycle during worker
+		// startup; apps only need this helper when package code calls it.
+		const { createPackageRuntimeInvokeTools } =
+			await import('#worker/package-invocations/service.ts')
 		const packageContext = {
 			packageId: this.ctx.props.packageId,
 			kodyId: this.ctx.props.kodyId,

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -9,7 +9,6 @@ import {
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 import { buildSentryOptions } from '#worker/sentry-options.ts'
-import { createPackageRuntimeInvokeTools } from '#worker/package-invocations/service.ts'
 import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from './published-source-dependencies.ts'
 
 const serviceStateStorageKey = 'package-service-state'
@@ -490,10 +489,14 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 			{ runBundledModuleWithRegistry },
 			{ buildKodyModuleBundle },
 			{ loadPublishedBundleArtifactByIdentity },
+			{ createPackageRuntimeInvokeTools },
 		] = await Promise.all([
 			import('#mcp/run-codemode-registry.ts'),
 			import('./module-graph.ts'),
 			import('./published-bundle-artifacts.ts'),
+			// Avoid a top-level package-service -> package-invocations cycle during
+			// capability registry initialization.
+			import('#worker/package-invocations/service.ts'),
 		])
 		const artifact = await loadPublishedBundleArtifactByIdentity({
 			env: this.env,

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -9,6 +9,7 @@ import {
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 import { buildSentryOptions } from '#worker/sentry-options.ts'
+import { createPackageRuntimeInvokeTools } from '#worker/package-invocations/service.ts'
 import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from './published-source-dependencies.ts'
 
 const serviceStateStorageKey = 'package-service-state'
@@ -530,6 +531,19 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 				storageId: runtime.storageId,
 			},
 		})
+		const runtimeDebug = {
+			packageId: binding.packageId,
+			kodyId: binding.kodyId,
+			sourceId: binding.sourceId,
+			publishedCommit:
+				runtime.loaded.packageSource.source.published_commit ?? null,
+			surface: 'service' as const,
+			name: binding.serviceName,
+			storageId: runtime.storageId,
+			metadata: {
+				mode: runtime.loaded.serviceDefinition?.mode ?? 'bounded',
+			},
+		}
 		const result = await runBundledModuleWithRegistry(
 			this.env,
 			callerContext,
@@ -554,19 +568,16 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 					storageId: runtime.storageId,
 					writable: true,
 				},
-				runtimeDebug: {
-					packageId: binding.packageId,
-					kodyId: binding.kodyId,
-					sourceId: binding.sourceId,
-					publishedCommit:
-						runtime.loaded.packageSource.source.published_commit ?? null,
-					surface: 'service',
-					name: binding.serviceName,
-					storageId: runtime.storageId,
-					metadata: {
-						mode: runtime.loaded.serviceDefinition?.mode ?? 'bounded',
-					},
-				},
+				runtimeDebug,
+				packageInvokeTools: createPackageRuntimeInvokeTools({
+					env: this.env,
+					baseUrl: binding.baseUrl,
+					callerContext,
+					packageContext: runtime.packageContext,
+					parentRuntimeDebug: runtimeDebug,
+					packageInvokeDepth: 0,
+				}),
+				packageInvokeDepth: 0,
 				executorTimeoutMs: runtime.executorTimeoutMs,
 			},
 		)

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -580,7 +580,6 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 					parentRuntimeDebug: runtimeDebug,
 					packageInvokeDepth: 0,
 				}),
-				packageInvokeDepth: 0,
 				executorTimeoutMs: runtime.executorTimeoutMs,
 			},
 		)

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -818,6 +818,22 @@ test('runRepoChecks typechecks ESM package job entrypoints', async () => {
 		'.__kody_repo_module_check__.ts',
 		expect.stringContaining('import userEntrypoint from "./src/job"'),
 	)
+	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
+		'.__kody_repo_runtime__.d.ts',
+		expect.stringContaining('type KodyPackagesInvokeTarget ='),
+	)
+	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
+		'.__kody_repo_runtime__.d.ts',
+		expect.stringContaining('export const storage: KodyStorageRuntime;'),
+	)
+	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
+		'.__kody_repo_runtime__.d.ts',
+		expect.stringContaining('export const email: KodyEmailRuntime;'),
+	)
+	expect(typeScriptFileSystem.write).toHaveBeenCalledWith(
+		'.__kody_repo_runtime__.d.ts',
+		expect.stringContaining('export const workflows: KodyWorkflowsRuntime;'),
+	)
 	expect(typeScriptFileSystem.write).not.toHaveBeenCalledWith(
 		'.__kody_repo_module_check__.ts',
 		expect.stringContaining('import userEntrypoint from "./src/index"'),

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -212,13 +212,16 @@ function createExecuteTypecheckPrelude(input?: { includeStorage?: boolean }) {
 
 type KodyCapabilityArgs = Record<string, unknown>;
 type KodyCapabilityResult = unknown;
-type KodyPackagesInvokeInput = {
-  kodyId?: string;
-  kody_id?: string;
-  packageId?: string;
-  package_id?: string;
-  exportName?: string;
-  export_name?: string;
+type KodyPackagesInvokeTarget =
+  | { kodyId: string; kody_id?: never; packageId?: never; package_id?: never }
+  | { kodyId?: never; kody_id: string; packageId?: never; package_id?: never }
+  | { kodyId?: never; kody_id?: never; packageId: string; package_id?: never }
+  | { kodyId?: never; kody_id?: never; packageId?: never; package_id: string };
+type KodyPackagesInvokeExport =
+  | { exportName: string; export_name?: never }
+  | { exportName?: never; export_name: string };
+type KodyPackagesInvokeInput = KodyPackagesInvokeTarget &
+  KodyPackagesInvokeExport & {
   params?: Record<string, unknown>;
   idempotencyKey?: string;
   idempotency_key?: string;
@@ -227,6 +230,23 @@ type KodyPackagesInvokeInput = {
 type KodyPackagesRuntime = {
   invoke(input: KodyPackagesInvokeInput): Promise<unknown>;
 };
+type KodyStorageRuntime = {
+  id: string;
+  get(key: string): Promise<unknown>;
+  list(options?: KodyCapabilityArgs): Promise<unknown>;
+  sql(query: string, params?: Array<KodyJsonValue>): Promise<unknown>;
+  set(key: string, value: KodyJsonValue): Promise<unknown>;
+  delete(key: string): Promise<unknown>;
+  clear(): Promise<unknown>;
+};
+type KodyEmailRuntime = {
+  getMessage(messageId: string): Promise<unknown>;
+  getAttachment(attachmentId: string): Promise<unknown>;
+  reply(input?: KodyCapabilityArgs): Promise<unknown>;
+} | null;
+type KodyWorkflowsRuntime = {
+  create(input: KodyCapabilityArgs): Promise<unknown>;
+} | null;
 
 declare const codemode: Record<
   string,
@@ -240,6 +260,8 @@ declare function createAuthenticatedFetch(
 declare const packageContext: { packageId: string; kodyId: string } | null;
 declare const serviceContext: { serviceName: string } | null;
 declare const packages: KodyPackagesRuntime | null;
+declare const email: KodyEmailRuntime;
+declare const workflows: KodyWorkflowsRuntime;
 declare const packageSecrets:
   | {
       get(alias: string): Promise<string>;
@@ -267,6 +289,13 @@ declare module "kody:runtime" {
   export const packageContext: { packageId: string; kodyId: string } | null;
   export const serviceContext: { serviceName: string } | null;
   export const packages: KodyPackagesRuntime | null;
+  export const storage: ${
+		input?.includeStorage === true
+			? 'KodyStorageRuntime'
+			: 'KodyStorageRuntime | undefined'
+	};
+  export const email: KodyEmailRuntime;
+  export const workflows: KodyWorkflowsRuntime;
   export const packageSecrets:
     | {
         get(alias: string): Promise<string>;
@@ -285,15 +314,7 @@ declare module "kody:runtime" {
 ${
 	input?.includeStorage === true
 		? `
-declare const storage: {
-  id: string;
-  get(key: string): Promise<unknown>;
-  list(options?: KodyCapabilityArgs): Promise<unknown>;
-  sql(query: string, params?: Array<KodyJsonValue>): Promise<unknown>;
-  set(key: string, value: KodyJsonValue): Promise<unknown>;
-  delete(key: string): Promise<unknown>;
-  clear(): Promise<unknown>;
-};
+declare const storage: KodyStorageRuntime;
 `
 		: ''
 }

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -212,6 +212,21 @@ function createExecuteTypecheckPrelude(input?: { includeStorage?: boolean }) {
 
 type KodyCapabilityArgs = Record<string, unknown>;
 type KodyCapabilityResult = unknown;
+type KodyPackagesInvokeInput = {
+  kodyId?: string;
+  kody_id?: string;
+  packageId?: string;
+  package_id?: string;
+  exportName?: string;
+  export_name?: string;
+  params?: Record<string, unknown>;
+  idempotencyKey?: string;
+  idempotency_key?: string;
+  topic?: string | null;
+};
+type KodyPackagesRuntime = {
+  invoke(input: KodyPackagesInvokeInput): Promise<unknown>;
+};
 
 declare const codemode: Record<
   string,
@@ -224,6 +239,7 @@ declare function createAuthenticatedFetch(
 ): Promise<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>;
 declare const packageContext: { packageId: string; kodyId: string } | null;
 declare const serviceContext: { serviceName: string } | null;
+declare const packages: KodyPackagesRuntime | null;
 declare const packageSecrets:
   | {
       get(alias: string): Promise<string>;
@@ -238,6 +254,34 @@ declare const service:
       clearAlarm(): Promise<unknown>;
     }
   | null;
+
+declare module "kody:runtime" {
+  export const codemode: Record<
+    string,
+    (args: KodyCapabilityArgs) => Promise<KodyCapabilityResult>
+  >;
+  export function refreshAccessToken(providerName: string): Promise<string>;
+  export function createAuthenticatedFetch(
+    providerName: string,
+  ): Promise<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>;
+  export const packageContext: { packageId: string; kodyId: string } | null;
+  export const serviceContext: { serviceName: string } | null;
+  export const packages: KodyPackagesRuntime | null;
+  export const packageSecrets:
+    | {
+        get(alias: string): Promise<string>;
+        has(alias: string): Promise<boolean>;
+      }
+    | null;
+  export const service:
+    | {
+        getStatus(): Promise<unknown>;
+        shouldStop(): Promise<boolean>;
+        setAlarm(runAt: string | Date): Promise<unknown>;
+        clearAlarm(): Promise<unknown>;
+      }
+    | null;
+}
 ${
 	input?.includeStorage === true
 		? `


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Expose `packages.invoke` from `kody:runtime` for package runtime contexts.
- Route dynamic package calls through the existing package invocation service so callers resolve the target package's current published export at runtime.
- Preserve same-user/package runtime context, add nested invocation depth protection, avoid runtime import cycles, and document idempotency behavior.
- Include parent runtime identity in generated nested idempotency keys so different parent exports sharing a domain idempotency key do not suppress each other.
- Tighten package runtime typechecking so `packages.invoke` requires one package identifier and one export alias, and declare the existing `storage`, `email`, and `workflows` runtime exports in the ambient module.
- Document when to use dynamic invocation for event subscribers/workflows/agents versus static `kody:@` imports for library-like pinned bundle behavior.

## Testing
- `npx vitest run --config vitest.node.config.ts packages/worker/src/repo/checks.node.test.ts packages/worker/src/package-invocations/service.node.test.ts packages/worker/src/mcp/run-codemode-registry.node.test.ts`
- `npx vitest run --config vitest.node.config.ts packages/worker/src/package-invocations/service.node.test.ts`
- `npx vitest run --config vitest.node.config.ts packages/worker/src/package-invocations/service.node.test.ts packages/worker/src/mcp/run-codemode-registry.node.test.ts packages/worker/src/package-runtime/module-graph.node.test.ts`
- `npx vitest run --config vitest.node.config.ts packages/worker/src/mcp/capabilities/apps/apps-domain.node.test.ts packages/worker/src/mcp/server-instructions.node.test.ts packages/worker/src/mcp/tools/search-format.node.test.ts packages/worker/src/package-invocations/service.node.test.ts packages/worker/src/mcp/run-codemode-registry.node.test.ts packages/worker/src/package-runtime/module-graph.node.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated warning in `packages/worker/src/email/inbound.workers.test.ts`)
- `npm run validate` (passes after latest review fixes: format, lint, typecheck, 110 unit/worker test files, 3 Playwright E2E tests, and 2 MCP E2E tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-263eb487-ff40-4605-a5ea-32c989d60008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-263eb487-ff40-4605-a5ea-32c989d60008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime `packages.invoke()` to call owned packages dynamically from running code, with nested-depth limiting and deterministic auto idempotency keys; runtime exposes a `packages` helper.

* **Documentation**
  * Detailed guides on dynamic invocation semantics, error/resolution behavior, idempotency, security/depth safeguards, and migration notes for switching from static imports.

* **Tests**
  * Expanded tests covering invocation, nesting/depth, idempotency, missing-package/export errors, and runtime preconditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/429)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->