### PR TITLE
Add Approve all hosts button to OAuth success screen

### DIFF
--- a/packages/worker/client/routes/account-approval-shared.node.test.ts
+++ b/packages/worker/client/routes/account-approval-shared.node.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vitest'
+import { buildHostApprovalRequestUrl } from './account-approval-shared.ts'
+
+test('buildHostApprovalRequestUrl maps secret approval links to account secrets API requests', () => {
+	expect(
+		buildHostApprovalRequestUrl(
+			'https://example.com/account/secrets/user/slackAccessToken?allowed-host=slack.com',
+			'https://example.com',
+		),
+	).toBe(
+		'/account/secrets.json?allowed-host=slack.com&selected=user%3A%3A%3A%3AslackAccessToken',
+	)
+	expect(
+		buildHostApprovalRequestUrl(
+			'/account/secrets/user/githubAccessToken?allowed-host=api.github.com',
+		),
+	).toBe(
+		'/account/secrets.json?allowed-host=api.github.com&selected=user%3A%3A%3A%3AgithubAccessToken',
+	)
+})
+
+test('buildHostApprovalRequestUrl rejects invalid approval links', () => {
+	expect(() =>
+		buildHostApprovalRequestUrl('/account/secrets?allowed-host=slack.com'),
+	).toThrow('Invalid approval link.')
+})

--- a/packages/worker/client/routes/account-approval-shared.ts
+++ b/packages/worker/client/routes/account-approval-shared.ts
@@ -1,3 +1,5 @@
+import { parseAccountSecretPath } from '@kody-internal/shared/account-secret-route.ts'
+
 export type AccountStatus = 'loading' | 'ready' | 'error'
 export type ApprovalAction = 'approve' | 'reject'
 export type ApprovalScope = 'session' | 'package' | 'user'
@@ -23,6 +25,21 @@ export function getScopeLabel(scope: ApprovalScope) {
 
 export async function readJson<T>(response: Response) {
 	return (await response.json().catch(() => null)) as T | null
+}
+
+export function buildHostApprovalRequestUrl(
+	approvalUrl: string,
+	baseUrl = 'http://localhost',
+) {
+	const approvalPageUrl = new URL(approvalUrl, baseUrl)
+	const parsedPath = parseAccountSecretPath(approvalPageUrl.pathname)
+	if (!parsedPath) {
+		throw new Error('Invalid approval link.')
+	}
+	const requestUrl = new URL(accountSecretsApiPath, baseUrl)
+	requestUrl.search = approvalPageUrl.search
+	requestUrl.searchParams.set('selected', parsedPath.id)
+	return `${requestUrl.pathname}${requestUrl.search}`
 }
 
 export async function submitApprovalRequest<

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -8,6 +8,10 @@ import {
 } from '@kody-internal/shared/url-hosts.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
+import {
+	buildHostApprovalRequestUrl,
+	submitApprovalRequest,
+} from '#client/routes/account-approval-shared.ts'
 import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
@@ -132,6 +136,7 @@ export function ConnectOauthRoute(handle: Handle) {
 	let hasConfigError = false
 	let connectOauthHandled = false
 	let hostApprovalLinks: Array<ConnectOauthHostApprovalLink> = []
+	let approvingAllHosts = false
 	let submitting = false
 	let initialLoadStarted = false
 	let clientIdInput = ''
@@ -158,6 +163,36 @@ export function ConnectOauthRoute(handle: Handle) {
 	): void => {
 		hostApprovalLinks = links
 		update()
+	}
+
+	const approveAllHostApprovals = async () => {
+		if (approvingAllHosts || hostApprovalLinks.length === 0) return
+		approvingAllHosts = true
+		update()
+		const remainingLinks = [...hostApprovalLinks]
+		try {
+			for (const link of remainingLinks) {
+				const requestUrl = buildHostApprovalRequestUrl(
+					link.approvalUrl,
+					window.location.origin,
+				)
+				await submitApprovalRequest('approve', requestUrl)
+				hostApprovalLinks = hostApprovalLinks.filter(
+					(entry) =>
+						entry.secretName !== link.secretName || entry.host !== link.host,
+				)
+				update()
+			}
+			setStatus('All hosts approved.', 'info')
+		} catch (error) {
+			setStatus(
+				error instanceof Error ? error.message : 'Unable to approve all hosts.',
+				'error',
+			)
+		} finally {
+			approvingAllHosts = false
+			update()
+		}
 	}
 
 	const readQueryConfig = (): ConnectOauthQueryConfig | null => {
@@ -1143,6 +1178,16 @@ export function ConnectOauthRoute(handle: Handle) {
 								<p mix={css(descriptionCss)}>
 									Approve each token host directly:
 								</p>
+								<button
+									type="button"
+									disabled={approvingAllHosts}
+									mix={[
+										on('click', () => void approveAllHostApprovals()),
+										css(primaryButtonCss),
+									]}
+								>
+									{approvingAllHosts ? 'Approving hosts…' : 'Approve all hosts'}
+								</button>
 								<ul mix={css(listCss)}>
 									{hostApprovalLinks.map((link) => (
 										<li key={`${link.secretName}:${link.host}`}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After OAuth connect, the success screen lists individual host-approval links for each saved token secret. This adds an **Approve all hosts** button that approves every pending link in one click, without opening each approval page separately.

## Changes

- Added `buildHostApprovalRequestUrl` helper in `account-approval-shared.ts` to convert a secret approval link into the existing `/account/secrets.json` approve API request.
- Added **Approve all hosts** button on the OAuth success step in `connect-oauth.tsx`; approvals run sequentially and the list shrinks as each succeeds.
- Added unit tests for the new URL helper.

## Test plan

- [x] `npx vitest run packages/worker/client/routes/account-approval-shared.node.test.ts`
- [x] `npm run typecheck`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/approve-all-secrets-button-e919`

**Classification:** composes — no primitives added or changed; this PR wires existing secret host-approval APIs into the OAuth connect success UI.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `remix-ui` | surfaces | composes — new bulk-approve button on connect OAuth success screen |
| `secrets` | storage | composes — reuses existing host approval POST flow |

### System map

```mermaid
flowchart LR
  OAuthSuccess["connect-oauth success step"] --> ApproveAll["Approve all hosts button"]
  ApproveAll --> Helper["buildHostApprovalRequestUrl"]
  Helper --> API["/account/secrets.json approve"]
  API --> Secrets["secrets host approval policy"]
```

### What changed

- OAuth success screen now offers one-click bulk host approval alongside the existing per-link approvals.
- Shared client helper maps approval URLs to the account secrets approve API.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e96c0865-7572-43ec-b6ef-c25c8112e919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e96c0865-7572-43ec-b6ef-c25c8112e919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Approve all hosts” option to streamline OAuth setup across multiple connected hosts.
  * Approval progress is shown while requests are processed, with success and error status messages.
  * Individual host approval links continue to be supported.

* **Bug Fixes**
  * Improved approval-link handling by validating links and preserving required host and selection details.
  * Invalid approval links now produce a clear error instead of generating an unusable request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->