### PR TITLE
Add search-skip exception to MCP two-step flow guidance

### DIFF
--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -54,7 +54,7 @@ export function buildBaseMcpServerInstructions(
 End-user documentation (workflows, secrets, troubleshooting):
 https://github.com/kentcdodds/kody/tree/main/docs/use
 
-Two-step flow:
+Two-step flow (unless you know exactly what to do):
 1. \`search\` — built-in kody, saved packages, persisted values, saved integrations, and secret references (metadata).
 2. \`execute\` — run one ephemeral module with imports/exports and runtime access through \`kody:runtime\`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

One-line change to the authoritative MCP server instructions in `packages/worker/src/mcp/server-instructions.ts`:

```diff
-Two-step flow:
+Two-step flow (unless you know exactly what to do):
```

## Why

The current guidance presents `search` → `execute` as an unconditional two-step flow. Agents that already know the exact package import and call shape were performing a redundant `search` call before every `execute`. The brief parenthetical exception lets them skip straight to `execute` in that case, while preserving the surrounding wording and the default search-first behavior for everything else.

No tests needed — this is an instruction-string-only edit.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `ba4669c4` · **Head:** `7c629088`

**Classification:** composes — no primitives added or changed; this PR edits one line of instruction text served by an existing primitive.

### Primitives touched

| Primitive    | Group    | Impact                                                       |
| ------------ | -------- | ------------------------------------------------------------ |
| `mcp-server` | surfaces | composes — one-line wording tweak in server instruction text |

### System map

MCP clients read the server instructions emitted by the MCP endpoint; this PR only changes one line of that instruction string.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::touched
	mcpClient["MCP clients"]:::untouched
	mcpServer -->|"server instructions: 'Two-step flow (unless you know exactly what to do)'"| mcpClient
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e36764f-2f14-4d3b-bd95-73ce8ace3a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e36764f-2f14-4d3b-bd95-73ce8ace3a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the two-step flow guidance in generated MCP server instructions by noting that it applies unless the correct action is already known.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->