### PR TITLE
Enforce storage bytes entitlement

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -132,11 +132,19 @@ Rules:
   against the limit instead of an accumulating count: the enforcement point
   passes the candidate size via `getCurrent` with `requested: 0`. There is no
   built-in counter for these.
-- `maxStorageBytes` is defined in the limits config but **still not enforced**;
-  it has no built-in counter and requires `getCurrent` when it gains an
-  enforcement point. The per-message `email_message_bytes` cap bounds each
-  stored email's size but is deliberately **not** full storage-bytes accounting
-  — that remains a separate effort.
+- **Storage-byte limits** (`storage_bytes`) use a built-in D1 byte estimate for
+  user-owned rows with durable payloads (`email_messages.raw_size` plus
+  extracted message bodies/metadata, externally stored attachments, values,
+  encrypted secrets, memories, saved-package projections, jobs, repo/session
+  metadata, package invocation results, package runtime debug rows, and
+  published artifact metadata). StorageRunner Durable Object buckets expose
+  their own `estimatedBytes`; write chokepoints that target a specific bucket
+  pass `getCurrent` as `D1 estimate + target bucket estimate` and `requested` as
+  the candidate payload size when known. The counter intentionally does **not**
+  attempt to scan Cloudflare Artifacts repository contents, KV snapshot/bundle
+  bodies, R2 object listings beyond `email_messages.raw_size`, or Vectorize:
+  those stores either lack reliable byte metadata or are derived from D1 and are
+  documented in `data-storage.md`.
 
 Because the plan check happens before any counting, enforcement adds zero
 counting overhead for NULL-plan users.
@@ -198,20 +206,20 @@ The exemplar is job scheduling: `createJob` in
 
 ## Enforcement points
 
-| Resource                      | Enforcement point                                                                  |
-| ----------------------------- | ---------------------------------------------------------------------------------- |
-| `scheduled_jobs`              | `createJob` in `packages/worker/src/jobs/service.ts` (exemplar)                    |
-| `saved_packages`              | new-package branch of `package_save` and projection insert                         |
-| `package_services`            | `service_start` capability path                                                    |
-| `persistent_package_services` | `service_start` for services declared `mode: 'persistent'`                         |
-| `repo_sessions`               | `repo_open_session` before creating a new session                                  |
-| `email_sends_per_day`         | `sendOutboundEmail` (atomic `consumeDailyEntitlement`, NULL-plan backstop)         |
-| `email_receives_per_day`      | `handleInboundEmail` (atomic `consumeDailyEntitlement`, NULL-plan fallback)        |
-| `stored_email_messages`       | `handleInboundEmail` before storage (NULL-plan fallback)                           |
-| `email_message_bytes`         | `handleInboundEmail` before quota/parse (per-message raw size, NULL-plan fallback) |
-| `secrets`                     | new-entry branch of `saveSecret` in `packages/worker/src/mcp/secrets/service.ts`   |
-| `concurrent_workflows`        | `createDynamicCallableWorkflow` (plan limit, env-var backstop for NULL plan)       |
-| `storage_bytes`               | not yet enforced                                                                   |
+| Resource                      | Enforcement point                                                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `scheduled_jobs`              | `createJob` in `packages/worker/src/jobs/service.ts` (exemplar)                                                                |
+| `saved_packages`              | new-package branch of `package_save` and projection insert                                                                     |
+| `package_services`            | `service_start` capability path                                                                                                |
+| `persistent_package_services` | `service_start` for services declared `mode: 'persistent'`                                                                     |
+| `repo_sessions`               | `repo_open_session` before creating a new session                                                                              |
+| `email_sends_per_day`         | `sendOutboundEmail` (atomic `consumeDailyEntitlement`, NULL-plan backstop)                                                     |
+| `email_receives_per_day`      | `handleInboundEmail` (atomic `consumeDailyEntitlement`, NULL-plan fallback)                                                    |
+| `stored_email_messages`       | `handleInboundEmail` before storage (NULL-plan fallback)                                                                       |
+| `email_message_bytes`         | `handleInboundEmail` before quota/parse (per-message raw size, NULL-plan fallback)                                             |
+| `secrets`                     | new-entry branch of `saveSecret` in `packages/worker/src/mcp/secrets/service.ts`                                               |
+| `concurrent_workflows`        | `createDynamicCallableWorkflow` (plan limit, env-var backstop for NULL plan)                                                   |
+| `storage_bytes`               | D1 payload writes (values, secrets, memories, saved-package projections, email storage) and StorageRunner write tools/app RPCs |
 
 ## Related tables and coordination
 

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -221,6 +221,7 @@ async function handleValueSetAction(input: {
 	const saved = await saveValue({
 		env: input.env,
 		userId: input.user.mcpUser.userId,
+		userEmail: input.user.mcpUser.email,
 		name,
 		value,
 		scope: 'user',
@@ -348,6 +349,7 @@ async function handleConnectOauthAction(input: {
 	const integrationName = await saveIntegrationConfig({
 		env: input.env,
 		userId: input.user.mcpUser.userId,
+		userEmail: input.user.mcpUser.email,
 		provider,
 		tokenUrl,
 		apiBaseUrl,
@@ -545,6 +547,7 @@ async function handleOAuthExchangeAction(input: {
 async function saveIntegrationConfig(input: {
 	env: Env
 	userId: string
+	userEmail: string
 	provider: string
 	tokenUrl: string
 	apiBaseUrl: string | null
@@ -590,6 +593,7 @@ async function saveIntegrationConfig(input: {
 	await saveValue({
 		env: input.env,
 		userId: input.userId,
+		userEmail: input.userEmail,
 		name: buildIntegrationValueName(integration.name),
 		value: JSON.stringify(integration),
 		scope: 'user',

--- a/packages/worker/src/email/inbound-entitlements.workers.test.ts
+++ b/packages/worker/src/email/inbound-entitlements.workers.test.ts
@@ -97,6 +97,18 @@ async function bulkInsertStoredMessages(userId: string, count: number) {
 		.run()
 }
 
+async function insertStoredMessageBytes(userId: string, rawSize: number) {
+	const now = new Date().toISOString()
+	await env.APP_DB.prepare(
+		`INSERT INTO email_messages (
+			id, direction, user_id, from_address, subject, raw_size,
+			processing_status, created_at, updated_at
+		) VALUES (?, 'inbound', ?, 'bulk@example.com', 'Bulk', ?, 'stored', ?, ?)`,
+	)
+		.bind(`storage-bytes-${crypto.randomUUID()}`, userId, rawSize, now, now)
+		.run()
+}
+
 async function readRejectionEvents(userId: string) {
 	const { results } = await env.APP_DB.prepare(
 		`SELECT id, detail_json FROM email_delivery_events
@@ -189,6 +201,30 @@ test('inbound email enforces personal-plan receive, storage, and size limits the
 	expect(await readDailyReceiveCounter(storageCapUserId)).toBe(1)
 	expect(
 		(await readRejectionEvents(storageCapUserId)).detailed[0]?.detail,
+	).toMatchObject({
+		phase: 'entitlement',
+	})
+
+	const storageBytesEmail = `storage-bytes-${crypto.randomUUID()}@example.com`
+	const storageBytesUserId =
+		await createStableUserIdFromEmail(storageBytesEmail)
+	const storageBytesLimit = planLimits.personal.maxStorageBytes
+	if (storageBytesLimit === null)
+		throw new Error('Expected a numeric personal storage byte cap.')
+	const { address: storageBytesAddress } = await seedAccountWithPlan({
+		email: storageBytesEmail,
+		plan: 'personal',
+	})
+	await insertStoredMessageBytes(storageBytesUserId, storageBytesLimit)
+
+	const storageBytesMessage = buildInboundMessage(storageBytesAddress)
+	await handleInboundEmail(storageBytesMessage, createInboundEnv())
+	expect(storageBytesMessage.rejectedReason).toBe(
+		'Recipient mailbox is over quota.',
+	)
+	expect(await readDailyReceiveCounter(storageBytesUserId)).toBe(0)
+	expect(
+		(await readRejectionEvents(storageBytesUserId)).detailed[0]?.detail,
 	).toMatchObject({
 		phase: 'entitlement',
 	})

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -8,6 +8,7 @@ import {
 } from '#worker/entitlements/plans.ts'
 import {
 	assertWithinEntitlement,
+	assertWithinStorageBytesEntitlement,
 	consumeDailyEntitlement,
 } from '#worker/entitlements/service.ts'
 import { recordUsage } from '#worker/usage/record-usage.ts'
@@ -319,6 +320,12 @@ export async function handleInboundEmail(
 			requested: 0,
 			getCurrent: async () => message.rawSize,
 			fallbackLimit: nullPlanEmailFallbackLimits.email_message_bytes,
+		})
+		await assertWithinStorageBytesEntitlement({
+			db: env.APP_DB,
+			userId,
+			email: account.email,
+			requested: message.rawSize,
 		})
 		await consumeDailyEntitlement({
 			db: env.APP_DB,

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -10,6 +10,7 @@ import {
 	assertWithinEntitlement,
 	assertWithinStorageBytesEntitlement,
 	consumeDailyEntitlement,
+	estimateEntitlementStorageEntryBytes,
 } from '#worker/entitlements/service.ts'
 import { recordUsage } from '#worker/usage/record-usage.ts'
 import {
@@ -56,6 +57,23 @@ type ParsedInboundEmail = Awaited<
  */
 function warnRejectionAuditWriteFailed(error: unknown) {
 	console.warn('email-rejection-audit-write-failed', error)
+}
+
+function estimateInboundEmailStorageBytes(input: {
+	message: ForwardableEmailMessage
+	recipient: string
+}) {
+	return (
+		input.message.rawSize * 2 +
+		estimateEntitlementStorageEntryBytes({
+			value: {
+				from: input.message.from,
+				to: input.message.to,
+				recipient: input.recipient,
+				headers: Object.fromEntries(input.message.headers.entries()),
+			},
+		})
+	)
 }
 
 async function parseAndStoreInboundEmail(input: {
@@ -278,8 +296,8 @@ export async function handleInboundEmail(
 	// Inbound volume is attacker-controlled (anyone can send to a
 	// {username}@<platform domain> address), so every fail-closed gate runs
 	// before any parsing work, cheapest rejection first: verified account,
-	// per-message size cap, per-day receive rate, and stored-message cap
-	// (entitlements with NULL-plan fallbacks).
+	// per-message size cap, storage bytes, per-day receive rate, and
+	// stored-message cap (entitlements with NULL-plan fallbacks).
 
 	// Verified-account gate first: an unverified account can never receive
 	// mail, so the attempt must not consume any of the daily receive quota
@@ -325,7 +343,7 @@ export async function handleInboundEmail(
 			db: env.APP_DB,
 			userId,
 			email: account.email,
-			requested: message.rawSize,
+			requested: estimateInboundEmailStorageBytes({ message, recipient }),
 		})
 		await consumeDailyEntitlement({
 			db: env.APP_DB,

--- a/packages/worker/src/email/outbound.ts
+++ b/packages/worker/src/email/outbound.ts
@@ -3,7 +3,11 @@ import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
 import { isAccountEmailVerified } from '#app/email-verification.ts'
 import { normalizeEmail } from '#app/normalize-email.ts'
 import { nullPlanEmailFallbackLimits } from '#worker/entitlements/plans.ts'
-import { consumeDailyEntitlement } from '#worker/entitlements/service.ts'
+import {
+	assertWithinStorageBytesEntitlement,
+	consumeDailyEntitlement,
+	estimateEntitlementStorageEntryBytes,
+} from '#worker/entitlements/service.ts'
 import { recordUsage } from '#worker/usage/record-usage.ts'
 import { normalizeEmailAddress } from './address.ts'
 import { resolveUserPlatformSender } from './platform-address.ts'
@@ -301,6 +305,29 @@ export async function sendOutboundEmail(
 	const text = input.text?.trim() || null
 	const html = input.html?.trim() || null
 	if (!text && !html) throw new Error('Email text or HTML body is required.')
+	const messageIdHeader = `<${crypto.randomUUID()}@kody.local>`
+	const storedHeaders = buildStoredHeaders({
+		messageId: messageIdHeader,
+		inReplyTo: input.inReplyToHeader ?? null,
+		references: input.references ?? [],
+	})
+	await assertWithinStorageBytesEntitlement({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		email: sender.accountEmail,
+		requested: estimateEntitlementStorageEntryBytes({
+			key: messageIdHeader,
+			value: {
+				from,
+				to,
+				subject,
+				replyTo: input.replyTo,
+				text,
+				html,
+				headers: storedHeaders,
+			},
+		}),
+	})
 
 	// Atomic check-and-increment: the counter tracks attempts for every user
 	// and denies the send when a plan's daily limit is reached. Users
@@ -326,12 +353,6 @@ export async function sendOutboundEmail(
 				lastMessageAt: new Date().toISOString(),
 			})
 	const threadId = existingThreadId ?? thread?.id ?? null
-	const messageIdHeader = `<${crypto.randomUUID()}@kody.local>`
-	const storedHeaders = buildStoredHeaders({
-		messageId: messageIdHeader,
-		inReplyTo: input.inReplyToHeader ?? null,
-		references: input.references ?? [],
-	})
 	const providerHeaders = buildProviderHeaders(storedHeaders)
 	const message = await insertEmailMessage({
 		db: input.env.APP_DB,

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -13,6 +13,8 @@ import {
 	assertWithinEntitlement,
 	assertWithinStorageBytesEntitlement,
 	consumeDailyEntitlement,
+	estimateEntitlementStorageEntryByteDelta,
+	estimateEntitlementStorageEntryBytes,
 	getUserPlan,
 	incrementDailyEntitlementCounter,
 } from './service.ts'
@@ -147,6 +149,50 @@ function createEntitlementsTestDb(
 }
 
 const plannedEmail = 'planned@example.com'
+
+test('storage byte entry estimates support net-positive upsert deltas', () => {
+	const existing = {
+		key: 'workspace',
+		value: {
+			description: 'Workspace slug',
+			value: 'kent-main-site',
+		},
+	}
+	expect(
+		estimateEntitlementStorageEntryByteDelta({
+			next: existing,
+			existing,
+		}),
+	).toBe(0)
+	expect(
+		estimateEntitlementStorageEntryByteDelta({
+			next: {
+				key: 'workspace',
+				value: {
+					description: 'Workspace slug',
+					value: 'kent',
+				},
+			},
+			existing,
+		}),
+	).toBe(0)
+	const growing = {
+		key: 'workspace',
+		value: {
+			description: 'Workspace slug',
+			value: 'kent-main-site-production',
+		},
+	}
+	expect(
+		estimateEntitlementStorageEntryByteDelta({
+			next: growing,
+			existing,
+		}),
+	).toBe(
+		estimateEntitlementStorageEntryBytes(growing) -
+			estimateEntitlementStorageEntryBytes(existing),
+	)
+})
 
 test('getUserPlan resolves plans through hashed email and short-circuits invalid lookups', async () => {
 	const userId = await createStableUserIdFromEmail(plannedEmail)

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -11,6 +11,7 @@ import {
 } from './plans.ts'
 import {
 	assertWithinEntitlement,
+	assertWithinStorageBytesEntitlement,
 	consumeDailyEntitlement,
 	getUserPlan,
 	incrementDailyEntitlementCounter,
@@ -33,7 +34,16 @@ function createEntitlementsTestDb(
 				| 'jobs'
 				| 'repo_sessions'
 				| 'package_runtime_runs'
+				| 'package_runtime_logs'
+				| 'package_invocations'
+				| 'published_bundle_artifacts'
 				| 'secret_entries'
+				| 'value_entries'
+				| 'mcp_memories'
+				| 'saved_packages'
+				| 'entity_sources'
+				| 'email_messages'
+				| 'email_attachments'
 				| 'workflow_runs',
 				number
 			>
@@ -48,11 +58,19 @@ function createEntitlementsTestDb(
 
 	function countFor(query: string) {
 		const tableNames = [
+			'email_attachments',
+			'email_messages',
+			'value_entries',
+			'secret_entries',
+			'mcp_memories',
 			'saved_packages',
+			'entity_sources',
 			'jobs',
 			'repo_sessions',
+			'package_invocations',
 			'package_runtime_runs',
-			'secret_entries',
+			'package_runtime_logs',
+			'published_bundle_artifacts',
 			'workflow_runs',
 		] as const
 		for (const table of tableNames) {
@@ -460,14 +478,6 @@ test('requested units and getCurrent overrides are honored', async () => {
 			resource: 'email_message_bytes',
 		}),
 	).rejects.toThrow('pass getCurrent')
-	await expect(
-		assertWithinEntitlement({
-			db,
-			userId,
-			email: plannedEmail,
-			resource: 'storage_bytes',
-		}),
-	).rejects.toThrow('pass getCurrent')
 
 	const overSavedPackages = await assertWithinEntitlement({
 		db,
@@ -495,5 +505,60 @@ test('requested units and getCurrent overrides are honored', async () => {
 		resource: 'saved_packages',
 		requested: 3,
 		getCurrent: async () => 17,
+	})
+})
+
+test('storage bytes enforce for planned users and skip NULL-plan users', async () => {
+	const userId = await createStableUserIdFromEmail(plannedEmail)
+	const limit = planLimits.personal.maxStorageBytes
+	if (limit === null)
+		throw new Error('Expected a numeric personal storage cap.')
+
+	const noPlan = createEntitlementsTestDb({
+		users: [{ email: plannedEmail, plan: null }],
+		counts: { email_messages: limit + 1 },
+	})
+	await assertWithinStorageBytesEntitlement({
+		db: noPlan.db,
+		userId,
+		email: plannedEmail,
+		requested: 1,
+	})
+	expect(noPlan.queries).toHaveLength(1)
+	expect(noPlan.queries[0]).toContain('SELECT plan FROM users')
+
+	const atLimit = createEntitlementsTestDb({
+		users: [{ email: plannedEmail, plan: 'personal' }],
+		counts: { email_messages: limit },
+	})
+	const denied = await assertWithinStorageBytesEntitlement({
+		db: atLimit.db,
+		userId,
+		email: plannedEmail,
+		requested: 1,
+	}).then(
+		() => null,
+		(thrown: unknown) => thrown,
+	)
+	if (!(denied instanceof EntitlementLimitError)) {
+		throw new Error('Expected an EntitlementLimitError.')
+	}
+	expect(denied.details).toMatchObject({
+		code: 'entitlement_limit_exceeded',
+		resource: 'storage_bytes',
+		plan: 'personal',
+		limit,
+		current: limit,
+	})
+
+	const underLimit = createEntitlementsTestDb({
+		users: [{ email: plannedEmail, plan: 'personal' }],
+		counts: { email_messages: limit - 1 },
+	})
+	await assertWithinStorageBytesEntitlement({
+		db: underLimit.db,
+		userId,
+		email: plannedEmail,
+		requested: 1,
 	})
 })

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -217,6 +217,302 @@ async function countRows(db: D1Database, sql: string, params: Array<unknown>) {
 	return Number(row?.count ?? 0)
 }
 
+const entitlementByteEncoder = new TextEncoder()
+
+function utf8ByteLength(value: string) {
+	return entitlementByteEncoder.encode(value).byteLength
+}
+
+function serializeByteEstimateValue(value: unknown): string {
+	if (typeof value === 'string') return value
+	if (value === undefined) return 'undefined'
+	try {
+		return JSON.stringify(value) ?? 'null'
+	} catch {
+		return String(value)
+	}
+}
+
+export function estimateEntitlementStorageBytes(value: unknown): number {
+	return utf8ByteLength(serializeByteEstimateValue(value))
+}
+
+export function estimateEntitlementStorageEntryBytes(input: {
+	key?: string | null
+	value: unknown
+}) {
+	return (
+		(input.key ? estimateEntitlementStorageBytes(input.key) : 0) +
+		estimateEntitlementStorageBytes(input.value)
+	)
+}
+
+function textBytesExpression(columns: ReadonlyArray<string>) {
+	return columns
+		.map((column) => `length(CAST(COALESCE(${column}, '') AS BLOB))`)
+		.join(' + ')
+}
+
+function isMissingStorageByteSurfaceError(error: unknown) {
+	return (
+		error instanceof Error && /\bno such (table|column)\b/i.test(error.message)
+	)
+}
+
+async function sumStorageBytes(
+	db: D1Database,
+	sql: string,
+	params: Array<unknown>,
+) {
+	const row = await db
+		.prepare(sql)
+		.bind(...params)
+		.first<{ count: number }>()
+		.catch((error: unknown) => {
+			if (isMissingStorageByteSurfaceError(error)) return null
+			throw error
+		})
+	return Number(row?.count ?? 0)
+}
+
+export async function readUserD1StorageBytes(input: {
+	db: D1Database
+	userId: string
+}) {
+	const { db, userId } = input
+	const sums = await Promise.all([
+		sumStorageBytes(
+			db,
+			`SELECT COALESCE(SUM(
+				COALESCE(raw_size, 0)
+				+ ${textBytesExpression([
+					'from_address',
+					'envelope_from',
+					'to_addresses_json',
+					'cc_addresses_json',
+					'bcc_addresses_json',
+					'reply_to_addresses_json',
+					'subject',
+					'message_id_header',
+					'in_reply_to_header',
+					'references_json',
+					'headers_json',
+					'auth_results',
+					'text_body',
+					'html_body',
+					'provider_message_id',
+					'error',
+				])}
+			), 0) AS count
+			FROM email_messages
+			WHERE user_id = ?`,
+			[userId],
+		),
+		sumStorageBytes(
+			db,
+			`SELECT COALESCE(SUM(size), 0) AS count
+			FROM email_attachments ea
+			JOIN email_messages em ON em.id = ea.message_id
+			WHERE em.user_id = ? AND ea.storage_kind = 'external'`,
+			[userId],
+		),
+		sumStorageBytes(
+			db,
+			`SELECT COALESCE(SUM(
+				${textBytesExpression(['ve.name', 've.description', 've.value'])}
+			), 0) AS count
+			FROM value_entries ve
+			JOIN value_buckets vb ON vb.id = ve.bucket_id
+			WHERE vb.user_id = ?`,
+			[userId],
+		),
+		sumStorageBytes(
+			db,
+			`SELECT COALESCE(SUM(
+				${textBytesExpression([
+					'se.name',
+					'se.description',
+					'se.encrypted_value',
+					'se.allowed_hosts',
+					'se.allowed_capabilities',
+					'se.allowed_packages',
+				])}
+			), 0) AS count
+			FROM secret_entries se
+			JOIN secret_buckets sb ON sb.id = se.bucket_id
+			WHERE sb.user_id = ?`,
+			[userId],
+		),
+		sumStorageBytes(
+			db,
+			`SELECT COALESCE(SUM(
+				${textBytesExpression([
+					'category',
+					'subject',
+					'summary',
+					'details',
+					'tags_json',
+					'source_uris_json',
+					'dedupe_key',
+				])}
+			), 0) AS count
+			FROM mcp_memories
+			WHERE user_id = ?`,
+			[userId],
+		),
+		sumStorageBytes(
+			db,
+			`SELECT COALESCE(SUM(
+				${textBytesExpression([
+					'name',
+					'kody_id',
+					'description',
+					'tags_json',
+					'search_text',
+					'source_id',
+				])}
+			), 0) AS count
+			FROM saved_packages
+			WHERE user_id = ?`,
+			[userId],
+		),
+		sumStorageBytes(
+			db,
+			`SELECT COALESCE(SUM(
+				${textBytesExpression([
+					'name',
+					'params_json',
+					'schedule_json',
+					'timezone',
+					'caller_context_json',
+					'last_run_status',
+					'last_run_error',
+					'run_history_json',
+					'source_id',
+					'published_commit',
+					'storage_id',
+				])}
+			), 0) AS count
+			FROM jobs
+			WHERE user_id = ?`,
+			[userId],
+		),
+		sumStorageBytes(
+			db,
+			`SELECT COALESCE(SUM(
+				${textBytesExpression([
+					'entity_kind',
+					'entity_id',
+					'repo_id',
+					'published_commit',
+					'indexed_commit',
+					'manifest_path',
+					'source_root',
+				])}
+			), 0) AS count
+			FROM entity_sources
+			WHERE user_id = ?`,
+			[userId],
+		),
+		sumStorageBytes(
+			db,
+			`SELECT COALESCE(SUM(
+				${textBytesExpression([
+					'source_id',
+					'source_repo_id',
+					'session_branch',
+					'source_branch',
+					'base_commit',
+					'source_root',
+					'conversation_id',
+					'last_checkpoint_commit',
+					'last_check_run_id',
+					'last_check_tree_hash',
+				])}
+			), 0) AS count
+			FROM repo_sessions
+			WHERE user_id = ?`,
+			[userId],
+		),
+		sumStorageBytes(
+			db,
+			`SELECT COALESCE(SUM(
+				${textBytesExpression([
+					'token_id',
+					'package_id',
+					'package_kody_id',
+					'export_name',
+					'idempotency_key',
+					'request_hash',
+					'source',
+					'topic',
+					'response_json',
+				])}
+			), 0) AS count
+			FROM package_invocations
+			WHERE user_id = ?`,
+			[userId],
+		),
+		sumStorageBytes(
+			db,
+			`SELECT COALESCE(SUM(
+				${textBytesExpression([
+					'package_id',
+					'package_kody_id',
+					'source_id',
+					'published_commit',
+					'name',
+					'error_name',
+					'error_message',
+					'storage_id',
+					'job_id',
+					'workflow_id',
+					'invocation_id',
+					'session_id',
+					'idempotency_key',
+					'parent_run_id',
+					'metadata_json',
+				])}
+			), 0) AS count
+			FROM package_runtime_runs
+			WHERE user_id = ?`,
+			[userId],
+		),
+		sumStorageBytes(
+			db,
+			`SELECT COALESCE(SUM(
+				${textBytesExpression([
+					'package_id',
+					'level',
+					'message',
+					'fields_json',
+				])}
+			), 0) AS count
+			FROM package_runtime_logs
+			WHERE user_id = ?`,
+			[userId],
+		),
+		sumStorageBytes(
+			db,
+			`SELECT COALESCE(SUM(
+				${textBytesExpression([
+					'source_id',
+					'artifact_kind',
+					'artifact_name',
+					'entry_point',
+					'published_commit',
+					'kv_key',
+					'dependencies_json',
+				])}
+			), 0) AS count
+			FROM published_bundle_artifacts
+			WHERE user_id = ?`,
+			[userId],
+		),
+	])
+	return sums.reduce((total, value) => total + value, 0)
+}
+
 /**
  * Recency window for counting running package services. Service runs are
  * tracked in package_runtime_runs; rows can be left in 'running' after a
@@ -335,9 +631,7 @@ export async function readEntitlementResourceUsage(input: {
 			)
 		}
 		case 'storage_bytes':
-			throw new Error(
-				'storage_bytes has no built-in counter; pass getCurrent to assertWithinEntitlement.',
-			)
+			return await readUserD1StorageBytes({ db, userId })
 		case 'email_message_bytes':
 			// Per-message limit, not an accumulating counter: enforcement
 			// passes the candidate message size via getCurrent.
@@ -349,6 +643,23 @@ export async function readEntitlementResourceUsage(input: {
 			throw new Error(`Unknown entitlement resource: ${String(exhaustive)}`)
 		}
 	}
+}
+
+export async function assertWithinStorageBytesEntitlement(input: {
+	db: D1Database
+	userId: string
+	email: string | null | undefined
+	requested?: number
+	getCurrent?: () => Promise<number>
+}) {
+	await assertWithinEntitlement({
+		db: input.db,
+		userId: input.userId,
+		email: input.email,
+		resource: 'storage_bytes',
+		requested: input.requested,
+		getCurrent: input.getCurrent,
+	})
 }
 
 export type AssertWithinEntitlementInput = {

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -247,6 +247,37 @@ export function estimateEntitlementStorageEntryBytes(input: {
 	)
 }
 
+export function estimateEntitlementStorageByteDelta(input: {
+	nextBytes: number
+	existingBytes?: number | null
+}) {
+	return Math.max(0, input.nextBytes - (input.existingBytes ?? 0))
+}
+
+export function estimateEntitlementStorageEntryByteDelta(input: {
+	next: { key?: string | null; value: unknown }
+	existing?: { key?: string | null; value: unknown } | null
+}) {
+	return estimateEntitlementStorageByteDelta({
+		nextBytes: estimateEntitlementStorageEntryBytes(input.next),
+		existingBytes: input.existing
+			? estimateEntitlementStorageEntryBytes(input.existing)
+			: 0,
+	})
+}
+
+export function estimateEntitlementStorageSqlWriteBytes(input: {
+	query: string
+	params?: Array<unknown>
+}) {
+	return estimateEntitlementStorageEntryBytes({
+		value: {
+			query: input.query,
+			params: input.params ?? [],
+		},
+	})
+}
+
 function textBytesExpression(columns: ReadonlyArray<string>) {
 	return columns
 		.map((column) => `length(CAST(COALESCE(${column}, '') AS BLOB))`)

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
@@ -67,6 +67,7 @@ export const integrationSaveCapability = defineDomainCapability(
 			const value = await saveValue({
 				env: ctx.env,
 				userId: user.userId,
+				userEmail: user.email,
 				name: buildIntegrationValueName(integration.name),
 				value: JSON.stringify(integration),
 				scope: 'user',

--- a/packages/worker/src/mcp/capabilities/meta/meta-memory-upsert.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-memory-upsert.ts
@@ -106,6 +106,7 @@ export const metaMemoryUpsertCapability = defineDomainCapability(
 			const result = await upsertMemory({
 				env: ctx.env,
 				userId: user.userId,
+				userEmail: user.email,
 				memoryId: args.memory_id ?? null,
 				category: args.category ?? null,
 				subject: args.subject,

--- a/packages/worker/src/mcp/capabilities/storage/storage-query.ts
+++ b/packages/worker/src/mcp/capabilities/storage/storage-query.ts
@@ -3,7 +3,10 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
-import { storageRunnerRpc } from '#worker/storage-runner.ts'
+import {
+	assertStorageRunnerWriteWithinEntitlement,
+	storageRunnerRpc,
+} from '#worker/storage-runner.ts'
 import { storageIdSchema } from './shared.ts'
 
 const outputSchema = z.object({
@@ -46,6 +49,16 @@ export const storageQueryCapability = defineDomainCapability(
 		outputSchema,
 		async handler(args, ctx: CapabilityContext) {
 			const user = requireMcpUser(ctx.callerContext)
+			const writable = args.writable ?? false
+			if (writable) {
+				await assertStorageRunnerWriteWithinEntitlement({
+					env: ctx.env,
+					userId: user.userId,
+					email: user.email,
+					storageId: args.storage_id,
+					requested: 1,
+				})
+			}
 			const result = await storageRunnerRpc({
 				env: ctx.env,
 				userId: user.userId,
@@ -53,7 +66,7 @@ export const storageQueryCapability = defineDomainCapability(
 			}).sqlQuery({
 				query: args.query,
 				params: args.params,
-				writable: args.writable ?? false,
+				writable,
 			})
 			return {
 				ok: true as const,
@@ -64,7 +77,7 @@ export const storageQueryCapability = defineDomainCapability(
 				row_count: result.rowCount,
 				rows_read: result.rowsRead,
 				rows_written: result.rowsWritten,
-				writable: args.writable ?? false,
+				writable,
 			}
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/storage/storage-query.ts
+++ b/packages/worker/src/mcp/capabilities/storage/storage-query.ts
@@ -7,6 +7,7 @@ import {
 	assertStorageRunnerWriteWithinEntitlement,
 	storageRunnerRpc,
 } from '#worker/storage-runner.ts'
+import { estimateEntitlementStorageSqlWriteBytes } from '#worker/entitlements/service.ts'
 import { storageIdSchema } from './shared.ts'
 
 const outputSchema = z.object({
@@ -56,7 +57,10 @@ export const storageQueryCapability = defineDomainCapability(
 					userId: user.userId,
 					email: user.email,
 					storageId: args.storage_id,
-					requested: 1,
+					requested: estimateEntitlementStorageSqlWriteBytes({
+						query: args.query,
+						params: args.params,
+					}),
 				})
 			}
 			const result = await storageRunnerRpc({

--- a/packages/worker/src/mcp/capabilities/values/value-set.ts
+++ b/packages/worker/src/mcp/capabilities/values/value-set.ts
@@ -41,6 +41,7 @@ export const valueSetCapability = defineDomainCapability(
 			const value = await saveValue({
 				env: ctx.env,
 				userId: user.userId,
+				userEmail: user.email,
 				name,
 				value: args.value,
 				scope: args.scope,

--- a/packages/worker/src/mcp/memory/service.ts
+++ b/packages/worker/src/mcp/memory/service.ts
@@ -18,6 +18,10 @@ import { buildMemoryEmbedText } from './memory-embed.ts'
 import { deleteMemoryVector, upsertMemoryVector } from './memory-vectorize.ts'
 import { queryMemoryVectorIds, searchMemories } from './memory-search.ts'
 import {
+	assertWithinStorageBytesEntitlement,
+	estimateEntitlementStorageEntryBytes,
+} from '#worker/entitlements/service.ts'
+import {
 	type McpMemoryRow,
 	type MemoryRecord,
 	type MemorySearchMatch,
@@ -63,6 +67,7 @@ function logMemoryVectorSyncError(input: {
 
 type MemoryOwnerContext = {
 	userId: string
+	userEmail?: string | null
 	storageContext?: StorageContext | null
 }
 
@@ -171,6 +176,25 @@ export async function upsertMemory(input: MemoryUpsertInput): Promise<{
 				last_accessed_at: null,
 				deleted_at: null,
 			}
+
+	await assertWithinStorageBytesEntitlement({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		email: input.userEmail,
+		requested: estimateEntitlementStorageEntryBytes({
+			key: row.id,
+			value: {
+				category: row.category,
+				status: row.status,
+				subject: row.subject,
+				summary: row.summary,
+				details: row.details,
+				tagsJson: row.tags_json,
+				sourceUrisJson: row.source_uris_json,
+				dedupeKey: row.dedupe_key,
+			},
+		}),
+	})
 
 	if (existing) {
 		const updated = await updateMemory(input.env.APP_DB, input.userId, row.id, {

--- a/packages/worker/src/mcp/memory/service.ts
+++ b/packages/worker/src/mcp/memory/service.ts
@@ -19,7 +19,7 @@ import { deleteMemoryVector, upsertMemoryVector } from './memory-vectorize.ts'
 import { queryMemoryVectorIds, searchMemories } from './memory-search.ts'
 import {
 	assertWithinStorageBytesEntitlement,
-	estimateEntitlementStorageEntryBytes,
+	estimateEntitlementStorageEntryByteDelta,
 } from '#worker/entitlements/service.ts'
 import {
 	type McpMemoryRow,
@@ -181,18 +181,35 @@ export async function upsertMemory(input: MemoryUpsertInput): Promise<{
 		db: input.env.APP_DB,
 		userId: input.userId,
 		email: input.userEmail,
-		requested: estimateEntitlementStorageEntryBytes({
-			key: row.id,
-			value: {
-				category: row.category,
-				status: row.status,
-				subject: row.subject,
-				summary: row.summary,
-				details: row.details,
-				tagsJson: row.tags_json,
-				sourceUrisJson: row.source_uris_json,
-				dedupeKey: row.dedupe_key,
+		requested: estimateEntitlementStorageEntryByteDelta({
+			next: {
+				key: row.id,
+				value: {
+					category: row.category,
+					status: row.status,
+					subject: row.subject,
+					summary: row.summary,
+					details: row.details,
+					tagsJson: row.tags_json,
+					sourceUrisJson: row.source_uris_json,
+					dedupeKey: row.dedupe_key,
+				},
 			},
+			existing: existing
+				? {
+						key: existing.id,
+						value: {
+							category: existing.category,
+							status: existing.status,
+							subject: existing.subject,
+							summary: existing.summary,
+							details: existing.details,
+							tagsJson: existing.tags_json,
+							sourceUrisJson: existing.source_uris_json,
+							dedupeKey: existing.dedupe_key,
+						},
+					}
+				: null,
 		}),
 	})
 

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -440,6 +440,7 @@ async function buildKodyToolContext(
 		? await createStorageKodyTools({
 				env,
 				userId: callerContext.user?.userId ?? '',
+				email: callerContext.user?.email,
 				storageId: storageTools.storageId,
 				writable: storageTools.writable,
 			})

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -32,7 +32,11 @@ import {
 	upsertSecretBucket,
 	upsertSecretEntry,
 } from './repo.ts'
-import { assertWithinEntitlement } from '#worker/entitlements/service.ts'
+import {
+	assertWithinEntitlement,
+	assertWithinStorageBytesEntitlement,
+	estimateEntitlementStorageEntryBytes,
+} from '#worker/entitlements/service.ts'
 import { type SecretMetadata, type SecretScope } from './types.ts'
 
 type SecretOwnerContext = {
@@ -117,6 +121,22 @@ export async function saveSecret(
 			resource: 'secrets',
 		})
 	}
+	const encryptedValue = await encryptSecretValue(input.env, value)
+	await assertWithinStorageBytesEntitlement({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		email: input.userEmail,
+		requested: estimateEntitlementStorageEntryBytes({
+			key: name,
+			value: {
+				description,
+				encryptedValue,
+				allowedHosts: existingEntry?.allowed_hosts ?? '[]',
+				allowedCapabilities: existingEntry?.allowed_capabilities ?? '[]',
+				allowedPackages: existingEntry?.allowed_packages ?? '[]',
+			},
+		}),
+	})
 	const now = new Date().toISOString()
 	await upsertSecretEntry({
 		db: input.env.APP_DB,
@@ -124,7 +144,7 @@ export async function saveSecret(
 			bucket_id: bucket.id,
 			name,
 			description,
-			encrypted_value: await encryptSecretValue(input.env, value),
+			encrypted_value: encryptedValue,
 			allowed_hosts: existingEntry?.allowed_hosts ?? '[]',
 			allowed_capabilities: existingEntry?.allowed_capabilities ?? '[]',
 			allowed_packages: existingEntry?.allowed_packages ?? '[]',

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -35,7 +35,7 @@ import {
 import {
 	assertWithinEntitlement,
 	assertWithinStorageBytesEntitlement,
-	estimateEntitlementStorageEntryBytes,
+	estimateEntitlementStorageEntryByteDelta,
 } from '#worker/entitlements/service.ts'
 import { type SecretMetadata, type SecretScope } from './types.ts'
 
@@ -126,15 +126,29 @@ export async function saveSecret(
 		db: input.env.APP_DB,
 		userId: input.userId,
 		email: input.userEmail,
-		requested: estimateEntitlementStorageEntryBytes({
-			key: name,
-			value: {
-				description,
-				encryptedValue,
-				allowedHosts: existingEntry?.allowed_hosts ?? '[]',
-				allowedCapabilities: existingEntry?.allowed_capabilities ?? '[]',
-				allowedPackages: existingEntry?.allowed_packages ?? '[]',
+		requested: estimateEntitlementStorageEntryByteDelta({
+			next: {
+				key: name,
+				value: {
+					description,
+					encryptedValue,
+					allowedHosts: existingEntry?.allowed_hosts ?? '[]',
+					allowedCapabilities: existingEntry?.allowed_capabilities ?? '[]',
+					allowedPackages: existingEntry?.allowed_packages ?? '[]',
+				},
 			},
+			existing: existingEntry
+				? {
+						key: existingEntry.name,
+						value: {
+							description: existingEntry.description,
+							encryptedValue: existingEntry.encrypted_value,
+							allowedHosts: existingEntry.allowed_hosts,
+							allowedCapabilities: existingEntry.allowed_capabilities,
+							allowedPackages: existingEntry.allowed_packages,
+						},
+					}
+				: null,
 		}),
 	})
 	const now = new Date().toISOString()

--- a/packages/worker/src/mcp/values/service.ts
+++ b/packages/worker/src/mcp/values/service.ts
@@ -15,7 +15,7 @@ import {
 import { type ValueMetadata, type ValueScope } from './types.ts'
 import {
 	assertWithinStorageBytesEntitlement,
-	estimateEntitlementStorageEntryBytes,
+	estimateEntitlementStorageEntryByteDelta,
 } from '#worker/entitlements/service.ts'
 
 type ValueOwnerContext = {
@@ -78,9 +78,20 @@ export async function saveValue(input: SaveValueInput): Promise<ValueMetadata> {
 		db: input.env.APP_DB,
 		userId: input.userId,
 		email: input.userEmail,
-		requested: estimateEntitlementStorageEntryBytes({
-			key: name,
-			value: { description, value },
+		requested: estimateEntitlementStorageEntryByteDelta({
+			next: {
+				key: name,
+				value: { description, value },
+			},
+			existing: existingEntry
+				? {
+						key: existingEntry.name,
+						value: {
+							description: existingEntry.description,
+							value: existingEntry.value,
+						},
+					}
+				: null,
 		}),
 	})
 	const now = new Date().toISOString()

--- a/packages/worker/src/mcp/values/service.ts
+++ b/packages/worker/src/mcp/values/service.ts
@@ -13,6 +13,10 @@ import {
 	upsertValueEntry,
 } from './repo.ts'
 import { type ValueMetadata, type ValueScope } from './types.ts'
+import {
+	assertWithinStorageBytesEntitlement,
+	estimateEntitlementStorageEntryBytes,
+} from '#worker/entitlements/service.ts'
 
 type ValueOwnerContext = {
 	userId: string
@@ -26,6 +30,7 @@ type SaveValueInput = ValueOwnerContext & {
 	value: string
 	description?: string | null
 	sessionExpiresAt?: string | null
+	userEmail?: string | null
 }
 
 type ListValuesInput = ValueOwnerContext & {
@@ -68,6 +73,15 @@ export async function saveValue(input: SaveValueInput): Promise<ValueMetadata> {
 		db: input.env.APP_DB,
 		bucketId: bucket.id,
 		name,
+	})
+	await assertWithinStorageBytesEntitlement({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		email: input.userEmail,
+		requested: estimateEntitlementStorageEntryBytes({
+			key: name,
+			value: { description, value },
+		}),
 	})
 	const now = new Date().toISOString()
 	await upsertValueEntry({

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -639,6 +639,28 @@ function createEntitlementsDatabase(input: {
 							) {
 								return { count: savedPackageCount } as T
 							}
+							const storageByteTables = [
+								'email_attachments',
+								'email_messages',
+								'value_entries',
+								'secret_entries',
+								'mcp_memories',
+								'saved_packages',
+								'entity_sources',
+								'jobs',
+								'repo_sessions',
+								'package_invocations',
+								'package_runtime_runs',
+								'package_runtime_logs',
+								'published_bundle_artifacts',
+							]
+							if (
+								storageByteTables.some((table) =>
+									query.includes(`FROM ${table}`),
+								)
+							) {
+								return { count: 0 } as T
+							}
 							throw new Error(`Unsupported first query: ${query}`)
 						},
 					}

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -38,7 +38,7 @@ import { deleteEntitySource } from '#worker/repo/entity-sources.ts'
 import {
 	assertWithinEntitlement,
 	assertWithinStorageBytesEntitlement,
-	estimateEntitlementStorageEntryBytes,
+	estimateEntitlementStorageEntryByteDelta,
 } from '#worker/entitlements/service.ts'
 
 function logPackageRetrieverProjectionError(input: {
@@ -125,16 +125,31 @@ export async function refreshSavedPackageProjection(input: {
 		db: input.env.APP_DB,
 		userId: input.userId,
 		email: input.userEmail,
-		requested: estimateEntitlementStorageEntryBytes({
-			key: row.id,
-			value: {
-				name: row.name,
-				kodyId: row.kody_id,
-				description: row.description,
-				tagsJson: row.tags_json,
-				searchText: row.search_text,
-				sourceId: row.source_id,
+		requested: estimateEntitlementStorageEntryByteDelta({
+			next: {
+				key: row.id,
+				value: {
+					name: row.name,
+					kodyId: row.kody_id,
+					description: row.description,
+					tagsJson: row.tags_json,
+					searchText: row.search_text,
+					sourceId: row.source_id,
+				},
 			},
+			existing: existing
+				? {
+						key: existing.id,
+						value: {
+							name: existing.name,
+							kodyId: existing.kodyId,
+							description: existing.description,
+							tagsJson: JSON.stringify(existing.tags),
+							searchText: existing.searchText,
+							sourceId: existing.sourceId,
+						},
+					}
+				: null,
 		}),
 	})
 	if (existing) {

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -35,7 +35,11 @@ import {
 } from '#worker/package-retrievers/manifest-cache.ts'
 import { cleanupArtifactReposForPackage } from '#worker/repo/artifact-repo-cleanup.ts'
 import { deleteEntitySource } from '#worker/repo/entity-sources.ts'
-import { assertWithinEntitlement } from '#worker/entitlements/service.ts'
+import {
+	assertWithinEntitlement,
+	assertWithinStorageBytesEntitlement,
+	estimateEntitlementStorageEntryBytes,
+} from '#worker/entitlements/service.ts'
 
 function logPackageRetrieverProjectionError(input: {
 	action: 'refresh' | 'delete'
@@ -116,6 +120,22 @@ export async function refreshSavedPackageProjection(input: {
 	const existing = await getSavedPackageById(input.env.APP_DB, {
 		userId: input.userId,
 		packageId: input.packageId,
+	})
+	await assertWithinStorageBytesEntitlement({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		email: input.userEmail,
+		requested: estimateEntitlementStorageEntryBytes({
+			key: row.id,
+			value: {
+				name: row.name,
+				kodyId: row.kody_id,
+				description: row.description,
+				tagsJson: row.tags_json,
+				searchText: row.search_text,
+				sourceId: row.source_id,
+			},
+		}),
 	})
 	if (existing) {
 		await updateSavedPackage(input.env.APP_DB, {

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -28,7 +28,11 @@ import {
 } from './published-bundle-artifacts.ts'
 import { PromiseLruCache } from '#worker/package-registry/published-package-cache.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
-import { storageRunnerRpc } from '#worker/storage-runner.ts'
+import {
+	assertStorageRunnerWriteWithinEntitlement,
+	storageRunnerRpc,
+} from '#worker/storage-runner.ts'
+import { estimateEntitlementStorageEntryBytes } from '#worker/entitlements/service.ts'
 import { packageRealtimeSessionRpc } from './realtime-session.ts'
 import {
 	createDynamicCallableWorkflow,
@@ -710,6 +714,19 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 		})
 	}
 
+	private async assertStorageWriteAllowed(input: {
+		storageId: string
+		requested?: number
+	}) {
+		await assertStorageRunnerWriteWithinEntitlement({
+			env: this.env,
+			userId: this.ctx.props.userId,
+			email: this.ctx.props.email,
+			storageId: input.storageId,
+			requested: input.requested,
+		})
+	}
+
 	private getRealtimeSessionRpc() {
 		return packageRealtimeSessionRpc({
 			env: this.env,
@@ -879,14 +896,28 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 		params?: Array<unknown>
 		writable?: boolean
 	}) {
+		const writable = input.writable ?? false
+		if (writable) {
+			await this.assertStorageWriteAllowed({
+				storageId: input.storageId,
+				requested: 1,
+			})
+		}
 		return await this.getStorageRunner(input.storageId).sqlQuery({
 			query: input.query,
 			params: input.params,
-			writable: input.writable ?? false,
+			writable,
 		})
 	}
 
 	async storageSet(input: { storageId: string; key: string; value: unknown }) {
+		await this.assertStorageWriteAllowed({
+			storageId: input.storageId,
+			requested: estimateEntitlementStorageEntryBytes({
+				key: input.key,
+				value: input.value,
+			}),
+		})
 		return await this.getStorageRunner(input.storageId).setValue({
 			key: input.key,
 			value: input.value,

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -32,7 +32,10 @@ import {
 	assertStorageRunnerWriteWithinEntitlement,
 	storageRunnerRpc,
 } from '#worker/storage-runner.ts'
-import { estimateEntitlementStorageEntryBytes } from '#worker/entitlements/service.ts'
+import {
+	estimateEntitlementStorageEntryByteDelta,
+	estimateEntitlementStorageSqlWriteBytes,
+} from '#worker/entitlements/service.ts'
 import { packageRealtimeSessionRpc } from './realtime-session.ts'
 import {
 	createDynamicCallableWorkflow,
@@ -900,7 +903,10 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 		if (writable) {
 			await this.assertStorageWriteAllowed({
 				storageId: input.storageId,
-				requested: 1,
+				requested: estimateEntitlementStorageSqlWriteBytes({
+					query: input.query,
+					params: input.params,
+				}),
 			})
 		}
 		return await this.getStorageRunner(input.storageId).sqlQuery({
@@ -911,11 +917,23 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 	}
 
 	async storageSet(input: { storageId: string; key: string; value: unknown }) {
+		const existing = await this.getStorageRunner(input.storageId).getValue({
+			key: input.key,
+		})
 		await this.assertStorageWriteAllowed({
 			storageId: input.storageId,
-			requested: estimateEntitlementStorageEntryBytes({
-				key: input.key,
-				value: input.value,
+			requested: estimateEntitlementStorageEntryByteDelta({
+				next: {
+					key: input.key,
+					value: input.value,
+				},
+				existing:
+					existing.value === null
+						? null
+						: {
+								key: input.key,
+								value: existing.value,
+							},
 			}),
 		})
 		return await this.getStorageRunner(input.storageId).setValue({

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -1,6 +1,11 @@
 import * as Sentry from '@sentry/cloudflare'
 import { DurableObject } from 'cloudflare:workers'
 import { buildSentryOptions } from '#worker/sentry-options.ts'
+import {
+	assertWithinStorageBytesEntitlement,
+	estimateEntitlementStorageEntryBytes,
+	readUserD1StorageBytes,
+} from '#worker/entitlements/service.ts'
 
 const defaultStorageExportPageSize = 250
 const maxStorageExportPageSize = 1_000
@@ -43,6 +48,10 @@ type StorageDeleteResult = {
 
 type StorageClearResult = {
 	ok: true
+}
+
+type StorageEstimateResult = {
+	estimatedBytes: number
 }
 
 function buildStorageRunnerName(userId: string, storageId: string) {
@@ -312,6 +321,10 @@ class StorageRunnerBase extends DurableObject<Env> {
 		return { ok: true }
 	}
 
+	async getEstimatedBytes(): Promise<StorageEstimateResult> {
+		return { estimatedBytes: this.ctx.storage.sql.databaseSize }
+	}
+
 	async listValues(input: {
 		prefix?: string | null
 		pageSize?: number
@@ -395,6 +408,7 @@ export function storageRunnerRpc(input: {
 		}) => Promise<StorageSetResult>
 		deleteValue: (payload: { key: string }) => Promise<StorageDeleteResult>
 		clearStorage: () => Promise<StorageClearResult>
+		getEstimatedBytes: () => Promise<StorageEstimateResult>
 		listValues: (payload: {
 			prefix?: string | null
 			pageSize?: number
@@ -412,9 +426,35 @@ export function storageRunnerRpc(input: {
 	}
 }
 
+export async function assertStorageRunnerWriteWithinEntitlement(input: {
+	env: Env
+	userId: string
+	email: string | null | undefined
+	storageId: string
+	requested?: number
+}) {
+	const runner = storageRunnerRpc({
+		env: input.env,
+		userId: input.userId,
+		storageId: input.storageId,
+	})
+	await assertWithinStorageBytesEntitlement({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		email: input.email,
+		requested: input.requested,
+		getCurrent: async () =>
+			(await readUserD1StorageBytes({
+				db: input.env.APP_DB,
+				userId: input.userId,
+			})) + (await runner.getEstimatedBytes()).estimatedBytes,
+	})
+}
+
 export function createStorageKodyTools(input: {
 	env: Env
 	userId: string
+	email?: string | null
 	storageId: string
 	writable: boolean
 }) {
@@ -459,14 +499,24 @@ export function createStorageKodyTools(input: {
 							writable?: unknown
 						})
 					: {}
+			const writable = input.writable
+				? payload.writable === undefined
+					? true
+					: Boolean(payload.writable)
+				: false
+			if (writable) {
+				await assertStorageRunnerWriteWithinEntitlement({
+					env: input.env,
+					userId: input.userId,
+					email: input.email,
+					storageId: input.storageId,
+					requested: 1,
+				})
+			}
 			return await runner.sqlQuery({
 				query: typeof payload.query === 'string' ? payload.query : '',
 				params: Array.isArray(payload.params) ? payload.params : undefined,
-				writable: input.writable
-					? payload.writable === undefined
-						? true
-						: Boolean(payload.writable)
-					: false,
+				writable,
 			})
 		},
 		...(input.writable
@@ -476,8 +526,19 @@ export function createStorageKodyTools(input: {
 							typeof args === 'object' && args !== null
 								? (args as { key?: unknown; value?: unknown })
 								: {}
+						const key = typeof payload.key === 'string' ? payload.key : ''
+						await assertStorageRunnerWriteWithinEntitlement({
+							env: input.env,
+							userId: input.userId,
+							email: input.email,
+							storageId: input.storageId,
+							requested: estimateEntitlementStorageEntryBytes({
+								key,
+								value: payload.value,
+							}),
+						})
 						return await runner.setValue({
-							key: typeof payload.key === 'string' ? payload.key : '',
+							key,
 							value: payload.value,
 						})
 					},

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -3,7 +3,8 @@ import { DurableObject } from 'cloudflare:workers'
 import { buildSentryOptions } from '#worker/sentry-options.ts'
 import {
 	assertWithinStorageBytesEntitlement,
-	estimateEntitlementStorageEntryBytes,
+	estimateEntitlementStorageEntryByteDelta,
+	estimateEntitlementStorageSqlWriteBytes,
 	readUserD1StorageBytes,
 } from '#worker/entitlements/service.ts'
 
@@ -504,18 +505,23 @@ export function createStorageKodyTools(input: {
 					? true
 					: Boolean(payload.writable)
 				: false
+			const query = typeof payload.query === 'string' ? payload.query : ''
+			const params = Array.isArray(payload.params) ? payload.params : undefined
 			if (writable) {
 				await assertStorageRunnerWriteWithinEntitlement({
 					env: input.env,
 					userId: input.userId,
 					email: input.email,
 					storageId: input.storageId,
-					requested: 1,
+					requested: estimateEntitlementStorageSqlWriteBytes({
+						query,
+						params,
+					}),
 				})
 			}
 			return await runner.sqlQuery({
-				query: typeof payload.query === 'string' ? payload.query : '',
-				params: Array.isArray(payload.params) ? payload.params : undefined,
+				query,
+				params,
 				writable,
 			})
 		},
@@ -527,14 +533,24 @@ export function createStorageKodyTools(input: {
 								? (args as { key?: unknown; value?: unknown })
 								: {}
 						const key = typeof payload.key === 'string' ? payload.key : ''
+						const existing = await runner.getValue({ key })
 						await assertStorageRunnerWriteWithinEntitlement({
 							env: input.env,
 							userId: input.userId,
 							email: input.email,
 							storageId: input.storageId,
-							requested: estimateEntitlementStorageEntryBytes({
-								key,
-								value: payload.value,
+							requested: estimateEntitlementStorageEntryByteDelta({
+								next: {
+									key,
+									value: payload.value,
+								},
+								existing:
+									existing.value === null
+										? null
+										: {
+												key,
+												value: existing.value,
+											},
 							}),
 						})
 						return await runner.setValue({

--- a/packages/worker/src/storage-runner.workers.test.ts
+++ b/packages/worker/src/storage-runner.workers.test.ts
@@ -1,11 +1,85 @@
 import { env } from 'cloudflare:workers'
 import { runInDurableObject } from 'cloudflare:test'
 import { expect, test } from 'vitest'
+import { EntitlementLimitError } from '#worker/entitlements/errors.ts'
+import { planLimits } from '#worker/entitlements/plans.ts'
+import { ensureEntitlementTestSchema } from '#worker/entitlements/test-schema.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import {
+	createStorageKodyTools,
 	createExecuteStorageId,
 	StorageRunner,
 	storageRunnerRpc,
 } from './storage-runner.ts'
+
+async function ensureStorageBytesEmailTestSchema() {
+	await ensureEntitlementTestSchema(env.APP_DB)
+	await env.APP_DB.prepare(
+		`CREATE TABLE IF NOT EXISTS email_messages (
+	id TEXT PRIMARY KEY,
+	direction TEXT NOT NULL,
+	user_id TEXT NOT NULL,
+	from_address TEXT NOT NULL DEFAULT '',
+	envelope_from TEXT,
+	to_addresses_json TEXT NOT NULL DEFAULT '[]',
+	cc_addresses_json TEXT NOT NULL DEFAULT '[]',
+	bcc_addresses_json TEXT NOT NULL DEFAULT '[]',
+	reply_to_addresses_json TEXT NOT NULL DEFAULT '[]',
+	subject TEXT NOT NULL DEFAULT '',
+	message_id_header TEXT,
+	in_reply_to_header TEXT,
+	references_json TEXT NOT NULL DEFAULT '[]',
+	headers_json TEXT NOT NULL DEFAULT '{}',
+	auth_results TEXT,
+	text_body TEXT,
+	html_body TEXT,
+	raw_mime TEXT,
+	raw_size INTEGER NOT NULL DEFAULT 0,
+	processing_status TEXT NOT NULL DEFAULT 'stored',
+	provider_message_id TEXT,
+	error TEXT,
+	received_at TEXT,
+	sent_at TEXT,
+	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+	updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+)`,
+	).run()
+}
+
+async function seedPlannedStorageUser(input: {
+	email: string
+	plan: 'personal' | null
+	rawSize: number
+}) {
+	const userId = await createStableUserIdFromEmail(input.email)
+	await env.APP_DB.prepare(
+		`INSERT INTO users (username, email, password_hash, email_verified_at, plan)
+		VALUES (?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			`storage-${crypto.randomUUID().slice(0, 8)}`,
+			input.email,
+			'test-password-hash',
+			new Date().toISOString(),
+			input.plan,
+		)
+		.run()
+	await env.APP_DB.prepare(
+		`INSERT INTO email_messages (
+			id, direction, user_id, from_address, raw_size, processing_status,
+			created_at, updated_at
+		) VALUES (?, 'inbound', ?, 'sender@example.com', ?, 'stored', ?, ?)`,
+	)
+		.bind(
+			`storage-quota-${crypto.randomUUID()}`,
+			userId,
+			input.rawSize,
+			new Date().toISOString(),
+			new Date().toISOString(),
+		)
+		.run()
+	return userId
+}
 
 test('storage runner preserves isolated state per storage id', async () => {
 	const storageIdA = createExecuteStorageId()
@@ -81,6 +155,74 @@ test('storage runner preserves isolated state per storage id', async () => {
 			},
 		],
 	})
+})
+
+test('storage runner write tools enforce storage byte entitlements for planned users', async () => {
+	await ensureStorageBytesEmailTestSchema()
+	const limit = planLimits.personal.maxStorageBytes
+	if (limit === null)
+		throw new Error('Expected a numeric personal storage cap.')
+	const plannedEmail = `storage-planned-${crypto.randomUUID()}@example.com`
+	const plannedUserId = await seedPlannedStorageUser({
+		email: plannedEmail,
+		plan: 'personal',
+		rawSize: limit,
+	})
+	const plannedStorageId = createExecuteStorageId()
+	const plannedTools = createStorageKodyTools({
+		env,
+		userId: plannedUserId,
+		email: plannedEmail,
+		storageId: plannedStorageId,
+		writable: true,
+	})
+
+	const denied = await plannedTools
+		.storage_set({
+			key: 'new-key',
+			value: 'new-value',
+		})
+		.then(
+			() => null,
+			(thrown: unknown) => thrown,
+		)
+	if (!(denied instanceof EntitlementLimitError)) {
+		throw new Error('Expected an EntitlementLimitError.')
+	}
+	expect(denied.details).toMatchObject({
+		resource: 'storage_bytes',
+		plan: 'personal',
+		limit,
+	})
+	expect(denied.details.current).toBeGreaterThanOrEqual(limit)
+	await expect(
+		storageRunnerRpc({
+			env,
+			userId: plannedUserId,
+			storageId: plannedStorageId,
+		}).getValue({ key: 'new-key' }),
+	).resolves.toEqual({ key: 'new-key', value: null })
+
+	const noPlanEmail = `storage-unplanned-${crypto.randomUUID()}@example.com`
+	const noPlanUserId = await seedPlannedStorageUser({
+		email: noPlanEmail,
+		plan: null,
+		rawSize: limit,
+	})
+	const noPlanStorageId = createExecuteStorageId()
+	const noPlanTools = createStorageKodyTools({
+		env,
+		userId: noPlanUserId,
+		email: noPlanEmail,
+		storageId: noPlanStorageId,
+		writable: true,
+	})
+	await expect(
+		noPlanTools.storage_set({
+			key: 'new-key',
+			value: 'new-value',
+		}),
+	).resolves.toEqual({ ok: true, key: 'new-key' })
 })
 
 test('storage runner supports raw SQL with explicit writable access', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Added a built-in `storage_bytes` D1 byte estimator for countable user-owned durable payloads (email raw/body metadata, values, encrypted secrets, memories, saved package/job/runtime metadata, and related projections).
- Wired storage quota enforcement into email storage, values, secrets, memories, saved-package projections, StorageRunner write tools, direct `storage_query` writable calls, and package app storage RPC writes.
- Tightened write estimates after AI review: upserts reserve only net-positive byte growth, writable SQL estimates query/params, and inbound email reserves raw MIME plus extracted/stored metadata.
- Updated entitlement architecture docs to describe counted storage, StorageRunner `getCurrent` handling, and current gaps for stores without reliable byte metadata (Artifacts/KV bodies/Vectorize scans).
- Added focused tests for planned users at the storage limit, NULL-plan users remaining unaffected, inbound email storage-byte rejection, StorageRunner write chokepoint enforcement, and net-positive upsert byte deltas.

## Verification

- `npm run test -- packages/worker/src/package-registry/service.node.test.ts packages/worker/src/entitlements/entitlements.node.test.ts packages/worker/src/storage-runner.workers.test.ts packages/worker/src/email/inbound-entitlements.workers.test.ts`
- `npm run typecheck`
- `npm run format:check`
- `npm run validate` (format, lint, typecheck, unit tests, Playwright E2E, and MCP E2E all exited 0)
- GitHub PR checks on latest head: Validate passed, preview passed, Cursor Bugbot passed, CodeRabbit passed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `80e35c5` · **Head:** `a57a8ed`

**Classification:** extends — this PR changes entitlement enforcement behavior for an existing plan resource and wires existing storage primitives into that guard.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | extends — `storage_bytes` now has a D1 byte counter, shared storage-byte assertion path, and byte-estimation/delta helpers |
| `durable-storage` | assistant | extends — StorageRunner write tools and package app storage RPCs check storage quota before writes |
| `d1-app-db` | storage | composes — existing user-scoped tables are read for byte estimates; no schema change |
| `email` | assistant | composes — inbound/outbound message storage checks storage quota |
| `values` | assistant | composes — value writes pass estimated payload byte deltas to the entitlement guard |
| `secrets` | assistant | composes — encrypted secret writes pass estimated stored byte deltas to the entitlement guard |
| `memories` | assistant | composes — memory upserts pass estimated stored byte deltas to the entitlement guard |
| `saved-packages` | assistant | composes — saved package projection writes pass estimated stored byte deltas to the entitlement guard |
| `mcp-server` | surfaces | composes — capability handlers thread caller email to storage enforcement |

### System map

```mermaid
flowchart LR
	mcpServer["mcp-server"]:::touched --> entitlements["entitlements"]:::extended
	appUi["app-ui"]:::untouched --> entitlements
	entitlements --> d1AppDb["d1-app-db"]:::touched
	entitlements --> durableStorage["durable-storage"]:::extended
	email["email"]:::touched --> entitlements
	values["values"]:::touched --> entitlements
	secrets["secrets"]:::touched --> entitlements
	memories["memories"]:::touched --> entitlements
	savedPackages["saved-packages"]:::touched --> entitlements
	packageApps["package-apps"]:::touched --> durableStorage
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Writer as Storage/write chokepoint
	participant Ent as assertWithinStorageBytesEntitlement
	participant D1 as APP_DB byte counter
	participant DO as StorageRunner bucket estimate
	Writer->>Ent: userId, email, requested byte delta
	Ent->>D1: resolve plan by verified user email
	alt known plan
		Ent->>D1: read user-scoped D1 byte estimate
		opt StorageRunner write
			Ent->>DO: read target bucket estimatedBytes
		end
		Ent-->>Writer: allow or EntitlementLimitError(storage_bytes)
	else NULL/unknown plan
		Ent-->>Writer: allow without counting
	end
```

### Invariants

- `per-user-isolation`: all byte-counting SQL filters by `user_id`, transitive child counts join back to user-owned parent rows, and StorageRunner estimates are read from the `(userId, storageId)` Durable Object namespace.
- NULL-plan invariant is preserved for `storage_bytes`: users without a known plan return before byte counting and remain unlimited for this resource.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6adb2fc2-1970-455d-a7f0-772092001623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6adb2fc2-1970-455d-a7f0-772092001623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added storage-byte quota enforcement across email, value, secret, memory, package, and storage-write flows.
  * Expanded storage write checks to account for estimated item size before saving data.
  * Improved handling of user email context for saved content and connected integrations.

* **Bug Fixes**
  * Inbound and outbound email actions now reject oversized storage usage earlier and more consistently.
  * Storage runner write tools now block writes when a user has reached their storage limit.

* **Documentation**
  * Updated entitlement docs to describe storage-byte limits and where they are enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->