### PR TITLE
Fix production community icon loading

### DIFF
--- a/packages/worker/src/app/handlers/community-icon.node.test.ts
+++ b/packages/worker/src/app/handlers/community-icon.node.test.ts
@@ -5,6 +5,7 @@ import { type CommunityListingRecord } from '#worker/community/types.ts'
 const mocks = vi.hoisted(() => ({
 	getCommunityIconObject: vi.fn(),
 	getCommunityListingById: vi.fn(),
+	renderCommunityIconFallbackPng: vi.fn(),
 }))
 
 vi.mock('#worker/community/community-icon.ts', () => {
@@ -13,6 +14,8 @@ vi.mock('#worker/community/community-icon.ts', () => {
 			`<svg xmlns="http://www.w3.org/2000/svg"><text>${name}</text></svg>`,
 		getCommunityIconObject: (...args: Array<unknown>) =>
 			mocks.getCommunityIconObject(...args),
+		renderCommunityIconFallbackPng: (...args: Array<unknown>) =>
+			mocks.renderCommunityIconFallbackPng(...args),
 	}
 })
 
@@ -82,11 +85,23 @@ test('community icon handler rejects stale commit URLs and degrades to a safe fa
 	mocks.getCommunityIconObject.mockRejectedValue(
 		new Error('Artifacts unavailable'),
 	)
+	const fallbackPng = Uint8Array.from([0x89, 0x50, 0x4e, 0x47])
+	mocks.renderCommunityIconFallbackPng.mockResolvedValue(fallbackPng)
 	const response = await callHandler()
 	expect(response.status).toBe(200)
-	expect(response.headers.get('Content-Type')).toBe(
+	expect(response.headers.get('Content-Type')).toBe('image/png')
+	expect(response.headers.get('Cache-Control')).toBe('no-store')
+	expect(response.headers.get('Content-Length')).toBe(
+		String(fallbackPng.byteLength),
+	)
+	expect(new Uint8Array(await response.arrayBuffer())).toEqual(fallbackPng)
+
+	mocks.renderCommunityIconFallbackPng.mockRejectedValue(
+		new Error('Renderer unavailable'),
+	)
+	const lastResortResponse = await callHandler()
+	expect(lastResortResponse.headers.get('Content-Type')).toBe(
 		'image/svg+xml; charset=utf-8',
 	)
-	expect(response.headers.get('Cache-Control')).toBe('no-store')
-	expect(await response.text()).toContain('<svg')
+	expect(await lastResortResponse.text()).toContain('<svg')
 })

--- a/packages/worker/src/app/handlers/community-icon.ts
+++ b/packages/worker/src/app/handlers/community-icon.ts
@@ -2,6 +2,7 @@ import { type Action } from 'remix/router'
 import {
 	buildCommunityIconFallbackSvg,
 	getCommunityIconObject,
+	renderCommunityIconFallbackPng,
 } from '#worker/community/community-icon.ts'
 import { getCommunityListingById } from '#worker/community/repo.ts'
 import { type routes } from '#app/routes.ts'
@@ -36,6 +37,23 @@ export function createCommunityIconHandler(env: Env) {
 				})
 			} catch (error) {
 				console.error('community-icon-load-failed', listing.id, error)
+				try {
+					const fallback = await renderCommunityIconFallbackPng(listing.name)
+					return new Response(new Uint8Array(fallback).buffer, {
+						headers: {
+							'Cache-Control': 'no-store',
+							'Content-Length': String(fallback.byteLength),
+							'Content-Type': 'image/png',
+							'X-Content-Type-Options': 'nosniff',
+						},
+					})
+				} catch (fallbackError) {
+					console.error(
+						'community-icon-fallback-render-failed',
+						listing.id,
+						fallbackError,
+					)
+				}
 				return new Response(buildCommunityIconFallbackSvg(listing.name), {
 					headers: {
 						'Cache-Control': 'no-store',

--- a/packages/worker/src/community/community-icon.node.test.ts
+++ b/packages/worker/src/community/community-icon.node.test.ts
@@ -3,6 +3,7 @@ import {
 	findCommunityIconPath,
 	getCommunityIconObject,
 	processCommunityIcon,
+	renderCommunityIconFallbackPng,
 } from './community-icon.ts'
 import { type CommunityListingRecord } from './types.ts'
 
@@ -186,6 +187,10 @@ test('community raster icon formats are validated and preserved', async () => {
 	expect(Array.from(renderedSvg.bytes.slice(0, 4))).toEqual([
 		0x89, 0x50, 0x4e, 0x47,
 	])
+	const fallbackPng = await renderCommunityIconFallbackPng(
+		'@kentcdodds/github-tools',
+	)
+	expect(Array.from(fallbackPng.slice(0, 4))).toEqual([0x89, 0x50, 0x4e, 0x47])
 	await expect(
 		processCommunityIcon({
 			path: 'community-icon.svg',
@@ -194,6 +199,42 @@ test('community raster icon formats are validated and preserved', async () => {
 			),
 		}),
 	).rejects.toThrow('active external content')
+})
+
+test('community SVG icons load directly from the retained listing snapshot', async () => {
+	const { kv } = createFakeKv()
+	const { bucket } = createFakeR2()
+	const env = {
+		APP_DB: {} as D1Database,
+		BUNDLE_ARTIFACTS_KV: kv,
+		COMMUNITY_ASSETS: bucket,
+	} as Env
+	mocks.readCommunitySnapshot.mockResolvedValue({
+		version: 1,
+		listingId: listing.id,
+		pinnedCommit: listing.pinnedCommit,
+		files: {
+			'community-icon.svg':
+				'<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><circle cx="32" cy="32" r="30" fill="#2563eb"/></svg>',
+		},
+		communityIconPath: 'community-icon.svg',
+		createdAt: '2026-07-10T00:00:00.000Z',
+	})
+	mocks.getCommunityListingById.mockResolvedValue(listing)
+
+	const result = await getCommunityIconObject({ env, listing })
+
+	expect(result.descriptor.sourcePath).toBe('community-icon.svg')
+	expect(result.descriptor.contentType).toBe('image/png')
+	expect(
+		Array.from(
+			new Uint8Array(
+				await new Response(result.object.body).arrayBuffer(),
+			).slice(0, 4),
+		),
+	).toEqual([0x89, 0x50, 0x4e, 0x47])
+	expect(mocks.getEntitySourceById).not.toHaveBeenCalled()
+	expect(mocks.readArtifactFileAtCommit).not.toHaveBeenCalled()
 })
 
 test('community icon descriptor caches the R2 reference and repairs a dangling reference', async () => {

--- a/packages/worker/src/community/community-icon.ts
+++ b/packages/worker/src/community/community-icon.ts
@@ -144,7 +144,18 @@ async function createCommunityIconDescriptor(input: {
 		communityIconPaths.find((path) => path === snapshot.communityIconPath) ??
 		findCommunityIconPath(snapshot.files)
 	let processed: ProcessedCommunityIcon
-	if (sourcePath) {
+	if (sourcePath === 'community-icon.svg') {
+		const source = snapshot.files[sourcePath]
+		if (source == null) {
+			throw new Error(
+				`Community icon "${sourcePath}" was not retained in the listing snapshot.`,
+			)
+		}
+		processed = await processCommunityIcon({
+			path: sourcePath,
+			sourceBytes: new TextEncoder().encode(source),
+		})
+	} else if (sourcePath) {
 		const source = await getEntitySourceById(
 			input.env.APP_DB,
 			input.listing.sourceId,
@@ -479,6 +490,10 @@ export function buildCommunityIconFallbackSvg(name: string) {
 	for (const character of name) hash = (hash * 31 + character.charCodeAt(0)) | 0
 	const background = colors[Math.abs(hash) % colors.length]
 	return `<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256"><rect width="256" height="256" rx="56" fill="${background}"/><text x="128" y="136" fill="white" font-family="sans-serif" font-size="92" font-weight="700" text-anchor="middle" dominant-baseline="middle">${initials}</text></svg>`
+}
+
+export async function renderCommunityIconFallbackPng(name: string) {
+	return await renderCommunitySvgIcon(buildCommunityIconFallbackSvg(name))
 }
 
 function isCommunityIconDescriptor(

--- a/packages/worker/src/repo/artifact-file.node.test.ts
+++ b/packages/worker/src/repo/artifact-file.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest'
 import { readArtifactFileAtCommit } from './artifact-file.ts'
 
 const mocks = vi.hoisted(() => ({
+	addRemote: vi.fn(),
 	fetch: vi.fn(),
 	init: vi.fn(),
 	readBlob: vi.fn(),
@@ -11,6 +12,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('isomorphic-git', () => ({
 	default: {
+		addRemote: (...args: Array<unknown>) => mocks.addRemote(...args),
 		fetch: (...args: Array<unknown>) => mocks.fetch(...args),
 		init: (...args: Array<unknown>) => mocks.init(...args),
 		readBlob: (...args: Array<unknown>) => mocks.readBlob(...args),
@@ -56,13 +58,24 @@ test('reads binary artifact files from an exact pinned commit', async () => {
 			dir: '/repo',
 		}),
 	)
+	expect(mocks.addRemote).toHaveBeenCalledWith(
+		expect.objectContaining({
+			dir: '/repo',
+			remote: 'origin',
+			url: 'https://artifacts.example.test/package.git',
+		}),
+	)
 	expect(mocks.fetch).toHaveBeenCalledWith(
 		expect.objectContaining({
+			remote: 'origin',
 			ref: 'abc123',
 			depth: 1,
 			singleBranch: true,
 			tags: false,
 		}),
+	)
+	expect(mocks.addRemote.mock.invocationCallOrder[0]).toBeLessThan(
+		mocks.fetch.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
 	)
 	expect(mocks.readBlob).toHaveBeenCalledWith(
 		expect.objectContaining({

--- a/packages/worker/src/repo/artifact-file.ts
+++ b/packages/worker/src/repo/artifact-file.ts
@@ -45,11 +45,17 @@ export async function readArtifactFileAtCommit(input: {
 		fs: workspace.fs,
 		dir: workspace.dir,
 	})
+	await git.addRemote({
+		fs: workspace.fs,
+		dir: workspace.dir,
+		remote: 'origin',
+		url: remote,
+	})
 	await git.fetch({
 		fs: workspace.fs,
 		http,
 		dir: workspace.dir,
-		url: remote,
+		remote: 'origin',
 		ref: input.commit,
 		depth: 1,
 		singleBranch: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- configure the Artifacts `origin` refspec before exact-commit shallow fetches
- render retained SVG icons directly from the pinned community snapshot
- return an uncached generated PNG when source or R2 loading genuinely fails
- add regression tests for fetch ordering, snapshot SVG processing, and fallback response types

## Root cause

`readArtifactFileAtCommit` initialized an in-memory git repository and fetched by raw commit without first adding `origin`. isomorphic-git deterministically threw `NoRefspecError` before `readBlob`, sending every repository-backed icon through the handler fallback. The same runtime probe succeeds after `git.addRemote(...)` and reads the exact-commit blob.

## Production walkthrough

<a href="https://cursor.com/agents/bc-66d7fd14-ea7d-4313-99d5-ff32126a272f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fproduction_community_icons_fixed_trimmed.mp4"><img src="https://cursor.com/artifacts/c/art-7d6bae65-81de-4324-912c-cedc8996fec5" alt="production_community_icons_fixed_trimmed.mp4" /></a>

![Production community listings with real brand icons](https://cursor.com/artifacts/c/art-707e39ff-874f-46e0-8550-349536ddeafd)

Spotify, Bluesky, Cloudflare, GitHub, and Google now return R2-served PNGs with public caching and distinct brand visuals.

## Testing

- `npm run validate`
- exact-commit raw-SHA fetch runtime probe: fails with `NoRefspecError` before the fix and succeeds after configuring `origin`
- local retained-SVG route returns `200 image/png`, `Cache-Control: public, max-age=3600`, an R2 ETag, and PNG magic bytes
- production repro packages return `200 image/png`, public caching, unique R2 ETags, and PNG magic bytes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `5163d9d9` · **Head:** `f672bd74`

**Classification:** extends — repairs existing community icon source resolution and fallback behavior without adding storage or route contracts.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | extends — snapshot SVG source and PNG soft fallback |
| `artifacts-repos` | storage | extends — configured exact-commit fetches |
| `community-assets-r2` | storage | composes — unchanged processed-byte persistence |
| `bundle-artifacts-kv` | storage | composes — unchanged cachified descriptor flow |

### System map

Community icon misses now use retained snapshot SVG directly or a correctly configured exact-commit Artifacts fetch before writing processed bytes to R2.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	communityListings["community-listings<br/>Community package listings"]:::extended
	bundleArtifactsKv["bundle-artifacts-kv<br/>Bundle artifacts KV"]:::touched
	artifactsRepos["artifacts-repos<br/>Artifacts repos"]:::extended
	communityAssetsR2["community-assets-r2<br/>Community asset storage (R2)"]:::touched
	communityListings -->|"retained community-icon.svg"| communityAssetsR2
	communityListings -->|"raster path at pinned commit"| artifactsRepos
	artifactsRepos -->|"validated source bytes"| communityAssetsR2
	communityAssetsR2 -->|"cachified descriptor"| bundleArtifactsKv
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Icon reads remain gated by an active listing and its exact pinned commit.
- Snapshot SVG content and Artifacts raster reads both remain listing-scoped.
- True load failures return uncached PNG output, so transient failures cannot poison descriptors.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66d7fd14-ea7d-4313-99d5-ff32126a272f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66d7fd14-ea7d-4313-99d5-ff32126a272f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Community icons can now use SVGs retained in listing snapshots.
  * Added PNG fallback rendering for unavailable community icons.

* **Bug Fixes**
  * Community icon requests now return a PNG fallback when primary assets cannot be loaded, with an SVG fallback if PNG rendering also fails.
  * Improved artifact retrieval by explicitly configuring the repository remote before fetching files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->