### PR TITLE
Preserve binary request bodies in the MCP fetch gateway

### DIFF
--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -270,6 +270,23 @@ test('fetch gateway preserves binary request bodies byte-for-byte', async () => 
 	}
 })
 
+test('fetch gateway preserves a leading UTF-8 BOM in text request bodies', async () => {
+	const bomBody = new Uint8Array([
+		0xef,
+		0xbb,
+		0xbf,
+		...new TextEncoder().encode('{"note":"bom-prefixed json"}'),
+	])
+	const request = new Request('https://example.com/api', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: bomBody,
+	})
+	const transformed = await expandSecretPlaceholders({ request, props, env })
+	const transformedBytes = new Uint8Array(await transformed.arrayBuffer())
+	expect(transformedBytes).toEqual(bomBody)
+})
+
 test('fetch gateway never resolves secret placeholder text embedded in a binary body', async () => {
 	const resolveSpy = vi.spyOn(secretService, 'resolveSecret')
 	const encoder = new TextEncoder()

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -223,6 +223,88 @@ test('opt-out header value "on" resolves normally and is stripped; unknown value
 	}
 })
 
+test('fetch gateway preserves binary request bodies byte-for-byte', async () => {
+	// PNG-like header bytes: invalid UTF-8, so the body must skip the text
+	// pipeline entirely and pass through unchanged.
+	const binaryBytes = new Uint8Array([
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe, 0x00, 0x01,
+	])
+	const boundary = '----TestBoundary123'
+	const encoder = new TextEncoder()
+	const prefix = encoder.encode(
+		`--${boundary}\r\nContent-Disposition: form-data; name="files[0]"; filename="image.png"\r\nContent-Type: image/png\r\n\r\n`,
+	)
+	const suffix = encoder.encode(`\r\n--${boundary}--\r\n`)
+	const multipartBody = new Uint8Array(
+		prefix.length + binaryBytes.length + suffix.length,
+	)
+	multipartBody.set(prefix, 0)
+	multipartBody.set(binaryBytes, prefix.length)
+	multipartBody.set(suffix, prefix.length + binaryBytes.length)
+
+	const resolveSpy = vi
+		.spyOn(secretService, 'resolveSecret')
+		.mockResolvedValue({
+			found: true,
+			value: 'secret-value',
+			scope: 'user',
+			allowedHosts: ['discord.com'],
+			allowedCapabilities: [],
+		})
+	try {
+		const request = new Request('https://discord.com/api/channels/1/messages', {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bot {{secret:discordBotToken|scope=user}}',
+				'Content-Type': `multipart/form-data; boundary=${boundary}`,
+			},
+			body: multipartBody,
+		})
+		const transformed = await expandSecretPlaceholders({ request, props, env })
+		// Header placeholders still resolve for binary-bodied requests.
+		expect(transformed.headers.get('Authorization')).toBe('Bot secret-value')
+		const transformedBytes = new Uint8Array(await transformed.arrayBuffer())
+		expect(transformedBytes).toEqual(multipartBody)
+	} finally {
+		resolveSpy.mockRestore()
+	}
+})
+
+test('fetch gateway never resolves secret placeholder text embedded in a binary body', async () => {
+	const resolveSpy = vi.spyOn(secretService, 'resolveSecret')
+	const encoder = new TextEncoder()
+	const placeholderText = encoder.encode('{{secret:name|scope=user}}')
+	const body = new Uint8Array(placeholderText.length + 2)
+	// Leading invalid UTF-8 byte marks the body as binary.
+	body[0] = 0xff
+	body.set(placeholderText, 1)
+	body[body.length - 1] = 0xfe
+
+	try {
+		const request = new Request('https://example.com/upload', {
+			method: 'PUT',
+			body,
+		})
+		const transformed = await expandSecretPlaceholders({ request, props, env })
+		expect(resolveSpy).not.toHaveBeenCalled()
+		const transformedBytes = new Uint8Array(await transformed.arrayBuffer())
+		expect(transformedBytes).toEqual(body)
+	} finally {
+		resolveSpy.mockRestore()
+	}
+})
+
+test('opt-out header passes binary bodies through unchanged', async () => {
+	const binaryBody = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10])
+	const request = new Request('https://example.com/upload', {
+		method: 'POST',
+		headers: { [secretResolutionHeaderName]: 'off' },
+		body: binaryBody,
+	})
+	const transformed = await expandSecretPlaceholders({ request, props, env })
+	expect(new Uint8Array(await transformed.arrayBuffer())).toEqual(binaryBody)
+})
+
 test('fetch gateway expands placeholders in form-urlencoded bodies', async () => {
 	const resolveSpy = vi
 		.spyOn(secretService, 'resolveSecret')

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -490,7 +490,12 @@ async function readRequestBody(
 	if (!shouldSendBody(request.method)) return null
 	const bytes = new Uint8Array(await request.arrayBuffer())
 	try {
-		const text = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+		// ignoreBOM keeps a leading UTF-8 BOM in the decoded text so text
+		// bodies round-trip byte-for-byte after placeholder expansion.
+		const text = new TextDecoder('utf-8', {
+			fatal: true,
+			ignoreBOM: true,
+		}).decode(bytes)
 		return { kind: 'text', text }
 	} catch {
 		return { kind: 'binary', bytes }

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -161,7 +161,7 @@ export async function expandSecretPlaceholders(input: {
 			{
 				method: input.request.method,
 				headers,
-				body: requestBody ?? undefined,
+				body: requestBodyInit(requestBody),
 				redirect: input.request.redirect,
 				credentials: input.request.credentials,
 				mode: input.request.mode,
@@ -288,11 +288,13 @@ export async function expandSecretPlaceholders(input: {
 	const nextBody =
 		requestBody == null
 			? undefined
-			: replaceSecretPlaceholdersInRequestBody(
-					headers,
-					requestBody,
-					replacements,
-				)
+			: requestBody.kind === 'binary'
+				? requestBody.bytes
+				: replaceSecretPlaceholdersInRequestBody(
+						headers,
+						requestBody.text,
+						replacements,
+					)
 	const nextRedirect =
 		hasReferencedSecrets && input.request.redirect === 'follow'
 			? 'manual'
@@ -412,26 +414,26 @@ function collectReferencedBasicAuthSecretPlaceholders(
 
 function collectReferencedBasicAuthSecretPlaceholdersFromRequestBody(
 	headers: Headers,
-	requestBody: string | null,
+	requestBody: GatewayRequestBody | null,
 ) {
-	if (!requestBody) return []
+	if (requestBody?.kind !== 'text' || !requestBody.text) return []
 	return isFormUrlEncodedRequest(headers)
 		? dedupeBasicAuthSecretPlaceholders(
-				parseBasicAuthSecretPlaceholdersFromFormUrlEncoded(requestBody),
+				parseBasicAuthSecretPlaceholdersFromFormUrlEncoded(requestBody.text),
 			)
-		: collectReferencedBasicAuthSecretPlaceholders([requestBody])
+		: collectReferencedBasicAuthSecretPlaceholders([requestBody.text])
 }
 
 function collectReferencedSecretsFromRequestBody(
 	headers: Headers,
-	requestBody: string | null,
+	requestBody: GatewayRequestBody | null,
 ) {
-	if (!requestBody) return []
+	if (requestBody?.kind !== 'text' || !requestBody.text) return []
 	return isFormUrlEncodedRequest(headers)
 		? dedupeReferencedSecrets(
-				parseSecretPlaceholdersFromFormUrlEncoded(requestBody),
+				parseSecretPlaceholdersFromFormUrlEncoded(requestBody.text),
 			)
-		: collectReferencedSecrets([requestBody])
+		: collectReferencedSecrets([requestBody.text])
 }
 
 function dedupeReferencedSecrets(referencedSecrets: Array<ReferencedSecret>) {
@@ -470,9 +472,34 @@ function isFormUrlEncodedRequest(headers: Headers) {
 	return contentType.startsWith('application/x-www-form-urlencoded')
 }
 
-async function readRequestBody(request: Request) {
+type GatewayRequestBody =
+	| { kind: 'text'; text: string }
+	| { kind: 'binary'; bytes: Uint8Array<ArrayBuffer> }
+
+/**
+ * Read the outbound request body without corrupting binary payloads. Bodies
+ * that decode as valid UTF-8 keep the text pipeline (secret placeholder
+ * scanning and replacement). Anything else — for example multipart uploads
+ * carrying raw file bytes — passes through byte-for-byte, and secret
+ * placeholders inside such a body are intentionally not resolved (URL and
+ * header placeholders still are).
+ */
+async function readRequestBody(
+	request: Request,
+): Promise<GatewayRequestBody | null> {
 	if (!shouldSendBody(request.method)) return null
-	return request.text()
+	const bytes = new Uint8Array(await request.arrayBuffer())
+	try {
+		const text = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+		return { kind: 'text', text }
+	} catch {
+		return { kind: 'binary', bytes }
+	}
+}
+
+function requestBodyInit(requestBody: GatewayRequestBody | null) {
+	if (requestBody == null) return undefined
+	return requestBody.kind === 'binary' ? requestBody.bytes : requestBody.text
 }
 
 function shouldSendBody(method: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The MCP fetch gateway read every outbound request body with `request.text()` before secret-placeholder expansion. Binary bodies (for example multipart uploads with file bytes, such as Discord attachment uploads from package code) were lossily decoded to a string and re-encoded, corrupting the bytes on the wire.

This PR makes the gateway binary-safe:

- `readRequestBody` now reads the body as an `ArrayBuffer` and attempts strict UTF-8 decoding (`fatal: true`). Valid UTF-8 bodies keep the existing text path; anything else is passed through as raw bytes.
- Request bodies are modeled as a discriminated union (`{ kind: 'text' } | { kind: 'binary' }`). Secret placeholder scanning, expansion, and Basic-auth placeholder collection only run on text bodies; binary bodies are forwarded byte-for-byte.
- Header placeholder resolution, host approval checks, and the `x-kody-secret-resolution: off` opt-out all behave the same for binary bodies as before.

Secret placeholders were never a supported feature inside binary payloads, so skipping expansion there is a behavior clarification, not a regression: placeholder text embedded in binary content is now guaranteed to leave the gateway unresolved.

## Testing

- New unit tests: binary bodies preserved byte-for-byte (with header secrets still resolved), placeholder-looking bytes inside binary bodies never resolved, and opt-out passthrough for binary bodies.
- `npm run validate` green locally.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `e5a88469` · **Head:** `54e7770a`

**Classification:** extends — changes the fetch gateway's request-body handling contract inside the capabilities execute runtime; no new primitives.

### Primitives touched

| Primitive              | Group   | Impact                                                                 |
| ---------------------- | ------- | ---------------------------------------------------------------------- |
| `capabilities-execute` | runtime | extends — gateway body pipeline becomes a text/binary discriminated union |
| `secrets`              | runtime | composes — placeholder expansion unchanged for text; explicitly skipped for binary bodies |

### System map

Package and execute `fetch` calls flow through the gateway, which now branches on body kind before secret placeholder expansion.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	capabilitiesExecute["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	secrets["secrets<br/>Secret references"]:::touched
	upstream["Upstream host (e.g. discord.com)"]:::untouched
	capabilitiesExecute -->|"text body: expand {{secret:...}}"| secrets
	capabilitiesExecute -->|"binary body: byte-for-byte passthrough"| upstream
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Body content                    | Before                              | After                                  |
| ------------------------------- | ----------------------------------- | -------------------------------------- |
| Valid UTF-8 text                | `request.text()`, placeholders resolved | Unchanged                              |
| Binary (invalid UTF-8)          | Corrupted via lossy decode/encode   | Passed through byte-for-byte, placeholders ignored |
| Header placeholders             | Resolved                            | Unchanged (both body kinds)            |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f49fc-31d9-7aa7-95f0-3cc26ac6e399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f49fc-31d9-7aa7-95f0-3cc26ac6e399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved binary request bodies byte-for-byte when forwarding through the gateway.
  * Secret placeholder processing now applies only to text-based payloads, preventing corruption of binary data.
  * Ensures placeholder resolution honors the secret-resolution opt-out, leaving binary requests unchanged.
  * Continued resolving secret placeholders in supported text payloads.
* **Tests**
  * Added coverage for binary/multipart payloads, BOM/byte-encoding edge cases, and opt-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->