### PR TITLE
Validate package artifact source heads

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
@@ -4,7 +4,8 @@ const mockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
 	getSavedPackageByKodyId: vi.fn(),
 	getEntitySourceById: vi.fn(),
-	resolveArtifactSourceRepo: vi.fn(),
+	resolveArtifactDefaultBranchHead: vi.fn(),
+	resolveExistingArtifactSourceRepo: vi.fn(),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -23,8 +24,10 @@ vi.mock('#worker/repo/artifacts.ts', async () => {
 	const actual = await vi.importActual('#worker/repo/artifacts.ts')
 	return {
 		...(actual as object),
-		resolveArtifactSourceRepo: (...args: Array<unknown>) =>
-			mockModule.resolveArtifactSourceRepo(...args),
+		resolveArtifactDefaultBranchHead: (...args: Array<unknown>) =>
+			mockModule.resolveArtifactDefaultBranchHead(...args),
+		resolveExistingArtifactSourceRepo: (...args: Array<unknown>) =>
+			mockModule.resolveExistingArtifactSourceRepo(...args),
 	}
 })
 
@@ -115,13 +118,20 @@ function mockPackageSource(sourceUserId = 'user-1') {
 		scope,
 		expiresAt: new Date(Date.now() + ttl * 1000).toISOString(),
 	}))
-	mockModule.resolveArtifactSourceRepo.mockResolvedValue({
+	const repo = {
 		info: vi.fn(async () => ({
 			remote:
 				'https://acct.artifacts.cloudflare.net/git/default/package-package-1.git',
 			defaultBranch: 'main',
 		})),
 		createToken,
+	}
+	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue(repo)
+	mockModule.resolveArtifactDefaultBranchHead.mockResolvedValue({
+		remote:
+			'https://acct.artifacts.cloudflare.net/git/default/package-package-1.git',
+		defaultBranch: 'main',
+		commit: 'commit-1',
 	})
 	return { createToken }
 }
@@ -191,4 +201,20 @@ test('get_git_remote returns scoped artifact remotes and rejects invalid input',
 			createContext(),
 		),
 	).rejects.toThrow()
+})
+
+test('get_git_remote rejects package sources whose artifact repo has no default branch HEAD', async () => {
+	resetMocks()
+	const { createToken } = mockPackageSource()
+	mockModule.resolveArtifactDefaultBranchHead.mockResolvedValueOnce(null)
+
+	await expect(
+		getGitRemoteCapability.handler(
+			{ package_id: 'package-1', ttl_seconds: 1800 },
+			createContext(),
+		),
+	).rejects.toThrow(
+		'artifact source repo "package-package-1" default branch has no HEAD',
+	)
+	expect(createToken).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
@@ -6,9 +6,11 @@ import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import {
 	buildAuthenticatedArtifactsRemote,
 	parseArtifactTokenSecret,
-	resolveArtifactSourceRepo,
 } from '#worker/repo/artifacts.ts'
-import { assertRestorablePackageSourceSnapshot } from '#worker/repo/source-safety-policy.ts'
+import {
+	assertPublishedPackageSourceRepoHead,
+	assertRestorablePackageSourceSnapshot,
+} from '#worker/repo/source-safety-policy.ts'
 import { resolveOwnedPackageSource } from './resolve-package-source.ts'
 
 const getGitRemoteInputSchema = z.object({
@@ -75,31 +77,35 @@ export const getGitRemoteCapability = defineDomainCapability(
 					operation: 'package_get_git_remote write access',
 				})
 			}
-			const repo = await resolveArtifactSourceRepo(ctx.env, source.repo_id)
-			const info = await repo.info()
-			if (!info?.remote) {
-				throw new Error('Artifact repo remote URL is unavailable.')
+			const sourceHead = await assertPublishedPackageSourceRepoHead({
+				env: ctx.env,
+				source,
+				operation: 'package_get_git_remote',
+			})
+			if (!sourceHead) {
+				throw new Error('package_get_git_remote requires a package source.')
 			}
+			const { repo } = sourceHead
 			const token = await repo.createToken(args.scope, args.ttl_seconds)
 			const gitExtraHeader = `Authorization: Bearer ${parseArtifactTokenSecret(token.plaintext)}`
 			const cloneDirectory = source.entity_id
 			return {
-				remote: info.remote,
+				remote: sourceHead.remote,
 				authenticated_remote: buildAuthenticatedArtifactsRemote({
-					remote: info.remote,
+					remote: sourceHead.remote,
 					token: token.plaintext,
 				}),
 				git_extra_header: gitExtraHeader,
 				scope: args.scope,
 				expires_at: token.expiresAt,
 				setup_commands: [
-					`git -c http.extraHeader=${shellQuote(gitExtraHeader)} clone ${shellQuote(info.remote)} ${shellQuote(cloneDirectory)}`,
+					`git -c http.extraHeader=${shellQuote(gitExtraHeader)} clone ${shellQuote(sourceHead.remote)} ${shellQuote(cloneDirectory)}`,
 					`cd ${shellQuote(cloneDirectory)}`,
-					`git remote add kody ${shellQuote(info.remote)}`,
+					`git remote add kody ${shellQuote(sourceHead.remote)}`,
 					`git config remote.kody.fetch '+refs/heads/*:refs/remotes/kody/*'`,
 					`git config --add remote.kody.fetch '+refs/notes/*:refs/notes/*'`,
 					`git -c http.extraHeader=${shellQuote(gitExtraHeader)} fetch kody 'refs/notes/*:refs/notes/*'`,
-					`git -c http.extraHeader=${shellQuote(gitExtraHeader)} push kody HEAD:${shellQuote(info.defaultBranch ?? 'main')}`,
+					`git -c http.extraHeader=${shellQuote(gitExtraHeader)} push kody HEAD:${shellQuote(sourceHead.defaultBranch)}`,
 				],
 			}
 		},

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -7,7 +7,9 @@ const {
 	getArtifactsBinding,
 	getArtifactsNamespace,
 	parseArtifactTokenSecret,
+	resolveArtifactSourceHead,
 	resolveArtifactSourceRepo,
+	resolveExistingArtifactSourceRepo,
 	resolveSessionRepo,
 } = await import('./artifacts.ts')
 
@@ -461,6 +463,44 @@ test('ensureArtifactRepoReady rereads after concurrent create conflicts', async 
 		repo: expect.any(Object),
 	})
 	expect(fetchMock).toHaveBeenCalledTimes(3)
+})
+
+test('source repo HEAD lookup does not recreate missing artifact repos', async () => {
+	const fetchMock = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			if (method === 'GET' && url.pathname.endsWith('/repos/repo-1')) {
+				return new Response(
+					JSON.stringify({
+						success: false,
+						result: null,
+						errors: [{ code: 1000, message: 'Repo not found' }],
+						messages: [],
+					}),
+					{
+						status: 404,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
+		})
+	const env = {
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token-123',
+		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+	} as Env
+
+	await expect(resolveExistingArtifactSourceRepo(env, 'repo-1')).resolves.toBe(
+		null,
+	)
+	await expect(resolveArtifactSourceHead(env, 'repo-1')).resolves.toEqual({
+		branch: 'main',
+		commit: null,
+	})
+	expect(fetchMock).toHaveBeenCalledTimes(2)
 })
 
 test('ensureArtifactRepoReady does not swallow generic create conflicts', async () => {

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -748,6 +748,23 @@ export async function resolveArtifactSourceRepo(env: Env, repoId: string) {
 	return result.repo
 }
 
+export async function resolveExistingArtifactSourceRepo(
+	env: Env,
+	repoId: string,
+	binding: ArtifactNamespaceBinding = getArtifactsBinding(env),
+) {
+	const result = await binding.get(repoId)
+	if (result.status === 'ready') {
+		return result.repo
+	}
+	if (result.status === 'not_found') {
+		return null
+	}
+	throw new Error(
+		`Artifacts repo "${repoId}" is ${result.status}. Retry after ${result.retryAfter}s.`,
+	)
+}
+
 export async function resolveSessionRepo(
 	env: Env,
 	input: { namespace?: string | null; name: string },
@@ -765,7 +782,13 @@ export async function resolveSessionRepo(
 }
 
 export async function resolveArtifactSourceHead(env: Env, repoId: string) {
-	const repo = await resolveArtifactSourceRepo(env, repoId)
+	const repo = await resolveExistingArtifactSourceRepo(env, repoId)
+	if (!repo) {
+		return {
+			branch: 'main',
+			commit: null,
+		}
+	}
 	const ref = await resolveArtifactDefaultBranchHead({ repo })
 	return {
 		branch: ref?.defaultBranch ?? 'main',

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -92,6 +92,7 @@ const mockModule = vi.hoisted(() => {
 		updateEntitySource: vi.fn(async () => undefined),
 		resolveSessionRepo: vi.fn(),
 		resolveArtifactSourceRepo: vi.fn(),
+		resolveExistingArtifactSourceRepo: vi.fn(),
 		resolveArtifactDefaultBranchHead: vi.fn(async () => ({
 			defaultBranch: 'main',
 			commit: 'commit-published-new',
@@ -138,6 +139,22 @@ function restoreRepoSessionMockBaseline() {
 	mockModule.storagePut.mockResolvedValue(undefined)
 	mockModule.updateRepoSession.mockResolvedValue(undefined)
 	mockModule.updateEntitySource.mockResolvedValue(undefined)
+	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
+		fork: vi.fn(async ({ name }: { name: string }) => ({
+			id: 'session-repo-1',
+			name,
+			description: null,
+			defaultBranch: 'main',
+			remote: `https://acct.artifacts.cloudflare.net/git/default/${name}.git`,
+			token: 'art_session_secret?expires=1760000200',
+			expiresAt: '2026-10-09T08:16:40.000Z',
+			repo: {
+				info: vi.fn(),
+				createToken: vi.fn(),
+				fork: vi.fn(),
+			},
+		})),
+	})
 	mockModule.resolveArtifactDefaultBranchHead.mockResolvedValue({
 		defaultBranch: 'main',
 		commit: 'commit-published-new',
@@ -286,6 +303,8 @@ vi.mock('./artifacts.ts', async () => {
 			mockModule.resolveSessionRepo(...args),
 		resolveArtifactSourceRepo: (...args: Array<unknown>) =>
 			mockModule.resolveArtifactSourceRepo(...args),
+		resolveExistingArtifactSourceRepo: (...args: Array<unknown>) =>
+			mockModule.resolveExistingArtifactSourceRepo(...args),
 		resolveArtifactDefaultBranchHead: (...args: Array<unknown>) =>
 			mockModule.resolveArtifactDefaultBranchHead(...args),
 	}
@@ -905,6 +924,86 @@ test('openSession persists ARTIFACTS_NAMESPACE as session_repo_namespace', async
 			session_repo_namespace: 'preview',
 		}),
 	)
+})
+
+test('openSession rejects package sources whose artifact repo has no default branch HEAD before forking', async () => {
+	restoreRepoSessionMockBaseline()
+	mockModule.getRepoSessionById.mockResolvedValue(null)
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'package-package-1',
+		published_commit: 'commit-base',
+		indexed_commit: 'commit-base',
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		created_at: '2026-04-16T00:00:00.000Z',
+		updated_at: '2026-04-16T00:00:00.000Z',
+	})
+	const fork = vi.fn()
+	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({
+		fork,
+	})
+	mockModule.resolveArtifactDefaultBranchHead.mockResolvedValueOnce(null)
+
+	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
+	await expect(
+		repoSession.openSession({
+			sessionId: 'session-empty-source-head',
+			sourceId: 'source-1',
+			userId: 'user-1',
+			baseUrl: 'https://example.com',
+			sourceRoot: '/',
+		}),
+	).rejects.toThrow(
+		'artifact source repo "package-package-1" default branch has no HEAD',
+	)
+	expect(fork).not.toHaveBeenCalled()
+	expect(mockModule.resolveArtifactSourceRepo).not.toHaveBeenCalled()
+})
+
+test('openSession rejects package sources whose artifact repo HEAD differs from the published base', async () => {
+	restoreRepoSessionMockBaseline()
+	mockModule.getRepoSessionById.mockResolvedValue(null)
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'package-package-1',
+		published_commit: 'commit-published',
+		indexed_commit: 'commit-published',
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		created_at: '2026-04-16T00:00:00.000Z',
+		updated_at: '2026-04-16T00:00:00.000Z',
+	})
+	const fork = vi.fn()
+	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue({ fork })
+	mockModule.resolveArtifactDefaultBranchHead.mockResolvedValueOnce({
+		defaultBranch: 'main',
+		commit: 'commit-unpublished',
+		remote:
+			'https://acct.artifacts.cloudflare.net/git/default/package-package-1.git',
+	})
+
+	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
+	await expect(
+		repoSession.openSession({
+			sessionId: 'session-stale-source-head',
+			sourceId: 'source-1',
+			userId: 'user-1',
+			baseUrl: 'https://example.com',
+			sourceRoot: '/',
+		}),
+	).rejects.toThrow(
+		'artifact source repo "package-package-1" default branch HEAD "commit-unpublished" does not match published commit "commit-published"',
+	)
+	expect(fork).not.toHaveBeenCalled()
 })
 
 test('readFile retries the D1 lookup when the persisted cache is missing and the row is not yet readable', async () => {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -65,6 +65,7 @@ import {
 } from './external-publish.ts'
 import {
 	assertPackageSourceOverwriteAllowed,
+	assertPublishedPackageSourceRepoHead,
 	buildSourceRecoveryProblemMessage,
 } from './source-safety-policy.ts'
 import {
@@ -718,16 +719,21 @@ class RepoSessionBase extends DurableObject<Env> {
 					`Source "${input.sourceId}" was not found for this user.`,
 				)
 			}
-			const sourceRepo = await resolveArtifactSourceRepo(
-				this.env,
-				source.repo_id,
-			)
 			const baseCommit = source.published_commit
 			if (!baseCommit) {
 				throw new Error(
 					`Source "${source.id}" has no published commit yet. Bootstrap the source repo before opening a repo session.`,
 				)
 			}
+			const sourceHead = await assertPublishedPackageSourceRepoHead({
+				env: this.env,
+				source,
+				operation: 'repo_open_session',
+				requirePublishedCommitHead: true,
+			})
+			const sourceRepo =
+				sourceHead?.repo ??
+				(await resolveArtifactSourceRepo(this.env, source.repo_id))
 			const sessionRepoName = buildSessionArtifactsRepoName(
 				source.repo_id,
 				input.sessionId,

--- a/packages/worker/src/repo/source-safety-policy.ts
+++ b/packages/worker/src/repo/source-safety-policy.ts
@@ -1,4 +1,9 @@
 import { loadPublishedSourceSnapshot } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import {
+	type ArtifactRepoHandle,
+	resolveArtifactDefaultBranchHead,
+	resolveExistingArtifactSourceRepo,
+} from './artifacts.ts'
 import { type EntitySourceRow } from './types.ts'
 
 export const productionPackageSourceSafetyPolicy =
@@ -116,6 +121,102 @@ export async function assertRestorablePackageSourceSnapshot(input: {
 		sourceId: input.source.id,
 		publishedCommit: input.source.published_commit,
 		fileCount,
+	}
+}
+
+export async function assertPublishedPackageSourceRepoHead(input: {
+	env: Env
+	source: EntitySourceRow
+	operation: string
+	requirePublishedCommitHead?: boolean
+}): Promise<{
+	sourceId: string
+	publishedCommit: string
+	commit: string
+	defaultBranch: string
+	remote: string
+	repo: ArtifactRepoHandle
+} | null> {
+	if (input.source.entity_kind !== 'package') {
+		return null
+	}
+	if (!input.source.published_commit) {
+		throw new Error(
+			buildSourceRecoveryProblemMessage({
+				source: input.source,
+				operation: input.operation,
+				reason: 'the source has no published commit',
+			}),
+		)
+	}
+	let repo: ArtifactRepoHandle | null
+	try {
+		repo = await resolveExistingArtifactSourceRepo(
+			input.env,
+			input.source.repo_id,
+		)
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		throw new Error(
+			buildSourceRecoveryProblemMessage({
+				source: input.source,
+				operation: input.operation,
+				reason: message,
+			}),
+			{ cause: error },
+		)
+	}
+	if (!repo) {
+		throw new Error(
+			buildSourceRecoveryProblemMessage({
+				source: input.source,
+				operation: input.operation,
+				reason: `artifact source repo "${input.source.repo_id}" was not found`,
+			}),
+		)
+	}
+	let head: Awaited<ReturnType<typeof resolveArtifactDefaultBranchHead>>
+	try {
+		head = await resolveArtifactDefaultBranchHead({ repo })
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		throw new Error(
+			buildSourceRecoveryProblemMessage({
+				source: input.source,
+				operation: input.operation,
+				reason: message,
+			}),
+			{ cause: error },
+		)
+	}
+	if (!head) {
+		throw new Error(
+			buildSourceRecoveryProblemMessage({
+				source: input.source,
+				operation: input.operation,
+				reason: `artifact source repo "${input.source.repo_id}" default branch has no HEAD`,
+			}),
+		)
+	}
+	if (
+		input.requirePublishedCommitHead === true &&
+		head.commit !== input.source.published_commit
+	) {
+		throw new Error(
+			buildSourceRecoveryProblemMessage({
+				source: input.source,
+				operation: input.operation,
+				reason: `artifact source repo "${input.source.repo_id}" default branch HEAD "${head.commit}" does not match published commit "${input.source.published_commit}"`,
+			}),
+		)
+	}
+	return {
+		sourceId: input.source.id,
+		publishedCommit: input.source.published_commit,
+		commit: head.commit,
+		defaultBranch: head.defaultBranch,
+		remote: head.remote,
+		repo,
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Prevent package git remote minting from returning a Cloudflare Artifacts remote when the saved package source repo is missing or has no default-branch HEAD.
- Validate package repo-session source HEADs before forking so sessions do not open from empty or stale source repos.
- Add regression coverage for non-creating source HEAD lookup, package git remote minting, and repo session opening failures.

## Validation
- `npx vitest run packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts packages/worker/src/repo/repo-session-do.node.test.ts packages/worker/src/repo/artifacts.node.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run validate`

## Notes
- No PR template was present in the repository.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a04cec53-99bd-4a54-a42c-c175a9295042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a04cec53-99bd-4a54-a42c-c175a9295042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for package sources to prevent operations when repository heads are missing or unavailable.
  * Improved error messages when package source repository information cannot be resolved.
  * Added checks during session creation to verify published package source repository states before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->