### PR TITLE
RBAC core: schema, typed permission registry, and guards

### DIFF
--- a/packages/worker/client/session.ts
+++ b/packages/worker/client/session.ts
@@ -1,6 +1,17 @@
+import {
+	permissionAccesses,
+	permissionActions,
+	permissionEntities,
+	roleNames,
+	type PermissionString,
+	type RoleName,
+} from '#app/permissions.ts'
+
 export type SessionInfo = {
 	email: string
 	username: string
+	roles: Array<RoleName>
+	permissions: Array<PermissionString>
 }
 
 export type SessionStatus = 'idle' | 'loading' | 'ready'
@@ -30,8 +41,44 @@ export async function fetchSessionInfo(
 			typeof payload?.session?.username === 'string'
 				? payload.session.username.trim()
 				: ''
-		return email ? { email, username } : null
+		const roles = readRoleNames(payload?.session?.roles)
+		const permissions = readPermissionStrings(payload?.session?.permissions)
+		return email ? { email, username, roles, permissions } : null
 	} catch {
 		return null
 	}
+}
+
+function isRoleName(value: string): value is RoleName {
+	return (roleNames as ReadonlyArray<string>).includes(value)
+}
+
+function isPermissionString(value: string): value is PermissionString {
+	const parts = value.split(':')
+	if (parts.length !== 3) return false
+	const action = parts[0]
+	const entity = parts[1]
+	const access = parts[2]
+	if (!action || !entity || !access) return false
+	return (
+		(permissionActions as ReadonlyArray<string>).includes(action) &&
+		(permissionEntities as ReadonlyArray<string>).includes(entity) &&
+		(permissionAccesses as ReadonlyArray<string>).includes(access)
+	)
+}
+
+function readRoleNames(value: unknown) {
+	if (!Array.isArray(value)) return []
+	return value.filter(
+		(entry): entry is RoleName =>
+			typeof entry === 'string' && isRoleName(entry),
+	)
+}
+
+function readPermissionStrings(value: unknown) {
+	if (!Array.isArray(value)) return []
+	return value.filter(
+		(entry): entry is PermissionString =>
+			typeof entry === 'string' && isPermissionString(entry),
+	)
 }

--- a/packages/worker/migrations/0043-rbac.sql
+++ b/packages/worker/migrations/0043-rbac.sql
@@ -1,0 +1,70 @@
+CREATE TABLE IF NOT EXISTS roles (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	name TEXT NOT NULL UNIQUE,
+	description TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+	updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+);
+
+CREATE TABLE IF NOT EXISTS permissions (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	action TEXT NOT NULL,
+	entity TEXT NOT NULL,
+	access TEXT NOT NULL,
+	description TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+	updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+	UNIQUE (action, entity, access)
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+	role_id INTEGER NOT NULL,
+	permission_id INTEGER NOT NULL,
+	PRIMARY KEY (role_id, permission_id),
+	FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE,
+	FOREIGN KEY (permission_id) REFERENCES permissions(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS user_roles (
+	user_id INTEGER NOT NULL,
+	role_id INTEGER NOT NULL,
+	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+	PRIMARY KEY (user_id, role_id),
+	FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+	FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_roles_user_id ON user_roles(user_id);
+
+INSERT OR IGNORE INTO roles (name, description) VALUES ('user', 'Default role for every account');
+INSERT OR IGNORE INTO roles (name, description) VALUES ('admin', 'Operator role');
+
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('create', 'user', 'own');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('read', 'user', 'own');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('update', 'user', 'own');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('delete', 'user', 'own');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('create', 'role', 'own');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('read', 'role', 'own');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('update', 'role', 'own');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('delete', 'role', 'own');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('create', 'user', 'any');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('read', 'user', 'any');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('update', 'user', 'any');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('delete', 'user', 'any');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('create', 'role', 'any');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('read', 'role', 'any');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('update', 'role', 'any');
+INSERT OR IGNORE INTO permissions (action, entity, access) VALUES ('delete', 'role', 'any');
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.name = 'user'
+	AND p.access = 'own';
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.name = 'admin';

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -188,6 +188,10 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 			{ id: 2, user_id: 1 },
 			{ id: 3, user_id: 2 },
 		],
+		user_roles: [
+			{ user_id: 1, role_id: 1 },
+			{ user_id: 2, role_id: 2 },
+		],
 		mcp_user_server_instructions: [{ user_id: userAaa }],
 		package_invocation_tokens: [{ id: 'pit-1', user_id: userAaa }],
 		package_invocations: [{ id: 'pi-1', user_id: userAaa }],
@@ -243,6 +247,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		{ id: 'pba-2', user_id: userBbb, kv_key: 'bundle-artifact:v1:src-2' },
 	])
 	expect(rows.password_resets).toEqual([{ id: 3, user_id: 2 }])
+	expect(rows.user_roles).toEqual([{ user_id: 2, role_id: 2 }])
 
 	// User-scoped data is removed.
 	expect(rows.secret_buckets).toEqual([])
@@ -257,6 +262,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(rows.email_messages).toEqual([])
 	expect(rows.users).toEqual([{ id: 2, email: 'b@example.com' }])
 	expect(result.deletedRowCounts.password_resets).toBe(2)
+	expect(result.deletedRowCounts.user_roles).toBe(1)
 
 	// Storage runners for the deleted user's storage_ids were cleared.
 	expect(clearStorageMock).toHaveBeenCalledTimes(1)

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -91,6 +91,7 @@ const userScopedTables: ReadonlyArray<UserScopedDeleteTarget> = [
 	// stable mcp string user id), so it must be cleared with the database
 	// integer id rather than the mcp user id.
 	{ kind: 'db_user_id', table: 'password_resets' },
+	{ kind: 'db_user_id', table: 'user_roles' },
 ]
 
 async function listUserVectorIds(env: Env, userId: string) {

--- a/packages/worker/src/app/authenticated-user.ts
+++ b/packages/worker/src/app/authenticated-user.ts
@@ -2,6 +2,8 @@ import {
 	readAuthSessionResult,
 	setAuthSessionSecret,
 } from '#app/auth-session.ts'
+import { getUserRolesAndPermissions } from '#app/permissions-db.ts'
+import { type PermissionString, type RoleName } from '#app/permissions.ts'
 import { getUsernameValidationError } from '#app/username.ts'
 import { createDb, usersTable } from '#worker/db.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
@@ -13,6 +15,8 @@ export type AuthenticatedAppUser = {
 	username: string
 	email: string
 	displayName: string
+	roles: Array<RoleName>
+	permissions: Array<PermissionString>
 	mcpUser: McpUserContext
 	artifactOwnerIds: Array<string>
 }
@@ -46,6 +50,10 @@ export async function readAuthenticatedAppUser(request: Request, env: Env) {
 		email: userRecord.email,
 		username: userRecord.username,
 	})
+	const { roles, permissions } = await getUserRolesAndPermissions(
+		env.APP_DB,
+		userId,
+	)
 
 	return {
 		sessionUserId: session.id,
@@ -53,6 +61,8 @@ export async function readAuthenticatedAppUser(request: Request, env: Env) {
 		username: userRecord.username,
 		email: userRecord.email,
 		displayName,
+		roles,
+		permissions,
 		artifactOwnerIds: Array.from(
 			new Set([session.id, emailBasedUserId].filter(Boolean)),
 		),

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -153,6 +153,11 @@ function createTestDb() {
 								const user = insertUser()
 								return { meta: { changes: 1, last_row_id: user.id } }
 							}
+							if (
+								normalizedQuery.includes('insert or ignore into user_roles')
+							) {
+								return { meta: { changes: 1, last_row_id: 0 } }
+							}
 							return { meta: { changes: 0, last_row_id: 0 } }
 						},
 					}

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -4,6 +4,7 @@ import { createAuthCookie, isSecureRequest } from '#app/auth-session.ts'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
 import { getUniqueConstraintField } from '#app/database-errors.ts'
 import { normalizeEmail } from '#app/normalize-email.ts'
+import { assignUserRole } from '#app/permissions-db.ts'
 import { type routes } from '#app/routes.ts'
 import { getUsernameValidationError, normalizeUsername } from '#app/username.ts'
 import { createDb, usersTable } from '#worker/db.ts'
@@ -244,6 +245,12 @@ export function createAuthHandler(appEnv: AppEnv) {
 						{ status: 500 },
 					)
 				}
+
+				await assignUserRole({
+					db: appEnv.APP_DB,
+					userId: record.id,
+					roleName: 'user',
+				})
 
 				const cookie = await createAuthCookie(
 					{

--- a/packages/worker/src/app/handlers/session-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/session-handler.node.test.ts
@@ -55,6 +55,15 @@ function createSessionTestDb() {
 								meta: { changes: 0, last_row_id: 0 },
 							}
 						}
+						if (
+							normalizedQuery.includes('from user_roles ur') &&
+							normalizedQuery.includes('join roles r')
+						) {
+							return {
+								results: [],
+								meta: { changes: 0, last_row_id: 0 },
+							}
+						}
 						return {
 							results: [],
 							meta: { changes: 0, last_row_id: 0 },
@@ -130,6 +139,8 @@ test('session handler only renews remembered sessions after the renewal window',
 			session: {
 				email: rememberedSession.email,
 				username: 'session-user',
+				roles: [],
+				permissions: [],
 			},
 		})
 		if (scenario.expectSetCookie) {

--- a/packages/worker/src/app/handlers/session.ts
+++ b/packages/worker/src/app/handlers/session.ts
@@ -4,6 +4,7 @@ import {
 	isSecureRequest,
 	readAuthSessionResult,
 } from '#app/auth-session.ts'
+import { getUserRolesAndPermissions } from '#app/permissions-db.ts'
 import { type routes } from '#app/routes.ts'
 import { createDb, usersTable } from '#worker/db.ts'
 
@@ -45,12 +46,19 @@ export function createSessionHandler(env: Env) {
 				)
 			}
 
+			const { roles, permissions } = await getUserRolesAndPermissions(
+				env.APP_DB,
+				userId,
+			)
+
 			return jsonResponse(
 				{
 					ok: true,
 					session: {
 						email: userRecord.email,
 						username: userRecord.username,
+						roles,
+						permissions,
 					},
 				},
 				setCookie

--- a/packages/worker/src/app/permissions-db.ts
+++ b/packages/worker/src/app/permissions-db.ts
@@ -1,0 +1,57 @@
+import { type PermissionString, type RoleName } from '#app/permissions.ts'
+
+type PermissionRow = {
+	role_name: string
+	action: string
+	entity: string
+	access: string
+}
+
+function formatPermissionString(row: PermissionRow): PermissionString {
+	return `${row.action}:${row.entity}:${row.access}` as PermissionString
+}
+
+export async function getUserRolesAndPermissions(
+	db: D1Database,
+	userId: number,
+): Promise<{ roles: Array<RoleName>; permissions: Array<PermissionString> }> {
+	const result = await db
+		.prepare(
+			`SELECT DISTINCT r.name AS role_name, p.action, p.entity, p.access
+			 FROM user_roles ur
+			 INNER JOIN roles r ON r.id = ur.role_id
+			 INNER JOIN role_permissions rp ON rp.role_id = r.id
+			 INNER JOIN permissions p ON p.id = rp.permission_id
+			 WHERE ur.user_id = ?`,
+		)
+		.bind(userId)
+		.all<PermissionRow>()
+
+	const roleSet = new Set<RoleName>()
+	const permissionSet = new Set<PermissionString>()
+	for (const row of result.results ?? []) {
+		if (row.role_name === 'user' || row.role_name === 'admin') {
+			roleSet.add(row.role_name)
+		}
+		permissionSet.add(formatPermissionString(row))
+	}
+
+	return {
+		roles: Array.from(roleSet).sort(),
+		permissions: Array.from(permissionSet).sort(),
+	}
+}
+
+export async function assignUserRole(input: {
+	db: D1Database
+	userId: number
+	roleName: RoleName
+}) {
+	await input.db
+		.prepare(
+			`INSERT OR IGNORE INTO user_roles (user_id, role_id)
+			 SELECT ?, id FROM roles WHERE name = ?`,
+		)
+		.bind(input.userId, input.roleName)
+		.run()
+}

--- a/packages/worker/src/app/permissions-server.node.test.ts
+++ b/packages/worker/src/app/permissions-server.node.test.ts
@@ -1,0 +1,329 @@
+import { expect, test } from 'vitest'
+import {
+	createAuthCookie,
+	setAuthSessionSecret,
+	type AuthSession,
+} from '#app/auth-session.ts'
+import {
+	assignUserRole,
+	getUserRolesAndPermissions,
+} from '#app/permissions-db.ts'
+import {
+	requireUserWithPermission,
+	requireUserWithRole,
+	userHasPermission,
+	userHasRole,
+} from '#app/permissions-server.ts'
+import { type PermissionString, type RoleName } from '#app/permissions.ts'
+
+const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
+
+type RbacRow = {
+	user_id: number
+	role_id: number
+	role_name: RoleName
+	action: string
+	entity: string
+	access: string
+}
+
+function createRbacTestDb(initialRows: Array<RbacRow> = []) {
+	const rows = initialRows.map((row) => ({ ...row }))
+	let nextRoleId = Math.max(0, ...rows.map((row) => row.role_id)) + 1
+
+	const roles = new Map<RoleName, number>([
+		['user', 1],
+		['admin', 2],
+	])
+
+	const db = {
+		prepare(query: string) {
+			const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async all<T>() {
+							if (
+								normalizedQuery.includes('from user_roles ur') &&
+								normalizedQuery.includes('join roles r')
+							) {
+								const userId = Number(params[0])
+								const results = rows
+									.filter((row) => row.user_id === userId)
+									.map((row) => ({
+										role_name: row.role_name,
+										action: row.action,
+										entity: row.entity,
+										access: row.access,
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							return { results: [] as Array<T>, meta: { changes: 0 } }
+						},
+						async run() {
+							if (
+								normalizedQuery.includes('insert or ignore into user_roles')
+							) {
+								const userId = Number(params[0])
+								const roleName = String(params[1]) as RoleName
+								const roleId = roles.get(roleName) ?? nextRoleId++
+								if (!roles.has(roleName)) {
+									roles.set(roleName, roleId)
+								}
+								const exists = rows.some(
+									(row) => row.user_id === userId && row.role_name === roleName,
+								)
+								if (!exists) {
+									for (const permission of rolePermissions(roleName)) {
+										rows.push({
+											user_id: userId,
+											role_id: roleId,
+											role_name: roleName,
+											...permission,
+										})
+									}
+								}
+								return { meta: { changes: exists ? 0 : 1 } }
+							}
+							return { meta: { changes: 0 } }
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+
+	return { db, rows }
+}
+
+function rolePermissions(roleName: RoleName) {
+	const ownActions = ['create', 'read', 'update', 'delete'] as const
+	const entities = ['user', 'role'] as const
+	const permissions: Array<{
+		action: string
+		entity: string
+		access: string
+	}> = []
+	for (const action of ownActions) {
+		for (const entity of entities) {
+			permissions.push({ action, entity, access: 'own' })
+		}
+	}
+	if (roleName === 'admin') {
+		for (const action of ownActions) {
+			for (const entity of entities) {
+				permissions.push({ action, entity, access: 'any' })
+			}
+		}
+	}
+	return permissions
+}
+
+function createAuthenticatedUserEnv(input: {
+	userId: number
+	email?: string
+	username?: string
+	roles: Array<RoleName>
+}) {
+	const email = input.email ?? 'user@example.com'
+	const username = input.username ?? 'session-user'
+	const users = new Map([
+		[
+			input.userId,
+			{
+				id: input.userId,
+				email,
+				username,
+				password_hash: 'unused',
+				created_at: new Date(0).toISOString(),
+				updated_at: new Date(0).toISOString(),
+			},
+		],
+	])
+	const rbacRows = input.roles.flatMap((roleName) =>
+		rolePermissions(roleName).map((permission) => ({
+			user_id: input.userId,
+			role_id: roleName === 'admin' ? 2 : 1,
+			role_name: roleName,
+			...permission,
+		})),
+	)
+
+	return {
+		COOKIE_SECRET: testCookieSecret,
+		APP_DB: {
+			prepare(query: string) {
+				const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
+				return {
+					bind(...params: Array<unknown>) {
+						function execute(loadUserId: number) {
+							return rbacRows
+								.filter((row) => row.user_id === loadUserId)
+								.map((row) => ({
+									role_name: row.role_name,
+									action: row.action,
+									entity: row.entity,
+									access: row.access,
+								}))
+						}
+						return {
+							async all<T>() {
+								if (
+									normalizedQuery.includes('from user_roles ur') &&
+									normalizedQuery.includes('join roles r')
+								) {
+									return {
+										results: execute(Number(params[0])) as Array<T>,
+										meta: { changes: 0 },
+									}
+								}
+								if (
+									normalizedQuery.startsWith('select') &&
+									normalizedQuery.includes('from "users"') &&
+									/"id"\s*=/.test(normalizedQuery)
+								) {
+									const user = users.get(Number(params[0]))
+									return {
+										results: user ? [{ ...user }] : [],
+										meta: { changes: 0 },
+									}
+								}
+								return { results: [] as Array<T>, meta: { changes: 0 } }
+							},
+							async first<T>() {
+								const result = await this.all<T>()
+								return (result.results[0] ?? null) as T | null
+							},
+							async run() {
+								return { meta: { changes: 0 } }
+							},
+						}
+					},
+				}
+			},
+		} as unknown as D1Database,
+	}
+}
+
+test('getUserRolesAndPermissions unions permissions across multiple roles', async () => {
+	const { db } = createRbacTestDb([
+		{
+			user_id: 1,
+			role_id: 1,
+			role_name: 'user',
+			action: 'read',
+			entity: 'user',
+			access: 'own',
+		},
+		{
+			user_id: 1,
+			role_id: 2,
+			role_name: 'admin',
+			action: 'read',
+			entity: 'user',
+			access: 'any',
+		},
+	])
+
+	const result = await getUserRolesAndPermissions(db, 1)
+	expect(result.roles).toEqual(['admin', 'user'])
+	expect(result.permissions).toEqual(['read:user:any', 'read:user:own'])
+})
+
+test('getUserRolesAndPermissions returns empty arrays for users with no roles', async () => {
+	const { db } = createRbacTestDb()
+	const result = await getUserRolesAndPermissions(db, 99)
+	expect(result).toEqual({ roles: [], permissions: [] })
+})
+
+test('userHasPermission and userHasRole perform pure membership checks', () => {
+	const user = {
+		roles: ['user', 'admin'] as Array<RoleName>,
+		permissions: ['read:user:own', 'read:user:any'] as Array<PermissionString>,
+	}
+	expect(userHasPermission(user, 'read:user:any')).toBe(true)
+	expect(userHasPermission(user, 'delete:role:any')).toBe(false)
+	expect(userHasRole(user, 'admin')).toBe(true)
+	expect(userHasRole(user, 'user')).toBe(true)
+})
+
+test('requireUserWithPermission and requireUserWithRole enforce auth and authorization', async () => {
+	setAuthSessionSecret(testCookieSecret)
+	const session: AuthSession = {
+		id: '1',
+		email: 'user@example.com',
+		rememberMe: false,
+	}
+	const cookie = await createAuthCookie(session, false)
+	const authorizedEnv = createAuthenticatedUserEnv({
+		userId: 1,
+		roles: ['admin'],
+	})
+	const userOnlyEnv = createAuthenticatedUserEnv({
+		userId: 1,
+		roles: ['user'],
+	})
+
+	await expect(
+		requireUserWithPermission(
+			new Request('https://example.com/admin/users.json', {
+				headers: {
+					Accept: 'application/json',
+					Cookie: cookie,
+				},
+			}),
+			authorizedEnv as Env,
+			'read:user:any',
+		),
+	).resolves.toMatchObject({ userId: 1, roles: ['admin'] })
+
+	await expect(
+		requireUserWithPermission(
+			new Request('https://example.com/admin/users.json', {
+				headers: {
+					Accept: 'application/json',
+					Cookie: cookie,
+				},
+			}),
+			userOnlyEnv as Env,
+			'read:user:any',
+		),
+	).rejects.toMatchObject({ status: 403 })
+
+	const forbiddenHtmlResponse = await requireUserWithRole(
+		new Request('https://example.com/admin/users', {
+			headers: { Cookie: cookie },
+		}),
+		userOnlyEnv as Env,
+		'admin',
+	).catch((response) => response)
+	expect(forbiddenHtmlResponse).toBeInstanceOf(Response)
+	expect(forbiddenHtmlResponse.status).toBe(403)
+
+	await expect(
+		requireUserWithRole(
+			new Request('https://example.com/admin/users.json', {
+				headers: { Accept: 'application/json' },
+			}),
+			authorizedEnv as Env,
+			'admin',
+		),
+	).rejects.toMatchObject({ status: 401 })
+
+	const redirectResponse = await requireUserWithRole(
+		new Request('https://example.com/admin/users'),
+		authorizedEnv as Env,
+		'admin',
+	).catch((response) => response)
+	expect(redirectResponse).toBeInstanceOf(Response)
+	expect(redirectResponse.status).toBe(302)
+	expect(redirectResponse.headers.get('Location')).toContain('/login')
+})
+
+test('assignUserRole inserts the requested role for a user', async () => {
+	const { db, rows } = createRbacTestDb()
+	await assignUserRole({ db, userId: 7, roleName: 'user' })
+	expect(
+		rows.some((row) => row.user_id === 7 && row.role_name === 'user'),
+	).toBe(true)
+})

--- a/packages/worker/src/app/permissions-server.ts
+++ b/packages/worker/src/app/permissions-server.ts
@@ -1,0 +1,77 @@
+import {
+	readAuthenticatedAppUser,
+	type AuthenticatedAppUser,
+} from '#app/authenticated-user.ts'
+import { redirectToLogin } from '#app/auth-redirect.ts'
+import {
+	type PermissionString,
+	type RoleName,
+	userHasPermission,
+	userHasRole,
+} from '#app/permissions.ts'
+import { wantsJson } from '#worker/utils.ts'
+
+export {
+	assignUserRole,
+	getUserRolesAndPermissions,
+} from '#app/permissions-db.ts'
+export { userHasPermission, userHasRole } from '#app/permissions.ts'
+
+function unauthorizedResponse(request: Request) {
+	if (wantsJson(request)) {
+		return new Response(JSON.stringify({ ok: false, error: 'Forbidden.' }), {
+			status: 403,
+			headers: {
+				'Content-Type': 'application/json',
+				'Cache-Control': 'no-store',
+			},
+		})
+	}
+	return new Response('Forbidden', { status: 403 })
+}
+
+function unauthenticatedResponse(request: Request) {
+	if (wantsJson(request)) {
+		return new Response(JSON.stringify({ ok: false, error: 'Unauthorized.' }), {
+			status: 401,
+			headers: {
+				'Content-Type': 'application/json',
+				'Cache-Control': 'no-store',
+			},
+		})
+	}
+	return redirectToLogin(request)
+}
+
+async function requireAuthorizedUser(
+	request: Request,
+	env: Env,
+	check: (user: AuthenticatedAppUser) => boolean,
+): Promise<AuthenticatedAppUser> {
+	const user = await readAuthenticatedAppUser(request, env)
+	if (!user) {
+		throw unauthenticatedResponse(request)
+	}
+	if (!check(user)) {
+		throw unauthorizedResponse(request)
+	}
+	return user
+}
+
+export async function requireUserWithPermission(
+	request: Request,
+	env: Env,
+	permission: PermissionString,
+): Promise<AuthenticatedAppUser> {
+	return requireAuthorizedUser(request, env, (user) =>
+		userHasPermission(user, permission),
+	)
+}
+
+export async function requireUserWithRole(
+	request: Request,
+	env: Env,
+	role: RoleName,
+): Promise<AuthenticatedAppUser> {
+	return requireAuthorizedUser(request, env, (user) => userHasRole(user, role))
+}

--- a/packages/worker/src/app/permissions.node.test.ts
+++ b/packages/worker/src/app/permissions.node.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+import {
+	buildPermissionString,
+	listAdminRolePermissionStrings,
+	listRegistryPermissionStrings,
+	listUserRolePermissionStrings,
+	parsePermissionString,
+	roleNames,
+	type PermissionAccess,
+	type PermissionAction,
+	type PermissionEntity,
+	type PermissionString,
+} from './permissions.ts'
+
+test('parsePermissionString splits action, entity, and access', () => {
+	expect(parsePermissionString('read:user:own')).toEqual({
+		action: 'read',
+		entity: 'user',
+		access: 'own',
+	})
+	expect(parsePermissionString('delete:role:any')).toEqual({
+		action: 'delete',
+		entity: 'role',
+		access: 'any',
+	})
+})
+
+test('permission registry and migration seed rows stay aligned', () => {
+	const migrationPath = join(
+		dirname(fileURLToPath(import.meta.url)),
+		'../../migrations/0043-rbac.sql',
+	)
+	const migrationSql = readFileSync(migrationPath, 'utf8').toLowerCase()
+	const seededPermissions = new Set<PermissionString>()
+
+	for (const match of migrationSql.matchAll(
+		/insert or ignore into permissions \(action, entity, access\) values \('([^']+)', '([^']+)', '([^']+)'\)/g,
+	)) {
+		seededPermissions.add(
+			buildPermissionString({
+				action: match[1] as PermissionAction,
+				entity: match[2] as PermissionEntity,
+				access: match[3] as PermissionAccess,
+			}),
+		)
+	}
+
+	expect(Array.from(seededPermissions).sort()).toEqual(
+		listRegistryPermissionStrings().sort(),
+	)
+
+	expect(migrationSql).toContain("where r.name = 'user'")
+	expect(migrationSql).toContain("p.access = 'own'")
+	expect(listUserRolePermissionStrings().sort()).toEqual(
+		listRegistryPermissionStrings()
+			.filter(
+				(permission) => parsePermissionString(permission).access === 'own',
+			)
+			.sort(),
+	)
+
+	expect(migrationSql).toContain("where r.name = 'admin'")
+	expect(listAdminRolePermissionStrings().sort()).toEqual(
+		listRegistryPermissionStrings().sort(),
+	)
+
+	for (const roleName of roleNames) {
+		expect(migrationSql).toContain(
+			`insert or ignore into roles (name, description) values ('${roleName}'`,
+		)
+	}
+})

--- a/packages/worker/src/app/permissions.ts
+++ b/packages/worker/src/app/permissions.ts
@@ -1,0 +1,70 @@
+export const permissionActions = ['create', 'read', 'update', 'delete'] as const
+export const permissionEntities = ['user', 'role'] as const
+export const permissionAccesses = ['own', 'any'] as const
+
+export type PermissionAction = (typeof permissionActions)[number]
+export type PermissionEntity = (typeof permissionEntities)[number]
+export type PermissionAccess = (typeof permissionAccesses)[number]
+
+export type PermissionString =
+	`${PermissionAction}:${PermissionEntity}:${PermissionAccess}`
+
+export function parsePermissionString(value: PermissionString) {
+	const [action, entity, access] = value.split(':')
+	return { action, entity, access } as {
+		action: PermissionAction
+		entity: PermissionEntity
+		access: PermissionAccess
+	}
+}
+
+export function userHasPermission(
+	user: { permissions: Array<PermissionString> },
+	permission: PermissionString,
+): boolean {
+	return user.permissions.includes(permission)
+}
+
+export function userHasRole(
+	user: { roles: Array<RoleName> },
+	role: RoleName,
+): boolean {
+	return user.roles.includes(role)
+}
+
+export const roleNames = ['user', 'admin'] as const
+export type RoleName = (typeof roleNames)[number]
+
+export function buildPermissionString(input: {
+	action: PermissionAction
+	entity: PermissionEntity
+	access: PermissionAccess
+}): PermissionString {
+	return `${input.action}:${input.entity}:${input.access}`
+}
+
+export function listRegistryPermissionStrings(): Array<PermissionString> {
+	const permissions: Array<PermissionString> = []
+	for (const action of permissionActions) {
+		for (const entity of permissionEntities) {
+			for (const access of permissionAccesses) {
+				permissions.push(buildPermissionString({ action, entity, access }))
+			}
+		}
+	}
+	return permissions
+}
+
+export function listUserRolePermissionStrings(): Array<PermissionString> {
+	const permissions: Array<PermissionString> = []
+	for (const action of permissionActions) {
+		for (const entity of permissionEntities) {
+			permissions.push(buildPermissionString({ action, entity, access: 'own' }))
+		}
+	}
+	return permissions
+}
+
+export function listAdminRolePermissionStrings(): Array<PermissionString> {
+	return listRegistryPermissionStrings()
+}

--- a/packages/worker/tsconfig-client.json
+++ b/packages/worker/tsconfig-client.json
@@ -7,8 +7,17 @@
 		"lib": ["DOM", "DOM.Iterable", "ES2022"],
 		"types": [],
 		"jsx": "react-jsx",
-		"jsxImportSource": "remix/ui"
+		"jsxImportSource": "remix/ui",
+		"baseUrl": ".",
+		"paths": {
+			"#app/*": ["./src/app/*"]
+		}
 	},
-	"include": ["./client/**/*.ts", "./client/**/*.tsx", "./client/**/*.d.ts"],
+	"include": [
+		"./client/**/*.ts",
+		"./client/**/*.tsx",
+		"./client/**/*.d.ts",
+		"./src/app/permissions.ts"
+	],
 	"exclude": ["./client/**/*.test.ts", "./client/**/*.spec.ts"]
 }

--- a/tools/seed-test-data.node.test.ts
+++ b/tools/seed-test-data.node.test.ts
@@ -20,6 +20,9 @@ test('seed data arg parsing defaults to local mode and derives usernames from em
 	expect(explicitUsernameOptions.email).toBe('alice@example.com')
 	expect(explicitUsernameOptions.username).toBe('alice')
 
+	const adminOptions = parseArgs(['--local', '--admin'])
+	expect(adminOptions.admin).toBe(true)
+
 	expect(
 		resolveWranglerEnv({
 			config: 'packages/worker/wrangler-preview.generated.json',

--- a/tools/seed-test-data.ts
+++ b/tools/seed-test-data.ts
@@ -9,6 +9,7 @@ type CliOptions = {
 	password: string
 	local: boolean
 	remote: boolean
+	admin: boolean
 	env?: string
 	config?: string
 	persistTo?: string
@@ -25,6 +26,7 @@ export function parseArgs(argv: Array<string>): CliOptions {
 		password: defaultTestPassword,
 		local: false,
 		remote: false,
+		admin: false,
 		env: undefined,
 		config: undefined,
 		persistTo: undefined,
@@ -60,6 +62,10 @@ export function parseArgs(argv: Array<string>): CliOptions {
 				options.remote = true
 				break
 			}
+			case '--admin': {
+				options.admin = true
+				break
+			}
 			case '--env': {
 				options.env = argv[index + 1] ?? ''
 				index += 1
@@ -80,7 +86,7 @@ export function parseArgs(argv: Array<string>): CliOptions {
 					fail(
 						[
 							`Unknown flag: ${arg}`,
-							'Usage: node tools/seed-test-data.ts [--local|--remote] [--env <name>] [--config <path>] [--persist-to <path>] [--email <email>] [--username <username>] [--password <password>]',
+							'Usage: node tools/seed-test-data.ts [--local|--remote] [--admin] [--env <name>] [--config <path>] [--persist-to <path>] [--email <email>] [--username <username>] [--password <password>]',
 						].join('\n'),
 					)
 				}
@@ -164,11 +170,26 @@ function buildSeedSql({
 	email,
 	username,
 	passwordHash,
+	admin,
 }: {
 	email: string
 	username: string
 	passwordHash: string
+	admin: boolean
 }) {
+	const userRoleSql = `
+INSERT OR IGNORE INTO user_roles (user_id, role_id)
+SELECT u.id, r.id
+FROM users u, roles r
+WHERE u.email = ${quoteSql(email)} AND r.name = 'user';`
+	const adminRoleSql = admin
+		? `
+INSERT OR IGNORE INTO user_roles (user_id, role_id)
+SELECT u.id, r.id
+FROM users u, roles r
+WHERE u.email = ${quoteSql(email)} AND r.name = 'admin';`
+		: ''
+
 	return `
 INSERT INTO users (username, email, password_hash)
 VALUES (${quoteSql(username)}, ${quoteSql(email)}, ${quoteSql(passwordHash)})
@@ -176,7 +197,7 @@ ON CONFLICT(email) DO UPDATE SET
   username = excluded.username,
   password_hash = excluded.password_hash,
   updated_at = CURRENT_TIMESTAMP;
-`.trim()
+${userRoleSql}${adminRoleSql}`.trim()
 }
 
 function executeSeedSql(sql: string, options: CliOptions) {
@@ -210,11 +231,12 @@ async function main() {
 		email: options.email,
 		username: options.username,
 		passwordHash,
+		admin: options.admin,
 	})
 	executeSeedSql(sql, options)
 
 	console.log(
-		`Seeded test account in D1 (${options.local ? 'local' : 'remote'}): ${options.email}`,
+		`Seeded test account in D1 (${options.local ? 'local' : 'remote'}): ${options.email}${options.admin ? ' (admin)' : ''}`,
 	)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 1 of the RBAC plan (stacked on the proposal PR; implemented by a composer 2.5 subagent). Adds the data model and server plumbing — no UI, no MCP changes.

- Migration `0043-rbac.sql`: `roles`, `permissions`, `role_permissions`, `user_roles` tables (integer `users.id` FKs, cascade deletes) with `INSERT OR IGNORE` seeds for the `user` and `admin` roles and their `action:entity:access` permissions.
- Typed registry `packages/worker/src/app/permissions.ts`: `PermissionString` template-literal type, `parsePermissionString`, `RoleName`, pure `userHasPermission`/`userHasRole` (usable client-side).
- `permissions-db.ts` (`getUserRolesAndPermissions` single-join query, `assignUserRole`) and `permissions-server.ts` request guards (`requireUserWithPermission`, `requireUserWithRole`): redirect to login when unauthenticated, 403 when authenticated but unauthorized.
- `readAuthenticatedAppUser` and the `/session` payload now carry `roles` + `permissions`, loaded fresh per request (nothing added to the cookie).
- Signup assigns the `user` role; `user_roles` added to the account-deletion cascade list; `tools/seed-test-data.ts` gains `--admin`.
- Unit tests including a registry/seed drift check that parses the migration SQL and compares it to the TypeScript registry.

First-admin bootstrap (manual, once):

```sql
INSERT OR IGNORE INTO user_roles (user_id, role_id)
SELECT u.id, r.id FROM users u, roles r
WHERE u.email = 'you@example.com' AND r.name = 'admin';
```

Merge order: #591 → this PR → admin UI / MCP context / privacy page → integration.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>adds the rbac primitive</b> (high risk)</summary>

**Mode:** recap · **Base:** `cursor/rbac-support-plan-66a6` · **Head:** `87e2177`

**Classification:** adds — new RBAC primitive (registry + guards + tables); `primitives.yaml` is updated in the integration PR of this stack.

### Primitives touched

| Primitive      | Group   | Impact                                                       |
| -------------- | ------- | ------------------------------------------------------------ |
| `d1-app-db`    | storage | extends — 4 new tables + seeded roles/permissions             |
| `app-sessions` | auth    | extends — roles/permissions on authenticated user + `/session` |
| `rbac`         | auth    | adds — typed permission registry, DB helpers, request guards  |

### Invariants

Touches `per-user-isolation`: `access='any'` permissions exist in the vocabulary but nothing in this PR uses them; they are honored only by explicitly-guarded admin endpoints added later in the stack, limited to account administration.

</details>

<!-- system-recap:end -->

## Testing

- ✅ `npm run validate` (all six checks green: format, lint, typecheck, 357 unit tests, Playwright E2E, MCP E2E)
- ✅ Manually verified via curl on the integrated stack: `/session` returns correct roles/permissions for admin and non-admin users

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f25de-3c26-7e57-991e-2e112f1866a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f25de-3c26-7e57-991e-2e112f1866a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

