### PR TITLE
Attach remote connectors to package invocations

### DIFF
--- a/packages/worker/src/package-invocations/http.ts
+++ b/packages/worker/src/package-invocations/http.ts
@@ -1,6 +1,7 @@
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
 import { findPublicUserIdentityByUsername } from '#app/user-lookup.ts'
+import { listAttachedRemoteConnectorRefs } from '#worker/remote-connector/settings-service.ts'
 import { packageInvocationRootExportRouteSegment } from '@kody-internal/shared/public-urls.ts'
 import {
 	invokePackageExport,
@@ -143,6 +144,10 @@ async function resolveTokenScope(input: {
 		id: record.id,
 	})
 	if (!touched) return null
+	const remoteConnectors = await listAttachedRemoteConnectorRefs({
+		env: input.env,
+		userId: record.user_id,
+	})
 	return {
 		tokenId: record.id,
 		userId: record.user_id,
@@ -152,6 +157,7 @@ async function resolveTokenScope(input: {
 		packageKodyIds: record.packageKodyIds,
 		exportNames: record.exportNames,
 		sources: record.sources,
+		remoteConnectors,
 	}
 }
 

--- a/packages/worker/src/package-invocations/http.workers.test.ts
+++ b/packages/worker/src/package-invocations/http.workers.test.ts
@@ -58,6 +58,19 @@ async function createEnv(
 			revoked_at: options.tokenRow?.revoked_at ?? null,
 		},
 	]
+	const remoteConnectorRows = [
+		{
+			id: 'home-default',
+			user_id: tokenUserId,
+			kind: 'home',
+			instance_id: 'default',
+			enabled: 1,
+			attached: 1,
+			encrypted_shared_secret: 'encrypted-secret',
+			created_at: '2026-04-27T00:00:00.000Z',
+			updated_at: '2026-04-27T00:00:00.000Z',
+		},
+	]
 	return {
 		APP_DB: {
 			prepare(query: string) {
@@ -88,6 +101,20 @@ async function createEnv(
 									) ?? null) as T | null
 								}
 								return null
+							},
+							async all<T = Record<string, unknown>>() {
+								if (query.includes('FROM remote_connector_settings')) {
+									const userId = String(params[0] ?? '')
+									return {
+										results: remoteConnectorRows.filter(
+											(row) =>
+												row.user_id === userId &&
+												row.enabled === 1 &&
+												row.attached === 1,
+										),
+									} as { results: Array<T> }
+								}
+								return { results: [] as Array<T> }
 							},
 							async run() {
 								if (query.includes('UPDATE package_invocation_tokens')) {
@@ -369,6 +396,7 @@ test('package invocation API invokes the package export with the scoped token co
 			packageKodyIds: ['discord-gateway'],
 			exportNames: ['./dispatch-message-created'],
 			sources: ['discord-gateway'],
+			remoteConnectors: [{ kind: 'home', instanceId: 'default' }],
 		},
 		request: {
 			packageIdOrKodyId: 'discord-gateway',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Load enabled, attached remote connector refs when resolving package invocation bearer tokens.
- Include those refs in `PackageInvocationTokenScope` so saved package invocation runtimes can mount home connector capabilities on event-driven HTTP dispatches.
- Extend the package invocation HTTP worker test to assert the `home/default` connector ref reaches `invokePackageExport`.

## Verification
- `npm test -- package-invocations/http.workers.test.ts` — 5 tests passed.
- `npm run typecheck` — passed.
- Pre-push hook: `npm run test` — 121 files / 379 tests passed.
- Pre-push hook: `npm run test:e2e:run` — Playwright smoke test passed.

## Rollout / production verification
- After deploy, test a real or simulated Discord reaction event and confirm `dispatch-message-reaction-add` can call the HRV handler without missing `home_default_kasa_*` tools.
- Then remove/disable the temporary `hrv-discord-reaction-poller` job (`504513c3-f29e-47f0-9ea1-402569ebef54`). Current `job_delete`/`job_update` attempts in production error with `Cannot read properties of undefined (reading 'bind')`, so that may need a separate platform cleanup if still present.

## Notes
- This keeps the fix on the event-driven package invocation path only; it does not add polling or scheduled poller behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8498d7d1-c61a-4087-a9d4-8f1622c4b449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8498d7d1-c61a-4087-a9d4-8f1622c4b449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package invocation tokens now include remote connector references in their scoped context.
* **Tests**
  * Updated worker tests to cover token scoping with attached remote connectors and the new scoped context shape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->