### PR TITLE
Enforce user-scoped Kody package names

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -101,7 +101,19 @@ beforeEach(() => {
 
 function createContext() {
 	return {
-		env: { APP_DB: {} } as Env,
+		env: {
+			APP_DB: {
+				prepare() {
+					return {
+						bind() {
+							return {
+								first: async () => ({ username: 'user' }),
+							}
+						},
+					}
+				},
+			},
+		} as unknown as Env,
 		callerContext: {
 			baseUrl: 'https://kody.test',
 			user: {
@@ -287,7 +299,7 @@ test('published output lists stale static dependents for the new dependency comm
 		}),
 	)
 	expect(mockModule.getStaticPackageDependentsSummary).toHaveBeenCalledWith({
-		db: {},
+		db: expect.any(Object),
 		userId: 'user-1',
 		sourceId: 'source-1',
 		currentDependencyCommit: 'commit-new',

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -163,6 +163,7 @@ test('publishes a new external Artifacts HEAD', async () => {
 			expectedHead: 'commit-new',
 			allowForce: false,
 			rebuildPackageArtifacts: false,
+			expectedPackageScope: 'user',
 		}),
 	)
 })

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -8,6 +8,7 @@ import {
 	getStaticPackageDependentsSummary,
 	type StaticPackageDependentsSummary,
 } from '#worker/package-runtime/static-package-dependents.ts'
+import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
 import { rebuildPublishedPackageArtifactsViaRepoSession } from '#mcp/capabilities/repo/package-artifact-rebuild.ts'
@@ -240,6 +241,10 @@ export const publishExternalPushCapability = defineDomainCapability(
 		outputSchema,
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
+			const expectedPackageScope = await getMcpUserPackageScope(
+				ctx.env.APP_DB,
+				user,
+			)
 			const maxAttempts = externalPublishRetryDelaysMs.length + 1
 			let lastTransientError: unknown = null
 			for (
@@ -280,6 +285,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 						allowForce: args.allow_force,
 						baseUrl: ctx.callerContext.baseUrl,
 						rebuildPackageArtifacts: false,
+						expectedPackageScope,
 					})
 					if (result.status === 'already_published') {
 						if (!result.published_commit) {

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -9,10 +9,7 @@ import {
 	getSavedPackageByKodyId,
 	insertSavedPackage,
 } from '#worker/package-registry/repo.ts'
-import {
-	assertAuthoredPackageJsonNameScope,
-	parseAuthoredPackageJson,
-} from '#worker/package-registry/manifest.ts'
+import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
 import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
 import { buildSavedPackageEmbedText } from '#worker/package-registry/embed.ts'
 import { upsertSavedPackageVector } from '#worker/package-registry/vectorize.ts'
@@ -76,17 +73,14 @@ export const savePackageCapability = defineDomainCapability(
 			if (!packageJsonContent) {
 				throw new Error('Saved packages require a root package.json file.')
 			}
+			const expectedPackageScope = await getMcpUserPackageScope(
+				ctx.env.APP_DB,
+				user,
+			)
 			const manifest = parseAuthoredPackageJson({
 				content: packageJsonContent,
 				manifestPath: 'package.json',
-			})
-			assertAuthoredPackageJsonNameScope({
-				manifest,
-				expectedPackageScope: await getMcpUserPackageScope(
-					ctx.env.APP_DB,
-					user,
-				),
-				manifestPath: 'package.json',
+				expectedPackageScope,
 			})
 			const existing =
 				args.package_id !== undefined

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -9,7 +9,11 @@ import {
 	getSavedPackageByKodyId,
 	insertSavedPackage,
 } from '#worker/package-registry/repo.ts'
-import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
+import {
+	assertAuthoredPackageJsonNameScope,
+	parseAuthoredPackageJson,
+} from '#worker/package-registry/manifest.ts'
+import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
 import { buildSavedPackageEmbedText } from '#worker/package-registry/embed.ts'
 import { upsertSavedPackageVector } from '#worker/package-registry/vectorize.ts'
 import { refreshSavedPackageProjection } from '#worker/package-registry/service.ts'
@@ -74,6 +78,14 @@ export const savePackageCapability = defineDomainCapability(
 			}
 			const manifest = parseAuthoredPackageJson({
 				content: packageJsonContent,
+				manifestPath: 'package.json',
+			})
+			assertAuthoredPackageJsonNameScope({
+				manifest,
+				expectedPackageScope: await getMcpUserPackageScope(
+					ctx.env.APP_DB,
+					user,
+				),
 				manifestPath: 'package.json',
 			})
 			const existing =

--- a/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
@@ -2,6 +2,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
+import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
 import {
 	repoPublishSessionOutputSchema,
 	repoSessionIdSchema,
@@ -31,6 +32,10 @@ export const repoPublishSessionCapability = defineDomainCapability(
 				sessionId: args.session_id,
 				userId: user.userId,
 				rebuildPackageArtifacts: false,
+				expectedPackageScope:
+					sessionInfo.entity_type === 'package'
+						? await getMcpUserPackageScope(ctx.env.APP_DB, user)
+						: undefined,
 			})
 			if (result.status === 'ok') {
 				if (sessionInfo.entity_type === 'package') {

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-checks.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-checks.ts
@@ -2,6 +2,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
+import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
 import {
 	normalizeRepoManifestSummary,
 	repoRunChecksOutputSchema,
@@ -22,9 +23,18 @@ export const repoRunChecksCapability = defineDomainCapability(
 		outputSchema: repoRunChecksOutputSchema,
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
-			const result = await repoSessionRpc(ctx.env, args.session_id).runChecks({
+			const session = repoSessionRpc(ctx.env, args.session_id)
+			const sessionInfo = await session.getSessionInfo({
 				sessionId: args.session_id,
 				userId: user.userId,
+			})
+			const result = await session.runChecks({
+				sessionId: args.session_id,
+				userId: user.userId,
+				expectedPackageScope:
+					sessionInfo.entity_type === 'package'
+						? await getMcpUserPackageScope(ctx.env.APP_DB, user)
+						: undefined,
 			})
 			return {
 				ok: result.ok,

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
@@ -80,6 +80,10 @@ export const repoRunCommandsCapability = defineDomainCapability(
 						})
 			const validatedSession = repoOpenSessionOutputSchema.parse(session)
 			const sessionRpc = repoSessionRpc(ctx.env, validatedSession.id)
+			const expectedPackageScope =
+				validatedSession.entity_type === 'package' && args.run_checks === true
+					? await getMcpUserPackageScope(ctx.env.APP_DB, user)
+					: undefined
 			const result = await sessionRpc.runCommands({
 				sessionId: validatedSession.id,
 				userId: user.userId,
@@ -87,6 +91,7 @@ export const repoRunCommandsCapability = defineDomainCapability(
 				dryRun: args.dry_run,
 				runChecks: args.run_checks,
 				publish: false,
+				expectedPackageScope,
 			})
 			let publish = result.publish
 			if (args.publish === true) {
@@ -104,10 +109,7 @@ export const repoRunCommandsCapability = defineDomainCapability(
 						sessionId: validatedSession.id,
 						userId: user.userId,
 						rebuildPackageArtifacts: false,
-						expectedPackageScope:
-							validatedSession.entity_type === 'package'
-								? await getMcpUserPackageScope(ctx.env.APP_DB, user)
-								: undefined,
+						expectedPackageScope,
 					})
 				} else {
 					publish = { status: 'not_requested' as const }

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
@@ -3,6 +3,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
+import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
 import { resolveRepoTargetFromSource } from './repo-resolve-target.ts'
 import { repoRunCommandsCapabilityDescription } from './repo-run-commands-text.ts'
 import {
@@ -103,6 +104,10 @@ export const repoRunCommandsCapability = defineDomainCapability(
 						sessionId: validatedSession.id,
 						userId: user.userId,
 						rebuildPackageArtifacts: false,
+						expectedPackageScope:
+							validatedSession.entity_type === 'package'
+								? await getMcpUserPackageScope(ctx.env.APP_DB, user)
+								: undefined,
 					})
 				} else {
 					publish = { status: 'not_requested' as const }

--- a/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
@@ -301,6 +301,7 @@ test('repo_run_commands reuses resolved target metadata when resuming an existin
 		dryRun: undefined,
 		runChecks: false,
 		publish: false,
+		expectedPackageScope: undefined,
 	})
 	expect(result.commands).toEqual([
 		{ line: 1, command: 'git status', ok: true, output: [] },
@@ -418,6 +419,7 @@ test('repo_run_commands opens by target and returns failed checks without publis
 		dryRun: undefined,
 		runChecks: true,
 		publish: false,
+		expectedPackageScope: 'user',
 	})
 	expect(result.checks).toEqual({
 		status: 'failed',

--- a/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
@@ -38,10 +38,26 @@ const { repoRunCommandsCapability } = await import('./repo-run-commands.ts')
 
 function createCapabilityContext() {
 	return {
-		env: { APP_DB: {} } as Env,
+		env: {
+			APP_DB: {
+				prepare() {
+					return {
+						bind() {
+							return {
+								first: async () => ({ username: 'user' }),
+							}
+						},
+					}
+				},
+			},
+		} as unknown as Env,
 		callerContext: createMcpCallerContext({
 			baseUrl: 'https://heykody.dev',
-			user: { userId: 'user-1', email: 'user@example.com' },
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'user',
+			},
 		}),
 	}
 }
@@ -683,6 +699,7 @@ test('repo_publish_session rebuilds package artifacts after direct publish', asy
 		sessionId: 'session-1',
 		userId: 'user-1',
 		rebuildPackageArtifacts: false,
+		expectedPackageScope: 'user',
 	})
 	expect(rpc.rebuildPublishedPackageArtifact).toHaveBeenCalledWith({
 		sessionId: 'session-1',

--- a/packages/worker/src/mcp/observability.workers.test.ts
+++ b/packages/worker/src/mcp/observability.workers.test.ts
@@ -169,7 +169,19 @@ test('package_save rejects invalid package.json before persistence', async () =>
 				],
 			},
 			{
-				env: {} as Env,
+				env: {
+					APP_DB: {
+						prepare() {
+							return {
+								bind() {
+									return {
+										first: async () => ({ username: 'user' }),
+									}
+								},
+							}
+						},
+					},
+				} as unknown as Env,
 				callerContext: createMcpCallerContext({
 					baseUrl: 'https://example.com',
 					user: {

--- a/packages/worker/src/mcp/observability.workers.test.ts
+++ b/packages/worker/src/mcp/observability.workers.test.ts
@@ -175,11 +175,69 @@ test('package_save rejects invalid package.json before persistence', async () =>
 					user: {
 						userId: 'user-1',
 						email: 'user@example.com',
+						displayName: 'user',
 					},
 				}),
 			},
 		),
 	).rejects.toThrow('Invalid package.json')
+})
+
+test('package_save rejects package names outside the signed-in username scope', async () => {
+	resetRepoPersistenceMocks()
+	const handler = capabilityMap['package_save'].handler
+	await expect(
+		handler(
+			{
+				files: [
+					{
+						path: 'package.json',
+						content: JSON.stringify({
+							name: '@other/observed-package',
+							exports: {
+								'.': './src/index.ts',
+							},
+							kody: {
+								id: 'observed-package',
+								description: 'Observation test package.',
+							},
+						}),
+					},
+					{
+						path: 'src/index.ts',
+						content:
+							'export default async function main() { return { ok: true } }\n',
+					},
+				],
+			},
+			{
+				env: {
+					APP_DB: {
+						prepare() {
+							return {
+								bind() {
+									return {
+										first: async () => ({ username: 'user' }),
+									}
+								},
+							}
+						},
+					},
+				} as unknown as Env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://example.com',
+					user: {
+						userId: 'user-1',
+						email: 'user@example.com',
+						displayName: 'user',
+					},
+				}),
+			},
+		),
+	).rejects.toThrow(
+		'package.json name "@other/observed-package" must use the authenticated user\'s package scope "@user/*".',
+	)
+	expect(repoMockModule.ensureEntitySource).not.toHaveBeenCalled()
 })
 
 test('logMcpEvent reports failure without throwing when Sentry is off', () => {
@@ -223,7 +281,7 @@ test('package_save capability logs success for valid invocation', async () => {
 					{
 						path: 'package.json',
 						content: JSON.stringify({
-							name: '@kody/observed-package',
+							name: '@user/observed-package',
 							exports: {
 								'.': './src/index.ts',
 							},
@@ -261,7 +319,7 @@ test('package_save capability logs success for valid invocation', async () => {
 												? {
 														id: 'package-1',
 														user_id: 'user-1',
-														name: '@kody/observed-package',
+														name: '@user/observed-package',
 														kody_id: 'observed-package',
 														description: 'Observation test package.',
 														tags_json: '[]',
@@ -271,21 +329,25 @@ test('package_save capability logs success for valid invocation', async () => {
 														created_at: '2026-04-13T00:00:00.000Z',
 														updated_at: '2026-04-13T00:00:00.000Z',
 													}
-												: query.includes('SELECT * FROM entity_sources')
+												: query.includes('FROM users')
 													? {
-															id: 'package-package-1',
-															user_id: 'user-1',
-															entity_kind: 'package',
-															entity_id: 'package-1',
-															repo_id: 'package-package-1',
-															published_commit: 'published-commit-1',
-															indexed_commit: 'published-commit-1',
-															manifest_path: 'package.json',
-															source_root: '/',
-															created_at: '2026-04-13T00:00:00.000Z',
-															updated_at: '2026-04-13T00:00:00.000Z',
+															username: 'user',
 														}
-													: null,
+													: query.includes('SELECT * FROM entity_sources')
+														? {
+																id: 'package-package-1',
+																user_id: 'user-1',
+																entity_kind: 'package',
+																entity_id: 'package-1',
+																repo_id: 'package-package-1',
+																published_commit: 'published-commit-1',
+																indexed_commit: 'published-commit-1',
+																manifest_path: 'package.json',
+																source_root: '/',
+																created_at: '2026-04-13T00:00:00.000Z',
+																updated_at: '2026-04-13T00:00:00.000Z',
+															}
+														: null,
 										all: async () => ({
 											results: [],
 										}),
@@ -311,7 +373,7 @@ test('package_save capability logs success for valid invocation', async () => {
 									sourceRoot: '/',
 									files: {
 										'package.json': JSON.stringify({
-											name: '@kody/observed-package',
+											name: '@user/observed-package',
 											exports: { '.': './src/index.ts' },
 											kody: {
 												id: 'observed-package',
@@ -367,7 +429,7 @@ test('package_save capability logs success for valid invocation', async () => {
 									content:
 										path === 'package.json'
 											? JSON.stringify({
-													name: '@kody/observed-package',
+													name: '@user/observed-package',
 													exports: { '.': './src/index.ts' },
 													kody: {
 														id: 'observed-package',
@@ -403,6 +465,7 @@ test('package_save capability logs success for valid invocation', async () => {
 					user: {
 						userId: 'user-1',
 						email: 'user@example.com',
+						displayName: 'user',
 					},
 				}),
 			},

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -18,10 +18,30 @@ test('parseAuthoredPackageJson validates scoped package names against kody.id', 
 			},
 		}),
 		manifestPath: 'package.json',
+		expectedPackageScope: 'kentcdodds',
 	})
 
 	expect(manifest.name).toBe('@kentcdodds/cursor-cloud-agents')
 	expect(manifest.kody.id).toBe('cursor-cloud-agents')
+
+	expect(() =>
+		parseAuthoredPackageJson({
+			content: JSON.stringify({
+				name: '@kentcdodds/cursor-cloud-agents',
+				exports: {
+					'.': './index.ts',
+				},
+				kody: {
+					id: 'cursor-cloud-agents',
+					description: 'Wrong package scope',
+				},
+			}),
+			manifestPath: 'package.json',
+			expectedPackageScope: 'kody',
+		}),
+	).toThrow(
+		'package.json name "@kentcdodds/cursor-cloud-agents" must use the authenticated user\'s package scope "@kody/*".',
+	)
 
 	expect(() =>
 		parseAuthoredPackageJson({

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -25,9 +25,31 @@ function getExpectedKodyName(name: string) {
 	return separator === -1 ? trimmed : trimmed.slice(separator + 1)
 }
 
+function getPackageNameScope(name: string) {
+	const trimmed = name.trim()
+	const separator = trimmed.indexOf('/')
+	if (separator <= 1) return null
+	return trimmed.slice(1, separator)
+}
+
+export function assertAuthoredPackageJsonNameScope(input: {
+	manifest: AuthoredPackageJson
+	expectedPackageScope: string
+	manifestPath?: string
+}) {
+	const expectedScope = input.expectedPackageScope.trim().replace(/^@/, '')
+	const actualScope = getPackageNameScope(input.manifest.name)
+	if (actualScope !== expectedScope) {
+		throw new Error(
+			`Invalid ${input.manifestPath ?? packageManifestPath}:\npackage.json name "${input.manifest.name}" must use the authenticated user's package scope "@${expectedScope}/*".`,
+		)
+	}
+}
+
 export function parseAuthoredPackageJson(input: {
 	content: string
 	manifestPath?: string
+	expectedPackageScope?: string
 }): AuthoredPackageJson {
 	let parsed: unknown
 	try {
@@ -72,6 +94,13 @@ export function parseAuthoredPackageJson(input: {
 		throw new Error(
 			`Invalid ${input.manifestPath ?? packageManifestPath}:\npackage.json name "${manifest.name}" must use a leaf package name that matches kody.id "${manifest.kody.id}".`,
 		)
+	}
+	if (input.expectedPackageScope !== undefined) {
+		assertAuthoredPackageJsonNameScope({
+			manifest,
+			expectedPackageScope: input.expectedPackageScope,
+			manifestPath: input.manifestPath,
+		})
 	}
 
 	return manifest

--- a/packages/worker/src/package-registry/user-scope.ts
+++ b/packages/worker/src/package-registry/user-scope.ts
@@ -1,0 +1,38 @@
+import { type McpUserContext } from '@kody-internal/shared/chat.ts'
+import { getUsernameValidationError, normalizeUsername } from '#app/username.ts'
+
+type UsernameRow = {
+	username?: unknown
+}
+
+function normalizePackageScopeUsername(value: unknown) {
+	const username = normalizeUsername(value)
+	const validationError = getUsernameValidationError(username)
+	if (validationError) {
+		throw new Error(
+			`Cannot validate package scope because the signed-in username is invalid: ${validationError}`,
+		)
+	}
+	return username
+}
+
+export async function getMcpUserPackageScope(
+	db: D1Database,
+	user: McpUserContext,
+) {
+	const row = await db
+		.prepare(
+			`SELECT username
+			FROM users
+			WHERE lower(email) = lower(?)
+			LIMIT 1`,
+		)
+		.bind(user.email)
+		.first<UsernameRow>()
+	if (!row) {
+		throw new Error(
+			'Cannot validate package scope because the signed-in user record was not found.',
+		)
+	}
+	return normalizePackageScopeUsername(row.username)
+}

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -834,6 +834,7 @@ export async function runRepoChecks(input: {
 	env?: Env
 	baseUrl?: string
 	userId?: string
+	expectedPackageScope?: string
 }): Promise<RepoCheckRunResult> {
 	const manifestContent = await input.workspace.readFile(input.manifestPath)
 	if (manifestContent == null) {
@@ -842,6 +843,7 @@ export async function runRepoChecks(input: {
 	const manifest = parseAuthoredPackageJson({
 		content: manifestContent,
 		manifestPath: input.manifestPath,
+		expectedPackageScope: input.expectedPackageScope,
 	})
 	const results: Array<RepoCheckResult> = [
 		{

--- a/packages/worker/src/repo/external-publish.ts
+++ b/packages/worker/src/repo/external-publish.ts
@@ -118,6 +118,7 @@ export async function publishFromExternalRef(input: {
 	sourceRoot?: string
 	runId?: string
 	rebuildPackageArtifacts?: boolean
+	expectedPackageScope?: string
 }): Promise<RepoExternalPublishResult> {
 	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
 	if (!source || source.user_id !== input.userId) {
@@ -151,6 +152,7 @@ export async function publishFromExternalRef(input: {
 		env: input.env,
 		baseUrl: input.baseUrl,
 		userId: input.userId,
+		expectedPackageScope: input.expectedPackageScope,
 	})
 	const runId = input.runId ?? crypto.randomUUID()
 	if (!checks.ok) {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -1114,6 +1114,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		dryRun?: boolean
 		runChecks?: boolean
 		publish?: boolean
+		expectedPackageScope?: string
 	}): Promise<RepoRunCommandsResult> {
 		const { sessionRow } = await this.getSessionState(
 			input.sessionId,
@@ -1149,7 +1150,11 @@ class RepoSessionBase extends DurableObject<Env> {
 				publish: { status: 'not_requested' },
 			}
 		}
-		const checkRun = await this.runChecks(input)
+		const checkRun = await this.runChecks({
+			sessionId: input.sessionId,
+			userId: input.userId,
+			expectedPackageScope: input.expectedPackageScope,
+		})
 		if (!checkRun.ok) {
 			const publish = shouldPublish
 				? {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -343,6 +343,7 @@ class RepoSessionBase extends DurableObject<Env> {
 	private async readManifestFromWorkspace(
 		manifestPath: string,
 		entityKind: EntityKind,
+		expectedPackageScope?: string,
 	) {
 		const manifestContent = await this.workspace.readFile(
 			resolveRepoWorkspacePath(manifestPath, repoSessionWorkspacePrefix),
@@ -354,6 +355,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			return parseAuthoredPackageJson({
 				content: manifestContent,
 				manifestPath,
+				expectedPackageScope,
 			})
 		}
 		return parseRepoManifest({
@@ -1246,6 +1248,7 @@ class RepoSessionBase extends DurableObject<Env> {
 	async runChecks(input: {
 		sessionId: string
 		userId: string
+		expectedPackageScope?: string
 	}): Promise<RepoSessionCheckRun> {
 		const { sessionRow, source } = await this.getSessionState(
 			input.sessionId,
@@ -1266,6 +1269,10 @@ class RepoSessionBase extends DurableObject<Env> {
 			env: this.env,
 			baseUrl: source.source_root,
 			userId: input.userId,
+			expectedPackageScope:
+				source.entity_kind === 'package'
+					? input.expectedPackageScope
+					: undefined,
 		})
 		const { sourceFiles: _sourceFiles, ...publicResult } = result
 		const runId = crypto.randomUUID()
@@ -1442,6 +1449,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		userId: string
 		force?: boolean
 		rebuildPackageArtifacts?: boolean
+		expectedPackageScope?: string
 	}): Promise<RepoSessionPublishResult> {
 		const { sessionRow, source, sessionAccess } = await this.getSessionState(
 			input.sessionId,
@@ -1483,6 +1491,11 @@ class RepoSessionBase extends DurableObject<Env> {
 		const sessionHeadCommit =
 			(await this.commitIfDirty(`Publish repo session ${input.sessionId}`)) ??
 			(await this.getHeadCommit())
+		await this.readManifestFromWorkspace(
+			source.manifest_path,
+			source.entity_kind,
+			input.expectedPackageScope,
+		)
 		await this.git.push({
 			dir: repoSessionWorkspacePrefix,
 			remote: 'origin',
@@ -1505,10 +1518,6 @@ class RepoSessionBase extends DurableObject<Env> {
 			ref: targetBranch,
 			...buildArtifactsGitAuth({ token: sourceAccess.token }),
 		})
-		await this.readManifestFromWorkspace(
-			source.manifest_path,
-			source.entity_kind,
-		)
 		const snapshotFiles = await this.collectWorkspaceFiles()
 		await finalizePublishedEntitySource({
 			env: this.env,
@@ -1543,6 +1552,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		allowForce?: boolean
 		baseUrl?: string
 		rebuildPackageArtifacts?: boolean
+		expectedPackageScope?: string
 	}): Promise<RepoExternalPublishResult> {
 		const source = await getEntitySourceById(this.env.APP_DB, input.sourceId)
 		if (!source || source.user_id !== input.userId) {
@@ -1605,6 +1615,7 @@ class RepoSessionBase extends DurableObject<Env> {
 				repoSessionWorkspacePrefix,
 			),
 			rebuildPackageArtifacts: input.rebuildPackageArtifacts ?? true,
+			expectedPackageScope: input.expectedPackageScope,
 		})
 	}
 }

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -91,6 +91,7 @@ export type RepoSessionRpc = {
 	runChecks: (payload: {
 		sessionId: string
 		userId: string
+		expectedPackageScope?: string
 	}) => Promise<RepoSessionCheckRun>
 	getCheckStatus: (payload: {
 		sessionId: string
@@ -122,6 +123,7 @@ export type RepoSessionRpc = {
 		userId: string
 		force?: boolean
 		rebuildPackageArtifacts?: boolean
+		expectedPackageScope?: string
 	}) => Promise<RepoSessionPublishResult>
 	publishFromExternalRef: (payload: {
 		sessionId: string
@@ -132,6 +134,7 @@ export type RepoSessionRpc = {
 		allowForce?: boolean
 		baseUrl?: string
 		rebuildPackageArtifacts?: boolean
+		expectedPackageScope?: string
 	}) => Promise<RepoExternalPublishResult>
 }
 

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -80,6 +80,7 @@ export type RepoSessionRpc = {
 		dryRun?: boolean
 		runChecks?: boolean
 		publish?: boolean
+		expectedPackageScope?: string
 	}) => Promise<RepoRunCommandsResult>
 	bootstrapSource: (payload: {
 		sessionId: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Require saved Kody package names to use the authenticated user's username scope.
- Apply the scope check to `package_save`, repo session checks/publish, repo command checks/publishes, and external package publish flows.
- Add focused coverage for manifest validation, package save rejection before persistence, and package publish scope plumbing.

### Testing
- `npx vitest run --project node-unit "packages/worker/src/package-registry/manifest.node.test.ts"`
- `npx vitest run --project workers-unit "packages/worker/src/mcp/observability.workers.test.ts"`
- `npx vitest run --project node-unit "packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts" "packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts"`
- `npm run typecheck`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-424f3bad-3283-4d2d-baa5-1643b1856071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-424f3bad-3283-4d2d-baa5-1643b1856071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced package scope: packages must match the authenticated user’s namespace during save, checks, and publishing (including external publishes and repo workflows).

* **Bug Fixes**
  * Stricter validation to prevent mismatched scoped package names.
  * Expanded test coverage for scope validation and related publish/check flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/454)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->