### PR TITLE
Stop reporting transient D1 SQLITE_BUSY errors to Sentry

### DIFF
--- a/packages/worker/src/d1-retry.ts
+++ b/packages/worker/src/d1-retry.ts
@@ -1,4 +1,5 @@
 import { errorCauseChainIncludes } from '@kody-internal/shared/error-message.ts'
+import type { ErrorEvent } from '@sentry/core'
 
 export const d1LockRetryMaxAttempts = 6
 
@@ -8,11 +9,24 @@ function sleep(ms: number) {
 	return new Promise<void>((resolve) => setTimeout(resolve, ms))
 }
 
+export function isRetryableD1LockMessage(message: string) {
+	return (
+		message.includes('SQLITE_BUSY') || message.includes('database is locked')
+	)
+}
+
 export function isRetryableD1LockError(error: unknown) {
-	return errorCauseChainIncludes(
-		error,
+	return errorCauseChainIncludes(error, isRetryableD1LockMessage)
+}
+
+export function isRetryableD1LockSentryEvent(event: ErrorEvent) {
+	const messages = [
+		event.message,
+		...(event.exception?.values?.map((value) => value.value) ?? []),
+	]
+	return messages.some(
 		(message) =>
-			message.includes('SQLITE_BUSY') || message.includes('database is locked'),
+			typeof message === 'string' && isRetryableD1LockMessage(message),
 	)
 }
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -9,6 +9,7 @@ import { RepoSession } from './repo/repo-session-do.ts'
 import { PackageRealtimeSession } from '#worker/package-runtime/realtime-session.ts'
 import { PackageServiceInstance } from '#worker/package-runtime/package-service.ts'
 import { DynamicCallableWorkflow } from '#worker/package-runtime/package-workflows.ts'
+import { isRetryableD1LockError } from './d1-retry.ts'
 import { getWorkerSentryOptions } from './sentry-options.ts'
 import { handleRequest } from '#app/handler.ts'
 import {
@@ -545,6 +546,13 @@ const workerHandler = {
 			try {
 				await lane.run()
 			} catch (error) {
+				if (isRetryableD1LockError(error)) {
+					console.warn(
+						`scheduled_lane_d1_lock_contention lane=${lane.name}`,
+						error,
+					)
+					continue
+				}
 				console.error(`scheduled_lane_failed lane=${lane.name}`, error)
 				Sentry.captureException(error)
 			}

--- a/packages/worker/src/index.workers.test.ts
+++ b/packages/worker/src/index.workers.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import * as Sentry from '@sentry/cloudflare'
 import { createExecutionContext, env } from 'cloudflare:test'
 
 const mocks = vi.hoisted(() => ({
@@ -93,5 +94,36 @@ test('scheduled isolates a failing lane: logs it and keeps siblings and the invo
 		)
 	} finally {
 		consoleErrorSpy.mockRestore()
+	}
+})
+
+test('scheduled logs D1 lock contention as a warning without reporting to Sentry', async () => {
+	const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	const captureException = vi
+		.spyOn(Sentry, 'captureException')
+		.mockImplementation(() => '')
+	mocks.reconcileArtifactsPushes.mockRejectedValueOnce(
+		new Error('D1_ERROR: NOSENTRY database is locked: SQLITE_BUSY'),
+	)
+	const scheduledTime = Date.parse('2026-07-05T10:20:00.000Z')
+
+	try {
+		await worker.scheduled?.(
+			createController(scheduledTime),
+			env,
+			createExecutionContext(),
+		)
+
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			'scheduled_lane_d1_lock_contention lane=reconcile_artifacts_pushes',
+			expect.objectContaining({
+				message: 'D1_ERROR: NOSENTRY database is locked: SQLITE_BUSY',
+			}),
+		)
+		expect(captureException).not.toHaveBeenCalled()
+		expect(mocks.cleanupRepoSessionBranches).toHaveBeenCalled()
+	} finally {
+		consoleWarnSpy.mockRestore()
+		captureException.mockRestore()
 	}
 })

--- a/packages/worker/src/repo/entity-sources.ts
+++ b/packages/worker/src/repo/entity-sources.ts
@@ -1,3 +1,4 @@
+import { runD1WithRetry } from '#worker/d1-retry.ts'
 import {
 	type EntityKind,
 	type EntitySourceRow,
@@ -144,14 +145,16 @@ export async function updateEntitySource(
 		add('last_external_check_at', input.lastExternalCheckAt)
 	}
 	add('updated_at', new Date().toISOString())
-	const result = await db
-		.prepare(
-			`UPDATE entity_sources
+	const result = await runD1WithRetry(() =>
+		db
+			.prepare(
+				`UPDATE entity_sources
 			SET ${assignments.join(', ')}
 			WHERE id = ? AND user_id = ?`,
-		)
-		.bind(...values, input.id, input.userId)
-		.run()
+			)
+			.bind(...values, input.id, input.userId)
+			.run(),
+	)
 	return (result.meta.changes ?? 0) > 0
 }
 

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'vitest'
+import { filterRetryableD1LockSentryEvent } from './sentry-options.ts'
+
+test('filterRetryableD1LockSentryEvent drops transient D1 SQLITE_BUSY events', () => {
+	expect(
+		filterRetryableD1LockSentryEvent({
+			exception: {
+				values: [
+					{
+						value: 'D1_ERROR: NOSENTRY database is locked: SQLITE_BUSY',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+})
+
+test('filterRetryableD1LockSentryEvent keeps unrelated errors', () => {
+	const event = {
+		exception: {
+			values: [{ value: 'D1_ERROR: syntax error near INSERTZ' }],
+		},
+	}
+	expect(filterRetryableD1LockSentryEvent(event)).toBe(event)
+})

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -1,9 +1,16 @@
 import { type CloudflareOptions } from '@sentry/cloudflare'
+import type { ErrorEvent } from '@sentry/core'
+import { isRetryableD1LockSentryEvent } from './d1-retry.ts'
 
 /**
  * Shared Sentry options for the Cloudflare Worker and Durable Objects.
  * `dsn` may be undefined when Sentry is not configured (local dev / opt-out).
  */
+export function filterRetryableD1LockSentryEvent(event: ErrorEvent) {
+	if (!isRetryableD1LockSentryEvent(event)) return event
+	return null
+}
+
 export function buildSentryOptions(env: Env): CloudflareOptions {
 	const dsn = env.SENTRY_DSN?.trim()
 	const environment = env.SENTRY_ENVIRONMENT?.trim() || 'development'
@@ -21,6 +28,11 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		...(release ? { release } : {}),
 		tracesSampleRate,
 		sendDefaultPii: false,
+		// D1 marks SQLITE_BUSY with NOSENTRY at the storage layer, but
+		// application capture paths (for example scheduled_lane_failed) still
+		// forwarded them. These are transient lock-contention errors retried in
+		// app code and should not open or regress Sentry issues.
+		beforeSend: filterRetryableD1LockSentryEvent,
 	}
 }
 

--- a/packages/worker/src/usage/aggregate-rollups.ts
+++ b/packages/worker/src/usage/aggregate-rollups.ts
@@ -19,6 +19,8 @@
  * directly there.
  */
 
+import { runD1WithRetry } from '#worker/d1-retry.ts'
+
 export const usageAggregationCronGateMinutes = 5
 export const usageAggregationCronIntervalMinutes = 60
 
@@ -203,10 +205,12 @@ async function deleteStaleCurrentMonthRollups(input: {
 	month: string
 	presentPairs: ReadonlySet<string>
 }) {
-	const { results } = await input.db
-		.prepare(`SELECT user_id, metric FROM usage_rollups WHERE month = ?`)
-		.bind(input.month)
-		.all<{ user_id: string; metric: string }>()
+	const { results } = await runD1WithRetry(() =>
+		input.db
+			.prepare(`SELECT user_id, metric FROM usage_rollups WHERE month = ?`)
+			.bind(input.month)
+			.all<{ user_id: string; metric: string }>(),
+	)
 	const stalePairs = (results ?? []).filter(
 		(row) => !input.presentPairs.has(rollupPairKey(row)),
 	)
@@ -220,15 +224,17 @@ async function deleteStaleCurrentMonthRollups(input: {
 		const pairPredicates = chunk
 			.map(() => '(user_id = ? AND metric = ?)')
 			.join(' OR ')
-		const result = await input.db
-			.prepare(
-				`DELETE FROM usage_rollups WHERE month = ? AND (${pairPredicates})`,
-			)
-			.bind(
-				input.month,
-				...chunk.flatMap((pair) => [pair.user_id, pair.metric]),
-			)
-			.run()
+		const result = await runD1WithRetry(() =>
+			input.db
+				.prepare(
+					`DELETE FROM usage_rollups WHERE month = ? AND (${pairPredicates})`,
+				)
+				.bind(
+					input.month,
+					...chunk.flatMap((pair) => [pair.user_id, pair.metric]),
+				)
+				.run(),
+		)
 		deleted += result.meta.changes ?? 0
 	}
 	return deleted
@@ -284,7 +290,9 @@ export async function aggregateUsageRollups(
 	)
 	const users = new Set(presentRows.map((row) => row.user_id)).size
 	for (let index = 0; index < statements.length; index += upsertBatchSize) {
-		await env.APP_DB.batch(statements.slice(index, index + upsertBatchSize))
+		await runD1WithRetry(() =>
+			env.APP_DB.batch(statements.slice(index, index + upsertBatchSize)),
+		)
 	}
 	// An entirely empty result is more likely Analytics Engine ingestion
 	// lag (or a dataset misconfiguration) than a genuinely event-free


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Follow-up to #679

PR #679 serialized cron lanes and added D1 lock retries for retention, but `KODY-CLOUDFLARE-M` can still fire because:

1. **Application Sentry still captured lock errors** — Cloudflare D1 prefixes transient `SQLITE_BUSY` with `NOSENTRY` at the storage layer, but `scheduled_lane_failed` still called `Sentry.captureException`.
2. **Other cron lanes lacked retry** — usage rollup aggregation and reconcile `updateEntitySource` writes had no `runD1WithRetry`.

## Changes

- Add `beforeSend` filter in `sentry-options.ts` to drop transient D1 lock-contention events from Sentry entirely.
- In the scheduled handler, log lock contention as `scheduled_lane_d1_lock_contention` warnings instead of reporting to Sentry.
- Extend `runD1WithRetry` to usage rollup batch upserts/deletes and reconcile entity source updates.

After deploy, mark `KODY-CLOUDFLARE-M` resolved in Sentry (no new events should arrive).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-326009cb-5c03-456d-a1a5-9cab435268a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-326009cb-5c03-456d-a1a5-9cab435268a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary database lock errors so background work can continue without failing the whole job.
  * Reduced noisy error reporting by suppressing transient lock-related alerts.
  * Made usage rollup updates and entity source updates more resilient during brief database contention.
* **New Features**
  * Added smarter retry handling for recurring lock-related database errors, including better detection across background processing and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->