### PR TITLE
Add ship-pr agent skill for CI loop and Discord notification

### DIFF
--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ship-pr
 description: >
-  Babysit a PR. Iterate with AI reviewers and CI. Get it ready and maybe merge. Send summary message. 
+  Babysit a PR. Iterate with AI reviewers and CI. Get it ready and maybe merge.
+  Send summary message.
 ---
 
 # Ship PR
@@ -11,7 +12,8 @@ description: >
 1. Mark ready — `kody:@kentcdodds/github-pr-tools/set-pr-review-status` with
    `{ owner, repo, number, ready: true }`
 2. Wait for CI — `gh pr checks` (compose `loop-on-ci`, `fix-ci`)
-3. Fix failures; address valid AI-reviewer feedback (ignore insignificant nits / already-fixed / wrong)
+3. Fix failures; address valid AI-reviewer feedback (ignore insignificant nits /
+   already-fixed / wrong)
 4. Green and no valid feedback left → break
 5. Push → repeat
 
@@ -19,7 +21,9 @@ description: >
 
 By default, continue to Discord message with summary and include PR link
 
-If explicitly requested, merge PR as Kody, watch CI deploy, when finished, continue to the discord message and include a summary with link to PR, deployed URL link, or failing job link.
+If explicitly requested, merge PR as Kody, watch CI deploy, when finished,
+continue to the discord message and include a summary with link to PR, deployed
+URL link, or failing job link.
 
 ## Done → Discord
 
@@ -27,7 +31,7 @@ If explicitly requested, merge PR as Kody, watch CI deploy, when finished, conti
 import sendMeAMessage from 'kody:@kentcdodds/discord-gateway/send-me-a-message'
 
 export default async function main() {
-  const content = ` ... `
+	const content = ` ... `
 	return sendMeAMessage({ content })
 }
 ```

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -44,3 +44,51 @@ After the loop: merge → watch `🚀 Deploy (production)` → smoke test produc
 - Production URL: `gh variable get APP_BASE_URL`; preview URL from PR comments
   if testing before merge
 - Mark ready / PR info: `github-pr-tools` package
+
+Discover exports when unsure: `search({ entity: "discord-gateway:package" })` or
+`search({ entity: "github-pr-tools:package" })`.
+
+## Kody examples
+
+Mark ready:
+
+```javascript
+import { packages } from 'kody:runtime'
+
+export default async function main({ owner, repo, number }) {
+	return packages.invokeChecked({
+		kodyId: 'github-pr-tools',
+		exportName: './set-pr-review-status',
+		params: { owner, repo, number, ready: true },
+	})
+}
+```
+
+Discord (default — no channel id):
+
+```javascript
+import { packages } from 'kody:runtime'
+
+export default async function main({ content }) {
+	return packages.invokeChecked({
+		kodyId: 'discord-gateway',
+		exportName: './send-me-a-message',
+		params: { content },
+	})
+}
+```
+
+Discord (specific workflow channel):
+
+```javascript
+import { packages, codemode } from 'kody:runtime'
+
+export default async function main({ valueName, content }) {
+	const channelId = await codemode.value_get({ name: valueName, scope: 'user' })
+	return packages.invokeChecked({
+		kodyId: 'discord-gateway',
+		exportName: './post-message',
+		params: { channelId, content },
+	})
+}
+```

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -1,318 +1,46 @@
 ---
 name: ship-pr
 description: >
-  Ship a pull request end-to-end: mark ready for review via Kody, loop on CI
-  failures and AI reviewer bot feedback until green, optionally merge and verify
-  production deploy with manual smoke testing, then notify Kent on Discord via
-  Kody. Resolves Discord destination and deploy URLs from Kody values and repo
-  metadata — no hardcoded channel or production URL. Use when asked to ship a
-  PR, mark ready for review, loop on CI, merge and verify, or send a Discord
-  notification about a PR.
+  Ship a PR: mark ready for review, loop on CI and AI reviewer feedback until
+  green, notify Kent on Discord via Kody. Optional merge-and-verify mode. Use
+  when asked to ship a PR, loop on CI, merge and verify, or message on Discord.
 ---
 
 # Ship PR
 
-Orchestrate PR shipping from draft → green CI → (optional) merge → Discord
-notification. Compose the existing CI and review skills instead of redefining
-their steps.
+**Default mode:** ready for review → Discord with PR link when done.
 
-**Do not hardcode Discord channel ids or production URLs.** Resolve them at
-runtime from Kody and the repo (see **Resolve context** below). You already have
-what you need when Kody MCP is connected.
+**Merge mode** (when user asks to merge): same loop, then merge, watch
+production deploy, smoke test, Discord summary.
 
-## Inputs
+## Loop
 
-| Input    | Default            | Notes                                                    |
-| -------- | ------------------ | -------------------------------------------------------- |
-| **mode** | `ready-for-review` | `merge-and-verify` adds merge, deploy watch, manual test |
+1. Mark PR ready for review (Kody `github-pr-tools/set-pr-review-status`,
+   `ready: true`)
+2. Wait for CI (`gh pr checks`)
+3. Fix failures; address valid AI-reviewer bot feedback (ignore
+   nits/already-fixed/wrong)
+4. If green and no valid feedback left → break
+5. Push → repeat
 
-If the user says "merge it", "ship to prod", or "verify deploy", use
-`merge-and-verify`. Otherwise default to `ready-for-review`.
+Compose `loop-on-ci`, `fix-ci`, and `get-pr-comments` when helpful.
 
-## Resolve context (always do this first)
+## Discord (Kody)
 
-Run these lookups once at the start. Cache the results for the rest of the run.
+Default: `discord-gateway/send-me-a-message` with the PR link and a one-liner.
+No channel id needed — it uses your configured general channel.
 
-### Kody packages (via `search`)
+Merge mode: include what merged, deploy status, and what you tested.
 
-| Need                               | Kody entity               | Export to use                               |
-| ---------------------------------- | ------------------------- | ------------------------------------------- |
-| Mark PR ready for review           | `github-pr-tools:package` | `./set-pr-review-status` with `ready: true` |
-| PR details                         | `github-pr-tools:package` | `./get-pr-info`                             |
-| Notify Kent on Discord (default)   | `discord-gateway:package` | `./send-me-a-message`                       |
-| Notify a specific workflow channel | `discord-gateway:package` | `./post-message` + resolved channel value   |
+## Merge-and-verify extras
 
-**Default Discord path:** `./send-me-a-message` posts to Kent's configured
-general channel. It reads `kodyDiscordGeneralChannelId` internally — you do
-**not** need a channel id for the usual "message me on Discord" case.
+After the loop: merge → watch `🚀 Deploy (production)` → smoke test production
+(`gh variable get APP_BASE_URL` for the URL) → Discord summary.
 
-**Workflow-specific channel:** when the user names a workflow (e.g. "GitHub
-summary channel"), search Kody values:
+## Resolve from Kody/repo (don't ask Kent)
 
-```
-search({ query: "discord channel <workflow>" })
-```
-
-Prefer values whose names end in `DiscordChannelId` (e.g.
-`dailyGithubSummaryDiscordChannelId`). Load with
-`search({ entity: "user:<name>:value" })` or `codemode.value_get`.
-
-### Deploy / health-check URL (from repo metadata)
-
-Resolve in this order; stop at the first hit:
-
-1. **Production (merge-and-verify mode):**
-
-   ```bash
-   gh variable get APP_BASE_URL --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)"
-   ```
-
-   GitHub Actions production deploy uses this variable (see
-   `.github/workflows/deploy.yml`).
-
-2. **Preview (optional pre-merge smoke test on kody PRs):** parse the PR body
-   for the preview marker:
-
-   ```bash
-   gh pr view --json body -q .body | rg -o 'https://[^ )]+' | head -1
-   # or look for the line after <!-- kody-preview-url -->
-   ```
-
-   Preview deploy comments are posted by `.github/workflows/preview.yml`.
-
-3. **Kody-hosted hint:** saved package invocation URLs (e.g. from
-   `search({ entity: "discord-gateway:package" })`) expose the canonical Kody
-   host (`https://heykody.dev`). Use only when the repo has no `APP_BASE_URL`
-   variable and you need a production fallback for the kody repo itself.
-
-4. **Deploy run output:** after watching `🚀 Deploy (production)`, read the
-   deploy job log or environment URL if steps 1–3 did not yield a URL.
-
-Health check: `curl -sf "${deployUrl}/health"` → `{"ok":true,...}`.
-
-## Prerequisites
-
-Before starting, confirm:
-
-1. **Active PR** for the current branch (`gh pr view`).
-2. **`gh` authenticated** with permission to push and (merge mode) merge.
-3. **Kody MCP connected** with saved packages `github-pr-tools` and
-   `discord-gateway` (plus invocation tokens for the exports you call).
-
-If Kody setup is missing, stop and link setup pages — never ask for tokens in
-chat.
-
-## Related skills (read when activated)
-
-| Step                                | Skill             |
-| ----------------------------------- | ----------------- |
-| CI watch loop                       | `loop-on-ci`      |
-| Fix failing checks                  | `fix-ci`          |
-| Summarize review feedback           | `get-pr-comments` |
-| PR description recap (kody repo)    | `visual-recap`    |
-| Manual browser testing (merge mode) | `control-ui`      |
-
-## Workflow
-
-### A. Prepare
-
-```bash
-gh pr view --json number,url,title,isDraft,headRefName,baseRefName,reviewDecision
-```
-
-Mark ready via **Kody** (preferred over raw `gh pr ready`):
-
-```javascript
-import { packages } from 'kody:runtime'
-
-export default async function main({ owner, repo, number }) {
-	return packages.invokeChecked({
-		kodyId: 'github-pr-tools',
-		exportName: './set-pr-review-status',
-		params: { owner, repo, number, ready: true },
-	})
-}
-```
-
-Pass `owner`, `repo`, and `number` from `gh pr view` / git remote. Fall back to
-`gh pr ready` only if Kody is unavailable.
-
-Marking ready matters in this repo: **Validate** and **Preview** workflows skip
-draft PRs. CI will not run until the PR is ready for review.
-
-If the repo has `.agents/skills/visual-recap/SKILL.md`, upsert the system recap
-block before entering the loop (recap mode).
-
-### B. Loop until exit
-
-Repeat until **all required checks pass** and **no unaddressed valid bot
-feedback** remains.
-
-#### 1. CI status
-
-Follow **loop-on-ci**. Use `gh pr checks` as the source of truth (not
-`gh run list` alone):
-
-```bash
-gh pr checks --json name,bucket,state,workflow,link
-gh pr checks --watch --fail-fast   # when checks are pending
-```
-
-If any check is in `FAIL`/`CANCEL`/`SKIPPED` when it should have run, follow
-**fix-ci** before continuing.
-
-#### 2. Fix failures
-
-Follow **fix-ci**:
-
-- One root cause per commit when possible.
-- Never bypass hooks (`--no-verify`).
-- After each push, re-run `gh pr checks --json name,bucket,state,workflow,link`.
-
-#### 3. AI reviewer bot feedback
-
-Follow **get-pr-comments**, then fetch raw comments when needed:
-
-```bash
-gh pr view --comments
-gh api repos/{owner}/{repo}/pulls/{number}/comments
-gh api repos/{owner}/{repo}/pulls/{number}/reviews
-```
-
-**Valid feedback** (must fix or explicitly rebut in a PR comment):
-
-- Correctness, security, or regression issues backed by the diff.
-- CI-related suggestions that match an actual failure.
-- Repeated bot themes (same comment class twice → treat as valid).
-
-**Ignore** (do not loop on):
-
-- Style-only nits already covered by lint/format.
-- Issues already fixed in the latest commit (verify against diff).
-- Hallucinated file/line references or suggestions contradicted by the code.
-- Subjective preferences with no project rule backing them.
-
-Optionally launch the **Bugbot** subagent for a deeper pass on large or risky
-diffs. Bot output still goes through the validity filter above.
-
-#### 4. Exit condition
-
-Break the loop when:
-
-- Every attached check is `PASS` or legitimately `SKIPPING`, and
-- No valid unaddressed bot feedback remains.
-
-If you fixed anything in steps 2–3, commit, push, and **go back to step 1**.
-
-### C. Mode branch
-
-#### Mode: `ready-for-review`
-
-Send Discord via Kody (see **Discord notification** below):
-
-- PR title and URL
-- One line: CI green, bot feedback addressed, ready for human review
-
-#### Mode: `merge-and-verify`
-
-Only when the user explicitly wants merge + deploy verification.
-
-1. **Pre-merge gate** — re-check:
-
-   ```bash
-   gh pr checks --json name,bucket,state,workflow,link
-   gh pr view --json mergeable,mergeStateStatus,reviewDecision
-   ```
-
-   Do not merge with failing required checks or unresolved merge conflicts.
-
-2. **Merge** (adjust flags if the user specifies otherwise):
-
-   ```bash
-   gh pr merge --squash --delete-branch
-   ```
-
-3. **Watch production deploy** — kody deploys after Validate succeeds on `main`:
-
-   ```bash
-   gh run list --workflow="🚀 Deploy (production)" --branch main --limit 1 \
-     --json databaseId,status,conclusion,url
-   gh run watch <run-id> --exit-status
-   ```
-
-4. **Manual smoke test** — follow **control-ui** (or equivalent), using the
-   **deploy URL resolved above**:
-   - `curl -sf "${deployUrl}/health"` → `{"ok":true,...}`
-   - One critical user flow relevant to the PR (sign-in, changed route, MCP
-     health, etc.)
-   - Record what was tested and the outcome.
-
-5. **Discord summary** — what merged, deploy run URL/status, smoke test notes,
-   and link to the (now merged) PR.
-
-## Discord notification (Kody)
-
-### Default: message Kent
-
-Use `./send-me-a-message` — no channel id required:
-
-```javascript
-import { packages } from 'kody:runtime'
-
-export default async function main({ content }) {
-	return packages.invokeChecked({
-		kodyId: 'discord-gateway',
-		exportName: './send-me-a-message',
-		params: { content },
-	})
-}
-```
-
-Discover the export contract when unsure:
-`search({ entity: "discord-gateway:package" })`.
-
-### Override: specific channel
-
-Only when the user names a workflow channel or `search` surfaces a better
-`*DiscordChannelId` value for this notification type:
-
-```javascript
-import { packages, codemode } from 'kody:runtime'
-
-export default async function main({ valueName, content }) {
-	const channelId = await codemode.value_get({
-		name: valueName,
-		scope: 'user',
-	})
-	return packages.invokeChecked({
-		kodyId: 'discord-gateway',
-		exportName: './post-message',
-		params: { channelId, content },
-	})
-}
-```
-
-Keep messages short; use markdown links for PR and deploy URLs.
-
-## Guardrails
-
-- Do not merge unless **mode** is `merge-and-verify` and intent is explicit.
-- Do not merge with failing required checks.
-- Do not bypass git hooks or force-push to main.
-- Do not send Discord until the success criteria for the chosen mode are met.
-- Do not ask the user for a Discord channel id when `./send-me-a-message` or
-  Kody value search can resolve it.
-- If CI failures are clearly unrelated and fixed on `main`, merge latest main
-  instead of unrelated fixes in the PR.
-- If checks are flaky, retry once and note flake evidence before looping again.
-
-## Output
-
-Report back with:
-
-- PR URL and final CI status
-- Resolved deploy URL and Discord path used
-- Fixes applied during the loop (if any)
-- Bot feedback addressed vs dismissed (brief)
-- Discord delivery confirmation
-- **Merge mode only:** merge SHA, deploy run URL, smoke test notes
+- Discord channel: `./send-me-a-message` (or search `*DiscordChannelId` values
+  if a specific channel is named)
+- Production URL: `gh variable get APP_BASE_URL`; preview URL from PR comments
+  if testing before merge
+- Mark ready / PR info: `github-pr-tools` package

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -1,41 +1,33 @@
 ---
 name: ship-pr
 description: >
-  Ship a PR: mark ready for review, loop on CI and AI reviewer feedback until
-  green, notify Kent on Discord via Kody. Optional merge-and-verify mode. Use
-  when asked to ship a PR, loop on CI, merge and verify, or message on Discord.
+  Babysit a PR. Iterate with AI reviewers and CI. Get it ready and maybe merge. Send summary message. 
 ---
 
 # Ship PR
 
-**Default:** ready for review → Discord with PR link when done.
-
-**Merge mode** (when asked): same loop, then merge, watch
-`🚀 Deploy (production)`, smoke test (`gh variable get APP_BASE_URL`), Discord
-summary.
-
 ## Loop
 
 1. Mark ready — `kody:@kentcdodds/github-pr-tools/set-pr-review-status` with
-   `{ owner, repo, number, ready: true }` (or `gh pr ready` if Kody unavailable)
+   `{ owner, repo, number, ready: true }`
 2. Wait for CI — `gh pr checks` (compose `loop-on-ci`, `fix-ci`)
-3. Fix failures; address valid AI-reviewer feedback (ignore nits / already-fixed
-   / wrong)
+3. Fix failures; address valid AI-reviewer feedback (ignore insignificant nits / already-fixed / wrong)
 4. Green and no valid feedback left → break
 5. Push → repeat
 
-## Done → Discord
+## Mode
 
-`kody:@kentcdodds/discord-gateway/send-me-a-message` — no channel id; uses your
-general channel. Merge mode: include deploy status and what you tested.
+By default, continue to Discord message with summary and include PR link
+
+If explicitly requested, merge PR as Kody, watch CI deploy, when finished, continue to the discord message and include a summary with link to PR, deployed URL link, or failing job link.
+
+## Done → Discord
 
 ```javascript
 import sendMeAMessage from 'kody:@kentcdodds/discord-gateway/send-me-a-message'
 
-export default async function main({ content }) {
+export default async function main() {
+  const content = ` ... `
 	return sendMeAMessage({ content })
 }
 ```
-
-Don't ask Kent for channel or production URL — resolve from Kody values /
-`gh variable get APP_BASE_URL` / PR preview comments.

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: ship-pr
+description: >
+  Ship a pull request end-to-end: mark ready for review, loop on CI failures and
+  AI reviewer bot feedback until green, optionally merge and verify production
+  deploy with manual smoke testing, then notify Kent on Discord via Kody. Use
+  when asked to ship a PR, mark ready for review, loop on CI, merge and verify,
+  or send a Discord notification about a PR.
+metadata:
+  discord-channel-id: ''
+  production-url: 'https://heykody.dev'
+---
+
+# Ship PR
+
+Orchestrate PR shipping from draft → green CI → (optional) merge → Discord
+notification. Compose the existing CI and review skills instead of redefining
+their steps.
+
+## Inputs
+
+Resolve at the start of every run:
+
+| Input                  | Default                       | Notes                                                    |
+| ---------------------- | ----------------------------- | -------------------------------------------------------- |
+| **mode**               | `ready-for-review`            | `merge-and-verify` adds merge, deploy watch, manual test |
+| **discord-channel-id** | `metadata.discord-channel-id` | Required before sending Discord; ask if empty            |
+| **production-url**     | `metadata.production-url`     | Health check target for merge mode                       |
+
+If the user says "merge it", "ship to prod", or "verify deploy", use
+`merge-and-verify`. Otherwise default to `ready-for-review`.
+
+## Prerequisites
+
+Before starting, confirm:
+
+1. **Active PR** for the current branch (`gh pr view`).
+2. **`gh` authenticated** with permission to push, mark ready, and (merge mode)
+   merge.
+3. **Kody MCP connected** with:
+   - Saved package `@kentcdodds/discord-gateway` (kody id `discord-gateway`)
+   - Secret `discordBotToken`
+   - Package invocation token for `./post-message`
+
+If Discord setup is missing, stop before the notification step and link the user
+to Kody secret/token setup — never ask for tokens in chat.
+
+## Related skills (read when activated)
+
+| Step                                | Skill             |
+| ----------------------------------- | ----------------- |
+| CI watch loop                       | `loop-on-ci`      |
+| Fix failing checks                  | `fix-ci`          |
+| Summarize review feedback           | `get-pr-comments` |
+| PR description recap (kody repo)    | `visual-recap`    |
+| Manual browser testing (merge mode) | `control-ui`      |
+
+## Workflow
+
+### A. Prepare
+
+```bash
+gh pr view --json number,url,title,isDraft,headRefName,baseRefName,reviewDecision
+gh pr ready
+```
+
+Marking ready matters in this repo: **Validate** and **Preview** workflows skip
+draft PRs. CI will not run until the PR is ready for review.
+
+If the repo has `.agents/skills/visual-recap/SKILL.md`, upsert the system recap
+block before entering the loop (recap mode).
+
+### B. Loop until exit
+
+Repeat until **all required checks pass** and **no unaddressed valid bot
+feedback** remains.
+
+#### 1. CI status
+
+Follow **loop-on-ci**. Use `gh pr checks` as the source of truth (not
+`gh run list` alone):
+
+```bash
+gh pr checks --json name,bucket,state,workflow,link
+gh pr checks --watch --fail-fast   # when checks are pending
+```
+
+If any check is in `FAIL`/`CANCEL`/`SKIPPED` when it should have run, follow
+**fix-ci** before continuing.
+
+#### 2. Fix failures
+
+Follow **fix-ci**:
+
+- One root cause per commit when possible.
+- Never bypass hooks (`--no-verify`).
+- After each push, re-run `gh pr checks --json name,bucket,state,workflow,link`.
+
+#### 3. AI reviewer bot feedback
+
+Follow **get-pr-comments**, then fetch raw comments when needed:
+
+```bash
+gh pr view --comments
+gh api repos/{owner}/{repo}/pulls/{number}/comments
+gh api repos/{owner}/{repo}/pulls/{number}/reviews
+```
+
+**Valid feedback** (must fix or explicitly rebut in a PR comment):
+
+- Correctness, security, or regression issues backed by the diff.
+- CI-related suggestions that match an actual failure.
+- Repeated bot themes (same comment class twice → treat as valid).
+
+**Ignore** (do not loop on):
+
+- Style-only nits already covered by lint/format.
+- Issues already fixed in the latest commit (verify against diff).
+- Hallucinated file/line references or suggestions contradicted by the code.
+- Subjective preferences with no project rule backing them.
+
+Optionally launch the **Bugbot** subagent for a deeper pass on large or risky
+diffs. Bot output still goes through the validity filter above.
+
+#### 4. Exit condition
+
+Break the loop when:
+
+- Every attached check is `PASS` or legitimately `SKIPPING`, and
+- No valid unaddressed bot feedback remains.
+
+If you fixed anything in steps 2–3, commit, push, and **go back to step 1**.
+
+### C. Mode branch
+
+#### Mode: `ready-for-review`
+
+Send Discord via Kody (see **Discord notification** below):
+
+- PR title and URL
+- One line: CI green, bot feedback addressed, ready for human review
+
+#### Mode: `merge-and-verify`
+
+Only when the user explicitly wants merge + deploy verification.
+
+1. **Pre-merge gate** — re-check:
+
+   ```bash
+   gh pr checks --json name,bucket,state,workflow,link
+   gh pr view --json mergeable,mergeStateStatus,reviewDecision
+   ```
+
+   Do not merge with failing required checks or unresolved merge conflicts.
+
+2. **Merge** (adjust flags if the user specifies otherwise):
+
+   ```bash
+   gh pr merge --squash --delete-branch
+   ```
+
+3. **Watch production deploy** — kody deploys after Validate succeeds on `main`:
+
+   ```bash
+   gh run list --workflow="🚀 Deploy (production)" --branch main --limit 1 \
+     --json databaseId,status,conclusion,url
+   gh run watch <run-id> --exit-status
+   ```
+
+4. **Manual smoke test** — follow **control-ui** (or equivalent):
+   - `curl -sf "${production-url}/health"` → `{"ok":true,...}`
+   - One critical user flow relevant to the PR (sign-in, changed route, MCP
+     health, etc.)
+   - Record what was tested and the outcome.
+
+5. **Discord summary** — what merged, deploy run URL/status, smoke test notes,
+   and link to the (now merged) PR.
+
+## Discord notification (Kody)
+
+1. Discover the package API (first run or when unsure):
+   ```
+   search({ entity: "discord-gateway:package" })
+   ```
+2. Send via `execute`:
+
+```javascript
+import { packages } from 'kody:runtime'
+
+export default async function main({ channelId, content }) {
+	return packages.invokeChecked({
+		kodyId: 'discord-gateway',
+		exportName: './post-message',
+		params: { channelId, content },
+	})
+}
+```
+
+Pass `channelId` from skill metadata or user input. Keep messages short; use
+markdown links for PR and deploy URLs.
+
+## Guardrails
+
+- Do not merge unless **mode** is `merge-and-verify` and intent is explicit.
+- Do not merge with failing required checks.
+- Do not bypass git hooks or force-push to main.
+- Do not send Discord until the success criteria for the chosen mode are met.
+- If CI failures are clearly unrelated and fixed on `main`, merge latest main
+  instead of unrelated fixes in the PR.
+- If checks are flaky, retry once and note flake evidence before looping again.
+
+## Output
+
+Report back with:
+
+- PR URL and final CI status
+- Fixes applied during the loop (if any)
+- Bot feedback addressed vs dismissed (brief)
+- Discord delivery confirmation
+- **Merge mode only:** merge SHA, deploy run URL, smoke test notes

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -8,87 +8,34 @@ description: >
 
 # Ship PR
 
-**Default mode:** ready for review → Discord with PR link when done.
+**Default:** ready for review → Discord with PR link when done.
 
-**Merge mode** (when user asks to merge): same loop, then merge, watch
-production deploy, smoke test, Discord summary.
+**Merge mode** (when asked): same loop, then merge, watch
+`🚀 Deploy (production)`, smoke test (`gh variable get APP_BASE_URL`), Discord
+summary.
 
 ## Loop
 
-1. Mark PR ready for review (Kody `github-pr-tools/set-pr-review-status`,
-   `ready: true`)
-2. Wait for CI (`gh pr checks`)
-3. Fix failures; address valid AI-reviewer bot feedback (ignore
-   nits/already-fixed/wrong)
-4. If green and no valid feedback left → break
+1. Mark ready — `kody:@kentcdodds/github-pr-tools/set-pr-review-status` with
+   `{ owner, repo, number, ready: true }` (or `gh pr ready` if Kody unavailable)
+2. Wait for CI — `gh pr checks` (compose `loop-on-ci`, `fix-ci`)
+3. Fix failures; address valid AI-reviewer feedback (ignore nits / already-fixed
+   / wrong)
+4. Green and no valid feedback left → break
 5. Push → repeat
 
-Compose `loop-on-ci`, `fix-ci`, and `get-pr-comments` when helpful.
+## Done → Discord
 
-## Discord (Kody)
-
-Default: `discord-gateway/send-me-a-message` with the PR link and a one-liner.
-No channel id needed — it uses your configured general channel.
-
-Merge mode: include what merged, deploy status, and what you tested.
-
-## Merge-and-verify extras
-
-After the loop: merge → watch `🚀 Deploy (production)` → smoke test production
-(`gh variable get APP_BASE_URL` for the URL) → Discord summary.
-
-## Resolve from Kody/repo (don't ask Kent)
-
-- Discord channel: `./send-me-a-message` (or search `*DiscordChannelId` values
-  if a specific channel is named)
-- Production URL: `gh variable get APP_BASE_URL`; preview URL from PR comments
-  if testing before merge
-- Mark ready / PR info: `github-pr-tools` package
-
-Discover exports when unsure: `search({ entity: "discord-gateway:package" })` or
-`search({ entity: "github-pr-tools:package" })`.
-
-## Kody examples
-
-Mark ready:
+`kody:@kentcdodds/discord-gateway/send-me-a-message` — no channel id; uses your
+general channel. Merge mode: include deploy status and what you tested.
 
 ```javascript
-import { packages } from 'kody:runtime'
-
-export default async function main({ owner, repo, number }) {
-	return packages.invokeChecked({
-		kodyId: 'github-pr-tools',
-		exportName: './set-pr-review-status',
-		params: { owner, repo, number, ready: true },
-	})
-}
-```
-
-Discord (default — no channel id):
-
-```javascript
-import { packages } from 'kody:runtime'
+import sendMeAMessage from 'kody:@kentcdodds/discord-gateway/send-me-a-message'
 
 export default async function main({ content }) {
-	return packages.invokeChecked({
-		kodyId: 'discord-gateway',
-		exportName: './send-me-a-message',
-		params: { content },
-	})
+	return sendMeAMessage({ content })
 }
 ```
 
-Discord (specific workflow channel):
-
-```javascript
-import { packages, codemode } from 'kody:runtime'
-
-export default async function main({ valueName, content }) {
-	const channelId = await codemode.value_get({ name: valueName, scope: 'user' })
-	return packages.invokeChecked({
-		kodyId: 'discord-gateway',
-		exportName: './post-message',
-		params: { channelId, content },
-	})
-}
-```
+Don't ask Kent for channel or production URL — resolve from Kody values /
+`gh variable get APP_BASE_URL` / PR preview comments.

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: ship-pr
 description: >
-  Ship a pull request end-to-end: mark ready for review, loop on CI failures and
-  AI reviewer bot feedback until green, optionally merge and verify production
-  deploy with manual smoke testing, then notify Kent on Discord via Kody. Use
-  when asked to ship a PR, mark ready for review, loop on CI, merge and verify,
-  or send a Discord notification about a PR.
-metadata:
-  discord-channel-id: ''
-  production-url: 'https://heykody.dev'
+  Ship a pull request end-to-end: mark ready for review via Kody, loop on CI
+  failures and AI reviewer bot feedback until green, optionally merge and verify
+  production deploy with manual smoke testing, then notify Kent on Discord via
+  Kody. Resolves Discord destination and deploy URLs from Kody values and repo
+  metadata — no hardcoded channel or production URL. Use when asked to ship a
+  PR, mark ready for review, loop on CI, merge and verify, or send a Discord
+  notification about a PR.
 ---
 
 # Ship PR
@@ -17,33 +16,91 @@ Orchestrate PR shipping from draft → green CI → (optional) merge → Discord
 notification. Compose the existing CI and review skills instead of redefining
 their steps.
 
+**Do not hardcode Discord channel ids or production URLs.** Resolve them at
+runtime from Kody and the repo (see **Resolve context** below). You already have
+what you need when Kody MCP is connected.
+
 ## Inputs
 
-Resolve at the start of every run:
-
-| Input                  | Default                       | Notes                                                    |
-| ---------------------- | ----------------------------- | -------------------------------------------------------- |
-| **mode**               | `ready-for-review`            | `merge-and-verify` adds merge, deploy watch, manual test |
-| **discord-channel-id** | `metadata.discord-channel-id` | Required before sending Discord; ask if empty            |
-| **production-url**     | `metadata.production-url`     | Health check target for merge mode                       |
+| Input    | Default            | Notes                                                    |
+| -------- | ------------------ | -------------------------------------------------------- |
+| **mode** | `ready-for-review` | `merge-and-verify` adds merge, deploy watch, manual test |
 
 If the user says "merge it", "ship to prod", or "verify deploy", use
 `merge-and-verify`. Otherwise default to `ready-for-review`.
+
+## Resolve context (always do this first)
+
+Run these lookups once at the start. Cache the results for the rest of the run.
+
+### Kody packages (via `search`)
+
+| Need                               | Kody entity               | Export to use                               |
+| ---------------------------------- | ------------------------- | ------------------------------------------- |
+| Mark PR ready for review           | `github-pr-tools:package` | `./set-pr-review-status` with `ready: true` |
+| PR details                         | `github-pr-tools:package` | `./get-pr-info`                             |
+| Notify Kent on Discord (default)   | `discord-gateway:package` | `./send-me-a-message`                       |
+| Notify a specific workflow channel | `discord-gateway:package` | `./post-message` + resolved channel value   |
+
+**Default Discord path:** `./send-me-a-message` posts to Kent's configured
+general channel. It reads `kodyDiscordGeneralChannelId` internally — you do
+**not** need a channel id for the usual "message me on Discord" case.
+
+**Workflow-specific channel:** when the user names a workflow (e.g. "GitHub
+summary channel"), search Kody values:
+
+```
+search({ query: "discord channel <workflow>" })
+```
+
+Prefer values whose names end in `DiscordChannelId` (e.g.
+`dailyGithubSummaryDiscordChannelId`). Load with
+`search({ entity: "user:<name>:value" })` or `codemode.value_get`.
+
+### Deploy / health-check URL (from repo metadata)
+
+Resolve in this order; stop at the first hit:
+
+1. **Production (merge-and-verify mode):**
+
+   ```bash
+   gh variable get APP_BASE_URL --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+   ```
+
+   GitHub Actions production deploy uses this variable (see
+   `.github/workflows/deploy.yml`).
+
+2. **Preview (optional pre-merge smoke test on kody PRs):** parse the PR body
+   for the preview marker:
+
+   ```bash
+   gh pr view --json body -q .body | rg -o 'https://[^ )]+' | head -1
+   # or look for the line after <!-- kody-preview-url -->
+   ```
+
+   Preview deploy comments are posted by `.github/workflows/preview.yml`.
+
+3. **Kody-hosted hint:** saved package invocation URLs (e.g. from
+   `search({ entity: "discord-gateway:package" })`) expose the canonical Kody
+   host (`https://heykody.dev`). Use only when the repo has no `APP_BASE_URL`
+   variable and you need a production fallback for the kody repo itself.
+
+4. **Deploy run output:** after watching `🚀 Deploy (production)`, read the
+   deploy job log or environment URL if steps 1–3 did not yield a URL.
+
+Health check: `curl -sf "${deployUrl}/health"` → `{"ok":true,...}`.
 
 ## Prerequisites
 
 Before starting, confirm:
 
 1. **Active PR** for the current branch (`gh pr view`).
-2. **`gh` authenticated** with permission to push, mark ready, and (merge mode)
-   merge.
-3. **Kody MCP connected** with:
-   - Saved package `@kentcdodds/discord-gateway` (kody id `discord-gateway`)
-   - Secret `discordBotToken`
-   - Package invocation token for `./post-message`
+2. **`gh` authenticated** with permission to push and (merge mode) merge.
+3. **Kody MCP connected** with saved packages `github-pr-tools` and
+   `discord-gateway` (plus invocation tokens for the exports you call).
 
-If Discord setup is missing, stop before the notification step and link the user
-to Kody secret/token setup — never ask for tokens in chat.
+If Kody setup is missing, stop and link setup pages — never ask for tokens in
+chat.
 
 ## Related skills (read when activated)
 
@@ -61,8 +118,24 @@ to Kody secret/token setup — never ask for tokens in chat.
 
 ```bash
 gh pr view --json number,url,title,isDraft,headRefName,baseRefName,reviewDecision
-gh pr ready
 ```
+
+Mark ready via **Kody** (preferred over raw `gh pr ready`):
+
+```javascript
+import { packages } from 'kody:runtime'
+
+export default async function main({ owner, repo, number }) {
+	return packages.invokeChecked({
+		kodyId: 'github-pr-tools',
+		exportName: './set-pr-review-status',
+		params: { owner, repo, number, ready: true },
+	})
+}
+```
+
+Pass `owner`, `repo`, and `number` from `gh pr view` / git remote. Fall back to
+`gh pr ready` only if Kody is unavailable.
 
 Marking ready matters in this repo: **Validate** and **Preview** workflows skip
 draft PRs. CI will not run until the PR is ready for review.
@@ -167,8 +240,9 @@ Only when the user explicitly wants merge + deploy verification.
    gh run watch <run-id> --exit-status
    ```
 
-4. **Manual smoke test** — follow **control-ui** (or equivalent):
-   - `curl -sf "${production-url}/health"` → `{"ok":true,...}`
+4. **Manual smoke test** — follow **control-ui** (or equivalent), using the
+   **deploy URL resolved above**:
+   - `curl -sf "${deployUrl}/health"` → `{"ok":true,...}`
    - One critical user flow relevant to the PR (sign-in, changed route, MCP
      health, etc.)
    - Record what was tested and the outcome.
@@ -178,16 +252,38 @@ Only when the user explicitly wants merge + deploy verification.
 
 ## Discord notification (Kody)
 
-1. Discover the package API (first run or when unsure):
-   ```
-   search({ entity: "discord-gateway:package" })
-   ```
-2. Send via `execute`:
+### Default: message Kent
+
+Use `./send-me-a-message` — no channel id required:
 
 ```javascript
 import { packages } from 'kody:runtime'
 
-export default async function main({ channelId, content }) {
+export default async function main({ content }) {
+	return packages.invokeChecked({
+		kodyId: 'discord-gateway',
+		exportName: './send-me-a-message',
+		params: { content },
+	})
+}
+```
+
+Discover the export contract when unsure:
+`search({ entity: "discord-gateway:package" })`.
+
+### Override: specific channel
+
+Only when the user names a workflow channel or `search` surfaces a better
+`*DiscordChannelId` value for this notification type:
+
+```javascript
+import { packages, codemode } from 'kody:runtime'
+
+export default async function main({ valueName, content }) {
+	const channelId = await codemode.value_get({
+		name: valueName,
+		scope: 'user',
+	})
 	return packages.invokeChecked({
 		kodyId: 'discord-gateway',
 		exportName: './post-message',
@@ -196,8 +292,7 @@ export default async function main({ channelId, content }) {
 }
 ```
 
-Pass `channelId` from skill metadata or user input. Keep messages short; use
-markdown links for PR and deploy URLs.
+Keep messages short; use markdown links for PR and deploy URLs.
 
 ## Guardrails
 
@@ -205,6 +300,8 @@ markdown links for PR and deploy URLs.
 - Do not merge with failing required checks.
 - Do not bypass git hooks or force-push to main.
 - Do not send Discord until the success criteria for the chosen mode are met.
+- Do not ask the user for a Discord channel id when `./send-me-a-message` or
+  Kody value search can resolve it.
 - If CI failures are clearly unrelated and fixed on `main`, merge latest main
   instead of unrelated fixes in the PR.
 - If checks are flaky, retry once and note flake evidence before looping again.
@@ -214,6 +311,7 @@ markdown links for PR and deploy URLs.
 Report back with:
 
 - PR URL and final CI status
+- Resolved deploy URL and Discord path used
 - Fixes applied during the loop (if any)
 - Bot feedback addressed vs dismissed (brief)
 - Discord delivery confirmation


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a repo-local Cursor agent skill that orchestrates the PR shipping workflow.

**Updates:** Discord channel and production URL are now resolved at runtime from Kody and repo metadata — no hardcoded config.

- **Mark ready:** Kody `github-pr-tools/set-pr-review-status`
- **Discord (default):** Kody `discord-gateway/send-me-a-message` (reads `kodyDiscordGeneralChannelId` internally)
- **Production URL:** `gh variable get APP_BASE_URL`, with preview URL from PR comments as fallback
- Loop composes `loop-on-ci`, `fix-ci`, `get-pr-comments`
- Optional **merge-and-verify** mode

## Usage

Invoke with `/ship-pr` or "ship this PR" / "merge and verify".
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec9dc2b0-07c3-40b1-82ab-418c8fa03231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec9dc2b0-07c3-40b1-82ab-418c8fa03231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for an end-to-end PR workflow (“PR babysitting”), including marking a PR ready, running CI checks, and automatically iterating until CI is green or remaining feedback is no longer valid.
  * Clarified two completion paths: a standard update flow and a merge-and-deploy flow with final status reporting.
  * Included an example for sending a completion message with the final PR outcome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->