### PR TITLE
Extract shared admin UI primitives

### DIFF
--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -16,7 +16,11 @@ import {
 	type SessionInfo,
 	type SessionStatus,
 } from './session.ts'
-import { layoutMaxWidths } from './styles/style-primitives.ts'
+import {
+	getSecondaryButtonCss,
+	layoutMaxWidths,
+	primaryLinkCss,
+} from './styles/style-primitives.ts'
 import { type AppLoaderData } from '#app/loader-data.ts'
 import { userHasRole } from '#app/permissions.ts'
 import { buildAuthLink } from './auth-links.ts'
@@ -98,17 +102,8 @@ export function App(handle: Handle<AppProps>) {
 		})
 	}
 
-	const navLinkCss = {
-		color: colors.primaryText,
-		fontWeight: typography.fontWeight.medium,
-		textDecoration: 'none',
-		'&:hover': {
-			textDecoration: 'underline',
-		},
-	}
-
 	const navHomeLinkCss = {
-		...navLinkCss,
+		...primaryLinkCss,
 		display: 'flex',
 		alignItems: 'center',
 		lineHeight: 0,
@@ -119,13 +114,8 @@ export function App(handle: Handle<AppProps>) {
 	}
 
 	const logOutButtonCss = {
+		...getSecondaryButtonCss(),
 		padding: `${spacing.xs} ${spacing.md}`,
-		borderRadius: '999px',
-		border: `1px solid ${colors.border}`,
-		backgroundColor: 'transparent',
-		color: colors.text,
-		fontWeight: typography.fontWeight.medium,
-		cursor: 'pointer',
 	}
 
 	const compactNavCss = {
@@ -195,41 +185,41 @@ export function App(handle: Handle<AppProps>) {
 								})}
 							/>
 						</a>
-						<a href="/community" mix={css(navLinkCss)}>
+						<a href="/community" mix={css(primaryLinkCss)}>
 							Community
 						</a>
 						{showAuthLinks ? (
 							<>
-								<a href={loginHref} mix={css(navLinkCss)}>
+								<a href={loginHref} mix={css(primaryLinkCss)}>
 									Login
 								</a>
-								<a href={signupHref} mix={css(navLinkCss)}>
+								<a href={signupHref} mix={css(primaryLinkCss)}>
 									Signup
 								</a>
 							</>
 						) : null}
 						{isLoggedIn ? (
 							<>
-								<a href="/account" mix={css(navLinkCss)}>
+								<a href="/account" mix={css(primaryLinkCss)}>
 									{sessionDisplayName}
 								</a>
-								<a href="/account/secrets" mix={css(navLinkCss)}>
+								<a href="/account/secrets" mix={css(primaryLinkCss)}>
 									Secrets
 								</a>
-								<a href="/account/integrations" mix={css(navLinkCss)}>
+								<a href="/account/integrations" mix={css(primaryLinkCss)}>
 									Integrations
 								</a>
 								<a
 									href="/account/package-invocation-tokens"
-									mix={css(navLinkCss)}
+									mix={css(primaryLinkCss)}
 								>
 									Package tokens
 								</a>
-								<a href="/account/remote-connectors" mix={css(navLinkCss)}>
+								<a href="/account/remote-connectors" mix={css(primaryLinkCss)}>
 									Connectors
 								</a>
 								{showAdminLink ? (
-									<a href="/admin/users" mix={css(navLinkCss)}>
+									<a href="/admin/users" mix={css(primaryLinkCss)}>
 										Admin
 									</a>
 								) : null}

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -18,6 +18,12 @@ import {
 
 type AccountManagementSlot = any
 
+type AccountManagementLinkNavItem = {
+	href: string
+	label: string
+	active: boolean
+}
+
 type AccountManagementShellProps = {
 	maxWidth?: string
 	children: AccountManagementSlot
@@ -106,6 +112,44 @@ const adminNavItems = [
 	},
 ] as const
 
+type AccountManagementLinkNavProps = {
+	label: string
+	items: Array<AccountManagementLinkNavItem>
+}
+
+export function AccountManagementLinkNav(
+	handle: Handle<AccountManagementLinkNavProps>,
+) {
+	const secondaryButtonCss = getSecondaryButtonCss()
+
+	return () => (
+		<nav
+			aria-label={handle.props.label}
+			mix={css({ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' })}
+		>
+			{handle.props.items.map((item) => (
+				<a
+					key={item.href}
+					href={item.href}
+					aria-current={item.active ? 'page' : undefined}
+					mix={css({
+						...secondaryButtonCss,
+						textDecoration: 'none',
+						...(item.active
+							? {
+									borderColor: colors.primary,
+									backgroundColor: colors.primarySoftest,
+								}
+							: {}),
+					})}
+				>
+					{item.label}
+				</a>
+			))}
+		</nav>
+	)
+}
+
 type AdminPageHeaderProps = {
 	title: string
 	description: string
@@ -113,8 +157,6 @@ type AdminPageHeaderProps = {
 }
 
 export function AdminPageHeader(handle: Handle<AdminPageHeaderProps>) {
-	const secondaryButtonCss = getSecondaryButtonCss()
-
 	return () => {
 		const currentPath = new URL(handle.props.currentHref, 'http://localhost')
 			.pathname
@@ -125,33 +167,14 @@ export function AdminPageHeader(handle: Handle<AdminPageHeaderProps>) {
 					title={handle.props.title}
 					description={handle.props.description}
 				/>
-				<nav
-					aria-label="Admin sections"
-					mix={css({ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' })}
-				>
-					{adminNavItems.map((item) => {
-						const isCurrent = item.paths.some((path) => path === currentPath)
-						return (
-							<a
-								key={item.href}
-								href={item.href}
-								aria-current={isCurrent ? 'page' : undefined}
-								mix={css({
-									...secondaryButtonCss,
-									textDecoration: 'none',
-									...(isCurrent
-										? {
-												borderColor: colors.primary,
-												backgroundColor: colors.primarySoftest,
-											}
-										: {}),
-								})}
-							>
-								{item.label}
-							</a>
-						)
-					})}
-				</nav>
+				<AccountManagementLinkNav
+					label="Admin sections"
+					items={adminNavItems.map((item) => ({
+						href: item.href,
+						label: item.label,
+						active: item.paths.some((path) => path === currentPath),
+					}))}
+				/>
 			</>
 		)
 	}
@@ -391,4 +414,23 @@ export const noticeCardCss = {
 	borderRadius: radius.lg,
 	border: `1px solid ${colors.primary}`,
 	backgroundColor: colors.primarySoftest,
+}
+
+export const accountManagementTableCss = {
+	width: '100%',
+	borderCollapse: 'collapse' as const,
+	fontSize: typography.fontSize.sm,
+}
+
+export const accountManagementTableCellCss = {
+	padding: `${spacing.sm} ${spacing.md}`,
+	borderBottom: `1px solid ${colors.border}`,
+	textAlign: 'left' as const,
+	verticalAlign: 'top' as const,
+}
+
+export const accountManagementTableNumericCellCss = {
+	...accountManagementTableCellCss,
+	textAlign: 'right' as const,
+	fontVariantNumeric: 'tabular-nums',
 }

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -2,6 +2,7 @@ import { type Handle, css } from 'remix/ui'
 import { createHref } from 'remix/route-pattern/href'
 import { on } from '#client/event-mixin.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { writeClipboardText } from '#client/clipboard.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import {
@@ -515,7 +516,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 	async function copyEditorRawToken() {
 		if (!editorState.rawToken || saveState !== 'idle') return
 		try {
-			await navigator.clipboard.writeText(editorState.rawToken)
+			await writeClipboardText(editorState.rawToken)
 			message = 'Copied raw token to clipboard.'
 			messageTone = 'info'
 		} catch {

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -498,6 +498,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 	}
 
 	function selectConnector(connector: RemoteConnectorListItem) {
+		if (saveState !== 'idle') return
 		editorState = createEditorStateFromConnector(connector)
 		deleteConfirm = false
 		showSharedSecret = false
@@ -625,10 +626,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 												<AccountManagementListItemButton
 													active={editorState.id === connector.id}
 													disabled={isMutating}
-													onClick={() => {
-														if (isMutating) return
-														selectConnector(connector)
-													}}
+													onClick={() => selectConnector(connector)}
 												>
 													<strong>{connectorLabel(connector)}</strong>
 													<span

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -13,16 +13,14 @@ import {
 } from '#client/route-loader.ts'
 import {
 	AccountManagementHeader,
+	AccountManagementLayout,
+	AccountManagementList,
+	AccountManagementListItemButton,
 	AccountManagementMessage,
 	AccountManagementShell,
+	AccountManagementSidebar,
 } from '#client/routes/account-management-components.tsx'
-import {
-	colors,
-	mq,
-	radius,
-	spacing,
-	typography,
-} from '#client/styles/tokens.ts'
+import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
 	cardTitleCss,
@@ -34,6 +32,7 @@ import {
 	getSecondaryButtonCss,
 	inputCss,
 } from '#client/styles/style-primitives.ts'
+import { writeClipboardText } from '#client/clipboard.ts'
 import { userScopedConnectorWebSocketUrl } from '@kody-internal/shared/remote-connectors.ts'
 
 type RemoteConnectorListItem = {
@@ -183,30 +182,6 @@ function CheckIcon() {
 			<path d="M20 6 9 17l-5-5" />
 		</svg>
 	)
-}
-
-async function writeClipboardText(value: string) {
-	const textArea = document.createElement('textarea')
-	textArea.value = value
-	textArea.setAttribute('readonly', '')
-	textArea.style.position = 'fixed'
-	textArea.style.opacity = '0'
-	document.body.append(textArea)
-	textArea.select()
-	try {
-		if (
-			typeof document.execCommand === 'function' &&
-			document.execCommand('copy')
-		) {
-			return
-		}
-	} catch {
-		// Ignore legacy clipboard failures and fall through to the modern API.
-	} finally {
-		textArea.remove()
-	}
-
-	await navigator.clipboard.writeText(value)
 }
 
 function EyeIcon(props: { showSecret: boolean }) {
@@ -632,64 +607,24 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 				) : null}
 
 				{status === 'ready' ? (
-					<section
-						mix={css({
-							display: 'grid',
-							gridTemplateColumns: 'minmax(18rem, 24rem) minmax(0, 1fr)',
-							gap: spacing.lg,
-							alignItems: 'start',
-							[mq.mobile]: {
-								gridTemplateColumns: '1fr',
-							},
-						})}
-					>
-						<aside mix={css(cardCss)}>
-							<div mix={css({ display: 'grid', gap: spacing.xs })}>
-								<h2 mix={css(cardTitleCss)}>Configured connectors</h2>
-								<p mix={css(descriptionCss)}>
-									Enabled and attached entries are included in your standard MCP
-									and chat caller context.
-								</p>
-							</div>
-							{connectors.length === 0 ? (
-								<p mix={css({ margin: 0, color: colors.textMuted })}>
-									No remote connectors yet. Create one to get started.
-								</p>
-							) : (
-								<ul
-									mix={css({
-										listStyle: 'none',
-										padding: 0,
-										margin: 0,
-										display: 'grid',
-										gap: spacing.sm,
-									})}
-								>
-									{connectors.map((connector) => {
-										const isSelected = editorState.id === connector.id
-										return (
+					<AccountManagementLayout
+						sidebarWidth="minmax(18rem, 24rem)"
+						sidebar={
+							<AccountManagementSidebar
+								title="Configured connectors"
+								description="Enabled and attached entries are included in your standard MCP and chat caller context."
+							>
+								{connectors.length === 0 ? (
+									<p mix={css({ margin: 0, color: colors.textMuted })}>
+										No remote connectors yet. Create one to get started.
+									</p>
+								) : (
+									<AccountManagementList>
+										{connectors.map((connector) => (
 											<li key={connector.id}>
-												<button
-													type="button"
-													mix={[
-														on('click', () => selectConnector(connector)),
-														css({
-															width: '100%',
-															display: 'grid',
-															gap: spacing.xs,
-															textAlign: 'left',
-															padding: spacing.md,
-															borderRadius: radius.md,
-															border: `1px solid ${
-																isSelected ? colors.primary : colors.border
-															}`,
-															backgroundColor: isSelected
-																? colors.primarySoftest
-																: colors.background,
-															color: colors.text,
-															cursor: 'pointer',
-														}),
-													]}
+												<AccountManagementListItemButton
+													active={editorState.id === connector.id}
+													onClick={() => selectConnector(connector)}
 												>
 													<strong>{connectorLabel(connector)}</strong>
 													<span
@@ -704,14 +639,14 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 															? 'Secret saved'
 															: 'Missing secret'}
 													</span>
-												</button>
+												</AccountManagementListItemButton>
 											</li>
-										)
-									})}
-								</ul>
-							)}
-						</aside>
-
+										))}
+									</AccountManagementList>
+								)}
+							</AccountManagementSidebar>
+						}
+					>
 						<form
 							method="post"
 							noValidate
@@ -1016,7 +951,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 								) : null}
 							</div>
 						</form>
-					</section>
+					</AccountManagementLayout>
 				) : null}
 			</AccountManagementShell>
 		)

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -624,7 +624,11 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 											<li key={connector.id}>
 												<AccountManagementListItemButton
 													active={editorState.id === connector.id}
-													onClick={() => selectConnector(connector)}
+													disabled={isMutating}
+													onClick={() => {
+														if (isMutating) return
+														selectConnector(connector)
+													}}
 												>
 													<strong>{connectorLabel(connector)}</strong>
 													<span

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -23,6 +23,11 @@ import {
 	readJson,
 } from '#client/routes/account-approval-shared.ts'
 import {
+	AccountManagementHeader,
+	AccountManagementMessage,
+	AccountManagementShell,
+} from '#client/routes/account-management-components.tsx'
+import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
 } from '#client/route-loader.ts'
@@ -339,30 +344,11 @@ export function AccountRoute(handle: Handle) {
 		const normalizedDraftEmail = draftEmail.trim().toLowerCase()
 
 		return (
-			<section
-				mix={css({
-					maxWidth: layoutMaxWidths.content,
-					margin: '0 auto',
-					display: 'grid',
-					gap: spacing.xl,
-				})}
-			>
-				<header mix={css({ display: 'grid', gap: spacing.xs })}>
-					<h1
-						mix={css({
-							fontSize: typography.fontSize.xl,
-							fontWeight: typography.fontWeight.semibold,
-							color: colors.text,
-							margin: 0,
-						})}
-					>
-						{username ? `${username} account` : 'Account'}
-					</h1>
-					<p mix={css({ color: colors.textMuted, margin: 0 })}>
-						Manage your profile, integrations, approval requests, stored
-						secrets, and package invocation tokens.
-					</p>
-				</header>
+			<AccountManagementShell maxWidth={layoutMaxWidths.content}>
+				<AccountManagementHeader
+					title={username ? `${username} account` : 'Account'}
+					description="Manage your profile, integrations, approval requests, stored secrets, and package invocation tokens."
+				/>
 
 				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
@@ -370,14 +356,9 @@ export function AccountRoute(handle: Handle) {
 					</p>
 				) : null}
 				{message ? (
-					<p
-						role="alert"
-						mix={css({
-							color: messageTone === 'error' ? colors.error : colors.text,
-						})}
-					>
+					<AccountManagementMessage tone={messageTone}>
 						{message}
-					</p>
+					</AccountManagementMessage>
 				) : null}
 
 				{status === 'ready' ? (
@@ -623,7 +604,7 @@ export function AccountRoute(handle: Handle) {
 						Privacy
 					</a>
 				</p>
-			</section>
+			</AccountManagementShell>
 		)
 	}
 }

--- a/packages/worker/client/routes/admin-community-reports.tsx
+++ b/packages/worker/client/routes/admin-community-reports.tsx
@@ -16,6 +16,7 @@ import {
 	inputCss,
 } from '#client/styles/style-primitives.ts'
 import {
+	AccountManagementLinkNav,
 	AccountManagementMessage,
 	AccountManagementShell,
 	AdminPageHeader,
@@ -282,27 +283,14 @@ export function AdminCommunityReportsRoute(handle: Handle) {
 					currentHref={currentHref}
 				/>
 
-				<div mix={css({ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' })}>
-					{statusOptions.map((option) => (
-						<a
-							key={option.value}
-							href={buildReportsHref(handle, option.value)}
-							aria-current={statusFilter === option.value ? 'page' : undefined}
-							mix={css({
-								...secondaryButtonCss,
-								textDecoration: 'none',
-								...(statusFilter === option.value
-									? {
-											borderColor: colors.primary,
-											backgroundColor: colors.primarySoftest,
-										}
-									: {}),
-							})}
-						>
-							{option.label}
-						</a>
-					))}
-				</div>
+				<AccountManagementLinkNav
+					label="Report status"
+					items={statusOptions.map((option) => ({
+						href: buildReportsHref(handle, option.value),
+						label: option.label,
+						active: statusFilter === option.value,
+					}))}
+				/>
 
 				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>

--- a/packages/worker/client/routes/admin-invites.tsx
+++ b/packages/worker/client/routes/admin-invites.tsx
@@ -20,6 +20,7 @@ import {
 	AccountManagementShell,
 	AdminPageHeader,
 	MetadataGrid,
+	noticeCardCss,
 } from './account-management-components.tsx'
 import {
 	type AdminCreatedUserSetup,
@@ -248,7 +249,7 @@ export function AdminInvitesRoute(handle: Handle) {
 				/>
 				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
-						Loading invites...
+						Loading invites…
 					</p>
 				) : null}
 				{message ? (
@@ -296,20 +297,11 @@ export function AdminInvitesRoute(handle: Handle) {
 							disabled={isMutating}
 							mix={css(primaryButtonCss)}
 						>
-							{actionState === 'creatingUser' ? 'Creating...' : 'Create user'}
+							{actionState === 'creatingUser' ? 'Creating…' : 'Create user'}
 						</button>
 					</div>
 					{createdUser ? (
-						<div
-							mix={css({
-								display: 'grid',
-								gap: spacing.sm,
-								padding: spacing.md,
-								border: `1px solid ${colors.primary}`,
-								borderRadius: '0.75rem',
-								backgroundColor: colors.primarySoftest,
-							})}
-						>
+						<div mix={css(noticeCardCss)}>
 							<p mix={css({ margin: 0 })}>
 								Setup link for <strong>{createdUser.email}</strong>:
 							</p>
@@ -394,7 +386,7 @@ export function AdminInvitesRoute(handle: Handle) {
 							disabled={isMutating}
 							mix={css(primaryButtonCss)}
 						>
-							{actionState === 'creating' ? 'Creating...' : 'Create'}
+							{actionState === 'creating' ? 'Creating…' : 'Create'}
 						</button>
 					</div>
 				</AccountManagementPanel>
@@ -458,7 +450,7 @@ export function AdminInvitesRoute(handle: Handle) {
 											css(secondaryButtonCss),
 										]}
 									>
-										{actionState === 'revoking' ? 'Revoking...' : 'Revoke'}
+										{actionState === 'revoking' ? 'Revoking…' : 'Revoke'}
 									</button>
 								</div>
 								<MetadataGrid

--- a/packages/worker/client/routes/admin-system-email.tsx
+++ b/packages/worker/client/routes/admin-system-email.tsx
@@ -4,7 +4,7 @@ import { readRouterSearch } from '#client/router-location.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
-import { colors, spacing, typography } from '#client/styles/tokens.ts'
+import { colors, typography } from '#client/styles/tokens.ts'
 import { cardCss } from '#client/styles/style-primitives.ts'
 import {
 	AccountManagementMessage,
@@ -12,6 +12,9 @@ import {
 	AccountManagementShell,
 	AdminPageHeader,
 	MetadataGrid,
+	accountManagementTableCellCss,
+	accountManagementTableCss,
+	accountManagementTableNumericCellCss,
 } from './account-management-components.tsx'
 import { type AdminSystemEmailLoaderData } from '#app/loader-data.ts'
 import {
@@ -132,22 +135,9 @@ export function AdminSystemEmailRoute(handle: Handle) {
 		return true
 	}
 
-	const tableCss = {
-		width: '100%',
-		borderCollapse: 'collapse' as const,
-		fontSize: typography.fontSize.sm,
-	}
-	const cellCss = {
-		padding: `${spacing.sm} ${spacing.md}`,
-		borderBottom: `1px solid ${colors.border}`,
-		textAlign: 'left' as const,
-		verticalAlign: 'top' as const,
-	}
-	const numericCellCss = {
-		...cellCss,
-		textAlign: 'right' as const,
-		fontVariantNumeric: 'tabular-nums',
-	}
+	const tableCss = accountManagementTableCss
+	const cellCss = accountManagementTableCellCss
+	const numericCellCss = accountManagementTableNumericCellCss
 
 	let lastSeenHref = ''
 
@@ -186,7 +176,7 @@ export function AdminSystemEmailRoute(handle: Handle) {
 				/>
 				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>
-						Loading system email...
+						Loading system email…
 					</p>
 				) : null}
 				{message ? (

--- a/packages/worker/client/routes/admin-usage.tsx
+++ b/packages/worker/client/routes/admin-usage.tsx
@@ -4,7 +4,7 @@ import { readRouterSearch } from '#client/router-location.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
-import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
+import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import { cardCss } from '#client/styles/style-primitives.ts'
 import {
 	AccountManagementMessage,
@@ -12,6 +12,10 @@ import {
 	AccountManagementShell,
 	AdminPageHeader,
 	MetadataGrid,
+	accountManagementTableCellCss,
+	accountManagementTableCss,
+	accountManagementTableNumericCellCss,
+	noticeCardCss,
 } from './account-management-components.tsx'
 import {
 	type AdminUsageLoaderData,
@@ -164,22 +168,9 @@ export function AdminUsageRoute(handle: Handle) {
 		return true
 	}
 
-	const tableCss = {
-		width: '100%',
-		borderCollapse: 'collapse' as const,
-		fontSize: typography.fontSize.sm,
-	}
-	const cellCss = {
-		padding: `${spacing.sm} ${spacing.md}`,
-		borderBottom: `1px solid ${colors.border}`,
-		textAlign: 'left' as const,
-		verticalAlign: 'top' as const,
-	}
-	const numericCellCss = {
-		...cellCss,
-		textAlign: 'right' as const,
-		fontVariantNumeric: 'tabular-nums',
-	}
+	const tableCss = accountManagementTableCss
+	const cellCss = accountManagementTableCellCss
+	const numericCellCss = accountManagementTableNumericCellCss
 
 	let lastSeenHref = ''
 
@@ -390,15 +381,7 @@ export function AdminUsageRoute(handle: Handle) {
 									]}
 								/>
 								{selectedUser.warnings.length > 0 ? (
-									<div
-										mix={css({
-											padding: spacing.md,
-											borderRadius: radius.md,
-											border: `1px solid ${colors.primary}`,
-											backgroundColor: colors.primarySoftest,
-											color: colors.text,
-										})}
-									>
+									<div mix={css(noticeCardCss)}>
 										<strong>Quota watch:</strong>{' '}
 										{selectedUser.warnings
 											.map(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a reusable `AccountManagementLinkNav` for shared pill-style navigation.
- Reuses that link nav for both admin section navigation and community-report status filters.
- Extracts shared account-management table styles for Usage and System email tables.
- Reuses the existing notice-card style for admin invite setup and usage warning surfaces.
- Moves Remote Connectors onto the shared account-management layout/sidebar/list primitives.
- Aligns the Account landing page with the shared account shell/header/message semantics.
- Reuses shared app chrome link/button styles and the shared clipboard fallback helper.
- Keeps the full cleanup net-negative: 165 additions / 263 deletions.

## Walkthrough

Latest account UI primitive reuse:

<a href="https://cursor.com/agents/bc-f41a6076-cf00-4afb-b1e7-6f0cfd2c6213/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faccount-ui-primitive-reuse.mp4"><img src="https://cursor.com/artifacts/c/art-521b5169-deec-4fb7-a258-8c5d9ce55cbb" alt="account-ui-primitive-reuse.mp4" /></a>

Final Remote Connectors state:

![Remote connectors using shared account-management sidebar](https://cursor.com/artifacts/c/art-0ad88314-d419-4bd8-a2f0-4e40830c2f76)

Earlier admin reuse cleanup:

<a href="https://cursor.com/agents/bc-f41a6076-cf00-4afb-b1e7-6f0cfd2c6213/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin-ui-reuse-cleanup.mp4"><img src="https://cursor.com/artifacts/c/art-7bcf93f2-538a-4eb6-a7ec-37367d7b943d" alt="admin-ui-reuse-cleanup.mp4" /></a>

## Testing

- `git push -u origin cursor/admin-ui-reuse-cleanup-6213` (latest pre-push ran typecheck, unit tests, client build, and full Playwright E2E: 186 unit files / 586 tests passed; 6 E2E passed)
- Manual browser walkthrough verified Account, Remote Connectors, connector copy feedback, Package token copy feedback, shared admin nav, report status filters, usage/system-email tables, and invite setup notice card.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `07d14bf` · **Head:** `9fb1eb3`

**Classification:** composes — no primitives added or changed; this PR reuses existing app/account/admin UI primitives across more routes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — shared account layout/list, pill-link nav, notice card, table styles, app chrome styles, and clipboard helper replace duplicated page-local code |

### System map

```mermaid
flowchart LR
	appUi["app-ui"]:::touched
	rbac["rbac"]:::untouched
	appSessions["app-sessions"]:::untouched
	appSessions --> appUi
	rbac --> appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| Remote Connectors hand-rolled account sidebar/list/selected-item styling. | Remote Connectors uses `AccountManagementLayout`, `AccountManagementSidebar`, `AccountManagementList`, and `AccountManagementListItemButton`. |
| Account hub hand-rolled shell/header/status message semantics. | Account hub uses `AccountManagementShell`, `AccountManagementHeader`, and `AccountManagementMessage`. |
| App nav duplicated `primaryLinkCss`; copy actions bypassed shared clipboard fallback. | App chrome and clipboard actions reuse existing primitives. |
| Community report filters duplicated admin nav pill-link styling. | Section nav and report filters share `AccountManagementLinkNav`. |
| Usage/system email duplicated table style objects. | Tables reuse shared account-management table style constants. |
| Invites reimplemented notice card styling. | Invite setup and usage warning states reuse `noticeCardCss`. |

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f41a6076-cf00-4afb-b1e7-6f0cfd2c6213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f41a6076-cf00-4afb-b1e7-6f0cfd2c6213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable labeled navigation component with active-state support for account and admin pages.
  * Adopted shared account-management layout and styling primitives (including table/card UI) across multiple routes.

* **Bug Fixes**
  * Standardized copy-to-clipboard for tokens and connector URLs via a shared clipboard helper.
  * Prevented connector selection while mutations are in progress.

* **Style**
  * Refreshed headers/navigation and admin/account table styling to use shared primitives.
  * Updated loading/action text to use the single-character ellipsis (`…`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->