### PR TITLE
Fix connector asset routing deploy config

### DIFF
--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -5,10 +5,11 @@ audit for findings and rationale.
 
 ## Public connector routes are WebSocket-only
 
-The Worker entrypoint (`packages/worker/src/index.ts`) only forwards connector
-route requests (`/connectors/...`) when the request carries a `WebSocket`
-upgrade header. Non-upgrade HTTP requests are rejected with `404` before
-reaching the Durable Object.
+The Worker entrypoint (`packages/worker/src/index.ts`) only forwards user-scoped
+connector route requests (`/connectors/u/{userId}/{kind}/{instanceId}`) when the
+request carries a `WebSocket` upgrade header. Non-upgrade HTTP requests and
+unmatched `/connectors/*` paths are rejected with `404` before reaching static
+assets or the Durable Object.
 
 As a second layer, the remote connector session Durable Object `fetch()` handler
 rejects all non-WebSocket requests with `404`. Worker-internal callers use

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -216,6 +216,10 @@ const appHandler = withCors({
 			return stub.fetch(forwardRequest)
 		}
 
+		if (url.pathname.startsWith('/connectors/')) {
+			return new Response('Not Found', { status: 404 })
+		}
+
 		// Sandboxed widget iframes have an opaque origin, so JS/CSS loads become CORS fetches.
 		// ChatGPT/MCP Jam can render with sandbox="allow-scripts", which requires these headers.
 		if (

--- a/packages/worker/src/security/public-route-hardening.workers.test.ts
+++ b/packages/worker/src/security/public-route-hardening.workers.test.ts
@@ -53,6 +53,21 @@ test('user-scoped connector entrypoints reject unauthenticated HTTP access while
 	expect(websocketResponse.webSocket).toBeTruthy()
 })
 
+test('unmatched connector ingress paths do not fall through to the SPA shell', async () => {
+	const requests = [
+		createRequest('/connectors/home/default'),
+		createRequest('/connectors/home/default', {
+			headers: { Upgrade: 'websocket' },
+		}),
+	]
+
+	for (const request of requests) {
+		const response = await workerFetch(request)
+		expect(response.status).toBe(404)
+		await expect(response.text()).resolves.toBe('Not Found')
+	}
+})
+
 test('unknown maintenance endpoints return a consistent JSON 404 response', async () => {
 	const requests = [
 		createRequest('/__maintenance/reindex-skills', {

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 
 import { parseJsonc, writeGeneratedWranglerConfig } from './resource-utils.ts'
 
@@ -118,6 +118,57 @@ test('writeGeneratedWranglerConfig copies preview asset routing to the deployed 
 		expect(generatedConfig.assets?.run_worker_first).toContain('/connectors/*')
 		expect(generatedConfig.assets).toEqual(generatedConfig.env?.preview?.assets)
 	} finally {
+		await rm(tempDir, { force: true, recursive: true })
+	}
+})
+
+test('writeGeneratedWranglerConfig rejects invalid environment asset config', async () => {
+	const tempDir = await mkdtemp(path.join(os.tmpdir(), 'kody-resource-utils-'))
+	const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+		throw new Error('process.exit')
+	}) as typeof process.exit)
+	const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+	try {
+		const baseConfigPath = path.join(tempDir, 'wrangler.jsonc')
+		const outConfigPath = path.join(
+			tempDir,
+			'wrangler-production.generated.json',
+		)
+		await writeFile(
+			baseConfigPath,
+			JSON.stringify({
+				env: {
+					production: {
+						assets: [],
+						d1_databases: [{ binding: 'APP_DB' }],
+						kv_namespaces: [
+							{ binding: 'OAUTH_KV' },
+							{ binding: 'BUNDLE_ARTIFACTS_KV' },
+						],
+					},
+				},
+			}),
+			'utf8',
+		)
+
+		await expect(
+			writeGeneratedWranglerConfig({
+				baseConfigPath,
+				outConfigPath,
+				envName: 'production',
+				d1DatabaseName: 'kody',
+				d1DatabaseId: 'dry-run-kody',
+				oauthKvId: 'dry-run-kody-oauth',
+				bundleArtifactsKvId: 'dry-run-kody-bundle-artifacts',
+			}),
+		).rejects.toThrow('process.exit')
+		expect(error).toHaveBeenCalledWith(
+			`wrangler config "${baseConfigPath}" is missing "env.production.assets".`,
+		)
+	} finally {
+		exit.mockRestore()
+		error.mockRestore()
 		await rm(tempDir, { force: true, recursive: true })
 	}
 })

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -55,3 +55,69 @@ test('writeGeneratedWranglerConfig keeps migrations ordered by tag version', asy
 		await rm(tempDir, { force: true, recursive: true })
 	}
 })
+
+test('writeGeneratedWranglerConfig copies production asset routing to the deployed top-level config', async () => {
+	const tempDir = await mkdtemp(path.join(os.tmpdir(), 'kody-resource-utils-'))
+
+	try {
+		const outConfigPath = path.join(
+			tempDir,
+			'wrangler-production.generated.json',
+		)
+		await writeGeneratedWranglerConfig({
+			baseConfigPath: workerWranglerConfigPath,
+			outConfigPath,
+			envName: 'production',
+			d1DatabaseName: 'kody',
+			d1DatabaseId: 'dry-run-kody',
+			oauthKvId: 'dry-run-kody-oauth',
+			bundleArtifactsKvId: 'dry-run-kody-bundle-artifacts',
+		})
+
+		const generatedConfigText = await readFile(outConfigPath, 'utf8')
+		const generatedConfig = parseJsonc<{
+			assets?: { run_worker_first?: Array<string> }
+			env?: {
+				production?: { assets?: { run_worker_first?: Array<string> } }
+			}
+		}>(generatedConfigText)
+
+		expect(generatedConfig.assets?.run_worker_first).toContain('/connectors/*')
+		expect(generatedConfig.assets).toEqual(
+			generatedConfig.env?.production?.assets,
+		)
+	} finally {
+		await rm(tempDir, { force: true, recursive: true })
+	}
+})
+
+test('writeGeneratedWranglerConfig copies preview asset routing to the deployed top-level config', async () => {
+	const tempDir = await mkdtemp(path.join(os.tmpdir(), 'kody-resource-utils-'))
+
+	try {
+		const outConfigPath = path.join(tempDir, 'wrangler-preview.generated.json')
+		await writeGeneratedWranglerConfig({
+			baseConfigPath: workerWranglerConfigPath,
+			outConfigPath,
+			envName: 'preview',
+			workerName: 'kody-pr-123',
+			d1DatabaseName: 'kody-pr-123-db',
+			d1DatabaseId: 'dry-run-kody-pr-123-db',
+			oauthKvId: 'dry-run-kody-pr-123-oauth',
+			bundleArtifactsKvId: 'dry-run-kody-pr-123-bundle-artifacts',
+		})
+
+		const generatedConfigText = await readFile(outConfigPath, 'utf8')
+		const generatedConfig = parseJsonc<{
+			assets?: { run_worker_first?: Array<string> }
+			env?: {
+				preview?: { assets?: { run_worker_first?: Array<string> } }
+			}
+		}>(generatedConfigText)
+
+		expect(generatedConfig.assets?.run_worker_first).toContain('/connectors/*')
+		expect(generatedConfig.assets).toEqual(generatedConfig.env?.preview?.assets)
+	} finally {
+		await rm(tempDir, { force: true, recursive: true })
+	}
+})

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -314,6 +314,14 @@ export async function writeGeneratedWranglerConfig({
 		config.name = workerName
 	}
 
+	const targetAssets = (targetEnv as Record<string, unknown>).assets
+	if (!targetAssets || typeof targetAssets !== 'object') {
+		fail(
+			`wrangler config "${baseConfigPath}" is missing "env.${envName}.assets".`,
+		)
+	}
+	config.assets = { ...(targetAssets as Record<string, unknown>) }
+
 	const d1Databases = (targetEnv as Record<string, unknown>).d1_databases
 	if (!Array.isArray(d1Databases)) {
 		fail(

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -315,7 +315,11 @@ export async function writeGeneratedWranglerConfig({
 	}
 
 	const targetAssets = (targetEnv as Record<string, unknown>).assets
-	if (!targetAssets || typeof targetAssets !== 'object') {
+	if (
+		!targetAssets ||
+		typeof targetAssets !== 'object' ||
+		Array.isArray(targetAssets)
+	) {
 		fail(
 			`wrangler config "${baseConfigPath}" is missing "env.${envName}.assets".`,
 		)

--- a/tools/wrangler-env-config.node.test.ts
+++ b/tools/wrangler-env-config.node.test.ts
@@ -1,0 +1,44 @@
+import path from 'node:path'
+import { expect, test } from 'vitest'
+
+import {
+	defaultWranglerConfigPath,
+	getDefaultWranglerConfigPath,
+	resolveWranglerConfigPath,
+} from './wrangler-env-config.ts'
+
+test('getDefaultWranglerConfigPath defaults to the repository worker config', () => {
+	expect(getDefaultWranglerConfigPath({})).toBe(defaultWranglerConfigPath)
+})
+
+test('getDefaultWranglerConfigPath honors WRANGLER_CONFIG for deploy wrappers', () => {
+	expect(
+		getDefaultWranglerConfigPath({
+			WRANGLER_CONFIG:
+				'/workspace/packages/worker/wrangler-production.generated.json',
+		}),
+	).toBe('/workspace/packages/worker/wrangler-production.generated.json')
+})
+
+test('resolveWranglerConfigPath preserves absolute generated config paths', () => {
+	expect(
+		resolveWranglerConfigPath(
+			'/workspace/packages/worker/wrangler-production.generated.json',
+			'/workspace',
+		),
+	).toBe('/workspace/packages/worker/wrangler-production.generated.json')
+})
+
+test('resolveWranglerConfigPath resolves relative config paths from cwd', () => {
+	expect(
+		resolveWranglerConfigPath(
+			'packages/worker/wrangler-production.generated.json',
+			'/workspace',
+		),
+	).toBe(
+		path.join(
+			'/workspace',
+			'packages/worker/wrangler-production.generated.json',
+		),
+	)
+})

--- a/tools/wrangler-env-config.ts
+++ b/tools/wrangler-env-config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path'
+
+export const defaultWranglerConfigPath = 'packages/worker/wrangler.jsonc'
+
+export function getDefaultWranglerConfigPath(
+	env: Partial<Pick<NodeJS.ProcessEnv, 'WRANGLER_CONFIG'>> = process.env,
+) {
+	const configuredPath = env.WRANGLER_CONFIG?.trim()
+	return configuredPath || defaultWranglerConfigPath
+}
+
+export function resolveWranglerConfigPath(configPath: string, cwd: string) {
+	return path.isAbsolute(configPath) ? configPath : path.join(cwd, configPath)
+}

--- a/wrangler-env.ts
+++ b/wrangler-env.ts
@@ -10,11 +10,15 @@ import {
 	stopChildProcessTree,
 } from './tools/dev-process-utils.ts'
 import { resolveLocalBinary } from './tools/node-runtime.ts'
+import {
+	getDefaultWranglerConfigPath,
+	resolveWranglerConfigPath,
+} from './tools/wrangler-env-config.ts'
 
 const envName = process.env.CLOUDFLARE_ENV ?? 'production'
 const portWaitTimeoutMs = 5000
 const args = process.argv.slice(2)
-const defaultWranglerConfigPath = 'packages/worker/wrangler.jsonc'
+const defaultWranglerConfigPath = getDefaultWranglerConfigPath()
 
 const hasEnvFlag = args.includes('--env') || args.includes('-e')
 const isDevCommand = args[0] === 'dev'
@@ -30,7 +34,9 @@ const commandArgs = [...args]
 
 if (
 	!hasConfigFlag &&
-	existsSync(path.join(process.cwd(), defaultWranglerConfigPath))
+	existsSync(
+		resolveWranglerConfigPath(defaultWranglerConfigPath, process.cwd()),
+	)
 ) {
 	commandArgs.push('--config', defaultWranglerConfigPath)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Copy the selected env asset routing block into the generated top-level Wrangler config so production/preview deploy artifacts explicitly include `assets.run_worker_first` for `/connectors/*` at the shape Cloudflare Assets documents.
- Make `wrangler-env.ts` honor `WRANGLER_CONFIG`, so the pre-deploy build step in production/preview workflows uses the same generated config as the final deploy.
- Reject unmatched `/connectors/*` paths before the static asset / SPA fallback, while keeping user-scoped connector WebSocket ingress on `/connectors/u/{userId}/{kind}/{instanceId}`.

## Investigation notes
- Current production is deployed at `9545255df1c6dc930e9e179471dccdab2d7657af`.
- Live `/connectors/home/default` is a legacy, non-user-scoped path; current code recognizes `/connectors/u/{userId}/{kind}/{instanceId}`.
- Live user-scoped HTTP probe already returns 404 and user-scoped WebSocket probe returns `server.ping`, which shows `/connectors/*` is reaching the Worker; the unsafe part was unmatched connector paths falling through to the SPA shell.

## Evidence / commands
- `curl -sS "https://heykody.dev/health"` -> `{"ok":true,"commitSha":"9545255df1c6dc930e9e179471dccdab2d7657af"}`
- `curl -sS -D - -o /tmp/kody-prod-legacy-connector.html "https://heykody.dev/connectors/home/default"` -> current prod `HTTP/2 200`, `content-type: text/html; charset=UTF-8`
- `curl -sS -D - -o /tmp/kody-prod-user-scoped-connector.txt "https://heykody.dev/connectors/u/probe-user/home/default"` -> `HTTP/2 404`, `content-length: 9`
- `node --input-type=module -e "const ws = new WebSocket('wss://heykody.dev/connectors/u/probe-user/home/default'); const finish = (code) => { clearTimeout(timeout); try { ws.close(); } catch {} setTimeout(() => process.exit(code), 20); }; const timeout = setTimeout(() => { console.error('timeout waiting for websocket'); finish(1); }, 5000); ws.addEventListener('open', () => console.log('open')); ws.addEventListener('message', (event) => { console.log(String(event.data)); finish(0); }); ws.addEventListener('error', (event) => { console.error('websocket error', event.message ?? event.type); finish(1); });"` -> `open`, `{"type":"server.ping"}`
- `node tools/ci/production-resources.ts ensure --dry-run --out-config packages/worker/wrangler-production.generated.json && CLOUDFLARE_ENV=production WRANGLER_CONFIG=/workspace/packages/worker/wrangler-production.generated.json node --env-file=packages/worker/.env ./wrangler-env.ts deploy --dry-run --outdir /tmp/kody-wrangler-dry-run-after --var APP_COMMIT_SHA:dry-run` -> `env.ASSETS` binding present, production D1/KV dry-run IDs loaded, `--dry-run: exiting now.`
- `node tools/ci/preview-resources.ts ensure --dry-run --worker-name kody-pr-dry-run --out-config packages/worker/wrangler-preview.generated.json && CLOUDFLARE_ENV=preview WRANGLER_CONFIG=/workspace/packages/worker/wrangler-preview.generated.json node --env-file=packages/worker/.env ./wrangler-env.ts deploy --dry-run --name kody-pr-dry-run --outdir /tmp/kody-wrangler-preview-dry-run-after --var APP_COMMIT_SHA:dry-run` -> `env.ASSETS` binding present, preview D1/KV dry-run IDs loaded, `--dry-run: exiting now.`
- `npx vitest run --project node-unit tools/ci/resource-utils.node.test.ts tools/wrangler-env-config.node.test.ts` -> 2 files / 7 tests passed
- `npx vitest run --project workers-unit packages/worker/src/security/public-route-hardening.workers.test.ts` -> 1 file / 4 tests passed
- `npm run format:check` -> passed
- `npm run lint` -> passed with 4 existing warnings in unrelated files
- `npm run typecheck` -> passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-907d91a1-aa56-4a8c-aa11-9b44f50b94e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-907d91a1-aa56-4a8c-aa11-9b44f50b94e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Stricter rejection of unmatched connector requests, returning 404 for non-matching paths and non-WebSocket upgrades.

* **Documentation**
  * Clarified security guidance about when connector routes are forwarded and which requests are rejected.

* **Tests**
  * Added tests covering connector route hardening and config generation behavior.

* **Chores**
  * Improved Wrangler config resolution and related tooling tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/443)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->