### PR TITLE
Add admin MCP capability domain

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -79,6 +79,9 @@ Optional fields:
 - `tags`: short labels that improve search precision
 - `keywords`: extra synonyms or task words that may not belong in the name
 - `readOnly`, `idempotent`, `destructive`: search hints for capability behavior
+- `requiredRole`: RBAC role required to see or execute the capability
+- `requiredPermission`: RBAC permission string required to see or execute the
+  capability
 
 `defineDomainCapability` delegates to `defineCapability()`, which:
 
@@ -90,6 +93,62 @@ Keep `description` concise. Prefer putting field-level examples, constraints,
 and shape details in the schemas rather than repeating them in the top-level
 capability description. Reserve the description for high-level purpose and
 behavior that the schemas do not express well.
+
+### Role-gated capabilities
+
+Capabilities are public to the authenticated caller by default. When a
+capability should be visible only to a privileged account, add `requiredRole`
+and/or `requiredPermission` to the capability definition:
+
+```ts
+export const exampleAdminCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		name: 'admin_example_read',
+		description: 'Read admin-only account metadata.',
+		requiredRole: 'admin',
+		readOnly: true,
+		idempotent: true,
+		inputSchema: z.object({}),
+		async handler(args, ctx) {
+			// ...
+		},
+	},
+)
+```
+
+The registry filters role-gated capabilities from `search`,
+`meta_list_capabilities`, and MCP server domain instructions for callers who do
+not satisfy the requirement. This filtering is UX only; execute-time checks are
+the security boundary. The codemode wrapper and normalized capability handler
+also reject unauthorized calls, even if a test or internal caller accidentally
+passes an unfiltered registry.
+
+Role and permission checks use the authenticated MCP caller context for the
+current request. Do **not** cache role or permission decisions into Vectorize
+metadata, OAuth grants, package state, or session-scoped data; role revocation
+must take effect on the next request.
+
+### Admin domain
+
+The `admin` domain is for MCP-accessible account administration. Capabilities in
+this domain must set `requiredRole: 'admin'` and must preserve the RBAC privacy
+boundary from [Authorization](./architecture/authorization.md): admin access is
+limited to user/role account metadata and sanitized audit metadata. Never return
+or join against user content tables such as packages, secrets, values, memories,
+jobs, email, chat threads, storage buckets, OAuth grants, or remote connectors.
+
+Current admin capabilities are read-only:
+
+- `admin_user_list`
+- `admin_user_get`
+- `admin_audit_log_query`
+
+When the invite-signup branch lands, expose its invite and admin
+create-user-by-email service functions by adding new `admin/*` capability files
+that call those service-layer functions directly, set `requiredRole: 'admin'`,
+and audit-log the invocation. Do not duplicate the invite/user-creation SQL in
+capability handlers.
 
 Use raw JSON Schema only when you need an escape hatch that Zod does not model
 cleanly. The registry and Code Mode layer consume normalized JSON Schema after

--- a/packages/worker/migrations/0049-audit-events.sql
+++ b/packages/worker/migrations/0049-audit-events.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS audit_events (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	category TEXT NOT NULL CHECK (category IN ('account', 'admin', 'auth', 'oauth')),
+	action TEXT NOT NULL,
+	result TEXT NOT NULL CHECK (result IN ('success', 'failure', 'rate_limited')),
+	email_hash TEXT,
+	ip_hash TEXT,
+	client_id TEXT,
+	path TEXT,
+	reason TEXT,
+	timestamp TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_timestamp
+	ON audit_events(timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_action_timestamp
+	ON audit_events(action, timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_email_hash_timestamp
+	ON audit_events(email_hash, timestamp DESC);

--- a/packages/worker/src/app/admin-users-data.ts
+++ b/packages/worker/src/app/admin-users-data.ts
@@ -73,6 +73,48 @@ export async function loadAdminUsersData(
 	}
 }
 
+export async function loadAdminUserByIdOrEmail(
+	db: D1Database,
+	input: { id?: number; email?: string },
+): Promise<AdminUserListItem | null> {
+	const email = input.email?.trim() ?? ''
+	const userRow = input.id
+		? await db
+				.prepare(
+					`SELECT id, username, email, created_at, updated_at
+					 FROM users
+					 WHERE id = ?`,
+				)
+				.bind(input.id)
+				.first<{
+					id: number
+					username: string
+					email: string
+					created_at: string
+					updated_at: string
+				}>()
+		: email
+			? await db
+					.prepare(
+						`SELECT id, username, email, created_at, updated_at
+						 FROM users
+						 WHERE email = ? COLLATE NOCASE`,
+					)
+					.bind(email)
+					.first<{
+						id: number
+						username: string
+						email: string
+						created_at: string
+						updated_at: string
+					}>()
+			: null
+	if (!userRow) return null
+
+	const rolesByUserId = await loadRolesByUserIds(db, [userRow.id])
+	return toAdminUserListItem(userRow, rolesByUserId.get(userRow.id) ?? [])
+}
+
 export async function loadRolesByUserIds(
 	db: D1Database,
 	userIds: Array<number>,

--- a/packages/worker/src/app/audit-log.ts
+++ b/packages/worker/src/app/audit-log.ts
@@ -1,15 +1,55 @@
 import { toHex } from '@kody-internal/shared/hex.ts'
 
+export const auditEventCategories = [
+	'account',
+	'admin',
+	'auth',
+	'oauth',
+] as const
+export const auditEventResults = ['success', 'failure', 'rate_limited'] as const
+
+export type AuditEventCategory = (typeof auditEventCategories)[number]
+export type AuditEventResult = (typeof auditEventResults)[number]
+
 type AuditEvent = {
-	category: 'account' | 'admin' | 'auth' | 'oauth'
+	db?: D1Database
+	category: AuditEventCategory
 	action: string
-	result: 'success' | 'failure' | 'rate_limited'
+	result: AuditEventResult
 	email?: string
 	ip?: string
 	clientId?: string
 	path?: string
 	reason?: string
 }
+
+export type AuditLogEntry = {
+	id: number
+	category: AuditEventCategory
+	action: string
+	result: AuditEventResult
+	email_hash: string | null
+	ip_hash: string | null
+	client_id: string | null
+	path: string | null
+	reason: string | null
+	timestamp: string
+}
+
+export type AuditLogQuery = {
+	action?: string
+	category?: AuditEventCategory
+	result?: AuditEventResult
+	user?: string
+	emailHash?: string
+	startTime?: string
+	endTime?: string
+	limit?: number
+	page?: number
+}
+
+const defaultAuditLogLimit = 50
+const maxAuditLogLimit = 100
 
 async function hashIdentifier(value: string) {
 	const data = new TextEncoder().encode(value.trim().toLowerCase())
@@ -31,25 +71,148 @@ export function getRequestIp(request: Request) {
 	)
 }
 
+function normalizeOptionalString(value: string | undefined) {
+	const trimmed = value?.trim()
+	return trimmed && trimmed.length > 0 ? trimmed : undefined
+}
+
+async function buildAuditPayload(event: AuditEvent) {
+	const [emailHash, ipHash] = await Promise.all([
+		event.email ? hashIdentifier(event.email) : undefined,
+		event.ip ? hashIdentifier(event.ip) : undefined,
+	])
+	return {
+		category: event.category,
+		action: event.action,
+		result: event.result,
+		emailHash,
+		ipHash,
+		clientId: event.clientId,
+		path: event.path,
+		reason: event.reason,
+		timestamp: new Date().toISOString(),
+	}
+}
+
+async function persistAuditEvent(
+	db: D1Database | undefined,
+	payload: Awaited<ReturnType<typeof buildAuditPayload>>,
+) {
+	if (!db) return
+	await db
+		.prepare(
+			`INSERT INTO audit_events (
+				category,
+				action,
+				result,
+				email_hash,
+				ip_hash,
+				client_id,
+				path,
+				reason,
+				timestamp
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.bind(
+			payload.category,
+			payload.action,
+			payload.result,
+			payload.emailHash ?? null,
+			payload.ipHash ?? null,
+			payload.clientId ?? null,
+			payload.path ?? null,
+			payload.reason ?? null,
+			payload.timestamp,
+		)
+		.run()
+}
+
 export async function logAuditEvent(event: AuditEvent) {
 	try {
-		const [emailHash, ipHash] = await Promise.all([
-			event.email ? hashIdentifier(event.email) : undefined,
-			event.ip ? hashIdentifier(event.ip) : undefined,
-		])
-		const payload = {
-			category: event.category,
-			action: event.action,
-			result: event.result,
-			emailHash,
-			ipHash,
-			clientId: event.clientId,
-			path: event.path,
-			reason: event.reason,
-			timestamp: new Date().toISOString(),
-		}
+		const payload = await buildAuditPayload(event)
 		console.info('audit-event', JSON.stringify(payload))
+		await persistAuditEvent(event.db, payload)
 	} catch (error) {
 		console.warn('audit-event-failed', error)
+	}
+}
+
+export async function queryAuditLog(db: D1Database, query: AuditLogQuery) {
+	const limit = Math.max(
+		1,
+		Math.min(Math.floor(query.limit ?? defaultAuditLogLimit), maxAuditLogLimit),
+	)
+	const page = Math.max(1, Math.floor(query.page ?? 1))
+	const offset = (page - 1) * limit
+	const where: Array<string> = []
+	const bindings: Array<string | number> = []
+
+	const action = normalizeOptionalString(query.action)
+	if (action) {
+		where.push('action = ?')
+		bindings.push(action)
+	}
+	if (query.category) {
+		where.push('category = ?')
+		bindings.push(query.category)
+	}
+	if (query.result) {
+		where.push('result = ?')
+		bindings.push(query.result)
+	}
+	const emailHash = normalizeOptionalString(query.emailHash)
+	const user = normalizeOptionalString(query.user)
+	const resolvedEmailHash =
+		emailHash ?? (user ? await hashIdentifier(user) : null)
+	if (resolvedEmailHash) {
+		where.push('email_hash = ?')
+		bindings.push(resolvedEmailHash)
+	}
+	const startTime = normalizeOptionalString(query.startTime)
+	if (startTime) {
+		where.push('timestamp >= ?')
+		bindings.push(startTime)
+	}
+	const endTime = normalizeOptionalString(query.endTime)
+	if (endTime) {
+		where.push('timestamp <= ?')
+		bindings.push(endTime)
+	}
+
+	const whereSql = where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''
+	const countStatement = db.prepare(
+		`SELECT COUNT(*) AS total FROM audit_events ${whereSql}`,
+	)
+	const countQuery =
+		bindings.length > 0 ? countStatement.bind(...bindings) : countStatement
+	const [totalRow, rows] = await Promise.all([
+		countQuery.first<{ total: number }>(),
+		db
+			.prepare(
+				`SELECT
+					id,
+					category,
+					action,
+					result,
+					email_hash,
+					ip_hash,
+					client_id,
+					path,
+					reason,
+					timestamp
+				 FROM audit_events
+				 ${whereSql}
+				 ORDER BY timestamp DESC, id DESC
+				 LIMIT ? OFFSET ?`,
+			)
+			.bind(...bindings, limit, offset)
+			.all<AuditLogEntry>(),
+	])
+
+	return {
+		total: totalRow?.total ?? 0,
+		page,
+		limit,
+		events: rows.results ?? [],
 	}
 }

--- a/packages/worker/src/mcp/capabilities/access-control.ts
+++ b/packages/worker/src/mcp/capabilities/access-control.ts
@@ -1,0 +1,142 @@
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import {
+	type PermissionString,
+	type RoleName,
+	userHasPermission,
+	userHasRole,
+} from '#app/permissions.ts'
+import { type BuiltCapabilityRegistry } from './build-capability-registry.ts'
+import { type Capability, type CapabilitySpec } from './types.ts'
+
+type CapabilityAccessRequirement = Pick<
+	Capability | CapabilitySpec,
+	'name' | 'requiredRole' | 'requiredPermission'
+>
+
+type McpUserAccessContext = {
+	roles?: Array<string>
+	permissions?: Array<string>
+} | null
+
+function getUserAccessContext(callerContext: McpCallerContext) {
+	return callerContext.user ?? null
+}
+
+function hasRequiredRole(user: McpUserAccessContext, role: RoleName) {
+	return userHasRole({ roles: (user?.roles ?? []) as Array<RoleName> }, role)
+}
+
+function hasRequiredPermission(
+	user: McpUserAccessContext,
+	permission: PermissionString,
+) {
+	return userHasPermission(
+		{ permissions: (user?.permissions ?? []) as Array<PermissionString> },
+		permission,
+	)
+}
+
+export function callerCanAccessCapability(
+	callerContext: McpCallerContext,
+	capability: CapabilityAccessRequirement,
+) {
+	const requiredRole = capability.requiredRole
+	const requiredPermission = capability.requiredPermission
+	if (!requiredRole && !requiredPermission) return true
+
+	const user = getUserAccessContext(callerContext)
+	if (!user) return false
+	if (requiredRole && !hasRequiredRole(user, requiredRole)) return false
+	if (requiredPermission && !hasRequiredPermission(user, requiredPermission)) {
+		return false
+	}
+	return true
+}
+
+export function assertCallerCanAccessCapability(
+	callerContext: McpCallerContext,
+	capability: CapabilityAccessRequirement,
+) {
+	if (callerCanAccessCapability(callerContext, capability)) return
+
+	const user = getUserAccessContext(callerContext)
+	if (!user) {
+		throw new Error(
+			`Authenticated MCP user is required to execute capability "${capability.name}".`,
+		)
+	}
+	if (
+		capability.requiredRole &&
+		!hasRequiredRole(user, capability.requiredRole)
+	) {
+		throw new Error(
+			`MCP user lacks required role "${capability.requiredRole}" for capability "${capability.name}".`,
+		)
+	}
+	if (
+		capability.requiredPermission &&
+		!hasRequiredPermission(user, capability.requiredPermission)
+	) {
+		throw new Error(
+			`MCP user lacks required permission "${capability.requiredPermission}" for capability "${capability.name}".`,
+		)
+	}
+	throw new Error(`MCP user cannot access capability "${capability.name}".`)
+}
+
+export function filterCapabilityRegistryForCaller(
+	registry: BuiltCapabilityRegistry,
+	callerContext: McpCallerContext,
+): BuiltCapabilityRegistry {
+	const capabilityList = registry.capabilityList.filter((capability) =>
+		callerCanAccessCapability(callerContext, capability),
+	)
+	if (capabilityList.length === registry.capabilityList.length) {
+		return registry
+	}
+
+	const allowedNames = new Set(
+		capabilityList.map((capability) => capability.name),
+	)
+	const allowedDomains = new Set(
+		capabilityList.map((capability) => capability.domain),
+	)
+	const capabilityDomains = registry.capabilityDomains.filter((domain) =>
+		allowedDomains.has(domain.name),
+	)
+	const capabilityDomainDescriptionsByName = Object.fromEntries(
+		Object.entries(registry.capabilityDomainDescriptionsByName).filter(
+			([name]) => allowedDomains.has(name),
+		),
+	) as BuiltCapabilityRegistry['capabilityDomainDescriptionsByName']
+	const capabilityMap = Object.fromEntries(
+		Object.entries(registry.capabilityMap).filter(([name]) =>
+			allowedNames.has(name),
+		),
+	) as BuiltCapabilityRegistry['capabilityMap']
+	const capabilitySpecs = Object.fromEntries(
+		Object.entries(registry.capabilitySpecs).filter(([name]) =>
+			allowedNames.has(name),
+		),
+	) as BuiltCapabilityRegistry['capabilitySpecs']
+	const capabilityToolDescriptors = Object.fromEntries(
+		Object.entries(registry.capabilityToolDescriptors).filter(([name]) =>
+			allowedNames.has(name),
+		),
+	) as BuiltCapabilityRegistry['capabilityToolDescriptors']
+	const capabilityHandlers = Object.fromEntries(
+		Object.entries(registry.capabilityHandlers).filter(([name]) =>
+			allowedNames.has(name),
+		),
+	) as BuiltCapabilityRegistry['capabilityHandlers']
+
+	return {
+		capabilityList,
+		capabilityDomains,
+		capabilityDomainDescriptionsByName,
+		capabilityMap,
+		capabilitySpecs,
+		capabilityToolDescriptors,
+		capabilityHandlers,
+	}
+}

--- a/packages/worker/src/mcp/capabilities/admin/admin-audit-log-query.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-audit-log-query.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod'
+import {
+	auditEventCategories,
+	auditEventResults,
+	queryAuditLog,
+} from '#app/audit-log.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	adminCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
+
+const inputSchema = z.object({
+	action: z
+		.string()
+		.min(1)
+		.optional()
+		.describe('Exact audit action to match, such as admin_user_list.'),
+	category: z
+		.enum(auditEventCategories)
+		.optional()
+		.describe('Audit event category filter.'),
+	result: z
+		.enum(auditEventResults)
+		.optional()
+		.describe('Audit event result filter.'),
+	user: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			'Actor email address to filter by. Kody hashes it before querying; raw emails are not stored in audit rows.',
+		),
+	emailHash: z
+		.string()
+		.min(1)
+		.optional()
+		.describe('Previously returned actor email hash to filter by.'),
+	startTime: z
+		.string()
+		.datetime()
+		.optional()
+		.describe('Inclusive ISO timestamp lower bound.'),
+	endTime: z
+		.string()
+		.datetime()
+		.optional()
+		.describe('Inclusive ISO timestamp upper bound.'),
+	page: z.number().int().min(1).optional().describe('One-indexed result page.'),
+	limit: z
+		.number()
+		.int()
+		.min(1)
+		.max(100)
+		.optional()
+		.describe('Events per page. Defaults to 50 and maxes at 100.'),
+})
+
+const auditLogEntrySchema = z.object({
+	id: z.number().int().positive(),
+	category: z.enum(auditEventCategories),
+	action: z.string(),
+	result: z.enum(auditEventResults),
+	email_hash: z.string().nullable(),
+	ip_hash: z.string().nullable(),
+	client_id: z.string().nullable(),
+	path: z.string().nullable(),
+	reason: z.string().nullable(),
+	timestamp: z.string(),
+})
+
+const outputSchema = z.object({
+	total: z.number().int().nonnegative(),
+	page: z.number().int().positive(),
+	limit: z.number().int().positive(),
+	events: z.array(auditLogEntrySchema),
+})
+
+export const adminAuditLogQueryCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminCapabilityAccess,
+		name: 'admin_audit_log_query',
+		description:
+			'Query sanitized account-administration audit metadata by action, actor, result, category, or time range. Admin-only; never returns user content.',
+		keywords: ['admin', 'audit', 'log', 'events', 'account metadata'],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_audit_log_query',
+				async () => queryAuditLog(ctx.env.APP_DB, args),
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
@@ -1,0 +1,306 @@
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { adminAuditLogQueryCapability } from './admin-audit-log-query.ts'
+import { adminUserGetCapability } from './admin-user-get.ts'
+import { adminUserListCapability } from './admin-user-list.ts'
+
+type UserRow = {
+	id: number
+	username: string
+	email: string
+	created_at: string
+	updated_at: string
+}
+
+type UserRoleRow = {
+	user_id: number
+	role_name: string
+}
+
+type AuditEventRow = {
+	id: number
+	category: string
+	action: string
+	result: string
+	email_hash: string | null
+	ip_hash: string | null
+	client_id: string | null
+	path: string | null
+	reason: string | null
+	timestamp: string
+}
+
+function normalizeQuery(query: string) {
+	return query.replace(/\s+/g, ' ').trim().toLowerCase()
+}
+
+function createAdminCapabilityTestDb(input: {
+	users: Array<UserRow>
+	userRoles: Array<UserRoleRow>
+}) {
+	const users = input.users.map((user) => ({ ...user }))
+	const userRoles = input.userRoles.map((row) => ({ ...row }))
+	const auditEvents: Array<AuditEventRow> = []
+
+	function selectAuditEvents(
+		normalizedQuery: string,
+		params: Array<unknown>,
+		options: { paginated: boolean },
+	) {
+		const filterParams = options.paginated ? params.slice(0, -2) : params
+		let index = 0
+		let rows = [...auditEvents]
+		if (normalizedQuery.includes('action = ?')) {
+			const action = String(filterParams[index++])
+			rows = rows.filter((row) => row.action === action)
+		}
+		if (normalizedQuery.includes('category = ?')) {
+			const category = String(filterParams[index++])
+			rows = rows.filter((row) => row.category === category)
+		}
+		if (normalizedQuery.includes('result = ?')) {
+			const result = String(filterParams[index++])
+			rows = rows.filter((row) => row.result === result)
+		}
+		if (normalizedQuery.includes('email_hash = ?')) {
+			const emailHash = String(filterParams[index++])
+			rows = rows.filter((row) => row.email_hash === emailHash)
+		}
+		if (normalizedQuery.includes('timestamp >= ?')) {
+			const startTime = String(filterParams[index++])
+			rows = rows.filter((row) => row.timestamp >= startTime)
+		}
+		if (normalizedQuery.includes('timestamp <= ?')) {
+			const endTime = String(filterParams[index++])
+			rows = rows.filter((row) => row.timestamp <= endTime)
+		}
+		rows.sort(
+			(left, right) =>
+				right.timestamp.localeCompare(left.timestamp) || right.id - left.id,
+		)
+		if (!options.paginated) return rows
+		const limit = Number(params.at(-2))
+		const offset = Number(params.at(-1))
+		return rows.slice(offset, offset + limit)
+	}
+
+	const db = {
+		prepare(query: string) {
+			const normalizedQuery = normalizeQuery(query)
+			const createStatement = (params: Array<unknown>) => ({
+				async first<T>() {
+					if (normalizedQuery.includes('select count(*) as total from users')) {
+						return { total: users.length } as T
+					}
+					if (
+						normalizedQuery.includes(
+							'select id, username, email, created_at, updated_at from users where id = ?',
+						)
+					) {
+						return (users.find((user) => user.id === params[0]) ??
+							null) as T | null
+					}
+					if (
+						normalizedQuery.includes(
+							'select id, username, email, created_at, updated_at from users where email = ? collate nocase',
+						)
+					) {
+						const email = String(params[0]).toLowerCase()
+						return (users.find((user) => user.email.toLowerCase() === email) ??
+							null) as T | null
+					}
+					if (
+						normalizedQuery.includes(
+							'select count(*) as total from audit_events',
+						)
+					) {
+						return {
+							total: selectAuditEvents(normalizedQuery, params, {
+								paginated: false,
+							}).length,
+						} as T
+					}
+					return null
+				},
+				async all<T>() {
+					if (
+						normalizedQuery.includes(
+							'select id, username, email, created_at, updated_at from users order by id asc limit ? offset ?',
+						)
+					) {
+						const pageSize = Number(params[0])
+						const offset = Number(params[1])
+						return {
+							results: users
+								.sort((left, right) => left.id - right.id)
+								.slice(offset, offset + pageSize) as Array<T>,
+						}
+					}
+					if (normalizedQuery.includes('where ur.user_id in')) {
+						const userIds = params.map((value) => Number(value))
+						return {
+							results: userRoles
+								.filter((row) => userIds.includes(row.user_id))
+								.map((row) => ({
+									user_id: row.user_id,
+									role_name: row.role_name,
+								})) as Array<T>,
+						}
+					}
+					if (normalizedQuery.includes('from audit_events')) {
+						return {
+							results: selectAuditEvents(normalizedQuery, params, {
+								paginated: true,
+							}) as Array<T>,
+						}
+					}
+					return { results: [] as Array<T> }
+				},
+				async run() {
+					if (normalizedQuery.includes('insert into audit_events')) {
+						auditEvents.push({
+							id: auditEvents.length + 1,
+							category: String(params[0]),
+							action: String(params[1]),
+							result: String(params[2]),
+							email_hash: params[3] ? String(params[3]) : null,
+							ip_hash: params[4] ? String(params[4]) : null,
+							client_id: params[5] ? String(params[5]) : null,
+							path: params[6] ? String(params[6]) : null,
+							reason: params[7] ? String(params[7]) : null,
+							timestamp: String(params[8]),
+						})
+					}
+					return { meta: { changes: 1 } }
+				},
+			})
+			return {
+				...createStatement([]),
+				bind(...params: Array<unknown>) {
+					return createStatement(params)
+				},
+			}
+		},
+	} as unknown as D1Database
+
+	return { db, auditEvents }
+}
+
+function createAdminCapabilityContext(db: D1Database) {
+	return {
+		env: { APP_DB: db } as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'admin-user',
+				email: 'admin@example.com',
+				displayName: 'admin',
+				roles: ['admin'],
+			},
+		}),
+	}
+}
+
+test('admin capabilities list and get account metadata and query sanitized audit rows', async () => {
+	const { db, auditEvents } = createAdminCapabilityTestDb({
+		users: [
+			{
+				id: 1,
+				username: 'admin',
+				email: 'admin@example.com',
+				created_at: '2026-01-01 00:00:00',
+				updated_at: '2026-01-02 00:00:00',
+			},
+			{
+				id: 2,
+				username: 'jane',
+				email: 'jane@example.com',
+				created_at: '2026-01-03 00:00:00',
+				updated_at: '2026-01-04 00:00:00',
+			},
+		],
+		userRoles: [
+			{ user_id: 1, role_name: 'admin' },
+			{ user_id: 1, role_name: 'user' },
+			{ user_id: 2, role_name: 'user' },
+		],
+	})
+	const ctx = createAdminCapabilityContext(db)
+
+	const list = await adminUserListCapability.handler({ pageSize: 10 }, ctx)
+	expect(list).toMatchObject({
+		total: 2,
+		page: 1,
+		pageSize: 10,
+		users: [
+			expect.objectContaining({
+				id: 1,
+				email: 'admin@example.com',
+				roles: ['admin', 'user'],
+			}),
+			expect.objectContaining({
+				id: 2,
+				email: 'jane@example.com',
+				roles: ['user'],
+			}),
+		],
+	})
+
+	const getByEmail = await adminUserGetCapability.handler(
+		{ email: 'JANE@example.com' },
+		ctx,
+	)
+	expect(getByEmail.user).toMatchObject({
+		id: 2,
+		username: 'jane',
+		email: 'jane@example.com',
+		roles: ['user'],
+	})
+
+	const audit = await adminAuditLogQueryCapability.handler(
+		{ action: 'admin_user_get', limit: 10 },
+		ctx,
+	)
+	expect(audit.total).toBe(1)
+	expect(audit.events).toEqual([
+		expect.objectContaining({
+			action: 'admin_user_get',
+			category: 'admin',
+			result: 'success',
+			email_hash: expect.any(String),
+			reason: 'mcp_admin_capability',
+		}),
+	])
+	expect(audit.events[0]).not.toHaveProperty('email')
+	expect(auditEvents.map((event) => event.action)).toEqual([
+		'admin_user_list',
+		'admin_user_get',
+		'admin_audit_log_query',
+	])
+})
+
+test('admin capabilities reject non-admin direct handler calls', async () => {
+	const { db } = createAdminCapabilityTestDb({
+		users: [],
+		userRoles: [],
+	})
+	await expect(
+		adminUserListCapability.handler(
+			{},
+			{
+				env: { APP_DB: db } as Env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://example.com',
+					user: {
+						userId: 'user-1',
+						email: 'user@example.com',
+						displayName: 'user',
+						roles: ['user'],
+					},
+				}),
+			},
+		),
+	).rejects.toThrow(
+		'MCP user lacks required role "admin" for capability "admin_user_list".',
+	)
+})

--- a/packages/worker/src/mcp/capabilities/admin/admin-shared.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-shared.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod'
+import { logAuditEvent } from '#app/audit-log.ts'
+import { roleNames } from '#app/permissions.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+
+export const adminCapabilityAccess = {
+	requiredRole: 'admin',
+	readOnly: true,
+	idempotent: true,
+	destructive: false,
+} as const
+
+export const roleNameSchema = z.enum(roleNames)
+
+export const adminUserMetadataSchema = z.object({
+	id: z.number().int().positive(),
+	username: z.string(),
+	email: z.string(),
+	created_at: z.string(),
+	updated_at: z.string(),
+	roles: z.array(roleNameSchema),
+})
+
+function getErrorReason(error: unknown) {
+	if (error instanceof Error && error.message.trim().length > 0) {
+		return error.message.slice(0, 240)
+	}
+	return 'unknown_error'
+}
+
+export async function auditAdminCapabilityInvocation<TResult>(
+	ctx: CapabilityContext,
+	capabilityName: string,
+	run: () => Promise<TResult>,
+): Promise<TResult> {
+	const actorEmail = ctx.callerContext.user?.email
+	try {
+		const result = await run()
+		await logAuditEvent({
+			db: ctx.env.APP_DB,
+			category: 'admin',
+			action: capabilityName,
+			result: 'success',
+			email: actorEmail,
+			path: '/mcp',
+			reason: 'mcp_admin_capability',
+		})
+		return result
+	} catch (error) {
+		await logAuditEvent({
+			db: ctx.env.APP_DB,
+			category: 'admin',
+			action: capabilityName,
+			result: 'failure',
+			email: actorEmail,
+			path: '/mcp',
+			reason: getErrorReason(error),
+		})
+		throw error
+	}
+}

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-get.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-get.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+import { loadAdminUserByIdOrEmail } from '#app/admin-users-data.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	adminCapabilityAccess,
+	adminUserMetadataSchema,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
+
+const inputSchema = z
+	.object({
+		id: z
+			.number()
+			.int()
+			.positive()
+			.optional()
+			.describe('Numeric users.id to look up.'),
+		email: z.string().email().optional().describe('Email address to look up.'),
+	})
+	.refine((value) => value.id !== undefined || value.email !== undefined, {
+		message: 'Provide either id or email.',
+	})
+
+const outputSchema = z.object({
+	user: adminUserMetadataSchema.nullable(),
+})
+
+export const adminUserGetCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminCapabilityAccess,
+		name: 'admin_user_get',
+		description:
+			'Get one user account metadata record and roles by id or email. Admin-only; never returns user content.',
+		keywords: ['admin', 'user', 'account', 'roles', 'lookup', 'rbac'],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			return auditAdminCapabilityInvocation(ctx, 'admin_user_get', async () => {
+				const user = await loadAdminUserByIdOrEmail(ctx.env.APP_DB, args)
+				return { user }
+			})
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-list.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-list.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod'
+import { loadAdminUsersData } from '#app/admin-users-data.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	adminCapabilityAccess,
+	adminUserMetadataSchema,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
+
+const inputSchema = z.object({
+	page: z
+		.number()
+		.int()
+		.min(1)
+		.optional()
+		.describe('One-indexed page of users to return. Defaults to 1.'),
+	pageSize: z
+		.number()
+		.int()
+		.min(1)
+		.max(100)
+		.optional()
+		.describe('Users per page. Defaults to 20 and maxes at 100.'),
+})
+
+const outputSchema = z.object({
+	total: z.number().int().nonnegative(),
+	page: z.number().int().positive(),
+	pageSize: z.number().int().positive(),
+	users: z.array(adminUserMetadataSchema),
+})
+
+export const adminUserListCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminCapabilityAccess,
+		name: 'admin_user_list',
+		description:
+			'List account metadata for users, including roles. Admin-only; never returns user content.',
+		keywords: ['admin', 'users', 'accounts', 'roles', 'rbac'],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_user_list',
+				async () => {
+					const url = new URL('https://kody.local/admin/users.json')
+					if (args.page) url.searchParams.set('page', String(args.page))
+					if (args.pageSize) {
+						url.searchParams.set('pageSize', String(args.pageSize))
+					}
+					const data = await loadAdminUsersData(ctx.env, url.toString())
+					return {
+						total: data.total,
+						page: data.page,
+						pageSize: data.pageSize,
+						users: data.users,
+					}
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/domain.ts
+++ b/packages/worker/src/mcp/capabilities/admin/domain.ts
@@ -1,0 +1,17 @@
+import { defineDomain } from '#mcp/capabilities/define-domain.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { adminAuditLogQueryCapability } from './admin-audit-log-query.ts'
+import { adminUserGetCapability } from './admin-user-get.ts'
+import { adminUserListCapability } from './admin-user-list.ts'
+
+export const adminDomain = defineDomain({
+	name: capabilityDomainNames.admin,
+	description:
+		'Admin-only account metadata capabilities for user and role administration. This domain never exposes user content such as packages, secrets, memories, jobs, or email.',
+	keywords: ['admin', 'rbac', 'account metadata', 'users', 'roles', 'audit'],
+	capabilities: [
+		adminUserListCapability,
+		adminUserGetCapability,
+		adminAuditLogQueryCapability,
+	],
+})

--- a/packages/worker/src/mcp/capabilities/admin/index.ts
+++ b/packages/worker/src/mcp/capabilities/admin/index.ts
@@ -1,0 +1,1 @@
+export { adminDomain } from './domain.ts'

--- a/packages/worker/src/mcp/capabilities/build-capability-registry.ts
+++ b/packages/worker/src/mcp/capabilities/build-capability-registry.ts
@@ -93,6 +93,12 @@ function createCapabilitySpecs(capabilities: Array<Capability>) {
 					readOnly: capability.readOnly,
 					idempotent: capability.idempotent,
 					destructive: capability.destructive,
+					...(capability.requiredRole
+						? { requiredRole: capability.requiredRole }
+						: {}),
+					...(capability.requiredPermission
+						? { requiredPermission: capability.requiredPermission }
+						: {}),
 					inputFields: getSchemaPropertyNames(capability.inputSchema),
 					requiredInputFields: getSchemaRequiredFields(capability.inputSchema),
 					outputFields: capability.outputSchema

--- a/packages/worker/src/mcp/capabilities/builtin-domains.ts
+++ b/packages/worker/src/mcp/capabilities/builtin-domains.ts
@@ -1,3 +1,4 @@
+import { adminDomain } from './admin/domain.ts'
 import { appsDomain } from './apps/domain.ts'
 import { communityDomain } from './community/domain.ts'
 import { codingDomain } from './coding/domain.ts'
@@ -21,6 +22,7 @@ import { valuesDomain } from './values/domain.ts'
  * (Workers typically snapshot capabilities at deploy time).
  */
 export const builtinDomains = [
+	adminDomain,
 	appsDomain,
 	communityDomain,
 	codingDomain,

--- a/packages/worker/src/mcp/capabilities/define-capability.ts
+++ b/packages/worker/src/mcp/capabilities/define-capability.ts
@@ -15,6 +15,7 @@ import {
 	createCapabilityTypeName,
 	createSchemaTypeDefinition,
 } from './schema-type-definitions.ts'
+import { assertCallerCanAccessCapability } from './access-control.ts'
 
 // Normalize capability authoring input into the JSON-Schema-based shape
 // consumed by the registry and sandbox search surface.
@@ -40,6 +41,12 @@ export function defineCapability<
 		readOnly: definition.readOnly ?? false,
 		idempotent: definition.idempotent ?? false,
 		destructive: definition.destructive ?? false,
+		...(definition.requiredRole
+			? { requiredRole: definition.requiredRole }
+			: {}),
+		...(definition.requiredPermission
+			? { requiredPermission: definition.requiredPermission }
+			: {}),
 		inputSchema,
 		...(outputSchema ? { outputSchema } : {}),
 		inputTypeDefinition: createSchemaTypeDefinition({
@@ -57,6 +64,7 @@ export function defineCapability<
 		async handler(args, ctx) {
 			const startedAt = performance.now()
 			const { baseUrl, hasUser } = callerContextFields(ctx.callerContext)
+			assertCallerCanAccessCapability(ctx.callerContext, definition)
 
 			let parsedArgs: InferCapabilitySchema<TInputSchema>
 			try {

--- a/packages/worker/src/mcp/capabilities/domain-metadata.ts
+++ b/packages/worker/src/mcp/capabilities/domain-metadata.ts
@@ -1,5 +1,6 @@
 /** Canonical domain id values; descriptions live on each `DomainSpec` (see `coding/domain.ts`, etc.). */
 export const capabilityDomainNames = {
+	admin: 'admin',
 	apps: 'apps',
 	community: 'community',
 	coding: 'coding',

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.ts
@@ -71,6 +71,7 @@ export const metaListCapabilitiesCapability = defineDomainCapability(
 		inputSchema: z.object({
 			domain: z
 				.enum([
+					capabilityDomainNames.admin,
 					capabilityDomainNames.apps,
 					capabilityDomainNames.community,
 					capabilityDomainNames.coding,

--- a/packages/worker/src/mcp/capabilities/registry.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/registry.node.test.ts
@@ -154,6 +154,7 @@ test('getCapabilityRegistryForContext bypasses connector caches when no connecto
 			userId: 'user-1',
 			email: 'user-1@example.com',
 			displayName: 'user-1',
+			roles: ['admin'],
 		},
 	})
 
@@ -164,4 +165,44 @@ test('getCapabilityRegistryForContext bypasses connector caches when no connecto
 
 	expect(get).not.toHaveBeenCalled()
 	expect(registry.capabilityMap).toBe(capabilityMap)
+})
+
+test('getCapabilityRegistryForContext filters admin capabilities by current caller roles', async () => {
+	const env = {} as Env
+	const adminContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: {
+			userId: 'user-1',
+			email: 'admin@example.com',
+			displayName: 'admin',
+			roles: ['admin'],
+		},
+	})
+	const regularContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: {
+			userId: 'user-1',
+			email: 'admin@example.com',
+			displayName: 'admin',
+			roles: ['user'],
+		},
+	})
+
+	const adminRegistry = await getCapabilityRegistryForContext({
+		env,
+		callerContext: adminContext,
+	})
+	const regularRegistry = await getCapabilityRegistryForContext({
+		env,
+		callerContext: regularContext,
+	})
+
+	expect(adminRegistry.capabilityMap.admin_user_list).toBeTruthy()
+	expect(
+		adminRegistry.capabilityDomains.some((domain) => domain.name === 'admin'),
+	).toBe(true)
+	expect(regularRegistry.capabilityMap.admin_user_list).toBeUndefined()
+	expect(
+		regularRegistry.capabilityDomains.some((domain) => domain.name === 'admin'),
+	).toBe(false)
 })

--- a/packages/worker/src/mcp/capabilities/registry.ts
+++ b/packages/worker/src/mcp/capabilities/registry.ts
@@ -2,6 +2,7 @@ import {
 	buildCapabilityRegistry,
 	type BuiltCapabilityRegistry,
 } from './build-capability-registry.ts'
+import { filterCapabilityRegistryForCaller } from './access-control.ts'
 import { builtinDomains } from './builtin-domains.ts'
 import { synthesizeRemoteToolDomain } from './remote-connector/index.ts'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
@@ -90,6 +91,13 @@ async function buildCapabilityRegistryForConnectors(input: {
 	return buildCapabilityRegistry([...builtinDomains, ...synthesizedDomains])
 }
 
+function filterRegistryForContext(input: {
+	registry: BuiltCapabilityRegistry
+	callerContext: McpCallerContext
+}) {
+	return filterCapabilityRegistryForCaller(input.registry, input.callerContext)
+}
+
 export async function getCapabilityRegistryForContext(input: {
 	env: Env
 	callerContext: McpCallerContext
@@ -97,7 +105,10 @@ export async function getCapabilityRegistryForContext(input: {
 	const refs = normalizeRemoteConnectorRefs(input.callerContext)
 	const userId = input.callerContext.user?.userId ?? null
 	if (refs.length === 0 || !userId) {
-		return staticRegistry
+		return filterRegistryForContext({
+			registry: staticRegistry,
+			callerContext: input.callerContext,
+		})
 	}
 	const snapshots = await Promise.all(
 		refs.map((ref) =>
@@ -114,7 +125,7 @@ export async function getCapabilityRegistryForContext(input: {
 		refs,
 		snapshots,
 	})
-	return capabilityRegistryCache.getOrCreate({
+	const registry = await capabilityRegistryCache.getOrCreate({
 		cacheKey,
 		create: () =>
 			buildCapabilityRegistryForConnectors({
@@ -123,6 +134,10 @@ export async function getCapabilityRegistryForContext(input: {
 				refs,
 				snapshots,
 			}),
+	})
+	return filterRegistryForContext({
+		registry,
+		callerContext: input.callerContext,
 	})
 }
 

--- a/packages/worker/src/mcp/capabilities/types.ts
+++ b/packages/worker/src/mcp/capabilities/types.ts
@@ -1,5 +1,6 @@
 import { type JsonSchemaToolDescriptor } from '@cloudflare/codemode'
 import { z, type ZodType } from 'zod'
+import { type PermissionString, type RoleName } from '#app/permissions.ts'
 import { type CapabilityDomain } from './domain-metadata.ts'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 
@@ -35,6 +36,8 @@ export type CapabilityDefinition<
 	readOnly?: boolean
 	idempotent?: boolean
 	destructive?: boolean
+	requiredRole?: RoleName
+	requiredPermission?: PermissionString
 	inputSchema: TInputSchema
 	outputSchema?: TOutputSchema
 	handler: (
@@ -56,6 +59,8 @@ export type Capability = {
 	readOnly: boolean
 	idempotent: boolean
 	destructive: boolean
+	requiredRole?: RoleName
+	requiredPermission?: PermissionString
 	inputSchema: CapabilityJsonSchema
 	outputSchema?: JsonSchemaToolDescriptor['outputSchema']
 	inputTypeDefinition: string
@@ -74,6 +79,8 @@ export type CapabilitySpec = {
 	readOnly: boolean
 	idempotent: boolean
 	destructive: boolean
+	requiredRole?: RoleName
+	requiredPermission?: PermissionString
 	inputFields: Array<string>
 	requiredInputFields: Array<string>
 	outputFields: Array<string>

--- a/packages/worker/src/mcp/index.ts
+++ b/packages/worker/src/mcp/index.ts
@@ -15,6 +15,7 @@ import {
 import { registerTools } from './register-tools.ts'
 import { createKodyMcpServer } from './sentry-mcp-server.ts'
 import { getMcpUserServerInstructions } from './user-server-instructions-repo.ts'
+import { getCapabilityRegistryForContext } from './capabilities/registry.ts'
 import { createRemoteConnectorMcpClient } from '#worker/remote-connector/client.ts'
 import { remoteConnectorDomainId } from '#worker/remote-connector/remote-domain-id.ts'
 import { normalizeRemoteConnectorRefs } from '@kody-internal/shared/remote-connectors.ts'
@@ -65,7 +66,7 @@ class MCPBase extends McpAgent<Env, State, Props> {
 	async init() {
 		const caller = this.getCallerContext()
 		const userId = caller.user?.userId ?? null
-		const [overlay, remoteConnectors] = await Promise.all([
+		const [overlay, remoteConnectors, registry] = await Promise.all([
 			userId !== null
 				? getMcpUserServerInstructions(this.env.APP_DB, userId)
 				: Promise.resolve(null),
@@ -73,10 +74,15 @@ class MCPBase extends McpAgent<Env, State, Props> {
 				env: this.env,
 				caller,
 			}),
+			getCapabilityRegistryForContext({
+				env: this.env,
+				callerContext: caller,
+			}),
 		])
 		this.server = createKodyMcpServer({
 			instructions: buildMcpServerInstructions({
 				userOverlay: overlay,
+				domains: registry.capabilityDomains,
 				remoteConnectors,
 			}),
 			jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),

--- a/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import {
+	assignRoleInMcpTestDatabase,
 	createMcpClient,
 	createTestDatabase,
 	startDevServer,
@@ -56,4 +57,61 @@ test('authenticated MCP smoke returns same-origin inline UI sessions', async () 
 	expect(executeEndpoint).toBeTruthy()
 	const executeUrl = new URL(String(executeEndpoint), server.origin)
 	expect(executeUrl.origin).toBe(server.origin)
+})
+
+test('authenticated MCP search shows admin capabilities only to admin users', async () => {
+	await using database = await createTestDatabase()
+	await using server = await startDevServer(database.persistDir)
+	const regularUser = {
+		email: 'jane@example.com',
+		username: 'jane',
+		password: 'ilikecode',
+	}
+	await using regularClient = await createMcpClient(server.origin, regularUser)
+
+	const regularSearch = await regularClient.client.callTool({
+		name: 'search',
+		arguments: {
+			query: 'admin users roles audit',
+			limit: 10,
+		},
+	})
+	const regularMatches =
+		(
+			(regularSearch as CallToolResult).structuredContent as {
+				result?: { matches?: Array<{ id?: string }> }
+			}
+		)?.result?.matches ?? []
+	expect(regularMatches.some((match) => match.id === 'admin_user_list')).toBe(
+		false,
+	)
+
+	await using bootstrapClient = await createMcpClient(
+		server.origin,
+		database.user,
+	)
+	void bootstrapClient
+	await assignRoleInMcpTestDatabase({
+		persistDir: database.persistDir,
+		email: database.user.email,
+		role: 'admin',
+	})
+	await using adminClient = await createMcpClient(server.origin, database.user)
+
+	const adminSearch = await adminClient.client.callTool({
+		name: 'search',
+		arguments: {
+			query: 'admin users roles audit',
+			limit: 10,
+		},
+	})
+	const adminMatches =
+		(
+			(adminSearch as CallToolResult).structuredContent as {
+				result?: { matches?: Array<{ id?: string }> }
+			}
+		)?.result?.matches ?? []
+	expect(adminMatches.some((match) => match.id === 'admin_user_list')).toBe(
+		true,
+	)
 })

--- a/packages/worker/src/mcp/run-codemode-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.node.test.ts
@@ -1,5 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import { type getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
+import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { buildKodyModuleBundle } from '#worker/package-runtime/module-graph.ts'
 import {
@@ -17,6 +19,45 @@ import {
 	type PersistedJobCallerContext,
 } from '#worker/jobs/types.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
+
+test('buildCodemodeFns rejects role-gated capabilities even when passed an unfiltered registry', async () => {
+	const adminOnlyCapability = defineDomainCapability('admin', {
+		name: 'admin_user_list',
+		description: 'List admin user account metadata',
+		readOnly: true,
+		idempotent: true,
+		requiredRole: 'admin',
+		inputSchema: {
+			type: 'object',
+			properties: {},
+		},
+		handler: async () => ({ ok: true }),
+	})
+	const registry = buildCapabilityRegistry([
+		{
+			name: 'admin',
+			description: 'Admin capabilities',
+			capabilities: [adminOnlyCapability],
+		},
+	])
+	const tools = await buildCodemodeFns(
+		{} as Env,
+		createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'user',
+				roles: ['user'],
+			},
+		}),
+		{ capabilityRegistry: registry },
+	)
+
+	await expect(tools.admin_user_list({})).rejects.toThrow(
+		'MCP user lacks required role "admin" for capability "admin_user_list".',
+	)
+})
 
 test('package workflow tools create instances from package context and honor caller overrides in runModuleWithRegistry', async () => {
 	const created: Array<WorkflowInstanceCreateOptions<unknown>> = []

--- a/packages/worker/src/mcp/run-codemode-registry.ts
+++ b/packages/worker/src/mcp/run-codemode-registry.ts
@@ -28,6 +28,7 @@ import { resolveSecret } from '#mcp/secrets/service.ts'
 import { type ReferencedSecret } from '#mcp/secrets/placeholders.ts'
 import { buildParameterizedSkillCode } from '#mcp/skills/skill-parameters.ts'
 import { type BuiltCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
+import { assertCallerCanAccessCapability } from '#mcp/capabilities/access-control.ts'
 import { getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
 import { createExecuteHelperPrelude } from '#mcp/execute-modules/codemode-utils.ts'
 import {
@@ -352,6 +353,7 @@ export async function buildCodemodeFns(
 		Object.values(capabilityMap).map((capability) => [
 			capability.name,
 			async (args: unknown) => {
+				assertCallerCanAccessCapability(callerContext, capability)
 				const resolveSecretValue =
 					options?.resolveSecretValue ??
 					createCapabilityInputSecretResolver(

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -1,8 +1,12 @@
-import { builtinDomains } from '#mcp/capabilities/builtin-domains.ts'
+import { type CapabilityDomainMetadata } from '#mcp/capabilities/types.ts'
 
-const domainInstructions = builtinDomains
-	.map((domain) => `- \`${domain.name}\`: ${domain.description}`)
-	.join('\n')
+function formatDomainInstructions(
+	domains: ReadonlyArray<CapabilityDomainMetadata>,
+) {
+	return domains
+		.map((domain) => `- \`${domain.name}\`: ${domain.description}`)
+		.join('\n')
+}
 
 const maxRemoteConnectorDescriptionChars = 240
 
@@ -41,9 +45,11 @@ export const conversationIdGuidance =
 
 export function buildBaseMcpServerInstructions(
 	input: {
+		domains?: ReadonlyArray<CapabilityDomainMetadata>
 		remoteConnectors?: ReadonlyArray<RemoteConnectorInstructionSummary>
 	} = {},
 ): string {
+	const domainInstructions = formatDomainInstructions(input.domains ?? [])
 	return `
 End-user documentation (workflows, secrets, troubleshooting):
 https://github.com/kentcdodds/kody/tree/main/docs/use
@@ -108,12 +114,14 @@ export function buildMcpServerInstructions(
 		| undefined
 		| {
 				userOverlay?: string | null | undefined
+				domains?: ReadonlyArray<CapabilityDomainMetadata>
 				remoteConnectors?: ReadonlyArray<RemoteConnectorInstructionSummary>
 		  },
 ): string {
 	const normalizedInput =
 		typeof input === 'object' && input !== null ? input : { userOverlay: input }
 	const base = buildBaseMcpServerInstructions({
+		domains: normalizedInput.domains,
 		remoteConnectors: normalizedInput.remoteConnectors,
 	})
 	const userOverlay = normalizedInput.userOverlay

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -1,6 +1,9 @@
 import { expect, test, vi } from 'vitest'
 import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
+import { filterCapabilityRegistryForCaller } from '#mcp/capabilities/access-control.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { buildIntegrationValueName } from '#mcp/capabilities/integrations/integration-shared.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
 import type * as PackageRegistrySource from '#worker/package-registry/source.ts'
 import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
 import {
@@ -11,6 +14,55 @@ import {
 	type OptionalSearchRowsResult,
 	type PackageSearchRow,
 } from './search.ts'
+
+function buildRoleGatedSearchRegistry() {
+	const publicCapability = defineDomainCapability('meta', {
+		name: 'public_docs_search',
+		description: 'Search public docs',
+		keywords: ['public', 'docs', 'search'],
+		readOnly: true,
+		idempotent: true,
+		inputSchema: {
+			type: 'object',
+			properties: {},
+		},
+		handler: async () => null,
+	})
+	const adminCapability = defineDomainCapability('admin', {
+		name: 'admin_user_list',
+		description: 'List admin user account metadata and roles',
+		keywords: ['admin', 'users', 'roles', 'accounts'],
+		readOnly: true,
+		idempotent: true,
+		requiredRole: 'admin',
+		inputSchema: {
+			type: 'object',
+			properties: {},
+		},
+		handler: async () => null,
+	})
+	return buildCapabilityRegistry([
+		{
+			name: 'admin',
+			description: 'Admin capabilities',
+			capabilities: [adminCapability],
+		},
+		{
+			name: 'meta',
+			description: 'Meta capabilities',
+			capabilities: [publicCapability],
+		},
+	])
+}
+
+const emptyOptionalSearchRows = {
+	packageRows: [],
+	userSecretRows: [],
+	userValueRows: [],
+} satisfies Pick<
+	OptionalSearchRowsResult,
+	'packageRows' | 'userSecretRows' | 'userValueRows'
+>
 
 function createPackageExportProjection(
 	subpath: string,
@@ -194,6 +246,113 @@ test('searchUnified ranks mixed search rows through one shared pipeline', async 
 			}),
 		]),
 	)
+})
+
+test('searchUnified hides admin capabilities from non-admins in offline search', async () => {
+	const registry = buildRoleGatedSearchRegistry()
+	const regularRegistry = filterCapabilityRegistryForCaller(
+		registry,
+		createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'user',
+				roles: ['user'],
+			},
+		}),
+	)
+	const adminRegistry = filterCapabilityRegistryForCaller(
+		registry,
+		createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'admin-1',
+				email: 'admin@example.com',
+				displayName: 'admin',
+				roles: ['admin'],
+			},
+		}),
+	)
+
+	const regularResult = await searchUnified({
+		env: { SENTRY_ENVIRONMENT: 'test' } as Env,
+		query: 'admin users roles',
+		limit: 5,
+		registry: regularRegistry,
+		optionalRows: emptyOptionalSearchRows,
+	})
+	const adminResult = await searchUnified({
+		env: { SENTRY_ENVIRONMENT: 'test' } as Env,
+		query: 'admin users roles',
+		limit: 5,
+		registry: adminRegistry,
+		optionalRows: emptyOptionalSearchRows,
+	})
+
+	expect(
+		regularResult.matches.some(
+			(match) =>
+				match.type === 'capability' && match.name === 'admin_user_list',
+		),
+	).toBe(false)
+	expect(
+		adminResult.matches.some(
+			(match) =>
+				match.type === 'capability' && match.name === 'admin_user_list',
+		),
+	).toBe(true)
+})
+
+test('searchUnified hides admin capabilities from non-admins in Vectorize-backed search', async () => {
+	const registry = buildRoleGatedSearchRegistry()
+	const regularRegistry = filterCapabilityRegistryForCaller(
+		registry,
+		createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'user',
+				roles: ['user'],
+			},
+		}),
+	)
+	const env = {
+		SENTRY_ENVIRONMENT: 'production',
+		CAPABILITY_VECTOR_INDEX: {
+			async query() {
+				return {
+					matches: [
+						{ id: 'admin_user_list', score: 0.99 },
+						{ id: 'public_docs_search', score: 0.5 },
+					],
+				}
+			},
+		},
+	} as unknown as Env
+
+	const result = await searchUnified({
+		env,
+		query: 'admin users roles',
+		limit: 5,
+		registry: regularRegistry,
+		optionalRows: emptyOptionalSearchRows,
+	})
+
+	expect(result.offline).toBe(false)
+	expect(
+		result.matches.some(
+			(match) =>
+				match.type === 'capability' && match.name === 'admin_user_list',
+		),
+	).toBe(false)
+	expect(
+		result.matches.some(
+			(match) =>
+				match.type === 'capability' && match.name === 'public_docs_search',
+		),
+	).toBe(true)
 })
 
 test('searchUnified ranks package retriever results alongside capabilities', async () => {

--- a/tools/mcp-test-support.ts
+++ b/tools/mcp-test-support.ts
@@ -44,6 +44,10 @@ type ConnectedTestClient = {
 	listTools(): ReturnType<Client['listTools']>
 }
 
+function quoteSql(value: string) {
+	return `'${value.replace(/'/g, "''")}'`
+}
+
 export async function createTestDatabase() {
 	const persistDir = await mkdtemp(path.join(tmpdir(), 'kody-mcp-e2e-'))
 	const user = {
@@ -167,6 +171,51 @@ export async function startDevServer(persistDir: string) {
 
 	throw new Error(
 		'Failed to start MCP test dev servers after multiple retries.',
+	)
+}
+
+export async function assignRoleInMcpTestDatabase(input: {
+	persistDir: string
+	email: string
+	role: string
+}) {
+	const sql = `
+INSERT OR IGNORE INTO user_roles (user_id, role_id)
+SELECT u.id, r.id
+FROM users u, roles r
+WHERE u.email = ${quoteSql(input.email)} AND r.name = ${quoteSql(input.role)};`.trim()
+	const proc = spawnProcess({
+		cmd: [
+			nodeBin,
+			'--env-file=packages/worker/.env',
+			'./wrangler-env.ts',
+			'd1',
+			'execute',
+			'APP_DB',
+			'--local',
+			'--persist-to',
+			input.persistDir,
+			'--command',
+			sql,
+		],
+		cwd: projectRoot,
+		env: {
+			...process.env,
+			CLOUDFLARE_ENV: 'test',
+		},
+	})
+	const getStdout = captureOutput(proc.stdout)
+	const getStderr = captureOutput(proc.stderr)
+	const exitCode = await proc.exited
+	if (exitCode === 0) return
+	throw new Error(
+		[
+			`Failed to assign MCP test role (exit ${String(exitCode)}).`,
+			getStdout(),
+			getStderr(),
+		]
+			.filter(Boolean)
+			.join('\n\n'),
 	)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds generic `requiredRole` / `requiredPermission` capability metadata with per-request registry filtering and execute-time hard rejection.
- Registers an admin-only MCP capability domain with `admin_user_list`, `admin_user_get`, and `admin_audit_log_query` for account/audit metadata only.
- Persists sanitized audit event metadata in D1 (`0049-audit-events.sql`) and audits admin capability invocations.
- Documents role-gated capabilities and notes that invite/create-user service functions can be exposed as admin capabilities after the invite-signup branch lands.

## Testing

- `npm run validate` ✅
  - format, lint, typecheck exited 0
  - unit tests: 161 files / 490 tests passed
  - Playwright E2E: 5 passed
  - MCP E2E: 3 passed

## Extension note

When the invite-signup branch merges, expose its invite and admin create-user-by-email service functions by adding new `packages/worker/src/mcp/capabilities/admin/*` capability files that call those service functions directly, set `requiredRole: 'admin'`, and audit-log the invocation. Do not duplicate invite/user-creation SQL in capability handlers.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `e234f85` · **Head:** `0222d32`

**Classification:** extends — this PR changes capability registry visibility/execution contracts, adds admin MCP capabilities, and extends the D1 app DB with sanitized audit-event storage.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — MCP instructions/search/list/execute now use caller-visible capability registries |
| `rbac` | auth | extends — capability registrations can require roles/permissions and admin capabilities depend on fresh MCP RBAC context |
| `capability-registry` | assistant | extends — adds `admin` domain and generic `requiredRole` / `requiredPermission` metadata |
| `codemode-execute` | runtime | extends — codemode rejects gated capabilities even when passed an unfiltered registry |
| `d1-app-db` | storage | extends — adds `audit_events` table for sanitized audit metadata |
| `vectorize-search` | storage | composes — search receives filtered specs so both Vectorize and offline rankers hide gated capabilities |

### System map

```mermaid
flowchart LR
	mcpOauth["mcp-oauth"]:::untouched --> rbac["rbac"]:::extended
	rbac --> capabilityRegistry["capability-registry"]:::extended
	capabilityRegistry --> mcpServer["mcp-server"]:::extended
	capabilityRegistry --> vectorizeSearch["vectorize-search"]:::touched
	mcpServer --> codemodeExecute["codemode-execute"]:::extended
	mcpServer --> d1AppDb["d1-app-db"]:::extended
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Host as MCP host
	participant MCP as MCP server
	participant Registry as Filtered registry
	participant Execute as Codemode execute
	participant DB as APP_DB
	Host->>MCP: search / meta_list_capabilities
	MCP->>Registry: filter capabilities by current caller roles
	Registry-->>MCP: admin capabilities only for admin role
	Host->>Execute: codemode.admin_user_list(...)
	Execute->>Registry: assert caller can access capability
	Execute->>DB: read users/roles account metadata
	Execute->>DB: write sanitized audit_events row
```

### Invariants

- Preserves `per-user-isolation`: admin capabilities expose account metadata and sanitized audit metadata only; they do not join or return user content tables such as packages, secrets, values, memories, jobs, email, storage, OAuth grants, or remote connectors.
- Role checks are evaluated from the current MCP caller context for each request; role decisions are not cached in Vectorize metadata, OAuth grants, or registry cache keys.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-578f0689-5faf-4898-bf1d-7a66e29a576e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-578f0689-5faf-4898-bf1d-7a66e29a576e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

