### PR TITLE
Enforce package.json private field for community publishing

### DIFF
--- a/docs/guides/package-authoring.md
+++ b/docs/guides/package-authoring.md
@@ -32,3 +32,20 @@ This package exists to ...
 
 Keep the section concise. It should explain why the package exists and what
 success means for the user, not duplicate every implementation detail.
+
+## Package visibility (`private`)
+
+Default new saved packages to `"private": true` in `package.json` unless the
+user explicitly wants public **community** publishing.
+
+Like npm, `"private": true` blocks community listings on this deployment.
+Account publishing still works so the owner can run the package privately.
+
+- Set `"private": true` when creating or forking a package unless the user asks
+  to share it publicly.
+- Require explicit user approval before changing `"private"` or creating a
+  package without `"private": true`.
+- Pass `confirm_private_visibility_change: true` on `package_save` or repo
+  publish only after that approval.
+- Community publish additionally requires `"private": false` or omitting
+  `private`, plus MIT license and README `## Intent`.

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -21,6 +21,9 @@ Requirements:
 
 - **`package.json#license`** must be `"MIT"`. Community publishing accepts
   permissive licensing only; MIT is the only accepted value.
+- **`package.json#private`** must not be `true`. Like npm, `"private": true`
+  blocks public community publishing; set `"private": false` or remove `private`
+  only after the user explicitly approves public sharing.
 - A root **`README.md`** with a **`## Intent`** section (same guidance as
   [Packages](./packages.md#save-and-edit-packages)).
 - A **published** saved package commit. Publishing creates a **pinned snapshot**

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -27,6 +27,9 @@ Use `package.json` as the source of truth.
 Important fields:
 
 - `name` — npm-valid package name
+- `private` — when `true`, blocks public community publishing (like npm); new
+  packages default to `"private": true` unless the user explicitly wants a
+  public community listing
 - `exports` — authoritative import/export map
 - `kody.id` — user-scoped Kody package id
 - `kody.description` — package description for search/detail

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -543,6 +543,50 @@ test('publishCommunityListing requires MIT license and Intent heading', async ()
 	).rejects.toThrow('README.md to include a "## Intent" section')
 })
 
+test('publishCommunityListing rejects private packages', async () => {
+	mockModule.getCommunityBan.mockResolvedValue(null)
+	mockModule.getSavedPackageById.mockResolvedValue(validSavedPackage())
+	mockModule.getCommunityListingByOwnerAndPackage.mockResolvedValue(null)
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: {
+			id: 'source-1',
+			published_commit: 'commit-1',
+		},
+		manifest: {
+			name: '@owner/discord-gateway',
+			exports: { '.': './src/index.ts' },
+			kody: {
+				id: 'discord-gateway',
+				description: 'Discord helpers',
+			},
+		},
+		files: {
+			'package.json': JSON.stringify({
+				name: '@owner/discord-gateway',
+				private: true,
+				license: 'MIT',
+				exports: { '.': './src/index.ts' },
+				kody: {
+					id: 'discord-gateway',
+					description: 'Discord helpers',
+				},
+			}),
+			'README.md': '# Discord Gateway\n\n## Intent\n\nBridge Discord events.',
+		},
+	})
+
+	await expect(
+		publishCommunityListing({
+			env: createEnv(),
+			baseUrl: 'https://heykody.dev',
+			userId: 'user-1',
+			packageId: 'package-1',
+		}),
+	).rejects.toThrow(
+		'community listings cannot publish packages with `"private": true`',
+	)
+})
+
 test('rateCommunityListing requires a fork and rejects owner self-ratings', async () => {
 	mockModule.getCommunityBan.mockResolvedValue(null)
 	mockModule.getCommunityListingById.mockResolvedValue(sampleListing())

--- a/packages/worker/src/community/fork-scan.node.test.ts
+++ b/packages/worker/src/community/fork-scan.node.test.ts
@@ -45,6 +45,7 @@ test('rewritePackageManifestForFork rewrites scope and kody id while preserving 
 
 	expect(parsed.name).toBe('@jane/my-discord-gateway')
 	expect(parsed.license).toBe('MIT')
+	expect(parsed.private).toBe(true)
 	expect(parsed.exports).toEqual({ '.': './src/index.ts' })
 	expect(parsed.kody.id).toBe('my-discord-gateway')
 	expect(parsed.kody.description).toBe('Discord helpers')

--- a/packages/worker/src/community/fork-scan.ts
+++ b/packages/worker/src/community/fork-scan.ts
@@ -34,6 +34,7 @@ export function rewritePackageManifestForFork(input: {
 	const next = {
 		...parsed,
 		name: targetName,
+		private: true,
 		kody: {
 			...(typeof parsed['kody'] === 'object' && parsed['kody'] != null
 				? (parsed['kody'] as Record<string, unknown>)

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -15,6 +15,7 @@ import { cleanupArtifactReposForPackage } from '#worker/repo/artifact-repo-clean
 import { deleteEntitySource } from '#worker/repo/entity-sources.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
+import { assertPackageNotPrivateForCommunityPublish } from '#worker/package-registry/package-private.ts'
 import { CommunityActionError } from './errors.ts'
 import {
 	countCommunityForksByListingIds,
@@ -291,6 +292,7 @@ export async function publishCommunityListing(input: {
 		throw new Error('Saved packages require a root package.json file.')
 	}
 	const license = parseRawPackageLicense(packageJsonContent)
+	assertPackageNotPrivateForCommunityPublish(packageJsonContent)
 
 	const readme = buildPackageReadmeDetail({
 		files: loadedSource.files,

--- a/packages/worker/src/mcp/capabilities/community/publish.ts
+++ b/packages/worker/src/mcp/capabilities/community/publish.ts
@@ -13,7 +13,7 @@ export const communityPublishCapability = defineDomainCapability(
 	{
 		name: 'community_publish',
 		description:
-			'Publish a saved package as a public community listing on this deployment. Requires MIT license in package.json `license`, a root README with a `## Intent` section, and a published commit. Publishing shares the pinned snapshot publicly with all users on this deployment. Re-publishing the same package updates the listing to the current published commit.',
+			'Publish a saved package as a public community listing on this deployment. Requires MIT license in package.json `license`, `"private"` not set to true, a root README with a `## Intent` section, and a published commit. Publishing shares the pinned snapshot publicly with all users on this deployment. Re-publishing the same package updates the listing to the current published commit.',
 		keywords: [
 			'community',
 			'publish',

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -7,9 +7,14 @@ import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 import { getEntitySourceByEntity } from '#worker/repo/entity-sources.ts'
 import {
 	assertPackageSourceOverwriteAllowed,
+	assertPackagePrivateVisibilityChangeAllowed,
+	defaultPackagePrivateGuidance,
 	destructiveOverwriteConfirmationDescription,
+	loadPriorPackageManifestContent,
+	privateVisibilityChangeConfirmationDescription,
 	productionPackageSourceSafetyPolicy,
 } from '#worker/repo/source-safety-policy.ts'
+import { injectDefaultPrivateField } from '#worker/package-registry/package-private.ts'
 import {
 	getSavedPackageById,
 	getSavedPackageByKodyId,
@@ -42,6 +47,11 @@ const inputSchema = z
 			.optional()
 			.default(false)
 			.describe(destructiveOverwriteConfirmationDescription),
+		confirm_private_visibility_change: z
+			.boolean()
+			.optional()
+			.default(false)
+			.describe(privateVisibilityChangeConfirmationDescription),
 	})
 	.superRefine((value, ctx) => {
 		const hasPackageJson = value.files.some(
@@ -69,7 +79,7 @@ export const savePackageCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
 		name: 'package_save',
-		description: `Create or replace a saved package by writing a complete package file set. Prefer package_get_git_remote or repo sessions for iterative edits. The package repo is rooted at package.json and package.json#kody is the Kody-specific metadata block. When creating or materially changing a package, include or maintain README.md with a concise Intent section that captures the user-defined goal; ask the user if intent is unclear. ${productionPackageSourceSafetyPolicy}`,
+		description: `Create or replace a saved package by writing a complete package file set. Prefer package_get_git_remote or repo sessions for iterative edits. The package repo is rooted at package.json and package.json#kody is the Kody-specific metadata block. When creating or materially changing a package, include or maintain README.md with a concise Intent section that captures the user-defined goal; ask the user if intent is unclear. ${defaultPackagePrivateGuidance} ${productionPackageSourceSafetyPolicy}`,
 		keywords: [
 			'package',
 			'save',
@@ -87,8 +97,8 @@ export const savePackageCapability = defineDomainCapability(
 		outputSchema: packageSummarySchema,
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
-			const files = normalizeFiles(args.files)
-			const packageJsonContent = files['package.json']
+			let files = normalizeFiles(args.files)
+			let packageJsonContent = files['package.json']
 			if (!packageJsonContent) {
 				throw new Error('Saved packages require a root package.json file.')
 			}
@@ -96,11 +106,6 @@ export const savePackageCapability = defineDomainCapability(
 				ctx.env.APP_DB,
 				user,
 			)
-			const manifest = parseAuthoredPackageJson({
-				content: packageJsonContent,
-				manifestPath: 'package.json',
-				expectedPackageScope,
-			})
 			const existing =
 				args.package_id !== undefined
 					? await getSavedPackageById(ctx.env.APP_DB, {
@@ -109,8 +114,21 @@ export const savePackageCapability = defineDomainCapability(
 						})
 					: await getSavedPackageByKodyId(ctx.env.APP_DB, {
 							userId: user.userId,
-							kodyId: manifest.kody.id,
+							kodyId: parseAuthoredPackageJson({
+								content: packageJsonContent,
+								manifestPath: 'package.json',
+								expectedPackageScope,
+							}).kody.id,
 						})
+			if (!existing) {
+				packageJsonContent = injectDefaultPrivateField(packageJsonContent)
+				files = { ...files, 'package.json': packageJsonContent }
+			}
+			const manifest = parseAuthoredPackageJson({
+				content: packageJsonContent,
+				manifestPath: 'package.json',
+				expectedPackageScope,
+			})
 			const packageId = existing?.id ?? args.package_id ?? crypto.randomUUID()
 			const canonicalExistingSource =
 				existing == null
@@ -129,6 +147,24 @@ export const savePackageCapability = defineDomainCapability(
 				sourceRoot: '/',
 				manifestPath: 'package.json',
 				requirePersistence: true,
+			})
+			const priorManifestContent =
+				existing == null
+					? null
+					: await loadPriorPackageManifestContent({
+							env: ctx.env,
+							userId: user.userId,
+							source:
+								canonicalExistingSource?.id === ensuredSource.id
+									? canonicalExistingSource
+									: ensuredSource,
+						})
+			assertPackagePrivateVisibilityChangeAllowed({
+				beforeContent: priorManifestContent,
+				afterContent: packageJsonContent,
+				isNewPackage: existing == null,
+				operation: 'package_save',
+				confirmed: args.confirm_private_visibility_change,
 			})
 			if (existing) {
 				await assertPackageSourceOverwriteAllowed({
@@ -150,6 +186,8 @@ export const savePackageCapability = defineDomainCapability(
 				bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
 				files,
 				destructiveOverwriteConfirmed: args.confirm_destructive_overwrite,
+				privateVisibilityChangeConfirmed:
+					args.confirm_private_visibility_change,
 			})
 			if (!existing) {
 				const now = new Date().toISOString()

--- a/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
@@ -4,8 +4,8 @@ import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
 import {
+	repoPublishSessionInputSchema,
 	repoPublishSessionOutputSchema,
-	repoSessionIdSchema,
 } from './repo-shared.ts'
 import { rebuildPublishedPackageArtifactsViaRepoSession } from './package-artifact-rebuild.ts'
 
@@ -14,12 +14,12 @@ export const repoPublishSessionCapability = defineDomainCapability(
 	{
 		name: 'repo_publish_session',
 		description:
-			'Publish an active repo session back to the source repo after checks pass on the current tree and the base commit is still current.',
+			'Publish an active repo session back to the source repo after checks pass on the current tree and the base commit is still current. Changing package.json `"private"` requires confirm_private_visibility_change after explicit user approval.',
 		keywords: ['repo', 'publish', 'session', 'checks', 'artifact'],
 		readOnly: false,
 		idempotent: false,
 		destructive: true,
-		inputSchema: repoSessionIdSchema,
+		inputSchema: repoPublishSessionInputSchema,
 		outputSchema: repoPublishSessionOutputSchema,
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
@@ -36,6 +36,8 @@ export const repoPublishSessionCapability = defineDomainCapability(
 					sessionInfo.entity_type === 'package'
 						? await getMcpUserPackageScope(ctx.env.APP_DB, user)
 						: undefined,
+				privateVisibilityChangeConfirmed:
+					args.confirm_private_visibility_change,
 			})
 			if (result.status === 'ok') {
 				if (sessionInfo.entity_type === 'package') {

--- a/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-run-commands.ts
@@ -110,6 +110,8 @@ export const repoRunCommandsCapability = defineDomainCapability(
 						userId: user.userId,
 						rebuildPackageArtifacts: false,
 						expectedPackageScope,
+						privateVisibilityChangeConfirmed:
+							args.confirm_private_visibility_change,
 					})
 				} else {
 					publish = { status: 'not_requested' as const }

--- a/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { repoRunCommandsCommandsFieldDescription } from './repo-run-commands-text.ts'
 import { entityKindValues } from '#worker/repo/types.ts'
+import { privateVisibilityChangeConfirmationDescription } from '#worker/repo/source-safety-policy.ts'
 
 export const repoSearchModeSchema = z.enum(['literal', 'regex'])
 export const repoSearchOutputModeSchema = z.enum(['content', 'files'])
@@ -42,6 +43,14 @@ export const repoResolvedTargetSchema = z.union([
 
 export const repoSessionIdSchema = z.object({
 	session_id: z.string().min(1).describe('Active repo session id.'),
+})
+
+export const repoPublishSessionInputSchema = repoSessionIdSchema.extend({
+	confirm_private_visibility_change: z
+		.boolean()
+		.optional()
+		.default(false)
+		.describe(privateVisibilityChangeConfirmationDescription),
 })
 
 export const repoOpenSessionInputSchema = z
@@ -328,6 +337,11 @@ export const repoRunCommandsInputSchema = z
 			.describe(
 				'Publish after successful checks. Requires run_checks to be true.',
 			),
+		confirm_private_visibility_change: z
+			.boolean()
+			.optional()
+			.default(false)
+			.describe(privateVisibilityChangeConfirmationDescription),
 	})
 	.superRefine((value, ctx) => {
 		const openRefCount =

--- a/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
@@ -649,6 +649,7 @@ test('repo_publish_session covers base_moved repair, artifact rebuild, and rebui
 		userId: 'user-1',
 		rebuildPackageArtifacts: false,
 		expectedPackageScope: 'user',
+		privateVisibilityChangeConfirmed: false,
 	})
 	expect(publishRpc.rebuildPublishedPackageArtifact).toHaveBeenCalledWith({
 		sessionId: 'session-1',

--- a/packages/worker/src/package-registry/package-private.node.test.ts
+++ b/packages/worker/src/package-registry/package-private.node.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest'
+import {
+	assertPackageNotPrivateForCommunityPublish,
+	injectDefaultPrivateField,
+	isPackagePrivate,
+	packagePrivateFieldChanged,
+	parsePackagePrivateField,
+	requiresPrivateVisibilityConfirmation,
+} from './package-private.ts'
+
+describe('parsePackagePrivateField', () => {
+	test('returns undefined when private is absent', () => {
+		expect(parsePackagePrivateField('{"name":"@a/b"}')).toBeUndefined()
+	})
+
+	test('returns boolean values', () => {
+		expect(parsePackagePrivateField('{"private":true}')).toBe(true)
+		expect(parsePackagePrivateField('{"private":false}')).toBe(false)
+	})
+
+	test('rejects non-boolean private values', () => {
+		expect(() => parsePackagePrivateField('{"private":"yes"}')).toThrow(
+			'must be a boolean',
+		)
+	})
+})
+
+describe('community publish gate', () => {
+	test('blocks private packages', () => {
+		expect(() =>
+			assertPackageNotPrivateForCommunityPublish('{"private":true}'),
+		).toThrow('community listings cannot publish packages')
+	})
+
+	test('allows public-capable packages', () => {
+		expect(() =>
+			assertPackageNotPrivateForCommunityPublish('{"private":false}'),
+		).not.toThrow()
+		expect(() => assertPackageNotPrivateForCommunityPublish('{}')).not.toThrow()
+	})
+})
+
+describe('private visibility confirmation', () => {
+	test('detects field changes', () => {
+		expect(
+			packagePrivateFieldChanged('{"private":true}', '{"private":false}'),
+		).toBe(true)
+		expect(
+			packagePrivateFieldChanged('{"private":true}', '{"private":true}'),
+		).toBe(false)
+	})
+
+	test('requires confirmation for new non-private packages', () => {
+		expect(
+			requiresPrivateVisibilityConfirmation({
+				beforeContent: null,
+				afterContent: '{"private":false}',
+				isNewPackage: true,
+			}),
+		).toBe(true)
+		expect(
+			requiresPrivateVisibilityConfirmation({
+				beforeContent: null,
+				afterContent: '{"private":true}',
+				isNewPackage: true,
+			}),
+		).toBe(false)
+	})
+})
+
+describe('injectDefaultPrivateField', () => {
+	test('adds private true when missing', () => {
+		const next = injectDefaultPrivateField('{"name":"@a/b"}\n')
+		expect(isPackagePrivate(next)).toBe(true)
+	})
+
+	test('preserves an explicit private value', () => {
+		const next = injectDefaultPrivateField('{"name":"@a/b","private":false}\n')
+		expect(parsePackagePrivateField(next)).toBe(false)
+	})
+})

--- a/packages/worker/src/package-registry/package-private.ts
+++ b/packages/worker/src/package-registry/package-private.ts
@@ -1,0 +1,72 @@
+export type PackagePrivateFieldValue = true | false | undefined
+
+function parsePackageJsonRecord(content: string): Record<string, unknown> {
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(content)
+	} catch {
+		throw new Error('Saved package package.json must be valid JSON.')
+	}
+	if (typeof parsed !== 'object' || parsed == null || Array.isArray(parsed)) {
+		throw new Error('Saved package package.json must be a JSON object.')
+	}
+	return parsed as Record<string, unknown>
+}
+
+export function parsePackagePrivateField(
+	content: string,
+): PackagePrivateFieldValue {
+	const parsed = parsePackageJsonRecord(content)
+	if (!('private' in parsed)) {
+		return undefined
+	}
+	const value = parsed['private']
+	if (value === true) return true
+	if (value === false) return false
+	throw new Error(
+		'Saved package package.json field "private" must be a boolean when present.',
+	)
+}
+
+export function isPackagePrivate(content: string): boolean {
+	return parsePackagePrivateField(content) === true
+}
+
+export function packagePrivateFieldChanged(
+	beforeContent: string | null | undefined,
+	afterContent: string,
+): boolean {
+	const before =
+		beforeContent == null ? undefined : parsePackagePrivateField(beforeContent)
+	const after = parsePackagePrivateField(afterContent)
+	return before !== after
+}
+
+export function requiresPrivateVisibilityConfirmation(input: {
+	beforeContent: string | null | undefined
+	afterContent: string
+	isNewPackage: boolean
+}): boolean {
+	if (input.isNewPackage) {
+		return !isPackagePrivate(input.afterContent)
+	}
+	return packagePrivateFieldChanged(input.beforeContent, input.afterContent)
+}
+
+export function assertPackageNotPrivateForCommunityPublish(
+	packageJsonContent: string,
+) {
+	if (isPackagePrivate(packageJsonContent)) {
+		throw new Error(
+			'community listings cannot publish packages with `"private": true` in package.json; set `"private": false` or remove `private` after the user explicitly approves public community sharing.',
+		)
+	}
+}
+
+export function injectDefaultPrivateField(content: string): string {
+	const parsed = parsePackageJsonRecord(content)
+	if ('private' in parsed) {
+		return content
+	}
+	return `${JSON.stringify({ ...parsed, private: true }, null, '\t')}\n`
+}

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -65,9 +65,11 @@ import {
 	publishFromExternalRef as publishExternalRefSource,
 } from './external-publish.ts'
 import {
+	assertPackagePrivateVisibilityChangeAllowed,
 	assertPackageSourceOverwriteAllowed,
 	assertPublishedPackageSourceRepoHead,
 	buildSourceRecoveryProblemMessage,
+	loadPriorPackageManifestContent,
 } from './source-safety-policy.ts'
 import {
 	attachPublishGitNoteBestEffort,
@@ -1735,6 +1737,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		userId: string
 		force?: boolean
 		destructiveOverwriteConfirmed?: boolean
+		privateVisibilityChangeConfirmed?: boolean
 		rebuildPackageArtifacts?: boolean
 		expectedPackageScope?: string
 	}): Promise<RepoSessionPublishResult> {
@@ -1777,6 +1780,25 @@ class RepoSessionBase extends DurableObject<Env> {
 				source,
 				operation: 'repo forced publish',
 				confirmed: input.destructiveOverwriteConfirmed,
+			})
+		}
+		if (source.entity_kind === 'package') {
+			const workspaceFiles = await this.collectWorkspaceFiles()
+			const afterContent = workspaceFiles[source.manifest_path]
+			if (typeof afterContent !== 'string') {
+				throw new Error(`Manifest "${source.manifest_path}" was not found.`)
+			}
+			const beforeContent = await loadPriorPackageManifestContent({
+				env: this.env,
+				userId: input.userId,
+				source,
+			})
+			assertPackagePrivateVisibilityChangeAllowed({
+				beforeContent,
+				afterContent,
+				isNewPackage: false,
+				operation: 'repo publish',
+				confirmed: input.privateVisibilityChangeConfirmed,
 			})
 		}
 		const sessionHeadCommit =

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -129,6 +129,7 @@ export type RepoSessionRpc = {
 		userId: string
 		force?: boolean
 		destructiveOverwriteConfirmed?: boolean
+		privateVisibilityChangeConfirmed?: boolean
 		rebuildPackageArtifacts?: boolean
 		expectedPackageScope?: string
 	}) => Promise<RepoSessionPublishResult>

--- a/packages/worker/src/repo/source-safety-policy.ts
+++ b/packages/worker/src/repo/source-safety-policy.ts
@@ -1,5 +1,10 @@
 import { loadPublishedSourceSnapshot } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import {
+	requiresPrivateVisibilityConfirmation,
+	type PackagePrivateFieldValue,
+	parsePackagePrivateField,
+} from '#worker/package-registry/package-private.ts'
+import {
 	type ArtifactRepoHandle,
 	resolveArtifactDefaultBranchHead,
 	resolveExistingArtifactSourceRepo,
@@ -9,11 +14,20 @@ import { type EntitySourceRow } from './types.ts'
 export const productionPackageSourceSafetyPolicy =
 	'Production package source safety policy: never replace source history, force publish, or package_save over an existing package unless Kody has created a restorable backup snapshot and the user explicitly approved destructive overwrite. If existing source cannot be cloned or verified, stop and report the source recovery problem.'
 
+export const defaultPackagePrivateGuidance =
+	'Default new saved packages to `"private": true` in package.json unless the user explicitly wants public community publishing. Like npm, `"private": true` blocks community listings on this deployment.'
+
 export const destructiveOverwriteConfirmationField =
 	'confirm_destructive_overwrite'
 
 export const destructiveOverwriteConfirmationDescription =
 	'Set to true only when the user explicitly approved destructive overwrite of existing package source history. Kody still verifies a restorable backup snapshot before publishing.'
+
+export const privateVisibilityChangeConfirmationField =
+	'confirm_private_visibility_change'
+
+export const privateVisibilityChangeConfirmationDescription =
+	'Set to true only when the user explicitly approved changing package.json `"private"` or creating a package without `"private": true`. This gates community publishing the same way npm blocks public registry publish for private packages.'
 
 export function buildSourceRecoveryProblemMessage(input: {
 	source: EntitySourceRow
@@ -239,4 +253,86 @@ export async function assertPackageSourceOverwriteAllowed(input: {
 		)
 	}
 	return await assertRestorablePackageSourceSnapshot(input)
+}
+
+function describePackagePrivateField(
+	value: PackagePrivateFieldValue | 'missing',
+): string {
+	if (value === true) return '"private": true'
+	if (value === false) return '"private": false'
+	return 'no "private" field'
+}
+
+function buildPrivateVisibilityChangeConfirmationMessage(input: {
+	operation: string
+	beforeContent: string | null | undefined
+	afterContent: string
+	isNewPackage: boolean
+}) {
+	const afterValue = parsePackagePrivateField(input.afterContent)
+	const beforeValue =
+		input.beforeContent == null
+			? 'missing'
+			: parsePackagePrivateField(input.beforeContent)
+	if (input.isNewPackage) {
+		return [
+			`${input.operation} would create a package that is not private-only (${describePackagePrivateField(afterValue)}).`,
+			`Set ${privateVisibilityChangeConfirmationField}: true only after the user explicitly approves making the package eligible for public community publishing.`,
+		].join(' ')
+	}
+	return [
+		`${input.operation} would change package.json private visibility from ${describePackagePrivateField(beforeValue)} to ${describePackagePrivateField(afterValue)}.`,
+		`Set ${privateVisibilityChangeConfirmationField}: true only after the user explicitly approves the visibility change.`,
+	].join(' ')
+}
+
+export function assertPackagePrivateVisibilityChangeAllowed(input: {
+	beforeContent: string | null | undefined
+	afterContent: string
+	isNewPackage: boolean
+	operation: string
+	confirmed?: boolean
+}) {
+	if (
+		!requiresPrivateVisibilityConfirmation({
+			beforeContent: input.beforeContent,
+			afterContent: input.afterContent,
+			isNewPackage: input.isNewPackage,
+		})
+	) {
+		return
+	}
+	if (input.confirmed !== true) {
+		throw new Error(
+			buildPrivateVisibilityChangeConfirmationMessage({
+				operation: input.operation,
+				beforeContent: input.beforeContent,
+				afterContent: input.afterContent,
+				isNewPackage: input.isNewPackage,
+			}),
+		)
+	}
+}
+
+export async function loadPriorPackageManifestContent(input: {
+	env: Env
+	userId: string
+	source: EntitySourceRow
+}): Promise<string | null> {
+	if (
+		input.source.entity_kind !== 'package' ||
+		!input.source.published_commit
+	) {
+		return null
+	}
+	const snapshot = await loadPublishedSourceSnapshot({
+		env: input.env,
+		userId: input.userId,
+		source: input.source,
+	})
+	if (!snapshot) {
+		return null
+	}
+	const manifestContent = snapshot.files[input.source.manifest_path]
+	return typeof manifestContent === 'string' ? manifestContent : null
 }

--- a/packages/worker/src/repo/source-sync.ts
+++ b/packages/worker/src/repo/source-sync.ts
@@ -22,6 +22,7 @@ type SyncArtifactSourceInput = {
 	files: Record<string, string>
 	bootstrapAccess?: ArtifactBootstrapAccess | null
 	destructiveOverwriteConfirmed?: boolean
+	privateVisibilityChangeConfirmed?: boolean
 }
 
 function validateEntitySourceManifest(input: {
@@ -186,6 +187,9 @@ export async function syncArtifactSourceSnapshot(
 			force: true,
 			...(input.destructiveOverwriteConfirmed === true
 				? { destructiveOverwriteConfirmed: true }
+				: {}),
+			...(input.privateVisibilityChangeConfirmed === true
+				? { privateVisibilityChangeConfirmed: true }
 				: {}),
 		})
 		if (publishResult.status !== 'ok') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Treat `package.json#private` like npm for community publishing: `"private": true` blocks public community listings, agents default new packages to private, and changing visibility requires explicit user confirmation.

## Summary

- **Community gate:** `community_publish` rejects packages with `"private": true` (account publish still works).
- **Confirmation:** `confirm_private_visibility_change: true` is required when changing `private` on `package_save`, `repo_publish_session`, or `repo_run_commands` publish — only after the user explicitly approves.
- **Default:** New packages created via `package_save` get `"private": true` injected when the field is omitted.
- **Forks:** Community forks rewrite `package.json` to `"private": true`.
- **Agent guidance:** Updated `package_save` description, `community_publish` description, and package authoring docs.

## Testing

- `package-private.node.test.ts` — parsing, community gate, confirmation rules, default injection
- `community-service.node.test.ts` — rejects private packages at publish time
- `fork-scan.node.test.ts` — fork sets `private: true`
- Updated `repo-workflow.node.test.ts` for new publish flag
- Typecheck and lint pass locally

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/package-private-visibility-2208`

**Classification:** extends — community listing and saved-package publish contracts gain a new npm-aligned visibility gate; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | storage | extends — `package_save` / repo publish require confirmation to change `private`; new packages default to `"private": true` |
| `community-listings` | surfaces | extends — `community_publish` rejects `"private": true` snapshots |
| `mcp-server` | surfaces | composes — capability descriptions and input schemas document the new confirmation field |

### System map

```mermaid
flowchart LR
  save[package_save] -->|default private:true| files[package.json]
  save -->|confirm_private_visibility_change| gate{visibility change?}
  repo[repo_publish_session] --> gate
  gate -->|approved| acct[account publish]
  acct --> comm[community_publish]
  comm -->|private:true| block[reject]
  comm -->|MIT + Intent + not private| listing[public listing]
```

### Notes

- Per-user isolation unchanged; community listings remain deployment-scoped public snapshots.
- Account-scoped publishing is intentionally **not** blocked by `private: true` — only community publishing.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2ddc-2987-7922-8f93-5eaf7b062208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2ddc-2987-7922-8f93-5eaf7b062208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

