### PR TITLE
Fix CSP-blocked social login and add connected-accounts management

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -296,13 +296,18 @@ definitions in `packages/worker/src/app/oauth-providers.ts`.
 
 - `POST /auth/:provider` starts the flow (CSRF state + PKCE verifier in the
   signed `kody_oauth_login` cookie); `GET /auth/:provider/callback` completes it
-  and issues the normal `kody_session` cookie
+  and issues the normal `kody_session` cookie. The first-party UI fetches the
+  start endpoint with `Accept: application/json` and navigates to the returned
+  authorize URL itself, because the CSP locks `form-action` and `connect-src` to
+  `'self'`
 - Existing connections sign in directly; the two-factor gate applies exactly as
   for password and passkey logins
 - A signed-in user hitting the callback links the provider identity to their
-  account; a provider-verified email matching an existing account auto-links and
-  signs in; otherwise account creation follows the signup posture (production
-  stays invite-gated, so OAuth signup is non-production only)
+  account, managed from the `/account` "Connected accounts" card backed by
+  `/account/connections.json` (disconnect is refused when the connection is the
+  only sign-in method); a provider-verified email matching an existing account
+  auto-links and signs in; otherwise account creation follows the signup posture
+  (production stays invite-gated, so OAuth signup is non-production only)
 - Buttons only render for providers whose client id/secret env vars are set;
   `MOCK_`-prefixed client ids activate an in-worker mock flow on non-production
   runtimes for dev and E2E tests

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -98,6 +98,7 @@ primitives:
       - packages/worker/src/app/auth-session.ts
       - packages/worker/src/app/handlers/auth.ts
       - packages/worker/src/app/handlers/auth-provider.ts
+      - packages/worker/src/app/handlers/account-connections.ts
       - packages/worker/src/app/oauth-providers.ts
       - packages/worker/src/app/oauth-login-state.ts
       - packages/worker/src/app/oauth-login-errors.ts

--- a/docs/contributing/social-login.md
+++ b/docs/contributing/social-login.md
@@ -12,19 +12,33 @@ persisted; the token is used once per login to fetch the profile.
 
 ## How the flow behaves
 
-Routes (see `packages/worker/src/app/handlers/auth-provider.ts`):
+Routes (see `packages/worker/src/app/handlers/auth-provider.ts` and
+`packages/worker/src/app/handlers/account-connections.ts`):
 
 - `GET /auth/providers.json` — enabled providers (drives the login buttons; a
   provider only appears when both its client id and secret env vars are set)
 - `POST /auth/:provider` — starts the flow (signed `kody_oauth_login` state
-  cookie with CSRF state + PKCE verifier, then a redirect to the provider)
+  cookie with CSRF state + PKCE verifier). With `Accept: application/json` it
+  returns `{ authorizeUrl }` for client-side navigation; otherwise it 302s.
 - `GET /auth/:provider/callback` — completes the flow
+- `GET/POST /account/connections.json` — signed-in connection management (list,
+  disconnect)
+
+The first-party UI always uses the JSON start mode: the CSP locks `form-action`
+and `connect-src` to `'self'`, so neither a form-POST redirect nor a
+fetch-followed redirect may leave the origin — the client fetches the start
+endpoint and performs a top-level navigation to the returned authorize URL
+itself.
 
 Callback resolution order:
 
-1. A known connection signs in its user (the two-factor gate applies exactly as
+1. A **signed-in** user gets the provider identity linked to their account
+   (`/account` has a "Connected accounts" card for this). A provider identity
+   already linked to a different user is a conflict error, never an account
+   switch; callback errors for signed-in users redirect to
+   `/account?oauthError=<code>`.
+2. A known connection signs in its user (the two-factor gate applies exactly as
    it does for password and passkey logins).
-2. A signed-in user gets the provider identity linked to their account.
 3. A **provider-verified** email matching an existing account links the identity
    and signs that account in (this also marks the account email verified, since
    the provider asserted ownership of the same address).
@@ -35,8 +49,10 @@ Callback resolution order:
 
 X frequently does not share an email (it requires the "Request email from users"
 app permission and a confirmed email), in which case only paths 1 and 2 work:
-sign in another way first, then use the X button while signed in to link the
-account.
+connect X from `/account` while signed in, then the X login button works.
+
+Disconnecting a provider from `/account` is refused when it is the account's
+only sign-in method (no usable password, no passkey, no other connection).
 
 ## Provider app setup
 

--- a/e2e/social-login.spec.ts
+++ b/e2e/social-login.spec.ts
@@ -6,12 +6,12 @@ import {
 
 // The test wrangler env ships MOCK_ social-login client ids, so the full
 // start -> provider -> callback redirect round-trip runs in-worker against
-// the canned mock GitHub profile (no provider app or network needed).
-test('social login signs in through the mock GitHub provider', async ({
+// canned mock provider profiles (no provider apps or network needed).
+test('social login signs in via mock GitHub and manages connections', async ({
 	page,
 }) => {
 	executeE2eD1Command(
-		`DELETE FROM oauth_connections WHERE provider_name = 'github' AND provider_id = 'mock-github-user-1'; DELETE FROM users WHERE email = 'mock-github-user@example.com';`,
+		`DELETE FROM oauth_connections WHERE provider_id IN ('mock-github-user-1', 'mock-google-user-1', 'mock-x-user-1'); DELETE FROM users WHERE email IN ('mock-github-user@example.com', 'mock-google-user@example.com');`,
 	)
 	clearAuthRateLimitsInE2eDatabase()
 	await page.context().clearCookies()
@@ -33,5 +33,40 @@ test('social login signs in through the mock GitHub provider', async ({
 	// The provider-verified email skips the verification-email flow entirely.
 	await expect(
 		page.getByText('Email: mock-github-user@example.com (verified)'),
+	).toBeVisible()
+
+	// The connections card lists the GitHub identity; it is the account's
+	// only sign-in method (no password), so disconnect stays disabled.
+	const connectionsCard = page.getByRole('region', {
+		name: 'Connected accounts',
+	})
+	await expect(
+		connectionsCard.getByText('Connected as mock-github-user'),
+	).toBeVisible()
+	await expect(
+		connectionsCard.getByRole('button', { name: 'Disconnect' }),
+	).toBeDisabled()
+
+	// Connecting Google while signed in links it to this account without
+	// logging out.
+	clearAuthRateLimitsInE2eDatabase()
+	await connectionsCard.getByRole('button', { name: 'Connect Google' }).click()
+	await expect(page).toHaveURL(/\/account\?oauthLinked=google$/)
+	await expect(page.getByText('Google connected.')).toBeVisible()
+	await expect(
+		connectionsCard.getByText('Google', { exact: true }),
+	).toBeVisible()
+
+	// With two connections, disconnecting one is allowed again.
+	const googleRow = connectionsCard
+		.getByRole('listitem')
+		.filter({ hasText: 'Google' })
+	await googleRow.getByRole('button', { name: 'Disconnect' }).click()
+	await expect(page.getByText('Google disconnected.')).toBeVisible()
+	await expect(
+		connectionsCard.getByText('Google', { exact: true }),
+	).not.toBeVisible()
+	await expect(
+		connectionsCard.getByRole('button', { name: 'Connect Google' }),
 	).toBeVisible()
 })

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -1,6 +1,11 @@
 import { type Handle, css } from 'remix/ui'
+import { getOauthLoginErrorMessage } from '#app/oauth-login-errors.ts'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
+import {
+	startSocialSignIn,
+	type AuthProviderInfo,
+} from '#client/social-sign-in.ts'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
@@ -11,7 +16,9 @@ import {
 	descriptionCss,
 	fieldCss,
 	fieldLabelCss,
+	getDangerButtonCss,
 	getPrimaryButtonCss,
+	getSecondaryButtonCss,
 	inputCss,
 	layoutMaxWidths,
 	mutedLinkCss,
@@ -41,8 +48,46 @@ type AccountProfilePayload = {
 	displayName: string
 }
 
+type AccountConnection = {
+	provider: string
+	label: string
+	displayName: string | null
+	createdAt: string
+}
+
+type AccountConnectionsPayload = {
+	ok: true
+	connections: Array<AccountConnection>
+	canDisconnect: boolean
+	availableProviders: Array<AuthProviderInfo>
+}
+
 const resendVerificationApiPath = '/account/resend-verification.json'
 const emailChangeApiPath = '/account/email-change.json'
+const connectionsApiPath = '/account/connections.json'
+
+const providerLabels: Record<string, string> = {
+	github: 'GitHub',
+	google: 'Google',
+	x: 'X',
+}
+
+/** One-shot message from the OAuth callback redirect query params. */
+function readConnectionCallbackMessage(href: string) {
+	const searchParams = new URL(href, 'http://localhost').searchParams
+	const linkedProvider = searchParams.get('oauthLinked')
+	if (linkedProvider) {
+		return {
+			text: `${providerLabels[linkedProvider] ?? linkedProvider} connected.`,
+			tone: 'info' as const,
+		}
+	}
+	const errorMessage = getOauthLoginErrorMessage(searchParams.get('oauthError'))
+	if (errorMessage) {
+		return { text: errorMessage, tone: 'error' as const }
+	}
+	return null
+}
 
 function isAccountPath(href: string) {
 	return new URL(href, 'http://localhost').pathname === '/account'
@@ -84,7 +129,120 @@ export function AccountRoute(handle: Handle) {
 	let messageTone: 'error' | 'info' = 'info'
 	let emailChangeMessage: string | null = null
 	let emailChangeTone: 'error' | 'info' = 'info'
+	let connectionsStatus: 'idle' | 'loading' | 'ready' | 'error' = 'idle'
+	let connectionsBusy = false
+	let connections: Array<AccountConnection> = []
+	let canDisconnect = true
+	let availableProviders: Array<AuthProviderInfo> = []
+	let connectionsMessage: { text: string; tone: 'error' | 'info' } | null = null
+	let consumedCallbackMessage = false
 	const loadLatch = createRouteLoadLatch()
+
+	function applyConnectionsPayload(payload: AccountConnectionsPayload) {
+		connections = payload.connections
+		canDisconnect = payload.canDisconnect
+		availableProviders = payload.availableProviders
+	}
+
+	async function loadConnections(signal: AbortSignal) {
+		try {
+			const response = await fetch(connectionsApiPath, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (signal.aborted) {
+				connectionsStatus = 'idle'
+				return
+			}
+			const payload = await readJson<AccountConnectionsPayload>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load connected accounts.')
+			}
+			applyConnectionsPayload(payload)
+			connectionsStatus = 'ready'
+			handle.update()
+		} catch (error) {
+			if (signal.aborted) {
+				connectionsStatus = 'idle'
+				return
+			}
+			connectionsStatus = 'error'
+			connectionsMessage = {
+				text:
+					error instanceof Error
+						? error.message
+						: 'Unable to load connected accounts.',
+				tone: 'error',
+			}
+			handle.update()
+		}
+	}
+
+	async function handleConnectProvider(providerId: string) {
+		connectionsBusy = true
+		connectionsMessage = null
+		handle.update()
+		try {
+			const errorMessage = await startSocialSignIn(providerId, null)
+			if (errorMessage) {
+				connectionsMessage = { text: errorMessage, tone: 'error' }
+				connectionsBusy = false
+			}
+			// On success the browser is navigating to the provider; keep the
+			// busy state until the page unloads.
+		} catch {
+			connectionsMessage = {
+				text: 'Network error. Please try again.',
+				tone: 'error',
+			}
+			connectionsBusy = false
+		}
+		handle.update()
+	}
+
+	async function handleDisconnectProvider(providerId: string) {
+		connectionsBusy = true
+		connectionsMessage = null
+		handle.update()
+		try {
+			const response = await fetch(connectionsApiPath, {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				credentials: 'include',
+				body: JSON.stringify({ intent: 'disconnect', provider: providerId }),
+			})
+			if (response.status === 401) {
+				window.location.assign('/login')
+				return
+			}
+			const payload = await readJson<
+				AccountConnectionsPayload & { error?: string }
+			>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error(payload?.error || 'Unable to disconnect the account.')
+			}
+			applyConnectionsPayload(payload)
+			connectionsMessage = {
+				text: `${providerLabels[providerId] ?? providerId} disconnected.`,
+				tone: 'info',
+			}
+		} catch (error) {
+			connectionsMessage = {
+				text:
+					error instanceof Error
+						? error.message
+						: 'Unable to disconnect the account.',
+				tone: 'error',
+			}
+		} finally {
+			connectionsBusy = false
+			handle.update()
+		}
+	}
 
 	async function loadAccountProfile(signal: AbortSignal) {
 		const href = readCurrentRouterHref(handle)
@@ -338,6 +496,17 @@ export function AccountRoute(handle: Handle) {
 		if (needsLoad && typeof document !== 'undefined') {
 			handle.queueTask(loadAccountProfile)
 		}
+		if (typeof document !== 'undefined') {
+			if (!consumedCallbackMessage) {
+				consumedCallbackMessage = true
+				connectionsMessage =
+					readConnectionCallbackMessage(currentHref) ?? connectionsMessage
+			}
+			if (connectionsStatus === 'idle') {
+				connectionsStatus = 'loading'
+				handle.queueTask(loadConnections)
+			}
+		}
 		const isSaving = saveStatus === 'saving'
 		const isSendingEmailChange = emailChangeStatus === 'sending'
 		const normalizedDraftUsername = draftUsername.trim().toLowerCase()
@@ -542,6 +711,127 @@ export function AccountRoute(handle: Handle) {
 								</a>
 							</div>
 						</section>
+						<section mix={css(cardCss)} aria-label="Connected accounts">
+							<h2 mix={css(cardTitleCss)}>Connected accounts</h2>
+							<p mix={css(descriptionCss)}>
+								Sign in with GitHub, Google, or X by connecting them to this
+								account. Connections with the same verified email also link
+								automatically at sign-in.
+							</p>
+							{connectionsMessage ? (
+								<p
+									role="status"
+									mix={css({
+										color:
+											connectionsMessage.tone === 'error'
+												? colors.error
+												: colors.text,
+										margin: 0,
+									})}
+								>
+									{connectionsMessage.text}
+								</p>
+							) : null}
+							{connectionsStatus === 'loading' ? (
+								<p mix={css({ color: colors.textMuted, margin: 0 })}>
+									Loading connected accounts…
+								</p>
+							) : null}
+							{connectionsStatus === 'ready' ? (
+								<div mix={css({ display: 'grid', gap: spacing.md })}>
+									{connections.length > 0 ? (
+										<ul
+											mix={css({
+												listStyle: 'none',
+												padding: 0,
+												margin: 0,
+												display: 'grid',
+												gap: spacing.md,
+											})}
+										>
+											{connections.map((connection) => (
+												<li
+													key={connection.provider}
+													mix={css({
+														display: 'flex',
+														justifyContent: 'space-between',
+														alignItems: 'center',
+														gap: spacing.md,
+														flexWrap: 'wrap',
+													})}
+												>
+													<span mix={css({ display: 'grid', gap: spacing.xs })}>
+														<span
+															mix={css({
+																fontWeight: typography.fontWeight.medium,
+																color: colors.text,
+															})}
+														>
+															{connection.label}
+														</span>
+														<span
+															mix={css({
+																color: colors.textMuted,
+																fontSize: typography.fontSize.sm,
+															})}
+														>
+															{connection.displayName
+																? `Connected as ${connection.displayName}`
+																: 'Connected'}
+														</span>
+													</span>
+													<button
+														type="button"
+														disabled={connectionsBusy || !canDisconnect}
+														title={
+															canDisconnect
+																? undefined
+																: 'This connection is your only way to sign in. Set a password or register a passkey first.'
+														}
+														mix={[
+															css(dangerButtonCss),
+															on('click', () =>
+																handleDisconnectProvider(connection.provider),
+															),
+														]}
+													>
+														Disconnect
+													</button>
+												</li>
+											))}
+										</ul>
+									) : (
+										<p mix={css({ color: colors.textMuted, margin: 0 })}>
+											No accounts connected yet.
+										</p>
+									)}
+									{availableProviders.length > 0 ? (
+										<div
+											mix={css({
+												display: 'flex',
+												gap: spacing.md,
+												flexWrap: 'wrap',
+											})}
+										>
+											{availableProviders.map((provider) => (
+												<button
+													type="button"
+													disabled={connectionsBusy}
+													mix={[
+														css(secondaryButtonCss),
+														on('click', () =>
+															handleConnectProvider(provider.id),
+														),
+													]}
+												>
+													Connect {provider.label}
+												</button>
+											))}
+										</div>
+									) : null}
+								</div>
+							) : null}
+						</section>
 						<section mix={css(cardCss)}>
 							<h2 mix={css(cardTitleCss)}>Secret management</h2>
 							<p mix={css(descriptionCss)}>
@@ -637,3 +927,5 @@ export function AccountRoute(handle: Handle) {
 }
 
 const primaryButtonCss = getPrimaryButtonCss()
+const secondaryButtonCss = getSecondaryButtonCss()
+const dangerButtonCss = getDangerButtonCss()

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -12,6 +12,11 @@ import {
 } from '#client/router-location.tsx'
 import { getOauthLoginErrorMessage } from '#app/oauth-login-errors.ts'
 import { fetchSessionInfo, type SessionStatus } from '#client/session.ts'
+import {
+	fetchEnabledAuthProviders,
+	startSocialSignIn,
+	type AuthProviderInfo,
+} from '#client/social-sign-in.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
@@ -30,36 +35,6 @@ import {
 
 type AuthMode = 'login' | 'signup'
 type AuthStatus = 'idle' | 'submitting' | 'success' | 'error'
-type AuthProviderInfo = { id: string; label: string }
-
-async function fetchEnabledAuthProviders(
-	signal?: AbortSignal,
-): Promise<Array<AuthProviderInfo>> {
-	try {
-		const response = await fetch('/auth/providers.json', {
-			headers: { Accept: 'application/json' },
-			signal,
-		})
-		const payload = await response.json().catch(() => null)
-		if (!response.ok || payload?.ok !== true) return []
-		const providers = Array.isArray(payload.providers) ? payload.providers : []
-		return providers.filter(
-			(provider: unknown): provider is AuthProviderInfo =>
-				typeof provider === 'object' &&
-				provider !== null &&
-				typeof (provider as AuthProviderInfo).id === 'string' &&
-				typeof (provider as AuthProviderInfo).label === 'string',
-		)
-	} catch {
-		return []
-	}
-}
-
-function buildProviderStartPath(providerId: string, redirectTo: string | null) {
-	return redirectTo
-		? `/auth/${providerId}?redirectTo=${encodeURIComponent(redirectTo)}`
-		: `/auth/${providerId}`
-}
 
 function normalizeRedirectTo(value: string | null) {
 	if (!value) return null
@@ -203,6 +178,23 @@ export function LoginRoute(handle: Handle) {
 				}
 				window.location.assign(getCurrentRedirectTo(handle) ?? '/account')
 			}
+		} catch {
+			setState('error', 'Network error. Please try again.')
+		}
+	}
+
+	async function handleProviderSignIn(providerId: string) {
+		setState('submitting')
+		try {
+			const errorMessage = await startSocialSignIn(
+				providerId,
+				getCurrentRedirectTo(handle),
+			)
+			if (errorMessage) {
+				setState('error', errorMessage)
+			}
+			// On success the browser is navigating to the provider; leave the
+			// submitting state in place.
 		} catch {
 			setState('error', 'Network error. Please try again.')
 		}
@@ -449,19 +441,16 @@ export function LoginRoute(handle: Handle) {
 							or
 						</p>
 						{authProviders.map((provider) => (
-							<form
-								method="post"
-								action={buildProviderStartPath(provider.id, redirectTo)}
-								mix={css({ display: 'grid' })}
+							<button
+								type="button"
+								disabled={isSubmitting}
+								mix={[
+									css(secondaryButtonCss),
+									on('click', () => handleProviderSignIn(provider.id)),
+								]}
 							>
-								<button
-									type="submit"
-									disabled={isSubmitting}
-									mix={css(secondaryButtonCss)}
-								>
-									Continue with {provider.label}
-								</button>
-							</form>
+								Continue with {provider.label}
+							</button>
 						))}
 					</div>
 				) : null}

--- a/packages/worker/client/social-sign-in.ts
+++ b/packages/worker/client/social-sign-in.ts
@@ -1,0 +1,63 @@
+export type AuthProviderInfo = { id: string; label: string }
+
+export function buildProviderStartPath(
+	providerId: string,
+	redirectTo: string | null,
+) {
+	return redirectTo
+		? `/auth/${providerId}?redirectTo=${encodeURIComponent(redirectTo)}`
+		: `/auth/${providerId}`
+}
+
+export async function fetchEnabledAuthProviders(
+	signal?: AbortSignal,
+): Promise<Array<AuthProviderInfo>> {
+	try {
+		const response = await fetch('/auth/providers.json', {
+			headers: { Accept: 'application/json' },
+			signal,
+		})
+		const payload = await response.json().catch(() => null)
+		if (!response.ok || payload?.ok !== true) return []
+		const providers = Array.isArray(payload.providers) ? payload.providers : []
+		return providers.filter(
+			(provider: unknown): provider is AuthProviderInfo =>
+				typeof provider === 'object' &&
+				provider !== null &&
+				typeof (provider as AuthProviderInfo).id === 'string' &&
+				typeof (provider as AuthProviderInfo).label === 'string',
+		)
+	} catch {
+		return []
+	}
+}
+
+/**
+ * Start a social sign-in or account connection: fetch the authorize URL from
+ * the start endpoint and navigate to it at the top level. The CSP locks
+ * `form-action` and `connect-src` to 'self', so neither a form-POST redirect
+ * nor a fetch-followed redirect may leave the origin — a top-level JS
+ * navigation may. Returns an error message, or null when navigation started.
+ */
+export async function startSocialSignIn(
+	providerId: string,
+	redirectTo: string | null,
+): Promise<string | null> {
+	const response = await fetch(buildProviderStartPath(providerId, redirectTo), {
+		method: 'POST',
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+	})
+	const payload = await response.json().catch(() => null)
+	if (
+		!response.ok ||
+		payload?.ok !== true ||
+		typeof payload.authorizeUrl !== 'string'
+	) {
+		return typeof payload?.error === 'string'
+			? payload.error
+			: 'Unable to start sign-in. Please try again.'
+	}
+	window.location.assign(payload.authorizeUrl)
+	return null
+}

--- a/packages/worker/src/app/handlers/account-connections.ts
+++ b/packages/worker/src/app/handlers/account-connections.ts
@@ -110,21 +110,37 @@ export function createAccountConnectionsApiHandler(env: Env) {
 			}
 			const provider = parsed.value.provider
 
-			// Removing this provider must leave at least one working sign-in
-			// method: a usable password, a passkey, or another connection.
-			const [connections, usablePassword, passkeys] = await Promise.all([
-				listConnections(env.APP_DB, user.userId),
-				hasUsablePassword(env.APP_DB, user.userId),
-				listPasskeysForUser(env.APP_DB, user.userId),
-			])
-			const remainingConnections = connections.filter(
-				(connection) => connection.provider_name !== provider,
+			const existing = await env.APP_DB.prepare(
+				`SELECT id FROM oauth_connections WHERE user_id = ? AND provider_name = ?`,
 			)
-			if (
-				!usablePassword &&
-				passkeys.length === 0 &&
-				remainingConnections.length === 0
-			) {
+				.bind(user.userId, provider)
+				.first<{ id: number }>()
+			if (!existing) {
+				return jsonResponse({ ok: false, error: 'Connection not found.' }, 404)
+			}
+
+			// Removing this provider must leave at least one working sign-in
+			// method: a usable password, a passkey, or another connection. The
+			// guard lives inside the DELETE itself so concurrent disconnects
+			// cannot both pass a separate pre-check and remove every method.
+			const result = await env.APP_DB.prepare(
+				`DELETE FROM oauth_connections
+				 WHERE user_id = ?1 AND provider_name = ?2
+				 AND (
+					EXISTS (
+						SELECT 1 FROM users
+						WHERE id = ?1 AND password_hash LIKE 'pbkdf2_sha256$%'
+					)
+					OR EXISTS (SELECT 1 FROM passkeys WHERE user_id = ?1)
+					OR EXISTS (
+						SELECT 1 FROM oauth_connections
+						WHERE user_id = ?1 AND provider_name != ?2
+					)
+				 )`,
+			)
+				.bind(user.userId, provider)
+				.run()
+			if ((result.meta?.changes ?? 0) === 0) {
 				return jsonResponse(
 					{
 						ok: false,
@@ -133,15 +149,6 @@ export function createAccountConnectionsApiHandler(env: Env) {
 					},
 					400,
 				)
-			}
-
-			const result = await env.APP_DB.prepare(
-				`DELETE FROM oauth_connections WHERE user_id = ? AND provider_name = ?`,
-			)
-				.bind(user.userId, provider)
-				.run()
-			if ((result.meta?.changes ?? 0) === 0) {
-				return jsonResponse({ ok: false, error: 'Connection not found.' }, 404)
 			}
 
 			void logAuditEvent({

--- a/packages/worker/src/app/handlers/account-connections.ts
+++ b/packages/worker/src/app/handlers/account-connections.ts
@@ -1,0 +1,161 @@
+import { jsonResponse } from '#worker/json-response.ts'
+import { type Action } from 'remix/router'
+import { object, parseSafe, string } from 'remix/data-schema'
+import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import {
+	getEnabledOauthProviders,
+	isOauthProviderId,
+	oauthProviderDefinitions,
+} from '#app/oauth-providers.ts'
+import { listPasskeysForUser } from '#app/passkeys.ts'
+import { type routes } from '#app/routes.ts'
+
+const disconnectSchema = object({
+	intent: string(),
+	provider: string(),
+})
+
+type ConnectionRow = {
+	id: number
+	provider_name: string
+	provider_display_name: string | null
+	created_at: string
+}
+
+async function listConnections(db: D1Database, userId: number) {
+	const result = await db
+		.prepare(
+			`SELECT id, provider_name, provider_display_name, created_at
+			 FROM oauth_connections
+			 WHERE user_id = ?
+			 ORDER BY created_at, id`,
+		)
+		.bind(userId)
+		.all<ConnectionRow>()
+	return result.results ?? []
+}
+
+async function hasUsablePassword(db: D1Database, userId: number) {
+	const row = await db
+		.prepare(`SELECT password_hash FROM users WHERE id = ?`)
+		.bind(userId)
+		.first<{ password_hash: string }>()
+	// Sentinel hashes (admin-created / OAuth-created accounts) never verify,
+	// so only a real PBKDF2 hash counts as a usable password.
+	return row?.password_hash.startsWith('pbkdf2_sha256$') === true
+}
+
+async function loadConnectionsPayload(input: { env: Env; userId: number }) {
+	const { env, userId } = input
+	const [connections, usablePassword, passkeys] = await Promise.all([
+		listConnections(env.APP_DB, userId),
+		hasUsablePassword(env.APP_DB, userId),
+		listPasskeysForUser(env.APP_DB, userId),
+	])
+	// Disconnecting the last connection is only safe when another first
+	// factor (password or passkey) can still sign the account in.
+	const canDisconnect =
+		usablePassword || passkeys.length > 0 || connections.length > 1
+	const connectedProviders = new Set(
+		connections.map((connection) => connection.provider_name),
+	)
+	return {
+		ok: true,
+		connections: connections.map((connection) => ({
+			provider: connection.provider_name,
+			label: isOauthProviderId(connection.provider_name)
+				? oauthProviderDefinitions[connection.provider_name].label
+				: connection.provider_name,
+			displayName: connection.provider_display_name,
+			createdAt: connection.created_at,
+		})),
+		canDisconnect,
+		availableProviders: getEnabledOauthProviders(env)
+			.filter((provider) => !connectedProviders.has(provider))
+			.map((provider) => ({
+				id: provider,
+				label: oauthProviderDefinitions[provider].label,
+			})),
+	}
+}
+
+export function createAccountConnectionsApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, url }) {
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+
+			if (request.method === 'GET') {
+				return jsonResponse(
+					await loadConnectionsPayload({ env, userId: user.userId }),
+				)
+			}
+
+			if (request.method !== 'POST') {
+				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+			}
+
+			const body = await request.json().catch(() => null)
+			const parsed = parseSafe(disconnectSchema, body)
+			if (
+				!parsed.success ||
+				parsed.value.intent !== 'disconnect' ||
+				!isOauthProviderId(parsed.value.provider)
+			) {
+				return jsonResponse({ ok: false, error: 'Invalid request body.' }, 400)
+			}
+			const provider = parsed.value.provider
+
+			// Removing this provider must leave at least one working sign-in
+			// method: a usable password, a passkey, or another connection.
+			const [connections, usablePassword, passkeys] = await Promise.all([
+				listConnections(env.APP_DB, user.userId),
+				hasUsablePassword(env.APP_DB, user.userId),
+				listPasskeysForUser(env.APP_DB, user.userId),
+			])
+			const remainingConnections = connections.filter(
+				(connection) => connection.provider_name !== provider,
+			)
+			if (
+				!usablePassword &&
+				passkeys.length === 0 &&
+				remainingConnections.length === 0
+			) {
+				return jsonResponse(
+					{
+						ok: false,
+						error:
+							'This connection is your only way to sign in. Set a password or register a passkey first.',
+					},
+					400,
+				)
+			}
+
+			const result = await env.APP_DB.prepare(
+				`DELETE FROM oauth_connections WHERE user_id = ? AND provider_name = ?`,
+			)
+				.bind(user.userId, provider)
+				.run()
+			if ((result.meta?.changes ?? 0) === 0) {
+				return jsonResponse({ ok: false, error: 'Connection not found.' }, 404)
+			}
+
+			void logAuditEvent({
+				category: 'auth',
+				action: 'oauth_connection_removed',
+				result: 'success',
+				email: user.email,
+				ip: getRequestIp(request) ?? undefined,
+				path: url.pathname,
+				reason: `provider=${provider}`,
+			})
+			return jsonResponse(
+				await loadConnectionsPayload({ env, userId: user.userId }),
+			)
+		},
+	} satisfies Action<typeof routes.accountConnectionsApi>
+}

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -2,7 +2,8 @@ import { readdirSync, readFileSync } from 'node:fs'
 import { DatabaseSync } from 'node:sqlite'
 import { HttpResponse, http } from 'msw'
 import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
-import { setAuthSessionSecret } from '#app/auth-session.ts'
+import { createAuthCookie, setAuthSessionSecret } from '#app/auth-session.ts'
+import { createAccountConnectionsApiHandler } from '#app/handlers/account-connections.ts'
 import {
 	createAuthProviderCallbackHandler,
 	createAuthProviderStartHandler,
@@ -461,6 +462,239 @@ test('callback rejects a state mismatch', async () => {
 	expect(callbackResponse.headers.get('Location')).toBe(
 		'/login?oauthError=state-mismatch&redirectTo=%2Fcommunity',
 	)
+})
+
+test('JSON start mode returns the authorize URL for client-side navigation', async () => {
+	const { db } = createMigratedDb()
+	const env = createAppEnv(db)
+
+	// The first-party UI fetches the start endpoint (Accept: json) and
+	// navigates itself because the CSP blocks form-POST and fetch-followed
+	// redirects to the provider origin.
+	const response = await runHandler(
+		createAuthProviderStartHandler(env),
+		new Request('http://example.com/auth/github?redirectTo=%2Fcommunity', {
+			method: 'POST',
+			headers: { Accept: 'application/json' },
+		}),
+		{ provider: 'github' },
+	)
+	expect(response.status).toBe(200)
+	const payload = (await response.json()) as {
+		ok: boolean
+		authorizeUrl: string
+	}
+	expect(payload.ok).toBe(true)
+	expect(payload.authorizeUrl).toContain(
+		'https://github.com/login/oauth/authorize',
+	)
+	expect(response.headers.get('Set-Cookie')).toContain('kody_oauth_login=')
+
+	const unknownProviderResponse = await runHandler(
+		createAuthProviderStartHandler(env),
+		new Request('http://example.com/auth/nope', {
+			method: 'POST',
+			headers: { Accept: 'application/json' },
+		}),
+		{ provider: 'nope' },
+	)
+	expect(unknownProviderResponse.status).toBe(400)
+	expect(await unknownProviderResponse.json()).toEqual({
+		ok: false,
+		code: 'unknown-provider',
+		error: 'That sign-in provider is not supported.',
+	})
+})
+
+test('signed-in users link and disconnect providers from their account', async () => {
+	const { sqlite, db } = createMigratedDb()
+	const env = createAppEnv(db, {
+		GITHUB_CLIENT_ID: 'MOCK_GITHUB_CLIENT_ID',
+		GITHUB_CLIENT_SECRET: 'MOCK_GITHUB_CLIENT_SECRET',
+	})
+	await seedUser(sqlite, {
+		id: 11,
+		email: 'linker@example.com',
+		username: 'linker',
+	})
+	const sessionCookiePair = getCookiePair(
+		await createAuthCookie(
+			{ id: '11', email: 'linker@example.com', rememberMe: false },
+			false,
+		),
+	)
+
+	// Linking: signed-in start + callback attaches the identity to the
+	// current account instead of creating or switching accounts.
+	const start = await startProviderFlow(
+		env,
+		'github',
+		'http://example.com/auth/github',
+	)
+	const callbackHandler = createAuthProviderCallbackHandler(env)
+	const linkResponse = await runHandler(
+		callbackHandler,
+		new Request(start.location, {
+			headers: { Cookie: `${start.stateCookie}; ${sessionCookiePair}` },
+		}),
+		{ provider: 'github' },
+	)
+	expect(linkResponse.status).toBe(302)
+	expect(linkResponse.headers.get('Location')).toBe(
+		'/account?oauthLinked=github',
+	)
+	const connection = sqlite
+		.prepare(
+			`SELECT user_id FROM oauth_connections WHERE provider_name = 'github'`,
+		)
+		.get() as { user_id: number }
+	expect(connection.user_id).toBe(11)
+
+	// Re-linking the same identity is a no-op success.
+	const secondStart = await startProviderFlow(
+		env,
+		'github',
+		'http://example.com/auth/github',
+	)
+	const relinkResponse = await runHandler(
+		callbackHandler,
+		new Request(secondStart.location, {
+			headers: { Cookie: `${secondStart.stateCookie}; ${sessionCookiePair}` },
+		}),
+		{ provider: 'github' },
+	)
+	expect(relinkResponse.headers.get('Location')).toBe(
+		'/account?oauthLinked=github',
+	)
+
+	// The same provider identity linked to a different signed-in user is a
+	// conflict surfaced on the account page, never an account switch.
+	await seedUser(sqlite, {
+		id: 12,
+		email: 'other@example.com',
+		username: 'other-user',
+	})
+	const otherSessionCookiePair = getCookiePair(
+		await createAuthCookie(
+			{ id: '12', email: 'other@example.com', rememberMe: false },
+			false,
+		),
+	)
+	const conflictStart = await startProviderFlow(
+		env,
+		'github',
+		'http://example.com/auth/github',
+	)
+	const conflictResponse = await runHandler(
+		callbackHandler,
+		new Request(conflictStart.location, {
+			headers: {
+				Cookie: `${conflictStart.stateCookie}; ${otherSessionCookiePair}`,
+			},
+		}),
+		{ provider: 'github' },
+	)
+	expect(conflictResponse.headers.get('Location')).toBe(
+		'/account?oauthError=connection-conflict',
+	)
+
+	// The connections API lists the link; disconnecting the only connection
+	// is allowed here because the seeded user has a usable password.
+	const connectionsHandler = createAccountConnectionsApiHandler(env)
+	const listResponse = await runHandler(
+		connectionsHandler,
+		new Request('http://example.com/account/connections.json', {
+			headers: { Cookie: sessionCookiePair, Accept: 'application/json' },
+		}),
+	)
+	const listPayload = (await listResponse.json()) as {
+		ok: boolean
+		connections: Array<{ provider: string; displayName: string | null }>
+		canDisconnect: boolean
+		availableProviders: Array<{ id: string }>
+	}
+	expect(listPayload.ok).toBe(true)
+	expect(listPayload.connections).toHaveLength(1)
+	expect(listPayload.connections[0]?.provider).toBe('github')
+	expect(listPayload.canDisconnect).toBe(true)
+	expect(listPayload.availableProviders.map((p) => p.id)).toEqual([
+		'google',
+		'x',
+	])
+
+	const disconnectResponse = await runHandler(
+		connectionsHandler,
+		new Request('http://example.com/account/connections.json', {
+			method: 'POST',
+			headers: {
+				Cookie: sessionCookiePair,
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ intent: 'disconnect', provider: 'github' }),
+		}),
+	)
+	const disconnectPayload = (await disconnectResponse.json()) as {
+		ok: boolean
+		connections: Array<unknown>
+	}
+	expect(disconnectPayload.ok).toBe(true)
+	expect(disconnectPayload.connections).toHaveLength(0)
+	expect(
+		sqlite.prepare(`SELECT COUNT(*) AS count FROM oauth_connections`).get(),
+	).toEqual({ count: 0 })
+})
+
+test('disconnect is refused when the connection is the only sign-in method', async () => {
+	const { sqlite, db } = createMigratedDb()
+	const env = createAppEnv(db, {
+		GITHUB_CLIENT_ID: 'MOCK_GITHUB_CLIENT_ID',
+		GITHUB_CLIENT_SECRET: 'MOCK_GITHUB_CLIENT_SECRET',
+	})
+
+	// Create an account through mock social signup: it has no usable
+	// password, so its single connection must not be removable.
+	const start = await startProviderFlow(
+		env,
+		'github',
+		'http://example.com/auth/github',
+	)
+	const signupResponse = await runHandler(
+		createAuthProviderCallbackHandler(env),
+		new Request(start.location, { headers: { Cookie: start.stateCookie } }),
+		{ provider: 'github' },
+	)
+	const sessionCookiePair = (signupResponse.headers.getSetCookie() ?? [])
+		.map(getCookiePair)
+		.find((pair) => pair.startsWith('kody_session='))
+	expect(sessionCookiePair).toBeTruthy()
+
+	const connectionsHandler = createAccountConnectionsApiHandler(env)
+	const listResponse = await runHandler(
+		connectionsHandler,
+		new Request('http://example.com/account/connections.json', {
+			headers: { Cookie: sessionCookiePair ?? '', Accept: 'application/json' },
+		}),
+	)
+	const listPayload = (await listResponse.json()) as { canDisconnect: boolean }
+	expect(listPayload.canDisconnect).toBe(false)
+
+	const disconnectResponse = await runHandler(
+		connectionsHandler,
+		new Request('http://example.com/account/connections.json', {
+			method: 'POST',
+			headers: {
+				Cookie: sessionCookiePair ?? '',
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ intent: 'disconnect', provider: 'github' }),
+		}),
+	)
+	expect(disconnectResponse.status).toBe(400)
+	expect(
+		sqlite.prepare(`SELECT COUNT(*) AS count FROM oauth_connections`).get(),
+	).toEqual({ count: 1 })
 })
 
 test('MOCK_ client ids run the whole flow in-worker without network access', async () => {

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -12,7 +12,10 @@ import { getUniqueConstraintField } from '#app/database-errors.ts'
 import { isNonProductionRuntime } from '#app/deployment-env.ts'
 import { getAvailableUsernameFromBase } from '#app/generated-username.ts'
 import { normalizeEmail } from '#app/normalize-email.ts'
-import { type OauthLoginErrorCode } from '#app/oauth-login-errors.ts'
+import {
+	oauthLoginErrorMessages,
+	type OauthLoginErrorCode,
+} from '#app/oauth-login-errors.ts'
 import {
 	createOauthLoginStateCookie,
 	destroyOauthLoginStateCookie,
@@ -75,6 +78,22 @@ function redirectToLoginWithError(
 	return redirect(`/login?oauthError=${code}${redirectToSuffix}`, cookies)
 }
 
+/**
+ * The login and connections UIs start flows via fetch (Accept: json) and
+ * navigate to the returned authorize URL themselves: the CSP locks
+ * `form-action`/`connect-src` to 'self', so neither a form POST redirect nor
+ * a fetch-followed redirect may leave the origin — but a top-level JS
+ * navigation may.
+ */
+function prefersJsonResponse(request: Request) {
+	return (
+		request.headers
+			.get('Accept')
+			?.toLowerCase()
+			.includes('application/json') === true
+	)
+}
+
 export function createAuthProvidersApiHandler(env: Env) {
 	return {
 		middleware: [],
@@ -94,13 +113,25 @@ export function createAuthProviderStartHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request, url, params }) {
+			const wantsJson = prefersJsonResponse(request)
 			const redirectTo = normalizeRedirectTo(url.searchParams.get('redirectTo'))
+
+			function startError(code: OauthLoginErrorCode) {
+				if (wantsJson) {
+					return jsonResponse(
+						{ ok: false, code, error: oauthLoginErrorMessages[code] },
+						400,
+					)
+				}
+				return redirectToLoginWithError(code, [], redirectTo)
+			}
+
 			const providerParam = params.provider
 			if (!isOauthProviderId(providerParam)) {
-				return redirectToLoginWithError('unknown-provider', [], redirectTo)
+				return startError('unknown-provider')
 			}
 			if (!getOauthClientConfig(env, providerParam)) {
-				return redirectToLoginWithError('not-configured', [], redirectTo)
+				return startError('not-configured')
 			}
 
 			setOauthLoginStateSecret(env.COOKIE_SECRET)
@@ -117,6 +148,16 @@ export function createAuthProviderStartHandler(env: Env) {
 				{ provider: providerParam, state, codeVerifier, redirectTo },
 				isSecureRequest(request),
 			)
+			// JSON mode: the CSP (`form-action`/`connect-src` locked to 'self')
+			// blocks both form-POST redirects and fetch-followed redirects to
+			// the provider, so the client fetches this endpoint and performs a
+			// top-level navigation to the returned authorize URL itself.
+			if (wantsJson) {
+				return jsonResponse(
+					{ ok: true, authorizeUrl },
+					{ headers: { 'Set-Cookie': stateCookie } },
+				)
+			}
 			return redirect(authorizeUrl, [stateCookie])
 		},
 	} satisfies Action<typeof routes.authProviderStart>
@@ -148,6 +189,7 @@ export function createAuthProviderCallbackHandler(env: Env) {
 			const requestIp = getRequestIp(request) ?? undefined
 			const loginState = await readOauthLoginState(request)
 			const redirectTo = normalizeRedirectTo(loginState?.redirectTo ?? null)
+			const { session } = await readAuthSessionResult(request)
 
 			function fail(code: OauthLoginErrorCode, reason: string) {
 				void logAuditEvent({
@@ -158,6 +200,12 @@ export function createAuthProviderCallbackHandler(env: Env) {
 					path: url.pathname,
 					reason,
 				})
+				// A signed-in user is connecting a provider from their account
+				// page; bouncing them to /login would immediately redirect back
+				// and drop the message.
+				if (session) {
+					return redirect(`/account?oauthError=${code}`, [clearStateCookie])
+				}
 				return redirectToLoginWithError(code, [clearStateCookie], redirectTo)
 			}
 
@@ -248,31 +296,30 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				])
 			}
 
-			// 1. A known connection signs in its user directly.
 			const connection = await db.findOne(oauthConnectionsTable, {
 				where: {
 					provider_name: provider,
 					provider_id: profile.providerUserId,
 				},
 			})
-			if (connection) {
-				const user = await db.findOne(usersTable, {
-					where: { id: connection.user_id },
-				})
-				if (!user) {
-					return fail('account-error', 'connection_user_missing')
-				}
-				return issueLogin(user)
-			}
 
-			// 2. A signed-in user links the provider identity to their account.
-			const { session } = await readAuthSessionResult(request)
+			// 1. A signed-in user links the provider identity to their account
+			// (an existing connection for another user is a conflict, never an
+			// account switch).
 			if (session) {
 				const currentUser = await db.findOne(usersTable, {
 					where: { id: Number(session.id) },
 				})
 				if (!currentUser) {
 					return fail('account-error', 'session_user_missing')
+				}
+				if (connection) {
+					if (connection.user_id === currentUser.id) {
+						return redirect(`/account?oauthLinked=${provider}`, [
+							clearStateCookie,
+						])
+					}
+					return fail('connection-conflict', 'connection_conflict')
 				}
 				try {
 					await createConnection({
@@ -295,7 +342,18 @@ export function createAuthProviderCallbackHandler(env: Env) {
 					path: url.pathname,
 					reason: `provider=${provider}`,
 				})
-				return redirect(redirectTo ?? '/account', [clearStateCookie])
+				return redirect(`/account?oauthLinked=${provider}`, [clearStateCookie])
+			}
+
+			// 2. A known connection signs its user in directly.
+			if (connection) {
+				const user = await db.findOne(usersTable, {
+					where: { id: connection.user_id },
+				})
+				if (!user) {
+					return fail('account-error', 'connection_user_missing')
+				}
+				return issueLogin(user)
 			}
 
 			// Without a provider-verified email we can neither match an

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -45,6 +45,7 @@ import {
 	createAccountPasskeysApiHandler,
 	createAccountPasskeysHandler,
 } from '#app/handlers/account-passkeys.ts'
+import { createAccountConnectionsApiHandler } from '#app/handlers/account-connections.ts'
 import { createAccountProfileApiHandler } from '#app/handlers/account-profile.ts'
 import {
 	createAccountTwoFactorApiHandler,
@@ -144,6 +145,8 @@ export function createAppRouter(env: Env) {
 				createAccountPackageInvocationTokensApiHandler(env),
 			accountPackageInvocationTokensApiPost:
 				createAccountPackageInvocationTokensApiHandler(env),
+			accountConnectionsApi: createAccountConnectionsApiHandler(env),
+			accountConnectionsApiPost: createAccountConnectionsApiHandler(env),
 			accountPasskeys: createAccountPasskeysHandler(env),
 			accountPasskeysApi: createAccountPasskeysApiHandler(env),
 			accountPasskeysApiPost: createAccountPasskeysApiHandler(env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -30,6 +30,8 @@ export const routes = route({
 	accountSecretsApprove: '/account/secrets/approve',
 	accountSecretsApi: '/account/secrets.json',
 	accountSecretsApiPost: post('/account/secrets.json'),
+	accountConnectionsApi: '/account/connections.json',
+	accountConnectionsApiPost: post('/account/connections.json'),
 	accountPasskeys: '/account/passkeys',
 	accountPasskeysApi: '/account/passkeys.json',
 	accountPasskeysApiPost: post('/account/passkeys.json'),

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -183,10 +183,15 @@ const appHandler = withCors({
 				authRateLimitConfig,
 			)
 			if (!result.allowed) {
-				// Social-login starts are native form POSTs (document
-				// navigations), so a JSON 429 body would render as raw text;
-				// bounce back to the login page instead. 303 forces a GET.
-				if (socialLoginStartPaths.has(url.pathname)) {
+				// A non-JSON social-login start is a document navigation, so a
+				// JSON 429 body would render as raw text; bounce back to the
+				// login page instead. 303 forces a GET. (The first-party UI
+				// sends Accept: application/json and gets the JSON 429.)
+				const prefersJson = request.headers
+					.get('Accept')
+					?.toLowerCase()
+					.includes('application/json')
+				if (socialLoginStartPaths.has(url.pathname) && !prefersJson) {
 					const loginUrl = new URL('/login', url)
 					loginUrl.searchParams.set('oauthError', 'rate-limited')
 					const redirectTo = normalizeRedirectTo(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<a href="https://cursor.com/agents/bc-ba638bd1-841f-4446-8160-e2a9e65e247b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnections_card_connect_google_disconnect_demo.mp4"><img src="https://cursor.com/artifacts/c/art-675a9a36-dbe1-41bd-937a-bbd3a5c4694f" alt="connections_card_connect_google_disconnect_demo.mp4" /></a>

Fixes the two issues found while testing social login live on heykody.dev, in one PR:

## 1. Every provider button errored (CSP)

The login buttons were native form POSTs. The client router intercepts document form submits and replays them as `fetch`, whose followed redirect to the provider origin violates `connect-src 'self'` — and even unintercepted forms would hit `form-action 'self'` on the post-submit redirect. The mock providers masked this in tests because their authorize URL is same-origin.

Fix: `POST /auth/:provider` now returns `{ authorizeUrl }` JSON when the request sends `Accept: application/json`, and the UI (login page + account card) fetches it and performs a **top-level navigation** to the provider, which CSP does not restrict. The 302 behavior remains for non-JSON clients, and the rate-limiter's 303-to-login fallback now only applies to non-JSON requests. No CSP loosening needed.

<a href="https://cursor.com/agents/bc-ba638bd1-841f-4446-8160-e2a9e65e247b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcsp_fix_github_button_navigates_to_real_github.mp4"><img src="https://cursor.com/artifacts/c/art-2acc407b-d7c4-41b5-b535-3f270a7ca41d" alt="csp_fix_github_button_navigates_to_real_github.mp4" /></a>
Demo with a real (non-mock) GitHub client id in dev: clicking "Continue with GitHub" now cleanly navigates to github.com with zero console errors.

## 2. Connect providers while signed in

`/account` gains a **Connected accounts** card (backed by `GET/POST /account/connections.json`):

- Lists linked providers with the provider-side handle and offers "Connect GitHub / Google / X" buttons for enabled, unlinked providers — no logout needed.
- Disconnect per provider, refused when the connection is the account's only sign-in method (no usable password, no passkey, no other connection). The guard lives inside the conditional `DELETE` itself so concurrent disconnects cannot race past a separate pre-check; the UI disables the button with an explanatory tooltip.
- The callback is now session-aware: signed-in users always **link** (a provider identity already linked to a different user is a `connection-conflict` error, never an account switch), success redirects to `/account?oauthLinked=<provider>` with a confirmation message, and signed-in errors land on `/account?oauthError=<code>` instead of bouncing through `/login`.

![Connected accounts card with disabled disconnect tooltip](https://cursor.com/artifacts/c/art-0faddbbe-562b-4190-af00-ecfe336e138c)

## Tests

- `auth-provider.node.test.ts`: 3 new tests — JSON start mode (authorize URL + state cookie, JSON errors), signed-in link / re-link no-op / cross-user conflict / list / disconnect, and the disconnect guard for passwordless social-only accounts.
- `e2e/social-login.spec.ts`: extended to cover the connections card end-to-end (disabled disconnect on the only sign-in method, connect Google, disconnect Google) via the mock providers.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1011ace3` · **Head:** `418ebf2f`

**Classification:** extends — reshapes the social-login start contract (JSON mode) inside `app-sessions` and adds connection management; no new primitive (`app-sessions` code list updated in `primitives.yaml`).

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-sessions` | auth | extends — JSON start mode for CSP-safe navigation, session-aware callback (link-only when signed in), `/account/connections.json` list/disconnect with an atomic last-sign-in-method guard |
| `app-ui` | surfaces | extends — login buttons switch to fetch-then-navigate; new "Connected accounts" card on `/account` |

### System map

```mermaid
flowchart LR
	appUi["app-ui"]:::extended
	appSessions["app-sessions"]:::extended
	d1AppDb["d1-app-db"]:::untouched
	rbac["rbac"]:::untouched
	appUi --> appSessions --> d1AppDb
	appSessions --> rbac
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant B as Browser (login or account card)
	participant K as Worker
	participant P as Provider
	B->>K: fetch POST /auth/:provider (Accept: json)
	K-->>B: { authorizeUrl } + kody_oauth_login cookie
	B->>P: top-level navigation (CSP-safe)
	P-->>B: 302 /auth/:provider/callback?code&state
	B->>K: GET callback
	alt signed in
		K-->>B: link -> /account?oauthLinked=… (conflict/em errors -> /account?oauthError=…)
	else signed out
		K-->>B: sign in / auto-link / signup as before
	end
```

### Invariants

- `per-user-isolation`: connections list/disconnect operate strictly on the authenticated user's rows (`WHERE user_id = ?`); linking never reassigns an identity that belongs to another user.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba638bd1-841f-4446-8160-e2a9e65e247b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba638bd1-841f-4446-8160-e2a9e65e247b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Connected accounts” section to account settings for viewing, linking, and disconnecting social sign-in providers.
  * Social sign-in now supports a JSON-based provider start flow so the app UI can launch OAuth and navigate reliably.
* **Bug Fixes**
  * Improved OAuth callback handling for signed-in users, including clearer linking behavior, identity conflict handling, and more precise error redirects.
  * Prevented disconnecting the last remaining sign-in method for an account.
  * Updated social-login rate-limit behavior to match JSON vs browser navigation expectations.
* **Documentation / Tests**
  * Updated social-login documentation and expanded e2e coverage for multi-provider linking/disconnecting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->