### PR TITLE
Clarify example-only Kody instance references in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,9 @@ Copy `packages/worker/.env.example` to `packages/worker/.env` if missing.
 
 ### Seeding a test account
 
-After `npm run migrate:local`, seed the default E2E login (`me@kentcdodds.com` /
-`iliketwix`) per [`docs/contributing/setup.md`](./docs/contributing/setup.md).
+After `npm run migrate:local`, seed a local E2E fixture login per
+[`docs/contributing/setup.md`](./docs/contributing/setup.md). The seed script's
+built-in defaults are fixtures only, not privileged runtime accounts.
 If `node tools/seed-test-data.ts --local` fails because Wrangler cannot resolve
 `APP_DB` without the worker config wrapper, run the seed SQL through
 `./wrangler-env.ts` instead (same pattern as the migrate script).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,9 +106,10 @@ Copy `packages/worker/.env.example` to `packages/worker/.env` if missing.
 
 ### Seeding a test account
 
-After `npm run migrate:local`, seed a local E2E fixture login per
-[`docs/contributing/setup.md`](./docs/contributing/setup.md). The seed script's
-built-in defaults are fixtures only, not privileged runtime accounts. If
+After `npm run migrate:local`, seed the local E2E fixture login
+(`kody@example.com` / `iliketwix`) per
+[`docs/contributing/setup.md`](./docs/contributing/setup.md). These credentials
+are fixtures only, not privileged runtime accounts. If
 `node tools/seed-test-data.ts --local` fails because Wrangler cannot resolve
 `APP_DB` without the worker config wrapper, run the seed SQL through
 `./wrangler-env.ts` instead (same pattern as the migrate script).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,8 +108,8 @@ Copy `packages/worker/.env.example` to `packages/worker/.env` if missing.
 
 After `npm run migrate:local`, seed a local E2E fixture login per
 [`docs/contributing/setup.md`](./docs/contributing/setup.md). The seed script's
-built-in defaults are fixtures only, not privileged runtime accounts.
-If `node tools/seed-test-data.ts --local` fails because Wrangler cannot resolve
+built-in defaults are fixtures only, not privileged runtime accounts. If
+`node tools/seed-test-data.ts --local` fails because Wrangler cannot resolve
 `APP_DB` without the worker config wrapper, run the seed SQL through
 `./wrangler-env.ts` instead (same pattern as the migrate script).
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ The project favors a compact MCP surface with powerful `search` and Code Mode
 
 Kody is a multi-user personal assistant: each signed-in user gets a fully
 isolated assistant (packages, jobs, secrets, values, memories, and related
-state). Tests and fixtures often reference `me@kentcdodds.com` as the
-maintainer's primary account; that address is not privileged at runtime. The
-repo follows several [epicflare](https://github.com/epicweb-dev/epicflare)
-starter conventions.
+state). Tests and fixtures may seed deterministic local accounts, but no account
+is privileged at runtime. The repo follows several
+[epicflare](https://github.com/epicweb-dev/epicflare) starter conventions.
 
 The repo is organized as an Nx monorepo, with shared modules in
 `packages/shared` (`@kody-internal/shared`), the main app worker under

--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -98,8 +98,8 @@ normalization runs.
 ## Secret-capable input fields
 
 Some capability input fields may accept secret placeholders such as
-`{{secret:lutronUsername}}` or `{{secret:lutronPassword|scope=user}}` instead of
-raw strings.
+`{{secret:exampleUsername}}` or `{{secret:examplePassword|scope=user}}` instead
+of raw strings.
 
 This is an explicit opt-in. A field only participates when its JSON Schema marks
 that string property with `x-kody-secret: true`.
@@ -165,8 +165,8 @@ const inputSchema = markSecretInputFields(
 ```
 
 If you are starting from Zod, call `markSecretInputFields(...)` after
-`z.toJSONSchema(...)` produces the schema object. That is what the home
-connector does for `lutron_set_credentials`.
+`z.toJSONSchema(...)` produces the schema object. Use that pattern for
+connector-style credential setup capabilities that store write-only values.
 
 ## Directory layout
 

--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -19,8 +19,6 @@ to become.
   Objects.
 - [Remote connectors](./remote-connectors.md): generic outbound WebSocket
   protocol, URLs, secrets, and MCP caller context for any `kind` / instance.
-- [Kody Home Connector](https://github.com/kentcdodds/kody-home-connector):
-  external `home` reference connector implementation.
 - [Local Agent Bridge Direction](./local-agent-bridge.md): proposed direction
   for securely reaching local-network systems through an outbound agent
   connection.

--- a/docs/contributing/architecture/remote-connectors.md
+++ b/docs/contributing/architecture/remote-connectors.md
@@ -28,7 +28,7 @@ All messages are **JSON objects** with a **`type`** field.
 1. **`connector.hello`** (required first logical message after open)
    - **`type`:** `"connector.hello"`
    - **`connectorId`:** string — instance id (for example `default`,
-     `living-room`).
+     `example-instance`).
    - **`sharedSecret`:** string — must match an enabled shared secret saved for
      the connector ref in D1.
    - **`connectorKind`:** non-empty string. Lowercase values are normalized.

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -149,8 +149,13 @@ npm run migrate:local
 node tools/seed-test-data.ts --local
 ```
 
-The seed script's built-in default credentials are a local test fixture only.
-Pass `--email <email> --password <password>` when you need explicit fixture
+Default fixture credentials:
+
+- Email: `kody@example.com`
+- Password: `iliketwix`
+
+These credentials are a local test fixture only. Pass
+`--email <email> --password <password>` when you need explicit fixture
 credentials.
 
 ## Build and deploy

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -149,10 +149,9 @@ npm run migrate:local
 node tools/seed-test-data.ts --local
 ```
 
-Default test credentials:
-
-- Email: `me@kentcdodds.com`
-- Password: `iliketwix`
+The seed script's built-in default credentials are a local test fixture only.
+Pass `--email <email> --password <password>` when you need explicit fixture
+credentials.
 
 ## Build and deploy
 

--- a/docs/contributing/package-invocation-api.md
+++ b/docs/contributing/package-invocation-api.md
@@ -24,8 +24,8 @@ Examples:
 
 The path uses the owner's username and the package `kody.id`.
 
-The export name is normalized to package export form, so
-`dispatch-event` resolves as `./dispatch-event`.
+The export name is normalized to package export form, so `dispatch-event`
+resolves as `./dispatch-event`.
 
 ## Authentication
 

--- a/docs/contributing/package-invocation-api.md
+++ b/docs/contributing/package-invocation-api.md
@@ -25,7 +25,7 @@ Examples:
 The path uses the owner's username and the package `kody.id`.
 
 The export name is normalized to package export form, so
-`dispatch-message-created` resolves as `./dispatch-message-created`.
+`dispatch-event` resolves as `./dispatch-event`.
 
 ## Authentication
 

--- a/docs/contributing/package-invocation-api.md
+++ b/docs/contributing/package-invocation-api.md
@@ -3,16 +3,16 @@
 Use this API when a trusted external service should invoke a saved package
 export inside Kody without going through the interactive MCP transport.
 
-A stable Discord Gateway proxy is a representative caller:
+A stable webhook proxy is a representative caller:
 
-1. the external proxy owns the long-lived Discord websocket
-2. the proxy normalizes gateway events
+1. the external proxy owns the provider-specific connection or webhook ingress
+2. the proxy normalizes inbound events
 3. the proxy calls Kody's package invocation API
 4. Kody executes the saved package export with package context, user context,
    package storage, and normal secret/capability rules
 
 Kody is the package runtime and storage brain. The external service owns the
-socket lifecycle.
+provider lifecycle.
 
 ## Endpoint
 
@@ -20,7 +20,7 @@ socket lifecycle.
 
 Examples:
 
-- `/@kent/api/package-invocations/discord-gateway/dispatch-message-created`
+- `/@alice/api/package-invocations/webhook-dispatcher/dispatch-event`
 
 The path uses the owner's username and the package `kody.id`.
 
@@ -91,12 +91,12 @@ Create payload shape:
 ```json
 {
 	"action": "create",
-	"name": "Personal automation",
+	"name": "Trusted external client",
 	"rawToken": "<raw-token>",
 	"packageKodyIds": ["*"],
 	"packageIds": [],
 	"exportNames": ["*"],
-	"sources": ["personal-client"]
+	"sources": ["trusted-client"]
 }
 ```
 
@@ -136,12 +136,12 @@ Agents should load `kody_official_guide` with
 ```json
 {
 	"params": {
-		"messageId": "123",
+		"eventId": "123",
 		"content": "hello"
 	},
-	"idempotencyKey": "discord:message-create:123",
-	"source": "discord-gateway",
-	"topic": "discord.message.created"
+	"idempotencyKey": "webhook:event:123",
+	"source": "webhook-dispatcher",
+	"topic": "webhook.event"
 }
 ```
 
@@ -172,7 +172,7 @@ Behavior:
 - duplicate while first invocation is still active =>
   `409 invocation_in_progress`
 
-This makes duplicate Discord gateway deliveries safe when the proxy retries.
+This makes duplicate event deliveries safe when the proxy retries.
 
 ## Response shape
 
@@ -183,13 +183,13 @@ Success:
 	"ok": true,
 	"package": {
 		"id": "pkg_123",
-		"kodyId": "discord-gateway"
+		"kodyId": "webhook-dispatcher"
 	},
-	"exportName": "./dispatch-message-created",
-	"source": "discord-gateway",
-	"topic": "discord.message.created",
+	"exportName": "./dispatch-event",
+	"source": "webhook-dispatcher",
+	"topic": "webhook.event",
 	"idempotency": {
-		"key": "discord:message-create:123",
+		"key": "webhook:event:123",
 		"replayed": false
 	},
 	"result": {
@@ -208,7 +208,7 @@ Failures return:
 	"ok": false,
 	"error": {
 		"code": "package_not_found",
-		"message": "Saved package \"discord-gateway\" was not found for this user."
+		"message": "Saved package \"webhook-dispatcher\" was not found for this user."
 	}
 }
 ```
@@ -244,15 +244,16 @@ The endpoint is shaped for standard Cloudflare edge rate limiting:
 Prefer Cloudflare WAF/rate limiting rules in front of this path rather than
 adding bespoke in-Worker rate limiting first.
 
-## Discord gateway proxy pattern
+## Webhook proxy pattern
 
 Recommended flow:
 
-1. keep the Discord Gateway websocket in a stable external process
-2. receive `MESSAGE_CREATE`
-3. derive a stable idempotency key from the gateway event
+1. keep the provider webhook or long-lived connection in a stable external
+   process
+2. receive a provider event
+3. derive a stable idempotency key from the provider event id
 4. call the Kody endpoint
-5. use Kody's structured result to decide what to post back to Discord
+5. use Kody's structured result to decide how the proxy should respond
 
 Example request:
 
@@ -261,31 +262,31 @@ curl --fail --silent \
 	-X POST \
 	-H "Authorization: Bearer $PACKAGE_INVOCATION_TOKEN" \
 	-H "Content-Type: application/json" \
-	"https://kody.example.com/@kent/api/package-invocations/discord-gateway/dispatch-message-created" \
+	"https://kody.example.com/@alice/api/package-invocations/webhook-dispatcher/dispatch-event" \
 	-d '{
 		"params": {
-			"messageId": "123",
-			"channelId": "456",
+			"eventId": "123",
+			"resourceId": "456",
 			"content": "hello"
 		},
-		"idempotencyKey": "discord:message-create:123",
-		"source": "discord-gateway",
-		"topic": "discord.message.created"
+		"idempotencyKey": "webhook:event:123",
+		"source": "webhook-dispatcher",
+		"topic": "webhook.event"
 	}'
 ```
 
-## Personal client pattern
+## Trusted external client pattern
 
-Recommended flow for a trusted personal client:
+Recommended flow for a trusted external client:
 
 1. generate a high-entropy raw token locally
 2. copy the raw token to the clipboard or keep it in the client's local secret
    storage
 3. open Kody at
-   `/account/package-invocation-tokens/new?name=Personal%20automation&packageKodyIds=*&exportNames=*&sources=personal-client`
+   `/account/package-invocation-tokens/new?name=Trusted%20External%20Client&packageKodyIds=*&exportNames=*&sources=trusted-client`
 4. paste the raw token into the form and create the token
 5. send invocation requests with `Authorization: Bearer <raw-token>` and
-   `"source": "personal-client"`
+   `"source": "trusted-client"`
 
 A wildcard token can call any package/export owned by the signed-in Kody user,
 but only for requests that identify themselves with an allowed source.

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -11,8 +11,8 @@ Kody-specific metadata.
 Use `package.json` as the canonical source of truth for saved package metadata.
 
 - `name` — npm-valid scoped package name (`@scope/<leaf>`); the leaf segment
-  must match `kody.id` (for example `@kentcdodds/cursor-cloud-agents` pairs with
-  `kody.id: "cursor-cloud-agents"`)
+  must match `kody.id` (for example `@scope/my-package` pairs with
+  `kody.id: "my-package"`)
 - `exports` — authoritative import/export map
 - `kody.id` — user-scoped Kody package id
 - `kody.description` — package description for search/detail
@@ -115,8 +115,8 @@ Package runtime contexts and authenticated ad hoc execute calls expose
 import { packages } from 'kody:runtime'
 
 await packages.invokeChecked({
-	kodyId: 'discord-general-chat',
-	exportName: './handle-discord-message-created',
+	kodyId: 'event-subscriber',
+	exportName: './handle-event',
 	params: { event },
 })
 ```
@@ -137,8 +137,8 @@ warnings before deciding whether to invoke:
 
 ```ts
 const check = await packages.check({
-	kodyId: 'discord-general-chat',
-	exportName: './handle-discord-message-created',
+	kodyId: 'event-subscriber',
+	exportName: './handle-event',
 	params: { event, dryRun: true },
 })
 
@@ -166,7 +166,7 @@ the check fails.
 Idempotency:
 
 - Callers may pass `idempotencyKey` (or `idempotency_key`) explicitly. This is
-  recommended for domain events such as Discord message ids.
+  recommended for domain events such as webhook event ids.
 - If omitted during a parent package invocation with its own idempotency key,
   Kody derives a nested key from the parent key, parent runtime surface/name,
   call order, target, export, and params so retries do not duplicate the same
@@ -184,10 +184,10 @@ Security and loop safeguards:
 - Nested dynamic package invocations are depth-limited to prevent runaway
   package-to-package loops.
 
-For the Discord gateway/subscriber pattern, switch dispatchers from statically
+For event dispatcher/subscriber packages, switch dispatchers from statically
 importing subscriber packages to
 `packages.invoke({ kodyId, exportName, params, idempotencyKey })`. Republish
-subscribers independently; the gateway will observe the current published
+subscribers independently; the dispatcher will observe the current published
 subscriber export on its next dispatch without being republished.
 
 ## Package apps
@@ -274,8 +274,8 @@ import { workflows } from 'kody:runtime'
 await workflows.create({
 	exportName: './workflow-run-event',
 	runAt: '2026-05-03T12:00:00.000Z',
-	idempotencyKey: 'shade-event:2026-05-03T12:00:00.000Z:office',
-	params: { eventId: 'event-123', roomId: 'office' },
+	idempotencyKey: 'sync-event:2026-05-03T12:00:00.000Z:account-123',
+	params: { eventId: 'event-123', accountId: 'account-123' },
 })
 ```
 

--- a/docs/contributing/project-intent.md
+++ b/docs/contributing/project-intent.md
@@ -37,9 +37,8 @@ shared state between users.
   can create an account. Operators who want to restrict who can sign up should
   put the worker behind their own network-layer access control rather than
   expecting the application to gate it.
-- Primary first-party user: `me@kentcdodds.com` (the maintainer's own account);
-  tests, fixtures, and historical examples often reference this address but it
-  is not a privileged account at runtime
+- Tests and fixtures may seed deterministic local accounts, but seeded accounts
+  are fixtures only and are not privileged at runtime
 
 Optimize for:
 

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -148,8 +148,8 @@ Use this script to ensure a known test login exists in any deployed environment:
   - `node tools/seed-test-data.ts --remote --config <wrangler-config-path>`
   - Add `--env <name>` when the config uses environment-scoped bindings and the
     environment is not already set via `CLOUDFLARE_ENV`.
-- The script's built-in default credentials are a test fixture only. They are not
-  privileged at runtime and should not be used to describe product behavior.
+- The script's built-in default credentials are a test fixture only. They are
+  not privileged at runtime and should not be used to describe product behavior.
 - Choose explicit fixture credentials when needed:
   - `node tools/seed-test-data.ts --email <email> --password <password>`
 - When changing DB schema/model definitions or migrations, review

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -148,8 +148,11 @@ Use this script to ensure a known test login exists in any deployed environment:
   - `node tools/seed-test-data.ts --remote --config <wrangler-config-path>`
   - Add `--env <name>` when the config uses environment-scoped bindings and the
     environment is not already set via `CLOUDFLARE_ENV`.
-- The script's built-in default credentials are a test fixture only. They are
-  not privileged at runtime and should not be used to describe product behavior.
+- Default fixture credentials:
+  - email: `kody@example.com`
+  - password: `iliketwix`
+- These credentials are a test fixture only. They are not privileged at runtime
+  and should not be used to describe product behavior.
 - Choose explicit fixture credentials when needed:
   - `node tools/seed-test-data.ts --email <email> --password <password>`
 - When changing DB schema/model definitions or migrations, review

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -148,10 +148,9 @@ Use this script to ensure a known test login exists in any deployed environment:
   - `node tools/seed-test-data.ts --remote --config <wrangler-config-path>`
   - Add `--env <name>` when the config uses environment-scoped bindings and the
     environment is not already set via `CLOUDFLARE_ENV`.
-- Default credentials:
-  - email: `me@kentcdodds.com`
-  - password: `iliketwix`
-- Override credentials when needed:
+- The script's built-in default credentials are a test fixture only. They are not
+  privileged at runtime and should not be used to describe product behavior.
+- Choose explicit fixture credentials when needed:
   - `node tools/seed-test-data.ts --email <email> --password <password>`
 - When changing DB schema/model definitions or migrations, review
   `tools/seed-test-data.ts` and update it so seeded data matches the new model

--- a/docs/guides/account-package-invocation-token-setup.md
+++ b/docs/guides/account-package-invocation-token-setup.md
@@ -42,11 +42,11 @@ will not show the raw value again.
 
 Provide the user a URL like:
 
-`https://heykody.dev/account/package-invocation-tokens/new?name=Discord%20Gateway&packageKodyIds=discord-gateway&exportNames=dispatch-message-created&allowedSources=discord-gateway`
+`https://<your-kody-origin>/account/package-invocation-tokens/new?name=Webhook%20Dispatcher&packageKodyIds=webhook-dispatcher&exportNames=dispatch-event&allowedSources=webhook-dispatcher`
 
 Wildcard package/export setup for a highly trusted personal client:
 
-`https://heykody.dev/account/package-invocation-tokens/new?name=Personal%20automation&packageKodyIds=*&exportNames=*&allowedSources=personal-client`
+`https://<your-kody-origin>/account/package-invocation-tokens/new?name=Trusted%20External%20Client&packageKodyIds=*&exportNames=*&allowedSources=trusted-client`
 
 ## Query params
 
@@ -60,7 +60,7 @@ field names without extra translation.
 | `packageKodyIds` / `packageKodyId`          | yes\*    | Saved package `kody.id` values, or `*` for all packages owned by the signed-in Kody user.                               |
 | `kodyIds` / `kodyId`                        | yes\*    | Alias for `packageKodyIds`.                                                                                             |
 | `packageIds` / `packageId`                  | yes\*    | Saved package ids, or `*` for all packages owned by the signed-in Kody user.                                            |
-| `exportNames` / `exportName`                | yes      | Package export names. `dispatch-message-created` is normalized to `./dispatch-message-created`; `*` allows all exports. |
+| `exportNames` / `exportName`                | yes      | Package export names. `dispatch-event` is normalized to `./dispatch-event`; `*` allows all exports.                    |
 | `allowedSources` / `allowedSource`          | no       | Optional exact source labels the external caller may send in request JSON.                                              |
 | `sources` / `source`                        | no       | Alias for `allowedSources`.                                                                                             |
 | `package_kody_ids`, `package-kody-ids`, etc | no       | Snake_case and kebab-case aliases are accepted for the fields above.                                                    |

--- a/docs/guides/account-package-invocation-token-setup.md
+++ b/docs/guides/account-package-invocation-token-setup.md
@@ -54,16 +54,16 @@ Repeat params or comma-separate values for list fields. The form also accepts
 common snake_case and kebab-case aliases so agents can construct URLs from API
 field names without extra translation.
 
-| Param                                       | Required | Description                                                                                                             |
-| ------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `name`                                      | yes      | Human-readable token name.                                                                                              |
-| `packageKodyIds` / `packageKodyId`          | yes\*    | Saved package `kody.id` values, or `*` for all packages owned by the signed-in Kody user.                               |
-| `kodyIds` / `kodyId`                        | yes\*    | Alias for `packageKodyIds`.                                                                                             |
-| `packageIds` / `packageId`                  | yes\*    | Saved package ids, or `*` for all packages owned by the signed-in Kody user.                                            |
-| `exportNames` / `exportName`                | yes      | Package export names. `dispatch-event` is normalized to `./dispatch-event`; `*` allows all exports.                    |
-| `allowedSources` / `allowedSource`          | no       | Optional exact source labels the external caller may send in request JSON.                                              |
-| `sources` / `source`                        | no       | Alias for `allowedSources`.                                                                                             |
-| `package_kody_ids`, `package-kody-ids`, etc | no       | Snake_case and kebab-case aliases are accepted for the fields above.                                                    |
+| Param                                       | Required | Description                                                                                         |
+| ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `name`                                      | yes      | Human-readable token name.                                                                          |
+| `packageKodyIds` / `packageKodyId`          | yes\*    | Saved package `kody.id` values, or `*` for all packages owned by the signed-in Kody user.           |
+| `kodyIds` / `kodyId`                        | yes\*    | Alias for `packageKodyIds`.                                                                         |
+| `packageIds` / `packageId`                  | yes\*    | Saved package ids, or `*` for all packages owned by the signed-in Kody user.                        |
+| `exportNames` / `exportName`                | yes      | Package export names. `dispatch-event` is normalized to `./dispatch-event`; `*` allows all exports. |
+| `allowedSources` / `allowedSource`          | no       | Optional exact source labels the external caller may send in request JSON.                          |
+| `sources` / `source`                        | no       | Alias for `allowedSources`.                                                                         |
+| `package_kody_ids`, `package-kody-ids`, etc | no       | Snake_case and kebab-case aliases are accepted for the fields above.                                |
 
 \* At least one package scope is required: either a package Kody id scope or a
 package id scope.

--- a/docs/guides/account-secret-setup.md
+++ b/docs/guides/account-secret-setup.md
@@ -24,13 +24,13 @@ Do **not** ask the user to paste secrets into chat.
 
 Provide the user a URL like:
 
-`https://heykody.dev/account/secrets/new?name=linearApiKey&description=Linear%20API%20key&allowedHosts=api.linear.app&scope=user&allowedCapabilities=linear_issue_list,linear_issue_create&allowedPackages=pkg_123`
+`https://<your-kody-origin>/account/secrets/new?name=exampleApiKey&description=Example%20API%20key&allowedHosts=api.example.com&scope=user&allowedCapabilities=example_capability&allowedPackages=pkg_123`
 
 ## Query params
 
 | Param                 | Required | Description                                                                                                                |
 | --------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `name`                | yes      | Secret name (for example `linearApiKey`).                                                                                  |
+| `name`                | yes      | Secret name (for example `exampleApiKey`).                                                                                 |
 | `description`         | no       | Human-readable description shown in the UI.                                                                                |
 | `allowedHosts`        | no       | Comma-separated hosts to review for approval.                                                                              |
 | `allowedCapabilities` | no       | Comma-separated capability names to review. Use only real Kody capability names from `search` or `meta_list_capabilities`. |

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -74,7 +74,8 @@ and the current client credentials.
 Prefer integration names like `<provider>-<purpose>` when multiple accounts may
 exist: `google` for a default account, `google-business` for a business account,
 or `google-youtube-brand` for a brand identity. Agents should call
-`integration_list` up front when a provider may have multiple accounts connected.
+`integration_list` up front when a provider may have multiple accounts
+connected.
 
 ## Not the same as MCP OAuth
 

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -17,7 +17,7 @@ This path does not require package-app-specific OAuth code.
 
 Example shape:
 
-`https://heykody.dev/connect/oauth?provider=...&authorizeUrl=...&tokenUrl=...`
+`https://<your-kody-origin>/connect/oauth?provider=...&authorizeUrl=...&tokenUrl=...`
 
 ## Redirect URI
 
@@ -72,10 +72,9 @@ and the current client credentials.
 ## Integration naming convention
 
 Prefer integration names like `<provider>-<purpose>` when multiple accounts may
-exist: `google` for the primary account, `google-business` for a business
-account, or `google-youtube-brand` for a brand identity. Agents should call
-`integration_list` up front when a provider may have multiple accounts
-connected.
+exist: `google` for a default account, `google-business` for a business account,
+or `google-youtube-brand` for a brand identity. Agents should call
+`integration_list` up front when a provider may have multiple accounts connected.
 
 ## Not the same as MCP OAuth
 

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -262,16 +262,17 @@ For OAuth 2 `client_credentials` token exchanges that require
 `Authorization: Basic base64(client_id:client_secret)`, save the client id and
 client secret separately. Do **not** ask the user to precompute or save the
 derived Basic header. Use `secretHeaders.basic(...)` directly in a fetch header,
-or use `oauthClientCredentials(...)` for the token request:
+or use `oauthClientCredentials(...)` for the token request. These examples use a
+placeholder API host and generic client credential secret names:
 
 ```ts
 import { oauthClientCredentials } from 'kody:runtime'
 
 export default async function main() {
 	const token = await oauthClientCredentials({
-		tokenUrl: 'https://api-m.paypal.com/v1/oauth2/token',
-		clientIdSecret: 'paypalClientId',
-		clientSecretSecret: 'paypalClientSecret',
+		tokenUrl: 'https://api.example.com/oauth/token',
+		clientIdSecret: 'exampleClientId',
+		clientSecretSecret: 'exampleClientSecret',
 		scope: 'user',
 	})
 
@@ -279,21 +280,21 @@ export default async function main() {
 }
 ```
 
-The lower-level PayPal token request is:
+The lower-level token request is:
 
 ```ts
 import { secretHeaders } from 'kody:runtime'
 
 export default async function main() {
 	const body = new URLSearchParams({ grant_type: 'client_credentials' })
-	const response = await fetch('https://api-m.paypal.com/v1/oauth2/token', {
+	const response = await fetch('https://api.example.com/oauth/token', {
 		method: 'POST',
 		headers: {
 			Accept: 'application/json',
 			'Content-Type': 'application/x-www-form-urlencoded',
 			Authorization: secretHeaders.basic({
-				usernameSecret: 'paypalClientId',
-				passwordSecret: 'paypalClientSecret',
+				usernameSecret: 'exampleClientId',
+				passwordSecret: 'exampleClientSecret',
 				scope: 'user',
 			}),
 		},

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -43,8 +43,7 @@ Important fields:
 
 For predictable package resolution, saved packages must use a scoped
 `package.json.name`, and the leaf segment must match `kody.id`. For example,
-`@kentcdodds/cursor-cloud-agents` must use
-`"kody": { "id": "cursor-cloud-agents" }`.
+`@scope/my-package` must use `"kody": { "id": "my-package" }`.
 
 ### npm dependencies
 
@@ -120,8 +119,8 @@ statically importing it:
 import { packages } from 'kody:runtime'
 
 const result = await packages.invoke({
-	kodyId: 'discord-general-chat',
-	exportName: './handle-discord-message-created',
+	kodyId: 'event-subscriber',
+	exportName: './handle-event',
 	params: { event },
 })
 ```
@@ -130,8 +129,8 @@ Use `packages.invokeChecked` for event subscribers, workflow dispatchers,
 agents, and other runtime fan-out where the caller should pick up the target
 package's current published export and wants Kody to validate the current
 runtime contract before invoking it. The check resolves the target package at
-runtime, so republishing `discord-general-chat` changes what `discord-gateway`
-observes without republishing `discord-gateway`.
+runtime, so republishing `event-subscriber` changes what `event-dispatcher`
+observes without republishing `event-dispatcher`.
 
 Use static `kody:@scope/package/export` imports for library-like dependencies
 where bundling a published dependency snapshot with the caller is desired.
@@ -143,8 +142,8 @@ before deciding whether to invoke:
 import { packages } from 'kody:runtime'
 
 const check = await packages.check({
-	kodyId: 'discord-general-chat',
-	exportName: './handle-discord-message-created',
+	kodyId: 'event-subscriber',
+	exportName: './handle-event',
 	params: { event, dryRun: true },
 })
 
@@ -160,8 +159,8 @@ For the common check-then-invoke flow, use the combined helper:
 import { packages } from 'kody:runtime'
 
 const result = await packages.invokeChecked({
-	kodyId: 'discord-general-chat',
-	exportName: './handle-discord-message-created',
+	kodyId: 'event-subscriber',
+	exportName: './handle-event',
 	params: { event, dryRun: true },
 })
 ```
@@ -215,10 +214,10 @@ params. In contexts without a parent invocation key, Kody uses a unique key,
 which avoids accidental replay. Pass your own `idempotencyKey` when the target
 operation must dedupe against a domain event id.
 
-For `discord-gateway`, subscriber dispatch should move from static imports such
-as `kody:@kentcdodds/discord-general-chat/handle-discord-message-created` to the
-dynamic shape above, using the Discord event id as the explicit `idempotencyKey`
-when available.
+For an event-dispatch package, subscriber dispatch should prefer the dynamic
+shape above over static imports such as
+`kody:@scope/event-subscriber/handle-event`, using the source event id as the
+explicit `idempotencyKey` when available.
 
 ## Package apps
 

--- a/docs/use/repo-sessions.md
+++ b/docs/use/repo-sessions.md
@@ -97,7 +97,7 @@ user-facing identity instead of requiring the internal `source_id`.
 Examples:
 
 ```json
-{ "target": { "kind": "package", "kody_id": "triage-github-pr" } }
+{ "target": { "kind": "package", "kody_id": "my-package" } }
 ```
 
 ```json
@@ -175,7 +175,7 @@ republishes the job module without opening a session.
 
 ```ts
 await codemode.repo_run_commands({
-	target: { kind: 'package', kody_id: 'triage-github-pr' },
+	target: { kind: 'package', kody_id: 'my-package' },
 	commands: `git apply <<'PATCH'
 --- a/src/index.ts
 +++ b/src/index.ts

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -25,17 +25,18 @@ resolves them for **approved** destinations.
 
 When an API requires Basic Auth derived from two saved secrets, import
 **`secretHeaders`** from **`kody:runtime`** and put the opaque helper result in
-the outbound fetch header:
+the outbound fetch header. This example uses a placeholder API host and generic
+client credential secret names:
 
 ```ts
 import { secretHeaders } from 'kody:runtime'
 
-await fetch('https://api-m.paypal.com/v1/oauth2/token', {
+await fetch('https://api.example.com/oauth/token', {
 	method: 'POST',
 	headers: {
 		Authorization: secretHeaders.basic({
-			usernameSecret: 'paypalClientId',
-			passwordSecret: 'paypalClientSecret',
+			usernameSecret: 'exampleClientId',
+			passwordSecret: 'exampleClientSecret',
 			scope: 'user',
 		}),
 		'Content-Type': 'application/x-www-form-urlencoded',

--- a/docs/use/workflows.md
+++ b/docs/use/workflows.md
@@ -54,8 +54,8 @@ export default async function main() {
 		packageId: 'pkg_123',
 		exportName: './workflow-run-event',
 		runAt: new Date(Date.now() + 60_000).toISOString(),
-		idempotencyKey: 'morning-shades-up',
-		params: { roomId: 'office' },
+		idempotencyKey: 'sync-account-123',
+		params: { accountId: 'account-123' },
 	})
 }
 ```

--- a/e2e/auth-test-user.ts
+++ b/e2e/auth-test-user.ts
@@ -1,8 +1,8 @@
 import { type APIRequestContext } from '@playwright/test'
 
 export const primaryTestUser = {
-	email: 'me@kentcdodds.com',
-	username: 'kentcdodds',
+	email: 'kody@example.com',
+	username: 'kody',
 	password: 'iliketwix',
 }
 

--- a/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
@@ -63,8 +63,8 @@ test('getPackageCapability returns ready-to-import package exports', async () =>
 				baseUrl: 'https://heykody.dev',
 				user: {
 					userId: 'user-1',
-					email: 'me@kentcdodds.com',
-					displayName: 'Kent',
+					email: 'kody@example.com',
+					displayName: 'Kody',
 				},
 				remoteConnectors: null,
 				storageContext: null,

--- a/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
@@ -94,9 +94,9 @@ test('getPackageCapability returns ready-to-import package exports', async () =>
 				type_definition: null,
 				external_invocation: {
 					method: 'POST',
-					url: 'https://heykody.dev/@kentcdodds/api/package-invocations/discord-gateway/__root__',
-					path: '/@kentcdodds/api/package-invocations/discord-gateway/__root__',
-					owner_username: 'kentcdodds',
+					url: 'https://heykody.dev/@kody/api/package-invocations/discord-gateway/__root__',
+					path: '/@kody/api/package-invocations/discord-gateway/__root__',
+					owner_username: 'kody',
 					kody_id: 'discord-gateway',
 					route_export_name: '__root__',
 					normalized_export_name: '.',
@@ -115,9 +115,9 @@ test('getPackageCapability returns ready-to-import package exports', async () =>
 				type_definition: null,
 				external_invocation: {
 					method: 'POST',
-					url: 'https://heykody.dev/@kentcdodds/api/package-invocations/discord-gateway/post-message',
-					path: '/@kentcdodds/api/package-invocations/discord-gateway/post-message',
-					owner_username: 'kentcdodds',
+					url: 'https://heykody.dev/@kody/api/package-invocations/discord-gateway/post-message',
+					path: '/@kody/api/package-invocations/discord-gateway/post-message',
+					owner_username: 'kody',
 					kody_id: 'discord-gateway',
 					route_export_name: 'post-message',
 					normalized_export_name: './post-message',
@@ -183,7 +183,6 @@ test('getPackageCapability keeps package details when no public username is avai
 				user: {
 					userId: 'user-1',
 					email: 'kody@example.com',
-					username: 'kody',
 					displayName: 'Kody',
 				},
 				remoteConnectors: null,

--- a/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.node.test.ts
@@ -25,8 +25,8 @@ function createCallerContext() {
 			baseUrl: 'https://heykody.dev',
 			user: {
 				userId: 'user-1',
-				email: 'me@kentcdodds.com',
-				displayName: 'Kent',
+				email: 'kody@example.com',
+				displayName: 'Kody',
 			},
 			remoteConnectors: null,
 			storageContext: null,

--- a/tools/mcp-test-support.ts
+++ b/tools/mcp-test-support.ts
@@ -14,7 +14,7 @@ import {
 } from '#mcp/test-process.ts'
 
 const projectRoot = process.cwd()
-const primaryUserEmail = 'me@kentcdodds.com'
+const primaryUserEmail = 'kody@example.com'
 const testUserPassword = 'secret'
 const localhost = '127.0.0.1'
 const defaultWaitTimeoutMs = process.env.CI ? 60_000 : 45_000
@@ -45,7 +45,7 @@ export async function createTestDatabase() {
 	const persistDir = await mkdtemp(path.join(tmpdir(), 'kody-mcp-e2e-'))
 	const user = {
 		email: primaryUserEmail,
-		username: 'kentcdodds',
+		username: 'kody',
 		password: testUserPassword,
 	} satisfies TestUser
 

--- a/tools/seed-test-data.ts
+++ b/tools/seed-test-data.ts
@@ -14,8 +14,8 @@ type CliOptions = {
 	persistTo?: string
 }
 
-const defaultTestEmail = 'me@kentcdodds.com'
-const defaultTestUsername = 'kentcdodds'
+const defaultTestEmail = 'kody@example.com'
+const defaultTestUsername = 'kody'
 const defaultTestPassword = 'iliketwix'
 
 export function parseArgs(argv: Array<string>): CliOptions {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Reframes seeded accounts, deployment URLs, package names, connector references, and provider-specific snippets as fixtures, placeholders, or generic examples.
- Changes the built-in seeded fixture account to `kody@example.com` / `kody` while keeping the seeded password `iliketwix`.
- Documents the fixture login clearly in development setup docs without treating it as product behavior.
- Addresses CodeRabbit feedback by aligning the package invocation export normalization example with `dispatch-event`.

### Testing
- `npm run validate` passes with format, lint, typecheck, unit tests, Playwright E2E, and MCP E2E.
- `gh pr checks 569 --watch --interval 10` reports CodeRabbit and Cursor Bugbot passing.
- Targeted scan confirms the old seeded account email/username no longer appear in TypeScript or Markdown sources.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0427-dea6-719c-acce-20f853e0f684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0427-dea6-719c-acce-20f853e0f684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that seeded test accounts and built-in credentials are local-only fixtures (not privileged runtime accounts) and updated default examples to use `kody@example.com` / `iliketwix`.
  * Updated setup, contributing, OAuth, secrets, packages, workflows, and repo-session docs to use generic placeholders and consistent “webhook dispatcher” / “trusted external client” terminology.
  * Refreshed architecture and contribution examples by removing product-specific/first-party references and swapping illustrative IDs/URLs to more general values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->