### PR TITLE
Fix workflows.create defaults for inline runtime calls

### DIFF
--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -12,10 +12,7 @@ import {
 	runBundledModuleWithRegistry,
 	runModuleWithRegistry,
 } from './run-kody-registry.ts'
-import {
-	createKodyProviderProxySource,
-	createToolDispatchers,
-} from '#mcp/executor.ts'
+import * as mcpExecutor from '#mcp/executor.ts'
 import { type KodyResolvedProvider } from '#mcp/kody-remote-types.ts'
 import { PackageSecretMountError } from '#mcp/secrets/package-access.ts'
 import * as packageAccess from '#mcp/secrets/package-access.ts'
@@ -219,6 +216,108 @@ export default async function run() {
 			workflowName: 'custom',
 		})
 	} finally {
+		createExecuteExecutorSpy.mockRestore()
+	}
+})
+
+test('runModuleWithRegistry queues inline workflows.create calls without runAt or idempotencyKey', async () => {
+	const created: Array<WorkflowInstanceCreateOptions<unknown>> = []
+	const env = {
+		APP_DB: {
+			prepare(query: string) {
+				return {
+					bind() {
+						return {
+							async first() {
+								if (query.includes('COUNT(*) AS count')) return { count: 0 }
+								return null
+							},
+							async run() {
+								return { success: true }
+							},
+						}
+					},
+				}
+			},
+		} as unknown as D1Database,
+		DYNAMIC_CALLABLE_WORKFLOWS: {
+			get: async () => {
+				throw new Error('not found')
+			},
+			create: async (options?: WorkflowInstanceCreateOptions<unknown>) => {
+				if (!options) throw new Error('missing options')
+				created.push(options)
+				return {
+					id: options.id ?? 'generated',
+					status: async () => ({ status: 'queued' }),
+				} as WorkflowInstance
+			},
+		} as Workflow<unknown>,
+	} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://app.example.com',
+		user: {
+			userId: 'user-1',
+			email: 'me@example.com',
+			displayName: 'Me',
+		},
+		storageContext: null,
+	})
+	let wrappedSource = ''
+	const createExecuteExecutorSpy = vi
+		.spyOn(mcpExecutor, 'createExecuteExecutor')
+		.mockReturnValue({
+			async execute(_wrapped, providers) {
+				wrappedSource = String(_wrapped)
+				const provider = providers[0] as {
+					fns: Record<string, (args: unknown) => Promise<unknown>>
+				}
+				return {
+					result: await provider.fns.package_workflow_create({
+						code: 'export default async function main() { return { ok: true } }',
+					}),
+					logs: [],
+				}
+			},
+		} as never)
+
+	try {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date('2026-05-03T12:34:56.000Z'))
+		const result = await runModuleWithRegistry(
+			env,
+			callerContext,
+			`import { workflows } from 'kody:runtime'
+export default async function main() {
+  return await workflows.create({ code: \`export default async function main() { return { ok: true } }\` })
+}`,
+		)
+
+		expect(result.result).toMatchObject({
+			ok: true,
+			source_type: 'inline',
+			workflow_name: 'inline-code',
+			export_name: null,
+			run_at: '2026-05-03T12:34:56.000Z',
+			plan_date: '2026-05-03',
+			status: 'queued',
+		})
+		expect(wrappedSource).toContain('const workflows = {')
+		expect(wrappedSource).toContain('kody.package_workflow_create')
+		expect(created).toHaveLength(1)
+		expect(created[0]?.params).toEqual(
+			expect.objectContaining({
+				sourceType: 'inline',
+				userId: 'user-1',
+				workflowName: 'inline-code',
+				code: 'export default async function main() { return { ok: true } }',
+				idempotencyKey: expect.stringMatching(/^generated:/),
+				runAt: '2026-05-03T12:34:56.000Z',
+				planDate: '2026-05-03',
+			}),
+		)
+	} finally {
+		vi.useRealTimers()
 		createExecuteExecutorSpy.mockRestore()
 	}
 })
@@ -1006,8 +1105,10 @@ test('remote connector calls round-trip through sanitized ToolDispatcher names',
 			dispatchName: 'remotelightinglutron_set_credentials',
 		}),
 	])
-	const dispatchers = createToolDispatchers([provider], { active: true })
-	const source = createKodyProviderProxySource({
+	const dispatchers = mcpExecutor.createToolDispatchers([provider], {
+		active: true,
+	})
+	const source = mcpExecutor.createKodyProviderProxySource({
 		providerName: provider.name,
 		remoteConnectors,
 	})

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -120,6 +120,14 @@ test('package app workflows proxy validates required workflow input fields', asy
 	})
 	await expect(
 		workflows.create({
+			exportName: './run-event',
+			code: '',
+		}),
+	).resolves.toEqual({
+		exportName: './run-event',
+	})
+	await expect(
+		workflows.create({
 			workflowName: 'shade-event',
 			exportName: './run-event',
 			runAt: 'not-a-date',
@@ -157,6 +165,16 @@ test('package app workflows proxy forwards inline code workflow input', async ()
 		runAt: new Date('2026-05-03T12:00:00.000Z'),
 		idempotencyKey: 'event-key',
 		params: { eventId: 'event-1' },
+	})
+
+	await expect(
+		workflows.create({
+			code,
+			params: { eventId: 'event-2' },
+		}),
+	).resolves.toEqual({
+		code,
+		params: { eventId: 'event-2' },
 	})
 })
 

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -266,13 +266,11 @@ function createWorkflowsProxy(runtimeBridge) {
 		const value = input?.[fieldName];
 		return typeof value === 'string' && value.trim() ? value : null;
 	};
-	const normalizeRequiredString = (input, fieldName) => {
-		const value = normalizeOptionalString(input, fieldName);
-		if (!value) throw new Error('workflows.create requires a non-empty ' + fieldName + '.');
-		return value;
-	};
 	const normalizeRunAt = (input) => {
 		const value = input?.runAt;
+		if (value === undefined || value === null || value === '') {
+			return null;
+		}
 		const date =
 			value instanceof Date
 				? value
@@ -300,9 +298,11 @@ function createWorkflowsProxy(runtimeBridge) {
 			}
 			const workflowName = normalizeOptionalString(input, 'workflowName');
 			const packageId = normalizeOptionalString(input, 'packageId');
+			const runAt = normalizeRunAt(input);
+			const idempotencyKey = normalizeOptionalString(input, 'idempotencyKey');
 			const payload = {
-				runAt: normalizeRunAt(input),
-				idempotencyKey: normalizeRequiredString(input, 'idempotencyKey'),
+				...(runAt ? { runAt } : {}),
+				...(idempotencyKey ? { idempotencyKey } : {}),
 				...(input.params === undefined ? {} : { params: input.params }),
 				...(workflowName ? { workflowName } : {}),
 				...(packageId ? { packageId } : {}),

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -684,6 +684,41 @@ test('createDynamicCallableWorkflow dedupes queued runs by user and idempotency 
 		}),
 	])
 
+	const preProjectionBinding = createStatefulWorkflowBinding()
+	const preProjectionDb = createWorkflowRunsDatabase()
+	const preProjectionEnv = {
+		APP_DB: preProjectionDb,
+		DYNAMIC_CALLABLE_WORKFLOWS: preProjectionBinding.workflow,
+	} as Env
+	vi.useFakeTimers()
+	try {
+		vi.setSystemTime(new Date('2026-05-08T19:30:00.000Z'))
+		const firstPreProjection = await createDynamicCallableWorkflow({
+			env: preProjectionEnv,
+			userId: 'user-1',
+			body: {
+				code: 'export default async function main() { return { ok: true } }',
+				idempotencyKey: 'inline-pre-projection-key',
+			},
+		})
+		preProjectionDb.workflowRuns.clear()
+		vi.setSystemTime(new Date('2026-05-08T19:31:00.000Z'))
+		const replayPreProjection = await createDynamicCallableWorkflow({
+			env: preProjectionEnv,
+			userId: 'user-1',
+			body: {
+				code: 'export default async function main() { return { ok: true } }',
+				idempotencyKey: 'inline-pre-projection-key',
+			},
+		})
+
+		expect(replayPreProjection.id).toBe(firstPreProjection.id)
+		expect(preProjectionBinding.create).toHaveBeenCalledTimes(1)
+		expect(preProjectionBinding.instances.size).toBe(1)
+	} finally {
+		vi.useRealTimers()
+	}
+
 	const perUserBinding = createStatefulWorkflowBinding()
 	const userOne = await createDynamicCallableWorkflow({
 		env: {

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -685,7 +685,10 @@ test('createDynamicCallableWorkflow dedupes queued runs by user and idempotency 
 	])
 
 	const preProjectionDb = createWorkflowRunsDatabase()
-	const preProjectionInstances = new Map<string, WorkflowInstanceCreateOptions>()
+	const preProjectionInstances = new Map<
+		string,
+		WorkflowInstanceCreateOptions
+	>()
 	const preProjectionCreate = vi.fn(
 		async (input: WorkflowInstanceCreateOptions) => {
 			expect([...preProjectionDb.workflowRuns.values()]).toEqual([

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -684,11 +684,39 @@ test('createDynamicCallableWorkflow dedupes queued runs by user and idempotency 
 		}),
 	])
 
-	const preProjectionBinding = createStatefulWorkflowBinding()
 	const preProjectionDb = createWorkflowRunsDatabase()
+	const preProjectionInstances = new Map<string, WorkflowInstanceCreateOptions>()
+	const preProjectionCreate = vi.fn(
+		async (input: WorkflowInstanceCreateOptions) => {
+			expect([...preProjectionDb.workflowRuns.values()]).toEqual([
+				expect.objectContaining({
+					id: input.id,
+					idempotency_key: 'inline-pre-projection-key',
+					run_at: '2026-05-08T19:30:00.000Z',
+				}),
+			])
+			preProjectionInstances.set(input.id, input)
+			return {
+				id: input.id,
+				status: async () => ({ status: 'queued' }),
+			} as WorkflowInstance
+		},
+	)
+	const preProjectionGet = vi.fn(async (id: string) => {
+		if (!preProjectionInstances.has(id)) {
+			throw new Error('workflow instance does not exist')
+		}
+		return {
+			id,
+			status: async () => ({ status: 'waiting' }),
+		} as WorkflowInstance
+	})
 	const preProjectionEnv = {
 		APP_DB: preProjectionDb,
-		DYNAMIC_CALLABLE_WORKFLOWS: preProjectionBinding.workflow,
+		DYNAMIC_CALLABLE_WORKFLOWS: {
+			get: preProjectionGet,
+			create: preProjectionCreate,
+		} as unknown as Workflow,
 	} as Env
 	vi.useFakeTimers()
 	try {
@@ -701,7 +729,6 @@ test('createDynamicCallableWorkflow dedupes queued runs by user and idempotency 
 				idempotencyKey: 'inline-pre-projection-key',
 			},
 		})
-		preProjectionDb.workflowRuns.clear()
 		vi.setSystemTime(new Date('2026-05-08T19:31:00.000Z'))
 		const replayPreProjection = await createDynamicCallableWorkflow({
 			env: preProjectionEnv,
@@ -713,8 +740,9 @@ test('createDynamicCallableWorkflow dedupes queued runs by user and idempotency 
 		})
 
 		expect(replayPreProjection.id).toBe(firstPreProjection.id)
-		expect(preProjectionBinding.create).toHaveBeenCalledTimes(1)
-		expect(preProjectionBinding.instances.size).toBe(1)
+		expect(replayPreProjection.run_at).toBe(firstPreProjection.run_at)
+		expect(preProjectionCreate).toHaveBeenCalledTimes(1)
+		expect(preProjectionInstances.size).toBe(1)
 	} finally {
 		vi.useRealTimers()
 	}

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -147,11 +147,17 @@ function createWorkflowRunsDatabase(options?: {
 							) {
 								const userId = params[0]
 								const idempotencyKey = params[1]
+								const ignoredStatus = query.includes(
+									"COALESCE(status, '') != ?",
+								)
+									? params[2]
+									: null
 								const matches = [...workflowRuns.values()]
 									.filter(
 										(row) =>
 											row['user_id'] === userId &&
-											row['idempotency_key'] === idempotencyKey,
+											row['idempotency_key'] === idempotencyKey &&
+											row['status'] !== ignoredStatus,
 									)
 									.sort((left, right) =>
 										String(left['created_at']).localeCompare(
@@ -178,24 +184,34 @@ function createWorkflowRunsDatabase(options?: {
 						},
 						async run() {
 							if (query.includes('INSERT INTO workflow_runs')) {
-								workflowRuns.set(String(params[0]), {
-									id: params[0],
-									user_id: params[1],
-									source_type: params[2],
-									package_id: params[3],
-									kody_id: params[4],
-									source_id: params[5],
-									workflow_name: params[6],
-									export_name: params[7],
-									idempotency_key: params[8],
-									run_at: params[9],
-									plan_date: params[10],
-									status: params[11],
-									created_at: params[12],
-									updated_at: params[13],
-									completed_at: params[14],
-									last_error: params[15],
-								})
+								const id = String(params[0])
+								const existing = workflowRuns.get(id)
+								if (existing) {
+									existing['status'] = params[11]
+									existing['updated_at'] = params[13]
+									existing['completed_at'] =
+										params[14] ?? existing['completed_at']
+									existing['last_error'] = params[15] ?? existing['last_error']
+								} else {
+									workflowRuns.set(id, {
+										id: params[0],
+										user_id: params[1],
+										source_type: params[2],
+										package_id: params[3],
+										kody_id: params[4],
+										source_id: params[5],
+										workflow_name: params[6],
+										export_name: params[7],
+										idempotency_key: params[8],
+										run_at: params[9],
+										plan_date: params[10],
+										status: params[11],
+										created_at: params[12],
+										updated_at: params[13],
+										completed_at: params[14],
+										last_error: params[15],
+									})
+								}
 							}
 							if (query.includes('UPDATE workflow_runs')) {
 								const row = workflowRuns.get(String(params[2]))
@@ -696,6 +712,7 @@ test('createDynamicCallableWorkflow dedupes queued runs by user and idempotency 
 					id: input.id,
 					idempotency_key: 'inline-pre-projection-key',
 					run_at: '2026-05-08T19:30:00.000Z',
+					status: 'creating',
 				}),
 			])
 			preProjectionInstances.set(input.id, input)
@@ -768,6 +785,79 @@ test('createDynamicCallableWorkflow dedupes queued runs by user and idempotency 
 		status: 'waiting',
 	})
 	expect(existingOverLimitBinding.create).not.toHaveBeenCalled()
+
+	const failedCreateDb = createWorkflowRunsDatabase()
+	const failedCreateInstances = new Map<string, WorkflowInstanceCreateOptions>()
+	let shouldFailCreate = true
+	const retryCreate = vi.fn(async (input: WorkflowInstanceCreateOptions) => {
+		if (shouldFailCreate) {
+			shouldFailCreate = false
+			throw new Error('transient workflow create failure')
+		}
+		failedCreateInstances.set(input.id, input)
+		return {
+			id: input.id,
+			status: async () => ({ status: 'queued' }),
+		} as WorkflowInstance
+	})
+	const retryGet = vi.fn(async (id: string) => {
+		if (!failedCreateInstances.has(id)) {
+			throw new Error('workflow instance does not exist')
+		}
+		return {
+			id,
+			status: async () => ({ status: 'waiting' }),
+		} as WorkflowInstance
+	})
+	const failedCreateEnv = {
+		APP_DB: failedCreateDb,
+		DYNAMIC_CALLABLE_WORKFLOWS: {
+			get: retryGet,
+			create: retryCreate,
+		} as unknown as Workflow,
+	} as Env
+	vi.useFakeTimers()
+	try {
+		vi.setSystemTime(new Date('2026-05-08T19:30:00.000Z'))
+		await expect(
+			createDynamicCallableWorkflow({
+				env: failedCreateEnv,
+				userId: 'user-1',
+				body: {
+					code: 'export default async function main() { return { ok: true } }',
+					idempotencyKey: 'failed-create-retry-key',
+				},
+			}),
+		).rejects.toThrow('transient workflow create failure')
+		expect([...failedCreateDb.workflowRuns.values()]).toEqual([
+			expect.objectContaining({
+				idempotency_key: 'failed-create-retry-key',
+				run_at: '2026-05-08T19:30:00.000Z',
+				status: 'creating',
+			}),
+		])
+		vi.setSystemTime(new Date('2026-05-08T19:31:00.000Z'))
+		const retryAfterFailure = await createDynamicCallableWorkflow({
+			env: failedCreateEnv,
+			userId: 'user-1',
+			body: {
+				code: 'export default async function main() { return { ok: true } }',
+				idempotencyKey: 'failed-create-retry-key',
+			},
+		})
+
+		expect(retryAfterFailure.run_at).toBe('2026-05-08T19:30:00.000Z')
+		expect(retryCreate).toHaveBeenCalledTimes(2)
+		expect([...failedCreateDb.workflowRuns.values()]).toEqual([
+			expect.objectContaining({
+				idempotency_key: 'failed-create-retry-key',
+				run_at: '2026-05-08T19:30:00.000Z',
+				status: 'queued',
+			}),
+		])
+	} finally {
+		vi.useRealTimers()
+	}
 
 	const perUserBinding = createStatefulWorkflowBinding()
 	const userOne = await createDynamicCallableWorkflow({

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -750,6 +750,25 @@ test('createDynamicCallableWorkflow dedupes queued runs by user and idempotency 
 		vi.useRealTimers()
 	}
 
+	const existingOverLimitBinding = createWorkflowBinding({})
+	await expect(
+		createDynamicCallableWorkflow({
+			env: {
+				APP_DB: createWorkflowRunsDatabase({ activeCount: 100 }),
+				DYNAMIC_CALLABLE_WORKFLOWS: existingOverLimitBinding.workflow,
+			} as Env,
+			userId: 'user-1',
+			body: {
+				code: 'export default async function main() { return { ok: true } }',
+				idempotencyKey: 'existing-over-limit-key',
+			},
+		}),
+	).resolves.toMatchObject({
+		ok: true,
+		status: 'waiting',
+	})
+	expect(existingOverLimitBinding.create).not.toHaveBeenCalled()
+
 	const perUserBinding = createStatefulWorkflowBinding()
 	const userOne = await createDynamicCallableWorkflow({
 		env: {

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -649,20 +649,6 @@ async function recordWorkflowRun(input: {
 		.run()
 }
 
-async function deleteWorkflowRun(input: {
-	db: D1Database
-	id: string
-	userId: string
-}) {
-	await input.db
-		.prepare(
-			`DELETE FROM workflow_runs
-			WHERE id = ? AND user_id = ?`,
-		)
-		.bind(input.id, input.userId)
-		.run()
-}
-
 async function updateWorkflowRunStatus(input: {
 	env: Env
 	id: string
@@ -794,25 +780,6 @@ export async function createDynamicCallableWorkflow(input: {
 		// workflow_runs projection row is written.
 		includeRunAt: !idempotencyKeyInput,
 	})
-	if (input.env.APP_DB) {
-		await assertWithinEntitlement({
-			db: input.env.APP_DB,
-			userId: payload.userId,
-			email: input.userEmail,
-			resource: 'concurrent_workflows',
-			fallbackLimit: getWorkflowConcurrencyBackstop(input.env as Env),
-		})
-	}
-	let preRecordedWorkflowRun = false
-	if (input.env.APP_DB && idempotencyKeyInput) {
-		await recordWorkflowRun({
-			db: input.env.APP_DB,
-			id,
-			payload,
-			status: 'queued',
-		})
-		preRecordedWorkflowRun = true
-	}
 	const existing = await getExistingWorkflowInstance(
 		input.env.DYNAMIC_CALLABLE_WORKFLOWS,
 		id,
@@ -827,6 +794,23 @@ export async function createDynamicCallableWorkflow(input: {
 			})
 		}
 		return createWorkflowCreateResult({ summary: existing, payload })
+	}
+	if (input.env.APP_DB) {
+		await assertWithinEntitlement({
+			db: input.env.APP_DB,
+			userId: payload.userId,
+			email: input.userEmail,
+			resource: 'concurrent_workflows',
+			fallbackLimit: getWorkflowConcurrencyBackstop(input.env as Env),
+		})
+	}
+	if (input.env.APP_DB && idempotencyKeyInput) {
+		await recordWorkflowRun({
+			db: input.env.APP_DB,
+			id,
+			payload,
+			status: 'queued',
+		})
 	}
 	let instance: WorkflowInstance
 	try {
@@ -850,13 +834,6 @@ export async function createDynamicCallableWorkflow(input: {
 					payload,
 				})
 			}
-		}
-		if (preRecordedWorkflowRun && input.env.APP_DB) {
-			await deleteWorkflowRun({
-				db: input.env.APP_DB,
-				id,
-				userId: payload.userId,
-			})
 		}
 		throw error
 	}

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -280,6 +280,9 @@ export async function createPackageWorkflowInstanceId(input: {
 	workflowName: string
 	idempotencyKey: string
 	runAt: string | Date
+	options?: {
+		includeRunAt?: boolean
+	}
 }) {
 	const canonical = canonicalJsonStringify({
 		userId: normalizeNonEmptyString(input.userId, 'userId'),
@@ -289,7 +292,9 @@ export async function createPackageWorkflowInstanceId(input: {
 			input.idempotencyKey,
 			'idempotencyKey',
 		),
-		runAt: normalizeRunAt(input.runAt),
+		...(input.options?.includeRunAt === false
+			? {}
+			: { runAt: normalizeRunAt(input.runAt) }),
 	})
 	return `pkgwf-${(await sha256Base64Url(canonical)).slice(0, 43)}`
 }
@@ -521,6 +526,9 @@ async function createInlineWorkflowInstanceId(input: {
 	workflowName: string
 	idempotencyKey: string
 	runAt: string | Date
+	options?: {
+		includeRunAt?: boolean
+	}
 }) {
 	const canonical = canonicalJsonStringify({
 		userId: normalizeNonEmptyString(input.userId, 'userId'),
@@ -530,18 +538,23 @@ async function createInlineWorkflowInstanceId(input: {
 			input.idempotencyKey,
 			'idempotencyKey',
 		),
-		runAt: normalizeRunAt(input.runAt),
+		...(input.options?.includeRunAt === false
+			? {}
+			: { runAt: normalizeRunAt(input.runAt) }),
 	})
 	return `dynwf-${(await sha256Base64Url(canonical)).slice(0, 43)}`
 }
 
 async function createDynamicCallableWorkflowInstanceId(
 	payload: DynamicCallableWorkflowPayload,
+	options?: {
+		includeRunAt?: boolean
+	},
 ) {
 	if (payload.sourceType === 'package') {
-		return await createPackageWorkflowInstanceId(payload)
+		return await createPackageWorkflowInstanceId({ ...payload, options })
 	}
-	return await createInlineWorkflowInstanceId(payload)
+	return await createInlineWorkflowInstanceId({ ...payload, options })
 }
 
 function mapWorkflowRunRow(
@@ -762,7 +775,11 @@ export async function createDynamicCallableWorkflow(input: {
 		}
 	}
 	const payload = await resolveWorkflowPayload(input)
-	const id = await createDynamicCallableWorkflowInstanceId(payload)
+	const id = await createDynamicCallableWorkflowInstanceId(payload, {
+		// An explicit idempotency key must single-flight even before the
+		// workflow_runs projection row is written.
+		includeRunAt: !idempotencyKeyInput,
+	})
 	const existing = await getExistingWorkflowInstance(
 		input.env.DYNAMIC_CALLABLE_WORKFLOWS,
 		id,

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -28,8 +28,8 @@ export type PackageWorkflowParams = Record<string, unknown>
 
 type WorkflowCreateBaseInput = {
 	workflowName?: string
-	runAt: string | Date
-	idempotencyKey: string
+	runAt?: string | Date
+	idempotencyKey?: string
 	params?: PackageWorkflowParams
 }
 
@@ -234,8 +234,13 @@ function normalizeOptionalWorkflowName(
 	return workflowName?.trim() || fallback
 }
 
-function normalizeRunAt(runAt: string | Date) {
-	const date = typeof runAt === 'string' ? new Date(runAt) : runAt
+function normalizeRunAt(runAt: string | Date | undefined) {
+	const date =
+		runAt === undefined
+			? new Date()
+			: typeof runAt === 'string'
+				? new Date(runAt)
+				: runAt
 	if (Number.isNaN(date.getTime())) {
 		throw new Error('runAt must be a valid date or ISO string.')
 	}
@@ -293,16 +298,24 @@ export function createPackageWorkflowPlanDate(runAt: string | Date) {
 	return normalizeRunAt(runAt).slice(0, 'YYYY-MM-DD'.length)
 }
 
+function normalizeWorkflowIdempotencyKey(idempotencyKey: string | undefined) {
+	if (idempotencyKey !== undefined) {
+		return normalizeNonEmptyString(idempotencyKey, 'idempotencyKey')
+	}
+	return `generated:${crypto.randomUUID()}`
+}
+
 function createInlineWorkflowPayload(input: {
 	userId: string
 	workflowName?: string
 	code: string
-	idempotencyKey: string
-	runAt: string | Date
+	idempotencyKey?: string
+	runAt?: string | Date
 	params?: PackageWorkflowParams | null
 	planDate?: string | null
 }): DynamicCallableWorkflowPayload {
 	const runAt = normalizeRunAt(input.runAt)
+	const idempotencyKey = normalizeWorkflowIdempotencyKey(input.idempotencyKey)
 	const params = normalizePackageWorkflowParams(input.params)
 	return {
 		version: 2,
@@ -313,10 +326,7 @@ function createInlineWorkflowPayload(input: {
 			'inline-code',
 		),
 		code: normalizeNonEmptyString(input.code, 'code'),
-		idempotencyKey: normalizeNonEmptyString(
-			input.idempotencyKey,
-			'idempotencyKey',
-		),
+		idempotencyKey,
 		runAt,
 		planDate: input.planDate?.trim() || createPackageWorkflowPlanDate(runAt),
 		...(params === undefined ? {} : { params }),
@@ -330,12 +340,13 @@ function createDynamicPackageWorkflowPayload(input: {
 	sourceId: string
 	workflowName?: string
 	exportName: string
-	idempotencyKey: string
-	runAt: string | Date
+	idempotencyKey?: string
+	runAt?: string | Date
 	params?: PackageWorkflowParams | null
 	planDate?: string | null
 }): DynamicCallableWorkflowPayload {
 	const runAt = normalizeRunAt(input.runAt)
+	const idempotencyKey = normalizeWorkflowIdempotencyKey(input.idempotencyKey)
 	const params = normalizePackageWorkflowParams(input.params)
 	const workflowName = normalizeNonEmptyString(
 		normalizeOptionalWorkflowName(input.workflowName, input.exportName),
@@ -350,10 +361,7 @@ function createDynamicPackageWorkflowPayload(input: {
 		sourceId: normalizeNonEmptyString(input.sourceId, 'sourceId'),
 		workflowName,
 		exportName: normalizeWorkflowExportName(input.exportName),
-		idempotencyKey: normalizeNonEmptyString(
-			input.idempotencyKey,
-			'idempotencyKey',
-		),
+		idempotencyKey,
 		runAt,
 		planDate: input.planDate?.trim() || createPackageWorkflowPlanDate(runAt),
 		...(params === undefined ? {} : { params }),

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -649,6 +649,20 @@ async function recordWorkflowRun(input: {
 		.run()
 }
 
+async function deleteWorkflowRun(input: {
+	db: D1Database
+	id: string
+	userId: string
+}) {
+	await input.db
+		.prepare(
+			`DELETE FROM workflow_runs
+			WHERE id = ? AND user_id = ?`,
+		)
+		.bind(input.id, input.userId)
+		.run()
+}
+
 async function updateWorkflowRunStatus(input: {
 	env: Env
 	id: string
@@ -780,6 +794,25 @@ export async function createDynamicCallableWorkflow(input: {
 		// workflow_runs projection row is written.
 		includeRunAt: !idempotencyKeyInput,
 	})
+	if (input.env.APP_DB) {
+		await assertWithinEntitlement({
+			db: input.env.APP_DB,
+			userId: payload.userId,
+			email: input.userEmail,
+			resource: 'concurrent_workflows',
+			fallbackLimit: getWorkflowConcurrencyBackstop(input.env as Env),
+		})
+	}
+	let preRecordedWorkflowRun = false
+	if (input.env.APP_DB && idempotencyKeyInput) {
+		await recordWorkflowRun({
+			db: input.env.APP_DB,
+			id,
+			payload,
+			status: 'queued',
+		})
+		preRecordedWorkflowRun = true
+	}
 	const existing = await getExistingWorkflowInstance(
 		input.env.DYNAMIC_CALLABLE_WORKFLOWS,
 		id,
@@ -794,15 +827,6 @@ export async function createDynamicCallableWorkflow(input: {
 			})
 		}
 		return createWorkflowCreateResult({ summary: existing, payload })
-	}
-	if (input.env.APP_DB) {
-		await assertWithinEntitlement({
-			db: input.env.APP_DB,
-			userId: payload.userId,
-			email: input.userEmail,
-			resource: 'concurrent_workflows',
-			fallbackLimit: getWorkflowConcurrencyBackstop(input.env as Env),
-		})
 	}
 	let instance: WorkflowInstance
 	try {
@@ -826,6 +850,13 @@ export async function createDynamicCallableWorkflow(input: {
 					payload,
 				})
 			}
+		}
+		if (preRecordedWorkflowRun && input.env.APP_DB) {
+			await deleteWorkflowRun({
+				db: input.env.APP_DB,
+				id,
+				userId: payload.userId,
+			})
 		}
 		throw error
 	}

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -142,6 +142,7 @@ type DynamicCallableWorkflowStep = {
 const packageWorkflowTokenId = 'internal:package-workflows'
 const maxPackageWorkflowParamsJsonBytes = 16 * 1024
 const workflowStatusRefreshTtlMs = 30_000
+const creatingWorkflowRunStatus = 'creating'
 const knownWorkflowStatusValues = [
 	...activeWorkflowStatusValues,
 	...terminalWorkflowStatusValues,
@@ -512,10 +513,11 @@ async function findWorkflowRunByIdempotencyKey(input: {
 			`SELECT *
 			FROM workflow_runs
 			WHERE user_id = ? AND idempotency_key = ?
+				AND COALESCE(status, '') != ?
 			ORDER BY created_at ASC
 			LIMIT 1`,
 		)
-		.bind(input.userId, trimmedKey)
+		.bind(input.userId, trimmedKey, creatingWorkflowRunStatus)
 		.first<Record<string, unknown>>()
 	if (!result) return null
 	return mapWorkflowRunRow(result)
@@ -792,6 +794,14 @@ export async function createDynamicCallableWorkflow(input: {
 				payload,
 				status: existing.status ?? null,
 			})
+			if (idempotencyKeyInput) {
+				const projectedRun = await findWorkflowRunByIdempotencyKey({
+					db: input.env.APP_DB,
+					userId: input.userId,
+					idempotencyKey: idempotencyKeyInput,
+				})
+				if (projectedRun) return createWorkflowCreateResultFromRow(projectedRun)
+			}
 		}
 		return createWorkflowCreateResult({ summary: existing, payload })
 	}
@@ -809,7 +819,7 @@ export async function createDynamicCallableWorkflow(input: {
 			db: input.env.APP_DB,
 			id,
 			payload,
-			status: 'queued',
+			status: creatingWorkflowRunStatus,
 		})
 	}
 	let instance: WorkflowInstance
@@ -829,6 +839,24 @@ export async function createDynamicCallableWorkflow(input: {
 				id,
 			)
 			if (concurrent) {
+				if (input.env.APP_DB) {
+					await recordWorkflowRun({
+						db: input.env.APP_DB,
+						id,
+						payload,
+						status: concurrent.status ?? null,
+					})
+					if (idempotencyKeyInput) {
+						const projectedRun = await findWorkflowRunByIdempotencyKey({
+							db: input.env.APP_DB,
+							userId: input.userId,
+							idempotencyKey: idempotencyKeyInput,
+						})
+						if (projectedRun) {
+							return createWorkflowCreateResultFromRow(projectedRun)
+						}
+					}
+				}
 				return createWorkflowCreateResult({
 					summary: concurrent,
 					payload,
@@ -853,6 +881,14 @@ export async function createDynamicCallableWorkflow(input: {
 			payload,
 			status: summary.status,
 		})
+	}
+	if (input.env.APP_DB && idempotencyKeyInput) {
+		const projectedRun = await findWorkflowRunByIdempotencyKey({
+			db: input.env.APP_DB,
+			userId: input.userId,
+			idempotencyKey: idempotencyKeyInput,
+		})
+		if (projectedRun) return createWorkflowCreateResultFromRow(projectedRun)
 	}
 	return createWorkflowCreateResult({ summary, payload })
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Default omitted `workflows.create` `runAt` to the current time before workflow payload creation.
- Generate an idempotency key when callers omit one, while making explicit idempotency keys stable single-flight identifiers.
- Pre-record explicit-key workflow runs as `creating` immediately before creating a new Workflow instance; successful creates promote the row, failed creates leave it retryable, and existing instances are rejoined before concurrency limits are checked.
- Align the saved package app `workflows.create` proxy so it no longer rejects omitted optional scheduling fields.
- Add regression coverage for inline-code `workflows.create` calls through the `runModuleWithRegistry` runtime provider glue, package app workflow proxy, explicit-key pre-projection retries, existing-instance retries at the concurrency limit, and retries after create failures.

## Validation

- `npx vitest run packages/worker/src/package-runtime/package-workflows.node.test.ts packages/worker/src/package-runtime/package-app.node.test.ts packages/worker/src/mcp/run-kody-registry.node.test.ts` ✅
- `npm run validate` ✅

## Post-deploy verification

From any MCP execute session, run:

```ts
import { workflows } from 'kody:runtime'

export default async function main() {
  return await workflows.create({
    code: `export default async function main() { return { ok: true } }`,
  })
}
```

Expected: returns an object containing `ok: true`, a workflow `id`, `source_type: 'inline'`, and a current `run_at` instead of throwing `Cannot read properties of undefined (reading 'getTime')`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `fd1a667a` · **Head:** `16188108`

**Classification:** extends — changes workflow runtime defaults, workflow instance identity/projection for explicit idempotency keys, and package app runtime proxy behavior.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | composes — runtime execute glue exposes `workflows.create` to MCP modules |
| `workflows` | assistant | extends — omitted `runAt` now means now, omitted `idempotencyKey` gets a generated key, explicit keys single-flight before and after projection writes |
| `package-apps` | assistant | extends — app runtime workflow proxy now forwards omitted optional scheduling fields |
| `d1-app-db` | storage | composes — existing workflow run projection stores the first explicit-key `run_at`, ignores still-creating rows for retry lookup, and still scopes idempotency lookup by user |

### System map

```mermaid
flowchart LR
	mcpServer["mcp-server"]:::touched --> workflows["workflows"]:::extended --> d1AppDb["d1-app-db"]:::touched
	packageApps["package-apps"]:::extended --> workflows
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Execute as MCP execute module
	participant App as Package app runtime
	participant Runtime as workflows helper/proxy
	participant Hub as DynamicCallableWorkflow hub
	participant Runs as workflow_runs projection
	Execute->>Runtime: workflows.create({ code })
	App->>Runtime: workflows.create({ code })
	Runtime->>Hub: package_workflow_create({ code })
	Hub->>Hub: default runAt + idempotencyKey
	Hub->>Hub: derive stable instance id for explicit idempotency keys
	Hub->>Runs: pre-record explicit-key creating run before create
	Hub->>Runs: promote creating row to queued/status projection
	Hub-->>Execute: { ok, id, source_type: 'inline', run_at }
```

### Invariants

- Workflow payloads and workflow run lookups remain scoped by `userId`.
- Existing workflow instances are rejoined before concurrency-limit checks, so idempotent retries do not consume extra capacity.
- Explicit idempotency keys still dedupe per user via `workflow_runs`; before the normal status projection path completes, the workflow instance ID and pre-recorded row are also stable for the explicit key.
- Failed Workflow creates leave only a `creating` projection row, which future idempotency lookups ignore so the same key can retry.
- Generated keys intentionally create a fresh workflow for each omitted-key call.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd03de3f-e587-41aa-a05b-d373a097809a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd03de3f-e587-41aa-a05b-d373a097809a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `workflows.create` now supports omitting `runAt` and `idempotencyKey`; defaults are applied automatically and an idempotency key is generated when needed.
  * Inline workflow submissions now queue with stable naming and scheduling metadata.

* **Bug Fixes**
  * Queued workflow payloads no longer include empty/absent `runAt` or `idempotencyKey`, and queued instance IDs follow consistent single-flight behavior when `idempotencyKey` isn’t provided.
  * Inline workflow deduplication behaves correctly when re-submitting after pre-projection state.

* **Tests**
  * Added/updated node tests covering inline scheduling defaults, payload forwarding, and deduplication scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->