### PR TITLE
docs: add Cursor Cloud dev environment notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ This file is intentionally brief. Detailed instructions live in focused docs:
   - [docs/contributing/architecture/authentication.md](./docs/contributing/architecture/authentication.md)
   - [docs/contributing/architecture/data-storage.md](./docs/contributing/architecture/data-storage.md)
 
-## Cursor Cloud specific instructions
+## Cursor Cloud-specific instructions
 
 Kody is a single Cloudflare Workers app (Remix 3 UI + OAuth-protected MCP). See
 [`docs/contributing/setup.md`](./docs/contributing/setup.md) for the full local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,56 @@ This file is intentionally brief. Detailed instructions live in focused docs:
   - [docs/contributing/architecture/request-lifecycle.md](./docs/contributing/architecture/request-lifecycle.md)
   - [docs/contributing/architecture/authentication.md](./docs/contributing/architecture/authentication.md)
   - [docs/contributing/architecture/data-storage.md](./docs/contributing/architecture/data-storage.md)
+
+## Cursor Cloud specific instructions
+
+Kody is a single Cloudflare Workers app (Remix 3 UI + OAuth-protected MCP). See
+[`docs/contributing/setup.md`](./docs/contributing/setup.md) for the full local
+dev guide; this section covers Cloud Agent VM gotchas only.
+
+### Node 24
+
+The repo requires Node **24.x** (`engines` in root `package.json`). Cloud Agent
+VMs may ship Node 22 at `/exec-daemon/node`, which takes precedence over nvm
+unless nvm’s Node 24 bin directory is prepended to `PATH`. Verify with
+`node --version` before running scripts.
+
+### Quick commands
+
+| Task             | Command                                                         |
+| ---------------- | --------------------------------------------------------------- |
+| Install deps     | `npm install`                                                   |
+| Start dev        | `npm run dev` (prints the resolved URL)                         |
+| Migrate local D1 | `npm run migrate:local`                                         |
+| Seed test login  | `node tools/seed-test-data.ts --local` (see seeding note below) |
+| Full CI gate     | `npm run validate`                                              |
+
+### Dev server
+
+- `npm run dev` starts the client esbuild watcher, optional Cloudflare API mock
+  worker, and the main worker with local D1/KV/DO persistence.
+- Default worker port is **3742** (`cli.ts`); the CLI picks a free port when
+  3742 is taken and prints `App running at http://localhost:<port>`.
+- Run long-lived dev in tmux so the session survives tool timeouts.
+- Health check (no auth): `curl http://localhost:<port>/health` →
+  `{"ok":true,"commitSha":...}`.
+
+### Environment file
+
+Copy `packages/worker/.env.example` to `packages/worker/.env` if missing.
+`COOKIE_SECRET` and `SECRET_STORE_KEY` are required for local dev.
+
+### Seeding a test account
+
+After `npm run migrate:local`, seed the default E2E login (`me@kentcdodds.com` /
+`iliketwix`) per [`docs/contributing/setup.md`](./docs/contributing/setup.md).
+If `node tools/seed-test-data.ts --local` fails because Wrangler cannot resolve
+`APP_DB` without the worker config wrapper, run the seed SQL through
+`./wrangler-env.ts` instead (same pattern as the migrate script).
+
+### Local limitations
+
+- Vectorize bindings are not emulated locally; capability search uses the
+  offline ranker when `WRANGLER_IS_LOCAL_DEV` is set (normal for `npm run dev`).
+- `/mcp` returns **401** without OAuth; use browser login or MCP E2E tests for
+  authenticated MCP checks.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Cursor Cloud specific instructions** section to `AGENTS.md` documenting VM gotchas discovered during Cloud Agent environment setup:

- Node 24 requirement and `/exec-daemon/node` PATH override via nvm
- Correct default dev port (**3742**, not 8787)
- Local dev server, health check, and seeding workflow notes
- Local Vectorize/MCP limitations

## Context

Cloud Agent VM setup verified:

- `npm install` with Node 24
- `npm run migrate:local` + seeded test user
- `npm run dev` (tmux) at `http://localhost:3742`
- Lint, format, typecheck, unit tests, and build all pass
- Hello-world: health check, API login, browser login to `/account`

![Logged-in account page](https://cursor.com/artifacts/c/art-145bf1eb-2b7c-47fb-a619-b4642c19abcc)

<a href="https://cursor.com/agents/bc-3d10e8e6-26b5-4bd7-9ca3-1c81f0ecef0d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkody-dev-login-demo.mp4"><img src="https://cursor.com/artifacts/c/art-6d63e3c4-f202-4c36-b28e-f9619913525c" alt="kody-dev-login-demo.mp4" /></a>

## VM update script

`npm install` (Node 24 PATH configured once in shell profile during initial setup).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d10e8e6-26b5-4bd7-9ca3-1c81f0ecef0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d10e8e6-26b5-4bd7-9ca3-1c81f0ecef0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New Cursor Cloud–specific instructions covering Node 24 requirements and PATH precedence, quick command references, development server behavior and health-check endpoint, required local environment variables, how to seed a test login, and known local limitations (vectorize bindings and OAuth behavior for /mcp), plus operational guidance for running and debugging locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->