### PR TITLE
Surface package workflow and connector ingress failures

### DIFF
--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -469,6 +469,62 @@ test('DynamicCallableWorkflowBase restores attached remote connectors for packag
 	)
 })
 
+test('DynamicCallableWorkflowBase marks package export error responses as workflow errors', async () => {
+	const binding = createStatefulWorkflowBinding()
+	const db = createWorkflowRunsDatabase()
+	const env = {
+		APP_DB: db,
+		DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+		APP_BASE_URL: 'https://app.example.com',
+	} as Env
+	const created = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		packageContext: null,
+		body: {
+			packageId: 'pkg-1',
+			exportName: './workflow-run-event',
+			runAt: '2026-05-03T12:34:56.000Z',
+			idempotencyKey: 'package-error-response-smoke',
+			params: { key: 'west-sensitive-reopen' },
+		},
+	})
+	const queued = binding.instances.get(created.id)
+	if (!queued?.params) throw new Error('Expected queued workflow payload.')
+	invocationMocks.invokePackageExport.mockReset()
+	invocationMocks.invokePackageExport.mockResolvedValueOnce({
+		status: 500,
+		body: {
+			ok: false,
+			error: {
+				message:
+					'Shade workflow event failed: Tool "home_default_bond_shade_set_position" not found',
+			},
+		},
+	})
+
+	const workflow = new DynamicCallableWorkflowBase({} as ExecutionContext, env)
+	const stepDo = vi.fn(
+		async (_name: string, _config: unknown, callback: () => unknown) =>
+			await callback(),
+	)
+	await expect(
+		workflow.run(
+			{
+				payload: queued.params as never,
+				timestamp: new Date(),
+				instanceId: created.id,
+			},
+			{ sleepUntil: vi.fn(), do: stepDo } as unknown as WorkflowStep,
+		),
+	).rejects.toThrow('home_default_bond_shade_set_position')
+	expect(db.workflowRuns.get(created.id)).toMatchObject({
+		status: 'errored',
+		completed_at: expect.any(String),
+		last_error: expect.stringContaining('home_default_bond_shade_set_position'),
+	})
+})
+
 test('createDynamicCallableWorkflow verifies package ownership before queueing package exports', async () => {
 	const binding = createWorkflowBinding({ existing: null })
 	const db = createWorkflowRunsDatabase()

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -525,6 +525,56 @@ test('DynamicCallableWorkflowBase marks package export error responses as workfl
 	})
 })
 
+test('DynamicCallableWorkflowBase rejects package export redirect responses', async () => {
+	const binding = createStatefulWorkflowBinding()
+	const db = createWorkflowRunsDatabase()
+	const env = {
+		APP_DB: db,
+		DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+		APP_BASE_URL: 'https://app.example.com',
+	} as Env
+	const created = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		packageContext: null,
+		body: {
+			packageId: 'pkg-1',
+			exportName: './workflow-run-event',
+			runAt: '2026-05-03T12:34:56.000Z',
+			idempotencyKey: 'package-redirect-response-smoke',
+			params: { key: 'west-sensitive-reopen' },
+		},
+	})
+	const queued = binding.instances.get(created.id)
+	if (!queued?.params) throw new Error('Expected queued workflow payload.')
+	invocationMocks.invokePackageExport.mockReset()
+	invocationMocks.invokePackageExport.mockResolvedValueOnce({
+		status: 302,
+		body: { ok: false },
+	})
+
+	const workflow = new DynamicCallableWorkflowBase({} as ExecutionContext, env)
+	const stepDo = vi.fn(
+		async (_name: string, _config: unknown, callback: () => unknown) =>
+			await callback(),
+	)
+	await expect(
+		workflow.run(
+			{
+				payload: queued.params as never,
+				timestamp: new Date(),
+				instanceId: created.id,
+			},
+			{ sleepUntil: vi.fn(), do: stepDo } as unknown as WorkflowStep,
+		),
+	).rejects.toThrow('Package workflow export failed with HTTP 302.')
+	expect(db.workflowRuns.get(created.id)).toMatchObject({
+		status: 'errored',
+		completed_at: expect.any(String),
+		last_error: 'Package workflow export failed with HTTP 302.',
+	})
+})
+
 test('createDynamicCallableWorkflow verifies package ownership before queueing package exports', async () => {
 	const binding = createWorkflowBinding({ existing: null })
 	const db = createWorkflowRunsDatabase()

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -201,6 +201,24 @@ function toSerializableJson(value: unknown): JsonValue {
 	}
 }
 
+function getWorkflowInvocationErrorMessage(response: {
+	status: number
+	body: unknown
+}) {
+	const body = response.body
+	const error =
+		body && typeof body === 'object'
+			? (body as Record<string, unknown>)['error']
+			: null
+	const message =
+		error && typeof error === 'object'
+			? (error as Record<string, unknown>)['message']
+			: null
+	return typeof message === 'string' && message.trim()
+		? message
+		: `Package workflow export failed with HTTP ${response.status}.`
+}
+
 function normalizeNonEmptyString(value: string, fieldName: string) {
 	const trimmed = value.trim()
 	if (!trimmed) {
@@ -992,6 +1010,9 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 				topic: payload.workflowName,
 			},
 		})
+		if (response.status < 200 || response.status >= 400) {
+			throw new Error(getWorkflowInvocationErrorMessage(response))
+		}
 		return {
 			status: response.status,
 			body: toSerializableJson(response.body),

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -1010,7 +1010,7 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 				topic: payload.workflowName,
 			},
 		})
-		if (response.status < 200 || response.status >= 400) {
+		if (response.status < 200 || response.status >= 300) {
 			throw new Error(getWorkflowInvocationErrorMessage(response))
 		}
 		return {

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -99,7 +99,7 @@
 			"assets": {
 				"directory": "./public",
 				"binding": "ASSETS",
-				"run_worker_first": ["/mcp-apps/*", "/styles.css"],
+				"run_worker_first": ["/connectors/*", "/mcp-apps/*", "/styles.css"],
 			},
 			"durable_objects": {
 				"bindings": [
@@ -183,7 +183,7 @@
 			"assets": {
 				"directory": "./public",
 				"binding": "ASSETS",
-				"run_worker_first": ["/mcp-apps/*", "/styles.css"],
+				"run_worker_first": ["/connectors/*", "/mcp-apps/*", "/styles.css"],
 			},
 			"durable_objects": {
 				"bindings": [

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -267,7 +267,7 @@
 			"assets": {
 				"directory": "./public",
 				"binding": "ASSETS",
-				"run_worker_first": ["/mcp-apps/*", "/styles.css"],
+				"run_worker_first": ["/connectors/*", "/mcp-apps/*", "/styles.css"],
 			},
 			"durable_objects": {
 				"bindings": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Surface non-2xx package workflow export responses as workflow errors so failed package invocations do not appear complete.
- Route `/connectors/*` through the Worker before Cloudflare Assets in production, preview, and test so home connector websocket ingress reaches `RemoteConnectorSession` instead of the SPA shell.
- Rebased on `main` after the remote-connector workflow support landed there.

## Verification

- `npx oxfmt --check packages/worker/wrangler.jsonc packages/worker/src/package-runtime/package-workflows.ts packages/worker/src/package-runtime/package-workflows.node.test.ts`
- `npx vitest run --project node-unit packages/worker/src/package-runtime/package-workflows.node.test.ts`
- `npx vitest run --project workers-unit packages/worker/src/security/public-route-hardening.workers.test.ts`
- `npm run typecheck`
- `npm run build`
- Local Wrangler probe confirmed `ws://127.0.0.1:3742/connectors/home/default` opens and receives `{"type":"server.ping"}`, while plain HTTP returns 404.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1087d1f1-97dd-4622-8388-bd81513a081d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1087d1f1-97dd-4622-8388-bd81513a081d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test cases for error handling in package workflow execution, including failure scenarios with API errors and redirect responses.

* **Improvements**
  * Enhanced error messaging for workflow export failures with more descriptive feedback.
  * Updated routing configuration for connector request handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/442)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->