### PR TITLE
Remove dead EMAIL_BLOBS binding-missing fallbacks

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -674,9 +674,9 @@ Current retention policies:
   (excluding the `system:email` owner) keep 365 days, deleted oldest first in
   batches. For rows with `raw_mime_key`, the `EMAIL_BLOBS` R2 blob is deleted
   before the row; if the blob delete fails, those rows are skipped and retried
-  on a later run so blobs are never orphaned. Dependent
-  `email_attachments` rows are deleted before their messages, and threads left
-  with no messages are pruned for the affected users.
+  on a later run so blobs are never orphaned. Dependent `email_attachments` rows
+  are deleted before their messages, and threads left with no messages are
+  pruned for the affected users.
 - `entitlement_daily_counters`: daily rate counters keep 400 days by `day` key.
 - `usage_rollups`: per user/metric/month rollups keep 24 months by `month` key;
   raw Analytics Engine usage events follow platform retention.

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -673,8 +673,8 @@ Current retention policies:
 - `email_messages` / `email_attachments` / `email_threads`: user-owned messages
   (excluding the `system:email` owner) keep 365 days, deleted oldest first in
   batches. For rows with `raw_mime_key`, the `EMAIL_BLOBS` R2 blob is deleted
-  before the row; if the binding is missing or the blob delete fails, those rows
-  are skipped and counted as warnings so blobs are never orphaned. Dependent
+  before the row; if the blob delete fails, those rows are skipped and retried
+  on a later run so blobs are never orphaned. Dependent
   `email_attachments` rows are deleted before their messages, and threads left
   with no messages are pruned for the affected users.
 - `entitlement_daily_counters`: daily rate counters keep 400 days by `day` key.

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -956,6 +956,11 @@ test('deleteUserAccount handles OAuth grant revocation and warning-only edge cas
 	const kvFailureResult = await deleteUserAccount({
 		env: {
 			APP_DB: kvFailureDb,
+			EMAIL_BLOBS: {
+				delete: vi.fn(async () => {
+					throw new Error('simulated R2 outage')
+				}),
+			},
 			STORAGE_RUNNER: {
 				idFromName: (name: string) => name as unknown as DurableObjectId,
 				get: () => ({ clearStorage: async () => ({ ok: true as const }) }),
@@ -968,11 +973,11 @@ test('deleteUserAccount handles OAuth grant revocation and warning-only edge cas
 	expect(kvFailureRows.archived_job_artifacts).toEqual([])
 	expect(kvFailureRows.email_messages).toEqual([])
 	expect(kvFailureResult.deletedKvKeys).toBe(0)
-	// The D1 rows are still removed when EMAIL_BLOBS is unavailable; the
-	// stranded blobs are reported as a warning instead of aborting.
+	// The D1 rows are still removed when the blob delete fails; the
+	// stranded blob is reported as a warning instead of aborting.
 	expect(kvFailureResult.deletedEmailBlobs).toBe(0)
 	expect(kvFailureResult.warnings).toContain(
-		'EMAIL_BLOBS binding was unavailable; 1 raw email MIME blob(s) referenced by the deleted user were not removed and must be cleaned up manually.',
+		'Email blob delete failed for email-raw:v1:user-aaa/em-1: simulated R2 outage',
 	)
 	expect(kvFailureResult.warnings.length).toBeGreaterThan(0)
 })

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -1066,17 +1066,11 @@ export async function deleteUserAccount(input: {
 		)
 	}
 
-	if (input.env.EMAIL_BLOBS) {
-		result.deletedEmailBlobs = await deleteEmailBlobs({
-			blobs: input.env.EMAIL_BLOBS,
-			keys: inventory.emailRawMimeKeys,
-			warnings,
-		})
-	} else if (inventory.emailRawMimeKeys.length > 0) {
-		warnings.push(
-			`EMAIL_BLOBS binding was unavailable; ${inventory.emailRawMimeKeys.length} raw email MIME blob(s) referenced by the deleted user were not removed and must be cleaned up manually.`,
-		)
-	}
+	result.deletedEmailBlobs = await deleteEmailBlobs({
+		blobs: input.env.EMAIL_BLOBS,
+		keys: inventory.emailRawMimeKeys,
+		warnings,
+	})
 
 	const d1Cleanup = await deleteUserScopedRows({
 		env: input.env,

--- a/packages/worker/src/app/admin-system-email-data.ts
+++ b/packages/worker/src/app/admin-system-email-data.ts
@@ -134,7 +134,7 @@ async function listAttachments(db: D1Database, messageId: string) {
 export async function loadAdminSystemEmailMessageById(
 	db: D1Database,
 	messageId: string,
-	blobs?: R2Bucket | null,
+	blobs: R2Bucket,
 ): Promise<AdminSystemEmailDetail | null> {
 	const row = await db
 		.prepare(

--- a/packages/worker/src/app/retention.node.test.ts
+++ b/packages/worker/src/app/retention.node.test.ts
@@ -766,7 +766,6 @@ test('email message retention deletes old user rows, R2 blobs, attachments, and 
 		deletedAttachments: 1,
 		deletedThreads: 1,
 		deletedRawMimeBlobs: 1,
-		skippedMissingBlobBinding: 0,
 		blobDeleteErrors: 0,
 		hasMore: false,
 		nextCursor: null,
@@ -793,15 +792,6 @@ test('email message retention never deletes rows whose blob cannot be deleted fi
 		createdAt: daysAgo(emailMessageRetentionDays + 1),
 	})
 
-	const missingBinding = await pruneUserEmailMessagesForRetention({ db, now })
-	expect(missingBinding).toMatchObject({
-		deletedMessages: 1,
-		deletedRawMimeBlobs: 0,
-		skippedMissingBlobBinding: 1,
-		blobDeleteErrors: 0,
-	})
-	expect(idsForTable(sqlite, 'email_messages')).toEqual(['msg-old-blob'])
-
 	const failingDelete = vi.fn(async () => {
 		throw new Error('r2 unavailable')
 	})
@@ -811,9 +801,8 @@ test('email message retention never deletes rows whose blob cannot be deleted fi
 		now,
 	})
 	expect(failedDelete).toMatchObject({
-		deletedMessages: 0,
+		deletedMessages: 1,
 		deletedRawMimeBlobs: 0,
-		skippedMissingBlobBinding: 0,
 		blobDeleteErrors: 1,
 	})
 	expect(idsForTable(sqlite, 'email_messages')).toEqual(['msg-old-blob'])
@@ -833,8 +822,8 @@ test('email message retention never deletes rows whose blob cannot be deleted fi
 
 test('email message retention cursor advances past skipped blob rows at the head', async () => {
 	const { sqlite, db } = createRetentionDb()
-	// The two oldest expired rows are blob-backed and unpassable without the
-	// EMAIL_BLOBS binding; the two plain expired rows behind them must still be
+	// The two oldest expired rows are blob-backed and unpassable while the
+	// R2 delete fails; the two plain expired rows behind them must still be
 	// pruned within the same run.
 	insertEmailMessage(sqlite, {
 		id: 'msg-blocked-a',
@@ -854,9 +843,15 @@ test('email message retention cursor advances past skipped blob rows at the head
 		id: 'msg-plain-b',
 		createdAt: daysAgo(emailMessageRetentionDays + 1),
 	})
+	const failingBlobs = {
+		delete: vi.fn(async () => {
+			throw new Error('r2 unavailable')
+		}),
+	} as unknown as Pick<R2Bucket, 'delete'>
 
 	const first = await pruneUserEmailMessagesForRetention({
 		db,
+		blobs: failingBlobs,
 		now,
 		batchSize: 2,
 	})
@@ -864,7 +859,7 @@ test('email message retention cursor advances past skipped blob rows at the head
 	// cursor must point past the skipped rows.
 	expect(first).toMatchObject({
 		deletedMessages: 0,
-		skippedMissingBlobBinding: 2,
+		blobDeleteErrors: 2,
 		hasMore: true,
 	})
 	expect(first.nextCursor).toEqual({
@@ -874,13 +869,14 @@ test('email message retention cursor advances past skipped blob rows at the head
 
 	const second = await pruneUserEmailMessagesForRetention({
 		db,
+		blobs: failingBlobs,
 		now,
 		batchSize: 2,
 		cursor: first.nextCursor,
 	})
 	expect(second).toMatchObject({
 		deletedMessages: 2,
-		skippedMissingBlobBinding: 0,
+		blobDeleteErrors: 0,
 		hasMore: true,
 	})
 	expect(idsForTable(sqlite, 'email_messages')).toEqual([
@@ -890,6 +886,7 @@ test('email message retention cursor advances past skipped blob rows at the head
 
 	const third = await pruneUserEmailMessagesForRetention({
 		db,
+		blobs: failingBlobs,
 		now,
 		batchSize: 2,
 		cursor: second.nextCursor,
@@ -921,15 +918,20 @@ test('retention run prunes expired plain emails behind a skipped blob-row head',
 	const env = {
 		APP_DB: db,
 		BUNDLE_ARTIFACTS_KV: { delete: vi.fn(async () => undefined) },
-	} as unknown as Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV'>
+		EMAIL_BLOBS: {
+			delete: vi.fn(async () => {
+				throw new Error('r2 unavailable')
+			}),
+		},
+	} as unknown as Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'EMAIL_BLOBS'>
 
-	// No EMAIL_BLOBS binding: every blob row is skipped, yet the run-level
-	// cursor advances past them so the plain rows in the second batch are
-	// still pruned within the same run.
+	// Every blob delete fails, so every blob row is skipped, yet the
+	// run-level cursor advances past them so the plain rows in the second
+	// batch are still pruned within the same run.
 	const result = await pruneRetention({ env, now })
 
 	expect(result.emailMessages.deletedMessages).toBe(5)
-	expect(result.emailMessages.skippedMissingBlobBinding).toBe(251)
+	expect(result.emailMessages.blobDeleteErrors).toBe(251)
 	expect(result.batchesPerTable['email_messages']).toBe(2)
 	expect(idsForTable(sqlite, 'email_messages')).toHaveLength(251)
 	expect(idsForTable(sqlite, 'email_messages')).not.toContain('msg-plain-0')
@@ -1277,7 +1279,8 @@ test('retention run loops batches per table until backlogs are drained', async (
 	const env = {
 		APP_DB: db,
 		BUNDLE_ARTIFACTS_KV: { delete: vi.fn(async () => undefined) },
-	} as unknown as Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV'>
+		EMAIL_BLOBS: { delete: vi.fn(async () => undefined) },
+	} as unknown as Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'EMAIL_BLOBS'>
 
 	const result = await pruneRetention({ env, now })
 
@@ -1307,7 +1310,8 @@ test('retention run gives every table one batch and stops when the budget is exh
 	const env = {
 		APP_DB: db,
 		BUNDLE_ARTIFACTS_KV: { delete: vi.fn(async () => undefined) },
-	} as unknown as Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV'>
+		EMAIL_BLOBS: { delete: vi.fn(async () => undefined) },
+	} as unknown as Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'EMAIL_BLOBS'>
 
 	const result = await pruneRetention({ env, now, timeBudgetMs: 0 })
 

--- a/packages/worker/src/app/retention.ts
+++ b/packages/worker/src/app/retention.ts
@@ -125,7 +125,7 @@ export const retentionPolicies: ReadonlyArray<RetentionPolicy> = [
 		retentionDays: emailMessageRetentionDays,
 		batchSize: retentionDefaultBatchSize,
 		description:
-			'User email messages keep 365 days, oldest first. R2 raw MIME blobs are deleted before their rows; rows with blobs are skipped when the EMAIL_BLOBS binding is missing so blobs are never orphaned. Operator system:email messages remain governed by system-email retention.',
+			'User email messages keep 365 days, oldest first. R2 raw MIME blobs are deleted before their rows; rows whose blob delete fails are skipped and retried so blobs are never orphaned. Operator system:email messages remain governed by system-email retention.',
 	},
 	{
 		table: 'email_attachments',
@@ -201,7 +201,6 @@ export type RetentionPruneResult = {
 		deletedAttachments: number
 		deletedThreads: number
 		deletedRawMimeBlobs: number
-		skippedMissingBlobBinding: number
 		blobDeleteErrors: number
 	}
 	entitlementDailyCounters: number
@@ -704,7 +703,6 @@ export type EmailMessageRetentionResult = {
 	deletedAttachments: number
 	deletedThreads: number
 	deletedRawMimeBlobs: number
-	skippedMissingBlobBinding: number
 	blobDeleteErrors: number
 	hasMore: boolean
 	nextCursor: EmailMessageRetentionCursor | null
@@ -712,7 +710,7 @@ export type EmailMessageRetentionResult = {
 
 export async function pruneUserEmailMessagesForRetention(input: {
 	db: D1Database
-	blobs?: Pick<R2Bucket, 'delete'> | undefined
+	blobs: Pick<R2Bucket, 'delete'>
 	now?: Date
 	batchSize?: number
 	cursor?: EmailMessageRetentionCursor | null
@@ -749,7 +747,6 @@ export async function pruneUserEmailMessagesForRetention(input: {
 		deletedAttachments: 0,
 		deletedThreads: 0,
 		deletedRawMimeBlobs: 0,
-		skippedMissingBlobBinding: 0,
 		blobDeleteErrors: 0,
 		hasMore: false,
 		nextCursor: null,
@@ -757,25 +754,18 @@ export async function pruneUserEmailMessagesForRetention(input: {
 	const rowsWithBlob = rows.filter((row) => row.raw_mime_key !== null)
 	let deletableRows = rows
 	if (rowsWithBlob.length > 0) {
-		if (!input.blobs) {
-			// Never delete a row whose R2 blob cannot be deleted first; skipping
-			// keeps blobs from being orphaned when the binding is missing.
-			result.skippedMissingBlobBinding = rowsWithBlob.length
+		// Never delete a row whose R2 blob could not be deleted first: once
+		// the row is gone its raw_mime_key is lost and the blob is orphaned
+		// forever. Failed rows are skipped and retried on a later run.
+		try {
+			await input.blobs.delete(
+				rowsWithBlob.map((row) => row.raw_mime_key as string),
+			)
+			result.deletedRawMimeBlobs = rowsWithBlob.length
+		} catch (error) {
+			result.blobDeleteErrors = rowsWithBlob.length
 			deletableRows = rows.filter((row) => row.raw_mime_key === null)
-			console.warn('retention-email-raw-mime-binding-missing', {
-				skipped: rowsWithBlob.length,
-			})
-		} else {
-			try {
-				await input.blobs.delete(
-					rowsWithBlob.map((row) => row.raw_mime_key as string),
-				)
-				result.deletedRawMimeBlobs = rowsWithBlob.length
-			} catch (error) {
-				result.blobDeleteErrors = rowsWithBlob.length
-				deletableRows = rows.filter((row) => row.raw_mime_key === null)
-				console.warn('retention-email-raw-mime-delete-failed', { error })
-			}
+			console.warn('retention-email-raw-mime-delete-failed', { error })
 		}
 	}
 	const messageIds = deletableRows.map((row) => row.id)
@@ -896,11 +886,7 @@ export async function pruneAuditEventsForRetention(input: {
 }
 
 export async function pruneRetention(input: {
-	// EMAIL_BLOBS stays optional so environments without the R2 binding still
-	// prune everything else; blob-backed email rows are then skipped.
-	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV'> & {
-		EMAIL_BLOBS?: R2Bucket | undefined
-	}
+	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'EMAIL_BLOBS'>
 	now?: Date
 	timeBudgetMs?: number
 }): Promise<RetentionPruneResult> {
@@ -929,7 +915,6 @@ export async function pruneRetention(input: {
 			deletedAttachments: 0,
 			deletedThreads: 0,
 			deletedRawMimeBlobs: 0,
-			skippedMissingBlobBinding: 0,
 			blobDeleteErrors: 0,
 		},
 		entitlementDailyCounters: 0,
@@ -1027,8 +1012,6 @@ export async function pruneRetention(input: {
 				result.emailMessages.deletedAttachments += batch.deletedAttachments
 				result.emailMessages.deletedThreads += batch.deletedThreads
 				result.emailMessages.deletedRawMimeBlobs += batch.deletedRawMimeBlobs
-				result.emailMessages.skippedMissingBlobBinding +=
-					batch.skippedMissingBlobBinding
 				result.emailMessages.blobDeleteErrors += batch.blobDeleteErrors
 				emailMessagesCursor = batch.nextCursor
 				return batch.hasMore

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -59,7 +59,7 @@ function warnRejectionAuditWriteFailed(error: unknown) {
 
 async function parseAndStoreInboundEmail(input: {
 	db: D1Database
-	blobs?: R2Bucket | null
+	blobs: R2Bucket
 	message: ForwardableEmailMessage
 	recipient: string
 	userId: string

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -545,6 +545,7 @@ test('getEmailAttachmentById reconstructs unnamed attachments from raw MIME', as
 	const userId = `email-attachment-user-${crypto.randomUUID()}`
 	const stored = await insertEmailMessageWithAttachments({
 		db: env.APP_DB,
+		blobs: env.EMAIL_BLOBS,
 		message: {
 			direction: 'inbound',
 			userId,
@@ -615,6 +616,7 @@ test('getEmailAttachmentById reconstructs unnamed attachments from raw MIME', as
 
 	const loaded = await getEmailAttachmentById({
 		db: env.APP_DB,
+		blobs: env.EMAIL_BLOBS,
 		userId,
 		attachmentId: attachment.id,
 	})
@@ -720,7 +722,7 @@ test('inbound email offloads raw MIME to R2 and readers and deletes follow the b
 	expect(await env.EMAIL_BLOBS.get(stored.rawMimeKey!)).toBeNull()
 })
 
-test('raw MIME stays inline when the EMAIL_BLOBS binding is unavailable', async () => {
+test('raw MIME stays inline when the R2 put fails', async () => {
 	await ensureEmailTestSchema(env.APP_DB)
 	const username = `inline-${crypto.randomUUID().slice(0, 8)}`
 	const accountEmail = `inline-${crypto.randomUUID()}@example.com`
@@ -745,11 +747,21 @@ test('raw MIME stays inline when the EMAIL_BLOBS binding is unavailable', async 
 		to: address,
 		raw,
 	})
-	const envWithoutBlobs = {
+	const failingBlobs = new Proxy(env.EMAIL_BLOBS, {
+		get(target, property, receiver) {
+			if (property === 'put') {
+				return async () => {
+					throw new Error('simulated R2 outage')
+				}
+			}
+			return Reflect.get(target, property, receiver)
+		},
+	})
+	const envWithFailingBlobs = {
 		...createInboundEnv(),
-		EMAIL_BLOBS: undefined,
-	} as unknown as Parameters<typeof handleInboundEmail>[1]
-	await handleInboundEmail(message, envWithoutBlobs)
+		EMAIL_BLOBS: failingBlobs,
+	} as Parameters<typeof handleInboundEmail>[1]
+	await handleInboundEmail(message, envWithFailingBlobs)
 	expect(message.rejectedReason).toBeNull()
 
 	const [stored] = await listEmailMessages({
@@ -760,11 +772,10 @@ test('raw MIME stays inline when the EMAIL_BLOBS binding is unavailable', async 
 	expect(stored).toBeDefined()
 	if (!stored) throw new Error('Expected stored inbound message')
 
-	// Legacy inline behavior: the fallback never throws and keeps mail.
+	// Legacy inline behavior: the offload never throws and keeps mail.
 	expect(stored.rawMime).toBe(raw)
 	expect(stored.rawMimeKey).toBeNull()
-	// The read helper prefers the inline payload and needs no bucket.
-	expect(await loadRawMime({ message: stored })).toBe(raw)
+	// The read helper prefers the inline payload over the bucket.
 	expect(await loadRawMime({ blobs: env.EMAIL_BLOBS, message: stored })).toBe(
 		raw,
 	)

--- a/packages/worker/src/email/outbound.workers.test.ts
+++ b/packages/worker/src/email/outbound.workers.test.ts
@@ -412,6 +412,7 @@ test('sendOutboundEmail preserves reply headers and records failed fallback send
 	})
 	const inbound = await insertEmailMessage({
 		db: env.APP_DB,
+		blobs: env.EMAIL_BLOBS,
 		message: {
 			direction: 'inbound',
 			userId,

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -29,24 +29,16 @@ export function emailRawMimeKey(userId: string, messageId: string) {
 
 /**
  * Best-effort raw-MIME offload to R2. Returns the stored object key, or
- * null when the payload must stay inline in D1 (binding unavailable or
- * the put failed). Never throws: falling back to the legacy inline
- * raw_mime column must not lose mail.
+ * null when the payload must stay inline in D1 because the put failed
+ * (for example a transient R2 outage). Never throws: falling back to
+ * the legacy inline raw_mime column must not lose mail.
  */
 async function offloadRawMimeToBlobs(input: {
-	blobs: R2Bucket | null | undefined
+	blobs: R2Bucket
 	userId: string
 	messageId: string
 	rawMime: string
 }): Promise<string | null> {
-	if (!input.blobs) {
-		console.debug(
-			'email-raw-mime-inline-fallback',
-			'EMAIL_BLOBS binding unavailable',
-			input.messageId,
-		)
-		return null
-	}
 	const key = emailRawMimeKey(input.userId, input.messageId)
 	try {
 		await input.blobs.put(key, input.rawMime)
@@ -69,16 +61,12 @@ async function offloadRawMimeToBlobs(input: {
  * the blob is unreachable.
  */
 export async function loadRawMime(input: {
-	blobs?: R2Bucket | null
+	blobs: R2Bucket
 	message: Pick<EmailMessageRecord, 'rawMime' | 'rawMimeKey'>
 }): Promise<string | null> {
 	if (input.message.rawMime != null) return input.message.rawMime
 	const key = input.message.rawMimeKey
 	if (!key) return null
-	if (!input.blobs) {
-		console.debug('email-raw-mime-blob-unavailable', key)
-		return null
-	}
 	const object = await input.blobs.get(key)
 	if (!object) return null
 	return await object.text()
@@ -584,11 +572,11 @@ export async function touchEmailThread(input: {
 export async function insertEmailMessage(input: {
 	db: D1Database
 	/**
-	 * EMAIL_BLOBS bucket. When present, raw MIME is offloaded to R2 and
-	 * only raw_mime_key is persisted; when absent, raw MIME stays inline
-	 * in the legacy raw_mime column.
+	 * EMAIL_BLOBS bucket. Raw MIME is offloaded to R2 and only
+	 * raw_mime_key is persisted; if the put fails the payload stays
+	 * inline in the legacy raw_mime column rather than losing mail.
 	 */
-	blobs?: R2Bucket | null
+	blobs: R2Bucket
 	message: {
 		id?: string
 		direction: EmailDirection
@@ -898,26 +886,23 @@ export async function searchEmailMessages(input: {
 
 export async function deleteEmailMessageById(input: {
 	db: D1Database
-	/** EMAIL_BLOBS bucket; when present the raw-MIME blob is also deleted. */
-	blobs?: R2Bucket | null
+	/** EMAIL_BLOBS bucket; the raw-MIME blob is deleted with the row. */
+	blobs: R2Bucket
 	messageId: string
 }) {
 	// Capture the blob key before the row disappears. A failed read must
 	// abort the delete (and be retried) rather than orphan the R2 blob; only
 	// the R2 delete itself is best-effort.
-	let rawMimeKey: string | null = null
-	if (input.blobs) {
-		const row = await input.db
-			.prepare(`SELECT raw_mime_key FROM email_messages WHERE id = ?`)
-			.bind(input.messageId)
-			.first<{ raw_mime_key: string | null }>()
-		rawMimeKey = row?.raw_mime_key ?? null
-	}
+	const row = await input.db
+		.prepare(`SELECT raw_mime_key FROM email_messages WHERE id = ?`)
+		.bind(input.messageId)
+		.first<{ raw_mime_key: string | null }>()
+	const rawMimeKey = row?.raw_mime_key ?? null
 	await input.db
 		.prepare(`DELETE FROM email_messages WHERE id = ?`)
 		.bind(input.messageId)
 		.run()
-	if (rawMimeKey != null && input.blobs) {
+	if (rawMimeKey != null) {
 		await input.blobs.delete(rawMimeKey).catch((error: unknown) => {
 			console.warn('email-raw-mime-blob-delete-failed', rawMimeKey, error)
 		})
@@ -1003,7 +988,7 @@ export async function listEmailAttachmentsForMessage(input: {
 export async function getEmailAttachmentById(input: {
 	db: D1Database
 	/** EMAIL_BLOBS bucket for messages whose raw MIME lives in R2. */
-	blobs?: R2Bucket | null
+	blobs: R2Bucket
 	userId: string
 	attachmentId: string
 }) {

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -704,7 +704,7 @@ export async function insertEmailMessage(input: {
 			.run()
 	} catch (error) {
 		// Best-effort orphan cleanup: the blob was written before the row.
-		if (rawMimeKey != null && input.blobs) {
+		if (rawMimeKey != null) {
 			await input.blobs.delete(rawMimeKey).catch(() => undefined)
 		}
 		throw error

--- a/packages/worker/src/email/system-email.ts
+++ b/packages/worker/src/email/system-email.ts
@@ -232,13 +232,12 @@ async function listSystemEmailMessages(input: {
 
 async function deleteSystemEmailMessagesByIds(input: {
 	db: D1Database
-	blobs?: R2Bucket | null
+	blobs: R2Bucket
 	messageIds: ReadonlyArray<string>
 }) {
 	const result = {
 		deletedMessages: 0,
 		deletedRawMimeBlobs: 0,
-		skippedMissingBlobBinding: 0,
 		blobDeleteErrors: 0,
 	}
 	for (
@@ -268,21 +267,13 @@ async function deleteSystemEmailMessagesByIds(input: {
 		let deletableIds: ReadonlyArray<string> = messageIds
 		if (blobRows.length > 0) {
 			const blobRowIds = new Set(blobRows.map((row) => row.id))
-			if (!input.blobs) {
-				result.skippedMissingBlobBinding += blobRows.length
+			try {
+				await input.blobs.delete(blobRows.map((row) => row.raw_mime_key))
+				result.deletedRawMimeBlobs += blobRows.length
+			} catch (error) {
+				result.blobDeleteErrors += blobRows.length
 				deletableIds = messageIds.filter((id) => !blobRowIds.has(id))
-				console.warn('system-email-raw-mime-binding-missing', {
-					skipped: blobRows.length,
-				})
-			} else {
-				try {
-					await input.blobs.delete(blobRows.map((row) => row.raw_mime_key))
-					result.deletedRawMimeBlobs += blobRows.length
-				} catch (error) {
-					result.blobDeleteErrors += blobRows.length
-					deletableIds = messageIds.filter((id) => !blobRowIds.has(id))
-					console.warn('system-email-raw-mime-blob-delete-failed', error)
-				}
+				console.warn('system-email-raw-mime-blob-delete-failed', error)
 			}
 		}
 		if (deletableIds.length === 0) continue
@@ -319,14 +310,13 @@ export type SystemEmailRetentionResult = {
 	deletedCounters: number
 	deletedThreads: number
 	deletedRawMimeBlobs: number
-	skippedMissingBlobBinding: number
 	blobDeleteErrors: number
 }
 
 export async function pruneSystemEmailRetention(input: {
 	db: D1Database
-	/** EMAIL_BLOBS bucket; when present raw-MIME blobs are also deleted. */
-	blobs?: R2Bucket | null
+	/** EMAIL_BLOBS bucket; raw-MIME blobs are deleted before their rows. */
+	blobs: R2Bucket
 	now?: Date
 	timeBudgetMs?: number
 }) {
@@ -344,19 +334,16 @@ export async function pruneSystemEmailRetention(input: {
 		deletedCounters: 0,
 		deletedThreads: 0,
 		deletedRawMimeBlobs: 0,
-		skippedMissingBlobBinding: 0,
 		blobDeleteErrors: 0,
 	}
 
 	const addMessageDelete = (batch: {
 		deletedMessages: number
 		deletedRawMimeBlobs: number
-		skippedMissingBlobBinding: number
 		blobDeleteErrors: number
 	}) => {
 		result.deletedMessages += batch.deletedMessages
 		result.deletedRawMimeBlobs += batch.deletedRawMimeBlobs
-		result.skippedMissingBlobBinding += batch.skippedMissingBlobBinding
 		result.blobDeleteErrors += batch.blobDeleteErrors
 	}
 

--- a/packages/worker/src/email/system-email.workers.test.ts
+++ b/packages/worker/src/email/system-email.workers.test.ts
@@ -412,42 +412,6 @@ test('system email retention deletes blobs before rows and keeps rows when the b
 	).toBeNull()
 })
 
-test('system email retention skips blob-backed rows when the blobs binding is missing', async () => {
-	await ensureEmailTestSchema(env.APP_DB)
-	const now = new Date('2026-07-06T12:00:00.000Z')
-	const old = new Date(
-		now.getTime() - (systemEmailLimits.retentionDays + 1) * 24 * 60 * 60 * 1000,
-	).toISOString()
-	const rawMimeKey = `email-raw:v1:${systemEmailOwnerId}/binding-missing-message`
-	await env.EMAIL_BLOBS.put(rawMimeKey, 'raw mime payload')
-	await env.APP_DB.prepare(
-		`INSERT INTO email_messages (
-			id, direction, user_id, from_address, subject, processing_status, raw_mime_key, created_at, updated_at
-		) VALUES ('binding-missing-message', 'inbound', ?, 'a@example.net', 'Blob', 'stored', ?, ?, ?)`,
-	)
-		.bind(systemEmailOwnerId, rawMimeKey, old, old)
-		.run()
-
-	const result = await pruneSystemEmailRetention({ db: env.APP_DB, now })
-
-	expect(result.deletedMessages).toBe(0)
-	expect(result.skippedMissingBlobBinding).toBe(1)
-	expect(await env.EMAIL_BLOBS.get(rawMimeKey)).not.toBeNull()
-	expect(
-		await env.APP_DB.prepare(
-			`SELECT id FROM email_messages WHERE id = 'binding-missing-message'`,
-		).first(),
-	).toMatchObject({ id: 'binding-missing-message' })
-
-	// Clean up so the skipped row does not leak into other tests.
-	const cleanup = await pruneSystemEmailRetention({
-		db: env.APP_DB,
-		blobs: env.EMAIL_BLOBS,
-		now,
-	})
-	expect(cleanup.deletedMessages).toBe(1)
-})
-
 test('system email retention advances past skipped blob rows at the head of a batch', async () => {
 	await ensureEmailTestSchema(env.APP_DB)
 	const now = new Date('2026-07-06T12:00:00.000Z')
@@ -501,12 +465,26 @@ test('system email retention advances past skipped blob rows at the head of a ba
 			.run()
 	}
 
-	// No blobs binding: the whole first batch is skipped, but the keyset
-	// cursor advances so the plain rows in the next batch are still pruned
-	// within the same run.
-	const result = await pruneSystemEmailRetention({ db: env.APP_DB, now })
+	// Every blob delete fails: the whole first batch is skipped, but the
+	// keyset cursor advances so the plain rows in the next batch are still
+	// pruned within the same run.
+	const failingBlobs = new Proxy(env.EMAIL_BLOBS, {
+		get(target, property, receiver) {
+			if (property === 'delete') {
+				return async () => {
+					throw new Error('simulated R2 outage')
+				}
+			}
+			return Reflect.get(target, property, receiver)
+		},
+	})
+	const result = await pruneSystemEmailRetention({
+		db: env.APP_DB,
+		blobs: failingBlobs,
+		now,
+	})
 
-	expect(result.skippedMissingBlobBinding).toBe(blockedCount)
+	expect(result.blobDeleteErrors).toBe(blockedCount)
 	expect(result.deletedMessages).toBe(plainCount)
 	const remainingPlain = await env.APP_DB.prepare(
 		`SELECT COUNT(*) AS count FROM email_messages WHERE id LIKE 'head-plain-%'`,
@@ -555,7 +533,11 @@ test('system email retention drains delivery-event backlogs larger than one batc
 			.run()
 	}
 
-	const result = await pruneSystemEmailRetention({ db: env.APP_DB, now })
+	const result = await pruneSystemEmailRetention({
+		db: env.APP_DB,
+		blobs: env.EMAIL_BLOBS,
+		now,
+	})
 
 	expect(result.deletedDeliveryEvents).toBeGreaterThanOrEqual(backlog)
 	const remaining = await env.APP_DB.prepare(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Follow-up cleanup to #673: now that the `EMAIL_BLOBS` R2 binding is guaranteed in every deployed environment (provisioning fails the deploy if R2 is unavailable), the worker-side "binding missing" code paths are dead. This removes them and tightens types so the compiler enforces the binding everywhere:

- `email/repo.ts`: `blobs` is now a required `R2Bucket` in `insertEmailMessage`, `deleteEmailMessageById`, `getEmailAttachmentById`, and `loadRawMime`; the binding-missing branches in `offloadRawMimeToBlobs` and `loadRawMime` are gone.
- `email/system-email.ts`: `pruneSystemEmailRetention` requires `blobs`; the `skippedMissingBlobBinding` counter and its skip branch are removed.
- `app/retention.ts`: `pruneUserEmailMessagesForRetention` requires `blobs`; `pruneRetention` requires `EMAIL_BLOBS` in its env; the `skippedMissingBlobBinding` counter is removed from both result types.
- `app/account-deletion.ts`: blob deletion runs unconditionally; the "binding was unavailable" warning branch is gone.
- `email/inbound.ts` / `app/admin-system-email-data.ts`: internal `blobs` params tightened from optional to required.

## What stays

The per-operation R2 failure fallbacks are kept deliberately — they are runtime resilience, not configuration fallbacks:

- A failed R2 `put` on insert keeps raw MIME inline in D1 rather than losing mail (the former binding-unavailable test was converted to cover exactly this path).
- Failed R2 `delete`s during retention skip the affected rows (blob-before-row ordering) and retry on a later run, with keyset cursors still advancing past blocked heads.
- `loadRawMime` still resolves legacy rows whose payload is inline in `raw_mime`.

## Tests

- Converted the inbound "binding unavailable" test to an R2-put-failure test.
- Rewrote the retention cursor-advance and head-blocked tests to use failing blob deletes instead of a missing binding.
- Removed the system-email "binding missing" test; the blob-first delete/retry tests remain.
- Updated the account-deletion warning test to assert the per-key blob-delete-failure warning.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4034-e834-7211-9e65-34c4ee486b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4034-e834-7211-9e65-34c4ee486b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email retention cleanup now retries rows when blob deletion fails, instead of skipping them permanently.
  * Retention and system-email pruning now require the blob store and treat blob-delete errors consistently, preventing premature row removal.
  * Account deletion and inbound/outbound email processing now handle blob-storage availability and outages more reliably.
  * Attachment/raw MIME loading more consistently pulls content from blob storage when applicable.
* **Documentation**
  * Updated retention policy text to reflect “skip and retry on blob deletion failures” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->