### PR TITLE
Reduce dynamic execute worker overhead: bundle cache, prelude gating, metadata trim

### DIFF
--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -153,6 +153,121 @@ test('kody remote proxy dispatches and reports connector/capability errors clear
 	)
 })
 
+test('generated kody provider source projects remote proxy metadata', () => {
+	const source = createKodyProviderProxySource({
+		providerName: 'kody',
+		remoteConnectors: [
+			{
+				name: 'home',
+				instanceId: 'home-instance',
+				status: {
+					state: 'connected',
+					connected: true,
+					toolCount: 1,
+					message: 'The connector "home" is connected.',
+					unavailableMessage: 'The connector "home" is connected.',
+				},
+				capabilities: [
+					{
+						name: 'set_pin',
+						dispatchName: 'remotehomeset_pin',
+					},
+				],
+			},
+		],
+		mcpServers: [
+			{
+				name: 'docs',
+				serverId: 'docs-server',
+				status: {
+					state: 'connected',
+					connected: true,
+					toolCount: 2,
+					message: 'The MCP server "docs" is connected.',
+					unavailableMessage: 'The MCP server "docs" is connected.',
+				},
+				capabilities: [
+					{
+						name: 'search',
+						dispatchName: 'mcpdocssearch',
+					},
+				],
+			},
+		],
+		openApiProviders: [
+			{
+				name: 'widgets',
+				bindingName: 'widgets-binding',
+				status: {
+					state: 'connected',
+					connected: true,
+					toolCount: 1,
+					message: 'The OpenAPI provider "widgets" is connected.',
+					unavailableMessage: 'The OpenAPI provider "widgets" is connected.',
+				},
+				capabilities: [
+					{
+						name: 'listwidgets',
+						dispatchName: 'openapiwidgetslistwidgets',
+					},
+				],
+			},
+		],
+	})
+
+	expect(source).not.toContain('"instanceId"')
+	expect(source).not.toContain('"serverId"')
+	expect(source).not.toContain('"bindingName"')
+	expect(source).not.toContain('"state":')
+	expect(source).not.toContain('"message":')
+	expect(source).toContain('"unavailableMessage":')
+	expect(source).toContain('"toolCount":')
+	expect(source).toContain('"dispatchName":"remotehomeset_pin"')
+	expect(source).toContain('"dispatchName":"mcpdocssearch"')
+	expect(source).toContain('"dispatchName":"openapiwidgetslistwidgets"')
+})
+
+test('generated kody provider source ignores volatile metadata fields for script identity', () => {
+	const baseConnectors = [
+		{
+			name: 'home',
+			instanceId: 'home-a',
+			status: {
+				state: 'connected',
+				connected: true,
+				toolCount: 1,
+				message: 'status prose A',
+				unavailableMessage: 'The connector "home" is connected.',
+			},
+			capabilities: [
+				{
+					name: 'set_pin',
+					dispatchName: 'remotehomeset_pin',
+				},
+			],
+		},
+	] as const
+	const first = createKodyProviderProxySource({
+		providerName: 'kody',
+		remoteConnectors: [...baseConnectors],
+	})
+	const second = createKodyProviderProxySource({
+		providerName: 'kody',
+		remoteConnectors: [
+			{
+				...baseConnectors[0],
+				instanceId: 'home-b',
+				status: {
+					...baseConnectors[0].status,
+					state: 'degraded',
+					message: 'status prose B — different volatile text',
+				},
+			},
+		],
+	})
+	expect(second).toBe(first)
+})
+
 test('generated kody provider source avoids bundle-scoped __name helpers', () => {
 	const source = createKodyProviderProxySource({
 		providerName: 'kody',

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -429,15 +429,51 @@ function createProviderProxySource(provider: ResolvedProvider) {
 		: `    const ${provider.name} = new Proxy({}, {\n      get: (_, toolName) => async (args) => {\n        const resJson = await __dispatchers.${provider.name}.call(String(toolName), JSON.stringify(args ?? {}));\n        const data = JSON.parse(resJson);\n        if (data.error) throw new Error(data.error);\n        return data.result;\n      }\n    });`
 }
 
+// Keep only fields the sandbox proxy reads so inlined executor scripts stay
+// smaller and volatile status prose does not churn the stable worker-ID hash.
+function projectKodyRemoteProxyMetadata(
+	entries: ReadonlyArray<{
+		name: string
+		status: {
+			connected: boolean
+			toolCount: number
+			unavailableMessage: string
+		}
+		capabilities: ReadonlyArray<{
+			name: string
+			dispatchName: string
+		}>
+	}>,
+) {
+	return entries.map((entry) => ({
+		name: entry.name,
+		status: {
+			connected: entry.status.connected,
+			toolCount: entry.status.toolCount,
+			unavailableMessage: entry.status.unavailableMessage,
+		},
+		capabilities: entry.capabilities.map((capability) => ({
+			name: capability.name,
+			dispatchName: capability.dispatchName,
+		})),
+	}))
+}
+
 export function createKodyProviderProxySource(input: {
 	providerName: string
 	remoteConnectors: Array<KodyRemoteConnectorMetadata>
 	mcpServers?: Array<KodyMcpServerMetadata>
 	openApiProviders?: Array<KodyOpenApiProviderMetadata>
 }) {
-	const metadataJson = JSON.stringify(input.remoteConnectors)
-	const mcpMetadataJson = JSON.stringify(input.mcpServers ?? [])
-	const openApiMetadataJson = JSON.stringify(input.openApiProviders ?? [])
+	const metadataJson = JSON.stringify(
+		projectKodyRemoteProxyMetadata(input.remoteConnectors),
+	)
+	const mcpMetadataJson = JSON.stringify(
+		projectKodyRemoteProxyMetadata(input.mcpServers ?? []),
+	)
+	const openApiMetadataJson = JSON.stringify(
+		projectKodyRemoteProxyMetadata(input.openApiProviders ?? []),
+	)
 	const source = `    const __kodyCreateRemoteProxy = ${kodyRemoteProxyFactorySource};
     const __kodyCallDispatcher = async (dispatchName, args) => {
       const resJson = await __dispatchers.${input.providerName}.call(dispatchName, JSON.stringify(args ?? {}));

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -2275,7 +2275,7 @@ test('runBundledModuleWithRegistry omits OAuth helper prelude when execute helpe
 		expect(wrappedSource).not.toContain('IntegrationHostNotAllowedError')
 		expect(wrappedSource).not.toContain('__kodyRefreshAccessToken')
 		expect(wrappedSource).toContain(
-			'typeof refreshAccessToken === \'undefined\' ? undefined : refreshAccessToken',
+			"typeof refreshAccessToken === 'undefined' ? undefined : refreshAccessToken",
 		)
 	} finally {
 		createExecuteExecutorSpy.mockRestore()

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -2235,3 +2235,150 @@ test('runBundledModuleWithRegistry records package_export usage for bundled runs
 		recordUsageSpy.mockRestore()
 	}
 })
+
+test('runBundledModuleWithRegistry omits OAuth helper prelude when execute helper capabilities are absent', async () => {
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+	})
+	const bundle = {
+		mainModule: 'entry.js',
+		modules: {
+			'entry.js': 'export default async () => "ok"',
+		},
+	}
+	let wrappedSource = ''
+	const createExecuteExecutorSpy = vi
+		.spyOn(await import('#mcp/executor.ts'), 'createExecuteExecutor')
+		.mockReturnValue({
+			async execute(wrapped) {
+				wrappedSource = String(wrapped)
+				return {
+					result: 'ok',
+					logs: [],
+				}
+			},
+		} as never)
+
+	try {
+		const result = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			bundle,
+			undefined,
+			{
+				skipCapabilityRegistry: true,
+			},
+		)
+		expect(result.result).toBe('ok')
+		expect(wrappedSource).not.toContain('IntegrationHostNotAllowedError')
+		expect(wrappedSource).not.toContain('__kodyRefreshAccessToken')
+		expect(wrappedSource).toContain(
+			'typeof refreshAccessToken === \'undefined\' ? undefined : refreshAccessToken',
+		)
+	} finally {
+		createExecuteExecutorSpy.mockRestore()
+	}
+})
+
+test('runBundledModuleWithRegistry injects OAuth helper prelude when execute helper capabilities are present', async () => {
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+	})
+	const bundle = {
+		mainModule: 'entry.js',
+		modules: {
+			'entry.js': 'export default async () => "ok"',
+		},
+	}
+	let wrappedSource = ''
+	const createExecuteExecutorSpy = vi
+		.spyOn(await import('#mcp/executor.ts'), 'createExecuteExecutor')
+		.mockReturnValue({
+			async execute(wrapped) {
+				wrappedSource = String(wrapped)
+				return {
+					result: 'ok',
+					logs: [],
+				}
+			},
+		} as never)
+
+	try {
+		const result = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			bundle,
+			undefined,
+			{
+				skipCapabilityRegistry: true,
+				additionalTools: {
+					integration_get: async () => ({}),
+					value_get: async () => ({}),
+					secret_set: async () => ({}),
+				},
+			},
+		)
+		expect(result.result).toBe('ok')
+		expect(wrappedSource).toContain('IntegrationHostNotAllowedError')
+		expect(wrappedSource).toContain('__kodyRefreshAccessToken')
+	} finally {
+		createExecuteExecutorSpy.mockRestore()
+	}
+})
+
+test('runKodyWithRegistry expression path omits OAuth helper prelude without execute helper capabilities', async () => {
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+	})
+	const emptyRegistry = {
+		capabilityDomains: [],
+		capabilityDomainDescriptionsByName: {} as Record<string, string>,
+		capabilityHandlers: {},
+		capabilityList: [],
+		capabilityMap: {},
+		capabilitySpecs: {},
+		capabilityToolDescriptors: {},
+	} as Awaited<ReturnType<typeof getCapabilityRegistryForContext>>
+	const getRegistrySpy = vi
+		.spyOn(
+			await import('#mcp/capabilities/registry.ts'),
+			'getCapabilityRegistryForContext',
+		)
+		.mockResolvedValue(emptyRegistry)
+	let wrappedSource = ''
+	const createExecuteExecutorSpy = vi
+		.spyOn(await import('#mcp/executor.ts'), 'createExecuteExecutor')
+		.mockReturnValue({
+			async execute(wrapped) {
+				wrappedSource = String(wrapped)
+				return {
+					result: 42,
+					logs: [],
+				}
+			},
+		} as never)
+
+	try {
+		const result = await runKodyWithRegistry(
+			env,
+			callerContext,
+			'async () => 42',
+			undefined,
+			{
+				capabilityRegistry: emptyRegistry,
+			},
+		)
+		expect(result.result).toBe(42)
+		expect(wrappedSource).not.toContain('IntegrationHostNotAllowedError')
+		expect(wrappedSource).not.toContain('__kodyRefreshAccessToken')
+	} finally {
+		createExecuteExecutorSpy.mockRestore()
+		getRegistrySpy.mockRestore()
+	}
+})

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -44,7 +44,10 @@ import {
 	type KodyResolvedProvider,
 } from '#mcp/kody-remote-types.ts'
 import { openApiProviderKodyName } from '#worker/openapi/openapi-domain-id.ts'
-import { createExecuteHelperPrelude } from '#mcp/execute-modules/kody-runtime-utils.ts'
+import {
+	createExecuteHelperPrelude,
+	getExecuteHelperCapabilityNames,
+} from '#mcp/execute-modules/kody-runtime-utils.ts'
 import {
 	hasTopLevelModuleSyntax,
 	stripCodeFences,
@@ -849,6 +852,10 @@ function createPackageEventRuntimeBridgeProvider(
 	return resolveProvider(provider)
 }
 
+function providerExposesExecuteHelperCapabilities(provider: ResolvedProvider) {
+	return getExecuteHelperCapabilityNames().every((name) => name in provider.fns)
+}
+
 function createCapabilityInputSecretResolver(
 	env: Env,
 	callerContext: McpCallerContext,
@@ -1018,8 +1025,13 @@ export async function runKodyWithRegistry(
 	]
 		.filter((value) => value.trim().length > 0)
 		.join('\n')
+	const executeHelperPrelude = providerExposesExecuteHelperCapabilities(
+		provider,
+	)
+		? createExecuteHelperPrelude()
+		: ''
 	const wrapped = `async () => {
-${createExecuteHelperPrelude()}
+${executeHelperPrelude ? `${executeHelperPrelude}\n` : ''}
 ${helperPrelude ? `${helperPrelude}\n` : ''}
   const __kodyUserCode = (${normalized});
   return await __kodyUserCode();
@@ -1246,11 +1258,16 @@ export async function runBundledModuleWithRegistry(
 		const eventsHelperPrelude = options?.packageEventTools
 			? createEventsHelperPrelude()
 			: ''
+		const executeHelperPrelude = providerExposesExecuteHelperCapabilities(
+			provider,
+		)
+			? createExecuteHelperPrelude()
+			: ''
 		const entrypointInputJson = JSON.stringify(params)
 		const entrypointInputSource =
 			entrypointInputJson === undefined ? 'undefined' : entrypointInputJson
 		const wrapped = `async () => {
-${createExecuteHelperPrelude()}
+${executeHelperPrelude ? `${executeHelperPrelude}\n` : ''}
 ${storageHelperPrelude ? `${storageHelperPrelude}\n` : ''}
 ${serviceHelperPrelude ? `${serviceHelperPrelude}\n` : ''}
 ${packageSecretsHelperPrelude ? `${packageSecretsHelperPrelude}\n` : ''}
@@ -1267,10 +1284,10 @@ ${eventsHelperPrelude ? `${eventsHelperPrelude}\n` : ''}
   const __kodyRuntime = {
     kody,
     storage: typeof storage === 'undefined' ? undefined : storage,
-    refreshAccessToken,
-    createAuthenticatedFetch,
-    secretHeaders,
-    oauthClientCredentials,
+    refreshAccessToken: typeof refreshAccessToken === 'undefined' ? undefined : refreshAccessToken,
+    createAuthenticatedFetch: typeof createAuthenticatedFetch === 'undefined' ? undefined : createAuthenticatedFetch,
+    secretHeaders: typeof secretHeaders === 'undefined' ? undefined : secretHeaders,
+    oauthClientCredentials: typeof oauthClientCredentials === 'undefined' ? undefined : oauthClientCredentials,
     packageContext: ${JSON.stringify(options?.packageContext ?? null)},
     serviceContext: ${JSON.stringify(options?.serviceContext ?? null)},
     service: typeof service === 'undefined' ? null : service,

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -1078,6 +1078,7 @@ export async function runModuleWithRegistry(
 			'entry.ts': code,
 		},
 		entryPoint: 'entry.ts',
+		reuseCachedBundle: true,
 	})
 	return runBundledModuleWithRegistry(
 		env,

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -43,6 +43,7 @@ vi.mock('./published-bundle-artifacts.ts', async () => {
 
 const {
 	buildKodyAppBundle,
+	buildKodyModuleBundle,
 	createPublishedPackageAppBundleCacheKey,
 	createRuntimeModuleSource,
 	hydrateKodyRuntimeModules,
@@ -91,6 +92,27 @@ function createBundleInput(input?: {
 		},
 		entryPoint: input?.entryPoint ?? 'app.js',
 		cacheKey: input?.cacheKey,
+	}
+}
+
+function createModuleBundleInput(input?: {
+	reuseCachedBundle?: boolean
+	userId?: string
+	code?: string
+}) {
+	return {
+		env: {
+			APP_DB: {},
+			REPO_SESSION: {},
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+		userId: input?.userId ?? 'user-1',
+		sourceFiles: {
+			'entry.ts':
+				input?.code ?? 'export default async function run() { return "ok" }',
+		},
+		entryPoint: 'entry.ts',
+		reuseCachedBundle: input?.reuseCachedBundle,
 	}
 }
 
@@ -474,6 +496,91 @@ test('buildKodyAppBundle cache lifecycle reuses hits, shares in-flight builds, e
 	)
 	expect(mockModule.createWorker).toHaveBeenCalledTimes(2)
 	expect(appBundle).not.toBe(adminBundle)
+})
+
+test('buildKodyModuleBundle cache lifecycle reuses hits, skips when disabled, keys by code and userId, and evicts failures', async () => {
+	mockModule.createWorker.mockReset()
+	mockModule.createWorker.mockResolvedValue(createBundleResult('module-warm'))
+
+	const first = await buildKodyModuleBundle(
+		createModuleBundleInput({ reuseCachedBundle: true }),
+	)
+	const second = await buildKodyModuleBundle(
+		createModuleBundleInput({ reuseCachedBundle: true }),
+	)
+	expect(mockModule.createWorker).toHaveBeenCalledTimes(1)
+	expect(first).toEqual(second)
+	expect(first.modules).not.toBe(second.modules)
+	expect(first.dependencies).not.toBe(second.dependencies)
+
+	mockModule.createWorker.mockReset()
+	mockModule.createWorker
+		.mockResolvedValueOnce(createBundleResult('module-uncached-first'))
+		.mockResolvedValueOnce(createBundleResult('module-uncached-second'))
+	await buildKodyModuleBundle(createModuleBundleInput())
+	await buildKodyModuleBundle(
+		createModuleBundleInput({ reuseCachedBundle: false }),
+	)
+	expect(mockModule.createWorker).toHaveBeenCalledTimes(2)
+
+	mockModule.createWorker.mockReset()
+	mockModule.createWorker
+		.mockResolvedValueOnce(createBundleResult('module-code-a'))
+		.mockResolvedValueOnce(createBundleResult('module-code-b'))
+	await buildKodyModuleBundle(
+		createModuleBundleInput({
+			reuseCachedBundle: true,
+			code: 'export default async function run() { return "a" }',
+		}),
+	)
+	await buildKodyModuleBundle(
+		createModuleBundleInput({
+			reuseCachedBundle: true,
+			code: 'export default async function run() { return "b" }',
+		}),
+	)
+	expect(mockModule.createWorker).toHaveBeenCalledTimes(2)
+
+	mockModule.createWorker.mockReset()
+	mockModule.createWorker
+		.mockResolvedValueOnce(createBundleResult('module-user-1'))
+		.mockResolvedValueOnce(createBundleResult('module-user-2'))
+	await buildKodyModuleBundle(
+		createModuleBundleInput({
+			reuseCachedBundle: true,
+			userId: 'user-cache-a',
+			code: 'export default async function run() { return "shared" }',
+		}),
+	)
+	await buildKodyModuleBundle(
+		createModuleBundleInput({
+			reuseCachedBundle: true,
+			userId: 'user-cache-b',
+			code: 'export default async function run() { return "shared" }',
+		}),
+	)
+	expect(mockModule.createWorker).toHaveBeenCalledTimes(2)
+
+	mockModule.createWorker.mockReset()
+	mockModule.createWorker
+		.mockRejectedValueOnce(new Error('module bundle failed'))
+		.mockResolvedValueOnce(createBundleResult('module-retry-success'))
+	await expect(
+		buildKodyModuleBundle(
+			createModuleBundleInput({
+				reuseCachedBundle: true,
+				code: 'export default async function run() { return "retry" }',
+			}),
+		),
+	).rejects.toThrow('module bundle failed')
+	const retried = await buildKodyModuleBundle(
+		createModuleBundleInput({
+			reuseCachedBundle: true,
+			code: 'export default async function run() { return "retry" }',
+		}),
+	)
+	expect(mockModule.createWorker).toHaveBeenCalledTimes(2)
+	expect(retried).toEqual(createBundleResult('module-retry-success'))
 })
 
 test('buildKodyModuleBundle resolves scoped package imports by full package name first', async () => {

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -1,3 +1,4 @@
+import { sha256Base64Url } from '@kody-internal/shared/sha256.ts'
 import {
 	loadPackageSourceBySourceId,
 	type LoadedPackageSource,
@@ -57,6 +58,7 @@ const dynamicPackageImportSpecifierExportName = '__kodyDynamicPackageSpecifier'
 const dynamicPackageImportResolvedMarker = '__kodyDynamicPackageResolved'
 const packageAppBundleCache =
 	createPublishedPackagePromiseCache<RuntimeBundle>()
+const moduleBundleCache = createPublishedPackagePromiseCache<RuntimeBundle>()
 let cachedRuntimeModuleSource: string | null = null
 
 async function createWorkerBundle(input: {
@@ -1485,12 +1487,54 @@ async function rewriteKodyImports(input: {
 	return helpers.length > 0 ? `${helpers.join('\n')}\n${rewritten}` : rewritten
 }
 
+function serializePreparedFilesRecord(files: Record<string, string>) {
+	const sortedKeys = Object.keys(files).sort()
+	const record: Record<string, string> = {}
+	for (const key of sortedKeys) {
+		const content = files[key]
+		if (content === undefined) continue
+		record[key] = content
+	}
+	return JSON.stringify(record)
+}
+
+async function createModuleBundleCacheKey(input: {
+	userId: string
+	entryPoint: string
+	files: Record<string, string>
+}) {
+	// Digest prepared files (not raw source) so package republishes that change
+	// rewritten graph contents invalidate the cache without a staleness window.
+	const filesDigest = await sha256Base64Url(
+		serializePreparedFilesRecord(input.files),
+	)
+	return JSON.stringify([
+		'module-bundle',
+		input.userId,
+		input.entryPoint,
+		filesDigest,
+	])
+}
+
+function cloneRuntimeBundle(bundle: RuntimeBundle): RuntimeBundle {
+	return {
+		mainModule: bundle.mainModule,
+		modules: { ...bundle.modules },
+		dependencies: [...bundle.dependencies],
+		...(bundle.dynamicDependencies
+			? { dynamicDependencies: [...bundle.dynamicDependencies] }
+			: {}),
+	}
+}
+
 export async function buildKodyModuleBundle(input: {
 	env: Env
 	baseUrl: string
 	userId: string
 	sourceFiles: Record<string, string>
 	entryPoint: string
+	// Opt-in: cache createWorkerBundle by prepared-files digest (see createModuleBundleCacheKey).
+	reuseCachedBundle?: boolean
 }) {
 	const { files, packages } = await prepareKodyGraphFiles({
 		env: input.env,
@@ -1512,30 +1556,48 @@ export async function buildKodyModuleBundle(input: {
 			normalizedEntrypoint,
 		),
 	})
-	const bundle = await createWorkerBundle({
-		files,
-		entryPoint: bootstrapPath,
-	})
-	const modules = {
-		...stripKodyRuntimeModules(bundle.modules as WorkerLoaderModules),
-		...collectDynamicPackageImportProxyModules(
+
+	const assembleBundle = async (): Promise<RuntimeBundle> => {
+		const bundle = await createWorkerBundle({
 			files,
-			bundle.modules as WorkerLoaderModules,
-		),
+			entryPoint: bootstrapPath,
+		})
+		const modules = {
+			...stripKodyRuntimeModules(bundle.modules as WorkerLoaderModules),
+			...collectDynamicPackageImportProxyModules(
+				files,
+				bundle.modules as WorkerLoaderModules,
+			),
+		}
+		assertBundleHasNoUnresolvedBareImports({
+			modules,
+			bundleLabel: `Saved package module "${normalizePackageWorkspacePath(input.entryPoint)}" bundle`,
+		})
+		return {
+			mainModule: bundle.mainModule,
+			modules,
+			dependencies: await resolveDirectKodyDependenciesForEntryPoint({
+				...input,
+				loadedPackages: packages,
+			}),
+			...includeDynamicDependenciesWhenPresent(modules),
+		}
 	}
-	assertBundleHasNoUnresolvedBareImports({
-		modules,
-		bundleLabel: `Saved package module "${normalizePackageWorkspacePath(input.entryPoint)}" bundle`,
+
+	if (!input.reuseCachedBundle) {
+		return await assembleBundle()
+	}
+
+	const cacheKey = await createModuleBundleCacheKey({
+		userId: input.userId,
+		entryPoint,
+		files,
 	})
-	return {
-		mainModule: bundle.mainModule,
-		modules,
-		dependencies: await resolveDirectKodyDependenciesForEntryPoint({
-			...input,
-			loadedPackages: packages,
-		}),
-		...includeDynamicDependenciesWhenPresent(modules),
-	}
+	const cached = await moduleBundleCache.getOrCreate({
+		cacheKey,
+		create: assembleBundle,
+	})
+	return cloneRuntimeBundle(cached)
 }
 
 export async function buildKodyImportableModuleBundle(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Three focused performance fixes for the dynamic execute worker pipeline:

1. **Cache ad-hoc execute module bundles** (`buildKodyModuleBundle` in `packages/worker/src/package-runtime/module-graph.ts`): new opt-in `reuseCachedBundle` flag, used only by `runModuleWithRegistry`. `prepareKodyGraphFiles` still runs every call (cheap, user-scoped, DB-backed); only the esbuild-wasm `createWorkerBundle` step + module assembly is cached in a `PromiseLruCache` (5 min TTL, limit 50). The cache key is `['module-bundle', userId, entryPoint, sha256(prepared files)]`, so package republishes or code changes invalidate automatically with no staleness window, and entries are user-scoped. Cached results are returned as shallow clones. Repo checks, publish, jobs, services, and invocations remain uncached.

2. **Gate the ~12 KB OAuth helper prelude on capability availability** (`packages/worker/src/mcp/run-kody-registry.ts`): `createExecuteHelperPrelude()` (defines `refreshAccessToken`, `createAuthenticatedFetch`, `secretHeaders`, `oauthClientCredentials`, host-allowlist checks) is now injected only when the resolved kody provider exposes `integration_get`, `value_get`, and `secret_set` — the capabilities those helpers require. When gated off (e.g. `skipCapabilityRegistry` or restricted registries) the helpers could only throw, so they were dead weight in the sandbox script. The bundled-path `__kodyRuntime` object now uses `typeof x === 'undefined'` guards for the four helper fields (same pattern as `storage`). The gate input (`provider.fns` keys) is deterministic per context, so stable worker-ID hashing is unaffected.

3. **Trim connector metadata inlined into `executor.js`** (`packages/worker/src/mcp/executor.ts`): `createKodyProviderProxySource` now projects remote-connector / MCP-server / OpenAPI metadata down to the fields the sandbox proxy actually reads (`name`, `status.connected`, `status.toolCount`, `status.unavailableMessage`, `capabilities[].{name,dispatchName}`). Dropped fields (`instanceId`, `serverId`, `bindingName`, `status.state`, `status.message`) both wasted script bytes and — because `executor.js` is hashed into the stable worker ID — caused isolate cache misses whenever volatile status prose changed even though the code was identical. A test now asserts that inputs differing only in dropped fields produce byte-identical executor source.

A fourth candidate (deduplicating the prelude vs `kody:runtime` exports in the bundled path) was investigated and intentionally skipped: the prelude *is* the implementation the runtime object closes over there, so there is no redundant copy to remove.

## Testing

- New unit tests: bundle-cache lifecycle (hit/miss/per-user/failure-eviction) in `module-graph.node.test.ts`, prelude gating on both wrapper paths in `run-kody-registry.node.test.ts`, metadata projection + byte-stability in `executor.node.test.ts`.
- Full `npm run validate` (format, lint, typecheck, unit, Playwright E2E, MCP E2E) run locally.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `0e95e1a8` · **Head:** `ee0d5d84`

**Classification:** extends — no new primitives; three existing runtime primitives change internal behavior (caching, conditional script injection, metadata projection) without altering their external contracts.

### Primitives touched

| Primitive              | Group    | Impact                                                                              |
| ---------------------- | -------- | ----------------------------------------------------------------------------------- |
| `package-runtime`      | runtime  | extends — `buildKodyModuleBundle` gains opt-in prepared-files-digest bundle cache    |
| `capabilities-execute` | runtime  | extends — OAuth helper prelude injected conditionally; `__kodyRuntime` typeof guards |
| `mcp-server`           | surfaces | extends — `executor.js` inlines projected (minimal, stable) connector metadata       |

### System map

Ad-hoc execute flows from the MCP endpoint through the execute runtime into the package runtime's bundler, which now short-circuits repeat builds via an in-memory cache.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::extended
	capabilitiesExecute["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	packageRuntime["package-runtime<br/>Package runtime"]:::extended
	capabilityRegistry["capability-registry<br/>Capability registry"]:::untouched
	mcpServer -->|"executor.js inlines projected connector metadata"| capabilitiesExecute
	capabilitiesExecute -->|"prelude gated on integration_get / value_get / secret_set"| capabilityRegistry
	capabilitiesExecute -->|"buildKodyModuleBundle(reuseCachedBundle: true)"| packageRuntime
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Per-user isolation: the new bundle cache key leads with `userId`, matching `createPublishedPackageCacheKey`; no cross-user bundle sharing.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a7196ad-d545-4a1d-a30f-af4dd7af10be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a7196ad-d545-4a1d-a30f-af4dd7af10be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

