### PR TITLE
Add package invocation URL guardrails

### DIFF
--- a/docs/guides/account-package-invocation-token-setup.md
+++ b/docs/guides/account-package-invocation-token-setup.md
@@ -145,15 +145,16 @@ shell, not the client-loaded token list, and
 cookie. Agents should not treat missing token metadata in the HTML shell as
 proof that a token was not saved.
 
-For external invocation smoke tests, the first failure boundary is bearer-token
-authentication on a correctly shaped endpoint. If a request returns
-`invalid_token`, first verify the endpoint includes the `@:username` owner slug
-and that the slug matches the package owner. The correct route shape is
-`/@:username/api/package-invocations/:kodyId/:exportName`;
-`/api/package-invocations/...` is missing the owner slug and is not an
-invocation route. After the endpoint shape and owner slug are confirmed, rotate
-the package invocation token or check that the external secret contains the
-exact active raw bearer value.
+For external invocation smoke tests, check failures in this order:
+
+1. `owner_slug_required`: the endpoint is missing the `@:username` owner slug.
+   Use `/@:username/api/package-invocations/:kodyId/:exportName`;
+   `/api/package-invocations/...` is not an invocation route.
+2. `not_found`: verify the owner slug matches the package owner.
+3. `invalid_token` or `Invalid package invocation token`: the request reached
+   bearer-token authentication on a correctly shaped owner-scoped endpoint.
+   Rotate the package invocation token or check that the external secret
+   contains the exact active raw bearer value.
 
 Package export names and `source` policy are checked only after bearer-token
 authentication succeeds.

--- a/docs/guides/account-package-invocation-token-setup.md
+++ b/docs/guides/account-package-invocation-token-setup.md
@@ -40,6 +40,12 @@ will not show the raw value again.
 
 ## URL format
 
+This section is only for token setup. Setup URLs under
+`/account/package-invocation-tokens/new` open the browser UI where the signed-in
+user creates or rotates a token. They are **not** package invocation URLs and
+must not be used by external workers, webhooks, or CLIs as the HTTP API
+endpoint.
+
 Provide the user a URL like:
 
 `https://heykody.dev/account/package-invocation-tokens/new?name=Discord%20Gateway&packageKodyIds=discord-gateway&exportNames=dispatch-message-created&allowedSources=discord-gateway`
@@ -68,6 +74,46 @@ field names without extra translation.
 \* At least one package scope is required: either a package Kody id scope or a
 package id scope.
 
+## Invocation URL format
+
+External callers invoke package exports with the owner-scoped route:
+
+`POST https://heykody.dev/@:username/api/package-invocations/:kodyId/:exportName`
+
+The `@:username` segment is required and must be the public username of the
+package owner. Do not use the stale unscoped form
+`/api/package-invocations/:kodyId/:exportName`.
+
+Export names are normalized for token scope checks. The URL path usually omits
+the leading `./`, so an export scoped as `./process-video` is invoked with the
+path segment `process-video`.
+
+Concrete YouTube WebSub Worker example:
+
+```sh
+curl -X POST \
+	"https://heykody.dev/@kentcdodds/api/package-invocations/youtube-livestream-vod-manager/process-video" \
+	-H "Authorization: Bearer <raw-token>" \
+	-H "Content-Type: application/json" \
+	-d '{
+		"idempotencyKey": "youtube:<video-id>",
+		"source": "youtube-websub-proxy",
+		"params": {
+			"videoId": "<video-id>"
+		}
+	}'
+```
+
+When a token is scoped to allowed sources, the request JSON `source` must match
+one of those source labels exactly. For Kent's YouTube Worker, use
+`"source": "youtube-websub-proxy"`.
+
+Prefer canonical URL metadata from package discovery over manual string
+construction. `package_get` and package entity search details include canonical
+external invocation metadata with the URL, path, route export name, normalized
+export name used for token scope checks, and source guidance for each callable
+export.
+
 ## Agent instructions
 
 1. Identify the saved package and export the external system needs to call.
@@ -81,10 +127,10 @@ package id scope.
    - For rotation, ask the user to open the existing token detail URL and paste
      or generate the new raw token in the **Token value** section.
    - The external service or secret store must receive the exact raw value that
-     was pasted/generated. If invocation later returns `invalid_token`, rotate
-     the package invocation token and update the external secret with the newly
-     copied value.
+     was pasted/generated.
 4. Instruct the external caller to send:
+   - `POST` to the canonical owner-scoped invocation URL from package metadata,
+     not to a `/account/package-invocation-tokens/...` setup URL
    - `Authorization: Bearer <raw-token>`
    - JSON `source` matching one of the allowed sources when sources are scoped
 5. Never display, log, store in docs, or send raw token material through chat or
@@ -100,10 +146,17 @@ cookie. Agents should not treat missing token metadata in the HTML shell as
 proof that a token was not saved.
 
 For external invocation smoke tests, the first failure boundary is bearer-token
-authentication. A `401 invalid_token` or `Invalid package invocation token`
-response means the presented raw bearer value did not match any active stored
-package invocation token for the route; package export names and `source` policy
-are checked only after authentication succeeds.
+authentication on a correctly shaped endpoint. If a request returns
+`invalid_token`, first verify the endpoint includes the `@:username` owner slug
+and that the slug matches the package owner. The correct route shape is
+`/@:username/api/package-invocations/:kodyId/:exportName`;
+`/api/package-invocations/...` is missing the owner slug and is not an
+invocation route. After the endpoint shape and owner slug are confirmed, rotate
+the package invocation token or check that the external secret contains the
+exact active raw bearer value.
+
+Package export names and `source` policy are checked only after bearer-token
+authentication succeeds.
 
 ## Related
 

--- a/packages/shared/src/public-urls.ts
+++ b/packages/shared/src/public-urls.ts
@@ -23,6 +23,8 @@ export function buildPackageAppUrl(input: {
 	return `${input.origin.trim().replace(/\/+$/, '')}${buildPackageAppPath(input)}`
 }
 
+export const packageInvocationRootExportRouteSegment = '__root__'
+
 export function normalizePackageInvocationExportName(exportName: string) {
 	const trimmed = exportName.trim()
 	if (!trimmed) {
@@ -36,6 +38,7 @@ export function normalizePackageInvocationExportName(exportName: string) {
 
 export function buildPackageInvocationRouteExportName(exportName: string) {
 	const normalized = normalizePackageInvocationExportName(exportName)
+	if (normalized === '.') return packageInvocationRootExportRouteSegment
 	return normalized.startsWith('./') ? normalized.slice(2) : normalized
 }
 

--- a/packages/shared/src/public-urls.ts
+++ b/packages/shared/src/public-urls.ts
@@ -23,6 +23,41 @@ export function buildPackageAppUrl(input: {
 	return `${input.origin.trim().replace(/\/+$/, '')}${buildPackageAppPath(input)}`
 }
 
+export function normalizePackageInvocationExportName(exportName: string) {
+	const trimmed = exportName.trim()
+	if (!trimmed) {
+		throw new Error('Package export name must not be empty.')
+	}
+	if (trimmed === '.' || trimmed === './') {
+		return '.'
+	}
+	return trimmed.startsWith('./') ? trimmed : `./${trimmed}`
+}
+
+export function buildPackageInvocationRouteExportName(exportName: string) {
+	const normalized = normalizePackageInvocationExportName(exportName)
+	return normalized.startsWith('./') ? normalized.slice(2) : normalized
+}
+
+export function buildPackageInvocationPath(input: {
+	username: string
+	kodyId: string
+	exportName: string
+}) {
+	return `${buildUsernamePathPrefix(input.username)}/api/package-invocations/${encodeURIComponent(
+		input.kodyId.trim(),
+	)}/${encodeURIComponent(buildPackageInvocationRouteExportName(input.exportName))}`
+}
+
+export function buildPackageInvocationUrl(input: {
+	origin: string
+	username: string
+	kodyId: string
+	exportName: string
+}) {
+	return `${input.origin.trim().replace(/\/+$/, '')}${buildPackageInvocationPath(input)}`
+}
+
 export function requireUsernameForPublicUrl(
 	username: string | null | undefined,
 ) {

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -62,7 +62,7 @@ export const kodyOfficialGuideCatalog = {
 		file: 'account-package-invocation-token-setup.md',
 		title: 'Account package invocation token setup guide',
 		summary:
-			'Hosted /account/package-invocation-tokens/new URL shape, query params, and bearer-token safety policy for external package invocation clients.',
+			'Hosted /account/package-invocation-tokens/new setup URL shape, owner-scoped /@:username/api/package-invocations invocation route shape, query params, and bearer-token safety policy for external package invocation clients.',
 	},
 	package_service_pattern: {
 		file: 'package-service-pattern.md',
@@ -146,7 +146,7 @@ const guideFieldSchema = z
 			'`oauth`: standard third-party OAuth via /connect/oauth (read this first for OAuth).',
 			'`generated_ui_oauth`: edge case—OAuth in a hosted package app.',
 			'`connect_secret`: /account/secrets/new for API keys, PATs, and other secret collection steps.',
-			'`package_invocation_token_setup`: /account/package-invocation-tokens/new URL shape, query params, and bearer-token safety policy for external package invocation clients.',
+			'`package_invocation_token_setup`: /account/package-invocation-tokens/new setup URL shape, owner-scoped /@:username/api/package-invocations invocation route shape, query params, and bearer-token safety policy for external package invocation clients.',
 			'`package_service_pattern`: package-native long-lived service architecture built on package services and package app realtime.',
 			'`package_subscriptions`: package-owned event subscriptions, package_subscription_list discovery, and email.message.received metadata-first handler payloads.',
 		].join(' '),

--- a/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
@@ -94,11 +94,11 @@ test('getPackageCapability returns ready-to-import package exports', async () =>
 				type_definition: null,
 				external_invocation: {
 					method: 'POST',
-					url: 'https://heykody.dev/@kentcdodds/api/package-invocations/discord-gateway/.',
-					path: '/@kentcdodds/api/package-invocations/discord-gateway/.',
+					url: 'https://heykody.dev/@kentcdodds/api/package-invocations/discord-gateway/__root__',
+					path: '/@kentcdodds/api/package-invocations/discord-gateway/__root__',
 					owner_username: 'kentcdodds',
 					kody_id: 'discord-gateway',
-					route_export_name: '.',
+					route_export_name: '__root__',
 					normalized_export_name: '.',
 					token_setup_url:
 						'https://heykody.dev/account/package-invocation-tokens/new?packageKodyIds=discord-gateway&exportNames=.',
@@ -135,4 +135,67 @@ test('getPackageCapability returns ready-to-import package exports', async () =>
 		userId: 'user-1',
 		sourceId: 'source-1',
 	})
+})
+
+test('getPackageCapability keeps package details when no public username is available', async () => {
+	mockModule.getSavedPackageById.mockReset()
+	mockModule.loadPackageManifestBySourceId.mockReset()
+	mockModule.getSavedPackageById.mockResolvedValueOnce({
+		id: 'package-1',
+		userId: 'user-1',
+		name: '@kentcdodds/discord-gateway',
+		kodyId: 'discord-gateway',
+		description: 'Discord helpers',
+		tags: ['discord'],
+		searchText: null,
+		sourceId: 'source-1',
+		hasApp: false,
+		createdAt: '2026-04-25T00:00:00.000Z',
+		updatedAt: '2026-04-26T00:00:00.000Z',
+	})
+	mockModule.loadPackageManifestBySourceId.mockResolvedValueOnce({
+		source: { id: 'source-1' },
+		manifest: {
+			name: '@kentcdodds/discord-gateway',
+			exports: {
+				'./post-message': './src/post-message.ts',
+			},
+			kody: {
+				id: 'discord-gateway',
+				description: 'Discord helpers',
+			},
+		},
+	})
+
+	const appDb = {
+		prepare: () => ({
+			bind: () => ({
+				first: async () => null,
+			}),
+		}),
+	} as unknown as D1Database
+	const result = await getPackageCapability.handler(
+		{ package_id: 'package-1' },
+		{
+			env: { APP_DB: appDb } as Env,
+			callerContext: {
+				baseUrl: 'https://heykody.dev',
+				user: {
+					userId: 'user-1',
+					email: 'me@kentcdodds.com',
+					displayName: 'Kent',
+				},
+				remoteConnectors: null,
+				storageContext: null,
+				repoContext: null,
+			},
+		},
+	)
+
+	expect(result.exports).toEqual([
+		expect.objectContaining({
+			subpath: './post-message',
+			external_invocation: null,
+		}),
+	])
 })

--- a/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
@@ -64,6 +64,7 @@ test('getPackageCapability returns ready-to-import package exports', async () =>
 				user: {
 					userId: 'user-1',
 					email: 'me@kentcdodds.com',
+					username: 'kentcdodds',
 					displayName: 'Kent',
 				},
 				remoteConnectors: null,
@@ -91,6 +92,19 @@ test('getPackageCapability returns ready-to-import package exports', async () =>
 				types_path: null,
 				description: null,
 				type_definition: null,
+				external_invocation: {
+					method: 'POST',
+					url: 'https://heykody.dev/@kentcdodds/api/package-invocations/discord-gateway/.',
+					path: '/@kentcdodds/api/package-invocations/discord-gateway/.',
+					owner_username: 'kentcdodds',
+					kody_id: 'discord-gateway',
+					route_export_name: '.',
+					normalized_export_name: '.',
+					token_setup_url:
+						'https://heykody.dev/account/package-invocation-tokens/new?packageKodyIds=discord-gateway&exportNames=.',
+					source_guidance:
+						'If the package invocation token is scoped to allowedSources, include JSON "source" with the exact allowed source label. Otherwise omit "source" or send null.',
+				},
 			},
 			{
 				subpath: './post-message',
@@ -99,6 +113,19 @@ test('getPackageCapability returns ready-to-import package exports', async () =>
 				types_path: 'src/post-message.ts',
 				description: null,
 				type_definition: null,
+				external_invocation: {
+					method: 'POST',
+					url: 'https://heykody.dev/@kentcdodds/api/package-invocations/discord-gateway/post-message',
+					path: '/@kentcdodds/api/package-invocations/discord-gateway/post-message',
+					owner_username: 'kentcdodds',
+					kody_id: 'discord-gateway',
+					route_export_name: 'post-message',
+					normalized_export_name: './post-message',
+					token_setup_url:
+						'https://heykody.dev/account/package-invocation-tokens/new?packageKodyIds=discord-gateway&exportNames=post-message',
+					source_guidance:
+						'If the package invocation token is scoped to allowedSources, include JSON "source" with the exact allowed source label. Otherwise omit "source" or send null.',
+				},
 			},
 		],
 	})

--- a/packages/worker/src/mcp/capabilities/packages/get-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.ts
@@ -2,6 +2,8 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { resolvePublicUsername } from '#app/user-lookup.ts'
+import { buildExternalPackageInvocationDescriptor } from '#worker/package-invocations/public-url.ts'
 import { buildPackageSearchProjection } from '#worker/package-registry/manifest.ts'
 import { buildPackageImportSpecifier } from '#worker/package-registry/package-import-specifier.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
@@ -13,8 +15,17 @@ export const getPackageCapability = defineDomainCapability(
 	{
 		name: 'package_get',
 		description:
-			'Load one saved package metadata record for the signed-in user, including ready-to-import export specifiers.',
-		keywords: ['package', 'get', 'read', 'metadata', 'exports', 'imports'],
+			'Load one saved package metadata record for the signed-in user, including ready-to-import export specifiers and canonical owner-scoped external invocation URLs for each export.',
+		keywords: [
+			'package',
+			'get',
+			'read',
+			'metadata',
+			'exports',
+			'imports',
+			'invocation url',
+			'package invocation token',
+		],
 		readOnly: true,
 		idempotent: true,
 		destructive: false,
@@ -30,6 +41,16 @@ export const getPackageCapability = defineDomainCapability(
 			})
 			if (!saved) {
 				throw new Error('Saved package not found for this user.')
+			}
+			const username = await resolvePublicUsername({
+				db: ctx.env.APP_DB,
+				username: user.username ?? null,
+				email: user.email ?? null,
+			})
+			if (!username) {
+				throw new Error(
+					'Username is required to build package invocation URLs.',
+				)
 			}
 			const loaded = await loadPackageManifestBySourceId({
 				env: ctx.env,
@@ -58,6 +79,25 @@ export const getPackageCapability = defineDomainCapability(
 					types_path: exportDetail.typesPath,
 					description: exportDetail.description,
 					type_definition: exportDetail.typeDefinition,
+					external_invocation: (() => {
+						const descriptor = buildExternalPackageInvocationDescriptor({
+							baseUrl: ctx.callerContext.baseUrl,
+							ownerUsername: username,
+							kodyId: saved.kodyId,
+							exportName: exportDetail.subpath,
+						})
+						return {
+							method: descriptor.method,
+							url: descriptor.url,
+							path: descriptor.path,
+							owner_username: descriptor.ownerUsername,
+							kody_id: descriptor.kodyId,
+							route_export_name: descriptor.routeExportName,
+							normalized_export_name: descriptor.normalizedExportName,
+							token_setup_url: descriptor.tokenSetupUrl,
+							source_guidance: descriptor.sourceGuidance,
+						}
+					})(),
 				})),
 			}
 		},

--- a/packages/worker/src/mcp/capabilities/packages/get-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.ts
@@ -47,11 +47,6 @@ export const getPackageCapability = defineDomainCapability(
 				username: user.username ?? null,
 				email: user.email ?? null,
 			})
-			if (!username) {
-				throw new Error(
-					'Username is required to build package invocation URLs.',
-				)
-			}
 			const loaded = await loadPackageManifestBySourceId({
 				env: ctx.env,
 				baseUrl: ctx.callerContext.baseUrl,
@@ -79,25 +74,27 @@ export const getPackageCapability = defineDomainCapability(
 					types_path: exportDetail.typesPath,
 					description: exportDetail.description,
 					type_definition: exportDetail.typeDefinition,
-					external_invocation: (() => {
-						const descriptor = buildExternalPackageInvocationDescriptor({
-							baseUrl: ctx.callerContext.baseUrl,
-							ownerUsername: username,
-							kodyId: saved.kodyId,
-							exportName: exportDetail.subpath,
-						})
-						return {
-							method: descriptor.method,
-							url: descriptor.url,
-							path: descriptor.path,
-							owner_username: descriptor.ownerUsername,
-							kody_id: descriptor.kodyId,
-							route_export_name: descriptor.routeExportName,
-							normalized_export_name: descriptor.normalizedExportName,
-							token_setup_url: descriptor.tokenSetupUrl,
-							source_guidance: descriptor.sourceGuidance,
-						}
-					})(),
+					external_invocation: username
+						? (() => {
+								const descriptor = buildExternalPackageInvocationDescriptor({
+									baseUrl: ctx.callerContext.baseUrl,
+									ownerUsername: username,
+									kodyId: saved.kodyId,
+									exportName: exportDetail.subpath,
+								})
+								return {
+									method: descriptor.method,
+									url: descriptor.url,
+									path: descriptor.path,
+									owner_username: descriptor.ownerUsername,
+									kody_id: descriptor.kodyId,
+									route_export_name: descriptor.routeExportName,
+									normalized_export_name: descriptor.normalizedExportName,
+									token_setup_url: descriptor.tokenSetupUrl,
+									source_guidance: descriptor.sourceGuidance,
+								}
+							})()
+						: null,
 				})),
 			}
 		},

--- a/packages/worker/src/mcp/capabilities/packages/shared.ts
+++ b/packages/worker/src/mcp/capabilities/packages/shared.ts
@@ -71,7 +71,7 @@ export const packageExportSurfaceSchema = z.object({
 			route_export_name: z
 				.string()
 				.describe(
-					'Export name segment used in the URL path; leading ./ is intentionally omitted.',
+					'Export name segment used in the URL path; leading ./ is omitted and the root export uses __root__.',
 				),
 			normalized_export_name: z
 				.string()
@@ -83,8 +83,9 @@ export const packageExportSurfaceSchema = z.object({
 				),
 			source_guidance: z.string(),
 		})
+		.nullable()
 		.describe(
-			'HTTP invocation metadata for external trusted callers using package invocation tokens.',
+			'HTTP invocation metadata for external trusted callers using package invocation tokens, or null when no public owner username is available.',
 		),
 })
 

--- a/packages/worker/src/mcp/capabilities/packages/shared.ts
+++ b/packages/worker/src/mcp/capabilities/packages/shared.ts
@@ -53,6 +53,39 @@ export const packageExportSurfaceSchema = z.object({
 		.describe(
 			'Primary export type signature parsed from source when available.',
 		),
+	external_invocation: z
+		.object({
+			method: z.literal('POST'),
+			url: z
+				.string()
+				.describe(
+					'Canonical owner-scoped external invocation URL for this package export.',
+				),
+			path: z
+				.string()
+				.describe(
+					'Canonical owner-scoped external invocation path for this package export.',
+				),
+			owner_username: z.string(),
+			kody_id: z.string(),
+			route_export_name: z
+				.string()
+				.describe(
+					'Export name segment used in the URL path; leading ./ is intentionally omitted.',
+				),
+			normalized_export_name: z
+				.string()
+				.describe('Export name after Kody normalization for scope checks.'),
+			token_setup_url: z
+				.string()
+				.describe(
+					'Token setup URL prefilled for this package and export. This is not an invocation URL.',
+				),
+			source_guidance: z.string(),
+		})
+		.describe(
+			'HTTP invocation metadata for external trusted callers using package invocation tokens.',
+		),
 })
 
 export const packageDetailSchema = packageSummarySchema.extend({

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -283,6 +283,8 @@ test('package entity detail includes exports, jobs, and referenced local types',
 		id: 'observed-package',
 		title: '@kody/observed-package',
 		description: 'Observed package with an app surface.',
+		baseUrl: 'http://localhost',
+		ownerUsername: 'test-user',
 		hostedUrl: 'http://localhost/@test-user/packages/observed-package',
 		record: {
 			id: 'package-123',
@@ -355,6 +357,15 @@ export declare function fetch(request: Request): Promise<Response>
 			}),
 			expect.objectContaining({
 				subpath: './app',
+				externalInvocation: expect.objectContaining({
+					method: 'POST',
+					url: 'http://localhost/@test-user/api/package-invocations/observed-package/app',
+					path: '/@test-user/api/package-invocations/observed-package/app',
+					routeExportName: 'app',
+					normalizedExportName: './app',
+					tokenSetupUrl:
+						'http://localhost/account/package-invocation-tokens/new?packageKodyIds=observed-package&exportNames=app',
+				}),
 				typesSource: null,
 				referencedTypes: [],
 				functions: [
@@ -383,6 +394,8 @@ export declare function fetch(request: Request): Promise<Response>
 		id: 'cursor-cloud-agents',
 		title: '@kentcdodds/cursor-cloud-agents',
 		description: 'Cursor cloud agents package.',
+		baseUrl: 'http://localhost',
+		ownerUsername: 'test-user',
 		hostedUrl: null,
 		record: {
 			id: 'package-456',

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -14,6 +14,7 @@ import {
 	type PackageReferencedTypeProjection,
 } from '#worker/package-registry/manifest.ts'
 import { type PackageRetrieverSurfaceResult } from '#worker/package-retrievers/types.ts'
+import { buildExternalPackageInvocationDescriptor } from '#worker/package-invocations/public-url.ts'
 import {
 	escapeMarkdownText,
 	formatMarkdownInlineCode,
@@ -248,6 +249,17 @@ export type SearchEntityDetailStructured =
 				// Full type source is no longer emitted by default; keep the nullable
 				// field for structured-output compatibility with existing clients.
 				typesSource: string | null
+				externalInvocation: {
+					method: 'POST'
+					url: string
+					path: string
+					ownerUsername: string
+					kodyId: string
+					routeExportName: string
+					normalizedExportName: string
+					tokenSetupUrl: string
+					sourceGuidance: string
+				} | null
 			}>
 			jobs: Array<{
 				name: string
@@ -330,7 +342,9 @@ export type SearchEntityDetail =
 			record: SavedPackageRecord
 			manifest: AuthoredPackageJson
 			files: Record<string, string>
+			baseUrl: string
 			hostedUrl: string | null
+			ownerUsername?: string | null
 	  }
 	| {
 			type: 'secret'
@@ -837,6 +851,14 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 				exportDetail.subpath,
 			),
 			typesSource: null,
+			externalInvocation: detail.ownerUsername
+				? buildExternalPackageInvocationDescriptor({
+						baseUrl: detail.baseUrl,
+						ownerUsername: detail.ownerUsername,
+						kodyId: detail.record.kodyId,
+						exportName: exportDetail.subpath,
+					})
+				: null,
 		}))
 		const jobs = Object.entries(detail.manifest.kody.jobs ?? {}).map(
 			([jobName, job]) => ({
@@ -891,6 +913,14 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 				lines.push(
 					`- \`${exportDetail.subpath}\` -> \`${exportDetail.importSpecifier}\`${exportDetail.runtimeTarget ? ` (runtime target: \`${exportDetail.runtimeTarget}\`)` : ''}${exportDetail.typesPath ? ` (types: \`${exportDetail.typesPath}\`)` : ''}`,
 				)
+				if (exportDetail.externalInvocation) {
+					lines.push(
+						`  - External invocation: \`${exportDetail.externalInvocation.method} ${exportDetail.externalInvocation.url}\``,
+						`  - Route export name: \`${exportDetail.externalInvocation.routeExportName}\`; normalized export name for token scope checks: \`${exportDetail.externalInvocation.normalizedExportName}\``,
+						`  - Token setup URL: \`${exportDetail.externalInvocation.tokenSetupUrl}\` (setup only; not an invocation URL)`,
+						`  - Source: ${escapeMarkdownText(exportDetail.externalInvocation.sourceGuidance)}`,
+					)
+				}
 				for (const exportedFunction of exportDetail.functions) {
 					if (exportedFunction.description) {
 						lines.push(

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -1609,6 +1609,8 @@ async function resolveEntityDetail(input: {
 			record,
 			manifest: loaded.manifest,
 			files: loaded.files,
+			baseUrl: input.callerContext.baseUrl,
+			ownerUsername: input.username,
 			hostedUrl:
 				record.hasApp && input.username
 					? buildPackageAppUrl({

--- a/packages/worker/src/package-invocations/http.ts
+++ b/packages/worker/src/package-invocations/http.ts
@@ -1,6 +1,7 @@
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
 import { findPublicUserIdentityByUsername } from '#app/user-lookup.ts'
+import { packageInvocationRootExportRouteSegment } from '@kody-internal/shared/public-urls.ts'
 import {
 	invokePackageExport,
 	type PackageInvocationTokenScope,
@@ -107,7 +108,11 @@ function parsePackageInvocationPath(pathname: string) {
 	}
 	const username = decodePathComponent(parts[0].slice(1))
 	const kodyId = decodePathComponent(parts[3] ?? '')
-	const exportName = decodePathComponent(parts.slice(4).join('/'))
+	const routeExportName = decodePathComponent(parts.slice(4).join('/'))
+	const exportName =
+		routeExportName === packageInvocationRootExportRouteSegment
+			? '.'
+			: routeExportName
 	if (!username || !kodyId || !exportName) {
 		return null
 	}

--- a/packages/worker/src/package-invocations/http.ts
+++ b/packages/worker/src/package-invocations/http.ts
@@ -63,6 +63,20 @@ function notFoundResponse() {
 	)
 }
 
+function ownerSlugRequiredResponse() {
+	return jsonResponse(
+		{
+			ok: false,
+			error: {
+				code: 'owner_slug_required',
+				message:
+					'Package invocation endpoints must include the package owner slug: POST /@:username/api/package-invocations/:kodyId/:exportName.',
+			},
+		},
+		{ status: 404 },
+	)
+}
+
 function readBearerToken(request: Request) {
 	const authHeader = request.headers.get('Authorization')
 	if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -98,6 +112,15 @@ function parsePackageInvocationPath(pathname: string) {
 		return null
 	}
 	return { username, kodyId, exportName }
+}
+
+function isUnscopedPackageInvocationPath(pathname: string) {
+	const parts = pathname.split('/').filter(Boolean)
+	return (
+		parts.length >= 4 &&
+		parts[0] === 'api' &&
+		parts[1] === 'package-invocations'
+	)
 }
 
 async function resolveTokenScope(input: {
@@ -170,7 +193,10 @@ async function readRequestBody(
 }
 
 export function isPackageInvocationApiRequest(pathname: string) {
-	return parsePackageInvocationPath(pathname) !== null
+	return (
+		parsePackageInvocationPath(pathname) !== null ||
+		isUnscopedPackageInvocationPath(pathname)
+	)
 }
 
 export async function handlePackageInvocationApiRequest(
@@ -178,7 +204,11 @@ export async function handlePackageInvocationApiRequest(
 	env: Env,
 	ctx?: ExecutionContext,
 ) {
-	const route = parsePackageInvocationPath(new URL(request.url).pathname)
+	const pathname = new URL(request.url).pathname
+	if (isUnscopedPackageInvocationPath(pathname)) {
+		return ownerSlugRequiredResponse()
+	}
+	const route = parsePackageInvocationPath(pathname)
 	if (!route) {
 		return notFoundResponse()
 	}

--- a/packages/worker/src/package-invocations/http.workers.test.ts
+++ b/packages/worker/src/package-invocations/http.workers.test.ts
@@ -157,6 +157,11 @@ test('package invocation API rejects missing, invalid, and unsafe tokens before 
 			'/@my-user/api/package-invocations/discord-gateway/dispatch-message-created',
 		),
 	).toBe(true)
+	expect(
+		isPackageInvocationApiRequest(
+			'/api/package-invocations/discord-gateway/dispatch-message-created',
+		),
+	).toBe(true)
 	expect(isPackageInvocationApiRequest('/api/me')).toBe(false)
 
 	const route =
@@ -252,6 +257,38 @@ test('package invocation API rejects missing, invalid, and unsafe tokens before 
 	).rejects.toThrow(
 		'Invalid package invocation token record: package_kody_ids_json must be valid JSON.',
 	)
+	expect(invocationMockModule.invokePackageExport).not.toHaveBeenCalled()
+})
+
+test('unscoped package invocation route reports missing owner slug instead of token failure', async () => {
+	invocationMockModule.invokePackageExport.mockClear()
+
+	const response = await handlePackageInvocationApiRequest(
+		new Request(
+			'https://example.com/api/package-invocations/discord-gateway/dispatch-message-created',
+			{
+				method: 'POST',
+				headers: {
+					Authorization: 'Bearer wrong-token',
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ idempotencyKey: 'evt-unscoped' }),
+			},
+		),
+		await createEnv(),
+		createContext(),
+	)
+
+	expect(response.status).toBe(404)
+	expect(response.headers.get('WWW-Authenticate')).toBeNull()
+	await expect(response.json()).resolves.toEqual({
+		ok: false,
+		error: {
+			code: 'owner_slug_required',
+			message:
+				'Package invocation endpoints must include the package owner slug: POST /@:username/api/package-invocations/:kodyId/:exportName.',
+		},
+	})
 	expect(invocationMockModule.invokePackageExport).not.toHaveBeenCalled()
 })
 

--- a/packages/worker/src/package-invocations/http.workers.test.ts
+++ b/packages/worker/src/package-invocations/http.workers.test.ts
@@ -392,3 +392,52 @@ test('package invocation API invokes the package export with the scoped token co
 		logs: ['ran'],
 	})
 })
+
+test('package invocation API translates the root export route segment before invoking', async () => {
+	invocationMockModule.invokePackageExport.mockResolvedValue({
+		status: 200,
+		body: {
+			ok: true,
+			exportName: '.',
+			idempotency: {
+				key: 'evt-root',
+				replayed: false,
+			},
+			result: { ok: true },
+			logs: [],
+		},
+	})
+
+	const response = await handlePackageInvocationApiRequest(
+		new Request(
+			'https://example.com/@my-user/api/package-invocations/discord-gateway/__root__',
+			{
+				method: 'POST',
+				headers: {
+					Authorization: 'Bearer private-token-123',
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					params: { content: 'hi' },
+					idempotencyKey: 'evt-root',
+					source: 'discord-gateway',
+				}),
+			},
+		),
+		await createEnv({
+			tokenRow: {
+				export_names_json: JSON.stringify(['.']),
+			},
+		}),
+		createContext(),
+	)
+
+	expect(invocationMockModule.invokePackageExport).toHaveBeenCalledWith(
+		expect.objectContaining({
+			request: expect.objectContaining({
+				exportName: '.',
+			}),
+		}),
+	)
+	expect(response.status).toBe(200)
+})

--- a/packages/worker/src/package-invocations/public-url.node.test.ts
+++ b/packages/worker/src/package-invocations/public-url.node.test.ts
@@ -29,6 +29,24 @@ test('canonical package invocation descriptor includes owner slug and normalized
 	expect(descriptor.sourceGuidance).toContain('"source"')
 })
 
+test('canonical root export invocation descriptor uses a URL-safe route segment', () => {
+	const descriptor = buildExternalPackageInvocationDescriptor({
+		baseUrl: 'https://heykody.dev',
+		ownerUsername: 'kentcdodds',
+		kodyId: 'discord-gateway',
+		exportName: '.',
+	})
+
+	expect(descriptor).toMatchObject({
+		url: 'https://heykody.dev/@kentcdodds/api/package-invocations/discord-gateway/__root__',
+		path: '/@kentcdodds/api/package-invocations/discord-gateway/__root__',
+		routeExportName: '__root__',
+		normalizedExportName: '.',
+		tokenSetupUrl:
+			'https://heykody.dev/account/package-invocation-tokens/new?packageKodyIds=discord-gateway&exportNames=.',
+	})
+})
+
 test('documented full invocation URL examples are owner scoped', async () => {
 	const paths = [
 		'docs/guides/account-package-invocation-token-setup.md',

--- a/packages/worker/src/package-invocations/public-url.node.test.ts
+++ b/packages/worker/src/package-invocations/public-url.node.test.ts
@@ -1,0 +1,49 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { expect, test } from 'vitest'
+import { buildExternalPackageInvocationDescriptor } from './public-url.ts'
+
+const currentDir = dirname(fileURLToPath(import.meta.url))
+const workspaceRoot = resolve(currentDir, '../../../..')
+
+test('canonical package invocation descriptor includes owner slug and normalized export names', () => {
+	const descriptor = buildExternalPackageInvocationDescriptor({
+		baseUrl: 'https://heykody.dev',
+		ownerUsername: 'kentcdodds',
+		kodyId: 'youtube-livestream-vod-manager',
+		exportName: './process-video',
+	})
+
+	expect(descriptor).toMatchObject({
+		method: 'POST',
+		url: 'https://heykody.dev/@kentcdodds/api/package-invocations/youtube-livestream-vod-manager/process-video',
+		path: '/@kentcdodds/api/package-invocations/youtube-livestream-vod-manager/process-video',
+		ownerUsername: 'kentcdodds',
+		kodyId: 'youtube-livestream-vod-manager',
+		routeExportName: 'process-video',
+		normalizedExportName: './process-video',
+		tokenSetupUrl:
+			'https://heykody.dev/account/package-invocation-tokens/new?packageKodyIds=youtube-livestream-vod-manager&exportNames=process-video',
+	})
+	expect(descriptor.sourceGuidance).toContain('"source"')
+})
+
+test('documented full invocation URL examples are owner scoped', async () => {
+	const paths = [
+		'docs/guides/account-package-invocation-token-setup.md',
+		'docs/contributing/package-invocation-api.md',
+	]
+	const urlPattern =
+		/https?:\/\/[^\s"'`]+\/api\/package-invocations\/[^\s"'`]+/g
+
+	for (const path of paths) {
+		const text = await readFile(resolve(workspaceRoot, path), 'utf8')
+		const urls = text.match(urlPattern) ?? []
+		for (const url of urls) {
+			expect(url, `${path} should use owner-scoped invocation URLs`).toMatch(
+				/\/@[^/]+\/api\/package-invocations\//,
+			)
+		}
+	}
+})

--- a/packages/worker/src/package-invocations/public-url.ts
+++ b/packages/worker/src/package-invocations/public-url.ts
@@ -20,6 +20,11 @@ export type ExternalPackageInvocationDescriptor = {
 const sourceGuidance =
 	'If the package invocation token is scoped to allowedSources, include JSON "source" with the exact allowed source label. Otherwise omit "source" or send null.'
 
+function buildPackageInvocationTokenSetupExportName(exportName: string) {
+	const normalized = normalizePackageInvocationExportName(exportName)
+	return normalized.startsWith('./') ? normalized.slice(2) : normalized
+}
+
 export function buildPackageInvocationTokenSetupUrl(input: {
 	baseUrl: string
 	kodyId: string
@@ -29,7 +34,7 @@ export function buildPackageInvocationTokenSetupUrl(input: {
 	url.searchParams.set('packageKodyIds', input.kodyId)
 	url.searchParams.set(
 		'exportNames',
-		buildPackageInvocationRouteExportName(input.exportName),
+		buildPackageInvocationTokenSetupExportName(input.exportName),
 	)
 	return url.toString()
 }
@@ -51,12 +56,12 @@ export function buildExternalPackageInvocationDescriptor(input: {
 			origin: input.baseUrl,
 			username: input.ownerUsername,
 			kodyId: input.kodyId,
-			exportName: routeExportName,
+			exportName: normalizedExportName,
 		}),
 		path: buildPackageInvocationPath({
 			username: input.ownerUsername,
 			kodyId: input.kodyId,
-			exportName: routeExportName,
+			exportName: normalizedExportName,
 		}),
 		ownerUsername: input.ownerUsername,
 		kodyId: input.kodyId,
@@ -65,7 +70,7 @@ export function buildExternalPackageInvocationDescriptor(input: {
 		tokenSetupUrl: buildPackageInvocationTokenSetupUrl({
 			baseUrl: input.baseUrl,
 			kodyId: input.kodyId,
-			exportName: routeExportName,
+			exportName: normalizedExportName,
 		}),
 		sourceGuidance,
 	}

--- a/packages/worker/src/package-invocations/public-url.ts
+++ b/packages/worker/src/package-invocations/public-url.ts
@@ -1,0 +1,72 @@
+import {
+	buildPackageInvocationPath,
+	buildPackageInvocationRouteExportName,
+	buildPackageInvocationUrl,
+	normalizePackageInvocationExportName,
+} from '@kody-internal/shared/public-urls.ts'
+
+export type ExternalPackageInvocationDescriptor = {
+	method: 'POST'
+	url: string
+	path: string
+	ownerUsername: string
+	kodyId: string
+	routeExportName: string
+	normalizedExportName: string
+	tokenSetupUrl: string
+	sourceGuidance: string
+}
+
+const sourceGuidance =
+	'If the package invocation token is scoped to allowedSources, include JSON "source" with the exact allowed source label. Otherwise omit "source" or send null.'
+
+export function buildPackageInvocationTokenSetupUrl(input: {
+	baseUrl: string
+	kodyId: string
+	exportName: string
+}) {
+	const url = new URL('/account/package-invocation-tokens/new', input.baseUrl)
+	url.searchParams.set('packageKodyIds', input.kodyId)
+	url.searchParams.set(
+		'exportNames',
+		buildPackageInvocationRouteExportName(input.exportName),
+	)
+	return url.toString()
+}
+
+export function buildExternalPackageInvocationDescriptor(input: {
+	baseUrl: string
+	ownerUsername: string
+	kodyId: string
+	exportName: string
+}): ExternalPackageInvocationDescriptor {
+	const normalizedExportName = normalizePackageInvocationExportName(
+		input.exportName,
+	)
+	const routeExportName =
+		buildPackageInvocationRouteExportName(normalizedExportName)
+	return {
+		method: 'POST',
+		url: buildPackageInvocationUrl({
+			origin: input.baseUrl,
+			username: input.ownerUsername,
+			kodyId: input.kodyId,
+			exportName: routeExportName,
+		}),
+		path: buildPackageInvocationPath({
+			username: input.ownerUsername,
+			kodyId: input.kodyId,
+			exportName: routeExportName,
+		}),
+		ownerUsername: input.ownerUsername,
+		kodyId: input.kodyId,
+		routeExportName,
+		normalizedExportName,
+		tokenSetupUrl: buildPackageInvocationTokenSetupUrl({
+			baseUrl: input.baseUrl,
+			kodyId: input.kodyId,
+			exportName: routeExportName,
+		}),
+		sourceGuidance,
+	}
+}

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -1,4 +1,5 @@
 import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
+import { normalizePackageInvocationExportName } from '@kody-internal/shared/public-urls.ts'
 import { toHex } from '@kody-internal/shared/hex.ts'
 import { type RemoteConnectorRef } from '@kody-internal/shared/remote-connectors.ts'
 import { extractRawContent, getExecutionErrorDetails } from '#mcp/executor.ts'
@@ -126,14 +127,7 @@ const maxPackageRuntimeInvokeDepth = 8
 export const packageInvocationScopeWildcard = '*'
 
 export function normalizeExportName(exportName: string) {
-	const trimmed = exportName.trim()
-	if (!trimmed) {
-		throw new Error('Package export name must not be empty.')
-	}
-	if (trimmed === '.' || trimmed === './') {
-		return '.'
-	}
-	return trimmed.startsWith('./') ? trimmed : `./${trimmed}`
+	return normalizePackageInvocationExportName(exportName)
 }
 
 function normalizeNullableString(value: string | null | undefined) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Walkthrough

- Clarify the official `package_invocation_token_setup` guide with the owner-scoped invocation route shape, the Kent YouTube WebSub Worker example, and troubleshooting guidance that checks the owner slug before rotating tokens.
- Add canonical package invocation URL helpers and surface per-export external invocation metadata from `package_get` and package entity search details.
- Route stale unscoped `POST /api/package-invocations/...` requests to a structured `owner_slug_required` 404 before OAuth token handling.
- Motivated by the YouTube WebSub Worker issue where agents called the unscoped route and misdiagnosed `invalid_token`; future agents should use the canonical URL helper/metadata instead of manually constructing package invocation routes.

## Testing

- `npx vitest run packages/worker/src/package-invocations/http.workers.test.ts packages/worker/src/package-invocations/public-url.node.test.ts packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts packages/worker/src/mcp/tools/search-format.node.test.ts`
- `npm run format:check`
- `npm run lint` (passes; reports existing warnings in unrelated test files)
- `npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81551729-f07b-4d5a-8493-a953b5e28d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81551729-f07b-4d5a-8493-a953b5e28d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added owner-scoped “external package invocation” URLs and surfaced per-export invocation metadata (method, URL/path, export name mapping, token setup link, and source guidance) in package details and search results.

* **Bug Fixes**
  * Improved handling of malformed/unscoped invocation requests with a clearer 404 error requiring the owner slug.
  * Ensured root export routes resolve correctly and token setup links are not treated as invocation endpoints.

* **Documentation**
  * Updated setup and verification instructions with the canonical owner-scoped URL format, correct headers/body examples, and export-name/source rules.

* **Tests**
  * Expanded coverage for invocation URL formatting, routing precedence, and external invocation metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->