### PR TITLE
Fix secret delete button

### DIFF
--- a/packages/worker/client/double-check.node.test.ts
+++ b/packages/worker/client/double-check.node.test.ts
@@ -1,0 +1,78 @@
+import { expect, test, vi } from 'vitest'
+
+const mockEventMixin = vi.hoisted(() => ({
+	on: vi.fn((type: string, handler: (event: Event) => void) => ({
+		type,
+		handler,
+	})),
+}))
+
+vi.mock('#client/event-mixin.ts', () => ({
+	on: mockEventMixin.on,
+}))
+
+const { createDoubleCheck } = await import('./double-check.ts')
+
+type RecordedMixin = {
+	type: string
+	handler: (event: Event) => void
+}
+
+function invoke(mixin: unknown, event: Event) {
+	const recordedMixin = mixin as RecordedMixin
+	recordedMixin.handler(event)
+}
+
+test('double check button mix requires two clicks before invoking action', () => {
+	const handle = { update: vi.fn() }
+	const action = vi.fn()
+	const doubleCheck = createDoubleCheck(handle as never)
+	const mix = doubleCheck.getButtonMix({
+		on: {
+			click: action,
+		},
+	})
+
+	expect(mix).toHaveLength(2)
+	expect((mix[0] as RecordedMixin).type).toBe('blur')
+	expect((mix[1] as RecordedMixin).type).toBe('click')
+
+	const firstClick = {
+		preventDefault: vi.fn(),
+	} as unknown as Event
+	invoke(mix[1], firstClick)
+
+	expect(firstClick.preventDefault).toHaveBeenCalled()
+	expect(doubleCheck.doubleCheck).toBe(true)
+	expect(action).not.toHaveBeenCalled()
+
+	const secondClick = {
+		preventDefault: vi.fn(),
+	} as unknown as Event
+	invoke(mix[1], secondClick)
+
+	expect(secondClick.preventDefault).not.toHaveBeenCalled()
+	expect(action).toHaveBeenCalledTimes(1)
+	expect(doubleCheck.doubleCheck).toBe(false)
+})
+
+test('double check button mix resets on blur', () => {
+	const handle = { update: vi.fn() }
+	const action = vi.fn()
+	const doubleCheck = createDoubleCheck(handle as never)
+	const mix = doubleCheck.getButtonMix({
+		on: {
+			click: action,
+		},
+	})
+
+	invoke(mix[1], {
+		preventDefault: vi.fn(),
+	} as unknown as Event)
+	expect(doubleCheck.doubleCheck).toBe(true)
+
+	invoke(mix[0], new Event('blur'))
+
+	expect(doubleCheck.doubleCheck).toBe(false)
+	expect(action).not.toHaveBeenCalled()
+})

--- a/packages/worker/client/double-check.ts
+++ b/packages/worker/client/double-check.ts
@@ -1,4 +1,5 @@
 import { type Handle } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
 
 type BlurHandler = (event: FocusEvent) => void
 type ClickHandler = (event: MouseEvent) => void
@@ -37,7 +38,7 @@ export function createDoubleCheck(handle: Handle) {
 		reset() {
 			setDoubleCheck(false)
 		},
-		getButtonProps<Props extends ButtonLikeProps>(props?: Props): Props {
+		getButtonMix<Props extends ButtonLikeProps>(props?: Props) {
 			const buttonProps = props ?? ({} as Props)
 
 			const onBlur: BlurHandler = () => {
@@ -55,14 +56,10 @@ export function createDoubleCheck(handle: Handle) {
 				setDoubleCheck(false)
 			}
 
-			return {
-				...buttonProps,
-				on: {
-					...buttonProps.on,
-					blur: callAll(onBlur, buttonProps.on?.blur),
-					click: onClick,
-				},
-			}
+			return [
+				on('blur', (event) => callAll(onBlur, buttonProps.on?.blur)(event)),
+				on('click', onClick),
+			]
 		},
 	}
 }

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -1776,11 +1776,6 @@ export function AccountSecretsRoute(handle: Handle) {
 										<button
 											type="button"
 											disabled={isMutating}
-											{...deleteSecretCheck.getButtonProps({
-												on: {
-													click: () => void deleteSelectedSecret(),
-												},
-											})}
 											aria-label={
 												deleteSecretCheck.doubleCheck
 													? `Confirm delete secret "${editorState.name}"`
@@ -1791,7 +1786,14 @@ export function AccountSecretsRoute(handle: Handle) {
 													? `Click again to delete "${editorState.name}"`
 													: `Delete secret "${editorState.name}"`
 											}
-											mix={css(dangerButtonCss)}
+											mix={[
+												...deleteSecretCheck.getButtonMix({
+													on: {
+														click: () => void deleteSelectedSecret(),
+													},
+												}),
+												css(dangerButtonCss),
+											]}
 										>
 											{saveState === 'deleting'
 												? 'Deleting...'

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -703,3 +703,39 @@ test('GET /account/secrets.json includes selected secret value for editing', asy
 		}),
 	)
 })
+
+test('delete action removes selected user secret and refreshes payload', async () => {
+	mockModule.deleteSecret.mockResolvedValueOnce(true)
+	mockModule.listSavedPackagesByUserId.mockResolvedValueOnce([])
+	mockModule.listSecrets.mockResolvedValueOnce([])
+	mockModule.listAppSecretsByAppIds.mockResolvedValueOnce(new Map())
+
+	const handler = createAccountSecretsApiHandler(createEnv())
+	const response = await handler.handler({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'delete',
+				currentId: 'user::::myApiKey',
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toMatchObject({
+		ok: true,
+		deleted: true,
+		selectedSecret: null,
+		secrets: [],
+	})
+	expect(mockModule.deleteSecret).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'stable-user-1',
+			name: 'myApiKey',
+			scope: 'user',
+			storageContext: { appId: null, sessionId: null },
+		}),
+	)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Wire the account secret delete double-check through Remix UI event mixins so the button click handler runs.
- Add focused regression coverage for the double-check helper and account secrets delete API response.

## Walkthrough
<a href="https://cursor.com/agents/bc-58a2079e-0b9d-49bd-9aa0-bfc958b593b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsecret-delete-button-walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-d6b3bb45-5be9-466a-89b5-df010adc9782" alt="secret-delete-button-walkthrough.mp4" /></a>
![Delete confirmation armed](https://cursor.com/artifacts/c/art-34613fa2-dd06-4734-89ea-591a91c9c3c8)
![Secret removed from list](https://cursor.com/artifacts/c/art-c0934bb0-5c2c-4309-a3c3-077945122605)

## Testing
- `npx vitest run --project node-unit packages/worker/client/double-check.node.test.ts packages/worker/src/app/handlers/account-secrets.node.test.ts`
- `npm run validate`
- Manual browser walkthrough at `http://localhost:3742/account/secrets`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58a2079e-0b9d-49bd-9aa0-bfc958b593b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58a2079e-0b9d-49bd-9aa0-bfc958b593b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the double-check confirmation feature, verifying that the delete action executes only after two clicks and properly resets state on blur.
  * Added test coverage for the account secrets delete handler to ensure deletion requests are processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->