### PR TITLE
Safe literal secret references: x-kody-secret-resolution opt-out header and inert placeholder convention

### DIFF
--- a/docs/guides/secret-backed-integration.md
+++ b/docs/guides/secret-backed-integration.md
@@ -98,8 +98,12 @@ Rules:
   to find the right secret name, then reference that name in a placeholder.
 - Placeholders only resolve in secret-aware `fetch` paths and capability inputs
   marked `x-kody-secret`; they are not general string interpolation.
-- Never echo the literal `{{secret:...}}` form into chat, logs, issue bodies, or
-  any content that may later be sent over `fetch`.
+- Never echo a resolvable literal placeholder into chat, logs, issue bodies, or
+  any content that may later be sent over `fetch`. To mention the syntax in
+  prose, use the inert `{{secret:<name>}}` form — angle brackets are outside the
+  name charset, so it never resolves. To deliberately deliver a resolvable
+  placeholder to a third party, set the `x-kody-secret-resolution: off` header
+  on that `fetch` (the gateway strips it and skips resolution for that request).
 - For Basic Auth derived from two secrets, use `secretHeaders.basic(...)` from
   `kody:runtime` (see the secrets usage docs).
 

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -319,9 +319,19 @@ placeholders, host approval, and **`kody.secret_list`** / **`secret_set`**.
 
 Treat placeholder syntax as operational wiring, not prose. Do not place the
 exact **`{{secret:...}}`** token into issue bodies, comments, prompts, logs, or
-other content that may be shown to users or sent to third parties. If you need
-to mention a placeholder literally, obfuscate it instead of embedding the exact
-token.
+other content that may be shown to users or sent to third parties — resolution
+runs on the final serialized request, so even string concatenation cannot keep a
+literal placeholder out of it.
+
+To **mention** the syntax in prose, use the inert form **`{{secret:<name>}}`** —
+angle brackets are outside the placeholder name charset, so it never resolves
+anywhere, now or downstream.
+
+To deliberately deliver a **resolvable** literal placeholder to a third party
+(for example, config that Kody itself resolves later), set the
+**`x-kody-secret-resolution: off`** header on that fetch. The gateway strips the
+header and skips resolution for that request only. The delivered text remains
+one resolution step from the real secret, so use this sparingly.
 
 ## Values
 

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -70,11 +70,26 @@ specific token exchange with ordinary **`fetch`**. For service-account JSON
 secrets, pass **`private_key_json_field: "private_key"`** to sign with that
 field.
 
-Do **not** place literal placeholder tokens into user-visible or
-third-party-visible content such as issue bodies, comments, prompts, logs, or
-returned strings. If you need to describe a placeholder as text, obfuscate it
-instead of embedding the exact **`{{secret:...}}`** form into content that may
-later be sent over **`fetch`**.
+## Mentioning placeholders without resolving them
+
+Resolution runs on the **final serialized request** (URL, headers, body), so a
+literal placeholder assembled by any means — including string concatenation —
+will resolve. Do **not** place resolvable placeholder tokens into user-visible
+or third-party-visible content such as issue bodies, comments, prompts, logs, or
+returned strings.
+
+- To **mention** the syntax in prose or docs, write **`{{secret:<name>}}`**.
+  Angle brackets are outside the placeholder name charset (`[a-zA-Z0-9._-]`), so
+  this form is inert everywhere — it cannot resolve in this request or any later
+  one.
+- To deliberately send a **resolvable** literal placeholder to a third party
+  (for example, config text that Kody itself will resolve later), set the
+  **`x-kody-secret-resolution: off`** header on that **`fetch`**. The gateway
+  strips the header and skips all placeholder resolution for that one request.
+  Only the calling code can set headers, so data flowing through a URL or body
+  can never disable resolution. Use this sparingly: the delivered text is still
+  one resolution step away from the real secret if it later flows back through a
+  secret-aware **`fetch`**.
 
 ## Host approval
 

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -3,6 +3,7 @@ import { expect, test, vi } from 'vitest'
 import {
 	executeGatewayFetch,
 	expandSecretPlaceholders,
+	secretResolutionHeaderName,
 } from '#mcp/fetch-gateway.ts'
 import { parseHostApprovalRequiredBatchMessage } from '#mcp/secrets/errors.ts'
 import {
@@ -85,6 +86,70 @@ test('fetch gateway blocks or expands secret placeholders based on host approval
 		)
 	} finally {
 		allowedResolveSpy.mockRestore()
+	}
+})
+
+test('opt-out header sends placeholders literally, strips itself, and never resolves secrets', async () => {
+	const resolveSpy = vi.spyOn(secretService, 'resolveSecret')
+	const request = new Request('https://discord.com/api/channels/1/messages', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			[secretResolutionHeaderName]: 'off',
+		},
+		body: JSON.stringify({
+			content: 'Use {{secret:name}} in your fetch call.',
+		}),
+	})
+
+	try {
+		const transformed = await expandSecretPlaceholders({ request, props, env })
+		expect(transformed.headers.get(secretResolutionHeaderName)).toBeNull()
+		expect(await transformed.text()).toBe(
+			JSON.stringify({ content: 'Use {{secret:name}} in your fetch call.' }),
+		)
+		expect(transformed.url).toBe('https://discord.com/api/channels/1/messages')
+		expect(resolveSpy).not.toHaveBeenCalled()
+	} finally {
+		resolveSpy.mockRestore()
+	}
+})
+
+test('opt-out header value "on" resolves normally and is stripped; unknown values fail loudly', async () => {
+	const resolveSpy = vi
+		.spyOn(secretService, 'resolveSecret')
+		.mockResolvedValue({
+			found: true,
+			value: 'secret-value',
+			scope: 'user',
+			allowedHosts: ['example.com'],
+			allowedCapabilities: [],
+		})
+	try {
+		const onRequest = new Request('https://example.com/api', {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer {{secret:spotifyRefreshToken|scope=user}}',
+				[secretResolutionHeaderName]: 'on',
+			},
+			body: '{}',
+		})
+		const transformed = await expandSecretPlaceholders({
+			request: onRequest,
+			props,
+			env,
+		})
+		expect(transformed.headers.get('Authorization')).toBe('Bearer secret-value')
+		expect(transformed.headers.get(secretResolutionHeaderName)).toBeNull()
+
+		const invalidRequest = new Request('https://example.com/api', {
+			headers: { [secretResolutionHeaderName]: 'of' },
+		})
+		await expect(
+			expandSecretPlaceholders({ request: invalidRequest, props, env }),
+		).rejects.toThrow(`Invalid ${secretResolutionHeaderName} header value "of"`)
+	} finally {
+		resolveSpy.mockRestore()
 	}
 })
 

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -30,6 +30,19 @@ type FetchGatewayProps = {
 }
 export type { FetchGatewayProps }
 
+/**
+ * Request header that disables secret placeholder resolution for one gateway
+ * fetch: `x-kody-secret-resolution: off`. The header is stripped before the
+ * request leaves the gateway, and any `{{secret:...}}` text passes through
+ * literally. Out-of-band by design — only calling code can set a header, so
+ * attacker-controlled *data* in a URL or body can never disable resolution.
+ * Use it when a third party must receive literal placeholder text (for
+ * example, writing config that Kody itself resolves later). For merely
+ * mentioning the syntax in prose, prefer the inert `{{secret:<name>}}` form
+ * instead, which never resolves anywhere.
+ */
+export const secretResolutionHeaderName = 'x-kody-secret-resolution'
+
 export class KodyFetchGateway extends WorkerEntrypoint<Env, FetchGatewayProps> {
 	async fetch(request: Request) {
 		return executeGatewayFetch({
@@ -136,17 +149,34 @@ export async function expandSecretPlaceholders(input: {
 	env: Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'>
 }) {
 	const headers = new Headers(input.request.headers)
+	const baseUrl = input.props.baseUrl.trim()
+	if (!baseUrl) {
+		throw new Error('Fetch gateway requires a non-empty baseUrl in props.')
+	}
 	const requestBody = await readRequestBody(input.request)
+	if (readSecretResolutionMode(headers) === 'off') {
+		return new Request(
+			resolveRequestUrlForFetchGateway(input.request.url, baseUrl),
+			{
+				method: input.request.method,
+				headers,
+				body: requestBody ?? undefined,
+				redirect: input.request.redirect,
+				credentials: input.request.credentials,
+				mode: input.request.mode,
+				cache: input.request.cache,
+				integrity: input.request.integrity,
+				keepalive: input.request.keepalive,
+				signal: input.request.signal,
+			},
+		)
+	}
 	const resolvedSecrets: Array<{
 		referenced: ReferencedSecret
 		resolved: ResolvedSecret
 	}> = []
 	const replacements = new Map<string, string>()
 	const resolvedValues = new Map<string, string>()
-	const baseUrl = input.props.baseUrl.trim()
-	if (!baseUrl) {
-		throw new Error('Fetch gateway requires a non-empty baseUrl in props.')
-	}
 	const basicAuthPlaceholders = dedupeBasicAuthSecretPlaceholders([
 		...collectReferencedBasicAuthSecretPlaceholders([
 			input.request.url,
@@ -336,6 +366,23 @@ function ensureFetchAllowed(props: FetchGatewayProps) {
 	if (!props.userId) {
 		throw new Error(fetchSecretAuthRequiredMessage)
 	}
+}
+
+/**
+ * Read and strip the resolution opt-out header. Unknown values fail loudly:
+ * a typo like "of" silently resolving placeholders would defeat the point of
+ * opting out.
+ */
+function readSecretResolutionMode(headers: Headers): 'on' | 'off' {
+	const raw = headers.get(secretResolutionHeaderName)
+	if (raw == null) return 'on'
+	headers.delete(secretResolutionHeaderName)
+	const value = raw.trim().toLowerCase()
+	if (value === 'off') return 'off'
+	if (value === 'on') return 'on'
+	throw new Error(
+		`Invalid ${secretResolutionHeaderName} header value "${raw}". Use "off" to send secret placeholders literally without resolution, or omit the header for normal resolution.`,
+	)
 }
 
 function collectReferencedSecrets(values: Array<string | null | undefined>) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The fetch gateway resolves `{{secret:...}}` placeholders on the final serialized request — URL, headers, and body — with no escape mechanism. Any prose that mentions the placeholder syntax (a Discord message, an issue body, docs written via API) either fails closed ("Secret … was not found") or, worse, resolves a real secret into third-party-visible content. Discovered while shipping #674: a summary message *about* the placeholder syntax could not be sent through the gateway.

## What

- **Opt-out header**: `x-kody-secret-resolution: off` disables placeholder resolution for one gateway fetch. The gateway strips the header before the request leaves, placeholders pass through literally, and no secret is resolved. Value `on` (or omitting the header) keeps normal behavior; unknown values fail loudly so a typo cannot silently re-enable resolution. Out-of-band by design: only calling code can set a header, so attacker-controlled data in a URL or body can never disable resolution.
- **Inert mention convention**: documented `{{secret:<name>}}` as the way to *mention* placeholder syntax in prose — angle brackets are outside the placeholder name charset (`[a-zA-Z0-9._-]`), so the form can never resolve, in this request or any later one.
- Docs updated in `docs/use/secrets-and-values.md` (new "Mentioning placeholders without resolving them" section), `docs/use/execute.md`, and `docs/guides/secret-backed-integration.md`, replacing the vague "obfuscate it" guidance with both concrete options and when to use each.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `f456bebf` · **Head:** `30be6328`

**Classification:** extends — the fetch gateway's secret-resolution contract gains an explicit, header-scoped opt-out; no primitives added.

### Primitives touched

| Primitive  | Group   | Impact                                                                  |
| ---------- | ------- | ----------------------------------------------------------------------- |
| `secrets`  | storage | extends — gateway resolution gains `x-kody-secret-resolution: off` opt-out |

### System map

```mermaid
flowchart LR
	capabilitiesExecute["capabilities-execute"]:::untouched
	packageRuntime["package-runtime"]:::untouched
	secrets["secrets"]:::extended
	thirdParty["third-party API"]:::untouched
	capabilitiesExecute --> secrets
	packageRuntime --> secrets
	secrets --> thirdParty
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
before: body contains "{{secret:name}}"  → resolved (or fails: secret not found)
        no way to send the literal text through the gateway

after:  header x-kody-secret-resolution: off
        → header stripped, placeholders pass through literally, zero resolution
        prose mention → use inert {{secret:<name>}} form (never resolves)
```

### Invariants

Secret isolation is preserved: the opt-out can only *prevent* resolution, never widen it. The header cannot be injected via data (headers are code-controlled), and unknown header values throw instead of silently resolving.

</details>

<!-- system-recap:end -->

## Testing

- New unit tests in `fetch-gateway.node.test.ts`: opt-out sends placeholders literally with the header stripped and `resolveSecret` never called; `on` resolves normally and strips the header; unknown values throw.
- `npm run validate` green (format, lint, typecheck, 688 unit tests, Playwright E2E, MCP E2E).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4031-2af6-74f1-af4c-f77291054ed0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4031-2af6-74f1-af4c-f77291054ed0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to keep secret placeholders literal in selected requests using an opt-out header.
  * Improved documentation for safely mentioning placeholder syntax in prose without triggering resolution.

* **Bug Fixes**
  * Tightened handling so invalid opt-out header values now produce a clear error instead of being accepted.
  * Clarified when placeholder resolution happens, helping prevent accidental exposure in chat, logs, and issue text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->