### PR TITLE
Invalidate stale package runtime bundles

### DIFF
--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -1,5 +1,5 @@
 import { env } from 'cloudflare:workers'
-import { expect, test, vi } from 'vitest'
+import { expect, test } from 'vitest'
 import {
 	getEmailDomain,
 	getEmailLocalPart,
@@ -17,7 +17,11 @@ import {
 	upsertEmailSenderIdentity,
 } from './repo.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
-import { buildPublishedSourceManifestSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import {
+	buildPublishedBundleArtifactKvKey,
+	buildPublishedSourceManifestSnapshotKvKey,
+} from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { getKodyRuntimeShimRevision } from '#worker/package-runtime/runtime-module.ts'
 
 function createForwardableEmailMessage(input: {
 	from: string
@@ -484,6 +488,7 @@ test('inbound email handler dispatches package subscriptions for stored inbound 
 
 	const subscriptionArtifact = {
 		version: 1,
+		runtimeShimRevision: getKodyRuntimeShimRevision(),
 		kind: 'module',
 		artifactName: 'subscription:email.message.received',
 		sourceId,
@@ -541,7 +546,13 @@ export default async function main(input = {}) {
 		createdAt: now,
 	}
 	const artifactJson = JSON.stringify(subscriptionArtifact)
-	const artifactKey = `bundle-artifact:v1:${sourceId}:commit-1:module:subscription:email.message.received:src/email-message-received.ts`
+	const artifactKey = buildPublishedBundleArtifactKvKey({
+		sourceId,
+		publishedCommit: 'commit-1',
+		kind: 'module',
+		artifactName: 'subscription:email.message.received',
+		entryPoint: 'src/email-message-received.ts',
+	})
 	bundleKv.set(artifactKey, artifactJson)
 	await db
 		.prepare(

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -74,6 +74,7 @@ import {
 	deletePublishedSourceSnapshot,
 	type PublishedBundleArtifact,
 } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { getKodyRuntimeShimRevision } from '#worker/package-runtime/runtime-module.ts'
 import {
 	logJobSchedulerError,
 	logJobSchedulerEvent,
@@ -189,6 +190,7 @@ async function persistPublishedJobBundleArtifact(input: {
 	})
 	const artifact: PublishedBundleArtifact = {
 		version: 1,
+		runtimeShimRevision: getKodyRuntimeShimRevision(),
 		kind: 'job',
 		artifactName: input.artifactName ?? null,
 		sourceId: input.sourceId,

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -16,6 +16,7 @@ const repoMockModule = vi.hoisted(() => ({
 	persistPublishedBundleArtifact: vi.fn(),
 	typecheckPackageEntrypointsFromSourceFiles: vi.fn(),
 	runBundledModuleWithRegistry: vi.fn(),
+	buildKodyModuleBundle: vi.fn(),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -52,6 +53,11 @@ vi.mock('#worker/repo/checks.ts', () => ({
 vi.mock('#mcp/run-codemode-registry.ts', () => ({
 	runBundledModuleWithRegistry: (...args: Array<unknown>) =>
 		repoMockModule.runBundledModuleWithRegistry(...args),
+}))
+
+vi.mock('#worker/package-runtime/module-graph.ts', () => ({
+	buildKodyModuleBundle: (...args: Array<unknown>) =>
+		repoMockModule.buildKodyModuleBundle(...args),
 }))
 
 function createDatabase(options: { failInsert?: boolean } = {}) {
@@ -324,6 +330,14 @@ function seedPackageResolution() {
 	repoMockModule.typecheckPackageEntrypointsFromSourceFiles.mockResolvedValue({
 		ok: true,
 		message: 'ok',
+	})
+	repoMockModule.buildKodyModuleBundle.mockResolvedValue({
+		mainModule: 'dist/rebuilt.js',
+		modules: {
+			'dist/rebuilt.js':
+				'export default async function run(){ return { rebuilt: true } }',
+		},
+		dependencies: [],
 	})
 	repoMockModule.persistPublishedBundleArtifact.mockResolvedValue('kv:key')
 }
@@ -644,6 +658,97 @@ test('invokePackageExport executes a scoped package export successfully', async 
 		(runOptions as { packageInvokeTools?: { invoke?: unknown } })
 			.packageInvokeTools?.invoke,
 	).toEqual(expect.any(Function))
+})
+
+test('invokePackageExport lazily rebuilds when the persisted artifact is invalidated', async () => {
+	const db = createDatabase()
+	seedPackageResolution()
+	repoMockModule.loadPublishedBundleArtifactByIdentity
+		.mockResolvedValueOnce({
+			row: {
+				id: 'artifact-stale-runtime',
+			},
+			artifact: null,
+		})
+		.mockResolvedValueOnce({
+			row: {
+				id: 'artifact-rebuilt-runtime',
+			},
+			artifact: {
+				version: 1,
+				runtimeShimRevision: 'current-runtime',
+				kind: 'module',
+				artifactName: './dispatch-message-created',
+				sourceId: 'source-1',
+				publishedCommit: 'commit-1',
+				entryPoint: 'src/dispatch-message-created.ts',
+				mainModule: 'dist/rebuilt.js',
+				modules: {
+					'dist/rebuilt.js':
+						'export default async function run(){ return { rebuilt: true } }',
+				},
+				dependencies: [],
+				packageContext: {
+					packageId: 'pkg-1',
+					kodyId: 'discord-gateway',
+					sourceId: 'source-1',
+				},
+				serviceContext: null,
+				createdAt: '2026-05-11T00:00:00.000Z',
+			},
+		})
+	repoMockModule.runBundledModuleWithRegistry.mockResolvedValue({
+		result: { rebuilt: true },
+		logs: [],
+	})
+
+	const response = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: {
+			packageIdOrKodyId: 'discord-gateway',
+			exportName: 'dispatch-message-created',
+			params: { content: 'hi' },
+			idempotencyKey: 'evt-stale-runtime',
+			source: 'discord-gateway',
+		},
+	})
+
+	expect(response.status).toBe(200)
+	expect(response.body).toMatchObject({
+		ok: true,
+		result: { rebuilt: true },
+	})
+	expect(
+		repoMockModule.typecheckPackageEntrypointsFromSourceFiles,
+	).toHaveBeenCalled()
+	expect(repoMockModule.buildKodyModuleBundle).toHaveBeenCalledWith({
+		env: expect.anything(),
+		baseUrl: 'https://kody.dev',
+		userId: 'user-123',
+		sourceFiles: expect.objectContaining({
+			'package.json': expect.any(String),
+			'src/dispatch-message-created.ts': expect.any(String),
+		}),
+		entryPoint: 'src/dispatch-message-created.ts',
+	})
+	expect(repoMockModule.persistPublishedBundleArtifact).toHaveBeenCalledWith(
+		expect.objectContaining({
+			kind: 'module',
+			artifactName: './dispatch-message-created',
+			entryPoint: 'src/dispatch-message-created.ts',
+		}),
+	)
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.anything(),
+		expect.objectContaining({
+			mainModule: 'dist/rebuilt.js',
+		}),
+		expect.anything(),
+		expect.anything(),
+	)
 })
 
 test('package runtime can dynamically invoke the current published export from another package', async () => {

--- a/packages/worker/src/package-registry/published-package-cache.ts
+++ b/packages/worker/src/package-registry/published-package-cache.ts
@@ -1,3 +1,5 @@
+import { getKodyRuntimeShimRevision } from '#worker/package-runtime/runtime-module.ts'
+
 type PublishedPackageCacheSource = {
 	id: string
 	published_commit: string | null
@@ -18,6 +20,7 @@ export function createPublishedPackageCacheKey(input: {
 	}
 
 	return JSON.stringify([
+		getKodyRuntimeShimRevision(),
 		input.userId,
 		input.source.id,
 		input.source.published_commit,

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -39,8 +39,17 @@ import {
 	isBarePackageImportSpecifier,
 } from './import-specifiers.ts'
 import { type RuntimeBundle } from './runtime-bundle-types.ts'
+import {
+	createRuntimeModuleSource,
+	getKodyRuntimeShimRevision,
+	runtimeModulePath,
+} from './runtime-module.ts'
+export {
+	createRuntimeModuleSource,
+	getKodyRuntimeShimRevision,
+	refreshKodyRuntimeModules,
+} from './runtime-module.ts'
 
-const runtimeModulePath = '.__kody_virtual__/runtime.js'
 const packageManifestPath = 'package.json'
 const wranglerConfigPaths = ['wrangler.toml', 'wrangler.json', 'wrangler.jsonc']
 const rootSourcePrefix = '.__kody_root__'
@@ -118,167 +127,6 @@ function createRelativeImportSpecifier(fromPath: string, targetPath: string) {
 			? relative
 			: `./${relative}`
 	return normalized.replaceAll('\\', '/')
-}
-
-export function createRuntimeModuleSource() {
-	// The runtime context for a single execute-call / package-app fetch is
-	// kept in AsyncLocalStorage rather than a single mutable globalThis slot.
-	// AsyncLocalStorage propagates through async chains so concurrent calls
-	// in the same isolate cannot clobber each other's runtime view, and the
-	// surrounding wrapper no longer needs a try/finally save/restore dance.
-	//
-	// The AsyncLocalStorage *instance* must be shared between this virtual
-	// runtime module and the surrounding execute / package-app wrapper,
-	// because the wrapper is the one that calls `.run(runtime, cb)` while
-	// user code reads the resulting store via the exports below. We share
-	// the instance through a globalThis symbol; only the *instance* lives on
-	// globalThis - the per-request runtime value is held inside the ALS, so
-	// concurrent requests do not stomp on each other's view.
-	//
-	// The exports are evaluated when the module is first imported. The
-	// surrounding wrapper resolves the same AsyncLocalStorage off the
-	// well-known symbol and calls \`storage.run(runtime, async () => {
-	// await import(...) })\`. Optional exports still capture the initial
-	// value so \`if (email) { ... }\` guards stay falsy when a wrapper
-	// intentionally omits that export.
-	//
-	// \`codemode\` is different: every execute/package runtime should provide
-	// it, and Worker module loaders may evaluate this virtual module before
-	// the wrapper installs the per-run store. In that preload case, expose a
-	// late-bound proxy so named imports like \`import { codemode } from
-	// 'kody:runtime'\` still resolve against the current AsyncLocalStorage
-	// store at call time instead of freezing as undefined.
-	return `
-import { AsyncLocalStorage } from 'node:async_hooks';
-
-const __kodyRuntimeStorageSymbol = Symbol.for('kody.runtimeStorage');
-const __globalAny = /** @type {any} */ (globalThis);
-const __kodyRuntimeStorage =
-	__globalAny[__kodyRuntimeStorageSymbol] ??
-	(__globalAny[__kodyRuntimeStorageSymbol] = new AsyncLocalStorage());
-
-export function __kodyRunInRuntime(runtime, callback) {
-	return __kodyRuntimeStorage.run(runtime, callback);
-}
-
-function __kodyReadRuntimeExport(exportName) {
-	const currentRuntime = __kodyRuntimeStorage.getStore();
-	const runtimeExport = currentRuntime?.[exportName];
-	if (runtimeExport == null) {
-		throw new Error(
-			\`kody:runtime export "\${exportName}" is not available in this execution context.\`,
-		);
-	}
-	return runtimeExport;
-}
-
-function __kodyRuntimeProxyLabel(exportName) {
-	return \`[KodyRuntime:\${exportName}]\`;
-}
-
-function __kodyRuntimeProxyInspectionValue(exportName, property) {
-	if (property === Symbol.toStringTag) return \`KodyRuntime:\${exportName}\`;
-	if (property === 'then') return undefined;
-	if (
-		property === Symbol.iterator ||
-		property === Symbol.asyncIterator
-	) {
-		return undefined;
-	}
-	if (
-		property === Symbol.toPrimitive ||
-		property === Symbol.for('nodejs.util.inspect.custom') ||
-		property === 'inspect' ||
-		property === 'toString'
-	) {
-		return () => __kodyRuntimeProxyLabel(exportName);
-	}
-	if (property === 'valueOf') {
-		return () => __kodyCreateRuntimeObjectProxy(exportName);
-	}
-	return undefined;
-}
-
-function __kodyIsRuntimeProxyInspectionProperty(property) {
-	return (
-		property === Symbol.toStringTag ||
-		property === 'then' ||
-		property === Symbol.iterator ||
-		property === Symbol.asyncIterator ||
-		property === Symbol.toPrimitive ||
-		property === Symbol.for('nodejs.util.inspect.custom') ||
-		property === 'inspect' ||
-		property === 'toString' ||
-		property === 'valueOf'
-	);
-}
-
-function __kodyCreateRuntimeObjectProxy(exportName) {
-	return new Proxy({}, {
-		get(_target, property) {
-			const inspectionValue = __kodyRuntimeProxyInspectionValue(
-				exportName,
-				property,
-			);
-			if (inspectionValue !== undefined || __kodyIsRuntimeProxyInspectionProperty(property)) {
-				return inspectionValue;
-			}
-			const runtimeExport = __kodyReadRuntimeExport(exportName);
-			const value = runtimeExport[property];
-			return typeof value === 'function' ? value.bind(runtimeExport) : value;
-		},
-		has(_target, property) {
-			if (__kodyIsRuntimeProxyInspectionProperty(property)) return false;
-			const currentRuntime = __kodyRuntimeStorage.getStore();
-			const runtimeExport = currentRuntime?.[exportName];
-			return runtimeExport != null && property in runtimeExport;
-		},
-	});
-}
-
-const __kodyInitialRuntime = __kodyRuntimeStorage.getStore();
-const runtime = __kodyInitialRuntime ?? {};
-const __kodyCodemode =
-	__kodyInitialRuntime === undefined
-		? __kodyCreateRuntimeObjectProxy('codemode')
-		: runtime.codemode;
-
-export const codemode = __kodyCodemode;
-export const storage = runtime.storage;
-export const refreshAccessToken = runtime.refreshAccessToken;
-export const createAuthenticatedFetch = runtime.createAuthenticatedFetch;
-export const packageContext = runtime.packageContext ?? null;
-export const serviceContext = runtime.serviceContext ?? null;
-export const service = runtime.service ?? null;
-export const packageSecrets = runtime.packageSecrets ?? null;
-export const email = runtime.email ?? null;
-export const workflows = runtime.workflows ?? null;
-export const packages = runtime.packages ?? null;
-
-export default
-	__kodyInitialRuntime === undefined
-		? { ...runtime, codemode: __kodyCodemode }
-		: runtime;
-`.trim()
-}
-
-function isRuntimeModulePath(modulePath: string) {
-	return (
-		modulePath === runtimeModulePath ||
-		modulePath.endsWith(`/${runtimeModulePath}`)
-	)
-}
-
-export function refreshKodyRuntimeModules(
-	modules: WorkerLoaderModules,
-): WorkerLoaderModules {
-	let refreshed: WorkerLoaderModules | null = null
-	for (const modulePath of Object.keys(modules)) {
-		if (!isRuntimeModulePath(modulePath)) continue
-		refreshed ??= { ...modules }
-		refreshed[modulePath] = createRuntimeModuleSource()
-	}
-	return refreshed ?? modules
 }
 
 function createExecuteEntrypointSource(input: { modulePath: string }) {
@@ -1105,6 +953,7 @@ export function createPublishedBundleArtifact(input: {
 }): PublishedBundleArtifact {
 	return {
 		version: 1,
+		runtimeShimRevision: getKodyRuntimeShimRevision(),
 		kind: input.kind,
 		artifactName: input.artifactName?.trim() || null,
 		sourceId: input.sourceId,

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -488,7 +488,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		const [
 			{ runBundledModuleWithRegistry },
 			{ buildKodyModuleBundle },
-			{ loadPublishedBundleArtifactByIdentity },
+			{ loadPublishedBundleArtifactByIdentity, persistPublishedBundleArtifact },
 			{ createPackageRuntimeInvokeTools },
 		] = await Promise.all([
 			import('#mcp/run-codemode-registry.ts'),
@@ -513,13 +513,26 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 					sourceFiles: runtime.loaded.packageSource.files,
 					bundleLabel: `Saved package service "${binding.serviceName}"`,
 				})
-				return await buildKodyModuleBundle({
+				const built = await buildKodyModuleBundle({
 					env: this.env,
 					baseUrl: binding.baseUrl,
 					userId: binding.userId,
 					sourceFiles: runtime.loaded.packageSource.files,
 					entryPoint: runtime.loaded.serviceEntry,
 				})
+				await persistPublishedBundleArtifact({
+					env: this.env,
+					userId: binding.userId,
+					source: runtime.loaded.packageSource.source,
+					kind: 'service',
+					artifactName: binding.serviceName,
+					entryPoint: runtime.loaded.serviceEntry,
+					mainModule: built.mainModule,
+					modules: built.modules,
+					dependencies: built.dependencies,
+					packageContext: runtime.packageContext,
+				})
+				return built
 			})())
 		const callerContext = createMcpCallerContext({
 			baseUrl: binding.baseUrl,

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.ts
@@ -17,6 +17,7 @@ import {
 	readPublishedBundleArtifact,
 	writePublishedBundleArtifact,
 } from './published-runtime-artifacts.ts'
+import { getKodyRuntimeShimRevision } from './runtime-module.ts'
 import {
 	deletePublishedBundleArtifactRowsBySourceId,
 	getPublishedBundleArtifactByIdentity,
@@ -98,6 +99,7 @@ export async function persistPublishedBundleArtifact(
 	})
 	const artifact: PublishedBundleArtifact = {
 		version: 1,
+		runtimeShimRevision: getKodyRuntimeShimRevision(),
 		kind: input.kind,
 		artifactName,
 		sourceId: input.source.id,

--- a/packages/worker/src/package-runtime/published-runtime-artifacts.node.test.ts
+++ b/packages/worker/src/package-runtime/published-runtime-artifacts.node.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from 'vitest'
+import {
+	buildPublishedBundleArtifactKvKey,
+	readPublishedBundleArtifact,
+	writePublishedBundleArtifact,
+	type PublishedBundleArtifact,
+} from './published-runtime-artifacts.ts'
+import { getKodyRuntimeShimRevision } from './runtime-module.ts'
+
+function createMemoryKv(initial: Record<string, string> = {}) {
+	const values = new Map(Object.entries(initial))
+	return {
+		values,
+		kv: {
+			async get(key: string, type?: 'json') {
+				const value = values.get(key) ?? null
+				if (type === 'json') {
+					return value == null ? null : JSON.parse(value)
+				}
+				return value
+			},
+			async put(key: string, value: string) {
+				values.set(key, value)
+			},
+			async delete(key: string) {
+				values.delete(key)
+			},
+		} as unknown as KVNamespace,
+	}
+}
+
+function createArtifact(
+	overrides: Partial<PublishedBundleArtifact> = {},
+): PublishedBundleArtifact {
+	return {
+		version: 1,
+		runtimeShimRevision: getKodyRuntimeShimRevision(),
+		kind: 'module',
+		artifactName: '.',
+		sourceId: 'source-1',
+		publishedCommit: 'commit-1',
+		entryPoint: 'src/index.ts',
+		mainModule: 'dist/index.js',
+		modules: {
+			'dist/index.js':
+				'import { codemode } from "../.__kody_virtual__/runtime.js"; export default async function run() { return codemode.secret_list({}) }',
+			'.__kody_virtual__/runtime.js': 'export const codemode = undefined;',
+		},
+		dependencies: [],
+		packageContext: null,
+		serviceContext: null,
+		createdAt: '2026-05-11T00:00:00.000Z',
+		...overrides,
+	}
+}
+
+test('published bundle artifact keys include the host runtime shim revision', () => {
+	const key = buildPublishedBundleArtifactKvKey({
+		sourceId: 'source-1',
+		publishedCommit: 'commit-1',
+		kind: 'module',
+		artifactName: '.',
+		entryPoint: 'src/index.ts',
+	})
+
+	expect(key).toBe(
+		`bundle-artifact:v1:${getKodyRuntimeShimRevision()}:source-1:commit-1:module:.:src/index.ts`,
+	)
+})
+
+test('readPublishedBundleArtifact treats stale runtime shim artifacts as cache misses', async () => {
+	const staleArtifact = createArtifact({
+		runtimeShimRevision: 'abi1-stale-runtime',
+	})
+	const { kv } = createMemoryKv({
+		'kv:stale': JSON.stringify(staleArtifact),
+	})
+
+	const artifact = await readPublishedBundleArtifact({
+		env: { BUNDLE_ARTIFACTS_KV: kv } as Env,
+		kvKey: 'kv:stale',
+	})
+
+	expect(artifact).toBeNull()
+})
+
+test('writePublishedBundleArtifact stamps the current runtime shim revision', async () => {
+	const { kv, values } = createMemoryKv()
+
+	await writePublishedBundleArtifact({
+		env: { BUNDLE_ARTIFACTS_KV: kv } as Env,
+		kvKey: 'kv:current',
+		artifact: createArtifact({
+			runtimeShimRevision: 'abi1-old-runtime',
+		}),
+	})
+	const stored = JSON.parse(values.get('kv:current') ?? '{}') as {
+		runtimeShimRevision?: string
+	}
+
+	expect(stored.runtimeShimRevision).toBe(getKodyRuntimeShimRevision())
+	await expect(
+		readPublishedBundleArtifact({
+			env: { BUNDLE_ARTIFACTS_KV: kv } as Env,
+			kvKey: 'kv:current',
+		}),
+	).resolves.toMatchObject({
+		runtimeShimRevision: getKodyRuntimeShimRevision(),
+		mainModule: 'dist/index.js',
+	})
+})

--- a/packages/worker/src/package-runtime/published-runtime-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-runtime-artifacts.ts
@@ -1,5 +1,6 @@
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
+import { getKodyRuntimeShimRevision } from './runtime-module.ts'
 
 const sourceSnapshotVersion = 1
 const sourceManifestSnapshotVersion = 1
@@ -56,6 +57,7 @@ export type PublishedSourceManifestSnapshot = {
 
 export type PublishedBundleArtifact = {
 	version: typeof bundleArtifactVersion
+	runtimeShimRevision: string
 	kind: BundleArtifactKind
 	artifactName: string | null
 	sourceId: string
@@ -192,6 +194,7 @@ export function buildPublishedBundleArtifactKvKey(input: {
 	return [
 		bundleArtifactPrefix,
 		`v${bundleArtifactVersion}`,
+		getKodyRuntimeShimRevision(),
 		input.sourceId,
 		input.publishedCommit,
 		input.kind,
@@ -412,6 +415,7 @@ export async function writePublishedBundleArtifact(input: {
 		kvKey,
 		JSON.stringify({
 			...input.artifact,
+			runtimeShimRevision: getKodyRuntimeShimRevision(),
 			modules: serializeWorkerLoaderModules(input.artifact.modules),
 		}),
 	)
@@ -427,6 +431,7 @@ export async function readPublishedBundleArtifact(input: {
 	const artifact = stored as StoredPublishedBundleArtifact
 	if (
 		artifact.version !== bundleArtifactVersion ||
+		artifact.runtimeShimRevision !== getKodyRuntimeShimRevision() ||
 		typeof artifact.modules !== 'object' ||
 		artifact.modules == null
 	) {

--- a/packages/worker/src/package-runtime/runtime-module.ts
+++ b/packages/worker/src/package-runtime/runtime-module.ts
@@ -1,0 +1,180 @@
+import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
+
+export const runtimeModulePath = '.__kody_virtual__/runtime.js'
+// Bump this when package bundle execution semantics change in a way that is
+// not reflected by createRuntimeModuleSource(), such as loader ABI changes.
+const runtimeArtifactAbiVersion = 1
+
+export function createRuntimeModuleSource() {
+	// The runtime context for a single execute-call / package-app fetch is
+	// kept in AsyncLocalStorage rather than a single mutable globalThis slot.
+	// AsyncLocalStorage propagates through async chains so concurrent calls
+	// in the same isolate cannot clobber each other's runtime view, and the
+	// surrounding wrapper no longer needs a try/finally save/restore dance.
+	//
+	// The AsyncLocalStorage *instance* must be shared between this virtual
+	// runtime module and the surrounding execute / package-app wrapper,
+	// because the wrapper is the one that calls `.run(runtime, cb)` while
+	// user code reads the resulting store via the exports below. We share
+	// the instance through a globalThis symbol; only the *instance* lives on
+	// globalThis - the per-request runtime value is held inside the ALS, so
+	// concurrent requests do not stomp on each other's view.
+	//
+	// The exports are evaluated when the module is first imported. The
+	// surrounding wrapper resolves the same AsyncLocalStorage off the
+	// well-known symbol and calls `storage.run(runtime, async () => {
+	// await import(...) })`. Optional exports still capture the initial
+	// value so `if (email) { ... }` guards stay falsy when a wrapper
+	// intentionally omits that export.
+	//
+	// `codemode` is different: every execute/package runtime should provide
+	// it, and Worker module loaders may evaluate this virtual module before
+	// the wrapper installs the per-run store. In that preload case, expose a
+	// late-bound proxy so named imports like `import { codemode } from
+	// 'kody:runtime'` still resolve against the current AsyncLocalStorage
+	// store at call time instead of freezing as undefined.
+	return `
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const __kodyRuntimeStorageSymbol = Symbol.for('kody.runtimeStorage');
+const __globalAny = /** @type {any} */ (globalThis);
+const __kodyRuntimeStorage =
+	__globalAny[__kodyRuntimeStorageSymbol] ??
+	(__globalAny[__kodyRuntimeStorageSymbol] = new AsyncLocalStorage());
+
+export function __kodyRunInRuntime(runtime, callback) {
+	return __kodyRuntimeStorage.run(runtime, callback);
+}
+
+function __kodyReadRuntimeExport(exportName) {
+	const currentRuntime = __kodyRuntimeStorage.getStore();
+	const runtimeExport = currentRuntime?.[exportName];
+	if (runtimeExport == null) {
+		throw new Error(
+			\`kody:runtime export "\${exportName}" is not available in this execution context.\`,
+		);
+	}
+	return runtimeExport;
+}
+
+function __kodyRuntimeProxyLabel(exportName) {
+	return \`[KodyRuntime:\${exportName}]\`;
+}
+
+function __kodyRuntimeProxyInspectionValue(exportName, property) {
+	if (property === Symbol.toStringTag) return \`KodyRuntime:\${exportName}\`;
+	if (property === 'then') return undefined;
+	if (
+		property === Symbol.iterator ||
+		property === Symbol.asyncIterator
+	) {
+		return undefined;
+	}
+	if (
+		property === Symbol.toPrimitive ||
+		property === Symbol.for('nodejs.util.inspect.custom') ||
+		property === 'inspect' ||
+		property === 'toString'
+	) {
+		return () => __kodyRuntimeProxyLabel(exportName);
+	}
+	if (property === 'valueOf') {
+		return () => __kodyCreateRuntimeObjectProxy(exportName);
+	}
+	return undefined;
+}
+
+function __kodyIsRuntimeProxyInspectionProperty(property) {
+	return (
+		property === Symbol.toStringTag ||
+		property === 'then' ||
+		property === Symbol.iterator ||
+		property === Symbol.asyncIterator ||
+		property === Symbol.toPrimitive ||
+		property === Symbol.for('nodejs.util.inspect.custom') ||
+		property === 'inspect' ||
+		property === 'toString' ||
+		property === 'valueOf'
+	);
+}
+
+function __kodyCreateRuntimeObjectProxy(exportName) {
+	return new Proxy({}, {
+		get(_target, property) {
+			const inspectionValue = __kodyRuntimeProxyInspectionValue(
+				exportName,
+				property,
+			);
+			if (inspectionValue !== undefined || __kodyIsRuntimeProxyInspectionProperty(property)) {
+				return inspectionValue;
+			}
+			const runtimeExport = __kodyReadRuntimeExport(exportName);
+			const value = runtimeExport[property];
+			return typeof value === 'function' ? value.bind(runtimeExport) : value;
+		},
+		has(_target, property) {
+			if (__kodyIsRuntimeProxyInspectionProperty(property)) return false;
+			const currentRuntime = __kodyRuntimeStorage.getStore();
+			const runtimeExport = currentRuntime?.[exportName];
+			return runtimeExport != null && property in runtimeExport;
+		},
+	});
+}
+
+const __kodyInitialRuntime = __kodyRuntimeStorage.getStore();
+const runtime = __kodyInitialRuntime ?? {};
+const __kodyCodemode =
+	__kodyInitialRuntime === undefined
+		? __kodyCreateRuntimeObjectProxy('codemode')
+		: runtime.codemode;
+
+export const codemode = __kodyCodemode;
+export const storage = runtime.storage;
+export const refreshAccessToken = runtime.refreshAccessToken;
+export const createAuthenticatedFetch = runtime.createAuthenticatedFetch;
+export const packageContext = runtime.packageContext ?? null;
+export const serviceContext = runtime.serviceContext ?? null;
+export const service = runtime.service ?? null;
+export const packageSecrets = runtime.packageSecrets ?? null;
+export const email = runtime.email ?? null;
+export const workflows = runtime.workflows ?? null;
+export const packages = runtime.packages ?? null;
+
+export default
+	__kodyInitialRuntime === undefined
+		? { ...runtime, codemode: __kodyCodemode }
+		: runtime;
+`.trim()
+}
+
+function fnv1a32(input: string) {
+	let hash = 2166136261
+	for (let index = 0; index < input.length; index += 1) {
+		hash ^= input.charCodeAt(index)
+		hash = Math.imul(hash, 16777619)
+	}
+	return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+export function getKodyRuntimeShimRevision() {
+	return `abi${runtimeArtifactAbiVersion}-${fnv1a32(createRuntimeModuleSource())}`
+}
+
+function isRuntimeModulePath(modulePath: string) {
+	return (
+		modulePath === runtimeModulePath ||
+		modulePath.endsWith(`/${runtimeModulePath}`)
+	)
+}
+
+export function refreshKodyRuntimeModules(
+	modules: WorkerLoaderModules,
+): WorkerLoaderModules {
+	let refreshed: WorkerLoaderModules | null = null
+	for (const modulePath of Object.keys(modules)) {
+		if (!isRuntimeModulePath(modulePath)) continue
+		refreshed ??= { ...modules }
+		refreshed[modulePath] = createRuntimeModuleSource()
+	}
+	return refreshed ?? modules
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Diagnoses and fixes the saved-package stale runtime-bundle failure mode where published package artifacts could keep an old inlined `kody:runtime` virtual module after a host/runtime deploy.

Root cause:
- Saved package publish stores prebuilt bundle artifacts in KV/D1 keyed mostly by source commit and surface identity.
- `kody:runtime` is a virtual module rewritten into those bundle artifacts at build time.
- A host deploy that changes the virtual runtime shim does not change a package source commit, so existing artifact rows remained valid cache hits and continued executing stale inlined runtime code.

Chosen strategy:
- Move runtime virtual module generation into `package-runtime/runtime-module.ts` and derive a deterministic runtime shim revision from that exact source.
- Stamp persisted bundle artifacts with `runtimeShimRevision` and include the revision in new bundle KV keys and package app in-process/KV cache keys.
- Treat artifacts with a missing/mismatched runtime shim revision as cache misses, so export/subscription/job/service/app paths lazily rebuild using the current host runtime without requiring no-op package commits.
- Keep the existing execution-time `kody:runtime` module refresh as an extra safety net for already-loaded module maps.
- Persist rebuilt service bundles on cache miss so services do not repeatedly rebuild after invalidation.

Alternatives considered:
- Bulk republish/no-op source commits: fragile, operationally expensive, and already hit a Durable Object memory reset on a larger package.
- Only refreshing modules at execution: helps module executions but leaves artifacts looking current and does not cover all surfaces cleanly.
- Full deploy-time rebuild: creates risky deploy coupling and concentrates large-package memory pressure during rollout.
- Manual version bump only: works, but easy to forget; this uses a source-derived revision plus an ABI escape hatch for non-source loader semantics.

Large package / memory note:
- This change removes the need for bulk republish for host-runtime-only changes. It does not rewrite the external publish pipeline memory profile for package source/dependency changes; if large package publish still resets isolates, that should be handled separately with chunked/streamed build/persist or out-of-DO rebuild tooling.

Manual migration/backfill:
- No manual backfill is required. Existing artifacts without `runtimeShimRevision` become cache misses and rebuild lazily on the next invocation/start/app load.

## Tests

- `npm exec vitest -- --config vitest.node.config.ts packages/worker/src/package-runtime/published-runtime-artifacts.node.test.ts packages/worker/src/package-invocations/service.node.test.ts packages/worker/src/mcp/run-codemode-registry.node.test.ts packages/worker/src/package-runtime/runtime-isolation.node.test.ts`
- `npm exec vitest -- --config vitest.workers.config.ts packages/worker/src/email/inbound.workers.test.ts`
- `npm run typecheck`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36077211-64b7-4328-86d7-55b34ec91082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36077211-64b7-4328-86d7-55b34ec91082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime artifact validation to detect and handle stale cached bundles, ensuring correct runtime versions are used during execution.

* **Tests**
  * Added comprehensive test coverage for runtime artifact caching and invalidation behavior.

* **Refactor**
  * Reorganized runtime module utilities and consolidated artifact versioning logic for better maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/438)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->