### PR TITLE
RBAC MCP context: fresh roles on the caller context

### DIFF
--- a/packages/shared/src/chat.node.test.ts
+++ b/packages/shared/src/chat.node.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest'
+import { parseSafe } from 'remix/data-schema'
+import { mcpCallerContextSchema, mcpUserContextSchema } from './chat.ts'
+
+test('mcp user context schema accepts contexts with and without roles and permissions', () => {
+	const withoutRbac = parseSafe(mcpUserContextSchema, {
+		userId: 'user-1',
+		email: 'user@example.com',
+		displayName: 'user',
+	})
+	expect(withoutRbac.success).toBe(true)
+	if (withoutRbac.success) {
+		expect(withoutRbac.value.roles).toBeUndefined()
+		expect(withoutRbac.value.permissions).toBeUndefined()
+	}
+
+	const withRbac = parseSafe(mcpUserContextSchema, {
+		userId: 'user-1',
+		email: 'user@example.com',
+		displayName: 'user',
+		roles: ['user', 'admin'],
+		permissions: ['read:user:any', 'read:role:any'],
+	})
+	expect(withRbac.success).toBe(true)
+	if (withRbac.success) {
+		expect(withRbac.value.roles).toEqual(['user', 'admin'])
+		expect(withRbac.value.permissions).toEqual([
+			'read:user:any',
+			'read:role:any',
+		])
+	}
+
+	const callerContext = parseSafe(mcpCallerContextSchema, {
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-1',
+			email: 'user@example.com',
+			displayName: 'user',
+		},
+	})
+	expect(callerContext.success).toBe(true)
+})

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -36,6 +36,8 @@ export const mcpUserContextSchema = object({
 	email: string(),
 	username: optional(string()),
 	displayName: string(),
+	roles: optional(array(string())),
+	permissions: optional(array(string())),
 })
 
 export const mcpStorageContextSchema = object({
@@ -69,7 +71,20 @@ export const mcpCallerContextSchema = object({
 	repoContext: optional(nullable(mcpRepoContextSchema)),
 })
 
-export type McpUserContext = InferOutput<typeof mcpUserContextSchema>
+type McpUserContextInferred = InferOutput<typeof mcpUserContextSchema>
+
+export type McpUserContext = Omit<
+	McpUserContextInferred,
+	'roles' | 'permissions' | 'username'
+> & {
+	username?: string
+	roles?: Array<string>
+	permissions?: Array<string>
+}
 export type McpStorageContext = InferOutput<typeof mcpStorageContextSchema>
 export type McpRepoContext = InferOutput<typeof mcpRepoContextSchema>
-export type McpCallerContext = InferOutput<typeof mcpCallerContextSchema>
+type McpCallerContextInferred = InferOutput<typeof mcpCallerContextSchema>
+
+export type McpCallerContext = Omit<McpCallerContextInferred, 'user'> & {
+	user?: McpUserContext | null
+}

--- a/packages/worker/src/mcp-auth-user-context.node.test.ts
+++ b/packages/worker/src/mcp-auth-user-context.node.test.ts
@@ -1,0 +1,103 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	getUserRolesAndPermissions: vi.fn(),
+	findOne: vi.fn(),
+}))
+
+vi.mock('#app/permissions-db.ts', () => ({
+	getUserRolesAndPermissions: (...args: Array<unknown>) =>
+		mockModule.getUserRolesAndPermissions(...args),
+}))
+
+vi.mock('#worker/db.ts', () => ({
+	createDb: () => ({
+		findOne: (...args: Array<unknown>) => mockModule.findOne(...args),
+	}),
+	usersTable: {},
+}))
+
+const { buildMcpUserContextFromGrantProps } =
+	await import('./mcp-auth-user-context.ts')
+
+function createMockAppDb() {
+	return {
+		prepare: () => ({
+			bind: () => ({
+				all: async () => ({ results: [], meta: { changes: 0 } }),
+			}),
+		}),
+	} as unknown as D1Database
+}
+
+test('buildMcpUserContextFromGrantProps loads fresh roles and permissions', async () => {
+	mockModule.findOne.mockResolvedValueOnce({
+		id: 42,
+		email: 'admin@example.com',
+		username: 'admin',
+	})
+	mockModule.getUserRolesAndPermissions.mockResolvedValueOnce({
+		roles: ['admin'],
+		permissions: ['read:user:any', 'read:role:any'],
+	})
+
+	const user = await buildMcpUserContextFromGrantProps(
+		{ APP_DB: createMockAppDb() } as Env,
+		{
+			userId: 'stable-admin-id',
+			email: 'admin@example.com',
+			username: 'admin',
+			displayName: 'admin',
+		},
+	)
+
+	expect(user).toEqual({
+		userId: 'stable-admin-id',
+		email: 'admin@example.com',
+		username: 'admin',
+		displayName: 'admin',
+		roles: ['admin'],
+		permissions: ['read:user:any', 'read:role:any'],
+	})
+	expect(mockModule.getUserRolesAndPermissions).toHaveBeenCalledWith(
+		expect.anything(),
+		42,
+	)
+})
+
+test('buildMcpUserContextFromGrantProps omits roles and permissions when the users row is missing', async () => {
+	mockModule.findOne.mockResolvedValueOnce(null)
+
+	const user = await buildMcpUserContextFromGrantProps(
+		{ APP_DB: createMockAppDb() } as Env,
+		{
+			userId: 'orphan-id',
+			email: 'missing@example.com',
+			displayName: 'missing',
+		},
+	)
+
+	expect(user).toEqual({
+		userId: 'orphan-id',
+		email: 'missing@example.com',
+		displayName: 'missing',
+	})
+	expect(mockModule.getUserRolesAndPermissions).not.toHaveBeenCalled()
+})
+
+test('buildMcpUserContextFromGrantProps skips rbac lookup when grant props omit email', async () => {
+	const user = await buildMcpUserContextFromGrantProps(
+		{ APP_DB: createMockAppDb() } as Env,
+		{
+			userId: 'legacy-id',
+		},
+	)
+
+	expect(user).toEqual({
+		userId: 'legacy-id',
+		email: '',
+		displayName: 'user',
+	})
+	expect(mockModule.findOne).not.toHaveBeenCalled()
+	expect(mockModule.getUserRolesAndPermissions).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/mcp-auth-user-context.ts
+++ b/packages/worker/src/mcp-auth-user-context.ts
@@ -1,0 +1,64 @@
+import { getUserRolesAndPermissions } from '#app/permissions-db.ts'
+import { createDb, usersTable } from '#worker/db.ts'
+import { type McpUserContext } from '@kody-internal/shared/chat.ts'
+
+type McpOAuthGrantProps = {
+	userId?: unknown
+	email?: unknown
+	username?: unknown
+	displayName?: unknown
+} | null
+
+function buildDisplayNameFromEmail(email: string) {
+	return email.split('@')[0] || 'user'
+}
+
+export async function buildMcpUserContextFromGrantProps(
+	env: Env,
+	grantProps: McpOAuthGrantProps,
+): Promise<McpUserContext | null> {
+	if (!grantProps || typeof grantProps.userId !== 'string') {
+		return null
+	}
+
+	const email =
+		typeof grantProps.email === 'string' ? grantProps.email.trim() : ''
+	const displayName =
+		typeof grantProps.displayName === 'string'
+			? grantProps.displayName
+			: email
+				? buildDisplayNameFromEmail(email)
+				: 'user'
+
+	const user: McpUserContext = {
+		userId: grantProps.userId,
+		email,
+		displayName,
+		...(typeof grantProps.username === 'string'
+			? { username: grantProps.username }
+			: {}),
+	}
+
+	if (!email) {
+		return user
+	}
+
+	const db = createDb(env.APP_DB)
+	const userRecord = await db.findOne(usersTable, {
+		where: { email },
+	})
+	if (!userRecord) {
+		return user
+	}
+
+	const { roles, permissions } = await getUserRolesAndPermissions(
+		env.APP_DB,
+		userRecord.id,
+	)
+
+	return {
+		...user,
+		roles,
+		permissions,
+	}
+}

--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -3,6 +3,7 @@ import {
 	type TokenSummary,
 } from '@cloudflare/workers-oauth-provider'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
+import { buildMcpUserContextFromGrantProps } from './mcp-auth-user-context.ts'
 import { createMcpCallerContext, type McpServerProps } from './mcp/context.ts'
 import { oauthScopes } from './oauth-handlers.ts'
 import { listAttachedRemoteConnectorRefs } from './remote-connector/settings-service.ts'
@@ -111,17 +112,18 @@ export async function handleMcpRequest({
 	}
 
 	const context = ctx as OAuthExecutionContext
-	const user = tokenSummary.grant.props ?? null
+	const grantProps = tokenSummary.grant.props ?? null
+	const mcpUser = await buildMcpUserContextFromGrantProps(env, grantProps)
 	const remoteConnectors =
-		user && typeof user.userId === 'string'
+		mcpUser && typeof mcpUser.userId === 'string'
 			? await listAttachedRemoteConnectorRefs({
 					env,
-					userId: user.userId,
+					userId: mcpUser.userId,
 				})
 			: null
 	const props: OAuthContextProps = createMcpCallerContext({
 		baseUrl: origin,
-		user,
+		user: mcpUser,
 		remoteConnectors,
 	})
 	context.props = props

--- a/packages/worker/src/mcp/capabilities/meta/require-permission.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/require-permission.node.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { requireMcpUserWithPermission } from './require-permission.ts'
+
+test('requireMcpUserWithPermission requires an authenticated user', () => {
+	expect(() =>
+		requireMcpUserWithPermission(
+			createMcpCallerContext({ baseUrl: 'https://example.com' }),
+			'read:user:any',
+		),
+	).toThrow('Authenticated MCP user is required for this capability.')
+})
+
+test('requireMcpUserWithPermission throws when the user lacks the permission', () => {
+	expect(() =>
+		requireMcpUserWithPermission(
+			createMcpCallerContext({
+				baseUrl: 'https://example.com',
+				user: {
+					userId: 'user-1',
+					email: 'user@example.com',
+					displayName: 'user',
+					roles: ['user'],
+					permissions: ['read:user:own'],
+				},
+			}),
+			'read:user:any',
+		),
+	).toThrow('MCP user lacks required permission: read:user:any')
+})
+
+test('requireMcpUserWithPermission returns the user when the permission is present', () => {
+	const user = {
+		userId: 'user-1',
+		email: 'admin@example.com',
+		displayName: 'admin',
+		roles: ['admin'],
+		permissions: ['read:user:any', 'read:role:any'],
+	}
+	expect(
+		requireMcpUserWithPermission(
+			createMcpCallerContext({
+				baseUrl: 'https://example.com',
+				user,
+			}),
+			'read:user:any',
+		),
+	).toEqual(user)
+})
+
+test('requireMcpUserWithPermission treats missing permissions as unauthorized', () => {
+	expect(() =>
+		requireMcpUserWithPermission(
+			createMcpCallerContext({
+				baseUrl: 'https://example.com',
+				user: {
+					userId: 'user-1',
+					email: 'user@example.com',
+					displayName: 'user',
+				},
+			}),
+			'read:user:any',
+		),
+	).toThrow('MCP user lacks required permission: read:user:any')
+})

--- a/packages/worker/src/mcp/capabilities/meta/require-permission.ts
+++ b/packages/worker/src/mcp/capabilities/meta/require-permission.ts
@@ -1,0 +1,19 @@
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { type PermissionString, userHasPermission } from '#app/permissions.ts'
+import { requireMcpUser } from './require-user.ts'
+
+export function requireMcpUserWithPermission(
+	context: McpCallerContext,
+	permission: PermissionString,
+) {
+	const user = requireMcpUser(context)
+	if (
+		!userHasPermission(
+			{ permissions: (user.permissions ?? []) as Array<PermissionString> },
+			permission,
+		)
+	) {
+		throw new Error(`MCP user lacks required permission: ${permission}`)
+	}
+	return user
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 3 of the RBAC plan (stacked on the core PR, parallel to the admin UI; implemented by a composer 2.5 subagent).

- `mcpUserContextSchema` (`packages/shared/src/chat.ts`) gains **optional** `roles` / `permissions` arrays, so stored and forwarded contexts without the fields stay valid.
- `mcp-auth.ts` loads roles/permissions **fresh per request** via new `mcp-auth-user-context.ts` (users row looked up by grant email → `getUserRolesAndPermissions`); OAuth grant props are untouched, so revocation takes effect immediately. A missing users row degrades gracefully to no roles.
- New `requireMcpUserWithPermission(context, permission)` helper beside `requireMcpUser`, typed with `PermissionString`. No existing capability is guarded — everything stays own-scoped; this is the single named escape hatch for future admin capabilities.
- Unit tests for context construction (fresh roles, missing user, no email), the guard, and schema compatibility.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends mcp-oauth caller context</b> (medium risk)</summary>

**Mode:** recap · **Base:** `cursor/rbac-core-66a6` · **Head:** `6ce5328`

**Classification:** extends — caller-context shape and construction change; no tool or capability behavior changes.

### Primitives touched

| Primitive    | Group | Impact                                                    |
| ------------ | ----- | ---------------------------------------------------------- |
| `mcp-oauth`  | auth  | extends — roles/permissions resolved into `McpCallerContext` |
| `rbac`       | auth  | composes — reuses `getUserRolesAndPermissions`               |

### Invariants

Respects `compact-mcp-surface`: no new tools; the guard helper exists for future capabilities behind `search`/`execute`.

</details>

<!-- system-recap:end -->

## Testing

- ✅ `npm run validate` (all six checks green, including MCP E2E which exercises the real OAuth + MCP handshake through the changed context construction)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f25de-3c26-7e57-991e-2e112f1866a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f25de-3c26-7e57-991e-2e112f1866a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

