### PR TITLE
Add email inbox search, inbound quotas, receive metering, and email_usage_get

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -134,7 +134,12 @@ Relational app data lives in D1.
 
 The schema is defined by migrations in `packages/worker/migrations/`:
 
-- `users`: login identity and password hash
+- `users`: login identity and password hash. There is no persisted mapping from
+  the stable MCP `userId` (SHA-256 of the normalized email) back to the row;
+  contextless paths (inbound email) reverse-resolve it by scanning and hashing
+  (`findUserAccountByStableUserId`). A persisted, indexed `stable_user_id`
+  column with an app-level backfill is required before onboarding external users
+  / design partners.
 - `password_resets`: hashed reset tokens with expiry and foreign key to users
 - `jobs`: persisted job metadata, caller context, schedule state, repo source
   pointers, and run observability counters/history

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -24,6 +24,12 @@ stored plan values are also treated as NULL so plan renames can never lock users
 out. Enforcement activates only when a known plan name is set — existing
 accounts keep working unchanged.
 
+Exception: the inbound email resources (`email_receives_per_day`,
+`stored_email_messages`) apply the `nullPlanEmailFallbackLimits` backstops from
+`plans.ts` to plan-less users, because inbound volume is attacker-controlled
+(anyone who learns an alias can send to it). Use `resolveEmailResourceLimit` to
+read the effective limit for those resources.
+
 ## Plan lookup
 
 The MCP `userId` is the SHA-256 hash of the normalized account email
@@ -45,6 +51,13 @@ available. Both auth surfaces provide it — app sessions expose
 (for example package-manifest job sync or workflow-spawned inline code) are
 documented fail-open gaps, acceptable because they are only reachable after a
 user action that is itself gated.
+
+One path cannot fail open: inbound email routing has no caller context but must
+enforce receive quotas. `findUserAccountByStableUserId` in `service.ts`
+reverse-resolves the stable user id to the account email (and plan) by scanning
+the users table and hashing each email — the same pattern
+`isAccountEmailVerified` uses. Only use it on contextless paths; interactive
+surfaces already carry the email.
 
 ## The error shape
 
@@ -85,13 +98,15 @@ Rules:
   concurrent workflows, running package services) are counted **directly from
   their source D1 tables at the enforcement point** via built-in counters in
   `service.ts`. They do not depend on any metering or rollup tables.
-- **Rate-style limits** (email sends per day) use the
+- **Rate-style limits** (email sends and receives per day) use the
   `entitlement_daily_counters` table keyed by `(user_id, resource, day)` with
   UTC day keys. Call `consumeDailyEntitlement` on every attempt: it checks the
   plan limit and increments the counter in one conditional D1 upsert (no
   check-then-increment race), and still increments (uncapped) for users without
-  a plan so counters reflect real usage the moment a plan is assigned. Counting
-  attempts rather than successes keeps the limit abuse-resistant.
+  a plan so counters reflect real usage the moment a plan is assigned — unless
+  the caller passes `fallbackLimit`, which caps plan-less users with a
+  deployment-level backstop (inbound email does this). Counting attempts rather
+  than successes keeps the limit abuse-resistant.
   `incrementDailyEntitlementCounter` remains for raw counter writes (tests,
   backfills).
 - **Boolean allowances** (persistent package services) are modeled as limit `0`
@@ -166,6 +181,8 @@ The exemplar is job scheduling: `createJob` in
 | `persistent_package_services` | `service_start` for services declared `mode: 'persistent'`                       |
 | `repo_sessions`               | `repo_open_session` before creating a new session                                |
 | `email_sends_per_day`         | `sendOutboundEmail` (atomic `consumeDailyEntitlement`)                           |
+| `email_receives_per_day`      | `handleInboundEmail` (atomic `consumeDailyEntitlement`, NULL-plan fallback)      |
+| `stored_email_messages`       | `handleInboundEmail` before storage (NULL-plan fallback)                         |
 | `secrets`                     | new-entry branch of `saveSecret` in `packages/worker/src/mcp/secrets/service.ts` |
 | `concurrent_workflows`        | `createDynamicCallableWorkflow` (plan limit, env-var backstop for NULL plan)     |
 | `storage_bytes`               | not yet enforced                                                                 |

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -25,10 +25,11 @@ out. Enforcement activates only when a known plan name is set — existing
 accounts keep working unchanged.
 
 Exception: the inbound email resources (`email_receives_per_day`,
-`stored_email_messages`) apply the `nullPlanEmailFallbackLimits` backstops from
-`plans.ts` to plan-less users, because inbound volume is attacker-controlled
-(anyone who learns an alias can send to it). Use `resolveEmailResourceLimit` to
-read the effective limit for those resources.
+`stored_email_messages`, `email_message_bytes`) apply the
+`nullPlanEmailFallbackLimits` backstops from `plans.ts` to plan-less users,
+because inbound volume is attacker-controlled (anyone who learns an alias can
+send to it). Use `resolveEmailResourceLimit` to read the effective limit for
+those resources.
 
 ## Plan lookup
 
@@ -60,6 +61,12 @@ the users table and hashing each email — the same pattern
 mapping is a content hash, so hits can never go stale) and re-verified with one
 point read. Only use it on contextless paths; interactive surfaces already carry
 the email.
+
+The cold-path scan is O(users) per isolate on an attacker-reachable path, which
+is acceptable for the current single-digit user count only. **A persisted
+`users.stable_user_id` column (indexed, with an app-level backfill — SQLite
+cannot compute SHA-256 in a migration) is required before onboarding external
+users / design partners**; the scan must not ship into multi-tenant use.
 
 ## The error shape
 
@@ -113,9 +120,15 @@ Rules:
   backfills).
 - **Boolean allowances** (persistent package services) are modeled as limit `0`
   (not allowed) vs `null` (allowed) so the numeric contract stays uniform.
-- `maxStorageBytes` is defined in the limits config but not yet enforced; it has
-  no built-in counter and requires `getCurrent` when it gains an enforcement
-  point.
+- **Per-unit size limits** (`email_message_bytes`) compare one candidate value
+  against the limit instead of an accumulating count: the enforcement point
+  passes the candidate size via `getCurrent` with `requested: 0`. There is no
+  built-in counter for these.
+- `maxStorageBytes` is defined in the limits config but **still not enforced**;
+  it has no built-in counter and requires `getCurrent` when it gains an
+  enforcement point. The per-message `email_message_bytes` cap bounds each
+  stored email's size but is deliberately **not** full storage-bytes accounting
+  — that remains a separate effort.
 
 Because the plan check happens before any counting, enforcement adds zero
 counting overhead for NULL-plan users.
@@ -175,19 +188,20 @@ The exemplar is job scheduling: `createJob` in
 
 ## Enforcement points
 
-| Resource                      | Enforcement point                                                                |
-| ----------------------------- | -------------------------------------------------------------------------------- |
-| `scheduled_jobs`              | `createJob` in `packages/worker/src/jobs/service.ts` (exemplar)                  |
-| `saved_packages`              | new-package branch of `package_save` and projection insert                       |
-| `package_services`            | `service_start` capability path                                                  |
-| `persistent_package_services` | `service_start` for services declared `mode: 'persistent'`                       |
-| `repo_sessions`               | `repo_open_session` before creating a new session                                |
-| `email_sends_per_day`         | `sendOutboundEmail` (atomic `consumeDailyEntitlement`)                           |
-| `email_receives_per_day`      | `handleInboundEmail` (atomic `consumeDailyEntitlement`, NULL-plan fallback)      |
-| `stored_email_messages`       | `handleInboundEmail` before storage (NULL-plan fallback)                         |
-| `secrets`                     | new-entry branch of `saveSecret` in `packages/worker/src/mcp/secrets/service.ts` |
-| `concurrent_workflows`        | `createDynamicCallableWorkflow` (plan limit, env-var backstop for NULL plan)     |
-| `storage_bytes`               | not yet enforced                                                                 |
+| Resource                      | Enforcement point                                                                  |
+| ----------------------------- | ---------------------------------------------------------------------------------- |
+| `scheduled_jobs`              | `createJob` in `packages/worker/src/jobs/service.ts` (exemplar)                    |
+| `saved_packages`              | new-package branch of `package_save` and projection insert                         |
+| `package_services`            | `service_start` capability path                                                    |
+| `persistent_package_services` | `service_start` for services declared `mode: 'persistent'`                         |
+| `repo_sessions`               | `repo_open_session` before creating a new session                                  |
+| `email_sends_per_day`         | `sendOutboundEmail` (atomic `consumeDailyEntitlement`)                             |
+| `email_receives_per_day`      | `handleInboundEmail` (atomic `consumeDailyEntitlement`, NULL-plan fallback)        |
+| `stored_email_messages`       | `handleInboundEmail` before storage (NULL-plan fallback)                           |
+| `email_message_bytes`         | `handleInboundEmail` before quota/parse (per-message raw size, NULL-plan fallback) |
+| `secrets`                     | new-entry branch of `saveSecret` in `packages/worker/src/mcp/secrets/service.ts`   |
+| `concurrent_workflows`        | `createDynamicCallableWorkflow` (plan limit, env-var backstop for NULL plan)       |
+| `storage_bytes`               | not yet enforced                                                                   |
 
 ## Related tables and coordination
 

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -56,8 +56,10 @@ One path cannot fail open: inbound email routing has no caller context but must
 enforce receive quotas. `findUserAccountByStableUserId` in `service.ts`
 reverse-resolves the stable user id to the account email (and plan) by scanning
 the users table and hashing each email — the same pattern
-`isAccountEmailVerified` uses. Only use it on contextless paths; interactive
-surfaces already carry the email.
+`isAccountEmailVerified` uses. Positive matches are cached per isolate (the
+mapping is a content hash, so hits can never go stale) and re-verified with one
+point read. Only use it on contextless paths; interactive surfaces already carry
+the email.
 
 ## The error shape
 

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -39,16 +39,22 @@ stays reviewable in one place.
 
 ### Metrics and their chokepoints
 
-| `eventType`        | Metered unit                                    | Recorded at                                                                                | `entityId`                  |
-| ------------------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------- |
-| `execute`          | one dynamic-worker sandbox evaluation           | `packages/worker/src/mcp/executor.ts` (`execute`)                                          | none                        |
-| `package_export`   | one saved-package bundled-code run              | `packages/worker/src/mcp/run-kody-registry.ts` (bundled runs with a package context)       | package id                  |
-| `job_run`          | one job execution                               | `packages/worker/src/jobs/service.ts` (`executeJobOnce`)                                   | job id                      |
-| `workflow_run`     | one Cloudflare Workflow run                     | `packages/worker/src/package-runtime/package-workflows.ts` (`DynamicCallableWorkflow.run`) | workflow instance id        |
-| `service_runtime`  | one package service run (bounded or persistent) | `packages/worker/src/package-runtime/package-service.ts` (run finalization)                | `{packageId}:{serviceName}` |
-| `realtime_session` | one realtime websocket session                  | reserved — not yet instrumented                                                            | session id                  |
-| `outbound_fetch`   | one outbound fetch through the gateway          | `packages/worker/src/mcp/fetch-gateway.ts` (`KodyFetchGateway.fetch`)                      | request host                |
-| `email_send`       | one outbound email send attempt                 | `packages/worker/src/email/outbound.ts` (`sendOutboundEmail`)                              | email message id            |
+| `eventType`        | Metered unit                                    | Recorded at                                                                                | `entityId`                     |
+| ------------------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------ |
+| `execute`          | one dynamic-worker sandbox evaluation           | `packages/worker/src/mcp/executor.ts` (`execute`)                                          | none                           |
+| `package_export`   | one saved-package bundled-code run              | `packages/worker/src/mcp/run-kody-registry.ts` (bundled runs with a package context)       | package id                     |
+| `job_run`          | one job execution                               | `packages/worker/src/jobs/service.ts` (`executeJobOnce`)                                   | job id                         |
+| `workflow_run`     | one Cloudflare Workflow run                     | `packages/worker/src/package-runtime/package-workflows.ts` (`DynamicCallableWorkflow.run`) | workflow instance id           |
+| `service_runtime`  | one package service run (bounded or persistent) | `packages/worker/src/package-runtime/package-service.ts` (run finalization)                | `{packageId}:{serviceName}`    |
+| `realtime_session` | one realtime websocket session                  | reserved — not yet instrumented                                                            | session id                     |
+| `outbound_fetch`   | one outbound fetch through the gateway          | `packages/worker/src/mcp/fetch-gateway.ts` (`KodyFetchGateway.fetch`)                      | request host                   |
+| `email_send`       | one outbound email send attempt                 | `packages/worker/src/email/outbound.ts` (`sendOutboundEmail`)                              | email message id               |
+| `email_received`   | one inbound receive attempt for a routed inbox  | `packages/worker/src/email/inbound.ts` (`handleInboundEmail`, after inbox resolution)      | email message id (when stored) |
+
+`email_received` covers receive attempts once an inbound message is routed to a
+known, enabled inbox: stored messages record `success`; entitlement rejections
+and parse failures record `error`. Mail rejected before inbox resolution
+(unknown alias, disabled inbox) has no owning user and is not metered.
 
 ### Nesting: metrics are independent, do not sum across types
 

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -52,11 +52,11 @@ stays reviewable in one place.
 | `email_received`   | one inbound receive attempt for a routed inbox  | `packages/worker/src/email/inbound.ts` (`handleInboundEmail`, after inbox resolution)      | email message id (when stored) |
 
 `email_received` covers receive attempts once an inbound message is routed to a
-known, enabled inbox: stored messages record `success`; size rejections,
-entitlement rejections, and parse failures record `error`. The `bytes` field
-always carries the raw message size, including for rejected mail. Mail rejected
-before inbox resolution (unknown alias, disabled inbox) has no owning user and
-is not metered.
+known, enabled inbox: stored messages record `success`; unverified-account
+rejections, size rejections, entitlement rejections, and parse failures record
+`error`. The `bytes` field always carries the raw message size, including for
+rejected mail. Mail rejected before inbox resolution (unknown alias, disabled
+inbox) has no owning user and is not metered.
 
 ### Nesting: metrics are independent, do not sum across types
 

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -52,9 +52,11 @@ stays reviewable in one place.
 | `email_received`   | one inbound receive attempt for a routed inbox  | `packages/worker/src/email/inbound.ts` (`handleInboundEmail`, after inbox resolution)      | email message id (when stored) |
 
 `email_received` covers receive attempts once an inbound message is routed to a
-known, enabled inbox: stored messages record `success`; entitlement rejections
-and parse failures record `error`. Mail rejected before inbox resolution
-(unknown alias, disabled inbox) has no owning user and is not metered.
+known, enabled inbox: stored messages record `success`; size rejections,
+entitlement rejections, and parse failures record `error`. The `bytes` field
+always carries the raw message size, including for rejected mail. Mail rejected
+before inbox resolution (unknown alias, disabled inbox) has no owning user and
+is not metered.
 
 ### Nesting: metrics are independent, do not sum across types
 

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -15,8 +15,28 @@ Use the MCP `email` domain:
 - `email_reply` replies to a stored inbound message.
 - `email_attachment_get` returns stored attachment bytes by attachment id.
 - `email_message_list` lists stored inbound and outbound messages.
+- `email_message_search` searches stored messages by case-insensitive substring
+  match against the subject, header `From`, and envelope sender. It accepts the
+  same `inbox_id` / `direction` / `processing_status` filters and limit caps as
+  `email_message_list`.
 - `email_message_get` returns parsed bodies, headers, thread metadata, and
   attachment metadata.
+- `email_usage_get` returns the signed-in user's email usage and limits: stored
+  message count, today's send and receive counts, the applicable caps, and the
+  plan name.
+
+## Quotas
+
+Inbound storage is quota-gated per user:
+
+- A daily receive limit (`email_receives_per_day`) and a stored-message cap
+  (`stored_email_messages`) apply at storage time. Mail over quota is rejected
+  at the routing layer with a generic "over quota" response to the sender, and
+  the detailed reason is recorded as a `rejected` delivery event.
+- Plan users get their plan's limits; users without a plan get conservative
+  deployment fallbacks (they are not unlimited for inbound mail).
+- Outbound sending stays limited by `email_sends_per_day` for plan users.
+- Check where you stand with `email_usage_get`.
 
 ## Safety model
 
@@ -25,7 +45,8 @@ Use the MCP `email` domain:
   `/account` page), email capabilities are rejected, inbound mail routed to the
   account's aliases is rejected before storage, and MCP access as a whole is
   disabled.
-- Any email routed to a configured Kody inbox on a verified account is stored.
+- Any email routed to a configured Kody inbox on a verified account is stored,
+  subject to the quotas above.
 - Unknown aliases are rejected before storage.
 - Display names are not trusted. Kody stores envelope sender, parsed `From`, and
   authentication headers separately.
@@ -124,4 +145,5 @@ Message-ID: <hello@example.com>
 Hello from local email routing.'
 ```
 
-Then inspect the message with `email_message_list` and `email_message_get`.
+Then inspect the message with `email_message_list`, `email_message_search`, and
+`email_message_get`.

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -34,15 +34,16 @@ Inbound storage is quota-gated per user:
   apply at storage time. Mail over any of these is rejected at the routing layer
   with a generic "over quota" response to the sender, and the detailed reason is
   recorded as a `rejected` delivery event. Oversize mail is rejected before it
-  consumes any daily receive quota.
+  consumes any daily receive quota, and mail to unverified accounts (which can
+  never receive) is rejected without consuming any quota at all.
 - Plan users get their plan's limits; users without a plan get conservative
   deployment fallbacks (they are not unlimited for inbound mail).
-- Quota and size rejections store at most five detailed `rejected` delivery
-  events per inbox per UTC day; further rejections increment a single daily
-  aggregate event (with a total count and the last reason) so rejected floods
-  cannot grow storage. Parse-failure rejections keep one event per attempt —
-  they are already bounded by the daily receive quota and the detail helps debug
-  a misbehaving sender.
+- Quota, size, and unverified-account rejections store at most five detailed
+  `rejected` delivery events per inbox per UTC day; further rejections increment
+  a single daily aggregate event (with a total count and the last reason) so
+  rejected floods cannot grow storage. Parse-failure rejections keep one event
+  per attempt — they are already bounded by the daily receive quota and the
+  detail helps debug a misbehaving sender.
 - Outbound sending stays limited by `email_sends_per_day` for plan users.
 - Check where you stand with `email_usage_get`.
 

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -29,12 +29,20 @@ Use the MCP `email` domain:
 
 Inbound storage is quota-gated per user:
 
-- A daily receive limit (`email_receives_per_day`) and a stored-message cap
-  (`stored_email_messages`) apply at storage time. Mail over quota is rejected
-  at the routing layer with a generic "over quota" response to the sender, and
-  the detailed reason is recorded as a `rejected` delivery event.
+- A per-message raw-size cap (`email_message_bytes`), a daily receive limit
+  (`email_receives_per_day`), and a stored-message cap (`stored_email_messages`)
+  apply at storage time. Mail over any of these is rejected at the routing layer
+  with a generic "over quota" response to the sender, and the detailed reason is
+  recorded as a `rejected` delivery event. Oversize mail is rejected before it
+  consumes any daily receive quota.
 - Plan users get their plan's limits; users without a plan get conservative
   deployment fallbacks (they are not unlimited for inbound mail).
+- Quota and size rejections store at most five detailed `rejected` delivery
+  events per inbox per UTC day; further rejections increment a single daily
+  aggregate event (with a total count and the last reason) so rejected floods
+  cannot grow storage. Parse-failure rejections keep one event per attempt —
+  they are already bounded by the daily receive quota and the detail helps debug
+  a misbehaving sender.
 - Outbound sending stays limited by `email_sends_per_day` for plan users.
 - Check where you stand with `email_usage_get`.
 

--- a/packages/worker/client/routes/admin-usage.tsx
+++ b/packages/worker/client/routes/admin-usage.tsx
@@ -38,6 +38,7 @@ const usageMetricLabels = {
 	service_runtime: 'Service runtime',
 	outbound_fetch: 'Fetches',
 	email_send: 'Email sends',
+	email_received: 'Email receives',
 } as const
 
 function isAdminUsagePath(href: string) {

--- a/packages/worker/src/app/admin-usage-data.node.test.ts
+++ b/packages/worker/src/app/admin-usage-data.node.test.ts
@@ -37,6 +37,7 @@ type ResourceCount = Partial<
 		| 'scheduled_jobs'
 		| 'package_services'
 		| 'repo_sessions'
+		| 'stored_email_messages'
 		| 'secrets'
 		| 'concurrent_workflows',
 		number
@@ -71,6 +72,9 @@ function createAdminUsageTestDb(input: {
 		}
 		if (normalizedQuery.includes('from repo_sessions')) {
 			return counts.repo_sessions ?? 0
+		}
+		if (normalizedQuery.includes('from email_messages')) {
+			return counts.stored_email_messages ?? 0
 		}
 		if (normalizedQuery.includes('from secret_entries')) {
 			return counts.secrets ?? 0
@@ -213,6 +217,11 @@ test('loadAdminUsageData returns zeroed usage for empty rollups', async () => {
 	).toBe(true)
 	expect(data.users[0]?.todayCounters).toEqual([
 		{ resource: 'email_sends_per_day', label: 'email sends per day', count: 0 },
+		{
+			resource: 'email_receives_per_day',
+			label: 'email receives per day',
+			count: 0,
+		},
 	])
 	expect(data.selectedUser?.monthUsage).toEqual([
 		{

--- a/packages/worker/src/app/admin-usage-data.node.test.ts
+++ b/packages/worker/src/app/admin-usage-data.node.test.ts
@@ -309,6 +309,62 @@ test('loadAdminUsageData aggregates multiple users and warns above eighty percen
 	).toEqual(['saved_packages', 'email_sends_per_day'])
 })
 
+test('loadAdminUsageData shows email fallback limits for plan-less users', async () => {
+	const email = 'null-plan-email@example.com'
+	const usageUserId = await createStableUserIdFromEmail(email)
+	const db = createAdminUsageTestDb({
+		users: [
+			{
+				id: 1,
+				username: 'nullplan',
+				email,
+				plan: null,
+			},
+		],
+		dailyCounters: [
+			{
+				user_id: usageUserId,
+				resource: 'email_receives_per_day',
+				day: '2026-07-05',
+				count: 190,
+			},
+		],
+		resourceCounts: {
+			[usageUserId]: { stored_email_messages: 12 },
+		},
+	})
+
+	const data = await loadAdminUsageData(
+		{ APP_DB: db } as Env,
+		'https://kody.local/admin/usage.json?userId=1',
+		new Date('2026-07-05T12:00:00.000Z'),
+	)
+
+	const consumption = new Map(
+		(data.selectedUser?.entitlementConsumption ?? []).map((entry) => [
+			entry.resource,
+			entry,
+		]),
+	)
+	// Plan-less users stay unlimited for ordinary resources...
+	expect(consumption.get('saved_packages')?.limit).toBeNull()
+	expect(consumption.get('email_sends_per_day')?.limit).toBeNull()
+	// ...but the inbound email resources show the deployment fallbacks.
+	expect(consumption.get('email_receives_per_day')).toMatchObject({
+		current: 190,
+		limit: 200,
+		overEightyPercent: true,
+	})
+	expect(consumption.get('stored_email_messages')).toMatchObject({
+		current: 12,
+		limit: 2000,
+		overEightyPercent: false,
+	})
+	expect(
+		data.selectedUser?.warnings.map((warning) => warning.resource),
+	).toEqual(['email_receives_per_day'])
+})
+
 test('loadAdminUsageData keeps current-month and month-over-month rollups on UTC month boundaries', async () => {
 	const email = 'month-boundary@example.com'
 	const usageUserId = await createStableUserIdFromEmail(email)

--- a/packages/worker/src/app/admin-usage-data.ts
+++ b/packages/worker/src/app/admin-usage-data.ts
@@ -1,6 +1,8 @@
 import {
 	entitlementResourceLabels,
+	isEmailFallbackResource,
 	parsePlanName,
+	resolveEmailResourceLimit,
 	resolvePlanLimit,
 	type EntitlementResource,
 	type PlanName,
@@ -308,9 +310,13 @@ async function readEntitlementConsumption(input: {
 				resource,
 				now: input.now,
 			})
-			const limit = input.user.plan
-				? resolvePlanLimit(input.user.plan, resource)
-				: null
+			// Inbound email resources cap plan-less users with deployment
+			// fallbacks, so show the effective limit instead of unlimited.
+			const limit = isEmailFallbackResource(resource)
+				? resolveEmailResourceLimit(input.user.plan, resource)
+				: input.user.plan
+					? resolvePlanLimit(input.user.plan, resource)
+					: null
 			const percentOfLimit =
 				limit == null || limit === 0 ? null : current / limit
 			return {

--- a/packages/worker/src/app/admin-usage-data.ts
+++ b/packages/worker/src/app/admin-usage-data.ts
@@ -30,6 +30,7 @@ export const adminUsageMetrics = [
 	'service_runtime',
 	'outbound_fetch',
 	'email_send',
+	'email_received',
 ] as const satisfies ReadonlyArray<AdminUsageMetric>
 
 export const adminUsageLiveResourceCounts = [
@@ -47,12 +48,15 @@ const adminUsageEntitlementResources = [
 	'persistent_package_services',
 	'repo_sessions',
 	'email_sends_per_day',
+	'email_receives_per_day',
+	'stored_email_messages',
 	'secrets',
 	'concurrent_workflows',
 ] as const satisfies ReadonlyArray<EntitlementResource>
 
 const adminUsageDailyCounterResources = [
 	'email_sends_per_day',
+	'email_receives_per_day',
 ] as const satisfies ReadonlyArray<EntitlementResource>
 
 const defaultPageSize = 20

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -101,6 +101,7 @@ export type AdminUsageMetric =
 	| 'service_runtime'
 	| 'outbound_fetch'
 	| 'email_send'
+	| 'email_received'
 
 export type AdminUsageEntitlementResource =
 	| 'saved_packages'
@@ -109,6 +110,8 @@ export type AdminUsageEntitlementResource =
 	| 'persistent_package_services'
 	| 'repo_sessions'
 	| 'email_sends_per_day'
+	| 'email_receives_per_day'
+	| 'stored_email_messages'
 	| 'secrets'
 	| 'concurrent_workflows'
 	| 'storage_bytes'

--- a/packages/worker/src/email/inbound-entitlements.workers.test.ts
+++ b/packages/worker/src/email/inbound-entitlements.workers.test.ts
@@ -28,6 +28,7 @@ import { ensureEmailTestSchema } from './test-schema.ts'
 async function seedAccountWithPlan(input: {
 	email: string
 	plan: 'personal' | null
+	emailVerifiedAt?: string | null
 }) {
 	await env.APP_DB.prepare(
 		`INSERT INTO users (username, email, password_hash, email_verified_at, plan)
@@ -37,7 +38,9 @@ async function seedAccountWithPlan(input: {
 			`inbound-entitlement-${crypto.randomUUID().slice(0, 8)}`,
 			input.email,
 			'test-password-hash',
-			new Date().toISOString(),
+			input.emailVerifiedAt === undefined
+				? new Date().toISOString()
+				: input.emailVerifiedAt,
 			input.plan,
 		)
 		.run()
@@ -210,9 +213,10 @@ test('inbound email rejects plan users at the stored message cap and still count
 test('inbound email applies the NULL-plan fallback receive limit', async () => {
 	await ensureEmailTestSchema(env.APP_DB)
 	await ensureUsageRollupsTestSchema(env.APP_DB)
-	// No users row exists for this synthetic user id, so the plan lookup
-	// resolves nothing and the deployment fallback applies.
-	const userId = `inbound-fallback-${crypto.randomUUID()}`
+	// A verified account with a NULL plan gets the deployment fallback.
+	const email = `fallback-${crypto.randomUUID()}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	await seedAccountWithPlan({ email, plan: null })
 	const fallbackLimit = nullPlanEmailFallbackLimits.email_receives_per_day
 	const { address } = await seedInboxWithAddress(userId)
 	await setDailyReceiveCounter(userId, fallbackLimit)
@@ -310,15 +314,19 @@ test('findUserAccountByStableUserId resolves accounts, caches hits, and recovers
 	expect(await findUserAccountByStableUserId(env.APP_DB, userId)).toEqual({
 		email,
 		plan: 'personal',
+		emailVerified: true,
 	})
 	// Second call takes the cached-email point-read path and must still
-	// reflect the current plan value.
-	await env.APP_DB.prepare(`UPDATE users SET plan = NULL WHERE email = ?`)
+	// reflect the current plan and verified state.
+	await env.APP_DB.prepare(
+		`UPDATE users SET plan = NULL, email_verified_at = NULL WHERE email = ?`,
+	)
 		.bind(email)
 		.run()
 	expect(await findUserAccountByStableUserId(env.APP_DB, userId)).toEqual({
 		email,
 		plan: null,
+		emailVerified: false,
 	})
 	// Deleting the account invalidates the cached entry.
 	await env.APP_DB.prepare(`DELETE FROM users WHERE email = ?`)
@@ -329,6 +337,42 @@ test('findUserAccountByStableUserId resolves accounts, caches hits, and recovers
 		await findUserAccountByStableUserId(env.APP_DB, `unknown-${userId}`),
 	).toBeNull()
 	expect(await findUserAccountByStableUserId(env.APP_DB, '  ')).toBeNull()
+})
+
+test('inbound email rejects unverified accounts without consuming quota, with bounded events', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	await ensureUsageRollupsTestSchema(env.APP_DB)
+	const email = `unverified-quota-${crypto.randomUUID()}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	await seedAccountWithPlan({ email, plan: 'personal', emailVerifiedAt: null })
+	const { address } = await seedInboxWithAddress(userId)
+
+	for (let index = 0; index < 2; index += 1) {
+		const message = buildInboundMessage(address)
+		await handleInboundEmail(message, env)
+		expect(message.rejectedReason).toBe('Account email is not verified.')
+	}
+
+	expect(
+		await listEmailMessages({ db: env.APP_DB, userId, limit: 10 }),
+	).toEqual([])
+	// An account that can never receive must not accumulate receive quota.
+	expect(await readDailyReceiveCounter(userId)).toBe(0)
+	const rejections = await readRejectionEvents(userId)
+	expect(rejections.detailed).toHaveLength(2)
+	expect(rejections.detailed[0]?.detail).toMatchObject({
+		phase: 'account-verification',
+		reason: 'Account email is not verified.',
+	})
+	expect(rejections.aggregate?.detail).toMatchObject({
+		count: 2,
+		last_phase: 'account-verification',
+	})
+	// Attempts are still metered for owner visibility.
+	expect(await readEmailReceivedRollup(userId)).toMatchObject({
+		event_count: 2,
+		error_count: 2,
+	})
 })
 
 test('inbound email under quota stores the message, counts the receive, and records usage', async () => {

--- a/packages/worker/src/email/inbound-entitlements.workers.test.ts
+++ b/packages/worker/src/email/inbound-entitlements.workers.test.ts
@@ -1,0 +1,247 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import {
+	nullPlanEmailFallbackLimits,
+	planLimits,
+} from '#worker/entitlements/plans.ts'
+import { utcDayKey } from '#worker/entitlements/service.ts'
+import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import {
+	getEmailDomain,
+	getEmailLocalPart,
+	requireNormalizedEmailAddress,
+} from './address.ts'
+import { handleInboundEmail } from './inbound.ts'
+import {
+	createEmailInbox,
+	createEmailInboxAddress,
+	listEmailMessages,
+} from './repo.ts'
+import { createForwardableEmailMessage } from './test-fixtures.ts'
+import { ensureEmailTestSchema } from './test-schema.ts'
+
+async function seedAccountWithPlan(input: {
+	email: string
+	plan: 'personal' | null
+}) {
+	await env.APP_DB.prepare(
+		`INSERT INTO users (username, email, password_hash, email_verified_at, plan)
+			VALUES (?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			`inbound-entitlement-${crypto.randomUUID().slice(0, 8)}`,
+			input.email,
+			'test-password-hash',
+			new Date().toISOString(),
+			input.plan,
+		)
+		.run()
+}
+
+async function seedInboxWithAddress(userId: string) {
+	const address = requireNormalizedEmailAddress(
+		`inbox-${crypto.randomUUID()}@example.com`,
+	)
+	const inbox = await createEmailInbox({
+		db: env.APP_DB,
+		userId,
+		name: 'Entitlement inbox',
+		description: 'Entitlement test inbox',
+	})
+	await createEmailInboxAddress({
+		db: env.APP_DB,
+		inboxId: inbox.id,
+		userId,
+		address,
+		localPart: getEmailLocalPart(address),
+		domain: getEmailDomain(address),
+	})
+	return { inbox, address }
+}
+
+function buildInboundMessage(address: string) {
+	return createForwardableEmailMessage({
+		from: 'sender@example.net',
+		to: address,
+		raw: [
+			'From: Sender <sender@example.net>',
+			`To: ${address}`,
+			'Subject: Quota test',
+			`Message-ID: <quota-${crypto.randomUUID()}@example.net>`,
+			'',
+			'Quota body.',
+		].join('\r\n'),
+	})
+}
+
+async function setDailyReceiveCounter(userId: string, count: number) {
+	await env.APP_DB.prepare(
+		`INSERT INTO entitlement_daily_counters (user_id, resource, day, count, updated_at)
+			VALUES (?, 'email_receives_per_day', ?, ?, ?)`,
+	)
+		.bind(userId, utcDayKey(), count, new Date().toISOString())
+		.run()
+}
+
+async function readDailyReceiveCounter(userId: string) {
+	const row = await env.APP_DB.prepare(
+		`SELECT count FROM entitlement_daily_counters
+			WHERE user_id = ? AND resource = 'email_receives_per_day' AND day = ?`,
+	)
+		.bind(userId, utcDayKey())
+		.first<{ count: number }>()
+	return Number(row?.count ?? 0)
+}
+
+async function bulkInsertStoredMessages(userId: string, count: number) {
+	await env.APP_DB.prepare(
+		`WITH RECURSIVE seq(n) AS (
+			SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < ?2
+		)
+		INSERT INTO email_messages (
+			id, direction, user_id, from_address, subject,
+			processing_status, created_at, updated_at
+		)
+		SELECT ?1 || '-bulk-' || n, 'inbound', ?1, 'bulk@example.com', 'Bulk',
+			'stored', ?3, ?3
+		FROM seq`,
+	)
+		.bind(userId, count, new Date().toISOString())
+		.run()
+}
+
+async function listRejectedDeliveryEvents(userId: string) {
+	const { results } = await env.APP_DB.prepare(
+		`SELECT event_type, detail_json FROM email_delivery_events
+			WHERE user_id = ? AND event_type = 'rejected'
+			ORDER BY created_at ASC`,
+	)
+		.bind(userId)
+		.all<{ event_type: string; detail_json: string }>()
+	return (results ?? []).map((row) => ({
+		eventType: row.event_type,
+		detail: JSON.parse(row.detail_json) as Record<string, unknown>,
+	}))
+}
+
+async function readEmailReceivedRollup(userId: string) {
+	return await env.APP_DB.prepare(
+		`SELECT event_count, error_count, total_bytes FROM usage_rollups
+			WHERE user_id = ? AND metric = 'email_received' AND month = ?`,
+	)
+		.bind(userId, new Date().toISOString().slice(0, 7))
+		.first<{ event_count: number; error_count: number; total_bytes: number }>()
+}
+
+test('inbound email rejects plan users at the daily receive limit', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	await ensureUsageRollupsTestSchema(env.APP_DB)
+	const email = `receive-limit-${crypto.randomUUID()}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	const limit = planLimits.personal.maxEmailReceivesPerDay
+	if (limit === null) throw new Error('Expected a numeric personal limit.')
+	await seedAccountWithPlan({ email, plan: 'personal' })
+	const { address } = await seedInboxWithAddress(userId)
+	await setDailyReceiveCounter(userId, limit)
+
+	const message = buildInboundMessage(address)
+	await handleInboundEmail(message, env)
+
+	expect(message.rejectedReason).toBe('Recipient mailbox is over quota.')
+	expect(
+		await listEmailMessages({ db: env.APP_DB, userId, limit: 10 }),
+	).toEqual([])
+	expect(await readDailyReceiveCounter(userId)).toBe(limit)
+	const rejections = await listRejectedDeliveryEvents(userId)
+	expect(rejections).toHaveLength(1)
+	// The plan-specific wording proves the stable-id reverse lookup resolved
+	// the account (the fallback message says "this deployment" instead).
+	expect(rejections[0]?.detail).toMatchObject({
+		phase: 'entitlement',
+		reason: expect.stringContaining(
+			`your "personal" plan allows at most ${limit} email receives per day`,
+		),
+	})
+	expect(await readEmailReceivedRollup(userId)).toMatchObject({
+		event_count: 1,
+		error_count: 1,
+	})
+})
+
+test('inbound email rejects plan users at the stored message cap and still counts the attempt', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	await ensureUsageRollupsTestSchema(env.APP_DB)
+	const email = `storage-cap-${crypto.randomUUID()}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	const cap = planLimits.personal.maxStoredEmailMessages
+	if (cap === null) throw new Error('Expected a numeric personal cap.')
+	await seedAccountWithPlan({ email, plan: 'personal' })
+	const { address } = await seedInboxWithAddress(userId)
+	await bulkInsertStoredMessages(userId, cap)
+
+	const message = buildInboundMessage(address)
+	await handleInboundEmail(message, env)
+
+	expect(message.rejectedReason).toBe('Recipient mailbox is over quota.')
+	expect(
+		await listEmailMessages({ db: env.APP_DB, userId, limit: cap + 10 }),
+	).toHaveLength(cap)
+	// The receive attempt is counted even when the storage cap rejects it.
+	expect(await readDailyReceiveCounter(userId)).toBe(1)
+	const rejections = await listRejectedDeliveryEvents(userId)
+	expect(rejections[0]?.detail).toMatchObject({
+		phase: 'entitlement',
+		reason: expect.stringContaining(
+			`your "personal" plan allows at most ${cap} stored email messages`,
+		),
+	})
+})
+
+test('inbound email applies the NULL-plan fallback receive limit', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	await ensureUsageRollupsTestSchema(env.APP_DB)
+	// No users row exists for this synthetic user id, so the plan lookup
+	// resolves nothing and the deployment fallback applies.
+	const userId = `inbound-fallback-${crypto.randomUUID()}`
+	const fallbackLimit = nullPlanEmailFallbackLimits.email_receives_per_day
+	const { address } = await seedInboxWithAddress(userId)
+	await setDailyReceiveCounter(userId, fallbackLimit)
+
+	const message = buildInboundMessage(address)
+	await handleInboundEmail(message, env)
+
+	expect(message.rejectedReason).toBe('Recipient mailbox is over quota.')
+	const rejections = await listRejectedDeliveryEvents(userId)
+	expect(rejections[0]?.detail).toMatchObject({
+		reason: expect.stringContaining(
+			`this deployment allows at most ${fallbackLimit} email receives per day`,
+		),
+	})
+})
+
+test('inbound email under quota stores the message, counts the receive, and records usage', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	await ensureUsageRollupsTestSchema(env.APP_DB)
+	const email = `under-quota-${crypto.randomUUID()}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	await seedAccountWithPlan({ email, plan: 'personal' })
+	const { address } = await seedInboxWithAddress(userId)
+
+	const message = buildInboundMessage(address)
+	await handleInboundEmail(message, env)
+
+	expect(message.rejectedReason).toBeNull()
+	const messages = await listEmailMessages({
+		db: env.APP_DB,
+		userId,
+		limit: 10,
+	})
+	expect(messages).toHaveLength(1)
+	expect(await readDailyReceiveCounter(userId)).toBe(1)
+	expect(await readEmailReceivedRollup(userId)).toMatchObject({
+		event_count: 1,
+		error_count: 0,
+		total_bytes: message.rawSize,
+	})
+})

--- a/packages/worker/src/email/inbound-entitlements.workers.test.ts
+++ b/packages/worker/src/email/inbound-entitlements.workers.test.ts
@@ -4,7 +4,10 @@ import {
 	nullPlanEmailFallbackLimits,
 	planLimits,
 } from '#worker/entitlements/plans.ts'
-import { utcDayKey } from '#worker/entitlements/service.ts'
+import {
+	findUserAccountByStableUserId,
+	utcDayKey,
+} from '#worker/entitlements/service.ts'
 import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import {
@@ -218,6 +221,36 @@ test('inbound email applies the NULL-plan fallback receive limit', async () => {
 			`this deployment allows at most ${fallbackLimit} email receives per day`,
 		),
 	})
+})
+
+test('findUserAccountByStableUserId resolves accounts, caches hits, and recovers from deletions', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const email = `reverse-lookup-${crypto.randomUUID()}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	await seedAccountWithPlan({ email, plan: 'personal' })
+
+	expect(await findUserAccountByStableUserId(env.APP_DB, userId)).toEqual({
+		email,
+		plan: 'personal',
+	})
+	// Second call takes the cached-email point-read path and must still
+	// reflect the current plan value.
+	await env.APP_DB.prepare(`UPDATE users SET plan = NULL WHERE email = ?`)
+		.bind(email)
+		.run()
+	expect(await findUserAccountByStableUserId(env.APP_DB, userId)).toEqual({
+		email,
+		plan: null,
+	})
+	// Deleting the account invalidates the cached entry.
+	await env.APP_DB.prepare(`DELETE FROM users WHERE email = ?`)
+		.bind(email)
+		.run()
+	expect(await findUserAccountByStableUserId(env.APP_DB, userId)).toBeNull()
+	expect(
+		await findUserAccountByStableUserId(env.APP_DB, `unknown-${userId}`),
+	).toBeNull()
+	expect(await findUserAccountByStableUserId(env.APP_DB, '  ')).toBeNull()
 })
 
 test('inbound email under quota stores the message, counts the receive, and records usage', async () => {

--- a/packages/worker/src/email/inbound-entitlements.workers.test.ts
+++ b/packages/worker/src/email/inbound-entitlements.workers.test.ts
@@ -20,6 +20,7 @@ import {
 	createEmailInbox,
 	createEmailInboxAddress,
 	listEmailMessages,
+	maxDetailedEmailRejectionEventsPerDay,
 } from './repo.ts'
 import { createForwardableEmailMessage } from './test-fixtures.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
@@ -114,18 +115,22 @@ async function bulkInsertStoredMessages(userId: string, count: number) {
 		.run()
 }
 
-async function listRejectedDeliveryEvents(userId: string) {
+async function readRejectionEvents(userId: string) {
 	const { results } = await env.APP_DB.prepare(
-		`SELECT event_type, detail_json FROM email_delivery_events
+		`SELECT id, detail_json FROM email_delivery_events
 			WHERE user_id = ? AND event_type = 'rejected'
-			ORDER BY created_at ASC`,
+			ORDER BY created_at ASC, id ASC`,
 	)
 		.bind(userId)
-		.all<{ event_type: string; detail_json: string }>()
-	return (results ?? []).map((row) => ({
-		eventType: row.event_type,
+		.all<{ id: string; detail_json: string }>()
+	const rows = (results ?? []).map((row) => ({
+		id: row.id,
 		detail: JSON.parse(row.detail_json) as Record<string, unknown>,
 	}))
+	return {
+		detailed: rows.filter((row) => row.detail['aggregate'] !== true),
+		aggregate: rows.find((row) => row.detail['aggregate'] === true) ?? null,
+	}
 }
 
 async function readEmailReceivedRollup(userId: string) {
@@ -156,16 +161,17 @@ test('inbound email rejects plan users at the daily receive limit', async () => 
 		await listEmailMessages({ db: env.APP_DB, userId, limit: 10 }),
 	).toEqual([])
 	expect(await readDailyReceiveCounter(userId)).toBe(limit)
-	const rejections = await listRejectedDeliveryEvents(userId)
-	expect(rejections).toHaveLength(1)
+	const rejections = await readRejectionEvents(userId)
+	expect(rejections.detailed).toHaveLength(1)
 	// The plan-specific wording proves the stable-id reverse lookup resolved
 	// the account (the fallback message says "this deployment" instead).
-	expect(rejections[0]?.detail).toMatchObject({
+	expect(rejections.detailed[0]?.detail).toMatchObject({
 		phase: 'entitlement',
 		reason: expect.stringContaining(
 			`your "personal" plan allows at most ${limit} email receives per day`,
 		),
 	})
+	expect(rejections.aggregate?.detail).toMatchObject({ count: 1 })
 	expect(await readEmailReceivedRollup(userId)).toMatchObject({
 		event_count: 1,
 		error_count: 1,
@@ -192,8 +198,8 @@ test('inbound email rejects plan users at the stored message cap and still count
 	).toHaveLength(cap)
 	// The receive attempt is counted even when the storage cap rejects it.
 	expect(await readDailyReceiveCounter(userId)).toBe(1)
-	const rejections = await listRejectedDeliveryEvents(userId)
-	expect(rejections[0]?.detail).toMatchObject({
+	const rejections = await readRejectionEvents(userId)
+	expect(rejections.detailed[0]?.detail).toMatchObject({
 		phase: 'entitlement',
 		reason: expect.stringContaining(
 			`your "personal" plan allows at most ${cap} stored email messages`,
@@ -215,11 +221,83 @@ test('inbound email applies the NULL-plan fallback receive limit', async () => {
 	await handleInboundEmail(message, env)
 
 	expect(message.rejectedReason).toBe('Recipient mailbox is over quota.')
-	const rejections = await listRejectedDeliveryEvents(userId)
-	expect(rejections[0]?.detail).toMatchObject({
+	const rejections = await readRejectionEvents(userId)
+	expect(rejections.detailed[0]?.detail).toMatchObject({
 		reason: expect.stringContaining(
 			`this deployment allows at most ${fallbackLimit} email receives per day`,
 		),
+	})
+})
+
+test('inbound email rejects oversize messages without consuming the daily receive quota', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	await ensureUsageRollupsTestSchema(env.APP_DB)
+	const email = `oversize-${crypto.randomUUID()}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	const maxBytes = planLimits.personal.maxEmailMessageBytes
+	if (maxBytes === null) throw new Error('Expected a numeric size cap.')
+	await seedAccountWithPlan({ email, plan: 'personal' })
+	const { address } = await seedInboxWithAddress(userId)
+
+	const message = buildInboundMessage(address)
+	const oversizeBytes = maxBytes + 1
+	Object.defineProperty(message, 'rawSize', { value: oversizeBytes })
+	await handleInboundEmail(message, env)
+
+	expect(message.rejectedReason).toBe('Recipient mailbox is over quota.')
+	expect(
+		await listEmailMessages({ db: env.APP_DB, userId, limit: 10 }),
+	).toEqual([])
+	// Oversize mail is rejected before the daily counter is consumed.
+	expect(await readDailyReceiveCounter(userId)).toBe(0)
+	const rejections = await readRejectionEvents(userId)
+	expect(rejections.detailed[0]?.detail).toMatchObject({
+		phase: 'size',
+		reason: expect.stringContaining(
+			`your "personal" plan allows at most ${maxBytes} bytes per email message`,
+		),
+	})
+	// The usage event records the rejected size in bytes.
+	expect(await readEmailReceivedRollup(userId)).toMatchObject({
+		event_count: 1,
+		error_count: 1,
+		total_bytes: oversizeBytes,
+	})
+})
+
+test('inbound email stores at most five detailed rejection events per inbox per day', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	await ensureUsageRollupsTestSchema(env.APP_DB)
+	const email = `rejection-bound-${crypto.randomUUID()}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	const limit = planLimits.personal.maxEmailReceivesPerDay
+	if (limit === null) throw new Error('Expected a numeric personal limit.')
+	await seedAccountWithPlan({ email, plan: 'personal' })
+	const { address } = await seedInboxWithAddress(userId)
+	await setDailyReceiveCounter(userId, limit)
+
+	const attempts = maxDetailedEmailRejectionEventsPerDay + 3
+	for (let index = 0; index < attempts; index += 1) {
+		const message = buildInboundMessage(address)
+		await handleInboundEmail(message, env)
+		expect(message.rejectedReason).toBe('Recipient mailbox is over quota.')
+	}
+
+	const rejections = await readRejectionEvents(userId)
+	// Detailed rows are capped; the aggregate row counts every attempt.
+	expect(rejections.detailed).toHaveLength(
+		maxDetailedEmailRejectionEventsPerDay,
+	)
+	expect(rejections.aggregate?.detail).toMatchObject({
+		aggregate: true,
+		count: attempts,
+		last_phase: 'entitlement',
+		last_reason: expect.stringContaining('email receives per day'),
+	})
+	// Every attempt is still metered even after detailed events stop.
+	expect(await readEmailReceivedRollup(userId)).toMatchObject({
+		event_count: attempts,
+		error_count: attempts,
 	})
 })
 

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -131,6 +131,10 @@ export async function handleInboundEmail(
 			resource: 'email_receives_per_day',
 			fallbackLimit: nullPlanEmailFallbackLimits.email_receives_per_day,
 		})
+		// Check-then-insert: a concurrent burst can overshoot the stored cap
+		// by a few rows, which is the documented row-count-limit trade-off
+		// (see entitlements.md "Concurrency") — this is a denial-of-wallet
+		// backstop, not billing-grade accounting.
 		await assertWithinEntitlement({
 			db: env.APP_DB,
 			userId,

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -1,4 +1,3 @@
-import { isAccountEmailVerified } from '#app/email-verification.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import {
 	nullPlanEmailFallbackLimits,
@@ -97,45 +96,41 @@ export async function handleInboundEmail(
 		})
 	}
 
-	// Inbox rows only store the stable user id, so this uses the stable-id
-	// scan inside `isAccountEmailVerified` (same pattern as outbound send).
-	// Cost is O(users) hashing per inbound message; if user counts grow
-	// enough to matter, add an indexed stable-id column on `users` instead
-	// of weakening this fail-closed check.
-	const accountEmailVerified = await isAccountEmailVerified({
-		db: env.APP_DB,
-		stableUserId: userId,
-	})
-	if (!accountEmailVerified) {
+	// Inbound volume is attacker-controlled (anyone who learns an alias can
+	// send to it), so every fail-closed gate runs before any parsing work,
+	// cheapest rejection first: verified account, per-message size cap,
+	// per-day receive rate, and stored-message cap (entitlements with
+	// NULL-plan fallbacks). The routing layer has no caller context, so one
+	// stable-id reverse lookup resolves the account email, plan, and
+	// verified state for all of the gates (same fail-closed stable-id scan
+	// `isAccountEmailVerified` uses, with a per-isolate id→email cache).
+	const account = await findUserAccountByStableUserId(env.APP_DB, userId)
+
+	// Verified-account gate first: an unverified (or deleted) account can
+	// never receive mail, so the attempt must not consume any of the daily
+	// receive quota or trip the other counters. Rejection rows go through
+	// the bounded recorder because unverified-alias floods are the same
+	// attacker-controlled row-growth shape as over-quota floods.
+	if (!account?.emailVerified) {
 		const reason = 'Account email is not verified.'
 		message.setReject(reason)
-		await insertEmailDeliveryEvent({
+		await recordBoundedEmailRejectionEvent({
 			db: env.APP_DB,
 			userId,
 			inboxId: inbox.id,
-			eventType: 'rejected',
-			provider: 'cloudflare-email-routing',
-			detail: {
-				recipient,
-				reason,
-				phase: 'account-verification',
-			},
+			recipient,
+			reason,
+			phase: 'account-verification',
 		}).catch(() => undefined)
+		await recordReceiveUsage({ outcome: 'error' })
 		return
 	}
 
-	// Inbound volume is attacker-controlled (anyone who learns an alias can
-	// send to it), so storage is gated before any parsing work: a per-message
-	// size cap, a per-day receive rate, and a stored-message cap, all with
-	// NULL-plan fallbacks. The routing layer has no caller context, so the
-	// account email for the plan lookup is reverse-resolved from the stable
-	// user id.
-	const account = await findUserAccountByStableUserId(env.APP_DB, userId)
 	// The plan's per-message cap also becomes the parser's raw-MIME ceiling
 	// so the two size gates can never disagree; a null (unlimited) plan
 	// limit still keeps the parser's hard platform-bound default.
 	const maxMessageBytes = resolveEmailResourceLimit(
-		account?.plan ?? null,
+		account.plan,
 		'email_message_bytes',
 	)
 	try {
@@ -145,7 +140,7 @@ export async function handleInboundEmail(
 		await assertWithinEntitlement({
 			db: env.APP_DB,
 			userId,
-			email: account?.email,
+			email: account.email,
 			resource: 'email_message_bytes',
 			requested: 0,
 			getCurrent: async () => message.rawSize,
@@ -154,7 +149,7 @@ export async function handleInboundEmail(
 		await consumeDailyEntitlement({
 			db: env.APP_DB,
 			userId,
-			email: account?.email,
+			email: account.email,
 			resource: 'email_receives_per_day',
 			fallbackLimit: nullPlanEmailFallbackLimits.email_receives_per_day,
 		})
@@ -165,7 +160,7 @@ export async function handleInboundEmail(
 		await assertWithinEntitlement({
 			db: env.APP_DB,
 			userId,
-			email: account?.email,
+			email: account.email,
 			resource: 'stored_email_messages',
 			fallbackLimit: nullPlanEmailFallbackLimits.stored_email_messages,
 		})

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -1,6 +1,9 @@
 import { isAccountEmailVerified } from '#app/email-verification.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
-import { nullPlanEmailFallbackLimits } from '#worker/entitlements/plans.ts'
+import {
+	nullPlanEmailFallbackLimits,
+	resolveEmailResourceLimit,
+} from '#worker/entitlements/plans.ts'
 import {
 	assertWithinEntitlement,
 	consumeDailyEntitlement,
@@ -12,7 +15,10 @@ import {
 	normalizeEmailAddress,
 	normalizeSubject,
 } from './address.ts'
-import { parseForwardableEmailMessage } from './parser.ts'
+import {
+	maxInlineRawMimeBytes,
+	parseForwardableEmailMessage,
+} from './parser.ts'
 import {
 	createEmailThread,
 	findEmailThreadForInboundMessage,
@@ -21,6 +27,7 @@ import {
 	getEmailInboxAddressByReplyTokenHash,
 	insertEmailDeliveryEvent,
 	insertEmailMessageWithAttachments,
+	recordBoundedEmailRejectionEvent,
 	touchEmailThread,
 } from './repo.ts'
 import { dispatchInboundEmailSubscriptionEvents } from './package-subscriptions.ts'
@@ -118,12 +125,32 @@ export async function handleInboundEmail(
 	}
 
 	// Inbound volume is attacker-controlled (anyone who learns an alias can
-	// send to it), so storage is gated before any parsing work: a per-day
-	// receive rate and a stored-message cap, with NULL-plan fallbacks. The
-	// routing layer has no caller context, so the account email for the plan
-	// lookup is reverse-resolved from the stable user id.
+	// send to it), so storage is gated before any parsing work: a per-message
+	// size cap, a per-day receive rate, and a stored-message cap, all with
+	// NULL-plan fallbacks. The routing layer has no caller context, so the
+	// account email for the plan lookup is reverse-resolved from the stable
+	// user id.
+	const account = await findUserAccountByStableUserId(env.APP_DB, userId)
+	// The plan's per-message cap also becomes the parser's raw-MIME ceiling
+	// so the two size gates can never disagree; a null (unlimited) plan
+	// limit still keeps the parser's hard platform-bound default.
+	const maxMessageBytes = resolveEmailResourceLimit(
+		account?.plan ?? null,
+		'email_message_bytes',
+	)
 	try {
-		const account = await findUserAccountByStableUserId(env.APP_DB, userId)
+		// Size first: an oversize message is rejected without consuming any
+		// of the owner's daily receive quota (griefing resistance) and
+		// without touching the counters.
+		await assertWithinEntitlement({
+			db: env.APP_DB,
+			userId,
+			email: account?.email,
+			resource: 'email_message_bytes',
+			requested: 0,
+			getCurrent: async () => message.rawSize,
+			fallbackLimit: nullPlanEmailFallbackLimits.email_message_bytes,
+		})
 		await consumeDailyEntitlement({
 			db: env.APP_DB,
 			userId,
@@ -146,18 +173,19 @@ export async function handleInboundEmail(
 		if (!isEntitlementLimitError(error)) throw error
 		// The SMTP reject reason goes to the arbitrary sender; keep it
 		// generic and store the detailed entitlement message for the owner.
+		// Rejection rows are bounded per inbox per day because over-quota
+		// traffic is exactly the flood these limits exist to absorb.
 		message.setReject('Recipient mailbox is over quota.')
-		await insertEmailDeliveryEvent({
+		await recordBoundedEmailRejectionEvent({
 			db: env.APP_DB,
 			userId,
 			inboxId: inbox.id,
-			eventType: 'rejected',
-			provider: 'cloudflare-email-routing',
-			detail: {
-				recipient,
-				reason: error.message,
-				phase: 'entitlement',
-			},
+			recipient,
+			reason: error.message,
+			phase:
+				error.details.resource === 'email_message_bytes'
+					? 'size'
+					: 'entitlement',
 		}).catch(() => undefined)
 		await recordReceiveUsage({ outcome: 'error' })
 		return
@@ -165,10 +193,16 @@ export async function handleInboundEmail(
 
 	let parsed: Awaited<ReturnType<typeof parseForwardableEmailMessage>>
 	try {
-		parsed = await parseForwardableEmailMessage(message)
+		parsed = await parseForwardableEmailMessage(message, {
+			maxRawSize: maxMessageBytes ?? maxInlineRawMimeBytes,
+		})
 	} catch (error) {
 		const reason =
 			error instanceof Error ? error.message : 'Failed to parse inbound email.'
+		// Parse failures keep one event per attempt: unlike quota/size
+		// rejections they are bounded by the daily receive quota (the
+		// counter was already consumed above), and the per-attempt detail
+		// is useful for the owner to debug a misbehaving sender.
 		message.setReject(reason)
 		await insertEmailDeliveryEvent({
 			db: env.APP_DB,

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -1,4 +1,12 @@
 import { isAccountEmailVerified } from '#app/email-verification.ts'
+import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
+import { nullPlanEmailFallbackLimits } from '#worker/entitlements/plans.ts'
+import {
+	assertWithinEntitlement,
+	consumeDailyEntitlement,
+	findUserAccountByStableUserId,
+} from '#worker/entitlements/service.ts'
+import { recordUsage } from '#worker/usage/record-usage.ts'
 import {
 	findReplyTokenHash,
 	normalizeEmailAddress,
@@ -19,7 +27,10 @@ import { dispatchInboundEmailSubscriptionEvents } from './package-subscriptions.
 
 export async function handleInboundEmail(
 	message: ForwardableEmailMessage,
-	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'APP_BASE_URL'>,
+	env: Pick<
+		Env,
+		'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'APP_BASE_URL' | 'USAGE_EVENTS'
+	>,
 	_ctx?: ExecutionContext,
 ) {
 	const recipient = normalizeEmailAddress(message.to)
@@ -64,6 +75,21 @@ export async function handleInboundEmail(
 	}
 
 	const userId = inboxAddress.userId
+	const receiveStartedAtMs = Date.now()
+	const recordReceiveUsage = async (input: {
+		entityId?: string | null
+		outcome: 'success' | 'error'
+	}) => {
+		await recordUsage(env, {
+			userId,
+			eventType: 'email_received',
+			entityId: input.entityId ?? null,
+			bytes: message.rawSize,
+			durationMs: Date.now() - receiveStartedAtMs,
+			outcome: input.outcome,
+		})
+	}
+
 	// Inbox rows only store the stable user id, so this uses the stable-id
 	// scan inside `isAccountEmailVerified` (same pattern as outbound send).
 	// Cost is O(users) hashing per inbound message; if user counts grow
@@ -91,6 +117,48 @@ export async function handleInboundEmail(
 		return
 	}
 
+	// Inbound volume is attacker-controlled (anyone who learns an alias can
+	// send to it), so storage is gated before any parsing work: a per-day
+	// receive rate and a stored-message cap, with NULL-plan fallbacks. The
+	// routing layer has no caller context, so the account email for the plan
+	// lookup is reverse-resolved from the stable user id.
+	try {
+		const account = await findUserAccountByStableUserId(env.APP_DB, userId)
+		await consumeDailyEntitlement({
+			db: env.APP_DB,
+			userId,
+			email: account?.email,
+			resource: 'email_receives_per_day',
+			fallbackLimit: nullPlanEmailFallbackLimits.email_receives_per_day,
+		})
+		await assertWithinEntitlement({
+			db: env.APP_DB,
+			userId,
+			email: account?.email,
+			resource: 'stored_email_messages',
+			fallbackLimit: nullPlanEmailFallbackLimits.stored_email_messages,
+		})
+	} catch (error) {
+		if (!isEntitlementLimitError(error)) throw error
+		// The SMTP reject reason goes to the arbitrary sender; keep it
+		// generic and store the detailed entitlement message for the owner.
+		message.setReject('Recipient mailbox is over quota.')
+		await insertEmailDeliveryEvent({
+			db: env.APP_DB,
+			userId,
+			inboxId: inbox.id,
+			eventType: 'rejected',
+			provider: 'cloudflare-email-routing',
+			detail: {
+				recipient,
+				reason: error.message,
+				phase: 'entitlement',
+			},
+		}).catch(() => undefined)
+		await recordReceiveUsage({ outcome: 'error' })
+		return
+	}
+
 	let parsed: Awaited<ReturnType<typeof parseForwardableEmailMessage>>
 	try {
 		parsed = await parseForwardableEmailMessage(message)
@@ -110,6 +178,7 @@ export async function handleInboundEmail(
 				phase: 'parse',
 			},
 		}).catch(() => undefined)
+		await recordReceiveUsage({ outcome: 'error' })
 		return
 	}
 	const now = new Date().toISOString()
@@ -189,6 +258,7 @@ export async function handleInboundEmail(
 			from_address: parsed.headerFrom,
 		},
 	})
+	await recordReceiveUsage({ entityId: stored.id, outcome: 'success' })
 	const dispatchPromise = dispatchInboundEmailSubscriptionEvents({
 		env,
 		userId,

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -219,25 +219,47 @@ test('inbound email handler rejects unknown aliases and malformed messages witho
 		localPart: getEmailLocalPart(address),
 		domain: getEmailDomain(address),
 	})
-	const malformedMessage = createForwardableEmailMessage({
+	// Oversize mail now trips the pre-parse email_message_bytes gate (the
+	// NULL-plan fallback is 512 KiB) with the generic over-quota reason.
+	const oversizeMessage = createForwardableEmailMessage({
 		from: 'sender@example.net',
 		to: address,
 		raw: 'Subject: Too large\r\n\r\nBody',
 	})
-	Object.defineProperty(malformedMessage, 'rawSize', {
+	Object.defineProperty(oversizeMessage, 'rawSize', {
 		value: 600 * 1024,
 	})
 
-	await handleInboundEmail(malformedMessage, env)
+	await handleInboundEmail(oversizeMessage, env)
 
-	expect(malformedMessage.rejectedReason).toMatch(/too large/)
-	const malformedMessages = await listEmailMessages({
+	expect(oversizeMessage.rejectedReason).toBe(
+		'Recipient mailbox is over quota.',
+	)
+
+	// A raw stream that fails mid-read exercises the parse-failure path.
+	const unreadableMessage = createForwardableEmailMessage({
+		from: 'sender@example.net',
+		to: address,
+		raw: 'Subject: Unreadable\r\n\r\nBody',
+	})
+	Object.defineProperty(unreadableMessage, 'raw', {
+		value: new ReadableStream({
+			pull() {
+				throw new Error('raw stream read failed')
+			},
+		}),
+	})
+
+	await handleInboundEmail(unreadableMessage, env)
+
+	expect(unreadableMessage.rejectedReason).toMatch(/raw stream read failed/)
+	const rejectedMessages = await listEmailMessages({
 		db: env.APP_DB,
 		userId,
 		inboxId: inbox.id,
 		limit: 10,
 	})
-	expect(malformedMessages).toEqual([])
+	expect(rejectedMessages).toEqual([])
 })
 
 test('inbound email handler rejects mail for unverified accounts', async () => {

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -1,5 +1,5 @@
 import { env } from 'cloudflare:workers'
-import { expect, test, vi } from 'vitest'
+import { expect, test } from 'vitest'
 import {
 	getEmailDomain,
 	getEmailLocalPart,
@@ -16,6 +16,7 @@ import {
 	listEmailAttachmentsForMessage,
 	upsertEmailSenderIdentity,
 } from './repo.ts'
+import { createForwardableEmailMessage } from './test-fixtures.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
 import { buildPublishedSourceManifestSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
@@ -65,38 +66,6 @@ async function seedVerifiedAccount(input: {
 	username: string
 }) {
 	await seedAccount(input)
-}
-
-function createForwardableEmailMessage(input: {
-	from: string
-	to: string
-	raw: string
-}): ForwardableEmailMessage & { rejectedReason: string | null } {
-	const encoded = new TextEncoder().encode(input.raw)
-	const headers = new Headers()
-	for (const line of input.raw.split(/\r?\n/)) {
-		if (!line.trim()) break
-		const separator = line.indexOf(':')
-		if (separator <= 0) continue
-		headers.append(line.slice(0, separator), line.slice(separator + 1).trim())
-	}
-	return {
-		from: input.from,
-		to: input.to,
-		headers,
-		raw: new Blob([encoded]).stream(),
-		rawSize: encoded.byteLength,
-		rejectedReason: null,
-		setReject(reason: string) {
-			this.rejectedReason = reason
-		},
-		async forward() {
-			return { messageId: 'unused-forward' }
-		},
-		async reply() {
-			return { messageId: 'unused-reply' }
-		},
-	}
 }
 
 test('inbound email handler stores all routed inbound messages', async () => {

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -312,16 +312,30 @@ test('inbound email handler rejects mail for unverified accounts', async () => {
 		limit: 10,
 	})
 	expect(messages).toEqual([])
+	// Unverified-account rejections go through the bounded recorder: one
+	// detailed event plus the daily aggregate row.
 	const events = await env.APP_DB.prepare(
 		`SELECT event_type, detail_json FROM email_delivery_events WHERE user_id = ?`,
 	)
 		.bind(userId)
 		.all<{ event_type: string; detail_json: string }>()
-	expect(events.results).toHaveLength(1)
-	expect(events.results?.[0]?.event_type).toBe('rejected')
-	expect(JSON.parse(events.results?.[0]?.detail_json ?? '{}')).toMatchObject({
+	const details = (events.results ?? []).map((row) => ({
+		eventType: row.event_type,
+		detail: JSON.parse(row.detail_json) as Record<string, unknown>,
+	}))
+	expect(details).toHaveLength(2)
+	expect(details.every((row) => row.eventType === 'rejected')).toBe(true)
+	expect(
+		details.find((row) => row.detail['aggregate'] !== true)?.detail,
+	).toMatchObject({
 		reason: 'Account email is not verified.',
 		phase: 'account-verification',
+	})
+	expect(
+		details.find((row) => row.detail['aggregate'] === true)?.detail,
+	).toMatchObject({
+		count: 1,
+		last_phase: 'account-verification',
 	})
 })
 

--- a/packages/worker/src/email/repo-search.workers.test.ts
+++ b/packages/worker/src/email/repo-search.workers.test.ts
@@ -1,0 +1,182 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import { searchEmailMessages } from './repo.ts'
+import { ensureEmailTestSchema } from './test-schema.ts'
+
+let messageSequence = 0
+
+async function insertMessage(input: {
+	userId: string
+	subject: string
+	fromAddress: string
+	envelopeFrom?: string | null
+	direction?: 'inbound' | 'outbound'
+	inboxId?: string | null
+}) {
+	messageSequence += 1
+	const id = `search-message-${crypto.randomUUID()}`
+	// Spread created_at values so ordering assertions are deterministic.
+	const createdAt = new Date(
+		Date.parse('2026-07-01T00:00:00.000Z') + messageSequence * 1000,
+	).toISOString()
+	await env.APP_DB.prepare(
+		`INSERT INTO email_messages (
+			id, direction, user_id, inbox_id, from_address, envelope_from,
+			subject, processing_status, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, 'stored', ?, ?)`,
+	)
+		.bind(
+			id,
+			input.direction ?? 'inbound',
+			input.userId,
+			input.inboxId ?? null,
+			input.fromAddress,
+			input.envelopeFrom ?? null,
+			input.subject,
+			createdAt,
+			createdAt,
+		)
+		.run()
+	return id
+}
+
+test('searchEmailMessages matches subject, from address, and envelope sender case-insensitively', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const userId = `search-user-${crypto.randomUUID()}`
+	const otherUserId = `search-other-${crypto.randomUUID()}`
+	const bySubject = await insertMessage({
+		userId,
+		subject: 'Invoice #123 due Friday',
+		fromAddress: 'billing@acme.example',
+	})
+	const byFrom = await insertMessage({
+		userId,
+		subject: 'Weekly digest',
+		fromAddress: 'no-reply@invoices.example',
+	})
+	const byEnvelope = await insertMessage({
+		userId,
+		subject: 'Hello',
+		fromAddress: 'friend@example.net',
+		envelopeFrom: 'bounce+invoice@mailer.example',
+	})
+	await insertMessage({
+		userId,
+		subject: 'Unrelated',
+		fromAddress: 'someone@example.net',
+	})
+	await insertMessage({
+		userId: otherUserId,
+		subject: 'Invoice for the other user',
+		fromAddress: 'billing@acme.example',
+	})
+
+	const results = await searchEmailMessages({
+		db: env.APP_DB,
+		userId,
+		query: 'INVOICE',
+		limit: 25,
+	})
+
+	// Newest first, and never another user's mail.
+	expect(results.map((message) => message.id)).toEqual([
+		byEnvelope,
+		byFrom,
+		bySubject,
+	])
+})
+
+test('searchEmailMessages treats LIKE wildcards in the query literally', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const userId = `search-escape-user-${crypto.randomUUID()}`
+	const literalPercent = await insertMessage({
+		userId,
+		subject: 'Save 100% today',
+		fromAddress: 'deals@example.net',
+	})
+	await insertMessage({
+		userId,
+		subject: 'Save 100 dollars today',
+		fromAddress: 'deals@example.net',
+	})
+	const literalUnderscore = await insertMessage({
+		userId,
+		subject: 'snake_case release notes',
+		fromAddress: 'dev@example.net',
+	})
+	await insertMessage({
+		userId,
+		subject: 'snakeXcase release notes',
+		fromAddress: 'dev@example.net',
+	})
+
+	const percentResults = await searchEmailMessages({
+		db: env.APP_DB,
+		userId,
+		query: '100%',
+		limit: 25,
+	})
+	expect(percentResults.map((message) => message.id)).toEqual([literalPercent])
+
+	const underscoreResults = await searchEmailMessages({
+		db: env.APP_DB,
+		userId,
+		query: 'snake_case',
+		limit: 25,
+	})
+	expect(underscoreResults.map((message) => message.id)).toEqual([
+		literalUnderscore,
+	])
+})
+
+test('searchEmailMessages applies filters and the result limit', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const userId = `search-filter-user-${crypto.randomUUID()}`
+	const inboxId = `inbox-${crypto.randomUUID()}`
+	const inboundInInbox = await insertMessage({
+		userId,
+		subject: 'Filtered report',
+		fromAddress: 'reports@example.net',
+		inboxId,
+	})
+	const outbound = await insertMessage({
+		userId,
+		subject: 'Filtered report reply',
+		fromAddress: 'me@example.net',
+		direction: 'outbound',
+	})
+	const inboundElsewhere = await insertMessage({
+		userId,
+		subject: 'Filtered report elsewhere',
+		fromAddress: 'reports@example.net',
+	})
+
+	const outboundOnly = await searchEmailMessages({
+		db: env.APP_DB,
+		userId,
+		query: 'filtered report',
+		direction: 'outbound',
+		limit: 25,
+	})
+	expect(outboundOnly.map((message) => message.id)).toEqual([outbound])
+
+	const inboxOnly = await searchEmailMessages({
+		db: env.APP_DB,
+		userId,
+		query: 'filtered report',
+		inboxId,
+		limit: 25,
+	})
+	expect(inboxOnly.map((message) => message.id)).toEqual([inboundInInbox])
+
+	const limited = await searchEmailMessages({
+		db: env.APP_DB,
+		userId,
+		query: 'filtered report',
+		limit: 2,
+	})
+	expect(limited.map((message) => message.id)).toEqual([
+		inboundElsewhere,
+		outbound,
+	])
+})

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -809,6 +809,59 @@ export async function listEmailMessages(input: {
 	return (result.results ?? []).map(mapMessageRow)
 }
 
+/** Escape LIKE wildcards so user queries match literally. */
+function escapeLikePattern(value: string) {
+	return value.replaceAll(/[\\%_]/g, (character) => `\\${character}`)
+}
+
+/**
+ * Case-insensitive substring search over stored messages' subject, header
+ * From, and envelope sender. Same filters, ordering, and limit contract as
+ * `listEmailMessages`; always scoped to one user.
+ */
+export async function searchEmailMessages(input: {
+	db: D1Database
+	userId: string
+	query: string
+	inboxId?: string | null
+	direction?: EmailDirection | null
+	processingStatus?: EmailProcessingStatus | null
+	limit: number
+}) {
+	const pattern = `%${escapeLikePattern(input.query.trim().toLowerCase())}%`
+	const result = await input.db
+		.prepare(
+			`SELECT *
+			FROM email_messages
+			WHERE user_id = ?
+				AND (? IS NULL OR inbox_id = ?)
+				AND (? IS NULL OR direction = ?)
+				AND (? IS NULL OR processing_status = ?)
+				AND (
+					LOWER(subject) LIKE ? ESCAPE '\\'
+					OR LOWER(from_address) LIKE ? ESCAPE '\\'
+					OR LOWER(COALESCE(envelope_from, '')) LIKE ? ESCAPE '\\'
+				)
+			ORDER BY created_at DESC, id DESC
+			LIMIT ?`,
+		)
+		.bind(
+			input.userId,
+			input.inboxId ?? null,
+			input.inboxId ?? null,
+			input.direction ?? null,
+			input.direction ?? null,
+			input.processingStatus ?? null,
+			input.processingStatus ?? null,
+			pattern,
+			pattern,
+			pattern,
+			input.limit,
+		)
+		.all<Record<string, unknown>>()
+	return (result.results ?? []).map(mapMessageRow)
+}
+
 export async function deleteEmailMessageById(input: {
 	db: D1Database
 	messageId: string

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -818,6 +818,10 @@ function escapeLikePattern(value: string) {
  * Case-insensitive substring search over stored messages' subject, header
  * From, and envelope sender. Same filters, ordering, and limit contract as
  * `listEmailMessages`; always scoped to one user.
+ *
+ * The leading-wildcard LIKE is a per-user linear scan (bounded by the
+ * stored_email_messages entitlement cap). Revisit with FTS5 or a search
+ * index if mailboxes outgrow that.
  */
 export async function searchEmailMessages(input: {
 	db: D1Database

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -1017,18 +1017,20 @@ export async function getEmailAttachmentById(input: {
 }
 
 /**
- * How many quota/size rejections per inbox per UTC day get their own
- * delivery-event row before collapsing into the daily aggregate row.
+ * How many quota/size/verification rejections per inbox per UTC day get
+ * their own delivery-event row before collapsing into the daily aggregate
+ * row.
  */
 export const maxDetailedEmailRejectionEventsPerDay = 5
 
 /**
- * Record an entitlement/size rejection without unbounded row growth. Every
- * rejection upserts one aggregate 'rejected' event per inbox per UTC day
- * (deterministic id, counter in detail_json), and only the first
- * `maxDetailedEmailRejectionEventsPerDay` attempts of the day also store an
- * individual detailed event. Over-quota traffic is attacker-controlled and
- * unmetered by the daily receive counter (which is already exhausted), so
+ * Record an entitlement/size/verification rejection without unbounded row
+ * growth. Every rejection upserts one aggregate 'rejected' event per inbox
+ * per UTC day (deterministic id, counter in detail_json), and only the
+ * first `maxDetailedEmailRejectionEventsPerDay` attempts of the day also
+ * store an individual detailed event. This traffic is attacker-controlled
+ * and not limited by the daily receive counter (over-quota mail has
+ * already exhausted it; unverified-account mail never consumes it), so
  * without this cap a flood of rejected mail would grow D1 one row per
  * attempt — the denial-of-wallet shape the quotas exist to prevent.
  */
@@ -1038,7 +1040,7 @@ export async function recordBoundedEmailRejectionEvent(input: {
 	inboxId: string
 	recipient: string
 	reason: string
-	phase: 'entitlement' | 'size'
+	phase: 'entitlement' | 'size' | 'account-verification'
 	now?: Date
 }) {
 	const now = input.now ?? new Date()

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -1016,6 +1016,82 @@ export async function getEmailAttachmentById(input: {
 	}
 }
 
+/**
+ * How many quota/size rejections per inbox per UTC day get their own
+ * delivery-event row before collapsing into the daily aggregate row.
+ */
+export const maxDetailedEmailRejectionEventsPerDay = 5
+
+/**
+ * Record an entitlement/size rejection without unbounded row growth. Every
+ * rejection upserts one aggregate 'rejected' event per inbox per UTC day
+ * (deterministic id, counter in detail_json), and only the first
+ * `maxDetailedEmailRejectionEventsPerDay` attempts of the day also store an
+ * individual detailed event. Over-quota traffic is attacker-controlled and
+ * unmetered by the daily receive counter (which is already exhausted), so
+ * without this cap a flood of rejected mail would grow D1 one row per
+ * attempt — the denial-of-wallet shape the quotas exist to prevent.
+ */
+export async function recordBoundedEmailRejectionEvent(input: {
+	db: D1Database
+	userId: string
+	inboxId: string
+	recipient: string
+	reason: string
+	phase: 'entitlement' | 'size'
+	now?: Date
+}) {
+	const now = input.now ?? new Date()
+	const nowIsoString = now.toISOString()
+	const day = nowIsoString.slice(0, 'YYYY-MM-DD'.length)
+	const aggregateDetail = JSON.stringify({
+		aggregate: true,
+		day,
+		count: 1,
+		last_reason: input.reason,
+		last_phase: input.phase,
+		last_at: nowIsoString,
+	})
+	const row = await input.db
+		.prepare(
+			`INSERT INTO email_delivery_events (
+				id, user_id, inbox_id, event_type, provider, detail_json, created_at
+			) VALUES (?, ?, ?, 'rejected', 'cloudflare-email-routing', ?, ?)
+			ON CONFLICT(id) DO UPDATE SET detail_json = json_set(
+				email_delivery_events.detail_json,
+				'$.count', COALESCE(json_extract(email_delivery_events.detail_json, '$.count'), 0) + 1,
+				'$.last_reason', json_extract(excluded.detail_json, '$.last_reason'),
+				'$.last_phase', json_extract(excluded.detail_json, '$.last_phase'),
+				'$.last_at', json_extract(excluded.detail_json, '$.last_at')
+			)
+			RETURNING json_extract(detail_json, '$.count') AS count`,
+		)
+		.bind(
+			`email-rejections:${input.inboxId}:${day}`,
+			input.userId,
+			input.inboxId,
+			aggregateDetail,
+			nowIsoString,
+		)
+		.first<{ count: number }>()
+	const rejectionsToday = Number(row?.count ?? 1)
+	if (rejectionsToday <= maxDetailedEmailRejectionEventsPerDay) {
+		await insertEmailDeliveryEvent({
+			db: input.db,
+			userId: input.userId,
+			inboxId: input.inboxId,
+			eventType: 'rejected',
+			provider: 'cloudflare-email-routing',
+			detail: {
+				recipient: input.recipient,
+				reason: input.reason,
+				phase: input.phase,
+			},
+		})
+	}
+	return rejectionsToday
+}
+
 export async function insertEmailDeliveryEvent(input: {
 	db: D1Database
 	messageId?: string | null

--- a/packages/worker/src/email/test-fixtures.ts
+++ b/packages/worker/src/email/test-fixtures.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared fixtures for email test suites.
+ */
+
+export type TestForwardableEmailMessage = ForwardableEmailMessage & {
+	rejectedReason: string | null
+}
+
+export function createForwardableEmailMessage(input: {
+	from: string
+	to: string
+	raw: string
+}): TestForwardableEmailMessage {
+	const encoded = new TextEncoder().encode(input.raw)
+	const headers = new Headers()
+	for (const line of input.raw.split(/\r?\n/)) {
+		if (!line.trim()) break
+		const separator = line.indexOf(':')
+		if (separator <= 0) continue
+		headers.append(line.slice(0, separator), line.slice(separator + 1).trim())
+	}
+	return {
+		from: input.from,
+		to: input.to,
+		headers,
+		raw: new Blob([encoded]).stream(),
+		rawSize: encoded.byteLength,
+		rejectedReason: null,
+		setReject(reason: string) {
+			this.rejectedReason = reason
+		},
+		async forward() {
+			return { messageId: 'unused-forward' }
+		},
+		async reply() {
+			return { messageId: 'unused-reply' }
+		},
+	}
+}

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -470,12 +470,55 @@ test('resolveEmailResourceLimit prefers plan limits and falls back for plan-less
 	expect(resolveEmailResourceLimit(null, 'stored_email_messages')).toBe(
 		nullPlanEmailFallbackLimits.stored_email_messages,
 	)
+	expect(resolveEmailResourceLimit(null, 'email_message_bytes')).toBe(
+		nullPlanEmailFallbackLimits.email_message_bytes,
+	)
 	expect(resolvePlanLimit('partner', 'email_receives_per_day')).toBe(
 		planLimits.partner.maxEmailReceivesPerDay,
 	)
 	expect(resolvePlanLimit('partner', 'stored_email_messages')).toBe(
 		planLimits.partner.maxStoredEmailMessages,
 	)
+	expect(resolvePlanLimit('pro', 'email_message_bytes')).toBe(
+		planLimits.pro.maxEmailMessageBytes,
+	)
+})
+
+test('email_message_bytes enforces the per-message size via getCurrent', async () => {
+	const userId = await createStableUserIdFromEmail(plannedEmail)
+	const { db } = createEntitlementsTestDb({
+		users: [{ email: plannedEmail, plan: 'personal' }],
+	})
+	const maxBytes = planLimits.personal.maxEmailMessageBytes
+	if (maxBytes === null) throw new Error('Expected a numeric size cap.')
+	await expect(
+		assertWithinEntitlement({
+			db,
+			userId,
+			email: plannedEmail,
+			resource: 'email_message_bytes',
+			requested: 0,
+			getCurrent: async () => maxBytes + 1,
+		}),
+	).rejects.toThrow(`at most ${maxBytes} bytes per email message`)
+	// A message exactly at the cap passes.
+	await assertWithinEntitlement({
+		db,
+		userId,
+		email: plannedEmail,
+		resource: 'email_message_bytes',
+		requested: 0,
+		getCurrent: async () => maxBytes,
+	})
+	// The per-message resource has no accumulating counter.
+	await expect(
+		assertWithinEntitlement({
+			db,
+			userId,
+			email: plannedEmail,
+			resource: 'email_message_bytes',
+		}),
+	).rejects.toThrow('pass getCurrent')
 })
 
 test('requested units and getCurrent overrides are honored', async () => {

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -5,7 +5,13 @@ import {
 	buildEntitlementLimitMessage,
 	isEntitlementLimitError,
 } from './errors.ts'
-import { parsePlanName, planLimits, resolvePlanLimit } from './plans.ts'
+import {
+	nullPlanEmailFallbackLimits,
+	parsePlanName,
+	planLimits,
+	resolveEmailResourceLimit,
+	resolvePlanLimit,
+} from './plans.ts'
 import {
 	assertWithinEntitlement,
 	consumeDailyEntitlement,
@@ -405,6 +411,71 @@ test('consumeDailyEntitlement counts attempts without capping plan-less users', 
 		})
 	}
 	expect(counters[0]?.count).toBe(limit + 1)
+})
+
+test('consumeDailyEntitlement caps plan-less users when a fallback limit is provided', async () => {
+	const { db, counters } = createEntitlementsTestDb()
+	const fallbackLimit = nullPlanEmailFallbackLimits.email_receives_per_day
+	const now = new Date('2026-07-05T15:00:00.000Z')
+	for (let index = 0; index < fallbackLimit; index += 1) {
+		await consumeDailyEntitlement({
+			db,
+			userId: 'user-1',
+			email: null,
+			resource: 'email_receives_per_day',
+			fallbackLimit,
+			now,
+		})
+	}
+	expect(counters[0]?.count).toBe(fallbackLimit)
+
+	const error = await consumeDailyEntitlement({
+		db,
+		userId: 'user-1',
+		email: null,
+		resource: 'email_receives_per_day',
+		fallbackLimit,
+		now,
+	}).then(
+		() => null,
+		(thrown: unknown) => thrown,
+	)
+	if (!(error instanceof EntitlementLimitError)) {
+		throw new Error('Expected an EntitlementLimitError.')
+	}
+	// plan is null because the limit came from the fallback, not a plan.
+	expect(error.details).toMatchObject({
+		code: 'entitlement_limit_exceeded',
+		resource: 'email_receives_per_day',
+		plan: null,
+		limit: fallbackLimit,
+		current: fallbackLimit,
+	})
+	expect(error.message).toContain(
+		`this deployment allows at most ${fallbackLimit} email receives per day`,
+	)
+	expect(counters[0]?.count).toBe(fallbackLimit)
+})
+
+test('resolveEmailResourceLimit prefers plan limits and falls back for plan-less users', () => {
+	expect(resolveEmailResourceLimit('personal', 'email_receives_per_day')).toBe(
+		planLimits.personal.maxEmailReceivesPerDay,
+	)
+	expect(resolveEmailResourceLimit('pro', 'stored_email_messages')).toBe(
+		planLimits.pro.maxStoredEmailMessages,
+	)
+	expect(resolveEmailResourceLimit(null, 'email_receives_per_day')).toBe(
+		nullPlanEmailFallbackLimits.email_receives_per_day,
+	)
+	expect(resolveEmailResourceLimit(null, 'stored_email_messages')).toBe(
+		nullPlanEmailFallbackLimits.stored_email_messages,
+	)
+	expect(resolvePlanLimit('partner', 'email_receives_per_day')).toBe(
+		planLimits.partner.maxEmailReceivesPerDay,
+	)
+	expect(resolvePlanLimit('partner', 'stored_email_messages')).toBe(
+		planLimits.partner.maxStoredEmailMessages,
+	)
 })
 
 test('requested units and getCurrent overrides are honored', async () => {

--- a/packages/worker/src/entitlements/plans.ts
+++ b/packages/worker/src/entitlements/plans.ts
@@ -31,6 +31,10 @@ export type PlanLimits = {
 	maxRepoSessions: number | null
 	/** Maximum outbound email send attempts per UTC day. */
 	maxEmailSendsPerDay: number | null
+	/** Maximum stored inbound email receipts per UTC day. */
+	maxEmailReceivesPerDay: number | null
+	/** Maximum stored email messages (rows in email_messages). */
+	maxStoredEmailMessages: number | null
 	/** Maximum stored secret entries across non-expired buckets. */
 	maxSecrets: number | null
 	/** Maximum durable storage bytes. Defined but not yet enforced. */
@@ -52,6 +56,8 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		packageServicePersistentAllowed: false,
 		maxRepoSessions: 5,
 		maxEmailSendsPerDay: 20,
+		maxEmailReceivesPerDay: 200,
+		maxStoredEmailMessages: 2000,
 		maxSecrets: 20,
 		maxStorageBytes: 256 * 1024 * 1024,
 		maxConcurrentWorkflows: 10,
@@ -63,6 +69,8 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		packageServicePersistentAllowed: true,
 		maxRepoSessions: 20,
 		maxEmailSendsPerDay: 200,
+		maxEmailReceivesPerDay: 1000,
+		maxStoredEmailMessages: 10_000,
 		maxSecrets: 100,
 		maxStorageBytes: 1024 * 1024 * 1024,
 		maxConcurrentWorkflows: 50,
@@ -74,6 +82,8 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		packageServicePersistentAllowed: true,
 		maxRepoSessions: 40,
 		maxEmailSendsPerDay: 500,
+		maxEmailReceivesPerDay: 2000,
+		maxStoredEmailMessages: 25_000,
 		maxSecrets: 200,
 		maxStorageBytes: 5 * 1024 * 1024 * 1024,
 		maxConcurrentWorkflows: 100,
@@ -87,6 +97,8 @@ export const entitlementResources = [
 	'persistent_package_services',
 	'repo_sessions',
 	'email_sends_per_day',
+	'email_receives_per_day',
+	'stored_email_messages',
 	'secrets',
 	'storage_bytes',
 	'concurrent_workflows',
@@ -102,9 +114,39 @@ export const entitlementResourceLabels: Record<EntitlementResource, string> = {
 	persistent_package_services: 'persistent package services',
 	repo_sessions: 'active repo sessions',
 	email_sends_per_day: 'email sends per day',
+	email_receives_per_day: 'email receives per day',
+	stored_email_messages: 'stored email messages',
 	secrets: 'secrets',
 	storage_bytes: 'storage bytes',
 	concurrent_workflows: 'concurrent workflows',
+}
+
+/**
+ * Fallback limits for users without a plan on the inbound email resources.
+ *
+ * Inbound mail is attacker-controlled volume (anyone who learns an alias can
+ * send to it), so unlike other resources the NULL-plan invariant does not
+ * mean unlimited here: plan-less users get these deployment-level backstops
+ * instead. The numbers match the `personal` plan.
+ */
+export const nullPlanEmailFallbackLimits = {
+	email_receives_per_day: 200,
+	stored_email_messages: 2000,
+} as const satisfies Partial<Record<EntitlementResource, number>>
+
+export type EmailFallbackResource = keyof typeof nullPlanEmailFallbackLimits
+
+/**
+ * Resolve the effective limit for an inbound email resource: the plan limit
+ * when the user has a plan, otherwise the NULL-plan fallback backstop.
+ */
+export function resolveEmailResourceLimit(
+	plan: PlanName | null,
+	resource: EmailFallbackResource,
+): number | null {
+	return plan
+		? resolvePlanLimit(plan, resource)
+		: nullPlanEmailFallbackLimits[resource]
 }
 
 /**
@@ -130,6 +172,10 @@ export function resolvePlanLimit(
 			return limits.maxRepoSessions
 		case 'email_sends_per_day':
 			return limits.maxEmailSendsPerDay
+		case 'email_receives_per_day':
+			return limits.maxEmailReceivesPerDay
+		case 'stored_email_messages':
+			return limits.maxStoredEmailMessages
 		case 'secrets':
 			return limits.maxSecrets
 		case 'storage_bytes':

--- a/packages/worker/src/entitlements/plans.ts
+++ b/packages/worker/src/entitlements/plans.ts
@@ -136,6 +136,12 @@ export const nullPlanEmailFallbackLimits = {
 
 export type EmailFallbackResource = keyof typeof nullPlanEmailFallbackLimits
 
+export function isEmailFallbackResource(
+	resource: EntitlementResource,
+): resource is EmailFallbackResource {
+	return resource in nullPlanEmailFallbackLimits
+}
+
 /**
  * Resolve the effective limit for an inbound email resource: the plan limit
  * when the user has a plan, otherwise the NULL-plan fallback backstop.

--- a/packages/worker/src/entitlements/plans.ts
+++ b/packages/worker/src/entitlements/plans.ts
@@ -35,6 +35,13 @@ export type PlanLimits = {
 	maxEmailReceivesPerDay: number | null
 	/** Maximum stored email messages (rows in email_messages). */
 	maxStoredEmailMessages: number | null
+	/**
+	 * Maximum raw MIME bytes for a single stored email message. Hard
+	 * platform bound: raw MIME is stored inline in the email_messages row
+	 * next to the extracted bodies (worst case ~2x raw), and D1 caps rows
+	 * at 2 MB — so keep this well under ~1 MB regardless of plan.
+	 */
+	maxEmailMessageBytes: number | null
 	/** Maximum stored secret entries across non-expired buckets. */
 	maxSecrets: number | null
 	/** Maximum durable storage bytes. Defined but not yet enforced. */
@@ -58,6 +65,7 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxEmailSendsPerDay: 20,
 		maxEmailReceivesPerDay: 200,
 		maxStoredEmailMessages: 2000,
+		maxEmailMessageBytes: 512 * 1024,
 		maxSecrets: 20,
 		maxStorageBytes: 256 * 1024 * 1024,
 		maxConcurrentWorkflows: 10,
@@ -71,6 +79,7 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxEmailSendsPerDay: 200,
 		maxEmailReceivesPerDay: 1000,
 		maxStoredEmailMessages: 10_000,
+		maxEmailMessageBytes: 768 * 1024,
 		maxSecrets: 100,
 		maxStorageBytes: 1024 * 1024 * 1024,
 		maxConcurrentWorkflows: 50,
@@ -84,6 +93,7 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxEmailSendsPerDay: 500,
 		maxEmailReceivesPerDay: 2000,
 		maxStoredEmailMessages: 25_000,
+		maxEmailMessageBytes: 768 * 1024,
 		maxSecrets: 200,
 		maxStorageBytes: 5 * 1024 * 1024 * 1024,
 		maxConcurrentWorkflows: 100,
@@ -99,6 +109,7 @@ export const entitlementResources = [
 	'email_sends_per_day',
 	'email_receives_per_day',
 	'stored_email_messages',
+	'email_message_bytes',
 	'secrets',
 	'storage_bytes',
 	'concurrent_workflows',
@@ -116,6 +127,7 @@ export const entitlementResourceLabels: Record<EntitlementResource, string> = {
 	email_sends_per_day: 'email sends per day',
 	email_receives_per_day: 'email receives per day',
 	stored_email_messages: 'stored email messages',
+	email_message_bytes: 'bytes per email message',
 	secrets: 'secrets',
 	storage_bytes: 'storage bytes',
 	concurrent_workflows: 'concurrent workflows',
@@ -132,6 +144,7 @@ export const entitlementResourceLabels: Record<EntitlementResource, string> = {
 export const nullPlanEmailFallbackLimits = {
 	email_receives_per_day: 200,
 	stored_email_messages: 2000,
+	email_message_bytes: 512 * 1024,
 } as const satisfies Partial<Record<EntitlementResource, number>>
 
 export type EmailFallbackResource = keyof typeof nullPlanEmailFallbackLimits
@@ -182,6 +195,8 @@ export function resolvePlanLimit(
 			return limits.maxEmailReceivesPerDay
 		case 'stored_email_messages':
 			return limits.maxStoredEmailMessages
+		case 'email_message_bytes':
+			return limits.maxEmailMessageBytes
 		case 'secrets':
 			return limits.maxSecrets
 		case 'storage_bytes':

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -33,6 +33,31 @@ export async function getUserPlan(
 	return parsePlanName(row?.plan)
 }
 
+/**
+ * Reverse-resolve a stable MCP userId (SHA-256 of the normalized account
+ * email) back to the account email and plan. There is no stored mapping, so
+ * this scans the users table and hashes each email until one matches — the
+ * same pattern `isAccountEmailVerified` uses. Only call this on paths that
+ * genuinely have no caller context email (for example inbound email
+ * routing); interactive surfaces already carry the email.
+ */
+export async function findUserAccountByStableUserId(
+	db: D1Database,
+	stableUserId: string,
+): Promise<{ email: string; plan: PlanName | null } | null> {
+	const trimmed = stableUserId.trim()
+	if (!trimmed) return null
+	const rows = await db
+		.prepare(`SELECT email, plan FROM users`)
+		.all<{ email: string; plan: string | null }>()
+	for (const row of rows.results ?? []) {
+		if ((await createStableUserIdFromEmail(row.email)) === trimmed) {
+			return { email: row.email, plan: parsePlanName(row.plan) }
+		}
+	}
+	return null
+}
+
 export function utcDayKey(date: Date = new Date()) {
 	return date.toISOString().slice(0, 'YYYY-MM-DD'.length)
 }
@@ -178,12 +203,19 @@ export async function readEntitlementResourceUsage(input: {
 				[userId],
 			)
 		case 'email_sends_per_day':
+		case 'email_receives_per_day':
 			return await readDailyEntitlementCounter({
 				db,
 				userId,
 				resource,
 				now,
 			})
+		case 'stored_email_messages':
+			return await countRows(
+				db,
+				`SELECT COUNT(*) AS count FROM email_messages WHERE user_id = ?`,
+				[userId],
+			)
 		case 'secrets':
 			return await countRows(
 				db,
@@ -289,13 +321,19 @@ export async function assertWithinEntitlement(
  *
  * Users without a plan (or without a resolvable limit) consume without a
  * cap: the counter still accumulates so limits bind the moment a plan is
- * assigned.
+ * assigned. Pass `fallbackLimit` to cap plan-less users with a
+ * deployment-level backstop (for example inbound email receives).
  */
 export async function consumeDailyEntitlement(input: {
 	db: D1Database
 	userId: string
 	email: string | null | undefined
 	resource: EntitlementResource
+	/**
+	 * Limit that applies when the user has no plan. Default: no limit for
+	 * plan-less users (the counter still accumulates).
+	 */
+	fallbackLimit?: number | null
 	now?: Date
 }): Promise<void> {
 	const now = input.now ?? new Date()
@@ -303,7 +341,9 @@ export async function consumeDailyEntitlement(input: {
 		userId: input.userId,
 		email: input.email,
 	})
-	const limit = plan ? resolvePlanLimit(plan, input.resource) : null
+	const limit = plan
+		? resolvePlanLimit(plan, input.resource)
+		: (input.fallbackLimit ?? null)
 	if (limit == null) {
 		await incrementDailyEntitlementCounter({
 			db: input.db,

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -34,12 +34,21 @@ export async function getUserPlan(
 }
 
 /**
+ * Per-isolate cache of stable user id → account email. The mapping is a
+ * content hash (sha256 of the normalized email), so a positive entry can
+ * never go stale; only cache hits are trusted and deleted entries fall
+ * back to a fresh scan.
+ */
+const stableUserIdEmailCache = new Map<string, string>()
+
+/**
  * Reverse-resolve a stable MCP userId (SHA-256 of the normalized account
  * email) back to the account email and plan. There is no stored mapping, so
- * this scans the users table and hashes each email until one matches — the
- * same pattern `isAccountEmailVerified` uses. Only call this on paths that
- * genuinely have no caller context email (for example inbound email
- * routing); interactive surfaces already carry the email.
+ * the cold path scans the users table and hashes each email until one
+ * matches — the same pattern `isAccountEmailVerified` uses — and positive
+ * matches are cached per isolate so hot paths pay one point read. Only call
+ * this on paths that genuinely have no caller context email (for example
+ * inbound email routing); interactive surfaces already carry the email.
  */
 export async function findUserAccountByStableUserId(
 	db: D1Database,
@@ -47,11 +56,22 @@ export async function findUserAccountByStableUserId(
 ): Promise<{ email: string; plan: PlanName | null } | null> {
 	const trimmed = stableUserId.trim()
 	if (!trimmed) return null
+	const cachedEmail = stableUserIdEmailCache.get(trimmed)
+	if (cachedEmail) {
+		const row = await db
+			.prepare(`SELECT plan FROM users WHERE email = ?`)
+			.bind(cachedEmail)
+			.first<{ plan: string | null }>()
+		if (row) return { email: cachedEmail, plan: parsePlanName(row.plan) }
+		// The account is gone (deleted); drop the entry and rescan.
+		stableUserIdEmailCache.delete(trimmed)
+	}
 	const rows = await db
 		.prepare(`SELECT email, plan FROM users`)
 		.all<{ email: string; plan: string | null }>()
 	for (const row of rows.results ?? []) {
 		if ((await createStableUserIdFromEmail(row.email)) === trimmed) {
+			stableUserIdEmailCache.set(trimmed, row.email)
 			return { email: row.email, plan: parsePlanName(row.plan) }
 		}
 	}

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -258,6 +258,12 @@ export async function readEntitlementResourceUsage(input: {
 			throw new Error(
 				'storage_bytes has no built-in counter; pass getCurrent to assertWithinEntitlement.',
 			)
+		case 'email_message_bytes':
+			// Per-message limit, not an accumulating counter: enforcement
+			// passes the candidate message size via getCurrent.
+			throw new Error(
+				'email_message_bytes has no built-in counter; pass getCurrent to assertWithinEntitlement.',
+			)
 		default: {
 			const exhaustive: never = resource
 			throw new Error(`Unknown entitlement resource: ${String(exhaustive)}`)

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -41,38 +41,62 @@ export async function getUserPlan(
  */
 const stableUserIdEmailCache = new Map<string, string>()
 
+export type StableUserAccount = {
+	email: string
+	plan: PlanName | null
+	/** Whether users.email_verified_at is set. Read fresh, never cached. */
+	emailVerified: boolean
+}
+
 /**
  * Reverse-resolve a stable MCP userId (SHA-256 of the normalized account
- * email) back to the account email and plan. There is no stored mapping, so
- * the cold path scans the users table and hashes each email until one
- * matches — the same pattern `isAccountEmailVerified` uses — and positive
- * matches are cached per isolate so hot paths pay one point read. Only call
- * this on paths that genuinely have no caller context email (for example
- * inbound email routing); interactive surfaces already carry the email.
+ * email) back to the account email, plan, and verified-email state. There
+ * is no stored mapping, so the cold path scans the users table and hashes
+ * each email until one matches — the same pattern `isAccountEmailVerified`
+ * uses — and positive matches are cached per isolate so hot paths pay one
+ * point read. Plan and verified state are always read fresh; only the
+ * id→email mapping (a content hash that can never go stale) is cached.
+ * Only call this on paths that genuinely have no caller context email
+ * (for example inbound email routing); interactive surfaces already carry
+ * the email.
  */
 export async function findUserAccountByStableUserId(
 	db: D1Database,
 	stableUserId: string,
-): Promise<{ email: string; plan: PlanName | null } | null> {
+): Promise<StableUserAccount | null> {
 	const trimmed = stableUserId.trim()
 	if (!trimmed) return null
 	const cachedEmail = stableUserIdEmailCache.get(trimmed)
 	if (cachedEmail) {
 		const row = await db
-			.prepare(`SELECT plan FROM users WHERE email = ?`)
+			.prepare(`SELECT plan, email_verified_at FROM users WHERE email = ?`)
 			.bind(cachedEmail)
-			.first<{ plan: string | null }>()
-		if (row) return { email: cachedEmail, plan: parsePlanName(row.plan) }
+			.first<{ plan: string | null; email_verified_at: string | null }>()
+		if (row) {
+			return {
+				email: cachedEmail,
+				plan: parsePlanName(row.plan),
+				emailVerified: Boolean(row.email_verified_at),
+			}
+		}
 		// The account is gone (deleted); drop the entry and rescan.
 		stableUserIdEmailCache.delete(trimmed)
 	}
 	const rows = await db
-		.prepare(`SELECT email, plan FROM users`)
-		.all<{ email: string; plan: string | null }>()
+		.prepare(`SELECT email, plan, email_verified_at FROM users`)
+		.all<{
+			email: string
+			plan: string | null
+			email_verified_at: string | null
+		}>()
 	for (const row of rows.results ?? []) {
 		if ((await createStableUserIdFromEmail(row.email)) === trimmed) {
 			stableUserIdEmailCache.set(trimmed, row.email)
-			return { email: row.email, plan: parsePlanName(row.plan) }
+			return {
+				email: row.email,
+				plan: parsePlanName(row.plan),
+				emailVerified: Boolean(row.email_verified_at),
+			}
 		}
 	}
 	return null

--- a/packages/worker/src/mcp/capabilities/admin/admin-usage-overview.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-usage-overview.ts
@@ -15,6 +15,7 @@ const usageMetricSchema = z.enum([
 	'service_runtime',
 	'outbound_fetch',
 	'email_send',
+	'email_received',
 ])
 
 const entitlementResourceSchema = z.enum([
@@ -24,6 +25,8 @@ const entitlementResourceSchema = z.enum([
 	'persistent_package_services',
 	'repo_sessions',
 	'email_sends_per_day',
+	'email_receives_per_day',
+	'stored_email_messages',
 	'secrets',
 	'concurrent_workflows',
 	'storage_bytes',

--- a/packages/worker/src/mcp/capabilities/email/domain.ts
+++ b/packages/worker/src/mcp/capabilities/email/domain.ts
@@ -5,9 +5,11 @@ import { emailInboxListCapability } from './email-inbox-list.ts'
 import { emailAttachmentGetCapability } from './email-attachment-get.ts'
 import { emailMessageGetCapability } from './email-message-get.ts'
 import { emailMessageListCapability } from './email-message-list.ts'
+import { emailMessageSearchCapability } from './email-message-search.ts'
 import { emailReplyCapability } from './email-reply.ts'
 import { emailSendCapability } from './email-send.ts'
 import { emailSenderIdentityVerifyCapability } from './email-sender-identity-verify.ts'
+import { emailUsageGetCapability } from './email-usage-get.ts'
 
 export const emailDomain = defineDomain({
 	name: capabilityDomainNames.email,
@@ -19,9 +21,11 @@ export const emailDomain = defineDomain({
 		emailInboxListCapability,
 		emailAttachmentGetCapability,
 		emailMessageListCapability,
+		emailMessageSearchCapability,
 		emailMessageGetCapability,
 		emailSendCapability,
 		emailReplyCapability,
 		emailSenderIdentityVerifyCapability,
+		emailUsageGetCapability,
 	],
 })

--- a/packages/worker/src/mcp/capabilities/email/email-message-search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-message-search.node.test.ts
@@ -13,21 +13,28 @@ const { emailMessageSearchCapability } =
 	await import('./email-message-search.ts')
 const { createMcpCallerContext } = await import('#mcp/context.ts')
 
-test('email_message_search requires a signed-in user and forwards the query scoped to that user', async () => {
-	const env = { APP_DB: {} } as Env
-	await expect(
-		emailMessageSearchCapability.handler(
-			{ query: 'invoice', limit: 25 },
-			{
-				env,
-				callerContext: createMcpCallerContext({
-					baseUrl: 'https://example.com',
-				}),
-			},
-		),
-	).rejects.toThrow(/Authenticated MCP user/)
+function createUsersDb(emailVerifiedAt: string | null) {
+	return {
+		prepare: () => ({
+			bind: () => ({
+				first: async () => ({ email_verified_at: emailVerifiedAt }),
+			}),
+		}),
+	} as unknown as D1Database
+}
 
-	const callerContext = createMcpCallerContext({
+function createEnv(options: { emailVerifiedAt?: string | null } = {}) {
+	return {
+		APP_DB: createUsersDb(
+			options.emailVerifiedAt === undefined
+				? '2026-01-01T00:00:00.000Z'
+				: options.emailVerifiedAt,
+		),
+	} as Env
+}
+
+function createUserContext() {
+	return createMcpCallerContext({
 		baseUrl: 'https://example.com',
 		user: {
 			userId: 'user-1',
@@ -35,6 +42,33 @@ test('email_message_search requires a signed-in user and forwards the query scop
 			displayName: 'User Example',
 		},
 	})
+}
+
+test('email_message_search requires a signed-in, verified user and forwards the query scoped to that user', async () => {
+	await expect(
+		emailMessageSearchCapability.handler(
+			{ query: 'invoice', limit: 25 },
+			{
+				env: createEnv(),
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://example.com',
+				}),
+			},
+		),
+	).rejects.toThrow(/Authenticated MCP user/)
+
+	await expect(
+		emailMessageSearchCapability.handler(
+			{ query: 'invoice', limit: 25 },
+			{
+				env: createEnv({ emailVerifiedAt: null }),
+				callerContext: createUserContext(),
+			},
+		),
+	).rejects.toThrow(/Account email is not verified/)
+	expect(mockModule.searchEmailMessages).not.toHaveBeenCalled()
+
+	const env = createEnv()
 	mockModule.searchEmailMessages.mockResolvedValueOnce([
 		{
 			id: 'message-1',
@@ -63,11 +97,11 @@ test('email_message_search requires a signed-in user and forwards the query scop
 			direction: 'inbound',
 			limit: 10,
 		},
-		{ env, callerContext },
+		{ env, callerContext: createUserContext() },
 	)
 
 	expect(mockModule.searchEmailMessages).toHaveBeenCalledWith({
-		db: {},
+		db: env.APP_DB,
 		userId: 'user-1',
 		query: 'invoice',
 		inboxId: 'inbox-1',

--- a/packages/worker/src/mcp/capabilities/email/email-message-search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-message-search.node.test.ts
@@ -1,0 +1,86 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	searchEmailMessages: vi.fn(),
+}))
+
+vi.mock('#worker/email/repo.ts', () => ({
+	searchEmailMessages: (...args: Array<unknown>) =>
+		mockModule.searchEmailMessages(...args),
+}))
+
+const { emailMessageSearchCapability } =
+	await import('./email-message-search.ts')
+const { createMcpCallerContext } = await import('#mcp/context.ts')
+
+test('email_message_search requires a signed-in user and forwards the query scoped to that user', async () => {
+	const env = { APP_DB: {} } as Env
+	await expect(
+		emailMessageSearchCapability.handler(
+			{ query: 'invoice', limit: 25 },
+			{
+				env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://example.com',
+				}),
+			},
+		),
+	).rejects.toThrow(/Authenticated MCP user/)
+
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-1',
+			email: 'user@example.com',
+			displayName: 'User Example',
+		},
+	})
+	mockModule.searchEmailMessages.mockResolvedValueOnce([
+		{
+			id: 'message-1',
+			direction: 'inbound',
+			inboxId: 'inbox-1',
+			threadId: null,
+			fromAddress: 'billing@acme.example',
+			envelopeFrom: 'bounce@acme.example',
+			toAddresses: ['alias@example.com'],
+			subject: 'Invoice #123',
+			messageIdHeader: '<invoice@acme.example>',
+			processingStatus: 'stored',
+			providerMessageId: null,
+			error: null,
+			receivedAt: '2026-07-01T00:00:00.000Z',
+			sentAt: null,
+			createdAt: '2026-07-01T00:00:00.000Z',
+			updatedAt: '2026-07-01T00:00:00.000Z',
+		},
+	])
+
+	const result = await emailMessageSearchCapability.handler(
+		{
+			query: 'invoice',
+			inbox_id: 'inbox-1',
+			direction: 'inbound',
+			limit: 10,
+		},
+		{ env, callerContext },
+	)
+
+	expect(mockModule.searchEmailMessages).toHaveBeenCalledWith({
+		db: {},
+		userId: 'user-1',
+		query: 'invoice',
+		inboxId: 'inbox-1',
+		direction: 'inbound',
+		processingStatus: null,
+		limit: 10,
+	})
+	expect(result.messages).toEqual([
+		expect.objectContaining({
+			id: 'message-1',
+			subject: 'Invoice #123',
+			from_address: 'billing@acme.example',
+			envelope_from: 'bounce@acme.example',
+		}),
+	])
+})

--- a/packages/worker/src/mcp/capabilities/email/email-message-search.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-message-search.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { searchEmailMessages } from '#worker/email/repo.ts'
 import {
 	emailDirectionValues,
 	emailProcessingStatusValues,
 } from '#worker/email/types.ts'
+import { requireVerifiedEmailAccountUser } from './require-verified-user.ts'
 import { emailMessageSummarySchema, toMessageSummary } from './shared.ts'
 
 export const emailMessageSearchCapability = defineDomainCapability(
@@ -37,7 +37,7 @@ export const emailMessageSearchCapability = defineDomainCapability(
 			messages: z.array(emailMessageSummarySchema),
 		}),
 		async handler(args, ctx) {
-			const user = requireMcpUser(ctx.callerContext)
+			const user = await requireVerifiedEmailAccountUser(ctx)
 			const messages = await searchEmailMessages({
 				db: ctx.env.APP_DB,
 				userId: user.userId,

--- a/packages/worker/src/mcp/capabilities/email/email-message-search.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-message-search.ts
@@ -3,6 +3,10 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { searchEmailMessages } from '#worker/email/repo.ts'
+import {
+	emailDirectionValues,
+	emailProcessingStatusValues,
+} from '#worker/email/types.ts'
 import { emailMessageSummarySchema, toMessageSummary } from './shared.ts'
 
 export const emailMessageSearchCapability = defineDomainCapability(
@@ -25,8 +29,8 @@ export const emailMessageSearchCapability = defineDomainCapability(
 					'Substring to match (case-insensitive) against subject, from address, and envelope sender.',
 				),
 			inbox_id: z.string().min(1).optional(),
-			direction: z.enum(['inbound', 'outbound']).optional(),
-			processing_status: z.enum(['stored', 'sent', 'failed']).optional(),
+			direction: z.enum(emailDirectionValues).optional(),
+			processing_status: z.enum(emailProcessingStatusValues).optional(),
 			limit: z.number().int().positive().max(100).default(25),
 		}),
 		outputSchema: z.object({

--- a/packages/worker/src/mcp/capabilities/email/email-message-search.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-message-search.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { searchEmailMessages } from '#worker/email/repo.ts'
+import { emailMessageSummarySchema, toMessageSummary } from './shared.ts'
+
+export const emailMessageSearchCapability = defineDomainCapability(
+	capabilityDomainNames.email,
+	{
+		name: 'email_message_search',
+		description:
+			'Search stored email messages owned by the signed-in user by case-insensitive substring match against subject, header From, and envelope sender.',
+		keywords: ['email', 'message', 'inbox', 'search', 'find', 'query'],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: z.object({
+			query: z
+				.string()
+				.trim()
+				.min(1)
+				.max(256)
+				.describe(
+					'Substring to match (case-insensitive) against subject, from address, and envelope sender.',
+				),
+			inbox_id: z.string().min(1).optional(),
+			direction: z.enum(['inbound', 'outbound']).optional(),
+			processing_status: z.enum(['stored', 'sent', 'failed']).optional(),
+			limit: z.number().int().positive().max(100).default(25),
+		}),
+		outputSchema: z.object({
+			messages: z.array(emailMessageSummarySchema),
+		}),
+		async handler(args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const messages = await searchEmailMessages({
+				db: ctx.env.APP_DB,
+				userId: user.userId,
+				query: args.query,
+				inboxId: args.inbox_id ?? null,
+				direction: args.direction ?? null,
+				processingStatus: args.processing_status ?? null,
+				limit: args.limit,
+			})
+			return { messages: messages.map(toMessageSummary) }
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/email/email-usage-get.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-usage-get.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
+import {
+	planNames,
+	resolveEmailResourceLimit,
+	resolvePlanLimit,
+} from '#worker/entitlements/plans.ts'
+import {
+	getUserPlan,
+	readEntitlementResourceUsage,
+	utcDayKey,
+} from '#worker/entitlements/service.ts'
+
+const usageEntrySchema = z.object({
+	count: z.number().int().nonnegative(),
+	/** null = unlimited. */
+	limit: z.number().int().nonnegative().nullable(),
+})
+
+export const emailUsageGetCapability = defineDomainCapability(
+	capabilityDomainNames.email,
+	{
+		name: 'email_usage_get',
+		description:
+			"Read the signed-in user's email usage and limits: stored message count, today's send and receive counts, the applicable caps, and the plan name.",
+		keywords: ['email', 'usage', 'quota', 'limits', 'plan', 'metrics'],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: emptyCapabilityInputSchema,
+		outputSchema: z.object({
+			plan: z.enum(planNames).nullable(),
+			/** UTC day the send/receive counters apply to (YYYY-MM-DD). */
+			day: z.string(),
+			stored_messages: usageEntrySchema,
+			sends_today: usageEntrySchema,
+			receives_today: usageEntrySchema,
+		}),
+		async handler(_args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const db = ctx.env.APP_DB
+			const now = new Date()
+			const plan = await getUserPlan(db, {
+				userId: user.userId,
+				email: user.email,
+			})
+			const [storedMessages, sendsToday, receivesToday] = await Promise.all([
+				readEntitlementResourceUsage({
+					db,
+					userId: user.userId,
+					resource: 'stored_email_messages',
+					now,
+				}),
+				readEntitlementResourceUsage({
+					db,
+					userId: user.userId,
+					resource: 'email_sends_per_day',
+					now,
+				}),
+				readEntitlementResourceUsage({
+					db,
+					userId: user.userId,
+					resource: 'email_receives_per_day',
+					now,
+				}),
+			])
+			return {
+				plan,
+				day: utcDayKey(now),
+				stored_messages: {
+					count: storedMessages,
+					limit: resolveEmailResourceLimit(plan, 'stored_email_messages'),
+				},
+				sends_today: {
+					count: sendsToday,
+					// Outbound sends have no NULL-plan fallback: plan-less users
+					// are unlimited (attempts are still counted).
+					limit: plan ? resolvePlanLimit(plan, 'email_sends_per_day') : null,
+				},
+				receives_today: {
+					count: receivesToday,
+					limit: resolveEmailResourceLimit(plan, 'email_receives_per_day'),
+				},
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/email/email-usage-get.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-usage-get.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
 import {
 	planNames,
@@ -13,6 +12,7 @@ import {
 	readEntitlementResourceUsage,
 	utcDayKey,
 } from '#worker/entitlements/service.ts'
+import { requireVerifiedEmailAccountUser } from './require-verified-user.ts'
 
 const usageEntrySchema = z.object({
 	count: z.number().int().nonnegative(),
@@ -42,7 +42,7 @@ export const emailUsageGetCapability = defineDomainCapability(
 			max_message_bytes: z.number().int().nonnegative().nullable(),
 		}),
 		async handler(_args, ctx) {
-			const user = requireMcpUser(ctx.callerContext)
+			const user = await requireVerifiedEmailAccountUser(ctx)
 			const db = ctx.env.APP_DB
 			const now = new Date()
 			const plan = await getUserPlan(db, {

--- a/packages/worker/src/mcp/capabilities/email/email-usage-get.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-usage-get.ts
@@ -38,6 +38,8 @@ export const emailUsageGetCapability = defineDomainCapability(
 			stored_messages: usageEntrySchema,
 			sends_today: usageEntrySchema,
 			receives_today: usageEntrySchema,
+			/** Maximum raw MIME bytes per stored message. null = unlimited. */
+			max_message_bytes: z.number().int().nonnegative().nullable(),
 		}),
 		async handler(_args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
@@ -84,6 +86,10 @@ export const emailUsageGetCapability = defineDomainCapability(
 					count: receivesToday,
 					limit: resolveEmailResourceLimit(plan, 'email_receives_per_day'),
 				},
+				max_message_bytes: resolveEmailResourceLimit(
+					plan,
+					'email_message_bytes',
+				),
 			}
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/email/email-usage-get.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-usage-get.workers.test.ts
@@ -104,6 +104,7 @@ test('email_usage_get returns plan limits and current counts for plan users', as
 			count: 5,
 			limit: planLimits.personal.maxEmailReceivesPerDay,
 		},
+		max_message_bytes: planLimits.personal.maxEmailMessageBytes,
 	})
 })
 
@@ -131,5 +132,6 @@ test('email_usage_get reports fallback limits for users without a plan', async (
 			count: 0,
 			limit: nullPlanEmailFallbackLimits.email_receives_per_day,
 		},
+		max_message_bytes: nullPlanEmailFallbackLimits.email_message_bytes,
 	})
 })

--- a/packages/worker/src/mcp/capabilities/email/email-usage-get.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-usage-get.workers.test.ts
@@ -10,7 +10,11 @@ import { ensureEmailTestSchema } from '#worker/email/test-schema.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { emailUsageGetCapability } from './email-usage-get.ts'
 
-async function seedUser(input: { email: string; plan: 'personal' | null }) {
+async function seedUser(input: {
+	email: string
+	plan: 'personal' | null
+	emailVerifiedAt?: string | null
+}) {
 	await env.APP_DB.prepare(
 		`INSERT INTO users (username, email, password_hash, email_verified_at, plan)
 			VALUES (?, ?, ?, ?, ?)`,
@@ -19,7 +23,9 @@ async function seedUser(input: { email: string; plan: 'personal' | null }) {
 			`email-usage-${crypto.randomUUID().slice(0, 8)}`,
 			input.email,
 			'test-password-hash',
-			new Date().toISOString(),
+			input.emailVerifiedAt === undefined
+				? new Date().toISOString()
+				: input.emailVerifiedAt,
 			input.plan,
 		)
 		.run()
@@ -65,13 +71,24 @@ function buildCallerContext(user: { userId: string; email: string } | null) {
 	})
 }
 
-test('email_usage_get requires a signed-in user', async () => {
+test('email_usage_get requires a signed-in, verified user', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
 	await expect(
 		emailUsageGetCapability.handler(
 			{},
 			{ env, callerContext: buildCallerContext(null) },
 		),
 	).rejects.toThrow(/Authenticated MCP user/)
+
+	const email = `usage-unverified-${crypto.randomUUID()}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	await seedUser({ email, plan: null, emailVerifiedAt: null })
+	await expect(
+		emailUsageGetCapability.handler(
+			{},
+			{ env, callerContext: buildCallerContext({ userId, email }) },
+		),
+	).rejects.toThrow(/Account email is not verified/)
 })
 
 test('email_usage_get returns plan limits and current counts for plan users', async () => {

--- a/packages/worker/src/mcp/capabilities/email/email-usage-get.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-usage-get.workers.test.ts
@@ -1,0 +1,135 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import {
+	nullPlanEmailFallbackLimits,
+	planLimits,
+} from '#worker/entitlements/plans.ts'
+import { utcDayKey } from '#worker/entitlements/service.ts'
+import { ensureEmailTestSchema } from '#worker/email/test-schema.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { emailUsageGetCapability } from './email-usage-get.ts'
+
+async function seedUser(input: { email: string; plan: 'personal' | null }) {
+	await env.APP_DB.prepare(
+		`INSERT INTO users (username, email, password_hash, email_verified_at, plan)
+			VALUES (?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			`email-usage-${crypto.randomUUID().slice(0, 8)}`,
+			input.email,
+			'test-password-hash',
+			new Date().toISOString(),
+			input.plan,
+		)
+		.run()
+}
+
+async function seedDailyCounter(input: {
+	userId: string
+	resource: 'email_sends_per_day' | 'email_receives_per_day'
+	count: number
+}) {
+	await env.APP_DB.prepare(
+		`INSERT INTO entitlement_daily_counters (user_id, resource, day, count, updated_at)
+			VALUES (?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			input.userId,
+			input.resource,
+			utcDayKey(),
+			input.count,
+			new Date().toISOString(),
+		)
+		.run()
+}
+
+async function seedStoredMessages(userId: string, count: number) {
+	const now = new Date().toISOString()
+	for (let index = 0; index < count; index += 1) {
+		await env.APP_DB.prepare(
+			`INSERT INTO email_messages (
+				id, direction, user_id, from_address, subject,
+				processing_status, created_at, updated_at
+			) VALUES (?, 'inbound', ?, 'sender@example.net', 'Stored', 'stored', ?, ?)`,
+		)
+			.bind(`usage-message-${crypto.randomUUID()}`, userId, now, now)
+			.run()
+	}
+}
+
+function buildCallerContext(user: { userId: string; email: string } | null) {
+	return createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		...(user ? { user: { ...user, displayName: 'Usage Tester' } } : {}),
+	})
+}
+
+test('email_usage_get requires a signed-in user', async () => {
+	await expect(
+		emailUsageGetCapability.handler(
+			{},
+			{ env, callerContext: buildCallerContext(null) },
+		),
+	).rejects.toThrow(/Authenticated MCP user/)
+})
+
+test('email_usage_get returns plan limits and current counts for plan users', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const email = `usage-plan-${crypto.randomUUID()}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	await seedUser({ email, plan: 'personal' })
+	await seedDailyCounter({ userId, resource: 'email_sends_per_day', count: 3 })
+	await seedDailyCounter({
+		userId,
+		resource: 'email_receives_per_day',
+		count: 5,
+	})
+	await seedStoredMessages(userId, 2)
+
+	const result = await emailUsageGetCapability.handler(
+		{},
+		{ env, callerContext: buildCallerContext({ userId, email }) },
+	)
+
+	expect(result).toEqual({
+		plan: 'personal',
+		day: utcDayKey(),
+		stored_messages: {
+			count: 2,
+			limit: planLimits.personal.maxStoredEmailMessages,
+		},
+		sends_today: { count: 3, limit: planLimits.personal.maxEmailSendsPerDay },
+		receives_today: {
+			count: 5,
+			limit: planLimits.personal.maxEmailReceivesPerDay,
+		},
+	})
+})
+
+test('email_usage_get reports fallback limits for users without a plan', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const email = `usage-null-plan-${crypto.randomUUID()}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	await seedUser({ email, plan: null })
+
+	const result = await emailUsageGetCapability.handler(
+		{},
+		{ env, callerContext: buildCallerContext({ userId, email }) },
+	)
+
+	expect(result).toEqual({
+		plan: null,
+		day: utcDayKey(),
+		stored_messages: {
+			count: 0,
+			limit: nullPlanEmailFallbackLimits.stored_email_messages,
+		},
+		// Outbound sends stay unlimited for plan-less users.
+		sends_today: { count: 0, limit: null },
+		receives_today: {
+			count: 0,
+			limit: nullPlanEmailFallbackLimits.email_receives_per_day,
+		},
+	})
+})

--- a/packages/worker/src/usage/record-usage.ts
+++ b/packages/worker/src/usage/record-usage.ts
@@ -3,8 +3,8 @@
  *
  * One event schema covers every metered chokepoint (execute runs, package
  * export invocations, job runs, workflow runs, package service runtime,
- * realtime websocket sessions, gateway fetches, email sends). Events are
- * written to two sinks:
+ * realtime websocket sessions, gateway fetches, email sends and receives).
+ * Events are written to two sinks:
  *
  * - Workers Analytics Engine (`USAGE_EVENTS`) for high-cardinality analysis.
  * - The D1 `usage_rollups` table (per-user, per-metric, per-month counters)
@@ -25,6 +25,7 @@ export type UsageEventType =
 	| 'realtime_session'
 	| 'outbound_fetch'
 	| 'email_send'
+	| 'email_received'
 
 export type UsageOutcome = 'success' | 'error'
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Fills the email visibility/quota gaps: users can now search their stored mail, inbound storage is quota-gated (rows **and** bytes), inbound receives are metered, and users can see where they stand. Updated for Kent's denial-of-wallet review, then rebased onto main after #637/#638/#632 landed, reconciling the verified-email gating with the quota enforcement.

### 1. Inbox search — `email_message_search`

- New read-only MCP capability: case-insensitive substring match against `subject`, `from_address`, and `envelope_from` (LIKE wildcards in the query are escaped so they match literally).
- Same `inbox_id` / `direction` / `processing_status` filters, ordering, and limit caps (max 100, default 25) as `email_message_list`; always `userId`-scoped. Like every email capability after #637, it requires a verified account email (`requireVerifiedEmailAccountUser`).

### 2. Entitlements / quotas (reconciled with #637's verified-email gating)

- All fail-closed gates run in `handleInboundEmail` **before parsing**, cheapest rejection first, fed by **one** stable-id account lookup (`findUserAccountByStableUserId` now also returns the verified-email state, read fresh on both cache paths):
  1. **Verified account** (#637's gate) — unverified or deleted accounts are rejected with main's reason/phase (`Account email is not verified.`, `account-verification`) **without consuming any daily receive quota**: an account that can never receive must not accumulate usage against its limits.
  2. `email_message_bytes` — per-message raw-size cap: personal 512 KiB, pro/partner 768 KiB, NULL-plan fallback 512 KiB. Checked before the daily counter so oversize mail doesn't burn receive quota. **Why not the suggested 5–10 MB:** raw MIME is stored inline in the `email_messages` row next to the extracted bodies, and D1 hard-caps rows at 2 MB — a 5 MB cap would accept mail that cannot physically be stored (the parser's pre-existing 512 KiB raw-MIME ceiling enforced this implicitly; the plan cap now drives that ceiling so the two gates can't disagree). ⚠️ **Practical consequence Kent should weigh:** ordinary email with a photo attachment easily exceeds 512 KiB, so legitimate attachment mail **will bounce** on personal plans until raw MIME moves out of D1 (R2/KV follow-up below) — the caps are a platform-storage constraint, not a product choice.
  3. `email_receives_per_day` — atomic `consumeDailyEntitlement` (counts attempts): personal 200, pro 1,000, partner 2,000, NULL-plan fallback 200.
  4. `stored_email_messages` — row count: personal 2,000, pro 10,000, partner 25,000, NULL-plan fallback 2,000 (check-then-insert; documented trade-off).
- **NULL-plan users are not unlimited for inbound email** (`nullPlanEmailFallbackLimits`); outbound sends keep their existing NULL-plan-unlimited behavior.
- Over-quota/oversize mail is rejected with a generic SMTP reason ("Recipient mailbox is over quota.") so the arbitrary sender never sees plan details; the detailed message is stored for the owner.
- **Bounded rejection writes:** quota, size, **and unverified-account** rejections store at most **5 detailed `rejected` delivery events per inbox per UTC day** plus one aggregate daily event row (deterministic id, total count + last reason/phase), so a rejected flood grows D1 by at most 6 rows per inbox per day. Unverified floods are the same attacker-controlled row-growth shape as over-quota floods, hence bounded too (this tightens #637's per-attempt event insert). Parse-failure rejections keep per-attempt events: they're bounded by the receive quota (consumed before parsing) and useful for debugging senders.

### 3. Usage metering — `email_received`

- New `UsageEventType` recorded once per receive attempt after inbox resolution: `success` on store, `error` on unverified-account rejection, size rejection, entitlement rejection, or parse failure. `bytes` always carries the raw message size — including for rejected mail — and `entityId` is the message id when stored. Mail rejected before inbox resolution (unknown alias) has no owning user and is not metered.

### 4. User-visible usage — `email_usage_get`

- Read-only MCP capability (verified users only) returning plan name, UTC day, stored message count/limit, today's send count/limit, today's receive count/limit, and `max_message_bytes`.
- Admin visibility: `email_received` metric and the new resources are wired into the admin usage page and `admin_usage_overview`, including effective fallback limits for plan-less users.

### 5. Tests + docs

- Workers tests: search SQL behavior, inbound enforcement (receive limit, storage cap, oversize rejection without quota consumption, NULL-plan fallback, under-quota success + metering), **unverified-account rejection without quota consumption + bounded events + metering**, rejection-event bounding, reverse-lookup caching (incl. fresh verified state), `email_usage_get` for plan/plan-less/unverified users.
- Node tests: `consumeDailyEntitlement` fallback capping, `resolveEmailResourceLimit`, `email_message_bytes` enforcement semantics, search capability wiring/auth incl. unverified rejection, admin usage data.
- Docs updated: `docs/use/email-primitives.md`, `docs/contributing/architecture/entitlements.md`, `docs/contributing/architecture/usage-metering.md`, `docs/contributing/architecture/data-storage.md`.

No migrations needed — the new resources reuse `entitlement_daily_counters` and existing tables (the aggregate rejection row reuses `email_delivery_events` with a deterministic id).

## Verification

- `npm run validate` fully green locally after the final rebase (format, lint, typecheck, 576 unit tests, Playwright E2E, MCP E2E).
- Manual E2E against the local worker (`/cdn-cgi/handler/email`):
  - Mail to an **unverified** account → HTTP 400 "Account email is not verified.", bounded rejection events (detailed + aggregate, phase `account-verification`), **zero** quota counters, metered as error. After verifying the account, the same alias stores mail and the receive counter increments.
  - 600 KiB message to a personal-plan inbox → HTTP 400 over-quota, phase `size`, no daily quota consumed, usage event with the rejected byte count.
  - 8-message flood at the daily receive limit → all rejected; rejected rows capped (5 detailed + 1 aggregate carrying the total); all attempts metered.
  - Under-quota mail still stored normally.

## Required follow-ups (not in this PR)

- **Before onboarding external users / design partners (required):** persist an indexed `users.stable_user_id` column with an app-level backfill (SQLite cannot compute SHA-256 in a migration) and replace the reverse-hash users-table scan in `findUserAccountByStableUserId` (which now also serves #637's verified-email gate on the inbound path). Documented in `entitlements.md` and `data-storage.md`.
- **Per-sender / per-alias throttle beneath the daily quota:** a third party who learns one alias can burn the owner's entire daily receive quota (griefing, distinct from denial-of-wallet).
- **Raw MIME out of D1 (R2/KV):** required before per-message size caps can rise to attachment-friendly levels (5–10 MB); D1's 2 MB row limit is the binding constraint today.
- **Full `maxStorageBytes` enforcement:** separate effort; the per-message size cap deliberately does not do storage-bytes accounting.
- **FTS5 / search index** if mailboxes outgrow the LIKE linear scan (bounded today by the stored-message cap).

## Notes for reviewer

- Post-deploy: reindex capability vectors (`POST /__maintenance/reindex-capabilities`) so the new capabilities appear in semantic `search`.
- Branch rebased onto current main (`f4d10022`); merge-base equals main head. The #637 conflicts in `inbound.ts` / `inbound.workers.test.ts` / `email-primitives.md` were reconciled in the dedicated commit "Reconcile verified-email gating with inbound quotas and size caps" — both behaviors preserved, ordering and quota semantics documented there.
- The `{username}@heykody.dev` auto-inbox refactor stays out of scope; enforcement sits at the shared insert path and applies unchanged after that refactor.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `f4d10022` · **Head:** `f1c2070f`

**Classification:** extends — no new primitives; the email, entitlements, and usage-metering primitives gain new behavior and contracts.

### Primitives touched

| Primitive        | Group     | Impact                                                                                     |
| ---------------- | --------- | ------------------------------------------------------------------------------------------ |
| `email`          | assistant | extends — inbound verified/size/rate/storage gating, bounded rejection events, `email_message_search`, `email_usage_get` |
| `entitlements`   | auth      | extends — 3 new resources (incl. per-message size), NULL-plan email fallbacks, `consumeDailyEntitlement` fallback, stable-id reverse lookup with verified state |
| `usage-metering` | runtime   | extends — new `email_received` event type (bytes recorded for rejected mail too)           |
| `app-ui`         | surfaces  | composes — admin usage page shows the new metric/resources                                 |
| `mcp-server`     | surfaces  | composes — two new registered email capabilities (verified-user gated)                     |

### System map

```mermaid
flowchart LR
	connectorIngress["connector-ingress (email routing)"]:::untouched
	email["email"]:::extended
	entitlements["entitlements"]:::extended
	usageMetering["usage-metering"]:::extended
	d1AppDb["d1-app-db"]:::untouched
	mcpServer["mcp-server"]:::touched
	appUi["app-ui (admin usage)"]:::touched
	connectorIngress --> email
	email --> entitlements --> d1AppDb
	email --> usageMetering --> d1AppDb
	mcpServer --> email
	appUi --> usageMetering
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant S as Sender
	participant H as handleInboundEmail
	participant E as entitlements
	participant D as D1
	S->>H: routed mail (known alias)
	H->>E: findUserAccountByStableUserId (email, plan, verified)
	alt account unverified
		H-->>S: reject "not verified" (no quota consumed)
		H->>D: bounded rejection events + email_received error
	else verified
		H->>E: size cap (no quota consumed on reject)
		H->>E: consumeDailyEntitlement (receives/day, fallback)
		H->>E: assertWithinEntitlement (stored cap, fallback)
		alt over quota or oversize
			H-->>S: reject "over quota" (generic)
			H->>D: bounded rejection events + email_received error
		else under quota
			H->>D: store message + email_received success
		end
	end
```

### Invariants

- Per-user isolation: search, usage reads, and enforcement are all `userId`-scoped; `findUserAccountByStableUserId` only returns the account whose email hashes to the given stable id.
- NULL-plan invariant: intentionally excepted for inbound email resources (documented in `entitlements.md`) because inbound volume is attacker-controlled.
- Fail-closed verified-email gate (#637) preserved and strengthened: same reason/phase, now with bounded rejection rows and no quota consumption.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-981ee99e-336f-4325-b9f6-8a8c947662a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-981ee99e-336f-4325-b9f6-8a8c947662a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stored-email search with query, inbox, direction, and status filtering.
  * Introduced an email usage view covering sends, receives, stored-message counts, and message-byte limits.
  * Expanded MCP email capabilities to support message search and usage retrieval.
* **Bug Fixes**
  * Improved inbound-email quota enforcement for plan-less accounts, including per-day receive limits, stored-message caps, and message-size gating.
  * Inbound processing now records received-email usage with clearer success/error tracking.
* **Documentation**
  * Updated architecture and usage-metering docs for inbound-email quotas, metering, and the new search/usage capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->