### PR TITLE
Performance: package app loading, MCP execute isolate reuse, and hot-path caching

### DIFF
--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -27,7 +27,14 @@ export function App(handle: Handle<AppProps>) {
 		handle.props.embeddedSession !== undefined ? 'ready' : 'idle'
 	let sessionRefreshInFlight = false
 	let sessionRefreshQueued = false
+	let lastSessionRefreshAt = 0
 	let currentPathname = readRouterPathname(handle)
+
+	// Navigation-triggered refreshes are throttled: auth rarely changes
+	// mid-session and every SPA navigation was previously a /session round
+	// trip (2 D1 queries). Explicit refreshes (login/logout/profile updates
+	// via setSessionRefreshHandler) always bypass the throttle.
+	const sessionRefreshThrottleMs = 30_000
 
 	function queueSessionRefresh() {
 		sessionRefreshQueued = true
@@ -44,6 +51,7 @@ export function App(handle: Handle<AppProps>) {
 			const nextSession = await fetchSessionInfo(signal)
 			sessionRefreshInFlight = false
 			if (signal.aborted) return
+			lastSessionRefreshAt = Date.now()
 			session = nextSession
 			sessionStatus = 'ready'
 			handle.update()
@@ -56,6 +64,16 @@ export function App(handle: Handle<AppProps>) {
 		}
 	}
 
+	function queueThrottledSessionRefresh() {
+		if (
+			sessionStatus === 'ready' &&
+			Date.now() - lastSessionRefreshAt < sessionRefreshThrottleMs
+		) {
+			return
+		}
+		queueSessionRefresh()
+	}
+
 	// Always revalidate after hydration: the embedded session renders the
 	// first paint without a flash ('ready' status keeps the refresh silent),
 	// but auth may have changed since the document was rendered.
@@ -66,7 +84,7 @@ export function App(handle: Handle<AppProps>) {
 		})
 		listenToRouterNavigation(handle, () => {
 			currentPathname = readRouterPathname(handle)
-			queueSessionRefresh()
+			queueThrottledSessionRefresh()
 			handle.update()
 		})
 	}

--- a/packages/worker/src/app/admin-users-data.ts
+++ b/packages/worker/src/app/admin-users-data.ts
@@ -37,25 +37,26 @@ export async function loadAdminUsersData(
 	)
 	const offset = (page - 1) * pageSize
 
-	const totalResult = await env.APP_DB.prepare(
-		`SELECT COUNT(*) AS total FROM users`,
-	).first<{ total: number }>()
+	const [totalResult, userRows] = await Promise.all([
+		env.APP_DB.prepare(`SELECT COUNT(*) AS total FROM users`).first<{
+			total: number
+		}>(),
+		env.APP_DB.prepare(
+			`SELECT id, username, email, created_at, updated_at
+			 FROM users
+			 ORDER BY id ASC
+			 LIMIT ? OFFSET ?`,
+		)
+			.bind(pageSize, offset)
+			.all<{
+				id: number
+				username: string
+				email: string
+				created_at: string
+				updated_at: string
+			}>(),
+	])
 	const total = totalResult?.total ?? 0
-
-	const userRows = await env.APP_DB.prepare(
-		`SELECT id, username, email, created_at, updated_at
-		 FROM users
-		 ORDER BY id ASC
-		 LIMIT ? OFFSET ?`,
-	)
-		.bind(pageSize, offset)
-		.all<{
-			id: number
-			username: string
-			email: string
-			created_at: string
-			updated_at: string
-		}>()
 
 	const userIds = (userRows.results ?? []).map((row) => row.id)
 	const rolesByUserId = await loadRolesByUserIds(env.APP_DB, userIds)

--- a/packages/worker/src/app/community-data.ts
+++ b/packages/worker/src/app/community-data.ts
@@ -93,7 +93,33 @@ export async function loadCommunityIndexData(
 	}
 }
 
-export async function loadCommunityDetailData(
+// One SSR request loads detail data twice: once in the HTML handler for the
+// loaderData embed and once in the frame renderer during streaming. Memoize
+// per Request so the second call reuses the first load.
+const requestDetailDataStore = new WeakMap<
+	Request,
+	Map<string, Promise<CommunityDetailLoaderData | null>>
+>()
+
+export function loadCommunityDetailData(
+	env: Env,
+	request: Request,
+	listingId: string,
+): Promise<CommunityDetailLoaderData | null> {
+	let byListingId = requestDetailDataStore.get(request)
+	if (!byListingId) {
+		byListingId = new Map()
+		requestDetailDataStore.set(request, byListingId)
+	}
+	let pending = byListingId.get(listingId)
+	if (!pending) {
+		pending = loadCommunityDetailDataUncached(env, request, listingId)
+		byListingId.set(listingId, pending)
+	}
+	return pending
+}
+
+async function loadCommunityDetailDataUncached(
 	env: Env,
 	request: Request,
 	listingId: string,

--- a/packages/worker/src/app/env.ts
+++ b/packages/worker/src/app/env.ts
@@ -1,7 +1,19 @@
 import { parseSafe } from 'remix/data-schema'
 import { EnvSchema, type AppEnv } from '#worker/env-schema.ts'
 
+// Env binding objects are stable per isolate; parse them once per identity
+// instead of running schema validation on every call.
+const parsedEnvCache = new WeakMap<Env, AppEnv>()
+
 export function getEnv(env: Env): AppEnv {
+	const cached = parsedEnvCache.get(env)
+	if (cached) return cached
+	const parsed = parseEnv(env)
+	parsedEnvCache.set(env, parsed)
+	return parsed
+}
+
+function parseEnv(env: Env): AppEnv {
 	const result = parseSafe(EnvSchema, env)
 
 	if (!result.success) {

--- a/packages/worker/src/app/handler.node.test.ts
+++ b/packages/worker/src/app/handler.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest'
+import { getEnv } from './env.ts'
 import { handleRequest } from './handler.ts'
 
 function createEnv(overrides: Record<string, unknown> = {}) {
@@ -30,4 +31,26 @@ test('account secrets api ignores legacy remote connector env secrets', async ()
 		ok: false,
 		error: 'Unauthorized.',
 	})
+})
+
+test('getEnv memoizes the parsed env per env object identity', () => {
+	const env = createEnv()
+	expect(getEnv(env)).toBe(getEnv(env))
+	expect(getEnv(createEnv())).not.toBe(getEnv(env))
+})
+
+test('handleRequest serves multiple requests from the same env object', async () => {
+	const env = createEnv()
+	const first = await handleRequest(
+		new Request('https://example.com/health'),
+		env,
+	)
+	const second = await handleRequest(
+		new Request('https://example.com/health'),
+		env,
+	)
+
+	expect(first.status).toBe(200)
+	expect(second.status).toBe(200)
+	await expect(second.json()).resolves.toMatchObject({ ok: true })
 })

--- a/packages/worker/src/app/handler.ts
+++ b/packages/worker/src/app/handler.ts
@@ -1,12 +1,33 @@
 import { setAuthSessionSecret } from '#app/auth-session.ts'
 import { getEnv } from '#app/env.ts'
 import { createAppRouter } from '#app/router.ts'
+import { type AppEnv } from '#worker/env-schema.ts'
+
+type AppRouterBundle = {
+	appEnv: AppEnv
+	router: ReturnType<typeof createAppRouter>
+}
+
+// Env binding objects are stable per isolate, so the parsed env and the
+// router (which closes over env, not the request) can be built once instead
+// of on every request. Keyed by identity so a new env object (new isolate or
+// updated bindings) gets a fresh router.
+const appRouterCache = new WeakMap<Env, AppRouterBundle>()
+
+function getAppRouterBundle(env: Env): AppRouterBundle {
+	let bundle = appRouterCache.get(env)
+	if (!bundle) {
+		const appEnv = getEnv(env)
+		bundle = { appEnv, router: createAppRouter(appEnv) }
+		appRouterCache.set(env, bundle)
+	}
+	return bundle
+}
 
 export async function handleRequest(request: Request, env: Env) {
 	try {
-		const appEnv = getEnv(env)
+		const { appEnv, router } = getAppRouterBundle(env)
 		setAuthSessionSecret(appEnv.COOKIE_SECRET)
-		const router = createAppRouter(appEnv)
 		return await router.fetch(request)
 	} catch (error) {
 		console.error('Remix server handler failed:', error)

--- a/packages/worker/src/app/handlers/package-app.node.test.ts
+++ b/packages/worker/src/app/handlers/package-app.node.test.ts
@@ -40,6 +40,9 @@ const mockModule = vi.hoisted(() => ({
 	loadPackageSourceBySourceId: vi.fn(async () => {
 		throw new Error('bundle failed')
 	}),
+	loadPackageManifestBySourceId: vi.fn(async () => {
+		throw new Error('manifest load failed')
+	}),
 	createPackageAppCallerContext: vi.fn(),
 	buildPackageAppWorker: vi.fn(),
 	packageRealtimeConnect: vi.fn(
@@ -79,6 +82,8 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 vi.mock('#worker/package-registry/source.ts', () => ({
 	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
 		mockModule.loadPackageSourceBySourceId(...args),
+	loadPackageManifestBySourceId: (...args: Array<unknown>) =>
+		mockModule.loadPackageManifestBySourceId(...args),
 }))
 
 vi.mock('#worker/package-runtime/package-app.ts', () => ({
@@ -182,18 +187,15 @@ test('handlePackageAppRequest reports host setup failures with helpful responses
 test('handlePackageAppRequest does not report package entrypoint failures to Kody Sentry', async () => {
 	resetMocks()
 
-	mockModule.loadPackageSourceBySourceId.mockResolvedValueOnce({
+	mockModule.loadPackageManifestBySourceId.mockResolvedValueOnce({
 		source: {
 			published_commit: 'commit-1',
 			manifest_path: 'package.json',
 			source_root: '/',
 		},
-		files: {
-			'package.json': JSON.stringify({
-				name: '@kody/example',
-				kody: { id: 'example', app: { entry: 'app.js' } },
-			}),
-			'app.js': 'export default {}',
+		manifest: {
+			name: '@kody/example',
+			kody: { id: 'example', app: { entry: 'app.js' } },
 		},
 	})
 	mockModule.buildPackageAppWorker.mockResolvedValueOnce({

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -6,7 +6,10 @@ import { redirectToLoginWhenUnauthenticated } from '#app/auth-redirect.ts'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
 import { getUsernameValidationError } from '#app/username.ts'
 import { getSavedPackageByKodyId } from '#worker/package-registry/repo.ts'
-import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
+import {
+	loadPackageManifestBySourceId,
+	loadPackageSourceBySourceId,
+} from '#worker/package-registry/source.ts'
 import {
 	buildPackageAppWorker,
 	createPackageAppCallerContext,
@@ -295,22 +298,24 @@ export async function handlePackageAppRequest(request: Request, env: Env) {
 	let forwardedRequest: Request
 	let entrypoint: { fetch(request: Request): Promise<Response> }
 	try {
-		const packageSource = await loadPackageSourceBySourceId({
-			env,
-			baseUrl,
-			userId: user.mcpUser.userId,
-			sourceId: savedPackage.sourceId,
-		})
-		const callerContext = await createPackageAppCallerContext({
-			baseUrl,
-			user: {
+		const [packageManifest, callerContext] = await Promise.all([
+			loadPackageManifestBySourceId({
+				env,
+				baseUrl,
 				userId: user.mcpUser.userId,
-				email: user.email,
-				displayName: user.displayName,
-				username: user.username,
-			},
-			packageId: savedPackage.id,
-		})
+				sourceId: savedPackage.sourceId,
+			}),
+			createPackageAppCallerContext({
+				baseUrl,
+				user: {
+					userId: user.mcpUser.userId,
+					email: user.email,
+					displayName: user.displayName,
+					username: user.username,
+				},
+				packageId: savedPackage.id,
+			}),
+		])
 		const appWorker = await buildPackageAppWorker({
 			env,
 			baseUrl,
@@ -320,11 +325,21 @@ export async function handlePackageAppRequest(request: Request, env: Env) {
 				kodyId: savedPackage.kodyId,
 				name: savedPackage.name,
 				sourceId: savedPackage.sourceId,
-				publishedCommit: packageSource.source.published_commit,
-				manifestPath: packageSource.source.manifest_path,
-				sourceRoot: packageSource.source.source_root,
+				publishedCommit: packageManifest.source.published_commit,
+				manifestPath: packageManifest.source.manifest_path,
+				sourceRoot: packageManifest.source.source_root,
 			},
-			sourceFiles: packageSource.files,
+			source: packageManifest.source,
+			manifest: packageManifest.manifest,
+			loadSourceFiles: async () => {
+				const packageSource = await loadPackageSourceBySourceId({
+					env,
+					baseUrl,
+					userId: user.mcpUser.userId,
+					sourceId: savedPackage.sourceId,
+				})
+				return packageSource.files
+			},
 			runtime: {
 				callerContext,
 			},

--- a/packages/worker/src/mcp/capabilities/registry.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/registry.node.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import {
+	clearCapabilityRegistryCacheForTests,
+	capabilityMap,
+	getCapabilityRegistryForContext,
+} from '#mcp/capabilities/registry.ts'
+import { clearRemoteConnectorSnapshotCacheForTests } from '#worker/remote-connector/snapshot-cache.ts'
+
+const runtimeTools = [
+	{
+		name: 'roku_press_key',
+		title: 'Press Roku Key',
+		description: 'Send a Roku ECP keypress.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				deviceId: { type: 'string' },
+				key: { type: 'string' },
+			},
+			required: ['deviceId', 'key'],
+		},
+	},
+] as const
+
+function buildRemoteConnectorEnv(input?: {
+	onGetSnapshot?: () => Promise<{
+		connectorKind: string
+		connectorId: string
+		connectedAt: string
+		lastSeenAt: string
+		tools: ReadonlyArray<(typeof runtimeTools)[number]>
+	}>
+}) {
+	const getSnapshot =
+		input?.onGetSnapshot ??
+		(() =>
+			Promise.resolve({
+				connectorKind: 'roku',
+				connectorId: 'default',
+				connectedAt: '2026-03-25T00:00:00.000Z',
+				lastSeenAt: '2026-03-25T00:00:01.000Z',
+				tools: runtimeTools,
+			}))
+	const get = vi.fn(() => ({
+		getSnapshot,
+	}))
+	return {
+		env: {
+			REMOTE_CONNECTOR_SESSION: {
+				idFromName(name: string) {
+					return name
+				},
+				get,
+			},
+		} as unknown as Env,
+		get,
+		getSnapshot,
+	}
+}
+
+beforeEach(() => {
+	clearRemoteConnectorSnapshotCacheForTests()
+	clearCapabilityRegistryCacheForTests()
+})
+
+test('getCapabilityRegistryForContext reuses cached snapshots within TTL', async () => {
+	let snapshotCalls = 0
+	const { env } = buildRemoteConnectorEnv({
+		onGetSnapshot: async () => {
+			snapshotCalls += 1
+			return {
+				connectorKind: 'roku',
+				connectorId: 'default',
+				connectedAt: '2026-03-25T00:00:00.000Z',
+				lastSeenAt: '2026-03-25T00:00:01.000Z',
+				tools: runtimeTools,
+			}
+		},
+	})
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: {
+			userId: 'user-1',
+			email: 'user-1@example.com',
+			displayName: 'user-1',
+		},
+		remoteConnectors: [{ kind: 'roku', instanceId: 'default' }],
+	})
+
+	await getCapabilityRegistryForContext({ env, callerContext })
+	await getCapabilityRegistryForContext({ env, callerContext })
+
+	expect(snapshotCalls).toBe(1)
+})
+
+test('getCapabilityRegistryForContext does not share snapshot cache across users', async () => {
+	let snapshotCalls = 0
+	const { env } = buildRemoteConnectorEnv({
+		onGetSnapshot: async () => {
+			snapshotCalls += 1
+			return {
+				connectorKind: 'roku',
+				connectorId: 'default',
+				connectedAt: '2026-03-25T00:00:00.000Z',
+				lastSeenAt: '2026-03-25T00:00:01.000Z',
+				tools: runtimeTools,
+			}
+		},
+	})
+	const connector = [{ kind: 'roku', instanceId: 'default' }] as const
+
+	await getCapabilityRegistryForContext({
+		env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId: 'user-1',
+				email: 'user-1@example.com',
+				displayName: 'user-1',
+			},
+			remoteConnectors: [...connector],
+		}),
+	})
+	await getCapabilityRegistryForContext({
+		env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId: 'user-2',
+				email: 'user-2@example.com',
+				displayName: 'user-2',
+			},
+			remoteConnectors: [...connector],
+		}),
+	})
+
+	expect(snapshotCalls).toBe(2)
+})
+
+test('getCapabilityRegistryForContext bypasses connector caches when no connectors are attached', async () => {
+	const get = vi.fn()
+	const env = {
+		REMOTE_CONNECTOR_SESSION: {
+			idFromName(name: string) {
+				return name
+			},
+			get,
+		},
+	} as unknown as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: {
+			userId: 'user-1',
+			email: 'user-1@example.com',
+			displayName: 'user-1',
+		},
+	})
+
+	const registry = await getCapabilityRegistryForContext({
+		env,
+		callerContext,
+	})
+
+	expect(get).not.toHaveBeenCalled()
+	expect(registry.capabilityMap).toBe(capabilityMap)
+})

--- a/packages/worker/src/mcp/capabilities/registry.ts
+++ b/packages/worker/src/mcp/capabilities/registry.ts
@@ -5,7 +5,13 @@ import {
 import { builtinDomains } from './builtin-domains.ts'
 import { synthesizeRemoteToolDomain } from './remote-connector/index.ts'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
-import { normalizeRemoteConnectorRefs } from '@kody-internal/shared/remote-connectors.ts'
+import {
+	normalizeRemoteConnectorRefs,
+	type RemoteConnectorRef,
+} from '@kody-internal/shared/remote-connectors.ts'
+import { PromiseLruCache } from '#worker/package-registry/published-package-cache.ts'
+import { getCachedRemoteConnectorSnapshot } from '#worker/remote-connector/snapshot-cache.ts'
+import { type RemoteConnectorSnapshot } from '#worker/remote-connector/types.ts'
 
 const staticRegistry = buildCapabilityRegistry(builtinDomains)
 
@@ -25,6 +31,65 @@ export const capabilityToolDescriptors =
 
 export const capabilityHandlers = staticRegistry.capabilityHandlers
 
+export const capabilityRegistryCacheTtlMs = 30_000
+export const capabilityRegistryCacheLimit = 50
+
+function createCapabilityRegistryCache() {
+	return new PromiseLruCache<BuiltCapabilityRegistry>({
+		ttlMs: capabilityRegistryCacheTtlMs,
+		limit: capabilityRegistryCacheLimit,
+	})
+}
+
+let capabilityRegistryCache = createCapabilityRegistryCache()
+
+function createCapabilityRegistryCacheKey(input: {
+	userId: string
+	refs: ReadonlyArray<RemoteConnectorRef>
+	snapshots: ReadonlyArray<RemoteConnectorSnapshot | null>
+}) {
+	const connectorParts = input.refs
+		.map((ref, index) => {
+			const snapshot = input.snapshots[index] ?? null
+			const refKey = `${ref.kind.trim().toLowerCase()}:${ref.instanceId.trim()}`
+			if (!snapshot) {
+				return `${refKey}:disconnected`
+			}
+			const toolNames = snapshot.tools
+				.map((tool) => tool.name)
+				.sort()
+				.join(',')
+			return `${refKey}:${snapshot.connectorId}:${snapshot.connectedAt}:${toolNames}`
+		})
+		.sort()
+	return `${input.userId}:${connectorParts.join('|')}`
+}
+
+async function buildCapabilityRegistryForConnectors(input: {
+	env: Env
+	userId: string
+	refs: ReadonlyArray<RemoteConnectorRef>
+	snapshots: ReadonlyArray<RemoteConnectorSnapshot | null>
+}): Promise<BuiltCapabilityRegistry> {
+	const synthesized = await Promise.all(
+		input.refs.map((ref, index) =>
+			synthesizeRemoteToolDomain({
+				env: input.env,
+				userId: input.userId,
+				ref,
+				snapshot: input.snapshots[index] ?? null,
+			}),
+		),
+	)
+	const synthesizedDomains = synthesized.flatMap((domain) =>
+		domain ? [domain.domain] : [],
+	)
+	if (synthesizedDomains.length === 0) {
+		return staticRegistry
+	}
+	return buildCapabilityRegistry([...builtinDomains, ...synthesizedDomains])
+}
+
 export async function getCapabilityRegistryForContext(input: {
 	env: Env
 	callerContext: McpCallerContext
@@ -34,20 +99,33 @@ export async function getCapabilityRegistryForContext(input: {
 	if (refs.length === 0 || !userId) {
 		return staticRegistry
 	}
-	const synthesized = await Promise.all(
+	const snapshots = await Promise.all(
 		refs.map((ref) =>
-			synthesizeRemoteToolDomain({ env: input.env, userId, ref }),
+			getCachedRemoteConnectorSnapshot({
+				env: input.env,
+				userId,
+				kind: ref.kind,
+				instanceId: ref.instanceId,
+			}),
 		),
 	)
-	const synthesizedDomains = synthesized.flatMap((domain) =>
-		domain ? [domain.domain] : [],
-	)
-	if (synthesizedDomains.length === 0) {
-		return staticRegistry
-	}
-	const registry = buildCapabilityRegistry([
-		...builtinDomains,
-		...synthesizedDomains,
-	])
-	return registry
+	const cacheKey = createCapabilityRegistryCacheKey({
+		userId,
+		refs,
+		snapshots,
+	})
+	return capabilityRegistryCache.getOrCreate({
+		cacheKey,
+		create: () =>
+			buildCapabilityRegistryForConnectors({
+				env: input.env,
+				userId,
+				refs,
+				snapshots,
+			}),
+	})
+}
+
+export function clearCapabilityRegistryCacheForTests() {
+	capabilityRegistryCache = createCapabilityRegistryCache()
 }

--- a/packages/worker/src/mcp/capabilities/remote-connector/index.ts
+++ b/packages/worker/src/mcp/capabilities/remote-connector/index.ts
@@ -169,14 +169,17 @@ export async function synthesizeRemoteToolDomain(input: {
 	env: Env
 	userId: string
 	ref: RemoteConnectorRef
+	snapshot?: RemoteConnectorSnapshot | null
 }): Promise<SynthesizedRemoteConnectorDomain | null> {
-	const client = createRemoteConnectorMcpClient({
-		env: input.env,
-		userId: input.userId,
-		kind: input.ref.kind,
-		instanceId: input.ref.instanceId,
-	})
-	const snapshot = await client.getSnapshot()
+	const snapshot =
+		input.snapshot !== undefined
+			? input.snapshot
+			: await createRemoteConnectorMcpClient({
+					env: input.env,
+					userId: input.userId,
+					kind: input.ref.kind,
+					instanceId: input.ref.instanceId,
+				}).getSnapshot()
 	const ref = input.ref
 	if (!snapshot || snapshot.tools.length === 0) return null
 

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -10,6 +10,7 @@ import {
 	createExecuteExecutor,
 	extractRawContent,
 	formatExecutionOutput,
+	formatLimitedExecutionOutput,
 	getExecutionErrorDetails,
 	limitExecutionResultValue,
 } from './executor.ts'
@@ -201,8 +202,63 @@ test('createExecuteExecutor reuses stable dynamic worker ids until binding conte
 		}).execute('async () => "ok"', scopedProviders)
 	}
 	expect(bundledLoader.ids).toHaveLength(2)
-	expect(new Set(bundledLoader.ids).size).toBe(2)
-	expect(bundledLoader.factoryCallCount).toBe(2)
+	expect(new Set(bundledLoader.ids).size).toBe(1)
+	expect(bundledLoader.factoryCallCount).toBe(1)
+
+	const differentUserBundledLoader = createFakeWorkerLoader()
+	for (const userId of ['user-1', 'user-2']) {
+		await createExecuteExecutor({
+			env: createExecutorTestEnv(differentUserBundledLoader.loader),
+			exports,
+			gatewayProps: createGatewayProps(userId),
+			modules: {
+				'entry.js': 'export default async function main() { return "ok" }',
+			},
+		}).execute('async () => "ok"', scopedProviders)
+	}
+	expect(differentUserBundledLoader.ids).toHaveLength(2)
+	expect(new Set(differentUserBundledLoader.ids).size).toBe(2)
+	expect(differentUserBundledLoader.factoryCallCount).toBe(2)
+
+	const differentStorageLoader = createFakeWorkerLoader()
+	const storageContexts = [
+		null,
+		{ sessionId: 'session-1', appId: 'app-1', storageId: 'storage-1' },
+	] as const
+	for (const storageContext of storageContexts) {
+		await createExecuteExecutor({
+			env: createExecutorTestEnv(differentStorageLoader.loader),
+			exports,
+			gatewayProps: {
+				...createGatewayProps('user-1'),
+				storageContext,
+			},
+			modules: {
+				'entry.js': 'export default async function main() { return "ok" }',
+			},
+		}).execute('async () => "ok"', scopedProviders)
+	}
+	expect(differentStorageLoader.ids).toHaveLength(2)
+	expect(new Set(differentStorageLoader.ids).size).toBe(2)
+	expect(differentStorageLoader.factoryCallCount).toBe(2)
+
+	const nonHashableModuleLoader = createFakeWorkerLoader()
+	for (let index = 0; index < 2; index += 1) {
+		await createExecuteExecutor({
+			env: createExecutorTestEnv(nonHashableModuleLoader.loader),
+			exports,
+			gatewayProps: createGatewayProps('user-1'),
+			modules: {
+				'entry.js': {
+					js: 'export default async function main() { return "ok" }',
+					onLoad: async () => 'not-hashable',
+				},
+			},
+		}).execute('async () => "ok"', scopedProviders)
+	}
+	expect(nonHashableModuleLoader.ids).toHaveLength(2)
+	expect(new Set(nonHashableModuleLoader.ids).size).toBe(2)
+	expect(nonHashableModuleLoader.factoryCallCount).toBe(2)
 })
 
 test('createExecuteExecutor rejects reserved JavaScript provider names before loading a worker', async () => {
@@ -381,4 +437,63 @@ test('executor maps secret errors, formats guidance, extracts raw content, and t
 	expect(
 		new TextEncoder().encode(String(threeByteLimit.value)).byteLength,
 	).toBe(3)
+})
+
+test('limitExecutionResultValue preserves output for representative small and oversized values', () => {
+	const smallObject = { ok: true, count: 3 }
+	const smallObjectLimited = limitExecutionResultValue(smallObject, 102_400)
+	expect(smallObjectLimited).toMatchObject({
+		value: smallObject,
+		returnedBytes: 21,
+		truncated: false,
+	})
+	expect(smallObjectLimited.displayText).toBe(
+		JSON.stringify(smallObject, null, 2),
+	)
+	expect(
+		formatLimitedExecutionOutput({
+			value: smallObjectLimited.value,
+			truncated: smallObjectLimited.truncated,
+			displayText: smallObjectLimited.displayText,
+		}),
+	).toBe(smallObjectLimited.displayText)
+
+	const oversizedObject = {
+		rows: [{ id: 'message-1', payload: 'abcdef' }],
+	}
+	const oversizedObjectLimited = limitExecutionResultValue(oversizedObject, 10)
+	expect(oversizedObjectLimited).toMatchObject({
+		value: {
+			truncated: true,
+			type: 'object',
+		},
+		returnedBytes: 48,
+		truncated: true,
+		note: 'Returned value was 48 bytes, exceeding responseLimit 10 bytes; output was truncated. Project fields before returning.',
+	})
+	expect(
+		formatLimitedExecutionOutput({
+			value: oversizedObjectLimited.value,
+			truncated: oversizedObjectLimited.truncated,
+			note: oversizedObjectLimited.note,
+			displayText: oversizedObjectLimited.displayText,
+		}),
+	).toBe(
+		`${oversizedObjectLimited.displayText}\n\n--- TRUNCATED ---\n${oversizedObjectLimited.note}`,
+	)
+
+	const oversizedStringLimited = limitExecutionResultValue('hello world', 5)
+	expect(oversizedStringLimited).toMatchObject({
+		value: 'hello',
+		returnedBytes: 11,
+		truncated: true,
+	})
+	expect(oversizedStringLimited.displayText).toBeUndefined()
+	expect(
+		formatLimitedExecutionOutput({
+			value: oversizedStringLimited.value,
+			truncated: oversizedStringLimited.truncated,
+			note: oversizedStringLimited.note,
+		}),
+	).toBe(`hello\n\n--- TRUNCATED ---\n${oversizedStringLimited.note}`)
 })

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -28,7 +28,7 @@ const dynamicWorkerCompatibilityDate = '2025-06-01'
 const dynamicWorkerCompatibilityFlags = ['nodejs_compat'] as const
 const dynamicWorkerMainModule = 'executor.js'
 const dynamicWorkerIdPrefix = 'codemode-'
-const dynamicWorkerCacheKeyVersion = 1
+const dynamicWorkerCacheKeyVersion = 2
 const reservedProviderNames = new Set(['__dispatchers', '__logs'])
 const validProviderNamePattern = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
 const javascriptReservedWords = new Set([
@@ -355,9 +355,78 @@ function canReuseDynamicWorkerId(input: {
 }) {
 	if (!input.gatewayProps.userId) return false
 	if (!input.appCommitSha) return false
-	return Object.keys(input.workerOptions.modules).every(
-		(moduleName) => moduleName === dynamicWorkerMainModule,
-	)
+	return areWorkerModulesDeterministicallyHashable(input.workerOptions.modules)
+}
+
+function areWorkerModulesDeterministicallyHashable(
+	modules: WorkerLoaderModules,
+) {
+	for (const moduleValue of Object.values(modules)) {
+		if (!isDeterministicallyHashableWorkerModule(moduleValue)) {
+			return false
+		}
+	}
+	return true
+}
+
+function isDeterministicallyHashableWorkerModule(
+	moduleValue: WorkerLoaderModules[string],
+) {
+	if (typeof moduleValue === 'string') return true
+	if (moduleValue === null || typeof moduleValue !== 'object') return false
+	const record = moduleValue as Record<string, unknown>
+	for (const key of ['js', 'cjs', 'text'] as const) {
+		const value = record[key]
+		if (value !== undefined && typeof value !== 'string') return false
+	}
+	if (record.data !== undefined && !(record.data instanceof ArrayBuffer)) {
+		return false
+	}
+	if (
+		record.json !== undefined &&
+		!isDeterministicallyHashableValue(record.json)
+	) {
+		return false
+	}
+	for (const [key, value] of Object.entries(record)) {
+		if (
+			key !== 'js' &&
+			key !== 'cjs' &&
+			key !== 'text' &&
+			key !== 'data' &&
+			key !== 'json'
+		) {
+			return false
+		}
+		if (key === 'data' || key === 'json') continue
+		if (value !== undefined && typeof value !== 'string') return false
+	}
+	return true
+}
+
+function isDeterministicallyHashableValue(value: unknown): boolean {
+	if (value === null) return true
+	const valueType = typeof value
+	if (
+		valueType === 'string' ||
+		valueType === 'number' ||
+		valueType === 'boolean'
+	) {
+		return true
+	}
+	if (valueType === 'bigint' || valueType === 'undefined') return true
+	if (valueType === 'function' || valueType === 'symbol') return false
+	if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return true
+	if (Array.isArray(value)) {
+		return value.every((entry) => isDeterministicallyHashableValue(entry))
+	}
+	if (valueType === 'object') {
+		const record = value as Record<string, unknown>
+		return Object.values(record).every((entry) =>
+			isDeterministicallyHashableValue(entry),
+		)
+	}
+	return false
 }
 
 function canonicalJsonStringify(value: unknown) {
@@ -677,28 +746,46 @@ export function limitExecutionResultValue(
 	value: unknown,
 	responseLimitBytes: number,
 ) {
-	const serialized = stringifyExecutionValueForBytes(value)
-	const returnedBytes = getUtf8ByteLength(serialized)
+	if (typeof value === 'string') {
+		const returnedBytes = getUtf8ByteLength(value)
+		if (returnedBytes <= responseLimitBytes) {
+			return {
+				value,
+				displayText: value,
+				returnedBytes,
+				truncated: false,
+			} as const
+		}
+		const note = `Returned value was ${returnedBytes.toLocaleString()} bytes, exceeding responseLimit ${responseLimitBytes.toLocaleString()} bytes; output was truncated. Project fields before returning.`
+		return {
+			value: truncateUtf8String(value, responseLimitBytes),
+			returnedBytes,
+			truncated: true,
+			note,
+		} as const
+	}
+
+	const compactSerialized = JSON.stringify(value) ?? 'undefined'
+	const returnedBytes = getUtf8ByteLength(compactSerialized)
 
 	if (returnedBytes <= responseLimitBytes) {
 		return {
 			value,
+			displayText: JSON.stringify(value, null, 2) ?? 'undefined',
 			returnedBytes,
 			truncated: false,
 		} as const
 	}
 
 	const note = `Returned value was ${returnedBytes.toLocaleString()} bytes, exceeding responseLimit ${responseLimitBytes.toLocaleString()} bytes; output was truncated. Project fields before returning.`
-	const truncatedValue =
-		typeof value === 'string'
-			? truncateUtf8String(value, responseLimitBytes)
-			: {
-					truncated: true,
-					type: describeExecutionValue(value),
-				}
+	const truncatedValue = {
+		truncated: true,
+		type: describeExecutionValue(value),
+	}
 
 	return {
 		value: truncatedValue,
+		displayText: JSON.stringify(truncatedValue, null, 2) ?? 'undefined',
 		returnedBytes,
 		truncated: true,
 		note,
@@ -709,15 +796,12 @@ export function formatLimitedExecutionOutput(input: {
 	value: unknown
 	truncated: boolean
 	note?: string
+	displayText?: string
 }) {
-	const text = stringifyExecutionValueForOutput(input.value)
+	const text =
+		input.displayText ?? stringifyExecutionValueForOutput(input.value)
 	if (!input.truncated) return text
 	return `${text}\n\n--- TRUNCATED ---\n${input.note}`
-}
-
-function stringifyExecutionValueForBytes(value: unknown) {
-	if (typeof value === 'string') return value
-	return JSON.stringify(value) ?? 'undefined'
 }
 
 function stringifyExecutionValueForOutput(value: unknown) {

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -96,16 +96,16 @@ export async function expandSecretPlaceholders(input: {
 			if (!resolved.found || typeof resolved.value !== 'string') {
 				throw new Error(createMissingSecretMessage(referenced.name))
 			}
-			return { referenced, resolved }
+			return { referenced, resolved, value: resolved.value }
 		}),
 	)
-	for (const { referenced, resolved } of resolvedSecretResults) {
+	for (const { referenced, resolved, value } of resolvedSecretResults) {
 		const placeholder = buildSecretPlaceholder(referenced)
 		if (!replacements.has(placeholder)) {
-			replacements.set(placeholder, resolved.value)
+			replacements.set(placeholder, value)
 		}
 		if (!resolvedValues.has(placeholder)) {
-			resolvedValues.set(placeholder, resolved.value)
+			resolvedValues.set(placeholder, value)
 		}
 		resolvedSecrets.push({ referenced, resolved })
 	}

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -84,17 +84,22 @@ export async function expandSecretPlaceholders(input: {
 	if (hasReferencedSecrets) {
 		ensureFetchAllowed(input.props)
 	}
-	for (const referenced of referencedSecrets) {
-		const resolved = await resolveSecret({
-			env: input.env,
-			userId: input.props.userId!,
-			name: referenced.name,
-			scope: referenced.scope,
-			storageContext: input.props.storageContext,
-		})
-		if (!resolved.found || typeof resolved.value !== 'string') {
-			throw new Error(createMissingSecretMessage(referenced.name))
-		}
+	const resolvedSecretResults = await Promise.all(
+		referencedSecrets.map(async (referenced) => {
+			const resolved = await resolveSecret({
+				env: input.env,
+				userId: input.props.userId!,
+				name: referenced.name,
+				scope: referenced.scope,
+				storageContext: input.props.storageContext,
+			})
+			if (!resolved.found || typeof resolved.value !== 'string') {
+				throw new Error(createMissingSecretMessage(referenced.name))
+			}
+			return { referenced, resolved }
+		}),
+	)
+	for (const { referenced, resolved } of resolvedSecretResults) {
 		const placeholder = buildSecretPlaceholder(referenced)
 		if (!replacements.has(placeholder)) {
 			replacements.set(placeholder, resolved.value)

--- a/packages/worker/src/mcp/run-codemode-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.node.test.ts
@@ -1785,3 +1785,59 @@ test('runBundledModuleWithRegistry passes params and injects runtime helpers', a
 		getRegistrySpy.mockRestore()
 	}
 })
+
+test('runBundledModuleWithRegistry uses a prebuilt capability registry without reloading', async () => {
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+	})
+	const emptyRegistry = {
+		capabilityDomains: [],
+		capabilityDomainDescriptionsByName: {} as Record<string, string>,
+		capabilityHandlers: {},
+		capabilityList: [],
+		capabilityMap: {},
+		capabilitySpecs: {},
+		capabilityToolDescriptors: {},
+	} as Awaited<ReturnType<typeof getCapabilityRegistryForContext>>
+	let loadCount = 0
+	const getRegistrySpy = vi
+		.spyOn(
+			await import('#mcp/capabilities/registry.ts'),
+			'getCapabilityRegistryForContext',
+		)
+		.mockImplementation(async () => {
+			loadCount += 1
+			return emptyRegistry
+		})
+	const createExecuteExecutorSpy = vi
+		.spyOn(await import('#mcp/executor.ts'), 'createExecuteExecutor')
+		.mockReturnValue({
+			async execute() {
+				return {
+					result: 'ok',
+					logs: [],
+				}
+			},
+		} as never)
+	const bundle = {
+		mainModule: 'entry.js',
+		modules: {
+			'entry.js': 'export default async () => "ok"',
+		},
+	}
+
+	try {
+		await runBundledModuleWithRegistry(env, callerContext, bundle, undefined, {
+			capabilityRegistry: emptyRegistry,
+		})
+		expect(loadCount).toBe(0)
+
+		await runBundledModuleWithRegistry(env, callerContext, bundle)
+		expect(loadCount).toBe(1)
+	} finally {
+		createExecuteExecutorSpy.mockRestore()
+		getRegistrySpy.mockRestore()
+	}
+})

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -27,6 +27,7 @@ import { buildSecretCapabilityApprovalUrl } from '#mcp/secrets/capability-approv
 import { resolveSecret } from '#mcp/secrets/service.ts'
 import { type ReferencedSecret } from '#mcp/secrets/placeholders.ts'
 import { buildParameterizedSkillCode } from '#mcp/skills/skill-parameters.ts'
+import { type BuiltCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
 import { getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
 import { createExecuteHelperPrelude } from '#mcp/execute-modules/codemode-utils.ts'
 import {
@@ -331,16 +332,19 @@ export async function buildCodemodeFns(
 		emailTools?: EmailToolOptions
 		workflowTools?: PackageWorkflowTools
 		skipCapabilityRegistry?: boolean
+		capabilityRegistry?: BuiltCapabilityRegistry
 	},
 ) {
 	const capabilityMap = options?.skipCapabilityRegistry
 		? {}
-		: (
-				await getCapabilityRegistryForContext({
-					env,
-					callerContext,
-				})
-			).capabilityMap
+		: options?.capabilityRegistry
+			? options.capabilityRegistry.capabilityMap
+			: (
+					await getCapabilityRegistryForContext({
+						env,
+						callerContext,
+					})
+				).capabilityMap
 	const additionalTools = options?.additionalTools ?? {}
 	const storageTools = options?.storageTools
 	assertNoCapabilityCollisions(capabilityMap, additionalTools)
@@ -513,6 +517,7 @@ export async function buildCodemodeProvider(
 		emailTools?: EmailToolOptions
 		workflowTools?: PackageWorkflowTools
 		skipCapabilityRegistry?: boolean
+		capabilityRegistry?: BuiltCapabilityRegistry
 	},
 ): Promise<ResolvedProvider> {
 	const tools = await buildCodemodeFns(env, callerContext, options)
@@ -632,6 +637,7 @@ export async function runCodemodeWithRegistry(
 		executorTimeoutMs?: number | null
 		packageInvokeTools?: PackageInvokeTools
 		packageEventTools?: PackageEventTools
+		capabilityRegistry?: BuiltCapabilityRegistry
 	},
 ): Promise<ExecuteResult> {
 	const moduleSource = stripCodeFences(code.trim())
@@ -650,6 +656,7 @@ export async function runCodemodeWithRegistry(
 			packageInvokeTools: options?.packageInvokeTools,
 			packageEventTools: options?.packageEventTools,
 			executorTimeoutMs: options?.executorTimeoutMs,
+			capabilityRegistry: options?.capabilityRegistry,
 		})
 	}
 	const secretRedactor = createExecutionSecretRedactor()
@@ -688,6 +695,7 @@ export async function runCodemodeWithRegistry(
 			: undefined,
 		emailTools: options?.emailTools,
 		workflowTools,
+		capabilityRegistry: options?.capabilityRegistry,
 	})
 	const wrappedCode =
 		params !== undefined
@@ -778,6 +786,7 @@ export async function runModuleWithRegistry(
 		executorTimeoutMs?: number | null
 		packageInvokeTools?: PackageInvokeTools
 		packageEventTools?: PackageEventTools
+		capabilityRegistry?: BuiltCapabilityRegistry
 	},
 ): Promise<ExecuteResult> {
 	const userId = callerContext.user?.userId ?? ''
@@ -848,6 +857,7 @@ export async function runBundledModuleWithRegistry(
 		skipCapabilityRegistry?: boolean
 		executorTimeoutMs?: number | null
 		runtimeDebug?: PackageRuntimeDebugContext | null
+		capabilityRegistry?: BuiltCapabilityRegistry
 	},
 ): Promise<ExecuteResult> {
 	const secretRedactor = createExecutionSecretRedactor()
@@ -911,6 +921,7 @@ export async function runBundledModuleWithRegistry(
 			emailTools: options?.emailTools,
 			workflowTools,
 			skipCapabilityRegistry: options?.skipCapabilityRegistry,
+			capabilityRegistry: options?.capabilityRegistry,
 		})
 		const storageHelperPrelude = options?.storageTools
 			? createStorageHelperPrelude({

--- a/packages/worker/src/mcp/secrets/capability-inputs.node.test.ts
+++ b/packages/worker/src/mcp/secrets/capability-inputs.node.test.ts
@@ -74,3 +74,21 @@ test('resolveCapabilityInputSecrets replaces annotated secret placeholders in ne
 		],
 	})
 })
+
+test('resolveCapabilityInputSecrets resolves duplicate secret references once', async () => {
+	const resolveCalls: Array<string> = []
+	const result = await resolveCapabilityInputSecrets({
+		schema: {
+			type: 'string',
+			[secretInputSchemaFlag]: true,
+		},
+		value: '{{secret:apiKey}} and {{secret:apiKey}} again',
+		resolveSecretValue: async (secret) => {
+			resolveCalls.push(secret.name)
+			return 'secret-val'
+		},
+	})
+
+	expect(result).toBe('secret-val and secret-val again')
+	expect(resolveCalls).toEqual(['apiKey'])
+})

--- a/packages/worker/src/mcp/secrets/capability-inputs.ts
+++ b/packages/worker/src/mcp/secrets/capability-inputs.ts
@@ -72,13 +72,23 @@ async function resolveStringPlaceholders(
 	const referencedSecrets = parseSecretPlaceholders(value)
 	if (referencedSecrets.length === 0) return value
 
+	const uniqueSecrets = dedupeReferencedSecrets(referencedSecrets)
 	const replacements = new Map<string, string>()
-	for (const secret of referencedSecrets) {
-		const placeholder = buildSecretPlaceholder(secret)
-		if (replacements.has(placeholder)) continue
-		replacements.set(placeholder, await resolveSecretValue(secret))
-	}
+	await Promise.all(
+		uniqueSecrets.map(async (secret) => {
+			const placeholder = buildSecretPlaceholder(secret)
+			replacements.set(placeholder, await resolveSecretValue(secret))
+		}),
+	)
 	return replaceSecretPlaceholders(value, replacements)
+}
+
+function dedupeReferencedSecrets(referencedSecrets: Array<ReferencedSecret>) {
+	const deduped = new Map<string, ReferencedSecret>()
+	for (const secret of referencedSecrets) {
+		deduped.set(buildSecretPlaceholder(secret), secret)
+	}
+	return Array.from(deduped.values())
 }
 
 export function isSecretInputSchema(schema: unknown): boolean {

--- a/packages/worker/src/mcp/secrets/crypto.node.test.ts
+++ b/packages/worker/src/mcp/secrets/crypto.node.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import {
 	decryptSecretValue,
 	decryptStringWithPurpose,
@@ -33,4 +33,69 @@ test('secret and purpose-based encryption round-trip and reject wrong keys or ma
 	expect(
 		await decryptStringWithPurpose(env, 'test-purpose', purposeEncrypted),
 	).toBe('hello')
+})
+
+test('secret store CryptoKey derivation is cached across encrypt and decrypt', async () => {
+	const cacheTestKey = 'cache-test-secret-store-key-32-chars-min!!'
+	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: cacheTestKey }
+	const derivedKeys: Array<CryptoKey> = []
+	const originalImportKey = crypto.subtle.importKey.bind(crypto.subtle)
+	const importKeySpy = vi
+		.spyOn(crypto.subtle, 'importKey')
+		.mockImplementation(async (...args) => {
+			const key = await originalImportKey(
+				...(args as Parameters<typeof crypto.subtle.importKey>),
+			)
+			derivedKeys.push(key)
+			return key
+		})
+	const digestSpy = vi.spyOn(crypto.subtle, 'digest')
+
+	try {
+		const encrypted = await encryptSecretValue(env, 'cached-value')
+		const digestCallsAfterEncrypt = digestSpy.mock.calls.length
+		const importKeyCallsAfterEncrypt = importKeySpy.mock.calls.length
+
+		expect(await decryptSecretValue(env, encrypted)).toBe('cached-value')
+		expect(digestSpy.mock.calls.length).toBe(digestCallsAfterEncrypt)
+		expect(importKeySpy.mock.calls.length).toBe(importKeyCallsAfterEncrypt)
+		expect(derivedKeys).toHaveLength(1)
+
+		await encryptSecretValue(env, 'another-value')
+		expect(digestSpy.mock.calls.length).toBe(digestCallsAfterEncrypt)
+		expect(importKeySpy.mock.calls.length).toBe(importKeyCallsAfterEncrypt)
+		expect(derivedKeys).toHaveLength(1)
+	} finally {
+		importKeySpy.mockRestore()
+		digestSpy.mockRestore()
+	}
+})
+
+test('failed secret store CryptoKey derivation is not cached', async () => {
+	const failureTestKey = 'failure-test-secret-store-key-32-chars-min!'
+	const env = { COOKIE_SECRET: cookieSecret, SECRET_STORE_KEY: failureTestKey }
+	let attempts = 0
+	const originalImportKey = crypto.subtle.importKey.bind(crypto.subtle)
+	const importKeySpy = vi
+		.spyOn(crypto.subtle, 'importKey')
+		.mockImplementation(async (...args) => {
+			attempts += 1
+			if (attempts === 1) {
+				throw new Error('transient derivation failure')
+			}
+			return originalImportKey(
+				...(args as Parameters<typeof crypto.subtle.importKey>),
+			)
+		})
+
+	try {
+		await expect(encryptSecretValue(env, 'fail')).rejects.toThrow(
+			'transient derivation failure',
+		)
+		const encrypted = await encryptSecretValue(env, 'ok')
+		expect(await decryptSecretValue(env, encrypted)).toBe('ok')
+		expect(attempts).toBe(2)
+	} finally {
+		importKeySpy.mockRestore()
+	}
 })

--- a/packages/worker/src/mcp/secrets/crypto.ts
+++ b/packages/worker/src/mcp/secrets/crypto.ts
@@ -24,15 +24,27 @@ function base64UrlToBytes(value: string) {
 	return Uint8Array.from(binary, (char) => char.charCodeAt(0))
 }
 
-async function deriveEncryptionKey(secret: string, purpose: string) {
-	const digest = await crypto.subtle.digest(
-		'SHA-256',
-		textEncoder.encode(`${purpose}:${secret}`),
-	)
-	return crypto.subtle.importKey('raw', digest, 'AES-GCM', false, [
-		'encrypt',
-		'decrypt',
-	])
+const derivedEncryptionKeyCache = new Map<string, Promise<CryptoKey>>()
+
+function deriveEncryptionKey(secret: string, purpose: string) {
+	const cacheKey = `${purpose}:${secret}`
+	const cached = derivedEncryptionKeyCache.get(cacheKey)
+	if (cached) return cached
+
+	const derivationPromise = crypto.subtle
+		.digest('SHA-256', textEncoder.encode(`${purpose}:${secret}`))
+		.then((digest) =>
+			crypto.subtle.importKey('raw', digest, 'AES-GCM', false, [
+				'encrypt',
+				'decrypt',
+			]),
+		)
+		.catch((error) => {
+			derivedEncryptionKeyCache.delete(cacheKey)
+			throw error
+		})
+	derivedEncryptionKeyCache.set(cacheKey, derivationPromise)
+	return derivationPromise
 }
 
 export async function encryptStringWithPurpose(

--- a/packages/worker/src/mcp/secrets/service.node.test.ts
+++ b/packages/worker/src/mcp/secrets/service.node.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { listSecrets, saveSecret } from './service.ts'
+import { listSecrets, resolveSecret, saveSecret } from './service.ts'
 
 type SecretBucketRow = {
 	id: string
@@ -214,4 +214,61 @@ test('reserved internal skill runner secret names cannot be saved or listed', as
 			scope: 'user',
 		}),
 	).resolves.toEqual([])
+})
+
+test('resolveSecret returns the first scope hit in precedence order', async () => {
+	const testDb = createSecretTestDb()
+	const env = {
+		APP_DB: testDb.db,
+		COOKIE_SECRET: 'test-cookie-secret',
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+	}
+	const userId = 'user-123'
+	const secretName = 'shared-secret'
+	const storageContext = {
+		sessionId: 'session-abc',
+		appId: 'app-xyz',
+		storageId: 'app-xyz',
+	}
+
+	await saveSecret({
+		env,
+		userId,
+		scope: 'user',
+		name: secretName,
+		value: 'user-value',
+	})
+	await saveSecret({
+		env,
+		userId,
+		scope: 'app',
+		name: secretName,
+		value: 'app-value',
+		storageContext,
+	})
+	await saveSecret({
+		env,
+		userId,
+		scope: 'session',
+		name: secretName,
+		value: 'session-value',
+		storageContext,
+		sessionExpiresAt: '2099-01-01T00:00:00.000Z',
+	})
+
+	const resolved = await resolveSecret({
+		env,
+		userId,
+		name: secretName,
+		storageContext,
+	})
+
+	expect(resolved).toEqual({
+		found: true,
+		value: 'session-value',
+		scope: 'session',
+		allowedHosts: [],
+		allowedCapabilities: [],
+		allowedPackages: [],
+	})
 })

--- a/packages/worker/src/mcp/secrets/service.node.test.ts
+++ b/packages/worker/src/mcp/secrets/service.node.test.ts
@@ -185,7 +185,15 @@ function createSecretTestDb() {
 		})
 	}
 
-	return { db, seedReservedSecret }
+	function corruptUserSecret(userId: string, name: string) {
+		const bucket = buckets.get(getBucketKey(userId, 'user', ''))
+		if (!bucket) throw new Error('user bucket not found')
+		const entry = entries.get(getEntryKey(bucket.id, name))
+		if (!entry) throw new Error('secret entry not found')
+		entry.encrypted_value = 'not-valid-ciphertext'
+	}
+
+	return { db, seedReservedSecret, corruptUserSecret }
 }
 
 test('reserved internal skill runner secret names cannot be saved or listed', async () => {
@@ -271,4 +279,49 @@ test('resolveSecret returns the first scope hit in precedence order', async () =
 		allowedCapabilities: [],
 		allowedPackages: [],
 	})
+})
+
+test('resolveSecret ignores a corrupted lower-precedence entry when a higher scope resolves', async () => {
+	const testDb = createSecretTestDb()
+	const env = {
+		APP_DB: testDb.db,
+		COOKIE_SECRET: 'test-cookie-secret',
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+	}
+	const userId = 'user-123'
+	const secretName = 'shared-secret'
+	const storageContext = {
+		sessionId: 'session-abc',
+		appId: 'app-xyz',
+		storageId: 'app-xyz',
+	}
+
+	await saveSecret({
+		env,
+		userId,
+		scope: 'user',
+		name: secretName,
+		value: 'user-value',
+	})
+	await saveSecret({
+		env,
+		userId,
+		scope: 'session',
+		name: secretName,
+		value: 'session-value',
+		storageContext,
+		sessionExpiresAt: '2099-01-01T00:00:00.000Z',
+	})
+	testDb.corruptUserSecret(userId, secretName)
+
+	const resolved = await resolveSecret({
+		env,
+		userId,
+		name: secretName,
+		storageContext,
+	})
+
+	expect(resolved.found).toBe(true)
+	expect(resolved.value).toBe('session-value')
+	expect(resolved.scope).toBe('session')
 })

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -185,29 +185,39 @@ export async function resolveSecret(
 	const scopes = input.scope
 		? [input.scope]
 		: resolveStorageScopeOrder(input.storageContext ?? null)
-	for (const scope of scopes) {
-		const bucket = await getExistingBucketForScope({
-			db: input.env.APP_DB,
-			userId: input.userId,
-			scope,
-			storageContext: input.storageContext ?? null,
-		})
-		if (!bucket) continue
-		const entry = await getSecretEntry({
-			db: input.env.APP_DB,
-			bucketId: bucket.id,
-			name: input.name,
-		})
-		if (!entry) continue
-		const decrypted = await decryptSecretValue(input.env, entry.encrypted_value)
-		return {
-			found: true,
-			value: decrypted,
-			scope,
-			allowedHosts: parseAllowedHosts(entry.allowed_hosts),
-			allowedCapabilities: parseAllowedCapabilities(entry.allowed_capabilities),
-			allowedPackages: parseAllowedPackages(entry.allowed_packages),
-		}
+	const scopeResults = await Promise.all(
+		scopes.map(async (scope) => {
+			const bucket = await getExistingBucketForScope({
+				db: input.env.APP_DB,
+				userId: input.userId,
+				scope,
+				storageContext: input.storageContext ?? null,
+			})
+			if (!bucket) return null
+			const entry = await getSecretEntry({
+				db: input.env.APP_DB,
+				bucketId: bucket.id,
+				name: input.name,
+			})
+			if (!entry) return null
+			const decrypted = await decryptSecretValue(
+				input.env,
+				entry.encrypted_value,
+			)
+			return {
+				found: true as const,
+				value: decrypted,
+				scope,
+				allowedHosts: parseAllowedHosts(entry.allowed_hosts),
+				allowedCapabilities: parseAllowedCapabilities(
+					entry.allowed_capabilities,
+				),
+				allowedPackages: parseAllowedPackages(entry.allowed_packages),
+			}
+		}),
+	)
+	for (const result of scopeResults) {
+		if (result) return result
 	}
 	return {
 		found: false,

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -185,7 +185,7 @@ export async function resolveSecret(
 	const scopes = input.scope
 		? [input.scope]
 		: resolveStorageScopeOrder(input.storageContext ?? null)
-	const scopeResults = await Promise.all(
+	const scopeResults = await Promise.allSettled(
 		scopes.map(async (scope) => {
 			const bucket = await getExistingBucketForScope({
 				db: input.env.APP_DB,
@@ -216,8 +216,12 @@ export async function resolveSecret(
 			}
 		}),
 	)
+	// Preserve sequential precedence semantics: a lower-precedence failure must
+	// not mask a higher-precedence hit, and a failure at the winning scope still
+	// surfaces as an error.
 	for (const result of scopeResults) {
-		if (result) return result
+		if (result.status === 'rejected') throw result.reason
+		if (result.value) return result.value
 	}
 	return {
 		found: false,

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -123,6 +123,20 @@ test('execute tool serializes successes and errors, binds storage, passes packag
 		conversationId: 'conv-123',
 	})
 
+	expect(mockModule.getCapabilityRegistryForContext).toHaveBeenCalledTimes(1)
+	expect(mockModule.runModuleWithRegistry).toHaveBeenLastCalledWith(
+		expect.anything(),
+		expect.anything(),
+		'async () => ({ __mcpContent: [] })',
+		undefined,
+		expect.objectContaining({
+			capabilityRegistry: {
+				capabilityHandlers: {
+					kody_official_guide: true,
+				},
+			},
+		}),
+	)
 	expect(mcpContentResponse.isError).toBe(false)
 	expect(mcpContentResponse.content).toEqual([
 		{

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -211,6 +211,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 						: undefined
 					return await runModuleWithRegistry(env, callerContext, code, params, {
 						executorExports: agent.getLoopbackExports(),
+						capabilityRegistry: registry,
 						storageTools: activeStorageId
 							? {
 									userId: callerContext.user?.userId ?? '',
@@ -288,7 +289,12 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					...(rawContent ?? [
 						{
 							type: 'text',
-							text: formatLimitedExecutionOutput(limitedResult),
+							text: formatLimitedExecutionOutput({
+								value: limitedResult.value,
+								truncated: limitedResult.truncated,
+								note: limitedResult.note,
+								displayText: limitedResult.displayText,
+							}),
 						},
 					]),
 					...formatSurfacedMemoriesMarkdown(surfacedMemories),

--- a/packages/worker/src/mcp/values/repo.ts
+++ b/packages/worker/src/mcp/values/repo.ts
@@ -146,6 +146,38 @@ export async function listValueMetadataForBucket(input: {
 	return (results ?? []).map(mapValueMetadataRow)
 }
 
+export async function listValueMetadataForBuckets(input: {
+	db: D1Database
+	userId: string
+	buckets: ReadonlyArray<ValueBucketRow>
+	now?: string
+}): Promise<Array<ValueMetadataRow>> {
+	if (input.buckets.length === 0) return []
+
+	const now = input.now ?? new Date().toISOString()
+	const bucketIds = input.buckets.map((bucket) => bucket.id)
+	const inPlaceholders = bucketIds.map(() => '?').join(', ')
+	const bucketOrderCase = bucketIds
+		.map((_bucketId, index) => `WHEN ? THEN ${index}`)
+		.join(' ')
+
+	const { results } = await input.db
+		.prepare(
+			`SELECT b.scope AS scope, b.binding_key AS binding_key,
+				e.name AS name, e.description AS description, e.value AS value,
+				e.created_at AS created_at, e.updated_at AS updated_at,
+				b.expires_at AS expires_at
+			FROM value_entries e
+			INNER JOIN value_buckets b ON b.id = e.bucket_id
+			WHERE b.user_id = ? AND b.id IN (${inPlaceholders})
+				AND (b.expires_at IS NULL OR b.expires_at > ?)
+			ORDER BY CASE b.id ${bucketOrderCase} END, e.name ASC`,
+		)
+		.bind(input.userId, ...bucketIds, now, ...bucketIds)
+		.all<Record<string, unknown>>()
+	return (results ?? []).map(mapValueMetadataRow)
+}
+
 export async function deleteValueBucketByBinding(input: {
 	db: D1Database
 	userId: string

--- a/packages/worker/src/mcp/values/service.node.test.ts
+++ b/packages/worker/src/mcp/values/service.node.test.ts
@@ -11,6 +11,7 @@ import { type ValueBucketRow, type ValueEntryRow } from './types.ts'
 function createValueTestDb() {
 	const buckets = new Map<string, ValueBucketRow>()
 	const entries = new Map<string, ValueEntryRow>()
+	let listMetadataQueryCount = 0
 
 	function getBucketKey(userId: string, scope: string, bindingKey: string) {
 		return `${userId}:${scope}:${bindingKey}`
@@ -18,6 +19,54 @@ function createValueTestDb() {
 
 	function getEntryKey(bucketId: string, name: string) {
 		return `${bucketId}:${name}`
+	}
+
+	function getBucketById(bucketId: string) {
+		for (const bucket of buckets.values()) {
+			if (bucket.id === bucketId) return bucket
+		}
+		return null
+	}
+
+	function listMetadataRowsFromBuckets(input: {
+		userId: string
+		bucketIds: Array<string>
+		now: string
+	}) {
+		const bucketOrder = new Map(
+			input.bucketIds.map((bucketId, index) => [bucketId, index]),
+		)
+		const results = Array.from(entries.values())
+			.map((entry) => {
+				const bucket = getBucketById(entry.bucket_id)
+				if (!bucket) return null
+				if (bucket.user_id !== input.userId) return null
+				if (!bucketOrder.has(bucket.id)) return null
+				if (bucket.expires_at != null && bucket.expires_at <= input.now) {
+					return null
+				}
+				return {
+					scope: bucket.scope,
+					binding_key: bucket.binding_key,
+					name: entry.name,
+					description: entry.description,
+					value: entry.value,
+					created_at: entry.created_at,
+					updated_at: entry.updated_at,
+					expires_at: bucket.expires_at,
+					bucketId: bucket.id,
+				}
+			})
+			.filter((row): row is NonNullable<typeof row> => row != null)
+			.sort((left, right) => {
+				const orderDiff =
+					(bucketOrder.get(left.bucketId) ?? 0) -
+					(bucketOrder.get(right.bucketId) ?? 0)
+				if (orderDiff !== 0) return orderDiff
+				return left.name.localeCompare(right.name)
+			})
+			.map(({ bucketId: _bucketId, ...row }) => row)
+		return results
 	}
 
 	const db = {
@@ -55,26 +104,44 @@ function createValueTestDb() {
 						},
 						async all<T>() {
 							if (
+								normalizedQuery.includes('from value_entries e') &&
+								normalizedQuery.includes('inner join value_buckets b')
+							) {
+								listMetadataQueryCount += 1
+								const bucketIdCount = (params.length - 2) / 2
+								const bucketIds = params.slice(
+									1,
+									1 + bucketIdCount,
+								) as Array<string>
+								const now = params[1 + bucketIdCount] as string
+								const results = listMetadataRowsFromBuckets({
+									userId: String(params[0]),
+									bucketIds,
+									now,
+								})
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
 								normalizedQuery.startsWith(
 									'select ? as scope, ? as binding_key',
 								) &&
 								normalizedQuery.includes('from value_entries')
 							) {
+								listMetadataQueryCount += 1
 								const [scope, bindingKey, expiresAt, bucketId] =
 									params as Array<string | null>
-								const results = Array.from(entries.values())
-									.filter((entry) => entry.bucket_id === bucketId)
-									.sort((left, right) => left.name.localeCompare(right.name))
-									.map((entry) => ({
-										scope,
-										binding_key: bindingKey,
-										name: entry.name,
-										description: entry.description,
-										value: entry.value,
-										created_at: entry.created_at,
-										updated_at: entry.updated_at,
-										expires_at: expiresAt,
-									}))
+								const results = listMetadataRowsFromBuckets({
+									userId:
+										getBucketById(String(bucketId))?.user_id ?? 'unknown-user',
+									bucketIds: [String(bucketId)],
+									now:
+										expiresAt == null ? new Date(0).toISOString() : expiresAt,
+								}).map((row) => ({
+									...row,
+									scope,
+									binding_key: bindingKey,
+									expires_at: expiresAt,
+								}))
 								return { results: results as Array<T>, meta: { changes: 0 } }
 							}
 							return { results: [] as Array<T>, meta: { changes: 0 } }
@@ -160,7 +227,14 @@ function createValueTestDb() {
 		},
 	} as unknown as D1Database
 
-	return { db, buckets, entries }
+	return {
+		db,
+		buckets,
+		entries,
+		get listMetadataQueryCount() {
+			return listMetadataQueryCount
+		},
+	}
 }
 
 test('value service respects storage context precedence and deletion', async () => {
@@ -338,4 +412,118 @@ test('deleteAllAppScopedValues removes all app-scoped values for one app', async
 	).resolves.toMatchObject({
 		value: 'app-two',
 	})
+})
+
+test('listValues uses one metadata query across buckets and preserves ordering', async () => {
+	const testDb = createValueTestDb()
+	const env = { APP_DB: testDb.db }
+	const storageContext = {
+		sessionId: 'session-456',
+		appId: 'app-456',
+	}
+
+	await saveValue({
+		env,
+		userId: 'user-456',
+		scope: 'user',
+		name: 'zebra',
+		value: 'user-zebra',
+	})
+	await saveValue({
+		env,
+		userId: 'user-456',
+		scope: 'user',
+		name: 'alpha',
+		value: 'user-alpha',
+	})
+	await saveValue({
+		env,
+		userId: 'user-456',
+		scope: 'app',
+		name: 'beta',
+		value: 'app-beta',
+		storageContext,
+	})
+	await saveValue({
+		env,
+		userId: 'user-456',
+		scope: 'session',
+		name: 'gamma',
+		value: 'session-gamma',
+		storageContext,
+		sessionExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+	})
+
+	const metadataQueriesBefore = testDb.listMetadataQueryCount
+	const listed = await listValues({
+		env,
+		userId: 'user-456',
+		storageContext,
+	})
+
+	expect(testDb.listMetadataQueryCount - metadataQueriesBefore).toBe(1)
+	expect(
+		listed.map((value) => `${value.scope}:${value.name}:${value.value}`),
+	).toEqual([
+		'session:gamma:session-gamma',
+		'app:beta:app-beta',
+		'user:alpha:user-alpha',
+		'user:zebra:user-zebra',
+	])
+})
+
+test('listValues ignores empty buckets and returns no values when none exist', async () => {
+	const testDb = createValueTestDb()
+	const env = { APP_DB: testDb.db }
+	const storageContext = {
+		sessionId: 'session-empty',
+		appId: 'app-empty',
+	}
+
+	await saveValue({
+		env,
+		userId: 'user-empty',
+		scope: 'session',
+		name: 'onlySessionValue',
+		value: 'present',
+		storageContext,
+		sessionExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+	})
+	await saveValue({
+		env,
+		userId: 'user-empty',
+		scope: 'app',
+		name: 'temporary',
+		value: 'gone',
+		storageContext,
+	})
+	await deleteValue({
+		env,
+		userId: 'user-empty',
+		name: 'temporary',
+		scope: 'app',
+		storageContext,
+	})
+
+	expect(
+		await listValues({
+			env,
+			userId: 'user-empty',
+			storageContext,
+		}),
+	).toEqual([
+		expect.objectContaining({
+			scope: 'session',
+			name: 'onlySessionValue',
+			value: 'present',
+		}),
+	])
+
+	expect(
+		await listValues({
+			env,
+			userId: 'user-missing',
+			storageContext,
+		}),
+	).toEqual([])
 })

--- a/packages/worker/src/mcp/values/service.ts
+++ b/packages/worker/src/mcp/values/service.ts
@@ -8,7 +8,7 @@ import {
 	deleteValueEntry,
 	getValueBucket,
 	getValueEntry,
-	listValueMetadataForBucket,
+	listValueMetadataForBuckets,
 	upsertValueBucket,
 	upsertValueEntry,
 } from './repo.ts'
@@ -102,15 +102,12 @@ export async function listValues(
 		scope: input.scope ?? null,
 		storageContext: input.storageContext ?? null,
 	})
-	const results = await Promise.all(
-		buckets.map((bucket) =>
-			listValueMetadataForBucket({
-				db: input.env.APP_DB,
-				bucket,
-			}),
-		),
-	)
-	return results.flat().map((row) =>
+	const rows = await listValueMetadataForBuckets({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		buckets,
+	})
+	return rows.map((row) =>
 		toValueMetadata({
 			name: row.name,
 			scope: row.scope,

--- a/packages/worker/src/package-registry/source.ts
+++ b/packages/worker/src/package-registry/source.ts
@@ -125,6 +125,7 @@ async function loadPackageSourceUncached(input: {
 		env: input.env,
 		userId: input.userId,
 		sourceId: input.source.id,
+		source: input.source,
 	})
 	return finalizeLoadedSource({
 		source: input.source,
@@ -200,6 +201,7 @@ export async function loadPackageManifestBySourceId(input: {
 			env: input.env,
 			userId: input.userId,
 			sourceId: source.id,
+			source,
 		})
 		return Object.freeze({
 			source,
@@ -220,6 +222,7 @@ export async function loadPackageManifestBySourceId(input: {
 				env: input.env,
 				userId: input.userId,
 				sourceId: source.id,
+				source,
 			})
 			return Object.freeze({
 				source,

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -172,6 +172,190 @@ function createLoadedPackageSource() {
 	}
 }
 
+test('hydrateKodyRuntimeModules resolves duplicate dynamic specifiers once per pass', async () => {
+	const createDynamicPlaceholder = (specifier: string) =>
+		`export const __kodyDynamicPackageSpecifier = ${JSON.stringify(specifier)};
+throw new Error('unhydrated ${specifier}');
+`
+	const artifact = {
+		version: 1,
+		kind: 'importable-module' as const,
+		artifactName: './value',
+		sourceId: 'source-1',
+		publishedCommit: 'commit-1',
+		entryPoint: './value.js',
+		mainModule: 'value.js',
+		modules: {
+			'value.js': 'export default function value() { return "resolved" }',
+		},
+		dependencies: [],
+		dynamicDependencies: [],
+		packageContext: null,
+		serviceContext: null,
+		createdAt: '2026-05-11T00:00:00.000Z',
+	}
+	mockModule.getSavedPackageByName.mockResolvedValue(createSavedPackageRecord())
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		...createLoadedPackageSource(),
+		manifest: {
+			...createLoadedPackageSource().manifest,
+			exports: {
+				'./value': './value.js',
+			},
+		},
+		files: {
+			'value.js': 'export default function value() { return "resolved" }',
+		},
+	})
+	mockModule.loadPublishedBundleArtifactByIdentity.mockResolvedValue({
+		row: {},
+		artifact,
+	})
+
+	const specifier = 'kody:@kentcdodds/example-package/value'
+	const hydratedModules = await hydrateKodyRuntimeModules({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		modules: {
+			'entry-a.js': `export default async function runA() {
+	const module = await import('./.__kody_virtual__/dynamic-imports/a.js')
+	return module.default
+}
+`,
+			'entry-b.js': `export default async function runB() {
+	const module = await import('./.__kody_virtual__/dynamic-imports/b.js')
+	return module.default
+}
+`,
+			'.__kody_virtual__/dynamic-imports/a.js':
+				createDynamicPlaceholder(specifier),
+			'.__kody_virtual__/dynamic-imports/b.js':
+				createDynamicPlaceholder(specifier),
+		},
+	})
+
+	expect(
+		mockModule.loadPublishedBundleArtifactByIdentity,
+	).toHaveBeenCalledTimes(1)
+	expect(hydratedModules['.__kody_virtual__/dynamic-imports/a.js']).toContain(
+		'__kodyDynamicPackageResolved',
+	)
+	expect(hydratedModules['.__kody_virtual__/dynamic-imports/b.js']).toContain(
+		'__kodyDynamicPackageResolved',
+	)
+})
+
+test('buildKodyModuleBundle keeps deterministic dependency ordering after parallel resolution', async () => {
+	mockModule.createWorker.mockResolvedValue(createBundleResult('ordered-deps'))
+	mockModule.getSavedPackageByName.mockImplementation(
+		async (
+			_db: unknown,
+			input: {
+				name: string
+			},
+		) => {
+			if (input.name === '@kentcdodds/zebra-package') {
+				return createSavedPackageRecord({
+					name: '@kentcdodds/zebra-package',
+					kodyId: 'zebra-package',
+					sourceId: 'source-zebra',
+				})
+			}
+			if (input.name === '@kentcdodds/alpha-package') {
+				return createSavedPackageRecord({
+					name: '@kentcdodds/alpha-package',
+					kodyId: 'alpha-package',
+					sourceId: 'source-alpha',
+				})
+			}
+			return null
+		},
+	)
+	mockModule.loadPackageSourceBySourceId.mockImplementation(
+		async (input: { sourceId: string }) => ({
+			...createLoadedPackageSource(),
+			source: {
+				id: input.sourceId,
+				published_commit: `commit-${input.sourceId}`,
+			},
+			manifest: {
+				name:
+					input.sourceId === 'source-zebra'
+						? '@kentcdodds/zebra-package'
+						: '@kentcdodds/alpha-package',
+				exports: {
+					'.': './index.js',
+				},
+				kody: {
+					id:
+						input.sourceId === 'source-zebra'
+							? 'zebra-package'
+							: 'alpha-package',
+					description: 'Dependency package',
+				},
+			},
+			files: {
+				'index.js': 'export default async function run() { return "ok" }',
+			},
+		}),
+	)
+
+	const { buildKodyModuleBundle } = await import('./module-graph.ts')
+
+	const result = await buildKodyModuleBundle({
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		sourceFiles: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/local-package',
+				exports: {
+					'.': './index.js',
+				},
+				kody: {
+					id: 'local-package',
+					description: 'Local package',
+				},
+			}),
+			'index.js': [
+				'import zebra from "kody:@kentcdodds/zebra-package"',
+				'import alpha from "kody:@kentcdodds/alpha-package"',
+				'export default [zebra, alpha]',
+			].join('\n'),
+		},
+		entryPoint: 'index.js',
+	})
+
+	expect(result.dependencies).toEqual([
+		{
+			sourceId: 'source-alpha',
+			publishedCommit: 'commit-source-alpha',
+			kodyId: 'alpha-package',
+			packageName: '@kentcdodds/alpha-package',
+		},
+		{
+			sourceId: 'source-zebra',
+			publishedCommit: 'commit-source-zebra',
+			kodyId: 'zebra-package',
+			packageName: '@kentcdodds/zebra-package',
+		},
+	])
+})
+
+test('createRuntimeModuleSource returns a stable memoized string', () => {
+	const first = createRuntimeModuleSource()
+	const second = createRuntimeModuleSource()
+	expect(first).toBe(second)
+	expect(first).toContain('__kodyCreateRuntimeObjectProxy')
+})
+
 test('buildKodyAppBundle cache lifecycle reuses hits, shares in-flight builds, evicts failures, and keys by entrypoint', async () => {
 	mockModule.createWorker.mockReset()
 	mockModule.createWorker.mockResolvedValue(createBundleResult('warm-cache'))

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -57,6 +57,7 @@ const dynamicPackageImportSpecifierExportName = '__kodyDynamicPackageSpecifier'
 const dynamicPackageImportResolvedMarker = '__kodyDynamicPackageResolved'
 const packageAppBundleCache =
 	createPublishedPackagePromiseCache<RuntimeBundle>()
+let cachedRuntimeModuleSource: string | null = null
 
 async function createWorkerBundle(input: {
 	files: Record<string, string>
@@ -143,6 +144,9 @@ function resolveRelativeModulePath(fromPath: string, specifier: string) {
 }
 
 export function createRuntimeModuleSource() {
+	if (cachedRuntimeModuleSource) {
+		return cachedRuntimeModuleSource
+	}
 	// The runtime context for a single execute-call / package-app fetch is
 	// kept in AsyncLocalStorage rather than a single mutable globalThis slot.
 	// AsyncLocalStorage propagates through async chains so concurrent calls
@@ -170,7 +174,7 @@ export function createRuntimeModuleSource() {
 	// late-bound proxy so named imports like \`import { codemode } from
 	// 'kody:runtime'\` still resolve against the current AsyncLocalStorage
 	// store at call time instead of freezing as undefined.
-	return `
+	const source = `
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 const __kodyRuntimeStorageSymbol = Symbol.for('kody.runtimeStorage');
@@ -285,6 +289,8 @@ export default
 		? { ...runtime, codemode: __kodyCodemode }
 		: runtime;
 `.trim()
+	cachedRuntimeModuleSource = source
+	return source
 }
 
 function isRuntimeModulePath(modulePath: string) {
@@ -698,44 +704,46 @@ async function resolveDirectKodyDependenciesForEntryPoint(input: {
 		if (imported.packageName === rootPackage?.manifest.name) continue
 		importedPackages.set(imported.packageName, imported.specifier)
 	}
-	const dependencies: Array<BundleArtifactDependency> = []
-	for (const specifier of [...importedPackages.values()].sort((left, right) =>
+	const sortedSpecifiers = [...importedPackages.values()].sort((left, right) =>
 		left.localeCompare(right),
-	)) {
-		const parsed = parseKodyPackageSpecifier(specifier)
-		const cached = input.loadedPackages?.get(parsed.packageName)
-		const row =
-			cached?.row ??
-			(await resolveSavedPackageImport({
-				db: input.env.APP_DB,
-				userId: input.userId,
-				specifier: parsed,
-			}))
-		if (!row) {
-			throw new Error(
-				`Saved package "${parsed.packageName}" was not found for this user.`,
-			)
-		}
-		const loaded =
-			cached ??
-			(await loadPackageSourceBySourceId({
-				env: input.env,
-				baseUrl: input.baseUrl,
-				userId: input.userId,
-				sourceId: row.sourceId,
-			}))
-		if (!loaded.source.published_commit) {
-			throw new Error(
-				`Saved package "${row.name}" source "${row.sourceId}" has no published commit.`,
-			)
-		}
-		dependencies.push({
-			sourceId: loaded.source.id,
-			publishedCommit: loaded.source.published_commit,
-			kodyId: row.kodyId,
-			packageName: row.name,
-		})
-	}
+	)
+	const dependencies = await Promise.all(
+		sortedSpecifiers.map(async (specifier) => {
+			const parsed = parseKodyPackageSpecifier(specifier)
+			const cached = input.loadedPackages?.get(parsed.packageName)
+			const row =
+				cached?.row ??
+				(await resolveSavedPackageImport({
+					db: input.env.APP_DB,
+					userId: input.userId,
+					specifier: parsed,
+				}))
+			if (!row) {
+				throw new Error(
+					`Saved package "${parsed.packageName}" was not found for this user.`,
+				)
+			}
+			const loaded =
+				cached ??
+				(await loadPackageSourceBySourceId({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					userId: input.userId,
+					sourceId: row.sourceId,
+				}))
+			if (!loaded.source.published_commit) {
+				throw new Error(
+					`Saved package "${row.name}" source "${row.sourceId}" has no published commit.`,
+				)
+			}
+			return {
+				sourceId: loaded.source.id,
+				publishedCommit: loaded.source.published_commit,
+				kodyId: row.kodyId,
+				packageName: row.name,
+			}
+		}),
+	)
 	return dependencies.sort(
 		(left, right) =>
 			left.kodyId.localeCompare(right.kodyId) ||
@@ -1120,24 +1128,35 @@ export async function hydrateKodyRuntimeModules(input: {
 	>()
 	while (true) {
 		let installedDynamicImport = false
-		for (const entry of collectDynamicPackageImportsFromModules(modules)) {
-			let resolved = resolvedArtifacts.get(entry.specifier)
-			if (!resolved) {
+		const dynamicImportEntries =
+			collectDynamicPackageImportsFromModules(modules)
+		const unresolvedSpecifiers = [
+			...new Set(
+				dynamicImportEntries
+					.map((entry) => entry.specifier)
+					.filter((specifier) => !resolvedArtifacts.has(specifier)),
+			),
+		]
+		await Promise.all(
+			unresolvedSpecifiers.map(async (specifier) => {
 				const artifact = await resolveCurrentDynamicPackageArtifact({
 					env: input.env,
 					baseUrl: input.baseUrl,
 					userId: input.userId,
-					specifier: entry.specifier,
+					specifier,
 				})
-				resolved = {
+				resolvedArtifacts.set(specifier, {
 					artifactKey: createDynamicPackageImportArtifactKey({
-						specifier: entry.specifier,
+						specifier,
 						artifact,
 					}),
 					artifact,
-				}
-				resolvedArtifacts.set(entry.specifier, resolved)
-			}
+				})
+			}),
+		)
+		for (const entry of dynamicImportEntries) {
+			const resolved = resolvedArtifacts.get(entry.specifier)
+			if (!resolved) continue
 			const existingArtifactMainModule =
 				resolved.installedArtifactMainModule ??
 				installedArtifacts.get(resolved.artifactKey)

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -227,6 +227,9 @@ function createPackageAppTestEnv() {
 				load: vi.fn(() => ({
 					getEntrypoint,
 				})),
+				get: vi.fn(() => ({
+					getEntrypoint,
+				})),
 			},
 		} as unknown as Env,
 		getEntrypoint,
@@ -312,6 +315,74 @@ test('buildPackageAppWorker loads published app artifacts with artifactName null
 	expect(
 		packageAppRuntimeMock.persistPublishedBundleArtifact,
 	).not.toHaveBeenCalled()
+})
+
+test('buildPackageAppWorker acquires a fresh stub per request while reusing the built worker options', async () => {
+	resetPackageAppRuntimeMocks()
+	const { env } = createPackageAppTestEnv()
+	packageAppRuntimeMock.loadPublishedBundleArtifactByIdentity.mockResolvedValue(
+		{
+			row: {
+				id: 'artifact-row-1',
+				artifactName: null,
+				entryPoint: 'app.js',
+			},
+			artifact: {
+				mainModule: 'dist/app.js',
+				modules: {
+					'dist/app.js':
+						'export default { fetch() { return new Response("cached") } }',
+				},
+				dependencies: [],
+				dynamicDependencies: [],
+			},
+		},
+	)
+
+	const buildInput = {
+		env,
+		baseUrl: 'https://example.com',
+		userId: 'user-stub-reuse',
+		savedPackage: {
+			id: 'package-stub-reuse',
+			kodyId: 'example-stub-reuse',
+			name: '@kody/example-stub-reuse',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			manifestPath: 'package.json',
+			sourceRoot: '/',
+		},
+		source: createPackageAppTestSource(),
+		manifest: createPackageAppTestManifest(),
+		runtime: {
+			callerContext: {
+				user: {
+					userId: 'user-stub-reuse',
+					email: 'stub-reuse@example.com',
+					displayName: 'Stub Reuse User',
+				},
+			},
+		} as never,
+	}
+
+	await buildPackageAppWorker(buildInput)
+	await buildPackageAppWorker(buildInput)
+
+	const loader = env.APP_LOADER as unknown as {
+		get: ReturnType<typeof vi.fn>
+		load: ReturnType<typeof vi.fn>
+	}
+	// The expensive build (artifact lookup + hydration) runs once; each request
+	// still re-acquires a request-bound stub with the same stable worker id.
+	expect(
+		packageAppRuntimeMock.loadPublishedBundleArtifactByIdentity,
+	).toHaveBeenCalledTimes(1)
+	expect(loader.get).toHaveBeenCalledTimes(2)
+	expect(loader.load).not.toHaveBeenCalled()
+	const [firstWorkerId] = loader.get.mock.calls[0] as [string]
+	const [secondWorkerId] = loader.get.mock.calls[1] as [string]
+	expect(firstWorkerId).toBe(secondWorkerId)
+	expect(firstWorkerId).toMatch(/^package-app-/)
 })
 
 test('buildPackageAppWorker persists rebuilt app artifacts with artifactName null', async () => {

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 
 async function extractCreatePackageAppWorkerSource() {
 	const sourceText = await readFile(
@@ -123,4 +123,314 @@ test('package app workflows proxy forwards validated input to runtime bridge', a
 		idempotencyKey: 'event-key',
 		params: { eventId: 'event-1' },
 	})
+})
+
+const packageAppRuntimeMock = vi.hoisted(() => ({
+	buildKodyAppBundle: vi.fn(),
+	hydrateKodyRuntimeModules: vi.fn(),
+	loadPublishedBundleArtifactByIdentity: vi.fn(),
+	persistPublishedBundleArtifact: vi.fn(),
+	assertPublishedSourceCanRebuildWithoutInstallingDeps: vi.fn(),
+	getEntitySourceById: vi.fn(),
+	packageAppRuntimeBridge: vi.fn((input: unknown) => input),
+}))
+
+vi.mock('cloudflare:workers', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('cloudflare:workers')>()
+	return {
+		...actual,
+		exports: {
+			...actual.exports,
+			PackageAppRuntimeBridge: packageAppRuntimeMock.packageAppRuntimeBridge,
+		},
+	}
+})
+
+vi.mock('./module-graph.ts', async () => {
+	const actual =
+		await vi.importActual<typeof import('./module-graph.ts')>(
+			'./module-graph.ts',
+		)
+	return {
+		...actual,
+		buildKodyAppBundle: (...args: Array<unknown>) =>
+			packageAppRuntimeMock.buildKodyAppBundle(...args),
+		hydrateKodyRuntimeModules: (...args: Array<unknown>) =>
+			packageAppRuntimeMock.hydrateKodyRuntimeModules(...args),
+	}
+})
+
+vi.mock('./published-bundle-artifacts.ts', async () => {
+	const actual = await vi.importActual<
+		typeof import('./published-bundle-artifacts.ts')
+	>('./published-bundle-artifacts.ts')
+	return {
+		...actual,
+		loadPublishedBundleArtifactByIdentity: (...args: Array<unknown>) =>
+			packageAppRuntimeMock.loadPublishedBundleArtifactByIdentity(...args),
+		persistPublishedBundleArtifact: (...args: Array<unknown>) =>
+			packageAppRuntimeMock.persistPublishedBundleArtifact(...args),
+	}
+})
+
+vi.mock('./published-source-dependencies.ts', () => ({
+	assertPublishedSourceCanRebuildWithoutInstallingDeps: (
+		...args: Array<unknown>
+	) =>
+		packageAppRuntimeMock.assertPublishedSourceCanRebuildWithoutInstallingDeps(
+			...args,
+		),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		packageAppRuntimeMock.getEntitySourceById(...args),
+}))
+
+function createPackageAppTestSource() {
+	return {
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package' as const,
+		entity_id: 'package-1',
+		repo_id: 'repo-1',
+		published_commit: 'commit-1',
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		created_at: '2026-04-30T00:00:00.000Z',
+		updated_at: '2026-04-30T00:00:00.000Z',
+	}
+}
+
+function createPackageAppTestManifest() {
+	return {
+		name: '@kody/example',
+		kody: {
+			id: 'example',
+			description: 'Example package',
+			app: {
+				entry: 'app.js',
+			},
+		},
+	}
+}
+
+function createPackageAppTestEnv() {
+	const getEntrypoint = vi.fn(() => ({
+		fetch: vi.fn(async () => new Response('ok')),
+	}))
+	return {
+		env: {
+			APP_DB: {},
+			APP_LOADER: {
+				load: vi.fn(() => ({
+					getEntrypoint,
+				})),
+			},
+		} as unknown as Env,
+		getEntrypoint,
+	}
+}
+
+function resetPackageAppRuntimeMocks() {
+	packageAppRuntimeMock.buildKodyAppBundle.mockReset()
+	packageAppRuntimeMock.hydrateKodyRuntimeModules.mockReset()
+	packageAppRuntimeMock.loadPublishedBundleArtifactByIdentity.mockReset()
+	packageAppRuntimeMock.persistPublishedBundleArtifact.mockReset()
+	packageAppRuntimeMock.assertPublishedSourceCanRebuildWithoutInstallingDeps.mockReset()
+	packageAppRuntimeMock.getEntitySourceById.mockReset()
+	packageAppRuntimeMock.hydrateKodyRuntimeModules.mockImplementation(
+		async ({ modules }: { modules: Record<string, string> }) => modules,
+	)
+}
+
+const { buildPackageAppWorker } = await import('./package-app.ts')
+
+test('buildPackageAppWorker loads published app artifacts with artifactName null', async () => {
+	resetPackageAppRuntimeMocks()
+	const { env } = createPackageAppTestEnv()
+	packageAppRuntimeMock.loadPublishedBundleArtifactByIdentity.mockResolvedValue(
+		{
+			row: {
+				id: 'artifact-row-1',
+				artifactName: null,
+				entryPoint: 'app.js',
+			},
+			artifact: {
+				mainModule: 'dist/app.js',
+				modules: {
+					'dist/app.js':
+						'export default { fetch() { return new Response("cached") } }',
+				},
+				dependencies: [],
+				dynamicDependencies: [],
+			},
+		},
+	)
+
+	await buildPackageAppWorker({
+		env,
+		baseUrl: 'https://example.com',
+		userId: 'user-artifact-hit',
+		savedPackage: {
+			id: 'package-artifact-hit',
+			kodyId: 'example-hit',
+			name: '@kody/example-hit',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			manifestPath: 'package.json',
+			sourceRoot: '/',
+		},
+		source: createPackageAppTestSource(),
+		manifest: createPackageAppTestManifest(),
+		loadSourceFiles: async () => {
+			throw new Error('full source load should be skipped on artifact hit')
+		},
+		runtime: {
+			callerContext: {
+				user: {
+					userId: 'user-artifact-hit',
+					email: 'artifact-hit@example.com',
+					displayName: 'Artifact Hit User',
+				},
+			},
+		} as never,
+	})
+
+	expect(
+		packageAppRuntimeMock.loadPublishedBundleArtifactByIdentity,
+	).toHaveBeenCalledWith({
+		env,
+		userId: 'user-artifact-hit',
+		sourceId: 'source-1',
+		kind: 'app',
+		artifactName: null,
+		entryPoint: 'app.js',
+	})
+	expect(packageAppRuntimeMock.buildKodyAppBundle).not.toHaveBeenCalled()
+	expect(
+		packageAppRuntimeMock.persistPublishedBundleArtifact,
+	).not.toHaveBeenCalled()
+})
+
+test('buildPackageAppWorker persists rebuilt app artifacts with artifactName null', async () => {
+	resetPackageAppRuntimeMocks()
+	const { env } = createPackageAppTestEnv()
+	const source = createPackageAppTestSource()
+	packageAppRuntimeMock.loadPublishedBundleArtifactByIdentity.mockResolvedValue(
+		null,
+	)
+	packageAppRuntimeMock.buildKodyAppBundle.mockResolvedValue({
+		mainModule: 'dist/app.js',
+		modules: {
+			'dist/app.js':
+				'export default { fetch() { return new Response("fresh") } }',
+		},
+		dependencies: [],
+		dynamicDependencies: [],
+	})
+	packageAppRuntimeMock.persistPublishedBundleArtifact.mockResolvedValue(
+		'bundle-artifact:v1:source-1:commit-1:app:_:app.js',
+	)
+
+	await buildPackageAppWorker({
+		env,
+		baseUrl: 'https://example.com',
+		userId: 'user-persist-miss',
+		savedPackage: {
+			id: 'package-persist-miss',
+			kodyId: 'example-miss',
+			name: '@kody/example-miss',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			manifestPath: 'package.json',
+			sourceRoot: '/',
+		},
+		source,
+		manifest: createPackageAppTestManifest(),
+		loadSourceFiles: async () => ({
+			'package.json': JSON.stringify(createPackageAppTestManifest()),
+			'app.js':
+				'export default { async fetch() { return new Response("ok") } }',
+		}),
+		runtime: {
+			callerContext: {
+				user: {
+					userId: 'user-persist-miss',
+					email: 'persist-miss@example.com',
+					displayName: 'Persist Miss User',
+				},
+			},
+		} as never,
+	})
+
+	expect(packageAppRuntimeMock.buildKodyAppBundle).toHaveBeenCalledTimes(1)
+	expect(
+		packageAppRuntimeMock.persistPublishedBundleArtifact,
+	).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-persist-miss',
+			source,
+			kind: 'app',
+			artifactName: null,
+			entryPoint: 'app.js',
+		}),
+	)
+})
+
+test('buildPackageAppWorker skips published artifact lookup when publishedCommit is null', async () => {
+	resetPackageAppRuntimeMocks()
+	const { env } = createPackageAppTestEnv()
+	const source = {
+		...createPackageAppTestSource(),
+		published_commit: null,
+	}
+	packageAppRuntimeMock.buildKodyAppBundle.mockResolvedValue({
+		mainModule: 'dist/app.js',
+		modules: {
+			'dist/app.js':
+				'export default { fetch() { return new Response("draft") } }',
+		},
+		dependencies: [],
+	})
+
+	await buildPackageAppWorker({
+		env,
+		baseUrl: 'https://example.com',
+		userId: 'user-unpublished',
+		savedPackage: {
+			id: 'package-unpublished',
+			kodyId: 'example-draft',
+			name: '@kody/example-draft',
+			sourceId: 'source-1',
+			publishedCommit: null,
+			manifestPath: 'package.json',
+			sourceRoot: '/',
+		},
+		source,
+		manifest: createPackageAppTestManifest(),
+		loadSourceFiles: async () => ({
+			'package.json': JSON.stringify(createPackageAppTestManifest()),
+			'app.js':
+				'export default { async fetch() { return new Response("ok") } }',
+		}),
+		runtime: {
+			callerContext: {
+				user: {
+					userId: 'user-unpublished',
+					email: 'unpublished@example.com',
+					displayName: 'Unpublished User',
+				},
+			},
+		} as never,
+	})
+
+	expect(
+		packageAppRuntimeMock.loadPublishedBundleArtifactByIdentity,
+	).not.toHaveBeenCalled()
+	expect(
+		packageAppRuntimeMock.persistPublishedBundleArtifact,
+	).not.toHaveBeenCalled()
+	expect(packageAppRuntimeMock.buildKodyAppBundle).toHaveBeenCalledTimes(1)
 })

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -408,7 +408,7 @@ test('buildPackageAppWorker persists rebuilt app artifacts with artifactName nul
 	await buildPackageAppWorker({
 		env,
 		baseUrl: 'https://example.com',
-		userId: 'user-persist-miss',
+		userId: 'user-1',
 		savedPackage: {
 			id: 'package-persist-miss',
 			kodyId: 'example-miss',
@@ -428,7 +428,7 @@ test('buildPackageAppWorker persists rebuilt app artifacts with artifactName nul
 		runtime: {
 			callerContext: {
 				user: {
-					userId: 'user-persist-miss',
+					userId: 'user-1',
 					email: 'persist-miss@example.com',
 					displayName: 'Persist Miss User',
 				},
@@ -436,18 +436,78 @@ test('buildPackageAppWorker persists rebuilt app artifacts with artifactName nul
 		} as never,
 	})
 
+	expect(packageAppRuntimeMock.getEntitySourceById).not.toHaveBeenCalled()
 	expect(packageAppRuntimeMock.buildKodyAppBundle).toHaveBeenCalledTimes(1)
 	expect(
 		packageAppRuntimeMock.persistPublishedBundleArtifact,
 	).toHaveBeenCalledWith(
 		expect.objectContaining({
-			userId: 'user-persist-miss',
+			userId: 'user-1',
 			source,
 			kind: 'app',
 			artifactName: null,
 			entryPoint: 'app.js',
 		}),
 	)
+})
+
+test('buildPackageAppWorker rejects persisting artifacts for a source owned by another user', async () => {
+	resetPackageAppRuntimeMocks()
+	const { env } = createPackageAppTestEnv()
+	const source = createPackageAppTestSource()
+	packageAppRuntimeMock.loadPublishedBundleArtifactByIdentity.mockResolvedValue(
+		null,
+	)
+	packageAppRuntimeMock.buildKodyAppBundle.mockResolvedValue({
+		mainModule: 'dist/app.js',
+		modules: {
+			'dist/app.js':
+				'export default { fetch() { return new Response("fresh") } }',
+		},
+		dependencies: [],
+		dynamicDependencies: [],
+	})
+	// The pre-resolved source belongs to user-1, so the fast path must be
+	// skipped and the DB lookup (which finds nothing for this user) must fail.
+	packageAppRuntimeMock.getEntitySourceById.mockResolvedValue(null)
+
+	await expect(
+		buildPackageAppWorker({
+			env,
+			baseUrl: 'https://example.com',
+			userId: 'user-other',
+			savedPackage: {
+				id: 'package-other',
+				kodyId: 'example-other',
+				name: '@kody/example-other',
+				sourceId: 'source-1',
+				publishedCommit: 'commit-1',
+				manifestPath: 'package.json',
+				sourceRoot: '/',
+			},
+			source,
+			manifest: createPackageAppTestManifest(),
+			loadSourceFiles: async () => ({
+				'package.json': JSON.stringify(createPackageAppTestManifest()),
+				'app.js':
+					'export default { async fetch() { return new Response("ok") } }',
+			}),
+			runtime: {
+				callerContext: {
+					user: {
+						userId: 'user-other',
+						email: 'other@example.com',
+						displayName: 'Other User',
+					},
+				},
+			} as never,
+		}),
+	).rejects.toThrow('Saved package source "source-1" was not found.')
+
+	expect(packageAppRuntimeMock.getEntitySourceById).toHaveBeenCalledTimes(1)
+	expect(
+		packageAppRuntimeMock.persistPublishedBundleArtifact,
+	).not.toHaveBeenCalled()
 })
 
 test('buildPackageAppWorker skips published artifact lookup when publishedCommit is null', async () => {

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -1181,7 +1181,7 @@ async function resolvePersistablePackageSource(input: {
 	source?: EntitySourceRow
 	sourceId: string
 }) {
-	if (input.source?.user_id && input.source.repo_id) {
+	if (input.source?.user_id === input.userId && input.source.repo_id) {
 		return input.source
 	}
 	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -1082,12 +1082,51 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 	}
 }
 
-type PackageAppWorkerResult = {
-	stub: ReturnType<Env['APP_LOADER']['load']>
-	entrypointName: string
+type PackageAppWorkerOptions = Parameters<Env['APP_LOADER']['load']>[0]
+
+type PackageAppWorkerBuild = {
+	workerId: string | null
+	workerOptions: PackageAppWorkerOptions
 }
 
-const packageAppWorkerCache = new PromiseLruCache<PackageAppWorkerResult>()
+// Caches the built worker options (bundle lookup + hydration + wrapper), not
+// loader stubs: worker-loader stubs are bound to the request that created them
+// and must be re-acquired per request via APP_LOADER.get/load.
+const packageAppWorkerOptionsCache =
+	new PromiseLruCache<PackageAppWorkerBuild>()
+
+async function createPackageAppWorkerId(input: {
+	cacheKey: string
+	workerOptions: PackageAppWorkerOptions
+}) {
+	const moduleEntries = Object.entries(input.workerOptions.modules ?? {})
+	if (
+		moduleEntries.some(([, moduleValue]) => typeof moduleValue !== 'string')
+	) {
+		// Non-string modules cannot be hashed deterministically; fall back to
+		// one-off loads for those workers.
+		return null
+	}
+	const sortedModuleEntries = [...moduleEntries].sort(([left], [right]) =>
+		left.localeCompare(right),
+	)
+	const digest = await crypto.subtle.digest(
+		'SHA-256',
+		new TextEncoder().encode(
+			JSON.stringify([
+				'package-app-worker@v1',
+				input.cacheKey,
+				input.workerOptions.mainModule,
+				sortedModuleEntries,
+			]),
+		),
+	)
+	const hash = btoa(String.fromCharCode(...new Uint8Array(digest)))
+		.replaceAll('+', '-')
+		.replaceAll('/', '_')
+		.replaceAll('=', '')
+	return `package-app-${hash.slice(0, 43)}`
+}
 
 function createPackageAppWorkerCacheKey(input: {
 	userId: string
@@ -1271,7 +1310,7 @@ async function resolvePackageAppSourceFiles(input: {
 	return await input.loadSourceFiles()
 }
 
-async function buildPackageAppWorkerUncached(input: {
+async function buildPackageAppWorkerOptionsUncached(input: {
 	env: Env
 	baseUrl: string
 	userId: string
@@ -1291,7 +1330,7 @@ async function buildPackageAppWorkerUncached(input: {
 	runtime: {
 		callerContext: ReturnType<typeof createMcpCallerContext>
 	}
-}): Promise<PackageAppWorkerResult> {
+}): Promise<PackageAppWorkerOptions> {
 	const manifest = resolvePackageAppManifest({
 		manifest: input.manifest,
 		source: input.source,
@@ -1322,50 +1361,45 @@ async function buildPackageAppWorkerUncached(input: {
 		}),
 	}
 	return {
-		// The loader stub is cached per caller identity (see createPackageAppWorkerCacheKey)
-		// so request-scoped runtime bridge props are not shared across users.
-		stub: input.env.APP_LOADER.load({
-			compatibilityDate: '2026-04-13',
-			compatibilityFlags: ['nodejs_compat', 'global_fetch_strictly_public'],
-			mainModule,
-			modules,
-			env: {
-				[packageAppRuntimeBindingName]: workerExports.PackageAppRuntimeBridge({
-					props: {
-						baseUrl: input.baseUrl,
-						userId: input.userId,
-						email: input.runtime.callerContext.user?.email ?? '',
-						displayName:
-							input.runtime.callerContext.user?.displayName ??
-							`package:${input.savedPackage.id}`,
-						packageId: input.savedPackage.id,
-						kodyId: input.savedPackage.kodyId,
-						sourceId: input.savedPackage.sourceId,
-						publishedCommit: input.savedPackage.publishedCommit,
-					},
-				}),
-				__kodyPackageContext: {
+		compatibilityDate: '2026-04-13',
+		compatibilityFlags: ['nodejs_compat', 'global_fetch_strictly_public'],
+		mainModule,
+		modules,
+		env: {
+			[packageAppRuntimeBindingName]: workerExports.PackageAppRuntimeBridge({
+				props: {
+					baseUrl: input.baseUrl,
+					userId: input.userId,
+					email: input.runtime.callerContext.user?.email ?? '',
+					displayName:
+						input.runtime.callerContext.user?.displayName ??
+						`package:${input.savedPackage.id}`,
 					packageId: input.savedPackage.id,
 					kodyId: input.savedPackage.kodyId,
 					sourceId: input.savedPackage.sourceId,
 					publishedCommit: input.savedPackage.publishedCommit,
 				},
+			}),
+			__kodyPackageContext: {
+				packageId: input.savedPackage.id,
+				kodyId: input.savedPackage.kodyId,
+				sourceId: input.savedPackage.sourceId,
+				publishedCommit: input.savedPackage.publishedCommit,
 			},
-			globalOutbound: workerExports?.CodemodeFetchGateway
-				? workerExports.CodemodeFetchGateway({
-						props: {
-							baseUrl: input.baseUrl,
-							userId: input.userId,
-							storageContext: {
-								sessionId: null,
-								appId: input.savedPackage.id,
-								storageId: input.savedPackage.id,
-							},
+		},
+		globalOutbound: workerExports?.CodemodeFetchGateway
+			? workerExports.CodemodeFetchGateway({
+					props: {
+						baseUrl: input.baseUrl,
+						userId: input.userId,
+						storageContext: {
+							sessionId: null,
+							appId: input.savedPackage.id,
+							storageId: input.savedPackage.id,
 						},
-					})
-				: null,
-		}),
-		entrypointName: packageAppEntrypointName,
+					},
+				})
+			: null,
 	}
 }
 
@@ -1403,12 +1437,32 @@ export async function buildPackageAppWorker(input: {
 			`package:${input.savedPackage.id}`,
 	})
 	if (!cacheKey) {
-		return await buildPackageAppWorkerUncached(input)
+		return {
+			stub: input.env.APP_LOADER.load(
+				await buildPackageAppWorkerOptionsUncached(input),
+			),
+			entrypointName: packageAppEntrypointName,
+		}
 	}
-	return await packageAppWorkerCache.getOrCreate({
+	const build = await packageAppWorkerOptionsCache.getOrCreate({
 		cacheKey,
-		create: async () => await buildPackageAppWorkerUncached(input),
+		create: async () => {
+			const workerOptions = await buildPackageAppWorkerOptionsUncached(input)
+			return {
+				workerId: await createPackageAppWorkerId({ cacheKey, workerOptions }),
+				workerOptions,
+			}
+		},
 	})
+	return {
+		// Stubs are request-bound, so acquire a fresh one per request. The stable
+		// worker id (derived from user + package + commit + caller identity) lets
+		// the loader reuse a warm isolate instead of compiling a new worker.
+		stub: build.workerId
+			? input.env.APP_LOADER.get(build.workerId, () => build.workerOptions)
+			: input.env.APP_LOADER.load(build.workerOptions),
+		entrypointName: packageAppEntrypointName,
+	}
 }
 
 export async function createPackageAppCallerContext(input: {

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -4,6 +4,8 @@ import {
 	getPackageAppEntryPath,
 	parseAuthoredPackageJson,
 } from '#worker/package-registry/manifest.ts'
+import { type AuthoredPackageJson } from '#worker/package-registry/types.ts'
+import { type EntitySourceRow } from '#worker/repo/types.ts'
 import {
 	buildCodemodeFns,
 	type PackageEventTools,
@@ -16,15 +18,16 @@ import {
 } from '#mcp/execute-modules/codemode-utils.ts'
 import {
 	buildKodyAppBundle,
-	createPublishedBundleArtifact,
 	createPublishedPackageAppBundleCacheKey,
 	hydrateKodyRuntimeModules,
 } from './module-graph.ts'
 import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from './published-source-dependencies.ts'
 import {
-	readPublishedBundleArtifact,
-	writePublishedBundleArtifact,
-} from './published-runtime-artifacts.ts'
+	loadPublishedBundleArtifactByIdentity,
+	persistPublishedBundleArtifact,
+} from './published-bundle-artifacts.ts'
+import { PromiseLruCache } from '#worker/package-registry/published-package-cache.ts'
+import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { storageRunnerRpc } from '#worker/storage-runner.ts'
 import { packageRealtimeSessionRpc } from './realtime-session.ts'
 import {
@@ -1079,7 +1082,196 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 	}
 }
 
-export async function buildPackageAppWorker(input: {
+type PackageAppWorkerResult = {
+	stub: ReturnType<Env['APP_LOADER']['load']>
+	entrypointName: string
+}
+
+const packageAppWorkerCache = new PromiseLruCache<PackageAppWorkerResult>()
+
+function createPackageAppWorkerCacheKey(input: {
+	userId: string
+	packageId: string
+	kodyId: string
+	sourceId: string
+	publishedCommit: string | null
+	baseUrl: string
+	callerEmail: string
+	callerDisplayName: string
+}) {
+	if (!input.publishedCommit) {
+		return null
+	}
+	return JSON.stringify([
+		input.userId,
+		input.packageId,
+		input.kodyId,
+		input.sourceId,
+		input.publishedCommit,
+		input.baseUrl,
+		input.callerEmail,
+		input.callerDisplayName,
+	])
+}
+
+function resolvePackageAppManifest(input: {
+	manifest?: AuthoredPackageJson
+	source?: EntitySourceRow
+	sourceFiles?: Record<string, string>
+	savedPackage: {
+		manifestPath: string
+	}
+}) {
+	if (input.manifest) {
+		return input.manifest
+	}
+	const packageJsonContent = input.sourceFiles?.['package.json']
+	if (!packageJsonContent) {
+		throw new Error('Saved package is missing package.json.')
+	}
+	return parseAuthoredPackageJson({
+		content: packageJsonContent,
+		manifestPath:
+			input.source?.manifest_path ?? input.savedPackage.manifestPath,
+	})
+}
+
+async function resolvePersistablePackageSource(input: {
+	env: Env
+	userId: string
+	source?: EntitySourceRow
+	sourceId: string
+}) {
+	if (input.source?.user_id && input.source.repo_id) {
+		return input.source
+	}
+	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
+	if (!source || source.user_id !== input.userId) {
+		throw new Error(`Saved package source "${input.sourceId}" was not found.`)
+	}
+	return source
+}
+
+async function resolvePackageAppBundledArtifact(input: {
+	env: Env
+	userId: string
+	source?: EntitySourceRow
+	manifest: AuthoredPackageJson
+	savedPackage: {
+		id: string
+		kodyId: string
+		sourceId: string
+		publishedCommit: string | null
+		manifestPath: string
+		sourceRoot: string
+	}
+	loadSourceFiles?: () => Promise<Record<string, string>>
+	sourceFiles?: Record<string, string>
+	baseUrl: string
+}) {
+	const appEntry = getPackageAppEntryPath(input.manifest)
+	if (!appEntry) {
+		throw new Error(
+			`Saved package "${input.savedPackage.kodyId}" does not define kody.app.entry.`,
+		)
+	}
+	const sourceForCache = input.source ?? {
+		id: input.savedPackage.sourceId,
+		published_commit: input.savedPackage.publishedCommit,
+		manifest_path: input.savedPackage.manifestPath,
+		source_root: input.savedPackage.sourceRoot,
+	}
+	const inMemoryCacheKey = createPublishedPackageAppBundleCacheKey({
+		userId: input.userId,
+		source: sourceForCache,
+		entryPoint: appEntry,
+	})
+	if (!input.savedPackage.publishedCommit) {
+		const sourceFiles = await resolvePackageAppSourceFiles(input)
+		assertPublishedSourceCanRebuildWithoutInstallingDeps({
+			sourceFiles,
+			bundleLabel: `Saved package app "${input.savedPackage.kodyId}"`,
+		})
+		return await buildKodyAppBundle({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.userId,
+			sourceFiles,
+			entryPoint: appEntry,
+			cacheKey: inMemoryCacheKey,
+		})
+	}
+	const loadedArtifact = await loadPublishedBundleArtifactByIdentity({
+		env: input.env,
+		userId: input.userId,
+		sourceId: input.savedPackage.sourceId,
+		kind: 'app',
+		artifactName: null,
+		entryPoint: appEntry,
+	})
+	if (loadedArtifact?.artifact) {
+		return {
+			mainModule: loadedArtifact.artifact.mainModule,
+			modules: loadedArtifact.artifact.modules,
+			dependencies: loadedArtifact.artifact.dependencies,
+			dynamicDependencies: loadedArtifact.artifact.dynamicDependencies,
+		}
+	}
+	const sourceFiles = await resolvePackageAppSourceFiles(input)
+	assertPublishedSourceCanRebuildWithoutInstallingDeps({
+		sourceFiles,
+		bundleLabel: `Saved package app "${input.savedPackage.kodyId}"`,
+	})
+	const compiled = await buildKodyAppBundle({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		sourceFiles,
+		entryPoint: appEntry,
+		cacheKey: inMemoryCacheKey,
+	})
+	const persistableSource = await resolvePersistablePackageSource({
+		env: input.env,
+		userId: input.userId,
+		source: input.source,
+		sourceId: input.savedPackage.sourceId,
+	})
+	await persistPublishedBundleArtifact({
+		env: input.env,
+		userId: input.userId,
+		source: persistableSource,
+		kind: 'app',
+		artifactName: null,
+		entryPoint: appEntry,
+		mainModule: compiled.mainModule,
+		modules: compiled.modules,
+		dependencies: compiled.dependencies,
+		dynamicDependencies: compiled.dynamicDependencies,
+		packageContext: {
+			packageId: input.savedPackage.id,
+			kodyId: input.savedPackage.kodyId,
+			sourceId: input.savedPackage.sourceId,
+		},
+	})
+	return compiled
+}
+
+async function resolvePackageAppSourceFiles(input: {
+	sourceFiles?: Record<string, string>
+	loadSourceFiles?: () => Promise<Record<string, string>>
+}) {
+	if (input.sourceFiles) {
+		return input.sourceFiles
+	}
+	if (!input.loadSourceFiles) {
+		throw new Error(
+			'Saved package source files are required to rebuild the app.',
+		)
+	}
+	return await input.loadSourceFiles()
+}
+
+async function buildPackageAppWorkerUncached(input: {
 	env: Env
 	baseUrl: string
 	userId: string
@@ -1092,82 +1284,30 @@ export async function buildPackageAppWorker(input: {
 		manifestPath: string
 		sourceRoot: string
 	}
-	sourceFiles: Record<string, string>
+	source?: EntitySourceRow
+	manifest?: AuthoredPackageJson
+	loadSourceFiles?: () => Promise<Record<string, string>>
+	sourceFiles?: Record<string, string>
 	runtime: {
 		callerContext: ReturnType<typeof createMcpCallerContext>
 	}
-}) {
-	const packageJsonContent = input.sourceFiles['package.json']
-	if (!packageJsonContent) {
-		throw new Error('Saved package is missing package.json.')
-	}
-	const manifest = parseAuthoredPackageJson({
-		content: packageJsonContent,
-		manifestPath: 'package.json',
+}): Promise<PackageAppWorkerResult> {
+	const manifest = resolvePackageAppManifest({
+		manifest: input.manifest,
+		source: input.source,
+		sourceFiles: input.sourceFiles,
+		savedPackage: input.savedPackage,
 	})
-	const appEntry = getPackageAppEntryPath(manifest)
-	if (!appEntry) {
-		throw new Error(
-			`Saved package "${input.savedPackage.kodyId}" does not define kody.app.entry.`,
-		)
-	}
-	const kvKey = createPublishedPackageAppBundleCacheKey({
+	const bundled = await resolvePackageAppBundledArtifact({
+		env: input.env,
+		baseUrl: input.baseUrl,
 		userId: input.userId,
-		source: {
-			id: input.savedPackage.sourceId,
-			published_commit: input.savedPackage.publishedCommit,
-			manifest_path: input.savedPackage.manifestPath,
-			source_root: input.savedPackage.sourceRoot,
-		},
-		entryPoint: appEntry,
+		source: input.source,
+		manifest,
+		savedPackage: input.savedPackage,
+		loadSourceFiles: input.loadSourceFiles,
+		sourceFiles: input.sourceFiles,
 	})
-	const artifact =
-		kvKey != null
-			? await readPublishedBundleArtifact({
-					env: input.env,
-					kvKey,
-				})
-			: null
-	const bundled =
-		artifact ??
-		(await (async () => {
-			assertPublishedSourceCanRebuildWithoutInstallingDeps({
-				sourceFiles: input.sourceFiles,
-				bundleLabel: `Saved package app "${input.savedPackage.kodyId}"`,
-			})
-			const compiled = await buildKodyAppBundle({
-				env: input.env,
-				baseUrl: input.baseUrl,
-				userId: input.userId,
-				sourceFiles: input.sourceFiles,
-				entryPoint: appEntry,
-				cacheKey: kvKey,
-			})
-			if (!input.savedPackage.publishedCommit || kvKey == null) {
-				return compiled
-			}
-			await writePublishedBundleArtifact({
-				env: input.env,
-				artifact: createPublishedBundleArtifact({
-					kind: 'app',
-					artifactName: input.savedPackage.kodyId,
-					sourceId: input.savedPackage.sourceId,
-					publishedCommit: input.savedPackage.publishedCommit,
-					entryPoint: appEntry,
-					mainModule: compiled.mainModule,
-					modules: compiled.modules,
-					dependencies: compiled.dependencies,
-					dynamicDependencies: compiled.dynamicDependencies,
-					packageContext: {
-						packageId: input.savedPackage.id,
-						kodyId: input.savedPackage.kodyId,
-						sourceId: input.savedPackage.sourceId,
-					},
-				}),
-				kvKey,
-			})
-			return compiled
-		})())
 	const mainModule = 'package-app-entry.js'
 	const hydratedModules = await hydrateKodyRuntimeModules({
 		env: input.env,
@@ -1182,9 +1322,8 @@ export async function buildPackageAppWorker(input: {
 		}),
 	}
 	return {
-		// Keep the loader stub per-request because the bound runtime bridge props are
-		// caller-specific (user/package context) and we do not want to risk leaking
-		// request-scoped bindings through a reused stub.
+		// The loader stub is cached per caller identity (see createPackageAppWorkerCacheKey)
+		// so request-scoped runtime bridge props are not shared across users.
 		stub: input.env.APP_LOADER.load({
 			compatibilityDate: '2026-04-13',
 			compatibilityFlags: ['nodejs_compat', 'global_fetch_strictly_public'],
@@ -1228,6 +1367,48 @@ export async function buildPackageAppWorker(input: {
 		}),
 		entrypointName: packageAppEntrypointName,
 	}
+}
+
+export async function buildPackageAppWorker(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	savedPackage: {
+		id: string
+		kodyId: string
+		name: string
+		sourceId: string
+		publishedCommit: string | null
+		manifestPath: string
+		sourceRoot: string
+	}
+	source?: EntitySourceRow
+	manifest?: AuthoredPackageJson
+	loadSourceFiles?: () => Promise<Record<string, string>>
+	sourceFiles?: Record<string, string>
+	runtime: {
+		callerContext: ReturnType<typeof createMcpCallerContext>
+	}
+}) {
+	const cacheKey = createPackageAppWorkerCacheKey({
+		userId: input.userId,
+		packageId: input.savedPackage.id,
+		kodyId: input.savedPackage.kodyId,
+		sourceId: input.savedPackage.sourceId,
+		publishedCommit: input.savedPackage.publishedCommit,
+		baseUrl: input.baseUrl,
+		callerEmail: input.runtime.callerContext.user?.email ?? '',
+		callerDisplayName:
+			input.runtime.callerContext.user?.displayName ??
+			`package:${input.savedPackage.id}`,
+	})
+	if (!cacheKey) {
+		return await buildPackageAppWorkerUncached(input)
+	}
+	return await packageAppWorkerCache.getOrCreate({
+		cacheKey,
+		create: async () => await buildPackageAppWorkerUncached(input),
+	})
 }
 
 export async function createPackageAppCallerContext(input: {

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
@@ -265,6 +265,98 @@ test('rebuildPublishedPackageArtifacts bundles declared subscription handlers', 
 	])
 })
 
+test('rebuildPublishedPackageArtifacts stores app bundles with artifactName null', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.getPublishedBundleArtifactByIdentity.mockReset()
+	mockModule.insertPublishedBundleArtifactRow.mockReset()
+	mockModule.updatePublishedBundleArtifactRow.mockReset()
+	mockModule.writePublishedBundleArtifact.mockReset()
+	mockModule.getPublishedBundleArtifactByIdentity.mockResolvedValue(null)
+	mockModule.writePublishedBundleArtifact.mockResolvedValue('kv:app')
+	mockModule.insertPublishedBundleArtifactRow.mockResolvedValue(undefined)
+
+	const buildAppBundle = vi.fn(async () => ({
+		mainModule: 'dist/app.js',
+		modules: {
+			'dist/app.js':
+				'export default { async fetch() { return new Response("ok") } }',
+		},
+		dependencies: [],
+	}))
+	const buildModuleBundle = vi.fn()
+	const buildImportableModuleBundle = vi.fn()
+
+	await rebuildPublishedPackageArtifacts({
+		env: {
+			APP_DB: {},
+			BUNDLE_ARTIFACTS_KV: {
+				get: async () => null,
+				put: async () => undefined,
+				delete: async () => undefined,
+			},
+		} as unknown as Env,
+		userId: 'user-1',
+		source: {
+			id: 'source-1',
+			user_id: 'user-1',
+			entity_kind: 'package',
+			entity_id: 'pkg-1',
+			repo_id: 'repo-1',
+			published_commit: 'commit-1',
+			indexed_commit: null,
+			manifest_path: 'package.json',
+			source_root: '/',
+			created_at: '2026-04-30T00:00:00.000Z',
+			updated_at: '2026-04-30T00:00:00.000Z',
+		},
+		savedPackage: {
+			id: 'pkg-1',
+			userId: 'user-1',
+			name: '@kentcdodds/example-app',
+			kodyId: 'example-app',
+			description: 'Example app package',
+			tags: [],
+			searchText: null,
+			sourceId: 'source-1',
+			hasApp: true,
+			createdAt: '2026-04-30T00:00:00.000Z',
+			updatedAt: '2026-04-30T00:00:00.000Z',
+		},
+		manifest: {
+			name: '@kentcdodds/example-app',
+			exports: {},
+			kody: {
+				id: 'example-app',
+				description: 'Example app package',
+				app: {
+					entry: 'app.js',
+				},
+			},
+		},
+		buildAppBundle,
+		buildModuleBundle,
+		buildImportableModuleBundle,
+	})
+
+	expect(buildAppBundle).toHaveBeenCalledWith({
+		entryPoint: 'app.js',
+	})
+	expect(mockModule.insertPublishedBundleArtifactRow).toHaveBeenCalledTimes(1)
+	expect(mockModule.insertPublishedBundleArtifactRow).toHaveBeenCalledWith(
+		{},
+		expect.objectContaining({
+			artifactKind: 'app',
+			artifactName: null,
+			entryPoint: 'app.js',
+		}),
+	)
+	expect(mockModule.writePublishedBundleArtifact).toHaveBeenCalledWith(
+		expect.objectContaining({
+			kvKey: 'bundle-artifact:v1:source-1:commit-1:app:_:app.js',
+		}),
+	)
+})
+
 test('rebuildPublishedPackageArtifacts uses builder dependency metadata instead of package-wide fallback scans', async () => {
 	mockModule.getEntitySourceById.mockReset()
 	mockModule.getPublishedBundleArtifactByIdentity.mockReset()

--- a/packages/worker/src/remote-connector/client.ts
+++ b/packages/worker/src/remote-connector/client.ts
@@ -1,5 +1,6 @@
 import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { userScopedConnectorSessionKey } from '#worker/remote-connector/connector-session-key.ts'
+import { getCachedRemoteConnectorSnapshot } from '#worker/remote-connector/snapshot-cache.ts'
 import {
 	type RemoteConnectorSnapshot,
 	type RemoteConnectorToolDescriptor,
@@ -48,7 +49,7 @@ export function createRemoteConnectorMcpClient(input: {
 			return (await stub.rpcCallTool(name, args ?? {})) as CallToolResult
 		},
 		async getSnapshot() {
-			return stub.getSnapshot()
+			return getCachedRemoteConnectorSnapshot(input)
 		},
 	}
 }

--- a/packages/worker/src/remote-connector/client.ts
+++ b/packages/worker/src/remote-connector/client.ts
@@ -1,6 +1,9 @@
 import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { userScopedConnectorSessionKey } from '#worker/remote-connector/connector-session-key.ts'
-import { getCachedRemoteConnectorSnapshot } from '#worker/remote-connector/snapshot-cache.ts'
+import {
+	getCachedRemoteConnectorSnapshot,
+	invalidateRemoteConnectorSnapshotCache,
+} from '#worker/remote-connector/snapshot-cache.ts'
 import {
 	type RemoteConnectorSnapshot,
 	type RemoteConnectorToolDescriptor,
@@ -41,12 +44,22 @@ export function createRemoteConnectorMcpClient(input: {
 }): RemoteConnectorMcpClient {
 	const stub = getSessionStub(input)
 
+	// A failed RPC usually means the connector dropped since the snapshot was
+	// cached, so evict it instead of serving a stale "connected" view for the
+	// rest of the TTL.
+	function invalidateSnapshotOnFailure(error: unknown): never {
+		invalidateRemoteConnectorSnapshotCache(input)
+		throw error
+	}
+
 	return {
 		async listTools() {
-			return stub.rpcListTools()
+			return stub.rpcListTools().catch(invalidateSnapshotOnFailure)
 		},
 		async callTool(name, args) {
-			return (await stub.rpcCallTool(name, args ?? {})) as CallToolResult
+			return (await stub
+				.rpcCallTool(name, args ?? {})
+				.catch(invalidateSnapshotOnFailure)) as CallToolResult
 		},
 		async getSnapshot() {
 			return getCachedRemoteConnectorSnapshot(input)

--- a/packages/worker/src/remote-connector/client.ts
+++ b/packages/worker/src/remote-connector/client.ts
@@ -54,12 +54,18 @@ export function createRemoteConnectorMcpClient(input: {
 
 	return {
 		async listTools() {
-			return stub.rpcListTools().catch(invalidateSnapshotOnFailure)
+			try {
+				return await stub.rpcListTools()
+			} catch (error) {
+				invalidateSnapshotOnFailure(error)
+			}
 		},
 		async callTool(name, args) {
-			return (await stub
-				.rpcCallTool(name, args ?? {})
-				.catch(invalidateSnapshotOnFailure)) as CallToolResult
+			try {
+				return (await stub.rpcCallTool(name, args ?? {})) as CallToolResult
+			} catch (error) {
+				invalidateSnapshotOnFailure(error)
+			}
 		},
 		async getSnapshot() {
 			return getCachedRemoteConnectorSnapshot(input)

--- a/packages/worker/src/remote-connector/snapshot-cache.node.test.ts
+++ b/packages/worker/src/remote-connector/snapshot-cache.node.test.ts
@@ -70,6 +70,34 @@ test('getCachedRemoteConnectorSnapshot reuses DO snapshots within TTL', async ()
 	expect(getSnapshotCalls()).toBe(1)
 })
 
+test('getCachedRemoteConnectorSnapshot does not retain disconnected snapshots', async () => {
+	let connected = false
+	const { env, getSnapshotCalls } = buildEnv(async () =>
+		connected
+			? {
+					connectorKind: 'roku',
+					connectorId: 'default',
+					connectedAt: '2026-03-25T00:00:00.000Z',
+					lastSeenAt: '2026-03-25T00:00:01.000Z',
+					tools: runtimeTools,
+				}
+			: null,
+	)
+	const request = {
+		env,
+		userId: 'user-1',
+		kind: 'roku',
+		instanceId: 'default',
+	}
+
+	await expect(getCachedRemoteConnectorSnapshot(request)).resolves.toBeNull()
+	connected = true
+	await expect(
+		getCachedRemoteConnectorSnapshot(request),
+	).resolves.not.toBeNull()
+	expect(getSnapshotCalls()).toBe(2)
+})
+
 test('getCachedRemoteConnectorSnapshot does not share entries across users', async () => {
 	const { env, getSnapshotCalls } = buildEnv(async () => ({
 		connectorKind: 'roku',

--- a/packages/worker/src/remote-connector/snapshot-cache.node.test.ts
+++ b/packages/worker/src/remote-connector/snapshot-cache.node.test.ts
@@ -21,7 +21,10 @@ const runtimeTools = [
 	},
 ] as const
 
-function buildEnv(onGetSnapshot: () => Promise<unknown>) {
+function buildEnv(
+	onGetSnapshot: () => Promise<unknown>,
+	onRpcCallTool?: () => Promise<unknown>,
+) {
 	let snapshotCalls = 0
 	const env = {
 		REMOTE_CONNECTOR_SESSION: {
@@ -33,6 +36,10 @@ function buildEnv(onGetSnapshot: () => Promise<unknown>) {
 					async getSnapshot() {
 						snapshotCalls += 1
 						return onGetSnapshot()
+					},
+					async rpcCallTool() {
+						if (!onRpcCallTool) throw new Error('rpcCallTool not stubbed')
+						return onRpcCallTool()
 					},
 				}
 			},
@@ -95,6 +102,40 @@ test('getCachedRemoteConnectorSnapshot does not retain disconnected snapshots', 
 	await expect(
 		getCachedRemoteConnectorSnapshot(request),
 	).resolves.not.toBeNull()
+	expect(getSnapshotCalls()).toBe(2)
+})
+
+test('a failed connector RPC evicts the cached snapshot', async () => {
+	const { env, getSnapshotCalls } = buildEnv(
+		async () => ({
+			connectorKind: 'roku',
+			connectorId: 'default',
+			connectedAt: '2026-03-25T00:00:00.000Z',
+			lastSeenAt: '2026-03-25T00:00:01.000Z',
+			tools: runtimeTools,
+		}),
+		async () => {
+			throw new Error('Remote connector websocket closed before RPC response.')
+		},
+	)
+	const request = {
+		env,
+		userId: 'user-1',
+		kind: 'roku',
+		instanceId: 'default',
+	}
+	const client = createRemoteConnectorMcpClient(request)
+
+	await client.getSnapshot()
+	await client.getSnapshot()
+	expect(getSnapshotCalls()).toBe(1)
+
+	await expect(client.callTool('roku_press_key', {})).rejects.toThrow(
+		'websocket closed',
+	)
+
+	// The disconnect signal must not keep serving the stale "connected" view.
+	await client.getSnapshot()
 	expect(getSnapshotCalls()).toBe(2)
 })
 

--- a/packages/worker/src/remote-connector/snapshot-cache.node.test.ts
+++ b/packages/worker/src/remote-connector/snapshot-cache.node.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, expect, test } from 'vitest'
+import { createRemoteConnectorMcpClient } from '#worker/remote-connector/client.ts'
+import {
+	clearRemoteConnectorSnapshotCacheForTests,
+	getCachedRemoteConnectorSnapshot,
+} from '#worker/remote-connector/snapshot-cache.ts'
+
+const runtimeTools = [
+	{
+		name: 'roku_press_key',
+		title: 'Press Roku Key',
+		description: 'Send a Roku ECP keypress.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				deviceId: { type: 'string' },
+				key: { type: 'string' },
+			},
+			required: ['deviceId', 'key'],
+		},
+	},
+] as const
+
+function buildEnv(onGetSnapshot: () => Promise<unknown>) {
+	let snapshotCalls = 0
+	const env = {
+		REMOTE_CONNECTOR_SESSION: {
+			idFromName(name: string) {
+				return name
+			},
+			get() {
+				return {
+					async getSnapshot() {
+						snapshotCalls += 1
+						return onGetSnapshot()
+					},
+				}
+			},
+		},
+	} as unknown as Env
+	return {
+		env,
+		getSnapshotCalls: () => snapshotCalls,
+	}
+}
+
+beforeEach(() => {
+	clearRemoteConnectorSnapshotCacheForTests()
+})
+
+test('getCachedRemoteConnectorSnapshot reuses DO snapshots within TTL', async () => {
+	const { env, getSnapshotCalls } = buildEnv(async () => ({
+		connectorKind: 'roku',
+		connectorId: 'default',
+		connectedAt: '2026-03-25T00:00:00.000Z',
+		lastSeenAt: '2026-03-25T00:00:01.000Z',
+		tools: runtimeTools,
+	}))
+	const request = {
+		env,
+		userId: 'user-1',
+		kind: 'roku',
+		instanceId: 'default',
+	}
+
+	await getCachedRemoteConnectorSnapshot(request)
+	await getCachedRemoteConnectorSnapshot(request)
+	await createRemoteConnectorMcpClient(request).getSnapshot()
+
+	expect(getSnapshotCalls()).toBe(1)
+})
+
+test('getCachedRemoteConnectorSnapshot does not share entries across users', async () => {
+	const { env, getSnapshotCalls } = buildEnv(async () => ({
+		connectorKind: 'roku',
+		connectorId: 'default',
+		connectedAt: '2026-03-25T00:00:00.000Z',
+		lastSeenAt: '2026-03-25T00:00:01.000Z',
+		tools: runtimeTools,
+	}))
+	const connector = {
+		env,
+		kind: 'roku',
+		instanceId: 'default',
+	}
+
+	await getCachedRemoteConnectorSnapshot({
+		...connector,
+		userId: 'user-1',
+	})
+	await getCachedRemoteConnectorSnapshot({
+		...connector,
+		userId: 'user-2',
+	})
+
+	expect(getSnapshotCalls()).toBe(2)
+})

--- a/packages/worker/src/remote-connector/snapshot-cache.ts
+++ b/packages/worker/src/remote-connector/snapshot-cache.ts
@@ -1,0 +1,55 @@
+import { PromiseLruCache } from '#worker/package-registry/published-package-cache.ts'
+import { userScopedConnectorSessionKey } from '#worker/remote-connector/connector-session-key.ts'
+import { type RemoteConnectorSnapshot } from '#worker/remote-connector/types.ts'
+
+export const remoteConnectorSnapshotCacheTtlMs = 30_000
+export const remoteConnectorSnapshotCacheLimit = 100
+
+function createRemoteConnectorSnapshotCache() {
+	return new PromiseLruCache<RemoteConnectorSnapshot | null>({
+		ttlMs: remoteConnectorSnapshotCacheTtlMs,
+		limit: remoteConnectorSnapshotCacheLimit,
+	})
+}
+
+let remoteConnectorSnapshotCache = createRemoteConnectorSnapshotCache()
+
+export function createRemoteConnectorSnapshotCacheKey(input: {
+	userId: string
+	kind: string
+	instanceId: string
+}) {
+	return userScopedConnectorSessionKey(input)
+}
+
+export function getCachedRemoteConnectorSnapshot(input: {
+	env: Env
+	userId: string
+	kind: string
+	instanceId: string
+}): Promise<RemoteConnectorSnapshot | null> {
+	const cacheKey = createRemoteConnectorSnapshotCacheKey(input)
+	return remoteConnectorSnapshotCache.getOrCreate({
+		cacheKey,
+		create: async () => {
+			const stub = input.env.REMOTE_CONNECTOR_SESSION.get(
+				input.env.REMOTE_CONNECTOR_SESSION.idFromName(cacheKey),
+			)
+			return stub.getSnapshot()
+		},
+	})
+}
+
+export function invalidateRemoteConnectorSnapshotCache(input: {
+	userId: string
+	kind: string
+	instanceId: string
+}) {
+	remoteConnectorSnapshotCache.delete(
+		createRemoteConnectorSnapshotCacheKey(input),
+	)
+}
+
+export function clearRemoteConnectorSnapshotCacheForTests() {
+	remoteConnectorSnapshotCache = createRemoteConnectorSnapshotCache()
+}

--- a/packages/worker/src/remote-connector/snapshot-cache.ts
+++ b/packages/worker/src/remote-connector/snapshot-cache.ts
@@ -35,7 +35,13 @@ export function getCachedRemoteConnectorSnapshot(input: {
 			const stub = input.env.REMOTE_CONNECTOR_SESSION.get(
 				input.env.REMOTE_CONNECTOR_SESSION.idFromName(cacheKey),
 			)
-			return stub.getSnapshot()
+			const snapshot = await stub.getSnapshot()
+			if (snapshot == null) {
+				// Do not retain disconnected results: a connector that comes online
+				// should be visible on the next lookup instead of after the TTL.
+				remoteConnectorSnapshotCache.delete(cacheKey)
+			}
+			return snapshot
 		},
 	})
 }

--- a/packages/worker/src/repo/published-source.ts
+++ b/packages/worker/src/repo/published-source.ts
@@ -89,9 +89,15 @@ export async function loadPublishedEntitySource(input: {
 	env: Env
 	userId: string
 	sourceId: string
+	source?: NonNullable<PublishedEntitySource['source']>
 }): Promise<PublishedEntitySource> {
-	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
+	const source =
+		input.source ??
+		(await getEntitySourceById(input.env.APP_DB, input.sourceId))
 	if (!source || source.user_id !== input.userId) {
+		throw new Error(`Published source "${input.sourceId}" was not found.`)
+	}
+	if (input.source && input.source.id !== input.sourceId) {
 		throw new Error(`Published source "${input.sourceId}" was not found.`)
 	}
 	assertPublishedCommit(source)
@@ -126,9 +132,15 @@ export async function loadPublishedEntityManifest(input: {
 	env: Env
 	userId: string
 	sourceId: string
+	source?: NonNullable<PublishedEntityManifest['source']>
 }): Promise<PublishedEntityManifest> {
-	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
+	const source =
+		input.source ??
+		(await getEntitySourceById(input.env.APP_DB, input.sourceId))
 	if (!source || source.user_id !== input.userId) {
+		throw new Error(`Published source "${input.sourceId}" was not found.`)
+	}
+	if (input.source && input.source.id !== input.sourceId) {
 		throw new Error(`Published source "${input.sourceId}" was not found.`)
 	}
 	assertPublishedCommit(source)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Performance optimizations across package apps, MCP execute, and hot paths

Package apps were slow to load. An audit of the dynamic-worker pipeline found that the runtime bundle lookup used a different KV key than the publish pipeline writes, so every app load after a publish re-bundled from scratch, plus several other hot-path inefficiencies. This PR fixes the critical path and a set of related wins across the board.

## Package app loading (the critical path)

- **Fix bundle artifact identity mismatch**: `buildPackageAppWorker` read KV with a JSON-array cache key while publish-time `rebuildPublishedPackageArtifacts` writes under the canonical `bundle-artifact:v1:...` key with a D1 index row. Runtime now uses `loadPublishedBundleArtifactByIdentity` (kind `app`, artifactName `null`) — the same identity the publish pipeline persists — and persists rebuilds via `persistPublishedBundleArtifact`. Publish-time bundling work is no longer wasted.
- **Manifest-first fast path**: on an artifact hit, the handler loads only the package manifest instead of every published source file; full source loads happen only on the rebuild path (via a `loadSourceFiles` callback).
- **Parallel host setup**: package manifest load and caller-context creation now run under `Promise.all`.
- **Worker isolate reuse**: the built worker *options* (bundle + hydrated module graph) are memoized in an isolate-level `PromiseLruCache` keyed by userId, packageId, kodyId, sourceId, publishedCommit, baseUrl, and caller email/displayName (only active for published commits). Each request then acquires a fresh stub via `APP_LOADER.get(stableContentHashedId, () => cachedOptions)`, so workerd reuses the warm isolate while the stub stays bound to the current request. (Stubs themselves are request-scoped in workerd and cannot be cached — caching them 500s on the second request, which manual testing caught.)
- **Deduped D1 reads**: `loadPublishedEntitySource` / `loadPublishedEntityManifest` accept a pre-resolved source row, removing a duplicate `getEntitySourceById` per source load. The persist fast path enforces the same ownership check as the DB-lookup branch.

## SSR hot path (follow-up after #601 merged)

- **Router + env memoization**: `handleRequest` built the full Remix router (~40 handler factories) and re-ran env schema validation on every request. Both are now memoized per `Env` object identity (stable per isolate); handlers already close over `env`, and the router keeps no per-request state.
- **Parallel admin queries**: `loadAdminUsersData` issues the `COUNT(*)` and page `SELECT` concurrently.
- **Request-scoped community detail load**: one `/community/:id` SSR response invoked `loadCommunityDetailData` twice (HTML handler for the loaderData embed + frame renderer during streaming). It is now memoized per `Request`.
- **Throttled session revalidation**: the client refetched `/session` (2 D1 queries) on every SPA navigation. Navigation-triggered refreshes are now throttled to 30s; hydration and explicit refreshes (login/logout/profile updates) always go through.

## MCP execute

- **Dynamic worker isolate reuse for bundled modules**: stable content-hashed worker IDs were previously only allowed when the module map contained just `executor.js`, so every bundled execute (any module with imports) got a fresh isolate via `crypto.randomUUID()`. The hash covers the full module map, gateway props (including userId), timeout, and compatibility settings; non-deterministic module shapes still fall back to random IDs. Cache key version bumped to 2.
- **Registry pass-through**: the capability registry loaded for logging in the execute tool is now threaded into `runModuleWithRegistry` instead of being rebuilt inside `buildCodemodeFns`.
- **Single-pass result serialization**: `limitExecutionResultValue` no longer JSON-stringifies large results twice.

## Module graph

- Dynamic `kody:` import hydration resolves unique specifiers per pass with `Promise.all` instead of sequentially.
- Direct kody dependency resolution parallelized with deterministic output ordering preserved.
- The `kody:runtime` virtual module source is memoized (it is parameter-free).

## Remote connectors and capability registry

- New isolate-level snapshot cache (30s TTL) shared by registry synthesis, MCP DO init, and connector clients — a cold MCP call previously hit each connector session DO 2-3 times. Failed connector RPCs evict the cached snapshot so a disconnect is not masked for the TTL.
- The built capability registry is memoized per user + connector snapshot identity (connector refs, connectedAt, tool names). Users without connectors keep the static registry fast path.

## Secrets and values

- Derived `CryptoKey`s for the server-wide secret-store key are cached at module level (previously SHA-256 + `importKey` on every encrypt/decrypt).
- Secret placeholder resolution (capability inputs and fetch gateway) deduplicates and parallelizes lookups; `resolveSecret` resolves scopes in parallel via `Promise.allSettled` while preserving session → app → user precedence (a corrupted lower-precedence entry cannot fail a resolved higher-precedence secret).
- `listValues` replaces per-bucket N+1 metadata queries with a single JOIN query (runs on every MCP `search` for signed-in users).

## Multi-user isolation

Every new cache is keyed by `userId` (worker options additionally by full caller identity; connector snapshots by user-scoped session key; registry by userId + connector identity). Unit tests assert users never share cache entries. The router/env memoization is user-agnostic by design (it caches only env parsing and handler wiring, never request or user state).

## Measured impact (local dev, `tools/perf-smoke` harness)

Publish a small package app via MCP `execute`, then load it over HTTP six times (3 runs each): first load improved from 51–107ms on `main` to 32–57ms on this branch, and warm loads from ~20–32ms to ~13–19ms. Local dev understates the win — production KV/D1 latency makes the eliminated re-bundle and duplicate reads count for more.

## Coordination with other open PRs

Rebased onto `main` after #604 (integrations) and #601 (SSR) merged; no conflicts. The SSR follow-up section above implements the low-risk wins from a perf audit of the merged SSR pipeline. Larger deferred items (community catalog SQL pagination/search, trimming hydration payloads for secrets/READMEs, fragment caching for frames) are candidates for future PRs.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `d5a6147` · **Head:** `2af044f`

**Classification:** extends — no new primitives; caching and lookup-identity behavior of several runtime primitives changed. No schema changes.

### Primitives touched

| Primitive             | Group   | Impact                                                                     |
| --------------------- | ------- | -------------------------------------------------------------------------- |
| `app-ui`              | runtime | extends — memoized router/env, request-scoped detail loads, throttled session refresh |
| `package-apps`        | runtime | extends — canonical artifact lookup, manifest fast path, isolate reuse via stable worker ids |
| `package-runtime`     | runtime | extends — parallel hydration/dependency resolution, memoized runtime module |
| `codemode-execute`    | runtime | extends — stable worker IDs for bundled modules, registry pass-through     |
| `capability-registry` | runtime | extends — per-user registry memoization (30s TTL)                          |
| `remote-connectors`   | runtime | extends — shared 30s snapshot cache with failure eviction                  |
| `secrets`             | storage | composes — CryptoKey cache, parallel placeholder/scope resolution          |
| `values`              | storage | composes — single JOIN replaces per-bucket N+1 queries                     |
| `bundle-artifacts-kv` | storage | composes — runtime reads/writes now use the existing canonical keys        |
| `d1-app-db`           | storage | composes — fewer round trips; no schema change                             |

### System map

```mermaid
flowchart LR
	appUi["app-ui"]:::extended
	packageApps["package-apps"]:::extended
	packageRuntime["package-runtime"]:::extended
	codemodeExecute["codemode-execute"]:::extended
	capabilityRegistry["capability-registry"]:::extended
	remoteConnectors["remote-connectors"]:::extended
	secrets["secrets"]:::touched
	values["values"]:::touched
	bundleArtifactsKv["bundle-artifacts-kv"]:::touched
	d1AppDb["d1-app-db"]:::touched
	mcpServer["mcp-server"]:::untouched
	appUi --> packageApps --> packageRuntime --> bundleArtifactsKv
	packageRuntime --> d1AppDb
	appUi --> d1AppDb
	mcpServer --> codemodeExecute --> capabilityRegistry --> remoteConnectors
	codemodeExecute --> secrets
	mcpServer --> values
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant B as Browser
	participant H as package-app handler
	participant D1 as D1
	participant KV as bundle-artifacts KV
	participant L as APP_LOADER
	Note over H: before — full source load + rebundle + new isolate per request
	B->>H: GET /@user/packages/:kodyId
	H->>D1: manifest row (parallel with caller ctx)
	H->>D1: artifact identity row
	H->>KV: canonical bundle artifact (hit)
	H->>L: get(stable worker id) with cached options — isolate reuse
	L-->>B: response
```

### Invariants

`per-user-isolation`: every new cache (worker options/ids, connector snapshots, registry, source rows) is keyed by `userId`; unit tests assert no cross-user sharing. Stable dynamic worker IDs include `userId` in the hashed material. Router/env memoization holds no user or request state.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2d9e-00cc-706f-92de-87a63c93ebb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2d9e-00cc-706f-92de-87a63c93ebb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote-connector snapshot caching and capability-registry memoization, including support for using a prebuilt capability registry.
  * Improved package app runtime loading by loading manifests up-front and reusing worker setup/options.
* **Bug Fixes**
  * Deduplicated secret placeholder resolution and resolved secrets across scopes more robustly.
  * Improved limited-output truncation formatting (including more accurate display handling).
* **Performance**
  * Parallelized multiple lookups (secrets, snapshots, module/package dependency resolution, admin-user totals).
  * Memoized env parsing, SSR community details, and reduced redundant session refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->