### PR TITLE
Clarify memory mutation id handling

### DIFF
--- a/packages/worker/src/mcp/capabilities/meta/meta-memory-delete.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-memory-delete.node.test.ts
@@ -1,0 +1,43 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	deleteMemory: vi.fn(),
+	getMemory: vi.fn(),
+}))
+
+vi.mock('#mcp/memory/service.ts', () => ({
+	deleteMemory: (...args: Array<unknown>) => mockModule.deleteMemory(...args),
+	getMemory: (...args: Array<unknown>) => mockModule.getMemory(...args),
+	getMemoryMutationNotFoundMessage: (memoryId: string) =>
+		`helpful not-found message for ${memoryId}`,
+}))
+
+const { metaMemoryDeleteCapability } = await import('./meta-memory-delete.ts')
+
+test('meta_memory_delete uses the mutation not-found guidance for rejected ids', async () => {
+	mockModule.getMemory.mockResolvedValueOnce(null)
+
+	await expect(
+		metaMemoryDeleteCapability.handler(
+			{
+				memory_id: 'transcribed-memory-id',
+				verified_by_agent: true,
+			},
+			{
+				env: {} as Env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://heykody.dev',
+					user: { userId: 'user-123' },
+				}),
+			},
+		),
+	).rejects.toThrow('helpful not-found message for transcribed-memory-id')
+	expect(mockModule.getMemory).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-123',
+			memoryId: 'transcribed-memory-id',
+		}),
+	)
+	expect(mockModule.deleteMemory).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/mcp/capabilities/meta/meta-memory-delete.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-memory-delete.ts
@@ -2,7 +2,11 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
-import { deleteMemory, getMemory } from '#mcp/memory/service.ts'
+import {
+	deleteMemory,
+	getMemory,
+	getMemoryMutationNotFoundMessage,
+} from '#mcp/memory/service.ts'
 import {
 	memoryRecordSchema,
 	verifyFirstGuidance,
@@ -68,7 +72,7 @@ export const metaMemoryDeleteCapability = defineDomainCapability(
 				memoryId: args.memory_id,
 			})
 			if (!existing) {
-				throw new Error('Memory not found for this user.')
+				throw new Error(getMemoryMutationNotFoundMessage(args.memory_id))
 			}
 			const memory = await deleteMemory({
 				env: ctx.env,

--- a/packages/worker/src/mcp/capabilities/meta/meta-memory-search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-memory-search.node.test.ts
@@ -1,0 +1,64 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	searchMemoryRecords: vi.fn(),
+}))
+
+vi.mock('#mcp/memory/service.ts', () => ({
+	memorySearchMutationGuidance: 'Use this exact id for memory mutations.',
+	searchMemoryRecords: (...args: Array<unknown>) =>
+		mockModule.searchMemoryRecords(...args),
+}))
+
+const { metaMemorySearchCapability } = await import('./meta-memory-search.ts')
+
+test('meta_memory_search annotates returned ids as mutable for the signed-in user', async () => {
+	mockModule.searchMemoryRecords.mockResolvedValueOnce({
+		query: 'theme preference',
+		matches: [
+			{
+				id: 'memory-1',
+				category: 'preference',
+				status: 'active',
+				subject: 'Preferred editor theme',
+				summary: 'User prefers a dark editor theme.',
+				details: '',
+				tags: ['theme'],
+				sourceUris: ['https://docs.example.com/preferences/editor-theme'],
+				dedupeKey: 'pref:editor-theme',
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-02T00:00:00.000Z',
+				lastAccessedAt: null,
+				deletedAt: null,
+				score: 0.98,
+			},
+		],
+		suppressedCount: 0,
+	})
+
+	const result = await metaMemorySearchCapability.handler(
+		{
+			query: 'theme preference',
+		},
+		{
+			env: {} as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				user: { userId: 'user-123' },
+			}),
+		},
+	)
+
+	expect(mockModule.searchMemoryRecords).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-123',
+			query: 'theme preference',
+		}),
+	)
+	expect(result.matches[0]).toMatchObject({
+		id: 'memory-1',
+		can_mutate: true,
+		mutation_guidance: 'Use this exact id for memory mutations.',
+	})
+})

--- a/packages/worker/src/mcp/capabilities/meta/meta-memory-search.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-memory-search.ts
@@ -2,19 +2,27 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
-import { searchMemoryRecords } from '#mcp/memory/service.ts'
+import {
+	memorySearchMutationGuidance,
+	searchMemoryRecords,
+} from '#mcp/memory/service.ts'
 import {
 	memoryMatchSchema,
 	requireMcpUser,
 	verifyFirstWarning,
 } from './meta-memory-shared.ts'
 
+const mutableMemoryMatchSchema = memoryMatchSchema.extend({
+	can_mutate: z.boolean(),
+	mutation_guidance: z.string(),
+})
+
 export const metaMemorySearchCapability = defineDomainCapability(
 	capabilityDomainNames.meta,
 	{
 		name: 'meta_memory_search',
 		description:
-			'Search stored memories for the signed-in user. Use this when you want to browse memory directly. If you are considering writing or deleting a memory, prefer meta_memory_verify first and review the related memories before taking action.',
+			'Search stored memories for the signed-in user. Returned matches are mutable for this signed-in user unless can_mutate is false. If you are considering writing or deleting a memory, prefer meta_memory_verify first and review the related memories before taking action.',
 		keywords: ['memory', 'search', 'lookup', 'related', 'verify'],
 		readOnly: true,
 		idempotent: true,
@@ -41,7 +49,7 @@ export const metaMemorySearchCapability = defineDomainCapability(
 		}),
 		outputSchema: z.object({
 			query: z.string(),
-			matches: z.array(memoryMatchSchema),
+			matches: z.array(mutableMemoryMatchSchema),
 			warning: z.string(),
 		}),
 		async handler(args, ctx: CapabilityContext) {
@@ -71,6 +79,8 @@ export const metaMemorySearchCapability = defineDomainCapability(
 					last_accessed_at: match.lastAccessedAt,
 					deleted_at: match.deletedAt,
 					score: match.score,
+					can_mutate: true,
+					mutation_guidance: memorySearchMutationGuidance,
 				})),
 				warning: verifyFirstWarning,
 			}

--- a/packages/worker/src/mcp/memory/service.node.test.ts
+++ b/packages/worker/src/mcp/memory/service.node.test.ts
@@ -330,6 +330,88 @@ test('memory service upserts, verifies, and soft deletes', async () => {
 	])
 })
 
+test('memory search returns mutable user-owned ids that can be updated and deleted', async () => {
+	const testDb = createMemoryTestDb()
+	const runtimeEnv = env(testDb.db)
+
+	await upsertMemory({
+		env: runtimeEnv,
+		userId: 'user-123',
+		subject: 'Mutable memory id',
+		summary: 'Search results should return ids that mutation calls can reuse.',
+		category: 'workflow',
+		verificationReference: 'verify-3',
+	})
+	await upsertMemory({
+		env: runtimeEnv,
+		userId: 'other-user',
+		subject: 'Mutable memory id',
+		summary: 'This other-user memory must not leak through search.',
+		category: 'workflow',
+		verificationReference: 'verify-4',
+	})
+
+	const search = await searchMemoryRecords({
+		env: runtimeEnv,
+		userId: 'user-123',
+		query: 'mutable memory id mutation calls',
+	})
+
+	expect(search.matches).toHaveLength(1)
+	const match = search.matches[0]!
+	expect(match.subject).toBe('Mutable memory id')
+
+	const updated = await upsertMemory({
+		env: runtimeEnv,
+		userId: 'user-123',
+		memoryId: match.id,
+		subject: 'Mutable memory id',
+		summary: 'The exact search result id was accepted by upsert.',
+		category: 'workflow',
+		verificationReference: 'verify-5',
+	})
+	expect(updated.mode).toBe('updated')
+	expect(updated.memory.id).toBe(match.id)
+
+	const deleted = await deleteMemory({
+		env: runtimeEnv,
+		userId: 'user-123',
+		memoryId: match.id,
+	})
+	expect(deleted?.id).toBe(match.id)
+	expect(deleted?.status).toBe('deleted')
+})
+
+test('memory upsert explains rejected mutation ids', async () => {
+	const testDb = createMemoryTestDb()
+	const runtimeEnv = env(testDb.db)
+
+	await expect(
+		upsertMemory({
+			env: runtimeEnv,
+			userId: 'user-123',
+			memoryId: 'transcribed-memory-id',
+			subject: 'Preferred editor theme',
+			summary: 'User prefers a dark theme in editors.',
+			category: 'preference',
+			verificationReference: 'verify-6',
+		}),
+	).rejects.toThrow(
+		'Memory "transcribed-memory-id" was not found in mutable memory storage for this signed-in user.',
+	)
+	await expect(
+		upsertMemory({
+			env: runtimeEnv,
+			userId: 'user-123',
+			memoryId: 'transcribed-memory-id',
+			subject: 'Preferred editor theme',
+			summary: 'User prefers a dark theme in editors.',
+			category: 'preference',
+			verificationReference: 'verify-7',
+		}),
+	).rejects.toThrow('copy the full id exactly and retry')
+})
+
 test('memory surfacing suppresses repeated memories per conversation', async () => {
 	const testDb = createMemoryTestDb()
 	const runtimeEnv = env(testDb.db)

--- a/packages/worker/src/mcp/memory/service.ts
+++ b/packages/worker/src/mcp/memory/service.ts
@@ -29,6 +29,12 @@ const maxTagCount = 16
 const maxSourceUriLength = 2_048
 const maxSourceUriCount = 12
 const defaultSuppressionTtlMs = 30 * 24 * 60 * 60 * 1_000
+export const memorySearchMutationGuidance =
+	'This result is mutable for the signed-in user. Use this exact id as memory_id with meta_memory_upsert or meta_memory_delete after meta_memory_verify.'
+
+export function getMemoryMutationNotFoundMessage(memoryId: string) {
+	return `Memory ${JSON.stringify(memoryId)} was not found in mutable memory storage for this signed-in user. If this id came from meta_memory_search or meta_memory_verify, copy the full id exactly and retry. If the exact id still fails, rerun meta_memory_search/meta_memory_verify to find the current mutable memory or create a replacement by omitting memory_id; the original id may be stale, deleted, owned by another user, or from a legacy/non-mutable source.`
+}
 
 function logMemoryVectorSyncError(input: {
 	operation: 'upsert' | 'delete'
@@ -124,7 +130,7 @@ export async function upsertMemory(input: MemoryUpsertInput): Promise<{
 		? await getMemoryById(input.env.APP_DB, input.userId, input.memoryId)
 		: null
 	if (input.memoryId && !existing) {
-		throw new Error('Memory not found for this user.')
+		throw new Error(getMemoryMutationNotFoundMessage(input.memoryId))
 	}
 	const status = input.status ?? 'active'
 	const row: McpMemoryRow = existing
@@ -171,7 +177,11 @@ export async function upsertMemory(input: MemoryUpsertInput): Promise<{
 			last_accessed_at: row.last_accessed_at,
 			deleted_at: row.deleted_at,
 		})
-		if (!updated) throw new Error('Memory not found for this user.')
+		if (!updated) {
+			throw new Error(
+				getMemoryMutationNotFoundMessage(input.memoryId ?? row.id),
+			)
+		}
 	} else {
 		await insertMemory(input.env.APP_DB, row)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Annotate `meta_memory_search` matches as mutable for the signed-in user, including guidance to use the exact id for memory mutations after verification.
- Replace ambiguous memory mutation not-found errors with id-specific guidance for copied/transcribed, stale, cross-user, deleted, or legacy/non-mutable ids.
- Add regression coverage for search-returned ids flowing into upsert/delete and the improved error handling.

## Testing
- `npx vitest run --project node-unit packages/worker/src/mcp/memory/service.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-memory-search.node.test.ts packages/worker/src/mcp/capabilities/meta/meta-memory-delete.node.test.ts` — 3 files / 7 tests passed.
- `npm run validate` — format, lint, typecheck, unit tests, Playwright E2E, and MCP E2E all passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c561740-839f-4aa8-8f63-df4fa669a494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c561740-839f-4aa8-8f63-df4fa669a494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

