### PR TITLE
Chunk dynamic package artifact path keys

### DIFF
--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -663,6 +663,163 @@ test('buildKodyModuleBundle imports published importable defaults as callable de
 	}
 })
 
+test('workflow-approved-email importable artifact can be inspected without invoking the workflow', async () => {
+	mockModule.createWorker.mockImplementation(
+		async (input: { files: Record<string, string>; entryPoint: string }) => ({
+			mainModule: input.entryPoint,
+			modules: input.files,
+			dependencies: [],
+		}),
+	)
+	mockModule.getSavedPackageByName.mockResolvedValue(
+		createSavedPackageRecord({
+			name: '@kentcdodds/email-received-subscriber',
+			kodyId: 'email-received-subscriber',
+			sourceId: 'source-email-received-subscriber',
+		}),
+	)
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: {
+			id: 'source-email-received-subscriber',
+			published_commit: 'commit-email-received-subscriber',
+		},
+		manifest: {
+			name: '@kentcdodds/email-received-subscriber',
+			exports: {
+				'./workflow-approved-email': './src/workflow-approved-email.ts',
+			},
+			kody: {
+				id: 'email-received-subscriber',
+				description: 'Email received subscriber',
+			},
+		},
+		files: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/email-received-subscriber',
+				exports: {
+					'./workflow-approved-email': './src/workflow-approved-email.ts',
+				},
+				kody: {
+					id: 'email-received-subscriber',
+					description: 'Email received subscriber',
+				},
+			}),
+			'src/workflow-approved-email.ts': [
+				'export default function workflowApprovedEmail(input = {}) {',
+				'\tif (!Array.isArray(input.messages) || input.messages.length === 0) {',
+				'\t\tthrow new Error("messages must include at least one message.")',
+				'\t}',
+				'\treturn { ok: true }',
+				'}',
+			].join('\n'),
+		},
+	})
+	mockModule.loadPublishedBundleArtifactByIdentity.mockImplementation(
+		async (input: {
+			kind: string
+			artifactName?: string | null
+			entryPoint: string
+		}) =>
+			input.kind === 'importable-module' &&
+			input.artifactName === './workflow-approved-email' &&
+			input.entryPoint === 'src/workflow-approved-email.ts'
+				? {
+						row: {
+							id: 'artifact-workflow-approved-email',
+						},
+						artifact: {
+							version: 1,
+							kind: 'importable-module',
+							artifactName: './workflow-approved-email',
+							sourceId: 'source-email-received-subscriber',
+							publishedCommit: 'commit-email-received-subscriber',
+							entryPoint: 'src/workflow-approved-email.ts',
+							mainModule: 'dist/workflow-approved-email.js',
+							modules: {
+								'dist/workflow-approved-email.js': [
+									'export default function workflowApprovedEmail(input = {}) {',
+									'\tif (!Array.isArray(input.messages) || input.messages.length === 0) {',
+									'\t\tthrow new Error("messages must include at least one message.")',
+									'\t}',
+									'\treturn { ok: true }',
+									'}',
+								].join('\n'),
+							},
+							dependencies: [],
+							dynamicDependencies: [],
+							packageContext: {
+								packageId: 'pkg-email-received-subscriber',
+								kodyId: 'email-received-subscriber',
+								sourceId: 'source-email-received-subscriber',
+							},
+							serviceContext: null,
+							createdAt: '2026-05-13T00:00:00.000Z',
+						},
+					}
+				: null,
+	)
+
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+	const staticBundle = await buildKodyModuleBundle({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'entry.ts': [
+				"import workflowApprovedEmail from 'kody:@kentcdodds/email-received-subscriber/workflow-approved-email'",
+				'export default function main() {',
+				'\treturn Function.prototype.toString.call(workflowApprovedEmail)',
+				'}',
+			].join('\n'),
+		},
+		entryPoint: 'entry.ts',
+	})
+	const staticModuleGraph = await createTemporaryModuleGraph(
+		staticBundle.modules,
+	)
+	try {
+		const entry = (await staticModuleGraph.importModule(
+			staticBundle.mainModule,
+		)) as {
+			default: () => Promise<string>
+		}
+		await expect(entry.default()).resolves.toContain('workflowApprovedEmail')
+	} finally {
+		await staticModuleGraph.cleanup()
+	}
+
+	const hydratedModules = await hydrateKodyRuntimeModules({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		modules: {
+			'entry.js': [
+				'export default async function main() {',
+				"\tconst module = await import('./.__kody_virtual__/dynamic-imports/workflow-approved-email.js')",
+				'\treturn Function.prototype.toString.call(module.default)',
+				'}',
+			].join('\n'),
+			'.__kody_virtual__/dynamic-imports/workflow-approved-email.js':
+				'export const __kodyDynamicPackageSpecifier = "kody:@kentcdodds/email-received-subscriber/workflow-approved-email";',
+		},
+	})
+	const dynamicModuleGraph = await createTemporaryModuleGraph(hydratedModules)
+	try {
+		const entry = (await dynamicModuleGraph.importModule('entry.js')) as {
+			default: () => Promise<string>
+		}
+		await expect(entry.default()).resolves.toContain('workflowApprovedEmail')
+	} finally {
+		await dynamicModuleGraph.cleanup()
+	}
+})
+
 test('hydrateKodyRuntimeModules replaces stale persisted kody runtime modules', async () => {
 	const staleRuntimeSource =
 		'export const codemode = { stale: true }; export default { codemode };'

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -444,6 +444,12 @@ function encodePathKey(value: string) {
 	).join('')
 }
 
+function encodePathKeyAsPath(value: string) {
+	const encoded = encodePathKey(value)
+	const chunks = encoded.match(/.{1,96}/g)
+	return chunks?.join('/') ?? encoded
+}
+
 function decodePathKey(value: string) {
 	const bytes = value.match(/[0-9a-f]{2}/gi)
 	if (!bytes || bytes.join('') !== value) return null
@@ -928,7 +934,7 @@ async function maybeEnsurePublishedArtifactTarget(input: {
 	const artifactPrefix = joinPath(
 		input.loaded.prefix,
 		'.__published_bundle__',
-		encodePathKey(exportName),
+		encodePathKeyAsPath(exportName),
 	)
 	for (const [modulePath, module] of Object.entries(
 		materializePublishedArtifactModules({
@@ -1045,7 +1051,7 @@ function installDynamicPackageArtifactModules(input: {
 	const artifactPrefix = joinPath(
 		dirname(input.modulePath),
 		dynamicPackageImportArtifactSegment,
-		encodePathKey(
+		encodePathKeyAsPath(
 			`${input.specifier}#${input.artifact.sourceId}#${input.artifact.publishedCommit}`,
 		),
 	)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Chunk encoded published artifact path keys so long package specifier/source/commit identities do not become one oversized module path segment.
- Add regression coverage for static and dynamic imports of `email-received-subscriber/workflow-approved-email` proving the export can be inspected without invoking the workflow.

## Testing
- `npx vitest run packages/worker/src/package-runtime/module-graph.node.test.ts -t workflow-approved-email`
- `npx oxfmt --check packages/worker/src/package-runtime/module-graph.ts packages/worker/src/package-runtime/module-graph.node.test.ts`
- `npx vitest run packages/worker/src/package-runtime/module-graph.node.test.ts`
- `npm run typecheck`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Tests**
  * Added test case verifying workflow artifacts can be properly inspected and imported without unintended execution.

* **Chores**
  * Optimized artifact installation path construction to improve artifact handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/457)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->