### PR TITLE
Load-then-render SPA navigation with subtle top progress bar

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -95,6 +95,30 @@ submissions (`GET`/`POST`) and routes them in-place through the client router.
 Normal app navigations stay in-place through the client router instead of
 requiring a full document refresh.
 
+### Preload-then-commit
+
+SPA navigations use a **preload-then-commit** model (similar to React Router
+data routers): before `history.pushState` and the route swap, the client router
+runs a registered **route loader** for the destination URL, fetches JSON API
+data, and stores it in a single-slot preloaded navigation store. Only after the
+loader finishes (or is skipped when no loader matches) does the router commit
+the URL change and notify subscribers. Route components consume that payload
+synchronously on first render via `tryConsumeRouteLoaderData`, so the UI updates
+once with data already present instead of swapping routes into a loading state.
+
+Route loaders are registered in `clientRouteLoaders` (`routes/index.tsx`) and
+matched with the same Remix route-pattern specificity as `clientRoutes`. Loaders
+return `null` to abort the SPA navigation (for example, `401` → full-page login
+redirect). Loader errors still commit the navigation so the destination route
+can fall back to its own fetch. Hash-only changes commit immediately without a
+loader. Back/forward (`popstate`) and same-path refreshes after form POST also
+run loaders before notifying, keeping the previous UI visible until data is
+ready.
+
+A thin top-of-viewport **navigation progress bar** listens for `navigationstart`
+/ `navigationend` on `routerEvents` and appears only when a navigation is still
+pending after a short delay.
+
 Full page navigations occur for:
 
 - Explicit browser reloads/new tab loads

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -108,12 +108,26 @@ once with data already present instead of swapping routes into a loading state.
 
 Route loaders are registered in `clientRouteLoaders` (`routes/index.tsx`) and
 matched with the same Remix route-pattern specificity as `clientRoutes`. Loaders
-return `null` to abort the SPA navigation (for example, `401` → full-page login
-redirect). Loader errors still commit the navigation so the destination route
-can fall back to its own fetch. Hash-only changes commit immediately without a
-loader. Back/forward (`popstate`) and same-path refreshes after form POST also
-run loaders before notifying, keeping the previous UI visible until data is
-ready.
+return a `RouteLoaderRedirect` (via `routeLoaderRedirect`) to abort the SPA
+navigation with a full-document redirect (for example, `401` → login). The
+router performs the redirect, never the loader itself, so speculative loader
+runs stay side-effect free. Loader errors still commit the navigation so the
+destination route can fall back to its own fetch. Hash-only changes commit
+immediately without a loader. Back/forward (`popstate`) and same-path refreshes
+after form POST also run loaders before notifying, keeping the previous UI
+visible until data is ready.
+
+### Intent prefetch
+
+Like React Router's `prefetch="intent"`, the client router speculatively runs
+the destination's route loader when the user shows intent to navigate —
+`mouseover`, `focusin`, or `touchstart` on a same-origin link with a registered
+loader (`intent-prefetch.ts`). A single latest-wins slot holds the speculative
+run; hovering a different link aborts the previous prefetch. When the click
+lands, the navigation adopts the in-flight or freshly settled prefetch instead
+of starting the loader from scratch; results expire after a short TTL and
+failures fall back to a normal loader run. Form POSTs abort any pending prefetch
+so pre-mutation data is never shown. Opt a link out with `data-prefetch="none"`.
 
 A thin top-of-viewport **navigation progress bar** listens for `navigationstart`
 / `navigationend` on `routerEvents` and appears only when a navigation is still

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -112,10 +112,12 @@ return a `RouteLoaderRedirect` (via `routeLoaderRedirect`) to abort the SPA
 navigation with a full-document redirect (for example, `401` → login). The
 router performs the redirect, never the loader itself, so speculative loader
 runs stay side-effect free. Loader errors still commit the navigation so the
-destination route can fall back to its own fetch. Hash-only changes commit
-immediately without a loader. Back/forward (`popstate`) and same-path refreshes
-after form POST also run loaders before notifying, keeping the previous UI
-visible until data is ready.
+destination route can fall back to its own fetch; the router marks the
+destination stale (`markNavigationDataStale`) so same-path refreshes — where no
+href change would otherwise trigger a refetch — still reload. Hash-only changes
+commit immediately without a loader. Back/forward (`popstate`) and same-path
+refreshes after form POST also run loaders before notifying, keeping the
+previous UI visible until data is ready.
 
 ### Intent prefetch
 

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -1,7 +1,12 @@
 import { type Handle, css } from 'remix/ui'
-import { clientRoutes } from './routes/index.tsx'
-import { listenToRouterNavigation, Router } from './client-router.tsx'
+import { clientRouteLoaders, clientRoutes } from './routes/index.tsx'
+import {
+	listenToRouterNavigation,
+	registerRouteLoaders,
+	Router,
+} from './client-router.tsx'
 import { AppLoaderDataProvider } from './loader-data-context.tsx'
+import { NavigationProgress } from './navigation-progress.tsx'
 import { readRouterPathname, readRouterSearch } from './router-location.tsx'
 import {
 	fetchSessionInfo,
@@ -14,6 +19,8 @@ import { type AppLoaderData } from '#app/loader-data.ts'
 import { userHasRole } from '#app/permissions.ts'
 import { buildAuthLink } from './auth-links.ts'
 import { colors, mq, spacing, typography } from './styles/tokens.ts'
+
+registerRouteLoaders(clientRouteLoaders)
 
 type AppProps = {
 	embeddedSession?: SessionInfo | null
@@ -144,6 +151,7 @@ export function App(handle: Handle<AppProps>) {
 
 		return (
 			<AppLoaderDataProvider loaderData={handle.props.loaderData}>
+				<NavigationProgress />
 				<main
 					mix={css({
 						maxWidth: isWideLayout ? 'none' : '52rem',

--- a/packages/worker/client/client-router.node.test.ts
+++ b/packages/worker/client/client-router.node.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest'
-import { matchRoute } from './client-router.tsx'
+import {
+	matchRoute,
+	matchRouteLoader,
+	type RouteLoader,
+} from './client-router.tsx'
 
 test('client route matching uses Remix route-pattern specificity', () => {
 	const tokenDetailRoute = 'token-detail-route' as unknown as JSX.Element
@@ -30,5 +34,47 @@ test('client route matching handles nested static routes over dynamic parents', 
 	)
 	expect(matchRoute('/account/secrets/secret-1', routes)).toBe(
 		genericSecretRoute,
+	)
+})
+
+test('route loader matching uses the same route-pattern specificity', () => {
+	const accountLoader = (async () => ({
+		accountProfile: { ok: true },
+	})) as RouteLoader
+	const tokenLoader = (async () => ({
+		accountPackageInvocationTokens: { ok: true },
+	})) as RouteLoader
+	const loaders = {
+		'/account/package-invocation-tokens/:tokenId': tokenLoader,
+		'/account/package-invocation-tokens/new': tokenLoader,
+		'/account': accountLoader,
+	}
+
+	expect(matchRouteLoader('/account', loaders)).toBe(accountLoader)
+	expect(
+		matchRouteLoader('/account/package-invocation-tokens/new', loaders),
+	).toBe(tokenLoader)
+	expect(
+		matchRouteLoader('/account/package-invocation-tokens/token-1', loaders),
+	).toBe(tokenLoader)
+})
+
+test('route loader matching prefers nested static routes over dynamic parents', () => {
+	const genericSecretLoader = (async () => ({
+		accountSecrets: { ok: true },
+	})) as RouteLoader
+	const userSecretLoader = (async () => ({
+		accountSecrets: { ok: true },
+	})) as RouteLoader
+	const loaders = {
+		'/account/secrets/:secretId': genericSecretLoader,
+		'/account/secrets/user/:secretName': userSecretLoader,
+	}
+
+	expect(matchRouteLoader('/account/secrets/user/github-token', loaders)).toBe(
+		userSecretLoader,
+	)
+	expect(matchRouteLoader('/account/secrets/secret-1', loaders)).toBe(
+		genericSecretLoader,
 	)
 })

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -1,11 +1,17 @@
 import { addEventListeners, type Handle } from 'remix/ui'
 import { createMultiMatcher } from 'remix/route-pattern/match'
 import { type AppLoaderData } from '#app/loader-data.ts'
+import { setPreloadedNavigationData } from './navigation-data.ts'
 import {
 	readRouterPathname,
 	readRouterUrl,
 	readSsrRouterUrl,
 } from './router-location.tsx'
+
+export type RouteLoader = (
+	url: URL,
+	signal: AbortSignal,
+) => Promise<Partial<AppLoaderData> | null>
 
 type RouterSetup = {
 	routes: Record<string, JSX.Element>
@@ -23,16 +29,37 @@ type FormSubmitDetails = {
 	formData: FormData
 }
 
+type NavigationRunOptions = {
+	/** Browser already changed the URL (popstate / same-path refresh). */
+	skipPushState?: boolean
+	/** Form POST already dispatched `navigationstart`; loader owns `navigationend`. */
+	suppressStart?: boolean
+}
+
 const clientRouteOrigin = 'https://kody.local'
 const routeMatchers = new WeakMap<
 	Record<string, JSX.Element>,
 	ReturnType<typeof createRouteMatcher>
 >()
+const loaderMatchers = new WeakMap<
+	Record<string, RouteLoader>,
+	ReturnType<typeof createLoaderMatcher>
+>()
 export const routerEvents = new EventTarget()
 let routerInitialized = false
+let registeredRouteLoaders: Record<string, RouteLoader> = {}
+let navigationAbortController: AbortController | null = null
 
 function notify() {
 	routerEvents.dispatchEvent(new Event('navigate'))
+}
+
+function dispatchNavigationStart() {
+	routerEvents.dispatchEvent(new Event('navigationstart'))
+}
+
+function dispatchNavigationEnd() {
+	routerEvents.dispatchEvent(new Event('navigationend'))
 }
 
 function createRouteMatcher(routes: Record<string, JSX.Element>) {
@@ -43,12 +70,41 @@ function createRouteMatcher(routes: Record<string, JSX.Element>) {
 	return matcher
 }
 
+function createLoaderMatcher(loaders: Record<string, RouteLoader>) {
+	const matcher = createMultiMatcher<RouteLoader>()
+	for (const [pattern, loader] of Object.entries(loaders)) {
+		matcher.add(pattern, loader)
+	}
+	return matcher
+}
+
 function getRouteMatcher(routes: Record<string, JSX.Element>) {
 	const existing = routeMatchers.get(routes)
 	if (existing) return existing
 	const matcher = createRouteMatcher(routes)
 	routeMatchers.set(routes, matcher)
 	return matcher
+}
+
+function getLoaderMatcher(loaders: Record<string, RouteLoader>) {
+	const existing = loaderMatchers.get(loaders)
+	if (existing) return existing
+	const matcher = createLoaderMatcher(loaders)
+	loaderMatchers.set(loaders, matcher)
+	return matcher
+}
+
+export function registerRouteLoaders(loaders: Record<string, RouteLoader>) {
+	registeredRouteLoaders = loaders
+	loaderMatchers.delete(loaders)
+}
+
+export function matchRouteLoader(
+	path: string | URL,
+	loaders: Record<string, RouteLoader> = registeredRouteLoaders,
+): RouteLoader | null {
+	const url = typeof path === 'string' ? new URL(path, clientRouteOrigin) : path
+	return getLoaderMatcher(loaders).match(url)?.data ?? null
 }
 
 export function matchRoute(
@@ -186,15 +242,83 @@ function getPathWithSearchAndHashFromUrl(url: URL) {
 	return `${url.pathname}${url.search}${url.hash}`
 }
 
-function navigateWithRefreshForSamePath(destination: URL) {
+function getCurrentPathWithSearchAndHash() {
+	if (typeof window === 'undefined') return '/'
+	return `${window.location.pathname}${window.location.search}${window.location.hash}`
+}
+
+function commitNavigation(nextPath: string) {
+	window.history.pushState({}, '', nextPath)
+	notify()
+}
+
+function commitImmediateNavigation(nextPath: string) {
+	dispatchNavigationStart()
+	commitNavigation(nextPath)
+	dispatchNavigationEnd()
+}
+
+async function runNavigationWithLoader(
+	destination: URL,
+	options?: NavigationRunOptions,
+) {
+	navigationAbortController?.abort()
+	const abortController = new AbortController()
+	navigationAbortController = abortController
+	const { signal } = abortController
+
+	if (!options?.suppressStart) {
+		dispatchNavigationStart()
+	}
+
+	const nextPath = getPathWithSearchAndHashFromUrl(destination)
+	const loader = matchRouteLoader(destination)
+
+	try {
+		if (loader) {
+			const data = await loader(destination, signal)
+			if (signal.aborted) return
+			if (data === null) {
+				dispatchNavigationEnd()
+				return
+			}
+			setPreloadedNavigationData(nextPath, data)
+		}
+
+		if (signal.aborted) return
+
+		if (options?.skipPushState) {
+			notify()
+		} else {
+			commitNavigation(nextPath)
+		}
+		dispatchNavigationEnd()
+	} catch {
+		if (signal.aborted) return
+		if (options?.skipPushState) {
+			notify()
+		} else {
+			commitNavigation(nextPath)
+		}
+		dispatchNavigationEnd()
+	}
+}
+
+async function navigateWithRefreshForSamePath(
+	destination: URL,
+	options?: Pick<NavigationRunOptions, 'suppressStart'>,
+) {
 	if (
 		getPathWithSearchAndHashFromUrl(destination) ===
 		getCurrentPathWithSearchAndHash()
 	) {
-		notify()
+		await runNavigationWithLoader(new URL(window.location.href), {
+			skipPushState: true,
+			suppressStart: options?.suppressStart,
+		})
 		return
 	}
-	navigate(destination.toString())
+	await navigateInternal(destination.toString(), options)
 }
 
 async function submitFormThroughRouter(details: FormSubmitDetails) {
@@ -203,41 +327,56 @@ async function submitFormThroughRouter(details: FormSubmitDetails) {
 		return
 	}
 
-	const init: RequestInit = {
-		method: details.method.toUpperCase(),
-		credentials: 'include',
-		redirect: 'follow',
-	}
+	// One `navigationstart` covers the POST fetch and the follow-up loader run;
+	// `navigateWithRefreshForSamePath` / `navigateInternal` suppress a second
+	// start and own the matching `navigationend`.
+	dispatchNavigationStart()
 
-	if (details.enctype === 'application/x-www-form-urlencoded') {
-		init.body = formDataToSearchParams(details.formData)
-		init.headers = {
-			'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+	try {
+		const init: RequestInit = {
+			method: details.method.toUpperCase(),
+			credentials: 'include',
+			redirect: 'follow',
 		}
-	} else if (details.enctype === 'text/plain') {
-		init.body = formDataToPlainText(details.formData)
-		init.headers = {
-			'Content-Type': 'text/plain;charset=UTF-8',
+
+		if (details.enctype === 'application/x-www-form-urlencoded') {
+			init.body = formDataToSearchParams(details.formData)
+			init.headers = {
+				'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+			}
+		} else if (details.enctype === 'text/plain') {
+			init.body = formDataToPlainText(details.formData)
+			init.headers = {
+				'Content-Type': 'text/plain;charset=UTF-8',
+			}
+		} else {
+			init.body = details.formData
 		}
-	} else {
-		init.body = details.formData
-	}
 
-	const response = await fetch(details.action.toString(), init)
-	if (response.redirected) {
-		navigateWithRefreshForSamePath(new URL(response.url, window.location.href))
-		return
-	}
+		const response = await fetch(details.action.toString(), init)
+		if (response.redirected) {
+			await navigateWithRefreshForSamePath(
+				new URL(response.url, window.location.href),
+				{ suppressStart: true },
+			)
+			return
+		}
 
-	const location = response.headers.get('Location')
-	if (location) {
-		navigateWithRefreshForSamePath(new URL(location, details.action))
-		return
-	}
+		const location = response.headers.get('Location')
+		if (location) {
+			await navigateWithRefreshForSamePath(new URL(location, details.action), {
+				suppressStart: true,
+			})
+			return
+		}
 
-	throw new Error(
-		`Expected redirect location after form submit (${response.status} ${response.statusText})`,
-	)
+		throw new Error(
+			`Expected redirect location after form submit (${response.status} ${response.statusText})`,
+		)
+	} catch (error: unknown) {
+		dispatchNavigationEnd()
+		console.error('Router form submit failed', error)
+	}
 }
 
 function handleDocumentSubmit(event: Event) {
@@ -252,8 +391,12 @@ function handleDocumentSubmit(event: Event) {
 	if (!details) return
 
 	event.preventDefault()
-	void submitFormThroughRouter(details).catch((error: unknown) => {
-		console.error('Router form submit failed', error)
+	void submitFormThroughRouter(details)
+}
+
+function handlePopState() {
+	void runNavigationWithLoader(new URL(window.location.href), {
+		skipPushState: true,
 	})
 }
 
@@ -261,7 +404,7 @@ function ensureRouter() {
 	if (typeof document === 'undefined') return
 	if (routerInitialized) return
 	routerInitialized = true
-	window.addEventListener('popstate', notify)
+	window.addEventListener('popstate', handlePopState)
 	document.addEventListener('click', handleDocumentClick)
 	document.addEventListener('submit', handleDocumentSubmit)
 }
@@ -289,24 +432,38 @@ export function getPathname(handle?: Pick<Handle, 'context'>) {
 	return window.location.pathname
 }
 
-function getCurrentPathWithSearchAndHash() {
-	if (typeof window === 'undefined') return '/'
-	return `${window.location.pathname}${window.location.search}${window.location.hash}`
-}
-
-export function navigate(to: string) {
-	if (typeof window === 'undefined') return
+async function navigateInternal(
+	to: string,
+	options?: Pick<NavigationRunOptions, 'suppressStart'>,
+) {
 	const destination = new URL(to, window.location.href)
 	if (destination.origin !== window.location.origin) {
 		window.location.assign(destination.toString())
 		return
 	}
 
-	const nextPath = `${destination.pathname}${destination.search}${destination.hash}`
-	if (nextPath === getCurrentPathWithSearchAndHash()) return
+	const current = new URL(window.location.href)
+	const nextPath = getPathWithSearchAndHashFromUrl(destination)
+	const currentPath = getCurrentPathWithSearchAndHash()
 
-	window.history.pushState({}, '', nextPath)
-	notify()
+	if (nextPath === currentPath) return
+
+	const sameDocumentLocation =
+		`${destination.pathname}${destination.search}` ===
+		`${current.pathname}${current.search}`
+	if (sameDocumentLocation && destination.hash !== current.hash) {
+		commitImmediateNavigation(nextPath)
+		return
+	}
+
+	await runNavigationWithLoader(destination, options)
+}
+
+export function navigate(to: string): void {
+	if (typeof window === 'undefined') return
+	void navigateInternal(to).catch(() => {
+		// Fire-and-forget: existing callers must not observe rejections.
+	})
 }
 
 type RouterHandle = Pick<Handle, 'signal' | 'update' | 'context'> & {

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -147,7 +147,12 @@ function handleDocumentClick(event: MouseEvent) {
 	navigate(`${destination.pathname}${destination.search}${destination.hash}`)
 }
 
-function getPrefetchDestination(target: EventTarget | null): URL | null {
+type PrefetchableLink = {
+	anchor: HTMLAnchorElement
+	destination: URL
+}
+
+function getPrefetchableLink(target: EventTarget | null): PrefetchableLink | null {
 	if (!(target instanceof Element)) return null
 	const anchor = target.closest('a')
 	if (!anchor || typeof window === 'undefined') return null
@@ -166,7 +171,35 @@ function getPrefetchDestination(target: EventTarget | null): URL | null {
 	) {
 		return null
 	}
-	return destination
+	return { anchor, destination }
+}
+
+function runIntentPrefetch(destination: URL) {
+	const loader = matchRouteLoader(destination)
+	if (!loader) return
+	prefetchRouteOnIntent(
+		getPathWithSearchAndHashFromUrl(destination),
+		loader,
+		destination,
+	)
+}
+
+/**
+ * Hovers shorter than this are treated as the mouse passing through, not
+ * intent to navigate, so sweeping across a nav list does not fire a
+ * speculative request per link crossed.
+ */
+const hoverIntentDelayMs = 100
+
+let hoverIntentAnchor: HTMLAnchorElement | null = null
+let hoverIntentTimer: ReturnType<typeof setTimeout> | null = null
+
+function cancelHoverIntent() {
+	if (hoverIntentTimer !== null) {
+		clearTimeout(hoverIntentTimer)
+		hoverIntentTimer = null
+	}
+	hoverIntentAnchor = null
 }
 
 /**
@@ -175,16 +208,44 @@ function getPrefetchDestination(target: EventTarget | null): URL | null {
  * loader so the data is already in flight — or already here — when the click
  * lands. Opt out per link with `data-prefetch="none"`.
  */
-function handleIntentPrefetch(event: Event) {
-	const destination = getPrefetchDestination(event.target)
-	if (!destination) return
-	const loader = matchRouteLoader(destination)
-	if (!loader) return
-	prefetchRouteOnIntent(
-		getPathWithSearchAndHashFromUrl(destination),
-		loader,
-		destination,
-	)
+function handleIntentHoverStart(event: MouseEvent) {
+	const link = getPrefetchableLink(event.target)
+	if (!link) return
+	if (hoverIntentAnchor === link.anchor) return
+
+	cancelHoverIntent()
+	hoverIntentAnchor = link.anchor
+	hoverIntentTimer = setTimeout(() => {
+		hoverIntentTimer = null
+		hoverIntentAnchor = null
+		runIntentPrefetch(link.destination)
+	}, hoverIntentDelayMs)
+}
+
+function handleIntentHoverEnd(event: MouseEvent) {
+	if (!hoverIntentAnchor) return
+	if (
+		!(event.target instanceof Node) ||
+		!hoverIntentAnchor.contains(event.target)
+	) {
+		return
+	}
+	// mouseout between an anchor's children stays "hovering"; only cancel
+	// when the pointer actually leaves the anchor.
+	if (
+		event.relatedTarget instanceof Node &&
+		hoverIntentAnchor.contains(event.relatedTarget)
+	) {
+		return
+	}
+	cancelHoverIntent()
+}
+
+/** Focus and touch are deliberate; prefetch immediately without the delay. */
+function handleImmediateIntent(event: Event) {
+	const link = getPrefetchableLink(event.target)
+	if (!link) return
+	runIntentPrefetch(link.destination)
 }
 
 function getFormSubmitter(event: SubmitEvent) {
@@ -499,9 +560,10 @@ function ensureRouter() {
 	window.addEventListener('popstate', handlePopState)
 	document.addEventListener('click', handleDocumentClick)
 	document.addEventListener('submit', handleDocumentSubmit)
-	document.addEventListener('mouseover', handleIntentPrefetch)
-	document.addEventListener('focusin', handleIntentPrefetch)
-	document.addEventListener('touchstart', handleIntentPrefetch, {
+	document.addEventListener('mouseover', handleIntentHoverStart)
+	document.addEventListener('mouseout', handleIntentHoverEnd)
+	document.addEventListener('focusin', handleImmediateIntent)
+	document.addEventListener('touchstart', handleImmediateIntent, {
 		passive: true,
 	})
 }

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -402,13 +402,16 @@ async function runNavigationWithLoader(
 	const loader = matchRouteLoader(destination)
 	activeNavigationPath = nextPath
 
+	// Adopt an intent prefetch when one is pending or fresh for this
+	// destination; otherwise run the loader now. Tying the prefetch to this
+	// navigation's signal keeps latest-wins abort semantics. Taken
+	// unconditionally (even for loaderless destinations) so a prefetch for a
+	// link the user did not follow never outlives this navigation.
+	const prefetched = takePrefetchedRouteResult(nextPath, signal)
+
 	try {
 		let loadedData: Partial<AppLoaderData> | undefined
 		if (loader) {
-			// Adopt an intent prefetch when one is pending or fresh for this
-			// destination; otherwise run the loader now. Tying the prefetch to
-			// this navigation's signal keeps latest-wins abort semantics.
-			const prefetched = takePrefetchedRouteResult(nextPath, signal)
 			const result = prefetched
 				? await prefetched
 				: await loader(destination, signal)

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -252,12 +252,17 @@ function commitNavigation(nextPath: string) {
 	notify()
 }
 
-function commitImmediateNavigation(nextPath: string) {
+function commitImmediateNavigation(
+	nextPath: string,
+	options?: Pick<NavigationRunOptions, 'suppressStart'>,
+) {
 	// A pending loader navigation must not commit after this immediate one
 	// and clobber the URL we are about to push.
 	navigationAbortController?.abort()
 	navigationAbortController = null
-	dispatchNavigationStart()
+	if (!options?.suppressStart) {
+		dispatchNavigationStart()
+	}
 	commitNavigation(nextPath)
 	dispatchNavigationEnd()
 }
@@ -279,6 +284,7 @@ async function runNavigationWithLoader(
 	const loader = matchRouteLoader(destination)
 
 	try {
+		let loadedData: Partial<AppLoaderData> | undefined
 		if (loader) {
 			const data = await loader(destination, signal)
 			if (signal.aborted) return
@@ -286,10 +292,17 @@ async function runNavigationWithLoader(
 				dispatchNavigationEnd()
 				return
 			}
-			setPreloadedNavigationData(nextPath, data)
+			loadedData = data
 		}
 
 		if (signal.aborted) return
+
+		// Store and commit in the same synchronous block so a superseding
+		// navigation can never leave consume-once data behind for a URL the
+		// user did not land on.
+		if (loadedData) {
+			setPreloadedNavigationData(nextPath, loadedData)
+		}
 
 		if (options?.skipPushState) {
 			notify()
@@ -331,6 +344,15 @@ async function submitFormThroughRouter(details: FormSubmitDetails) {
 		return
 	}
 
+	// Participate in the latest-wins navigation chain: a newer navigation
+	// aborts this submission's follow-up redirect navigation so a late
+	// response cannot hijack the URL. The POST itself is a mutation and is
+	// never cancelled client-side.
+	navigationAbortController?.abort()
+	const abortController = new AbortController()
+	navigationAbortController = abortController
+	const { signal } = abortController
+
 	// One `navigationstart` covers the POST fetch and the follow-up loader run;
 	// `navigateWithRefreshForSamePath` / `navigateInternal` suppress a second
 	// start and own the matching `navigationend`.
@@ -358,6 +380,8 @@ async function submitFormThroughRouter(details: FormSubmitDetails) {
 		}
 
 		const response = await fetch(details.action.toString(), init)
+		if (signal.aborted) return
+
 		if (response.redirected) {
 			await navigateWithRefreshForSamePath(
 				new URL(response.url, window.location.href),
@@ -378,8 +402,9 @@ async function submitFormThroughRouter(details: FormSubmitDetails) {
 			`Expected redirect location after form submit (${response.status} ${response.statusText})`,
 		)
 	} catch (error: unknown) {
-		dispatchNavigationEnd()
 		console.error('Router form submit failed', error)
+		if (signal.aborted) return
+		dispatchNavigationEnd()
 	}
 }
 
@@ -456,7 +481,7 @@ async function navigateInternal(
 		`${destination.pathname}${destination.search}` ===
 		`${current.pathname}${current.search}`
 	if (sameDocumentLocation && destination.hash !== current.hash) {
-		commitImmediateNavigation(nextPath)
+		commitImmediateNavigation(nextPath, options)
 		return
 	}
 

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -177,6 +177,14 @@ function getPrefetchableLink(
 }
 
 function runIntentPrefetch(destination: URL) {
+	// Re-check at fire time (the hover timer may outlive the hover): never
+	// speculatively refetch the page the user is already on.
+	if (
+		getPathWithSearchAndHashFromUrl(destination) ===
+		getCurrentPathWithSearchAndHash()
+	) {
+		return
+	}
 	const loader = matchRouteLoader(destination)
 	if (!loader) return
 	prefetchRouteOnIntent(
@@ -362,6 +370,7 @@ function commitImmediateNavigation(
 	nextPath: string,
 	options?: Pick<NavigationRunOptions, 'suppressStart'>,
 ) {
+	cancelHoverIntent()
 	// A pending loader navigation must not commit after this immediate one
 	// and clobber the URL we are about to push.
 	navigationAbortController?.abort()
@@ -377,6 +386,10 @@ async function runNavigationWithLoader(
 	destination: URL,
 	options?: NavigationRunOptions,
 ) {
+	// A hover-intent timer set right before the click (e.g. on mousedown)
+	// must not fire after we navigate and prefetch the page we are already
+	// heading to.
+	cancelHoverIntent()
 	navigationAbortController?.abort()
 	const abortController = new AbortController()
 	navigationAbortController = abortController
@@ -467,7 +480,8 @@ async function submitFormThroughRouter(details: FormSubmitDetails) {
 
 	// The POST is about to mutate server state, so any speculative loader data
 	// fetched before the mutation must never be adopted by the follow-up
-	// navigation.
+	// navigation — including a hover timer that has not fired yet.
+	cancelHoverIntent()
 	abortIntentPrefetch()
 
 	// Participate in the latest-wins navigation chain: a newer navigation

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -253,6 +253,10 @@ function commitNavigation(nextPath: string) {
 }
 
 function commitImmediateNavigation(nextPath: string) {
+	// A pending loader navigation must not commit after this immediate one
+	// and clobber the URL we are about to push.
+	navigationAbortController?.abort()
+	navigationAbortController = null
 	dispatchNavigationStart()
 	commitNavigation(nextPath)
 	dispatchNavigationEnd()

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -6,7 +6,10 @@ import {
 	prefetchRouteOnIntent,
 	takePrefetchedRouteResult,
 } from './intent-prefetch.ts'
-import { setPreloadedNavigationData } from './navigation-data.ts'
+import {
+	markNavigationDataStale,
+	setPreloadedNavigationData,
+} from './navigation-data.ts'
 import { isRouteLoaderRedirect, type RouteLoader } from './route-loader.ts'
 import {
 	readRouterPathname,
@@ -449,6 +452,11 @@ async function runNavigationWithLoader(
 		dispatchNavigationEnd()
 	} catch {
 		if (signal.aborted) return
+		// The loader failed, so no preloaded data exists for the committed
+		// destination. Same-path refreshes (form POST redirects back to the
+		// current URL) have no href change to trigger a route's fallback
+		// refetch, so mark the destination stale for routes to consume.
+		markNavigationDataStale(nextPath)
 		if (options?.skipPushState) {
 			notify()
 		} else {

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -289,6 +289,14 @@ async function runNavigationWithLoader(
 			const data = await loader(destination, signal)
 			if (signal.aborted) return
 			if (data === null) {
+				// The loader handled the navigation externally (e.g. a 401 →
+				// login redirect). When the browser URL already moved
+				// (popstate), still sync the UI to it so the app does not
+				// render the previous route under the new URL while the full
+				// document navigation loads.
+				if (options?.skipPushState) {
+					notify()
+				}
 				dispatchNavigationEnd()
 				return
 			}

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -257,6 +257,10 @@ function handleIntentHoverEnd(event: MouseEvent) {
 function handleImmediateIntent(event: Event) {
 	const link = getPrefetchableLink(event.target)
 	if (!link) return
+	// A pending hover timer (possibly for a different link) must not fire
+	// after this deliberate intent and abort its prefetch — the slot is
+	// latest-wins and this is the latest intent.
+	cancelHoverIntent()
 	runIntentPrefetch(link.destination)
 }
 

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -56,8 +56,17 @@ let routerInitialized = false
 let registeredRouteLoaders: Record<string, RouteLoader> = {}
 let navigationAbortController: AbortController | null = null
 let activeNavigationPath: string | null = null
+// The pathname+search (no hash) the app last rendered. Popstate compares
+// against this to detect hash-only history moves, since `window.location`
+// has already changed by the time the event fires.
+let lastNotifiedDocumentPath: string | null = null
+
+function getCurrentDocumentPath() {
+	return `${window.location.pathname}${window.location.search}`
+}
 
 function notify() {
+	lastNotifiedDocumentPath = getCurrentDocumentPath()
 	routerEvents.dispatchEvent(new Event('navigate'))
 }
 
@@ -584,6 +593,20 @@ function handleDocumentSubmit(event: Event) {
 }
 
 function handlePopState() {
+	// Hash-only history moves have no data to load — mirror forward hash-only
+	// navigations (`commitImmediateNavigation`) and sync the UI immediately
+	// instead of running the loader.
+	if (getCurrentDocumentPath() === lastNotifiedDocumentPath) {
+		cancelHoverIntent()
+		// A pending loader navigation must not commit after this immediate
+		// one and clobber the URL the browser already restored.
+		navigationAbortController?.abort()
+		navigationAbortController = null
+		dispatchNavigationStart()
+		notify()
+		dispatchNavigationEnd()
+		return
+	}
 	void runNavigationWithLoader(new URL(window.location.href), {
 		skipPushState: true,
 	})
@@ -593,6 +616,7 @@ function ensureRouter() {
 	if (typeof document === 'undefined') return
 	if (routerInitialized) return
 	routerInitialized = true
+	lastNotifiedDocumentPath = getCurrentDocumentPath()
 	window.addEventListener('popstate', handlePopState)
 	document.addEventListener('click', handleDocumentClick)
 	document.addEventListener('submit', handleDocumentSubmit)

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -152,7 +152,9 @@ type PrefetchableLink = {
 	destination: URL
 }
 
-function getPrefetchableLink(target: EventTarget | null): PrefetchableLink | null {
+function getPrefetchableLink(
+	target: EventTarget | null,
+): PrefetchableLink | null {
 	if (!(target instanceof Element)) return null
 	const anchor = target.closest('a')
 	if (!anchor || typeof window === 'undefined') return null

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -52,6 +52,7 @@ export const routerEvents = new EventTarget()
 let routerInitialized = false
 let registeredRouteLoaders: Record<string, RouteLoader> = {}
 let navigationAbortController: AbortController | null = null
+let activeNavigationPath: string | null = null
 
 function notify() {
 	routerEvents.dispatchEvent(new Event('navigate'))
@@ -177,14 +178,12 @@ function getPrefetchableLink(
 }
 
 function runIntentPrefetch(destination: URL) {
-	// Re-check at fire time (the hover timer may outlive the hover): never
-	// speculatively refetch the page the user is already on.
-	if (
-		getPathWithSearchAndHashFromUrl(destination) ===
-		getCurrentPathWithSearchAndHash()
-	) {
-		return
-	}
+	const destinationPath = getPathWithSearchAndHashFromUrl(destination)
+	// Never speculatively refetch the page the user is already on, or the one
+	// a navigation is already loading (clicking a link focuses it, and that
+	// focusin lands after the navigation consumed the prefetch slot).
+	if (destinationPath === getCurrentPathWithSearchAndHash()) return
+	if (destinationPath === activeNavigationPath) return
 	const loader = matchRouteLoader(destination)
 	if (!loader) return
 	prefetchRouteOnIntent(
@@ -401,6 +400,7 @@ async function runNavigationWithLoader(
 
 	const nextPath = getPathWithSearchAndHashFromUrl(destination)
 	const loader = matchRouteLoader(destination)
+	activeNavigationPath = nextPath
 
 	try {
 		let loadedData: Partial<AppLoaderData> | undefined
@@ -452,6 +452,11 @@ async function runNavigationWithLoader(
 			commitNavigation(nextPath)
 		}
 		dispatchNavigationEnd()
+	} finally {
+		// A superseding navigation owns the marker now; only clear our own.
+		if (navigationAbortController === abortController) {
+			activeNavigationPath = null
+		}
 	}
 }
 

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -1,17 +1,20 @@
 import { addEventListeners, type Handle } from 'remix/ui'
 import { createMultiMatcher } from 'remix/route-pattern/match'
 import { type AppLoaderData } from '#app/loader-data.ts'
+import {
+	abortIntentPrefetch,
+	prefetchRouteOnIntent,
+	takePrefetchedRouteResult,
+} from './intent-prefetch.ts'
 import { setPreloadedNavigationData } from './navigation-data.ts'
+import { isRouteLoaderRedirect, type RouteLoader } from './route-loader.ts'
 import {
 	readRouterPathname,
 	readRouterUrl,
 	readSsrRouterUrl,
 } from './router-location.tsx'
 
-export type RouteLoader = (
-	url: URL,
-	signal: AbortSignal,
-) => Promise<Partial<AppLoaderData> | null>
+export { type RouteLoader } from './route-loader.ts'
 
 type RouterSetup = {
 	routes: Record<string, JSX.Element>
@@ -142,6 +145,46 @@ function handleDocumentClick(event: MouseEvent) {
 	event.preventDefault()
 	const destination = new URL(anchor.href, window.location.href)
 	navigate(`${destination.pathname}${destination.search}${destination.hash}`)
+}
+
+function getPrefetchDestination(target: EventTarget | null): URL | null {
+	if (!(target instanceof Element)) return null
+	const anchor = target.closest('a')
+	if (!anchor || typeof window === 'undefined') return null
+	if (anchor.dataset.prefetch === 'none') return null
+	if (anchor.target && anchor.target !== '_self') return null
+	if (anchor.hasAttribute('download')) return null
+
+	const href = anchor.getAttribute('href')
+	if (!href || href.startsWith('#')) return null
+
+	const destination = new URL(href, window.location.href)
+	if (destination.origin !== window.location.origin) return null
+	if (
+		getPathWithSearchAndHashFromUrl(destination) ===
+		getCurrentPathWithSearchAndHash()
+	) {
+		return null
+	}
+	return destination
+}
+
+/**
+ * Intent prefetch (hover / focus / touch on internal links, like React
+ * Router's `prefetch="intent"`): speculatively runs the destination's route
+ * loader so the data is already in flight — or already here — when the click
+ * lands. Opt out per link with `data-prefetch="none"`.
+ */
+function handleIntentPrefetch(event: Event) {
+	const destination = getPrefetchDestination(event.target)
+	if (!destination) return
+	const loader = matchRouteLoader(destination)
+	if (!loader) return
+	prefetchRouteOnIntent(
+		getPathWithSearchAndHashFromUrl(destination),
+		loader,
+		destination,
+	)
 }
 
 function getFormSubmitter(event: SubmitEvent) {
@@ -286,10 +329,16 @@ async function runNavigationWithLoader(
 	try {
 		let loadedData: Partial<AppLoaderData> | undefined
 		if (loader) {
-			const data = await loader(destination, signal)
+			// Adopt an intent prefetch when one is pending or fresh for this
+			// destination; otherwise run the loader now. Tying the prefetch to
+			// this navigation's signal keeps latest-wins abort semantics.
+			const prefetched = takePrefetchedRouteResult(nextPath, signal)
+			const result = prefetched
+				? await prefetched
+				: await loader(destination, signal)
 			if (signal.aborted) return
-			if (data === null) {
-				// The loader handled the navigation externally (e.g. a 401 →
+			if (isRouteLoaderRedirect(result)) {
+				// The loader wants a full-document navigation (e.g. a 401 →
 				// login redirect). When the browser URL already moved
 				// (popstate), still sync the UI to it so the app does not
 				// render the previous route under the new URL while the full
@@ -298,9 +347,10 @@ async function runNavigationWithLoader(
 					notify()
 				}
 				dispatchNavigationEnd()
+				window.location.assign(result.to)
 				return
 			}
-			loadedData = data
+			loadedData = result
 		}
 
 		if (signal.aborted) return
@@ -351,6 +401,11 @@ async function submitFormThroughRouter(details: FormSubmitDetails) {
 		navigate(buildGetDestination(details.action, details.formData).toString())
 		return
 	}
+
+	// The POST is about to mutate server state, so any speculative loader data
+	// fetched before the mutation must never be adopted by the follow-up
+	// navigation.
+	abortIntentPrefetch()
 
 	// Participate in the latest-wins navigation chain: a newer navigation
 	// aborts this submission's follow-up redirect navigation so a late
@@ -444,6 +499,11 @@ function ensureRouter() {
 	window.addEventListener('popstate', handlePopState)
 	document.addEventListener('click', handleDocumentClick)
 	document.addEventListener('submit', handleDocumentSubmit)
+	document.addEventListener('mouseover', handleIntentPrefetch)
+	document.addEventListener('focusin', handleIntentPrefetch)
+	document.addEventListener('touchstart', handleIntentPrefetch, {
+		passive: true,
+	})
 }
 
 export function listenToRouterNavigation(

--- a/packages/worker/client/entry.tsx
+++ b/packages/worker/client/entry.tsx
@@ -1,5 +1,6 @@
 import { run } from 'remix/ui'
 import { REMIX_FRAME_TARGET_HEADER } from '#app/frame-constants.ts'
+import { consumePrefetchedFrame } from '#client/frame-prefetch.ts'
 import { AppRoot, APP_ROOT_ENTRY_ID } from './app-root.tsx'
 
 const clientRegistry: Record<string, typeof AppRoot> = {
@@ -19,6 +20,10 @@ const app = run({
 		return component
 	},
 	async resolveFrame(src, signal, target) {
+		const cached = consumePrefetchedFrame(src, target)
+		if (cached !== undefined) {
+			return cached
+		}
 		const headers = new Headers({ Accept: 'text/html' })
 		if (target) {
 			headers.set(REMIX_FRAME_TARGET_HEADER, target)

--- a/packages/worker/client/frame-prefetch.ts
+++ b/packages/worker/client/frame-prefetch.ts
@@ -1,0 +1,53 @@
+import { REMIX_FRAME_TARGET_HEADER } from '#app/frame-constants.ts'
+
+type FrameCacheKey = string
+
+function makeCacheKey(src: string, target: string | undefined): FrameCacheKey {
+	return `${src}\0${target ?? ''}`
+}
+
+const frameCache = new Map<FrameCacheKey, string>()
+
+/** Clears all prefetched frame HTML. Called at the start of each prefetch. */
+export function clearPrefetchedFrames(): void {
+	frameCache.clear()
+}
+
+/**
+ * Prefetches frame HTML for `resolveFrame`. Failures are silent; a miss falls
+ * back to a normal fetch. Each prefetch clears the cache first so stale HTML
+ * from a prior navigation cannot be consumed.
+ */
+export async function prefetchFrame(
+	src: string,
+	target: string | undefined,
+	signal: AbortSignal,
+): Promise<void> {
+	clearPrefetchedFrames()
+	try {
+		const headers = new Headers({ Accept: 'text/html' })
+		if (target) {
+			headers.set(REMIX_FRAME_TARGET_HEADER, target)
+		}
+		const response = await fetch(src, { headers, signal })
+		if (signal.aborted) return
+		if (!response.ok) return
+		const text = await response.text()
+		if (signal.aborted) return
+		frameCache.set(makeCacheKey(src, target), text)
+	} catch {
+		// Prefetch failures degrade to the normal resolveFrame fetch.
+	}
+}
+
+/** Returns cached frame HTML for an exact `src` + `target` match, then deletes it. */
+export function consumePrefetchedFrame(
+	src: string,
+	target: string | undefined,
+): string | undefined {
+	const key = makeCacheKey(src, target)
+	const html = frameCache.get(key)
+	if (html === undefined) return undefined
+	frameCache.delete(key)
+	return html
+}

--- a/packages/worker/client/intent-prefetch.node.test.ts
+++ b/packages/worker/client/intent-prefetch.node.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import {
+	abortIntentPrefetch,
+	maxPrefetchAgeMs,
+	prefetchRouteOnIntent,
+	takePrefetchedRouteResult,
+} from './intent-prefetch.ts'
+import { type RouteLoader, routeLoaderRedirect } from './route-loader.ts'
+
+function createDeferredLoader() {
+	let resolve!: (value: Awaited<ReturnType<RouteLoader>>) => void
+	let reject!: (reason: unknown) => void
+	const calls: Array<{ url: URL; signal: AbortSignal }> = []
+	const loader: RouteLoader = (url, signal) => {
+		calls.push({ url, signal })
+		return new Promise((res, rej) => {
+			resolve = res
+			reject = rej
+		})
+	}
+	return {
+		loader,
+		calls,
+		resolve: (value: Awaited<ReturnType<RouteLoader>>) => resolve(value),
+		reject: (reason: unknown) => reject(reason),
+	}
+}
+
+const accountUrl = new URL('https://kody.local/account')
+
+afterEach(() => {
+	abortIntentPrefetch()
+	vi.useRealTimers()
+})
+
+test('takePrefetchedRouteResult returns the in-flight promise once', async () => {
+	const deferred = createDeferredLoader()
+	prefetchRouteOnIntent('/account', deferred.loader, accountUrl)
+
+	const taken = takePrefetchedRouteResult('/account')
+	expect(taken).not.toBeNull()
+	expect(takePrefetchedRouteResult('/account')).toBeNull()
+
+	deferred.resolve({ accountProfile: { ok: true } as never })
+	await expect(taken).resolves.toEqual({ accountProfile: { ok: true } })
+})
+
+test('takePrefetchedRouteResult ignores mismatched hrefs', () => {
+	const deferred = createDeferredLoader()
+	prefetchRouteOnIntent('/account', deferred.loader, accountUrl)
+
+	expect(takePrefetchedRouteResult('/account/secrets')).toBeNull()
+	expect(takePrefetchedRouteResult('/account')).not.toBeNull()
+})
+
+test('repeat intent for the same href reuses the in-flight run', () => {
+	const deferred = createDeferredLoader()
+	prefetchRouteOnIntent('/account', deferred.loader, accountUrl)
+	prefetchRouteOnIntent('/account', deferred.loader, accountUrl)
+	prefetchRouteOnIntent('/account', deferred.loader, accountUrl)
+
+	expect(deferred.calls).toHaveLength(1)
+})
+
+test('intent for a different href aborts the previous prefetch', () => {
+	const first = createDeferredLoader()
+	prefetchRouteOnIntent('/account', first.loader, accountUrl)
+
+	const second = createDeferredLoader()
+	prefetchRouteOnIntent(
+		'/account/secrets',
+		second.loader,
+		new URL('https://kody.local/account/secrets'),
+	)
+
+	expect(first.calls[0]?.signal.aborted).toBe(true)
+	expect(takePrefetchedRouteResult('/account')).toBeNull()
+	expect(takePrefetchedRouteResult('/account/secrets')).not.toBeNull()
+})
+
+test('failed prefetches are not adopted so navigations retry the loader', async () => {
+	const deferred = createDeferredLoader()
+	prefetchRouteOnIntent('/account', deferred.loader, accountUrl)
+	deferred.reject(new Error('network down'))
+	await Promise.resolve()
+
+	expect(takePrefetchedRouteResult('/account')).toBeNull()
+})
+
+test('failed prefetches allow a fresh run on the next intent', async () => {
+	const first = createDeferredLoader()
+	prefetchRouteOnIntent('/account', first.loader, accountUrl)
+	first.reject(new Error('network down'))
+	await Promise.resolve()
+
+	const second = createDeferredLoader()
+	prefetchRouteOnIntent('/account', second.loader, accountUrl)
+	expect(second.calls).toHaveLength(1)
+	expect(takePrefetchedRouteResult('/account')).not.toBeNull()
+})
+
+test('settled prefetches expire after maxPrefetchAgeMs', async () => {
+	vi.useFakeTimers()
+	const deferred = createDeferredLoader()
+	prefetchRouteOnIntent('/account', deferred.loader, accountUrl)
+	deferred.resolve({})
+	await Promise.resolve()
+
+	vi.advanceTimersByTime(maxPrefetchAgeMs + 1)
+	expect(takePrefetchedRouteResult('/account')).toBeNull()
+})
+
+test('expired prefetches restart on the next intent for the same href', async () => {
+	vi.useFakeTimers()
+	const first = createDeferredLoader()
+	prefetchRouteOnIntent('/account', first.loader, accountUrl)
+	first.resolve({})
+	await Promise.resolve()
+
+	vi.advanceTimersByTime(maxPrefetchAgeMs + 1)
+	const second = createDeferredLoader()
+	prefetchRouteOnIntent('/account', second.loader, accountUrl)
+	expect(second.calls).toHaveLength(1)
+})
+
+test('aborting the adopting navigation aborts the underlying prefetch', () => {
+	const deferred = createDeferredLoader()
+	prefetchRouteOnIntent('/account', deferred.loader, accountUrl)
+
+	const navigation = new AbortController()
+	const taken = takePrefetchedRouteResult('/account', navigation.signal)
+	expect(taken).not.toBeNull()
+	// Swallow the eventual AbortError rejection from the loader promise.
+	deferred.calls[0]?.signal.addEventListener('abort', () =>
+		deferred.reject(new DOMException('aborted', 'AbortError')),
+	)
+	void taken?.catch(() => {})
+
+	navigation.abort()
+	expect(deferred.calls[0]?.signal.aborted).toBe(true)
+})
+
+test('redirect results flow through prefetch adoption', async () => {
+	const deferred = createDeferredLoader()
+	prefetchRouteOnIntent('/account', deferred.loader, accountUrl)
+	const taken = takePrefetchedRouteResult('/account')
+	deferred.resolve(routeLoaderRedirect('/login'))
+
+	await expect(taken).resolves.toEqual(routeLoaderRedirect('/login'))
+})

--- a/packages/worker/client/intent-prefetch.node.test.ts
+++ b/packages/worker/client/intent-prefetch.node.test.ts
@@ -45,12 +45,16 @@ test('takePrefetchedRouteResult returns the in-flight promise once', async () =>
 	await expect(taken).resolves.toEqual({ accountProfile: { ok: true } })
 })
 
-test('takePrefetchedRouteResult ignores mismatched hrefs', () => {
+test('navigating elsewhere aborts and clears the prefetch slot', () => {
 	const deferred = createDeferredLoader()
 	prefetchRouteOnIntent('/account', deferred.loader, accountUrl)
 
+	// A navigation to a different destination consumes nothing but must
+	// invalidate the speculative result so a later navigation to /account
+	// cannot adopt data prefetched before the user went elsewhere.
 	expect(takePrefetchedRouteResult('/account/secrets')).toBeNull()
-	expect(takePrefetchedRouteResult('/account')).not.toBeNull()
+	expect(deferred.calls[0]?.signal.aborted).toBe(true)
+	expect(takePrefetchedRouteResult('/account')).toBeNull()
 })
 
 test('repeat intent for the same href reuses the in-flight run', () => {
@@ -74,8 +78,10 @@ test('intent for a different href aborts the previous prefetch', () => {
 	)
 
 	expect(first.calls[0]?.signal.aborted).toBe(true)
-	expect(takePrefetchedRouteResult('/account')).toBeNull()
+	// Consume the fresh prefetch first; taking a mismatched href clears the
+	// slot, so the stale href is checked after.
 	expect(takePrefetchedRouteResult('/account/secrets')).not.toBeNull()
+	expect(takePrefetchedRouteResult('/account')).toBeNull()
 })
 
 test('failed prefetches are not adopted so navigations retry the loader', async () => {

--- a/packages/worker/client/intent-prefetch.ts
+++ b/packages/worker/client/intent-prefetch.ts
@@ -79,15 +79,21 @@ export function prefetchRouteOnIntent(
  * Consumes the prefetched loader result for `href`. Returns the in-flight or
  * fresh settled promise, or `null` when there is no usable prefetch (wrong
  * href, expired, or failed — failures let the navigation retry the loader).
- * Consumption is one-shot. When `signal` aborts (a superseding navigation),
- * an still-running prefetch request is aborted with it.
+ * Consumption is one-shot. A mismatched href also aborts and clears the slot:
+ * the user navigated somewhere other than the prefetched link, so the
+ * speculative result must not survive to be adopted by a later navigation.
+ * When `signal` aborts (a superseding navigation), a still-running prefetch
+ * request is aborted with it.
  */
 export function takePrefetchedRouteResult(
 	href: string,
 	signal?: AbortSignal,
 ): Promise<RouteLoaderResult> | null {
 	if (!slot) return null
-	if (slot.href !== normalizePrefetchHref(href)) return null
+	if (slot.href !== normalizePrefetchHref(href)) {
+		abortIntentPrefetch()
+		return null
+	}
 
 	const current = slot
 	slot = null

--- a/packages/worker/client/intent-prefetch.ts
+++ b/packages/worker/client/intent-prefetch.ts
@@ -1,0 +1,107 @@
+import { type RouteLoader, type RouteLoaderResult } from './route-loader.ts'
+
+const routerHrefOrigin = 'https://kody.local'
+
+/**
+ * How long a settled prefetch stays consumable. Covers the usual
+ * hover-then-click gap while keeping the staleness window small: navigations
+ * that consume a prefetch skip the loader entirely, so older data would be
+ * shown as-is.
+ */
+export const maxPrefetchAgeMs = 10_000
+
+function normalizePrefetchHref(href: string) {
+	const url = new URL(href, routerHrefOrigin)
+	return `${url.pathname}${url.search}${url.hash}`
+}
+
+type PrefetchSlot = {
+	href: string
+	promise: Promise<RouteLoaderResult>
+	controller: AbortController
+	settledAt: number | null
+	failed: boolean
+}
+
+// Single slot: the latest intent wins, mirroring the router's latest-wins
+// navigation semantics and keeping at most one speculative request in flight.
+let slot: PrefetchSlot | null = null
+
+/**
+ * Starts (or reuses) a speculative loader run for a link the user showed
+ * intent for. Re-invoking for the same href while the previous run is in
+ * flight or still fresh is a no-op; a different href aborts the previous run.
+ */
+export function prefetchRouteOnIntent(
+	href: string,
+	loader: RouteLoader,
+	url: URL,
+): void {
+	const normalized = normalizePrefetchHref(href)
+	if (slot && slot.href === normalized && !slot.failed) {
+		if (
+			slot.settledAt === null ||
+			Date.now() - slot.settledAt <= maxPrefetchAgeMs
+		) {
+			return
+		}
+	}
+
+	slot?.controller.abort()
+	const controller = new AbortController()
+	const nextSlot: PrefetchSlot = {
+		href: normalized,
+		promise: loader(url, controller.signal),
+		controller,
+		settledAt: null,
+		failed: false,
+	}
+	slot = nextSlot
+	nextSlot.promise.then(
+		() => {
+			nextSlot.settledAt = Date.now()
+		},
+		() => {
+			nextSlot.settledAt = Date.now()
+			nextSlot.failed = true
+		},
+	)
+}
+
+/**
+ * Consumes the prefetched loader result for `href`. Returns the in-flight or
+ * fresh settled promise, or `null` when there is no usable prefetch (wrong
+ * href, expired, or failed — failures let the navigation retry the loader).
+ * Consumption is one-shot. When `signal` aborts (a superseding navigation),
+ * an still-running prefetch request is aborted with it.
+ */
+export function takePrefetchedRouteResult(
+	href: string,
+	signal?: AbortSignal,
+): Promise<RouteLoaderResult> | null {
+	if (!slot) return null
+	if (slot.href !== normalizePrefetchHref(href)) return null
+
+	const current = slot
+	slot = null
+	if (current.failed) return null
+	if (
+		current.settledAt !== null &&
+		Date.now() - current.settledAt > maxPrefetchAgeMs
+	) {
+		return null
+	}
+	signal?.addEventListener('abort', () => current.controller.abort(), {
+		once: true,
+	})
+	return current.promise
+}
+
+/**
+ * Aborts and clears any pending intent prefetch. Called after form POST
+ * mutations so speculative pre-mutation data is never shown, and by tests.
+ */
+export function abortIntentPrefetch(): void {
+	slot?.controller.abort()
+	slot = null
+}

--- a/packages/worker/client/intent-prefetch.ts
+++ b/packages/worker/client/intent-prefetch.ts
@@ -4,15 +4,22 @@ const routerHrefOrigin = 'https://kody.local'
 
 /**
  * How long a settled prefetch stays consumable. Covers the usual
- * hover-then-click gap while keeping the staleness window small: navigations
- * that consume a prefetch skip the loader entirely, so older data would be
- * shown as-is.
+ * hover-read-then-click gap while keeping the staleness window bounded:
+ * navigations that consume a prefetch skip the loader entirely, so older
+ * data would be shown as-is. Form POSTs abort pending prefetches, so
+ * mutations never serve pre-mutation data regardless of this window.
  */
-export const maxPrefetchAgeMs = 10_000
+export const maxPrefetchAgeMs = 30_000
 
 function normalizePrefetchHref(href: string) {
 	const url = new URL(href, routerHrefOrigin)
 	return `${url.pathname}${url.search}${url.hash}`
+}
+
+// Monotonic clock: freshness math must not break when the wall clock is
+// adjusted (NTP sync, suspend/resume).
+function monotonicNow() {
+	return performance.now()
 }
 
 type PrefetchSlot = {
@@ -41,7 +48,7 @@ export function prefetchRouteOnIntent(
 	if (slot && slot.href === normalized && !slot.failed) {
 		if (
 			slot.settledAt === null ||
-			Date.now() - slot.settledAt <= maxPrefetchAgeMs
+			monotonicNow() - slot.settledAt <= maxPrefetchAgeMs
 		) {
 			return
 		}
@@ -59,10 +66,10 @@ export function prefetchRouteOnIntent(
 	slot = nextSlot
 	nextSlot.promise.then(
 		() => {
-			nextSlot.settledAt = Date.now()
+			nextSlot.settledAt = monotonicNow()
 		},
 		() => {
-			nextSlot.settledAt = Date.now()
+			nextSlot.settledAt = monotonicNow()
 			nextSlot.failed = true
 		},
 	)
@@ -87,7 +94,7 @@ export function takePrefetchedRouteResult(
 	if (current.failed) return null
 	if (
 		current.settledAt !== null &&
-		Date.now() - current.settledAt > maxPrefetchAgeMs
+		monotonicNow() - current.settledAt > maxPrefetchAgeMs
 	) {
 		return null
 	}

--- a/packages/worker/client/loader-data-context.tsx
+++ b/packages/worker/client/loader-data-context.tsx
@@ -1,4 +1,5 @@
 import { type Handle, type RemixNode } from 'remix/ui'
+import { tryConsumePreloadedLoaderData } from '#client/navigation-data.ts'
 import { readSsrRouterUrl } from '#client/router-location.tsx'
 import { type AppLoaderData } from '#app/loader-data.ts'
 
@@ -63,4 +64,18 @@ export function tryConsumeEmbeddedLoaderData<K extends keyof AppLoaderData>(
 
 	ctx.consumedKeys.add(key)
 	return embedded
+}
+
+/**
+ * Returns loader data for `key` from SSR-embedded props or a preloaded SPA
+ * navigation slot. Each source is consume-once per key.
+ */
+export function tryConsumeRouteLoaderData<K extends keyof AppLoaderData>(
+	handle: Handle,
+	key: K,
+	currentHref: string,
+): AppLoaderData[K] | undefined {
+	const embedded = tryConsumeEmbeddedLoaderData(handle, key, currentHref)
+	if (embedded !== undefined) return embedded
+	return tryConsumePreloadedLoaderData(key, currentHref)
 }

--- a/packages/worker/client/navigation-data.node.test.ts
+++ b/packages/worker/client/navigation-data.node.test.ts
@@ -1,0 +1,128 @@
+import { expect, test } from 'vitest'
+import { type AppLoaderData } from '#app/loader-data.ts'
+import {
+	clearPreloadedNavigationData,
+	setPreloadedNavigationData,
+	tryConsumePreloadedLoaderData,
+} from './navigation-data.ts'
+
+test('tryConsumePreloadedLoaderData returns data once for matching href', () => {
+	clearPreloadedNavigationData()
+	setPreloadedNavigationData('/account', {
+		accountProfile: {
+			ok: true,
+			email: 'kody@example.com',
+			username: 'kody',
+			displayName: 'Kody',
+		},
+	})
+
+	expect(tryConsumePreloadedLoaderData('accountProfile', '/account')).toEqual({
+		ok: true,
+		email: 'kody@example.com',
+		username: 'kody',
+		displayName: 'Kody',
+	})
+	expect(
+		tryConsumePreloadedLoaderData('accountProfile', '/account'),
+	).toBeUndefined()
+})
+
+test('tryConsumePreloadedLoaderData ignores mismatched href', () => {
+	clearPreloadedNavigationData()
+	setPreloadedNavigationData('/account', {
+		accountProfile: {
+			ok: true,
+			email: 'kody@example.com',
+			username: 'kody',
+			displayName: 'Kody',
+		},
+	})
+
+	expect(
+		tryConsumePreloadedLoaderData('accountProfile', '/account/secrets'),
+	).toBeUndefined()
+	expect(tryConsumePreloadedLoaderData('accountProfile', '/account')).toEqual({
+		ok: true,
+		email: 'kody@example.com',
+		username: 'kody',
+		displayName: 'Kody',
+	})
+})
+
+test('tryConsumePreloadedLoaderData normalizes href before matching', () => {
+	clearPreloadedNavigationData()
+	setPreloadedNavigationData('https://kody.local/account?q=1#top', {
+		accountProfile: {
+			ok: true,
+			email: 'kody@example.com',
+			username: 'kody',
+			displayName: 'Kody',
+		},
+	})
+
+	expect(
+		tryConsumePreloadedLoaderData('accountProfile', '/account?q=1#top'),
+	).toEqual({
+		ok: true,
+		email: 'kody@example.com',
+		username: 'kody',
+		displayName: 'Kody',
+	})
+})
+
+test('setPreloadedNavigationData replaces the previous slot', () => {
+	clearPreloadedNavigationData()
+	setPreloadedNavigationData('/account', {
+		accountProfile: {
+			ok: true,
+			email: 'first@example.com',
+			username: 'first',
+			displayName: 'First',
+		},
+	})
+	setPreloadedNavigationData('/account', {
+		accountProfile: {
+			ok: true,
+			email: 'second@example.com',
+			username: 'second',
+			displayName: 'Second',
+		},
+	})
+
+	expect(tryConsumePreloadedLoaderData('accountProfile', '/account')).toEqual({
+		ok: true,
+		email: 'second@example.com',
+		username: 'second',
+		displayName: 'Second',
+	})
+})
+
+test('tryConsumePreloadedLoaderData leaves unrelated keys until consumed', () => {
+	clearPreloadedNavigationData()
+	const payload: Partial<AppLoaderData> = {
+		accountProfile: {
+			ok: true,
+			email: 'kody@example.com',
+			username: 'kody',
+			displayName: 'Kody',
+		},
+		adminUsers: {
+			ok: true,
+			users: [],
+			page: 1,
+			pageSize: 25,
+			total: 0,
+			availableRoles: [],
+		},
+	}
+	setPreloadedNavigationData('/account', payload)
+
+	expect(
+		tryConsumePreloadedLoaderData('accountProfile', '/account'),
+	).toBeTruthy()
+	expect(tryConsumePreloadedLoaderData('adminUsers', '/account')).toBeTruthy()
+	expect(
+		tryConsumePreloadedLoaderData('adminUsers', '/account'),
+	).toBeUndefined()
+})

--- a/packages/worker/client/navigation-data.node.test.ts
+++ b/packages/worker/client/navigation-data.node.test.ts
@@ -2,6 +2,8 @@ import { expect, test } from 'vitest'
 import { type AppLoaderData } from '#app/loader-data.ts'
 import {
 	clearPreloadedNavigationData,
+	consumeStaleNavigationData,
+	markNavigationDataStale,
 	setPreloadedNavigationData,
 	tryConsumePreloadedLoaderData,
 } from './navigation-data.ts'
@@ -125,4 +127,27 @@ test('tryConsumePreloadedLoaderData leaves unrelated keys until consumed', () =>
 	expect(
 		tryConsumePreloadedLoaderData('adminUsers', '/account'),
 	).toBeUndefined()
+})
+
+test('consumeStaleNavigationData is one-shot for the marked href', () => {
+	clearPreloadedNavigationData()
+	markNavigationDataStale('/account')
+
+	expect(consumeStaleNavigationData('/account')).toBe(true)
+	expect(consumeStaleNavigationData('/account')).toBe(false)
+})
+
+test('consumeStaleNavigationData clears the marker on href mismatch', () => {
+	clearPreloadedNavigationData()
+	markNavigationDataStale('/account')
+
+	expect(consumeStaleNavigationData('/account/secrets')).toBe(false)
+	expect(consumeStaleNavigationData('/account')).toBe(false)
+})
+
+test('consumeStaleNavigationData normalizes hrefs before matching', () => {
+	clearPreloadedNavigationData()
+	markNavigationDataStale('https://kody.local/account?q=1')
+
+	expect(consumeStaleNavigationData('/account?q=1')).toBe(true)
 })

--- a/packages/worker/client/navigation-data.ts
+++ b/packages/worker/client/navigation-data.ts
@@ -36,7 +36,33 @@ export function tryConsumePreloadedLoaderData<K extends keyof AppLoaderData>(
 	return value
 }
 
+let staleNavigationHref: string | null = null
+
+/**
+ * Records that a navigation to `href` committed without preloaded data
+ * because its route loader failed. Routes whose href-based freshness checks
+ * cannot detect same-path refreshes (form POST redirects back to the current
+ * URL) consume this marker to force a fallback refetch instead of silently
+ * rendering stale, pre-mutation data.
+ */
+export function markNavigationDataStale(href: string): void {
+	staleNavigationHref = normalizeNavigationHref(href)
+}
+
+/**
+ * One-shot: returns whether `href` was marked stale, clearing the marker
+ * either way. A mismatched href means the user navigated somewhere else,
+ * where href-change freshness checks already force a refetch.
+ */
+export function consumeStaleNavigationData(href: string): boolean {
+	if (staleNavigationHref === null) return false
+	const isStale = staleNavigationHref === normalizeNavigationHref(href)
+	staleNavigationHref = null
+	return isStale
+}
+
 /** Test helper — clears the single-slot preloaded navigation store. */
 export function clearPreloadedNavigationData() {
 	preloadedSlot = null
+	staleNavigationHref = null
 }

--- a/packages/worker/client/navigation-data.ts
+++ b/packages/worker/client/navigation-data.ts
@@ -1,0 +1,42 @@
+import { type AppLoaderData } from '#app/loader-data.ts'
+
+const routerHrefOrigin = 'https://kody.local'
+
+function normalizeNavigationHref(href: string) {
+	const url = new URL(href, routerHrefOrigin)
+	return `${url.pathname}${url.search}${url.hash}`
+}
+
+let preloadedSlot: { href: string; data: Partial<AppLoaderData> } | null = null
+
+export function setPreloadedNavigationData(
+	href: string,
+	data: Partial<AppLoaderData>,
+): void {
+	preloadedSlot = {
+		href: normalizeNavigationHref(href),
+		data: { ...data },
+	}
+}
+
+export function tryConsumePreloadedLoaderData<K extends keyof AppLoaderData>(
+	key: K,
+	href: string,
+): AppLoaderData[K] | undefined {
+	if (!preloadedSlot) return undefined
+	if (normalizeNavigationHref(href) !== preloadedSlot.href) return undefined
+
+	const value = preloadedSlot.data[key]
+	if (value === undefined) return undefined
+
+	delete preloadedSlot.data[key]
+	if (Object.keys(preloadedSlot.data).length === 0) {
+		preloadedSlot = null
+	}
+	return value
+}
+
+/** Test helper — clears the single-slot preloaded navigation store. */
+export function clearPreloadedNavigationData() {
+	preloadedSlot = null
+}

--- a/packages/worker/client/navigation-progress.tsx
+++ b/packages/worker/client/navigation-progress.tsx
@@ -1,0 +1,149 @@
+import { addEventListeners, type Handle, css } from 'remix/ui'
+import { routerEvents } from './client-router.tsx'
+import { colors } from './styles/tokens.ts'
+
+const showDelayMs = 150
+const trickleIntervalMs = 200
+const trickleIncrement = 4
+const maxTrickleProgress = 90
+const fadeDurationMs = 200
+
+export function NavigationProgress(handle: Handle) {
+	let visible = false
+	let progress = 0
+	let opacity = 0
+	// Boolean, not a counter: navigations are latest-wins and a superseded
+	// (aborted) navigation never dispatches its own `navigationend`, so the
+	// winning navigation's end event must clear the pending state outright.
+	let navigationPending = false
+	let showTimeoutId: ReturnType<typeof globalThis.setTimeout> | null = null
+	let trickleIntervalId: ReturnType<typeof globalThis.setInterval> | null = null
+	let fadeTimeoutId: ReturnType<typeof globalThis.setTimeout> | null = null
+	let resetTimeoutId: ReturnType<typeof globalThis.setTimeout> | null = null
+
+	function clearShowTimeout() {
+		if (showTimeoutId === null) return
+		globalThis.clearTimeout(showTimeoutId)
+		showTimeoutId = null
+	}
+
+	function clearTrickleInterval() {
+		if (trickleIntervalId === null) return
+		globalThis.clearInterval(trickleIntervalId)
+		trickleIntervalId = null
+	}
+
+	function clearFadeTimers() {
+		if (fadeTimeoutId !== null) {
+			globalThis.clearTimeout(fadeTimeoutId)
+			fadeTimeoutId = null
+		}
+		if (resetTimeoutId !== null) {
+			globalThis.clearTimeout(resetTimeoutId)
+			resetTimeoutId = null
+		}
+	}
+
+	function startTrickle() {
+		clearTrickleInterval()
+		trickleIntervalId = globalThis.setInterval(() => {
+			if (progress >= maxTrickleProgress) return
+			progress = Math.min(maxTrickleProgress, progress + trickleIncrement)
+			handle.update()
+		}, trickleIntervalMs)
+	}
+
+	function scheduleShow() {
+		clearShowTimeout()
+		showTimeoutId = globalThis.setTimeout(() => {
+			showTimeoutId = null
+			if (!navigationPending) return
+			visible = true
+			opacity = 1
+			if (progress === 0) progress = 8
+			startTrickle()
+			handle.update()
+		}, showDelayMs)
+	}
+
+	function onNavigationStart() {
+		navigationPending = true
+		clearFadeTimers()
+		if (!visible) {
+			scheduleShow()
+			return
+		}
+		opacity = 1
+		if (progress >= 100) progress = 8
+		startTrickle()
+		handle.update()
+	}
+
+	function onNavigationEnd() {
+		if (!navigationPending) return
+		navigationPending = false
+
+		clearShowTimeout()
+		clearTrickleInterval()
+
+		// Fast navigations that finished before the show delay stay invisible;
+		// completing the bar for them would cause the flash the delay avoids.
+		if (!visible) {
+			progress = 0
+			return
+		}
+
+		progress = 100
+		opacity = 1
+		handle.update()
+
+		fadeTimeoutId = globalThis.setTimeout(() => {
+			fadeTimeoutId = null
+			opacity = 0
+			handle.update()
+			resetTimeoutId = globalThis.setTimeout(() => {
+				resetTimeoutId = null
+				visible = false
+				progress = 0
+				handle.update()
+			}, fadeDurationMs)
+		}, 80)
+	}
+
+	if (typeof document !== 'undefined') {
+		addEventListeners(routerEvents, handle.signal, {
+			navigationstart: onNavigationStart,
+			navigationend: onNavigationEnd,
+		})
+	}
+
+	return () => {
+		if (typeof document === 'undefined' || !visible) return null
+
+		return (
+			<div
+				aria-hidden="true"
+				mix={css({
+					position: 'fixed',
+					top: 0,
+					left: 0,
+					width: '100%',
+					height: '3px',
+					zIndex: 9999,
+					pointerEvents: 'none',
+					backgroundColor: 'transparent',
+				})}
+			>
+				<div
+					mix={css({
+						height: '100%',
+						width: `${progress}%`,
+						backgroundColor: colors.primary,
+						opacity,
+						transition: `width 200ms ease-out, opacity ${fadeDurationMs}ms ease-out`,
+					})}
+				/>
+			</div>
+		)
+	}
+}

--- a/packages/worker/client/navigation-progress.tsx
+++ b/packages/worker/client/navigation-progress.tsx
@@ -2,7 +2,12 @@ import { addEventListeners, type Handle, css } from 'remix/ui'
 import { routerEvents } from './client-router.tsx'
 import { colors } from './styles/tokens.ts'
 
+// Spin-delay semantics (https://npm.im/spin-delay): the bar only appears if a
+// navigation is still pending after `showDelayMs`, and once shown it stays
+// visible for at least `minShowDurationMs` so fast completions never flash.
 const showDelayMs = 150
+const minShowDurationMs = 200
+const completePauseMs = 80
 const trickleIntervalMs = 200
 const trickleIncrement = 4
 const maxTrickleProgress = 90
@@ -16,8 +21,10 @@ export function NavigationProgress(handle: Handle) {
 	// (aborted) navigation never dispatches its own `navigationend`, so the
 	// winning navigation's end event must clear the pending state outright.
 	let navigationPending = false
+	let shownAt = 0
 	let showTimeoutId: ReturnType<typeof globalThis.setTimeout> | null = null
 	let trickleIntervalId: ReturnType<typeof globalThis.setInterval> | null = null
+	let completeTimeoutId: ReturnType<typeof globalThis.setTimeout> | null = null
 	let fadeTimeoutId: ReturnType<typeof globalThis.setTimeout> | null = null
 	let resetTimeoutId: ReturnType<typeof globalThis.setTimeout> | null = null
 
@@ -33,7 +40,11 @@ export function NavigationProgress(handle: Handle) {
 		trickleIntervalId = null
 	}
 
-	function clearFadeTimers() {
+	function clearCompletionTimers() {
+		if (completeTimeoutId !== null) {
+			globalThis.clearTimeout(completeTimeoutId)
+			completeTimeoutId = null
+		}
 		if (fadeTimeoutId !== null) {
 			globalThis.clearTimeout(fadeTimeoutId)
 			fadeTimeoutId = null
@@ -59,6 +70,7 @@ export function NavigationProgress(handle: Handle) {
 			showTimeoutId = null
 			if (!navigationPending) return
 			visible = true
+			shownAt = Date.now()
 			opacity = 1
 			if (progress === 0) progress = 8
 			startTrickle()
@@ -68,7 +80,7 @@ export function NavigationProgress(handle: Handle) {
 
 	function onNavigationStart() {
 		navigationPending = true
-		clearFadeTimers()
+		clearCompletionTimers()
 		if (!visible) {
 			scheduleShow()
 			return
@@ -79,20 +91,8 @@ export function NavigationProgress(handle: Handle) {
 		handle.update()
 	}
 
-	function onNavigationEnd() {
-		if (!navigationPending) return
-		navigationPending = false
-
-		clearShowTimeout()
+	function completeAndFadeOut() {
 		clearTrickleInterval()
-
-		// Fast navigations that finished before the show delay stay invisible;
-		// completing the bar for them would cause the flash the delay avoids.
-		if (!visible) {
-			progress = 0
-			return
-		}
-
 		progress = 100
 		opacity = 1
 		handle.update()
@@ -107,7 +107,37 @@ export function NavigationProgress(handle: Handle) {
 				progress = 0
 				handle.update()
 			}, fadeDurationMs)
-		}, 80)
+		}, completePauseMs)
+	}
+
+	function onNavigationEnd() {
+		if (!navigationPending) return
+		navigationPending = false
+
+		clearShowTimeout()
+
+		// Fast navigations that finished before the show delay stay invisible;
+		// completing the bar for them would cause the flash the delay avoids.
+		if (!visible) {
+			clearTrickleInterval()
+			progress = 0
+			return
+		}
+
+		// Once shown, keep the bar up for the minimum duration before
+		// completing so near-instant loads don't flash it.
+		const remainingShowMs = Math.max(
+			0,
+			minShowDurationMs - (Date.now() - shownAt),
+		)
+		if (remainingShowMs === 0) {
+			completeAndFadeOut()
+			return
+		}
+		completeTimeoutId = globalThis.setTimeout(() => {
+			completeTimeoutId = null
+			completeAndFadeOut()
+		}, remainingShowMs)
 	}
 
 	if (typeof document !== 'undefined') {

--- a/packages/worker/client/route-loader.ts
+++ b/packages/worker/client/route-loader.ts
@@ -1,0 +1,29 @@
+import { type AppLoaderData } from '#app/loader-data.ts'
+
+/**
+ * Loader result asking the router to leave the SPA with a full-document
+ * navigation (for example, `401` → login). Loaders must return this instead
+ * of calling `window.location.assign` themselves: intent prefetches run
+ * loaders speculatively, and a prefetch must never redirect the page the
+ * user is still looking at.
+ */
+export class RouteLoaderRedirect {
+	constructor(readonly to: string) {}
+}
+
+export function routeLoaderRedirect(to: string): RouteLoaderRedirect {
+	return new RouteLoaderRedirect(to)
+}
+
+export function isRouteLoaderRedirect(
+	value: unknown,
+): value is RouteLoaderRedirect {
+	return value instanceof RouteLoaderRedirect
+}
+
+export type RouteLoaderResult = Partial<AppLoaderData> | RouteLoaderRedirect
+
+export type RouteLoader = (
+	url: URL,
+	signal: AbortSignal,
+) => Promise<RouteLoaderResult>

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -5,7 +5,10 @@ import {
 	type AccountStatus,
 	readJson,
 } from '#client/routes/account-approval-shared.ts'
-import { type AppLoaderData } from '#app/loader-data.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
 import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
@@ -67,15 +70,14 @@ function isAccountIntegrationsPath(href: string) {
 export async function accountIntegrationsRouteLoader(
 	_url: URL,
 	signal: AbortSignal,
-): Promise<Partial<AppLoaderData> | null> {
+): Promise<RouteLoaderResult> {
 	const response = await fetch(accountIntegrationsApiPath, {
 		headers: { Accept: 'application/json' },
 		credentials: 'include',
 		signal,
 	})
 	if (response.status === 401) {
-		window.location.assign('/login')
-		return null
+		return routeLoaderRedirect('/login')
 	}
 	const payload = await readJson<AccountIntegrationsPayload>(response)
 	if (!response.ok || !payload?.ok) {

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -183,15 +183,15 @@ export function AccountIntegrationsRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
+		const appliedRouteData = applyRouteLoaderData(currentHref)
 		const isRefreshingForLocationChange =
 			status !== 'loading' && currentHref !== lastLoadedHref
-		if (status === 'loading' || isRefreshingForLocationChange) {
-			if (
-				!applyRouteLoaderData(currentHref) &&
-				typeof document !== 'undefined'
-			) {
-				handle.queueTask(loadIntegrations)
-			}
+		if (
+			!appliedRouteData &&
+			(status === 'loading' || isRefreshingForLocationChange) &&
+			typeof document !== 'undefined'
+		) {
+			handle.queueTask(loadIntegrations)
 		}
 
 		return (

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -1,6 +1,7 @@
 import { type Handle, css } from 'remix/ui'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import {
 	type AccountStatus,
 	readJson,
@@ -186,11 +187,17 @@ export function AccountIntegrationsRoute(handle: Handle) {
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
 		const appliedRouteData = applyRouteLoaderData(currentHref)
+		// A same-path refresh whose loader failed leaves no preload and no
+		// href change; the stale marker forces the fallback refetch.
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const isRefreshingForLocationChange =
 			status !== 'loading' && currentHref !== lastLoadedHref
 		if (
 			!appliedRouteData &&
-			(status === 'loading' || isRefreshingForLocationChange) &&
+			(status === 'loading' ||
+				isRefreshingForLocationChange ||
+				needsStaleRefresh) &&
 			typeof document !== 'undefined'
 		) {
 			handle.queueTask(loadIntegrations)

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -1,13 +1,11 @@
 import { type Handle, css } from 'remix/ui'
-import {
-	listenToRouterNavigation,
-	readCurrentRouterHref,
-} from '#client/client-router.tsx'
-import { tryConsumeEmbeddedLoaderData } from '#client/loader-data-context.tsx'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import {
 	type AccountStatus,
 	readJson,
 } from '#client/routes/account-approval-shared.ts'
+import { type AppLoaderData } from '#app/loader-data.ts'
 import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
@@ -64,6 +62,26 @@ const accountIntegrationsPath = '/account/integrations'
 
 function isAccountIntegrationsPath(href: string) {
 	return new URL(href, 'http://localhost').pathname === accountIntegrationsPath
+}
+
+export async function accountIntegrationsRouteLoader(
+	_url: URL,
+	signal: AbortSignal,
+): Promise<Partial<AppLoaderData> | null> {
+	const response = await fetch(accountIntegrationsApiPath, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		window.location.assign('/login')
+		return null
+	}
+	const payload = await readJson<AccountIntegrationsPayload>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load integrations.')
+	}
+	return { accountIntegrations: payload }
 }
 
 function formatTimestamp(value: string) {
@@ -147,24 +165,16 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		}
 	}
 
-	listenToRouterNavigation(handle, () => {
-		const href = readCurrentRouterHref(handle)
-		if (href !== lastLoadedHref && status !== 'loading') {
-			status = 'loading'
-			handle.update()
-		}
-	})
-
-	function applyEmbeddedLoaderData(href: string) {
+	function applyRouteLoaderData(href: string) {
 		if (!isAccountIntegrationsPath(href)) return false
-		const embedded = tryConsumeEmbeddedLoaderData(
+		const routeData = tryConsumeRouteLoaderData(
 			handle,
 			'accountIntegrations',
 			href,
 		)
-		if (!embedded) return false
-		email = embedded.email
-		integrations = embedded.integrations
+		if (!routeData) return false
+		email = routeData.email
+		integrations = routeData.integrations
 		status = 'ready'
 		message = null
 		lastLoadedHref = href
@@ -177,7 +187,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 			status !== 'loading' && currentHref !== lastLoadedHref
 		if (status === 'loading' || isRefreshingForLocationChange) {
 			if (
-				!applyEmbeddedLoaderData(currentHref) &&
+				!applyRouteLoaderData(currentHref) &&
 				typeof document !== 'undefined'
 			) {
 				handle.queueTask(loadIntegrations)

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -3,6 +3,7 @@ import { createHref } from 'remix/route-pattern/href'
 import { on } from '#client/event-mixin.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import {
 	type AccountStatus,
 	readJson,
@@ -926,11 +927,17 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
 		const appliedRouteData = applyRouteLoaderData(currentHref)
+		// A same-path refresh whose loader failed leaves no preload and no
+		// href change; the stale marker forces the fallback refetch.
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const isRefreshingForLocationChange =
 			status !== 'loading' && currentHref !== lastLoadedHref
 		if (
 			!appliedRouteData &&
-			(status === 'loading' || isRefreshingForLocationChange) &&
+			(status === 'loading' ||
+				isRefreshingForLocationChange ||
+				needsStaleRefresh) &&
 			typeof document !== 'undefined'
 		) {
 			handle.queueTask(loadTokens)

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -7,7 +7,10 @@ import {
 	type AccountStatus,
 	readJson,
 } from '#client/routes/account-approval-shared.ts'
-import { type AppLoaderData } from '#app/loader-data.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
 import {
 	colors,
 	mq,
@@ -187,15 +190,14 @@ function isAccountPackageInvocationTokensPath(href: string) {
 export async function accountPackageInvocationTokensRouteLoader(
 	_url: URL,
 	signal: AbortSignal,
-): Promise<Partial<AppLoaderData> | null> {
+): Promise<RouteLoaderResult> {
 	const response = await fetch(accountPackageInvocationTokensApiPath, {
 		headers: { Accept: 'application/json' },
 		credentials: 'include',
 		signal,
 	})
 	if (response.status === 401) {
-		window.location.assign('/login')
-		return null
+		return routeLoaderRedirect('/login')
 	}
 	const payload =
 		await readJson<AccountPackageInvocationTokensPayload>(response)

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -384,14 +384,13 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		)
 	}
 
-	function normalizeRouterHref(href: string) {
-		if (typeof window === 'undefined') return href
-		const destination = new URL(href, window.location.href)
-		return `${destination.pathname}${destination.search}${destination.hash}`
-	}
-
 	function syncRouterLocation(nextPath: string) {
-		lastLoadedHref = normalizeRouterHref(nextPath)
+		// Do not pre-set `lastLoadedHref` to the destination: `navigate` is
+		// async (preload-then-commit), so until it commits the current href is
+		// unchanged and a pre-set would make interim renders look like a
+		// location change and fire a spurious fallback fetch for the old URL.
+		// The commit render consumes the navigation's preloaded data (or the
+		// stale marker) and updates `lastLoadedHref` itself.
 		navigate(nextPath)
 	}
 

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -923,15 +923,15 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
+		const appliedRouteData = applyRouteLoaderData(currentHref)
 		const isRefreshingForLocationChange =
 			status !== 'loading' && currentHref !== lastLoadedHref
-		if (status === 'loading' || isRefreshingForLocationChange) {
-			if (
-				!applyRouteLoaderData(currentHref) &&
-				typeof document !== 'undefined'
-			) {
-				handle.queueTask(loadTokens)
-			}
+		if (
+			!appliedRouteData &&
+			(status === 'loading' || isRefreshingForLocationChange) &&
+			typeof document !== 'undefined'
+		) {
+			handle.queueTask(loadTokens)
 		}
 		const isMutating = saveState !== 'idle'
 		const isCreatingToken = isNewTokenPath(currentHref)

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -1,16 +1,13 @@
 import { type Handle, css } from 'remix/ui'
 import { createHref } from 'remix/route-pattern/href'
 import { on } from '#client/event-mixin.ts'
-import {
-	listenToRouterNavigation,
-	navigate,
-	readCurrentRouterHref,
-} from '#client/client-router.tsx'
-import { tryConsumeEmbeddedLoaderData } from '#client/loader-data-context.tsx'
+import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import {
 	type AccountStatus,
 	readJson,
 } from '#client/routes/account-approval-shared.ts'
+import { type AppLoaderData } from '#app/loader-data.ts'
 import {
 	colors,
 	mq,
@@ -185,6 +182,27 @@ function isAccountPackageInvocationTokensPath(href: string) {
 		path === `${accountPackageInvocationTokensBasePath}/new` ||
 		path.startsWith(`${accountPackageInvocationTokensBasePath}/`)
 	)
+}
+
+export async function accountPackageInvocationTokensRouteLoader(
+	_url: URL,
+	signal: AbortSignal,
+): Promise<Partial<AppLoaderData> | null> {
+	const response = await fetch(accountPackageInvocationTokensApiPath, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		window.location.assign('/login')
+		return null
+	}
+	const payload =
+		await readJson<AccountPackageInvocationTokensPayload>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load package invocation tokens.')
+	}
+	return { accountPackageInvocationTokens: payload }
 }
 
 function getSelectedTokenIdFromPath(href: string) {
@@ -887,23 +905,15 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		handle.update()
 	}
 
-	listenToRouterNavigation(handle, () => {
-		const href = readCurrentRouterHref(handle)
-		if (href !== lastLoadedHref && status !== 'loading') {
-			status = 'loading'
-			handle.update()
-		}
-	})
-
-	function applyEmbeddedLoaderData(href: string) {
+	function applyRouteLoaderData(href: string) {
 		if (!isAccountPackageInvocationTokensPath(href)) return false
-		const embedded = tryConsumeEmbeddedLoaderData(
+		const routeData = tryConsumeRouteLoaderData(
 			handle,
 			'accountPackageInvocationTokens',
 			href,
 		)
-		if (!embedded) return false
-		applyPayload(embedded, href)
+		if (!routeData) return false
+		applyPayload(routeData, href)
 		status = 'ready'
 		message = null
 		messageTone = 'info'
@@ -917,7 +927,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 			status !== 'loading' && currentHref !== lastLoadedHref
 		if (status === 'loading' || isRefreshingForLocationChange) {
 			if (
-				!applyEmbeddedLoaderData(currentHref) &&
+				!applyRouteLoaderData(currentHref) &&
 				typeof document !== 'undefined'
 			) {
 				handle.queueTask(loadTokens)

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -2,6 +2,7 @@ import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import {
 	type AccountStatus,
 	readJson,
@@ -586,11 +587,17 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
 		const appliedRouteData = applyRouteLoaderData(currentHref)
+		// A same-path refresh whose loader failed leaves no preload and no
+		// href change; the stale marker forces the fallback refetch.
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const isRefreshingForLocationChange =
 			status !== 'loading' && currentHref !== lastLoadedHref
 		if (
 			!appliedRouteData &&
-			(status === 'loading' || isRefreshingForLocationChange) &&
+			(status === 'loading' ||
+				isRefreshingForLocationChange ||
+				needsStaleRefresh) &&
 			typeof document !== 'undefined'
 		) {
 			handle.queueTask(loadRemoteConnectors)

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -583,15 +583,15 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
+		const appliedRouteData = applyRouteLoaderData(currentHref)
 		const isRefreshingForLocationChange =
 			status !== 'loading' && currentHref !== lastLoadedHref
-		if (status === 'loading' || isRefreshingForLocationChange) {
-			if (
-				!applyRouteLoaderData(currentHref) &&
-				typeof document !== 'undefined'
-			) {
-				handle.queueTask(loadRemoteConnectors)
-			}
+		if (
+			!appliedRouteData &&
+			(status === 'loading' || isRefreshingForLocationChange) &&
+			typeof document !== 'undefined'
+		) {
+			handle.queueTask(loadRemoteConnectors)
 		}
 		const isMutating = saveState !== 'idle'
 		const isEditing = Boolean(editorState.id)

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -1,14 +1,12 @@
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
-import {
-	listenToRouterNavigation,
-	readCurrentRouterHref,
-} from '#client/client-router.tsx'
-import { tryConsumeEmbeddedLoaderData } from '#client/loader-data-context.tsx'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import {
 	type AccountStatus,
 	readJson,
 } from '#client/routes/account-approval-shared.ts'
+import { type AppLoaderData } from '#app/loader-data.ts'
 import {
 	colors,
 	mq,
@@ -69,6 +67,26 @@ function isAccountRemoteConnectorsPath(href: string) {
 	return (
 		new URL(href, 'http://localhost').pathname === accountRemoteConnectorsPath
 	)
+}
+
+export async function accountRemoteConnectorsRouteLoader(
+	_url: URL,
+	signal: AbortSignal,
+): Promise<Partial<AppLoaderData> | null> {
+	const response = await fetch(accountRemoteConnectorsApiPath, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		window.location.assign('/login')
+		return null
+	}
+	const payload = await readJson<AccountRemoteConnectorsPayload>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load remote connector settings.')
+	}
+	return { accountRemoteConnectors: payload }
 }
 
 function createEmptyEditorState(): EditorState {
@@ -548,23 +566,15 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 		})
 	}
 
-	listenToRouterNavigation(handle, () => {
-		const href = readCurrentRouterHref(handle)
-		if (href !== lastLoadedHref && status !== 'loading') {
-			status = 'loading'
-			handle.update()
-		}
-	})
-
-	function applyEmbeddedLoaderData(href: string) {
+	function applyRouteLoaderData(href: string) {
 		if (!isAccountRemoteConnectorsPath(href)) return false
-		const embedded = tryConsumeEmbeddedLoaderData(
+		const routeData = tryConsumeRouteLoaderData(
 			handle,
 			'accountRemoteConnectors',
 			href,
 		)
-		if (!embedded) return false
-		applyPayload(embedded)
+		if (!routeData) return false
+		applyPayload(routeData)
 		status = 'ready'
 		message = null
 		lastLoadedHref = href
@@ -577,7 +587,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 			status !== 'loading' && currentHref !== lastLoadedHref
 		if (status === 'loading' || isRefreshingForLocationChange) {
 			if (
-				!applyEmbeddedLoaderData(currentHref) &&
+				!applyRouteLoaderData(currentHref) &&
 				typeof document !== 'undefined'
 			) {
 				handle.queueTask(loadRemoteConnectors)

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -6,7 +6,10 @@ import {
 	type AccountStatus,
 	readJson,
 } from '#client/routes/account-approval-shared.ts'
-import { type AppLoaderData } from '#app/loader-data.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
 import {
 	colors,
 	mq,
@@ -72,15 +75,14 @@ function isAccountRemoteConnectorsPath(href: string) {
 export async function accountRemoteConnectorsRouteLoader(
 	_url: URL,
 	signal: AbortSignal,
-): Promise<Partial<AppLoaderData> | null> {
+): Promise<RouteLoaderResult> {
 	const response = await fetch(accountRemoteConnectorsApiPath, {
 		headers: { Accept: 'application/json' },
 		credentials: 'include',
 		signal,
 	})
 	if (response.status === 401) {
-		window.location.assign('/login')
-		return null
+		return routeLoaderRedirect('/login')
 	}
 	const payload = await readJson<AccountRemoteConnectorsPayload>(response)
 	if (!response.ok || !payload?.ok) {

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -1101,21 +1101,19 @@ export function AccountSecretsRoute(handle: Handle) {
 		]
 
 		const currentDataKey = getDataRefreshKey(currentHref)
+		const appliedRouteData = applyRouteLoaderData(currentHref)
 		const isRefreshingForLocationChange =
 			status !== 'loading' &&
 			currentDataKey !== lastLoadedDataKey &&
 			currentDataKey !== lastFailedDataKey
 		const isLoadingCurrentLocation = loadingDataKey === currentDataKey
 		if (
+			!appliedRouteData &&
 			(status === 'loading' || isRefreshingForLocationChange) &&
-			!isLoadingCurrentLocation
+			!isLoadingCurrentLocation &&
+			typeof document !== 'undefined'
 		) {
-			if (
-				!applyRouteLoaderData(currentHref) &&
-				typeof document !== 'undefined'
-			) {
-				handle.queueTask(loadAccountSecrets)
-			}
+			handle.queueTask(loadAccountSecrets)
 		}
 
 		const activeSecretId =

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -11,6 +11,7 @@ import {
 	readCurrentRouterHref,
 } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
@@ -1104,6 +1105,10 @@ export function AccountSecretsRoute(handle: Handle) {
 
 		const currentDataKey = getDataRefreshKey(currentHref)
 		const appliedRouteData = applyRouteLoaderData(currentHref)
+		// A same-path refresh whose loader failed leaves no preload and no
+		// data-key change; the stale marker forces the fallback refetch.
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const isRefreshingForLocationChange =
 			status !== 'loading' &&
 			currentDataKey !== lastLoadedDataKey &&
@@ -1111,7 +1116,9 @@ export function AccountSecretsRoute(handle: Handle) {
 		const isLoadingCurrentLocation = loadingDataKey === currentDataKey
 		if (
 			!appliedRouteData &&
-			(status === 'loading' || isRefreshingForLocationChange) &&
+			(status === 'loading' ||
+				isRefreshingForLocationChange ||
+				needsStaleRefresh) &&
 			!isLoadingCurrentLocation &&
 			typeof document !== 'undefined'
 		) {

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -11,7 +11,10 @@ import {
 	readCurrentRouterHref,
 } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { type AppLoaderData } from '#app/loader-data.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
 import { createDoubleCheck } from '#client/double-check.ts'
 import {
 	type AccountStatus,
@@ -508,7 +511,7 @@ function buildSecretsApiRequestUrl(href: string) {
 export async function accountSecretsRouteLoader(
 	url: URL,
 	signal: AbortSignal,
-): Promise<Partial<AppLoaderData> | null> {
+): Promise<RouteLoaderResult> {
 	const href = `${url.pathname}${url.search}`
 	const requestUrl = buildSecretsApiRequestUrl(href)
 	const response = await fetch(`${requestUrl.pathname}${requestUrl.search}`, {
@@ -517,8 +520,7 @@ export async function accountSecretsRouteLoader(
 		signal,
 	})
 	if (response.status === 401) {
-		window.location.assign('/login')
-		return null
+		return routeLoaderRedirect('/login')
 	}
 	const payload = await readJson<AccountSecretsPayload>(response)
 	if (!response.ok || !payload?.ok) {

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -8,10 +8,10 @@ import {
 import {
 	navigate,
 	routerEvents,
-	listenToRouterNavigation,
 	readCurrentRouterHref,
 } from '#client/client-router.tsx'
-import { tryConsumeEmbeddedLoaderData } from '#client/loader-data-context.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { type AppLoaderData } from '#app/loader-data.ts'
 import { createDoubleCheck } from '#client/double-check.ts'
 import {
 	type AccountStatus,
@@ -492,6 +492,41 @@ function getDataRefreshKey(href: string) {
 	return `${url.pathname}?allowed-host=${requestedHost}&capability=${requestedCapability}&package_id=${requestedPackageId}&new-secret=${newSecretQuery}`
 }
 
+function buildSecretsApiRequestUrl(href: string) {
+	const pageUrl = new URL(href, 'http://localhost')
+	const selection = getSelectionState(href)
+	const requestUrl = new URL(accountSecretsApiPath, 'http://localhost')
+	requestUrl.search = pageUrl.search
+	if (selection.selectedSecretId) {
+		requestUrl.searchParams.set('selected', selection.selectedSecretId)
+	} else {
+		requestUrl.searchParams.delete('selected')
+	}
+	return requestUrl
+}
+
+export async function accountSecretsRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<Partial<AppLoaderData> | null> {
+	const href = `${url.pathname}${url.search}`
+	const requestUrl = buildSecretsApiRequestUrl(href)
+	const response = await fetch(`${requestUrl.pathname}${requestUrl.search}`, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		window.location.assign('/login')
+		return null
+	}
+	const payload = await readJson<AccountSecretsPayload>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load your secrets.')
+	}
+	return { accountSecrets: payload }
+}
+
 function readFilterState(
 	href: string,
 	apps: Array<PackageAppOption>,
@@ -682,13 +717,7 @@ export function AccountSecretsRoute(handle: Handle) {
 		const requestId = ++loadRequestId
 		loadingDataKey = dataKey
 		try {
-			const requestUrl = new URL(accountSecretsApiPath, 'http://localhost')
-			requestUrl.search = getCurrentSearch()
-			if (selection.selectedSecretId) {
-				requestUrl.searchParams.set('selected', selection.selectedSecretId)
-			} else {
-				requestUrl.searchParams.delete('selected')
-			}
+			const requestUrl = buildSecretsApiRequestUrl(href)
 
 			const response = await fetch(
 				`${requestUrl.pathname}${requestUrl.search}`,
@@ -1041,25 +1070,12 @@ export function AccountSecretsRoute(handle: Handle) {
 		handle.update()
 	}
 
-	listenToRouterNavigation(handle, () => {
-		const href = getCurrentHref()
-		const nextDataKey = getDataRefreshKey(href)
-		if (nextDataKey !== lastLoadedDataKey && status !== 'loading') {
-			status = 'loading'
-			handle.update()
-		}
-	})
-
-	function applyEmbeddedLoaderData(href: string) {
+	function applyRouteLoaderData(href: string) {
 		if (!isAccountSecretsPath(href)) return false
-		const embedded = tryConsumeEmbeddedLoaderData(
-			handle,
-			'accountSecrets',
-			href,
-		)
-		if (!embedded) return false
+		const routeData = tryConsumeRouteLoaderData(handle, 'accountSecrets', href)
+		if (!routeData) return false
 		const selection = getSelectionState(href)
-		applyPayload(embedded, selection, embedded.approvalError)
+		applyPayload(routeData, selection, routeData.approvalError)
 		lastLoadedDataKey = getDataRefreshKey(href)
 		lastFailedDataKey = null
 		return true
@@ -1095,7 +1111,7 @@ export function AccountSecretsRoute(handle: Handle) {
 			!isLoadingCurrentLocation
 		) {
 			if (
-				!applyEmbeddedLoaderData(currentHref) &&
+				!applyRouteLoaderData(currentHref) &&
 				typeof document !== 'undefined'
 			) {
 				handle.queueTask(loadAccountSecrets)

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -833,8 +833,12 @@ export function AccountSecretsRoute(handle: Handle) {
 				nextUrl.searchParams.delete('capability')
 				nextUrl.searchParams.delete('package_id')
 				nextUrl.searchParams.delete('package')
+				// `navigate` is async (preload-then-commit); the commit render
+				// consumes its preloaded data and updates `lastLoadedDataKey`.
+				// Pre-setting it to the destination here would make interim
+				// renders (current URL unchanged) look like a location change
+				// and fire a spurious refetch for the pre-approval URL.
 				navigate(`${nextUrl.pathname}${nextUrl.search}`)
-				lastLoadedDataKey = getDataRefreshKey(nextUrl.toString())
 			}
 		} catch (error) {
 			submittingApprovalAction = null

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -172,15 +172,15 @@ export function AccountRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
+		const appliedRouteData = applyRouteLoaderData(currentHref)
 		const isRefreshingForLocationChange =
 			status !== 'loading' && currentHref !== lastLoadedHref
-		if (status === 'loading' || isRefreshingForLocationChange) {
-			if (
-				!applyRouteLoaderData(currentHref) &&
-				typeof document !== 'undefined'
-			) {
-				handle.queueTask(loadAccountProfile)
-			}
+		if (
+			!appliedRouteData &&
+			(status === 'loading' || isRefreshingForLocationChange) &&
+			typeof document !== 'undefined'
+		) {
+			handle.queueTask(loadAccountProfile)
 		}
 		const isSaving = saveStatus === 'saving'
 		const normalizedDraftUsername = draftUsername.trim().toLowerCase()

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -1,10 +1,7 @@
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
-import {
-	listenToRouterNavigation,
-	readCurrentRouterHref,
-} from '#client/client-router.tsx'
-import { tryConsumeEmbeddedLoaderData } from '#client/loader-data-context.tsx'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
@@ -23,6 +20,7 @@ import {
 	accountProfileApiPath,
 	readJson,
 } from '#client/routes/account-approval-shared.ts'
+import { type AppLoaderData } from '#app/loader-data.ts'
 
 type AccountProfilePayload = {
 	ok: true
@@ -33,6 +31,26 @@ type AccountProfilePayload = {
 
 function isAccountPath(href: string) {
 	return new URL(href, 'http://localhost').pathname === '/account'
+}
+
+export async function accountRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<Partial<AppLoaderData> | null> {
+	const response = await fetch(`${accountProfileApiPath}${url.search}`, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		window.location.assign('/login')
+		return null
+	}
+	const payload = await readJson<AccountProfilePayload>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load your account.')
+	}
+	return { accountProfile: payload }
 }
 
 export function AccountRoute(handle: Handle) {
@@ -138,25 +156,13 @@ export function AccountRoute(handle: Handle) {
 		}
 	}
 
-	listenToRouterNavigation(handle, () => {
-		const href = readCurrentRouterHref(handle)
-		if (href !== lastLoadedHref && status !== 'loading') {
-			status = 'loading'
-			handle.update()
-		}
-	})
-
-	function applyEmbeddedLoaderData(href: string) {
+	function applyRouteLoaderData(href: string) {
 		if (!isAccountPath(href)) return false
-		const embedded = tryConsumeEmbeddedLoaderData(
-			handle,
-			'accountProfile',
-			href,
-		)
-		if (!embedded) return false
-		email = embedded.email
-		username = embedded.username
-		draftUsername = embedded.username
+		const routeData = tryConsumeRouteLoaderData(handle, 'accountProfile', href)
+		if (!routeData) return false
+		email = routeData.email
+		username = routeData.username
+		draftUsername = routeData.username
 		status = 'ready'
 		message = null
 		messageTone = 'info'
@@ -170,7 +176,7 @@ export function AccountRoute(handle: Handle) {
 			status !== 'loading' && currentHref !== lastLoadedHref
 		if (status === 'loading' || isRefreshingForLocationChange) {
 			if (
-				!applyEmbeddedLoaderData(currentHref) &&
+				!applyRouteLoaderData(currentHref) &&
 				typeof document !== 'undefined'
 			) {
 				handle.queueTask(loadAccountProfile)

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -20,7 +20,10 @@ import {
 	accountProfileApiPath,
 	readJson,
 } from '#client/routes/account-approval-shared.ts'
-import { type AppLoaderData } from '#app/loader-data.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
 
 type AccountProfilePayload = {
 	ok: true
@@ -36,15 +39,14 @@ function isAccountPath(href: string) {
 export async function accountRouteLoader(
 	url: URL,
 	signal: AbortSignal,
-): Promise<Partial<AppLoaderData> | null> {
+): Promise<RouteLoaderResult> {
 	const response = await fetch(`${accountProfileApiPath}${url.search}`, {
 		headers: { Accept: 'application/json' },
 		credentials: 'include',
 		signal,
 	})
 	if (response.status === 401) {
-		window.location.assign('/login')
-		return null
+		return routeLoaderRedirect('/login')
 	}
 	const payload = await readJson<AccountProfilePayload>(response)
 	if (!response.ok || !payload?.ok) {

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -2,6 +2,7 @@ import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
@@ -175,11 +176,17 @@ export function AccountRoute(handle: Handle) {
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
 		const appliedRouteData = applyRouteLoaderData(currentHref)
+		// A same-path refresh whose loader failed leaves no preload and no
+		// href change; the stale marker forces the fallback refetch.
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const isRefreshingForLocationChange =
 			status !== 'loading' && currentHref !== lastLoadedHref
 		if (
 			!appliedRouteData &&
-			(status === 'loading' || isRefreshingForLocationChange) &&
+			(status === 'loading' ||
+				isRefreshingForLocationChange ||
+				needsStaleRefresh) &&
 			typeof document !== 'undefined'
 		) {
 			handle.queueTask(loadAccountProfile)

--- a/packages/worker/client/routes/admin-community-reports.tsx
+++ b/packages/worker/client/routes/admin-community-reports.tsx
@@ -237,15 +237,24 @@ export function AdminCommunityReportsRoute(handle: Handle) {
 		status = 'ready'
 		message = null
 		lastLoadedHref = href
+		lastFailedHref = null
 		return true
 	}
 
 	const secondaryButtonCss = getSecondaryButtonCss()
 	const dangerButtonCss = getDangerButtonCss()
 
+	let lastSeenHref = ''
+
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
 		const isMutating = actionState !== 'idle'
+		// The failure latch only guards retry loops for the location that
+		// failed; leaving it (or coming back) must allow a fresh attempt.
+		if (currentHref !== lastSeenHref) {
+			lastSeenHref = currentHref
+			lastFailedHref = null
+		}
 
 		const appliedRouteData = applyRouteLoaderData(currentHref)
 		const needsLoad =

--- a/packages/worker/client/routes/admin-community-reports.tsx
+++ b/packages/worker/client/routes/admin-community-reports.tsx
@@ -247,16 +247,15 @@ export function AdminCommunityReportsRoute(handle: Handle) {
 		const currentHref = readCurrentRouterHref(handle)
 		const isMutating = actionState !== 'idle'
 
+		const appliedRouteData = applyRouteLoaderData(currentHref)
 		const needsLoad =
 			(status === 'loading' || currentHref !== lastLoadedHref) &&
 			currentHref !== lastFailedHref &&
 			loadingForHref !== currentHref
-		if (needsLoad && !applyRouteLoaderData(currentHref)) {
-			if (typeof document !== 'undefined') {
-				status = 'loading'
-				loadingForHref = currentHref
-				handle.queueTask(loadReports)
-			}
+		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
+			loadingForHref = currentHref
+			handle.queueTask(loadReports)
 		}
 
 		return (

--- a/packages/worker/client/routes/admin-community-reports.tsx
+++ b/packages/worker/client/routes/admin-community-reports.tsx
@@ -1,11 +1,8 @@
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
-import {
-	listenToRouterNavigation,
-	readCurrentRouterHref,
-} from '#client/client-router.tsx'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { readRouterSearch } from '#client/router-location.tsx'
-import { tryConsumeEmbeddedLoaderData } from '#client/loader-data-context.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import {
@@ -22,7 +19,10 @@ import {
 	AccountManagementMessage,
 	AccountManagementShell,
 } from './account-management-components.tsx'
-import { type AdminCommunityReportsLoaderData } from '#app/loader-data.ts'
+import {
+	type AdminCommunityReportsLoaderData,
+	type AppLoaderData,
+} from '#app/loader-data.ts'
 
 type AdminCommunityReportListItem =
 	AdminCommunityReportsLoaderData['reports'][number]
@@ -59,6 +59,29 @@ function buildReportsHref(handle: Handle, status: string) {
 	if (status === 'open') url.searchParams.delete('status')
 	else url.searchParams.set('status', status)
 	return `${url.pathname}${url.search}`
+}
+
+export async function adminCommunityReportsRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<Partial<AppLoaderData> | null> {
+	const response = await fetch(`${adminCommunityReportsApiPath}${url.search}`, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		window.location.assign('/login')
+		return null
+	}
+	if (response.status === 403) {
+		throw new Error('You do not have permission to view community reports.')
+	}
+	const payload = await readJson<AdminCommunityReportsLoaderData>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load community reports.')
+	}
+	return { adminCommunityReports: payload }
 }
 
 export function AdminCommunityReportsRoute(handle: Handle) {
@@ -201,25 +224,16 @@ export function AdminCommunityReportsRoute(handle: Handle) {
 		}
 	}
 
-	listenToRouterNavigation(handle, () => {
-		const href = readCurrentRouterHref(handle)
-		if (href !== lastLoadedHref) {
-			status = 'loading'
-			lastFailedHref = null
-			handle.update()
-		}
-	})
-
-	function applyEmbeddedLoaderData(href: string) {
+	function applyRouteLoaderData(href: string) {
 		if (!isAdminCommunityReportsPath(href)) return false
-		const embedded = tryConsumeEmbeddedLoaderData(
+		const routeData = tryConsumeRouteLoaderData(
 			handle,
 			'adminCommunityReports',
 			href,
 		)
-		if (!embedded) return false
-		reports = embedded.reports
-		statusFilter = embedded.statusFilter
+		if (!routeData) return false
+		reports = routeData.reports
+		statusFilter = routeData.statusFilter
 		status = 'ready'
 		message = null
 		lastLoadedHref = href
@@ -237,7 +251,7 @@ export function AdminCommunityReportsRoute(handle: Handle) {
 			(status === 'loading' || currentHref !== lastLoadedHref) &&
 			currentHref !== lastFailedHref &&
 			loadingForHref !== currentHref
-		if (needsLoad && !applyEmbeddedLoaderData(currentHref)) {
+		if (needsLoad && !applyRouteLoaderData(currentHref)) {
 			if (typeof document !== 'undefined') {
 				status = 'loading'
 				loadingForHref = currentHref

--- a/packages/worker/client/routes/admin-community-reports.tsx
+++ b/packages/worker/client/routes/admin-community-reports.tsx
@@ -3,6 +3,7 @@ import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { readRouterSearch } from '#client/router-location.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import {
@@ -257,8 +258,14 @@ export function AdminCommunityReportsRoute(handle: Handle) {
 		}
 
 		const appliedRouteData = applyRouteLoaderData(currentHref)
+		// A same-path refresh whose loader failed leaves no preload and no
+		// href change; the stale marker forces the fallback refetch.
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const needsLoad =
-			(status === 'loading' || currentHref !== lastLoadedHref) &&
+			(status === 'loading' ||
+				currentHref !== lastLoadedHref ||
+				needsStaleRefresh) &&
 			currentHref !== lastFailedHref &&
 			loadingForHref !== currentHref
 		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {

--- a/packages/worker/client/routes/admin-community-reports.tsx
+++ b/packages/worker/client/routes/admin-community-reports.tsx
@@ -19,10 +19,11 @@ import {
 	AccountManagementMessage,
 	AccountManagementShell,
 } from './account-management-components.tsx'
+import { type AdminCommunityReportsLoaderData } from '#app/loader-data.ts'
 import {
-	type AdminCommunityReportsLoaderData,
-	type AppLoaderData,
-} from '#app/loader-data.ts'
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
 
 type AdminCommunityReportListItem =
 	AdminCommunityReportsLoaderData['reports'][number]
@@ -64,15 +65,14 @@ function buildReportsHref(handle: Handle, status: string) {
 export async function adminCommunityReportsRouteLoader(
 	url: URL,
 	signal: AbortSignal,
-): Promise<Partial<AppLoaderData> | null> {
+): Promise<RouteLoaderResult> {
 	const response = await fetch(`${adminCommunityReportsApiPath}${url.search}`, {
 		headers: { Accept: 'application/json' },
 		credentials: 'include',
 		signal,
 	})
 	if (response.status === 401) {
-		window.location.assign('/login')
-		return null
+		return routeLoaderRedirect('/login')
 	}
 	if (response.status === 403) {
 		throw new Error('You do not have permission to view community reports.')

--- a/packages/worker/client/routes/admin-roles.tsx
+++ b/packages/worker/client/routes/admin-roles.tsx
@@ -114,16 +114,15 @@ export function AdminRolesRoute(handle: Handle) {
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
 
+		const appliedRouteData = applyRouteLoaderData(currentHref)
 		const needsLoad =
 			(status === 'loading' || currentHref !== lastLoadedHref) &&
 			currentHref !== lastFailedHref &&
 			loadingForHref !== currentHref
-		if (needsLoad && !applyRouteLoaderData(currentHref)) {
-			if (typeof document !== 'undefined') {
-				status = 'loading'
-				loadingForHref = currentHref
-				handle.queueTask(loadAdminRoles)
-			}
+		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
+			loadingForHref = currentHref
+			handle.queueTask(loadAdminRoles)
 		}
 
 		return (

--- a/packages/worker/client/routes/admin-roles.tsx
+++ b/packages/worker/client/routes/admin-roles.tsx
@@ -10,10 +10,11 @@ import {
 	AccountManagementPanel,
 	AccountManagementShell,
 } from './account-management-components.tsx'
+import { type AdminRolesLoaderData } from '#app/loader-data.ts'
 import {
-	type AdminRolesLoaderData,
-	type AppLoaderData,
-} from '#app/loader-data.ts'
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
 
 type AccountStatus = 'loading' | 'ready' | 'error'
 
@@ -26,15 +27,14 @@ function isAdminRolesPath(href: string) {
 export async function adminRolesRouteLoader(
 	_url: URL,
 	signal: AbortSignal,
-): Promise<Partial<AppLoaderData> | null> {
+): Promise<RouteLoaderResult> {
 	const response = await fetch(adminRolesApiPath, {
 		headers: { Accept: 'application/json' },
 		credentials: 'include',
 		signal,
 	})
 	if (response.status === 401) {
-		window.location.assign('/login')
-		return null
+		return routeLoaderRedirect('/login')
 	}
 	if (response.status === 403) {
 		throw new Error('You do not have permission to view admin roles.')

--- a/packages/worker/client/routes/admin-roles.tsx
+++ b/packages/worker/client/routes/admin-roles.tsx
@@ -1,9 +1,6 @@
 import { type Handle, css } from 'remix/ui'
-import {
-	listenToRouterNavigation,
-	readCurrentRouterHref,
-} from '#client/client-router.tsx'
-import { tryConsumeEmbeddedLoaderData } from '#client/loader-data-context.tsx'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import { getSecondaryButtonCss } from '#client/styles/style-primitives.ts'
@@ -13,7 +10,10 @@ import {
 	AccountManagementPanel,
 	AccountManagementShell,
 } from './account-management-components.tsx'
-import { type AdminRolesLoaderData } from '#app/loader-data.ts'
+import {
+	type AdminRolesLoaderData,
+	type AppLoaderData,
+} from '#app/loader-data.ts'
 
 type AccountStatus = 'loading' | 'ready' | 'error'
 
@@ -21,6 +21,29 @@ const adminRolesApiPath = '/admin/roles.json'
 
 function isAdminRolesPath(href: string) {
 	return new URL(href, 'http://localhost').pathname === '/admin/roles'
+}
+
+export async function adminRolesRouteLoader(
+	_url: URL,
+	signal: AbortSignal,
+): Promise<Partial<AppLoaderData> | null> {
+	const response = await fetch(adminRolesApiPath, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		window.location.assign('/login')
+		return null
+	}
+	if (response.status === 403) {
+		throw new Error('You do not have permission to view admin roles.')
+	}
+	const payload = await readJson<AdminRolesLoaderData>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load admin roles.')
+	}
+	return { adminRoles: payload }
 }
 
 export function AdminRolesRoute(handle: Handle) {
@@ -75,20 +98,11 @@ export function AdminRolesRoute(handle: Handle) {
 		}
 	}
 
-	listenToRouterNavigation(handle, () => {
-		const href = readCurrentRouterHref(handle)
-		if (href !== lastLoadedHref) {
-			status = 'loading'
-			lastFailedHref = null
-			handle.update()
-		}
-	})
-
-	function applyEmbeddedLoaderData(href: string) {
+	function applyRouteLoaderData(href: string) {
 		if (!isAdminRolesPath(href)) return false
-		const embedded = tryConsumeEmbeddedLoaderData(handle, 'adminRoles', href)
-		if (!embedded) return false
-		roles = embedded.roles
+		const routeData = tryConsumeRouteLoaderData(handle, 'adminRoles', href)
+		if (!routeData) return false
+		roles = routeData.roles
 		status = 'ready'
 		message = null
 		lastLoadedHref = href
@@ -104,7 +118,7 @@ export function AdminRolesRoute(handle: Handle) {
 			(status === 'loading' || currentHref !== lastLoadedHref) &&
 			currentHref !== lastFailedHref &&
 			loadingForHref !== currentHref
-		if (needsLoad && !applyEmbeddedLoaderData(currentHref)) {
+		if (needsLoad && !applyRouteLoaderData(currentHref)) {
 			if (typeof document !== 'undefined') {
 				status = 'loading'
 				loadingForHref = currentHref

--- a/packages/worker/client/routes/admin-roles.tsx
+++ b/packages/worker/client/routes/admin-roles.tsx
@@ -106,13 +106,22 @@ export function AdminRolesRoute(handle: Handle) {
 		status = 'ready'
 		message = null
 		lastLoadedHref = href
+		lastFailedHref = null
 		return true
 	}
 
 	const secondaryButtonCss = getSecondaryButtonCss()
 
+	let lastSeenHref = ''
+
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
+		// The failure latch only guards retry loops for the location that
+		// failed; leaving it (or coming back) must allow a fresh attempt.
+		if (currentHref !== lastSeenHref) {
+			lastSeenHref = currentHref
+			lastFailedHref = null
+		}
 
 		const appliedRouteData = applyRouteLoaderData(currentHref)
 		const needsLoad =

--- a/packages/worker/client/routes/admin-roles.tsx
+++ b/packages/worker/client/routes/admin-roles.tsx
@@ -1,6 +1,7 @@
 import { type Handle, css } from 'remix/ui'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import { getSecondaryButtonCss } from '#client/styles/style-primitives.ts'
@@ -124,8 +125,14 @@ export function AdminRolesRoute(handle: Handle) {
 		}
 
 		const appliedRouteData = applyRouteLoaderData(currentHref)
+		// A same-path refresh whose loader failed leaves no preload and no
+		// href change; the stale marker forces the fallback refetch.
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const needsLoad =
-			(status === 'loading' || currentHref !== lastLoadedHref) &&
+			(status === 'loading' ||
+				currentHref !== lastLoadedHref ||
+				needsStaleRefresh) &&
 			currentHref !== lastFailedHref &&
 			loadingForHref !== currentHref
 		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -232,11 +232,20 @@ export function AdminUsersRoute(handle: Handle) {
 		}
 		status = 'ready'
 		message = null
+		lastFailedHref = null
 		return true
 	}
 
+	let lastSeenHref = ''
+
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
+		// The failure latch only guards retry loops for the location that
+		// failed; leaving it (or coming back) must allow a fresh attempt.
+		if (currentHref !== lastSeenHref) {
+			lastSeenHref = currentHref
+			lastFailedHref = null
+		}
 		const totalPages = Math.max(1, Math.ceil(total / pageSize))
 		const selectedUser = getSelectedUser()
 		const isMutating = actionState !== 'idle'

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -239,16 +239,15 @@ export function AdminUsersRoute(handle: Handle) {
 		const selectedUser = getSelectedUser()
 		const isMutating = actionState !== 'idle'
 
+		const appliedRouteData = applyRouteLoaderData(currentHref)
 		const needsLoad =
 			(status === 'loading' || currentHref !== lastLoadedHref) &&
 			currentHref !== lastFailedHref &&
 			loadingForHref !== currentHref
-		if (needsLoad && !applyRouteLoaderData(currentHref)) {
-			if (typeof document !== 'undefined') {
-				status = 'loading'
-				loadingForHref = currentHref
-				handle.queueTask(loadAdminUsers)
-			}
+		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
+			loadingForHref = currentHref
+			handle.queueTask(loadAdminUsers)
 		}
 
 		return (

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -3,6 +3,7 @@ import { on } from '#client/event-mixin.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { readRouterSearch } from '#client/router-location.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, mq, spacing, typography } from '#client/styles/tokens.ts'
 import {
@@ -251,8 +252,14 @@ export function AdminUsersRoute(handle: Handle) {
 		const isMutating = actionState !== 'idle'
 
 		const appliedRouteData = applyRouteLoaderData(currentHref)
+		// A same-path refresh whose loader failed leaves no preload and no
+		// href change; the stale marker forces the fallback refetch.
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const needsLoad =
-			(status === 'loading' || currentHref !== lastLoadedHref) &&
+			(status === 'loading' ||
+				currentHref !== lastLoadedHref ||
+				needsStaleRefresh) &&
 			currentHref !== lastFailedHref &&
 			loadingForHref !== currentHref
 		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -1,12 +1,8 @@
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
-import {
-	navigate,
-	listenToRouterNavigation,
-	readCurrentRouterHref,
-} from '#client/client-router.tsx'
+import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { readRouterSearch } from '#client/router-location.tsx'
-import { tryConsumeEmbeddedLoaderData } from '#client/loader-data-context.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, mq, spacing, typography } from '#client/styles/tokens.ts'
 import {
@@ -32,6 +28,7 @@ import { type RoleName } from '#app/permissions.ts'
 import {
 	type AdminUserListItem,
 	type AdminUsersLoaderData,
+	type AppLoaderData,
 } from '#app/loader-data.ts'
 
 type AccountStatus = 'loading' | 'ready' | 'error'
@@ -52,6 +49,29 @@ function buildUsersHref(handle: Handle, page: number) {
 	if (page <= 1) url.searchParams.delete('page')
 	else url.searchParams.set('page', String(page))
 	return `${url.pathname}${url.search}`
+}
+
+export async function adminUsersRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<Partial<AppLoaderData> | null> {
+	const response = await fetch(`${adminUsersApiPath}${url.search}`, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		window.location.assign('/login')
+		return null
+	}
+	if (response.status === 403) {
+		throw new Error('You do not have permission to view admin users.')
+	}
+	const payload = await readJson<AdminUsersLoaderData>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load admin users.')
+	}
+	return { adminUsers: payload }
 }
 
 export function AdminUsersRoute(handle: Handle) {
@@ -189,26 +209,15 @@ export function AdminUsersRoute(handle: Handle) {
 	const primaryButtonCss = getPrimaryButtonCss()
 	const secondaryButtonCss = getSecondaryButtonCss()
 
-	handle.queueTask(() => {
-		listenToRouterNavigation(handle, () => {
-			const nextHref = readCurrentRouterHref(handle)
-			if (nextHref !== lastLoadedHref && status !== 'loading') {
-				status = 'loading'
-				lastFailedHref = null
-				handle.update()
-			}
-		})
-	})
-
-	function applyEmbeddedLoaderData(href: string) {
+	function applyRouteLoaderData(href: string) {
 		if (!isAdminUsersPath(href)) return false
-		const embedded = tryConsumeEmbeddedLoaderData(handle, 'adminUsers', href)
-		if (!embedded) return false
-		users = embedded.users
-		availableRoles = embedded.availableRoles
-		page = embedded.page
-		pageSize = embedded.pageSize
-		total = embedded.total
+		const routeData = tryConsumeRouteLoaderData(handle, 'adminUsers', href)
+		if (!routeData) return false
+		users = routeData.users
+		availableRoles = routeData.availableRoles
+		page = routeData.page
+		pageSize = routeData.pageSize
+		total = routeData.total
 		lastLoadedHref = href
 		if (
 			selectedUserId != null &&
@@ -234,7 +243,7 @@ export function AdminUsersRoute(handle: Handle) {
 			(status === 'loading' || currentHref !== lastLoadedHref) &&
 			currentHref !== lastFailedHref &&
 			loadingForHref !== currentHref
-		if (needsLoad && !applyEmbeddedLoaderData(currentHref)) {
+		if (needsLoad && !applyRouteLoaderData(currentHref)) {
 			if (typeof document !== 'undefined') {
 				status = 'loading'
 				loadingForHref = currentHref

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -28,8 +28,11 @@ import { type RoleName } from '#app/permissions.ts'
 import {
 	type AdminUserListItem,
 	type AdminUsersLoaderData,
-	type AppLoaderData,
 } from '#app/loader-data.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
 
 type AccountStatus = 'loading' | 'ready' | 'error'
 
@@ -54,15 +57,14 @@ function buildUsersHref(handle: Handle, page: number) {
 export async function adminUsersRouteLoader(
 	url: URL,
 	signal: AbortSignal,
-): Promise<Partial<AppLoaderData> | null> {
+): Promise<RouteLoaderResult> {
 	const response = await fetch(`${adminUsersApiPath}${url.search}`, {
 		headers: { Accept: 'application/json' },
 		credentials: 'include',
 		signal,
 	})
 	if (response.status === 401) {
-		window.location.assign('/login')
-		return null
+		return routeLoaderRedirect('/login')
 	}
 	if (response.status === 403) {
 		throw new Error('You do not have permission to view admin users.')

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -6,7 +6,9 @@ import {
 	listenToRouterNavigation,
 	readCurrentRouterHref,
 } from '#client/client-router.tsx'
-import { tryConsumeEmbeddedLoaderData } from '#client/loader-data-context.tsx'
+import { prefetchFrame } from '#client/frame-prefetch.ts'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { type AppLoaderData } from '#app/loader-data.ts'
 import { readRouterPathname } from '#client/router-location.tsx'
 import { on } from '#client/event-mixin.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
@@ -33,14 +35,59 @@ type CommunityDetailApiPayload = {
 	forkPrompt: string
 }
 
-function getCurrentListingId(handle: Handle) {
-	const pathname = readRouterPathname(handle)
+function getListingIdFromPathname(pathname: string) {
 	const prefix = `${routes.community.href()}/`
 	if (!pathname.startsWith(prefix)) return null
 	const listingId = decodeURIComponent(
 		pathname.slice(prefix.length).replace(/\/$/, ''),
 	)
 	return listingId || null
+}
+
+function getCurrentListingId(handle: Handle) {
+	return getListingIdFromPathname(readRouterPathname(handle))
+}
+
+export async function communityDetailRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<Partial<AppLoaderData> | null> {
+	const listingId = getListingIdFromPathname(url.pathname)
+	if (!listingId) {
+		throw new Error('Community listing not found.')
+	}
+
+	const frameSrc = routes.communityDetail.href({ listingId })
+	const shellPromise = fetch(routes.communityDetailApi.href({ listingId }), {
+		headers: { Accept: 'application/json' },
+		signal,
+	})
+	const framePrefetchPromise = prefetchFrame(
+		frameSrc,
+		COMMUNITY_DETAIL_TARGET,
+		signal,
+	)
+
+	const response = await shellPromise
+	if (response.status === 404) {
+		throw new Error('Community listing not found.')
+	}
+	const payload = await readJson<CommunityDetailApiPayload>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load community package.')
+	}
+
+	await framePrefetchPromise
+
+	return {
+		communityDetailShell: {
+			ok: true,
+			listingId,
+			forkPrompt: payload.forkPrompt,
+			loggedIn: payload.loggedIn,
+			readmeContent: payload.listing.readmeContent,
+		},
+	}
 }
 
 function buildReportApiPath(listingId: string) {
@@ -176,31 +223,21 @@ export function CommunityDetailRoute(handle: Handle) {
 			frame.src = nextSrc
 		}
 		void frame.reload()
-
-		// Revalidate the shell alongside the frame so the fork prompt, README,
-		// and report login state stay as fresh as the listing metadata. When
-		// the listing changed, flip to loading synchronously so the previous
-		// listing's shell never renders under the new listing's header.
-		shellRequestedForListingId = listingId
-		if (shellLoadedForListingId !== listingId) {
-			shellStatus = 'loading'
-		}
-		handle.queueTask(loadDetailShell)
 	})
 
-	function applyEmbeddedShellData(href: string, listingId: string | null) {
+	function applyRouteShellData(href: string, listingId: string | null) {
 		if (!listingId || shellLoadedForListingId === listingId) return false
-		const embedded = tryConsumeEmbeddedLoaderData(
+		const routeData = tryConsumeRouteLoaderData(
 			handle,
 			'communityDetailShell',
 			href,
 		)
-		if (!embedded || embedded.listingId !== listingId) {
+		if (!routeData || routeData.listingId !== listingId) {
 			return false
 		}
-		forkPrompt = embedded.forkPrompt
-		loggedIn = embedded.loggedIn
-		readmeContent = embedded.readmeContent
+		forkPrompt = routeData.forkPrompt
+		loggedIn = routeData.loggedIn
+		readmeContent = routeData.readmeContent
 		reportState = 'idle'
 		reportMessage = null
 		shellLoadedForListingId = listingId
@@ -231,7 +268,7 @@ export function CommunityDetailRoute(handle: Handle) {
 			)
 		}
 
-		applyEmbeddedShellData(currentHref, listingId)
+		applyRouteShellData(currentHref, listingId)
 		if (
 			shellLoadedForListingId !== listingId &&
 			shellRequestedForListingId !== listingId &&

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -8,6 +8,7 @@ import {
 } from '#client/client-router.tsx'
 import { prefetchFrame } from '#client/frame-prefetch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { readRouterPathname } from '#client/router-location.tsx'
 import { on } from '#client/event-mixin.ts'
@@ -268,18 +269,26 @@ export function CommunityDetailRoute(handle: Handle) {
 			)
 		}
 
-		applyRouteShellData(currentHref, listingId)
+		const appliedShellData = applyRouteShellData(currentHref, listingId)
+		// A same-path refresh whose loader failed leaves no preload and the
+		// listing id unchanged; the stale marker forces the fallback refetch.
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedShellData
 		if (
-			shellLoadedForListingId !== listingId &&
-			shellRequestedForListingId !== listingId &&
+			(needsStaleRefresh ||
+				(shellLoadedForListingId !== listingId &&
+					shellRequestedForListingId !== listingId)) &&
 			typeof document !== 'undefined'
 		) {
 			// Show the loading state immediately so the previous listing's
 			// shell (fork prompt, README, login state) never renders under the
-			// new listing's header while the refetch is in flight. Tracking the
-			// requested listing separately keeps re-renders from enqueueing
+			// new listing's header while the refetch is in flight. Same-listing
+			// stale refreshes keep the current shell visible instead. Tracking
+			// the requested listing separately keeps re-renders from enqueueing
 			// duplicate fetches while one is already in flight.
-			shellStatus = 'loading'
+			if (shellLoadedForListingId !== listingId) {
+				shellStatus = 'loading'
+			}
 			shellRequestedForListingId = listingId
 			handle.queueTask(loadDetailShell)
 		}

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -8,7 +8,7 @@ import {
 } from '#client/client-router.tsx'
 import { prefetchFrame } from '#client/frame-prefetch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
-import { type AppLoaderData } from '#app/loader-data.ts'
+import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { readRouterPathname } from '#client/router-location.tsx'
 import { on } from '#client/event-mixin.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
@@ -51,7 +51,7 @@ function getCurrentListingId(handle: Handle) {
 export async function communityDetailRouteLoader(
 	url: URL,
 	signal: AbortSignal,
-): Promise<Partial<AppLoaderData> | null> {
+): Promise<RouteLoaderResult> {
 	const listingId = getListingIdFromPathname(url.pathname)
 	if (!listingId) {
 		throw new Error('Community listing not found.')

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -226,7 +226,7 @@ export function CommunityDetailRoute(handle: Handle) {
 	})
 
 	function applyRouteShellData(href: string, listingId: string | null) {
-		if (!listingId || shellLoadedForListingId === listingId) return false
+		if (!listingId) return false
 		const routeData = tryConsumeRouteLoaderData(
 			handle,
 			'communityDetailShell',

--- a/packages/worker/client/routes/community.tsx
+++ b/packages/worker/client/routes/community.tsx
@@ -1,10 +1,12 @@
 import { Frame, type Handle, css } from 'remix/ui'
 import { routes } from '#app/routes.ts'
 import { COMMUNITY_LISTINGS_TARGET } from '#app/community-frame-constants.ts'
+import { type AppLoaderData } from '#app/loader-data.ts'
 import {
 	listenToRouterNavigation,
 	readCurrentRouterHref,
 } from '#client/client-router.tsx'
+import { prefetchFrame } from '#client/frame-prefetch.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	fieldCss,
@@ -26,6 +28,21 @@ function isCommunityIndexPath(href: string) {
 function buildCommunityListingsFrameSrc(href: string) {
 	const url = new URL(href, 'http://localhost')
 	return `${routes.community.href()}${url.search}`
+}
+
+export async function communityRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<Partial<AppLoaderData> | null> {
+	try {
+		const frameSrc = buildCommunityListingsFrameSrc(
+			`${url.pathname}${url.search}`,
+		)
+		await prefetchFrame(frameSrc, COMMUNITY_LISTINGS_TARGET, signal)
+	} catch {
+		// Prefetch failures degrade to the post-commit frame fetch.
+	}
+	return {}
 }
 
 export function CommunityRoute(handle: Handle) {

--- a/packages/worker/client/routes/community.tsx
+++ b/packages/worker/client/routes/community.tsx
@@ -1,7 +1,7 @@
 import { Frame, type Handle, css } from 'remix/ui'
 import { routes } from '#app/routes.ts'
 import { COMMUNITY_LISTINGS_TARGET } from '#app/community-frame-constants.ts'
-import { type AppLoaderData } from '#app/loader-data.ts'
+import { type RouteLoaderResult } from '#client/route-loader.ts'
 import {
 	listenToRouterNavigation,
 	readCurrentRouterHref,
@@ -33,7 +33,7 @@ function buildCommunityListingsFrameSrc(href: string) {
 export async function communityRouteLoader(
 	url: URL,
 	signal: AbortSignal,
-): Promise<Partial<AppLoaderData> | null> {
+): Promise<RouteLoaderResult> {
 	try {
 		const frameSrc = buildCommunityListingsFrameSrc(
 			`${url.pathname}${url.search}`,

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -1,4 +1,5 @@
-import { AccountRoute } from './account.tsx'
+import { type RouteLoader } from '#client/client-router.tsx'
+import { AccountRoute, accountRouteLoader } from './account.tsx'
 import { AccountIntegrationsRoute } from './account-integrations.tsx'
 import { AccountPackageInvocationTokensRoute } from './account-package-invocation-tokens.tsx'
 import { AccountRemoteConnectorsRoute } from './account-remote-connectors.tsx'
@@ -15,6 +16,10 @@ import { PrivacyRoute } from './privacy.tsx'
 import { OAuthAuthorizeRoute } from './oauth-authorize.tsx'
 import { OAuthCallbackRoute } from './oauth-callback.tsx'
 import { ResetPasswordRoute } from './reset-password.tsx'
+
+export const clientRouteLoaders: Record<string, RouteLoader> = {
+	'/account': accountRouteLoader,
+}
 
 export const clientRoutes = {
 	'/': <HomeRoute />,

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -1,24 +1,67 @@
 import { type RouteLoader } from '#client/client-router.tsx'
 import { AccountRoute, accountRouteLoader } from './account.tsx'
-import { AccountIntegrationsRoute } from './account-integrations.tsx'
-import { AccountPackageInvocationTokensRoute } from './account-package-invocation-tokens.tsx'
-import { AccountRemoteConnectorsRoute } from './account-remote-connectors.tsx'
-import { AccountSecretsRoute } from './account-secrets.tsx'
-import { AdminCommunityReportsRoute } from './admin-community-reports.tsx'
-import { AdminRolesRoute } from './admin-roles.tsx'
-import { AdminUsersRoute } from './admin-users.tsx'
-import { CommunityDetailRoute } from './community-detail.tsx'
-import { CommunityRoute } from './community.tsx'
+import {
+	AccountIntegrationsRoute,
+	accountIntegrationsRouteLoader,
+} from './account-integrations.tsx'
+import {
+	AccountPackageInvocationTokensRoute,
+	accountPackageInvocationTokensRouteLoader,
+} from './account-package-invocation-tokens.tsx'
+import {
+	AccountRemoteConnectorsRoute,
+	accountRemoteConnectorsRouteLoader,
+} from './account-remote-connectors.tsx'
+import {
+	AccountSecretsRoute,
+	accountSecretsRouteLoader,
+} from './account-secrets.tsx'
+import {
+	AdminCommunityReportsRoute,
+	adminCommunityReportsRouteLoader,
+} from './admin-community-reports.tsx'
+import { AdminRolesRoute, adminRolesRouteLoader } from './admin-roles.tsx'
+import { AdminUsersRoute, adminUsersRouteLoader } from './admin-users.tsx'
+import {
+	CommunityDetailRoute,
+	communityDetailRouteLoader,
+} from './community-detail.tsx'
+import { CommunityRoute, communityRouteLoader } from './community.tsx'
 import { ConnectOauthRoute } from './connect-oauth.tsx'
 import { HomeRoute } from './home.tsx'
 import { LoginRoute } from './login.tsx'
 import { PrivacyRoute } from './privacy.tsx'
-import { OAuthAuthorizeRoute } from './oauth-authorize.tsx'
+import {
+	OAuthAuthorizeRoute,
+	oauthAuthorizeRouteLoader,
+} from './oauth-authorize.tsx'
 import { OAuthCallbackRoute } from './oauth-callback.tsx'
 import { ResetPasswordRoute } from './reset-password.tsx'
 
 export const clientRouteLoaders: Record<string, RouteLoader> = {
 	'/account': accountRouteLoader,
+	'/account/integrations': accountIntegrationsRouteLoader,
+	'/account/package-invocation-tokens':
+		accountPackageInvocationTokensRouteLoader,
+	'/account/package-invocation-tokens/new':
+		accountPackageInvocationTokensRouteLoader,
+	'/account/package-invocation-tokens/:tokenId':
+		accountPackageInvocationTokensRouteLoader,
+	'/account/remote-connectors': accountRemoteConnectorsRouteLoader,
+	'/account/secrets': accountSecretsRouteLoader,
+	'/account/secrets/new': accountSecretsRouteLoader,
+	'/account/secrets/approve': accountSecretsRouteLoader,
+	'/account/secrets/:secretId': accountSecretsRouteLoader,
+	'/account/secrets/user/:secretName': accountSecretsRouteLoader,
+	'/account/secrets/app/:appId/:secretName': accountSecretsRouteLoader,
+	'/account/secrets/session/:sessionId/:secretName': accountSecretsRouteLoader,
+	'/admin': adminUsersRouteLoader,
+	'/admin/users': adminUsersRouteLoader,
+	'/admin/roles': adminRolesRouteLoader,
+	'/admin/community-reports': adminCommunityReportsRouteLoader,
+	'/community': communityRouteLoader,
+	'/community/:listingId': communityDetailRouteLoader,
+	'/oauth/authorize': oauthAuthorizeRouteLoader,
 }
 
 export const clientRoutes = {

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -1,8 +1,9 @@
 import { type Handle, css } from 'remix/ui'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { on } from '#client/event-mixin.ts'
-import { tryConsumeEmbeddedLoaderData } from '#client/loader-data-context.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { readRouterSearch } from '#client/router-location.tsx'
+import { type AppLoaderData } from '#app/loader-data.ts'
 import {
 	fetchSessionInfo,
 	getSessionDisplayName,
@@ -45,6 +46,38 @@ function getSearchParams(handle: Handle) {
 
 function isOAuthAuthorizePath(href: string) {
 	return new URL(href, 'http://localhost').pathname === '/oauth/authorize'
+}
+
+export async function oauthAuthorizeRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<Partial<AppLoaderData> | null> {
+	const response = await fetch(`/oauth/authorize-info${url.search}`, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	const payload = await response.json().catch(() => null)
+	if (!response.ok || !payload?.ok) {
+		const errorText =
+			typeof payload?.error === 'string'
+				? payload.error
+				: 'Unable to load authorization details.'
+		return {
+			oauthAuthorize: {
+				ok: false,
+				error: errorText,
+				allowClientReset: payload?.allowClientReset === true,
+			},
+		}
+	}
+	return {
+		oauthAuthorize: {
+			ok: true,
+			client: payload.client,
+			scopes: payload.scopes,
+		},
+	}
 }
 
 export function OAuthAuthorizeRoute(handle: Handle) {
@@ -124,18 +157,18 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		handle.update()
 	}
 
-	function applyEmbeddedLoaderData(currentHref: string) {
+	function applyRouteLoaderData(currentHref: string) {
 		if (!isOAuthAuthorizePath(currentHref)) return false
-		const embedded = tryConsumeEmbeddedLoaderData(
+		const routeData = tryConsumeRouteLoaderData(
 			handle,
 			'oauthAuthorize',
 			currentHref,
 		)
-		if (!embedded) return false
-		if (embedded.ok) {
+		if (!routeData) return false
+		if (routeData.ok) {
 			info = {
-				client: embedded.client,
-				scopes: embedded.scopes,
+				client: routeData.client,
+				scopes: routeData.scopes,
 			}
 			status = 'ready'
 			allowClientReset = false
@@ -143,8 +176,8 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		} else {
 			info = null
 			status = 'error'
-			allowClientReset = embedded.allowClientReset
-			message = { type: 'error', text: embedded.error }
+			allowClientReset = routeData.allowClientReset
+			message = { type: 'error', text: routeData.error }
 		}
 		return true
 	}
@@ -235,7 +268,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 			lastSearch = currentSearch
 			resetCompleted = false
 			const queryError = readQueryError()
-			if (!applyEmbeddedLoaderData(currentHref)) {
+			if (!applyRouteLoaderData(currentHref)) {
 				allowClientReset = false
 				info = null
 				status = 'loading'

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -3,7 +3,7 @@ import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { on } from '#client/event-mixin.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { readRouterSearch } from '#client/router-location.tsx'
-import { type AppLoaderData } from '#app/loader-data.ts'
+import { type RouteLoaderResult } from '#client/route-loader.ts'
 import {
 	fetchSessionInfo,
 	getSessionDisplayName,
@@ -51,7 +51,7 @@ function isOAuthAuthorizePath(href: string) {
 export async function oauthAuthorizeRouteLoader(
 	url: URL,
 	signal: AbortSignal,
-): Promise<Partial<AppLoaderData> | null> {
+): Promise<RouteLoaderResult> {
 	const response = await fetch(`/oauth/authorize-info${url.search}`, {
 		headers: { Accept: 'application/json' },
 		credentials: 'include',

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -165,6 +165,10 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 			currentHref,
 		)
 		if (!routeData) return false
+		// Invalidate any in-flight fallback fetch so a stale response cannot
+		// overwrite the fresher consumed payload.
+		activeInfoRequestId += 1
+		resetCompleted = false
 		if (routeData.ok) {
 			info = {
 				client: routeData.client,
@@ -264,20 +268,23 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
 		const currentSearch = readRouterSearch(handle)
-		if (status === 'idle' || currentSearch !== lastSearch) {
+		// Consume on every render so same-path preload-then-commit refreshes
+		// (unchanged search) still apply fresh loader data.
+		const appliedRouteData = applyRouteLoaderData(currentHref)
+		if (appliedRouteData) {
+			lastSearch = currentSearch
+		} else if (status === 'idle' || currentSearch !== lastSearch) {
 			lastSearch = currentSearch
 			resetCompleted = false
 			const queryError = readQueryError()
-			if (!applyRouteLoaderData(currentHref)) {
-				allowClientReset = false
-				info = null
-				status = 'loading'
-				message = queryError ? { type: 'error', text: queryError } : null
-				activeInfoRequestId += 1
-				const requestId = activeInfoRequestId
-				if (typeof document !== 'undefined') {
-					handle.queueTask(() => loadInfo(requestId))
-				}
+			allowClientReset = false
+			info = null
+			status = 'loading'
+			message = queryError ? { type: 'error', text: queryError } : null
+			activeInfoRequestId += 1
+			const requestId = activeInfoRequestId
+			if (typeof document !== 'undefined') {
+				handle.queueTask(() => loadInfo(requestId))
 			}
 		}
 		if (sessionStatus === 'idle' && typeof document !== 'undefined') {

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -2,6 +2,7 @@ import { type Handle, css } from 'remix/ui'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { on } from '#client/event-mixin.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readRouterSearch } from '#client/router-location.tsx'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import {
@@ -271,9 +272,17 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		// Consume on every render so same-path preload-then-commit refreshes
 		// (unchanged search) still apply fresh loader data.
 		const appliedRouteData = applyRouteLoaderData(currentHref)
+		// A same-path refresh whose loader failed leaves no preload and no
+		// search change; the stale marker forces the fallback refetch.
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		if (appliedRouteData) {
 			lastSearch = currentSearch
-		} else if (status === 'idle' || currentSearch !== lastSearch) {
+		} else if (
+			status === 'idle' ||
+			currentSearch !== lastSearch ||
+			needsStaleRefresh
+		) {
 			lastSearch = currentSearch
 			resetCompleted = false
 			const queryError = readQueryError()

--- a/packages/worker/public/mcp-apps/kody-ui-utils.css
+++ b/packages/worker/public/mcp-apps/kody-ui-utils.css
@@ -1,176 +1,172 @@
 /* packages/worker/client/mcp-apps/kody-ui-utils.css */
 :root {
-  color-scheme: light dark;
-  --font-body:
-    ui-sans-serif,
-    system-ui,
-    sans-serif;
-  --font-mono:
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    monospace;
-  --spacing-1: 0.25rem;
-  --spacing-2: 0.5rem;
-  --spacing-3: 0.75rem;
-  --spacing-4: 1rem;
-  --spacing-6: 1.5rem;
-  --radius-2: 0.5rem;
-  --radius-3: 0.75rem;
-  --shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
-  --color-bg: #ffffff;
-  --color-surface: #f8fafc;
-  --color-fg: #0f172a;
-  --color-muted: #475569;
-  --color-border: #dbe2ea;
-  --color-accent: #2563eb;
-  --color-accent-contrast: #ffffff;
-  --color-code-bg: rgb(15 23 42 / 0.06);
+	color-scheme: light dark;
+	--font-body: ui-sans-serif, system-ui, sans-serif;
+	--font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	--spacing-1: 0.25rem;
+	--spacing-2: 0.5rem;
+	--spacing-3: 0.75rem;
+	--spacing-4: 1rem;
+	--spacing-6: 1.5rem;
+	--radius-2: 0.5rem;
+	--radius-3: 0.75rem;
+	--shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
+	--color-bg: #ffffff;
+	--color-surface: #f8fafc;
+	--color-fg: #0f172a;
+	--color-muted: #475569;
+	--color-border: #dbe2ea;
+	--color-accent: #2563eb;
+	--color-accent-contrast: #ffffff;
+	--color-code-bg: rgb(15 23 42 / 0.06);
 }
 @media (prefers-color-scheme: dark) {
-  :root {
-    --color-bg: #0f172a;
-    --color-surface: #162033;
-    --color-fg: #e5eef8;
-    --color-muted: #a5b4c7;
-    --color-border: #2a3950;
-    --color-accent: #60a5fa;
-    --color-accent-contrast: #0f172a;
-    --color-code-bg: rgb(148 163 184 / 0.16);
-  }
+	:root {
+		--color-bg: #0f172a;
+		--color-surface: #162033;
+		--color-fg: #e5eef8;
+		--color-muted: #a5b4c7;
+		--color-border: #2a3950;
+		--color-accent: #60a5fa;
+		--color-accent-contrast: #0f172a;
+		--color-code-bg: rgb(148 163 184 / 0.16);
+	}
 }
 :where(html) {
-  min-height: 100%;
-  background: var(--color-bg);
-  color: var(--color-fg);
+	min-height: 100%;
+	background: var(--color-bg);
+	color: var(--color-fg);
 }
 :where(body) {
-  min-height: 100%;
-  margin: 0;
-  padding: var(--spacing-4);
-  background: var(--color-bg);
-  color: var(--color-fg);
-  font: 400 14px/1.5 var(--font-body);
+	min-height: 100%;
+	margin: 0;
+	padding: var(--spacing-4);
+	background: var(--color-bg);
+	color: var(--color-fg);
+	font: 400 14px/1.5 var(--font-body);
 }
-:where(body[data-kody-runtime=javascript]) {
-  padding: 0;
+:where(body[data-kody-runtime='javascript']) {
+	padding: 0;
 }
 :where(*, *::before, *::after) {
-  box-sizing: border-box;
+	box-sizing: border-box;
 }
 :where(a) {
-  color: var(--color-accent);
+	color: var(--color-accent);
 }
 :where(p, ul, ol, dl, pre, table, blockquote, fieldset) {
-  margin: 0 0 var(--spacing-4);
+	margin: 0 0 var(--spacing-4);
 }
 :where(h1, h2, h3, h4, h5, h6) {
-  margin: 0 0 var(--spacing-3);
-  line-height: 1.2;
+	margin: 0 0 var(--spacing-3);
+	line-height: 1.2;
 }
 :where(h1) {
-  font-size: 1.875rem;
+	font-size: 1.875rem;
 }
 :where(h2) {
-  font-size: 1.5rem;
+	font-size: 1.5rem;
 }
 :where(h3) {
-  font-size: 1.25rem;
+	font-size: 1.25rem;
 }
 :where(ul, ol) {
-  padding-left: 1.5rem;
+	padding-left: 1.5rem;
 }
 :where(hr) {
-  border: 0;
-  border-top: 1px solid var(--color-border);
-  margin: var(--spacing-6) 0;
+	border: 0;
+	border-top: 1px solid var(--color-border);
+	margin: var(--spacing-6) 0;
 }
 :where(code, kbd, samp) {
-  font-family: var(--font-mono);
-  font-size: 0.95em;
+	font-family: var(--font-mono);
+	font-size: 0.95em;
 }
 :where(code) {
-  background: var(--color-code-bg);
-  border-radius: 0.375rem;
-  padding: 0.1rem 0.35rem;
+	background: var(--color-code-bg);
+	border-radius: 0.375rem;
+	padding: 0.1rem 0.35rem;
 }
 :where(pre) {
-  overflow-x: auto;
-  padding: var(--spacing-3);
-  background: var(--color-code-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-2);
+	overflow-x: auto;
+	padding: var(--spacing-3);
+	background: var(--color-code-bg);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-2);
 }
 :where(pre code) {
-  background: transparent;
-  padding: 0;
+	background: transparent;
+	padding: 0;
 }
 :where(form) {
-  display: grid;
-  gap: var(--spacing-4);
+	display: grid;
+	gap: var(--spacing-4);
 }
 :where(label) {
-  display: grid;
-  gap: var(--spacing-2);
-  font-weight: 600;
+	display: grid;
+	gap: var(--spacing-2);
+	font-weight: 600;
 }
 :where(input, button, textarea, select) {
-  font: inherit;
+	font: inherit;
 }
-:where(input:not([type=checkbox]):not([type=radio]), textarea, select) {
-  width: 100%;
-  padding: var(--spacing-2) var(--spacing-3);
-  background: var(--color-surface);
-  color: var(--color-fg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-2);
-  box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
+:where(input:not([type='checkbox']):not([type='radio']), textarea, select) {
+	width: 100%;
+	padding: var(--spacing-2) var(--spacing-3);
+	background: var(--color-surface);
+	color: var(--color-fg);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-2);
+	box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
 }
 :where(textarea) {
-  min-height: 7rem;
-  resize: vertical;
+	min-height: 7rem;
+	resize: vertical;
 }
-:where(input[type=checkbox], input[type=radio]) {
-  accent-color: var(--color-accent);
+:where(input[type='checkbox'], input[type='radio']) {
+	accent-color: var(--color-accent);
 }
 :where(button) {
-  width: fit-content;
-  padding: var(--spacing-2) var(--spacing-4);
-  background: var(--color-accent);
-  color: var(--color-accent-contrast);
-  border: 1px solid transparent;
-  border-radius: var(--radius-2);
-  box-shadow: var(--shadow-1);
-  cursor: pointer;
+	width: fit-content;
+	padding: var(--spacing-2) var(--spacing-4);
+	background: var(--color-accent);
+	color: var(--color-accent-contrast);
+	border: 1px solid transparent;
+	border-radius: var(--radius-2);
+	box-shadow: var(--shadow-1);
+	cursor: pointer;
 }
 :where(button:disabled, input:disabled, textarea:disabled, select:disabled) {
-  opacity: 0.7;
-  cursor: not-allowed;
+	opacity: 0.7;
+	cursor: not-allowed;
 }
-:where(button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible) {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
+:where(
+	button:focus-visible,
+	input:focus-visible,
+	textarea:focus-visible,
+	select:focus-visible
+) {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
 }
 :where(table) {
-  width: 100%;
-  border-collapse: collapse;
+	width: 100%;
+	border-collapse: collapse;
 }
 :where(th, td) {
-  padding: var(--spacing-2) var(--spacing-3);
-  border: 1px solid var(--color-border);
-  text-align: left;
+	padding: var(--spacing-2) var(--spacing-3);
+	border: 1px solid var(--color-border);
+	text-align: left;
 }
 :where(th) {
-  background: var(--color-surface);
+	background: var(--color-surface);
 }
 :where(blockquote) {
-  margin-left: 0;
-  padding-left: var(--spacing-4);
-  border-left: 3px solid var(--color-border);
-  color: var(--color-muted);
+	margin-left: 0;
+	padding-left: var(--spacing-4);
+	border-left: 3px solid var(--color-border);
+	color: var(--color-muted);
 }
 :where([data-generated-ui-root]) {
-  min-height: 100%;
+	min-height: 100%;
 }

--- a/packages/worker/public/mcp-apps/kody-ui-utils.css
+++ b/packages/worker/public/mcp-apps/kody-ui-utils.css
@@ -1,172 +1,176 @@
 /* packages/worker/client/mcp-apps/kody-ui-utils.css */
 :root {
-	color-scheme: light dark;
-	--font-body: ui-sans-serif, system-ui, sans-serif;
-	--font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-	--spacing-1: 0.25rem;
-	--spacing-2: 0.5rem;
-	--spacing-3: 0.75rem;
-	--spacing-4: 1rem;
-	--spacing-6: 1.5rem;
-	--radius-2: 0.5rem;
-	--radius-3: 0.75rem;
-	--shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
-	--color-bg: #ffffff;
-	--color-surface: #f8fafc;
-	--color-fg: #0f172a;
-	--color-muted: #475569;
-	--color-border: #dbe2ea;
-	--color-accent: #2563eb;
-	--color-accent-contrast: #ffffff;
-	--color-code-bg: rgb(15 23 42 / 0.06);
+  color-scheme: light dark;
+  --font-body:
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+  --font-mono:
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace;
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-6: 1.5rem;
+  --radius-2: 0.5rem;
+  --radius-3: 0.75rem;
+  --shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
+  --color-bg: #ffffff;
+  --color-surface: #f8fafc;
+  --color-fg: #0f172a;
+  --color-muted: #475569;
+  --color-border: #dbe2ea;
+  --color-accent: #2563eb;
+  --color-accent-contrast: #ffffff;
+  --color-code-bg: rgb(15 23 42 / 0.06);
 }
 @media (prefers-color-scheme: dark) {
-	:root {
-		--color-bg: #0f172a;
-		--color-surface: #162033;
-		--color-fg: #e5eef8;
-		--color-muted: #a5b4c7;
-		--color-border: #2a3950;
-		--color-accent: #60a5fa;
-		--color-accent-contrast: #0f172a;
-		--color-code-bg: rgb(148 163 184 / 0.16);
-	}
+  :root {
+    --color-bg: #0f172a;
+    --color-surface: #162033;
+    --color-fg: #e5eef8;
+    --color-muted: #a5b4c7;
+    --color-border: #2a3950;
+    --color-accent: #60a5fa;
+    --color-accent-contrast: #0f172a;
+    --color-code-bg: rgb(148 163 184 / 0.16);
+  }
 }
 :where(html) {
-	min-height: 100%;
-	background: var(--color-bg);
-	color: var(--color-fg);
+  min-height: 100%;
+  background: var(--color-bg);
+  color: var(--color-fg);
 }
 :where(body) {
-	min-height: 100%;
-	margin: 0;
-	padding: var(--spacing-4);
-	background: var(--color-bg);
-	color: var(--color-fg);
-	font: 400 14px/1.5 var(--font-body);
+  min-height: 100%;
+  margin: 0;
+  padding: var(--spacing-4);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font: 400 14px/1.5 var(--font-body);
 }
-:where(body[data-kody-runtime='javascript']) {
-	padding: 0;
+:where(body[data-kody-runtime=javascript]) {
+  padding: 0;
 }
 :where(*, *::before, *::after) {
-	box-sizing: border-box;
+  box-sizing: border-box;
 }
 :where(a) {
-	color: var(--color-accent);
+  color: var(--color-accent);
 }
 :where(p, ul, ol, dl, pre, table, blockquote, fieldset) {
-	margin: 0 0 var(--spacing-4);
+  margin: 0 0 var(--spacing-4);
 }
 :where(h1, h2, h3, h4, h5, h6) {
-	margin: 0 0 var(--spacing-3);
-	line-height: 1.2;
+  margin: 0 0 var(--spacing-3);
+  line-height: 1.2;
 }
 :where(h1) {
-	font-size: 1.875rem;
+  font-size: 1.875rem;
 }
 :where(h2) {
-	font-size: 1.5rem;
+  font-size: 1.5rem;
 }
 :where(h3) {
-	font-size: 1.25rem;
+  font-size: 1.25rem;
 }
 :where(ul, ol) {
-	padding-left: 1.5rem;
+  padding-left: 1.5rem;
 }
 :where(hr) {
-	border: 0;
-	border-top: 1px solid var(--color-border);
-	margin: var(--spacing-6) 0;
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  margin: var(--spacing-6) 0;
 }
 :where(code, kbd, samp) {
-	font-family: var(--font-mono);
-	font-size: 0.95em;
+  font-family: var(--font-mono);
+  font-size: 0.95em;
 }
 :where(code) {
-	background: var(--color-code-bg);
-	border-radius: 0.375rem;
-	padding: 0.1rem 0.35rem;
+  background: var(--color-code-bg);
+  border-radius: 0.375rem;
+  padding: 0.1rem 0.35rem;
 }
 :where(pre) {
-	overflow-x: auto;
-	padding: var(--spacing-3);
-	background: var(--color-code-bg);
-	border: 1px solid var(--color-border);
-	border-radius: var(--radius-2);
+  overflow-x: auto;
+  padding: var(--spacing-3);
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
 }
 :where(pre code) {
-	background: transparent;
-	padding: 0;
+  background: transparent;
+  padding: 0;
 }
 :where(form) {
-	display: grid;
-	gap: var(--spacing-4);
+  display: grid;
+  gap: var(--spacing-4);
 }
 :where(label) {
-	display: grid;
-	gap: var(--spacing-2);
-	font-weight: 600;
+  display: grid;
+  gap: var(--spacing-2);
+  font-weight: 600;
 }
 :where(input, button, textarea, select) {
-	font: inherit;
+  font: inherit;
 }
-:where(input:not([type='checkbox']):not([type='radio']), textarea, select) {
-	width: 100%;
-	padding: var(--spacing-2) var(--spacing-3);
-	background: var(--color-surface);
-	color: var(--color-fg);
-	border: 1px solid var(--color-border);
-	border-radius: var(--radius-2);
-	box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
+:where(input:not([type=checkbox]):not([type=radio]), textarea, select) {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--color-surface);
+  color: var(--color-fg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+  box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
 }
 :where(textarea) {
-	min-height: 7rem;
-	resize: vertical;
+  min-height: 7rem;
+  resize: vertical;
 }
-:where(input[type='checkbox'], input[type='radio']) {
-	accent-color: var(--color-accent);
+:where(input[type=checkbox], input[type=radio]) {
+  accent-color: var(--color-accent);
 }
 :where(button) {
-	width: fit-content;
-	padding: var(--spacing-2) var(--spacing-4);
-	background: var(--color-accent);
-	color: var(--color-accent-contrast);
-	border: 1px solid transparent;
-	border-radius: var(--radius-2);
-	box-shadow: var(--shadow-1);
-	cursor: pointer;
+  width: fit-content;
+  padding: var(--spacing-2) var(--spacing-4);
+  background: var(--color-accent);
+  color: var(--color-accent-contrast);
+  border: 1px solid transparent;
+  border-radius: var(--radius-2);
+  box-shadow: var(--shadow-1);
+  cursor: pointer;
 }
 :where(button:disabled, input:disabled, textarea:disabled, select:disabled) {
-	opacity: 0.7;
-	cursor: not-allowed;
+  opacity: 0.7;
+  cursor: not-allowed;
 }
-:where(
-	button:focus-visible,
-	input:focus-visible,
-	textarea:focus-visible,
-	select:focus-visible
-) {
-	outline: 2px solid var(--color-accent);
-	outline-offset: 2px;
+:where(button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible) {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 :where(table) {
-	width: 100%;
-	border-collapse: collapse;
+  width: 100%;
+  border-collapse: collapse;
 }
 :where(th, td) {
-	padding: var(--spacing-2) var(--spacing-3);
-	border: 1px solid var(--color-border);
-	text-align: left;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--color-border);
+  text-align: left;
 }
 :where(th) {
-	background: var(--color-surface);
+  background: var(--color-surface);
 }
 :where(blockquote) {
-	margin-left: 0;
-	padding-left: var(--spacing-4);
-	border-left: 3px solid var(--color-border);
-	color: var(--color-muted);
+  margin-left: 0;
+  padding-left: var(--spacing-4);
+  border-left: 3px solid var(--color-border);
+  color: var(--color-muted);
 }
 :where([data-generated-ui-root]) {
-	min-height: 100%;
+  min-height: 100%;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Changes client-side navigation from "swap UI, then fetch, then update again" to React Router-style **preload-then-commit**: on navigation the router first runs a client loader that fetches the destination route's data, and only then commits the URL change and UI swap — so the UI updates exactly once, already populated. Adds a subtle 3px progress bar along the very top of the page (spin-delay semantics: appears only after 150ms pending, shown at least 200ms — no spinner). Also adds **intent prefetch** (like React Router's `prefetch="intent"`): hovering, focusing, or touching an internal link speculatively starts its route loader, and the click adopts the in-flight or settled result instead of refetching.

<img src="https://cursor.com/artifacts/c/art-87e64c3e-ae33-460f-b469-0f9585f7b1b2" alt="navigation_single_update_demo.mp4" />

Nav across account/secrets/integrations/tokens/connectors/admin/community renders each page fully populated in a single update — no "Loading …" flashes.

<img src="https://cursor.com/artifacts/c/art-7b3af062-7e36-49f3-826b-a3fcc6ffb498" alt="progress_bar_demo.mp4" />

Progress bar demo (with a temporary 1.5s artificial loader delay, since local loads complete under the 150ms threshold): the previous page stays visible while the bar trickles, then the new page swaps in complete.

<img src="https://cursor.com/artifacts/c/art-d63712e2-523b-40a4-893b-17dc586ce734" alt="hover_intent_prefetch_single_request_demo.mp4" />

Intent prefetch demo: hovering the "Secrets" nav link fires `secrets.json` before any click (visible in the DevTools network log); the click then navigates instantly and the log still shows exactly one request — the prefetch was reused.

## How

- `client-router.tsx`: route-loader registry (`registerRouteLoaders`, matched with `remix/route-pattern`), async `navigate()` that aborts superseded navigations (latest wins), runs the matched loader, then commits (`pushState` + notify). Applies to link clicks, popstate (old UI stays until data is ready), GET/POST form submissions, and same-path refreshes after POST redirects. Hash-only moves — forward clicks and popstate — commit immediately without running loaders. New `navigationstart`/`navigationend` events drive the progress bar. Loader errors commit anyway and let the route's fallback fetch surface the error; the router marks the destination stale so same-path refreshes (no href change) still trigger that fallback refetch.
- `route-loader.ts`: loaders now return `RouteLoaderRedirect` (via `routeLoaderRedirect`) instead of calling `window.location.assign` themselves; the **router** performs the full-document redirect at commit time. This keeps speculative prefetch runs side-effect free — hovering a link whose loader hits a 401 can never redirect the page the user is still on.
- `intent-prefetch.ts`: single latest-wins prefetch slot. Hover intent is debounced (100ms dwell) so sweeping the cursor across a nav list fires nothing; focus and touch prefetch immediately (and cancel any pending hover timer so it can't fire later and clobber the deliberate prefetch). Navigations adopt the pending or freshly settled promise (30s TTL, monotonic clock); failed prefetches fall back to a normal loader run; hovering a different link aborts the previous prefetch; form POSTs abort pending prefetches so pre-mutation data is never adopted. Navigating anywhere other than the prefetched link aborts and clears the slot, so a speculative result for a link the user never followed can't be adopted later. Prefetch is skipped for the current page and for the path an active navigation is already loading. Opt out per link with `data-prefetch="none"`.
- `navigation-data.ts`: single-slot, consume-once preloaded data store; `tryConsumeRouteLoaderData` in `loader-data-context.tsx` unifies SSR-embedded and navigation-preloaded consumption. Also holds the one-shot stale marker (`markNavigationDataStale` / `consumeStaleNavigationData`) routes consume to force a refetch after a failed same-path refresh.
- `navigation-progress.tsx`: fixed top bar, `colors.primary`, trickles to 90%, completes and fades on end; [spin-delay](https://npm.im/spin-delay)-style 150ms show delay + 200ms minimum visibility.
- All data routes converted to export loaders (account, integrations, package tokens, connectors, secrets, admin users/roles/reports, oauth-authorize, community index/detail). Each keeps its fallback fetch path for loader-error and edge cases. Admin routes reset their load-failure latch when the route href changes. Routes no longer pre-set their "loaded href" to a destination before `navigate()` commits — the async navigation made that optimistic set race interim renders and fire spurious fallback fetches for the old URL.
- `frame-prefetch.ts`: community pages prefetch their `<Frame>` HTML in the loader; `resolveFrame` in `entry.tsx` consumes the cache (consume-once, cleared per prefetch) so frame content is instant after commit.
- Docs: request-lifecycle client navigation section updated (preload-then-commit + intent prefetch).

## Testing

- `npm run validate` — all six checks green (format, lint, typecheck, unit tests, Playwright E2E, MCP E2E).
- Manual browser testing (logged in as seeded admin): all nav links, community search, back/forward, logout/login form POSTs, DevTools console clean; verified no loading-text flashes and single-update renders (videos above).
- Intent prefetch verified end-to-end in headless Chromium and desktop Chrome: hover fires exactly one request which the click reuses (1 total request per navigation); quick sweeps across links fire nothing; keyboard focus + Enter reuses the prefetch; hovering an auth-only link while logged out does **not** redirect, but clicking it does; hovering link B supersedes and aborts link A's prefetch; hover-A-then-focus-B prefetches only B.
- Bug-repro scripts run against both the pre-fix and post-fix builds: same-path refresh with a failing loader now refetches (was: silent stale UI); token-page URL updates no longer double-fetch from an optimistic href race (2 GETs → 1); hash-only back/forward no longer runs route loaders while cross-path back still does.
- Progress bar verified with an artificial loader delay (reverted before commit).
- All Bugbot and CodeRabbit findings addressed across five review rounds; the final Bugbot run passes with no findings. One earlier suggestion ("aborted navigations skip navigationend") was assessed as a false positive: every abort comes from a superseding navigation that owns the matching `navigationend`, and the progress bar's pending flag is a boolean, so the winning navigation's end always clears it.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends app-ui</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `e51fa91` · **Head:** `f5cef55`

**Classification:** extends — changes the browser app's client navigation contract (preload-then-commit + intent prefetch) and adds a navigation progress indicator; no new primitives, no server route changes.

### Primitives touched

| Primitive | Group    | Impact                                                                                          |
| --------- | -------- | ----------------------------------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — client router runs route loaders before committing navigations; hover/focus intent prefetch; new progress bar |

### System map

```mermaid
flowchart LR
	appUi["app-ui"]:::extended
	appSessions["app-sessions"]:::untouched
	d1AppDb["d1-app-db"]:::untouched
	appUi --> appSessions --> d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant User
	participant Router as client-router
	participant Prefetch as intent-prefetch
	participant Loader as route loader
	participant UI as Router component

	User->>Router: hover / focus / touch internal link
	Router->>Prefetch: debounce 100ms, then run loader speculatively
	Prefetch->>Loader: fetch destination JSON (+ frame HTML prefetch)
	User->>Router: click link / popstate / form redirect
	Router->>Router: navigationstart (progress bar arms, 150ms delay)
	Router->>Prefetch: adopt pending/settled result (or run loader now)
	Loader-->>Router: Partial<AppLoaderData> or RouteLoaderRedirect
	Router->>Router: store preloaded slot, pushState
	Router->>UI: navigate event → single render with data
	Router->>Router: navigationend (bar completes, fades)
```

### Before / after

| Aspect                | Before                                             | After                                           |
| --------------------- | -------------------------------------------------- | ----------------------------------------------- |
| SPA navigation        | swap UI → "Loading …" → fetch → second update      | run loader → commit once, fully populated       |
| Link hover            | nothing                                            | loader starts speculatively; click adopts it    |
| Back/forward          | instant swap + refetch                             | old UI stays until data ready, then one swap    |
| Pending indication    | per-route "Loading …" text                         | top progress bar (>150ms only, min 200ms shown) |
| Loader auth redirects | loader called `window.location.assign` directly    | loader returns redirect; router performs it at commit |
| Community frames      | frame fetched after route swap                     | frame HTML prefetched in loader, instant swap   |

### Invariants

Per-user isolation unaffected: loaders call the same authenticated JSON APIs the routes already used; 401s still redirect to login at commit time — and never from a speculative prefetch.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2e72-3b68-7eaf-b3f7-eb19e9fd6834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2e72-3b68-7eaf-b3f7-eb19e9fd6834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added route-loader-driven data loading across account, admin, community, and OAuth pages.
  * Implemented preload-then-commit SPA navigation with one-slot preloaded loader data for faster first render.
  * Added link intent prefetching for route loaders, plus a cached frame prefetch system.
  * Introduced a top-of-viewport navigation progress indicator.
* **Bug Fixes**
  * Improved navigation consistency for redirects, back/forward, same-path refresh, and hash-only updates.
  * Prevented displaying stale, pre-mutation data by aborting pending prefetches on form POST.
* **Tests**
  * Added coverage for route-loader matching, prefetch adoption, and preloaded navigation data consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->