### PR TITLE
Fix package runtime codemode preload

### DIFF
--- a/packages/worker/src/mcp/run-codemode-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.node.test.ts
@@ -180,15 +180,21 @@ export default async function run() {
 	}
 })
 
-vi.mock('#worker/package-runtime/module-graph.ts', () => ({
-	buildKodyModuleBundle: vi.fn(async () => ({
-		mainModule: 'entry.js',
-		modules: {
-			'entry.js':
-				'export default async function main(input = {}) { return input }',
-		},
-	})),
-}))
+vi.mock('#worker/package-runtime/module-graph.ts', async () => {
+	const actual = await vi.importActual<
+		typeof import('#worker/package-runtime/module-graph.ts')
+	>('#worker/package-runtime/module-graph.ts')
+	return {
+		...actual,
+		buildKodyModuleBundle: vi.fn(async () => ({
+			mainModule: 'entry.js',
+			modules: {
+				'entry.js':
+					'export default async function main(input = {}) { return input }',
+			},
+		})),
+	}
+})
 
 test('runBundledModuleWithRegistry passes params as an explicit entrypoint argument', async () => {
 	const env = {} as Env
@@ -246,6 +252,67 @@ test('runBundledModuleWithRegistry passes params as an explicit entrypoint argum
 	} finally {
 		createExecuteExecutorSpy.mockRestore()
 		getRegistrySpy.mockRestore()
+	}
+})
+
+test('runBundledModuleWithRegistry refreshes persisted kody runtime modules before execution', async () => {
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+	})
+	const staleRuntimeSource = 'export const codemode = undefined;'
+	const createExecuteExecutorSpy = vi
+		.spyOn(await import('#mcp/executor.ts'), 'createExecuteExecutor')
+		.mockImplementation((input) => {
+			const modules = input.modules as Record<string, string>
+			expect(modules['entry.js']).toBe(
+				'export default async function main() { return "ok" }',
+			)
+			expect(modules['.__kody_virtual__/runtime.js']).toContain(
+				'__kodyCreateRuntimeObjectProxy',
+			)
+			expect(
+				modules[
+					'.__kody_packages__/@kentcdodds/ai-chat/.__published_bundle__/2e/.__kody_virtual__/runtime.js'
+				],
+			).toContain('__kodyCreateRuntimeObjectProxy')
+			expect(modules['.__kody_virtual__/runtime.js']).not.toBe(
+				staleRuntimeSource,
+			)
+			return {
+				async execute() {
+					return {
+						result: 'ok',
+						logs: [],
+					}
+				},
+			} as never
+		})
+
+	try {
+		const result = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			{
+				mainModule: 'entry.js',
+				modules: {
+					'entry.js': 'export default async function main() { return "ok" }',
+					'.__kody_virtual__/runtime.js': staleRuntimeSource,
+					'.__kody_packages__/@kentcdodds/ai-chat/.__published_bundle__/2e/.__kody_virtual__/runtime.js':
+						staleRuntimeSource,
+				},
+			},
+			undefined,
+			{
+				skipCapabilityRegistry: true,
+			},
+		)
+
+		expect(result.result).toBe('ok')
+		expect(createExecuteExecutorSpy).toHaveBeenCalledTimes(1)
+	} finally {
+		createExecuteExecutorSpy.mockRestore()
 	}
 })
 

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -33,7 +33,10 @@ import {
 	hasTopLevelModuleSyntax,
 	stripCodeFences,
 } from '#worker/module-source.ts'
-import { buildKodyModuleBundle } from '#worker/package-runtime/module-graph.ts'
+import {
+	buildKodyModuleBundle,
+	refreshKodyRuntimeModules,
+} from '#worker/package-runtime/module-graph.ts'
 import {
 	beginPackageRuntimeRun,
 	finishPackageRuntimeRun,
@@ -811,7 +814,7 @@ export async function runBundledModuleWithRegistry(
 				userId: callerContext.user?.userId ?? null,
 				storageContext: normalizedStorageContext,
 			},
-			modules: bundle.modules,
+			modules: refreshKodyRuntimeModules(bundle.modules),
 		})
 		const workflowTools =
 			options?.workflowTools ??

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -112,15 +112,24 @@ async function createTemporaryModuleGraph(files: Record<string, string>) {
 		'utf8',
 	)
 	return {
-		async importModule(modulePath: string) {
+		async importModule(modulePath: string, options?: { cacheBust?: boolean }) {
 			const moduleUrl = pathToFileURL(join(root, modulePath))
-			moduleUrl.searchParams.set('cache', crypto.randomUUID())
+			if (options?.cacheBust ?? true) {
+				moduleUrl.searchParams.set('cache', crypto.randomUUID())
+			}
 			return await import(moduleUrl.href)
 		},
 		async cleanup() {
 			await rm(root, { recursive: true, force: true })
 		},
 	}
+}
+
+type RuntimeModule = {
+	__kodyRunInRuntime: <T>(
+		runtime: Record<string, unknown>,
+		callback: () => Promise<T>,
+	) => Promise<T>
 }
 
 function createSavedPackageRecord(input?: {
@@ -649,6 +658,116 @@ test('buildKodyModuleBundle imports published importable defaults as callable de
 		await moduleGraph.cleanup()
 	}
 })
+
+test.each([
+	{
+		name: 'subscription service start',
+		entryPoint: 'src/handle-email-message-received.ts',
+		source: `import { codemode } from 'kody:runtime'
+
+export default async function handleEmailMessageReceived() {
+	return await codemode.service_start({
+		package_id: 'pkg-1',
+		service_name: 'email-agent-processor',
+	})
+}
+`,
+		codemode: {
+			async service_start(input: unknown) {
+				return { ok: true, tool: 'service_start', input }
+			},
+		},
+		expected: {
+			ok: true,
+			tool: 'service_start',
+			input: {
+				package_id: 'pkg-1',
+				service_name: 'email-agent-processor',
+			},
+		},
+	},
+	{
+		name: 'export secret list',
+		entryPoint: 'src/launch-agent.ts',
+		source: `import { codemode } from 'kody:runtime'
+
+export default async function launchAgent() {
+	return await codemode.secret_list({ scope: 'user' })
+}
+`,
+		codemode: {
+			async secret_list(input: unknown) {
+				return { ok: true, tool: 'secret_list', input }
+			},
+		},
+		expected: {
+			ok: true,
+			tool: 'secret_list',
+			input: { scope: 'user' },
+		},
+	},
+])(
+	'buildKodyModuleBundle keeps codemode available for a preloaded package $name runtime',
+	async ({ entryPoint, source, codemode, expected }) => {
+		mockModule.createWorker.mockImplementation(
+			async (input: { files: Record<string, string>; entryPoint: string }) => ({
+				mainModule: input.entryPoint,
+				modules: input.files,
+				dependencies: [],
+			}),
+		)
+
+		const { buildKodyModuleBundle } = await import('./module-graph.ts')
+		const bundle = await buildKodyModuleBundle({
+			env: {
+				APP_DB: {},
+				REPO_SESSION: {},
+			} as Env,
+			baseUrl: 'https://heykody.dev',
+			userId: 'user-1',
+			sourceFiles: {
+				'package.json': JSON.stringify({
+					name: '@kentcdodds/email-received-subscriber',
+					exports: {
+						'./launch-agent': './src/launch-agent.ts',
+					},
+					kody: {
+						id: 'email-received-subscriber',
+						description: 'Email received subscriber',
+						subscriptions: {
+							'email.message.received': {
+								handler: './src/handle-email-message-received.ts',
+							},
+						},
+					},
+				}),
+				[entryPoint]: source,
+			},
+			entryPoint,
+		})
+
+		const moduleGraph = await createTemporaryModuleGraph(bundle.modules)
+		try {
+			const runtime = (await moduleGraph.importModule(
+				'.__kody_virtual__/runtime.js',
+				{ cacheBust: false },
+			)) as RuntimeModule
+			const result = await runtime.__kodyRunInRuntime(
+				{ codemode },
+				async () => {
+					const entry = (await moduleGraph.importModule(bundle.mainModule, {
+						cacheBust: false,
+					})) as { default: (input?: unknown) => Promise<unknown> }
+					return await entry.default({})
+				},
+			)
+
+			expect(result).toEqual(expected)
+		} finally {
+			await moduleGraph.cleanup()
+		}
+	},
+)
 
 test('buildKodyModuleBundle keeps distinct proxy and artifact paths for exports whose names only differ by punctuation', async () => {
 	mockModule.createWorker.mockResolvedValue(

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -748,6 +748,8 @@ export default async function launchAgent() {
 
 		const moduleGraph = await createTemporaryModuleGraph(bundle.modules)
 		try {
+			// Keep both imports on the same Node ESM cache entry to reproduce a
+			// preloaded runtime module shared with the bundled entry.
 			const runtime = (await moduleGraph.importModule(
 				'.__kody_virtual__/runtime.js',
 				{ cacheBust: false },

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -120,7 +120,7 @@ function createRelativeImportSpecifier(fromPath: string, targetPath: string) {
 	return normalized.replaceAll('\\', '/')
 }
 
-function createRuntimeModuleSource() {
+export function createRuntimeModuleSource() {
 	// The runtime context for a single execute-call / package-app fetch is
 	// kept in AsyncLocalStorage rather than a single mutable globalThis slot.
 	// AsyncLocalStorage propagates through async chains so concurrent calls
@@ -172,16 +172,63 @@ function __kodyReadRuntimeExport(exportName) {
 	return runtimeExport;
 }
 
+function __kodyRuntimeProxyLabel(exportName) {
+	return \`[KodyRuntime:\${exportName}]\`;
+}
+
+function __kodyRuntimeProxyInspectionValue(exportName, property) {
+	if (property === Symbol.toStringTag) return \`KodyRuntime:\${exportName}\`;
+	if (property === 'then') return undefined;
+	if (
+		property === Symbol.iterator ||
+		property === Symbol.asyncIterator
+	) {
+		return undefined;
+	}
+	if (
+		property === Symbol.toPrimitive ||
+		property === Symbol.for('nodejs.util.inspect.custom') ||
+		property === 'inspect' ||
+		property === 'toString'
+	) {
+		return () => __kodyRuntimeProxyLabel(exportName);
+	}
+	if (property === 'valueOf') {
+		return () => __kodyCreateRuntimeObjectProxy(exportName);
+	}
+	return undefined;
+}
+
+function __kodyIsRuntimeProxyInspectionProperty(property) {
+	return (
+		property === Symbol.toStringTag ||
+		property === 'then' ||
+		property === Symbol.iterator ||
+		property === Symbol.asyncIterator ||
+		property === Symbol.toPrimitive ||
+		property === Symbol.for('nodejs.util.inspect.custom') ||
+		property === 'inspect' ||
+		property === 'toString' ||
+		property === 'valueOf'
+	);
+}
+
 function __kodyCreateRuntimeObjectProxy(exportName) {
 	return new Proxy({}, {
 		get(_target, property) {
-			if (property === Symbol.toStringTag) return \`KodyRuntime:\${exportName}\`;
-			if (property === 'then') return undefined;
+			const inspectionValue = __kodyRuntimeProxyInspectionValue(
+				exportName,
+				property,
+			);
+			if (inspectionValue !== undefined || __kodyIsRuntimeProxyInspectionProperty(property)) {
+				return inspectionValue;
+			}
 			const runtimeExport = __kodyReadRuntimeExport(exportName);
 			const value = runtimeExport[property];
 			return typeof value === 'function' ? value.bind(runtimeExport) : value;
 		},
 		has(_target, property) {
+			if (__kodyIsRuntimeProxyInspectionProperty(property)) return false;
 			const currentRuntime = __kodyRuntimeStorage.getStore();
 			const runtimeExport = currentRuntime?.[exportName];
 			return runtimeExport != null && property in runtimeExport;

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -135,20 +135,19 @@ function createRuntimeModuleSource() {
 	// globalThis - the per-request runtime value is held inside the ALS, so
 	// concurrent requests do not stomp on each other's view.
 	//
-	// The exports are evaluated when the module is first imported. Both
-	// the codemode executor and the package-app worker load this bundle
-	// fresh per request (DynamicWorkerExecutor for codemode,
-	// APP_LOADER.load() for package-app), and each wrapper resolves the
-	// same AsyncLocalStorage off the well-known symbol and calls
-	// \`storage.run(runtime, async () => { await import(...) })\` before
-	// any user module - so the store is already populated by the time
-	// the assignments below run. \`__kodyRunInRuntime\` exposes that same
-	// \`storage.run(...)\` for tests and for any future wrapper that wants
-	// to call into the runtime module directly. Capturing the values
-	// statically (rather than via Proxies) preserves the original
-	// semantics of \`import { email } from 'kody:runtime'\`: optional
-	// runtime exports stay falsy when the surrounding wrapper did not
-	// provide them, so \`if (email) { ... }\` guards continue to work.
+	// The exports are evaluated when the module is first imported. The
+	// surrounding wrapper resolves the same AsyncLocalStorage off the
+	// well-known symbol and calls \`storage.run(runtime, async () => {
+	// await import(...) })\`. Optional exports still capture the initial
+	// value so \`if (email) { ... }\` guards stay falsy when a wrapper
+	// intentionally omits that export.
+	//
+	// \`codemode\` is different: every execute/package runtime should provide
+	// it, and Worker module loaders may evaluate this virtual module before
+	// the wrapper installs the per-run store. In that preload case, expose a
+	// late-bound proxy so named imports like \`import { codemode } from
+	// 'kody:runtime'\` still resolve against the current AsyncLocalStorage
+	// store at call time instead of freezing as undefined.
 	return `
 import { AsyncLocalStorage } from 'node:async_hooks';
 
@@ -162,9 +161,41 @@ export function __kodyRunInRuntime(runtime, callback) {
 	return __kodyRuntimeStorage.run(runtime, callback);
 }
 
-const runtime = __kodyRuntimeStorage.getStore() ?? {};
+function __kodyReadRuntimeExport(exportName) {
+	const currentRuntime = __kodyRuntimeStorage.getStore();
+	const runtimeExport = currentRuntime?.[exportName];
+	if (runtimeExport == null) {
+		throw new Error(
+			\`kody:runtime export "\${exportName}" is not available in this execution context.\`,
+		);
+	}
+	return runtimeExport;
+}
 
-export const codemode = runtime.codemode;
+function __kodyCreateRuntimeObjectProxy(exportName) {
+	return new Proxy({}, {
+		get(_target, property) {
+			if (property === Symbol.toStringTag) return \`KodyRuntime:\${exportName}\`;
+			if (property === 'then') return undefined;
+			const runtimeExport = __kodyReadRuntimeExport(exportName);
+			const value = runtimeExport[property];
+			return typeof value === 'function' ? value.bind(runtimeExport) : value;
+		},
+		has(_target, property) {
+			const currentRuntime = __kodyRuntimeStorage.getStore();
+			const runtimeExport = currentRuntime?.[exportName];
+			return runtimeExport != null && property in runtimeExport;
+		},
+	});
+}
+
+const __kodyInitialRuntime = __kodyRuntimeStorage.getStore();
+const runtime = __kodyInitialRuntime ?? {};
+
+export const codemode =
+	__kodyInitialRuntime === undefined
+		? __kodyCreateRuntimeObjectProxy('codemode')
+		: runtime.codemode;
 export const storage = runtime.storage;
 export const refreshAccessToken = runtime.refreshAccessToken;
 export const createAuthenticatedFetch = runtime.createAuthenticatedFetch;

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -211,6 +211,25 @@ export default runtime;
 `.trim()
 }
 
+function isRuntimeModulePath(modulePath: string) {
+	return (
+		modulePath === runtimeModulePath ||
+		modulePath.endsWith(`/${runtimeModulePath}`)
+	)
+}
+
+export function refreshKodyRuntimeModules(
+	modules: WorkerLoaderModules,
+): WorkerLoaderModules {
+	let refreshed: WorkerLoaderModules | null = null
+	for (const modulePath of Object.keys(modules)) {
+		if (!isRuntimeModulePath(modulePath)) continue
+		refreshed ??= { ...modules }
+		refreshed[modulePath] = createRuntimeModuleSource()
+	}
+	return refreshed ?? modules
+}
+
 function createExecuteEntrypointSource(input: { modulePath: string }) {
 	return `
 import userEntrypoint from ${JSON.stringify(input.modulePath)};

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -238,11 +238,12 @@ function __kodyCreateRuntimeObjectProxy(exportName) {
 
 const __kodyInitialRuntime = __kodyRuntimeStorage.getStore();
 const runtime = __kodyInitialRuntime ?? {};
-
-export const codemode =
+const __kodyCodemode =
 	__kodyInitialRuntime === undefined
 		? __kodyCreateRuntimeObjectProxy('codemode')
 		: runtime.codemode;
+
+export const codemode = __kodyCodemode;
 export const storage = runtime.storage;
 export const refreshAccessToken = runtime.refreshAccessToken;
 export const createAuthenticatedFetch = runtime.createAuthenticatedFetch;
@@ -254,7 +255,10 @@ export const email = runtime.email ?? null;
 export const workflows = runtime.workflows ?? null;
 export const packages = runtime.packages ?? null;
 
-export default runtime;
+export default
+	__kodyInitialRuntime === undefined
+		? { ...runtime, codemode: __kodyCodemode }
+		: runtime;
 `.trim()
 }
 

--- a/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
+++ b/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
@@ -29,6 +29,9 @@ type RuntimeModule = {
 	storage: { get: (key: string) => Promise<unknown> } | undefined
 	email: unknown
 	packageContext: Record<string, unknown> | null
+	default: {
+		codemode?: { tool_call: (args: unknown) => Promise<unknown> }
+	}
 }
 
 const cleanupCallbacks: Array<() => Promise<void>> = []
@@ -186,6 +189,35 @@ test('preloaded codemode export resolves from the active runtime store', async (
 	expect(result).toEqual({
 		ok: true,
 		args: { value: 'active-store' },
+	})
+})
+
+test('preloaded default runtime export exposes active codemode store', async () => {
+	const sharedStorage = new AsyncLocalStorage<unknown>()
+	;(globalThis as unknown as Record<symbol, unknown>)[
+		Symbol.for('kody.runtimeStorage')
+	] = sharedStorage
+	const url = await writeRuntimeFile()
+	const mod = (await import(url)) as RuntimeModule
+
+	const result = await sharedStorage.run(
+		{
+			codemode: {
+				async tool_call(args: unknown) {
+					return { ok: true, args }
+				},
+			},
+		},
+		async () => {
+			const tool = mod.default.codemode
+			if (!tool) throw new Error('default codemode missing')
+			return await tool.tool_call({ value: 'default-active-store' })
+		},
+	)
+
+	expect(result).toEqual({
+		ok: true,
+		args: { value: 'default-active-store' },
 	})
 })
 

--- a/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
+++ b/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { pathToFileURL } from 'node:url'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { afterEach, beforeEach, expect, test } from 'vitest'
+import { createRuntimeModuleSource } from './module-graph.ts'
 
 // The kody:runtime virtual module captures its named exports statically
 // when it evaluates inside the surrounding AsyncLocalStorage context. The
@@ -17,59 +18,7 @@ import { afterEach, beforeEach, expect, test } from 'vitest'
 // working, and a preloaded runtime still late-binds the always-present codemode
 // namespace inside the execution context.
 
-const runtimeSource = `
-import { AsyncLocalStorage } from 'node:async_hooks';
-
-const __kodyRuntimeStorageSymbol = Symbol.for('kody.runtimeStorage');
-const __globalAny = globalThis;
-const __kodyRuntimeStorage =
-	__globalAny[__kodyRuntimeStorageSymbol] ??
-	(__globalAny[__kodyRuntimeStorageSymbol] = new AsyncLocalStorage());
-
-export function __kodyRunInRuntime(runtime, callback) {
-	return __kodyRuntimeStorage.run(runtime, callback);
-}
-
-function __kodyReadRuntimeExport(exportName) {
-	const currentRuntime = __kodyRuntimeStorage.getStore();
-	const runtimeExport = currentRuntime?.[exportName];
-	if (runtimeExport == null) {
-		throw new Error(
-			\`kody:runtime export "\${exportName}" is not available in this execution context.\`,
-		);
-	}
-	return runtimeExport;
-}
-
-function __kodyCreateRuntimeObjectProxy(exportName) {
-	return new Proxy({}, {
-		get(_target, property) {
-			if (property === Symbol.toStringTag) return \`KodyRuntime:\${exportName}\`;
-			if (property === 'then') return undefined;
-			const runtimeExport = __kodyReadRuntimeExport(exportName);
-			const value = runtimeExport[property];
-			return typeof value === 'function' ? value.bind(runtimeExport) : value;
-		},
-		has(_target, property) {
-			const currentRuntime = __kodyRuntimeStorage.getStore();
-			const runtimeExport = currentRuntime?.[exportName];
-			return runtimeExport != null && property in runtimeExport;
-		},
-	});
-}
-
-const __kodyInitialRuntime = __kodyRuntimeStorage.getStore();
-const runtime = __kodyInitialRuntime ?? {};
-
-export const codemode =
-	__kodyInitialRuntime === undefined
-		? __kodyCreateRuntimeObjectProxy('codemode')
-		: runtime.codemode;
-export const storage = runtime.storage;
-export const email = runtime.email ?? null;
-export const packageContext = runtime.packageContext ?? null;
-export default runtime;
-`.trim()
+const runtimeSource = createRuntimeModuleSource()
 
 type RuntimeModule = {
 	__kodyRunInRuntime: <T>(
@@ -238,4 +187,18 @@ test('preloaded codemode export resolves from the active runtime store', async (
 		ok: true,
 		args: { value: 'active-store' },
 	})
+})
+
+test('preloaded codemode export supports inspection outside a runtime store', async () => {
+	const url = await writeRuntimeFile()
+	const mod = (await import(url)) as RuntimeModule
+
+	expect(String(mod.codemode)).toBe('[KodyRuntime:codemode]')
+	expect(Object.prototype.toString.call(mod.codemode)).toBe(
+		'[object KodyRuntime:codemode]',
+	)
+	expect(Symbol.iterator in Object(mod.codemode)).toBe(false)
+	expect(() => mod.codemode?.tool_call({})).toThrow(
+		'kody:runtime export "codemode" is not available in this execution context.',
+	)
 })

--- a/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
+++ b/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
@@ -11,11 +11,11 @@ import { afterEach, beforeEach, expect, test } from 'vitest'
 // bundle fresh per request, so each request gets a fresh evaluation with
 // the per-request runtime values.
 //
-// These tests stand up the same shape against the local filesystem: a
-// fresh on-disk copy per "request", evaluated inside __kodyRunInRuntime,
-// to verify that two concurrent calls each capture their own runtime
-// view and that optional (undefined) runtime exports stay falsy so user
-// code's `if (email) { ... }` guards keep working.
+// These tests stand up the same shape against the local filesystem to verify
+// that two concurrent calls each capture their own runtime view, optional
+// runtime exports stay falsy so user code's `if (email) { ... }` guards keep
+// working, and a preloaded runtime still late-binds the always-present codemode
+// namespace inside the execution context.
 
 const runtimeSource = `
 import { AsyncLocalStorage } from 'node:async_hooks';
@@ -30,9 +30,41 @@ export function __kodyRunInRuntime(runtime, callback) {
 	return __kodyRuntimeStorage.run(runtime, callback);
 }
 
-const runtime = __kodyRuntimeStorage.getStore() ?? {};
+function __kodyReadRuntimeExport(exportName) {
+	const currentRuntime = __kodyRuntimeStorage.getStore();
+	const runtimeExport = currentRuntime?.[exportName];
+	if (runtimeExport == null) {
+		throw new Error(
+			\`kody:runtime export "\${exportName}" is not available in this execution context.\`,
+		);
+	}
+	return runtimeExport;
+}
 
-export const codemode = runtime.codemode;
+function __kodyCreateRuntimeObjectProxy(exportName) {
+	return new Proxy({}, {
+		get(_target, property) {
+			if (property === Symbol.toStringTag) return \`KodyRuntime:\${exportName}\`;
+			if (property === 'then') return undefined;
+			const runtimeExport = __kodyReadRuntimeExport(exportName);
+			const value = runtimeExport[property];
+			return typeof value === 'function' ? value.bind(runtimeExport) : value;
+		},
+		has(_target, property) {
+			const currentRuntime = __kodyRuntimeStorage.getStore();
+			const runtimeExport = currentRuntime?.[exportName];
+			return runtimeExport != null && property in runtimeExport;
+		},
+	});
+}
+
+const __kodyInitialRuntime = __kodyRuntimeStorage.getStore();
+const runtime = __kodyInitialRuntime ?? {};
+
+export const codemode =
+	__kodyInitialRuntime === undefined
+		? __kodyCreateRuntimeObjectProxy('codemode')
+		: runtime.codemode;
 export const storage = runtime.storage;
 export const email = runtime.email ?? null;
 export const packageContext = runtime.packageContext ?? null;
@@ -177,4 +209,33 @@ test('optional runtime exports stay falsy when the wrapper omits them', async ()
 	expect(Boolean(mod.storage)).toBe(false)
 	// Provided exports survive.
 	expect(mod.packageContext).toEqual({ packageId: 'pkg-1' })
+})
+
+test('preloaded codemode export resolves from the active runtime store', async () => {
+	const sharedStorage = new AsyncLocalStorage<unknown>()
+	;(globalThis as unknown as Record<symbol, unknown>)[
+		Symbol.for('kody.runtimeStorage')
+	] = sharedStorage
+	const url = await writeRuntimeFile()
+	const mod = (await import(url)) as RuntimeModule
+
+	const result = await sharedStorage.run(
+		{
+			codemode: {
+				async tool_call(args: unknown) {
+					return { ok: true, args }
+				},
+			},
+		},
+		async () => {
+			const tool = mod.codemode
+			if (!tool) throw new Error('codemode missing')
+			return await tool.tool_call({ value: 'active-store' })
+		},
+	)
+
+	expect(result).toEqual({
+		ok: true,
+		args: { value: 'active-store' },
+	})
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes `kody:runtime` so package runtime `codemode` named imports do not freeze as `undefined` if the virtual runtime module is evaluated before the per-run AsyncLocalStorage store is installed.
- Refreshes persisted saved-package bundle runtime modules at execution time, including nested published-package runtime modules, so existing already-published artifacts pick up the host fix without requiring a package republish solely for `codemode` access.
- Adds regression coverage for package subscription-style `codemode.service_start(...)` and package export/default-import-style `codemode.secret_list(...)` handlers under a preloaded runtime module.
- Updates runtime-isolation coverage to use the canonical generated runtime source, document the late-bound `codemode` behavior, and preserve falsy optional exports when a wrapper intentionally omits them.
- Hardens the lazy `codemode` proxy so incidental inspection outside an active runtime store remains benign while actual tool access still fails loudly.

## Root cause
The virtual `kody:runtime` module captured named exports statically at module evaluation. If a package runtime module graph preloaded `.__kody_virtual__/runtime.js` before `runBundledModuleWithRegistry` installed the per-run runtime store, `export const codemode = runtime.codemode` was permanently initialized to `undefined` for that module instance. Later subscription/export handlers then failed on calls like `codemode.service_start(...)` or `codemode.secret_list(...)`. Existing saved package artifacts also persisted their generated virtual runtime source, so the execution path must refresh those runtime modules as well as fixing newly generated bundles.

## Fix
When `kody:runtime` evaluates without an active runtime store, `codemode` now exports a late-bound proxy that resolves the current AsyncLocalStorage store at property access/call time. If the module evaluates inside an active store, existing static capture semantics are preserved. The default runtime export also receives the same late-bound `codemode` proxy in the preload path, so `import runtime from 'kody:runtime'; runtime.codemode...` works consistently with named imports. Optional exports such as `email` remain falsy when the wrapper intentionally omits them.

`runBundledModuleWithRegistry` now replaces every `.__kody_virtual__/runtime.js` module in the bundle (root and nested published package artifacts) with the current host-generated runtime source before handing modules to the executor.

## Tests
- `npx vitest run packages/worker/src/package-runtime/module-graph.node.test.ts -t "preloaded package"` (failed before fix with the production-style `Cannot read properties of undefined` errors; passes after fix)
- `npx vitest run packages/worker/src/mcp/run-codemode-registry.node.test.ts -t "refreshes persisted kody runtime modules"`
- `npx vitest run packages/worker/src/package-runtime/module-graph.node.test.ts packages/worker/src/package-runtime/runtime-isolation.node.test.ts`
- `npx vitest run packages/worker/src/mcp/run-codemode-registry.node.test.ts`
- `npx vitest run packages/worker/src/package-runtime/runtime-isolation.node.test.ts packages/worker/src/package-runtime/module-graph.node.test.ts packages/worker/src/mcp/run-codemode-registry.node.test.ts`
- `npm run validate` locally before review follow-ups: format, lint, typecheck, unit tests, Playwright E2E, MCP E2E all exited 0
- PR CI on final pushed revision: ✅ Validate success, 🔎 Preview success, Cursor Bugbot success, CodeRabbit success

## Production follow-up
After this host/runtime fix deploys, the saved packages should not need source changes or republish solely for `codemode` access because execution refreshes persisted runtime modules. The failed inbound message `5fa11d6f-c20f-4595-9a98-69cbee20a2ba` was already stored but its subscription run failed before queueing/starting the service, so it likely still needs a safe reprocess/retry after deploy if the desired outbound reply should be generated. Do not reprocess before deploy, and avoid any real email/calendar side effects during investigation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1aca6e5-c7d8-4a71-8de3-d22b9ea22413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1aca6e5-c7d8-4a71-8de3-d22b9ea22413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime modules are now refreshed before execution to prevent stale persisted bundles from running.
  * Preloaded runtime bindings now late-bind to the active execution context, improving isolation and predictable behavior.

* **Tests**
  * Added tests validating runtime refresh behavior and correct context-bound resolution of preloaded runtime exports.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/437)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->