### PR TITLE
Add admin user plan updates across API, MCP, and admin UI

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -149,6 +149,7 @@ Current admin capabilities:
 - `admin_user_list`
 - `admin_user_get`
 - `admin_user_create`
+- `admin_user_update`
 - `admin_audit_log_query`
 
 When adding more admin actions, expose service-layer functions by adding new

--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -137,25 +137,27 @@ the same way).
 
 ### Where guards are used
 
-| Route / handler                               | Guard                                              |
-| --------------------------------------------- | -------------------------------------------------- |
-| `GET /admin`                                  | `requireUserWithRole('admin')` → redirect to users |
-| `GET /admin/users`                            | `requireUserWithRole('admin')`                     |
-| `GET /admin/users.json`                       | `requireUserWithPermission('read:user:any')`       |
-| `POST /admin/users.json` (assign/remove role) | `requireUserWithPermission('update:user:any')`     |
-| `GET /admin/roles`                            | `requireUserWithRole('admin')`                     |
-| `GET /admin/roles.json`                       | `requireUserWithPermission('read:role:any')`       |
-| `GET /admin/invites`                          | `requireUserWithRole('admin')`                     |
-| `GET/POST /admin/invites.json`                | `requireUserWithRole('admin')`                     |
-| `GET /admin/system-email`                     | `requireUserWithRole('admin')`                     |
-| `GET /admin/system-email.json`                | `requireUserWithRole('admin')`                     |
+| Route / handler                        | Guard                                              |
+| -------------------------------------- | -------------------------------------------------- |
+| `GET /admin`                           | `requireUserWithRole('admin')` → redirect to users |
+| `GET /admin/users`                     | `requireUserWithRole('admin')`                     |
+| `GET /admin/users.json`                | `requireUserWithPermission('read:user:any')`       |
+| `POST /admin/users.json` (roles, plan) | `requireUserWithPermission('update:user:any')`     |
+| `GET /admin/roles`                     | `requireUserWithRole('admin')`                     |
+| `GET /admin/roles.json`                | `requireUserWithPermission('read:role:any')`       |
+| `GET /admin/invites`                   | `requireUserWithRole('admin')`                     |
+| `GET/POST /admin/invites.json`         | `requireUserWithRole('admin')`                     |
+| `GET /admin/system-email`              | `requireUserWithRole('admin')`                     |
+| `GET /admin/system-email.json`         | `requireUserWithRole('admin')`                     |
 
 Handlers: `packages/worker/src/app/handlers/admin-users.ts`,
 `packages/worker/src/app/handlers/admin-roles.ts`,
 `packages/worker/src/app/handlers/admin-invites.ts`.
 
-Role assignment and removal emit audit events via `logAuditEvent` with category
-`admin`.
+`POST /admin/users.json` dispatches on an `action` field: `assign_role`,
+`remove_role`, and `update_plan` (set or clear — `plan: null` — a user's
+entitlement plan; see [Entitlements](./entitlements.md)). All three mutations
+emit audit events via `logAuditEvent` with category `admin`.
 
 ### Last-admin guardrail
 
@@ -235,7 +237,10 @@ behind `search`/`execute`.
 The admin role is an **account-administration** role, not a data-access role.
 
 **Admins can see** account metadata only: user id, username, email,
-`created_at`, `updated_at`, and role assignments.
+email-verification state, entitlement plan, `created_at`, `updated_at`, and role
+assignments. The plan is account metadata (it drives quota enforcement), not
+user content, and admins can change it via `/admin/users` or the
+`admin_user_update` MCP capability.
 
 **Admins cannot see** user content (secrets, values, memories, packages, jobs,
 user inbox email, chat threads, durable storage, remote connectors, OAuth
@@ -258,10 +263,10 @@ This boundary is enforced structurally:
    is separate and filters email rows by `user_id = 'system:email'`.
 3. **A shape test pins the admin users API payload.**
    `adminUserListItemFieldNames` in `admin-users.ts` defines the allowed fields
-   (`id`, `username`, `email`, `created_at`, `updated_at`, `roles`). The unit
-   test in `admin-users.node.test.ts` asserts every user object in the list
-   response has exactly those keys — an accidental widening fails
-   `npm run validate`.
+   (`id`, `username`, `email`, `email_verified`, `email_verified_at`, `plan`,
+   `created_at`, `updated_at`, `roles`). The unit test in
+   `admin-users.node.test.ts` asserts every user object in the list response has
+   exactly those keys — an accidental widening fails `npm run validate`.
 4. **Existing owner-only paths take no admin bypass.** Secret reveal remains
    session-authenticated and owner-only.
 

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -33,6 +33,25 @@ attacker-controlled (anyone can send to a `{username}@<platform domain>`
 address). Use `resolveEmailResourceLimit` to read the effective limit for those
 resources.
 
+## Assigning plans
+
+Signup and invites never set a plan — new accounts start with `plan = NULL`
+(legacy/unlimited plus the email backstops above). Admins assign or clear plans
+through two audited, admin-only surfaces, both backed by `updateAdminUserPlan`
+in `packages/worker/src/app/admin-users-data.ts`:
+
+- **Admin UI** — the "Manage plan" panel on `/admin/users` posts
+  `{ action: 'update_plan', userId, plan }` to `POST /admin/users.json` (guarded
+  by `update:user:any`). `plan: null` clears the plan; unknown plan strings are
+  rejected with `400` rather than coerced to null.
+- **MCP** — the `admin_user_update` capability (`requiredRole: 'admin'`) updates
+  one user by `id` or `email` and accepts `plan: PlanName | null`.
+
+Both paths validate against the plan registry (`parsePlanName` / `planNames`)
+and write an `admin`-category audit event with reason `target_user_id=…;plan=…`.
+Because daily counters accumulate even for plan-less users, assigning a plan
+later binds immediately against the usage already counted that day.
+
 ## Plan lookup
 
 The MCP `userId` is the SHA-256 hash of the normalized account email

--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -119,11 +119,13 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 			'email_verified',
 			'email_verified_at',
 			'id',
+			'plan',
 			'roles',
 			'updated_at',
 			'username',
 		].sort(),
 	)
+	expect(memberRecord.plan).toBe(null)
 	expect(JSON.stringify(memberRecord)).not.toContain('memberPrivateSecret')
 	expect(JSON.stringify(memberRecord)).not.toContain('super-secret-value')
 
@@ -145,6 +147,21 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	await page.goto(`/admin/users?pageSize=100&page=${lastUsersPage}`)
 	await page.getByRole('button', { name: memberUser.username }).click()
 	await expect(page.getByText('Account metadata only')).toBeVisible()
+
+	const planSelect = page.getByLabel('Plan')
+	await expect(planSelect).toHaveValue('')
+	await planSelect.selectOption('pro')
+	await page.getByRole('button', { name: 'Save plan' }).click()
+	await expect(page.getByText('Updated plan to pro.')).toBeVisible()
+	const planApiResponse = await page.request.get(
+		`/admin/users.json?pageSize=100&page=${lastUsersPage}`,
+	)
+	expect(planApiResponse.ok()).toBe(true)
+	const planPayload = await planApiResponse.json()
+	const memberAfterPlan = planPayload.users.find(
+		(user: { email: string }) => user.email === memberUser.email,
+	)
+	expect(memberAfterPlan.plan).toBe('pro')
 
 	const roleSelect = page.getByLabel('Role')
 	await roleSelect.selectOption('admin')

--- a/packages/worker/client/navigation-data.node.test.ts
+++ b/packages/worker/client/navigation-data.node.test.ts
@@ -115,6 +115,7 @@ test('preloaded navigation data is consumed once for matching hrefs and replaced
 			pageSize: 25,
 			total: 0,
 			availableRoles: [],
+			availablePlans: [],
 		},
 	}
 	setPreloadedNavigationData('/account', payload)

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -28,6 +28,7 @@ import {
 } from './account-management-components.tsx'
 import { type RoleName } from '#app/permissions.ts'
 import {
+	type AdminPlanName,
 	type AdminUserListItem,
 	type AdminUsersLoaderData,
 } from '#app/loader-data.ts'
@@ -78,13 +79,18 @@ export function AdminUsersRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
 	let users: Array<AdminUserListItem> = []
 	let availableRoles: Array<RoleName> = []
+	let availablePlans: Array<AdminPlanName> = []
 	let page = 1
 	let pageSize = 20
 	let total = 0
 	let selectedUserId: number | null = null
 	let message: string | null = null
-	let actionState: 'idle' | 'assigning' | 'removing' = 'idle'
+	let actionState: 'idle' | 'assigning' | 'removing' | 'saving-plan' = 'idle'
 	let selectedRoleToAssign = 'user' as RoleName
+	// '' represents the NULL plan (legacy/unlimited). The draft follows the
+	// selected user (see the render body) until the admin edits it.
+	let selectedPlanChoice: AdminPlanName | '' = ''
+	let planDraftUserId: number | null = null
 	let loadRequestId = 0
 	let lastLoadedHref = ''
 	let loadingForHref: string | null = null
@@ -121,6 +127,7 @@ export function AdminUsersRoute(handle: Handle) {
 			}
 			users = payload.users
 			availableRoles = payload.availableRoles
+			availablePlans = payload.availablePlans
 			page = payload.page
 			pageSize = payload.pageSize
 			total = payload.total
@@ -186,6 +193,7 @@ export function AdminUsersRoute(handle: Handle) {
 			}
 			users = payload.users
 			availableRoles = payload.availableRoles
+			availablePlans = payload.availablePlans
 			page = payload.page
 			pageSize = payload.pageSize
 			total = payload.total
@@ -206,6 +214,61 @@ export function AdminUsersRoute(handle: Handle) {
 		}
 	}
 
+	async function submitPlanAction() {
+		const selectedUser = getSelectedUser()
+		if (!selectedUser || actionState !== 'idle') return
+		const plan = selectedPlanChoice === '' ? null : selectedPlanChoice
+		actionState = 'saving-plan'
+		message = null
+		handle.update()
+		try {
+			// Carry the current query string so the server rebuilds the same
+			// page/pageSize slice the user is viewing, not page one.
+			const search = new URL(readCurrentRouterHref(handle), 'http://localhost')
+				.search
+			const response = await fetch(`${adminUsersApiPath}${search}`, {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				credentials: 'include',
+				body: JSON.stringify({
+					action: 'update_plan',
+					userId: selectedUser.id,
+					plan,
+				}),
+			})
+			if (response.status === 401) {
+				window.location.assign('/login')
+				return
+			}
+			const payload = await readJson<
+				AdminUsersLoaderData & { ok?: boolean; error?: string }
+			>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error(payload?.error || 'Unable to update user plan.')
+			}
+			users = payload.users
+			availableRoles = payload.availableRoles
+			availablePlans = payload.availablePlans
+			page = payload.page
+			pageSize = payload.pageSize
+			total = payload.total
+			selectedUserId = selectedUser.id
+			lastLoadedHref = readCurrentRouterHref(handle)
+			message = `Updated plan to ${plan ?? 'legacy/unlimited'}.`
+			status = 'ready'
+			actionState = 'idle'
+			handle.update()
+		} catch (error) {
+			actionState = 'idle'
+			message =
+				error instanceof Error ? error.message : 'Unable to update user plan.'
+			handle.update()
+		}
+	}
+
 	const primaryButtonCss = getPrimaryButtonCss()
 	const secondaryButtonCss = getSecondaryButtonCss()
 
@@ -215,6 +278,7 @@ export function AdminUsersRoute(handle: Handle) {
 		if (!routeData) return false
 		users = routeData.users
 		availableRoles = routeData.availableRoles
+		availablePlans = routeData.availablePlans
 		page = routeData.page
 		pageSize = routeData.pageSize
 		total = routeData.total
@@ -268,11 +332,18 @@ export function AdminUsersRoute(handle: Handle) {
 		const selectedUser = getSelectedUser()
 		const isMutating = actionState !== 'idle'
 
+		// Re-seed the plan draft whenever a different user becomes selected so
+		// the select always starts from that user's stored plan.
+		if (selectedUser && selectedUser.id !== planDraftUserId) {
+			planDraftUserId = selectedUser.id
+			selectedPlanChoice = selectedUser.plan ?? ''
+		}
+
 		return (
 			<AccountManagementShell>
 				<AdminPageHeader
 					title="Admin users"
-					description="Review account metadata and manage role assignments. User content is never shown here."
+					description="Review account metadata and manage role assignments and entitlement plans. User content is never shown here."
 					currentHref={currentHref}
 				/>
 				{status === 'loading' ? (
@@ -416,6 +487,10 @@ export function AdminUsersRoute(handle: Handle) {
 													: 'None',
 										},
 										{
+											label: 'Plan',
+											value: selectedUser.plan ?? 'Legacy/unlimited',
+										},
+										{
 											label: 'Created',
 											value: formatTimestamp(selectedUser.created_at),
 										},
@@ -479,6 +554,55 @@ export function AdminUsersRoute(handle: Handle) {
 											]}
 										>
 											{actionState === 'removing' ? 'Removing…' : 'Remove'}
+										</button>
+									</div>
+								</AccountManagementPanel>
+								<AccountManagementPanel title="Manage plan">
+									<div
+										mix={css({
+											display: 'grid',
+											gap: spacing.md,
+											gridTemplateColumns: 'minmax(0, 1fr) auto',
+											alignItems: 'end',
+											[mq.mobile]: { gridTemplateColumns: '1fr' },
+										})}
+									>
+										<label mix={css(fieldCss)}>
+											<span mix={css(fieldLabelCss)}>Plan</span>
+											<select
+												value={selectedPlanChoice}
+												disabled={isMutating}
+												aria-label="Plan"
+												mix={[
+													on('change', (event) => {
+														selectedPlanChoice = event.currentTarget.value as
+															| AdminPlanName
+															| ''
+														handle.update()
+													}),
+													css(inputCss),
+												]}
+											>
+												<option value="">Legacy/unlimited (no plan)</option>
+												{availablePlans.map((plan) => (
+													<option key={plan} value={plan}>
+														{plan}
+													</option>
+												))}
+											</select>
+										</label>
+										<button
+											type="button"
+											disabled={
+												isMutating ||
+												selectedPlanChoice === (selectedUser.plan ?? '')
+											}
+											mix={[
+												on('click', () => void submitPlanAction()),
+												css(primaryButtonCss),
+											]}
+										>
+											{actionState === 'saving-plan' ? 'Saving…' : 'Save plan'}
 										</button>
 									</div>
 								</AccountManagementPanel>

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -100,6 +100,13 @@ export function AdminUsersRoute(handle: Handle) {
 		return users.find((user) => user.id === selectedUserId) ?? null
 	}
 
+	// Any refresh of `users` may carry a newer stored plan, so drop the
+	// unsaved draft and let the render pass reseed the select from the
+	// refreshed record.
+	function resetPlanDraft() {
+		planDraftUserId = null
+	}
+
 	async function loadAdminUsers() {
 		const href = readCurrentRouterHref(handle)
 		loadingForHref = href
@@ -131,6 +138,7 @@ export function AdminUsersRoute(handle: Handle) {
 			page = payload.page
 			pageSize = payload.pageSize
 			total = payload.total
+			resetPlanDraft()
 			lastLoadedHref = href
 			if (
 				selectedUserId != null &&
@@ -197,6 +205,7 @@ export function AdminUsersRoute(handle: Handle) {
 			page = payload.page
 			pageSize = payload.pageSize
 			total = payload.total
+			resetPlanDraft()
 			selectedUserId = selectedUser.id
 			lastLoadedHref = readCurrentRouterHref(handle)
 			message =
@@ -255,6 +264,7 @@ export function AdminUsersRoute(handle: Handle) {
 			page = payload.page
 			pageSize = payload.pageSize
 			total = payload.total
+			resetPlanDraft()
 			selectedUserId = selectedUser.id
 			lastLoadedHref = readCurrentRouterHref(handle)
 			message = `Updated plan to ${plan ?? 'legacy/unlimited'}.`
@@ -282,6 +292,7 @@ export function AdminUsersRoute(handle: Handle) {
 		page = routeData.page
 		pageSize = routeData.pageSize
 		total = routeData.total
+		resetPlanDraft()
 		lastLoadedHref = href
 		if (
 			selectedUserId != null &&

--- a/packages/worker/src/app/admin-users-data.ts
+++ b/packages/worker/src/app/admin-users-data.ts
@@ -1,6 +1,12 @@
+import { utcSqliteTimestamp } from '@kody-internal/shared/date-keys.ts'
 import { readPagination } from '#app/query-params.ts'
 import { type AdminUsersLoaderData } from '#app/loader-data.ts'
 import { type RoleName, roleNames } from '#app/permissions.ts'
+import {
+	parsePlanName,
+	planNames,
+	type PlanName,
+} from '#worker/entitlements/plans.ts'
 import {
 	chunkArray,
 	maxD1BoundParameters,
@@ -12,6 +18,7 @@ export const adminUserListItemFieldNames = [
 	'email',
 	'email_verified',
 	'email_verified_at',
+	'plan',
 	'created_at',
 	'updated_at',
 	'roles',
@@ -26,6 +33,7 @@ export type AdminUserListItem = Record<AdminUserListItemFieldName, unknown> & {
 	email: string
 	email_verified: boolean
 	email_verified_at: string | null
+	plan: PlanName | null
 	created_at: string
 	updated_at: string
 	roles: Array<RoleName>
@@ -49,20 +57,13 @@ export async function loadAdminUsersData(
 			total: number
 		}>(),
 		env.APP_DB.prepare(
-			`SELECT id, username, email, email_verified_at, created_at, updated_at
+			`SELECT id, username, email, email_verified_at, plan, created_at, updated_at
 			 FROM users
 			 ORDER BY id ASC
 			 LIMIT ? OFFSET ?`,
 		)
 			.bind(pageSize, offset)
-			.all<{
-				id: number
-				username: string
-				email: string
-				email_verified_at: string | null
-				created_at: string
-				updated_at: string
-			}>(),
+			.all<AdminUserRow>(),
 	])
 	const total = totalResult?.total ?? 0
 
@@ -78,6 +79,7 @@ export async function loadAdminUsersData(
 		pageSize,
 		total,
 		availableRoles: [...roleNames],
+		availablePlans: [...planNames],
 	}
 }
 
@@ -89,40 +91,46 @@ export async function loadAdminUserByIdOrEmail(
 	const userRow = input.id
 		? await db
 				.prepare(
-					`SELECT id, username, email, email_verified_at, created_at, updated_at
+					`SELECT id, username, email, email_verified_at, plan, created_at, updated_at
 					 FROM users
 					 WHERE id = ?`,
 				)
 				.bind(input.id)
-				.first<{
-					id: number
-					username: string
-					email: string
-					email_verified_at: string | null
-					created_at: string
-					updated_at: string
-				}>()
+				.first<AdminUserRow>()
 		: email
 			? await db
 					.prepare(
-						`SELECT id, username, email, email_verified_at, created_at, updated_at
+						`SELECT id, username, email, email_verified_at, plan, created_at, updated_at
 						 FROM users
 						 WHERE email = ? COLLATE NOCASE`,
 					)
 					.bind(email)
-					.first<{
-						id: number
-						username: string
-						email: string
-						email_verified_at: string | null
-						created_at: string
-						updated_at: string
-					}>()
+					.first<AdminUserRow>()
 			: null
 	if (!userRow) return null
 
 	const rolesByUserId = await loadRolesByUserIds(db, [userRow.id])
 	return toAdminUserListItem(userRow, rolesByUserId.get(userRow.id) ?? [])
+}
+
+/**
+ * Set or clear (null = legacy/unlimited) the entitlement plan on one user
+ * account. Returns the updated account metadata record, or null when no
+ * user matches `id`/`email`.
+ */
+export async function updateAdminUserPlan(
+	db: D1Database,
+	input: { id?: number; email?: string; plan: PlanName | null },
+): Promise<AdminUserListItem | null> {
+	const existing = await loadAdminUserByIdOrEmail(db, input)
+	if (!existing) return null
+
+	await db
+		.prepare(`UPDATE users SET plan = ?, updated_at = ? WHERE id = ?`)
+		.bind(input.plan, utcSqliteTimestamp(), existing.id)
+		.run()
+
+	return loadAdminUserByIdOrEmail(db, { id: existing.id })
 }
 
 export async function loadRolesByUserIds(
@@ -160,15 +168,18 @@ export async function loadRolesByUserIds(
 	return rolesByUserId
 }
 
+type AdminUserRow = {
+	id: number
+	username: string
+	email: string
+	email_verified_at: string | null
+	plan: string | null
+	created_at: string
+	updated_at: string
+}
+
 function toAdminUserListItem(
-	row: {
-		id: number
-		username: string
-		email: string
-		email_verified_at: string | null
-		created_at: string
-		updated_at: string
-	},
+	row: AdminUserRow,
 	roles: Array<RoleName>,
 ): AdminUserListItem {
 	return {
@@ -177,6 +188,7 @@ function toAdminUserListItem(
 		email: row.email,
 		email_verified: Boolean(row.email_verified_at),
 		email_verified_at: row.email_verified_at,
+		plan: parsePlanName(row.plan),
 		created_at: row.created_at,
 		updated_at: row.updated_at,
 		roles,

--- a/packages/worker/src/app/handlers/admin-users.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-users.node.test.ts
@@ -22,6 +22,7 @@ type UserRow = {
 	username: string
 	email: string
 	email_verified_at?: string | null
+	plan?: string | null
 	created_at: string
 	updated_at: string
 }
@@ -124,6 +125,14 @@ function createAdminTestEnv(input: {
 								}
 								if (
 									normalizedQuery.includes(
+										'select id, username, email, email_verified_at, plan, created_at, updated_at from users where id =',
+									)
+								) {
+									const user = users.get(Number(params[0]))
+									return user ? ({ ...user } as T) : null
+								}
+								if (
+									normalizedQuery.includes(
 										'count(distinct ur.user_id) as count',
 									)
 								) {
@@ -185,6 +194,17 @@ function createAdminTestEnv(input: {
 									if (index >= 0) userRoles.splice(index, 1)
 									return { meta: { changes: 1 } }
 								}
+								if (
+									normalizedQuery.includes(
+										'update users set plan = ?, updated_at = ? where id =',
+									)
+								) {
+									const user = users.get(Number(params[2]))
+									if (!user) return { meta: { changes: 0 } }
+									user.plan = params[0] === null ? null : String(params[0])
+									user.updated_at = String(params[1])
+									return { meta: { changes: 1 } }
+								}
 								return { meta: { changes: 0 } }
 							},
 						}
@@ -208,6 +228,7 @@ test('admin users list payload exposes only account metadata fields', async () =
 				username: 'admin-user',
 				email: 'admin@example.com',
 				email_verified_at: '2026-01-01T00:00:00.000Z',
+				plan: 'pro',
 				created_at: '2026-01-01 00:00:00',
 				updated_at: '2026-01-02 00:00:00',
 			},
@@ -216,6 +237,7 @@ test('admin users list payload exposes only account metadata fields', async () =
 				username: 'member',
 				email: 'member@example.com',
 				email_verified_at: null,
+				plan: 'not-a-real-plan',
 				created_at: '2026-01-03 00:00:00',
 				updated_at: '2026-01-04 00:00:00',
 			},
@@ -238,7 +260,15 @@ test('admin users list payload exposes only account metadata fields', async () =
 	expect(response.status).toBe(200)
 	const payload = await response.json()
 	expect(Object.keys(payload).sort()).toEqual(
-		['availableRoles', 'ok', 'page', 'pageSize', 'total', 'users'].sort(),
+		[
+			'availablePlans',
+			'availableRoles',
+			'ok',
+			'page',
+			'pageSize',
+			'total',
+			'users',
+		].sort(),
 	)
 	for (const user of payload.users) {
 		expect(Object.keys(user).sort()).toEqual(
@@ -250,11 +280,14 @@ test('admin users list payload exposes only account metadata fields', async () =
 			email: 'admin@example.com',
 			email_verified: true,
 			email_verified_at: '2026-01-01T00:00:00.000Z',
+			plan: 'pro',
 		}),
 		expect.objectContaining({
 			email: 'member@example.com',
 			email_verified: false,
 			email_verified_at: null,
+			// Unknown stored plan values read back as null (legacy/unlimited).
+			plan: null,
 		}),
 	])
 })
@@ -400,6 +433,162 @@ test('remove role removes admin when another admin remains', async () => {
 			result: 'success',
 		}),
 	)
+})
+
+test('update plan action sets the plan and logs an audit event', async () => {
+	mockModule.logAuditEvent.mockClear()
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(
+		createAdminActor(['admin']),
+	)
+	const env = createAdminTestEnv({
+		users: [
+			{
+				id: 2,
+				username: 'member',
+				email: 'member@example.com',
+				plan: null,
+				created_at: '2026-01-03 00:00:00',
+				updated_at: '2026-01-04 00:00:00',
+			},
+		],
+		userRoles: [{ user_id: 2, role_name: 'user' }],
+	})
+
+	const handler = createAdminUsersApiHandler(env as unknown as Env)
+	const response = await handler.handler({
+		request: new Request('https://example.com/admin/users.json', {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				action: 'update_plan',
+				userId: 2,
+				plan: 'personal',
+			}),
+		}),
+		params: {},
+		url: new URL('https://example.com/admin/users.json'),
+	} as never)
+
+	expect(response.status).toBe(200)
+	const payload = await response.json()
+	expect(payload.users[0].plan).toBe('personal')
+	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'admin',
+			action: 'update_plan',
+			result: 'success',
+			reason: 'target_user_id=2;plan=personal',
+		}),
+	)
+})
+
+test('update plan action clears the plan with explicit null', async () => {
+	mockModule.logAuditEvent.mockClear()
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(
+		createAdminActor(['admin']),
+	)
+	const env = createAdminTestEnv({
+		users: [
+			{
+				id: 2,
+				username: 'member',
+				email: 'member@example.com',
+				plan: 'pro',
+				created_at: '2026-01-03 00:00:00',
+				updated_at: '2026-01-04 00:00:00',
+			},
+		],
+		userRoles: [{ user_id: 2, role_name: 'user' }],
+	})
+
+	const handler = createAdminUsersApiHandler(env as unknown as Env)
+	const response = await handler.handler({
+		request: new Request('https://example.com/admin/users.json', {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ action: 'update_plan', userId: 2, plan: null }),
+		}),
+		params: {},
+		url: new URL('https://example.com/admin/users.json'),
+	} as never)
+
+	expect(response.status).toBe(200)
+	const payload = await response.json()
+	expect(payload.users[0].plan).toBe(null)
+	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'admin',
+			action: 'update_plan',
+			result: 'success',
+			reason: 'target_user_id=2;plan=null',
+		}),
+	)
+})
+
+test('update plan action rejects unknown plan values and missing plan key', async () => {
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(
+		createAdminActor(['admin']),
+	)
+	const env = createAdminTestEnv({
+		users: [
+			{
+				id: 2,
+				username: 'member',
+				email: 'member@example.com',
+				plan: 'pro',
+				created_at: '2026-01-03 00:00:00',
+				updated_at: '2026-01-04 00:00:00',
+			},
+		],
+		userRoles: [{ user_id: 2, role_name: 'user' }],
+	})
+	const handler = createAdminUsersApiHandler(env as unknown as Env)
+
+	for (const body of [
+		{ action: 'update_plan', userId: 2, plan: 'enterprise' },
+		{ action: 'update_plan', userId: 2 },
+	]) {
+		const response = await handler.handler({
+			request: new Request('https://example.com/admin/users.json', {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify(body),
+			}),
+			params: {},
+			url: new URL('https://example.com/admin/users.json'),
+		} as never)
+		expect(response.status).toBe(400)
+	}
+})
+
+test('update plan action returns 404 for an unknown user', async () => {
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(
+		createAdminActor(['admin']),
+	)
+	const env = createAdminTestEnv({ users: [], userRoles: [] })
+	const handler = createAdminUsersApiHandler(env as unknown as Env)
+	const response = await handler.handler({
+		request: new Request('https://example.com/admin/users.json', {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ action: 'update_plan', userId: 42, plan: 'pro' }),
+		}),
+		params: {},
+		url: new URL('https://example.com/admin/users.json'),
+	} as never)
+	expect(response.status).toBe(404)
 })
 
 test('admin users API returns 403 without read:user:any permission', async () => {

--- a/packages/worker/src/app/handlers/admin-users.ts
+++ b/packages/worker/src/app/handlers/admin-users.ts
@@ -6,8 +6,10 @@ import {
 	loadAdminUsersData,
 	loadRolesByUserIds,
 	adminUserListItemFieldNames,
+	updateAdminUserPlan,
 	type AdminUserListItem,
 } from '#app/admin-users-data.ts'
+import { parsePlanName, type PlanName } from '#worker/entitlements/plans.ts'
 import { readAuthSessionResult } from '#app/auth-session.ts'
 import { redirectToLogin } from '#app/auth-redirect.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
@@ -106,6 +108,15 @@ export function createAdminUsersApiHandler(env: Env) {
 				}
 				if (action === 'remove_role') {
 					return handleRemoveRoleAction({
+						env,
+						request,
+						url,
+						actor,
+						body,
+					})
+				}
+				if (action === 'update_plan') {
+					return handleUpdatePlanAction({
 						env,
 						request,
 						url,
@@ -255,6 +266,70 @@ async function handleRemoveRoleAction(input: {
 
 	const payload = await loadAdminUsersData(input.env, input.request.url)
 	return jsonResponse(payload)
+}
+
+async function handleUpdatePlanAction(input: {
+	env: Env
+	request: Request
+	url: URL
+	actor: Awaited<ReturnType<typeof requireUserWithPermission>>
+	body: object
+}) {
+	const targetUserId = readPositiveInt(readString(input.body, 'userId'), 0)
+	if (!targetUserId) {
+		return jsonResponse({ ok: false, error: 'User id is required.' }, 400)
+	}
+	const planUpdate = readPlanUpdate(input.body)
+	if (!planUpdate.ok) {
+		return jsonResponse(
+			{
+				ok: false,
+				error:
+					'Plan must be one of the known plan names, or null to clear the plan.',
+			},
+			400,
+		)
+	}
+
+	const updatedUser = await updateAdminUserPlan(input.env.APP_DB, {
+		id: targetUserId,
+		plan: planUpdate.plan,
+	})
+	if (!updatedUser) {
+		return jsonResponse({ ok: false, error: 'User not found.' }, 404)
+	}
+
+	const requestIp = getRequestIp(input.request) ?? undefined
+	void logAuditEvent({
+		category: 'admin',
+		action: 'update_plan',
+		result: 'success',
+		email: input.actor.email,
+		ip: requestIp,
+		path: input.url.pathname,
+		reason: `target_user_id=${targetUserId};plan=${planUpdate.plan ?? 'null'}`,
+	})
+
+	const payload = await loadAdminUsersData(input.env, input.request.url)
+	return jsonResponse(payload)
+}
+
+/**
+ * Read the requested plan value: a known plan name sets it, explicit null
+ * clears it (legacy/unlimited). Anything else — including a missing key or
+ * an unknown plan string — is rejected instead of being coerced to null.
+ */
+function readPlanUpdate(
+	body: object,
+): { ok: true; plan: PlanName | null } | { ok: false } {
+	if (!('plan' in body)) return { ok: false }
+	const value = (body as Record<string, unknown>).plan
+	if (value === null) return { ok: true, plan: null }
+	if (typeof value === 'string') {
+		const plan = parsePlanName(value.trim())
+		if (plan) return { ok: true, plan }
+	}
+	return { ok: false }
 }
 
 function isRoleName(value: string): value is RoleName {

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -34,6 +34,7 @@ export type AdminUserListItem = {
 	email: string
 	email_verified: boolean
 	email_verified_at: string | null
+	plan: AdminPlanName | null
 	created_at: string
 	updated_at: string
 	roles: Array<RoleName>
@@ -46,6 +47,7 @@ export type AdminUsersLoaderData = {
 	pageSize: number
 	total: number
 	availableRoles: Array<RoleName>
+	availablePlans: Array<AdminPlanName>
 }
 
 export type AdminRoleListItem = {
@@ -118,7 +120,7 @@ export type AdminUsageEntitlementResource =
 	| 'concurrent_workflows'
 	| 'storage_bytes'
 
-export type AdminUsagePlanName = 'partner' | 'personal' | 'pro'
+export type AdminPlanName = 'partner' | 'personal' | 'pro'
 
 export type AdminUsageRollup = {
 	metric: AdminUsageMetric
@@ -159,7 +161,7 @@ export type AdminUsageUserSummary = {
 	id: number
 	username: string
 	email: string
-	plan: AdminUsagePlanName | null
+	plan: AdminPlanName | null
 	currentMonthUsage: Array<AdminUsageRollup>
 	todayCounters: Array<AdminUsageDailyCounter>
 	resourceCounts: Array<AdminUsageResourceCount>

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -6,7 +6,9 @@ import {
 } from './errors.ts'
 import {
 	nullPlanEmailFallbackLimits,
+	parsePlanName,
 	planLimits,
+	planNames,
 	resolvePlanLimit,
 } from './plans.ts'
 import {
@@ -129,6 +131,18 @@ function createEntitlementsTestDb(
 }
 
 const plannedEmail = 'planned@example.com'
+
+test('parsePlanName accepts registered plan names and treats everything else as null', () => {
+	for (const plan of planNames) {
+		expect(parsePlanName(plan)).toBe(plan)
+	}
+	expect(parsePlanName('enterprise')).toBeNull()
+	expect(parsePlanName(' pro ')).toBeNull()
+	expect(parsePlanName('')).toBeNull()
+	expect(parsePlanName(null)).toBeNull()
+	expect(parsePlanName(undefined)).toBeNull()
+	expect(parsePlanName(1)).toBeNull()
+})
 
 test('getUserPlan resolves plans through hashed email and short-circuits invalid lookups', async () => {
 	const userId = await createStableUserIdFromEmail(plannedEmail)

--- a/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
@@ -7,6 +7,7 @@ import { adminUsageOverviewCapability } from './admin-usage-overview.ts'
 import { adminUserCreateCapability } from './admin-user-create.ts'
 import { adminUserGetCapability } from './admin-user-get.ts'
 import { adminUserListCapability } from './admin-user-list.ts'
+import { adminUserUpdateCapability } from './admin-user-update.ts'
 
 type UserRow = {
 	id: number
@@ -158,7 +159,7 @@ function createAdminCapabilityTestDb(input: {
 					}
 					if (
 						normalizedQuery.includes(
-							'select id, username, email, email_verified_at, created_at, updated_at from users where id = ?',
+							'select id, username, email, email_verified_at, plan, created_at, updated_at from users where id = ?',
 						)
 					) {
 						return (users.find((user) => user.id === params[0]) ??
@@ -174,7 +175,7 @@ function createAdminCapabilityTestDb(input: {
 					}
 					if (
 						normalizedQuery.includes(
-							'select id, username, email, email_verified_at, created_at, updated_at from users where email = ? collate nocase',
+							'select id, username, email, email_verified_at, plan, created_at, updated_at from users where email = ? collate nocase',
 						)
 					) {
 						const email = String(params[0]).toLowerCase()
@@ -250,7 +251,7 @@ function createAdminCapabilityTestDb(input: {
 				async all<T>() {
 					if (
 						normalizedQuery.includes(
-							'select id, username, email, email_verified_at, created_at, updated_at from users order by id asc limit ? offset ?',
+							'select id, username, email, email_verified_at, plan, created_at, updated_at from users order by id asc limit ? offset ?',
 						)
 					) {
 						const pageSize = Number(params[0])
@@ -397,6 +398,17 @@ function createAdminCapabilityTestDb(input: {
 							expires_at: Number(expiresAt),
 						})
 						return { meta: { changes: 1, last_row_id: 1 } }
+					}
+					if (
+						normalizedQuery.includes(
+							'update users set plan = ?, updated_at = ? where id = ?',
+						)
+					) {
+						const user = users.find((row) => row.id === Number(params[2]))
+						if (!user) return { meta: { changes: 0, last_row_id: 0 } }
+						user.plan = params[0] === null ? null : String(params[0])
+						user.updated_at = String(params[1])
+						return { meta: { changes: 1, last_row_id: 0 } }
 					}
 					if (normalizedQuery.startsWith('delete from users')) {
 						const userId = Number(params[0])
@@ -662,6 +674,103 @@ test('admin_user_create records audit metadata and assigns the default role', as
 	])
 })
 
+test('admin_user_update sets and clears the entitlement plan with audit metadata', async () => {
+	const { db, auditEvents, users } = createAdminCapabilityTestDb({
+		users: [
+			{
+				id: 1,
+				username: 'admin',
+				email: 'admin@example.com',
+				created_at: '2026-01-01 00:00:00',
+				updated_at: '2026-01-02 00:00:00',
+			},
+			{
+				id: 2,
+				username: 'jane',
+				email: 'jane@example.com',
+				email_verified_at: null,
+				plan: null,
+				created_at: '2026-01-03 00:00:00',
+				updated_at: '2026-01-04 00:00:00',
+			},
+		],
+		userRoles: [
+			{ user_id: 1, role_name: 'admin' },
+			{ user_id: 2, role_name: 'user' },
+		],
+	})
+	const ctx = createAdminCapabilityContext(db)
+
+	const setByEmail = await adminUserUpdateCapability.handler(
+		{ email: 'JANE@example.com', plan: 'pro' },
+		ctx,
+	)
+	expect(setByEmail.user).toMatchObject({
+		id: 2,
+		username: 'jane',
+		plan: 'pro',
+		roles: ['user'],
+	})
+	expect(users.find((user) => user.id === 2)?.plan).toBe('pro')
+
+	const clearById = await adminUserUpdateCapability.handler(
+		{ id: 2, plan: null },
+		ctx,
+	)
+	expect(clearById.user).toMatchObject({ id: 2, plan: null })
+	expect(users.find((user) => user.id === 2)?.plan).toBe(null)
+
+	expect(auditEvents).toEqual([
+		expect.objectContaining({
+			action: 'admin_user_update',
+			result: 'success',
+			reason: 'target_user_id=2;plan=pro',
+		}),
+		expect.objectContaining({
+			action: 'admin_user_update',
+			result: 'success',
+			reason: 'target_user_id=2;plan=null',
+		}),
+	])
+})
+
+test('admin_user_update rejects unknown users and unknown plan names', async () => {
+	const { db, auditEvents } = createAdminCapabilityTestDb({
+		users: [
+			{
+				id: 1,
+				username: 'admin',
+				email: 'admin@example.com',
+				created_at: '2026-01-01 00:00:00',
+				updated_at: '2026-01-02 00:00:00',
+			},
+		],
+		userRoles: [{ user_id: 1, role_name: 'admin' }],
+	})
+	const ctx = createAdminCapabilityContext(db)
+
+	await expect(
+		adminUserUpdateCapability.handler(
+			{ email: 'missing@example.com', plan: 'pro' },
+			ctx,
+		),
+	).rejects.toThrow('User not found.')
+	expect(auditEvents).toEqual([
+		expect.objectContaining({
+			action: 'admin_user_update',
+			result: 'failure',
+			reason: 'User not found.',
+		}),
+	])
+
+	await expect(
+		adminUserUpdateCapability.handler(
+			{ id: 1, plan: 'enterprise' } as never,
+			ctx,
+		),
+	).rejects.toThrow()
+})
+
 test('admin capabilities reject non-admin direct handler calls', async () => {
 	const { db } = createAdminCapabilityTestDb({
 		users: [],
@@ -704,5 +813,24 @@ test('admin capabilities reject non-admin direct handler calls', async () => {
 		),
 	).rejects.toThrow(
 		'MCP user lacks required role "admin" for capability "admin_system_email_list".',
+	)
+	await expect(
+		adminUserUpdateCapability.handler(
+			{ id: 1, plan: 'pro' },
+			{
+				env: { APP_DB: db } as Env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://example.com',
+					user: {
+						userId: 'user-1',
+						email: 'user@example.com',
+						displayName: 'user',
+						roles: ['user'],
+					},
+				}),
+			},
+		),
+	).rejects.toThrow(
+		'MCP user lacks required role "admin" for capability "admin_user_update".',
 	)
 })

--- a/packages/worker/src/mcp/capabilities/admin/admin-shared.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-shared.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { logAuditEvent, redactEmailRecipient } from '#app/audit-log.ts'
 import { roleNames } from '#app/permissions.ts'
+import { planNames } from '#worker/entitlements/plans.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 
 export const adminCapabilityAccess = {
@@ -19,6 +20,8 @@ export const adminMutationCapabilityAccess = {
 
 export const roleNameSchema = z.enum(roleNames)
 
+export const planNameSchema = z.enum(planNames)
+
 export const adminUserMetadataSchema = z.object({
 	id: z.number().int().positive(),
 	username: z.string(),
@@ -30,6 +33,11 @@ export const adminUserMetadataSchema = z.object({
 		.string()
 		.nullable()
 		.describe('Raw users.email_verified_at timestamp, or null if unverified.'),
+	plan: planNameSchema
+		.nullable()
+		.describe(
+			'Entitlement plan, or null for legacy/unlimited (no entitlement enforcement).',
+		),
 	created_at: z.string(),
 	updated_at: z.string(),
 	roles: z.array(roleNameSchema),

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-update.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-update.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod'
+import { updateAdminUserPlan } from '#app/admin-users-data.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	adminMutationCapabilityAccess,
+	adminUserMetadataSchema,
+	auditAdminCapabilityInvocation,
+	planNameSchema,
+} from './admin-shared.ts'
+
+const inputSchema = z
+	.object({
+		id: z
+			.number()
+			.int()
+			.positive()
+			.optional()
+			.describe('Numeric users.id to update.'),
+		email: z.string().email().optional().describe('Email address to update.'),
+		plan: planNameSchema
+			.nullable()
+			.describe(
+				'Entitlement plan to set, or null to clear the plan (legacy/unlimited: no entitlement enforcement).',
+			),
+	})
+	.refine((value) => value.id !== undefined || value.email !== undefined, {
+		message: 'Provide either id or email.',
+	})
+
+const outputSchema = z.object({
+	user: adminUserMetadataSchema,
+})
+
+export const adminUserUpdateCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminMutationCapabilityAccess,
+		name: 'admin_user_update',
+		description:
+			'Update account metadata for one user by id or email. Supports setting or clearing the entitlement plan. Admin-only; never touches user content.',
+		keywords: ['admin', 'user', 'update', 'account', 'plan', 'entitlements'],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_user_update',
+				async () => {
+					const user = await updateAdminUserPlan(ctx.env.APP_DB, {
+						id: args.id,
+						email: args.email,
+						plan: args.plan,
+					})
+					if (!user) {
+						throw new Error('User not found.')
+					}
+					return { user }
+				},
+				{
+					successReason: ({ user }) =>
+						`target_user_id=${user.id};plan=${user.plan ?? 'null'}`,
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/domain.ts
+++ b/packages/worker/src/mcp/capabilities/admin/domain.ts
@@ -7,6 +7,7 @@ import { adminSystemEmailListCapability } from './admin-system-email-list.ts'
 import { adminUserCreateCapability } from './admin-user-create.ts'
 import { adminUserGetCapability } from './admin-user-get.ts'
 import { adminUserListCapability } from './admin-user-list.ts'
+import { adminUserUpdateCapability } from './admin-user-update.ts'
 
 export const adminDomain = defineDomain({
 	name: capabilityDomainNames.admin,
@@ -18,6 +19,7 @@ export const adminDomain = defineDomain({
 		'account metadata',
 		'users',
 		'roles',
+		'plans',
 		'audit',
 		'system email',
 	],
@@ -25,6 +27,7 @@ export const adminDomain = defineDomain({
 		adminUserListCapability,
 		adminUserGetCapability,
 		adminUserCreateCapability,
+		adminUserUpdateCapability,
 		adminAuditLogQueryCapability,
 		adminUsageOverviewCapability,
 		adminSystemEmailListCapability,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Admins can now modify a user account record's entitlement plan — previously the only way to set `users.plan` was a manual SQL update.

- **Users admin API** — `POST /admin/users.json` gains an `update_plan` action (guarded by `update:user:any`) that sets or clears (`plan: null` → legacy/unlimited) a user's plan. Unknown plan strings are rejected with `400` rather than coerced to null. Success writes an `admin`-category audit event with reason `target_user_id=…;plan=…`.
- **MCP** — new `admin_user_update` capability (admin domain, `requiredRole: 'admin'`, audited via `auditAdminCapabilityInvocation`) updates one user by `id` or `email` with `plan: PlanName | null` and returns the updated account metadata record.
- **Admin UI** — `/admin/users` shows the plan in the metadata grid and adds a "Manage plan" panel with a plan select (including "Legacy/unlimited (no plan)") and a Save button that stays disabled while the selection matches the stored plan.
- **Payload shape** — the admin users API/MCP metadata now includes `plan` (validated through `parsePlanName`, so unknown stored values read back as `null`) and `availablePlans`; the privacy-boundary field pin and its tests were widened accordingly.

Username editing was deliberately left out: usernames drive `{username}@<platform domain>` email routing and public identity lookups, so an admin rename has side effects beyond account metadata.

## Testing

- Unit: `update_plan` handler actions (set / clear / invalid plan 400 / unknown user 404 / audit reasons), `admin_user_update` MCP capability (set/clear by email/id, audit rows, non-admin rejection, unknown-plan rejection), and `parsePlanName` parsing.
- E2E: `admin-rbac.spec.ts` now changes a plan through the UI, asserts the success message, and verifies `plan` via the API alongside the widened payload key pin.
- Manual GUI test on the local dev server (video below): set jane's plan to `pro`, then cleared it back to legacy/unlimited; audit log recorded `update_plan` events with the expected reasons.
- `npm run validate` passes (format, lint, typecheck, unit, Playwright E2E, MCP E2E).

<a href="https://cursor.com/agents/bc-77fef001-4c12-4d5f-86f3-d2a1c95433a9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_users_plan_editing_full_flow.mp4"><img src="https://cursor.com/artifacts/c/art-95e201e0-f3b6-44cc-854b-1a31aa627b57" alt="admin_users_plan_editing_full_flow.mp4" /></a>

![Admin users page with jane](https://cursor.com/artifacts/c/art-a4d8d6ce-01d0-4b83-8f30-707cabfd7936)

## Docs

- `docs/contributing/architecture/authorization.md` — POST actions, privacy boundary (plan is account metadata), widened field pin.
- `docs/contributing/architecture/entitlements.md` — new "Assigning plans" section covering both audited admin surfaces.
- `docs/contributing/adding-capabilities.md` — `admin_user_update` added to the admin capability list.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `80e35c57` · **Head:** `b1b453f0`

**Classification:** extends — the RBAC admin surface gains a plan mutation
(HTTP action + MCP capability) and the admin users payload contract widens to
include `plan`/`availablePlans`. No primitives added; `primitives.yaml`
unchanged.

### Primitives touched

| Primitive      | Group    | Impact                                                                                                                              |
| -------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
| `rbac`         | auth     | extends — `update_plan` action on `POST /admin/users.json`, new `admin_user_update` MCP capability, payload pin widened with `plan` |
| `entitlements` | auth     | composes — reuses `planNames`/`parsePlanName` for validation; plan config and enforcement unchanged                                 |
| `app-ui`       | surfaces | extends — `/admin/users` gains a Manage plan panel and Plan metadata field                                                          |
| `mcp-server`   | surfaces | composes — one more capability registered in the existing admin domain                                                              |

### System map

```mermaid
flowchart LR
	appUi["app-ui"]:::extended
	mcpServer["mcp-server"]:::touched
	rbac["rbac"]:::extended
	entitlements["entitlements"]:::touched
	d1AppDb["d1-app-db"]:::untouched
	capabilityRegistry["capability-registry"]:::untouched
	appUi --> rbac
	mcpServer --> capabilityRegistry --> rbac
	rbac --> d1AppDb
	rbac --> entitlements
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Admin
	participant UI as /admin/users
	participant API as POST /admin/users.json
	participant MCP as admin_user_update
	participant D1 as users.plan
	Admin->>UI: select plan, Save plan
	UI->>API: { action: update_plan, userId, plan | null }
	Admin->>MCP: { id | email, plan | null }
	API->>D1: updateAdminUserPlan (parsePlanName-validated)
	MCP->>D1: updateAdminUserPlan (zod planNames-validated)
	API-->>Admin: refreshed users payload + audit event
	MCP-->>Admin: updated user metadata + audit event
```

### Before / after

| Surface                    | Before             | After                                             |
| -------------------------- | ------------------ | ------------------------------------------------- |
| `users.plan` writes        | manual SQL only    | audited admin UI action + `admin_user_update` MCP |
| Admin users payload fields | id…roles (no plan) | + `plan` (parsed), + `availablePlans`             |
| Admin MCP domain           | list/get/create    | + update (plan set/clear)                         |

### Invariants

`per-user-isolation`: the new mutation stays inside the documented RBAC
exception — admin-only guards (`update:user:any` / `requiredRole: 'admin'`),
account metadata only, audit-logged; the privacy-boundary field pin test was
widened deliberately to include `plan` and still rejects any other widening.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77fef001-4c12-4d5f-86f3-d2a1c95433a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77fef001-4c12-4d5f-86f3-d2a1c95433a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin users can now view and update account plans.
  * The admin users screen now includes a plan selector and shows each user’s current plan.
  * The admin tools now support setting or clearing a plan, including legacy/unlimited accounts.

* **Bug Fixes**
  * Admin user lists now include plan and email-verification details consistently.
  * Plan changes are now reflected immediately in refreshed admin user data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->