### PR TITLE
Fix Vectorize ids for package jobs

### DIFF
--- a/docs/contributing/architecture/capability-and-primitive-audit-2026-07.md
+++ b/docs/contributing/architecture/capability-and-primitive-audit-2026-07.md
@@ -287,9 +287,10 @@ orphaned KV entries, missed account deletion cleanup, or stale search results.
 
 **Recommendation: acceptable with documentation**
 
-This PR documents the current formats in `data-storage.md`. Follow up with a
-Vectorize metadata reindex playbook and KV cleanup policy for old publish
-artifacts.
+This PR documents the current formats in `data-storage.md`, including the
+length-safe Vectorize id fallback for user-owned ids that would exceed
+Cloudflare's 64-byte limit. Follow up with a Vectorize metadata reindex playbook
+and KV cleanup policy for old publish artifacts.
 
 ### Medium: `primitives.yaml` lagged recent platform changes
 

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -503,13 +503,21 @@ or a deliberate retention note.
 
 ### Vectorize metadata contracts
 
-Vector ids and metadata are conventional and require reindexing when changed:
+Vector ids and metadata are conventional and require reindexing when changed.
+User-owned ids must also stay within Cloudflare Vectorize's 64-byte id limit:
+builders first emit the legacy passthrough form when it fits, then fall back to
+`{prefix}_sha256:{truncatedHexDigest}` for overlong raw ids. Length checks are
+UTF-8 byte checks, not JavaScript string-length checks, and the digest form is
+deterministic so upserts and deletes target the same vector.
 
 - Memories: `memory_{memoryId}` with metadata
-  `{ kind: 'memory', userId, status, category? }`.
-- Jobs: `job_{jobId}` with metadata `{ kind: 'job', userId }`.
-- Saved packages: `package_{packageId}` with metadata
-  `{ kind: 'package', userId }`.
+  `{ kind: 'memory', userId, status, category? }`. Memory ids are UUID-like, so
+  search parses only the passthrough `memory_` form back to the D1 id.
+- Jobs: `job_{jobId}` or `job_sha256:{digest}` with metadata
+  `{ kind: 'job', userId }`. Package-owned job ids
+  `package-job:{packageId}:{jobName}` often need the digest form.
+- Saved packages: `package_{packageId}` or `package_sha256:{digest}` with
+  metadata `{ kind: 'package', userId }`.
 - Builtin capabilities: id is the capability name with metadata
   `{ kind: 'builtin', domain }`.
 

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -410,8 +410,9 @@ primitives:
       substitutes in local dev.
     code:
       - packages/worker/src/mcp/capabilities/capability-search.ts
+      - packages/worker/src/mcp/capabilities/vector-ids.ts
     docs:
-      - docs/contributing/adding-kody.md
+      - docs/contributing/architecture/data-storage.md
 
   - id: usage-metering
     group: storage

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -807,7 +807,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(result.deletedRowCounts.community_bans).toBe(1)
 	expect(result.updatedRowCounts.community_bans).toBe(1)
 	expect(result.deletedKvKeys).toBe(11)
-	expect(result.deletedVectors).toBe(4)
+	expect(result.deletedVectors).toBe(5)
 	expect(result.clearedDurableObjects).toMatchObject({
 		storageRunners: 6,
 		jobManagers: 1,

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -6,6 +6,7 @@ import {
 	getAccountDeletionD1UserColumnCoverage,
 } from './account-deletion.ts'
 import { accountUserDataExcludedOwnerIds } from './account-data-targets.ts'
+import { jobVectorId } from '#mcp/jobs-vectorize.ts'
 
 type RowMap = Record<string, Array<Record<string, unknown>>>
 
@@ -431,6 +432,8 @@ test('account deletion documents and preserves operator-owned system email rows'
 test('deleteUserAccount cascades user-scoped rows for the requested user', async () => {
 	const userAaa = 'user-aaa'
 	const userBbb = 'user-bbb'
+	const packageJobId =
+		'package-job:b2fda105-005a-4e2b-9f22-1513b6752da2:event-runner'
 	const { db, rows } = createTestDb({
 		users: [
 			{ id: 1, email: 'a@example.com' },
@@ -439,6 +442,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		jobs: [
 			{ id: 'job-1', user_id: userAaa, storage_id: 'job:job-1' },
 			{ id: 'job-2', user_id: userAaa, storage_id: null },
+			{ id: packageJobId, user_id: userAaa, storage_id: null },
 			{ id: 'job-3', user_id: userBbb, storage_id: 'job:job-3' },
 		],
 		package_runtime_runs: [
@@ -757,6 +761,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		'memory_mem-1',
 		'job_job-1',
 		'job_job-2',
+		jobVectorId(packageJobId),
 		'package_pkg-1',
 	])
 	expect(clearStorageMock).toHaveBeenCalledTimes(6)
@@ -789,7 +794,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	])
 
 	// Result accounting captures the per-table counts.
-	expect(result.deletedRowCounts.jobs).toBe(2)
+	expect(result.deletedRowCounts.jobs).toBe(3)
 	expect(result.deletedRowCounts.users).toBe(1)
 	expect(result.deletedRowCounts.email_attachments).toBe(1)
 	expect(result.deletedRowCounts.package_runtime_runs).toBe(3)

--- a/packages/worker/src/jobs/job-reindex.node.test.ts
+++ b/packages/worker/src/jobs/job-reindex.node.test.ts
@@ -1,0 +1,76 @@
+import { expect, test, vi } from 'vitest'
+import { jobVectorId } from '#mcp/jobs-vectorize.ts'
+
+const mockModule = vi.hoisted(() => ({
+	embedTextForVectorize: vi.fn(),
+	embedTextsForVectorize: vi.fn(),
+	getCapabilityVectorIndex: vi.fn(),
+	isCapabilitySearchOffline: vi.fn(),
+	listJobs: vi.fn(),
+}))
+
+vi.mock('#mcp/capabilities/capability-search.ts', () => ({
+	embedTextForVectorize: (...args: Array<unknown>) =>
+		mockModule.embedTextForVectorize(...args),
+	embedTextsForVectorize: (...args: Array<unknown>) =>
+		mockModule.embedTextsForVectorize(...args),
+	getCapabilityVectorIndex: (...args: Array<unknown>) =>
+		mockModule.getCapabilityVectorIndex(...args),
+	isCapabilitySearchOffline: (...args: Array<unknown>) =>
+		mockModule.isCapabilitySearchOffline(...args),
+}))
+
+vi.mock('./service.ts', () => ({
+	listJobs: (...args: Array<unknown>) => mockModule.listJobs(...args),
+}))
+
+const { reindexJobVectors } = await import('./job-reindex.ts')
+
+const textEncoder = new TextEncoder()
+
+function byteLength(value: string) {
+	return textEncoder.encode(value).length
+}
+
+test('job reindex keeps package job vector ids under the Vectorize limit', async () => {
+	const rawJobId =
+		'package-job:b2fda105-005a-4e2b-9f22-1513b6752da2:event-runner'
+	const vectorId = jobVectorId(rawJobId)
+	const upsert = vi.fn(async () => {})
+	const env = {
+		APP_DB: {
+			prepare: () => ({
+				all: async () => ({ results: [{ user_id: 'user-1' }] }),
+			}),
+		},
+	} as unknown as Env
+
+	mockModule.embedTextsForVectorize.mockReset()
+	mockModule.getCapabilityVectorIndex.mockReset()
+	mockModule.isCapabilitySearchOffline.mockReset()
+	mockModule.listJobs.mockReset()
+	mockModule.getCapabilityVectorIndex.mockReturnValue({ upsert })
+	mockModule.isCapabilitySearchOffline.mockReturnValue(false)
+	mockModule.embedTextsForVectorize.mockResolvedValue([[0.4, 0.5, 0.6]])
+	mockModule.listJobs.mockResolvedValue([
+		{
+			id: rawJobId,
+			name: 'Event runner',
+			scheduleSummary: 'Every hour',
+			sourceId: 'source-1',
+			publishedCommit: null,
+		},
+	])
+
+	await expect(reindexJobVectors(env)).resolves.toEqual({ upserted: 1 })
+
+	expect(byteLength(`job_${rawJobId}`)).toBeGreaterThan(64)
+	expect(byteLength(vectorId)).toBeLessThanOrEqual(64)
+	expect(upsert).toHaveBeenCalledWith([
+		{
+			id: vectorId,
+			values: [0.4, 0.5, 0.6],
+			metadata: { kind: 'job', userId: 'user-1' },
+		},
+	])
+})

--- a/packages/worker/src/mcp/capabilities/vector-ids.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/vector-ids.node.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from 'vitest'
+import {
+	buildLengthSafeVectorId,
+	getRawIdFromPassthroughVectorId,
+	vectorizeMaxIdBytes,
+} from './vector-ids.ts'
+
+const textEncoder = new TextEncoder()
+
+function byteLength(value: string) {
+	return textEncoder.encode(value).length
+}
+
+test('buildLengthSafeVectorId preserves ids at or below the Vectorize limit', () => {
+	const rawId = 'a'.repeat(60)
+	const vectorId = buildLengthSafeVectorId({ prefix: 'job', rawId })
+
+	expect(vectorId).toBe(`job_${rawId}`)
+	expect(byteLength(vectorId)).toBe(vectorizeMaxIdBytes)
+})
+
+test('buildLengthSafeVectorId uses a deterministic digest above the limit', () => {
+	expect(
+		buildLengthSafeVectorId({ prefix: 'job', rawId: 'a'.repeat(61) }),
+	).toBe('job_sha256:35d5fc17cfbbadd00f5e710ada39f194c5ad7c766ad67072245f1')
+
+	const rawId = 'package-job:b2fda105-005a-4e2b-9f22-1513b6752da2:event-runner'
+	const firstVectorId = buildLengthSafeVectorId({ prefix: 'job', rawId })
+	const secondVectorId = buildLengthSafeVectorId({ prefix: 'job', rawId })
+	const differentVectorId = buildLengthSafeVectorId({
+		prefix: 'job',
+		rawId: `${rawId}-2`,
+	})
+
+	expect(byteLength(`job_${rawId}`)).toBeGreaterThan(vectorizeMaxIdBytes)
+	expect(firstVectorId).toBe(secondVectorId)
+	expect(firstVectorId).not.toBe(differentVectorId)
+	expect(firstVectorId).toMatch(/^job_sha256:[0-9a-f]+$/)
+	expect(byteLength(firstVectorId)).toBeLessThanOrEqual(vectorizeMaxIdBytes)
+})
+
+test('buildLengthSafeVectorId checks UTF-8 bytes instead of string length', () => {
+	const rawId = '界'.repeat(20)
+	const passthrough = `memory_${rawId}`
+	const vectorId = buildLengthSafeVectorId({ prefix: 'memory', rawId })
+
+	expect(passthrough.length).toBeLessThanOrEqual(vectorizeMaxIdBytes)
+	expect(byteLength(passthrough)).toBeGreaterThan(vectorizeMaxIdBytes)
+	expect(vectorId).toMatch(/^memory_sha256:[0-9a-f]+$/)
+	expect(byteLength(vectorId)).toBeLessThanOrEqual(vectorizeMaxIdBytes)
+})
+
+test('getRawIdFromPassthroughVectorId only parses passthrough ids', () => {
+	expect(
+		getRawIdFromPassthroughVectorId({
+			prefix: 'memory',
+			vectorId: 'memory_mem-1',
+		}),
+	).toBe('mem-1')
+	expect(
+		getRawIdFromPassthroughVectorId({
+			prefix: 'memory',
+			vectorId:
+				'memory_sha256:1b1856c0142a4f2d8993664f79b51e7fa4b8a431e3e1f2e542',
+		}),
+	).toBeNull()
+	expect(
+		getRawIdFromPassthroughVectorId({
+			prefix: 'memory',
+			vectorId: 'job_mem-1',
+		}),
+	).toBeNull()
+})

--- a/packages/worker/src/mcp/capabilities/vector-ids.ts
+++ b/packages/worker/src/mcp/capabilities/vector-ids.ts
@@ -1,0 +1,165 @@
+const textEncoder = new TextEncoder()
+
+export const vectorizeMaxIdBytes = 64
+
+const sha256InitialHash = [
+	0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c,
+	0x1f83d9ab, 0x5be0cd19,
+] as const
+
+const sha256RoundConstants = [
+	0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+	0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+	0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+	0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+	0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+	0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+	0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+	0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+	0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+	0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+	0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+] as const
+
+function utf8ByteLength(value: string) {
+	return textEncoder.encode(value).length
+}
+
+function rightRotate(value: number, bits: number) {
+	return (value >>> bits) | (value << (32 - bits))
+}
+
+function sha256Bytes(input: Uint8Array) {
+	const bitLength = BigInt(input.length) * 8n
+	const paddedLength = Math.ceil((input.length + 9) / 64) * 64
+	const padded = new Uint8Array(paddedLength)
+	padded.set(input)
+	padded[input.length] = 0x80
+	for (let index = 0; index < 8; index += 1) {
+		padded[paddedLength - 1 - index] = Number(
+			(bitLength >> BigInt(index * 8)) & 0xffn,
+		)
+	}
+
+	const words = new Uint32Array(64)
+	let hash0: number = sha256InitialHash[0]
+	let hash1: number = sha256InitialHash[1]
+	let hash2: number = sha256InitialHash[2]
+	let hash3: number = sha256InitialHash[3]
+	let hash4: number = sha256InitialHash[4]
+	let hash5: number = sha256InitialHash[5]
+	let hash6: number = sha256InitialHash[6]
+	let hash7: number = sha256InitialHash[7]
+
+	for (let offset = 0; offset < padded.length; offset += 64) {
+		for (let index = 0; index < 16; index += 1) {
+			const wordOffset = offset + index * 4
+			words[index] =
+				((padded[wordOffset]! << 24) |
+					(padded[wordOffset + 1]! << 16) |
+					(padded[wordOffset + 2]! << 8) |
+					padded[wordOffset + 3]!) >>>
+				0
+		}
+		for (let index = 16; index < 64; index += 1) {
+			const s0 =
+				rightRotate(words[index - 15]!, 7) ^
+				rightRotate(words[index - 15]!, 18) ^
+				(words[index - 15]! >>> 3)
+			const s1 =
+				rightRotate(words[index - 2]!, 17) ^
+				rightRotate(words[index - 2]!, 19) ^
+				(words[index - 2]! >>> 10)
+			words[index] = (words[index - 16]! + s0 + words[index - 7]! + s1) >>> 0
+		}
+
+		let a = hash0
+		let b = hash1
+		let c = hash2
+		let d = hash3
+		let e = hash4
+		let f = hash5
+		let g = hash6
+		let h = hash7
+
+		for (let index = 0; index < 64; index += 1) {
+			const s1 = rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25)
+			const choice = (e & f) ^ (~e & g)
+			const temp1 =
+				(h + s1 + choice + sha256RoundConstants[index]! + words[index]!) >>> 0
+			const s0 = rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22)
+			const majority = (a & b) ^ (a & c) ^ (b & c)
+			const temp2 = (s0 + majority) >>> 0
+
+			h = g
+			g = f
+			f = e
+			e = (d + temp1) >>> 0
+			d = c
+			c = b
+			b = a
+			a = (temp1 + temp2) >>> 0
+		}
+
+		hash0 = (hash0 + a) >>> 0
+		hash1 = (hash1 + b) >>> 0
+		hash2 = (hash2 + c) >>> 0
+		hash3 = (hash3 + d) >>> 0
+		hash4 = (hash4 + e) >>> 0
+		hash5 = (hash5 + f) >>> 0
+		hash6 = (hash6 + g) >>> 0
+		hash7 = (hash7 + h) >>> 0
+	}
+
+	const output = new Uint8Array(32)
+	const hashes = [hash0, hash1, hash2, hash3, hash4, hash5, hash6, hash7]
+	for (let index = 0; index < hashes.length; index += 1) {
+		const value = hashes[index]!
+		const offset = index * 4
+		output[offset] = value >>> 24
+		output[offset + 1] = value >>> 16
+		output[offset + 2] = value >>> 8
+		output[offset + 3] = value
+	}
+	return output
+}
+
+function bytesToHex(bytes: Uint8Array) {
+	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+		'',
+	)
+}
+
+function sha256Hex(value: string) {
+	return bytesToHex(sha256Bytes(textEncoder.encode(value)))
+}
+
+export function buildLengthSafeVectorId(input: {
+	prefix: string
+	rawId: string
+}) {
+	const passthrough = `${input.prefix}_${input.rawId}`
+	if (utf8ByteLength(passthrough) <= vectorizeMaxIdBytes) {
+		return passthrough
+	}
+
+	const digestPrefix = `${input.prefix}_sha256:`
+	const digestCharacters = vectorizeMaxIdBytes - utf8ByteLength(digestPrefix)
+	if (digestCharacters <= 0) {
+		throw new Error(
+			`Vectorize id prefix "${digestPrefix}" exceeds ${vectorizeMaxIdBytes} bytes.`,
+		)
+	}
+	return `${digestPrefix}${sha256Hex(input.rawId).slice(0, digestCharacters)}`
+}
+
+export function getRawIdFromPassthroughVectorId(input: {
+	prefix: string
+	vectorId: string
+}) {
+	const passthroughPrefix = `${input.prefix}_`
+	const digestPrefix = `${input.prefix}_sha256:`
+	if (!input.vectorId.startsWith(passthroughPrefix)) return null
+	if (input.vectorId.startsWith(digestPrefix)) return null
+	return input.vectorId.slice(passthroughPrefix.length)
+}

--- a/packages/worker/src/mcp/jobs-vectorize.node.test.ts
+++ b/packages/worker/src/mcp/jobs-vectorize.node.test.ts
@@ -1,0 +1,61 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	embedTextForVectorize: vi.fn(),
+	getCapabilityVectorIndex: vi.fn(),
+	isCapabilitySearchOffline: vi.fn(),
+}))
+
+vi.mock('#mcp/capabilities/capability-search.ts', () => ({
+	embedTextForVectorize: (...args: Array<unknown>) =>
+		mockModule.embedTextForVectorize(...args),
+	getCapabilityVectorIndex: (...args: Array<unknown>) =>
+		mockModule.getCapabilityVectorIndex(...args),
+	isCapabilitySearchOffline: (...args: Array<unknown>) =>
+		mockModule.isCapabilitySearchOffline(...args),
+}))
+
+const { deleteJobVector, jobVectorId, upsertJobVector } =
+	await import('./jobs-vectorize.ts')
+
+const textEncoder = new TextEncoder()
+
+function byteLength(value: string) {
+	return textEncoder.encode(value).length
+}
+
+test('job vectors use the same length-safe id for upsert and delete', async () => {
+	const rawJobId =
+		'package-job:b2fda105-005a-4e2b-9f22-1513b6752da2:event-runner'
+	const vectorId = jobVectorId(rawJobId)
+	const upsert = vi.fn(async () => {})
+	const deleteByIds = vi.fn(async () => {})
+	const env = {} as Env
+
+	mockModule.embedTextForVectorize.mockReset()
+	mockModule.getCapabilityVectorIndex.mockReset()
+	mockModule.isCapabilitySearchOffline.mockReset()
+	mockModule.embedTextForVectorize.mockResolvedValue([0.1, 0.2, 0.3])
+	mockModule.getCapabilityVectorIndex.mockReturnValue({ upsert, deleteByIds })
+	mockModule.isCapabilitySearchOffline.mockReturnValue(false)
+
+	expect(byteLength(`job_${rawJobId}`)).toBeGreaterThan(64)
+	expect(vectorId).toMatch(/^job_sha256:[0-9a-f]+$/)
+	expect(byteLength(vectorId)).toBeLessThanOrEqual(64)
+
+	await upsertJobVector(env, {
+		jobId: rawJobId,
+		userId: 'user-1',
+		embedText: 'event runner job',
+	})
+	await deleteJobVector(env, rawJobId)
+
+	expect(upsert).toHaveBeenCalledWith([
+		{
+			id: vectorId,
+			values: [0.1, 0.2, 0.3],
+			metadata: { kind: 'job', userId: 'user-1' },
+		},
+	])
+	expect(deleteByIds).toHaveBeenCalledWith([vectorId])
+})

--- a/packages/worker/src/mcp/jobs-vectorize.ts
+++ b/packages/worker/src/mcp/jobs-vectorize.ts
@@ -3,9 +3,10 @@ import {
 	getCapabilityVectorIndex,
 	isCapabilitySearchOffline,
 } from '#mcp/capabilities/capability-search.ts'
+import { buildLengthSafeVectorId } from '#mcp/capabilities/vector-ids.ts'
 
 export function jobVectorId(jobId: string): string {
-	return `job_${jobId}`
+	return buildLengthSafeVectorId({ prefix: 'job', rawId: jobId })
 }
 
 export async function upsertJobVector(

--- a/packages/worker/src/mcp/memory/memory-search.ts
+++ b/packages/worker/src/mcp/memory/memory-search.ts
@@ -9,6 +9,7 @@ import {
 	reciprocalRankFusion,
 	sortIdsByScore,
 } from '#mcp/capabilities/capability-search.ts'
+import { getRawIdFromPassthroughVectorId } from '#mcp/capabilities/vector-ids.ts'
 import { parseJsonStringArray } from './json-string-array.ts'
 import { buildMemoryEmbedTextFromRow } from './memory-embed.ts'
 import { type McpMemoryRow, type MemorySearchMatch } from './types.ts'
@@ -70,8 +71,11 @@ export async function searchMemories(input: {
 		const fromIndex: Array<string> = []
 		for (const match of vectorMatches.matches) {
 			if (typeof match.id !== 'string' || seen.has(match.id)) continue
-			if (!match.id.startsWith('memory_')) continue
-			const memoryId = match.id.slice('memory_'.length)
+			const memoryId = getRawIdFromPassthroughVectorId({
+				prefix: 'memory',
+				vectorId: match.id,
+			})
+			if (!memoryId) continue
 			if (!rowsById.has(memoryId)) continue
 			seen.add(match.id)
 			fromIndex.push(memoryId)

--- a/packages/worker/src/mcp/memory/memory-vectorize.ts
+++ b/packages/worker/src/mcp/memory/memory-vectorize.ts
@@ -3,10 +3,11 @@ import {
 	getCapabilityVectorIndex,
 	isCapabilitySearchOffline,
 } from '#mcp/capabilities/capability-search.ts'
+import { buildLengthSafeVectorId } from '#mcp/capabilities/vector-ids.ts'
 import { type MemoryStatus } from './types.ts'
 
 export function memoryVectorId(memoryId: string): string {
-	return `memory_${memoryId}`
+	return buildLengthSafeVectorId({ prefix: 'memory', rawId: memoryId })
 }
 
 export async function upsertMemoryVector(

--- a/packages/worker/src/package-registry/repo.ts
+++ b/packages/worker/src/package-registry/repo.ts
@@ -1,7 +1,8 @@
+import { buildLengthSafeVectorId } from '#mcp/capabilities/vector-ids.ts'
 import { type SavedPackageRecord, type SavedPackageRow } from './types.ts'
 
 export function savedPackageVectorId(packageId: string) {
-	return `package_${packageId}`
+	return buildLengthSafeVectorId({ prefix: 'package', rawId: packageId })
 }
 
 function mapSavedPackageRow(row: Record<string, unknown>): SavedPackageRecord {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a centralized length-safe Vectorize id builder for user-owned vectors.
- Preserves legacy passthrough ids that fit within 64 UTF-8 bytes, and uses deterministic `*_sha256:<digest>` ids for overlong job/package/memory ids.
- Routes job, memory, saved-package, account-deletion, and memory-search id handling through the shared contract.
- Documents the new Vectorize id rule in the architecture docs.

## Verification

- `npm run validate` passed locally.
- Pre-push gate passed: `npm run typecheck`, `npm run test`, and `npm run test:e2e:run`.
- Post-deploy verification: the reindex endpoint returns 2xx with zero job failures.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `8f32b31` · **Head:** `2fdcd89`

**Classification:** extends — this changes the storage contract for user-owned Vectorize ids while preserving the existing passthrough format for ids already within the 64-byte limit.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `vectorize-search` | storage | extends — adds deterministic length-safe id fallback and shared parser/helper |
| `d1-app-db` | storage | composes — D1 rows remain the source for account deletion and reindex inventory |

### System map

```mermaid
flowchart LR
	D1["d1-app-db"]:::touched --> Helper["vector-id helper"]:::extended
	Helper --> Vectorize["vectorize-search"]:::extended
	Vectorize --> Reindex["reindex maintenance"]:::touched
	Vectorize --> AccountDeletion["account deletion"]:::touched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
Before: job_<raw job id> could exceed Vectorize's 64-byte id limit for package-job:<packageId>:<jobName>.
After:  job_<raw job id> is kept when <=64 UTF-8 bytes; otherwise job_sha256:<truncated digest> is used deterministically.
```

### Invariants

- User-owned Vectorize metadata remains scoped by `userId`.
- Existing standalone job ids keep their `job_<uuid>` vector ids, so current vectors are not orphaned by this change.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59e4ae71-003a-4167-ab82-3c24a746d2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59e4ae71-003a-4167-ab82-3c24a746d2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added length-safe vector IDs so stored search records stay within platform limits, with automatic fallback for long IDs.
  * Improved handling for memories, jobs, and saved packages when vector IDs need to be generated or reused.

* **Bug Fixes**
  * Fixed vector search and cleanup flows to work reliably with long identifiers.
  * Ensured account deletion also removes related job vectors.

* **Documentation**
  * Expanded storage and architecture docs with clearer vector ID rules and reindex/cleanup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->