### PR TITLE
Fix preview cleanup Cloudflare account selection

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -141,6 +141,7 @@ jobs:
       - name: 🗄️ Apply D1 Migrations (preview)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_ENV: preview
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
         run:
@@ -151,6 +152,7 @@ jobs:
         id: deploy_mocks
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           APP_WORKER_NAME: ${{ steps.names.outputs.worker_name }}
         run: |
           set -euo pipefail
@@ -232,6 +234,7 @@ jobs:
         id: deploy_preview
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_ENV: preview
           APP_WORKER_NAME: ${{ steps.names.outputs.worker_name }}
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
@@ -254,6 +257,7 @@ jobs:
       - name: 🔐 Sync preview app Worker secrets (bulk)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           APP_WORKER_NAME: ${{ steps.names.outputs.worker_name }}
           OVERRIDES_FILE: ${{ steps.deploy_mocks.outputs.overrides_file }}
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
@@ -297,6 +301,7 @@ jobs:
         shell: bash
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_ENV: preview
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
         run: |
@@ -522,14 +527,16 @@ jobs:
       - name: 🗑️ Delete preview Workers
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           APP_WORKER_NAME: ${{ steps.names.outputs.worker_name }}
         run: |
           set -euo pipefail
           delete_worker() {
             local name="$1"
+            local config="$2"
             local output=""
             set +e
-            output="$(npx wrangler delete "$name" --env preview --force 2>&1)"
+            output="$(npx wrangler delete "$name" --env preview --config "$config" --force 2>&1)"
             local exit_code="$?"
             set -e
 
@@ -549,7 +556,7 @@ jobs:
             return "$exit_code"
           }
 
-          delete_worker "$APP_WORKER_NAME"
+          delete_worker "$APP_WORKER_NAME" "packages/worker/wrangler.jsonc"
 
           for dir in packages/mock-servers/*; do
             if [ ! -d "$dir" ]; then
@@ -561,13 +568,14 @@ jobs:
 
             service="$(basename "$dir")"
             mock_worker_name="${APP_WORKER_NAME}-mock-${service}"
-            delete_worker "$mock_worker_name"
+            delete_worker "$mock_worker_name" "$dir/wrangler.jsonc"
           done
 
       - name: 🧹 Delete preview resources (D1 + KV)
         if: always()
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           APP_WORKER_NAME: ${{ steps.names.outputs.worker_name }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Pass `CLOUDFLARE_ACCOUNT_ID` to preview workflow Cloudflare operations so Wrangler can select the intended account non-interactively.
- Delete preview Workers with the correct Wrangler config path for app and mock Workers.
- Cleaned up stale Cloudflare PR preview resources for closed/merged PRs 318, 338, 368, 372, 418, 423, 424, 505, 554, 645, 646, and 647.

## Testing

- `npx oxfmt --check .github/workflows/preview.yml`
- Focused Node assertion for cleanup account/config workflow invariants
- Kody Cloudflare API verification: stale `kody-pr-*` Workers, D1 DBs, and KV namespaces now list empty
- `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `07d14bf8` · **Head:** `e8094189`

**Classification:** composes — workflow wiring only; no runtime primitive behavior or data contract changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `d1-app-db` | storage | composes — preview cleanup now selects the correct Cloudflare account before deleting PR D1 databases |
| `bundle-artifacts-kv` | storage | composes — preview cleanup now selects the correct Cloudflare account before deleting PR KV namespaces |

### System map

```mermaid
flowchart LR
	previewWorkflow["preview.yml cleanup"]:::touched
	d1AppDb["d1-app-db"]:::touched
	bundleArtifactsKv["bundle-artifacts-kv"]:::touched
	previewWorkflow --> d1AppDb
	previewWorkflow --> bundleArtifactsKv
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart LR
	closedPr["PR closed"] --> cleanup["Cleanup job"]
	cleanup --> account["CLOUDFLARE_ACCOUNT_ID"]
	cleanup --> config["Wrangler config path"]
	account --> workers["Delete Workers"]
	config --> workers
	account --> resources["Delete D1 + KV"]
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5ac80f0-e7d7-4af9-9e79-33e7d85c5d8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5ac80f0-e7d7-4af9-9e79-33e7d85c5d8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview environment setup and cleanup so deployments and deletions are more reliable.
  * Fixed preview resource handling to ensure the correct configuration is used during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->