### PR TITLE
Fix D1 SQLITE_BUSY lock contention from parallel cron lanes

### DIFF
--- a/packages/worker/src/app/retention.ts
+++ b/packages/worker/src/app/retention.ts
@@ -1,4 +1,5 @@
 import { systemEmailOwnerId } from '#worker/email/system-email.ts'
+import { runD1WithRetry } from '#worker/d1-retry.ts'
 import {
 	buildPublishedSourceManifestSnapshotKvKey,
 	buildPublishedSourceSnapshotKvKey,
@@ -249,10 +250,12 @@ async function selectIds(input: {
 	column?: string
 }): Promise<Array<IdValue>> {
 	const column = input.column ?? 'id'
-	const { results } = await input.db
-		.prepare(input.sql)
-		.bind(...input.bindings)
-		.all<Record<string, unknown>>()
+	const { results } = await runD1WithRetry(() =>
+		input.db
+			.prepare(input.sql)
+			.bind(...input.bindings)
+			.all<Record<string, unknown>>(),
+	)
 	return (results ?? []).map((row) => row[column] as IdValue)
 }
 
@@ -293,13 +296,15 @@ async function deleteByIds(input: {
 		index += retentionDeleteIdsMaxParameters
 	) {
 		const ids = input.ids.slice(index, index + retentionDeleteIdsMaxParameters)
-		const result = await input.db
-			.prepare(
-				`DELETE FROM ${input.table}
+		const result = await runD1WithRetry(() =>
+			input.db
+				.prepare(
+					`DELETE FROM ${input.table}
 				WHERE ${input.idColumn} IN (${placeholders(ids)})`,
-			)
-			.bind(...ids)
-			.run()
+				)
+				.bind(...ids)
+				.run(),
+		)
 		deleted += result.meta.changes ?? 0
 	}
 	return deleted
@@ -311,9 +316,10 @@ async function deletePublishedBundleArtifactRowIfStillStale(input: {
 	kvKey: string
 	cutoff: string
 }) {
-	const result = await input.db
-		.prepare(
-			`DELETE FROM published_bundle_artifacts
+	const result = await runD1WithRetry(() =>
+		input.db
+			.prepare(
+				`DELETE FROM published_bundle_artifacts
 			WHERE id = ?
 				AND kv_key = ?
 				AND created_at < ?
@@ -331,9 +337,10 @@ async function deletePublishedBundleArtifactRowIfStillStale(input: {
 						AND session.source_id = published_bundle_artifacts.source_id
 						AND session.status = 'active'
 				)`,
-		)
-		.bind(input.id, input.kvKey, input.cutoff)
-		.run()
+			)
+			.bind(input.id, input.kvKey, input.cutoff)
+			.run(),
+	)
 	return result.meta.changes ?? 0
 }
 
@@ -401,17 +408,19 @@ export async function prunePackageRuntimeRetention(input: {
 	let capPairCount = 0
 	let capDeletedCandidates = 0
 	if (runIds.size < batchSize) {
-		const { results: pairs } = await input.db
-			.prepare(
-				`SELECT user_id, package_id, COUNT(*) AS run_count
+		const { results: pairs } = await runD1WithRetry(() =>
+			input.db
+				.prepare(
+					`SELECT user_id, package_id, COUNT(*) AS run_count
 				FROM package_runtime_runs
 				GROUP BY user_id, package_id
 				HAVING COUNT(*) > ?
 				ORDER BY run_count DESC
 				LIMIT ?`,
-			)
-			.bind(packageRuntimeMaxRunsPerPackage, maxCapPairs)
-			.all<{ user_id: string; package_id: string; run_count: number }>()
+				)
+				.bind(packageRuntimeMaxRunsPerPackage, maxCapPairs)
+				.all<{ user_id: string; package_id: string; run_count: number }>(),
+		)
 		capPairCount = (pairs ?? []).length
 		for (const pair of pairs ?? []) {
 			if (runIds.size >= batchSize) break
@@ -566,8 +575,9 @@ export async function prunePublishedBundleArtifactsForRetention(input: {
 		publishedBundleArtifactRetentionDays,
 	)
 	const batchSize = input.batchSize ?? publishedBundleArtifactRetentionBatchSize
-	const { results } = await input.env.APP_DB.prepare(
-		`SELECT artifact.id, artifact.kv_key, artifact.source_id, artifact.published_commit
+	const { results } = await runD1WithRetry(() =>
+		input.env.APP_DB.prepare(
+			`SELECT artifact.id, artifact.kv_key, artifact.source_id, artifact.published_commit
 		FROM published_bundle_artifacts AS artifact
 		WHERE artifact.created_at < ?
 			AND NOT EXISTS (
@@ -586,14 +596,15 @@ export async function prunePublishedBundleArtifactsForRetention(input: {
 			)
 		ORDER BY artifact.created_at ASC, artifact.id ASC
 		LIMIT ?`,
+		)
+			.bind(cutoff, batchSize)
+			.all<{
+				id: string
+				kv_key: string
+				source_id: string
+				published_commit: string
+			}>(),
 	)
-		.bind(cutoff, batchSize)
-		.all<{
-			id: string
-			kv_key: string
-			source_id: string
-			published_commit: string
-		}>()
 	const rows = results ?? []
 	let deletedRows = 0
 	let deletedKvKeys = 0
@@ -724,23 +735,25 @@ export async function pruneUserEmailMessagesForRetention(input: {
 	const cursorBindings = cursor
 		? [cursor.createdAt, cursor.createdAt, cursor.id]
 		: []
-	const { results } = await input.db
-		.prepare(
-			`SELECT id, user_id, raw_mime_key, created_at
+	const { results } = await runD1WithRetry(() =>
+		input.db
+			.prepare(
+				`SELECT id, user_id, raw_mime_key, created_at
 			FROM email_messages
 			WHERE user_id != ?
 				AND created_at < ?
 				${cursorClause}
 			ORDER BY created_at ASC, id ASC
 			LIMIT ?`,
-		)
-		.bind(systemEmailOwnerId, cutoff, ...cursorBindings, batchSize)
-		.all<{
-			id: string
-			user_id: string
-			raw_mime_key: string | null
-			created_at: string
-		}>()
+			)
+			.bind(systemEmailOwnerId, cutoff, ...cursorBindings, batchSize)
+			.all<{
+				id: string
+				user_id: string
+				raw_mime_key: string | null
+				created_at: string
+			}>(),
+	)
 	const rows = results ?? []
 	const result: EmailMessageRetentionResult = {
 		deletedMessages: 0,
@@ -793,18 +806,20 @@ export async function pruneUserEmailMessagesForRetention(input: {
 			index,
 			index + retentionDeleteIdsMaxParameters,
 		)
-		const threadDelete = await input.db
-			.prepare(
-				`DELETE FROM email_threads
+		const threadDelete = await runD1WithRetry(() =>
+			input.db
+				.prepare(
+					`DELETE FROM email_threads
 				WHERE user_id IN (${placeholders(userIds)})
 					AND NOT EXISTS (
 						SELECT 1
 						FROM email_messages
 						WHERE email_messages.thread_id = email_threads.id
 					)`,
-			)
-			.bind(...userIds)
-			.run()
+				)
+				.bind(...userIds)
+				.run(),
+		)
 		result.deletedThreads += threadDelete.meta.changes ?? 0
 	}
 	// hasMore is based on the selected count: a full batch means more eligible

--- a/packages/worker/src/d1-retry.node.test.ts
+++ b/packages/worker/src/d1-retry.node.test.ts
@@ -1,0 +1,50 @@
+import { expect, test, vi } from 'vitest'
+import {
+	d1LockRetryBaseDelayMs,
+	isRetryableD1LockError,
+	runD1WithRetry,
+} from './d1-retry.ts'
+
+test('isRetryableD1LockError matches SQLITE_BUSY and database is locked', () => {
+	expect(
+		isRetryableD1LockError(
+			new Error('D1_ERROR: NOSENTRY database is locked: SQLITE_BUSY'),
+		),
+	).toBe(true)
+	expect(isRetryableD1LockError(new Error('database is locked'))).toBe(true)
+	expect(isRetryableD1LockError(new Error('syntax error near SELECT'))).toBe(
+		false,
+	)
+})
+
+test('runD1WithRetry succeeds on the first attempt', async () => {
+	const operation = vi.fn(async () => 'ok')
+	await expect(runD1WithRetry(operation)).resolves.toBe('ok')
+	expect(operation).toHaveBeenCalledTimes(1)
+})
+
+test('runD1WithRetry retries lock contention and eventually succeeds', async () => {
+	vi.useFakeTimers()
+	const operation = vi
+		.fn()
+		.mockRejectedValueOnce(
+			new Error('D1_ERROR: NOSENTRY database is locked: SQLITE_BUSY'),
+		)
+		.mockResolvedValueOnce('ok')
+	try {
+		const resultPromise = runD1WithRetry(operation)
+		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
+		await expect(resultPromise).resolves.toBe('ok')
+		expect(operation).toHaveBeenCalledTimes(2)
+	} finally {
+		vi.useRealTimers()
+	}
+})
+
+test('runD1WithRetry rethrows non-lock errors immediately', async () => {
+	const operation = vi
+		.fn()
+		.mockRejectedValue(new Error('D1_ERROR: syntax error near INSERTZ'))
+	await expect(runD1WithRetry(operation)).rejects.toThrow('syntax error')
+	expect(operation).toHaveBeenCalledTimes(1)
+})

--- a/packages/worker/src/d1-retry.ts
+++ b/packages/worker/src/d1-retry.ts
@@ -12,8 +12,7 @@ export function isRetryableD1LockError(error: unknown) {
 	return errorCauseChainIncludes(
 		error,
 		(message) =>
-			message.includes('SQLITE_BUSY') ||
-			message.includes('database is locked'),
+			message.includes('SQLITE_BUSY') || message.includes('database is locked'),
 	)
 }
 

--- a/packages/worker/src/d1-retry.ts
+++ b/packages/worker/src/d1-retry.ts
@@ -1,0 +1,48 @@
+import { errorCauseChainIncludes } from '@kody-internal/shared/error-message.ts'
+
+export const d1LockRetryMaxAttempts = 6
+
+export const d1LockRetryBaseDelayMs = 150
+
+function sleep(ms: number) {
+	return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+export function isRetryableD1LockError(error: unknown) {
+	return errorCauseChainIncludes(
+		error,
+		(message) =>
+			message.includes('SQLITE_BUSY') ||
+			message.includes('database is locked'),
+	)
+}
+
+/**
+ * Retries transient D1 lock contention (SQLITE_BUSY). D1 does not
+ * automatically retry write queries, so cron lanes and long-running
+ * retention batches need application-level backoff when they overlap
+ * with concurrent writers.
+ */
+export async function runD1WithRetry<T>(
+	operation: () => Promise<T>,
+	options?: {
+		maxAttempts?: number
+		baseDelayMs?: number
+	},
+): Promise<T> {
+	const maxAttempts = options?.maxAttempts ?? d1LockRetryMaxAttempts
+	const baseDelayMs = options?.baseDelayMs ?? d1LockRetryBaseDelayMs
+	let lastError: unknown
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			return await operation()
+		} catch (error) {
+			lastError = error
+			if (!isRetryableD1LockError(error) || attempt === maxAttempts) {
+				throw error
+			}
+			await sleep(baseDelayMs * 2 ** (attempt - 1))
+		}
+	}
+	throw lastError
+}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -505,15 +505,16 @@ const workerHandler = {
 		// Lane failures are isolated: each rejection is logged and reported to
 		// Sentry explicitly (the withSentry wrapper flushes captured events via
 		// waitUntil), but the handler never throws, so one broken lane cannot
-		// fail the cron invocation or hide sibling lane failures.
-		const results = await Promise.allSettled(lanes.map((lane) => lane.run()))
-		for (const [index, result] of results.entries()) {
-			if (result.status !== 'rejected') continue
-			console.error(
-				`scheduled_lane_failed lane=${lanes[index]?.name ?? 'unknown'}`,
-				result.reason,
-			)
-			Sentry.captureException(result.reason)
+		// fail the cron invocation or hide sibling lane failures. Lanes run
+		// sequentially so D1 write-heavy crons (retention, reconcile, usage
+		// aggregation) do not contend for the same SQLite lock.
+		for (const lane of lanes) {
+			try {
+				await lane.run()
+			} catch (error) {
+				console.error(`scheduled_lane_failed lane=${lane.name}`, error)
+				Sentry.captureException(error)
+			}
 		}
 	},
 } satisfies ExportedHandler<Env>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production Sentry alert `KODY-CLOUDFLARE-M` reports:

```
D1_ERROR: NOSENTRY database is locked: SQLITE_BUSY
```

Scale hardening (#669) made scheduled cron lanes run in parallel via `Promise.allSettled`. Several lanes are D1 write-heavy and long-running:

- **retention** — round-robin deletes under a 20s time budget
- **reconcile_artifacts_pushes** — loops batches under a 60s budget
- **usage_aggregation** — upserts/deletes `usage_rollups`
- **system_email_retention** — batched deletes

When these overlap, they contend for the same D1 SQLite lock. D1 does not automatically retry write queries on `SQLITE_BUSY`, so the failure surfaces as a `scheduled_lane_failed` Sentry event.

## Fix

1. **Serialize scheduled cron lanes** so D1 write-heavy crons no longer run concurrently against `APP_DB`.
2. **Add `runD1WithRetry`** — application-level exponential backoff for transient `SQLITE_BUSY` / `database is locked` errors (mirrors the existing E2E `d1-utils.ts` pattern).
3. **Wrap retention D1 reads/writes** with the retry helper as defense in depth when retention overlaps with live request traffic.

Lane failure isolation is unchanged: each lane still logs and reports to Sentry independently without aborting siblings.

## Testing

- Added `d1-retry.node.test.ts` covering lock detection and retry behavior
- Existing `index.workers.test.ts` and `retention.node.test.ts` pass
- `npm run typecheck` passes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `8367cecd` · **Head:** `2bd548e9`

**Classification:** extends — scheduled cron execution and D1 retention write paths gain lock-contention handling.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `scheduled-cron` | runtime | extends — lanes now run sequentially to avoid D1 lock contention |
| `d1-app-db` | storage | extends — retention writes retry transient `SQLITE_BUSY` |

### System map

```mermaid
flowchart LR
	scheduledCron["scheduled-cron"]:::extended
	d1AppDb["d1-app-db"]:::extended
	scheduledCron --> d1AppDb
	classDef extended fill:#9a6700,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Cron as scheduled handler
	participant Lane as cron lane
	participant D1 as APP_DB
	Cron->>Lane: run lane 1 (sequential)
	Lane->>D1: writes with runD1WithRetry
	Cron->>Lane: run lane 2
	Lane->>D1: writes
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-326009cb-5c03-456d-a1a5-9cab435268a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-326009cb-5c03-456d-a1a5-9cab435268a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

