### PR TITLE
fix(oauth): support Basic Auth token exchange for Notion

### DIFF
--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from 'vitest'
 import {
 	buildIntegrationValueName,
+	formatOAuthExchangeFailure,
 	getIntegrationValueCandidates,
+	isOAuthExchangeSessionExpired,
 	mergeConnectOauthConfig,
 	parseStoredIntegrationConfig,
 	summarizeStoredSetupState,
@@ -88,6 +90,7 @@ test('connect OAuth helpers parse stored integrations, merge reconnect configs, 
 		apiBaseUrl: 'https://api.github.com',
 		scopes: ['repo', 'read:user'],
 		flow: 'confidential',
+		tokenExchangeStyle: 'form',
 		scopeSeparator: ' ',
 		extraAuthorizeParams: { prompt: 'consent' },
 		dashboardUrl: 'https://github.com/settings/developers',
@@ -227,6 +230,7 @@ test('connect OAuth helpers parse stored integrations, merge reconnect configs, 
 		tokenHost: 'accounts.spotify.com',
 		tokenUrl: 'https://accounts.spotify.com/api/token',
 		flow: 'pkce',
+		tokenExchangeStyle: 'form',
 		clientIdValueName: 'spotify-client-id',
 		clientSecretSecretName: null,
 		accessTokenSecretName: 'spotifyAccessToken',
@@ -248,4 +252,97 @@ test('connect OAuth helpers parse stored integrations, merge reconnect configs, 
 	})
 	expect(pkceSetup.isReady).toBe(true)
 	expect(pkceSetup.missingFields).toEqual([])
+})
+
+test('connect OAuth derives Notion basic-json exchange and surfaces provider failures instead of session expiry', () => {
+	const notionConfig = mergeConnectOauthConfig({
+		queryConfig: {
+			provider: 'notion',
+			providerKey: 'notion',
+			authorizeHost: 'api.notion.com',
+			authorizeUrl: 'https://api.notion.com/v1/oauth/authorize',
+			tokenUrl: 'https://api.notion.com/v1/oauth/token',
+			apiBaseUrl: 'https://api.notion.com/v1',
+			scopes: [],
+			flow: 'confidential',
+			scopeSeparator: ' ',
+			extraAuthorizeParams: { owner: 'user', response_type: 'code' },
+			providerSetupInstructions: null,
+			dashboardUrl: null,
+			allowedHosts: ['api.notion.com'],
+		},
+		storedIntegration: null,
+	})
+
+	expect(notionConfig).toMatchObject({
+		provider: 'notion',
+		tokenUrl: 'https://api.notion.com/v1/oauth/token',
+		flow: 'confidential',
+		tokenExchangeStyle: 'basic-json',
+		clientSecretSecretName: 'notionClientSecret',
+		accessTokenSecretName: 'notionAccessToken',
+	})
+
+	const storedNotion = parseStoredIntegrationConfig(
+		JSON.stringify({
+			name: 'notion',
+			tokenUrl: 'https://api.notion.com/v1/oauth/token',
+			apiBaseUrl: 'https://api.notion.com/v1',
+			flow: 'confidential',
+			clientIdValueName: 'notion-client-id',
+			clientSecretSecretName: 'notionClientSecret',
+			accessTokenSecretName: 'notionAccessToken',
+			refreshTokenSecretName: 'notionRefreshToken',
+			requiredHosts: ['api.notion.com'],
+			tokenExchangeStyle: 'basic-json',
+			authorization: {
+				authorizeUrl: 'https://api.notion.com/v1/oauth/authorize',
+				scopes: [],
+				scopeSeparator: null,
+				extraAuthorizeParams: { owner: 'user' },
+			},
+		}),
+		null,
+	)
+	expect(storedNotion?.tokenExchangeStyle).toBe('basic-json')
+
+	expect(
+		formatOAuthExchangeFailure({
+			status: 401,
+			data: { ok: false, error: 'Unauthorized.' },
+		}),
+	).toEqual({
+		treatAsSessionExpired: true,
+		error: 'Session expired.',
+	})
+	expect(
+		isOAuthExchangeSessionExpired({
+			status: 401,
+			data: { ok: false, error: 'Unauthorized.' },
+		}),
+	).toBe(true)
+
+	expect(
+		formatOAuthExchangeFailure({
+			status: 502,
+			data: {
+				ok: false,
+				error: 'invalid_client',
+				error_description: 'Client authentication failed',
+				providerStatus: 401,
+			},
+		}),
+	).toEqual({
+		treatAsSessionExpired: false,
+		error: 'Client authentication failed',
+	})
+	expect(
+		isOAuthExchangeSessionExpired({
+			status: 401,
+			data: {
+				error: 'invalid_client',
+				error_description: 'Client authentication failed',
+			},
+		}),
+	).toBe(false)
 })

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -38,6 +38,7 @@ import {
 } from '#client/styles/style-primitives.ts'
 
 type OAuthFlow = 'pkce' | 'confidential'
+type TokenExchangeStyle = 'form' | 'basic-json'
 
 type ConnectOauthQueryConfig = {
 	provider: string
@@ -65,6 +66,7 @@ type ConnectOauthConfig = {
 	apiBaseUrl: string | null
 	scopes: Array<string>
 	flow: OAuthFlow
+	tokenExchangeStyle: TokenExchangeStyle
 	scopeSeparator: string
 	extraAuthorizeParams: Record<string, string>
 	providerSetupInstructions: string | null
@@ -86,6 +88,7 @@ type StoredIntegrationConfig = {
 	accessTokenSecretName: string
 	refreshTokenSecretName: string | null
 	requiredHosts: Array<string>
+	tokenExchangeStyle?: TokenExchangeStyle | null
 	authorization?: StoredIntegrationAuthorization | null
 }
 
@@ -601,13 +604,11 @@ export function ConnectOauthRoute(handle: Handle) {
 				tokenUrl: nextConfig.tokenUrl,
 				params: params.toString(),
 				flow: nextConfig.flow,
+				tokenExchangeStyle: nextConfig.tokenExchangeStyle,
 				clientSecretSecretName: nextConfig.clientSecretSecretName,
 				allowedHosts: nextConfig.allowedHosts,
 			}),
 		})
-		if (redirectToLoginOn401(response)) {
-			return { ok: false, status: 401, error: 'Session expired.' }
-		}
 		const text = await response.text()
 		let data: Record<string, unknown> | null = null
 		try {
@@ -615,17 +616,19 @@ export function ConnectOauthRoute(handle: Handle) {
 		} catch {
 			data = null
 		}
+		const failure = formatOAuthExchangeFailure({
+			status: response.status,
+			data,
+		})
+		if (failure.treatAsSessionExpired) {
+			window.location.assign('/login')
+			return { ok: false, status: 401, error: 'Session expired.' }
+		}
 		if (!response.ok || !data) {
-			const errorDescription =
-				typeof data?.error_description === 'string'
-					? data.error_description
-					: typeof data?.error === 'string'
-						? data.error
-						: null
 			return {
 				ok: false,
 				status: response.status,
-				error: errorDescription ?? 'Token exchange failed.',
+				error: failure.error,
 			}
 		}
 		return { ok: true, data, status: response.status }
@@ -753,6 +756,7 @@ export function ConnectOauthRoute(handle: Handle) {
 				scopeSeparator: config.scopeSeparator,
 				extraAuthorizeParams: config.extraAuthorizeParams,
 				flow: config.flow,
+				tokenExchangeStyle: config.tokenExchangeStyle,
 				clientIdValueName: config.clientIdValueName,
 				clientSecretSecretName: config.clientSecretSecretName,
 				allowedHosts: config.allowedHosts,
@@ -1304,6 +1308,9 @@ export function parseStoredIntegrationConfig(
 			parsed.clientSecretSecretName.trim()
 				? parsed.clientSecretSecretName.trim()
 				: null
+		const tokenExchangeStyle = parseTokenExchangeStyle(
+			parsed.tokenExchangeStyle,
+		)
 		const requiredHosts = Array.isArray(parsed.requiredHosts)
 			? parsed.requiredHosts.filter(
 					(value): value is string => typeof value === 'string',
@@ -1328,6 +1335,7 @@ export function parseStoredIntegrationConfig(
 			accessTokenSecretName,
 			refreshTokenSecretName,
 			requiredHosts: normalizeHosts(requiredHosts),
+			...(tokenExchangeStyle ? { tokenExchangeStyle } : {}),
 			authorization,
 		}
 	} catch {
@@ -1426,6 +1434,10 @@ export function mergeConnectOauthConfig(input: {
 			input.storedIntegration?.apiBaseUrl ?? input.queryConfig.apiBaseUrl,
 		scopes,
 		flow,
+		tokenExchangeStyle: resolveConnectOauthTokenExchangeStyle({
+			tokenUrl,
+			storedStyle: input.storedIntegration?.tokenExchangeStyle ?? null,
+		}),
 		scopeSeparator:
 			input.queryConfig.scopeSeparator ??
 			input.storedIntegration?.authorization?.scopeSeparator ??
@@ -1485,6 +1497,69 @@ export function summarizeStoredSetupState(input: {
 		missingFields,
 		isReady: missingFields.length === 0,
 	}
+}
+
+/**
+ * Distinguish real Kody session expiry (401 Unauthorized) from provider token
+ * exchange failures that historically leaked through as HTTP 401.
+ */
+export function formatOAuthExchangeFailure(input: {
+	status: number
+	data: Record<string, unknown> | null
+}): { treatAsSessionExpired: boolean; error: string } {
+	if (isOAuthExchangeSessionExpired(input)) {
+		return { treatAsSessionExpired: true, error: 'Session expired.' }
+	}
+	const errorDescription =
+		typeof input.data?.error_description === 'string' &&
+		input.data.error_description.trim()
+			? input.data.error_description.trim()
+			: typeof input.data?.error === 'string' && input.data.error.trim()
+				? input.data.error.trim()
+				: null
+	return {
+		treatAsSessionExpired: false,
+		error: errorDescription ?? 'Token exchange failed.',
+	}
+}
+
+export function isOAuthExchangeSessionExpired(input: {
+	status: number
+	data: Record<string, unknown> | null
+}) {
+	if (input.status !== 401) return false
+	if (hasProviderOAuthExchangeError(input.data)) return false
+	return true
+}
+
+function hasProviderOAuthExchangeError(data: Record<string, unknown> | null) {
+	if (!data) return false
+	if (typeof data.providerStatus === 'number') return true
+	if (
+		typeof data.error_description === 'string' &&
+		data.error_description.trim()
+	) {
+		return true
+	}
+	return (
+		typeof data.error === 'string' &&
+		data.error.trim() !== '' &&
+		data.error !== 'Unauthorized.'
+	)
+}
+
+function resolveConnectOauthTokenExchangeStyle(input: {
+	tokenUrl: string
+	storedStyle: TokenExchangeStyle | null
+}): TokenExchangeStyle {
+	if (input.storedStyle) return input.storedStyle
+	const host = safeParseHost(input.tokenUrl)
+	if (host === 'api.notion.com') return 'basic-json'
+	return 'form'
+}
+
+function parseTokenExchangeStyle(raw: unknown): TokenExchangeStyle | null {
+	return raw === 'form' || raw === 'basic-json' ? raw : null
 }
 
 function formatMissingSetupFields(missingFields: Array<string>) {

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -715,3 +715,159 @@ test('account secrets API loads selected secret values and deletes the selected 
 		}),
 	)
 })
+
+test('oauth_exchange supports Notion basic-json and confidential form-body styles without leaking provider 401', async () => {
+	const fetchMock = vi.fn()
+	vi.stubGlobal('fetch', fetchMock)
+	const handler = createAccountSecretsApiHandler(createEnv())
+
+	mockModule.resolveSecret.mockResolvedValueOnce({
+		found: true,
+		value: 'notion-client-secret',
+	})
+	fetchMock.mockResolvedValueOnce(
+		new Response(
+			JSON.stringify({
+				access_token: 'notion-access',
+				refresh_token: 'notion-refresh',
+			}),
+			{ status: 200, headers: { 'Content-Type': 'application/json' } },
+		),
+	)
+
+	const notionSuccess = await handler.handler({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'oauth_exchange',
+				tokenUrl: 'https://api.notion.com/v1/oauth/token',
+				params: new URLSearchParams({
+					grant_type: 'authorization_code',
+					client_id: 'notion-client-id',
+					code: 'auth-code',
+					redirect_uri: 'https://example.com/connect/oauth',
+				}).toString(),
+				flow: 'confidential',
+				clientSecretSecretName: 'notionClientSecret',
+				allowedHosts: ['api.notion.com'],
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(notionSuccess.status).toBe(200)
+	await expect(notionSuccess.json()).resolves.toMatchObject({
+		access_token: 'notion-access',
+		refresh_token: 'notion-refresh',
+	})
+	expect(fetchMock).toHaveBeenCalledTimes(1)
+	const notionRequest = fetchMock.mock.calls[0]?.[1] as RequestInit
+	expect(notionRequest.method).toBe('POST')
+	expect(notionRequest.headers).toMatchObject({
+		Accept: 'application/json',
+		'Content-Type': 'application/json',
+		Authorization: `Basic ${btoa('notion-client-id:notion-client-secret')}`,
+	})
+	expect(JSON.parse(String(notionRequest.body))).toEqual({
+		grant_type: 'authorization_code',
+		code: 'auth-code',
+		redirect_uri: 'https://example.com/connect/oauth',
+	})
+
+	mockModule.resolveSecret.mockResolvedValueOnce({
+		found: true,
+		value: 'slack-client-secret',
+	})
+	fetchMock.mockResolvedValueOnce(
+		new Response(JSON.stringify({ access_token: 'slack-access' }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' },
+		}),
+	)
+
+	const formSuccess = await handler.handler({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'oauth_exchange',
+				tokenUrl: 'https://slack.com/api/oauth.v2.access',
+				params: new URLSearchParams({
+					grant_type: 'authorization_code',
+					client_id: 'slack-client-id',
+					code: 'slack-code',
+					redirect_uri: 'https://example.com/connect/oauth',
+				}).toString(),
+				flow: 'confidential',
+				tokenExchangeStyle: 'form',
+				clientSecretSecretName: 'slackClientSecret',
+				allowedHosts: ['slack.com'],
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(formSuccess.status).toBe(200)
+	await expect(formSuccess.json()).resolves.toMatchObject({
+		access_token: 'slack-access',
+	})
+	expect(fetchMock).toHaveBeenCalledTimes(2)
+	const formRequest = fetchMock.mock.calls[1]?.[1] as RequestInit
+	expect(formRequest.headers).toMatchObject({
+		Accept: 'application/json',
+		'Content-Type': 'application/x-www-form-urlencoded',
+	})
+	expect(formRequest.headers).not.toHaveProperty('Authorization')
+	expect(
+		new URLSearchParams(String(formRequest.body)).get('client_secret'),
+	).toBe('slack-client-secret')
+	expect(new URLSearchParams(String(formRequest.body)).get('client_id')).toBe(
+		'slack-client-id',
+	)
+
+	mockModule.resolveSecret.mockResolvedValueOnce({
+		found: true,
+		value: 'notion-client-secret',
+	})
+	fetchMock.mockResolvedValueOnce(
+		new Response(
+			JSON.stringify({
+				error: 'invalid_client',
+				error_description: 'Client authentication failed',
+			}),
+			{ status: 401, headers: { 'Content-Type': 'application/json' } },
+		),
+	)
+
+	const notionFailure = await handler.handler({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'oauth_exchange',
+				tokenUrl: 'https://api.notion.com/v1/oauth/token',
+				params: new URLSearchParams({
+					grant_type: 'authorization_code',
+					client_id: 'notion-client-id',
+					code: 'bad-code',
+					redirect_uri: 'https://example.com/connect/oauth',
+				}).toString(),
+				flow: 'confidential',
+				clientSecretSecretName: 'notionClientSecret',
+				allowedHosts: ['api.notion.com'],
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(notionFailure.status).toBe(502)
+	await expect(notionFailure.json()).resolves.toEqual({
+		ok: false,
+		error: 'invalid_client',
+		error_description: 'Client authentication failed',
+		providerStatus: 401,
+	})
+
+	vi.unstubAllGlobals()
+})

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -45,6 +45,13 @@ import {
 	buildIntegrationValueName,
 	parseIntegrationConfig,
 } from '#mcp/capabilities/integrations/integration-shared.ts'
+import {
+	buildOAuthTokenExchangeFailurePayload,
+	buildOAuthTokenExchangeRequest,
+	oauthTokenExchangeFailureHttpStatus,
+	resolveTokenExchangeStyle,
+	type TokenExchangeStyle,
+} from '#app/oauth-token-exchange.ts'
 
 type AccountEditableSecretScope = Extract<SecretScope, 'package' | 'user'>
 
@@ -356,6 +363,10 @@ async function handleConnectOauthAction(input: {
 		clientSecretSecretName,
 		accessTokenSecretName,
 		refreshTokenSecretName,
+		tokenExchangeStyle: resolveTokenExchangeStyle({
+			tokenUrl,
+			tokenExchangeStyle: readOptionalString(input.body, 'tokenExchangeStyle'),
+		}),
 		tokenPayload: tokenRecord,
 		allowedHosts,
 		authorization: authorizeUrl
@@ -497,7 +508,13 @@ async function handleOAuthExchangeAction(input: {
 		)
 	}
 
+	const tokenExchangeStyle = resolveTokenExchangeStyle({
+		tokenUrl,
+		tokenExchangeStyle: readOptionalString(input.body, 'tokenExchangeStyle'),
+	})
+
 	const params = new URLSearchParams(paramsRaw)
+	let clientSecret: string | null = null
 	if (flow === 'confidential') {
 		if (!clientSecretSecretName) {
 			return jsonResponse(
@@ -515,16 +532,34 @@ async function handleOAuthExchangeAction(input: {
 		if (!resolved.found || !resolved.value) {
 			return jsonResponse({ ok: false, error: 'Client secret not found.' }, 400)
 		}
-		params.set('client_secret', resolved.value)
+		clientSecret = resolved.value
+	}
+
+	let exchangeRequest: { headers: Record<string, string>; body: string }
+	try {
+		exchangeRequest = buildOAuthTokenExchangeRequest({
+			params,
+			flow,
+			clientSecret,
+			style: tokenExchangeStyle,
+		})
+	} catch (error) {
+		return jsonResponse(
+			{
+				ok: false,
+				error:
+					error instanceof Error
+						? error.message
+						: 'Unable to build token exchange request.',
+			},
+			400,
+		)
 	}
 
 	const response = await fetch(tokenUrl, {
 		method: 'POST',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/x-www-form-urlencoded',
-		},
-		body: params.toString(),
+		headers: exchangeRequest.headers,
+		body: exchangeRequest.body,
 	})
 	const text = await response.text()
 	let payload: unknown = null
@@ -533,13 +568,29 @@ async function handleOAuthExchangeAction(input: {
 	} catch {
 		payload = null
 	}
-	if (!payload || typeof payload !== 'object') {
+	const payloadRecord =
+		payload && typeof payload === 'object' && !Array.isArray(payload)
+			? (payload as Record<string, unknown>)
+			: null
+	if (!response.ok) {
 		return jsonResponse(
-			{ ok: false, error: 'Token exchange failed.' },
-			response.status,
+			buildOAuthTokenExchangeFailurePayload({
+				providerStatus: response.status,
+				payload: payloadRecord,
+			}),
+			oauthTokenExchangeFailureHttpStatus(),
 		)
 	}
-	return jsonResponse(payload as Record<string, unknown>, response.status)
+	if (!payloadRecord) {
+		return jsonResponse(
+			buildOAuthTokenExchangeFailurePayload({
+				providerStatus: response.status,
+				payload: null,
+			}),
+			oauthTokenExchangeFailureHttpStatus(),
+		)
+	}
+	return jsonResponse(payloadRecord, response.status)
 }
 
 async function saveIntegrationConfig(input: {
@@ -554,6 +605,7 @@ async function saveIntegrationConfig(input: {
 	clientSecretSecretName: string | null
 	accessTokenSecretName: string
 	refreshTokenSecretName: string | null
+	tokenExchangeStyle: TokenExchangeStyle | null
 	tokenPayload: Record<string, unknown>
 	allowedHosts: Array<string>
 	authorization: {
@@ -581,6 +633,9 @@ async function saveIntegrationConfig(input: {
 			accessTokenSecretName: input.accessTokenSecretName,
 			refreshTokenSecretName: input.refreshTokenSecretName,
 			requiredHosts: input.allowedHosts,
+			...(input.tokenExchangeStyle && input.tokenExchangeStyle !== 'form'
+				? { tokenExchangeStyle: input.tokenExchangeStyle }
+				: {}),
 			...(input.authorization ? { authorization: input.authorization } : {}),
 		},
 		input.provider,

--- a/packages/worker/src/app/oauth-token-exchange.node.test.ts
+++ b/packages/worker/src/app/oauth-token-exchange.node.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from 'vitest'
+import {
+	buildOAuthTokenExchangeFailurePayload,
+	buildOAuthTokenExchangeRequest,
+	oauthTokenExchangeFailureHttpStatus,
+	resolveTokenExchangeStyle,
+} from './oauth-token-exchange.ts'
+
+test('token exchange style resolves Notion basic-json and builds both request shapes', () => {
+	expect(
+		resolveTokenExchangeStyle({
+			tokenUrl: 'https://api.notion.com/v1/oauth/token',
+		}),
+	).toBe('basic-json')
+	expect(
+		resolveTokenExchangeStyle({
+			tokenUrl: 'https://slack.com/api/oauth.v2.access',
+		}),
+	).toBe('form')
+	expect(
+		resolveTokenExchangeStyle({
+			tokenUrl: 'https://api.notion.com/v1/oauth/token',
+			tokenExchangeStyle: 'form',
+		}),
+	).toBe('form')
+
+	const notionRequest = buildOAuthTokenExchangeRequest({
+		params: new URLSearchParams({
+			grant_type: 'authorization_code',
+			client_id: 'client-id',
+			code: 'code',
+			redirect_uri: 'https://example.com/connect/oauth',
+		}),
+		flow: 'confidential',
+		clientSecret: 'client-secret',
+		style: 'basic-json',
+	})
+	expect(notionRequest.headers).toEqual({
+		Accept: 'application/json',
+		'Content-Type': 'application/json',
+		Authorization: `Basic ${btoa('client-id:client-secret')}`,
+	})
+	expect(JSON.parse(notionRequest.body)).toEqual({
+		grant_type: 'authorization_code',
+		code: 'code',
+		redirect_uri: 'https://example.com/connect/oauth',
+	})
+
+	const formRequest = buildOAuthTokenExchangeRequest({
+		params: new URLSearchParams({
+			grant_type: 'authorization_code',
+			client_id: 'client-id',
+			code: 'code',
+			redirect_uri: 'https://example.com/connect/oauth',
+		}),
+		flow: 'confidential',
+		clientSecret: 'client-secret',
+		style: 'form',
+	})
+	expect(formRequest.headers).toEqual({
+		Accept: 'application/json',
+		'Content-Type': 'application/x-www-form-urlencoded',
+	})
+	expect(new URLSearchParams(formRequest.body).get('client_secret')).toBe(
+		'client-secret',
+	)
+
+	expect(oauthTokenExchangeFailureHttpStatus()).toBe(502)
+	expect(
+		buildOAuthTokenExchangeFailurePayload({
+			providerStatus: 401,
+			payload: {
+				error: 'invalid_client',
+				error_description: 'Client authentication failed',
+			},
+		}),
+	).toEqual({
+		ok: false,
+		error: 'invalid_client',
+		error_description: 'Client authentication failed',
+		providerStatus: 401,
+	})
+})

--- a/packages/worker/src/app/oauth-token-exchange.ts
+++ b/packages/worker/src/app/oauth-token-exchange.ts
@@ -1,0 +1,124 @@
+import { bytesToBase64 } from '@kody-internal/shared/base64.ts'
+import { safeParseHost } from '@kody-internal/shared/url-hosts.ts'
+
+/**
+ * Outbound integration token-exchange request styles for `/connect/oauth`.
+ *
+ * - `form`: application/x-www-form-urlencoded body; confidential clients put
+ *   `client_secret` in the body (GitHub/Slack-style).
+ * - `basic-json`: HTTP Basic (client_id:client_secret) + JSON body without
+ *   credentials in the body (Notion-style).
+ */
+export const tokenExchangeStyles = ['form', 'basic-json'] as const
+export type TokenExchangeStyle = (typeof tokenExchangeStyles)[number]
+
+export function isTokenExchangeStyle(
+	value: string,
+): value is TokenExchangeStyle {
+	return (tokenExchangeStyles as ReadonlyArray<string>).includes(value)
+}
+
+export function resolveTokenExchangeStyle(input: {
+	tokenUrl: string
+	tokenExchangeStyle?: string | null
+}): TokenExchangeStyle {
+	const explicit = input.tokenExchangeStyle?.trim()
+	if (explicit && isTokenExchangeStyle(explicit)) return explicit
+	const host = safeParseHost(input.tokenUrl)
+	// Notion's token endpoint rejects form-body client_secret and requires
+	// Basic Auth + JSON: https://developers.notion.com/guides/get-started/authorization
+	if (host === 'api.notion.com') return 'basic-json'
+	return 'form'
+}
+
+export function buildOAuthTokenExchangeRequest(input: {
+	params: URLSearchParams
+	flow: 'pkce' | 'confidential'
+	clientSecret: string | null
+	style: TokenExchangeStyle
+}): { headers: Record<string, string>; body: string } {
+	const params = new URLSearchParams(input.params)
+	switch (input.style) {
+		case 'basic-json': {
+			if (input.flow !== 'confidential' || !input.clientSecret) {
+				throw new Error(
+					'basic-json token exchange requires confidential flow with a client secret.',
+				)
+			}
+			const clientId = params.get('client_id')?.trim() ?? ''
+			if (!clientId) {
+				throw new Error(
+					'basic-json token exchange requires client_id in params.',
+				)
+			}
+			params.delete('client_id')
+			params.delete('client_secret')
+			const bodyObject = Object.fromEntries(params.entries())
+			return {
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+					Authorization: `Basic ${bytesToBase64(
+						new TextEncoder().encode(`${clientId}:${input.clientSecret}`),
+					)}`,
+				},
+				body: JSON.stringify(bodyObject),
+			}
+		}
+		case 'form': {
+			if (input.flow === 'confidential') {
+				if (!input.clientSecret) {
+					throw new Error('Confidential flow requires a client secret.')
+				}
+				params.set('client_secret', input.clientSecret)
+			}
+			return {
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: params.toString(),
+			}
+		}
+		default: {
+			const exhaustiveCheck: never = input.style
+			throw new Error(
+				`Unhandled token exchange style: ${String(exhaustiveCheck)}`,
+			)
+		}
+	}
+}
+
+/**
+ * Provider token-endpoint failures must not reuse HTTP 401 — the connect UI
+ * treats 401 from `/account/secrets.json` as an expired Kody session.
+ */
+export function oauthTokenExchangeFailureHttpStatus(): number {
+	return 502
+}
+
+export function buildOAuthTokenExchangeFailurePayload(input: {
+	providerStatus: number
+	payload: Record<string, unknown> | null
+}): {
+	ok: false
+	error: string
+	error_description?: string
+	providerStatus: number
+} {
+	const error =
+		typeof input.payload?.error === 'string' && input.payload.error.trim()
+			? input.payload.error.trim()
+			: 'Token exchange failed.'
+	const errorDescription =
+		typeof input.payload?.error_description === 'string' &&
+		input.payload.error_description.trim()
+			? input.payload.error_description.trim()
+			: null
+	return {
+		ok: false,
+		error,
+		...(errorDescription ? { error_description: errorDescription } : {}),
+		providerStatus: input.providerStatus,
+	}
+}

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
@@ -96,6 +96,9 @@ function createNewIntegrationConfig(args: z.infer<typeof inputSchema>) {
 		accessTokenSecretName: args.accessTokenSecretName,
 		refreshTokenSecretName: args.refreshTokenSecretName ?? null,
 		requiredHosts: args.requiredHosts,
+		...(args.tokenExchangeStyle !== undefined
+			? { tokenExchangeStyle: args.tokenExchangeStyle }
+			: {}),
 		...(args.authorization !== undefined
 			? { authorization: args.authorization }
 			: {}),

--- a/packages/worker/src/mcp/capabilities/integrations/integration-shared.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-shared.ts
@@ -5,6 +5,8 @@ export const integrationFlowValues = ['pkce', 'confidential'] as const
 
 const defaultIntegrationScopeSeparator = ' '
 
+export const tokenExchangeStyleValues = ['form', 'basic-json'] as const
+
 export const integrationAuthorizationSchema = z
 	.object({
 		authorizeUrl: z.string().url().refine(isHttpUrl, {
@@ -33,6 +35,7 @@ export const integrationConfigSchema = z.object({
 	accessTokenSecretName: z.string().min(1),
 	refreshTokenSecretName: z.string().min(1).optional().nullable(),
 	requiredHosts: z.array(z.string()).optional(),
+	tokenExchangeStyle: z.enum(tokenExchangeStyleValues).optional().nullable(),
 	authorization: integrationAuthorizationSchema.optional().nullable(),
 })
 
@@ -50,6 +53,7 @@ export const integrationSaveSchema = z
 		accessTokenSecretName: z.string().min(1).optional(),
 		refreshTokenSecretName: z.string().min(1).nullable().optional(),
 		requiredHosts: z.array(z.string()).optional(),
+		tokenExchangeStyle: z.enum(tokenExchangeStyleValues).nullable().optional(),
 		authorization: integrationAuthorizationSchema.nullable().optional(),
 	})
 	.strict()
@@ -62,6 +66,7 @@ export function normalizeIntegrationConfig(
 	const authorization = value.authorization
 		? normalizeIntegrationAuthorization(value.authorization)
 		: null
+	const tokenExchangeStyle = value.tokenExchangeStyle ?? null
 	return {
 		...value,
 		name: value.name.trim(),
@@ -72,6 +77,7 @@ export function normalizeIntegrationConfig(
 		accessTokenSecretName: value.accessTokenSecretName.trim(),
 		refreshTokenSecretName: value.refreshTokenSecretName?.trim() || null,
 		requiredHosts: normalizeAllowedHosts(value.requiredHosts ?? []),
+		...(tokenExchangeStyle ? { tokenExchangeStyle } : {}),
 		...(authorization ? { authorization } : {}),
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Notion OAuth via `/connect/oauth` failed after the user approved access: Kody exchanged the code with a form-urlencoded `client_secret` body (no Basic Auth), Notion returned HTTP 401, and the connect UI treated that 401 as a Kody session expiry ("Session expired.") instead of showing the provider error. Tokens were never saved.

## Fix

- Add `tokenExchangeStyle`: `form` (default, existing confidential body-secret flows) and `basic-json` (HTTP Basic + JSON body).
- Auto-detect `basic-json` for `api.notion.com`; allow explicit override via request body / integration metadata.
- On provider token-exchange failure, return **502** with `error` / `error_description` / `providerStatus` instead of passthrough 401.
- Connect UI distinguishes real session 401 (`Unauthorized.`) from provider failures and surfaces `error_description`.

## Test plan

- [x] Unit: Notion-style Basic Auth + JSON exchange
- [x] Unit: confidential form-body exchange still works
- [x] Unit: provider 401 mapped to 502 (not session expiry)
- [x] Unit: connect-oauth messaging for provider failure vs session expiry
- [x] `npm run typecheck`
- [x] oxlint on touched files

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `0e95e1a8` · **Head:** `620a996d`

**Classification:** extends — outbound OAuth token exchange and integration config gain a `tokenExchangeStyle` contract; connect UI error handling for `/account/secrets.json` oauth_exchange changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — `/connect/oauth` exchange + failure messaging |
| `secrets` | assistant | extends — `oauth_exchange` Basic Auth/JSON styles; provider errors → 502 |
| `values` | assistant | extends — optional `tokenExchangeStyle` on integration config |

### System map

Connect OAuth token exchange now chooses form vs Notion-style Basic+JSON before calling the provider, and provider auth failures no longer look like Kody session expiry.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	secrets["secrets<br/>Secret references"]:::extended
	values["values<br/>Values"]:::extended
	appUi -->|"oauth_exchange + tokenExchangeStyle"| secrets
	secrets -->|"Basic Auth or form body"| providerToken["Provider token endpoint"]:::untouched
	appUi -->|"connect_oauth persists style"| values
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant UI as connect-oauth
	participant API as account-secrets oauth_exchange
	participant P as Provider token URL
	UI->>API: oauth_exchange (params, flow, style)
	API->>P: Basic+JSON or form body
	alt provider 401/4xx
		P-->>API: error JSON
		API-->>UI: 502 + error_description
		UI-->>UI: show provider error (not Session expired)
	else success
		P-->>API: tokens
		API-->>UI: 200 token payload
	end
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Notion exchange | form body + `client_secret` | Basic Auth + JSON body |
| Provider 401 | HTTP 401 to browser | HTTP 502 + provider details |
| Connect UI | "Session expired." | Provider `error_description` |

### Invariants

- Per-user isolation unchanged: secret resolution and integration saves remain scoped by `userId`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81de18be-70fd-4940-8aca-f73036d39f17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81de18be-70fd-4940-8aca-f73036d39f17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for OAuth providers using form-based or JSON-based token exchange.
  - Automatically selects the appropriate exchange format for supported providers, with saved configurations preserved.
  - Improved OAuth error handling to distinguish provider failures from actual session expiration.
  - Provider token-exchange failures now return clearer error details without incorrectly redirecting users to login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->