### PR TITLE
Add account integrations page

### DIFF
--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -90,6 +90,7 @@ export function App(handle: Handle) {
 
 	return () => {
 		const isWideLayout =
+			currentPathname.startsWith('/account/integrations') ||
 			currentPathname.startsWith('/account/package-invocation-tokens') ||
 			currentPathname.startsWith('/account/remote-connectors') ||
 			currentPathname.startsWith('/account/secrets')
@@ -182,6 +183,9 @@ export function App(handle: Handle) {
 							</a>
 							<a href="/account/secrets" mix={css(navLinkCss)}>
 								Secrets
+							</a>
+							<a href="/account/integrations" mix={css(navLinkCss)}>
+								Integrations
 							</a>
 							<a
 								href="/account/package-invocation-tokens"

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -73,35 +73,7 @@ function buildConnectOauthHref(integration: AccountIntegrationListItem) {
 	const authorization = integration.authorization
 	if (!authorization?.authorizeUrl) return null
 
-	const params = new URLSearchParams({
-		provider: integration.name,
-		authorizeUrl: authorization.authorizeUrl,
-		tokenUrl: integration.tokenUrl,
-		flow: integration.flow,
-	})
-	if (integration.apiBaseUrl) {
-		params.set('apiBaseUrl', integration.apiBaseUrl)
-	}
-	if (authorization.scopes.length > 0) {
-		params.set('scopes', JSON.stringify(authorization.scopes))
-	}
-	if (authorization.scopeSeparator) {
-		params.set('scopeSeparator', authorization.scopeSeparator)
-	}
-	if (
-		authorization.extraAuthorizeParams &&
-		Object.keys(authorization.extraAuthorizeParams).length > 0
-	) {
-		params.set(
-			'extraAuthorizeParams',
-			JSON.stringify(authorization.extraAuthorizeParams),
-		)
-	}
-	const requiredHosts = integration.requiredHosts ?? []
-	if (requiredHosts.length > 0) {
-		params.set('allowedHosts', requiredHosts.join(','))
-	}
-
+	const params = new URLSearchParams({ provider: integration.name })
 	return `/connect/oauth?${params.toString()}`
 }
 

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -1,0 +1,347 @@
+import { type Handle, css } from 'remix/ui'
+import {
+	type AccountStatus,
+	readJson,
+} from '#client/routes/account-approval-shared.ts'
+import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
+import {
+	cardCss,
+	cardTitleCss,
+	descriptionCss,
+	detailGridCss,
+	detailItemCss,
+	detailLabelCss,
+	detailValueCss,
+	getPrimaryButtonCss,
+	insetCardCss,
+	pageDescriptionCss,
+	pageHeaderCss,
+	pageTitleCss,
+	primaryLinkCss,
+	sectionTitleCss,
+	stackedPageCss,
+} from '#client/styles/style-primitives.ts'
+
+type IntegrationFlow = 'pkce' | 'confidential'
+
+type IntegrationAuthorization = {
+	authorizeUrl: string
+	scopes: Array<string>
+	scopeSeparator?: string | null
+	extraAuthorizeParams?: Record<string, string>
+}
+
+type AccountIntegrationListItem = {
+	name: string
+	valueName: string
+	tokenUrl: string
+	apiBaseUrl?: string | null
+	flow: IntegrationFlow
+	clientIdValueName: string
+	clientSecretSecretName?: string | null
+	accessTokenSecretName: string
+	refreshTokenSecretName?: string | null
+	requiredHosts?: Array<string>
+	authorization?: IntegrationAuthorization | null
+	createdAt: string
+	updatedAt: string
+}
+
+type AccountIntegrationsPayload = {
+	ok: true
+	email: string
+	username: string
+	integrations: Array<AccountIntegrationListItem>
+}
+
+const accountIntegrationsApiPath = '/account/integrations.json'
+
+function formatTimestamp(value: string) {
+	return new Date(value).toLocaleString()
+}
+
+function formatList(values: Array<string> | null | undefined) {
+	if (!values || values.length === 0) return 'None'
+	return values.join(', ')
+}
+
+function formatOptional(value: string | null | undefined) {
+	return value?.trim() ? value : 'None'
+}
+
+function buildConnectOauthHref(integration: AccountIntegrationListItem) {
+	const authorization = integration.authorization
+	if (!authorization?.authorizeUrl) return null
+
+	const params = new URLSearchParams({
+		provider: integration.name,
+		authorizeUrl: authorization.authorizeUrl,
+		tokenUrl: integration.tokenUrl,
+		flow: integration.flow,
+	})
+	if (integration.apiBaseUrl) {
+		params.set('apiBaseUrl', integration.apiBaseUrl)
+	}
+	if (authorization.scopes.length > 0) {
+		params.set('scopes', JSON.stringify(authorization.scopes))
+	}
+	if (authorization.scopeSeparator) {
+		params.set('scopeSeparator', authorization.scopeSeparator)
+	}
+	if (
+		authorization.extraAuthorizeParams &&
+		Object.keys(authorization.extraAuthorizeParams).length > 0
+	) {
+		params.set(
+			'extraAuthorizeParams',
+			JSON.stringify(authorization.extraAuthorizeParams),
+		)
+	}
+	const requiredHosts = integration.requiredHosts ?? []
+	if (requiredHosts.length > 0) {
+		params.set('allowedHosts', requiredHosts.join(','))
+	}
+
+	return `/connect/oauth?${params.toString()}`
+}
+
+function IntegrationDetail(props: { label: string; value: string }) {
+	return (
+		<div mix={css(detailItemCss)}>
+			<span mix={css(detailLabelCss)}>{props.label}</span>
+			<span mix={css(detailValueCss)}>{props.value}</span>
+		</div>
+	)
+}
+
+export function AccountIntegrationsRoute(handle: Handle) {
+	let status: AccountStatus = 'loading'
+	let email = ''
+	let integrations: Array<AccountIntegrationListItem> = []
+	let message: string | null = null
+	let lastLoadedHref = ''
+
+	async function loadIntegrations(signal: AbortSignal) {
+		try {
+			const href =
+				typeof window === 'undefined'
+					? '/account/integrations'
+					: window.location.href
+			lastLoadedHref = href
+			const response = await fetch(accountIntegrationsApiPath, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (signal.aborted) return
+			if (response.status === 401) {
+				window.location.assign('/login')
+				return
+			}
+			const payload = await readJson<AccountIntegrationsPayload>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load integrations.')
+			}
+			email = payload.email
+			integrations = payload.integrations
+			status = 'ready'
+			message = null
+			handle.update()
+		} catch (error) {
+			if (signal.aborted) return
+			status = 'error'
+			message =
+				error instanceof Error ? error.message : 'Unable to load integrations.'
+			handle.update()
+		}
+	}
+
+	return () => {
+		const currentHref =
+			typeof window === 'undefined'
+				? '/account/integrations'
+				: window.location.href
+		const isRefreshingForLocationChange =
+			status !== 'loading' && currentHref !== lastLoadedHref
+		if (status === 'loading' || isRefreshingForLocationChange) {
+			handle.queueTask(loadIntegrations)
+		}
+
+		return (
+			<section
+				mix={css({
+					...stackedPageCss,
+					maxWidth: '76rem',
+					margin: '0 auto',
+				})}
+			>
+				<header mix={css(pageHeaderCss)}>
+					<h1 mix={css(pageTitleCss)}>
+						{email ? `${email} integrations` : 'Integrations'}
+					</h1>
+					<p mix={css(pageDescriptionCss)}>
+						Review saved OAuth integrations and reconnect providers when tokens
+						need to be refreshed.
+					</p>
+				</header>
+
+				{status === 'loading' ? (
+					<p mix={css({ color: colors.textMuted, margin: 0 })}>
+						Loading integrations...
+					</p>
+				) : null}
+				{message ? (
+					<p
+						role="alert"
+						mix={css({
+							color: status === 'error' ? colors.error : colors.text,
+							margin: 0,
+						})}
+					>
+						{message}
+					</p>
+				) : null}
+
+				{status === 'ready' && integrations.length === 0 ? (
+					<section mix={css(cardCss)}>
+						<h2 mix={css(cardTitleCss)}>No integrations yet</h2>
+						<p mix={css(descriptionCss)}>
+							OAuth integrations appear here after Kody saves provider
+							configuration through an OAuth setup flow.
+						</p>
+					</section>
+				) : null}
+
+				{status === 'ready' && integrations.length > 0 ? (
+					<section
+						mix={css({
+							display: 'grid',
+							gridTemplateColumns: 'repeat(auto-fit, minmax(22rem, 1fr))',
+							gap: spacing.lg,
+						})}
+					>
+						{integrations.map((integration) => {
+							const connectHref = buildConnectOauthHref(integration)
+							return (
+								<article key={integration.valueName} mix={css(cardCss)}>
+									<header
+										mix={css({
+											display: 'flex',
+											alignItems: 'flex-start',
+											justifyContent: 'space-between',
+											gap: spacing.md,
+										})}
+									>
+										<div mix={css({ display: 'grid', gap: spacing.xs })}>
+											<h2 mix={css(cardTitleCss)}>{integration.name}</h2>
+											<p mix={css(descriptionCss)}>
+												Stored as {integration.valueName}
+											</p>
+										</div>
+										<span
+											mix={css({
+												width: 'max-content',
+												padding: `${spacing.xs} ${spacing.sm}`,
+												borderRadius: radius.full,
+												backgroundColor: colors.primarySoftest,
+												color: colors.primaryText,
+												fontSize: typography.fontSize.sm,
+												fontWeight: typography.fontWeight.medium,
+											})}
+										>
+											{integration.flow}
+										</span>
+									</header>
+
+									<section mix={css(detailGridCss)}>
+										<IntegrationDetail
+											label="Token URL"
+											value={integration.tokenUrl}
+										/>
+										<IntegrationDetail
+											label="API base URL"
+											value={formatOptional(integration.apiBaseUrl)}
+										/>
+										<IntegrationDetail
+											label="Authorize URL"
+											value={formatOptional(
+												integration.authorization?.authorizeUrl,
+											)}
+										/>
+										<IntegrationDetail
+											label="Scopes"
+											value={formatList(integration.authorization?.scopes)}
+										/>
+									</section>
+
+									<section mix={css(insetCardCss)}>
+										<h3 mix={css(sectionTitleCss)}>Stored names</h3>
+										<div mix={css(detailGridCss)}>
+											<IntegrationDetail
+												label="Client ID value"
+												value={integration.clientIdValueName}
+											/>
+											<IntegrationDetail
+												label="Client secret"
+												value={formatOptional(
+													integration.clientSecretSecretName,
+												)}
+											/>
+											<IntegrationDetail
+												label="Access token secret"
+												value={integration.accessTokenSecretName}
+											/>
+											<IntegrationDetail
+												label="Refresh token secret"
+												value={formatOptional(
+													integration.refreshTokenSecretName,
+												)}
+											/>
+										</div>
+									</section>
+
+									<section mix={css(detailGridCss)}>
+										<IntegrationDetail
+											label="Required hosts"
+											value={formatList(integration.requiredHosts)}
+										/>
+										<IntegrationDetail
+											label="Updated"
+											value={formatTimestamp(integration.updatedAt)}
+										/>
+									</section>
+
+									{connectHref ? (
+										<div>
+											<a
+												href={connectHref}
+												mix={css({
+													...getPrimaryButtonCss(),
+													display: 'inline-flex',
+													textDecoration: 'none',
+												})}
+											>
+												Reconnect OAuth
+											</a>
+										</div>
+									) : (
+										<p mix={css(descriptionCss)}>
+											This integration does not include authorization details
+											yet.
+										</p>
+									)}
+								</article>
+							)
+						})}
+					</section>
+				) : null}
+
+				<p mix={css({ margin: 0 })}>
+					<a href="/account" mix={css(primaryLinkCss)}>
+						Back to account
+					</a>
+				</p>
+			</section>
+		)
+	}
+}

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -107,13 +107,17 @@ function buildConnectOauthHref(integration: AccountIntegrationListItem) {
 
 function renderIntegrationDetail(label: string, value: string) {
 	return (
-		<div mix={css(detailItemCss)}>
+		<div mix={css({ ...detailItemCss, minWidth: 0 })}>
 			<span mix={css(detailLabelCss)}>{label}</span>
 			<span
 				mix={css({
 					...detailValueCss,
+					display: 'block',
+					maxWidth: '100%',
+					minWidth: 0,
 					overflowWrap: 'anywhere',
-					wordBreak: 'break-word',
+					whiteSpace: 'normal',
+					wordBreak: 'break-all',
 				})}
 			>
 				{value}

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -109,7 +109,15 @@ function renderIntegrationDetail(label: string, value: string) {
 	return (
 		<div mix={css(detailItemCss)}>
 			<span mix={css(detailLabelCss)}>{label}</span>
-			<span mix={css(detailValueCss)}>{value}</span>
+			<span
+				mix={css({
+					...detailValueCss,
+					overflowWrap: 'anywhere',
+					wordBreak: 'break-word',
+				})}
+			>
+				{value}
+			</span>
 		</div>
 	)
 }

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -105,11 +105,11 @@ function buildConnectOauthHref(integration: AccountIntegrationListItem) {
 	return `/connect/oauth?${params.toString()}`
 }
 
-function IntegrationDetail(props: { label: string; value: string }) {
+function renderIntegrationDetail(label: string, value: string) {
 	return (
 		<div mix={css(detailItemCss)}>
-			<span mix={css(detailLabelCss)}>{props.label}</span>
-			<span mix={css(detailValueCss)}>{props.value}</span>
+			<span mix={css(detailLabelCss)}>{label}</span>
+			<span mix={css(detailValueCss)}>{value}</span>
 		</div>
 	)
 }
@@ -254,61 +254,52 @@ export function AccountIntegrationsRoute(handle: Handle) {
 									</header>
 
 									<section mix={css(detailGridCss)}>
-										<IntegrationDetail
-											label="Token URL"
-											value={integration.tokenUrl}
-										/>
-										<IntegrationDetail
-											label="API base URL"
-											value={formatOptional(integration.apiBaseUrl)}
-										/>
-										<IntegrationDetail
-											label="Authorize URL"
-											value={formatOptional(
-												integration.authorization?.authorizeUrl,
-											)}
-										/>
-										<IntegrationDetail
-											label="Scopes"
-											value={formatList(integration.authorization?.scopes)}
-										/>
+										{renderIntegrationDetail('Token URL', integration.tokenUrl)}
+										{renderIntegrationDetail(
+											'API base URL',
+											formatOptional(integration.apiBaseUrl),
+										)}
+										{renderIntegrationDetail(
+											'Authorize URL',
+											formatOptional(integration.authorization?.authorizeUrl),
+										)}
+										{renderIntegrationDetail(
+											'Scopes',
+											formatList(integration.authorization?.scopes),
+										)}
 									</section>
 
 									<section mix={css(insetCardCss)}>
 										<h3 mix={css(sectionTitleCss)}>Stored names</h3>
 										<div mix={css(detailGridCss)}>
-											<IntegrationDetail
-												label="Client ID value"
-												value={integration.clientIdValueName}
-											/>
-											<IntegrationDetail
-												label="Client secret"
-												value={formatOptional(
-													integration.clientSecretSecretName,
-												)}
-											/>
-											<IntegrationDetail
-												label="Access token secret"
-												value={integration.accessTokenSecretName}
-											/>
-											<IntegrationDetail
-												label="Refresh token secret"
-												value={formatOptional(
-													integration.refreshTokenSecretName,
-												)}
-											/>
+											{renderIntegrationDetail(
+												'Client ID value',
+												integration.clientIdValueName,
+											)}
+											{renderIntegrationDetail(
+												'Client secret',
+												formatOptional(integration.clientSecretSecretName),
+											)}
+											{renderIntegrationDetail(
+												'Access token secret',
+												integration.accessTokenSecretName,
+											)}
+											{renderIntegrationDetail(
+												'Refresh token secret',
+												formatOptional(integration.refreshTokenSecretName),
+											)}
 										</div>
 									</section>
 
 									<section mix={css(detailGridCss)}>
-										<IntegrationDetail
-											label="Required hosts"
-											value={formatList(integration.requiredHosts)}
-										/>
-										<IntegrationDetail
-											label="Updated"
-											value={formatTimestamp(integration.updatedAt)}
-										/>
+										{renderIntegrationDetail(
+											'Required hosts',
+											formatList(integration.requiredHosts),
+										)}
+										{renderIntegrationDetail(
+											'Updated',
+											formatTimestamp(integration.updatedAt),
+										)}
 									</section>
 
 									{connectHref ? (

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -161,8 +161,8 @@ export function AccountRoute(handle: Handle) {
 						{username ? `${username} account` : 'Account'}
 					</h1>
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
-						Manage your profile, approval requests, stored secrets, and package
-						invocation tokens.
+						Manage your profile, integrations, approval requests, stored
+						secrets, and package invocation tokens.
 					</p>
 				</header>
 
@@ -232,6 +232,18 @@ export function AccountRoute(handle: Handle) {
 							<div>
 								<a href="/account/secrets" mix={css(primaryLinkCss)}>
 									Manage secrets
+								</a>
+							</div>
+						</section>
+						<section mix={css(cardCss)}>
+							<h2 mix={css(cardTitleCss)}>Integrations</h2>
+							<p mix={css(descriptionCss)}>
+								Review saved OAuth provider configurations and reconnect
+								integrations when tokens need to be refreshed.
+							</p>
+							<div>
+								<a href="/account/integrations" mix={css(primaryLinkCss)}>
+									Manage integrations
 								</a>
 							</div>
 						</section>

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -1,4 +1,5 @@
 import { AccountRoute } from './account.tsx'
+import { AccountIntegrationsRoute } from './account-integrations.tsx'
 import { AccountPackageInvocationTokensRoute } from './account-package-invocation-tokens.tsx'
 import { AccountRemoteConnectorsRoute } from './account-remote-connectors.tsx'
 import { AccountSecretsRoute } from './account-secrets.tsx'
@@ -12,6 +13,7 @@ import { ResetPasswordRoute } from './reset-password.tsx'
 export const clientRoutes = {
 	'/': <HomeRoute />,
 	'/account': <AccountRoute />,
+	'/account/integrations': <AccountIntegrationsRoute />,
 	'/account/package-invocation-tokens': <AccountPackageInvocationTokensRoute />,
 	'/account/package-invocation-tokens/new': (
 		<AccountPackageInvocationTokensRoute />

--- a/packages/worker/src/app/handlers/account-integrations.node.test.ts
+++ b/packages/worker/src/app/handlers/account-integrations.node.test.ts
@@ -1,0 +1,147 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	readAuthenticatedAppUser: vi.fn(async () => ({
+		sessionUserId: '42',
+		userId: 42,
+		username: 'test-user',
+		email: 'user@example.com',
+		displayName: 'user',
+		artifactOwnerIds: [],
+		mcpUser: {
+			userId: 'stable-user-1',
+			email: 'user@example.com',
+			username: 'test-user',
+			displayName: 'user',
+		},
+	})),
+	readAuthSessionResult: async () => ({ session: null, setCookie: null }),
+	listValues: vi.fn(async () => [
+		{
+			name: '_integration:github',
+			scope: 'user',
+			value: JSON.stringify({
+				tokenUrl: 'https://github.com/login/oauth/access_token',
+				apiBaseUrl: 'https://api.github.com',
+				flow: 'confidential',
+				clientIdValueName: 'github-client-id',
+				clientSecretSecretName: 'githubClientSecret',
+				accessTokenSecretName: 'githubAccessToken',
+				refreshTokenSecretName: null,
+				requiredHosts: ['api.github.com'],
+				authorization: {
+					authorizeUrl: 'https://github.com/login/oauth/authorize',
+					scopes: ['repo', 'read:user'],
+				},
+			}),
+			description: '',
+			appId: null,
+			createdAt: '1970-01-01T00:00:00.000Z',
+			updatedAt: '1970-01-01T00:00:00.001Z',
+			ttlMs: null,
+		},
+		{
+			name: '_integration:broken',
+			scope: 'user',
+			value: '{',
+			description: '',
+			appId: null,
+			createdAt: '1970-01-01T00:00:00.000Z',
+			updatedAt: '1970-01-01T00:00:00.001Z',
+			ttlMs: null,
+		},
+		{
+			name: 'plain-value',
+			scope: 'user',
+			value: 'ignored',
+			description: '',
+			appId: null,
+			createdAt: '1970-01-01T00:00:00.000Z',
+			updatedAt: '1970-01-01T00:00:00.001Z',
+			ttlMs: null,
+		},
+	]),
+}))
+
+const createdAt = '1970-01-01T00:00:00.000Z'
+const updatedAt = '1970-01-01T00:00:00.001Z'
+
+vi.mock('#app/authenticated-user.ts', () => ({
+	readAuthenticatedAppUser: (...args: Array<unknown>) =>
+		mockModule.readAuthenticatedAppUser(...args),
+}))
+
+vi.mock('#app/auth-session.ts', () => ({
+	readAuthSessionResult: (...args: Array<unknown>) =>
+		mockModule.readAuthSessionResult(...args),
+}))
+
+vi.mock('#app/auth-redirect.ts', () => ({
+	redirectToLogin: () => new Response(null, { status: 302 }),
+}))
+
+vi.mock('#app/layout.ts', () => ({
+	Layout: () => null,
+}))
+
+vi.mock('#app/render.ts', () => ({
+	render: () => new Response('ok'),
+}))
+
+vi.mock('#mcp/values/service.ts', () => ({
+	listValues: (...args: Array<unknown>) => mockModule.listValues(...args),
+}))
+
+const { createAccountIntegrationsApiHandler } =
+	await import('./account-integrations.ts')
+
+function createEnv() {
+	return {
+		APP_DB: {} as D1Database,
+		SECRET_STORE_KEY: 'x'.repeat(32),
+	} as Env
+}
+
+test('integrations API lists valid user-scoped OAuth integrations', async () => {
+	const handler = createAccountIntegrationsApiHandler(createEnv())
+	const response = await handler.handler({
+		request: new Request('https://example.com/account/integrations.json'),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	expect(response.headers.get('Cache-Control')).toBe('no-store')
+	expect(mockModule.listValues).toHaveBeenCalledWith({
+		env: expect.any(Object),
+		userId: 'stable-user-1',
+		scope: 'user',
+		storageContext: { sessionId: null, appId: null },
+	})
+	await expect(response.json()).resolves.toEqual({
+		ok: true,
+		email: 'user@example.com',
+		username: 'test-user',
+		integrations: [
+			{
+				name: 'github',
+				valueName: '_integration:github',
+				tokenUrl: 'https://github.com/login/oauth/access_token',
+				apiBaseUrl: 'https://api.github.com',
+				flow: 'confidential',
+				clientIdValueName: 'github-client-id',
+				clientSecretSecretName: 'githubClientSecret',
+				accessTokenSecretName: 'githubAccessToken',
+				refreshTokenSecretName: null,
+				requiredHosts: ['api.github.com'],
+				authorization: {
+					authorizeUrl: 'https://github.com/login/oauth/authorize',
+					scopes: ['repo', 'read:user'],
+					scopeSeparator: null,
+					extraAuthorizeParams: {},
+				},
+				createdAt,
+				updatedAt,
+			},
+		],
+	})
+})

--- a/packages/worker/src/app/handlers/account-integrations.ts
+++ b/packages/worker/src/app/handlers/account-integrations.ts
@@ -1,0 +1,114 @@
+import { type Action } from 'remix/router'
+import { redirectToLogin } from '#app/auth-redirect.ts'
+import { readAuthSessionResult } from '#app/auth-session.ts'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { Layout } from '#app/layout.ts'
+import { render } from '#app/render.ts'
+import { type routes } from '#app/routes.ts'
+import {
+	type IntegrationConfig,
+	parseIntegrationConfig,
+	parseIntegrationJson,
+	parseIntegrationValueName,
+} from '#mcp/capabilities/values/integration-shared.ts'
+import { listValues } from '#mcp/values/service.ts'
+
+type AuthenticatedUser = NonNullable<
+	Awaited<ReturnType<typeof readAuthenticatedAppUser>>
+>
+
+type AccountIntegrationListItem = IntegrationConfig & {
+	valueName: string
+	createdAt: string
+	updatedAt: string
+}
+
+type AccountIntegrationsPayload = {
+	ok: true
+	email: string
+	username: string
+	integrations: Array<AccountIntegrationListItem>
+}
+
+export function createAccountIntegrationsHandler(_env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const { session, setCookie } = await readAuthSessionResult(request)
+			if (!session) {
+				return redirectToLogin(request)
+			}
+
+			const response = render(Layout({ title: 'Integrations' }))
+			if (setCookie) {
+				response.headers.set('Set-Cookie', setCookie)
+			}
+			return response
+		},
+	} satisfies Action<typeof routes.accountIntegrations>
+}
+
+export function createAccountIntegrationsApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+
+			if (request.method !== 'GET') {
+				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+			}
+
+			return jsonResponse(await buildPayload({ env, user }))
+		},
+	} satisfies Action<typeof routes.accountIntegrationsApi>
+}
+
+async function buildPayload(input: {
+	env: Env
+	user: AuthenticatedUser
+}): Promise<AccountIntegrationsPayload> {
+	const values = await listValues({
+		env: input.env,
+		userId: input.user.mcpUser.userId,
+		scope: 'user',
+		storageContext: { sessionId: null, appId: null },
+	})
+	const integrations = values
+		.map((value) => {
+			const integrationName = parseIntegrationValueName(value.name)
+			if (!integrationName) return null
+			const config = parseIntegrationConfig(
+				parseIntegrationJson(value.value),
+				integrationName,
+			)
+			if (!config) return null
+			return {
+				...config,
+				valueName: value.name,
+				createdAt: value.createdAt,
+				updatedAt: value.updatedAt,
+			}
+		})
+		.filter((entry): entry is AccountIntegrationListItem => Boolean(entry))
+		.sort((left, right) => left.name.localeCompare(right.name))
+
+	return {
+		ok: true,
+		email: input.user.email,
+		username: input.user.username,
+		integrations,
+	}
+}
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: {
+			'Content-Type': 'application/json',
+			'Cache-Control': 'no-store',
+		},
+	})
+}

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -2,6 +2,10 @@ import { createRouter } from 'remix/router'
 import { account } from '#app/handlers/account.ts'
 import { createAccountDeleteHandler } from '#app/handlers/account-delete.ts'
 import {
+	createAccountIntegrationsApiHandler,
+	createAccountIntegrationsHandler,
+} from '#app/handlers/account-integrations.ts'
+import {
 	createAccountPackageInvocationTokensApiHandler,
 	createAccountPackageInvocationTokensHandler,
 } from '#app/handlers/account-package-invocation-tokens.ts'
@@ -47,6 +51,12 @@ export function createAppRouter(appEnv: AppEnv) {
 			signup,
 			account,
 			accountDelete: createAccountDeleteHandler(appEnv as unknown as Env),
+			accountIntegrations: createAccountIntegrationsHandler(
+				appEnv as unknown as Env,
+			),
+			accountIntegrationsApi: createAccountIntegrationsApiHandler(
+				appEnv as unknown as Env,
+			),
 			accountPackageInvocationTokens:
 				createAccountPackageInvocationTokensHandler(appEnv as unknown as Env),
 			accountPackageInvocationTokenNew:

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -3,6 +3,8 @@ import { post, route } from 'remix/routes'
 export const routes = route({
 	home: '/',
 	connectOauth: '/connect/oauth',
+	accountIntegrations: '/account/integrations',
+	accountIntegrationsApi: '/account/integrations.json',
 	accountPackageInvocationTokens: '/account/package-invocation-tokens',
 	accountPackageInvocationTokenNew: '/account/package-invocation-tokens/new',
 	accountPackageInvocationTokensApi: '/account/package-invocation-tokens.json',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an authenticated `/account/integrations` page and JSON endpoint for saved OAuth integration metadata.
- Link integrations from the signed-in nav and account landing page.
- Add a focused handler test for user-scoped integration listing.
- Keep reconnect links provider-only so `/connect/oauth` reloads the latest stored integration config.

## Walkthrough
<a href="https://cursor.com/agents/bc-4d6bc297-c884-458f-bfda-66797a833411/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintegrations-page-final-demo.mp4"><img src="https://cursor.com/artifacts/c/art-0332ba6a-5312-4f40-98b7-2a587db65908" alt="integrations-page-final-demo.mp4" /></a>
![Integrations page with wrapped OAuth details](https://cursor.com/artifacts/c/art-9dfce047-10d2-447e-bb30-1cf836f85371)
<a href="https://cursor.com/agents/bc-4d6bc297-c884-458f-bfda-66797a833411/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freconnect-provider-only-demo.mp4"><img src="https://cursor.com/artifacts/c/art-7f9d8acc-4155-4039-8bc6-0c6c773662d7" alt="reconnect-provider-only-demo.mp4" /></a>

## Testing
- `npx vitest run packages/worker/src/app/handlers/account-integrations.node.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run format:check`
- `npm run validate`
- Manual browser walkthrough against local dev server with seeded login and integration metadata.
- Manual browser walkthrough verified Reconnect OAuth navigates to `/connect/oauth?provider=github` and loads the current stored integration config.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d6bc297-c884-458f-bfda-66797a833411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d6bc297-c884-458f-bfda-66797a833411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Integrations” page to the account menu and account details area.
  * Users can view saved OAuth integrations, including scopes/host details and last-updated timestamps.
  * Added “Reconnect OAuth” actions for eligible integrations.
* **Tests**
  * Added test coverage for the integrations API endpoint (including authentication and response content).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->