### PR TITLE
Dispatch system inbound email to admin-saved package subscriptions

### DIFF
--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -251,6 +251,11 @@ grants, and so on). None of it appears in admin endpoints, pages, or payloads.
 is stored under `system:email` as platform content, not under Kent's or any
 other user's account. Admin reads through MCP (`admin_system_email_list`,
 `admin_system_email_get`) and the `/admin/system-email` UI are audit logged.
+Stored system mail also fans out metadata (never bodies or attachment bytes) on
+the `email.system-message.received` package subscription topic, and only to
+packages saved by users who hold the admin role at dispatch time — a non-admin
+subscriber never receives the event, and revoking admin stops delivery
+immediately.
 
 This boundary is enforced structurally:
 

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -261,8 +261,8 @@ Operator system-inbox mail (`system:email` owner) dispatches the separate
 `email.system-message.received` topic to packages saved by users who hold the
 admin role at dispatch time. The payload is the same metadata-first envelope
 plus an `admin_url` link to the message in `/admin/system-email`. Handlers run
-as the admin package owner (not the system owner), so user-scoped email reads
-do not apply to the system message.
+as the admin package owner (not the system owner), so user-scoped email reads do
+not apply to the system message.
 
 ## Package-owned workflows
 

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -257,6 +257,13 @@ event. Handlers should fetch full bodies or bytes only when needed through
 `email_message_get`, `email_attachment_get`, or the package runtime `email`
 helper.
 
+Operator system-inbox mail (`system:email` owner) dispatches the separate
+`email.system-message.received` topic to packages saved by users who hold the
+admin role at dispatch time. The payload is the same metadata-first envelope
+plus an `admin_url` link to the message in `/admin/system-email`. Handlers run
+as the admin package owner (not the system owner), so user-scoped email reads
+do not apply to the system message.
+
 ## Package-owned workflows
 
 Packages declare workflow entrypoints in runtime code, not in

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -5,16 +5,16 @@ Official markdown guides for agent and contributor workflows. At runtime, the
 branch via `raw.githubusercontent.com` (see capability description in code for
 available `guide` ids).
 
-| File                                                                                     | Topic                                                                                                       |
-| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| [package-authoring.md](./package-authoring.md)                                           | General package-authoring guidance, including the README Intent section                                     |
-| [integration-bootstrap.md](./integration-bootstrap.md)                                   | **Start here** for third-party integrations that must work before saving a dependent package or package app |
-| [openapi-integrations.md](./openapi-integrations.md)                                     | OpenAPI discover → summarize → scaffold or curated `openapi:<name>` binding                                 |
-| [secret-backed-integration.md](./secret-backed-integration.md)                           | Default recipe for non-OAuth integrations that use one or more saved secrets                                |
-| [integration-backed-app-happy-path.md](./integration-backed-app-happy-path.md)           | Default package app pattern after integration smoke test passes                                             |
-| [package-service-pattern.md](./package-service-pattern.md)                               | General package-service pattern for native long-lived runtimes inside Kody                                  |
+| File                                                                                     | Topic                                                                                                                       |
+| ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| [package-authoring.md](./package-authoring.md)                                           | General package-authoring guidance, including the README Intent section                                                     |
+| [integration-bootstrap.md](./integration-bootstrap.md)                                   | **Start here** for third-party integrations that must work before saving a dependent package or package app                 |
+| [openapi-integrations.md](./openapi-integrations.md)                                     | OpenAPI discover → summarize → scaffold or curated `openapi:<name>` binding                                                 |
+| [secret-backed-integration.md](./secret-backed-integration.md)                           | Default recipe for non-OAuth integrations that use one or more saved secrets                                                |
+| [integration-backed-app-happy-path.md](./integration-backed-app-happy-path.md)           | Default package app pattern after integration smoke test passes                                                             |
+| [package-service-pattern.md](./package-service-pattern.md)                               | General package-service pattern for native long-lived runtimes inside Kody                                                  |
 | [package-subscriptions.md](./package-subscriptions.md)                                   | Package subscription manifest shape, discovery, and email.message.received / email.system-message.received payload guidance |
-| [platform-friction.md](./platform-friction.md)                                           | Agent self-improvement loop for Kody capability, package, memory, and guide friction                        |
-| [oauth.md](./oauth.md)                                                                   | **Start here** for third-party OAuth (`/connect/oauth`, redirect URI, params)                               |
-| [account-secret-setup.md](./account-secret-setup.md)                                     | `/account/secrets/new` URL parameters and policies                                                          |
-| [account-package-invocation-token-setup.md](./account-package-invocation-token-setup.md) | `/account/package-invocation-tokens/new` URL parameters and bearer-token safety policy                      |
+| [platform-friction.md](./platform-friction.md)                                           | Agent self-improvement loop for Kody capability, package, memory, and guide friction                                        |
+| [oauth.md](./oauth.md)                                                                   | **Start here** for third-party OAuth (`/connect/oauth`, redirect URI, params)                                               |
+| [account-secret-setup.md](./account-secret-setup.md)                                     | `/account/secrets/new` URL parameters and policies                                                                          |
+| [account-package-invocation-token-setup.md](./account-package-invocation-token-setup.md) | `/account/package-invocation-tokens/new` URL parameters and bearer-token safety policy                                      |

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -13,7 +13,7 @@ available `guide` ids).
 | [secret-backed-integration.md](./secret-backed-integration.md)                           | Default recipe for non-OAuth integrations that use one or more saved secrets                                |
 | [integration-backed-app-happy-path.md](./integration-backed-app-happy-path.md)           | Default package app pattern after integration smoke test passes                                             |
 | [package-service-pattern.md](./package-service-pattern.md)                               | General package-service pattern for native long-lived runtimes inside Kody                                  |
-| [package-subscriptions.md](./package-subscriptions.md)                                   | Package subscription manifest shape, discovery, and email.message.received payload guidance                 |
+| [package-subscriptions.md](./package-subscriptions.md)                                   | Package subscription manifest shape, discovery, and email.message.received / email.system-message.received payload guidance |
 | [platform-friction.md](./platform-friction.md)                                           | Agent self-improvement loop for Kody capability, package, memory, and guide friction                        |
 | [oauth.md](./oauth.md)                                                                   | **Start here** for third-party OAuth (`/connect/oauth`, redirect URI, params)                               |
 | [account-secret-setup.md](./account-secret-setup.md)                                     | `/account/secrets/new` URL parameters and policies                                                          |

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -100,3 +100,18 @@ Do not expect parsed bodies or attachment bytes in the event. Fetch full message
 bodies, parsed headers beyond the event metadata, or attachment bytes only when
 the handler needs them with `email_message_get`, `email_attachment_get`, or the
 package runtime `email` helper.
+
+## `email.system-message.received` (admins)
+
+Mail stored in the operator-owned system inbox (`kody@<apex>`,
+`support@<apex>`, and the other reserved system locals) dispatches
+`email.system-message.received` to packages saved by users who hold the admin
+role at dispatch time. Non-admin subscribers never receive system mail.
+
+The payload matches `email.message.received` (with
+`event: 'email.system-message.received'`) plus an `admin_url` string linking to
+the stored message in the admin interface (`/admin/system-email?messageId=...`).
+Handlers run as the admin package owner, so the user-scoped email capabilities
+and the `email` runtime helper cannot read the system message — use the
+metadata and `admin_url` for notifications, and the admin
+`admin_system_email_get` capability for full contents.

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -103,15 +103,15 @@ package runtime `email` helper.
 
 ## `email.system-message.received` (admins)
 
-Mail stored in the operator-owned system inbox (`kody@<apex>`,
-`support@<apex>`, and the other reserved system locals) dispatches
-`email.system-message.received` to packages saved by users who hold the admin
-role at dispatch time. Non-admin subscribers never receive system mail.
+Mail stored in the operator-owned system inbox (`kody@<apex>`, `support@<apex>`,
+and the other reserved system locals) dispatches `email.system-message.received`
+to packages saved by users who hold the admin role at dispatch time. Non-admin
+subscribers never receive system mail.
 
 The payload matches `email.message.received` (with
 `event: 'email.system-message.received'`) plus an `admin_url` string linking to
 the stored message in the admin interface (`/admin/system-email?messageId=...`).
 Handlers run as the admin package owner, so the user-scoped email capabilities
-and the `email` runtime helper cannot read the system message — use the
-metadata and `admin_url` for notifications, and the admin
-`admin_system_email_get` capability for full contents.
+and the `email` runtime helper cannot read the system message — use the metadata
+and `admin_url` for notifications, and the admin `admin_system_email_get`
+capability for full contents.

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -182,6 +182,32 @@ the package runtime `email` helper. Use `package_subscriptions_list` with
 `topic: "email.message.received"` to discover which saved packages subscribe for
 the signed-in user.
 
+## `email.system-message.received` package subscription (admins)
+
+Mail stored in the operator-owned system inbox (`kody`, `support`, `abuse`,
+`postmaster`, `security`, and `admin` at the apex) dispatches the separate
+package subscription topic `email.system-message.received`. It fans out to
+packages saved by users who hold the admin role at dispatch time — a non-admin
+saving the same subscription never receives system mail, and a revoked admin
+stops receiving immediately.
+
+The payload is the same metadata-first envelope as `email.message.received`
+(with `event: 'email.system-message.received'`), plus one extra field:
+
+```ts
+type SystemEmailMessageReceivedEvent = EmailMessageReceivedEvent & {
+	event: 'email.system-message.received'
+	/** Link to the stored message in the admin interface. */
+	admin_url: string
+}
+```
+
+Handlers run as the admin package owner, not the system owner, so the
+user-scoped email capabilities and the `kody:runtime` `email` helper cannot
+read the system message. Use the metadata for routing and notifications (for
+example a Discord report), and follow `admin_url` (or the admin
+`admin_system_email_get` capability) for full contents.
+
 ## Local inbound testing
 
 Run the worker locally with `APP_BASE_URL` set, sign up a user, then post raw

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -203,10 +203,10 @@ type SystemEmailMessageReceivedEvent = EmailMessageReceivedEvent & {
 ```
 
 Handlers run as the admin package owner, not the system owner, so the
-user-scoped email capabilities and the `kody:runtime` `email` helper cannot
-read the system message. Use the metadata for routing and notifications (for
-example a Discord report), and follow `admin_url` (or the admin
-`admin_system_email_get` capability) for full contents.
+user-scoped email capabilities and the `kody:runtime` `email` helper cannot read
+the system message. Use the metadata for routing and notifications (for example
+a Discord report), and follow `admin_url` (or the admin `admin_system_email_get`
+capability) for full contents.
 
 ## Local inbound testing
 

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -195,7 +195,10 @@ The payload is the same metadata-first envelope as `email.message.received`
 (with `event: 'email.system-message.received'`), plus one extra field:
 
 ```ts
-type SystemEmailMessageReceivedEvent = EmailMessageReceivedEvent & {
+type SystemEmailMessageReceivedEvent = Omit<
+	EmailMessageReceivedEvent,
+	'event'
+> & {
 	event: 'email.system-message.received'
 	/** Link to the stored message in the admin interface. */
 	admin_url: string

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -323,8 +323,8 @@ bodies or attachment bytes only when needed with `email_message_get`,
 `email_attachment_get`, or the `email` helper from `kody:runtime`. Operator
 system-inbox mail dispatches the separate `email.system-message.received` topic
 to packages saved by admin users; its payload adds an `admin_url` link to the
-message in the admin interface. See
-[Email primitives](./email-primitives.md) for the full payload shapes.
+message in the admin interface. See [Email primitives](./email-primitives.md)
+for the full payload shapes.
 
 ## Package-owned jobs
 

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -316,12 +316,15 @@ topic. This is the generic discovery step before building fan-out, debugging why
 an event did or did not dispatch, or checking which packages subscribe to
 `email.message.received`.
 
-For stored inbound email, the current topic is `email.message.received`. Its
-payload is metadata-first: handlers receive the stored message id, recipient and
-sender metadata, timestamps, processing status, and attachment metadata. Fetch
-parsed bodies or attachment bytes only when needed with `email_message_get`,
-`email_attachment_get`, or the `email` helper from `kody:runtime`. See
-[Email primitives](./email-primitives.md) for the full payload shape.
+For stored inbound email, the topic is `email.message.received`. Its payload is
+metadata-first: handlers receive the stored message id, recipient and sender
+metadata, timestamps, processing status, and attachment metadata. Fetch parsed
+bodies or attachment bytes only when needed with `email_message_get`,
+`email_attachment_get`, or the `email` helper from `kody:runtime`. Operator
+system-inbox mail dispatches the separate `email.system-message.received` topic
+to packages saved by admin users; its payload adds an `admin_url` link to the
+message in the admin interface. See
+[Email primitives](./email-primitives.md) for the full payload shapes.
 
 ## Package-owned jobs
 

--- a/packages/worker/src/app/permissions-db.ts
+++ b/packages/worker/src/app/permissions-db.ts
@@ -1,4 +1,8 @@
 import { type PermissionString, type RoleName } from '#app/permissions.ts'
+import {
+	isMissingStableUserIdColumnError,
+	type UserStableIdRow,
+} from '#worker/user-id.ts'
 
 type PermissionRow = {
 	role_name: string
@@ -39,6 +43,49 @@ export async function getUserRolesAndPermissions(
 	return {
 		roles: Array.from(roleSet).sort(),
 		permissions: Array.from(permissionSet).sort(),
+	}
+}
+
+function isMissingRbacTableError(error: unknown) {
+	if (!(error instanceof Error)) return false
+	const message = error.message.toLowerCase()
+	return (
+		message.includes('no such table: user_roles') ||
+		message.includes('no such table: roles')
+	)
+}
+
+/**
+ * List account rows (email + stored stable id) for every user holding the
+ * admin role. Returns an empty list on pre-RBAC databases so callers can
+ * treat "no RBAC tables" as "no admins".
+ */
+export async function listAdminAccountRows(
+	db: D1Database,
+): Promise<Array<UserStableIdRow>> {
+	const select = (columns: string) =>
+		`SELECT DISTINCT ${columns}
+		 FROM users u
+		 INNER JOIN user_roles ur ON ur.user_id = u.id
+		 INNER JOIN roles r ON r.id = ur.role_id
+		 WHERE r.name = 'admin'`
+	try {
+		const result = await db
+			.prepare(select('u.email, u.stable_user_id'))
+			.all<{ email: string; stable_user_id: string | null }>()
+		return result.results ?? []
+	} catch (error) {
+		if (isMissingRbacTableError(error)) return []
+		if (!isMissingStableUserIdColumnError(error)) throw error
+	}
+	try {
+		const result = await db
+			.prepare(select('u.email'))
+			.all<{ email: string }>()
+		return result.results ?? []
+	} catch (error) {
+		if (isMissingRbacTableError(error)) return []
+		throw error
 	}
 }
 

--- a/packages/worker/src/app/permissions-db.ts
+++ b/packages/worker/src/app/permissions-db.ts
@@ -79,9 +79,7 @@ export async function listAdminAccountRows(
 		if (!isMissingStableUserIdColumnError(error)) throw error
 	}
 	try {
-		const result = await db
-			.prepare(select('u.email'))
-			.all<{ email: string }>()
+		const result = await db.prepare(select('u.email')).all<{ email: string }>()
 		return result.results ?? []
 	} catch (error) {
 		if (isMissingRbacTableError(error)) return []

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -35,7 +35,10 @@ import {
 	recordBoundedEmailRejectionEvent,
 	touchEmailThread,
 } from './repo.ts'
-import { dispatchInboundEmailSubscriptionEvents } from './package-subscriptions.ts'
+import {
+	dispatchInboundEmailSubscriptionEvents,
+	dispatchSystemInboundEmailSubscriptionEvents,
+} from './package-subscriptions.ts'
 import {
 	consumeSystemEmailDailyReceive,
 	countStoredSystemEmailMessages,
@@ -227,6 +230,7 @@ export async function handleInboundEmail(
 			recipient,
 			localPart: localBase,
 			systemDomain,
+			ctx: _ctx,
 		})
 		return
 	}
@@ -442,6 +446,7 @@ async function handleSystemInboundEmail(input: {
 	recipient: string
 	localPart: SystemEmailLocal
 	systemDomain: string
+	ctx?: ExecutionContext
 }) {
 	const provisioned = await ensureSystemEmailInbox({
 		db: input.env.APP_DB,
@@ -543,4 +548,21 @@ async function handleSystemInboundEmail(input: {
 	})
 	if (!stored) return
 	await recordReceiveUsage({ entityId: stored.id, outcome: 'success' })
+	// System mail fans out to packages saved by admin users on the dedicated
+	// email.system-message.received topic (never to the synthetic system
+	// owner, which has no saved packages).
+	const dispatchPromise = dispatchSystemInboundEmailSubscriptionEvents({
+		env: input.env,
+		message: stored,
+	})
+	if (input.ctx) {
+		input.ctx.waitUntil(dispatchPromise)
+	} else {
+		void dispatchPromise.catch((error) => {
+			console.error(
+				'System inbound email package subscription dispatch failed',
+				error,
+			)
+		})
+	}
 }

--- a/packages/worker/src/email/package-subscriptions.ts
+++ b/packages/worker/src/email/package-subscriptions.ts
@@ -202,10 +202,25 @@ export async function dispatchInboundEmailSubscriptionEvents(input: {
 
 async function listAdminStableUserIds(db: D1Database) {
 	const rows = await listAdminAccountRows(db)
-	const stableIds = await Promise.all(
+	// One unresolvable admin row (for example corrupt account data) must not
+	// block dispatch to the remaining admins.
+	const settled = await Promise.allSettled(
 		rows.map(async (row) => await resolveUserStableId(row)),
 	)
-	return Array.from(new Set(stableIds))
+	const stableIds = new Set<string>()
+	for (const result of settled) {
+		if (result.status === 'fulfilled' && result.value) {
+			stableIds.add(result.value)
+			continue
+		}
+		if (result.status === 'rejected') {
+			console.warn(
+				'Failed to resolve admin stable user id for system email dispatch',
+				result.reason,
+			)
+		}
+	}
+	return Array.from(stableIds)
 }
 
 /**

--- a/packages/worker/src/email/package-subscriptions.ts
+++ b/packages/worker/src/email/package-subscriptions.ts
@@ -43,11 +43,12 @@ type EmailReceiptSubscriptionEnvelope = {
 	}>
 }
 
-type SystemEmailReceiptSubscriptionEnvelope = EmailReceiptSubscriptionEnvelope & {
-	event: typeof systemInboundEmailReceiptTopic
-	/** Admin-interface link for the stored system message. */
-	admin_url: string
-}
+type SystemEmailReceiptSubscriptionEnvelope =
+	EmailReceiptSubscriptionEnvelope & {
+		event: typeof systemInboundEmailReceiptTopic
+		/** Admin-interface link for the stored system message. */
+		admin_url: string
+	}
 
 type LoadedEmailSubscription = {
 	savedPackage: SavedPackageRecord

--- a/packages/worker/src/email/package-subscriptions.ts
+++ b/packages/worker/src/email/package-subscriptions.ts
@@ -1,16 +1,19 @@
 import { getAppBaseUrl } from '#app/app-base-url.ts'
+import { listAdminAccountRows } from '#app/permissions-db.ts'
 import { invokePackageSubscription } from '#worker/package-invocations/service.ts'
 import { listPackageSubscriptions } from '#worker/package-registry/manifest.ts'
 import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+import { resolveUserStableId } from '#worker/user-id.ts'
 import { listEmailAttachmentsForMessage } from './repo.ts'
 import { type EmailAttachmentRecord, type EmailMessageRecord } from './types.ts'
 
 const inboundEmailReceiptTopic = 'email.message.received'
+const systemInboundEmailReceiptTopic = 'email.system-message.received'
 
 type EmailReceiptSubscriptionEnvelope = {
-	event: typeof inboundEmailReceiptTopic
+	event: typeof inboundEmailReceiptTopic | typeof systemInboundEmailReceiptTopic
 	message: {
 		id: string
 		inbox_id: string | null
@@ -40,6 +43,12 @@ type EmailReceiptSubscriptionEnvelope = {
 	}>
 }
 
+type SystemEmailReceiptSubscriptionEnvelope = EmailReceiptSubscriptionEnvelope & {
+	event: typeof systemInboundEmailReceiptTopic
+	/** Admin-interface link for the stored system message. */
+	admin_url: string
+}
+
 type LoadedEmailSubscription = {
 	savedPackage: SavedPackageRecord
 	subscription: ReturnType<typeof listPackageSubscriptions>[number]
@@ -64,11 +73,12 @@ function toRuntimeAttachmentMetadata(attachment: EmailAttachmentRecord) {
 }
 
 function buildEmailEventPayload(input: {
+	event: EmailReceiptSubscriptionEnvelope['event']
 	message: EmailMessageRecord
 	attachments: Array<EmailAttachmentRecord>
 }) {
 	return {
-		event: inboundEmailReceiptTopic,
+		event: input.event,
 		message: {
 			id: input.message.id,
 			inbox_id: input.message.inboxId,
@@ -92,14 +102,16 @@ function buildEmailEventPayload(input: {
 function buildSubscriptionIdempotencyKey(input: {
 	messageId: string
 	packageId: string
+	topic: string
 }) {
-	return `email:${input.messageId}:${input.packageId}:${inboundEmailReceiptTopic}`
+	return `email:${input.messageId}:${input.packageId}:${input.topic}`
 }
 
 async function loadMatchingEmailSubscriptions(input: {
 	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV'>
 	baseUrl: string
 	userId: string
+	topic: string
 }) {
 	let savedPackages: Array<SavedPackageRecord>
 	try {
@@ -125,7 +137,7 @@ async function loadMatchingEmailSubscriptions(input: {
 					sourceId: savedPackage.sourceId,
 				})
 				const subscription = listPackageSubscriptions(loaded.manifest).find(
-					(candidate) => candidate.topic === inboundEmailReceiptTopic,
+					(candidate) => candidate.topic === input.topic,
 				)
 				if (!subscription) return null
 				return { savedPackage, subscription } satisfies LoadedEmailSubscription
@@ -160,8 +172,10 @@ export async function dispatchInboundEmailSubscriptionEvents(input: {
 		env: input.env,
 		baseUrl,
 		userId: input.userId,
+		topic: inboundEmailReceiptTopic,
 	})
 	const eventPayload = buildEmailEventPayload({
+		event: inboundEmailReceiptTopic,
 		message: input.message,
 		attachments,
 	})
@@ -177,6 +191,79 @@ export async function dispatchInboundEmailSubscriptionEvents(input: {
 					idempotencyKey: buildSubscriptionIdempotencyKey({
 						messageId: input.message.id,
 						packageId: savedPackage.id,
+						topic: inboundEmailReceiptTopic,
+					}),
+					source: 'email',
+				}),
+		),
+	)
+}
+
+async function listAdminStableUserIds(db: D1Database) {
+	const rows = await listAdminAccountRows(db)
+	const stableIds = await Promise.all(
+		rows.map(async (row) => await resolveUserStableId(row)),
+	)
+	return Array.from(new Set(stableIds))
+}
+
+/**
+ * Fan a stored system-inbox message (`system:email` owner) out to packages
+ * saved by users who hold the admin role at dispatch time. The payload is the
+ * same metadata-first envelope as `email.message.received` on a dedicated
+ * `email.system-message.received` topic, plus an `admin_url` link to the
+ * message in the admin interface — handlers run as the admin package owner,
+ * not the system owner, so they read full contents through the admin UI/API
+ * rather than the user-scoped email helpers.
+ */
+export async function dispatchSystemInboundEmailSubscriptionEvents(input: {
+	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'APP_BASE_URL'>
+	message: EmailMessageRecord
+}) {
+	const baseUrl = getAppBaseUrl({
+		env: input.env,
+	})
+	const adminUserIds = await listAdminStableUserIds(input.env.APP_DB)
+	if (adminUserIds.length === 0) return []
+	const attachments = await listEmailAttachmentsForMessage({
+		db: input.env.APP_DB,
+		messageId: input.message.id,
+	})
+	const eventPayload = {
+		...buildEmailEventPayload({
+			event: systemInboundEmailReceiptTopic,
+			message: input.message,
+			attachments,
+		}),
+		event: systemInboundEmailReceiptTopic,
+		admin_url: `${baseUrl}/admin/system-email?messageId=${encodeURIComponent(
+			input.message.id,
+		)}`,
+	} satisfies SystemEmailReceiptSubscriptionEnvelope
+	const subscriptionGroups = await Promise.all(
+		adminUserIds.map(
+			async (userId) =>
+				await loadMatchingEmailSubscriptions({
+					env: input.env,
+					baseUrl,
+					userId,
+					topic: systemInboundEmailReceiptTopic,
+				}),
+		),
+	)
+	return await Promise.all(
+		subscriptionGroups.flat().map(
+			async ({ savedPackage }) =>
+				await invokePackageSubscription({
+					env: input.env as Env,
+					baseUrl,
+					savedPackage,
+					topic: systemInboundEmailReceiptTopic,
+					params: eventPayload as Record<string, unknown>,
+					idempotencyKey: buildSubscriptionIdempotencyKey({
+						messageId: input.message.id,
+						packageId: savedPackage.id,
+						topic: systemInboundEmailReceiptTopic,
 					}),
 					source: 'email',
 				}),

--- a/packages/worker/src/email/system-email-subscriptions.workers.test.ts
+++ b/packages/worker/src/email/system-email-subscriptions.workers.test.ts
@@ -1,0 +1,410 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import { handleInboundEmail } from './inbound.ts'
+import { listEmailMessages } from './repo.ts'
+import { systemEmailOwnerId } from './system-email.ts'
+import { createForwardableEmailMessage } from './test-fixtures.ts'
+import { ensureEmailTestSchema } from './test-schema.ts'
+import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
+import { buildPublishedSourceManifestSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+
+const platformBaseUrl = 'https://kody.example.com'
+const systemDomain = 'kody.example.com'
+const systemTopic = 'email.system-message.received'
+
+function createInboundEnv() {
+	return { ...env, APP_BASE_URL: platformBaseUrl }
+}
+
+async function ensurePackageSubscriptionTestSchema(db: D1Database) {
+	const statements = [
+		`CREATE TABLE IF NOT EXISTS saved_packages (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			kody_id TEXT NOT NULL,
+			description TEXT NOT NULL,
+			tags_json TEXT NOT NULL DEFAULT '[]',
+			search_text TEXT,
+			source_id TEXT NOT NULL,
+			has_app INTEGER NOT NULL DEFAULT 0,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS entity_sources (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			entity_kind TEXT NOT NULL,
+			entity_id TEXT NOT NULL,
+			repo_id TEXT NOT NULL,
+			published_commit TEXT,
+			indexed_commit TEXT,
+			manifest_path TEXT NOT NULL,
+			source_root TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS published_bundle_artifacts (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			published_commit TEXT NOT NULL,
+			artifact_kind TEXT NOT NULL,
+			artifact_name TEXT,
+			entry_point TEXT NOT NULL,
+			kv_key TEXT NOT NULL,
+			dependencies_json TEXT NOT NULL DEFAULT '[]',
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_published_bundle_artifacts_identity
+		ON published_bundle_artifacts(user_id, source_id, artifact_kind, COALESCE(artifact_name, ''), entry_point)`,
+		`CREATE TABLE IF NOT EXISTS package_invocations (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			token_id TEXT NOT NULL,
+			package_id TEXT NOT NULL,
+			package_kody_id TEXT NOT NULL,
+			export_name TEXT NOT NULL,
+			idempotency_key TEXT NOT NULL,
+			request_hash TEXT NOT NULL,
+			source TEXT,
+			topic TEXT,
+			status TEXT NOT NULL,
+			response_json TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_package_invocations_key
+		ON package_invocations(user_id, token_id, package_id, export_name, idempotency_key)`,
+	]
+	for (const statement of statements) {
+		await db.prepare(statement).run()
+	}
+}
+
+async function ensureRbacTestSchema(db: D1Database) {
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS roles (
+				id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+				name TEXT NOT NULL UNIQUE,
+				description TEXT NOT NULL DEFAULT ''
+			)`,
+		)
+		.run()
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS user_roles (
+				user_id INTEGER NOT NULL,
+				role_id INTEGER NOT NULL,
+				PRIMARY KEY (user_id, role_id)
+			)`,
+		)
+		.run()
+	await db
+		.prepare(`INSERT OR IGNORE INTO roles (name) VALUES ('user'), ('admin')`)
+		.run()
+}
+
+async function seedAccount(input: { email: string; username: string }) {
+	await env.APP_DB.prepare(
+		`INSERT INTO users (username, email, password_hash, email_verified_at)
+		 VALUES (?, ?, 'test-password-hash', ?)
+		 ON CONFLICT(email) DO UPDATE SET
+			username = excluded.username,
+			updated_at = CURRENT_TIMESTAMP`,
+	)
+		.bind(input.username, input.email, new Date().toISOString())
+		.run()
+	const row = await env.APP_DB.prepare(`SELECT id FROM users WHERE email = ?`)
+		.bind(input.email)
+		.first<{ id: number }>()
+	if (!row) throw new Error(`Expected seeded user row for ${input.email}`)
+	return row.id
+}
+
+async function assignAdminRole(userId: number) {
+	await env.APP_DB.prepare(
+		`INSERT OR IGNORE INTO user_roles (user_id, role_id)
+		 SELECT ?, id FROM roles WHERE name = 'admin'`,
+	)
+		.bind(userId)
+		.run()
+}
+
+async function seedSubscribedPackage(input: {
+	bundleKv: Map<string, string>
+	userId: string
+	scope: string
+}) {
+	const db = env.APP_DB
+	const sourceId = `source-${crypto.randomUUID()}`
+	const packageId = `package-${crypto.randomUUID()}`
+	const now = new Date().toISOString()
+	await db
+		.prepare(
+			`INSERT INTO saved_packages (
+				id, user_id, name, kody_id, description, tags_json, search_text, source_id, has_app, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, '[]', NULL, ?, 0, ?, ?)`,
+		)
+		.bind(
+			packageId,
+			input.userId,
+			`@${input.scope}/system-email-notifier`,
+			'system-email-notifier',
+			'System email notifier',
+			sourceId,
+			now,
+			now,
+		)
+		.run()
+	await db
+		.prepare(
+			`INSERT INTO entity_sources (
+				id, user_id, entity_kind, entity_id, repo_id, published_commit, indexed_commit, manifest_path, source_root, created_at, updated_at
+			) VALUES (?, ?, 'package', ?, 'repo-1', 'commit-1', NULL, 'package.json', '/', ?, ?)`,
+		)
+		.bind(sourceId, input.userId, packageId, now, now)
+		.run()
+
+	const manifest = {
+		name: `@${input.scope}/system-email-notifier`,
+		exports: {
+			'.': './src/index.ts',
+		},
+		kody: {
+			id: 'system-email-notifier',
+			description: 'System email notifier',
+			subscriptions: {
+				[systemTopic]: {
+					handler: './src/on-system-email.ts',
+				},
+			},
+		},
+	}
+	input.bundleKv.set(
+		buildPublishedSourceManifestSnapshotKvKey({
+			sourceId,
+			publishedCommit: 'commit-1',
+		}),
+		JSON.stringify({
+			version: 1,
+			sourceId,
+			publishedCommit: 'commit-1',
+			manifestPath: 'package.json',
+			manifestContent: JSON.stringify(manifest),
+			createdAt: now,
+		}),
+	)
+
+	const subscriptionArtifact = {
+		version: 1,
+		kind: 'module',
+		artifactName: `subscription:${systemTopic}`,
+		sourceId,
+		publishedCommit: 'commit-1',
+		entryPoint: 'src/on-system-email.ts',
+		mainModule: 'dist/subscription.js',
+		modules: {
+			'dist/subscription.js': `
+export default async function main(input = {}) {
+	return {
+		event: input.event,
+		messageId: input.message?.id ?? null,
+		subject: input.message?.subject ?? null,
+		adminUrl: input.admin_url ?? null,
+	}
+}
+`,
+		},
+		dependencies: [],
+		packageContext: {
+			packageId,
+			kodyId: 'system-email-notifier',
+			sourceId,
+		},
+		serviceContext: null,
+		createdAt: now,
+	}
+	const artifactKey = `bundle-artifact:v1:${sourceId}:commit-1:module:subscription:${systemTopic}:src/on-system-email.ts`
+	input.bundleKv.set(artifactKey, JSON.stringify(subscriptionArtifact))
+	await db
+		.prepare(
+			`INSERT INTO published_bundle_artifacts (
+				id, user_id, source_id, published_commit, artifact_kind, artifact_name, entry_point, kv_key, dependencies_json, created_at, updated_at
+			) VALUES (?, ?, ?, 'commit-1', 'module', ?, 'src/on-system-email.ts', ?, '[]', ?, ?)`,
+		)
+		.bind(
+			`artifact-${crypto.randomUUID()}`,
+			input.userId,
+			sourceId,
+			`subscription:${systemTopic}`,
+			artifactKey,
+			now,
+			now,
+		)
+		.run()
+	return { packageId, sourceId }
+}
+
+test('system inbound email dispatches email.system-message.received to admin-saved packages only', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	await ensureUsageRollupsTestSchema(env.APP_DB)
+	await ensurePackageSubscriptionTestSchema(env.APP_DB)
+	await ensureRbacTestSchema(env.APP_DB)
+
+	const adminEmail = `system-sub-admin-${crypto.randomUUID()}@example.com`
+	const adminStableId = await createStableUserIdFromEmail(adminEmail)
+	const adminAccountId = await seedAccount({
+		email: adminEmail,
+		username: `sysadmin-${crypto.randomUUID().slice(0, 8)}`,
+	})
+	await assignAdminRole(adminAccountId)
+
+	const regularEmail = `system-sub-user-${crypto.randomUUID()}@example.com`
+	const regularStableId = await createStableUserIdFromEmail(regularEmail)
+	await seedAccount({
+		email: regularEmail,
+		username: `sysuser-${crypto.randomUUID().slice(0, 8)}`,
+	})
+
+	const bundleKv = new Map<string, string>()
+	const adminPackage = await seedSubscribedPackage({
+		bundleKv,
+		userId: adminStableId,
+		scope: 'sysadmin',
+	})
+	// A non-admin saving the identical subscription must never receive
+	// operator system mail.
+	const regularPackage = await seedSubscribedPackage({
+		bundleKv,
+		userId: regularStableId,
+		scope: 'sysuser',
+	})
+
+	const waitUntilPromises: Array<Promise<unknown>> = []
+	const ctx = {
+		waitUntil(promise: Promise<unknown>) {
+			waitUntilPromises.push(promise)
+		},
+		passThroughOnException() {},
+	} as ExecutionContext
+
+	const originalKv = env.BUNDLE_ARTIFACTS_KV
+	Object.assign(env, {
+		BUNDLE_ARTIFACTS_KV: {
+			async get(key: string, type?: string) {
+				const value = bundleKv.get(key) ?? null
+				if (value == null) return null
+				if (type === 'json') return JSON.parse(value) as unknown
+				return value
+			},
+			async put() {
+				return undefined
+			},
+			async delete() {
+				return undefined
+			},
+		},
+	})
+
+	try {
+		const message = createForwardableEmailMessage({
+			from: 'provider@example.net',
+			to: `postmaster@${systemDomain}`,
+			raw: [
+				'From: Provider <provider@example.net>',
+				`To: postmaster@${systemDomain}`,
+				'Subject: Delivery report',
+				'Message-ID: <system-subscription@example.net>',
+				'',
+				'System body.',
+			].join('\r\n'),
+		})
+		await handleInboundEmail(message, createInboundEnv(), ctx)
+		expect(message.rejectedReason).toBeNull()
+		await Promise.all(waitUntilPromises)
+
+		const [stored] = await listEmailMessages({
+			db: env.APP_DB,
+			userId: systemEmailOwnerId,
+			limit: 1,
+		})
+		expect(stored).toBeDefined()
+		if (!stored) throw new Error('Expected stored system message')
+
+		const invocations = await env.APP_DB.prepare(
+			`SELECT package_id, export_name, topic, source, idempotency_key, response_json
+			FROM package_invocations
+			WHERE package_id IN (?, ?)`,
+		)
+			.bind(adminPackage.packageId, regularPackage.packageId)
+			.all<Record<string, unknown>>()
+		expect(invocations.results).toHaveLength(1)
+		const invocation = invocations.results?.[0]
+		expect(invocation).toMatchObject({
+			package_id: adminPackage.packageId,
+			export_name: `subscription:${systemTopic}`,
+			topic: systemTopic,
+			source: 'email',
+			idempotency_key: `email:${stored.id}:${adminPackage.packageId}:${systemTopic}`,
+		})
+		const response = JSON.parse(String(invocation?.['response_json'])) as {
+			body: Record<string, unknown>
+		}
+		expect(response.body).toMatchObject({
+			ok: true,
+			result: {
+				event: systemTopic,
+				messageId: stored.id,
+				subject: 'Delivery report',
+				adminUrl: `${platformBaseUrl}/admin/system-email?messageId=${encodeURIComponent(stored.id)}`,
+			},
+		})
+	} finally {
+		Object.assign(env, { BUNDLE_ARTIFACTS_KV: originalKv })
+	}
+})
+
+test('system inbound email dispatch is a no-op without admins or RBAC tables', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	await ensureUsageRollupsTestSchema(env.APP_DB)
+	await ensurePackageSubscriptionTestSchema(env.APP_DB)
+	// No RBAC tables at all: pre-RBAC databases must store system mail
+	// without dispatching (and without throwing).
+	await env.APP_DB.prepare(`DROP TABLE IF EXISTS user_roles`).run()
+	await env.APP_DB.prepare(`DROP TABLE IF EXISTS roles`).run()
+
+	const waitUntilPromises: Array<Promise<unknown>> = []
+	const ctx = {
+		waitUntil(promise: Promise<unknown>) {
+			waitUntilPromises.push(promise)
+		},
+		passThroughOnException() {},
+	} as ExecutionContext
+
+	const message = createForwardableEmailMessage({
+		from: 'provider@example.net',
+		to: `security@${systemDomain}`,
+		raw: [
+			'From: Provider <provider@example.net>',
+			`To: security@${systemDomain}`,
+			'Subject: No admins yet',
+			'Message-ID: <system-no-admins@example.net>',
+			'',
+			'System body.',
+		].join('\r\n'),
+	})
+	await handleInboundEmail(message, createInboundEnv(), ctx)
+	expect(message.rejectedReason).toBeNull()
+	await Promise.all(waitUntilPromises)
+
+	const messages = await listEmailMessages({
+		db: env.APP_DB,
+		userId: systemEmailOwnerId,
+		limit: 5,
+	})
+	expect(messages.some((row) => row.subject === 'No admins yet')).toBe(true)
+})

--- a/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
@@ -31,6 +31,8 @@ export const listPackageSubscriptionsCapability = defineDomainCapability(
 			'handler',
 			'email.message.received',
 			'email message received',
+			'email.system-message.received',
+			'system email',
 			'inbound email',
 			'list',
 			'discover',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Packages could subscribe to `email.message.received` for a user's own inbound mail, but operator system-inbox mail (`kody@`, `support@`, `postmaster@`, … on the apex, stored under the `system:email` owner) ended after storage — no package could react to it. This made it impossible to reuse an existing "report inbound mail to Discord" handler for system emails.

## What

- New package subscription topic `email.system-message.received`, dispatched after a system-inbox message is stored (`handleSystemInboundEmail` in `packages/worker/src/email/inbound.ts`, via `ctx.waitUntil`).
- Fan-out targets are packages saved by users who hold the **admin role at dispatch time** (`listAdminAccountRows` in `packages/worker/src/app/permissions-db.ts`, resolved to stable user ids). Non-admin subscribers never receive the event; revoking admin stops delivery immediately. Pre-RBAC databases dispatch to no one instead of failing.
- The payload is the same metadata-first envelope as `email.message.received` (no bodies or attachment bytes) plus an `admin_url` link to the message in the admin interface (`/admin/system-email?messageId=...`), since handlers run as the admin package owner and the user-scoped email helpers cannot read `system:email` messages.
- Idempotency keys carry the topic (`email:<messageId>:<packageId>:<topic>`), keeping the user-topic keys byte-identical to before.
- Docs updated (`docs/use/email-primitives.md`, `docs/use/packages.md`, `docs/guides/package-subscriptions.md`, `docs/contributing/packages-and-manifests.md`, `docs/contributing/architecture/authorization.md`) and `package_subscriptions_list` discovery keywords extended.

## Testing

- New workers tests in `packages/worker/src/email/system-email-subscriptions.workers.test.ts`:
  - end-to-end apex delivery → storage → dispatch → package-runtime handler execution, asserting the admin-saved package is invoked exactly once with the right topic, idempotency key, and `admin_url`, while an identical non-admin subscription receives nothing
  - no-op storage path when RBAC tables/admins do not exist
- `npm run validate` fully green (format, lint, typecheck, 796 unit tests, Playwright E2E, MCP E2E).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends the email primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `132d3dcb` · **Head:** `9ff3efc3`

**Classification:** extends — the email primitive gains a new subscription topic on the system-inbox path; no new primitive, `primitives.yaml` unchanged (summary still accurate).

### Primitives touched

| Primitive         | Group     | Impact                                                                     |
| ----------------- | --------- | -------------------------------------------------------------------------- |
| `email`           | assistant | extends — new `email.system-message.received` dispatch after system-inbox storage |
| `rbac`            | auth      | composes — admin-role lookup gates who receives system-mail events        |
| `saved-packages`  | assistant | composes — existing manifest subscriptions matched per admin user         |
| `package-runtime` | runtime   | composes — handlers invoked through existing `invokePackageSubscription`  |
| `d1-app-db`       | storage   | composes — reads `users`/`user_roles`/`roles`, no schema change           |

### System map

System-inbox mail flows from the email handler through an admin-role lookup into the existing package subscription runtime.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	email["email<br/>Email"]:::extended
	rbac["rbac<br/>Role-based access control"]:::touched
	savedPackages["saved-packages<br/>Saved packages"]:::touched
	packageRuntime["package-runtime<br/>Package runtime"]:::touched
	d1AppDb["d1-app-db<br/>D1 app database"]:::touched
	email -->|"listAdminAccountRows (admin role at dispatch time)"| rbac
	rbac -->|"users / user_roles / roles reads"| d1AppDb
	email -->|"match kody.subscriptions on email.system-message.received"| savedPackages
	email -->|"invokePackageSubscription + admin_url payload"| packageRuntime
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Per-user isolation holds: only metadata (never bodies or attachment bytes) leaves the `system:email` owner, and only to packages of users holding the admin role at dispatch time — the same audience that can already read this mail via `/admin/system-email`.
- User-topic dispatch (`email.message.received`) is behavior- and idempotency-key-identical to before.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f49fc-31d9-7aa7-95f0-3cc26ac6e399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f49fc-31d9-7aa7-95f0-3cc26ac6e399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-only `email.system-message.received` subscription for operator system inbox messages.
  * Payload provides message metadata plus an `admin_url`, and delivery targets currently-authorized admins only.
  * Revoking admin access stops delivery immediately.

* **Documentation**
  * Expanded system email subscription docs, including payload shapes and handler execution/access limitations.

* **Bug Fixes**
  * Improved robustness for environments missing RBAC tables or stable user IDs, ensuring correct dispatch behavior.

* **Tests**
  * Added coverage for admin-only system inbound email dispatch and RBAC-missing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->