### PR TITLE
Add package invocation token view and edit lifecycle UI

### DIFF
--- a/docs/contributing/package-invocation-api.md
+++ b/docs/contributing/package-invocation-api.md
@@ -59,7 +59,7 @@ The token is not a global backdoor:
 - tokens can be revoked without deploys
 - execution uses normal package runtime machinery
 
-### Creating and revoking tokens
+### Managing tokens
 
 Signed-in users manage package invocation tokens from:
 
@@ -67,7 +67,8 @@ Signed-in users manage package invocation tokens from:
 - `/account/package-invocation-tokens/new`
 
 The creation form accepts the raw token exactly once, hashes it server-side, and
-stores only the hash. Token lists never return the raw token or token hash.
+stores only the hash. Token list/detail payloads never return the raw token or
+token hash.
 
 The backing same-origin JSON endpoint is:
 
@@ -75,8 +76,14 @@ The backing same-origin JSON endpoint is:
   metadata
 - `POST /account/package-invocation-tokens.json` with `action: "create"` —
   create a token from a raw token and allowlists
+- `POST /account/package-invocation-tokens.json` with `action: "update"` —
+  update token name and allowlists without changing the stored token hash
 - `POST /account/package-invocation-tokens.json` with `action: "revoke"` —
   revoke a token by id
+- `POST /account/package-invocation-tokens.json` with `action: "unrevoke"` —
+  restore a revoked token by id
+- `POST /account/package-invocation-tokens.json` with `action: "delete"` —
+  permanently delete a token row by id
 
 Create payload shape:
 
@@ -103,10 +110,16 @@ The `/new` page supports metadata prefill query parameters for setup flows:
 - `packageKodyId` / `packageKodyIds` / `kodyId` / `kodyIds`
 - `packageId` / `packageIds`
 - `exportName` / `exportNames`
-- `source` / `sources`
+- `allowedSource` / `allowedSources` / `source` / `sources`
 
-Repeat parameters or comma-separate values. Do not put the raw token in the URL;
-paste it into the form or submit it over the authenticated same-origin JSON API.
+Snake case and kebab case aliases are accepted for list fields, such as
+`package_kody_ids`, `package-kody-ids`, `export_names`, `export-names`,
+`allowed_sources`, and `allowed-sources`. Repeat parameters or comma-separate
+values. Do not put the raw token in the URL; paste it into the form or submit it
+over the authenticated same-origin JSON API.
+
+Agents should load `kody_official_guide` with
+`guide: "package_invocation_token_setup"` before sending a user to this page.
 
 ## Request body
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -5,14 +5,15 @@ Official markdown guides for agent and contributor workflows. At runtime, the
 branch via `raw.githubusercontent.com` (see capability description in code for
 available `guide` ids).
 
-| File                                                                           | Topic                                                                                                       |
-| ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| [package-authoring.md](./package-authoring.md)                                 | General package-authoring guidance, including the README Intent section                                     |
-| [integration-bootstrap.md](./integration-bootstrap.md)                         | **Start here** for third-party integrations that must work before saving a dependent package or package app |
-| [secret-backed-integration.md](./secret-backed-integration.md)                 | Default recipe for non-OAuth integrations that use one or more saved secrets                                |
-| [integration-backed-app-happy-path.md](./integration-backed-app-happy-path.md) | Default package app pattern after integration smoke test passes                                             |
-| [package-service-pattern.md](./package-service-pattern.md)                     | General package-service pattern for native long-lived runtimes inside Kody                                  |
-| [package-subscriptions.md](./package-subscriptions.md)                         | Package subscription manifest shape, discovery, and email.message.received payload guidance                 |
-| [oauth.md](./oauth.md)                                                         | **Start here** for third-party OAuth (`/connect/oauth`, redirect URI, params)                               |
-| [generated-ui-oauth.md](./generated-ui-oauth.md)                               | Edge case: OAuth in a hosted package app (`open_generated_ui` on a saved package)                           |
-| [account-secret-setup.md](./account-secret-setup.md)                           | `/account/secrets/new` URL parameters and policies                                                          |
+| File                                                                                     | Topic                                                                                                       |
+| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [package-authoring.md](./package-authoring.md)                                           | General package-authoring guidance, including the README Intent section                                     |
+| [integration-bootstrap.md](./integration-bootstrap.md)                                   | **Start here** for third-party integrations that must work before saving a dependent package or package app |
+| [secret-backed-integration.md](./secret-backed-integration.md)                           | Default recipe for non-OAuth integrations that use one or more saved secrets                                |
+| [integration-backed-app-happy-path.md](./integration-backed-app-happy-path.md)           | Default package app pattern after integration smoke test passes                                             |
+| [package-service-pattern.md](./package-service-pattern.md)                               | General package-service pattern for native long-lived runtimes inside Kody                                  |
+| [package-subscriptions.md](./package-subscriptions.md)                                   | Package subscription manifest shape, discovery, and email.message.received payload guidance                 |
+| [oauth.md](./oauth.md)                                                                   | **Start here** for third-party OAuth (`/connect/oauth`, redirect URI, params)                               |
+| [generated-ui-oauth.md](./generated-ui-oauth.md)                                         | Edge case: OAuth in a hosted package app (`open_generated_ui` on a saved package)                           |
+| [account-secret-setup.md](./account-secret-setup.md)                                     | `/account/secrets/new` URL parameters and policies                                                          |
+| [account-package-invocation-token-setup.md](./account-package-invocation-token-setup.md) | `/account/package-invocation-tokens/new` URL parameters and bearer-token safety policy                      |

--- a/docs/guides/account-package-invocation-token-setup.md
+++ b/docs/guides/account-package-invocation-token-setup.md
@@ -1,0 +1,74 @@
+# Account package invocation token setup guide
+
+Use the hosted **`/account/package-invocation-tokens/new`** page when an
+external trusted client needs to call Kody package exports through the package
+invocation HTTP API. The agent may construct a prefilled setup URL, but the
+agent must never see, generate for chat, or place the raw bearer token in the
+URL.
+
+For package runtime code that runs inside Kody, prefer `packages.invoke` or
+`packages.invokeChecked` instead of bearer tokens. Package invocation tokens are
+for external systems such as webhooks, gateway proxies, CLIs, or other trusted
+personal clients that call Kody over HTTP.
+
+## When to use `/account/package-invocation-tokens/new`
+
+Use it when:
+
+- a non-Kody process must invoke a saved package export
+- the user will store the raw bearer token in that external system
+- package access should be scoped to specific packages, exports, and optional
+  source labels
+
+Do **not** ask the user to paste bearer tokens into chat. Do **not** include a
+`rawToken`, `token`, `bearer`, or token hash query parameter.
+
+## URL format
+
+Provide the user a URL like:
+
+`https://heykody.dev/account/package-invocation-tokens/new?name=Discord%20Gateway&packageKodyIds=discord-gateway&exportNames=dispatch-message-created&allowedSources=discord-gateway`
+
+Wildcard package/export setup for a highly trusted personal client:
+
+`https://heykody.dev/account/package-invocation-tokens/new?name=Personal%20automation&packageKodyIds=*&exportNames=*&allowedSources=personal-client`
+
+## Query params
+
+Repeat params or comma-separate values for list fields. The form also accepts
+common snake_case and kebab-case aliases so agents can construct URLs from API
+field names without extra translation.
+
+| Param                                       | Required | Description                                                                                                             |
+| ------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `name`                                      | yes      | Human-readable token name.                                                                                              |
+| `packageKodyIds` / `packageKodyId`          | yes\*    | Saved package `kody.id` values, or `*` for all packages owned by the signed-in Kody user.                               |
+| `kodyIds` / `kodyId`                        | yes\*    | Alias for `packageKodyIds`.                                                                                             |
+| `packageIds` / `packageId`                  | yes\*    | Saved package ids, or `*` for all packages owned by the signed-in Kody user.                                            |
+| `exportNames` / `exportName`                | yes      | Package export names. `dispatch-message-created` is normalized to `./dispatch-message-created`; `*` allows all exports. |
+| `allowedSources` / `allowedSource`          | no       | Optional exact source labels the external caller may send in request JSON.                                              |
+| `sources` / `source`                        | no       | Alias for `allowedSources`.                                                                                             |
+| `package_kody_ids`, `package-kody-ids`, etc | no       | Snake_case and kebab-case aliases are accepted for the fields above.                                                    |
+
+\* At least one package scope is required: either a package Kody id scope or a
+package id scope.
+
+## Agent instructions
+
+1. Identify the saved package and export the external system needs to call.
+   - Use package Kody ids when possible because they are human-readable.
+   - Use `*` only for highly trusted personal clients.
+2. Generate a `/account/package-invocation-tokens/new` URL with `name`, package
+   scope, export scope, and optional `allowedSources`.
+3. Ask the user to open the URL, paste their locally generated raw token into
+   the Raw token field, and create the token.
+4. Instruct the external caller to send:
+   - `Authorization: Bearer <raw-token>`
+   - JSON `source` matching one of the allowed sources when sources are scoped
+5. Never display, log, store in docs, or send raw token material through chat or
+   query params.
+
+## Related
+
+- [External package invocation API](../contributing/package-invocation-api.md)
+- [Packages](../use/packages.md)

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -195,6 +195,12 @@ authenticated user. Package code does not need to mint or pass
 package-invocation bearer tokens. Nested package invocations are depth-limited
 to prevent runaway loops.
 
+External trusted clients that must call package exports over HTTP use package
+invocation tokens instead. Before sending a user to create one, agents should
+load `kody_official_guide` with `guide: "package_invocation_token_setup"` and
+construct a prefilled `/account/package-invocation-tokens/new` URL without raw
+token material.
+
 Static package imports from ad hoc MCP `execute` code, such as
 `kody:@scope/package/export`, do not get a package runtime context. They run as
 library/snapshot imports in the execute caller's runtime. Use

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -308,6 +308,14 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		}
 	}
 
+	function getCurrentSelectedTokenId() {
+		const href =
+			typeof window === 'undefined'
+				? accountPackageInvocationTokensBasePath
+				: window.location.href
+		return getSelectedTokenIdFromPath(href) ?? selectedTokenId
+	}
+
 	async function loadTokens(signal: AbortSignal) {
 		const loadStartedAtMutationVersion = mutationVersion
 		try {
@@ -554,7 +562,8 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 	}
 
 	async function updateSelectedToken(form?: HTMLFormElement) {
-		if (!selectedTokenId || saveState !== 'idle') return
+		const tokenId = getCurrentSelectedTokenId()
+		if (!tokenId || saveState !== 'idle') return
 		const nextEditorState = form ? readEditorStateFromForm(form) : editorState
 		editorState = nextEditorState
 		const packageIds = parseListText(nextEditorState.packageIdsText)
@@ -596,7 +605,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 				credentials: 'include',
 				body: JSON.stringify({
 					action: 'update',
-					id: selectedTokenId,
+					id: tokenId,
 					name: nextEditorState.name,
 					packageIds,
 					packageKodyIds,
@@ -615,18 +624,14 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 				throw new Error(payload?.error || 'Unable to update token.')
 			}
 			mutationVersion += 1
-			applyPayload(payload, buildTokenDetailPath(selectedTokenId))
+			applyPayload(payload, buildTokenDetailPath(tokenId))
 			saveState = 'idle'
 			editorState = createEmptyEditorState()
 			editMode = false
 			message = 'Saved token.'
 			messageTone = 'info'
 			if (typeof window !== 'undefined') {
-				window.history.pushState(
-					null,
-					'',
-					buildTokenDetailPath(selectedTokenId),
-				)
+				window.history.pushState(null, '', buildTokenDetailPath(tokenId))
 				lastLoadedHref = window.location.href
 			}
 			handle.update()
@@ -640,8 +645,8 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 	}
 
 	async function revokeSelectedToken() {
-		if (!selectedTokenId || saveState !== 'idle') return
-		const tokenId = selectedTokenId
+		const tokenId = getCurrentSelectedTokenId()
+		if (!tokenId || saveState !== 'idle') return
 		saveState = 'revoking'
 		message = null
 		messageTone = 'info'
@@ -656,7 +661,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 				credentials: 'include',
 				body: JSON.stringify({
 					action: 'revoke',
-					id: selectedTokenId,
+					id: tokenId,
 				}),
 			})
 			if (response.status === 401) {
@@ -692,8 +697,8 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 	}
 
 	async function unrevokeSelectedToken() {
-		if (!selectedTokenId || saveState !== 'idle') return
-		const tokenId = selectedTokenId
+		const tokenId = getCurrentSelectedTokenId()
+		if (!tokenId || saveState !== 'idle') return
 		saveState = 'unrevoking'
 		message = null
 		messageTone = 'info'
@@ -741,7 +746,8 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 	}
 
 	async function deleteSelectedToken() {
-		if (!selectedTokenId || saveState !== 'idle') return
+		const tokenId = getCurrentSelectedTokenId()
+		if (!tokenId || saveState !== 'idle') return
 		saveState = 'deleting'
 		message = null
 		messageTone = 'info'
@@ -756,7 +762,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 				credentials: 'include',
 				body: JSON.stringify({
 					action: 'delete',
-					id: selectedTokenId,
+					id: tokenId,
 				}),
 			})
 			if (response.status === 401) {
@@ -824,10 +830,18 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		const isMutating = saveState !== 'idle'
 		const isCreatingToken = isNewTokenPath(currentHref)
 		const requestedTokenId = getSelectedTokenIdFromPath(currentHref)
+		const effectiveSelectedTokenId = requestedTokenId ?? selectedTokenId
 		const selectedToken =
-			tokens.find((token) => token.id === selectedTokenId) ?? null
+			tokens.find((token) => token.id === effectiveSelectedTokenId) ?? null
 		const isEditingSelectedToken =
-			editMode && selectedToken != null && !selectedToken.revokedAt
+			editMode &&
+			!isRefreshingForLocationChange &&
+			selectedToken != null &&
+			!selectedToken.revokedAt
+		const showTokenNotFound =
+			requestedTokenId != null &&
+			!selectedToken &&
+			!isRefreshingForLocationChange
 		const endpointTemplate = username
 			? `${invocationUrlOrigin}/@${username}/api/package-invocations/<kodyId>/<exportName>`
 			: ''
@@ -929,7 +943,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 									})}
 								>
 									{tokens.map((token) => {
-										const isSelected = selectedTokenId === token.id
+										const isSelected = effectiveSelectedTokenId === token.id
 										return (
 											<li key={token.id}>
 												<button
@@ -1494,7 +1508,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 								</section>
 							) : null}
 
-							{requestedTokenId && !selectedToken ? (
+							{showTokenNotFound ? (
 								<section mix={css(cardCss)}>
 									<h2 mix={css(cardTitleCss)}>Token not found</h2>
 									<p mix={css(descriptionCss)}>

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -453,10 +453,6 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		deleteConfirm = false
 		message = null
 		messageTone = 'info'
-		if (typeof window !== 'undefined') {
-			window.history.pushState(null, '', buildTokenDetailPath(token.id))
-			lastLoadedHref = window.location.href
-		}
 		handle.update()
 	}
 
@@ -830,7 +826,8 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		const isMutating = saveState !== 'idle'
 		const isCreatingToken = isNewTokenPath(currentHref)
 		const requestedTokenId = getSelectedTokenIdFromPath(currentHref)
-		const effectiveSelectedTokenId = requestedTokenId ?? selectedTokenId
+		const effectiveSelectedTokenId =
+			typeof window === 'undefined' ? selectedTokenId : requestedTokenId
 		const selectedToken =
 			tokens.find((token) => token.id === effectiveSelectedTokenId) ?? null
 		const isEditingSelectedToken =

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -19,6 +19,7 @@ import {
 	fieldLabelCss,
 	getDangerButtonCss,
 	getPrimaryButtonCss,
+	getSecondaryButtonCss,
 	inputCss,
 	textareaCss,
 } from '#client/styles/style-primitives.ts'
@@ -124,6 +125,23 @@ function isNewTokenPath(href: string) {
 	return url.pathname === `${accountPackageInvocationTokensBasePath}/new`
 }
 
+function getSelectedTokenIdFromPath(href: string) {
+	const url = new URL(href, 'http://localhost')
+	const detailPrefix = `${accountPackageInvocationTokensBasePath}/`
+	if (
+		url.pathname === `${accountPackageInvocationTokensBasePath}/new` ||
+		!url.pathname.startsWith(detailPrefix)
+	) {
+		return null
+	}
+	const tokenId = decodeURIComponent(url.pathname.slice(detailPrefix.length))
+	return tokenId || null
+}
+
+function buildTokenDetailPath(tokenId: string) {
+	return `${accountPackageInvocationTokensBasePath}/${encodeURIComponent(tokenId)}`
+}
+
 function getNewTokenQueryKey(href: string) {
 	const url = new URL(href, 'http://localhost')
 	if (url.pathname !== `${accountPackageInvocationTokensBasePath}/new`)
@@ -179,9 +197,28 @@ function tokenStatusCss(token: PackageInvocationTokenListItem) {
 	}
 }
 
+function createEditorStateFromToken(
+	token: PackageInvocationTokenListItem,
+): EditorState {
+	return {
+		name: token.name,
+		rawToken: '',
+		packageIdsText: token.packageIds.join('\n'),
+		packageKodyIdsText: token.packageKodyIds.join('\n'),
+		exportNamesText: token.exportNames.join('\n'),
+		sourcesText: token.sources.join('\n'),
+	}
+}
+
 export function AccountPackageInvocationTokensRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
-	let saveState: 'idle' | 'creating' | 'revoking' = 'idle'
+	let saveState:
+		| 'idle'
+		| 'creating'
+		| 'updating'
+		| 'revoking'
+		| 'unrevoking'
+		| 'deleting' = 'idle'
 	let email = ''
 	let username = ''
 	let invocationUrlOrigin = ''
@@ -195,9 +232,12 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 	let lastNewTokenQueryKey = ''
 	let mutationVersion = 0
 	let revokeConfirm = false
+	let deleteConfirm = false
+	let editMode = false
 
 	const primaryButtonCss = getPrimaryButtonCss()
 	const dangerButtonCss = getDangerButtonCss()
+	const secondaryButtonCss = getSecondaryButtonCss()
 
 	function redirectToLogin() {
 		saveState = 'idle'
@@ -264,10 +304,12 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		packages = payload.packages
 		tokens = payload.tokens
 		revokeConfirm = false
+		deleteConfirm = false
 		if (payload.selectedTokenId) {
 			selectedTokenId = payload.selectedTokenId
 			editorState = createEmptyEditorState()
 			lastNewTokenQueryKey = ''
+			editMode = false
 			return
 		}
 		if (isNewTokenPath(href)) {
@@ -276,17 +318,22 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 				lastNewTokenQueryKey = queryKey
 				editorState = createEditorStateFromNewTokenQuery(href)
 				selectedTokenId = null
+				editMode = false
 			}
+			return
+		}
+		const pathSelectedTokenId = getSelectedTokenIdFromPath(href)
+		if (pathSelectedTokenId) {
+			selectedTokenId = pathSelectedTokenId
+			editorState = createEmptyEditorState()
+			lastNewTokenQueryKey = ''
+			editMode = false
 			return
 		}
 		editorState = createEmptyEditorState()
 		lastNewTokenQueryKey = ''
-		if (
-			selectedTokenId &&
-			!tokens.some((token) => token.id === selectedTokenId)
-		) {
-			selectedTokenId = null
-		}
+		editMode = false
+		selectedTokenId = null
 	}
 
 	function setEditorField(field: keyof EditorState, value: string) {
@@ -312,6 +359,8 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		editorState = createEmptyEditorState()
 		selectedTokenId = null
 		revokeConfirm = false
+		deleteConfirm = false
+		editMode = false
 		message = null
 		messageTone = 'info'
 		if (typeof window !== 'undefined') {
@@ -323,6 +372,32 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 			lastLoadedHref = window.location.href
 			lastNewTokenQueryKey = getNewTokenQueryKey(window.location.href)
 		}
+		handle.update()
+	}
+
+	function startEditToken(token: PackageInvocationTokenListItem) {
+		if (token.revokedAt) return
+		editorState = createEditorStateFromToken(token)
+		selectedTokenId = token.id
+		editMode = true
+		revokeConfirm = false
+		deleteConfirm = false
+		message = null
+		messageTone = 'info'
+		if (typeof window !== 'undefined') {
+			window.history.pushState(null, '', buildTokenDetailPath(token.id))
+			lastLoadedHref = window.location.href
+		}
+		handle.update()
+	}
+
+	function cancelEditToken() {
+		editorState = createEmptyEditorState()
+		editMode = false
+		revokeConfirm = false
+		deleteConfirm = false
+		message = null
+		messageTone = 'info'
 		handle.update()
 	}
 
@@ -401,11 +476,10 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 				'Created token. The raw token was not stored and will not be shown again.'
 			messageTone = 'info'
 			if (typeof window !== 'undefined') {
-				window.history.pushState(
-					null,
-					'',
-					accountPackageInvocationTokensBasePath,
-				)
+				const nextPath = payload.selectedTokenId
+					? buildTokenDetailPath(payload.selectedTokenId)
+					: accountPackageInvocationTokensBasePath
+				window.history.pushState(null, '', nextPath)
 				lastLoadedHref = window.location.href
 			}
 			handle.update()
@@ -418,8 +492,95 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		}
 	}
 
+	async function updateSelectedToken(form?: HTMLFormElement) {
+		if (!selectedTokenId || saveState !== 'idle') return
+		const nextEditorState = form ? readEditorStateFromForm(form) : editorState
+		editorState = nextEditorState
+		const packageIds = parseListText(nextEditorState.packageIdsText)
+		const packageKodyIds = parseListText(nextEditorState.packageKodyIdsText)
+		const exportNames = parseListText(nextEditorState.exportNamesText)
+		const sources = parseListText(nextEditorState.sourcesText)
+
+		if (!nextEditorState.name) {
+			message = 'Token name is required.'
+			messageTone = 'error'
+			handle.update()
+			return
+		}
+		if (packageIds.length === 0 && packageKodyIds.length === 0) {
+			message =
+				'Add at least one package id, Kody id, or wildcard package scope.'
+			messageTone = 'error'
+			handle.update()
+			return
+		}
+		if (exportNames.length === 0) {
+			message = 'Add at least one export name or wildcard export scope.'
+			messageTone = 'error'
+			handle.update()
+			return
+		}
+
+		saveState = 'updating'
+		message = null
+		messageTone = 'info'
+		handle.update()
+		try {
+			const response = await fetch(accountPackageInvocationTokensApiPath, {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				credentials: 'include',
+				body: JSON.stringify({
+					action: 'update',
+					id: selectedTokenId,
+					name: nextEditorState.name,
+					packageIds,
+					packageKodyIds,
+					exportNames,
+					sources,
+				}),
+			})
+			if (response.status === 401) {
+				redirectToLogin()
+				return
+			}
+			const payload = await readJson<
+				AccountPackageInvocationTokensPayload & { error?: string; ok?: boolean }
+			>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error(payload?.error || 'Unable to update token.')
+			}
+			mutationVersion += 1
+			applyPayload(payload, buildTokenDetailPath(selectedTokenId))
+			saveState = 'idle'
+			editorState = createEmptyEditorState()
+			editMode = false
+			message = 'Saved token.'
+			messageTone = 'info'
+			if (typeof window !== 'undefined') {
+				window.history.pushState(
+					null,
+					'',
+					buildTokenDetailPath(selectedTokenId),
+				)
+				lastLoadedHref = window.location.href
+			}
+			handle.update()
+		} catch (error) {
+			saveState = 'idle'
+			message =
+				error instanceof Error ? error.message : 'Unable to update token.'
+			messageTone = 'error'
+			handle.update()
+		}
+	}
+
 	async function revokeSelectedToken() {
 		if (!selectedTokenId || saveState !== 'idle') return
+		const tokenId = selectedTokenId
 		saveState = 'revoking'
 		message = null
 		messageTone = 'info'
@@ -448,10 +609,17 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 				throw new Error(payload?.error || 'Unable to revoke token.')
 			}
 			mutationVersion += 1
-			applyPayload(payload, accountPackageInvocationTokensBasePath)
+			applyPayload(
+				{ ...payload, selectedTokenId: tokenId },
+				buildTokenDetailPath(tokenId),
+			)
 			saveState = 'idle'
 			message = 'Revoked token.'
 			messageTone = 'info'
+			if (typeof window !== 'undefined') {
+				window.history.pushState(null, '', buildTokenDetailPath(tokenId))
+				lastLoadedHref = window.location.href
+			}
 			handle.update()
 		} catch (error) {
 			saveState = 'idle'
@@ -462,15 +630,121 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		}
 	}
 
+	async function unrevokeSelectedToken() {
+		if (!selectedTokenId || saveState !== 'idle') return
+		const tokenId = selectedTokenId
+		saveState = 'unrevoking'
+		message = null
+		messageTone = 'info'
+		handle.update()
+		try {
+			const response = await fetch(accountPackageInvocationTokensApiPath, {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				credentials: 'include',
+				body: JSON.stringify({
+					action: 'unrevoke',
+					id: tokenId,
+				}),
+			})
+			if (response.status === 401) {
+				redirectToLogin()
+				return
+			}
+			const payload = await readJson<
+				AccountPackageInvocationTokensPayload & { error?: string; ok?: boolean }
+			>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error(payload?.error || 'Unable to un-revoke token.')
+			}
+			mutationVersion += 1
+			applyPayload(payload, buildTokenDetailPath(tokenId))
+			saveState = 'idle'
+			message = 'Un-revoked token.'
+			messageTone = 'info'
+			if (typeof window !== 'undefined') {
+				window.history.pushState(null, '', buildTokenDetailPath(tokenId))
+				lastLoadedHref = window.location.href
+			}
+			handle.update()
+		} catch (error) {
+			saveState = 'idle'
+			message =
+				error instanceof Error ? error.message : 'Unable to un-revoke token.'
+			messageTone = 'error'
+			handle.update()
+		}
+	}
+
+	async function deleteSelectedToken() {
+		if (!selectedTokenId || saveState !== 'idle') return
+		saveState = 'deleting'
+		message = null
+		messageTone = 'info'
+		handle.update()
+		try {
+			const response = await fetch(accountPackageInvocationTokensApiPath, {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				credentials: 'include',
+				body: JSON.stringify({
+					action: 'delete',
+					id: selectedTokenId,
+				}),
+			})
+			if (response.status === 401) {
+				redirectToLogin()
+				return
+			}
+			const payload = await readJson<
+				AccountPackageInvocationTokensPayload & { error?: string; ok?: boolean }
+			>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error(payload?.error || 'Unable to delete token.')
+			}
+			mutationVersion += 1
+			applyPayload(payload, accountPackageInvocationTokensBasePath)
+			saveState = 'idle'
+			selectedTokenId = null
+			editorState = createEmptyEditorState()
+			editMode = false
+			message = 'Deleted token permanently.'
+			messageTone = 'info'
+			if (typeof window !== 'undefined') {
+				window.history.pushState(
+					null,
+					'',
+					accountPackageInvocationTokensBasePath,
+				)
+				lastLoadedHref = window.location.href
+			}
+			handle.update()
+		} catch (error) {
+			saveState = 'idle'
+			message =
+				error instanceof Error ? error.message : 'Unable to delete token.'
+			messageTone = 'error'
+			handle.update()
+		}
+	}
+
 	function selectToken(token: PackageInvocationTokenListItem) {
 		selectedTokenId = token.id
 		editorState = createEmptyEditorState()
 		lastNewTokenQueryKey = ''
 		revokeConfirm = false
+		deleteConfirm = false
+		editMode = false
 		message = null
 		messageTone = 'info'
 		if (typeof window !== 'undefined') {
-			window.history.pushState(null, '', accountPackageInvocationTokensBasePath)
+			window.history.pushState(null, '', buildTokenDetailPath(token.id))
 			lastLoadedHref = window.location.href
 		}
 		handle.update()
@@ -487,8 +761,12 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 			handle.queueTask(loadTokens)
 		}
 		const isMutating = saveState !== 'idle'
+		const isCreatingToken = isNewTokenPath(currentHref)
+		const requestedTokenId = getSelectedTokenIdFromPath(currentHref)
 		const selectedToken =
 			tokens.find((token) => token.id === selectedTokenId) ?? null
+		const isEditingSelectedToken =
+			editMode && selectedToken != null && !selectedToken.revokedAt
 		const endpointTemplate = username
 			? `${invocationUrlOrigin}/@${username}/api/package-invocations/<kodyId>/<exportName>`
 			: ''
@@ -636,174 +914,345 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 						</aside>
 
 						<div mix={css({ display: 'grid', gap: spacing.lg })}>
-							<form
-								method="post"
-								noValidate
-								mix={[
-									on('submit', (event) => {
-										event.preventDefault()
-										if (event.currentTarget instanceof HTMLFormElement) {
-											void createToken(event.currentTarget)
-										}
-									}),
-									css(cardCss),
-								]}
-							>
-								<div mix={css({ display: 'grid', gap: spacing.xs })}>
-									<h2 mix={css(cardTitleCss)}>Create token</h2>
-									<p mix={css(descriptionCss)}>
-										Paste the raw token once. Kody stores only its hash, so keep
-										the raw value in the trusted client.
-									</p>
-								</div>
-
-								<label mix={css(fieldCss)}>
-									<span mix={css(fieldLabelCss)}>Name</span>
-									<input
-										name="name"
-										type="text"
-										value={editorState.name}
-										placeholder="Personal automation"
-										disabled={isMutating}
-										required
-										mix={[
-											on('input', (event) => {
-												setEditorField('name', event.currentTarget.value)
-												handle.update()
-											}),
-											css(inputCss),
-										]}
-									/>
-								</label>
-
-								<label mix={css(fieldCss)}>
-									<span mix={css(fieldLabelCss)}>Raw token</span>
-									<input
-										name="rawToken"
-										type="password"
-										value={editorState.rawToken}
-										placeholder="Paste the locally generated token"
-										autoComplete="off"
-										disabled={isMutating}
-										required
-										mix={[
-											on('input', (event) => {
-												setEditorField('rawToken', event.currentTarget.value)
-												handle.update()
-											}),
-											css(inputCss),
-										]}
-									/>
-								</label>
-
-								<div
-									mix={css({
-										display: 'grid',
-										gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
-										gap: spacing.md,
-										[mq.mobile]: {
-											gridTemplateColumns: '1fr',
-										},
-									})}
+							{isCreatingToken || (!requestedTokenId && !selectedToken) ? (
+								<form
+									method="post"
+									noValidate
+									mix={[
+										on('submit', (event) => {
+											event.preventDefault()
+											if (event.currentTarget instanceof HTMLFormElement) {
+												void createToken(event.currentTarget)
+											}
+										}),
+										css(cardCss),
+									]}
 								>
+									<div mix={css({ display: 'grid', gap: spacing.xs })}>
+										<h2 mix={css(cardTitleCss)}>Create token</h2>
+										<p mix={css(descriptionCss)}>
+											Paste the raw token once. Kody stores only its hash, so
+											keep the raw value in the trusted client.
+										</p>
+									</div>
+
 									<label mix={css(fieldCss)}>
-										<span mix={css(fieldLabelCss)}>Package Kody IDs</span>
-										<textarea
-											name="packageKodyIds"
-											value={editorState.packageKodyIdsText}
-											placeholder={'discord-gateway\n*'}
+										<span mix={css(fieldLabelCss)}>Name</span>
+										<input
+											name="name"
+											type="text"
+											value={editorState.name}
+											placeholder="Personal automation"
 											disabled={isMutating}
+											required
 											mix={[
 												on('input', (event) => {
-													setEditorField(
-														'packageKodyIdsText',
-														event.currentTarget.value,
-													)
+													setEditorField('name', event.currentTarget.value)
 													handle.update()
 												}),
-												css(textareaCss),
+												css(inputCss),
 											]}
 										/>
 									</label>
+
 									<label mix={css(fieldCss)}>
-										<span mix={css(fieldLabelCss)}>Package IDs</span>
-										<textarea
-											name="packageIds"
-											value={editorState.packageIdsText}
-											placeholder="pkg_..."
+										<span mix={css(fieldLabelCss)}>Raw token</span>
+										<input
+											name="rawToken"
+											type="password"
+											value={editorState.rawToken}
+											placeholder="Paste the locally generated token"
+											autoComplete="off"
 											disabled={isMutating}
+											required
 											mix={[
 												on('input', (event) => {
-													setEditorField(
-														'packageIdsText',
-														event.currentTarget.value,
-													)
+													setEditorField('rawToken', event.currentTarget.value)
 													handle.update()
 												}),
-												css(textareaCss),
+												css(inputCss),
 											]}
 										/>
 									</label>
-								</div>
 
-								<label mix={css(fieldCss)}>
-									<span mix={css(fieldLabelCss)}>Export names</span>
-									<textarea
-										name="exportNames"
-										value={editorState.exportNamesText}
-										placeholder={'dispatch-message-created\n*'}
-										disabled={isMutating}
-										required
-										mix={[
-											on('input', (event) => {
-												setEditorField(
-													'exportNamesText',
-													event.currentTarget.value,
-												)
-												handle.update()
-											}),
-											css(textareaCss),
-										]}
-									/>
-								</label>
-
-								<label mix={css(fieldCss)}>
-									<span mix={css(fieldLabelCss)}>Allowed sources</span>
-									<textarea
-										name="sources"
-										value={editorState.sourcesText}
-										placeholder="personal-client"
-										disabled={isMutating}
-										mix={[
-											on('input', (event) => {
-												setEditorField('sourcesText', event.currentTarget.value)
-												handle.update()
-											}),
-											css(textareaCss),
-										]}
-									/>
-									<span mix={css(descriptionCss)}>
-										Leave blank to allow requests that omit source. If a request
-										supplies source, it must be listed here exactly.
-									</span>
-								</label>
-
-								<div
-									mix={css({
-										display: 'flex',
-										gap: spacing.sm,
-										flexWrap: 'wrap',
-									})}
-								>
-									<button
-										type="submit"
-										disabled={isMutating}
-										mix={css(primaryButtonCss)}
+									<div
+										mix={css({
+											display: 'grid',
+											gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+											gap: spacing.md,
+											[mq.mobile]: {
+												gridTemplateColumns: '1fr',
+											},
+										})}
 									>
-										{saveState === 'creating' ? 'Creating...' : 'Create token'}
-									</button>
-								</div>
-							</form>
+										<label mix={css(fieldCss)}>
+											<span mix={css(fieldLabelCss)}>Package Kody IDs</span>
+											<textarea
+												name="packageKodyIds"
+												value={editorState.packageKodyIdsText}
+												placeholder={'discord-gateway\n*'}
+												disabled={isMutating}
+												mix={[
+													on('input', (event) => {
+														setEditorField(
+															'packageKodyIdsText',
+															event.currentTarget.value,
+														)
+														handle.update()
+													}),
+													css(textareaCss),
+												]}
+											/>
+										</label>
+										<label mix={css(fieldCss)}>
+											<span mix={css(fieldLabelCss)}>Package IDs</span>
+											<textarea
+												name="packageIds"
+												value={editorState.packageIdsText}
+												placeholder="pkg_..."
+												disabled={isMutating}
+												mix={[
+													on('input', (event) => {
+														setEditorField(
+															'packageIdsText',
+															event.currentTarget.value,
+														)
+														handle.update()
+													}),
+													css(textareaCss),
+												]}
+											/>
+										</label>
+									</div>
+
+									<label mix={css(fieldCss)}>
+										<span mix={css(fieldLabelCss)}>Export names</span>
+										<textarea
+											name="exportNames"
+											value={editorState.exportNamesText}
+											placeholder={'dispatch-message-created\n*'}
+											disabled={isMutating}
+											required
+											mix={[
+												on('input', (event) => {
+													setEditorField(
+														'exportNamesText',
+														event.currentTarget.value,
+													)
+													handle.update()
+												}),
+												css(textareaCss),
+											]}
+										/>
+									</label>
+
+									<label mix={css(fieldCss)}>
+										<span mix={css(fieldLabelCss)}>Allowed sources</span>
+										<textarea
+											name="sources"
+											value={editorState.sourcesText}
+											placeholder="personal-client"
+											disabled={isMutating}
+											mix={[
+												on('input', (event) => {
+													setEditorField(
+														'sourcesText',
+														event.currentTarget.value,
+													)
+													handle.update()
+												}),
+												css(textareaCss),
+											]}
+										/>
+										<span mix={css(descriptionCss)}>
+											Leave blank to allow requests that omit source. If a
+											request supplies source, it must be listed here exactly.
+										</span>
+									</label>
+
+									<div
+										mix={css({
+											display: 'flex',
+											gap: spacing.sm,
+											flexWrap: 'wrap',
+										})}
+									>
+										<button
+											type="submit"
+											disabled={isMutating}
+											mix={css(primaryButtonCss)}
+										>
+											{saveState === 'creating'
+												? 'Creating...'
+												: 'Create token'}
+										</button>
+									</div>
+								</form>
+							) : null}
+
+							{isEditingSelectedToken ? (
+								<form
+									method="post"
+									noValidate
+									mix={[
+										on('submit', (event) => {
+											event.preventDefault()
+											if (event.currentTarget instanceof HTMLFormElement) {
+												void updateSelectedToken(event.currentTarget)
+											}
+										}),
+										css(cardCss),
+									]}
+								>
+									<div mix={css({ display: 'grid', gap: spacing.xs })}>
+										<h2 mix={css(cardTitleCss)}>Edit token</h2>
+										<p mix={css(descriptionCss)}>
+											Update this token's display name and allowed scopes. The
+											raw token and stored hash are preserved and never shown.
+										</p>
+									</div>
+
+									<label mix={css(fieldCss)}>
+										<span mix={css(fieldLabelCss)}>Name</span>
+										<input
+											name="name"
+											type="text"
+											value={editorState.name}
+											placeholder="Personal automation"
+											disabled={isMutating}
+											required
+											mix={[
+												on('input', (event) => {
+													setEditorField('name', event.currentTarget.value)
+													handle.update()
+												}),
+												css(inputCss),
+											]}
+										/>
+									</label>
+
+									<div
+										mix={css({
+											display: 'grid',
+											gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+											gap: spacing.md,
+											[mq.mobile]: {
+												gridTemplateColumns: '1fr',
+											},
+										})}
+									>
+										<label mix={css(fieldCss)}>
+											<span mix={css(fieldLabelCss)}>Package Kody IDs</span>
+											<textarea
+												name="packageKodyIds"
+												value={editorState.packageKodyIdsText}
+												placeholder={'discord-gateway\n*'}
+												disabled={isMutating}
+												mix={[
+													on('input', (event) => {
+														setEditorField(
+															'packageKodyIdsText',
+															event.currentTarget.value,
+														)
+														handle.update()
+													}),
+													css(textareaCss),
+												]}
+											/>
+										</label>
+										<label mix={css(fieldCss)}>
+											<span mix={css(fieldLabelCss)}>Package IDs</span>
+											<textarea
+												name="packageIds"
+												value={editorState.packageIdsText}
+												placeholder="pkg_..."
+												disabled={isMutating}
+												mix={[
+													on('input', (event) => {
+														setEditorField(
+															'packageIdsText',
+															event.currentTarget.value,
+														)
+														handle.update()
+													}),
+													css(textareaCss),
+												]}
+											/>
+										</label>
+									</div>
+
+									<label mix={css(fieldCss)}>
+										<span mix={css(fieldLabelCss)}>Export names</span>
+										<textarea
+											name="exportNames"
+											value={editorState.exportNamesText}
+											placeholder={'dispatch-message-created\n*'}
+											disabled={isMutating}
+											required
+											mix={[
+												on('input', (event) => {
+													setEditorField(
+														'exportNamesText',
+														event.currentTarget.value,
+													)
+													handle.update()
+												}),
+												css(textareaCss),
+											]}
+										/>
+									</label>
+
+									<label mix={css(fieldCss)}>
+										<span mix={css(fieldLabelCss)}>Allowed sources</span>
+										<textarea
+											name="sources"
+											value={editorState.sourcesText}
+											placeholder="personal-client"
+											disabled={isMutating}
+											mix={[
+												on('input', (event) => {
+													setEditorField(
+														'sourcesText',
+														event.currentTarget.value,
+													)
+													handle.update()
+												}),
+												css(textareaCss),
+											]}
+										/>
+										<span mix={css(descriptionCss)}>
+											Leave blank to allow requests that omit source. If a
+											request supplies source, it must be listed here exactly.
+										</span>
+									</label>
+
+									<div
+										mix={css({
+											display: 'flex',
+											gap: spacing.sm,
+											flexWrap: 'wrap',
+										})}
+									>
+										<button
+											type="submit"
+											disabled={isMutating}
+											mix={css(primaryButtonCss)}
+										>
+											{saveState === 'updating' ? 'Saving...' : 'Save token'}
+										</button>
+										<button
+											type="button"
+											disabled={isMutating}
+											mix={[
+												on('click', cancelEditToken),
+												css(secondaryButtonCss),
+											]}
+										>
+											Cancel
+										</button>
+									</div>
+								</form>
+							) : null}
 
 							<section mix={css(cardCss)}>
 								<h2 mix={css(cardTitleCss)}>Invocation endpoint</h2>
@@ -828,13 +1277,17 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 								</code>
 							</section>
 
-							{selectedToken ? (
+							{selectedToken && !isEditingSelectedToken ? (
 								<section mix={css(cardCss)}>
 									<div mix={css({ display: 'grid', gap: spacing.xs })}>
 										<h2 mix={css(cardTitleCss)}>{selectedToken.name}</h2>
 										<span mix={css(tokenStatusCss(selectedToken))}>
 											{tokenStatus(selectedToken)}
 										</span>
+										<p mix={css(descriptionCss)}>
+											Token material is hidden permanently. This view only shows
+											metadata and policy scopes.
+										</p>
 									</div>
 									<dl
 										mix={css({
@@ -848,12 +1301,15 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 										})}
 									>
 										<div>
-											<dt mix={css(fieldLabelCss)}>Packages</dt>
+											<dt mix={css(fieldLabelCss)}>Package Kody IDs</dt>
 											<dd mix={css({ margin: 0, color: colors.text })}>
-												{formatScope([
-													...selectedToken.packageKodyIds,
-													...selectedToken.packageIds,
-												])}
+												{formatScope(selectedToken.packageKodyIds)}
+											</dd>
+										</div>
+										<div>
+											<dt mix={css(fieldLabelCss)}>Package IDs</dt>
+											<dd mix={css({ margin: 0, color: colors.text })}>
+												{formatScope(selectedToken.packageIds)}
 											</dd>
 										</div>
 										<div>
@@ -881,37 +1337,132 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 											</dd>
 										</div>
 										<div>
+											<dt mix={css(fieldLabelCss)}>Updated</dt>
+											<dd mix={css({ margin: 0, color: colors.text })}>
+												{formatTimestamp(selectedToken.updatedAt)}
+											</dd>
+										</div>
+										<div>
 											<dt mix={css(fieldLabelCss)}>Revoked</dt>
 											<dd mix={css({ margin: 0, color: colors.text })}>
 												{formatTimestamp(selectedToken.revokedAt)}
 											</dd>
 										</div>
 									</dl>
-									{selectedToken.revokedAt ? null : (
-										<div>
+									<div
+										mix={css({
+											display: 'flex',
+											gap: spacing.sm,
+											flexWrap: 'wrap',
+										})}
+									>
+										{selectedToken.revokedAt ? (
 											<button
 												type="button"
 												disabled={isMutating}
 												mix={[
 													on('click', () => {
-														if (!revokeConfirm) {
-															revokeConfirm = true
-															handle.update()
-															return
-														}
-														void revokeSelectedToken()
+														void unrevokeSelectedToken()
 													}),
-													css(dangerButtonCss),
+													css(secondaryButtonCss),
 												]}
 											>
-												{saveState === 'revoking'
-													? 'Revoking...'
-													: revokeConfirm
-														? 'Confirm revoke'
-														: 'Revoke token'}
+												{saveState === 'unrevoking'
+													? 'Un-revoking...'
+													: 'Un-revoke token'}
 											</button>
-										</div>
-									)}
+										) : (
+											<>
+												<button
+													type="button"
+													disabled={isMutating}
+													mix={[
+														on('click', () => startEditToken(selectedToken)),
+														css(secondaryButtonCss),
+													]}
+												>
+													Edit token
+												</button>
+												<button
+													type="button"
+													disabled={isMutating}
+													mix={[
+														on('click', () => {
+															if (!revokeConfirm) {
+																revokeConfirm = true
+																deleteConfirm = false
+																handle.update()
+																return
+															}
+															void revokeSelectedToken()
+														}),
+														css(dangerButtonCss),
+													]}
+												>
+													{saveState === 'revoking'
+														? 'Revoking...'
+														: revokeConfirm
+															? 'Confirm revoke'
+															: 'Revoke token'}
+												</button>
+											</>
+										)}
+										<button
+											type="button"
+											disabled={isMutating}
+											mix={[
+												on('click', () => {
+													if (!deleteConfirm) {
+														deleteConfirm = true
+														revokeConfirm = false
+														handle.update()
+														return
+													}
+													void deleteSelectedToken()
+												}),
+												css(dangerButtonCss),
+											]}
+										>
+											{saveState === 'deleting'
+												? 'Deleting...'
+												: deleteConfirm
+													? 'Confirm permanent delete'
+													: 'Delete permanently'}
+										</button>
+									</div>
+								</section>
+							) : null}
+
+							{requestedTokenId && !selectedToken ? (
+								<section mix={css(cardCss)}>
+									<h2 mix={css(cardTitleCss)}>Token not found</h2>
+									<p mix={css(descriptionCss)}>
+										This package invocation token does not exist for this
+										account or is no longer available.
+									</p>
+									<button
+										type="button"
+										disabled={isMutating}
+										mix={[
+											on('click', () => {
+												selectedTokenId = null
+												editorState = createEmptyEditorState()
+												editMode = false
+												if (typeof window !== 'undefined') {
+													window.history.pushState(
+														null,
+														'',
+														accountPackageInvocationTokensBasePath,
+													)
+													lastLoadedHref = window.location.href
+												}
+												handle.update()
+											}),
+											css(secondaryButtonCss),
+										]}
+									>
+										Back to tokens
+									</button>
 								</section>
 							) : null}
 

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -101,15 +101,50 @@ function readCommaListParams(params: URLSearchParams, keys: Array<string>) {
 function createEditorStateFromNewTokenQuery(href: string): EditorState {
 	const params = new URL(href, 'http://localhost').searchParams
 	const state = createEmptyEditorState()
-	const packageIds = readCommaListParams(params, ['packageId', 'packageIds'])
+	const packageIds = readCommaListParams(params, [
+		'packageId',
+		'packageIds',
+		'package_id',
+		'package_ids',
+		'package-id',
+		'package-ids',
+	])
 	const packageKodyIds = readCommaListParams(params, [
 		'packageKodyId',
 		'packageKodyIds',
+		'package_kody_id',
+		'package_kody_ids',
+		'package-kody-id',
+		'package-kody-ids',
 		'kodyId',
 		'kodyIds',
+		'kody_id',
+		'kody_ids',
+		'kody-id',
+		'kody-ids',
 	])
-	const exportNames = readCommaListParams(params, ['exportName', 'exportNames'])
-	const sources = readCommaListParams(params, ['source', 'sources'])
+	const exportNames = readCommaListParams(params, [
+		'exportName',
+		'exportNames',
+		'export_name',
+		'export_names',
+		'export-name',
+		'export-names',
+	])
+	const sources = readCommaListParams(params, [
+		'source',
+		'sources',
+		'source_name',
+		'source_names',
+		'source-name',
+		'source-names',
+		'allowedSource',
+		'allowedSources',
+		'allowed_source',
+		'allowed_sources',
+		'allowed-source',
+		'allowed-sources',
+	])
 	return {
 		...state,
 		name: readTrimmedParam(params, 'name') ?? state.name,
@@ -150,14 +185,40 @@ function getNewTokenQueryKey(href: string) {
 		'name',
 		'packageId',
 		'packageIds',
+		'package_id',
+		'package_ids',
+		'package-id',
+		'package-ids',
 		'packageKodyId',
 		'packageKodyIds',
+		'package_kody_id',
+		'package_kody_ids',
+		'package-kody-id',
+		'package-kody-ids',
 		'kodyId',
 		'kodyIds',
+		'kody_id',
+		'kody_ids',
+		'kody-id',
+		'kody-ids',
 		'exportName',
 		'exportNames',
+		'export_name',
+		'export_names',
+		'export-name',
+		'export-names',
 		'source',
 		'sources',
+		'source_name',
+		'source_names',
+		'source-name',
+		'source-names',
+		'allowedSource',
+		'allowedSources',
+		'allowed_source',
+		'allowed_sources',
+		'allowed-source',
+		'allowed-sources',
 	]
 	return keys
 		.map((key) => `${key}=${url.searchParams.getAll(key).join('\u0000')}`)

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -18,6 +18,9 @@ export const clientRoutes = {
 	'/account/package-invocation-tokens/new': (
 		<AccountPackageInvocationTokensRoute />
 	),
+	'/account/package-invocation-tokens/:tokenId': (
+		<AccountPackageInvocationTokensRoute />
+	),
 	'/account/remote-connectors': <AccountRemoteConnectorsRoute />,
 	'/account/secrets': <AccountSecretsRoute />,
 	'/account/secrets/new': <AccountSecretsRoute />,

--- a/packages/worker/src/app/handlers/account-package-invocation-tokens.node.test.ts
+++ b/packages/worker/src/app/handlers/account-package-invocation-tokens.node.test.ts
@@ -42,6 +42,9 @@ const mockModule = vi.hoisted(() => ({
 		},
 	]),
 	revokePackageInvocationToken: vi.fn(async () => true),
+	unrevokePackageInvocationToken: vi.fn(async () => true),
+	deletePackageInvocationToken: vi.fn(async () => true),
+	updatePackageInvocationToken: vi.fn(async () => true),
 	listSavedPackagesByUserId: vi.fn(async () => [
 		{
 			id: 'pkg-1',
@@ -94,6 +97,12 @@ vi.mock('#worker/package-invocations/repo.ts', () => ({
 		mockModule.listPackageInvocationTokensByUserId(...args),
 	revokePackageInvocationToken: (...args: Array<unknown>) =>
 		mockModule.revokePackageInvocationToken(...args),
+	unrevokePackageInvocationToken: (...args: Array<unknown>) =>
+		mockModule.unrevokePackageInvocationToken(...args),
+	deletePackageInvocationToken: (...args: Array<unknown>) =>
+		mockModule.deletePackageInvocationToken(...args),
+	updatePackageInvocationToken: (...args: Array<unknown>) =>
+		mockModule.updatePackageInvocationToken(...args),
 }))
 
 vi.mock('#worker/package-invocations/service.ts', () => ({
@@ -126,10 +135,13 @@ function resetMocks() {
 	mockModule.insertPackageInvocationToken.mockClear()
 	mockModule.listPackageInvocationTokensByUserId.mockClear()
 	mockModule.revokePackageInvocationToken.mockClear()
+	mockModule.unrevokePackageInvocationToken.mockClear()
+	mockModule.deletePackageInvocationToken.mockClear()
+	mockModule.updatePackageInvocationToken.mockClear()
 	mockModule.listSavedPackagesByUserId.mockClear()
 }
 
-test('package invocation token API lists, creates, validates, and revokes tokens', async () => {
+test('package invocation token API lists, creates, updates, validates, revokes, restores, and deletes tokens', async () => {
 	resetMocks()
 	const env = createEnv()
 	const handler = createAccountPackageInvocationTokensApiHandler(env)
@@ -242,6 +254,72 @@ test('package invocation token API lists, creates, validates, and revokes tokens
 	})
 	expect(mockModule.insertPackageInvocationToken).toHaveBeenCalledTimes(1)
 
+	const updateResponse = await handler.handler({
+		request: new Request(
+			'https://example.com/account/package-invocation-tokens.json',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					action: 'update',
+					id: 'token-1',
+					name: 'Updated personal client',
+					packageKodyIds: ['discord-gateway'],
+					exportNames: ['dispatch-message-created'],
+					sources: ['updated-client'],
+					rawToken: 'should-not-be-read',
+					tokenHash: 'should-not-be-read',
+				}),
+			},
+		),
+		params: {},
+	} as never)
+
+	expect(updateResponse.status).toBe(200)
+	expect(mockModule.hashPackageInvocationBearerToken).toHaveBeenCalledTimes(1)
+	expect(mockModule.updatePackageInvocationToken).toHaveBeenCalledWith({
+		db: env.APP_DB,
+		userId: 'stable-user-1',
+		id: 'token-1',
+		name: 'Updated personal client',
+		packageIds: [],
+		packageKodyIds: ['discord-gateway'],
+		exportNames: ['./dispatch-message-created'],
+		sources: ['updated-client'],
+	})
+	const updateText = await updateResponse.text()
+	expect(updateText).not.toContain('should-not-be-read')
+	expect(updateText).not.toContain('stored-hash')
+	expect(JSON.parse(updateText)).toMatchObject({
+		ok: true,
+		selectedTokenId: 'token-1',
+	})
+
+	const invalidUpdateResponse = await handler.handler({
+		request: new Request(
+			'https://example.com/account/package-invocation-tokens.json',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					action: 'update',
+					id: 'token-1',
+					name: 'Bad update',
+					packageKodyIds: ['other-package'],
+					exportNames: ['run'],
+				}),
+			},
+		),
+		params: {},
+	} as never)
+
+	expect(invalidUpdateResponse.status).toBe(400)
+	await expect(invalidUpdateResponse.json()).resolves.toEqual({
+		ok: false,
+		error: 'Unknown package Kody id: other-package',
+	})
+	expect(mockModule.updatePackageInvocationToken).toHaveBeenCalledTimes(1)
+
 	const revokeResponse = await handler.handler({
 		request: new Request(
 			'https://example.com/account/package-invocation-tokens.json',
@@ -264,4 +342,55 @@ test('package invocation token API lists, creates, validates, and revokes tokens
 		id: 'token-1',
 	})
 	await expect(revokeResponse.json()).resolves.toMatchObject({ ok: true })
+
+	const unrevokeResponse = await handler.handler({
+		request: new Request(
+			'https://example.com/account/package-invocation-tokens.json',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					action: 'unrevoke',
+					id: 'token-1',
+				}),
+			},
+		),
+		params: {},
+	} as never)
+
+	expect(unrevokeResponse.status).toBe(200)
+	expect(mockModule.unrevokePackageInvocationToken).toHaveBeenCalledWith({
+		db: env.APP_DB,
+		userId: 'stable-user-1',
+		id: 'token-1',
+	})
+	await expect(unrevokeResponse.json()).resolves.toMatchObject({
+		ok: true,
+		selectedTokenId: 'token-1',
+	})
+
+	const deleteResponse = await handler.handler({
+		request: new Request(
+			'https://example.com/account/package-invocation-tokens.json',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					action: 'delete',
+					id: 'token-1',
+				}),
+			},
+		),
+		params: {},
+	} as never)
+
+	expect(deleteResponse.status).toBe(200)
+	expect(mockModule.deletePackageInvocationToken).toHaveBeenCalledWith({
+		db: env.APP_DB,
+		userId: 'stable-user-1',
+		id: 'token-1',
+	})
+	const deletePayload = await deleteResponse.json()
+	expect(deletePayload).toMatchObject({ ok: true })
+	expect(deletePayload).not.toHaveProperty('selectedTokenId')
 })

--- a/packages/worker/src/app/handlers/account-package-invocation-tokens.ts
+++ b/packages/worker/src/app/handlers/account-package-invocation-tokens.ts
@@ -7,11 +7,14 @@ import { Layout } from '#app/layout.ts'
 import { render } from '#app/render.ts'
 import { type routes } from '#app/routes.ts'
 import {
+	deletePackageInvocationToken,
 	hashPackageInvocationBearerToken,
 	insertPackageInvocationToken,
 	listPackageInvocationTokensByUserId,
 	revokePackageInvocationToken,
 	type PackageInvocationTokenRecord,
+	unrevokePackageInvocationToken,
+	updatePackageInvocationToken,
 } from '#worker/package-invocations/repo.ts'
 import {
 	normalizeExportName,
@@ -98,6 +101,15 @@ export function createAccountPackageInvocationTokensApiHandler(env: Env) {
 			}
 			if (action === 'revoke') {
 				return handleRevokeAction({ env, request, user, body })
+			}
+			if (action === 'unrevoke') {
+				return handleUnrevokeAction({ env, request, user, body })
+			}
+			if (action === 'delete') {
+				return handleDeleteAction({ env, request, user, body })
+			}
+			if (action === 'update') {
+				return handleUpdateAction({ env, request, user, body })
 			}
 
 			return jsonResponse({ ok: false, error: 'Invalid action.' }, 400)
@@ -231,6 +243,116 @@ async function handleCreateAction(input: {
 	})
 }
 
+async function handleUpdateAction(input: {
+	env: Env
+	request: Request
+	user: AuthenticatedUser
+	body: object
+}) {
+	const id = readString(input.body, 'id')
+	const name = readString(input.body, 'name')
+	if (!id) {
+		return jsonResponse({ ok: false, error: 'Token id is required.' }, 400)
+	}
+	if (!name) {
+		return jsonResponse({ ok: false, error: 'Token name is required.' }, 400)
+	}
+
+	let packageIds: Array<string>
+	let packageKodyIds: Array<string>
+	let exportNames: Array<string>
+	try {
+		packageIds = normalizeScopeList(
+			readStringArray(input.body, ['packageIds', 'packageId', 'package_ids']),
+			{ allowWildcard: true },
+		)
+		packageKodyIds = normalizeScopeList(
+			readStringArray(input.body, [
+				'packageKodyIds',
+				'packageKodyId',
+				'package_kody_ids',
+				'kodyIds',
+				'kodyId',
+			]),
+			{ allowWildcard: true },
+		)
+		exportNames = normalizeExportScopeList(
+			readStringArray(input.body, [
+				'exportNames',
+				'exportName',
+				'export_names',
+			]),
+		)
+	} catch (error) {
+		return jsonResponse(
+			{
+				ok: false,
+				error:
+					error instanceof Error
+						? error.message
+						: 'Invalid package invocation token scope.',
+			},
+			400,
+		)
+	}
+	const sources = normalizeScopeList(
+		readStringArray(input.body, ['sources', 'source', 'source_names']),
+		{ allowWildcard: false },
+	)
+
+	if (packageIds.length === 0 && packageKodyIds.length === 0) {
+		return jsonResponse(
+			{ ok: false, error: 'Choose at least one package scope.' },
+			400,
+		)
+	}
+	if (exportNames.length === 0) {
+		return jsonResponse(
+			{ ok: false, error: 'Choose at least one export scope.' },
+			400,
+		)
+	}
+
+	const savedPackages = await listSavedPackagesByUserId(input.env.APP_DB, {
+		userId: input.user.mcpUser.userId,
+	})
+	const scopeError = validatePackageScopes({
+		savedPackages,
+		packageIds,
+		packageKodyIds,
+	})
+	if (scopeError) {
+		return jsonResponse({ ok: false, error: scopeError }, 400)
+	}
+
+	const updated = await updatePackageInvocationToken({
+		db: input.env.APP_DB,
+		userId: input.user.mcpUser.userId,
+		id,
+		name,
+		packageIds,
+		packageKodyIds,
+		exportNames,
+		sources,
+	})
+	if (!updated) {
+		return jsonResponse(
+			{ ok: false, error: 'Package invocation token not found or revoked.' },
+			404,
+		)
+	}
+
+	return jsonResponse({
+		...(await buildPayload({
+			env: input.env,
+			request: input.request,
+			user: input.user,
+			savedPackages,
+		})),
+		selectedTokenId: id,
+	})
+}
+
 async function handleRevokeAction(input: {
 	env: Env
 	request: Request
@@ -247,6 +369,67 @@ async function handleRevokeAction(input: {
 		id,
 	})
 	if (!revoked) {
+		return jsonResponse(
+			{ ok: false, error: 'Package invocation token not found.' },
+			404,
+		)
+	}
+	return jsonResponse(
+		await buildPayload({
+			env: input.env,
+			request: input.request,
+			user: input.user,
+		}),
+	)
+}
+
+async function handleUnrevokeAction(input: {
+	env: Env
+	request: Request
+	user: AuthenticatedUser
+	body: object
+}) {
+	const id = readString(input.body, 'id')
+	if (!id) {
+		return jsonResponse({ ok: false, error: 'Token id is required.' }, 400)
+	}
+	const restored = await unrevokePackageInvocationToken({
+		db: input.env.APP_DB,
+		userId: input.user.mcpUser.userId,
+		id,
+	})
+	if (!restored) {
+		return jsonResponse(
+			{ ok: false, error: 'Package invocation token not found or active.' },
+			404,
+		)
+	}
+	return jsonResponse({
+		...(await buildPayload({
+			env: input.env,
+			request: input.request,
+			user: input.user,
+		})),
+		selectedTokenId: id,
+	})
+}
+
+async function handleDeleteAction(input: {
+	env: Env
+	request: Request
+	user: AuthenticatedUser
+	body: object
+}) {
+	const id = readString(input.body, 'id')
+	if (!id) {
+		return jsonResponse({ ok: false, error: 'Token id is required.' }, 400)
+	}
+	const deleted = await deletePackageInvocationToken({
+		db: input.env.APP_DB,
+		userId: input.user.mcpUser.userId,
+		id,
+	})
+	if (!deleted) {
 		return jsonResponse(
 			{ ok: false, error: 'Package invocation token not found.' },
 			404,

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -61,6 +61,8 @@ export function createAppRouter(appEnv: AppEnv) {
 				createAccountPackageInvocationTokensHandler(appEnv as unknown as Env),
 			accountPackageInvocationTokenNew:
 				createAccountPackageInvocationTokensHandler(appEnv as unknown as Env),
+			accountPackageInvocationTokenDetail:
+				createAccountPackageInvocationTokensHandler(appEnv as unknown as Env),
 			accountPackageInvocationTokensApi:
 				createAccountPackageInvocationTokensApiHandler(
 					appEnv as unknown as Env,

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -7,6 +7,8 @@ export const routes = route({
 	accountIntegrationsApi: '/account/integrations.json',
 	accountPackageInvocationTokens: '/account/package-invocation-tokens',
 	accountPackageInvocationTokenNew: '/account/package-invocation-tokens/new',
+	accountPackageInvocationTokenDetail:
+		'/account/package-invocation-tokens/:tokenId',
 	accountPackageInvocationTokensApi: '/account/package-invocation-tokens.json',
 	accountPackageInvocationTokensApiPost: post(
 		'/account/package-invocation-tokens.json',

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -146,6 +146,7 @@ const guideFieldSchema = z
 			'`oauth`: standard third-party OAuth via /connect/oauth (read this first for OAuth).',
 			'`generated_ui_oauth`: edge case—OAuth in a hosted package app.',
 			'`connect_secret`: /account/secrets/new for API keys, PATs, and other secret collection steps.',
+			'`package_invocation_token_setup`: /account/package-invocation-tokens/new URL shape, query params, and bearer-token safety policy for external package invocation clients.',
 			'`package_service_pattern`: package-native long-lived service architecture built on package services and package app realtime.',
 			'`package_subscriptions`: package-owned event subscriptions, package_subscription_list discovery, and email.message.received metadata-first handler payloads.',
 		].join(' '),

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -58,6 +58,12 @@ export const kodyOfficialGuideCatalog = {
 		summary:
 			'Hosted /account/secrets/new URL shape, query params, and approval policy for API keys and PATs.',
 	},
+	package_invocation_token_setup: {
+		file: 'account-package-invocation-token-setup.md',
+		title: 'Account package invocation token setup guide',
+		summary:
+			'Hosted /account/package-invocation-tokens/new URL shape, query params, and bearer-token safety policy for external package invocation clients.',
+	},
 	package_service_pattern: {
 		file: 'package-service-pattern.md',
 		title: 'Package service pattern guide',

--- a/packages/worker/src/package-invocations/repo.ts
+++ b/packages/worker/src/package-invocations/repo.ts
@@ -262,6 +262,43 @@ export async function insertPackageInvocationToken(input: {
 		.run()
 }
 
+export async function updatePackageInvocationToken(input: {
+	db: D1Database
+	userId: string
+	id: string
+	name: string
+	packageIds: Array<string>
+	packageKodyIds: Array<string>
+	exportNames: Array<string>
+	sources: Array<string>
+}) {
+	const result = await input.db
+		.prepare(
+			`UPDATE package_invocation_tokens
+			SET name = ?,
+				package_ids_json = ?,
+				package_kody_ids_json = ?,
+				export_names_json = ?,
+				sources_json = ?,
+				updated_at = ?
+			WHERE id = ?
+				AND user_id = ?
+				AND revoked_at IS NULL`,
+		)
+		.bind(
+			input.name,
+			JSON.stringify(input.packageIds),
+			JSON.stringify(input.packageKodyIds),
+			JSON.stringify(input.exportNames),
+			JSON.stringify(input.sources),
+			new Date().toISOString(),
+			input.id,
+			input.userId,
+		)
+		.run()
+	return (result.meta.changes ?? 0) > 0
+}
+
 export async function revokePackageInvocationToken(input: {
 	db: D1Database
 	userId: string
@@ -277,6 +314,40 @@ export async function revokePackageInvocationToken(input: {
 				AND revoked_at IS NULL`,
 		)
 		.bind(now, now, input.id, input.userId)
+		.run()
+	return (result.meta.changes ?? 0) > 0
+}
+
+export async function unrevokePackageInvocationToken(input: {
+	db: D1Database
+	userId: string
+	id: string
+}) {
+	const result = await input.db
+		.prepare(
+			`UPDATE package_invocation_tokens
+			SET revoked_at = NULL, updated_at = ?
+			WHERE id = ?
+				AND user_id = ?
+				AND revoked_at IS NOT NULL`,
+		)
+		.bind(new Date().toISOString(), input.id, input.userId)
+		.run()
+	return (result.meta.changes ?? 0) > 0
+}
+
+export async function deletePackageInvocationToken(input: {
+	db: D1Database
+	userId: string
+	id: string
+}) {
+	const result = await input.db
+		.prepare(
+			`DELETE FROM package_invocation_tokens
+			WHERE id = ?
+				AND user_id = ?`,
+		)
+		.bind(input.id, input.userId)
 		.run()
 	return (result.meta.changes ?? 0) > 0
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add stable package invocation token detail URLs and a safe metadata/editor view that never returns or displays existing raw token material or token hashes.
- Rework package token management to follow the secrets UI pattern more closely: selecting an active token opens an editor form directly.
- Add optional write-only token value rotation: leaving the replacement field blank preserves the current hash; entering a new raw token replaces the stored hash.
- Add revoke, un-revoke, and permanent delete lifecycle actions in the account UI/API.
- Add shared account management UI components used by both the secrets and package-token pages.
- Add `/account/package-invocation-tokens/new` query-param prefill aliases and an official `package_invocation_token_setup` guide for agents.
- Extend focused handler coverage for list/create/update/replace-token/revoke/un-revoke/delete and no-secret response behavior.

## Walkthrough
<a href="https://cursor.com/agents/bc-fcef8bdd-53d0-4f33-b8eb-9ca7e2067030/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpackage-token-view-edit-revoke.mp4"><img src="https://cursor.com/artifacts/c/art-bb32af5f-9508-4b6a-aa5e-c20d390bbec8" alt="package-token-view-edit-revoke.mp4" /></a>
<a href="https://cursor.com/agents/bc-fcef8bdd-53d0-4f33-b8eb-9ca7e2067030/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpackage-token-unrevoke-delete.mp4"><img src="https://cursor.com/artifacts/c/art-4b584d7b-eea6-4daf-83c3-3375c6ba0959" alt="package-token-unrevoke-delete.mp4" /></a>
<a href="https://cursor.com/agents/bc-fcef8bdd-53d0-4f33-b8eb-9ca7e2067030/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpackage-token-prefill-back.mp4"><img src="https://cursor.com/artifacts/c/art-4d7c9e74-6365-44fa-8b77-7541b6e47e28" alt="package-token-prefill-back.mp4" /></a>
<a href="https://cursor.com/agents/bc-fcef8bdd-53d0-4f33-b8eb-9ca7e2067030/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpackage-token-edit-rotate-shared-ui-passed.mp4"><img src="https://cursor.com/artifacts/c/art-285b6b44-c79d-4be1-b964-b7e6e90fcf92" alt="package-token-edit-rotate-shared-ui-passed.mp4" /></a>

## Testing
- `npx vitest run packages/worker/src/app/handlers/account-package-invocation-tokens.node.test.ts`
- `npx vitest run packages/worker/src/app/handlers/account-package-invocation-tokens.node.test.ts packages/worker/src/mcp/capabilities/coding/kody-official-guide.node.test.ts`
- `npm run typecheck`
- `npm run format:check`
- `npm run lint` (existing unrelated warnings only)
- `npm run validate`
- Manual browser walkthroughs on local dev server at `http://localhost:3742` covering secrets page rendering, create, query-param prefill, direct token editor, write-only token value replacement, revoke, un-revoke, permanent delete, and edit/back behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcef8bdd-53d0-4f33-b8eb-9ca7e2067030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcef8bdd-53d0-4f33-b8eb-9ca7e2067030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token-specific detail pages using URL path navigation.
  * Added full token lifecycle actions: create, edit, update, revoke/unrevoke, and permanent delete.
* **Bug Fixes**
  * Added a clear “token not found” view when the URL token ID doesn’t match loaded data.
  * Improved in-app history/navigation so actions remain on the correct token detail view.
* **Tests**
  * Expanded API and route test coverage for update, unrevoke, delete, and invalid update scenarios.
* **Documentation**
  * Updated token-management docs and added a new guide for setting up account package invocation tokens, including supported URL/query aliases and bearer-token safety guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->