### PR TITLE
Report the NULL-plan send backstop in email_usage_get

### DIFF
--- a/packages/worker/src/mcp/capabilities/email/email-usage-get.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-usage-get.ts
@@ -5,7 +5,6 @@ import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
 import {
 	planNames,
 	resolveEmailResourceLimit,
-	resolvePlanLimit,
 } from '#worker/entitlements/plans.ts'
 import {
 	getUserPlan,
@@ -78,9 +77,7 @@ export const emailUsageGetCapability = defineDomainCapability(
 				},
 				sends_today: {
 					count: sendsToday,
-					// Outbound sends have no NULL-plan fallback: plan-less users
-					// are unlimited (attempts are still counted).
-					limit: plan ? resolvePlanLimit(plan, 'email_sends_per_day') : null,
+					limit: resolveEmailResourceLimit(plan, 'email_sends_per_day'),
 				},
 				receives_today: {
 					count: receivesToday,

--- a/packages/worker/src/mcp/capabilities/email/email-usage-get.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-usage-get.workers.test.ts
@@ -156,7 +156,10 @@ test('email_usage_get returns usage for verified users and enforces auth require
 			count: 0,
 			limit: nullPlanEmailFallbackLimits.stored_email_messages,
 		},
-		sends_today: { count: 0, limit: null },
+		sends_today: {
+			count: 0,
+			limit: nullPlanEmailFallbackLimits.email_sends_per_day,
+		},
 		receives_today: {
 			count: 0,
 			limit: nullPlanEmailFallbackLimits.email_receives_per_day,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Small follow-up to #635, found while running the post-deploy migration audit.

When the username-based email model merged, `email_sends_per_day` joined `nullPlanEmailFallbackLimits` (100/day backstop for plan-less users) — but #636's `email_usage_get` landed in parallel with a hardcoded assumption that plan-less sends are unlimited, so it reports `sends_today.limit: null` while enforcement actually caps at 100. Observed live right after the deploy:

```json
"sends_today": { "count": 0, "limit": null }
```

Fix: resolve the send limit through `resolveEmailResourceLimit` like the other email resources, so the usage surface matches enforcement. Updated the workers test expectation accordingly.

`npm run validate` green locally (the only test-expectation change is the NULL-plan `sends_today.limit`).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `858befed` · **Head:** `c8f605a5`

**Classification:** composes — one capability read path aligned with the entitlement enforcement that already shipped; no primitive contracts change.

### Primitives touched

| Primitive      | Group     | Impact                                                          |
| -------------- | --------- | ---------------------------------------------------------------- |
| `email`        | assistant | composes — `email_usage_get` reports the existing send backstop |
| `entitlements` | auth      | composes — read-only use of `resolveEmailResourceLimit`         |

### System map

```mermaid
flowchart LR
	mcpServer["mcp-server"]:::untouched
	email["email"]:::touched
	entitlements["entitlements"]:::touched
	mcpServer -->|"email_usage_get"| email
	email --> entitlements
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c875e2e-c66f-4a64-8ae5-150ad91c30b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c875e2e-c66f-4a64-8ae5-150ad91c30b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email usage limits so daily send counts now display a consistent fallback limit when no plan is available.
  * Updated the email usage response to better reflect send quota information for accounts without an assigned plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->