### PR TITLE
Fix production capability vector reindex resilience

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -268,8 +268,16 @@ jobs:
           fi
           base="${DEPLOY_URL%/}"
           echo "POST ${base}/__maintenance/reindex-capabilities"
-          curl --fail --silent --show-error --location --max-time 120 \
+          status="$(curl --silent --show-error --location --max-time 120 \
             -X POST \
             -H "Authorization: Bearer ${CAPABILITY_REINDEX_SECRET}" \
             -H "Accept: application/json" \
-            "${base}/__maintenance/reindex-capabilities"
+            --output reindex-response.json \
+            --write-out "%{http_code}" \
+            "${base}/__maintenance/reindex-capabilities")"
+          cat reindex-response.json
+          echo
+          if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+            echo "Capability reindex failed with HTTP ${status}." >&2
+            exit 1
+          fi

--- a/packages/worker/src/capability-maintenance.node.test.ts
+++ b/packages/worker/src/capability-maintenance.node.test.ts
@@ -123,6 +123,20 @@ test('capability reindex maintenance route attempts every vector kind before rep
 			failed: 1,
 			error: '1 saved package vector(s) failed to reindex',
 		},
+		failure: {
+			phase: 'reindex-capability-vectors',
+			failedPhases: [
+				{
+					phase: 'memories',
+					cause: 'memory failed',
+				},
+				{
+					phase: 'packages',
+					cause: '1 saved package vector(s) failed to reindex',
+					failed: 1,
+				},
+			],
+		},
 		error:
 			'Capability search vector reindex failed for memories, packages: memories: memory failed; packages: 1 saved package vector(s) failed to reindex',
 	})

--- a/packages/worker/src/capability-maintenance.ts
+++ b/packages/worker/src/capability-maintenance.ts
@@ -13,10 +13,23 @@ type ReindexStepResult = {
 	upserted: number
 	error?: string
 	failed?: number
+	warning?: string
+	failures?: Array<{
+		id: string
+		phase: string
+		error: string
+	}>
+}
+
+type ReindexFailureSummary = {
+	phase: string
+	cause: string
+	failed?: number
+	failures?: ReindexStepResult['failures']
 }
 
 async function runReindexStep(
-	run: () => Promise<{ upserted: number }>,
+	run: () => Promise<ReindexStepResult>,
 ): Promise<ReindexStepResult> {
 	try {
 		return await run()
@@ -65,13 +78,27 @@ export async function handleCapabilityReindexRequest(
 					typeof entry[1].error === 'string',
 			)
 			if (failed.length > 0) {
+				const failedPhases: Array<ReindexFailureSummary> = failed.map(
+					([phase, step]) => ({
+						phase,
+						cause: step.error,
+						...(typeof step.failed === 'number' ? { failed: step.failed } : {}),
+						...(step.failures ? { failures: step.failures } : {}),
+					}),
+				)
 				throw new MaintenanceFailureError(
 					`Capability search vector reindex failed for ${failed
 						.map(([kind]) => kind)
 						.join(', ')}: ${failed
 						.map(([kind, step]) => `${kind}: ${step.error}`)
 						.join('; ')}`,
-					result,
+					{
+						...result,
+						failure: {
+							phase: 'reindex-capability-vectors',
+							failedPhases,
+						},
+					},
 				)
 			}
 			return result

--- a/packages/worker/src/jobs/job-reindex.ts
+++ b/packages/worker/src/jobs/job-reindex.ts
@@ -1,17 +1,18 @@
 import {
-	embedTextsForVectorize,
 	getCapabilityVectorIndex,
 	isCapabilitySearchOffline,
 } from '#mcp/capabilities/capability-search.ts'
+import {
+	reindexVectorCandidates,
+	type VectorReindexResult,
+} from '#mcp/capabilities/reindex-batches.ts'
 import { buildJobEmbedText } from '#mcp/jobs-embed.ts'
 import { jobVectorId } from '#mcp/jobs-vectorize.ts'
 import { listJobs } from './service.ts'
 
-const upsertBatchSize = 16
-
 export async function reindexJobVectors(
 	env: Env,
-): Promise<{ upserted: number }> {
+): Promise<VectorReindexResult> {
 	const index = getCapabilityVectorIndex(env)
 	if (!index) {
 		throw new Error('CAPABILITY_VECTOR_INDEX binding is not configured')
@@ -38,27 +39,19 @@ export async function reindexJobVectors(
 	).flat()
 	if (jobs.length === 0) return { upserted: 0 }
 
-	let upserted = 0
-	for (let offset = 0; offset < jobs.length; offset += upsertBatchSize) {
-		const batch = jobs.slice(offset, offset + upsertBatchSize)
-		const texts = batch.map(({ job }) =>
-			buildJobEmbedText({
+	return reindexVectorCandidates({
+		env,
+		index,
+		kind: 'job',
+		candidates: jobs.map(({ userId, job }) => ({
+			id: jobVectorId(job.id),
+			text: buildJobEmbedText({
 				name: job.name,
 				scheduleSummary: job.scheduleSummary,
 				sourceId: job.sourceId,
 				publishedCommit: job.publishedCommit,
 			}),
-		)
-		const vectors = await embedTextsForVectorize(env, texts)
-		await index.upsert(
-			batch.map(({ userId, job }, index_) => ({
-				id: jobVectorId(job.id),
-				values: vectors[index_]!,
-				metadata: { kind: 'job', userId },
-			})),
-		)
-		upserted += batch.length
-	}
-
-	return { upserted }
+			metadata: { kind: 'job', userId },
+		})),
+	})
 }

--- a/packages/worker/src/mcp/capabilities/capability-reindex.ts
+++ b/packages/worker/src/mcp/capabilities/capability-reindex.ts
@@ -1,38 +1,30 @@
 import {
 	buildCapabilityEmbedText,
-	embedTextsForVectorize,
 	getCapabilityVectorIndex,
 } from './capability-search.ts'
+import {
+	reindexVectorCandidates,
+	type VectorReindexResult,
+} from './reindex-batches.ts'
 import { type CapabilitySpec } from './types.ts'
-
-const upsertBatchSize = 16
 
 export async function reindexCapabilityVectors(
 	env: Env,
 	specs: Record<string, CapabilitySpec>,
-): Promise<{ upserted: number }> {
+): Promise<VectorReindexResult> {
 	const index = getCapabilityVectorIndex(env)
 	if (!index) {
 		throw new Error('CAPABILITY_VECTOR_INDEX binding is not configured')
 	}
 
-	const list = Object.values(specs)
-	let upserted = 0
-
-	for (let offset = 0; offset < list.length; offset += upsertBatchSize) {
-		const batch = list.slice(offset, offset + upsertBatchSize)
-		const texts = batch.map((spec) => buildCapabilityEmbedText(spec))
-		const rows = await embedTextsForVectorize(env, texts)
-
-		const vectors = batch.map((spec, index_) => ({
+	return reindexVectorCandidates({
+		env,
+		index,
+		kind: 'builtin capability',
+		candidates: Object.values(specs).map((spec) => ({
 			id: spec.name,
-			values: rows[index_]!,
+			text: buildCapabilityEmbedText(spec),
 			metadata: { domain: spec.domain, kind: 'builtin' },
-		}))
-
-		await index.upsert(vectors)
-		upserted += vectors.length
-	}
-
-	return { upserted }
+		})),
+	})
 }

--- a/packages/worker/src/mcp/capabilities/capability-search.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.ts
@@ -1,4 +1,5 @@
 import { type CapabilitySpec } from './types.ts'
+import { getErrorMessage } from './error-message.ts'
 
 type CapabilityVectorizeEnv = {
 	AI?: Ai
@@ -20,8 +21,15 @@ export function getCapabilityVectorIndex(env: Env): VectorizeIndex | undefined {
 /** Must match Vectorize index dimensions for production indexes. */
 export const CAPABILITY_EMBEDDING_DIMENSIONS = 384
 export const CAPABILITY_EMBEDDING_MODEL = '@cf/baai/bge-small-en-v1.5'
+export const CAPABILITY_EMBEDDING_BATCH_SIZE = 8
+export const CAPABILITY_EMBEDDING_MAX_INPUT_CHARS = 2_000
 
 export const CAPABILITY_SEARCH_RRF_K = 60
+
+function truncateEmbeddingInput(text: string) {
+	if (text.length <= CAPABILITY_EMBEDDING_MAX_INPUT_CHARS) return text
+	return text.slice(0, CAPABILITY_EMBEDDING_MAX_INPUT_CHARS)
+}
 
 function fnv1a32(input: string): number {
 	let hash = 2_166_136_261
@@ -206,26 +214,40 @@ export async function embedTextsForVectorize(
 	texts: ReadonlyArray<string>,
 ): Promise<Array<Array<number>>> {
 	if (texts.length === 0) return []
+	const truncatedTexts = texts.map((text) => truncateEmbeddingInput(text))
 
 	const runtime = env as unknown as CapabilityVectorizeEnv
 	if (!runtime.AI) {
 		if (runtime.SENTRY_ENVIRONMENT !== 'production') {
-			return texts.map((text) => deterministicEmbedding(text))
+			return truncatedTexts.map((text) => deterministicEmbedding(text))
 		}
 		throw new Error(
 			'AI binding is required for capability embeddings in production.',
 		)
 	}
+	const aiRuntime = runtime as CapabilityVectorizeEnv & { AI: Ai }
 
-	const options =
-		runtime.AI_GATEWAY_ID && runtime.AI_GATEWAY_ID.trim().length > 0
-			? {
-					gateway: {
-						id: runtime.AI_GATEWAY_ID.trim(),
-					},
-				}
-			: undefined
-	const response = (await runtime.AI.run(
+	const rows: Array<Array<number>> = []
+	for (
+		let offset = 0;
+		offset < truncatedTexts.length;
+		offset += CAPABILITY_EMBEDDING_BATCH_SIZE
+	) {
+		const batch = truncatedTexts.slice(
+			offset,
+			offset + CAPABILITY_EMBEDDING_BATCH_SIZE,
+		)
+		rows.push(...(await embedTextBatchForVectorize(aiRuntime, batch)))
+	}
+	return rows
+}
+
+async function runWorkersAiEmbeddingRequest(
+	runtime: CapabilityVectorizeEnv & { AI: Ai },
+	texts: ReadonlyArray<string>,
+	options?: { gateway: { id: string } },
+) {
+	return (await runtime.AI.run(
 		CAPABILITY_EMBEDDING_MODEL,
 		{
 			text: [...texts],
@@ -233,7 +255,40 @@ export async function embedTextsForVectorize(
 		},
 		options,
 	)) as WorkersAiEmbeddingResponse
+}
 
+async function embedTextBatchForVectorize(
+	runtime: CapabilityVectorizeEnv & { AI: Ai },
+	texts: ReadonlyArray<string>,
+) {
+	const gatewayId = runtime.AI_GATEWAY_ID?.trim()
+	if (gatewayId) {
+		try {
+			const response = await runWorkersAiEmbeddingRequest(runtime, texts, {
+				gateway: { id: gatewayId },
+			})
+			return parseWorkersAiEmbeddingResponse(response, texts.length)
+		} catch (error) {
+			console.warn(
+				JSON.stringify({
+					message:
+						'Workers AI Gateway embedding request failed; retrying direct Workers AI',
+					gatewayId,
+					error: getErrorMessage(error),
+				}),
+			)
+			try {
+				const response = await runWorkersAiEmbeddingRequest(runtime, texts)
+				return parseWorkersAiEmbeddingResponse(response, texts.length)
+			} catch (directError) {
+				throw new Error(
+					`Workers AI embedding request failed after AI Gateway fallback. Gateway error: ${getErrorMessage(error)}. Direct error: ${getErrorMessage(directError)}`,
+				)
+			}
+		}
+	}
+
+	const response = await runWorkersAiEmbeddingRequest(runtime, texts)
 	return parseWorkersAiEmbeddingResponse(response, texts.length)
 }
 

--- a/packages/worker/src/mcp/capabilities/capability-search.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.workers.test.ts
@@ -1,6 +1,8 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import {
+	CAPABILITY_EMBEDDING_BATCH_SIZE,
 	CAPABILITY_EMBEDDING_DIMENSIONS,
+	CAPABILITY_EMBEDDING_MAX_INPUT_CHARS,
 	CAPABILITY_EMBEDDING_MODEL,
 	deterministicEmbedding,
 	embedTextsForVectorize,
@@ -115,6 +117,85 @@ test('embedding wrapper batches texts through Workers AI and AI Gateway', async 
 			{ gateway: { id: 'gateway-123' } },
 		],
 	])
+})
+
+test('embedding wrapper falls back to direct Workers AI when AI Gateway fails', async () => {
+	const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	const calls: Array<Array<unknown>> = []
+	const rows = [embeddingRow(1), embeddingRow(2)]
+	const env = aiEnv(
+		async (...args) => {
+			calls.push(args)
+			if (args[2]) throw new Error('gateway not found')
+			return { data: rows, shape: [2, CAPABILITY_EMBEDDING_DIMENSIONS] }
+		},
+		{ AI_GATEWAY_ID: 'stale-gateway' },
+	)
+
+	try {
+		await expect(
+			embedTextsForVectorize(env, ['alpha', 'beta']),
+		).resolves.toEqual(rows)
+		expect(calls).toEqual([
+			[
+				CAPABILITY_EMBEDDING_MODEL,
+				{ text: ['alpha', 'beta'], pooling: 'cls' },
+				{ gateway: { id: 'stale-gateway' } },
+			],
+			[
+				CAPABILITY_EMBEDDING_MODEL,
+				{ text: ['alpha', 'beta'], pooling: 'cls' },
+				undefined,
+			],
+		])
+		expect(consoleWarn).toHaveBeenCalledWith(
+			expect.stringContaining('retrying direct Workers AI'),
+		)
+	} finally {
+		consoleWarn.mockRestore()
+	}
+})
+
+test('embedding wrapper chunks large batches and truncates long inputs', async () => {
+	const calls: Array<Array<unknown>> = []
+	const inputCount = CAPABILITY_EMBEDDING_BATCH_SIZE + 1
+	const env = aiEnv(async (...args) => {
+		calls.push(args)
+		const payload = args[1] as { text: Array<string> }
+		return {
+			data: payload.text.map((_, index) =>
+				embeddingRow(calls.length * 10 + index),
+			),
+			shape: [payload.text.length, CAPABILITY_EMBEDDING_DIMENSIONS],
+		}
+	})
+
+	await expect(
+		embedTextsForVectorize(env, [
+			'x'.repeat(CAPABILITY_EMBEDDING_MAX_INPUT_CHARS + 500),
+			...Array.from({ length: inputCount - 1 }, (_, index) => `text-${index}`),
+		]),
+	).resolves.toHaveLength(inputCount)
+
+	expect(calls).toHaveLength(2)
+	expect(
+		calls.map((args) => (args[1] as { text: Array<string> }).text.length),
+	).toEqual([CAPABILITY_EMBEDDING_BATCH_SIZE, 1])
+	expect(
+		(calls[0]![1] as { text: Array<string> }).text.every(
+			(text) => text.length <= CAPABILITY_EMBEDDING_MAX_INPUT_CHARS,
+		),
+	).toBe(true)
+})
+
+test('embedding wrapper reports direct Workers AI failures', async () => {
+	const env = aiEnv(async () => {
+		throw new Error('workers ai unavailable')
+	})
+
+	await expect(embedTextsForVectorize(env, ['alpha'])).rejects.toThrow(
+		/workers ai unavailable/,
+	)
 })
 
 test('embedding wrapper falls back deterministically outside production when AI is unavailable', async () => {

--- a/packages/worker/src/mcp/capabilities/reindex-batches.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/reindex-batches.node.test.ts
@@ -1,0 +1,98 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	embedTextsForVectorize: vi.fn(),
+}))
+
+vi.mock('./capability-search.ts', () => ({
+	embedTextsForVectorize: (...args: Array<unknown>) =>
+		mockModule.embedTextsForVectorize(...args),
+}))
+
+const { reindexVectorCandidates } = await import('./reindex-batches.ts')
+
+test('reindexVectorCandidates isolates failed embedding items and upserts the rest', async () => {
+	mockModule.embedTextsForVectorize.mockReset()
+	const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+	const upsert = vi.fn()
+	const env = {} as Env
+	mockModule.embedTextsForVectorize.mockImplementation(
+		async (_env: Env, texts: Array<string>) => {
+			if (texts.includes('bad')) throw new Error('embedding input rejected')
+			return texts.map((text) => [text.length])
+		},
+	)
+
+	try {
+		await expect(
+			reindexVectorCandidates({
+				env,
+				index: { upsert } as unknown as VectorizeIndex,
+				kind: 'test',
+				candidates: [
+					{ id: 'good-1', text: 'alpha', metadata: { kind: 'test' } },
+					{ id: 'bad-1', text: 'bad', metadata: { kind: 'test' } },
+					{ id: 'good-2', text: 'beta', metadata: { kind: 'test' } },
+				],
+			}),
+		).resolves.toEqual({
+			upserted: 2,
+			failed: 1,
+			failures: [
+				{
+					id: 'bad-1',
+					phase: 'embed',
+					error: 'embedding input rejected',
+				},
+			],
+			warning: '1 test vector(s) failed to reindex',
+		})
+
+		expect(upsert).toHaveBeenCalledWith([
+			{
+				id: 'good-1',
+				values: [5],
+				metadata: { kind: 'test' },
+			},
+		])
+		expect(upsert).toHaveBeenCalledWith([
+			{
+				id: 'good-2',
+				values: [4],
+				metadata: { kind: 'test' },
+			},
+		])
+		expect(consoleError).toHaveBeenCalledWith(
+			expect.stringContaining('capability vector reindex skipped vector'),
+		)
+	} finally {
+		consoleError.mockRestore()
+	}
+})
+
+test('reindexVectorCandidates marks a phase fatal when every vector fails', async () => {
+	mockModule.embedTextsForVectorize.mockReset()
+	const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+	const env = {} as Env
+	mockModule.embedTextsForVectorize.mockRejectedValue(new Error('ai down'))
+
+	try {
+		await expect(
+			reindexVectorCandidates({
+				env,
+				index: { upsert: vi.fn() } as unknown as VectorizeIndex,
+				kind: 'test',
+				candidates: [
+					{ id: 'bad-1', text: 'alpha', metadata: { kind: 'test' } },
+					{ id: 'bad-2', text: 'beta', metadata: { kind: 'test' } },
+				],
+			}),
+		).resolves.toMatchObject({
+			upserted: 0,
+			failed: 2,
+			error: '2 test vector(s) failed to reindex',
+		})
+	} finally {
+		consoleError.mockRestore()
+	}
+})

--- a/packages/worker/src/mcp/capabilities/reindex-batches.ts
+++ b/packages/worker/src/mcp/capabilities/reindex-batches.ts
@@ -1,0 +1,124 @@
+import { getErrorMessage } from './error-message.ts'
+import { embedTextsForVectorize } from './capability-search.ts'
+
+export type VectorReindexFailurePhase = 'load' | 'embed' | 'upsert'
+
+export type VectorReindexFailure = {
+	id: string
+	phase: VectorReindexFailurePhase
+	error: string
+}
+
+export type VectorReindexCandidate = {
+	id: string
+	text: string
+	metadata: Record<string, VectorizeVectorMetadata>
+}
+
+export type VectorReindexResult = {
+	upserted: number
+	failed?: number
+	warning?: string
+	error?: string
+	failures?: Array<VectorReindexFailure>
+}
+
+const upsertBatchSize = 16
+const maxReportedFailures = 20
+
+export async function reindexVectorCandidates(input: {
+	env: Env
+	index: VectorizeIndex
+	kind: string
+	candidates: ReadonlyArray<VectorReindexCandidate>
+}): Promise<VectorReindexResult> {
+	let upserted = 0
+	let failed = 0
+	const failures: Array<VectorReindexFailure> = []
+
+	function recordFailure(input_: {
+		candidate: VectorReindexCandidate
+		phase: VectorReindexFailurePhase
+		error: unknown
+	}) {
+		failed += 1
+		const failure = {
+			id: input_.candidate.id,
+			phase: input_.phase,
+			error: getErrorMessage(input_.error),
+		}
+		if (failures.length < maxReportedFailures) failures.push(failure)
+		console.error(
+			JSON.stringify({
+				message: 'capability vector reindex skipped vector',
+				kind: input.kind,
+				vectorId: input_.candidate.id,
+				phase: input_.phase,
+				error: failure.error,
+			}),
+		)
+	}
+
+	async function splitOrRecord(
+		batch: ReadonlyArray<VectorReindexCandidate>,
+		phase: VectorReindexFailurePhase,
+		error: unknown,
+	) {
+		if (batch.length === 1) {
+			recordFailure({ candidate: batch[0]!, phase, error })
+			return
+		}
+		const midpoint = Math.ceil(batch.length / 2)
+		await processBatch(batch.slice(0, midpoint))
+		await processBatch(batch.slice(midpoint))
+	}
+
+	async function processBatch(batch: ReadonlyArray<VectorReindexCandidate>) {
+		let embeddings: Array<Array<number>>
+		try {
+			embeddings = await embedTextsForVectorize(
+				input.env,
+				batch.map((candidate) => candidate.text),
+			)
+		} catch (error) {
+			await splitOrRecord(batch, 'embed', error)
+			return
+		}
+
+		try {
+			await input.index.upsert(
+				batch.map((candidate, index_) => ({
+					id: candidate.id,
+					values: embeddings[index_]!,
+					metadata: candidate.metadata,
+				})),
+			)
+			upserted += batch.length
+		} catch (error) {
+			await splitOrRecord(batch, 'upsert', error)
+		}
+	}
+
+	for (
+		let offset = 0;
+		offset < input.candidates.length;
+		offset += upsertBatchSize
+	) {
+		await processBatch(input.candidates.slice(offset, offset + upsertBatchSize))
+	}
+
+	if (failed === 0) return { upserted }
+
+	const result: VectorReindexResult = {
+		upserted,
+		failed,
+		failures,
+	}
+	const message = `${failed} ${input.kind} vector(s) failed to reindex`
+	if (upserted === 0 && input.candidates.length > 0) {
+		result.error = message
+	} else {
+		result.warning = message
+	}
+	return result
+}

--- a/packages/worker/src/mcp/memory/memory-reindex.ts
+++ b/packages/worker/src/mcp/memory/memory-reindex.ts
@@ -1,17 +1,18 @@
 import {
-	embedTextsForVectorize,
 	getCapabilityVectorIndex,
 	isCapabilitySearchOffline,
 } from '#mcp/capabilities/capability-search.ts'
+import {
+	reindexVectorCandidates,
+	type VectorReindexResult,
+} from '#mcp/capabilities/reindex-batches.ts'
 import { buildMemoryEmbedTextFromRow } from './memory-embed.ts'
 import { listAllMemories } from './repo.ts'
 import { memoryVectorId } from './memory-vectorize.ts'
 
-const upsertBatchSize = 16
-
-export async function reindexMemoryVectors(env: Env): Promise<{
-	upserted: number
-}> {
+export async function reindexMemoryVectors(
+	env: Env,
+): Promise<VectorReindexResult> {
 	const index = getCapabilityVectorIndex(env)
 	if (!index) {
 		throw new Error('CAPABILITY_VECTOR_INDEX binding is not configured')
@@ -27,25 +28,19 @@ export async function reindexMemoryVectors(env: Env): Promise<{
 		return { upserted: 0 }
 	}
 
-	let upserted = 0
-	for (let offset = 0; offset < rows.length; offset += upsertBatchSize) {
-		const batch = rows.slice(offset, offset + upsertBatchSize)
-		const texts = batch.map((row) => buildMemoryEmbedTextFromRow(row))
-		const vectors = await embedTextsForVectorize(env, texts)
-		await index.upsert(
-			batch.map((row, index_) => ({
-				id: memoryVectorId(row.id),
-				values: vectors[index_]!,
-				metadata: {
-					kind: 'memory',
-					userId: row.user_id,
-					status: row.status,
-					...(row.category ? { category: row.category } : {}),
-				},
-			})),
-		)
-		upserted += batch.length
-	}
-
-	return { upserted }
+	return reindexVectorCandidates({
+		env,
+		index,
+		kind: 'memory',
+		candidates: rows.map((row) => ({
+			id: memoryVectorId(row.id),
+			text: buildMemoryEmbedTextFromRow(row),
+			metadata: {
+				kind: 'memory',
+				userId: row.user_id,
+				status: row.status,
+				...(row.category ? { category: row.category } : {}),
+			},
+		})),
+	})
 }

--- a/packages/worker/src/package-registry/package-reindex.node.test.ts
+++ b/packages/worker/src/package-registry/package-reindex.node.test.ts
@@ -176,7 +176,14 @@ test('saved package reindex skips failed manifest loads and continues the batch'
 		).resolves.toEqual({
 			upserted: 1,
 			failed: 1,
-			error: '1 saved package vector(s) failed to reindex',
+			failures: [
+				{
+					id: 'package_pkg-bad',
+					phase: 'load',
+					error: 'manifest missing',
+				},
+			],
+			warning: '1 saved package vector(s) failed to reindex',
 		})
 
 		expect(mockModule.embedTextsForVectorize).toHaveBeenCalledWith(env, [

--- a/packages/worker/src/package-registry/package-reindex.ts
+++ b/packages/worker/src/package-registry/package-reindex.ts
@@ -1,19 +1,27 @@
 import {
-	embedTextsForVectorize,
 	getCapabilityVectorIndex,
 	isCapabilitySearchOffline,
 } from '#mcp/capabilities/capability-search.ts'
+import {
+	reindexVectorCandidates,
+	type VectorReindexCandidate,
+	type VectorReindexFailure,
+} from '#mcp/capabilities/reindex-batches.ts'
 import { getErrorMessage } from '#mcp/capabilities/error-message.ts'
 import { buildSavedPackageEmbedText } from './embed.ts'
 import { listAllSavedPackages, savedPackageVectorId } from './repo.ts'
 import { loadPackageManifestBySourceId } from './source.ts'
 
-const upsertBatchSize = 16
-
 export async function reindexSavedPackageVectors(
 	env: Env,
 	input: { baseUrl: string },
-): Promise<{ upserted: number; failed?: number; error?: string }> {
+): Promise<{
+	upserted: number
+	failed?: number
+	warning?: string
+	error?: string
+	failures?: Array<VectorReindexFailure>
+}> {
 	const index = getCapabilityVectorIndex(env)
 	if (!index) {
 		throw new Error('CAPABILITY_VECTOR_INDEX binding is not configured')
@@ -27,58 +35,59 @@ export async function reindexSavedPackageVectors(
 		return { upserted: 0 }
 	}
 
-	let upserted = 0
 	let failed = 0
-	for (let offset = 0; offset < rows.length; offset += upsertBatchSize) {
-		const batch = rows.slice(offset, offset + upsertBatchSize)
-		const loaded: Array<{ row: (typeof batch)[number]; embedText: string }> = []
-		for (const row of batch) {
-			try {
-				const { manifest } = await loadPackageManifestBySourceId({
-					env,
-					baseUrl: input.baseUrl,
-					userId: row.userId,
-					sourceId: row.sourceId,
-				})
-				loaded.push({
-					row,
-					embedText: buildSavedPackageEmbedText(manifest),
-				})
-			} catch (error) {
-				failed += 1
-				console.error(
-					JSON.stringify({
-						message: 'saved package vector reindex skipped package',
-						packageId: row.id,
-						sourceId: row.sourceId,
-						error: getErrorMessage(error),
-					}),
-				)
-			}
-		}
-		if (loaded.length === 0) continue
-		const vectors = await embedTextsForVectorize(
-			env,
-			loaded.map(({ embedText }) => embedText),
-		)
-		await index.upsert(
-			loaded.map(({ row }, index_) => ({
+	const failures: Array<VectorReindexFailure> = []
+	const candidates: Array<VectorReindexCandidate> = []
+	for (const row of rows) {
+		try {
+			const { manifest } = await loadPackageManifestBySourceId({
+				env,
+				baseUrl: input.baseUrl,
+				userId: row.userId,
+				sourceId: row.sourceId,
+			})
+			candidates.push({
 				id: savedPackageVectorId(row.id),
-				values: vectors[index_]!,
+				text: buildSavedPackageEmbedText(manifest),
 				metadata: {
 					kind: 'package',
 					userId: row.userId,
 				},
-			})),
-		)
-		upserted += loaded.length
+			})
+		} catch (error) {
+			failed += 1
+			const failure = {
+				id: savedPackageVectorId(row.id),
+				phase: 'load' as const,
+				error: getErrorMessage(error),
+			}
+			failures.push(failure)
+			console.error(
+				JSON.stringify({
+					message: 'saved package vector reindex skipped package',
+					packageId: row.id,
+					sourceId: row.sourceId,
+					error: failure.error,
+				}),
+			)
+		}
 	}
 
-	return failed > 0
-		? {
-				upserted,
-				failed,
-				error: `${failed} saved package vector(s) failed to reindex`,
-			}
-		: { upserted }
+	const result = await reindexVectorCandidates({
+		env,
+		index,
+		kind: 'saved package',
+		candidates,
+	})
+	const totalFailed = failed + (result.failed ?? 0)
+	const allFailures = [...failures, ...(result.failures ?? [])]
+	if (totalFailed === 0) return { upserted: result.upserted }
+
+	const summary = `${totalFailed} saved package vector(s) failed to reindex`
+	return {
+		upserted: result.upserted,
+		failed: totalFailed,
+		failures: allFailures,
+		...(result.upserted === 0 ? { error: summary } : { warning: summary }),
+	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Make optional `AI_GATEWAY_ID` routing fail-open: if Workers AI via AI Gateway throws, embeddings retry direct Workers AI and log a structured warning.
- Bound embedding calls with safe batching and input truncation, then make reindex upserts recursively split failed batches down to individual vectors so one bad item is skipped/reported instead of aborting an entire phase.
- Return structured maintenance failure JSON with failing phase/cause and print the response body from the deploy workflow on non-2xx reindex responses.

## Root-cause analysis
Most plausible root cause is AI Gateway misconfiguration exposed by #613. `AI_GATEWAY_ID` had been synced as an optional secret but unused; after #613, every embedding call passed that id into `env.AI.run`. If the gateway id is stale/nonexistent in the Cloudflare account, the first embedding request throws and the production maintenance endpoint returns 500. The code also had two secondary production risks: it did not enforce Workers AI embedding batch/input limits in `embedTextsForVectorize`, and reindex batches were all-or-nothing on embed/upsert failures.

I cannot verify account-level Cloudflare Gateway configuration from the repo. Kent should check the production `AI_GATEWAY_ID` secret: either create/fix the matching AI Gateway in the Cloudflare account, or unset the secret. With this PR, an invalid gateway no longer blocks embeddings because direct Workers AI is retried automatically.

## Validation
- `npx vitest run --project node-unit packages/worker/src/capability-maintenance.node.test.ts packages/worker/src/package-registry/package-reindex.node.test.ts packages/worker/src/mcp/capabilities/reindex-batches.node.test.ts`
- `npx vitest run --project workers-unit packages/worker/src/mcp/capabilities/capability-search.workers.test.ts`
- `npm run typecheck`
- `npm run test:e2e:run`
- `npm run validate` (pass; first validate attempt hit a transient Playwright `ssr-hydration` socket hang-up, then E2E and full validate passed on rerun)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `7fb5290` · **Head:** `dcec519`

**Classification:** extends — this changes vector embedding/reindex failure behavior and maintenance response shape, without adding a new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `vectorize-search` | storage | extends — Workers AI embedding calls are batched/truncated, gateway routing is fail-open, and vector reindexing isolates failed items |
| `capability-registry` | assistant | composes — builtin capability vectors use the shared tolerant reindex helper |
| `memories` | assistant | composes — memory vectors use the shared tolerant reindex helper with existing `userId` metadata |
| `jobs` | assistant | composes — job vectors use the shared tolerant reindex helper with existing `userId` metadata |
| `saved-packages` | assistant | composes — saved package vectors distinguish manifest-load failures from embed/upsert failures |
| `scheduled-cron` | surfaces | extends — maintenance failures include structured phase/cause JSON |

### System map

```mermaid
flowchart LR
	maintenance["scheduled-cron / maintenance"]:::extended --> vectorizeSearch["vectorize-search"]:::extended
	capabilityRegistry["capability-registry"]:::touched --> vectorizeSearch
	memories["memories"]:::touched --> vectorizeSearch
	jobs["jobs"]:::touched --> vectorizeSearch
	savedPackages["saved-packages"]:::touched --> vectorizeSearch
	d1AppDb["d1-app-db"]:::untouched --> memories
	d1AppDb --> jobs
	d1AppDb --> savedPackages
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Deploy
	participant Maintenance
	participant Embed as Workers AI embedding
	participant Vectorize
	Deploy->>Maintenance: POST /__maintenance/reindex-capabilities
	Maintenance->>Embed: embed chunks (gateway if configured)
	Embed-->>Maintenance: gateway error
	Maintenance->>Embed: retry direct Workers AI
	Maintenance->>Vectorize: upsert vector batch
	Vectorize-->>Maintenance: item/batch failure
	Maintenance->>Maintenance: split batch to isolate item
	Maintenance-->>Deploy: JSON ok/warning or structured fatal phase
```

### Invariants

- Preserves `per-user-isolation`: memory, job, and package vector metadata continue to carry `userId`; builtin vectors remain global with `kind: builtin`.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e2b0389-68bf-4d1f-8ea4-31a066a98912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e2b0389-68bf-4d1f-8ea4-31a066a98912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reindex operations now provide clearer progress and failure details, including partial-success warnings and per-item failure summaries.
  * Large embedding requests are processed in smaller chunks for more reliable handling.

* **Bug Fixes**
  * Improved resilience when embedding requests fail, including retrying without gateway routing when needed.
  * Reindex jobs now continue past individual item failures and report what was skipped instead of failing silently.
  * Production deploy checks now validate reindex responses more strictly and surface the returned details in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->