### PR TITLE
Unify app layout widths

### DIFF
--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -128,6 +128,11 @@ export function App(handle: Handle<AppProps>) {
 		cursor: 'pointer',
 	}
 
+	const compactNavCss = {
+		gap: spacing.sm,
+		marginBottom: spacing.lg,
+	}
+
 	return () => {
 		currentPathname = readRouterPathname(handle)
 		const sessionEmail = session?.email ?? ''
@@ -173,14 +178,8 @@ export function App(handle: Handle<AppProps>) {
 							alignItems: 'center',
 							gap: spacing.md,
 							flexWrap: 'wrap',
-							[mq.tablet]: {
-								gap: spacing.sm,
-								marginBottom: spacing.lg,
-							},
-							[mq.mobile]: {
-								gap: spacing.sm,
-								marginBottom: spacing.lg,
-							},
+							[mq.tablet]: compactNavCss,
+							[mq.mobile]: compactNavCss,
 						})}
 					>
 						<a href="/" aria-label="Home" mix={css(navHomeLinkCss)}>

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -16,6 +16,7 @@ import {
 	type SessionInfo,
 	type SessionStatus,
 } from './session.ts'
+import { layoutMaxWidths } from './styles/style-primitives.ts'
 import { type AppLoaderData } from '#app/loader-data.ts'
 import { userHasRole } from '#app/permissions.ts'
 import { buildAuthLink } from './auth-links.ts'
@@ -129,13 +130,6 @@ export function App(handle: Handle<AppProps>) {
 
 	return () => {
 		currentPathname = readRouterPathname(handle)
-		const isWideLayout =
-			currentPathname.startsWith('/account/integrations') ||
-			currentPathname.startsWith('/account/package-invocation-tokens') ||
-			currentPathname.startsWith('/account/remote-connectors') ||
-			currentPathname.startsWith('/account/secrets') ||
-			currentPathname.startsWith('/admin') ||
-			currentPathname.startsWith('/community')
 		const sessionEmail = session?.email ?? ''
 		const sessionDisplayName = getSessionDisplayName(session)
 		const isSessionReady = sessionStatus === 'ready'
@@ -154,49 +148,38 @@ export function App(handle: Handle<AppProps>) {
 			<AppLoaderDataProvider loaderData={handle.props.loaderData}>
 				<NavigationProgress />
 				<ScrollRestoration />
-				<main
+				<div
 					mix={css({
-						maxWidth: isWideLayout ? 'none' : '52rem',
 						width: '100%',
-						margin: isWideLayout ? 0 : '0 auto',
-						padding: isWideLayout
-							? `${spacing.lg} ${spacing.xl} ${spacing.sm}`
-							: spacing['2xl'],
-						minHeight: isWideLayout ? '100vh' : undefined,
+						minHeight: '100vh',
+						padding: `${spacing.lg} ${spacing.xl} ${spacing.sm}`,
 						fontFamily: typography.fontFamily,
 						boxSizing: 'border-box',
-						[mq.tablet]: isWideLayout
-							? {
-									padding: `${spacing.sm} ${spacing.sm} 0`,
-								}
-							: {
-									padding: spacing.xl,
-								},
-						[mq.mobile]: isWideLayout
-							? {
-									padding: `${spacing.md} ${spacing.md} ${spacing.sm}`,
-								}
-							: {
-									padding: spacing.md,
-								},
+						[mq.tablet]: {
+							padding: `${spacing.sm} ${spacing.sm} 0`,
+						},
+						[mq.mobile]: {
+							padding: `${spacing.md} ${spacing.md} ${spacing.sm}`,
+						},
 					})}
 				>
 					<nav
 						mix={css({
+							maxWidth: layoutMaxWidths.wide,
+							width: '100%',
+							margin: `0 auto ${spacing.xl}`,
+							boxSizing: 'border-box',
 							display: 'flex',
 							alignItems: 'center',
 							gap: spacing.md,
 							flexWrap: 'wrap',
-							marginBottom: isWideLayout ? spacing.lg : spacing.xl,
-							[mq.tablet]: isWideLayout
-								? {
-										gap: spacing.sm,
-										marginBottom: spacing.sm,
-									}
-								: {},
+							[mq.tablet]: {
+								gap: spacing.sm,
+								marginBottom: spacing.lg,
+							},
 							[mq.mobile]: {
 								gap: spacing.sm,
-								marginBottom: isWideLayout ? spacing.md : spacing.lg,
+								marginBottom: spacing.lg,
 							},
 						})}
 					>
@@ -259,29 +242,31 @@ export function App(handle: Handle<AppProps>) {
 							</>
 						) : null}
 					</nav>
-					<Router
-						routes={clientRoutes}
-						loaderData={handle.props.loaderData}
-						notFound={handle.props.notFound}
-						fallback={
-							<section>
-								<h2
-									mix={css({
-										fontSize: typography.fontSize.lg,
-										fontWeight: typography.fontWeight.semibold,
-										marginBottom: spacing.sm,
-										color: colors.text,
-									})}
-								>
-									Not Found
-								</h2>
-								<p mix={css({ color: colors.textMuted })}>
-									We could not find that page.
-								</p>
-							</section>
-						}
-					/>
-				</main>
+					<main mix={css({ width: '100%', boxSizing: 'border-box' })}>
+						<Router
+							routes={clientRoutes}
+							loaderData={handle.props.loaderData}
+							notFound={handle.props.notFound}
+							fallback={
+								<section>
+									<h2
+										mix={css({
+											fontSize: typography.fontSize.lg,
+											fontWeight: typography.fontWeight.semibold,
+											marginBottom: spacing.sm,
+											color: colors.text,
+										})}
+									>
+										Not Found
+									</h2>
+									<p mix={css({ color: colors.textMuted })}>
+										We could not find that page.
+									</p>
+								</section>
+							}
+						/>
+					</main>
+				</div>
 			</AppLoaderDataProvider>
 		)
 	}

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -10,6 +10,11 @@ import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
 } from '#client/route-loader.ts'
+import {
+	AccountManagementHeader,
+	AccountManagementMessage,
+	AccountManagementShell,
+} from '#client/routes/account-management-components.tsx'
 import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
@@ -21,12 +26,8 @@ import {
 	detailValueCss,
 	getPrimaryButtonCss,
 	insetCardCss,
-	pageDescriptionCss,
-	pageHeaderCss,
-	pageTitleCss,
 	primaryLinkCss,
 	sectionTitleCss,
-	stackedPageCss,
 } from '#client/styles/style-primitives.ts'
 
 type IntegrationFlow = 'pkce' | 'confidential'
@@ -204,22 +205,11 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		}
 
 		return (
-			<section
-				mix={css({
-					...stackedPageCss,
-					maxWidth: '76rem',
-					margin: '0 auto',
-				})}
-			>
-				<header mix={css(pageHeaderCss)}>
-					<h1 mix={css(pageTitleCss)}>
-						{email ? `${email} integrations` : 'Integrations'}
-					</h1>
-					<p mix={css(pageDescriptionCss)}>
-						Review saved OAuth integrations and reconnect providers when tokens
-						need to be refreshed.
-					</p>
-				</header>
+			<AccountManagementShell>
+				<AccountManagementHeader
+					title={email ? `${email} integrations` : 'Integrations'}
+					description="Review saved OAuth integrations and reconnect providers when tokens need to be refreshed."
+				/>
 
 				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
@@ -227,15 +217,11 @@ export function AccountIntegrationsRoute(handle: Handle) {
 					</p>
 				) : null}
 				{message ? (
-					<p
-						role="alert"
-						mix={css({
-							color: status === 'error' ? colors.error : colors.text,
-							margin: 0,
-						})}
+					<AccountManagementMessage
+						tone={status === 'error' ? 'error' : 'info'}
 					>
 						{message}
-					</p>
+					</AccountManagementMessage>
 				) : null}
 
 				{status === 'ready' && integrations.length === 0 ? (
@@ -368,7 +354,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 						Back to account
 					</a>
 				</p>
-			</section>
+			</AccountManagementShell>
 		)
 	}
 }

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -12,6 +12,7 @@ import {
 	cardTitleCss,
 	descriptionCss,
 	fieldLabelCss,
+	layoutMaxWidths,
 } from '#client/styles/style-primitives.ts'
 
 type AccountManagementSlot = any
@@ -27,7 +28,7 @@ export function AccountManagementShell(
 	return () => (
 		<section
 			mix={css({
-				maxWidth: handle.props.maxWidth ?? '96rem',
+				maxWidth: handle.props.maxWidth ?? layoutMaxWidths.wide,
 				margin: '0 auto',
 				display: 'grid',
 				gap: spacing.xl,

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -965,7 +965,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 			: ''
 
 		return (
-			<AccountManagementShell maxWidth="76rem">
+			<AccountManagementShell>
 				<AccountManagementHeader
 					title={
 						email

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -13,6 +13,7 @@ import {
 } from '#client/route-loader.ts'
 import {
 	AccountManagementHeader,
+	AccountManagementMessage,
 	AccountManagementShell,
 } from '#client/routes/account-management-components.tsx'
 import {
@@ -636,15 +637,11 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 					</p>
 				) : null}
 				{message ? (
-					<p
-						role="alert"
-						mix={css({
-							color: status === 'error' ? colors.error : colors.text,
-							margin: 0,
-						})}
+					<AccountManagementMessage
+						tone={status === 'error' ? 'error' : 'info'}
 					>
 						{message}
-					</p>
+					</AccountManagementMessage>
 				) : null}
 
 				{status === 'ready' ? (

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -12,6 +12,10 @@ import {
 	type RouteLoaderResult,
 } from '#client/route-loader.ts'
 import {
+	AccountManagementHeader,
+	AccountManagementShell,
+} from '#client/routes/account-management-components.tsx'
+import {
 	colors,
 	mq,
 	radius,
@@ -611,47 +615,20 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 		const connectorUrl = getEditorConnectorUrl()
 
 		return (
-			<section
-				mix={css({
-					maxWidth: '76rem',
-					margin: '0 auto',
-					display: 'grid',
-					gap: spacing.xl,
-				})}
-			>
-				<header
-					mix={css({
-						display: 'flex',
-						justifyContent: 'space-between',
-						alignItems: 'flex-start',
-						gap: spacing.md,
-						flexWrap: 'wrap',
-					})}
-				>
-					<div mix={css({ display: 'grid', gap: spacing.xs })}>
-						<h1
-							mix={css({
-								fontSize: typography.fontSize.xl,
-								fontWeight: typography.fontWeight.semibold,
-								color: colors.text,
-								margin: 0,
-							})}
+			<AccountManagementShell>
+				<AccountManagementHeader
+					title={email ? `${email} remote connectors` : 'Remote connectors'}
+					description="Attach connector refs to normal Kody sessions and manage the shared secrets used by connector hello authentication."
+					actions={
+						<button
+							type="button"
+							disabled={isMutating}
+							mix={[on('click', startNewConnector), css(primaryButtonCss)]}
 						>
-							{email ? `${email} remote connectors` : 'Remote connectors'}
-						</h1>
-						<p mix={css({ color: colors.textMuted, margin: 0 })}>
-							Attach connector refs to normal Kody sessions and manage the
-							shared secrets used by connector hello authentication.
-						</p>
-					</div>
-					<button
-						type="button"
-						disabled={isMutating}
-						mix={[on('click', startNewConnector), css(primaryButtonCss)]}
-					>
-						New connector
-					</button>
-				</header>
+							New connector
+						</button>
+					}
+				/>
 
 				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
@@ -1078,7 +1055,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 						</form>
 					</section>
 				) : null}
-			</section>
+			</AccountManagementShell>
 		)
 	}
 }

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -12,6 +12,7 @@ import {
 	fieldLabelCss,
 	getPrimaryButtonCss,
 	inputCss,
+	layoutMaxWidths,
 	mutedLinkCss,
 	primaryLinkCss,
 } from '#client/styles/style-primitives.ts'
@@ -197,7 +198,7 @@ export function AccountRoute(handle: Handle) {
 		return (
 			<section
 				mix={css({
-					maxWidth: '64rem',
+					maxWidth: layoutMaxWidths.content,
 					margin: '0 auto',
 					display: 'grid',
 					gap: spacing.xl,

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -23,6 +23,7 @@ import {
 	getPrimaryButtonCss,
 	getSecondaryButtonCss,
 	insetCardCss,
+	layoutMaxWidths,
 	mutedLinkCss,
 	stackedPageCss,
 	textareaCss,
@@ -413,7 +414,7 @@ export function CommunityDetailRoute(handle: Handle) {
 
 const pageCss = {
 	...stackedPageCss,
-	maxWidth: '48rem',
+	maxWidth: layoutMaxWidths.narrow,
 	margin: '0 auto',
 	width: '100%',
 }

--- a/packages/worker/client/routes/community.tsx
+++ b/packages/worker/client/routes/community.tsx
@@ -13,6 +13,7 @@ import {
 	fieldLabelCss,
 	getPrimaryButtonCss,
 	inputCss,
+	layoutMaxWidths,
 	pageDescriptionCss,
 	pageHeaderCss,
 	pageTitleCss,
@@ -107,7 +108,7 @@ export function CommunityRoute(handle: Handle) {
 
 const pageCss = {
 	...stackedPageCss,
-	maxWidth: '72rem',
+	maxWidth: layoutMaxWidths.extended,
 	margin: '0 auto',
 	width: '100%',
 }

--- a/packages/worker/client/routes/community.tsx
+++ b/packages/worker/client/routes/community.tsx
@@ -7,7 +7,7 @@ import {
 	readCurrentRouterHref,
 } from '#client/client-router.tsx'
 import { prefetchFrame } from '#client/frame-prefetch.ts'
-import { colors, spacing, typography } from '#client/styles/tokens.ts'
+import { spacing } from '#client/styles/tokens.ts'
 import {
 	fieldCss,
 	fieldLabelCss,

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -7,6 +7,7 @@ import {
 	typography,
 	mq,
 } from '#client/styles/tokens.ts'
+import { layoutMaxWidths } from '#client/styles/style-primitives.ts'
 
 export function HomeRoute(_handle: Handle) {
 	return () => (
@@ -35,7 +36,7 @@ export function HomeRoute(_handle: Handle) {
 					border: `1px solid ${colors.border}`,
 					background: `linear-gradient(135deg, ${colors.primarySoftStrong}, ${colors.primarySoftest})`,
 					boxShadow: shadows.md,
-					maxWidth: '48rem',
+					maxWidth: layoutMaxWidths.narrow,
 					width: '100%',
 					[mq.mobile]: {
 						padding: spacing.lg,
@@ -96,7 +97,7 @@ export function HomeRoute(_handle: Handle) {
 					display: 'grid',
 					gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
 					gap: spacing.lg,
-					maxWidth: '64rem',
+					maxWidth: layoutMaxWidths.content,
 					width: '100%',
 					[mq.mobile]: {
 						gridTemplateColumns: '1fr',

--- a/packages/worker/client/styles/style-primitives.ts
+++ b/packages/worker/client/styles/style-primitives.ts
@@ -96,6 +96,13 @@ export const stackedPageCss = {
 	gap: spacing.lg,
 }
 
+export const layoutMaxWidths = {
+	narrow: '48rem',
+	content: '64rem',
+	extended: '72rem',
+	wide: '96rem',
+} as const
+
 export const pageHeaderCss = {
 	display: 'grid',
 	gap: spacing.xs,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Remove the pathname-based app shell width switch so the top nav has one shared max width across pages.
- Add named layout max-width primitives and reuse them in shared page shells.
- Move integrations, remote connectors, and package invocation tokens onto the default account management shell width.
- Address reviewer consistency nitpicks by sharing compact nav breakpoint styles and using `AccountManagementMessage` in remote connectors.

### Testing
- `npm run validate` passed on the final head: format, lint, typecheck, unit tests, Playwright E2E, and MCP E2E.
- Browser measurement at 1920px viewport showed `navWidth = 1536` and `navLeft = 192` for `/`, `/community`, `/account`, `/account/secrets`, `/account/integrations`, `/account/package-invocation-tokens`, and `/account/remote-connectors`; the changed account management pages also measured `sectionWidth = 1536`.
- Manual walkthrough verified home, community, and account management pages visually.

<a href="https://cursor.com/agents/bc-8bf7ee20-a2c2-425b-a0f2-6ff49acc69db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flayout-width-walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-a9d93621-b9f6-4250-9145-b255f35f019e" alt="layout-width-walkthrough.mp4" /></a>

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `cf8c22e` · **Head:** `e4a0080`

**Classification:** extends — the browser app shell layout behavior changes, but no persisted data, auth, or runtime primitive is added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — route-independent nav/content shell width behavior |
| `community-listings` | assistant | composes — community routes consume shared layout width primitives |

### System map

```mermaid
flowchart LR
	appUi["app-ui"]:::extended
	communityListings["community-listings"]:::touched
	appUi --> communityListings
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart TD
	oldShell["pathname-based app shell width"] --> newShell["fixed nav container + route-owned main width"]
	routeLiterals["shared route width literals"] --> primitives["layoutMaxWidths"]
	accountPages["account management pages"] --> accountShell["AccountManagementShell default width"]
	reviewNits["review nitpicks"] --> consistency["shared compact nav styles + AccountManagementMessage"]
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bf7ee20-a2c2-425b-a0f2-6ff49acc69db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bf7ee20-a2c2-425b-a0f2-6ff49acc69db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Standardized app and account-management page layouts using shared headers, shells, and responsive max-width rules.
  * Updated multiple pages (home, community, account, remote connectors, integrations, and token pages) to consistently apply the new shared width tokens.
  * Improved status/info messaging visuals on account-management screens.
  * Simplified the top-level layout structure and updated the “Not Found” styling while keeping the same behavior.

* **Refactor**
  * Replaced hard-coded layout width values with shared `layoutMaxWidths` across affected routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->