### PR TITLE
Add current user info capability

### DIFF
--- a/packages/worker/src/mcp/capabilities/meta/domain.ts
+++ b/packages/worker/src/mcp/capabilities/meta/domain.ts
@@ -5,6 +5,7 @@ import { metaMemoryGetCapability } from './meta-memory-get.ts'
 import { metaMemorySearchCapability } from './meta-memory-search.ts'
 import { metaMemoryUpsertCapability } from './meta-memory-upsert.ts'
 import { metaMemoryVerifyCapability } from './meta-memory-verify.ts'
+import { metaGetCurrentUserCapability } from './meta-get-current-user.ts'
 import { metaListRemoteConnectorStatusCapability } from './meta-list-remote-connector-status.ts'
 import { metaGetMcpServerInstructionsCapability } from './meta-get-mcp-server-instructions.ts'
 import { executeCapability } from './execute.ts'
@@ -21,6 +22,7 @@ export const metaDomain = defineDomain({
 		searchCapability,
 		executeCapability,
 		metaListCapabilitiesCapability,
+		metaGetCurrentUserCapability,
 		metaGetMcpServerInstructionsCapability,
 		metaSetMcpServerInstructionsCapability,
 		metaListRemoteConnectorStatusCapability,

--- a/packages/worker/src/mcp/capabilities/meta/meta-get-current-user.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-get-current-user.node.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { capabilitySpecs } from '#mcp/capabilities/registry.ts'
+import { metaGetCurrentUserCapability } from './meta-get-current-user.ts'
+
+test('meta_get_current_user returns safe signed-in user identity fields', async () => {
+	const result = await metaGetCurrentUserCapability.handler(
+		{},
+		{
+			env: {} as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				user: {
+					userId: 'user-1',
+					email: 'user@example.com',
+					displayName: 'Ada Lovelace',
+				},
+			}),
+		},
+	)
+
+	expect(result).toEqual({
+		user_id: 'user-1',
+		email: 'user@example.com',
+		display_name: 'Ada Lovelace',
+	})
+})
+
+test('meta_get_current_user requires an authenticated MCP user', async () => {
+	await expect(
+		metaGetCurrentUserCapability.handler(
+			{},
+			{
+				env: {} as Env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://heykody.dev',
+				}),
+			},
+		),
+	).rejects.toThrow('Authenticated MCP user is required for this capability.')
+})
+
+test('meta_get_current_user is registered as a searchable meta capability', () => {
+	expect(capabilitySpecs.meta_get_current_user).toMatchObject({
+		name: 'meta_get_current_user',
+		domain: 'meta',
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		outputFields: ['user_id', 'email', 'display_name'],
+	})
+})

--- a/packages/worker/src/mcp/capabilities/meta/meta-get-current-user.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-get-current-user.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { requireMcpUser } from './require-user.ts'
+
+const outputSchema = z.object({
+	user_id: z.string(),
+	email: z.email(),
+	display_name: z.string(),
+})
+
+export const metaGetCurrentUserCapability = defineDomainCapability(
+	capabilityDomainNames.meta,
+	{
+		name: 'meta_get_current_user',
+		description:
+			'Get harmless identity fields for the signed-in MCP user: id, email, and display name.',
+		keywords: [
+			'user',
+			'current user',
+			'profile',
+			'identity',
+			'account',
+			'email',
+			'name',
+		],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: z.object({}),
+		outputSchema,
+		async handler(_args, ctx: CapabilityContext) {
+			const user = requireMcpUser(ctx.callerContext)
+			return {
+				user_id: user.userId,
+				email: user.email,
+				display_name: user.displayName,
+			}
+		},
+	},
+)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `meta_get_current_user` to expose safe signed-in user identity fields to trusted LLM workflows.
- Register the capability in the meta domain and cover authenticated, anonymous, and registry behavior.

## Testing
- `npm run test -- packages/worker/src/mcp/capabilities/meta/meta-get-current-user.node.test.ts`
- `npm run format:check -- packages/worker/src/mcp/capabilities/meta/meta-get-current-user.ts packages/worker/src/mcp/capabilities/meta/domain.ts packages/worker/src/mcp/capabilities/meta/meta-get-current-user.node.test.ts`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7974b48-3801-401f-91a7-44e060684679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7974b48-3801-401f-91a7-44e060684679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new capability to retrieve current signed-in user information, returning user ID, email, and display name. This read-only, non-destructive operation provides secure access to authenticated user identity details.

* **Tests**
  * Comprehensive test coverage added to verify capability functionality and authentication requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/444)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->