### PR TITLE
Add OAuth authorization metadata to integrations

### DIFF
--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -54,6 +54,21 @@ with `allowedHosts` when needed.
 Client ID, access token, and refresh token names are derived from a normalized
 slug of `provider`.
 
+After a successful connection, Kody saves the non-secret OAuth authorization
+metadata needed for future reconnects in the integration record:
+
+- `authorizeUrl`
+- requested `scopes`
+- non-default `scopeSeparator`
+- provider-specific `extraAuthorizeParams` such as Google `access_type=offline`
+  and `prompt=consent`
+
+For an existing integration, agents can call `integration_get` or
+`integration_list` to inspect this metadata. To reconnect without rebuilding the
+full authorize URL by hand, open `/connect/oauth?provider=<integration-name>`;
+the page derives the provider authorize URL from the saved integration config
+and the current client credentials.
+
 ## Integration naming convention
 
 Prefer integration names like `<provider>-<purpose>` when multiple accounts may

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -250,6 +250,12 @@ accounts may exist, such as `google`, `google-business`, or
 `google-youtube-brand`. Call **`integration_list`** up front when a provider may
 have multiple accounts connected.
 
+OAuth integrations may include `authorization` metadata with the saved
+`authorizeUrl`, requested `scopes`, any non-default `scopeSeparator`, and
+provider-specific `extraAuthorizeParams`. Use that metadata when a refresh token
+is stale and the user needs to reconnect; open
+`/connect/oauth?provider=<integration-name>` instead of guessing the scope set.
+
 For OAuth 2 `client_credentials` token exchanges that require
 `Authorization: Basic base64(client_id:client_secret)`, save the client id and
 client secret separately. Do **not** ask the user to precompute or save the

--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -48,6 +48,30 @@ test('parseStoredIntegrationConfig returns normalized integration config', () =>
 	})
 })
 
+test('parseStoredIntegrationConfig rejects non-http authorization URLs', () => {
+	const parsed = parseStoredIntegrationConfig(
+		JSON.stringify({
+			name: 'GitHub',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			flow: 'confidential',
+			clientIdValueName: 'github-client-id',
+			clientSecretSecretName: 'githubClientSecret',
+			accessTokenSecretName: 'githubAccessToken',
+			refreshTokenSecretName: 'githubRefreshToken',
+			requiredHosts: ['github.com'],
+			authorization: {
+				authorizeUrl: 'ftp://github.com/login/oauth/authorize',
+				scopes: ['repo'],
+				scopeSeparator: null,
+				extraAuthorizeParams: {},
+			},
+		}),
+		null,
+	)
+
+	expect(parsed?.authorization).toBeNull()
+})
+
 test('getIntegrationValueCandidates prefers provider and normalized key without duplicates', () => {
 	expect(getIntegrationValueCandidates('GitHub', 'github')).toEqual([
 		buildIntegrationValueName('GitHub'),
@@ -168,6 +192,54 @@ test('mergeConnectOauthConfig can derive reconnect authorization from stored int
 			prompt: 'consent',
 		},
 		allowedHosts: ['oauth2.googleapis.com', 'www.googleapis.com'],
+	})
+})
+
+test('mergeConnectOauthConfig falls back to stored authorization when query values are empty defaults', () => {
+	const config = mergeConnectOauthConfig({
+		queryConfig: {
+			provider: 'google-youtube-brand',
+			providerKey: 'google-youtube-brand',
+			authorizeHost: null,
+			authorizeUrl: null,
+			tokenUrl: null,
+			apiBaseUrl: null,
+			scopes: [],
+			flow: null,
+			scopeSeparator: null,
+			extraAuthorizeParams: {},
+			providerSetupInstructions: null,
+			dashboardUrl: null,
+			allowedHosts: [],
+		},
+		storedIntegration: {
+			name: 'google-youtube-brand',
+			tokenUrl: 'https://oauth2.googleapis.com/token',
+			apiBaseUrl: 'https://www.googleapis.com/youtube/v3',
+			flow: 'confidential',
+			clientIdValueName: 'google-youtube-brand-client-id',
+			clientSecretSecretName: 'googleYoutubeBrandClientSecret',
+			accessTokenSecretName: 'googleYoutubeBrandAccessToken',
+			refreshTokenSecretName: 'googleYoutubeBrandRefreshToken',
+			requiredHosts: ['oauth2.googleapis.com', 'www.googleapis.com'],
+			authorization: {
+				authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+				scopes: ['https://www.googleapis.com/auth/youtube.force-ssl'],
+				scopeSeparator: null,
+				extraAuthorizeParams: {
+					access_type: 'offline',
+					prompt: 'consent',
+				},
+			},
+		},
+	})
+
+	expect(config).toMatchObject({
+		scopes: ['https://www.googleapis.com/auth/youtube.force-ssl'],
+		extraAuthorizeParams: {
+			access_type: 'offline',
+			prompt: 'consent',
+		},
 	})
 })
 

--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -19,6 +19,12 @@ test('parseStoredIntegrationConfig returns normalized integration config', () =>
 			accessTokenSecretName: 'githubAccessToken',
 			refreshTokenSecretName: 'githubRefreshToken',
 			requiredHosts: ['api.github.com', ' github.com ', 'api.github.com'],
+			authorization: {
+				authorizeUrl: 'https://github.com/login/oauth/authorize',
+				scopes: ['repo', 'read:user'],
+				scopeSeparator: null,
+				extraAuthorizeParams: { prompt: 'consent' },
+			},
 		}),
 		null,
 	)
@@ -33,6 +39,12 @@ test('parseStoredIntegrationConfig returns normalized integration config', () =>
 		accessTokenSecretName: 'githubAccessToken',
 		refreshTokenSecretName: 'githubRefreshToken',
 		requiredHosts: ['api.github.com', 'github.com'],
+		authorization: {
+			authorizeUrl: 'https://github.com/login/oauth/authorize',
+			scopes: ['repo', 'read:user'],
+			scopeSeparator: null,
+			extraAuthorizeParams: { prompt: 'consent' },
+		},
 	})
 })
 
@@ -96,6 +108,66 @@ test('mergeConnectOauthConfig prefers stored integration metadata for saved prov
 		accessTokenSecretName: 'githubAccessToken',
 		refreshTokenSecretName: 'githubRefreshToken',
 		allowedHosts: ['api.github.com', 'github.com'],
+	})
+})
+
+test('mergeConnectOauthConfig can derive reconnect authorization from stored integration metadata', () => {
+	const config = mergeConnectOauthConfig({
+		queryConfig: {
+			provider: 'google-youtube-brand',
+			providerKey: 'google-youtube-brand',
+			authorizeHost: null,
+			authorizeUrl: null,
+			tokenUrl: null,
+			apiBaseUrl: null,
+			scopes: null,
+			flow: null,
+			scopeSeparator: null,
+			extraAuthorizeParams: null,
+			providerSetupInstructions: null,
+			dashboardUrl: null,
+			allowedHosts: [],
+		},
+		storedIntegration: {
+			name: 'google-youtube-brand',
+			tokenUrl: 'https://oauth2.googleapis.com/token',
+			apiBaseUrl: 'https://www.googleapis.com/youtube/v3',
+			flow: 'confidential',
+			clientIdValueName: 'google-youtube-brand-client-id',
+			clientSecretSecretName: 'googleYoutubeBrandClientSecret',
+			accessTokenSecretName: 'googleYoutubeBrandAccessToken',
+			refreshTokenSecretName: 'googleYoutubeBrandRefreshToken',
+			requiredHosts: ['oauth2.googleapis.com', 'www.googleapis.com'],
+			authorization: {
+				authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+				scopes: [
+					'https://www.googleapis.com/auth/youtube',
+					'https://www.googleapis.com/auth/youtube.force-ssl',
+				],
+				scopeSeparator: null,
+				extraAuthorizeParams: {
+					access_type: 'offline',
+					prompt: 'consent',
+				},
+			},
+		},
+	})
+
+	expect(config).toMatchObject({
+		provider: 'google-youtube-brand',
+		authorizeHost: 'accounts.google.com',
+		authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+		tokenUrl: 'https://oauth2.googleapis.com/token',
+		scopes: [
+			'https://www.googleapis.com/auth/youtube',
+			'https://www.googleapis.com/auth/youtube.force-ssl',
+		],
+		scopeSeparator: ' ',
+		extraAuthorizeParams: {
+			access_type: 'offline',
+			prompt: 'consent',
+		},
+		allowedHosts: ['oauth2.googleapis.com', 'www.googleapis.com'],
 	})
 })
 

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -1259,7 +1259,13 @@ function parseStoredIntegrationAuthorization(
 	const parsed = raw as Record<string, unknown>
 	const authorizeUrl =
 		typeof parsed.authorizeUrl === 'string' ? parsed.authorizeUrl.trim() : ''
-	if (!authorizeUrl || !safeParseHost(authorizeUrl)) return null
+	if (
+		!authorizeUrl ||
+		!isSafeExternalUrl(authorizeUrl) ||
+		!safeParseHost(authorizeUrl)
+	) {
+		return null
+	}
 	const scopes = Array.isArray(parsed.scopes)
 		? parsed.scopes.filter(
 				(value): value is string => typeof value === 'string' && Boolean(value),
@@ -1318,6 +1324,8 @@ export function mergeConnectOauthConfig(input: {
 		return null
 	}
 	const flow = input.storedIntegration?.flow ?? input.queryConfig.flow ?? 'pkce'
+	const scopes = resolveConnectOauthScopes(input)
+	const extraAuthorizeParams = resolveConnectOauthExtraAuthorizeParams(input)
 	const allowedHosts = normalizeHosts([
 		tokenHost,
 		...input.queryConfig.allowedHosts,
@@ -1333,19 +1341,13 @@ export function mergeConnectOauthConfig(input: {
 		tokenUrl,
 		apiBaseUrl:
 			input.storedIntegration?.apiBaseUrl ?? input.queryConfig.apiBaseUrl,
-		scopes:
-			input.queryConfig.scopes ??
-			input.storedIntegration?.authorization?.scopes ??
-			[],
+		scopes,
 		flow,
 		scopeSeparator:
 			input.queryConfig.scopeSeparator ??
 			input.storedIntegration?.authorization?.scopeSeparator ??
 			' ',
-		extraAuthorizeParams:
-			input.queryConfig.extraAuthorizeParams ??
-			input.storedIntegration?.authorization?.extraAuthorizeParams ??
-			{},
+		extraAuthorizeParams,
 		providerSetupInstructions: input.queryConfig.providerSetupInstructions,
 		dashboardUrl: input.queryConfig.dashboardUrl,
 		clientIdValueName:
@@ -1363,6 +1365,27 @@ export function mergeConnectOauthConfig(input: {
 			`${providerKey}RefreshToken`,
 		allowedHosts,
 	}
+}
+
+function resolveConnectOauthScopes(input: {
+	queryConfig: ConnectOauthQueryConfig
+	storedIntegration: StoredIntegrationConfig | null
+}) {
+	if (input.queryConfig.scopes && input.queryConfig.scopes.length > 0) {
+		return input.queryConfig.scopes
+	}
+	return input.storedIntegration?.authorization?.scopes ?? []
+}
+
+function resolveConnectOauthExtraAuthorizeParams(input: {
+	queryConfig: ConnectOauthQueryConfig
+	storedIntegration: StoredIntegrationConfig | null
+}) {
+	const queryParams = input.queryConfig.extraAuthorizeParams
+	if (queryParams && Object.keys(queryParams).length > 0) {
+		return queryParams
+	}
+	return input.storedIntegration?.authorization?.extraAuthorizeParams ?? {}
 }
 
 export function summarizeStoredSetupState(input: {

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -30,14 +30,14 @@ type OAuthFlow = 'pkce' | 'confidential'
 type ConnectOauthQueryConfig = {
 	provider: string
 	providerKey: string
-	authorizeHost: string
-	authorizeUrl: string
+	authorizeHost: string | null
+	authorizeUrl: string | null
 	tokenUrl: string | null
 	apiBaseUrl: string | null
-	scopes: Array<string>
+	scopes: Array<string> | null
 	flow: OAuthFlow | null
-	scopeSeparator: string
-	extraAuthorizeParams: Record<string, string>
+	scopeSeparator: string | null
+	extraAuthorizeParams: Record<string, string> | null
 	providerSetupInstructions: string | null
 	dashboardUrl: string | null
 	allowedHosts: Array<string>
@@ -74,6 +74,14 @@ type StoredIntegrationConfig = {
 	accessTokenSecretName: string
 	refreshTokenSecretName: string | null
 	requiredHosts: Array<string>
+	authorization?: StoredIntegrationAuthorization | null
+}
+
+type StoredIntegrationAuthorization = {
+	authorizeUrl: string
+	scopes: Array<string>
+	scopeSeparator: string | null
+	extraAuthorizeParams: Record<string, string>
 }
 
 type OAuthExchangeResult =
@@ -157,16 +165,16 @@ export function ConnectOauthRoute(handle: Handle) {
 			return value && value.trim() ? value.trim() : null
 		}
 		const provider = readRequired('provider')
-		const authorizeUrl = readRequired('authorizeUrl')
+		const authorizeUrl = readOptional('authorizeUrl')
 		const tokenUrl = readOptional('tokenUrl')
 		const apiBaseUrl = parseOptionalUrl(readOptional('apiBaseUrl'))
-		if (!provider || !authorizeUrl) {
+		if (!provider) {
 			hasConfigError = true
 			setStatus('Missing required OAuth configuration parameters.', 'error')
 			return null
 		}
-		const authorizeHost = safeParseHost(authorizeUrl)
-		if (!authorizeHost) {
+		const authorizeHost = authorizeUrl ? safeParseHost(authorizeUrl) : null
+		if (authorizeUrl && !authorizeHost) {
 			hasConfigError = true
 			setStatus('Authorize URL must be valid.', 'error')
 			return null
@@ -179,11 +187,14 @@ export function ConnectOauthRoute(handle: Handle) {
 		}
 		let flow = (readOptional('flow') ?? 'pkce').toLowerCase()
 		if (flow !== 'pkce' && flow !== 'confidential') flow = 'pkce'
-		const scopes = parseScopes(readOptional('scopes'))
-		const scopeSeparator = readOptional('scopeSeparator') ?? ' '
-		const extraAuthorizeParams = parseExtraParams(
-			readOptional('extraAuthorizeParams'),
-		)
+		const rawScopes = readOptional('scopes')
+		const scopes = rawScopes == null ? null : parseScopes(rawScopes)
+		const scopeSeparator = readOptional('scopeSeparator')
+		const rawExtraAuthorizeParams = readOptional('extraAuthorizeParams')
+		const extraAuthorizeParams =
+			rawExtraAuthorizeParams == null
+				? null
+				: parseExtraParams(rawExtraAuthorizeParams)
 		const dashboardUrl = parseOptionalUrl(readOptional('dashboardUrl'))
 		const providerKey = normalizeProviderKey(provider)
 		if (!providerKey) {
@@ -671,8 +682,12 @@ export function ConnectOauthRoute(handle: Handle) {
 				action: 'connect_oauth',
 				provider: config.provider,
 				callbackUrl,
+				authorizeUrl: config.authorizeUrl,
 				tokenUrl: config.tokenUrl,
 				apiBaseUrl: config.apiBaseUrl,
+				scopes: config.scopes,
+				scopeSeparator: config.scopeSeparator,
+				extraAuthorizeParams: config.extraAuthorizeParams,
 				flow: config.flow,
 				clientIdValueName: config.clientIdValueName,
 				clientSecretSecretName: config.clientSecretSecretName,
@@ -782,6 +797,27 @@ export function ConnectOauthRoute(handle: Handle) {
 						</code>
 					</div>
 				</div>
+				{existingIntegrationConfig.authorization ? (
+					<div mix={css(insetCardCss)}>
+						<strong mix={css(sectionTitleCss)}>Authorization metadata</strong>
+						<div mix={css(detailGridCss)}>
+							<div mix={css(detailItemCss)}>
+								<span mix={css(detailLabelCss)}>Authorize URL</span>
+								<code>
+									{existingIntegrationConfig.authorization.authorizeUrl}
+								</code>
+							</div>
+							<div mix={css(detailItemCss)}>
+								<span mix={css(detailLabelCss)}>Scopes</span>
+								<span mix={css(detailValueCss)}>
+									{existingIntegrationConfig.authorization.scopes.length
+										? existingIntegrationConfig.authorization.scopes.join(' ')
+										: 'None'}
+								</span>
+							</div>
+						</div>
+					</div>
+				) : null}
 				<div mix={css(insetCardCss)}>
 					<strong mix={css(sectionTitleCss)}>Required hosts</strong>
 					{existingIntegrationConfig.requiredHosts.length > 0 ? (
@@ -1190,6 +1226,9 @@ export function parseStoredIntegrationConfig(
 					(value): value is string => typeof value === 'string',
 				)
 			: []
+		const authorization = parseStoredIntegrationAuthorization(
+			parsed.authorization,
+		)
 		if (!name || !tokenUrl || !clientIdValueName || !accessTokenSecretName) {
 			return null
 		}
@@ -1206,9 +1245,48 @@ export function parseStoredIntegrationConfig(
 			accessTokenSecretName,
 			refreshTokenSecretName,
 			requiredHosts: normalizeHosts(requiredHosts),
+			authorization,
 		}
 	} catch {
 		return null
+	}
+}
+
+function parseStoredIntegrationAuthorization(
+	raw: unknown,
+): StoredIntegrationAuthorization | null {
+	if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+	const parsed = raw as Record<string, unknown>
+	const authorizeUrl =
+		typeof parsed.authorizeUrl === 'string' ? parsed.authorizeUrl.trim() : ''
+	if (!authorizeUrl || !safeParseHost(authorizeUrl)) return null
+	const scopes = Array.isArray(parsed.scopes)
+		? parsed.scopes.filter(
+				(value): value is string => typeof value === 'string' && Boolean(value),
+			)
+		: []
+	const scopeSeparator =
+		typeof parsed.scopeSeparator === 'string' && parsed.scopeSeparator
+			? parsed.scopeSeparator
+			: null
+	const extraAuthorizeParams =
+		parsed.extraAuthorizeParams &&
+		typeof parsed.extraAuthorizeParams === 'object' &&
+		!Array.isArray(parsed.extraAuthorizeParams)
+			? Object.fromEntries(
+					Object.entries(parsed.extraAuthorizeParams)
+						.filter(
+							(entry): entry is [string, string] =>
+								typeof entry[1] === 'string',
+						)
+						.map(([key, value]) => [key, value]),
+				)
+			: {}
+	return {
+		authorizeUrl,
+		scopes,
+		scopeSeparator,
+		extraAuthorizeParams,
 	}
 }
 
@@ -1221,11 +1299,22 @@ export function mergeConnectOauthConfig(input: {
 	const providerKey = normalizeProviderKey(
 		provider || input.queryConfig.providerKey,
 	)
-	const authorizeHost = safeParseHost(input.queryConfig.authorizeUrl)
+	const authorizeUrl =
+		input.queryConfig.authorizeUrl ??
+		input.storedIntegration?.authorization?.authorizeUrl ??
+		null
+	const authorizeHost = authorizeUrl ? safeParseHost(authorizeUrl) : null
 	const tokenUrl =
 		input.storedIntegration?.tokenUrl ?? input.queryConfig.tokenUrl
 	const tokenHost = tokenUrl ? safeParseHost(tokenUrl) : null
-	if (!provider || !authorizeHost || !tokenUrl || !tokenHost || !providerKey) {
+	if (
+		!provider ||
+		!authorizeUrl ||
+		!authorizeHost ||
+		!tokenUrl ||
+		!tokenHost ||
+		!providerKey
+	) {
 		return null
 	}
 	const flow = input.storedIntegration?.flow ?? input.queryConfig.flow ?? 'pkce'
@@ -1240,14 +1329,23 @@ export function mergeConnectOauthConfig(input: {
 		providerKey,
 		authorizeHost,
 		tokenHost,
-		authorizeUrl: input.queryConfig.authorizeUrl,
+		authorizeUrl,
 		tokenUrl,
 		apiBaseUrl:
 			input.storedIntegration?.apiBaseUrl ?? input.queryConfig.apiBaseUrl,
-		scopes: input.queryConfig.scopes,
+		scopes:
+			input.queryConfig.scopes ??
+			input.storedIntegration?.authorization?.scopes ??
+			[],
 		flow,
-		scopeSeparator: input.queryConfig.scopeSeparator,
-		extraAuthorizeParams: input.queryConfig.extraAuthorizeParams,
+		scopeSeparator:
+			input.queryConfig.scopeSeparator ??
+			input.storedIntegration?.authorization?.scopeSeparator ??
+			' ',
+		extraAuthorizeParams:
+			input.queryConfig.extraAuthorizeParams ??
+			input.storedIntegration?.authorization?.extraAuthorizeParams ??
+			{},
 		providerSetupInstructions: input.queryConfig.providerSetupInstructions,
 		dashboardUrl: input.queryConfig.dashboardUrl,
 		clientIdValueName:

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -174,7 +174,7 @@ export function ConnectOauthRoute(handle: Handle) {
 			return null
 		}
 		const authorizeHost = authorizeUrl ? safeParseHost(authorizeUrl) : null
-		if (authorizeUrl && !authorizeHost) {
+		if (authorizeUrl && (!isSafeExternalUrl(authorizeUrl) || !authorizeHost)) {
 			hasConfigError = true
 			setStatus('Authorize URL must be valid.', 'error')
 			return null

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -288,6 +288,48 @@ test('connect oauth omits direct host approval links when hosts are already appr
 	expect(mockModule.buildSecretHostApprovalUrl).not.toHaveBeenCalled()
 })
 
+test('connect oauth drops invalid authorization metadata without hiding the integration', async () => {
+	mockModule.saveValue.mockClear()
+
+	const handler = createAccountSecretsApiHandler(createEnv())
+	const response = await handler.handler({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'connect_oauth',
+				provider: 'GitHub',
+				authorizeUrl: 'ftp://github.com/login/oauth/authorize',
+				tokenUrl: 'https://github.com/login/oauth/access_token',
+				apiBaseUrl: 'https://api.github.com',
+				scopes: ['repo'],
+				flow: 'pkce',
+				clientIdValueName: 'github-client-id',
+				accessTokenSecretName: 'githubAccessToken',
+				refreshTokenSecretName: 'githubRefreshToken',
+				allowedHosts: ['api.github.com'],
+				tokenPayload: {
+					access_token: 'access-token',
+					refresh_token: 'refresh-token',
+				},
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toMatchObject({
+		ok: true,
+		integrationName: 'GitHub',
+	})
+	expect(mockModule.saveValue).toHaveBeenCalledWith(
+		expect.objectContaining({
+			name: '_integration:GitHub',
+			value: expect.not.stringContaining('ftp://'),
+		}),
+	)
+})
+
 test('host approval view is derived from allowed-host and selected secret', async () => {
 	mockModule.listSecrets.mockResolvedValueOnce([
 		{

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -119,6 +119,7 @@ function createEnv() {
 }
 
 test('connect oauth returns direct host approval links for saved token secrets', async () => {
+	mockModule.saveValue.mockClear()
 	const handler = createAccountSecretsApiHandler(createEnv())
 	const response = await handler.handler({
 		request: new Request('https://example.com/account/secrets.json', {
@@ -127,8 +128,12 @@ test('connect oauth returns direct host approval links for saved token secrets',
 			body: JSON.stringify({
 				action: 'connect_oauth',
 				provider: 'GitHub',
+				authorizeUrl: 'https://github.com/login/oauth/authorize',
 				tokenUrl: 'https://github.com/login/oauth/access_token',
 				apiBaseUrl: 'https://api.github.com',
+				scopes: ['repo', 'read:user'],
+				scopeSeparator: ' ',
+				extraAuthorizeParams: { prompt: 'consent' },
 				flow: 'pkce',
 				clientIdValueName: 'github-client-id',
 				accessTokenSecretName: 'githubAccessToken',
@@ -179,6 +184,28 @@ test('connect oauth returns direct host approval links for saved token secrets',
 	})
 	expect(mockModule.buildSecretHostApprovalUrl).toHaveBeenCalledTimes(4)
 	expect(mockModule.setSecretAllowedHosts).not.toHaveBeenCalled()
+	expect(mockModule.saveValue).toHaveBeenCalledWith(
+		expect.objectContaining({
+			name: '_integration:GitHub',
+			value: JSON.stringify({
+				name: 'GitHub',
+				tokenUrl: 'https://github.com/login/oauth/access_token',
+				apiBaseUrl: 'https://api.github.com',
+				flow: 'pkce',
+				clientIdValueName: 'github-client-id',
+				clientSecretSecretName: null,
+				accessTokenSecretName: 'githubAccessToken',
+				refreshTokenSecretName: 'githubRefreshToken',
+				requiredHosts: ['api.github.com', 'github.com'],
+				authorization: {
+					authorizeUrl: 'https://github.com/login/oauth/authorize',
+					scopes: ['repo', 'read:user'],
+					scopeSeparator: null,
+					extraAuthorizeParams: { prompt: 'consent' },
+				},
+			}),
+		}),
+	)
 })
 
 test('connect oauth omits direct host approval links when hosts are already approved', async () => {

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -30,7 +30,7 @@ import { normalizeAllowedHosts } from '#mcp/secrets/allowed-hosts.ts'
 import { getValue, saveValue } from '#mcp/values/service.ts'
 import {
 	buildIntegrationValueName,
-	normalizeIntegrationConfig,
+	parseIntegrationConfig,
 } from '#mcp/capabilities/values/integration-shared.ts'
 
 type AccountEditableSecretScope = Extract<SecretScope, 'app' | 'user'>
@@ -590,23 +590,32 @@ async function saveIntegrationConfig(input: {
 	if (!providerKey) {
 		throw new Error('Provider must contain letters or numbers.')
 	}
-	const integration = normalizeIntegrationConfig({
-		name: input.provider,
-		tokenUrl: input.tokenUrl,
-		apiBaseUrl: input.apiBaseUrl,
-		flow: input.flow,
-		clientIdValueName: input.clientIdValueName,
-		clientSecretSecretName:
-			input.flow === 'confidential'
-				? (input.clientSecretSecretName ?? `${providerKey}ClientSecret`)
+	const integration = parseIntegrationConfig(
+		{
+			name: input.provider,
+			tokenUrl: input.tokenUrl,
+			apiBaseUrl: input.apiBaseUrl,
+			flow: input.flow,
+			clientIdValueName: input.clientIdValueName,
+			clientSecretSecretName:
+				input.flow === 'confidential'
+					? (input.clientSecretSecretName ?? `${providerKey}ClientSecret`)
+					: null,
+			accessTokenSecretName: input.accessTokenSecretName,
+			refreshTokenSecretName: readTokenField(
+				input.tokenPayload,
+				'refresh_token',
+			)
+				? input.refreshTokenSecretName
 				: null,
-		accessTokenSecretName: input.accessTokenSecretName,
-		refreshTokenSecretName: readTokenField(input.tokenPayload, 'refresh_token')
-			? input.refreshTokenSecretName
-			: null,
-		requiredHosts: input.allowedHosts,
-		...(input.authorization ? { authorization: input.authorization } : {}),
-	})
+			requiredHosts: input.allowedHosts,
+			...(input.authorization ? { authorization: input.authorization } : {}),
+		},
+		input.provider,
+	)
+	if (!integration) {
+		throw new Error('OAuth integration configuration is invalid.')
+	}
 	await saveValue({
 		env: input.env,
 		userId: input.userId,

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -265,6 +265,7 @@ async function handleConnectOauthAction(input: {
 	const provider = readString(input.body, 'provider')
 	const tokenUrl = readOptionalString(input.body, 'tokenUrl')
 	const apiBaseUrl = readOptionalString(input.body, 'apiBaseUrl')
+	const authorizeUrl = readOptionalString(input.body, 'authorizeUrl')
 	const flow = readOptionalString(input.body, 'flow')
 	const clientIdValueName = readOptionalString(input.body, 'clientIdValueName')
 	const clientSecretSecretName = readOptionalString(
@@ -278,6 +279,12 @@ async function handleConnectOauthAction(input: {
 	)
 	const allowedHosts = normalizeAllowedHosts(
 		readStringArray(input.body, 'allowedHosts'),
+	)
+	const scopes = readStringArray(input.body, 'scopes')
+	const scopeSeparator = readRawOptionalString(input.body, 'scopeSeparator')
+	const extraAuthorizeParams = readStringRecord(
+		input.body,
+		'extraAuthorizeParams',
 	)
 	const tokenPayload =
 		(input.body as Record<string, unknown>)['tokenPayload'] ?? null
@@ -375,6 +382,14 @@ async function handleConnectOauthAction(input: {
 		refreshTokenSecretName,
 		tokenPayload: tokenRecord,
 		allowedHosts,
+		authorization: authorizeUrl
+			? {
+					authorizeUrl,
+					scopes,
+					scopeSeparator,
+					extraAuthorizeParams,
+				}
+			: null,
 	})
 	const approvalSecretNames = [
 		accessTokenSecretName,
@@ -564,6 +579,12 @@ async function saveIntegrationConfig(input: {
 	refreshTokenSecretName: string | null
 	tokenPayload: Record<string, unknown>
 	allowedHosts: Array<string>
+	authorization: {
+		authorizeUrl: string
+		scopes: Array<string>
+		scopeSeparator: string | null
+		extraAuthorizeParams: Record<string, string>
+	} | null
 }) {
 	const providerKey = normalizeProviderKey(input.provider)
 	if (!providerKey) {
@@ -584,6 +605,7 @@ async function saveIntegrationConfig(input: {
 			? input.refreshTokenSecretName
 			: null,
 		requiredHosts: input.allowedHosts,
+		...(input.authorization ? { authorization: input.authorization } : {}),
 	})
 	await saveValue({
 		env: input.env,
@@ -1247,6 +1269,11 @@ function readOptionalString(body: object, key: string) {
 	return typeof value === 'string' ? value.trim() : null
 }
 
+function readRawOptionalString(body: object, key: string) {
+	const value = (body as Record<string, unknown>)[key]
+	return typeof value === 'string' ? value : null
+}
+
 function safeParseHost(raw: string) {
 	try {
 		return new URL(raw).hostname
@@ -1259,6 +1286,18 @@ function readStringArray(body: object, key: string) {
 	const value = (body as Record<string, unknown>)[key]
 	if (!Array.isArray(value)) return []
 	return value.filter((item): item is string => typeof item === 'string')
+}
+
+function readStringRecord(body: object, key: string) {
+	const value = (body as Record<string, unknown>)[key]
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+	return Object.fromEntries(
+		Object.entries(value)
+			.filter(
+				(entry): entry is [string, string] => typeof entry[1] === 'string',
+			)
+			.map(([recordKey, recordValue]) => [recordKey, recordValue]),
+	)
 }
 
 function readAccountSecretScope(

--- a/packages/worker/src/mcp/capabilities/values/integration-save.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-save.node.test.ts
@@ -134,6 +134,48 @@ test('parseIntegrationConfig keeps older rows readable when apiBaseUrl is missin
 	})
 })
 
+test('parseIntegrationConfig rejects unsafe authorization URLs and whitespace-only scopes', () => {
+	expect(
+		parseIntegrationConfig(
+			{
+				name: 'spotify',
+				tokenUrl: 'https://accounts.spotify.com/api/token',
+				flow: 'pkce',
+				clientIdValueName: 'spotify-client-id',
+				clientSecretSecretName: null,
+				accessTokenSecretName: 'spotifyAccessToken',
+				refreshTokenSecretName: 'spotifyRefreshToken',
+				requiredHosts: ['api.spotify.com'],
+				authorization: {
+					authorizeUrl: 'ftp://accounts.spotify.com/authorize',
+					scopes: ['user-read-email'],
+				},
+			},
+			null,
+		),
+	).toBeNull()
+
+	expect(
+		parseIntegrationConfig(
+			{
+				name: 'spotify',
+				tokenUrl: 'https://accounts.spotify.com/api/token',
+				flow: 'pkce',
+				clientIdValueName: 'spotify-client-id',
+				clientSecretSecretName: null,
+				accessTokenSecretName: 'spotifyAccessToken',
+				refreshTokenSecretName: 'spotifyRefreshToken',
+				requiredHosts: ['api.spotify.com'],
+				authorization: {
+					authorizeUrl: 'https://accounts.spotify.com/authorize',
+					scopes: [' '],
+				},
+			},
+			null,
+		),
+	).toBeNull()
+})
+
 test('integration_save creates a new integration record', async () => {
 	const testDb = createValueTestDb()
 

--- a/packages/worker/src/mcp/capabilities/values/integration-save.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-save.node.test.ts
@@ -80,17 +80,35 @@ test('mergeIntegrationConfig applies patch fields and preserves existing fields'
 		accessTokenSecretName: 'spotifyAccessToken',
 		refreshTokenSecretName: 'spotifyRefreshToken',
 		requiredHosts: ['accounts.spotify.com', 'api.spotify.com'],
+		authorization: {
+			authorizeUrl: 'https://accounts.spotify.com/authorize',
+			scopes: ['user-read-email'],
+			scopeSeparator: ' ',
+			extraAuthorizeParams: {},
+		},
 	})
 
 	const merged = mergeIntegrationConfig(current, {
 		name: 'spotify',
 		apiBaseUrl: 'https://api.spotify.com/v2/',
+		authorization: {
+			authorizeUrl: 'https://accounts.spotify.com/oauth2/authorize',
+			scopes: ['user-read-email', 'playlist-read-private'],
+			scopeSeparator: ' ',
+			extraAuthorizeParams: { prompt: 'consent' },
+		},
 		requiredHosts: ['api.spotify.com'],
 	})
 
 	expect(merged).toEqual({
 		...current,
 		apiBaseUrl: 'https://api.spotify.com/v2/',
+		authorization: {
+			authorizeUrl: 'https://accounts.spotify.com/oauth2/authorize',
+			scopes: ['user-read-email', 'playlist-read-private'],
+			scopeSeparator: null,
+			extraAuthorizeParams: { prompt: 'consent' },
+		},
 		requiredHosts: ['api.spotify.com'],
 	})
 })
@@ -130,6 +148,12 @@ test('integration_save creates a new integration record', async () => {
 			accessTokenSecretName: 'spotifyAccessToken',
 			refreshTokenSecretName: 'spotifyRefreshToken',
 			requiredHosts: ['api.spotify.com'],
+			authorization: {
+				authorizeUrl: 'https://accounts.spotify.com/authorize',
+				scopes: ['user-read-email', 'playlist-read-private'],
+				scopeSeparator: ' ',
+				extraAuthorizeParams: { show_dialog: 'true' },
+			},
 		},
 		{
 			env: { APP_DB: testDb.db } as unknown as Env,
@@ -149,6 +173,12 @@ test('integration_save creates a new integration record', async () => {
 		accessTokenSecretName: 'spotifyAccessToken',
 		refreshTokenSecretName: 'spotifyRefreshToken',
 		requiredHosts: ['api.spotify.com'],
+		authorization: {
+			authorizeUrl: 'https://accounts.spotify.com/authorize',
+			scopes: ['user-read-email', 'playlist-read-private'],
+			scopeSeparator: null,
+			extraAuthorizeParams: { show_dialog: 'true' },
+		},
 	})
 	expect(
 		JSON.parse(testDb.entries.get('_integration:spotify') ?? '{}'),
@@ -161,6 +191,12 @@ test('integration_save creates a new integration record', async () => {
 		accessTokenSecretName: 'spotifyAccessToken',
 		refreshTokenSecretName: 'spotifyRefreshToken',
 		requiredHosts: ['api.spotify.com'],
+		authorization: {
+			authorizeUrl: 'https://accounts.spotify.com/authorize',
+			scopes: ['user-read-email', 'playlist-read-private'],
+			scopeSeparator: null,
+			extraAuthorizeParams: { show_dialog: 'true' },
+		},
 	})
 })
 

--- a/packages/worker/src/mcp/capabilities/values/integration-save.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-save.node.test.ts
@@ -134,7 +134,7 @@ test('parseIntegrationConfig keeps older rows readable when apiBaseUrl is missin
 	})
 })
 
-test('parseIntegrationConfig rejects unsafe authorization URLs and whitespace-only scopes', () => {
+test('parseIntegrationConfig drops invalid authorization metadata while preserving the integration', () => {
 	expect(
 		parseIntegrationConfig(
 			{
@@ -153,7 +153,10 @@ test('parseIntegrationConfig rejects unsafe authorization URLs and whitespace-on
 			},
 			null,
 		),
-	).toBeNull()
+	).toMatchObject({
+		name: 'spotify',
+		authorization: null,
+	})
 
 	expect(
 		parseIntegrationConfig(
@@ -173,7 +176,10 @@ test('parseIntegrationConfig rejects unsafe authorization URLs and whitespace-on
 			},
 			null,
 		),
-	).toBeNull()
+	).toMatchObject({
+		name: 'spotify',
+		authorization: null,
+	})
 })
 
 test('integration_save creates a new integration record', async () => {

--- a/packages/worker/src/mcp/capabilities/values/integration-save.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-save.ts
@@ -95,6 +95,9 @@ function createNewIntegrationConfig(args: z.infer<typeof inputSchema>) {
 		accessTokenSecretName: args.accessTokenSecretName,
 		refreshTokenSecretName: args.refreshTokenSecretName ?? null,
 		requiredHosts: args.requiredHosts,
+		...(args.authorization !== undefined
+			? { authorization: args.authorization }
+			: {}),
 	})
 	if (!parsed.success) {
 		const details = parsed.error.issues

--- a/packages/worker/src/mcp/capabilities/values/integration-shared.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-shared.ts
@@ -77,17 +77,22 @@ export function normalizeIntegrationAuthorization(
 		value.scopeSeparator === defaultIntegrationScopeSeparator
 			? null
 			: value.scopeSeparator
-	const extraAuthorizeParams = Object.fromEntries(
-		Object.entries(value.extraAuthorizeParams ?? {})
-			.map(([key, paramValue]) => [key.trim(), paramValue])
-			.filter(([key]) => key.length > 0)
-			.sort(([left], [right]) => left.localeCompare(right)),
-	)
+	const extraAuthorizeParams: Record<string, string> = {}
+	for (const [rawKey, paramValue] of Object.entries(
+		value.extraAuthorizeParams ?? {},
+	)) {
+		const key = rawKey.trim()
+		if (key) extraAuthorizeParams[key] = paramValue
+	}
 	return {
 		authorizeUrl: value.authorizeUrl.trim(),
 		scopes: value.scopes.map((scope) => scope.trim()).filter(Boolean),
 		scopeSeparator,
-		extraAuthorizeParams,
+		extraAuthorizeParams: Object.fromEntries(
+			Object.keys(extraAuthorizeParams)
+				.sort((left, right) => left.localeCompare(right))
+				.map((key) => [key, extraAuthorizeParams[key] ?? '']),
+		),
 	}
 }
 

--- a/packages/worker/src/mcp/capabilities/values/integration-shared.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-shared.ts
@@ -3,6 +3,17 @@ import { normalizeAllowedHosts } from '#mcp/secrets/allowed-hosts.ts'
 
 export const integrationFlowValues = ['pkce', 'confidential'] as const
 
+export const defaultIntegrationScopeSeparator = ' '
+
+export const integrationAuthorizationSchema = z
+	.object({
+		authorizeUrl: z.string().url(),
+		scopes: z.array(z.string().min(1)),
+		scopeSeparator: z.string().min(1).optional().nullable(),
+		extraAuthorizeParams: z.record(z.string(), z.string()).optional(),
+	})
+	.strict()
+
 export const integrationConfigSchema = z.object({
 	name: z.string().min(1),
 	tokenUrl: z.string().url(),
@@ -13,9 +24,13 @@ export const integrationConfigSchema = z.object({
 	accessTokenSecretName: z.string().min(1),
 	refreshTokenSecretName: z.string().min(1).optional().nullable(),
 	requiredHosts: z.array(z.string()).optional(),
+	authorization: integrationAuthorizationSchema.optional().nullable(),
 })
 
 export type IntegrationConfig = z.infer<typeof integrationConfigSchema>
+export type IntegrationAuthorization = z.infer<
+	typeof integrationAuthorizationSchema
+>
 
 export const integrationSaveSchema = z
 	.object({
@@ -28,6 +43,7 @@ export const integrationSaveSchema = z
 		accessTokenSecretName: z.string().min(1).optional(),
 		refreshTokenSecretName: z.string().min(1).nullable().optional(),
 		requiredHosts: z.array(z.string()).optional(),
+		authorization: integrationAuthorizationSchema.nullable().optional(),
 	})
 	.strict()
 
@@ -36,6 +52,9 @@ export type IntegrationSaveInput = z.infer<typeof integrationSaveSchema>
 export function normalizeIntegrationConfig(
 	value: IntegrationConfig,
 ): IntegrationConfig {
+	const authorization = value.authorization
+		? normalizeIntegrationAuthorization(value.authorization)
+		: null
 	return {
 		...value,
 		name: value.name.trim(),
@@ -46,6 +65,29 @@ export function normalizeIntegrationConfig(
 		accessTokenSecretName: value.accessTokenSecretName.trim(),
 		refreshTokenSecretName: value.refreshTokenSecretName?.trim() || null,
 		requiredHosts: normalizeAllowedHosts(value.requiredHosts ?? []),
+		...(authorization ? { authorization } : {}),
+	}
+}
+
+export function normalizeIntegrationAuthorization(
+	value: IntegrationAuthorization,
+): IntegrationAuthorization {
+	const scopeSeparator =
+		value.scopeSeparator == null ||
+		value.scopeSeparator === defaultIntegrationScopeSeparator
+			? null
+			: value.scopeSeparator
+	const extraAuthorizeParams = Object.fromEntries(
+		Object.entries(value.extraAuthorizeParams ?? {})
+			.map(([key, paramValue]) => [key.trim(), paramValue])
+			.filter(([key]) => key.length > 0)
+			.sort(([left], [right]) => left.localeCompare(right)),
+	)
+	return {
+		authorizeUrl: value.authorizeUrl.trim(),
+		scopes: value.scopes.map((scope) => scope.trim()).filter(Boolean),
+		scopeSeparator,
+		extraAuthorizeParams,
 	}
 }
 

--- a/packages/worker/src/mcp/capabilities/values/integration-shared.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-shared.ts
@@ -139,7 +139,21 @@ export function parseIntegrationConfig(
 				? { ...record, name: fallbackName }
 				: record
 	const parsed = integrationConfigSchema.safeParse(configCandidate)
-	return parsed.success ? normalizeIntegrationConfig(parsed.data) : null
+	if (parsed.success) return normalizeIntegrationConfig(parsed.data)
+	if (
+		configCandidate &&
+		typeof configCandidate === 'object' &&
+		'authorization' in configCandidate
+	) {
+		const fallbackParsed = integrationConfigSchema.safeParse({
+			...configCandidate,
+			authorization: null,
+		})
+		if (fallbackParsed.success) {
+			return normalizeIntegrationConfig(fallbackParsed.data)
+		}
+	}
+	return null
 }
 
 export function parseIntegrationJson(raw: string) {

--- a/packages/worker/src/mcp/capabilities/values/integration-shared.ts
+++ b/packages/worker/src/mcp/capabilities/values/integration-shared.ts
@@ -3,12 +3,21 @@ import { normalizeAllowedHosts } from '#mcp/secrets/allowed-hosts.ts'
 
 export const integrationFlowValues = ['pkce', 'confidential'] as const
 
-export const defaultIntegrationScopeSeparator = ' '
+const defaultIntegrationScopeSeparator = ' '
 
 export const integrationAuthorizationSchema = z
 	.object({
-		authorizeUrl: z.string().url(),
-		scopes: z.array(z.string().min(1)),
+		authorizeUrl: z.string().url().refine(isHttpUrl, {
+			message: 'Authorize URL must use http or https.',
+		}),
+		scopes: z.array(
+			z
+				.string()
+				.min(1)
+				.refine((scope) => scope.trim().length > 0, {
+					message: 'Scope cannot be whitespace-only.',
+				}),
+		),
 		scopeSeparator: z.string().min(1).optional().nullable(),
 		extraAuthorizeParams: z.record(z.string(), z.string()).optional(),
 	})
@@ -28,9 +37,7 @@ export const integrationConfigSchema = z.object({
 })
 
 export type IntegrationConfig = z.infer<typeof integrationConfigSchema>
-export type IntegrationAuthorization = z.infer<
-	typeof integrationAuthorizationSchema
->
+type IntegrationAuthorization = z.infer<typeof integrationAuthorizationSchema>
 
 export const integrationSaveSchema = z
 	.object({
@@ -69,7 +76,7 @@ export function normalizeIntegrationConfig(
 	}
 }
 
-export function normalizeIntegrationAuthorization(
+function normalizeIntegrationAuthorization(
 	value: IntegrationAuthorization,
 ): IntegrationAuthorization {
 	const scopeSeparator =
@@ -140,5 +147,14 @@ export function parseIntegrationJson(raw: string) {
 		return JSON.parse(raw)
 	} catch {
 		return null
+	}
+}
+
+function isHttpUrl(raw: string) {
+	try {
+		const url = new URL(raw)
+		return url.protocol === 'http:' || url.protocol === 'https:'
+	} catch {
+		return false
 	}
 }

--- a/packages/worker/src/mcp/execute-modules/codemode-utils.ts
+++ b/packages/worker/src/mcp/execute-modules/codemode-utils.ts
@@ -25,6 +25,12 @@ type IntegrationConfig = {
 	accessTokenSecretName: string
 	refreshTokenSecretName?: string | null
 	requiredHosts?: Array<string>
+	authorization?: {
+		authorizeUrl: string
+		scopes: Array<string>
+		scopeSeparator?: string | null
+		extraAuthorizeParams?: Record<string, string>
+	} | null
 }
 
 type IntegrationGetResult = {

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -183,6 +183,7 @@ test('entity detail formatting returns stable structured details for values and 
 		},
 	})
 	expect(integrationDetail.markdown).toContain('OAuth authorization metadata')
+	expect(integrationDetail.markdown).toContain('/connect/oauth?provider=github')
 })
 
 test('capability entity detail keeps the structured execute contract stable', () => {

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -70,6 +70,12 @@ test('search formatting keeps value and integration entity refs in the structure
 				accessTokenSecretName: 'github_access_token',
 				refreshTokenSecretName: 'github_refresh_token',
 				requiredHosts: ['api.github.com'],
+				authorization: {
+					authorizeUrl: 'https://github.com/login/oauth/authorize',
+					scopes: ['repo', 'read:user'],
+					scopeSeparator: null,
+					extraAuthorizeParams: { prompt: 'consent' },
+				},
 				usage: 'Read with integration_get: {"name":"github"}.',
 				fusedScore: 0.9,
 			},
@@ -92,6 +98,10 @@ test('search formatting keeps value and integration entity refs in the structure
 		flow: 'confidential',
 		tokenUrl: 'https://github.com/login/oauth/access_token',
 		requiredHosts: ['api.github.com'],
+		authorization: {
+			authorizeUrl: 'https://github.com/login/oauth/authorize',
+			scopes: ['repo', 'read:user'],
+		},
 		usage: expect.any(String),
 	})
 	expect(integrationMatch?.nextStep).toEqual(expect.any(String))
@@ -146,6 +156,12 @@ test('entity detail formatting returns stable structured details for values and 
 			accessTokenSecretName: 'github_access_token',
 			refreshTokenSecretName: 'github_refresh_token',
 			requiredHosts: ['api.github.com'],
+			authorization: {
+				authorizeUrl: 'https://github.com/login/oauth/authorize',
+				scopes: ['repo', 'read:user'],
+				scopeSeparator: null,
+				extraAuthorizeParams: { prompt: 'consent' },
+			},
 		},
 	})
 	expect(integrationDetail.structured).toMatchObject({
@@ -159,7 +175,14 @@ test('entity detail formatting returns stable structured details for values and 
 		accessTokenSecretName: 'github_access_token',
 		refreshTokenSecretName: 'github_refresh_token',
 		requiredHosts: ['api.github.com'],
+		authorization: {
+			authorizeUrl: 'https://github.com/login/oauth/authorize',
+			scopes: ['repo', 'read:user'],
+			scopeSeparator: null,
+			extraAuthorizeParams: { prompt: 'consent' },
+		},
 	})
+	expect(integrationDetail.markdown).toContain('OAuth authorization metadata')
 })
 
 test('capability entity detail keeps the structured execute contract stable', () => {

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -181,6 +181,7 @@ export type SlimSearchMatch =
 			clientSecretSecretName: string | null
 			accessTokenSecretName: string
 			refreshTokenSecretName: string | null
+			authorization: IntegrationConfig['authorization'] | null
 			nextStep?: string
 	  }
 	| {
@@ -310,6 +311,7 @@ export type SearchEntityDetailStructured =
 			accessTokenSecretName: string
 			refreshTokenSecretName: string | null
 			requiredHosts: Array<string>
+			authorization: IntegrationConfig['authorization'] | null
 	  }
 
 export type SearchEntityDetail =
@@ -396,6 +398,7 @@ export type SearchMatch =
 			clientSecretSecretName: string | null
 			accessTokenSecretName: string
 			refreshTokenSecretName: string | null
+			authorization?: IntegrationConfig['authorization'] | null
 	  }
 	| {
 			type: 'secret'
@@ -733,6 +736,7 @@ export function toSlimStructuredMatches(input: {
 				clientSecretSecretName: match.clientSecretSecretName,
 				accessTokenSecretName: match.accessTokenSecretName,
 				refreshTokenSecretName: match.refreshTokenSecretName,
+				authorization: match.authorization ?? null,
 				nextStep: `Inspect integration detail with search({ entity: "${match.integrationName}:integration" }) and then run a minimal authenticated execute smoke test before building or calling integration-backed code.`,
 			}
 		}
@@ -1013,6 +1017,7 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 
 	if (detail.type === 'integration') {
 		const requiredHosts = detail.config.requiredHosts ?? []
+		const authorization = detail.config.authorization ?? null
 		const lines = [
 			`# Integration — \`${detail.config.name}\``,
 			'',
@@ -1025,6 +1030,8 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 			`- Token URL: \`${detail.config.tokenUrl}\``,
 			`- API base URL: ${detail.config.apiBaseUrl ? `\`${detail.config.apiBaseUrl}\`` : 'none'}`,
 			`- Required hosts: ${requiredHosts.length > 0 ? requiredHosts.map((host) => `\`${host}\``).join(', ') : 'none'}`,
+			`- Authorize URL: ${authorization ? `\`${authorization.authorizeUrl}\`` : 'none'}`,
+			`- Scopes: ${authorization && authorization.scopes.length > 0 ? authorization.scopes.map((scope) => `\`${scope}\``).join(', ') : 'none'}`,
 			'',
 			'## Read this integration',
 			'',
@@ -1038,6 +1045,23 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 			`- Access token secret name: \`${detail.config.accessTokenSecretName}\``,
 			`- Refresh token secret name: ${detail.config.refreshTokenSecretName ? `\`${detail.config.refreshTokenSecretName}\`` : 'none'}`,
 		]
+		if (authorization) {
+			lines.push(
+				'',
+				'## OAuth authorization metadata',
+				'',
+				`- Scope separator: ${authorization.scopeSeparator ? `\`${authorization.scopeSeparator}\`` : 'default single space'}`,
+				`- Extra authorize params: ${
+					Object.keys(authorization.extraAuthorizeParams ?? {}).length > 0
+						? Object.entries(authorization.extraAuthorizeParams ?? {})
+								.map(([key, value]) => `\`${key}=${value}\``)
+								.join(', ')
+						: 'none'
+				}`,
+				'',
+				'Reconnect with `/connect/oauth?provider=<integration-name>`; Kody derives the provider authorize URL from the saved integration metadata plus the current client credentials.',
+			)
+		}
 		return {
 			markdown: lines.join('\n'),
 			structured: {
@@ -1056,6 +1080,7 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 				accessTokenSecretName: detail.config.accessTokenSecretName,
 				refreshTokenSecretName: detail.config.refreshTokenSecretName ?? null,
 				requiredHosts,
+				authorization,
 			} satisfies SearchEntityDetailStructured,
 		}
 	}

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -1059,7 +1059,7 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 						: 'none'
 				}`,
 				'',
-				'Reconnect with `/connect/oauth?provider=<integration-name>`; Kody derives the provider authorize URL from the saved integration metadata plus the current client credentials.',
+				`Reconnect with \`/connect/oauth?provider=${encodeURIComponent(detail.config.name)}\`; Kody derives the provider authorize URL from the saved integration metadata plus the current client credentials.`,
 			)
 		}
 		return {

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -283,6 +283,8 @@ function buildIntegrationSearchDocument(input: {
 		input.config.tokenUrl,
 		input.config.apiBaseUrl ?? '',
 		input.config.flow,
+		input.config.authorization?.authorizeUrl ?? '',
+		...(input.config.authorization?.scopes ?? []),
 		...(input.config.requiredHosts ?? []),
 	]
 		.filter((value) => value.trim().length > 0)
@@ -1121,6 +1123,7 @@ function buildIntegrationCandidates(input: {
 						clientSecretSecretName: config.clientSecretSecretName ?? null,
 						accessTokenSecretName: config.accessTokenSecretName,
 						refreshTokenSecretName: config.refreshTokenSecretName ?? null,
+						authorization: config.authorization ?? null,
 					},
 					type: 'integration' as const,
 					id: integrationName,
@@ -1131,6 +1134,8 @@ function buildIntegrationCandidates(input: {
 						config.flow,
 						config.apiBaseUrl ?? '',
 						config.tokenUrl,
+						config.authorization?.authorizeUrl ?? '',
+						...(config.authorization?.scopes ?? []),
 						...(config.requiredHosts ?? []),
 					],
 					scoreComponents: buildCandidateBaseScore({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add optional OAuth authorization metadata to saved integration configs (authorize URL, scopes, non-default separator, extra authorize params)
- Persist authorization metadata from `/connect/oauth` and reuse it for provider-only reconnects
- Expose authorization metadata through integration search/detail output and docs
- Address AI-reviewer feedback by hardening authorize URL validation, preserving integrations when authorization metadata is invalid, avoiding empty reconnect inputs overriding stored scopes, and narrowing unnecessary exports

## Walkthrough
<a href="https://cursor.com/agents/bc-b62238df-2617-4537-a8b7-994fb635a623/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnect_oauth_metadata_and_credentials_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-932e21c6-33ea-4ce2-a9f4-ee6c9c6e8aa2" alt="connect_oauth_metadata_and_credentials_walkthrough.mp4" /></a>

## Testing
- `npm run test -- --run packages/worker/src/mcp/capabilities/values/integration-save.node.test.ts packages/worker/client/routes/connect-oauth.node.test.ts packages/worker/src/app/handlers/account-secrets.node.test.ts packages/worker/src/mcp/tools/search-format.node.test.ts`
- `npm run typecheck`
- CI `✅ Validate` passed on commit `15b9a32`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b62238df-2617-4537-a8b7-994fb635a623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b62238df-2617-4537-a8b7-994fb635a623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OAuth integrations now persist authorization metadata (authorize URLs, scopes, and parameters) to enable seamless future reconnections
  * Authorization metadata is now visible when viewing saved integrations
  * OAuth authorization details are now searchable and included in integration information

* **Documentation**
  * Added guidance on accessing and using stored OAuth authorization metadata for integration reconnections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/469)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->