### PR TITLE
Add Cloud Agent setup bootstrap

### DIFF
--- a/.cursor/CLOUD.md
+++ b/.cursor/CLOUD.md
@@ -6,6 +6,7 @@ A full-stack web application built on Cloudflare Workers with Remix 3 (alpha).
 
 | Task                   | Command                |
 | ---------------------- | ---------------------- |
+| Bootstrap Cloud VM     | `npm run setup:cloud-agent` |
 | Start dev server       | `npm run dev`          |
 | Full validation        | `npm run validate`     |
 | Apply formatter / lint | `npm run validate:fix` |

--- a/.cursor/CLOUD.md
+++ b/.cursor/CLOUD.md
@@ -4,17 +4,17 @@ A full-stack web application built on Cloudflare Workers with Remix 3 (alpha).
 
 ## Quick Reference
 
-| Task                   | Command                |
-| ---------------------- | ---------------------- |
+| Task                   | Command                     |
+| ---------------------- | --------------------------- |
 | Bootstrap Cloud VM     | `npm run setup:cloud-agent` |
-| Start dev server       | `npm run dev`          |
-| Full validation        | `npm run validate`     |
-| Apply formatter / lint | `npm run validate:fix` |
-| Lint                   | `npm run lint`         |
-| Format                 | `npm run format`       |
-| Type check             | `npm run typecheck`    |
-| Build                  | `npm run build`        |
-| E2E tests              | `npm run test:e2e:run` |
+| Start dev server       | `npm run dev`               |
+| Full validation        | `npm run validate`          |
+| Apply formatter / lint | `npm run validate:fix`      |
+| Lint                   | `npm run lint`              |
+| Format                 | `npm run format`            |
+| Type check             | `npm run typecheck`         |
+| Build                  | `npm run build`             |
+| E2E tests              | `npm run test:e2e:run`      |
 
 `npm run validate` is the single authoritative gate. CI runs the same script, so
 a green local `validate` means CI will pass. `validate` is read-only; use

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,14 +81,14 @@ unless nvm’s Node 24 bin directory is prepended to `PATH`. Verify with
 
 ### Quick commands
 
-| Task             | Command                                                         |
-| ---------------- | --------------------------------------------------------------- |
-| Cloud VM setup   | `npm run setup:cloud-agent`                                     |
-| Install deps     | `npm install`                                                   |
-| Start dev        | `npm run dev` (prints the resolved URL)                         |
-| Migrate local D1 | `npm run migrate:local`                                         |
-| Seed test login  | `npm run seed:local` (see seeding note below)                   |
-| Full CI gate     | `npm run validate`                                              |
+| Task             | Command                                       |
+| ---------------- | --------------------------------------------- |
+| Cloud VM setup   | `npm run setup:cloud-agent`                   |
+| Install deps     | `npm install`                                 |
+| Start dev        | `npm run dev` (prints the resolved URL)       |
+| Migrate local D1 | `npm run migrate:local`                       |
+| Seed test login  | `npm run seed:local` (see seeding note below) |
+| Full CI gate     | `npm run validate`                            |
 
 ### Dev server
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,10 +83,11 @@ unless nvm’s Node 24 bin directory is prepended to `PATH`. Verify with
 
 | Task             | Command                                                         |
 | ---------------- | --------------------------------------------------------------- |
+| Cloud VM setup   | `npm run setup:cloud-agent`                                     |
 | Install deps     | `npm install`                                                   |
 | Start dev        | `npm run dev` (prints the resolved URL)                         |
 | Migrate local D1 | `npm run migrate:local`                                         |
-| Seed test login  | `node tools/seed-test-data.ts --local` (see seeding note below) |
+| Seed test login  | `npm run seed:local` (see seeding note below)                   |
 | Full CI gate     | `npm run validate`                                              |
 
 ### Dev server
@@ -107,10 +108,8 @@ Copy `packages/worker/.env.example` to `packages/worker/.env` if missing.
 ### Seeding a test account
 
 After `npm run migrate:local`, seed the default E2E login (`me@kentcdodds.com` /
-`iliketwix`) per [`docs/contributing/setup.md`](./docs/contributing/setup.md).
-If `node tools/seed-test-data.ts --local` fails because Wrangler cannot resolve
-`APP_DB` without the worker config wrapper, run the seed SQL through
-`./wrangler-env.ts` instead (same pattern as the migrate script).
+`iliketwix`) with `npm run seed:local`. That command passes
+`--config packages/worker/wrangler.jsonc` so Wrangler can resolve `APP_DB`.
 
 ### Local limitations
 

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -11,6 +11,9 @@ Quick notes for getting a local kody environment running.
 - `npm install`
 - The repo root hosts the Nx workspace metadata; runtime packages live under
   `packages/`.
+- On Cursor Cloud VMs, run `npm run setup:cloud-agent` to select Node 24,
+  install dependencies, prepare `packages/worker/.env`, migrate local D1, and
+  seed the default test account.
 
 ## Local development
 
@@ -141,9 +144,9 @@ Use this script to ensure a known test login exists in any deployed environment:
 
 - Local D1 (default):
   - `npm run migrate:local`
-  - `node tools/seed-test-data.ts --local`
+  - `npm run seed:local`
 - Local D1 with custom persisted state:
-  - `node tools/seed-test-data.ts --local --persist-to .wrangler/state/e2e`
+  - `node tools/seed-test-data.ts --local --config packages/worker/wrangler.jsonc --persist-to .wrangler/state/e2e`
 - Remote D1:
   - `node tools/seed-test-data.ts --remote --config <wrangler-config-path>`
   - Add `--env <name>` when the config uses environment-scoped bindings and the
@@ -166,7 +169,7 @@ For a full local reset before seeding:
 2. Re-apply migrations:
    - `npm run migrate:local`
 3. Seed test account:
-   - `node tools/seed-test-data.ts`
+   - `npm run seed:local`
 
 For preview environments, we do a full resource reset:
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     ]
   },
   "scripts": {
+    "setup:cloud-agent": "bash tools/cloud-agent-setup.sh",
+    "setup:local": "node tools/prepare-e2e-env.ts && npm run migrate:local && npm run seed:local",
     "dev": "node --env-file=packages/worker/.env cli.ts",
     "dev:client": "concurrently --kill-others-on-fail -n web,mcp-apps -c green,cyan \"npm run dev:client:web\" \"npm run dev:mcp-apps\"",
     "dev:client:web": "esbuild packages/worker/client/entry.tsx --bundle --format=esm --target=es2022 --outdir=packages/worker/public --entry-names=client-entry --chunk-names=assets/[name] --asset-names=assets/[name] --jsx=automatic --jsx-import-source=remix/ui --watch",
@@ -39,6 +41,7 @@
     "format:check": "oxfmt --check",
     "migrate:local": "node --env-file=packages/worker/.env ./wrangler-env.ts d1 migrations apply APP_DB --local",
     "migrate:e2e": "node --env-file=packages/worker/.env ./wrangler-env.ts d1 migrations apply APP_DB --local --persist-to .wrangler/state/e2e",
+    "seed:local": "node tools/seed-test-data.ts --local --config packages/worker/wrangler.jsonc",
     "preview": "nx run worker:build-client && npm run migrate:local && node --env-file=packages/worker/.env ./wrangler-env.ts dev --local",
     "preview:e2e": "node --env-file=packages/worker/.env tools/prepare-e2e-env.ts && nx run worker:build-client && npm run migrate:e2e && node --env-file=packages/worker/.env ./wrangler-env.ts dev --local --persist-to .wrangler/state/e2e",
     "generate-types": "node --env-file=packages/worker/.env ./wrangler-env.ts types ./packages/worker/worker-configuration.d.ts",

--- a/tools/cloud-agent-setup.sh
+++ b/tools/cloud-agent-setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+node_24_bin="${KODY_NODE_24_BIN:-$HOME/.nvm/versions/node/v24.15.0/bin}"
+
+if [[ -x "$node_24_bin/node" ]]; then
+	export PATH="$node_24_bin:$PATH"
+fi
+
+node_major="$(node -p "process.versions.node.split('.')[0]")"
+if [[ "$node_major" != "24" ]]; then
+	echo "Kody requires Node 24.x, but startup resolved $(node --version)." >&2
+	echo "Install Node 24 or set KODY_NODE_24_BIN to its bin directory." >&2
+	exit 1
+fi
+
+npm install
+npm run setup:local


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `npm run setup:cloud-agent` to select Node 24, install dependencies, prepare local env, migrate local D1, and seed with the explicit Wrangler config.
- Add `npm run seed:local` so local seeding always passes `packages/worker/wrangler.jsonc`.
- Update Cloud Agent and contributor setup docs to use the reliable setup path.

## Testing
- `npm run setup:cloud-agent`
- `npm run format:check`
- `npx vitest run tools/seed-test-data.node.test.ts --project node-unit`
- `git push -u origin cursor/fix-cloud-setup-0fc3` (Husky pre-push ran unit + smoke E2E under Node 24)
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8034cc6e-c5f2-4a64-bed8-16cddd3d0fc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8034cc6e-c5f2-4a64-bed8-16cddd3d0fc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive updates to setup, agent, and quick reference documentation with detailed Cloud VM initialization workflows and enhanced local development instructions.

* **New Features**
  * Added new npm scripts for automated environment setup: Cloud VM bootstrap (`setup:cloud-agent`), local initialization (`setup:local`), and test data seeding (`seed:local`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->