### PR TITLE
Require R2 provisioning: remove EMAIL_BLOBS fail-soft fallback

### DIFF
--- a/tools/ci/preview-resources.ts
+++ b/tools/ci/preview-resources.ts
@@ -276,7 +276,7 @@ async function ensurePreviewResources(options: CliOptions) {
 		d1DatabaseId: d1.id,
 		oauthKvId: oauthKv.id,
 		bundleArtifactsKvId: bundleArtifactsKv.id,
-		emailBlobsBucketName: emailBlobs.available ? emailBlobs.name : null,
+		emailBlobsBucketName: emailBlobs.name,
 		workerVars: {
 			CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID,
 		},
@@ -290,9 +290,7 @@ async function ensurePreviewResources(options: CliOptions) {
 	console.log(`oauth_kv_id=${oauthKv.id}`)
 	console.log(`bundle_artifacts_kv_title=${bundleArtifactsKv.title}`)
 	console.log(`bundle_artifacts_kv_id=${bundleArtifactsKv.id}`)
-	console.log(
-		`email_blobs_bucket_name=${emailBlobs.available ? emailBlobs.name : ''}`,
-	)
+	console.log(`email_blobs_bucket_name=${emailBlobs.name}`)
 }
 
 async function cleanupPreviewResources(options: CliOptions) {

--- a/tools/ci/production-resources.ts
+++ b/tools/ci/production-resources.ts
@@ -387,7 +387,7 @@ async function ensureProductionResources(options: CliOptions) {
 		d1DatabaseId: d1.id,
 		oauthKvId: oauthKv.id,
 		bundleArtifactsKvId: bundleArtifactsKv.id,
-		emailBlobsBucketName: emailBlobs.available ? emailBlobs.name : null,
+		emailBlobsBucketName: emailBlobs.name,
 		workerVars: {
 			APP_BASE_URL: process.env.APP_BASE_URL,
 			CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID,
@@ -402,9 +402,7 @@ async function ensureProductionResources(options: CliOptions) {
 	console.log(`oauth_kv_id=${oauthKv.id}`)
 	console.log(`bundle_artifacts_kv_title=${bundleArtifactsKv.title}`)
 	console.log(`bundle_artifacts_kv_id=${bundleArtifactsKv.id}`)
-	console.log(
-		`email_blobs_bucket_name=${emailBlobs.available ? emailBlobs.name : ''}`,
-	)
+	console.log(`email_blobs_bucket_name=${emailBlobs.name}`)
 }
 
 async function main() {

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -106,40 +106,6 @@ test('writeGeneratedWranglerConfig preserves migrations and copies environment a
 	}
 })
 
-test('writeGeneratedWranglerConfig drops the EMAIL_BLOBS binding when the bucket is unavailable', async () => {
-	const tempDir = await mkdtemp(path.join(os.tmpdir(), 'kody-resource-utils-'))
-
-	try {
-		const outPath = path.join(tempDir, 'wrangler-production.generated.json')
-		await writeGeneratedWranglerConfig({
-			baseConfigPath: workerWranglerConfigPath,
-			outConfigPath: outPath,
-			envName: 'production',
-			d1DatabaseName: 'kody',
-			d1DatabaseId: 'dry-run-kody',
-			oauthKvId: 'dry-run-kody-oauth',
-			bundleArtifactsKvId: 'dry-run-kody-bundle-artifacts',
-			emailBlobsBucketName: null,
-		})
-
-		const config = parseJsonc<{
-			env?: {
-				production?: {
-					r2_buckets?: Array<{ binding: string; bucket_name: string }>
-				}
-			}
-		}>(await readFile(outPath, 'utf8'))
-		// EMAIL_BLOBS is the only R2 binding, so the r2_buckets key must be
-		// removed entirely rather than left as an empty array.
-		expect(config.env?.production?.r2_buckets).toBeUndefined()
-		expect(
-			Object.keys(config.env?.production ?? {}).includes('r2_buckets'),
-		).toBe(false)
-	} finally {
-		await rm(tempDir, { force: true, recursive: true })
-	}
-})
-
 test('parseR2BucketListOutput reads bucket names from labelled wrangler output', () => {
 	const output = [
 		'Listing buckets...',

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -131,74 +131,43 @@ export function parseR2BucketListOutput(output: string): Array<string> {
 	return names
 }
 
-/**
- * Returns `null` when the listing fails (for example when the API token
- * lacks R2 permissions) so callers can degrade gracefully instead of
- * aborting the whole provisioning run.
- */
-export function listR2BucketNames(): Array<string> | null {
+export function listR2BucketNames(): Array<string> {
 	const result = runWrangler(['r2', 'bucket', 'list'], { quiet: true })
 	if (result.status !== 0) {
-		console.error('Failed to list R2 buckets (wrangler r2 bucket list).')
-		return null
+		fail('Failed to list R2 buckets (wrangler r2 bucket list).')
 	}
 	return parseR2BucketListOutput(result.stdout)
 }
 
-const r2ProvisioningWarning =
-	"Warning: R2 bucket provisioning failed (the API token may lack R2 permissions). Deploying without the EMAIL_BLOBS binding; raw email MIME will be stored inline in D1. Grant the token 'Workers R2 Storage: Edit' and re-run to enable blob offload."
-
-export type EnsureR2BucketResult = {
-	name: string
-	available: boolean
-}
-
-/**
- * The worker degrades gracefully when EMAIL_BLOBS is absent (raw MIME
- * stays inline in D1), so R2 provisioning failures are non-fatal: the
- * caller gets `available: false` and must drop the binding from the
- * generated config instead of failing the deploy.
- */
 export function ensureR2Bucket({
 	name,
 	dryRun,
 }: {
 	name: string
 	dryRun: boolean
-}): EnsureR2BucketResult {
+}): { name: string } {
 	if (dryRun) {
 		console.error(`[dry-run] ensure R2 bucket: ${name}`)
-		return { name, available: true }
+		return { name }
 	}
 
-	const bucketNames = listR2BucketNames()
-	if (bucketNames === null) {
-		console.error(r2ProvisioningWarning)
-		return { name, available: false }
-	}
-
-	if (bucketNames.includes(name)) {
+	if (listR2BucketNames().includes(name)) {
 		console.error(`R2 bucket exists: ${name}`)
-		return { name, available: true }
+		return { name }
 	}
 
 	const createResult = runWrangler(['r2', 'bucket', 'create', name], {
 		quiet: true,
 	})
 	if (createResult.status !== 0) {
-		console.error(`Failed to create R2 bucket: ${name}`)
-		console.error(r2ProvisioningWarning)
-		return { name, available: false }
+		fail(`Failed to create R2 bucket: ${name}`)
 	}
 
-	const namesAfterCreate = listR2BucketNames()
-	if (namesAfterCreate === null || !namesAfterCreate.includes(name)) {
-		console.error(`Created R2 bucket "${name}" but could not find it via list.`)
-		console.error(r2ProvisioningWarning)
-		return { name, available: false }
+	if (!listR2BucketNames().includes(name)) {
+		fail(`Created R2 bucket "${name}" but could not find it via list.`)
 	}
 	console.error(`Created R2 bucket: ${name}`)
-	return { name, available: true }
+	return { name }
 }
 
 export function deleteR2Bucket({
@@ -213,15 +182,7 @@ export function deleteR2Bucket({
 		return
 	}
 
-	const bucketNames = listR2BucketNames()
-	if (bucketNames === null) {
-		console.error(
-			`Warning: could not list R2 buckets while deleting ${name} (the API token may lack R2 permissions); skipping R2 cleanup.`,
-		)
-		return
-	}
-
-	if (!bucketNames.includes(name)) {
+	if (!listR2BucketNames().includes(name)) {
 		console.error(`R2 bucket already deleted: ${name}`)
 		return
 	}
@@ -426,7 +387,7 @@ export async function writeGeneratedWranglerConfig({
 	d1DatabaseId: string
 	oauthKvId: string
 	bundleArtifactsKvId: string
-	emailBlobsBucketName: string | null
+	emailBlobsBucketName: string
 	workerVars?: Record<string, string | undefined>
 	extraMigrations?: Array<WranglerMigration>
 }) {
@@ -546,24 +507,13 @@ export async function writeGeneratedWranglerConfig({
 		)
 	}
 
-	if (emailBlobsBucketName === null) {
-		// R2 provisioning was unavailable (for example, the API token lacks
-		// R2 permissions). Drop the binding so `wrangler deploy` does not
-		// reference a nonexistent bucket; the worker falls back to inline
-		// raw MIME storage in D1 when EMAIL_BLOBS is absent.
-		r2Buckets.splice(emailBlobsEntryIndex, 1)
-		if (r2Buckets.length === 0) {
-			delete (targetEnv as Record<string, unknown>).r2_buckets
-		}
-	} else {
-		const emailBlobsEntry = r2Buckets[emailBlobsEntryIndex] as Record<
-			string,
-			unknown
-		>
-		r2Buckets[emailBlobsEntryIndex] = {
-			...emailBlobsEntry,
-			bucket_name: emailBlobsBucketName,
-		}
+	const emailBlobsEntry = r2Buckets[emailBlobsEntryIndex] as Record<
+		string,
+		unknown
+	>
+	r2Buckets[emailBlobsEntryIndex] = {
+		...emailBlobsEntry,
+		bucket_name: emailBlobsBucketName,
 	}
 
 	const existingVars = (targetEnv as Record<string, unknown>).vars


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Removes the fail-soft fallback added in #669 for CI runs whose Cloudflare API token lacked R2 permissions. The token has since been granted R2 access, so R2 provisioning is now a hard requirement again:

- `listR2BucketNames()` fails the run instead of returning `null` when `wrangler r2 bucket list` errors.
- `ensureR2Bucket()` fails the run when bucket creation or post-create verification fails, and no longer reports an `available` flag.
- `writeGeneratedWranglerConfig()` requires `emailBlobsBucketName: string` and always writes the `EMAIL_BLOBS` binding (the drop-the-binding path is gone).
- `deleteR2Bucket()` no longer skips cleanup on list failures (the non-empty-bucket warning remains, since R2 refuses to delete non-empty buckets).
- Production and preview provisioning scripts pass the bucket name through unconditionally.

## Why

Deploys should fail loudly if R2 provisioning breaks rather than silently shipping without blob offload (which would leave raw email MIME inline in D1).

## Notes

The worker-side inline fallback (`offloadRawMimeToBlobs` returning `null` when a put fails) is intentionally untouched: it is a per-message resilience path that prevents mail loss, not a deploy-time configuration fallback.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4034-e834-7211-9e65-34c4ee486b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4034-e834-7211-9e65-34c4ee486b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview and production resource generation now always include the email blobs bucket name, avoiding missing or empty bucket values in generated output.
  * R2 bucket setup now fails immediately on errors instead of continuing with partial or ambiguous state.
  * Generated configuration now consistently keeps the email blobs storage binding in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->