### PR TITLE
Fix empty secrets list after client-side navigation

### DIFF
--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -1088,24 +1088,10 @@ export function AccountSecretsRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = getCurrentHref()
-		const selection = getSelectionState(currentHref)
-		const filters = readFilterState(currentHref, apps)
-		const filteredSecrets = filterSecrets(secrets, filters)
-		const appOptions = apps.map((app) => ({
-			id: app.id,
-			label: app.title,
-			description: buildAppOptionDescription(app.updatedAt),
-		}))
-		const filterAppOptions = [
-			{
-				id: '',
-				label: 'All apps',
-				description: 'Show secrets across every app',
-			},
-			...appOptions,
-		]
-
 		const currentDataKey = getDataRefreshKey(currentHref)
+		// Consume route-loader data before deriving list state below; deriving
+		// first would render this pass from the stale pre-navigation `secrets`
+		// (an empty list on SPA navigation) with no follow-up refetch queued.
 		const appliedRouteData = applyRouteLoaderData(currentHref)
 		// A same-path refresh whose loader failed leaves no preload and no
 		// data-key change; the stale marker forces the fallback refetch.
@@ -1126,6 +1112,23 @@ export function AccountSecretsRoute(handle: Handle) {
 		) {
 			handle.queueTask(loadAccountSecrets)
 		}
+
+		const selection = getSelectionState(currentHref)
+		const filters = readFilterState(currentHref, apps)
+		const filteredSecrets = filterSecrets(secrets, filters)
+		const appOptions = apps.map((app) => ({
+			id: app.id,
+			label: app.title,
+			description: buildAppOptionDescription(app.updatedAt),
+		}))
+		const filterAppOptions = [
+			{
+				id: '',
+				label: 'All apps',
+				description: 'Show secrets across every app',
+			},
+			...appOptions,
+		]
 
 		const activeSecretId =
 			selection.selectedSecretId ?? selectedSecret?.id ?? null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Navigating to `/account/secrets` via a top-navigation link (client-side navigation) rendered an empty "Saved secrets" list ("No secrets match the current filters.") even when the user has secrets. A full page refresh showed the list correctly.

## Root cause

In `AccountSecretsRoute`'s render pass, `filteredSecrets` was derived from the `secrets` closure **before** `applyRouteLoaderData()` consumed the preloaded route-loader data. On SPA navigation the component mounts with `secrets = []`, so the pass rendered the stale empty list while `status` was already flipped to `ready` — and because the preload was successfully applied, no fallback refetch was queued, leaving the list permanently empty until a full reload. Every other account-management route (`account.tsx`, `account-integrations.tsx`, `account-remote-connectors.tsx`, `account-package-invocation-tokens.tsx`, ...) already applies route-loader data first; secrets was the outlier.

## Fix

Reorder the render pass in `packages/worker/client/routes/account-secrets.tsx` to consume route-loader data (and run the stale/refetch checks) before deriving `selection`, `filters`, `filteredSecrets`, and app options, matching the other routes.

## Evidence

Bug reproduced before the fix — SPA navigation vs refresh:

![Before fix: empty list after SPA navigation](https://cursor.com/artifacts/c/art-2dc4992f-12d6-4c8d-9ff4-2f28581a70d9)
![Before fix: list shows after full refresh](https://cursor.com/artifacts/c/art-57108e5e-0b40-4c25-92ae-1bca624e5e06)

After the fix, the secret appears immediately on client-side navigation (repeated twice):

<a href="https://cursor.com/agents/bc-019f3fda-8f8b-7756-9094-39d24bb7db97/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsecrets_list_after_spa_navigation_fixed.mp4"><img src="https://cursor.com/artifacts/c/art-87adec4e-6d32-483e-b092-961f76a2ae5d" alt="secrets_list_after_spa_navigation_fixed.mp4" /></a>

## Testing

- Manually reproduced the bug on `main`, then verified the fix in the browser: two consecutive client-side navigations to the secrets page both render the seeded secret with no empty-state flash.
- `npm run validate` passes (format, lint, typecheck, unit tests, Playwright E2E, MCP E2E).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `82c78085` · **Head:** `1b7eea56`

**Classification:** composes — no primitives added or changed; this PR reorders statements inside an existing client route render pass.

### Primitives touched

| Primitive | Group    | Impact                                                                  |
| --------- | -------- | ----------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — render-order fix in the secrets account route (client-side) |

### System map

```mermaid
flowchart LR
	appUi["app-ui"]:::touched
	appSessions["app-sessions"]:::untouched
	secrets["secrets"]:::untouched
	appUi --> appSessions
	appUi --> secrets
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Nav as client-router
	participant Route as AccountSecretsRoute
	Nav->>Route: navigate (preload stored)
	Note over Route: before: derive filteredSecrets from stale [] → consume preload → render empty
	Note over Route: after: consume preload → derive filteredSecrets → render list
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3fda-8f8b-7756-9094-39d24bb7db97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3fda-8f8b-7756-9094-39d24bb7db97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account secrets navigation so the page now shows the freshest available data during in-app route changes.
  * Prevented the list and filters from briefly reflecting outdated secrets after moving between pages.
  * Reduced unnecessary fallback loading behavior caused by stale route data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->