### PR TITLE
Keep dynamic package imports from replacing entrypoints

### DIFF
--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -1313,16 +1313,49 @@ function ensureDynamicPackageImportProxy(
 
 function collectDynamicPackageImportProxyModules(
 	files: Record<string, string>,
+	emittedModules: WorkerLoaderModules,
 ) {
+	const referencedProxyPaths = collectReferencedDynamicPackageImportProxyPaths(
+		emittedModules,
+	)
 	return Object.fromEntries(
 		Object.entries(files).filter(([modulePath]) => {
 			const normalizedPath = normalizeWorkspaceModulePath(modulePath)
 			return (
-				normalizedPath.startsWith(`${dynamicPackageImportProxyPrefix}/`) ||
-				normalizedPath.includes(`/${dynamicPackageImportProxyPrefix}/`)
+				isDynamicPackageImportProxyPath(normalizedPath) &&
+				referencedProxyPaths.has(normalizedPath)
 			)
 		}),
 	)
+}
+
+function isDynamicPackageImportProxyPath(modulePath: string) {
+	return (
+		modulePath.startsWith(`${dynamicPackageImportProxyPrefix}/`) ||
+		modulePath.includes(`/${dynamicPackageImportProxyPrefix}/`)
+	)
+}
+
+function collectReferencedDynamicPackageImportProxyPaths(
+	modules: WorkerLoaderModules,
+) {
+	const referencedPaths = new Set<string>()
+	const proxyReferencePattern =
+		/["']((?:\.\.?\/)?[^"']*\.?__kody_virtual__\/dynamic-imports\/[^"']+?\.js)["']/g
+	for (const [modulePath, module] of iterateModuleSourceTexts(modules)) {
+		if (isDynamicPackageImportProxyPath(normalizeWorkspaceModulePath(modulePath))) {
+			referencedPaths.add(normalizeWorkspaceModulePath(modulePath))
+		}
+		for (const match of module.matchAll(proxyReferencePattern)) {
+			const specifier = match[1]
+			if (!specifier) continue
+			const resolvedPath = resolveRelativeModulePath(modulePath, specifier)
+			referencedPaths.add(
+				resolvedPath ?? normalizeWorkspaceModulePath(specifier),
+			)
+		}
+	}
+	return referencedPaths
 }
 
 function createUniqueHelperName(source: string, baseName: string) {
@@ -1380,6 +1413,8 @@ async function rewriteKodyImports(input: {
 				input.state,
 				node.literalSpecifier,
 			)
+			input.state.files[joinPath(rootSourcePrefix, proxyPath)] ??=
+				input.state.files[proxyPath] ?? ''
 			input.state.files[joinPath(dirname(input.modulePath), proxyPath)] ??=
 				input.state.files[proxyPath] ?? ''
 			dynamicPackageImportHelperName ??= createUniqueHelperName(
@@ -1462,7 +1497,10 @@ export async function buildKodyModuleBundle(input: {
 	})
 	const modules = {
 		...stripKodyRuntimeModules(bundle.modules as WorkerLoaderModules),
-		...collectDynamicPackageImportProxyModules(files),
+		...collectDynamicPackageImportProxyModules(
+			files,
+			bundle.modules as WorkerLoaderModules,
+		),
 	}
 	assertBundleHasNoUnresolvedBareImports({
 		modules,
@@ -1512,7 +1550,10 @@ export async function buildKodyImportableModuleBundle(input: {
 	})
 	const modules = {
 		...stripKodyRuntimeModules(bundle.modules as WorkerLoaderModules),
-		...collectDynamicPackageImportProxyModules(files),
+		...collectDynamicPackageImportProxyModules(
+			files,
+			bundle.modules as WorkerLoaderModules,
+		),
 	}
 	assertBundleHasNoUnresolvedBareImports({
 		modules,
@@ -1631,7 +1672,10 @@ export async function buildKodyAppBundle(input: {
 		})
 		const modules = {
 			...stripKodyRuntimeModules(bundle.modules as WorkerLoaderModules),
-			...collectDynamicPackageImportProxyModules(files),
+			...collectDynamicPackageImportProxyModules(
+				files,
+				bundle.modules as WorkerLoaderModules,
+			),
 		}
 		assertBundleHasNoUnresolvedBareImports({
 			modules,

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -1315,9 +1315,8 @@ function collectDynamicPackageImportProxyModules(
 	files: Record<string, string>,
 	emittedModules: WorkerLoaderModules,
 ) {
-	const referencedProxyPaths = collectReferencedDynamicPackageImportProxyPaths(
-		emittedModules,
-	)
+	const referencedProxyPaths =
+		collectReferencedDynamicPackageImportProxyPaths(emittedModules)
 	return Object.fromEntries(
 		Object.entries(files).filter(([modulePath]) => {
 			const normalizedPath = normalizeWorkspaceModulePath(modulePath)
@@ -1343,7 +1342,9 @@ function collectReferencedDynamicPackageImportProxyPaths(
 	const proxyReferencePattern =
 		/["']((?:\.\.?\/)?[^"']*\.?__kody_virtual__\/dynamic-imports\/[^"']+?\.js)["']/g
 	for (const [modulePath, module] of iterateModuleSourceTexts(modules)) {
-		if (isDynamicPackageImportProxyPath(normalizeWorkspaceModulePath(modulePath))) {
+		if (
+			isDynamicPackageImportProxyPath(normalizeWorkspaceModulePath(modulePath))
+		) {
 			referencedPaths.add(normalizeWorkspaceModulePath(modulePath))
 		}
 		for (const match of module.matchAll(proxyReferencePattern)) {

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -430,6 +430,14 @@ const ${input.helperName} = async (specifier) => {
 `.trim()
 }
 
+function createDynamicPackageImportHelperSource(input: { helperName: string }) {
+	return `
+const ${input.helperName} = async (specifier) => {
+	return await import(specifier);
+};
+`.trim()
+}
+
 function createImportableEntrypointSource(input: { modulePath: string }) {
 	return `
 export * from ${JSON.stringify(input.modulePath)};
@@ -835,10 +843,19 @@ function materializePublishedArtifactModules(input: {
 	}) as Record<string, string>
 }
 
+function isStandaloneDynamicPackageImportPlaceholder(source: string) {
+	return source
+		.trimStart()
+		.startsWith(`export const ${dynamicPackageImportSpecifierExportName}`)
+}
+
 function readDynamicPackageImportSpecifier(input: {
 	modulePath: string
 	module: WorkerLoaderModules[string]
 }) {
+	const specifierFromProxyPath = createPackageSpecifierFromProxyPath(
+		input.modulePath,
+	)
 	const source =
 		typeof input.module === 'string'
 			? input.module
@@ -851,13 +868,18 @@ function readDynamicPackageImportSpecifier(input: {
 						: ''
 	if (!source.includes(dynamicPackageImportSpecifierExportName)) {
 		if (source.includes(dynamicPackageImportResolvedMarker)) return null
-		return createPackageSpecifierFromProxyPath(input.modulePath)
+		return specifierFromProxyPath
+	}
+	if (
+		!specifierFromProxyPath &&
+		!isStandaloneDynamicPackageImportPlaceholder(source)
+	) {
+		return null
 	}
 	const markerIndex = source.indexOf(dynamicPackageImportSpecifierExportName)
 	const match = source.slice(markerIndex).match(/=\s*("(?:[^"\\]|\\.)*")/)
 	const rawSpecifier = match?.[1]
-	if (!rawSpecifier)
-		return createPackageSpecifierFromProxyPath(input.modulePath)
+	if (!rawSpecifier) return specifierFromProxyPath
 	try {
 		const specifier = JSON.parse(rawSpecifier) as unknown
 		return typeof specifier === 'string' &&
@@ -865,7 +887,7 @@ function readDynamicPackageImportSpecifier(input: {
 			? specifier
 			: null
 	} catch {
-		return createPackageSpecifierFromProxyPath(input.modulePath)
+		return specifierFromProxyPath
 	}
 }
 
@@ -1289,6 +1311,20 @@ function ensureDynamicPackageImportProxy(
 	return proxyPath
 }
 
+function collectDynamicPackageImportProxyModules(
+	files: Record<string, string>,
+) {
+	return Object.fromEntries(
+		Object.entries(files).filter(([modulePath]) => {
+			const normalizedPath = normalizeWorkspaceModulePath(modulePath)
+			return (
+				normalizedPath.startsWith(`${dynamicPackageImportProxyPrefix}/`) ||
+				normalizedPath.includes(`/${dynamicPackageImportProxyPrefix}/`)
+			)
+		}),
+	)
+}
+
 function createUniqueHelperName(source: string, baseName: string) {
 	let candidate = baseName
 	let suffix = 0
@@ -1325,17 +1361,6 @@ async function rewriteKodyImports(input: {
 			continue
 		}
 		if (node.kind === 'dynamic') {
-			const proxyPath = ensureDynamicPackageImportProxy(
-				input.state,
-				node.specifier,
-			)
-			replacements.push({
-				start: node.start,
-				end: node.end,
-				value: JSON.stringify(
-					createRelativeImportSpecifier(input.modulePath, proxyPath),
-				),
-			})
 			continue
 		}
 		const proxyPath = await ensurePackageProxy(input.state, node.specifier)
@@ -1347,19 +1372,38 @@ async function rewriteKodyImports(input: {
 			),
 		})
 	}
-	const nonLiteralDynamicImports = dynamicImportNodes.filter(
-		(node) => node.literalSpecifier == null,
-	)
-	let helperName: string | null = null
-	for (const node of nonLiteralDynamicImports) {
-		helperName ??= createUniqueHelperName(
+	let computedImportHelperName: string | null = null
+	let dynamicPackageImportHelperName: string | null = null
+	for (const node of dynamicImportNodes) {
+		if (node.literalSpecifier?.startsWith(packageSpecifierPrefix)) {
+			const proxyPath = ensureDynamicPackageImportProxy(
+				input.state,
+				node.literalSpecifier,
+			)
+			input.state.files[joinPath(dirname(input.modulePath), proxyPath)] ??=
+				input.state.files[proxyPath] ?? ''
+			dynamicPackageImportHelperName ??= createUniqueHelperName(
+				input.source,
+				'__kodyDynamicPackageImport',
+			)
+			replacements.push({
+				start: node.start,
+				end: node.end,
+				value: `${dynamicPackageImportHelperName}(${JSON.stringify(
+					`./${proxyPath}`,
+				)})`,
+			})
+			continue
+		}
+		if (node.literalSpecifier != null) continue
+		computedImportHelperName ??= createUniqueHelperName(
 			input.source,
 			'__kodyDynamicImportGuard',
 		)
 		replacements.push({
 			start: node.start,
 			end: node.end,
-			value: `${helperName}(${input.source.slice(
+			value: `${computedImportHelperName}(${input.source.slice(
 				node.sourceStart,
 				node.sourceEnd,
 			)})`,
@@ -1370,9 +1414,19 @@ async function rewriteKodyImports(input: {
 	)
 	assertReplacementsDoNotOverlap(sortedReplacements)
 	const rewritten = applyReplacements(input.source, sortedReplacements)
-	return helperName
-		? `${createComputedDynamicImportGuardSource({ helperName })}\n${rewritten}`
-		: rewritten
+	const helpers = [
+		dynamicPackageImportHelperName
+			? createDynamicPackageImportHelperSource({
+					helperName: dynamicPackageImportHelperName,
+				})
+			: '',
+		computedImportHelperName
+			? createComputedDynamicImportGuardSource({
+					helperName: computedImportHelperName,
+				})
+			: '',
+	].filter(Boolean)
+	return helpers.length > 0 ? `${helpers.join('\n')}\n${rewritten}` : rewritten
 }
 
 export async function buildKodyModuleBundle(input: {
@@ -1406,7 +1460,10 @@ export async function buildKodyModuleBundle(input: {
 		files,
 		entryPoint: bootstrapPath,
 	})
-	const modules = stripKodyRuntimeModules(bundle.modules as WorkerLoaderModules)
+	const modules = {
+		...stripKodyRuntimeModules(bundle.modules as WorkerLoaderModules),
+		...collectDynamicPackageImportProxyModules(files),
+	}
 	assertBundleHasNoUnresolvedBareImports({
 		modules,
 		bundleLabel: `Saved package module "${normalizePackageWorkspacePath(input.entryPoint)}" bundle`,
@@ -1453,7 +1510,10 @@ export async function buildKodyImportableModuleBundle(input: {
 		files,
 		entryPoint: bootstrapPath,
 	})
-	const modules = stripKodyRuntimeModules(bundle.modules as WorkerLoaderModules)
+	const modules = {
+		...stripKodyRuntimeModules(bundle.modules as WorkerLoaderModules),
+		...collectDynamicPackageImportProxyModules(files),
+	}
 	assertBundleHasNoUnresolvedBareImports({
 		modules,
 		bundleLabel: `Saved package import "${normalizePackageWorkspacePath(input.entryPoint)}" bundle`,
@@ -1569,9 +1629,10 @@ export async function buildKodyAppBundle(input: {
 			files,
 			entryPoint: bootstrapPath,
 		})
-		const modules = stripKodyRuntimeModules(
-			bundle.modules as WorkerLoaderModules,
-		)
+		const modules = {
+			...stripKodyRuntimeModules(bundle.modules as WorkerLoaderModules),
+			...collectDynamicPackageImportProxyModules(files),
+		}
 		assertBundleHasNoUnresolvedBareImports({
 			modules,
 			bundleLabel: `Saved package app "${normalizePackageWorkspacePath(input.entryPoint)}" bundle`,

--- a/packages/worker/src/package-runtime/module-graph.workers.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.workers.test.ts
@@ -1,8 +1,122 @@
 import { env } from 'cloudflare:workers'
 import { expect, test } from 'vitest'
+import { createWorker } from '@cloudflare/worker-bundler'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { runBundledModuleWithRegistry } from '#mcp/run-codemode-registry.ts'
-import { buildKodyModuleBundle } from './module-graph.ts'
+import {
+	buildKodyImportableModuleBundle,
+	buildKodyModuleBundle,
+} from './module-graph.ts'
+import { persistPublishedSourceSnapshot } from './published-runtime-artifacts.ts'
+import { persistPublishedBundleArtifact } from './published-bundle-artifacts.ts'
+
+async function runSql(sql: string, ...values: Array<unknown>) {
+	await env.APP_DB.prepare(sql)
+		.bind(...values)
+		.run()
+}
+
+async function ensureSavedPackageArtifactSchema() {
+	await runSql(`CREATE TABLE IF NOT EXISTS entity_sources (
+		id TEXT PRIMARY KEY,
+		user_id TEXT NOT NULL,
+		entity_kind TEXT NOT NULL,
+		entity_id TEXT NOT NULL,
+		repo_id TEXT NOT NULL,
+		published_commit TEXT,
+		indexed_commit TEXT,
+		manifest_path TEXT NOT NULL DEFAULT 'package.json',
+		source_root TEXT NOT NULL DEFAULT '/',
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	)`)
+	await runSql(`CREATE TABLE IF NOT EXISTS saved_packages (
+		id TEXT PRIMARY KEY NOT NULL,
+		user_id TEXT NOT NULL,
+		name TEXT NOT NULL,
+		kody_id TEXT NOT NULL,
+		description TEXT NOT NULL,
+		tags_json TEXT NOT NULL DEFAULT '[]',
+		search_text TEXT,
+		source_id TEXT NOT NULL,
+		has_app INTEGER NOT NULL DEFAULT 0 CHECK (has_app IN (0, 1)),
+		created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+		updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+	)`)
+	await runSql(`CREATE TABLE IF NOT EXISTS published_bundle_artifacts (
+		id TEXT PRIMARY KEY,
+		user_id TEXT NOT NULL,
+		source_id TEXT NOT NULL,
+		published_commit TEXT NOT NULL,
+		artifact_kind TEXT NOT NULL,
+		artifact_name TEXT,
+		entry_point TEXT NOT NULL,
+		kv_key TEXT NOT NULL,
+		dependencies_json TEXT NOT NULL DEFAULT '[]',
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	)`)
+}
+
+function createSourceRow(input: {
+	userId: string
+	packageId: string
+	sourceId: string
+	publishedCommit: string
+}) {
+	return {
+		id: input.sourceId,
+		user_id: input.userId,
+		entity_kind: 'package' as const,
+		entity_id: input.packageId,
+		repo_id: `repo-${input.sourceId}`,
+		published_commit: input.publishedCommit,
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		created_at: '2026-05-13T00:00:00.000Z',
+		updated_at: '2026-05-13T00:00:00.000Z',
+	}
+}
+
+async function insertSavedPackage(input: {
+	userId: string
+	packageId: string
+	kodyId: string
+	name: string
+	sourceId: string
+	publishedCommit: string
+}) {
+	const now = new Date().toISOString()
+	await runSql(
+		`INSERT INTO saved_packages (
+			id, user_id, name, kody_id, description, tags_json, search_text,
+			source_id, has_app, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, '[]', NULL, ?, 0, ?, ?)`,
+		input.packageId,
+		input.userId,
+		input.name,
+		input.kodyId,
+		`${input.name} package`,
+		input.sourceId,
+		now,
+		now,
+	)
+	await runSql(
+		`INSERT INTO entity_sources (
+			id, user_id, entity_kind, entity_id, repo_id, published_commit,
+			indexed_commit, manifest_path, source_root, created_at, updated_at
+		) VALUES (?, ?, 'package', ?, ?, ?, NULL, 'package.json', '/', ?, ?)`,
+		input.sourceId,
+		input.userId,
+		input.packageId,
+		`repo-${input.sourceId}`,
+		input.publishedCommit,
+		now,
+		now,
+	)
+	return createSourceRow(input)
+}
 
 test(
 	'saved package bundles and executes npm dependencies declared in package.json',
@@ -75,6 +189,236 @@ test(
 		})
 	},
 )
+
+test('worker bundler executes the wrapper when multiple package artifact defaults are imported', async () => {
+	const bundle = await createWorker({
+		files: {
+			'.__kody_root__/.__kody_execute_entry__.js': [
+				'import userEntrypoint from "./entry.js"',
+				'export default async function __kodyExecuteEntrypoint(input) {',
+				'\treturn await userEntrypoint(input)',
+				'}',
+			].join('\n'),
+			'.__kody_root__/entry.js': [
+				'import listTraces from "../.__kody_virtual__/imports/list-traces.js"',
+				'import smokeTest from "../.__kody_virtual__/imports/smoke-test.js"',
+				'import workflowDiscord from "../.__kody_virtual__/imports/workflow-discord.js"',
+				'export default async function main() {',
+				'\treturn {',
+				'\t\tlistTraces: { staticType: typeof listTraces },',
+				'\t\tsmokeTest: { staticType: typeof smokeTest },',
+				'\t\tworkflowDiscord: { staticType: typeof workflowDiscord },',
+				'\t}',
+				'}',
+			].join('\n'),
+			'.__kody_virtual__/imports/list-traces.js': [
+				'export * from "../published/list-traces.js"',
+				'import * as module from "../published/list-traces.js"',
+				'export default module.default',
+			].join('\n'),
+			'.__kody_virtual__/imports/smoke-test.js': [
+				'export * from "../published/smoke-test.js"',
+				'import * as module from "../published/smoke-test.js"',
+				'export default module.default',
+			].join('\n'),
+			'.__kody_virtual__/imports/workflow-discord.js': [
+				'export * from "../published/workflow-discord.js"',
+				'import * as module from "../published/workflow-discord.js"',
+				'export default module.default',
+			].join('\n'),
+			'.__kody_virtual__/published/list-traces.js': [
+				'export default async function listTraces() {',
+				'\treturn { traces: [] }',
+				'}',
+			].join('\n'),
+			'.__kody_virtual__/published/smoke-test.js': [
+				'export default async function smokeTest() {',
+				'\treturn { smoke: true }',
+				'}',
+			].join('\n'),
+			'.__kody_virtual__/published/workflow-discord.js': [
+				'export default async function workflowDiscord() {',
+				'\treturn { discord: true }',
+				'}',
+			].join('\n'),
+		},
+		entryPoint: '.__kody_root__/.__kody_execute_entry__.js',
+	})
+
+	const result = await runBundledModuleWithRegistry(
+		env,
+		createMcpCallerContext({
+			baseUrl: 'https://kody.dev',
+			user: {
+				userId: 'user-workers-test',
+				email: 'worker@example.com',
+				displayName: 'Worker Test',
+			},
+		}),
+		{
+			mainModule: bundle.mainModule,
+			modules: bundle.modules,
+		},
+		undefined,
+		{
+			skipCapabilityRegistry: true,
+		},
+	)
+	expect(result.error).toBeUndefined()
+	expect(result.result).toEqual({
+		listTraces: {
+			staticType: 'function',
+		},
+		smokeTest: {
+			staticType: 'function',
+		},
+		workflowDiscord: {
+			staticType: 'function',
+		},
+	})
+})
+
+test('saved package artifact imports keep the execute wrapper as the runtime entrypoint', async () => {
+	await ensureSavedPackageArtifactSchema()
+	const unique = crypto.randomUUID()
+	const userId = `user-${unique}`
+	const sourceId = `source-${unique}`
+	const packageId = `pkg-${unique}`
+	const publishedCommit = `commit-${unique}`
+	const source = await insertSavedPackage({
+		userId,
+		packageId,
+		kodyId: 'email-received-subscriber',
+		name: '@kentcdodds/email-received-subscriber',
+		sourceId,
+		publishedCommit,
+	})
+	const sourceFiles = {
+		'package.json': JSON.stringify({
+			name: '@kentcdodds/email-received-subscriber',
+			exports: {
+				'./list-traces': './src/list-traces.ts',
+				'./smoke-test': './src/package-smoke-test.ts',
+				'./workflow-discord-message-created':
+					'./src/workflow-discord-message-created.ts',
+			},
+			kody: {
+				id: 'email-received-subscriber',
+				description: 'Email received subscriber',
+			},
+		}),
+		'src/list-traces.ts':
+			'export default async function listTraces() { return { traces: [] } }',
+		'src/package-smoke-test.ts':
+			'export default async function smokeTest() { return { smoke: true } }',
+		'src/workflow-discord-message-created.ts':
+			'export default async function workflowDiscord() { return { discord: true } }',
+	}
+	await persistPublishedSourceSnapshot({
+		env,
+		userId,
+		source,
+		snapshot: {
+			files: sourceFiles,
+		},
+	})
+	for (const target of [
+		{
+			artifactName: './list-traces',
+			entryPoint: 'src/list-traces.ts',
+		},
+		{
+			artifactName: './smoke-test',
+			entryPoint: 'src/package-smoke-test.ts',
+		},
+		{
+			artifactName: './workflow-discord-message-created',
+			entryPoint: 'src/workflow-discord-message-created.ts',
+		},
+	]) {
+		const artifactBundle = await buildKodyImportableModuleBundle({
+			env,
+			baseUrl: 'https://kody.dev',
+			userId,
+			sourceFiles,
+			entryPoint: target.entryPoint,
+		})
+		await persistPublishedBundleArtifact({
+			env,
+			userId,
+			source,
+			kind: 'importable-module',
+			artifactName: target.artifactName,
+			entryPoint: target.entryPoint,
+			mainModule: artifactBundle.mainModule,
+			modules: artifactBundle.modules,
+			dependencies: artifactBundle.dependencies,
+			packageContext: {
+				packageId,
+				kodyId: 'email-received-subscriber',
+				sourceId,
+			},
+		})
+	}
+
+	const bundle = await buildKodyModuleBundle({
+		env,
+		baseUrl: 'https://kody.dev',
+		userId,
+		sourceFiles: {
+			'entry.ts': [
+				"import listTraces from 'kody:@kentcdodds/email-received-subscriber/list-traces'",
+				"import smokeTest from 'kody:@kentcdodds/email-received-subscriber/smoke-test'",
+				"import workflowDiscord from 'kody:@kentcdodds/email-received-subscriber/workflow-discord-message-created'",
+				'export default async function main() {',
+				"\tconst dynamicListTraces = await import('kody:@kentcdodds/email-received-subscriber/list-traces')",
+				'\treturn {',
+				'\t\tlistTraces: { staticType: typeof listTraces },',
+				'\t\tsmokeTest: { staticType: typeof smokeTest },',
+				'\t\tworkflowDiscord: { staticType: typeof workflowDiscord },',
+				'\t\tdynamicListTraces: { defaultType: typeof dynamicListTraces.default },',
+				'\t}',
+				'}',
+			].join('\n'),
+		},
+		entryPoint: 'entry.ts',
+	})
+	const result = await runBundledModuleWithRegistry(
+		env,
+		createMcpCallerContext({
+			baseUrl: 'https://kody.dev',
+			user: {
+				userId,
+				email: 'worker@example.com',
+				displayName: 'Worker Test',
+			},
+		}),
+		{
+			mainModule: bundle.mainModule,
+			modules: bundle.modules,
+		},
+		undefined,
+		{
+			skipCapabilityRegistry: true,
+		},
+	)
+
+	expect(result.error).toBeUndefined()
+	expect(result.result).toEqual({
+		listTraces: {
+			staticType: 'function',
+		},
+		smokeTest: {
+			staticType: 'function',
+		},
+		workflowDiscord: {
+			staticType: 'function',
+		},
+		dynamicListTraces: {
+			defaultType: 'function',
+		},
+	})
+})
 
 test('subscription bundles refresh stale nested runtime modules from static package dependencies', async () => {
 	const nestedRuntimeModule =

--- a/packages/worker/src/package-runtime/module-graph.workers.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.workers.test.ts
@@ -370,14 +370,23 @@ test('saved package artifact imports keep the execute wrapper as the runtime ent
 				"import listTraces from 'kody:@kentcdodds/email-received-subscriber/list-traces'",
 				"import smokeTest from 'kody:@kentcdodds/email-received-subscriber/smoke-test'",
 				"import workflowDiscord from 'kody:@kentcdodds/email-received-subscriber/workflow-discord-message-created'",
+				"import { inspectNestedImport } from './src/deep/nested.ts'",
 				'export default async function main() {',
 				"\tconst dynamicListTraces = await import('kody:@kentcdodds/email-received-subscriber/list-traces')",
+				'\tconst nestedImport = await inspectNestedImport()',
 				'\treturn {',
 				'\t\tlistTraces: { staticType: typeof listTraces },',
 				'\t\tsmokeTest: { staticType: typeof smokeTest },',
 				'\t\tworkflowDiscord: { staticType: typeof workflowDiscord },',
 				'\t\tdynamicListTraces: { defaultType: typeof dynamicListTraces.default },',
+				'\t\tnestedImport,',
 				'\t}',
+				'}',
+			].join('\n'),
+			'src/deep/nested.ts': [
+				'export async function inspectNestedImport() {',
+				"\tconst dynamicListTraces = await import('kody:@kentcdodds/email-received-subscriber/list-traces')",
+				'\treturn { defaultType: typeof dynamicListTraces.default }',
 				'}',
 			].join('\n'),
 		},
@@ -415,6 +424,9 @@ test('saved package artifact imports keep the execute wrapper as the runtime ent
 			staticType: 'function',
 		},
 		dynamicListTraces: {
+			defaultType: 'function',
+		},
+		nestedImport: {
 			defaultType: 'function',
 		},
 	})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rewrite literal dynamic `kody:` imports through a runtime helper so worker bundling cannot inline placeholder modules into the main bundle.
- Preserve only emitted-graph-referenced dynamic package import proxy modules alongside bundled output for module, importable module, and app bundles.
- Add a Workers regression for the production symptom where importing subscriber subpaths returned `{ traces: [] }` instead of the execute wrapper result, including nested-module dynamic imports.

## Testing
- `npx vitest run --project workers-unit packages/worker/src/package-runtime/module-graph.workers.test.ts -t "saved package artifact imports keep"`
- `npx vitest run packages/worker/src/package-runtime/module-graph.node.test.ts -t "dynamic"`
- `npx vitest run --project workers-unit packages/worker/src/package-runtime/module-graph.workers.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated warnings)
- `npm run validate`

## Production follow-up
- After deployment, rerun the exact `workflow-approved-email` static+dynamic import smoke test.
- Force-republish `email-received-subscriber` again after deployment so its own dynamic `ai-chat` imports are rebuilt with the runtime-computed import shape.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker bundles now include dynamically generated proxy modules so dynamic package imports are resolved and bundled reliably.
  * Runtime import helpers are generated on-demand and more robustly handle literal and computed dynamic imports, with stricter specifier validation.

* **Tests**
  * Added tests for worker bundle builds with multiple package imports (static and dynamic), including nested dynamic imports.
  * Added end-to-end tests for persisted package artifacts and importable bundle behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/459)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->