### PR TITLE
Add package invocation token metadata capabilities

### DIFF
--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -22,11 +22,10 @@ description: >
 By default, continue to Discord message with summary and include PR link
 
 If explicitly requested, merge PR as Kody with
-`kody:@kentcdodds/github/pr/merge` using
-`{ prUrl, mergeMethod: 'squash' }` (or `{ owner, repo, prNumber, ... }`;
-optional `commitTitle`), watch CI deploy, when finished, continue to the discord
-message and include a summary with link to PR, deployed URL link, or failing job
-link.
+`kody:@kentcdodds/github/pr/merge` using `{ prUrl, mergeMethod: 'squash' }` (or
+`{ owner, repo, prNumber, ... }`; optional `commitTitle`), watch CI deploy, when
+finished, continue to the discord message and include a summary with link to PR,
+deployed URL link, or failing job link.
 
 Other useful exports on the same package: `pr/get-checks` for check-run status
 without `gh`, and `request` / `graphql` (`kody:@kentcdodds/github/request`,

--- a/docs/guides/account-package-invocation-token-setup.md
+++ b/docs/guides/account-package-invocation-token-setup.md
@@ -28,6 +28,12 @@ is write-only and optional: leaving it blank keeps the current bearer value,
 while pasting a new raw token replaces the stored hash. The UI never shows the
 existing raw token or token hash.
 
+Agents can inspect existing token record metadata with
+`package_invocation_token_list` and `package_invocation_token_get`. These
+capabilities return record ids, names, package/export/source scopes, timestamps,
+last-used metadata, and revocation status for the signed-in user's own records.
+They never return raw bearer token values or stored token hashes.
+
 In the editor, look for the **Token value** section. The **New raw token value**
 field is where the user pastes or generates a replacement token value before
 saving.
@@ -119,21 +125,26 @@ export.
 1. Identify the saved package and export the external system needs to call.
    - Use package Kody ids when possible because they are human-readable.
    - Use `*` only for highly trusted personal clients.
-2. Generate a `/account/package-invocation-tokens/new` URL with `name`, package
+2. If debugging an existing setup, call `package_invocation_token_list` or
+   `package_invocation_token_get` first to confirm which token record exists and
+   whether its package, export, and allowed-source scopes match the external
+   caller. Do not ask the user to read token metadata out of the browser UI
+   unless the capability response is insufficient.
+3. Generate a `/account/package-invocation-tokens/new` URL with `name`, package
    scope, export scope, and optional `allowedSources`.
-3. Ask the user to open the URL, paste their locally generated raw token into
+4. Ask the user to open the URL, paste their locally generated raw token into
    the Raw token field, or click **Generate** and copy/deliver the generated
    value before creating the token.
    - For rotation, ask the user to open the existing token detail URL and paste
      or generate the new raw token in the **Token value** section.
    - The external service or secret store must receive the exact raw value that
      was pasted/generated.
-4. Instruct the external caller to send:
+5. Instruct the external caller to send:
    - `POST` to the canonical owner-scoped invocation URL from package metadata,
      not to a `/account/package-invocation-tokens/...` setup URL
    - `Authorization: Bearer <raw-token>`
    - JSON `source` matching one of the allowed sources when sources are scoped
-5. Never display, log, store in docs, or send raw token material through chat or
+6. Never display, log, store in docs, or send raw token material through chat or
    query params.
 
 ## Verification notes for agents

--- a/packages/worker/src/mcp/capabilities/packages/domain.ts
+++ b/packages/worker/src/mcp/capabilities/packages/domain.ts
@@ -7,6 +7,8 @@ import { listPackagesCapability } from './list-packages.ts'
 import { listPackageSubscriptionsCapability } from './list-package-subscriptions.ts'
 import { packageDebugGetRunCapability } from './package-debug-get-run.ts'
 import { packageDebugListRunsCapability } from './package-debug-list-runs.ts'
+import { packageInvocationTokenGetCapability } from './package-invocation-token-get.ts'
+import { packageInvocationTokenListCapability } from './package-invocation-token-list.ts'
 import { publishExternalPushCapability } from './publish-external-push.ts'
 import { savePackageCapability } from './save-package.ts'
 
@@ -31,6 +33,8 @@ export const packagesDomain = defineDomain({
 		getGitRemoteCapability,
 		listPackagesCapability,
 		listPackageSubscriptionsCapability,
+		packageInvocationTokenListCapability,
+		packageInvocationTokenGetCapability,
 		packageDebugListRunsCapability,
 		packageDebugGetRunCapability,
 		publishExternalPushCapability,

--- a/packages/worker/src/mcp/capabilities/packages/package-invocation-token-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-invocation-token-capabilities.node.test.ts
@@ -1,0 +1,168 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	listPackageInvocationTokensByUserId: vi.fn(),
+	getPackageInvocationTokenById: vi.fn(),
+}))
+
+vi.mock('#worker/package-invocations/repo.ts', () => ({
+	listPackageInvocationTokensByUserId: (...args: Array<unknown>) =>
+		mockModule.listPackageInvocationTokensByUserId(...args),
+	getPackageInvocationTokenById: (...args: Array<unknown>) =>
+		mockModule.getPackageInvocationTokenById(...args),
+}))
+
+const { capabilityMap, capabilitySpecs } =
+	await import('#mcp/capabilities/registry.ts')
+const { packageInvocationTokenListCapability } =
+	await import('./package-invocation-token-list.ts')
+const { packageInvocationTokenGetCapability } =
+	await import('./package-invocation-token-get.ts')
+
+const tokenRecord = {
+	id: 'pit-1',
+	user_id: 'user-1',
+	token_hash: 'stored-token-hash',
+	name: 'Discord gateway',
+	email: 'user@example.com',
+	display_name: 'User',
+	package_ids_json: '["package-1"]',
+	package_kody_ids_json: '["discord-gateway","*"]',
+	export_names_json: '["./dispatch-event"]',
+	sources_json: '["discord-fly-proxy"]',
+	created_at: '2026-07-01T00:00:00.000Z',
+	updated_at: '2026-07-02T00:00:00.000Z',
+	last_used_at: '2026-07-03T00:00:00.000Z',
+	revoked_at: null,
+	packageIds: ['package-1'],
+	packageKodyIds: ['discord-gateway', '*'],
+	exportNames: ['./dispatch-event'],
+	sources: ['discord-fly-proxy'],
+}
+
+function createCapabilityContext() {
+	return {
+		env: { APP_DB: {} as D1Database } as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'User',
+			},
+		}),
+	}
+}
+
+test('package invocation token capabilities are registered for discovery', () => {
+	expect(capabilityMap.package_invocation_token_list).toBe(
+		packageInvocationTokenListCapability,
+	)
+	expect(capabilityMap.package_invocation_token_get).toBe(
+		packageInvocationTokenGetCapability,
+	)
+	expect(capabilitySpecs.package_invocation_token_list).toMatchObject({
+		domain: 'packages',
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		outputFields: ['tokens'],
+	})
+	expect(capabilitySpecs.package_invocation_token_get).toMatchObject({
+		domain: 'packages',
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		requiredInputFields: ['token_id'],
+		outputFields: ['token'],
+	})
+})
+
+test('package_invocation_token_list returns user-scoped metadata without token hashes', async () => {
+	mockModule.listPackageInvocationTokensByUserId.mockReset()
+	mockModule.listPackageInvocationTokensByUserId.mockResolvedValue([
+		tokenRecord,
+	])
+
+	const result = await packageInvocationTokenListCapability.handler(
+		{},
+		createCapabilityContext(),
+	)
+
+	expect(mockModule.listPackageInvocationTokensByUserId).toHaveBeenCalledWith({
+		db: expect.anything(),
+		userId: 'user-1',
+	})
+	expect(JSON.stringify(result)).not.toContain('stored-token-hash')
+	expect(result).toEqual({
+		tokens: [
+			{
+				token_id: 'pit-1',
+				name: 'Discord gateway',
+				package_ids: ['package-1'],
+				package_kody_ids: ['discord-gateway', '*'],
+				export_names: ['./dispatch-event'],
+				allowed_sources: ['discord-fly-proxy'],
+				created_at: '2026-07-01T00:00:00.000Z',
+				updated_at: '2026-07-02T00:00:00.000Z',
+				last_used_at: '2026-07-03T00:00:00.000Z',
+				revoked_at: null,
+			},
+		],
+	})
+})
+
+test('package_invocation_token_get returns one user-scoped metadata record', async () => {
+	mockModule.getPackageInvocationTokenById.mockReset()
+	mockModule.getPackageInvocationTokenById.mockResolvedValue({
+		...tokenRecord,
+		id: 'pit-2',
+		name: 'Revoked client',
+		last_used_at: null,
+		revoked_at: '2026-07-04T00:00:00.000Z',
+	})
+
+	const result = await packageInvocationTokenGetCapability.handler(
+		{ token_id: 'pit-2' },
+		createCapabilityContext(),
+	)
+
+	expect(mockModule.getPackageInvocationTokenById).toHaveBeenCalledWith({
+		db: expect.anything(),
+		userId: 'user-1',
+		tokenId: 'pit-2',
+	})
+	expect(JSON.stringify(result)).not.toContain('stored-token-hash')
+	expect(result).toEqual({
+		token: {
+			token_id: 'pit-2',
+			name: 'Revoked client',
+			package_ids: ['package-1'],
+			package_kody_ids: ['discord-gateway', '*'],
+			export_names: ['./dispatch-event'],
+			allowed_sources: ['discord-fly-proxy'],
+			created_at: '2026-07-01T00:00:00.000Z',
+			updated_at: '2026-07-02T00:00:00.000Z',
+			last_used_at: null,
+			revoked_at: '2026-07-04T00:00:00.000Z',
+		},
+	})
+})
+
+test('package_invocation_token_get rejects tokens outside the signed-in user scope', async () => {
+	mockModule.getPackageInvocationTokenById.mockReset()
+	mockModule.getPackageInvocationTokenById.mockResolvedValue(null)
+
+	await expect(
+		packageInvocationTokenGetCapability.handler(
+			{ token_id: 'other-user-token' },
+			createCapabilityContext(),
+		),
+	).rejects.toThrow('Package invocation token not found for this user.')
+	expect(mockModule.getPackageInvocationTokenById).toHaveBeenCalledWith({
+		db: expect.anything(),
+		userId: 'user-1',
+		tokenId: 'other-user-token',
+	})
+})

--- a/packages/worker/src/mcp/capabilities/packages/package-invocation-token-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-invocation-token-capabilities.node.test.ts
@@ -94,7 +94,10 @@ test('package_invocation_token_list returns user-scoped metadata without token h
 		db: expect.anything(),
 		userId: 'user-1',
 	})
-	expect(JSON.stringify(result)).not.toContain('stored-token-hash')
+	const serialized = JSON.stringify(result)
+	expect(serialized).not.toContain('stored-token-hash')
+	expect(serialized).not.toContain('user@example.com')
+	expect(serialized).not.toContain('"display_name"')
 	expect(result).toEqual({
 		tokens: [
 			{
@@ -133,7 +136,10 @@ test('package_invocation_token_get returns one user-scoped metadata record', asy
 		userId: 'user-1',
 		tokenId: 'pit-2',
 	})
-	expect(JSON.stringify(result)).not.toContain('stored-token-hash')
+	const serialized = JSON.stringify(result)
+	expect(serialized).not.toContain('stored-token-hash')
+	expect(serialized).not.toContain('user@example.com')
+	expect(serialized).not.toContain('"display_name"')
 	expect(result).toEqual({
 		token: {
 			token_id: 'pit-2',

--- a/packages/worker/src/mcp/capabilities/packages/package-invocation-token-get.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-invocation-token-get.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { getPackageInvocationTokenById } from '#worker/package-invocations/repo.ts'
+import { packageInvocationTokenMetadataSchema } from './shared.ts'
+
+export const packageInvocationTokenGetCapability = defineDomainCapability(
+	capabilityDomainNames.packages,
+	{
+		name: 'package_invocation_token_get',
+		description:
+			'Get metadata for one package invocation token record owned by the signed-in user, including package/export/source scopes, timestamps, last-used, and revocation status. Raw bearer token values and stored token hashes are never returned.',
+		keywords: [
+			'package invocation token',
+			'invocation token',
+			'bearer token',
+			'external package invocation',
+			'metadata',
+			'get',
+		],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: z.object({
+			token_id: z
+				.string()
+				.min(1)
+				.describe('Package invocation token record id to inspect.'),
+		}),
+		outputSchema: z.object({
+			token: packageInvocationTokenMetadataSchema,
+		}),
+		async handler(args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const token = await getPackageInvocationTokenById({
+				db: ctx.env.APP_DB,
+				userId: user.userId,
+				tokenId: args.token_id,
+			})
+			if (!token) {
+				throw new Error('Package invocation token not found for this user.')
+			}
+			return {
+				token: {
+					token_id: token.id,
+					name: token.name,
+					package_ids: token.packageIds,
+					package_kody_ids: token.packageKodyIds,
+					export_names: token.exportNames,
+					allowed_sources: token.sources,
+					created_at: token.created_at,
+					updated_at: token.updated_at,
+					last_used_at: token.last_used_at,
+					revoked_at: token.revoked_at,
+				},
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/packages/package-invocation-token-list.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-invocation-token-list.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
+import { listPackageInvocationTokensByUserId } from '#worker/package-invocations/repo.ts'
+import { packageInvocationTokenMetadataSchema } from './shared.ts'
+
+export const packageInvocationTokenListCapability = defineDomainCapability(
+	capabilityDomainNames.packages,
+	{
+		name: 'package_invocation_token_list',
+		description:
+			'List package invocation token record metadata for the signed-in user, including package/export/source scopes, timestamps, last-used, and revocation status. Raw bearer token values and stored token hashes are never returned.',
+		keywords: [
+			'package invocation token',
+			'invocation token',
+			'bearer token',
+			'external package invocation',
+			'metadata',
+			'list',
+		],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: emptyCapabilityInputSchema,
+		outputSchema: z.object({
+			tokens: z.array(packageInvocationTokenMetadataSchema),
+		}),
+		async handler(_args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const tokens = await listPackageInvocationTokensByUserId({
+				db: ctx.env.APP_DB,
+				userId: user.userId,
+			})
+			return {
+				tokens: tokens.map((token) => ({
+					token_id: token.id,
+					name: token.name,
+					package_ids: token.packageIds,
+					package_kody_ids: token.packageKodyIds,
+					export_names: token.exportNames,
+					allowed_sources: token.sources,
+					created_at: token.created_at,
+					updated_at: token.updated_at,
+					last_used_at: token.last_used_at,
+					revoked_at: token.revoked_at,
+				})),
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/packages/shared.ts
+++ b/packages/worker/src/mcp/capabilities/packages/shared.ts
@@ -92,3 +92,40 @@ export const packageExportSurfaceSchema = z.object({
 export const packageDetailSchema = packageSummarySchema.extend({
 	exports: z.array(packageExportSurfaceSchema),
 })
+
+export const packageInvocationTokenMetadataSchema = z.object({
+	token_id: z
+		.string()
+		.describe(
+			'Package invocation token record id. This is not a bearer token.',
+		),
+	name: z.string().describe('Human-readable token record name.'),
+	package_ids: z
+		.array(z.string())
+		.describe(
+			'Saved package ids allowed by this token record, including * when wildcard-scoped.',
+		),
+	package_kody_ids: z
+		.array(z.string())
+		.describe(
+			'Saved package kody.id scopes allowed by this token record, including * when wildcard-scoped.',
+		),
+	export_names: z
+		.array(z.string())
+		.describe(
+			'Normalized package export scopes allowed by this token record, including * when wildcard-scoped.',
+		),
+	allowed_sources: z
+		.array(z.string())
+		.describe('Optional exact source labels allowed by this token record.'),
+	created_at: z.string(),
+	updated_at: z.string(),
+	last_used_at: z
+		.string()
+		.nullable()
+		.describe('Most recent successful bearer-token use, when tracked.'),
+	revoked_at: z
+		.string()
+		.nullable()
+		.describe('Revocation timestamp, or null when the token record is active.'),
+})

--- a/packages/worker/src/package-invocations/repo.ts
+++ b/packages/worker/src/package-invocations/repo.ts
@@ -212,6 +212,24 @@ export async function listPackageInvocationTokensByUserId(input: {
 	return (rows.results ?? []).map(mapTokenRow)
 }
 
+export async function getPackageInvocationTokenById(input: {
+	db: D1Database
+	userId: string
+	tokenId: string
+}) {
+	const row = await input.db
+		.prepare(
+			`SELECT *
+			FROM package_invocation_tokens
+			WHERE id = ?
+				AND user_id = ?
+			LIMIT 1`,
+		)
+		.bind(input.tokenId, input.userId)
+		.first<Record<string, unknown>>()
+	return row ? mapTokenRow(row) : null
+}
+
 export async function insertPackageInvocationToken(input: {
 	db: D1Database
 	row: {

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -1597,6 +1597,26 @@ export default async function launchAgent() {
 			input: { scope: 'user' },
 		},
 	},
+	{
+		name: 'export package invocation token list',
+		entryPoint: 'src/launch-agent.ts',
+		source: `import { kody } from 'kody:runtime'
+
+export default async function launchAgent() {
+	return await kody.package_invocation_token_list({})
+}
+`,
+		kody: {
+			async package_invocation_token_list(input: unknown) {
+				return { ok: true, tool: 'package_invocation_token_list', input }
+			},
+		},
+		expected: {
+			ok: true,
+			tool: 'package_invocation_token_list',
+			input: {},
+		},
+	},
 ])(
 	'buildKodyModuleBundle keeps kody available for a preloaded package $name runtime',
 	async ({ entryPoint, source, kody, expected }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add read-only `package_invocation_token_list` and `package_invocation_token_get` capabilities under the packages domain.
- Return token record metadata only: ids, names, package/export/source scopes, timestamps, last-used, and revocation status scoped to the signed-in user.
- Update the token setup guide and add capability/runtime tests, including redaction checks for token hashes and token-record PII.

## Security note
No raw bearer token value, stored `token_hash`, or hash-derived fingerprint is returned. I omitted a fingerprint because Kody's existing account export/security conventions treat package invocation token hashes as credential-equivalent redacted fields; exposing a stable derivative would weaken that boundary.

## Validation
- `npm exec -- vitest run --project node-unit packages/worker/src/mcp/capabilities/packages/package-invocation-token-capabilities.node.test.ts`
- `npm exec -- vitest run --project node-unit packages/worker/src/package-runtime/module-graph.node.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run format:check`
- `npm run validate` (format, lint, typecheck, unit, Playwright E2E, MCP E2E all exited 0)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1fa6480a` · **Head:** `3d65312b`

**Classification:** extends — this PR adds new read-only capabilities to the existing capability registry and package capability domain, without introducing a new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capability-registry` | assistant | extends — registers two new read-only package invocation token metadata capabilities |
| `saved-packages` | assistant | extends — packages domain now exposes external invocation token metadata for package debugging |
| `mcp-server` | surfaces | composes — existing search/execute discovery surfaces the new registered capabilities |
| `d1-app-db` | storage | composes — reads existing `package_invocation_tokens` rows scoped by `user_id` |
| `package-runtime` | runtime | composes — adds test coverage that `kody.package_invocation_token_list` bridges through `kody:runtime` |

### System map

Package invocation token metadata flows through the existing MCP capability registry to the existing D1 token table, with metadata-only responses returned to agents.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::touched
	capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::touched
	packageRuntime["package-runtime<br/>Package runtime"]:::touched
	mcpServer -->|"search/execute exposes package_invocation_token_*"| capabilityRegistry
	capabilityRegistry -->|"packages domain registers list/get"| savedPackages
	savedPackages -->|"SELECT package_invocation_tokens WHERE user_id"| d1AppDb
	packageRuntime -->|"kody:runtime bridge test for kody.package_invocation_token_list"| capabilityRegistry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
Before: MCP agents could only infer package invocation token scopes by probing external calls or asking the user to inspect the browser UI.
After: MCP agents can call package_invocation_token_list/get for signed-in-user metadata; raw bearer values and stored hashes remain unavailable.
```

### Invariants

- `per-user-isolation`: list/get handlers require an MCP user and query token records by that `userId` only.
- `no-secrets-in-chat`: responses omit raw bearer values, stored hashes, hash-derived fingerprints, email, and display-name fields from token records.
- `compact-mcp-surface`: functionality lands behind existing search/execute capabilities, not a new top-level MCP tool.

### Plan vs actual

- Implemented as planned, with one review-driven test hardening pass to assert token-record PII stays out of list/get responses.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f7be631-f961-41d1-81ff-23943d0fb6ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f7be631-f961-41d1-81ff-23943d0fb6ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tools to list and retrieve package invocation token metadata for the signed-in user, including scope details, timestamps, and revocation status (without exposing bearer tokens or stored token hashes).
  * Exposed these new capabilities in the agent workflow and verified them in runtime behavior.
* **Documentation**
  * Updated the token setup guide to instruct agents to inspect existing token records first, using the appropriate listing/get capabilities, and to adjust the troubleshooting step flow.
* **Bug Fixes**
  * Ensured token details are only returned when the token exists for—and belongs to—the signed-in user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->