### PR TITLE
Add operator-owned system email inboxes

### DIFF
--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -3,7 +3,9 @@
 Kody is multi-user with strict per-user isolation as the default. Role-based
 access control (RBAC) adds a **narrow, explicitly-guarded exception** for
 deployment operators: permissions with `access = 'any'` allow specific
-account-administration endpoints to cross user boundaries. See
+account-administration endpoints to cross user boundaries. Operator-owned system
+email for reserved platform addresses is the other deliberate exception: it is
+stored under the reserved `system:email` owner id, not any human account. See
 [Project intent](../project-intent.md) and the `per-user-isolation` invariant in
 [Primitives map](./primitives.yaml).
 
@@ -145,6 +147,8 @@ the same way).
 | `GET /admin/roles.json`                       | `requireUserWithPermission('read:role:any')`       |
 | `GET /admin/invites`                          | `requireUserWithRole('admin')`                     |
 | `GET/POST /admin/invites.json`                | `requireUserWithRole('admin')`                     |
+| `GET /admin/system-email`                     | `requireUserWithRole('admin')`                     |
+| `GET /admin/system-email.json`                | `requireUserWithRole('admin')`                     |
 
 Handlers: `packages/worker/src/app/handlers/admin-users.ts`,
 `packages/worker/src/app/handlers/admin-roles.ts`,
@@ -234,17 +238,24 @@ The admin role is an **account-administration** role, not a data-access role.
 `created_at`, `updated_at`, and role assignments.
 
 **Admins cannot see** user content (secrets, values, memories, packages, jobs,
-email, chat threads, durable storage, remote connectors, OAuth grants, and so
-on). None of it appears in admin endpoints, pages, or payloads.
+user inbox email, chat threads, durable storage, remote connectors, OAuth
+grants, and so on). None of it appears in admin endpoints, pages, or payloads.
+
+**Admins can see** operator-owned system mail for reserved platform addresses
+(`kody`, `support`, `abuse`, `postmaster`, `security`, and `admin`). That mail
+is stored under `system:email` as platform content, not under Kent's or any
+other user's account. Admin reads through MCP (`admin_system_email_list`,
+`admin_system_email_get`) and the `/admin/system-email` UI are audit logged.
 
 This boundary is enforced structurally:
 
-1. **The permission vocabulary cannot express content access.**
+1. **The permission vocabulary cannot express user content access.**
    `permissionEntities` contains only `user` and `role`, so a guard like
    `requireUserWithPermission(..., 'read:secret:any')` is a compile error.
-2. **Admin queries touch identity tables only.** `/admin/*.json` handlers select
-   explicit column lists from `users`, `user_roles`, and `roles`. They never
-   join content tables.
+2. **Admin account queries touch identity tables only.** `/admin/users*.json`
+   and role handlers select explicit column lists from `users`, `user_roles`,
+   and `roles`. They never join user content tables. `/admin/system-email*.json`
+   is separate and filters email rows by `user_id = 'system:email'`.
 3. **A shape test pins the admin users API payload.**
    `adminUserListItemFieldNames` in `admin-users.ts` defines the allowed fields
    (`id`, `username`, `email`, `created_at`, `updated_at`, `roles`). The unit

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -13,6 +13,16 @@ different durable objects and different rows. Any new persistence layer added to
 the project must follow the same convention; user-scoped tests should exercise
 both the "happy" path and a cross-user denial path.
 
+The deliberate storage exception is **operator-owned system email** for reserved
+platform local parts (`kody`, `support`, `abuse`, `postmaster`, `security`, and
+`admin`). Those messages reuse the email tables but are stored under the
+reserved owner id `system:email`, which is not a login account and must not be
+conflated with the `kody@example.com` fixture or Kent's personal account.
+Account deletion and export treat `system:email` rows as platform/operator
+content, not user data; the exclusion is listed in
+`accountUserDataExcludedOwnerIds` with a reason and is covered by guardrail
+tests.
+
 ## Account deletion inventory
 
 Account deletion is implemented in `packages/worker/src/app/account-deletion.ts`
@@ -25,6 +35,11 @@ and what needs operator attention. Re-running the operation is safe: missing
 rows, missing KV keys, missing vectors, deleted Artifacts repos, and
 already-cleared Durable Objects are treated as successful no-ops or warning-only
 failures.
+
+System email rows owned by `system:email` are intentionally excluded from
+account deletion. They are operator-owned inbound mail for reserved platform
+addresses, not portable user content, and are bounded by fixed system caps plus
+the scheduled system-email retention prune.
 
 Deletion must cover these user-owned surfaces:
 
@@ -64,6 +79,11 @@ migrations to SQLite and fails if a `user_id` / `*_user_id` column is not
 covered by the export list. The hard invariant is the same as every storage
 path: callers pass the authenticated user's stable MCP `userId`, and every query
 or Durable Object lookup is scoped to that id.
+
+System email rows owned by `system:email` are intentionally absent from account
+exports for the same reason they are absent from deletion: they belong to the
+operator inbox surface, not to the exporting user. The export manifest lists
+this under `excludedD1Surfaces` so the omission is explicit.
 
 Exports are versioned JSON documents:
 
@@ -425,6 +445,10 @@ on write unless a migration backfills existing rows.
   `email_messages.headers_json`, and `email_delivery_events.detail_json`
   (`0030-email-primitives.sql`, `0031-unified-email-receipt.sql`) store parsed
   email metadata; `detail_json` is write-mostly audit detail.
+- `system_email_daily_counters` (`0051-system-email-daily-counters.sql`) stores
+  fixed per-local daily receive counters for operator-owned system inboxes.
+  These counters are not user entitlements and are pruned by the system-email
+  retention job.
 - `mcp_memories.tags_json` and `mcp_memories.source_uris_json`
   (`0016-mcp-memories.sql`, `0018-mcp-memory-source-uris.sql`) back memory
   search and provenance.
@@ -520,8 +544,12 @@ migration plan.
 ### Growth and retention watch list
 
 These tables can grow without a built-in retention policy beyond account
-deletion or narrow cleanup paths: `audit_events`, `email_messages` and related
-email tables, `package_runtime_runs`, `package_runtime_logs`, `workflow_runs`,
-`package_invocations`, and old published bundle/KV artifacts. `usage_rollups` is
-bounded by `(user_id, metric, month)`, while raw Analytics Engine usage events
-follow platform retention.
+deletion or narrow cleanup paths: `audit_events`, user-owned `email_messages`
+and related email tables, `package_runtime_runs`, `package_runtime_logs`,
+`workflow_runs`, `package_invocations`, and old published bundle/KV artifacts.
+System email rows under `system:email` are the email exception: cron prunes
+messages and delivery events older than 90 days, deletes stale
+`system_email_daily_counters`, and caps stored system messages at 5000. User
+email retention is still account-deletion scoped. `usage_rollups` is bounded by
+`(user_id, metric, month)`, while raw Analytics Engine usage events follow
+platform retention.

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -277,8 +277,9 @@ primitives:
     group: assistant
     name: Email
     summary:
-      Automatic per-user inbox at {username}@<platform domain>, inbound message
-      storage, and platform-addressed outbound send backed by Cloudflare email
+      Automatic per-user inbox at {username}@<platform domain>, operator-owned
+      system inboxes for configured reserved locals, inbound message storage,
+      and platform-addressed outbound send backed by Cloudflare email
       primitives.
     code:
       - packages/worker/src/email/
@@ -433,8 +434,10 @@ invariants:
       Every read/write path is scoped by userId, every user-owned Durable Object
       id is user-namespaced, and every search/vector path filters by userId.
       Cross-user data sharing is a bug. RBAC provides a narrow exception for
-      account administration only (permissions with access=any on user/role
-      entities, behind explicit guards) — never for user content.
+      account administration (permissions with access=any on user/role entities,
+      behind explicit guards), and system email uses the reserved system:email
+      owner id for operator-owned reserved-address mail — never for user
+      content.
     docs:
       - docs/contributing/project-intent.md
       - docs/contributing/architecture/data-storage.md

--- a/docs/contributing/project-intent.md
+++ b/docs/contributing/project-intent.md
@@ -43,9 +43,10 @@ shared state between users.
 Optimize for:
 
 - Per-user isolation as a first-class invariant, enforced at the storage,
-  durable-object, vectorize, and runtime layers. RBAC provides a narrow,
-  explicitly-guarded exception for account administration (`access = 'any'`,
-  limited to `user` and `role` entities — never user content). See
+  durable-object, vectorize, and runtime layers. Two narrow, documented
+  exceptions exist: RBAC account administration (`access = 'any'`, limited to
+  `user` and `role` entities — never user content) and operator-owned system
+  email for reserved platform addresses stored under `system:email`. See
   [Authorization](./architecture/authorization.md).
 - Fast iteration on the personal-assistant experience
 - Interoperability across MCP-capable hosts
@@ -81,10 +82,10 @@ When working in this repo, do not assume:
 - This project is trying to become a generic starter kit for others.
 - This is a single-user system. Per-user isolation is an invariant, not a future
   direction; treat any code path that reads or writes data without a `userId`
-  (or that shares a Durable Object id across users) as a bug. The RBAC
-  account-administration exception (`:any` on `user`/`role` only, behind
-  explicit guards) is the sole intentional cross-user boundary — see
-  [Authorization](./architecture/authorization.md).
+  (or that shares a Durable Object id across users) as a bug. The intentional
+  cross-user boundaries are RBAC account administration (`:any` on `user`/`role`
+  only, behind explicit guards) and operator-owned system email for reserved
+  platform addresses — see [Authorization](./architecture/authorization.md).
 - The main goal is enterprise-grade least-privilege design for many users.
 
 Also do not document capabilities as if they already exist. Keep design notes

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -13,10 +13,13 @@ replies from the matching platform-assigned sender address.
   that username. The default inbox is provisioned automatically at signup (or on
   the first inbound message), so there is nothing to create or configure.
 - Mail to unknown usernames is rejected.
-- Reserved local parts (`kody`, `postmaster`, `abuse`, and other role or system
-  names) never route to a user inbox and can never be registered as usernames.
-  `kody@<platform domain>` is the system transactional sender (verification and
-  password-reset mail) only.
+- Reserved local parts never route to a user inbox and can never be registered
+  as usernames. A configured subset is operator-owned system mail: `kody`,
+  `support`, `abuse`, `postmaster`, `security`, and `admin` at the platform
+  domain route to Kody's system inbox. Other reserved locals still reject.
+- `kody@<platform domain>` is also the system transactional sender for
+  verification and password-reset mail. Inbound replies to that address are
+  operator-owned system mail, not a user's inbox.
 - User outbound mail always sends from `{username}@<platform domain>`. The from
   address is platform-assigned: a verified sender identity for it is provisioned
   automatically alongside the default inbox. There is no self-service sender
@@ -75,7 +78,9 @@ Inbound storage is quota-gated per user:
   whole is disabled.
 - Any email routed to a verified user's platform address is stored, subject to
   the quotas above.
-- Unknown usernames and reserved local parts are rejected before storage.
+- Unknown usernames and reserved local parts outside the configured system
+  address subset are rejected before storage. Configured system addresses are
+  stored in the operator-owned system inbox and are visible only to admins.
 - Display names are not trusted. Kody stores envelope sender, parsed `From`, and
   authentication headers separately.
 - Outbound sending requires a verified account email, sends only from the
@@ -84,6 +89,10 @@ Inbound storage is quota-gated per user:
   recipients, and only recipients taken from stored inbound mail.
 - Outbound sends consume a per-day entitlement. Users without a plan are capped
   by a global daily backstop instead of sending unlimited mail.
+- System inbox mail is not gated by a user plan or account-verification state.
+  It has fixed platform caps and retention: messages are pruned after 90 days
+  and the stored system inbox is capped so arbitrary sender traffic cannot grow
+  without bound.
 - Stored inbound mail is the source of truth. If a user wants email automation,
   they can publish a package that subscribes to the stored inbound email topic
   `email.message.received` using normal package subscriptions. This is package

--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -109,7 +109,16 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	)
 	expect(memberRecord).toBeTruthy()
 	expect(Object.keys(memberRecord).sort()).toEqual(
-		['created_at', 'email', 'id', 'roles', 'updated_at', 'username'].sort(),
+		[
+			'created_at',
+			'email',
+			'email_verified',
+			'email_verified_at',
+			'id',
+			'roles',
+			'updated_at',
+			'username',
+		].sort(),
 	)
 	expect(JSON.stringify(memberRecord)).not.toContain('memberPrivateSecret')
 	expect(JSON.stringify(memberRecord)).not.toContain('super-secret-value')

--- a/packages/worker/client/routes/admin-community-reports.tsx
+++ b/packages/worker/client/routes/admin-community-reports.tsx
@@ -299,6 +299,12 @@ export function AdminCommunityReportsRoute(handle: Handle) {
 							>
 								Usage
 							</a>
+							<a
+								href="/admin/system-email"
+								mix={css({ ...secondaryButtonCss, textDecoration: 'none' })}
+							>
+								System email
+							</a>
 						</>
 					}
 				/>

--- a/packages/worker/client/routes/admin-invites.tsx
+++ b/packages/worker/client/routes/admin-invites.tsx
@@ -264,6 +264,12 @@ export function AdminInvitesRoute(handle: Handle) {
 							>
 								Usage
 							</a>
+							<a
+								href="/admin/system-email"
+								mix={css({ ...secondaryButtonCss, textDecoration: 'none' })}
+							>
+								System email
+							</a>
 						</>
 					}
 				/>

--- a/packages/worker/client/routes/admin-roles.tsx
+++ b/packages/worker/client/routes/admin-roles.tsx
@@ -161,6 +161,12 @@ export function AdminRolesRoute(handle: Handle) {
 								Usage
 							</a>
 							<a
+								href="/admin/system-email"
+								mix={css({ ...secondaryButtonCss, textDecoration: 'none' })}
+							>
+								System email
+							</a>
+							<a
 								href="/admin/community-reports"
 								mix={css({ ...secondaryButtonCss, textDecoration: 'none' })}
 							>

--- a/packages/worker/client/routes/admin-system-email.tsx
+++ b/packages/worker/client/routes/admin-system-email.tsx
@@ -1,0 +1,381 @@
+import { type Handle, css } from 'remix/ui'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { readRouterSearch } from '#client/router-location.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { readJson } from '#client/routes/account-approval-shared.ts'
+import { colors, spacing, typography } from '#client/styles/tokens.ts'
+import {
+	cardCss,
+	getSecondaryButtonCss,
+} from '#client/styles/style-primitives.ts'
+import {
+	AccountManagementHeader,
+	AccountManagementMessage,
+	AccountManagementPanel,
+	AccountManagementShell,
+	MetadataGrid,
+} from './account-management-components.tsx'
+import { type AdminSystemEmailLoaderData } from '#app/loader-data.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
+
+type PageStatus = 'loading' | 'ready' | 'error'
+
+const adminSystemEmailApiPath = '/admin/system-email.json'
+
+function isAdminSystemEmailPath(href: string) {
+	return new URL(href, 'http://localhost').pathname === '/admin/system-email'
+}
+
+function formatTimestamp(value: string | null) {
+	return value ? new Date(value).toLocaleString() : 'Unknown'
+}
+
+function formatBytes(value: number) {
+	return new Intl.NumberFormat().format(value)
+}
+
+function messageHref(messageId: string) {
+	return `/admin/system-email?messageId=${encodeURIComponent(messageId)}`
+}
+
+export async function adminSystemEmailRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const response = await fetch(`${adminSystemEmailApiPath}${url.search}`, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		return routeLoaderRedirect('/login')
+	}
+	if (response.status === 403) {
+		throw new Error('You do not have permission to view system email.')
+	}
+	const payload = await readJson<AdminSystemEmailLoaderData>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load system email.')
+	}
+	return { adminSystemEmail: payload }
+}
+
+export function AdminSystemEmailRoute(handle: Handle) {
+	let status: PageStatus = 'loading'
+	let data: AdminSystemEmailLoaderData | null = null
+	let message: string | null = null
+	let loadRequestId = 0
+	let lastLoadedHref = ''
+	let loadingForHref: string | null = null
+	let lastFailedHref: string | null = null
+
+	function applyData(payload: AdminSystemEmailLoaderData, href: string) {
+		data = payload
+		status = 'ready'
+		message = null
+		lastLoadedHref = href
+		lastFailedHref = null
+	}
+
+	async function loadSystemEmail() {
+		const href = readCurrentRouterHref(handle)
+		loadingForHref = href
+		const requestId = ++loadRequestId
+		try {
+			const response = await fetch(
+				`${adminSystemEmailApiPath}${readRouterSearch(handle)}`,
+				{
+					headers: { Accept: 'application/json' },
+					credentials: 'include',
+				},
+			)
+			if (requestId !== loadRequestId) return
+			if (response.status === 401) {
+				window.location.assign('/login')
+				return
+			}
+			if (response.status === 403) {
+				status = 'error'
+				message = 'You do not have permission to view system email.'
+				lastFailedHref = href
+				handle.update()
+				return
+			}
+			const payload = await readJson<AdminSystemEmailLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load system email.')
+			}
+			applyData(payload, href)
+			handle.update()
+		} catch (error) {
+			if (requestId !== loadRequestId) return
+			status = 'error'
+			message =
+				error instanceof Error ? error.message : 'Unable to load system email.'
+			lastFailedHref = href
+			handle.update()
+		} finally {
+			if (requestId === loadRequestId) loadingForHref = null
+		}
+	}
+
+	function applyRouteLoaderData(href: string) {
+		if (!isAdminSystemEmailPath(href)) return false
+		const routeData = tryConsumeRouteLoaderData(
+			handle,
+			'adminSystemEmail',
+			href,
+		)
+		if (!routeData) return false
+		applyData(routeData, href)
+		return true
+	}
+
+	const secondaryButtonCss = getSecondaryButtonCss()
+	const tableCss = {
+		width: '100%',
+		borderCollapse: 'collapse' as const,
+		fontSize: typography.fontSize.sm,
+	}
+	const cellCss = {
+		padding: `${spacing.sm} ${spacing.md}`,
+		borderBottom: `1px solid ${colors.border}`,
+		textAlign: 'left' as const,
+		verticalAlign: 'top' as const,
+	}
+	const numericCellCss = {
+		...cellCss,
+		textAlign: 'right' as const,
+		fontVariantNumeric: 'tabular-nums',
+	}
+
+	let lastSeenHref = ''
+
+	return () => {
+		const currentHref = readCurrentRouterHref(handle)
+		if (currentHref !== lastSeenHref) {
+			lastSeenHref = currentHref
+			lastFailedHref = null
+		}
+		const appliedRouteData = applyRouteLoaderData(currentHref)
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
+		const needsLoad =
+			(status === 'loading' ||
+				currentHref !== lastLoadedHref ||
+				needsStaleRefresh) &&
+			currentHref !== lastFailedHref &&
+			loadingForHref !== currentHref
+		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
+			loadingForHref = currentHref
+			handle.queueTask(loadSystemEmail)
+		}
+
+		const totalPages = data
+			? Math.max(1, Math.ceil(data.total / data.pageSize))
+			: 1
+		const selectedMessage = data?.selectedMessage ?? null
+
+		return (
+			<AccountManagementShell maxWidth="min(100%, 92rem)">
+				<AccountManagementHeader
+					title="Admin system email"
+					description="Operator-owned inboxes for reserved platform addresses. These messages are not user account data."
+					actions={
+						<>
+							<a
+								href="/admin/users"
+								mix={css({ ...secondaryButtonCss, textDecoration: 'none' })}
+							>
+								Users
+							</a>
+							<a
+								href="/admin/usage"
+								mix={css({ ...secondaryButtonCss, textDecoration: 'none' })}
+							>
+								Usage
+							</a>
+							<a
+								href="/admin/invites"
+								mix={css({ ...secondaryButtonCss, textDecoration: 'none' })}
+							>
+								Invites
+							</a>
+							<a
+								href="/admin/roles"
+								mix={css({ ...secondaryButtonCss, textDecoration: 'none' })}
+							>
+								Roles
+							</a>
+						</>
+					}
+				/>
+				{status === 'loading' ? (
+					<p mix={css({ color: colors.textMuted, margin: 0 })}>
+						Loading system email...
+					</p>
+				) : null}
+				{message ? (
+					<AccountManagementMessage
+						tone={status === 'error' ? 'error' : 'info'}
+					>
+						{message}
+					</AccountManagementMessage>
+				) : null}
+				{data ? (
+					<>
+						<AccountManagementPanel
+							title="System inbox messages"
+							description={`Addresses: ${data.systemLocals
+								.map((local) => `${local}@<platform domain>`)
+								.join(
+									', ',
+								)}. Retention keeps ${data.limits.retentionDays} days and at most ${data.limits.maxStoredMessages} stored messages.`}
+						>
+							<div mix={css({ overflowX: 'auto' })}>
+								<table mix={css(tableCss)}>
+									<thead>
+										<tr>
+											<th mix={css(cellCss)}>Inbox</th>
+											<th mix={css(cellCss)}>From</th>
+											<th mix={css(cellCss)}>Subject</th>
+											<th mix={css(numericCellCss)}>Bytes</th>
+											<th mix={css(cellCss)}>Received</th>
+										</tr>
+									</thead>
+									<tbody>
+										{data.messages.map((systemMessage) => (
+											<tr key={systemMessage.id}>
+												<td mix={css(cellCss)}>
+													<a href={messageHref(systemMessage.id)}>
+														{systemMessage.inbox_local_part}
+													</a>
+												</td>
+												<td mix={css(cellCss)}>
+													{systemMessage.from_address ??
+														systemMessage.envelope_from ??
+														'Unknown'}
+												</td>
+												<td mix={css(cellCss)}>
+													{systemMessage.subject || '(no subject)'}
+												</td>
+												<td mix={css(numericCellCss)}>
+													{formatBytes(systemMessage.raw_size)}
+												</td>
+												<td mix={css(cellCss)}>
+													{formatTimestamp(
+														systemMessage.received_at ??
+															systemMessage.created_at,
+													)}
+												</td>
+											</tr>
+										))}
+									</tbody>
+								</table>
+							</div>
+							{data.messages.length === 0 ? (
+								<p mix={css({ margin: 0, color: colors.textMuted })}>
+									No system mail has been stored.
+								</p>
+							) : null}
+							{totalPages > 1 ? (
+								<p mix={css({ margin: 0, color: colors.textMuted })}>
+									Page {data.page} of {totalPages}
+								</p>
+							) : null}
+						</AccountManagementPanel>
+
+						{selectedMessage ? (
+							<AccountManagementPanel
+								title={`Message: ${selectedMessage.subject || '(no subject)'}`}
+								description="Admin reads of message content are audit logged."
+							>
+								<MetadataGrid
+									columns={3}
+									items={[
+										{
+											label: 'Inbox',
+											value: selectedMessage.inbox_local_part,
+										},
+										{
+											label: 'From',
+											value:
+												selectedMessage.from_address ??
+												selectedMessage.envelope_from ??
+												'Unknown',
+										},
+										{
+											label: 'Received',
+											value: formatTimestamp(
+												selectedMessage.received_at ??
+													selectedMessage.created_at,
+											),
+										},
+										{
+											label: 'To',
+											value: selectedMessage.to_addresses.join(', ') || 'None',
+										},
+										{
+											label: 'Reply-To',
+											value:
+												selectedMessage.reply_to_addresses.join(', ') || 'None',
+										},
+										{
+											label: 'Attachments',
+											value: String(selectedMessage.attachments.length),
+										},
+									]}
+								/>
+								<section mix={css(cardCss)}>
+									<h3
+										mix={css({
+											margin: 0,
+											fontSize: typography.fontSize.base,
+										})}
+									>
+										Text body
+									</h3>
+									<pre
+										mix={css({
+											margin: 0,
+											whiteSpace: 'pre-wrap',
+											overflowX: 'auto',
+										})}
+									>
+										{selectedMessage.text_body ?? '(no text body)'}
+									</pre>
+								</section>
+								{selectedMessage.html_body ? (
+									<section mix={css(cardCss)}>
+										<h3
+											mix={css({
+												margin: 0,
+												fontSize: typography.fontSize.base,
+											})}
+										>
+											HTML body source
+										</h3>
+										<pre
+											mix={css({
+												margin: 0,
+												whiteSpace: 'pre-wrap',
+												overflowX: 'auto',
+											})}
+										>
+											{selectedMessage.html_body}
+										</pre>
+									</section>
+								) : null}
+							</AccountManagementPanel>
+						) : null}
+					</>
+				) : null}
+			</AccountManagementShell>
+		)
+	}
+}

--- a/packages/worker/client/routes/admin-usage.tsx
+++ b/packages/worker/client/routes/admin-usage.tsx
@@ -228,6 +228,12 @@ export function AdminUsageRoute(handle: Handle) {
 								Users
 							</a>
 							<a
+								href="/admin/system-email"
+								mix={css({ ...secondaryButtonCss, textDecoration: 'none' })}
+							>
+								System email
+							</a>
+							<a
 								href="/admin/invites"
 								mix={css({ ...secondaryButtonCss, textDecoration: 'none' })}
 							>

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -282,6 +282,12 @@ export function AdminUsersRoute(handle: Handle) {
 								Usage
 							</a>
 							<a
+								href="/admin/system-email"
+								mix={css({ ...secondaryButtonCss, textDecoration: 'none' })}
+							>
+								System email
+							</a>
+							<a
 								href="/admin/community-reports"
 								mix={css({ ...secondaryButtonCss, textDecoration: 'none' })}
 							>
@@ -428,6 +434,12 @@ export function AdminUsersRoute(handle: Handle) {
 									columns={3}
 									items={[
 										{ label: 'Email', value: selectedUser.email },
+										{
+											label: 'Email verified',
+											value: selectedUser.email_verified
+												? (selectedUser.email_verified_at ?? 'Verified')
+												: 'No',
+										},
 										{ label: 'User id', value: String(selectedUser.id) },
 										{
 											label: 'Roles',

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -22,6 +22,10 @@ import {
 } from './admin-community-reports.tsx'
 import { AdminInvitesRoute, adminInvitesRouteLoader } from './admin-invites.tsx'
 import { AdminRolesRoute, adminRolesRouteLoader } from './admin-roles.tsx'
+import {
+	AdminSystemEmailRoute,
+	adminSystemEmailRouteLoader,
+} from './admin-system-email.tsx'
 import { AdminUsageRoute, adminUsageRouteLoader } from './admin-usage.tsx'
 import { AdminUsersRoute, adminUsersRouteLoader } from './admin-users.tsx'
 import {
@@ -64,6 +68,7 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 	'/admin/roles': adminRolesRouteLoader,
 	'/admin/community-reports': adminCommunityReportsRouteLoader,
 	'/admin/usage': adminUsageRouteLoader,
+	'/admin/system-email': adminSystemEmailRouteLoader,
 	'/community': communityRouteLoader,
 	'/community/:listingId': communityDetailRouteLoader,
 	'/oauth/authorize': oauthAuthorizeRouteLoader,
@@ -94,6 +99,7 @@ export const clientRoutes = {
 	'/admin/roles': <AdminRolesRoute />,
 	'/admin/community-reports': <AdminCommunityReportsRoute />,
 	'/admin/usage': <AdminUsageRoute />,
+	'/admin/system-email': <AdminSystemEmailRoute />,
 	'/community': <CommunityRoute />,
 	'/community/:listingId': <CommunityDetailRoute />,
 	'/login': <LoginRoute />,

--- a/packages/worker/migrations/0051-system-email-daily-counters.sql
+++ b/packages/worker/migrations/0051-system-email-daily-counters.sql
@@ -1,0 +1,11 @@
+-- System inboxes receive mail for operator-owned reserved local parts (for
+-- example kody@, abuse@, and postmaster@). Their receive caps are deployment
+-- constants rather than user plan entitlements, so their daily counter is kept
+-- separate from entitlement_daily_counters.
+CREATE TABLE IF NOT EXISTS system_email_daily_counters (
+	local_part TEXT NOT NULL,
+	day TEXT NOT NULL,
+	count INTEGER NOT NULL DEFAULT 0,
+	updated_at TEXT NOT NULL,
+	PRIMARY KEY (local_part, day)
+);

--- a/packages/worker/src/app/account-data-targets.ts
+++ b/packages/worker/src/app/account-data-targets.ts
@@ -20,11 +20,23 @@ export type UserScopedDataTarget =
 	| { kind: 'community_listing_child'; table: string; listingColumn: string }
 	| { kind: 'mcp_memory_suppression' }
 
+export const accountUserDataExcludedOwnerIds = [
+	{
+		ownerId: 'system:email',
+		surface: 'system_email_inboxes',
+		reason:
+			'Operator-owned inbound mail for reserved platform locals is stored under the reserved system:email owner id. It is not a user account, must not be attributed to any user, and is excluded from per-user account deletion/export while system retention pruning bounds growth.',
+	},
+] as const
+
 /**
  * Tables that are scoped by `user_id` (directly or transitively) and should
  * be included in per-user account operations. The list is intentionally
  * explicit so adding a new user-scoped table requires a deliberate update here
  * and a corresponding deletion/export guardrail test update.
+ * Rows owned by accountUserDataExcludedOwnerIds are operator/platform data,
+ * not user data; tests assert those owner ids stay deliberately excluded from
+ * user account operations.
  *
  * Order matters for deletion: child tables come before parent tables so the
  * cascade is self-contained even on engines / configs where foreign-key

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -5,6 +5,7 @@ import {
 	deleteUserAccount,
 	getAccountDeletionD1UserColumnCoverage,
 } from './account-deletion.ts'
+import { accountUserDataExcludedOwnerIds } from './account-data-targets.ts'
 
 type RowMap = Record<string, Array<Record<string, unknown>>>
 
@@ -374,6 +375,57 @@ test('account deletion D1 coverage includes every live user-owned schema column'
 		'user-owned D1 columns missing from account deletion',
 	).toEqual([])
 	expect(stale, 'account deletion references stale D1 columns').toEqual([])
+})
+
+test('account deletion documents and preserves operator-owned system email rows', async () => {
+	const systemEmailExclusion = accountUserDataExcludedOwnerIds.find(
+		(exclusion) => exclusion.ownerId === 'system:email',
+	)
+	expect(systemEmailExclusion?.reason).toContain('Operator-owned inbound mail')
+	expect(systemEmailExclusion?.reason).toContain(
+		'not be attributed to any user',
+	)
+
+	const { db, rows } = createTestDb({
+		users: [{ id: 1, email: 'user@example.com' }],
+		email_messages: [
+			{ id: 'user-message', user_id: 'user-aaa' },
+			{ id: 'system-message', user_id: 'system:email' },
+		],
+		email_delivery_events: [
+			{ id: 'user-event', user_id: 'user-aaa' },
+			{ id: 'system-event', user_id: 'system:email' },
+		],
+		email_inboxes: [
+			{ id: 'user-inbox', user_id: 'user-aaa' },
+			{ id: 'system-inbox', user_id: 'system:email' },
+		],
+		email_inbox_addresses: [
+			{ id: 'user-address', user_id: 'user-aaa' },
+			{ id: 'system-address', user_id: 'system:email' },
+		],
+	})
+
+	await deleteUserAccount({
+		env: { APP_DB: db } as unknown as Parameters<
+			typeof deleteUserAccount
+		>[0]['env'],
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+	})
+
+	expect(rows.email_messages).toEqual([
+		{ id: 'system-message', user_id: 'system:email' },
+	])
+	expect(rows.email_delivery_events).toEqual([
+		{ id: 'system-event', user_id: 'system:email' },
+	])
+	expect(rows.email_inboxes).toEqual([
+		{ id: 'system-inbox', user_id: 'system:email' },
+	])
+	expect(rows.email_inbox_addresses).toEqual([
+		{ id: 'system-address', user_id: 'system:email' },
+	])
 })
 
 test('deleteUserAccount cascades user-scoped rows for the requested user', async () => {

--- a/packages/worker/src/app/account-export.node.test.ts
+++ b/packages/worker/src/app/account-export.node.test.ts
@@ -108,6 +108,37 @@ test('account export D1 coverage includes every live user-owned schema column', 
 	expect(stale, 'account export references stale D1 columns').toEqual([])
 })
 
+test('account export documents and excludes operator-owned system email rows', async () => {
+	const { sqlite, db } = createMigratedDb()
+	sqlite.exec(`
+		INSERT INTO users (id, username, email, password_hash, created_at, updated_at, email_verified_at)
+		VALUES (1, 'user-a', 'a@example.com', 'password-hash-a', '2026-07-05', '2026-07-05', '2026-07-05');
+
+		INSERT INTO email_messages (
+			id, direction, user_id, from_address, subject, processing_status, created_at, updated_at
+		) VALUES
+			('user-message', 'inbound', 'user-aaa', 'sender@example.net', 'User mail', 'stored', '2026-07-05', '2026-07-05'),
+			('system-message', 'inbound', 'system:email', 'sender@example.net', 'System mail', 'stored', '2026-07-05', '2026-07-05');
+	`)
+
+	const accountExport = await createAccountExport({
+		env: { APP_DB: db } as Env,
+		dbUserId: 1,
+		mcpUserId: 'user-aaa',
+		generatedAt: '2026-07-05T00:00:00.000Z',
+	})
+
+	expect(accountExport.d1.email_messages.rows).toEqual([
+		expect.objectContaining({ id: 'user-message', user_id: 'user-aaa' }),
+	])
+	expect(accountExport.manifest.excludedD1Surfaces).toEqual([
+		expect.objectContaining({
+			name: 'system_email_inboxes',
+			reason: expect.stringContaining('Operator-owned inbound mail'),
+		}),
+	])
+})
+
 test('createAccountExport redacts secrets and credential-equivalent hashes', async () => {
 	const { sqlite, db } = createMigratedDb()
 	sqlite.exec(`

--- a/packages/worker/src/app/account-export.ts
+++ b/packages/worker/src/app/account-export.ts
@@ -1,5 +1,6 @@
 import {
 	accountUserDataTargets,
+	accountUserDataExcludedOwnerIds,
 	type UserScopedDataTarget,
 	getAccountD1UserColumnCoverage,
 } from '#app/account-data-targets.ts'
@@ -134,6 +135,10 @@ export type AccountExportManifest = {
 		vectorize: string
 	}
 	excludedDurableObjects: Array<{
+		name: string
+		reason: string
+	}>
+	excludedD1Surfaces: Array<{
 		name: string
 		reason: string
 	}>
@@ -1082,6 +1087,10 @@ function buildManifest(input: {
 					'Ephemeral live websocket/session state. Durable app storage is exported through StorageRunner buckets.',
 			},
 		],
+		excludedD1Surfaces: accountUserDataExcludedOwnerIds.map((exclusion) => ({
+			name: exclusion.surface,
+			reason: exclusion.reason,
+		})),
 	} satisfies AccountExportManifest
 }
 

--- a/packages/worker/src/app/admin-system-email-data.ts
+++ b/packages/worker/src/app/admin-system-email-data.ts
@@ -1,0 +1,226 @@
+import { type AdminSystemEmailLoaderData } from '#app/loader-data.ts'
+import {
+	systemEmailLimits,
+	systemEmailLocals,
+	systemEmailOwnerId,
+} from '#worker/email/system-email.ts'
+
+export const adminSystemEmailListItemFieldNames = [
+	'id',
+	'inbox_local_part',
+	'from_address',
+	'envelope_from',
+	'subject',
+	'processing_status',
+	'raw_size',
+	'received_at',
+	'created_at',
+] as const
+
+type AdminSystemEmailListItemFieldName =
+	(typeof adminSystemEmailListItemFieldNames)[number]
+
+export type AdminSystemEmailListItem = Record<
+	AdminSystemEmailListItemFieldName,
+	unknown
+> & {
+	id: string
+	inbox_local_part: string
+	from_address: string | null
+	envelope_from: string | null
+	subject: string | null
+	processing_status: string
+	raw_size: number
+	received_at: string | null
+	created_at: string
+}
+
+export type AdminSystemEmailDetail = AdminSystemEmailListItem & {
+	to_addresses: Array<string>
+	cc_addresses: Array<string>
+	reply_to_addresses: Array<string>
+	headers: Record<string, Array<string>>
+	text_body: string | null
+	html_body: string | null
+	raw_mime: string | null
+	attachments: Array<{
+		id: string
+		filename: string | null
+		content_type: string | null
+		content_id: string | null
+		disposition: string | null
+		size: number
+		storage_kind: string
+		created_at: string
+	}>
+}
+
+const defaultPageSize = 25
+const maxPageSize = 100
+
+function readPositiveInt(value: string | null, fallback: number) {
+	if (!value) return fallback
+	const parsed = Number.parseInt(value, 10)
+	if (!Number.isFinite(parsed) || parsed < 1) return fallback
+	return parsed
+}
+
+function parseStringArray(value: string | null) {
+	if (!value) return []
+	const parsed = JSON.parse(value) as unknown
+	return Array.isArray(parsed)
+		? parsed.filter((entry): entry is string => typeof entry === 'string')
+		: []
+}
+
+function parseHeaders(value: string | null): Record<string, Array<string>> {
+	if (!value) return {}
+	const parsed = JSON.parse(value) as unknown
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+	const headers: Record<string, Array<string>> = {}
+	for (const [key, headerValue] of Object.entries(parsed)) {
+		if (!Array.isArray(headerValue)) continue
+		headers[key] = headerValue.filter(
+			(entry): entry is string => typeof entry === 'string',
+		)
+	}
+	return headers
+}
+
+function toListItem(row: Record<string, unknown>): AdminSystemEmailListItem {
+	return {
+		id: String(row['id']),
+		inbox_local_part: String(row['inbox_local_part'] ?? ''),
+		from_address:
+			row['from_address'] == null ? null : String(row['from_address']),
+		envelope_from:
+			row['envelope_from'] == null ? null : String(row['envelope_from']),
+		subject: row['subject'] == null ? null : String(row['subject']),
+		processing_status: String(row['processing_status']),
+		raw_size: Number(row['raw_size'] ?? 0),
+		received_at: row['received_at'] == null ? null : String(row['received_at']),
+		created_at: String(row['created_at']),
+	}
+}
+
+async function listAttachments(db: D1Database, messageId: string) {
+	const result = await db
+		.prepare(
+			`SELECT id, filename, content_type, content_id, disposition, size, storage_kind, created_at
+			FROM email_attachments
+			WHERE message_id = ?
+			ORDER BY created_at ASC, id ASC`,
+		)
+		.bind(messageId)
+		.all<Record<string, unknown>>()
+	return (result.results ?? []).map((row) => ({
+		id: String(row['id']),
+		filename: row['filename'] == null ? null : String(row['filename']),
+		content_type:
+			row['content_type'] == null ? null : String(row['content_type']),
+		content_id: row['content_id'] == null ? null : String(row['content_id']),
+		disposition: row['disposition'] == null ? null : String(row['disposition']),
+		size: Number(row['size'] ?? 0),
+		storage_kind: String(row['storage_kind']),
+		created_at: String(row['created_at']),
+	}))
+}
+
+export async function loadAdminSystemEmailMessageById(
+	db: D1Database,
+	messageId: string,
+): Promise<AdminSystemEmailDetail | null> {
+	const row = await db
+		.prepare(
+			`SELECT message.*, address.local_part AS inbox_local_part
+			FROM email_messages AS message
+			LEFT JOIN email_inbox_addresses AS address
+				ON address.inbox_id = message.inbox_id
+				AND address.user_id = message.user_id
+			WHERE message.user_id = ?
+				AND message.id = ?
+			LIMIT 1`,
+		)
+		.bind(systemEmailOwnerId, messageId)
+		.first<Record<string, unknown>>()
+	if (!row) return null
+	return {
+		...toListItem(row),
+		to_addresses: parseStringArray(
+			row['to_addresses_json'] == null
+				? null
+				: String(row['to_addresses_json']),
+		),
+		cc_addresses: parseStringArray(
+			row['cc_addresses_json'] == null
+				? null
+				: String(row['cc_addresses_json']),
+		),
+		reply_to_addresses: parseStringArray(
+			row['reply_to_addresses_json'] == null
+				? null
+				: String(row['reply_to_addresses_json']),
+		),
+		headers: parseHeaders(
+			row['headers_json'] == null ? null : String(row['headers_json']),
+		),
+		text_body: row['text_body'] == null ? null : String(row['text_body']),
+		html_body: row['html_body'] == null ? null : String(row['html_body']),
+		raw_mime: row['raw_mime'] == null ? null : String(row['raw_mime']),
+		attachments: await listAttachments(db, messageId),
+	}
+}
+
+export async function loadAdminSystemEmailData(
+	env: Env,
+	requestUrl: string,
+): Promise<AdminSystemEmailLoaderData> {
+	const url = new URL(requestUrl, 'http://localhost')
+	const page = readPositiveInt(url.searchParams.get('page'), 1)
+	const pageSize = Math.min(
+		readPositiveInt(url.searchParams.get('pageSize'), defaultPageSize),
+		maxPageSize,
+	)
+	const selectedMessageId = url.searchParams.get('messageId')?.trim() || null
+	const offset = (page - 1) * pageSize
+	const [totalResult, messageRows, selectedMessage] = await Promise.all([
+		env.APP_DB.prepare(
+			`SELECT COUNT(*) AS total
+			FROM email_messages
+			WHERE user_id = ?
+				AND direction = 'inbound'`,
+		)
+			.bind(systemEmailOwnerId)
+			.first<{ total: number }>(),
+		env.APP_DB.prepare(
+			`SELECT message.id, address.local_part AS inbox_local_part,
+				message.from_address, message.envelope_from, message.subject,
+				message.processing_status, message.raw_size, message.received_at,
+				message.created_at
+			FROM email_messages AS message
+			LEFT JOIN email_inbox_addresses AS address
+				ON address.inbox_id = message.inbox_id
+				AND address.user_id = message.user_id
+			WHERE message.user_id = ?
+				AND message.direction = 'inbound'
+			ORDER BY message.created_at DESC, message.id DESC
+			LIMIT ? OFFSET ?`,
+		)
+			.bind(systemEmailOwnerId, pageSize, offset)
+			.all<Record<string, unknown>>(),
+		selectedMessageId
+			? loadAdminSystemEmailMessageById(env.APP_DB, selectedMessageId)
+			: Promise.resolve(null),
+	])
+	return {
+		ok: true,
+		ownerId: systemEmailOwnerId,
+		systemLocals: [...systemEmailLocals],
+		limits: { ...systemEmailLimits },
+		messages: (messageRows.results ?? []).map(toListItem),
+		selectedMessage,
+		page,
+		pageSize,
+		total: Number(totalResult?.total ?? 0),
+	}
+}

--- a/packages/worker/src/app/admin-users-data.ts
+++ b/packages/worker/src/app/admin-users-data.ts
@@ -5,6 +5,8 @@ export const adminUserListItemFieldNames = [
 	'id',
 	'username',
 	'email',
+	'email_verified',
+	'email_verified_at',
 	'created_at',
 	'updated_at',
 	'roles',
@@ -17,6 +19,8 @@ export type AdminUserListItem = Record<AdminUserListItemFieldName, unknown> & {
 	id: number
 	username: string
 	email: string
+	email_verified: boolean
+	email_verified_at: string | null
 	created_at: string
 	updated_at: string
 	roles: Array<RoleName>
@@ -42,7 +46,7 @@ export async function loadAdminUsersData(
 			total: number
 		}>(),
 		env.APP_DB.prepare(
-			`SELECT id, username, email, created_at, updated_at
+			`SELECT id, username, email, email_verified_at, created_at, updated_at
 			 FROM users
 			 ORDER BY id ASC
 			 LIMIT ? OFFSET ?`,
@@ -52,6 +56,7 @@ export async function loadAdminUsersData(
 				id: number
 				username: string
 				email: string
+				email_verified_at: string | null
 				created_at: string
 				updated_at: string
 			}>(),
@@ -81,7 +86,7 @@ export async function loadAdminUserByIdOrEmail(
 	const userRow = input.id
 		? await db
 				.prepare(
-					`SELECT id, username, email, created_at, updated_at
+					`SELECT id, username, email, email_verified_at, created_at, updated_at
 					 FROM users
 					 WHERE id = ?`,
 				)
@@ -90,13 +95,14 @@ export async function loadAdminUserByIdOrEmail(
 					id: number
 					username: string
 					email: string
+					email_verified_at: string | null
 					created_at: string
 					updated_at: string
 				}>()
 		: email
 			? await db
 					.prepare(
-						`SELECT id, username, email, created_at, updated_at
+						`SELECT id, username, email, email_verified_at, created_at, updated_at
 						 FROM users
 						 WHERE email = ? COLLATE NOCASE`,
 					)
@@ -105,6 +111,7 @@ export async function loadAdminUserByIdOrEmail(
 						id: number
 						username: string
 						email: string
+						email_verified_at: string | null
 						created_at: string
 						updated_at: string
 					}>()
@@ -151,6 +158,7 @@ function toAdminUserListItem(
 		id: number
 		username: string
 		email: string
+		email_verified_at: string | null
 		created_at: string
 		updated_at: string
 	},
@@ -160,6 +168,8 @@ function toAdminUserListItem(
 		id: row.id,
 		username: row.username,
 		email: row.email,
+		email_verified: Boolean(row.email_verified_at),
+		email_verified_at: row.email_verified_at,
 		created_at: row.created_at,
 		updated_at: row.updated_at,
 		roles,

--- a/packages/worker/src/app/handlers/admin-system-email.ts
+++ b/packages/worker/src/app/handlers/admin-system-email.ts
@@ -1,0 +1,102 @@
+import { type Action } from 'remix/router'
+import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
+import { loadAdminSystemEmailData } from '#app/admin-system-email-data.ts'
+import { readAuthSessionResult } from '#app/auth-session.ts'
+import { redirectToLogin } from '#app/auth-redirect.ts'
+import { requireUserWithRole } from '#app/permissions-server.ts'
+import { type routes } from '#app/routes.ts'
+import { renderAppPage } from '#app/ssr-render.tsx'
+
+async function auditSystemEmailRead(input: {
+	env: Env
+	request: Request
+	actorEmail?: string | null
+	action: 'admin_system_email_list' | 'admin_system_email_get'
+	messageId?: string | null
+}) {
+	await logAuditEvent({
+		db: input.env.APP_DB,
+		category: 'admin',
+		action: input.action,
+		result: 'success',
+		email: input.actorEmail ?? undefined,
+		ip: getRequestIp(input.request) ?? undefined,
+		path: new URL(input.request.url).pathname,
+		reason: input.messageId
+			? `target_message_id=${input.messageId}`
+			: 'system_email_list',
+	})
+}
+
+export function createAdminSystemEmailHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			let actor: Awaited<ReturnType<typeof requireUserWithRole>>
+			try {
+				actor = await requireUserWithRole(request, env, 'admin')
+			} catch (error) {
+				if (error instanceof Response) return error
+				throw error
+			}
+
+			const { session } = await readAuthSessionResult(request)
+			if (!session) {
+				return redirectToLogin(request)
+			}
+
+			const adminSystemEmail = await loadAdminSystemEmailData(env, request.url)
+			await auditSystemEmailRead({
+				env,
+				request,
+				actorEmail: actor.email,
+				action: adminSystemEmail.selectedMessage
+					? 'admin_system_email_get'
+					: 'admin_system_email_list',
+				messageId: adminSystemEmail.selectedMessage?.id,
+			})
+
+			return renderAppPage({
+				request,
+				env,
+				title: 'Admin system email',
+				loaderData: { adminSystemEmail },
+			})
+		},
+	} satisfies Action<typeof routes.adminSystemEmail>
+}
+
+export function createAdminSystemEmailApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			try {
+				const actor = await requireUserWithRole(request, env, 'admin')
+				const payload = await loadAdminSystemEmailData(env, request.url)
+				await auditSystemEmailRead({
+					env,
+					request,
+					actorEmail: actor.email,
+					action: payload.selectedMessage
+						? 'admin_system_email_get'
+						: 'admin_system_email_list',
+					messageId: payload.selectedMessage?.id,
+				})
+				return jsonResponse(payload)
+			} catch (error) {
+				if (error instanceof Response) return error
+				throw error
+			}
+		},
+	} satisfies Action<typeof routes.adminSystemEmailApi>
+}
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: {
+			'Cache-Control': 'no-store',
+			'Content-Type': 'application/json; charset=utf-8',
+		},
+	})
+}

--- a/packages/worker/src/app/handlers/admin-users.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-users.node.test.ts
@@ -21,6 +21,7 @@ type UserRow = {
 	id: number
 	username: string
 	email: string
+	email_verified_at?: string | null
 	created_at: string
 	updated_at: string
 }
@@ -206,6 +207,7 @@ test('admin users list payload exposes only account metadata fields', async () =
 				id: 1,
 				username: 'admin-user',
 				email: 'admin@example.com',
+				email_verified_at: '2026-01-01T00:00:00.000Z',
 				created_at: '2026-01-01 00:00:00',
 				updated_at: '2026-01-02 00:00:00',
 			},
@@ -213,6 +215,7 @@ test('admin users list payload exposes only account metadata fields', async () =
 				id: 2,
 				username: 'member',
 				email: 'member@example.com',
+				email_verified_at: null,
 				created_at: '2026-01-03 00:00:00',
 				updated_at: '2026-01-04 00:00:00',
 			},
@@ -242,6 +245,18 @@ test('admin users list payload exposes only account metadata fields', async () =
 			[...adminUserListItemFieldNames].sort(),
 		)
 	}
+	expect(payload.users).toEqual([
+		expect.objectContaining({
+			email: 'admin@example.com',
+			email_verified: true,
+			email_verified_at: '2026-01-01T00:00:00.000Z',
+		}),
+		expect.objectContaining({
+			email: 'member@example.com',
+			email_verified: false,
+			email_verified_at: null,
+		}),
+	])
 })
 
 test('assign role action updates user roles and logs audit event', async () => {

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -32,6 +32,8 @@ export type AdminUserListItem = {
 	id: number
 	username: string
 	email: string
+	email_verified: boolean
+	email_verified_at: string | null
 	created_at: string
 	updated_at: string
 	roles: Array<RoleName>
@@ -178,6 +180,56 @@ export type AdminUsageLoaderData = {
 	total: number
 	currentMonth: string
 	today: string
+}
+
+export type AdminSystemEmailListItem = {
+	id: string
+	inbox_local_part: string
+	from_address: string | null
+	envelope_from: string | null
+	subject: string | null
+	processing_status: string
+	raw_size: number
+	received_at: string | null
+	created_at: string
+}
+
+export type AdminSystemEmailDetail = AdminSystemEmailListItem & {
+	to_addresses: Array<string>
+	cc_addresses: Array<string>
+	reply_to_addresses: Array<string>
+	headers: Record<string, Array<string>>
+	text_body: string | null
+	html_body: string | null
+	raw_mime: string | null
+	attachments: Array<{
+		id: string
+		filename: string | null
+		content_type: string | null
+		content_id: string | null
+		disposition: string | null
+		size: number
+		storage_kind: string
+		created_at: string
+	}>
+}
+
+export type AdminSystemEmailLoaderData = {
+	ok: true
+	ownerId: string
+	systemLocals: Array<string>
+	limits: {
+		maxMessageBytes: number
+		maxReceivesPerDay: number
+		maxStoredMessages: number
+		retentionDays: number
+		pruneBatchSize: number
+	}
+	messages: Array<AdminSystemEmailListItem>
+	selectedMessage: AdminSystemEmailDetail | null
+	page: number
+	pageSize: number
+	total: number
 }
 
 export type AdminCreatedUserSetup = {
@@ -346,6 +398,7 @@ export type AppLoaderData = {
 	adminCommunityReports?: AdminCommunityReportsLoaderData
 	adminInvites?: AdminInvitesLoaderData
 	adminUsage?: AdminUsageLoaderData
+	adminSystemEmail?: AdminSystemEmailLoaderData
 	accountProfile?: AccountProfileLoaderData
 	accountIntegrations?: AccountIntegrationsLoaderData
 	accountRemoteConnectors?: AccountRemoteConnectorsLoaderData

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -20,6 +20,10 @@ import {
 	createAdminUsageApiHandler,
 	createAdminUsageHandler,
 } from '#app/handlers/admin-usage.ts'
+import {
+	createAdminSystemEmailApiHandler,
+	createAdminSystemEmailHandler,
+} from '#app/handlers/admin-system-email.ts'
 import { createAccountHandler } from '#app/handlers/account.ts'
 import { createAccountDeleteHandler } from '#app/handlers/account-delete.ts'
 import { createAccountExportHandler } from '#app/handlers/account-export.ts'
@@ -141,6 +145,8 @@ export function createAppRouter(appEnv: AppEnv) {
 			adminCommunityReportsApiPost: createAdminCommunityReportsApiHandler(env),
 			adminUsage: createAdminUsageHandler(env),
 			adminUsageApi: createAdminUsageApiHandler(env),
+			adminSystemEmail: createAdminSystemEmailHandler(env),
+			adminSystemEmailApi: createAdminSystemEmailApiHandler(env),
 			community: createCommunityHandler(env),
 			communityApi: createCommunityApiHandler(env),
 			communityDetail: createCommunityDetailHandler(env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -44,6 +44,8 @@ export const routes = route({
 	adminCommunityReportsApiPost: post('/admin/community-reports.json'),
 	adminUsage: '/admin/usage',
 	adminUsageApi: '/admin/usage.json',
+	adminSystemEmail: '/admin/system-email',
+	adminSystemEmailApi: '/admin/system-email.json',
 	community: '/community',
 	communityApi: '/community.json',
 	communityDetail: '/community/:listingId',

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -27,6 +27,120 @@ import {
 	touchEmailThread,
 } from './repo.ts'
 import { dispatchInboundEmailSubscriptionEvents } from './package-subscriptions.ts'
+import {
+	consumeSystemEmailDailyReceive,
+	countStoredSystemEmailMessages,
+	ensureSystemEmailInbox,
+	isSystemEmailLocal,
+	systemEmailLimits,
+	systemEmailOwnerId,
+	type SystemEmailLocal,
+} from './system-email.ts'
+
+type ParsedInboundEmail = Awaited<
+	ReturnType<typeof parseForwardableEmailMessage>
+>
+
+async function parseAndStoreInboundEmail(input: {
+	db: D1Database
+	message: ForwardableEmailMessage
+	recipient: string
+	userId: string
+	inboxId: string
+	maxMessageBytes: number
+	onParseRejected: (reason: string) => Promise<void>
+}) {
+	let parsed: ParsedInboundEmail
+	try {
+		parsed = await parseForwardableEmailMessage(input.message, {
+			maxRawSize: input.maxMessageBytes,
+		})
+	} catch (error) {
+		const reason =
+			error instanceof Error ? error.message : 'Failed to parse inbound email.'
+		input.message.setReject(reason)
+		await input.onParseRejected(reason)
+		return null
+	}
+	const now = new Date().toISOString()
+	const subjectNormalized = normalizeSubject(parsed.subject)
+	const existingThread = await findEmailThreadForInboundMessage({
+		db: input.db,
+		userId: input.userId,
+		inboxId: input.inboxId,
+		references: parsed.references,
+		inReplyToHeader: parsed.inReplyTo,
+	})
+	const thread =
+		existingThread ??
+		(await createEmailThread({
+			db: input.db,
+			userId: input.userId,
+			inboxId: input.inboxId,
+			subjectNormalized,
+			rootMessageIdHeader: parsed.messageId,
+			lastMessageAt: now,
+		}))
+	const stored = await insertEmailMessageWithAttachments({
+		db: input.db,
+		message: {
+			direction: 'inbound',
+			userId: input.userId,
+			inboxId: input.inboxId,
+			threadId: thread.id,
+			senderIdentityId: null,
+			fromAddress: parsed.headerFrom,
+			envelopeFrom: parsed.envelopeFrom,
+			toAddresses: parsed.to.map((entry) => entry.address),
+			ccAddresses: parsed.cc.map((entry) => entry.address),
+			bccAddresses: parsed.bcc.map((entry) => entry.address),
+			replyToAddresses: parsed.replyTo.map((entry) => entry.address),
+			subject: parsed.subject,
+			messageIdHeader: parsed.messageId,
+			inReplyToHeader: parsed.inReplyTo,
+			references: parsed.references,
+			headers: parsed.headers,
+			authResults: parsed.authResults,
+			textBody: parsed.textBody,
+			htmlBody: parsed.htmlBody,
+			rawMime: parsed.rawMime,
+			rawSize: parsed.rawSize,
+			processingStatus: 'stored',
+			providerMessageId: null,
+			error: null,
+			receivedAt: now,
+			sentAt: null,
+		},
+		attachments: parsed.attachments.map((attachment) => ({
+			filename: attachment.filename,
+			contentType: attachment.contentType,
+			contentId: attachment.contentId,
+			disposition: attachment.disposition,
+			size: attachment.size,
+			storageKind: 'raw-mime',
+			storageKey: null,
+		})),
+	})
+	await touchEmailThread({
+		db: input.db,
+		threadId: thread.id,
+		lastMessageAt: now,
+	})
+	await insertEmailDeliveryEvent({
+		db: input.db,
+		messageId: stored.id,
+		userId: input.userId,
+		inboxId: input.inboxId,
+		eventType: 'received',
+		provider: 'cloudflare-email-routing',
+		detail: {
+			recipient: input.recipient,
+			envelope_from: parsed.envelopeFrom,
+			from_address: parsed.headerFrom,
+		},
+	})
+	return stored
+}
 
 export async function handleInboundEmail(
 	message: ForwardableEmailMessage,
@@ -53,6 +167,16 @@ export async function handleInboundEmail(
 	const recipientDomain = recipient.slice(atIndex + 1)
 	if (recipientDomain !== platformDomain) {
 		message.setReject('Unknown Kody email address.')
+		return
+	}
+	if (isSystemEmailLocal(localPart)) {
+		await handleSystemInboundEmail({
+			message,
+			env,
+			recipient,
+			localPart,
+			platformDomain,
+		})
 		return
 	}
 	if (isReservedUsername(localPart)) {
@@ -200,111 +324,34 @@ export async function handleInboundEmail(
 		return
 	}
 
-	let parsed: Awaited<ReturnType<typeof parseForwardableEmailMessage>>
-	try {
-		parsed = await parseForwardableEmailMessage(message, {
-			maxRawSize: maxMessageBytes ?? maxInlineRawMimeBytes,
-		})
-	} catch (error) {
-		const reason =
-			error instanceof Error ? error.message : 'Failed to parse inbound email.'
-		// Parse failures keep one event per attempt: unlike quota/size
-		// rejections they are bounded by the daily receive quota (the
-		// counter was already consumed above), and the per-attempt detail
-		// is useful for the owner to debug a misbehaving sender.
-		message.setReject(reason)
-		await insertEmailDeliveryEvent({
-			db: env.APP_DB,
-			userId,
-			inboxId: inbox.id,
-			eventType: 'rejected',
-			provider: 'cloudflare-email-routing',
-			detail: {
-				recipient,
-				reason,
-				phase: 'parse',
-			},
-		}).catch(() => undefined)
-		await recordReceiveUsage({ outcome: 'error' })
-		return
-	}
-	const now = new Date().toISOString()
-	const subjectNormalized = normalizeSubject(parsed.subject)
-	const existingThread = await findEmailThreadForInboundMessage({
+	const stored = await parseAndStoreInboundEmail({
 		db: env.APP_DB,
+		message,
+		recipient,
 		userId,
 		inboxId: inbox.id,
-		references: parsed.references,
-		inReplyToHeader: parsed.inReplyTo,
-	})
-	const thread =
-		existingThread ??
-		(await createEmailThread({
-			db: env.APP_DB,
-			userId,
-			inboxId: inbox.id,
-			subjectNormalized,
-			rootMessageIdHeader: parsed.messageId,
-			lastMessageAt: now,
-		}))
-	const stored = await insertEmailMessageWithAttachments({
-		db: env.APP_DB,
-		message: {
-			direction: 'inbound',
-			userId,
-			inboxId: inbox.id,
-			threadId: thread.id,
-			senderIdentityId: null,
-			fromAddress: parsed.headerFrom,
-			envelopeFrom: parsed.envelopeFrom,
-			toAddresses: parsed.to.map((entry) => entry.address),
-			ccAddresses: parsed.cc.map((entry) => entry.address),
-			bccAddresses: parsed.bcc.map((entry) => entry.address),
-			replyToAddresses: parsed.replyTo.map((entry) => entry.address),
-			subject: parsed.subject,
-			messageIdHeader: parsed.messageId,
-			inReplyToHeader: parsed.inReplyTo,
-			references: parsed.references,
-			headers: parsed.headers,
-			authResults: parsed.authResults,
-			textBody: parsed.textBody,
-			htmlBody: parsed.htmlBody,
-			rawMime: parsed.rawMime,
-			rawSize: parsed.rawSize,
-			processingStatus: 'stored',
-			providerMessageId: null,
-			error: null,
-			receivedAt: now,
-			sentAt: null,
-		},
-		attachments: parsed.attachments.map((attachment) => ({
-			filename: attachment.filename,
-			contentType: attachment.contentType,
-			contentId: attachment.contentId,
-			disposition: attachment.disposition,
-			size: attachment.size,
-			storageKind: 'raw-mime',
-			storageKey: null,
-		})),
-	})
-	await touchEmailThread({
-		db: env.APP_DB,
-		threadId: thread.id,
-		lastMessageAt: now,
-	})
-	await insertEmailDeliveryEvent({
-		db: env.APP_DB,
-		messageId: stored.id,
-		userId,
-		inboxId: inbox.id,
-		eventType: 'received',
-		provider: 'cloudflare-email-routing',
-		detail: {
-			recipient,
-			envelope_from: parsed.envelopeFrom,
-			from_address: parsed.headerFrom,
+		maxMessageBytes: maxMessageBytes ?? maxInlineRawMimeBytes,
+		async onParseRejected(reason) {
+			// Parse failures keep one event per attempt: unlike quota/size
+			// rejections they are bounded by the daily receive quota (the
+			// counter was already consumed above), and the per-attempt detail
+			// is useful for the owner to debug a misbehaving sender.
+			await insertEmailDeliveryEvent({
+				db: env.APP_DB,
+				userId,
+				inboxId: inbox.id,
+				eventType: 'rejected',
+				provider: 'cloudflare-email-routing',
+				detail: {
+					recipient,
+					reason,
+					phase: 'parse',
+				},
+			}).catch(() => undefined)
+			await recordReceiveUsage({ outcome: 'error' })
 		},
 	})
+	if (!stored) return
 	await recordReceiveUsage({ entityId: stored.id, outcome: 'success' })
 	const dispatchPromise = dispatchInboundEmailSubscriptionEvents({
 		env,
@@ -318,4 +365,115 @@ export async function handleInboundEmail(
 			console.error('Inbound email package subscription dispatch failed', error)
 		})
 	}
+}
+
+async function handleSystemInboundEmail(input: {
+	message: ForwardableEmailMessage
+	env: Pick<
+		Env,
+		'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'APP_BASE_URL' | 'USAGE_EVENTS'
+	>
+	recipient: string
+	localPart: SystemEmailLocal
+	platformDomain: string
+}) {
+	const provisioned = await ensureSystemEmailInbox({
+		db: input.env.APP_DB,
+		localPart: input.localPart,
+		domain: input.platformDomain,
+	})
+	if (!provisioned) {
+		input.message.setReject('Email inbox is unavailable.')
+		return
+	}
+	const { inbox } = provisioned
+	const receiveStartedAtMs = Date.now()
+	const recordReceiveUsage = async (recordInput: {
+		entityId?: string | null
+		outcome: 'success' | 'error'
+	}) => {
+		await recordUsage(input.env, {
+			userId: systemEmailOwnerId,
+			eventType: 'email_received',
+			entityId: recordInput.entityId ?? null,
+			bytes: input.message.rawSize,
+			durationMs: Date.now() - receiveStartedAtMs,
+			outcome: recordInput.outcome,
+		})
+	}
+
+	if (input.message.rawSize > systemEmailLimits.maxMessageBytes) {
+		input.message.setReject('Recipient mailbox is over quota.')
+		await recordBoundedEmailRejectionEvent({
+			db: input.env.APP_DB,
+			userId: systemEmailOwnerId,
+			inboxId: inbox.id,
+			recipient: input.recipient,
+			reason: `Message size ${input.message.rawSize} exceeds system inbox cap ${systemEmailLimits.maxMessageBytes}.`,
+			phase: 'size',
+		}).catch(() => undefined)
+		await recordReceiveUsage({ outcome: 'error' })
+		return
+	}
+
+	const receivesToday = await consumeSystemEmailDailyReceive({
+		db: input.env.APP_DB,
+		localPart: input.localPart,
+	})
+	if (receivesToday === null) {
+		input.message.setReject('Recipient mailbox is over quota.')
+		await recordBoundedEmailRejectionEvent({
+			db: input.env.APP_DB,
+			userId: systemEmailOwnerId,
+			inboxId: inbox.id,
+			recipient: input.recipient,
+			reason: `System inbox daily receive cap ${systemEmailLimits.maxReceivesPerDay} reached for ${input.localPart}.`,
+			phase: 'system-limit',
+		}).catch(() => undefined)
+		await recordReceiveUsage({ outcome: 'error' })
+		return
+	}
+
+	const storedMessages = await countStoredSystemEmailMessages({
+		db: input.env.APP_DB,
+	})
+	if (storedMessages >= systemEmailLimits.maxStoredMessages) {
+		input.message.setReject('Recipient mailbox is over quota.')
+		await recordBoundedEmailRejectionEvent({
+			db: input.env.APP_DB,
+			userId: systemEmailOwnerId,
+			inboxId: inbox.id,
+			recipient: input.recipient,
+			reason: `System inbox stored-message cap ${systemEmailLimits.maxStoredMessages} reached.`,
+			phase: 'system-limit',
+		}).catch(() => undefined)
+		await recordReceiveUsage({ outcome: 'error' })
+		return
+	}
+
+	const stored = await parseAndStoreInboundEmail({
+		db: input.env.APP_DB,
+		message: input.message,
+		recipient: input.recipient,
+		userId: systemEmailOwnerId,
+		inboxId: inbox.id,
+		maxMessageBytes: systemEmailLimits.maxMessageBytes,
+		async onParseRejected(reason) {
+			await insertEmailDeliveryEvent({
+				db: input.env.APP_DB,
+				userId: systemEmailOwnerId,
+				inboxId: inbox.id,
+				eventType: 'rejected',
+				provider: 'cloudflare-email-routing',
+				detail: {
+					recipient: input.recipient,
+					reason,
+					phase: 'parse',
+				},
+			}).catch(() => undefined)
+			await recordReceiveUsage({ outcome: 'error' })
+		},
+	})
+	if (!stored) return
+	await recordReceiveUsage({ entityId: stored.id, outcome: 'success' })
 }

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -203,15 +203,10 @@ test('inbound email rejects unknown usernames, reserved locals, and foreign doma
 		to: `missing-${crypto.randomUUID().slice(0, 8)}@${platformDomain}`,
 		reason: 'Unknown Kody email address.',
 	})
-	// kody@ is the system transactional sender, never a user inbox. The
-	// reserved check runs before any username lookup, so even a legacy user
-	// row holding a reserved username can never receive here.
+	// Reserved locals that are not configured system inboxes still reject before
+	// any username lookup.
 	await expectRejected({
-		to: `kody@${platformDomain}`,
-		reason: 'This address is reserved for system mail.',
-	})
-	await expectRejected({
-		to: `postmaster@${platformDomain}`,
+		to: `help@${platformDomain}`,
 		reason: 'This address is reserved for system mail.',
 	})
 	// Mail for other domains is never a Kody user inbox.

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -968,7 +968,7 @@ export async function recordBoundedEmailRejectionEvent(input: {
 	inboxId: string
 	recipient: string
 	reason: string
-	phase: 'entitlement' | 'size' | 'account-verification'
+	phase: 'entitlement' | 'size' | 'account-verification' | 'system-limit'
 	now?: Date
 }) {
 	const now = input.now ?? new Date()

--- a/packages/worker/src/email/system-email.ts
+++ b/packages/worker/src/email/system-email.ts
@@ -1,0 +1,303 @@
+import { maxInlineRawMimeBytes } from './parser.ts'
+import {
+	createEmailInbox,
+	createEmailInboxAddress,
+	deleteEmailInboxAddressById,
+	deleteEmailMessageById,
+	getEmailInboxAddressByAddress,
+	getEmailInboxById,
+	getEmailInboxByName,
+} from './repo.ts'
+import { buildPlatformEmailAddress } from './platform-address.ts'
+import { type EmailInboxAddressRecord, type EmailInboxRecord } from './types.ts'
+
+export const systemEmailOwnerId = 'system:email'
+
+export const systemEmailLocals = [
+	'kody',
+	'support',
+	'abuse',
+	'postmaster',
+	'security',
+	'admin',
+] as const
+
+export type SystemEmailLocal = (typeof systemEmailLocals)[number]
+
+export const systemEmailLimits = {
+	maxMessageBytes: maxInlineRawMimeBytes,
+	maxReceivesPerDay: 1000,
+	maxStoredMessages: 5000,
+	retentionDays: 90,
+	pruneBatchSize: 500,
+} as const
+
+const systemEmailLocalSet = new Set<string>(systemEmailLocals)
+
+export type ProvisionedSystemEmailInbox = {
+	inbox: EmailInboxRecord
+	address: EmailInboxAddressRecord
+}
+
+export function isSystemEmailLocal(
+	localPart: string,
+): localPart is SystemEmailLocal {
+	return systemEmailLocalSet.has(localPart.trim().toLowerCase())
+}
+
+export async function ensureSystemEmailInbox(input: {
+	db: D1Database
+	localPart: SystemEmailLocal
+	domain: string
+}): Promise<ProvisionedSystemEmailInbox | null> {
+	const localPart = input.localPart.trim().toLowerCase() as SystemEmailLocal
+	const address = buildPlatformEmailAddress({
+		username: localPart,
+		domain: input.domain,
+	})
+
+	const readExisting = async () => {
+		const existingAddress = await getEmailInboxAddressByAddress({
+			db: input.db,
+			address,
+		})
+		if (!existingAddress) return null
+		if (existingAddress.userId !== systemEmailOwnerId) {
+			await deleteEmailInboxAddressById({
+				db: input.db,
+				addressId: existingAddress.id,
+			})
+			return null
+		}
+		if (!existingAddress.enabled) {
+			return { conflict: true as const }
+		}
+		const inbox = await getEmailInboxById({
+			db: input.db,
+			userId: systemEmailOwnerId,
+			id: existingAddress.inboxId,
+		})
+		if (!inbox?.enabled) return { conflict: true as const }
+		return { conflict: false as const, inbox, address: existingAddress }
+	}
+
+	const existing = await readExisting()
+	if (existing) {
+		return existing.conflict
+			? null
+			: { inbox: existing.inbox, address: existing.address }
+	}
+
+	let inbox = await getEmailInboxByName({
+		db: input.db,
+		userId: systemEmailOwnerId,
+		name: localPart,
+	})
+	if (!inbox) {
+		try {
+			inbox = await createEmailInbox({
+				db: input.db,
+				userId: systemEmailOwnerId,
+				name: localPart,
+				description: `Operator-owned system inbox for ${address}`,
+			})
+		} catch (error) {
+			inbox = await getEmailInboxByName({
+				db: input.db,
+				userId: systemEmailOwnerId,
+				name: localPart,
+			})
+			if (!inbox) throw error
+		}
+	}
+
+	try {
+		const created = await createEmailInboxAddress({
+			db: input.db,
+			inboxId: inbox.id,
+			userId: systemEmailOwnerId,
+			address,
+			localPart,
+			domain: input.domain,
+		})
+		return { inbox, address: created }
+	} catch (error) {
+		const raced = await readExisting()
+		if (raced) {
+			return raced.conflict
+				? null
+				: { inbox: raced.inbox, address: raced.address }
+		}
+		throw error
+	}
+}
+
+export function systemEmailDayKey(now = new Date()) {
+	return now.toISOString().slice(0, 'YYYY-MM-DD'.length)
+}
+
+export async function consumeSystemEmailDailyReceive(input: {
+	db: D1Database
+	localPart: SystemEmailLocal
+	now?: Date
+	limit?: number
+}) {
+	const now = input.now ?? new Date()
+	const limit = input.limit ?? systemEmailLimits.maxReceivesPerDay
+	const row = await input.db
+		.prepare(
+			`INSERT INTO system_email_daily_counters (
+				local_part, day, count, updated_at
+			) VALUES (?, ?, 1, ?)
+			ON CONFLICT(local_part, day) DO UPDATE SET
+				count = count + 1,
+				updated_at = excluded.updated_at
+			WHERE count < ?
+			RETURNING count`,
+		)
+		.bind(input.localPart, systemEmailDayKey(now), now.toISOString(), limit)
+		.first<{ count: number }>()
+	return row ? Number(row.count) : null
+}
+
+export async function countStoredSystemEmailMessages(input: {
+	db: D1Database
+}) {
+	const row = await input.db
+		.prepare(
+			`SELECT COUNT(*) AS count
+			FROM email_messages
+			WHERE user_id = ?
+				AND direction = 'inbound'`,
+		)
+		.bind(systemEmailOwnerId)
+		.first<{ count: number }>()
+	return Number(row?.count ?? 0)
+}
+
+async function listSystemEmailMessageIds(input: {
+	db: D1Database
+	before?: string
+	offset?: number
+	limit: number
+}) {
+	const where = [`user_id = ?`, `direction = 'inbound'`]
+	const bindings: Array<string | number> = [systemEmailOwnerId]
+	if (input.before) {
+		where.push(`created_at < ?`)
+		bindings.push(input.before)
+	}
+	const offset = input.offset ?? 0
+	const result = await input.db
+		.prepare(
+			`SELECT id
+			FROM email_messages
+			WHERE ${where.join(' AND ')}
+			ORDER BY created_at DESC, id DESC
+			LIMIT ? OFFSET ?`,
+		)
+		.bind(...bindings, input.limit, offset)
+		.all<{ id: string }>()
+	return (result.results ?? []).map((row) => row.id)
+}
+
+async function deleteSystemEmailMessagesByIds(input: {
+	db: D1Database
+	messageIds: ReadonlyArray<string>
+}) {
+	if (input.messageIds.length === 0) return 0
+	const placeholders = input.messageIds.map(() => '?').join(', ')
+	await input.db
+		.prepare(
+			`DELETE FROM email_attachments
+			WHERE message_id IN (${placeholders})`,
+		)
+		.bind(...input.messageIds)
+		.run()
+	await input.db
+		.prepare(
+			`DELETE FROM email_delivery_events
+			WHERE message_id IN (${placeholders})`,
+		)
+		.bind(...input.messageIds)
+		.run()
+	for (const messageId of input.messageIds) {
+		await deleteEmailMessageById({ db: input.db, messageId })
+	}
+	return input.messageIds.length
+}
+
+export type SystemEmailRetentionResult = {
+	deletedMessages: number
+	deletedDeliveryEvents: number
+	deletedCounters: number
+	deletedThreads: number
+}
+
+export async function pruneSystemEmailRetention(input: {
+	db: D1Database
+	now?: Date
+}) {
+	const now = input.now ?? new Date()
+	const cutoff = new Date(
+		now.getTime() - systemEmailLimits.retentionDays * 24 * 60 * 60 * 1000,
+	)
+	const cutoffIso = cutoff.toISOString()
+	const cutoffDay = systemEmailDayKey(cutoff)
+	const result: SystemEmailRetentionResult = {
+		deletedMessages: 0,
+		deletedDeliveryEvents: 0,
+		deletedCounters: 0,
+		deletedThreads: 0,
+	}
+
+	const oldMessageIds = await listSystemEmailMessageIds({
+		db: input.db,
+		before: cutoffIso,
+		limit: systemEmailLimits.pruneBatchSize,
+	})
+	result.deletedMessages += await deleteSystemEmailMessagesByIds({
+		db: input.db,
+		messageIds: oldMessageIds,
+	})
+
+	const overCapMessageIds = await listSystemEmailMessageIds({
+		db: input.db,
+		offset: systemEmailLimits.maxStoredMessages,
+		limit: systemEmailLimits.pruneBatchSize,
+	})
+	result.deletedMessages += await deleteSystemEmailMessagesByIds({
+		db: input.db,
+		messageIds: overCapMessageIds,
+	})
+
+	const eventDelete = await input.db
+		.prepare(
+			`DELETE FROM email_delivery_events
+			WHERE user_id = ?
+				AND created_at < ?`,
+		)
+		.bind(systemEmailOwnerId, cutoffIso)
+		.run()
+	result.deletedDeliveryEvents = eventDelete.meta.changes ?? 0
+
+	const counterDelete = await input.db
+		.prepare(`DELETE FROM system_email_daily_counters WHERE day < ?`)
+		.bind(cutoffDay)
+		.run()
+	result.deletedCounters = counterDelete.meta.changes ?? 0
+
+	const threadDelete = await input.db
+		.prepare(
+			`DELETE FROM email_threads
+			WHERE user_id = ?
+				AND NOT EXISTS (
+					SELECT 1 FROM email_messages WHERE email_messages.thread_id = email_threads.id
+				)`,
+		)
+		.bind(systemEmailOwnerId)
+		.run()
+	result.deletedThreads = threadDelete.meta.changes ?? 0
+
+	return result
+}

--- a/packages/worker/src/email/system-email.workers.test.ts
+++ b/packages/worker/src/email/system-email.workers.test.ts
@@ -1,0 +1,276 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import { handleInboundEmail } from './inbound.ts'
+import {
+	listEmailInboxesForUser,
+	listEmailMessages,
+	maxDetailedEmailRejectionEventsPerDay,
+} from './repo.ts'
+import {
+	pruneSystemEmailRetention,
+	systemEmailLimits,
+	systemEmailOwnerId,
+} from './system-email.ts'
+import { createForwardableEmailMessage } from './test-fixtures.ts'
+import { ensureEmailTestSchema } from './test-schema.ts'
+import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+
+const platformBaseUrl = 'https://kody.example.com'
+const platformDomain = 'kody.example.com'
+
+function createInboundEnv() {
+	return { ...env, APP_BASE_URL: platformBaseUrl }
+}
+
+function buildInboundMessage(input: {
+	to: string
+	subject?: string
+	messageId?: string
+}) {
+	return createForwardableEmailMessage({
+		from: 'sender@example.net',
+		to: input.to,
+		raw: [
+			'From: Sender <sender@example.net>',
+			`To: ${input.to}`,
+			`Subject: ${input.subject ?? 'System mail'}`,
+			`Message-ID: <${input.messageId ?? crypto.randomUUID()}@example.net>`,
+			'',
+			'System body.',
+		].join('\r\n'),
+	})
+}
+
+async function seedVerifiedAccount(input: { email: string; username: string }) {
+	await env.APP_DB.prepare(
+		`INSERT INTO users (username, email, password_hash, email_verified_at)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(username) DO UPDATE SET
+			email = excluded.email,
+			email_verified_at = excluded.email_verified_at,
+			updated_at = CURRENT_TIMESTAMP`,
+	)
+		.bind(
+			input.username,
+			input.email,
+			'test-password-hash',
+			new Date().toISOString(),
+		)
+		.run()
+}
+
+async function readRejectionEvents() {
+	const { results } = await env.APP_DB.prepare(
+		`SELECT id, detail_json FROM email_delivery_events
+		WHERE user_id = ? AND event_type = 'rejected'
+		ORDER BY created_at ASC, id ASC`,
+	)
+		.bind(systemEmailOwnerId)
+		.all<{ id: string; detail_json: string }>()
+	const rows = (results ?? []).map((row) => ({
+		id: row.id,
+		detail: JSON.parse(row.detail_json) as Record<string, unknown>,
+	}))
+	return {
+		detailed: rows.filter((row) => row.detail['aggregate'] !== true),
+		aggregate: rows.find((row) => row.detail['aggregate'] === true) ?? null,
+	}
+}
+
+test('reserved system locals store under the operator-owned system inbox', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	await ensureUsageRollupsTestSchema(env.APP_DB)
+	const legacyEmail = `legacy-kody-${crypto.randomUUID()}@example.com`
+	const legacyUserId = await createStableUserIdFromEmail(legacyEmail)
+	await seedVerifiedAccount({ email: legacyEmail, username: 'kody' })
+
+	const message = buildInboundMessage({
+		to: `kody@${platformDomain}`,
+		subject: 'Cloudflare confirmation',
+	})
+	await handleInboundEmail(message, createInboundEnv())
+
+	expect(message.rejectedReason).toBeNull()
+	expect(
+		await listEmailMessages({
+			db: env.APP_DB,
+			userId: legacyUserId,
+			limit: 10,
+		}),
+	).toEqual([])
+	const messages = await listEmailMessages({
+		db: env.APP_DB,
+		userId: systemEmailOwnerId,
+		limit: 10,
+	})
+	expect(messages).toHaveLength(1)
+	expect(messages[0]).toMatchObject({
+		subject: 'Cloudflare confirmation',
+		fromAddress: 'sender@example.net',
+		processingStatus: 'stored',
+	})
+	const inboxes = await listEmailInboxesForUser({
+		db: env.APP_DB,
+		userId: systemEmailOwnerId,
+	})
+	expect(inboxes.map((inbox) => inbox.name)).toEqual(['kody'])
+	const rollup = await env.APP_DB.prepare(
+		`SELECT event_count, error_count FROM usage_rollups
+		WHERE user_id = ? AND metric = 'email_received'`,
+	)
+		.bind(systemEmailOwnerId)
+		.first<{ event_count: number; error_count: number }>()
+	expect(rollup).toMatchObject({ event_count: 1, error_count: 0 })
+})
+
+test('non-system reserved locals still reject while username addresses are unaffected', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const username = `normal-${crypto.randomUUID().slice(0, 8)}`
+	const email = `normal-${crypto.randomUUID()}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	await seedVerifiedAccount({ email, username })
+
+	const reservedMessage = buildInboundMessage({
+		to: `help@${platformDomain}`,
+	})
+	await handleInboundEmail(reservedMessage, createInboundEnv())
+	expect(reservedMessage.rejectedReason).toBe(
+		'This address is reserved for system mail.',
+	)
+
+	const userMessage = buildInboundMessage({
+		to: `${username}@${platformDomain}`,
+		subject: 'User inbox still works',
+	})
+	await handleInboundEmail(userMessage, createInboundEnv())
+	expect(userMessage.rejectedReason).toBeNull()
+	expect(
+		await listEmailMessages({ db: env.APP_DB, userId, limit: 10 }),
+	).toHaveLength(1)
+})
+
+test('system email size and daily caps reject before storage with bounded events', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	await ensureUsageRollupsTestSchema(env.APP_DB)
+
+	const oversize = buildInboundMessage({ to: `abuse@${platformDomain}` })
+	Object.defineProperty(oversize, 'rawSize', {
+		value: systemEmailLimits.maxMessageBytes + 1,
+	})
+	await handleInboundEmail(oversize, createInboundEnv())
+	expect(oversize.rejectedReason).toBe('Recipient mailbox is over quota.')
+	expect(
+		await env.APP_DB.prepare(
+			`SELECT count FROM system_email_daily_counters WHERE local_part = 'abuse'`,
+		).first(),
+	).toBeNull()
+	await env.APP_DB.prepare(
+		`DELETE FROM email_delivery_events WHERE user_id = ?`,
+	)
+		.bind(systemEmailOwnerId)
+		.run()
+
+	await env.APP_DB.prepare(
+		`INSERT INTO system_email_daily_counters (local_part, day, count, updated_at)
+		VALUES ('support', ?, ?, ?)`,
+	)
+		.bind(
+			new Date().toISOString().slice(0, 10),
+			systemEmailLimits.maxReceivesPerDay,
+			new Date().toISOString(),
+		)
+		.run()
+	const attempts = maxDetailedEmailRejectionEventsPerDay + 2
+	for (let index = 0; index < attempts; index += 1) {
+		const capped = buildInboundMessage({
+			to: `support@${platformDomain}`,
+			messageId: `system-cap-${index}`,
+		})
+		await handleInboundEmail(capped, createInboundEnv())
+		expect(capped.rejectedReason).toBe('Recipient mailbox is over quota.')
+	}
+	expect(
+		await listEmailMessages({
+			db: env.APP_DB,
+			userId: systemEmailOwnerId,
+			limit: 10,
+		}),
+	).toEqual([])
+	const rejections = await readRejectionEvents()
+	expect(rejections.detailed).toHaveLength(
+		maxDetailedEmailRejectionEventsPerDay,
+	)
+	expect(rejections.aggregate?.detail).toMatchObject({
+		aggregate: true,
+		count: attempts,
+		last_phase: 'system-limit',
+	})
+})
+
+test('system email retention prunes old operator-owned messages and counters', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const now = new Date('2026-07-06T12:00:00.000Z')
+	const old = new Date(
+		now.getTime() - (systemEmailLimits.retentionDays + 1) * 24 * 60 * 60 * 1000,
+	).toISOString()
+	const fresh = now.toISOString()
+	await env.APP_DB.prepare(
+		`INSERT INTO email_messages (
+			id, direction, user_id, from_address, subject, processing_status, created_at, updated_at
+		) VALUES
+			('old-system-message', 'inbound', ?, 'old@example.net', 'Old', 'stored', ?, ?),
+			('fresh-system-message', 'inbound', ?, 'fresh@example.net', 'Fresh', 'stored', ?, ?)`,
+	)
+		.bind(systemEmailOwnerId, old, old, systemEmailOwnerId, fresh, fresh)
+		.run()
+	await env.APP_DB.prepare(
+		`INSERT INTO email_attachments (
+			id, message_id, filename, content_type, size, storage_kind, created_at
+		) VALUES ('old-attachment', 'old-system-message', 'old.txt', 'text/plain', 1, 'raw-mime', ?)`,
+	)
+		.bind(old)
+		.run()
+	await env.APP_DB.prepare(
+		`INSERT INTO email_delivery_events (
+			id, message_id, user_id, inbox_id, event_type, provider, detail_json, created_at
+		) VALUES
+			('old-event', 'old-system-message', ?, NULL, 'received', 'test', '{}', ?),
+			('fresh-event', 'fresh-system-message', ?, NULL, 'received', 'test', '{}', ?)`,
+	)
+		.bind(systemEmailOwnerId, old, systemEmailOwnerId, fresh)
+		.run()
+	await env.APP_DB.prepare(
+		`INSERT INTO system_email_daily_counters (local_part, day, count, updated_at)
+		VALUES ('admin', '2026-01-01', 1, ?)`,
+	)
+		.bind(old)
+		.run()
+
+	const result = await pruneSystemEmailRetention({ db: env.APP_DB, now })
+
+	expect(result.deletedMessages).toBe(1)
+	expect(result.deletedCounters).toBe(1)
+	expect(
+		await listEmailMessages({
+			db: env.APP_DB,
+			userId: systemEmailOwnerId,
+			limit: 10,
+		}),
+	).toEqual([
+		expect.objectContaining({
+			id: 'fresh-system-message',
+			subject: 'Fresh',
+		}),
+	])
+	expect(
+		await env.APP_DB.prepare(
+			`SELECT id FROM email_attachments WHERE id = 'old-attachment'`,
+		).first(),
+	).toBeNull()
+	expect(
+		await env.APP_DB.prepare(
+			`SELECT id FROM email_delivery_events ORDER BY id ASC`,
+		).all(),
+	).toMatchObject({ results: [{ id: 'fresh-event' }] })
+})

--- a/packages/worker/src/email/test-schema.ts
+++ b/packages/worker/src/email/test-schema.ts
@@ -5,6 +5,7 @@ export async function ensureEmailTestSchema(db: D1Database) {
 	// exercising email sends needs the entitlement tables too.
 	await ensureEntitlementTestSchema(db)
 	const statements = [
+		`DROP TABLE IF EXISTS system_email_daily_counters;`,
 		`DROP TABLE IF EXISTS email_sender_policies;`,
 		`DROP TABLE IF EXISTS email_delivery_events;`,
 		`DROP TABLE IF EXISTS email_attachments;`,
@@ -119,6 +120,13 @@ ON email_sender_identities(user_id, email);`,
 	provider_message_id TEXT,
 	detail_json TEXT NOT NULL DEFAULT '{}',
 	created_at TEXT NOT NULL
+);`,
+		`CREATE TABLE IF NOT EXISTS system_email_daily_counters (
+	local_part TEXT NOT NULL,
+	day TEXT NOT NULL,
+	count INTEGER NOT NULL DEFAULT 0,
+	updated_at TEXT NOT NULL,
+	PRIMARY KEY (local_part, day)
 );`,
 	]
 	for (const statement of statements) {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -55,6 +55,7 @@ import {
 } from '#app/handlers/package-app.ts'
 import { PackageAppRuntimeBridge } from '#worker/package-runtime/package-app.ts'
 import { handleInboundEmail } from '#worker/email/inbound.ts'
+import { pruneSystemEmailRetention } from '#worker/email/system-email.ts'
 import { findPublicUserIdentityByUsername } from '#app/user-lookup.ts'
 
 export {
@@ -534,19 +535,25 @@ const workerHandler = {
 	) {
 		const baseUrl = env.APP_BASE_URL ?? 'https://kody.local'
 		const scheduledAt = new Date(controller.scheduledTime)
-		const [pushesResult, cleanupResult] = await Promise.allSettled([
-			reconcileArtifactsPushes({
-				env,
-				baseUrl,
-				now: scheduledAt,
-			}),
-			cleanupRepoSessionBranches({
-				env,
-				now: scheduledAt,
-			}),
-		])
+		const [pushesResult, cleanupResult, systemEmailResult] =
+			await Promise.allSettled([
+				reconcileArtifactsPushes({
+					env,
+					baseUrl,
+					now: scheduledAt,
+				}),
+				cleanupRepoSessionBranches({
+					env,
+					now: scheduledAt,
+				}),
+				pruneSystemEmailRetention({
+					db: env.APP_DB,
+					now: scheduledAt,
+				}),
+			])
 		if (pushesResult.status === 'rejected') throw pushesResult.reason
 		if (cleanupResult.status === 'rejected') throw cleanupResult.reason
+		if (systemEmailResult.status === 'rejected') throw systemEmailResult.reason
 	},
 } satisfies ExportedHandler<Env>
 

--- a/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from 'vitest'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { adminAuditLogQueryCapability } from './admin-audit-log-query.ts'
+import { adminSystemEmailGetCapability } from './admin-system-email-get.ts'
+import { adminSystemEmailListCapability } from './admin-system-email-list.ts'
 import { adminUsageOverviewCapability } from './admin-usage-overview.ts'
 import { adminUserCreateCapability } from './admin-user-create.ts'
 import { adminUserGetCapability } from './admin-user-get.ts'
@@ -41,6 +43,32 @@ type PasswordResetRow = {
 	expires_at: number
 }
 
+type SystemEmailMessageRow = {
+	id: string
+	user_id: string
+	inbox_id: string | null
+	from_address: string | null
+	envelope_from: string | null
+	to_addresses_json?: string
+	cc_addresses_json?: string
+	reply_to_addresses_json?: string
+	headers_json?: string
+	text_body?: string | null
+	html_body?: string | null
+	raw_mime?: string | null
+	subject: string | null
+	processing_status: string
+	raw_size: number
+	received_at: string | null
+	created_at: string
+}
+
+type EmailInboxAddressRow = {
+	inbox_id: string
+	user_id: string
+	local_part: string
+}
+
 function normalizeQuery(query: string) {
 	return query.replace(/\s+/g, ' ').trim().toLowerCase()
 }
@@ -48,12 +76,20 @@ function normalizeQuery(query: string) {
 function createAdminCapabilityTestDb(input: {
 	users: Array<UserRow>
 	userRoles: Array<UserRoleRow>
+	systemEmailMessages?: Array<SystemEmailMessageRow>
+	emailInboxAddresses?: Array<EmailInboxAddressRow>
 }) {
 	let nextUserId = Math.max(0, ...input.users.map((user) => user.id)) + 1
 	const users = input.users.map((user) => ({ ...user }))
 	const userRoles = input.userRoles.map((row) => ({ ...row }))
 	const auditEvents: Array<AuditEventRow> = []
 	const passwordResets: Array<PasswordResetRow> = []
+	const systemEmailMessages = (input.systemEmailMessages ?? []).map((row) => ({
+		...row,
+	}))
+	const emailInboxAddresses = (input.emailInboxAddresses ?? []).map((row) => ({
+		...row,
+	}))
 
 	function selectAuditEvents(
 		normalizedQuery: string,
@@ -122,7 +158,7 @@ function createAdminCapabilityTestDb(input: {
 					}
 					if (
 						normalizedQuery.includes(
-							'select id, username, email, created_at, updated_at from users where id = ?',
+							'select id, username, email, email_verified_at, created_at, updated_at from users where id = ?',
 						)
 					) {
 						return (users.find((user) => user.id === params[0]) ??
@@ -138,7 +174,7 @@ function createAdminCapabilityTestDb(input: {
 					}
 					if (
 						normalizedQuery.includes(
-							'select id, username, email, created_at, updated_at from users where email = ? collate nocase',
+							'select id, username, email, email_verified_at, created_at, updated_at from users where email = ? collate nocase',
 						)
 					) {
 						const email = String(params[0]).toLowerCase()
@@ -168,6 +204,42 @@ function createAdminCapabilityTestDb(input: {
 							}).length,
 						} as T
 					}
+					if (
+						normalizedQuery.includes(
+							'select count(*) as total from email_messages',
+						)
+					) {
+						return {
+							total: systemEmailMessages.filter(
+								(row) => row.user_id === params[0] && row.id,
+							).length,
+						} as T
+					}
+					if (
+						normalizedQuery.includes('from email_messages as message') &&
+						normalizedQuery.includes('message.id = ?')
+					) {
+						const message = systemEmailMessages.find(
+							(row) => row.user_id === params[0] && row.id === params[1],
+						)
+						if (!message) return null
+						const address = emailInboxAddresses.find(
+							(row) =>
+								row.user_id === message.user_id &&
+								row.inbox_id === message.inbox_id,
+						)
+						return {
+							...message,
+							inbox_local_part: address?.local_part ?? '',
+							to_addresses_json: message.to_addresses_json ?? '[]',
+							cc_addresses_json: message.cc_addresses_json ?? '[]',
+							reply_to_addresses_json: message.reply_to_addresses_json ?? '[]',
+							headers_json: message.headers_json ?? '{}',
+							text_body: message.text_body ?? null,
+							html_body: message.html_body ?? null,
+							raw_mime: message.raw_mime ?? null,
+						} as T
+					}
 					if (normalizedQuery.includes('from entitlement_daily_counters')) {
 						return null
 					}
@@ -178,7 +250,7 @@ function createAdminCapabilityTestDb(input: {
 				async all<T>() {
 					if (
 						normalizedQuery.includes(
-							'select id, username, email, created_at, updated_at from users order by id asc limit ? offset ?',
+							'select id, username, email, email_verified_at, created_at, updated_at from users order by id asc limit ? offset ?',
 						)
 					) {
 						const pageSize = Number(params[0])
@@ -225,6 +297,37 @@ function createAdminCapabilityTestDb(input: {
 								paginated: true,
 							}) as Array<T>,
 						}
+					}
+					if (
+						normalizedQuery.includes('from email_messages as message') &&
+						normalizedQuery.includes("message.direction = 'inbound'")
+					) {
+						const pageSize = Number(params[1])
+						const offset = Number(params[2])
+						return {
+							results: systemEmailMessages
+								.filter((row) => row.user_id === params[0])
+								.sort(
+									(left, right) =>
+										right.created_at.localeCompare(left.created_at) ||
+										right.id.localeCompare(left.id),
+								)
+								.slice(offset, offset + pageSize)
+								.map((message) => {
+									const address = emailInboxAddresses.find(
+										(row) =>
+											row.user_id === message.user_id &&
+											row.inbox_id === message.inbox_id,
+									)
+									return {
+										...message,
+										inbox_local_part: address?.local_part ?? '',
+									}
+								}) as Array<T>,
+						}
+					}
+					if (normalizedQuery.includes('from email_attachments')) {
+						return { results: [] as Array<T> }
 					}
 					if (normalizedQuery.includes('from usage_rollups')) {
 						return { results: [] as Array<T> }
@@ -352,6 +455,7 @@ test('admin capabilities list and get account metadata and query sanitized audit
 				id: 1,
 				username: 'admin',
 				email: 'admin@example.com',
+				email_verified_at: '2026-01-01T00:00:00.000Z',
 				created_at: '2026-01-01 00:00:00',
 				updated_at: '2026-01-02 00:00:00',
 			},
@@ -359,6 +463,7 @@ test('admin capabilities list and get account metadata and query sanitized audit
 				id: 2,
 				username: 'jane',
 				email: 'jane@example.com',
+				email_verified_at: null,
 				created_at: '2026-01-03 00:00:00',
 				updated_at: '2026-01-04 00:00:00',
 			},
@@ -380,11 +485,15 @@ test('admin capabilities list and get account metadata and query sanitized audit
 			expect.objectContaining({
 				id: 1,
 				email: 'admin@example.com',
+				email_verified: true,
+				email_verified_at: '2026-01-01T00:00:00.000Z',
 				roles: ['admin', 'user'],
 			}),
 			expect.objectContaining({
 				id: 2,
 				email: 'jane@example.com',
+				email_verified: false,
+				email_verified_at: null,
 				roles: ['user'],
 			}),
 		],
@@ -428,6 +537,95 @@ test('admin capabilities list and get account metadata and query sanitized audit
 		'admin_usage_overview',
 		'admin_audit_log_query',
 	])
+})
+
+test('admin system email capabilities read only system-owned mail and audit reads', async () => {
+	const { db, auditEvents } = createAdminCapabilityTestDb({
+		users: [
+			{
+				id: 1,
+				username: 'admin',
+				email: 'admin@example.com',
+				created_at: '2026-01-01 00:00:00',
+				updated_at: '2026-01-02 00:00:00',
+			},
+		],
+		userRoles: [{ user_id: 1, role_name: 'admin' }],
+		emailInboxAddresses: [
+			{
+				inbox_id: 'system-inbox-1',
+				user_id: 'system:email',
+				local_part: 'abuse',
+			},
+		],
+		systemEmailMessages: [
+			{
+				id: 'system-message-1',
+				user_id: 'system:email',
+				inbox_id: 'system-inbox-1',
+				from_address: 'sender@example.net',
+				envelope_from: 'bounce@example.net',
+				to_addresses_json: '["abuse@example.com"]',
+				cc_addresses_json: '[]',
+				reply_to_addresses_json: '["sender@example.net"]',
+				headers_json: '{"from":["Sender <sender@example.net>"]}',
+				text_body: 'System body.',
+				html_body: null,
+				raw_mime: 'Subject: Abuse\r\n\r\nSystem body.',
+				subject: 'Abuse report',
+				processing_status: 'stored',
+				raw_size: 32,
+				received_at: '2026-01-03T00:00:00.000Z',
+				created_at: '2026-01-03T00:00:00.000Z',
+			},
+			{
+				id: 'user-message-1',
+				user_id: 'user-123',
+				inbox_id: 'user-inbox-1',
+				from_address: 'private@example.net',
+				envelope_from: 'private@example.net',
+				subject: 'Private user mail',
+				processing_status: 'stored',
+				raw_size: 12,
+				received_at: '2026-01-04T00:00:00.000Z',
+				created_at: '2026-01-04T00:00:00.000Z',
+			},
+		],
+	})
+	const ctx = createAdminCapabilityContext(db)
+
+	const list = await adminSystemEmailListCapability.handler(
+		{ pageSize: 10 },
+		ctx,
+	)
+	expect(list.messages).toEqual([
+		expect.objectContaining({
+			id: 'system-message-1',
+			inbox_local_part: 'abuse',
+			subject: 'Abuse report',
+		}),
+	])
+
+	const get = await adminSystemEmailGetCapability.handler(
+		{ id: 'system-message-1' },
+		ctx,
+	)
+	expect(get.message).toMatchObject({
+		id: 'system-message-1',
+		text_body: 'System body.',
+		raw_mime: 'Subject: Abuse\r\n\r\nSystem body.',
+	})
+	expect(
+		await adminSystemEmailGetCapability.handler({ id: 'user-message-1' }, ctx),
+	).toEqual({ message: null })
+	expect(auditEvents.map((event) => event.action)).toEqual([
+		'admin_system_email_list',
+		'admin_system_email_get',
+		'admin_system_email_get',
+	])
+	expect(auditEvents[1]).toMatchObject({
+		reason: 'target_message_id=system-message-1',
+	})
 })
 
 test('admin_user_create records audit metadata and assigns the default role', async () => {
@@ -487,5 +685,24 @@ test('admin capabilities reject non-admin direct handler calls', async () => {
 		),
 	).rejects.toThrow(
 		'MCP user lacks required role "admin" for capability "admin_user_list".',
+	)
+	await expect(
+		adminSystemEmailListCapability.handler(
+			{},
+			{
+				env: { APP_DB: db } as Env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://example.com',
+					user: {
+						userId: 'user-1',
+						email: 'user@example.com',
+						displayName: 'user',
+						roles: ['user'],
+					},
+				}),
+			},
+		),
+	).rejects.toThrow(
+		'MCP user lacks required role "admin" for capability "admin_system_email_list".',
 	)
 })

--- a/packages/worker/src/mcp/capabilities/admin/admin-shared.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-shared.ts
@@ -23,6 +23,13 @@ export const adminUserMetadataSchema = z.object({
 	id: z.number().int().positive(),
 	username: z.string(),
 	email: z.string(),
+	email_verified: z
+		.boolean()
+		.describe('True when email_verified_at is non-null.'),
+	email_verified_at: z
+		.string()
+		.nullable()
+		.describe('Raw users.email_verified_at timestamp, or null if unverified.'),
 	created_at: z.string(),
 	updated_at: z.string(),
 	roles: z.array(roleNameSchema),

--- a/packages/worker/src/mcp/capabilities/admin/admin-system-email-get.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-system-email-get.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod'
+import { loadAdminSystemEmailMessageById } from '#app/admin-system-email-data.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	adminCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
+import { adminSystemEmailListItemSchema } from './admin-system-email-list.ts'
+
+const inputSchema = z.object({
+	id: z.string().min(1).describe('System email message id to read.'),
+})
+
+const attachmentSchema = z.object({
+	id: z.string(),
+	filename: z.string().nullable(),
+	content_type: z.string().nullable(),
+	content_id: z.string().nullable(),
+	disposition: z.string().nullable(),
+	size: z.number().int().nonnegative(),
+	storage_kind: z.string(),
+	created_at: z.string(),
+})
+
+const systemEmailDetailSchema = adminSystemEmailListItemSchema.extend({
+	to_addresses: z.array(z.string()),
+	cc_addresses: z.array(z.string()),
+	reply_to_addresses: z.array(z.string()),
+	headers: z.record(z.string(), z.array(z.string())),
+	text_body: z.string().nullable(),
+	html_body: z.string().nullable(),
+	raw_mime: z.string().nullable(),
+	attachments: z.array(attachmentSchema),
+})
+
+const outputSchema = z.object({
+	message: systemEmailDetailSchema.nullable(),
+})
+
+export const adminSystemEmailGetCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminCapabilityAccess,
+		name: 'admin_system_email_get',
+		description:
+			'Read one operator-owned system inbox message, including body content and attachment metadata. Admin-only; never reads user-owned email.',
+		keywords: [
+			'admin',
+			'system email',
+			'message content',
+			'abuse',
+			'postmaster',
+		],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_system_email_get',
+				async () => {
+					const message = await loadAdminSystemEmailMessageById(
+						ctx.env.APP_DB,
+						args.id,
+					)
+					return { message }
+				},
+				{
+					successReason: (result) =>
+						result.message
+							? `target_message_id=${result.message.id}`
+							: `target_message_id=${args.id};not_found`,
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/admin-system-email-list.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-system-email-list.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod'
+import { loadAdminSystemEmailData } from '#app/admin-system-email-data.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	adminCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
+
+const inputSchema = z.object({
+	page: z
+		.number()
+		.int()
+		.min(1)
+		.optional()
+		.describe(
+			'One-indexed page of system email messages to return. Defaults to 1.',
+		),
+	pageSize: z
+		.number()
+		.int()
+		.min(1)
+		.max(100)
+		.optional()
+		.describe('Messages per page. Defaults to 25 and maxes at 100.'),
+})
+
+export const adminSystemEmailListItemSchema = z.object({
+	id: z.string(),
+	inbox_local_part: z.string(),
+	from_address: z.string().nullable(),
+	envelope_from: z.string().nullable(),
+	subject: z.string().nullable(),
+	processing_status: z.string(),
+	raw_size: z.number().int().nonnegative(),
+	received_at: z.string().nullable(),
+	created_at: z.string(),
+})
+
+const outputSchema = z.object({
+	total: z.number().int().nonnegative(),
+	page: z.number().int().positive(),
+	pageSize: z.number().int().positive(),
+	ownerId: z
+		.string()
+		.describe(
+			'Reserved operator-owned storage owner id; not a user account id.',
+		),
+	systemLocals: z.array(z.string()),
+	messages: z.array(adminSystemEmailListItemSchema),
+})
+
+export const adminSystemEmailListCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminCapabilityAccess,
+		name: 'admin_system_email_list',
+		description:
+			'List operator-owned system inbox messages for reserved platform addresses. Admin-only; never returns user-owned email.',
+		keywords: [
+			'admin',
+			'system email',
+			'operator inbox',
+			'abuse',
+			'postmaster',
+		],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_system_email_list',
+				async () => {
+					const url = new URL('https://kody.local/admin/system-email.json')
+					if (args.page) url.searchParams.set('page', String(args.page))
+					if (args.pageSize) {
+						url.searchParams.set('pageSize', String(args.pageSize))
+					}
+					const data = await loadAdminSystemEmailData(ctx.env, url.toString())
+					return {
+						total: data.total,
+						page: data.page,
+						pageSize: data.pageSize,
+						ownerId: data.ownerId,
+						systemLocals: data.systemLocals,
+						messages: data.messages,
+					}
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/domain.ts
+++ b/packages/worker/src/mcp/capabilities/admin/domain.ts
@@ -2,6 +2,8 @@ import { defineDomain } from '#mcp/capabilities/define-domain.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { adminAuditLogQueryCapability } from './admin-audit-log-query.ts'
 import { adminUsageOverviewCapability } from './admin-usage-overview.ts'
+import { adminSystemEmailGetCapability } from './admin-system-email-get.ts'
+import { adminSystemEmailListCapability } from './admin-system-email-list.ts'
 import { adminUserCreateCapability } from './admin-user-create.ts'
 import { adminUserGetCapability } from './admin-user-get.ts'
 import { adminUserListCapability } from './admin-user-list.ts'
@@ -9,13 +11,23 @@ import { adminUserListCapability } from './admin-user-list.ts'
 export const adminDomain = defineDomain({
 	name: capabilityDomainNames.admin,
 	description:
-		'Admin-only account metadata capabilities for user and role administration. This domain never exposes user content such as packages, secrets, memories, jobs, or email.',
-	keywords: ['admin', 'rbac', 'account metadata', 'users', 'roles', 'audit'],
+		'Admin-only operator capabilities for account metadata and system email. System email is operator-owned mail for reserved platform addresses; this domain never exposes user-owned content such as packages, secrets, memories, jobs, or user inbox email.',
+	keywords: [
+		'admin',
+		'rbac',
+		'account metadata',
+		'users',
+		'roles',
+		'audit',
+		'system email',
+	],
 	capabilities: [
 		adminUserListCapability,
 		adminUserGetCapability,
 		adminUserCreateCapability,
 		adminAuditLogQueryCapability,
 		adminUsageOverviewCapability,
+		adminSystemEmailListCapability,
+		adminSystemEmailGetCapability,
 	],
 })

--- a/tools/mcp-test-support.ts
+++ b/tools/mcp-test-support.ts
@@ -138,6 +138,8 @@ export async function startDevServer(persistDir: string) {
 				`CLOUDFLARE_API_TOKEN:${mockCloudflareToken}`,
 				'--var',
 				'CLOUDFLARE_ACCOUNT_ID:cf_account_mock_123',
+				'--var',
+				`APP_BASE_URL:${origin}`,
 			],
 			cwd: projectRoot,
 			env: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Route configured reserved locals (`kody`, `support`, `abuse`, `postmaster`, `security`, `admin`) into an operator-owned `system:email` inbox instead of rejecting them, while other reserved locals still reject and username inboxes remain unchanged.
- Add fixed system receive/size/storage caps, bounded rejection events, scheduled 90-day/5000-message retention pruning, and explicit account deletion/export exclusions for system mail.
- Add admin-only MCP capabilities and `/admin/system-email` UI with audit-logged reads, plus unambiguous `email_verified` / `email_verified_at` fields on admin user list/get.

## Walkthrough artifact
<a href="https://cursor.com/agents/bc-0adaa7c5-5eab-4623-9322-e49770672d2f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_system_email_ui_verification.mp4"><img src="https://cursor.com/artifacts/c/art-b939ec3d-d86c-4f26-8df8-0cb4ba3c68c0" alt="admin_system_email_ui_verification.mp4" /></a>

## Validation
- `npx vitest run --project workers-unit packages/worker/src/email/system-email.workers.test.ts packages/worker/src/email/inbound.workers.test.ts`
- `npx vitest run --project node-unit packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts packages/worker/src/app/handlers/admin-users.node.test.ts packages/worker/src/app/account-deletion.node.test.ts packages/worker/src/app/account-export.node.test.ts`
- `npm run typecheck`
- `npx playwright test e2e/admin-rbac.spec.ts`
- `npm run test:mcp`
- `npm run test:e2e:run`
- `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `858befed` · **Head:** `e8f8b922`

**Classification:** extends — this PR extends the existing `email`, `capability-registry`, `d1-app-db`, and admin surfaces for operator-owned system inboxes; it updates the per-user isolation invariant documentation for the explicit `system:email` exception.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `email` | assistant | extends — reserved system locals route to `system:email`, with system caps and retention |
| `capability-registry` | runtime | extends — new admin MCP capabilities for system email list/get |
| `d1-app-db` | storage | extends — new `system_email_daily_counters` table and export/deletion manifest exclusions |
| `usage-metering` | observability | composes — records system receive outcomes under the system owner id |
| `per-user-isolation` | invariant | extends docs/tests — documents operator-owned system email as a deliberate non-user scope |

### System map

```mermaid
flowchart LR
	email["email"]:::extended
	adminUi["admin UI"]:::touched
	capabilityRegistry["capability-registry"]:::extended
	d1["d1-app-db"]:::extended
	usage["usage-metering"]:::touched
	isolation["per-user-isolation"]:::extended

	email --> d1
	email --> usage
	adminUi --> d1
	capabilityRegistry --> d1
	d1 --> isolation

	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart TD
	inbound["Inbound email"] --> domain{"platform domain?"}
	domain -->|system local| systemInbox["ensure system inbox\nuser_id = system:email"]
	domain -->|reserved non-system| reject["reserved reject"]
	domain -->|username| userInbox["existing user inbox path"]
	systemInbox --> gates["fixed size/day/stored caps"]
	gates --> store["store parsed message"]
	store --> adminRead["admin_system_email_* + /admin/system-email"]
	adminRead --> audit["audit_events"]
```

### Invariants

- User-owned inboxes, search, deletion, and export remain scoped by authenticated `userId`.
- System mail uses the reserved owner id `system:email`; it is operator content, not Kent's or any user's personal account data.
- Account deletion/export guardrail tests explicitly preserve/exclude `system:email` rows with documented reasoning.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0adaa7c5-5eab-4623-9322-e49770672d2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0adaa7c5-5eab-4623-9322-e49770672d2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin “System email” page and matching links throughout the admin interface.
  * Admins can now view system-owned mail for reserved platform addresses, including message details and pagination.
  * Admin user lists now show email verification status.

* **Bug Fixes**
  * Reserved system email handling now correctly separates operator-owned mail from user account data.
  * Account deletion and export now exclude system-owned mail rows, preserving operator messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->