### PR TITLE
Fix remote connector execute dispatch

### DIFF
--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -12,6 +12,7 @@ import {
 	createKodyProviderProxySource,
 	createExecuteExecutor,
 	createExecutorModuleSource,
+	createToolDispatchers,
 	extractRawContent,
 	formatExecutionOutput,
 	formatLimitedExecutionOutput,
@@ -108,7 +109,7 @@ test('kody remote proxy dispatches and reports connector/capability errors clear
 				capabilities: [
 					{
 						name: 'set_pin',
-						dispatchName: 'remote:home:set_pin',
+						dispatchName: 'remotehomeset_pin',
 					},
 				],
 			},
@@ -137,7 +138,7 @@ test('kody remote proxy dispatches and reports connector/capability errors clear
 	})
 	expect(calls).toEqual([
 		{
-			dispatchName: 'remote:home:set_pin',
+			dispatchName: 'remotehomeset_pin',
 			args: { pin: '1234' },
 		},
 	])
@@ -199,7 +200,7 @@ test('generated kody provider source wires remote proxy dispatch', async () => {
 				capabilities: [
 					{
 						name: 'set_pin',
-						dispatchName: 'remote:home:set_pin',
+						dispatchName: 'remotehomeset_pin',
 					},
 				],
 			},
@@ -222,7 +223,7 @@ test('generated kody provider source wires remote proxy dispatch', async () => {
 	})
 	expect(calls).toEqual([
 		{
-			name: 'remote:home:set_pin',
+			name: 'remotehomeset_pin',
 			argsJson: JSON.stringify({ pin: '1234' }),
 		},
 	])
@@ -579,6 +580,25 @@ test('createExecuteExecutor disables dispatchers after execution completes', asy
 	expect(JSON.parse(result ?? '{}')).toEqual({
 		error: 'Execution has already completed.',
 	})
+})
+
+test('createToolDispatchers rejects duplicate sanitized tool names', () => {
+	expect(() =>
+		createToolDispatchers(
+			[
+				{
+					name: 'kody',
+					fns: {
+						'remote:home:set_pin': async () => ({ ok: true }),
+						remotehomeset_pin: async () => ({ ok: false }),
+					},
+				},
+			],
+			{ active: true },
+		),
+	).toThrow(
+		'Provider "kody" has tool names "remote:home:set_pin" and "remotehomeset_pin" that both sanitize to "remotehomeset_pin".',
+	)
 })
 
 test('executor maps secret errors, formats guidance, extracts raw content, and truncates on UTF-8 boundaries', () => {

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -444,7 +444,7 @@ export function createKodyProviderProxySource(input: {
 	return source
 }
 
-function createToolDispatchers(
+export function createToolDispatchers(
 	providers: Array<ResolvedProvider>,
 	executionState: { active: boolean },
 ) {
@@ -454,8 +454,17 @@ function createToolDispatchers(
 			string,
 			(...args: Array<unknown>) => Promise<unknown>
 		> = {}
+		const rawNamesBySanitizedName = new Map<string, string>()
 		for (const [name, fn] of Object.entries(provider.fns)) {
-			sanitizedFns[sanitizeToolName(name)] = async (...args) => {
+			const sanitizedName = sanitizeToolName(name)
+			if (rawNamesBySanitizedName.has(sanitizedName)) {
+				const existingName = rawNamesBySanitizedName.get(sanitizedName) ?? ''
+				throw new Error(
+					`Provider "${provider.name}" has tool names "${existingName}" and "${name}" that both sanitize to "${sanitizedName}".`,
+				)
+			}
+			rawNamesBySanitizedName.set(sanitizedName, name)
+			sanitizedFns[sanitizedName] = async (...args) => {
 				if (!executionState.active) {
 					throw new Error('Execution has already completed.')
 				}

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -6,11 +6,17 @@ import { createMcpCallerContext } from '#mcp/context.ts'
 import { buildKodyModuleBundle } from '#worker/package-runtime/module-graph.ts'
 import {
 	buildKodyFns,
+	buildKodyProvider,
 	createWorkflowTools,
 	runKodyWithRegistry,
 	runBundledModuleWithRegistry,
 	runModuleWithRegistry,
 } from './run-kody-registry.ts'
+import {
+	createKodyProviderProxySource,
+	createToolDispatchers,
+} from '#mcp/executor.ts'
+import { type KodyResolvedProvider } from '#mcp/kody-remote-types.ts'
 import { PackageSecretMountError } from '#mcp/secrets/package-access.ts'
 import * as packageAccess from '#mcp/secrets/package-access.ts'
 import * as secretService from '#mcp/secrets/service.ts'
@@ -941,6 +947,85 @@ test('buildKodyFns resolves, denies, and tracks secret-marked capability inputs'
 	} finally {
 		getRegistrySpy.mockRestore()
 	}
+})
+
+test('remote connector calls round-trip through sanitized ToolDispatcher names', async () => {
+	let toolArguments: Record<string, unknown> | null = null
+	const connectorEnv = {
+		REMOTE_CONNECTOR_SESSION: {
+			idFromName(name: string) {
+				return name
+			},
+			get() {
+				return {
+					async getSnapshot() {
+						return {
+							connectorId: 'lighting',
+							connectedAt: '2026-03-27T00:00:00.000Z',
+							lastSeenAt: '2026-03-27T00:00:01.000Z',
+							tools: [
+								{
+									name: 'lutron_set_credentials',
+									title: 'Set Lutron Credentials',
+									description: 'Store Lutron credentials.',
+									inputSchema: {
+										type: 'object',
+										properties: {
+											processorId: { type: 'string' },
+										},
+										required: ['processorId'],
+									},
+								},
+							],
+						}
+					},
+					async rpcCallTool(name: string, args: Record<string, unknown>) {
+						toolArguments = { name, ...args }
+						return {
+							structuredContent: {
+								ok: true,
+							},
+						}
+					},
+				}
+			},
+		},
+	} as unknown as Env
+	const provider = (await buildKodyProvider(
+		connectorEnv,
+		createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: { userId: 'user-123' },
+			remoteConnectors: [{ instanceId: 'lighting' }],
+		}),
+	)) as KodyResolvedProvider
+	const remoteConnectors = provider.kodyRemoteConnectors ?? []
+	expect(remoteConnectors[0]?.capabilities).toEqual([
+		expect.objectContaining({
+			name: 'lutron_set_credentials',
+			dispatchName: 'remotelightinglutron_set_credentials',
+		}),
+	])
+	const dispatchers = createToolDispatchers([provider], { active: true })
+	const source = createKodyProviderProxySource({
+		providerName: provider.name,
+		remoteConnectors,
+	})
+	const kody = new Function('__dispatchers', `${source}; return kody;`)(
+		dispatchers,
+	) as {
+		remote: Record<string, Record<string, (args: unknown) => Promise<unknown>>>
+	}
+
+	await expect(
+		kody.remote['lighting']?.lutron_set_credentials({
+			processorId: 'lutron-192-168-0-41',
+		}),
+	).resolves.toEqual({ ok: true })
+	expect(toolArguments).toEqual({
+		name: 'lutron_set_credentials',
+		processorId: 'lutron-192-168-0-41',
+	})
 })
 
 test('buildKodyFns rejects storage kody tools that collide with capabilities', async () => {

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -1,6 +1,7 @@
 import {
 	normalizeCode,
 	resolveProvider,
+	sanitizeToolName,
 	type ExecuteResult,
 	type ResolvedProvider,
 	type ToolProvider,
@@ -611,7 +612,7 @@ async function buildKodyRemoteConnectorMetadata(input: {
 			} satisfies KodyRemoteConnectorMetadata)
 		existing.capabilities.push({
 			name: remote.toolName,
-			dispatchName: capability.name,
+			dispatchName: sanitizeToolName(capability.name),
 		})
 		existing.capabilities.sort((a, b) => a.name.localeCompare(b.name, 'en'))
 		existing.status.toolCount = Math.max(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Sanitize remote connector `dispatchName` metadata so `kody.remote[connector].capability()` dispatches to the same ToolDispatcher key registered for colon-format remote capability IDs.
- Add ToolDispatcher registration collision detection for raw tool names that sanitize to the same dispatch key.
- Add regression coverage that builds the Kody provider from a connected remote connector, routes through generated `kody.remote` proxy source, and calls a real ToolDispatcher.

## Tests

- `npx vitest run packages/worker/src/mcp/executor.node.test.ts packages/worker/src/mcp/run-kody-registry.node.test.ts`
- `npm run validate`
- commit/push hooks: `npm run typecheck`, `npm run test:push`

## Post-deploy verification

Run this in production execute with the `home` connector connected:

```js
export default async function main() {
	return await kody.remote['home'].sonos_list_players({})
}
```

Expected: returns the connected Sonos player list instead of `Tool "remote:home:sonos_list_players" not found`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `c7ca6c69` · **Head:** `c2aa6589`

**Classification:** extends — fixes execute-time dispatch behavior for synthesized remote connector capabilities without adding a new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — remote capability metadata now stores dispatcher-safe names |
| `capabilities-execute` | runtime | extends — dispatcher registration rejects sanitized-name collisions and remote proxy calls round-trip through sanitized keys |
| `capability-registry` | assistant | composes — existing synthesized remote capabilities feed the corrected dispatch metadata |

### System map

```mermaid
flowchart LR
	mcpServer["mcp-server"]:::extended
	capabilityRegistry["capability-registry"]:::touched
	capabilitiesExecute["capabilities-execute"]:::extended
	connectorIngress["connector-ingress"]:::untouched
	mcpServer --> capabilityRegistry --> capabilitiesExecute
	connectorIngress --> capabilityRegistry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| Remote metadata used colon-format IDs like `remote:home:sonos_list_players` while ToolDispatcher registered `remotehomesonos_list_players`. | Remote metadata uses the sanitized dispatcher key, matching ToolDispatcher registration. |
| Sanitized name collisions could overwrite prior functions silently. | Collisions throw during dispatcher construction with both raw tool names named. |

### Invariants

- Per-user remote connector scoping is unchanged; this only aligns dispatch names after capabilities have already been built for the caller context.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c94bac1b-ad19-4d7f-a5d1-5703b4c8d2c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c94bac1b-ad19-4d7f-a5d1-5703b4c8d2c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote tool dispatch names are now consistently sanitized before use.
  * Added protection against name collisions when different tools would produce the same sanitized name, preventing one tool from overwriting another.
  * Updated remote connector calls so the visible dispatch name and the actual tool call name stay aligned correctly.

* **Tests**
  * Added coverage for sanitized dispatch naming and collision handling.
  * Expanded remote connector round-trip tests to verify tool calls still reach the expected underlying tool names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->