### PR TITLE
Stop password managers from saving OAuth client credentials as logins

### DIFF
--- a/packages/worker/client/password-manager-ignore.node.test.ts
+++ b/packages/worker/client/password-manager-ignore.node.test.ts
@@ -1,0 +1,60 @@
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+import { passwordManagerIgnoreProps } from './password-manager-ignore.ts'
+
+const clientDir = path.dirname(fileURLToPath(import.meta.url))
+const routesDir = path.join(clientDir, 'routes')
+
+/** Account password sign-in / sign-up surfaces where managers should help. */
+const passwordManagerAllowedFiles = new Set([
+	'login.tsx',
+	'oauth-authorize.tsx',
+])
+
+async function listTsxFiles(dir: string): Promise<Array<string>> {
+	const entries = await readdir(dir, { withFileTypes: true })
+	const files: Array<string> = []
+	for (const entry of entries) {
+		const fullPath = path.join(dir, entry.name)
+		if (entry.isDirectory()) {
+			files.push(...(await listTsxFiles(fullPath)))
+			continue
+		}
+		if (entry.isFile() && entry.name.endsWith('.tsx')) {
+			files.push(fullPath)
+		}
+	}
+	return files
+}
+
+test('passwordManagerIgnoreProps exports the ignore attributes password managers recognize', () => {
+	expect(passwordManagerIgnoreProps.autoComplete).toBe('off')
+	expect(passwordManagerIgnoreProps['data-1p-ignore']).toBe(true)
+	expect(passwordManagerIgnoreProps['data-lpignore']).toBe('true')
+})
+
+test('password inputs outside sign-in/sign-up opt out of password managers', async () => {
+	const files = await listTsxFiles(routesDir)
+	const violations: Array<string> = []
+
+	for (const filePath of files) {
+		const relativeName = path.relative(routesDir, filePath)
+		if (passwordManagerAllowedFiles.has(path.basename(filePath))) {
+			continue
+		}
+		const source = await readFile(filePath, 'utf8')
+		if (!source.includes('type="password"')) {
+			continue
+		}
+		if (
+			!source.includes('passwordManagerIgnoreProps') &&
+			!source.includes('data-1p-ignore')
+		) {
+			violations.push(relativeName)
+		}
+	}
+
+	expect(violations).toEqual([])
+})

--- a/packages/worker/client/password-manager-ignore.ts
+++ b/packages/worker/client/password-manager-ignore.ts
@@ -1,0 +1,13 @@
+/**
+ * Ask password managers not to autofill or offer to save this field/form.
+ *
+ * Use on secret, token, API-key, and other non-login protected inputs. Keep
+ * password-manager behavior on the account sign-in / sign-up flow in
+ * `routes/login.tsx` and the OAuth authorize sign-in form in
+ * `routes/oauth-authorize.tsx`.
+ */
+export const passwordManagerIgnoreProps = {
+	autoComplete: 'off',
+	'data-1p-ignore': true,
+	'data-lpignore': 'true',
+} as const

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -4,6 +4,7 @@ import { bytesToBase64Url } from '@kody-internal/shared/base64.ts'
 import { type Handle, css } from 'remix/ui'
 import { createHref } from 'remix/route-pattern/href'
 import { on } from '#client/event-mixin.ts'
+import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { writeClipboardText } from '#client/clipboard.ts'
@@ -1019,6 +1020,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 								<form
 									method="post"
 									noValidate
+									{...passwordManagerIgnoreProps}
 									mix={[
 										on('submit', (event) => {
 											event.preventDefault()
@@ -1073,7 +1075,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 												type="password"
 												value={editorState.rawToken}
 												placeholder="Paste or generate a token"
-												autoComplete="off"
+												{...passwordManagerIgnoreProps}
 												disabled={isMutating}
 												required
 												mix={[
@@ -1234,6 +1236,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 								<form
 									method="post"
 									noValidate
+									{...passwordManagerIgnoreProps}
 									mix={[
 										on('submit', (event) => {
 											event.preventDefault()
@@ -1310,7 +1313,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 													type="password"
 													value={editorState.rawToken}
 													placeholder="Leave blank to keep the current token value"
-													autoComplete="off"
+													{...passwordManagerIgnoreProps}
 													disabled={isMutating}
 													mix={[
 														on('input', (event) => {

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -2,6 +2,7 @@ import { formatTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
 import toggle from 'remix/ui/toggle'
 import { on } from '#client/event-mixin.ts'
+import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
@@ -639,6 +640,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 						<form
 							method="post"
 							noValidate
+							{...passwordManagerIgnoreProps}
 							mix={[
 								on('submit', (event) => {
 									event.preventDefault()
@@ -745,7 +747,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 												type="text"
 												value={editorState.sharedSecret}
 												placeholder="Connector hello shared secret"
-												autoComplete="off"
+												{...passwordManagerIgnoreProps}
 												disabled={isMutating}
 												mix={[
 													on('input', (event) => {
@@ -765,7 +767,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 												type="password"
 												value={editorState.sharedSecret}
 												placeholder="Connector hello shared secret"
-												autoComplete="off"
+												{...passwordManagerIgnoreProps}
 												disabled={isMutating}
 												mix={[
 													on('input', (event) => {

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -2,6 +2,7 @@ import { formatTimestamp } from '#client/format-timestamp.ts'
 import { readCommaListParams, readTrimmedParam } from '#client/url-params.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
+import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import {
 	buildAccountSecretPath,
 	parseAccountSecretPath,
@@ -1485,6 +1486,7 @@ export function AccountSecretsRoute(handle: Handle) {
 					>
 						{showEditor ? (
 							<form
+								{...passwordManagerIgnoreProps}
 								mix={[
 									css({ display: 'grid', gap: spacing.lg }),
 									on('submit', saveSecretChanges),

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -1,6 +1,7 @@
 import { type Handle, css } from 'remix/ui'
 import { getOauthLoginErrorMessage } from '#app/oauth-login-errors.ts'
 import { on } from '#client/event-mixin.ts'
+import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { ProviderIcon } from '#client/provider-icons.tsx'
 import {
@@ -635,6 +636,7 @@ export function AccountRoute(handle: Handle) {
 								</div>
 							</form>
 							<form
+								{...passwordManagerIgnoreProps}
 								mix={[
 									css({
 										display: 'grid',
@@ -679,7 +681,7 @@ export function AccountRoute(handle: Handle) {
 										type="password"
 										name="password"
 										required
-										autoComplete="current-password"
+										{...passwordManagerIgnoreProps}
 										value={emailChangePassword}
 										mix={[
 											css(inputCss),

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -1039,6 +1039,9 @@ export function ConnectOauthRoute(handle: Handle) {
 						{renderProviderInstructions()}
 						{renderAllowedHosts()}
 						<form
+							autoComplete="off"
+							data-1p-ignore
+							data-lpignore="true"
 							mix={[
 								on('submit', handleSetupSubmit),
 								css({ display: 'grid', gap: spacing.md }),
@@ -1047,8 +1050,11 @@ export function ConnectOauthRoute(handle: Handle) {
 							<label mix={css(fieldCss)}>
 								<span mix={css(fieldLabelCss)}>Client ID</span>
 								<input
-									name="clientId"
+									name="oauthClientId"
 									required
+									autoComplete="off"
+									data-1p-ignore
+									data-lpignore="true"
 									value={clientIdInput}
 									mix={[
 										on(
@@ -1102,9 +1108,12 @@ export function ConnectOauthRoute(handle: Handle) {
 									<label mix={css(fieldCss)}>
 										<span mix={css(fieldLabelCss)}>Client Secret</span>
 										<input
-											name="clientSecret"
+											name="oauthClientSecret"
 											type="password"
 											required
+											autoComplete="off"
+											data-1p-ignore
+											data-lpignore="true"
 											value={clientSecretInput}
 											mix={[
 												on(

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -8,6 +8,7 @@ import {
 } from '@kody-internal/shared/url-hosts.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
+import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import {
 	buildHostApprovalRequestUrl,
 	submitApprovalRequest,
@@ -1039,9 +1040,7 @@ export function ConnectOauthRoute(handle: Handle) {
 						{renderProviderInstructions()}
 						{renderAllowedHosts()}
 						<form
-							autoComplete="off"
-							data-1p-ignore
-							data-lpignore="true"
+							{...passwordManagerIgnoreProps}
 							mix={[
 								on('submit', handleSetupSubmit),
 								css({ display: 'grid', gap: spacing.md }),
@@ -1052,9 +1051,7 @@ export function ConnectOauthRoute(handle: Handle) {
 								<input
 									name="oauthClientId"
 									required
-									autoComplete="off"
-									data-1p-ignore
-									data-lpignore="true"
+									{...passwordManagerIgnoreProps}
 									value={clientIdInput}
 									mix={[
 										on(
@@ -1111,9 +1108,7 @@ export function ConnectOauthRoute(handle: Handle) {
 											name="oauthClientSecret"
 											type="password"
 											required
-											autoComplete="off"
-											data-1p-ignore
-											data-lpignore="true"
+											{...passwordManagerIgnoreProps}
 											value={clientSecretInput}
 											mix={[
 												on(

--- a/packages/worker/client/routes/reset-password.tsx
+++ b/packages/worker/client/routes/reset-password.tsx
@@ -1,5 +1,6 @@
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
+import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { readRouterSearch } from '#client/router-location.tsx'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import {
@@ -123,6 +124,7 @@ export function ResetPasswordRoute(handle: Handle) {
 					<p mix={css(pageDescriptionCss)}>{description}</p>
 				</header>
 				<form
+					{...passwordManagerIgnoreProps}
 					mix={[
 						css(cardCss),
 						on(
@@ -142,7 +144,7 @@ export function ResetPasswordRoute(handle: Handle) {
 								type="password"
 								name="password"
 								required
-								autoComplete="new-password"
+								{...passwordManagerIgnoreProps}
 								placeholder="At least 8 characters"
 								disabled={isSubmitting}
 								mix={css(inputCss)}

--- a/packages/worker/client/routes/secret-editor-fields.tsx
+++ b/packages/worker/client/routes/secret-editor-fields.tsx
@@ -72,7 +72,9 @@ export function SecretEditorFields(handle: Handle<SecretEditorFieldsProps>) {
 							<input
 								type="text"
 								required
-								autoComplete="new-password"
+								autoComplete="off"
+								data-1p-ignore
+								data-lpignore="true"
 								value={props.value}
 								placeholder={props.valuePlaceholder ?? 'Enter the secret value'}
 								mix={[
@@ -94,7 +96,9 @@ export function SecretEditorFields(handle: Handle<SecretEditorFieldsProps>) {
 							<input
 								type="password"
 								required
-								autoComplete="new-password"
+								autoComplete="off"
+								data-1p-ignore
+								data-lpignore="true"
 								value={props.value}
 								placeholder={props.valuePlaceholder ?? 'Enter the secret value'}
 								mix={[

--- a/packages/worker/client/routes/secret-editor-fields.tsx
+++ b/packages/worker/client/routes/secret-editor-fields.tsx
@@ -1,5 +1,6 @@
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
+import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { colors, mq, spacing } from '#client/styles/tokens.ts'
 import {
 	fieldCss,
@@ -72,9 +73,7 @@ export function SecretEditorFields(handle: Handle<SecretEditorFieldsProps>) {
 							<input
 								type="text"
 								required
-								autoComplete="off"
-								data-1p-ignore
-								data-lpignore="true"
+								{...passwordManagerIgnoreProps}
 								value={props.value}
 								placeholder={props.valuePlaceholder ?? 'Enter the secret value'}
 								mix={[
@@ -96,9 +95,7 @@ export function SecretEditorFields(handle: Handle<SecretEditorFieldsProps>) {
 							<input
 								type="password"
 								required
-								autoComplete="off"
-								data-1p-ignore
-								data-lpignore="true"
+								{...passwordManagerIgnoreProps}
 								value={props.value}
 								placeholder={props.valuePlaceholder ?? 'Enter the secret value'}
 								mix={[


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Password managers (notably 1Password) were treating non-login protected fields as website logins — especially `/connect/oauth` client id + secret on submit.

## Changes

- Add shared `passwordManagerIgnoreProps` (`autocomplete="off"`, `data-1p-ignore`, `data-lpignore`)
- Apply it to every protected input outside account sign-in/sign-up:
  - OAuth connect client id/secret
  - Secret editor values (+ secrets form)
  - Remote connector shared secrets
  - Package invocation tokens
  - Account email-change reauth password
  - Password reset
- Leave `login.tsx` and `oauth-authorize.tsx` alone so 1Password still works for sign-in/sign-up
- Guardrail unit test fails if a new `type="password"` field is added outside that allowlist without the ignore props

Low-risk UI attribute change only; no auth or storage behavior changes.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `5163d9d9` · **Head:** `593e196c`

**Classification:** composes — shared HTML attributes on existing Remix form fields; no primitive contracts changed.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — password-manager ignore attrs on non-login forms |
| `secrets` | assistant | composes — secret value inputs; storage path unchanged |

### System map

```mermaid
flowchart LR
  Login["login + oauth-authorize<br/>1Password allowed"]
  Other["secrets / OAuth client / tokens / reset<br/>passwordManagerIgnoreProps"]
  Sec["secrets"]
  Val["values"]
  Other --> Sec
  Other --> Val
  Login --> Auth["account password"]
```

### Risk callouts

- Password-manager ignore attributes are best-effort; managers can still choose to prompt.
- Password reset and email-change reauth no longer invite 1Password save/autofill by design (sign-in/sign-up only).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc145805-1aee-4f75-a384-593af3aa863a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc145805-1aee-4f75-a384-593af3aa863a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of sensitive fields to prevent unwanted browser password-manager autofill and save prompts.
  * Applied this behavior across account settings, secrets, remote connectors, OAuth setup, token management, and password reset forms.
  * Updated OAuth field identifiers for clearer form handling.

* **Tests**
  * Added coverage to verify password-manager protection and detect unprotected password fields in route interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->