### PR TITLE
Add Kody platform friction guidance

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -13,6 +13,7 @@ available `guide` ids).
 | [integration-backed-app-happy-path.md](./integration-backed-app-happy-path.md)           | Default package app pattern after integration smoke test passes                                             |
 | [package-service-pattern.md](./package-service-pattern.md)                               | General package-service pattern for native long-lived runtimes inside Kody                                  |
 | [package-subscriptions.md](./package-subscriptions.md)                                   | Package subscription manifest shape, discovery, and email.message.received payload guidance                 |
+| [platform-friction.md](./platform-friction.md)                                           | Agent self-improvement loop for Kody capability, package, memory, and guide friction                        |
 | [oauth.md](./oauth.md)                                                                   | **Start here** for third-party OAuth (`/connect/oauth`, redirect URI, params)                               |
 | [generated-ui-oauth.md](./generated-ui-oauth.md)                                         | Edge case: OAuth in a hosted package app (`open_generated_ui` on a saved package)                           |
 | [account-secret-setup.md](./account-secret-setup.md)                                     | `/account/secrets/new` URL parameters and policies                                                          |

--- a/docs/guides/platform-friction.md
+++ b/docs/guides/platform-friction.md
@@ -1,0 +1,90 @@
+# Kody platform friction guide
+
+Use this guide when Kody itself creates friction while you are using built-in
+capabilities, saved packages, package apps, jobs, memories, values,
+integrations, or official Kody guides.
+
+The goal is small, user-approved self-improvement: reduce repeated friction
+without turning the user's task into platform maintenance.
+
+## What counts as Kody friction
+
+Treat these as friction points:
+
+- confusing or missing package README guidance
+- a saved package whose intent or setup steps are unclear
+- capability descriptions, schemas, or guide text that caused a wrong turn
+- recurring user-specific preferences or workarounds that Kody could remember
+- reproducible Kody bugs, misleading errors, or missing troubleshooting steps
+
+Do not use this guide for normal product scope decisions, third-party API
+failures, or credentials setup. Use `integration_bootstrap`, `oauth`, or
+`connect_secret` for those workflows.
+
+## Core rule
+
+When you notice a Kody friction point and you can suggest a concrete
+improvement, tell the user briefly and ask whether they want you to smooth it
+out.
+
+If the improvement is obvious, low-risk, and already within the work you are
+doing, you may make it directly. Examples:
+
+- fix a typo or stale setup step in a package README you are already editing
+- clarify a package `## Intent` section after the user expanded the package
+  scope
+- add a missing usage note to package docs after you verified the behavior
+
+Still mention the improvement in your final response so the user can see what
+changed.
+
+## Memory changes require approval
+
+Ask before writing, updating, or deleting long-term memory.
+
+Use memory only for durable user-specific facts, preferences, or repeated
+workarounds. Do not store product bugs, transient task state, secrets, or raw
+credentials as memory.
+
+Before any memory mutation:
+
+1. Explain the proposed memory in plain language.
+2. Ask for user approval.
+3. Run `meta_memory_verify`.
+4. Only then run `meta_memory_upsert` or `meta_memory_delete` if the
+   verification result supports the change.
+
+## Package or docs improvements
+
+When the friction is in a saved package or package-facing documentation:
+
+1. Identify the smallest improvement that would have avoided the friction.
+2. Prefer README, guide, or capability-description text over new primitives.
+3. Make obvious, local documentation fixes when you are already modifying that
+   package or repo.
+4. Ask the user before changing package behavior, adding jobs, changing
+   visibility, or broadening scope.
+
+## Platform bugs and larger improvements
+
+For Kody platform issues that you cannot fix in the current context:
+
+1. Tell the user what went wrong and what workaround you used.
+2. Suggest the smallest follow-up, such as a docs clarification, package update,
+   or bug report.
+3. Ask whether they want you to take that follow-up.
+
+Keep this separate from the user's main task. Do not block a successful result
+on filing a bug or improving docs unless the friction prevents completion.
+
+## Suggested phrasing
+
+Use concise language:
+
+> I hit a Kody friction point: `<specific issue>`. A small improvement would be
+> `<proposed fix>`. Would you like me to make that smoother?
+
+For memory:
+
+> This seems like a durable preference/workaround. I can propose a memory for
+> it, but I will only write it after you approve.

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.node.test.ts
@@ -15,7 +15,7 @@ const ctx = {
 }
 
 test('coding_guide_get fetches markdown and surfaces fetch failures', async () => {
-	const url = buildKodyOfficialGuideUrlForTest('package_subscriptions')
+	const url = buildKodyOfficialGuideUrlForTest('platform_friction')
 	{
 		using _server = createMswNodeServer([
 			http.get(url, () =>
@@ -25,7 +25,7 @@ test('coding_guide_get fetches markdown and surfaces fetch failures', async () =
 			),
 		])
 		const result = await kodyOfficialGuideCapability.handler(
-			{ guide: 'package_subscriptions' },
+			{ guide: 'platform_friction' },
 			ctx,
 		)
 		expect(result.body).toBe('# Hello\n\nbody')

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -76,6 +76,12 @@ export const kodyOfficialGuideCatalog = {
 		summary:
 			'Use package.json#kody.subscriptions for package-owned event handlers; discover subscribers with package_subscriptions_list and follow metadata-first email.message.received payload guidance.',
 	},
+	platform_friction: {
+		file: 'platform-friction.md',
+		title: 'Kody platform friction guide',
+		summary:
+			'Use when Kody capabilities, packages, memories, or guides create avoidable friction: mention it, ask before memory changes, and make obvious local docs/package improvements.',
+	},
 } as const
 
 const guideIds = Object.keys(kodyOfficialGuideCatalog) as Array<
@@ -129,6 +135,7 @@ function buildCapabilityDescription(): string {
 		'Prefer this capability plus `search` results over local repo spelunking when Kody auth or integration behavior is already documented.',
 		'Use `guide: "package_authoring"` for package creation or material package updates, and `guide: "integration_bootstrap"` before building integration-dependent packages, package apps, or workflows.',
 		'Integration bootstrap covers checking saved `integration` / `secret` entities and running a cheap authenticated smoke test before building.',
+		'Use `guide: "platform_friction"` when Kody itself creates avoidable friction and you can propose a docs, package, or memory follow-up.',
 		'',
 		'The `guide` input describes each available guide and when to use it. If you are unsure, call this capability instead of guessing.',
 	].join('\n')
@@ -149,6 +156,7 @@ const guideFieldSchema = z
 			'`package_invocation_token_setup`: /account/package-invocation-tokens/new setup URL shape, owner-scoped /@:username/api/package-invocations invocation route shape, query params, and bearer-token safety policy for external package invocation clients.',
 			'`package_service_pattern`: package-native long-lived service architecture built on package services and package app realtime.',
 			'`package_subscriptions`: package-owned event subscriptions, package_subscriptions_list discovery, and email.message.received metadata-first handler payloads.',
+			'`platform_friction`: self-improvement workflow for Kody capability/package/memory/guide friction; ask before memory mutations.',
 		].join(' '),
 	)
 
@@ -204,6 +212,12 @@ const allKeywords = [
 		'service package',
 		'package subscription',
 		'package subscriptions',
+		'platform friction',
+		'self improvement',
+		'self-improvement',
+		'friction',
+		'workaround',
+		'agent improvement',
 		'package_subscriptions_list',
 		'package.json#kody.subscriptions',
 		'email.message.received',

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -78,6 +78,7 @@ Conventions
 - Package services are inspected and controlled through \`service_list\`, \`service_get\`, \`service_start\`, and \`service_stop\`.
 - Memory writes are verify-first: always run \`meta_memory_verify\` before \`meta_memory_upsert\` or \`meta_memory_delete\`. Kody retrieves related memories; the consuming agent decides whether to upsert, delete, both, or do nothing. \`meta_memory_upsert\` creates a new memory when \`memory_id\` is omitted and updates an existing memory when \`memory_id\` is provided.
 - User-specific MCP instructions: \`meta_get_mcp_server_instructions\` / \`meta_set_mcp_server_instructions\` (signed-in users). Updates apply to **new** MCP sessions (reconnect to refresh what the host shows).
+- Kody friction: when capabilities, packages, memories, or guides create avoidable friction, call \`coding_guide_get\` with \`guide: "platform_friction"\`; mention the friction to the user, ask before memory changes, and make obvious local docs/package improvements when already in scope.
 
 Kody repository (for contributors): https://github.com/kentcdodds/kody
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add an official `platform_friction` Kody guide for agent self-improvement around capability, package, memory, and guide friction.
- Register the guide in `coding_guide_get` metadata and base MCP instructions so agents can discover it.
- Cover the new guide id in the existing official-guide fetch test.

## Testing

- `npm exec vitest -- run --project node-unit packages/worker/src/mcp/capabilities/coding/kody-official-guide.node.test.ts`
- Pre-push hook: `npm run typecheck`, `npm run test`, `npm run test:e2e:run`
- `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/platform-friction-guidance-f505`

**Classification:** composes — no primitive is added or reshaped; this wires a new official guide into the existing MCP guide-discovery surface.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | composes — adds one base instruction pointing agents to the guide |
| `capability-registry` | assistant | composes — registers a new `coding_guide_get` guide id and keywords |
| `memories` | assistant | composes — documents approval/verify-first behavior without changing storage |

### System map

```mermaid
flowchart LR
	mcpServer["mcp-server"]:::touched
	capabilityRegistry["capability-registry"]:::touched
	memories["memories"]:::touched
	mcpServer --> capabilityRegistry
	capabilityRegistry --> memories
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- `compact-mcp-surface`: preserved; the change adds a guide behind existing `search`/`execute` capability discovery instead of adding a top-level MCP tool.
- `per-user-isolation`: unaffected; no read/write path or storage behavior changes.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3efa-1ad3-7528-b9a5-ef8bac61f505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3efa-1ad3-7528-b9a5-ef8bac61f505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new official guide for handling platform friction, including when to flag issues, propose improvements, and request approval for memory-related changes.
  * Updated agent-facing instructions so the new guidance is surfaced during relevant workflows.
  * Added the new guide to the guides index for easier discovery.

* **Tests**
  * Updated the guide coverage test to verify the new platform friction guide entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->