### PR TITLE
Fix preview cleanup worker delete regression

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -524,54 +524,7 @@ jobs:
 
           echo "worker_name=$APP_WORKER_NAME" >> "$GITHUB_OUTPUT"
 
-      - name: 🗑️ Delete preview Workers
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          APP_WORKER_NAME: ${{ steps.names.outputs.worker_name }}
-        run: |
-          set -euo pipefail
-          delete_worker() {
-            local name="$1"
-            local config="$2"
-            local output=""
-            set +e
-            output="$(npx wrangler delete "$name" --env preview --config "$config" --force 2>&1)"
-            local exit_code="$?"
-            set -e
-
-            if [ "$exit_code" -eq 0 ]; then
-              echo "$output"
-              return 0
-            fi
-
-            local lower
-            lower="$(echo "$output" | tr '[:upper:]' '[:lower:]')"
-            if [[ "$lower" == *"not found"* ]] || [[ "$lower" == *"no such"* ]] || [[ "$lower" == *"does not exist"* ]]; then
-              echo "Worker $name already deleted."
-              return 0
-            fi
-
-            echo "$output" >&2
-            return "$exit_code"
-          }
-
-          delete_worker "$APP_WORKER_NAME" "packages/worker/wrangler.jsonc"
-
-          for dir in packages/mock-servers/*; do
-            if [ ! -d "$dir" ]; then
-              continue
-            fi
-            if [ ! -f "$dir/wrangler.jsonc" ]; then
-              continue
-            fi
-
-            service="$(basename "$dir")"
-            mock_worker_name="${APP_WORKER_NAME}-mock-${service}"
-            delete_worker "$mock_worker_name" "$dir/wrangler.jsonc"
-          done
-
-      - name: 🧹 Delete preview resources (D1 + KV)
+      - name: 🧹 Delete preview Workers and resources (D1 + KV + R2)
         if: always()
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -198,8 +198,8 @@ each PR preview is isolated:
 - D1 database: `<preview-worker-name>-db`
 - KV namespace (OAuth state): `<preview-worker-name>-oauth-kv`
 
-When a PR is closed, the cleanup job deletes the preview Worker(s) and these
-resources as well.
+When a PR is closed, the cleanup job deletes the preview Worker(s), mock
+Workers, and these resources as well.
 
 Cloudflare Workers supports version `preview_urls`, but those preview URLs are
 not available for Workers that use Durable Objects. The main app Worker binds

--- a/tools/ci/preview-resources.ts
+++ b/tools/ci/preview-resources.ts
@@ -1,5 +1,9 @@
+import { readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+
 import {
 	deleteR2Bucket,
+	deleteWorkerScript,
 	ensureR2Bucket,
 	fail,
 	listD1Databases,
@@ -293,6 +297,38 @@ async function ensurePreviewResources(options: CliOptions) {
 	console.log(`email_blobs_bucket_name=${emailBlobs.name}`)
 }
 
+function listMockServerNames() {
+	const mockServersRoot = path.resolve('packages/mock-servers')
+	let entries: Array<string>
+	try {
+		entries = readdirSync(mockServersRoot)
+	} catch {
+		return []
+	}
+
+	return entries.filter((entry) => {
+		const dir = path.join(mockServersRoot, entry)
+		try {
+			if (!statSync(dir).isDirectory()) {
+				return false
+			}
+		} catch {
+			return false
+		}
+		return readdirSync(dir).some((file) => file === 'wrangler.jsonc')
+	})
+}
+
+function deletePreviewWorkers(workerName: string, dryRun: boolean) {
+	deleteWorkerScript({ name: workerName, dryRun })
+	for (const service of listMockServerNames()) {
+		deleteWorkerScript({
+			name: `${workerName}-mock-${service}`,
+			dryRun,
+		})
+	}
+}
+
 async function cleanupPreviewResources(options: CliOptions) {
 	const {
 		d1DatabaseName,
@@ -300,6 +336,7 @@ async function cleanupPreviewResources(options: CliOptions) {
 		bundleArtifactsKvTitle,
 		emailBlobsBucketName,
 	} = buildPreviewResourceNames(options.workerName)
+	deletePreviewWorkers(options.workerName, options.dryRun)
 	deleteR2Bucket({ name: emailBlobsBucketName, dryRun: options.dryRun })
 	deleteKvNamespace({ title: bundleArtifactsKvTitle, dryRun: options.dryRun })
 	deleteKvNamespace({ title: oauthKvTitle, dryRun: options.dryRun })

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { expect, test, vi } from 'vitest'
 
 import {
+	isWranglerNotFoundOutput,
 	parseJsonc,
 	parseR2BucketListOutput,
 	writeGeneratedWranglerConfig,
@@ -15,6 +16,17 @@ const workerWranglerConfigPath = path.resolve(
 	thisDir,
 	'../../packages/worker/wrangler.jsonc',
 )
+
+test('isWranglerNotFoundOutput recognizes common Wrangler missing-resource messages', () => {
+	expect(isWranglerNotFoundOutput('Worker not found')).toBe(true)
+	expect(isWranglerNotFoundOutput('No such script exists')).toBe(true)
+	expect(
+		isWranglerNotFoundOutput('The requested resource does not exist'),
+	).toBe(true)
+	expect(isWranglerNotFoundOutput('Authentication error [code: 10000]')).toBe(
+		false,
+	)
+})
 
 test('writeGeneratedWranglerConfig preserves migrations and copies environment asset routing', async () => {
 	const tempDir = await mkdtemp(path.join(os.tmpdir(), 'kody-resource-utils-'))

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -104,8 +104,54 @@ export function listKvNamespaces(): Array<KvNamespaceListEntry> {
 	try {
 		return JSON.parse(result.stdout) as Array<KvNamespaceListEntry>
 	} catch {
-		fail('Could not parse JSON output from wrangler kv namespace list.')
+		fail('Failed to parse JSON output from wrangler kv namespace list.')
 	}
+}
+
+export function isWranglerNotFoundOutput(output: string) {
+	const lower = output.toLowerCase()
+	return (
+		lower.includes('not found') ||
+		lower.includes('no such') ||
+		lower.includes('does not exist')
+	)
+}
+
+export function deleteWorkerScript({
+	name,
+	dryRun,
+}: {
+	name: string
+	dryRun: boolean
+}) {
+	if (dryRun) {
+		console.error(`[dry-run] delete Worker script: ${name}`)
+		return
+	}
+
+	// Delete by script name only. Passing --config/--env makes Wrangler resolve
+	// bindings from wrangler.jsonc (including KV namespaces without ids) and
+	// can fail even when the token can delete the Worker and preview resources.
+	const result = runWrangler(['delete', name, '--force'], { quiet: true })
+	const output = `${result.stdout}${result.stderr}`.trim()
+
+	if (result.status === 0) {
+		if (output) {
+			console.error(output)
+		}
+		console.error(`Deleted Worker script: ${name}`)
+		return
+	}
+
+	if (isWranglerNotFoundOutput(output)) {
+		console.error(`Worker script already deleted: ${name}`)
+		return
+	}
+
+	if (output) {
+		console.error(output)
+	}
+	fail(`Failed to delete Worker script: ${name}`)
 }
 
 const ansiEscape = String.fromCharCode(27)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes preview cleanup failures like [actions run 29109815863](https://github.com/kentcdodds/kody/actions/runs/29109815863) when PRs close.

PR #648 added `--config` to `wrangler delete` during cleanup. That makes Wrangler validate preview bindings from `wrangler.jsonc` (KV namespaces without ids, memberships checks) before deleting the script. The same `CLOUDFLARE_API_TOKEN` then successfully deleted KV/D1/R2 in the next step, so this was not a token-permissions gap.

Delete preview Workers by script name only (`wrangler delete <name> --force` with `CLOUDFLARE_ACCOUNT_ID` set), consolidated into `preview-resources.ts cleanup`.

## Changes

- Add `deleteWorkerScript()` to `tools/ci/resource-utils.ts` (name-only delete, tolerant of already-deleted workers)
- Extend `preview-resources.ts cleanup` to delete app + mock Workers before D1/KV/R2 teardown
- Remove the inline bash `delete_worker` step from `.github/workflows/preview.yml`
- Document that cleanup deletes mock Workers too

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `ab7d938` · **Head:** `98781b6`

**Classification:** composes — CI preview cleanup wiring only; no runtime primitive contracts changed.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none from primitives.yaml)_ | — | composes — preview deploy/cleanup workflow and CI helpers only |

### System map

```mermaid
flowchart LR
  PR_close[PR closed] --> cleanup_job[preview.yml cleanup job]
  cleanup_job --> preview_resources[preview-resources.ts cleanup]
  preview_resources --> worker_delete[deleteWorkerScript by name]
  preview_resources --> resource_delete[D1 / KV / R2 delete]
  cleanup_job --> github_env[GitHub env + deployment delete]
```

### What changed

- Worker deletion no longer passes `--config` / `--env preview` to Wrangler during cleanup.
- Preview cleanup is a single `preview-resources.ts cleanup` step (Workers + resources).

### Invariants

- No change to per-user isolation or runtime request paths.
- `CLOUDFLARE_ACCOUNT_ID` remains required for account-scoped Wrangler calls.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-887ba830-b061-4ebf-b7d7-d011943a6dd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-887ba830-b061-4ebf-b7d7-d011943a6dd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preview deployment cleanup now removes mock Worker scripts along with preview Workers and related resources.
  - Cleanup safely handles resources that have already been deleted while still reporting other deletion failures.

- **Documentation**
  - Updated contributor guidance to clarify that closing a pull request removes preview Workers, mock Workers, and associated resources.

- **Tests**
  - Added coverage for detecting missing-resource responses during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->