### PR TITLE
Surface failed email reply deliveries

### DIFF
--- a/packages/worker/src/email/outbound.ts
+++ b/packages/worker/src/email/outbound.ts
@@ -73,12 +73,9 @@ const cloudflareSendAllowedHeaders = new Set(['in-reply-to', 'references'])
 
 function buildProviderHeaders(headers: Record<string, string>) {
 	return Object.fromEntries(
-		Object.entries(headers).filter(([name]) => {
-			return (
-				name.startsWith('X-') ||
-				cloudflareSendAllowedHeaders.has(name.toLowerCase())
-			)
-		}),
+		Object.entries(headers).filter(([name]) =>
+			cloudflareSendAllowedHeaders.has(name.toLowerCase()),
+		),
 	)
 }
 

--- a/packages/worker/src/email/outbound.workers.test.ts
+++ b/packages/worker/src/email/outbound.workers.test.ts
@@ -41,9 +41,7 @@ test('sendOutboundEmail uses SendEmail binding and stores sent delivery state', 
 	})
 
 	expect(sent).toHaveLength(1)
-	expect(sent[0]?.headers).toEqual({
-		'X-Kody-Email-Message-Id': result.message.messageIdHeader,
-	})
+	expect(sent[0]?.headers).toEqual({})
 	expect(result.status).toBe('sent')
 	expect(result.providerMessageId).toBe('provider-message-123')
 	const stored = await getEmailMessageById({
@@ -183,12 +181,14 @@ test('sendOutboundEmail preserves reply headers and records failed fallback send
 			html: 'Body',
 			replyTo: 'reply@example.com',
 			headers: {
-				'X-Kody-Email-Message-Id': result.message.messageIdHeader,
 				'In-Reply-To': original.message.messageIdHeader,
 				References: '<root@example.com>',
 			},
 		})
 		expect(fetchCalls[0]?.body.headers).not.toHaveProperty('Message-ID')
+		expect(fetchCalls[0]?.body.headers).not.toHaveProperty(
+			'X-Kody-Email-Message-Id',
+		)
 		const stored = await getEmailMessageById({
 			db: env.APP_DB,
 			userId,

--- a/packages/worker/src/mcp/capabilities/email/email-reply.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-reply.node.test.ts
@@ -1,0 +1,92 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mocks = vi.hoisted(() => ({
+	getEmailMessageById: vi.fn(),
+	sendOutboundEmail: vi.fn(),
+}))
+
+vi.mock('#worker/email/repo.ts', () => ({
+	getEmailMessageById: mocks.getEmailMessageById,
+}))
+
+vi.mock('#worker/email/outbound.ts', () => ({
+	sendOutboundEmail: mocks.sendOutboundEmail,
+}))
+
+const { emailReplyCapability } = await import('./email-reply.ts')
+
+function createContext() {
+	return {
+		env: {} as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'User Example',
+			},
+		}),
+	}
+}
+
+test('email_reply throws when provider delivery is persisted as failed', async () => {
+	mocks.getEmailMessageById.mockResolvedValue({
+		id: 'inbound-1',
+		subject: 'Hello',
+		fromAddress: 'sender@example.com',
+		envelopeFrom: null,
+		replyToAddresses: [],
+		messageIdHeader: '<inbound@example.com>',
+		references: [],
+		threadId: 'thread-1',
+		inboxId: 'inbox-1',
+	})
+	mocks.sendOutboundEmail.mockResolvedValue({
+		status: 'failed',
+		error: 'Invalid email address: Invalid input',
+		providerMessageId: null,
+		message: {
+			id: 'outbound-1',
+			direction: 'outbound',
+			inboxId: 'inbox-1',
+			threadId: 'thread-1',
+			fromAddress: 'kody@heykody.dev',
+			envelopeFrom: 'kody@heykody.dev',
+			toAddresses: ['sender@example.com'],
+			subject: 'Re: Hello',
+			messageIdHeader: '<outbound@heykody.dev>',
+			processingStatus: 'failed',
+			providerMessageId: null,
+			error: 'Invalid email address: Invalid input',
+			receivedAt: null,
+			sentAt: null,
+			createdAt: '2026-05-13T07:30:16.000Z',
+			updatedAt: '2026-05-13T07:30:16.000Z',
+		},
+	})
+
+	await expect(
+		emailReplyCapability.handler(
+			{
+				message_id: 'inbound-1',
+				from: 'kody@heykody.dev',
+				text: 'Reply body',
+			},
+			createContext(),
+		),
+	).rejects.toThrow(
+		'Email reply delivery failed: Invalid email address: Invalid input',
+	)
+	expect(mocks.sendOutboundEmail).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-1',
+			from: 'kody@heykody.dev',
+			to: 'sender@example.com',
+			subject: 'Re: Hello',
+			inReplyToHeader: '<inbound@example.com>',
+			threadId: 'thread-1',
+			inboxId: 'inbox-1',
+		}),
+	)
+})

--- a/packages/worker/src/mcp/capabilities/email/email-reply.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-reply.ts
@@ -65,6 +65,11 @@ export const emailReplyCapability = defineDomainCapability(
 				threadId: original.threadId,
 				inboxId: original.inboxId,
 			})
+			if (result.status === 'failed') {
+				throw new Error(
+					`Email reply delivery failed: ${result.error ?? 'Unknown provider error.'}`,
+				)
+			}
 			return toMessageSummary(result.message)
 		},
 	},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Stop sending internal Kody message-id headers to email providers while preserving them in stored records.
- Make `email_reply` throw when outbound delivery is persisted as failed, so subscriber services record the provider failure instead of completing silently.
- Add regressions for provider-bound headers and failed reply delivery bubbling.

### Testing
- `npx vitest run packages/worker/src/mcp/capabilities/email/email-reply.node.test.ts packages/worker/src/email/outbound.workers.test.ts`
- `npm run typecheck`
- `npx oxfmt --check "packages/worker/src/email/outbound.ts" "packages/worker/src/email/outbound.workers.test.ts" "packages/worker/src/mcp/capabilities/email/email-reply.ts" "packages/worker/src/mcp/capabilities/email/email-reply.node.test.ts"`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added proper error handling for failed email reply deliveries with descriptive error messages

* **Changes**
  * Restricted email headers forwarded during replies to include only reply-related fields (In-Reply-To, References)

* **Tests**
  * Expanded test suite to cover email reply failure scenarios and delivery status validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/461)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->