### PR TITLE
docs: remove stale post-download.ts setup references (closes #585)

### DIFF
--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -39,10 +39,6 @@ The setup flow assumes:
   generated Wrangler configs with real IDs (see `docs/contributing/setup.md`).
   **Local development does not require** provisioning remote D1 or KV;
   `npm run dev` uses local Wrangler persistence.
-- You can write to files in the repository (the script updates config files and
-  replaces template `kody` tokens across text files).
-- Wrangler is optional for post-download setup. It is only needed when you
-  choose to create Cloudflare resources directly from the script.
 
 See `docs/contributing/setup-manifest.md` for required resources and secrets.
 
@@ -51,35 +47,51 @@ For optional Cloudflare offerings (R2, Workers AI, AI Gateway, extra KV), see
 
 ## Preflight checks
 
-Run a quick validation of your environment and Wrangler login status:
+Verify Node 24 and that dependencies are installed:
 
+```bash
+node --version   # expect v24.x
+npm install
 ```
-node ./docs/post-download.ts --check
+
+For deploy work, confirm Wrangler can reach your Cloudflare account:
+
+```bash
+npx wrangler whoami
 ```
 
 ## Quick Start (local only)
 
-1. Run the guided setup script:
+1. Copy the local environment file and adjust secrets if needed:
 
-```
-node ./docs/post-download.ts --guided
+```bash
+cp packages/worker/.env.example packages/worker/.env
 ```
 
-2. Start local development:
+`COOKIE_SECRET` and `SECRET_STORE_KEY` are required. The example file includes
+placeholder values that work for local development.
 
+2. Apply local D1 migrations:
+
+```bash
+npm run migrate:local
 ```
+
+3. Start local development:
+
+```bash
 npm run dev
+```
+
+The CLI prints the resolved URL (default port `3742`). Health check:
+
+```bash
+curl http://localhost:<port>/health
 ```
 
 ## Full Cloudflare setup (deploy)
 
-1. Run the guided setup script:
-
-```
-node ./docs/post-download.ts --guided
-```
-
-This setup step does not create Cloudflare resources. The checked-in Wrangler
+Local setup does not create Cloudflare resources. The checked-in Wrangler
 template omits remote D1/KV IDs on purpose. The production deploy workflow runs
 `node tools/ci/production-resources.ts ensure`, which creates missing D1/KV
 resources when needed and writes
@@ -87,7 +99,7 @@ resources when needed and writes
 deploy. Cloudflare deploys do not auto-create those resources from bindings
 alone, so the workflow runs that ensure step before migrations/deploy.
 
-2. Configure GitHub Actions secrets and variables for deploy:
+1. Configure GitHub Actions secrets and variables for deploy:
 
 - `CLOUDFLARE_API_TOKEN` (Workers deploy + D1 edit access on the correct
   account)
@@ -95,48 +107,36 @@ alone, so the workflow runs that ensure step before migrations/deploy.
 - See `docs/contributing/setup-manifest.md` (`GitHub Actions configuration`) for
   full optional secrets/variables and where to get each value.
 
-3. Deploy:
+2. Deploy:
 
-```
+```bash
 npm run deploy
 ```
 
 ## Agent/CI setup
 
-Use non-interactive flags or `--defaults`. The `--defaults` flag skips prompts
-and uses defaults based on the current directory name (app/package naming), plus
-a generated cookie secret.
+For non-interactive or automated setup:
 
+1. Ensure `packages/worker/.env` exists (copy from `.env.example` if missing).
+2. Run migrations and the full validation gate:
+
+```bash
+npm run migrate:local
+npm run validate
 ```
-node ./docs/post-download.ts --defaults
+
+`npm run validate` is the single authoritative CI gate. It runs format, lint,
+typecheck, unit tests, Playwright E2E, and MCP E2E in parallel.
+
+To seed a deterministic test login after migrations:
+
+```bash
+node tools/seed-test-data.ts --local
 ```
 
-To preview changes without writing, add `--dry-run`. To emit a JSON summary, add
-`--json`. To run preflight checks only, add `--check`.
-
-When running in a non-TTY shell, the script fails fast if required prompt values
-are missing (for example `--app-name` without `--defaults`, and init choice when
-`--guided` is set without `--init` or `--no-init`).
-
-### Script flags
-
-- `--guided`: interactive, state-aware flow (optional git init/first commit
-  prompt).
-- `--init` / `--no-init`: force or skip git init + initial `init` commit.
-- `--check`: run preflight checks only.
-- `--defaults`: accept defaults without prompts.
-- `--dry-run`: show changes without writing or deleting the script.
-- `--json`: print a JSON summary.
-- `--app-name`: app name used for branding token replacement.
-- `--package-name`: override package name (defaults to kebab-cased app name).
-- `--github-username`: derives repository URL as
-  `git+ssh://git@github.com/<username>/<package-name>.git`.
-- `--repository-url`: explicit repository URL override.
-- `--cookie-secret`: explicit `COOKIE_SECRET` value (otherwise generated).
-
-Cloudflare resources are managed during deploy. The setup script does not create
-Cloudflare resources; deploy-time ensure steps inject real D1/KV IDs into
-generated Wrangler configs (not into the checked-in template).
+Cloudflare resources are managed during deploy. Deploy-time ensure steps inject
+real D1/KV IDs into generated Wrangler configs (not into the checked-in
+template).
 
 ## Local development
 
@@ -162,12 +162,12 @@ credentials.
 
 Build the project:
 
-```
+```bash
 npm run build
 ```
 
 Deploy to Cloudflare:
 
-```
+```bash
 npm run deploy
 ```

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -101,8 +101,8 @@ alone, so the workflow runs that ensure step before migrations/deploy.
 
 1. Configure GitHub Actions secrets and variables for deploy:
 
-- `CLOUDFLARE_API_TOKEN` (Workers deploy + D1 edit access on the correct
-  account)
+- `CLOUDFLARE_API_TOKEN` (Workers deploy + D1 edit + Workers KV Storage:Edit
+  access on the correct account)
 - `COOKIE_SECRET` (generate with `openssl rand -hex 32` or similar)
 - See `docs/contributing/setup-manifest.md` (`GitHub Actions configuration`) for
   full optional secrets/variables and where to get each value.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `docs/contributing/getting-started.md` to match the current contributor setup flow.

The doc still referenced `docs/post-download.ts` and its flags (`--guided`, `--defaults`, `--check`), but that epicflare-era script no longer exists in this repo.

## Changes

- Replace post-download script steps with the actual local setup path: copy `.env`, run migrations, start dev
- Simplify expectations (no script-driven token replacement or Wrangler preflight)
- Point agent/CI setup at `npm run validate` and the seed script instead of removed script flags

Closes #585
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1ff70a2-12a1-49a4-9860-b46e033687a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1ff70a2-12a1-49a4-9860-b46e033687a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the contributor getting-started guide with revised setup guidance, including added preflight checks.
  * Added a streamlined “local only” quick start covering environment setup, migrations, dev server start, and a health check.
  * Expanded cloud deployment instructions with clearer CI configuration steps and structured production deploy flow.
  * Reworked automated/non-interactive setup guidance and clarified build/deploy command examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->