### PR TITLE
Provide remote connector tools to package workflows

### DIFF
--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -179,6 +179,7 @@ function createToken(
 	overrides: Partial<{
 		exportNames: Array<string>
 		sources: Array<string>
+		remoteConnectors: Array<{ kind: string; instanceId: string }>
 	}> = {},
 ) {
 	return {
@@ -189,6 +190,7 @@ function createToken(
 		packageKodyIds: ['discord-gateway'],
 		exportNames: overrides.exportNames ?? ['./dispatch-message-created'],
 		sources: overrides.sources ?? ['discord-gateway'],
+		remoteConnectors: overrides.remoteConnectors,
 	} as const
 }
 
@@ -543,7 +545,9 @@ test('invokePackageExport executes a scoped package export successfully', async 
 	const response = await invokePackageExport({
 		env: createEnv(db),
 		baseUrl: 'https://kody.dev',
-		token: createToken(),
+		token: createToken({
+			remoteConnectors: [{ kind: 'home', instanceId: 'default' }],
+		}),
 		request: {
 			packageIdOrKodyId: 'discord-gateway',
 			exportName: 'dispatch-message-created',
@@ -565,6 +569,15 @@ test('invokePackageExport executes a scoped package export successfully', async 
 		logs: ['dispatched'],
 	})
 	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({
+			remoteConnectors: [{ kind: 'home', instanceId: 'default' }],
+		}),
+		expect.anything(),
+		expect.anything(),
+		expect.anything(),
+	)
 })
 
 test('package runtime can dynamically invoke the current published export from another package', async () => {

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -1,5 +1,6 @@
 import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { toHex } from '@kody-internal/shared/hex.ts'
+import { type RemoteConnectorRef } from '@kody-internal/shared/remote-connectors.ts'
 import { extractRawContent, getExecutionErrorDetails } from '#mcp/executor.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import {
@@ -58,6 +59,7 @@ export type PackageInvocationTokenScope = {
 	packageKodyIds?: Array<string>
 	exportNames?: Array<string>
 	sources?: Array<string>
+	remoteConnectors?: Array<RemoteConnectorRef>
 }
 
 export type PackageInvocationRequest = {
@@ -76,6 +78,7 @@ type PackageInvocationActor = {
 	userId: string
 	email: string
 	displayName: string
+	remoteConnectors?: Array<RemoteConnectorRef> | null
 }
 
 type PackageModuleSelector =
@@ -808,6 +811,7 @@ async function invokeSavedPackageModule(input: {
 				appId: input.savedPackage.id,
 				storageId: buildPackageInvocationStorageId(input.savedPackage.id),
 			},
+			remoteConnectors: input.actor.remoteConnectors ?? null,
 			repoContext: repoSource ? createRepoContext(repoSource) : null,
 		})
 		const runtimeSurface = resolveInvocationRuntimeSurface({
@@ -1061,6 +1065,7 @@ export function createPackageRuntimeInvokeTools(input: {
 					userId: user.userId,
 					email: user.email ?? '',
 					displayName: user.displayName ?? '',
+					remoteConnectors: input.callerContext.remoteConnectors ?? null,
 					packageContext: input.packageContext,
 				},
 				request: {
@@ -1103,6 +1108,7 @@ async function invokePackageExportForPackageRuntime(input: {
 		userId: string
 		email: string
 		displayName: string
+		remoteConnectors?: Array<RemoteConnectorRef> | null
 		packageContext: PackageRuntimeContext
 	}
 	request: PackageInvocationRequest
@@ -1148,6 +1154,7 @@ async function invokePackageExportForPackageRuntime(input: {
 			displayName:
 				input.caller.displayName ||
 				`package:${input.caller.packageContext.kodyId}`,
+			remoteConnectors: input.caller.remoteConnectors ?? null,
 		},
 		savedPackage,
 		invocationName: exportName,
@@ -1238,6 +1245,7 @@ export async function invokePackageExport(input: {
 			userId: input.token.userId,
 			email: input.token.email,
 			displayName: input.token.displayName,
+			remoteConnectors: input.token.remoteConnectors ?? null,
 		},
 		savedPackage,
 		invocationName: exportName,

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -11,9 +11,18 @@ const invocationMocks = vi.hoisted(() => ({
 	runModuleWithRegistry: vi.fn(),
 }))
 
+const remoteConnectorMocks = vi.hoisted(() => ({
+	safelyListAttachedRemoteConnectorRefs: vi.fn(async () => []),
+}))
+
 vi.mock('#worker/package-invocations/service.ts', () => ({
 	invokePackageExport: (...args: Array<unknown>) =>
 		invocationMocks.invokePackageExport(...args),
+}))
+
+vi.mock('#worker/remote-connector/settings-service.ts', () => ({
+	safelyListAttachedRemoteConnectorRefs: (...args: Array<unknown>) =>
+		remoteConnectorMocks.safelyListAttachedRemoteConnectorRefs(...args),
 }))
 
 vi.mock('#mcp/run-codemode-registry.ts', () => ({
@@ -339,6 +348,125 @@ test('DynamicCallableWorkflowBase executes queued inline code and records comple
 	} finally {
 		vi.useRealTimers()
 	}
+})
+
+test('DynamicCallableWorkflowBase restores attached remote connectors for inline code', async () => {
+	const binding = createStatefulWorkflowBinding()
+	const db = createWorkflowRunsDatabase()
+	const env = {
+		APP_DB: db,
+		DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+		APP_BASE_URL: 'https://app.example.com',
+	} as Env
+	const created = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		packageContext: null,
+		body: {
+			code: 'export default async function main(){ return { ok: true }; }',
+			runAt: '2026-05-03T12:34:56.000Z',
+			idempotencyKey: 'execute-remote-connector-smoke',
+		},
+	})
+	const queued = binding.instances.get(created.id)
+	if (!queued?.params) throw new Error('Expected queued workflow payload.')
+	invocationMocks.runModuleWithRegistry.mockReset()
+	invocationMocks.runModuleWithRegistry.mockResolvedValueOnce({
+		result: { ok: true },
+		logs: [],
+	})
+	remoteConnectorMocks.safelyListAttachedRemoteConnectorRefs.mockResolvedValueOnce(
+		[{ kind: 'home', instanceId: 'default' }],
+	)
+
+	const workflow = new DynamicCallableWorkflowBase({} as ExecutionContext, env)
+	const stepDo = vi.fn(
+		async (_name: string, _config: unknown, callback: () => unknown) =>
+			await callback(),
+	)
+	await workflow.run(
+		{
+			payload: queued.params as never,
+			timestamp: new Date(),
+			instanceId: created.id,
+		},
+		{ sleepUntil: vi.fn(), do: stepDo } as unknown as WorkflowStep,
+	)
+
+	expect(
+		remoteConnectorMocks.safelyListAttachedRemoteConnectorRefs,
+	).toHaveBeenCalledWith({
+		env,
+		userId: 'user-1',
+	})
+	expect(invocationMocks.runModuleWithRegistry).toHaveBeenCalledWith(
+		expect.any(Object),
+		expect.objectContaining({
+			remoteConnectors: [{ kind: 'home', instanceId: 'default' }],
+		}),
+		expect.any(String),
+		undefined,
+	)
+})
+
+test('DynamicCallableWorkflowBase restores attached remote connectors for package exports', async () => {
+	const binding = createStatefulWorkflowBinding()
+	const db = createWorkflowRunsDatabase()
+	const env = {
+		APP_DB: db,
+		DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+		APP_BASE_URL: 'https://app.example.com',
+	} as Env
+	const created = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		packageContext: null,
+		body: {
+			packageId: 'pkg-1',
+			exportName: './workflow-run-event',
+			runAt: '2026-05-03T12:34:56.000Z',
+			idempotencyKey: 'package-remote-connector-smoke',
+			params: { key: 'north-east-open' },
+		},
+	})
+	const queued = binding.instances.get(created.id)
+	if (!queued?.params) throw new Error('Expected queued workflow payload.')
+	invocationMocks.invokePackageExport.mockReset()
+	invocationMocks.invokePackageExport.mockResolvedValueOnce({
+		status: 200,
+		body: { result: { ok: true } },
+	})
+	remoteConnectorMocks.safelyListAttachedRemoteConnectorRefs.mockResolvedValueOnce(
+		[{ kind: 'home', instanceId: 'default' }],
+	)
+
+	const workflow = new DynamicCallableWorkflowBase({} as ExecutionContext, env)
+	const stepDo = vi.fn(
+		async (_name: string, _config: unknown, callback: () => unknown) =>
+			await callback(),
+	)
+	await workflow.run(
+		{
+			payload: queued.params as never,
+			timestamp: new Date(),
+			instanceId: created.id,
+		},
+		{ sleepUntil: vi.fn(), do: stepDo } as unknown as WorkflowStep,
+	)
+
+	expect(
+		remoteConnectorMocks.safelyListAttachedRemoteConnectorRefs,
+	).toHaveBeenCalledWith({
+		env,
+		userId: 'user-1',
+	})
+	expect(invocationMocks.invokePackageExport).toHaveBeenCalledWith(
+		expect.objectContaining({
+			token: expect.objectContaining({
+				remoteConnectors: [{ kind: 'home', instanceId: 'default' }],
+			}),
+		}),
+	)
 })
 
 test('createDynamicCallableWorkflow verifies package ownership before queueing package exports', async () => {

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -11,6 +11,7 @@ import {
 	getSavedPackageById,
 	getSavedPackageByKodyId,
 } from '#worker/package-registry/repo.ts'
+import { safelyListAttachedRemoteConnectorRefs } from '#worker/remote-connector/settings-service.ts'
 import { buildSentryOptions } from '#worker/sentry-options.ts'
 
 export type PackageWorkflowParams = Record<string, unknown>
@@ -961,6 +962,10 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 	private async invokePackageWorkflowExport(
 		payload: Extract<DynamicCallableWorkflowPayload, { sourceType: 'package' }>,
 	): Promise<JsonValue> {
+		const remoteConnectors = await safelyListAttachedRemoteConnectorRefs({
+			env: this.env,
+			userId: payload.userId,
+		})
 		const response = await invokePackageExport({
 			env: this.env,
 			baseUrl: getAppBaseUrl({
@@ -976,6 +981,7 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 				packageKodyIds: [payload.kodyId],
 				exportNames: [payload.exportName],
 				sources: [packageWorkflowInvocationSource],
+				remoteConnectors,
 			},
 			request: {
 				packageIdOrKodyId: payload.packageId,
@@ -1000,6 +1006,10 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 				import('#mcp/run-codemode-registry.ts'),
 				import('#mcp/context.ts'),
 			])
+		const remoteConnectors = await safelyListAttachedRemoteConnectorRefs({
+			env: this.env,
+			userId: payload.userId,
+		})
 		const result = await runModuleWithRegistry(
 			this.env,
 			createMcpCallerContext({
@@ -1012,6 +1022,7 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 					email: '',
 					displayName: `workflow:${payload.workflowName}`,
 				},
+				remoteConnectors,
 			}),
 			payload.code,
 			payload.params,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Restore attached remote connector refs when dynamic package workflows execute inline code or package exports.
- Thread connector refs through package invocation caller contexts so `codemode` can synthesize connector tools such as Bond shade controls.
- Add regression coverage for inline/package workflow connector propagation and package export caller contexts.

## Testing
- `npx vitest run packages/worker/src/package-runtime/package-workflows.node.test.ts packages/worker/src/package-invocations/service.node.test.ts --config vitest.node.config.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1087d1f1-97dd-4622-8388-bd81513a081d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1087d1f1-97dd-4622-8388-bd81513a081d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Remote connectors now propagate through package invocations, enabling them in saved package exports and inline workflow execution.
  * Attached remote connectors are automatically restored and available during package and workflow execution.

* **Tests**
  * Added smoke tests to verify remote connector propagation in workflow execution paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/433)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->