### PR TITLE
Make admin and community screens mobile friendly

### DIFF
--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -238,7 +238,8 @@ export function AccountIntegrationsRoute(handle: Handle) {
 					<section
 						mix={css({
 							display: 'grid',
-							gridTemplateColumns: 'repeat(auto-fit, minmax(22rem, 1fr))',
+							gridTemplateColumns:
+								'repeat(auto-fit, minmax(min(22rem, 100%), 1fr))',
 							gap: spacing.lg,
 						})}
 					>

--- a/packages/worker/client/routes/admin-invites.tsx
+++ b/packages/worker/client/routes/admin-invites.tsx
@@ -4,7 +4,7 @@ import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
-import { colors, spacing, typography } from '#client/styles/tokens.ts'
+import { colors, mq, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
 	descriptionCss,
@@ -269,6 +269,10 @@ export function AdminInvitesRoute(handle: Handle) {
 							gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr) auto',
 							gap: spacing.md,
 							alignItems: 'end',
+							[mq.mobile]: {
+								gridTemplateColumns: 'minmax(0, 1fr)',
+								alignItems: 'stretch',
+							},
 						})}
 					>
 						<label mix={css(fieldCss)}>
@@ -339,6 +343,13 @@ export function AdminInvitesRoute(handle: Handle) {
 							gridTemplateColumns: 'repeat(4, minmax(0, 1fr)) auto',
 							gap: spacing.md,
 							alignItems: 'end',
+							[mq.tablet]: {
+								gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+							},
+							[mq.mobile]: {
+								gridTemplateColumns: 'minmax(0, 1fr)',
+								alignItems: 'stretch',
+							},
 						})}
 					>
 						<label mix={css(fieldCss)}>

--- a/packages/worker/client/routes/admin-usage.tsx
+++ b/packages/worker/client/routes/admin-usage.tsx
@@ -395,7 +395,8 @@ export function AdminUsageRoute(handle: Handle) {
 									mix={css({
 										display: 'grid',
 										gap: spacing.lg,
-										gridTemplateColumns: 'repeat(auto-fit, minmax(24rem, 1fr))',
+										gridTemplateColumns:
+											'repeat(auto-fit, minmax(min(24rem, 100%), 1fr))',
 									})}
 								>
 									<section mix={css(cardCss)}>
@@ -407,34 +408,36 @@ export function AdminUsageRoute(handle: Handle) {
 										>
 											Entitlements
 										</h3>
-										<table mix={css(tableCss)}>
-											<thead>
-												<tr>
-													<th mix={css(cellCss)}>Resource</th>
-													<th mix={css(numericCellCss)}>Current</th>
-													<th mix={css(numericCellCss)}>Limit</th>
-													<th mix={css(numericCellCss)}>Used</th>
-												</tr>
-											</thead>
-											<tbody>
-												{selectedUser.entitlementConsumption.map((item) => (
-													<tr key={item.resource}>
-														<td mix={css(cellCss)}>{item.label}</td>
-														<td mix={css(numericCellCss)}>
-															{item.current === null
-																? 'Not measured'
-																: formatInteger(item.current)}
-														</td>
-														<td mix={css(numericCellCss)}>
-															{formatLimit(item.limit)}
-														</td>
-														<td mix={css(numericCellCss)}>
-															{formatPercent(item.percentOfLimit)}
-														</td>
+										<div mix={css({ overflowX: 'auto' })}>
+											<table mix={css(tableCss)}>
+												<thead>
+													<tr>
+														<th mix={css(cellCss)}>Resource</th>
+														<th mix={css(numericCellCss)}>Current</th>
+														<th mix={css(numericCellCss)}>Limit</th>
+														<th mix={css(numericCellCss)}>Used</th>
 													</tr>
-												))}
-											</tbody>
-										</table>
+												</thead>
+												<tbody>
+													{selectedUser.entitlementConsumption.map((item) => (
+														<tr key={item.resource}>
+															<td mix={css(cellCss)}>{item.label}</td>
+															<td mix={css(numericCellCss)}>
+																{item.current === null
+																	? 'Not measured'
+																	: formatInteger(item.current)}
+															</td>
+															<td mix={css(numericCellCss)}>
+																{formatLimit(item.limit)}
+															</td>
+															<td mix={css(numericCellCss)}>
+																{formatPercent(item.percentOfLimit)}
+															</td>
+														</tr>
+													))}
+												</tbody>
+											</table>
+										</div>
 									</section>
 									<section mix={css(cardCss)}>
 										<h3

--- a/packages/worker/client/routes/community.tsx
+++ b/packages/worker/client/routes/community.tsx
@@ -124,7 +124,7 @@ const searchFormCss = {
 const searchFieldCss = {
 	...fieldCss,
 	flex: 1,
-	minWidth: '20rem',
+	minWidth: 'min(20rem, 100%)',
 	maxWidth: '40rem',
 }
 

--- a/packages/worker/client/styles/style-primitives.ts
+++ b/packages/worker/client/styles/style-primitives.ts
@@ -210,7 +210,7 @@ export const listCss = {
 
 export const detailGridCss = {
 	display: 'grid',
-	gridTemplateColumns: 'repeat(auto-fit, minmax(14rem, 1fr))',
+	gridTemplateColumns: 'repeat(auto-fit, minmax(min(14rem, 100%), 1fr))',
 	gap: spacing.md,
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited every screen of the web UI at 320px, 360px, and 390px viewports (logged out, logged in, and admin) with an automated Playwright harness that flags horizontal document overflow, and fixed everything it caught:

- **`/admin/invites`** (the worst offender): the "Create user" (3-track) and "Create invite" (5-track) form grids never stacked, so inputs were squished to ~30px and the datetime input pushed the page 78–85px past the viewport. They now collapse to 2 columns on tablet and a single column on mobile, using `minmax(0, 1fr)` so intrinsic input widths can't force overflow.
- **`/admin/usage`**: the drill-down card grid used `minmax(24rem, 1fr)` (384px minimum) which overflowed phones, and the Entitlements table had no horizontal-scroll wrapper. The grid minimum is now `min(24rem, 100%)` and the table scrolls within its card like the neighboring tables.
- **`/account/integrations`**: the integration card grid's `minmax(22rem, 1fr)` minimum could overflow at ≤360px; now `min(22rem, 100%)`.
- **`/community`**: the search field's `minWidth: 20rem` overflowed a 320px viewport; now `min(20rem, 100%)`.
- **`detailGridCss`** (shared primitive): grid minimum now `min(14rem, 100%)` as a defensive floor for very narrow screens.

After the fixes, all 24 audited screens report **0px horizontal overflow** at 320/360/390px, and tablet (800px) and desktop (1280px) layouts are unchanged.

## Before / after (390px)

| Admin invites before | Admin invites after |
| --- | --- |
| ![Admin invites mobile before](https://cursor.com/artifacts/c/art-f3290096-05f7-4a39-a468-1fdd4cdc8400) | ![Admin invites mobile after](https://cursor.com/artifacts/c/art-75712641-1612-4218-af69-0bc575aa4ffa) |

| Admin usage before | Admin usage after |
| --- | --- |
| ![Admin usage mobile before](https://cursor.com/artifacts/c/art-4eabcbf8-3b26-4e50-851b-7fa06deb5ef9) | ![Admin usage mobile after](https://cursor.com/artifacts/c/art-50adca75-26d2-4f04-b519-adbab99d7791) |

Demo of the invite-creation flow on an emulated iPhone 12 Pro:

<a href="https://cursor.com/agents/bc-019f3f9a-430b-7df9-942b-50427359f2ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_invites_mobile_demo.mp4"><img src="https://cursor.com/artifacts/c/art-0dffcda1-e234-4f33-98a0-08440b595693" alt="admin_invites_mobile_demo.mp4" /></a>

## Testing

- ✅ `npm run validate` (format, lint, typecheck, unit, Playwright E2E, MCP E2E — all green)
- ✅ Automated mobile overflow audit of 24 screens at 320/360/390px: 0px overflow everywhere
- ✅ Tablet (800px) and desktop (1280px) spot checks on the changed pages: layout unchanged, 0px overflow
- ✅ Manual mobile-emulation test of the invite creation flow (see video)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `09c293a0` · **Head:** `14023e8a`

**Classification:** composes — responsive CSS-in-JS layout tweaks inside the browser app; no primitive behavior, shape, or contract changes.

### Primitives touched

| Primitive | Group    | Impact                                                       |
| --------- | -------- | ------------------------------------------------------------ |
| `app-ui`  | surfaces | composes — mobile breakpoint styling in client routes/styles |

### System map

```mermaid
flowchart LR
	appUi["app-ui"]:::touched
	worker["worker (entry)"]:::untouched
	worker --> appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3f9a-430b-7df9-942b-50427359f2ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3f9a-430b-7df9-942b-50427359f2ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Made several grid-based layouts and form sections more responsive on smaller screens.
  * Search, account integrations, and usage views now fit narrower containers better without overflowing.
  * Improved the usability of table and detail layouts by allowing horizontal scrolling or more flexible column sizing where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->