### PR TITLE
Refresh nested package artifact runtimes

### DIFF
--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -788,6 +788,115 @@ test('hydrateKodyRuntimeModules fixes stale nested runtime modules from static p
 	}
 })
 
+test('buildKodyModuleBundle refreshes nested artifact runtimes before static import rebundling', async () => {
+	const staleRuntimeSource = [
+		'const runtime = {}',
+		'export const codemode = runtime.codemode',
+		'export default runtime',
+	].join('\n')
+	mockModule.createWorker.mockResolvedValue(
+		createBundleResult('ai-chat-caller'),
+	)
+	mockModule.getSavedPackageByName.mockResolvedValue(
+		createSavedPackageRecord({
+			name: '@kentcdodds/ai-chat',
+			kodyId: 'ai-chat',
+			sourceId: 'source-ai-chat',
+		}),
+	)
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: {
+			id: 'source-ai-chat',
+			published_commit: 'commit-ai-chat',
+		},
+		manifest: {
+			name: '@kentcdodds/ai-chat',
+			exports: {
+				'.': './src/index.ts',
+			},
+			kody: {
+				id: 'ai-chat',
+				description: 'AI chat helpers',
+			},
+		},
+		files: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/ai-chat',
+				exports: {
+					'.': './src/index.ts',
+				},
+				kody: {
+					id: 'ai-chat',
+					description: 'AI chat helpers',
+				},
+			}),
+			'src/index.ts':
+				'import { codemode } from "kody:runtime"\nexport async function runAgentTurnNonStreaming() { return await codemode.value_get({ name: "ai-chat" }) }',
+		},
+	})
+	mockModule.loadPublishedBundleArtifactByIdentity.mockResolvedValue({
+		row: {},
+		artifact: {
+			version: 1,
+			kind: 'importable-module',
+			artifactName: '.',
+			sourceId: 'source-ai-chat',
+			publishedCommit: 'commit-ai-chat',
+			entryPoint: './src/index.ts',
+			mainModule: 'dist/index.js',
+			modules: {
+				'dist/index.js': [
+					"import { codemode } from './.__kody_virtual__/runtime.js'",
+					'export async function runAgentTurnNonStreaming() {',
+					'\treturn await codemode.value_get({ name: "ai-chat" })',
+					'}',
+				].join('\n'),
+				'dist/.__kody_virtual__/runtime.js': staleRuntimeSource,
+			},
+			dependencies: [],
+			dynamicDependencies: [],
+			packageContext: {
+				packageId: 'pkg-ai-chat',
+				kodyId: 'ai-chat',
+				sourceId: 'source-ai-chat',
+			},
+			serviceContext: null,
+			createdAt: '2026-05-13T00:00:00.000Z',
+		},
+	})
+
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+	await buildKodyModuleBundle({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'entry.ts': [
+				"import { runAgentTurnNonStreaming } from 'kody:@kentcdodds/ai-chat'",
+				'export default async function main() {',
+				'\treturn await runAgentTurnNonStreaming()',
+				'}',
+			].join('\n'),
+		},
+		entryPoint: 'entry.ts',
+	})
+
+	const bundlerInput = mockModule.createWorker.mock.calls[0]?.[0] as
+		| {
+				files?: Record<string, string>
+		  }
+		| undefined
+	const nestedRuntimePath =
+		'.__kody_packages__/@kentcdodds/ai-chat/.__published_bundle__/2e/dist/.__kody_virtual__/runtime.js'
+	expect(bundlerInput?.files?.[nestedRuntimePath]).toContain(
+		'__kodyCreateRuntimeObjectProxy',
+	)
+	expect(bundlerInput?.files?.[nestedRuntimePath]).not.toBe(staleRuntimeSource)
+})
+
 test('buildKodyModuleBundle keeps static imports pinned while literal dynamic imports resolve current packages', async () => {
 	mockModule.createWorker.mockImplementation(
 		async (input: { files: Record<string, string>; entryPoint: string }) => ({

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -293,8 +293,15 @@ function isRuntimeModulePath(modulePath: string) {
 	)
 }
 
-function collectReferencedRuntimeModulePaths(modules: WorkerLoaderModules) {
-	const runtimePaths = new Set<string>([runtimeModulePath])
+function collectReferencedRuntimeModulePaths(
+	modules: WorkerLoaderModules,
+	options?: {
+		includeDefaultRuntimePath?: boolean
+	},
+) {
+	const runtimePaths = new Set<string>(
+		options?.includeDefaultRuntimePath === false ? [] : [runtimeModulePath],
+	)
 	for (const modulePath of Object.keys(modules)) {
 		if (isRuntimeModulePath(modulePath)) {
 			runtimePaths.add(modulePath)
@@ -313,9 +320,15 @@ function collectReferencedRuntimeModulePaths(modules: WorkerLoaderModules) {
 
 export function refreshKodyRuntimeModules(
 	modules: WorkerLoaderModules,
+	options?: {
+		includeDefaultRuntimePath?: boolean
+	},
 ): WorkerLoaderModules {
 	const refreshed: WorkerLoaderModules = { ...modules }
-	for (const modulePath of collectReferencedRuntimeModulePaths(modules)) {
+	for (const modulePath of collectReferencedRuntimeModulePaths(
+		modules,
+		options,
+	)) {
 		refreshed[modulePath] = createRuntimeModuleSource()
 	}
 	return refreshed
@@ -799,6 +812,23 @@ function materializeArtifactModuleSource(input: {
 	)
 }
 
+function materializePublishedArtifactModules(input: {
+	artifactPrefix: string
+	modules: WorkerLoaderModules
+}) {
+	const modules: Record<string, string> = {}
+	for (const [modulePath, module] of Object.entries(input.modules)) {
+		modules[joinPath(input.artifactPrefix, modulePath)] =
+			materializeArtifactModuleSource({
+				modulePath,
+				module,
+			})
+	}
+	return refreshKodyRuntimeModules(modules, {
+		includeDefaultRuntimePath: false,
+	}) as Record<string, string>
+}
+
 function readDynamicPackageImportSpecifier(input: {
 	modulePath: string
 	module: WorkerLoaderModules[string]
@@ -901,16 +931,13 @@ async function maybeEnsurePublishedArtifactTarget(input: {
 		encodePathKey(exportName),
 	)
 	for (const [modulePath, module] of Object.entries(
-		artifact.artifact.modules,
+		materializePublishedArtifactModules({
+			artifactPrefix,
+			modules: artifact.artifact.modules,
+		}),
 	)) {
-		input.state.files[joinPath(artifactPrefix, modulePath)] =
-			materializeArtifactModuleSource({
-				modulePath,
-				module,
-			})
+		input.state.files[modulePath] = module
 	}
-	input.state.files[joinPath(artifactPrefix, runtimeModulePath)] =
-		createRuntimeModuleSource()
 	return joinPath(artifactPrefix, artifact.artifact.mainModule)
 }
 
@@ -1023,9 +1050,12 @@ function installDynamicPackageArtifactModules(input: {
 		),
 	)
 	for (const [artifactModulePath, module] of Object.entries(
-		input.artifact.modules,
+		materializePublishedArtifactModules({
+			artifactPrefix,
+			modules: input.artifact.modules,
+		}),
 	)) {
-		input.modules[joinPath(artifactPrefix, artifactModulePath)] = module
+		input.modules[artifactModulePath] = module
 	}
 	input.modules[input.modulePath] = createDynamicPackageImportProxySource({
 		targetPath: createRelativeImportSpecifier(

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -816,15 +816,15 @@ function materializePublishedArtifactModules(input: {
 	artifactPrefix: string
 	modules: WorkerLoaderModules
 }) {
-	const modules: Record<string, string> = {}
+	const materializedModules: Record<string, string> = {}
 	for (const [modulePath, module] of Object.entries(input.modules)) {
-		modules[joinPath(input.artifactPrefix, modulePath)] =
+		materializedModules[joinPath(input.artifactPrefix, modulePath)] =
 			materializeArtifactModuleSource({
 				modulePath,
 				module,
 			})
 	}
-	return refreshKodyRuntimeModules(modules, {
+	return refreshKodyRuntimeModules(materializedModules, {
 		includeDefaultRuntimePath: false,
 	}) as Record<string, string>
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refresh all referenced nested `kody:runtime` modules when materializing published artifacts for static rebundling.
- Add a regression covering stale `@kentcdodds/ai-chat` artifact runtimes that would otherwise leave `codemode` undefined.
- Address CodeRabbit's clarity nit by renaming the materialized artifact module collector.

## Testing
- `npx vitest run packages/worker/src/package-runtime/module-graph.node.test.ts packages/worker/src/package-runtime/module-graph.workers.test.ts packages/worker/src/mcp/run-codemode-registry.node.test.ts packages/worker/src/package-invocations/service.node.test.ts`
- `npm run validate`
- `npx vitest run packages/worker/src/package-runtime/module-graph.node.test.ts packages/worker/src/package-runtime/module-graph.workers.test.ts`
- `npx oxfmt --check packages/worker/src/package-runtime/module-graph.ts packages/worker/src/package-runtime/module-graph.node.test.ts`
- PR CI: `✅ Validate`, `🔎 Deploy Preview Resources`, `Cursor Bugbot`, and `CodeRabbit` are green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test verifying stale nested runtime modules are refreshed before bundling published artifacts.

* **Refactor**
  * Made runtime-module refresh configurable so only referenced runtime pieces are regenerated when materializing published artifacts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/456)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->