### PR TITLE
Add regression coverage for subscription runtime codemode

### DIFF
--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -44,6 +44,7 @@ vi.mock('./published-bundle-artifacts.ts', async () => {
 const {
 	buildKodyAppBundle,
 	createPublishedPackageAppBundleCacheKey,
+	createRuntimeModuleSource,
 	hydrateKodyRuntimeModules,
 } = await import('./module-graph.ts')
 
@@ -701,6 +702,89 @@ export async function runWithRuntime(runtime) {
 		expect(result).toBe('current-host-runtime')
 	} finally {
 		await moduleGraph.cleanup()
+	}
+})
+
+test('hydrateKodyRuntimeModules fixes stale nested runtime modules from static package artifacts', async () => {
+	const nestedRuntimePath =
+		'.__kody_packages__/@kentcdodds/ai-chat/.__published_bundle__/2e/.__kody_virtual__/runtime.js'
+	const staleRuntimeSource = [
+		'const runtime = {}',
+		'export const codemode = runtime.codemode',
+		'export default runtime',
+	].join('\n')
+	const modules = {
+		'.__kody_virtual__/runtime.js': createRuntimeModuleSource(),
+		'entry.js': [
+			"import { __kodyRunInRuntime } from './.__kody_virtual__/runtime.js'",
+			"import runDependency from './.__kody_packages__/@kentcdodds/ai-chat/.__published_bundle__/2e/index.js'",
+			'',
+			'export async function runWithRuntime(runtime) {',
+			'\treturn await __kodyRunInRuntime(runtime, async () => runDependency())',
+			'}',
+		].join('\n'),
+		'.__kody_packages__/@kentcdodds/ai-chat/.__published_bundle__/2e/index.js':
+			[
+				"import { codemode } from './.__kody_virtual__/runtime.js'",
+				'',
+				'export default async function runDependency() {',
+				'\treturn await codemode.service_start({ source: "email" })',
+				'}',
+			].join('\n'),
+		[nestedRuntimePath]: staleRuntimeSource,
+	}
+	const staleModuleGraph = await createTemporaryModuleGraph(modules)
+	try {
+		const staleEntry = (await staleModuleGraph.importModule('entry.js')) as {
+			runWithRuntime: (runtime: Record<string, unknown>) => Promise<unknown>
+		}
+		await expect(
+			staleEntry.runWithRuntime({
+				codemode: {
+					async service_start() {
+						return { ok: true }
+					},
+				},
+			}),
+		).rejects.toThrow(
+			"Cannot read properties of undefined (reading 'service_start')",
+		)
+	} finally {
+		await staleModuleGraph.cleanup()
+	}
+
+	const hydratedModules = await hydrateKodyRuntimeModules({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		modules,
+	})
+	expect(hydratedModules[nestedRuntimePath]).not.toBe(staleRuntimeSource)
+	const hydratedModuleGraph = await createTemporaryModuleGraph(hydratedModules)
+	try {
+		const hydratedEntry = (await hydratedModuleGraph.importModule(
+			'entry.js',
+		)) as {
+			runWithRuntime: (runtime: Record<string, unknown>) => Promise<unknown>
+		}
+		const result = await hydratedEntry.runWithRuntime({
+			codemode: {
+				async service_start(args: unknown) {
+					return { ok: true, args }
+				},
+			},
+		})
+		expect(result).toEqual({
+			ok: true,
+			args: {
+				source: 'email',
+			},
+		})
+	} finally {
+		await hydratedModuleGraph.cleanup()
 	}
 })
 

--- a/packages/worker/src/package-runtime/module-graph.workers.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.workers.test.ts
@@ -76,6 +76,70 @@ test(
 	},
 )
 
+test('subscription bundles refresh stale nested runtime modules from static package dependencies', async () => {
+	const nestedRuntimeModule =
+		'.__kody_packages__/@kentcdodds/ai-chat/.__published_bundle__/2e/.__kody_virtual__/runtime.js'
+	const result = await runBundledModuleWithRegistry(
+		env,
+		createMcpCallerContext({
+			baseUrl: 'https://kody.dev',
+			user: {
+				userId: 'user-workers-test',
+				email: 'worker@example.com',
+				displayName: 'Worker Test',
+			},
+		}),
+		{
+			mainModule: 'dist/subscription.js',
+			modules: {
+				'dist/subscription.js': [
+					"import runDependency from '../.__kody_packages__/@kentcdodds/ai-chat/.__published_bundle__/2e/index.js'",
+					'',
+					'export default async function subscription(input = {}) {',
+					'\treturn await runDependency(input)',
+					'}',
+				].join('\n'),
+				'.__kody_packages__/@kentcdodds/ai-chat/.__published_bundle__/2e/index.js':
+					[
+						"import { codemode } from './.__kody_virtual__/runtime.js'",
+						'',
+						'export default async function runDependency(input = {}) {',
+						"\treturn await codemode.service_start({ source: input.source ?? 'email' })",
+						'}',
+					].join('\n'),
+				[nestedRuntimeModule]: [
+					'const runtime = {}',
+					'export const codemode = runtime.codemode',
+					'export default runtime',
+				].join('\n'),
+			},
+		},
+		{ source: 'email' },
+		{
+			additionalTools: {
+				service_start: async (args) => ({
+					ok: true,
+					args,
+				}),
+			},
+			packageContext: {
+				packageId: 'pkg-subscription',
+				kodyId: 'email-subscriber',
+				sourceId: 'source-subscription',
+			},
+			skipCapabilityRegistry: true,
+		},
+	)
+
+	expect(result.error).toBeUndefined()
+	expect(result.result).toEqual({
+		ok: true,
+		args: {
+			source: 'email',
+		},
+	})
+})
+
 test('saved package execution passes input as the default export argument', async () => {
 	const packageJson = JSON.stringify({
 		name: '@kentcdodds/input-package',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds regression coverage for stale nested `kody:runtime` modules inside static package dependency artifacts.
- Verifies subscription execution refreshes stale nested runtime modules so `codemode.service_start` remains available.

### Testing
- `npx vitest run packages/worker/src/package-runtime/module-graph.node.test.ts packages/worker/src/package-runtime/module-graph.workers.test.ts packages/worker/src/mcp/run-codemode-registry.node.test.ts packages/worker/src/package-invocations/service.node.test.ts`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for runtime module hydration and stale module refreshing in static package dependencies to improve system reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/455)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->