### PR TITLE
Make route-loader consumption self-correcting

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -107,6 +107,12 @@ loader finishes (or is skipped when no loader matches) does the router commit
 the URL change and notify subscribers. Route components consume that payload
 synchronously on first render via `tryConsumeRouteLoaderData`, so the UI updates
 once with data already present instead of swapping routes into a loading state.
+Because consumption mutates route closure state mid-render, a successful consume
+also schedules one follow-up render of the consuming component (flushed in the
+same microtask, before paint); values a route derived before the consume call
+therefore cannot persist stale. Routes should still consume before deriving
+list/detail state — the follow-up render is a safety net, not the primary
+ordering contract.
 
 Route loaders are registered in `clientRouteLoaders` (`routes/index.tsx`) and
 matched with the same Remix route-pattern specificity as `clientRoutes`. Loaders

--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -70,6 +70,10 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	await expect(page).toHaveURL(/\/admin\/users\/?$/)
 	await expect(page.getByRole('heading', { name: 'Admin users' })).toBeVisible()
 	await expect(page.getByText('Unable to load admin users.')).toHaveCount(0)
+	// The detail panel must render the auto-selected user after SPA
+	// navigation (regression: preloaded loader data consumed mid-render left
+	// derivations from pre-navigation state on screen).
+	await expect(page.getByText('Account metadata only')).toBeVisible()
 	expect(
 		await page.evaluate(
 			() => (window as Window & { __e2eMarker?: boolean }).__e2eMarker,

--- a/packages/worker/client/loader-data-context.node.test.ts
+++ b/packages/worker/client/loader-data-context.node.test.ts
@@ -1,8 +1,15 @@
 import { expect, test } from 'vitest'
+import { type Handle } from 'remix/ui'
 import {
+	AppLoaderDataProvider,
 	hrefMatchesSsrUrl,
 	normalizeRouterHref,
+	tryConsumeRouteLoaderData,
 } from './loader-data-context.tsx'
+import {
+	clearPreloadedNavigationData,
+	setPreloadedNavigationData,
+} from './navigation-data.ts'
 
 test('loader href helpers normalize URLs and compare pathname and search', () => {
 	expect(normalizeRouterHref('/community?q=beta')).toBe('/community?q=beta')
@@ -31,4 +38,73 @@ test('loader href helpers normalize URLs and compare pathname and search', () =>
 			'/account/package-invocation-tokens/token-1',
 		),
 	).toBe(false)
+})
+
+function createStubHandle() {
+	const queuedTasks: Array<(signal?: AbortSignal) => unknown> = []
+	let updateCount = 0
+	const handle = {
+		context: {
+			get(provider: unknown) {
+				if (provider === AppLoaderDataProvider) {
+					return { loaderData: undefined, consumedKeys: new Set() }
+				}
+				// No RouterLocationProvider in the stub tree; consumption
+				// falls through to the preloaded navigation slot.
+				throw new Error('context not available')
+			},
+		},
+		queueTask(task: (signal?: AbortSignal) => unknown) {
+			queuedTasks.push(task)
+		},
+		update() {
+			updateCount++
+			return Promise.resolve(new AbortController().signal)
+		},
+	} as unknown as Handle
+	return {
+		handle,
+		queuedTasks,
+		getUpdateCount: () => updateCount,
+	}
+}
+
+test('consuming route loader data schedules a corrective re-render exactly once', () => {
+	clearPreloadedNavigationData()
+	setPreloadedNavigationData('/account', {
+		accountProfile: {
+			ok: true,
+			email: 'kody@example.com',
+			emailVerified: true,
+			username: 'kody',
+			displayName: 'Kody',
+		},
+	})
+	const { handle, queuedTasks, getUpdateCount } = createStubHandle()
+
+	// Routes apply consumed payloads by mutating closure state mid-render, so
+	// a follow-up render must be scheduled or derivations made before the
+	// consume call would persist stale.
+	const consumed = tryConsumeRouteLoaderData(
+		handle,
+		'accountProfile',
+		'/account',
+	)
+	expect(consumed?.email).toBe('kody@example.com')
+	expect(queuedTasks).toHaveLength(1)
+	for (const task of queuedTasks.splice(0)) task()
+	expect(getUpdateCount()).toBe(1)
+
+	// Consume-once: the follow-up render finds nothing and schedules nothing,
+	// so the corrective render cannot loop.
+	const reconsumed = tryConsumeRouteLoaderData(
+		handle,
+		'accountProfile',
+		'/account',
+	)
+	expect(reconsumed).toBeUndefined()
+	expect(queuedTasks).toHaveLength(0)
+	expect(getUpdateCount()).toBe(1)
+
+	clearPreloadedNavigationData()
 })

--- a/packages/worker/client/loader-data-context.tsx
+++ b/packages/worker/client/loader-data-context.tsx
@@ -67,8 +67,27 @@ export function tryConsumeEmbeddedLoaderData<K extends keyof AppLoaderData>(
 }
 
 /**
+ * Consumption happens mid-render and the caller applies the payload by
+ * mutating route closure state, so anything the route derived earlier in the
+ * same render pass is stale. Schedule one follow-up render so the route
+ * re-derives everything from the applied data. The scheduler flushes queued
+ * tasks and the resulting update in the same microtask as the current render
+ * (before the browser paints), and consume-once semantics guarantee the
+ * follow-up pass consumes nothing, so this cannot loop. `queueTask` (not a
+ * direct `update()`) because a component's update scheduling is not wired
+ * until its first render returns; on the server `queueTask` is a no-op.
+ */
+function scheduleCorrectiveRender(handle: Handle) {
+	handle.queueTask(() => {
+		void handle.update()
+	})
+}
+
+/**
  * Returns loader data for `key` from SSR-embedded props or a preloaded SPA
- * navigation slot. Each source is consume-once per key.
+ * navigation slot. Each source is consume-once per key. Successful reads
+ * schedule a follow-up render of the consuming component so values derived
+ * before consumption in the same render pass cannot persist stale.
  */
 export function tryConsumeRouteLoaderData<K extends keyof AppLoaderData>(
 	handle: Handle,
@@ -76,6 +95,12 @@ export function tryConsumeRouteLoaderData<K extends keyof AppLoaderData>(
 	currentHref: string,
 ): AppLoaderData[K] | undefined {
 	const embedded = tryConsumeEmbeddedLoaderData(handle, key, currentHref)
-	if (embedded !== undefined) return embedded
-	return tryConsumePreloadedLoaderData(key, currentHref)
+	const data =
+		embedded !== undefined
+			? embedded
+			: tryConsumePreloadedLoaderData(key, currentHref)
+	if (data !== undefined) {
+		scheduleCorrectiveRender(handle)
+	}
+	return data
 }

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -247,10 +247,9 @@ export function AdminUsersRoute(handle: Handle) {
 			lastSeenHref = currentHref
 			lastFailedHref = null
 		}
-		const totalPages = Math.max(1, Math.ceil(total / pageSize))
-		const selectedUser = getSelectedUser()
-		const isMutating = actionState !== 'idle'
-
+		// Consume route-loader data before deriving `totalPages` and
+		// `selectedUser`; deriving first would render this pass from the
+		// stale pre-navigation closure state.
 		const appliedRouteData = applyRouteLoaderData(currentHref)
 		// A same-path refresh whose loader failed leaves no preload and no
 		// href change; the stale marker forces the fallback refetch.
@@ -267,6 +266,10 @@ export function AdminUsersRoute(handle: Handle) {
 			loadingForHref = currentHref
 			handle.queueTask(loadAdminUsers)
 		}
+
+		const totalPages = Math.max(1, Math.ceil(total / pageSize))
+		const selectedUser = getSelectedUser()
+		const isMutating = actionState !== 'idle'
 
 		return (
 			<AccountManagementShell>

--- a/packages/worker/public/mcp-apps/kody-ui-utils.css
+++ b/packages/worker/public/mcp-apps/kody-ui-utils.css
@@ -1,176 +1,172 @@
 /* packages/worker/client/mcp-apps/kody-ui-utils.css */
 :root {
-  color-scheme: light dark;
-  --font-body:
-    ui-sans-serif,
-    system-ui,
-    sans-serif;
-  --font-mono:
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    monospace;
-  --spacing-1: 0.25rem;
-  --spacing-2: 0.5rem;
-  --spacing-3: 0.75rem;
-  --spacing-4: 1rem;
-  --spacing-6: 1.5rem;
-  --radius-2: 0.5rem;
-  --radius-3: 0.75rem;
-  --shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
-  --color-bg: #ffffff;
-  --color-surface: #f8fafc;
-  --color-fg: #0f172a;
-  --color-muted: #475569;
-  --color-border: #dbe2ea;
-  --color-accent: #2563eb;
-  --color-accent-contrast: #ffffff;
-  --color-code-bg: rgb(15 23 42 / 0.06);
+	color-scheme: light dark;
+	--font-body: ui-sans-serif, system-ui, sans-serif;
+	--font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	--spacing-1: 0.25rem;
+	--spacing-2: 0.5rem;
+	--spacing-3: 0.75rem;
+	--spacing-4: 1rem;
+	--spacing-6: 1.5rem;
+	--radius-2: 0.5rem;
+	--radius-3: 0.75rem;
+	--shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
+	--color-bg: #ffffff;
+	--color-surface: #f8fafc;
+	--color-fg: #0f172a;
+	--color-muted: #475569;
+	--color-border: #dbe2ea;
+	--color-accent: #2563eb;
+	--color-accent-contrast: #ffffff;
+	--color-code-bg: rgb(15 23 42 / 0.06);
 }
 @media (prefers-color-scheme: dark) {
-  :root {
-    --color-bg: #0f172a;
-    --color-surface: #162033;
-    --color-fg: #e5eef8;
-    --color-muted: #a5b4c7;
-    --color-border: #2a3950;
-    --color-accent: #60a5fa;
-    --color-accent-contrast: #0f172a;
-    --color-code-bg: rgb(148 163 184 / 0.16);
-  }
+	:root {
+		--color-bg: #0f172a;
+		--color-surface: #162033;
+		--color-fg: #e5eef8;
+		--color-muted: #a5b4c7;
+		--color-border: #2a3950;
+		--color-accent: #60a5fa;
+		--color-accent-contrast: #0f172a;
+		--color-code-bg: rgb(148 163 184 / 0.16);
+	}
 }
 :where(html) {
-  min-height: 100%;
-  background: var(--color-bg);
-  color: var(--color-fg);
+	min-height: 100%;
+	background: var(--color-bg);
+	color: var(--color-fg);
 }
 :where(body) {
-  min-height: 100%;
-  margin: 0;
-  padding: var(--spacing-4);
-  background: var(--color-bg);
-  color: var(--color-fg);
-  font: 400 14px/1.5 var(--font-body);
+	min-height: 100%;
+	margin: 0;
+	padding: var(--spacing-4);
+	background: var(--color-bg);
+	color: var(--color-fg);
+	font: 400 14px/1.5 var(--font-body);
 }
-:where(body[data-kody-runtime=javascript]) {
-  padding: 0;
+:where(body[data-kody-runtime='javascript']) {
+	padding: 0;
 }
 :where(*, *::before, *::after) {
-  box-sizing: border-box;
+	box-sizing: border-box;
 }
 :where(a) {
-  color: var(--color-accent);
+	color: var(--color-accent);
 }
 :where(p, ul, ol, dl, pre, table, blockquote, fieldset) {
-  margin: 0 0 var(--spacing-4);
+	margin: 0 0 var(--spacing-4);
 }
 :where(h1, h2, h3, h4, h5, h6) {
-  margin: 0 0 var(--spacing-3);
-  line-height: 1.2;
+	margin: 0 0 var(--spacing-3);
+	line-height: 1.2;
 }
 :where(h1) {
-  font-size: 1.875rem;
+	font-size: 1.875rem;
 }
 :where(h2) {
-  font-size: 1.5rem;
+	font-size: 1.5rem;
 }
 :where(h3) {
-  font-size: 1.25rem;
+	font-size: 1.25rem;
 }
 :where(ul, ol) {
-  padding-left: 1.5rem;
+	padding-left: 1.5rem;
 }
 :where(hr) {
-  border: 0;
-  border-top: 1px solid var(--color-border);
-  margin: var(--spacing-6) 0;
+	border: 0;
+	border-top: 1px solid var(--color-border);
+	margin: var(--spacing-6) 0;
 }
 :where(code, kbd, samp) {
-  font-family: var(--font-mono);
-  font-size: 0.95em;
+	font-family: var(--font-mono);
+	font-size: 0.95em;
 }
 :where(code) {
-  background: var(--color-code-bg);
-  border-radius: 0.375rem;
-  padding: 0.1rem 0.35rem;
+	background: var(--color-code-bg);
+	border-radius: 0.375rem;
+	padding: 0.1rem 0.35rem;
 }
 :where(pre) {
-  overflow-x: auto;
-  padding: var(--spacing-3);
-  background: var(--color-code-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-2);
+	overflow-x: auto;
+	padding: var(--spacing-3);
+	background: var(--color-code-bg);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-2);
 }
 :where(pre code) {
-  background: transparent;
-  padding: 0;
+	background: transparent;
+	padding: 0;
 }
 :where(form) {
-  display: grid;
-  gap: var(--spacing-4);
+	display: grid;
+	gap: var(--spacing-4);
 }
 :where(label) {
-  display: grid;
-  gap: var(--spacing-2);
-  font-weight: 600;
+	display: grid;
+	gap: var(--spacing-2);
+	font-weight: 600;
 }
 :where(input, button, textarea, select) {
-  font: inherit;
+	font: inherit;
 }
-:where(input:not([type=checkbox]):not([type=radio]), textarea, select) {
-  width: 100%;
-  padding: var(--spacing-2) var(--spacing-3);
-  background: var(--color-surface);
-  color: var(--color-fg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-2);
-  box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
+:where(input:not([type='checkbox']):not([type='radio']), textarea, select) {
+	width: 100%;
+	padding: var(--spacing-2) var(--spacing-3);
+	background: var(--color-surface);
+	color: var(--color-fg);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-2);
+	box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
 }
 :where(textarea) {
-  min-height: 7rem;
-  resize: vertical;
+	min-height: 7rem;
+	resize: vertical;
 }
-:where(input[type=checkbox], input[type=radio]) {
-  accent-color: var(--color-accent);
+:where(input[type='checkbox'], input[type='radio']) {
+	accent-color: var(--color-accent);
 }
 :where(button) {
-  width: fit-content;
-  padding: var(--spacing-2) var(--spacing-4);
-  background: var(--color-accent);
-  color: var(--color-accent-contrast);
-  border: 1px solid transparent;
-  border-radius: var(--radius-2);
-  box-shadow: var(--shadow-1);
-  cursor: pointer;
+	width: fit-content;
+	padding: var(--spacing-2) var(--spacing-4);
+	background: var(--color-accent);
+	color: var(--color-accent-contrast);
+	border: 1px solid transparent;
+	border-radius: var(--radius-2);
+	box-shadow: var(--shadow-1);
+	cursor: pointer;
 }
 :where(button:disabled, input:disabled, textarea:disabled, select:disabled) {
-  opacity: 0.7;
-  cursor: not-allowed;
+	opacity: 0.7;
+	cursor: not-allowed;
 }
-:where(button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible) {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
+:where(
+	button:focus-visible,
+	input:focus-visible,
+	textarea:focus-visible,
+	select:focus-visible
+) {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
 }
 :where(table) {
-  width: 100%;
-  border-collapse: collapse;
+	width: 100%;
+	border-collapse: collapse;
 }
 :where(th, td) {
-  padding: var(--spacing-2) var(--spacing-3);
-  border: 1px solid var(--color-border);
-  text-align: left;
+	padding: var(--spacing-2) var(--spacing-3);
+	border: 1px solid var(--color-border);
+	text-align: left;
 }
 :where(th) {
-  background: var(--color-surface);
+	background: var(--color-surface);
 }
 :where(blockquote) {
-  margin-left: 0;
-  padding-left: var(--spacing-4);
-  border-left: 3px solid var(--color-border);
-  color: var(--color-muted);
+	margin-left: 0;
+	padding-left: var(--spacing-4);
+	border-left: 3px solid var(--color-border);
+	color: var(--color-muted);
 }
 :where([data-generated-ui-root]) {
-  min-height: 100%;
+	min-height: 100%;
 }

--- a/packages/worker/public/mcp-apps/kody-ui-utils.css
+++ b/packages/worker/public/mcp-apps/kody-ui-utils.css
@@ -1,172 +1,176 @@
 /* packages/worker/client/mcp-apps/kody-ui-utils.css */
 :root {
-	color-scheme: light dark;
-	--font-body: ui-sans-serif, system-ui, sans-serif;
-	--font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-	--spacing-1: 0.25rem;
-	--spacing-2: 0.5rem;
-	--spacing-3: 0.75rem;
-	--spacing-4: 1rem;
-	--spacing-6: 1.5rem;
-	--radius-2: 0.5rem;
-	--radius-3: 0.75rem;
-	--shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
-	--color-bg: #ffffff;
-	--color-surface: #f8fafc;
-	--color-fg: #0f172a;
-	--color-muted: #475569;
-	--color-border: #dbe2ea;
-	--color-accent: #2563eb;
-	--color-accent-contrast: #ffffff;
-	--color-code-bg: rgb(15 23 42 / 0.06);
+  color-scheme: light dark;
+  --font-body:
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+  --font-mono:
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace;
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-6: 1.5rem;
+  --radius-2: 0.5rem;
+  --radius-3: 0.75rem;
+  --shadow-1: 0 1px 2px rgb(15 23 42 / 0.08);
+  --color-bg: #ffffff;
+  --color-surface: #f8fafc;
+  --color-fg: #0f172a;
+  --color-muted: #475569;
+  --color-border: #dbe2ea;
+  --color-accent: #2563eb;
+  --color-accent-contrast: #ffffff;
+  --color-code-bg: rgb(15 23 42 / 0.06);
 }
 @media (prefers-color-scheme: dark) {
-	:root {
-		--color-bg: #0f172a;
-		--color-surface: #162033;
-		--color-fg: #e5eef8;
-		--color-muted: #a5b4c7;
-		--color-border: #2a3950;
-		--color-accent: #60a5fa;
-		--color-accent-contrast: #0f172a;
-		--color-code-bg: rgb(148 163 184 / 0.16);
-	}
+  :root {
+    --color-bg: #0f172a;
+    --color-surface: #162033;
+    --color-fg: #e5eef8;
+    --color-muted: #a5b4c7;
+    --color-border: #2a3950;
+    --color-accent: #60a5fa;
+    --color-accent-contrast: #0f172a;
+    --color-code-bg: rgb(148 163 184 / 0.16);
+  }
 }
 :where(html) {
-	min-height: 100%;
-	background: var(--color-bg);
-	color: var(--color-fg);
+  min-height: 100%;
+  background: var(--color-bg);
+  color: var(--color-fg);
 }
 :where(body) {
-	min-height: 100%;
-	margin: 0;
-	padding: var(--spacing-4);
-	background: var(--color-bg);
-	color: var(--color-fg);
-	font: 400 14px/1.5 var(--font-body);
+  min-height: 100%;
+  margin: 0;
+  padding: var(--spacing-4);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font: 400 14px/1.5 var(--font-body);
 }
-:where(body[data-kody-runtime='javascript']) {
-	padding: 0;
+:where(body[data-kody-runtime=javascript]) {
+  padding: 0;
 }
 :where(*, *::before, *::after) {
-	box-sizing: border-box;
+  box-sizing: border-box;
 }
 :where(a) {
-	color: var(--color-accent);
+  color: var(--color-accent);
 }
 :where(p, ul, ol, dl, pre, table, blockquote, fieldset) {
-	margin: 0 0 var(--spacing-4);
+  margin: 0 0 var(--spacing-4);
 }
 :where(h1, h2, h3, h4, h5, h6) {
-	margin: 0 0 var(--spacing-3);
-	line-height: 1.2;
+  margin: 0 0 var(--spacing-3);
+  line-height: 1.2;
 }
 :where(h1) {
-	font-size: 1.875rem;
+  font-size: 1.875rem;
 }
 :where(h2) {
-	font-size: 1.5rem;
+  font-size: 1.5rem;
 }
 :where(h3) {
-	font-size: 1.25rem;
+  font-size: 1.25rem;
 }
 :where(ul, ol) {
-	padding-left: 1.5rem;
+  padding-left: 1.5rem;
 }
 :where(hr) {
-	border: 0;
-	border-top: 1px solid var(--color-border);
-	margin: var(--spacing-6) 0;
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  margin: var(--spacing-6) 0;
 }
 :where(code, kbd, samp) {
-	font-family: var(--font-mono);
-	font-size: 0.95em;
+  font-family: var(--font-mono);
+  font-size: 0.95em;
 }
 :where(code) {
-	background: var(--color-code-bg);
-	border-radius: 0.375rem;
-	padding: 0.1rem 0.35rem;
+  background: var(--color-code-bg);
+  border-radius: 0.375rem;
+  padding: 0.1rem 0.35rem;
 }
 :where(pre) {
-	overflow-x: auto;
-	padding: var(--spacing-3);
-	background: var(--color-code-bg);
-	border: 1px solid var(--color-border);
-	border-radius: var(--radius-2);
+  overflow-x: auto;
+  padding: var(--spacing-3);
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
 }
 :where(pre code) {
-	background: transparent;
-	padding: 0;
+  background: transparent;
+  padding: 0;
 }
 :where(form) {
-	display: grid;
-	gap: var(--spacing-4);
+  display: grid;
+  gap: var(--spacing-4);
 }
 :where(label) {
-	display: grid;
-	gap: var(--spacing-2);
-	font-weight: 600;
+  display: grid;
+  gap: var(--spacing-2);
+  font-weight: 600;
 }
 :where(input, button, textarea, select) {
-	font: inherit;
+  font: inherit;
 }
-:where(input:not([type='checkbox']):not([type='radio']), textarea, select) {
-	width: 100%;
-	padding: var(--spacing-2) var(--spacing-3);
-	background: var(--color-surface);
-	color: var(--color-fg);
-	border: 1px solid var(--color-border);
-	border-radius: var(--radius-2);
-	box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
+:where(input:not([type=checkbox]):not([type=radio]), textarea, select) {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--color-surface);
+  color: var(--color-fg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+  box-shadow: inset 0 1px 2px rgb(15 23 42 / 0.04);
 }
 :where(textarea) {
-	min-height: 7rem;
-	resize: vertical;
+  min-height: 7rem;
+  resize: vertical;
 }
-:where(input[type='checkbox'], input[type='radio']) {
-	accent-color: var(--color-accent);
+:where(input[type=checkbox], input[type=radio]) {
+  accent-color: var(--color-accent);
 }
 :where(button) {
-	width: fit-content;
-	padding: var(--spacing-2) var(--spacing-4);
-	background: var(--color-accent);
-	color: var(--color-accent-contrast);
-	border: 1px solid transparent;
-	border-radius: var(--radius-2);
-	box-shadow: var(--shadow-1);
-	cursor: pointer;
+  width: fit-content;
+  padding: var(--spacing-2) var(--spacing-4);
+  background: var(--color-accent);
+  color: var(--color-accent-contrast);
+  border: 1px solid transparent;
+  border-radius: var(--radius-2);
+  box-shadow: var(--shadow-1);
+  cursor: pointer;
 }
 :where(button:disabled, input:disabled, textarea:disabled, select:disabled) {
-	opacity: 0.7;
-	cursor: not-allowed;
+  opacity: 0.7;
+  cursor: not-allowed;
 }
-:where(
-	button:focus-visible,
-	input:focus-visible,
-	textarea:focus-visible,
-	select:focus-visible
-) {
-	outline: 2px solid var(--color-accent);
-	outline-offset: 2px;
+:where(button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible) {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 :where(table) {
-	width: 100%;
-	border-collapse: collapse;
+  width: 100%;
+  border-collapse: collapse;
 }
 :where(th, td) {
-	padding: var(--spacing-2) var(--spacing-3);
-	border: 1px solid var(--color-border);
-	text-align: left;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--color-border);
+  text-align: left;
 }
 :where(th) {
-	background: var(--color-surface);
+  background: var(--color-surface);
 }
 :where(blockquote) {
-	margin-left: 0;
-	padding-left: var(--spacing-4);
-	border-left: 3px solid var(--color-border);
-	color: var(--color-muted);
+  margin-left: 0;
+  padding-left: var(--spacing-4);
+  border-left: 3px solid var(--color-border);
+  color: var(--color-muted);
 }
 :where([data-generated-ui-root]) {
-	min-height: 100%;
+  min-height: 100%;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`tryConsumeRouteLoaderData` runs mid-render and routes apply the consumed payload by mutating closure state. Any value a route derived *before* the consume call in the same render pass renders stale — and because the preload was successfully applied, no fallback refetch is queued, so the stale UI persists until the next unrelated update or a full reload. This class caused the empty secrets list (#664) and, still live on `main`, a stale `/admin/users` detail panel: after SPA navigation the sidebar auto-highlights the first user but the panel shows "Choose an account from the list..." (and pagination can be hidden).

## Fix

Eliminate the class at the consumption layer instead of relying on per-route statement ordering:

- `tryConsumeRouteLoaderData` now schedules one corrective re-render of the consuming component whenever it returns data (`handle.queueTask(() => handle.update())`). The `remix/ui` scheduler flushes queued tasks and the resulting update inside the same microtask-driven flush loop as the current render — before the browser paints — so even a mis-ordered route can no longer show stale derivations. Consume-once semantics guarantee the follow-up pass consumes nothing, so it cannot loop (and the scheduler's cascading-update guard backstops that). On the server `queueTask` is a no-op, so SSR is unaffected.
- Reordered `/admin/users` to consume before deriving `totalPages` / `selectedUser` (the last mis-ordered route), keeping "consume first" the primary contract with the framework behavior as safety net.
- Strengthened the admin RBAC e2e journey: after the SPA navigation to `/admin/users` it now asserts the auto-selected detail panel actually rendered ("Account metadata only"), which fails without this fix.
- Added a unit test pinning the contract: consuming schedules exactly one corrective render; re-consuming schedules nothing.
- Documented the safety net in `docs/contributing/architecture/request-lifecycle.md`.

## Evidence

The safety net was verified in isolation: with only the `loader-data-context.tsx` change applied (admin-users still mis-ordered), the `/admin/users` detail panel rendered correctly after SPA navigation, with no visible flash.

Before (current `main`): stale placeholder panel after clicking Admin in the top nav; correct after F5:

![Before: stale admin detail panel after SPA navigation](https://cursor.com/artifacts/c/art-726125a9-7a61-4708-a1c9-99f8ce417f8b)

After (framework fix only, route untouched):

![After: populated admin detail panel after SPA navigation](https://cursor.com/artifacts/c/art-9ab47108-2b8d-4bfb-ae91-dea78ba51c71)

Final demo — SPA navigation to admin users (twice) and secrets, all populated immediately:

<a href="https://cursor.com/agents/bc-019f3fda-8f8b-7756-9094-39d24bb7db97/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspa_navigation_admin_and_secrets_after_router_fix.mp4"><img src="https://cursor.com/artifacts/c/art-831ae571-f2d2-4ea5-973a-45239237a602" alt="spa_navigation_admin_and_secrets_after_router_fix.mp4" /></a>

## Testing

- ✅ `npm run validate` (format, lint, typecheck, 631 unit tests, 10 Playwright e2e incl. the strengthened admin assertion, MCP e2e)
- Manual: reproduced the stale `/admin/users` panel on `main`, verified the framework fix corrects it with the route still mis-ordered, then applied the route reorder and re-verified both admin and secrets pages across repeated client-side navigations.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends a primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `27b28a4c` · **Head:** `c9e0bff6`

**Classification:** extends — changes the client route-loader consumption contract in `app-ui` (successful consumes now schedule a corrective re-render). No primitives added.

### Primitives touched

| Primitive | Group    | Impact                                                                                     |
| --------- | -------- | ------------------------------------------------------------------------------------------ |
| `app-ui`  | surfaces | extends — `tryConsumeRouteLoaderData` self-corrects; `/admin/users` render-order cleanup |

### System map

```mermaid
flowchart LR
	appUi["app-ui"]:::extended
	appSessions["app-sessions"]:::untouched
	rbac["rbac"]:::untouched
	appUi --> appSessions
	appUi --> rbac
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Router as client-router
	participant Route as route component
	participant Sched as remix/ui scheduler
	Router->>Route: commit navigation (preload stored)
	Route->>Route: render pass consumes preload (closure mutated)
	Route->>Sched: queueTask(update) on successful consume
	Sched->>Route: corrective render (same flush, before paint)
	Note over Route: derivations re-run from applied data — stale values cannot persist
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3fda-8f8b-7756-9094-39d24bb7db97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3fda-8f8b-7756-9094-39d24bb7db97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin user navigation so the detail view shows the correct selected user and metadata after route changes.
  * Fixed stale render state when consuming preloaded route data, reducing cases where the UI could briefly show outdated values.

* **Documentation**
  * Clarified routing guidance for data consumption and render ordering in the contribution docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->