### PR TITLE
Add MCP onboarding page and banner for new accounts

### DIFF
--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -33,8 +33,8 @@ primitives:
     group: surfaces
     name: Browser app (Remix 3)
     summary:
-      Server-first Remix 3 UI and app routes (home, auth, account, session,
-      admin, community, privacy, health) served by the Worker.
+      Server-first Remix 3 UI and app routes (home, auth, account, onboarding,
+      session, admin, community, privacy, health) served by the Worker.
     code:
       - packages/worker/src/app/
     docs:

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -1,0 +1,26 @@
+# Connect your agent
+
+Kody is an MCP server. You use it from Cursor, Claude Desktop, or any other AI
+agent that supports MCP — not from a separate Kody chat app.
+
+## Add the MCP server
+
+1. In your agent host, add a remote MCP server.
+2. Use this deployment’s MCP URL: `https://<this-host>/mcp`. The in-app Get
+   started page (`/onboarding`) shows the exact URL for the host you are on.
+3. Complete the OAuth flow when the host opens it. Sign in to Kody if needed,
+   then approve access.
+
+MCP stays unavailable until your account email is verified. If authorize fails
+for that reason, verify from your account page and try again.
+
+## Ask your agent to help set up
+
+After the connection works, paste a short setup prompt into your agent (the Get
+started page has a copy button). Ask it to explain what Kody can do and help
+configure secrets, integrations, or packages you need.
+
+## Where to go next
+
+- [First steps](./first-steps.md) — search-first habits and common goals
+- [Troubleshooting](./troubleshooting.md) — auth, empty results, and approvals

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -1,13 +1,16 @@
 # Using Kody
 
-Documentation for people who already connect their agent to Kody over MCP. Setup
-and repository development live elsewhere
-([contributing docs](../contributing/index.md)).
+Documentation for people who connect their agent to Kody over MCP. Setup and
+repository development live elsewhere
+([contributing docs](../contributing/index.md)). The in-app Get started page
+(`/onboarding`) walks through connecting a host for the first time.
 
 Read in order for a full tour, or jump to a topic.
 
 ## Guides
 
+- [Connect your agent](./connect-your-agent.md) — add `{origin}/mcp`, complete
+  OAuth, and use the setup prompt
 - [First steps — what to ask Kody to do](./first-steps.md)
 - [Search](./search.md)
 - [Execute and workflows](./execute.md) — includes per-user MCP instruction

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -35,6 +35,11 @@ import {
 	AccountManagementMessage,
 	AccountManagementShell,
 } from '#client/routes/account-management-components.tsx'
+import { renderOnboardingBanner } from '#client/routes/onboarding-banner.tsx'
+import {
+	fetchOnboardingPayload,
+	type OnboardingPayload,
+} from '#client/routes/onboarding.tsx'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
@@ -97,19 +102,25 @@ export async function accountRouteLoader(
 	url: URL,
 	signal: AbortSignal,
 ): Promise<RouteLoaderResult> {
-	const response = await fetch(`${accountProfileApiPath}${url.search}`, {
-		headers: { Accept: 'application/json' },
-		credentials: 'include',
-		signal,
-	})
-	if (response.status === 401) {
+	const [profileResponse, onboarding] = await Promise.all([
+		fetch(`${accountProfileApiPath}${url.search}`, {
+			headers: { Accept: 'application/json' },
+			credentials: 'include',
+			signal,
+		}),
+		fetchOnboardingPayload(signal),
+	])
+	if (profileResponse.status === 401) {
 		return routeLoaderRedirect('/login')
 	}
-	const payload = await readJson<AccountProfilePayload>(response)
-	if (!response.ok || !payload?.ok) {
+	const payload = await readJson<AccountProfilePayload>(profileResponse)
+	if (!profileResponse.ok || !payload?.ok) {
 		throw new Error('Unable to load your account.')
 	}
-	return { accountProfile: payload }
+	return {
+		accountProfile: payload,
+		...(onboarding ? { onboarding } : {}),
+	}
 }
 
 export function AccountRoute(handle: Handle) {
@@ -136,6 +147,7 @@ export function AccountRoute(handle: Handle) {
 	let availableProviders: Array<AuthProviderInfo> = []
 	let connectionsMessage: { text: string; tone: 'error' | 'info' } | null = null
 	let consumedCallbackMessage = false
+	let needsOnboarding = false
 	const loadLatch = createRouteLoadLatch()
 
 	function applyConnectionsPayload(payload: AccountConnectionsPayload) {
@@ -244,15 +256,22 @@ export function AccountRoute(handle: Handle) {
 		}
 	}
 
+	function applyOnboardingPayload(payload: OnboardingPayload | null) {
+		needsOnboarding = payload?.needsOnboarding === true
+	}
+
 	async function loadAccountProfile(signal: AbortSignal) {
 		const href = readCurrentRouterHref(handle)
 		try {
 			const search = new URL(href, 'http://localhost').search
-			const response = await fetch(`${accountProfileApiPath}${search}`, {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-				signal,
-			})
+			const [response, onboarding] = await Promise.all([
+				fetch(`${accountProfileApiPath}${search}`, {
+					headers: { Accept: 'application/json' },
+					credentials: 'include',
+					signal,
+				}),
+				fetchOnboardingPayload(signal),
+			])
 			if (signal.aborted) return
 			if (response.status === 401) {
 				window.location.assign('/login')
@@ -262,6 +281,7 @@ export function AccountRoute(handle: Handle) {
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load your account.')
 			}
+			applyOnboardingPayload(onboarding)
 			email = payload.email
 			emailVerified = payload.emailVerified
 			username = payload.username
@@ -473,6 +493,10 @@ export function AccountRoute(handle: Handle) {
 		username = routeData.username
 		draftUsername = routeData.username
 		draftEmail = routeData.email
+		const onboardingData = tryConsumeRouteLoaderData(handle, 'onboarding', href)
+		if (onboardingData) {
+			applyOnboardingPayload(onboardingData)
+		}
 		status = 'ready'
 		message = null
 		messageTone = 'info'
@@ -532,6 +556,7 @@ export function AccountRoute(handle: Handle) {
 
 				{status === 'ready' ? (
 					<>
+						{needsOnboarding ? renderOnboardingBanner() : null}
 						{!emailVerified ? (
 							<section
 								aria-label="Email verification status"

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -1,4 +1,14 @@
 import { type Handle, css } from 'remix/ui'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { createRouteLoadLatch } from '#client/route-load-latch.ts'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { renderOnboardingBanner } from '#client/routes/onboarding-banner.tsx'
+import {
+	fetchOnboardingPayload,
+	type OnboardingPayload,
+} from '#client/routes/onboarding.tsx'
+import { type RouteLoaderResult } from '#client/route-loader.ts'
 import {
 	colors,
 	radius,
@@ -9,123 +19,199 @@ import {
 } from '#client/styles/tokens.ts'
 import { layoutMaxWidths } from '#client/styles/style-primitives.ts'
 
-export function HomeRoute(_handle: Handle) {
-	return () => (
-		<section
-			mix={css({
-				display: 'flex',
-				flexDirection: 'column',
-				alignItems: 'center',
-				gap: spacing['2xl'],
-				textAlign: 'center',
-				width: '100%',
-				boxSizing: 'border-box',
-				padding: spacing.md,
-				[mq.mobile]: {
-					padding: spacing.sm,
-					gap: spacing.xl,
-				},
-			})}
-		>
-			<div
+function isHomePath(href: string) {
+	return new URL(href, 'http://localhost').pathname === '/'
+}
+
+export async function homeRouteLoader(
+	_url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const onboarding = await fetchOnboardingPayload(signal)
+	if (!onboarding) return {}
+	return { onboarding }
+}
+
+export function HomeRoute(handle: Handle) {
+	let needsOnboarding = false
+	let onboardingStatus: 'idle' | 'loading' | 'ready' = 'idle'
+	const loadLatch = createRouteLoadLatch()
+
+	function applyOnboardingPayload(payload: OnboardingPayload | null) {
+		needsOnboarding = payload?.needsOnboarding === true
+		onboardingStatus = 'ready'
+	}
+
+	async function loadOnboarding(signal: AbortSignal) {
+		const href = readCurrentRouterHref(handle)
+		try {
+			const payload = await fetchOnboardingPayload(signal)
+			if (signal.aborted) return
+			applyOnboardingPayload(payload)
+			loadLatch.markLoaded(href)
+			handle.update()
+		} catch {
+			if (signal.aborted) return
+			needsOnboarding = false
+			onboardingStatus = 'ready'
+			loadLatch.markFailed(href)
+			handle.update()
+		}
+	}
+
+	function applyRouteLoaderData(href: string) {
+		if (!isHomePath(href)) return false
+		const routeData = tryConsumeRouteLoaderData(handle, 'onboarding', href)
+		if (!routeData) return false
+		applyOnboardingPayload(routeData)
+		loadLatch.markLoaded(href)
+		return true
+	}
+
+	return () => {
+		const currentHref = readCurrentRouterHref(handle)
+		const appliedRouteData = applyRouteLoaderData(currentHref)
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
+		const needsLoad = loadLatch.needsLoad({
+			currentHref,
+			isLoading: onboardingStatus === 'loading' || onboardingStatus === 'idle',
+			appliedRouteData,
+			needsStaleRefresh,
+		})
+		if (needsLoad && typeof document !== 'undefined') {
+			onboardingStatus = 'loading'
+			handle.queueTask(loadOnboarding)
+		}
+
+		return (
+			<section
 				mix={css({
-					display: 'grid',
-					gap: spacing.lg,
-					padding: spacing['2xl'],
-					borderRadius: radius.xl,
-					border: `1px solid ${colors.border}`,
-					background: `linear-gradient(135deg, ${colors.primarySoftStrong}, ${colors.primarySoftest})`,
-					boxShadow: shadows.md,
-					maxWidth: layoutMaxWidths.narrow,
+					display: 'flex',
+					flexDirection: 'column',
+					alignItems: 'center',
+					gap: spacing['2xl'],
+					textAlign: 'center',
 					width: '100%',
+					boxSizing: 'border-box',
+					padding: spacing.md,
 					[mq.mobile]: {
-						padding: spacing.lg,
+						padding: spacing.sm,
+						gap: spacing.xl,
 					},
 				})}
 			>
+				{needsOnboarding ? (
+					<div
+						mix={css({
+							width: '100%',
+							maxWidth: layoutMaxWidths.content,
+							textAlign: 'left',
+						})}
+					>
+						{renderOnboardingBanner()}
+					</div>
+				) : null}
 				<div
 					mix={css({
 						display: 'grid',
 						gap: spacing.lg,
-						justifyItems: 'center',
+						padding: spacing['2xl'],
+						borderRadius: radius.xl,
+						border: `1px solid ${colors.border}`,
+						background: `linear-gradient(135deg, ${colors.primarySoftStrong}, ${colors.primarySoftest})`,
+						boxShadow: shadows.md,
+						maxWidth: layoutMaxWidths.narrow,
+						width: '100%',
+						[mq.mobile]: {
+							padding: spacing.lg,
+						},
 					})}
 				>
-					<img
-						src="/logo.png"
-						alt="kody logo"
+					<div
 						mix={css({
-							width: '220px',
-							maxWidth: '100%',
-							height: 'auto',
-							[mq.mobile]: {
-								width: '160px',
-							},
+							display: 'grid',
+							gap: spacing.lg,
+							justifyItems: 'center',
 						})}
-					/>
-
-					<div mix={css({ display: 'grid', gap: spacing.md })}>
-						<h1
+					>
+						<img
+							src="/logo.png"
+							alt="kody logo"
 							mix={css({
-								fontSize: typography.fontSize['2xl'],
-								fontWeight: typography.fontWeight.bold,
-								margin: 0,
-								color: colors.text,
-							})}
-						>
-							Meet <span mix={css({ color: colors.primaryText })}>kody</span>
-						</h1>
-						<p
-							mix={css({
-								margin: 0,
-								color: colors.textMuted,
-								fontSize: typography.fontSize.lg,
-								lineHeight: 1.6,
+								width: '220px',
+								maxWidth: '100%',
+								height: 'auto',
 								[mq.mobile]: {
-									fontSize: typography.fontSize.base,
+									width: '160px',
 								},
 							})}
-						>
-							Your personal assistant, built to work from any AI agent host that
-							supports MCP.
-						</p>
+						/>
+
+						<div mix={css({ display: 'grid', gap: spacing.md })}>
+							<h1
+								mix={css({
+									fontSize: typography.fontSize['2xl'],
+									fontWeight: typography.fontWeight.bold,
+									margin: 0,
+									color: colors.text,
+								})}
+							>
+								Meet <span mix={css({ color: colors.primaryText })}>kody</span>
+							</h1>
+							<p
+								mix={css({
+									margin: 0,
+									color: colors.textMuted,
+									fontSize: typography.fontSize.lg,
+									lineHeight: 1.6,
+									[mq.mobile]: {
+										fontSize: typography.fontSize.base,
+									},
+								})}
+							>
+								Your personal assistant, built to work from any AI agent host
+								that supports MCP.
+							</p>
+						</div>
 					</div>
 				</div>
-			</div>
 
-			<div
-				mix={css({
-					display: 'grid',
-					gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
-					gap: spacing.lg,
-					maxWidth: layoutMaxWidths.content,
-					width: '100%',
-					[mq.mobile]: {
-						gridTemplateColumns: '1fr',
-						gap: spacing.md,
-					},
-				})}
-			>
-				{renderFeatureCard({
-					title: 'MCP Powered',
-					description:
-						'Designed to keep the public MCP surface small while exposing a vast graph of capabilities behind the scenes.',
-					icon: '🔌',
-				})}
-				{renderFeatureCard({
-					title: 'Highly Portable',
-					description:
-						'Built to interoperate across MCP-capable hosts, keeping the focus on the assistant rather than host-specific apps.',
-					icon: '🚀',
-				})}
-				{renderFeatureCard({
-					title: 'Personalized',
-					description:
-						'Optimized for personal workflows and fast iteration, not generic multi-tenant administration.',
-					icon: '🧠',
-				})}
-			</div>
-		</section>
-	)
+				<div
+					mix={css({
+						display: 'grid',
+						gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+						gap: spacing.lg,
+						maxWidth: layoutMaxWidths.content,
+						width: '100%',
+						[mq.mobile]: {
+							gridTemplateColumns: '1fr',
+							gap: spacing.md,
+						},
+					})}
+				>
+					{renderFeatureCard({
+						title: 'MCP Powered',
+						description:
+							'Designed to keep the public MCP surface small while exposing a vast graph of capabilities behind the scenes.',
+						icon: '🔌',
+					})}
+					{renderFeatureCard({
+						title: 'Highly Portable',
+						description:
+							'Built to interoperate across MCP-capable hosts, keeping the focus on the assistant rather than host-specific apps.',
+						icon: '🚀',
+					})}
+					{renderFeatureCard({
+						title: 'Personalized',
+						description:
+							'Optimized for personal workflows and fast iteration, not generic multi-tenant administration.',
+						icon: '🧠',
+					})}
+				</div>
+			</section>
+		)
+	}
 }
 
 function renderFeatureCard({

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -46,8 +46,9 @@ import {
 } from './community-detail.tsx'
 import { CommunityRoute, communityRouteLoader } from './community.tsx'
 import { ConnectOauthRoute } from './connect-oauth.tsx'
-import { HomeRoute } from './home.tsx'
+import { HomeRoute, homeRouteLoader } from './home.tsx'
 import { LoginRoute } from './login.tsx'
+import { OnboardingRoute, onboardingRouteLoader } from './onboarding.tsx'
 import { PrivacyRoute } from './privacy.tsx'
 import {
 	OAuthAuthorizeRoute,
@@ -59,6 +60,7 @@ import { VerifyEmailRoute } from './verify-email.tsx'
 import { VerifyRoute } from './verify.tsx'
 
 export const clientRouteLoaders: Record<string, RouteLoader> = {
+	'/': homeRouteLoader,
 	'/account': accountRouteLoader,
 	'/account/integrations': accountIntegrationsRouteLoader,
 	'/account/mcp-servers': accountMcpServersRouteLoader,
@@ -88,6 +90,7 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 	'/community': communityRouteLoader,
 	'/community/:listingId': communityDetailRouteLoader,
 	'/oauth/authorize': oauthAuthorizeRouteLoader,
+	'/onboarding': onboardingRouteLoader,
 }
 
 export const clientRoutes = {
@@ -122,6 +125,7 @@ export const clientRoutes = {
 	'/community': <CommunityRoute />,
 	'/community/:listingId': <CommunityDetailRoute />,
 	'/login': <LoginRoute />,
+	'/onboarding': <OnboardingRoute />,
 	'/privacy': <PrivacyRoute />,
 	'/signup': <LoginRoute />,
 	'/reset-password': <ResetPasswordRoute />,

--- a/packages/worker/client/routes/onboarding-banner.tsx
+++ b/packages/worker/client/routes/onboarding-banner.tsx
@@ -1,0 +1,37 @@
+import { css } from 'remix/ui'
+import { colors } from '#client/styles/tokens.ts'
+import {
+	cardCss,
+	cardTitleCss,
+	descriptionCss,
+	primaryLinkCss,
+} from '#client/styles/style-primitives.ts'
+import { onboardingPath } from '#client/routes/onboarding.tsx'
+
+/**
+ * Callout shown when the signed-in user has never authorized an MCP host.
+ */
+export function renderOnboardingBanner() {
+	return (
+		<section
+			aria-label="Get started with Kody"
+			mix={css({
+				...cardCss,
+				borderColor: colors.primary,
+				backgroundColor: colors.primarySoftest,
+			})}
+		>
+			<h2 mix={css(cardTitleCss)}>Connect your AI agent</h2>
+			<p mix={css(descriptionCss)}>
+				Kody works through MCP. Add this deployment as an MCP server in Cursor,
+				Claude, or any MCP-capable agent, complete the OAuth flow, then ask your
+				agent to help you get set up.
+			</p>
+			<p mix={css({ margin: 0 })}>
+				<a href={onboardingPath} mix={css(primaryLinkCss)}>
+					Open onboarding guide
+				</a>
+			</p>
+		</section>
+	)
+}

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -1,0 +1,303 @@
+import { type Handle, css } from 'remix/ui'
+import { writeClipboardText } from '#client/clipboard.ts'
+import { on } from '#client/event-mixin.ts'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { createRouteLoadLatch } from '#client/route-load-latch.ts'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import {
+	type AccountStatus,
+	readJson,
+} from '#client/routes/account-approval-shared.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
+import {
+	AccountManagementHeader,
+	AccountManagementMessage,
+	AccountManagementShell,
+} from '#client/routes/account-management-components.tsx'
+import { colors, spacing, typography } from '#client/styles/tokens.ts'
+import {
+	cardCss,
+	cardTitleCss,
+	descriptionCss,
+	getPrimaryButtonCss,
+	getSecondaryButtonCss,
+	insetCardCss,
+	layoutMaxWidths,
+	mutedLinkCss,
+	primaryLinkCss,
+} from '#client/styles/style-primitives.ts'
+
+export type OnboardingPayload = {
+	ok: true
+	mcpServerUrl: string
+	setupPrompt: string
+	hasMcpClient: boolean
+	needsOnboarding: boolean
+}
+
+export const onboardingApiPath = '/onboarding.json'
+export const onboardingPath = '/onboarding'
+
+function isOnboardingPath(href: string) {
+	return new URL(href, 'http://localhost').pathname === onboardingPath
+}
+
+export async function onboardingRouteLoader(
+	_url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const response = await fetch(onboardingApiPath, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		return routeLoaderRedirect('/login')
+	}
+	const payload = await readJson<OnboardingPayload>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load onboarding.')
+	}
+	return { onboarding: payload }
+}
+
+export async function fetchOnboardingPayload(signal?: AbortSignal) {
+	const response = await fetch(onboardingApiPath, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) return null
+	const payload = await readJson<OnboardingPayload>(response)
+	if (!response.ok || !payload?.ok) return null
+	return payload
+}
+
+export function OnboardingRoute(handle: Handle) {
+	let status: AccountStatus = 'loading'
+	let message: string | null = null
+	let mcpServerUrl = ''
+	let setupPrompt = ''
+	let hasMcpClient = false
+	let urlCopyState: 'idle' | 'copied' | 'error' = 'idle'
+	let promptCopyState: 'idle' | 'copied' | 'error' = 'idle'
+	const loadLatch = createRouteLoadLatch()
+	let urlCopyResetTimer: ReturnType<typeof setTimeout> | null = null
+	let promptCopyResetTimer: ReturnType<typeof setTimeout> | null = null
+
+	function applyPayload(payload: OnboardingPayload) {
+		mcpServerUrl = payload.mcpServerUrl
+		setupPrompt = payload.setupPrompt
+		hasMcpClient = payload.hasMcpClient
+		status = 'ready'
+		message = null
+	}
+
+	async function loadOnboarding(signal: AbortSignal) {
+		const href = readCurrentRouterHref(handle)
+		try {
+			const response = await fetch(onboardingApiPath, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (signal.aborted) return
+			if (response.status === 401) {
+				window.location.assign('/login?redirectTo=%2Fonboarding')
+				return
+			}
+			const payload = await readJson<OnboardingPayload>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load onboarding.')
+			}
+			applyPayload(payload)
+			loadLatch.markLoaded(href)
+			handle.update()
+		} catch (error) {
+			if (signal.aborted) return
+			status = 'error'
+			message =
+				error instanceof Error ? error.message : 'Unable to load onboarding.'
+			loadLatch.markFailed(href)
+			handle.update()
+		}
+	}
+
+	function applyRouteLoaderData(href: string) {
+		if (!isOnboardingPath(href)) return false
+		const routeData = tryConsumeRouteLoaderData(handle, 'onboarding', href)
+		if (!routeData) return false
+		applyPayload(routeData)
+		loadLatch.markLoaded(href)
+		return true
+	}
+
+	async function copyValue(value: string, kind: 'url' | 'prompt') {
+		try {
+			await writeClipboardText(value)
+			if (kind === 'url') {
+				urlCopyState = 'copied'
+				if (urlCopyResetTimer) clearTimeout(urlCopyResetTimer)
+				urlCopyResetTimer = setTimeout(() => {
+					urlCopyState = 'idle'
+					handle.update()
+				}, 2000)
+			} else {
+				promptCopyState = 'copied'
+				if (promptCopyResetTimer) clearTimeout(promptCopyResetTimer)
+				promptCopyResetTimer = setTimeout(() => {
+					promptCopyState = 'idle'
+					handle.update()
+				}, 2000)
+			}
+		} catch {
+			if (kind === 'url') urlCopyState = 'error'
+			else promptCopyState = 'error'
+		}
+		handle.update()
+	}
+
+	return () => {
+		const currentHref = readCurrentRouterHref(handle)
+		const appliedRouteData = applyRouteLoaderData(currentHref)
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
+		const needsLoad = loadLatch.needsLoad({
+			currentHref,
+			isLoading: status === 'loading',
+			appliedRouteData,
+			needsStaleRefresh,
+		})
+		if (needsLoad && typeof document !== 'undefined') {
+			handle.queueTask(loadOnboarding)
+		}
+
+		const primaryButtonCss = getPrimaryButtonCss()
+		const secondaryButtonCss = getSecondaryButtonCss()
+
+		return (
+			<AccountManagementShell maxWidth={layoutMaxWidths.content}>
+				<AccountManagementHeader
+					title="Get started with Kody"
+					description="Connect any MCP-capable AI agent to your Kody account, then ask it to help you set things up."
+				/>
+
+				{status === 'loading' ? (
+					<p mix={css({ color: colors.textMuted, margin: 0 })}>
+						Loading onboarding…
+					</p>
+				) : null}
+				{message ? (
+					<AccountManagementMessage tone="error">
+						{message}
+					</AccountManagementMessage>
+				) : null}
+
+				{status === 'ready' ? (
+					<>
+						{hasMcpClient ? (
+							<section mix={css(cardCss)}>
+								<h2 mix={css(cardTitleCss)}>You are connected</h2>
+								<p mix={css(descriptionCss)}>
+									At least one AI agent has already authorized access to this
+									account. You can still use the steps below to connect another
+									host or re-run setup with your agent.
+								</p>
+							</section>
+						) : null}
+
+						<section mix={css(cardCss)}>
+							<h2 mix={css(cardTitleCss)}>1. Add Kody as an MCP server</h2>
+							<p mix={css(descriptionCss)}>
+								In Cursor, Claude Desktop, or any other AI agent that supports
+								MCP, add a remote MCP server pointed at this URL:
+							</p>
+							<pre mix={css(codeBlockCss)}>{mcpServerUrl}</pre>
+							<div
+								mix={css({
+									display: 'flex',
+									gap: spacing.sm,
+									flexWrap: 'wrap',
+								})}
+							>
+								<button
+									type="button"
+									mix={[
+										css(primaryButtonCss),
+										on('click', () => void copyValue(mcpServerUrl, 'url')),
+									]}
+								>
+									{urlCopyState === 'copied'
+										? 'Copied'
+										: urlCopyState === 'error'
+											? 'Copy failed'
+											: 'Copy MCP URL'}
+								</button>
+							</div>
+							<p mix={css(descriptionCss)}>
+								When your agent connects, it starts an OAuth flow. Sign in to
+								Kody if needed, approve the request, and the agent receives a
+								token scoped to your account.
+							</p>
+							<p mix={css(descriptionCss)}>
+								Verify your account email first if you have not already — MCP
+								access stays disabled until the email is verified.
+							</p>
+						</section>
+
+						<section mix={css(cardCss)}>
+							<h2 mix={css(cardTitleCss)}>2. Ask your agent to help set up</h2>
+							<p mix={css(descriptionCss)}>
+								After the connection succeeds, paste this prompt into your
+								agent. It asks the agent to explain what Kody can do and help
+								you configure the basics.
+							</p>
+							<pre mix={css(codeBlockCss)}>{setupPrompt}</pre>
+							<button
+								type="button"
+								mix={[
+									css(secondaryButtonCss),
+									on('click', () => void copyValue(setupPrompt, 'prompt')),
+								]}
+							>
+								{promptCopyState === 'copied'
+									? 'Copied'
+									: promptCopyState === 'error'
+										? 'Copy failed'
+										: 'Copy prompt'}
+							</button>
+						</section>
+
+						<p mix={css({ margin: 0 })}>
+							<a href="/account" mix={css(mutedLinkCss)}>
+								Back to account
+							</a>
+							{' · '}
+							<a href="/account/secrets" mix={css(primaryLinkCss)}>
+								Secrets
+							</a>
+							{' · '}
+							<a href="/account/integrations" mix={css(primaryLinkCss)}>
+								Integrations
+							</a>
+						</p>
+					</>
+				) : null}
+			</AccountManagementShell>
+		)
+	}
+}
+
+const codeBlockCss = {
+	...insetCardCss,
+	margin: 0,
+	whiteSpace: 'pre-wrap' as const,
+	wordBreak: 'break-word' as const,
+	fontFamily: typography.fontFamily,
+	fontSize: typography.fontSize.sm,
+	lineHeight: 1.6,
+}

--- a/packages/worker/src/app/handlers/account.ts
+++ b/packages/worker/src/app/handlers/account.ts
@@ -6,6 +6,7 @@ import {
 	redirectToLogin,
 	redirectToLoginWhenUnauthenticated,
 } from '#app/auth-redirect.ts'
+import { loadOnboardingData } from '#app/onboarding-data.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 
@@ -24,12 +25,19 @@ export function createAccountHandler(env: Env) {
 				return redirectToLoginWhenUnauthenticated(request, env)
 			}
 
-			const accountProfile = await loadAccountProfileData(user)
+			const [accountProfile, onboarding] = await Promise.all([
+				loadAccountProfileData(user),
+				loadOnboardingData({
+					env,
+					requestUrl: request.url,
+					stableUserId: user.mcpUser.userId,
+				}),
+			])
 			return renderAppPage({
 				request,
 				env,
 				title: 'Account',
-				loaderData: { accountProfile },
+				loaderData: { accountProfile, onboarding },
 			})
 		},
 	} satisfies Action<typeof routes.account>

--- a/packages/worker/src/app/handlers/home.ts
+++ b/packages/worker/src/app/handlers/home.ts
@@ -1,4 +1,6 @@
 import { type Action } from 'remix/router'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { loadOnboardingData } from '#app/onboarding-data.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 
@@ -6,7 +8,21 @@ export function createHomeHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			return renderAppPage({ request, env })
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return renderAppPage({ request, env })
+			}
+
+			const onboarding = await loadOnboardingData({
+				env,
+				requestUrl: request.url,
+				stableUserId: user.mcpUser.userId,
+			})
+			return renderAppPage({
+				request,
+				env,
+				loaderData: { onboarding },
+			})
 		},
 	} satisfies Action<typeof routes.home>
 }

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -1,0 +1,104 @@
+import { expect, test, vi } from 'vitest'
+import { RequestContext } from 'remix/router'
+import {
+	createAuthCookie,
+	setAuthSessionSecret,
+	type AuthSession,
+} from '#app/auth-session.ts'
+import {
+	createOnboardingApiHandler,
+	createOnboardingHandler,
+} from '#app/handlers/onboarding.ts'
+
+const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
+
+vi.mock('#app/onboarding-data.ts', () => ({
+	loadOnboardingData: vi.fn(async () => ({
+		ok: true,
+		mcpServerUrl: 'https://example.com/mcp',
+		setupPrompt: 'Help me get started with Kody.',
+		hasMcpClient: false,
+		needsOnboarding: true,
+	})),
+}))
+
+vi.mock('#app/ssr-render.tsx', () => ({
+	renderAppPage: vi.fn(async () => new Response('ok')),
+}))
+
+function createStaleSessionTestEnv() {
+	return {
+		COOKIE_SECRET: testCookieSecret,
+		APP_DB: {
+			prepare(query: string) {
+				const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
+				return {
+					bind() {
+						return {
+							async all() {
+								if (
+									normalizedQuery.startsWith('select') &&
+									normalizedQuery.includes('from "users"')
+								) {
+									return { results: [], meta: { changes: 0 } }
+								}
+								if (normalizedQuery.includes('from user_roles ur')) {
+									return { results: [], meta: { changes: 0 } }
+								}
+								return { results: [], meta: { changes: 0 } }
+							},
+							async first() {
+								return null
+							},
+							async run() {
+								return { meta: { changes: 0 } }
+							},
+						}
+					},
+				}
+			},
+			async exec() {
+				return
+			},
+		} as unknown as D1Database,
+	} as Env
+}
+
+test('onboarding handler redirects to login with a session-destroy cookie for stale sessions', async () => {
+	setAuthSessionSecret(testCookieSecret)
+	const session: AuthSession = {
+		id: '99',
+		email: 'missing@example.com',
+		rememberMe: false,
+	}
+	const cookie = await createAuthCookie(session, false)
+	const handler = createOnboardingHandler(createStaleSessionTestEnv())
+	const response = await handler.handler(
+		new RequestContext(
+			new Request('https://example.com/onboarding', {
+				headers: { Cookie: cookie },
+			}),
+		),
+	)
+
+	expect(response.status).toBe(302)
+	expect(response.headers.get('Location')).toBe(
+		'https://example.com/login?redirectTo=%2Fonboarding',
+	)
+	const setCookie = response.headers.get('Set-Cookie') ?? ''
+	expect(setCookie).toContain('kody_session=')
+	expect(setCookie).toContain('Max-Age=0')
+})
+
+test('onboarding API returns 401 for anonymous requests', async () => {
+	setAuthSessionSecret(testCookieSecret)
+	const handler = createOnboardingApiHandler(createStaleSessionTestEnv())
+	const response = await handler.handler(
+		new RequestContext(new Request('https://example.com/onboarding.json')),
+	)
+	expect(response.status).toBe(401)
+	await expect(response.json()).resolves.toEqual({
+		ok: false,
+		error: 'Unauthorized.',
+	})
+})

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -1,0 +1,64 @@
+import { jsonResponse } from '#worker/json-response.ts'
+import { type Action } from 'remix/router'
+import {
+	redirectToLogin,
+	redirectToLoginWhenUnauthenticated,
+} from '#app/auth-redirect.ts'
+import { readAuthSessionResult } from '#app/auth-session.ts'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { loadOnboardingData } from '#app/onboarding-data.ts'
+import { renderAppPage } from '#app/ssr-render.tsx'
+import { type routes } from '#app/routes.ts'
+
+export function createOnboardingHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const { session } = await readAuthSessionResult(request)
+			if (!session) {
+				return redirectToLogin(request)
+			}
+
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return redirectToLoginWhenUnauthenticated(request, env)
+			}
+
+			const onboarding = await loadOnboardingData({
+				env,
+				requestUrl: request.url,
+				stableUserId: user.mcpUser.userId,
+			})
+			return renderAppPage({
+				request,
+				env,
+				title: 'Get started',
+				loaderData: { onboarding },
+			})
+		},
+	} satisfies Action<typeof routes.onboarding>
+}
+
+export function createOnboardingApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+
+			if (request.method !== 'GET') {
+				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+			}
+
+			return jsonResponse(
+				await loadOnboardingData({
+					env,
+					requestUrl: request.url,
+					stableUserId: user.mcpUser.userId,
+				}),
+			)
+		},
+	} satisfies Action<typeof routes.onboardingApi>
+}

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -250,6 +250,14 @@ export type AccountProfileLoaderData = {
 	displayName: string
 }
 
+export type OnboardingLoaderData = {
+	ok: true
+	mcpServerUrl: string
+	setupPrompt: string
+	hasMcpClient: boolean
+	needsOnboarding: boolean
+}
+
 export type AccountTwoFactorLoaderData = {
 	ok: true
 	enabled: boolean
@@ -442,6 +450,7 @@ export type AppLoaderData = {
 	adminUsage?: AdminUsageLoaderData
 	adminSystemEmail?: AdminSystemEmailLoaderData
 	accountProfile?: AccountProfileLoaderData
+	onboarding?: OnboardingLoaderData
 	accountTwoFactor?: AccountTwoFactorLoaderData
 	accountPasskeys?: AccountPasskeysLoaderData
 	accountIntegrations?: AccountIntegrationsLoaderData

--- a/packages/worker/src/app/onboarding-data.node.test.ts
+++ b/packages/worker/src/app/onboarding-data.node.test.ts
@@ -1,0 +1,92 @@
+import { expect, test, vi } from 'vitest'
+import {
+	buildMcpServerUrl,
+	buildOnboardingSetupPrompt,
+	loadOnboardingData,
+	userHasMcpOAuthGrants,
+} from '#app/onboarding-data.ts'
+
+test('buildMcpServerUrl prefers the request origin and appends /mcp', () => {
+	expect(
+		buildMcpServerUrl({
+			env: { APP_BASE_URL: 'https://configured.example' },
+			requestUrl: 'https://preview.example/account',
+		}),
+	).toBe('https://preview.example/mcp')
+})
+
+test('userHasMcpOAuthGrants is false without a provider or grants', async () => {
+	expect(await userHasMcpOAuthGrants({}, 'user-1')).toBe(false)
+	expect(
+		await userHasMcpOAuthGrants(
+			{
+				OAUTH_PROVIDER: {
+					listUserGrants: vi.fn(async () => ({ items: [] })),
+				},
+			},
+			'user-1',
+		),
+	).toBe(false)
+})
+
+test('userHasMcpOAuthGrants is true when the first page has a grant', async () => {
+	const listUserGrants = vi.fn(async () => ({
+		items: [{ id: 'grant-1', clientId: 'client-1' }],
+	}))
+	expect(
+		await userHasMcpOAuthGrants(
+			{ OAUTH_PROVIDER: { listUserGrants } },
+			'user-1',
+		),
+	).toBe(true)
+	expect(listUserGrants).toHaveBeenCalledWith('user-1')
+})
+
+test('userHasMcpOAuthGrants treats listing failures as no grants', async () => {
+	expect(
+		await userHasMcpOAuthGrants(
+			{
+				OAUTH_PROVIDER: {
+					listUserGrants: vi.fn(async () => {
+						throw new Error('provider unavailable')
+					}),
+				},
+			},
+			'user-1',
+		),
+	).toBe(false)
+})
+
+test('loadOnboardingData returns the MCP URL, setup prompt, and needs flag', async () => {
+	const withoutClient = await loadOnboardingData({
+		env: {
+			OAUTH_PROVIDER: {
+				listUserGrants: vi.fn(async () => ({ items: [] })),
+			},
+		},
+		requestUrl: 'https://heykody.dev/onboarding',
+		stableUserId: 'user-1',
+	})
+	expect(withoutClient).toEqual({
+		ok: true,
+		mcpServerUrl: 'https://heykody.dev/mcp',
+		setupPrompt: buildOnboardingSetupPrompt(),
+		hasMcpClient: false,
+		needsOnboarding: true,
+	})
+
+	const withClient = await loadOnboardingData({
+		env: {
+			OAUTH_PROVIDER: {
+				listUserGrants: vi.fn(async () => ({
+					items: [{ id: 'grant-1' }],
+				})),
+			},
+		},
+		requestUrl: 'http://localhost:3742/onboarding',
+		stableUserId: 'user-1',
+	})
+	expect(withClient.needsOnboarding).toBe(false)
+	expect(withClient.hasMcpClient).toBe(true)
+	expect(withClient.mcpServerUrl).toBe('http://localhost:3742/mcp')
+})

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -1,0 +1,74 @@
+import { getAppBaseUrl } from '#app/app-base-url.ts'
+import { type OnboardingLoaderData } from '#app/loader-data.ts'
+
+const mcpServerPath = '/mcp'
+
+type OnboardingEnv = {
+	APP_BASE_URL?: string | null
+	OAUTH_PROVIDER?: {
+		listUserGrants(
+			userId: string,
+			options?: { cursor?: string },
+		): Promise<{ items: Array<unknown>; cursor?: string }>
+	}
+}
+
+export function buildMcpServerUrl(input: {
+	env: Pick<OnboardingEnv, 'APP_BASE_URL'>
+	requestUrl: string | URL
+}) {
+	return `${getAppBaseUrl({
+		env: input.env,
+		requestUrl: input.requestUrl,
+	})}${mcpServerPath}`
+}
+
+export function buildOnboardingSetupPrompt() {
+	return [
+		'Help me get started with Kody.',
+		'First explain what Kody can do for me in plain language.',
+		'Then help me set up the basics for my account — for example secrets, integrations, or packages I might need.',
+		'Prefer searching first, then executing.',
+	].join(' ')
+}
+
+/**
+ * True when the user has at least one inbound MCP OAuth grant (an AI host
+ * authorized against this account). Listing failures treat the user as still
+ * needing onboarding so the banner stays available.
+ */
+export async function userHasMcpOAuthGrants(
+	env: OnboardingEnv,
+	stableUserId: string,
+) {
+	const helpers = env.OAUTH_PROVIDER
+	if (!helpers) return false
+	try {
+		const page = await helpers.listUserGrants(stableUserId)
+		return page.items.length > 0
+	} catch {
+		return false
+	}
+}
+
+export async function loadOnboardingData(input: {
+	env: OnboardingEnv
+	requestUrl: string | URL
+	stableUserId: string
+}): Promise<OnboardingLoaderData> {
+	const mcpServerUrl = buildMcpServerUrl({
+		env: input.env,
+		requestUrl: input.requestUrl,
+	})
+	const hasMcpClient = await userHasMcpOAuthGrants(
+		input.env,
+		input.stableUserId,
+	)
+	return {
+		ok: true,
+		mcpServerUrl,
+		setupPrompt: buildOnboardingSetupPrompt(),
+		hasMcpClient,
+		needsOnboarding: !hasMcpClient,
+	}
+}

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -80,6 +80,10 @@ import {
 import { createHealthHandler } from '#app/handlers/health.ts'
 import { createHomeHandler } from '#app/handlers/home.ts'
 import { createLoginHandler } from '#app/handlers/login.ts'
+import {
+	createOnboardingApiHandler,
+	createOnboardingHandler,
+} from '#app/handlers/onboarding.ts'
 import { createPrivacyHandler } from '#app/handlers/privacy.ts'
 import { createResetPasswordHandler } from '#app/handlers/reset-password.ts'
 import {
@@ -121,6 +125,8 @@ export function createAppRouter(env: Env) {
 			health: createHealthHandler(env),
 			login: createLoginHandler(env),
 			privacy: createPrivacyHandler(env),
+			onboarding: createOnboardingHandler(env),
+			onboardingApi: createOnboardingApiHandler(env),
 			resetPassword: createResetPasswordHandler(env),
 			verifyEmail: createVerifyEmailHandler(env),
 			verifyEmailChange: createVerifyEmailChangeHandler(env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -68,6 +68,8 @@ export const routes = route({
 	health: '/health',
 	login: '/login',
 	privacy: '/privacy',
+	onboarding: '/onboarding',
+	onboardingApi: '/onboarding.json',
 	resetPassword: '/reset-password',
 	verify: '/verify',
 	verifyTwoFactorApi: post('/verify/2fa.json'),

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -8,7 +8,9 @@ import {
 } from '#app/auth-session.ts'
 import { createAccountHandler } from '#app/handlers/account.ts'
 import { createCommunityHandler } from '#app/handlers/community.tsx'
+import { createOnboardingHandler } from '#app/handlers/onboarding.ts'
 import { createResetPasswordHandler } from '#app/handlers/reset-password.ts'
+import { buildOnboardingSetupPrompt } from '#app/onboarding-data.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { resetDataCacheForTests } from '#app/data-cache.ts'
 
@@ -246,6 +248,44 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		username: 'account-user',
 		displayName: 'account-user',
 	})
+	expect(accountProps.loaderData?.onboarding).toEqual({
+		ok: true,
+		mcpServerUrl: 'https://example.com/mcp',
+		setupPrompt: buildOnboardingSetupPrompt(),
+		hasMcpClient: false,
+		needsOnboarding: true,
+	})
+	expect(accountHtml).toContain('Connect your AI agent')
+	expect(accountHtml).toContain('/onboarding')
+
+	const onboardingResponse = await runHtmlHandler(
+		createOnboardingHandler(env),
+		new Request('https://example.com/onboarding', {
+			headers: { Cookie: accountCookie },
+		}),
+	)
+	expect(onboardingResponse.status).toBe(200)
+	const onboardingHtml = await readResponseText(onboardingResponse)
+	expect(onboardingHtml).toContain('Get started with Kody')
+	expect(onboardingHtml).toContain('https://example.com/mcp')
+	expect(onboardingHtml).toContain(buildOnboardingSetupPrompt())
+	const onboardingProps = readAppRootProps(onboardingHtml)
+	expect(onboardingProps.loaderData?.onboarding).toEqual({
+		ok: true,
+		mcpServerUrl: 'https://example.com/mcp',
+		setupPrompt: buildOnboardingSetupPrompt(),
+		hasMcpClient: false,
+		needsOnboarding: true,
+	})
+
+	const anonymousOnboardingResponse = await runHtmlHandler(
+		createOnboardingHandler(env),
+		new Request('https://example.com/onboarding'),
+	)
+	expect(anonymousOnboardingResponse.status).toBe(302)
+	expect(anonymousOnboardingResponse.headers.get('Location')).toBe(
+		'https://example.com/login?redirectTo=%2Fonboarding',
+	)
 
 	const anonymousAccountResponse = await runHtmlHandler(
 		createAccountHandler(env),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

New invitees (and anyone who has never authorized an MCP host) need a clear first step. This adds:

- A **Connect your AI agent** banner on `/` and `/account` when the user has no inbound MCP OAuth grants
- An authenticated **`/onboarding`** page that shows the request-scoped MCP URL (`{origin}/mcp`), explains the OAuth flow, and provides a copyable setup prompt for their agent
- A short usage doc: [Connect your agent](docs/use/connect-your-agent.md)

“Has a client” is detected via `OAUTH_PROVIDER.listUserGrants(stableUserId)` — the same grant store used when an agent completes `/oauth/authorize`.

## Test plan

- [ ] Sign up / log in as a user with no MCP grants → banner on `/account` and `/`
- [ ] Open `/onboarding` → MCP URL matches the current host + `/mcp`; copy buttons work
- [ ] Complete MCP OAuth from an agent → banner disappears on next account/home load
- [ ] Anonymous `/` still works; `/onboarding` redirects to login
- [ ] `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `ecfeed79` · **Head:** `917c24b1`

**Classification:** composes — wires existing app UI, sessions, and MCP OAuth grant listing into a new onboarding route and banner; no primitive contracts changed.

### Primitives touched

| Primitive   | Group    | Impact                                                                 |
| ----------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`    | surfaces | composes — `/onboarding`, home/account banners, loader data            |
| `app-sessions` | auth  | composes — auth-gated onboarding handlers                              |
| `mcp-oauth` | auth     | composes — `listUserGrants` to detect first MCP client connection      |
| `mcp-server`| surfaces | composes — displays request-scoped `{origin}/mcp` URL for hosts        |

### System map

Logged-in users without MCP grants see a banner that links to `/onboarding`, which reads OAuth grants and shows the MCP URL for the current request host.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::touched
	appSessions["app-sessions<br/>Browser sessions"]:::touched
	mcpOauth["mcp-oauth<br/>MCP OAuth"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint"]:::touched
	appUi -->|"GET /onboarding + banner on / and /account"| appSessions
	appUi -->|"listUserGrants for needsOnboarding"| mcpOauth
	appUi -->|"shows request-origin /mcp URL"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant User
	participant App as app-ui
	participant OAuth as mcp-oauth
	User->>App: GET /account or /
	App->>OAuth: listUserGrants(stableUserId)
	alt no grants
		App-->>User: banner → /onboarding
		User->>App: GET /onboarding
		App-->>User: MCP URL + setup prompt
	else has grants
		App-->>User: normal page (no banner)
	end
```

### Invariants

- Per-user isolation: grant listing and onboarding data are scoped to the authenticated user's stable id.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f433b-ec67-7336-a076-fa943f6c428e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f433b-ec67-7336-a076-fa943f6c428e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

