### PR TITLE
Add sandboxed HTML preview tabs to admin system email view

### DIFF
--- a/packages/worker/client/email-html-preview.node.test.ts
+++ b/packages/worker/client/email-html-preview.node.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest'
+import {
+	buildAdminEmailHtmlPreviewDocument,
+	stripDangerousEmailHtml,
+} from './email-html-preview.ts'
+
+test('stripDangerousEmailHtml removes script blocks', () => {
+	const html =
+		'<p>Hello</p><script>alert("xss")</script><p>World</p><SCRIPT type="text/javascript">evil()</SCRIPT>'
+	expect(stripDangerousEmailHtml(html)).toBe('<p>Hello</p><p>World</p>')
+})
+
+test('buildAdminEmailHtmlPreviewDocument wraps HTML fragments', () => {
+	const document = buildAdminEmailHtmlPreviewDocument(
+		'<p>Invoice <strong>due</strong></p>',
+	)
+	expect(document).toMatch(/^<!DOCTYPE html>/i)
+	expect(document).toContain('<meta name="referrer" content="no-referrer">')
+	expect(document).toContain('<p>Invoice <strong>due</strong></p>')
+})
+
+test('buildAdminEmailHtmlPreviewDocument preserves full HTML documents', () => {
+	const html = `<!DOCTYPE html>
+<html>
+<head><title>Newsletter</title></head>
+<body><h1>Title</h1></body>
+</html>`
+	const document = buildAdminEmailHtmlPreviewDocument(html)
+	expect(document).toContain('<title>Newsletter</title>')
+	expect(document).toContain('<meta name="referrer" content="no-referrer">')
+	expect(document).not.toMatch(/<html>[\s\S]*<html>/i)
+})
+
+test('buildAdminEmailHtmlPreviewDocument strips scripts from full documents', () => {
+	const html = `<html><head></head><body><script>bad()</script><p>ok</p></body></html>`
+	const document = buildAdminEmailHtmlPreviewDocument(html)
+	expect(document).toContain('<p>ok</p>')
+	expect(document).not.toMatch(/<script/i)
+})

--- a/packages/worker/client/email-html-preview.ts
+++ b/packages/worker/client/email-html-preview.ts
@@ -1,0 +1,58 @@
+const fullHtmlDocumentPattern = /^<!DOCTYPE\s+html\b/i
+const htmlRootPattern = /^<html[\s>]/i
+
+/** Strip script blocks from inbound email HTML before sandboxed preview. */
+export function stripDangerousEmailHtml(html: string) {
+	return html.replaceAll(
+		/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+		'',
+	)
+}
+
+function isFullHtmlDocument(html: string) {
+	const trimmed = html.trimStart()
+	return fullHtmlDocumentPattern.test(trimmed) || htmlRootPattern.test(trimmed)
+}
+
+function injectReferrerMeta(html: string) {
+	const referrerMeta = '<meta name="referrer" content="no-referrer">'
+	if (/<head[\s>]/i.test(html)) {
+		return html.replace(/<head([^>]*)>/i, `<head$1>${referrerMeta}`)
+	}
+	return `${referrerMeta}${html}`
+}
+
+function wrapEmailHtmlFragment(html: string) {
+	return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="referrer" content="no-referrer">
+<base target="_blank" rel="noopener noreferrer">
+<style>
+html, body { margin: 0; padding: 0; }
+body {
+	padding: 1rem;
+	word-wrap: break-word;
+	overflow-wrap: anywhere;
+	color: #101010;
+	font-family: ui-sans-serif, system-ui, sans-serif;
+}
+img { max-width: 100%; height: auto; }
+table { max-width: 100%; }
+</style>
+</head>
+<body>
+${html}
+</body>
+</html>`
+}
+
+/** Build srcdoc HTML for a sandboxed admin email preview iframe. */
+export function buildAdminEmailHtmlPreviewDocument(htmlBody: string) {
+	const sanitized = stripDangerousEmailHtml(htmlBody)
+	if (isFullHtmlDocument(sanitized)) {
+		return injectReferrerMeta(sanitized)
+	}
+	return wrapEmailHtmlFragment(sanitized)
+}

--- a/packages/worker/client/routes/admin-system-email.tsx
+++ b/packages/worker/client/routes/admin-system-email.tsx
@@ -1,11 +1,13 @@
+import { buildAdminEmailHtmlPreviewDocument } from '#client/email-html-preview.ts'
 import { formatNullableTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
+import { Tab, TabList, TabPanel, Tabs } from 'remix/ui/tabs'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { readRouterSearch } from '#client/router-location.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
-import { colors, typography } from '#client/styles/tokens.ts'
+import { colors, radius, typography } from '#client/styles/tokens.ts'
 import { cardCss } from '#client/styles/style-primitives.ts'
 import {
 	AccountManagementMessage,
@@ -26,6 +28,26 @@ import {
 type PageStatus = 'loading' | 'ready' | 'error'
 
 const adminSystemEmailApiPath = '/admin/system-email.json'
+
+const emailBodyPreCss = css({
+	margin: 0,
+	whiteSpace: 'pre-wrap',
+	overflowX: 'auto',
+})
+
+const emailBodyEmptyCss = css({
+	margin: 0,
+	color: colors.textMuted,
+})
+
+const emailHtmlPreviewIframeCss = css({
+	display: 'block',
+	width: '100%',
+	minHeight: '24rem',
+	border: `1px solid ${colors.border}`,
+	borderRadius: radius.md,
+	background: colors.surface,
+})
 
 function isAdminSystemEmailPath(href: string) {
 	return new URL(href, 'http://localhost').pathname === '/admin/system-email'
@@ -295,39 +317,55 @@ export function AdminSystemEmailRoute(handle: Handle) {
 											fontSize: typography.fontSize.base,
 										})}
 									>
-										Text body
+										Message body
 									</h3>
-									<pre
-										mix={css({
-											margin: 0,
-											whiteSpace: 'pre-wrap',
-											overflowX: 'auto',
-										})}
-									>
-										{selectedMessage.text_body ?? '(no text body)'}
-									</pre>
+									<Tabs defaultActiveTab="html">
+										<TabList aria-label="Email body">
+											<Tab name="html">HTML</Tab>
+											<Tab name="text">Text</Tab>
+											<Tab name="source">HTML Source</Tab>
+										</TabList>
+										<TabPanel name="html">
+											{selectedMessage.html_body ? (
+												<iframe
+													title="Email HTML preview"
+													sandbox=""
+													referrerPolicy="no-referrer"
+													srcdoc={buildAdminEmailHtmlPreviewDocument(
+														selectedMessage.html_body,
+													)}
+													mix={emailHtmlPreviewIframeCss}
+												/>
+											) : (
+												<p mix={emailBodyEmptyCss}>
+													No HTML body exists for this message.
+												</p>
+											)}
+										</TabPanel>
+										<TabPanel name="text">
+											{selectedMessage.text_body ? (
+												<pre mix={emailBodyPreCss}>
+													{selectedMessage.text_body}
+												</pre>
+											) : (
+												<p mix={emailBodyEmptyCss}>
+													No text exists in this tab content.
+												</p>
+											)}
+										</TabPanel>
+										<TabPanel name="source">
+											{selectedMessage.html_body ? (
+												<pre mix={emailBodyPreCss}>
+													{selectedMessage.html_body}
+												</pre>
+											) : (
+												<p mix={emailBodyEmptyCss}>
+													No HTML body exists for this message.
+												</p>
+											)}
+										</TabPanel>
+									</Tabs>
 								</section>
-								{selectedMessage.html_body ? (
-									<section mix={css(cardCss)}>
-										<h3
-											mix={css({
-												margin: 0,
-												fontSize: typography.fontSize.base,
-											})}
-										>
-											HTML body source
-										</h3>
-										<pre
-											mix={css({
-												margin: 0,
-												whiteSpace: 'pre-wrap',
-												overflowX: 'auto',
-											})}
-										>
-											{selectedMessage.html_body}
-										</pre>
-									</section>
-								) : null}
 							</AccountManagementPanel>
 						) : null}
 					</>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The admin system email detail view now renders inbound HTML safely instead of showing raw markup only. Message bodies use Remix v3 tabs with three panels:

- **HTML** (default) — sandboxed iframe preview with `referrerPolicy="no-referrer"`; external images and styles load, scripts do not
- **Text** — plain-text body, or an empty-state message when none exists
- **HTML Source** — raw stored HTML for debugging

Script tags are stripped before preview as defense in depth. No server or storage changes.

## Security model

- Preview runs in a sandboxed iframe (`sandbox=""`) so scripts, forms, and top navigation are blocked
- `referrerPolicy="no-referrer"` on the iframe (plus a meta tag in the preview document)
- Inbound email HTML is still attacker-controlled, but rendering is isolated to admins on an audit-logged route

## Testing

- Added unit tests for HTML preview document building and script stripping
- `npm run typecheck` and pre-push unit + E2E suites pass locally

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `1011ace` · **Head:** `7a7bc77`

**Classification:** composes — admin UI wiring only; no primitive contracts or storage paths changed.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `surfaces` | surfaces | composes — `/admin/system-email` message body UI |
| `rbac` | auth | composes — unchanged admin-only access |
| `email` | capabilities | composes — reads existing stored `html_body` / `text_body` |

### System map

```mermaid
flowchart LR
  Admin["Admin user"] --> Route["/admin/system-email"]
  Route --> API["admin-system-email.json"]
  API --> D1["email_messages (system:email)"]
  Route --> Tabs["Remix Tabs"]
  Tabs --> Preview["Sandboxed iframe srcdoc"]
  Tabs --> Text["Plain text panel"]
  Tabs --> Source["HTML source panel"]
```

### What changed

- New `email-html-preview.ts` helper wraps/strips HTML for iframe `srcdoc`
- `admin-system-email.tsx` replaces separate text/HTML `<pre>` blocks with tabbed preview UI using `remix/ui/tabs`

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3040c08b-a712-4637-88d0-302026d908e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3040c08b-a712-4637-88d0-302026d908e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tabbed views for system emails: HTML preview, plain text, and HTML source.
  * Added clear empty-state messages when email content is unavailable.
  * HTML previews now display safely with scripts removed and referrer information blocked.

* **Bug Fixes**
  * Prevented duplicate nested HTML documents when previewing complete email pages.

* **Style**
  * Improved formatting, sizing, overflow handling, and visual styling for email content previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->