### PR TITLE
Update stale Kody terminology

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -144,8 +144,8 @@ Bindings are configured per environment in `packages/worker/wrangler.jsonc`
 
 ## Repo-backed source and Artifacts
 
-Repo-backed saved packages, package apps, and jobs use Cloudflare Artifacts repos
-plus D1 `entity_sources` / `repo_sessions` rows.
+Repo-backed saved packages, package apps, and jobs use Cloudflare Artifacts
+repos plus D1 `entity_sources` / `repo_sessions` rows.
 
 - Primary code lives under `packages/worker/src/repo/`.
 - `entity_sources` stores the durable mapping from

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -144,8 +144,8 @@ Bindings are configured per environment in `packages/worker/wrangler.jsonc`
 
 ## Repo-backed source and Artifacts
 
-Repo-backed saved packages, apps, skills, and jobs use Cloudflare Artifacts
-repos plus D1 `entity_sources` / `repo_sessions` rows.
+Repo-backed saved packages, package apps, and jobs use Cloudflare Artifacts repos
+plus D1 `entity_sources` / `repo_sessions` rows.
 
 - Primary code lives under `packages/worker/src/repo/`.
 - `entity_sources` stores the durable mapping from
@@ -157,17 +157,17 @@ repos plus D1 `entity_sources` / `repo_sessions` rows.
 
 Canonical source contract:
 
-- Published repo source is the only canonical source for saved packages, apps,
-  skills, and jobs.
-- D1 keeps metadata and projections only. It does not store canonical app HTML,
-  app backend code, skill code, or job code.
+- Published repo source is the only canonical source for saved packages, package
+  apps, and jobs.
+- D1 keeps metadata and projections only. It does not store canonical package
+  export code, app backend code, or job code.
 - App rows keep display metadata, parameters, visibility, `has_server_code`, and
-  `source_id`.
+  `source_id` for app projections.
 - Job rows keep scheduling/execution metadata, params, storage id, caller
   context, repo check policy, `source_id`, and the published commit last synced
   into the job projection.
-- Skill rows keep display/search metadata, parameters, capability annotations,
-  collection metadata, and `source_id`.
+- Saved package rows keep display/search metadata, tags, app availability, and
+  `source_id` for Kody search and package discovery.
 - Projection updates are made from published repo state by the publish/reindex
   paths; stale D1 inline source fields are not a fallback.
 

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -95,12 +95,10 @@ Worker bindings (see `packages/worker/wrangler.jsonc`):
 Optional Worker secret:
 
 - **`CAPABILITY_REINDEX_SECRET`** — Bearer token for
-  `POST /__maintenance/reindex-capabilities` and
-  `POST /__maintenance/reindex-skills` (production deploy workflow calls both
-  after healthcheck when the GitHub secret is set). Use skill reindex when
-  `mcp_skills` and Vectorize disagree (restore, manual D1 edits, etc.). Local
-  dev uses offline search while `WRANGLER_IS_LOCAL_DEV` is set or the binding is
-  missing.
+  `POST /__maintenance/reindex-capabilities` (production deploy workflow calls
+  it after healthcheck when the GitHub secret is set). Use capability reindex
+  when built-in capability metadata and Vectorize disagree. Local dev uses
+  offline search while `WRANGLER_IS_LOCAL_DEV` is set or the binding is missing.
 
 ## Cloudflare API (Worker + Email)
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -132,9 +132,9 @@ How to get/set each value:
 - `CLOUDFLARE_API_TOKEN`
   - In Cloudflare Dashboard, create an API Token with permissions to deploy
     Workers and edit D1 on the target account. This is the same token to reuse
-    for remote AI and Cloudflare API workflows that run with account secrets +
-    skills; when you do, also include the product permissions needed for those
-    APIs.
+    for remote AI and Cloudflare API workflows that run with account secrets and
+    saved packages; when you do, also include the product permissions needed for
+    those APIs.
   - In GitHub: `Settings` → `Secrets and variables` → `Actions` →
     `New repository secret`.
 - `COOKIE_SECRET`
@@ -175,9 +175,8 @@ How to get/set each value:
   - Generate a long random secret (for example `openssl rand -hex 32`), store it
     as the repository secret `CAPABILITY_REINDEX_SECRET`, and let the deploy
     workflow sync it to the Worker. After each production deploy, CI POSTs to
-    `/__maintenance/reindex-capabilities` and `/__maintenance/reindex-skills`
-    with `Authorization: Bearer …` to refresh capability and user-skill
-    embeddings.
+    `/__maintenance/reindex-capabilities` with `Authorization: Bearer …` to
+    refresh built-in capability embeddings.
 
 Preview deploys for pull requests create a separate Worker per PR named
 `<app-name>-pr-<number>` (for kody: `kody-pr-123`) plus one Worker per mock

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -94,7 +94,7 @@ automatically:
   `npm run dev` targets the Cloudflare mock unless `SKIP_CLOUDFLARE_MOCK=1`. The
   internal Cloudflare API client expects paths under `/client/v4/`.)
 - `CAPABILITY_REINDEX_SECRET` (optional Worker secret; bearer auth for
-  `POST /__maintenance/reindex-capabilities` to refresh builtin capability
+  `POST /__maintenance/reindex-capabilities` to refresh built-in capability
   embeddings in Vectorize. Saved package projections refresh when packages are
   saved or published.)
 

--- a/docs/use/repo-sessions.md
+++ b/docs/use/repo-sessions.md
@@ -146,7 +146,8 @@ files.
 `repo_write_file` overwrites one or more files with full new content and returns
 a per-file diff plus a `changed` flag. Reach for it when:
 
-- replacing the entire body of a package export module, job module, or app server
+- replacing the entire body of a package export module, job module, or app
+  server
 - writing a freshly generated package file that does not yet exist
 - patching a one-line config when you do not want to hand-craft a diff hunk
 

--- a/docs/use/repo-sessions.md
+++ b/docs/use/repo-sessions.md
@@ -146,7 +146,7 @@ files.
 `repo_write_file` overwrites one or more files with full new content and returns
 a per-file diff plus a `changed` flag. Reach for it when:
 
-- replacing the entire body of a job, app server, or skill module
+- replacing the entire body of a package export module, job module, or app server
 - writing a freshly generated package file that does not yet exist
 - patching a one-line config when you do not want to hand-craft a diff hunk
 

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -3,7 +3,7 @@
 ## Search returns no good matches
 
 - **Rephrase the query** using domain vocabulary from the search tool’s domain
-  hints (for example “GitHub”, “Cloudflare”, “meta skills”).
+  hints (for example “GitHub”, “Cloudflare”, “meta capabilities”).
 - Try **`meta_list_capabilities`** for the full live registry, including dynamic
   capabilities.
 - **`entity: "id:capability"`** looks up a **known** id. It does **not** turn an

--- a/packages/worker/.env.example
+++ b/packages/worker/.env.example
@@ -38,9 +38,9 @@ APP_BASE_URL=
 # Skip starting the Cloudflare mock during dev (use live API + token in `packages/worker/.env` instead):
 # SKIP_CLOUDFLARE_MOCK=1
 
-# Capability + skill vector search (optional Worker secret).
-# POST /__maintenance/reindex-capabilities and /__maintenance/reindex-skills with
-# Authorization: Bearer <this value> repopulates Vectorize after deploys. CI can set
-# GitHub secret CAPABILITY_REINDEX_SECRET and sync it via deploy workflow.
+# Capability vector search (optional Worker secret).
+# POST /__maintenance/reindex-capabilities with Authorization: Bearer <this value>
+# repopulates Vectorize after deploys. CI can set GitHub secret
+# CAPABILITY_REINDEX_SECRET and sync it via deploy workflow.
 # CAPABILITY_REINDEX_SECRET=
 

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -1330,7 +1330,7 @@ test('createJob rejects legacy async-arrow snippet code', async () => {
 			},
 		}),
 	).rejects.toThrow(
-		'Repo-backed job and skill entrypoints must default export a function',
+		'Repo-backed package export entrypoints and job entrypoints must default export a function',
 	)
 })
 

--- a/packages/worker/src/mcp/skills/skill-parameters.node.test.ts
+++ b/packages/worker/src/mcp/skills/skill-parameters.node.test.ts
@@ -5,7 +5,7 @@ import {
 	normalizeSkillParameters,
 } from './skill-parameters.ts'
 
-test('skill parameter definitions normalize names and resolve one workflow end to end', () => {
+test('module parameter definitions normalize names and resolve one workflow end to end', () => {
 	const definitions = normalizeSkillParameters([
 		{
 			name: ' owner ',
@@ -37,14 +37,14 @@ test('skill parameter definitions normalize names and resolve one workflow end t
 
 	expect(() =>
 		applySkillParameters({ definitions, values: { limit: 2 } }),
-	).toThrow('Missing required skill parameter: owner.')
+	).toThrow('Missing required module parameter: owner.')
 
 	expect(() =>
 		applySkillParameters({
 			definitions,
 			values: { owner: 'kody', extra: true },
 		}),
-	).toThrow('Unknown skill parameter(s): extra.')
+	).toThrow('Unknown module parameter(s): extra.')
 
 	expect(
 		applySkillParameters({ definitions, values: { owner: 'kody' } }),
@@ -59,6 +59,6 @@ test('buildParameterizedSkillCode applies params through the generated wrapper',
 		'async (params) => params.owner',
 		{ owner: 'kody' },
 	)
-	const skill = Function(`return (${code})`)() as () => Promise<unknown>
-	await expect(skill()).resolves.toBe('kody')
+	const module = Function(`return (${code})`)() as () => Promise<unknown>
+	await expect(module()).resolves.toBe('kody')
 })

--- a/packages/worker/src/mcp/skills/skill-parameters.ts
+++ b/packages/worker/src/mcp/skills/skill-parameters.ts
@@ -36,7 +36,7 @@ export const skillParameterSchema = z.object({
 	description: z
 		.string()
 		.min(1)
-		.describe('What this parameter controls for the skill.'),
+		.describe('What this parameter controls for the executable module.'),
 	type: z
 		.enum(skillParameterTypes)
 		.describe('Expected parameter type for runtime validation.'),
@@ -61,13 +61,13 @@ export function normalizeSkillParameters(
 	for (const param of input) {
 		const name = param.name.trim()
 		if (!name) {
-			throw new Error('Skill parameter name cannot be empty.')
+			throw new Error('Module parameter name cannot be empty.')
 		}
 		if (reservedParameterNames.has(name)) {
-			throw new Error(`Skill parameter name "${name}" is not allowed.`)
+			throw new Error(`Module parameter name "${name}" is not allowed.`)
 		}
 		if (seen.has(name)) {
-			throw new Error(`Duplicate skill parameter name: ${name}.`)
+			throw new Error(`Duplicate module parameter name: ${name}.`)
 		}
 		seen.add(name)
 		if (param.default !== undefined) {
@@ -105,14 +105,14 @@ export function applySkillParameters(input: {
 }): Record<string, unknown> {
 	if (!input.definitions || input.definitions.length === 0) {
 		const fallback = input.values ?? {}
-		assertJsonSerializable(fallback, 'skill params')
+		assertJsonSerializable(fallback, 'module params')
 		return fallback
 	}
 	const values = input.values ?? {}
 	const definedNames = new Set(input.definitions.map((def) => def.name))
 	const unknown = Object.keys(values).filter((key) => !definedNames.has(key))
 	if (unknown.length > 0) {
-		throw new Error(`Unknown skill parameter(s): ${unknown.join(', ')}.`)
+		throw new Error(`Unknown module parameter(s): ${unknown.join(', ')}.`)
 	}
 	const resolved: Record<string, unknown> = Object.create(null)
 	for (const def of input.definitions) {
@@ -127,10 +127,10 @@ export function applySkillParameters(input: {
 			continue
 		}
 		if (def.required) {
-			throw new Error(`Missing required skill parameter: ${def.name}.`)
+			throw new Error(`Missing required module parameter: ${def.name}.`)
 		}
 	}
-	assertJsonSerializable(resolved, 'skill params')
+	assertJsonSerializable(resolved, 'module params')
 	return resolved
 }
 
@@ -141,12 +141,12 @@ export async function buildParameterizedSkillCode(
 	const normalized = normalizeSkillCode(code)
 	const paramsJson = JSON.stringify(params)
 	if (paramsJson == null) {
-		throw new Error('Skill parameters must be JSON-serializable.')
+		throw new Error('Module parameters must be JSON-serializable.')
 	}
 	return `async () => {
   const params = ${paramsJson};
-  const skill = (${normalized});
-  return await skill(params);
+  const module = (${normalized});
+  return await module(params);
 }`
 }
 
@@ -213,24 +213,24 @@ function assertParameterValueType(
 	label: string,
 ) {
 	if (value === undefined) {
-		throw new Error(`Skill parameter "${label}" must not be undefined.`)
+		throw new Error(`Module parameter "${label}" must not be undefined.`)
 	}
 	if (type === 'json') return
 	if (type === 'string') {
 		if (typeof value !== 'string') {
-			throw new Error(`Skill parameter "${label}" must be a string.`)
+			throw new Error(`Module parameter "${label}" must be a string.`)
 		}
 		return
 	}
 	if (type === 'number') {
 		if (typeof value !== 'number' || !Number.isFinite(value)) {
-			throw new Error(`Skill parameter "${label}" must be a number.`)
+			throw new Error(`Module parameter "${label}" must be a number.`)
 		}
 		return
 	}
 	if (type === 'boolean') {
 		if (typeof value !== 'boolean') {
-			throw new Error(`Skill parameter "${label}" must be a boolean.`)
+			throw new Error(`Module parameter "${label}" must be a boolean.`)
 		}
 	}
 }

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -672,7 +672,7 @@ test('runRepoChecks rejects legacy async-arrow package job entrypoints', async (
 				kind: 'typecheck',
 				ok: false,
 				message: expect.stringContaining(
-					'Repo-backed job and skill entrypoints must default export a function',
+					'Repo-backed package export entrypoints and job entrypoints must default export a function',
 				),
 			}),
 		]),
@@ -750,7 +750,7 @@ test('published package entrypoint typecheck rejects legacy async-arrow job entr
 	expect(result).toEqual({
 		ok: false,
 		message: expect.stringContaining(
-			'Repo-backed job and skill entrypoints must default export a function',
+			'Repo-backed package export entrypoints and job entrypoints must default export a function',
 		),
 	})
 	expect(mockModule.createTypescriptLanguageService).not.toHaveBeenCalled()

--- a/packages/worker/src/repo/repo-codemode-execution.ts
+++ b/packages/worker/src/repo/repo-codemode-execution.ts
@@ -6,7 +6,7 @@ export const repoCodemodeModuleTypecheckHarnessPath =
 	'.__kody_repo_module_check__.ts'
 
 export const repoBackedModuleEntrypointExportErrorMessage =
-	'Repo-backed job and skill entrypoints must default export a function so Kody can invoke them with execute semantics.'
+	'Repo-backed package export entrypoints and job entrypoints must default export a function so Kody can invoke them with execute semantics.'
 
 const repoCodemodeSourceReadConcurrency = 8
 const repoCodemodeSourceMaxFiles = 250


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace stale skill/reindex-skill wording in user and contributor docs with package/capability terminology.
- Clarify capability Vectorize reindex docs and env comments to match implemented maintenance routes.
- Update agent-facing module parameter and repo entrypoint error text plus exact-string tests.
- Address CodeRabbit feedback by standardizing `built-in` wording.

## Testing
- `npx vitest run --project node-unit packages/worker/src/mcp/skills/skill-parameters.node.test.ts packages/worker/src/repo/checks.node.test.ts packages/worker/src/jobs/service.node.test.ts`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d988973-a3be-43aa-b76e-42bca17368ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d988973-a3be-43aa-b76e-42bca17368ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined data-storage and repo-backed entity descriptions (saved packages, package apps, jobs)
  * Clarified maintenance endpoint and capability reindexing guidance; removed skill reindexing docs
  * Updated setup and troubleshooting wording for clearer workflows

* **Behavior / Messaging**
  * Standardized wording from “skill” to “module” and adjusted error/message text accordingly

* **Tests**
  * Updated tests to match revised messaging and validation wording

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/475)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->