### PR TITLE
Externalize kody runtime for package artifacts

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -122,6 +122,15 @@ implementations, and
 `packages/worker/src/package-runtime/runtime-isolation.node.test.ts` for the
 concurrent two-runtime test that pins this invariant.
 
+`kody:runtime` is also a host-external package-runtime module. Saved package
+bundle artifacts reserve `.__kody_virtual__/runtime.js` import paths but strip
+the runtime source before persistence. Execution loaders hydrate those paths
+with the currently deployed host runtime source for every package surface
+(exports, subscriptions, jobs, services, package apps, workflows, and ad hoc
+execute). Static `kody:@...` package imports remain pinned snapshots, while
+literal dynamic `import("kody:@...")` imports are hydrated at execution time
+from the current published package export under the caller's `userId`.
+
 ## Configuration reference
 
 Bindings are configured per environment in `packages/worker/wrangler.jsonc`

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -74,14 +74,31 @@ The top-level saved identity is the package.
   publish-time artifact rebuilds, Kody records the imported saved package's
   published commit in bundle dependency metadata. A later publish of that
   imported package does not rewrite already-published dependent bundles.
+- Literal dynamic imports such as `await import("kody:@scope/pkg/export")` are
+  runtime/current package dependencies. Bundle artifacts persist only a
+  host-resolved placeholder plus review metadata; just before execution, Kody
+  resolves the target package under the caller's `userId` and hydrates the
+  current published `importable-module` artifact into the dynamic worker module
+  graph.
 - Direct static `kody:@...` imports are a breaking manifest contract: they must
   be listed in `package.json#kody.dependencies` by package name, for example
   `"dependencies": ["@scope/my-package"]` inside the `kody` object. Repo checks
   fail when a static import is missing from the list or when the list contains a
   package that is not statically imported. Type-only imports do not count, and
   declaration files such as `.d.ts` are treated as type-only. Literal dynamic
-  `import("kody:@...")` expressions are bundled snapshots too, so they must be
-  declared.
+  `import("kody:@...")` expressions are not static dependency declarations.
+- Computed dynamic Kody package imports are intentionally unsupported. The
+  bundler rewrites non-literal `import(...)` expressions with a guard that
+  throws clearly when the runtime specifier starts with `kody:@`; do not add
+  arbitrary computed package resolution until the security and review model is
+  designed.
+- `kody:runtime` is a reserved host-external virtual module. The bundler may add
+  a placeholder so author code can keep
+  `import { codemode } from "kody:runtime"`, but published bundle artifacts must
+  not persist the host runtime implementation. Execution loaders hydrate the
+  currently deployed host runtime module into every referenced
+  `.__kody_virtual__/runtime.js` path, including nested static dependency
+  artifacts and package-app workers.
 - Callable exports are resolved from package exports, not from a second Kody
   registry.
 - Packages may also export non-callable helper modules and values for reuse.

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -50,7 +50,23 @@ helpers are runtime exports:
   package-service timeout
 - use **`import thing from 'kody:@scope/my-package/export-name'`** or
   **`import { helper } from 'kody:@scope/my-package/export-name'`** to reuse a
-  saved package export by full package name
+  saved package export by full package name. Static `kody:@...` imports are
+  pinned to the dependency's published artifact when the caller is bundled.
+
+`kody:runtime` is always supplied by the Kody host at execution time. Saved
+package artifacts do not contain a copy of the host runtime implementation, so
+old package artifacts automatically observe current host runtime behavior.
+
+Use literal dynamic imports when package code needs the current published
+version of another saved package export:
+
+```ts
+const helper = await import('kody:@scope/my-package/export-name')
+```
+
+Kody resolves that literal import at runtime for the signed-in user. Computed
+dynamic Kody package imports, including variables and template strings, are not
+supported yet.
 
 **execute** also accepts optional **`params`**. Kody passes that JSON object to
 the module's **default export** as the first function argument. Shared helpers

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -78,13 +78,26 @@ exhaustive.
   runtime artifacts as snapshots of the imported package's then-published
   bundle. If the imported package is published again later, already-published
   dependents keep using the older bundled snapshot until they are republished.
+- Literal dynamic imports such as
+  `await import("kody:@scope/my-package/export")` are current-version package
+  dependencies. Kody leaves them out of the saved bundle and resolves the target
+  package export at runtime for the signed-in user, so the next execution sees
+  the target package's current published importable artifact.
 - Every direct static `kody:@...` import must be declared in
   `package.json#kody.dependencies` using the imported package name, for example
   `"dependencies": ["@scope/my-package"]` inside the `kody` object. Package
   checks fail when static imports and declarations differ. Type-only imports do
-  not count, and declaration files such as `.d.ts` are treated as type-only;
-  literal dynamic `import("kody:@...")` expressions are bundled and must be
-  declared.
+  not count, declaration files such as `.d.ts` are treated as type-only, and
+  current-version literal dynamic `import("kody:@...")` expressions do not need
+  `kody.dependencies` declarations.
+- Computed dynamic Kody package imports, including template strings and
+  variables such as `import(packageSpecifier)`, are unsupported for now. Use a
+  string literal `import("kody:@scope/my-package/export")` when you want
+  current-version runtime resolution.
+- `kody:runtime` is always host-owned and request-scoped. Static imports such as
+  `import { codemode } from "kody:runtime"` stay valid, but saved package
+  artifacts do not persist Kody's runtime implementation; execution always uses
+  the currently deployed host runtime.
 - Exports are normal modules. They may expose a default export, named exports,
   or both.
 - Direct package invocation calls the resolved module's default export when that

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -197,6 +197,7 @@ async function persistPublishedJobBundleArtifact(input: {
 		mainModule: bundle.mainModule,
 		modules: bundle.modules,
 		dependencies: bundle.dependencies,
+		dynamicDependencies: bundle.dynamicDependencies ?? [],
 		packageContext: input.packageContext ?? null,
 		serviceContext: null,
 		createdAt: new Date().toISOString(),
@@ -211,6 +212,7 @@ async function persistPublishedJobBundleArtifact(input: {
 		mainModule: bundle.mainModule,
 		modules: bundle.modules,
 		dependencies: bundle.dependencies,
+		dynamicDependencies: bundle.dynamicDependencies,
 		packageContext: input.packageContext ?? null,
 	})
 	logJobSchedulerEvent({
@@ -482,7 +484,9 @@ async function executePublishedJobArtifact(input: {
 	env: Env
 	job: JobRecord
 	callerContext: PersistedJobCallerContext
-	artifact: Awaited<ReturnType<typeof ensurePublishedBundleArtifactForJob>>
+	artifact:
+		| PublishedBundleArtifact
+		| Awaited<ReturnType<typeof ensurePublishedBundleArtifactForJob>>
 	bypassLogs: Array<string>
 }): Promise<ExecuteResult> {
 	const source = await getEntitySourceById(input.env.APP_DB, input.job.sourceId)

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -35,7 +35,7 @@ import {
 } from '#worker/module-source.ts'
 import {
 	buildKodyModuleBundle,
-	refreshKodyRuntimeModules,
+	hydrateKodyRuntimeModules,
 } from '#worker/package-runtime/module-graph.ts'
 import {
 	beginPackageRuntimeRun,
@@ -814,7 +814,12 @@ export async function runBundledModuleWithRegistry(
 				userId: callerContext.user?.userId ?? null,
 				storageContext: normalizedStorageContext,
 			},
-			modules: refreshKodyRuntimeModules(bundle.modules),
+			modules: await hydrateKodyRuntimeModules({
+				env,
+				baseUrl: callerContext.baseUrl,
+				userId: callerContext.user?.userId ?? '',
+				modules: bundle.modules,
+			}),
 		})
 		const workflowTools =
 			options?.workflowTools ??

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -647,6 +647,7 @@ async function ensureModuleArtifact(input: {
 		mainModule: bundle.mainModule,
 		modules: bundle.modules,
 		dependencies: bundle.dependencies,
+		dynamicDependencies: bundle.dynamicDependencies,
 		packageContext: {
 			packageId: input.savedPackage.id,
 			kodyId: input.savedPackage.kodyId,

--- a/packages/worker/src/package-runtime/import-specifiers.ts
+++ b/packages/worker/src/package-runtime/import-specifiers.ts
@@ -4,6 +4,15 @@ export type LiteralImportNode = {
 	start: number
 	end: number
 	specifier: string
+	kind: 'dynamic' | 'static'
+}
+
+export type DynamicImportExpressionNode = {
+	start: number
+	end: number
+	sourceStart: number
+	sourceEnd: number
+	literalSpecifier: string | null
 }
 
 function readLiteralStringNode(
@@ -88,13 +97,13 @@ export function collectLiteralImportNodes(
 			}
 			const literalNode = readLiteralStringNode(typedNode.source)
 			if (literalNode) {
-				nodes.push(literalNode)
+				nodes.push({ ...literalNode, kind: 'static' })
 			}
 		}
 		if (typedNode.type === 'ImportExpression') {
 			const literalNode = readLiteralStringNode(typedNode.source)
 			if (literalNode) {
-				nodes.push(literalNode)
+				nodes.push({ ...literalNode, kind: 'dynamic' })
 			}
 		}
 		for (const value of Object.values(
@@ -119,6 +128,61 @@ export function collectLiteralImportNodes(
 
 export function collectLiteralImportSpecifiers(source: string): Array<string> {
 	return collectLiteralImportNodes(source).map((node) => node.specifier)
+}
+
+export function collectDynamicImportExpressionNodes(
+	source: string,
+): Array<DynamicImportExpressionNode> {
+	const nodes: Array<DynamicImportExpressionNode> = []
+
+	function visit(node: unknown): void {
+		if (node == null || typeof node !== 'object') return
+		if (Array.isArray(node)) {
+			for (const item of node) visit(item)
+			return
+		}
+		if (!('type' in node)) return
+		const typedNode = node as ModuleAstNode & {
+			start?: number
+			end?: number
+			source?: { start?: number; end?: number }
+		}
+		if (typedNode.type === 'ImportExpression') {
+			const sourceNode = typedNode.source
+			if (
+				typeof typedNode.start === 'number' &&
+				typeof typedNode.end === 'number' &&
+				typeof sourceNode?.start === 'number' &&
+				typeof sourceNode.end === 'number'
+			) {
+				nodes.push({
+					start: typedNode.start,
+					end: typedNode.end,
+					sourceStart: sourceNode.start,
+					sourceEnd: sourceNode.end,
+					literalSpecifier:
+						readLiteralStringNode(sourceNode)?.specifier ?? null,
+				})
+			}
+		}
+		for (const value of Object.values(
+			typedNode as unknown as Record<string, unknown>,
+		)) {
+			if (value == null) continue
+			if (typeof value === 'object') {
+				visit(value)
+			}
+		}
+	}
+
+	try {
+		const program = parseModuleSource(source)
+		visit(program)
+	} catch {
+		return []
+	}
+
+	return nodes.sort((left, right) => left.start - right.start)
 }
 
 export function isBarePackageImportSpecifier(specifier: string) {

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -1058,7 +1058,39 @@ throw new Error('unhydrated ${specifier}');
 	).toEqual(currentArtifactModulePaths)
 	expect(
 		mockModule.loadPublishedBundleArtifactByIdentity,
-	).toHaveBeenCalledTimes(3)
+	).toHaveBeenCalledTimes(2)
+})
+
+test('buildKodyModuleBundle rejects nested dynamic kody package import rewrites clearly', async () => {
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+
+	await expect(
+		buildKodyModuleBundle({
+			env: {
+				APP_DB: {},
+				REPO_SESSION: {},
+			} as Env,
+			baseUrl: 'https://heykody.dev',
+			userId: 'user-1',
+			sourceFiles: {
+				'package.json': JSON.stringify({
+					name: '@kentcdodds/local-package',
+					exports: {
+						'.': './index.js',
+					},
+					kody: {
+						id: 'local-package',
+						description: 'Local package',
+					},
+				}),
+				'index.js': `export default async function run() {
+	return await import(String(await import('kody:@kentcdodds/example-package/value')))
+}
+`,
+			},
+			entryPoint: 'index.js',
+		}),
+	).rejects.toThrow('Nested dynamic import expressions involving Kody package')
 })
 
 test.each([

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -41,8 +41,11 @@ vi.mock('./published-bundle-artifacts.ts', async () => {
 	}
 })
 
-const { buildKodyAppBundle, createPublishedPackageAppBundleCacheKey } =
-	await import('./module-graph.ts')
+const {
+	buildKodyAppBundle,
+	createPublishedPackageAppBundleCacheKey,
+	hydrateKodyRuntimeModules,
+} = await import('./module-graph.ts')
 
 // eslint-disable-next-line epic-web/prefer-dispose-in-tests -- this legacy suite resets shared hoisted mocks between tests.
 beforeEach(() => {
@@ -659,6 +662,239 @@ test('buildKodyModuleBundle imports published importable defaults as callable de
 	}
 })
 
+test('hydrateKodyRuntimeModules replaces stale persisted kody runtime modules', async () => {
+	const staleRuntimeSource =
+		'export const codemode = { stale: true }; export default { codemode };'
+	const hydratedModules = await hydrateKodyRuntimeModules({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		modules: {
+			'.__kody_virtual__/runtime.js': staleRuntimeSource,
+			'entry.js': `import { __kodyRunInRuntime, codemode } from './.__kody_virtual__/runtime.js'
+
+export async function runWithRuntime(runtime) {
+	return await __kodyRunInRuntime(runtime, async () => codemode.hostRuntimeVersion({}))
+}
+`,
+		},
+	})
+
+	expect(hydratedModules['.__kody_virtual__/runtime.js']).not.toBe(
+		staleRuntimeSource,
+	)
+	const moduleGraph = await createTemporaryModuleGraph(hydratedModules)
+	try {
+		const entry = (await moduleGraph.importModule('entry.js')) as {
+			runWithRuntime: (runtime: Record<string, unknown>) => Promise<unknown>
+		}
+		const result = await entry.runWithRuntime({
+			codemode: {
+				async hostRuntimeVersion() {
+					return 'current-host-runtime'
+				},
+			},
+		})
+		expect(result).toBe('current-host-runtime')
+	} finally {
+		await moduleGraph.cleanup()
+	}
+})
+
+test('buildKodyModuleBundle keeps static imports pinned while literal dynamic imports resolve current packages', async () => {
+	mockModule.createWorker.mockImplementation(
+		async (input: { files: Record<string, string>; entryPoint: string }) => ({
+			mainModule: input.entryPoint,
+			modules: input.files,
+			dependencies: [],
+		}),
+	)
+	mockModule.getSavedPackageByName.mockResolvedValue(createSavedPackageRecord())
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		...createLoadedPackageSource(),
+		manifest: {
+			...createLoadedPackageSource().manifest,
+			exports: {
+				'./value': './value.js',
+			},
+		},
+		files: {
+			'value.js': 'export default function value() { return "source" }',
+		},
+	})
+	let packageVersion = 'pinned'
+	mockModule.loadPublishedBundleArtifactByIdentity.mockImplementation(
+		async (input: { userId: string; kind: string; artifactName?: string }) => {
+			if (input.kind !== 'importable-module') return null
+			return {
+				row: {},
+				artifact: {
+					version: 1,
+					kind: 'importable-module',
+					artifactName: input.artifactName ?? './value',
+					sourceId: 'source-1',
+					publishedCommit:
+						packageVersion === 'pinned' ? 'commit-pinned' : 'commit-current',
+					entryPoint: './value.js',
+					mainModule: 'value.js',
+					modules: {
+						'value.js': `export const marker = ${JSON.stringify(packageVersion)}
+export default function value() { return ${JSON.stringify(packageVersion)} }`,
+					},
+					dependencies: [],
+					dynamicDependencies: [],
+					packageContext: null,
+					serviceContext: null,
+					createdAt: '2026-05-11T00:00:00.000Z',
+				},
+			}
+		},
+	)
+
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+	const bundle = await buildKodyModuleBundle({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/local-package',
+				exports: {
+					'.': './index.js',
+				},
+				kody: {
+					id: 'local-package',
+					description: 'Local package',
+					dependencies: ['@kentcdodds/example-package'],
+				},
+			}),
+			'index.js': `import staticValue from 'kody:@kentcdodds/example-package/value'
+
+export default async function run() {
+	const dynamicModule = await import('kody:@kentcdodds/example-package/value')
+	return {
+		staticValue: staticValue(),
+		dynamicValue: dynamicModule.default(),
+		dynamicMarker: dynamicModule.marker,
+	}
+}
+`,
+		},
+		entryPoint: 'index.js',
+	})
+
+	expect(bundle.dependencies).toEqual([
+		{
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			kodyId: 'example-package',
+			packageName: '@kentcdodds/example-package',
+		},
+	])
+	expect(bundle.dynamicDependencies).toEqual([
+		{
+			specifier: 'kody:@kentcdodds/example-package/value',
+			packageName: '@kentcdodds/example-package',
+			exportName: './value',
+		},
+	])
+	packageVersion = 'current'
+	const hydratedModules = await hydrateKodyRuntimeModules({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		modules: bundle.modules,
+	})
+	const moduleGraph = await createTemporaryModuleGraph(hydratedModules)
+	try {
+		const entry = (await moduleGraph.importModule(bundle.mainModule)) as {
+			default: () => Promise<unknown>
+		}
+		await expect(entry.default()).resolves.toEqual({
+			staticValue: 'pinned',
+			dynamicValue: 'current',
+			dynamicMarker: 'current',
+		})
+	} finally {
+		await moduleGraph.cleanup()
+	}
+	expect(mockModule.getSavedPackageByName).toHaveBeenCalledWith(
+		{},
+		expect.objectContaining({
+			userId: 'user-1',
+			name: '@kentcdodds/example-package',
+		}),
+	)
+})
+
+test('buildKodyModuleBundle rejects computed dynamic kody package imports clearly at runtime', async () => {
+	mockModule.createWorker.mockImplementation(
+		async (input: { files: Record<string, string>; entryPoint: string }) => ({
+			mainModule: input.entryPoint,
+			modules: input.files,
+			dependencies: [],
+		}),
+	)
+
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+	const bundle = await buildKodyModuleBundle({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/local-package',
+				exports: {
+					'.': './index.js',
+				},
+				kody: {
+					id: 'local-package',
+					description: 'Local package',
+				},
+			}),
+			'index.js': `const specifier = 'kody:@kentcdodds/example-package/value'
+
+export default async function run() {
+	return await import(specifier)
+}
+`,
+		},
+		entryPoint: 'index.js',
+	})
+	const hydratedModules = await hydrateKodyRuntimeModules({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		modules: bundle.modules,
+	})
+	const moduleGraph = await createTemporaryModuleGraph(hydratedModules)
+	try {
+		const entry = (await moduleGraph.importModule(bundle.mainModule)) as {
+			default: () => Promise<unknown>
+		}
+		await expect(entry.default()).rejects.toThrow(
+			'Computed dynamic Kody package imports are unsupported',
+		)
+	} finally {
+		await moduleGraph.cleanup()
+	}
+})
+
 test.each([
 	{
 		name: 'subscription service start',
@@ -746,7 +982,17 @@ export default async function launchAgent() {
 			entryPoint,
 		})
 
-		const moduleGraph = await createTemporaryModuleGraph(bundle.modules)
+		expect(bundle.modules).not.toHaveProperty('.__kody_virtual__/runtime.js')
+		const hydratedModules = await hydrateKodyRuntimeModules({
+			env: {
+				APP_DB: {},
+				REPO_SESSION: {},
+			} as Env,
+			baseUrl: 'https://heykody.dev',
+			userId: 'user-1',
+			modules: bundle.modules,
+		})
+		const moduleGraph = await createTemporaryModuleGraph(hydratedModules)
 		try {
 			// Keep both imports on the same Node ESM cache entry to reproduce a
 			// preloaded runtime module shared with the bundled entry.

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -1056,6 +1056,9 @@ throw new Error('unhydrated ${specifier}');
 			path.includes('/.__kody_current__/'),
 		),
 	).toEqual(currentArtifactModulePaths)
+	expect(
+		mockModule.loadPublishedBundleArtifactByIdentity,
+	).toHaveBeenCalledTimes(3)
 })
 
 test.each([

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -895,6 +895,169 @@ export default async function run() {
 	}
 })
 
+test('hydrateKodyRuntimeModules terminates circular literal dynamic package imports', async () => {
+	const createDynamicPlaceholder = (specifier: string) =>
+		`export const __kodyDynamicPackageSpecifier = ${JSON.stringify(specifier)};
+throw new Error('unhydrated ${specifier}');
+`
+	const createLoadedPackage = (input: {
+		name: string
+		kodyId: string
+		sourceId: string
+		commit: string
+	}) => ({
+		source: {
+			id: input.sourceId,
+			published_commit: input.commit,
+		},
+		manifest: {
+			name: input.name,
+			exports: {
+				'./run': './index.js',
+			},
+			kody: {
+				id: input.kodyId,
+				description: `${input.name} package`,
+			},
+		},
+		files: {
+			'index.js': 'export default async function run() { return "ok" }',
+		},
+	})
+	const createArtifact = (input: {
+		sourceId: string
+		commit: string
+		specifier: string
+		nextSpecifier: string
+	}) => ({
+		version: 1,
+		kind: 'importable-module' as const,
+		artifactName: './run',
+		sourceId: input.sourceId,
+		publishedCommit: input.commit,
+		entryPoint: './index.js',
+		mainModule: 'index.js',
+		modules: {
+			'index.js': `export default async function run() {
+	const module = await import('./.__kody_virtual__/dynamic-imports/next.js')
+	return module.default
+}
+`,
+			'.__kody_virtual__/dynamic-imports/next.js': createDynamicPlaceholder(
+				input.nextSpecifier,
+			),
+		},
+		dependencies: [],
+		dynamicDependencies: [
+			{
+				specifier: input.nextSpecifier,
+				packageName: input.nextSpecifier
+					.replace('kody:', '')
+					.split('/')
+					.slice(0, 2)
+					.join('/'),
+				exportName: './run',
+			},
+		],
+		packageContext: null,
+		serviceContext: null,
+		createdAt: '2026-05-11T00:00:00.000Z',
+	})
+	const packages = new Map([
+		[
+			'@kentcdodds/a-package',
+			{
+				row: createSavedPackageRecord({
+					name: '@kentcdodds/a-package',
+					kodyId: 'a-package',
+					sourceId: 'source-a',
+				}),
+				loaded: createLoadedPackage({
+					name: '@kentcdodds/a-package',
+					kodyId: 'a-package',
+					sourceId: 'source-a',
+					commit: 'commit-a',
+				}),
+				artifact: createArtifact({
+					sourceId: 'source-a',
+					commit: 'commit-a',
+					specifier: 'kody:@kentcdodds/a-package/run',
+					nextSpecifier: 'kody:@kentcdodds/b-package/run',
+				}),
+			},
+		],
+		[
+			'@kentcdodds/b-package',
+			{
+				row: createSavedPackageRecord({
+					name: '@kentcdodds/b-package',
+					kodyId: 'b-package',
+					sourceId: 'source-b',
+				}),
+				loaded: createLoadedPackage({
+					name: '@kentcdodds/b-package',
+					kodyId: 'b-package',
+					sourceId: 'source-b',
+					commit: 'commit-b',
+				}),
+				artifact: createArtifact({
+					sourceId: 'source-b',
+					commit: 'commit-b',
+					specifier: 'kody:@kentcdodds/b-package/run',
+					nextSpecifier: 'kody:@kentcdodds/a-package/run',
+				}),
+			},
+		],
+	])
+	mockModule.getSavedPackageByName.mockImplementation(
+		async (_db: unknown, input: { name: string }) =>
+			packages.get(input.name)?.row ?? null,
+	)
+	mockModule.loadPackageSourceBySourceId.mockImplementation(
+		async (input: { sourceId: string }) =>
+			[...packages.values()].find(
+				(entry) => entry.row.sourceId === input.sourceId,
+			)?.loaded ?? null,
+	)
+	mockModule.loadPublishedBundleArtifactByIdentity.mockImplementation(
+		async (input: { sourceId: string }) => ({
+			row: {},
+			artifact: [...packages.values()].find(
+				(entry) => entry.row.sourceId === input.sourceId,
+			)?.artifact,
+		}),
+	)
+
+	const hydratedModules = await hydrateKodyRuntimeModules({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		modules: {
+			'entry.js': `export default async function run() {
+	const module = await import('./.__kody_virtual__/dynamic-imports/a.js')
+	return module.default
+}
+`,
+			'.__kody_virtual__/dynamic-imports/a.js': createDynamicPlaceholder(
+				'kody:@kentcdodds/a-package/run',
+			),
+		},
+	})
+
+	const currentArtifactModulePaths = Object.keys(hydratedModules).filter(
+		(path) => path.includes('/.__kody_current__/'),
+	)
+	expect(currentArtifactModulePaths).toHaveLength(4)
+	expect(
+		currentArtifactModulePaths.filter((path) =>
+			path.includes('/.__kody_current__/'),
+		),
+	).toEqual(currentArtifactModulePaths)
+})
+
 test.each([
 	{
 		name: 'subscription service start',

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -54,6 +54,7 @@ const packageImportProxyPrefix = '.__kody_virtual__/imports'
 const dynamicPackageImportProxyPrefix = '.__kody_virtual__/dynamic-imports'
 const dynamicPackageImportArtifactSegment = '.__kody_current__'
 const dynamicPackageImportSpecifierExportName = '__kodyDynamicPackageSpecifier'
+const dynamicPackageImportResolvedMarker = '__kodyDynamicPackageResolved'
 const packageAppBundleCache =
 	createPublishedPackagePromiseCache<RuntimeBundle>()
 
@@ -393,7 +394,10 @@ throw new Error(
 }
 
 function createDynamicPackageImportProxySource(input: { targetPath: string }) {
-	return createPackageImportProxySource(input)
+	return `
+// ${dynamicPackageImportResolvedMarker}
+${createPackageImportProxySource(input)}
+`.trim()
 }
 
 function createComputedDynamicImportGuardSource(input: { helperName: string }) {
@@ -808,6 +812,7 @@ function readDynamicPackageImportSpecifier(input: {
 						? input.module.text
 						: ''
 	if (!source.includes(dynamicPackageImportSpecifierExportName)) {
+		if (source.includes(dynamicPackageImportResolvedMarker)) return null
 		return createPackageSpecifierFromProxyPath(input.modulePath)
 	}
 	const markerIndex = source.indexOf(dynamicPackageImportSpecifierExportName)

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -1049,20 +1049,37 @@ export async function hydrateKodyRuntimeModules(input: {
 }): Promise<WorkerLoaderModules> {
 	const modules = refreshKodyRuntimeModules(input.modules)
 	const installedArtifacts = new Map<string, string>()
+	const resolvedArtifacts = new Map<
+		string,
+		{
+			artifactKey: string
+			artifact: PublishedBundleArtifact
+			installedArtifactMainModule?: string
+		}
+	>()
 	while (true) {
 		let installedDynamicImport = false
 		for (const entry of collectDynamicPackageImportsFromModules(modules)) {
-			const artifact = await resolveCurrentDynamicPackageArtifact({
-				env: input.env,
-				baseUrl: input.baseUrl,
-				userId: input.userId,
-				specifier: entry.specifier,
-			})
-			const artifactKey = createDynamicPackageImportArtifactKey({
-				specifier: entry.specifier,
-				artifact,
-			})
-			const existingArtifactMainModule = installedArtifacts.get(artifactKey)
+			let resolved = resolvedArtifacts.get(entry.specifier)
+			if (!resolved) {
+				const artifact = await resolveCurrentDynamicPackageArtifact({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					userId: input.userId,
+					specifier: entry.specifier,
+				})
+				resolved = {
+					artifactKey: createDynamicPackageImportArtifactKey({
+						specifier: entry.specifier,
+						artifact,
+					}),
+					artifact,
+				}
+				resolvedArtifacts.set(entry.specifier, resolved)
+			}
+			const existingArtifactMainModule =
+				resolved.installedArtifactMainModule ??
+				installedArtifacts.get(resolved.artifactKey)
 			if (existingArtifactMainModule) {
 				modules[entry.modulePath] = createDynamicPackageImportProxySource({
 					targetPath: createRelativeImportSpecifier(
@@ -1076,9 +1093,10 @@ export async function hydrateKodyRuntimeModules(input: {
 				modules,
 				modulePath: entry.modulePath,
 				specifier: entry.specifier,
-				artifact,
+				artifact: resolved.artifact,
 			})
-			installedArtifacts.set(artifactKey, installedArtifactMainModule)
+			resolved.installedArtifactMainModule = installedArtifactMainModule
+			installedArtifacts.set(resolved.artifactKey, installedArtifactMainModule)
 			installedDynamicImport = true
 		}
 		if (!installedDynamicImport) return refreshKodyRuntimeModules(modules)
@@ -1099,6 +1117,19 @@ function applyReplacements(
 	}
 	nextSource += source.slice(cursor)
 	return nextSource
+}
+
+function assertReplacementsDoNotOverlap(
+	replacements: Array<RewriteReplacement>,
+) {
+	for (let index = 1; index < replacements.length; index += 1) {
+		const previous = replacements[index - 1]
+		const current = replacements[index]
+		if (!previous || !current || current.start >= previous.end) continue
+		throw new Error(
+			'Nested dynamic import expressions involving Kody package imports are unsupported. Keep import("kody:@scope/package/export") as its own expression.',
+		)
+	}
 }
 
 async function ensurePackageLoaded(
@@ -1296,10 +1327,11 @@ async function rewriteKodyImports(input: {
 			)})`,
 		})
 	}
-	const rewritten = applyReplacements(
-		input.source,
-		replacements.sort((left, right) => left.start - right.start),
+	const sortedReplacements = replacements.sort(
+		(left, right) => left.start - right.start,
 	)
+	assertReplacementsDoNotOverlap(sortedReplacements)
+	const rewritten = applyReplacements(input.source, sortedReplacements)
 	return helperName
 		? `${createComputedDynamicImportGuardSource({ helperName })}\n${rewritten}`
 		: rewritten

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -19,6 +19,7 @@ import {
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
 import {
 	type BundleArtifactDependency,
+	type BundleArtifactDynamicDependency,
 	type BundleArtifactKind,
 	type PublishedBundleArtifact,
 } from './published-runtime-artifacts.ts'
@@ -27,13 +28,17 @@ import {
 	packageSpecifierPrefix,
 	resolveSavedPackageImport,
 } from './package-import-resolution.ts'
-import { loadPublishedBundleArtifactByIdentity } from './published-bundle-artifacts.ts'
+import {
+	loadPublishedBundleArtifactByIdentity,
+	persistPublishedBundleArtifact,
+} from './published-bundle-artifacts.ts'
 import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from './published-source-dependencies.ts'
 import {
 	collectStaticKodyPackageImportsFromFiles,
 	isTypeDeclarationFilePath,
 } from './static-kody-imports.ts'
 import {
+	collectDynamicImportExpressionNodes,
 	collectLiteralImportNodes,
 	collectLiteralImportSpecifiers,
 	isBarePackageImportSpecifier,
@@ -46,6 +51,9 @@ const wranglerConfigPaths = ['wrangler.toml', 'wrangler.json', 'wrangler.jsonc']
 const rootSourcePrefix = '.__kody_root__'
 const packageSourcePrefix = '.__kody_packages__'
 const packageImportProxyPrefix = '.__kody_virtual__/imports'
+const dynamicPackageImportProxyPrefix = '.__kody_virtual__/dynamic-imports'
+const dynamicPackageImportArtifactSegment = '.__kody_current__'
+const dynamicPackageImportSpecifierExportName = '__kodyDynamicPackageSpecifier'
 const packageAppBundleCache =
 	createPublishedPackagePromiseCache<RuntimeBundle>()
 
@@ -104,6 +112,7 @@ type RewriteState = {
 		prefix: string
 	} | null
 	proxies: Map<string, string>
+	dynamicPackageImports: Map<string, string>
 	packages: Map<
 		string,
 		LoadedPackageSource & { row: SavedPackageRecord; prefix: string }
@@ -114,10 +123,22 @@ function createRelativeImportSpecifier(fromPath: string, targetPath: string) {
 	const fromDir = dirname(fromPath)
 	const relative = relativePath(fromDir, targetPath)
 	const normalized =
-		relative.startsWith('.') || relative.startsWith('..')
+		relative === '.' || relative.startsWith('./') || relative.startsWith('../')
 			? relative
 			: `./${relative}`
 	return normalized.replaceAll('\\', '/')
+}
+
+function includeDynamicDependenciesWhenPresent(modules: WorkerLoaderModules) {
+	const dynamicDependencies = collectDynamicKodyDependenciesFromModules(modules)
+	return dynamicDependencies.length > 0 ? { dynamicDependencies } : {}
+}
+
+function resolveRelativeModulePath(fromPath: string, specifier: string) {
+	if (!specifier.startsWith('./') && !specifier.startsWith('../')) {
+		return null
+	}
+	return normalizeWorkspaceModulePath(joinPath(dirname(fromPath), specifier))
 }
 
 export function createRuntimeModuleSource() {
@@ -269,16 +290,42 @@ function isRuntimeModulePath(modulePath: string) {
 	)
 }
 
+function collectReferencedRuntimeModulePaths(modules: WorkerLoaderModules) {
+	const runtimePaths = new Set<string>([runtimeModulePath])
+	for (const modulePath of Object.keys(modules)) {
+		if (isRuntimeModulePath(modulePath)) {
+			runtimePaths.add(modulePath)
+		}
+	}
+	for (const [modulePath, source] of iterateModuleSourceTexts(modules)) {
+		for (const node of collectLiteralImportNodes(source)) {
+			const resolvedPath = resolveRelativeModulePath(modulePath, node.specifier)
+			if (resolvedPath && isRuntimeModulePath(resolvedPath)) {
+				runtimePaths.add(resolvedPath)
+			}
+		}
+	}
+	return runtimePaths
+}
+
 export function refreshKodyRuntimeModules(
 	modules: WorkerLoaderModules,
 ): WorkerLoaderModules {
-	let refreshed: WorkerLoaderModules | null = null
-	for (const modulePath of Object.keys(modules)) {
-		if (!isRuntimeModulePath(modulePath)) continue
-		refreshed ??= { ...modules }
+	const refreshed: WorkerLoaderModules = { ...modules }
+	for (const modulePath of collectReferencedRuntimeModulePaths(modules)) {
 		refreshed[modulePath] = createRuntimeModuleSource()
 	}
-	return refreshed ?? modules
+	return refreshed
+}
+
+function stripKodyRuntimeModules(modules: WorkerLoaderModules) {
+	let stripped: WorkerLoaderModules | null = null
+	for (const modulePath of Object.keys(modules)) {
+		if (!isRuntimeModulePath(modulePath)) continue
+		stripped ??= { ...modules }
+		delete stripped[modulePath]
+	}
+	return stripped ?? modules
 }
 
 function createExecuteEntrypointSource(input: { modulePath: string }) {
@@ -333,6 +380,37 @@ export default __kodyPackageModule.default;
 `.trim()
 }
 
+function createDynamicPackageImportPlaceholderSource(input: {
+	specifier: string
+}) {
+	return `
+export const ${dynamicPackageImportSpecifierExportName} = ${JSON.stringify(input.specifier)};
+
+throw new Error(
+	${JSON.stringify(`Kody dynamic package import "${input.specifier}" was not resolved by the host runtime.`)},
+);
+`.trim()
+}
+
+function createDynamicPackageImportProxySource(input: { targetPath: string }) {
+	return createPackageImportProxySource(input)
+}
+
+function createComputedDynamicImportGuardSource(input: { helperName: string }) {
+	return `
+const ${input.helperName} = async (specifier) => {
+	if (typeof specifier === 'string' && specifier.startsWith(${JSON.stringify(
+		packageSpecifierPrefix,
+	)})) {
+		throw new Error(
+			'Computed dynamic Kody package imports are unsupported. Use a string literal like import("kody:@scope/package/export") for current runtime package resolution.',
+		);
+	}
+	return await import(specifier);
+};
+`.trim()
+}
+
 function createImportableEntrypointSource(input: { modulePath: string }) {
 	return `
 export * from ${JSON.stringify(input.modulePath)};
@@ -347,11 +425,46 @@ function encodePathKey(value: string) {
 	).join('')
 }
 
+function decodePathKey(value: string) {
+	const bytes = value.match(/[0-9a-f]{2}/gi)
+	if (!bytes || bytes.join('') !== value) return null
+	try {
+		return new TextDecoder().decode(
+			new Uint8Array(bytes.map((byte) => Number.parseInt(byte, 16))),
+		)
+	} catch {
+		return null
+	}
+}
+
 function createPackageProxyPathSegment(specifier: string) {
 	const parsed = parseKodyPackageSpecifier(specifier)
 	return encodePathKey(
 		`${parsed.packageName}#${normalizePackageExportKey(parsed.exportName)}`,
 	)
+}
+
+function createPackageSpecifierFromProxyPath(modulePath: string) {
+	const normalizedPath = normalizeWorkspaceModulePath(modulePath)
+	const prefix = `${dynamicPackageImportProxyPrefix}/`
+	const prefixIndex = normalizedPath.indexOf(prefix)
+	if (prefixIndex === -1) return null
+	const encodedSegment = normalizedPath
+		.slice(prefixIndex + prefix.length)
+		.split('/')[0]
+		?.replace(/\.js$/, '')
+	if (!encodedSegment) return null
+	const decoded = decodePathKey(encodedSegment)
+	const separator = decoded?.indexOf('#') ?? -1
+	if (!decoded || separator === -1) return null
+	const packageName = decoded.slice(0, separator)
+	const exportName = decoded.slice(separator + 1)
+	if (!packageName.startsWith('@')) return null
+	const exportSuffix =
+		exportName && exportName !== '.'
+			? `/${exportName.replace(/^\.?\//, '')}`
+			: ''
+	return `kody:${packageName}${exportSuffix}`
 }
 
 function resolvePackageExportSourcePath(input: {
@@ -485,7 +598,10 @@ function collectReachableSourceFilePaths(input: {
 		if (source == null) continue
 		reachable.add(filePath)
 		for (const node of collectLiteralImportNodes(source)) {
-			if (node.specifier.startsWith(packageSpecifierPrefix)) {
+			if (
+				node.kind === 'static' &&
+				node.specifier.startsWith(packageSpecifierPrefix)
+			) {
 				const parsed = parseKodyPackageSpecifier(node.specifier)
 				if (parsed.packageName === input.rootPackage?.manifest.name) {
 					const exportPath = resolvePackageExportPath({
@@ -677,6 +793,76 @@ function materializeArtifactModuleSource(input: {
 	)
 }
 
+function readDynamicPackageImportSpecifier(input: {
+	modulePath: string
+	module: WorkerLoaderModules[string]
+}) {
+	const source =
+		typeof input.module === 'string'
+			? input.module
+			: typeof input.module.js === 'string'
+				? input.module.js
+				: typeof input.module.cjs === 'string'
+					? input.module.cjs
+					: typeof input.module.text === 'string'
+						? input.module.text
+						: ''
+	if (!source.includes(dynamicPackageImportSpecifierExportName)) {
+		return createPackageSpecifierFromProxyPath(input.modulePath)
+	}
+	const markerIndex = source.indexOf(dynamicPackageImportSpecifierExportName)
+	const match = source.slice(markerIndex).match(/=\s*("(?:[^"\\]|\\.)*")/)
+	const rawSpecifier = match?.[1]
+	if (!rawSpecifier)
+		return createPackageSpecifierFromProxyPath(input.modulePath)
+	try {
+		const specifier = JSON.parse(rawSpecifier) as unknown
+		return typeof specifier === 'string' &&
+			specifier.startsWith(packageSpecifierPrefix)
+			? specifier
+			: null
+	} catch {
+		return createPackageSpecifierFromProxyPath(input.modulePath)
+	}
+}
+
+function collectDynamicPackageImportsFromModules(modules: WorkerLoaderModules) {
+	return Object.entries(modules)
+		.map(([modulePath, module]) => ({
+			modulePath,
+			specifier: readDynamicPackageImportSpecifier({ modulePath, module }),
+		}))
+		.filter(
+			(
+				entry,
+			): entry is {
+				modulePath: string
+				specifier: string
+			} => entry.specifier != null,
+		)
+}
+
+function collectDynamicKodyDependenciesFromModules(
+	modules: WorkerLoaderModules,
+): Array<BundleArtifactDynamicDependency> {
+	const dependencies = new Map<string, BundleArtifactDynamicDependency>()
+	for (const { specifier } of collectDynamicPackageImportsFromModules(
+		modules,
+	)) {
+		const parsed = parseKodyPackageSpecifier(specifier)
+		dependencies.set(specifier, {
+			specifier,
+			packageName: parsed.packageName,
+			exportName: normalizePackageExportKey(parsed.exportName),
+		})
+	}
+	return [...dependencies.values()].sort(
+		(left, right) =>
+			left.packageName.localeCompare(right.packageName) ||
+			left.exportName.localeCompare(right.exportName),
+	)
+}
+
 async function maybeEnsurePublishedArtifactTarget(input: {
 	state: RewriteState
 	specifier: string
@@ -716,7 +902,162 @@ async function maybeEnsurePublishedArtifactTarget(input: {
 				module,
 			})
 	}
+	input.state.files[joinPath(artifactPrefix, runtimeModulePath)] =
+		createRuntimeModuleSource()
 	return joinPath(artifactPrefix, artifact.artifact.mainModule)
+}
+
+async function resolveCurrentDynamicPackageArtifact(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	specifier: string
+}) {
+	if (!input.userId) {
+		throw new Error(
+			`Dynamic Kody package import "${input.specifier}" requires an authenticated user.`,
+		)
+	}
+	const parsed = parseKodyPackageSpecifier(input.specifier)
+	const row = await resolveSavedPackageImport({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		specifier: parsed,
+	})
+	if (!row) {
+		throw new Error(
+			`Dynamic Kody package import "${input.specifier}" could not find saved package "${parsed.packageName}" for this user.`,
+		)
+	}
+	const loaded = await loadPackageSourceBySourceId({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		sourceId: row.sourceId,
+	})
+	if (!loaded.source.published_commit) {
+		throw new Error(
+			`Dynamic Kody package import "${input.specifier}" resolved saved package "${row.name}" source "${row.sourceId}", but it has no published commit.`,
+		)
+	}
+	const exportName = normalizePackageExportKey(parsed.exportName)
+	const entryPoint = resolvePackageExportPath({
+		manifest: loaded.manifest,
+		exportName,
+	})
+	const loadedArtifact = await loadPublishedBundleArtifactByIdentity({
+		env: input.env,
+		userId: input.userId,
+		sourceId: row.sourceId,
+		kind: 'importable-module',
+		artifactName: exportName,
+		entryPoint,
+	})
+	if (loadedArtifact?.artifact) {
+		return loadedArtifact.artifact
+	}
+	assertPublishedSourceCanRebuildWithoutInstallingDeps({
+		sourceFiles: loaded.files,
+		bundleLabel: `Dynamic Kody package import "${input.specifier}"`,
+	})
+	const rebuilt = await buildKodyImportableModuleBundle({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		sourceFiles: loaded.files,
+		entryPoint,
+	})
+	await persistPublishedBundleArtifact({
+		env: input.env,
+		userId: input.userId,
+		source: loaded.source,
+		kind: 'importable-module',
+		artifactName: exportName,
+		entryPoint,
+		mainModule: rebuilt.mainModule,
+		modules: rebuilt.modules,
+		dependencies: rebuilt.dependencies,
+		dynamicDependencies: rebuilt.dynamicDependencies,
+		packageContext: {
+			packageId: row.id,
+			kodyId: row.kodyId,
+			sourceId: row.sourceId,
+		},
+	})
+	return createPublishedBundleArtifact({
+		kind: 'importable-module',
+		artifactName: exportName,
+		sourceId: loaded.source.id,
+		publishedCommit: loaded.source.published_commit,
+		entryPoint,
+		mainModule: rebuilt.mainModule,
+		modules: rebuilt.modules,
+		dependencies: rebuilt.dependencies,
+		dynamicDependencies: rebuilt.dynamicDependencies,
+		packageContext: {
+			packageId: row.id,
+			kodyId: row.kodyId,
+			sourceId: row.sourceId,
+		},
+	})
+}
+
+function installDynamicPackageArtifactModules(input: {
+	modules: WorkerLoaderModules
+	modulePath: string
+	specifier: string
+	artifact: PublishedBundleArtifact
+}) {
+	const artifactPrefix = joinPath(
+		dirname(input.modulePath),
+		dynamicPackageImportArtifactSegment,
+		encodePathKey(
+			`${input.specifier}#${input.artifact.sourceId}#${input.artifact.publishedCommit}`,
+		),
+	)
+	for (const [artifactModulePath, module] of Object.entries(
+		input.artifact.modules,
+	)) {
+		input.modules[joinPath(artifactPrefix, artifactModulePath)] = module
+	}
+	input.modules[input.modulePath] = createDynamicPackageImportProxySource({
+		targetPath: createRelativeImportSpecifier(
+			input.modulePath,
+			joinPath(artifactPrefix, input.artifact.mainModule),
+		),
+	})
+}
+
+export async function hydrateKodyRuntimeModules(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	modules: WorkerLoaderModules
+}): Promise<WorkerLoaderModules> {
+	const modules = refreshKodyRuntimeModules(input.modules)
+	const hydratedDynamicImports = new Set<string>()
+	while (true) {
+		let installedDynamicImport = false
+		for (const entry of collectDynamicPackageImportsFromModules(modules)) {
+			const importKey = `${entry.modulePath}:${entry.specifier}`
+			if (hydratedDynamicImports.has(importKey)) continue
+			hydratedDynamicImports.add(importKey)
+			const artifact = await resolveCurrentDynamicPackageArtifact({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				specifier: entry.specifier,
+			})
+			installDynamicPackageArtifactModules({
+				modules,
+				modulePath: entry.modulePath,
+				specifier: entry.specifier,
+				artifact,
+			})
+			installedDynamicImport = true
+		}
+		if (!installedDynamicImport) return refreshKodyRuntimeModules(modules)
+	}
 }
 
 function applyReplacements(
@@ -837,13 +1178,43 @@ async function ensurePackageProxy(
 	return proxyPath
 }
 
+function ensureDynamicPackageImportProxy(
+	state: RewriteState,
+	specifier: string,
+) {
+	const existing = state.dynamicPackageImports.get(specifier)
+	if (existing) return existing
+	const proxyPath = joinPath(
+		dynamicPackageImportProxyPrefix,
+		`${createPackageProxyPathSegment(specifier)}.js`,
+	)
+	state.files[proxyPath] = createDynamicPackageImportPlaceholderSource({
+		specifier,
+	})
+	state.dynamicPackageImports.set(specifier, proxyPath)
+	return proxyPath
+}
+
+function createUniqueHelperName(source: string, baseName: string) {
+	let candidate = baseName
+	let suffix = 0
+	while (source.includes(candidate)) {
+		suffix += 1
+		candidate = `${baseName}${suffix}`
+	}
+	return candidate
+}
+
 async function rewriteKodyImports(input: {
 	state: RewriteState
 	source: string
 	modulePath: string
 }) {
 	const importNodes = collectLiteralImportNodes(input.source)
-	if (importNodes.length === 0) return input.source
+	const dynamicImportNodes = collectDynamicImportExpressionNodes(input.source)
+	if (importNodes.length === 0 && dynamicImportNodes.length === 0) {
+		return input.source
+	}
 	const replacements: Array<RewriteReplacement> = []
 	for (const node of importNodes) {
 		if (node.specifier === 'kody:runtime') {
@@ -859,6 +1230,20 @@ async function rewriteKodyImports(input: {
 		if (!node.specifier.startsWith(packageSpecifierPrefix)) {
 			continue
 		}
+		if (node.kind === 'dynamic') {
+			const proxyPath = ensureDynamicPackageImportProxy(
+				input.state,
+				node.specifier,
+			)
+			replacements.push({
+				start: node.start,
+				end: node.end,
+				value: JSON.stringify(
+					createRelativeImportSpecifier(input.modulePath, proxyPath),
+				),
+			})
+			continue
+		}
 		const proxyPath = await ensurePackageProxy(input.state, node.specifier)
 		replacements.push({
 			start: node.start,
@@ -868,7 +1253,31 @@ async function rewriteKodyImports(input: {
 			),
 		})
 	}
-	return applyReplacements(input.source, replacements)
+	const nonLiteralDynamicImports = dynamicImportNodes.filter(
+		(node) => node.literalSpecifier == null,
+	)
+	let helperName: string | null = null
+	for (const node of nonLiteralDynamicImports) {
+		helperName ??= createUniqueHelperName(
+			input.source,
+			'__kodyDynamicImportGuard',
+		)
+		replacements.push({
+			start: node.start,
+			end: node.end,
+			value: `${helperName}(${input.source.slice(
+				node.sourceStart,
+				node.sourceEnd,
+			)})`,
+		})
+	}
+	const rewritten = applyReplacements(
+		input.source,
+		replacements.sort((left, right) => left.start - right.start),
+	)
+	return helperName
+		? `${createComputedDynamicImportGuardSource({ helperName })}\n${rewritten}`
+		: rewritten
 }
 
 export async function buildKodyModuleBundle(input: {
@@ -902,17 +1311,19 @@ export async function buildKodyModuleBundle(input: {
 		files,
 		entryPoint: bootstrapPath,
 	})
+	const modules = stripKodyRuntimeModules(bundle.modules as WorkerLoaderModules)
 	assertBundleHasNoUnresolvedBareImports({
-		modules: bundle.modules as WorkerLoaderModules,
+		modules,
 		bundleLabel: `Saved package module "${normalizePackageWorkspacePath(input.entryPoint)}" bundle`,
 	})
 	return {
 		mainModule: bundle.mainModule,
-		modules: bundle.modules as WorkerLoaderModules,
+		modules,
 		dependencies: await resolveDirectKodyDependenciesForEntryPoint({
 			...input,
 			loadedPackages: packages,
 		}),
+		...includeDynamicDependenciesWhenPresent(modules),
 	}
 }
 
@@ -947,17 +1358,19 @@ export async function buildKodyImportableModuleBundle(input: {
 		files,
 		entryPoint: bootstrapPath,
 	})
+	const modules = stripKodyRuntimeModules(bundle.modules as WorkerLoaderModules)
 	assertBundleHasNoUnresolvedBareImports({
-		modules: bundle.modules as WorkerLoaderModules,
+		modules,
 		bundleLabel: `Saved package import "${normalizePackageWorkspacePath(input.entryPoint)}" bundle`,
 	})
 	return {
 		mainModule: bundle.mainModule,
-		modules: bundle.modules as WorkerLoaderModules,
+		modules,
 		dependencies: await resolveDirectKodyDependenciesForEntryPoint({
 			...input,
 			loadedPackages: packages,
 		}),
+		...includeDynamicDependenciesWhenPresent(modules),
 	}
 }
 
@@ -990,6 +1403,7 @@ async function prepareKodyGraphFiles(input: {
 		sourceFiles: input.sourceFiles,
 		rootPackage,
 		proxies: new Map(),
+		dynamicPackageImports: new Map(),
 		packages: new Map(),
 	}
 	for (const [filePath, content] of Object.entries(input.sourceFiles)) {
@@ -1060,17 +1474,21 @@ export async function buildKodyAppBundle(input: {
 			files,
 			entryPoint: bootstrapPath,
 		})
+		const modules = stripKodyRuntimeModules(
+			bundle.modules as WorkerLoaderModules,
+		)
 		assertBundleHasNoUnresolvedBareImports({
-			modules: bundle.modules as WorkerLoaderModules,
+			modules,
 			bundleLabel: `Saved package app "${normalizePackageWorkspacePath(input.entryPoint)}" bundle`,
 		})
 		return {
 			mainModule: bundle.mainModule,
-			modules: bundle.modules as WorkerLoaderModules,
+			modules,
 			dependencies: await resolveDirectKodyDependenciesForEntryPoint({
 				...input,
 				loadedPackages: packages,
 			}),
+			...includeDynamicDependenciesWhenPresent(modules),
 		}
 	}
 
@@ -1094,6 +1512,7 @@ export function createPublishedBundleArtifact(input: {
 	mainModule: string
 	modules: WorkerLoaderModules
 	dependencies: Array<BundleArtifactDependency>
+	dynamicDependencies?: Array<BundleArtifactDynamicDependency>
 	packageContext?: {
 		packageId: string
 		kodyId: string
@@ -1113,6 +1532,7 @@ export function createPublishedBundleArtifact(input: {
 		mainModule: input.mainModule,
 		modules: input.modules,
 		dependencies: input.dependencies,
+		dynamicDependencies: input.dynamicDependencies ?? [],
 		packageContext: input.packageContext ?? null,
 		serviceContext: input.serviceContext ?? null,
 		createdAt: new Date().toISOString(),

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -1026,6 +1026,14 @@ function installDynamicPackageArtifactModules(input: {
 			joinPath(artifactPrefix, input.artifact.mainModule),
 		),
 	})
+	return joinPath(artifactPrefix, input.artifact.mainModule)
+}
+
+function createDynamicPackageImportArtifactKey(input: {
+	specifier: string
+	artifact: PublishedBundleArtifact
+}) {
+	return `${input.specifier}:${input.artifact.sourceId}:${input.artifact.publishedCommit}`
 }
 
 export async function hydrateKodyRuntimeModules(input: {
@@ -1035,25 +1043,37 @@ export async function hydrateKodyRuntimeModules(input: {
 	modules: WorkerLoaderModules
 }): Promise<WorkerLoaderModules> {
 	const modules = refreshKodyRuntimeModules(input.modules)
-	const hydratedDynamicImports = new Set<string>()
+	const installedArtifacts = new Map<string, string>()
 	while (true) {
 		let installedDynamicImport = false
 		for (const entry of collectDynamicPackageImportsFromModules(modules)) {
-			const importKey = `${entry.modulePath}:${entry.specifier}`
-			if (hydratedDynamicImports.has(importKey)) continue
-			hydratedDynamicImports.add(importKey)
 			const artifact = await resolveCurrentDynamicPackageArtifact({
 				env: input.env,
 				baseUrl: input.baseUrl,
 				userId: input.userId,
 				specifier: entry.specifier,
 			})
-			installDynamicPackageArtifactModules({
+			const artifactKey = createDynamicPackageImportArtifactKey({
+				specifier: entry.specifier,
+				artifact,
+			})
+			const existingArtifactMainModule = installedArtifacts.get(artifactKey)
+			if (existingArtifactMainModule) {
+				modules[entry.modulePath] = createDynamicPackageImportProxySource({
+					targetPath: createRelativeImportSpecifier(
+						entry.modulePath,
+						existingArtifactMainModule,
+					),
+				})
+				continue
+			}
+			const installedArtifactMainModule = installDynamicPackageArtifactModules({
 				modules,
 				modulePath: entry.modulePath,
 				specifier: entry.specifier,
 				artifact,
 			})
+			installedArtifacts.set(artifactKey, installedArtifactMainModule)
 			installedDynamicImport = true
 		}
 		if (!installedDynamicImport) return refreshKodyRuntimeModules(modules)

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -17,6 +17,7 @@ import {
 	buildKodyAppBundle,
 	createPublishedBundleArtifact,
 	createPublishedPackageAppBundleCacheKey,
+	hydrateKodyRuntimeModules,
 } from './module-graph.ts'
 import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from './published-source-dependencies.ts'
 import {
@@ -1114,6 +1115,7 @@ export async function buildPackageAppWorker(input: {
 					mainModule: compiled.mainModule,
 					modules: compiled.modules,
 					dependencies: compiled.dependencies,
+					dynamicDependencies: compiled.dynamicDependencies,
 					packageContext: {
 						packageId: input.savedPackage.id,
 						kodyId: input.savedPackage.kodyId,
@@ -1125,8 +1127,14 @@ export async function buildPackageAppWorker(input: {
 			return compiled
 		})())
 	const mainModule = 'package-app-entry.js'
+	const hydratedModules = await hydrateKodyRuntimeModules({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		modules: bundled.modules,
+	})
 	const modules = {
-		...bundled.modules,
+		...hydratedModules,
 		[mainModule]: createPackageAppWorkerSource({
 			mainModule: bundled.mainModule,
 		}),

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.ts
@@ -9,6 +9,7 @@ import {
 } from '#worker/package-registry/types.ts'
 import {
 	type BundleArtifactDependency,
+	type BundleArtifactDynamicDependency,
 	type BundleArtifactKind,
 	type PublishedBundleArtifact,
 	buildPublishedBundleArtifactKvKey,
@@ -40,6 +41,7 @@ type PersistPublishedBundleArtifactInput = {
 	mainModule: string
 	modules: WorkerLoaderModules
 	dependencies: Array<BundleArtifactDependency>
+	dynamicDependencies?: Array<BundleArtifactDynamicDependency>
 	packageContext?: PublishedBundleArtifact['packageContext']
 }
 
@@ -106,6 +108,7 @@ export async function persistPublishedBundleArtifact(
 		mainModule: input.mainModule,
 		modules: input.modules,
 		dependencies: input.dependencies,
+		dynamicDependencies: input.dynamicDependencies ?? [],
 		packageContext: input.packageContext ?? null,
 		serviceContext: null,
 		createdAt: new Date().toISOString(),
@@ -199,16 +202,19 @@ export async function rebuildPublishedPackageArtifacts(input: {
 		mainModule: string
 		modules: WorkerLoaderModules
 		dependencies: Array<BundleArtifactDependency>
+		dynamicDependencies?: Array<BundleArtifactDynamicDependency>
 	}>
 	buildModuleBundle: (args: { entryPoint: string }) => Promise<{
 		mainModule: string
 		modules: WorkerLoaderModules
 		dependencies: Array<BundleArtifactDependency>
+		dynamicDependencies?: Array<BundleArtifactDynamicDependency>
 	}>
 	buildImportableModuleBundle: (args: { entryPoint: string }) => Promise<{
 		mainModule: string
 		modules: WorkerLoaderModules
 		dependencies: Array<BundleArtifactDependency>
+		dynamicDependencies?: Array<BundleArtifactDynamicDependency>
 	}>
 }) {
 	if (input.manifest.kody.app) {
@@ -224,6 +230,7 @@ export async function rebuildPublishedPackageArtifacts(input: {
 				mainModule: bundle.mainModule,
 				modules: bundle.modules,
 				dependencies: bundle.dependencies,
+				dynamicDependencies: bundle.dynamicDependencies,
 				packageContext: {
 					packageId: input.savedPackage.id,
 					kodyId: input.savedPackage.kodyId,
@@ -246,6 +253,7 @@ export async function rebuildPublishedPackageArtifacts(input: {
 			mainModule: bundle.mainModule,
 			modules: bundle.modules,
 			dependencies: bundle.dependencies,
+			dynamicDependencies: bundle.dynamicDependencies,
 			packageContext: {
 				packageId: input.savedPackage.id,
 				kodyId: input.savedPackage.kodyId,
@@ -274,6 +282,7 @@ export async function rebuildPublishedPackageArtifacts(input: {
 			mainModule: bundle.mainModule,
 			modules: bundle.modules,
 			dependencies: bundle.dependencies,
+			dynamicDependencies: bundle.dynamicDependencies,
 			packageContext: {
 				packageId: input.savedPackage.id,
 				kodyId: input.savedPackage.kodyId,
@@ -293,6 +302,7 @@ export async function rebuildPublishedPackageArtifacts(input: {
 			mainModule: importableBundle.mainModule,
 			modules: importableBundle.modules,
 			dependencies: importableBundle.dependencies,
+			dynamicDependencies: importableBundle.dynamicDependencies,
 			packageContext: {
 				packageId: input.savedPackage.id,
 				kodyId: input.savedPackage.kodyId,
@@ -314,6 +324,7 @@ export async function rebuildPublishedPackageArtifacts(input: {
 			mainModule: bundle.mainModule,
 			modules: bundle.modules,
 			dependencies: bundle.dependencies,
+			dynamicDependencies: bundle.dynamicDependencies,
 			packageContext: {
 				packageId: input.savedPackage.id,
 				kodyId: input.savedPackage.kodyId,
@@ -339,6 +350,7 @@ export async function rebuildPublishedPackageArtifacts(input: {
 			mainModule: bundle.mainModule,
 			modules: bundle.modules,
 			dependencies: bundle.dependencies,
+			dynamicDependencies: bundle.dynamicDependencies,
 			packageContext: {
 				packageId: input.savedPackage.id,
 				kodyId: input.savedPackage.kodyId,

--- a/packages/worker/src/package-runtime/published-runtime-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-runtime-artifacts.ts
@@ -22,6 +22,12 @@ export type BundleArtifactDependency = {
 	packageName?: string
 }
 
+export type BundleArtifactDynamicDependency = {
+	specifier: string
+	packageName: string
+	exportName: string
+}
+
 type SerializedWorkerLoaderModule =
 	| string
 	| {
@@ -64,6 +70,7 @@ export type PublishedBundleArtifact = {
 	mainModule: string
 	modules: WorkerLoaderModules
 	dependencies: Array<BundleArtifactDependency>
+	dynamicDependencies?: Array<BundleArtifactDynamicDependency>
 	packageContext: {
 		packageId: string
 		kodyId: string
@@ -434,6 +441,7 @@ export async function readPublishedBundleArtifact(input: {
 	}
 	return {
 		...artifact,
+		dynamicDependencies: artifact.dynamicDependencies ?? [],
 		packageContext: artifact.packageContext
 			? {
 					...artifact.packageContext,

--- a/packages/worker/src/package-runtime/runtime-bundle-types.ts
+++ b/packages/worker/src/package-runtime/runtime-bundle-types.ts
@@ -1,8 +1,12 @@
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
-import { type BundleArtifactDependency } from './published-runtime-artifacts.ts'
+import {
+	type BundleArtifactDependency,
+	type BundleArtifactDynamicDependency,
+} from './published-runtime-artifacts.ts'
 
 export type RuntimeBundle = {
 	mainModule: string
 	modules: WorkerLoaderModules
 	dependencies: Array<BundleArtifactDependency>
+	dynamicDependencies?: Array<BundleArtifactDynamicDependency>
 }

--- a/packages/worker/src/package-runtime/static-kody-imports.ts
+++ b/packages/worker/src/package-runtime/static-kody-imports.ts
@@ -21,6 +21,7 @@ function collectStaticKodyPackageImportsFromSource(input: {
 }): Array<StaticKodyPackageImport> {
 	const imports: Array<StaticKodyPackageImport> = []
 	for (const node of collectLiteralImportNodes(input.source)) {
+		if (node.kind !== 'static') continue
 		if (!node.specifier.startsWith(packageSpecifierPrefix)) continue
 		const parsedSpecifier = parseKodyPackageSpecifier(node.specifier)
 		imports.push({

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -1268,7 +1268,7 @@ test('runRepoChecks requires mixed value export-from kody package imports to be 
 	)
 })
 
-test('runRepoChecks requires literal dynamic kody package imports to be declared', async () => {
+test('runRepoChecks does not require current-resolved literal dynamic kody package imports to be declared', async () => {
 	const files = new Map<string, string>([
 		[
 			'package.json',
@@ -1299,13 +1299,11 @@ test('runRepoChecks requires literal dynamic kody package imports to be declared
 		sourceRoot: '/',
 	})
 
-	expect(result.ok).toBe(false)
 	expect(result.results).toEqual(
 		expect.arrayContaining([
 			expect.objectContaining({
 				kind: 'dependencies',
-				ok: false,
-				message: expect.stringContaining('missing "@kentcdodds/dynamic"'),
+				ok: true,
 			}),
 		]),
 	)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

Saved package bundle artifacts persisted the generated `kody:runtime` virtual module source alongside package code. That made old package artifacts observe the host runtime implementation from publish/build time instead of the currently deployed host runtime. Tactical refreshes helped some execution paths, but the artifact format still treated host-owned runtime code as package-owned bundled code.

## Chosen design

- Treat `kody:runtime` as a reserved host-external virtual module. Package builds may reserve `.__kody_virtual__/runtime.js` so static author imports still bundle, but runtime module source is stripped before artifacts are persisted.
- Hydrate package modules immediately before execution with the current host runtime source for every referenced runtime virtual path, including nested static dependency artifacts and package apps.
- Route shared execution through `hydrateKodyRuntimeModules`, covering package exports, subscriptions, jobs, services, hosted package apps, workflows/ad hoc execute surfaces that use bundled modules.
- Preserve static `kody:@...` imports as pinned/bundled package dependency snapshots with existing source commit dependency metadata.
- Add literal dynamic `import("kody:@...")` support as runtime/current package resolution. Builds persist a host-resolved placeholder plus dynamic dependency metadata; execution resolves the current published importable artifact under the caller's `userId` and hydrates it into the module graph.
- Reject computed dynamic Kody package imports with a clear runtime error instead of attempting arbitrary resolution.

## Package author semantics

- `import { codemode } from "kody:runtime"` remains valid, but `kody:runtime` is always host-owned and request-scoped. Saved artifacts do not contain its implementation.
- Static `import thing from "kody:@scope/pkg/export"` remains pinned to the dependency artifact available when the importing package is built/published.
- Literal `await import("kody:@scope/pkg/export")` resolves the current published package export at runtime for the signed-in user.
- Computed/template Kody dynamic imports are unsupported for now; authors should use a string literal for current runtime resolution.

## Docs added

- Updated external package/execute docs with host-external runtime, static pinned imports, literal dynamic current imports, and computed dynamic import limitations.
- Updated contributor package/manifest and architecture docs with the artifact and hydration model.

## Tests run

- `npm test -- --run packages/worker/src/package-runtime/module-graph.node.test.ts packages/worker/src/repo/checks.node.test.ts`
- `npm run typecheck`
- `npm test -- --run packages/worker/src/package-runtime/module-graph.node.test.ts packages/worker/src/repo/checks.node.test.ts packages/worker/src/mcp/run-codemode-registry.node.test.ts packages/worker/src/package-runtime/package-app.node.test.ts packages/worker/src/package-invocations/service.node.test.ts packages/worker/src/jobs/service.node.test.ts`
- `npm test -- --run packages/worker/src/package-runtime/module-graph.node.test.ts`
- `npm run validate`

## AI review follow-up

- Addressed Bugbot feedback by bounding circular dynamic import hydration, reusing already-installed current artifacts, memoizing resolved dynamic specifiers before DB/artifact work, and rejecting overlapping nested dynamic import rewrites clearly.
- Latest CI and Bugbot runs are green for head `7d627aa80db992850b5b4b1b8df63266a252ee7d`. CodeRabbit is rate-limited and did not provide actionable code feedback.

## Migration / backfill notes

No bulk republish, artifact invalidation, or manual no-op package commits are required. Old artifacts that still contain stale runtime modules are hydrated with current host runtime source at execution time. New artifacts strip runtime source before persistence. Existing static dependency metadata remains pinned; new dynamic dependency metadata is stored on bundle artifacts for review/debugging without changing static dependency rows.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1b1497f-19e7-4735-8151-a7e9d421d934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1b1497f-19e7-4735-8151-a7e9d421d934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

