### PR TITLE
Validate published bundle artifact identity

### DIFF
--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -671,41 +671,144 @@ test('workflow-approved-email importable artifact can be inspected without invok
 			dependencies: [],
 		}),
 	)
-	mockModule.getSavedPackageByName.mockResolvedValue(
-		createSavedPackageRecord({
-			name: '@kentcdodds/email-received-subscriber',
+	mockModule.getSavedPackageByName.mockImplementation(
+		async (_db: unknown, input: { name: string }) =>
+			input.name === '@kentcdodds/email-received-subscriber'
+				? createSavedPackageRecord({
+						name: '@kentcdodds/email-received-subscriber',
+						kodyId: 'email-received-subscriber',
+						sourceId: 'source-email-received-subscriber',
+					})
+				: input.name === '@kentcdodds/ai-chat'
+					? createSavedPackageRecord({
+							name: '@kentcdodds/ai-chat',
+							kodyId: 'ai-chat',
+							sourceId: 'source-ai-chat',
+						})
+					: null,
+	)
+	mockModule.loadPackageSourceBySourceId.mockImplementation(
+		async (input: { sourceId: string }) =>
+			input.sourceId === 'source-email-received-subscriber'
+				? {
+						source: {
+							id: 'source-email-received-subscriber',
+							published_commit: 'commit-email-received-subscriber',
+						},
+						manifest: {
+							name: '@kentcdodds/email-received-subscriber',
+							exports: {
+								'./workflow-approved-email': './src/workflow-approved-email.ts',
+							},
+							kody: {
+								id: 'email-received-subscriber',
+								description: 'Email received subscriber',
+							},
+						},
+						files: {
+							'package.json': JSON.stringify({
+								name: '@kentcdodds/email-received-subscriber',
+								exports: {
+									'./workflow-approved-email':
+										'./src/workflow-approved-email.ts',
+								},
+								kody: {
+									id: 'email-received-subscriber',
+									description: 'Email received subscriber',
+								},
+							}),
+							'src/workflow-approved-email.ts': [
+								'import { processApprovedEmailWorkflow } from "./core.js"',
+								'export default function workflowApprovedEmail(input = {}) {',
+								'\treturn processApprovedEmailWorkflow(input)',
+								'}',
+							].join('\n'),
+						},
+					}
+				: input.sourceId === 'source-ai-chat'
+					? {
+							source: {
+								id: 'source-ai-chat',
+								published_commit: 'commit-ai-chat',
+							},
+							manifest: {
+								name: '@kentcdodds/ai-chat',
+								exports: {
+									'.': './src/index.ts',
+								},
+								kody: {
+									id: 'ai-chat',
+									description: 'AI chat',
+								},
+							},
+							files: {
+								'package.json': JSON.stringify({
+									name: '@kentcdodds/ai-chat',
+									exports: {
+										'.': './src/index.ts',
+									},
+									kody: {
+										id: 'ai-chat',
+										description: 'AI chat',
+									},
+								}),
+								'src/index.ts':
+									'export default async function runAgentTurn() { return { ok: true } }',
+							},
+						}
+					: null,
+	)
+	const createWorkflowArtifact = () => ({
+		version: 1,
+		kind: 'importable-module' as const,
+		artifactName: './workflow-approved-email',
+		sourceId: 'source-email-received-subscriber',
+		publishedCommit: 'commit-email-received-subscriber',
+		entryPoint: 'src/workflow-approved-email.ts',
+		mainModule: 'dist/workflow-approved-email.js',
+		modules: {
+			'dist/workflow-approved-email.js': [
+				'import { processApprovedEmailWorkflow } from "./core.js"',
+				'export default function workflowApprovedEmail(input = {}) {',
+				'\treturn processApprovedEmailWorkflow(input)',
+				'}',
+			].join('\n'),
+			'dist/core.js': [
+				'export async function processApprovedEmailWorkflow(input = {}) {',
+				"\tconst aiChat = await import('./.__kody_virtual__/dynamic-imports/ai-chat.js')",
+				'\treturn await aiChat.default({ messages: input.messages })',
+				'}',
+			].join('\n'),
+			'dist/.__kody_virtual__/dynamic-imports/ai-chat.js':
+				'export const __kodyDynamicPackageSpecifier = "kody:@kentcdodds/ai-chat";',
+		},
+		dependencies: [],
+		dynamicDependencies: [
+			{
+				specifier: 'kody:@kentcdodds/ai-chat',
+				packageName: '@kentcdodds/ai-chat',
+				exportName: '.',
+			},
+		],
+		packageContext: {
+			packageId: 'pkg-email-received-subscriber',
 			kodyId: 'email-received-subscriber',
 			sourceId: 'source-email-received-subscriber',
-		}),
-	)
-	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
-		source: {
-			id: 'source-email-received-subscriber',
-			published_commit: 'commit-email-received-subscriber',
 		},
-		manifest: {
-			name: '@kentcdodds/email-received-subscriber',
-			exports: {
-				'./workflow-approved-email': './src/workflow-approved-email.ts',
-			},
-			kody: {
-				id: 'email-received-subscriber',
-				description: 'Email received subscriber',
-			},
-		},
-		files: {
-			'package.json': JSON.stringify({
-				name: '@kentcdodds/email-received-subscriber',
-				exports: {
-					'./workflow-approved-email': './src/workflow-approved-email.ts',
-				},
-				kody: {
-					id: 'email-received-subscriber',
-					description: 'Email received subscriber',
-				},
-			}),
-			'src/workflow-approved-email.ts': [
-				'export default function workflowApprovedEmail(input = {}) {',
+		serviceContext: null,
+		createdAt: '2026-05-13T00:00:00.000Z',
+	})
+	const aiChatArtifact = {
+		version: 1,
+		kind: 'importable-module' as const,
+		artifactName: '.',
+		sourceId: 'source-ai-chat',
+		publishedCommit: 'commit-ai-chat',
+		entryPoint: 'src/index.ts',
+		mainModule: 'dist/index.js',
+		modules: {
+			'dist/index.js': [
+				'export default async function runAgentTurn(input = {}) {',
 				'\tif (!Array.isArray(input.messages) || input.messages.length === 0) {',
 				'\t\tthrow new Error("messages must include at least one message.")',
 				'\t}',
@@ -713,50 +816,51 @@ test('workflow-approved-email importable artifact can be inspected without invok
 				'}',
 			].join('\n'),
 		},
-	})
+		dependencies: [],
+		dynamicDependencies: [],
+		packageContext: {
+			packageId: 'pkg-ai-chat',
+			kodyId: 'ai-chat',
+			sourceId: 'source-ai-chat',
+		},
+		serviceContext: null,
+		createdAt: '2026-05-13T00:00:00.000Z',
+	}
 	mockModule.loadPublishedBundleArtifactByIdentity.mockImplementation(
 		async (input: {
 			kind: string
+			sourceId: string
 			artifactName?: string | null
 			entryPoint: string
-		}) =>
-			input.kind === 'importable-module' &&
-			input.artifactName === './workflow-approved-email' &&
-			input.entryPoint === 'src/workflow-approved-email.ts'
-				? {
-						row: {
-							id: 'artifact-workflow-approved-email',
-						},
-						artifact: {
-							version: 1,
-							kind: 'importable-module',
-							artifactName: './workflow-approved-email',
-							sourceId: 'source-email-received-subscriber',
-							publishedCommit: 'commit-email-received-subscriber',
-							entryPoint: 'src/workflow-approved-email.ts',
-							mainModule: 'dist/workflow-approved-email.js',
-							modules: {
-								'dist/workflow-approved-email.js': [
-									'export default function workflowApprovedEmail(input = {}) {',
-									'\tif (!Array.isArray(input.messages) || input.messages.length === 0) {',
-									'\t\tthrow new Error("messages must include at least one message.")',
-									'\t}',
-									'\treturn { ok: true }',
-									'}',
-								].join('\n'),
-							},
-							dependencies: [],
-							dynamicDependencies: [],
-							packageContext: {
-								packageId: 'pkg-email-received-subscriber',
-								kodyId: 'email-received-subscriber',
-								sourceId: 'source-email-received-subscriber',
-							},
-							serviceContext: null,
-							createdAt: '2026-05-13T00:00:00.000Z',
-						},
-					}
-				: null,
+		}) => {
+			if (
+				input.kind === 'importable-module' &&
+				input.sourceId === 'source-email-received-subscriber' &&
+				input.artifactName === './workflow-approved-email' &&
+				input.entryPoint === 'src/workflow-approved-email.ts'
+			) {
+				return {
+					row: {
+						id: 'artifact-workflow-approved-email',
+					},
+					artifact: createWorkflowArtifact(),
+				}
+			}
+			if (
+				input.kind === 'importable-module' &&
+				input.sourceId === 'source-ai-chat' &&
+				input.artifactName === '.' &&
+				input.entryPoint === 'src/index.ts'
+			) {
+				return {
+					row: {
+						id: 'artifact-ai-chat',
+					},
+					artifact: aiChatArtifact,
+				}
+			}
+			return null
+		},
 	)
 
 	const { buildKodyModuleBundle } = await import('./module-graph.ts')

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
@@ -1,12 +1,16 @@
 import { expect, test, vi } from 'vitest'
 import type * as PublishedBundleArtifactRepo from '#worker/repo/published-bundle-artifacts-repo.ts'
 import type * as PublishedRuntimeArtifacts from './published-runtime-artifacts.ts'
-import { rebuildPublishedPackageArtifacts } from './published-bundle-artifacts.ts'
+import {
+	loadPublishedBundleArtifactByIdentity,
+	rebuildPublishedPackageArtifacts,
+} from './published-bundle-artifacts.ts'
 
 const mockModule = vi.hoisted(() => ({
 	getEntitySourceById: vi.fn(),
 	getPublishedBundleArtifactByIdentity: vi.fn(),
 	insertPublishedBundleArtifactRow: vi.fn(),
+	readPublishedBundleArtifact: vi.fn(),
 	updatePublishedBundleArtifactRow: vi.fn(),
 	writePublishedBundleArtifact: vi.fn(),
 }))
@@ -37,15 +41,79 @@ vi.mock('./published-runtime-artifacts.ts', async () => {
 	)
 	return {
 		...actual,
+		readPublishedBundleArtifact: (...args: Array<unknown>) =>
+			mockModule.readPublishedBundleArtifact(...args),
 		writePublishedBundleArtifact: (...args: Array<unknown>) =>
 			mockModule.writePublishedBundleArtifact(...args),
 	}
+})
+
+test('loadPublishedBundleArtifactByIdentity rejects mismatched KV artifact payloads', async () => {
+	mockModule.getPublishedBundleArtifactByIdentity.mockReset()
+	mockModule.readPublishedBundleArtifact.mockReset()
+	mockModule.getPublishedBundleArtifactByIdentity.mockResolvedValue({
+		id: 'artifact-row-1',
+		userId: 'user-1',
+		sourceId: 'source-email-received-subscriber',
+		publishedCommit: 'commit-email-received-subscriber',
+		artifactKind: 'importable-module',
+		artifactName: './workflow-approved-email',
+		entryPoint: 'src/workflow-approved-email.ts',
+		kvKey: 'kv:workflow-approved-email',
+		dependenciesJson: '[]',
+		createdAt: '2026-05-13T00:00:00.000Z',
+		updatedAt: '2026-05-13T00:00:00.000Z',
+	})
+	mockModule.readPublishedBundleArtifact.mockResolvedValue({
+		version: 1,
+		kind: 'importable-module',
+		artifactName: '.',
+		sourceId: 'source-ai-chat',
+		publishedCommit: 'commit-ai-chat',
+		entryPoint: 'src/index.ts',
+		mainModule: 'dist/index.js',
+		modules: {
+			'dist/index.js':
+				'export default async function runAgentTurn() { throw new Error("messages must include at least one message.") }',
+		},
+		dependencies: [],
+		dynamicDependencies: [],
+		packageContext: {
+			packageId: 'pkg-ai-chat',
+			kodyId: 'ai-chat',
+			sourceId: 'source-ai-chat',
+		},
+		serviceContext: null,
+		createdAt: '2026-05-13T00:00:00.000Z',
+	})
+
+	await expect(
+		loadPublishedBundleArtifactByIdentity({
+			env: {
+				APP_DB: {},
+				BUNDLE_ARTIFACTS_KV: {},
+			} as unknown as Env,
+			userId: 'user-1',
+			sourceId: 'source-email-received-subscriber',
+			kind: 'importable-module',
+			artifactName: './workflow-approved-email',
+			entryPoint: './src/workflow-approved-email.ts',
+		}),
+	).resolves.toEqual({
+		row: expect.objectContaining({
+			sourceId: 'source-email-received-subscriber',
+			artifactName: './workflow-approved-email',
+			entryPoint: 'src/workflow-approved-email.ts',
+		}),
+		artifact: null,
+	})
 })
 
 test('rebuildPublishedPackageArtifacts bundles declared subscription handlers', async () => {
 	mockModule.getEntitySourceById.mockReset()
 	mockModule.getPublishedBundleArtifactByIdentity.mockReset()
 	mockModule.insertPublishedBundleArtifactRow.mockReset()
+	mockModule.readPublishedBundleArtifact.mockReset()
 	mockModule.updatePublishedBundleArtifactRow.mockReset()
 	mockModule.writePublishedBundleArtifact.mockReset()
 	mockModule.getPublishedBundleArtifactByIdentity.mockResolvedValue(null)

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
@@ -109,6 +109,67 @@ test('loadPublishedBundleArtifactByIdentity rejects mismatched KV artifact paylo
 	})
 })
 
+test('loadPublishedBundleArtifactByIdentity treats malformed KV artifact payloads as cache misses', async () => {
+	mockModule.getPublishedBundleArtifactByIdentity.mockReset()
+	mockModule.readPublishedBundleArtifact.mockReset()
+	mockModule.getPublishedBundleArtifactByIdentity.mockResolvedValue({
+		id: 'artifact-row-1',
+		userId: 'user-1',
+		sourceId: 'source-email-received-subscriber',
+		publishedCommit: 'commit-email-received-subscriber',
+		artifactKind: 'importable-module',
+		artifactName: './workflow-approved-email',
+		entryPoint: 'src/workflow-approved-email.ts',
+		kvKey: 'kv:workflow-approved-email',
+		dependenciesJson: '[]',
+		createdAt: '2026-05-13T00:00:00.000Z',
+		updatedAt: '2026-05-13T00:00:00.000Z',
+	})
+	mockModule.readPublishedBundleArtifact.mockResolvedValue({
+		version: 1,
+		kind: 'importable-module',
+		artifactName: './workflow-approved-email',
+		sourceId: 'source-email-received-subscriber',
+		publishedCommit: 'commit-email-received-subscriber',
+		entryPoint: '',
+		mainModule: 'dist/workflow-approved-email.js',
+		modules: {
+			'dist/workflow-approved-email.js':
+				'export default async function run() { return "ok" }',
+		},
+		dependencies: [],
+		dynamicDependencies: [],
+		packageContext: {
+			packageId: 'pkg-email-received-subscriber',
+			kodyId: 'email-received-subscriber',
+			sourceId: 'source-email-received-subscriber',
+		},
+		serviceContext: null,
+		createdAt: '2026-05-13T00:00:00.000Z',
+	})
+
+	await expect(
+		loadPublishedBundleArtifactByIdentity({
+			env: {
+				APP_DB: {},
+				BUNDLE_ARTIFACTS_KV: {},
+			} as unknown as Env,
+			userId: 'user-1',
+			sourceId: 'source-email-received-subscriber',
+			kind: 'importable-module',
+			artifactName: './workflow-approved-email',
+			entryPoint: './src/workflow-approved-email.ts',
+		}),
+	).resolves.toEqual({
+		row: expect.objectContaining({
+			sourceId: 'source-email-received-subscriber',
+			artifactName: './workflow-approved-email',
+			entryPoint: 'src/workflow-approved-email.ts',
+		}),
+		artifact: null,
+	})
+})
+
 test('rebuildPublishedPackageArtifacts bundles declared subscription handlers', async () => {
 	mockModule.getEntitySourceById.mockReset()
 	mockModule.getPublishedBundleArtifactByIdentity.mockReset()

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.ts
@@ -116,12 +116,18 @@ function matchesPublishedBundleArtifactIdentity(input: {
 	artifactName: string | null
 	entryPoint: string
 }) {
+	let artifactEntryPoint: string
+	try {
+		artifactEntryPoint = normalizeEntryPoint(input.artifact.entryPoint)
+	} catch {
+		return false
+	}
 	return (
 		input.artifact.sourceId === input.sourceId &&
 		input.artifact.publishedCommit === input.publishedCommit &&
 		input.artifact.kind === input.kind &&
 		normalizeArtifactName(input.artifact.artifactName) === input.artifactName &&
-		normalizeEntryPoint(input.artifact.entryPoint) === input.entryPoint &&
+		artifactEntryPoint === input.entryPoint &&
 		input.artifact.modules[input.artifact.mainModule] != null
 	)
 }

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.ts
@@ -108,6 +108,24 @@ function toDbRowInput(input: {
 	}
 }
 
+function matchesPublishedBundleArtifactIdentity(input: {
+	artifact: PublishedBundleArtifact
+	sourceId: string
+	publishedCommit: string
+	kind: BundleArtifactKind
+	artifactName: string | null
+	entryPoint: string
+}) {
+	return (
+		input.artifact.sourceId === input.sourceId &&
+		input.artifact.publishedCommit === input.publishedCommit &&
+		input.artifact.kind === input.kind &&
+		normalizeArtifactName(input.artifact.artifactName) === input.artifactName &&
+		normalizeEntryPoint(input.artifact.entryPoint) === input.entryPoint &&
+		input.artifact.modules[input.artifact.mainModule] != null
+	)
+}
+
 export async function persistPublishedBundleArtifact(
 	input: PersistPublishedBundleArtifactInput,
 ) {
@@ -195,12 +213,14 @@ export async function loadPublishedBundleArtifactByIdentity(input: {
 	artifactName?: string | null
 	entryPoint: string
 }) {
+	const artifactName = normalizeArtifactName(input.artifactName)
+	const entryPoint = normalizeEntryPoint(input.entryPoint)
 	const row = await getPublishedBundleArtifactByIdentity(input.env.APP_DB, {
 		userId: input.userId,
 		sourceId: input.sourceId,
 		artifactKind: input.kind,
-		artifactName: normalizeArtifactName(input.artifactName),
-		entryPoint: normalizeEntryPoint(input.entryPoint),
+		artifactName,
+		entryPoint,
 	})
 	if (!row) return null
 	const artifact = await readPublishedBundleArtifact({
@@ -208,6 +228,21 @@ export async function loadPublishedBundleArtifactByIdentity(input: {
 		kvKey: row.kvKey,
 	})
 	if (!artifact) {
+		return {
+			row,
+			artifact: null,
+		}
+	}
+	if (
+		!matchesPublishedBundleArtifactIdentity({
+			artifact,
+			sourceId: row.sourceId,
+			publishedCommit: row.publishedCommit,
+			kind: input.kind,
+			artifactName,
+			entryPoint,
+		})
+	) {
 		return {
 			row,
 			artifact: null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Validate loaded published bundle artifact payload identity against the DB row before executing it.
- Return a cache miss for mismatched or malformed KV payloads so callers rebuild or fall back instead of executing the wrong package artifact.
- Add regressions for the observed `workflow-approved-email` / `ai-chat` artifact mismatch, malformed artifact payload handling, and import inspection behavior.

## Testing
- `npx vitest run packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts`
- `npx vitest run packages/worker/src/package-runtime/module-graph.node.test.ts -t workflow-approved-email`
- `npx vitest run packages/worker/src/package-runtime/module-graph.node.test.ts packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated warnings)
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for inspecting workflow artifacts that dynamically import from multiple packages; mocks now simulate multi-package setups and callable dynamic dependencies.
  * Added tests ensuring KV-stored bundle artifacts are treated as cache misses when malformed or mismatched.

* **Bug Fixes**
  * Strengthened artifact identity validation to avoid returning bundle artifacts that don’t match their recorded metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/458)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->