### PR TITLE
Increase artifact git remote token default

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
@@ -147,7 +147,7 @@ test('honors explicit read scope', async () => {
 		{ kody_id: 'unleashed-wifi', scope: 'read' },
 		createContext(),
 	)
-	expect(createToken).toHaveBeenCalledWith('read', 1800)
+	expect(createToken).toHaveBeenCalledWith('read', 3600)
 	expect(result.scope).toBe('read')
 })
 

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
@@ -14,7 +14,7 @@ const getGitRemoteInputSchema = z.object({
 	package_id: z.string().min(1).optional(),
 	kody_id: z.string().min(1).optional(),
 	scope: z.enum(['read', 'write']).default('write'),
-	ttl_seconds: z.number().int().min(60).max(86_400).default(1800),
+	ttl_seconds: z.number().int().min(60).max(86_400).default(3600),
 })
 
 const outputSchema = markSecretInputFields(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Increase `package_get_git_remote` default artifact token TTL from 30 minutes to 1 hour.
- Update the focused unit test expectation for the default TTL.

## Testing
- `npx vitest run --project node-unit packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92f2701b-2344-4eac-b1ae-1edb72dfcb45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92f2701b-2344-4eac-b1ae-1edb72dfcb45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased default token time-to-live (TTL) for git remote operations from 30 minutes to 1 hour, allowing longer-lived credentials for extended operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/446)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->