### PR TITLE
Make account deletion cover user storage inventory

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1,6 +1,6 @@
 # Data storage
 
-This project uses three Cloudflare storage systems for different purposes.
+This project uses several Cloudflare storage systems for different purposes.
 
 ## Per-user isolation invariant
 
@@ -8,10 +8,49 @@ Kody is multi-user with strict per-user isolation. Every storage layer described
 below is scoped by `user_id` (D1 columns, Vectorize metadata, KV key prefixes,
 Durable Object names) and every read/write path takes a `userId` argument. Two
 users with the same logical identifier (for example the same `kind`/`instanceId`
-pair on a remote connector, or the same `sessionId` on an agent turn) land on
+pair on a remote connector, the same package id, or the same storage id) land on
 different durable objects and different rows. Any new persistence layer added to
 the project must follow the same convention; user-scoped tests should exercise
 both the "happy" path and a cross-user denial path.
+
+## Account deletion inventory
+
+Account deletion is implemented in `packages/worker/src/app/account-deletion.ts`
+and is intentionally inventory driven. The operation first enumerates user-owned
+identifiers while D1 rows still exist, then best-effort deletes out-of-band
+stores, then deletes D1 rows, revokes OAuth grants, and finally deletes the
+`users` row. Each step records counts and warnings so the HTTP response states
+what was removed and what needs operator attention. Re-running the operation is
+safe: missing rows, missing KV keys, missing vectors, deleted Artifacts repos,
+and already-cleared Durable Objects are treated as successful no-ops or
+warning-only failures.
+
+Deletion must cover these user-owned surfaces:
+
+- **D1:** every live table with `user_id` / `*_user_id` ownership columns, plus
+  transitive children (`secret_entries`, `value_entries`, `email_attachments`)
+  and listing children for community-owned listings. The guardrail test in
+  `packages/worker/src/app/account-deletion.node.test.ts` applies the live
+  migrations to SQLite and fails if a user-owned schema column is not
+  represented in the deletion target list, or if the deletion target list
+  references a stale column.
+- **Durable Objects:** `JobManager`, `StorageRunner`, `RepoSession`,
+  `RemoteConnectorSession`, `PackageRealtimeSession`, and
+  `PackageServiceInstance` are purged through account-deletion RPCs after their
+  D1 identifiers are collected. `MCP` objects are session-keyed by the MCP SDK
+  rather than user-keyed and are not globally enumerable; account deletion
+  revokes OAuth grants/tokens so those sessions cannot continue making
+  authorized user requests.
+- **Vectorize:** memory, job, and saved-package vector ids are derived from D1
+  rows and removed with `deleteByIds`.
+- **KV:** published bundle artifact keys, source/manifest snapshot keys,
+  community listing snapshots, and per-user package retriever cache/index keys
+  in `BUNDLE_ARTIFACTS_KV` are deleted before D1 projection rows are removed.
+  OAuth token/grant KV is owned by the OAuth provider and is handled through
+  provider grant revocation rather than app-level key scans.
+- **Cloudflare Artifacts:** source repos referenced by `entity_sources` and
+  `repo_sessions` are deleted through the REST client in
+  `packages/worker/src/repo/artifacts.ts`.
 
 ## D1 (`APP_DB`)
 
@@ -38,16 +77,22 @@ App access pattern:
   `remix/data-table` (including `findOne`, `create`, `update`, `deleteMany`, and
   `count`)
 
-## KV (`OAUTH_KV`)
+## KV (`OAUTH_KV`, `BUNDLE_ARTIFACTS_KV`)
 
-OAuth provider state is stored in KV through the
-`@cloudflare/workers-oauth-provider` integration.
+OAuth provider state is stored in `OAUTH_KV` through the
+`@cloudflare/workers-oauth-provider` integration. Published package/job source
+snapshots, bundle artifacts, package retriever caches, and community listing
+snapshots are stored in `BUNDLE_ARTIFACTS_KV`.
 
-- Binding is configured in `packages/worker/wrangler.jsonc` (remote KV IDs are
+- Bindings are configured in `packages/worker/wrangler.jsonc` (remote KV IDs are
   supplied at deploy time via generated Wrangler configs, not committed in the
-  checked-in config)
-- This supports OAuth client and token flows without custom storage code in the
-  app handlers
+  checked-in config).
+- `OAUTH_KV` supports OAuth client and token flows without custom storage code
+  in the app handlers; account deletion revokes all provider grants for the
+  user.
+- `BUNDLE_ARTIFACTS_KV` keys are deleted from account deletion using D1-derived
+  source ids, published commits, bundle artifact rows, community listing ids,
+  and package ids.
 
 ## Durable Objects (`MCP_OBJECT`)
 
@@ -88,24 +133,23 @@ that two different users always resolve to two different object ids:
   (`packages/worker/src/jobs/manager-client.ts`).
 - `StorageRunner` — `idFromName(JSON.stringify([userId, storageId]))`
   (`packages/worker/src/storage-runner.ts`).
+- `RepoSession` — keyed by `repo_sessions.id`; every RPC validates the D1
+  session row's `user_id` before touching the workspace. Account deletion
+  enumerates the user's session ids before deleting D1 rows and purges each DO.
 - `PackageRealtimeSession` and `PackageServiceInstance` — keyed by
   `(userId, packageId, ...)` via the helpers in
-  `packages/worker/src/package-runtime/`.
+  `packages/worker/src/package-runtime/`. Account deletion enumerates app
+  packages and observed service instances, closes live sessions/services, clears
+  alarms, and deletes DO storage.
 - `RemoteConnectorSession` —
   `userScopedConnectorSessionKey(userId, kind, instanceId)`. Connectors must
   connect through the username-scoped ingress URL
   `/@{username}/connectors/{kind}/{instanceId}`. The DO carries the ingress user
   id forward via headers + websocket attachment and verifies the shared secret
-  against that user's row only.
-- `AgentTurnRunner` — `idFromName(JSON.stringify([userId, sessionId]))`. The
-  runner DO also requires every request to carry an `X-Kody-User-Id` header,
-  persists `ownerUserId` on first contact, and rejects mismatched callers with
-  HTTP 403.
-
-The `MCP` and `ChatAgent` Durable Objects are addressed by request
-session/thread id rather than user id; ownership is enforced at the request
-boundary by validating the authenticated user against the `McpCallerContext` /
-`chat_threads` row before routing.
+  against that user's row only. The `MCP` Durable Object is addressed by MCP
+  session id rather than user id; ownership is enforced at the request boundary
+  by validating the authenticated user against the `McpCallerContext` on every
+  request.
 
 ## Per-user runtime context (no shared `globalThis`)
 
@@ -137,9 +181,14 @@ Bindings are configured per environment in `packages/worker/wrangler.jsonc`
 
 - `APP_DB` (D1)
 - `OAUTH_KV` (KV)
+- `BUNDLE_ARTIFACTS_KV` (KV)
 - `MCP_OBJECT` (Durable Objects)
+- `REMOTE_CONNECTOR_SESSION` (Durable Objects)
 - `JOB_MANAGER` (Durable Objects)
 - `STORAGE_RUNNER` (Durable Objects)
+- `REPO_SESSION` (Durable Objects)
+- `PACKAGE_REALTIME_SESSION` (Durable Objects)
+- `PACKAGE_SERVICE_INSTANCE` (Durable Objects)
 - `ASSETS` (static assets bucket)
 
 ## Repo-backed source and Artifacts

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -18,12 +18,13 @@ both the "happy" path and a cross-user denial path.
 Account deletion is implemented in `packages/worker/src/app/account-deletion.ts`
 and is intentionally inventory driven. The operation first enumerates user-owned
 identifiers while D1 rows still exist, then best-effort deletes out-of-band
-stores, then deletes D1 rows, revokes OAuth grants, and finally deletes the
-`users` row. Each step records counts and warnings so the HTTP response states
-what was removed and what needs operator attention. Re-running the operation is
-safe: missing rows, missing KV keys, missing vectors, deleted Artifacts repos,
-and already-cleared Durable Objects are treated as successful no-ops or
-warning-only failures.
+stores, then deletes or clears D1 rows, revokes OAuth grants, and finally
+deletes the `users` row. Each step records deleted counts, updated counts for
+cleared references, and warnings so the HTTP response states what was removed
+and what needs operator attention. Re-running the operation is safe: missing
+rows, missing KV keys, missing vectors, deleted Artifacts repos, and
+already-cleared Durable Objects are treated as successful no-ops or warning-only
+failures.
 
 Deletion must cover these user-owned surfaces:
 

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -208,7 +208,7 @@ function createTestDb(initial: RowMap): {
 						async run() {
 							const userId = params[0] as string | number
 							const nullColumnMatch = lower.match(
-								/^update (\w+) set (.+) where (\w+) = \?$/,
+								/^update (\w+) set ((?:\w+ = null)(?:, \w+ = null)*) where (\w+) = \?$/,
 							)
 							if (nullColumnMatch) {
 								const table = nullColumnMatch[1] as string
@@ -222,6 +222,21 @@ function createTestDb(initial: RowMap): {
 									for (const column of assignments) {
 										row[column] = null
 									}
+									changed += 1
+								}
+								return { meta: { changes: changed } }
+							}
+							const replaceColumnMatch = lower.match(
+								/^update (\w+) set (\w+) = \? where (\w+) = \?$/,
+							)
+							if (replaceColumnMatch) {
+								const table = replaceColumnMatch[1] as string
+								const setColumn = replaceColumnMatch[2] as string
+								const matchColumn = replaceColumnMatch[3] as string
+								let changed = 0
+								for (const row of rows[table] ?? []) {
+									if (row[matchColumn] !== params[1]) continue
+									row[setColumn] = params[0]
 									changed += 1
 								}
 								return { meta: { changes: changed } }
@@ -672,7 +687,9 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 			resolution_note: null,
 		},
 	])
-	expect(rows.community_bans).toEqual([])
+	expect(rows.community_bans).toEqual([
+		{ user_id: userBbb, banned_by_user_id: 'deleted-user' },
+	])
 	expect(rows.users).toEqual([{ id: 2, email: 'b@example.com' }])
 	expect(result.deletedRowCounts.password_resets).toBe(2)
 	expect(result.deletedRowCounts.user_roles).toBe(1)
@@ -724,6 +741,8 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(result.deletedRowCounts.community_ratings).toBe(2)
 	expect(result.deletedRowCounts.community_reports).toBe(2)
 	expect(result.updatedRowCounts.community_reports).toBe(1)
+	expect(result.deletedRowCounts.community_bans).toBe(1)
+	expect(result.updatedRowCounts.community_bans).toBe(1)
 	expect(result.deletedKvKeys).toBe(11)
 	expect(result.deletedVectors).toBe(4)
 	expect(result.clearedDurableObjects).toMatchObject({

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -727,6 +727,9 @@ test('deleteUserAccount handles OAuth grant revocation and warning-only edge cas
 	})
 	expect(revokeGrant).toHaveBeenCalledTimes(2)
 	expect(revokeResult.revokedOAuthGrants).toBe(2)
+	expect(revokeResult.warnings).toContain(
+		'JOB_MANAGER binding was unavailable; the user scheduler Durable Object was not purged.',
+	)
 
 	const { db: oauthFailureDb, rows: oauthFailureRows } = createTestDb({
 		users: [{ id: 1, email: 'a@example.com' }],

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -146,7 +146,6 @@ function createTestDb(initial: RowMap): {
 									)
 									const sourceId =
 										savedPackage?.['source_id'] ?? row['source_id']
-									if (sourceId == null) continue
 									const key = `${String(row['package_id'])}:${String(row['name'])}`
 									if (seen.has(key)) continue
 									seen.add(key)
@@ -208,6 +207,25 @@ function createTestDb(initial: RowMap): {
 						},
 						async run() {
 							const userId = params[0] as string | number
+							const nullColumnMatch = lower.match(
+								/^update (\w+) set (.+) where (\w+) = \?$/,
+							)
+							if (nullColumnMatch) {
+								const table = nullColumnMatch[1] as string
+								const assignments = nullColumnMatch[2]!
+									.split(', ')
+									.map((part) => part.replace(' = null', ''))
+								const matchColumn = nullColumnMatch[3] as string
+								let changed = 0
+								for (const row of rows[table] ?? []) {
+									if (row[matchColumn] !== userId) continue
+									for (const column of assignments) {
+										row[column] = null
+									}
+									changed += 1
+								}
+								return { meta: { changes: changed } }
+							}
 							const userColumnsMatch = lower.match(
 								/^delete from (\w+) where ((?:\w+ = \?)(?: or \w+ = \?)*)$/,
 							)
@@ -377,6 +395,16 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 				surface: 'app_fetch',
 				name: null,
 				storage_id: 'exec:run-2',
+			},
+			{
+				id: 'run-orphan-service',
+				user_id: userAaa,
+				package_id: 'pkg-orphan',
+				package_kody_id: 'legacy',
+				source_id: null,
+				surface: 'service',
+				name: 'legacy-sync',
+				storage_id: null,
 			},
 			{
 				id: 'run-3',
@@ -633,7 +661,17 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(rows.community_ratings).toEqual([
 		{ id: 'rating-3', listing_id: 'listing-2', user_id: userBbb },
 	])
-	expect(rows.community_reports).toEqual([])
+	expect(rows.community_reports).toEqual([
+		{
+			id: 'report-3',
+			listing_id: 'listing-2',
+			listing_owner_user_id: userBbb,
+			reporter_user_id: userBbb,
+			resolved_by_user_id: null,
+			resolved_at: null,
+			resolution_note: null,
+		},
+	])
 	expect(rows.community_bans).toEqual([])
 	expect(rows.users).toEqual([{ id: 2, email: 'b@example.com' }])
 	expect(result.deletedRowCounts.password_resets).toBe(2)
@@ -646,7 +684,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		'job_job-2',
 		'package_pkg-1',
 	])
-	expect(clearStorageMock).toHaveBeenCalledTimes(5)
+	expect(clearStorageMock).toHaveBeenCalledTimes(6)
 	expect(purgeJobManagerMock).toHaveBeenCalledTimes(1)
 	expect(purgeRepoSessionMock).toHaveBeenCalledWith({
 		sessionId: 'rs-1',
@@ -657,7 +695,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		kind: 'home',
 		instanceId: 'default',
 	})
-	expect(doFetchMock).toHaveBeenCalledTimes(2)
+	expect(doFetchMock).toHaveBeenCalledTimes(3)
 
 	// Bundle KV keys for the deleted user were removed; the other user's keys
 	// remain in storage.
@@ -679,20 +717,22 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(result.deletedRowCounts.jobs).toBe(2)
 	expect(result.deletedRowCounts.users).toBe(1)
 	expect(result.deletedRowCounts.email_attachments).toBe(1)
-	expect(result.deletedRowCounts.package_runtime_runs).toBe(2)
+	expect(result.deletedRowCounts.package_runtime_runs).toBe(3)
 	expect(result.deletedRowCounts.package_runtime_logs).toBe(1)
 	expect(result.deletedRowCounts.community_listings).toBe(1)
 	expect(result.deletedRowCounts.community_forks).toBe(2)
 	expect(result.deletedRowCounts.community_ratings).toBe(2)
+	expect(result.deletedRowCounts.community_reports).toBe(2)
+	expect(result.updatedRowCounts.community_reports).toBe(1)
 	expect(result.deletedKvKeys).toBe(11)
 	expect(result.deletedVectors).toBe(4)
 	expect(result.clearedDurableObjects).toMatchObject({
-		storageRunners: 5,
+		storageRunners: 6,
 		jobManagers: 1,
 		repoSessions: 1,
 		remoteConnectorSessions: 1,
 		packageRealtimeSessions: 1,
-		packageServiceInstances: 1,
+		packageServiceInstances: 2,
 	})
 	expect(result.warnings.length).toBeGreaterThan(0)
 })

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -1,5 +1,10 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
-import { deleteUserAccount } from './account-deletion.ts'
+import {
+	deleteUserAccount,
+	getAccountDeletionD1UserColumnCoverage,
+} from './account-deletion.ts'
 
 type RowMap = Record<string, Array<Record<string, unknown>>>
 
@@ -46,6 +51,124 @@ function createTestDb(initial: RowMap): {
 						async all<T>() {
 							let results: Array<unknown> = []
 							const userId = params[0] as string
+							if (
+								lower ===
+								'select id from saved_packages where user_id = ? and has_app = 1'
+							) {
+								results = (rows.saved_packages ?? [])
+									.filter(
+										(row) =>
+											row['user_id'] === userId &&
+											(row['has_app'] === 1 ||
+												row['has_app'] === '1' ||
+												row['has_app'] === true),
+									)
+									.map((row) => ({ id: row['id'] }))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower ===
+								'select id, published_commit from entity_sources where user_id = ?'
+							) {
+								results = (rows.entity_sources ?? [])
+									.filter((row) => row['user_id'] === userId)
+									.map((row) => ({
+										id: row['id'],
+										published_commit: row['published_commit'] ?? null,
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower ===
+								'select id, kody_id, source_id, has_app from saved_packages where user_id = ?'
+							) {
+								results = (rows.saved_packages ?? [])
+									.filter((row) => row['user_id'] === userId)
+									.map((row) => ({
+										id: row['id'],
+										kody_id: row['kody_id'],
+										source_id: row['source_id'],
+										has_app: row['has_app'],
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower ===
+								'select kind, instance_id from remote_connector_settings where user_id = ?'
+							) {
+								results = (rows.remote_connector_settings ?? [])
+									.filter((row) => row['user_id'] === userId)
+									.map((row) => ({
+										kind: row['kind'],
+										instance_id: row['instance_id'],
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower ===
+								"select distinct package_id, name from package_runtime_runs where user_id = ? and surface = 'service' and name is not null"
+							) {
+								const seen = new Set<string>()
+								results = []
+								for (const row of rows.package_runtime_runs ?? []) {
+									if (
+										row['user_id'] !== userId ||
+										row['surface'] !== 'service' ||
+										row['name'] == null
+									) {
+										continue
+									}
+									const key = `${String(row['package_id'])}:${String(row['name'])}`
+									if (seen.has(key)) continue
+									seen.add(key)
+									results.push({
+										package_id: row['package_id'],
+										name: row['name'],
+									})
+								}
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (lower.startsWith('select distinct r.package_id,')) {
+								const seen = new Set<string>()
+								results = []
+								for (const row of rows.package_runtime_runs ?? []) {
+									if (
+										row['user_id'] !== userId ||
+										row['surface'] !== 'service' ||
+										row['name'] == null
+									) {
+										continue
+									}
+									const savedPackage = (rows.saved_packages ?? []).find(
+										(pkg) =>
+											pkg['id'] === row['package_id'] &&
+											pkg['user_id'] === row['user_id'],
+									)
+									const sourceId =
+										savedPackage?.['source_id'] ?? row['source_id']
+									if (sourceId == null) continue
+									const key = `${String(row['package_id'])}:${String(row['name'])}`
+									if (seen.has(key)) continue
+									seen.add(key)
+									results.push({
+										package_id: row['package_id'],
+										kody_id:
+											savedPackage?.['kody_id'] ?? row['package_kody_id'],
+										source_id: sourceId,
+										name: row['name'],
+									})
+								}
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower ===
+								'select id from community_listings where owner_user_id = ?'
+							) {
+								results = (rows.community_listings ?? [])
+									.filter((row) => row['owner_user_id'] === userId)
+									.map((row) => ({ id: row['id'] }))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
 							const m = lower.match(/^select id from (\w+) where user_id = \?/)
 							if (m) {
 								const table = m[1] as string
@@ -85,6 +208,21 @@ function createTestDb(initial: RowMap): {
 						},
 						async run() {
 							const userId = params[0] as string | number
+							const userColumnsMatch = lower.match(
+								/^delete from (\w+) where ((?:\w+ = \?)(?: or \w+ = \?)*)$/,
+							)
+							if (userColumnsMatch) {
+								const table = userColumnsMatch[1] as string
+								const columns = userColumnsMatch[2]!
+									.split(' or ')
+									.map((part) => part.replace(' = ?', ''))
+								const removed = deleteByPredicate(table, (row) =>
+									columns.some(
+										(column, index) => row[column] === params[index],
+									),
+								)
+								return { meta: { changes: removed } }
+							}
 							const userIdMatch = lower.match(
 								/^delete from (\w+) where user_id = \?/,
 							)
@@ -125,6 +263,23 @@ function createTestDb(initial: RowMap): {
 								)
 								return { meta: { changes: removed } }
 							}
+							const communityListingChildMatch = lower.match(
+								/^delete from (\w+) where (\w+) in \( select id from community_listings where owner_user_id = \? \)/,
+							)
+							if (communityListingChildMatch) {
+								const table = communityListingChildMatch[1] as string
+								const listingColumn = communityListingChildMatch[2] as string
+								const listingIds = new Set(
+									selectIds(
+										'community_listings',
+										(row) => row['owner_user_id'] === userId,
+									),
+								)
+								const removed = deleteByPredicate(table, (row) =>
+									listingIds.has(row[listingColumn]),
+								)
+								return { meta: { changes: removed } }
+							}
 							const usersMatch = lower.match(/^delete from users where id = \?/)
 							if (usersMatch) {
 								const removed = deleteByPredicate(
@@ -144,6 +299,51 @@ function createTestDb(initial: RowMap): {
 	return { db, rows }
 }
 
+function quoteSqlIdentifier(identifier: string) {
+	return `"${identifier.replaceAll('"', '""')}"`
+}
+
+test('account deletion D1 coverage includes every live user-owned schema column', () => {
+	const migrationsDir = new URL('../../migrations/', import.meta.url)
+	const db = new DatabaseSync(':memory:')
+	for (const fileName of readdirSync(migrationsDir)
+		.filter((file) => file.endsWith('.sql'))
+		.sort()) {
+		db.exec(readFileSync(new URL(fileName, migrationsDir), 'utf8'))
+	}
+	const tables = db
+		.prepare(
+			`SELECT name
+			FROM sqlite_schema
+			WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+			ORDER BY name`,
+		)
+		.all() as Array<{ name: string }>
+	const liveUserColumns = new Set<string>()
+	for (const table of tables) {
+		const columns = db
+			.prepare(`PRAGMA table_info(${quoteSqlIdentifier(table.name)})`)
+			.all() as Array<{ name: string }>
+		for (const column of columns) {
+			if (column.name === 'user_id' || column.name.endsWith('_user_id')) {
+				liveUserColumns.add(`${table.name}.${column.name}`)
+			}
+		}
+	}
+	const coveredColumns = getAccountDeletionD1UserColumnCoverage()
+	const missing = [...liveUserColumns].filter(
+		(column) => !coveredColumns.has(column),
+	)
+	const stale = [...coveredColumns].filter(
+		(column) => !liveUserColumns.has(column),
+	)
+	expect(
+		missing,
+		'user-owned D1 columns missing from account deletion',
+	).toEqual([])
+	expect(stale, 'account deletion references stale D1 columns').toEqual([])
+})
+
 test('deleteUserAccount cascades user-scoped rows for the requested user', async () => {
 	const userAaa = 'user-aaa'
 	const userBbb = 'user-bbb'
@@ -157,6 +357,42 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 			{ id: 'job-2', user_id: userAaa, storage_id: null },
 			{ id: 'job-3', user_id: userBbb, storage_id: 'job:job-3' },
 		],
+		package_runtime_runs: [
+			{
+				id: 'run-1',
+				user_id: userAaa,
+				package_id: 'pkg-1',
+				package_kody_id: 'demo',
+				source_id: 'src-1',
+				surface: 'service',
+				name: 'sync',
+				storage_id: 'service:pkg-1:sync',
+			},
+			{
+				id: 'run-2',
+				user_id: userAaa,
+				package_id: 'pkg-1',
+				package_kody_id: 'demo',
+				source_id: 'src-1',
+				surface: 'app_fetch',
+				name: null,
+				storage_id: 'exec:run-2',
+			},
+			{
+				id: 'run-3',
+				user_id: userBbb,
+				package_id: 'pkg-2',
+				package_kody_id: 'other',
+				source_id: 'src-2',
+				surface: 'service',
+				name: 'sync',
+				storage_id: 'service:pkg-2:sync',
+			},
+		],
+		package_runtime_logs: [
+			{ id: 'log-1', run_id: 'run-1', user_id: userAaa, package_id: 'pkg-1' },
+			{ id: 'log-2', run_id: 'run-3', user_id: userBbb, package_id: 'pkg-2' },
+		],
 		mcp_memories: [
 			{ id: 'mem-1', user_id: userAaa },
 			{ id: 'mem-2', user_id: userBbb },
@@ -166,23 +402,37 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		value_buckets: [{ id: 'vb-1', user_id: userAaa }],
 		value_entries: [{ bucket_id: 'vb-1', name: 'v', user_id: 'unused' }],
 		remote_connector_settings: [
-			{ id: 'rc-1', user_id: userAaa },
-			{ id: 'rc-2', user_id: userBbb },
+			{ id: 'rc-1', user_id: userAaa, kind: 'home', instance_id: 'default' },
+			{ id: 'rc-2', user_id: userBbb, kind: 'home', instance_id: 'other' },
 		],
 		saved_packages: [
-			{ id: 'pkg-1', user_id: userAaa },
-			{ id: 'pkg-2', user_id: userBbb },
+			{
+				id: 'pkg-1',
+				user_id: userAaa,
+				kody_id: 'demo',
+				source_id: 'src-1',
+				has_app: 1,
+			},
+			{
+				id: 'pkg-2',
+				user_id: userBbb,
+				kody_id: 'other',
+				source_id: 'src-2',
+				has_app: 0,
+			},
 		],
 		published_bundle_artifacts: [
 			{ id: 'pba-1', user_id: userAaa, kv_key: 'bundle-artifact:v1:src-1' },
 			{ id: 'pba-2', user_id: userBbb, kv_key: 'bundle-artifact:v1:src-2' },
 		],
 		archived_job_artifacts: [
-			{ id: 'aja-1', user_id: userAaa, kv_key: 'archived:src-1' },
+			{ id: 'aja-1', user_id: userAaa, storage_id: 'job:archived-1' },
 		],
-		entity_sources: [{ id: 'es-1', user_id: userAaa }],
+		entity_sources: [
+			{ id: 'src-1', user_id: userAaa, published_commit: 'abc123' },
+			{ id: 'src-2', user_id: userBbb, published_commit: 'def456' },
+		],
 		repo_sessions: [{ id: 'rs-1', user_id: userAaa }],
-		chat_threads: [{ id: 't-1', user_id: userAaa }],
 		password_resets: [
 			{ id: 1, user_id: 1 },
 			{ id: 2, user_id: 1 },
@@ -206,6 +456,47 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		email_attachments: [{ id: 'ea-1', message_id: 'em-1' }],
 		email_delivery_events: [{ id: 'ed-1', user_id: userAaa }],
 		email_sender_identities: [{ id: 'ei-1', user_id: userAaa }],
+		community_listings: [
+			{ id: 'listing-1', owner_user_id: userAaa },
+			{ id: 'listing-2', owner_user_id: userBbb },
+		],
+		community_forks: [
+			{ id: 'fork-1', listing_id: 'listing-1', forker_user_id: userBbb },
+			{ id: 'fork-2', listing_id: 'listing-2', forker_user_id: userAaa },
+			{ id: 'fork-3', listing_id: 'listing-2', forker_user_id: userBbb },
+		],
+		community_ratings: [
+			{ id: 'rating-1', listing_id: 'listing-1', user_id: userBbb },
+			{ id: 'rating-2', listing_id: 'listing-2', user_id: userAaa },
+			{ id: 'rating-3', listing_id: 'listing-2', user_id: userBbb },
+		],
+		community_reports: [
+			{
+				id: 'report-1',
+				listing_id: 'listing-1',
+				listing_owner_user_id: userAaa,
+				reporter_user_id: userBbb,
+				resolved_by_user_id: null,
+			},
+			{
+				id: 'report-2',
+				listing_id: 'listing-2',
+				listing_owner_user_id: userBbb,
+				reporter_user_id: userAaa,
+				resolved_by_user_id: null,
+			},
+			{
+				id: 'report-3',
+				listing_id: 'listing-2',
+				listing_owner_user_id: userBbb,
+				reporter_user_id: userBbb,
+				resolved_by_user_id: userAaa,
+			},
+		],
+		community_bans: [
+			{ user_id: userAaa, banned_by_user_id: userBbb },
+			{ user_id: userBbb, banned_by_user_id: userAaa },
+		],
 	})
 
 	const deletedKvKeys: Array<string> = []
@@ -213,15 +504,64 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		async delete(key: string) {
 			deletedKvKeys.push(key)
 		},
+		async list(options?: { prefix?: string; cursor?: string }) {
+			const allKeys = [
+				'source-snapshot:v1:src-1:abc123',
+				'source-manifest-snapshot:v1:src-1:abc123',
+				'source-snapshot:v1:src-1:old456',
+				'source-manifest-snapshot:v1:src-1:old456',
+				'source-snapshot:v1:src-2:def456',
+				'package-retriever-manifest:v1:user-aaa:pkg-1:abc123',
+				'package-retriever-index-entry:v1:user-aaa:search:pkg-1:notes',
+				'package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes',
+				'package-retriever-index-entry:v1:user-bbb:search:pkg-2:notes',
+			]
+			const keys = allKeys
+				.filter((key) => key.startsWith(options?.prefix ?? ''))
+				.map((name) => ({ name }))
+			return {
+				keys,
+				list_complete: true,
+				cursor: undefined,
+			}
+		},
 	} as unknown as KVNamespace
 
 	const clearStorageMock = vi.fn(async () => ({ ok: true as const }))
+	const purgeJobManagerMock = vi.fn(async () => ({ ok: true as const }))
+	const purgeRepoSessionMock = vi.fn(async () => ({ ok: true as const }))
+	const purgeRemoteConnectorMock = vi.fn(async () => ({ ok: true as const }))
+	const doFetchMock = vi.fn(async () => Response.json({ ok: true }))
+	const deleteVectorsMock = vi.fn(async () => undefined)
 	const env = {
 		APP_DB: db,
 		BUNDLE_ARTIFACTS_KV: kv,
+		CAPABILITY_VECTOR_INDEX: {
+			deleteByIds: deleteVectorsMock,
+		},
 		STORAGE_RUNNER: {
 			idFromName: (name: string) => name as unknown as DurableObjectId,
 			get: () => ({ clearStorage: clearStorageMock }),
+		},
+		JOB_MANAGER: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ purgeUser: purgeJobManagerMock }),
+		},
+		REPO_SESSION: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ purgeSession: purgeRepoSessionMock }),
+		},
+		REMOTE_CONNECTOR_SESSION: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ rpcPurgeUserSession: purgeRemoteConnectorMock }),
+		},
+		PACKAGE_REALTIME_SESSION: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ fetch: doFetchMock }),
+		},
+		PACKAGE_SERVICE_INSTANCE: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ fetch: doFetchMock }),
 		},
 	} as unknown as Env
 
@@ -239,9 +579,17 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		{ id: 'job-3', user_id: userBbb, storage_id: 'job:job-3' },
 	])
 	expect(rows.mcp_memories).toEqual([{ id: 'mem-2', user_id: userBbb }])
-	expect(rows.saved_packages).toEqual([{ id: 'pkg-2', user_id: userBbb }])
+	expect(rows.saved_packages).toEqual([
+		{
+			id: 'pkg-2',
+			user_id: userBbb,
+			kody_id: 'other',
+			source_id: 'src-2',
+			has_app: 0,
+		},
+	])
 	expect(rows.remote_connector_settings).toEqual([
-		{ id: 'rc-2', user_id: userBbb },
+		{ id: 'rc-2', user_id: userBbb, kind: 'home', instance_id: 'other' },
 	])
 	expect(rows.published_bundle_artifacts).toEqual([
 		{ id: 'pba-2', user_id: userBbb, kv_key: 'bundle-artifact:v1:src-2' },
@@ -255,29 +603,97 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(rows.value_buckets).toEqual([])
 	expect(rows.value_entries).toEqual([])
 	expect(rows.archived_job_artifacts).toEqual([])
-	expect(rows.entity_sources).toEqual([])
+	expect(rows.entity_sources).toEqual([
+		{ id: 'src-2', user_id: userBbb, published_commit: 'def456' },
+	])
 	expect(rows.repo_sessions).toEqual([])
-	expect(rows.chat_threads).toEqual([])
 	expect(rows.email_attachments).toEqual([])
 	expect(rows.email_messages).toEqual([])
+	expect(rows.package_runtime_runs).toEqual([
+		{
+			id: 'run-3',
+			user_id: userBbb,
+			package_id: 'pkg-2',
+			package_kody_id: 'other',
+			source_id: 'src-2',
+			surface: 'service',
+			name: 'sync',
+			storage_id: 'service:pkg-2:sync',
+		},
+	])
+	expect(rows.package_runtime_logs).toEqual([
+		{ id: 'log-2', run_id: 'run-3', user_id: userBbb, package_id: 'pkg-2' },
+	])
+	expect(rows.community_listings).toEqual([
+		{ id: 'listing-2', owner_user_id: userBbb },
+	])
+	expect(rows.community_forks).toEqual([
+		{ id: 'fork-3', listing_id: 'listing-2', forker_user_id: userBbb },
+	])
+	expect(rows.community_ratings).toEqual([
+		{ id: 'rating-3', listing_id: 'listing-2', user_id: userBbb },
+	])
+	expect(rows.community_reports).toEqual([])
+	expect(rows.community_bans).toEqual([])
 	expect(rows.users).toEqual([{ id: 2, email: 'b@example.com' }])
 	expect(result.deletedRowCounts.password_resets).toBe(2)
 	expect(result.deletedRowCounts.user_roles).toBe(1)
 
-	// Storage runners for the deleted user's storage_ids were cleared.
-	expect(clearStorageMock).toHaveBeenCalledTimes(1)
+	// Out-of-band stores for the deleted user were cleared.
+	expect(deleteVectorsMock).toHaveBeenCalledWith([
+		'memory_mem-1',
+		'job_job-1',
+		'job_job-2',
+		'package_pkg-1',
+	])
+	expect(clearStorageMock).toHaveBeenCalledTimes(5)
+	expect(purgeJobManagerMock).toHaveBeenCalledTimes(1)
+	expect(purgeRepoSessionMock).toHaveBeenCalledWith({
+		sessionId: 'rs-1',
+		userId: userAaa,
+	})
+	expect(purgeRemoteConnectorMock).toHaveBeenCalledWith({
+		userId: userAaa,
+		kind: 'home',
+		instanceId: 'default',
+	})
+	expect(doFetchMock).toHaveBeenCalledTimes(2)
 
 	// Bundle KV keys for the deleted user were removed; the other user's keys
 	// remain in storage.
 	expect(deletedKvKeys.sort()).toEqual([
-		'archived:src-1',
 		'bundle-artifact:v1:src-1',
+		'community-snapshot:v1:listing-1',
+		'package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes',
+		'package-retriever-index-entry:v1:user-aaa:search:pkg-1:notes',
+		'package-retriever-index:v1:user-aaa:context',
+		'package-retriever-index:v1:user-aaa:search',
+		'package-retriever-manifest:v1:user-aaa:pkg-1:abc123',
+		'source-manifest-snapshot:v1:src-1:abc123',
+		'source-manifest-snapshot:v1:src-1:old456',
+		'source-snapshot:v1:src-1:abc123',
+		'source-snapshot:v1:src-1:old456',
 	])
 
 	// Result accounting captures the per-table counts.
 	expect(result.deletedRowCounts.jobs).toBe(2)
 	expect(result.deletedRowCounts.users).toBe(1)
 	expect(result.deletedRowCounts.email_attachments).toBe(1)
+	expect(result.deletedRowCounts.package_runtime_runs).toBe(2)
+	expect(result.deletedRowCounts.package_runtime_logs).toBe(1)
+	expect(result.deletedRowCounts.community_listings).toBe(1)
+	expect(result.deletedRowCounts.community_forks).toBe(2)
+	expect(result.deletedRowCounts.community_ratings).toBe(2)
+	expect(result.deletedKvKeys).toBe(11)
+	expect(result.deletedVectors).toBe(4)
+	expect(result.clearedDurableObjects).toMatchObject({
+		storageRunners: 5,
+		jobManagers: 1,
+		repoSessions: 1,
+		remoteConnectorSessions: 1,
+		packageRealtimeSessions: 1,
+		packageServiceInstances: 1,
+	})
 	expect(result.warnings.length).toBeGreaterThan(0)
 })
 

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -60,6 +60,13 @@ type UserScopedDeleteTarget =
 			matchColumn: string
 			nullColumns: ReadonlyArray<string>
 	  }
+	| {
+			kind: 'replace_user_column'
+			table: string
+			matchColumn: string
+			setColumn: string
+			value: string
+	  }
 	| { kind: 'bucket_parent'; table: string; parentTable: string }
 	| { kind: 'attachment_parent'; table: string }
 	| { kind: 'community_listing_child'; table: string; listingColumn: string }
@@ -146,7 +153,14 @@ const userScopedTables: ReadonlyArray<UserScopedDeleteTarget> = [
 	{
 		kind: 'user_columns',
 		table: 'community_bans',
-		columns: ['user_id', 'banned_by_user_id'],
+		columns: ['user_id'],
+	},
+	{
+		kind: 'replace_user_column',
+		table: 'community_bans',
+		matchColumn: 'banned_by_user_id',
+		setColumn: 'banned_by_user_id',
+		value: 'deleted-user',
 	},
 	{
 		kind: 'user_columns',
@@ -181,6 +195,10 @@ export function getAccountDeletionD1UserColumnCoverage() {
 				break
 			}
 			case 'null_user_column': {
+				covered.add(`${target.table}.${target.matchColumn}`)
+				break
+			}
+			case 'replace_user_column': {
 				covered.add(`${target.table}.${target.matchColumn}`)
 				break
 			}
@@ -887,6 +905,14 @@ async function deleteUserScopedRows(input: {
 					tableName = target.table
 					break
 				}
+				case 'replace_user_column': {
+					sql = `UPDATE ${target.table}
+						SET ${target.setColumn} = ?
+						WHERE ${target.matchColumn} = ?`
+					params = [target.value, input.mcpUserId]
+					tableName = target.table
+					break
+				}
 				case 'bucket_parent': {
 					sql = `DELETE FROM ${target.table} WHERE bucket_id IN (
 						SELECT id FROM ${target.parentTable} WHERE user_id = ?
@@ -927,7 +953,10 @@ async function deleteUserScopedRows(input: {
 			const result = await input.env.APP_DB.prepare(sql)
 				.bind(...params)
 				.run()
-			if (target.kind === 'null_user_column') {
+			if (
+				target.kind === 'null_user_column' ||
+				target.kind === 'replace_user_column'
+			) {
 				recordUpdated(tableName, result.meta.changes)
 			} else {
 				recordDeleted(tableName, result.meta.changes)
@@ -939,7 +968,10 @@ async function deleteUserScopedRows(input: {
 					? 'mcp_memory_conversation_suppressions'
 					: target.table
 			input.warnings.push(`Failed to delete from ${targetLabel}: ${message}`)
-			if (target.kind === 'null_user_column') {
+			if (
+				target.kind === 'null_user_column' ||
+				target.kind === 'replace_user_column'
+			) {
 				recordUpdated(targetLabel, 0)
 			} else {
 				recordDeleted(targetLabel, 0)

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -590,6 +590,11 @@ async function purgeJobManager(input: {
 			env: input.env,
 			userId: input.userId,
 		})
+		if (!result.purged) {
+			input.warnings.push(
+				'JOB_MANAGER binding was unavailable; the user scheduler Durable Object was not purged.',
+			)
+		}
 		return result.purged ? 1 : 0
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -1,9 +1,23 @@
 import { storageRunnerRpc } from '#worker/storage-runner.ts'
+import { purgeJobManagerForUser } from '#worker/jobs/manager-client.ts'
 import { jobVectorId } from '#mcp/jobs-vectorize.ts'
 import { memoryVectorId } from '#mcp/memory/memory-vectorize.ts'
 import { savedPackageVectorId } from '#worker/package-registry/repo.ts'
 import { getCapabilityVectorIndex } from '#mcp/capabilities/capability-search.ts'
 import { cleanupAllUserArtifactRepos } from '#worker/repo/artifact-repo-cleanup.ts'
+import { repoSessionRpc } from '#worker/repo/repo-session-rpc.ts'
+import { userScopedConnectorSessionKey } from '#worker/remote-connector/connector-session-key.ts'
+import {
+	buildPackageServiceStorageId,
+	packageServiceRpc,
+} from '#worker/package-runtime/package-service.ts'
+import { packageRealtimeSessionRpc } from '#worker/package-runtime/realtime-session.ts'
+import {
+	buildPublishedSourceManifestSnapshotKvKey,
+	buildPublishedSourceSnapshotKvKey,
+} from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { deleteAllPackageRetrieverCacheEntriesForUser } from '#worker/package-retrievers/manifest-cache.ts'
+import { buildCommunitySnapshotKvKey } from '#worker/community/snapshot.ts'
 
 // Imported manually instead of via `@cloudflare/workers-oauth-provider` so
 // node-only unit tests can require this module without dragging in
@@ -38,8 +52,10 @@ export type AccountDeletionResult = {
 type UserScopedDeleteTarget =
 	| { kind: 'user_id'; table: string }
 	| { kind: 'db_user_id'; table: string }
+	| { kind: 'user_columns'; table: string; columns: ReadonlyArray<string> }
 	| { kind: 'bucket_parent'; table: string; parentTable: string }
 	| { kind: 'attachment_parent'; table: string }
+	| { kind: 'community_listing_child'; table: string; listingColumn: string }
 	| { kind: 'mcp_memory_suppression' }
 
 /**
@@ -57,6 +73,8 @@ const userScopedTables: ReadonlyArray<UserScopedDeleteTarget> = [
 	{ kind: 'user_id', table: 'package_invocations' },
 	{ kind: 'user_id', table: 'package_invocation_tokens' },
 	{ kind: 'user_id', table: 'workflow_runs' },
+	{ kind: 'user_id', table: 'package_runtime_logs' },
+	{ kind: 'user_id', table: 'package_runtime_runs' },
 	{ kind: 'mcp_memory_suppression' },
 	{ kind: 'user_id', table: 'mcp_memories' },
 	{ kind: 'user_id', table: 'mcp_user_server_instructions' },
@@ -86,13 +104,138 @@ const userScopedTables: ReadonlyArray<UserScopedDeleteTarget> = [
 	{ kind: 'user_id', table: 'email_inbox_addresses' },
 	{ kind: 'user_id', table: 'email_inboxes' },
 	{ kind: 'user_id', table: 'email_sender_identities' },
-	{ kind: 'user_id', table: 'chat_threads' },
+	{
+		kind: 'community_listing_child',
+		table: 'community_ratings',
+		listingColumn: 'listing_id',
+	},
+	{ kind: 'user_id', table: 'community_ratings' },
+	{
+		kind: 'community_listing_child',
+		table: 'community_forks',
+		listingColumn: 'listing_id',
+	},
+	{
+		kind: 'user_columns',
+		table: 'community_forks',
+		columns: ['forker_user_id'],
+	},
+	{
+		kind: 'community_listing_child',
+		table: 'community_reports',
+		listingColumn: 'listing_id',
+	},
+	{
+		kind: 'user_columns',
+		table: 'community_reports',
+		columns: [
+			'listing_owner_user_id',
+			'reporter_user_id',
+			'resolved_by_user_id',
+		],
+	},
+	{
+		kind: 'user_columns',
+		table: 'community_bans',
+		columns: ['user_id', 'banned_by_user_id'],
+	},
+	{
+		kind: 'user_columns',
+		table: 'community_listings',
+		columns: ['owner_user_id'],
+	},
 	// password_resets.user_id is an INTEGER FK to users.id (predates the
 	// stable mcp string user id), so it must be cleared with the database
 	// integer id rather than the mcp user id.
 	{ kind: 'db_user_id', table: 'password_resets' },
 	{ kind: 'db_user_id', table: 'user_roles' },
 ]
+
+export function getAccountDeletionD1UserColumnCoverage() {
+	const covered = new Set<string>()
+	for (const target of userScopedTables) {
+		switch (target.kind) {
+			case 'user_id':
+			case 'db_user_id':
+			case 'mcp_memory_suppression': {
+				const table =
+					target.kind === 'mcp_memory_suppression'
+						? 'mcp_memory_conversation_suppressions'
+						: target.table
+				covered.add(`${table}.user_id`)
+				break
+			}
+			case 'user_columns': {
+				for (const column of target.columns) {
+					covered.add(`${target.table}.${column}`)
+				}
+				break
+			}
+			case 'bucket_parent':
+			case 'attachment_parent':
+			case 'community_listing_child': {
+				break
+			}
+			default: {
+				const exhaustive: never = target
+				throw new Error(
+					`Unhandled account deletion coverage target: ${JSON.stringify(exhaustive)}`,
+				)
+			}
+		}
+	}
+	return covered
+}
+
+type UserSourceSnapshot = {
+	sourceId: string
+	publishedCommit: string | null
+}
+
+type UserSavedPackageSnapshot = {
+	id: string
+	kodyId: string
+	sourceId: string
+	hasApp: boolean
+}
+
+type UserRepoSessionSnapshot = {
+	id: string
+}
+
+type UserRemoteConnectorSnapshot = {
+	kind: string
+	instanceId: string
+}
+
+type UserPackageServiceSnapshot = {
+	packageId: string
+	kodyId: string
+	sourceId: string
+	serviceName: string
+}
+
+type UserDeletionInventory = {
+	vectorIds: Array<string>
+	storageIds: Array<string>
+	bundleKvKeys: Array<string>
+	sourceSnapshots: Array<UserSourceSnapshot>
+	savedPackages: Array<UserSavedPackageSnapshot>
+	repoSessions: Array<UserRepoSessionSnapshot>
+	remoteConnectors: Array<UserRemoteConnectorSnapshot>
+	packageServices: Array<UserPackageServiceSnapshot>
+	communityListingIds: Array<string>
+}
+
+function uniqueStrings(values: Iterable<string | null | undefined>) {
+	return Array.from(
+		new Set(
+			Array.from(values)
+				.map((value) => value?.trim() ?? '')
+				.filter((value) => value.length > 0),
+		),
+	)
+}
 
 async function listUserVectorIds(env: Env, userId: string) {
 	const memoryRows = await env.APP_DB.prepare(
@@ -124,39 +267,253 @@ async function listUserVectorIds(env: Env, userId: string) {
 }
 
 async function listUserStorageIds(env: Env, userId: string) {
-	const jobRows = await env.APP_DB.prepare(
-		`SELECT storage_id FROM jobs WHERE user_id = ? AND storage_id IS NOT NULL`,
-	)
-		.bind(userId)
-		.all<{ storage_id: string }>()
-	return Array.from(
-		new Set(
-			(jobRows.results ?? [])
-				.map((row) => row.storage_id)
-				.filter((id): id is string => Boolean(id)),
+	const [jobRows, archivedRows, runtimeRows, packageRows, serviceRows] =
+		await Promise.all([
+			env.APP_DB.prepare(
+				`SELECT storage_id FROM jobs WHERE user_id = ? AND storage_id IS NOT NULL`,
+			)
+				.bind(userId)
+				.all<{ storage_id: string }>(),
+			env.APP_DB.prepare(
+				`SELECT storage_id FROM archived_job_artifacts WHERE user_id = ? AND storage_id IS NOT NULL`,
+			)
+				.bind(userId)
+				.all<{ storage_id: string }>(),
+			env.APP_DB.prepare(
+				`SELECT storage_id FROM package_runtime_runs WHERE user_id = ? AND storage_id IS NOT NULL`,
+			)
+				.bind(userId)
+				.all<{ storage_id: string }>(),
+			env.APP_DB.prepare(
+				`SELECT id FROM saved_packages WHERE user_id = ? AND has_app = 1`,
+			)
+				.bind(userId)
+				.all<{ id: string }>(),
+			env.APP_DB.prepare(
+				`SELECT DISTINCT package_id, name
+				FROM package_runtime_runs
+				WHERE user_id = ? AND surface = 'service' AND name IS NOT NULL`,
+			)
+				.bind(userId)
+				.all<{ package_id: string; name: string }>(),
+		])
+	return uniqueStrings([
+		...(jobRows.results ?? []).map((row) => row.storage_id),
+		...(archivedRows.results ?? []).map((row) => row.storage_id),
+		...(runtimeRows.results ?? []).map((row) => row.storage_id),
+		...(packageRows.results ?? []).map((row) => row.id),
+		...(serviceRows.results ?? []).map((row) =>
+			buildPackageServiceStorageId(row.package_id, row.name),
 		),
-	)
+	])
 }
 
-async function listUserBundleKvKeys(env: Env, userId: string) {
-	const published = await env.APP_DB.prepare(
+async function listUserSourceSnapshots(env: Env, userId: string) {
+	const sourceRows = await env.APP_DB.prepare(
+		`SELECT id, published_commit
+		FROM entity_sources
+		WHERE user_id = ?`,
+	)
+		.bind(userId)
+		.all<{ id: string; published_commit: string | null }>()
+	return (sourceRows.results ?? []).map((row) => ({
+		sourceId: row.id,
+		publishedCommit: row.published_commit,
+	}))
+}
+
+async function listUserSavedPackages(env: Env, userId: string) {
+	const rows = await env.APP_DB.prepare(
+		`SELECT id, kody_id, source_id, has_app
+		FROM saved_packages
+		WHERE user_id = ?`,
+	)
+		.bind(userId)
+		.all<{
+			id: string
+			kody_id: string
+			source_id: string
+			has_app: number | string | boolean
+		}>()
+	return (rows.results ?? []).map((row) => ({
+		id: row.id,
+		kodyId: row.kody_id,
+		sourceId: row.source_id,
+		hasApp: row.has_app === 1 || row.has_app === '1' || row.has_app === true,
+	}))
+}
+
+async function listUserRepoSessions(env: Env, userId: string) {
+	const rows = await env.APP_DB.prepare(
+		`SELECT id FROM repo_sessions WHERE user_id = ?`,
+	)
+		.bind(userId)
+		.all<{ id: string }>()
+	return (rows.results ?? []).map((row) => ({ id: row.id }))
+}
+
+async function listUserRemoteConnectors(env: Env, userId: string) {
+	const rows = await env.APP_DB.prepare(
+		`SELECT kind, instance_id
+		FROM remote_connector_settings
+		WHERE user_id = ?`,
+	)
+		.bind(userId)
+		.all<{ kind: string; instance_id: string }>()
+	return (rows.results ?? []).map((row) => ({
+		kind: row.kind,
+		instanceId: row.instance_id,
+	}))
+}
+
+async function listUserPackageServices(env: Env, userId: string) {
+	const rows = await env.APP_DB.prepare(
+		`SELECT DISTINCT
+			r.package_id,
+			COALESCE(p.kody_id, r.package_kody_id) AS kody_id,
+			COALESCE(p.source_id, r.source_id) AS source_id,
+			r.name
+		FROM package_runtime_runs AS r
+		LEFT JOIN saved_packages AS p
+			ON p.id = r.package_id AND p.user_id = r.user_id
+		WHERE r.user_id = ?
+			AND r.surface = 'service'
+			AND r.name IS NOT NULL`,
+	)
+		.bind(userId)
+		.all<{
+			package_id: string
+			kody_id: string
+			source_id: string | null
+			name: string
+		}>()
+	return (rows.results ?? [])
+		.filter((row) => row.source_id != null)
+		.map((row) => ({
+			packageId: row.package_id,
+			kodyId: row.kody_id,
+			sourceId: row.source_id ?? '',
+			serviceName: row.name,
+		}))
+}
+
+async function listUserCommunityListingIds(env: Env, userId: string) {
+	const rows = await env.APP_DB.prepare(
+		`SELECT id FROM community_listings WHERE owner_user_id = ?`,
+	)
+		.bind(userId)
+		.all<{ id: string }>()
+	return uniqueStrings((rows.results ?? []).map((row) => row.id))
+}
+
+async function listUserBundleKvKeys(input: {
+	env: Env
+	userId: string
+	sourceSnapshots: ReadonlyArray<UserSourceSnapshot>
+	communityListingIds: ReadonlyArray<string>
+}) {
+	const published = await input.env.APP_DB.prepare(
 		`SELECT kv_key FROM published_bundle_artifacts WHERE user_id = ?`,
 	)
-		.bind(userId)
+		.bind(input.userId)
 		.all<{ kv_key: string }>()
-	const archived = await env.APP_DB.prepare(
-		`SELECT kv_key FROM archived_job_artifacts WHERE user_id = ?`,
-	)
-		.bind(userId)
-		.all<{ kv_key: string }>()
-	const keys = new Set<string>()
-	for (const row of published.results ?? []) {
-		if (row.kv_key) keys.add(row.kv_key)
+	return uniqueStrings([
+		...(published.results ?? []).map((row) => row.kv_key),
+		...input.sourceSnapshots.flatMap((source) =>
+			source.publishedCommit
+				? [
+						buildPublishedSourceSnapshotKvKey({
+							sourceId: source.sourceId,
+							publishedCommit: source.publishedCommit,
+						}),
+						buildPublishedSourceManifestSnapshotKvKey({
+							sourceId: source.sourceId,
+							publishedCommit: source.publishedCommit,
+						}),
+					]
+				: [],
+		),
+		...input.communityListingIds.map(buildCommunitySnapshotKvKey),
+	])
+}
+
+async function collectUserDeletionInventory(input: {
+	env: Env
+	userId: string
+	warnings: Array<string>
+}): Promise<UserDeletionInventory> {
+	const [
+		vectorIds,
+		storageIds,
+		sourceSnapshots,
+		savedPackages,
+		repoSessions,
+		remoteConnectors,
+		packageServices,
+		communityListingIds,
+	] = await Promise.all([
+		listUserVectorIds(input.env, input.userId).catch((error) => {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(`Failed to enumerate vector ids: ${message}`)
+			return [] as Array<string>
+		}),
+		listUserStorageIds(input.env, input.userId).catch((error) => {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(`Failed to enumerate storage ids: ${message}`)
+			return [] as Array<string>
+		}),
+		listUserSourceSnapshots(input.env, input.userId).catch((error) => {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(`Failed to enumerate source snapshots: ${message}`)
+			return [] as Array<UserSourceSnapshot>
+		}),
+		listUserSavedPackages(input.env, input.userId).catch((error) => {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(`Failed to enumerate saved packages: ${message}`)
+			return [] as Array<UserSavedPackageSnapshot>
+		}),
+		listUserRepoSessions(input.env, input.userId).catch((error) => {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(`Failed to enumerate repo sessions: ${message}`)
+			return [] as Array<UserRepoSessionSnapshot>
+		}),
+		listUserRemoteConnectors(input.env, input.userId).catch((error) => {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(`Failed to enumerate remote connectors: ${message}`)
+			return [] as Array<UserRemoteConnectorSnapshot>
+		}),
+		listUserPackageServices(input.env, input.userId).catch((error) => {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(`Failed to enumerate package services: ${message}`)
+			return [] as Array<UserPackageServiceSnapshot>
+		}),
+		listUserCommunityListingIds(input.env, input.userId).catch((error) => {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(`Failed to enumerate community listings: ${message}`)
+			return [] as Array<string>
+		}),
+	])
+	const bundleKvKeys = await listUserBundleKvKeys({
+		env: input.env,
+		userId: input.userId,
+		sourceSnapshots,
+		communityListingIds,
+	}).catch((error) => {
+		const message = error instanceof Error ? error.message : String(error)
+		input.warnings.push(`Failed to enumerate bundle KV keys: ${message}`)
+		return [] as Array<string>
+	})
+	return {
+		vectorIds,
+		storageIds,
+		bundleKvKeys,
+		sourceSnapshots,
+		savedPackages,
+		repoSessions,
+		remoteConnectors,
+		packageServices,
+		communityListingIds,
 	}
-	for (const row of archived.results ?? []) {
-		if (row.kv_key) keys.add(row.kv_key)
-	}
-	return Array.from(keys)
 }
 
 async function revokeAllOAuthGrants(input: {
@@ -223,6 +580,153 @@ async function clearStorageRunners(input: {
 	return cleared
 }
 
+async function purgeJobManager(input: {
+	env: Env
+	userId: string
+	warnings: Array<string>
+}): Promise<number> {
+	try {
+		const result = await purgeJobManagerForUser({
+			env: input.env,
+			userId: input.userId,
+		})
+		return result.purged ? 1 : 0
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		input.warnings.push(`Job manager purge failed: ${message}`)
+		return 0
+	}
+}
+
+async function purgeRepoSessions(input: {
+	env: Env
+	userId: string
+	sessions: ReadonlyArray<UserRepoSessionSnapshot>
+	warnings: Array<string>
+}): Promise<number> {
+	let purged = 0
+	for (const session of input.sessions) {
+		try {
+			await repoSessionRpc(input.env, session.id).purgeSession({
+				sessionId: session.id,
+				userId: input.userId,
+			})
+			purged += 1
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(
+				`Repo session purge failed for ${session.id}: ${message}`,
+			)
+		}
+	}
+	return purged
+}
+
+async function purgeRemoteConnectorSessions(input: {
+	env: Env
+	userId: string
+	connectors: ReadonlyArray<UserRemoteConnectorSnapshot>
+	warnings: Array<string>
+}): Promise<number> {
+	const namespace = input.env.REMOTE_CONNECTOR_SESSION
+	if (!namespace) {
+		if (input.connectors.length > 0) {
+			input.warnings.push(
+				`REMOTE_CONNECTOR_SESSION binding was unavailable; ${input.connectors.length} connector session(s) were not purged.`,
+			)
+		}
+		return 0
+	}
+	let purged = 0
+	for (const connector of input.connectors) {
+		const sessionKey = userScopedConnectorSessionKey({
+			userId: input.userId,
+			kind: connector.kind,
+			instanceId: connector.instanceId,
+		})
+		try {
+			const stub = namespace.get(
+				namespace.idFromName(sessionKey),
+			) as unknown as {
+				rpcPurgeUserSession: (payload: {
+					userId: string
+					kind: string
+					instanceId: string
+				}) => Promise<{ ok: true }>
+			}
+			await stub.rpcPurgeUserSession({
+				userId: input.userId,
+				kind: connector.kind,
+				instanceId: connector.instanceId,
+			})
+			purged += 1
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(
+				`Remote connector session purge failed for ${connector.kind}/${connector.instanceId}: ${message}`,
+			)
+		}
+	}
+	return purged
+}
+
+async function purgePackageRealtimeSessions(input: {
+	env: Env
+	userId: string
+	packages: ReadonlyArray<UserSavedPackageSnapshot>
+	warnings: Array<string>
+}): Promise<number> {
+	let purged = 0
+	for (const savedPackage of input.packages.filter((pkg) => pkg.hasApp)) {
+		try {
+			await packageRealtimeSessionRpc({
+				env: input.env,
+				userId: input.userId,
+				packageId: savedPackage.id,
+				kodyId: savedPackage.kodyId,
+				sourceId: savedPackage.sourceId,
+				baseUrl: 'https://account-deletion.invalid',
+			}).purge()
+			purged += 1
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(
+				`Package realtime session purge failed for ${savedPackage.id}: ${message}`,
+			)
+		}
+	}
+	return purged
+}
+
+async function purgePackageServices(input: {
+	env: Env
+	userId: string
+	services: ReadonlyArray<UserPackageServiceSnapshot>
+	warnings: Array<string>
+}): Promise<number> {
+	let purged = 0
+	for (const service of input.services) {
+		try {
+			await packageServiceRpc({
+				env: input.env,
+				userId: input.userId,
+				packageId: service.packageId,
+				kodyId: service.kodyId,
+				sourceId: service.sourceId,
+				baseUrl: 'https://account-deletion.invalid',
+				serviceName: service.serviceName,
+			}).purge()
+			purged += 1
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			input.warnings.push(
+				`Package service purge failed for ${service.packageId}/${service.serviceName}: ${message}`,
+			)
+		}
+	}
+	return purged
+}
+
 async function deleteVectorsByIds(input: {
 	env: Env
 	ids: ReadonlyArray<string>
@@ -264,6 +768,56 @@ async function deleteKvKeys(input: {
 	return deleted
 }
 
+async function listKvKeysByPrefix(input: {
+	kv: KVNamespace
+	prefixes: ReadonlyArray<string>
+	warnings: Array<string>
+}) {
+	const keys = new Set<string>()
+	if (typeof input.kv.list !== 'function') return keys
+	for (const prefix of input.prefixes) {
+		let cursor: string | undefined
+		do {
+			try {
+				const result = await input.kv.list({
+					prefix,
+					cursor,
+				})
+				for (const key of result.keys) {
+					keys.add(key.name)
+				}
+				cursor = result.list_complete ? undefined : result.cursor
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error)
+				input.warnings.push(
+					`KV prefix listing failed for ${prefix}: ${message}`,
+				)
+				cursor = undefined
+			}
+		} while (cursor)
+	}
+	return keys
+}
+
+async function deleteRetrieverCache(input: {
+	env: Env
+	userId: string
+	packageIds: ReadonlyArray<string>
+	warnings: Array<string>
+}) {
+	try {
+		return await deleteAllPackageRetrieverCacheEntriesForUser({
+			env: input.env,
+			userId: input.userId,
+			packageIds: input.packageIds,
+		})
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		input.warnings.push(`Package retriever KV cleanup failed: ${message}`)
+		return 0
+	}
+}
+
 async function deleteUserScopedRows(input: {
 	env: Env
 	mcpUserId: string
@@ -271,6 +825,9 @@ async function deleteUserScopedRows(input: {
 	warnings: Array<string>
 }): Promise<Record<string, number>> {
 	const counts: Record<string, number> = {}
+	function recordCount(tableName: string, changes: number | undefined) {
+		counts[tableName] = (counts[tableName] ?? 0) + (changes ?? 0)
+	}
 	for (const target of userScopedTables) {
 		try {
 			let sql: string
@@ -286,6 +843,14 @@ async function deleteUserScopedRows(input: {
 				case 'db_user_id': {
 					sql = `DELETE FROM ${target.table} WHERE user_id = ?`
 					params = [input.dbUserId]
+					tableName = target.table
+					break
+				}
+				case 'user_columns': {
+					sql = `DELETE FROM ${target.table} WHERE ${target.columns
+						.map((column) => `${column} = ?`)
+						.join(' OR ')}`
+					params = target.columns.map(() => input.mcpUserId)
 					tableName = target.table
 					break
 				}
@@ -305,6 +870,14 @@ async function deleteUserScopedRows(input: {
 					tableName = 'email_attachments'
 					break
 				}
+				case 'community_listing_child': {
+					sql = `DELETE FROM ${target.table} WHERE ${target.listingColumn} IN (
+						SELECT id FROM community_listings WHERE owner_user_id = ?
+					)`
+					params = [input.mcpUserId]
+					tableName = target.table
+					break
+				}
 				case 'mcp_memory_suppression': {
 					sql = `DELETE FROM mcp_memory_conversation_suppressions WHERE user_id = ?`
 					params = [input.mcpUserId]
@@ -321,7 +894,7 @@ async function deleteUserScopedRows(input: {
 			const result = await input.env.APP_DB.prepare(sql)
 				.bind(...params)
 				.run()
-			counts[tableName] = result.meta.changes ?? 0
+			recordCount(tableName, result.meta.changes)
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
 			const targetLabel =
@@ -329,7 +902,7 @@ async function deleteUserScopedRows(input: {
 					? 'mcp_memory_conversation_suppressions'
 					: target.table
 			input.warnings.push(`Failed to delete from ${targetLabel}: ${message}`)
-			counts[targetLabel] = 0
+			recordCount(targetLabel, 0)
 		}
 	}
 	return counts
@@ -360,11 +933,11 @@ async function deleteUserRow(input: {
  * not re-authenticate.
  *
  * The cleanup ordering is:
- *   1. Pre-collect identifiers we need (vector ids, storage ids, KV keys)
- *      while their owning rows still exist.
+ *   1. Pre-collect identifiers we need (vector ids, storage ids, KV keys,
+ *      repo/session/package ids) while their owning rows still exist.
  *   2. Best-effort destructive cleanup of out-of-band stores (Vectorize,
- *      KV, durable storage) - each batch records a warning on failure but
- *      does not abort the cascade.
+ *      Artifacts repos, Durable Objects, KV) - each batch records a warning on
+ *      failure but does not abort the cascade.
  *   3. Delete user-scoped D1 rows in dependency-safe order.
  *   4. Revoke OAuth grants and delete the user's row last so a partially
  *      failed run can be retried with the same email.
@@ -385,27 +958,15 @@ export async function deleteUserAccount(input: {
 		warnings,
 	}
 
-	const [vectorIds, storageIds, bundleKvKeys] = await Promise.all([
-		listUserVectorIds(input.env, input.mcpUserId).catch((error) => {
-			const message = error instanceof Error ? error.message : String(error)
-			warnings.push(`Failed to enumerate vector ids: ${message}`)
-			return [] as Array<string>
-		}),
-		listUserStorageIds(input.env, input.mcpUserId).catch((error) => {
-			const message = error instanceof Error ? error.message : String(error)
-			warnings.push(`Failed to enumerate storage ids: ${message}`)
-			return [] as Array<string>
-		}),
-		listUserBundleKvKeys(input.env, input.mcpUserId).catch((error) => {
-			const message = error instanceof Error ? error.message : String(error)
-			warnings.push(`Failed to enumerate bundle KV keys: ${message}`)
-			return [] as Array<string>
-		}),
-	])
+	const inventory = await collectUserDeletionInventory({
+		env: input.env,
+		userId: input.mcpUserId,
+		warnings,
+	})
 
 	result.deletedVectors = await deleteVectorsByIds({
 		env: input.env,
-		ids: vectorIds,
+		ids: inventory.vectorIds,
 		warnings,
 	})
 
@@ -419,27 +980,74 @@ export async function deleteUserAccount(input: {
 		return 0
 	})
 
+	result.clearedDurableObjects.jobManagers = await purgeJobManager({
+		env: input.env,
+		userId: input.mcpUserId,
+		warnings,
+	})
+	result.clearedDurableObjects.repoSessions = await purgeRepoSessions({
+		env: input.env,
+		userId: input.mcpUserId,
+		sessions: inventory.repoSessions,
+		warnings,
+	})
+	result.clearedDurableObjects.remoteConnectorSessions =
+		await purgeRemoteConnectorSessions({
+			env: input.env,
+			userId: input.mcpUserId,
+			connectors: inventory.remoteConnectors,
+			warnings,
+		})
+	result.clearedDurableObjects.packageRealtimeSessions =
+		await purgePackageRealtimeSessions({
+			env: input.env,
+			userId: input.mcpUserId,
+			packages: inventory.savedPackages,
+			warnings,
+		})
+	result.clearedDurableObjects.packageServiceInstances =
+		await purgePackageServices({
+			env: input.env,
+			userId: input.mcpUserId,
+			services: inventory.packageServices,
+			warnings,
+		})
 	result.clearedDurableObjects.storageRunners = await clearStorageRunners({
 		env: input.env,
 		userId: input.mcpUserId,
-		storageIds,
+		storageIds: inventory.storageIds,
 		warnings,
 	})
 
 	if (input.env.BUNDLE_ARTIFACTS_KV) {
-		result.deletedKvKeys = await deleteKvKeys({
+		const sourceSnapshotKeys = await listKvKeysByPrefix({
 			kv: input.env.BUNDLE_ARTIFACTS_KV,
-			keys: bundleKvKeys,
+			prefixes: inventory.sourceSnapshots.flatMap((source) => [
+				`source-snapshot:v1:${source.sourceId}:`,
+				`source-manifest-snapshot:v1:${source.sourceId}:`,
+			]),
 			warnings,
 		})
-	} else if (bundleKvKeys.length > 0) {
-		// We collected keys from D1 (published_bundle_artifacts /
-		// archived_job_artifacts) but the KV binding is missing, so
-		// deleteUserScopedRows below would drop the D1 rows without
-		// reaping the underlying KV entries. Surface that as a warning
-		// so the operator knows the KV namespace needs a manual sweep.
+		result.deletedKvKeys =
+			(await deleteKvKeys({
+				kv: input.env.BUNDLE_ARTIFACTS_KV,
+				keys: Array.from(
+					new Set([...inventory.bundleKvKeys, ...sourceSnapshotKeys]),
+				),
+				warnings,
+			})) +
+			(await deleteRetrieverCache({
+				env: input.env,
+				userId: input.mcpUserId,
+				packageIds: inventory.savedPackages.map((pkg) => pkg.id),
+				warnings,
+			}))
+	} else if (
+		inventory.bundleKvKeys.length > 0 ||
+		inventory.savedPackages.length > 0
+	) {
 		warnings.push(
-			`BUNDLE_ARTIFACTS_KV binding was unavailable; ${bundleKvKeys.length} bundle artifact key(s) referenced by the deleted user were not removed and must be cleaned up manually.`,
+			`BUNDLE_ARTIFACTS_KV binding was unavailable; ${inventory.bundleKvKeys.length} bundle/source/community key(s) and retriever cache entries for ${inventory.savedPackages.length} package(s) referenced by the deleted user were not removed and must be cleaned up manually.`,
 		)
 	}
 

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -41,6 +41,7 @@ type AccountDeletionEnv = Env & {
 
 export type AccountDeletionResult = {
 	deletedRowCounts: Record<string, number>
+	updatedRowCounts: Record<string, number>
 	deletedKvKeys: number
 	deletedArtifactRepos: number
 	revokedOAuthGrants: number
@@ -53,6 +54,12 @@ type UserScopedDeleteTarget =
 	| { kind: 'user_id'; table: string }
 	| { kind: 'db_user_id'; table: string }
 	| { kind: 'user_columns'; table: string; columns: ReadonlyArray<string> }
+	| {
+			kind: 'null_user_column'
+			table: string
+			matchColumn: string
+			nullColumns: ReadonlyArray<string>
+	  }
 	| { kind: 'bucket_parent'; table: string; parentTable: string }
 	| { kind: 'attachment_parent'; table: string }
 	| { kind: 'community_listing_child'; table: string; listingColumn: string }
@@ -128,11 +135,13 @@ const userScopedTables: ReadonlyArray<UserScopedDeleteTarget> = [
 	{
 		kind: 'user_columns',
 		table: 'community_reports',
-		columns: [
-			'listing_owner_user_id',
-			'reporter_user_id',
-			'resolved_by_user_id',
-		],
+		columns: ['listing_owner_user_id', 'reporter_user_id'],
+	},
+	{
+		kind: 'null_user_column',
+		table: 'community_reports',
+		matchColumn: 'resolved_by_user_id',
+		nullColumns: ['resolved_by_user_id', 'resolved_at', 'resolution_note'],
 	},
 	{
 		kind: 'user_columns',
@@ -169,6 +178,10 @@ export function getAccountDeletionD1UserColumnCoverage() {
 				for (const column of target.columns) {
 					covered.add(`${target.table}.${column}`)
 				}
+				break
+			}
+			case 'null_user_column': {
+				covered.add(`${target.table}.${target.matchColumn}`)
 				break
 			}
 			case 'bucket_parent':
@@ -387,14 +400,12 @@ async function listUserPackageServices(env: Env, userId: string) {
 			source_id: string | null
 			name: string
 		}>()
-	return (rows.results ?? [])
-		.filter((row) => row.source_id != null)
-		.map((row) => ({
-			packageId: row.package_id,
-			kodyId: row.kody_id,
-			sourceId: row.source_id ?? '',
-			serviceName: row.name,
-		}))
+	return (rows.results ?? []).map((row) => ({
+		packageId: row.package_id,
+		kodyId: row.kody_id,
+		sourceId: row.source_id ?? '',
+		serviceName: row.name,
+	}))
 }
 
 async function listUserCommunityListingIds(env: Env, userId: string) {
@@ -828,10 +839,19 @@ async function deleteUserScopedRows(input: {
 	mcpUserId: string
 	dbUserId: number
 	warnings: Array<string>
-}): Promise<Record<string, number>> {
-	const counts: Record<string, number> = {}
-	function recordCount(tableName: string, changes: number | undefined) {
-		counts[tableName] = (counts[tableName] ?? 0) + (changes ?? 0)
+}): Promise<{
+	deletedRowCounts: Record<string, number>
+	updatedRowCounts: Record<string, number>
+}> {
+	const deletedRowCounts: Record<string, number> = {}
+	const updatedRowCounts: Record<string, number> = {}
+	function recordDeleted(tableName: string, changes: number | undefined) {
+		deletedRowCounts[tableName] =
+			(deletedRowCounts[tableName] ?? 0) + (changes ?? 0)
+	}
+	function recordUpdated(tableName: string, changes: number | undefined) {
+		updatedRowCounts[tableName] =
+			(updatedRowCounts[tableName] ?? 0) + (changes ?? 0)
 	}
 	for (const target of userScopedTables) {
 		try {
@@ -856,6 +876,14 @@ async function deleteUserScopedRows(input: {
 						.map((column) => `${column} = ?`)
 						.join(' OR ')}`
 					params = target.columns.map(() => input.mcpUserId)
+					tableName = target.table
+					break
+				}
+				case 'null_user_column': {
+					sql = `UPDATE ${target.table}
+						SET ${target.nullColumns.map((column) => `${column} = NULL`).join(', ')}
+						WHERE ${target.matchColumn} = ?`
+					params = [input.mcpUserId]
 					tableName = target.table
 					break
 				}
@@ -899,7 +927,11 @@ async function deleteUserScopedRows(input: {
 			const result = await input.env.APP_DB.prepare(sql)
 				.bind(...params)
 				.run()
-			recordCount(tableName, result.meta.changes)
+			if (target.kind === 'null_user_column') {
+				recordUpdated(tableName, result.meta.changes)
+			} else {
+				recordDeleted(tableName, result.meta.changes)
+			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
 			const targetLabel =
@@ -907,10 +939,14 @@ async function deleteUserScopedRows(input: {
 					? 'mcp_memory_conversation_suppressions'
 					: target.table
 			input.warnings.push(`Failed to delete from ${targetLabel}: ${message}`)
-			recordCount(targetLabel, 0)
+			if (target.kind === 'null_user_column') {
+				recordUpdated(targetLabel, 0)
+			} else {
+				recordDeleted(targetLabel, 0)
+			}
 		}
 	}
-	return counts
+	return { deletedRowCounts, updatedRowCounts }
 }
 
 async function deleteUserRow(input: {
@@ -955,6 +991,7 @@ export async function deleteUserAccount(input: {
 	const warnings: Array<string> = []
 	const result: AccountDeletionResult = {
 		deletedRowCounts: {},
+		updatedRowCounts: {},
 		deletedKvKeys: 0,
 		deletedArtifactRepos: 0,
 		revokedOAuthGrants: 0,
@@ -1056,12 +1093,14 @@ export async function deleteUserAccount(input: {
 		)
 	}
 
-	result.deletedRowCounts = await deleteUserScopedRows({
+	const d1Cleanup = await deleteUserScopedRows({
 		env: input.env,
 		mcpUserId: input.mcpUserId,
 		dbUserId: input.dbUserId,
 		warnings,
 	})
+	result.deletedRowCounts = d1Cleanup.deletedRowCounts
+	result.updatedRowCounts = d1Cleanup.updatedRowCounts
 
 	const helpers = input.env.OAUTH_PROVIDER
 	if (helpers) {

--- a/packages/worker/src/jobs/manager-client.ts
+++ b/packages/worker/src/jobs/manager-client.ts
@@ -27,6 +27,10 @@ export type JobManagerDebugState = {
 }
 
 type JobManagerRpc = {
+	purgeUser: (payload: { userId: string }) => Promise<{
+		ok: true
+		userId: string
+	}>
 	syncAlarm: (payload: {
 		userId: string
 		source?: 'alarm' | 'rpc' | 'run_now'
@@ -54,6 +58,26 @@ export function jobManagerRpc(env: Env, userId: string): JobManagerRpc | null {
 		return null
 	}
 	return namespace.get(namespace.idFromName(userId)) as unknown as JobManagerRpc
+}
+
+export async function purgeJobManagerForUser(input: {
+	env: Env
+	userId: string
+}) {
+	const rpc = jobManagerRpc(input.env, input.userId)
+	if (!rpc) {
+		return {
+			ok: true as const,
+			userId: input.userId,
+			purged: false,
+		}
+	}
+	await rpc.purgeUser({ userId: input.userId })
+	return {
+		ok: true as const,
+		userId: input.userId,
+		purged: true,
+	}
 }
 
 export async function syncJobManagerAlarm(input: { env: Env; userId: string }) {

--- a/packages/worker/src/jobs/manager-do.ts
+++ b/packages/worker/src/jobs/manager-do.ts
@@ -16,6 +16,26 @@ import { type JobManagerDebugState } from './manager-client.ts'
 const userIdStorageKey = 'user-id'
 
 export class JobManagerBase extends DurableObject<Env> {
+	async purgeUser(input: { userId: string }) {
+		const userId = input.userId.trim()
+		if (!userId) {
+			throw new Error('Job manager requires a non-empty userId.')
+		}
+		await this.ctx.storage.deleteAlarm().catch(() => {
+			// Best effort: deleteAll below still removes persisted scheduler state.
+		})
+		await this.ctx.storage.deleteAll()
+		logJobSchedulerEvent({
+			event: 'purge_user',
+			userId,
+			reason: 'account_deletion',
+		})
+		return {
+			ok: true as const,
+			userId,
+		}
+	}
+
 	async syncAlarm(input: {
 		userId: string
 		source?: 'alarm' | 'rpc' | 'run_now'

--- a/packages/worker/src/package-retrievers/manifest-cache.ts
+++ b/packages/worker/src/package-retrievers/manifest-cache.ts
@@ -475,6 +475,51 @@ export async function removePackageRetrieverManifestCacheEntries(input: {
 	)
 }
 
+export async function deleteAllPackageRetrieverCacheEntriesForUser(input: {
+	env: Env
+	userId: string
+	packageIds: ReadonlyArray<string>
+}) {
+	if (!hasRetrieverKv(input.env)) return 0
+	const keys = new Set<string>()
+	for (const packageId of input.packageIds) {
+		for (const key of await listManifestCacheKeys({
+			env: input.env,
+			userId: input.userId,
+			packageId,
+		})) {
+			keys.add(key)
+		}
+		for (const scope of [
+			'search',
+			'context',
+		] satisfies Array<PackageRetrieverScope>) {
+			for (const key of await listScopeEntryKeys({
+				env: input.env,
+				userId: input.userId,
+				scope,
+				packageId,
+			})) {
+				keys.add(key)
+			}
+		}
+	}
+	for (const scope of [
+		'search',
+		'context',
+	] satisfies Array<PackageRetrieverScope>) {
+		keys.add(
+			buildPackageRetrieverScopeIndexKey({
+				userId: input.userId,
+				scope,
+			}),
+		)
+	}
+	const kv = getRetrieverKv(input.env)
+	await Promise.all(Array.from(keys).map(async (key) => await kv.delete(key)))
+	return keys.size
+}
+
 async function writeLegacyScopeIndex(input: {
 	env: Env
 	userId: string

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -694,6 +694,25 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		})
 	}
 
+	private async handlePurgeRequest(input: {
+		binding: PackageServiceBindingState
+	}) {
+		try {
+			await this.handleStopRequest(input)
+		} catch {
+			// Continue with hard deletion even if package/source lookup fails.
+		}
+		this.stateSnapshot = createInitialPackageServiceState()
+		this.activeRunPromise = null
+		await this.ctx.storage.deleteAlarm().catch(() => {
+			// Best effort cleanup before deleteAll.
+		})
+		await this.ctx.storage.deleteAll()
+		return Response.json({
+			ok: true,
+		})
+	}
+
 	async fetch(request: Request) {
 		const url = new URL(request.url)
 		const body = (await request.json().catch(() => null)) as {
@@ -711,6 +730,9 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		}
 		if (request.method === 'POST' && url.pathname.endsWith('/stop')) {
 			return await this.handleStopRequest({ binding })
+		}
+		if (request.method === 'POST' && url.pathname.endsWith('/purge')) {
+			return await this.handlePurgeRequest({ binding })
 		}
 		return new Response('Not found', { status: 404 })
 	}
@@ -818,6 +840,9 @@ export function packageServiceRpc(input: {
 		},
 		async stop() {
 			return await callService<{ ok: true }>('/service/stop')
+		},
+		async purge() {
+			return await callService<{ ok: true }>('/service/purge')
 		},
 	}
 }

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -399,6 +399,21 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		await this.ctx.storage.put(sessionStateStorageKey, this.stateSnapshot)
 	}
 
+	private async purgeSessionState() {
+		for (const socket of this.ctx.getWebSockets()) {
+			try {
+				socket.close(1000, 'account-deleted')
+			} catch {
+				// Ignore sockets that are already closing.
+			}
+		}
+		this.stateSnapshot = createInitialState()
+		this.cachedAppWorkerKey = null
+		this.cachedAppWorkerKeyLookup = null
+		this.cachedAppWorkerPromise = null
+		await this.ctx.storage.deleteAll()
+	}
+
 	private async initializeBinding(binding: PackageRealtimeBindingState) {
 		if (!this.stateSnapshot.binding) {
 			this.stateSnapshot.binding = binding
@@ -749,6 +764,15 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 			return Response.json({ ok: true })
 		}
 
+		if (request.method === 'POST' && url.pathname.endsWith('/purge')) {
+			const body = (await request.json()) as {
+				binding: PackageRealtimeBindingState
+			}
+			await this.initializeBinding(body.binding)
+			await this.purgeSessionState()
+			return Response.json({ ok: true })
+		}
+
 		return new Response('Not found', { status: 404 })
 	}
 
@@ -976,6 +1000,20 @@ export function packageRealtimeSessionRpc(input: {
 				}),
 			)
 			return await response.json()
+		},
+		async purge() {
+			const response = await stub.fetch(
+				new Request('https://package-realtime.invalid/session/purge', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({
+						binding,
+					}),
+				}),
+			)
+			return (await response.json()) as { ok: true }
 		},
 	}
 }

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -235,6 +235,30 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		}
 	}
 
+	async rpcPurgeUserSession(input: {
+		userId: string
+		kind: string
+		instanceId: string
+	}) {
+		const sessionKey = userScopedConnectorSessionKey(input)
+		if (!sessionKey) {
+			throw new Error('Remote connector session key was invalid.')
+		}
+		this.rejectPendingRequests('Remote connector session purged')
+		for (const socket of this.ctx.getWebSockets(connectorTag)) {
+			try {
+				socket.close(1000, 'account-deleted')
+			} catch {
+				// Ignore sockets that are already closing.
+			}
+		}
+		this.clearConnectionState()
+		await this.ctx.storage.deleteAll()
+		return {
+			ok: true as const,
+		}
+	}
+
 	private async restoreState() {
 		const stored =
 			await this.ctx.storage.get<RemoteConnectorSessionState>(stateStorageKey)

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -1076,6 +1076,30 @@ class RepoSessionBase extends DurableObject<Env> {
 		}
 	}
 
+	async purgeSession(input: { sessionId: string; userId: string }) {
+		const sessionRow = await getRepoSessionById(
+			this.env.APP_DB,
+			input.sessionId,
+		)
+		if (sessionRow && sessionRow.user_id !== input.userId) {
+			throw new Error(
+				`Repo session "${input.sessionId}" was not found for this user.`,
+			)
+		}
+		await this.clearCachedSessionState(input.sessionId)
+		await this.resetWorkspace().catch(() => {
+			// deleteAll below clears the SQLite-backed workspace state even if the
+			// higher-level workspace adapter cannot remove a path cleanly.
+		})
+		this.inMemorySessionState.delete(input.sessionId)
+		this.initializedSessionId = null
+		await this.ctx.storage.deleteAll()
+		return {
+			ok: true as const,
+			sessionId: input.sessionId,
+		}
+	}
+
 	async cleanupSessionBranch(input: {
 		sessionId: string
 		userId: string

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -36,6 +36,10 @@ export type RepoSessionRpc = {
 		sessionId: string
 		userId: string
 	}) => Promise<RepoSessionDiscardResult>
+	purgeSession: (payload: {
+		sessionId: string
+		userId: string
+	}) => Promise<{ ok: true; sessionId: string }>
 	cleanupSessionBranch: (payload: {
 		sessionId: string
 		userId: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Rebuilt account deletion around a pre-delete inventory so D1 rows, Vectorize ids, KV keys, Artifacts repos, and user-enumerable Durable Objects are cleaned up before the user row is removed.
- Removed the stale `chat_threads` deletion target and added coverage for package runtime debug tables, community ownership/reference tables, source snapshots, retriever cache keys, archived/runtime/app/service storage ids, and DO purge entrypoints.
- Added a schema guardrail test that applies the live migrations and fails if any `user_id` / `*_user_id` column is missing from account deletion coverage or if deletion references stale schema.
- Updated `docs/contributing/architecture/data-storage.md` with the account deletion inventory and current Durable Object storage model.

## Validation

- `npm run validate` (green: format, lint, typecheck, unit, Playwright E2E, MCP E2E)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `cf8c22e` · **Head:** `01693a6`

**Classification:** extends — this PR changes deletion behavior and purge contracts for existing storage/runtime primitives; it does not add a new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `d1-app-db` | storage | extends — schema-derived deletion guardrail and broader D1 cascade/update coverage |
| `bundle-artifacts-kv` | storage | extends — account deletion removes bundle, source snapshot, community snapshot, and retriever cache keys |
| `artifacts-repos` | storage | composes — account deletion continues using existing Artifacts REST cleanup |
| `vectorize-search` | storage | composes — account deletion deletes memory/job/package vector ids by D1 inventory |
| `durable-storage` | assistant | extends — deletion clears job/archive/runtime/app/service storage buckets |
| `jobs` | assistant | extends — JobManager gets a purge RPC for account deletion and reports missing bindings |
| `repo-sessions` | runtime | extends — RepoSession gets a hard purge RPC for account deletion |
| `remote-connectors` | assistant | extends — RemoteConnectorSession gets a purge RPC for account deletion |
| `realtime-sessions` | assistant | extends — PackageRealtimeSession gets a purge endpoint for account deletion |
| `package-services` | assistant | extends — PackageServiceInstance gets a purge endpoint for account deletion, including legacy service rows without source ids |
| `community-listings` | assistant | extends — account deletion removes owned/listing-related community rows/snapshots, clears resolver-only report references, and preserves bans made by deleted moderators with an anonymized moderator reference |
| `mcp-oauth` | auth | composes — account deletion continues revoking all OAuth grants |
| `app-ui` | surfaces | extends — `/account/delete` response reports expanded cleanup counts/warnings, including updated row counts |

### System map

```mermaid
flowchart LR
	appUi["app-ui"]:::extended --> d1["d1-app-db"]:::extended
	appUi --> oauth["mcp-oauth"]:::touched
	d1 --> vector["vectorize-search"]:::touched
	d1 --> kv["bundle-artifacts-kv"]:::extended
	d1 --> artifacts["artifacts-repos"]:::touched
	d1 --> durable["durable-storage"]:::extended
	d1 --> jobs["jobs"]:::extended
	d1 --> repos["repo-sessions"]:::extended
	d1 --> connectors["remote-connectors"]:::extended
	d1 --> realtime["realtime-sessions"]:::extended
	d1 --> services["package-services"]:::extended
	d1 --> community["community-listings"]:::extended
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Route as POST /account/delete
	participant Delete as deleteUserAccount
	participant D1 as APP_DB inventory
	participant Stores as Vectorize/KV/Artifacts/DOs
	participant OAuth as OAuth provider
	Route->>Delete: verified dbUserId + mcpUserId
	Delete->>D1: collect vectors, sources, packages, sessions, connectors, services, listings, storage ids
	Delete->>Stores: best-effort delete/purge with warnings per failure
	Delete->>D1: delete user-scoped rows or clear/anonymize user references in dependency-safe order
	Delete->>OAuth: revoke all grants
	Delete->>D1: delete users row last
	Delete-->>Route: exact deleted/updated counts + warnings
```

### Invariants

- Preserves the hard per-user isolation invariant: all inventory queries filter by `mcpUserId`/`dbUserId`, DO names are user-scoped where applicable, and cross-user rows/keys remain untouched in tests.
- Adds a migration-backed guardrail so future user-owned D1 columns fail tests until account deletion explicitly covers them.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-844b87b7-9d7c-4cd6-919c-5b6777164e60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-844b87b7-9d7c-4cd6-919c-5b6777164e60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

