### PR TITLE
Clarify package runtime invoke availability

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -30,6 +30,9 @@ helpers are runtime exports:
   [Workflows](./workflows.md)
 - use **`import { packageContext } from 'kody:runtime'`** inside saved package
   code when you need package metadata; it is **`null`** for ad hoc execute calls
+- use **`import { packages } from 'kody:runtime'`** only inside saved package
+  runtime contexts when you need dynamic current-version invocation through
+  `packages.invoke(...)`; it is **`null`** for ad hoc execute calls
 - use **`import { serviceContext } from 'kody:runtime'`** inside package service
   code when you need the current service identity; it is **`null`** outside
   package service runs

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -109,11 +109,11 @@ module-oriented runtime model:
 - **`codemode.job_run_now(...)`** runs an existing scheduled job immediately and
   returns both the updated job state and the execution result for debugging
 
-Static saved-package imports from ad hoc **execute** run under the ad hoc execute
-runtime. That means imported package modules can share exported helpers, but
-`packageContext` and `packages` remain **`null`** unless the module is entered
-through a true saved-package runtime surface such as package invocation, a
-package job, a package service, a package app, or a package subscription.
+Static saved-package imports from ad hoc **execute** run under the ad hoc
+execute runtime. That means imported package modules can share exported helpers,
+but `packageContext` and `packages` remain **`null`** unless the module is
+entered through a true saved-package runtime surface such as package invocation,
+a package job, a package service, a package app, or a package subscription.
 
 When you need to edit saved source, prefer the repo-backed workflow in
 [Repo-backed editing sessions](./repo-sessions.md). Open by package identity

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -109,6 +109,12 @@ module-oriented runtime model:
 - **`codemode.job_run_now(...)`** runs an existing scheduled job immediately and
   returns both the updated job state and the execution result for debugging
 
+Static saved-package imports from ad hoc **execute** run under the ad hoc execute
+runtime. That means imported package modules can share exported helpers, but
+`packageContext` and `packages` remain **`null`** unless the module is entered
+through a true saved-package runtime surface such as package invocation, a
+package job, a package service, a package app, or a package subscription.
+
 When you need to edit saved source, prefer the repo-backed workflow in
 [Repo-backed editing sessions](./repo-sessions.md). Open by package identity
 instead of internal source ids whenever possible.

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -132,6 +132,12 @@ scoped to packages owned by the current authenticated user. Package code does
 not need to mint or pass package-invocation bearer tokens. Nested package
 invocations are depth-limited to prevent runaway loops.
 
+Ad hoc MCP `execute` code, including saved package modules imported from that
+execute call, does not get a package runtime context. In those runs
+`import { packages } from 'kody:runtime'` returns `null`; enter the package
+through package invocation, a package subscription, a package job, service, or
+app when the code needs `packages.invoke`.
+
 If `idempotencyKey` is omitted, Kody generates one. In package invocations that
 already have a parent idempotency key, the generated key is deterministic for
 the parent key, parent runtime surface/name, call order, target, export, and

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -53,6 +53,7 @@ Sandbox surface:
 - \`import { workflows } from 'kody:runtime'\` for durable Cloudflare Workflows. \`workflows.create\` accepts either inline \`code\` or a saved-package \`exportName\`; use \`workflow_list\` to inspect recent runs.
 - Optional \`params\` are passed as the first argument to the module default export. Prefer \`export default async function main(input = {}) { ... }\`; pass \`input\` to shared helpers explicitly.
 - \`import { packageContext } from 'kody:runtime'\` in saved package code when you need package metadata; it is \`null\` for ad hoc execute calls.
+- \`import { packages } from 'kody:runtime'\` exposes \`packages.invoke(...)\` only in saved package runtime contexts; it is \`null\` for ad hoc execute calls.
 - \`fetch(...)\` is the host-provided network global; \`{{secret:name}}\` / \`{{secret:name|scope=user}}\` work in URL, headers, or body on approved hosts only.
 - Fields marked \`x-kody-secret: true\` accept the same placeholder form; respect per-secret allowed-capability lists.
 - Placeholders are not general string interpolation (they do not resolve in arbitrary return values).

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -578,6 +578,19 @@ test('invokePackageExport executes a scoped package export successfully', async 
 		expect.anything(),
 		expect.anything(),
 	)
+	const runOptions =
+		repoMockModule.runBundledModuleWithRegistry.mock.calls[0]?.[4]
+	expect(runOptions).toMatchObject({
+		packageContext: {
+			packageId: 'pkg-1',
+			kodyId: 'discord-gateway',
+			sourceId: 'source-1',
+		},
+	})
+	expect(
+		(runOptions as { packageInvokeTools?: { invoke?: unknown } })
+			.packageInvokeTools?.invoke,
+	).toEqual(expect.any(Function))
 })
 
 test('package runtime can dynamically invoke the current published export from another package', async () => {
@@ -668,6 +681,25 @@ test('package runtime can dynamically invoke the current published export from a
 		},
 	})
 	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(4)
+	const firstGatewayRunOptions =
+		repoMockModule.runBundledModuleWithRegistry.mock.calls[0]?.[4]
+	const firstSubscriberRunOptions =
+		repoMockModule.runBundledModuleWithRegistry.mock.calls[1]?.[4]
+	expect(
+		(firstGatewayRunOptions as { packageInvokeTools?: { invoke?: unknown } })
+			.packageInvokeTools?.invoke,
+	).toEqual(expect.any(Function))
+	expect(firstSubscriberRunOptions).toMatchObject({
+		packageContext: {
+			packageId: 'pkg-subscriber',
+			kodyId: 'discord-general-chat',
+			sourceId: 'source-subscriber',
+		},
+	})
+	expect(
+		(firstSubscriberRunOptions as { packageInvokeTools?: { invoke?: unknown } })
+			.packageInvokeTools?.invoke,
+	).toEqual(expect.any(Function))
 })
 
 test('package runtime invocation errors clearly when the target package is missing', async () => {

--- a/packages/worker/src/package-runtime/module-graph.workers.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.workers.test.ts
@@ -128,3 +128,142 @@ test('saved package execution passes input as the default export argument', asyn
 		missing: 'defaulted',
 	})
 })
+
+test('saved package execution exposes packages.invoke when package invoke tools are provided', async () => {
+	const packageJson = JSON.stringify({
+		name: '@kentcdodds/invoker-package',
+		exports: {
+			'.': './src/index.ts',
+		},
+		kody: {
+			id: 'invoker-package',
+			description: 'Exercises package invocation runtime helper',
+		},
+	})
+	const bundle = await buildKodyModuleBundle({
+		env,
+		baseUrl: 'https://kody.dev',
+		userId: 'user-workers-test',
+		sourceFiles: {
+			'package.json': packageJson,
+			'src/index.ts': [
+				"import { packageContext, packages } from 'kody:runtime'",
+				'',
+				'export default async function main(input = {}) {',
+				'\treturn {',
+				'\t\tpackageId: packageContext?.packageId ?? null,',
+				"\t\thasInvoke: typeof packages?.invoke === 'function',",
+				'\t\tinvoked: await packages?.invoke({',
+				"\t\t\tkodyId: 'target-package',",
+				"\t\t\texportName: './run',",
+				'\t\t\tparams: input,',
+				'\t\t}),',
+				'\t}',
+				'}',
+			].join('\n'),
+		},
+		entryPoint: 'src/index.ts',
+	})
+	const invokedInputs: Array<Record<string, unknown>> = []
+	const result = await runBundledModuleWithRegistry(
+		env,
+		createMcpCallerContext({
+			baseUrl: 'https://kody.dev',
+			user: {
+				userId: 'user-workers-test',
+				email: 'worker@example.com',
+				displayName: 'Worker Test',
+			},
+		}),
+		{
+			mainModule: bundle.mainModule,
+			modules: bundle.modules,
+		},
+		{ eventId: 'event-1' },
+		{
+			packageContext: {
+				packageId: 'pkg-invoker',
+				kodyId: 'invoker-package',
+				sourceId: 'source-invoker',
+			},
+			packageInvokeTools: {
+				invoke: async (input) => {
+					invokedInputs.push(input)
+					return { ok: true, input }
+				},
+			},
+			skipCapabilityRegistry: true,
+		},
+	)
+
+	expect(result.error).toBeUndefined()
+	expect(result.result).toEqual({
+		packageId: 'pkg-invoker',
+		hasInvoke: true,
+		invoked: {
+			ok: true,
+			input: {
+				kodyId: 'target-package',
+				exportName: './run',
+				params: { eventId: 'event-1' },
+			},
+		},
+	})
+	expect(invokedInputs).toEqual([
+		{
+			kodyId: 'target-package',
+			exportName: './run',
+			params: { eventId: 'event-1' },
+		},
+	])
+})
+
+test('ad hoc execute runtime exposes packages as null without package invoke tools', async () => {
+	const bundle = await buildKodyModuleBundle({
+		env,
+		baseUrl: 'https://kody.dev',
+		userId: 'user-workers-test',
+		sourceFiles: {
+			'entry.ts': [
+				"import { packageContext, packages } from 'kody:runtime'",
+				'',
+				'export default async function main() {',
+				'\treturn {',
+				'\t\tpackageContextIsNull: packageContext === null,',
+				'\t\tpackagesIsNull: packages === null,',
+				"\t\thasInvoke: typeof packages?.invoke === 'function',",
+				'\t}',
+				'}',
+			].join('\n'),
+		},
+		entryPoint: 'entry.ts',
+	})
+
+	const result = await runBundledModuleWithRegistry(
+		env,
+		createMcpCallerContext({
+			baseUrl: 'https://kody.dev',
+			user: {
+				userId: 'user-workers-test',
+				email: 'worker@example.com',
+				displayName: 'Worker Test',
+			},
+		}),
+		{
+			mainModule: bundle.mainModule,
+			modules: bundle.modules,
+		},
+		undefined,
+		{
+			packageContext: null,
+			skipCapabilityRegistry: true,
+		},
+	)
+
+	expect(result.error).toBeUndefined()
+	expect(result.result).toEqual({
+		packageContextIsNull: true,
+		packagesIsNull: true,
+		hasInvoke: false,
+	})
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Document that `packages.invoke` is available in true saved-package runtime contexts and intentionally `null` for ad hoc MCP execute, including ad hoc execute code that statically imports saved package modules.
- Add worker runtime coverage proving `kody:runtime` exposes `packages.invoke` when package invoke tools are supplied and exposes `packages` as `null` without them.
- Tighten package invocation service tests to assert the external invocation path supplies package runtime invoke tools and supports dynamic Discord-style subscriber dispatch.

## Testing
- `npx vitest run --config vitest.workers.config.ts "packages/worker/src/package-runtime/module-graph.workers.test.ts"`
- `npx vitest run --config vitest.node.config.ts "packages/worker/src/package-invocations/service.node.test.ts" --testNamePattern "invokePackageExport executes|package runtime can dynamically invoke|requires package context"`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a49a9bd-42c6-4db1-b671-eac3c4fa2cd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a49a9bd-42c6-4db1-b671-eac3c4fa2cd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified runtime behavior: `packages` is null for ad hoc/execute runs and only available in true saved-package runtime contexts; noted that static saved-package imports in ad hoc runs share exported helpers but lack package runtime values.
  * Updated tool/user guidance to reflect sandbox/runtime constraints.

* **Tests**
  * Added and strengthened tests verifying package runtime invocation behavior and presence/absence of package helpers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/434)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->