### PR TITLE
Fix Claude OAuth authorize malformed client recovery

### DIFF
--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -1,5 +1,6 @@
 import {
 	type AuthRequest,
+	type ClientInfo,
 	type OAuthHelpers,
 } from '@cloudflare/workers-oauth-provider'
 import { createCookie } from '@remix-run/cookie'
@@ -30,6 +31,8 @@ export const oauthPaths = {
 }
 
 export const oauthScopes: Array<string> = ['profile', 'email']
+const invalidOAuthClientRegistrationMessage =
+	'Invalid OAuth client registration.'
 
 type OAuthProps = {
 	userId: string
@@ -222,7 +225,11 @@ async function resolveAuthRequest(helpers: OAuthHelpers, request: Request) {
 		return { authRequest, client }
 	} catch (error) {
 		const message =
-			error instanceof Error ? error.message : 'Unable to parse OAuth request.'
+			error instanceof TypeError
+				? invalidOAuthClientRegistrationMessage
+				: error instanceof Error
+					? error.message
+					: 'Unable to parse OAuth request.'
 		return { error: message }
 	}
 }
@@ -266,6 +273,14 @@ function redirectUriMatchesRegisteredUri(
 	})
 }
 
+function readRegisteredRedirectUris(client: ClientInfo) {
+	const redirectUris = (client as { redirectUris?: unknown }).redirectUris
+	return Array.isArray(redirectUris) &&
+		redirectUris.every((uri) => typeof uri === 'string')
+		? redirectUris
+		: null
+}
+
 async function requestHasRedirectUriMismatch(
 	helpers: OAuthHelpers,
 	request: Request,
@@ -274,9 +289,16 @@ async function requestHasRedirectUriMismatch(
 	const clientId = url.searchParams.get('client_id')?.trim()
 	const redirectUri = url.searchParams.get('redirect_uri')?.trim()
 	if (!clientId || !redirectUri) return false
-	const client = await helpers.lookupClient(clientId)
+	let client: ClientInfo | null
+	try {
+		client = await helpers.lookupClient(clientId)
+	} catch {
+		return false
+	}
 	if (!client) return false
-	return !redirectUriMatchesRegisteredUri(redirectUri, client.redirectUris)
+	const registeredUris = readRegisteredRedirectUris(client)
+	if (!registeredUris) return true
+	return !redirectUriMatchesRegisteredUri(redirectUri, registeredUris)
 }
 
 async function listUserGrantsForClient(

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -5,13 +5,14 @@ import {
 	type CompleteAuthorizationOptions,
 	type OAuthHelpers,
 } from '@cloudflare/workers-oauth-provider'
+import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { env, exports } from 'cloudflare:workers'
 import { createAuthCookie, setAuthSessionSecret } from '#app/auth-session.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
 import { invalidClientIdMismatchMessage } from '@kody-internal/shared/oauth-messages.ts'
 import {
 	handleAuthorizeInfo,
 	handleAuthorizeRequest,
-	handleOAuthCallback,
 	oauthScopes,
 } from './oauth-handlers.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
@@ -31,6 +32,24 @@ const baseClient: ClientInfo = {
 	tokenEndpointAuthMethod: 'client_secret_basic',
 }
 const cookieSecret = 'test-secret-0123456789abcdef0123456789'
+const claudeAuthorizeUrl =
+	'https://heykody.dev/oauth/authorize?response_type=code&client_id=ZlV_ZKY8Xe1Hnw2a&redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback&code_challenge=sp23xso5O3jXO-73NoQqSxwu742uqSbPXw1VA8jRfNE&code_challenge_method=S256&state=x5z9jORTCRNTmZ5_fiH7tdVWDVbiPujOHtUkyHzBvmc&scope=profile+email&resource=https%3A%2F%2Fheykody.dev%2Fmcp'
+const claudeAuthRequest: AuthRequest = {
+	responseType: 'code',
+	clientId: 'ZlV_ZKY8Xe1Hnw2a',
+	redirectUri: 'https://claude.ai/api/mcp/auth_callback',
+	scope: ['profile', 'email'],
+	state: 'x5z9jORTCRNTmZ5_fiH7tdVWDVbiPujOHtUkyHzBvmc',
+	codeChallenge: 'sp23xso5O3jXO-73NoQqSxwu742uqSbPXw1VA8jRfNE',
+	codeChallengeMethod: 'S256',
+	resource: 'https://heykody.dev/mcp',
+}
+const claudeClient: ClientInfo = {
+	clientId: claudeAuthRequest.clientId,
+	redirectUris: [claudeAuthRequest.redirectUri],
+	clientName: 'Claude',
+	tokenEndpointAuthMethod: 'none',
+}
 
 function createHelpers(overrides: Partial<OAuthHelpers> = {}): OAuthHelpers {
 	return {
@@ -129,6 +148,13 @@ function createEnv(
 			'package-service-instance-test-id',
 		),
 	} as unknown as Env
+}
+
+async function workerFetch(request: Request): Promise<Response> {
+	const ctx = createExecutionContext()
+	const response = await exports.default.fetch(request, env, ctx)
+	await waitOnExecutionContext(ctx)
+	return response
 }
 
 function createFormRequest(
@@ -295,6 +321,108 @@ test('authorize info, denial, approval, and default scopes follow the OAuth work
 	)
 	const defaultScopeOptions = await capturedOptionsPromise
 	expect(defaultScopeOptions.scope).toEqual(oauthScopes)
+})
+
+test('Claude-shaped authorize requests render and approve without throwing', async () => {
+	const htmlResponse = await handleAuthorizeRequest(
+		new Request(claudeAuthorizeUrl),
+		createEnv(
+			createHelpers({
+				parseAuthRequest: async () => claudeAuthRequest,
+				lookupClient: async () => claudeClient,
+			}),
+		),
+	)
+
+	expect(htmlResponse.status).toBe(200)
+	expect(htmlResponse.headers.get('Content-Type')).toContain('text/html')
+	const html = await htmlResponse.text()
+	expect(html).toContain('Claude')
+	expect(html).toContain('"oauthAuthorize"')
+
+	let capturedOptions: CompleteAuthorizationOptions | null = null
+	const helpers = createHelpers({
+		parseAuthRequest: async () => claudeAuthRequest,
+		lookupClient: async () => claudeClient,
+		async completeAuthorization(options) {
+			capturedOptions = options
+			return {
+				redirectTo:
+					'https://claude.ai/api/mcp/auth_callback?code=demo&state=x5z9jORTCRNTmZ5_fiH7tdVWDVbiPujOHtUkyHzBvmc',
+			}
+		},
+	})
+	const postResponse = await handleAuthorizeRequest(
+		new Request(claudeAuthorizeUrl, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				decision: 'approve',
+				email: 'user@example.com',
+				password: 'password123',
+			}),
+		}),
+		createEnv(helpers, await createDatabase('password123')),
+	)
+
+	expect(postResponse.status).toBe(200)
+	await expect(postResponse.json()).resolves.toEqual({
+		ok: true,
+		redirectTo:
+			'https://claude.ai/api/mcp/auth_callback?code=demo&state=x5z9jORTCRNTmZ5_fiH7tdVWDVbiPujOHtUkyHzBvmc',
+	})
+	expect(capturedOptions?.request.resource).toBe('https://heykody.dev/mcp')
+	expect(capturedOptions?.request.scope).toEqual(['profile', 'email'])
+})
+
+test('worker entrypoint handles Claude-shaped authorize GET requests', async () => {
+	await env.OAUTH_KV.put(
+		`client:${claudeClient.clientId}`,
+		JSON.stringify(claudeClient),
+	)
+
+	const response = await workerFetch(new Request(claudeAuthorizeUrl))
+
+	expect(response.status).toBe(200)
+	expect(response.headers.get('Content-Type')).toContain('text/html')
+	const html = await response.text()
+	expect(html).toContain('Claude')
+	expect(html).toContain('"oauthAuthorize"')
+})
+
+test('worker entrypoint renders a recoverable error for missing Claude clients', async () => {
+	await env.OAUTH_KV.delete(`client:${claudeClient.clientId}`)
+
+	const response = await workerFetch(new Request(claudeAuthorizeUrl))
+
+	expect(response.status).toBe(200)
+	expect(response.headers.get('Content-Type')).toContain('text/html')
+	const html = await response.text()
+	expect(html).toContain('Invalid client')
+	expect(html).toContain('"oauthAuthorize"')
+})
+
+test('worker entrypoint renders a recoverable error for malformed Claude clients', async () => {
+	await env.OAUTH_KV.put(
+		`client:${claudeClient.clientId}`,
+		JSON.stringify({
+			client_id: claudeClient.clientId,
+			redirect_uris: [claudeAuthRequest.redirectUri],
+			client_name: claudeClient.clientName,
+			token_endpoint_auth_method: 'none',
+		}),
+	)
+
+	const response = await workerFetch(new Request(claudeAuthorizeUrl))
+
+	expect(response.status).toBe(200)
+	expect(response.headers.get('Content-Type')).toContain('text/html')
+	const html = await response.text()
+	expect(html).toContain('Invalid OAuth client registration.')
+	expect(html).toContain('"oauthAuthorize"')
 })
 
 test('reset client deletes matching grants for redirect-uri, client-id, and authorize-info mismatches', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Prevent malformed or stale OAuth client registrations from crashing `/oauth/authorize`.
- Render recoverable OAuth errors for Claude-shaped authorize requests when the stored client is missing or malformed.
- Add worker-entrypoint regression coverage for the Claude MCP OAuth URL shape.

## Testing
- `npx vitest run --project workers-unit packages/worker/src/oauth-handlers.workers.test.ts -t "Claude-shaped|malformed Claude clients"`
- `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `f73e1ee` · **Head:** `135f187`

**Classification:** extends — changes `mcp-oauth` error recovery so stale or malformed client records render recoverable authorize errors instead of throwing.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-oauth` | auth | extends — validates stored redirect URI shape and sanitizes malformed-client provider errors |
| `app-ui` | surfaces | composes — existing authorize SPA shell displays the recovered loader error |
| `mcp-server` | surfaces | composes — Claude MCP auth flow remains routed to `/mcp` resource audience |

### System map

```mermaid
flowchart LR
	claude["Claude MCP client"]:::untouched --> mcpOauth["mcp-oauth"]:::extended
	mcpOauth --> appUi["app-ui"]:::touched
	mcpOauth --> mcpServer["mcp-server"]:::touched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart TD
	request["/oauth/authorize Claude URL"] --> parse["parse/lookup OAuth client"]
	parse -->|valid client| render["render authorize shell"]
	parse -->|missing/malformed client| recover["return loader error data"]
	recover --> render
	render --> no1101["no Worker 1101"]
```

### Before / after

| Before | After |
| --- | --- |
| Malformed stored client could trigger `TypeError` during recovery. | Malformed stored client becomes `Invalid OAuth client registration.` loader data. |
| Recovery assumed `client.redirectUris` was always an array. | Recovery validates redirect URI shape before comparing. |

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3565-f37a-7f15-9ce1-f05f738f634a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3565-f37a-7f15-9ce1-f05f738f634a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

