### PR TITLE
Fix e2e scroll-restoration flake and guard console output in tests

### DIFF
--- a/docs/contributing/testing-principles.md
+++ b/docs/contributing/testing-principles.md
@@ -53,6 +53,14 @@ when that makes a single test longer and more assertion-heavy.
   setup a test needs rather than relying on leftover state from a prior case.
   Keep explicit mid-test resets only when one workflow test runs multiple
   scenarios in a single `test(...)`.
+- Console output is guarded globally
+  (`packages/worker/src/test-support/console-spies.ts`, wired via `setupFiles`):
+  unexpected `console.error`/`console.warn` calls fail the test, and
+  `console.info`/`console.debug` are silenced. When code under test
+  intentionally logs, import the exported `consoleError`/`consoleWarn` spies,
+  call `.mockImplementation(() => {})` in the test, and assert on the calls
+  (prefer the stable first-argument tag plus `expect.any(Error)`; do not pin
+  long prose). Keep test output free of stray logging.
 
 ## Examples
 

--- a/e2e/og-images.spec.ts
+++ b/e2e/og-images.spec.ts
@@ -18,7 +18,12 @@ test('public pages emit OG meta and serve generated PNG images', async ({
 		ownerEmail: primaryTestUser.email,
 	})
 
-	const homeHtml = await (await request.get('/')).text()
+	// Seeding above shells out to `wrangler d1 execute` for multiple seconds.
+	// Playwright's APIRequestContext pools keep-alive sockets in a
+	// process-global agent, so the first request after that idle gap can race
+	// the dev server closing the stale socket ("socket hang up"/ECONNRESET).
+	// `maxRetries` opts into Playwright's built-in ECONNRESET-only retry.
+	const homeHtml = await (await request.get('/', { maxRetries: 1 })).text()
 	expect(homeHtml).toContain('property="og:image"')
 	expect(homeHtml).toContain('/og/home.png')
 	expect(homeHtml).toContain(

--- a/e2e/scroll-restore-slow-frame.spec.ts
+++ b/e2e/scroll-restore-slow-frame.spec.ts
@@ -34,6 +34,10 @@ test('scroll restoration retries until slow frame content makes the saved positi
 	await page.setViewportSize({ width: 900, height: 320 })
 
 	await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+	// Clicking auto-scrolls the link into view, which the router saves as the
+	// pop-restoration position. Make that scroll explicit and measure the
+	// position the click actually navigates from.
+	await page.getByRole('link', { name: listing.name }).scrollIntoViewIfNeeded()
 	const communityScrollY = await page.evaluate(() => window.scrollY)
 	expect(communityScrollY).toBeGreaterThan(0)
 
@@ -71,7 +75,9 @@ test('scroll restoration retries until slow frame content makes the saved positi
 	await expect(page.getByText(listing.description)).toBeVisible({
 		timeout: 10_000,
 	})
+	// Restoration must land back at the saved bottom-of-list position, not
+	// merely somewhere below the detail page's small offset.
 	await expect
 		.poll(() => page.evaluate(() => window.scrollY), { timeout: 10_000 })
-		.toBeGreaterThan(detailScrollY + 20)
+		.toBeGreaterThanOrEqual(communityScrollY - 2)
 })

--- a/e2e/scroll-restore-slow-frame.spec.ts
+++ b/e2e/scroll-restore-slow-frame.spec.ts
@@ -1,0 +1,77 @@
+// Regression coverage for a CI flake: when the community frame prefetch
+// degrades and the fallback frame fetch is slow, the document is still too
+// short when pop-navigation scroll restoration first runs. Restoration must
+// retry until the grown content makes the saved position reachable.
+import { expect, test } from '@playwright/test'
+import { ensurePrimaryUserExists, primaryTestUser } from './auth-test-user.ts'
+import { seedCommunityListingInE2eDatabase } from './d1-utils.ts'
+
+const listing = {
+	listingId: 'e2e-slow-frame-listing',
+	name: '@kody/slow-frame-package',
+	description: 'Slow frame fixture package for scroll restoration tests.',
+	tags: ['slow', 'frame'],
+}
+
+const longReadme = `# Scroll restoration fixture
+
+${Array.from({ length: 24 }, (_, index) => {
+	return `This README paragraph ${index + 1} makes the detail route scrollable.`
+}).join('\n\n')}`
+
+test('scroll restoration retries until slow frame content makes the saved position reachable', async ({
+	page,
+}) => {
+	await ensurePrimaryUserExists()
+	await seedCommunityListingInE2eDatabase({
+		...listing,
+		ownerEmail: primaryTestUser.email,
+		readmeContent: longReadme,
+	})
+
+	await page.goto('/community')
+	await expect(page.getByText(listing.description)).toBeVisible()
+	await page.setViewportSize({ width: 900, height: 320 })
+
+	await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+	const communityScrollY = await page.evaluate(() => window.scrollY)
+	expect(communityScrollY).toBeGreaterThan(0)
+
+	await page.getByRole('link', { name: listing.name }).click()
+	await expect(page).toHaveURL(new RegExp(`/community/${listing.listingId}$`))
+	await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
+
+	await page.evaluate(() => window.scrollTo(0, 40))
+	const detailScrollY = await page.evaluate(() => window.scrollY)
+	expect(detailScrollY).toBeGreaterThan(0)
+
+	// Abort the loader's frame prefetch so it degrades to the post-commit
+	// frame fetch, then serve that fallback slowly. The pop navigation commits
+	// with a short document and content grows ~1.5s later.
+	let frameRequestCount = 0
+	await page.route(
+		(url) => url.pathname === '/community',
+		async (route) => {
+			if (route.request().headers()['x-remix-target'] === undefined) {
+				await route.continue()
+				return
+			}
+			frameRequestCount += 1
+			if (frameRequestCount === 1) {
+				await route.abort()
+				return
+			}
+			await new Promise((resolve) => setTimeout(resolve, 1500))
+			await route.continue()
+		},
+	)
+
+	await page.goBack()
+	await expect(page).toHaveURL(/\/community$/)
+	await expect(page.getByText(listing.description)).toBeVisible({
+		timeout: 10_000,
+	})
+	await expect
+		.poll(() => page.evaluate(() => window.scrollY), { timeout: 10_000 })
+		.toBeGreaterThan(detailScrollY + 20)
+})

--- a/e2e/ssr-hydration.spec.ts
+++ b/e2e/ssr-hydration.spec.ts
@@ -87,8 +87,15 @@ test('SSR community HTML hydrates SPA navigation and client search', async ({
 	expect(communityScrollY).toBeGreaterThan(detailScrollY + 20)
 	await page.goBack()
 	await expect(page).toHaveURL(/\/community$/)
+	// Scroll restoration retries until the async listings frame renders and
+	// the saved position becomes reachable, so wait for the content first.
+	// Generous timeouts: in CI the whole validate pipeline shares one runner
+	// and the frame fetch alone can take several seconds.
+	await expect(page.getByText(alphaListing.description)).toBeVisible({
+		timeout: 15_000,
+	})
 	await expect
-		.poll(() => page.evaluate(() => window.scrollY))
+		.poll(() => page.evaluate(() => window.scrollY), { timeout: 15_000 })
 		.toBeGreaterThan(detailScrollY + 20)
 
 	await page

--- a/e2e/ssr-hydration.spec.ts
+++ b/e2e/ssr-hydration.spec.ts
@@ -68,6 +68,12 @@ test('SSR community HTML hydrates SPA navigation and client search', async ({
 	})
 
 	await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+	// Clicking auto-scrolls the link into view, which the router saves as the
+	// pop-restoration position. Make that scroll explicit and measure the
+	// position the click actually navigates from.
+	await page
+		.getByRole('link', { name: alphaListing.name })
+		.scrollIntoViewIfNeeded()
 	const communityScrollY = await page.evaluate(() => window.scrollY)
 	expect(communityScrollY).toBeGreaterThan(0)
 
@@ -97,9 +103,11 @@ test('SSR community HTML hydrates SPA navigation and client search', async ({
 	await expect(page.getByText(alphaListing.description)).toBeVisible({
 		timeout: 15_000,
 	})
+	// Restoration must land back at the saved bottom-of-list position, not
+	// merely somewhere below the detail page's small offset.
 	await expect
 		.poll(() => page.evaluate(() => window.scrollY), { timeout: 15_000 })
-		.toBeGreaterThan(detailScrollY + 20)
+		.toBeGreaterThanOrEqual(communityScrollY - 2)
 
 	await page
 		.getByRole('link', { name: betaListing.name })

--- a/e2e/ssr-hydration.spec.ts
+++ b/e2e/ssr-hydration.spec.ts
@@ -40,7 +40,10 @@ test('SSR community HTML hydrates SPA navigation and client search', async ({
 		readmeContent: longReadme,
 	})
 
-	const htmlResponse = await request.get('/community')
+	// First API request after the multi-second `wrangler d1 execute` seeding
+	// gap can reuse a keep-alive socket the dev server already closed
+	// ("socket hang up"). `maxRetries` enables Playwright's ECONNRESET retry.
+	const htmlResponse = await request.get('/community', { maxRetries: 1 })
 	expect(htmlResponse.ok()).toBe(true)
 	const rawHtml = await htmlResponse.text()
 	expect(rawHtml).toContain(alphaListing.description)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "packages/mock-servers/*"
       ],
       "devDependencies": {
-        "@cloudflare/vitest-pool-workers": "^0.14.7",
+        "@cloudflare/vitest-pool-workers": "^0.14.9",
         "@cloudflare/workers-types": "^4.20260415.1",
         "@epic-web/config": "^1.24.1",
         "@kody-internal/shared": "file:packages/shared",
@@ -518,16 +518,16 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.14.7.tgz",
-      "integrity": "sha512-6LooO25358uPn/7U3LUg5f5pLULncDTShGuOf00TyEn3VIBW2otq92dTNf8ScIR3gV9QDztXNfChc4mqPCSBEA==",
+      "version": "0.14.9",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.14.9.tgz",
+      "integrity": "sha512-XLJTOd+3A3BB6vPzD7gi1LTVKFSVge9HhGWXnLouPzySphMLbg+6xXELykFxZKyqP1AEjT2tc28AkBjM9GteFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cjs-module-lexer": "^1.2.3",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260415.0",
-        "wrangler": "4.83.0",
+        "miniflare": "4.20260421.0",
+        "wrangler": "4.84.1",
         "zod": "^3.25.76"
       },
       "peerDependencies": {
@@ -1044,9 +1044,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260415.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260415.1.tgz",
-      "integrity": "sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg==",
+      "version": "1.20260421.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260421.1.tgz",
+      "integrity": "sha512-DLU5ZTZ1VHeZZnj0PuVJEMHKGisfLe2XShyImP5P/PPj/m/t7CLEJmPiI7FMxvT7ynArkckJl7m+Z5x7u4Kkdw==",
       "cpu": [
         "x64"
       ],
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260415.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260415.1.tgz",
-      "integrity": "sha512-+JgSgVA49KyKteHRA1SnonE4Zn5Ei5zdAp5FQMxFmXI8qulZw4Hl7safXxRyK4i9sTO8gl7TFOKO5Q64VPvSDQ==",
+      "version": "1.20260421.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260421.1.tgz",
+      "integrity": "sha512-Trotq3xRAkIcpC505WoxM8+kIH4JIvOJCNuRatyHcz9uF5S+ukgiVUFUlM+GIjw1uCM/Bda2St+vSniX1RZdpw==",
       "cpu": [
         "arm64"
       ],
@@ -1078,9 +1078,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260415.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260415.1.tgz",
-      "integrity": "sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA==",
+      "version": "1.20260421.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260421.1.tgz",
+      "integrity": "sha512-938QjUv0z+QqK6BAvgwX/lCIZ2b224ZXoXtGTbhyNVMhB+mt4Dj24cj9qca4ekNXjVM7uTKp1yOHZO97fVSacw==",
       "cpu": [
         "x64"
       ],
@@ -1095,9 +1095,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260415.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260415.1.tgz",
-      "integrity": "sha512-bR9uITnV19r5NQ14xnypi2xHXu2iQvfYV8cVgx0JouFUmWwTEEAwFVojDdssGq93VHX9hr/pi2IRUZeegbYBog==",
+      "version": "1.20260421.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260421.1.tgz",
+      "integrity": "sha512-YI4+mLfwnJcKJ+iPyxzx+tp2Jy4o29BxBPSQGZxl/AZyvZ9eTKsmNZmtjEiT4i3O/M0tdO/B/d9ESDHbRCs2rQ==",
       "cpu": [
         "arm64"
       ],
@@ -1112,9 +1112,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260415.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260415.1.tgz",
-      "integrity": "sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ==",
+      "version": "1.20260421.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260421.1.tgz",
+      "integrity": "sha512-q1SFgwlNH9lFmw74vh7EJbJtduo92Nx51mNOfd3/u6pux6AldcwRviYzKEEv3FEbtv6OBB7J8D5f8vtZj7Z6Sg==",
       "cpu": [
         "x64"
       ],
@@ -7330,7 +7330,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.4.3",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11032,16 +11034,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260415.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260415.0.tgz",
-      "integrity": "sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng==",
+      "version": "4.20260421.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260421.0.tgz",
+      "integrity": "sha512-7ZkNQ7brgQ2hh5ha9iQCDUjxBkLvuiG2VdDns9esRL8O8lXg+MoP6E0dO1rtp+ZY2I+vV1tPWr6td5IojkewLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
         "undici": "7.24.8",
-        "workerd": "1.20260415.1",
+        "workerd": "1.20260421.1",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10"
       },
@@ -14254,9 +14256,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260415.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260415.1.tgz",
-      "integrity": "sha512-phyPjRnx+mQDfkhN9ENPioL1L0SdhYs4S0YmJK/xF9Oga+ykNfdSy1MHnsOj8yqnOV96zcVQMx32dJ0r3pq0jQ==",
+      "version": "1.20260421.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260421.1.tgz",
+      "integrity": "sha512-zTYD+xFR4d7TUCxsyl7FTPth9a8CDgk8pM7xUWbJxo0SGUx+2e5C7Q5LrramBZwmuAErtzXmOjlQ15PtkPAhZA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -14267,17 +14269,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260415.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260415.1",
-        "@cloudflare/workerd-linux-64": "1.20260415.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260415.1",
-        "@cloudflare/workerd-windows-64": "1.20260415.1"
+        "@cloudflare/workerd-darwin-64": "1.20260421.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260421.1",
+        "@cloudflare/workerd-linux-64": "1.20260421.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260421.1",
+        "@cloudflare/workerd-windows-64": "1.20260421.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.83.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.83.0.tgz",
-      "integrity": "sha512-gw5g3LCiuAqVWxaoKY6+quE0HzAUEFb/FV3oAlNkE1ttd4XP3FiV91XDkkzUCcdqxS4WjhQvPhIDBNdhEi8P0A==",
+      "version": "4.84.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.84.1.tgz",
+      "integrity": "sha512-Xe1S/Bik7pNdtdJ+asHsEZC2dX9k3WxYn2BbxFtOrrLVxN/LKi750zsrjX41jSAk00M/O1l7jzyQV4sQqw8ftg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -14285,10 +14287,10 @@
         "@cloudflare/unenv-preset": "2.16.0",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260415.0",
+        "miniflare": "4.20260421.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260415.1"
+        "workerd": "1.20260421.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -14301,7 +14303,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260415.1"
+        "@cloudflare/workers-types": "^4.20260421.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "audit:prod": "npm audit --omit=dev"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "^0.14.7",
+    "@cloudflare/vitest-pool-workers": "^0.14.9",
     "@cloudflare/workers-types": "^4.20260415.1",
     "@epic-web/config": "^1.24.1",
     "@kody-internal/shared": "file:packages/shared",

--- a/packages/worker/client/scroll-restoration.tsx
+++ b/packages/worker/client/scroll-restoration.tsx
@@ -90,6 +90,15 @@ function isRouterNavigationEvent(
 // position, and retries stop early on user scroll or the next navigation.
 const scrollRestorationDeadlineMs = 15_000
 
+// Input that signals the user has taken over scrolling; mousedown covers
+// scrollbar drags.
+const userScrollInputEvents = [
+	'wheel',
+	'touchmove',
+	'keydown',
+	'mousedown',
+] as const
+
 function maxWindowScrollPosition(): ScrollPosition {
 	const root = document.documentElement
 	return {
@@ -149,8 +158,22 @@ function restoreWindowScroll(
 	})
 	const requestId = ++restoreScrollRequestId
 	const startedAt = Date.now()
-	let lastAppliedX: number | null = null
-	let lastAppliedY: number | null = null
+	// Restoration must never fight manual scrolling, but layout-driven shifts
+	// (scroll anchoring, async content replacing nodes above the viewport) can
+	// move the position between attempts without any user involvement. Watch
+	// for real input instead of comparing positions across attempts.
+	let userInteracted = false
+	const markUserInteraction = () => {
+		userInteracted = true
+	}
+	for (const eventName of userScrollInputEvents) {
+		window.addEventListener(eventName, markUserInteraction, { passive: true })
+	}
+	const stopListening = () => {
+		for (const eventName of userScrollInputEvents) {
+			window.removeEventListener(eventName, markUserInteraction)
+		}
+	}
 	const schedule = (run: () => void) => {
 		if (typeof window.requestAnimationFrame === 'function') {
 			window.requestAnimationFrame(run)
@@ -159,21 +182,19 @@ function restoreWindowScroll(
 		window.setTimeout(run, 0)
 	}
 	const attempt = () => {
-		if (signal.aborted || requestId !== restoreScrollRequestId) return
-		// Stop retrying when something else (like the user) scrolled between
-		// attempts; restoration must never fight manual scrolling.
 		if (
-			lastAppliedY !== null &&
-			(window.scrollX !== lastAppliedX || window.scrollY !== lastAppliedY)
+			signal.aborted ||
+			requestId !== restoreScrollRequestId ||
+			userInteracted
 		) {
+			stopListening()
 			return
 		}
 		const isFinalAttempt = Date.now() - startedAt >= scrollRestorationDeadlineMs
 		if (applyWindowScroll(detail, target, isFinalAttempt) || isFinalAttempt) {
+			stopListening()
 			return
 		}
-		lastAppliedX = window.scrollX
-		lastAppliedY = window.scrollY
 		schedule(attempt)
 	}
 	schedule(attempt)

--- a/packages/worker/client/scroll-restoration.tsx
+++ b/packages/worker/client/scroll-restoration.tsx
@@ -85,8 +85,10 @@ function isRouterNavigationEvent(
 
 // Async route content (frames, deferred lists, images) can keep the document
 // too short to reach a saved scroll position right after navigation. Retry on
-// animation frames until the position becomes reachable or this deadline hits.
-const scrollRestorationDeadlineMs = 3_000
+// animation frames until the position becomes reachable or this deadline
+// hits. Generous on purpose: slow fetches must not strand the old scroll
+// position, and retries stop early on user scroll or the next navigation.
+const scrollRestorationDeadlineMs = 15_000
 
 function maxWindowScrollPosition(): ScrollPosition {
 	const root = document.documentElement

--- a/packages/worker/client/scroll-restoration.tsx
+++ b/packages/worker/client/scroll-restoration.tsx
@@ -6,6 +6,7 @@ import {
 	getScrollRestorationTarget,
 	type RouterNavigationEventDetail,
 	type ScrollPosition,
+	type ScrollRestorationTarget,
 } from './router-scroll-state.ts'
 
 const scrollPositionsSessionKey = 'kody:router-scroll-positions'
@@ -82,50 +83,50 @@ function isRouterNavigationEvent(
 	)
 }
 
-function scheduleScrollRestoration(
-	applyScroll: () => void,
-	signal: AbortSignal,
-) {
-	const requestId = ++restoreScrollRequestId
-	const run = () => {
-		if (signal.aborted || requestId !== restoreScrollRequestId) return
-		applyScroll()
+// Async route content (frames, deferred lists, images) can keep the document
+// too short to reach a saved scroll position right after navigation. Retry on
+// animation frames until the position becomes reachable or this deadline hits.
+const scrollRestorationDeadlineMs = 3_000
+
+function maxWindowScrollPosition(): ScrollPosition {
+	const root = document.documentElement
+	return {
+		x: Math.max(0, root.scrollWidth - window.innerWidth),
+		y: Math.max(0, root.scrollHeight - window.innerHeight),
 	}
-	if (typeof window.requestAnimationFrame === 'function') {
-		window.requestAnimationFrame(run)
-		return
-	}
-	window.setTimeout(run, 0)
 }
 
-function applyWindowScroll(detail: RouterNavigationEventDetail) {
-	const key = getCurrentScrollRestorationKey()
-	const target = getScrollRestorationTarget({
-		historyAction: detail.historyAction,
-		location: detail.location,
-		preventScrollReset: detail.preventScrollReset,
-		savedPosition: key ? savedScrollPositions.get(key) : null,
-	})
-
+function applyWindowScroll(
+	detail: RouterNavigationEventDetail,
+	target: ScrollRestorationTarget,
+	isFinalAttempt: boolean,
+): boolean {
 	switch (target.type) {
-		case 'position':
+		case 'position': {
 			window.scrollTo(target.position.x, target.position.y)
-			return
+			const max = maxWindowScrollPosition()
+			// Report failure while the document is still too short to reach the
+			// saved position so the caller retries once more content rendered.
+			return target.position.y <= max.y && target.position.x <= max.x
+		}
 		case 'hash': {
 			const element = getHashTarget(target.id)
 			if (element) {
 				element.scrollIntoView()
-				return
+				return true
 			}
-			if (detail.preventScrollReset) return
+			// The hash target may render asynchronously; retry until the deadline
+			// before falling back.
+			if (!isFinalAttempt) return false
+			if (detail.preventScrollReset) return true
 			window.scrollTo(0, 0)
-			return
+			return true
 		}
 		case 'preserve':
-			return
+			return true
 		case 'top':
 			window.scrollTo(0, 0)
-			return
+			return true
 		default: {
 			const exhaustive: never = target
 			return exhaustive
@@ -137,7 +138,43 @@ function restoreWindowScroll(
 	detail: RouterNavigationEventDetail,
 	signal: AbortSignal,
 ) {
-	scheduleScrollRestoration(() => applyWindowScroll(detail), signal)
+	const key = getCurrentScrollRestorationKey()
+	const target = getScrollRestorationTarget({
+		historyAction: detail.historyAction,
+		location: detail.location,
+		preventScrollReset: detail.preventScrollReset,
+		savedPosition: key ? savedScrollPositions.get(key) : null,
+	})
+	const requestId = ++restoreScrollRequestId
+	const startedAt = Date.now()
+	let lastAppliedX: number | null = null
+	let lastAppliedY: number | null = null
+	const schedule = (run: () => void) => {
+		if (typeof window.requestAnimationFrame === 'function') {
+			window.requestAnimationFrame(run)
+			return
+		}
+		window.setTimeout(run, 0)
+	}
+	const attempt = () => {
+		if (signal.aborted || requestId !== restoreScrollRequestId) return
+		// Stop retrying when something else (like the user) scrolled between
+		// attempts; restoration must never fight manual scrolling.
+		if (
+			lastAppliedY !== null &&
+			(window.scrollX !== lastAppliedX || window.scrollY !== lastAppliedY)
+		) {
+			return
+		}
+		const isFinalAttempt = Date.now() - startedAt >= scrollRestorationDeadlineMs
+		if (applyWindowScroll(detail, target, isFinalAttempt) || isFinalAttempt) {
+			return
+		}
+		lastAppliedX = window.scrollX
+		lastAppliedY = window.scrollY
+		schedule(attempt)
+	}
+	schedule(attempt)
 }
 
 function handleNavigationStart(event: Event) {

--- a/packages/worker/src/app/handlers/account-email-change.node.test.ts
+++ b/packages/worker/src/app/handlers/account-email-change.node.test.ts
@@ -11,6 +11,7 @@ import { verifyEmailChangeToken } from '#app/email-change.ts'
 import { hashVerificationToken } from '#app/email-verification.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { createAccountEmailChangeHandler } from './account-email-change.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
@@ -186,6 +187,9 @@ beforeAll(() => {
 })
 
 test('email change requests require the current password and create a pending verification', async () => {
+	// No email sender is configured in this test env, so the skipped
+	// verification send logs a warning.
+	consoleWarn.mockImplementation(() => {})
 	const { sqlite, db } = createMigratedDb()
 	await seedUser(sqlite, {
 		id: 1,
@@ -268,6 +272,7 @@ test('email change requests require the current password and create a pending ve
 		token_hash: expect.any(String),
 	})
 	expect(pendingRows[0]?.token_hash).not.toBe(firstPendingToken)
+	expect(consoleWarn).toHaveBeenCalledWith('email-change-send-skipped', 1)
 })
 
 test('email change requests reject emails already owned by another account', async () => {

--- a/packages/worker/src/app/handlers/account-resend-verification.node.test.ts
+++ b/packages/worker/src/app/handlers/account-resend-verification.node.test.ts
@@ -4,6 +4,10 @@ import {
 	setAuthSessionSecret,
 	type AuthSession,
 } from '#app/auth-session.ts'
+import {
+	consoleError,
+	consoleWarn,
+} from '#worker/test-support/console-spies.ts'
 import { createAccountResendVerificationHandler } from './account-resend-verification.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
@@ -156,6 +160,9 @@ test('resend verification requires an authenticated session', async () => {
 })
 
 test('resend verification issues a fresh token for unverified accounts and rate-limits repeats', async () => {
+	// No email sender is configured in this test env, so each resend logs
+	// a send-skipped warning.
+	consoleWarn.mockImplementation(() => {})
 	const testDb = createResendTestDb({ emailVerifiedAt: null })
 	const handler = createAccountResendVerificationHandler(
 		createAppEnv(testDb.db),
@@ -174,6 +181,10 @@ test('resend verification issues a fresh token for unverified accounts and rate-
 	}
 	expect(testDb.state.verificationInserts).toBe(3)
 	expect(testDb.state.verificationDeletes).toBe(3)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'email-verification-send-skipped',
+		expect.any(Number),
+	)
 
 	const rateLimitedResponse = await runHandler(
 		handler,
@@ -207,6 +218,8 @@ test('resend verification rejects already-verified accounts', async () => {
 })
 
 test('resend verification surfaces send failures without pretending success', async () => {
+	consoleError.mockImplementation(() => {})
+	consoleWarn.mockImplementation(() => {})
 	const testDb = createResendTestDb({ emailVerifiedAt: null })
 	const handler = createAccountResendVerificationHandler(
 		createAppEnv(testDb.db, {
@@ -237,5 +250,14 @@ test('resend verification surfaces send failures without pretending success', as
 	// net-new token remains and prior tokens stay untouched.
 	expect(testDb.state.verificationInserts).toBe(1)
 	expect(testDb.state.verificationDeletes).toBe(1)
+	expect(consoleError).toHaveBeenCalledWith(
+		expect.any(String),
+		expect.any(Error),
+	)
+	// The failed Cloudflare API send is warned for operators.
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'cloudflare-email-api-failed',
+		expect.any(String),
+	)
 	vi.unstubAllGlobals()
 })

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -3,6 +3,10 @@ import { RequestContext } from 'remix/router'
 import { setAuthSessionSecret } from '#app/auth-session.ts'
 import { createAuthHandler } from '#app/handlers/auth.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
+import {
+	consoleError,
+	consoleWarn,
+} from '#worker/test-support/console-spies.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -325,6 +329,9 @@ function stubCloudflareEmailFetch(
 }
 
 test('auth handler login and signup workflow', async () => {
+	// The signup context has no email sender configured, so the skipped
+	// verification send logs a warning in the non-production runtime.
+	consoleWarn.mockImplementation(() => {})
 	// Production signups must actually deliver the verification email, so
 	// the production context gets a (stubbed) configured Cloudflare sender.
 	const productionContext = createAuthTestContext({ emailConfigured: true })
@@ -413,6 +420,10 @@ test('auth handler login and signup workflow', async () => {
 	expect(signupContext.testDb.users.has('allowed@example.com')).toBe(true)
 	expect(signupContext.testDb.users.get('allowed@example.com')?.username).toBe(
 		'allowed-user',
+	)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'email-verification-send-skipped',
+		expect.any(Number),
 	)
 
 	await signupContext.testDb.addUser(
@@ -524,6 +535,8 @@ test('signup fails when the default user role cannot be assigned', async () => {
 })
 
 test('signup rolls back when the verification email cannot be sent', async () => {
+	consoleError.mockImplementation(() => {})
+	consoleWarn.mockImplementation(() => {})
 	const context = createAuthTestContext({
 		signupEnabled: true,
 		emailConfigured: true,
@@ -544,9 +557,22 @@ test('signup rolls back when the verification email cannot be sent', async () =>
 	expect(response.headers.get('Set-Cookie')).toBeNull()
 	// The created user row is rolled back so signup can be retried.
 	expect(context.testDb.users.has('undeliverable@example.com')).toBe(false)
+	// Only the verification failure is logged; the rollback delete succeeds.
+	expect(consoleError).toHaveBeenCalledTimes(1)
+	expect(consoleError).toHaveBeenCalledWith(
+		expect.any(String),
+		expect.any(Error),
+	)
+	// The failed Cloudflare API send is warned for operators.
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'cloudflare-email-api-failed',
+		expect.any(String),
+	)
 })
 
 test('production signup fails closed when no verification email sender is configured', async () => {
+	consoleError.mockImplementation(() => {})
+	consoleWarn.mockImplementation(() => {})
 	const context = createAuthTestContext()
 	context.testDb.addInvite('PROD-NO-EMAIL')
 
@@ -565,4 +591,13 @@ test('production signup fails closed when no verification email sender is config
 	expect(context.testDb.users.has('no-sender@example.com')).toBe(false)
 	// The consumed invite use is released so the invite can be retried.
 	expect(context.testDb.invites.get('PROD-NO-EMAIL')?.use_count).toBe(0)
+	expect(consoleError).toHaveBeenCalledWith(
+		expect.any(String),
+		expect.any(Error),
+	)
+	// The skipped send is warned with the unconfigured-sender tag.
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'cloudflare-email-unconfigured',
+		expect.any(String),
+	)
 })

--- a/packages/worker/src/app/handlers/community-icon.node.test.ts
+++ b/packages/worker/src/app/handlers/community-icon.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { consoleError } from '#worker/test-support/console-spies.ts'
 import { createCommunityIconHandler } from './community-icon.ts'
 import { type CommunityListingRecord } from '#worker/community/types.ts'
 
@@ -76,6 +77,7 @@ test('community icon handler serves cached R2 bytes for the pinned listing', asy
 })
 
 test('community icon handler rejects stale commit URLs and degrades to a safe fallback', async () => {
+	consoleError.mockImplementation(() => {})
 	mocks.getCommunityListingById.mockResolvedValue(listing)
 	expect((await callHandler('old-commit')).status).toBe(404)
 
@@ -89,4 +91,9 @@ test('community icon handler rejects stale commit URLs and degrades to a safe fa
 	)
 	expect(response.headers.get('Cache-Control')).toBe('no-store')
 	expect(await response.text()).toContain('<svg')
+	expect(consoleError).toHaveBeenCalledWith(
+		'community-icon-load-failed',
+		listing.id,
+		expect.any(Error),
+	)
 })

--- a/packages/worker/src/app/handlers/package-app.node.test.ts
+++ b/packages/worker/src/app/handlers/package-app.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { consoleError } from '#worker/test-support/console-spies.ts'
 
 const mockModule = vi.hoisted(() => ({
 	captureException: vi.fn(),
@@ -108,6 +109,7 @@ function resetMocks() {
 
 test('handlePackageAppRequest reports host setup failures with helpful responses and Sentry context', async () => {
 	resetMocks()
+	consoleError.mockImplementation(() => {})
 
 	const response = await handlePackageAppRequest(
 		new Request(
@@ -182,10 +184,17 @@ test('handlePackageAppRequest reports host setup failures with helpful responses
 		},
 		request_path: '/@test-user/packages/example/api/data',
 	})
+	// Both host-setup failures are logged for operators.
+	expect(consoleError).toHaveBeenCalledTimes(2)
+	expect(consoleError).toHaveBeenCalledWith(
+		expect.any(String),
+		expect.any(Error),
+	)
 })
 
 test('handlePackageAppRequest does not report package entrypoint failures to Kody Sentry', async () => {
 	resetMocks()
+	consoleError.mockImplementation(() => {})
 
 	mockModule.loadPackageManifestBySourceId.mockResolvedValueOnce({
 		source: {
@@ -216,6 +225,12 @@ test('handlePackageAppRequest does not report package entrypoint failures to Kod
 
 	expect(response.status).toBe(500)
 	expect(mockModule.captureException).not.toHaveBeenCalled()
+	// The entrypoint failure is still logged even though it is not
+	// reported to Kody Sentry.
+	expect(consoleError).toHaveBeenCalledWith(
+		expect.any(String),
+		expect.any(Error),
+	)
 })
 
 test('handlePackageAppRequest routes websocket package paths to realtime session manager', async () => {

--- a/packages/worker/src/app/retention.node.test.ts
+++ b/packages/worker/src/app/retention.node.test.ts
@@ -27,6 +27,7 @@ import {
 	workflowRunRetentionDays,
 } from './retention.ts'
 import { systemEmailOwnerId } from '#worker/email/system-email.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 function applyMigrations(db: DatabaseSync) {
 	const migrationsDir = new URL('../../migrations/', import.meta.url)
@@ -795,6 +796,7 @@ test('email message retention deletes old user rows, R2 blobs, attachments, and 
 })
 
 test('email message retention never deletes rows whose blob cannot be deleted first', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const { sqlite, db } = createRetentionDb()
 	insertEmailMessage(sqlite, {
 		id: 'msg-old-blob',
@@ -819,6 +821,10 @@ test('email message retention never deletes rows whose blob cannot be deleted fi
 		deletedRawMimeBlobs: 0,
 		blobDeleteErrors: 1,
 	})
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'retention-email-blob-delete-failed',
+		{ error: expect.any(Error) },
+	)
 	expect(idsForTable(sqlite, 'email_messages')).toEqual(['msg-old-blob'])
 
 	const workingDelete = vi.fn(async () => undefined)
@@ -835,6 +841,8 @@ test('email message retention never deletes rows whose blob cannot be deleted fi
 })
 
 test('email message retention cursor advances past skipped blob rows at the head', async () => {
+	// Failed blob deletes are already counted via blobDeleteErrors below.
+	consoleWarn.mockImplementation(() => {})
 	const { sqlite, db } = createRetentionDb()
 	// The two oldest expired rows are blob-backed and unpassable while the
 	// R2 delete fails; the two plain expired rows behind them must still be
@@ -909,6 +917,8 @@ test('email message retention cursor advances past skipped blob rows at the head
 })
 
 test('retention run prunes expired plain emails behind a skipped blob-row head', async () => {
+	// Failed blob deletes are already counted via blobDeleteErrors below.
+	consoleWarn.mockImplementation(() => {})
 	const { sqlite, db } = createRetentionDb()
 	// 251 blob-backed rows fill the first default-size batch and spill into the
 	// second; 5 plain expired rows sit behind them.

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -19,6 +19,7 @@ import { createForwardableEmailMessage } from './test-fixtures.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
 import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
 import { buildPublishedSourceManifestSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 
 const platformBaseUrl = 'https://kody.example.com'
@@ -64,6 +65,9 @@ async function seedVerifiedAccount(input: {
 }
 
 test('inbound email routes {username}@platform-domain and auto-provisions the default inbox', async () => {
+	// Usage recording degrades with a warn when the usage_rollups table is
+	// not part of this test's schema; that is incidental to routing.
+	consoleWarn.mockImplementation(() => {})
 	await ensureEmailTestSchema(env.APP_DB)
 	const username = `inbound-${crypto.randomUUID().slice(0, 8)}`
 	const accountEmail = `account-${crypto.randomUUID()}@example.com`
@@ -219,6 +223,9 @@ test('inbound email routes {username}@platform-domain and auto-provisions the de
 })
 
 test('inbound email rejects unknown usernames, reserved locals, and foreign domains', async () => {
+	// Usage recording degrades with a warn when the usage_rollups table is
+	// not part of this test's schema; that is incidental to rejection.
+	consoleWarn.mockImplementation(() => {})
 	await ensureEmailTestSchema(env.APP_DB)
 
 	async function expectRejected(input: { to: string; reason: string }) {
@@ -383,6 +390,9 @@ test('inbound email rejects unknown usernames, reserved locals, and foreign doma
 })
 
 test('inbound email reclaims a platform address left behind by a username change', async () => {
+	// Usage recording degrades with a warn when the usage_rollups table is
+	// not part of this test's schema; that is incidental to reclaiming.
+	consoleWarn.mockImplementation(() => {})
 	await ensureEmailTestSchema(env.APP_DB)
 	const username = `recycled-${crypto.randomUUID().slice(0, 8)}`
 	const address = `${username}@${platformDomain}`
@@ -782,6 +792,9 @@ test('raw MIME stays inline when the R2 put fails', async () => {
 })
 
 test('inbound email handler dispatches package subscriptions for stored inbound email', async () => {
+	// The subscription runtime warns on optional lookups (usage rollups, MCP
+	// server refs) whose tables are not part of this test's schema.
+	consoleWarn.mockImplementation(() => {})
 	await ensureEmailTestSchema(env.APP_DB)
 	const username = `subscriber-${crypto.randomUUID().slice(0, 8)}`
 	const accountEmail = `email-subscription-user-${crypto.randomUUID()}@example.com`

--- a/packages/worker/src/email/outbound.workers.test.ts
+++ b/packages/worker/src/email/outbound.workers.test.ts
@@ -16,6 +16,7 @@ import {
 	maxOutboundEmailAttachmentTotalBytes,
 	sendOutboundEmail,
 } from './outbound.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { createMswNodeServer } from '#worker/test-support/msw-node-server.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import {
@@ -112,6 +113,9 @@ function restFallbackMustNotRunHandler() {
 }
 
 test('sendOutboundEmail sends from the platform-assigned username address to the account email', async () => {
+	// Usage recording degrades with a warn when the usage_rollups table is
+	// not part of this test's schema; that is incidental to sending.
+	consoleWarn.mockImplementation(() => {})
 	await ensureEmailTestSchema(env.APP_DB)
 	const accountEmail = `account-${crypto.randomUUID()}@example.com`
 	const userId = await createStableUserIdFromEmail(accountEmail)
@@ -187,6 +191,9 @@ test('sendOutboundEmail sends from the platform-assigned username address to the
 })
 
 test('sendOutboundEmail rejects non-self recipients under the self policy', async () => {
+	// Usage recording degrades with a warn when the usage_rollups table is
+	// not part of this test's schema; that is incidental to the policy.
+	consoleWarn.mockImplementation(() => {})
 	await ensureEmailTestSchema(env.APP_DB)
 	const accountEmail = `account-${crypto.randomUUID()}@example.com`
 	const userId = await createStableUserIdFromEmail(accountEmail)
@@ -273,6 +280,9 @@ test('sendOutboundEmail blocks reserved usernames and unconfigured platform doma
 })
 
 test('sendOutboundEmail skips REST fallback when the binding succeeds or validation fails first', async () => {
+	// Usage recording degrades with a warn when the usage_rollups table is
+	// not part of this test's schema; that is incidental to the fallback.
+	consoleWarn.mockImplementation(() => {})
 	await ensureEmailTestSchema(env.APP_DB)
 	const mswOptions = { onUnhandledRequest: 'bypass' as const }
 
@@ -372,6 +382,7 @@ test('sendOutboundEmail blocks unverified accounts', async () => {
 })
 
 test('sendOutboundEmail preserves reply headers and records failed fallback sends', async () => {
+	consoleWarn.mockImplementation(() => {})
 	await ensureEmailTestSchema(env.APP_DB)
 	await ensureUsageRollupsTestSchema(env.APP_DB)
 	const isolatedUserId = `email-outbound-isolated-user-${crypto.randomUUID()}`
@@ -455,6 +466,11 @@ test('sendOutboundEmail preserves reply headers and records failed fallback send
 
 	expect(result.status).toBe('failed')
 	expect(result.error).toBe('provider down')
+	// The failed REST fallback is warned for operators.
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'cloudflare-email-api-failed',
+		expect.any(String),
+	)
 	// The recipient is always derived from the stored inbound message.
 	expect(result.message.toAddresses).toEqual(['recipient@example.com'])
 	expect(fetchCalls).toHaveLength(1)

--- a/packages/worker/src/email/system-email-subscriptions.workers.test.ts
+++ b/packages/worker/src/email/system-email-subscriptions.workers.test.ts
@@ -7,6 +7,7 @@ import { createForwardableEmailMessage } from './test-fixtures.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
 import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
 import { buildPublishedSourceManifestSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 
 const platformBaseUrl = 'https://kody.example.com'
@@ -250,6 +251,9 @@ export default async function main(input = {}) {
 }
 
 test('system inbound email dispatches email.system-message.received to admin-saved packages only', async () => {
+	// The subscription runtime warns on optional lookups (e.g. MCP server
+	// refs) whose tables are not part of this test's schema.
+	consoleWarn.mockImplementation(() => {})
 	await ensureEmailTestSchema(env.APP_DB)
 	await ensureUsageRollupsTestSchema(env.APP_DB)
 	await ensurePackageSubscriptionTestSchema(env.APP_DB)

--- a/packages/worker/src/email/system-email.workers.test.ts
+++ b/packages/worker/src/email/system-email.workers.test.ts
@@ -13,6 +13,7 @@ import {
 } from './system-email.ts'
 import { createForwardableEmailMessage } from './test-fixtures.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 
@@ -337,6 +338,7 @@ test('system email retention prunes old operator-owned messages and counters', a
 })
 
 test('system email retention deletes blobs before rows and keeps rows when the blob delete fails', async () => {
+	consoleWarn.mockImplementation(() => {})
 	await ensureEmailTestSchema(env.APP_DB)
 	const now = new Date('2026-07-06T12:00:00.000Z')
 	const old = new Date(
@@ -378,6 +380,11 @@ test('system email retention deletes blobs before rows and keeps rows when the b
 		now,
 	})
 
+	// The simulated outage is warned for operators.
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'system-email-raw-mime-blob-delete-failed',
+		expect.any(Error),
+	)
 	// The blob-backed row survives the failed blob delete; only the plain row
 	// is pruned, and the blob is still readable for the retry.
 	expect(failed.deletedMessages).toBe(1)
@@ -413,6 +420,7 @@ test('system email retention deletes blobs before rows and keeps rows when the b
 })
 
 test('system email retention advances past skipped blob rows at the head of a batch', async () => {
+	consoleWarn.mockImplementation(() => {})
 	await ensureEmailTestSchema(env.APP_DB)
 	const now = new Date('2026-07-06T12:00:00.000Z')
 	const oldMs =
@@ -486,6 +494,11 @@ test('system email retention advances past skipped blob rows at the head of a ba
 
 	expect(result.blobDeleteErrors).toBe(blockedCount)
 	expect(result.deletedMessages).toBe(plainCount)
+	// The simulated outage is warned for operators.
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'system-email-raw-mime-blob-delete-failed',
+		expect.any(Error),
+	)
 	const remainingPlain = await env.APP_DB.prepare(
 		`SELECT COUNT(*) AS count FROM email_messages WHERE id LIKE 'head-plain-%'`,
 	).first<{ count: number }>()

--- a/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
+++ b/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 const mockModule = vi.hoisted(() => ({
 	listEntitySourcesForExternalReconcile: vi.fn(),
@@ -132,6 +133,7 @@ test('publishes changed Artifacts HEADs and records reconcile checks', async () 
 })
 
 test('reconcile records source checks and continues the batch when a source or its check write fails', async () => {
+	consoleWarn.mockImplementation(() => {})
 	mockModule.listEntitySourcesForExternalReconcile.mockResolvedValue([source()])
 	mockModule.resolveArtifactSourceHead.mockRejectedValueOnce(new Error('boom'))
 
@@ -142,6 +144,10 @@ test('reconcile records source checks and continues the batch when a source or i
 	})
 
 	expect(singleFailure.errors).toBe(1)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'reconcile_artifacts_pushes source failed',
+		expect.objectContaining({ sourceId: 'source-1' }),
+	)
 	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
 		expect.anything(),
 		{
@@ -188,9 +194,14 @@ test('reconcile records source checks and continues the batch when a source or i
 		budgetExhausted: false,
 	})
 	expect(mockModule.resolveArtifactSourceHead).toHaveBeenCalledTimes(2)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'reconcile_artifacts_pushes cursor update failed',
+		expect.objectContaining({ sourceId: 'source-1' }),
+	)
 })
 
 test('reconcile runs token cleanup in the 03:00 UTC window without blocking publish on cleanup failure', async () => {
+	consoleWarn.mockImplementation(() => {})
 	mockModule.listEntitySourcesForExternalReconcile.mockResolvedValue([source()])
 	mockModule.resolveArtifactSourceHead.mockResolvedValue({
 		branch: 'main',
@@ -242,6 +253,10 @@ test('reconcile runs token cleanup in the 03:00 UTC window without blocking publ
 			errors: 0,
 			tokenCleanupErrors: 1,
 		}),
+	)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'reconcile_artifacts_pushes token cleanup failed',
+		expect.objectContaining({ sourceId: 'source-1' }),
 	)
 	expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(1)
 })
@@ -331,6 +346,7 @@ test('reconcile stops between items once the time budget is exhausted', async ()
 })
 
 test('reconcile does not reprocess a source whose cursor write keeps failing', async () => {
+	consoleWarn.mockImplementation(() => {})
 	mockModule.listEntitySourcesForExternalReconcile.mockReset()
 	mockModule.listEntitySourcesForExternalReconcile.mockResolvedValue([
 		source({ id: 'source-1', published_commit: 'commit-current' }),
@@ -363,12 +379,19 @@ test('reconcile does not reprocess a source whose cursor write keeps failing', a
 	expect(
 		mockModule.listEntitySourcesForExternalReconcile,
 	).toHaveBeenCalledTimes(2)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'reconcile_artifacts_pushes cursor update failed',
+		expect.objectContaining({ sourceId: 'source-1' }),
+	)
 
 	mockModule.updateEntitySource.mockReset()
 	mockModule.updateEntitySource.mockResolvedValue(true)
 })
 
 test('head sources with failing cursor writes do not starve sources behind them within a tick', async () => {
+	// Cursor-write failure warns are covered elsewhere; this test is about
+	// keyset paging, so the warns are silenced without assertions.
+	consoleWarn.mockImplementation(() => {})
 	// Simulated table: two head-of-queue sources whose cursor writes keep
 	// failing, plus one healthy source ordered behind them.
 	const rows = [

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi, afterEach } from 'vitest'
 import { createMcpCallerContext } from '#mcp/context.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { planLimits } from '#worker/entitlements/plans.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
@@ -1702,6 +1703,8 @@ test('getJobInspection reports alarm state, source code, and artifact gaps', asy
 })
 
 test('executeJobOnce binds scheduled jobs to writable storage', async () => {
+	// Usage rollup writes are best-effort and fail against this fake env.
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	const env = {
 		APP_DB: db,
@@ -1884,6 +1887,7 @@ test('executeJobOnce binds scheduled jobs to writable storage', async () => {
 })
 
 test('executeJobOnce runs repo-backed one-off jobs from kody.json manifests', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	const env = {
 		APP_DB: db,
@@ -2082,6 +2086,7 @@ test('executeJobOnce runs repo-backed one-off jobs from kody.json manifests', as
 })
 
 test('executeJobOnce preserves kody secret and value semantics', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	const env = {
@@ -2258,6 +2263,7 @@ test('executeJobOnce preserves kody secret and value semantics', async () => {
 })
 
 test('executeJobOnce refreshes repo sessions when base commit moves', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -2428,6 +2434,7 @@ test('executeJobOnce refreshes repo sessions when base commit moves', async () =
 })
 
 test('executeJobOnce rebuilds stale published job bundles after the source commit changes', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -2567,6 +2574,7 @@ test('executeJobOnce rebuilds stale published job bundles after the source commi
 })
 
 test('executeJobOnce executes package-backed jobs from published artifacts', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -2695,6 +2703,7 @@ test('executeJobOnce executes package-backed jobs from published artifacts', asy
 })
 
 test('executeJobOnce bypasses typecheck-only failures when the stored repo policy allows it', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -2851,6 +2860,7 @@ test('executeJobOnce bypasses typecheck-only failures when the stored repo polic
 })
 
 test('executeJobOnce preserves bypass audit logs when execution fails after a typecheck-only bypass', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -3010,6 +3020,7 @@ test('executeJobOnce preserves bypass audit logs when execution fails after a ty
 })
 
 test('executeJobOnce succeeds for repo-backed jobs with repo-session absolute paths and migrated entrypoints', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -3191,6 +3202,7 @@ test('executeJobOnce succeeds for repo-backed jobs with repo-session absolute pa
 })
 
 test('executeJobOnce fails instead of reusing a stale repo session when discard fails', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -3295,6 +3307,7 @@ test('executeJobOnce fails instead of reusing a stale repo session when discard 
 })
 
 test('executeJobOnce bundles and runs ESM repo-backed job entrypoints', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -3496,6 +3509,7 @@ test('executeJobOnce bundles and runs ESM repo-backed job entrypoints', async ()
 })
 
 test('executeJobOnce returns an error when kody secret policy would reject execution', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -3643,6 +3657,7 @@ test('executeJobOnce returns an error when kody secret policy would reject execu
 })
 
 test('runJobNow deletes vectors for once jobs', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	const env = {
@@ -3789,6 +3804,7 @@ test('runJobNow deletes vectors for once jobs', async () => {
 })
 
 test('runJobNow can use a one-off repo check policy override without changing the stored job', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const db = createDatabase()
 	await insertPublishedEntitySource({
 		db,

--- a/packages/worker/src/maintenance-handler.node.test.ts
+++ b/packages/worker/src/maintenance-handler.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import {
 	backfillStableUserIds,
 	handleSecretMaintenanceRequest,
@@ -176,6 +177,7 @@ test('backfillStableUserIds pages with a keyset and only touches NULL rows', asy
 })
 
 test('backfillStableUserIds counts per-row failures without aborting', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const { db, users } = createBackfillTestDb({
 		users: [
 			{ id: 1, email: 'ok@example.com', stable_user_id: null },
@@ -190,6 +192,11 @@ test('backfillStableUserIds counts per-row failures without aborting', async () 
 	expect(result).toEqual({ scanned: 3, backfilled: 2, failed: 1 })
 	expect(users[1]?.stable_user_id).toBeNull()
 	expect(users[2]?.stable_user_id).not.toBeNull()
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'stable-user-id-backfill-row-failed',
+		2,
+		expect.any(Error),
+	)
 })
 
 test('handleStableUserIdBackfillRequest enforces the maintenance auth pattern', async () => {

--- a/packages/worker/src/mcp-auth.workers.test.ts
+++ b/packages/worker/src/mcp-auth.workers.test.ts
@@ -12,6 +12,7 @@ import {
 } from './mcp-auth.ts'
 import { oauthScopes } from './oauth-handlers.ts'
 import { createStableUserIdFromEmail } from './user-id.ts'
+import { consoleError } from '#worker/test-support/console-spies.ts'
 
 function expectAuthenticateHeader(
 	header: string,
@@ -272,6 +273,9 @@ test('mcp request enforces token audience and forwards caller props', async () =
 		remoteConnectors: [{ instanceId: 'home' }],
 	})
 
+	// The failing D1 lookup logs the roles-load failure before the request
+	// rethrows the underlying error.
+	consoleError.mockImplementation(() => {})
 	const appDbUnavailable = {
 		prepare: () => {
 			throw new Error('D1 unavailable')
@@ -293,6 +297,10 @@ test('mcp request enforces token audience and forwards caller props', async () =
 			},
 		}),
 	).rejects.toThrow('D1 unavailable')
+	expect(consoleError).toHaveBeenCalledWith(
+		'Failed to load roles for MCP user context:',
+		expect.any(Error),
+	)
 })
 
 test('mcp request rejects unverified and unidentifiable accounts fail-closed', async () => {

--- a/packages/worker/src/mcp/capabilities/integrations/integration-registry-search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-registry-search.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import { http, HttpResponse } from 'msw'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { createMswNodeServer } from '#worker/test-support/msw-node-server.ts'
 import {
 	buildIntegrationRegistrySearchUrlForTest,
@@ -41,6 +42,9 @@ const searchFixture = {
 }
 
 test('integration_registry_search returns parsed results and rejects upstream failures', async () => {
+	// msw warns about the query string in the handler URL; that tooling
+	// notice is incidental to the capability behavior under test.
+	consoleWarn.mockImplementation(() => {})
 	const url = buildIntegrationRegistrySearchUrlForTest('linear')
 	using _successServer = createMswNodeServer([
 		http.get(url, () => HttpResponse.json(searchFixture)),

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 const mockModule = vi.hoisted(() => ({
 	captureException: vi.fn(),
@@ -413,6 +414,7 @@ test('force publish passes destructive confirmation through and refuses without 
 })
 
 test('publishExternalPush recovers from transient Durable Object resets', async () => {
+	consoleWarn.mockImplementation(() => {})
 	setupDefaultMocks()
 	mockModule.resolveArtifactSourceHead.mockResolvedValue({
 		branch: 'main',
@@ -457,6 +459,8 @@ test('publishExternalPush recovers from transient Durable Object resets', async 
 			},
 		}),
 	)
+	// Each transient reset leaves exactly one retry warn trail.
+	expect(consoleWarn).toHaveBeenCalledTimes(1)
 
 	setupDefaultMocks()
 	mockModule.getEntitySourceById

--- a/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
+++ b/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from 'vitest'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
 import { buildKodyModuleBundle } from '#worker/package-runtime/module-graph.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 /**
  * Regression coverage for the production "RPC stub used after being
@@ -42,6 +43,8 @@ test(
 	'sequential executes with identical code reuse the dynamic worker without stale dispatcher stubs',
 	{ timeout: 60_000 },
 	async () => {
+		// The worker bundler emits an incidental experimental warning.
+		consoleWarn.mockImplementation(() => {})
 		const bundle = await buildKodyModuleBundle({
 			env: reuseEnv,
 			baseUrl: 'https://kody.dev',

--- a/packages/worker/src/mcp/observability.workers.test.ts
+++ b/packages/worker/src/mcp/observability.workers.test.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest'
 import { capabilityMap } from '#mcp/capabilities/registry.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { errorFields, logMcpEvent } from '#mcp/observability.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 const repoMockModule = vi.hoisted(() => ({
 	ensureEntitySource: vi.fn(),
@@ -129,6 +130,9 @@ test('observability helpers normalize errors and emit resilient mcp-event logs',
 })
 
 test('package_save logs parse failures, rejects invalid manifests, and logs successful saves', async () => {
+	// The worker bundler emits an incidental experimental warning during the
+	// successful save's artifact rebuild.
+	consoleWarn.mockImplementation(() => {})
 	const originalInfo = console.info
 	const payloads: Array<string> = []
 	console.info = ((tag: unknown, json?: unknown) => {

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { type getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
 import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
@@ -24,6 +25,9 @@ import {
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 
 test('buildKodyFns rejects role-gated capabilities even when passed an unfiltered registry', async () => {
+	// The stub Env has no MCP server storage, so metadata loading warns
+	// 'mcp-server-refs-load-failed' before degrading to "no MCP servers".
+	consoleWarn.mockImplementation(() => {})
 	const adminOnlyCapability = defineDomainCapability('admin', {
 		name: 'admin_user_list',
 		description: 'List admin user account metadata',
@@ -63,6 +67,7 @@ test('buildKodyFns rejects role-gated capabilities even when passed an unfiltere
 })
 
 test('package workflow tools create instances from package context and honor caller overrides in runModuleWithRegistry', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const created: Array<WorkflowInstanceCreateOptions<unknown>> = []
 	const workflowTools = createWorkflowTools({
 		env: {
@@ -221,6 +226,7 @@ export default async function run() {
 })
 
 test('runModuleWithRegistry queues inline workflows.create calls without runAt or idempotencyKey', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const created: Array<WorkflowInstanceCreateOptions<unknown>> = []
 	const env = {
 		APP_DB: {
@@ -643,6 +649,7 @@ function createRepoSessionRow(input: {
 }
 
 test('buildKodyFns updates and deletes jobs through production-shaped bindings', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
 		user: {
@@ -819,6 +826,7 @@ test('buildKodyFns updates and deletes jobs through production-shaped bindings',
 })
 
 test('buildKodyFns resolves, denies, and tracks secret-marked capability inputs', async () => {
+	consoleWarn.mockImplementation(() => {})
 	let toolArguments: Record<string, unknown> | null = null
 	const connectorEnv = {
 		REMOTE_CONNECTOR_SESSION: {
@@ -1049,6 +1057,7 @@ test('buildKodyFns resolves, denies, and tracks secret-marked capability inputs'
 })
 
 test('remote connector calls round-trip through sanitized ToolDispatcher names', async () => {
+	consoleWarn.mockImplementation(() => {})
 	let toolArguments: Record<string, unknown> | null = null
 	const connectorEnv = {
 		REMOTE_CONNECTOR_SESSION: {
@@ -1130,6 +1139,7 @@ test('remote connector calls round-trip through sanitized ToolDispatcher names',
 })
 
 test('buildKodyFns rejects storage kody tools that collide with capabilities', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const env = {
 		STORAGE_RUNNER: {
 			idFromName(name: string) {
@@ -1229,6 +1239,7 @@ test('buildKodyFns rejects storage kody tools that collide with capabilities', a
 })
 
 test('runKodyWithRegistry redacts secret keys and survives cyclic results', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -1399,6 +1410,7 @@ export default async function run() {
 })
 
 test('runKodyWithRegistry routes module and snippet inputs through the expected execution path', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -1516,6 +1528,7 @@ export default async function run() {
 })
 
 test('runKodyWithRegistry forwards package context for module syntax', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -1627,6 +1640,7 @@ export default async function run() {
 })
 
 test('runBundledModuleWithRegistry passes params and injects runtime helpers', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const created: Array<WorkflowInstanceCreateOptions<unknown>> = []
 	const workflowEnv = {
 		APP_DB: {
@@ -2016,6 +2030,7 @@ test('runBundledModuleWithRegistry passes params and injects runtime helpers', a
 })
 
 test('runBundledModuleWithRegistry uses a prebuilt capability registry without reloading', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -2072,6 +2087,7 @@ test('runBundledModuleWithRegistry uses a prebuilt capability registry without r
 })
 
 test('runBundledModuleWithRegistry records package_export usage for bundled runs with package context', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -2237,6 +2253,7 @@ test('runBundledModuleWithRegistry records package_export usage for bundled runs
 })
 
 test('runBundledModuleWithRegistry omits OAuth helper prelude when execute helper capabilities are absent', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -2283,6 +2300,7 @@ test('runBundledModuleWithRegistry omits OAuth helper prelude when execute helpe
 })
 
 test('runBundledModuleWithRegistry injects OAuth helper prelude when execute helper capabilities are present', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -2331,6 +2349,7 @@ test('runBundledModuleWithRegistry injects OAuth helper prelude when execute hel
 })
 
 test('runKodyWithRegistry expression path omits OAuth helper prelude without execute helper capabilities', async () => {
+	consoleWarn.mockImplementation(() => {})
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
 import {
 	CAPABILITY_EMBEDDING_DIMENSIONS,
@@ -766,6 +767,7 @@ export declare function traceProcessorFailure(messageId: string): Promise<void>
 	expect(sourceMocks.loadPackageSourceBySourceId).toHaveBeenCalledTimes(1)
 
 	// Hydration failures degrade to the lean match instead of failing search.
+	consoleWarn.mockImplementation(() => {})
 	sourceMocks.loadPackageSourceBySourceId.mockRejectedValueOnce(
 		new Error('missing-source'),
 	)
@@ -808,6 +810,10 @@ export declare function traceProcessorFailure(messageId: string): Promise<void>
 				readmeSnippet: null,
 			}),
 		]),
+	)
+	// The degraded path leaves a hydration-failure trail for the package.
+	expect(consoleWarn).toHaveBeenCalledWith(
+		expect.stringContaining('package-123'),
 	)
 })
 
@@ -899,6 +905,7 @@ test('searchUnified ranks packages via user-filtered package vectors when Vector
 })
 
 test('searchUnified degrades to lexical package ranking when the vector query throws', async () => {
+	consoleWarn.mockImplementation(() => {})
 	let packageVectorQueryAttempts = 0
 	const env = {
 		SENTRY_ENVIRONMENT: 'production',
@@ -968,6 +975,10 @@ test('searchUnified degrades to lexical package ranking when the vector query th
 			(match) => match.type === 'package' && match.packageId === 'pkg-inbox',
 		),
 	).toBe(true)
+	// The degradation leaves a warn trail carrying the vector failure.
+	expect(consoleWarn).toHaveBeenCalledWith(
+		expect.stringContaining('vectorize unavailable'),
+	)
 })
 
 test('down remote connector statuses surface only disconnected connectors for signed-in users', async () => {

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest'
 import { createMcpCallerContext } from '#mcp/context.ts'
+import { consoleError } from '#worker/test-support/console-spies.ts'
 import {
 	createExecutePackageInvokeTools,
 	createPackageRuntimeInvokeTools,
@@ -1477,6 +1478,7 @@ test('invokePackageExport enforces idempotency replay, mismatch, corruption, and
 
 	const failingDb = createDatabase({ failInsert: true })
 	seedPackageResolution()
+	consoleError.mockImplementation(() => {})
 	const persistenceFailure = await invokePackageExport({
 		env: createEnv(failingDb),
 		baseUrl: 'https://kody.dev',
@@ -1502,6 +1504,10 @@ test('invokePackageExport enforces idempotency replay, mismatch, corruption, and
 			replayed: false,
 		},
 	})
+	expect(consoleError).toHaveBeenCalledWith(
+		'package invocation idempotency persistence failed',
+		expect.any(Error),
+	)
 })
 
 test('invokePackageExport enforces source scopes for wildcard tokens', async () => {

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -1,4 +1,8 @@
 import { expect, test, vi } from 'vitest'
+import {
+	consoleError,
+	consoleWarn,
+} from '#worker/test-support/console-spies.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { planLimits } from '#worker/entitlements/plans.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
@@ -344,6 +348,7 @@ test('refreshSavedPackageProjection omits files when artifact rebuild is skipped
 })
 
 test('refreshSavedPackageProjection continues best-effort cleanup when dependent steps fail', async () => {
+	consoleError.mockImplementation(() => {})
 	setupDefaultMocks()
 	const manifest = {
 		name: '@kentcdodds/shade-automation',
@@ -402,6 +407,8 @@ test('refreshSavedPackageProjection continues best-effort cleanup when dependent
 		env: envAfterRetrieverFailure,
 		userId: 'user-1',
 	})
+	// The swallowed retriever-cache failure is still logged for operators.
+	expect(consoleError).toHaveBeenCalledTimes(1)
 
 	setupDefaultMocks()
 	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
@@ -536,6 +543,8 @@ test('deleteSavedPackageProjection resyncs the job manager after removing packag
 })
 
 test('deleteSavedPackageProjection continues best-effort cleanup when dependent steps fail', async () => {
+	consoleError.mockImplementation(() => {})
+	consoleWarn.mockImplementation(() => {})
 	setupDefaultMocks()
 	const env = createEnv()
 	mockModule.getSavedPackageById.mockResolvedValue({
@@ -567,6 +576,8 @@ test('deleteSavedPackageProjection continues best-effort cleanup when dependent 
 		env,
 		userId: 'user-1',
 	})
+	// The swallowed entity source cleanup failure is still logged.
+	expect(consoleWarn).toHaveBeenCalledTimes(1)
 
 	setupDefaultMocks()
 	mockModule.getSavedPackageById.mockResolvedValue({

--- a/packages/worker/src/package-runtime/module-graph.workers.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.workers.test.ts
@@ -9,6 +9,14 @@ import {
 } from './module-graph.ts'
 import { persistPublishedSourceSnapshot } from './published-runtime-artifacts.ts'
 import { persistPublishedBundleArtifact } from './published-bundle-artifacts.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
+
+// Every test here runs the bundler (incidental experimental warning) and the
+// registry runtime, whose optional MCP-server and usage lookups warn when
+// their tables are absent from the test schema.
+function silenceIncidentalRuntimeWarnings() {
+	consoleWarn.mockImplementation(() => {})
+}
 
 async function runSql(sql: string, ...values: Array<unknown>) {
 	await env.APP_DB.prepare(sql)
@@ -122,6 +130,7 @@ test(
 	'saved package bundles and executes npm dependencies declared in package.json',
 	{ timeout: 20_000 },
 	async () => {
+		silenceIncidentalRuntimeWarnings()
 		const packageJson = JSON.stringify({
 			name: '@kentcdodds/dependency-package',
 			exports: {
@@ -191,6 +200,7 @@ test(
 )
 
 test('worker bundler executes the wrapper when multiple package artifact defaults are imported', async () => {
+	silenceIncidentalRuntimeWarnings()
 	const bundle = await createWorker({
 		files: {
 			'.__kody_root__/.__kody_execute_entry__.js': [
@@ -279,6 +289,7 @@ test('worker bundler executes the wrapper when multiple package artifact default
 })
 
 test('saved package artifact imports keep the execute wrapper as the runtime entrypoint', async () => {
+	silenceIncidentalRuntimeWarnings()
 	await ensureSavedPackageArtifactSchema()
 	const unique = crypto.randomUUID()
 	const userId = `user-${unique}`
@@ -433,6 +444,7 @@ test('saved package artifact imports keep the execute wrapper as the runtime ent
 })
 
 test('subscription bundles refresh stale nested runtime modules from static package dependencies', async () => {
+	silenceIncidentalRuntimeWarnings()
 	const nestedRuntimeModule =
 		'.__kody_packages__/@kentcdodds/ai-chat/.__published_bundle__/2e/.__kody_virtual__/runtime.js'
 	const result = await runBundledModuleWithRegistry(
@@ -497,6 +509,7 @@ test('subscription bundles refresh stale nested runtime modules from static pack
 })
 
 test('saved package execution passes input as the default export argument', async () => {
+	silenceIncidentalRuntimeWarnings()
 	const packageJson = JSON.stringify({
 		name: '@kentcdodds/input-package',
 		exports: {
@@ -550,6 +563,7 @@ test('saved package execution passes input as the default export argument', asyn
 })
 
 test('saved package execution exposes packages.invoke when package invoke tools are provided', async () => {
+	silenceIncidentalRuntimeWarnings()
 	const packageJson = JSON.stringify({
 		name: '@kentcdodds/invoker-package',
 		exports: {
@@ -682,6 +696,7 @@ test('saved package execution exposes packages.invoke when package invoke tools 
 })
 
 test('ad hoc execute runtime exposes packages.invoke when package invoke tools are provided', async () => {
+	silenceIncidentalRuntimeWarnings()
 	const bundle = await buildKodyModuleBundle({
 		env,
 		baseUrl: 'https://kody.dev',
@@ -795,6 +810,7 @@ test('ad hoc execute runtime exposes packages.invoke when package invoke tools a
 })
 
 test('ad hoc execute runtime exposes packages as null without package invoke tools', async () => {
+	silenceIncidentalRuntimeWarnings()
 	const bundle = await buildKodyModuleBundle({
 		env,
 		baseUrl: 'https://kody.dev',

--- a/packages/worker/src/package-runtime/package-runtime-debug.node.test.ts
+++ b/packages/worker/src/package-runtime/package-runtime-debug.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import {
 	beginPackageRuntimeRun,
 	finishPackageRuntimeRun,
@@ -299,6 +300,7 @@ test('package runtime debug records runs, enforces log limits, and surfaces erro
 		message: 'line-204',
 	})
 
+	consoleWarn.mockImplementation(() => {})
 	const failingLogEnv = {
 		APP_DB: createDebugDatabase({ failLogInsert: true }),
 	} as Env
@@ -332,4 +334,8 @@ test('package runtime debug records runs, enforces log limits, and surfaces erro
 		runId: logFailureRun?.id ?? '',
 	})
 	expect(loadedAfterLogFailure?.logs).toEqual([])
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'package-runtime-debug-logs-failed',
+		expect.any(Error),
+	)
 })

--- a/packages/worker/src/remote-connector/session.node.test.ts
+++ b/packages/worker/src/remote-connector/session.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 const captureMessageMock = vi.fn()
 
@@ -95,6 +96,9 @@ async function createRemoteConnectorSession(
 }
 
 test('remote connector session lifecycle across restore, snapshot, heartbeat, close, and error', async () => {
+	// Websocket closes log an operational warning alongside the Sentry
+	// capture asserted below.
+	consoleWarn.mockImplementation(() => {})
 	const restored = await createRemoteConnectorSession({
 		storedState: {
 			persisted: {

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import type * as CloudflareWorkers from 'cloudflare:workers'
 import type * as Artifacts from './artifacts.ts'
 import type * as PublishedRuntimeArtifacts from '#worker/package-runtime/published-runtime-artifacts.ts'
@@ -420,6 +421,9 @@ function setCommonSessionFixtures() {
 }
 
 test('rebaseSession and publishSession use Artifacts username/password auth without token override', async () => {
+	// Best-effort publish git-note attachment fails in this mocked git
+	// environment and logs a warning that is incidental to auth behavior.
+	consoleWarn.mockImplementation(() => {})
 	setCommonSessionFixtures()
 	mockModule.writePublishedSourceSnapshot.mockClear()
 	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
@@ -599,6 +603,8 @@ test('runCommands rejects publish without checks for direct RPC callers', async 
 })
 
 test('runCommands fetches session metadata after publish side effects', async () => {
+	// Best-effort publish git-note attachment logs an incidental warning.
+	consoleWarn.mockImplementation(() => {})
 	setCommonSessionFixtures()
 	mockModule.gitState.headCommit = 'commit-published'
 	mockModule.workspaceGlob.mockResolvedValue([
@@ -657,6 +663,8 @@ test('runCommands fetches session metadata after publish side effects', async ()
 })
 
 test('publishSession persists the workspace snapshot to BUNDLE_ARTIFACTS_KV so downstream readers find the freshly published commit', async () => {
+	// Best-effort publish git-note attachment logs an incidental warning.
+	consoleWarn.mockImplementation(() => {})
 	setCommonSessionFixtures()
 	mockModule.gitState.headCommit = 'commit-published-new'
 	mockModule.gitState.statusEntries = [{ status: 'modified' }]
@@ -1345,6 +1353,8 @@ test('publishFromExternalRef rejects stale expected HEAD values', async () => {
 })
 
 test('publishFromExternalRef checks fast-forward ancestry through shell git adapter', async () => {
+	// Best-effort publish git-note setup logs an incidental warning.
+	consoleWarn.mockImplementation(() => {})
 	setCommonSessionFixtures()
 	mockModule.getEntitySourceById.mockResolvedValue({
 		id: 'source-1',

--- a/packages/worker/src/test-support/console-spies.ts
+++ b/packages/worker/src/test-support/console-spies.ts
@@ -1,0 +1,39 @@
+import { beforeEach, vi, type MockInstance } from 'vitest'
+
+// Epic Stack-style console guard. Tests fail loudly when code under test
+// calls console.error/console.warn unless the test opts in with
+// `consoleError.mockImplementation(() => {})` (and can then assert on the
+// calls). console.info/console.debug are operational logging and are silenced
+// by default; assert on the exported spies when a test cares about them.
+export let consoleError: MockInstance<(typeof console)['error']>
+export let consoleWarn: MockInstance<(typeof console)['warn']>
+export let consoleInfo: MockInstance<(typeof console)['info']>
+export let consoleDebug: MockInstance<(typeof console)['debug']>
+
+const originalError = console.error.bind(console)
+const originalWarn = console.warn.bind(console)
+
+function failOnUnexpectedCall(
+	method: 'error' | 'warn',
+	original: (...args: Array<unknown>) => void,
+) {
+	return (...args: Array<unknown>) => {
+		original(...args)
+		throw new Error(
+			`Unexpected console.${method} call. If this is expected, import console${
+				method === 'error' ? 'Error' : 'Warn'
+			} from #worker/test-support/console-spies.ts, call .mockImplementation(() => {}) in the test, and assert on the calls.`,
+		)
+	}
+}
+
+beforeEach(() => {
+	consoleError = vi
+		.spyOn(console, 'error')
+		.mockImplementation(failOnUnexpectedCall('error', originalError))
+	consoleWarn = vi
+		.spyOn(console, 'warn')
+		.mockImplementation(failOnUnexpectedCall('warn', originalWarn))
+	consoleInfo = vi.spyOn(console, 'info').mockImplementation(() => {})
+	consoleDebug = vi.spyOn(console, 'debug').mockImplementation(() => {})
+})

--- a/packages/worker/src/test-support/console-spies.ts
+++ b/packages/worker/src/test-support/console-spies.ts
@@ -1,4 +1,4 @@
-import { beforeEach, vi, type MockInstance } from 'vitest'
+import { afterEach, beforeEach, vi, type MockInstance } from 'vitest'
 
 // Epic Stack-style console guard. Tests fail loudly when code under test
 // calls console.error/console.warn unless the test opts in with
@@ -36,4 +36,14 @@ beforeEach(() => {
 		.mockImplementation(failOnUnexpectedCall('warn', originalWarn))
 	consoleInfo = vi.spyOn(console, 'info').mockImplementation(() => {})
 	consoleDebug = vi.spyOn(console, 'debug').mockImplementation(() => {})
+})
+
+// vitest-shared.ts enables clearMocks/mockReset but not restoreMocks, so
+// restore these spies explicitly to hand the real console methods back
+// between tests instead of leaving spy wrappers installed.
+afterEach(() => {
+	consoleError.mockRestore()
+	consoleWarn.mockRestore()
+	consoleInfo.mockRestore()
+	consoleDebug.mockRestore()
 })

--- a/packages/worker/src/usage/record-usage.workers.test.ts
+++ b/packages/worker/src/usage/record-usage.workers.test.ts
@@ -2,6 +2,7 @@ import { env } from 'cloudflare:workers'
 import { expect, test } from 'vitest'
 import { recordUsage } from './record-usage.ts'
 import { ensureUsageRollupsTestSchema } from './test-schema.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 async function listRollups(db: D1Database, userId: string) {
 	const { results } = await db
@@ -149,6 +150,7 @@ test('recordUsage accumulates per-user monthly rollups without USAGE_EVENTS (loc
 })
 
 test('recordUsage never throws when bindings are missing, sinks fail, or userId is empty', async () => {
+	consoleWarn.mockImplementation(() => {})
 	await ensureUsageRollupsTestSchema(env.APP_DB)
 	const userId = `usage-degrade-user-${crypto.randomUUID()}`
 
@@ -180,6 +182,10 @@ test('recordUsage never throws when bindings are missing, sinks fail, or userId 
 		),
 	).resolves.toBeUndefined()
 	expect(await listRollups(env.APP_DB, userId)).toEqual([])
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'usage-event-analytics-failed',
+		expect.any(Error),
+	)
 
 	// Missing userId: skipped entirely, no row written.
 	await expect(
@@ -198,4 +204,8 @@ test('recordUsage never throws when bindings are missing, sinks fail, or userId 
 			{ userId, eventType: 'execute', outcome: 'success' },
 		),
 	).resolves.toBeUndefined()
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'usage-rollup-failed',
+		expect.any(Error),
+	)
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 0,
+	// CI runs `validate`, which executes unit, MCP, and Playwright suites
+	// concurrently on one runner. The default 30s per-test budget flakes under
+	// that resource contention (page.goto alone has been observed taking >30s).
+	timeout: process.env.CI ? 60_000 : 30_000,
 	// Every worker hits the same local D1 file (`.wrangler/state/e2e`) through
 	// Wrangler and the `d1 execute` helpers. Parallel workers cause SQLITE_BUSY
 	// and transient 500s during auth/admin flows.

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { expect, test, vi } from 'vitest'
+import { consoleError } from '#worker/test-support/console-spies.ts'
 
 import {
 	isWranglerNotFoundOutput,
@@ -29,6 +30,7 @@ test('isWranglerNotFoundOutput recognizes common Wrangler missing-resource messa
 })
 
 test('writeGeneratedWranglerConfig preserves migrations and copies environment asset routing', async () => {
+	consoleError.mockImplementation(() => {})
 	const tempDir = await mkdtemp(path.join(os.tmpdir(), 'kody-resource-utils-'))
 
 	try {
@@ -120,6 +122,9 @@ test('writeGeneratedWranglerConfig preserves migrations and copies environment a
 			},
 			{ binding: 'EMAIL_BLOBS', bucket_name: 'kody-pr-123-email-blobs' },
 		])
+		expect(consoleError).toHaveBeenCalledWith(
+			`Wrote generated Wrangler config: ${previewOutPath}`,
+		)
 	} finally {
 		await rm(tempDir, { force: true, recursive: true })
 	}

--- a/vitest-shared.ts
+++ b/vitest-shared.ts
@@ -45,5 +45,8 @@ export const sharedProjectConfig = {
 		fileParallelism: false,
 		clearMocks: true,
 		mockReset: true,
+		setupFiles: [
+			resolve(rootDir, 'packages/worker/src/test-support/console-spies.ts'),
+		],
 	},
 } satisfies UserConfig


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Cleans up the three remaining flaky tests and drastically reduces test log noise, per the "mock console and assert on it" convention from the Epic Stack.

### Flake fixes

- **Scroll restoration race (app fix):** `e2e/ssr-hydration.spec.ts` flaked because pop-navigation scroll restoration ran once, before the async community listings frame rendered, leaving the document too short to reach the saved position. `packages/worker/client/scroll-restoration.tsx` now retries restoration on animation frames (up to a 15s deadline), backs off if the user scrolls manually, and retries hash targets that render asynchronously. New regression test `e2e/scroll-restore-slow-frame.spec.ts` simulates a degraded prefetch + slow frame fetch and fails without the fix.
- **Stale keep-alive socket race:** `e2e/og-images.spec.ts` (and the same pattern in `ssr-hydration.spec.ts`) intermittently failed with `socket hang up` on the first request after seeding. Root-caused with instrumentation: Playwright's `APIRequestContext` pools keep-alive sockets in a process-global agent, and the first request after the multi-second `wrangler d1 execute` seeding gap can reuse a socket the dev server already closed. Fixed by opting those first-after-idle requests into Playwright's built-in ECONNRESET-only retry (`maxRetries: 1`). Verified: failed 5/5 full-suite runs before, passed 2/2 after.
- **CI timeout headroom:** CI runs unit, MCP, and Playwright suites concurrently on one runner; `page.goto` alone has been observed exceeding the default 30s test budget (`two-factor.spec.ts`). Playwright's per-test timeout is now 60s in CI only. `ssr-hydration.spec.ts` also waits for the frame content to be visible before polling `window.scrollY`.

### Console output cleanup

- New global setup `packages/worker/src/test-support/console-spies.ts` (wired via `setupFiles` in `vitest-shared.ts`, so it applies to node-unit, workers-unit, and mcp-e2e projects): unexpected `console.error`/`console.warn` calls **fail the test**; `console.info`/`console.debug` are silenced. Tests that expect logging import the exported spies, call `.mockImplementation(() => {})`, and assert on the calls.
- 27 test files updated to follow the pattern (silence + assert instead of spewing).
- Upgraded `@cloudflare/vitest-pool-workers` 0.14.7 → 0.14.9, which drops the `[vpw:debug]`/`[vpw:info]` chatter.
- Convention documented in `docs/contributing/testing-principles.md`.

Historical unit-test flakes (`search.node.test.ts` AI-binding error, `cloudflare-rest-client.node.test.ts` timeout) were verified as already fixed by #618 and #580.

Merged `main` (including #718/#719) and resolved the `community-icon.node.test.ts` conflict by keeping the new PNG-fallback test structure plus console-spy assertions.

## Verification

- `npm run validate` green locally (format, lint, typecheck, unit, Playwright E2E, MCP E2E) after the merge with main.
- `e2e/scroll-restore-slow-frame.spec.ts` reproduces the scroll flake without the `scroll-restoration.tsx` fix and passes with it.
- og-images socket-hang-up flake reproduced 5/5 before the `maxRetries` fix and passed 2/2 full-suite runs after.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `497af020` · **Head:** `2e273b5d`

**Classification:** extends — changes the browser app's scroll-restoration behavior; everything else is test infrastructure and test-file cleanup, which is not primitive-touching.

### Primitives touched

| Primitive | Group    | Impact                                                                             |
| --------- | -------- | ---------------------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — pop-navigation scroll restoration now retries until async content grows |

### System map

Pop navigation in the browser app now retries scroll restoration until the async frame content makes the saved position reachable.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	testInfra["test setup (not a primitive)<br/>console-spies + vitest/playwright config"]:::untouched
	appUi -->|"scroll-restoration.tsx: retry until saved position reachable"| appUi
	testInfra -->|"fail on unexpected console.error/warn across all vitest projects"| testInfra
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant U as User (back button)
	participant R as client-router
	participant S as scroll-restoration
	participant F as async frame content
	U->>R: pop navigation
	R->>S: router navigation event
	S->>S: apply saved position (too short → not reachable)
	F-->>S: frame HTML renders, document grows
	S->>S: retry on animation frame until reachable or 15s deadline
	Note over S: aborts if the user scrolls manually between attempts
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d046b009-ba3d-4628-9c76-8cc8993fb0fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d046b009-ba3d-4628-9c76-8cc8993fb0fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll restoration on back/forward navigation for community listings, including slow fallback and SSR hydration scenarios.
  * Added deadline-bounded retries for restoring scroll position, with safeguards for hash, top, preserve, and user-initiated scrolling.

* **Documentation**
  * Expanded testing guidance on console handling during tests (what fails vs what’s silenced) and how to assert expected warnings/errors.

* **Tests**
  * Added Playwright e2e regression coverage for slow scroll-restoration and improved SSR hydration back-navigation checks.
  * Updated CI-aware Playwright timeouts and strengthened console-logging assertions via shared test console spies.

* **Chores**
  * Bumped the development dependency `@cloudflare/vitest-pool-workers` to a newer patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->