### PR TITLE
Add scheduled retention pruning for growth tables

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -549,15 +549,49 @@ Saved package imports in user code use `kody:@scope/name/export` specifiers:
 Do not change this grammar or static/dynamic distinction without a user-code
 migration plan.
 
-### Growth and retention watch list
+### Growth and retention policies
 
-These tables can grow without a built-in retention policy beyond account
-deletion or narrow cleanup paths: `audit_events`, user-owned `email_messages`
-and related email tables, `package_runtime_runs`, `package_runtime_logs`,
-`workflow_runs`, `package_invocations`, and old published bundle/KV artifacts.
-System email rows under `system:email` are the email exception: cron prunes
-messages and delivery events older than 90 days, deletes stale
-`system_email_daily_counters`, and caps stored system messages at 5000. User
-email retention is still account-deletion scoped. `usage_rollups` is bounded by
-`(user_id, metric, month)`, while raw Analytics Engine usage events follow
-platform retention.
+The Worker scheduled handler runs every five minutes, but
+`packages/worker/src/app/retention.ts` gates the general retention job to the
+top of the hour and deletes at most one configured batch per table each time.
+This keeps D1 single-writer pressure bounded when a backlog exists; progress is
+reported with a one-line `retention-prune` log. The retention module owns the
+named constants and manifest, and
+`packages/worker/src/app/retention.node.test.ts` fails if a future
+growth-pattern D1 table is added without either a policy or a documented
+exemption.
+
+Current retention policies:
+
+- `package_runtime_runs` / `package_runtime_logs`: keep 30 days of debug runs
+  and at most 500 runs per `(user_id, package_id)`. Logs are deleted before
+  their runs, and orphan logs are pruned separately. Rows with
+  `status = 'running'`, active invocation/workflow/session references, or a
+  running child debug run are kept.
+- `package_invocations`: keep terminal idempotency rows for 90 days. Rows with
+  `status = 'in_progress'` are never pruned so duplicate requests cannot bypass
+  the in-flight guard.
+- `mcp_memory_conversation_suppressions`: keep active suppressions and prune
+  expired rows only after they have not been seen for 90 days. The existing
+  request-time memory prune may remove expired rows sooner.
+- `workflow_runs`: keep terminal projections (`complete`, `errored`,
+  `terminated`) for 90 days based on `completed_at` / `updated_at` /
+  `created_at`. Non-terminal workflow rows are never pruned by retention.
+- `published_bundle_artifacts`: delete D1 rows and their `BUNDLE_ARTIFACTS_KV`
+  blobs only when the row is older than 30 days, its `published_commit` is no
+  longer current for any matching `entity_sources` row, and there is no active
+  repo session for the source. Ambiguous publish/edit cases are intentionally
+  kept.
+- `email_delivery_events`: user-owned delivery events keep 90 days. System email
+  rows under `system:email` remain governed by the system-email retention job,
+  which prunes messages and delivery events older than 90 days, deletes stale
+  `system_email_daily_counters`, and caps stored system messages at 5000.
+- `audit_events`: global hashed auth/security audit events keep 180 days. They
+  are not user-owned D1 rows and remain independent of account deletion/export.
+
+`email_messages` and related user inbox tables remain account-deletion scoped;
+the scheduled policy currently bounds delivery/audit metadata, not user message
+history. `usage_rollups` is bounded by `(user_id, metric, month)`, while raw
+Analytics Engine usage events follow platform retention.
+`archived_job_artifacts` is explicitly exempt from the retention manifest
+because job artifact cleanup is driven by each row's `retain_until` value.

--- a/packages/worker/src/app/retention.node.test.ts
+++ b/packages/worker/src/app/retention.node.test.ts
@@ -1,0 +1,686 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+import {
+	auditEventRetentionDays,
+	emailDeliveryEventRetentionDays,
+	getRetentionPolicyCoverage,
+	memorySuppressionRetentionDays,
+	packageInvocationRetentionDays,
+	packageRuntimeRunRetentionDays,
+	pruneAuditEventsForRetention,
+	pruneEmailDeliveryEventsForRetention,
+	pruneMemorySuppressionsForRetention,
+	prunePackageInvocationsForRetention,
+	prunePackageRuntimeRetention,
+	prunePublishedBundleArtifactsForRetention,
+	pruneWorkflowRunsForRetention,
+	publishedBundleArtifactRetentionDays,
+	retentionPolicies,
+	shouldRunRetentionCron,
+	workflowRunRetentionDays,
+} from './retention.ts'
+import { systemEmailOwnerId } from '#worker/email/system-email.ts'
+
+function quoteSqlIdentifier(identifier: string) {
+	return `"${identifier.replaceAll('"', '""')}"`
+}
+
+function applyMigrations(db: DatabaseSync) {
+	const migrationsDir = new URL('../../migrations/', import.meta.url)
+	for (const fileName of readdirSync(migrationsDir)
+		.filter((file) => file.endsWith('.sql'))
+		.sort()) {
+		db.exec(readFileSync(new URL(fileName, migrationsDir), 'utf8'))
+	}
+}
+
+function createD1FromSqlite(db: DatabaseSync) {
+	return {
+		prepare(query: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async all<T>() {
+							const statement = db.prepare(query)
+							const rows = statement.all(...params) as Array<T>
+							return { results: rows, meta: { changes: 0 } }
+						},
+						async first<T>() {
+							const statement = db.prepare(query)
+							return (statement.get(...params) ?? null) as T | null
+						},
+						async run() {
+							const statement = db.prepare(query)
+							const result = statement.run(...params)
+							return { meta: { changes: result.changes } }
+						},
+					}
+				},
+				async all<T>() {
+					const statement = db.prepare(query)
+					const rows = statement.all() as Array<T>
+					return { results: rows, meta: { changes: 0 } }
+				},
+				async first<T>() {
+					const statement = db.prepare(query)
+					return (statement.get() ?? null) as T | null
+				},
+				async run() {
+					const statement = db.prepare(query)
+					const result = statement.run()
+					return { meta: { changes: result.changes } }
+				},
+			}
+		},
+	} as unknown as D1Database
+}
+
+function createRetentionDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	sqlite.exec(`
+		CREATE TABLE package_runtime_runs (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			package_id TEXT NOT NULL,
+			package_kody_id TEXT NOT NULL,
+			source_id TEXT,
+			published_commit TEXT,
+			surface TEXT NOT NULL,
+			name TEXT,
+			status TEXT NOT NULL,
+			started_at TEXT NOT NULL,
+			finished_at TEXT,
+			duration_ms INTEGER,
+			error_name TEXT,
+			error_message TEXT,
+			storage_id TEXT,
+			job_id TEXT,
+			workflow_id TEXT,
+			invocation_id TEXT,
+			session_id TEXT,
+			idempotency_key TEXT,
+			parent_run_id TEXT,
+			metadata_json TEXT NOT NULL DEFAULT '{}',
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+		CREATE TABLE package_runtime_logs (
+			id TEXT PRIMARY KEY,
+			run_id TEXT NOT NULL,
+			user_id TEXT NOT NULL,
+			package_id TEXT NOT NULL,
+			timestamp TEXT NOT NULL,
+			sequence INTEGER NOT NULL,
+			level TEXT NOT NULL,
+			message TEXT NOT NULL,
+			fields_json TEXT,
+			created_at TEXT NOT NULL
+		);
+		CREATE TABLE package_invocations (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			token_id TEXT NOT NULL,
+			package_id TEXT NOT NULL,
+			package_kody_id TEXT NOT NULL,
+			export_name TEXT NOT NULL,
+			idempotency_key TEXT NOT NULL,
+			request_hash TEXT NOT NULL,
+			source TEXT,
+			topic TEXT,
+			status TEXT NOT NULL,
+			response_json TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+		CREATE TABLE workflow_runs (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			source_type TEXT NOT NULL,
+			package_id TEXT,
+			kody_id TEXT,
+			source_id TEXT,
+			workflow_name TEXT NOT NULL,
+			export_name TEXT,
+			idempotency_key TEXT NOT NULL,
+			run_at TEXT NOT NULL,
+			plan_date TEXT,
+			status TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			completed_at TEXT,
+			last_error TEXT
+		);
+		CREATE TABLE repo_sessions (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			status TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+		CREATE TABLE mcp_memory_conversation_suppressions (
+			user_id TEXT NOT NULL,
+			conversation_id TEXT NOT NULL,
+			memory_id TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			last_seen_at TEXT NOT NULL,
+			expires_at TEXT NOT NULL,
+			PRIMARY KEY (user_id, conversation_id, memory_id)
+		);
+		CREATE TABLE entity_sources (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			entity_kind TEXT NOT NULL,
+			entity_id TEXT NOT NULL,
+			repo_id TEXT NOT NULL,
+			published_commit TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+		CREATE TABLE published_bundle_artifacts (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			published_commit TEXT NOT NULL,
+			artifact_kind TEXT NOT NULL,
+			artifact_name TEXT,
+			entry_point TEXT NOT NULL,
+			kv_key TEXT NOT NULL,
+			dependencies_json TEXT NOT NULL DEFAULT '[]',
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+		CREATE TABLE email_delivery_events (
+			id TEXT PRIMARY KEY,
+			message_id TEXT,
+			user_id TEXT NOT NULL,
+			inbox_id TEXT,
+			event_type TEXT NOT NULL,
+			provider TEXT,
+			provider_message_id TEXT,
+			detail_json TEXT,
+			created_at TEXT NOT NULL
+		);
+		CREATE TABLE audit_events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+			category TEXT NOT NULL,
+			action TEXT NOT NULL,
+			result TEXT NOT NULL,
+			email_hash TEXT,
+			ip_hash TEXT,
+			client_id TEXT,
+			path TEXT,
+			reason TEXT,
+			timestamp TEXT NOT NULL
+		);
+	`)
+	return {
+		sqlite,
+		db: createD1FromSqlite(sqlite),
+	}
+}
+
+const now = new Date('2026-07-07T00:00:00.000Z')
+
+function daysAgo(days: number) {
+	return new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString()
+}
+
+function insertRuntimeRun(
+	db: DatabaseSync,
+	input: {
+		id: string
+		packageId?: string
+		status?: string
+		startedAt: string
+		invocationId?: string | null
+		workflowId?: string | null
+		sessionId?: string | null
+		parentRunId?: string | null
+	},
+) {
+	db.prepare(
+		`INSERT INTO package_runtime_runs (
+			id, user_id, package_id, package_kody_id, surface, status, started_at,
+			invocation_id, workflow_id, session_id, parent_run_id, created_at, updated_at
+		) VALUES (?, 'user-1', ?, ?, 'export', ?, ?, ?, ?, ?, ?, ?, ?)`,
+	).run(
+		input.id,
+		input.packageId ?? 'pkg-1',
+		input.packageId ?? 'pkg-1',
+		input.status ?? 'success',
+		input.startedAt,
+		input.invocationId ?? null,
+		input.workflowId ?? null,
+		input.sessionId ?? null,
+		input.parentRunId ?? null,
+		input.startedAt,
+		input.startedAt,
+	)
+	db.prepare(
+		`INSERT INTO package_runtime_logs (
+			id, run_id, user_id, package_id, timestamp, sequence, level, message, created_at
+		) VALUES (?, ?, 'user-1', ?, ?, 0, 'log', 'message', ?)`,
+	).run(
+		`log-${input.id}`,
+		input.id,
+		input.packageId ?? 'pkg-1',
+		input.startedAt,
+		input.startedAt,
+	)
+}
+
+function idsForTable(db: DatabaseSync, table: string) {
+	return (
+		db.prepare(`SELECT id FROM ${table} ORDER BY id ASC`).all() as Array<{
+			id: string
+		}>
+	).map((row) => row.id)
+}
+
+test('retention manifest covers the requested growth tables and cron is hourly gated', () => {
+	expect(retentionPolicies.map((policy) => policy.table).sort()).toEqual([
+		'audit_events',
+		'email_delivery_events',
+		'mcp_memory_conversation_suppressions',
+		'package_invocations',
+		'package_runtime_logs',
+		'package_runtime_runs',
+		'published_bundle_artifacts',
+		'workflow_runs',
+	])
+	expect(shouldRunRetentionCron(new Date('2026-07-07T03:00:00.000Z'))).toBe(
+		true,
+	)
+	expect(shouldRunRetentionCron(new Date('2026-07-07T03:05:00.000Z'))).toBe(
+		false,
+	)
+})
+
+test('runtime retention prunes old runs, caps per package, and keeps active references', async () => {
+	const { sqlite, db } = createRetentionDb()
+	const cutoff = daysAgo(packageRuntimeRunRetentionDays)
+	insertRuntimeRun(sqlite, { id: 'old-delete', startedAt: daysAgo(31) })
+	insertRuntimeRun(sqlite, { id: 'boundary-keep', startedAt: cutoff })
+	insertRuntimeRun(sqlite, {
+		id: 'running-keep',
+		status: 'running',
+		startedAt: daysAgo(31),
+	})
+	sqlite
+		.prepare(
+			`INSERT INTO package_invocations (
+			id, user_id, token_id, package_id, package_kody_id, export_name,
+			idempotency_key, request_hash, status, created_at, updated_at
+		) VALUES ('inv-active', 'user-1', 'token', 'pkg-1', 'pkg-1', '.', 'key', 'hash', 'in_progress', ?, ?)`,
+		)
+		.run(daysAgo(31), daysAgo(31))
+	insertRuntimeRun(sqlite, {
+		id: 'invocation-keep',
+		startedAt: daysAgo(31),
+		invocationId: 'inv-active',
+	})
+	sqlite
+		.prepare(
+			`INSERT INTO workflow_runs (
+			id, user_id, source_type, workflow_name, idempotency_key, run_at, status,
+			created_at, updated_at
+		) VALUES ('workflow-active', 'user-1', 'inline', 'wf', 'key', ?, 'running', ?, ?)`,
+		)
+		.run(daysAgo(31), daysAgo(31), daysAgo(31))
+	insertRuntimeRun(sqlite, {
+		id: 'workflow-keep',
+		startedAt: daysAgo(31),
+		workflowId: 'workflow-active',
+	})
+	sqlite
+		.prepare(
+			`INSERT INTO repo_sessions (
+			id, user_id, source_id, status, created_at, updated_at
+		) VALUES ('session-active', 'user-1', 'source-1', 'active', ?, ?)`,
+		)
+		.run(daysAgo(31), daysAgo(31))
+	insertRuntimeRun(sqlite, {
+		id: 'session-keep',
+		startedAt: daysAgo(31),
+		sessionId: 'session-active',
+	})
+	insertRuntimeRun(sqlite, { id: 'parent-keep', startedAt: daysAgo(31) })
+	insertRuntimeRun(sqlite, {
+		id: 'child-running',
+		status: 'running',
+		startedAt: daysAgo(1),
+		parentRunId: 'parent-keep',
+	})
+	for (let index = 0; index < 502; index += 1) {
+		insertRuntimeRun(sqlite, {
+			id: `cap-${String(index).padStart(3, '0')}`,
+			packageId: 'pkg-cap',
+			startedAt: new Date(now.getTime() - index * 1000).toISOString(),
+		})
+	}
+	sqlite
+		.prepare(
+			`INSERT INTO package_runtime_logs (
+			id, run_id, user_id, package_id, timestamp, sequence, level, message, created_at
+		) VALUES ('orphan-log', 'missing-run', 'user-1', 'pkg-1', ?, 0, 'log', 'orphan', ?)`,
+		)
+		.run(daysAgo(40), daysAgo(40))
+
+	const result = await prunePackageRuntimeRetention({ db, now, batchSize: 20 })
+
+	expect(result).toEqual({
+		deletedRuns: 3,
+		deletedLogs: 3,
+		deletedOrphanLogs: 1,
+	})
+	expect(idsForTable(sqlite, 'package_runtime_runs')).toContain('boundary-keep')
+	expect(idsForTable(sqlite, 'package_runtime_runs')).toContain('running-keep')
+	expect(idsForTable(sqlite, 'package_runtime_runs')).toContain(
+		'invocation-keep',
+	)
+	expect(idsForTable(sqlite, 'package_runtime_runs')).toContain('workflow-keep')
+	expect(idsForTable(sqlite, 'package_runtime_runs')).toContain('session-keep')
+	expect(idsForTable(sqlite, 'package_runtime_runs')).toContain('parent-keep')
+	expect(idsForTable(sqlite, 'package_runtime_runs')).not.toContain(
+		'old-delete',
+	)
+	expect(idsForTable(sqlite, 'package_runtime_runs')).not.toContain('cap-500')
+	expect(idsForTable(sqlite, 'package_runtime_runs')).not.toContain('cap-501')
+	expect(idsForTable(sqlite, 'package_runtime_logs')).not.toContain(
+		'orphan-log',
+	)
+})
+
+test('package invocation and workflow retention keeps boundary and active idempotency rows', async () => {
+	const { sqlite, db } = createRetentionDb()
+	for (const [id, status, createdAt] of [
+		[
+			'inv-old-completed',
+			'completed',
+			daysAgo(packageInvocationRetentionDays + 1),
+		],
+		['inv-old-failed', 'failed', daysAgo(packageInvocationRetentionDays + 1)],
+		['inv-boundary', 'completed', daysAgo(packageInvocationRetentionDays)],
+		[
+			'inv-in-progress',
+			'in_progress',
+			daysAgo(packageInvocationRetentionDays + 1),
+		],
+	]) {
+		sqlite
+			.prepare(
+				`INSERT INTO package_invocations (
+				id, user_id, token_id, package_id, package_kody_id, export_name,
+				idempotency_key, request_hash, status, response_json, created_at, updated_at
+			) VALUES (?, 'user-1', 'token', 'pkg-1', 'pkg-1', '.', ?, 'hash', ?, '{}', ?, ?)`,
+			)
+			.run(id, id, status, createdAt, createdAt)
+	}
+	for (const [id, status, completedAt] of [
+		[
+			'workflow-old-complete',
+			'complete',
+			daysAgo(workflowRunRetentionDays + 1),
+		],
+		['workflow-old-errored', 'errored', daysAgo(workflowRunRetentionDays + 1)],
+		['workflow-boundary', 'complete', daysAgo(workflowRunRetentionDays)],
+		['workflow-running', 'running', daysAgo(workflowRunRetentionDays + 1)],
+		['workflow-unknown', null, daysAgo(workflowRunRetentionDays + 1)],
+	] as const) {
+		sqlite
+			.prepare(
+				`INSERT INTO workflow_runs (
+				id, user_id, source_type, workflow_name, idempotency_key, run_at, status,
+				created_at, updated_at, completed_at
+			) VALUES (?, 'user-1', 'inline', 'wf', ?, ?, ?, ?, ?, ?)`,
+			)
+			.run(id, id, completedAt, status, completedAt, completedAt, completedAt)
+	}
+
+	expect(await prunePackageInvocationsForRetention({ db, now })).toBe(2)
+	expect(await pruneWorkflowRunsForRetention({ db, now })).toBe(2)
+
+	expect(idsForTable(sqlite, 'package_invocations')).toEqual([
+		'inv-boundary',
+		'inv-in-progress',
+	])
+	expect(idsForTable(sqlite, 'workflow_runs')).toEqual([
+		'workflow-boundary',
+		'workflow-running',
+		'workflow-unknown',
+	])
+})
+
+test('memory suppression, email delivery, and audit retention respect boundaries', async () => {
+	const { sqlite, db } = createRetentionDb()
+	for (const [memoryId, lastSeenAt, expiresAt] of [
+		[
+			'memory-old-expired',
+			daysAgo(memorySuppressionRetentionDays + 1),
+			daysAgo(1),
+		],
+		['memory-boundary', daysAgo(memorySuppressionRetentionDays), daysAgo(1)],
+		['memory-active', daysAgo(memorySuppressionRetentionDays + 1), daysAgo(-1)],
+	]) {
+		sqlite
+			.prepare(
+				`INSERT INTO mcp_memory_conversation_suppressions (
+				user_id, conversation_id, memory_id, created_at, last_seen_at, expires_at
+			) VALUES ('user-1', 'conversation', ?, ?, ?, ?)`,
+			)
+			.run(memoryId, lastSeenAt, lastSeenAt, expiresAt)
+	}
+	for (const [id, userId, createdAt] of [
+		['email-old-user', 'user-1', daysAgo(emailDeliveryEventRetentionDays + 1)],
+		['email-boundary-user', 'user-1', daysAgo(emailDeliveryEventRetentionDays)],
+		[
+			'email-old-system',
+			systemEmailOwnerId,
+			daysAgo(emailDeliveryEventRetentionDays + 1),
+		],
+	]) {
+		sqlite
+			.prepare(
+				`INSERT INTO email_delivery_events (
+				id, user_id, event_type, created_at
+			) VALUES (?, ?, 'received', ?)`,
+			)
+			.run(id, userId, createdAt)
+	}
+	for (const [timestamp] of [
+		[daysAgo(auditEventRetentionDays + 1)],
+		[daysAgo(auditEventRetentionDays)],
+	]) {
+		sqlite
+			.prepare(
+				`INSERT INTO audit_events (
+				category, action, result, timestamp
+			) VALUES ('auth', 'login', 'success', ?)`,
+			)
+			.run(timestamp)
+	}
+
+	expect(await pruneMemorySuppressionsForRetention({ db, now })).toBe(1)
+	expect(await pruneEmailDeliveryEventsForRetention({ db, now })).toBe(1)
+	expect(await pruneAuditEventsForRetention({ db, now })).toBe(1)
+
+	const memories = sqlite
+		.prepare(
+			`SELECT memory_id
+			FROM mcp_memory_conversation_suppressions
+			ORDER BY memory_id`,
+		)
+		.all() as Array<{ memory_id: string }>
+	expect(memories.map((row) => row.memory_id)).toEqual([
+		'memory-active',
+		'memory-boundary',
+	])
+	expect(idsForTable(sqlite, 'email_delivery_events')).toEqual([
+		'email-boundary-user',
+		'email-old-system',
+	])
+	const auditRows = sqlite
+		.prepare(`SELECT timestamp FROM audit_events ORDER BY timestamp`)
+		.all() as Array<{ timestamp: string }>
+	expect(auditRows.map((row) => row.timestamp)).toEqual([
+		daysAgo(auditEventRetentionDays),
+	])
+})
+
+test('published bundle artifact retention deletes only stale unreferenced rows and KV blobs', async () => {
+	const { sqlite, db } = createRetentionDb()
+	const kvDelete = vi.fn(async () => undefined)
+	const env = {
+		APP_DB: db,
+		BUNDLE_ARTIFACTS_KV: {
+			delete: kvDelete,
+		},
+	} as unknown as Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV'>
+	for (const [sourceId, publishedCommit] of [
+		['source-current', 'commit-current'],
+		['source-stale', 'commit-current'],
+		['source-session', 'commit-current'],
+	]) {
+		sqlite
+			.prepare(
+				`INSERT INTO entity_sources (
+				id, user_id, entity_kind, entity_id, repo_id, published_commit,
+				created_at, updated_at
+			) VALUES (?, 'user-1', 'package', ?, ?, ?, ?, ?)`,
+			)
+			.run(
+				sourceId,
+				`pkg-${sourceId}`,
+				`repo-${sourceId}`,
+				publishedCommit,
+				daysAgo(60),
+				daysAgo(60),
+			)
+	}
+	sqlite
+		.prepare(
+			`INSERT INTO repo_sessions (
+			id, user_id, source_id, status, created_at, updated_at
+		) VALUES ('session-1', 'user-1', 'source-session', 'active', ?, ?)`,
+		)
+		.run(daysAgo(1), daysAgo(1))
+	for (const [id, sourceId, commit, createdAt] of [
+		[
+			'artifact-delete',
+			'source-stale',
+			'commit-old',
+			daysAgo(publishedBundleArtifactRetentionDays + 1),
+		],
+		[
+			'artifact-current',
+			'source-current',
+			'commit-current',
+			daysAgo(publishedBundleArtifactRetentionDays + 1),
+		],
+		[
+			'artifact-fresh',
+			'source-stale',
+			'commit-old',
+			daysAgo(publishedBundleArtifactRetentionDays),
+		],
+		[
+			'artifact-session',
+			'source-session',
+			'commit-old',
+			daysAgo(publishedBundleArtifactRetentionDays + 1),
+		],
+	]) {
+		sqlite
+			.prepare(
+				`INSERT INTO published_bundle_artifacts (
+				id, user_id, source_id, published_commit, artifact_kind, entry_point,
+				kv_key, created_at, updated_at
+			) VALUES (?, 'user-1', ?, ?, 'module', 'src/index.ts', ?, ?, ?)`,
+			)
+			.run(id, sourceId, commit, `kv:${id}`, createdAt, createdAt)
+	}
+
+	const result = await prunePublishedBundleArtifactsForRetention({
+		env,
+		now,
+		batchSize: 10,
+	})
+
+	expect(result).toEqual({
+		deletedRows: 1,
+		deletedKvKeys: 1,
+		kvDeleteErrors: 0,
+	})
+	expect(kvDelete).toHaveBeenCalledWith('kv:artifact-delete')
+	expect(idsForTable(sqlite, 'published_bundle_artifacts')).toEqual([
+		'artifact-current',
+		'artifact-fresh',
+		'artifact-session',
+	])
+})
+
+test('retention pruning deletes only one configured batch per table invocation', async () => {
+	const { sqlite, db } = createRetentionDb()
+	for (let index = 0; index < 3; index += 1) {
+		sqlite
+			.prepare(
+				`INSERT INTO package_invocations (
+				id, user_id, token_id, package_id, package_kody_id, export_name,
+				idempotency_key, request_hash, status, created_at, updated_at
+			) VALUES (?, 'user-1', 'token', 'pkg-1', 'pkg-1', '.', ?, 'hash', 'completed', ?, ?)`,
+			)
+			.run(`inv-${index}`, `key-${index}`, daysAgo(120), daysAgo(120))
+	}
+
+	expect(
+		await prunePackageInvocationsForRetention({ db, now, batchSize: 2 }),
+	).toBe(2)
+	expect(idsForTable(sqlite, 'package_invocations')).toEqual(['inv-2'])
+	expect(
+		await prunePackageInvocationsForRetention({ db, now, batchSize: 2 }),
+	).toBe(1)
+	expect(idsForTable(sqlite, 'package_invocations')).toEqual([])
+})
+
+test('retention coverage includes every live growth-pattern table or documented exemption', () => {
+	const db = new DatabaseSync(':memory:')
+	applyMigrations(db)
+	const tables = db
+		.prepare(
+			`SELECT name
+			FROM sqlite_schema
+			WHERE type = 'table'
+				AND name NOT LIKE 'sqlite_%'
+			ORDER BY name`,
+		)
+		.all() as Array<{ name: string }>
+	const candidateTables = new Set<string>()
+	const growthPattern =
+		/(?:_runs|_logs|_events|_invocations|_suppressions|_artifacts)$/u
+	for (const table of tables) {
+		const columns = db
+			.prepare(`PRAGMA table_info(${quoteSqlIdentifier(table.name)})`)
+			.all() as Array<{ name: string }>
+		const columnNames = new Set(columns.map((column) => column.name))
+		const hasUserCreatedGrowthShape =
+			columnNames.has('user_id') &&
+			columnNames.has('created_at') &&
+			growthPattern.test(table.name)
+		const hasGlobalAuditShape =
+			table.name === 'audit_events' && columnNames.has('timestamp')
+		if (hasUserCreatedGrowthShape || hasGlobalAuditShape) {
+			candidateTables.add(table.name)
+		}
+	}
+	const covered = getRetentionPolicyCoverage()
+	const missing = [...candidateTables].filter((table) => !covered.has(table))
+	const stale = [...covered].filter(
+		(table) =>
+			!candidateTables.has(table) && !tables.some((row) => row.name === table),
+	)
+
+	expect(missing).toEqual([])
+	expect(stale).toEqual([])
+})

--- a/packages/worker/src/app/retention.node.test.ts
+++ b/packages/worker/src/app/retention.node.test.ts
@@ -35,11 +35,23 @@ function applyMigrations(db: DatabaseSync) {
 	}
 }
 
-function createD1FromSqlite(db: DatabaseSync) {
+function createD1FromSqlite(
+	db: DatabaseSync,
+	options?: { maxBindings?: number },
+) {
+	function assertBindingCount(params: Array<unknown>) {
+		if (
+			options?.maxBindings !== undefined &&
+			params.length > options.maxBindings
+		) {
+			throw new Error(`too many SQL variables: ${params.length}`)
+		}
+	}
 	return {
 		prepare(query: string) {
 			return {
 				bind(...params: Array<unknown>) {
+					assertBindingCount(params)
 					return {
 						async all<T>() {
 							const statement = db.prepare(query)
@@ -621,6 +633,90 @@ test('published bundle artifact retention deletes only stale unreferenced rows a
 	])
 })
 
+test('published bundle artifact retention rechecks staleness before deleting selected rows', async () => {
+	const { sqlite } = createRetentionDb()
+	const baseDb = createD1FromSqlite(sqlite)
+	const kvDelete = vi.fn(async () => undefined)
+	let refreshedBeforeDelete = false
+	const dbWithRefreshRace = {
+		prepare(query: string) {
+			const prepared = baseDb.prepare(query)
+			if (
+				query.includes('DELETE FROM published_bundle_artifacts') &&
+				query.includes('AND kv_key = ?')
+			) {
+				return {
+					bind(...params: Array<unknown>) {
+						const bound = prepared.bind(...params)
+						return {
+							async run() {
+								refreshedBeforeDelete = true
+								sqlite
+									.prepare(
+										`UPDATE entity_sources
+										SET published_commit = 'commit-old'
+										WHERE id = 'source-race'`,
+									)
+									.run()
+								return bound.run()
+							},
+							all: bound.all,
+							first: bound.first,
+						}
+					},
+				}
+			}
+			return prepared
+		},
+	} as unknown as D1Database
+	const env = {
+		APP_DB: dbWithRefreshRace,
+		BUNDLE_ARTIFACTS_KV: {
+			delete: kvDelete,
+		},
+	} as unknown as Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV'>
+	sqlite
+		.prepare(
+			`INSERT INTO entity_sources (
+				id, user_id, entity_kind, entity_id, repo_id, published_commit,
+				created_at, updated_at
+			) VALUES ('source-race', 'user-1', 'package', 'pkg-race', 'repo-race',
+				'commit-current', ?, ?)`,
+		)
+		.run(daysAgo(60), daysAgo(60))
+	sqlite
+		.prepare(
+			`INSERT INTO published_bundle_artifacts (
+				id, user_id, source_id, published_commit, artifact_kind, entry_point,
+				kv_key, created_at, updated_at
+			) VALUES (
+				'artifact-race', 'user-1', 'source-race', 'commit-old', 'module',
+				'src/index.ts', 'kv:artifact-race', ?, ?
+			)`,
+		)
+		.run(
+			daysAgo(publishedBundleArtifactRetentionDays + 1),
+			daysAgo(publishedBundleArtifactRetentionDays + 1),
+		)
+
+	const result = await prunePublishedBundleArtifactsForRetention({
+		env,
+		now,
+		batchSize: 10,
+	})
+
+	expect(refreshedBeforeDelete).toBe(true)
+	expect(result).toEqual({
+		deletedRows: 0,
+		deletedKvKeys: 0,
+		kvDeleteErrors: 0,
+	})
+	expect(kvDelete).not.toHaveBeenCalled()
+	expect(idsForTable(sqlite, 'published_bundle_artifacts')).toEqual([
+		'artifact-race',
+	])
+})
+
 test('retention pruning deletes only one configured batch per table invocation', async () => {
 	const { sqlite, db } = createRetentionDb()
 	for (let index = 0; index < 3; index += 1) {
@@ -641,6 +737,27 @@ test('retention pruning deletes only one configured batch per table invocation',
 	expect(
 		await prunePackageInvocationsForRetention({ db, now, batchSize: 2 }),
 	).toBe(1)
+	expect(idsForTable(sqlite, 'package_invocations')).toEqual([])
+})
+
+test('retention row deletes chunk ids to stay within the D1 binding limit', async () => {
+	const { sqlite } = createRetentionDb()
+	const db = createD1FromSqlite(sqlite, { maxBindings: 100 })
+	for (let index = 0; index < 101; index += 1) {
+		sqlite
+			.prepare(
+				`INSERT INTO package_invocations (
+					id, user_id, token_id, package_id, package_kody_id, export_name,
+					idempotency_key, request_hash, status, created_at, updated_at
+				) VALUES (?, 'user-1', 'token', 'pkg-1', 'pkg-1', '.', ?, 'hash',
+					'completed', ?, ?)`,
+			)
+			.run(`inv-${index}`, `key-${index}`, daysAgo(120), daysAgo(120))
+	}
+
+	expect(
+		await prunePackageInvocationsForRetention({ db, now, batchSize: 101 }),
+	).toBe(101)
 	expect(idsForTable(sqlite, 'package_invocations')).toEqual([])
 })
 

--- a/packages/worker/src/app/retention.ts
+++ b/packages/worker/src/app/retention.ts
@@ -20,6 +20,7 @@ type IdValue = string | number
 export const retentionCronGateMinutes = 5
 export const retentionCronIntervalMinutes = 60
 export const retentionDefaultBatchSize = 250
+export const retentionDeleteIdsMaxParameters = 100
 export const publishedBundleArtifactRetentionBatchSize = 100
 
 export const packageRuntimeRunRetentionDays = 30
@@ -182,12 +183,53 @@ async function deleteByIds(input: {
 	ids: ReadonlyArray<IdValue>
 }) {
 	if (input.ids.length === 0) return 0
+	let deleted = 0
+	for (
+		let index = 0;
+		index < input.ids.length;
+		index += retentionDeleteIdsMaxParameters
+	) {
+		const ids = input.ids.slice(index, index + retentionDeleteIdsMaxParameters)
+		const result = await input.db
+			.prepare(
+				`DELETE FROM ${input.table}
+				WHERE ${input.idColumn} IN (${placeholders(ids)})`,
+			)
+			.bind(...ids)
+			.run()
+		deleted += result.meta.changes ?? 0
+	}
+	return deleted
+}
+
+async function deletePublishedBundleArtifactRowIfStillStale(input: {
+	db: D1Database
+	id: string
+	kvKey: string
+	cutoff: string
+}) {
 	const result = await input.db
 		.prepare(
-			`DELETE FROM ${input.table}
-			WHERE ${input.idColumn} IN (${placeholders(input.ids)})`,
+			`DELETE FROM published_bundle_artifacts
+			WHERE id = ?
+				AND kv_key = ?
+				AND created_at < ?
+				AND NOT EXISTS (
+					SELECT 1
+					FROM entity_sources AS source
+					WHERE source.user_id = published_bundle_artifacts.user_id
+						AND source.id = published_bundle_artifacts.source_id
+						AND source.published_commit = published_bundle_artifacts.published_commit
+				)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM repo_sessions AS session
+					WHERE session.user_id = published_bundle_artifacts.user_id
+						AND session.source_id = published_bundle_artifacts.source_id
+						AND session.status = 'active'
+				)`,
 		)
-		.bind(...input.ids)
+		.bind(input.id, input.kvKey, input.cutoff)
 		.run()
 	return result.meta.changes ?? 0
 }
@@ -404,14 +446,21 @@ export async function prunePublishedBundleArtifactsForRetention(input: {
 		.bind(cutoff, input.batchSize ?? publishedBundleArtifactRetentionBatchSize)
 		.all<{ id: string; kv_key: string }>()
 	const rows = results ?? []
-	const deletedRowIds: Array<string> = []
+	let deletedRows = 0
 	let deletedKvKeys = 0
 	let kvDeleteErrors = 0
 	for (const row of rows) {
+		const rowDeleted = await deletePublishedBundleArtifactRowIfStillStale({
+			db: input.env.APP_DB,
+			id: row.id,
+			kvKey: row.kv_key,
+			cutoff,
+		})
+		if (rowDeleted === 0) continue
+		deletedRows += rowDeleted
 		try {
 			await input.env.BUNDLE_ARTIFACTS_KV.delete(row.kv_key)
 			deletedKvKeys += 1
-			deletedRowIds.push(row.id)
 		} catch (error) {
 			kvDeleteErrors += 1
 			console.warn('retention-published-bundle-kv-delete-failed', {
@@ -421,12 +470,6 @@ export async function prunePublishedBundleArtifactsForRetention(input: {
 			})
 		}
 	}
-	const deletedRows = await deleteByIds({
-		db: input.env.APP_DB,
-		table: 'published_bundle_artifacts',
-		idColumn: 'id',
-		ids: deletedRowIds,
-	})
 	return { deletedRows, deletedKvKeys, kvDeleteErrors }
 }
 

--- a/packages/worker/src/app/retention.ts
+++ b/packages/worker/src/app/retention.ts
@@ -1,0 +1,524 @@
+import { systemEmailOwnerId } from '#worker/email/system-email.ts'
+import { terminalWorkflowStatusValues } from '#worker/package-runtime/workflow-statuses.ts'
+
+type RetentionPolicy = {
+	table: string
+	scope: 'per-user' | 'global'
+	retentionDays?: number
+	maxRowsPerPartition?: number
+	batchSize: number
+	description: string
+}
+
+type RetentionPolicyExemption = {
+	table: string
+	reason: string
+}
+
+type IdValue = string | number
+
+export const retentionCronGateMinutes = 5
+export const retentionCronIntervalMinutes = 60
+export const retentionDefaultBatchSize = 250
+export const publishedBundleArtifactRetentionBatchSize = 100
+
+export const packageRuntimeRunRetentionDays = 30
+export const packageRuntimeMaxRunsPerPackage = 500
+export const packageInvocationRetentionDays = 90
+export const memorySuppressionRetentionDays = 90
+export const workflowRunRetentionDays = 90
+export const publishedBundleArtifactRetentionDays = 30
+export const emailDeliveryEventRetentionDays = 90
+export const auditEventRetentionDays = 180
+
+const millisecondsPerDay = 24 * 60 * 60 * 1000
+const terminalWorkflowStatusList = terminalWorkflowStatusValues
+	.map((status) => `'${status}'`)
+	.join(', ')
+
+/**
+ * Inventory of D1 growth-table retention policies. Keep this manifest in sync
+ * with the scheduled prune implementation and data-storage.md so future growth
+ * tables have an explicit retention story or a documented exemption.
+ */
+export const retentionPolicies: ReadonlyArray<RetentionPolicy> = [
+	{
+		table: 'package_runtime_runs',
+		scope: 'per-user',
+		retentionDays: packageRuntimeRunRetentionDays,
+		maxRowsPerPartition: packageRuntimeMaxRunsPerPackage,
+		batchSize: retentionDefaultBatchSize,
+		description:
+			'Runtime debug runs keep 30 days and at most 500 rows per user/package. Running or actively referenced runs are kept.',
+	},
+	{
+		table: 'package_runtime_logs',
+		scope: 'per-user',
+		batchSize: retentionDefaultBatchSize,
+		description:
+			'Runtime logs follow retained runtime runs; orphan logs are pruned in small batches.',
+	},
+	{
+		table: 'package_invocations',
+		scope: 'per-user',
+		retentionDays: packageInvocationRetentionDays,
+		batchSize: retentionDefaultBatchSize,
+		description:
+			'Package invocation idempotency rows keep terminal responses for 90 days; in-progress rows are never pruned.',
+	},
+	{
+		table: 'mcp_memory_conversation_suppressions',
+		scope: 'per-user',
+		retentionDays: memorySuppressionRetentionDays,
+		batchSize: retentionDefaultBatchSize,
+		description:
+			'Conversation suppression rows are kept while active and for up to 90 days since last seen.',
+	},
+	{
+		table: 'workflow_runs',
+		scope: 'per-user',
+		retentionDays: workflowRunRetentionDays,
+		batchSize: retentionDefaultBatchSize,
+		description:
+			'Workflow run projections keep terminal states for 90 days; non-terminal rows are never pruned.',
+	},
+	{
+		table: 'published_bundle_artifacts',
+		scope: 'per-user',
+		retentionDays: publishedBundleArtifactRetentionDays,
+		batchSize: publishedBundleArtifactRetentionBatchSize,
+		description:
+			'Published bundle rows and KV blobs are deleted only when older than 30 days, not current for any source, and not tied to an active repo session.',
+	},
+	{
+		table: 'email_delivery_events',
+		scope: 'per-user',
+		retentionDays: emailDeliveryEventRetentionDays,
+		batchSize: retentionDefaultBatchSize,
+		description:
+			'User email delivery events keep 90 days; operator system email remains governed by system-email retention.',
+	},
+	{
+		table: 'audit_events',
+		scope: 'global',
+		retentionDays: auditEventRetentionDays,
+		batchSize: retentionDefaultBatchSize,
+		description:
+			'Global hashed auth/security audit events keep 180 days and are independent of account deletion.',
+	},
+] as const
+
+export const retentionPolicyExemptions: ReadonlyArray<RetentionPolicyExemption> =
+	[
+		{
+			table: 'archived_job_artifacts',
+			reason:
+				'Archived job artifact rows are bounded by retain_until and cleaned by the job artifact cleanup path.',
+		},
+	] as const
+
+export type RetentionPruneResult = {
+	runtimeRuns: {
+		deletedRuns: number
+		deletedLogs: number
+		deletedOrphanLogs: number
+	}
+	packageInvocations: number
+	memorySuppressions: number
+	workflowRuns: number
+	publishedBundleArtifacts: {
+		deletedRows: number
+		deletedKvKeys: number
+		kvDeleteErrors: number
+	}
+	emailDeliveryEvents: number
+	auditEvents: number
+}
+
+export function shouldRunRetentionCron(now: Date) {
+	return (
+		now.getUTCMinutes() < retentionCronGateMinutes &&
+		now.getUTCMinutes() % retentionCronIntervalMinutes === 0
+	)
+}
+
+export function getRetentionPolicyCoverage() {
+	const covered = new Set<string>()
+	for (const policy of retentionPolicies) {
+		covered.add(policy.table)
+	}
+	for (const exemption of retentionPolicyExemptions) {
+		covered.add(exemption.table)
+	}
+	return covered
+}
+
+function cutoffIso(now: Date, days: number) {
+	return new Date(now.getTime() - days * millisecondsPerDay).toISOString()
+}
+
+function placeholders(values: ReadonlyArray<unknown>) {
+	return values.map(() => '?').join(', ')
+}
+
+async function selectIds(input: {
+	db: D1Database
+	sql: string
+	bindings: ReadonlyArray<string | number>
+	column?: string
+}): Promise<Array<IdValue>> {
+	const column = input.column ?? 'id'
+	const { results } = await input.db
+		.prepare(input.sql)
+		.bind(...input.bindings)
+		.all<Record<string, unknown>>()
+	return (results ?? []).map((row) => row[column] as IdValue)
+}
+
+async function deleteByIds(input: {
+	db: D1Database
+	table: string
+	idColumn: string
+	ids: ReadonlyArray<IdValue>
+}) {
+	if (input.ids.length === 0) return 0
+	const result = await input.db
+		.prepare(
+			`DELETE FROM ${input.table}
+			WHERE ${input.idColumn} IN (${placeholders(input.ids)})`,
+		)
+		.bind(...input.ids)
+		.run()
+	return result.meta.changes ?? 0
+}
+
+export async function prunePackageRuntimeRetention(input: {
+	db: D1Database
+	now?: Date
+	batchSize?: number
+}) {
+	const now = input.now ?? new Date()
+	const cutoff = cutoffIso(now, packageRuntimeRunRetentionDays)
+	const batchSize = input.batchSize ?? retentionDefaultBatchSize
+	const runIds = await selectIds({
+		db: input.db,
+		bindings: [cutoff, packageRuntimeMaxRunsPerPackage, batchSize],
+		sql: `WITH ranked_runs AS (
+				SELECT
+					id,
+					user_id,
+					started_at,
+					status,
+					invocation_id,
+					workflow_id,
+					session_id,
+					ROW_NUMBER() OVER (
+						PARTITION BY user_id, package_id
+						ORDER BY started_at DESC, id DESC
+					) AS package_rank
+				FROM package_runtime_runs
+			)
+			SELECT id
+			FROM ranked_runs AS run
+			WHERE (run.started_at < ? OR run.package_rank > ?)
+				AND run.status != 'running'
+				AND NOT EXISTS (
+					SELECT 1
+					FROM package_invocations AS invocation
+					WHERE invocation.user_id = run.user_id
+						AND invocation.id = run.invocation_id
+						AND invocation.status = 'in_progress'
+				)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM workflow_runs AS workflow
+					WHERE workflow.user_id = run.user_id
+						AND workflow.id = run.workflow_id
+						AND (
+							workflow.status IS NULL
+							OR workflow.status NOT IN (${terminalWorkflowStatusList})
+						)
+				)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM repo_sessions AS session
+					WHERE session.user_id = run.user_id
+						AND session.id = run.session_id
+						AND session.status = 'active'
+				)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM package_runtime_runs AS child_run
+					WHERE child_run.user_id = run.user_id
+						AND child_run.parent_run_id = run.id
+						AND child_run.status = 'running'
+				)
+			ORDER BY run.started_at ASC, run.id ASC
+			LIMIT ?`,
+	})
+	const deletedLogs = await deleteByIds({
+		db: input.db,
+		table: 'package_runtime_logs',
+		idColumn: 'run_id',
+		ids: runIds,
+	})
+	const deletedRuns = await deleteByIds({
+		db: input.db,
+		table: 'package_runtime_runs',
+		idColumn: 'id',
+		ids: runIds,
+	})
+	const orphanLogIds = await selectIds({
+		db: input.db,
+		bindings: [batchSize],
+		sql: `SELECT log.id
+			FROM package_runtime_logs AS log
+			WHERE NOT EXISTS (
+				SELECT 1
+				FROM package_runtime_runs AS run
+				WHERE run.user_id = log.user_id AND run.id = log.run_id
+			)
+			ORDER BY log.created_at ASC, log.id ASC
+			LIMIT ?`,
+	})
+	const deletedOrphanLogs = await deleteByIds({
+		db: input.db,
+		table: 'package_runtime_logs',
+		idColumn: 'id',
+		ids: orphanLogIds,
+	})
+	return { deletedRuns, deletedLogs, deletedOrphanLogs }
+}
+
+export async function prunePackageInvocationsForRetention(input: {
+	db: D1Database
+	now?: Date
+	batchSize?: number
+}) {
+	const cutoff = cutoffIso(
+		input.now ?? new Date(),
+		packageInvocationRetentionDays,
+	)
+	const ids = await selectIds({
+		db: input.db,
+		bindings: [cutoff, input.batchSize ?? retentionDefaultBatchSize],
+		sql: `SELECT id
+			FROM package_invocations
+			WHERE created_at < ?
+				AND status != 'in_progress'
+			ORDER BY created_at ASC, id ASC
+			LIMIT ?`,
+	})
+	return deleteByIds({
+		db: input.db,
+		table: 'package_invocations',
+		idColumn: 'id',
+		ids,
+	})
+}
+
+export async function pruneMemorySuppressionsForRetention(input: {
+	db: D1Database
+	now?: Date
+	batchSize?: number
+}) {
+	const now = input.now ?? new Date()
+	const cutoff = cutoffIso(now, memorySuppressionRetentionDays)
+	const rowIds = await selectIds({
+		db: input.db,
+		column: 'rowid',
+		bindings: [
+			now.toISOString(),
+			cutoff,
+			input.batchSize ?? retentionDefaultBatchSize,
+		],
+		sql: `SELECT rowid
+			FROM mcp_memory_conversation_suppressions
+			WHERE expires_at <= ?
+				AND last_seen_at < ?
+			ORDER BY last_seen_at ASC, rowid ASC
+			LIMIT ?`,
+	})
+	return deleteByIds({
+		db: input.db,
+		table: 'mcp_memory_conversation_suppressions',
+		idColumn: 'rowid',
+		ids: rowIds,
+	})
+}
+
+export async function pruneWorkflowRunsForRetention(input: {
+	db: D1Database
+	now?: Date
+	batchSize?: number
+}) {
+	const cutoff = cutoffIso(input.now ?? new Date(), workflowRunRetentionDays)
+	const ids = await selectIds({
+		db: input.db,
+		bindings: [cutoff, input.batchSize ?? retentionDefaultBatchSize],
+		sql: `SELECT id
+			FROM workflow_runs
+			WHERE status IN (${terminalWorkflowStatusList})
+				AND COALESCE(completed_at, updated_at, created_at) < ?
+			ORDER BY COALESCE(completed_at, updated_at, created_at) ASC, id ASC
+			LIMIT ?`,
+	})
+	return deleteByIds({
+		db: input.db,
+		table: 'workflow_runs',
+		idColumn: 'id',
+		ids,
+	})
+}
+
+export async function prunePublishedBundleArtifactsForRetention(input: {
+	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV'>
+	now?: Date
+	batchSize?: number
+}) {
+	const cutoff = cutoffIso(
+		input.now ?? new Date(),
+		publishedBundleArtifactRetentionDays,
+	)
+	const { results } = await input.env.APP_DB.prepare(
+		`SELECT artifact.id, artifact.kv_key
+		FROM published_bundle_artifacts AS artifact
+		WHERE artifact.created_at < ?
+			AND NOT EXISTS (
+				SELECT 1
+				FROM entity_sources AS source
+				WHERE source.user_id = artifact.user_id
+					AND source.id = artifact.source_id
+					AND source.published_commit = artifact.published_commit
+			)
+			AND NOT EXISTS (
+				SELECT 1
+				FROM repo_sessions AS session
+				WHERE session.user_id = artifact.user_id
+					AND session.source_id = artifact.source_id
+					AND session.status = 'active'
+			)
+		ORDER BY artifact.created_at ASC, artifact.id ASC
+		LIMIT ?`,
+	)
+		.bind(cutoff, input.batchSize ?? publishedBundleArtifactRetentionBatchSize)
+		.all<{ id: string; kv_key: string }>()
+	const rows = results ?? []
+	const deletedRowIds: Array<string> = []
+	let deletedKvKeys = 0
+	let kvDeleteErrors = 0
+	for (const row of rows) {
+		try {
+			await input.env.BUNDLE_ARTIFACTS_KV.delete(row.kv_key)
+			deletedKvKeys += 1
+			deletedRowIds.push(row.id)
+		} catch (error) {
+			kvDeleteErrors += 1
+			console.warn('retention-published-bundle-kv-delete-failed', {
+				id: row.id,
+				kvKey: row.kv_key,
+				error,
+			})
+		}
+	}
+	const deletedRows = await deleteByIds({
+		db: input.env.APP_DB,
+		table: 'published_bundle_artifacts',
+		idColumn: 'id',
+		ids: deletedRowIds,
+	})
+	return { deletedRows, deletedKvKeys, kvDeleteErrors }
+}
+
+export async function pruneEmailDeliveryEventsForRetention(input: {
+	db: D1Database
+	now?: Date
+	batchSize?: number
+}) {
+	const cutoff = cutoffIso(
+		input.now ?? new Date(),
+		emailDeliveryEventRetentionDays,
+	)
+	const ids = await selectIds({
+		db: input.db,
+		bindings: [
+			systemEmailOwnerId,
+			cutoff,
+			input.batchSize ?? retentionDefaultBatchSize,
+		],
+		sql: `SELECT id
+			FROM email_delivery_events
+			WHERE user_id != ?
+				AND created_at < ?
+			ORDER BY created_at ASC, id ASC
+			LIMIT ?`,
+	})
+	return deleteByIds({
+		db: input.db,
+		table: 'email_delivery_events',
+		idColumn: 'id',
+		ids,
+	})
+}
+
+export async function pruneAuditEventsForRetention(input: {
+	db: D1Database
+	now?: Date
+	batchSize?: number
+}) {
+	const cutoff = cutoffIso(input.now ?? new Date(), auditEventRetentionDays)
+	const ids = await selectIds({
+		db: input.db,
+		bindings: [cutoff, input.batchSize ?? retentionDefaultBatchSize],
+		sql: `SELECT id
+			FROM audit_events
+			WHERE timestamp < ?
+			ORDER BY timestamp ASC, id ASC
+			LIMIT ?`,
+	})
+	return deleteByIds({
+		db: input.db,
+		table: 'audit_events',
+		idColumn: 'id',
+		ids,
+	})
+}
+
+export async function pruneRetention(input: {
+	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV'>
+	now?: Date
+}): Promise<RetentionPruneResult> {
+	const now = input.now ?? new Date()
+	const result: RetentionPruneResult = {
+		runtimeRuns: await prunePackageRuntimeRetention({
+			db: input.env.APP_DB,
+			now,
+		}),
+		packageInvocations: await prunePackageInvocationsForRetention({
+			db: input.env.APP_DB,
+			now,
+		}),
+		memorySuppressions: await pruneMemorySuppressionsForRetention({
+			db: input.env.APP_DB,
+			now,
+		}),
+		workflowRuns: await pruneWorkflowRunsForRetention({
+			db: input.env.APP_DB,
+			now,
+		}),
+		publishedBundleArtifacts: await prunePublishedBundleArtifactsForRetention({
+			env: input.env,
+			now,
+		}),
+		emailDeliveryEvents: await pruneEmailDeliveryEventsForRetention({
+			db: input.env.APP_DB,
+			now,
+		}),
+		auditEvents: await pruneAuditEventsForRetention({
+			db: input.env.APP_DB,
+			now,
+		}),
+	}
+	console.info('retention-prune', JSON.stringify(result))
+	return result
+}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -57,6 +57,7 @@ import { PackageAppRuntimeBridge } from '#worker/package-runtime/package-app.ts'
 import { handleInboundEmail } from '#worker/email/inbound.ts'
 import { pruneSystemEmailRetention } from '#worker/email/system-email.ts'
 import { findPublicUserIdentityByUsername } from '#app/user-lookup.ts'
+import { pruneRetention, shouldRunRetentionCron } from '#app/retention.ts'
 
 export {
 	RepoSession,
@@ -535,7 +536,13 @@ const workerHandler = {
 	) {
 		const baseUrl = env.APP_BASE_URL ?? 'https://kody.local'
 		const scheduledAt = new Date(controller.scheduledTime)
-		const [pushesResult, cleanupResult, systemEmailResult] =
+		const retentionPromise = shouldRunRetentionCron(scheduledAt)
+			? pruneRetention({
+					env,
+					now: scheduledAt,
+				})
+			: Promise.resolve(null)
+		const [pushesResult, cleanupResult, systemEmailResult, retentionResult] =
 			await Promise.allSettled([
 				reconcileArtifactsPushes({
 					env,
@@ -550,10 +557,12 @@ const workerHandler = {
 					db: env.APP_DB,
 					now: scheduledAt,
 				}),
+				retentionPromise,
 			])
 		if (pushesResult.status === 'rejected') throw pushesResult.reason
 		if (cleanupResult.status === 'rejected') throw cleanupResult.reason
 		if (systemEmailResult.status === 'rejected') throw systemEmailResult.reason
+		if (retentionResult.status === 'rejected') throw retentionResult.reason
 	},
 } satisfies ExportedHandler<Env>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `packages/worker/src/app/retention.ts` with named retention constants, a manifest, hourly cron gating, batched D1 deletes, and conservative KV GC for stale published bundle artifacts.
- Wires the retention job into the existing scheduled handler alongside artifact reconcile, repo-session cleanup, and system-email pruning.
- Documents the retention policies in `docs/contributing/architecture/data-storage.md`.
- Adds SQL-backed unit tests for table policies, boundaries, batching, D1 100-binding delete chunking, KV referenced-vs-unreferenced behavior, artifact refresh race safety, and the retention coverage guardrail.

## Validation

- `npx vitest run packages/worker/src/app/retention.node.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- Pre-push hook: `npm run test`
- Pre-push hook: `npm run test:e2e:run`
- `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `f497ee9` · **Head:** `8f7d196`

**Classification:** extends — this PR changes scheduled storage maintenance behavior for existing D1 and Bundle Artifacts KV primitives; it does not add a new system primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `scheduled-cron` | surfaces | extends — adds an hourly-gated retention sub-job to the existing Worker scheduled handler |
| `d1-app-db` | storage | extends — adds batched retention deletes, D1 binding-limit-safe delete chunks, and a schema coverage guardrail for growth tables |
| `bundle-artifacts-kv` | storage | extends — deletes stale bundle artifact KV blobs only after D1 proves the stale row is still unreferenced at deletion time |
| `package-runtime` | runtime | composes — runtime debug runs/logs are pruned through D1 retention policy without changing execution loaders |
| `workflows` | assistant | composes — terminal workflow projections are pruned while active rows are preserved |
| `email` | assistant | composes — user delivery-event metadata gains scheduled retention; system email keeps its existing policy |

### System map

```mermaid
flowchart LR
	scheduledCron["scheduled-cron"]:::extended --> retention["retention job"]:::extended
	retention --> d1AppDb["d1-app-db"]:::extended
	retention --> bundleArtifactsKv["bundle-artifacts-kv"]:::extended
	packageRuntime["package-runtime"]:::touched --> d1AppDb
	workflows["workflows"]:::touched --> d1AppDb
	email["email"]:::touched --> d1AppDb
	repoSessions["repo-sessions"]:::untouched --> d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart TD
	cron["*/5 scheduled handler"] --> gate{"top-of-hour gate?"}
	gate -->|no| skip["skip general retention"]
	gate -->|yes| prune["run batched retention policies"]
	prune --> runtime["runtime logs before runs"]
	prune --> idempotency["terminal invocations/workflows only"]
	prune --> artifactSelect["select stale unreferenced bundle rows"]
	artifactSelect --> guardedDelete["guard-delete D1 row if still stale"]
	guardedDelete --> kvDelete["delete old BUNDLE_ARTIFACTS_KV blob"]
```

### Invariants

- Per-user isolation is preserved by partitioning caps by `(user_id, package_id)` and by requiring matching `user_id` joins for active invocation, workflow, repo-session, entity-source, and artifact checks.
- Ambiguous published artifact cases are kept: current `entity_sources.published_commit` rows and sources with active repo sessions are not garbage-collected; rows refreshed after candidate selection fail the guarded delete and keep their KV blob.
- Audit events remain global hashed security records, independent of account deletion/export, with a 180-day time retention.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8cf186f-ccb5-4be2-9986-63e62886d2cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8cf186f-ccb5-4be2-9986-63e62886d2cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated retention cleanup for runtime runs, invocations, workflow runs, memory suppressions, email delivery events, audit events, and published bundle artifacts.
  * Scheduled retention runs as a background worker task only at the top of the hour, with explicit per-area retention policies.
* **Bug Fixes**
  * Improved pruning accuracy to keep boundary/in-progress/active references and only remove expired, orphaned, or stale data (including safe handling for system-owned emails).
  * Added controlled batching so deletions proceed reliably without overloading parameter limits.
* **Tests**
  * Added a comprehensive retention pruning test suite with migration-backed schema verification and coverage checks.
* **Documentation**
  * Updated the retention section to describe policies, exemptions, and deletion vs platform-retained scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->