### PR TITLE
Fix disposed RPC stub failures in reused execute sandboxes

### DIFF
--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -23,7 +23,13 @@ Requirements:
   permissive licensing only; MIT is the only accepted value.
 - **`package.json#private`** must not be `true`. Like npm, `"private": true`
   blocks public community publishing; set `"private": false` or remove `private`
-  only after the user explicitly approves public sharing.
+  only after the user explicitly approves public sharing. Note that
+  `package_save` always creates **new** packages as `"private": true` when the
+  manifest omits `private` — even when `confirm_private_visibility_change` is
+  true, because that flag only confirms an explicit manifest state. To create a
+  community-publishable package, send `"private": false` explicitly along with
+  the confirmation. Removing `private` (with confirmation) works when
+  **updating** an existing package.
 - A root **`README.md`** with a **`## Intent`** section (same guidance as
   [Packages](./packages.md#save-and-edit-packages)).
 - A **published** saved package commit. Publishing creates a **pinned snapshot**

--- a/packages/worker/src/mcp/capabilities/packages/save-package-private-visibility.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package-private-visibility.node.test.ts
@@ -1,0 +1,238 @@
+import { expect, test, vi } from 'vitest'
+import type * as sourceSafetyPolicyModule from '#worker/repo/source-safety-policy.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	ensureEntitySource: vi.fn(),
+	syncArtifactSourceSnapshot: vi.fn(),
+	refreshSavedPackageProjection: vi.fn(),
+	upsertSavedPackageVector: vi.fn(),
+	getEntitySourceByEntity: vi.fn(),
+	loadPriorPackageManifestContent: vi.fn(),
+}))
+
+vi.mock('#worker/repo/source-service.ts', () => ({
+	ensureEntitySource: (...args: Array<unknown>) =>
+		mockModule.ensureEntitySource(...args),
+}))
+
+vi.mock('#worker/repo/source-sync.ts', () => ({
+	syncArtifactSourceSnapshot: (...args: Array<unknown>) =>
+		mockModule.syncArtifactSourceSnapshot(...args),
+}))
+
+vi.mock('#worker/package-registry/service.ts', () => ({
+	refreshSavedPackageProjection: (...args: Array<unknown>) =>
+		mockModule.refreshSavedPackageProjection(...args),
+}))
+
+vi.mock('#worker/package-registry/vectorize.ts', () => ({
+	upsertSavedPackageVector: (...args: Array<unknown>) =>
+		mockModule.upsertSavedPackageVector(...args),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceByEntity: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceByEntity(...args),
+}))
+
+vi.mock('#worker/repo/source-safety-policy.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof sourceSafetyPolicyModule>()
+	return {
+		...actual,
+		loadPriorPackageManifestContent: (...args: Array<unknown>) =>
+			mockModule.loadPriorPackageManifestContent(...args),
+		assertPackageSourceOverwriteAllowed: vi.fn(async () => undefined),
+	}
+})
+
+const { savePackageCapability } = await import('./save-package.ts')
+
+function createDatabase(users: Array<Record<string, unknown>>) {
+	return {
+		prepare(query: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async first() {
+							if (query.includes('SELECT plan FROM users')) {
+								return users.find((row) => row['email'] === params[0]) ?? null
+							}
+							if (
+								query.includes('SELECT username') &&
+								query.includes('FROM users')
+							) {
+								return (
+									users.find(
+										(row) =>
+											String(row['email']).toLowerCase() ===
+											String(params[0]).toLowerCase(),
+									) ?? null
+								)
+							}
+							if (
+								query.includes('SELECT COUNT(*) AS count FROM saved_packages')
+							) {
+								return { count: 0 }
+							}
+							if (query.includes('FROM saved_packages')) {
+								return null
+							}
+							throw new Error(`Unsupported first query: ${query}`)
+						},
+						async run() {
+							if (query.includes('INSERT INTO saved_packages')) {
+								return { meta: { changes: 1 } }
+							}
+							throw new Error(`Unsupported run query: ${query}`)
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+}
+
+function setupPersistenceMocks() {
+	mockModule.ensureEntitySource.mockReset()
+	mockModule.syncArtifactSourceSnapshot.mockReset()
+	mockModule.refreshSavedPackageProjection.mockReset()
+	mockModule.upsertSavedPackageVector.mockReset()
+	mockModule.getEntitySourceByEntity.mockReset()
+	mockModule.loadPriorPackageManifestContent.mockReset()
+
+	mockModule.ensureEntitySource.mockImplementation(
+		async ({ entityId, userId }) => ({
+			id: `source-${entityId}`,
+			user_id: userId,
+			entity_kind: 'package',
+			entity_id: entityId,
+			repo_id: `repo-${entityId}`,
+			published_commit: 'published-commit-1',
+			indexed_commit: 'published-commit-1',
+			manifest_path: 'package.json',
+			source_root: '/',
+			created_at: '2026-07-10T00:00:00.000Z',
+			updated_at: '2026-07-10T00:00:00.000Z',
+			bootstrapAccess: null,
+		}),
+	)
+	mockModule.syncArtifactSourceSnapshot.mockResolvedValue('published-commit-1')
+	mockModule.refreshSavedPackageProjection.mockImplementation(
+		async ({ packageId, userId }) => ({
+			record: {
+				id: packageId,
+				userId,
+				name: '@visibility/pkg',
+				kodyId: 'pkg',
+				description: 'Package pkg',
+				tags: [],
+				searchText: null,
+				sourceId: `source-${packageId}`,
+				hasApp: false,
+				createdAt: '2026-07-10T00:00:00.000Z',
+				updatedAt: '2026-07-10T00:00:00.000Z',
+			},
+		}),
+	)
+	mockModule.upsertSavedPackageVector.mockResolvedValue(undefined)
+	mockModule.getEntitySourceByEntity.mockResolvedValue(null)
+	mockModule.loadPriorPackageManifestContent.mockResolvedValue(null)
+}
+
+function buildPackageFiles(input: { privateField?: boolean }) {
+	return [
+		{
+			path: 'package.json',
+			content: JSON.stringify({
+				name: '@visibility/new-package',
+				...(input.privateField === undefined
+					? {}
+					: { private: input.privateField }),
+				exports: { '.': './src/index.ts' },
+				kody: {
+					id: 'new-package',
+					description: 'Package new-package',
+				},
+			}),
+		},
+		{
+			path: 'src/index.ts',
+			content: 'export default async function main() { return { ok: true } }\n',
+		},
+	]
+}
+
+async function createContext() {
+	const email = 'visibility@example.com'
+	const userId = await createStableUserIdFromEmail(email)
+	return {
+		env: {
+			APP_DB: createDatabase([
+				{ email, plan: null, username: 'visibility' },
+			]),
+		} as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId,
+				email,
+				displayName: 'Visibility User',
+			},
+		}),
+	}
+}
+
+function readSyncedPackageJson() {
+	const syncCall = mockModule.syncArtifactSourceSnapshot.mock.calls.at(-1)
+	if (!syncCall) throw new Error('Expected syncArtifactSourceSnapshot call.')
+	const files = (syncCall[0] as { files: Record<string, string> }).files
+	return JSON.parse(files['package.json'] ?? '{}') as Record<string, unknown>
+}
+
+test('package_save injects private:true for new packages that omit private, even with confirm_private_visibility_change', async () => {
+	setupPersistenceMocks()
+	const ctx = await createContext()
+
+	await savePackageCapability.handler(
+		{
+			files: buildPackageFiles({}),
+			// The confirmation flag alone never requests public visibility; it
+			// only approves an explicit manifest state. Omission stays private.
+			confirm_private_visibility_change: true,
+		},
+		ctx,
+	)
+
+	expect(readSyncedPackageJson()['private']).toBe(true)
+})
+
+test('package_save creates a public package only with an explicit private:false plus confirmation', async () => {
+	setupPersistenceMocks()
+	const ctx = await createContext()
+
+	await savePackageCapability.handler(
+		{
+			files: buildPackageFiles({ privateField: false }),
+			confirm_private_visibility_change: true,
+		},
+		ctx,
+	)
+
+	expect(readSyncedPackageJson()['private']).toBe(false)
+})
+
+test('package_save rejects an explicit private:false create without confirmation', async () => {
+	setupPersistenceMocks()
+	const ctx = await createContext()
+
+	await expect(
+		savePackageCapability.handler(
+			{ files: buildPackageFiles({ privateField: false }) },
+			ctx,
+		),
+	).rejects.toThrow('confirm_private_visibility_change')
+
+	expect(mockModule.syncArtifactSourceSnapshot).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/mcp/capabilities/packages/save-package-private-visibility.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package-private-visibility.node.test.ts
@@ -169,9 +169,7 @@ async function createContext() {
 	const userId = await createStableUserIdFromEmail(email)
 	return {
 		env: {
-			APP_DB: createDatabase([
-				{ email, plan: null, username: 'visibility' },
-			]),
+			APP_DB: createDatabase([{ email, plan: null, username: 'visibility' }]),
 		} as Env,
 		callerContext: createMcpCallerContext({
 			baseUrl: 'https://example.com',

--- a/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
+++ b/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
@@ -1,0 +1,111 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
+import { buildKodyModuleBundle } from '#worker/package-runtime/module-graph.ts'
+
+/**
+ * Regression coverage for the production "RPC stub used after being
+ * disposed" failures (community_publish / community_search / repo publish
+ * capabilities intermittently failing on repeated calls).
+ *
+ * Execute uses stable dynamic-worker ids when `APP_COMMIT_SHA` is set, so two
+ * executes with identical code reuse one sandbox isolate — and the isolate's
+ * ES module cache survives between them. The `kody:runtime` virtual module
+ * used to freeze the first run's `kody` capability proxy into module scope;
+ * that proxy closes over the first `evaluate()` call's RPC ToolDispatcher
+ * stubs, which workerd implicitly disposes when that call returns. Every
+ * later execute with the same code (including from a brand-new conversation)
+ * then called capabilities through disposed stubs.
+ *
+ * `APP_COMMIT_SHA` is unset in local dev and tests, which is why this only
+ * reproduced in deployed environments before this suite pinned it.
+ */
+
+const reuseEnv = {
+	...env,
+	APP_COMMIT_SHA: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+} as Env
+
+function createCaller() {
+	return createMcpCallerContext({
+		baseUrl: 'https://kody.dev',
+		user: {
+			userId: 'user-reuse-test',
+			email: 'reuse@example.com',
+			displayName: 'Reuse Test',
+		},
+	})
+}
+
+test(
+	'sequential executes with identical code reuse the dynamic worker without stale dispatcher stubs',
+	{ timeout: 60_000 },
+	async () => {
+		const bundle = await buildKodyModuleBundle({
+			env: reuseEnv,
+			baseUrl: 'https://kody.dev',
+			userId: 'user-reuse-test',
+			sourceFiles: {
+				'entry.ts': [
+					"import { kody } from 'kody:runtime'",
+					'export default async function main() {',
+					"\treturn await kody.ping_capability({ query: 'slack' })",
+					'}',
+				].join('\n'),
+			},
+			entryPoint: 'entry.ts',
+		})
+
+		const runOnce = async (label: string) =>
+			await runBundledModuleWithRegistry(
+				reuseEnv,
+				// A fresh caller context per call models fresh MCP tool calls —
+				// including calls issued with brand-new conversation ids, which
+				// still hashed to the same cached dynamic worker in production.
+				createCaller(),
+				{
+					mainModule: bundle.mainModule,
+					modules: bundle.modules,
+				},
+				undefined,
+				{
+					skipCapabilityRegistry: true,
+					additionalTools: {
+						ping_capability: async (args: unknown) => ({
+							ok: true,
+							label,
+							args,
+						}),
+					},
+				},
+			)
+
+		const first = await runOnce('first')
+		expect(first.error).toBeUndefined()
+		expect(first.result).toEqual({
+			ok: true,
+			label: 'first',
+			args: { query: 'slack' },
+		})
+
+		// Before the kody:runtime late-binding fix this failed with
+		// "RPC stub used after being disposed.": the reused isolate's cached
+		// runtime module still pointed at the first run's dispatcher stubs.
+		const second = await runOnce('second')
+		expect(second.error).toBeUndefined()
+		expect(second.result).toEqual({
+			ok: true,
+			label: 'second',
+			args: { query: 'slack' },
+		})
+
+		const third = await runOnce('third')
+		expect(third.error).toBeUndefined()
+		expect(third.result).toEqual({
+			ok: true,
+			label: 'third',
+			args: { query: 'slack' },
+		})
+	},
+)

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -799,6 +799,17 @@ test('executor maps secret errors, formats guidance, extracts raw content, and t
 		getExecutionErrorDetails(new Error('myHelper is not defined')),
 	).toBeNull()
 
+	// A disposed RPC stub in the sandbox means per-run state leaked into a
+	// cached dynamic worker; the structured hint explains how to escape the
+	// poisoned worker instead of suggesting a futile identical retry.
+	expect(
+		getExecutionErrorDetails(new Error('RPC stub used after being disposed.')),
+	).toMatchObject({
+		kind: 'sandbox_runtime_stale',
+		nextStep: expect.stringContaining('fresh sandbox'),
+		suggestedAction: { type: 'report_bug' },
+	})
+
 	const errors = [
 		capabilityError,
 		new Error(createMissingSecretMessage('missingToken')),

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -783,6 +783,14 @@ export type ExecutionErrorDetails =
 				resource: EntitlementLimitErrorDetails['resource']
 			}
 	  }
+	| {
+			kind: 'sandbox_runtime_stale'
+			message: string
+			nextStep: string
+			suggestedAction: {
+				type: 'report_bug'
+			}
+	  }
 
 export function getExecutionErrorDetails(
 	error: unknown,
@@ -918,6 +926,18 @@ export function getExecutionErrorDetails(
 		}
 	}
 
+	if (isDisposedRpcStubMessage(message)) {
+		return {
+			kind: 'sandbox_runtime_stale',
+			message,
+			nextStep:
+				'The sandbox reused an RPC stub from an earlier execution, which is a Kody runtime lifecycle bug — retrying the identical call will hit the same cached sandbox worker. Re-run the execute call with a trivially different module (for example, add a comment) so a fresh sandbox is created, and report this error.',
+			suggestedAction: {
+				type: 'report_bug',
+			},
+		}
+	}
+
 	const missingRuntimeExport = parseMissingRuntimeExportMessage(message)
 	if (missingRuntimeExport) {
 		return {
@@ -956,6 +976,17 @@ const kodyRuntimeExportNames = new Set([
 	'packages',
 	'events',
 ])
+
+/**
+ * workerd throws this when an RPC stub outlives the execution context that
+ * created it (stubs passed as RPC parameters are implicitly disposed when the
+ * call returns; everything else when the I/O context is destroyed). In the
+ * execute pipeline this indicates per-run state leaked into a cached dynamic
+ * worker, so surface a structured hint instead of a bare error string.
+ */
+function isDisposedRpcStubMessage(message: string) {
+	return message.includes('RPC stub used after being disposed')
+}
 
 function parseMissingRuntimeExportMessage(message: string) {
 	const match = /^(?:ReferenceError: )?(\w+) is not defined\b/.exec(message)

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -356,6 +356,76 @@ test('createRuntimeModuleSource returns a stable memoized string', () => {
 	expect(first).toContain('__kodyCreateRuntimeObjectProxy')
 })
 
+test('kody:runtime exports resolve against the current run when the module instance is reused across sequential runs', async () => {
+	// Dynamic workers with identical code are cached and reused, so the
+	// runtime module evaluates once and then serves every later run from the
+	// isolate's ES module cache. Each run's `kody` closes over that run's RPC
+	// dispatcher stubs, which are disposed when the run's evaluate() call
+	// returns — a frozen `export const kody = runtime.kody` therefore made
+	// every later run fail with "RPC stub used after being disposed".
+	const modules = {
+		'.__kody_virtual__/runtime.js': createRuntimeModuleSource(),
+		'entry.js': [
+			"import { kody, email } from './.__kody_virtual__/runtime.js'",
+			'const capturedSearch = kody.community_search',
+			'export default async function main() {',
+			'\treturn {',
+			"\t\tviaProxy: await kody.community_search({ query: 'slack' }),",
+			"\t\tviaTopLevelCapture: await capturedSearch({ query: 'slack' }),",
+			'\t\temail,',
+			'\t}',
+			'}',
+		].join('\n'),
+	}
+	const moduleGraph = await createTemporaryModuleGraph(modules)
+	try {
+		const runtimeModule = (await moduleGraph.importModule(
+			'.__kody_virtual__/runtime.js',
+			{ cacheBust: false },
+		)) as RuntimeModule
+		const createRunRuntime = (label: string, state: { disposed: boolean }) => ({
+			kody: {
+				community_search: async (args: unknown) => {
+					if (state.disposed) {
+						throw new Error('RPC stub used after being disposed.')
+					}
+					return { label, args }
+				},
+			},
+			email: null,
+		})
+		const runOnce = async (runtime: Record<string, unknown>) =>
+			await runtimeModule.__kodyRunInRuntime(runtime, async () => {
+				const entry = (await moduleGraph.importModule('entry.js', {
+					cacheBust: false,
+				})) as { default: () => Promise<unknown> }
+				return await entry.default()
+			})
+
+		const firstState = { disposed: false }
+		const first = await runOnce(createRunRuntime('first-run', firstState))
+		expect(first).toEqual({
+			viaProxy: { label: 'first-run', args: { query: 'slack' } },
+			viaTopLevelCapture: { label: 'first-run', args: { query: 'slack' } },
+			email: null,
+		})
+
+		// The first run's dispatcher stubs die once its evaluate() returns.
+		firstState.disposed = true
+
+		const second = await runOnce(
+			createRunRuntime('second-run', { disposed: false }),
+		)
+		expect(second).toEqual({
+			viaProxy: { label: 'second-run', args: { query: 'slack' } },
+			viaTopLevelCapture: { label: 'second-run', args: { query: 'slack' } },
+			email: null,
+		})
+	} finally {
+		await moduleGraph.cleanup()
+	}
+})
+
 test('buildKodyAppBundle cache lifecycle reuses hits, shares in-flight builds, evicts failures, and keys by entrypoint', async () => {
 	mockModule.createWorker.mockReset()
 	mockModule.createWorker.mockResolvedValue(createBundleResult('warm-cache'))

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -161,19 +161,30 @@ export function createRuntimeModuleSource() {
 	// globalThis - the per-request runtime value is held inside the ALS, so
 	// concurrent requests do not stomp on each other's view.
 	//
-	// The exports are evaluated when the module is first imported. The
-	// surrounding wrapper resolves the same AsyncLocalStorage off the
-	// well-known symbol and calls \`storage.run(runtime, async () => {
-	// await import(...) })\`. Optional exports still capture the initial
-	// value so \`if (email) { ... }\` guards stay falsy when a wrapper
-	// intentionally omits that export.
+	// This module is evaluated at most once per isolate, but dynamic workers
+	// with identical code are cached and reused across executions (stable
+	// worker-loader ids). Per-run values must therefore never freeze into
+	// module scope: the \`kody\` capability proxy in particular closes over
+	// the RPC ToolDispatcher stubs passed to a single \`evaluate()\` call,
+	// and those stubs are implicitly disposed when that call returns. A
+	// frozen \`export const kody = runtime.kody\` would make every later run
+	// in a reused worker call capabilities through the first run's disposed
+	// stubs ("RPC stub used after being disposed"). Every export below is
+	// instead late-bound: it re-reads the current AsyncLocalStorage store on
+	// each property access / call.
 	//
-	// \`kody\` is different: every execute/package runtime should provide
-	// it, and Worker module loaders may evaluate this virtual module before
-	// the wrapper installs the per-run store. In that preload case, expose a
-	// late-bound proxy so named imports like \`import { kody } from
-	// 'kody:runtime'\` still resolve against the current AsyncLocalStorage
-	// store at call time instead of freezing as undefined.
+	// Optional helpers (\`storage\`, \`email\`, ...) still preserve their
+	// absent value (\`undefined\` / \`null\`) so \`if (email) { ... }\`
+	// guards stay falsy when a wrapper intentionally omits that export.
+	// Helper *presence* is decided by the generated wrapper source, which is
+	// part of the worker id hash, so presence observed on the first in-run
+	// evaluation is identical for every later run of the same worker.
+	//
+	// \`kody\` is always exported as a late-bound proxy: every
+	// execute/package runtime provides it, and Worker module loaders may
+	// evaluate this virtual module before the wrapper installs the per-run
+	// store. The proxy resolves against the current AsyncLocalStorage store
+	// at call time in both the preload and the reused-worker case.
 	const source = `
 import { AsyncLocalStorage } from 'node:async_hooks';
 
@@ -251,7 +262,22 @@ function __kodyCreateRuntimeObjectProxy(exportName) {
 			}
 			const runtimeExport = __kodyReadRuntimeExport(exportName);
 			const value = runtimeExport[property];
-			return typeof value === 'function' ? value.bind(runtimeExport) : value;
+			if (typeof value !== 'function') return value;
+			// Late-bind method calls to the runtime of the *calling* run: a
+			// function captured at property-access time (for example a
+			// top-level \`const search = kody.community_search\`) would
+			// otherwise keep pointing at the run that evaluated this module,
+			// whose RPC dispatcher stubs are disposed once that run returns.
+			return function (...args) {
+				const currentExport = __kodyReadRuntimeExport(exportName);
+				const currentValue = currentExport[property];
+				if (typeof currentValue !== 'function') {
+					throw new Error(
+						\`kody:runtime export "\${exportName}.\${String(property)}" is not callable in this execution context.\`,
+					);
+				}
+				return currentValue.apply(currentExport, args);
+			};
 		},
 		has(_target, property) {
 			if (__kodyIsRuntimeProxyInspectionProperty(property)) return false;
@@ -259,35 +285,112 @@ function __kodyCreateRuntimeObjectProxy(exportName) {
 			const runtimeExport = currentRuntime?.[exportName];
 			return runtimeExport != null && property in runtimeExport;
 		},
+		ownKeys() {
+			const currentRuntime = __kodyRuntimeStorage.getStore();
+			const runtimeExport = currentRuntime?.[exportName];
+			return runtimeExport == null ? [] : Reflect.ownKeys(runtimeExport);
+		},
+		getOwnPropertyDescriptor(_target, property) {
+			const currentRuntime = __kodyRuntimeStorage.getStore();
+			const runtimeExport = currentRuntime?.[exportName];
+			if (runtimeExport == null) return undefined;
+			const descriptor = Reflect.getOwnPropertyDescriptor(runtimeExport, property);
+			if (descriptor === undefined) return undefined;
+			return { ...descriptor, configurable: true };
+		},
 	});
 }
 
+function __kodyCreateRuntimeFunctionExport(exportName) {
+	return function (...args) {
+		const runtimeExport = __kodyReadRuntimeExport(exportName);
+		if (typeof runtimeExport !== 'function') {
+			throw new Error(
+				\`kody:runtime export "\${exportName}" is not callable in this execution context.\`,
+			);
+		}
+		return runtimeExport(...args);
+	};
+}
+
 const __kodyInitialRuntime = __kodyRuntimeStorage.getStore();
-const runtime = __kodyInitialRuntime ?? {};
-const __kodyObject =
-	__kodyInitialRuntime === undefined
-		? __kodyCreateRuntimeObjectProxy('kody')
-		: runtime.kody;
 
-export const kody = __kodyObject;
-export const storage = runtime.storage;
-export const refreshAccessToken = runtime.refreshAccessToken;
-export const createAuthenticatedFetch = runtime.createAuthenticatedFetch;
-export const secretHeaders = runtime.secretHeaders;
-export const oauthClientCredentials = runtime.oauthClientCredentials;
-export const packageContext = runtime.packageContext ?? null;
-export const serviceContext = runtime.serviceContext ?? null;
-export const service = runtime.service ?? null;
-export const packageSecrets = runtime.packageSecrets ?? null;
-export const email = runtime.email ?? null;
-export const workflows = runtime.workflows ?? null;
-export const packages = runtime.packages ?? null;
-export const events = runtime.events ?? null;
+function __kodyOptionalRuntimeObjectExport(exportName, absentValue) {
+	if (__kodyInitialRuntime === undefined) return absentValue;
+	if (__kodyInitialRuntime[exportName] == null) return absentValue;
+	return __kodyCreateRuntimeObjectProxy(exportName);
+}
 
-export default
-	__kodyInitialRuntime === undefined
-		? { ...runtime, kody: __kodyObject }
-		: runtime;
+function __kodyOptionalRuntimeFunctionExport(exportName) {
+	if (__kodyInitialRuntime === undefined) return undefined;
+	if (typeof __kodyInitialRuntime[exportName] !== 'function') return undefined;
+	return __kodyCreateRuntimeFunctionExport(exportName);
+}
+
+export const kody = __kodyCreateRuntimeObjectProxy('kody');
+export const storage = __kodyOptionalRuntimeObjectExport('storage', undefined);
+export const refreshAccessToken = __kodyOptionalRuntimeFunctionExport('refreshAccessToken');
+export const createAuthenticatedFetch = __kodyOptionalRuntimeFunctionExport('createAuthenticatedFetch');
+export const secretHeaders = __kodyOptionalRuntimeObjectExport('secretHeaders', undefined);
+export const oauthClientCredentials = __kodyOptionalRuntimeFunctionExport('oauthClientCredentials');
+export const packageContext = __kodyInitialRuntime?.packageContext ?? null;
+export const serviceContext = __kodyInitialRuntime?.serviceContext ?? null;
+export const service = __kodyOptionalRuntimeObjectExport('service', null);
+export const packageSecrets = __kodyOptionalRuntimeObjectExport('packageSecrets', null);
+export const email = __kodyOptionalRuntimeObjectExport('email', null);
+export const workflows = __kodyOptionalRuntimeObjectExport('workflows', null);
+export const packages = __kodyOptionalRuntimeObjectExport('packages', null);
+export const events = __kodyOptionalRuntimeObjectExport('events', null);
+
+const __kodyRuntimeNamedExports = {
+	kody,
+	storage,
+	refreshAccessToken,
+	createAuthenticatedFetch,
+	secretHeaders,
+	oauthClientCredentials,
+	packageContext,
+	serviceContext,
+	service,
+	packageSecrets,
+	email,
+	workflows,
+	packages,
+	events,
+};
+
+// The default export mirrors the named exports and forwards any extra
+// wrapper-specific helpers (for example package-app \`realtime\`) to the
+// current run's store instead of freezing the first run's object.
+export default new Proxy(__kodyRuntimeNamedExports, {
+	get(target, property) {
+		if (Reflect.has(target, property)) return Reflect.get(target, property);
+		const currentRuntime = __kodyRuntimeStorage.getStore();
+		return currentRuntime?.[property];
+	},
+	has(target, property) {
+		if (Reflect.has(target, property)) return true;
+		const currentRuntime = __kodyRuntimeStorage.getStore();
+		return currentRuntime != null && property in currentRuntime;
+	},
+	ownKeys(target) {
+		const keys = new Set(Reflect.ownKeys(target));
+		const currentRuntime = __kodyRuntimeStorage.getStore();
+		if (currentRuntime != null) {
+			for (const key of Reflect.ownKeys(currentRuntime)) keys.add(key);
+		}
+		return [...keys];
+	},
+	getOwnPropertyDescriptor(target, property) {
+		const ownDescriptor = Reflect.getOwnPropertyDescriptor(target, property);
+		if (ownDescriptor) return ownDescriptor;
+		const currentRuntime = __kodyRuntimeStorage.getStore();
+		if (currentRuntime == null) return undefined;
+		const descriptor = Reflect.getOwnPropertyDescriptor(currentRuntime, property);
+		if (descriptor === undefined) return undefined;
+		return { ...descriptor, configurable: true };
+	},
+});
 `.trim()
 	cachedRuntimeModuleSource = source
 	return source

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -327,7 +327,15 @@ function __kodyOptionalRuntimeFunctionExport(exportName) {
 	return __kodyCreateRuntimeFunctionExport(exportName);
 }
 
-export const kody = __kodyCreateRuntimeObjectProxy('kody');
+// \`kody\` keeps its preload late-binding (imported before any store exists)
+// and additionally stays late-bound for in-run evaluations, so reused worker
+// isolates never pin the first run's dispatcher-backed proxy. A wrapper that
+// deliberately omits \`kody\` still observes \`undefined\` so falsiness
+// guards keep working.
+export const kody =
+	__kodyInitialRuntime === undefined || __kodyInitialRuntime.kody != null
+		? __kodyCreateRuntimeObjectProxy('kody')
+		: undefined;
 export const storage = __kodyOptionalRuntimeObjectExport('storage', undefined);
 export const refreshAccessToken = __kodyOptionalRuntimeFunctionExport('refreshAccessToken');
 export const createAuthenticatedFetch = __kodyOptionalRuntimeFunctionExport('createAuthenticatedFetch');

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -292,7 +292,7 @@ function createPackageAppWorkerBindingIdentity(
 	])
 }
 
-async function resolvePackageAppWorker(input: {
+async function resolvePackageAppWorkerBuildInput(input: {
 	env: Env
 	binding: PackageRealtimeBindingState
 }) {
@@ -325,8 +325,7 @@ async function resolvePackageAppWorker(input: {
 		},
 		repoContext: null,
 	})
-	return await buildPackageAppWorker({
-		env: input.env,
+	return {
 		baseUrl: input.binding.baseUrl,
 		userId: input.binding.userId,
 		savedPackage: {
@@ -342,7 +341,7 @@ async function resolvePackageAppWorker(input: {
 		runtime: {
 			callerContext,
 		},
-	})
+	}
 }
 
 export async function resolvePackageAppWorkerCacheKey(input: {
@@ -374,8 +373,12 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		cacheKey: string
 		expiresAt: number
 	} | null = null
-	private cachedAppWorkerPromise: Promise<
-		Awaited<ReturnType<typeof buildPackageAppWorker>>
+	// Caches only the build *input* (D1 rows + source files + caller context).
+	// The worker stub itself is request-bound and must be re-acquired per
+	// event via buildPackageAppWorker, which reuses cached worker options and
+	// warm loader isolates internally.
+	private cachedAppWorkerBuildInputPromise: Promise<
+		Awaited<ReturnType<typeof resolvePackageAppWorkerBuildInput>>
 	> | null = null
 
 	constructor(ctx: DurableObjectState, env: Env) {
@@ -411,7 +414,7 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		this.stateSnapshot = createInitialState()
 		this.cachedAppWorkerKey = null
 		this.cachedAppWorkerKeyLookup = null
-		this.cachedAppWorkerPromise = null
+		this.cachedAppWorkerBuildInputPromise = null
 		await this.ctx.storage.deleteAll()
 	}
 
@@ -442,24 +445,31 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		}
 	}
 
-	private async getCachedPackageAppWorker(
-		binding: PackageRealtimeBindingState,
-	) {
+	private async getPackageAppWorker(binding: PackageRealtimeBindingState) {
 		const cacheKey = await this.getResolvedPackageAppWorkerCacheKey(binding)
-		if (this.cachedAppWorkerKey !== cacheKey || !this.cachedAppWorkerPromise) {
+		if (
+			this.cachedAppWorkerKey !== cacheKey ||
+			!this.cachedAppWorkerBuildInputPromise
+		) {
 			this.cachedAppWorkerKey = cacheKey
-			this.cachedAppWorkerPromise = resolvePackageAppWorker({
-				env: this.env,
-				binding,
-			}).catch((error) => {
+			this.cachedAppWorkerBuildInputPromise = resolvePackageAppWorkerBuildInput(
+				{
+					env: this.env,
+					binding,
+				},
+			).catch((error) => {
 				if (this.cachedAppWorkerKey === cacheKey) {
 					this.cachedAppWorkerKey = null
-					this.cachedAppWorkerPromise = null
+					this.cachedAppWorkerBuildInputPromise = null
 				}
 				throw error
 			})
 		}
-		return await this.cachedAppWorkerPromise
+		const buildInput = await this.cachedAppWorkerBuildInputPromise
+		return await buildPackageAppWorker({
+			env: this.env,
+			...buildInput,
+		})
 	}
 
 	private async getResolvedPackageAppWorkerCacheKey(
@@ -581,7 +591,7 @@ export class PackageRealtimeSession extends DurableObject<Env> {
 		binding: PackageRealtimeBindingState
 		payload: PackageRealtimeHookInput
 	}) {
-		const appWorker = await this.getCachedPackageAppWorker(input.binding)
+		const appWorker = await this.getPackageAppWorker(input.binding)
 		const entrypoint = appWorker.stub.getEntrypoint(
 			appWorker.entrypointName,
 		) as {

--- a/packages/worker/src/repo/source-safety-policy.ts
+++ b/packages/worker/src/repo/source-safety-policy.ts
@@ -16,7 +16,7 @@ export const productionPackageSourceSafetyPolicy =
 	'Production package source safety policy: never replace source history, force publish, or package_save over an existing package unless Kody has created a restorable backup snapshot and the user explicitly approved destructive overwrite. If existing source cannot be cloned or verified, stop and report the source recovery problem.'
 
 export const defaultPackagePrivateGuidance =
-	'Default new saved packages to `"private": true` in package.json unless the user explicitly wants public community publishing. Like npm, `"private": true` blocks community listings on this deployment.'
+	'Default new saved packages to `"private": true` in package.json unless the user explicitly wants public community publishing. Like npm, `"private": true` blocks community listings on this deployment. When package.json omits `"private"` on create, Kody always saves the new package with `"private": true` — even when confirm_private_visibility_change is true. To create a package eligible for community publishing, set `"private": false` explicitly in package.json and pass confirm_private_visibility_change: true after explicit user approval.'
 
 export const destructiveOverwriteConfirmationField =
 	'confirm_destructive_overwrite'
@@ -28,7 +28,7 @@ export const privateVisibilityChangeConfirmationField =
 	'confirm_private_visibility_change'
 
 export const privateVisibilityChangeConfirmationDescription =
-	'Set to true only when the user explicitly approved changing package.json `"private"` or creating a package without `"private": true`. This gates community publishing the same way npm blocks public registry publish for private packages.'
+	'Set to true only when the user explicitly approved changing package.json `"private"` or creating a package without `"private": true`. This flag is a confirmation gate, not a visibility request: it never changes `"private"` by itself. A new package whose manifest omits `"private"` is always saved with `"private": true`; send `"private": false` explicitly (plus this confirmation) to create a community-publishable package. This gates community publishing the same way npm blocks public registry publish for private packages.'
 
 export function buildSourceRecoveryProblemMessage(input: {
 	source: EntitySourceRow


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production evidence (2026-07-09/10, `@kentcdodds/slack` publish flow): `community_publish`, `community_search`, `repo_publish_session`, and `repo_run_commands` intermittently failed with **"RPC stub used after being disposed"** — including calls made with fresh Kody conversation ids — while a first call with the same code often succeeded.

## Root cause

Execute derives **stable dynamic-worker ids** when `APP_COMMIT_SHA` is set (production/preview only — unset in dev and tests, which is why this never reproduced locally). Two execute calls with identical module code reuse one sandbox isolate, and the isolate's ES module cache survives between them.

The `kody:runtime` virtual module evaluated once per isolate and **froze the first run's runtime object into module scope** (`export const kody = runtime.kody`). That `kody` proxy closes over the first `evaluate()` call's RPC `ToolDispatcher` stubs, and workerd implicitly disposes stubs passed as RPC parameters when the call returns. Every later execute that hashed to the same worker — LLM-generated capability snippets are frequently byte-identical across retries and across conversations — called capabilities through the first run's disposed stubs. Conversation ids are irrelevant: the worker cache is isolate-wide and keyed by code + user + commit, which is exactly why fresh conversations kept failing.

Reproduced deterministically in `execute-dynamic-worker-reuse.workers.test.ts` — the second identical execute fails with the exact production error without the fix (verified by stashing the fix and re-running).

## Fix

- **`kody:runtime` exports are now late-bound** (`module-graph.ts`): every export re-reads the current `AsyncLocalStorage` store per property access/call; method values re-resolve at call time so even top-level captures (`const search = kody.community_search`) cannot pin a dead run; the default export forwards wrapper-specific helpers (e.g. package-app `realtime`) to the current store. Optional helper presence (`storage`, `email`, …) still freezes to its absent value so `if (email)` guards keep working — presence is part of the worker-id hash, so it is identical for every run of a given worker.
- **`PackageRealtimeSession` no longer caches a request-bound worker stub** across websocket events (same lifecycle class); it caches only the resolved build input and re-acquires a fresh loader stub per event.
- **Diagnostics**: execute errors containing "RPC stub used after being disposed" now map to a structured `sandbox_runtime_stale` detail explaining that identical retries hit the same cached worker and how to escape it (change the module so a fresh worker id is derived), instead of a bare string that invites futile retries.

### The 07-09 `undefined.bind` error

The earlier "Cannot read properties of undefined (reading 'bind')" from `repo_publish_session` could not be pinned to an exact frame without a production stack trace. Audit results: every `.bind` in the repo/publish path is guarded (D1 `prepare().bind()` chains, `candidate.fetch.bind(candidate)` behind `typeof` checks, the runtime proxy's method binding behind a `typeof value === 'function'` check). It is consistent with the same class of stale per-isolate sandbox state that this PR eliminates, and the new structured diagnostics will make any recurrence traceable.

## `package_save` private visibility

Reviewed and kept as intended, now clearly documented and pinned by tests: `confirm_private_visibility_change` is a **confirmation gate, never a visibility request**. A new package whose manifest omits `"private"` is always saved with `"private": true`, even with the confirmation flag set; community-publishable packages require an explicit `"private": false` plus the confirmation. Clarified in the capability guidance, the field description, and `docs/use/community-packages.md`; three new handler-level tests pin omission+confirm, explicit-false+confirm, and explicit-false-without-confirm.

## Testing

- New workers regression test runs three sequential identical executes through the real worker loader with `APP_COMMIT_SHA` pinned (fails with the production error pre-fix, passes post-fix), including per-call fresh caller contexts modeling fresh conversations.
- New node test pins that a cached `kody:runtime` module instance resolves `kody` per run and that a "disposed" first run cannot poison the second.
- Existing suites (`runtime-isolation`, `module-graph`, `realtime-session`, executor) pass; full `npm run validate` run on the branch.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `ab7d9382` · **Head:** `d8fde2fe`

**Classification:** extends — changes the `kody:runtime` module lifecycle contract inside the execute sandbox and the realtime session's worker-stub handling; no new primitives.

### Primitives touched

| Primitive              | Group     | Impact                                                                        |
| ---------------------- | --------- | ----------------------------------------------------------------------------- |
| `package-runtime`      | runtime   | extends — `kody:runtime` virtual module exports become late-bound per run     |
| `capabilities-execute` | runtime   | extends — structured `sandbox_runtime_stale` error detail for disposed stubs  |
| `realtime-sessions`    | assistant | extends — caches build input instead of a request-bound worker stub           |
| `saved-packages`       | assistant | composes — `package_save` private-visibility guidance clarified + pinned      |
| `community-listings`   | assistant | composes — docs clarify explicit `"private": false` requirement for publish   |

### System map

An execute call flows through the sandbox runtime module into capability dispatch; the fix makes the cached runtime module re-read each run's dispatchers instead of pinning the first run's.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	execute["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	pkgRuntime["package-runtime<br/>Package runtime"]:::extended
	realtime["realtime-sessions<br/>Realtime sessions"]:::extended
	savedPackages["saved-packages<br/>Saved packages"]:::touched
	community["community-listings<br/>Community package listings"]:::untouched
	execute -->|"late-bound kody:runtime exports per evaluate()"| pkgRuntime
	pkgRuntime -->|"fresh loader stub per websocket event"| realtime
	savedPackages -->|"explicit private:false required for publish"| community
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant E1 as evaluate() #1
	participant M as kody:runtime module (cached per isolate)
	participant E2 as evaluate() #2 (reused worker)
	E1->>M: first import evaluates module
	Note over M: before: exports frozen to run #1's dispatchers
	E1-->>E1: returns — run #1 dispatcher stubs disposed
	E2->>M: cached import
	Note over M: before: kody.* → disposed stubs ("RPC stub used after being disposed")
	Note over M: after: exports read the current AsyncLocalStorage store per call
	E2->>E2: kody.* → run #2's live dispatchers
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45152ca0-3d1b-4b4f-b9b2-37d2291bda5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45152ca0-3d1b-4b4f-b9b2-37d2291bda5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

