### PR TITLE
feat(oauth): support confidential + PKCE token exchange for Canva Connect

### DIFF
--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -46,16 +46,38 @@ with `allowedHosts` when needed.
 
 ## Common optional parameters
 
-| Param                       | Purpose                                    |
-| --------------------------- | ------------------------------------------ |
-| `flow`                      | `pkce` (default) or `confidential`.        |
-| `scopes`                    | Space- or separator-separated scopes.      |
-| `scopeSeparator`            | Defaults to a single space.                |
-| `allowedHosts`              | Extra API hosts beyond the token host.     |
-| `apiBaseUrl`                | Optional API base URL hint.                |
-| `dashboardUrl`              | Provider settings link.                    |
-| `extraAuthorizeParams`      | Provider-specific authorize params.        |
-| `providerSetupInstructions` | Free-form setup hints shown in the wizard. |
+| Param                       | Purpose                                                                      |
+| --------------------------- | ---------------------------------------------------------------------------- |
+| `flow`                      | `pkce` (default) or `confidential`.                                          |
+| `pkce`                      | `true` or `false`; overrides the PKCE default (see below).                   |
+| `tokenExchangeStyle`        | `form` (default), `basic-json`, or `basic-form`; overrides the host default. |
+| `scopes`                    | Space- or separator-separated scopes.                                        |
+| `scopeSeparator`            | Defaults to a single space.                                                  |
+| `allowedHosts`              | Extra API hosts beyond the token host.                                       |
+| `apiBaseUrl`                | Optional API base URL hint.                                                  |
+| `dashboardUrl`              | Provider settings link.                                                      |
+| `extraAuthorizeParams`      | Provider-specific authorize params.                                          |
+| `providerSetupInstructions` | Free-form setup hints shown in the wizard.                                   |
+
+## PKCE and client secrets are orthogonal
+
+`flow` decides whether a client secret is collected and sent (`confidential`) or
+not (`pkce`). PKCE itself is a separate switch: it defaults to on for the `pkce`
+flow and off for `confidential`, and `pkce=true` enables S256 PKCE on top of a
+confidential flow for providers that require both.
+
+`tokenExchangeStyle` decides how confidential credentials reach the token
+endpoint: `form` puts `client_secret` in the urlencoded body (GitHub, Slack,
+Google), `basic-json` sends HTTP Basic with a JSON body (Notion), and
+`basic-form` sends HTTP Basic with an urlencoded body (Canva).
+
+Known host defaults (no extra params needed):
+
+- `api.notion.com`: `basic-json` token exchange.
+- `api.canva.com` (Canva Connect): `confidential` flow with S256 PKCE and
+  `basic-form` token exchange. Authorize URL is
+  `https://www.canva.com/api/oauth/authorize`, token URL is
+  `https://api.canva.com/rest/v1/oauth/token`.
 
 Client ID, access token, and refresh token names are derived from a normalized
 slug of `provider`.

--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -483,8 +483,8 @@ test('connect OAuth derives Canva confidential + PKCE basic-form defaults and ho
 	})
 })
 
-test('session config parsing backfills usePkce for configs persisted before the orthogonal-PKCE change', () => {
-	const legacyConfig = {
+test('session config parsing is strict: usePkce is required and stale shapes are rejected', () => {
+	const sessionConfig = {
 		provider: 'spotify',
 		providerKey: 'spotify',
 		authorizeHost: 'accounts.spotify.com',
@@ -494,6 +494,7 @@ test('session config parsing backfills usePkce for configs persisted before the 
 		apiBaseUrl: null,
 		scopes: [],
 		flow: 'pkce',
+		usePkce: true,
 		tokenExchangeStyle: 'form',
 		scopeSeparator: ' ',
 		extraAuthorizeParams: {},
@@ -506,41 +507,25 @@ test('session config parsing backfills usePkce for configs persisted before the 
 		allowedHosts: ['accounts.spotify.com'],
 	}
 
-	// Mid-flight configs without usePkce derive the flow default so callbacks
-	// keep working across the deploy boundary.
 	expect(
-		parseSessionConnectOauthConfig(JSON.stringify(legacyConfig)),
+		parseSessionConnectOauthConfig(JSON.stringify(sessionConfig)),
 	).toMatchObject({ provider: 'spotify', flow: 'pkce', usePkce: true })
-
 	expect(
 		parseSessionConnectOauthConfig(
 			JSON.stringify({
-				...legacyConfig,
-				provider: 'github',
+				...sessionConfig,
 				flow: 'confidential',
+				usePkce: false,
 			}),
 		),
 	).toMatchObject({ flow: 'confidential', usePkce: false })
 
-	// Canva host default enables PKCE even for legacy confidential configs.
+	// No back-compat: a snapshot without usePkce (persisted by pre-change code)
+	// is rejected and the user restarts the flow.
+	const { usePkce: _omitted, ...withoutUsePkce } = sessionConfig
 	expect(
-		parseSessionConnectOauthConfig(
-			JSON.stringify({
-				...legacyConfig,
-				provider: 'canva',
-				flow: 'confidential',
-				tokenHost: 'api.canva.com',
-				tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
-			}),
-		),
-	).toMatchObject({ flow: 'confidential', usePkce: true })
-
-	// An explicit persisted choice is respected as-is.
-	expect(
-		parseSessionConnectOauthConfig(
-			JSON.stringify({ ...legacyConfig, usePkce: false }),
-		),
-	).toMatchObject({ flow: 'pkce', usePkce: false })
+		parseSessionConnectOauthConfig(JSON.stringify(withoutUsePkce)),
+	).toBeNull()
 
 	expect(parseSessionConnectOauthConfig('not json')).toBeNull()
 	expect(
@@ -548,7 +533,7 @@ test('session config parsing backfills usePkce for configs persisted before the 
 	).toBeNull()
 	expect(
 		parseSessionConnectOauthConfig(
-			JSON.stringify({ ...legacyConfig, flow: 'implicit' }),
+			JSON.stringify({ ...sessionConfig, flow: 'implicit' }),
 		),
 	).toBeNull()
 })

--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -5,6 +5,7 @@ import {
 	getIntegrationValueCandidates,
 	isOAuthExchangeSessionExpired,
 	mergeConnectOauthConfig,
+	parseSessionConnectOauthConfig,
 	parseStoredIntegrationConfig,
 	summarizeStoredSetupState,
 } from './connect-oauth.tsx'
@@ -480,4 +481,74 @@ test('connect OAuth derives Canva confidential + PKCE basic-form defaults and ho
 		usePkce: true,
 		tokenExchangeStyle: 'basic-form',
 	})
+})
+
+test('session config parsing backfills usePkce for configs persisted before the orthogonal-PKCE change', () => {
+	const legacyConfig = {
+		provider: 'spotify',
+		providerKey: 'spotify',
+		authorizeHost: 'accounts.spotify.com',
+		tokenHost: 'accounts.spotify.com',
+		authorizeUrl: 'https://accounts.spotify.com/authorize',
+		tokenUrl: 'https://accounts.spotify.com/api/token',
+		apiBaseUrl: null,
+		scopes: [],
+		flow: 'pkce',
+		tokenExchangeStyle: 'form',
+		scopeSeparator: ' ',
+		extraAuthorizeParams: {},
+		providerSetupInstructions: null,
+		dashboardUrl: null,
+		clientIdValueName: 'spotify-client-id',
+		clientSecretSecretName: null,
+		accessTokenSecretName: 'spotifyAccessToken',
+		refreshTokenSecretName: 'spotifyRefreshToken',
+		allowedHosts: ['accounts.spotify.com'],
+	}
+
+	// Mid-flight configs without usePkce derive the flow default so callbacks
+	// keep working across the deploy boundary.
+	expect(
+		parseSessionConnectOauthConfig(JSON.stringify(legacyConfig)),
+	).toMatchObject({ provider: 'spotify', flow: 'pkce', usePkce: true })
+
+	expect(
+		parseSessionConnectOauthConfig(
+			JSON.stringify({
+				...legacyConfig,
+				provider: 'github',
+				flow: 'confidential',
+			}),
+		),
+	).toMatchObject({ flow: 'confidential', usePkce: false })
+
+	// Canva host default enables PKCE even for legacy confidential configs.
+	expect(
+		parseSessionConnectOauthConfig(
+			JSON.stringify({
+				...legacyConfig,
+				provider: 'canva',
+				flow: 'confidential',
+				tokenHost: 'api.canva.com',
+				tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+			}),
+		),
+	).toMatchObject({ flow: 'confidential', usePkce: true })
+
+	// An explicit persisted choice is respected as-is.
+	expect(
+		parseSessionConnectOauthConfig(
+			JSON.stringify({ ...legacyConfig, usePkce: false }),
+		),
+	).toMatchObject({ flow: 'pkce', usePkce: false })
+
+	expect(parseSessionConnectOauthConfig('not json')).toBeNull()
+	expect(
+		parseSessionConnectOauthConfig(JSON.stringify({ provider: 'x' })),
+	).toBeNull()
+	expect(
+		parseSessionConnectOauthConfig(
+			JSON.stringify({ ...legacyConfig, flow: 'implicit' }),
+		),
+	).toBeNull()
 })

--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -36,6 +36,7 @@ test('connect OAuth helpers parse stored integrations, merge reconnect configs, 
 		tokenUrl: 'https://github.com/login/oauth/access_token',
 		apiBaseUrl: 'https://api.github.com/',
 		flow: 'confidential',
+		usePkce: null,
 		clientIdValueName: 'github-client-id',
 		clientSecretSecretName: 'githubClientSecret',
 		accessTokenSecretName: 'githubAccessToken',
@@ -61,6 +62,8 @@ test('connect OAuth helpers parse stored integrations, merge reconnect configs, 
 			apiBaseUrl: null,
 			scopes: ['repo', 'read:user'],
 			flow: null,
+			usePkce: null,
+			tokenExchangeStyle: null,
 			scopeSeparator: ' ',
 			extraAuthorizeParams: { prompt: 'consent' },
 			providerSetupInstructions: 'Open the GitHub app settings.',
@@ -90,6 +93,7 @@ test('connect OAuth helpers parse stored integrations, merge reconnect configs, 
 		apiBaseUrl: 'https://api.github.com',
 		scopes: ['repo', 'read:user'],
 		flow: 'confidential',
+		usePkce: false,
 		tokenExchangeStyle: 'form',
 		scopeSeparator: ' ',
 		extraAuthorizeParams: { prompt: 'consent' },
@@ -111,6 +115,8 @@ test('connect OAuth helpers parse stored integrations, merge reconnect configs, 
 			apiBaseUrl: null,
 			scopes: null,
 			flow: null,
+			usePkce: null,
+			tokenExchangeStyle: null,
 			scopeSeparator: null,
 			extraAuthorizeParams: null,
 			providerSetupInstructions: null,
@@ -169,6 +175,8 @@ test('connect OAuth helpers parse stored integrations, merge reconnect configs, 
 			apiBaseUrl: null,
 			scopes: [],
 			flow: null,
+			usePkce: null,
+			tokenExchangeStyle: null,
 			scopeSeparator: null,
 			extraAuthorizeParams: {},
 			providerSetupInstructions: null,
@@ -215,6 +223,8 @@ test('connect OAuth helpers parse stored integrations, merge reconnect configs, 
 			apiBaseUrl: null,
 			scopes: [],
 			flow: 'pkce',
+			usePkce: null,
+			tokenExchangeStyle: null,
 			scopeSeparator: ' ',
 			extraAuthorizeParams: {},
 			providerSetupInstructions: null,
@@ -230,6 +240,7 @@ test('connect OAuth helpers parse stored integrations, merge reconnect configs, 
 		tokenHost: 'accounts.spotify.com',
 		tokenUrl: 'https://accounts.spotify.com/api/token',
 		flow: 'pkce',
+		usePkce: true,
 		tokenExchangeStyle: 'form',
 		clientIdValueName: 'spotify-client-id',
 		clientSecretSecretName: null,
@@ -265,6 +276,8 @@ test('connect OAuth derives Notion basic-json exchange and surfaces provider fai
 			apiBaseUrl: 'https://api.notion.com/v1',
 			scopes: [],
 			flow: 'confidential',
+			usePkce: null,
+			tokenExchangeStyle: null,
 			scopeSeparator: ' ',
 			extraAuthorizeParams: { owner: 'user', response_type: 'code' },
 			providerSetupInstructions: null,
@@ -278,6 +291,7 @@ test('connect OAuth derives Notion basic-json exchange and surfaces provider fai
 		provider: 'notion',
 		tokenUrl: 'https://api.notion.com/v1/oauth/token',
 		flow: 'confidential',
+		usePkce: false,
 		tokenExchangeStyle: 'basic-json',
 		clientSecretSecretName: 'notionClientSecret',
 		accessTokenSecretName: 'notionAccessToken',
@@ -345,4 +359,125 @@ test('connect OAuth derives Notion basic-json exchange and surfaces provider fai
 			},
 		}),
 	).toBe(false)
+})
+
+test('connect OAuth derives Canva confidential + PKCE basic-form defaults and honors explicit overrides', () => {
+	const canvaQueryConfig = {
+		provider: 'canva',
+		providerKey: 'canva',
+		authorizeHost: 'www.canva.com',
+		authorizeUrl: 'https://www.canva.com/api/oauth/authorize',
+		tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+		apiBaseUrl: 'https://api.canva.com/rest/v1',
+		scopes: ['design:content:read'],
+		flow: null,
+		usePkce: null,
+		tokenExchangeStyle: null,
+		scopeSeparator: ' ',
+		extraAuthorizeParams: {},
+		providerSetupInstructions: null,
+		dashboardUrl: null,
+		allowedHosts: ['api.canva.com'],
+	}
+
+	// Canva requires BOTH S256 PKCE and a client secret on token exchange, so
+	// the host defaults must combine a confidential flow with PKCE enabled.
+	const canvaConfig = mergeConnectOauthConfig({
+		queryConfig: canvaQueryConfig,
+		storedIntegration: null,
+	})
+	expect(canvaConfig).toMatchObject({
+		provider: 'canva',
+		tokenHost: 'api.canva.com',
+		flow: 'confidential',
+		usePkce: true,
+		tokenExchangeStyle: 'basic-form',
+		clientSecretSecretName: 'canvaClientSecret',
+		accessTokenSecretName: 'canvaAccessToken',
+	})
+
+	// Explicit query params still win over host defaults.
+	const overriddenConfig = mergeConnectOauthConfig({
+		queryConfig: {
+			...canvaQueryConfig,
+			usePkce: false,
+			tokenExchangeStyle: 'form',
+		},
+		storedIntegration: null,
+	})
+	expect(overriddenConfig).toMatchObject({
+		flow: 'confidential',
+		usePkce: false,
+		tokenExchangeStyle: 'form',
+	})
+
+	// PKCE can be enabled on top of a confidential flow for any provider.
+	const confidentialPkceConfig = mergeConnectOauthConfig({
+		queryConfig: {
+			...canvaQueryConfig,
+			provider: 'acme',
+			providerKey: 'acme',
+			authorizeHost: 'auth.acme.test',
+			authorizeUrl: 'https://auth.acme.test/oauth/authorize',
+			tokenUrl: 'https://auth.acme.test/oauth/token',
+			apiBaseUrl: null,
+			flow: 'confidential',
+			usePkce: true,
+			allowedHosts: ['auth.acme.test'],
+		},
+		storedIntegration: null,
+	})
+	expect(confidentialPkceConfig).toMatchObject({
+		flow: 'confidential',
+		usePkce: true,
+		tokenExchangeStyle: 'form',
+		clientSecretSecretName: 'acmeClientSecret',
+	})
+
+	// Reconnects read the persisted PKCE choice back from the stored config.
+	const storedCanva = parseStoredIntegrationConfig(
+		JSON.stringify({
+			name: 'canva',
+			tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+			apiBaseUrl: 'https://api.canva.com/rest/v1',
+			flow: 'confidential',
+			usePkce: true,
+			clientIdValueName: 'canva-client-id',
+			clientSecretSecretName: 'canvaClientSecret',
+			accessTokenSecretName: 'canvaAccessToken',
+			refreshTokenSecretName: 'canvaRefreshToken',
+			requiredHosts: ['api.canva.com'],
+			tokenExchangeStyle: 'basic-form',
+			authorization: {
+				authorizeUrl: 'https://www.canva.com/api/oauth/authorize',
+				scopes: ['design:content:read'],
+				scopeSeparator: null,
+				extraAuthorizeParams: {},
+			},
+		}),
+		null,
+	)
+	expect(storedCanva?.usePkce).toBe(true)
+	expect(storedCanva?.tokenExchangeStyle).toBe('basic-form')
+
+	const reconnectConfig = mergeConnectOauthConfig({
+		queryConfig: {
+			...canvaQueryConfig,
+			authorizeHost: null,
+			authorizeUrl: null,
+			tokenUrl: null,
+			apiBaseUrl: null,
+			scopes: null,
+			allowedHosts: [],
+		},
+		storedIntegration: storedCanva,
+	})
+	expect(reconnectConfig).toMatchObject({
+		provider: 'canva',
+		authorizeUrl: 'https://www.canva.com/api/oauth/authorize',
+		tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+		flow: 'confidential',
+		usePkce: true,
+		tokenExchangeStyle: 'basic-form',
+	})
 })

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -38,7 +38,7 @@ import {
 } from '#client/styles/style-primitives.ts'
 
 type OAuthFlow = 'pkce' | 'confidential'
-type TokenExchangeStyle = 'form' | 'basic-json'
+type TokenExchangeStyle = 'form' | 'basic-json' | 'basic-form'
 
 type ConnectOauthQueryConfig = {
 	provider: string
@@ -49,6 +49,8 @@ type ConnectOauthQueryConfig = {
 	apiBaseUrl: string | null
 	scopes: Array<string> | null
 	flow: OAuthFlow | null
+	usePkce: boolean | null
+	tokenExchangeStyle: TokenExchangeStyle | null
 	scopeSeparator: string | null
 	extraAuthorizeParams: Record<string, string> | null
 	providerSetupInstructions: string | null
@@ -66,6 +68,11 @@ type ConnectOauthConfig = {
 	apiBaseUrl: string | null
 	scopes: Array<string>
 	flow: OAuthFlow
+	/**
+	 * PKCE is orthogonal to `flow`: providers like Canva require S256 PKCE
+	 * *and* a client secret on token exchange.
+	 */
+	usePkce: boolean
 	tokenExchangeStyle: TokenExchangeStyle
 	scopeSeparator: string
 	extraAuthorizeParams: Record<string, string>
@@ -83,6 +90,7 @@ type StoredIntegrationConfig = {
 	tokenUrl: string
 	apiBaseUrl: string | null
 	flow: OAuthFlow
+	usePkce?: boolean | null
 	clientIdValueName: string
 	clientSecretSecretName: string | null
 	accessTokenSecretName: string
@@ -231,8 +239,13 @@ export function ConnectOauthRoute(handle: Handle) {
 			setStatus('Token URL must be valid when provided.', 'error')
 			return null
 		}
-		let flow = (readOptional('flow') ?? 'pkce').toLowerCase()
-		if (flow !== 'pkce' && flow !== 'confidential') flow = 'pkce'
+		const rawFlow = readOptional('flow')?.toLowerCase() ?? null
+		const flow: OAuthFlow | null =
+			rawFlow === 'pkce' || rawFlow === 'confidential' ? rawFlow : null
+		const usePkce = parseOptionalBoolean(readOptional('pkce'))
+		const tokenExchangeStyle = parseTokenExchangeStyle(
+			readOptional('tokenExchangeStyle'),
+		)
 		const rawScopes = readOptional('scopes')
 		const scopes = rawScopes == null ? null : parseScopes(rawScopes)
 		const scopeSeparator = readOptional('scopeSeparator')
@@ -263,7 +276,9 @@ export function ConnectOauthRoute(handle: Handle) {
 			tokenUrl,
 			apiBaseUrl,
 			scopes,
-			flow: flow as OAuthFlow,
+			flow,
+			usePkce,
+			tokenExchangeStyle,
 			scopeSeparator,
 			extraAuthorizeParams,
 			providerSetupInstructions,
@@ -310,6 +325,7 @@ export function ConnectOauthRoute(handle: Handle) {
 			typeof record.authorizeHost === 'string' &&
 			typeof record.tokenHost === 'string' &&
 			typeof record.flow === 'string' &&
+			typeof record.usePkce === 'boolean' &&
 			typeof record.scopeSeparator === 'string' &&
 			typeof record.clientIdValueName === 'string' &&
 			typeof record.accessTokenSecretName === 'string' &&
@@ -380,7 +396,7 @@ export function ConnectOauthRoute(handle: Handle) {
 		}
 		const state = createState(getStateKey(nextConfig.providerKey))
 		url.searchParams.set('state', state)
-		if (nextConfig.flow === 'pkce') {
+		if (nextConfig.usePkce) {
 			const verifier = createCodeVerifier()
 			sessionStorage.setItem(getPkceKey(nextConfig.providerKey), verifier)
 			const challenge = await createCodeChallenge(verifier)
@@ -583,7 +599,7 @@ export function ConnectOauthRoute(handle: Handle) {
 		params.set('client_id', clientId)
 		params.set('code', code)
 		params.set('redirect_uri', getRedirectUri())
-		if (nextConfig.flow === 'pkce') {
+		if (nextConfig.usePkce) {
 			const verifier = sessionStorage.getItem(
 				getPkceKey(nextConfig.providerKey),
 			)
@@ -756,6 +772,7 @@ export function ConnectOauthRoute(handle: Handle) {
 				scopeSeparator: config.scopeSeparator,
 				extraAuthorizeParams: config.extraAuthorizeParams,
 				flow: config.flow,
+				usePkce: config.usePkce,
 				tokenExchangeStyle: config.tokenExchangeStyle,
 				clientIdValueName: config.clientIdValueName,
 				clientSecretSecretName: config.clientSecretSecretName,
@@ -1010,6 +1027,12 @@ export function ConnectOauthRoute(handle: Handle) {
 						<div mix={css(detailItemCss)}>
 							<span mix={css(detailLabelCss)}>Flow</span>
 							<span mix={css(detailValueCss)}>{config.flow}</span>
+						</div>
+						<div mix={css(detailItemCss)}>
+							<span mix={css(detailLabelCss)}>PKCE</span>
+							<span mix={css(detailValueCss)}>
+								{config.usePkce ? 'S256' : 'off'}
+							</span>
 						</div>
 						<div mix={css(detailItemCss)}>
 							<span mix={css(detailLabelCss)}>Scopes</span>
@@ -1290,6 +1313,7 @@ export function parseStoredIntegrationConfig(
 		const tokenUrl =
 			typeof parsed.tokenUrl === 'string' ? parsed.tokenUrl.trim() : ''
 		const flow = parsed.flow === 'confidential' ? 'confidential' : 'pkce'
+		const usePkce = typeof parsed.usePkce === 'boolean' ? parsed.usePkce : null
 		const clientIdValueName =
 			typeof parsed.clientIdValueName === 'string'
 				? parsed.clientIdValueName.trim()
@@ -1330,6 +1354,7 @@ export function parseStoredIntegrationConfig(
 					? parsed.apiBaseUrl.trim()
 					: null,
 			flow,
+			usePkce,
 			clientIdValueName,
 			clientSecretSecretName,
 			accessTokenSecretName,
@@ -1414,7 +1439,14 @@ export function mergeConnectOauthConfig(input: {
 	) {
 		return null
 	}
-	const flow = input.storedIntegration?.flow ?? input.queryConfig.flow ?? 'pkce'
+	const flow =
+		input.storedIntegration?.flow ??
+		input.queryConfig.flow ??
+		defaultConnectOauthFlow(tokenUrl)
+	const usePkce =
+		input.queryConfig.usePkce ??
+		input.storedIntegration?.usePkce ??
+		defaultConnectOauthUsePkce({ flow, tokenUrl })
 	const scopes = resolveConnectOauthScopes(input)
 	const extraAuthorizeParams = resolveConnectOauthExtraAuthorizeParams(input)
 	const allowedHosts = normalizeHosts([
@@ -1434,8 +1466,10 @@ export function mergeConnectOauthConfig(input: {
 			input.storedIntegration?.apiBaseUrl ?? input.queryConfig.apiBaseUrl,
 		scopes,
 		flow,
+		usePkce,
 		tokenExchangeStyle: resolveConnectOauthTokenExchangeStyle({
 			tokenUrl,
+			queryStyle: input.queryConfig.tokenExchangeStyle,
 			storedStyle: input.storedIntegration?.tokenExchangeStyle ?? null,
 		}),
 		scopeSeparator:
@@ -1550,16 +1584,45 @@ function hasProviderOAuthExchangeError(data: Record<string, unknown> | null) {
 
 function resolveConnectOauthTokenExchangeStyle(input: {
 	tokenUrl: string
+	queryStyle: TokenExchangeStyle | null
 	storedStyle: TokenExchangeStyle | null
 }): TokenExchangeStyle {
+	if (input.queryStyle) return input.queryStyle
 	if (input.storedStyle) return input.storedStyle
 	const host = safeParseHost(input.tokenUrl)
 	if (host === 'api.notion.com') return 'basic-json'
+	if (host === 'api.canva.com') return 'basic-form'
 	return 'form'
 }
 
+/**
+ * Hosts that require a confidential client even though the default flow is
+ * PKCE-only. Canva requires both S256 PKCE and a client secret.
+ */
+function defaultConnectOauthFlow(tokenUrl: string): OAuthFlow {
+	return safeParseHost(tokenUrl) === 'api.canva.com' ? 'confidential' : 'pkce'
+}
+
+function defaultConnectOauthUsePkce(input: {
+	flow: OAuthFlow
+	tokenUrl: string
+}): boolean {
+	if (input.flow === 'pkce') return true
+	return safeParseHost(input.tokenUrl) === 'api.canva.com'
+}
+
 function parseTokenExchangeStyle(raw: unknown): TokenExchangeStyle | null {
-	return raw === 'form' || raw === 'basic-json' ? raw : null
+	return raw === 'form' || raw === 'basic-json' || raw === 'basic-form'
+		? raw
+		: null
+}
+
+function parseOptionalBoolean(raw: string | null): boolean | null {
+	if (raw == null) return null
+	const normalized = raw.trim().toLowerCase()
+	if (normalized === 'true' || normalized === '1') return true
+	if (normalized === 'false' || normalized === '0') return false
+	return null
 }
 
 function formatMissingSetupFields(missingFields: Array<string>) {
@@ -1676,7 +1739,10 @@ const pageCss = {
 
 const headerCss = pageHeaderCss
 const eyebrowCss = pageEyebrowCss
-const primaryButtonCss = getPrimaryButtonCss({ size: 'lg', weight: 'semibold' })
+const primaryButtonCss = getPrimaryButtonCss({
+	size: 'lg',
+	weight: 'semibold',
+})
 const secondaryButtonCss = getSecondaryButtonCss({
 	size: 'lg',
 	weight: 'semibold',

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -312,30 +312,6 @@ export function ConnectOauthRoute(handle: Handle) {
 
 	const configStorageKey = 'connect-oauth:config'
 
-	const isConnectOauthConfig = (
-		value: unknown,
-	): value is ConnectOauthConfig => {
-		if (!value || typeof value !== 'object') return false
-		const record = value as Record<string, unknown>
-		return (
-			typeof record.provider === 'string' &&
-			typeof record.providerKey === 'string' &&
-			typeof record.authorizeUrl === 'string' &&
-			typeof record.tokenUrl === 'string' &&
-			typeof record.authorizeHost === 'string' &&
-			typeof record.tokenHost === 'string' &&
-			typeof record.flow === 'string' &&
-			typeof record.usePkce === 'boolean' &&
-			typeof record.scopeSeparator === 'string' &&
-			typeof record.clientIdValueName === 'string' &&
-			typeof record.accessTokenSecretName === 'string' &&
-			Array.isArray(record.scopes) &&
-			Array.isArray(record.allowedHosts) &&
-			record.scopes.every((value) => typeof value === 'string') &&
-			record.allowedHosts.every((value) => typeof value === 'string')
-		)
-	}
-
 	const persistConfig = (nextConfig: ConnectOauthConfig) => {
 		try {
 			sessionStorage.setItem(configStorageKey, JSON.stringify(nextConfig))
@@ -346,12 +322,7 @@ export function ConnectOauthRoute(handle: Handle) {
 		if (typeof window === 'undefined') return null
 		const raw = sessionStorage.getItem(configStorageKey)
 		if (!raw) return null
-		try {
-			const parsed = JSON.parse(raw)
-			return isConnectOauthConfig(parsed) ? parsed : null
-		} catch {
-			return null
-		}
+		return parseSessionConnectOauthConfig(raw)
 	}
 
 	const createState = (key: string) => {
@@ -1515,6 +1486,49 @@ function resolveConnectOauthExtraAuthorizeParams(input: {
 		return queryParams
 	}
 	return input.storedIntegration?.authorization?.extraAuthorizeParams ?? {}
+}
+
+/**
+ * Parses the sessionStorage config persisted before redirecting to the
+ * provider. Configs written before the orthogonal-PKCE change lack `usePkce`,
+ * and the callback leg cannot rebuild settings from the URL alone, so backfill
+ * the flow/host default instead of rejecting mid-flight connects.
+ */
+export function parseSessionConnectOauthConfig(
+	raw: string,
+): ConnectOauthConfig | null {
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(raw)
+	} catch {
+		return null
+	}
+	if (!parsed || typeof parsed !== 'object') return null
+	const record = parsed as Record<string, unknown>
+	const isValid =
+		typeof record.provider === 'string' &&
+		typeof record.providerKey === 'string' &&
+		typeof record.authorizeUrl === 'string' &&
+		typeof record.tokenUrl === 'string' &&
+		typeof record.authorizeHost === 'string' &&
+		typeof record.tokenHost === 'string' &&
+		(record.flow === 'pkce' || record.flow === 'confidential') &&
+		typeof record.scopeSeparator === 'string' &&
+		typeof record.clientIdValueName === 'string' &&
+		typeof record.accessTokenSecretName === 'string' &&
+		Array.isArray(record.scopes) &&
+		Array.isArray(record.allowedHosts) &&
+		record.scopes.every((value) => typeof value === 'string') &&
+		record.allowedHosts.every((value) => typeof value === 'string')
+	if (!isValid) return null
+	const config = record as unknown as ConnectOauthConfig
+	if (typeof record.usePkce !== 'boolean') {
+		config.usePkce = defaultConnectOauthUsePkce({
+			flow: config.flow,
+			tokenUrl: config.tokenUrl,
+		})
+	}
+	return config
 }
 
 export function summarizeStoredSetupState(input: {

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -1490,9 +1490,10 @@ function resolveConnectOauthExtraAuthorizeParams(input: {
 
 /**
  * Parses the sessionStorage config persisted before redirecting to the
- * provider. Configs written before the orthogonal-PKCE change lack `usePkce`,
- * and the callback leg cannot rebuild settings from the URL alone, so backfill
- * the flow/host default instead of rejecting mid-flight connects.
+ * provider. Validation is deliberately strict with no back-compat for older
+ * shapes: the snapshot lives for a single authorize round trip, so a stale
+ * shape can only exist for a flow in-flight across a deploy, and the recovery
+ * is simply restarting the connect flow from its URL.
  */
 export function parseSessionConnectOauthConfig(
 	raw: string,
@@ -1513,6 +1514,7 @@ export function parseSessionConnectOauthConfig(
 		typeof record.authorizeHost === 'string' &&
 		typeof record.tokenHost === 'string' &&
 		(record.flow === 'pkce' || record.flow === 'confidential') &&
+		typeof record.usePkce === 'boolean' &&
 		typeof record.scopeSeparator === 'string' &&
 		typeof record.clientIdValueName === 'string' &&
 		typeof record.accessTokenSecretName === 'string' &&
@@ -1521,14 +1523,7 @@ export function parseSessionConnectOauthConfig(
 		record.scopes.every((value) => typeof value === 'string') &&
 		record.allowedHosts.every((value) => typeof value === 'string')
 	if (!isValid) return null
-	const config = record as unknown as ConnectOauthConfig
-	if (typeof record.usePkce !== 'boolean') {
-		config.usePkce = defaultConnectOauthUsePkce({
-			flow: config.flow,
-			tokenUrl: config.tokenUrl,
-		})
-	}
-	return config
+	return record as unknown as ConnectOauthConfig
 }
 
 export function summarizeStoredSetupState(input: {

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -871,3 +871,136 @@ test('oauth_exchange supports Notion basic-json and confidential form-body style
 
 	vi.unstubAllGlobals()
 })
+
+test('oauth_exchange supports Canva basic-form with PKCE code_verifier and a client secret together', async () => {
+	const fetchMock = vi.fn()
+	vi.stubGlobal('fetch', fetchMock)
+	const handler = createAccountSecretsApiHandler(createEnv())
+
+	mockModule.resolveSecret.mockResolvedValueOnce({
+		found: true,
+		value: 'canva-client-secret',
+	})
+	fetchMock.mockResolvedValueOnce(
+		new Response(
+			JSON.stringify({
+				access_token: 'canva-access',
+				refresh_token: 'canva-refresh',
+			}),
+			{ status: 200, headers: { 'Content-Type': 'application/json' } },
+		),
+	)
+
+	const canvaSuccess = await handler.handler({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'oauth_exchange',
+				tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+				params: new URLSearchParams({
+					grant_type: 'authorization_code',
+					client_id: 'canva-client-id',
+					code: 'canva-code',
+					redirect_uri: 'https://example.com/connect/oauth',
+					code_verifier: 'pkce-verifier',
+				}).toString(),
+				flow: 'confidential',
+				clientSecretSecretName: 'canvaClientSecret',
+				allowedHosts: ['api.canva.com'],
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(canvaSuccess.status).toBe(200)
+	await expect(canvaSuccess.json()).resolves.toMatchObject({
+		access_token: 'canva-access',
+		refresh_token: 'canva-refresh',
+	})
+	expect(fetchMock).toHaveBeenCalledTimes(1)
+	expect(fetchMock.mock.calls[0]?.[0]).toBe(
+		'https://api.canva.com/rest/v1/oauth/token',
+	)
+	const canvaRequest = fetchMock.mock.calls[0]?.[1] as RequestInit
+	expect(canvaRequest.method).toBe('POST')
+	expect(canvaRequest.headers).toMatchObject({
+		Accept: 'application/json',
+		'Content-Type': 'application/x-www-form-urlencoded',
+		Authorization: `Basic ${btoa('canva-client-id:canva-client-secret')}`,
+	})
+	const canvaBody = new URLSearchParams(String(canvaRequest.body))
+	expect(canvaBody.get('grant_type')).toBe('authorization_code')
+	expect(canvaBody.get('code')).toBe('canva-code')
+	expect(canvaBody.get('code_verifier')).toBe('pkce-verifier')
+	expect(canvaBody.get('client_id')).toBeNull()
+	expect(canvaBody.get('client_secret')).toBeNull()
+
+	vi.unstubAllGlobals()
+})
+
+test('connect oauth persists usePkce for confidential + PKCE providers like Canva', async () => {
+	mockModule.saveValue.mockClear()
+	const handler = createAccountSecretsApiHandler(createEnv())
+
+	const canvaResponse = await handler.handler({
+		request: new Request('https://example.com/account/secrets.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'connect_oauth',
+				provider: 'canva',
+				authorizeUrl: 'https://www.canva.com/api/oauth/authorize',
+				tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+				apiBaseUrl: 'https://api.canva.com/rest/v1',
+				scopes: ['design:content:read'],
+				scopeSeparator: ' ',
+				flow: 'confidential',
+				usePkce: true,
+				tokenExchangeStyle: 'basic-form',
+				clientIdValueName: 'canva-client-id',
+				clientSecretSecretName: 'canvaClientSecret',
+				accessTokenSecretName: 'canvaAccessToken',
+				refreshTokenSecretName: 'canvaRefreshToken',
+				allowedHosts: ['api.canva.com'],
+				tokenPayload: {
+					access_token: 'access-token',
+					refresh_token: 'refresh-token',
+				},
+			}),
+		}),
+		params: {},
+	} as never)
+
+	expect(canvaResponse.status).toBe(200)
+	await expect(canvaResponse.json()).resolves.toMatchObject({
+		ok: true,
+		accessTokenSaved: true,
+		refreshTokenSaved: true,
+		integrationName: 'canva',
+	})
+	expect(mockModule.saveValue).toHaveBeenCalledWith(
+		expect.objectContaining({
+			name: '_integration:canva',
+			value: JSON.stringify({
+				name: 'canva',
+				tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+				apiBaseUrl: 'https://api.canva.com/rest/v1',
+				flow: 'confidential',
+				usePkce: true,
+				clientIdValueName: 'canva-client-id',
+				clientSecretSecretName: 'canvaClientSecret',
+				accessTokenSecretName: 'canvaAccessToken',
+				refreshTokenSecretName: 'canvaRefreshToken',
+				requiredHosts: ['api.canva.com'],
+				tokenExchangeStyle: 'basic-form',
+				authorization: {
+					authorizeUrl: 'https://www.canva.com/api/oauth/authorize',
+					scopes: ['design:content:read'],
+					scopeSeparator: null,
+					extraAuthorizeParams: {},
+				},
+			}),
+		}),
+	)
+})

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -247,6 +247,7 @@ async function handleConnectOauthAction(input: {
 	const apiBaseUrl = readOptionalString(input.body, 'apiBaseUrl')
 	const authorizeUrl = readOptionalString(input.body, 'authorizeUrl')
 	const flow = readOptionalString(input.body, 'flow')
+	const usePkce = readOptionalBoolean(input.body, 'usePkce')
 	const clientIdValueName = readOptionalString(input.body, 'clientIdValueName')
 	const clientSecretSecretName = readOptionalString(
 		input.body,
@@ -359,6 +360,7 @@ async function handleConnectOauthAction(input: {
 		tokenUrl,
 		apiBaseUrl,
 		flow: flow === 'confidential' ? 'confidential' : 'pkce',
+		usePkce,
 		clientIdValueName,
 		clientSecretSecretName,
 		accessTokenSecretName,
@@ -601,6 +603,7 @@ async function saveIntegrationConfig(input: {
 	tokenUrl: string
 	apiBaseUrl: string | null
 	flow: 'pkce' | 'confidential'
+	usePkce: boolean | null
 	clientIdValueName: string
 	clientSecretSecretName: string | null
 	accessTokenSecretName: string
@@ -625,6 +628,7 @@ async function saveIntegrationConfig(input: {
 			tokenUrl: input.tokenUrl,
 			apiBaseUrl: input.apiBaseUrl,
 			flow: input.flow,
+			...(input.usePkce == null ? {} : { usePkce: input.usePkce }),
 			clientIdValueName: input.clientIdValueName,
 			clientSecretSecretName:
 				input.flow === 'confidential'
@@ -995,6 +999,11 @@ function readString(body: object, key: string) {
 function readOptionalString(body: object, key: string) {
 	const value = (body as Record<string, unknown>)[key]
 	return typeof value === 'string' ? value.trim() : null
+}
+
+function readOptionalBoolean(body: object, key: string) {
+	const value = (body as Record<string, unknown>)[key]
+	return typeof value === 'boolean' ? value : null
 }
 
 function readRawOptionalString(body: object, key: string) {

--- a/packages/worker/src/app/oauth-token-exchange.node.test.ts
+++ b/packages/worker/src/app/oauth-token-exchange.node.test.ts
@@ -65,6 +65,24 @@ test('token exchange style resolves Notion basic-json and builds both request sh
 		'client-secret',
 	)
 
+	const formPkceConfidentialRequest = buildOAuthTokenExchangeRequest({
+		params: new URLSearchParams({
+			grant_type: 'authorization_code',
+			client_id: 'client-id',
+			code: 'code',
+			redirect_uri: 'https://example.com/connect/oauth',
+			code_verifier: 'pkce-verifier',
+		}),
+		flow: 'confidential',
+		clientSecret: 'client-secret',
+		style: 'form',
+	})
+	const formPkceConfidentialBody = new URLSearchParams(
+		formPkceConfidentialRequest.body,
+	)
+	expect(formPkceConfidentialBody.get('client_secret')).toBe('client-secret')
+	expect(formPkceConfidentialBody.get('code_verifier')).toBe('pkce-verifier')
+
 	expect(oauthTokenExchangeFailureHttpStatus()).toBe(502)
 	expect(
 		buildOAuthTokenExchangeFailurePayload({
@@ -80,4 +98,68 @@ test('token exchange style resolves Notion basic-json and builds both request sh
 		error_description: 'Client authentication failed',
 		providerStatus: 401,
 	})
+})
+
+test('token exchange style resolves Canva basic-form and keeps PKCE code_verifier alongside Basic client auth', () => {
+	expect(
+		resolveTokenExchangeStyle({
+			tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+		}),
+	).toBe('basic-form')
+	expect(
+		resolveTokenExchangeStyle({
+			tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+			tokenExchangeStyle: 'form',
+		}),
+	).toBe('form')
+
+	const canvaRequest = buildOAuthTokenExchangeRequest({
+		params: new URLSearchParams({
+			grant_type: 'authorization_code',
+			client_id: 'canva-client-id',
+			code: 'canva-code',
+			redirect_uri: 'https://example.com/connect/oauth',
+			code_verifier: 'pkce-verifier',
+		}),
+		flow: 'confidential',
+		clientSecret: 'canva-client-secret',
+		style: 'basic-form',
+	})
+	expect(canvaRequest.headers).toEqual({
+		Accept: 'application/json',
+		'Content-Type': 'application/x-www-form-urlencoded',
+		Authorization: `Basic ${btoa('canva-client-id:canva-client-secret')}`,
+	})
+	const canvaBody = new URLSearchParams(canvaRequest.body)
+	expect(canvaBody.get('grant_type')).toBe('authorization_code')
+	expect(canvaBody.get('code')).toBe('canva-code')
+	expect(canvaBody.get('code_verifier')).toBe('pkce-verifier')
+	expect(canvaBody.get('client_id')).toBeNull()
+	expect(canvaBody.get('client_secret')).toBeNull()
+
+	expect(() =>
+		buildOAuthTokenExchangeRequest({
+			params: new URLSearchParams({
+				grant_type: 'authorization_code',
+				client_id: 'canva-client-id',
+				code: 'canva-code',
+			}),
+			flow: 'pkce',
+			clientSecret: null,
+			style: 'basic-form',
+		}),
+	).toThrow(
+		'basic-form token exchange requires confidential flow with a client secret.',
+	)
+	expect(() =>
+		buildOAuthTokenExchangeRequest({
+			params: new URLSearchParams({
+				grant_type: 'authorization_code',
+				code: 'canva-code',
+			}),
+			flow: 'confidential',
+			clientSecret: 'canva-client-secret',
+			style: 'basic-form',
+		}),
+	).toThrow('basic-form token exchange requires client_id in params.')
 })

--- a/packages/worker/src/app/oauth-token-exchange.node.test.ts
+++ b/packages/worker/src/app/oauth-token-exchange.node.test.ts
@@ -117,6 +117,7 @@ test('token exchange style resolves Canva basic-form and keeps PKCE code_verifie
 		params: new URLSearchParams({
 			grant_type: 'authorization_code',
 			client_id: 'canva-client-id',
+			client_secret: 'stale-body-secret',
 			code: 'canva-code',
 			redirect_uri: 'https://example.com/connect/oauth',
 			code_verifier: 'pkce-verifier',
@@ -137,6 +138,24 @@ test('token exchange style resolves Canva basic-form and keeps PKCE code_verifie
 	expect(canvaBody.get('client_id')).toBeNull()
 	expect(canvaBody.get('client_secret')).toBeNull()
 
+	// Basic-auth credentials are form-urlencoded per RFC 6749 §2.3.1, so
+	// reserved characters like ":" and "%" survive the Basic header.
+	const reservedCharacterRequest = buildOAuthTokenExchangeRequest({
+		params: new URLSearchParams({
+			grant_type: 'authorization_code',
+			client_id: 'client:id',
+			code: 'canva-code',
+		}),
+		flow: 'confidential',
+		clientSecret: 'secret%value',
+		style: 'basic-form',
+	})
+	expect(reservedCharacterRequest.headers.Authorization).toBe(
+		`Basic ${btoa('client%3Aid:secret%25value')}`,
+	)
+
+	// Each validation condition fails independently: PKCE-only flow, missing
+	// secret with confidential flow, and missing client_id.
 	expect(() =>
 		buildOAuthTokenExchangeRequest({
 			params: new URLSearchParams({
@@ -145,6 +164,20 @@ test('token exchange style resolves Canva basic-form and keeps PKCE code_verifie
 				code: 'canva-code',
 			}),
 			flow: 'pkce',
+			clientSecret: 'canva-client-secret',
+			style: 'basic-form',
+		}),
+	).toThrow(
+		'basic-form token exchange requires confidential flow with a client secret.',
+	)
+	expect(() =>
+		buildOAuthTokenExchangeRequest({
+			params: new URLSearchParams({
+				grant_type: 'authorization_code',
+				client_id: 'canva-client-id',
+				code: 'canva-code',
+			}),
+			flow: 'confidential',
 			clientSecret: null,
 			style: 'basic-form',
 		}),

--- a/packages/worker/src/app/oauth-token-exchange.ts
+++ b/packages/worker/src/app/oauth-token-exchange.ts
@@ -8,8 +8,15 @@ import { safeParseHost } from '@kody-internal/shared/url-hosts.ts'
  *   `client_secret` in the body (GitHub/Slack-style).
  * - `basic-json`: HTTP Basic (client_id:client_secret) + JSON body without
  *   credentials in the body (Notion-style).
+ * - `basic-form`: HTTP Basic (client_id:client_secret) +
+ *   application/x-www-form-urlencoded body without credentials in the body
+ *   (Canva-style).
+ *
+ * Client-secret authentication and PKCE are orthogonal: `params` may carry a
+ * PKCE `code_verifier` in any style, so providers like Canva that require both
+ * S256 PKCE and a client secret on token exchange are supported.
  */
-export const tokenExchangeStyles = ['form', 'basic-json'] as const
+export const tokenExchangeStyles = ['form', 'basic-json', 'basic-form'] as const
 export type TokenExchangeStyle = (typeof tokenExchangeStyles)[number]
 
 export function isTokenExchangeStyle(
@@ -28,6 +35,9 @@ export function resolveTokenExchangeStyle(input: {
 	// Notion's token endpoint rejects form-body client_secret and requires
 	// Basic Auth + JSON: https://developers.notion.com/guides/get-started/authorization
 	if (host === 'api.notion.com') return 'basic-json'
+	// Canva's token endpoint takes Basic Auth (or form-body credentials) with
+	// an urlencoded body: https://www.canva.dev/docs/connect/authentication/
+	if (host === 'api.canva.com') return 'basic-form'
 	return 'form'
 }
 
@@ -40,29 +50,36 @@ export function buildOAuthTokenExchangeRequest(input: {
 	const params = new URLSearchParams(input.params)
 	switch (input.style) {
 		case 'basic-json': {
-			if (input.flow !== 'confidential' || !input.clientSecret) {
-				throw new Error(
-					'basic-json token exchange requires confidential flow with a client secret.',
-				)
-			}
-			const clientId = params.get('client_id')?.trim() ?? ''
-			if (!clientId) {
-				throw new Error(
-					'basic-json token exchange requires client_id in params.',
-				)
-			}
-			params.delete('client_id')
-			params.delete('client_secret')
+			const authorization = buildBasicAuthorization({
+				params,
+				flow: input.flow,
+				clientSecret: input.clientSecret,
+				style: input.style,
+			})
 			const bodyObject = Object.fromEntries(params.entries())
 			return {
 				headers: {
 					Accept: 'application/json',
 					'Content-Type': 'application/json',
-					Authorization: `Basic ${bytesToBase64(
-						new TextEncoder().encode(`${clientId}:${input.clientSecret}`),
-					)}`,
+					Authorization: authorization,
 				},
 				body: JSON.stringify(bodyObject),
+			}
+		}
+		case 'basic-form': {
+			const authorization = buildBasicAuthorization({
+				params,
+				flow: input.flow,
+				clientSecret: input.clientSecret,
+				style: input.style,
+			})
+			return {
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/x-www-form-urlencoded',
+					Authorization: authorization,
+				},
+				body: params.toString(),
 			}
 		}
 		case 'form': {
@@ -87,6 +104,34 @@ export function buildOAuthTokenExchangeRequest(input: {
 			)
 		}
 	}
+}
+
+/**
+ * Builds the HTTP Basic Authorization header for the basic-* styles and strips
+ * the credentials from the body params. Mutates `params`.
+ */
+function buildBasicAuthorization(input: {
+	params: URLSearchParams
+	flow: 'pkce' | 'confidential'
+	clientSecret: string | null
+	style: TokenExchangeStyle
+}): string {
+	if (input.flow !== 'confidential' || !input.clientSecret) {
+		throw new Error(
+			`${input.style} token exchange requires confidential flow with a client secret.`,
+		)
+	}
+	const clientId = input.params.get('client_id')?.trim() ?? ''
+	if (!clientId) {
+		throw new Error(
+			`${input.style} token exchange requires client_id in params.`,
+		)
+	}
+	input.params.delete('client_id')
+	input.params.delete('client_secret')
+	return `Basic ${bytesToBase64(
+		new TextEncoder().encode(`${clientId}:${input.clientSecret}`),
+	)}`
 }
 
 /**

--- a/packages/worker/src/app/oauth-token-exchange.ts
+++ b/packages/worker/src/app/oauth-token-exchange.ts
@@ -130,8 +130,22 @@ function buildBasicAuthorization(input: {
 	input.params.delete('client_id')
 	input.params.delete('client_secret')
 	return `Basic ${bytesToBase64(
-		new TextEncoder().encode(`${clientId}:${input.clientSecret}`),
+		new TextEncoder().encode(
+			`${formUrlEncodeBasicCredential(clientId)}:${formUrlEncodeBasicCredential(
+				input.clientSecret,
+			)}`,
+		),
 	)}`
+}
+
+/**
+ * RFC 6749 §2.3.1: Basic-auth client credentials are
+ * application/x-www-form-urlencoded before being joined with ":" and
+ * base64-encoded, so ids or secrets containing ":" or "%" survive intact.
+ * A no-op for the alphanumeric credentials real providers issue.
+ */
+function formUrlEncodeBasicCredential(value: string) {
+	return encodeURIComponent(value).replace(/%20/g, '+')
 }
 
 /**

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
@@ -283,3 +283,68 @@ test('integration config helpers and integration_save persist validated integrat
 		requiredHosts: ['api.spotify.com'],
 	})
 })
+
+test('integration_save persists usePkce only when it differs from the flow default', async () => {
+	// Canva-style: confidential flow with PKCE enabled must round-trip.
+	const canvaDb = createValueTestDb()
+	const canvaResult = await integrationSaveCapability.handler(
+		{
+			name: 'canva',
+			tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+			apiBaseUrl: 'https://api.canva.com/rest/v1',
+			flow: 'confidential',
+			usePkce: true,
+			clientIdValueName: 'canva-client-id',
+			clientSecretSecretName: 'canvaClientSecret',
+			accessTokenSecretName: 'canvaAccessToken',
+			refreshTokenSecretName: 'canvaRefreshToken',
+			requiredHosts: ['api.canva.com'],
+			tokenExchangeStyle: 'basic-form',
+		},
+		{
+			env: { APP_DB: canvaDb.db } as unknown as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				user: { userId: 'user-123' },
+			}),
+		},
+	)
+	expect(canvaResult.integration).toMatchObject({
+		name: 'canva',
+		flow: 'confidential',
+		usePkce: true,
+		tokenExchangeStyle: 'basic-form',
+	})
+	expect(
+		JSON.parse(canvaDb.entries.get('_integration:canva') ?? '{}'),
+	).toMatchObject({
+		flow: 'confidential',
+		usePkce: true,
+		tokenExchangeStyle: 'basic-form',
+	})
+
+	// Flow-default PKCE choices normalize away instead of being stored.
+	const defaultDb = createValueTestDb()
+	const defaultResult = await integrationSaveCapability.handler(
+		{
+			name: 'spotify',
+			tokenUrl: 'https://accounts.spotify.com/api/token',
+			flow: 'pkce',
+			usePkce: true,
+			clientIdValueName: 'spotify-client-id',
+			accessTokenSecretName: 'spotifyAccessToken',
+			requiredHosts: ['api.spotify.com'],
+		},
+		{
+			env: { APP_DB: defaultDb.db } as unknown as Env,
+			callerContext: createMcpCallerContext({
+				baseUrl: 'https://heykody.dev',
+				user: { userId: 'user-123' },
+			}),
+		},
+	)
+	expect(defaultResult.integration).not.toHaveProperty('usePkce')
+	expect(
+		JSON.parse(defaultDb.entries.get('_integration:spotify') ?? '{}'),
+	).not.toHaveProperty('usePkce')
+})

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
@@ -91,6 +91,7 @@ function createNewIntegrationConfig(args: z.infer<typeof inputSchema>) {
 		tokenUrl: args.tokenUrl,
 		apiBaseUrl: args.apiBaseUrl ?? null,
 		flow: args.flow,
+		...(args.usePkce !== undefined ? { usePkce: args.usePkce } : {}),
 		clientIdValueName: args.clientIdValueName,
 		clientSecretSecretName: args.clientSecretSecretName ?? null,
 		accessTokenSecretName: args.accessTokenSecretName,

--- a/packages/worker/src/mcp/capabilities/integrations/integration-shared.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-shared.ts
@@ -5,7 +5,11 @@ export const integrationFlowValues = ['pkce', 'confidential'] as const
 
 const defaultIntegrationScopeSeparator = ' '
 
-export const tokenExchangeStyleValues = ['form', 'basic-json'] as const
+export const tokenExchangeStyleValues = [
+	'form',
+	'basic-json',
+	'basic-form',
+] as const
 
 export const integrationAuthorizationSchema = z
 	.object({
@@ -30,6 +34,12 @@ export const integrationConfigSchema = z.object({
 	tokenUrl: z.string().url(),
 	apiBaseUrl: z.string().url().optional().nullable(),
 	flow: z.enum(integrationFlowValues),
+	/**
+	 * PKCE is orthogonal to `flow`. Absent means the flow default: PKCE on for
+	 * `pkce` flow, off for `confidential`. Canva-style providers store
+	 * `usePkce: true` with `confidential` flow.
+	 */
+	usePkce: z.boolean().optional().nullable(),
 	clientIdValueName: z.string().min(1),
 	clientSecretSecretName: z.string().min(1).optional().nullable(),
 	accessTokenSecretName: z.string().min(1),
@@ -48,6 +58,7 @@ export const integrationSaveSchema = z
 		tokenUrl: z.string().url().optional(),
 		apiBaseUrl: z.string().url().nullable().optional(),
 		flow: z.enum(integrationFlowValues).optional(),
+		usePkce: z.boolean().nullable().optional(),
 		clientIdValueName: z.string().min(1).optional(),
 		clientSecretSecretName: z.string().min(1).nullable().optional(),
 		accessTokenSecretName: z.string().min(1).optional(),
@@ -67,11 +78,19 @@ export function normalizeIntegrationConfig(
 		? normalizeIntegrationAuthorization(value.authorization)
 		: null
 	const tokenExchangeStyle = value.tokenExchangeStyle ?? null
+	// Store usePkce only when it differs from the flow default so existing
+	// integration records keep their canonical shape.
+	const usePkce =
+		typeof value.usePkce === 'boolean' &&
+		value.usePkce !== (value.flow === 'pkce')
+			? value.usePkce
+			: null
 	return {
-		...value,
 		name: value.name.trim(),
 		tokenUrl: value.tokenUrl.trim(),
 		apiBaseUrl: value.apiBaseUrl?.trim() || null,
+		flow: value.flow,
+		...(usePkce == null ? {} : { usePkce }),
 		clientIdValueName: value.clientIdValueName.trim(),
 		clientSecretSecretName: value.clientSecretSecretName?.trim() || null,
 		accessTokenSecretName: value.accessTokenSecretName.trim(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Canva Connect cannot be connected through `/connect/oauth`: Canva requires **both** S256 PKCE **and** client-secret authentication on token exchange, but the connect wizard treated `flow` as an XOR (`pkce` = code_verifier only, `confidential` = client secret only). There was also no token-exchange style for Canva's contract (HTTP Basic client auth + `application/x-www-form-urlencoded` body).

## What changed

- **PKCE is now orthogonal to `flow`.** A new `usePkce` switch controls whether `code_challenge`/`code_verifier` are used; `flow` keeps controlling whether a client secret is collected and sent. Defaults preserve existing behavior (`pkce` flow → PKCE on, `confidential` → off), and a new `pkce=true|false` query param overrides it, so any confidential+PKCE provider works.
- **New `basic-form` token exchange style** (HTTP Basic `client_id:client_secret` + urlencoded body, credentials stripped from the body), alongside the existing `form` and `basic-json` (Notion) styles. `code_verifier` passes through in every style. Also exposed `tokenExchangeStyle` as a `/connect/oauth` query param override.
- **`api.canva.com` host defaults** (mirroring the Notion `basic-json` auto-detection): `confidential` flow, PKCE on, `basic-form` exchange — so `/connect/oauth?provider=canva&authorizeUrl=https://www.canva.com/api/oauth/authorize&tokenUrl=https://api.canva.com/rest/v1/oauth/token` works with no extra params.
- **Persistence:** the integration record stores `usePkce` (only when it differs from the flow default, keeping existing records' canonical shape), so provider-only reconnects (`/connect/oauth?provider=canva`) restore the confidential+PKCE combination. `integration_save` / `integration_get` schemas accept the new field and style.
- The wizard's Provider details card now shows a PKCE row (`S256` / `off`).
- Docs: `docs/guides/oauth.md` documents `pkce`, `tokenExchangeStyle`, and the Canva host defaults.

Spotify (pkce/form), GitHub (confidential/form), and Notion (confidential/basic-json) behavior is unchanged — covered by existing tests which still pass, now with explicit `usePkce` assertions.

## Testing

- Unit tests: new coverage for `basic-form` request building (Basic header + urlencoded body + `code_verifier`, credentials stripped), Canva style/host resolution, confidential+PKCE `form` bodies, client config merging/overrides/reconnect, `oauth_exchange` handler with Canva params, `connect_oauth` persistence of `usePkce`, and `integration_save` round-trip/normalization.
- `npm run validate` passes (format, lint, typecheck, unit, Playwright E2E, MCP E2E).
- Manual GUI test against a local mock provider that **enforces** Canva's contract (rejects the token request unless HTTP Basic auth, urlencoded body, and a matching S256 `code_verifier` are all present): full wizard flow succeeds end-to-end, including a provider-only reconnect from the stored integration record.

![Canva host defaults: confidential flow with S256 PKCE derived automatically](https://cursor.com/artifacts/c/art-e2fb727d-3cb8-4114-8a24-f715c38173dc)

<a href="https://cursor.com/agents/bc-23520844-9181-4b2b-ae83-bc720fd2f031/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcanva_style_oauth_confidential_pkce_basic_form_end_to_end.mp4"><img src="https://cursor.com/artifacts/c/art-4e28b1a8-5828-4adc-bb03-89203a6c89a4" alt="canva_style_oauth_confidential_pkce_basic_form_end_to_end.mp4" /></a>

![Reconnect with only provider name restores confidential + PKCE + basic-form from the stored integration](https://cursor.com/artifacts/c/art-44cb80b7-9fb3-4de7-921b-dcb5df2196aa)

![Success step with access and refresh tokens saved](https://cursor.com/artifacts/c/art-14a62425-d7a8-4301-8769-4d89b3558b7e)

Mock provider log for the recorded run (Basic auth + S256 verifier accepted together):

```
AUTHORIZE { "code_challenge_method": "S256", "code_challenge": "S27A-YZNnYchvkSb8wMfFigz31PfS30IqRq4yRNIvKI", ... }
TOKEN { "authorization": "Basic bW9jay1jYW52YS1jbGllbnQtaWQ6...", "contentType": "application/x-www-form-urlencoded",
        "body": { "grant_type": "authorization_code", "code": "mock-canva-code-123", "code_verifier": "vgs9hjC_..." } }
TOKEN ACCEPTED: Basic auth + S256 PKCE verified together
```

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `232fbbd6` · **Head:** `47006e54`

**Classification:** extends — the outbound OAuth connect contract gains an orthogonal PKCE switch and a new token-exchange style; no new primitives.

### Primitives touched

| Primitive             | Group     | Impact                                                                                                              |
| --------------------- | --------- | ------------------------------------------------------------------------------------------------------------------- |
| `app-ui`              | surfaces  | extends — `/connect/oauth` wizard gains `usePkce` + `tokenExchangeStyle` params; `oauth_exchange` builds `basic-form` requests |
| `capability-registry` | assistant | extends — integrations domain schema adds `usePkce` and the `basic-form` style value                                 |
| `values`              | assistant | composes — `_integration:{name}` records may now carry `usePkce`                                                     |

### System map

The connect wizard sends PKCE + confidential exchanges through the account-secrets handler and persists the PKCE choice in the integration value record.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
	values["values<br/>Values"]:::touched
	provider["Canva token endpoint<br/>(external)"]:::untouched
	appUi -->|"oauth_exchange: code_verifier + basic-form Basic auth"| provider
	appUi -->|"connect_oauth persists usePkce"| capabilityRegistry
	capabilityRegistry -->|"_integration:{name} value with usePkce"| values
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```
flow=pkce         → code_verifier, no client secret            (unchanged)
flow=confidential → client secret, no code_verifier            (unchanged default)
flow=confidential + pkce=true → client secret AND code_verifier (new)
tokenExchangeStyle: form | basic-json | basic-form (new)
api.canva.com host default: confidential + PKCE + basic-form   (new)
```

### Invariants

`integration-host-allowlist` is untouched: the token host is still forced into `allowedHosts`/`requiredHosts`, and host approvals remain manual.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23520844-9181-4b2b-ae83-bc720fd2f031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23520844-9181-4b2b-ae83-bc720fd2f031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent PKCE configuration for OAuth connections, including support alongside confidential flows.
  * Added the `basic-form` token exchange option, including automatic support for Canva.
  * OAuth connection settings now display whether PKCE uses S256 or is disabled.
  * Saved integrations preserve PKCE and token exchange preferences when applicable.

* **Documentation**
  * Expanded OAuth guidance with parameter details, defaults, and provider-specific token exchange examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->