### PR TITLE
Add per-user account data export

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -53,6 +53,81 @@ Deletion must cover these user-owned surfaces:
   `repo_sessions` are deleted through the REST client in
   `packages/worker/src/repo/artifacts.ts`.
 
+## Account export inventory
+
+Account export is implemented in `packages/worker/src/app/account-export.ts`. It
+mirrors the deletion inventory so portability and account migration cover the
+same user-owned storage surfaces. The D1 table list is shared with account
+deletion (`accountUserDataTargets`), and
+`packages/worker/src/app/account-export.node.test.ts` applies the live
+migrations to SQLite and fails if a `user_id` / `*_user_id` column is not
+covered by the export list. The hard invariant is the same as every storage
+path: callers pass the authenticated user's stable MCP `userId`, and every query
+or Durable Object lookup is scoped to that id.
+
+Exports are versioned JSON documents:
+
+- `manifest.schemaVersion` — currently `1`.
+- `manifest.generatedAt` — UTC timestamp.
+- `manifest.sections` — per-section counts, warnings, and redacted columns.
+- `manifest.security.secretValuesExported` — always `false`.
+- `d1` — user-scoped D1 rows grouped by table.
+- `durableObjects` — exported user-scoped Durable Object state where it is
+  durable and enumerable.
+- `oauthGrants` — OAuth grant metadata only.
+- `artifactRepos` — Artifacts repo pointers from `entity_sources`.
+- `kvKeys` — KV source/cache keys that belong to the user.
+
+Secret values are **never** exported. `secret_entries` rows are metadata-only:
+name, description, bucket, allowed hosts, allowed capabilities, allowed
+packages, and timestamps. The encrypted payload (`encrypted_value`) and lookup
+hash (`lookup_hash`) are omitted. The same redaction rule is applied to other
+credential-equivalent fields such as password hashes, password/email reset token
+hashes, package invocation token hashes, and email reply token hashes. The
+manifest states these redactions explicitly so a partial or intentionally
+redacted export is not mistaken for a complete secret backup.
+
+The browser route `GET /account/export.json` downloads a full JSON export for
+the signed-in user. The MCP capability domain `account` provides a
+migration-safe chunked interface:
+
+- `account_export_manifest` returns the manifest, counts, warnings, and chunking
+  instructions.
+- `account_export_section` pages through one section at a time. D1 rows are read
+  with `section: "d1_table"` and a table name. Durable storage buckets are read
+  with `section: "storage_runner"` and a `storage_id`, using the same
+  StorageRunner `exportStorage({ pageSize, startAfter })` RPC as the dedicated
+  storage export capability.
+
+Durable Object export behavior:
+
+- `StorageRunner` bucket contents are exported with paged entries. These buckets
+  hold application/job/service durable state and are the primary account
+  migration surface for Durable Object storage.
+- `JobManager` exposes scheduler alarm/debug state through an export RPC.
+- `RemoteConnectorSession` exposes persisted connector metadata and tool
+  descriptors through an export RPC.
+- `PackageServiceInstance` uses its status RPC as the stable persisted service
+  state summary.
+- `MCP`, `RepoSession`, and `PackageRealtimeSession` are documented exclusions:
+  MCP objects are SDK session-keyed and not globally enumerable; RepoSession is
+  an ephemeral editing workspace; PackageRealtimeSession is live websocket
+  state. Canonical repo-backed source and durable package app state are covered
+  by Artifacts pointers and StorageRunner buckets instead.
+
+Vectorize entries are intentionally excluded. Memory text and metadata, job
+metadata, and package projections are exported from D1; vectors are derived and
+should be rebuilt by reindexing after import.
+
+Cloudflare Artifacts repo contents are not inlined in the JSON export. D1 stores
+metadata/projections, while canonical package, job, and app source lives in the
+Artifacts repos referenced by `entity_sources.repo_id` and
+`repo_sessions.source_repo_id`. For account migration to a new Cloudflare
+account, first run `account_export_manifest`, page through export sections as
+needed, then separately fetch or clone every repo listed in `artifactRepos`
+using Artifacts access and recreate those repos in the destination account
+before importing D1 projections or republishing packages.
+
 ## D1 (`APP_DB`)
 
 Relational app data lives in D1.

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -312,6 +312,24 @@ export function AccountRoute(handle: Handle) {
 							</div>
 						</section>
 						<section mix={css(cardCss)}>
+							<h2 mix={css(cardTitleCss)}>Your data</h2>
+							<p mix={css(descriptionCss)}>
+								Download a portable JSON export of your Kody account data for
+								backup or migration. Secret values are never included; secret
+								entries export metadata such as names, hosts, and allowlists
+								only.
+							</p>
+							<div>
+								<a
+									href="/account/export.json"
+									download="kody-account-export.json"
+									mix={css(primaryLinkCss)}
+								>
+									Download account export
+								</a>
+							</div>
+						</section>
+						<section mix={css(cardCss)}>
 							<h2 mix={css(cardTitleCss)}>Integrations</h2>
 							<p mix={css(descriptionCss)}>
 								Review saved OAuth provider configurations and reconnect

--- a/packages/worker/src/app/account-data-targets.ts
+++ b/packages/worker/src/app/account-data-targets.ts
@@ -1,0 +1,170 @@
+export type UserScopedDataTarget =
+	| { kind: 'user_id'; table: string }
+	| { kind: 'db_user_id'; table: string }
+	| { kind: 'user_columns'; table: string; columns: ReadonlyArray<string> }
+	| {
+			kind: 'null_user_column'
+			table: string
+			matchColumn: string
+			nullColumns: ReadonlyArray<string>
+	  }
+	| {
+			kind: 'replace_user_column'
+			table: string
+			matchColumn: string
+			setColumn: string
+			value: string
+	  }
+	| { kind: 'bucket_parent'; table: string; parentTable: string }
+	| { kind: 'attachment_parent'; table: string }
+	| { kind: 'community_listing_child'; table: string; listingColumn: string }
+	| { kind: 'mcp_memory_suppression' }
+
+/**
+ * Tables that are scoped by `user_id` (directly or transitively) and should
+ * be included in per-user account operations. The list is intentionally
+ * explicit so adding a new user-scoped table requires a deliberate update here
+ * and a corresponding deletion/export guardrail test update.
+ *
+ * Order matters for deletion: child tables come before parent tables so the
+ * cascade is self-contained even on engines / configs where foreign-key
+ * cascades are disabled. Tables with no `user_id` column (e.g. global mock
+ * tables) are not represented.
+ */
+export const accountUserDataTargets: ReadonlyArray<UserScopedDataTarget> = [
+	{ kind: 'user_id', table: 'package_invocations' },
+	{ kind: 'user_id', table: 'package_invocation_tokens' },
+	{ kind: 'user_id', table: 'workflow_runs' },
+	{ kind: 'user_id', table: 'package_runtime_logs' },
+	{ kind: 'user_id', table: 'package_runtime_runs' },
+	{ kind: 'user_id', table: 'usage_rollups' },
+	{ kind: 'mcp_memory_suppression' },
+	{ kind: 'user_id', table: 'mcp_memories' },
+	{ kind: 'user_id', table: 'mcp_user_server_instructions' },
+	{
+		kind: 'bucket_parent',
+		table: 'value_entries',
+		parentTable: 'value_buckets',
+	},
+	{ kind: 'user_id', table: 'value_buckets' },
+	{
+		kind: 'bucket_parent',
+		table: 'secret_entries',
+		parentTable: 'secret_buckets',
+	},
+	{ kind: 'user_id', table: 'secret_buckets' },
+	{ kind: 'user_id', table: 'remote_connector_settings' },
+	{ kind: 'user_id', table: 'archived_job_artifacts' },
+	{ kind: 'user_id', table: 'published_bundle_artifacts' },
+	{ kind: 'user_id', table: 'jobs' },
+	{ kind: 'user_id', table: 'repo_sessions' },
+	{ kind: 'user_id', table: 'saved_packages' },
+	{ kind: 'user_id', table: 'entity_sources' },
+	{ kind: 'user_id', table: 'email_delivery_events' },
+	{ kind: 'attachment_parent', table: 'email_attachments' },
+	{ kind: 'user_id', table: 'email_messages' },
+	{ kind: 'user_id', table: 'email_threads' },
+	{ kind: 'user_id', table: 'email_inbox_addresses' },
+	{ kind: 'user_id', table: 'email_inboxes' },
+	{ kind: 'user_id', table: 'email_sender_identities' },
+	{ kind: 'user_id', table: 'entitlement_daily_counters' },
+	{
+		kind: 'community_listing_child',
+		table: 'community_ratings',
+		listingColumn: 'listing_id',
+	},
+	{ kind: 'user_id', table: 'community_ratings' },
+	{
+		kind: 'community_listing_child',
+		table: 'community_forks',
+		listingColumn: 'listing_id',
+	},
+	{
+		kind: 'user_columns',
+		table: 'community_forks',
+		columns: ['forker_user_id'],
+	},
+	{
+		kind: 'community_listing_child',
+		table: 'community_reports',
+		listingColumn: 'listing_id',
+	},
+	{
+		kind: 'user_columns',
+		table: 'community_reports',
+		columns: ['listing_owner_user_id', 'reporter_user_id'],
+	},
+	{
+		kind: 'null_user_column',
+		table: 'community_reports',
+		matchColumn: 'resolved_by_user_id',
+		nullColumns: ['resolved_by_user_id', 'resolved_at', 'resolution_note'],
+	},
+	{
+		kind: 'user_columns',
+		table: 'community_bans',
+		columns: ['user_id'],
+	},
+	{
+		kind: 'replace_user_column',
+		table: 'community_bans',
+		matchColumn: 'banned_by_user_id',
+		setColumn: 'banned_by_user_id',
+		value: 'deleted-user',
+	},
+	{
+		kind: 'user_columns',
+		table: 'community_listings',
+		columns: ['owner_user_id'],
+	},
+	// password_resets.user_id is an INTEGER FK to users.id (predates the
+	// stable mcp string user id), so it must be handled with the database
+	// integer id rather than the mcp user id.
+	{ kind: 'db_user_id', table: 'email_verifications' },
+	{ kind: 'db_user_id', table: 'password_resets' },
+	{ kind: 'db_user_id', table: 'user_roles' },
+]
+
+export function getAccountD1UserColumnCoverage() {
+	const covered = new Set<string>()
+	for (const target of accountUserDataTargets) {
+		switch (target.kind) {
+			case 'user_id':
+			case 'db_user_id':
+			case 'mcp_memory_suppression': {
+				const table =
+					target.kind === 'mcp_memory_suppression'
+						? 'mcp_memory_conversation_suppressions'
+						: target.table
+				covered.add(`${table}.user_id`)
+				break
+			}
+			case 'user_columns': {
+				for (const column of target.columns) {
+					covered.add(`${target.table}.${column}`)
+				}
+				break
+			}
+			case 'null_user_column': {
+				covered.add(`${target.table}.${target.matchColumn}`)
+				break
+			}
+			case 'replace_user_column': {
+				covered.add(`${target.table}.${target.matchColumn}`)
+				break
+			}
+			case 'bucket_parent':
+			case 'attachment_parent':
+			case 'community_listing_child': {
+				break
+			}
+			default: {
+				const exhaustive: never = target
+				throw new Error(
+					`Unhandled account data coverage target: ${JSON.stringify(exhaustive)}`,
+				)
+			}
+		}
+	}
+	return covered
+}

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -13,6 +13,10 @@ import {
 } from '#worker/package-runtime/package-service.ts'
 import { packageRealtimeSessionRpc } from '#worker/package-runtime/realtime-session.ts'
 import {
+	accountUserDataTargets,
+	getAccountD1UserColumnCoverage,
+} from '#app/account-data-targets.ts'
+import {
 	buildPublishedSourceManifestSnapshotKvKey,
 	buildPublishedSourceSnapshotKvKey,
 } from '#worker/package-runtime/published-runtime-artifacts.ts'
@@ -50,175 +54,8 @@ export type AccountDeletionResult = {
 	warnings: Array<string>
 }
 
-type UserScopedDeleteTarget =
-	| { kind: 'user_id'; table: string }
-	| { kind: 'db_user_id'; table: string }
-	| { kind: 'user_columns'; table: string; columns: ReadonlyArray<string> }
-	| {
-			kind: 'null_user_column'
-			table: string
-			matchColumn: string
-			nullColumns: ReadonlyArray<string>
-	  }
-	| {
-			kind: 'replace_user_column'
-			table: string
-			matchColumn: string
-			setColumn: string
-			value: string
-	  }
-	| { kind: 'bucket_parent'; table: string; parentTable: string }
-	| { kind: 'attachment_parent'; table: string }
-	| { kind: 'community_listing_child'; table: string; listingColumn: string }
-	| { kind: 'mcp_memory_suppression' }
-
-/**
- * Tables that are scoped by `user_id` (directly or transitively) and should
- * be cascade-deleted when a user removes their account. The list is
- * intentionally explicit so adding a new user-scoped table requires a
- * deliberate update here (and a corresponding test).
- *
- * Order matters: child tables come before parent tables so the cascade is
- * self-contained even on engines / configs where foreign-key cascades are
- * disabled. Tables with no `user_id` column (e.g. global mock tables) are
- * not represented.
- */
-const userScopedTables: ReadonlyArray<UserScopedDeleteTarget> = [
-	{ kind: 'user_id', table: 'package_invocations' },
-	{ kind: 'user_id', table: 'package_invocation_tokens' },
-	{ kind: 'user_id', table: 'workflow_runs' },
-	{ kind: 'user_id', table: 'package_runtime_logs' },
-	{ kind: 'user_id', table: 'package_runtime_runs' },
-	{ kind: 'user_id', table: 'usage_rollups' },
-	{ kind: 'mcp_memory_suppression' },
-	{ kind: 'user_id', table: 'mcp_memories' },
-	{ kind: 'user_id', table: 'mcp_user_server_instructions' },
-	{
-		kind: 'bucket_parent',
-		table: 'value_entries',
-		parentTable: 'value_buckets',
-	},
-	{ kind: 'user_id', table: 'value_buckets' },
-	{
-		kind: 'bucket_parent',
-		table: 'secret_entries',
-		parentTable: 'secret_buckets',
-	},
-	{ kind: 'user_id', table: 'secret_buckets' },
-	{ kind: 'user_id', table: 'remote_connector_settings' },
-	{ kind: 'user_id', table: 'archived_job_artifacts' },
-	{ kind: 'user_id', table: 'published_bundle_artifacts' },
-	{ kind: 'user_id', table: 'jobs' },
-	{ kind: 'user_id', table: 'repo_sessions' },
-	{ kind: 'user_id', table: 'saved_packages' },
-	{ kind: 'user_id', table: 'entity_sources' },
-	{ kind: 'user_id', table: 'email_delivery_events' },
-	{ kind: 'attachment_parent', table: 'email_attachments' },
-	{ kind: 'user_id', table: 'email_messages' },
-	{ kind: 'user_id', table: 'email_threads' },
-	{ kind: 'user_id', table: 'email_inbox_addresses' },
-	{ kind: 'user_id', table: 'email_inboxes' },
-	{ kind: 'user_id', table: 'email_sender_identities' },
-	{ kind: 'user_id', table: 'entitlement_daily_counters' },
-	{
-		kind: 'community_listing_child',
-		table: 'community_ratings',
-		listingColumn: 'listing_id',
-	},
-	{ kind: 'user_id', table: 'community_ratings' },
-	{
-		kind: 'community_listing_child',
-		table: 'community_forks',
-		listingColumn: 'listing_id',
-	},
-	{
-		kind: 'user_columns',
-		table: 'community_forks',
-		columns: ['forker_user_id'],
-	},
-	{
-		kind: 'community_listing_child',
-		table: 'community_reports',
-		listingColumn: 'listing_id',
-	},
-	{
-		kind: 'user_columns',
-		table: 'community_reports',
-		columns: ['listing_owner_user_id', 'reporter_user_id'],
-	},
-	{
-		kind: 'null_user_column',
-		table: 'community_reports',
-		matchColumn: 'resolved_by_user_id',
-		nullColumns: ['resolved_by_user_id', 'resolved_at', 'resolution_note'],
-	},
-	{
-		kind: 'user_columns',
-		table: 'community_bans',
-		columns: ['user_id'],
-	},
-	{
-		kind: 'replace_user_column',
-		table: 'community_bans',
-		matchColumn: 'banned_by_user_id',
-		setColumn: 'banned_by_user_id',
-		value: 'deleted-user',
-	},
-	{
-		kind: 'user_columns',
-		table: 'community_listings',
-		columns: ['owner_user_id'],
-	},
-	// password_resets.user_id is an INTEGER FK to users.id (predates the
-	// stable mcp string user id), so it must be cleared with the database
-	// integer id rather than the mcp user id.
-	{ kind: 'db_user_id', table: 'email_verifications' },
-	{ kind: 'db_user_id', table: 'password_resets' },
-	{ kind: 'db_user_id', table: 'user_roles' },
-]
-
 export function getAccountDeletionD1UserColumnCoverage() {
-	const covered = new Set<string>()
-	for (const target of userScopedTables) {
-		switch (target.kind) {
-			case 'user_id':
-			case 'db_user_id':
-			case 'mcp_memory_suppression': {
-				const table =
-					target.kind === 'mcp_memory_suppression'
-						? 'mcp_memory_conversation_suppressions'
-						: target.table
-				covered.add(`${table}.user_id`)
-				break
-			}
-			case 'user_columns': {
-				for (const column of target.columns) {
-					covered.add(`${target.table}.${column}`)
-				}
-				break
-			}
-			case 'null_user_column': {
-				covered.add(`${target.table}.${target.matchColumn}`)
-				break
-			}
-			case 'replace_user_column': {
-				covered.add(`${target.table}.${target.matchColumn}`)
-				break
-			}
-			case 'bucket_parent':
-			case 'attachment_parent':
-			case 'community_listing_child': {
-				break
-			}
-			default: {
-				const exhaustive: never = target
-				throw new Error(
-					`Unhandled account deletion coverage target: ${JSON.stringify(exhaustive)}`,
-				)
-			}
-		}
-	}
-	return covered
+	return getAccountD1UserColumnCoverage()
 }
 
 type UserSourceSnapshot = {
@@ -874,7 +711,7 @@ async function deleteUserScopedRows(input: {
 		updatedRowCounts[tableName] =
 			(updatedRowCounts[tableName] ?? 0) + (changes ?? 0)
 	}
-	for (const target of userScopedTables) {
+	for (const target of accountUserDataTargets) {
 		try {
 			let sql: string
 			let params: Array<unknown>

--- a/packages/worker/src/app/account-export.node.test.ts
+++ b/packages/worker/src/app/account-export.node.test.ts
@@ -314,5 +314,16 @@ test('createAccountExport records partial-failure warnings and section paginatio
 	})
 	expect(page.items).toHaveLength(1)
 	expect(page.truncated).toBe(true)
-	expect(page.nextStartAfter).toBe('1')
+	expect(page.nextStartAfter).toBe('value-bucket-a:first')
+	const nextPage = await readAccountExportSection({
+		env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+		section: 'd1_table',
+		table: 'value_entries',
+		pageSize: 1,
+		startAfter: page.nextStartAfter ?? undefined,
+	})
+	expect(nextPage.items).toEqual([expect.objectContaining({ name: 'second' })])
+	expect(nextPage.truncated).toBe(false)
 })

--- a/packages/worker/src/app/account-export.node.test.ts
+++ b/packages/worker/src/app/account-export.node.test.ts
@@ -172,6 +172,25 @@ test('createAccountExport redacts secrets and credential-equivalent hashes', asy
 		INSERT INTO password_resets (id, user_id, token_hash, expires_at, created_at)
 		VALUES (1, 1, 'reset-token-hash-a', 2000000000, '2026-07-05');
 
+		INSERT INTO remote_connector_settings (
+			id,
+			user_id,
+			kind,
+			instance_id,
+			encrypted_shared_secret,
+			created_at,
+			updated_at
+		)
+		VALUES (
+			'connector-a',
+			'user-aaa',
+			'home',
+			'default',
+			'encrypted-connector-secret',
+			'2026-07-05',
+			'2026-07-05'
+		);
+
 		INSERT INTO mcp_memories (id, user_id, subject, summary, details)
 		VALUES
 			('memory-a', 'user-aaa', 'Favorite color', 'Blue', 'Likes navy.'),
@@ -223,6 +242,16 @@ test('createAccountExport redacts secrets and credential-equivalent hashes', asy
 	expect(accountExport.d1.password_resets.rows[0]).not.toHaveProperty(
 		'token_hash',
 	)
+	expect(accountExport.d1.remote_connector_settings.rows[0]).toEqual(
+		expect.objectContaining({
+			id: 'connector-a',
+			kind: 'home',
+			instance_id: 'default',
+		}),
+	)
+	expect(accountExport.d1.remote_connector_settings.rows[0]).not.toHaveProperty(
+		'encrypted_shared_secret',
+	)
 	expect(accountExport.d1.value_entries.rows).toEqual([
 		expect.objectContaining({ value: 'America/Denver' }),
 	])
@@ -235,6 +264,10 @@ test('createAccountExport redacts secrets and credential-equivalent hashes', asy
 	expect(
 		accountExport.manifest.sections['d1.secret_entries']?.redactedColumns,
 	).toEqual(['encrypted_value', 'lookup_hash'])
+	expect(
+		accountExport.manifest.sections['d1.remote_connector_settings']
+			?.redactedColumns,
+	).toEqual(['encrypted_shared_secret'])
 })
 
 test('createAccountExport records partial-failure warnings and section pagination works', async () => {

--- a/packages/worker/src/app/account-export.node.test.ts
+++ b/packages/worker/src/app/account-export.node.test.ts
@@ -1,0 +1,318 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+import {
+	createAccountExport,
+	getAccountExportD1UserColumnCoverage,
+	readAccountExportSection,
+} from './account-export.ts'
+
+function quoteSqlIdentifier(identifier: string) {
+	return `"${identifier.replaceAll('"', '""')}"`
+}
+
+function applyMigrations(db: DatabaseSync) {
+	const migrationsDir = new URL('../../migrations/', import.meta.url)
+	for (const fileName of readdirSync(migrationsDir)
+		.filter((file) => file.endsWith('.sql'))
+		.sort()) {
+		db.exec(readFileSync(new URL(fileName, migrationsDir), 'utf8'))
+	}
+}
+
+function createD1FromSqlite(db: DatabaseSync) {
+	return {
+		prepare(query: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async all<T>() {
+							const statement = db.prepare(query)
+							const rows = statement.all(...params) as Array<T>
+							return { results: rows, meta: { changes: 0 } }
+						},
+						async first<T>() {
+							const statement = db.prepare(query)
+							return (statement.get(...params) ?? null) as T | null
+						},
+						async run() {
+							const statement = db.prepare(query)
+							const result = statement.run(...params)
+							return { meta: { changes: result.changes } }
+						},
+					}
+				},
+				async all<T>() {
+					const statement = db.prepare(query)
+					const rows = statement.all() as Array<T>
+					return { results: rows, meta: { changes: 0 } }
+				},
+				async first<T>() {
+					const statement = db.prepare(query)
+					return (statement.get() ?? null) as T | null
+				},
+				async run() {
+					const statement = db.prepare(query)
+					const result = statement.run()
+					return { meta: { changes: result.changes } }
+				},
+			}
+		},
+		async exec(query: string) {
+			db.exec(query)
+		},
+	} as unknown as D1Database
+}
+
+function createMigratedDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyMigrations(sqlite)
+	return {
+		sqlite,
+		db: createD1FromSqlite(sqlite),
+	}
+}
+
+test('account export D1 coverage includes every live user-owned schema column', () => {
+	const db = new DatabaseSync(':memory:')
+	applyMigrations(db)
+	const tables = db
+		.prepare(
+			`SELECT name
+			FROM sqlite_schema
+			WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+			ORDER BY name`,
+		)
+		.all() as Array<{ name: string }>
+	const liveUserColumns = new Set<string>()
+	for (const table of tables) {
+		const columns = db
+			.prepare(`PRAGMA table_info(${quoteSqlIdentifier(table.name)})`)
+			.all() as Array<{ name: string }>
+		for (const column of columns) {
+			if (column.name === 'user_id' || column.name.endsWith('_user_id')) {
+				liveUserColumns.add(`${table.name}.${column.name}`)
+			}
+		}
+	}
+	const coveredColumns = getAccountExportD1UserColumnCoverage()
+	const missing = [...liveUserColumns].filter(
+		(column) => !coveredColumns.has(column),
+	)
+	const stale = [...coveredColumns].filter(
+		(column) => !liveUserColumns.has(column),
+	)
+	expect(missing, 'user-owned D1 columns missing from account export').toEqual(
+		[],
+	)
+	expect(stale, 'account export references stale D1 columns').toEqual([])
+})
+
+test('createAccountExport redacts secrets and credential-equivalent hashes', async () => {
+	const { sqlite, db } = createMigratedDb()
+	sqlite.exec(`
+		INSERT INTO users (id, username, email, password_hash, created_at, updated_at, email_verified_at)
+		VALUES
+			(1, 'user-a', 'a@example.com', 'password-hash-a', '2026-07-05', '2026-07-05', '2026-07-05'),
+			(2, 'user-b', 'b@example.com', 'password-hash-b', '2026-07-05', '2026-07-05', '2026-07-05');
+
+		INSERT INTO secret_buckets (id, user_id, scope, binding_key, created_at, updated_at)
+		VALUES ('secret-bucket-a', 'user-aaa', 'user', 'global', '2026-07-05', '2026-07-05');
+		INSERT INTO secret_entries (
+			bucket_id,
+			name,
+			description,
+			encrypted_value,
+			allowed_hosts,
+			allowed_capabilities,
+			allowed_packages,
+			lookup_hash,
+			created_at,
+			updated_at
+		)
+		VALUES (
+			'secret-bucket-a',
+			'api-key',
+			'API key',
+			'encrypted-secret-value',
+			'["api.example.com"]',
+			'["fetch"]',
+			'["@user/pkg"]',
+			'lookup-hash',
+			'2026-07-05',
+			'2026-07-05'
+		);
+
+		INSERT INTO value_buckets (id, user_id, scope, binding_key, created_at, updated_at)
+		VALUES ('value-bucket-a', 'user-aaa', 'user', 'global', '2026-07-05', '2026-07-05');
+		INSERT INTO value_entries (bucket_id, name, description, value, created_at, updated_at)
+		VALUES ('value-bucket-a', 'timezone', 'Preferred timezone', 'America/Denver', '2026-07-05', '2026-07-05');
+
+		INSERT INTO package_invocation_tokens (
+			id,
+			user_id,
+			name,
+			token_hash,
+			email,
+			display_name,
+			created_at,
+			updated_at
+		)
+		VALUES (
+			'token-a',
+			'user-aaa',
+			'Migration token',
+			'token-hash-a',
+			'a@example.com',
+			'User A',
+			'2026-07-05',
+			'2026-07-05'
+		);
+
+		INSERT INTO password_resets (id, user_id, token_hash, expires_at, created_at)
+		VALUES (1, 1, 'reset-token-hash-a', 2000000000, '2026-07-05');
+
+		INSERT INTO mcp_memories (id, user_id, subject, summary, details)
+		VALUES
+			('memory-a', 'user-aaa', 'Favorite color', 'Blue', 'Likes navy.'),
+			('memory-b', 'user-bbb', 'Favorite color', 'Green', 'Likes moss.');
+	`)
+	const accountExport = await createAccountExport({
+		env: {
+			APP_DB: db,
+			STORAGE_RUNNER: {
+				idFromName: (name: string) => name as unknown as DurableObjectId,
+				get: () => ({
+					exportStorage: async () => ({
+						entries: [],
+						estimatedBytes: 0,
+						truncated: false,
+						nextStartAfter: null,
+						pageSize: 500,
+					}),
+				}),
+			},
+		} as unknown as Env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+		generatedAt: '2026-07-05T00:00:00.000Z',
+	})
+
+	expect(accountExport.manifest.security.secretValuesExported).toBe(false)
+	expect(accountExport.d1.users.rows).toEqual([
+		expect.not.objectContaining({ password_hash: expect.anything() }),
+	])
+	expect(accountExport.d1.secret_entries.rows).toEqual([
+		expect.objectContaining({
+			bucket_id: 'secret-bucket-a',
+			name: 'api-key',
+			allowed_hosts: '["api.example.com"]',
+			allowed_capabilities: '["fetch"]',
+			allowed_packages: '["@user/pkg"]',
+		}),
+	])
+	expect(accountExport.d1.secret_entries.rows[0]).not.toHaveProperty(
+		'encrypted_value',
+	)
+	expect(accountExport.d1.secret_entries.rows[0]).not.toHaveProperty(
+		'lookup_hash',
+	)
+	expect(accountExport.d1.package_invocation_tokens.rows[0]).not.toHaveProperty(
+		'token_hash',
+	)
+	expect(accountExport.d1.password_resets.rows[0]).not.toHaveProperty(
+		'token_hash',
+	)
+	expect(accountExport.d1.value_entries.rows).toEqual([
+		expect.objectContaining({ value: 'America/Denver' }),
+	])
+	expect(accountExport.d1.mcp_memories.rows).toEqual([
+		expect.objectContaining({ id: 'memory-a', summary: 'Blue' }),
+	])
+	expect(
+		accountExport.d1.mcp_memories.rows.some((row) => row.id === 'memory-b'),
+	).toBe(false)
+	expect(
+		accountExport.manifest.sections['d1.secret_entries']?.redactedColumns,
+	).toEqual(['encrypted_value', 'lookup_hash'])
+})
+
+test('createAccountExport records partial-failure warnings and section pagination works', async () => {
+	const { sqlite, db } = createMigratedDb()
+	sqlite.exec(`
+		INSERT INTO users (id, username, email, password_hash, created_at, updated_at, email_verified_at)
+		VALUES (1, 'user-a', 'a@example.com', 'password-hash-a', '2026-07-05', '2026-07-05', '2026-07-05');
+		INSERT INTO archived_job_artifacts (
+			id,
+			job_id,
+			user_id,
+			source_id,
+			published_commit,
+			storage_id,
+			retain_until,
+			created_at,
+			updated_at
+		)
+		VALUES (
+			'archive-a',
+			'job-a',
+			'user-aaa',
+			'source-a',
+			'commit-a',
+			'job:archive-a',
+			'2026-08-05',
+			'2026-07-05',
+			'2026-07-05'
+		);
+		INSERT INTO value_buckets (id, user_id, scope, binding_key, created_at, updated_at)
+		VALUES ('value-bucket-a', 'user-aaa', 'user', 'global', '2026-07-05', '2026-07-05');
+		INSERT INTO value_entries (bucket_id, name, description, value, created_at, updated_at)
+		VALUES
+			('value-bucket-a', 'first', '', '1', '2026-07-05', '2026-07-05'),
+			('value-bucket-a', 'second', '', '2', '2026-07-05', '2026-07-05');
+	`)
+	const exportStorage = vi.fn(async () => {
+		throw new Error('storage unavailable')
+	})
+	const env = {
+		APP_DB: db,
+		STORAGE_RUNNER: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ exportStorage }),
+		},
+		OAUTH_PROVIDER: {
+			async listUserGrants() {
+				throw new Error('oauth unavailable')
+			},
+		},
+	} as unknown as Env & {
+		OAUTH_PROVIDER: {
+			listUserGrants: () => Promise<never>
+		}
+	}
+
+	const accountExport = await createAccountExport({
+		env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+		generatedAt: '2026-07-05T00:00:00.000Z',
+	})
+	expect(accountExport.manifest.warnings).toEqual(
+		expect.arrayContaining([
+			expect.stringContaining('Storage runner export failed for job:archive-a'),
+			expect.stringContaining('OAuth grant listing failed'),
+		]),
+	)
+
+	const page = await readAccountExportSection({
+		env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+		section: 'd1_table',
+		table: 'value_entries',
+		pageSize: 1,
+	})
+	expect(page.items).toHaveLength(1)
+	expect(page.truncated).toBe(true)
+	expect(page.nextStartAfter).toBe('1')
+})

--- a/packages/worker/src/app/account-export.ts
+++ b/packages/worker/src/app/account-export.ts
@@ -1,0 +1,1237 @@
+import {
+	accountUserDataTargets,
+	type UserScopedDataTarget,
+	getAccountD1UserColumnCoverage,
+} from '#app/account-data-targets.ts'
+import { exportJobManagerForUser } from '#worker/jobs/manager-client.ts'
+import {
+	buildPackageServiceStorageId,
+	packageServiceRpc,
+} from '#worker/package-runtime/package-service.ts'
+import {
+	buildPublishedSourceManifestSnapshotKvKey,
+	buildPublishedSourceSnapshotKvKey,
+} from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { buildCommunitySnapshotKvKey } from '#worker/community/snapshot.ts'
+import { storageRunnerRpc } from '#worker/storage-runner.ts'
+import { userScopedConnectorSessionKey } from '#worker/remote-connector/connector-session-key.ts'
+import { type RemoteConnectorSessionExport } from '#worker/remote-connector/types.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+
+const accountExportSchemaVersion = 1
+const defaultExportPageSize = 100
+const maxExportPageSize = 500
+
+// Secret values and credential-equivalent hashes must never leave Kody through
+// account export. Secret entries are metadata-only; encrypted payloads stay
+// server-side and token/password hashes are omitted for the same reason.
+const redactedColumnsByTable: Readonly<Record<string, ReadonlyArray<string>>> =
+	{
+		email_inbox_addresses: ['reply_token_hash'],
+		email_verifications: ['token_hash'],
+		package_invocation_tokens: ['token_hash'],
+		password_resets: ['token_hash'],
+		secret_entries: ['encrypted_value', 'lookup_hash'],
+		users: ['password_hash'],
+	}
+
+export const accountExportSectionNames = [
+	'd1_table',
+	'storage_runner',
+	'oauth_grants',
+	'artifact_repos',
+	'kv_keys',
+	'durable_object_summaries',
+] as const
+
+export type AccountExportSectionName =
+	(typeof accountExportSectionNames)[number]
+
+type OAuthGrantPage = {
+	items: Array<{ id: string; clientId: string }>
+	cursor: string | undefined
+}
+
+type OAuthHelpersShape = {
+	listUserGrants(
+		userId: string,
+		options: { cursor: string | undefined },
+	): Promise<OAuthGrantPage>
+}
+
+type AccountExportEnv = Env & {
+	OAUTH_PROVIDER?: OAuthHelpersShape
+}
+
+type UserSourceSnapshot = {
+	sourceId: string
+	publishedCommit: string | null
+	repoId: string
+	entityKind: string
+	entityId: string
+	manifestPath: string
+	sourceRoot: string
+}
+
+type UserSavedPackageSnapshot = {
+	id: string
+	kodyId: string
+	sourceId: string
+	hasApp: boolean
+}
+
+type UserRemoteConnectorSnapshot = {
+	kind: string
+	instanceId: string
+}
+
+type UserPackageServiceSnapshot = {
+	packageId: string
+	kodyId: string
+	sourceId: string
+	serviceName: string
+}
+
+type UserExportInventory = {
+	storageIds: Array<string>
+	sourceSnapshots: Array<UserSourceSnapshot>
+	savedPackages: Array<UserSavedPackageSnapshot>
+	remoteConnectors: Array<UserRemoteConnectorSnapshot>
+	packageServices: Array<UserPackageServiceSnapshot>
+	communityListingIds: Array<string>
+	bundleKvKeys: Array<string>
+	artifactRepos: Array<AccountExportArtifactRepo>
+}
+
+export type AccountExportManifestSection = {
+	count: number
+	warnings: Array<string>
+	redactedColumns?: Array<string>
+}
+
+export type AccountExportManifest = {
+	schemaVersion: number
+	generatedAt: string
+	user: {
+		dbUserId: number
+		userId: string
+	}
+	security: {
+		secretValuesExported: false
+		note: string
+	}
+	sections: Record<string, AccountExportManifestSection>
+	warnings: Array<string>
+	chunking: {
+		sections: Array<AccountExportSectionName>
+		defaultPageSize: number
+		maxPageSize: number
+	}
+	artifacts: {
+		canonicalPackageSource: string
+	}
+	derivedData: {
+		vectorize: string
+	}
+	excludedDurableObjects: Array<{
+		name: string
+		reason: string
+	}>
+}
+
+export type AccountExportD1Table = {
+	table: string
+	rows: Array<Record<string, unknown>>
+	redactedColumns: Array<string>
+	warnings: Array<string>
+}
+
+export type AccountExportArtifactRepo = {
+	sourceId: string
+	entityKind: string
+	entityId: string
+	repoId: string
+	publishedCommit: string | null
+	manifestPath: string
+	sourceRoot: string
+}
+
+type AccountExportDurableObjects = {
+	jobManager: unknown | null
+	remoteConnectorSessions: Array<{
+		kind: string
+		instanceId: string
+		export: RemoteConnectorSessionExport | null
+	}>
+	packageServices: Array<{
+		packageId: string
+		serviceName: string
+		status: unknown | null
+	}>
+	storageRunners: Array<{
+		storageId: string
+		export: Awaited<
+			ReturnType<ReturnType<typeof storageRunnerRpc>['exportStorage']>
+		>
+	}>
+}
+
+export type AccountExportFile = {
+	manifest: AccountExportManifest
+	d1: Record<string, AccountExportD1Table>
+	durableObjects: AccountExportDurableObjects
+	oauthGrants: Array<{ id: string; clientId: string }>
+	artifactRepos: Array<AccountExportArtifactRepo>
+	kvKeys: Array<string>
+}
+
+export type AccountExportSectionResult = {
+	section: AccountExportSectionName
+	items: Array<unknown>
+	truncated: boolean
+	nextStartAfter: string | null
+	pageSize: number
+	warnings: Array<string>
+}
+
+function normalizePageSize(pageSize: number | undefined) {
+	const requested =
+		typeof pageSize === 'number' && Number.isFinite(pageSize)
+			? Math.trunc(pageSize)
+			: defaultExportPageSize
+	return Math.min(Math.max(requested, 1), maxExportPageSize)
+}
+
+function paginateItems<T>(input: {
+	items: ReadonlyArray<T>
+	pageSize: number | undefined
+	startAfter: string | undefined
+}) {
+	const pageSize = normalizePageSize(input.pageSize)
+	const startIndex = input.startAfter
+		? Number.parseInt(input.startAfter, 10)
+		: 0
+	const safeStart =
+		Number.isFinite(startIndex) && startIndex > 0 ? startIndex : 0
+	const page = input.items.slice(safeStart, safeStart + pageSize)
+	const nextIndex = safeStart + page.length
+	const truncated = nextIndex < input.items.length
+	return {
+		items: page,
+		truncated,
+		nextStartAfter: truncated ? String(nextIndex) : null,
+		pageSize,
+	}
+}
+
+function uniqueStrings(values: Iterable<string | null | undefined>) {
+	return Array.from(
+		new Set(
+			Array.from(values)
+				.map((value) => value?.trim() ?? '')
+				.filter((value) => value.length > 0),
+		),
+	)
+}
+
+function normalizeBoolean(value: unknown) {
+	return value === 1 || value === '1' || value === true
+}
+
+function getErrorMessage(error: unknown) {
+	return error instanceof Error ? error.message : String(error)
+}
+
+function getTargetTableName(target: UserScopedDataTarget) {
+	return target.kind === 'mcp_memory_suppression'
+		? 'mcp_memory_conversation_suppressions'
+		: target.table
+}
+
+function buildSelectForTarget(input: {
+	target: UserScopedDataTarget
+	mcpUserId: string
+	dbUserId: number
+}) {
+	const { target } = input
+	switch (target.kind) {
+		case 'user_id': {
+			return {
+				table: target.table,
+				sql: `SELECT * FROM ${target.table} WHERE user_id = ?`,
+				params: [input.mcpUserId],
+			}
+		}
+		case 'db_user_id': {
+			return {
+				table: target.table,
+				sql: `SELECT * FROM ${target.table} WHERE user_id = ?`,
+				params: [input.dbUserId],
+			}
+		}
+		case 'user_columns': {
+			return {
+				table: target.table,
+				sql: `SELECT * FROM ${target.table} WHERE ${target.columns
+					.map((column) => `${column} = ?`)
+					.join(' OR ')}`,
+				params: target.columns.map(() => input.mcpUserId),
+			}
+		}
+		case 'null_user_column': {
+			return {
+				table: target.table,
+				sql: `SELECT * FROM ${target.table} WHERE ${target.matchColumn} = ?`,
+				params: [input.mcpUserId],
+			}
+		}
+		case 'replace_user_column': {
+			return {
+				table: target.table,
+				sql: `SELECT * FROM ${target.table} WHERE ${target.matchColumn} = ?`,
+				params: [input.mcpUserId],
+			}
+		}
+		case 'bucket_parent': {
+			return {
+				table: target.table,
+				sql: `SELECT ${target.table}.*
+					FROM ${target.table}
+					INNER JOIN ${target.parentTable}
+						ON ${target.parentTable}.id = ${target.table}.bucket_id
+					WHERE ${target.parentTable}.user_id = ?`,
+				params: [input.mcpUserId],
+			}
+		}
+		case 'attachment_parent': {
+			return {
+				table: 'email_attachments',
+				sql: `SELECT email_attachments.*
+					FROM email_attachments
+					INNER JOIN email_messages
+						ON email_messages.id = email_attachments.message_id
+					WHERE email_messages.user_id = ?`,
+				params: [input.mcpUserId],
+			}
+		}
+		case 'community_listing_child': {
+			return {
+				table: target.table,
+				sql: `SELECT * FROM ${target.table}
+					WHERE ${target.listingColumn} IN (
+						SELECT id FROM community_listings WHERE owner_user_id = ?
+					)`,
+				params: [input.mcpUserId],
+			}
+		}
+		case 'mcp_memory_suppression': {
+			return {
+				table: 'mcp_memory_conversation_suppressions',
+				sql: `SELECT * FROM mcp_memory_conversation_suppressions WHERE user_id = ?`,
+				params: [input.mcpUserId],
+			}
+		}
+		default: {
+			const exhaustive: never = target
+			throw new Error(
+				`Unhandled account export target: ${JSON.stringify(exhaustive)}`,
+			)
+		}
+	}
+}
+
+function sanitizeRow(table: string, row: Record<string, unknown>) {
+	const redactedColumns = redactedColumnsByTable[table] ?? []
+	const sanitized: Record<string, unknown> = {}
+	for (const [key, value] of Object.entries(row)) {
+		if (redactedColumns.includes(key)) continue
+		sanitized[key] = value
+	}
+	return {
+		row: sanitized,
+		redactedColumns: redactedColumns.filter((column) => column in row),
+	}
+}
+
+function rowDedupeKey(row: Record<string, unknown>) {
+	if ('id' in row && row.id !== null && row.id !== undefined)
+		return String(row.id)
+	if ('bucket_id' in row && 'name' in row) {
+		return `${String(row.bucket_id)}:${String(row.name)}`
+	}
+	if ('user_id' in row && 'role_id' in row) {
+		return `${String(row.user_id)}:${String(row.role_id)}`
+	}
+	return JSON.stringify(row)
+}
+
+async function selectRows<T extends Record<string, unknown>>(
+	env: Env,
+	sql: string,
+	params: ReadonlyArray<unknown>,
+) {
+	const result = await env.APP_DB.prepare(sql)
+		.bind(...params)
+		.all<T>()
+	return result.results ?? []
+}
+
+async function listUserStorageIds(env: Env, userId: string) {
+	const [jobRows, archivedRows, runtimeRows, packageRows, serviceRows] =
+		await Promise.all([
+			selectRows<{ storage_id: string }>(
+				env,
+				`SELECT storage_id FROM jobs WHERE user_id = ? AND storage_id IS NOT NULL`,
+				[userId],
+			),
+			selectRows<{ storage_id: string }>(
+				env,
+				`SELECT storage_id FROM archived_job_artifacts WHERE user_id = ? AND storage_id IS NOT NULL`,
+				[userId],
+			),
+			selectRows<{ storage_id: string }>(
+				env,
+				`SELECT storage_id FROM package_runtime_runs WHERE user_id = ? AND storage_id IS NOT NULL`,
+				[userId],
+			),
+			selectRows<{ id: string }>(
+				env,
+				`SELECT id FROM saved_packages WHERE user_id = ? AND has_app = 1`,
+				[userId],
+			),
+			selectRows<{ package_id: string; name: string }>(
+				env,
+				`SELECT DISTINCT package_id, name
+				FROM package_runtime_runs
+				WHERE user_id = ? AND surface = 'service' AND name IS NOT NULL`,
+				[userId],
+			),
+		])
+	return uniqueStrings([
+		...jobRows.map((row) => row.storage_id),
+		...archivedRows.map((row) => row.storage_id),
+		...runtimeRows.map((row) => row.storage_id),
+		...packageRows.map((row) => row.id),
+		...serviceRows.map((row) =>
+			buildPackageServiceStorageId(row.package_id, row.name),
+		),
+	])
+}
+
+async function listUserSourceSnapshots(env: Env, userId: string) {
+	const rows = await selectRows<{
+		id: string
+		published_commit: string | null
+		repo_id: string
+		entity_kind: string
+		entity_id: string
+		manifest_path: string
+		source_root: string
+	}>(
+		env,
+		`SELECT id, published_commit, repo_id, entity_kind, entity_id, manifest_path, source_root
+		FROM entity_sources
+		WHERE user_id = ?`,
+		[userId],
+	)
+	return rows.map((row) => ({
+		sourceId: row.id,
+		publishedCommit: row.published_commit,
+		repoId: row.repo_id,
+		entityKind: row.entity_kind,
+		entityId: row.entity_id,
+		manifestPath: row.manifest_path,
+		sourceRoot: row.source_root,
+	}))
+}
+
+async function listUserSavedPackages(env: Env, userId: string) {
+	const rows = await selectRows<{
+		id: string
+		kody_id: string
+		source_id: string
+		has_app: number | string | boolean
+	}>(
+		env,
+		`SELECT id, kody_id, source_id, has_app
+		FROM saved_packages
+		WHERE user_id = ?`,
+		[userId],
+	)
+	return rows.map((row) => ({
+		id: row.id,
+		kodyId: row.kody_id,
+		sourceId: row.source_id,
+		hasApp: normalizeBoolean(row.has_app),
+	}))
+}
+
+async function listUserRemoteConnectors(env: Env, userId: string) {
+	const rows = await selectRows<{ kind: string; instance_id: string }>(
+		env,
+		`SELECT kind, instance_id
+		FROM remote_connector_settings
+		WHERE user_id = ?`,
+		[userId],
+	)
+	return rows.map((row) => ({
+		kind: row.kind,
+		instanceId: row.instance_id,
+	}))
+}
+
+async function listUserPackageServices(env: Env, userId: string) {
+	const rows = await selectRows<{
+		package_id: string
+		kody_id: string
+		source_id: string | null
+		name: string
+	}>(
+		env,
+		`SELECT DISTINCT
+			r.package_id,
+			COALESCE(p.kody_id, r.package_kody_id) AS kody_id,
+			COALESCE(p.source_id, r.source_id) AS source_id,
+			r.name
+		FROM package_runtime_runs AS r
+		LEFT JOIN saved_packages AS p
+			ON p.id = r.package_id AND p.user_id = r.user_id
+		WHERE r.user_id = ?
+			AND r.surface = 'service'
+			AND r.name IS NOT NULL`,
+		[userId],
+	)
+	return rows.map((row) => ({
+		packageId: row.package_id,
+		kodyId: row.kody_id,
+		sourceId: row.source_id ?? '',
+		serviceName: row.name,
+	}))
+}
+
+async function listUserCommunityListingIds(env: Env, userId: string) {
+	const rows = await selectRows<{ id: string }>(
+		env,
+		`SELECT id FROM community_listings WHERE owner_user_id = ?`,
+		[userId],
+	)
+	return uniqueStrings(rows.map((row) => row.id))
+}
+
+async function listUserBundleKvKeys(input: {
+	env: Env
+	userId: string
+	sourceSnapshots: ReadonlyArray<UserSourceSnapshot>
+	communityListingIds: ReadonlyArray<string>
+	warnings: Array<string>
+}) {
+	const published = await selectRows<{ kv_key: string }>(
+		input.env,
+		`SELECT kv_key FROM published_bundle_artifacts WHERE user_id = ?`,
+		[input.userId],
+	)
+	const keys = new Set(
+		uniqueStrings([
+			...published.map((row) => row.kv_key),
+			...input.sourceSnapshots.flatMap((source) =>
+				source.publishedCommit
+					? [
+							buildPublishedSourceSnapshotKvKey({
+								sourceId: source.sourceId,
+								publishedCommit: source.publishedCommit,
+							}),
+							buildPublishedSourceManifestSnapshotKvKey({
+								sourceId: source.sourceId,
+								publishedCommit: source.publishedCommit,
+							}),
+						]
+					: [],
+			),
+			...input.communityListingIds.map(buildCommunitySnapshotKvKey),
+		]),
+	)
+	if (!input.env.BUNDLE_ARTIFACTS_KV?.list) return Array.from(keys)
+	const prefixes = input.sourceSnapshots.flatMap((source) => [
+		`source-snapshot:v1:${source.sourceId}:`,
+		`source-manifest-snapshot:v1:${source.sourceId}:`,
+	])
+	for (const prefix of prefixes) {
+		let cursor: string | undefined
+		do {
+			try {
+				const result = await input.env.BUNDLE_ARTIFACTS_KV.list({
+					prefix,
+					cursor,
+				})
+				for (const key of result.keys) {
+					keys.add(key.name)
+				}
+				cursor = result.list_complete ? undefined : result.cursor
+			} catch (error) {
+				input.warnings.push(
+					`KV prefix listing failed for ${prefix}: ${getErrorMessage(error)}`,
+				)
+				cursor = undefined
+			}
+		} while (cursor)
+	}
+	return Array.from(keys).sort()
+}
+
+async function collectInventory(input: {
+	env: AccountExportEnv
+	userId: string
+	warnings: Array<string>
+}): Promise<UserExportInventory> {
+	const [
+		storageIds,
+		sourceSnapshots,
+		savedPackages,
+		remoteConnectors,
+		packageServices,
+		communityListingIds,
+	] = await Promise.all([
+		listUserStorageIds(input.env, input.userId).catch((error) => {
+			input.warnings.push(
+				`Failed to enumerate storage ids: ${getErrorMessage(error)}`,
+			)
+			return [] as Array<string>
+		}),
+		listUserSourceSnapshots(input.env, input.userId).catch((error) => {
+			input.warnings.push(
+				`Failed to enumerate entity sources: ${getErrorMessage(error)}`,
+			)
+			return [] as Array<UserSourceSnapshot>
+		}),
+		listUserSavedPackages(input.env, input.userId).catch((error) => {
+			input.warnings.push(
+				`Failed to enumerate saved packages: ${getErrorMessage(error)}`,
+			)
+			return [] as Array<UserSavedPackageSnapshot>
+		}),
+		listUserRemoteConnectors(input.env, input.userId).catch((error) => {
+			input.warnings.push(
+				`Failed to enumerate remote connectors: ${getErrorMessage(error)}`,
+			)
+			return [] as Array<UserRemoteConnectorSnapshot>
+		}),
+		listUserPackageServices(input.env, input.userId).catch((error) => {
+			input.warnings.push(
+				`Failed to enumerate package services: ${getErrorMessage(error)}`,
+			)
+			return [] as Array<UserPackageServiceSnapshot>
+		}),
+		listUserCommunityListingIds(input.env, input.userId).catch((error) => {
+			input.warnings.push(
+				`Failed to enumerate community listings: ${getErrorMessage(error)}`,
+			)
+			return [] as Array<string>
+		}),
+	])
+	const bundleKvKeys = await listUserBundleKvKeys({
+		env: input.env,
+		userId: input.userId,
+		sourceSnapshots,
+		communityListingIds,
+		warnings: input.warnings,
+	}).catch((error) => {
+		input.warnings.push(
+			`Failed to enumerate bundle KV keys: ${getErrorMessage(error)}`,
+		)
+		return [] as Array<string>
+	})
+	const artifactRepos = sourceSnapshots.map((source) => ({
+		sourceId: source.sourceId,
+		entityKind: source.entityKind,
+		entityId: source.entityId,
+		repoId: source.repoId,
+		publishedCommit: source.publishedCommit,
+		manifestPath: source.manifestPath,
+		sourceRoot: source.sourceRoot,
+	}))
+	return {
+		storageIds,
+		sourceSnapshots,
+		savedPackages,
+		remoteConnectors,
+		packageServices,
+		communityListingIds,
+		bundleKvKeys,
+		artifactRepos,
+	}
+}
+
+async function collectD1Tables(input: {
+	env: AccountExportEnv
+	dbUserId: number
+	mcpUserId: string
+	warnings: Array<string>
+}) {
+	const tables = new Map<string, AccountExportD1Table>()
+	function getTable(table: string) {
+		const existing = tables.get(table)
+		if (existing) return existing
+		const created: AccountExportD1Table = {
+			table,
+			rows: [],
+			redactedColumns: [],
+			warnings: [],
+		}
+		tables.set(table, created)
+		return created
+	}
+	async function collectQuery(
+		table: string,
+		sql: string,
+		params: Array<unknown>,
+	) {
+		const section = getTable(table)
+		try {
+			const rows = await selectRows(input.env, sql, params)
+			const seen = new Set(section.rows.map(rowDedupeKey))
+			const redacted = new Set(section.redactedColumns)
+			for (const rawRow of rows) {
+				const sanitized = sanitizeRow(table, rawRow)
+				for (const column of sanitized.redactedColumns) redacted.add(column)
+				const key = rowDedupeKey(sanitized.row)
+				if (seen.has(key)) continue
+				seen.add(key)
+				section.rows.push(sanitized.row)
+			}
+			section.redactedColumns = Array.from(redacted).sort()
+		} catch (error) {
+			const warning = `D1 export failed for ${table}: ${getErrorMessage(error)}`
+			section.warnings.push(warning)
+			input.warnings.push(warning)
+		}
+	}
+
+	await collectQuery('users', `SELECT * FROM users WHERE id = ?`, [
+		input.dbUserId,
+	])
+	for (const target of accountUserDataTargets) {
+		const query = buildSelectForTarget({
+			target,
+			mcpUserId: input.mcpUserId,
+			dbUserId: input.dbUserId,
+		})
+		await collectQuery(getTargetTableName(target), query.sql, query.params)
+	}
+	return Object.fromEntries(
+		Array.from(tables.entries()).sort(([left], [right]) =>
+			left.localeCompare(right),
+		),
+	)
+}
+
+async function listOAuthGrants(input: {
+	env: AccountExportEnv
+	userId: string
+	warnings: Array<string>
+}) {
+	const helpers = input.env.OAUTH_PROVIDER
+	if (!helpers) {
+		input.warnings.push(
+			'OAuth provider binding was unavailable; OAuth grant metadata was not exported.',
+		)
+		return [] as Array<{ id: string; clientId: string }>
+	}
+	const grants: Array<{ id: string; clientId: string }> = []
+	let cursor: string | undefined
+	while (true) {
+		let page: OAuthGrantPage
+		try {
+			page = await helpers.listUserGrants(input.userId, { cursor })
+		} catch (error) {
+			input.warnings.push(
+				`OAuth grant listing failed after ${grants.length} grant(s): ${getErrorMessage(error)}`,
+			)
+			return grants
+		}
+		grants.push(...page.items.map((grant) => ({ ...grant })))
+		if (!page.cursor) return grants
+		cursor = page.cursor
+	}
+}
+
+async function exportStorageRunners(input: {
+	env: AccountExportEnv
+	userId: string
+	storageIds: ReadonlyArray<string>
+	warnings: Array<string>
+}) {
+	const storageRunners: AccountExportDurableObjects['storageRunners'] = []
+	for (const storageId of input.storageIds) {
+		try {
+			const runnerExport = await storageRunnerRpc({
+				env: input.env,
+				userId: input.userId,
+				storageId,
+			}).exportStorage({ pageSize: maxExportPageSize })
+			storageRunners.push({ storageId, export: runnerExport })
+			if (runnerExport.truncated) {
+				input.warnings.push(
+					`Storage runner ${storageId} was truncated in the full export; use account_export_section with section "storage_runner" and storage_id "${storageId}" to retrieve additional pages.`,
+				)
+			}
+		} catch (error) {
+			input.warnings.push(
+				`Storage runner export failed for ${storageId}: ${getErrorMessage(error)}`,
+			)
+		}
+	}
+	return storageRunners
+}
+
+async function exportRemoteConnectorSessions(input: {
+	env: AccountExportEnv
+	userId: string
+	connectors: ReadonlyArray<UserRemoteConnectorSnapshot>
+	warnings: Array<string>
+}) {
+	const namespace = input.env.REMOTE_CONNECTOR_SESSION
+	if (!namespace) {
+		if (input.connectors.length > 0) {
+			input.warnings.push(
+				`REMOTE_CONNECTOR_SESSION binding was unavailable; ${input.connectors.length} connector session export(s) were skipped.`,
+			)
+		}
+		return [] as AccountExportDurableObjects['remoteConnectorSessions']
+	}
+	const sessions: AccountExportDurableObjects['remoteConnectorSessions'] = []
+	for (const connector of input.connectors) {
+		const sessionKey = userScopedConnectorSessionKey({
+			userId: input.userId,
+			kind: connector.kind,
+			instanceId: connector.instanceId,
+		})
+		try {
+			const stub = namespace.get(
+				namespace.idFromName(sessionKey),
+			) as unknown as {
+				rpcExportUserSession: (payload: {
+					userId: string
+					kind: string
+					instanceId: string
+				}) => Promise<RemoteConnectorSessionExport>
+			}
+			sessions.push({
+				kind: connector.kind,
+				instanceId: connector.instanceId,
+				export: await stub.rpcExportUserSession({
+					userId: input.userId,
+					kind: connector.kind,
+					instanceId: connector.instanceId,
+				}),
+			})
+		} catch (error) {
+			input.warnings.push(
+				`Remote connector session export failed for ${connector.kind}/${connector.instanceId}: ${getErrorMessage(error)}`,
+			)
+			sessions.push({
+				kind: connector.kind,
+				instanceId: connector.instanceId,
+				export: null,
+			})
+		}
+	}
+	return sessions
+}
+
+async function exportPackageServices(input: {
+	env: AccountExportEnv
+	userId: string
+	services: ReadonlyArray<UserPackageServiceSnapshot>
+	warnings: Array<string>
+}) {
+	const statuses: AccountExportDurableObjects['packageServices'] = []
+	for (const service of input.services) {
+		try {
+			statuses.push({
+				packageId: service.packageId,
+				serviceName: service.serviceName,
+				status: await packageServiceRpc({
+					env: input.env,
+					userId: input.userId,
+					packageId: service.packageId,
+					kodyId: service.kodyId,
+					sourceId: service.sourceId,
+					baseUrl: 'https://account-export.invalid',
+					serviceName: service.serviceName,
+				}).status(),
+			})
+		} catch (error) {
+			input.warnings.push(
+				`Package service status export failed for ${service.packageId}/${service.serviceName}: ${getErrorMessage(error)}`,
+			)
+			statuses.push({
+				packageId: service.packageId,
+				serviceName: service.serviceName,
+				status: null,
+			})
+		}
+	}
+	return statuses
+}
+
+async function exportDurableObjects(input: {
+	env: AccountExportEnv
+	userId: string
+	inventory: UserExportInventory
+	warnings: Array<string>
+}): Promise<AccountExportDurableObjects> {
+	const [storageRunners, remoteConnectorSessions, packageServices] =
+		await Promise.all([
+			exportStorageRunners({
+				env: input.env,
+				userId: input.userId,
+				storageIds: input.inventory.storageIds,
+				warnings: input.warnings,
+			}),
+			exportRemoteConnectorSessions({
+				env: input.env,
+				userId: input.userId,
+				connectors: input.inventory.remoteConnectors,
+				warnings: input.warnings,
+			}),
+			exportPackageServices({
+				env: input.env,
+				userId: input.userId,
+				services: input.inventory.packageServices,
+				warnings: input.warnings,
+			}),
+		])
+	let jobManager: unknown | null = null
+	try {
+		jobManager = await exportJobManagerForUser({
+			env: input.env,
+			userId: input.userId,
+		})
+	} catch (error) {
+		input.warnings.push(`Job manager export failed: ${getErrorMessage(error)}`)
+	}
+	return {
+		jobManager,
+		remoteConnectorSessions,
+		packageServices,
+		storageRunners,
+	}
+}
+
+function buildManifest(input: {
+	generatedAt: string
+	dbUserId: number
+	mcpUserId: string
+	d1: Record<string, AccountExportD1Table>
+	durableObjects?: AccountExportDurableObjects | null
+	oauthGrants?: ReadonlyArray<{ id: string; clientId: string }>
+	inventory: UserExportInventory
+	warnings: Array<string>
+}) {
+	const sections: Record<string, AccountExportManifestSection> = {}
+	for (const [table, exportTable] of Object.entries(input.d1)) {
+		sections[`d1.${table}`] = {
+			count: exportTable.rows.length,
+			warnings: exportTable.warnings,
+			...(exportTable.redactedColumns.length > 0
+				? { redactedColumns: exportTable.redactedColumns }
+				: {}),
+		}
+	}
+	sections.storage_runners = {
+		count: input.inventory.storageIds.length,
+		warnings: input.warnings.filter((warning) =>
+			warning.startsWith('Storage runner '),
+		),
+	}
+	sections.remote_connector_sessions = {
+		count: input.inventory.remoteConnectors.length,
+		warnings: input.warnings.filter((warning) =>
+			warning.startsWith('Remote connector session '),
+		),
+	}
+	sections.package_services = {
+		count: input.inventory.packageServices.length,
+		warnings: input.warnings.filter((warning) =>
+			warning.startsWith('Package service '),
+		),
+	}
+	sections.oauth_grants = {
+		count: input.oauthGrants?.length ?? 0,
+		warnings: input.warnings.filter((warning) =>
+			warning.startsWith('OAuth grant '),
+		),
+	}
+	sections.artifact_repos = {
+		count: input.inventory.artifactRepos.length,
+		warnings: [],
+	}
+	sections.kv_keys = {
+		count: input.inventory.bundleKvKeys.length,
+		warnings: input.warnings.filter((warning) => warning.startsWith('KV ')),
+	}
+	return {
+		schemaVersion: accountExportSchemaVersion,
+		generatedAt: input.generatedAt,
+		user: {
+			dbUserId: input.dbUserId,
+			userId: input.mcpUserId,
+		},
+		security: {
+			secretValuesExported: false as const,
+			note: 'Secret values, encrypted secret payloads, password hashes, token hashes, and credential-equivalent hashes are never exported. Secret entries contain metadata only.',
+		},
+		sections,
+		warnings: input.warnings,
+		chunking: {
+			sections: [...accountExportSectionNames],
+			defaultPageSize: defaultExportPageSize,
+			maxPageSize: maxExportPageSize,
+		},
+		artifacts: {
+			canonicalPackageSource:
+				'Package/job source code is stored in Cloudflare Artifacts repos referenced by entity_sources.repo_id. This export lists repo pointers and published commits; fetch or clone those repos separately with Artifacts access rather than relying on D1 projections.',
+		},
+		derivedData: {
+			vectorize:
+				'Vectorize entries for memories, jobs, and packages are derived from exported D1 rows and are intentionally excluded; rebuild them by reindexing after import.',
+		},
+		excludedDurableObjects: [
+			{
+				name: 'MCP',
+				reason:
+					'Session-keyed by the MCP SDK and not globally enumerable; durable user data is carried by D1 and user-scoped stores instead.',
+			},
+			{
+				name: 'RepoSession',
+				reason:
+					'Ephemeral editing workspace. Canonical repo-backed source is exported as Artifacts repo pointers via entity_sources and repo_sessions metadata.',
+			},
+			{
+				name: 'PackageRealtimeSession',
+				reason:
+					'Ephemeral live websocket/session state. Durable app storage is exported through StorageRunner buckets.',
+			},
+		],
+	} satisfies AccountExportManifest
+}
+
+export function getAccountExportD1UserColumnCoverage() {
+	return getAccountD1UserColumnCoverage()
+}
+
+export async function resolveAccountExportDbUserId(input: {
+	env: AccountExportEnv
+	mcpUserId: string
+	email?: string | null
+}) {
+	const email = input.email?.trim().toLowerCase()
+	if (!email) {
+		throw new Error('Account export requires an authenticated user email.')
+	}
+	const stableUserId = await createStableUserIdFromEmail(email)
+	if (stableUserId !== input.mcpUserId) {
+		throw new Error(
+			'Authenticated user identity did not match the account email.',
+		)
+	}
+	const row = await input.env.APP_DB.prepare(
+		`SELECT id FROM users WHERE email = ?`,
+	)
+		.bind(email)
+		.first<{ id: number }>()
+	if (!row) {
+		throw new Error('Authenticated account was not found.')
+	}
+	return row.id
+}
+
+export async function createAccountExportManifest(input: {
+	env: AccountExportEnv
+	dbUserId: number
+	mcpUserId: string
+	generatedAt?: string
+}): Promise<AccountExportManifest> {
+	const warnings: Array<string> = []
+	const generatedAt = input.generatedAt ?? new Date().toISOString()
+	const [d1, inventory, oauthGrants] = await Promise.all([
+		collectD1Tables({
+			env: input.env,
+			dbUserId: input.dbUserId,
+			mcpUserId: input.mcpUserId,
+			warnings,
+		}),
+		collectInventory({
+			env: input.env,
+			userId: input.mcpUserId,
+			warnings,
+		}),
+		listOAuthGrants({
+			env: input.env,
+			userId: input.mcpUserId,
+			warnings,
+		}),
+	])
+	return buildManifest({
+		generatedAt,
+		dbUserId: input.dbUserId,
+		mcpUserId: input.mcpUserId,
+		d1,
+		inventory,
+		oauthGrants,
+		warnings,
+	})
+}
+
+export async function createAccountExport(input: {
+	env: AccountExportEnv
+	dbUserId: number
+	mcpUserId: string
+	generatedAt?: string
+}): Promise<AccountExportFile> {
+	const warnings: Array<string> = []
+	const generatedAt = input.generatedAt ?? new Date().toISOString()
+	const [d1, inventory, oauthGrants] = await Promise.all([
+		collectD1Tables({
+			env: input.env,
+			dbUserId: input.dbUserId,
+			mcpUserId: input.mcpUserId,
+			warnings,
+		}),
+		collectInventory({
+			env: input.env,
+			userId: input.mcpUserId,
+			warnings,
+		}),
+		listOAuthGrants({
+			env: input.env,
+			userId: input.mcpUserId,
+			warnings,
+		}),
+	])
+	const durableObjects = await exportDurableObjects({
+		env: input.env,
+		userId: input.mcpUserId,
+		inventory,
+		warnings,
+	})
+	return {
+		manifest: buildManifest({
+			generatedAt,
+			dbUserId: input.dbUserId,
+			mcpUserId: input.mcpUserId,
+			d1,
+			durableObjects,
+			oauthGrants,
+			inventory,
+			warnings,
+		}),
+		d1,
+		durableObjects,
+		oauthGrants,
+		artifactRepos: inventory.artifactRepos,
+		kvKeys: inventory.bundleKvKeys,
+	}
+}
+
+export async function readAccountExportSection(input: {
+	env: AccountExportEnv
+	dbUserId: number
+	mcpUserId: string
+	section: AccountExportSectionName
+	table?: string
+	storageId?: string
+	pageSize?: number
+	startAfter?: string
+}): Promise<AccountExportSectionResult> {
+	const warnings: Array<string> = []
+	if (input.section === 'storage_runner') {
+		if (!input.storageId) {
+			throw new Error('storage_id is required when section is storage_runner.')
+		}
+		const pageSize = normalizePageSize(input.pageSize)
+		const runnerExport = await storageRunnerRpc({
+			env: input.env,
+			userId: input.mcpUserId,
+			storageId: input.storageId,
+		}).exportStorage({
+			pageSize,
+			startAfter: input.startAfter,
+		})
+		return {
+			section: input.section,
+			items: runnerExport.entries,
+			truncated: runnerExport.truncated,
+			nextStartAfter: runnerExport.nextStartAfter,
+			pageSize: runnerExport.pageSize,
+			warnings,
+		}
+	}
+	const [d1, inventory, oauthGrants] = await Promise.all([
+		collectD1Tables({
+			env: input.env,
+			dbUserId: input.dbUserId,
+			mcpUserId: input.mcpUserId,
+			warnings,
+		}),
+		collectInventory({
+			env: input.env,
+			userId: input.mcpUserId,
+			warnings,
+		}),
+		listOAuthGrants({
+			env: input.env,
+			userId: input.mcpUserId,
+			warnings,
+		}),
+	])
+	let items: Array<unknown>
+	switch (input.section) {
+		case 'd1_table': {
+			if (!input.table) {
+				throw new Error('table is required when section is d1_table.')
+			}
+			const table = d1[input.table]
+			if (!table) {
+				throw new Error(`Table "${input.table}" is not part of account export.`)
+			}
+			items = table.rows
+			break
+		}
+		case 'oauth_grants': {
+			items = [...oauthGrants]
+			break
+		}
+		case 'artifact_repos': {
+			items = inventory.artifactRepos
+			break
+		}
+		case 'kv_keys': {
+			items = inventory.bundleKvKeys
+			break
+		}
+		case 'durable_object_summaries': {
+			items = [
+				{ kind: 'storage_runner', ids: inventory.storageIds },
+				{ kind: 'remote_connector_session', refs: inventory.remoteConnectors },
+				{ kind: 'package_service', refs: inventory.packageServices },
+				{ kind: 'job_manager', userId: input.mcpUserId },
+			]
+			break
+		}
+		default: {
+			const exhaustive: never = input.section
+			throw new Error(`Unhandled account export section: ${exhaustive}`)
+		}
+	}
+	const page = paginateItems({
+		items,
+		pageSize: input.pageSize,
+		startAfter: input.startAfter,
+	})
+	return {
+		section: input.section,
+		...page,
+		warnings,
+	}
+}

--- a/packages/worker/src/app/account-export.ts
+++ b/packages/worker/src/app/account-export.ts
@@ -31,6 +31,7 @@ const redactedColumnsByTable: Readonly<Record<string, ReadonlyArray<string>>> =
 		email_verifications: ['token_hash'],
 		package_invocation_tokens: ['token_hash'],
 		password_resets: ['token_hash'],
+		remote_connector_settings: ['encrypted_shared_secret'],
 		secret_entries: ['encrypted_value', 'lookup_hash'],
 		users: ['password_hash'],
 	}

--- a/packages/worker/src/app/account-export.ts
+++ b/packages/worker/src/app/account-export.ts
@@ -365,6 +365,12 @@ function rowDedupeKey(row: Record<string, unknown>) {
 	return JSON.stringify(row)
 }
 
+function sortRowsByDedupeKey(rows: Array<Record<string, unknown>>) {
+	return rows.sort((left, right) =>
+		rowDedupeKey(left).localeCompare(rowDedupeKey(right)),
+	)
+}
+
 async function selectRows<T extends Record<string, unknown>>(
 	env: Env,
 	sql: string,
@@ -374,6 +380,56 @@ async function selectRows<T extends Record<string, unknown>>(
 		.bind(...params)
 		.all<T>()
 	return result.results ?? []
+}
+
+function createD1ExportCollector(input: {
+	env: AccountExportEnv
+	warnings: Array<string>
+}) {
+	const tables = new Map<string, AccountExportD1Table>()
+	function getTable(table: string) {
+		const existing = tables.get(table)
+		if (existing) return existing
+		const created: AccountExportD1Table = {
+			table,
+			rows: [],
+			redactedColumns: [],
+			warnings: [],
+		}
+		tables.set(table, created)
+		return created
+	}
+	async function collectQuery(
+		table: string,
+		sql: string,
+		params: Array<unknown>,
+	) {
+		const section = getTable(table)
+		try {
+			const rows = await selectRows(input.env, sql, params)
+			const seen = new Set(section.rows.map(rowDedupeKey))
+			const redacted = new Set(section.redactedColumns)
+			for (const rawRow of rows) {
+				const sanitized = sanitizeRow(table, rawRow)
+				for (const column of sanitized.redactedColumns) redacted.add(column)
+				const key = rowDedupeKey(sanitized.row)
+				if (seen.has(key)) continue
+				seen.add(key)
+				section.rows.push(sanitized.row)
+			}
+			section.rows = sortRowsByDedupeKey(section.rows)
+			section.redactedColumns = Array.from(redacted).sort()
+		} catch (error) {
+			const warning = `D1 export failed for ${table}: ${getErrorMessage(error)}`
+			section.warnings.push(warning)
+			input.warnings.push(warning)
+		}
+	}
+	return {
+		collectQuery,
+		getTable,
+		tables,
+	}
 }
 
 async function listUserStorageIds(env: Env, userId: string) {
@@ -667,46 +723,9 @@ async function collectD1Tables(input: {
 	mcpUserId: string
 	warnings: Array<string>
 }) {
-	const tables = new Map<string, AccountExportD1Table>()
-	function getTable(table: string) {
-		const existing = tables.get(table)
-		if (existing) return existing
-		const created: AccountExportD1Table = {
-			table,
-			rows: [],
-			redactedColumns: [],
-			warnings: [],
-		}
-		tables.set(table, created)
-		return created
-	}
-	async function collectQuery(
-		table: string,
-		sql: string,
-		params: Array<unknown>,
-	) {
-		const section = getTable(table)
-		try {
-			const rows = await selectRows(input.env, sql, params)
-			const seen = new Set(section.rows.map(rowDedupeKey))
-			const redacted = new Set(section.redactedColumns)
-			for (const rawRow of rows) {
-				const sanitized = sanitizeRow(table, rawRow)
-				for (const column of sanitized.redactedColumns) redacted.add(column)
-				const key = rowDedupeKey(sanitized.row)
-				if (seen.has(key)) continue
-				seen.add(key)
-				section.rows.push(sanitized.row)
-			}
-			section.redactedColumns = Array.from(redacted).sort()
-		} catch (error) {
-			const warning = `D1 export failed for ${table}: ${getErrorMessage(error)}`
-			section.warnings.push(warning)
-			input.warnings.push(warning)
-		}
-	}
+	const collector = createD1ExportCollector(input)
 
-	await collectQuery('users', `SELECT * FROM users WHERE id = ?`, [
+	await collector.collectQuery('users', `SELECT * FROM users WHERE id = ?`, [
 		input.dbUserId,
 	])
 	for (const target of accountUserDataTargets) {
@@ -715,13 +734,70 @@ async function collectD1Tables(input: {
 			mcpUserId: input.mcpUserId,
 			dbUserId: input.dbUserId,
 		})
-		await collectQuery(getTargetTableName(target), query.sql, query.params)
+		await collector.collectQuery(
+			getTargetTableName(target),
+			query.sql,
+			query.params,
+		)
 	}
 	return Object.fromEntries(
-		Array.from(tables.entries()).sort(([left], [right]) =>
+		Array.from(collector.tables.entries()).sort(([left], [right]) =>
 			left.localeCompare(right),
 		),
 	)
+}
+
+async function collectD1Table(input: {
+	env: AccountExportEnv
+	dbUserId: number
+	mcpUserId: string
+	table: string
+	warnings: Array<string>
+}) {
+	const collector = createD1ExportCollector(input)
+	if (input.table === 'users') {
+		await collector.collectQuery('users', `SELECT * FROM users WHERE id = ?`, [
+			input.dbUserId,
+		])
+		return collector.getTable('users')
+	}
+	const targets = accountUserDataTargets.filter(
+		(target) => getTargetTableName(target) === input.table,
+	)
+	if (targets.length === 0) return null
+	for (const target of targets) {
+		const query = buildSelectForTarget({
+			target,
+			mcpUserId: input.mcpUserId,
+			dbUserId: input.dbUserId,
+		})
+		await collector.collectQuery(input.table, query.sql, query.params)
+	}
+	return collector.getTable(input.table)
+}
+
+function paginateRowsByDedupeKey(input: {
+	rows: ReadonlyArray<Record<string, unknown>>
+	pageSize: number | undefined
+	startAfter: string | undefined
+}) {
+	const pageSize = normalizePageSize(input.pageSize)
+	const sortedRows = sortRowsByDedupeKey([...input.rows])
+	const cursor = input.startAfter
+	const startIndex = cursor
+		? sortedRows.findIndex((row) => rowDedupeKey(row) > cursor)
+		: 0
+	const safeStart = startIndex < 0 ? sortedRows.length : startIndex
+	const page = sortedRows.slice(safeStart, safeStart + pageSize)
+	const nextRow = page.at(-1)
+	const nextIndex = safeStart + page.length
+	const truncated = nextIndex < sortedRows.length
+	return {
+		items: page,
+		truncated,
+		nextStartAfter: truncated && nextRow ? rowDedupeKey(nextRow) : null,
+		pageSize,
+	}
 }
 
 async function listOAuthGrants(input: {
@@ -1167,50 +1243,66 @@ export async function readAccountExportSection(input: {
 			warnings,
 		}
 	}
-	const [d1, inventory, oauthGrants] = await Promise.all([
-		collectD1Tables({
-			env: input.env,
-			dbUserId: input.dbUserId,
-			mcpUserId: input.mcpUserId,
-			warnings,
-		}),
-		collectInventory({
-			env: input.env,
-			userId: input.mcpUserId,
-			warnings,
-		}),
-		listOAuthGrants({
-			env: input.env,
-			userId: input.mcpUserId,
-			warnings,
-		}),
-	])
 	let items: Array<unknown>
 	switch (input.section) {
 		case 'd1_table': {
 			if (!input.table) {
 				throw new Error('table is required when section is d1_table.')
 			}
-			const table = d1[input.table]
+			const table = await collectD1Table({
+				env: input.env,
+				dbUserId: input.dbUserId,
+				mcpUserId: input.mcpUserId,
+				table: input.table,
+				warnings,
+			})
 			if (!table) {
 				throw new Error(`Table "${input.table}" is not part of account export.`)
 			}
-			items = table.rows
-			break
+			const page = paginateRowsByDedupeKey({
+				rows: table.rows,
+				pageSize: input.pageSize,
+				startAfter: input.startAfter,
+			})
+			return {
+				section: input.section,
+				...page,
+				warnings,
+			}
 		}
 		case 'oauth_grants': {
+			const oauthGrants = await listOAuthGrants({
+				env: input.env,
+				userId: input.mcpUserId,
+				warnings,
+			})
 			items = [...oauthGrants]
 			break
 		}
 		case 'artifact_repos': {
+			const inventory = await collectInventory({
+				env: input.env,
+				userId: input.mcpUserId,
+				warnings,
+			})
 			items = inventory.artifactRepos
 			break
 		}
 		case 'kv_keys': {
+			const inventory = await collectInventory({
+				env: input.env,
+				userId: input.mcpUserId,
+				warnings,
+			})
 			items = inventory.bundleKvKeys
 			break
 		}
 		case 'durable_object_summaries': {
+			const inventory = await collectInventory({
+				env: input.env,
+				userId: input.mcpUserId,
+				warnings,
+			})
 			items = [
 				{ kind: 'storage_runner', ids: inventory.storageIds },
 				{ kind: 'remote_connector_session', refs: inventory.remoteConnectors },

--- a/packages/worker/src/app/handlers/account-export.ts
+++ b/packages/worker/src/app/handlers/account-export.ts
@@ -1,0 +1,42 @@
+import { type Action } from 'remix/router'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { createAccountExport } from '#app/account-export.ts'
+import { type routes } from '#app/routes.ts'
+
+function buildExportFilename(username: string) {
+	const safeUsername = username
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9_-]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+	return `kody-account-export-${safeUsername || 'user'}.json`
+}
+
+export function createAccountExportHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return Response.json(
+					{ error: 'Authentication required.' },
+					{ status: 401 },
+				)
+			}
+			const accountExport = await createAccountExport({
+				env,
+				dbUserId: user.userId,
+				mcpUserId: user.mcpUser.userId,
+			})
+			const body = JSON.stringify(accountExport, null, 2)
+			return new Response(body, {
+				status: 200,
+				headers: {
+					'Cache-Control': 'no-store',
+					'Content-Disposition': `attachment; filename="${buildExportFilename(user.username)}"`,
+					'Content-Type': 'application/json; charset=utf-8',
+				},
+			})
+		},
+	} satisfies Action<typeof routes.accountExport>
+}

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -22,6 +22,7 @@ import {
 } from '#app/handlers/admin-usage.ts'
 import { createAccountHandler } from '#app/handlers/account.ts'
 import { createAccountDeleteHandler } from '#app/handlers/account-delete.ts'
+import { createAccountExportHandler } from '#app/handlers/account-export.ts'
 import {
 	createAccountIntegrationsApiHandler,
 	createAccountIntegrationsHandler,
@@ -95,6 +96,7 @@ export function createAppRouter(appEnv: AppEnv) {
 			signup: createSignupHandler(env),
 			account: createAccountHandler(env),
 			accountDelete: createAccountDeleteHandler(env),
+			accountExport: createAccountExportHandler(env),
 			accountIntegrations: createAccountIntegrationsHandler(env),
 			accountIntegrationsApi: createAccountIntegrationsApiHandler(env),
 			accountPackageInvocationTokens:

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -28,6 +28,7 @@ export const routes = route({
 	accountSecretsApiPost: post('/account/secrets.json'),
 	accountProfileApi: '/account/profile.json',
 	accountProfileApiPost: post('/account/profile.json'),
+	accountExport: '/account/export.json',
 	admin: '/admin',
 	adminUsers: '/admin/users',
 	adminUsersApi: '/admin/users.json',

--- a/packages/worker/src/jobs/manager-client.ts
+++ b/packages/worker/src/jobs/manager-client.ts
@@ -31,6 +31,7 @@ type JobManagerRpc = {
 		ok: true
 		userId: string
 	}>
+	exportUser: (payload: { userId: string }) => Promise<JobManagerDebugState>
 	syncAlarm: (payload: {
 		userId: string
 		source?: 'alarm' | 'rpc' | 'run_now'
@@ -140,6 +141,27 @@ export async function getJobManagerDebugState(input: {
 		}
 	}
 	return rpc.getDebugState({
+		userId: input.userId,
+	})
+}
+
+export async function exportJobManagerForUser(input: {
+	env: Env
+	userId: string
+}) {
+	const rpc = jobManagerRpc(input.env, input.userId)
+	if (!rpc) {
+		return {
+			bindingAvailable: false,
+			status: 'missing_binding' as const,
+			storedUserId: null,
+			alarmScheduledFor: null,
+			nextRunnableJobId: null,
+			nextRunnableRunAt: null,
+			alarmInSync: null,
+		} satisfies JobManagerDebugState
+	}
+	return rpc.exportUser({
 		userId: input.userId,
 	})
 }

--- a/packages/worker/src/jobs/manager-do.node.test.ts
+++ b/packages/worker/src/jobs/manager-do.node.test.ts
@@ -213,6 +213,29 @@ test('syncAlarm arms, clears, and logs scheduler state transitions', async () =>
 	})
 })
 
+test('exportUser returns the scheduler state for account export', async () => {
+	resetMocks()
+	const nextRunAt = '2026-04-20T18:30:00.000Z'
+	mockModule.getNextRunnableJob.mockResolvedValue({
+		id: 'job-123',
+		nextRunAt,
+	})
+	const state = createState({
+		currentAlarmAt: Date.parse(nextRunAt),
+	})
+	const manager = new JobManagerBase(state.state, {} as Env)
+
+	await expect(manager.exportUser({ userId: 'user-123' })).resolves.toEqual({
+		bindingAvailable: true,
+		status: 'armed',
+		storedUserId: 'user-123',
+		alarmScheduledFor: nextRunAt,
+		nextRunnableJobId: 'job-123',
+		nextRunnableRunAt: nextRunAt,
+		alarmInSync: true,
+	})
+})
+
 test('alarm logs firing, due-job outcomes, and resyncs the next alarm', async () => {
 	resetMocks()
 	mockModule.runDueJobsForUser.mockResolvedValue({

--- a/packages/worker/src/jobs/manager-do.ts
+++ b/packages/worker/src/jobs/manager-do.ts
@@ -133,6 +133,10 @@ export class JobManagerBase extends DurableObject<Env> {
 		}
 	}
 
+	async exportUser(input: { userId: string }): Promise<JobManagerDebugState> {
+		return this.getDebugState(input)
+	}
+
 	async alarm(alarmInfo?: {
 		retryCount?: number
 		isRetry?: boolean

--- a/packages/worker/src/mcp/capabilities/account/account-export-manifest.ts
+++ b/packages/worker/src/mcp/capabilities/account/account-export-manifest.ts
@@ -1,0 +1,41 @@
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import {
+	emptyCapabilityInputSchema,
+	type CapabilityContext,
+} from '#mcp/capabilities/types.ts'
+import {
+	createAccountExportManifest,
+	resolveAccountExportDbUserId,
+} from '#app/account-export.ts'
+import { accountExportManifestOutputSchema } from './account-export-shared.ts'
+
+export const accountExportManifestCapability = defineDomainCapability(
+	capabilityDomainNames.account,
+	{
+		name: 'account_export_manifest',
+		description:
+			'Build a signed-in user data export manifest with schema version, section counts, redactions, warnings, and chunking instructions. Secret values are never exported.',
+		keywords: ['account', 'export', 'backup', 'migration', 'gdpr', 'ccpa'],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: emptyCapabilityInputSchema,
+		outputSchema: accountExportManifestOutputSchema,
+		async handler(_args, ctx: CapabilityContext) {
+			const user = requireMcpUser(ctx.callerContext)
+			const dbUserId = await resolveAccountExportDbUserId({
+				env: ctx.env,
+				mcpUserId: user.userId,
+				email: user.email,
+			})
+			const manifest = await createAccountExportManifest({
+				env: ctx.env,
+				dbUserId,
+				mcpUserId: user.userId,
+			})
+			return { manifest }
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/account/account-export-section.ts
+++ b/packages/worker/src/mcp/capabilities/account/account-export-section.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import {
+	readAccountExportSection,
+	resolveAccountExportDbUserId,
+} from '#app/account-export.ts'
+import {
+	accountExportSectionOutputSchema,
+	accountExportSectionSchema,
+} from './account-export-shared.ts'
+
+export const accountExportSectionCapability = defineDomainCapability(
+	capabilityDomainNames.account,
+	{
+		name: 'account_export_section',
+		description:
+			'Read a paged section of the signed-in user account export. Use account_export_manifest first for section counts and warnings. Secret values are never exported.',
+		keywords: ['account', 'export', 'chunk', 'backup', 'migration'],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: z.object({
+			section: accountExportSectionSchema,
+			table: z
+				.string()
+				.min(1)
+				.optional()
+				.describe('Required when section is d1_table.'),
+			storage_id: z
+				.string()
+				.min(1)
+				.optional()
+				.describe('Required when section is storage_runner.'),
+			page_size: z.number().int().min(1).max(500).optional(),
+			start_after: z
+				.string()
+				.min(1)
+				.optional()
+				.describe('Opaque cursor from a previous account_export_section page.'),
+		}),
+		outputSchema: accountExportSectionOutputSchema,
+		async handler(args, ctx: CapabilityContext) {
+			const user = requireMcpUser(ctx.callerContext)
+			const dbUserId = await resolveAccountExportDbUserId({
+				env: ctx.env,
+				mcpUserId: user.userId,
+				email: user.email,
+			})
+			const result = await readAccountExportSection({
+				env: ctx.env,
+				dbUserId,
+				mcpUserId: user.userId,
+				section: args.section,
+				table: args.table,
+				storageId: args.storage_id,
+				pageSize: args.page_size,
+				startAfter: args.start_after,
+			})
+			return {
+				section: result.section,
+				items: result.items,
+				truncated: result.truncated,
+				next_start_after: result.nextStartAfter,
+				page_size: result.pageSize,
+				warnings: result.warnings,
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/account/account-export-shared.ts
+++ b/packages/worker/src/mcp/capabilities/account/account-export-shared.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+import { accountExportSectionNames } from '#app/account-export.ts'
+
+export const accountExportSectionSchema = z.enum(accountExportSectionNames)
+
+export const accountExportManifestOutputSchema = z.object({
+	manifest: z.unknown(),
+})
+
+export const accountExportSectionOutputSchema = z.object({
+	section: accountExportSectionSchema,
+	items: z.array(z.unknown()),
+	truncated: z.boolean(),
+	next_start_after: z.string().nullable(),
+	page_size: z.number(),
+	warnings: z.array(z.string()),
+})

--- a/packages/worker/src/mcp/capabilities/account/domain.ts
+++ b/packages/worker/src/mcp/capabilities/account/domain.ts
@@ -1,0 +1,15 @@
+import { defineDomain } from '#mcp/capabilities/define-domain.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { accountExportManifestCapability } from './account-export-manifest.ts'
+import { accountExportSectionCapability } from './account-export-section.ts'
+
+export const accountDomain = defineDomain({
+	name: capabilityDomainNames.account,
+	description:
+		'User-owned account operations such as self-service data export for portability, backups, and migration. Secret values are never exported.',
+	keywords: ['account', 'export', 'backup', 'migration', 'privacy'],
+	capabilities: [
+		accountExportManifestCapability,
+		accountExportSectionCapability,
+	],
+})

--- a/packages/worker/src/mcp/capabilities/builtin-domains.ts
+++ b/packages/worker/src/mcp/capabilities/builtin-domains.ts
@@ -1,3 +1,4 @@
+import { accountDomain } from './account/domain.ts'
 import { adminDomain } from './admin/domain.ts'
 import { appsDomain } from './apps/domain.ts'
 import { communityDomain } from './community/domain.ts'
@@ -22,6 +23,7 @@ import { valuesDomain } from './values/domain.ts'
  * (Workers typically snapshot capabilities at deploy time).
  */
 export const builtinDomains = [
+	accountDomain,
 	adminDomain,
 	appsDomain,
 	communityDomain,

--- a/packages/worker/src/mcp/capabilities/domain-metadata.ts
+++ b/packages/worker/src/mcp/capabilities/domain-metadata.ts
@@ -1,5 +1,6 @@
 /** Canonical domain id values; descriptions live on each `DomainSpec` (see `coding/domain.ts`, etc.). */
 export const capabilityDomainNames = {
+	account: 'account',
 	admin: 'admin',
 	apps: 'apps',
 	community: 'community',

--- a/packages/worker/src/remote-connector/session.node.test.ts
+++ b/packages/worker/src/remote-connector/session.node.test.ts
@@ -117,6 +117,23 @@ test('remote connector session lifecycle across restore, snapshot, heartbeat, cl
 		description: 'Local lighting automation.',
 		tools: [{ name: 'bond_shade_set_position' }],
 	})
+	await expect(
+		restored.session.rpcExportUserSession({
+			userId: 'user-123',
+			kind: 'lights',
+			instanceId: 'default',
+		}),
+	).resolves.toEqual({
+		persisted: {
+			connectorId: 'default',
+			connectorKind: 'lights',
+			description: 'Local lighting automation.',
+			connectedAt: '2026-04-26T05:00:00.000Z',
+			lastSeenAt: '2026-04-26T05:01:00.000Z',
+		},
+		tools: [{ name: 'bond_shade_set_position' }],
+		connected: true,
+	})
 
 	const disconnected = await createRemoteConnectorSession({
 		storedState: {

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -6,6 +6,7 @@ import {
 	type RemoteConnectorHelloMessage,
 	type RemoteConnectorJsonRpcResponse,
 	type RemoteConnectorPersistedState,
+	type RemoteConnectorSessionExport,
 	type RemoteConnectorServerMessage,
 	type RemoteConnectorSnapshot,
 } from './types.ts'
@@ -232,6 +233,22 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			connectedAt,
 			lastSeenAt,
 			tools: this.stateSnapshot.tools,
+		}
+	}
+
+	async rpcExportUserSession(input: {
+		userId: string
+		kind: string
+		instanceId: string
+	}): Promise<RemoteConnectorSessionExport> {
+		const sessionKey = userScopedConnectorSessionKey(input)
+		if (!sessionKey) {
+			throw new Error('Remote connector session key was invalid.')
+		}
+		return {
+			persisted: { ...this.stateSnapshot.persisted },
+			tools: this.stateSnapshot.tools.map((tool) => ({ ...tool })),
+			connected: this.ctx.getWebSockets(connectorTag).length > 0,
 		}
 	}
 

--- a/packages/worker/src/remote-connector/types.ts
+++ b/packages/worker/src/remote-connector/types.ts
@@ -52,6 +52,12 @@ export type RemoteConnectorPersistedState = {
 	lastSeenAt: string | null
 }
 
+export type RemoteConnectorSessionExport = {
+	persisted: RemoteConnectorPersistedState
+	tools: Array<RemoteConnectorToolDescriptor>
+	connected: boolean
+}
+
 export type RemoteConnectorJsonRpcResponse =
 	| JSONRPCResultResponse
 	| JSONRPCErrorResponse


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a user-scoped account export service with a versioned manifest, D1 table coverage shared with account deletion, section warnings, redaction metadata, and chunked section retrieval for MCP migration tooling.
- Adds authenticated `/account/export.json` download UI plus a non-admin `account` capability domain (`account_export_manifest`, `account_export_section`).
- Adds Durable Object export/read RPCs for JobManager and RemoteConnectorSession, uses existing StorageRunner/package service status exports, and documents exclusions/rebuildable derived data.

## Testing

- `npm run validate` ✅ (after rebasing onto latest `main` @ `c392e2a`; 173 test files / 524 tests passed)
- PR CI ✅ Validate + Bugbot + CodeRabbit passed on `9ee6b01`
- Focused tests: account export guardrail/redaction/partial failure plus DO export RPC assertions
- Manual browser walkthrough:

<a href="https://cursor.com/agents/bc-46501930-bb82-485e-a9fb-36390c4e0502/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faccount_export_chrome_downloads_page.mp4"><img src="https://cursor.com/artifacts/c/art-3f3b6694-b150-4498-b716-ad4eda445d79" alt="account_export_chrome_downloads_page.mp4" /></a>

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `c392e2a` · **Head:** `9ee6b01`

**Classification:** extends — adds new export behavior and routes/capabilities on top of existing app, MCP, D1, Durable Object, KV, and Artifacts primitives; no new primitive is introduced.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — authenticated account export download route and account page card |
| `mcp-server` | surfaces | extends — user-facing export capabilities behind search/execute |
| `capability-registry` | assistant | extends — new non-admin `account` capability domain |
| `d1-app-db` | storage | extends — shared account data target list + export coverage guardrail |
| `durable-storage` | assistant | extends — account export enumerates StorageRunner buckets via paged export |
| `jobs` | assistant | extends — JobManager export RPC mirrors scheduler debug state |
| `remote-connectors` | assistant | extends — RemoteConnectorSession export RPC for persisted metadata/tools; encrypted connector shared secrets are redacted from D1 export |
| `package-services` | assistant | composes — package service status is included as export summary |
| `artifacts-repos` | storage | composes — export lists repo pointers, not repo contents |
| `bundle-artifacts-kv` | storage | composes — export lists user-owned KV keys, not cached payloads |
| `vectorize-search` | storage | composes — vectors documented as excluded derived data |
| `secrets` | assistant | extends — export redaction contract explicitly excludes secret values/hashes |

### System map

```mermaid
flowchart LR
	appUi["app-ui"]:::extended --> d1AppDb["d1-app-db"]:::extended
	mcpServer["mcp-server"]:::extended --> capabilityRegistry["capability-registry"]:::extended
	capabilityRegistry --> d1AppDb
	d1AppDb --> durableStorage["durable-storage"]:::extended
	d1AppDb --> jobs["jobs"]:::extended
	d1AppDb --> remoteConnectors["remote-connectors"]:::extended
	d1AppDb --> packageServices["package-services"]:::touched
	d1AppDb --> artifactsRepos["artifacts-repos"]:::touched
	d1AppDb --> bundleArtifactsKv["bundle-artifacts-kv"]:::touched
	d1AppDb --> vectorizeSearch["vectorize-search"]:::touched
	d1AppDb --> secrets["secrets"]:::extended
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart TD
	user["signed-in user"] --> accountRoute["/account/export.json"]
	user --> accountCaps["account_export_manifest / account_export_section"]
	accountRoute --> exportService["account-export.ts"]
	accountCaps --> exportService
	exportService --> d1["shared D1 user targets"]
	exportService --> storage["StorageRunner exportStorage"]
	exportService --> doState["JobManager / RemoteConnector / service status"]
	exportService --> pointers["Artifacts + KV pointers"]
	exportService --> manifest["manifest warnings + counts + redactions"]
```

### Before / after

| Before | After |
| --- | --- |
| Account deletion owned the only full user-data inventory. | Deletion and export share the D1 target list and both have schema guardrails. |
| Users had no self-service portable data export. | `/account/export.json` downloads a JSON export for the signed-in user. |
| MCP had no whole-account export surface. | `account_export_manifest` and `account_export_section` support chunked migration tooling with stable D1 row-key cursors. |
| Secret export behavior was implicit because no export existed. | Manifest, docs, code comments, and tests assert secret values/hashes/ciphertexts are never exported. |

### Invariants

- `per-user-isolation`: every export path derives `userId` from the authenticated browser/MCP user and namespaces Durable Object access by that user.
- `no-secrets-in-chat`: secret values, encrypted payloads, connector shared-secret ciphertexts, token hashes, password hashes, and credential-equivalent hashes are omitted from exports and reported as redactions.
- `canonical-repo-source`: canonical package/job/app source remains in Cloudflare Artifacts repos; the export includes pointers and docs for separate fetch/clone during migration.
- `compact-mcp-surface`: export is added as capabilities behind existing search/execute rather than a new public MCP tool.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46501930-bb82-485e-a9fb-36390c4e0502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46501930-bb82-485e-a9fb-36390c4e0502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

