### PR TITLE
Add copyable remote connector URLs

### DIFF
--- a/docs/contributing/architecture/remote-connectors.md
+++ b/docs/contributing/architecture/remote-connectors.md
@@ -8,9 +8,10 @@ calls to JSON-RPC on the socket.
 
 ## URLs and session keys
 
-`wss://<worker-origin>/connectors/<kind>/<instanceId>`
+`wss://<worker-origin>/connectors/u/<userId>/<kind>/<instanceId>`
 
-Session key = `<kind>:<instanceId>` (lowercase compared after trim).
+Session key = JSON tuple `[userId, kind, instanceId]` where `kind` is lowercase
+after trim.
 
 The Worker sets header **`X-Kody-Connector-Session-Key`** on requests forwarded
 into the Durable Object. The connector’s **`connector.hello`** must declare a
@@ -95,15 +96,8 @@ saved remote connector settings. Operators can manage those settings at
   `connector.hello` for that ref.
 - **`attached`** controls whether the ref is included in normal Kody MCP/chat
   caller context.
-- **`sharedSecret`** is encrypted in D1 and is never returned by the account UI
-  API after saving. Enter a new value to replace it; leave it blank when editing
-  to keep the saved value.
-
-A connector WebSocket session is shared by **`kind:instanceId`** across users.
-Because `connector.hello` does not identify a user, any user's enabled saved
-secret for that ref can authenticate that shared session. To make connector
-hello authentication user-isolated in the future, thread user identity through
-the connector hello flow and filter stored secret lookup by `user_id`.
+- **`sharedSecret`** is encrypted in D1 and authenticates only the user-scoped
+  connector URL for the saved ref.
 
 Source: `packages/shared/src/chat.ts`,
 `packages/shared/src/remote-connectors.ts`, and
@@ -117,8 +111,8 @@ Source: `packages/shared/src/chat.ts`,
 
 ## Connector checklist
 
-1. **Outbound WebSocket** to the correct path for your **`kind`** and
-   **`instanceId`**.
+1. **Outbound WebSocket** to the full account page URL for your **`userId`**,
+   **`kind`**, and **`instanceId`**.
 2. **Hello first** with matching **`connectorKind`** + **`connectorId`** and a
    **valid `sharedSecret`** for that `kind:instanceId` pair.
 3. Implement **`tools/list`** and **`tools/call`** on the socket via

--- a/docs/contributing/architecture/remote-connectors.md
+++ b/docs/contributing/architecture/remote-connectors.md
@@ -111,8 +111,8 @@ Source: `packages/shared/src/chat.ts`,
 
 ## Connector checklist
 
-1. **Outbound WebSocket** to the full account page URL for your **`userId`**,
-   **`kind`**, and **`instanceId`**.
+1. **Outbound WebSocket** to your connector URL:
+   `wss://<worker-origin>/connectors/u/<userId>/<kind>/<instanceId>`.
 2. **Hello first** with matching **`connectorKind`** + **`connectorId`** and a
    **valid `sharedSecret`** for that `kind:instanceId` pair.
 3. Implement **`tools/list`** and **`tools/call`** on the socket via

--- a/e2e/remote-connectors.spec.ts
+++ b/e2e/remote-connectors.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from './playwright-utils.ts'
 
 test('remote connector form reloads, reveals, and generates shared secrets', async ({
+	context,
 	page,
 	login,
 }) => {
+	await context.grantPermissions(['clipboard-read', 'clipboard-write'])
 	await login()
 
 	const nonce = Date.now().toString(36)
@@ -16,10 +18,18 @@ test('remote connector form reloads, reveals, and generates shared secrets', asy
 		page.getByRole('heading', { level: 1, name: /remote connectors/i }),
 	).toBeVisible()
 	await expect(page.getByRole('button', { name: 'Generate' })).toBeVisible()
-	await expect(page.getByRole('button', { name: 'Copy' })).toHaveCount(0)
+	await expect(
+		page.getByRole('button', { name: /copy connector url/i }),
+	).toHaveCount(0)
 
 	await page.getByLabel('Kind').fill(kind)
 	await page.getByLabel('Instance ID').fill(instanceId)
+	const connectorUrl = page
+		.locator('code')
+		.filter({ hasText: '/connectors/u/' })
+	await expect(connectorUrl).toHaveText(
+		new RegExp(`/connectors/u/[^/]+/${kind}/${instanceId}$`),
+	)
 	await page.getByRole('textbox', { name: 'Shared secret' }).fill(sharedSecret)
 	const saveResponse = page.waitForResponse(
 		(response) =>
@@ -39,7 +49,16 @@ test('remote connector form reloads, reveals, and generates shared secrets', asy
 	})
 	await expect(sharedSecretInput).toHaveAttribute('type', 'password')
 	await expect(sharedSecretInput).toHaveValue(sharedSecret)
-	await expect(page.getByRole('button', { name: 'Copy' })).toHaveCount(0)
+	await expect(
+		page.getByRole('button', { name: /copy connector url/i }),
+	).toBeVisible()
+	await page.getByRole('button', { name: /copy connector url/i }).click()
+	await expect(
+		page.getByRole('button', { name: /copied connector url/i }),
+	).toBeVisible()
+	await expect
+		.poll(() => page.evaluate(() => navigator.clipboard.readText()))
+		.toMatch(new RegExp(`/connectors/u/[^/]+/${kind}/${instanceId}$`))
 
 	await page.getByRole('button', { name: 'Show shared secret' }).click()
 	await expect(sharedSecretInput).toHaveAttribute('type', 'text')

--- a/packages/shared/src/remote-connectors.ts
+++ b/packages/shared/src/remote-connectors.ts
@@ -8,12 +8,35 @@ export type RemoteConnectorRef = {
 	instanceId: string
 }
 
-function normalizeKind(kind: string): string {
+export function normalizeRemoteConnectorKind(kind: string): string {
 	return kind.trim().toLowerCase()
 }
 
-function normalizeInstanceId(instanceId: string): string {
+export function normalizeRemoteConnectorInstanceId(instanceId: string): string {
 	return instanceId.trim()
+}
+
+export function userScopedConnectorIngressPath(input: {
+	userId: string
+	kind: string
+	instanceId: string
+}) {
+	const userId = encodeURIComponent(input.userId.trim())
+	const kind = encodeURIComponent(normalizeRemoteConnectorKind(input.kind))
+	const instanceId = encodeURIComponent(
+		normalizeRemoteConnectorInstanceId(input.instanceId),
+	)
+	return `/connectors/u/${userId}/${kind}/${instanceId}`
+}
+
+export function userScopedConnectorWebSocketUrl(input: {
+	origin: string
+	userId: string
+	kind: string
+	instanceId: string
+}) {
+	const origin = input.origin.trim().replace(/\/+$/, '')
+	return `${origin}${userScopedConnectorIngressPath(input)}`
 }
 
 export function normalizeRemoteConnectorRefs(
@@ -21,8 +44,8 @@ export function normalizeRemoteConnectorRefs(
 ): Array<RemoteConnectorRef> {
 	return (context.remoteConnectors ?? [])
 		.map((ref) => ({
-			kind: normalizeKind(ref.kind),
-			instanceId: normalizeInstanceId(ref.instanceId),
+			kind: normalizeRemoteConnectorKind(ref.kind),
+			instanceId: normalizeRemoteConnectorInstanceId(ref.instanceId),
 		}))
 		.filter((ref) => ref.kind.length > 0 && ref.instanceId.length > 0)
 }

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -151,6 +151,23 @@ function CheckIcon() {
 	)
 }
 
+async function writeClipboardText(value: string) {
+	const textArea = document.createElement('textarea')
+	textArea.value = value
+	textArea.setAttribute('readonly', '')
+	textArea.style.position = 'fixed'
+	textArea.style.opacity = '0'
+	document.body.append(textArea)
+	textArea.select()
+	try {
+		if (document.execCommand('copy')) return
+	} finally {
+		textArea.remove()
+	}
+
+	await navigator.clipboard.writeText(value)
+}
+
 function EyeIcon(props: { showSecret: boolean }) {
 	return props.showSecret ? (
 		<svg
@@ -206,16 +223,16 @@ function CopyToClipboard(handle: Handle<{ url: string }>) {
 				mix={[
 					on('click', async (_event, signal) => {
 						try {
-							await navigator.clipboard.writeText(handle.props.url)
+							await writeClipboardText(handle.props.url)
 							if (signal.aborted) return
 						} catch {
 							state = 'error'
-							handle.update()
+							await handle.update()
 							return
 						}
 
 						state = 'copied'
-						handle.update()
+						await handle.update()
 						setTimeout(() => {
 							if (signal.aborted) return
 							state = 'idle'

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -22,11 +22,13 @@ import {
 	getSecondaryButtonCss,
 	inputCss,
 } from '#client/styles/style-primitives.ts'
+import { userScopedConnectorWebSocketUrl } from '@kody-internal/shared/remote-connectors.ts'
 
 type RemoteConnectorListItem = {
 	id: string
 	kind: string
 	instanceId: string
+	connectorUrl: string
 	enabled: boolean
 	attached: boolean
 	hasSharedSecret: boolean
@@ -38,6 +40,8 @@ type RemoteConnectorListItem = {
 type AccountRemoteConnectorsPayload = {
 	ok: true
 	email: string
+	userId: string
+	connectorUrlOrigin: string
 	connectors: Array<RemoteConnectorListItem>
 	selectedConnectorId?: string
 }
@@ -108,6 +112,45 @@ function generateSharedSecret() {
 	return bytesToBase64Url(bytes)
 }
 
+function ClipboardIcon() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="18"
+			height="18"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+			<path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+		</svg>
+	)
+}
+
+function CheckIcon() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="18"
+			height="18"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M20 6 9 17l-5-5" />
+		</svg>
+	)
+}
+
 function EyeIcon(props: { showSecret: boolean }) {
 	return props.showSecret ? (
 		<svg
@@ -144,6 +187,57 @@ function EyeIcon(props: { showSecret: boolean }) {
 	)
 }
 
+function CopyToClipboard(handle: Handle<{ url: string }>) {
+	let state: 'idle' | 'copied' | 'error' = 'idle'
+
+	return () => {
+		const label =
+			state === 'idle'
+				? 'Copy connector URL'
+				: state === 'copied'
+					? 'Copied connector URL'
+					: 'Could not copy connector URL'
+
+		return (
+			<button
+				type="button"
+				aria-label={label}
+				aria-live="polite"
+				mix={[
+					on('click', async (_event, signal) => {
+						try {
+							await navigator.clipboard.writeText(handle.props.url)
+							if (signal.aborted) return
+						} catch {
+							state = 'error'
+							handle.update()
+							return
+						}
+
+						state = 'copied'
+						handle.update()
+						setTimeout(() => {
+							if (signal.aborted) return
+							state = 'idle'
+							handle.update()
+						}, 2000)
+					}),
+					css({
+						...getSecondaryButtonCss(),
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: spacing.xs,
+						whiteSpace: 'nowrap',
+					}),
+				]}
+			>
+				{state === 'copied' ? CheckIcon() : ClipboardIcon()}
+				{state === 'copied' ? 'Copied' : state === 'error' ? 'Error' : 'Copy'}
+			</button>
+		)
+	}
+}
+
 const iconButtonCss = {
 	position: 'absolute' as const,
 	right: spacing.sm,
@@ -175,6 +269,8 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
 	let saveState: 'idle' | 'saving' | 'deleting' = 'idle'
 	let email = ''
+	let userId = ''
+	let connectorUrlOrigin = ''
 	let connectors: Array<RemoteConnectorListItem> = []
 	let editorState = createEmptyEditorState()
 	let message: string | null = null
@@ -224,6 +320,8 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 
 	function applyPayload(payload: AccountRemoteConnectorsPayload) {
 		email = payload.email
+		userId = payload.userId
+		connectorUrlOrigin = payload.connectorUrlOrigin
 		connectors = payload.connectors
 		deleteConfirm = false
 		if (payload.selectedConnectorId) {
@@ -406,6 +504,17 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 		handle.update()
 	}
 
+	function getEditorConnectorUrl() {
+		if (!userId || !connectorUrlOrigin) return null
+		if (!editorState.kind.trim() || !editorState.instanceId.trim()) return null
+		return userScopedConnectorWebSocketUrl({
+			origin: connectorUrlOrigin,
+			userId,
+			kind: editorState.kind,
+			instanceId: editorState.instanceId,
+		})
+	}
+
 	return () => {
 		const currentHref =
 			typeof window === 'undefined'
@@ -422,6 +531,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 			editorState.kind && editorState.instanceId
 				? `${editorState.kind}:${editorState.instanceId}`
 				: 'New remote connector'
+		const connectorUrl = getEditorConnectorUrl()
 
 		return (
 			<section
@@ -627,6 +737,46 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 									]}
 								/>
 							</label>
+							<div mix={css(fieldCss)}>
+								<span mix={css(fieldLabelCss)}>Connector URL</span>
+								{connectorUrl ? (
+									<div
+										mix={css({
+											display: 'flex',
+											gap: spacing.sm,
+											alignItems: 'stretch',
+											flexWrap: 'wrap',
+										})}
+									>
+										<code
+											mix={css({
+												flex: '1 1 22rem',
+												minWidth: 0,
+												padding: spacing.sm,
+												borderRadius: radius.md,
+												border: `1px solid ${colors.border}`,
+												backgroundColor: colors.background,
+												color: colors.text,
+												fontFamily: 'monospace',
+												fontSize: typography.fontSize.sm,
+												overflowWrap: 'anywhere',
+											})}
+										>
+											{connectorUrl}
+										</code>
+										<CopyToClipboard key={connectorUrl} url={connectorUrl} />
+									</div>
+								) : (
+									<p mix={css(descriptionCss)}>
+										Enter a kind and instance ID to build the connector
+										WebSocket URL.
+									</p>
+								)}
+								<p mix={css(descriptionCss)}>
+									Includes your MCP user ID <code>{userId}</code> so connector
+									sessions stay isolated to your account.
+								</p>
+							</div>
 							<div mix={css(fieldCss)}>
 								<span mix={css(fieldLabelCss)}>
 									Shared secret

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -160,7 +160,14 @@ async function writeClipboardText(value: string) {
 	document.body.append(textArea)
 	textArea.select()
 	try {
-		if (document.execCommand('copy')) return
+		if (
+			typeof document.execCommand === 'function' &&
+			document.execCommand('copy')
+		) {
+			return
+		}
+	} catch {
+		// Ignore legacy clipboard failures and fall through to the modern API.
 	} finally {
 		textArea.remove()
 	}

--- a/packages/worker/src/app/handlers/account-remote-connectors.node.test.ts
+++ b/packages/worker/src/app/handlers/account-remote-connectors.node.test.ts
@@ -95,11 +95,15 @@ test('remote connector settings API lists settings with plaintext secrets', asyn
 	expect(JSON.parse(text)).toEqual({
 		ok: true,
 		email: 'user@example.com',
+		userId: 'stable-user-1',
+		connectorUrlOrigin: 'wss://example.com',
 		connectors: [
 			{
 				id: 'connector-1',
 				kind: 'lights',
 				instanceId: 'default',
+				connectorUrl:
+					'wss://example.com/connectors/u/stable-user-1/lights/default',
 				enabled: true,
 				attached: true,
 				hasSharedSecret: true,
@@ -141,12 +145,16 @@ test('remote connector settings API passes submitted secret to save service', as
 	expect(await response.json()).toEqual({
 		ok: true,
 		email: 'user@example.com',
+		userId: 'stable-user-1',
+		connectorUrlOrigin: 'wss://example.com',
 		selectedConnectorId: 'connector-1',
 		connectors: [
 			{
 				id: 'connector-1',
 				kind: 'lights',
 				instanceId: 'default',
+				connectorUrl:
+					'wss://example.com/connectors/u/stable-user-1/lights/default',
 				enabled: true,
 				attached: true,
 				hasSharedSecret: true,

--- a/packages/worker/src/app/handlers/account-remote-connectors.ts
+++ b/packages/worker/src/app/handlers/account-remote-connectors.ts
@@ -10,6 +10,7 @@ import {
 	listRemoteConnectorSettingsWithSharedSecrets,
 	saveRemoteConnectorSetting,
 } from '#worker/remote-connector/settings-service.ts'
+import { userScopedConnectorWebSocketUrl } from '@kody-internal/shared/remote-connectors.ts'
 
 type AuthenticatedUser = NonNullable<
 	Awaited<ReturnType<typeof readAuthenticatedAppUser>>
@@ -19,6 +20,7 @@ type AccountRemoteConnectorListItem = {
 	id: string
 	kind: string
 	instanceId: string
+	connectorUrl: string
 	enabled: boolean
 	attached: boolean
 	hasSharedSecret: boolean
@@ -30,6 +32,8 @@ type AccountRemoteConnectorListItem = {
 type AccountRemoteConnectorsPayload = {
 	ok: true
 	email: string
+	userId: string
+	connectorUrlOrigin: string
 	connectors: Array<AccountRemoteConnectorListItem>
 }
 
@@ -62,9 +66,12 @@ export function createAccountRemoteConnectorsApiHandler(env: Env) {
 			if (!user) {
 				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
 			}
+			const connectorUrlOrigin = getConnectorUrlOrigin(request)
 
 			if (request.method === 'GET') {
-				return jsonResponse(await buildPayload({ env, user }))
+				return jsonResponse(
+					await buildPayload({ env, user, connectorUrlOrigin }),
+				)
 			}
 
 			if (request.method !== 'POST') {
@@ -79,10 +86,20 @@ export function createAccountRemoteConnectorsApiHandler(env: Env) {
 			const action = readString(body, 'action')
 			try {
 				if (action === 'save') {
-					return await handleSaveAction({ env, user, body })
+					return await handleSaveAction({
+						env,
+						user,
+						body,
+						connectorUrlOrigin,
+					})
 				}
 				if (action === 'delete') {
-					return await handleDeleteAction({ env, user, body })
+					return await handleDeleteAction({
+						env,
+						user,
+						body,
+						connectorUrlOrigin,
+					})
 				}
 			} catch (error) {
 				return jsonResponse(
@@ -109,6 +126,7 @@ async function handleSaveAction(input: {
 	env: Env
 	user: AuthenticatedUser
 	body: object
+	connectorUrlOrigin: string
 }) {
 	const saved = await saveRemoteConnectorSetting({
 		env: input.env,
@@ -120,7 +138,11 @@ async function handleSaveAction(input: {
 		attached: readBoolean(input.body, 'attached', true),
 		sharedSecret: readOptionalString(input.body, 'sharedSecret'),
 	})
-	const payload = await buildPayload({ env: input.env, user: input.user })
+	const payload = await buildPayload({
+		env: input.env,
+		user: input.user,
+		connectorUrlOrigin: input.connectorUrlOrigin,
+	})
 	return jsonResponse({
 		...payload,
 		selectedConnectorId: saved.id,
@@ -131,6 +153,7 @@ async function handleDeleteAction(input: {
 	env: Env
 	user: AuthenticatedUser
 	body: object
+	connectorUrlOrigin: string
 }) {
 	const id = readString(input.body, 'id')
 	if (!id) {
@@ -150,22 +173,46 @@ async function handleDeleteAction(input: {
 			404,
 		)
 	}
-	return jsonResponse(await buildPayload({ env: input.env, user: input.user }))
+	return jsonResponse(
+		await buildPayload({
+			env: input.env,
+			user: input.user,
+			connectorUrlOrigin: input.connectorUrlOrigin,
+		}),
+	)
 }
 
 async function buildPayload(input: {
 	env: Env
 	user: AuthenticatedUser
+	connectorUrlOrigin: string
 }): Promise<AccountRemoteConnectorsPayload> {
 	const connectors = await listRemoteConnectorSettingsWithSharedSecrets({
 		env: input.env,
 		userId: input.user.mcpUser.userId,
 	})
+	const userId = input.user.mcpUser.userId
 	return {
 		ok: true,
 		email: input.user.email,
-		connectors,
+		userId,
+		connectorUrlOrigin: input.connectorUrlOrigin,
+		connectors: connectors.map((connector) => ({
+			...connector,
+			connectorUrl: userScopedConnectorWebSocketUrl({
+				origin: input.connectorUrlOrigin,
+				userId,
+				kind: connector.kind,
+				instanceId: connector.instanceId,
+			}),
+		})),
 	}
+}
+
+function getConnectorUrlOrigin(request: Request) {
+	const url = new URL(request.url)
+	const protocol = url.protocol === 'http:' ? 'ws:' : 'wss:'
+	return `${protocol}//${url.host}`
 }
 
 function readString(body: object, key: string) {

--- a/packages/worker/src/remote-connector/connector-session-key.ts
+++ b/packages/worker/src/remote-connector/connector-session-key.ts
@@ -1,4 +1,9 @@
-const userScopedConnectorIngressPrefix = '/connectors/u/'
+import {
+	normalizeRemoteConnectorInstanceId,
+	normalizeRemoteConnectorKind,
+} from '@kody-internal/shared/remote-connectors.ts'
+
+export { userScopedConnectorIngressPath } from '@kody-internal/shared/remote-connectors.ts'
 
 export type UserScopedConnectorRouteMatch = {
 	userId: string
@@ -21,20 +26,9 @@ export function userScopedConnectorSessionKey(input: {
 }) {
 	return JSON.stringify([
 		input.userId.trim(),
-		input.kind.trim().toLowerCase(),
-		input.instanceId.trim(),
+		normalizeRemoteConnectorKind(input.kind),
+		normalizeRemoteConnectorInstanceId(input.instanceId),
 	])
-}
-
-export function userScopedConnectorIngressPath(input: {
-	userId: string
-	kind: string
-	instanceId: string
-}) {
-	const userId = encodeURIComponent(input.userId.trim())
-	const kind = encodeURIComponent(input.kind.trim().toLowerCase())
-	const instanceId = encodeURIComponent(input.instanceId.trim())
-	return `${userScopedConnectorIngressPrefix}${userId}/${kind}/${instanceId}`
 }
 
 export function parseUserScopedConnectorRoutePath(

--- a/packages/worker/src/remote-connector/remote-connectors-shared.node.test.ts
+++ b/packages/worker/src/remote-connector/remote-connectors-shared.node.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from 'vitest'
-import { normalizeRemoteConnectorRefs } from '@kody-internal/shared/remote-connectors.ts'
+import {
+	normalizeRemoteConnectorRefs,
+	userScopedConnectorWebSocketUrl,
+} from '@kody-internal/shared/remote-connectors.ts'
 
 test('normalizeRemoteConnectorRefs returns empty when remoteConnectors unset', () => {
 	expect(
@@ -29,4 +32,15 @@ test('normalizeRemoteConnectorRefs preserves an empty connector list', () => {
 			remoteConnectors: [],
 		}),
 	).toEqual([])
+})
+
+test('userScopedConnectorWebSocketUrl builds encoded user-scoped connector URLs', () => {
+	expect(
+		userScopedConnectorWebSocketUrl({
+			origin: 'wss://kody.example.com/',
+			userId: 'user aaa',
+			kind: 'Lights',
+			instanceId: 'living room',
+		}),
+	).toBe('wss://kody.example.com/connectors/u/user%20aaa/lights/living%20room')
 })

--- a/packages/worker/src/remote-connector/resolve-remote-connector-secret.ts
+++ b/packages/worker/src/remote-connector/resolve-remote-connector-secret.ts
@@ -1,8 +1,10 @@
 import {
-	hasRemoteConnectorSharedSecretForRef,
-	listRemoteConnectorSharedSecretsForRef,
 	normalizeRemoteConnectorInstanceId,
 	normalizeRemoteConnectorKind,
+} from '@kody-internal/shared/remote-connectors.ts'
+import {
+	hasRemoteConnectorSharedSecretForRef,
+	listRemoteConnectorSharedSecretsForRef,
 } from './settings-service.ts'
 
 const textEncoder = new TextEncoder()

--- a/packages/worker/src/remote-connector/settings-service.ts
+++ b/packages/worker/src/remote-connector/settings-service.ts
@@ -1,4 +1,8 @@
-import { type RemoteConnectorRef } from '@kody-internal/shared/remote-connectors.ts'
+import {
+	normalizeRemoteConnectorInstanceId,
+	normalizeRemoteConnectorKind,
+	type RemoteConnectorRef,
+} from '@kody-internal/shared/remote-connectors.ts'
 import { decryptSecretValue, encryptSecretValue } from '#mcp/secrets/crypto.ts'
 import {
 	deleteRemoteConnectorSettingRow,
@@ -27,14 +31,6 @@ export type SaveRemoteConnectorSettingInput = {
 	enabled: boolean
 	attached: boolean
 	sharedSecret?: string | null
-}
-
-export function normalizeRemoteConnectorKind(kind: string) {
-	return kind.trim().toLowerCase()
-}
-
-export function normalizeRemoteConnectorInstanceId(instanceId: string) {
-	return instanceId.trim()
 }
 
 function toMetadata(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Show the authenticated MCP user id on `/account/remote-connectors` as part of the connector URL guidance.
- Build user-scoped connector WebSocket URLs with a copy button in the remote connector editor.
- Add a robust clipboard fallback and update remote connector tests/docs for `/connectors/u/{userId}/{kind}/{instanceId}` URLs.
- Address CodeRabbit/Bugbot feedback on connector endpoint wording, clipboard fallback error handling, and duplicated normalization helpers.

## Walkthrough
![Remote connector URL copy state](https://cursor.com/artifacts/c/art-828bf920-683b-42a6-90f5-a7bcb85903eb)
<a href="https://cursor.com/agents/bc-181c6597-a100-482d-bb7f-d366f348b260/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fremote_connector_copy_url_demo.mp4"><img src="https://cursor.com/artifacts/c/art-c1cefd6d-8ea5-4ed8-91ae-0e56f995cb74" alt="remote_connector_copy_url_demo.mp4" /></a>

## Testing
- `npx vitest run "packages/worker/src/app/handlers/account-remote-connectors.node.test.ts" "packages/worker/src/remote-connector/remote-connectors-shared.node.test.ts" "packages/worker/src/remote-connector/connector-session-key.node.test.ts"`
- `npx vitest run "packages/worker/src/remote-connector/settings-service.node.test.ts" "packages/worker/src/remote-connector/resolve-remote-connector-secret.node.test.ts" "packages/worker/src/remote-connector/remote-connectors-shared.node.test.ts" "packages/worker/src/remote-connector/connector-session-key.node.test.ts" "packages/worker/src/app/handlers/account-remote-connectors.node.test.ts"`
- `npm run typecheck`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3847 npx playwright test "e2e/remote-connectors.spec.ts"`
- `npm run lint && npm run format:check`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3847 npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-181c6597-a100-482d-bb7f-d366f348b260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-181c6597-a100-482d-bb7f-d366f348b260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account settings show a read-only, user-scoped connector WebSocket URL with a copy-to-clipboard control; saved connector entries include the computed URL.

* **Documentation**
  * Architecture docs updated to describe the user-scoped URL scheme, session key tuple format, and shared-secret scope.

* **Tests**
  * E2E and unit tests expanded to validate URL generation, display, and clipboard copy behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/445)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->