### PR TITLE
Enforce package source safety policy

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
@@ -38,7 +38,36 @@ function resetMocks() {
 
 function createContext(userId = 'user-1') {
 	return {
-		env: { APP_DB: {} } as Env,
+		env: {
+			APP_DB: {},
+			BUNDLE_ARTIFACTS_KV: {
+				async get(_key: string, type?: 'text' | 'json') {
+					if (type !== 'json') return null
+					return {
+						version: 1,
+						sourceId: 'source-1',
+						repoId: 'package-package-1',
+						entityKind: 'package',
+						entityId: 'package-1',
+						publishedCommit: 'commit-1',
+						manifestPath: 'package.json',
+						sourceRoot: '/',
+						files: {
+							'package.json': JSON.stringify({
+								name: '@kentcdodds/unleashed-wifi',
+								exports: { '.': './src/index.ts' },
+								kody: {
+									id: 'unleashed-wifi',
+									description: 'Unleashed WiFi controls.',
+								},
+							}),
+							'src/index.ts': 'export default async function main() {}\n',
+						},
+						createdAt: '2026-05-04T00:00:00.000Z',
+					}
+				},
+			},
+		} as unknown as Env,
 		callerContext: {
 			baseUrl: 'https://heykody.dev',
 			user: {

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
@@ -8,6 +8,10 @@ import {
 	parseArtifactTokenSecret,
 	resolveArtifactSourceRepo,
 } from '#worker/repo/artifacts.ts'
+import {
+	assertRestorablePackageSourceSnapshot,
+	withProductionPackageSourceSafetyPolicy,
+} from '#worker/repo/source-safety-policy.ts'
 import { resolveOwnedPackageSource } from './resolve-package-source.ts'
 
 const getGitRemoteInputSchema = z.object({
@@ -39,8 +43,9 @@ export const getGitRemoteCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
 		name: 'package_get_git_remote',
-		description:
+		description: withProductionPackageSourceSafetyPolicy(
 			'Mint a short-lived Cloudflare Artifacts git remote for coding agents with local filesystem/git access to clone a saved package into a temporary directory, edit normally, push, and publish with package_publish_external_push.',
+		),
 		keywords: [
 			'package',
 			'git',
@@ -66,6 +71,14 @@ export const getGitRemoteCapability = defineDomainCapability(
 					kody_id: args.kody_id,
 				},
 			})
+			if (args.scope === 'write') {
+				await assertRestorablePackageSourceSnapshot({
+					env: ctx.env,
+					userId: user.userId,
+					source,
+					operation: 'package_get_git_remote write access',
+				})
+			}
 			const repo = await resolveArtifactSourceRepo(ctx.env, source.repo_id)
 			const info = await repo.info()
 			if (!info?.remote) {

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
@@ -10,7 +10,6 @@ import {
 } from '#worker/repo/artifacts.ts'
 import {
 	assertRestorablePackageSourceSnapshot,
-	withProductionPackageSourceSafetyPolicy,
 } from '#worker/repo/source-safety-policy.ts'
 import { resolveOwnedPackageSource } from './resolve-package-source.ts'
 
@@ -43,9 +42,8 @@ export const getGitRemoteCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
 		name: 'package_get_git_remote',
-		description: withProductionPackageSourceSafetyPolicy(
-			'Mint a short-lived Cloudflare Artifacts git remote for coding agents with local filesystem/git access to clone a saved package into a temporary directory, edit normally, push, and publish with package_publish_external_push.',
-		),
+		description:
+			'Mint a short-lived Cloudflare Artifacts git remote for coding agents with local filesystem/git access to clone a saved package into a temporary directory, edit normally, push, and publish with package_publish_external_push. Write access verifies the current package source has a restorable backup snapshot before clone/edit/publish.',
 		keywords: [
 			'package',
 			'git',

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
@@ -8,9 +8,7 @@ import {
 	parseArtifactTokenSecret,
 	resolveArtifactSourceRepo,
 } from '#worker/repo/artifacts.ts'
-import {
-	assertRestorablePackageSourceSnapshot,
-} from '#worker/repo/source-safety-policy.ts'
+import { assertRestorablePackageSourceSnapshot } from '#worker/repo/source-safety-policy.ts'
 import { resolveOwnedPackageSource } from './resolve-package-source.ts'
 
 const getGitRemoteInputSchema = z.object({

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -388,7 +388,7 @@ test('surfaces not-fast-forward refusal without force', async () => {
 	)
 })
 
-test('passes allow_force through to the publish pipeline', async () => {
+test('passes allow_force and destructive confirmation through to the publish pipeline', async () => {
 	mockModule.resolveArtifactSourceHead.mockResolvedValue({
 		branch: 'main',
 		commit: 'commit-rewrite',
@@ -402,13 +402,18 @@ test('passes allow_force through to the publish pipeline', async () => {
 	})
 
 	await publishExternalPushCapability.handler(
-		{ package_id: 'package-1', allow_force: true },
+		{
+			package_id: 'package-1',
+			allow_force: true,
+			confirm_destructive_overwrite: true,
+		},
 		createContext(),
 	)
 
 	expect(mockModule.publishFromExternalRef).toHaveBeenCalledWith(
 		expect.objectContaining({
 			allowForce: true,
+			destructiveOverwriteConfirmed: true,
 		}),
 	)
 })

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -14,7 +14,6 @@ import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
 import { rebuildPublishedPackageArtifactsViaRepoSession } from '#mcp/capabilities/repo/package-artifact-rebuild.ts'
 import {
 	destructiveOverwriteConfirmationDescription,
-	withProductionPackageSourceSafetyPolicy,
 } from '#worker/repo/source-safety-policy.ts'
 import { resolveOwnedPackageSource } from './resolve-package-source.ts'
 
@@ -240,9 +239,8 @@ export const publishExternalPushCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
 		name: 'package_publish_external_push',
-		description: withProductionPackageSourceSafetyPolicy(
-			'Publish the current Artifacts git HEAD for a saved package after a package_get_git_remote clone/edit/push workflow and server-side checks pass. Published and already_published responses include bounded static dependent metadata so agents can decide whether stale kody:@ bundled snapshots need inspection or dependent republish; Kody does not republish dependents automatically.',
-		),
+		description:
+			'Publish the current Artifacts git HEAD for a saved package after a package_get_git_remote clone/edit/push workflow and server-side checks pass. Non-fast-forward publishes require explicit destructive overwrite confirmation and a verified restorable backup snapshot. Published and already_published responses include bounded static dependent metadata so agents can decide whether stale kody:@ bundled snapshots need inspection or dependent republish; Kody does not republish dependents automatically.',
 		keywords: ['package', 'publish', 'git', 'artifacts', 'external', 'push'],
 		readOnly: false,
 		idempotent: true,

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -12,12 +12,21 @@ import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
 import { rebuildPublishedPackageArtifactsViaRepoSession } from '#mcp/capabilities/repo/package-artifact-rebuild.ts'
+import {
+	destructiveOverwriteConfirmationDescription,
+	withProductionPackageSourceSafetyPolicy,
+} from '#worker/repo/source-safety-policy.ts'
 import { resolveOwnedPackageSource } from './resolve-package-source.ts'
 
 const inputSchema = z.object({
 	package_id: z.string().min(1).optional(),
 	kody_id: z.string().min(1).optional(),
 	allow_force: z.boolean().optional().default(false),
+	confirm_destructive_overwrite: z
+		.boolean()
+		.optional()
+		.default(false)
+		.describe(destructiveOverwriteConfirmationDescription),
 })
 
 const externalPublishRetryDelaysMs = [100, 500] as const
@@ -231,12 +240,13 @@ export const publishExternalPushCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
 		name: 'package_publish_external_push',
-		description:
+		description: withProductionPackageSourceSafetyPolicy(
 			'Publish the current Artifacts git HEAD for a saved package after a package_get_git_remote clone/edit/push workflow and server-side checks pass. Published and already_published responses include bounded static dependent metadata so agents can decide whether stale kody:@ bundled snapshots need inspection or dependent republish; Kody does not republish dependents automatically.',
+		),
 		keywords: ['package', 'publish', 'git', 'artifacts', 'external', 'push'],
 		readOnly: false,
 		idempotent: true,
-		destructive: false,
+		destructive: true,
 		inputSchema,
 		outputSchema,
 		async handler(args, ctx) {
@@ -283,6 +293,8 @@ export const publishExternalPushCapability = defineDomainCapability(
 						newCommit,
 						expectedHead: newCommit,
 						allowForce: args.allow_force,
+						destructiveOverwriteConfirmed:
+							args.confirm_destructive_overwrite,
 						baseUrl: ctx.callerContext.baseUrl,
 						rebuildPackageArtifacts: false,
 						expectedPackageScope,

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -293,8 +293,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 						newCommit,
 						expectedHead: newCommit,
 						allowForce: args.allow_force,
-						destructiveOverwriteConfirmed:
-							args.confirm_destructive_overwrite,
+						destructiveOverwriteConfirmed: args.confirm_destructive_overwrite,
 						baseUrl: ctx.callerContext.baseUrl,
 						rebuildPackageArtifacts: false,
 						expectedPackageScope,

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -12,9 +12,7 @@ import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
 import { rebuildPublishedPackageArtifactsViaRepoSession } from '#mcp/capabilities/repo/package-artifact-rebuild.ts'
-import {
-	destructiveOverwriteConfirmationDescription,
-} from '#worker/repo/source-safety-policy.ts'
+import { destructiveOverwriteConfirmationDescription } from '#worker/repo/source-safety-policy.ts'
 import { resolveOwnedPackageSource } from './resolve-package-source.ts'
 
 const inputSchema = z.object({

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -5,6 +5,11 @@ import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 import {
+	assertPackageSourceOverwriteAllowed,
+	destructiveOverwriteConfirmationDescription,
+	withProductionPackageSourceSafetyPolicy,
+} from '#worker/repo/source-safety-policy.ts'
+import {
 	getSavedPackageById,
 	getSavedPackageByKodyId,
 	insertSavedPackage,
@@ -31,6 +36,11 @@ const inputSchema = z
 			.describe(
 				'Full package file set to write. Must include package.json at the repo root.',
 			),
+		confirm_destructive_overwrite: z
+			.boolean()
+			.optional()
+			.default(false)
+			.describe(destructiveOverwriteConfirmationDescription),
 	})
 	.superRefine((value, ctx) => {
 		const hasPackageJson = value.files.some(
@@ -58,8 +68,9 @@ export const savePackageCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
 		name: 'package_save',
-		description:
+		description: withProductionPackageSourceSafetyPolicy(
 			'Create or replace a saved package by writing a complete package file set. Prefer package_get_git_remote or repo sessions for iterative edits. The package repo is rooted at package.json and package.json#kody is the Kody-specific metadata block. When creating or materially changing a package, include or maintain README.md with a concise Intent section that captures the user-defined goal; ask the user if intent is unclear.',
+		),
 		keywords: [
 			'package',
 			'save',
@@ -72,7 +83,7 @@ export const savePackageCapability = defineDomainCapability(
 		],
 		readOnly: false,
 		idempotent: false,
-		destructive: false,
+		destructive: true,
 		inputSchema,
 		outputSchema: packageSummarySchema,
 		async handler(args, ctx) {
@@ -112,6 +123,15 @@ export const savePackageCapability = defineDomainCapability(
 				manifestPath: 'package.json',
 				requirePersistence: true,
 			})
+			if (existing) {
+				await assertPackageSourceOverwriteAllowed({
+					env: ctx.env,
+					userId: user.userId,
+					source: ensuredSource,
+					operation: 'package_save',
+					confirmed: args.confirm_destructive_overwrite,
+				})
+			}
 			await syncArtifactSourceSnapshot({
 				env: ctx.env,
 				userId: user.userId,
@@ -119,6 +139,7 @@ export const savePackageCapability = defineDomainCapability(
 				sourceId: ensuredSource.id,
 				bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
 				files,
+				destructiveOverwriteConfirmed: args.confirm_destructive_overwrite,
 			})
 			if (!existing) {
 				const now = new Date().toISOString()

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -8,7 +8,7 @@ import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import {
 	assertPackageSourceOverwriteAllowed,
 	destructiveOverwriteConfirmationDescription,
-	withProductionPackageSourceSafetyPolicy,
+	productionPackageSourceSafetyPolicy,
 } from '#worker/repo/source-safety-policy.ts'
 import {
 	getSavedPackageById,
@@ -69,9 +69,7 @@ export const savePackageCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
 		name: 'package_save',
-		description: withProductionPackageSourceSafetyPolicy(
-			'Create or replace a saved package by writing a complete package file set. Prefer package_get_git_remote or repo sessions for iterative edits. The package repo is rooted at package.json and package.json#kody is the Kody-specific metadata block. When creating or materially changing a package, include or maintain README.md with a concise Intent section that captures the user-defined goal; ask the user if intent is unclear.',
-		),
+		description: `Create or replace a saved package by writing a complete package file set. Prefer package_get_git_remote or repo sessions for iterative edits. The package repo is rooted at package.json and package.json#kody is the Kody-specific metadata block. When creating or materially changing a package, include or maintain README.md with a concise Intent section that captures the user-defined goal; ask the user if intent is unclear. ${productionPackageSourceSafetyPolicy}`,
 		keywords: [
 			'package',
 			'save',

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -4,6 +4,7 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
+import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import {
 	assertPackageSourceOverwriteAllowed,
 	destructiveOverwriteConfirmationDescription,
@@ -113,6 +114,10 @@ export const savePackageCapability = defineDomainCapability(
 							kodyId: manifest.kody.id,
 						})
 			const packageId = existing?.id ?? args.package_id ?? crypto.randomUUID()
+			const existingSource =
+				existing == null
+					? null
+					: await getEntitySourceById(ctx.env.APP_DB, existing.sourceId)
 			const ensuredSource = await ensureEntitySource({
 				db: ctx.env.APP_DB,
 				env: ctx.env,
@@ -127,7 +132,10 @@ export const savePackageCapability = defineDomainCapability(
 				await assertPackageSourceOverwriteAllowed({
 					env: ctx.env,
 					userId: user.userId,
-					source: ensuredSource,
+					source:
+						existingSource?.user_id === user.userId
+							? existingSource
+							: ensuredSource,
 					operation: 'package_save',
 					confirmed: args.confirm_destructive_overwrite,
 				})

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -4,7 +4,7 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
-import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
+import { getEntitySourceByEntity } from '#worker/repo/entity-sources.ts'
 import {
 	assertPackageSourceOverwriteAllowed,
 	destructiveOverwriteConfirmationDescription,
@@ -112,10 +112,14 @@ export const savePackageCapability = defineDomainCapability(
 							kodyId: manifest.kody.id,
 						})
 			const packageId = existing?.id ?? args.package_id ?? crypto.randomUUID()
-			const existingSource =
+			const canonicalExistingSource =
 				existing == null
 					? null
-					: await getEntitySourceById(ctx.env.APP_DB, existing.sourceId)
+					: await getEntitySourceByEntity(ctx.env.APP_DB, {
+							userId: user.userId,
+							entityKind: 'package',
+							entityId: packageId,
+						})
 			const ensuredSource = await ensureEntitySource({
 				db: ctx.env.APP_DB,
 				env: ctx.env,
@@ -131,8 +135,8 @@ export const savePackageCapability = defineDomainCapability(
 					env: ctx.env,
 					userId: user.userId,
 					source:
-						existingSource?.user_id === user.userId
-							? existingSource
+						canonicalExistingSource?.id === ensuredSource.id
+							? canonicalExistingSource
 							: ensuredSource,
 					operation: 'package_save',
 					confirmed: args.confirm_destructive_overwrite,

--- a/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
@@ -3,6 +3,7 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
+import { withProductionPackageSourceSafetyPolicy } from '#worker/repo/source-safety-policy.ts'
 import {
 	repoPublishSessionOutputSchema,
 	repoSessionIdSchema,
@@ -13,12 +14,13 @@ export const repoPublishSessionCapability = defineDomainCapability(
 	capabilityDomainNames.repo,
 	{
 		name: 'repo_publish_session',
-		description:
+		description: withProductionPackageSourceSafetyPolicy(
 			'Publish an active repo session back to the source repo after checks pass on the current tree and the base commit is still current.',
+		),
 		keywords: ['repo', 'publish', 'session', 'checks', 'artifact'],
 		readOnly: false,
 		idempotent: false,
-		destructive: false,
+		destructive: true,
 		inputSchema: repoSessionIdSchema,
 		outputSchema: repoPublishSessionOutputSchema,
 		async handler(args, ctx) {

--- a/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
@@ -3,7 +3,6 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
-import { withProductionPackageSourceSafetyPolicy } from '#worker/repo/source-safety-policy.ts'
 import {
 	repoPublishSessionOutputSchema,
 	repoSessionIdSchema,
@@ -14,9 +13,8 @@ export const repoPublishSessionCapability = defineDomainCapability(
 	capabilityDomainNames.repo,
 	{
 		name: 'repo_publish_session',
-		description: withProductionPackageSourceSafetyPolicy(
+		description:
 			'Publish an active repo session back to the source repo after checks pass on the current tree and the base commit is still current.',
-		),
 		keywords: ['repo', 'publish', 'session', 'checks', 'artifact'],
 		readOnly: false,
 		idempotent: false,

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands-text.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands-text.ts
@@ -17,15 +17,17 @@ export const repoRunCommandsSupportedForms = [
 ] as const
 
 export const repoRunCommandsCapabilityDescription =
-	withProductionPackageSourceSafetyPolicy([
-	'Run a parsed git-only workflow in a Kody-managed repo session for MCP-native edits.',
-	'Use this for tool-only agents without local filesystem/git access; coding agents that can clone locally should prefer `package_get_git_remote` (saved packages only) plus `package_publish_external_push`.',
-	'Commands are newline-separated and parsed, not shell-executed.',
-	'Only supported git command forms are accepted; unsupported syntax returns line-specific parse errors.',
-	'`git apply` requires heredoc form and a standard unified diff body with `--- a/<path>` / `+++ b/<path>` headers and `@@ ... @@` hunk markers; one heredoc may contain multiple file patches stacked back-to-back, and `/dev/null` on either side creates or deletes a file.',
-	'For exact whole-file replacements (especially single-file job sources, freshly generated files, or any edit where you have the full new content), prefer `repo_write_file` over `git apply`; it avoids unified-diff context drift entirely.',
-	'For one-file edits to non-package repo-backed scheduled job source, prefer `job_update` with a replacement `code` string; it republishes the job module without needing a repo session.',
-].join(' '))
+	withProductionPackageSourceSafetyPolicy(
+		[
+			'Run a parsed git-only workflow in a Kody-managed repo session for MCP-native edits.',
+			'Use this for tool-only agents without local filesystem/git access; coding agents that can clone locally should prefer `package_get_git_remote` (saved packages only) plus `package_publish_external_push`.',
+			'Commands are newline-separated and parsed, not shell-executed.',
+			'Only supported git command forms are accepted; unsupported syntax returns line-specific parse errors.',
+			'`git apply` requires heredoc form and a standard unified diff body with `--- a/<path>` / `+++ b/<path>` headers and `@@ ... @@` hunk markers; one heredoc may contain multiple file patches stacked back-to-back, and `/dev/null` on either side creates or deletes a file.',
+			'For exact whole-file replacements (especially single-file job sources, freshly generated files, or any edit where you have the full new content), prefer `repo_write_file` over `git apply`; it avoids unified-diff context drift entirely.',
+			'For one-file edits to non-package repo-backed scheduled job source, prefer `job_update` with a replacement `code` string; it republishes the job module without needing a repo session.',
+		].join(' '),
+	)
 
 export const repoRunCommandsUnsupportedSyntaxDescription = [
 	'Only git commands are accepted.',

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands-text.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands-text.ts
@@ -1,3 +1,5 @@
+import { withProductionPackageSourceSafetyPolicy } from '#worker/repo/source-safety-policy.ts'
+
 export const repoRunCommandsSupportedForms = [
 	'git status [--short]',
 	'git diff',
@@ -14,7 +16,8 @@ export const repoRunCommandsSupportedForms = [
 	'git remote, git remote -v, git remote add <name> <url>, git remote remove <name>',
 ] as const
 
-export const repoRunCommandsCapabilityDescription = [
+export const repoRunCommandsCapabilityDescription =
+	withProductionPackageSourceSafetyPolicy([
 	'Run a parsed git-only workflow in a Kody-managed repo session for MCP-native edits.',
 	'Use this for tool-only agents without local filesystem/git access; coding agents that can clone locally should prefer `package_get_git_remote` (saved packages only) plus `package_publish_external_push`.',
 	'Commands are newline-separated and parsed, not shell-executed.',
@@ -22,7 +25,7 @@ export const repoRunCommandsCapabilityDescription = [
 	'`git apply` requires heredoc form and a standard unified diff body with `--- a/<path>` / `+++ b/<path>` headers and `@@ ... @@` hunk markers; one heredoc may contain multiple file patches stacked back-to-back, and `/dev/null` on either side creates or deletes a file.',
 	'For exact whole-file replacements (especially single-file job sources, freshly generated files, or any edit where you have the full new content), prefer `repo_write_file` over `git apply`; it avoids unified-diff context drift entirely.',
 	'For one-file edits to non-package repo-backed scheduled job source, prefer `job_update` with a replacement `code` string; it republishes the job module without needing a repo session.',
-].join(' ')
+].join(' '))
 
 export const repoRunCommandsUnsupportedSyntaxDescription = [
 	'Only git commands are accepted.',

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands-text.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands-text.ts
@@ -1,5 +1,3 @@
-import { withProductionPackageSourceSafetyPolicy } from '#worker/repo/source-safety-policy.ts'
-
 export const repoRunCommandsSupportedForms = [
 	'git status [--short]',
 	'git diff',
@@ -16,18 +14,15 @@ export const repoRunCommandsSupportedForms = [
 	'git remote, git remote -v, git remote add <name> <url>, git remote remove <name>',
 ] as const
 
-export const repoRunCommandsCapabilityDescription =
-	withProductionPackageSourceSafetyPolicy(
-		[
-			'Run a parsed git-only workflow in a Kody-managed repo session for MCP-native edits.',
-			'Use this for tool-only agents without local filesystem/git access; coding agents that can clone locally should prefer `package_get_git_remote` (saved packages only) plus `package_publish_external_push`.',
-			'Commands are newline-separated and parsed, not shell-executed.',
-			'Only supported git command forms are accepted; unsupported syntax returns line-specific parse errors.',
-			'`git apply` requires heredoc form and a standard unified diff body with `--- a/<path>` / `+++ b/<path>` headers and `@@ ... @@` hunk markers; one heredoc may contain multiple file patches stacked back-to-back, and `/dev/null` on either side creates or deletes a file.',
-			'For exact whole-file replacements (especially single-file job sources, freshly generated files, or any edit where you have the full new content), prefer `repo_write_file` over `git apply`; it avoids unified-diff context drift entirely.',
-			'For one-file edits to non-package repo-backed scheduled job source, prefer `job_update` with a replacement `code` string; it republishes the job module without needing a repo session.',
-		].join(' '),
-	)
+export const repoRunCommandsCapabilityDescription = [
+	'Run a parsed git-only workflow in a Kody-managed repo session for MCP-native edits.',
+	'Use this for tool-only agents without local filesystem/git access; coding agents that can clone locally should prefer `package_get_git_remote` (saved packages only) plus `package_publish_external_push`.',
+	'Commands are newline-separated and parsed, not shell-executed.',
+	'Only supported git command forms are accepted; unsupported syntax returns line-specific parse errors.',
+	'`git apply` requires heredoc form and a standard unified diff body with `--- a/<path>` / `+++ b/<path>` headers and `@@ ... @@` hunk markers; one heredoc may contain multiple file patches stacked back-to-back, and `/dev/null` on either side creates or deletes a file.',
+	'For exact whole-file replacements (especially single-file job sources, freshly generated files, or any edit where you have the full new content), prefer `repo_write_file` over `git apply`; it avoids unified-diff context drift entirely.',
+	'For one-file edits to non-package repo-backed scheduled job source, prefer `job_update` with a replacement `code` string; it republishes the job module without needing a repo session.',
+].join(' ')
 
 export const repoRunCommandsUnsupportedSyntaxDescription = [
 	'Only git commands are accepted.',

--- a/packages/worker/src/mcp/observability.workers.test.ts
+++ b/packages/worker/src/mcp/observability.workers.test.ts
@@ -250,13 +250,18 @@ test('package_save capability logs success for valid invocation', async () => {
 		entity_kind: 'package',
 		entity_id: 'package-1',
 		repo_id: 'package-package-1',
-		published_commit: 'published-commit-1',
-		indexed_commit: 'published-commit-1',
+		published_commit: null,
+		indexed_commit: null,
 		manifest_path: 'package.json',
 		source_root: '/',
 		created_at: '2026-04-13T00:00:00.000Z',
 		updated_at: '2026-04-13T00:00:00.000Z',
-		bootstrapAccess: null,
+		bootstrapAccess: {
+			defaultBranch: 'main',
+			remote: 'https://example.com/artifacts/package-package-1.git',
+			token: 'art_v1_bootstrap?expires=1760000000',
+			expiresAt: '2026-06-06T00:00:00.000Z',
+		},
 	})
 	console.info = ((tag: unknown, json?: unknown) => {
 		if (tag === 'mcp-event' && typeof json === 'string') {
@@ -463,6 +468,15 @@ test('package_save capability logs success for valid invocation', async () => {
 		)
 		expect((result as { package_id: string }).package_id).toBeTruthy()
 		expect((result as { has_app: boolean }).has_app).toBe(true)
+		expect(repoMockModule.syncArtifactSourceSnapshot).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sourceId: 'package-package-1',
+				destructiveOverwriteConfirmed: true,
+				bootstrapAccess: expect.objectContaining({
+					remote: 'https://example.com/artifacts/package-package-1.git',
+				}),
+			}),
+		)
 	} finally {
 		console.info = originalInfo
 	}

--- a/packages/worker/src/mcp/observability.workers.test.ts
+++ b/packages/worker/src/mcp/observability.workers.test.ts
@@ -244,6 +244,20 @@ test('package_save capability logs success for valid invocation', async () => {
 	const originalInfo = console.info
 	const payloads: Array<string> = []
 	resetRepoPersistenceMocks()
+	repoMockModule.ensureEntitySource.mockResolvedValue({
+		id: 'package-package-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'package-package-1',
+		published_commit: 'published-commit-1',
+		indexed_commit: 'published-commit-1',
+		manifest_path: 'package.json',
+		source_root: '/',
+		created_at: '2026-04-13T00:00:00.000Z',
+		updated_at: '2026-04-13T00:00:00.000Z',
+		bootstrapAccess: null,
+	})
 	console.info = ((tag: unknown, json?: unknown) => {
 		if (tag === 'mcp-event' && typeof json === 'string') {
 			payloads.push(json)
@@ -253,6 +267,7 @@ test('package_save capability logs success for valid invocation', async () => {
 		const handler = capabilityMap['package_save'].handler
 		const result = await handler(
 			{
+				confirm_destructive_overwrite: true,
 				files: [
 					{
 						path: 'package.json',

--- a/packages/worker/src/repo/external-publish.node.test.ts
+++ b/packages/worker/src/repo/external-publish.node.test.ts
@@ -5,6 +5,7 @@ const mockModule = vi.hoisted(() => ({
 	updateEntitySource: vi.fn(async () => true),
 	runRepoChecks: vi.fn(),
 	writePublishedSourceSnapshot: vi.fn(async () => 'snapshot-key'),
+	loadPublishedSourceSnapshot: vi.fn(),
 	refreshSavedPackageProjection: vi.fn(),
 	hasPublishedRuntimeArtifacts: vi.fn(() => false),
 }))
@@ -23,6 +24,8 @@ vi.mock('./checks.ts', () => ({
 vi.mock('#worker/package-runtime/published-runtime-artifacts.ts', () => ({
 	hasPublishedRuntimeArtifacts: (...args: Array<unknown>) =>
 		mockModule.hasPublishedRuntimeArtifacts(...args),
+	loadPublishedSourceSnapshot: (...args: Array<unknown>) =>
+		mockModule.loadPublishedSourceSnapshot(...args),
 	writePublishedSourceSnapshot: (...args: Array<unknown>) =>
 		mockModule.writePublishedSourceSnapshot(...args),
 }))
@@ -62,6 +65,9 @@ function workspace() {
 // eslint-disable-next-line epic-web/prefer-dispose-in-tests -- restores shared default mock behavior after global mockReset.
 beforeEach(() => {
 	mockModule.writePublishedSourceSnapshot.mockResolvedValue('snapshot-key')
+	mockModule.loadPublishedSourceSnapshot.mockResolvedValue({
+		files: { 'package.json': '{}' },
+	})
 	mockModule.hasPublishedRuntimeArtifacts.mockReturnValue(false)
 })
 
@@ -176,14 +182,57 @@ test('refuses non-fast-forward publish unless allowForce is true', async () => {
 		status: 'not_fast_forward',
 		previous_commit: 'commit-old',
 		published_commit: 'commit-rewritten',
-		message:
-			'The external Artifacts HEAD is not a descendant of the current published commit. Retry with allow_force to publish it.',
+		message: expect.stringContaining(
+			'production package source safety policy',
+		),
 	})
 	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
 })
 
-test('allows non-fast-forward publish when allowForce is true', async () => {
+test('refuses non-fast-forward publish with allowForce but without destructive confirmation', async () => {
+	mockModule.getEntitySourceById.mockResolvedValue(source())
+
+	await expect(
+		publishFromExternalRef({
+			env: { APP_DB: {} } as Env,
+			sourceId: 'source-1',
+			userId: 'user-1',
+			newCommit: 'commit-rewritten',
+			isFastForward: async () => false,
+			allowForce: true,
+			workspace: workspace(),
+			files: { 'package.json': '{}' },
+			baseUrl: 'https://kody.test',
+		}),
+	).rejects.toThrow('confirm_destructive_overwrite')
+	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+})
+
+test('refuses non-fast-forward publish when the backup snapshot is missing', async () => {
+	mockModule.getEntitySourceById.mockResolvedValue(source())
+	mockModule.loadPublishedSourceSnapshot.mockResolvedValueOnce(null)
+
+	await expect(
+		publishFromExternalRef({
+			env: { APP_DB: {} } as Env,
+			sourceId: 'source-1',
+			userId: 'user-1',
+			newCommit: 'commit-rewritten',
+			isFastForward: async () => false,
+			allowForce: true,
+			destructiveOverwriteConfirmed: true,
+			workspace: workspace(),
+			files: { 'package.json': '{}' },
+			baseUrl: 'https://kody.test',
+		}),
+	).rejects.toThrow('Stop and report this source recovery problem')
+	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+})
+
+test('allows non-fast-forward publish when allowForce is true and destructive overwrite is confirmed', async () => {
 	mockModule.getEntitySourceById.mockResolvedValue(source())
 	mockModule.runRepoChecks.mockResolvedValue({
 		ok: true,
@@ -202,6 +251,7 @@ test('allows non-fast-forward publish when allowForce is true', async () => {
 		newCommit: 'commit-rewritten',
 		isFastForward: async () => false,
 		allowForce: true,
+		destructiveOverwriteConfirmed: true,
 		workspace: workspace(),
 		files: { 'package.json': '{}' },
 		baseUrl: 'https://kody.test',
@@ -244,8 +294,9 @@ test('rechecks fast-forward against the latest source row before publishing', as
 		status: 'not_fast_forward',
 		previous_commit: 'commit-concurrent',
 		published_commit: 'commit-new',
-		message:
-			'The external Artifacts HEAD is not a descendant of the current published commit. Retry with allow_force to publish it.',
+		message: expect.stringContaining(
+			'production package source safety policy',
+		),
 	})
 	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()

--- a/packages/worker/src/repo/external-publish.node.test.ts
+++ b/packages/worker/src/repo/external-publish.node.test.ts
@@ -182,7 +182,7 @@ test('refuses non-fast-forward publish unless allowForce is true', async () => {
 		status: 'not_fast_forward',
 		previous_commit: 'commit-old',
 		published_commit: 'commit-rewritten',
-		message: expect.stringContaining('production package source safety policy'),
+		message: expect.stringContaining('package source safety gate'),
 	})
 	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
@@ -292,7 +292,7 @@ test('rechecks fast-forward against the latest source row before publishing', as
 		status: 'not_fast_forward',
 		previous_commit: 'commit-concurrent',
 		published_commit: 'commit-new',
-		message: expect.stringContaining('production package source safety policy'),
+		message: expect.stringContaining('package source safety gate'),
 	})
 	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()

--- a/packages/worker/src/repo/external-publish.node.test.ts
+++ b/packages/worker/src/repo/external-publish.node.test.ts
@@ -182,9 +182,7 @@ test('refuses non-fast-forward publish unless allowForce is true', async () => {
 		status: 'not_fast_forward',
 		previous_commit: 'commit-old',
 		published_commit: 'commit-rewritten',
-		message: expect.stringContaining(
-			'production package source safety policy',
-		),
+		message: expect.stringContaining('production package source safety policy'),
 	})
 	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
@@ -294,9 +292,7 @@ test('rechecks fast-forward against the latest source row before publishing', as
 		status: 'not_fast_forward',
 		previous_commit: 'commit-concurrent',
 		published_commit: 'commit-new',
-		message: expect.stringContaining(
-			'production package source safety policy',
-		),
+		message: expect.stringContaining('production package source safety policy'),
 	})
 	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()

--- a/packages/worker/src/repo/external-publish.ts
+++ b/packages/worker/src/repo/external-publish.ts
@@ -10,6 +10,10 @@ import {
 	type EntitySourceRow,
 	type RepoExternalPublishResult,
 } from './types.ts'
+import {
+	assertPackageSourceOverwriteAllowed,
+	productionPackageSourceSafetyPolicy,
+} from './source-safety-policy.ts'
 
 export type RepoPublishWorkspace = {
 	readFile(path: string): Promise<string | null>
@@ -111,6 +115,7 @@ export async function publishFromExternalRef(input: {
 	newCommit: string
 	isFastForward(input: { previousCommit: string }): Promise<boolean>
 	allowForce?: boolean
+	destructiveOverwriteConfirmed?: boolean
 	workspace: RepoPublishWorkspace
 	files?: Record<string, string>
 	baseUrl: string
@@ -130,19 +135,28 @@ export async function publishFromExternalRef(input: {
 			published_commit: source.published_commit,
 		}
 	}
-	if (
-		source.published_commit &&
-		!input.allowForce &&
-		!(await input.isFastForward({
+	if (source.published_commit) {
+		const isFastForward = await input.isFastForward({
 			previousCommit: source.published_commit,
-		}))
-	) {
-		return {
-			status: 'not_fast_forward',
-			previous_commit: source.published_commit,
-			published_commit: input.newCommit,
-			message:
-				'The external Artifacts HEAD is not a descendant of the current published commit. Retry with allow_force to publish it.',
+		})
+		if (!isFastForward && !input.allowForce) {
+			return {
+				status: 'not_fast_forward',
+				previous_commit: source.published_commit,
+				published_commit: input.newCommit,
+				message:
+					'The external Artifacts HEAD is not a descendant of the current published commit. Retry only after satisfying the production package source safety policy and setting allow_force with explicit destructive overwrite confirmation. ' +
+					productionPackageSourceSafetyPolicy,
+			}
+		}
+		if (!isFastForward) {
+			await assertPackageSourceOverwriteAllowed({
+				env: input.env,
+				userId: input.userId,
+				source,
+				operation: 'package_publish_external_push force publish',
+				confirmed: input.destructiveOverwriteConfirmed,
+			})
 		}
 	}
 	const checks = await runRepoChecks({

--- a/packages/worker/src/repo/external-publish.ts
+++ b/packages/worker/src/repo/external-publish.ts
@@ -10,9 +10,7 @@ import {
 	type EntitySourceRow,
 	type RepoExternalPublishResult,
 } from './types.ts'
-import {
-	assertPackageSourceOverwriteAllowed,
-} from './source-safety-policy.ts'
+import { assertPackageSourceOverwriteAllowed } from './source-safety-policy.ts'
 
 export type RepoPublishWorkspace = {
 	readFile(path: string): Promise<string | null>

--- a/packages/worker/src/repo/external-publish.ts
+++ b/packages/worker/src/repo/external-publish.ts
@@ -12,7 +12,6 @@ import {
 } from './types.ts'
 import {
 	assertPackageSourceOverwriteAllowed,
-	productionPackageSourceSafetyPolicy,
 } from './source-safety-policy.ts'
 
 export type RepoPublishWorkspace = {
@@ -145,8 +144,7 @@ export async function publishFromExternalRef(input: {
 				previous_commit: source.published_commit,
 				published_commit: input.newCommit,
 				message:
-					'The external Artifacts HEAD is not a descendant of the current published commit. Retry only after satisfying the production package source safety policy and setting allow_force with explicit destructive overwrite confirmation. ' +
-					productionPackageSourceSafetyPolicy,
+					'The external Artifacts HEAD is not a descendant of the current published commit. Retry only after satisfying the package source safety gate and setting allow_force with explicit destructive overwrite confirmation.',
 			}
 		}
 		if (!isFastForward) {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -1563,7 +1563,7 @@ class RepoSessionBase extends DurableObject<Env> {
 					'The source repo has moved since this session opened. Rebase the session before publishing.',
 			}
 		}
-		if (input.force === true) {
+		if (input.force === true && source.entity_kind === 'package') {
 			await assertPackageSourceOverwriteAllowed({
 				env: this.env,
 				userId: input.userId,

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -64,6 +64,10 @@ import {
 	publishFromExternalRef as publishExternalRefSource,
 } from './external-publish.ts'
 import {
+	assertPackageSourceOverwriteAllowed,
+	buildSourceRecoveryProblemMessage,
+} from './source-safety-policy.ts'
+import {
 	attachPublishGitNoteBestEffort,
 	buildPublishGitNote,
 	type KodyPublishGitNoteChecks,
@@ -1524,6 +1528,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		sessionId: string
 		userId: string
 		force?: boolean
+		destructiveOverwriteConfirmed?: boolean
 		rebuildPackageArtifacts?: boolean
 		expectedPackageScope?: string
 	}): Promise<RepoSessionPublishResult> {
@@ -1557,6 +1562,15 @@ class RepoSessionBase extends DurableObject<Env> {
 				message:
 					'The source repo has moved since this session opened. Rebase the session before publishing.',
 			}
+		}
+		if (input.force === true) {
+			await assertPackageSourceOverwriteAllowed({
+				env: this.env,
+				userId: input.userId,
+				source,
+				operation: 'repo forced publish',
+				confirmed: input.destructiveOverwriteConfirmed,
+			})
 		}
 		const sourceRepo = await resolveArtifactSourceRepo(this.env, source.repo_id)
 		const sourceInfo = await sourceRepo.info()
@@ -1641,6 +1655,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		newCommit: string
 		expectedHead?: string | null
 		allowForce?: boolean
+		destructiveOverwriteConfirmed?: boolean
 		baseUrl?: string
 		rebuildPackageArtifacts?: boolean
 		expectedPackageScope?: string
@@ -1670,20 +1685,32 @@ class RepoSessionBase extends DurableObject<Env> {
 		await this.workspace.mkdir(repoSessionWorkspacePrefix, {
 			recursive: true,
 		})
-		await this.git.clone({
-			dir: repoSessionWorkspacePrefix,
-			branch: targetBranch,
-			singleBranch: true,
-			...buildGitCloneAuth({
-				remote: sourceAccess.remote,
-				token: sourceAccess.token,
-			}),
-		})
-		await this.git.checkout({
-			dir: repoSessionWorkspacePrefix,
-			ref: input.newCommit,
-			force: true,
-		})
+		try {
+			await this.git.clone({
+				dir: repoSessionWorkspacePrefix,
+				branch: targetBranch,
+				singleBranch: true,
+				...buildGitCloneAuth({
+					remote: sourceAccess.remote,
+					token: sourceAccess.token,
+				}),
+			})
+			await this.git.checkout({
+				dir: repoSessionWorkspacePrefix,
+				ref: input.newCommit,
+				force: true,
+			})
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			throw new Error(
+				buildSourceRecoveryProblemMessage({
+					source,
+					operation: 'package_publish_external_push',
+					reason: `source clone or commit checkout failed: ${message}`,
+				}),
+				{ cause: error },
+			)
+		}
 		const runId = crypto.randomUUID()
 		const publishResult = await publishExternalRefSource({
 			env: this.env,
@@ -1697,6 +1724,7 @@ class RepoSessionBase extends DurableObject<Env> {
 					descendant: input.newCommit,
 				}),
 			allowForce: input.allowForce,
+			destructiveOverwriteConfirmed: input.destructiveOverwriteConfirmed,
 			workspace: this.workspace,
 			baseUrl: input.baseUrl ?? source.source_root,
 			manifestPath: resolveRepoWorkspacePath(

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -123,6 +123,7 @@ export type RepoSessionRpc = {
 		sessionId: string
 		userId: string
 		force?: boolean
+		destructiveOverwriteConfirmed?: boolean
 		rebuildPackageArtifacts?: boolean
 		expectedPackageScope?: string
 	}) => Promise<RepoSessionPublishResult>
@@ -133,6 +134,7 @@ export type RepoSessionRpc = {
 		newCommit: string
 		expectedHead?: string | null
 		allowForce?: boolean
+		destructiveOverwriteConfirmed?: boolean
 		baseUrl?: string
 		rebuildPackageArtifacts?: boolean
 		expectedPackageScope?: string

--- a/packages/worker/src/repo/source-safety-policy.node.test.ts
+++ b/packages/worker/src/repo/source-safety-policy.node.test.ts
@@ -54,6 +54,16 @@ function createEnvWithSnapshot(files: Record<string, string> | null) {
 	} as unknown as Env
 }
 
+function createEnvWithRawSnapshot(snapshot: unknown) {
+	return {
+		BUNDLE_ARTIFACTS_KV: {
+			async get(_key: string, type?: 'text' | 'json') {
+				return type === 'json' ? snapshot : null
+			},
+		},
+	} as unknown as Env
+}
+
 test('package source overwrite requires explicit destructive confirmation before snapshot verification', async () => {
 	await expect(
 		assertPackageSourceOverwriteAllowed({
@@ -83,6 +93,20 @@ test('restorable package source snapshot verification rejects missing and corrup
 			operation: 'package_publish_external_push force publish',
 		}),
 	).rejects.toThrow('missing manifest "package.json"')
+
+	await expect(
+		assertRestorablePackageSourceSnapshot({
+			env: createEnvWithRawSnapshot({
+				version: 1,
+				sourceId: 'source-1',
+				publishedCommit: 'commit-1',
+				files: null,
+			}),
+			userId: 'user-1',
+			source: packageSource(),
+			operation: 'package_publish_external_push force publish',
+		}),
+	).rejects.toThrow('the published source snapshot is missing or malformed')
 })
 
 test('restorable package source snapshot verification accepts a manifest-bearing snapshot', async () => {

--- a/packages/worker/src/repo/source-safety-policy.node.test.ts
+++ b/packages/worker/src/repo/source-safety-policy.node.test.ts
@@ -1,0 +1,122 @@
+import { expect, test } from 'vitest'
+import {
+	assertPackageSourceOverwriteAllowed,
+	assertRestorablePackageSourceSnapshot,
+	destructiveOverwriteConfirmationField,
+	productionPackageSourceSafetyPolicy,
+} from './source-safety-policy.ts'
+import { savePackageCapability } from '#mcp/capabilities/packages/save-package.ts'
+import { publishExternalPushCapability } from '#mcp/capabilities/packages/publish-external-push.ts'
+import { getGitRemoteCapability } from '#mcp/capabilities/packages/get-git-remote.ts'
+import { repoPublishSessionCapability } from '#mcp/capabilities/repo/repo-publish-session.ts'
+import { repoRunCommandsCapabilityDescription } from '#mcp/capabilities/repo/repo-run-commands-text.ts'
+import { type EntitySourceRow } from './types.ts'
+
+function packageSource(
+	overrides: Partial<EntitySourceRow> = {},
+): EntitySourceRow {
+	return {
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'repo-1',
+		published_commit: 'commit-1',
+		indexed_commit: 'commit-1',
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		created_at: '2026-06-06T00:00:00.000Z',
+		updated_at: '2026-06-06T00:00:00.000Z',
+		...overrides,
+	}
+}
+
+function createEnvWithSnapshot(files: Record<string, string> | null) {
+	return {
+		BUNDLE_ARTIFACTS_KV: {
+			async get(_key: string, type?: 'text' | 'json') {
+				if (type !== 'json' || files == null) return null
+				return {
+					version: 1,
+					sourceId: 'source-1',
+					repoId: 'repo-1',
+					entityKind: 'package',
+					entityId: 'package-1',
+					publishedCommit: 'commit-1',
+					manifestPath: 'package.json',
+					sourceRoot: '/',
+					files,
+					createdAt: '2026-06-06T00:00:00.000Z',
+				}
+			},
+		},
+	} as unknown as Env
+}
+
+test('package source overwrite requires explicit destructive confirmation before snapshot verification', async () => {
+	await expect(
+		assertPackageSourceOverwriteAllowed({
+			env: createEnvWithSnapshot({ 'package.json': '{}' }),
+			userId: 'user-1',
+			source: packageSource(),
+			operation: 'package_save',
+		}),
+	).rejects.toThrow(destructiveOverwriteConfirmationField)
+})
+
+test('restorable package source snapshot verification rejects missing and corrupt snapshots with recovery guidance', async () => {
+	await expect(
+		assertRestorablePackageSourceSnapshot({
+			env: createEnvWithSnapshot(null),
+			userId: 'user-1',
+			source: packageSource(),
+			operation: 'package_publish_external_push force publish',
+		}),
+	).rejects.toThrow('Stop and report this source recovery problem')
+
+	await expect(
+		assertRestorablePackageSourceSnapshot({
+			env: createEnvWithSnapshot({ 'src/index.ts': 'export {}' }),
+			userId: 'user-1',
+			source: packageSource(),
+			operation: 'package_publish_external_push force publish',
+		}),
+	).rejects.toThrow('missing manifest "package.json"')
+})
+
+test('restorable package source snapshot verification accepts a manifest-bearing snapshot', async () => {
+	await expect(
+		assertRestorablePackageSourceSnapshot({
+			env: createEnvWithSnapshot({
+				'package.json': '{"name":"@user/demo"}',
+				'src/index.ts': 'export {}',
+			}),
+			userId: 'user-1',
+			source: packageSource(),
+			operation: 'package_get_git_remote write access',
+		}),
+	).resolves.toEqual({
+		sourceId: 'source-1',
+		publishedCommit: 'commit-1',
+		fileCount: 2,
+	})
+})
+
+test('package mutation capabilities surface the canonical production source safety policy', () => {
+	expect(savePackageCapability.description).toContain(
+		productionPackageSourceSafetyPolicy,
+	)
+	expect(publishExternalPushCapability.description).toContain(
+		productionPackageSourceSafetyPolicy,
+	)
+	expect(getGitRemoteCapability.description).toContain(
+		productionPackageSourceSafetyPolicy,
+	)
+	expect(repoPublishSessionCapability.description).toContain(
+		productionPackageSourceSafetyPolicy,
+	)
+	expect(repoRunCommandsCapabilityDescription).toContain(
+		productionPackageSourceSafetyPolicy,
+	)
+})

--- a/packages/worker/src/repo/source-safety-policy.node.test.ts
+++ b/packages/worker/src/repo/source-safety-policy.node.test.ts
@@ -131,16 +131,16 @@ test('package mutation capabilities surface the canonical production source safe
 	expect(savePackageCapability.description).toContain(
 		productionPackageSourceSafetyPolicy,
 	)
-	expect(publishExternalPushCapability.description).toContain(
+	expect(publishExternalPushCapability.description).not.toContain(
 		productionPackageSourceSafetyPolicy,
 	)
-	expect(getGitRemoteCapability.description).toContain(
+	expect(getGitRemoteCapability.description).not.toContain(
 		productionPackageSourceSafetyPolicy,
 	)
-	expect(repoPublishSessionCapability.description).toContain(
+	expect(repoPublishSessionCapability.description).not.toContain(
 		productionPackageSourceSafetyPolicy,
 	)
-	expect(repoRunCommandsCapabilityDescription).toContain(
+	expect(repoRunCommandsCapabilityDescription).not.toContain(
 		productionPackageSourceSafetyPolicy,
 	)
 })

--- a/packages/worker/src/repo/source-safety-policy.ts
+++ b/packages/worker/src/repo/source-safety-policy.ts
@@ -10,10 +10,6 @@ export const destructiveOverwriteConfirmationField =
 export const destructiveOverwriteConfirmationDescription =
 	'Set to true only when the user explicitly approved destructive overwrite of existing package source history. Kody still verifies a restorable backup snapshot before publishing.'
 
-export function withProductionPackageSourceSafetyPolicy(description: string) {
-	return `${description} ${productionPackageSourceSafetyPolicy}`
-}
-
 export function buildSourceRecoveryProblemMessage(input: {
 	source: EntitySourceRow
 	operation: string
@@ -24,7 +20,6 @@ export function buildSourceRecoveryProblemMessage(input: {
 		`${input.operation} stopped by the production package source safety policy.`,
 		`Kody could not verify a restorable backup snapshot for source "${input.source.id}" at published commit "${publishedCommit}": ${input.reason}`,
 		'Stop and report this source recovery problem instead of rebuilding or overwriting the package in place.',
-		productionPackageSourceSafetyPolicy,
 	].join(' ')
 }
 
@@ -35,7 +30,6 @@ function buildDestructiveOverwriteConfirmationMessage(input: {
 	return [
 		`${input.operation} would overwrite existing package source "${input.source.id}".`,
 		`Set ${destructiveOverwriteConfirmationField}: true only after the user explicitly approves destructive overwrite; Kody will also verify a restorable backup snapshot first.`,
-		productionPackageSourceSafetyPolicy,
 	].join(' ')
 }
 

--- a/packages/worker/src/repo/source-safety-policy.ts
+++ b/packages/worker/src/repo/source-safety-policy.ts
@@ -84,6 +84,19 @@ export async function assertRestorablePackageSourceSnapshot(input: {
 			}),
 		)
 	}
+	if (
+		typeof snapshot.files !== 'object' ||
+		snapshot.files == null ||
+		Array.isArray(snapshot.files)
+	) {
+		throw new Error(
+			buildSourceRecoveryProblemMessage({
+				source: input.source,
+				operation: input.operation,
+				reason: 'the published source snapshot is missing or malformed',
+			}),
+		)
+	}
 	const files = snapshot.files
 	const fileCount = Object.keys(files).length
 	const manifestContent = files[input.source.manifest_path]

--- a/packages/worker/src/repo/source-safety-policy.ts
+++ b/packages/worker/src/repo/source-safety-policy.ts
@@ -1,0 +1,134 @@
+import { loadPublishedSourceSnapshot } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { type EntitySourceRow } from './types.ts'
+
+export const productionPackageSourceSafetyPolicy =
+	'Production package source safety policy: never replace source history, force publish, or package_save over an existing package unless Kody has created a restorable backup snapshot and the user explicitly approved destructive overwrite. If existing source cannot be cloned or verified, stop and report the source recovery problem.'
+
+export const destructiveOverwriteConfirmationField =
+	'confirm_destructive_overwrite'
+
+export const destructiveOverwriteConfirmationDescription =
+	'Set to true only when the user explicitly approved destructive overwrite of existing package source history. Kody still verifies a restorable backup snapshot before publishing.'
+
+export function withProductionPackageSourceSafetyPolicy(description: string) {
+	return `${description} ${productionPackageSourceSafetyPolicy}`
+}
+
+export function buildSourceRecoveryProblemMessage(input: {
+	source: EntitySourceRow
+	operation: string
+	reason: string
+}) {
+	const publishedCommit = input.source.published_commit ?? 'none'
+	return [
+		`${input.operation} stopped by the production package source safety policy.`,
+		`Kody could not verify a restorable backup snapshot for source "${input.source.id}" at published commit "${publishedCommit}": ${input.reason}`,
+		'Stop and report this source recovery problem instead of rebuilding or overwriting the package in place.',
+		productionPackageSourceSafetyPolicy,
+	].join(' ')
+}
+
+function buildDestructiveOverwriteConfirmationMessage(input: {
+	source: EntitySourceRow
+	operation: string
+}) {
+	return [
+		`${input.operation} would overwrite existing package source "${input.source.id}".`,
+		`Set ${destructiveOverwriteConfirmationField}: true only after the user explicitly approves destructive overwrite; Kody will also verify a restorable backup snapshot first.`,
+		productionPackageSourceSafetyPolicy,
+	].join(' ')
+}
+
+export async function assertRestorablePackageSourceSnapshot(input: {
+	env: Env
+	userId: string
+	source: EntitySourceRow
+	operation: string
+}) {
+	if (input.source.entity_kind !== 'package') {
+		return null
+	}
+	if (!input.source.published_commit) {
+		throw new Error(
+			buildSourceRecoveryProblemMessage({
+				source: input.source,
+				operation: input.operation,
+				reason: 'the source has no published commit',
+			}),
+		)
+	}
+	let snapshot: Awaited<ReturnType<typeof loadPublishedSourceSnapshot>>
+	try {
+		snapshot = await loadPublishedSourceSnapshot({
+			env: input.env,
+			userId: input.userId,
+			source: input.source,
+		})
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		throw new Error(
+			buildSourceRecoveryProblemMessage({
+				source: input.source,
+				operation: input.operation,
+				reason: message,
+			}),
+			{ cause: error },
+		)
+	}
+	if (!snapshot) {
+		throw new Error(
+			buildSourceRecoveryProblemMessage({
+				source: input.source,
+				operation: input.operation,
+				reason: 'no published source snapshot was found',
+			}),
+		)
+	}
+	const files = snapshot.files
+	const fileCount = Object.keys(files).length
+	const manifestContent = files[input.source.manifest_path]
+	if (fileCount === 0) {
+		throw new Error(
+			buildSourceRecoveryProblemMessage({
+				source: input.source,
+				operation: input.operation,
+				reason: 'the published source snapshot is empty',
+			}),
+		)
+	}
+	if (typeof manifestContent !== 'string' || manifestContent.trim() === '') {
+		throw new Error(
+			buildSourceRecoveryProblemMessage({
+				source: input.source,
+				operation: input.operation,
+				reason: `the published source snapshot is missing manifest "${input.source.manifest_path}"`,
+			}),
+		)
+	}
+	return {
+		sourceId: input.source.id,
+		publishedCommit: input.source.published_commit,
+		fileCount,
+	}
+}
+
+export async function assertPackageSourceOverwriteAllowed(input: {
+	env: Env
+	userId: string
+	source: EntitySourceRow
+	operation: string
+	confirmed?: boolean
+}) {
+	if (input.source.entity_kind !== 'package') {
+		return null
+	}
+	if (input.confirmed !== true) {
+		throw new Error(
+			buildDestructiveOverwriteConfirmationMessage({
+				source: input.source,
+				operation: input.operation,
+			}),
+		)
+	}
+	return await assertRestorablePackageSourceSnapshot(input)
+}

--- a/packages/worker/src/repo/source-sync.ts
+++ b/packages/worker/src/repo/source-sync.ts
@@ -21,6 +21,7 @@ type SyncArtifactSourceInput = {
 	sourceId: string | null
 	files: Record<string, string>
 	bootstrapAccess?: ArtifactBootstrapAccess | null
+	destructiveOverwriteConfirmed?: boolean
 }
 
 function validateEntitySourceManifest(input: {
@@ -183,6 +184,9 @@ export async function syncArtifactSourceSnapshot(
 			sessionId,
 			userId: input.userId,
 			force: true,
+			...(input.destructiveOverwriteConfirmed === true
+				? { destructiveOverwriteConfirmed: true }
+				: {}),
 		})
 		if (publishResult.status !== 'ok') {
 			throw new Error(publishResult.message)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds the canonical production package source safety policy at `packages/worker/src/repo/source-safety-policy.ts`.
- Surfaces the full policy text in one capability/help location: `package_save`, the direct whole-source replacement entry point.
- Keeps clone/publish/session capabilities concise while preserving the runtime gates for explicit destructive overwrite confirmation and restorable snapshot verification.

## Enforcement notes
- `package_save` verifies the existing package source snapshot before syncing replacement files and requires `confirm_destructive_overwrite` for existing package replacement.
- If an existing package Artifacts repo was recreated and `ensureEntitySource` clears `published_commit`, `package_save` verifies the pre-recreation canonical package entity source snapshot before allowing confirmed recovery/bootstrap.
- `package_save` verifies against the canonical package entity source, not a potentially stale saved-package `source_id` pointer.
- `package_publish_external_push` / external publish rejects non-fast-forward force publishes unless `allow_force` and `confirm_destructive_overwrite` are provided and the current published snapshot is restorable.
- Repo forced publish RPC paths call the shared policy guard only for package sources.
- `package_get_git_remote` verifies a restorable package source snapshot before minting write access, so agents stop before clone/edit/publish if the original source cannot be recovered.

## Validation
- `npx vitest run --project node-unit packages/worker/src/repo/source-safety-policy.node.test.ts packages/worker/src/repo/external-publish.node.test.ts packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts`
- `npx vitest run --project workers-unit packages/worker/src/mcp/observability.workers.test.ts`
- `npx vitest run --project node-unit packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts packages/worker/src/repo/source-safety-policy.node.test.ts`
- `npx vitest run --project workers-unit packages/worker/src/mcp/observability.workers.test.ts && npx vitest run --project node-unit packages/worker/src/repo/source-safety-policy.node.test.ts`
- `npx vitest run --project node-unit packages/worker/src/repo/source-safety-policy.node.test.ts packages/worker/src/repo/external-publish.node.test.ts`
- `npx vitest run --project workers-unit packages/worker/src/mcp/observability.workers.test.ts && npx vitest run --project node-unit packages/worker/src/repo/source-safety-policy.node.test.ts packages/worker/src/repo/external-publish.node.test.ts`
- `npm run format:check && npm run lint && npm run typecheck`
- `npm run validate`
- PR CI after latest push: `✅ Validate` passed, preview deploy passed, CodeRabbit passed, Cursor Bugbot passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebe0297c-76d4-4f6b-b753-1348cf70ae30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebe0297c-76d4-4f6b-b753-1348cf70ae30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit confirmation requirement for destructive package operations (overwrites, force publishes).
  * Implemented source snapshot backup validation to ensure package recovery capability before allowing destructive changes.

* **Improvements**
  * Enhanced error messaging for non-fast-forward publish scenarios with clearer safety policy guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->