### PR TITLE
Handle generated UI tool error payloads

### DIFF
--- a/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
+++ b/packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts
@@ -177,6 +177,22 @@ test('readSavedPackageAppSourceFromHostToolResult handles success and host tool 
 		handled: true,
 		errorMessage: 'Saved package app not found for this user.',
 	})
+	expect(
+		readSavedPackageAppSourceFromHostToolResult({
+			isError: true,
+			structuredContent: {
+				error: 'Secret "cloudflareToken" was not found.',
+				errorDetails: {
+					nextStep:
+						'Send the user to /account/secrets/new?name=cloudflareToken so they can provide and save this secret, then retry the workflow.',
+				},
+			},
+		}),
+	).toEqual({
+		handled: true,
+		errorMessage:
+			'Secret "cloudflareToken" was not found.\n\nNext step: Send the user to /account/secrets/new?name=cloudflareToken so they can provide and save this secret, then retry the workflow.',
+	})
 })
 
 test('buildCodemodeCapabilityExecuteCode runs the intended capability with the original args', async () => {

--- a/packages/worker/client/mcp-apps/kody-ui-utils.ts
+++ b/packages/worker/client/mcp-apps/kody-ui-utils.ts
@@ -309,12 +309,31 @@ function getHostToolErrorMessage(result: HostToolResult | null) {
 	const structuredContent = isRecord(result.structuredContent)
 		? result.structuredContent
 		: null
-	const error = isRecord(structuredContent?.error)
-		? structuredContent.error
+	const errorMessage = getStructuredErrorMessage(structuredContent?.error)
+	const errorDetails = isRecord(structuredContent?.errorDetails)
+		? structuredContent.errorDetails
 		: null
-	return typeof error?.message === 'string'
+	const nextStep =
+		typeof errorDetails?.nextStep === 'string' &&
+		errorDetails.nextStep.trim().length > 0
+			? errorDetails.nextStep
+			: null
+	const message = errorMessage ?? 'Code execution failed.'
+	return nextStep && !message.includes(nextStep)
+		? `${message}\n\nNext step: ${nextStep}`
+		: message
+}
+
+function getStructuredErrorMessage(error: unknown) {
+	if (typeof error === 'string' && error.trim().length > 0) {
+		return error
+	}
+	if (!isRecord(error)) {
+		return null
+	}
+	return typeof error.message === 'string' && error.message.trim().length > 0
 		? error.message
-		: 'Code execution failed.'
+		: null
 }
 
 export function readSavedPackageAppSourceFromHostToolResult(
@@ -367,11 +386,14 @@ async function executeCodeWithHostTool(
 		},
 		timeoutMs: 90_000,
 	})) as HostToolResult | null
+	if (!result) {
+		throw new Error('Code execution failed before the host returned a result.')
+	}
 	const errorMessage = getHostToolErrorMessage(result)
 	if (errorMessage) {
 		throw new Error(errorMessage)
 	}
-	const structuredContent = isRecord(result?.structuredContent)
+	const structuredContent = isRecord(result.structuredContent)
 		? result.structuredContent
 		: null
 	return structuredContent?.result ?? null
@@ -1144,7 +1166,17 @@ async function initializeShellHostDocument() {
 				await renderError('The tool result did not include renderable HTML.')
 				return
 			}
-			await renderCode(envelope.code, envelope.runtime ?? 'html')
+			try {
+				await renderCode(envelope.code, envelope.runtime ?? 'html')
+			} catch (error) {
+				if (isStaleRender(renderId)) {
+					return
+				}
+				const errorMessage = getStructuredErrorMessage(error)
+				await renderError(
+					`Unable to render generated UI.\n\n${errorMessage ?? 'Unknown error'}`,
+				)
+			}
 			return
 		}
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Surface MCP host tool string error payloads in generated UI flows instead of falling back to generic messages.
- Include actionable execution `nextStep` details when returned by the server.
- Show generated UI render failures inside the shell error document instead of silently swallowing them.

## Validation
- `npm run test -- packages/worker/client/mcp-apps/kody-ui-utils.node.test.ts packages/worker/src/mcp/tools/execute.node.test.ts`
- `npm run build:mcp-apps`
- `npm run typecheck`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95ebca01-1dcb-41e0-8b45-1c40da8b5f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95ebca01-1dcb-41e0-8b45-1c40da8b5f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error handling for host tool failures, now providing clearer messages and actionable next steps when credentials are missing
  * Improved stability in code execution by adding better null/undefined checks
  * Enhanced error reporting for UI rendering failures with more informative user feedback

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kody/pull/515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->