### PR TITLE
Clean up Artifacts repos on package delete and account deletion

### DIFF
--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -3,6 +3,7 @@ import { jobVectorId } from '#mcp/jobs-vectorize.ts'
 import { memoryVectorId } from '#mcp/memory/memory-vectorize.ts'
 import { savedPackageVectorId } from '#worker/package-registry/repo.ts'
 import { getCapabilityVectorIndex } from '#mcp/capabilities/capability-search.ts'
+import { cleanupAllUserArtifactRepos } from '#worker/repo/artifact-repo-cleanup.ts'
 
 // Imported manually instead of via `@cloudflare/workers-oauth-provider` so
 // node-only unit tests can require this module without dragging in
@@ -27,6 +28,7 @@ type AccountDeletionEnv = Env & {
 export type AccountDeletionResult = {
 	deletedRowCounts: Record<string, number>
 	deletedKvKeys: number
+	deletedArtifactRepos: number
 	revokedOAuthGrants: number
 	clearedDurableObjects: Record<string, number>
 	deletedVectors: number
@@ -377,6 +379,7 @@ export async function deleteUserAccount(input: {
 	const result: AccountDeletionResult = {
 		deletedRowCounts: {},
 		deletedKvKeys: 0,
+		deletedArtifactRepos: 0,
 		revokedOAuthGrants: 0,
 		clearedDurableObjects: {},
 		deletedVectors: 0,
@@ -404,6 +407,12 @@ export async function deleteUserAccount(input: {
 	result.deletedVectors = await deleteVectorsByIds({
 		env: input.env,
 		ids: vectorIds,
+		warnings,
+	})
+
+	result.deletedArtifactRepos = await cleanupAllUserArtifactRepos({
+		env: input.env,
+		userId: input.mcpUserId,
 		warnings,
 	})
 

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -414,6 +414,10 @@ export async function deleteUserAccount(input: {
 		env: input.env,
 		userId: input.mcpUserId,
 		warnings,
+	}).catch((error) => {
+		const message = error instanceof Error ? error.message : String(error)
+		warnings.push(`Artifact repo cleanup failed unexpectedly: ${message}`)
+		return 0
 	})
 
 	result.clearedDurableObjects.storageRunners = await clearStorageRunners({

--- a/packages/worker/src/mcp/capabilities/packages/delete-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/delete-package.ts
@@ -10,7 +10,7 @@ export const deletePackageCapability = defineDomainCapability(
 	{
 		name: 'package_delete',
 		description:
-			'Delete a saved package projection for the signed-in user. This removes the saved package from discovery. Repo-backed source cleanup is handled separately.',
+			'Delete a saved package projection for the signed-in user. This removes the saved package from discovery and cleans up associated Artifacts repos.',
 		keywords: ['package', 'delete', 'remove'],
 		readOnly: false,
 		idempotent: false,

--- a/packages/worker/src/mcp/capabilities/packages/delete-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/delete-package.ts
@@ -10,7 +10,7 @@ export const deletePackageCapability = defineDomainCapability(
 	{
 		name: 'package_delete',
 		description:
-			'Delete a saved package projection for the signed-in user. This removes the saved package from discovery and cleans up associated Artifacts repos.',
+			'Delete a saved package projection for the signed-in user. This removes the saved package from discovery and attempts to clean up associated Artifacts repos (best-effort).',
 		keywords: ['package', 'delete', 'remove'],
 		readOnly: false,
 		idempotent: false,

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -34,6 +34,7 @@ const mockModule = vi.hoisted(() => ({
 	syncPackageJobsForPackage: vi.fn(),
 	updateSavedPackage: vi.fn(),
 	upsertSavedPackageVector: vi.fn(),
+	cleanupArtifactReposForPackage: vi.fn(),
 }))
 
 vi.mock('./manifest.ts', () => ({
@@ -111,6 +112,11 @@ vi.mock('#worker/jobs/service.ts', () => ({
 		mockModule.syncPackageJobsForPackage(...args),
 }))
 
+vi.mock('#worker/repo/artifact-repo-cleanup.ts', () => ({
+	cleanupArtifactReposForPackage: (...args: Array<unknown>) =>
+		mockModule.cleanupArtifactReposForPackage(...args),
+}))
+
 const { deleteSavedPackageProjection, refreshSavedPackageProjection } =
 	await import('./service.ts')
 
@@ -152,6 +158,7 @@ beforeEach(() => {
 	mockModule.deleteSavedPackage.mockResolvedValue(undefined)
 	mockModule.deleteSavedPackageVector.mockResolvedValue(undefined)
 	mockModule.deleteJobRow.mockResolvedValue(undefined)
+	mockModule.cleanupArtifactReposForPackage.mockResolvedValue(0)
 	mockModule.listSavedPackageServices.mockResolvedValue({
 		savedPackage: {
 			id: 'package-1',
@@ -352,6 +359,11 @@ test('deleteSavedPackageProjection resyncs the job manager after removing packag
 		packageId: 'package-1',
 	})
 
+	expect(mockModule.cleanupArtifactReposForPackage).toHaveBeenCalledWith({
+		env,
+		userId: 'user-1',
+		sourceId: 'source-1',
+	})
 	expect(mockModule.packageServiceRpc).toHaveBeenCalledWith({
 		env,
 		userId: 'user-1',

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -31,6 +31,7 @@ import {
 	refreshPackageRetrieverManifestCache,
 	removePackageRetrieverManifestCacheEntries,
 } from '#worker/package-retrievers/manifest-cache.ts'
+import { cleanupArtifactReposForPackage } from '#worker/repo/artifact-repo-cleanup.ts'
 
 function logPackageRetrieverProjectionError(input: {
 	action: 'refresh' | 'delete'
@@ -270,6 +271,21 @@ export async function deleteSavedPackageProjection(input: {
 		packageId: input.packageId,
 	})
 	if (savedPackage) {
+		await cleanupArtifactReposForPackage({
+			env: input.env,
+			userId: input.userId,
+			sourceId: savedPackage.sourceId,
+		}).catch((error) => {
+			console.warn(
+				JSON.stringify({
+					message: 'package artifact repo cleanup failed',
+					userId: input.userId,
+					packageId: input.packageId,
+					sourceId: savedPackage.sourceId,
+					error: error instanceof Error ? error.message : String(error),
+				}),
+			)
+		})
 		const listedServices = await listSavedPackageServices({
 			env: input.env,
 			userId: input.userId,

--- a/packages/worker/src/repo/artifact-repo-cleanup.node.test.ts
+++ b/packages/worker/src/repo/artifact-repo-cleanup.node.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	deleteArtifactRepo: vi.fn(),
+	getEntitySourceById: vi.fn(),
+	listEntitySourcesByUser: vi.fn(),
+	listRepoSessionsBySource: vi.fn(),
+	listRepoSessionsByUser: vi.fn(),
+	hasArtifactsAccess: vi.fn(),
+}))
+
+vi.mock('./artifacts.ts', () => ({
+	getArtifactsBinding: () => ({
+		delete: (...args: Array<unknown>) => mockModule.deleteArtifactRepo(...args),
+	}),
+	hasArtifactsAccess: (...args: Array<unknown>) =>
+		mockModule.hasArtifactsAccess(...args),
+}))
+
+vi.mock('./entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+	listEntitySourcesByUser: (...args: Array<unknown>) =>
+		mockModule.listEntitySourcesByUser(...args),
+}))
+
+vi.mock('./repo-sessions.ts', () => ({
+	listRepoSessionsBySource: (...args: Array<unknown>) =>
+		mockModule.listRepoSessionsBySource(...args),
+	listRepoSessionsByUser: (...args: Array<unknown>) =>
+		mockModule.listRepoSessionsByUser(...args),
+}))
+
+const {
+	cleanupAllUserArtifactRepos,
+	cleanupArtifactReposForPackage,
+	deleteUserScopedArtifactRepo,
+} = await import('./artifact-repo-cleanup.ts')
+
+const env = { APP_DB: {} } as Env
+
+afterEach(() => {
+	vi.clearAllMocks()
+})
+
+test('deleteUserScopedArtifactRepo deletes a repo and treats 404 as success', async () => {
+	mockModule.hasArtifactsAccess.mockReturnValue(true)
+	mockModule.deleteArtifactRepo.mockResolvedValueOnce({
+		id: 'repo_1',
+		alreadyDeleted: false,
+	})
+	mockModule.deleteArtifactRepo.mockResolvedValueOnce({
+		id: null,
+		alreadyDeleted: true,
+	})
+
+	expect(
+		await deleteUserScopedArtifactRepo({
+			env,
+			userId: 'user-1',
+			repoName: 'package-src-1',
+		}),
+	).toBe(true)
+	expect(
+		await deleteUserScopedArtifactRepo({
+			env,
+			userId: 'user-1',
+			repoName: 'package-src-1-session-abc',
+		}),
+	).toBe(true)
+	expect(mockModule.deleteArtifactRepo).toHaveBeenCalledTimes(2)
+})
+
+test('cleanupArtifactReposForPackage deletes session fork repos before entity repo', async () => {
+	mockModule.hasArtifactsAccess.mockReturnValue(true)
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		repo_id: 'package-pkg-1',
+	})
+	mockModule.listRepoSessionsBySource.mockResolvedValue([
+		{
+			id: 'session-1',
+			user_id: 'user-1',
+			source_id: 'source-1',
+			session_repo_name: 'package-pkg-1-abc123',
+		},
+	])
+	mockModule.deleteArtifactRepo.mockResolvedValue({
+		id: 'repo_deleted',
+		alreadyDeleted: false,
+	})
+
+	const deleted = await cleanupArtifactReposForPackage({
+		env,
+		userId: 'user-1',
+		sourceId: 'source-1',
+	})
+
+	expect(deleted).toBe(2)
+	expect(mockModule.deleteArtifactRepo).toHaveBeenCalledWith(
+		'package-pkg-1-abc123',
+	)
+	expect(mockModule.deleteArtifactRepo).toHaveBeenCalledWith('package-pkg-1')
+	expect(mockModule.getEntitySourceById).toHaveBeenCalledWith({}, 'source-1')
+})
+
+test('cleanupArtifactReposForPackage skips repos owned by another user', async () => {
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-other',
+		repo_id: 'package-pkg-1',
+	})
+	const warnings: Array<string> = []
+
+	const deleted = await cleanupArtifactReposForPackage({
+		env,
+		userId: 'user-1',
+		sourceId: 'source-1',
+		warnings,
+	})
+
+	expect(deleted).toBe(0)
+	expect(mockModule.deleteArtifactRepo).not.toHaveBeenCalled()
+	expect(warnings[0]).toContain('user scope mismatch')
+})
+
+test('cleanupAllUserArtifactRepos deduplicates repos across sources and sessions', async () => {
+	mockModule.hasArtifactsAccess.mockReturnValue(true)
+	mockModule.listEntitySourcesByUser.mockResolvedValue([
+		{ id: 'source-1', user_id: 'user-1', repo_id: 'package-pkg-1' },
+		{ id: 'source-2', user_id: 'user-1', repo_id: 'job-job-1' },
+	])
+	mockModule.listRepoSessionsByUser.mockResolvedValue([
+		{
+			id: 'session-1',
+			user_id: 'user-1',
+			session_repo_name: 'package-pkg-1-abc123',
+		},
+	])
+	mockModule.deleteArtifactRepo.mockResolvedValue({
+		id: 'repo_deleted',
+		alreadyDeleted: false,
+	})
+
+	const warnings: Array<string> = []
+	const deleted = await cleanupAllUserArtifactRepos({
+		env,
+		userId: 'user-1',
+		warnings,
+	})
+
+	expect(deleted).toBe(3)
+	expect(mockModule.deleteArtifactRepo).toHaveBeenCalledTimes(3)
+})
+
+test('cleanupAllUserArtifactRepos records a warning when Artifacts access is unavailable', async () => {
+	mockModule.hasArtifactsAccess.mockReturnValue(false)
+	mockModule.listEntitySourcesByUser.mockResolvedValue([
+		{ id: 'source-1', user_id: 'user-1', repo_id: 'package-pkg-1' },
+	])
+	mockModule.listRepoSessionsByUser.mockResolvedValue([])
+
+	const warnings: Array<string> = []
+	const deleted = await cleanupAllUserArtifactRepos({
+		env,
+		userId: 'user-1',
+		warnings,
+	})
+
+	expect(deleted).toBe(0)
+	expect(warnings[0]).toContain('Cloudflare Artifacts access was unavailable')
+})

--- a/packages/worker/src/repo/artifact-repo-cleanup.ts
+++ b/packages/worker/src/repo/artifact-repo-cleanup.ts
@@ -1,0 +1,202 @@
+import {
+	getArtifactsBinding,
+	hasArtifactsAccess,
+	type ArtifactDeleteRepoResult,
+} from './artifacts.ts'
+import {
+	getEntitySourceById,
+	listEntitySourcesByUser,
+} from './entity-sources.ts'
+import {
+	listRepoSessionsBySource,
+	listRepoSessionsByUser,
+} from './repo-sessions.ts'
+import { type EntitySourceRow } from './types.ts'
+
+function logArtifactRepoDeleted(input: {
+	userId: string
+	repoName: string
+	result: ArtifactDeleteRepoResult
+}) {
+	console.info(
+		JSON.stringify({
+			message: input.result.alreadyDeleted
+				? 'artifact repo already absent during cleanup'
+				: 'artifact repo deleted',
+			userId: input.userId,
+			repoName: input.repoName,
+			repoId: input.result.id,
+		}),
+	)
+}
+
+export async function deleteUserScopedArtifactRepo(input: {
+	env: Env
+	userId: string
+	repoName: string
+	warnings?: Array<string>
+}): Promise<boolean> {
+	const repoName = input.repoName.trim()
+	if (!repoName) return false
+	if (!hasArtifactsAccess(input.env)) {
+		return false
+	}
+	try {
+		const binding = getArtifactsBinding(input.env)
+		const result = await binding.delete(repoName)
+		logArtifactRepoDeleted({
+			userId: input.userId,
+			repoName,
+			result,
+		})
+		return true
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		input.warnings?.push(
+			`Artifact repo delete failed for ${repoName}: ${message}`,
+		)
+		console.warn(
+			JSON.stringify({
+				message: 'artifact repo delete failed',
+				userId: input.userId,
+				repoName,
+				error: message,
+			}),
+		)
+		return false
+	}
+}
+
+function collectUniqueRepoNames(
+	repoNames: ReadonlyArray<string | null | undefined>,
+) {
+	const unique = new Set<string>()
+	for (const repoName of repoNames) {
+		const trimmed = repoName?.trim()
+		if (trimmed) unique.add(trimmed)
+	}
+	return Array.from(unique)
+}
+
+async function deleteReposForEntitySource(input: {
+	env: Env
+	userId: string
+	source: EntitySourceRow
+	warnings?: Array<string>
+}) {
+	if (input.source.user_id !== input.userId) {
+		input.warnings?.push(
+			`Skipped artifact repo cleanup for source ${input.source.id}: user scope mismatch.`,
+		)
+		return 0
+	}
+	const sessions = await listRepoSessionsBySource(input.env.APP_DB, {
+		userId: input.userId,
+		sourceId: input.source.id,
+	})
+	const repoNames = collectUniqueRepoNames([
+		...sessions.map((session) => session.session_repo_name),
+		input.source.repo_id,
+	])
+	let deleted = 0
+	for (const repoName of repoNames) {
+		if (
+			await deleteUserScopedArtifactRepo({
+				env: input.env,
+				userId: input.userId,
+				repoName,
+				warnings: input.warnings,
+			})
+		) {
+			deleted += 1
+		}
+	}
+	return deleted
+}
+
+export async function cleanupArtifactReposForPackage(input: {
+	env: Env
+	userId: string
+	sourceId: string
+	warnings?: Array<string>
+}) {
+	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
+	if (!source) return 0
+	if (source.user_id !== input.userId) {
+		input.warnings?.push(
+			`Skipped artifact repo cleanup for package source ${input.sourceId}: user scope mismatch.`,
+		)
+		return 0
+	}
+	if (!hasArtifactsAccess(input.env)) {
+		const sessions = await listRepoSessionsBySource(input.env.APP_DB, {
+			userId: input.userId,
+			sourceId: source.id,
+		})
+		const repoCount = collectUniqueRepoNames([
+			...sessions.map((session) => session.session_repo_name),
+			source.repo_id,
+		]).length
+		if (repoCount > 0) {
+			input.warnings?.push(
+				`Cloudflare Artifacts access was unavailable; ${repoCount} artifact repo(s) for the deleted package were not removed and must be cleaned up manually.`,
+			)
+		}
+		return 0
+	}
+	return deleteReposForEntitySource({
+		env: input.env,
+		userId: input.userId,
+		source,
+		warnings: input.warnings,
+	})
+}
+
+export async function cleanupAllUserArtifactRepos(input: {
+	env: Env
+	userId: string
+	warnings: Array<string>
+}) {
+	if (!hasArtifactsAccess(input.env)) {
+		if ((await countUserArtifactRepoReferences(input.env, input.userId)) > 0) {
+			input.warnings.push(
+				'Cloudflare Artifacts access was unavailable; artifact repos referenced by the deleted user were not removed and must be cleaned up manually.',
+			)
+		}
+		return 0
+	}
+
+	const [sources, sessions] = await Promise.all([
+		listEntitySourcesByUser(input.env.APP_DB, input.userId),
+		listRepoSessionsByUser(input.env.APP_DB, input.userId),
+	])
+	const repoNames = collectUniqueRepoNames([
+		...sources.map((source) => source.repo_id),
+		...sessions.map((session) => session.session_repo_name),
+	])
+	let deleted = 0
+	for (const repoName of repoNames) {
+		if (
+			await deleteUserScopedArtifactRepo({
+				env: input.env,
+				userId: input.userId,
+				repoName,
+				warnings: input.warnings,
+			})
+		) {
+			deleted += 1
+		}
+	}
+	return deleted
+}
+
+async function countUserArtifactRepoReferences(env: Env, userId: string) {
+	const [sources, sessions] = await Promise.all([
+		listEntitySourcesByUser(env.APP_DB, userId),
+		listRepoSessionsByUser(env.APP_DB, userId),
+	])
+	return collectUniqueRepoNames([
+		...sources.map((source) => source.repo_id),
+		...sessions.map((session) => session.session_repo_name),
+	]).length
+}

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -123,6 +123,22 @@ test('artifacts REST client supports get, create, token, and fork operations', a
 					},
 				)
 			}
+			if (method === 'DELETE' && url.pathname.endsWith('/repos/repo-1')) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo_1',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 202,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
 			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
 		})
 
@@ -164,8 +180,12 @@ test('artifacts REST client supports get, create, token, and fork operations', a
 		remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-copy.git',
 		token: 'art_v1_fork?expires=1760000200',
 	})
+	await expect(binding.delete('repo-1')).resolves.toEqual({
+		id: 'repo_1',
+		alreadyDeleted: false,
+	})
 
-	expect(fetchMock).toHaveBeenCalledTimes(6)
+	expect(fetchMock).toHaveBeenCalledTimes(7)
 })
 
 test('artifacts REST client uses fallback API error text when envelope errors are missing', async () => {

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -81,6 +81,7 @@ export type ArtifactNamespaceBinding = {
 		expiresAt: string
 	}>
 	get(name: string): Promise<ArtifactGetRepoResult>
+	delete(name: string): Promise<ArtifactDeleteRepoResult>
 	list(opts?: { limit?: number; cursor?: string }): Promise<{
 		repos: Array<Omit<ArtifactRepoInfo, 'remote'>>
 		total: number
@@ -302,6 +303,23 @@ function createArtifactsRestBinding(env: Env) {
 			return {
 				status: 'ready' as const,
 				repo: repoHandle(name),
+			}
+		},
+		delete: async (name) => {
+			const envelope = await requestArtifactsEnvelope<{ id: string }>(client, {
+				method: 'DELETE',
+				path: `${basePath}/repos/${encodeURIComponent(name)}`,
+				treat404AsNull: true,
+			})
+			if (!envelope.result) {
+				return {
+					id: null,
+					alreadyDeleted: true,
+				}
+			}
+			return {
+				id: envelope.result.id,
+				alreadyDeleted: false,
 			}
 		},
 		list: async (opts) => {

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -63,6 +63,11 @@ export type ArtifactGetRepoResult =
 	| { status: 'importing'; retryAfter: number }
 	| { status: 'forking'; retryAfter: number }
 
+export type ArtifactDeleteRepoResult = {
+	id: string | null
+	alreadyDeleted: boolean
+}
+
 export type ArtifactNamespaceBinding = {
 	create(
 		name: string,

--- a/packages/worker/src/repo/repo-sessions.ts
+++ b/packages/worker/src/repo/repo-sessions.ts
@@ -120,6 +120,21 @@ export async function listRepoSessionsBySource(
 	return (results ?? []).map(mapRepoSessionRow)
 }
 
+export async function listRepoSessionsByUser(
+	db: D1Database,
+	userId: string,
+): Promise<Array<RepoSessionRow>> {
+	const { results } = await db
+		.prepare(
+			`SELECT * FROM repo_sessions
+			WHERE user_id = ?
+			ORDER BY updated_at DESC`,
+		)
+		.bind(userId)
+		.all<Record<string, unknown>>()
+	return (results ?? []).map(mapRepoSessionRow)
+}
+
 export async function updateRepoSession(
 	db: D1Database,
 	input: {


### PR DESCRIPTION
Add DELETE support to the Artifacts REST binding and best-effort cleanup orchestration for entity source repos and session fork repos. Wire cleanup into deleteSavedPackageProjection and deleteUserAccount while preserving existing D1 and KV cascade behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destructive, best-effort remote deletes tied to user data removal; failures are warned but D1 cleanup still proceeds, so orphaned Artifacts repos are possible if the API is down or mis-scoped.
> 
> **Overview**
> Adds **DELETE** to the Cloudflare Artifacts REST binding (404 treated as already gone) and a new **best-effort** cleanup layer that removes entity-source repos and session fork repos for the signed-in user, with user-scope checks and warnings when Artifacts is unavailable.
> 
> **Package delete** now runs `cleanupArtifactReposForPackage` before stopping services and removing D1/KV/vector projection data; the `package_delete` capability text reflects that behavior.
> 
> **Account deletion** runs `cleanupAllUserArtifactRepos` after vector cleanup and before storage/KV/D1 cascades, and reports `deletedArtifactRepos` on the deletion result.
> 
> Supporting changes: `listRepoSessionsByUser` for enumerating all session repos on full account cleanup, plus unit tests for the binding delete path and cleanup orchestration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7da4d5c7cecba2192c7a476baae90e20d3414eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artifact repositories associated with user accounts are now automatically cleaned up when accounts are deleted
  * Artifact repositories linked to saved packages are now automatically removed when those packages are deleted

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->