### PR TITLE
Assert on silenced console output instead of blanket-suppressing it

### DIFF
--- a/docs/contributing/testing-principles.md
+++ b/docs/contributing/testing-principles.md
@@ -56,11 +56,22 @@ when that makes a single test longer and more assertion-heavy.
 - Console output is guarded globally
   (`packages/worker/src/test-support/console-spies.ts`, wired via `setupFiles`):
   unexpected `console.error`/`console.warn` calls fail the test, and
-  `console.info`/`console.debug` are silenced. When code under test
-  intentionally logs, import the exported `consoleError`/`consoleWarn` spies,
-  call `.mockImplementation(() => {})` in the test, and assert on the calls
-  (prefer the stable first-argument tag plus `expect.any(Error)`; do not pin
-  long prose). Keep test output free of stray logging.
+  `console.info`/`console.debug` are silenced. Never silence blindly — a blanket
+  `.mockImplementation(() => {})` can hide a real regression. Instead:
+  - When the log is part of the tested contract, import the exported
+    `consoleError`/`consoleWarn` spies, call `.mockImplementation(() => {})`,
+    and assert on the calls (prefer the stable first-argument tag plus
+    `expect.any(Error)`; do not pin long prose). Assert the call count too when
+    it is deterministic.
+  - When the log is incidental to the behavior under test, use
+    `silenceExpectedConsoleWarns([...])` / `silenceExpectedConsoleErrors([...])`
+    (same module) with the exact expected message tags, or
+    `silenceIncidentalRuntimeWarnings()`
+    (`packages/worker/src/test-support/incidental-runtime-warnings.ts`) for the
+    bundler/registry-runtime noise set. Anything outside the allowlist still
+    fails the test.
+
+  Keep test output free of stray logging.
 
 ## Examples
 

--- a/docs/contributing/testing-principles.md
+++ b/docs/contributing/testing-principles.md
@@ -73,6 +73,15 @@ when that makes a single test longer and more assertion-heavy.
 
   Keep test output free of stray logging.
 
+- The audit-log sink is mocked globally for `node-unit` tests
+  (`packages/worker/src/test-support/audit-log-spy.ts`, wired via the project's
+  `setupFiles`): import `logAuditEventSpy` and assert the audit events a handler
+  is expected to emit (and `not.toHaveBeenCalled()` where none are). Tests that
+  exercise the real audit pipeline opt out with
+  `vi.unmock('#app/audit-log.ts')`; tests that need to override other exports
+  (e.g. `getRequestIp`) declare their own `vi.mock('#app/audit-log.ts', ...)`
+  and route `logAuditEvent` back through the shared spy.
+
 ## Examples
 
 ### `Symbol.dispose` with `using`

--- a/packages/worker/src/app/email/cloudflare-email.node.test.ts
+++ b/packages/worker/src/app/email/cloudflare-email.node.test.ts
@@ -141,6 +141,9 @@ test('sendCloudflareEmail delivers through the mock API and handles configuratio
 		ok: false,
 		error: 'Failed to fetch',
 	})
+	// Exactly the one expected warning; anything else the mock swallowed
+	// would be a regression hidden by the opt-in above.
+	expect(consoleWarn).toHaveBeenCalledTimes(1)
 	expect(consoleWarn).toHaveBeenCalledWith(
 		'cloudflare-email-api-request-failed',
 		expect.any(Error),
@@ -171,4 +174,8 @@ test('sendCloudflareEmail delivers through the mock API and handles configuratio
 			},
 		),
 	).rejects.toThrow('not valid JSON')
+	// The parse failure throws before any operator warning, so the silenced
+	// consoleWarn must not have picked up anything new.
+	expect(consoleWarn).toHaveBeenCalledTimes(1)
+	expect(consoleInfo).toHaveBeenCalledTimes(1)
 })

--- a/packages/worker/src/app/handlers/account-profile.node.test.ts
+++ b/packages/worker/src/app/handlers/account-profile.node.test.ts
@@ -8,12 +8,17 @@ import { createAccountProfileApiHandler } from './account-profile.ts'
 
 // The handler fires `void logAuditEvent(...)` without awaiting it; those
 // promises can resolve after the test ends and leak `audit-event` lines into
-// the runner output once the console spies are restored. Stub the audit sink.
+// the runner output once the console spies are restored. Route the sink to a
+// spy so the expected audit events are asserted instead of silently dropped.
+const auditSpy = vi.hoisted(() => ({
+	logAuditEvent: vi.fn(async () => undefined),
+}))
+
 vi.mock('#app/audit-log.ts', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
 	return {
 		...actual,
-		logAuditEvent: async () => undefined,
+		logAuditEvent: (...args: Array<unknown>) => auditSpy.logAuditEvent(...args),
 	}
 })
 
@@ -206,6 +211,8 @@ test('account profile API returns email and username for the signed-in user', as
 		username: 'current-user',
 		displayName: 'current-user',
 	})
+	// Reads are not audited.
+	expect(auditSpy.logAuditEvent).not.toHaveBeenCalled()
 })
 
 test('account profile API updates username for the signed-in user', async () => {
@@ -233,6 +240,14 @@ test('account profile API updates username for the signed-in user', async () => 
 		displayName: 'next_user',
 	})
 	expect(testDb.users.get(1)?.username).toBe('next_user')
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledTimes(1)
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'account',
+			action: 'update_username',
+			result: 'success',
+		}),
+	)
 })
 
 test('account profile API rejects invalid or duplicate usernames', async () => {
@@ -285,4 +300,14 @@ test('account profile API rejects invalid or duplicate usernames', async () => {
 		error: 'Username already registered.',
 	})
 	expect(testDb.users.get(1)?.username).toBe('current-user')
+	// Only the duplicate attempt is audited; validation rejections are not.
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledTimes(1)
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'account',
+			action: 'update_username',
+			result: 'failure',
+			reason: 'username_exists',
+		}),
+	)
 })

--- a/packages/worker/src/app/handlers/account-profile.node.test.ts
+++ b/packages/worker/src/app/handlers/account-profile.node.test.ts
@@ -5,22 +5,7 @@ import {
 	type AuthSession,
 } from '#app/auth-session.ts'
 import { createAccountProfileApiHandler } from './account-profile.ts'
-
-// The handler fires `void logAuditEvent(...)` without awaiting it; those
-// promises can resolve after the test ends and leak `audit-event` lines into
-// the runner output once the console spies are restored. Route the sink to a
-// spy so the expected audit events are asserted instead of silently dropped.
-const auditSpy = vi.hoisted(() => ({
-	logAuditEvent: vi.fn(async () => undefined),
-}))
-
-vi.mock('#app/audit-log.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
-	return {
-		...actual,
-		logAuditEvent: (...args: Array<unknown>) => auditSpy.logAuditEvent(...args),
-	}
-})
+import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -212,7 +197,7 @@ test('account profile API returns email and username for the signed-in user', as
 		displayName: 'current-user',
 	})
 	// Reads are not audited.
-	expect(auditSpy.logAuditEvent).not.toHaveBeenCalled()
+	expect(logAuditEventSpy).not.toHaveBeenCalled()
 })
 
 test('account profile API updates username for the signed-in user', async () => {
@@ -240,8 +225,8 @@ test('account profile API updates username for the signed-in user', async () => 
 		displayName: 'next_user',
 	})
 	expect(testDb.users.get(1)?.username).toBe('next_user')
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledTimes(1)
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledTimes(1)
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'account',
 			action: 'update_username',
@@ -301,8 +286,8 @@ test('account profile API rejects invalid or duplicate usernames', async () => {
 	})
 	expect(testDb.users.get(1)?.username).toBe('current-user')
 	// Only the duplicate attempt is audited; validation rejections are not.
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledTimes(1)
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledTimes(1)
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'account',
 			action: 'update_username',

--- a/packages/worker/src/app/handlers/account-resend-verification.node.test.ts
+++ b/packages/worker/src/app/handlers/account-resend-verification.node.test.ts
@@ -10,22 +10,7 @@ import {
 	consoleWarn,
 } from '#worker/test-support/console-spies.ts'
 import { createAccountResendVerificationHandler } from './account-resend-verification.ts'
-
-// The handler fires `void logAuditEvent(...)` without awaiting it; those
-// promises can resolve after the test ends and leak `audit-event` lines into
-// the runner output once the console spies are restored. Route the sink to a
-// spy so the expected audit events are asserted instead of silently dropped.
-const auditSpy = vi.hoisted(() => ({
-	logAuditEvent: vi.fn(async () => undefined),
-}))
-
-vi.mock('#app/audit-log.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
-	return {
-		...actual,
-		logAuditEvent: (...args: Array<unknown>) => auditSpy.logAuditEvent(...args),
-	}
-})
+import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -215,8 +200,8 @@ test('resend verification issues a fresh token for unverified accounts and rate-
 	// No new token is created for rate-limited requests.
 	expect(testDb.state.verificationInserts).toBe(3)
 	// Three successful resends plus the rate-limited attempt are audited.
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledTimes(4)
-	expect(auditSpy.logAuditEvent).toHaveBeenNthCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledTimes(4)
+	expect(logAuditEventSpy).toHaveBeenNthCalledWith(
 		3,
 		expect.objectContaining({
 			category: 'auth',
@@ -224,7 +209,7 @@ test('resend verification issues a fresh token for unverified accounts and rate-
 			result: 'success',
 		}),
 	)
-	expect(auditSpy.logAuditEvent).toHaveBeenNthCalledWith(
+	expect(logAuditEventSpy).toHaveBeenNthCalledWith(
 		4,
 		expect.objectContaining({
 			category: 'auth',
@@ -293,8 +278,8 @@ test('resend verification surfaces send failures without pretending success', as
 		'cloudflare-email-api-failed',
 		expect.any(String),
 	)
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledTimes(1)
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledTimes(1)
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'auth',
 			action: 'email_verification_resend',

--- a/packages/worker/src/app/handlers/account-resend-verification.node.test.ts
+++ b/packages/worker/src/app/handlers/account-resend-verification.node.test.ts
@@ -13,12 +13,17 @@ import { createAccountResendVerificationHandler } from './account-resend-verific
 
 // The handler fires `void logAuditEvent(...)` without awaiting it; those
 // promises can resolve after the test ends and leak `audit-event` lines into
-// the runner output once the console spies are restored. Stub the audit sink.
+// the runner output once the console spies are restored. Route the sink to a
+// spy so the expected audit events are asserted instead of silently dropped.
+const auditSpy = vi.hoisted(() => ({
+	logAuditEvent: vi.fn(async () => undefined),
+}))
+
 vi.mock('#app/audit-log.ts', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
 	return {
 		...actual,
-		logAuditEvent: async () => undefined,
+		logAuditEvent: (...args: Array<unknown>) => auditSpy.logAuditEvent(...args),
 	}
 })
 
@@ -209,6 +214,24 @@ test('resend verification issues a fresh token for unverified accounts and rate-
 	})
 	// No new token is created for rate-limited requests.
 	expect(testDb.state.verificationInserts).toBe(3)
+	// Three successful resends plus the rate-limited attempt are audited.
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledTimes(4)
+	expect(auditSpy.logAuditEvent).toHaveBeenNthCalledWith(
+		3,
+		expect.objectContaining({
+			category: 'auth',
+			action: 'email_verification_resend',
+			result: 'success',
+		}),
+	)
+	expect(auditSpy.logAuditEvent).toHaveBeenNthCalledWith(
+		4,
+		expect.objectContaining({
+			category: 'auth',
+			action: 'email_verification_resend',
+			result: 'rate_limited',
+		}),
+	)
 })
 
 test('resend verification rejects already-verified accounts', async () => {
@@ -269,6 +292,15 @@ test('resend verification surfaces send failures without pretending success', as
 	expect(consoleWarn).toHaveBeenCalledWith(
 		'cloudflare-email-api-failed',
 		expect.any(String),
+	)
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledTimes(1)
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'email_verification_resend',
+			result: 'failure',
+			reason: 'send_failed',
+		}),
 	)
 	vi.unstubAllGlobals()
 })

--- a/packages/worker/src/app/handlers/admin-users.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-users.node.test.ts
@@ -1,10 +1,10 @@
 import { expect, test, vi } from 'vitest'
 import { adminUserListItemFieldNames } from './admin-users.ts'
 import { type PermissionString, type RoleName } from '#app/permissions.ts'
+import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
 
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(),
-	logAuditEvent: vi.fn(async () => undefined),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -12,10 +12,17 @@ vi.mock('#app/authenticated-user.ts', () => ({
 		mockModule.readAuthenticatedAppUser(...args),
 }))
 
-vi.mock('#app/audit-log.ts', () => ({
-	getRequestIp: () => '127.0.0.1',
-	logAuditEvent: (...args: Array<unknown>) => mockModule.logAuditEvent(...args),
-}))
+// The shared audit-log-spy setup file routes logAuditEvent; this test also
+// needs a deterministic request IP for its audit assertions.
+vi.mock('#app/audit-log.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
+	return {
+		...actual,
+		getRequestIp: () => '127.0.0.1',
+		logAuditEvent: (...args: Parameters<typeof actual.logAuditEvent>) =>
+			logAuditEventSpy(...args),
+	}
+})
 
 type UserRow = {
 	id: number
@@ -293,7 +300,7 @@ test('admin users list payload exposes only account metadata fields', async () =
 })
 
 test('assign role action updates user roles and logs audit event', async () => {
-	mockModule.logAuditEvent.mockClear()
+	logAuditEventSpy.mockClear()
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(
 		createAdminActor(['admin']),
 	)
@@ -331,7 +338,7 @@ test('assign role action updates user roles and logs audit event', async () => {
 	expect(response.status).toBe(200)
 	const payload = await response.json()
 	expect(payload.users[0].roles).toContain('admin')
-	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({ category: 'admin', action: 'assign_role' }),
 	)
 })
@@ -426,7 +433,7 @@ test('remove role removes admin when another admin remains', async () => {
 		(user: { id: number }) => user.id === 2,
 	)
 	expect(secondAdmin.roles).not.toContain('admin')
-	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'admin',
 			action: 'remove_role',
@@ -436,7 +443,7 @@ test('remove role removes admin when another admin remains', async () => {
 })
 
 test('update plan action sets, clears, validates, and scopes plan changes', async () => {
-	mockModule.logAuditEvent.mockClear()
+	logAuditEventSpy.mockClear()
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(
 		createAdminActor(['admin']),
 	)
@@ -475,7 +482,7 @@ test('update plan action sets, clears, validates, and scopes plan changes', asyn
 	})
 	expect(setPlanResponse.status).toBe(200)
 	expect((await setPlanResponse.json()).users[0].plan).toBe('personal')
-	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'admin',
 			action: 'update_plan',
@@ -491,7 +498,7 @@ test('update plan action sets, clears, validates, and scopes plan changes', asyn
 	})
 	expect(clearPlanResponse.status).toBe(200)
 	expect((await clearPlanResponse.json()).users[0].plan).toBe(null)
-	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'admin',
 			action: 'update_plan',

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -8,7 +8,10 @@ import {
 	consoleInfo,
 	consoleWarn,
 } from '#worker/test-support/console-spies.ts'
-import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -545,6 +548,27 @@ test('auth handler login and signup workflow', async () => {
 	expect(secureCookieResponse.headers.get('Set-Cookie') ?? '').toContain(
 		'Secure',
 	)
+	// The full workflow audits exactly these events, in order: the unknown
+	// login, the invite-less production signup, the invited signup (+ invite
+	// use), the weak-password rejection, the open signup, the six username
+	// rejections, and the three successful logins.
+	expect(auditEventSummaries()).toEqual([
+		'login:failure',
+		'signup:failure',
+		'signup:success',
+		'invite_use:success',
+		'signup:failure',
+		'signup:success',
+		'signup:failure',
+		'signup:failure',
+		'signup:failure',
+		'signup:failure',
+		'signup:failure',
+		'signup:failure',
+		'login:success',
+		'login:success',
+		'login:success',
+	])
 })
 
 test('signup fails when the default user role cannot be assigned', async () => {
@@ -564,6 +588,7 @@ test('signup fails when the default user role cannot be assigned', async () => {
 	expect(response.headers.get('Set-Cookie')).toBeNull()
 	// The created user row is rolled back so signup can be retried.
 	expect(context.testDb.users.has('roleless@example.com')).toBe(false)
+	expect(auditEventSummaries()).toEqual(['signup:failure'])
 	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'auth',

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -8,22 +8,7 @@ import {
 	consoleInfo,
 	consoleWarn,
 } from '#worker/test-support/console-spies.ts'
-
-// The auth handler fires `void logAuditEvent(...)` without awaiting it; those
-// promises can resolve after the test ends and leak `audit-event` lines into
-// the runner output once the console spies are restored. Route the sink to a
-// spy so the expected audit events are asserted instead of silently dropped.
-const auditSpy = vi.hoisted(() => ({
-	logAuditEvent: vi.fn(async () => undefined),
-}))
-
-vi.mock('#app/audit-log.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
-	return {
-		...actual,
-		logAuditEvent: (...args: Array<unknown>) => auditSpy.logAuditEvent(...args),
-	}
-})
+import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -375,7 +360,7 @@ test('auth handler login and signup workflow', async () => {
 	expect(await unknownUserLoginResponse.json()).toEqual({
 		error: 'Invalid email or password.',
 	})
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'auth',
 			action: 'login',
@@ -413,7 +398,7 @@ test('auth handler login and signup workflow', async () => {
 	})
 	expect(productionContext.testDb.users.has('invited@example.com')).toBe(true)
 	expect(productionContext.testDb.invites.get('PROD-INVITE')?.use_count).toBe(1)
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'auth',
 			action: 'signup',
@@ -421,7 +406,7 @@ test('auth handler login and signup workflow', async () => {
 			email: 'invited@example.com',
 		}),
 	)
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'auth',
 			action: 'invite_use',
@@ -532,7 +517,7 @@ test('auth handler login and signup workflow', async () => {
 	const loginCookie = loginResponse.headers.get('Set-Cookie') ?? ''
 	expect(loginCookie).toContain('kody_session=')
 	expect(loginCookie).toContain('Max-Age=604800')
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'auth',
 			action: 'login',
@@ -579,7 +564,7 @@ test('signup fails when the default user role cannot be assigned', async () => {
 	expect(response.headers.get('Set-Cookie')).toBeNull()
 	// The created user row is rolled back so signup can be retried.
 	expect(context.testDb.users.has('roleless@example.com')).toBe(false)
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'auth',
 			action: 'signup',

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -11,12 +11,17 @@ import {
 
 // The auth handler fires `void logAuditEvent(...)` without awaiting it; those
 // promises can resolve after the test ends and leak `audit-event` lines into
-// the runner output once the console spies are restored. Stub the audit sink.
+// the runner output once the console spies are restored. Route the sink to a
+// spy so the expected audit events are asserted instead of silently dropped.
+const auditSpy = vi.hoisted(() => ({
+	logAuditEvent: vi.fn(async () => undefined),
+}))
+
 vi.mock('#app/audit-log.ts', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
 	return {
 		...actual,
-		logAuditEvent: async () => undefined,
+		logAuditEvent: (...args: Array<unknown>) => auditSpy.logAuditEvent(...args),
 	}
 })
 
@@ -370,6 +375,14 @@ test('auth handler login and signup workflow', async () => {
 	expect(await unknownUserLoginResponse.json()).toEqual({
 		error: 'Invalid email or password.',
 	})
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'login',
+			result: 'failure',
+			reason: 'invalid_credentials',
+		}),
+	)
 
 	const blockedSignupResponse = await productionContext.request({
 		email: 'new@example.com',
@@ -400,6 +413,21 @@ test('auth handler login and signup workflow', async () => {
 	})
 	expect(productionContext.testDb.users.has('invited@example.com')).toBe(true)
 	expect(productionContext.testDb.invites.get('PROD-INVITE')?.use_count).toBe(1)
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'signup',
+			result: 'success',
+			email: 'invited@example.com',
+		}),
+	)
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'invite_use',
+			result: 'success',
+		}),
+	)
 
 	const weakPasswordSignupResponse = await signupContext.request({
 		email: 'weak@example.com',
@@ -504,6 +532,14 @@ test('auth handler login and signup workflow', async () => {
 	const loginCookie = loginResponse.headers.get('Set-Cookie') ?? ''
 	expect(loginCookie).toContain('kody_session=')
 	expect(loginCookie).toContain('Max-Age=604800')
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'login',
+			result: 'success',
+			email,
+		}),
+	)
 
 	const rememberMeResponse = await productionContext.request({
 		email,
@@ -543,6 +579,13 @@ test('signup fails when the default user role cannot be assigned', async () => {
 	expect(response.headers.get('Set-Cookie')).toBeNull()
 	// The created user row is rolled back so signup can be retried.
 	expect(context.testDb.users.has('roleless@example.com')).toBe(false)
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'signup',
+			result: 'failure',
+		}),
+	)
 })
 
 test('signup rolls back when the verification email cannot be sent', async () => {

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -13,7 +13,10 @@ import { createMswNodeServer } from '#worker/test-support/msw-node-server.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { quoteSqlString } from '@kody-internal/shared/sql-literals.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
-import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -336,6 +339,13 @@ test('github sign-in creates a verified account, then signs it back in', async (
 		.prepare(`SELECT COUNT(*) AS count FROM users`)
 		.get() as { count: number }
 	expect(userCount.count).toBe(1)
+	// The first callback signs the user up and logs them in; the second
+	// callback is a pure login. Nothing else is audited.
+	expect(auditEventSummaries()).toEqual([
+		'oauth_signup:success',
+		'oauth_login:success',
+		'oauth_login:success',
+	])
 	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'auth',

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -16,12 +16,17 @@ import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
 
 // The handlers fire `void logAuditEvent(...)` without awaiting it; those
 // promises can resolve after the test ends and leak `audit-event` lines into
-// the runner output once the console spies are restored. Stub the audit sink.
+// the runner output once the console spies are restored. Route the sink to a
+// spy so the expected audit events are asserted instead of silently dropped.
+const auditSpy = vi.hoisted(() => ({
+	logAuditEvent: vi.fn(async () => undefined),
+}))
+
 vi.mock('#app/audit-log.ts', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
 	return {
 		...actual,
-		logAuditEvent: async () => undefined,
+		logAuditEvent: (...args: Array<unknown>) => auditSpy.logAuditEvent(...args),
 	}
 })
 
@@ -312,6 +317,14 @@ test('github sign-in creates a verified account, then signs it back in', async (
 		)
 		.get() as Record<string, unknown>
 	expect(connection.user_id).toBe(user.id)
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'oauth_signup',
+			result: 'success',
+			reason: 'provider=github',
+		}),
+	)
 
 	// A second sign-in with the same provider identity reuses the account.
 	const secondStart = await startProviderFlow(
@@ -338,6 +351,14 @@ test('github sign-in creates a verified account, then signs it back in', async (
 		.prepare(`SELECT COUNT(*) AS count FROM users`)
 		.get() as { count: number }
 	expect(userCount.count).toBe(1)
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'oauth_login',
+			result: 'success',
+			reason: 'provider=github',
+		}),
+	)
 })
 
 test('google sign-in links a matching verified email to the existing account', async () => {

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -13,22 +13,7 @@ import { createMswNodeServer } from '#worker/test-support/msw-node-server.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { quoteSqlString } from '@kody-internal/shared/sql-literals.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
-
-// The handlers fire `void logAuditEvent(...)` without awaiting it; those
-// promises can resolve after the test ends and leak `audit-event` lines into
-// the runner output once the console spies are restored. Route the sink to a
-// spy so the expected audit events are asserted instead of silently dropped.
-const auditSpy = vi.hoisted(() => ({
-	logAuditEvent: vi.fn(async () => undefined),
-}))
-
-vi.mock('#app/audit-log.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
-	return {
-		...actual,
-		logAuditEvent: (...args: Array<unknown>) => auditSpy.logAuditEvent(...args),
-	}
-})
+import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -317,7 +302,7 @@ test('github sign-in creates a verified account, then signs it back in', async (
 		)
 		.get() as Record<string, unknown>
 	expect(connection.user_id).toBe(user.id)
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'auth',
 			action: 'oauth_signup',
@@ -351,7 +336,7 @@ test('github sign-in creates a verified account, then signs it back in', async (
 		.prepare(`SELECT COUNT(*) AS count FROM users`)
 		.get() as { count: number }
 	expect(userCount.count).toBe(1)
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'auth',
 			action: 'oauth_login',

--- a/packages/worker/src/app/handlers/password-reset.node.test.ts
+++ b/packages/worker/src/app/handlers/password-reset.node.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import type * as AuditLog from '#app/audit-log.ts'
+import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
 
 const mockModule = vi.hoisted(() => ({
 	createRecord: vi.fn(async () => undefined),
@@ -8,7 +8,6 @@ const mockModule = vi.hoisted(() => ({
 		id: 123,
 		email: 'user@example.com',
 	})),
-	logAuditEvent: vi.fn(async () => undefined),
 	sendCloudflareEmail: vi.fn(async () => ({ ok: true })),
 }))
 
@@ -22,13 +21,15 @@ vi.mock('#worker/db.ts', () => ({
 	usersTable: {},
 }))
 
+// The shared audit-log-spy setup file routes logAuditEvent; this test also
+// needs getRequestIp pinned to null for deterministic audit payloads.
 vi.mock('#app/audit-log.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof AuditLog>()
+	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
 	return {
 		...actual,
 		getRequestIp: () => null,
-		logAuditEvent: (...args: Array<unknown>) =>
-			mockModule.logAuditEvent(...args),
+		logAuditEvent: (...args: Parameters<typeof actual.logAuditEvent>) =>
+			logAuditEventSpy(...args),
 	}
 })
 
@@ -120,6 +121,13 @@ test('password reset sends from the APP_BASE_URL hostname without logging the to
 			expect(joined).not.toContain('token=')
 			expect(joined).not.toMatch(hexTokenPattern)
 		}
+		expect(logAuditEventSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				category: 'auth',
+				action: 'password_reset_request',
+				result: 'success',
+			}),
+		)
 	} finally {
 		warnSpy.mockRestore()
 	}

--- a/packages/worker/src/app/handlers/two-factor.node.test.ts
+++ b/packages/worker/src/app/handlers/two-factor.node.test.ts
@@ -15,22 +15,7 @@ import { createTwoFactorVerifyApiHandler } from '#app/handlers/verify.ts'
 import { setVerifySessionSecret } from '#app/verify-session.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
-
-// The handlers fire `void logAuditEvent(...)` without awaiting it; those
-// promises can resolve after the test ends and leak `audit-event` lines into
-// the runner output once the console spies are restored. Route the sink to a
-// spy so the expected audit events are asserted instead of silently dropped.
-const auditSpy = vi.hoisted(() => ({
-	logAuditEvent: vi.fn(async () => undefined),
-}))
-
-vi.mock('#app/audit-log.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
-	return {
-		...actual,
-		logAuditEvent: (...args: Array<unknown>) => auditSpy.logAuditEvent(...args),
-	}
-})
+import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -319,21 +304,21 @@ test('two-factor setup requires authentication and a valid code before activatin
 		secret: setupPayload.secret,
 	})
 	// Setup start, the rejected confirm, and the successful enable are audited.
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'account',
 			action: 'two_factor_setup_start',
 			result: 'success',
 		}),
 	)
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'account',
 			action: 'two_factor_enable',
 			result: 'failure',
 		}),
 	)
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'account',
 			action: 'two_factor_enable',
@@ -575,14 +560,14 @@ test('disabling 2fa requires a valid current code and clears stale pending rows'
 				.get() as { count: number }
 		).count,
 	).toBe(0)
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'account',
 			action: 'two_factor_disable',
 			result: 'failure',
 		}),
 	)
-	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'account',
 			action: 'two_factor_disable',

--- a/packages/worker/src/app/handlers/two-factor.node.test.ts
+++ b/packages/worker/src/app/handlers/two-factor.node.test.ts
@@ -15,7 +15,10 @@ import { createTwoFactorVerifyApiHandler } from '#app/handlers/verify.ts'
 import { setVerifySessionSecret } from '#app/verify-session.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
-import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -303,21 +306,13 @@ test('two-factor setup requires authentication and a valid code before activatin
 		type: '2fa',
 		secret: setupPayload.secret,
 	})
-	// Setup start, the rejected confirm, and the successful enable are audited.
-	expect(logAuditEventSpy).toHaveBeenCalledWith(
-		expect.objectContaining({
-			category: 'account',
-			action: 'two_factor_setup_start',
-			result: 'success',
-		}),
-	)
-	expect(logAuditEventSpy).toHaveBeenCalledWith(
-		expect.objectContaining({
-			category: 'account',
-			action: 'two_factor_enable',
-			result: 'failure',
-		}),
-	)
+	// Setup start, the rejected confirm, and the successful enable are audited
+	// — and nothing else.
+	expect(auditEventSummaries()).toEqual([
+		'two_factor_setup_start:success',
+		'two_factor_enable:failure',
+		'two_factor_enable:success',
+	])
 	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'account',
@@ -560,13 +555,14 @@ test('disabling 2fa requires a valid current code and clears stale pending rows'
 				.get() as { count: number }
 		).count,
 	).toBe(0)
-	expect(logAuditEventSpy).toHaveBeenCalledWith(
-		expect.objectContaining({
-			category: 'account',
-			action: 'two_factor_disable',
-			result: 'failure',
-		}),
-	)
+	// The in-test 2FA enablement plus the rejected and successful disable
+	// attempts are audited — and nothing else.
+	expect(auditEventSummaries()).toEqual([
+		'two_factor_setup_start:success',
+		'two_factor_enable:success',
+		'two_factor_disable:failure',
+		'two_factor_disable:success',
+	])
 	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'account',

--- a/packages/worker/src/app/handlers/two-factor.node.test.ts
+++ b/packages/worker/src/app/handlers/two-factor.node.test.ts
@@ -18,12 +18,17 @@ import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
 
 // The handlers fire `void logAuditEvent(...)` without awaiting it; those
 // promises can resolve after the test ends and leak `audit-event` lines into
-// the runner output once the console spies are restored. Stub the audit sink.
+// the runner output once the console spies are restored. Route the sink to a
+// spy so the expected audit events are asserted instead of silently dropped.
+const auditSpy = vi.hoisted(() => ({
+	logAuditEvent: vi.fn(async () => undefined),
+}))
+
 vi.mock('#app/audit-log.ts', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
 	return {
 		...actual,
-		logAuditEvent: async () => undefined,
+		logAuditEvent: (...args: Array<unknown>) => auditSpy.logAuditEvent(...args),
 	}
 })
 
@@ -313,6 +318,28 @@ test('two-factor setup requires authentication and a valid code before activatin
 		type: '2fa',
 		secret: setupPayload.secret,
 	})
+	// Setup start, the rejected confirm, and the successful enable are audited.
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'account',
+			action: 'two_factor_setup_start',
+			result: 'success',
+		}),
+	)
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'account',
+			action: 'two_factor_enable',
+			result: 'failure',
+		}),
+	)
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'account',
+			action: 'two_factor_enable',
+			result: 'success',
+		}),
+	)
 })
 
 test('cancelling a pending setup removes it without touching active 2fa', async () => {
@@ -548,6 +575,20 @@ test('disabling 2fa requires a valid current code and clears stale pending rows'
 				.get() as { count: number }
 		).count,
 	).toBe(0)
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'account',
+			action: 'two_factor_disable',
+			result: 'failure',
+		}),
+	)
+	expect(auditSpy.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'account',
+			action: 'two_factor_disable',
+			result: 'success',
+		}),
+	)
 })
 
 test('setup and confirm are rejected while 2fa is already enabled', async () => {

--- a/packages/worker/src/app/retention.node.test.ts
+++ b/packages/worker/src/app/retention.node.test.ts
@@ -27,7 +27,10 @@ import {
 	workflowRunRetentionDays,
 } from './retention.ts'
 import { systemEmailOwnerId } from '#worker/email/system-email.ts'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import {
+	consoleWarn,
+	silenceExpectedConsoleWarns,
+} from '#worker/test-support/console-spies.ts'
 
 function applyMigrations(db: DatabaseSync) {
 	const migrationsDir = new URL('../../migrations/', import.meta.url)
@@ -842,7 +845,7 @@ test('email message retention never deletes rows whose blob cannot be deleted fi
 
 test('email message retention cursor advances past skipped blob rows at the head', async () => {
 	// Failed blob deletes are already counted via blobDeleteErrors below.
-	consoleWarn.mockImplementation(() => {})
+	silenceExpectedConsoleWarns(['retention-email-blob-delete-failed'])
 	const { sqlite, db } = createRetentionDb()
 	// The two oldest expired rows are blob-backed and unpassable while the
 	// R2 delete fails; the two plain expired rows behind them must still be
@@ -918,7 +921,7 @@ test('email message retention cursor advances past skipped blob rows at the head
 
 test('retention run prunes expired plain emails behind a skipped blob-row head', async () => {
 	// Failed blob deletes are already counted via blobDeleteErrors below.
-	consoleWarn.mockImplementation(() => {})
+	silenceExpectedConsoleWarns(['retention-email-blob-delete-failed'])
 	const { sqlite, db } = createRetentionDb()
 	// 251 blob-backed rows fill the first default-size batch and spill into the
 	// second; 5 plain expired rows sit behind them.

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -19,7 +19,7 @@ import { createForwardableEmailMessage } from './test-fixtures.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
 import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
 import { buildPublishedSourceManifestSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 
 const platformBaseUrl = 'https://kody.example.com'
@@ -67,7 +67,7 @@ async function seedVerifiedAccount(input: {
 test('inbound email routes {username}@platform-domain and auto-provisions the default inbox', async () => {
 	// Usage recording degrades with a warn when the usage_rollups table is
 	// not part of this test's schema; that is incidental to routing.
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	await ensureEmailTestSchema(env.APP_DB)
 	const username = `inbound-${crypto.randomUUID().slice(0, 8)}`
 	const accountEmail = `account-${crypto.randomUUID()}@example.com`
@@ -225,7 +225,7 @@ test('inbound email routes {username}@platform-domain and auto-provisions the de
 test('inbound email rejects unknown usernames, reserved locals, and foreign domains', async () => {
 	// Usage recording degrades with a warn when the usage_rollups table is
 	// not part of this test's schema; that is incidental to rejection.
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	await ensureEmailTestSchema(env.APP_DB)
 
 	async function expectRejected(input: { to: string; reason: string }) {
@@ -392,7 +392,7 @@ test('inbound email rejects unknown usernames, reserved locals, and foreign doma
 test('inbound email reclaims a platform address left behind by a username change', async () => {
 	// Usage recording degrades with a warn when the usage_rollups table is
 	// not part of this test's schema; that is incidental to reclaiming.
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	await ensureEmailTestSchema(env.APP_DB)
 	const username = `recycled-${crypto.randomUUID().slice(0, 8)}`
 	const address = `${username}@${platformDomain}`
@@ -794,7 +794,7 @@ test('raw MIME stays inline when the R2 put fails', async () => {
 test('inbound email handler dispatches package subscriptions for stored inbound email', async () => {
 	// The subscription runtime warns on optional lookups (usage rollups, MCP
 	// server refs) whose tables are not part of this test's schema.
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	await ensureEmailTestSchema(env.APP_DB)
 	const username = `subscriber-${crypto.randomUUID().slice(0, 8)}`
 	const accountEmail = `email-subscription-user-${crypto.randomUUID()}@example.com`

--- a/packages/worker/src/email/outbound.workers.test.ts
+++ b/packages/worker/src/email/outbound.workers.test.ts
@@ -17,6 +17,7 @@ import {
 	sendOutboundEmail,
 } from './outbound.ts'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 import { createMswNodeServer } from '#worker/test-support/msw-node-server.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import {
@@ -115,7 +116,7 @@ function restFallbackMustNotRunHandler() {
 test('sendOutboundEmail sends from the platform-assigned username address to the account email', async () => {
 	// Usage recording degrades with a warn when the usage_rollups table is
 	// not part of this test's schema; that is incidental to sending.
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	await ensureEmailTestSchema(env.APP_DB)
 	const accountEmail = `account-${crypto.randomUUID()}@example.com`
 	const userId = await createStableUserIdFromEmail(accountEmail)
@@ -193,7 +194,7 @@ test('sendOutboundEmail sends from the platform-assigned username address to the
 test('sendOutboundEmail rejects non-self recipients under the self policy', async () => {
 	// Usage recording degrades with a warn when the usage_rollups table is
 	// not part of this test's schema; that is incidental to the policy.
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	await ensureEmailTestSchema(env.APP_DB)
 	const accountEmail = `account-${crypto.randomUUID()}@example.com`
 	const userId = await createStableUserIdFromEmail(accountEmail)
@@ -282,7 +283,7 @@ test('sendOutboundEmail blocks reserved usernames and unconfigured platform doma
 test('sendOutboundEmail skips REST fallback when the binding succeeds or validation fails first', async () => {
 	// Usage recording degrades with a warn when the usage_rollups table is
 	// not part of this test's schema; that is incidental to the fallback.
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	await ensureEmailTestSchema(env.APP_DB)
 	const mswOptions = { onUnhandledRequest: 'bypass' as const }
 
@@ -382,7 +383,7 @@ test('sendOutboundEmail blocks unverified accounts', async () => {
 })
 
 test('sendOutboundEmail preserves reply headers and records failed fallback sends', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings(['cloudflare-email-api-failed'])
 	await ensureEmailTestSchema(env.APP_DB)
 	await ensureUsageRollupsTestSchema(env.APP_DB)
 	const isolatedUserId = `email-outbound-isolated-user-${crypto.randomUUID()}`

--- a/packages/worker/src/email/system-email-subscriptions.workers.test.ts
+++ b/packages/worker/src/email/system-email-subscriptions.workers.test.ts
@@ -7,7 +7,7 @@ import { createForwardableEmailMessage } from './test-fixtures.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
 import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
 import { buildPublishedSourceManifestSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 
 const platformBaseUrl = 'https://kody.example.com'
@@ -253,7 +253,7 @@ export default async function main(input = {}) {
 test('system inbound email dispatches email.system-message.received to admin-saved packages only', async () => {
 	// The subscription runtime warns on optional lookups (e.g. MCP server
 	// refs) whose tables are not part of this test's schema.
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	await ensureEmailTestSchema(env.APP_DB)
 	await ensureUsageRollupsTestSchema(env.APP_DB)
 	await ensurePackageSubscriptionTestSchema(env.APP_DB)

--- a/packages/worker/src/email/system-email.workers.test.ts
+++ b/packages/worker/src/email/system-email.workers.test.ts
@@ -14,6 +14,7 @@ import {
 import { createForwardableEmailMessage } from './test-fixtures.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 
@@ -338,7 +339,7 @@ test('system email retention prunes old operator-owned messages and counters', a
 })
 
 test('system email retention deletes blobs before rows and keeps rows when the blob delete fails', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings(['system-email-raw-mime-blob-delete-failed'])
 	await ensureEmailTestSchema(env.APP_DB)
 	const now = new Date('2026-07-06T12:00:00.000Z')
 	const old = new Date(
@@ -420,7 +421,7 @@ test('system email retention deletes blobs before rows and keeps rows when the b
 })
 
 test('system email retention advances past skipped blob rows at the head of a batch', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings(['system-email-raw-mime-blob-delete-failed'])
 	await ensureEmailTestSchema(env.APP_DB)
 	const now = new Date('2026-07-06T12:00:00.000Z')
 	const oldMs =

--- a/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
+++ b/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
@@ -1,5 +1,8 @@
 import { expect, test, vi } from 'vitest'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import {
+	consoleWarn,
+	silenceExpectedConsoleWarns,
+} from '#worker/test-support/console-spies.ts'
 
 const mockModule = vi.hoisted(() => ({
 	listEntitySourcesForExternalReconcile: vi.fn(),
@@ -391,7 +394,10 @@ test('reconcile does not reprocess a source whose cursor write keeps failing', a
 test('head sources with failing cursor writes do not starve sources behind them within a tick', async () => {
 	// Cursor-write failure warns are covered elsewhere; this test is about
 	// keyset paging, so the warns are silenced without assertions.
-	consoleWarn.mockImplementation(() => {})
+	silenceExpectedConsoleWarns([
+		'reconcile_artifacts_pushes cursor update failed',
+		'reconcile_artifacts_pushes source failed',
+	])
 	// Simulated table: two head-of-queue sources whose cursor writes keep
 	// failing, plus one healthy source ordered behind them.
 	const rows = [

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi, afterEach } from 'vitest'
 import { createMcpCallerContext } from '#mcp/context.ts'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { planLimits } from '#worker/entitlements/plans.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
@@ -1704,7 +1704,7 @@ test('getJobInspection reports alarm state, source code, and artifact gaps', asy
 
 test('executeJobOnce binds scheduled jobs to writable storage', async () => {
 	// Usage rollup writes are best-effort and fail against this fake env.
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	const env = {
 		APP_DB: db,
@@ -1887,7 +1887,7 @@ test('executeJobOnce binds scheduled jobs to writable storage', async () => {
 })
 
 test('executeJobOnce runs repo-backed one-off jobs from kody.json manifests', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	const env = {
 		APP_DB: db,
@@ -2086,7 +2086,7 @@ test('executeJobOnce runs repo-backed one-off jobs from kody.json manifests', as
 })
 
 test('executeJobOnce preserves kody secret and value semantics', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	const env = {
@@ -2263,7 +2263,7 @@ test('executeJobOnce preserves kody secret and value semantics', async () => {
 })
 
 test('executeJobOnce refreshes repo sessions when base commit moves', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -2434,7 +2434,7 @@ test('executeJobOnce refreshes repo sessions when base commit moves', async () =
 })
 
 test('executeJobOnce rebuilds stale published job bundles after the source commit changes', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -2574,7 +2574,7 @@ test('executeJobOnce rebuilds stale published job bundles after the source commi
 })
 
 test('executeJobOnce executes package-backed jobs from published artifacts', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -2703,7 +2703,7 @@ test('executeJobOnce executes package-backed jobs from published artifacts', asy
 })
 
 test('executeJobOnce bypasses typecheck-only failures when the stored repo policy allows it', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -2860,7 +2860,7 @@ test('executeJobOnce bypasses typecheck-only failures when the stored repo polic
 })
 
 test('executeJobOnce preserves bypass audit logs when execution fails after a typecheck-only bypass', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -3020,7 +3020,7 @@ test('executeJobOnce preserves bypass audit logs when execution fails after a ty
 })
 
 test('executeJobOnce succeeds for repo-backed jobs with repo-session absolute paths and migrated entrypoints', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -3202,7 +3202,7 @@ test('executeJobOnce succeeds for repo-backed jobs with repo-session absolute pa
 })
 
 test('executeJobOnce fails instead of reusing a stale repo session when discard fails', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -3307,7 +3307,7 @@ test('executeJobOnce fails instead of reusing a stale repo session when discard 
 })
 
 test('executeJobOnce bundles and runs ESM repo-backed job entrypoints', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -3509,7 +3509,7 @@ test('executeJobOnce bundles and runs ESM repo-backed job entrypoints', async ()
 })
 
 test('executeJobOnce returns an error when kody secret policy would reject execution', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	await insertPublishedEntitySource({
@@ -3657,7 +3657,7 @@ test('executeJobOnce returns an error when kody secret policy would reject execu
 })
 
 test('runJobNow deletes vectors for once jobs', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	const bundleKv = createBundleArtifactsKv()
 	const env = {
@@ -3804,7 +3804,7 @@ test('runJobNow deletes vectors for once jobs', async () => {
 })
 
 test('runJobNow can use a one-off repo check policy override without changing the stored job', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const db = createDatabase()
 	await insertPublishedEntitySource({
 		db,

--- a/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
@@ -1,5 +1,9 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { createMcpCallerContext } from '#mcp/context.ts'
+
+// These tests assert real `audit_events` rows written through the actual
+// audit pipeline, so opt out of the shared audit-log-spy setup mock.
+vi.unmock('#app/audit-log.ts')
 import { adminAuditLogQueryCapability } from './admin-audit-log-query.ts'
 import { adminSystemEmailGetCapability } from './admin-system-email-get.ts'
 import { adminSystemEmailListCapability } from './admin-system-email-list.ts'

--- a/packages/worker/src/mcp/capabilities/integrations/integration-registry-search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-registry-search.node.test.ts
@@ -44,7 +44,9 @@ const searchFixture = {
 test('integration_registry_search returns parsed results and rejects upstream failures', async () => {
 	// msw warns about the query string in the handler URL; that tooling
 	// notice is incidental to the capability behavior under test.
-	silenceExpectedConsoleWarns([/^\[MSW\] /])
+	silenceExpectedConsoleWarns([
+		/^\[MSW\] Found a redundant usage of query parameters/,
+	])
 	const url = buildIntegrationRegistrySearchUrlForTest('linear')
 	using _successServer = createMswNodeServer([
 		http.get(url, () => HttpResponse.json(searchFixture)),

--- a/packages/worker/src/mcp/capabilities/integrations/integration-registry-search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-registry-search.node.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { http, HttpResponse } from 'msw'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { silenceExpectedConsoleWarns } from '#worker/test-support/console-spies.ts'
 import { createMswNodeServer } from '#worker/test-support/msw-node-server.ts'
 import {
 	buildIntegrationRegistrySearchUrlForTest,
@@ -44,7 +44,7 @@ const searchFixture = {
 test('integration_registry_search returns parsed results and rejects upstream failures', async () => {
 	// msw warns about the query string in the handler URL; that tooling
 	// notice is incidental to the capability behavior under test.
-	consoleWarn.mockImplementation(() => {})
+	silenceExpectedConsoleWarns([/^\[MSW\] /])
 	const url = buildIntegrationRegistrySearchUrlForTest('linear')
 	using _successServer = createMswNodeServer([
 		http.get(url, () => HttpResponse.json(searchFixture)),

--- a/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
+++ b/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
 import { buildKodyModuleBundle } from '#worker/package-runtime/module-graph.ts'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 
 /**
  * Regression coverage for the production "RPC stub used after being
@@ -43,8 +43,9 @@ test(
 	'sequential executes with identical code reuse the dynamic worker without stale dispatcher stubs',
 	{ timeout: 60_000 },
 	async () => {
-		// The worker bundler emits an incidental experimental warning.
-		consoleWarn.mockImplementation(() => {})
+		// The bundler and registry runtime emit known incidental warnings; only
+		// those are swallowed, anything else still fails the test.
+		silenceIncidentalRuntimeWarnings()
 		const bundle = await buildKodyModuleBundle({
 			env: reuseEnv,
 			baseUrl: 'https://kody.dev',

--- a/packages/worker/src/mcp/observability.workers.test.ts
+++ b/packages/worker/src/mcp/observability.workers.test.ts
@@ -2,7 +2,7 @@ import { expect, test, vi } from 'vitest'
 import { capabilityMap } from '#mcp/capabilities/registry.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { errorFields, logMcpEvent } from '#mcp/observability.ts'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 
 const repoMockModule = vi.hoisted(() => ({
 	ensureEntitySource: vi.fn(),
@@ -132,7 +132,7 @@ test('observability helpers normalize errors and emit resilient mcp-event logs',
 test('package_save logs parse failures, rejects invalid manifests, and logs successful saves', async () => {
 	// The worker bundler emits an incidental experimental warning during the
 	// successful save's artifact rebuild.
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const originalInfo = console.info
 	const payloads: Array<string> = []
 	console.info = ((tag: unknown, json?: unknown) => {

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 import { type getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
 import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
@@ -27,7 +27,7 @@ import { type EntitySourceRow } from '#worker/repo/types.ts'
 test('buildKodyFns rejects role-gated capabilities even when passed an unfiltered registry', async () => {
 	// The stub Env has no MCP server storage, so metadata loading warns
 	// 'mcp-server-refs-load-failed' before degrading to "no MCP servers".
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const adminOnlyCapability = defineDomainCapability('admin', {
 		name: 'admin_user_list',
 		description: 'List admin user account metadata',
@@ -67,7 +67,7 @@ test('buildKodyFns rejects role-gated capabilities even when passed an unfiltere
 })
 
 test('package workflow tools create instances from package context and honor caller overrides in runModuleWithRegistry', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const created: Array<WorkflowInstanceCreateOptions<unknown>> = []
 	const workflowTools = createWorkflowTools({
 		env: {
@@ -226,7 +226,7 @@ export default async function run() {
 })
 
 test('runModuleWithRegistry queues inline workflows.create calls without runAt or idempotencyKey', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const created: Array<WorkflowInstanceCreateOptions<unknown>> = []
 	const env = {
 		APP_DB: {
@@ -649,7 +649,11 @@ function createRepoSessionRow(input: {
 }
 
 test('buildKodyFns updates and deletes jobs through production-shaped bindings', async () => {
-	consoleWarn.mockImplementation(() => {})
+	// Deleting the job also best-effort deletes its artifact repo, which fails
+	// against this test's stub fetch and logs a JSON warning.
+	silenceIncidentalRuntimeWarnings([
+		/^\{"message":"artifact repo delete failed"/,
+	])
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
 		user: {
@@ -826,7 +830,7 @@ test('buildKodyFns updates and deletes jobs through production-shaped bindings',
 })
 
 test('buildKodyFns resolves, denies, and tracks secret-marked capability inputs', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	let toolArguments: Record<string, unknown> | null = null
 	const connectorEnv = {
 		REMOTE_CONNECTOR_SESSION: {
@@ -1057,7 +1061,7 @@ test('buildKodyFns resolves, denies, and tracks secret-marked capability inputs'
 })
 
 test('remote connector calls round-trip through sanitized ToolDispatcher names', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	let toolArguments: Record<string, unknown> | null = null
 	const connectorEnv = {
 		REMOTE_CONNECTOR_SESSION: {
@@ -1139,7 +1143,7 @@ test('remote connector calls round-trip through sanitized ToolDispatcher names',
 })
 
 test('buildKodyFns rejects storage kody tools that collide with capabilities', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const env = {
 		STORAGE_RUNNER: {
 			idFromName(name: string) {
@@ -1239,7 +1243,7 @@ test('buildKodyFns rejects storage kody tools that collide with capabilities', a
 })
 
 test('runKodyWithRegistry redacts secret keys and survives cyclic results', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -1410,7 +1414,7 @@ export default async function run() {
 })
 
 test('runKodyWithRegistry routes module and snippet inputs through the expected execution path', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -1528,7 +1532,7 @@ export default async function run() {
 })
 
 test('runKodyWithRegistry forwards package context for module syntax', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -1640,7 +1644,7 @@ export default async function run() {
 })
 
 test('runBundledModuleWithRegistry passes params and injects runtime helpers', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const created: Array<WorkflowInstanceCreateOptions<unknown>> = []
 	const workflowEnv = {
 		APP_DB: {
@@ -2030,7 +2034,7 @@ test('runBundledModuleWithRegistry passes params and injects runtime helpers', a
 })
 
 test('runBundledModuleWithRegistry uses a prebuilt capability registry without reloading', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -2087,7 +2091,7 @@ test('runBundledModuleWithRegistry uses a prebuilt capability registry without r
 })
 
 test('runBundledModuleWithRegistry records package_export usage for bundled runs with package context', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -2253,7 +2257,7 @@ test('runBundledModuleWithRegistry records package_export usage for bundled runs
 })
 
 test('runBundledModuleWithRegistry omits OAuth helper prelude when execute helper capabilities are absent', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -2300,7 +2304,7 @@ test('runBundledModuleWithRegistry omits OAuth helper prelude when execute helpe
 })
 
 test('runBundledModuleWithRegistry injects OAuth helper prelude when execute helper capabilities are present', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',
@@ -2349,7 +2353,7 @@ test('runBundledModuleWithRegistry injects OAuth helper prelude when execute hel
 })
 
 test('runKodyWithRegistry expression path omits OAuth helper prelude without execute helper capabilities', async () => {
-	consoleWarn.mockImplementation(() => {})
+	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://heykody.dev',

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest'
 import {
 	consoleError,
 	consoleWarn,
+	silenceExpectedConsoleErrors,
 } from '#worker/test-support/console-spies.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { planLimits } from '#worker/entitlements/plans.ts'
@@ -543,7 +544,9 @@ test('deleteSavedPackageProjection resyncs the job manager after removing packag
 })
 
 test('deleteSavedPackageProjection continues best-effort cleanup when dependent steps fail', async () => {
-	consoleError.mockImplementation(() => {})
+	silenceExpectedConsoleErrors([
+		/"message":"package retriever projection update failed"/,
+	])
 	consoleWarn.mockImplementation(() => {})
 	setupDefaultMocks()
 	const env = createEnv()

--- a/packages/worker/src/package-runtime/module-graph.workers.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.workers.test.ts
@@ -9,14 +9,7 @@ import {
 } from './module-graph.ts'
 import { persistPublishedSourceSnapshot } from './published-runtime-artifacts.ts'
 import { persistPublishedBundleArtifact } from './published-bundle-artifacts.ts'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
-
-// Every test here runs the bundler (incidental experimental warning) and the
-// registry runtime, whose optional MCP-server and usage lookups warn when
-// their tables are absent from the test schema.
-function silenceIncidentalRuntimeWarnings() {
-	consoleWarn.mockImplementation(() => {})
-}
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 
 async function runSql(sql: string, ...values: Array<unknown>) {
 	await env.APP_DB.prepare(sql)

--- a/packages/worker/src/remote-connector/session.node.test.ts
+++ b/packages/worker/src/remote-connector/session.node.test.ts
@@ -161,6 +161,10 @@ test('remote connector session lifecycle across restore, snapshot, heartbeat, cl
 	closed.state.getWebSockets.mockReturnValue([])
 	await closed.session.webSocketClose({} as WebSocket, 1006, 'network', false)
 
+	expect(consoleWarn).toHaveBeenCalledTimes(1)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'Remote connector session websocket closed code=1006 wasClean=false reason=network',
+	)
 	expect(captureMessageMock).toHaveBeenCalledWith(
 		expect.any(String),
 		expect.objectContaining({

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -422,7 +422,8 @@ function setCommonSessionFixtures() {
 
 test('rebaseSession and publishSession use Artifacts username/password auth without token override', async () => {
 	// Best-effort publish git-note attachment fails in this mocked git
-	// environment and logs a warning that is incidental to auth behavior.
+	// environment and logs a warning that is incidental to auth behavior;
+	// it is asserted at the end of the test.
 	consoleWarn.mockImplementation(() => {})
 	setCommonSessionFixtures()
 	mockModule.writePublishedSourceSnapshot.mockClear()
@@ -482,6 +483,10 @@ test('rebaseSession and publishSession use Artifacts username/password auth with
 	for (const call of mockModule.git.push.mock.calls) {
 		expect(call[0]).not.toHaveProperty('token')
 	}
+	expect(consoleWarn).toHaveBeenCalledWith(
+		expect.stringContaining('publish_git_note'),
+		expect.anything(),
+	)
 })
 
 test('runCommands applies git apply patches (modify, delete, and rename)', async () => {
@@ -660,6 +665,10 @@ test('runCommands fetches session metadata after publish side effects', async ()
 		}),
 	)
 	expect(result.session.published_commit).toBe('commit-published')
+	expect(consoleWarn).toHaveBeenCalledWith(
+		expect.stringContaining('publish_git_note'),
+		expect.anything(),
+	)
 })
 
 test('publishSession persists the workspace snapshot to BUNDLE_ARTIFACTS_KV so downstream readers find the freshly published commit', async () => {
@@ -718,6 +727,10 @@ test('publishSession persists the workspace snapshot to BUNDLE_ARTIFACTS_KV so d
 			id: 'source-1',
 			publishedCommit: 'commit-published-new',
 		}),
+	)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		expect.stringContaining('publish_git_note'),
+		expect.anything(),
 	)
 })
 
@@ -1403,6 +1416,12 @@ test('publishFromExternalRef checks fast-forward ancestry through shell git adap
 				'package.json': '{"name":"@kody/demo"}',
 				'index.ts': 'export const ready = true\n',
 			},
+		}),
+	)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'publish_git_note failed',
+		expect.objectContaining({
+			scope: 'repo.publishFromExternalRef.publish-git-note',
 		}),
 	)
 })

--- a/packages/worker/src/test-support/audit-log-spy.ts
+++ b/packages/worker/src/test-support/audit-log-spy.ts
@@ -27,3 +27,12 @@ vi.mock('#app/audit-log.ts', async (importOriginal) => {
 			logAuditEventSpy(...args),
 	}
 })
+
+// Compact `action:result` view of every audit event recorded so far, in call
+// order. Asserting on this catches extra unexpected events that a bare
+// `toHaveBeenCalledWith` would let through.
+export function auditEventSummaries() {
+	return logAuditEventSpy.mock.calls.map(
+		([event]) => `${event.action}:${event.result}`,
+	)
+}

--- a/packages/worker/src/test-support/audit-log-spy.ts
+++ b/packages/worker/src/test-support/audit-log-spy.ts
@@ -1,0 +1,29 @@
+import { vi } from 'vitest'
+import type * as AuditLog from '#app/audit-log.ts'
+
+// Handlers fire `void logAuditEvent(...)` without awaiting it; with the real
+// sink those promises resolve after a test ends and leak `audit-event` lines
+// into the runner output once the console spies are restored. This setup file
+// (wired into the node-unit project in vitest.node.config.ts) routes the sink
+// through a shared spy so every test can assert the audit events it expects —
+// and that none fire where they shouldn't — instead of stubbing the module in
+// each test file.
+//
+// - Calls are cleared between tests (`clearMocks: true`), so assertions are
+//   always per-test.
+// - Files that test the real audit pipeline (e.g. asserting `audit_events`
+//   rows) opt out with `vi.unmock('#app/audit-log.ts')`.
+// - Files that need to override other exports (e.g. `getRequestIp`) declare
+//   their own `vi.mock('#app/audit-log.ts', ...)`, which takes precedence.
+export const logAuditEventSpy = vi.fn<typeof AuditLog.logAuditEvent>(
+	async () => undefined,
+)
+
+vi.mock('#app/audit-log.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof AuditLog>()
+	return {
+		...actual,
+		logAuditEvent: (...args: Parameters<typeof AuditLog.logAuditEvent>) =>
+			logAuditEventSpy(...args),
+	}
+})

--- a/packages/worker/src/test-support/console-spies.ts
+++ b/packages/worker/src/test-support/console-spies.ts
@@ -27,6 +27,40 @@ function failOnUnexpectedCall(
 	}
 }
 
+// For tests that exercise paths with known operational warnings/errors that
+// are incidental to the behavior under test: swallow exactly the expected
+// messages and fail on anything else, so silencing can never hide a new
+// unexpected log. Prefer asserting on the spy directly when the message
+// itself is part of the tested contract.
+function silenceExpectedCalls(
+	method: 'error' | 'warn',
+	spy: () => MockInstance<(...args: Array<unknown>) => void>,
+	patterns: Array<RegExp | string>,
+) {
+	spy().mockImplementation((...args: Array<unknown>) => {
+		const [first] = args
+		if (
+			typeof first === 'string' &&
+			patterns.some((pattern) =>
+				typeof pattern === 'string' ? pattern === first : pattern.test(first),
+			)
+		) {
+			return
+		}
+		throw new Error(
+			`Unexpected console.${method} call (not in this test's expected-message allowlist): ${String(first)}`,
+		)
+	})
+}
+
+export function silenceExpectedConsoleWarns(patterns: Array<RegExp | string>) {
+	silenceExpectedCalls('warn', () => consoleWarn, patterns)
+}
+
+export function silenceExpectedConsoleErrors(patterns: Array<RegExp | string>) {
+	silenceExpectedCalls('error', () => consoleError, patterns)
+}
+
 beforeEach(() => {
 	consoleError = vi
 		.spyOn(console, 'error')

--- a/packages/worker/src/test-support/incidental-runtime-warnings.ts
+++ b/packages/worker/src/test-support/incidental-runtime-warnings.ts
@@ -1,0 +1,24 @@
+import { silenceExpectedConsoleWarns } from './console-spies.ts'
+
+// The worker bundler warns that it is experimental, and the registry runtime's
+// optional MCP-server, usage, and runtime-debug lookups warn when their tables
+// are absent from the unit-test schema. Tests that run those paths swallow
+// exactly these messages; any other warning still fails the test so real
+// problems are never silently suppressed.
+const incidentalRuntimeWarnings = [
+	/^\[worker-bundler\] /,
+	'mcp-server-refs-load-failed',
+	'usage-event-record-failed',
+	'usage-event-analytics-failed',
+	'usage-rollup-failed',
+	'package-runtime-debug-start-failed',
+	'package-runtime-debug-logs-failed',
+	'package-runtime-debug-status-failed',
+	'package-runtime-debug-finish-unhandled',
+]
+
+export function silenceIncidentalRuntimeWarnings(
+	extraPatterns: Array<RegExp | string> = [],
+) {
+	silenceExpectedConsoleWarns([...incidentalRuntimeWarnings, ...extraPatterns])
+}

--- a/tools/vite-suppress-sourcemap-warnings.node.test.ts
+++ b/tools/vite-suppress-sourcemap-warnings.node.test.ts
@@ -1,0 +1,60 @@
+import { expect, test, vi } from 'vitest'
+import { type ResolvedConfig } from 'vite'
+import {
+	isThirdPartySourcemapWarning,
+	suppressThirdPartySourcemapWarnings,
+} from './vite-suppress-sourcemap-warnings.ts'
+
+const thirdPartyWarning =
+	'Sourcemap for "/workspace/node_modules/@modelcontextprotocol/sdk/dist/esm/types.js" points to missing source files'
+const firstPartyWarning =
+	'Sourcemap for "/workspace/packages/worker/src/index.ts" points to missing source files'
+
+test('matches only the third-party missing-sourcemap warning', () => {
+	expect(isThirdPartySourcemapWarning(thirdPartyWarning)).toBe(true)
+	expect(
+		isThirdPartySourcemapWarning(
+			'Sourcemap for "/workspace/node_modules/cron-schedule/dist/cron.js" points to missing source files',
+		),
+	).toBe(true)
+
+	// A first-party file with a broken sourcemap is our bug and must surface.
+	expect(isThirdPartySourcemapWarning(firstPartyWarning)).toBe(false)
+	expect(isThirdPartySourcemapWarning('Some unrelated vite warning')).toBe(
+		false,
+	)
+	expect(
+		isThirdPartySourcemapWarning(
+			`prefix ${thirdPartyWarning} suffix that changes the message`,
+		),
+	).toBe(false)
+})
+
+test('plugin drops third-party sourcemap warnings and forwards everything else', () => {
+	const warn = vi.fn()
+	const warnOnce = vi.fn()
+	const config = {
+		logger: { warn, warnOnce },
+	} as unknown as ResolvedConfig
+
+	const plugin = suppressThirdPartySourcemapWarnings()
+	const configResolved = plugin.configResolved
+	if (typeof configResolved !== 'function') {
+		throw new Error('expected configResolved hook to be a function')
+	}
+	configResolved.call(undefined as never, config)
+
+	config.logger.warn(thirdPartyWarning)
+	config.logger.warnOnce(thirdPartyWarning)
+	expect(warn).not.toHaveBeenCalled()
+	expect(warnOnce).not.toHaveBeenCalled()
+
+	config.logger.warn(firstPartyWarning)
+	config.logger.warnOnce('another real warning', { timestamp: true })
+	expect(warn).toHaveBeenCalledTimes(1)
+	expect(warn).toHaveBeenCalledWith(firstPartyWarning, undefined)
+	expect(warnOnce).toHaveBeenCalledTimes(1)
+	expect(warnOnce).toHaveBeenCalledWith('another real warning', {
+		timestamp: true,
+	})
+})

--- a/tools/vite-suppress-sourcemap-warnings.ts
+++ b/tools/vite-suppress-sourcemap-warnings.ts
@@ -1,0 +1,32 @@
+import { type Plugin } from 'vite'
+
+// Several npm packages (e.g. @modelcontextprotocol/sdk, cron-schedule) ship
+// sourcemaps whose `sources` files are not published, and Vite warns once per
+// transformed file ("Sourcemap ... points to missing source files"). That is
+// third-party packaging noise we cannot act on. Only that exact message for
+// node_modules files is dropped; every other Vite warning still surfaces so
+// real problems are never silently suppressed (see the companion test).
+const thirdPartySourcemapWarningPattern =
+	/^Sourcemap for ".*\/node_modules\/.*" points to missing source files$/
+
+export function isThirdPartySourcemapWarning(message: string): boolean {
+	return thirdPartySourcemapWarningPattern.test(message)
+}
+
+export function suppressThirdPartySourcemapWarnings(): Plugin {
+	return {
+		name: 'kody:suppress-third-party-sourcemap-warnings',
+		configResolved(config) {
+			const originalWarn = config.logger.warn.bind(config.logger)
+			const originalWarnOnce = config.logger.warnOnce.bind(config.logger)
+			config.logger.warn = (message, options) => {
+				if (isThirdPartySourcemapWarning(message)) return
+				originalWarn(message, options)
+			}
+			config.logger.warnOnce = (message, options) => {
+				if (isThirdPartySourcemapWarning(message)) return
+				originalWarnOnce(message, options)
+			}
+		},
+	}
+}

--- a/vitest-shared.ts
+++ b/vitest-shared.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { config as loadDotEnv } from 'dotenv'
 import { type UserConfig } from 'vitest/config'
+import { suppressThirdPartySourcemapWarnings } from './tools/vite-suppress-sourcemap-warnings.ts'
 
 export const rootDir = fileURLToPath(new URL('.', import.meta.url))
 const testTimeout = process.env.CI ? 20_000 : 5_000
@@ -11,14 +12,8 @@ loadDotEnv({
 	quiet: true,
 })
 
-// Several npm packages (e.g. @modelcontextprotocol/sdk, cron-schedule) ship
-// sourcemaps whose `sources` files are not published, and Vite warns once per
-// transformed file ("Sourcemap ... points to missing source files"). That is
-// third-party packaging noise we cannot act on, so only surface Vite errors.
-export const viteLogLevel = 'error' as const
-
 export const sharedProjectConfig = {
-	logLevel: viteLogLevel,
+	plugins: [suppressThirdPartySourcemapWarnings()],
 	resolve: {
 		alias: [
 			{

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vitest/config'
-import { viteLogLevel } from './vitest-shared.ts'
+import { suppressThirdPartySourcemapWarnings } from './tools/vite-suppress-sourcemap-warnings.ts'
 
 export default defineConfig({
 	// The workers pool resolves modules through this root-level Vite server, so
 	// the broken-third-party-sourcemap warning filter has to apply here too
-	// (see vitest-shared.ts).
-	logLevel: viteLogLevel,
+	// (see tools/vite-suppress-sourcemap-warnings.ts).
+	plugins: [suppressThirdPartySourcemapWarnings()],
 	test: {
 		projects: [
 			'./vitest.node.config.ts',

--- a/vitest.node.config.ts
+++ b/vitest.node.config.ts
@@ -44,6 +44,11 @@ export default mergeConfig(
 			name: 'node-unit',
 			environment: 'node',
 			include: ['**/*.node.test.ts'],
+			// Merged with the shared setupFiles (console spies). Routes the
+			// audit-log sink through a shared spy; see test-support/audit-log-spy.ts.
+			setupFiles: [
+				resolve(rootDir, 'packages/worker/src/test-support/audit-log-spy.ts'),
+			],
 		},
 	}),
 )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Follow-up to #721. When output is silenced in tests, we must assert on the output we expect — and assert the absence of output we don't — so a suppression can never hide a real regression. Several suppressions from the console-noise cleanup were blanket silences that violated that principle.

## What changed

### Vite warnings: blanket `logLevel: 'error'` → targeted filter
- `logLevel: 'error'` suppressed **every** Vite warning. Replaced with a `tools/vite-suppress-sourcemap-warnings.ts` plugin that drops only the exact `Sourcemap for "…/node_modules/…" points to missing source files` message; all other warnings (including first-party sourcemap breakage) still surface.
- `tools/vite-suppress-sourcemap-warnings.node.test.ts` asserts both directions: the third-party message is dropped, and first-party/unknown warnings pass through.

### Audit log: silent stubs → one shared spy with assertions
- New `packages/worker/src/test-support/audit-log-spy.ts` setup file (wired into the `node-unit` project) routes `logAuditEvent` through a single exported `logAuditEventSpy`, replacing the per-file `vi.hoisted` + `vi.mock` blocks that were previously repeated in seven handler test files (`auth-handler`, `auth-provider`, `two-factor`, `account-resend-verification`, `account-profile`, `password-reset`, `admin-users`).
- An `auditEventSummaries()` helper returns the ordered `action:result` list so tests assert the **exact** audit event sequence — extra unexpected events fail, not just missing ones. Tests also assert `not.toHaveBeenCalled()` where no audit is expected (profile reads).
- `admin-capabilities.node.test.ts` asserts real `audit_events` rows, so it opts out with `vi.unmock('#app/audit-log.ts')`; `password-reset`/`admin-users` keep a file-local mock only to pin `getRequestIp`, routing the sink back through the shared spy.

### Console silences: blanket `mockImplementation(() => {})` → allowlists or assertions
- New `silenceExpectedConsoleWarns` / `silenceExpectedConsoleErrors` helpers in `console-spies.ts`: swallow only an explicit allowlist of expected messages and **throw on anything else**.
- New `incidental-runtime-warnings.ts` shared allowlist for the recurring bundler/registry-runtime noise (`[worker-bundler]` experimental notice, `mcp-server-refs-load-failed`, `usage-*-failed`, `package-runtime-debug-*`).
- Converted all 44 previously-unasserted blanket silences across 16 test files (jobs service, run-kody-registry, email inbound/outbound/system, retention, reconcile, module-graph, observability, integration search, package-registry service, remote-connector session, repo-session DO) to either targeted allowlists or explicit `expect(consoleWarn).toHaveBeenCalledWith(...)` assertions.
- Every remaining `mockImplementation(() => {})` site now has an assertion on the captured calls (verified by scanning the tree).

### Docs
- `docs/contributing/testing-principles.md` now documents both rules: never silence blindly (assert on contract logs, use the allowlist helpers for incidental logs), and use the shared `logAuditEventSpy` for audit assertions.

## Testing

- ✅ `npm run validate` (format, lint, typecheck, 806 unit tests, 13 Playwright E2E, MCP E2E — all green)
- ✅ Verified the sourcemap filter end-to-end: with the filter disabled the workers pool emits 28 `Sourcemap … missing source files` warnings; with it enabled the full unit run has zero, and the unit test proves non-matching warnings still pass through.
- ✅ Full-suite output scan: 0 hits for `Sourcemap for`, `Using secrets defined`, `ExperimentalWarning`, `audit-event {`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk, test-only)</summary>

**Mode:** recap · **Base:** `main` @ `47c9a24e` · **Head:** `35562e0f`

**Classification:** composes — no runtime primitive code changes. The diff touches only test files, test-support helpers (`console-spies.ts`, new `incidental-runtime-warnings.ts` and `audit-log-spy.ts`), Vitest configuration, and a new Vite test plugin (`tools/vite-suppress-sourcemap-warnings.ts`). No entry in `primitives.yaml` is added or reshaped.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none)_  | —     | Tests covering `app-ui` auth/account handlers, `jobs`, `email`, `repo-sessions`, `package-runtime`, and `capabilities-execute` gained assertions on previously-silenced console output; the primitives themselves are unchanged. |

### Change flow

Test harness only: console silencing now goes through allowlist helpers that throw on unexpected messages, and per-file audit-log stubs became one shared setup-file spy with exact-sequence assertions.

```mermaid
flowchart LR
	testGuard["console-spies.ts<br/>global console guard"]:::extended
	allowlist["incidental-runtime-warnings.ts<br/>shared warning allowlist"]:::added
	auditSpy["audit-log-spy.ts<br/>shared logAuditEvent spy (node-unit setupFiles)"]:::added
	viteFilter["vite-suppress-sourcemap-warnings.ts<br/>targeted Vite warning filter"]:::added
	tests["17 test files<br/>unit + workers suites"]:::touched
	tests -->|"silenceExpectedConsoleWarns/Errors(allowlist)"| testGuard
	tests -->|"auditEventSummaries() exact-sequence assertions"| auditSpy
	tests -->|"silenceIncidentalRuntimeWarnings()"| allowlist
	testGuard -->|"throws on non-allowlisted messages"| tests
	viteFilter -->|"drops only third-party missing-sourcemap warning"| tests
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

_Red here means "new test-support module", not a new system primitive._

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d046b009-ba3d-4628-9c76-8cc8993fb0fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d046b009-ba3d-4628-9c76-8cc8993fb0fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened audit-log assertions across authentication, account, resend verification, two-factor, password reset, admin, and other worker workflows (including call counts and ordering).
  * Tightened console warning/error handling using targeted allowlisting for expected noise, while keeping unexpected logs as test failures.
  * Improved incidental runtime-warning suppression across multiple email, job, repo, and MCP scenarios.
  * Added unit tests for third-party sourcemap warning suppression and verified plugin behavior.
* **Documentation**
  * Updated testing principles to clarify expected vs incidental console log handling and audit-log mocking guidance.
* **Chores**
  * Introduced shared test helpers for audit-log capturing and selective console-noise silencing; registered the sourcemap-warning suppression plugin in Vitest config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->