### PR TITLE
Handle OAuth provider and authorize route exceptions

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -393,6 +393,57 @@ function addOAuthDiscoveryCorsHeaders(
 	})
 }
 
+function isOAuthProviderOwnedPath(pathname: string) {
+	return (
+		pathname === oauthPaths.token ||
+		pathname === oauthPaths.register ||
+		pathname === '/.well-known/oauth-authorization-server' ||
+		pathname === protectedResourceMetadataPath ||
+		pathname.startsWith(`${protectedResourceMetadataPath}/`) ||
+		pathname.startsWith(oauthPaths.apiPrefix)
+	)
+}
+
+function isMalformedOAuthClientException(error: unknown, pathname: string) {
+	const message = error instanceof Error ? error.message : ''
+	return (
+		pathname === oauthPaths.token &&
+		message.includes("Cannot read properties of undefined (reading 'some')")
+	)
+}
+
+function createOAuthProviderExceptionResponse(
+	error: unknown,
+	pathname: string,
+) {
+	const headers = {
+		'Cache-Control': 'no-store',
+		'Content-Type': 'application/json',
+	}
+	if (isMalformedOAuthClientException(error, pathname)) {
+		return new Response(
+			JSON.stringify({
+				error: 'invalid_client',
+				error_description: 'Invalid OAuth client registration.',
+			}),
+			{ status: 401, headers },
+		)
+	}
+
+	const errorDescription =
+		pathname === oauthPaths.register
+			? 'Invalid OAuth client registration.'
+			: 'OAuth provider request failed.'
+	return new Response(
+		JSON.stringify({
+			error:
+				pathname === oauthPaths.register ? 'invalid_request' : 'server_error',
+			error_description: errorDescription,
+		}),
+		{ status: pathname === oauthPaths.register ? 400 : 500, headers },
+	)
+}
+
 const workerHandler = {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext) {
 		const url = new URL(request.url)
@@ -448,7 +499,15 @@ const workerHandler = {
 				return addOAuthDiscoveryCorsHeaders(metadataResponse, request)
 			}
 		}
-		return oauthProvider.fetch(request, env, ctx)
+		try {
+			return await oauthProvider.fetch(request, env, ctx)
+		} catch (error) {
+			if (!isOAuthProviderOwnedPath(url.pathname)) throw error
+			if (!isMalformedOAuthClientException(error, url.pathname)) {
+				Sentry.captureException(error)
+			}
+			return createOAuthProviderExceptionResponse(error, url.pathname)
+		}
 	},
 	async email(
 		message: ForwardableEmailMessage,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -12,6 +12,7 @@ import { getWorkerSentryOptions } from './sentry-options.ts'
 import { handleRequest } from '#app/handler.ts'
 import {
 	apiHandler,
+	handleAuthorizeRouteException,
 	handleAuthorizeRequest,
 	handleAuthorizeInfo,
 	handleOAuthCallback,
@@ -231,11 +232,21 @@ const appHandler = withCors({
 		}
 
 		if (url.pathname === oauthPaths.authorize) {
-			return handleAuthorizeRequest(request, env)
+			try {
+				return await handleAuthorizeRequest(request, env)
+			} catch (error) {
+				Sentry.captureException(error)
+				return handleAuthorizeRouteException(request)
+			}
 		}
 
 		if (url.pathname === oauthPaths.authorizeInfo) {
-			return handleAuthorizeInfo(request, env)
+			try {
+				return await handleAuthorizeInfo(request, env)
+			} catch (error) {
+				Sentry.captureException(error)
+				return handleAuthorizeRouteException(request)
+			}
 		}
 
 		if (url.pathname === oauthPaths.callback) {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -408,7 +408,7 @@ function isOAuthProviderOwnedPath(pathname: string) {
 	return (
 		pathname === oauthPaths.token ||
 		pathname === oauthPaths.register ||
-		pathname === '/.well-known/oauth-authorization-server' ||
+		pathname === oauthPaths.discovery ||
 		pathname === protectedResourceMetadataPath ||
 		pathname.startsWith(`${protectedResourceMetadataPath}/`) ||
 		pathname.startsWith(oauthPaths.apiPrefix)
@@ -417,6 +417,8 @@ function isOAuthProviderOwnedPath(pathname: string) {
 
 function isMalformedOAuthClientException(error: unknown, pathname: string) {
 	const message = error instanceof Error ? error.message : ''
+	// @cloudflare/workers-oauth-provider@0.4.0 throws this raw TypeError
+	// when a stored client is missing redirectUris during token validation.
 	return (
 		pathname === oauthPaths.token &&
 		message.includes("Cannot read properties of undefined (reading 'some')")
@@ -514,9 +516,7 @@ const workerHandler = {
 			return await oauthProvider.fetch(request, env, ctx)
 		} catch (error) {
 			if (!isOAuthProviderOwnedPath(url.pathname)) throw error
-			if (!isMalformedOAuthClientException(error, url.pathname)) {
-				Sentry.captureException(error)
-			}
+			Sentry.captureException(error)
 			return createOAuthProviderExceptionResponse(error, url.pathname)
 		}
 	},

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -98,6 +98,19 @@ function jsonResponse(data: unknown, init?: ResponseInit) {
 	})
 }
 
+function standaloneAuthorizeErrorHtmlResponse(message: string, status: number) {
+	return new Response(
+		`<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>OAuth authorization failed</title></head><body><main style="font-family:system-ui,sans-serif;max-width:36rem;margin:4rem auto;padding:0 1rem"><p style="font-size:.8rem;letter-spacing:.08em;text-transform:uppercase;color:#57606a">Kody secure connection</p><h1>Authorize access</h1><p>${message}</p><p><a href="/">Back home</a></p></main></body></html>`,
+		{
+			status,
+			headers: {
+				'Cache-Control': 'no-store',
+				'Content-Type': 'text/html; charset=utf-8',
+			},
+		},
+	)
+}
+
 function getOAuthHelpers(env: Env) {
 	const helpers = (env as OAuthEnv).OAUTH_PROVIDER
 	if (!helpers) {
@@ -638,6 +651,37 @@ export async function handleAuthorizeInfo(
 			headers: createSetCookieHeaders([setCookie]),
 		},
 	)
+}
+
+export function handleAuthorizeRouteException(
+	request: Request,
+): Promise<Response> | Response {
+	const url = new URL(request.url)
+	if (url.pathname === oauthPaths.authorizeInfo) {
+		return jsonResponse(
+			{
+				ok: false,
+				error: 'Unable to load authorization details.',
+				allowClientReset: false,
+			},
+			{ status: 500 },
+		)
+	}
+
+	const message =
+		'OAuth authorization failed. Please start the connection again.'
+	if (wantsJson(request)) {
+		return jsonResponse(
+			{ ok: false, error: message, code: 'server_error' },
+			{ status: 500 },
+		)
+	}
+
+	if (request.method === 'POST') {
+		return createAuthorizeErrorRedirect(request, 'server_error', message)
+	}
+
+	return standaloneAuthorizeErrorHtmlResponse(message, 500)
 }
 
 export async function handleAuthorizeRequest(

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -28,6 +28,7 @@ export const oauthPaths = {
 	register: '/oauth/register',
 	callback: '/oauth/callback',
 	apiPrefix: '/api/',
+	discovery: '/.well-known/oauth-authorization-server',
 }
 
 export const oauthScopes: Array<string> = ['profile', 'email']

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -1,4 +1,5 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
+import * as Sentry from '@sentry/cloudflare'
 import {
 	type AuthRequest,
 	type ClientInfo,
@@ -591,6 +592,9 @@ test('worker entrypoint returns OAuth errors for provider-owned route exceptions
 		}),
 	)
 
+	const captureException = vi
+		.spyOn(Sentry, 'captureException')
+		.mockImplementation(() => undefined)
 	const tokenResponse = await workerFetch(
 		new Request('https://heykody.dev/oauth/token', {
 			method: 'POST',
@@ -610,6 +614,8 @@ test('worker entrypoint returns OAuth errors for provider-owned route exceptions
 		error: 'invalid_client',
 		error_description: 'Invalid OAuth client registration.',
 	})
+	expect(captureException).toHaveBeenCalledOnce()
+	captureException.mockRestore()
 })
 
 test('worker entrypoint renders OAuth errors for delegated authorize route exceptions', async () => {

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -157,6 +157,48 @@ async function workerFetch(request: Request): Promise<Response> {
 	return response
 }
 
+async function createS256CodeChallenge(verifier: string) {
+	const digest = await crypto.subtle.digest(
+		'SHA-256',
+		new TextEncoder().encode(verifier),
+	)
+	return btoa(String.fromCharCode(...new Uint8Array(digest)))
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+		.replace(/=+$/, '')
+}
+
+async function createSha256Hex(value: string) {
+	const digest = await crypto.subtle.digest(
+		'SHA-256',
+		new TextEncoder().encode(value),
+	)
+	return Array.from(new Uint8Array(digest))
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('')
+}
+
+async function seedWorkerUser(email: string, password: string) {
+	const passwordHash = await createPasswordHash(password)
+	await env.APP_DB.prepare(
+		`CREATE TABLE IF NOT EXISTS users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+			username TEXT NOT NULL UNIQUE,
+			email TEXT NOT NULL UNIQUE,
+			password_hash TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+			updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+		)`,
+	).run()
+	await env.APP_DB.prepare(
+		`INSERT INTO users (username, email, password_hash)
+			VALUES (?, ?, ?)
+			ON CONFLICT(email) DO UPDATE SET password_hash = excluded.password_hash`,
+	)
+		.bind(`user-${crypto.randomUUID().slice(0, 8)}`, email, passwordHash)
+		.run()
+}
+
 function createFormRequest(
 	data: Record<string, string>,
 	headers: Record<string, string> = {},
@@ -423,6 +465,148 @@ test('worker entrypoint renders a recoverable error for malformed Claude clients
 	const html = await response.text()
 	expect(html).toContain('Invalid OAuth client registration.')
 	expect(html).toContain('"oauthAuthorize"')
+})
+
+test('worker entrypoint completes Claude-shaped dynamic registration and token exchange', async () => {
+	const email = `claude-oauth-${crypto.randomUUID()}@example.com`
+	const password = 'password123'
+	await seedWorkerUser(email, password)
+
+	const registerResponse = await workerFetch(
+		new Request('https://heykody.dev/oauth/register', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				redirect_uris: [claudeAuthRequest.redirectUri],
+				client_name: 'Claude',
+				token_endpoint_auth_method: 'none',
+				grant_types: ['authorization_code', 'refresh_token'],
+				response_types: ['code'],
+			}),
+		}),
+	)
+	expect(registerResponse.status).toBe(201)
+	const registeredClient = (await registerResponse.json()) as {
+		client_id: string
+	}
+	const verifier = 'claude-verifier-0123456789'
+	const authorizeUrl = new URL(claudeAuthorizeUrl)
+	authorizeUrl.searchParams.set('client_id', registeredClient.client_id)
+	authorizeUrl.searchParams.set(
+		'code_challenge',
+		await createS256CodeChallenge(verifier),
+	)
+
+	const authorizeResponse = await workerFetch(new Request(authorizeUrl))
+	expect(authorizeResponse.status).toBe(200)
+	expect(await authorizeResponse.text()).toContain('Claude')
+
+	const approvalResponse = await workerFetch(
+		new Request(authorizeUrl, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				decision: 'approve',
+				email,
+				password,
+			}),
+		}),
+	)
+	expect(approvalResponse.status).toBe(200)
+	const approvalPayload = (await approvalResponse.json()) as {
+		redirectTo: string
+	}
+	const callbackUrl = new URL(approvalPayload.redirectTo)
+	const code = callbackUrl.searchParams.get('code')
+	expect(code).toBeTruthy()
+
+	const tokenResponse = await workerFetch(
+		new Request('https://heykody.dev/oauth/token', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({
+				grant_type: 'authorization_code',
+				client_id: registeredClient.client_id,
+				code: code ?? '',
+				redirect_uri: claudeAuthRequest.redirectUri,
+				code_verifier: verifier,
+				resource: 'https://heykody.dev/mcp',
+			}),
+		}),
+	)
+	expect(tokenResponse.status).toBe(200)
+	await expect(tokenResponse.json()).resolves.toMatchObject({
+		token_type: 'bearer',
+		resource: 'https://heykody.dev/mcp',
+		scope: 'profile email',
+	})
+})
+
+test('worker entrypoint returns OAuth errors for provider-owned route exceptions', async () => {
+	const registerResponse = await workerFetch(
+		new Request('https://heykody.dev/oauth/register', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: 'null',
+		}),
+	)
+	expect(registerResponse.status).toBe(400)
+	await expect(registerResponse.json()).resolves.toEqual({
+		error: 'invalid_request',
+		error_description: 'Invalid OAuth client registration.',
+	})
+
+	const clientId = `malformed-token-client-${crypto.randomUUID()}`
+	const userId = `oauth-user-${crypto.randomUUID()}`
+	const grantId = `oauth-grant-${crypto.randomUUID()}`
+	const code = `${userId}:${grantId}:secret`
+	await env.OAUTH_KV.put(
+		`client:${clientId}`,
+		JSON.stringify({
+			clientId,
+			clientName: 'Claude',
+			tokenEndpointAuthMethod: 'none',
+		}),
+	)
+	await env.OAUTH_KV.put(
+		`grant:${userId}:${grantId}`,
+		JSON.stringify({
+			id: grantId,
+			clientId,
+			userId,
+			scope: ['profile', 'email'],
+			metadata: {},
+			encryptedProps: '',
+			createdAt: Math.floor(Date.now() / 1000),
+			authCodeId: await createSha256Hex(code),
+			resource: 'https://heykody.dev/mcp',
+			codeChallenge: 'verifier',
+			codeChallengeMethod: 'plain',
+		}),
+	)
+
+	const tokenResponse = await workerFetch(
+		new Request('https://heykody.dev/oauth/token', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({
+				grant_type: 'authorization_code',
+				client_id: clientId,
+				code,
+				redirect_uri: claudeAuthRequest.redirectUri,
+				code_verifier: 'verifier',
+				resource: 'https://heykody.dev/mcp',
+			}),
+		}),
+	)
+	expect(tokenResponse.status).toBe(401)
+	await expect(tokenResponse.json()).resolves.toEqual({
+		error: 'invalid_client',
+		error_description: 'Invalid OAuth client registration.',
+	})
 })
 
 test('reset client deletes matching grants for redirect-uri, client-id, and authorize-info mismatches', async () => {

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -150,9 +150,12 @@ function createEnv(
 	} as unknown as Env
 }
 
-async function workerFetch(request: Request): Promise<Response> {
+async function workerFetch(
+	request: Request,
+	workerEnv: Env = env,
+): Promise<Response> {
 	const ctx = createExecutionContext()
-	const response = await exports.default.fetch(request, env, ctx)
+	const response = await exports.default.fetch(request, workerEnv, ctx)
 	await waitOnExecutionContext(ctx)
 	return response
 }
@@ -606,6 +609,27 @@ test('worker entrypoint returns OAuth errors for provider-owned route exceptions
 	await expect(tokenResponse.json()).resolves.toEqual({
 		error: 'invalid_client',
 		error_description: 'Invalid OAuth client registration.',
+	})
+})
+
+test('worker entrypoint renders OAuth errors for delegated authorize route exceptions', async () => {
+	const response = await workerFetch(
+		new Request(claudeAuthorizeUrl, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'multipart/form-data',
+			},
+			body: 'not a valid multipart body',
+		}),
+	)
+
+	expect(response.status).toBe(500)
+	expect(response.headers.get('Content-Type')).toContain('application/json')
+	await expect(response.json()).resolves.toEqual({
+		ok: false,
+		error: 'OAuth authorization failed. Please start the connection again.',
+		code: 'server_error',
 	})
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add error boundaries for OAuth provider-owned routes (`/oauth/token`, `/oauth/register`, discovery/API routes) so provider exceptions return OAuth JSON errors instead of Worker 1101s.
- Add a delegated `/oauth/authorize` and `/oauth/authorize-info` boundary so Kody captures route exceptions and returns recoverable OAuth responses.
- Expand Claude-shaped coverage to include dynamic registration -> authorize -> token exchange plus malformed provider and authorize request failures, including Sentry capture for malformed token-client failures.

## Research notes
- Production analytics for the retry window showed successful `/oauth/register` requests followed by three `/oauth/authorize` 500s at 03:54-03:55 UTC.
- Sentry had no matching Kody issue for that window, consistent with exceptions escaping before app-level capture.
- Cloudflare Log Explorer request-level traces are not enabled for this account/token, so GraphQL HTTP analytics was the available production evidence.
- Provider source confirms `isValidRedirectUri(..., clientInfo.redirectUris)` can still throw on malformed client records in provider-owned token paths.

## Testing
- `npx vitest run --project workers-unit packages/worker/src/oauth-handlers.workers.test.ts -t "delegated authorize|provider-owned|dynamic registration|Claude-shaped"`
- `npx vitest run --project workers-unit packages/worker/src/oauth-handlers.workers.test.ts`
- `npm run test -- packages/worker/src/oauth-handlers.workers.test.ts`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run validate`
- Pre-push hook: `npm run test:push`
- GitHub checks: `Validate`, `Deploy Preview Resources`, `CodeRabbit`, and `Cursor Bugbot`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `82c720b2` · **Head:** `386c3f4c`

**Classification:** extends — changes `mcp-oauth` error handling for provider-owned and delegated authorize routes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-oauth` | auth | extends — converts uncaught OAuth route exceptions into OAuth responses and captures provider-owned failures |
| `app-ui` | surfaces | composes — browser authorize failures get a minimal recoverable page instead of Cloudflare 1101 |
| `mcp-server` | surfaces | composes — Claude MCP OAuth flow remains scoped to `/mcp` resource audience |

### System map

```mermaid
flowchart LR
	claude["Claude MCP client"]:::untouched --> mcpOauth["mcp-oauth"]:::extended
	mcpOauth --> appUi["app-ui"]:::touched
	mcpOauth --> mcpServer["mcp-server"]:::touched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart TD
	register["/oauth/register"] --> authorize["/oauth/authorize"]
	authorize -->|success| token["/oauth/token"]
	authorize -->|route exception| authError["OAuth error page or JSON"]
	token -->|provider exception| tokenError["OAuth JSON error + Sentry"]
	authError --> no1101["no Worker 1101"]
	tokenError --> no1101
```

### Before / after

| Before | After |
| --- | --- |
| Provider token/register exceptions and delegated authorize exceptions could escape as Worker 1101. | OAuth routes return OAuth-shaped JSON or a minimal authorize error page and unexpected failures are reported to Sentry. |
| Tests covered only valid and malformed authorize GET records. | Tests cover fresh Claude dynamic registration, token exchange, provider-route exceptions with Sentry capture, and delegated authorize exceptions. |

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3565-f37a-7f15-9ce1-f05f738f634a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3565-f37a-7f15-9ce1-f05f738f634a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OAuth authorization server discovery support at `/.well-known/oauth-authorization-server`.
  - Standardized OAuth error responses across JSON, HTML, and redirect formats for authorization flows.

- **Bug Fixes**
  - Prevented exceptions from bubbling out of OAuth authorize and provider-owned routes by returning consistent, mapped OAuth error payloads.
  - Improved handling for specific malformed-client and client-registration error cases, including Sentry reporting.

- **Tests**
  - Expanded end-to-end OAuth coverage (PKCE/S256, registration, approval, code extraction, token exchange).
  - Added new provider-owned and delegated authorization error-path tests with Sentry assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->