### PR TITLE
Require verified account email for MCP and email features

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -104,16 +104,49 @@ through `packages/worker/src/app/email/cloudflare-email.ts`, and store
 `users.email_verified_at` only after `GET /verify-email?token=...` succeeds.
 Verification tokens expire after 24 hours and only token hashes are stored.
 
+Signup fails hard when the verification email cannot be sent: the created user
+row is rolled back and any consumed invite use is released, so the
+email/username can be retried. An account must never exist without a way to
+verify it. The only exception is non-production runtimes (local dev, preview,
+test — see `isNonProductionRuntime`) with no Cloudflare email sender configured;
+there the send is skipped and accounts are verified through seeded tokens
+instead.
+
+Signed-in users with an unverified email can request a fresh link with
+`POST /account/resend-verification.json`
+(`packages/worker/src/app/handlers/account-resend-verification.ts`), surfaced as
+a "Resend verification email" button on `/account`. The endpoint reuses
+`createEmailVerification` (invalidating older tokens) and is rate-limited per
+user (3 requests per 15 minutes).
+
 Existing accounts are marked verified by the migration that introduces
 `email_verified_at` so shipped users are not silently blocked by the new gate.
 Seeded/test fixture accounts are also created verified. New accounts created via
 normal signup start unverified, can still sign in, and see the unverified state
 on `/account`.
 
-At minimum, unverified accounts are blocked from sending outbound email. The MCP
-email send/reply capabilities pass the authenticated account email into
-`packages/worker/src/email/outbound.ts`, which checks `users.email_verified_at`
-before sending through a verified sender identity.
+Unverified accounts can still use browser sessions and complete OAuth flows
+(authorize + token exchange keep working so clients can finish login), but
+assistant features are blocked until the email is verified:
+
+- **MCP**: `handleMcpRequest` in `packages/worker/src/mcp-auth.ts` is the single
+  chokepoint for `/mcp`. After token validation it checks
+  `users.email_verified_at` (via `isAccountEmailVerified`) and rejects
+  unverified — or unidentifiable — accounts with a
+  `403 email_verification_required` JSON response pointing at `/account`. The
+  gate fails closed: when verification cannot be established, the request is
+  rejected.
+- **Inbound email**: `handleInboundEmail` in
+  `packages/worker/src/email/inbound.ts` rejects routed mail for unverified
+  accounts right after inbox lookup (`setReject` plus a `rejected` email
+  delivery event); nothing is stored.
+- **Email capabilities**: every capability in the MCP `email` domain calls
+  `requireVerifiedEmailAccountUser`
+  (`packages/worker/src/mcp/capabilities/email/require-verified-user.ts`) as
+  defense-in-depth for callers that do not pass through `/mcp` (execute runtime,
+  package jobs). Outbound sending additionally re-checks the account inside
+  `packages/worker/src/email/outbound.ts` before using a verified sender
+  identity.
 
 ### Password policy
 
@@ -227,6 +260,9 @@ routed from `packages/worker/src/index.ts`.
 - Token is validated via OAuth provider helpers (`unwrapToken`)
 - Audience must match the app origin or `<origin>/mcp`
 - Unauthenticated requests return `401` with `WWW-Authenticate` metadata
+- The account email must be verified; unverified accounts receive a
+  `403 email_verification_required` response (see the email verification section
+  above)
 
 ## What to read when changing auth
 
@@ -239,8 +275,10 @@ routed from `packages/worker/src/index.ts`.
   `packages/worker/src/app/handlers/admin-invites.ts` for invite management
 - `packages/worker/src/app/admin-user-creation.ts` for admin-created account
   setup links
-- `packages/worker/src/app/email-verification.ts` and
-  `packages/worker/src/app/handlers/verify-email.ts` for verification tokens
+- `packages/worker/src/app/email-verification.ts`,
+  `packages/worker/src/app/handlers/verify-email.ts`, and
+  `packages/worker/src/app/handlers/account-resend-verification.ts` for
+  verification tokens and resends
 - `packages/worker/src/app/handlers/account-secrets.ts` for owner-scoped secret
   reveal
 - `packages/worker/src/app/deployment-env.ts` for the production/non-production

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -20,7 +20,12 @@ Use the MCP `email` domain:
 
 ## Safety model
 
-- Any email routed to a configured Kody inbox is stored.
+- Every email capability requires a **verified account email**. Until the
+  account email is verified (via the link sent at signup, or a resend from the
+  `/account` page), email capabilities are rejected, inbound mail routed to the
+  account's aliases is rejected before storage, and MCP access as a whole is
+  disabled.
+- Any email routed to a configured Kody inbox on a verified account is stored.
 - Unknown aliases are rejected before storage.
 - Display names are not trusted. Kody stores envelope sender, parsed `From`, and
   authentication headers separately.

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -1,5 +1,12 @@
 # Troubleshooting
 
+## MCP requests fail with `email_verification_required`
+
+Kody requires a verified account email before any MCP access. Open the
+verification link sent to the account email at signup, or sign in to the app and
+use **Resend verification email** on the `/account` page, then reconnect the MCP
+client.
+
 ## Search returns no good matches
 
 - **Rephrase the query** using domain vocabulary from the search tool’s domain

--- a/e2e/invite-signup-verification.spec.ts
+++ b/e2e/invite-signup-verification.spec.ts
@@ -93,7 +93,12 @@ test('admin invite signup and email verification happy path', async ({
 		page.getByRole('heading', { name: 'Verify your email' }),
 	).toBeVisible()
 	await expect(
-		page.getByText('Outbound email sending stays disabled'),
+		page.getByText('MCP access and email features stay disabled'),
+	).toBeVisible()
+
+	await page.getByRole('button', { name: 'Resend verification email' }).click()
+	await expect(
+		page.getByText('Verification email sent. Check your inbox.'),
 	).toBeVisible()
 
 	await setEmailVerificationTokenInE2eDatabase({

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -35,6 +35,8 @@ type AccountProfilePayload = {
 	displayName: string
 }
 
+const resendVerificationApiPath = '/account/resend-verification.json'
+
 function isAccountPath(href: string) {
 	return new URL(href, 'http://localhost').pathname === '/account'
 }
@@ -61,6 +63,9 @@ export async function accountRouteLoader(
 export function AccountRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
 	let saveStatus: 'idle' | 'saving' = 'idle'
+	let resendStatus: 'idle' | 'sending' = 'idle'
+	let resendMessage: string | null = null
+	let resendTone: 'error' | 'info' = 'info'
 	let email = ''
 	let emailVerified = false
 	let username = ''
@@ -102,6 +107,47 @@ export function AccountRoute(handle: Handle) {
 			message =
 				error instanceof Error ? error.message : 'Unable to load your account.'
 			messageTone = 'error'
+			handle.update()
+		}
+	}
+
+	async function handleResendVerification() {
+		resendStatus = 'sending'
+		resendMessage = null
+		resendTone = 'info'
+		handle.update()
+
+		try {
+			const response = await fetch(resendVerificationApiPath, {
+				method: 'POST',
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+			})
+			if (response.status === 401) {
+				window.location.assign('/login')
+				return
+			}
+			const payload = await readJson<{
+				ok?: boolean
+				message?: string
+				error?: string
+			}>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error(
+					payload?.error || 'Unable to send the verification email.',
+				)
+			}
+			resendMessage =
+				payload.message ?? 'Verification email sent. Check your inbox.'
+			resendTone = 'info'
+		} catch (error) {
+			resendMessage =
+				error instanceof Error
+					? error.message
+					: 'Unable to send the verification email.'
+			resendTone = 'error'
+		} finally {
+			resendStatus = 'idle'
 			handle.update()
 		}
 	}
@@ -255,9 +301,36 @@ export function AccountRoute(handle: Handle) {
 							>
 								<h2 mix={css(cardTitleCss)}>Verify your email</h2>
 								<p mix={css(descriptionCss)}>
-									Check your inbox for the verification link. Outbound email
-									sending stays disabled until this account email is verified.
+									Check your inbox for the verification link. MCP access and
+									email features stay disabled until this account email is
+									verified.
 								</p>
+								<div>
+									<button
+										type="button"
+										disabled={resendStatus === 'sending'}
+										mix={[
+											css(primaryButtonCss),
+											on('click', handleResendVerification),
+										]}
+									>
+										{resendStatus === 'sending'
+											? 'Sending...'
+											: 'Resend verification email'}
+									</button>
+								</div>
+								{resendMessage ? (
+									<p
+										role="status"
+										mix={css({
+											color:
+												resendTone === 'error' ? colors.error : colors.text,
+											margin: 0,
+										})}
+									>
+										{resendMessage}
+									</p>
+								) : null}
 							</section>
 						) : null}
 						<section mix={css(cardCss)}>

--- a/packages/worker/src/app/email-verification.ts
+++ b/packages/worker/src/app/email-verification.ts
@@ -1,3 +1,4 @@
+import { isNonProductionRuntime } from '#app/deployment-env.ts'
 import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
 import { normalizeEmail } from '#app/normalize-email.ts'
 import { createDb, emailVerificationsTable } from '#worker/db.ts'
@@ -81,23 +82,31 @@ export async function createEmailVerification(input: {
 	verificationUrl.searchParams.set('token', token)
 	const email = buildVerificationEmail(verificationUrl.toString())
 
-	try {
-		await sendCloudflareEmail(
-			{
-				accountId: input.appEnv.CLOUDFLARE_ACCOUNT_ID,
-				apiBaseUrl: input.appEnv.CLOUDFLARE_API_BASE_URL,
-				apiToken: input.appEnv.CLOUDFLARE_API_TOKEN,
-			},
-			{
-				to: input.email,
-				from: emailConfig.fromEmail,
-				subject: email.subject,
-				html: email.html,
-				text: email.text,
-			},
-		)
-	} catch (error) {
-		console.warn('email-verification-send-error', error)
+	const sendResult = await sendCloudflareEmail(
+		{
+			accountId: input.appEnv.CLOUDFLARE_ACCOUNT_ID,
+			apiBaseUrl: input.appEnv.CLOUDFLARE_API_BASE_URL,
+			apiToken: input.appEnv.CLOUDFLARE_API_TOKEN,
+		},
+		{
+			to: input.email,
+			from: emailConfig.fromEmail,
+			subject: email.subject,
+			html: email.html,
+			text: email.text,
+		},
+	)
+	if (!sendResult.ok) {
+		// Local dev, preview, and test runtimes may have no email sender
+		// configured; those accounts are verified through seeded tokens
+		// instead. Anywhere else an unsent verification email would strand
+		// the account with no way to verify, so fail hard and let callers
+		// roll back.
+		if (sendResult.skipped && isNonProductionRuntime(input.appEnv)) {
+			console.warn('email-verification-send-skipped', input.userId)
+			return
+		}
+		throw new Error(sendResult.error ?? 'Verification email could not be sent.')
 	}
 }
 
@@ -178,4 +187,17 @@ export async function isAccountEmailVerified(input: {
 		}
 	}
 	return false
+}
+
+export const emailVerificationRequiredMessage =
+	'Account email is not verified. Open the verification link sent to your account email, or resend it from the /account page.'
+
+export async function assertAccountEmailVerified(input: {
+	db: D1Database
+	email?: string | null
+	stableUserId?: string | null
+}) {
+	if (!(await isAccountEmailVerified(input))) {
+		throw new Error(emailVerificationRequiredMessage)
+	}
 }

--- a/packages/worker/src/app/email-verification.ts
+++ b/packages/worker/src/app/email-verification.ts
@@ -127,12 +127,19 @@ export async function createEmailVerification(input: {
 	}
 
 	// The new token is delivered (or the send was deliberately skipped in a
-	// non-production runtime); retire older outstanding tokens now.
+	// non-production runtime); retire older outstanding tokens. Best-effort
+	// only: the email is already out, so a cleanup failure must not bubble
+	// up and make callers (signup rollback) treat the send as failed —
+	// stale tokens expire on their own and are purged when any token
+	// verifies.
 	await input.appEnv.APP_DB.prepare(
 		`DELETE FROM email_verifications WHERE user_id = ? AND token_hash != ?`,
 	)
 		.bind(input.userId, tokenHash)
 		.run()
+		.catch((error) => {
+			console.warn('email-verification-token-cleanup-failed', error)
+		})
 }
 
 export type VerifyEmailResult =

--- a/packages/worker/src/app/email-verification.ts
+++ b/packages/worker/src/app/email-verification.ts
@@ -65,14 +65,23 @@ export async function createEmailVerification(input: {
 	const tokenHash = await hashVerificationToken(token)
 	const expiresAt = Date.now() + verificationTokenExpiryMs
 
-	await db.deleteMany(emailVerificationsTable, {
-		where: { user_id: input.userId },
-	})
+	// Insert the replacement token before sending so the link works the
+	// moment the email lands, but keep prior tokens valid until the send
+	// succeeds — a failed resend must not invalidate a link the user
+	// already received.
 	await db.create(emailVerificationsTable, {
 		user_id: input.userId,
 		token_hash: tokenHash,
 		expires_at: expiresAt,
 	})
+	async function discardNewToken() {
+		await input.appEnv.APP_DB.prepare(
+			`DELETE FROM email_verifications WHERE token_hash = ?`,
+		)
+			.bind(tokenHash)
+			.run()
+			.catch(() => undefined)
+	}
 
 	const emailConfig = getVerificationEmailConfig({
 		appEnv: input.appEnv,
@@ -82,32 +91,48 @@ export async function createEmailVerification(input: {
 	verificationUrl.searchParams.set('token', token)
 	const email = buildVerificationEmail(verificationUrl.toString())
 
-	const sendResult = await sendCloudflareEmail(
-		{
-			accountId: input.appEnv.CLOUDFLARE_ACCOUNT_ID,
-			apiBaseUrl: input.appEnv.CLOUDFLARE_API_BASE_URL,
-			apiToken: input.appEnv.CLOUDFLARE_API_TOKEN,
-		},
-		{
-			to: input.email,
-			from: emailConfig.fromEmail,
-			subject: email.subject,
-			html: email.html,
-			text: email.text,
-		},
-	)
+	let sendResult: Awaited<ReturnType<typeof sendCloudflareEmail>>
+	try {
+		sendResult = await sendCloudflareEmail(
+			{
+				accountId: input.appEnv.CLOUDFLARE_ACCOUNT_ID,
+				apiBaseUrl: input.appEnv.CLOUDFLARE_API_BASE_URL,
+				apiToken: input.appEnv.CLOUDFLARE_API_TOKEN,
+			},
+			{
+				to: input.email,
+				from: emailConfig.fromEmail,
+				subject: email.subject,
+				html: email.html,
+				text: email.text,
+			},
+		)
+	} catch (error) {
+		await discardNewToken()
+		throw error
+	}
 	if (!sendResult.ok) {
 		// Local dev, preview, and test runtimes may have no email sender
 		// configured; those accounts are verified through seeded tokens
 		// instead. Anywhere else an unsent verification email would strand
 		// the account with no way to verify, so fail hard and let callers
 		// roll back.
-		if (sendResult.skipped && isNonProductionRuntime(input.appEnv)) {
-			console.warn('email-verification-send-skipped', input.userId)
-			return
+		if (!(sendResult.skipped && isNonProductionRuntime(input.appEnv))) {
+			await discardNewToken()
+			throw new Error(
+				sendResult.error ?? 'Verification email could not be sent.',
+			)
 		}
-		throw new Error(sendResult.error ?? 'Verification email could not be sent.')
+		console.warn('email-verification-send-skipped', input.userId)
 	}
+
+	// The new token is delivered (or the send was deliberately skipped in a
+	// non-production runtime); retire older outstanding tokens now.
+	await input.appEnv.APP_DB.prepare(
+		`DELETE FROM email_verifications WHERE user_id = ? AND token_hash != ?`,
+	)
+		.bind(input.userId, tokenHash)
+		.run()
 }
 
 export type VerifyEmailResult =

--- a/packages/worker/src/app/handlers/account-resend-verification.node.test.ts
+++ b/packages/worker/src/app/handlers/account-resend-verification.node.test.ts
@@ -59,11 +59,14 @@ function createResendTestDb(options: { emailVerifiedAt?: string | null } = {}) {
 				return result.results[0] ?? null
 			},
 			async run() {
-				if (normalized.includes('delete from "email_verifications"')) {
+				if (/delete from "?email_verifications"?/.test(normalized)) {
 					state.verificationDeletes += 1
 				}
-				if (normalized.includes('insert into "email_verifications"')) {
+				if (/insert into "?email_verifications"?/.test(normalized)) {
 					state.verificationInserts += 1
+				}
+				if (normalized.includes('delete from _rate_limits')) {
+					state.rateLimitAttempts = Math.max(0, state.rateLimitAttempts - 1)
 				}
 				return { meta: { changes: 1, last_row_id: 1 } }
 			},
@@ -232,4 +235,10 @@ test('resend verification surfaces send failures without pretending success', as
 		ok: false,
 		error: 'Unable to send the verification email. Please try again later.',
 	})
+	// The failed send refunds the consumed rate-limit slot.
+	expect(testDb.state.rateLimitAttempts).toBe(0)
+	// The freshly inserted token is discarded again on send failure, so no
+	// net-new token remains and prior tokens stay untouched.
+	expect(testDb.state.verificationInserts).toBe(1)
+	expect(testDb.state.verificationDeletes).toBe(1)
 })

--- a/packages/worker/src/app/handlers/account-resend-verification.node.test.ts
+++ b/packages/worker/src/app/handlers/account-resend-verification.node.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeAll, expect, test, vi } from 'vitest'
+import {
+	createAuthCookie,
+	setAuthSessionSecret,
+	type AuthSession,
+} from '#app/auth-session.ts'
+import { createAccountResendVerificationHandler } from './account-resend-verification.ts'
+
+const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
+
+type StatementMeta = { changes: number; last_row_id: number }
+
+function createResendTestDb(options: { emailVerifiedAt?: string | null } = {}) {
+	const user = {
+		id: 1,
+		email: 'resend-user@example.com',
+		username: 'resend-user',
+		password_hash: 'unused',
+		email_verified_at: options.emailVerifiedAt ?? null,
+		created_at: new Date(0).toISOString(),
+		updated_at: new Date(0).toISOString(),
+	}
+	const state = {
+		verificationInserts: 0,
+		verificationDeletes: 0,
+		rateLimitAttempts: 0,
+		rateLimitMax: 3,
+	}
+
+	function createStatement(query: string) {
+		const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
+		const statement = {
+			query: normalized,
+			bind: () => statement,
+			async all() {
+				if (
+					normalized.startsWith('select') &&
+					normalized.includes('from "users"')
+				) {
+					return {
+						results: [{ ...user }],
+						meta: { changes: 0, last_row_id: 0 } satisfies StatementMeta,
+					}
+				}
+				if (normalized.includes('insert into "email_verifications"')) {
+					state.verificationInserts += 1
+					return {
+						results: [],
+						meta: { changes: 1, last_row_id: 1 } satisfies StatementMeta,
+					}
+				}
+				return {
+					results: [],
+					meta: { changes: 0, last_row_id: 0 } satisfies StatementMeta,
+				}
+			},
+			async first() {
+				const result = await statement.all()
+				return result.results[0] ?? null
+			},
+			async run() {
+				if (normalized.includes('delete from "email_verifications"')) {
+					state.verificationDeletes += 1
+				}
+				if (normalized.includes('insert into "email_verifications"')) {
+					state.verificationInserts += 1
+				}
+				return { meta: { changes: 1, last_row_id: 1 } }
+			},
+		}
+		return statement
+	}
+
+	const db = {
+		prepare: (query: string) => createStatement(query),
+		async batch(statements: Array<{ query?: string }>) {
+			if (
+				statements.some((statement) =>
+					statement.query?.includes('create table'),
+				)
+			) {
+				return statements.map(() => ({
+					meta: { changes: 0, last_row_id: 0 },
+				}))
+			}
+			state.rateLimitAttempts += 1
+			const allowed = state.rateLimitAttempts <= state.rateLimitMax
+			return [
+				{ meta: { changes: 0, last_row_id: 0 } },
+				{ meta: { changes: allowed ? 1 : 0, last_row_id: 0 } },
+			]
+		},
+		async exec() {
+			return
+		},
+	} as unknown as D1Database
+
+	return { db, state }
+}
+
+function createAppEnv(db: D1Database, overrides: Record<string, unknown> = {}) {
+	return {
+		APP_DB: db,
+		COOKIE_SECRET: testCookieSecret,
+		SENTRY_ENVIRONMENT: 'test',
+		...overrides,
+	} as unknown as Parameters<typeof createAccountResendVerificationHandler>[0]
+}
+
+async function createResendRequest(session: AuthSession) {
+	const cookie = await createAuthCookie(session, false)
+	return new Request('http://example.com/account/resend-verification.json', {
+		method: 'POST',
+		headers: { Cookie: cookie },
+	})
+}
+
+async function runHandler(
+	handler: ReturnType<typeof createAccountResendVerificationHandler>,
+	request: Request,
+) {
+	return handler.handler({
+		request,
+		url: new URL(request.url),
+		params: {},
+	} as never)
+}
+
+const session: AuthSession = {
+	id: '1',
+	email: 'resend-user@example.com',
+	rememberMe: false,
+}
+
+beforeAll(() => {
+	setAuthSessionSecret(testCookieSecret)
+})
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+test('resend verification requires an authenticated session', async () => {
+	const testDb = createResendTestDb()
+	const handler = createAccountResendVerificationHandler(
+		createAppEnv(testDb.db),
+	)
+
+	const response = await runHandler(
+		handler,
+		new Request('http://example.com/account/resend-verification.json', {
+			method: 'POST',
+		}),
+	)
+	expect(response.status).toBe(401)
+	expect(testDb.state.verificationInserts).toBe(0)
+})
+
+test('resend verification issues a fresh token for unverified accounts and rate-limits repeats', async () => {
+	const testDb = createResendTestDb({ emailVerifiedAt: null })
+	const handler = createAccountResendVerificationHandler(
+		createAppEnv(testDb.db),
+	)
+
+	for (let attempt = 1; attempt <= 3; attempt++) {
+		const response = await runHandler(
+			handler,
+			await createResendRequest(session),
+		)
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			ok: true,
+			message: 'Verification email sent. Check your inbox.',
+		})
+	}
+	expect(testDb.state.verificationInserts).toBe(3)
+	expect(testDb.state.verificationDeletes).toBe(3)
+
+	const rateLimitedResponse = await runHandler(
+		handler,
+		await createResendRequest(session),
+	)
+	expect(rateLimitedResponse.status).toBe(429)
+	expect(rateLimitedResponse.headers.get('Retry-After')).toBeTruthy()
+	expect(await rateLimitedResponse.json()).toEqual({
+		ok: false,
+		error: 'Too many verification emails requested. Please try again later.',
+	})
+	// No new token is created for rate-limited requests.
+	expect(testDb.state.verificationInserts).toBe(3)
+})
+
+test('resend verification rejects already-verified accounts', async () => {
+	const testDb = createResendTestDb({
+		emailVerifiedAt: new Date(0).toISOString(),
+	})
+	const handler = createAccountResendVerificationHandler(
+		createAppEnv(testDb.db),
+	)
+
+	const response = await runHandler(handler, await createResendRequest(session))
+	expect(response.status).toBe(400)
+	expect(await response.json()).toEqual({
+		ok: false,
+		error: 'Your email is already verified.',
+	})
+	expect(testDb.state.verificationInserts).toBe(0)
+})
+
+test('resend verification surfaces send failures without pretending success', async () => {
+	const testDb = createResendTestDb({ emailVerifiedAt: null })
+	const handler = createAccountResendVerificationHandler(
+		createAppEnv(testDb.db, {
+			CLOUDFLARE_ACCOUNT_ID: 'cf-account-test',
+			CLOUDFLARE_API_TOKEN: 'cf-token-test',
+			CLOUDFLARE_API_BASE_URL: 'https://cloudflare-api.example.com',
+		}),
+	)
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () =>
+			Response.json(
+				{ success: false, errors: [{ message: 'delivery refused' }] },
+				{ status: 500 },
+			),
+		),
+	)
+
+	const response = await runHandler(handler, await createResendRequest(session))
+	expect(response.status).toBe(502)
+	expect(await response.json()).toEqual({
+		ok: false,
+		error: 'Unable to send the verification email. Please try again later.',
+	})
+})

--- a/packages/worker/src/app/handlers/account-resend-verification.ts
+++ b/packages/worker/src/app/handlers/account-resend-verification.ts
@@ -1,0 +1,115 @@
+import { type Action } from 'remix/router'
+import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { createEmailVerification } from '#app/email-verification.ts'
+import { checkRateLimit } from '#app/rate-limit.ts'
+import { type routes } from '#app/routes.ts'
+import { type AppEnv } from '#worker/env-schema.ts'
+
+export const resendVerificationRateLimitConfig = {
+	maxRequests: 3,
+	windowSeconds: 15 * 60,
+}
+
+export function createAccountResendVerificationHandler(appEnv: AppEnv) {
+	const env = appEnv as unknown as Env
+
+	return {
+		middleware: [],
+		async handler({ request, url }) {
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+
+			const requestIp = getRequestIp(request) ?? undefined
+			if (user.emailVerified) {
+				return jsonResponse(
+					{ ok: false, error: 'Your email is already verified.' },
+					400,
+				)
+			}
+
+			const rateLimit = await checkRateLimit(
+				appEnv.APP_DB,
+				`verification-resend:user:${user.userId}`,
+				resendVerificationRateLimitConfig,
+			)
+			if (!rateLimit.allowed) {
+				void logAuditEvent({
+					category: 'auth',
+					action: 'email_verification_resend',
+					result: 'rate_limited',
+					email: user.email,
+					ip: requestIp,
+					path: url.pathname,
+				})
+				return jsonResponse(
+					{
+						ok: false,
+						error:
+							'Too many verification emails requested. Please try again later.',
+					},
+					429,
+					{ 'Retry-After': String(rateLimit.retryAfterSeconds ?? 60) },
+				)
+			}
+
+			try {
+				await createEmailVerification({
+					appEnv,
+					userId: user.userId,
+					email: user.email,
+					requestUrl: url,
+				})
+			} catch (error) {
+				console.error('Failed to resend verification email:', error)
+				void logAuditEvent({
+					category: 'auth',
+					action: 'email_verification_resend',
+					result: 'failure',
+					email: user.email,
+					ip: requestIp,
+					path: url.pathname,
+					reason: 'send_failed',
+				})
+				return jsonResponse(
+					{
+						ok: false,
+						error:
+							'Unable to send the verification email. Please try again later.',
+					},
+					502,
+				)
+			}
+
+			void logAuditEvent({
+				category: 'auth',
+				action: 'email_verification_resend',
+				result: 'success',
+				email: user.email,
+				ip: requestIp,
+				path: url.pathname,
+			})
+			return jsonResponse({
+				ok: true,
+				message: 'Verification email sent. Check your inbox.',
+			})
+		},
+	} satisfies Action<typeof routes.accountResendVerification>
+}
+
+function jsonResponse(
+	body: Record<string, unknown>,
+	status = 200,
+	extraHeaders: Record<string, string> = {},
+) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: {
+			'Cache-Control': 'no-store',
+			'Content-Type': 'application/json; charset=utf-8',
+			...extraHeaders,
+		},
+	})
+}

--- a/packages/worker/src/app/handlers/account-resend-verification.ts
+++ b/packages/worker/src/app/handlers/account-resend-verification.ts
@@ -2,7 +2,7 @@ import { type Action } from 'remix/router'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { createEmailVerification } from '#app/email-verification.ts'
-import { checkRateLimit } from '#app/rate-limit.ts'
+import { checkRateLimit, releaseRateLimit } from '#app/rate-limit.ts'
 import { type routes } from '#app/routes.ts'
 import { type AppEnv } from '#worker/env-schema.ts'
 
@@ -30,9 +30,10 @@ export function createAccountResendVerificationHandler(appEnv: AppEnv) {
 				)
 			}
 
+			const rateLimitKey = `verification-resend:user:${user.userId}`
 			const rateLimit = await checkRateLimit(
 				appEnv.APP_DB,
-				`verification-resend:user:${user.userId}`,
+				rateLimitKey,
 				resendVerificationRateLimitConfig,
 			)
 			if (!rateLimit.allowed) {
@@ -64,6 +65,11 @@ export function createAccountResendVerificationHandler(appEnv: AppEnv) {
 				})
 			} catch (error) {
 				console.error('Failed to resend verification email:', error)
+				// A failed send should not eat into the user's resend
+				// allowance; refund the slot so they can retry promptly.
+				await releaseRateLimit(appEnv.APP_DB, rateLimitKey).catch(
+					() => undefined,
+				)
 				void logAuditEvent({
 					category: 'auth',
 					action: 'email_verification_resend',

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, expect, test } from 'vitest'
+import { afterEach, beforeAll, expect, test, vi } from 'vitest'
 import { RequestContext } from 'remix/router'
 import { setAuthSessionSecret } from '#app/auth-session.ts'
 import { createAuthHandler } from '#app/handlers/auth.ts'
@@ -24,7 +24,11 @@ function createAuthRequest(
 }
 
 function createAuthTestContext(
-	options: { signupEnabled?: boolean; failRoleAssignment?: boolean } = {},
+	options: {
+		signupEnabled?: boolean
+		failRoleAssignment?: boolean
+		emailConfigured?: boolean
+	} = {},
 ) {
 	const testDb = createTestDb({
 		failRoleAssignment: options.failRoleAssignment ?? false,
@@ -42,6 +46,13 @@ function createAuthTestContext(
 			: {
 					SENTRY_ENVIRONMENT: 'production' as const,
 				}),
+		...(options.emailConfigured
+			? {
+					CLOUDFLARE_ACCOUNT_ID: 'cf-account-test',
+					CLOUDFLARE_API_TOKEN: 'cf-token-test',
+					CLOUDFLARE_API_BASE_URL: 'https://cloudflare-api.example.com',
+				}
+			: {}),
 	} as unknown as Parameters<typeof createAuthHandler>[0])
 
 	return {
@@ -294,9 +305,31 @@ beforeAll(() => {
 	setAuthSessionSecret(testCookieSecret)
 })
 
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+function stubCloudflareEmailFetch(
+	result: { ok: true } | { ok: false; message: string },
+) {
+	const fetchStub = vi.fn(async () =>
+		result.ok
+			? Response.json({ success: true, result: { message_id: 'msg-1' } })
+			: Response.json(
+					{ success: false, errors: [{ message: result.message }] },
+					{ status: 500 },
+				),
+	)
+	vi.stubGlobal('fetch', fetchStub)
+	return fetchStub
+}
+
 test('auth handler login and signup workflow', async () => {
-	const productionContext = createAuthTestContext()
+	// Production signups must actually deliver the verification email, so
+	// the production context gets a (stubbed) configured Cloudflare sender.
+	const productionContext = createAuthTestContext({ emailConfigured: true })
 	const signupContext = createAuthTestContext({ signupEnabled: true })
+	stubCloudflareEmailFetch({ ok: true })
 
 	const invalidJsonResponse = await productionContext.request('{')
 	expect(invalidJsonResponse.status).toBe(400)
@@ -473,4 +506,48 @@ test('signup fails when the default user role cannot be assigned', async () => {
 	expect(response.headers.get('Set-Cookie')).toBeNull()
 	// The created user row is rolled back so signup can be retried.
 	expect(context.testDb.users.has('roleless@example.com')).toBe(false)
+})
+
+test('signup rolls back when the verification email cannot be sent', async () => {
+	const context = createAuthTestContext({
+		signupEnabled: true,
+		emailConfigured: true,
+	})
+	stubCloudflareEmailFetch({ ok: false, message: 'delivery refused' })
+
+	const response = await context.request({
+		email: 'undeliverable@example.com',
+		username: 'undeliverable-user',
+		password: 'password123',
+		mode: 'signup',
+	})
+	expect(response.status).toBe(500)
+	expect(await response.json()).toEqual({
+		error:
+			'Unable to send the verification email. Please try signing up again.',
+	})
+	expect(response.headers.get('Set-Cookie')).toBeNull()
+	// The created user row is rolled back so signup can be retried.
+	expect(context.testDb.users.has('undeliverable@example.com')).toBe(false)
+})
+
+test('production signup fails closed when no verification email sender is configured', async () => {
+	const context = createAuthTestContext()
+	context.testDb.addInvite('PROD-NO-EMAIL')
+
+	const response = await context.request({
+		email: 'no-sender@example.com',
+		username: 'no-sender-user',
+		password: 'password123',
+		mode: 'signup',
+		inviteCode: 'prod-no-email',
+	})
+	expect(response.status).toBe(500)
+	expect(await response.json()).toEqual({
+		error:
+			'Unable to send the verification email. Please try signing up again.',
+	})
+	expect(context.testDb.users.has('no-sender@example.com')).toBe(false)
+	// The consumed invite use is released so the invite can be retried.
+	expect(context.testDb.invites.get('PROD-NO-EMAIL')?.use_count).toBe(0)
 })

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -349,7 +349,10 @@ export function createAuthHandler(appEnv: AppEnv) {
 						reason: 'email_verification_setup_failed',
 					})
 					return Response.json(
-						{ error: 'Unable to create account.' },
+						{
+							error:
+								'Unable to send the verification email. Please try signing up again.',
+						},
 						{ status: 500 },
 					)
 				}

--- a/packages/worker/src/app/rate-limit.ts
+++ b/packages/worker/src/app/rate-limit.ts
@@ -70,6 +70,24 @@ export async function checkRateLimit(
 	return { allowed: true, retryAfterSeconds: null }
 }
 
+/**
+ * Refund the most recent slot consumed for `key`. Use when the
+ * rate-limited operation itself failed, so transient downstream errors
+ * do not eat into the caller's allowance.
+ */
+export async function releaseRateLimit(db: D1Database, key: string) {
+	await ensureRateLimitTable(db)
+	await db
+		.prepare(
+			`DELETE FROM _rate_limits
+			 WHERE id = (
+				SELECT id FROM _rate_limits WHERE key = ? ORDER BY id DESC LIMIT 1
+			 )`,
+		)
+		.bind(key)
+		.run()
+}
+
 export const authRateLimitConfig: RateLimitConfig = {
 	maxRequests: 10,
 	windowSeconds: 60,

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -32,6 +32,7 @@ import {
 	createAccountPackageInvocationTokensHandler,
 } from '#app/handlers/account-package-invocation-tokens.ts'
 import { createAccountProfileApiHandler } from '#app/handlers/account-profile.ts'
+import { createAccountResendVerificationHandler } from '#app/handlers/account-resend-verification.ts'
 import {
 	createAccountRemoteConnectorsApiHandler,
 	createAccountRemoteConnectorsHandler,
@@ -111,6 +112,7 @@ export function createAppRouter(appEnv: AppEnv) {
 				createAccountPackageInvocationTokensApiHandler(env),
 			accountProfileApi: createAccountProfileApiHandler(env),
 			accountProfileApiPost: createAccountProfileApiHandler(env),
+			accountResendVerification: createAccountResendVerificationHandler(appEnv),
 			accountRemoteConnectors: createAccountRemoteConnectorsHandler(env),
 			accountRemoteConnectorsApi: createAccountRemoteConnectorsApiHandler(env),
 			accountRemoteConnectorsApiPost:

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -28,6 +28,7 @@ export const routes = route({
 	accountSecretsApiPost: post('/account/secrets.json'),
 	accountProfileApi: '/account/profile.json',
 	accountProfileApiPost: post('/account/profile.json'),
+	accountResendVerification: post('/account/resend-verification.json'),
 	accountExport: '/account/export.json',
 	admin: '/admin',
 	adminUsers: '/admin/users',

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -64,6 +64,11 @@ export async function handleInboundEmail(
 	}
 
 	const userId = inboxAddress.userId
+	// Inbox rows only store the stable user id, so this uses the stable-id
+	// scan inside `isAccountEmailVerified` (same pattern as outbound send).
+	// Cost is O(users) hashing per inbound message; if user counts grow
+	// enough to matter, add an indexed stable-id column on `users` instead
+	// of weakening this fail-closed check.
 	const accountEmailVerified = await isAccountEmailVerified({
 		db: env.APP_DB,
 		stableUserId: userId,

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -1,3 +1,4 @@
+import { isAccountEmailVerified } from '#app/email-verification.ts'
 import {
 	findReplyTokenHash,
 	normalizeEmailAddress,
@@ -63,6 +64,28 @@ export async function handleInboundEmail(
 	}
 
 	const userId = inboxAddress.userId
+	const accountEmailVerified = await isAccountEmailVerified({
+		db: env.APP_DB,
+		stableUserId: userId,
+	})
+	if (!accountEmailVerified) {
+		const reason = 'Account email is not verified.'
+		message.setReject(reason)
+		await insertEmailDeliveryEvent({
+			db: env.APP_DB,
+			userId,
+			inboxId: inbox.id,
+			eventType: 'rejected',
+			provider: 'cloudflare-email-routing',
+			detail: {
+				recipient,
+				reason,
+				phase: 'account-verification',
+			},
+		}).catch(() => undefined)
+		return
+	}
+
 	let parsed: Awaited<ReturnType<typeof parseForwardableEmailMessage>>
 	try {
 		parsed = await parseForwardableEmailMessage(message)

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -20,10 +20,11 @@ import { ensureEmailTestSchema } from './test-schema.ts'
 import { buildPublishedSourceManifestSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 
-async function seedVerifiedAccount(input: {
+async function seedAccount(input: {
 	db: D1Database
 	email: string
 	username: string
+	emailVerifiedAt?: string | null
 }) {
 	await input.db
 		.prepare(
@@ -51,9 +52,19 @@ async function seedVerifiedAccount(input: {
 			input.username,
 			input.email,
 			'test-password-hash',
-			new Date().toISOString(),
+			input.emailVerifiedAt === undefined
+				? new Date().toISOString()
+				: input.emailVerifiedAt,
 		)
 		.run()
+}
+
+async function seedVerifiedAccount(input: {
+	db: D1Database
+	email: string
+	username: string
+}) {
+	await seedAccount(input)
 }
 
 function createForwardableEmailMessage(input: {
@@ -90,7 +101,13 @@ function createForwardableEmailMessage(input: {
 
 test('inbound email handler stores all routed inbound messages', async () => {
 	await ensureEmailTestSchema(env.APP_DB)
-	const userId = `email-user-${crypto.randomUUID()}`
+	const accountEmail = `email-user-${crypto.randomUUID()}@example.com`
+	await seedVerifiedAccount({
+		db: env.APP_DB,
+		email: accountEmail,
+		username: `email-user-${crypto.randomUUID()}`,
+	})
+	const userId = await createStableUserIdFromEmail(accountEmail)
 	const address = requireNormalizedEmailAddress(
 		`support-${crypto.randomUUID()}@example.com`,
 	)
@@ -209,7 +226,13 @@ test('inbound email handler rejects unknown aliases and malformed messages witho
 	})
 	expect(unknownAliasMessages).toEqual([])
 
-	const userId = `email-parse-user-${crypto.randomUUID()}`
+	const accountEmail = `email-parse-user-${crypto.randomUUID()}@example.com`
+	await seedVerifiedAccount({
+		db: env.APP_DB,
+		email: accountEmail,
+		username: `email-parse-user-${crypto.randomUUID()}`,
+	})
+	const userId = await createStableUserIdFromEmail(accountEmail)
 	const address = requireNormalizedEmailAddress(
 		`parse-${crypto.randomUUID()}@example.com`,
 	)
@@ -246,6 +269,69 @@ test('inbound email handler rejects unknown aliases and malformed messages witho
 		limit: 10,
 	})
 	expect(malformedMessages).toEqual([])
+})
+
+test('inbound email handler rejects mail for unverified accounts', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const accountEmail = `email-unverified-${crypto.randomUUID()}@example.com`
+	await seedAccount({
+		db: env.APP_DB,
+		email: accountEmail,
+		username: `email-unverified-${crypto.randomUUID()}`,
+		emailVerifiedAt: null,
+	})
+	const userId = await createStableUserIdFromEmail(accountEmail)
+	const address = requireNormalizedEmailAddress(
+		`unverified-${crypto.randomUUID()}@example.com`,
+	)
+	const inbox = await createEmailInbox({
+		db: env.APP_DB,
+		userId,
+		name: 'Unverified',
+		description: 'Unverified account inbox',
+	})
+	await createEmailInboxAddress({
+		db: env.APP_DB,
+		inboxId: inbox.id,
+		userId,
+		address,
+		localPart: getEmailLocalPart(address),
+		domain: getEmailDomain(address),
+	})
+
+	const message = createForwardableEmailMessage({
+		from: 'stranger@example.net',
+		to: address,
+		raw: [
+			'From: Stranger <stranger@example.net>',
+			`To: ${address}`,
+			'Subject: Should be rejected',
+			'Message-ID: <rejected@example.net>',
+			'',
+			'Please help.',
+		].join('\r\n'),
+	})
+	await handleInboundEmail(message, env)
+
+	expect(message.rejectedReason).toBe('Account email is not verified.')
+	const messages = await listEmailMessages({
+		db: env.APP_DB,
+		userId,
+		inboxId: inbox.id,
+		limit: 10,
+	})
+	expect(messages).toEqual([])
+	const events = await env.APP_DB.prepare(
+		`SELECT event_type, detail_json FROM email_delivery_events WHERE user_id = ?`,
+	)
+		.bind(userId)
+		.all<{ event_type: string; detail_json: string }>()
+	expect(events.results).toHaveLength(1)
+	expect(events.results?.[0]?.event_type).toBe('rejected')
+	expect(JSON.parse(events.results?.[0]?.detail_json ?? '{}')).toMatchObject({
+		reason: 'Account email is not verified.',
+		phase: 'account-verification',
+	})
 })
 
 test('getEmailAttachmentById reconstructs unnamed attachments from raw MIME', async () => {

--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -3,6 +3,7 @@ import {
 	type TokenSummary,
 } from '@cloudflare/workers-oauth-provider'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
+import { isAccountEmailVerified } from '#app/email-verification.ts'
 import { buildMcpUserContextFromGrantProps } from './mcp-auth-user-context.ts'
 import { createMcpCallerContext, type McpServerProps } from './mcp/context.ts'
 import { oauthScopes } from './oauth-handlers.ts'
@@ -65,6 +66,18 @@ function createUnauthorizedResponse(origin: string) {
 	})
 }
 
+export function createEmailVerificationRequiredResponse(origin: string) {
+	return Response.json(
+		{
+			error: 'email_verification_required',
+			error_description:
+				'Your account email address is not verified, so MCP access is disabled. ' +
+				`Open the verification link sent to your email, or resend it from ${origin}/account.`,
+		},
+		{ status: 403 },
+	)
+}
+
 function audienceMatches(
 	audience: string | Array<string> | undefined,
 	origin: string,
@@ -114,13 +127,28 @@ export async function handleMcpRequest({
 	const context = ctx as OAuthExecutionContext
 	const grantProps = tokenSummary.grant.props ?? null
 	const mcpUser = await buildMcpUserContextFromGrantProps(env, grantProps)
-	const remoteConnectors =
-		mcpUser && typeof mcpUser.userId === 'string'
-			? await listAttachedRemoteConnectorRefs({
-					env,
-					userId: mcpUser.userId,
-				})
-			: null
+
+	// Fail-closed email verification gate: every MCP request must map to an
+	// account whose email is verified. Tokens without an identifiable user
+	// are rejected too, since verification cannot be established for them.
+	// A D1 failure inside `isAccountEmailVerified` propagates as an error
+	// instead of silently allowing access.
+	if (!mcpUser) {
+		return createEmailVerificationRequiredResponse(origin)
+	}
+	const emailVerified = await isAccountEmailVerified({
+		db: env.APP_DB,
+		email: mcpUser.email,
+		stableUserId: mcpUser.userId,
+	})
+	if (!emailVerified) {
+		return createEmailVerificationRequiredResponse(origin)
+	}
+
+	const remoteConnectors = await listAttachedRemoteConnectorRefs({
+		env,
+		userId: mcpUser.userId,
+	})
 	const props: OAuthContextProps = createMcpCallerContext({
 		baseUrl: origin,
 		user: mcpUser,

--- a/packages/worker/src/mcp-auth.workers.test.ts
+++ b/packages/worker/src/mcp-auth.workers.test.ts
@@ -11,6 +11,7 @@ import {
 	protectedResourceMetadataPath,
 } from './mcp-auth.ts'
 import { oauthScopes } from './oauth-handlers.ts'
+import { createStableUserIdFromEmail } from './user-id.ts'
 
 function expectAuthenticateHeader(
 	header: string,
@@ -50,15 +51,55 @@ function createHelpers(overrides: Partial<OAuthHelpers> = {}): OAuthHelpers {
 	}
 }
 
-function createEnv(helpers: OAuthHelpers, overrides: Partial<Env> = {}) {
+type MockDbOptions = {
+	// Row returned for the `email_verified_at` lookup keyed by account email.
+	emailVerifiedAt?: string | null
+	// Rows returned for the full `users` table scan (stable-user-id fallback).
+	userRows?: Array<{ email: string; email_verified_at: string | null }>
+	// Rows returned for remote connector settings queries.
+	connectorRows?: Array<Record<string, unknown>>
+}
+
+function createMockDb(options: MockDbOptions = {}) {
+	const statementFor = (query: string) => {
+		const statement = {
+			bind: () => statement,
+			async all() {
+				if (/from\s+"?users"?/i.test(query)) {
+					return {
+						results: options.userRows ?? [],
+						meta: { changes: 0 },
+					}
+				}
+				return {
+					results: options.connectorRows ?? [],
+					meta: { changes: 0 },
+				}
+			},
+			async first() {
+				if (query.includes('email_verified_at')) {
+					return options.emailVerifiedAt === undefined
+						? null
+						: { email_verified_at: options.emailVerifiedAt }
+				}
+				const result = await statement.all()
+				return result.results[0] ?? null
+			},
+		}
+		return statement
+	}
 	return {
-		APP_DB: {
-			prepare: () => ({
-				bind: () => ({
-					all: async () => ({ results: [], meta: { changes: 0 } }),
-				}),
-			}),
-		} as unknown as D1Database,
+		prepare: (query: string) => statementFor(query),
+	} as unknown as D1Database
+}
+
+function createEnv(
+	helpers: OAuthHelpers,
+	overrides: Partial<Env> = {},
+	dbOptions: MockDbOptions = {},
+) {
+	return {
+		APP_DB: createMockDb(dbOptions),
 		OAUTH_PROVIDER: helpers,
 		...overrides,
 	} as unknown as Env
@@ -139,12 +180,15 @@ test('mcp request enforces token audience and forwards caller props', async () =
 		grant: {
 			clientId: 'client',
 			scope: oauthScopes,
-			props: { userId: 'user' },
+			props: { userId: 'user', email: 'user@example.com' },
 		},
 	}
 	const validToken: TokenSummary = {
 		...tokenWithoutAudience,
 		audience: `https://example.com${mcpResourcePath}`,
+	}
+	const verifiedDb: MockDbOptions = {
+		emailVerifiedAt: new Date(0).toISOString(),
 	}
 
 	const invalidResponse = await handleMcpRequest({
@@ -178,6 +222,8 @@ test('mcp request enforces token audience and forwards caller props', async () =
 			createHelpers({
 				unwrapToken: async () => validToken,
 			}),
+			{},
+			verifiedDb,
 		),
 		ctx: createContext(),
 		fetchMcp: (_request, _env, ctx) => {
@@ -193,34 +239,28 @@ test('mcp request enforces token audience and forwards caller props', async () =
 		user: { userId: 'user' },
 	})
 
-	const appDbWithConnector = {
-		prepare: () => ({
-			bind: () => ({
-				all: async () => ({
-					results: [
-						{
-							id: 'connector-1',
-							user_id: 'user',
-							instance_id: 'home',
-							enabled: 1,
-							attached: 1,
-							encrypted_shared_secret: 'encrypted',
-							created_at: new Date(0).toISOString(),
-							updated_at: new Date(0).toISOString(),
-						},
-					],
-					meta: { changes: 0 },
-				}),
-			}),
-		}),
-	} as unknown as D1Database
 	const withConnectorResponse = await handleMcpRequest({
 		request,
 		env: createEnv(
 			createHelpers({
 				unwrapToken: async () => validToken,
 			}),
-			{ APP_DB: appDbWithConnector },
+			{},
+			{
+				...verifiedDb,
+				connectorRows: [
+					{
+						id: 'connector-1',
+						user_id: 'user',
+						instance_id: 'home',
+						enabled: 1,
+						attached: 1,
+						encrypted_shared_secret: 'encrypted',
+						created_at: new Date(0).toISOString(),
+						updated_at: new Date(0).toISOString(),
+					},
+				],
+			},
 		),
 		ctx: createContext(),
 		fetchMcp: (_request, _env, ctx) => {
@@ -254,4 +294,104 @@ test('mcp request enforces token audience and forwards caller props', async () =
 			},
 		}),
 	).rejects.toThrow('D1 unavailable')
+})
+
+test('mcp request rejects unverified and unidentifiable accounts fail-closed', async () => {
+	const request = new Request(`https://example.com${mcpResourcePath}`, {
+		headers: { Authorization: 'Bearer token' },
+	})
+	function createToken(props: Record<string, unknown>): TokenSummary {
+		return {
+			id: 'token',
+			grantId: 'grant',
+			userId: 'user',
+			createdAt: 0,
+			expiresAt: 999999,
+			audience: `https://example.com${mcpResourcePath}`,
+			grant: {
+				clientId: 'client',
+				scope: oauthScopes,
+				props,
+			},
+		}
+	}
+
+	let fetchMcpCalled = false
+	const fetchMcp = () => {
+		fetchMcpCalled = true
+		return new Response('ok')
+	}
+
+	// Account exists but email_verified_at is null.
+	const unverifiedResponse = await handleMcpRequest({
+		request,
+		env: createEnv(
+			createHelpers({
+				unwrapToken: async () =>
+					createToken({ userId: 'user', email: 'user@example.com' }),
+			}),
+			{},
+			{ emailVerifiedAt: null },
+		),
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(unverifiedResponse.status).toBe(403)
+	expect(await unverifiedResponse.json()).toMatchObject({
+		error: 'email_verification_required',
+		error_description: expect.stringContaining('/account'),
+	})
+
+	// No matching account row at all.
+	const unknownAccountResponse = await handleMcpRequest({
+		request,
+		env: createEnv(
+			createHelpers({
+				unwrapToken: async () =>
+					createToken({ userId: 'user', email: 'user@example.com' }),
+			}),
+		),
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(unknownAccountResponse.status).toBe(403)
+
+	// Grant props without an identifiable user.
+	const noUserResponse = await handleMcpRequest({
+		request,
+		env: createEnv(
+			createHelpers({
+				unwrapToken: async () => createToken({}),
+			}),
+		),
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(noUserResponse.status).toBe(403)
+	expect(fetchMcpCalled).toBe(false)
+
+	// Stable-user-id fallback verifies accounts when grant props lack email.
+	const fallbackEmail = 'fallback@example.com'
+	const stableUserId = await createStableUserIdFromEmail(fallbackEmail)
+	const fallbackResponse = await handleMcpRequest({
+		request,
+		env: createEnv(
+			createHelpers({
+				unwrapToken: async () => createToken({ userId: stableUserId }),
+			}),
+			{},
+			{
+				userRows: [
+					{
+						email: fallbackEmail,
+						email_verified_at: new Date(0).toISOString(),
+					},
+				],
+			},
+		),
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(fallbackResponse.status).toBe(200)
+	expect(fetchMcpCalled).toBe(true)
 })

--- a/packages/worker/src/mcp/capabilities/email/email-attachment-get.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-attachment-get.node.test.ts
@@ -13,6 +13,16 @@ const { emailAttachmentGetCapability } =
 	await import('./email-attachment-get.ts')
 const { createMcpCallerContext } = await import('#mcp/context.ts')
 
+function createUsersDb(emailVerifiedAt: string | null) {
+	return {
+		prepare: () => ({
+			bind: () => ({
+				first: async () => ({ email_verified_at: emailVerifiedAt }),
+			}),
+		}),
+	} as unknown as D1Database
+}
+
 test('email capabilities require a signed-in user and return attachment content or reject missing ids', async () => {
 	await expect(
 		emailAttachmentGetCapability.handler(
@@ -34,7 +44,19 @@ test('email capabilities require a signed-in user and return attachment content 
 			displayName: 'User Example',
 		},
 	})
-	const env = { APP_DB: {} } as Env
+	const verifiedDb = createUsersDb('2026-01-01T00:00:00.000Z')
+	const env = { APP_DB: verifiedDb } as Env
+
+	await expect(
+		emailAttachmentGetCapability.handler(
+			{ attachment_id: 'attachment-1' },
+			{
+				env: { APP_DB: createUsersDb(null) } as Env,
+				callerContext,
+			},
+		),
+	).rejects.toThrow(/Account email is not verified/)
+	expect(mockModule.getEmailAttachmentById).not.toHaveBeenCalled()
 
 	mockModule.getEmailAttachmentById.mockResolvedValueOnce({
 		id: 'attachment-1',
@@ -56,7 +78,7 @@ test('email capabilities require a signed-in user and return attachment content 
 	)
 
 	expect(mockModule.getEmailAttachmentById).toHaveBeenCalledWith({
-		db: {},
+		db: verifiedDb,
 		userId: 'user-1',
 		attachmentId: 'attachment-1',
 	})

--- a/packages/worker/src/mcp/capabilities/email/email-attachment-get.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-attachment-get.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { requireVerifiedEmailAccountUser } from './require-verified-user.ts'
 import { getEmailAttachmentById } from '#worker/email/repo.ts'
 
 const emailAttachmentContentSchema = z.object({
@@ -30,7 +30,7 @@ export const emailAttachmentGetCapability = defineDomainCapability(
 		}),
 		outputSchema: emailAttachmentContentSchema,
 		async handler(args, ctx) {
-			const user = requireMcpUser(ctx.callerContext)
+			const user = await requireVerifiedEmailAccountUser(ctx)
 			const attachment = await getEmailAttachmentById({
 				db: ctx.env.APP_DB,
 				userId: user.userId,

--- a/packages/worker/src/mcp/capabilities/email/email-inbox-create.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-inbox-create.ts
@@ -9,7 +9,7 @@ import {
 import { createEmailInboxWithAddress } from '#worker/email/repo.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { requireVerifiedEmailAccountUser } from './require-verified-user.ts'
 import { emailInboxCreateOutputSchema } from './shared.ts'
 
 export const emailInboxCreateCapability = defineDomainCapability(
@@ -29,7 +29,7 @@ export const emailInboxCreateCapability = defineDomainCapability(
 		}),
 		outputSchema: emailInboxCreateOutputSchema,
 		async handler(args, ctx) {
-			const user = requireMcpUser(ctx.callerContext)
+			const user = await requireVerifiedEmailAccountUser(ctx)
 			const address = requireNormalizedEmailAddress(
 				args.address,
 				'Inbox address',

--- a/packages/worker/src/mcp/capabilities/email/email-inbox-list.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-inbox-list.ts
@@ -1,6 +1,6 @@
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { requireVerifiedEmailAccountUser } from './require-verified-user.ts'
 import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
 import {
 	listEmailInboxAddressesForUser,
@@ -21,7 +21,7 @@ export const emailInboxListCapability = defineDomainCapability(
 		inputSchema: emptyCapabilityInputSchema,
 		outputSchema: emailInboxListSchema,
 		async handler(_args, ctx) {
-			const user = requireMcpUser(ctx.callerContext)
+			const user = await requireVerifiedEmailAccountUser(ctx)
 			const [inboxes, addresses] = await Promise.all([
 				listEmailInboxesForUser({ db: ctx.env.APP_DB, userId: user.userId }),
 				listEmailInboxAddressesForUser({

--- a/packages/worker/src/mcp/capabilities/email/email-message-get.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-message-get.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { requireVerifiedEmailAccountUser } from './require-verified-user.ts'
 import {
 	getEmailMessageById,
 	listEmailAttachmentsForMessage,
@@ -23,7 +23,7 @@ export const emailMessageGetCapability = defineDomainCapability(
 		}),
 		outputSchema: emailMessageDetailSchema,
 		async handler(args, ctx) {
-			const user = requireMcpUser(ctx.callerContext)
+			const user = await requireVerifiedEmailAccountUser(ctx)
 			const message = await getEmailMessageById({
 				db: ctx.env.APP_DB,
 				userId: user.userId,

--- a/packages/worker/src/mcp/capabilities/email/email-message-list.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-message-list.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { requireVerifiedEmailAccountUser } from './require-verified-user.ts'
 import { listEmailMessages } from '#worker/email/repo.ts'
 import { emailMessageSummarySchema, toMessageSummary } from './shared.ts'
 
@@ -25,7 +25,7 @@ export const emailMessageListCapability = defineDomainCapability(
 			messages: z.array(emailMessageSummarySchema),
 		}),
 		async handler(args, ctx) {
-			const user = requireMcpUser(ctx.callerContext)
+			const user = await requireVerifiedEmailAccountUser(ctx)
 			const messages = await listEmailMessages({
 				db: ctx.env.APP_DB,
 				userId: user.userId,

--- a/packages/worker/src/mcp/capabilities/email/email-reply.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-reply.node.test.ts
@@ -16,9 +16,25 @@ vi.mock('#worker/email/outbound.ts', () => ({
 
 const { emailReplyCapability } = await import('./email-reply.ts')
 
-function createContext() {
+function createUsersDb(emailVerifiedAt: string | null) {
 	return {
-		env: {} as Env,
+		prepare: () => ({
+			bind: () => ({
+				first: async () => ({ email_verified_at: emailVerifiedAt }),
+			}),
+		}),
+	} as unknown as D1Database
+}
+
+function createContext(options: { emailVerifiedAt?: string | null } = {}) {
+	return {
+		env: {
+			APP_DB: createUsersDb(
+				options.emailVerifiedAt === undefined
+					? '2026-01-01T00:00:00.000Z'
+					: options.emailVerifiedAt,
+			),
+		} as Env,
 		callerContext: createMcpCallerContext({
 			baseUrl: 'https://example.com',
 			user: {
@@ -29,6 +45,20 @@ function createContext() {
 		}),
 	}
 }
+
+test('email_reply is rejected for unverified accounts', async () => {
+	await expect(
+		emailReplyCapability.handler(
+			{
+				message_id: 'inbound-1',
+				from: 'kody@heykody.dev',
+				text: 'Reply body',
+			},
+			createContext({ emailVerifiedAt: null }),
+		),
+	).rejects.toThrow(/Account email is not verified/)
+	expect(mocks.sendOutboundEmail).not.toHaveBeenCalled()
+})
 
 test('email_reply throws when provider delivery is persisted as failed', async () => {
 	mocks.getEmailMessageById.mockResolvedValue({

--- a/packages/worker/src/mcp/capabilities/email/email-reply.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-reply.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { requireVerifiedEmailAccountUser } from './require-verified-user.ts'
 import { sendOutboundEmail } from '#worker/email/outbound.ts'
 import { getEmailMessageById } from '#worker/email/repo.ts'
 import {
@@ -33,7 +33,7 @@ export const emailReplyCapability = defineDomainCapability(
 			}),
 		outputSchema: emailMessageSummarySchema,
 		async handler(args, ctx) {
-			const user = requireMcpUser(ctx.callerContext)
+			const user = await requireVerifiedEmailAccountUser(ctx)
 			const original = await getEmailMessageById({
 				db: ctx.env.APP_DB,
 				userId: user.userId,

--- a/packages/worker/src/mcp/capabilities/email/email-send.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-send.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { requireVerifiedEmailAccountUser } from './require-verified-user.ts'
 import { sendOutboundEmail } from '#worker/email/outbound.ts'
 import { emailMessageSummarySchema, toMessageSummary } from './shared.ts'
 
@@ -37,7 +37,7 @@ export const emailSendCapability = defineDomainCapability(
 			error: z.string().nullable(),
 		}),
 		async handler(args, ctx) {
-			const user = requireMcpUser(ctx.callerContext)
+			const user = await requireVerifiedEmailAccountUser(ctx)
 			const result = await sendOutboundEmail({
 				env: ctx.env,
 				userId: user.userId,

--- a/packages/worker/src/mcp/capabilities/email/email-sender-identity-verify.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-sender-identity-verify.ts
@@ -6,7 +6,7 @@ import {
 import { upsertEmailSenderIdentity } from '#worker/email/repo.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { requireVerifiedEmailAccountUser } from './require-verified-user.ts'
 
 const emailSenderIdentityVerifyOutputSchema = z.object({
 	identity_id: z.string(),
@@ -27,7 +27,7 @@ export const emailSenderIdentityVerifyCapability = defineDomainCapability(
 		}),
 		outputSchema: emailSenderIdentityVerifyOutputSchema,
 		async handler(args, ctx) {
-			const user = requireMcpUser(ctx.callerContext)
+			const user = await requireVerifiedEmailAccountUser(ctx)
 			const email = requireNormalizedEmailAddress(args.email)
 			const identity = await upsertEmailSenderIdentity({
 				db: ctx.env.APP_DB,

--- a/packages/worker/src/mcp/capabilities/email/require-verified-user.ts
+++ b/packages/worker/src/mcp/capabilities/email/require-verified-user.ts
@@ -1,0 +1,25 @@
+import {
+	emailVerificationRequiredMessage,
+	isAccountEmailVerified,
+} from '#app/email-verification.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+
+/**
+ * Defense-in-depth for the email domain: even though `/mcp` already rejects
+ * unverified accounts centrally, every email capability re-checks
+ * `users.email_verified_at` so email access stays gated on paths that do not
+ * go through `handleMcpRequest` (execute runtime, jobs, future callers).
+ */
+export async function requireVerifiedEmailAccountUser(ctx: CapabilityContext) {
+	const user = requireMcpUser(ctx.callerContext)
+	const verified = await isAccountEmailVerified({
+		db: ctx.env.APP_DB,
+		email: user.email,
+		stableUserId: user.userId,
+	})
+	if (!verified) {
+		throw new Error(emailVerificationRequiredMessage)
+	}
+	return user
+}

--- a/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/mcp-server.mcp-e2e.test.ts
@@ -34,7 +34,9 @@ test('mcp endpoint requires OAuth bearer auth', async () => {
 test('authenticated MCP smoke returns same-origin inline UI sessions', async () => {
 	await using database = await createTestDatabase()
 	await using server = await startDevServer(database.persistDir)
-	await using mcpClient = await createMcpClient(server.origin, database.user)
+	await using mcpClient = await createMcpClient(server.origin, database.user, {
+		persistDir: database.persistDir,
+	})
 
 	const inlineUiResult = await mcpClient.client.callTool({
 		name: 'open_generated_ui',
@@ -67,7 +69,11 @@ test('authenticated MCP search shows admin capabilities only to admin users', as
 		username: 'jane',
 		password: 'ilikecode',
 	}
-	await using regularClient = await createMcpClient(server.origin, regularUser)
+	await using regularClient = await createMcpClient(
+		server.origin,
+		regularUser,
+		{ persistDir: database.persistDir },
+	)
 
 	const regularSearch = await regularClient.client.callTool({
 		name: 'search',
@@ -89,6 +95,7 @@ test('authenticated MCP search shows admin capabilities only to admin users', as
 	await using bootstrapClient = await createMcpClient(
 		server.origin,
 		database.user,
+		{ persistDir: database.persistDir },
 	)
 	void bootstrapClient
 	await assignRoleInMcpTestDatabase({
@@ -96,7 +103,11 @@ test('authenticated MCP search shows admin capabilities only to admin users', as
 		email: database.user.email,
 		role: 'admin',
 	})
-	await using adminClient = await createMcpClient(server.origin, database.user)
+	await using adminClient = await createMcpClient(
+		server.origin,
+		database.user,
+		{ persistDir: database.persistDir },
+	)
 
 	const adminSearch = await adminClient.client.callTool({
 		name: 'search',

--- a/tools/mcp-test-support.ts
+++ b/tools/mcp-test-support.ts
@@ -174,6 +174,50 @@ export async function startDevServer(persistDir: string) {
 	)
 }
 
+export async function markEmailVerifiedInMcpTestDatabase(input: {
+	persistDir: string
+	email: string
+}) {
+	const sql = `
+UPDATE users
+SET email_verified_at = CURRENT_TIMESTAMP,
+    updated_at = CURRENT_TIMESTAMP
+WHERE email = ${quoteSql(input.email)};`.trim()
+	const proc = spawnProcess({
+		cmd: [
+			nodeBin,
+			'--env-file=packages/worker/.env',
+			'./wrangler-env.ts',
+			'd1',
+			'execute',
+			'APP_DB',
+			'--local',
+			'--persist-to',
+			input.persistDir,
+			'--command',
+			sql,
+		],
+		cwd: projectRoot,
+		env: {
+			...process.env,
+			CLOUDFLARE_ENV: 'test',
+		},
+	})
+	const getStdout = captureOutput(proc.stdout)
+	const getStderr = captureOutput(proc.stderr)
+	const exitCode = await proc.exited
+	if (exitCode === 0) return
+	throw new Error(
+		[
+			`Failed to mark MCP test user email verified (exit ${String(exitCode)}).`,
+			getStdout(),
+			getStderr(),
+		]
+			.filter(Boolean)
+			.join('\n\n'),
+	)
+}
+
 export async function assignRoleInMcpTestDatabase(input: {
 	persistDir: string
 	email: string
@@ -255,9 +299,19 @@ async function loginToApp(origin: string, user: TestUser) {
 export async function createMcpClient(
 	origin: string,
 	user: TestUser,
-	extraHeaders?: Record<string, string>,
+	options: {
+		// `/mcp` rejects unverified accounts, so the test user's email is
+		// marked verified in the local D1 database before connecting.
+		persistDir: string
+		extraHeaders?: Record<string, string>
+	},
 ) {
+	const extraHeaders = options.extraHeaders
 	const cookieHeader = await loginToApp(origin, user)
+	await markEmailVerifiedInMcpTestDatabase({
+		persistDir: options.persistDir,
+		email: user.email,
+	})
 	const clientRegistration = await registerOAuthClient(origin)
 	const code = await authorizeOAuthClient(
 		origin,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens account email verification so an unverified account can no longer use the assistant. Previously only outbound email was gated; unverified users could still use MCP and receive inbound mail.

- **Signup fails closed when the verification email cannot be sent.** `createEmailVerification` now inspects the Cloudflare send result and throws on failure, which triggers the existing signup rollback (user row deleted, invite use released) instead of `console.warn`. The only tolerated skip is a non-production runtime (`isNonProductionRuntime`) with no configured sender, where accounts are verified through seeded tokens.
- **Resend verification email.** New authenticated `POST /account/resend-verification.json` reuses `createEmailVerification`, rate-limited to 3 requests / 15 minutes per user, with audit events. The `/account` unverified card gains a "Resend verification email" button and updated copy. A failed resend refunds the rate-limit slot and never rotates away a previously delivered token (the new token is inserted first; older tokens are retired only after the send succeeds, best-effort).
- **MCP blocked until verified.** `handleMcpRequest` (`packages/worker/src/mcp-auth.ts`) is the single fail-closed chokepoint for `/mcp`: after token validation it checks `users.email_verified_at` (by account email, with the stable-user-id scan as fallback) and rejects unverified — or unidentifiable — accounts with a `403 email_verification_required` JSON response pointing at `/account`. OAuth authorize/token exchange keep working so clients can finish login.
- **Email features blocked until verified.** `handleInboundEmail` rejects routed mail for unverified accounts right after inbox lookup (`setReject` + a `rejected` email delivery event; nothing stored). Every email-domain capability calls a new shared `requireVerifiedEmailAccountUser` helper as defense-in-depth for callers that bypass `/mcp` (execute runtime, package jobs), on top of the existing outbound check in `sendOutboundEmail`. The checks are self-contained in the inbound handler and a new helper file, so they merge cleanly with parallel inbox/username-routing work.
- **Docs** updated: `docs/contributing/architecture/authentication.md`, `docs/use/email-primitives.md`, `docs/use/troubleshooting.md`.

## Testing

- `npm run validate` fully green (format, lint, typecheck, 544 unit tests, Playwright E2E, MCP E2E).
- New tests: resend endpoint (auth, happy path, already-verified, rate limit, send failure with slot refund), signup rollback on send failure, production fail-closed signup without a sender, MCP gate (unverified 403, unknown account 403, no-user grant 403, stable-id fallback 200), inbound rejection with delivery event, email capability rejection for unverified accounts.
- MCP E2E test support now marks test users verified in local D1 before connecting; the invite-signup Playwright spec exercises the resend button end to end.
- Manual end-to-end check against `npm run dev`: OAuth flow as a fresh unverified user → `/mcp` returns the 403 `email_verification_required` body; after setting `email_verified_at` the same token initializes normally. Resend endpoint returns success ×3 then 429, and 401 unauthenticated.

<a href="https://cursor.com/agents/bc-999559c9-fbef-4c3d-8a27-f3ab2e2e7eb9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsignup_unverified_account_resend_verification_email.mp4"><img src="https://cursor.com/artifacts/c/art-b8e6001f-cb10-48e4-b339-481084af4626" alt="signup_unverified_account_resend_verification_email.mp4" /></a>

![Account page resend verification success](https://cursor.com/artifacts/c/art-47f585d0-f0b8-43d9-802a-c77d87fa8c3b)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `c7ca6c69` · **Head:** `8cfbd76a`

**Classification:** extends — no new primitives; the auth, MCP-auth, and email primitives gain a verified-email contract.

### Primitives touched

| Primitive      | Group     | Impact                                                                                                |
| -------------- | --------- | ----------------------------------------------------------------------------------------------------- |
| `app-sessions` | auth      | extends — signup fails closed on unsent verification email; new resend endpoint + per-user rate limit |
| `mcp-oauth`    | auth      | extends — `/mcp` rejects unverified/unidentifiable accounts with `403 email_verification_required`    |
| `email`        | assistant | extends — inbound mail rejected for unverified accounts; all email capabilities require verification  |
| `app-ui`       | surfaces  | composes — `/account` resend button and route wiring                                                  |

### System map

```mermaid
flowchart LR
	appUi["app-ui"]:::touched
	appSessions["app-sessions"]:::extended
	mcpOauth["mcp-oauth"]:::extended
	mcpServer["mcp-server"]:::untouched
	email["email"]:::extended
	capabilityRegistry["capability-registry"]:::untouched
	d1AppDb["d1-app-db"]:::untouched
	appUi --> appSessions --> d1AppDb
	mcpOauth --> mcpServer --> capabilityRegistry --> email
	mcpOauth --> d1AppDb
	email --> d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Client as MCP client
	participant Gate as handleMcpRequest
	participant D1 as users.email_verified_at
	Client->>Gate: Bearer token + /mcp request
	Gate->>D1: isAccountEmailVerified(email | stableUserId)
	alt verified
		Gate->>Client: forward to MCP server
	else unverified / unknown
		Gate->>Client: 403 email_verification_required (resend at /account)
	end
```

### Invariants

Per-user isolation unchanged: all new lookups are keyed by the account email or stable user id of the requesting user; the gate only ever reads the caller's own `users` row state.

### Plan vs actual

Shipped as planned, plus two review-driven hardenings: a failed resend no longer rotates away previously delivered verification tokens (new token inserted first, older tokens retired only after a successful send, cleanup best-effort), and a failed send refunds the consumed resend rate-limit slot.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-999559c9-fbef-4c3d-8a27-f3ab2e2e7eb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-999559c9-fbef-4c3d-8a27-f3ab2e2e7eb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

