### PR TITLE
Fix ship-pr PR status invocation

### DIFF
--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -10,7 +10,7 @@ description: >
 ## Loop
 
 1. Mark ready — `kody:@kentcdodds/github-pr-tools/set-pr-review-status` with
-   `{ owner, repo, number, ready: true }`
+   `{ prUrl, status: 'ready' }`, or `{ owner, repo, prNumber, status: 'ready' }`
 2. Wait for CI — `gh pr checks` (compose `loop-on-ci`, `fix-ci`)
 3. Fix failures; address valid AI-reviewer feedback (ignore insignificant nits /
    already-fixed / wrong)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Updated `.agents/skills/ship-pr/SKILL.md` to call `@kentcdodds/github-pr-tools/set-pr-review-status` with the actual `status` + PR locator contract.
- Separately published the saved package fix through Kody (`@kentcdodds/github-pr-tools` commit `4782100a`) for `secret_list` handling, alias support, and combined validation errors.

## Validation

- `npm run validate` ✅
- Package publish checks via Kody: manifest/dependencies/bundle/typecheck/lint ✅
- Package smoke test: `set-pr-review-status({ prUrl: 'https://github.com/kentcdodds/kody/pull/599', status: 'ready' })` returned `changed: false`, `draft: false`, `message: "PR #599 is already ready for review."`
- Alias smoke test: `{ owner: 'kentcdodds', repo: 'kody', number: 599, ready: true }` returned the same successful no-op.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `d146b31` · **Head:** `737fcdd`

**Classification:** composes — updates agent workflow documentation only; no Kody runtime primitive behavior, storage, auth, MCP surface, or package runtime code changes in this repo diff.

### Primitives touched

No mapped system primitives are touched by the repo diff.

### Change flow

```mermaid
flowchart LR
	shipPrSkill["ship-pr skill"]:::touched --> githubPrTools["github-pr-tools package contract"]:::untouched
	classDef touched fill:#1a7f37,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8492a6a2-dc5d-4c1a-bd4c-6679217d5f23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8492a6a2-dc5d-4c1a-bd4c-6679217d5f23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Mark ready” guidance to match the latest review-status command format.
  * Clarified the accepted argument shape for setting a PR to ready, including the updated parameter name and status-based option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->