### PR TITLE
Fix OAuth reauth access token usage

### DIFF
--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -208,6 +208,53 @@ test('connect oauth returns direct host approval links for saved token secrets',
 	)
 })
 
+test('connect oauth keeps existing refresh token secret name when provider omits a rotated refresh token', async () => {
+	mockModule.saveValue.mockClear()
+	const handler = createAccountSecretsApiHandler(createEnv())
+	const response = await handler.handler({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'connect_oauth',
+				provider: 'spotify',
+				authorizeUrl: 'https://accounts.spotify.com/authorize',
+				tokenUrl: 'https://accounts.spotify.com/api/token',
+				apiBaseUrl: 'https://api.spotify.com/v1',
+				scopes: ['user-read-playback-state', 'playlist-modify-private'],
+				scopeSeparator: ' ',
+				extraAuthorizeParams: { show_dialog: 'true' },
+				flow: 'pkce',
+				clientIdValueName: 'spotify-client-id',
+				accessTokenSecretName: 'spotifyAccessToken',
+				refreshTokenSecretName: 'spotifyRefreshToken',
+				allowedHosts: ['api.spotify.com'],
+				tokenPayload: {
+					access_token: 'newly-scoped-access-token',
+					scope: 'user-read-playback-state playlist-modify-private',
+				},
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toMatchObject({
+		ok: true,
+		accessTokenSaved: true,
+		refreshTokenSaved: false,
+		integrationName: 'spotify',
+	})
+	expect(mockModule.saveValue).toHaveBeenCalledWith(
+		expect.objectContaining({
+			name: '_integration:spotify',
+			value: expect.stringContaining(
+				'"refreshTokenSecretName":"spotifyRefreshToken"',
+			),
+		}),
+	)
+})
+
 test('connect oauth omits direct host approval links when hosts are already approved', async () => {
 	mockModule.listSecrets.mockResolvedValueOnce([
 		{

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -602,12 +602,7 @@ async function saveIntegrationConfig(input: {
 					? (input.clientSecretSecretName ?? `${providerKey}ClientSecret`)
 					: null,
 			accessTokenSecretName: input.accessTokenSecretName,
-			refreshTokenSecretName: readTokenField(
-				input.tokenPayload,
-				'refresh_token',
-			)
-				? input.refreshTokenSecretName
-				: null,
+			refreshTokenSecretName: input.refreshTokenSecretName,
 			requiredHosts: input.allowedHosts,
 			...(input.authorization ? { authorization: input.authorization } : {}),
 		},

--- a/packages/worker/src/mcp/execute-modules/authenticated-fetch.node.test.ts
+++ b/packages/worker/src/mcp/execute-modules/authenticated-fetch.node.test.ts
@@ -24,6 +24,8 @@ type SandboxHelpers = {
 }
 
 const fakeAccessToken = 'test-access-token-abc123'
+const spotifyAccessTokenPlaceholder =
+	'Bearer {{secret:spotifyAccessToken|scope=user}}'
 
 const spotifyIntegration = {
 	name: 'spotify',
@@ -127,7 +129,7 @@ test('succeeds for apiBaseUrl host and attaches bearer token', async () => {
 	const lastCall = fetchCalls[fetchCalls.length - 1]!
 	expect(lastCall.url).toBe('https://api.spotify.com/v1/me')
 	expect(lastCall.headers.get('authorization')).toBe(
-		`Bearer ${fakeAccessToken}`,
+		spotifyAccessTokenPlaceholder,
 	)
 })
 
@@ -146,7 +148,7 @@ test('succeeds for a requiredHosts entry that is not apiBaseUrl', async () => {
 	const lastCall = fetchCalls[fetchCalls.length - 1]!
 	expect(lastCall.url).toBe('https://cdn.spotify.com/images/cover.jpg')
 	expect(lastCall.headers.get('authorization')).toBe(
-		`Bearer ${fakeAccessToken}`,
+		spotifyAccessTokenPlaceholder,
 	)
 })
 
@@ -215,7 +217,7 @@ test('prelude sandbox version allows requests to valid hosts', async () => {
 	expect(response.status).toBe(200)
 	const lastCall = fetchCalls[fetchCalls.length - 1]!
 	expect(lastCall.headers.get('authorization')).toBe(
-		`Bearer ${fakeAccessToken}`,
+		spotifyAccessTokenPlaceholder,
 	)
 })
 

--- a/packages/worker/src/mcp/execute-modules/codemode-utils.node.test.ts
+++ b/packages/worker/src/mcp/execute-modules/codemode-utils.node.test.ts
@@ -28,6 +28,11 @@ type SandboxHelpers = {
 	oauthClientCredentials: typeof oauthClientCredentials
 }
 
+type ApiResponseSpec = {
+	status: number
+	body: Record<string, unknown>
+}
+
 const spotifyIntegration = {
 	name: 'spotify',
 	tokenUrl: 'https://accounts.spotify.test/api/token',
@@ -40,8 +45,16 @@ const spotifyIntegration = {
 	requiredHosts: ['api.spotify.test'],
 }
 
-function createCodemode(payload: Record<string, unknown>) {
+function createCodemode(
+	payload: Record<string, unknown>,
+	options: {
+		apiErrors?: Array<Error>
+		apiResponses?: Array<ApiResponseSpec>
+	} = {},
+) {
 	const secretSetCalls: Array<SecretSetCall> = []
+	const apiErrors = [...(options.apiErrors ?? [])]
+	const apiResponses = [...(options.apiResponses ?? [])]
 	const codemode = {
 		async integration_get(args: CapabilityArgs) {
 			const name = args.name
@@ -73,6 +86,15 @@ function createCodemode(payload: Record<string, unknown>) {
 		if (request.url === spotifyIntegration.tokenUrl) {
 			return new Response(JSON.stringify(payload), {
 				status: 200,
+				headers: { 'content-type': 'application/json' },
+			})
+		}
+		const apiError = apiErrors.shift()
+		if (apiError) throw apiError
+		const apiResponse = apiResponses.shift()
+		if (apiResponse) {
+			return new Response(JSON.stringify(apiResponse.body), {
+				status: apiResponse.status,
 				headers: { 'content-type': 'application/json' },
 			})
 		}
@@ -128,14 +150,36 @@ test('refreshAccessToken persists rotated refresh token and access token', async
 	)
 })
 
-test('createAuthenticatedFetch persists refreshed access token even without refresh token rotation', async () => {
+test('createAuthenticatedFetch uses the stored access token before refreshing', async () => {
 	const { codemode, secretSetCalls, fetchStub, fetchCalls } = createCodemode({
-		access_token: 'new-access-token',
+		access_token: 'refreshed-access-token',
 	})
 
-	const authenticatedFetch = await withPatchedFetch(fetchStub, () =>
-		createAuthenticatedFetch(codemode, 'spotify'),
+	const authenticatedFetch = await createAuthenticatedFetch(codemode, 'spotify')
+	const response = await withPatchedFetch(fetchStub, () =>
+		authenticatedFetch('/me/playlists', { method: 'POST' }),
 	)
+
+	expect(secretSetCalls).toEqual([])
+	expect(fetchCalls).toHaveLength(1)
+	expect(fetchCalls[0]?.url).toBe('https://api.spotify.test/v1/me/playlists')
+	expect(fetchCalls[0]?.headers.get('authorization')).toBe(
+		'Bearer {{secret:spotifyAccessToken|scope=user}}',
+	)
+	expect(await response.json()).toEqual({ ok: true })
+})
+
+test('createAuthenticatedFetch refreshes when the stored access token secret is missing', async () => {
+	const { codemode, secretSetCalls, fetchStub, fetchCalls } = createCodemode(
+		{
+			access_token: 'new-access-token',
+		},
+		{
+			apiErrors: [new Error('Secret "spotifyAccessToken" was not found.')],
+		},
+	)
+
+	const authenticatedFetch = await createAuthenticatedFetch(codemode, 'spotify')
 	const response = await withPatchedFetch(fetchStub, () =>
 		authenticatedFetch('/me?market=US'),
 	)
@@ -147,9 +191,50 @@ test('createAuthenticatedFetch persists refreshed access token even without refr
 			scope: 'user',
 		},
 	])
-	expect(fetchCalls).toHaveLength(2)
-	expect(fetchCalls[1]?.url).toBe('https://api.spotify.test/v1/me?market=US')
-	expect(fetchCalls[1]?.headers.get('authorization')).toBe(
+	expect(fetchCalls).toHaveLength(3)
+	expect(fetchCalls[0]?.headers.get('authorization')).toBe(
+		'Bearer {{secret:spotifyAccessToken|scope=user}}',
+	)
+	expect(fetchCalls[1]?.url).toBe('https://accounts.spotify.test/api/token')
+	expect(fetchCalls[2]?.headers.get('authorization')).toBe(
+		'Bearer new-access-token',
+	)
+	expect(await response.json()).toEqual({ ok: true })
+})
+
+test('createAuthenticatedFetch persists refreshed access token even without refresh token rotation', async () => {
+	const { codemode, secretSetCalls, fetchStub, fetchCalls } = createCodemode(
+		{
+			access_token: 'new-access-token',
+		},
+		{
+			apiResponses: [
+				{ status: 401, body: { error: 'expired' } },
+				{ status: 200, body: { ok: true } },
+			],
+		},
+	)
+
+	const authenticatedFetch = await createAuthenticatedFetch(codemode, 'spotify')
+	const response = await withPatchedFetch(fetchStub, () =>
+		authenticatedFetch('/me?market=US'),
+	)
+
+	expect(secretSetCalls).toEqual([
+		{
+			name: 'spotifyAccessToken',
+			value: 'new-access-token',
+			scope: 'user',
+		},
+	])
+	expect(fetchCalls).toHaveLength(3)
+	expect(fetchCalls[0]?.url).toBe('https://api.spotify.test/v1/me?market=US')
+	expect(fetchCalls[0]?.headers.get('authorization')).toBe(
+		'Bearer {{secret:spotifyAccessToken|scope=user}}',
+	)
+	expect(fetchCalls[1]?.url).toBe('https://accounts.spotify.test/api/token')
+	expect(fetchCalls[2]?.url).toBe('https://api.spotify.test/v1/me?market=US')
+	expect(fetchCalls[2]?.headers.get('authorization')).toBe(
 		'Bearer new-access-token',
 	)
 	expect(await response.json()).toEqual({ ok: true })
@@ -187,20 +272,10 @@ test('createExecuteHelperPrelude persists rotated refresh token and access token
 			value: 'new-access-token',
 			scope: 'user',
 		},
-		{
-			name: 'spotifyRefreshToken',
-			value: 'new-refresh-token',
-			scope: 'user',
-		},
-		{
-			name: 'spotifyAccessToken',
-			value: 'new-access-token',
-			scope: 'user',
-		},
 	])
-	expect(fetchCalls).toHaveLength(3)
-	expect(fetchCalls[2]?.headers.get('authorization')).toBe(
-		'Bearer new-access-token',
+	expect(fetchCalls).toHaveLength(2)
+	expect(fetchCalls[1]?.headers.get('authorization')).toBe(
+		'Bearer {{secret:spotifyAccessToken|scope=user}}',
 	)
 })
 

--- a/packages/worker/src/mcp/execute-modules/codemode-utils.ts
+++ b/packages/worker/src/mcp/execute-modules/codemode-utils.ts
@@ -120,7 +120,7 @@ export async function createAuthenticatedFetch(
 		assertIntegrationHostAllowed(providerName, integration, resolvedUrl)
 
 		const request = new Request(resolvedUrl, init)
-		const retryRequest = new Request(request)
+		const retryRequest: Request = request.clone() as Request
 		let response: Response
 		try {
 			response = await fetch(

--- a/packages/worker/src/mcp/execute-modules/codemode-utils.ts
+++ b/packages/worker/src/mcp/execute-modules/codemode-utils.ts
@@ -114,24 +114,42 @@ export async function createAuthenticatedFetch(
 	(input: ExecuteRequestInput, init?: RequestInit) => Promise<Response>
 > {
 	const integration = await readIntegrationConfig(codemode, providerName)
-	const accessToken = await refreshAccessTokenWithIntegration(
-		codemode,
-		providerName,
-		integration,
-	)
 
 	return async (input: ExecuteRequestInput, init?: RequestInit) => {
 		const resolvedUrl = resolveRequestUrl(input, integration)
 		assertIntegrationHostAllowed(providerName, integration, resolvedUrl)
 
 		const request = new Request(resolvedUrl, init)
-		const headers = new Headers(request.headers)
-		headers.set('Authorization', `Bearer ${accessToken}`)
+		const retryRequest = new Request(request)
+		let response: Response
+		try {
+			response = await fetch(
+				createBearerRequest(
+					request,
+					buildAccessTokenAuthorizationHeader(providerName, integration),
+				),
+			)
+		} catch (error) {
+			if (!isMissingAccessTokenSecretError(error, integration)) throw error
+			const refreshedAccessToken = await refreshAccessTokenWithIntegration(
+				codemode,
+				providerName,
+				integration,
+			)
+			return fetch(
+				createBearerRequest(retryRequest, `Bearer ${refreshedAccessToken}`),
+			)
+		}
+		if (response.status !== 401) return response
 
+		await response.body?.cancel()
+		const refreshedAccessToken = await refreshAccessTokenWithIntegration(
+			codemode,
+			providerName,
+			integration,
+		)
 		return fetch(
-			new Request(request, {
-				headers,
-			}),
+			createBearerRequest(retryRequest, `Bearer ${refreshedAccessToken}`),
 		)
 	}
 }
@@ -330,6 +348,37 @@ function buildSecretPlaceholder(
 	return `{{secret:${name}|scope=${scope}}}`
 }
 
+function buildAccessTokenAuthorizationHeader(
+	providerName: string,
+	integration: IntegrationConfig,
+) {
+	const accessTokenSecretName = integration.accessTokenSecretName.trim()
+	if (!accessTokenSecretName) {
+		throw new Error(
+			`Integration "${providerName}" does not define an access token secret name.`,
+		)
+	}
+	return `Bearer ${buildSecretPlaceholder(accessTokenSecretName, 'user')}`
+}
+
+function createBearerRequest(request: Request, authorization: string) {
+	const headers = new Headers(request.headers)
+	headers.set('Authorization', authorization)
+	return new Request(request, { headers })
+}
+
+function isMissingAccessTokenSecretError(
+	error: unknown,
+	integration: IntegrationConfig,
+) {
+	const accessTokenSecretName = integration.accessTokenSecretName.trim()
+	return (
+		error instanceof Error &&
+		accessTokenSecretName.length > 0 &&
+		error.message === `Secret "${accessTokenSecretName}" was not found.`
+	)
+}
+
 function buildBasicAuthSecretPlaceholder(input: {
 	usernameSecret: string
 	passwordSecret: string
@@ -487,6 +536,28 @@ const __kodyAssertIntegrationHostAllowed = (integrationName, integration, url) =
 };
 const __kodyBuildSecretPlaceholder = (name, scope) =>
   \`{{secret:\${name}|scope=\${scope}}}\`;
+const __kodyBuildAccessTokenAuthorizationHeader = (providerName, integration) => {
+  const accessTokenSecretName = integration.accessTokenSecretName.trim();
+  if (!accessTokenSecretName) {
+    throw new Error(
+      \`Integration "\${providerName}" does not define an access token secret name.\`,
+    );
+  }
+  return \`Bearer \${__kodyBuildSecretPlaceholder(accessTokenSecretName, 'user')}\`;
+};
+const __kodyCreateBearerRequest = (request, authorization) => {
+  const headers = new Headers(request.headers);
+  headers.set('Authorization', authorization);
+  return new Request(request, { headers });
+};
+const __kodyIsMissingAccessTokenSecretError = (error, integration) => {
+  const accessTokenSecretName = integration.accessTokenSecretName.trim();
+  return (
+    error instanceof Error &&
+    accessTokenSecretName.length > 0 &&
+    error.message === \`Secret "\${accessTokenSecretName}" was not found.\`
+  );
+};
 const __kodyNormalizeSecretName = (value, fieldName) => {
   const normalized = String(value ?? '').trim();
   if (!/^[a-zA-Z0-9._-]+$/.test(normalized)) {
@@ -671,17 +742,31 @@ const __kodyRefreshAccessToken = async (providerName) => {
 };
 const __kodyCreateAuthenticatedFetch = async (providerName) => {
   const integration = await __kodyReadIntegrationConfig(providerName);
-  const accessToken = await __kodyRefreshAccessToken(providerName);
   return async (input, init) => {
     const resolvedUrl = __kodyResolveRequestUrl(input, integration);
     __kodyAssertIntegrationHostAllowed(providerName, integration, resolvedUrl);
     const request = new Request(resolvedUrl, init);
-    const headers = new Headers(request.headers);
-    headers.set('Authorization', \`Bearer \${accessToken}\`);
+    const retryRequest = request.clone();
+    let response;
+    try {
+      response = await fetch(
+        __kodyCreateBearerRequest(
+          request,
+          __kodyBuildAccessTokenAuthorizationHeader(providerName, integration),
+        ),
+      );
+    } catch (error) {
+      if (!__kodyIsMissingAccessTokenSecretError(error, integration)) throw error;
+      const refreshedAccessToken = await __kodyRefreshAccessToken(providerName);
+      return fetch(
+        __kodyCreateBearerRequest(retryRequest, \`Bearer \${refreshedAccessToken}\`),
+      );
+    }
+    if (response.status !== 401) return response;
+    await response.body?.cancel();
+    const refreshedAccessToken = await __kodyRefreshAccessToken(providerName);
     return fetch(
-      new Request(request, {
-        headers,
-      }),
+      __kodyCreateBearerRequest(retryRequest, \`Bearer \${refreshedAccessToken}\`),
     );
   };
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Preserve the configured OAuth refresh-token secret name when reauth token responses omit a rotated refresh token.
- Update `createAuthenticatedFetch` to use the saved access-token secret first, only refreshing on missing token or HTTP 401 and retrying once.
- Use a cloned retry request for authenticated-fetch retries so body-bearing requests remain safe, matching the sandbox prelude behavior.
- Keep the sandbox helper prelude behavior in sync and add regressions for OAuth reauth/no-refresh-token responses.

## Validation
- `npx vitest run --project node-unit packages/worker/src/app/handlers/account-secrets.node.test.ts packages/worker/src/mcp/execute-modules/codemode-utils.node.test.ts packages/worker/src/mcp/execute-modules/authenticated-fetch.node.test.ts`
- `npx vitest run --project node-unit packages/worker/src/mcp/execute-modules/codemode-utils.node.test.ts packages/worker/src/mcp/execute-modules/authenticated-fetch.node.test.ts`
- `npm run typecheck`
- `npm run validate`

## CI / robot feedback
- Addressed Bugbot feedback about cloning the retry request before the initial fetch attempt.
- Latest PR checks are green: Validate, Preview, Cursor Bugbot, and CodeRabbit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d2aa5ca-ad79-4285-8fd4-faa99784e452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d2aa5ca-ad79-4285-8fd4-faa99784e452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering OAuth flows, handling when providers omit rotated refresh tokens, and authenticated request behaviors (including retry scenarios).

* **Improvements**
  * More robust OAuth/token handling: preserves existing refresh-token references when rotation is omitted and retries requests automatically on missing/expired tokens for more reliable API calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->