### PR TITLE
fix: repair missing Artifacts repos and clean up entity_sources on delete

### DIFF
--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -21,6 +21,7 @@ const mockModule = vi.hoisted(() => ({
 	refreshPackageRetrieverManifestCache: vi.fn(),
 	removePackageRetrieverManifestCacheEntries: vi.fn(),
 	deleteJobRow: vi.fn(),
+	deleteEntitySource: vi.fn(),
 	deleteSavedPackage: vi.fn(),
 	deleteSavedPackageVector: vi.fn(),
 	getSavedPackageById: vi.fn(),
@@ -117,6 +118,11 @@ vi.mock('#worker/repo/artifact-repo-cleanup.ts', () => ({
 		mockModule.cleanupArtifactReposForPackage(...args),
 }))
 
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	deleteEntitySource: (...args: Array<unknown>) =>
+		mockModule.deleteEntitySource(...args),
+}))
+
 const { deleteSavedPackageProjection, refreshSavedPackageProjection } =
 	await import('./service.ts')
 
@@ -152,6 +158,7 @@ beforeEach(() => {
 	)
 	mockModule.updateSavedPackage.mockResolvedValue(undefined)
 	mockModule.insertSavedPackage.mockResolvedValue(undefined)
+	mockModule.deleteEntitySource.mockResolvedValue(undefined)
 	mockModule.deleteSavedPackage.mockResolvedValue(undefined)
 	mockModule.deleteSavedPackageVector.mockResolvedValue(undefined)
 	mockModule.deleteJobRow.mockResolvedValue(undefined)
@@ -361,6 +368,13 @@ test('deleteSavedPackageProjection resyncs the job manager after removing packag
 		userId: 'user-1',
 		sourceId: 'source-1',
 	})
+	expect(mockModule.deleteEntitySource).toHaveBeenCalledWith(
+		{},
+		{
+			id: 'source-1',
+			userId: 'user-1',
+		},
+	)
 	expect(mockModule.packageServiceRpc).toHaveBeenCalledWith({
 		env,
 		userId: 'user-1',
@@ -397,6 +411,40 @@ test('deleteSavedPackageProjection resyncs the job manager after removing packag
 	expect(
 		mockModule.syncJobManagerAlarm.mock.invocationCallOrder[0],
 	).toBeGreaterThan(mockModule.deleteSavedPackage.mock.invocationCallOrder[0])
+})
+
+test('deleteSavedPackageProjection removes the entity source row for the package source', async () => {
+	const env = createEnv()
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: 'package-1',
+		kodyId: 'shade-automation',
+		sourceId: 'source-1',
+	})
+	mockModule.listJobRowsByUserId.mockResolvedValue([])
+
+	await deleteSavedPackageProjection({
+		env,
+		userId: 'user-1',
+		packageId: 'package-1',
+	})
+
+	expect(mockModule.cleanupArtifactReposForPackage).toHaveBeenCalledWith({
+		env,
+		userId: 'user-1',
+		sourceId: 'source-1',
+	})
+	expect(
+		mockModule.deleteEntitySource.mock.invocationCallOrder[0],
+	).toBeGreaterThan(
+		mockModule.cleanupArtifactReposForPackage.mock.invocationCallOrder[0],
+	)
+	expect(mockModule.deleteEntitySource).toHaveBeenCalledWith(
+		{},
+		{
+			id: 'source-1',
+			userId: 'user-1',
+		},
+	)
 })
 
 test('refreshSavedPackageProjection continues when retriever cache refresh fails', async () => {

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -447,6 +447,41 @@ test('deleteSavedPackageProjection removes the entity source row for the package
 	)
 })
 
+test('deleteSavedPackageProjection continues when entity source removal fails', async () => {
+	const env = createEnv()
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: 'package-1',
+		kodyId: 'shade-automation',
+		sourceId: 'source-1',
+	})
+	mockModule.listJobRowsByUserId.mockResolvedValue([])
+	mockModule.deleteEntitySource.mockRejectedValueOnce(
+		new Error('d1 unavailable'),
+	)
+
+	await deleteSavedPackageProjection({
+		env,
+		userId: 'user-1',
+		packageId: 'package-1',
+	})
+
+	expect(mockModule.deleteSavedPackage).toHaveBeenCalledWith(
+		{},
+		{
+			userId: 'user-1',
+			packageId: 'package-1',
+		},
+	)
+	expect(mockModule.deleteSavedPackageVector).toHaveBeenCalledWith(
+		env,
+		'package-1',
+	)
+	expect(mockModule.syncJobManagerAlarm).toHaveBeenCalledWith({
+		env,
+		userId: 'user-1',
+	})
+})
+
 test('refreshSavedPackageProjection continues when retriever cache refresh fails', async () => {
 	const env = createEnv()
 	const manifest = {

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -32,6 +32,7 @@ import {
 	removePackageRetrieverManifestCacheEntries,
 } from '#worker/package-retrievers/manifest-cache.ts'
 import { cleanupArtifactReposForPackage } from '#worker/repo/artifact-repo-cleanup.ts'
+import { deleteEntitySource } from '#worker/repo/entity-sources.ts'
 
 function logPackageRetrieverProjectionError(input: {
 	action: 'refresh' | 'delete'
@@ -285,6 +286,10 @@ export async function deleteSavedPackageProjection(input: {
 					error: error instanceof Error ? error.message : String(error),
 				}),
 			)
+		})
+		await deleteEntitySource(input.env.APP_DB, {
+			id: savedPackage.sourceId,
+			userId: input.userId,
 		})
 		const listedServices = await listSavedPackageServices({
 			env: input.env,

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -290,6 +290,16 @@ export async function deleteSavedPackageProjection(input: {
 		await deleteEntitySource(input.env.APP_DB, {
 			id: savedPackage.sourceId,
 			userId: input.userId,
+		}).catch((error) => {
+			console.warn(
+				JSON.stringify({
+					message: 'package entity source cleanup failed',
+					userId: input.userId,
+					packageId: input.packageId,
+					sourceId: savedPackage.sourceId,
+					error: error instanceof Error ? error.message : String(error),
+				}),
+			)
 		})
 		const listedServices = await listSavedPackageServices({
 			env: input.env,

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -303,6 +303,90 @@ test('artifacts REST client supports get, create, token, and fork operations', a
 	expect(fetchMock).toHaveBeenCalledTimes(7)
 })
 
+test('resolveArtifactSourceRepo recreates missing source repos', async () => {
+	let getRepoCount = 0
+	const fetchMock = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			if (method === 'GET' && url.pathname.endsWith('/repos/repo-1')) {
+				getRepoCount += 1
+				if (getRepoCount === 1) {
+					return new Response(
+						JSON.stringify({
+							success: false,
+							result: null,
+							errors: [{ code: 1000, message: 'Repo not found' }],
+							messages: [],
+						}),
+						{
+							status: 404,
+							headers: { 'content-type': 'application/json' },
+						},
+					)
+				}
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo_1',
+							name: 'repo-1',
+							description: null,
+							default_branch: 'main',
+							created_at: '2026-04-18T00:00:00.000Z',
+							updated_at: '2026-04-18T00:00:00.000Z',
+							last_push_at: null,
+							source: null,
+							read_only: false,
+							remote:
+								'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			if (method === 'POST' && url.pathname.endsWith('/repos')) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo_1',
+							name: 'repo-1',
+							description: null,
+							default_branch: 'main',
+							remote:
+								'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+							token: 'art_v1_create?expires=1760000000',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
+		})
+	const env = {
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token-123',
+		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+	} as Env
+
+	const repo = await resolveArtifactSourceRepo(env, 'repo-1')
+
+	expect(repo).toHaveProperty('info', expect.any(Function))
+	expect(fetchMock).toHaveBeenCalledTimes(3)
+})
+
 test('artifacts REST client uses fallback API error text when envelope errors are missing', async () => {
 	vi.spyOn(globalThis, 'fetch').mockResolvedValue(
 		new Response(

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -465,6 +465,54 @@ test('ensureArtifactRepoReady rereads after concurrent create conflicts', async 
 	expect(fetchMock).toHaveBeenCalledTimes(3)
 })
 
+test('ensureArtifactRepoReady does not swallow generic create conflicts', async () => {
+	const fetchMock = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			if (method === 'GET' && url.pathname.endsWith('/repos/repo-1')) {
+				return new Response(
+					JSON.stringify({
+						success: false,
+						result: null,
+						errors: [{ code: 1000, message: 'Repo not found' }],
+						messages: [],
+					}),
+					{
+						status: 404,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			if (method === 'POST' && url.pathname.endsWith('/repos')) {
+				return new Response(
+					JSON.stringify({
+						success: false,
+						result: null,
+						errors: [{ code: 9000, message: 'Different conflict' }],
+						messages: [],
+					}),
+					{
+						status: 409,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
+		})
+	const env = {
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token-123',
+		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+	} as Env
+
+	await expect(ensureArtifactRepoReady(env, 'repo-1')).rejects.toThrow(
+		'Different conflict',
+	)
+	expect(fetchMock).toHaveBeenCalledTimes(2)
+})
+
 test('artifacts REST client uses fallback API error text when envelope errors are missing', async () => {
 	vi.spyOn(globalThis, 'fetch').mockResolvedValue(
 		new Response(

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -301,7 +301,7 @@ test('artifacts REST client supports get, create, token, and fork operations', a
 		alreadyDeleted: false,
 	})
 
-	expect(fetchMock).toHaveBeenCalledTimes(8)
+	expect(fetchMock).toHaveBeenCalledTimes(7)
 })
 
 test('resolveArtifactSourceRepo recreates missing source repos', async () => {
@@ -385,7 +385,7 @@ test('resolveArtifactSourceRepo recreates missing source repos', async () => {
 	const repo = await resolveArtifactSourceRepo(env, 'repo-1')
 
 	expect(repo).toHaveProperty('info', expect.any(Function))
-	expect(fetchMock).toHaveBeenCalledTimes(4)
+	expect(fetchMock).toHaveBeenCalledTimes(3)
 })
 
 test('ensureArtifactRepoReady rereads after concurrent create conflicts', async () => {
@@ -458,8 +458,9 @@ test('ensureArtifactRepoReady rereads after concurrent create conflicts', async 
 		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
 	} as Env
 
-	await expect(ensureArtifactRepoReady(env, 'repo-1')).resolves.toEqual({
+	await expect(ensureArtifactRepoReady(env, 'repo-1')).resolves.toMatchObject({
 		recreated: false,
+		repo: expect.any(Object),
 	})
 	expect(fetchMock).toHaveBeenCalledTimes(3)
 })

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -3,6 +3,7 @@ import { afterEach, expect, test, vi } from 'vitest'
 const {
 	buildArtifactsGitAuth,
 	buildAuthenticatedArtifactsRemote,
+	ensureArtifactRepoReady,
 	getArtifactsBinding,
 	getArtifactsNamespace,
 	parseArtifactTokenSecret,
@@ -300,7 +301,7 @@ test('artifacts REST client supports get, create, token, and fork operations', a
 		alreadyDeleted: false,
 	})
 
-	expect(fetchMock).toHaveBeenCalledTimes(7)
+	expect(fetchMock).toHaveBeenCalledTimes(8)
 })
 
 test('resolveArtifactSourceRepo recreates missing source repos', async () => {
@@ -384,6 +385,82 @@ test('resolveArtifactSourceRepo recreates missing source repos', async () => {
 	const repo = await resolveArtifactSourceRepo(env, 'repo-1')
 
 	expect(repo).toHaveProperty('info', expect.any(Function))
+	expect(fetchMock).toHaveBeenCalledTimes(4)
+})
+
+test('ensureArtifactRepoReady rereads after concurrent create conflicts', async () => {
+	let getRepoCount = 0
+	const fetchMock = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			if (method === 'GET' && url.pathname.endsWith('/repos/repo-1')) {
+				getRepoCount += 1
+				if (getRepoCount === 1) {
+					return new Response(
+						JSON.stringify({
+							success: false,
+							result: null,
+							errors: [{ code: 1000, message: 'Repo not found' }],
+							messages: [],
+						}),
+						{
+							status: 404,
+							headers: { 'content-type': 'application/json' },
+						},
+					)
+				}
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo_1',
+							name: 'repo-1',
+							description: null,
+							default_branch: 'main',
+							created_at: '2026-04-18T00:00:00.000Z',
+							updated_at: '2026-04-18T00:00:00.000Z',
+							last_push_at: null,
+							source: null,
+							read_only: false,
+							remote:
+								'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			if (method === 'POST' && url.pathname.endsWith('/repos')) {
+				return new Response(
+					JSON.stringify({
+						success: false,
+						result: null,
+						errors: [{ code: 10201, message: 'Create failed' }],
+						messages: [],
+					}),
+					{
+						status: 409,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
+		})
+	const env = {
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token-123',
+		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+	} as Env
+
+	await expect(ensureArtifactRepoReady(env, 'repo-1')).resolves.toEqual({
+		recreated: false,
+	})
 	expect(fetchMock).toHaveBeenCalledTimes(3)
 })
 

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -635,14 +635,26 @@ export async function readMockArtifactSnapshot(input: {
 export async function resolveArtifactSourceRepo(env: Env, repoId: string) {
 	const binding = getArtifactsBinding(env)
 	const result = await binding.get(repoId)
-	if (result.status !== 'ready') {
+	if (result.status === 'ready') {
+		return result.repo
+	}
+	if (result.status === 'not_found') {
+		const created = await binding.create(repoId, { readOnly: false })
+		const createdResult = await binding.get(created.name)
+		if (createdResult.status === 'ready') {
+			return createdResult.repo
+		}
 		throw new Error(
-			`Artifacts repo "${repoId}" is ${result.status}${
-				'retryAfter' in result ? ` (retry after ${result.retryAfter}s)` : ''
-			}.`,
+			`Artifacts repo "${created.name}" is ${createdResult.status} after create.`,
 		)
 	}
-	return result.repo
+	if (result.status === 'importing' || result.status === 'forking') {
+		throw new Error(
+			`Artifacts repo "${repoId}" is ${result.status} (retry after ${result.retryAfter}s).`,
+		)
+	}
+	const exhaustive: never = result
+	throw new Error(`Unexpected Artifacts repo status: ${String(exhaustive)}.`)
 }
 
 export async function resolveSessionRepo(

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -645,12 +645,22 @@ export async function readMockArtifactSnapshot(input: {
 }
 
 function isArtifactRepoAlreadyExistsError(error: unknown) {
-	const text = error instanceof Error ? error.message : String(error)
-	const cause = error instanceof Error ? error.cause : undefined
-	const causeText =
-		cause && typeof cause === 'object' ? JSON.stringify(cause) : String(cause)
-	return /already[\s_-]*exists|already_exists|10201|conflict|409/i.test(
-		`${text} ${causeText}`,
+	if (!(error instanceof Error)) {
+		return false
+	}
+	const text = error.message
+	const cause = error.cause
+	const causeMessage =
+		cause && typeof cause === 'object' && 'message' in cause
+			? String(cause.message)
+			: ''
+	const causeCode =
+		cause && typeof cause === 'object' && 'code' in cause
+			? Number(cause.code)
+			: null
+	return (
+		causeCode === 10201 ||
+		/already[\s_-]*exists|already_exists/i.test(`${text} ${causeMessage}`)
 	)
 }
 

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -28,8 +28,12 @@ export type ArtifactBootstrapAccess = {
 }
 
 export type ArtifactRepoReadyResult =
-	| { recreated: false }
-	| { recreated: true; bootstrapAccess: ArtifactBootstrapAccess }
+	| { recreated: false; repo: ArtifactRepoHandle }
+	| {
+			recreated: true
+			bootstrapAccess: ArtifactBootstrapAccess
+			repo: ArtifactRepoHandle
+	  }
 
 export type ArtifactRepoInfo = {
 	id: string
@@ -666,7 +670,7 @@ async function waitForArtifactRepoReadyAfterCreateConflict(input: {
 	for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
 		const result = await input.binding.get(input.repoId)
 		if (result.status === 'ready') {
-			return { recreated: false }
+			return { recreated: false, repo: result.repo }
 		}
 		lastStatus = result.status
 		if (result.status === 'importing' || result.status === 'forking') {
@@ -689,7 +693,9 @@ export async function ensureArtifactRepoReady(
 	binding: ArtifactNamespaceBinding = getArtifactsBinding(env),
 ): Promise<ArtifactRepoReadyResult> {
 	const existing = await binding.get(repoId)
-	if (existing.status === 'ready') return { recreated: false }
+	if (existing.status === 'ready') {
+		return { recreated: false, repo: existing.repo }
+	}
 	if (existing.status === 'importing' || existing.status === 'forking') {
 		throw new Error(
 			`Artifacts repo "${repoId}" is ${existing.status}. Retry after ${existing.retryAfter}s.`,
@@ -722,22 +728,14 @@ export async function ensureArtifactRepoReady(
 	return {
 		recreated: true,
 		bootstrapAccess,
+		repo: getResult.repo,
 	}
 }
 
 export async function resolveArtifactSourceRepo(env: Env, repoId: string) {
 	const binding = getArtifactsBinding(env)
-	await ensureArtifactRepoReady(env, repoId, binding)
-	const result = await binding.get(repoId)
-	if (result.status === 'ready') {
-		return result.repo
-	}
-	if (result.status === 'importing' || result.status === 'forking') {
-		throw new Error(
-			`Artifacts repo "${repoId}" is ${result.status} (retry after ${result.retryAfter}s).`,
-		)
-	}
-	throw new Error(`Artifacts repo "${repoId}" is ${result.status}.`)
+	const result = await ensureArtifactRepoReady(env, repoId, binding)
+	return result.repo
 }
 
 export async function resolveSessionRepo(

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -27,6 +27,10 @@ export type ArtifactBootstrapAccess = {
 	expiresAt: string
 }
 
+export type ArtifactRepoReadyResult =
+	| { recreated: false }
+	| { recreated: true; bootstrapAccess: ArtifactBootstrapAccess }
+
 export type ArtifactRepoInfo = {
 	id: string
 	name: string
@@ -407,8 +411,9 @@ async function requestArtifactsEnvelope<T>(
 		})
 		const envelope = response.body as ArtifactApiEnvelope<T> | null
 		if (!envelope?.success) {
+			const primaryError = envelope?.errors?.[0]
 			const message =
-				envelope?.errors?.[0]?.message ??
+				primaryError?.message ??
 				`Artifacts API request failed (${response.status}).`
 			if (input.treat404AsNull && response.status === 404) {
 				return {
@@ -418,7 +423,10 @@ async function requestArtifactsEnvelope<T>(
 					messages: [],
 				} satisfies ArtifactApiEnvelope<T>
 			}
-			throw new Error(message)
+			throw new Error(
+				message,
+				primaryError ? { cause: primaryError } : undefined,
+			)
 		}
 		return envelope
 	} catch (error) {
@@ -632,29 +640,104 @@ export async function readMockArtifactSnapshot(input: {
 	return envelope.result
 }
 
+function isArtifactRepoAlreadyExistsError(error: unknown) {
+	const text = error instanceof Error ? error.message : String(error)
+	const cause = error instanceof Error ? error.cause : undefined
+	const causeText =
+		cause && typeof cause === 'object' ? JSON.stringify(cause) : String(cause)
+	return /already[\s_-]*exists|already_exists|10201|conflict|409/i.test(
+		`${text} ${causeText}`,
+	)
+}
+
+function waitForArtifactRepoCheck(delayMs: number) {
+	return new Promise((resolve) => setTimeout(resolve, delayMs))
+}
+
+async function waitForArtifactRepoReadyAfterCreateConflict(input: {
+	binding: ArtifactNamespaceBinding
+	repoId: string
+	maxAttempts?: number
+	delayMs?: number
+}): Promise<ArtifactRepoReadyResult> {
+	const maxAttempts = input.maxAttempts ?? 5
+	const delayMs = input.delayMs ?? 50
+	let lastStatus = 'not_found'
+	for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+		const result = await input.binding.get(input.repoId)
+		if (result.status === 'ready') {
+			return { recreated: false }
+		}
+		lastStatus = result.status
+		if (result.status === 'importing' || result.status === 'forking') {
+			throw new Error(
+				`Artifacts repo "${input.repoId}" is ${result.status}. Retry after ${result.retryAfter}s.`,
+			)
+		}
+		if (attempt < maxAttempts) {
+			await waitForArtifactRepoCheck(delayMs)
+		}
+	}
+	throw new Error(
+		`Artifacts repo "${input.repoId}" is ${lastStatus} after create conflict.`,
+	)
+}
+
+export async function ensureArtifactRepoReady(
+	env: Env,
+	repoId: string,
+	binding: ArtifactNamespaceBinding = getArtifactsBinding(env),
+): Promise<ArtifactRepoReadyResult> {
+	const existing = await binding.get(repoId)
+	if (existing.status === 'ready') return { recreated: false }
+	if (existing.status === 'importing' || existing.status === 'forking') {
+		throw new Error(
+			`Artifacts repo "${repoId}" is ${existing.status}. Retry after ${existing.retryAfter}s.`,
+		)
+	}
+	let created: Awaited<ReturnType<ArtifactNamespaceBinding['create']>>
+	try {
+		created = await binding.create(repoId, { readOnly: false })
+	} catch (error) {
+		if (isArtifactRepoAlreadyExistsError(error)) {
+			return await waitForArtifactRepoReadyAfterCreateConflict({
+				binding,
+				repoId,
+			})
+		}
+		throw error
+	}
+	const getResult = await binding.get(created.name)
+	if (getResult.status !== 'ready') {
+		throw new Error(
+			`Artifacts repo "${created.name}" is ${getResult.status} after create.`,
+		)
+	}
+	const bootstrapAccess = {
+		defaultBranch: created.defaultBranch,
+		remote: created.remote,
+		token: created.token,
+		expiresAt: created.expiresAt,
+	}
+	return {
+		recreated: true,
+		bootstrapAccess,
+	}
+}
+
 export async function resolveArtifactSourceRepo(env: Env, repoId: string) {
 	const binding = getArtifactsBinding(env)
+	await ensureArtifactRepoReady(env, repoId, binding)
 	const result = await binding.get(repoId)
 	if (result.status === 'ready') {
 		return result.repo
-	}
-	if (result.status === 'not_found') {
-		const created = await binding.create(repoId, { readOnly: false })
-		const createdResult = await binding.get(created.name)
-		if (createdResult.status === 'ready') {
-			return createdResult.repo
-		}
-		throw new Error(
-			`Artifacts repo "${created.name}" is ${createdResult.status} after create.`,
-		)
 	}
 	if (result.status === 'importing' || result.status === 'forking') {
 		throw new Error(
 			`Artifacts repo "${repoId}" is ${result.status} (retry after ${result.retryAfter}s).`,
 		)
 	}
-	const exhaustive: never = result
-	throw new Error(`Unexpected Artifacts repo status: ${String(exhaustive)}.`)
+	throw new Error(`Artifacts repo "${repoId}" is ${result.status}.`)
 }
 
 export async function resolveSessionRepo(

--- a/packages/worker/src/repo/source-service.node.test.ts
+++ b/packages/worker/src/repo/source-service.node.test.ts
@@ -6,6 +6,23 @@ afterEach(() => {
 	vi.restoreAllMocks()
 })
 
+function createEntitySourceRow() {
+	return {
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'package-package-1',
+		published_commit: 'abc123',
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		created_at: '2026-04-18T00:00:00.000Z',
+		updated_at: '2026-04-18T00:00:00.000Z',
+	}
+}
+
 test('ensureEntitySource fails closed when durable persistence is required without Artifacts REST credentials', async () => {
 	const db = {
 		prepare() {
@@ -157,4 +174,203 @@ test('ensureEntitySource returns bootstrap access for brand-new repos', async ()
 		token: 'art_v1_create?expires=1760000000',
 		expiresAt: '2025-10-09T08:53:20.000Z',
 	})
+})
+
+test('ensureEntitySource recreates a missing Artifacts repo for an existing entity source', async () => {
+	const existingRow = createEntitySourceRow()
+	const runMock = vi.fn()
+	const db = {
+		prepare(query: string) {
+			return {
+				bind() {
+					return {
+						async first() {
+							if (query.includes('FROM entity_sources')) {
+								return existingRow
+							}
+							return null
+						},
+						run: runMock,
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+
+	let getRepoCount = 0
+	const fetchMock = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			if (
+				method === 'GET' &&
+				url.pathname.endsWith('/repos/package-package-1')
+			) {
+				getRepoCount += 1
+				if (getRepoCount === 1) {
+					return new Response(
+						JSON.stringify({
+							success: false,
+							result: null,
+							errors: [{ code: 1000, message: 'Repo not found' }],
+							messages: [],
+						}),
+						{
+							status: 404,
+							headers: { 'content-type': 'application/json' },
+						},
+					)
+				}
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo-1',
+							name: 'package-package-1',
+							description: null,
+							default_branch: 'main',
+							created_at: '2026-04-18T00:00:00.000Z',
+							updated_at: '2026-04-18T00:00:00.000Z',
+							last_push_at: null,
+							source: null,
+							read_only: false,
+							remote:
+								'https://acct.artifacts.cloudflare.net/git/default/package-package-1.git',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			if (method === 'POST' && url.pathname.endsWith('/repos')) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo-1',
+							name: 'package-package-1',
+							description: null,
+							default_branch: 'main',
+							remote:
+								'https://acct.artifacts.cloudflare.net/git/default/package-package-1.git',
+							token: 'art_v1_create?expires=1760000000',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
+		})
+
+	const source = await ensureEntitySource({
+		db,
+		env: {
+			APP_DB: db,
+			CLOUDFLARE_ACCOUNT_ID: 'acct',
+			CLOUDFLARE_API_TOKEN: 'token-123',
+			CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+		} as Env,
+		userId: 'user-1',
+		entityKind: 'package',
+		entityId: 'package-1',
+		sourceRoot: '/',
+	})
+
+	expect(fetchMock).toHaveBeenCalledTimes(3)
+	expect(runMock).not.toHaveBeenCalled()
+	expect(source).toMatchObject(existingRow)
+	expect(source.bootstrapAccess).toEqual({
+		defaultBranch: 'main',
+		remote:
+			'https://acct.artifacts.cloudflare.net/git/default/package-package-1.git',
+		token: 'art_v1_create?expires=1760000000',
+		expiresAt: '2025-10-09T08:53:20.000Z',
+	})
+})
+
+test('ensureEntitySource reuses an existing entity source when its Artifacts repo is ready', async () => {
+	const existingRow = createEntitySourceRow()
+	const runMock = vi.fn()
+	const db = {
+		prepare(query: string) {
+			return {
+				bind() {
+					return {
+						async first() {
+							if (query.includes('FROM entity_sources')) {
+								return existingRow
+							}
+							return null
+						},
+						run: runMock,
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+	const fetchMock = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			if (
+				method === 'GET' &&
+				url.pathname.endsWith('/repos/package-package-1')
+			) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo-1',
+							name: 'package-package-1',
+							description: null,
+							default_branch: 'main',
+							created_at: '2026-04-18T00:00:00.000Z',
+							updated_at: '2026-04-18T00:00:00.000Z',
+							last_push_at: null,
+							source: null,
+							read_only: false,
+							remote:
+								'https://acct.artifacts.cloudflare.net/git/default/package-package-1.git',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
+		})
+
+	const source = await ensureEntitySource({
+		db,
+		env: {
+			APP_DB: db,
+			CLOUDFLARE_ACCOUNT_ID: 'acct',
+			CLOUDFLARE_API_TOKEN: 'token-123',
+			CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+		} as Env,
+		userId: 'user-1',
+		entityKind: 'package',
+		entityId: 'package-1',
+		sourceRoot: '/',
+	})
+
+	expect(fetchMock).toHaveBeenCalledTimes(1)
+	expect(runMock).not.toHaveBeenCalled()
+	expect(source).toEqual(existingRow)
+	expect(source.bootstrapAccess).toBeUndefined()
 })

--- a/packages/worker/src/repo/source-service.node.test.ts
+++ b/packages/worker/src/repo/source-service.node.test.ts
@@ -178,7 +178,7 @@ test('ensureEntitySource returns bootstrap access for brand-new repos', async ()
 
 test('ensureEntitySource recreates a missing Artifacts repo for an existing entity source', async () => {
 	const existingRow = createEntitySourceRow()
-	const runMock = vi.fn()
+	const runMock = vi.fn(async () => ({ meta: { changes: 1 } }))
 	const db = {
 		prepare(query: string) {
 			return {
@@ -287,8 +287,12 @@ test('ensureEntitySource recreates a missing Artifacts repo for an existing enti
 	})
 
 	expect(fetchMock).toHaveBeenCalledTimes(3)
-	expect(runMock).not.toHaveBeenCalled()
-	expect(source).toMatchObject(existingRow)
+	expect(runMock).toHaveBeenCalledTimes(1)
+	expect(source).toMatchObject({
+		...existingRow,
+		published_commit: null,
+		indexed_commit: null,
+	})
 	expect(source.bootstrapAccess).toEqual({
 		defaultBranch: 'main',
 		remote:

--- a/packages/worker/src/repo/source-service.ts
+++ b/packages/worker/src/repo/source-service.ts
@@ -10,11 +10,6 @@ import {
 } from './entity-sources.ts'
 import { type EntityKind, type EntitySourceRow } from './types.ts'
 
-export {
-	ensureArtifactRepoReady,
-	type ArtifactRepoReadyResult,
-} from './artifacts.ts'
-
 export type EnsuredEntitySource = EntitySourceRow & {
 	bootstrapAccess?: ArtifactBootstrapAccess | null
 }

--- a/packages/worker/src/repo/source-service.ts
+++ b/packages/worker/src/repo/source-service.ts
@@ -7,6 +7,7 @@ import {
 import {
 	getEntitySourceByEntity,
 	insertEntitySource,
+	updateEntitySource,
 } from './entity-sources.ts'
 import { type EntityKind, type EntitySourceRow } from './types.ts'
 
@@ -93,8 +94,16 @@ export async function ensureEntitySource(input: {
 	if (existing) {
 		const repoReady = await ensureArtifactRepoReady(input.env, existing.repo_id)
 		if (!repoReady.recreated) return existing
+		await updateEntitySource(input.db, {
+			id: existing.id,
+			userId: existing.user_id,
+			publishedCommit: null,
+			indexedCommit: null,
+		})
 		return {
 			...existing,
+			published_commit: null,
+			indexed_commit: null,
 			bootstrapAccess: repoReady.bootstrapAccess,
 		}
 	}

--- a/packages/worker/src/repo/source-service.ts
+++ b/packages/worker/src/repo/source-service.ts
@@ -1,9 +1,8 @@
 import {
 	buildEntityRepoId,
-	getArtifactsBinding,
 	hasArtifactsAccess,
+	ensureArtifactRepoReady,
 	type ArtifactBootstrapAccess,
-	type ArtifactNamespaceBinding,
 } from './artifacts.ts'
 import {
 	getEntitySourceByEntity,
@@ -11,13 +10,14 @@ import {
 } from './entity-sources.ts'
 import { type EntityKind, type EntitySourceRow } from './types.ts'
 
+export {
+	ensureArtifactRepoReady,
+	type ArtifactRepoReadyResult,
+} from './artifacts.ts'
+
 export type EnsuredEntitySource = EntitySourceRow & {
 	bootstrapAccess?: ArtifactBootstrapAccess | null
 }
-
-export type ArtifactRepoReadyResult =
-	| { recreated: false }
-	| { recreated: true; bootstrapAccess: ArtifactBootstrapAccess }
 
 function buildEntitySourceRow(input: {
 	id?: string
@@ -136,35 +136,4 @@ function missingPersistenceRequirements(input: {
 		missing.push('CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN')
 	}
 	return missing
-}
-
-export async function ensureArtifactRepoReady(
-	env: Env,
-	repoId: string,
-	binding: ArtifactNamespaceBinding = getArtifactsBinding(env),
-): Promise<ArtifactRepoReadyResult> {
-	const existing = await binding.get(repoId)
-	if (existing.status === 'ready') return { recreated: false }
-	if (existing.status === 'importing' || existing.status === 'forking') {
-		throw new Error(
-			`Artifacts repo "${repoId}" is ${existing.status}. Retry after ${existing.retryAfter}s.`,
-		)
-	}
-	const created = await binding.create(repoId, { readOnly: false })
-	const getResult = await binding.get(created.name)
-	if (getResult.status !== 'ready') {
-		throw new Error(
-			`Artifacts repo "${created.name}" is ${getResult.status} after create.`,
-		)
-	}
-	const bootstrapAccess = {
-		defaultBranch: created.defaultBranch,
-		remote: created.remote,
-		token: created.token,
-		expiresAt: created.expiresAt,
-	}
-	return {
-		recreated: true,
-		bootstrapAccess,
-	}
 }

--- a/packages/worker/src/repo/source-service.ts
+++ b/packages/worker/src/repo/source-service.ts
@@ -15,6 +15,10 @@ export type EnsuredEntitySource = EntitySourceRow & {
 	bootstrapAccess?: ArtifactBootstrapAccess | null
 }
 
+export type ArtifactRepoReadyResult =
+	| { recreated: false }
+	| { recreated: true; bootstrapAccess: ArtifactBootstrapAccess }
+
 function buildEntitySourceRow(input: {
 	id?: string
 	userId: string
@@ -91,7 +95,14 @@ export async function ensureEntitySource(input: {
 		entityKind: input.entityKind,
 		entityId: input.entityId,
 	})
-	if (existing) return existing
+	if (existing) {
+		const repoReady = await ensureArtifactRepoReady(input.env, existing.repo_id)
+		if (!repoReady.recreated) return existing
+		return {
+			...existing,
+			bootstrapAccess: repoReady.bootstrapAccess,
+		}
+	}
 	const row = buildEntitySourceRow({
 		id: input.id,
 		userId: input.userId,
@@ -101,14 +112,11 @@ export async function ensureEntitySource(input: {
 		manifestPath: input.manifestPath,
 		sourceRoot: input.sourceRoot,
 	})
-	const bootstrapAccess = await createArtifactsRepoIfMissing(
-		input.env,
-		row.repo_id,
-	)
+	const repoReady = await ensureArtifactRepoReady(input.env, row.repo_id)
 	await insertEntitySource(input.db, row)
 	return {
 		...row,
-		bootstrapAccess,
+		bootstrapAccess: repoReady.recreated ? repoReady.bootstrapAccess : null,
 	}
 }
 
@@ -130,13 +138,13 @@ function missingPersistenceRequirements(input: {
 	return missing
 }
 
-async function createArtifactsRepoIfMissing(
+export async function ensureArtifactRepoReady(
 	env: Env,
 	repoId: string,
 	binding: ArtifactNamespaceBinding = getArtifactsBinding(env),
-): Promise<ArtifactBootstrapAccess | null> {
+): Promise<ArtifactRepoReadyResult> {
 	const existing = await binding.get(repoId)
-	if (existing.status === 'ready') return null
+	if (existing.status === 'ready') return { recreated: false }
 	if (existing.status === 'importing' || existing.status === 'forking') {
 		throw new Error(
 			`Artifacts repo "${repoId}" is ${existing.status}. Retry after ${existing.retryAfter}s.`,
@@ -149,10 +157,14 @@ async function createArtifactsRepoIfMissing(
 			`Artifacts repo "${created.name}" is ${getResult.status} after create.`,
 		)
 	}
-	return {
+	const bootstrapAccess = {
 		defaultBranch: created.defaultBranch,
 		remote: created.remote,
 		token: created.token,
 		expiresAt: created.expiresAt,
+	}
+	return {
+		recreated: true,
+		bootstrapAccess,
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes the root cause where `ensureEntitySource()` reused persisted `entity_sources` rows without verifying the backing Cloudflare Artifacts repo still exists.
- Adds shared, race-safe repo readiness repair for missing source repos: ready repos are reused, importing/forking repos still fail closed, `not_found` repos are recreated, and concurrent duplicate-create conflicts re-read until ready.
- Clears stale published/indexed commits when an existing source repo is recreated so downstream sync uses the bootstrap path against the empty replacement repo.
- Updates package deletion cleanup to remove the associated `entity_sources` row after Artifacts cleanup without blocking package deletion if that best-effort cleanup fails.
- Keeps source repo resolution on a single ready-path Artifacts lookup by returning the repo handle from the shared readiness helper.

## Tests
- `npx vitest run --config vitest.node.config.ts packages/worker/src/repo/source-service.node.test.ts packages/worker/src/repo/artifacts.node.test.ts packages/worker/src/package-registry/service.node.test.ts`
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b28b722f-6c05-4b0c-93b3-2196008bb589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b28b722f-6c05-4b0c-93b3-2196008bb589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized repo readiness and automatic recreation for missing artifact repositories; readiness details now available to calling services.

* **Bug Fixes**
  * Saved-package deletion now also removes associated entity-source records and continues cleanup even if source removal fails.
  * Improved error messages for artifact API failures with clearer primary-error context.

* **Tests**
  * Expanded tests covering repo recreation, entity-source handling, deletion/cleanup ordering, and failure resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->