### PR TITLE
Send scalar recipients to email binding

### DIFF
--- a/packages/worker/src/email/outbound.ts
+++ b/packages/worker/src/email/outbound.ts
@@ -111,7 +111,7 @@ async function sendViaBinding(input: {
 	if (!binding) return { sent: false, messageId: null }
 	const result = await binding.send({
 		from: input.from,
-		to: input.to,
+		to: input.to.length === 1 ? input.to[0]! : input.to,
 		subject: input.subject,
 		...(input.replyTo ? { replyTo: input.replyTo } : {}),
 		headers: input.headers,

--- a/packages/worker/src/email/outbound.workers.test.ts
+++ b/packages/worker/src/email/outbound.workers.test.ts
@@ -41,6 +41,7 @@ test('sendOutboundEmail uses SendEmail binding and stores sent delivery state', 
 	})
 
 	expect(sent).toHaveLength(1)
+	expect(sent[0]?.to).toBe('recipient@example.com')
 	expect(sent[0]?.headers).toEqual({})
 	expect(result.status).toBe('sent')
 	expect(result.providerMessageId).toBe('provider-message-123')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Send a scalar `to` value to the Cloudflare email binding when there is exactly one normalized recipient.
- Keep array recipients for multi-recipient sends and keep the REST fallback behavior unchanged.
- Add a regression assertion covering the binding payload shape that production rejected.

### Testing
- `npx vitest run packages/worker/src/email/outbound.workers.test.ts packages/worker/src/mcp/capabilities/email/email-reply.node.test.ts`
- `npm run typecheck`
- `npx oxfmt --check "packages/worker/src/email/outbound.ts" "packages/worker/src/email/outbound.workers.test.ts"`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b28d147-8c9e-44cf-a2d7-1ca40177ae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified email sending logic to properly format the recipient field: single recipients are now passed as strings to the email binding, while multiple recipients are passed as arrays, ensuring correct delivery handling.

* **Tests**
  * Updated email sending tests to verify the proper formatting of recipient fields based on recipient count.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/466)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->