### PR TITLE
security: harden web/auth surface (headers, dev-route gate, rate limits, PKCE, password policy)

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -47,11 +47,28 @@ request so cookie signing and verification are available to handlers.
 
 ### Signup posture
 
-Signup is open. The auth handler does not gate on email — anyone who can reach
-`POST /auth` with `mode: 'signup'` and a valid body can create an account. There
-is no application-level allowlist, invite flow, or privileged "primary user".
-Operators who want to restrict who can sign up should put the worker behind
-their own network-layer access control.
+Signup is **blocked in production** and only enabled in non-production runtimes
+(local dev, preview, and e2e test). The gate lives in
+`packages/worker/src/app/deployment-env.ts` (`isNonProductionRuntime`), which
+the auth handler consults before honoring `mode: 'signup'`. Production wrangler
+env sets `SENTRY_ENVIRONMENT: 'production'`; `npm run dev` sets
+`WRANGLER_IS_LOCAL_DEV=true`; preview/test set `SENTRY_ENVIRONMENT` to
+`'preview'` / `'test'`. The predicate fails closed: if it cannot positively
+confirm a non-production runtime, signup is denied with `403`.
+
+There is no application-level allowlist, invite flow, or privileged "primary
+user" for the non-production environments where signup is enabled. Operators who
+want to open signup on their own deployment should relax
+`isNonProductionRuntime` deliberately and put the worker behind their own
+network-layer access control.
+
+### Password policy
+
+New passwords (signup and password-reset confirmation) must satisfy the
+server-side policy in `@kody-internal/shared/password-policy.ts`
+(`minPasswordLength`, currently 8). The server is the trust boundary; the
+browser hint is advisory only. Login does **not** re-check length so
+pre-existing accounts are never locked out.
 
 ## Account deletion
 
@@ -109,21 +126,33 @@ Password reset handlers are in
 ## Account secret reveal
 
 The account secrets API (`packages/worker/src/app/handlers/account-secrets.ts`)
-never returns plaintext secret values in `GET /account/secrets.json`. To view a
-stored value, the client calls a separate reveal endpoint:
+returns a decrypted secret value to the **owner** only, and only for the
+currently selected secret:
 
-- `POST /account/secrets/reveal` with JSON body `{ secretId, password }`
-- Requires an active `kody_session` cookie (same as all account endpoints)
-- Requires the user's current password for reauthentication (verified via PBKDF2
-  through `@kody-internal/shared/password-hash.ts`)
-- On success, returns `{ ok: true, value }` with `Cache-Control: no-store`
-- On failure (wrong password), returns 401 and writes an audit log entry with
-  `action: 'secret_reveal'`, `result: 'failure'`
-- Successful reveals also emit an audit log entry with
-  `action: 'secret_reveal'`, `result: 'success'`
+- `GET /account/secrets.json?selected=<secretId>` resolves the value into the
+  `selectedSecret.value` field of the JSON payload
+- Requires an active `kody_session` cookie; the value is scoped to the
+  authenticated user's `mcpUser.userId`, so a session can only ever read its own
+  secrets
+- All responses set `Cache-Control: no-store`
+- There is **no** separate `/account/secrets/reveal` endpoint and **no**
+  password reauthentication step — revealing a secret is inside the owner's own
+  trust boundary (same-origin, session-authenticated)
 
-The UI prompts for the password on each reveal and does not cache the value in
-memory across navigation events.
+This is an intentional design decision, not an oversight. The exfiltration
+concern (XSS or a stolen session reading the owner's secrets) is mitigated by:
+
+- the strict first-party `Content-Security-Policy` (`script-src 'self'`, no
+  inline scripts) plus `HttpOnly` + `SameSite=Lax` session cookies (see
+  `docs/contributing/security.md`), which make script-injection theft hard
+- decryption at rest and per-user scoping on every read
+
+Residual risk: a stolen session cookie can read the owning user's own secrets
+until it expires (sessions are stateless — see the "Accepted residual risks"
+section of `docs/contributing/security.md`). If a future change needs a stronger
+control, the recommended approach is a password-reauthenticated reveal endpoint
+combined with server-side session invalidation. Do not silently reintroduce
+plaintext reveal without also considering that hardening.
 
 ## OAuth for MCP
 
@@ -152,5 +181,7 @@ routed from `packages/worker/src/index.ts`.
 - `packages/worker/src/mcp-auth.ts` for MCP token enforcement
 - `packages/worker/src/app/auth-session.ts` for cookie format/signing
 - `packages/worker/src/app/handlers/auth.ts` for app login/signup flow
-- `packages/worker/src/app/handlers/account-secrets.ts` for secret reveal with
-  reauth
+- `packages/worker/src/app/handlers/account-secrets.ts` for owner-scoped secret
+  reveal
+- `packages/worker/src/app/deployment-env.ts` for the production/non-production
+  gate shared by signup and developer-only routes

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -33,8 +33,10 @@ generated-UI / package-app surfaces:
    `packages/worker/src/index.ts` (`rateLimitedAuthPaths`).
 5. **New passwords go through the shared policy.** Use `getPasswordPolicyError`
    from `@kody-internal/shared/password-policy.ts` wherever a password is set.
-6. **OAuth stays S256-only.** Keep `allowPlainPKCE: false` on the
-   `OAuthProvider`.
+6. **OAuth PKCE stays S256-only.** Keep the `getPkceValidationError` check in
+   `oauth-handlers.ts` (reject `code_challenge_method` other than S256 when a
+   challenge is present). Do not switch to the provider's `allowPlainPKCE`
+   option — see the OAuth section below for why.
 7. **Every data path is `userId`-scoped.** New D1 queries, Durable Object names,
    and Vectorize filters must include `userId`. Prefer parameterized SQL
    (`.prepare(...).bind(...)`); never interpolate user input into SQL.
@@ -97,9 +99,14 @@ accounts are never locked out.
 
 ## OAuth / MCP hardening
 
-- `OAuthProvider` is configured with `allowPlainPKCE: false`, so only the S256
-  PKCE challenge method is accepted (`packages/worker/src/index.ts`). All MCP
-  clients use S256; plain PKCE offers no protection against code interception.
+- PKCE is validated at the application layer: `getPkceValidationError`
+  (`packages/worker/src/oauth-handlers.ts`) rejects an authorize request whose
+  `code_challenge_method` is anything other than `S256` when a `code_challenge`
+  is present. Plain PKCE offers no protection against code interception. We do
+  **not** use the provider's `allowPlainPKCE: false` option because, in this
+  provider version, it rejects every authorize request that lacks an explicit
+  `code_challenge_method=S256` — including legitimate confidential-client flows
+  that use no PKCE at all — which breaks real MCP clients.
 - Dynamic client registration (`/oauth/register`) is intentionally **open**: the
   MCP OAuth spec requires it, and clients (including native/public clients using
   PKCE) rely on it. This is a deliberate acceptance, not a gap. Do not add

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -1,7 +1,112 @@
 # Security
 
-Security-relevant patterns in the Worker. See the 2026-05-01 internal security
-audit for findings and rationale.
+Security-relevant patterns in the Worker, and the reasoning behind them. This
+doc is the authoritative record of what is protected, what is intentionally out
+of scope, and the invariants future changes must not regress. See the 2026-05-01
+and 2026-07-01 internal security audits for the underlying findings.
+
+Kody is a single Cloudflare Workers app: a Remix 3 browser UI plus an
+OAuth-protected MCP server. It is multi-user, so the overarching invariant is
+that **every read/write path is scoped by `userId`** (see
+[`AGENTS.md`](../../AGENTS.md)). Cross-user data sharing is a bug, not a
+feature.
+
+## Invariants for future agents (do not regress)
+
+Read this list before touching auth, routing, response construction, or the
+generated-UI / package-app surfaces:
+
+1. **First-party HTML keeps its security headers.** All trusted account/auth
+   pages must go through `render()` (`packages/worker/src/app/render.ts`), which
+   applies `packages/worker/src/app/security-headers.ts`. Never add
+   `'unsafe-inline'` to the CSP `script-src`.
+2. **Untrusted surfaces stay off the strict CSP.** Hosted package apps
+   (`/@username/packages/*`) and the generated-UI runtime (`/mcp-apps/*`,
+   `/dev/generated-ui`) execute author-supplied HTML/JS and intentionally do not
+   use the first-party CSP. Do not "unify" the two.
+3. **Developer-only routes fail closed.** Anything that runs attacker-authored
+   content or aids debugging must be gated behind `isNonProductionRuntime`
+   (`packages/worker/src/app/deployment-env.ts`) so it is unreachable in
+   production.
+4. **Credential endpoints are rate limited.** Any new endpoint that accepts a
+   password, token, or reset code must join the shared auth rate-limit bucket in
+   `packages/worker/src/index.ts` (`rateLimitedAuthPaths`).
+5. **New passwords go through the shared policy.** Use `getPasswordPolicyError`
+   from `@kody-internal/shared/password-policy.ts` wherever a password is set.
+6. **OAuth stays S256-only.** Keep `allowPlainPKCE: false` on the
+   `OAuthProvider`.
+7. **Every data path is `userId`-scoped.** New D1 queries, Durable Object names,
+   and Vectorize filters must include `userId`. Prefer parameterized SQL
+   (`.prepare(...).bind(...)`); never interpolate user input into SQL.
+
+## First-party HTTP security headers
+
+`render()` attaches the header set in
+`packages/worker/src/app/security-headers.ts` to every trusted HTML response
+(login, signup, account pages, the OAuth consent screen, and the SPA shell):
+
+- `Content-Security-Policy` with `script-src 'self'` (no inline scripts),
+  `frame-ancestors 'none'`, `base-uri 'self'`, `object-src 'none'`,
+  `form-action 'self'`, and same-origin `connect-src`. The client bundle loads
+  as an external module, so this does not require inline scripts. `style-src`
+  allows `'unsafe-inline'` because SSR-streamed styles arrive as inline
+  `<style>` tags; style injection is far lower risk than script injection.
+- `X-Frame-Options: DENY` plus `frame-ancestors 'none'` — stops clickjacking of
+  the OAuth consent screen and account pages.
+- `X-Content-Type-Options: nosniff`.
+- `Referrer-Policy: strict-origin-when-cross-origin`.
+- `Strict-Transport-Security` (ignored by browsers over plain HTTP, enforced
+  over HTTPS).
+
+These headers are deliberately **not** applied to hosted package apps or the
+generated-UI runtime, which need their own looser policies to run
+author-authored code.
+
+## Generated-UI developer route is non-production only
+
+`GET /dev/generated-ui` serves the generated-UI runtime HTML entry for iframe
+testing. That runtime parses and executes HTML/JS delivered via `postMessage`,
+so exposing it in production would allow any site to frame it and run script on
+Kody's origin. The route in `packages/worker/src/index.ts` is gated behind
+`isNonProductionRuntime(env)` and returns `404` in production.
+
+## Auth rate limiting
+
+Credential-accepting POST endpoints share one per-IP auth rate-limit bucket
+(`auth:ip:<ip>`) backed by a D1 atomic limiter
+(`packages/worker/src/app/rate-limit.ts`, default 10 requests per 60-second
+window). The shared bucket means brute-force attempts cannot fan out across
+parallel paths. Covered paths (`rateLimitedAuthPaths` in
+`packages/worker/src/index.ts`):
+
+- `POST /auth` (password login/signup)
+- `POST /oauth/authorize` (inline OAuth login)
+- `POST /password-reset` (reset request)
+- `POST /password-reset/confirm` (reset confirmation)
+
+Excess requests receive `429 Too Many Requests` with a `Retry-After` header. The
+D1 approach uses a batched INSERT + COUNT in a single transaction, avoiding the
+read-then-write race that KV-backed limiters suffer under concurrency.
+
+## Password policy
+
+Signup and password-reset confirmation enforce a minimum password length via
+`@kody-internal/shared/password-policy.ts`. The server is the trust boundary;
+the browser hint is advisory. Login does not re-check length, so existing
+accounts are never locked out.
+
+## OAuth / MCP hardening
+
+- `OAuthProvider` is configured with `allowPlainPKCE: false`, so only the S256
+  PKCE challenge method is accepted (`packages/worker/src/index.ts`). All MCP
+  clients use S256; plain PKCE offers no protection against code interception.
+- Dynamic client registration (`/oauth/register`) is intentionally **open**: the
+  MCP OAuth spec requires it, and clients (including native/public clients using
+  PKCE) rely on it. This is a deliberate acceptance, not a gap. Do not add
+  `disallowPublicClientRegistration` without a plan for how MCP clients
+  register.
+- `/mcp` requires a bearer token whose audience matches the origin
+  (`packages/worker/src/mcp-auth.ts`).
 
 ## Public connector routes are WebSocket-only
 
@@ -16,18 +121,48 @@ rejects all non-WebSocket requests with `404`. Worker-internal callers use
 Durable Object RPC methods (`getSnapshot()`, `rpcListTools()`, `rpcCallTool()`)
 directly on the stub, bypassing `fetch()` entirely.
 
-## Auth rate limiting
-
-`POST /auth` and `POST /password-reset` are rate-limited per IP address using a
-D1-backed atomic rate limiter (`packages/worker/src/app/rate-limit.ts`). The
-default configuration allows 10 requests per 60-second window per IP. Excess
-requests receive `429 Too Many Requests` with a `Retry-After` header. The D1
-approach uses a batched INSERT + COUNT in a single transaction, avoiding the
-read-then-write race condition that KV-backed rate limiters suffer from under
-concurrent requests.
-
 ## Maintenance route guard
 
 Any `/__maintenance/*` path that does not match a known handler returns `404`
 with a JSON body. This prevents unhandled maintenance paths from falling through
-to the SPA shell and silently returning `200 OK`.
+to the SPA shell and silently returning `200 OK`. Known maintenance handlers are
+guarded by a bearer secret comparison.
+
+## Secrets and user code execution (in-scope model)
+
+- Saved secrets are encrypted at rest with AES-GCM under `SECRET_STORE_KEY` and
+  scoped by `userId` (`packages/worker/src/mcp/secrets/`).
+- Outbound secret use goes through the fetch gateway
+  (`packages/worker/src/mcp/fetch-gateway.ts`), which is deny-by-default: a
+  secret placeholder is only substituted for a host the user explicitly approved
+  in the account UI. Policy writes (allowed hosts/capabilities/packages) are
+  only reachable through the authenticated account UI.
+- User code runs in a Cloudflare Worker Loader isolate without the parent `env`;
+  capabilities are RPC'd back to handlers that enforce the caller's `userId`.
+
+## Accepted residual risks and out-of-scope items
+
+These were reviewed and intentionally left as-is for this project. Document any
+change to these decisions here so future agents do not relitigate them.
+
+- **Stateless sessions have no server-side revocation.** `kody_session` is a
+  signed cookie with no server store, so a password reset does not invalidate
+  existing sessions and there is no global "log out everywhere". This is a
+  deliberate tradeoff of the stateless design. A future hardening would add a
+  `password_changed_at` check against a per-session `issuedAt`.
+- **Account secret reveal is owner-scoped, not password-reauthenticated.** See
+  the "Account secret reveal" section of
+  [`architecture/authentication.md`](./architecture/authentication.md).
+- **`refreshAccessToken` materializes plaintext OAuth tokens** inside user code
+  for integration calls. Prefer `createAuthenticatedFetch`, which enforces the
+  integration host allowlist. This is documented at the call site
+  (`packages/worker/src/mcp/execute-modules/codemode-utils.ts`).
+- **Sandbox `fetch` has no general SSRF denylist.** Secret-bearing requests are
+  constrained by per-secret host allowlists; non-secret requests rely on the
+  Cloudflare Workers platform egress model.
+- **PBKDF2-SHA256 (100k iterations)** is used for password hashing rather than a
+  memory-hard KDF. Acceptable here; changing it requires a rehash-on-login
+  migration.
+- **No CSRF tokens.** State-changing requests are protected by `SameSite=Lax`
+  cookies plus JSON `Content-Type` on mutating endpoints. Revisit if any
+  mutating endpoint starts accepting cross-site form posts or `SameSite=None`.

--- a/packages/shared/src/password-policy.node.test.ts
+++ b/packages/shared/src/password-policy.node.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest'
-import { getPasswordPolicyError, minPasswordLength } from './password-policy.ts'
+import {
+	getPasswordPolicyError,
+	maxPasswordLength,
+	minPasswordLength,
+} from './password-policy.ts'
 
 test('rejects passwords shorter than the minimum length', () => {
 	expect(getPasswordPolicyError('short')).toBe(
@@ -10,7 +14,14 @@ test('rejects passwords shorter than the minimum length', () => {
 	)
 })
 
-test('accepts passwords at or above the minimum length', () => {
+test('rejects passwords longer than the maximum length', () => {
+	expect(getPasswordPolicyError('a'.repeat(maxPasswordLength + 1))).toBe(
+		`Password must be at most ${maxPasswordLength} characters.`,
+	)
+})
+
+test('accepts passwords within the allowed length range', () => {
 	expect(getPasswordPolicyError('a'.repeat(minPasswordLength))).toBeNull()
+	expect(getPasswordPolicyError('a'.repeat(maxPasswordLength))).toBeNull()
 	expect(getPasswordPolicyError('a-longer-passphrase')).toBeNull()
 })

--- a/packages/shared/src/password-policy.node.test.ts
+++ b/packages/shared/src/password-policy.node.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+import { getPasswordPolicyError, minPasswordLength } from './password-policy.ts'
+
+test('rejects passwords shorter than the minimum length', () => {
+	expect(getPasswordPolicyError('short')).toBe(
+		`Password must be at least ${minPasswordLength} characters.`,
+	)
+	expect(getPasswordPolicyError('')).toBe(
+		`Password must be at least ${minPasswordLength} characters.`,
+	)
+})
+
+test('accepts passwords at or above the minimum length', () => {
+	expect(getPasswordPolicyError('a'.repeat(minPasswordLength))).toBeNull()
+	expect(getPasswordPolicyError('a-longer-passphrase')).toBeNull()
+})

--- a/packages/shared/src/password-policy.ts
+++ b/packages/shared/src/password-policy.ts
@@ -1,0 +1,14 @@
+/**
+ * Server-side password policy shared by every code path that sets a new
+ * password (signup and password-reset confirmation). The browser UI hints the
+ * same minimum, but the server is the trust boundary: never rely on the client
+ * to enforce password strength.
+ */
+export const minPasswordLength = 8
+
+export function getPasswordPolicyError(password: string): string | null {
+	if (password.length < minPasswordLength) {
+		return `Password must be at least ${minPasswordLength} characters.`
+	}
+	return null
+}

--- a/packages/shared/src/password-policy.ts
+++ b/packages/shared/src/password-policy.ts
@@ -5,10 +5,16 @@
  * to enforce password strength.
  */
 export const minPasswordLength = 8
+// Upper bound keeps unbounded input out of PBKDF2 (100k iterations), which
+// would otherwise let a caller inflate per-request CPU cost with huge strings.
+export const maxPasswordLength = 128
 
 export function getPasswordPolicyError(password: string): string | null {
 	if (password.length < minPasswordLength) {
 		return `Password must be at least ${minPasswordLength} characters.`
+	}
+	if (password.length > maxPasswordLength) {
+		return `Password must be at most ${maxPasswordLength} characters.`
 	}
 	return null
 }

--- a/packages/worker/src/app/deployment-env.node.test.ts
+++ b/packages/worker/src/app/deployment-env.node.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+import { isNonProductionRuntime } from './deployment-env.ts'
+
+test('treats production wrangler env as production (fails closed)', () => {
+	expect(isNonProductionRuntime({ SENTRY_ENVIRONMENT: 'production' })).toBe(
+		false,
+	)
+	expect(isNonProductionRuntime({})).toBe(false)
+	expect(isNonProductionRuntime({ SENTRY_ENVIRONMENT: undefined })).toBe(false)
+})
+
+test('recognizes local dev, preview, and test as non-production', () => {
+	expect(isNonProductionRuntime({ WRANGLER_IS_LOCAL_DEV: 'true' })).toBe(true)
+	expect(isNonProductionRuntime({ SENTRY_ENVIRONMENT: 'preview' })).toBe(true)
+	expect(isNonProductionRuntime({ SENTRY_ENVIRONMENT: 'test' })).toBe(true)
+})

--- a/packages/worker/src/app/deployment-env.ts
+++ b/packages/worker/src/app/deployment-env.ts
@@ -1,0 +1,19 @@
+/**
+ * Runtime deployment posture detection.
+ *
+ * Production wrangler env sets `SENTRY_ENVIRONMENT: 'production'`; the preview
+ * and e2e-test environments set `'preview'` / `'test'`; `npm run dev` sets
+ * `WRANGLER_IS_LOCAL_DEV=true`. Anything that should never be reachable in a
+ * real deployment (developer tooling routes, signup) must fail closed: it is
+ * only enabled when we can positively confirm a non-production runtime.
+ */
+type DeploymentEnvLike = {
+	WRANGLER_IS_LOCAL_DEV?: string | undefined
+	SENTRY_ENVIRONMENT?: string | undefined
+}
+
+export function isNonProductionRuntime(env: DeploymentEnvLike): boolean {
+	if (env.WRANGLER_IS_LOCAL_DEV === 'true') return true
+	const sentryEnv = env.SENTRY_ENVIRONMENT
+	return sentryEnv === 'test' || sentryEnv === 'preview'
+}

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -224,10 +224,22 @@ test('auth handler login and signup workflow', async () => {
 	})
 	expect(productionContext.testDb.users.has('new@example.com')).toBe(false)
 
+	const weakPasswordSignupResponse = await signupContext.request({
+		email: 'weak@example.com',
+		username: 'weak-user',
+		password: 'short',
+		mode: 'signup',
+	})
+	expect(weakPasswordSignupResponse.status).toBe(400)
+	expect(await weakPasswordSignupResponse.json()).toEqual({
+		error: 'Password must be at least 8 characters.',
+	})
+	expect(signupContext.testDb.users.has('weak@example.com')).toBe(false)
+
 	const allowedSignupResponse = await signupContext.request({
 		email: 'allowed@example.com',
 		username: 'allowed-user',
-		password: 'secret',
+		password: 'password123',
 		mode: 'signup',
 	})
 	expect(allowedSignupResponse.status).toBe(200)
@@ -271,7 +283,7 @@ test('auth handler login and signup workflow', async () => {
 	const duplicateUsernameResponse = await signupContext.request({
 		email: 'duplicate@example.com',
 		username: 'Existing-User',
-		password: 'secret',
+		password: 'password123',
 		mode: 'signup',
 	})
 	expect(duplicateUsernameResponse.status).toBe(409)

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -11,6 +11,8 @@ import {
 	createPasswordHash,
 	verifyPassword,
 } from '@kody-internal/shared/password-hash.ts'
+import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts'
+import { isNonProductionRuntime } from '#app/deployment-env.ts'
 import { type AppEnv } from '#worker/env-schema.ts'
 
 const authModes = ['login', 'signup'] as const
@@ -25,10 +27,12 @@ type AuthMode = (typeof authModes)[number]
  * 'test'; `npm run dev` sets `WRANGLER_IS_LOCAL_DEV=true`.
  */
 function isSignupAllowed(appEnv: AppEnv) {
-	const runtime = appEnv as unknown as Record<string, string | undefined>
-	if (runtime['WRANGLER_IS_LOCAL_DEV'] === 'true') return true
-	const sentryEnv = runtime['SENTRY_ENVIRONMENT']
-	return sentryEnv === 'test' || sentryEnv === 'preview'
+	return isNonProductionRuntime(
+		appEnv as unknown as {
+			WRANGLER_IS_LOCAL_DEV?: string
+			SENTRY_ENVIRONMENT?: string
+		},
+	)
 }
 
 const authRequestSchema = object({
@@ -132,6 +136,19 @@ export function createAuthHandler(appEnv: AppEnv) {
 						reason: 'invalid_username',
 					})
 					return Response.json({ error: usernameError }, { status: 400 })
+				}
+				const passwordError = getPasswordPolicyError(normalizedPassword)
+				if (passwordError) {
+					void logAuditEvent({
+						category: 'auth',
+						action: 'signup',
+						result: 'failure',
+						email: normalizedEmail,
+						ip: requestIp,
+						path: url.pathname,
+						reason: 'weak_password',
+					})
+					return Response.json({ error: passwordError }, { status: 400 })
 				}
 			}
 

--- a/packages/worker/src/app/handlers/password-reset.ts
+++ b/packages/worker/src/app/handlers/password-reset.ts
@@ -11,6 +11,7 @@ import { normalizeEmail } from '#app/normalize-email.ts'
 import { type routes } from '#app/routes.ts'
 import { toHex } from '@kody-internal/shared/hex.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
+import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts'
 import { type AppEnv } from '#worker/env-schema.ts'
 
 const resetTokenBytes = 32
@@ -230,6 +231,19 @@ export function createPasswordResetConfirmHandler(appEnv: AppEnv) {
 					{ error: 'Token and password are required.' },
 					{ status: 400 },
 				)
+			}
+
+			const passwordError = getPasswordPolicyError(password)
+			if (passwordError) {
+				void logAuditEvent({
+					category: 'auth',
+					action: 'password_reset_confirm',
+					result: 'failure',
+					ip: requestIp,
+					path: url.pathname,
+					reason: 'weak_password',
+				})
+				return Response.json({ error: passwordError }, { status: 400 })
 			}
 
 			const tokenHash = await hashResetToken(token)

--- a/packages/worker/src/app/render.ts
+++ b/packages/worker/src/app/render.ts
@@ -1,6 +1,7 @@
 import { type SafeHtml } from 'remix/html-template'
 import { createHtmlResponse } from 'remix/response/html'
+import { applyFirstPartySecurityHeaders } from '#app/security-headers.ts'
 
 export function render(body: string | SafeHtml, init?: ResponseInit) {
-	return createHtmlResponse(body, init)
+	return applyFirstPartySecurityHeaders(createHtmlResponse(body, init))
 }

--- a/packages/worker/src/app/security-headers.node.test.ts
+++ b/packages/worker/src/app/security-headers.node.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'vitest'
+import {
+	applyFirstPartySecurityHeaders,
+	firstPartySecurityHeaders,
+} from './security-headers.ts'
+
+test('applies the full first-party security header set to a response', () => {
+	const response = applyFirstPartySecurityHeaders(new Response('ok'))
+	for (const [name, value] of Object.entries(firstPartySecurityHeaders)) {
+		expect(response.headers.get(name)).toBe(value)
+	}
+})
+
+test('content security policy locks down scripts, framing, and base uri', () => {
+	const csp = firstPartySecurityHeaders['Content-Security-Policy'] ?? ''
+	expect(csp).toContain("script-src 'self'")
+	// script-src must never allow inline scripts (the key XSS protection).
+	expect(csp).not.toContain("script-src 'self' 'unsafe-inline'")
+	expect(csp).toContain("frame-ancestors 'none'")
+	expect(csp).toContain("base-uri 'self'")
+	expect(csp).toContain("object-src 'none'")
+	expect(csp).toContain("form-action 'self'")
+})
+
+test('sets clickjacking and sniffing protections', () => {
+	expect(firstPartySecurityHeaders['X-Frame-Options']).toBe('DENY')
+	expect(firstPartySecurityHeaders['X-Content-Type-Options']).toBe('nosniff')
+})

--- a/packages/worker/src/app/security-headers.ts
+++ b/packages/worker/src/app/security-headers.ts
@@ -1,0 +1,54 @@
+/**
+ * First-party HTTP security headers.
+ *
+ * These are applied to the trusted account/auth UI shell (see
+ * `packages/worker/src/app/render.ts`). They are intentionally NOT applied to
+ * untrusted, dynamically-authored surfaces such as hosted package apps
+ * (`/@username/packages/*`) or the generated-UI runtime (`/mcp-apps/*`,
+ * `/dev/generated-ui`), which execute author-supplied HTML/JS and need their
+ * own, looser policies.
+ *
+ * Content-Security-Policy notes:
+ * - `script-src 'self'` (no `'unsafe-inline'`) is the important protection: the
+ *   client bundle is loaded as an external module from the same origin, so an
+ *   injected inline `<script>` cannot execute. Do NOT add `'unsafe-inline'` to
+ *   `script-src`.
+ * - `style-src` allows `'unsafe-inline'` because SSR streamed styles arrive as
+ *   inline `<style>` tags; style injection is far lower risk than script
+ *   injection. Client-side styles use constructable stylesheets, which CSP does
+ *   not gate.
+ * - `frame-ancestors 'none'` (plus `X-Frame-Options: DENY`) stops clickjacking
+ *   of the OAuth consent screen and account pages.
+ * - `base-uri`, `object-src`, and `form-action` are locked to prevent base-tag
+ *   injection, plugin content, and form exfiltration to third-party origins.
+ * - `connect-src 'self'` is safe because the first-party client only calls
+ *   same-origin JSON endpoints; all third-party calls happen server-side.
+ */
+const contentSecurityPolicy = [
+	"default-src 'self'",
+	"base-uri 'self'",
+	"object-src 'none'",
+	"frame-ancestors 'none'",
+	"form-action 'self'",
+	"img-src 'self' data: blob:",
+	"font-src 'self' data:",
+	"style-src 'self' 'unsafe-inline'",
+	"script-src 'self'",
+	"connect-src 'self'",
+].join('; ')
+
+export const firstPartySecurityHeaders: Readonly<Record<string, string>> = {
+	'Content-Security-Policy': contentSecurityPolicy,
+	'X-Frame-Options': 'DENY',
+	'X-Content-Type-Options': 'nosniff',
+	'Referrer-Policy': 'strict-origin-when-cross-origin',
+	// Ignored by browsers over plain HTTP (local dev), enforced over HTTPS.
+	'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+}
+
+export function applyFirstPartySecurityHeaders(response: Response): Response {
+	for (const [name, value] of Object.entries(firstPartySecurityHeaders)) {
+		response.headers.set(name, value)
+	}
+	return response
+}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -326,10 +326,11 @@ const oauthProvider = new OAuthProvider({
 	tokenEndpoint: oauthPaths.token,
 	clientRegistrationEndpoint: oauthPaths.register,
 	scopesSupported: oauthScopes,
-	// Require PKCE S256; reject the weaker `plain` challenge method. MCP clients
-	// all use S256, so this does not break dynamic client registration (which
-	// the MCP OAuth spec requires and we intentionally keep open).
-	allowPlainPKCE: false,
+	// NOTE: we intentionally do NOT set `allowPlainPKCE: false`. In this provider
+	// version that option rejects EVERY authorize request whose
+	// `code_challenge_method` is absent or `plain` — including confidential
+	// clients that legitimately use no PKCE — which breaks real MCP clients. See
+	// the OAuth section of docs/contributing/security.md before changing this.
 })
 
 /**

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -284,12 +284,16 @@ const appHandler = withCors({
 
 		// Dev route: serve generated UI runtime HTML entry for iframe testing.
 		// This runtime executes attacker-authored HTML/JS delivered via
-		// postMessage, so it must never be reachable in production.
-		if (
-			url.pathname === '/dev/generated-ui' &&
-			isNonProductionRuntime(env) &&
-			(request.method === 'GET' || request.method === 'HEAD')
-		) {
+		// postMessage, so it must never be reachable in production. Return 404
+		// immediately outside non-production so the path can never fall through
+		// to assets or the app router.
+		if (url.pathname === '/dev/generated-ui') {
+			if (
+				!isNonProductionRuntime(env) ||
+				(request.method !== 'GET' && request.method !== 'HEAD')
+			) {
+				return new Response('Not Found', { status: 404 })
+			}
 			const { renderGeneratedUiRuntimeHtmlEntry } =
 				await import('./mcp/apps/generated-ui-runtime-html-entry.ts')
 			const baseUrl = new URL('/', url.origin)

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -34,6 +34,7 @@ import {
 	isPackageInvocationApiRequest,
 } from './package-invocations/http.ts'
 import { withCors } from './utils.ts'
+import { isNonProductionRuntime } from '#app/deployment-env.ts'
 import { checkRateLimit, authRateLimitConfig } from '#app/rate-limit.ts'
 import { getRequestIp } from '#app/audit-log.ts'
 import { handleCapabilityReindexRequest } from './capability-maintenance.ts'
@@ -68,6 +69,16 @@ export {
 }
 
 const claudeWidgetDomainSuffix = '.claudemcpcontent.com'
+
+// Credential-accepting POST endpoints share one per-IP auth rate-limit bucket
+// so brute-force attempts cannot fan out across parallel paths (password login,
+// OAuth inline login, password-reset request, and password-reset confirm).
+const rateLimitedAuthPaths = new Set([
+	'/auth',
+	'/oauth/authorize',
+	'/password-reset',
+	'/password-reset/confirm',
+])
 
 function isNamespacedPackageInvocationEndpointPath(pathname: string) {
 	const parts = pathname.split('/').filter(Boolean)
@@ -159,10 +170,7 @@ const appHandler = withCors({
 	async handler(request, env, ctx) {
 		const url = new URL(request.url)
 
-		if (
-			request.method === 'POST' &&
-			(url.pathname === '/auth' || url.pathname === '/password-reset')
-		) {
+		if (request.method === 'POST' && rateLimitedAuthPaths.has(url.pathname)) {
 			const ip = getRequestIp(request) ?? 'unknown'
 			const rateLimitKey = `auth:ip:${ip}`
 			const result = await checkRateLimit(
@@ -275,8 +283,11 @@ const appHandler = withCors({
 		}
 
 		// Dev route: serve generated UI runtime HTML entry for iframe testing.
+		// This runtime executes attacker-authored HTML/JS delivered via
+		// postMessage, so it must never be reachable in production.
 		if (
 			url.pathname === '/dev/generated-ui' &&
+			isNonProductionRuntime(env) &&
 			(request.method === 'GET' || request.method === 'HEAD')
 		) {
 			const { renderGeneratedUiRuntimeHtmlEntry } =
@@ -315,6 +326,10 @@ const oauthProvider = new OAuthProvider({
 	tokenEndpoint: oauthPaths.token,
 	clientRegistrationEndpoint: oauthPaths.register,
 	scopesSupported: oauthScopes,
+	// Require PKCE S256; reject the weaker `plain` challenge method. MCP clients
+	// all use S256, so this does not break dynamic client registration (which
+	// the MCP OAuth spec requires and we intentionally keep open).
+	allowPlainPKCE: false,
 })
 
 /**

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -18,6 +18,7 @@ import { wantsJson } from './utils.ts'
 import { verifyPassword } from '@kody-internal/shared/password-hash.ts'
 import { invalidClientIdMismatchMessage } from '@kody-internal/shared/oauth-messages.ts'
 import { getUsernameValidationError } from '#app/username.ts'
+import { getPkceValidationError } from '#worker/oauth-pkce.ts'
 
 export const oauthPaths = {
 	authorize: '/oauth/authorize',
@@ -599,6 +600,19 @@ export async function handleAuthorizeRequest(
 	}
 
 	const { authRequest } = resolution
+	const pkceError = getPkceValidationError(authRequest)
+	if (pkceError) {
+		void logAuditEvent({
+			category: 'oauth',
+			action: 'authorize',
+			result: 'failure',
+			ip: requestIp,
+			clientId: authRequest.clientId,
+			reason: 'invalid_pkce_method',
+		})
+		return respondAuthorizeError(request, pkceError)
+	}
+
 	if (decision === 'deny') {
 		const redirectTo = createAccessDeniedRedirectUrl(authRequest)
 		if (!redirectTo) {

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -600,7 +600,12 @@ export async function handleAuthorizeRequest(
 	}
 
 	const { authRequest } = resolution
-	const pkceError = getPkceValidationError(authRequest)
+	// Reading the fields off the typed `AuthRequest` (rather than passing the
+	// whole object) makes provider field renames a compile-time error here.
+	const pkceError = getPkceValidationError({
+		codeChallenge: authRequest.codeChallenge,
+		codeChallengeMethod: authRequest.codeChallengeMethod,
+	})
 	if (pkceError) {
 		void logAuditEvent({
 			category: 'oauth',

--- a/packages/worker/src/oauth-pkce.node.test.ts
+++ b/packages/worker/src/oauth-pkce.node.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'vitest'
+import { getPkceValidationError } from './oauth-pkce.ts'
+
+test('allows requests with no PKCE challenge (confidential clients)', () => {
+	expect(getPkceValidationError({ codeChallengeMethod: 'plain' })).toBeNull()
+	expect(getPkceValidationError({})).toBeNull()
+})
+
+test('allows S256 PKCE challenges', () => {
+	expect(
+		getPkceValidationError({
+			codeChallenge: 'abc123',
+			codeChallengeMethod: 'S256',
+		}),
+	).toBeNull()
+})
+
+test('rejects a plain or method-less PKCE challenge', () => {
+	expect(
+		getPkceValidationError({
+			codeChallenge: 'abc123',
+			codeChallengeMethod: 'plain',
+		}),
+	).toBe('PKCE code_challenge_method must be S256.')
+	expect(getPkceValidationError({ codeChallenge: 'abc123' })).toBe(
+		'PKCE code_challenge_method must be S256.',
+	)
+})

--- a/packages/worker/src/oauth-pkce.ts
+++ b/packages/worker/src/oauth-pkce.ts
@@ -1,3 +1,8 @@
+// Fully type-only import statement: it is erased at compile time, so this
+// module stays loadable in the plain-Node test pool even though the provider
+// package imports `cloudflare:` modules at runtime.
+import  { type AuthRequest } from '@cloudflare/workers-oauth-provider'
+
 /**
  * PKCE is optional for confidential clients, but when a `code_challenge` is
  * present it must use the S256 method. The `plain` method offers no protection
@@ -8,10 +13,9 @@
  * an explicit `code_challenge_method=S256` — including legitimate no-PKCE
  * confidential-client flows — which breaks real MCP clients.
  */
-export function getPkceValidationError(input: {
-	codeChallenge?: string
-	codeChallengeMethod?: string
-}): string | null {
+export function getPkceValidationError(
+	input: Pick<AuthRequest, 'codeChallenge' | 'codeChallengeMethod'>,
+): string | null {
 	if (input.codeChallenge && input.codeChallengeMethod !== 'S256') {
 		return 'PKCE code_challenge_method must be S256.'
 	}

--- a/packages/worker/src/oauth-pkce.ts
+++ b/packages/worker/src/oauth-pkce.ts
@@ -1,8 +1,3 @@
-// Fully type-only import statement: it is erased at compile time, so this
-// module stays loadable in the plain-Node test pool even though the provider
-// package imports `cloudflare:` modules at runtime.
-import  { type AuthRequest } from '@cloudflare/workers-oauth-provider'
-
 /**
  * PKCE is optional for confidential clients, but when a `code_challenge` is
  * present it must use the S256 method. The `plain` method offers no protection
@@ -12,10 +7,19 @@ import  { type AuthRequest } from '@cloudflare/workers-oauth-provider'
  * `allowPlainPKCE` option: that option rejects every authorize request lacking
  * an explicit `code_challenge_method=S256` — including legitimate no-PKCE
  * confidential-client flows — which breaks real MCP clients.
+ *
+ * The input type is structural (not the provider's `AuthRequest`) so this
+ * module stays importable in the plain-Node test pool — the provider package
+ * imports `cloudflare:` modules at load time, and the lint fixer rewrites
+ * `import type` statements into inline type specifiers that vitest's transform
+ * does not erase. Drift protection against provider field renames lives at the
+ * call site in `oauth-handlers.ts`, which reads the two fields off a typed
+ * `AuthRequest` explicitly.
  */
-export function getPkceValidationError(
-	input: Pick<AuthRequest, 'codeChallenge' | 'codeChallengeMethod'>,
-): string | null {
+export function getPkceValidationError(input: {
+	codeChallenge?: string
+	codeChallengeMethod?: string
+}): string | null {
 	if (input.codeChallenge && input.codeChallengeMethod !== 'S256') {
 		return 'PKCE code_challenge_method must be S256.'
 	}

--- a/packages/worker/src/oauth-pkce.ts
+++ b/packages/worker/src/oauth-pkce.ts
@@ -1,0 +1,19 @@
+/**
+ * PKCE is optional for confidential clients, but when a `code_challenge` is
+ * present it must use the S256 method. The `plain` method offers no protection
+ * against authorization-code interception, so we reject it.
+ *
+ * This is enforced at the application layer rather than via the provider's
+ * `allowPlainPKCE` option: that option rejects every authorize request lacking
+ * an explicit `code_challenge_method=S256` — including legitimate no-PKCE
+ * confidential-client flows — which breaks real MCP clients.
+ */
+export function getPkceValidationError(input: {
+	codeChallenge?: string
+	codeChallengeMethod?: string
+}): string | null {
+	if (input.codeChallenge && input.codeChallengeMethod !== 'S256') {
+		return 'PKCE code_challenge_method must be S256.'
+	}
+	return null
+}

--- a/packages/worker/src/security/security-hardening.workers.test.ts
+++ b/packages/worker/src/security/security-hardening.workers.test.ts
@@ -35,10 +35,17 @@ test('first-party HTML shell carries security headers', async () => {
 test('generated-ui dev route is reachable in the non-production test env', async () => {
 	// The test wrangler environment sets SENTRY_ENVIRONMENT=test, which is a
 	// non-production runtime, so the developer route is served. In production
-	// (SENTRY_ENVIRONMENT=production) the same request falls through to a 404.
+	// (SENTRY_ENVIRONMENT=production) the same request returns 404 immediately
+	// without falling through to assets or the app router.
 	const response = await workerFetch(createRequest('/dev/generated-ui'))
 	expect(response.status).toBe(200)
 	expect(response.headers.get('Content-Type')).toContain('text/html')
+
+	// Non-GET/HEAD methods hit the early 404 branch even in non-production.
+	const postResponse = await workerFetch(
+		createRequest('/dev/generated-ui', { method: 'POST' }),
+	)
+	expect(postResponse.status).toBe(404)
 })
 
 test('oauth authorize login shares the auth rate-limit bucket', async () => {

--- a/packages/worker/src/security/security-hardening.workers.test.ts
+++ b/packages/worker/src/security/security-hardening.workers.test.ts
@@ -1,0 +1,93 @@
+import { env, exports } from 'cloudflare:workers'
+import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { expect, test } from 'vitest'
+
+function createRequest(
+	path: string,
+	options: RequestInit & { headers?: Record<string, string> } = {},
+): Request {
+	return new Request(`https://test.kody.dev${path}`, options)
+}
+
+async function workerFetch(request: Request): Promise<Response> {
+	const ctx = createExecutionContext()
+	const response = await exports.default.fetch(request, env, ctx)
+	await waitOnExecutionContext(ctx)
+	return response
+}
+
+test('first-party HTML shell carries security headers', async () => {
+	const response = await workerFetch(createRequest('/login'))
+	expect(response.status).toBe(200)
+	const csp = response.headers.get('Content-Security-Policy') ?? ''
+	expect(csp).toContain("script-src 'self'")
+	expect(csp).toContain("frame-ancestors 'none'")
+	expect(response.headers.get('X-Frame-Options')).toBe('DENY')
+	expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+	expect(response.headers.get('Referrer-Policy')).toBe(
+		'strict-origin-when-cross-origin',
+	)
+	expect(response.headers.get('Strict-Transport-Security')).toContain(
+		'max-age=',
+	)
+})
+
+test('generated-ui dev route is reachable in the non-production test env', async () => {
+	// The test wrangler environment sets SENTRY_ENVIRONMENT=test, which is a
+	// non-production runtime, so the developer route is served. In production
+	// (SENTRY_ENVIRONMENT=production) the same request falls through to a 404.
+	const response = await workerFetch(createRequest('/dev/generated-ui'))
+	expect(response.status).toBe(200)
+	expect(response.headers.get('Content-Type')).toContain('text/html')
+})
+
+test('oauth authorize login shares the auth rate-limit bucket', async () => {
+	let rateLimited = false
+	for (let i = 0; i < 25; i++) {
+		const response = await workerFetch(
+			createRequest('/oauth/authorize', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+					'CF-Connecting-IP': '203.0.113.7',
+				},
+				body: new URLSearchParams({
+					decision: 'approve',
+					email: 'attacker@example.com',
+					password: 'password123',
+				}).toString(),
+			}),
+		)
+		if (response.status === 429) {
+			rateLimited = true
+			expect(response.headers.get('Retry-After')).toBeTruthy()
+			break
+		}
+	}
+	expect(rateLimited).toBe(true)
+})
+
+test('password-reset confirm is rate limited', async () => {
+	let rateLimited = false
+	for (let i = 0; i < 25; i++) {
+		const response = await workerFetch(
+			createRequest('/password-reset/confirm', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'CF-Connecting-IP': '203.0.113.9',
+				},
+				body: JSON.stringify({
+					token: 'a'.repeat(64),
+					password: 'password123',
+				}),
+			}),
+		)
+		if (response.status === 429) {
+			rateLimited = true
+			expect(response.headers.get('Retry-After')).toBeTruthy()
+			break
+		}
+	}
+	expect(rateLimited).toBe(true)
+})

--- a/tools/mcp-test-support.ts
+++ b/tools/mcp-test-support.ts
@@ -15,7 +15,10 @@ import {
 
 const projectRoot = process.cwd()
 const primaryUserEmail = 'kody@example.com'
-const testUserPassword = 'secret'
+// Must satisfy the server-side password policy (see
+// @kody-internal/shared/password-policy.ts). Matches the documented local seed
+// fixture login (kody@example.com / iliketwix).
+const testUserPassword = 'iliketwix'
 const localhost = '127.0.0.1'
 const defaultWaitTimeoutMs = process.env.CI ? 60_000 : 45_000
 const maxPortBindRetries = 5


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A scoped security audit and repair focused only on issues that apply to this
project (a single Cloudflare Workers app: Remix 3 UI + OAuth-protected MCP). In-scope
findings are fixed; out-of-scope/accepted risks are documented so future agents
don't relitigate or recreate them.

### Fixes

- **First-party HTTP security headers.** New `app/security-headers.ts` applied
  centrally in `render()`: `Content-Security-Policy` (`script-src 'self'` — no
  inline scripts — plus `frame-ancestors 'none'`, `base-uri`, `object-src`,
  `form-action`, same-origin `connect-src`), `X-Frame-Options: DENY`,
  `X-Content-Type-Options: nosniff`, `Referrer-Policy`, and HSTS. Closes
  clickjacking of the OAuth consent screen / account pages and adds an XSS
  backstop. Untrusted package-app / generated-UI surfaces are intentionally left
  on their own looser policies.
- **`/dev/generated-ui` gated to non-production.** This runtime executes
  attacker-authored HTML/JS via `postMessage`; it was reachable in production.
  Now gated behind `isNonProductionRuntime` (new `app/deployment-env.ts`, fails
  closed) and returns 404 in production.
- **Auth rate limiting extended.** `POST /oauth/authorize` and
  `POST /password-reset/confirm` now share the existing per-IP auth bucket, so
  brute force can't fan out across parallel credential paths.
- **OAuth: reject plain PKCE at the app layer.** `getPkceValidationError`
  (`oauth-pkce.ts`) rejects any authorize request whose `code_challenge_method`
  isn't S256 when a challenge is present. Deliberately not using the provider's
  `allowPlainPKCE` option, which rejects legitimate no-PKCE confidential-client
  flows and breaks real MCP clients. Dynamic client registration stays open
  (required by the MCP OAuth spec; documented).
- **Server-side password policy** (min length) enforced on signup and
  password-reset confirmation via shared `password-policy.ts`.

### Docs

- `docs/contributing/security.md` rewritten as the authoritative posture doc:
  invariants future changes must not regress, and an "Accepted residual risks /
  out of scope" section (stateless sessions, owner-scoped secret reveal,
  `refreshAccessToken`, SSRF model, PBKDF2, CSRF via SameSite).
- `docs/contributing/architecture/authentication.md` corrected: signup is
  production-gated (was documented as "open"); the "secret reveal" section now
  describes actual owner-scoped behavior (the documented password-reauth
  `/account/secrets/reveal` endpoint never existed).

## Walkthrough

The new CSP does not break the app — every first-party page renders with full
styling and the DevTools console is free of CSP violations.

<a href="https://cursor.com/agents/bc-485d930c-bbf4-4f31-b6ed-f9ed666b7920/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_and_reset_render_under_csp.mp4"><img src="https://cursor.com/artifacts/c/art-6db77d82-39d5-41b2-a094-234d6c7ac15f" alt="login_and_reset_render_under_csp.mp4" /></a>

![Login page rendered under strict CSP](https://cursor.com/artifacts/c/art-416c38f0-f369-4d23-bd8c-35961f6ba0a5)
![DevTools console with no CSP violations](https://cursor.com/artifacts/c/art-1a0208e4-3b6b-40ce-ba78-ef6aa538084f)

Header + policy evidence (local dev):
[security_headers_verification.txt](https://cursor.com/artifacts/c/art-5da79da2-abe1-4640-bc63-b7b822cedaa7)

## Testing

- ✅ `npm run validate` (format, lint, typecheck, unit, Playwright e2e, MCP e2e — all green)
- ✅ Manual browser verification of headers + rendering under the new CSP

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-485d930c-bbf4-4f31-b6ed-f9ed666b7920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-485d930c-bbf4-4f31-b6ed-f9ed666b7920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signup is now limited to non-production environments, preventing new account creation in production.
  * Account secrets can now be revealed directly from the account page without a separate password re-entry step.

* **Security Improvements**
  * Added stronger security headers across first-party pages.
  * Enforced stronger password requirements for signup and password reset.
  * Added PKCE validation and broader auth rate limiting for better abuse protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->