### PR TITLE
docs: Cloud Agent env setup notes (Playwright io_uring workaround)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,33 @@ VMs may ship Node 22 at `/exec-daemon/node`, which takes precedence over nvm
 unless nvm’s Node 26 bin directory is prepended to `PATH`. Verify with
 `node --version` before running scripts.
 
+### Playwright browsers
+
+Playwright's Chromium (used by `npm run test:e2e:run` / `validate`) is
+pre-installed in `~/.cache/ms-playwright` and persists in the VM snapshot, so
+normally nothing extra is needed. The **non-obvious gotcha**:
+`playwright install` (and `test:e2e:install` / `test:e2e:ensure`) **hangs** on
+this VM kernel — its Node-based zip extractor stalls on an `io_uring` write
+partway through (around `libwidevinecdm.so`), and `UV_USE_IO_URING=0` does not
+stop it. The browser zip downloads fine; only the built-in extraction hangs.
+
+If browsers are ever missing (e.g. a Playwright version bump changes the
+revision), do **not** rely on `playwright install`. Instead download and extract
+manually with native `unzip`:
+
+1. Get the revision + Chrome-for-Testing version from
+   `node_modules/playwright-core/browsers.json` and the CDN URL printed by
+   `npx playwright install chromium` (form:
+   `https://cdn.playwright.dev/builds/cft/<cft-version>/linux64/chrome-linux64.zip`
+   and `.../chrome-headless-shell-linux64.zip`).
+2. `curl -fsSL -o /tmp/c.zip <chrome-linux64.zip>` then
+   `unzip -q /tmp/c.zip -d ~/.cache/ms-playwright/chromium-<rev>/` and
+   `touch ~/.cache/ms-playwright/chromium-<rev>/INSTALLATION_COMPLETE`.
+3. Repeat for the headless shell into
+   `~/.cache/ms-playwright/chromium_headless_shell-<rev>/` (Playwright launches
+   headless via the separate headless-shell binary, so both are required).
+4. `chmod +x` the `chrome` and `chrome-headless-shell` binaries.
+
 ### Quick commands
 
 | Task             | Command                                                         |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,82 +71,8 @@ This file is intentionally brief. Detailed instructions live in focused docs:
 
 ## Cursor Cloud-specific instructions
 
-Kody is a single Cloudflare Workers app (Remix 3 UI + OAuth-protected MCP). See
-[`docs/contributing/setup.md`](./docs/contributing/setup.md) for the full local
-dev guide; this section covers Cloud Agent VM gotchas only.
+Cloud Agent VM gotchas (Node 26 on `PATH`, the Playwright browser-install hang
+and manual workaround, dev server, seeding, and local limitations) live in a
+dedicated reference:
 
-### Node 26
-
-The repo requires Node **>=26** (`engines` in root `package.json`). Cloud Agent
-VMs may ship Node 22 at `/exec-daemon/node`, which takes precedence over nvm
-unless nvm’s Node 26 bin directory is prepended to `PATH`. Verify with
-`node --version` before running scripts.
-
-### Playwright browsers
-
-Playwright's Chromium (used by `npm run test:e2e:run` / `validate`) is
-pre-installed in `~/.cache/ms-playwright` and persists in the VM snapshot, so
-normally nothing extra is needed. The **non-obvious gotcha**:
-`playwright install` (and `test:e2e:install` / `test:e2e:ensure`) **hangs** on
-this VM kernel — its Node-based zip extractor stalls on an `io_uring` write
-partway through (around `libwidevinecdm.so`), and `UV_USE_IO_URING=0` does not
-stop it. The browser zip downloads fine; only the built-in extraction hangs.
-
-If browsers are ever missing (e.g. a Playwright version bump changes the
-revision), do **not** rely on `playwright install`. Instead download and extract
-manually with native `unzip`:
-
-1. Get the revision + Chrome-for-Testing version from
-   `node_modules/playwright-core/browsers.json` and the CDN URL printed by
-   `npx playwright install chromium` (form:
-   `https://cdn.playwright.dev/builds/cft/<cft-version>/linux64/chrome-linux64.zip`
-   and `.../chrome-headless-shell-linux64.zip`).
-2. `curl -fsSL -o /tmp/c.zip <chrome-linux64.zip>` then
-   `unzip -q /tmp/c.zip -d ~/.cache/ms-playwright/chromium-<rev>/` and
-   `touch ~/.cache/ms-playwright/chromium-<rev>/INSTALLATION_COMPLETE`.
-3. Repeat for the headless shell into
-   `~/.cache/ms-playwright/chromium_headless_shell-<rev>/` (Playwright launches
-   headless via the separate headless-shell binary, so both are required).
-4. `chmod +x` the `chrome` and `chrome-headless-shell` binaries.
-
-### Quick commands
-
-| Task             | Command                                                         |
-| ---------------- | --------------------------------------------------------------- |
-| Install deps     | `npm install`                                                   |
-| Start dev        | `npm run dev` (prints the resolved URL)                         |
-| Migrate local D1 | `npm run migrate:local`                                         |
-| Seed test login  | `node tools/seed-test-data.ts --local` (see seeding note below) |
-| Full CI gate     | `npm run validate`                                              |
-
-### Dev server
-
-- `npm run dev` starts the client esbuild watcher, optional Cloudflare API mock
-  worker, and the main worker with local D1/KV/DO persistence.
-- Default worker port is **3742** (`cli.ts`); the CLI picks a free port when
-  3742 is taken and prints `App running at http://localhost:<port>`.
-- Run long-lived dev in tmux so the session survives tool timeouts.
-- Health check (no auth): `curl http://localhost:<port>/health` →
-  `{"ok":true,"commitSha":...}`.
-
-### Environment file
-
-Copy `packages/worker/.env.example` to `packages/worker/.env` if missing.
-`COOKIE_SECRET` and `SECRET_STORE_KEY` are required for local dev.
-
-### Seeding a test account
-
-After `npm run migrate:local`, seed the local fixture logins per
-[`docs/contributing/setup.md`](./docs/contributing/setup.md): `kody@example.com`
-/ `ilikecode` (seeded with the `admin` role) and `jane@example.com` /
-`ilikecode` (regular account). These credentials are local test fixtures only.
-The seed script resolves the worker Wrangler config automatically (same default
-as `wrangler-env.ts`), so `node tools/seed-test-data.ts --local` works without
-extra flags.
-
-### Local limitations
-
-- Vectorize bindings are not emulated locally; capability search uses the
-  offline ranker when `WRANGLER_IS_LOCAL_DEV` is set (normal for `npm run dev`).
-- `/mcp` returns **401** without OAuth; use browser login or MCP E2E tests for
-  authenticated MCP checks.
+- [Cursor Cloud Agent notes](./docs/contributing/cloud-agents.md)

--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -1,0 +1,80 @@
+# Cursor Cloud Agent notes
+
+Kody is a single Cloudflare Workers app (Remix 3 UI + OAuth-protected MCP). See
+[`setup.md`](./setup.md) for the full local dev guide; this document covers
+Cloud Agent VM gotchas only.
+
+## Node 26
+
+The repo requires Node **>=26** (`engines` in root `package.json`). Cloud Agent
+VMs may ship Node 22 at `/exec-daemon/node`, which takes precedence over nvm
+unless nvm’s Node 26 bin directory is prepended to `PATH`. Verify with
+`node --version` before running scripts.
+
+## Playwright browsers
+
+Playwright's Chromium (used by `npm run test:e2e:run` / `validate`) is
+pre-installed in `~/.cache/ms-playwright` and persists in the VM snapshot, so
+normally nothing extra is needed. The **non-obvious gotcha**:
+`playwright install` (and `test:e2e:install` / `test:e2e:ensure`) **hangs** on
+this VM kernel — its Node-based zip extractor stalls on an `io_uring` write
+partway through (around `libwidevinecdm.so`), and `UV_USE_IO_URING=0` does not
+stop it. The browser zip downloads fine; only the built-in extraction hangs.
+
+If browsers are ever missing (e.g. a Playwright version bump changes the
+revision), do **not** rely on `playwright install`. Instead download and extract
+manually with native `unzip`:
+
+1. Get the revision + Chrome-for-Testing version from
+   `node_modules/playwright-core/browsers.json` and the CDN URL printed by
+   `npx playwright install chromium` (form:
+   `https://cdn.playwright.dev/builds/cft/<cft-version>/linux64/chrome-linux64.zip`
+   and `.../chrome-headless-shell-linux64.zip`).
+2. `curl -fsSL -o /tmp/c.zip <chrome-linux64.zip>` then
+   `unzip -q /tmp/c.zip -d ~/.cache/ms-playwright/chromium-<rev>/` and
+   `touch ~/.cache/ms-playwright/chromium-<rev>/INSTALLATION_COMPLETE`.
+3. Repeat for the headless shell into
+   `~/.cache/ms-playwright/chromium_headless_shell-<rev>/` (Playwright launches
+   headless via the separate headless-shell binary, so both are required).
+4. `chmod +x` the `chrome` and `chrome-headless-shell` binaries.
+
+## Quick commands
+
+| Task             | Command                                                         |
+| ---------------- | --------------------------------------------------------------- |
+| Install deps     | `npm install`                                                   |
+| Start dev        | `npm run dev` (prints the resolved URL)                         |
+| Migrate local D1 | `npm run migrate:local`                                         |
+| Seed test login  | `node tools/seed-test-data.ts --local` (see seeding note below) |
+| Full CI gate     | `npm run validate`                                              |
+
+## Dev server
+
+- `npm run dev` starts the client esbuild watcher, optional Cloudflare API mock
+  worker, and the main worker with local D1/KV/DO persistence.
+- Default worker port is **3742** (`cli.ts`); the CLI picks a free port when
+  3742 is taken and prints `App running at http://localhost:<port>`.
+- Run long-lived dev in tmux so the session survives tool timeouts.
+- Health check (no auth): `curl http://localhost:<port>/health` →
+  `{"ok":true,"commitSha":...}`.
+
+## Environment file
+
+Copy `packages/worker/.env.example` to `packages/worker/.env` if missing.
+`COOKIE_SECRET` and `SECRET_STORE_KEY` are required for local dev.
+
+## Seeding a test account
+
+After `npm run migrate:local`, seed the local fixture logins per
+[`setup.md`](./setup.md): `kody@example.com` / `ilikecode` (seeded with the
+`admin` role) and `jane@example.com` / `ilikecode` (regular account). These
+credentials are local test fixtures only. The seed script resolves the worker
+Wrangler config automatically (same default as `wrangler-env.ts`), so
+`node tools/seed-test-data.ts --local` works without extra flags.
+
+## Local limitations
+
+- Vectorize bindings are not emulated locally; capability search uses the
+  offline ranker when `WRANGLER_IS_LOCAL_DEV` is set (normal for `npm run dev`).
+- `/mcp` returns **401** without OAuth; use browser login or MCP E2E tests for
+  authenticated MCP checks.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -9,6 +9,7 @@ style, tests, MCP capabilities, and runtime architecture.
 - [Optional Cloudflare offerings](./cloudflare-offerings.md)
 - [Setup](./setup.md), [code style](./code-style.md),
   [testing](./testing-principles.md)
+- [Cursor Cloud Agent notes](./cloud-agents.md)
 - [Remix skills](./remix.md), [frames](./frames.md)
 - [Packages and manifests](./packages-and-manifests.md)
 - [Community packages](./community-packages.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and validates the Cloud Agent development environment for Kody and captures the one non-obvious gotcha found during setup, while keeping `AGENTS.md` a lean index.

- Moves the existing `## Cursor Cloud-specific instructions` content out of `AGENTS.md` into a new dedicated reference doc `docs/contributing/cloud-agents.md`; `AGENTS.md` now just links to it.
- Documents the **Playwright browser-install hang**: `playwright install` (and `test:e2e:install` / `test:e2e:ensure`) stalls on this VM kernel because its Node-based zip extractor blocks on an `io_uring` write (`UV_USE_IO_URING=0` does not help). The workaround is to download the Chrome-for-Testing zips and extract them with native `unzip` + an `INSTALLATION_COMPLETE` marker (both `chromium` and `chromium_headless_shell` are required).
- Adds the new doc to `docs/contributing/index.md`.

No application code changes.

## Environment validated

Ran with Node 26 on `PATH`:

- `npm install`
- `npm run lint` — 0 errors
- `npm run typecheck` — pass
- `npm run test` — 484 passed
- `npm run test:e2e:run` — 5 passed (with manually-extracted Chromium)
- `npm run test:mcp` — 2 passed
- `npm run format:check` — clean
- `npm run build` — success
- `npm run dev` on `http://localhost:3742`, `/health` → `{"ok":true}`

Hello-world flow (logged in as the seeded `kody@example.com` account and created a user-scoped secret `HELLO_WORLD_KEY`):

<a href="https://cursor.com/agents/bc-8f546957-8829-47f0-bae2-f1522b1141ef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkody_login_create_secret.mp4"><img src="https://cursor.com/artifacts/c/art-dc9e7dd2-0dd9-4fec-9cde-0e598f03befa" alt="kody_login_create_secret.mp4" /></a>

![Secrets list showing HELLO_WORLD_KEY](https://cursor.com/artifacts/c/art-524747f3-3875-4245-ad8e-ab129760fb37)

The update script for future Cloud Agent VMs is `npm install`; the Playwright browser cache persists in the snapshot, and `playwright install` is intentionally kept out of the startup script because it hangs on this kernel.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f546957-8829-47f0-bae2-f1522b1141ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f546957-8829-47f0-bae2-f1522b1141ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Cloud Agent setup guide with practical notes for working in the cloud environment, including Node version requirements, browser setup tips, local server details, environment file setup, seeding steps, and known limitations.
  * Updated the contributing index to include a direct link to the new Cloud Agent notes.
  * Simplified the main agent instructions page by replacing lengthy embedded guidance with a link to the dedicated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->