### PR TITLE
Fix saved package publish artifact rebuild memory pressure

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -7,6 +7,8 @@ const mockModule = vi.hoisted(() => ({
 	getEntitySourceById: vi.fn(),
 	resolveArtifactSourceHead: vi.fn(),
 	publishFromExternalRef: vi.fn(),
+	listPublishedPackageArtifactTargets: vi.fn(),
+	rebuildPublishedPackageArtifact: vi.fn(),
 	getStaticPackageDependentsSummary: vi.fn(),
 }))
 
@@ -36,6 +38,10 @@ vi.mock('#worker/repo/repo-session-do.ts', () => ({
 	repoSessionRpc: () => ({
 		publishFromExternalRef: (...args: Array<unknown>) =>
 			mockModule.publishFromExternalRef(...args),
+		listPublishedPackageArtifactTargets: (...args: Array<unknown>) =>
+			mockModule.listPublishedPackageArtifactTargets(...args),
+		rebuildPublishedPackageArtifact: (...args: Array<unknown>) =>
+			mockModule.rebuildPublishedPackageArtifact(...args),
 	}),
 }))
 
@@ -79,6 +85,17 @@ beforeEach(() => {
 		items: [],
 		recommended_next_action:
 			'No published bundle artifacts currently declare a static dependency on this package.',
+	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue([])
+	mockModule.rebuildPublishedPackageArtifact.mockResolvedValue({
+		ok: true,
+		target: {
+			kind: 'module',
+			artifactName: '.',
+			entryPoint: 'src/index.ts',
+			bundleKind: 'module',
+		},
+		kvKey: 'bundle-key',
 	})
 })
 
@@ -133,15 +150,29 @@ test('publishes a new external Artifacts HEAD', async () => {
 			newCommit: 'commit-new',
 			expectedHead: 'commit-new',
 			allowForce: false,
+			rebuildPackageArtifacts: false,
 		}),
 	)
 })
 
 test('returns already_published when Artifacts HEAD matches D1', async () => {
+	const targets = [
+		{
+			kind: 'service',
+			artifactName: 'inbox',
+			entryPoint: 'src/service.ts',
+			bundleKind: 'module',
+		},
+	]
 	mockModule.resolveArtifactSourceHead.mockResolvedValue({
 		branch: 'main',
 		commit: 'commit-old',
 	})
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'already_published',
+		published_commit: 'commit-old',
+	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(targets)
 
 	const result = await publishExternalPushCapability.handler(
 		{ package_id: 'package-1' },
@@ -160,7 +191,19 @@ test('returns already_published when Artifacts HEAD matches D1', async () => {
 				'No published bundle artifacts currently declare a static dependency on this package.',
 		},
 	})
-	expect(mockModule.publishFromExternalRef).not.toHaveBeenCalled()
+	expect(mockModule.publishFromExternalRef).toHaveBeenCalledWith(
+		expect.objectContaining({
+			sourceId: 'source-1',
+			newCommit: 'commit-old',
+		}),
+	)
+	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledWith({
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-old',
+		target: targets[0],
+		baseUrl: 'https://kody.test',
+	})
 })
 
 test('published output lists stale static dependents for the new dependency commit', async () => {
@@ -233,6 +276,67 @@ test('published output lists stale static dependents for the new dependency comm
 	)
 	expect(publishExternalPushCapability.outputTypeDefinition).toContain(
 		'current_dependency_commit',
+	)
+})
+
+test('rebuilds published package bundle artifacts one target at a time after publish', async () => {
+	const targets = [
+		{
+			kind: 'module',
+			artifactName: '.',
+			entryPoint: 'src/index.ts',
+			bundleKind: 'module',
+		},
+		{
+			kind: 'importable-module',
+			artifactName: '.',
+			entryPoint: 'src/index.ts',
+			bundleKind: 'importable-module',
+		},
+	]
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-new',
+	})
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'published',
+		previous_commit: 'commit-old',
+		published_commit: 'commit-new',
+		manifest: {},
+		checks: [{ kind: 'manifest', ok: true, message: 'ok' }],
+	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(targets)
+
+	const result = await publishExternalPushCapability.handler(
+		{ package_id: 'package-1' },
+		createContext(),
+	)
+
+	expect(result.status).toBe('published')
+	expect(mockModule.listPublishedPackageArtifactTargets).toHaveBeenCalledWith({
+		sourceId: 'source-1',
+		userId: 'user-1',
+	})
+	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(2)
+	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenNthCalledWith(
+		1,
+		{
+			sourceId: 'source-1',
+			userId: 'user-1',
+			publishedCommit: 'commit-new',
+			target: targets[0],
+			baseUrl: 'https://kody.test',
+		},
+	)
+	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenNthCalledWith(
+		2,
+		{
+			sourceId: 'source-1',
+			userId: 'user-1',
+			publishedCommit: 'commit-new',
+			target: targets[1],
+			baseUrl: 'https://kody.test',
+		},
 	)
 })
 
@@ -377,11 +481,16 @@ test('returns already_published when a retry observes that the reset attempt com
 			created_at: '2026-05-04T00:00:00.000Z',
 			updated_at: '2026-05-04T00:00:00.000Z',
 		})
-	mockModule.publishFromExternalRef.mockRejectedValueOnce(
-		new Error(
-			"Durable Object's isolate exceeded its memory limit and was reset",
-		),
-	)
+	mockModule.publishFromExternalRef
+		.mockRejectedValueOnce(
+			new Error(
+				"Durable Object's isolate exceeded its memory limit and was reset",
+			),
+		)
+		.mockResolvedValueOnce({
+			status: 'already_published',
+			published_commit: 'commit-new',
+		})
 
 	try {
 		const result = await publishExternalPushCapability.handler(
@@ -401,7 +510,7 @@ test('returns already_published when a retry observes that the reset attempt com
 					'No published bundle artifacts currently declare a static dependency on this package.',
 			},
 		})
-		expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(1)
+		expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(2)
 	} finally {
 		warnSpy.mockRestore()
 	}

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -206,6 +206,27 @@ test('returns already_published when Artifacts HEAD matches D1', async () => {
 	})
 })
 
+test('already_published without a commit fails instead of silently skipping artifact rebuild', async () => {
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-old',
+	})
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'already_published',
+		published_commit: null,
+	})
+
+	await expect(
+		publishExternalPushCapability.handler(
+			{ package_id: 'package-1' },
+			createContext(),
+		),
+	).rejects.toThrow(
+		'already published, but no published commit is available to rebuild artifacts',
+	)
+	expect(mockModule.rebuildPublishedPackageArtifact).not.toHaveBeenCalled()
+})
+
 test('published output lists stale static dependents for the new dependency commit', async () => {
 	mockModule.resolveArtifactSourceHead.mockResolvedValue({
 		branch: 'main',

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -10,6 +10,7 @@ import {
 } from '#worker/package-runtime/static-package-dependents.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
+import { rebuildPublishedPackageArtifactsViaRepoSession } from '#mcp/capabilities/repo/package-artifact-rebuild.ts'
 import { resolveOwnedPackageSource } from './resolve-package-source.ts'
 
 const inputSchema = z.object({
@@ -225,33 +226,6 @@ async function getPublishStaticDependents(input: {
 	})
 }
 
-async function rebuildPublishedPackageArtifactsForExternalPublish(input: {
-	env: Env
-	sessionId: string
-	sourceId: string
-	userId: string
-	publishedCommit: string
-	baseUrl: string
-}) {
-	const session = repoSessionRpc(input.env, input.sessionId)
-	const targets = await session.listPublishedPackageArtifactTargets({
-		sourceId: input.sourceId,
-		userId: input.userId,
-	})
-	for (const target of targets) {
-		await repoSessionRpc(
-			input.env,
-			input.sessionId,
-		).rebuildPublishedPackageArtifact({
-			sourceId: input.sourceId,
-			userId: input.userId,
-			publishedCommit: input.publishedCommit,
-			target,
-			baseUrl: input.baseUrl,
-		})
-	}
-}
-
 export const publishExternalPushCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
@@ -309,9 +283,9 @@ export const publishExternalPushCapability = defineDomainCapability(
 					})
 					if (result.status === 'already_published') {
 						if (result.published_commit) {
-							await rebuildPublishedPackageArtifactsForExternalPublish({
+							await rebuildPublishedPackageArtifactsViaRepoSession({
 								env: ctx.env,
-								sessionId,
+								rpcSessionId: sessionId,
 								sourceId: source.id,
 								userId: user.userId,
 								publishedCommit: result.published_commit,
@@ -331,9 +305,9 @@ export const publishExternalPushCapability = defineDomainCapability(
 					if (result.status !== 'published') {
 						return result
 					}
-					await rebuildPublishedPackageArtifactsForExternalPublish({
+					await rebuildPublishedPackageArtifactsViaRepoSession({
 						env: ctx.env,
-						sessionId,
+						rpcSessionId: sessionId,
 						sourceId: source.id,
 						userId: user.userId,
 						publishedCommit: result.published_commit,

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -225,6 +225,33 @@ async function getPublishStaticDependents(input: {
 	})
 }
 
+async function rebuildPublishedPackageArtifactsForExternalPublish(input: {
+	env: Env
+	sessionId: string
+	sourceId: string
+	userId: string
+	publishedCommit: string
+	baseUrl: string
+}) {
+	const session = repoSessionRpc(input.env, input.sessionId)
+	const targets = await session.listPublishedPackageArtifactTargets({
+		sourceId: input.sourceId,
+		userId: input.userId,
+	})
+	for (const target of targets) {
+		await repoSessionRpc(
+			input.env,
+			input.sessionId,
+		).rebuildPublishedPackageArtifact({
+			sourceId: input.sourceId,
+			userId: input.userId,
+			publishedCommit: input.publishedCommit,
+			target,
+			baseUrl: input.baseUrl,
+		})
+	}
+}
+
 export const publishExternalPushCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
@@ -255,25 +282,12 @@ export const publishExternalPushCapability = defineDomainCapability(
 						kody_id: args.kody_id,
 					},
 				})
-				const publishedCommit = source.published_commit
 				const head = await resolveArtifactSourceHead(ctx.env, source.repo_id)
 				const newCommit = head.commit
 				if (!newCommit) {
 					throw new Error(
 						`Artifacts repo "${source.repo_id}" has no published HEAD to reconcile.`,
 					)
-				}
-				if (newCommit === publishedCommit) {
-					return {
-						status: 'already_published',
-						published_commit: publishedCommit,
-						static_dependents: await getPublishStaticDependents({
-							db: ctx.env.APP_DB,
-							userId: user.userId,
-							sourceId: source.id,
-							publishedCommit,
-						}),
-					} as const
 				}
 				const sessionId =
 					attemptIndex === 0
@@ -291,8 +305,19 @@ export const publishExternalPushCapability = defineDomainCapability(
 						expectedHead: newCommit,
 						allowForce: args.allow_force,
 						baseUrl: ctx.callerContext.baseUrl,
+						rebuildPackageArtifacts: false,
 					})
 					if (result.status === 'already_published') {
+						if (result.published_commit) {
+							await rebuildPublishedPackageArtifactsForExternalPublish({
+								env: ctx.env,
+								sessionId,
+								sourceId: source.id,
+								userId: user.userId,
+								publishedCommit: result.published_commit,
+								baseUrl: ctx.callerContext.baseUrl,
+							})
+						}
 						return {
 							...result,
 							static_dependents: await getPublishStaticDependents({
@@ -306,6 +331,14 @@ export const publishExternalPushCapability = defineDomainCapability(
 					if (result.status !== 'published') {
 						return result
 					}
+					await rebuildPublishedPackageArtifactsForExternalPublish({
+						env: ctx.env,
+						sessionId,
+						sourceId: source.id,
+						userId: user.userId,
+						publishedCommit: result.published_commit,
+						baseUrl: ctx.callerContext.baseUrl,
+					})
 					return {
 						...result,
 						static_dependents: await getPublishStaticDependents({

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -282,16 +282,19 @@ export const publishExternalPushCapability = defineDomainCapability(
 						rebuildPackageArtifacts: false,
 					})
 					if (result.status === 'already_published') {
-						if (result.published_commit) {
-							await rebuildPublishedPackageArtifactsViaRepoSession({
-								env: ctx.env,
-								rpcSessionId: sessionId,
-								sourceId: source.id,
-								userId: user.userId,
-								publishedCommit: result.published_commit,
-								baseUrl: ctx.callerContext.baseUrl,
-							})
+						if (!result.published_commit) {
+							throw new Error(
+								`Package "${packageId}" is already published, but no published commit is available to rebuild artifacts.`,
+							)
 						}
+						await rebuildPublishedPackageArtifactsViaRepoSession({
+							env: ctx.env,
+							rpcSessionId: sessionId,
+							sourceId: source.id,
+							userId: user.userId,
+							publishedCommit: result.published_commit,
+							baseUrl: ctx.callerContext.baseUrl,
+						})
 						return {
 							...result,
 							static_dependents: await getPublishStaticDependents({

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -17,10 +17,7 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 			userId: input.userId,
 		})
 		for (const target of targets) {
-			await repoSessionRpc(
-				input.env,
-				input.rpcSessionId,
-			).rebuildPublishedPackageArtifact({
+			await session.rebuildPublishedPackageArtifact({
 				sessionId: input.repoSessionId,
 				sourceId: input.sourceId,
 				userId: input.userId,

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -3,7 +3,7 @@ import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 	env: Env
 	rpcSessionId: string
-	sessionId?: string
+	repoSessionId?: string
 	sourceId: string
 	userId: string
 	publishedCommit: string
@@ -12,7 +12,7 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 	try {
 		const session = repoSessionRpc(input.env, input.rpcSessionId)
 		const targets = await session.listPublishedPackageArtifactTargets({
-			sessionId: input.sessionId,
+			sessionId: input.repoSessionId,
 			sourceId: input.sourceId,
 			userId: input.userId,
 		})
@@ -21,7 +21,7 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 				input.env,
 				input.rpcSessionId,
 			).rebuildPublishedPackageArtifact({
-				sessionId: input.sessionId,
+				sessionId: input.repoSessionId,
 				sourceId: input.sourceId,
 				userId: input.userId,
 				publishedCommit: input.publishedCommit,

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -1,0 +1,31 @@
+import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
+
+export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
+	env: Env
+	rpcSessionId: string
+	sessionId?: string
+	sourceId: string
+	userId: string
+	publishedCommit: string
+	baseUrl: string
+}) {
+	const session = repoSessionRpc(input.env, input.rpcSessionId)
+	const targets = await session.listPublishedPackageArtifactTargets({
+		sessionId: input.sessionId,
+		sourceId: input.sourceId,
+		userId: input.userId,
+	})
+	for (const target of targets) {
+		await repoSessionRpc(
+			input.env,
+			input.rpcSessionId,
+		).rebuildPublishedPackageArtifact({
+			sessionId: input.sessionId,
+			sourceId: input.sourceId,
+			userId: input.userId,
+			publishedCommit: input.publishedCommit,
+			target,
+			baseUrl: input.baseUrl,
+		})
+	}
+}

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -9,23 +9,30 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 	publishedCommit: string
 	baseUrl: string
 }) {
-	const session = repoSessionRpc(input.env, input.rpcSessionId)
-	const targets = await session.listPublishedPackageArtifactTargets({
-		sessionId: input.sessionId,
-		sourceId: input.sourceId,
-		userId: input.userId,
-	})
-	for (const target of targets) {
-		await repoSessionRpc(
-			input.env,
-			input.rpcSessionId,
-		).rebuildPublishedPackageArtifact({
+	try {
+		const session = repoSessionRpc(input.env, input.rpcSessionId)
+		const targets = await session.listPublishedPackageArtifactTargets({
 			sessionId: input.sessionId,
 			sourceId: input.sourceId,
 			userId: input.userId,
-			publishedCommit: input.publishedCommit,
-			target,
-			baseUrl: input.baseUrl,
 		})
+		for (const target of targets) {
+			await repoSessionRpc(
+				input.env,
+				input.rpcSessionId,
+			).rebuildPublishedPackageArtifact({
+				sessionId: input.sessionId,
+				sourceId: input.sourceId,
+				userId: input.userId,
+				publishedCommit: input.publishedCommit,
+				target,
+				baseUrl: input.baseUrl,
+			})
+		}
+	} catch (error) {
+		throw new Error(
+			`Package source publish succeeded, but bundle artifact rebuild failed for source "${input.sourceId}" at commit "${input.publishedCommit}". Re-run the publish capability to repair artifacts.`,
+			{ cause: error },
+		)
 	}
 }

--- a/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
@@ -6,6 +6,7 @@ import {
 	repoPublishSessionOutputSchema,
 	repoSessionIdSchema,
 } from './repo-shared.ts'
+import { rebuildPublishedPackageArtifactsViaRepoSession } from './package-artifact-rebuild.ts'
 
 export const repoPublishSessionCapability = defineDomainCapability(
 	capabilityDomainNames.repo,
@@ -21,14 +22,28 @@ export const repoPublishSessionCapability = defineDomainCapability(
 		outputSchema: repoPublishSessionOutputSchema,
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
-			const result = await repoSessionRpc(
-				ctx.env,
-				args.session_id,
-			).publishSession({
+			const session = repoSessionRpc(ctx.env, args.session_id)
+			const sessionInfo = await session.getSessionInfo({
 				sessionId: args.session_id,
 				userId: user.userId,
 			})
+			const result = await session.publishSession({
+				sessionId: args.session_id,
+				userId: user.userId,
+				rebuildPackageArtifacts: false,
+			})
 			if (result.status === 'ok') {
+				if (sessionInfo.entity_type === 'package') {
+					await rebuildPublishedPackageArtifactsViaRepoSession({
+						env: ctx.env,
+						rpcSessionId: args.session_id,
+						sessionId: args.session_id,
+						sourceId: sessionInfo.source_id,
+						userId: user.userId,
+						publishedCommit: result.publishedCommit,
+						baseUrl: ctx.callerContext.baseUrl,
+					})
+				}
 				return {
 					status: 'ok' as const,
 					session_id: result.sessionId,

--- a/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
@@ -37,7 +37,7 @@ export const repoPublishSessionCapability = defineDomainCapability(
 					await rebuildPublishedPackageArtifactsViaRepoSession({
 						env: ctx.env,
 						rpcSessionId: args.session_id,
-						sessionId: args.session_id,
+						repoSessionId: args.session_id,
 						sourceId: sessionInfo.source_id,
 						userId: user.userId,
 						publishedCommit: result.publishedCommit,

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
@@ -116,7 +116,7 @@ export const repoRunCommandsCapability = defineDomainCapability(
 				await rebuildPublishedPackageArtifactsViaRepoSession({
 					env: ctx.env,
 					rpcSessionId: validatedSession.id,
-					sessionId: validatedSession.id,
+					repoSessionId: validatedSession.id,
 					sourceId: validatedSession.source_id,
 					userId: user.userId,
 					publishedCommit: publish.publishedCommit,

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
@@ -87,25 +87,27 @@ export const repoRunCommandsCapability = defineDomainCapability(
 				runChecks: args.run_checks,
 				publish: false,
 			})
-			const publish =
-				args.publish === true
-					? result.checks.status === 'failed'
-						? {
-								status: 'blocked_by_checks' as const,
-								message: 'Publishing skipped because repo checks failed.',
-								failedChecks: result.checks.failedChecks,
-								runId: result.checks.runId,
-								treeHash: result.checks.treeHash,
-								checkedAt: result.checks.checkedAt,
-							}
-						: result.checks.status === 'passed'
-							? await sessionRpc.publishSession({
-									sessionId: validatedSession.id,
-									userId: user.userId,
-									rebuildPackageArtifacts: false,
-								})
-							: { status: 'not_requested' as const }
-					: result.publish
+			let publish = result.publish
+			if (args.publish === true) {
+				if (result.checks.status === 'failed') {
+					publish = {
+						status: 'blocked_by_checks' as const,
+						message: 'Publishing skipped because repo checks failed.',
+						failedChecks: result.checks.failedChecks,
+						runId: result.checks.runId,
+						treeHash: result.checks.treeHash,
+						checkedAt: result.checks.checkedAt,
+					}
+				} else if (result.checks.status === 'passed') {
+					publish = await sessionRpc.publishSession({
+						sessionId: validatedSession.id,
+						userId: user.userId,
+						rebuildPackageArtifacts: false,
+					})
+				} else {
+					publish = { status: 'not_requested' as const }
+				}
+			}
 			if (
 				args.publish === true &&
 				publish.status === 'ok' &&

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
@@ -16,6 +16,35 @@ import { repoOpenSessionCapability } from './repo-open-session.ts'
 
 type RepoRunCommandsOutput = z.infer<typeof repoRunCommandsOutputSchema>
 
+async function rebuildPublishedPackageArtifactsForSession(input: {
+	env: Env
+	sessionId: string
+	sourceId: string
+	userId: string
+	publishedCommit: string
+	baseUrl: string
+}) {
+	const session = repoSessionRpc(input.env, input.sessionId)
+	const targets = await session.listPublishedPackageArtifactTargets({
+		sessionId: input.sessionId,
+		sourceId: input.sourceId,
+		userId: input.userId,
+	})
+	for (const target of targets) {
+		await repoSessionRpc(
+			input.env,
+			input.sessionId,
+		).rebuildPublishedPackageArtifact({
+			sessionId: input.sessionId,
+			sourceId: input.sourceId,
+			userId: input.userId,
+			publishedCommit: input.publishedCommit,
+			target,
+			baseUrl: input.baseUrl,
+		})
+	}
+}
+
 async function loadRepoCommandSession(input: {
 	env: Env
 	userId: string
@@ -77,23 +106,60 @@ export const repoRunCommandsCapability = defineDomainCapability(
 							sessionId: args.session_id,
 						})
 			const validatedSession = repoOpenSessionOutputSchema.parse(session)
-			const result = await repoSessionRpc(
-				ctx.env,
-				validatedSession.id,
-			).runCommands({
+			const sessionRpc = repoSessionRpc(ctx.env, validatedSession.id)
+			const result = await sessionRpc.runCommands({
 				sessionId: validatedSession.id,
 				userId: user.userId,
 				commands: args.commands,
 				dryRun: args.dry_run,
 				runChecks: args.run_checks,
-				publish: args.publish,
+				publish: false,
 			})
+			const publish =
+				args.publish === true
+					? result.checks.status === 'failed'
+						? {
+								status: 'blocked_by_checks' as const,
+								message: 'Publishing skipped because repo checks failed.',
+								failedChecks: result.checks.failedChecks,
+								runId: result.checks.runId,
+								treeHash: result.checks.treeHash,
+								checkedAt: result.checks.checkedAt,
+							}
+						: result.checks.status === 'passed'
+							? await sessionRpc.publishSession({
+									sessionId: validatedSession.id,
+									userId: user.userId,
+								})
+							: { status: 'not_requested' as const }
+					: result.publish
+			if (
+				args.publish === true &&
+				publish.status === 'ok' &&
+				validatedSession.entity_type === 'package'
+			) {
+				await rebuildPublishedPackageArtifactsForSession({
+					env: ctx.env,
+					sessionId: validatedSession.id,
+					sourceId: validatedSession.source_id,
+					userId: user.userId,
+					publishedCommit: publish.publishedCommit,
+					baseUrl: ctx.callerContext.baseUrl,
+				})
+			}
+			const responseSession =
+				args.publish === true && publish.status === 'ok'
+					? await sessionRpc.getSessionInfo({
+							sessionId: validatedSession.id,
+							userId: user.userId,
+						})
+					: result.session
 			return {
-				session: result.session,
+				session: responseSession,
 				resolved_target: validatedSession.resolved_target,
 				commands: result.commands,
 				checks: normalizeRepoCommandChecks(result.checks),
-				publish: normalizeRepoCommandPublish(result.publish),
+				publish: normalizeRepoCommandPublish(publish),
 			}
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
@@ -13,37 +13,9 @@ import {
 	repoRunCommandsOutputSchema,
 } from './repo-shared.ts'
 import { repoOpenSessionCapability } from './repo-open-session.ts'
+import { rebuildPublishedPackageArtifactsViaRepoSession } from './package-artifact-rebuild.ts'
 
 type RepoRunCommandsOutput = z.infer<typeof repoRunCommandsOutputSchema>
-
-async function rebuildPublishedPackageArtifactsForSession(input: {
-	env: Env
-	sessionId: string
-	sourceId: string
-	userId: string
-	publishedCommit: string
-	baseUrl: string
-}) {
-	const session = repoSessionRpc(input.env, input.sessionId)
-	const targets = await session.listPublishedPackageArtifactTargets({
-		sessionId: input.sessionId,
-		sourceId: input.sourceId,
-		userId: input.userId,
-	})
-	for (const target of targets) {
-		await repoSessionRpc(
-			input.env,
-			input.sessionId,
-		).rebuildPublishedPackageArtifact({
-			sessionId: input.sessionId,
-			sourceId: input.sourceId,
-			userId: input.userId,
-			publishedCommit: input.publishedCommit,
-			target,
-			baseUrl: input.baseUrl,
-		})
-	}
-}
 
 async function loadRepoCommandSession(input: {
 	env: Env
@@ -130,6 +102,7 @@ export const repoRunCommandsCapability = defineDomainCapability(
 							? await sessionRpc.publishSession({
 									sessionId: validatedSession.id,
 									userId: user.userId,
+									rebuildPackageArtifacts: false,
 								})
 							: { status: 'not_requested' as const }
 					: result.publish
@@ -138,8 +111,9 @@ export const repoRunCommandsCapability = defineDomainCapability(
 				publish.status === 'ok' &&
 				validatedSession.entity_type === 'package'
 			) {
-				await rebuildPublishedPackageArtifactsForSession({
+				await rebuildPublishedPackageArtifactsViaRepoSession({
 					env: ctx.env,
+					rpcSessionId: validatedSession.id,
 					sessionId: validatedSession.id,
 					sourceId: validatedSession.source_id,
 					userId: user.userId,

--- a/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
@@ -53,6 +53,8 @@ function createRepoRpc(overrides?: Partial<Record<string, unknown>>) {
 		runCommands: vi.fn(),
 		runChecks: vi.fn(),
 		publishSession: vi.fn(),
+		listPublishedPackageArtifactTargets: vi.fn(async () => []),
+		rebuildPublishedPackageArtifact: vi.fn(),
 		...overrides,
 	}
 }
@@ -399,7 +401,7 @@ test('repo_run_commands opens by target and returns failed checks without publis
 		commands,
 		dryRun: undefined,
 		runChecks: true,
-		publish: true,
+		publish: false,
 	})
 	expect(result.checks).toEqual({
 		status: 'failed',
@@ -424,6 +426,12 @@ test('repo_run_commands opens by target and returns failed checks without publis
 	expect(result.publish).toEqual({
 		status: 'blocked_by_checks',
 		message: 'Publishing skipped because repo checks failed.',
+		failed_checks: [
+			{ kind: 'typecheck', ok: false, message: 'Typecheck failed' },
+		],
+		run_id: 'check-1',
+		tree_hash: 'tree-1',
+		checked_at: '2026-04-18T00:02:00.000Z',
 	})
 })
 
@@ -510,13 +518,28 @@ test('repo_run_commands returns published result after checks pass', async () =>
 			treeHash: 'tree-1',
 			checkedAt: '2026-04-18T00:02:00.000Z',
 		},
-		publish: {
-			status: 'ok',
-			sessionId: 'session-existing',
-			publishedCommit: 'commit-published',
-			message: 'Published session.',
-		},
+		publish: { status: 'not_requested' },
 	})
+	rpc.publishSession.mockResolvedValueOnce({
+		status: 'ok',
+		sessionId: 'session-existing',
+		publishedCommit: 'commit-published',
+		message: 'Published session.',
+	})
+	rpc.listPublishedPackageArtifactTargets.mockResolvedValueOnce([
+		{
+			kind: 'module',
+			artifactName: '.',
+			entryPoint: 'src/index.ts',
+			bundleKind: 'module',
+		},
+		{
+			kind: 'importable-module',
+			artifactName: '.',
+			entryPoint: 'src/index.ts',
+			bundleKind: 'importable-module',
+		},
+	])
 	mockModule.repoSessionRpc.mockReturnValue(rpc)
 
 	const result = await repoRunCommandsCapability.handler(
@@ -549,6 +572,7 @@ test('repo_run_commands returns published result after checks pass', async () =>
 		published_commit: 'commit-published',
 		message: 'Published session.',
 	})
+	expect(rpc.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(2)
 })
 
 test('repo_publish_session returns structured base_moved repair details', async () => {

--- a/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
@@ -578,6 +578,25 @@ test('repo_run_commands returns published result after checks pass', async () =>
 test('repo_publish_session returns structured base_moved repair details', async () => {
 	resetMocks()
 	const rpc = createRepoRpc()
+	rpc.getSessionInfo.mockResolvedValueOnce({
+		id: 'session-1',
+		source_id: 'source-package-1',
+		source_root: '/',
+		base_commit: 'commit-old',
+		session_repo_id: 'session-repo-1',
+		session_repo_name: 'repo-package-1-session-1',
+		session_repo_namespace: 'default',
+		conversation_id: null,
+		last_checkpoint_commit: 'commit-old',
+		last_check_run_id: 'check-1',
+		last_check_tree_hash: 'tree-1',
+		expires_at: null,
+		created_at: '2026-04-18T00:01:00.000Z',
+		updated_at: '2026-04-18T00:02:00.000Z',
+		published_commit: 'commit-old',
+		manifest_path: 'package.json',
+		entity_type: 'package',
+	})
 	rpc.publishSession.mockResolvedValueOnce({
 		status: 'base_moved',
 		sessionId: 'session-1',
@@ -606,6 +625,77 @@ test('repo_publish_session returns structured base_moved repair details', async 
 		repair_hint: 'repo_rebase_session',
 		session_base_commit: 'commit-old',
 		current_published_commit: 'commit-new',
+	})
+})
+
+test('repo_publish_session rebuilds package artifacts after direct publish', async () => {
+	resetMocks()
+	const rpc = createRepoRpc()
+	rpc.getSessionInfo.mockResolvedValueOnce({
+		id: 'session-1',
+		source_id: 'source-package-1',
+		source_root: '/',
+		base_commit: 'commit-old',
+		session_repo_id: 'session-repo-1',
+		session_repo_name: 'repo-package-1-session-1',
+		session_repo_namespace: 'default',
+		conversation_id: null,
+		last_checkpoint_commit: 'commit-old',
+		last_check_run_id: 'check-1',
+		last_check_tree_hash: 'tree-1',
+		expires_at: null,
+		created_at: '2026-04-18T00:01:00.000Z',
+		updated_at: '2026-04-18T00:02:00.000Z',
+		published_commit: 'commit-old',
+		manifest_path: 'package.json',
+		entity_type: 'package',
+	})
+	rpc.publishSession.mockResolvedValueOnce({
+		status: 'ok',
+		sessionId: 'session-1',
+		publishedCommit: 'commit-new',
+		message: 'Published session.',
+	})
+	rpc.listPublishedPackageArtifactTargets.mockResolvedValueOnce([
+		{
+			kind: 'module',
+			artifactName: '.',
+			entryPoint: 'src/index.ts',
+			bundleKind: 'module',
+		},
+	])
+	mockModule.repoSessionRpc.mockReturnValue(rpc)
+
+	const result = await repoPublishSessionCapability.handler(
+		{
+			session_id: 'session-1',
+		},
+		createCapabilityContext(),
+	)
+
+	expect(result).toEqual({
+		status: 'ok',
+		session_id: 'session-1',
+		published_commit: 'commit-new',
+		message: 'Published session.',
+	})
+	expect(rpc.publishSession).toHaveBeenCalledWith({
+		sessionId: 'session-1',
+		userId: 'user-1',
+		rebuildPackageArtifacts: false,
+	})
+	expect(rpc.rebuildPublishedPackageArtifact).toHaveBeenCalledWith({
+		sessionId: 'session-1',
+		sourceId: 'source-package-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-new',
+		target: {
+			kind: 'module',
+			artifactName: '.',
+			entryPoint: 'src/index.ts',
+			bundleKind: 'module',
+		},
+		baseUrl: 'https://heykody.dev',
 	})
 })
 

--- a/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
@@ -699,6 +699,59 @@ test('repo_publish_session rebuilds package artifacts after direct publish', asy
 	})
 })
 
+test('repo_publish_session annotates post-publish artifact rebuild failures', async () => {
+	resetMocks()
+	const rpc = createRepoRpc()
+	rpc.getSessionInfo.mockResolvedValueOnce({
+		id: 'session-1',
+		source_id: 'source-package-1',
+		source_root: '/',
+		base_commit: 'commit-old',
+		session_repo_id: 'session-repo-1',
+		session_repo_name: 'repo-package-1-session-1',
+		session_repo_namespace: 'default',
+		conversation_id: null,
+		last_checkpoint_commit: 'commit-old',
+		last_check_run_id: 'check-1',
+		last_check_tree_hash: 'tree-1',
+		expires_at: null,
+		created_at: '2026-04-18T00:01:00.000Z',
+		updated_at: '2026-04-18T00:02:00.000Z',
+		published_commit: 'commit-old',
+		manifest_path: 'package.json',
+		entity_type: 'package',
+	})
+	rpc.publishSession.mockResolvedValueOnce({
+		status: 'ok',
+		sessionId: 'session-1',
+		publishedCommit: 'commit-new',
+		message: 'Published session.',
+	})
+	rpc.listPublishedPackageArtifactTargets.mockResolvedValueOnce([
+		{
+			kind: 'module',
+			artifactName: '.',
+			entryPoint: 'src/index.ts',
+			bundleKind: 'module',
+		},
+	])
+	rpc.rebuildPublishedPackageArtifact.mockRejectedValueOnce(
+		new Error('bundle too large'),
+	)
+	mockModule.repoSessionRpc.mockReturnValue(rpc)
+
+	await expect(
+		repoPublishSessionCapability.handler(
+			{
+				session_id: 'session-1',
+			},
+			createCapabilityContext(),
+		),
+	).rejects.toThrow(
+		'Package source publish succeeded, but bundle artifact rebuild failed',
+	)
+})
+
 test('repo_run_commands surfaces line-specific command parse errors', async () => {
 	resetMocks()
 	const rpc = createRepoRpc()

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -241,7 +241,6 @@ test('refreshSavedPackageProjection resyncs the job manager after syncing packag
 			createdAt: '2026-04-20T00:00:00.000Z',
 		}),
 		manifest,
-		files: { 'package.json': '{}' },
 		buildAppBundle: expect.any(Function),
 		buildModuleBundle: expect.any(Function),
 		buildImportableModuleBundle: expect.any(Function),

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -27,6 +27,7 @@ const mockModule = vi.hoisted(() => ({
 	insertSavedPackage: vi.fn(),
 	listSavedPackageServices: vi.fn(),
 	listJobRowsByUserId: vi.fn(),
+	loadPackageManifestBySourceId: vi.fn(),
 	loadPackageSourceBySourceId: vi.fn(),
 	packageServiceRpc: vi.fn(),
 	syncJobManagerAlarm: vi.fn(),
@@ -81,6 +82,8 @@ vi.mock('./repo.ts', () => ({
 }))
 
 vi.mock('./source.ts', () => ({
+	loadPackageManifestBySourceId: (...args: Array<unknown>) =>
+		mockModule.loadPackageManifestBySourceId(...args),
 	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
 		mockModule.loadPackageSourceBySourceId(...args),
 }))
@@ -270,6 +273,51 @@ test('refreshSavedPackageProjection resyncs the job manager after syncing packag
 	).toBeGreaterThan(
 		mockModule.syncPackageJobsForPackage.mock.invocationCallOrder[0],
 	)
+})
+
+test('refreshSavedPackageProjection omits files when artifact rebuild is skipped', async () => {
+	const env = createEnv()
+	const manifest = {
+		name: '@kentcdodds/shade-automation',
+		kody: {
+			id: 'shade-automation',
+			description: 'Shade automation package',
+		},
+	}
+	mockModule.loadPackageManifestBySourceId.mockResolvedValue({
+		source: {
+			id: 'source-1',
+			entity_id: 'package-1',
+			entity_kind: 'package',
+		},
+		manifest,
+	})
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: 'package-1',
+		userId: 'user-1',
+		name: '@kentcdodds/shade-automation',
+		kodyId: 'shade-automation',
+		description: 'Shade automation package',
+		tags: [],
+		searchText: null,
+		sourceId: 'source-1',
+		hasApp: false,
+		createdAt: '2026-04-20T00:00:00.000Z',
+		updatedAt: '2026-04-20T00:00:00.000Z',
+	})
+
+	const refreshed = await refreshSavedPackageProjection({
+		env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		packageId: 'package-1',
+		sourceId: 'source-1',
+		rebuildArtifacts: false,
+	})
+
+	expect(refreshed).not.toHaveProperty('files')
+	expect(mockModule.loadPackageSourceBySourceId).not.toHaveBeenCalled()
+	expect(mockModule.buildPublishedPackageArtifacts).not.toHaveBeenCalled()
 })
 
 test('deleteSavedPackageProjection resyncs the job manager after removing package jobs', async () => {

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -156,7 +156,6 @@ export async function refreshSavedPackageProjection(input: {
 			source: loaded.source,
 			savedPackage,
 			manifest: loaded.manifest,
-			files: loadedFiles,
 			buildAppBundle: async ({ entryPoint }) => {
 				const { buildKodyAppBundle } =
 					await import('#worker/package-runtime/module-graph.ts')

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -7,7 +7,10 @@ import {
 	insertSavedPackage,
 	updateSavedPackage,
 } from './repo.ts'
-import { loadPackageSourceBySourceId } from './source.ts'
+import {
+	loadPackageManifestBySourceId,
+	loadPackageSourceBySourceId,
+} from './source.ts'
 import {
 	type AuthoredPackageJson,
 	type SavedPackageRecord,
@@ -82,13 +85,22 @@ export async function refreshSavedPackageProjection(input: {
 	userId: string
 	packageId: string
 	sourceId: string
+	rebuildArtifacts?: boolean
 }) {
-	const loaded = await loadPackageSourceBySourceId({
-		env: input.env,
-		baseUrl: input.baseUrl,
-		userId: input.userId,
-		sourceId: input.sourceId,
-	})
+	const shouldRebuildArtifacts = input.rebuildArtifacts ?? true
+	const loaded = shouldRebuildArtifacts
+		? await loadPackageSourceBySourceId({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				sourceId: input.sourceId,
+			})
+		: await loadPackageManifestBySourceId({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				sourceId: input.sourceId,
+			})
 	const row = toSavedPackageInsertRow({
 		packageId: input.packageId,
 		userId: input.userId,
@@ -133,48 +145,54 @@ export async function refreshSavedPackageProjection(input: {
 		createdAt: existing?.createdAt ?? refreshedAt,
 		updatedAt: refreshedAt,
 	} satisfies SavedPackageRecord
-	await rebuildPublishedPackageArtifacts({
-		env: input.env,
-		userId: input.userId,
-		source: loaded.source,
-		savedPackage,
-		manifest: loaded.manifest,
-		files: loaded.files,
-		buildAppBundle: async ({ entryPoint }) => {
-			const { buildKodyAppBundle } =
-				await import('#worker/package-runtime/module-graph.ts')
-			return await buildKodyAppBundle({
-				env: input.env,
-				baseUrl: input.baseUrl,
-				userId: input.userId,
-				sourceFiles: loaded.files,
-				entryPoint,
-				cacheKey: null,
-			})
-		},
-		buildModuleBundle: async ({ entryPoint }) => {
-			const { buildKodyModuleBundle } =
-				await import('#worker/package-runtime/module-graph.ts')
-			return await buildKodyModuleBundle({
-				env: input.env,
-				baseUrl: input.baseUrl,
-				userId: input.userId,
-				sourceFiles: loaded.files,
-				entryPoint,
-			})
-		},
-		buildImportableModuleBundle: async ({ entryPoint }) => {
-			const { buildKodyImportableModuleBundle } =
-				await import('#worker/package-runtime/module-graph.ts')
-			return await buildKodyImportableModuleBundle({
-				env: input.env,
-				baseUrl: input.baseUrl,
-				userId: input.userId,
-				sourceFiles: loaded.files,
-				entryPoint,
-			})
-		},
-	})
+	const loadedFiles: Record<string, string> | null =
+		shouldRebuildArtifacts && 'files' in loaded
+			? (loaded.files as Record<string, string>)
+			: null
+	if (loadedFiles) {
+		await rebuildPublishedPackageArtifacts({
+			env: input.env,
+			userId: input.userId,
+			source: loaded.source,
+			savedPackage,
+			manifest: loaded.manifest,
+			files: loadedFiles,
+			buildAppBundle: async ({ entryPoint }) => {
+				const { buildKodyAppBundle } =
+					await import('#worker/package-runtime/module-graph.ts')
+				return await buildKodyAppBundle({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					userId: input.userId,
+					sourceFiles: loadedFiles,
+					entryPoint,
+					cacheKey: null,
+				})
+			},
+			buildModuleBundle: async ({ entryPoint }) => {
+				const { buildKodyModuleBundle } =
+					await import('#worker/package-runtime/module-graph.ts')
+				return await buildKodyModuleBundle({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					userId: input.userId,
+					sourceFiles: loadedFiles,
+					entryPoint,
+				})
+			},
+			buildImportableModuleBundle: async ({ entryPoint }) => {
+				const { buildKodyImportableModuleBundle } =
+					await import('#worker/package-runtime/module-graph.ts')
+				return await buildKodyImportableModuleBundle({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					userId: input.userId,
+					sourceFiles: loadedFiles,
+					entryPoint,
+				})
+			},
+		})
+	}
 	try {
 		await refreshPackageRetrieverManifestCache({
 			env: input.env,
@@ -239,7 +257,7 @@ export async function refreshSavedPackageProjection(input: {
 				updatedAt: new Date().toISOString(),
 			} satisfies SavedPackageRecord),
 		manifest: loaded.manifest,
-		files: loaded.files,
+		files: 'files' in loaded ? loaded.files : {},
 	}
 }
 

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -257,7 +257,7 @@ export async function refreshSavedPackageProjection(input: {
 				updatedAt: new Date().toISOString(),
 			} satisfies SavedPackageRecord),
 		manifest: loaded.manifest,
-		files: 'files' in loaded ? loaded.files : {},
+		...(loadedFiles ? { files: loadedFiles } : {}),
 	}
 }
 

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
@@ -128,14 +128,6 @@ test('rebuildPublishedPackageArtifacts bundles declared subscription handlers', 
 				},
 			},
 		},
-		files: {
-			'package.json': '{}',
-			'src/index.ts': 'export default async function run() { return "ok" }',
-			'src/on-email-received.ts':
-				'export default async function run() { return "received" }',
-			'src/on-email-quarantined.ts':
-				'export default async function run() { return "quarantined" }',
-		},
 		buildAppBundle,
 		buildModuleBundle,
 		buildImportableModuleBundle,
@@ -240,12 +232,6 @@ test('rebuildPublishedPackageArtifacts uses builder dependency metadata instead 
 				id: 'reachable-only',
 				description: 'Reachable-only dependency package',
 			},
-		},
-		files: {
-			'package.json': '{}',
-			'src/index.ts': 'export default async function run() { return "ok" }',
-			'src/dead.ts':
-				'import dead from "kody:@kentcdodds/missing-package"; export { dead }',
 		},
 		buildAppBundle,
 		buildModuleBundle,

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.ts
@@ -45,6 +45,34 @@ type PersistPublishedBundleArtifactInput = {
 	packageContext?: PublishedBundleArtifact['packageContext']
 }
 
+export type PublishedPackageArtifactBuildTarget = {
+	kind: BundleArtifactKind
+	artifactName?: string | null
+	entryPoint: string
+	bundleKind: 'app' | 'module' | 'importable-module'
+}
+
+type PublishedPackageArtifactBuilders = {
+	buildAppBundle: (args: { entryPoint: string }) => Promise<{
+		mainModule: string
+		modules: WorkerLoaderModules
+		dependencies: Array<BundleArtifactDependency>
+		dynamicDependencies?: Array<BundleArtifactDynamicDependency>
+	}>
+	buildModuleBundle: (args: { entryPoint: string }) => Promise<{
+		mainModule: string
+		modules: WorkerLoaderModules
+		dependencies: Array<BundleArtifactDependency>
+		dynamicDependencies?: Array<BundleArtifactDynamicDependency>
+	}>
+	buildImportableModuleBundle: (args: { entryPoint: string }) => Promise<{
+		mainModule: string
+		modules: WorkerLoaderModules
+		dependencies: Array<BundleArtifactDependency>
+		dynamicDependencies?: Array<BundleArtifactDynamicDependency>
+	}>
+}
+
 function normalizeArtifactName(artifactName: string | null | undefined) {
 	const trimmed = artifactName?.trim()
 	return trimmed && trimmed.length > 0 ? trimmed : null
@@ -191,171 +219,129 @@ export async function loadPublishedBundleArtifactByIdentity(input: {
 	}
 }
 
-export async function rebuildPublishedPackageArtifacts(input: {
-	env: Env
-	userId: string
-	source: EntitySourceRow
-	savedPackage: SavedPackageRecord
-	manifest: AuthoredPackageJson
-	files: Record<string, string>
-	buildAppBundle: (args: { entryPoint: string }) => Promise<{
-		mainModule: string
-		modules: WorkerLoaderModules
-		dependencies: Array<BundleArtifactDependency>
-		dynamicDependencies?: Array<BundleArtifactDynamicDependency>
-	}>
-	buildModuleBundle: (args: { entryPoint: string }) => Promise<{
-		mainModule: string
-		modules: WorkerLoaderModules
-		dependencies: Array<BundleArtifactDependency>
-		dynamicDependencies?: Array<BundleArtifactDynamicDependency>
-	}>
-	buildImportableModuleBundle: (args: { entryPoint: string }) => Promise<{
-		mainModule: string
-		modules: WorkerLoaderModules
-		dependencies: Array<BundleArtifactDependency>
-		dynamicDependencies?: Array<BundleArtifactDynamicDependency>
-	}>
-}) {
-	if (input.manifest.kody.app) {
-		const entryPoint = getPackageAppEntryPath(input.manifest)
+export function collectPublishedPackageArtifactTargets(
+	manifest: AuthoredPackageJson,
+) {
+	const targets: Array<PublishedPackageArtifactBuildTarget> = []
+	if (manifest.kody.app) {
+		const entryPoint = getPackageAppEntryPath(manifest)
 		if (entryPoint) {
-			const bundle = await input.buildAppBundle({ entryPoint })
-			await persistPublishedBundleArtifact({
-				env: input.env,
-				userId: input.userId,
-				source: input.source,
+			targets.push({
 				kind: 'app',
 				entryPoint,
-				mainModule: bundle.mainModule,
-				modules: bundle.modules,
-				dependencies: bundle.dependencies,
-				dynamicDependencies: bundle.dynamicDependencies,
-				packageContext: {
-					packageId: input.savedPackage.id,
-					kodyId: input.savedPackage.kodyId,
-					sourceId: input.savedPackage.sourceId,
-				},
+				bundleKind: 'app',
 			})
 		}
 	}
-	for (const service of listPackageServices(input.manifest)) {
-		const bundle = await input.buildModuleBundle({
-			entryPoint: service.entry,
-		})
-		await persistPublishedBundleArtifact({
-			env: input.env,
-			userId: input.userId,
-			source: input.source,
+	for (const service of listPackageServices(manifest)) {
+		targets.push({
 			kind: 'service',
 			artifactName: service.name,
 			entryPoint: service.entry,
-			mainModule: bundle.mainModule,
-			modules: bundle.modules,
-			dependencies: bundle.dependencies,
-			dynamicDependencies: bundle.dynamicDependencies,
-			packageContext: {
-				packageId: input.savedPackage.id,
-				kodyId: input.savedPackage.kodyId,
-				sourceId: input.savedPackage.sourceId,
-			},
+			bundleKind: 'module',
 		})
 	}
 	for (const [exportName, exportTarget] of Object.entries(
-		input.manifest.exports,
+		manifest.exports,
 	) as Array<[string, AuthoredPackageJson['exports'][string]]>) {
 		const entryPoint =
 			typeof exportTarget === 'string'
 				? exportTarget
 				: (exportTarget.import ?? exportTarget.default ?? null)
 		if (!entryPoint) continue
-		const bundle = await input.buildModuleBundle({
-			entryPoint,
-		})
-		await persistPublishedBundleArtifact({
-			env: input.env,
-			userId: input.userId,
-			source: input.source,
+		targets.push({
 			kind: 'module',
 			artifactName: exportName,
 			entryPoint,
-			mainModule: bundle.mainModule,
-			modules: bundle.modules,
-			dependencies: bundle.dependencies,
-			dynamicDependencies: bundle.dynamicDependencies,
-			packageContext: {
-				packageId: input.savedPackage.id,
-				kodyId: input.savedPackage.kodyId,
-				sourceId: input.savedPackage.sourceId,
-			},
+			bundleKind: 'module',
 		})
-		const importableBundle = await input.buildImportableModuleBundle({
-			entryPoint,
-		})
-		await persistPublishedBundleArtifact({
-			env: input.env,
-			userId: input.userId,
-			source: input.source,
+		targets.push({
 			kind: 'importable-module',
 			artifactName: exportName,
 			entryPoint,
-			mainModule: importableBundle.mainModule,
-			modules: importableBundle.modules,
-			dependencies: importableBundle.dependencies,
-			dynamicDependencies: importableBundle.dynamicDependencies,
-			packageContext: {
-				packageId: input.savedPackage.id,
-				kodyId: input.savedPackage.kodyId,
-				sourceId: input.savedPackage.sourceId,
-			},
+			bundleKind: 'importable-module',
 		})
 	}
-	for (const subscription of listPackageSubscriptions(input.manifest)) {
-		const bundle = await input.buildModuleBundle({
-			entryPoint: subscription.handler,
-		})
-		await persistPublishedBundleArtifact({
-			env: input.env,
-			userId: input.userId,
-			source: input.source,
+	for (const subscription of listPackageSubscriptions(manifest)) {
+		targets.push({
 			kind: 'module',
 			artifactName: buildPackageSubscriptionArtifactName(subscription.topic),
 			entryPoint: subscription.handler,
-			mainModule: bundle.mainModule,
-			modules: bundle.modules,
-			dependencies: bundle.dependencies,
-			dynamicDependencies: bundle.dynamicDependencies,
-			packageContext: {
-				packageId: input.savedPackage.id,
-				kodyId: input.savedPackage.kodyId,
-				sourceId: input.savedPackage.sourceId,
-			},
+			bundleKind: 'module',
 		})
 	}
 	for (const [jobName, jobDefinition] of Object.entries(
-		input.manifest.kody.jobs ?? {},
+		manifest.kody.jobs ?? {},
 	) as Array<
 		[string, NonNullable<AuthoredPackageJson['kody']['jobs']>[string]]
 	>) {
-		const bundle = await input.buildModuleBundle({
-			entryPoint: jobDefinition.entry,
-		})
-		await persistPublishedBundleArtifact({
-			env: input.env,
-			userId: input.userId,
-			source: input.source,
+		targets.push({
 			kind: 'job',
 			artifactName: jobName,
 			entryPoint: jobDefinition.entry,
-			mainModule: bundle.mainModule,
-			modules: bundle.modules,
-			dependencies: bundle.dependencies,
-			dynamicDependencies: bundle.dynamicDependencies,
-			packageContext: {
-				packageId: input.savedPackage.id,
-				kodyId: input.savedPackage.kodyId,
-				sourceId: input.savedPackage.sourceId,
-			},
+			bundleKind: 'module',
+		})
+	}
+	return targets
+}
+
+export async function persistPublishedPackageArtifactTarget(
+	input: {
+		env: Env
+		userId: string
+		source: EntitySourceRow
+		savedPackage: SavedPackageRecord
+		target: PublishedPackageArtifactBuildTarget
+	} & PublishedPackageArtifactBuilders,
+) {
+	const bundle =
+		input.target.bundleKind === 'app'
+			? await input.buildAppBundle({ entryPoint: input.target.entryPoint })
+			: input.target.bundleKind === 'importable-module'
+				? await input.buildImportableModuleBundle({
+						entryPoint: input.target.entryPoint,
+					})
+				: await input.buildModuleBundle({
+						entryPoint: input.target.entryPoint,
+					})
+	return await persistPublishedBundleArtifact({
+		env: input.env,
+		userId: input.userId,
+		source: input.source,
+		kind: input.target.kind,
+		artifactName: input.target.artifactName,
+		entryPoint: input.target.entryPoint,
+		mainModule: bundle.mainModule,
+		modules: bundle.modules,
+		dependencies: bundle.dependencies,
+		dynamicDependencies: bundle.dynamicDependencies,
+		packageContext: {
+			packageId: input.savedPackage.id,
+			kodyId: input.savedPackage.kodyId,
+			sourceId: input.savedPackage.sourceId,
+		},
+	})
+}
+
+export async function rebuildPublishedPackageArtifacts(
+	input: {
+		env: Env
+		userId: string
+		source: EntitySourceRow
+		savedPackage: SavedPackageRecord
+		manifest: AuthoredPackageJson
+	} & PublishedPackageArtifactBuilders,
+) {
+	for (const target of collectPublishedPackageArtifactTargets(input.manifest)) {
+		await persistPublishedPackageArtifactTarget({
+			env: input.env,
+			userId: input.userId,
+			source: input.source,
+			savedPackage: input.savedPackage,
+			target,
+			buildAppBundle: input.buildAppBundle,
+			buildModuleBundle: input.buildModuleBundle,
+			buildImportableModuleBundle: input.buildImportableModuleBundle,
 		})
 	}
 }

--- a/packages/worker/src/repo/external-publish.ts
+++ b/packages/worker/src/repo/external-publish.ts
@@ -22,6 +22,7 @@ export type FinalizePublishedSourceInput = {
 	publishedCommit: string
 	files: Record<string, string>
 	baseUrl?: string
+	rebuildPackageArtifacts?: boolean
 }
 
 export async function finalizePublishedEntitySource(
@@ -77,6 +78,7 @@ export async function finalizePublishedEntitySource(
 				userId: input.source.user_id,
 				packageId: input.source.entity_id,
 				sourceId: input.source.id,
+				rebuildArtifacts: input.rebuildPackageArtifacts ?? true,
 			})
 		} catch (projectionError) {
 			Sentry.captureException(projectionError, {
@@ -115,6 +117,7 @@ export async function publishFromExternalRef(input: {
 	manifestPath?: string
 	sourceRoot?: string
 	runId?: string
+	rebuildPackageArtifacts?: boolean
 }): Promise<RepoExternalPublishResult> {
 	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
 	if (!source || source.user_id !== input.userId) {
@@ -164,6 +167,7 @@ export async function publishFromExternalRef(input: {
 		publishedCommit: input.newCommit,
 		files: input.files ?? checks.sourceFiles,
 		baseUrl: input.baseUrl,
+		rebuildPackageArtifacts: input.rebuildPackageArtifacts,
 	})
 	return {
 		status: 'published',

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -1441,6 +1441,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		sessionId: string
 		userId: string
 		force?: boolean
+		rebuildPackageArtifacts?: boolean
 	}): Promise<RepoSessionPublishResult> {
 		const { sessionRow, source, sessionAccess } = await this.getSessionState(
 			input.sessionId,
@@ -1515,7 +1516,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			publishedCommit: sessionHeadCommit ?? sessionRow.base_commit,
 			files: snapshotFiles,
 			baseUrl: source.source_root,
-			rebuildPackageArtifacts: false,
+			rebuildPackageArtifacts: input.rebuildPackageArtifacts ?? true,
 		})
 		await updateRepoSession(this.env.APP_DB, {
 			id: sessionRow.id,

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -25,6 +25,12 @@ import {
 import { buildSentryOptions } from '#worker/sentry-options.ts'
 import { getEntitySourceById, updateEntitySource } from './entity-sources.ts'
 import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
+import { getSavedPackageById } from '#worker/package-registry/repo.ts'
+import {
+	collectPublishedPackageArtifactTargets,
+	persistPublishedPackageArtifactTarget,
+	type PublishedPackageArtifactBuildTarget,
+} from '#worker/package-runtime/published-bundle-artifacts.ts'
 import { searchRepoWorkspace } from './repo-session-search.ts'
 import { repoSessionRpc as createRepoSessionRpc } from './repo-session-rpc.ts'
 import {
@@ -481,6 +487,39 @@ class RepoSessionBase extends DurableObject<Env> {
 				ok: null,
 				results: null,
 			}
+		)
+	}
+
+	private async resolvePublishSource(input: {
+		sessionId?: string
+		sourceId?: string
+		userId: string
+	}) {
+		if (input.sessionId) {
+			const { source } = await this.getSessionState(
+				input.sessionId,
+				input.userId,
+			)
+			return source
+		}
+		if (!input.sourceId) {
+			throw new Error('A sessionId or sourceId is required.')
+		}
+		const source = await getEntitySourceById(this.env.APP_DB, input.sourceId)
+		if (!source || source.user_id !== input.userId) {
+			throw new Error('Repo source was not found for this user.')
+		}
+		return source
+	}
+
+	private async listPackageArtifactTargetsForSource(source: EntitySourceRow) {
+		if (source.entity_kind !== 'package') return []
+		const manifest = await this.readManifestFromWorkspace(
+			source.manifest_path,
+			source.entity_kind,
+		)
+		return collectPublishedPackageArtifactTargets(
+			manifest as Parameters<typeof collectPublishedPackageArtifactTargets>[0],
 		)
 	}
 
@@ -1228,6 +1267,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			baseUrl: source.source_root,
 			userId: input.userId,
 		})
+		const { sourceFiles: _sourceFiles, ...publicResult } = result
 		const runId = crypto.randomUUID()
 		const treeHash = await this.computeTreeHash()
 		const checkedAt = nowIso()
@@ -1242,15 +1282,15 @@ class RepoSessionBase extends DurableObject<Env> {
 			runId,
 			treeHash,
 			checkedAt,
-			ok: result.ok,
-			results: result.results.map((entry) => ({
+			ok: publicResult.ok,
+			results: publicResult.results.map((entry) => ({
 				kind: entry.kind,
 				ok: entry.ok,
 				message: entry.message,
 			})),
 		})
 		return {
-			...result,
+			...publicResult,
 			runId,
 			treeHash,
 			checkedAt,
@@ -1260,6 +1300,89 @@ class RepoSessionBase extends DurableObject<Env> {
 	async getCheckStatus(input: { sessionId: string; userId: string }) {
 		await this.getSessionState(input.sessionId, input.userId)
 		return this.readCheckStatus()
+	}
+
+	async listPublishedPackageArtifactTargets(input: {
+		sessionId?: string
+		sourceId?: string
+		userId: string
+	}): Promise<Array<PublishedPackageArtifactBuildTarget>> {
+		const source = await this.resolvePublishSource(input)
+		return await this.listPackageArtifactTargetsForSource(source)
+	}
+
+	async rebuildPublishedPackageArtifact(input: {
+		sessionId?: string
+		sourceId?: string
+		userId: string
+		publishedCommit: string
+		target: PublishedPackageArtifactBuildTarget
+		baseUrl?: string
+	}): Promise<{
+		ok: true
+		target: PublishedPackageArtifactBuildTarget
+		kvKey: string | null
+	}> {
+		const source = await this.resolvePublishSource(input)
+		if (source.entity_kind !== 'package') {
+			throw new Error(
+				'Published bundle artifacts can only be rebuilt for packages.',
+			)
+		}
+		const savedPackage = await getSavedPackageById(this.env.APP_DB, {
+			userId: input.userId,
+			packageId: source.entity_id,
+		})
+		if (!savedPackage) {
+			throw new Error(`Saved package "${source.entity_id}" was not found.`)
+		}
+		const sourceFiles = await this.collectWorkspaceFiles()
+		const sourceAtPublishedCommit = {
+			...source,
+			published_commit: input.publishedCommit,
+		}
+		const {
+			buildKodyAppBundle,
+			buildKodyModuleBundle,
+			buildKodyImportableModuleBundle,
+		} = await import('#worker/package-runtime/module-graph.ts')
+		const kvKey = await persistPublishedPackageArtifactTarget({
+			env: this.env,
+			userId: input.userId,
+			source: sourceAtPublishedCommit,
+			savedPackage,
+			target: input.target,
+			buildAppBundle: async ({ entryPoint }) =>
+				await buildKodyAppBundle({
+					env: this.env,
+					baseUrl: input.baseUrl ?? source.source_root,
+					userId: input.userId,
+					sourceFiles,
+					entryPoint,
+					cacheKey: null,
+				}),
+			buildModuleBundle: async ({ entryPoint }) =>
+				await buildKodyModuleBundle({
+					env: this.env,
+					baseUrl: input.baseUrl ?? source.source_root,
+					userId: input.userId,
+					sourceFiles,
+					entryPoint,
+				}),
+			buildImportableModuleBundle: async ({ entryPoint }) =>
+				await buildKodyImportableModuleBundle({
+					env: this.env,
+					baseUrl: input.baseUrl ?? source.source_root,
+					userId: input.userId,
+					sourceFiles,
+					entryPoint,
+				}),
+		})
+		return {
+			ok: true,
+			target: input.target,
+			kvKey,
+		}
 	}
 
 	async rebaseSession(input: {
@@ -1392,6 +1515,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			publishedCommit: sessionHeadCommit ?? sessionRow.base_commit,
 			files: snapshotFiles,
 			baseUrl: source.source_root,
+			rebuildPackageArtifacts: false,
 		})
 		await updateRepoSession(this.env.APP_DB, {
 			id: sessionRow.id,
@@ -1417,6 +1541,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		expectedHead?: string | null
 		allowForce?: boolean
 		baseUrl?: string
+		rebuildPackageArtifacts?: boolean
 	}): Promise<RepoExternalPublishResult> {
 		const source = await getEntitySourceById(this.env.APP_DB, input.sourceId)
 		if (!source || source.user_id !== input.userId) {
@@ -1478,6 +1603,7 @@ class RepoSessionBase extends DurableObject<Env> {
 				source.source_root || repoSessionWorkspacePrefix,
 				repoSessionWorkspacePrefix,
 			),
+			rebuildPackageArtifacts: input.rebuildPackageArtifacts ?? true,
 		})
 	}
 }

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -121,6 +121,7 @@ export type RepoSessionRpc = {
 		sessionId: string
 		userId: string
 		force?: boolean
+		rebuildPackageArtifacts?: boolean
 	}) => Promise<RepoSessionPublishResult>
 	publishFromExternalRef: (payload: {
 		sessionId: string

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -1,4 +1,5 @@
 import { type ArtifactBootstrapAccess } from './artifacts.ts'
+import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtime/published-bundle-artifacts.ts'
 import { type RepoRunCommandsResult } from './repo-session-commands.ts'
 import {
 	type RepoSourceBootstrapResult,
@@ -95,6 +96,23 @@ export type RepoSessionRpc = {
 		sessionId: string
 		userId: string
 	}) => Promise<RepoSessionCheckStatus>
+	listPublishedPackageArtifactTargets: (payload: {
+		sessionId?: string
+		sourceId?: string
+		userId: string
+	}) => Promise<Array<PublishedPackageArtifactBuildTarget>>
+	rebuildPublishedPackageArtifact: (payload: {
+		sessionId?: string
+		sourceId?: string
+		userId: string
+		publishedCommit: string
+		target: PublishedPackageArtifactBuildTarget
+		baseUrl?: string
+	}) => Promise<{
+		ok: true
+		target: PublishedPackageArtifactBuildTarget
+		kvKey: string | null
+	}>
 	rebaseSession: (payload: {
 		sessionId: string
 		userId: string
@@ -112,6 +130,7 @@ export type RepoSessionRpc = {
 		expectedHead?: string | null
 		allowForce?: boolean
 		baseUrl?: string
+		rebuildPackageArtifacts?: boolean
 	}) => Promise<RepoExternalPublishResult>
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### Root cause

Large saved package publishes were doing too much work inside one `RepoSession` Durable Object invocation. The hot path ran checks, kept full `sourceFiles` snapshots reachable, wrote whole-source KV snapshots, refreshed package projection, and rebuilt every published bundle artifact in the same isolate. `repo_run_commands` also returned the full `sourceFiles` map from `runRepoChecks` through the DO RPC object before MCP output normalization discarded it. For large/multi-entrypoint packages such as `ai-chat` and `email-received-subscriber`, that stacked whole source trees, typecheck/bundle state, serialized snapshots, and bundle artifact module maps in one memory lifetime.

### Memory hotspots found

- `runRepoChecks` collects a full `Record<string, string>` source tree and builds a second worker-bundler snapshot from it.
- `RepoSession.runChecks` was spreading that full check result back to callers, so `sourceFiles` could be serialized over RPC even though public schemas do not expose it.
- `publishSession` collected the full workspace again after checks.
- `finalizePublishedEntitySource` advanced source metadata and then called `refreshSavedPackageProjection`, which loaded source again and rebuilt every package bundle artifact in the same DO publish invocation.
- External publish retry could observe an already-advanced commit and return `already_published` without repairing stale/missing bundle artifacts.

### Chosen design

- Strip `sourceFiles` before persisting/check-returning `RepoSession` check results, so large source trees are not serialized to MCP callers.
- Add reusable package artifact target planning (`collectPublishedPackageArtifactTargets`) and single-target persistence (`persistPublishedPackageArtifactTarget`).
- Let package projection refresh skip bundle rebuilding and load only the manifest when publish callers request `rebuildArtifacts: false`.
- Make the MCP publish paths (`repo_run_commands(... publish: true)` and `package_publish_external_push`) publish/finalize source metadata first, then rebuild saved-package artifacts one target at a time through separate `RepoSession` RPC invocations.
- Keep legacy inline rebuild behavior as the default for other callers (for example artifact reconcile jobs) unless they explicitly opt out.
- For `package_publish_external_push`, remove the early `already_published` shortcut: the capability now clones/prepares the workspace and rebuilds artifacts even when D1 already points at the current Artifacts HEAD. This gives operators a safe repair path for stale/missing bundles.

### Tests run

- `npx vitest run --project node-unit packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts packages/worker/src/repo/repo-session-do.node.test.ts packages/worker/src/repo/external-publish.node.test.ts && npm run typecheck`
- `npm run validate` (format, lint, typecheck, unit tests, Playwright E2E, MCP E2E all completed successfully)

### Operational steps after deploy

Re-run `package_publish_external_push` for the blocked packages, starting with `email-received-subscriber` (`2710d748-686c-4cfa-8425-6b34f7d204a3`) and `ai-chat`. It is now useful even if Artifacts HEAD already equals `published_commit`, because the already-published path rebuilds current bundle artifacts one target at a time. Then republish affected dependents (`discord-gateway`, `discord-general-chat`, `social-intelligence`, and other stale static dependents reported by the response) as needed so their static `kody:@` snapshots capture the refreshed dependency commits.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9568908d-e69a-4427-8204-057ab2a12ad1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9568908d-e69a-4427-8204-057ab2a12ad1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published package artifacts are rebuilt automatically after publish; can be opted out to skip rebuilds.
  * Added on-demand rebuild endpoint for published package artifacts and sequential rebuild processing.

* **Refactor**
  * Centralized artifact target collection and per-target build/persist flow for more consistent artifact generation.

* **Tests**
  * Expanded test coverage for publish + rebuild flows, retry behavior, error handling, and projection refresh without files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/440)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->