### PR TITLE
Fix overlapping OAuth provider detail URLs

### DIFF
--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -109,21 +109,9 @@ function buildConnectOauthHref(integration: AccountIntegrationListItem) {
 
 function renderIntegrationDetail(label: string, value: string) {
 	return (
-		<div mix={css({ ...detailItemCss, minWidth: 0 })}>
+		<div mix={css(detailItemCss)}>
 			<span mix={css(detailLabelCss)}>{label}</span>
-			<span
-				mix={css({
-					...detailValueCss,
-					display: 'block',
-					maxWidth: '100%',
-					minWidth: 0,
-					overflowWrap: 'anywhere',
-					whiteSpace: 'normal',
-					wordBreak: 'break-all',
-				})}
-			>
-				{value}
-			</span>
+			<span mix={css(detailValueCss)}>{value}</span>
 		</div>
 	)
 }

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -798,31 +798,39 @@ export function ConnectOauthRoute(handle: Handle) {
 					</div>
 					<div mix={css(detailItemCss)}>
 						<span mix={css(detailLabelCss)}>Token URL</span>
-						<code>{existingIntegrationConfig.tokenUrl}</code>
+						<code mix={css(detailValueCss)}>
+							{existingIntegrationConfig.tokenUrl}
+						</code>
 					</div>
 					{existingIntegrationConfig.apiBaseUrl ? (
 						<div mix={css(detailItemCss)}>
 							<span mix={css(detailLabelCss)}>API base URL</span>
-							<code>{existingIntegrationConfig.apiBaseUrl}</code>
+							<code mix={css(detailValueCss)}>
+								{existingIntegrationConfig.apiBaseUrl}
+							</code>
 						</div>
 					) : null}
 					<div mix={css(detailItemCss)}>
 						<span mix={css(detailLabelCss)}>Client ID value</span>
-						<code>{existingIntegrationConfig.clientIdValueName}</code>
+						<code mix={css(detailValueCss)}>
+							{existingIntegrationConfig.clientIdValueName}
+						</code>
 					</div>
 					<div mix={css(detailItemCss)}>
 						<span mix={css(detailLabelCss)}>Client secret secret</span>
-						<code>
+						<code mix={css(detailValueCss)}>
 							{existingIntegrationConfig.clientSecretSecretName ?? 'Not used'}
 						</code>
 					</div>
 					<div mix={css(detailItemCss)}>
 						<span mix={css(detailLabelCss)}>Access token secret</span>
-						<code>{existingIntegrationConfig.accessTokenSecretName}</code>
+						<code mix={css(detailValueCss)}>
+							{existingIntegrationConfig.accessTokenSecretName}
+						</code>
 					</div>
 					<div mix={css(detailItemCss)}>
 						<span mix={css(detailLabelCss)}>Refresh token secret</span>
-						<code>
+						<code mix={css(detailValueCss)}>
 							{existingIntegrationConfig.refreshTokenSecretName ?? 'Not used'}
 						</code>
 					</div>
@@ -833,7 +841,7 @@ export function ConnectOauthRoute(handle: Handle) {
 						<div mix={css(detailGridCss)}>
 							<div mix={css(detailItemCss)}>
 								<span mix={css(detailLabelCss)}>Authorize URL</span>
-								<code>
+								<code mix={css(detailValueCss)}>
 									{existingIntegrationConfig.authorization.authorizeUrl}
 								</code>
 							</div>
@@ -954,11 +962,11 @@ export function ConnectOauthRoute(handle: Handle) {
 					<div mix={css(detailGridCss)}>
 						<div mix={css(detailItemCss)}>
 							<span mix={css(detailLabelCss)}>Authorize URL</span>
-							<code>{config.authorizeUrl}</code>
+							<code mix={css(detailValueCss)}>{config.authorizeUrl}</code>
 						</div>
 						<div mix={css(detailItemCss)}>
 							<span mix={css(detailLabelCss)}>Token URL</span>
-							<code>{config.tokenUrl}</code>
+							<code mix={css(detailValueCss)}>{config.tokenUrl}</code>
 						</div>
 						<div mix={css(detailItemCss)}>
 							<span mix={css(detailLabelCss)}>Flow</span>

--- a/packages/worker/client/styles/style-primitives.ts
+++ b/packages/worker/client/styles/style-primitives.ts
@@ -218,6 +218,7 @@ export const detailItemCss = {
 	display: 'grid',
 	gap: spacing.xs,
 	alignContent: 'start',
+	minWidth: 0,
 }
 
 export const detailLabelCss = {
@@ -227,7 +228,13 @@ export const detailLabelCss = {
 }
 
 export const detailValueCss = {
+	display: 'block',
+	maxWidth: '100%',
+	minWidth: 0,
 	color: colors.text,
+	overflowWrap: 'anywhere',
+	whiteSpace: 'normal',
+	wordBreak: 'break-all',
 }
 
 export const primaryLinkCss = {

--- a/packages/worker/client/styles/style-primitives.ts
+++ b/packages/worker/client/styles/style-primitives.ts
@@ -234,7 +234,6 @@ export const detailValueCss = {
 	color: colors.text,
 	overflowWrap: 'anywhere',
 	whiteSpace: 'normal',
-	wordBreak: 'break-all',
 }
 
 export const primaryLinkCss = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Long authorize/token URLs in the Provider details grid were overflowing into neighboring columns on `/connect/oauth`.

## Changes
- Teach shared `detailItemCss` / `detailValueCss` to constrain width and wrap unbroken strings (`min-width: 0`, `overflow-wrap: anywhere`).
- Apply `detailValueCss` to bare `<code>` URL/name fields on the connect OAuth page.
- Drop the duplicate wrap styles from account integrations now that the shared primitive handles it.
- Follow-up: drop `word-break: break-all` so multi-word values can wrap at spaces.

## Verification
![Provider details at desktop width](https://cursor.com/artifacts/c/art-4dfca342-ed2f-4aca-9ad3-bb2b206dee72)
![Provider details at 800px width](https://cursor.com/artifacts/c/art-2df035ee-f70e-40cf-99cf-f10dbbe5560b)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `5fe4a1cd` · **Head:** latest on branch

**Classification:** extends — shared UI detail styles now wrap long values so grid columns stay in bounds.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — detail grid/value CSS wraps long URLs; connect OAuth and account integrations consume it |

### System map

```mermaid
flowchart LR
  connect["/connect/oauth Provider details"] --> detail["detailGridCss / detailValueCss"]
  integrations["/account/integrations"] --> detail
  detail --> wrap["min-width 0 + overflow-wrap"]
```

### Risk callouts
- Visual-only CSS change; no auth, storage, or MCP contract changes.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d89e528d-32dd-4407-9bec-de6a070aadf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d89e528d-32dd-4407-9bec-de6a070aadf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of integration and provider detail sections to better handle long content.
  * Updated detail value layout and wrapping so long URLs/tokens/metadata wrap within their containers rather than overflowing.
  * Standardized styling for code-formatted fields across OAuth configuration screens, including “Authorize URL” and “Token URL” values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->