### PR TITLE
Add admin insights dashboard with hand-rolled SVG charts

### DIFF
--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -32,6 +32,11 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	await page.goto('/admin/usage')
 	await expect(page.getByRole('heading', { name: 'Admin usage' })).toBeHidden()
 	await expect(page.getByText('Forbidden')).toBeVisible()
+	await page.goto('/admin/insights')
+	await expect(
+		page.getByRole('heading', { name: 'Admin insights' }),
+	).toBeHidden()
+	await expect(page.getByText('Forbidden')).toBeVisible()
 	await expect(
 		page.getByRole('link', { name: 'Admin', exact: true }),
 	).toHaveCount(0)
@@ -143,6 +148,23 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	expect(usagePayload.ok).toBe(true)
 	expect(JSON.stringify(usagePayload)).not.toContain('memberPrivateSecret')
 	expect(JSON.stringify(usagePayload)).not.toContain('super-secret-value')
+
+	await page.goto('/admin/insights')
+	await expect(
+		page.getByRole('heading', { name: 'Admin insights' }),
+	).toBeVisible()
+	await expect(page.getByText('Unable to load admin insights.')).toHaveCount(0)
+	await expect(page.getByRole('heading', { name: 'User growth' })).toBeVisible()
+	await expect(
+		page.getByRole('img', { name: 'Cumulative registered users per week' }),
+	).toBeVisible()
+	const insightsApiResponse = await page.request.get('/admin/insights.json')
+	expect(insightsApiResponse.ok()).toBe(true)
+	const insightsPayload = await insightsApiResponse.json()
+	expect(insightsPayload.ok).toBe(true)
+	expect(JSON.stringify(insightsPayload)).not.toContain('memberPrivateSecret')
+	expect(JSON.stringify(insightsPayload)).not.toContain('super-secret-value')
+	expect(JSON.stringify(insightsPayload)).not.toContain(memberUser.email)
 
 	await page.goto(`/admin/users?pageSize=100&page=${lastUsersPage}`)
 	await page.getByRole('button', { name: memberUser.username }).click()

--- a/packages/worker/client/charts/area-chart.tsx
+++ b/packages/worker/client/charts/area-chart.tsx
@@ -1,0 +1,185 @@
+import { css, type Handle } from 'remix/ui'
+import { colors } from '#client/styles/tokens.ts'
+import {
+	buildSmoothAreaPath,
+	buildSmoothLinePath,
+	buildTicks,
+	type ChartPoint,
+} from './chart-geometry.ts'
+import {
+	chartAxisTextCss,
+	chartGridStroke,
+	formatCompactNumber,
+	formatIntegerNumber,
+	softColor,
+} from './chart-theme.ts'
+
+export type AreaChartSeries = {
+	label: string
+	color: string
+	values: Array<number>
+}
+
+type AreaChartProps = {
+	/** Unique id prefix for gradient defs (must be unique per page). */
+	id: string
+	series: Array<AreaChartSeries>
+	/** One label per data point, oldest first. */
+	xLabels: Array<string>
+	ariaLabel: string
+	/** Render every nth x axis label (default: fit about six labels). */
+	xTickEvery?: number
+	height?: number
+}
+
+const width = 720
+const pad = { top: 14, right: 16, bottom: 26, left: 46 }
+
+/**
+ * Smooth multi-series area chart with gradient fills, grid lines, and
+ * native hover tooltips (per-column `<title>` elements).
+ */
+export function AreaChart(handle: Handle<AreaChartProps>) {
+	return () => {
+		const { id, series, xLabels, ariaLabel } = handle.props
+		const height = handle.props.height ?? 230
+		const plotWidth = width - pad.left - pad.right
+		const plotHeight = height - pad.top - pad.bottom
+		const baselineY = pad.top + plotHeight
+		const pointCount = xLabels.length
+		const maxValue = Math.max(
+			0,
+			...series.flatMap((entry) => entry.values.map((value) => value ?? 0)),
+		)
+		const ticks = buildTicks(maxValue)
+		const topTick = ticks[ticks.length - 1] ?? 1
+		const xAt = (index: number) =>
+			pointCount <= 1
+				? pad.left + plotWidth / 2
+				: pad.left + (plotWidth * index) / (pointCount - 1)
+		const yAt = (value: number) => baselineY - (plotHeight * value) / topTick
+		const seriesPoints = series.map((entry) =>
+			entry.values.map(
+				(value, index): ChartPoint => ({ x: xAt(index), y: yAt(value ?? 0) }),
+			),
+		)
+		const xTickEvery =
+			handle.props.xTickEvery ?? Math.max(1, Math.ceil(pointCount / 6))
+
+		return (
+			<svg
+				viewBox={`0 0 ${width} ${height}`}
+				role="img"
+				aria-label={ariaLabel}
+				mix={css({ width: '100%', height: 'auto', display: 'block' })}
+			>
+				<defs>
+					{series.map((entry, seriesIndex) => (
+						<linearGradient
+							key={entry.label}
+							id={`${id}-grad-${seriesIndex}`}
+							x1="0"
+							y1="0"
+							x2="0"
+							y2="1"
+						>
+							<stop offset="0%" stopColor={entry.color} stopOpacity="0.32" />
+							<stop offset="100%" stopColor={entry.color} stopOpacity="0" />
+						</linearGradient>
+					))}
+				</defs>
+				{ticks.map((tick) => (
+					<g key={tick}>
+						<line
+							x1={pad.left}
+							y1={yAt(tick)}
+							x2={width - pad.right}
+							y2={yAt(tick)}
+							stroke={chartGridStroke}
+							strokeWidth="1"
+							strokeDasharray={tick === 0 ? undefined : '3 5'}
+						/>
+						<text
+							x={pad.left - 8}
+							y={yAt(tick) + 3.5}
+							textAnchor="end"
+							mix={css(chartAxisTextCss)}
+						>
+							{formatCompactNumber(tick)}
+						</text>
+					</g>
+				))}
+				{xLabels.map((label, index) =>
+					index % xTickEvery === 0 ? (
+						<text
+							key={`${label}-${index}`}
+							x={xAt(index)}
+							y={height - 8}
+							textAnchor="middle"
+							mix={css(chartAxisTextCss)}
+						>
+							{label}
+						</text>
+					) : null,
+				)}
+				{series.map((entry, seriesIndex) => {
+					const points = seriesPoints[seriesIndex] ?? []
+					const lastPoint = points[points.length - 1]
+					return (
+						<g key={entry.label}>
+							<path
+								d={buildSmoothAreaPath(points, baselineY)}
+								fill={`url(#${id}-grad-${seriesIndex})`}
+							/>
+							<path
+								d={buildSmoothLinePath(points)}
+								fill="none"
+								stroke={entry.color}
+								strokeWidth="2.5"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							/>
+							{lastPoint ? (
+								<circle
+									cx={lastPoint.x}
+									cy={lastPoint.y}
+									r="4"
+									fill={entry.color}
+									stroke={colors.surface}
+									strokeWidth="1.5"
+								/>
+							) : null}
+						</g>
+					)
+				})}
+				{xLabels.map((label, index) => (
+					<rect
+						key={`hover-${label}-${index}`}
+						x={
+							pointCount <= 1
+								? pad.left
+								: xAt(index) - plotWidth / (pointCount - 1) / 2
+						}
+						y={pad.top}
+						width={pointCount <= 1 ? plotWidth : plotWidth / (pointCount - 1)}
+						height={plotHeight}
+						fill="transparent"
+						mix={css({
+							'&:hover': { fill: softColor(colors.primary, 7) },
+						})}
+					>
+						<title>
+							{[
+								label,
+								...series.map(
+									(entry) =>
+										`${entry.label}: ${formatIntegerNumber(entry.values[index] ?? 0)}`,
+								),
+							].join('\n')}
+						</title>
+					</rect>
+				))}
+			</svg>
+		)
+	}
+}

--- a/packages/worker/client/charts/chart-geometry.node.test.ts
+++ b/packages/worker/client/charts/chart-geometry.node.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from 'vitest'
+import {
+	buildDonutSegments,
+	buildSmoothAreaPath,
+	buildSmoothLinePath,
+	buildTicks,
+	niceMax,
+} from './chart-geometry.ts'
+
+test('niceMax rounds up to a 1/2/2.5/5 x 10^n value', () => {
+	expect(niceMax(0)).toBe(1)
+	expect(niceMax(1)).toBe(1)
+	expect(niceMax(3)).toBe(5)
+	expect(niceMax(7)).toBe(10)
+	expect(niceMax(23)).toBe(25)
+	expect(niceMax(120)).toBe(200)
+	expect(niceMax(4900)).toBe(5000)
+})
+
+test('buildTicks returns evenly spaced values including zero and the top', () => {
+	expect(buildTicks(7)).toEqual([0, 2.5, 5, 7.5, 10])
+	expect(buildTicks(0)).toEqual([0, 0.25, 0.5, 0.75, 1])
+})
+
+test('buildSmoothLinePath starts with a move and emits bezier segments', () => {
+	const path = buildSmoothLinePath([
+		{ x: 0, y: 10 },
+		{ x: 10, y: 0 },
+		{ x: 20, y: 10 },
+	])
+	expect(path.startsWith('M 0 10')).toBe(true)
+	expect(path.match(/C /g)).toHaveLength(2)
+	expect(buildSmoothLinePath([])).toBe('')
+	expect(buildSmoothLinePath([{ x: 3, y: 4 }])).toBe('M 3 4')
+})
+
+test('buildSmoothAreaPath closes the shape down to the baseline', () => {
+	const path = buildSmoothAreaPath(
+		[
+			{ x: 0, y: 10 },
+			{ x: 10, y: 0 },
+		],
+		50,
+	)
+	expect(path.endsWith('L 10 50 L 0 50 Z')).toBe(true)
+})
+
+test('buildDonutSegments allocates angles proportionally with gaps', () => {
+	const segments = buildDonutSegments([3, 1], 0.04)
+	expect(segments).toHaveLength(2)
+	const first = segments[0]
+	const second = segments[1]
+	if (!first || !second) throw new Error('expected two segments')
+	expect(first.fraction).toBeCloseTo(0.75)
+	expect(second.fraction).toBeCloseTo(0.25)
+	const firstSpan = first.endAngle - first.startAngle
+	const secondSpan = second.endAngle - second.startAngle
+	expect(firstSpan / secondSpan).toBeCloseTo(3)
+	// Two gaps of 0.04 radians are reserved.
+	expect(firstSpan + secondSpan).toBeCloseTo(Math.PI * 2 - 0.08)
+})
+
+test('buildDonutSegments handles zero totals and zero-value slices', () => {
+	expect(buildDonutSegments([0, 0])).toEqual([
+		{ startAngle: 0, endAngle: 0, fraction: 0 },
+		{ startAngle: 0, endAngle: 0, fraction: 0 },
+	])
+	const segments = buildDonutSegments([5, 0], 0.04)
+	// A single visible slice takes the full circle with no gap.
+	const only = segments[0]
+	if (!only) throw new Error('expected a segment')
+	expect(only.endAngle - only.startAngle).toBeCloseTo(Math.PI * 2)
+	expect(segments[1]?.fraction).toBe(0)
+})

--- a/packages/worker/client/charts/chart-geometry.ts
+++ b/packages/worker/client/charts/chart-geometry.ts
@@ -1,0 +1,149 @@
+/**
+ * Pure geometry helpers for the hand-rolled SVG charts. Kept free of DOM
+ * and framework imports so they can be unit tested directly.
+ */
+
+export type ChartPoint = { x: number; y: number }
+
+/** Smallest 1/2/2.5/5 x 10^n value that is >= the given value. */
+export function niceMax(value: number) {
+	if (!Number.isFinite(value) || value <= 0) return 1
+	const exponent = Math.floor(Math.log10(value))
+	const magnitude = 10 ** exponent
+	const fraction = value / magnitude
+	if (fraction <= 1) return magnitude
+	if (fraction <= 2) return 2 * magnitude
+	if (fraction <= 2.5) return 2.5 * magnitude
+	if (fraction <= 5) return 5 * magnitude
+	return 10 * magnitude
+}
+
+/** Evenly spaced axis tick values from 0 to niceMax(maxValue) inclusive. */
+export function buildTicks(maxValue: number, count = 4) {
+	const top = niceMax(maxValue)
+	const ticks: Array<number> = []
+	for (let index = 0; index <= count; index += 1) {
+		ticks.push((top * index) / count)
+	}
+	return ticks
+}
+
+/**
+ * Smooth open path through the given points using Catmull-Rom segments
+ * converted to cubic beziers, clamped so the curve never dips below the
+ * horizontal band of its neighboring points (avoids fake negative dips).
+ */
+export function buildSmoothLinePath(points: Array<ChartPoint>) {
+	if (points.length === 0) return ''
+	const start = points[0]
+	if (!start) return ''
+	if (points.length === 1) return `M ${round(start.x)} ${round(start.y)}`
+	let path = `M ${round(start.x)} ${round(start.y)}`
+	for (let index = 0; index < points.length - 1; index += 1) {
+		const previous = points[index - 1] ?? points[index]
+		const current = points[index]
+		const next = points[index + 1]
+		const following = points[index + 2] ?? next
+		if (!previous || !current || !next || !following) continue
+		const control1 = {
+			x: current.x + (next.x - previous.x) / 6,
+			y: clampBetween(current.y + (next.y - previous.y) / 6, current.y, next.y),
+		}
+		const control2 = {
+			x: next.x - (following.x - current.x) / 6,
+			y: clampBetween(
+				next.y - (following.y - current.y) / 6,
+				current.y,
+				next.y,
+			),
+		}
+		path += ` C ${round(control1.x)} ${round(control1.y)}, ${round(control2.x)} ${round(control2.y)}, ${round(next.x)} ${round(next.y)}`
+	}
+	return path
+}
+
+/** Closed path for the area under a smooth line down to the baseline. */
+export function buildSmoothAreaPath(
+	points: Array<ChartPoint>,
+	baselineY: number,
+) {
+	const first = points[0]
+	const last = points[points.length - 1]
+	if (!first || !last) return ''
+	const line = buildSmoothLinePath(points)
+	return `${line} L ${round(last.x)} ${round(baselineY)} L ${round(first.x)} ${round(baselineY)} Z`
+}
+
+/**
+ * SVG arc path along a circle, for donut slices drawn with strokes. Angles
+ * are in radians with 0 at 12 o'clock, increasing clockwise.
+ */
+export function describeArc(
+	cx: number,
+	cy: number,
+	radius: number,
+	startAngle: number,
+	endAngle: number,
+) {
+	const start = pointOnCircle(cx, cy, radius, startAngle)
+	const end = pointOnCircle(cx, cy, radius, endAngle)
+	const largeArc = endAngle - startAngle > Math.PI ? 1 : 0
+	return `M ${round(start.x)} ${round(start.y)} A ${radius} ${radius} 0 ${largeArc} 1 ${round(end.x)} ${round(end.y)}`
+}
+
+export type DonutSegmentGeometry = {
+	startAngle: number
+	endAngle: number
+	fraction: number
+}
+
+/**
+ * Angular segments for a donut chart with a small gap between slices.
+ * Zero-value slices produce zero-length segments so indexes stay aligned
+ * with the input values.
+ */
+export function buildDonutSegments(
+	values: Array<number>,
+	padAngle = 0.04,
+): Array<DonutSegmentGeometry> {
+	const total = values.reduce((sum, value) => sum + Math.max(0, value), 0)
+	if (total <= 0) {
+		return values.map(() => ({ startAngle: 0, endAngle: 0, fraction: 0 }))
+	}
+	const visibleCount = values.filter((value) => value > 0).length
+	const gap = visibleCount > 1 ? padAngle : 0
+	const available = Math.PI * 2 - gap * visibleCount
+	let cursor = 0
+	return values.map((value) => {
+		const fraction = Math.max(0, value) / total
+		if (value <= 0) {
+			return { startAngle: cursor, endAngle: cursor, fraction: 0 }
+		}
+		const startAngle = cursor
+		const endAngle = startAngle + available * fraction
+		cursor = endAngle + gap
+		return { startAngle, endAngle, fraction }
+	})
+}
+
+export function pointOnCircle(
+	cx: number,
+	cy: number,
+	radius: number,
+	angle: number,
+) {
+	return {
+		x: cx + radius * Math.sin(angle),
+		y: cy - radius * Math.cos(angle),
+	}
+}
+
+function clampBetween(value: number, boundA: number, boundB: number) {
+	const min = Math.min(boundA, boundB)
+	const max = Math.max(boundA, boundB)
+	return Math.min(max, Math.max(min, value))
+}
+
+function round(value: number) {
+	return Math.round(value * 100) / 100
+}

--- a/packages/worker/client/charts/chart-legend.tsx
+++ b/packages/worker/client/charts/chart-legend.tsx
@@ -1,0 +1,64 @@
+import { css, type Handle } from 'remix/ui'
+import { colors, spacing, typography } from '#client/styles/tokens.ts'
+
+export type ChartLegendItem = {
+	label: string
+	color: string
+	value?: string
+}
+
+type ChartLegendProps = {
+	items: Array<ChartLegendItem>
+}
+
+/** Wrapped inline legend of colored dots for the larger charts. */
+export function ChartLegend(handle: Handle<ChartLegendProps>) {
+	return () => (
+		<ul
+			mix={css({
+				listStyle: 'none',
+				margin: 0,
+				padding: 0,
+				display: 'flex',
+				flexWrap: 'wrap',
+				gap: `${spacing.xs} ${spacing.lg}`,
+			})}
+		>
+			{handle.props.items.map((item) => (
+				<li
+					key={item.label}
+					mix={css({
+						display: 'flex',
+						alignItems: 'center',
+						gap: spacing.sm,
+						fontSize: typography.fontSize.sm,
+						color: colors.textMuted,
+					})}
+				>
+					<span
+						aria-hidden="true"
+						mix={css({
+							width: '0.625rem',
+							height: '0.625rem',
+							borderRadius: '999px',
+							backgroundColor: item.color,
+							flexShrink: 0,
+						})}
+					/>
+					{item.label}
+					{item.value ? (
+						<span
+							mix={css({
+								color: colors.text,
+								fontWeight: typography.fontWeight.medium,
+								fontVariantNumeric: 'tabular-nums',
+							})}
+						>
+							{item.value}
+						</span>
+					) : null}
+				</li>
+			))}
+		</ul>
+	)
+}

--- a/packages/worker/client/charts/chart-theme.ts
+++ b/packages/worker/client/charts/chart-theme.ts
@@ -1,0 +1,65 @@
+import { colors, typography } from '#client/styles/tokens.ts'
+
+/**
+ * Chart series palette. Mid-lightness hues chosen to stay legible on both
+ * the light and dark surface colors.
+ */
+export const chartColor = {
+	blue: '#3b82f6',
+	emerald: '#10b981',
+	amber: '#f59e0b',
+	violet: '#8b5cf6',
+	rose: '#f43f5e',
+	cyan: '#06b6d4',
+	lime: '#84cc16',
+	fuchsia: '#d946ef',
+} as const
+
+export const chartSeriesColors = [
+	chartColor.blue,
+	chartColor.emerald,
+	chartColor.amber,
+	chartColor.violet,
+	chartColor.rose,
+	chartColor.cyan,
+	chartColor.lime,
+	chartColor.fuchsia,
+] as const
+
+export const chartGridStroke =
+	'color-mix(in srgb, var(--color-border) 55%, transparent)'
+
+export const chartEmptyFill =
+	'color-mix(in srgb, var(--color-border) 45%, transparent)'
+
+export const chartAxisTextCss = {
+	fill: colors.textMuted,
+	fontSize: '11px',
+	fontFamily: typography.fontFamily,
+} as const
+
+export function softColor(color: string, percent: number) {
+	return `color-mix(in srgb, ${color} ${percent}%, transparent)`
+}
+
+const compactFormatter = new Intl.NumberFormat('en-US', {
+	notation: 'compact',
+	maximumFractionDigits: 1,
+})
+
+const integerFormatter = new Intl.NumberFormat('en-US')
+
+export function formatCompactNumber(value: number) {
+	return compactFormatter.format(value)
+}
+
+export function formatIntegerNumber(value: number) {
+	return integerFormatter.format(value)
+}
+
+export function formatPercentShare(fraction: number) {
+	if (!Number.isFinite(fraction)) return '0%'
+	const percent = fraction * 100
+	if (percent > 0 && percent < 1) return '<1%'
+	return `${Math.round(percent)}%`
+}

--- a/packages/worker/client/charts/donut-chart.tsx
+++ b/packages/worker/client/charts/donut-chart.tsx
@@ -1,0 +1,198 @@
+import { css, type Handle } from 'remix/ui'
+import { colors, spacing, typography } from '#client/styles/tokens.ts'
+import { buildDonutSegments, describeArc } from './chart-geometry.ts'
+import {
+	chartEmptyFill,
+	formatIntegerNumber,
+	formatPercentShare,
+} from './chart-theme.ts'
+
+export type DonutSlice = {
+	label: string
+	value: number
+	color: string
+}
+
+type DonutChartProps = {
+	slices: Array<DonutSlice>
+	centerLabel: string
+	ariaLabel: string
+	/** Text shown when every slice is zero. */
+	emptyText?: string
+}
+
+const size = 180
+const radius = 66
+const strokeWidth = 26
+const center = size / 2
+
+/**
+ * Donut chart with a center total and a wrapped legend showing counts and
+ * percent shares. Slices get native hover tooltips.
+ */
+export function DonutChart(handle: Handle<DonutChartProps>) {
+	return () => {
+		const { slices, centerLabel, ariaLabel } = handle.props
+		const total = slices.reduce((sum, slice) => sum + slice.value, 0)
+		const segments = buildDonutSegments(slices.map((slice) => slice.value))
+
+		return (
+			<div
+				mix={css({
+					display: 'flex',
+					gap: spacing.lg,
+					alignItems: 'center',
+					flexWrap: 'wrap',
+				})}
+			>
+				<svg
+					viewBox={`0 0 ${size} ${size}`}
+					role="img"
+					aria-label={ariaLabel}
+					mix={css({ width: '11.25rem', maxWidth: '100%', flexShrink: 0 })}
+				>
+					{total <= 0 ? (
+						<circle
+							cx={center}
+							cy={center}
+							r={radius}
+							fill="none"
+							stroke={chartEmptyFill}
+							strokeWidth={strokeWidth}
+						/>
+					) : (
+						slices.map((slice, index) => {
+							const segment = segments[index]
+							if (!segment || segment.fraction <= 0) return null
+							// A single full-circle slice cannot be drawn with an arc
+							// command (start and end coincide), so use a circle.
+							if (segment.fraction >= 1) {
+								return (
+									<circle
+										key={slice.label}
+										cx={center}
+										cy={center}
+										r={radius}
+										fill="none"
+										stroke={slice.color}
+										strokeWidth={strokeWidth}
+									>
+										<title>{`${slice.label}: ${formatIntegerNumber(slice.value)} (100%)`}</title>
+									</circle>
+								)
+							}
+							return (
+								<path
+									key={slice.label}
+									d={describeArc(
+										center,
+										center,
+										radius,
+										segment.startAngle,
+										segment.endAngle,
+									)}
+									fill="none"
+									stroke={slice.color}
+									strokeWidth={strokeWidth}
+									mix={css({
+										transition: 'opacity var(--transition-fast)',
+										'&:hover': { opacity: 0.8 },
+									})}
+								>
+									<title>{`${slice.label}: ${formatIntegerNumber(slice.value)} (${formatPercentShare(segment.fraction)})`}</title>
+								</path>
+							)
+						})
+					)}
+					<text
+						x={center}
+						y={center - 4}
+						textAnchor="middle"
+						mix={css({
+							fill: colors.text,
+							fontSize: '26px',
+							fontWeight: typography.fontWeight.semibold,
+							fontFamily: typography.fontFamily,
+						})}
+					>
+						{formatIntegerNumber(total)}
+					</text>
+					<text
+						x={center}
+						y={center + 16}
+						textAnchor="middle"
+						mix={css({
+							fill: colors.textMuted,
+							fontSize: '11px',
+							fontFamily: typography.fontFamily,
+						})}
+					>
+						{centerLabel}
+					</text>
+				</svg>
+				<ul
+					mix={css({
+						listStyle: 'none',
+						margin: 0,
+						padding: 0,
+						display: 'grid',
+						gap: spacing.xs,
+						minWidth: 0,
+					})}
+				>
+					{total <= 0 ? (
+						<li
+							mix={css({
+								color: colors.textMuted,
+								fontSize: typography.fontSize.sm,
+							})}
+						>
+							{handle.props.emptyText ?? 'No data yet.'}
+						</li>
+					) : (
+						slices
+							.filter((slice) => slice.value > 0)
+							.map((slice) => (
+								<li
+									key={slice.label}
+									mix={css({
+										display: 'flex',
+										alignItems: 'center',
+										gap: spacing.sm,
+										fontSize: typography.fontSize.sm,
+										color: colors.text,
+									})}
+								>
+									<span
+										aria-hidden="true"
+										mix={css({
+											width: '0.625rem',
+											height: '0.625rem',
+											borderRadius: '999px',
+											backgroundColor: slice.color,
+											flexShrink: 0,
+										})}
+									/>
+									<span mix={css({ minWidth: 0, overflowWrap: 'anywhere' })}>
+										{slice.label}
+									</span>
+									<span
+										mix={css({
+											color: colors.textMuted,
+											whiteSpace: 'nowrap',
+											marginLeft: 'auto',
+											paddingLeft: spacing.sm,
+											fontVariantNumeric: 'tabular-nums',
+										})}
+									>
+										{formatIntegerNumber(slice.value)} ·{' '}
+										{formatPercentShare(slice.value / total)}
+									</span>
+								</li>
+							))
+					)}
+				</ul>
+			</div>
+		)
+	}
+}

--- a/packages/worker/client/charts/heatmap-chart.tsx
+++ b/packages/worker/client/charts/heatmap-chart.tsx
@@ -1,0 +1,104 @@
+import { css, type Handle } from 'remix/ui'
+import { chartAxisTextCss, chartEmptyFill, softColor } from './chart-theme.ts'
+
+export type HeatmapCell = {
+	/** 0 = Sunday through 6 = Saturday, matching `Date#getUTCDay`. */
+	weekday: number
+	/** Hour of day, 0-23. */
+	hour: number
+	count: number
+}
+
+type HeatmapChartProps = {
+	cells: Array<HeatmapCell>
+	color: string
+	ariaLabel: string
+	/** Tooltip noun, for example `auth events`. */
+	unitLabel: string
+}
+
+// Rows are displayed Monday-first.
+const weekdayRows = [1, 2, 3, 4, 5, 6, 0] as const
+const weekdayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
+
+const leftPad = 34
+const topPad = 6
+const cellWidth = 24
+const cellHeight = 17
+const cellGap = 3
+const width = leftPad + 24 * (cellWidth + cellGap)
+const height = topPad + 7 * (cellHeight + cellGap) + 20
+
+/**
+ * Weekday x hour activity heatmap (UTC) with intensity scaled to the
+ * busiest cell.
+ */
+export function HeatmapChart(handle: Handle<HeatmapChartProps>) {
+	return () => {
+		const { cells, color, ariaLabel, unitLabel } = handle.props
+		const countByCell = new Map<string, number>()
+		let maxCount = 0
+		for (const cell of cells) {
+			countByCell.set(`${cell.weekday}:${cell.hour}`, cell.count)
+			maxCount = Math.max(maxCount, cell.count)
+		}
+
+		return (
+			<svg
+				viewBox={`0 0 ${width} ${height}`}
+				role="img"
+				aria-label={ariaLabel}
+				mix={css({ width: '100%', height: 'auto', display: 'block' })}
+			>
+				{weekdayRows.map((weekday, rowIndex) => (
+					<text
+						key={weekday}
+						x={leftPad - 8}
+						y={topPad + rowIndex * (cellHeight + cellGap) + cellHeight / 2 + 4}
+						textAnchor="end"
+						mix={css(chartAxisTextCss)}
+					>
+						{weekdayLabels[weekday]}
+					</text>
+				))}
+				{Array.from({ length: 24 }, (_, hour) =>
+					hour % 6 === 0 ? (
+						<text
+							key={hour}
+							x={leftPad + hour * (cellWidth + cellGap) + cellWidth / 2}
+							y={height - 4}
+							textAnchor="middle"
+							mix={css(chartAxisTextCss)}
+						>
+							{String(hour).padStart(2, '0')}:00
+						</text>
+					) : null,
+				)}
+				{weekdayRows.map((weekday, rowIndex) =>
+					Array.from({ length: 24 }, (_, hour) => {
+						const count = countByCell.get(`${weekday}:${hour}`) ?? 0
+						const intensity =
+							maxCount > 0 && count > 0
+								? 12 + Math.round((count / maxCount) * 78)
+								: 0
+						return (
+							<rect
+								key={`${weekday}-${hour}`}
+								x={leftPad + hour * (cellWidth + cellGap)}
+								y={topPad + rowIndex * (cellHeight + cellGap)}
+								width={cellWidth}
+								height={cellHeight}
+								rx="3.5"
+								fill={
+									intensity > 0 ? softColor(color, intensity) : chartEmptyFill
+								}
+							>
+								<title>{`${weekdayLabels[weekday]} ${String(hour).padStart(2, '0')}:00 UTC — ${count} ${unitLabel}`}</title>
+							</rect>
+						)
+					}),
+				)}
+			</svg>
+		)
+	}
+}

--- a/packages/worker/client/charts/stacked-bar-chart.tsx
+++ b/packages/worker/client/charts/stacked-bar-chart.tsx
@@ -1,0 +1,158 @@
+import { css, type Handle } from 'remix/ui'
+import { buildTicks } from './chart-geometry.ts'
+import {
+	chartAxisTextCss,
+	chartGridStroke,
+	formatCompactNumber,
+	formatIntegerNumber,
+} from './chart-theme.ts'
+
+export type StackedBarSeries = {
+	label: string
+	color: string
+	/** One value per x label, oldest first. */
+	values: Array<number>
+}
+
+type StackedBarChartProps = {
+	/** Unique id prefix for clip paths (must be unique per page). */
+	id: string
+	series: Array<StackedBarSeries>
+	xLabels: Array<string>
+	ariaLabel: string
+	xTickEvery?: number
+	height?: number
+}
+
+const width = 720
+const pad = { top: 14, right: 16, bottom: 26, left: 46 }
+
+/**
+ * Stacked bar chart with rounded column tops (via per-column clip paths),
+ * grid lines, and native hover tooltips.
+ */
+export function StackedBarChart(handle: Handle<StackedBarChartProps>) {
+	return () => {
+		const { id, series, xLabels, ariaLabel } = handle.props
+		const height = handle.props.height ?? 230
+		const plotWidth = width - pad.left - pad.right
+		const plotHeight = height - pad.top - pad.bottom
+		const baselineY = pad.top + plotHeight
+		const pointCount = Math.max(1, xLabels.length)
+		const columnTotals = xLabels.map((_, index) =>
+			series.reduce((sum, entry) => sum + (entry.values[index] ?? 0), 0),
+		)
+		const ticks = buildTicks(Math.max(0, ...columnTotals))
+		const topTick = ticks[ticks.length - 1] ?? 1
+		const slotWidth = plotWidth / pointCount
+		const barWidth = Math.min(34, slotWidth * 0.62)
+		const cornerRadius = Math.min(5, barWidth / 2)
+		const heightFor = (value: number) => (plotHeight * value) / topTick
+		const xTickEvery =
+			handle.props.xTickEvery ?? Math.max(1, Math.ceil(pointCount / 6))
+
+		return (
+			<svg
+				viewBox={`0 0 ${width} ${height}`}
+				role="img"
+				aria-label={ariaLabel}
+				mix={css({ width: '100%', height: 'auto', display: 'block' })}
+			>
+				{ticks.map((tick) => (
+					<g key={tick}>
+						<line
+							x1={pad.left}
+							y1={baselineY - heightFor(tick)}
+							x2={width - pad.right}
+							y2={baselineY - heightFor(tick)}
+							stroke={chartGridStroke}
+							strokeWidth="1"
+							strokeDasharray={tick === 0 ? undefined : '3 5'}
+						/>
+						<text
+							x={pad.left - 8}
+							y={baselineY - heightFor(tick) + 3.5}
+							textAnchor="end"
+							mix={css(chartAxisTextCss)}
+						>
+							{formatCompactNumber(tick)}
+						</text>
+					</g>
+				))}
+				{xLabels.map((label, index) => {
+					const total = columnTotals[index] ?? 0
+					const barX = pad.left + slotWidth * index + (slotWidth - barWidth) / 2
+					const barTop = baselineY - heightFor(total)
+					let stackY = baselineY
+					return (
+						<g key={`${label}-${index}`}>
+							{total > 0 ? (
+								<>
+									<clipPath id={`${id}-clip-${index}`}>
+										<rect
+											x={barX}
+											y={barTop}
+											width={barWidth}
+											height={baselineY - barTop}
+											rx={cornerRadius}
+										/>
+									</clipPath>
+									<g clipPath={`url(#${id}-clip-${index})`}>
+										{series.map((entry) => {
+											const segmentHeight = heightFor(entry.values[index] ?? 0)
+											stackY -= segmentHeight
+											return (
+												<rect
+													key={entry.label}
+													x={barX}
+													y={stackY}
+													width={barWidth}
+													height={segmentHeight}
+													fill={entry.color}
+												/>
+											)
+										})}
+									</g>
+								</>
+							) : null}
+							{index % xTickEvery === 0 ? (
+								<text
+									x={barX + barWidth / 2}
+									y={height - 8}
+									textAnchor="middle"
+									mix={css(chartAxisTextCss)}
+								>
+									{label}
+								</text>
+							) : null}
+							<rect
+								x={pad.left + slotWidth * index}
+								y={pad.top}
+								width={slotWidth}
+								height={plotHeight}
+								fill="transparent"
+								mix={css({
+									'&:hover': {
+										fill: 'color-mix(in srgb, var(--color-primary) 7%, transparent)',
+									},
+								})}
+							>
+								<title>
+									{[
+										`${label} — total ${formatIntegerNumber(total)}`,
+										...series
+											.filter((entry) => (entry.values[index] ?? 0) > 0)
+											.map(
+												(entry) =>
+													`${entry.label}: ${formatIntegerNumber(entry.values[index] ?? 0)}`,
+											),
+									].join('\n')}
+								</title>
+							</rect>
+						</g>
+					)
+				})}
+			</svg>
+		)
+	}
+}

--- a/packages/worker/client/charts/stacked-bar-chart.tsx
+++ b/packages/worker/client/charts/stacked-bar-chart.tsx
@@ -22,9 +22,13 @@ type StackedBarChartProps = {
 	ariaLabel: string
 	xTickEvery?: number
 	height?: number
+	/**
+	 * ViewBox width. Use a smaller value for charts rendered in narrow
+	 * cards so axis text keeps a readable on-screen size.
+	 */
+	viewBoxWidth?: number
 }
 
-const width = 720
 const pad = { top: 14, right: 16, bottom: 26, left: 46 }
 
 /**
@@ -34,6 +38,7 @@ const pad = { top: 14, right: 16, bottom: 26, left: 46 }
 export function StackedBarChart(handle: Handle<StackedBarChartProps>) {
 	return () => {
 		const { id, series, xLabels, ariaLabel } = handle.props
+		const width = handle.props.viewBoxWidth ?? 720
 		const height = handle.props.height ?? 230
 		const plotWidth = width - pad.left - pad.right
 		const plotHeight = height - pad.top - pad.bottom

--- a/packages/worker/client/charts/stat-card.tsx
+++ b/packages/worker/client/charts/stat-card.tsx
@@ -27,6 +27,7 @@ const sparkHeight = 44
 export function StatCard(handle: Handle<StatCardProps>) {
 	return () => {
 		const { id, label, value, sub, color, sparkValues } = handle.props
+		const hasSparkline = Boolean(sparkValues && sparkValues.length > 1)
 		return (
 			<div
 				mix={css({
@@ -36,6 +37,8 @@ export function StatCard(handle: Handle<StatCardProps>) {
 					gap: spacing.xs,
 					alignContent: 'start',
 					padding: spacing.lg,
+					// Keep the sub text clear of the sparkline strip.
+					paddingBottom: hasSparkline ? '2.75rem' : spacing.lg,
 					borderRadius: radius.lg,
 					border: `1px solid ${colors.border}`,
 					backgroundColor: colors.surface,
@@ -88,7 +91,7 @@ export function StatCard(handle: Handle<StatCardProps>) {
 						{sub}
 					</span>
 				) : null}
-				{sparkValues && sparkValues.length > 1
+				{hasSparkline && sparkValues
 					? renderSparkline(id, color, sparkValues)
 					: null}
 			</div>

--- a/packages/worker/client/charts/stat-card.tsx
+++ b/packages/worker/client/charts/stat-card.tsx
@@ -1,0 +1,147 @@
+import { css, type Handle } from 'remix/ui'
+import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
+import {
+	buildSmoothAreaPath,
+	buildSmoothLinePath,
+	type ChartPoint,
+} from './chart-geometry.ts'
+import { softColor } from './chart-theme.ts'
+
+type StatCardProps = {
+	/** Unique id prefix for the sparkline gradient. */
+	id: string
+	label: string
+	value: string
+	sub?: string
+	color: string
+	/** Optional small trend line rendered along the card bottom. */
+	sparkValues?: Array<number>
+}
+
+const sparkWidth = 220
+const sparkHeight = 44
+
+/**
+ * KPI tile with an accent color, a big value, and an optional sparkline.
+ */
+export function StatCard(handle: Handle<StatCardProps>) {
+	return () => {
+		const { id, label, value, sub, color, sparkValues } = handle.props
+		return (
+			<div
+				mix={css({
+					position: 'relative',
+					overflow: 'hidden',
+					display: 'grid',
+					gap: spacing.xs,
+					alignContent: 'start',
+					padding: spacing.lg,
+					borderRadius: radius.lg,
+					border: `1px solid ${colors.border}`,
+					backgroundColor: colors.surface,
+					backgroundImage: `linear-gradient(140deg, ${softColor(color, 10)}, transparent 55%)`,
+					minHeight: '6.5rem',
+				})}
+			>
+				<span
+					mix={css({
+						display: 'flex',
+						alignItems: 'center',
+						gap: spacing.sm,
+						fontSize: typography.fontSize.xs,
+						letterSpacing: '0.08em',
+						textTransform: 'uppercase',
+						color: colors.textMuted,
+						fontWeight: typography.fontWeight.medium,
+					})}
+				>
+					<span
+						aria-hidden="true"
+						mix={css({
+							width: '0.5rem',
+							height: '0.5rem',
+							borderRadius: '999px',
+							backgroundColor: color,
+							flexShrink: 0,
+						})}
+					/>
+					{label}
+				</span>
+				<span
+					mix={css({
+						fontSize: typography.fontSize.xl,
+						fontWeight: typography.fontWeight.semibold,
+						color: colors.text,
+						lineHeight: 1.1,
+						fontVariantNumeric: 'tabular-nums',
+					})}
+				>
+					{value}
+				</span>
+				{sub ? (
+					<span
+						mix={css({
+							fontSize: typography.fontSize.sm,
+							color: colors.textMuted,
+						})}
+					>
+						{sub}
+					</span>
+				) : null}
+				{sparkValues && sparkValues.length > 1
+					? renderSparkline(id, color, sparkValues)
+					: null}
+			</div>
+		)
+	}
+}
+
+function renderSparkline(id: string, color: string, values: Array<number>) {
+	const maxValue = Math.max(1, ...values)
+	const points = values.map(
+		(value, index): ChartPoint => ({
+			x: (sparkWidth * index) / (values.length - 1),
+			y: sparkHeight - 5 - (sparkHeight - 12) * (value / maxValue),
+		}),
+	)
+	const lastPoint = points[points.length - 1]
+	return (
+		<svg
+			viewBox={`0 0 ${sparkWidth} ${sparkHeight}`}
+			aria-hidden="true"
+			preserveAspectRatio="none"
+			mix={css({
+				position: 'absolute',
+				insetInlineStart: 0,
+				insetBlockEnd: 0,
+				width: '100%',
+				height: '2.25rem',
+				display: 'block',
+				pointerEvents: 'none',
+			})}
+		>
+			<defs>
+				<linearGradient id={`${id}-spark`} x1="0" y1="0" x2="0" y2="1">
+					<stop offset="0%" stopColor={color} stopOpacity="0.25" />
+					<stop offset="100%" stopColor={color} stopOpacity="0" />
+				</linearGradient>
+			</defs>
+			<path
+				d={buildSmoothAreaPath(points, sparkHeight)}
+				fill={`url(#${id}-spark)`}
+			/>
+			<path
+				d={buildSmoothLinePath(points)}
+				fill="none"
+				stroke={color}
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				opacity="0.85"
+			/>
+			{lastPoint ? (
+				<circle cx={lastPoint.x} cy={lastPoint.y} r="2.5" fill={color} />
+			) : null}
+		</svg>
+	)
+}

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -97,6 +97,7 @@ export function AccountManagementHeader(
 
 const adminNavItems = [
 	{ href: '/admin/users', label: 'Users', paths: ['/admin', '/admin/users'] },
+	{ href: '/admin/insights', label: 'Insights', paths: ['/admin/insights'] },
 	{ href: '/admin/invites', label: 'Invites', paths: ['/admin/invites'] },
 	{ href: '/admin/roles', label: 'Roles', paths: ['/admin/roles'] },
 	{

--- a/packages/worker/client/routes/admin-insights.tsx
+++ b/packages/worker/client/routes/admin-insights.tsx
@@ -1,0 +1,667 @@
+import { css, type Handle } from 'remix/ui'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { readJson } from '#client/routes/account-approval-shared.ts'
+import { colors, mq, spacing, typography } from '#client/styles/tokens.ts'
+import { cardCss } from '#client/styles/style-primitives.ts'
+import { AreaChart } from '#client/charts/area-chart.tsx'
+import { ChartLegend } from '#client/charts/chart-legend.tsx'
+import { DonutChart } from '#client/charts/donut-chart.tsx'
+import { HeatmapChart } from '#client/charts/heatmap-chart.tsx'
+import { StackedBarChart } from '#client/charts/stacked-bar-chart.tsx'
+import { StatCard } from '#client/charts/stat-card.tsx'
+import {
+	chartColor,
+	formatCompactNumber,
+	formatIntegerNumber,
+	formatPercentShare,
+} from '#client/charts/chart-theme.ts'
+import {
+	AccountManagementMessage,
+	AccountManagementShell,
+	AdminPageHeader,
+} from './account-management-components.tsx'
+import {
+	type AdminInsightsLoaderData,
+	type AdminUsageMetric,
+} from '#app/loader-data.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
+
+type PageStatus = 'loading' | 'ready' | 'error'
+
+const adminInsightsApiPath = '/admin/insights.json'
+
+const usageMetricSeries: Array<{
+	metric: AdminUsageMetric
+	label: string
+	color: string
+}> = [
+	{ metric: 'execute', label: 'Executes', color: chartColor.blue },
+	{
+		metric: 'package_export',
+		label: 'Package runs',
+		color: chartColor.emerald,
+	},
+	{ metric: 'job_run', label: 'Job runs', color: chartColor.amber },
+	{ metric: 'workflow_run', label: 'Workflow runs', color: chartColor.violet },
+	{
+		metric: 'service_runtime',
+		label: 'Service runtime',
+		color: chartColor.rose,
+	},
+	{ metric: 'outbound_fetch', label: 'Fetches', color: chartColor.cyan },
+	{ metric: 'email_send', label: 'Email sends', color: chartColor.lime },
+	{
+		metric: 'email_received',
+		label: 'Email receives',
+		color: chartColor.fuchsia,
+	},
+]
+
+const planColors: Record<string, string> = {
+	pro: chartColor.violet,
+	personal: chartColor.blue,
+	partner: chartColor.emerald,
+	none: chartColor.cyan,
+}
+
+const workflowStatusColors: Record<string, string> = {
+	complete: chartColor.emerald,
+	completed: chartColor.emerald,
+	running: chartColor.blue,
+	queued: chartColor.cyan,
+	waiting: chartColor.amber,
+	paused: chartColor.amber,
+	errored: chartColor.rose,
+	failed: chartColor.rose,
+	terminated: chartColor.fuchsia,
+	unknown: chartColor.lime,
+}
+
+const authCategoryColors: Record<string, string> = {
+	auth: chartColor.blue,
+	account: chartColor.emerald,
+	admin: chartColor.amber,
+	oauth: chartColor.violet,
+}
+
+const monthNames = [
+	'Jan',
+	'Feb',
+	'Mar',
+	'Apr',
+	'May',
+	'Jun',
+	'Jul',
+	'Aug',
+	'Sep',
+	'Oct',
+	'Nov',
+	'Dec',
+] as const
+
+function isAdminInsightsPath(href: string) {
+	return new URL(href, 'http://localhost').pathname === '/admin/insights'
+}
+
+/** `2026-06-29` -> `Jun 29` */
+function formatDayLabel(dayKey: string) {
+	const monthIndex = Number(dayKey.slice(5, 7)) - 1
+	const dayOfMonth = Number(dayKey.slice(8, 10))
+	return `${monthNames[monthIndex] ?? '?'} ${dayOfMonth}`
+}
+
+/** `2026-06` -> `Jun ’26` */
+function formatMonthLabel(monthKey: string) {
+	const monthIndex = Number(monthKey.slice(5, 7)) - 1
+	return `${monthNames[monthIndex] ?? '?'} ’${monthKey.slice(2, 4)}`
+}
+
+function formatPlanLabel(plan: string) {
+	return plan === 'none' ? 'No plan' : plan
+}
+
+export async function adminInsightsRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const response = await fetch(`${adminInsightsApiPath}${url.search}`, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		return routeLoaderRedirect('/login')
+	}
+	if (response.status === 403) {
+		throw new Error('You do not have permission to view admin insights.')
+	}
+	const payload = await readJson<AdminInsightsLoaderData>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load admin insights.')
+	}
+	return { adminInsights: payload }
+}
+
+type ChartCardProps = {
+	title: string
+	sub?: string
+	/** Grid column span on wide screens out of 12. */
+	span?: 4 | 6 | 8 | 12
+	legend?: any
+	children: any
+}
+
+function ChartCard(handle: Handle<ChartCardProps>) {
+	return () => (
+		<section
+			aria-label={handle.props.title}
+			mix={css({
+				...cardCss,
+				gridColumn: `span ${handle.props.span ?? 12}`,
+				alignContent: 'start',
+				minWidth: 0,
+				[mq.tablet]: { gridColumn: 'span 12' },
+			})}
+		>
+			<div mix={css({ display: 'grid', gap: spacing.xs })}>
+				<h2
+					mix={css({
+						margin: 0,
+						fontSize: typography.fontSize.base,
+						fontWeight: typography.fontWeight.semibold,
+						color: colors.text,
+					})}
+				>
+					{handle.props.title}
+				</h2>
+				{handle.props.sub ? (
+					<p
+						mix={css({
+							margin: 0,
+							color: colors.textMuted,
+							fontSize: typography.fontSize.sm,
+						})}
+					>
+						{handle.props.sub}
+					</p>
+				) : null}
+			</div>
+			{handle.props.legend ?? null}
+			{handle.props.children}
+		</section>
+	)
+}
+
+export function AdminInsightsRoute(handle: Handle) {
+	let status: PageStatus = 'loading'
+	let data: AdminInsightsLoaderData | null = null
+	let message: string | null = null
+	let loadRequestId = 0
+	let lastLoadedHref = ''
+	let loadingForHref: string | null = null
+	let lastFailedHref: string | null = null
+
+	function applyData(payload: AdminInsightsLoaderData, href: string) {
+		data = payload
+		status = 'ready'
+		message = null
+		lastLoadedHref = href
+		lastFailedHref = null
+	}
+
+	async function loadAdminInsights() {
+		const href = readCurrentRouterHref(handle)
+		loadingForHref = href
+		const requestId = ++loadRequestId
+		try {
+			const response = await fetch(adminInsightsApiPath, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+			})
+			if (requestId !== loadRequestId) return
+			if (response.status === 401) {
+				window.location.assign('/login')
+				return
+			}
+			if (response.status === 403) {
+				status = 'error'
+				message = 'You do not have permission to view admin insights.'
+				lastFailedHref = href
+				handle.update()
+				return
+			}
+			const payload = await readJson<AdminInsightsLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load admin insights.')
+			}
+			applyData(payload, href)
+			handle.update()
+		} catch (error) {
+			if (requestId !== loadRequestId) return
+			status = 'error'
+			message =
+				error instanceof Error
+					? error.message
+					: 'Unable to load admin insights.'
+			lastFailedHref = href
+			handle.update()
+		} finally {
+			if (requestId === loadRequestId) loadingForHref = null
+		}
+	}
+
+	function applyRouteLoaderData(href: string) {
+		if (!isAdminInsightsPath(href)) return false
+		const routeData = tryConsumeRouteLoaderData(handle, 'adminInsights', href)
+		if (!routeData) return false
+		applyData(routeData, href)
+		return true
+	}
+
+	let lastSeenHref = ''
+
+	return () => {
+		const currentHref = readCurrentRouterHref(handle)
+		if (currentHref !== lastSeenHref) {
+			lastSeenHref = currentHref
+			lastFailedHref = null
+		}
+
+		const appliedRouteData = applyRouteLoaderData(currentHref)
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
+		const needsLoad =
+			(status === 'loading' ||
+				currentHref !== lastLoadedHref ||
+				needsStaleRefresh) &&
+			currentHref !== lastFailedHref &&
+			loadingForHref !== currentHref
+		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
+			loadingForHref = currentHref
+			handle.queueTask(loadAdminInsights)
+		}
+
+		return (
+			<AccountManagementShell maxWidth="min(100%, 92rem)">
+				<AdminPageHeader
+					title="Admin insights"
+					description="Platform-wide activity at a glance. Aggregated account metadata only — user content is never shown."
+					currentHref={currentHref}
+				/>
+				{status === 'loading' ? (
+					<p mix={css({ color: colors.textMuted, margin: 0 })}>
+						Loading insights…
+					</p>
+				) : null}
+				{message ? (
+					<AccountManagementMessage
+						tone={status === 'error' ? 'error' : 'info'}
+					>
+						{message}
+					</AccountManagementMessage>
+				) : null}
+				{data ? renderDashboard(data) : null}
+			</AccountManagementShell>
+		)
+	}
+}
+
+function renderDashboard(data: AdminInsightsLoaderData) {
+	const signupWeeks = data.signupsByWeek
+	const latestWeek = signupWeeks[signupWeeks.length - 1]
+	const weekLabels = signupWeeks.map((week) => formatDayLabel(week.weekStart))
+	const monthLabels = data.usageByMonth.map((month) =>
+		formatMonthLabel(month.month),
+	)
+	const dayLabels = data.emailByDay.map((day) => formatDayLabel(day.day))
+	const authDayLabels = data.authByDay.map((day) => formatDayLabel(day.day))
+	const totalAuthEvents = data.authByCategory.reduce(
+		(sum, entry) => sum + entry.count,
+		0,
+	)
+	const totalJobRuns = data.jobHealth.successRuns + data.jobHealth.errorRuns
+	const emailWindowTotal = data.emailByDay.reduce(
+		(sum, day) => sum + day.sends + day.receives,
+		0,
+	)
+	const verifiedShare =
+		data.totals.users > 0 ? data.totals.verifiedUsers / data.totals.users : 0
+
+	return (
+		<>
+			<div
+				mix={css({
+					display: 'grid',
+					gap: spacing.md,
+					gridTemplateColumns:
+						'repeat(auto-fit, minmax(min(13rem, 100%), 1fr))',
+				})}
+			>
+				<StatCard
+					id="stat-users"
+					label="Users"
+					value={formatIntegerNumber(data.totals.users)}
+					sub={`${formatPercentShare(verifiedShare)} verified · +${formatIntegerNumber(latestWeek?.signups ?? 0)} this week`}
+					color={chartColor.blue}
+					sparkValues={signupWeeks.map((week) => week.cumulativeUsers)}
+				/>
+				<StatCard
+					id="stat-packages"
+					label="Saved packages"
+					value={formatIntegerNumber(data.totals.savedPackages)}
+					sub={`${formatIntegerNumber(data.totals.activeCommunityListings)} community listings`}
+					color={chartColor.emerald}
+				/>
+				<StatCard
+					id="stat-jobs"
+					label="Scheduled jobs"
+					value={formatIntegerNumber(data.totals.scheduledJobs)}
+					sub={`${formatIntegerNumber(data.totals.enabledJobs)} enabled · ${formatIntegerNumber(totalJobRuns)} runs recorded`}
+					color={chartColor.amber}
+				/>
+				<StatCard
+					id="stat-workflows"
+					label="Workflow runs"
+					value={formatIntegerNumber(data.totals.workflowRuns)}
+					sub="All-time durable runs"
+					color={chartColor.violet}
+				/>
+				<StatCard
+					id="stat-memories"
+					label="Active memories"
+					value={formatIntegerNumber(data.totals.activeMemories)}
+					sub="Long-term assistant memory"
+					color={chartColor.rose}
+				/>
+				<StatCard
+					id="stat-email"
+					label="Stored emails"
+					value={formatIntegerNumber(data.totals.storedEmailMessages)}
+					sub={`${formatCompactNumber(emailWindowTotal)} sent + received in 28 days`}
+					color={chartColor.cyan}
+					sparkValues={data.emailByDay.map((day) => day.sends + day.receives)}
+				/>
+				<StatCard
+					id="stat-secrets"
+					label="Secrets"
+					value={formatIntegerNumber(data.totals.secrets)}
+					sub="Encrypted references (values never shown)"
+					color={chartColor.lime}
+				/>
+				<StatCard
+					id="stat-signin"
+					label="Sign-in methods"
+					value={formatIntegerNumber(
+						data.totals.passkeys + data.totals.oauthConnections,
+					)}
+					sub={`${formatIntegerNumber(data.totals.passkeys)} passkeys · ${formatIntegerNumber(data.totals.oauthConnections)} social links`}
+					color={chartColor.fuchsia}
+				/>
+			</div>
+
+			<div
+				mix={css({
+					display: 'grid',
+					gap: spacing.lg,
+					gridTemplateColumns: 'repeat(12, minmax(0, 1fr))',
+					[mq.tablet]: { gridTemplateColumns: 'minmax(0, 1fr)' },
+				})}
+			>
+				<ChartCard
+					title="User growth"
+					sub="Cumulative registered users over the last 12 weeks."
+					span={8}
+				>
+					<AreaChart
+						id="growth"
+						ariaLabel="Cumulative registered users per week"
+						series={[
+							{
+								label: 'Total users',
+								color: chartColor.blue,
+								values: signupWeeks.map((week) => week.cumulativeUsers),
+							},
+						]}
+						xLabels={weekLabels}
+					/>
+				</ChartCard>
+				<ChartCard title="New signups" sub="Fresh accounts per week." span={4}>
+					<StackedBarChart
+						id="signups"
+						ariaLabel="New signups per week"
+						series={[
+							{
+								label: 'Signups',
+								color: chartColor.emerald,
+								values: signupWeeks.map((week) => week.signups),
+							},
+						]}
+						xLabels={weekLabels}
+						xTickEvery={3}
+					/>
+				</ChartCard>
+
+				<ChartCard
+					title="Platform activity"
+					sub="Metered events across all accounts by month, from the usage rollups."
+					span={12}
+					legend={
+						<ChartLegend
+							items={usageMetricSeries.map((entry) => ({
+								label: entry.label,
+								color: entry.color,
+							}))}
+						/>
+					}
+				>
+					<StackedBarChart
+						id="activity"
+						ariaLabel="Metered platform events by month"
+						series={usageMetricSeries.map((entry) => ({
+							label: entry.label,
+							color: entry.color,
+							values: data.usageByMonth.map(
+								(month) => month.events[entry.metric] ?? 0,
+							),
+						}))}
+						xLabels={monthLabels}
+						xTickEvery={1}
+					/>
+				</ChartCard>
+
+				<ChartCard
+					title="Email traffic"
+					sub="Daily sends and receives across every inbox, last 28 days."
+					span={8}
+					legend={
+						<ChartLegend
+							items={[
+								{ label: 'Sends', color: chartColor.cyan },
+								{ label: 'Receives', color: chartColor.violet },
+							]}
+						/>
+					}
+				>
+					<AreaChart
+						id="email"
+						ariaLabel="Email sends and receives per day"
+						series={[
+							{
+								label: 'Sends',
+								color: chartColor.cyan,
+								values: data.emailByDay.map((day) => day.sends),
+							},
+							{
+								label: 'Receives',
+								color: chartColor.violet,
+								values: data.emailByDay.map((day) => day.receives),
+							},
+						]}
+						xLabels={dayLabels}
+					/>
+				</ChartCard>
+				<ChartCard
+					title="Users by plan"
+					sub="Current plan distribution."
+					span={4}
+				>
+					<DonutChart
+						ariaLabel="Users by plan"
+						centerLabel="users"
+						slices={data.plans.map((slice, index) => ({
+							label: formatPlanLabel(slice.plan),
+							value: slice.count,
+							color:
+								planColors[slice.plan] ??
+								[chartColor.amber, chartColor.rose, chartColor.lime][
+									index % 3
+								] ??
+								chartColor.amber,
+						}))}
+					/>
+				</ChartCard>
+
+				<ChartCard
+					title="Auth pulse"
+					sub="Authentication and account events per day, last 28 days."
+					span={8}
+					legend={
+						<ChartLegend
+							items={[
+								{ label: 'Success', color: chartColor.emerald },
+								{ label: 'Failure', color: chartColor.rose },
+								{ label: 'Rate limited', color: chartColor.amber },
+							]}
+						/>
+					}
+				>
+					<StackedBarChart
+						id="auth"
+						ariaLabel="Audit events per day by result"
+						series={[
+							{
+								label: 'Success',
+								color: chartColor.emerald,
+								values: data.authByDay.map((day) => day.success),
+							},
+							{
+								label: 'Failure',
+								color: chartColor.rose,
+								values: data.authByDay.map((day) => day.failure),
+							},
+							{
+								label: 'Rate limited',
+								color: chartColor.amber,
+								values: data.authByDay.map((day) => day.rateLimited),
+							},
+						]}
+						xLabels={authDayLabels}
+					/>
+				</ChartCard>
+				<ChartCard
+					title="Event categories"
+					sub={`${formatIntegerNumber(totalAuthEvents)} audit events in 28 days.`}
+					span={4}
+				>
+					<DonutChart
+						ariaLabel="Audit events by category"
+						centerLabel="events"
+						slices={data.authByCategory.map((entry, index) => ({
+							label: entry.category,
+							value: entry.count,
+							color:
+								authCategoryColors[entry.category] ??
+								[chartColor.cyan, chartColor.lime][index % 2] ??
+								chartColor.cyan,
+						}))}
+					/>
+				</ChartCard>
+
+				<ChartCard
+					title="When things happen"
+					sub="Audit event activity by weekday and hour (UTC), last 28 days."
+					span={8}
+				>
+					<HeatmapChart
+						ariaLabel="Audit events by weekday and hour"
+						cells={data.authHeatmap}
+						color={chartColor.blue}
+						unitLabel="events"
+					/>
+				</ChartCard>
+				<ChartCard
+					title="Workflow outcomes"
+					sub="All durable workflow runs by status."
+					span={4}
+				>
+					<DonutChart
+						ariaLabel="Workflow runs by status"
+						centerLabel="runs"
+						slices={data.workflowStatuses.map((entry, index) => ({
+							label: entry.status,
+							value: entry.count,
+							color:
+								workflowStatusColors[entry.status] ??
+								[chartColor.cyan, chartColor.lime, chartColor.fuchsia][
+									index % 3
+								] ??
+								chartColor.cyan,
+						}))}
+					/>
+				</ChartCard>
+
+				<ChartCard
+					title="Job run health"
+					sub={`${formatIntegerNumber(data.jobHealth.enabledJobs)} of ${formatIntegerNumber(data.jobHealth.totalJobs)} scheduled jobs enabled.`}
+					span={6}
+				>
+					<DonutChart
+						ariaLabel="Job runs by outcome"
+						centerLabel="job runs"
+						emptyText="No job runs recorded yet."
+						slices={[
+							{
+								label: 'Succeeded',
+								value: data.jobHealth.successRuns,
+								color: chartColor.emerald,
+							},
+							{
+								label: 'Failed',
+								value: data.jobHealth.errorRuns,
+								color: chartColor.rose,
+							},
+						]}
+					/>
+				</ChartCard>
+				<ChartCard
+					title="Email verification"
+					sub="Verified versus unverified accounts."
+					span={6}
+				>
+					<DonutChart
+						ariaLabel="Users by email verification"
+						centerLabel="users"
+						slices={[
+							{
+								label: 'Verified',
+								value: data.totals.verifiedUsers,
+								color: chartColor.blue,
+							},
+							{
+								label: 'Unverified',
+								value: data.totals.users - data.totals.verifiedUsers,
+								color: chartColor.amber,
+							},
+						]}
+					/>
+				</ChartCard>
+			</div>
+		</>
+	)
+}

--- a/packages/worker/client/routes/admin-insights.tsx
+++ b/packages/worker/client/routes/admin-insights.tsx
@@ -339,8 +339,9 @@ function renderDashboard(data: AdminInsightsLoaderData) {
 				mix={css({
 					display: 'grid',
 					gap: spacing.md,
-					gridTemplateColumns:
-						'repeat(auto-fit, minmax(min(13rem, 100%), 1fr))',
+					gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+					[mq.tablet]: { gridTemplateColumns: 'repeat(2, minmax(0, 1fr))' },
+					[mq.mobile]: { gridTemplateColumns: 'minmax(0, 1fr)' },
 				})}
 			>
 				<StatCard
@@ -444,6 +445,7 @@ function renderDashboard(data: AdminInsightsLoaderData) {
 						]}
 						xLabels={weekLabels}
 						xTickEvery={3}
+						viewBoxWidth={360}
 					/>
 				</ChartCard>
 

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -32,6 +32,10 @@ import {
 	AdminCommunityReportsRoute,
 	adminCommunityReportsRouteLoader,
 } from './admin-community-reports.tsx'
+import {
+	AdminInsightsRoute,
+	adminInsightsRouteLoader,
+} from './admin-insights.tsx'
 import { AdminInvitesRoute, adminInvitesRouteLoader } from './admin-invites.tsx'
 import { AdminRolesRoute, adminRolesRouteLoader } from './admin-roles.tsx'
 import {
@@ -85,6 +89,7 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 	'/admin/roles': adminRolesRouteLoader,
 	'/admin/community-reports': adminCommunityReportsRouteLoader,
 	'/admin/usage': adminUsageRouteLoader,
+	'/admin/insights': adminInsightsRouteLoader,
 	'/admin/system-email': adminSystemEmailRouteLoader,
 	'/community': communityRouteLoader,
 	'/community/:listingId': communityDetailRouteLoader,
@@ -121,6 +126,7 @@ export const clientRoutes = {
 	'/admin/roles': <AdminRolesRoute />,
 	'/admin/community-reports': <AdminCommunityReportsRoute />,
 	'/admin/usage': <AdminUsageRoute />,
+	'/admin/insights': <AdminInsightsRoute />,
 	'/admin/system-email': <AdminSystemEmailRoute />,
 	'/community': <CommunityRoute />,
 	'/community/:listingId': <CommunityDetailRoute />,

--- a/packages/worker/src/app/admin-insights-data.node.test.ts
+++ b/packages/worker/src/app/admin-insights-data.node.test.ts
@@ -1,0 +1,302 @@
+import { expect, test } from 'vitest'
+import {
+	buildAuthDays,
+	buildEmailDays,
+	buildHeatmapCells,
+	buildSignupWeeks,
+	buildUsageMonths,
+	listUtcDayKeys,
+	listUtcMonthKeys,
+	listUtcWeekStarts,
+	loadAdminInsightsData,
+	utcWeekStart,
+} from './admin-insights-data.ts'
+
+const now = new Date('2026-07-08T12:00:00.000Z')
+
+test('utcWeekStart returns the UTC Monday of the containing week', () => {
+	// 2026-07-08 is a Wednesday; 2026-07-06 is the Monday before.
+	expect(utcWeekStart(new Date('2026-07-08T12:00:00.000Z'))).toBe('2026-07-06')
+	expect(utcWeekStart(new Date('2026-07-06T00:00:00.000Z'))).toBe('2026-07-06')
+	// Sunday belongs to the week that started the previous Monday.
+	expect(utcWeekStart(new Date('2026-07-05T23:59:59.000Z'))).toBe('2026-06-29')
+})
+
+test('listUtcWeekStarts and listUtcDayKeys are oldest-first and end at now', () => {
+	const weeks = listUtcWeekStarts(now, 3)
+	expect(weeks).toEqual(['2026-06-22', '2026-06-29', '2026-07-06'])
+	const days = listUtcDayKeys(now, 3)
+	expect(days).toEqual(['2026-07-06', '2026-07-07', '2026-07-08'])
+	expect(listUtcMonthKeys(now, 3)).toEqual(['2026-05', '2026-06', '2026-07'])
+})
+
+test('buildSignupWeeks buckets daily rows into weeks and accumulates totals', () => {
+	const result = buildSignupWeeks({
+		dayRows: [
+			{ day: '2026-06-23', n: 2 },
+			{ day: '2026-06-29', n: 1 },
+			{ day: '2026-07-04', n: 3 },
+			{ day: '2026-07-08', n: 5 },
+		],
+		usersBeforeWindow: 10,
+		now,
+		weeks: 3,
+	})
+	expect(result).toEqual([
+		{ weekStart: '2026-06-22', signups: 2, cumulativeUsers: 12 },
+		{ weekStart: '2026-06-29', signups: 4, cumulativeUsers: 16 },
+		{ weekStart: '2026-07-06', signups: 5, cumulativeUsers: 21 },
+	])
+})
+
+test('buildUsageMonths zero-fills months and ignores unknown metrics', () => {
+	const result = buildUsageMonths(
+		[
+			{ month: '2026-06', metric: 'execute', events: 7, errors: 1 },
+			{ month: '2026-06', metric: 'job_run', events: 3, errors: 0 },
+			{ month: '2026-07', metric: 'not_a_metric', events: 99, errors: 9 },
+		],
+		now,
+		2,
+	)
+	expect(result.map((month) => month.month)).toEqual(['2026-06', '2026-07'])
+	expect(result[0]?.events.execute).toBe(7)
+	expect(result[0]?.events.job_run).toBe(3)
+	expect(result[0]?.errorCount).toBe(1)
+	expect(result[1]?.errorCount).toBe(0)
+	expect(Object.values(result[1]?.events ?? {}).every((n) => n === 0)).toBe(
+		true,
+	)
+})
+
+test('buildEmailDays and buildAuthDays zero-fill the window', () => {
+	const emailDays = buildEmailDays(
+		[
+			{ day: '2026-07-07', resource: 'email_sends_per_day', n: 4 },
+			{ day: '2026-07-07', resource: 'email_receives_per_day', n: 6 },
+		],
+		now,
+		2,
+	)
+	expect(emailDays).toEqual([
+		{ day: '2026-07-07', sends: 4, receives: 6 },
+		{ day: '2026-07-08', sends: 0, receives: 0 },
+	])
+
+	const authDays = buildAuthDays(
+		[
+			{ day: '2026-07-08', result: 'success', n: 9 },
+			{ day: '2026-07-08', result: 'failure', n: 2 },
+			{ day: '2026-07-08', result: 'rate_limited', n: 1 },
+		],
+		now,
+		2,
+	)
+	expect(authDays[1]).toEqual({
+		day: '2026-07-08',
+		success: 9,
+		failure: 2,
+		rateLimited: 1,
+	})
+})
+
+test('buildHeatmapCells folds days into weekday x hour cells', () => {
+	// 2026-07-01 and 2026-07-08 are both Wednesdays (weekday 3).
+	const cells = buildHeatmapCells([
+		{ day: '2026-07-01', hour: '09', n: 2 },
+		{ day: '2026-07-08', hour: '09', n: 3 },
+		{ day: '2026-07-05', hour: '23', n: 1 },
+		{ day: '2026-07-05', hour: 'xx', n: 5 },
+	])
+	expect(cells).toEqual([
+		{ weekday: 0, hour: 23, count: 1 },
+		{ weekday: 3, hour: 9, count: 5 },
+	])
+})
+
+function normalizeQuery(query: string) {
+	return query.replace(/\s+/g, ' ').trim().toLowerCase()
+}
+
+function createInsightsTestDb() {
+	const db = {
+		prepare(query: string) {
+			const normalizedQuery = normalizeQuery(query)
+			const createStatement = (params: Array<unknown>) => ({
+				async first<T>() {
+					if (normalizedQuery.includes('sum(enabled) as enabled')) {
+						return {
+							total: 4,
+							enabled: 3,
+							success_runs: 20,
+							error_runs: 2,
+						} as T
+					}
+					if (normalizedQuery.includes('from users where created_at < ?')) {
+						return { n: 6 } as T
+					}
+					if (
+						normalizedQuery.includes(
+							'count(*) as n from users where email_verified_at',
+						)
+					) {
+						return { n: 5 } as T
+					}
+					if (normalizedQuery.includes('count(*) as n from users')) {
+						return { n: 8 } as T
+					}
+					if (normalizedQuery.includes('from saved_packages')) {
+						return { n: 11 } as T
+					}
+					if (normalizedQuery.includes('count(*) as n from workflow_runs')) {
+						return { n: 9 } as T
+					}
+					if (normalizedQuery.includes('from mcp_memories')) {
+						return { n: 13 } as T
+					}
+					if (normalizedQuery.includes('from email_messages')) {
+						return { n: 15 } as T
+					}
+					if (normalizedQuery.includes('from secret_entries')) {
+						return { n: 7 } as T
+					}
+					if (normalizedQuery.includes('from community_listings')) {
+						return { n: 2 } as T
+					}
+					if (normalizedQuery.includes('from passkeys')) {
+						return { n: 3 } as T
+					}
+					if (normalizedQuery.includes('from oauth_connections')) {
+						return { n: 4 } as T
+					}
+					throw new Error(`Unsupported first query: ${query}`)
+				},
+				async all<T>() {
+					if (
+						normalizedQuery.includes('from users') &&
+						normalizedQuery.includes('group by day')
+					) {
+						return { results: [{ day: '2026-07-07', n: 2 }] as Array<T> }
+					}
+					if (normalizedQuery.includes('from usage_rollups')) {
+						expect(params[0]).toBe('2025-08')
+						return {
+							results: [
+								{ month: '2026-07', metric: 'execute', events: 12, errors: 1 },
+							] as Array<T>,
+						}
+					}
+					if (normalizedQuery.includes('from entitlement_daily_counters')) {
+						return {
+							results: [
+								{
+									day: '2026-07-08',
+									resource: 'email_sends_per_day',
+									n: 3,
+								},
+							] as Array<T>,
+						}
+					}
+					if (normalizedQuery.includes("coalesce(plan, 'none')")) {
+						return {
+							results: [
+								{ plan: 'pro', n: 2 },
+								{ plan: 'none', n: 6 },
+							] as Array<T>,
+						}
+					}
+					if (
+						normalizedQuery.includes('from audit_events') &&
+						normalizedQuery.includes('result')
+					) {
+						return {
+							results: [
+								{ day: '2026-07-08', result: 'success', n: 4 },
+							] as Array<T>,
+						}
+					}
+					if (
+						normalizedQuery.includes('from audit_events') &&
+						normalizedQuery.includes('group by category')
+					) {
+						return { results: [{ category: 'auth', n: 4 }] as Array<T> }
+					}
+					if (normalizedQuery.includes('substr(timestamp, 12, 2)')) {
+						return {
+							results: [{ day: '2026-07-08', hour: '09', n: 4 }] as Array<T>,
+						}
+					}
+					if (normalizedQuery.includes('from workflow_runs')) {
+						return {
+							results: [
+								{ status: 'complete', n: 8 },
+								{ status: 'errored', n: 1 },
+							] as Array<T>,
+						}
+					}
+					throw new Error(`Unsupported all query: ${query}`)
+				},
+				async run() {
+					throw new Error(`Unsupported run query: ${query}`)
+				},
+			})
+			return {
+				...createStatement([]),
+				bind(...params: Array<unknown>) {
+					return createStatement(params)
+				},
+			}
+		},
+	} as unknown as D1Database
+	return db
+}
+
+test('loadAdminInsightsData assembles the dashboard payload', async () => {
+	const data = await loadAdminInsightsData(
+		{ APP_DB: createInsightsTestDb() } as Env,
+		now,
+	)
+
+	expect(data.ok).toBe(true)
+	expect(data.totals).toEqual({
+		users: 8,
+		verifiedUsers: 5,
+		savedPackages: 11,
+		scheduledJobs: 4,
+		enabledJobs: 3,
+		workflowRuns: 9,
+		activeMemories: 13,
+		storedEmailMessages: 15,
+		secrets: 7,
+		activeCommunityListings: 2,
+		passkeys: 3,
+		oauthConnections: 4,
+	})
+	expect(data.signupsByWeek).toHaveLength(12)
+	expect(data.signupsByWeek.at(-1)).toEqual({
+		weekStart: '2026-07-06',
+		signups: 2,
+		cumulativeUsers: 8,
+	})
+	expect(data.usageByMonth).toHaveLength(12)
+	expect(data.usageByMonth.at(-1)?.events.execute).toBe(12)
+	expect(data.emailByDay).toHaveLength(28)
+	expect(data.emailByDay.at(-1)).toEqual({
+		day: '2026-07-08',
+		sends: 3,
+		receives: 0,
+	})
+	expect(data.authByDay.at(-1)?.success).toBe(4)
+	expect(data.authByCategory).toEqual([{ category: 'auth', count: 4 }])
+	expect(data.authHeatmap).toEqual([{ weekday: 3, hour: 9, count: 4 }])
+	expect(data.workflowStatuses).toEqual([
+		{ status: 'complete', count: 8 },
+		{ status: 'errored', count: 1 },
+	])
+	expect(data.jobHealth).toEqual({
+		totalJobs: 4,
+		enabledJobs: 3,
+		successRuns: 20,
+		errorRuns: 2,
+	})
+})

--- a/packages/worker/src/app/admin-insights-data.ts
+++ b/packages/worker/src/app/admin-insights-data.ts
@@ -1,0 +1,448 @@
+import { cachified } from '@epic-web/cachified'
+import { utcDayKey, utcMonthKey } from '@kody-internal/shared/date-keys.ts'
+import { createKvCachifiedCache } from '#worker/kv-cachified.ts'
+import { adminUsageMetrics } from '#app/admin-usage-data.ts'
+import {
+	type AdminInsightsAuthCategory,
+	type AdminInsightsAuthDay,
+	type AdminInsightsEmailDay,
+	type AdminInsightsHeatmapCell,
+	type AdminInsightsJobHealth,
+	type AdminInsightsLoaderData,
+	type AdminInsightsPlanSlice,
+	type AdminInsightsSignupWeek,
+	type AdminInsightsTotals,
+	type AdminInsightsUsageMonth,
+	type AdminInsightsWorkflowStatus,
+	type AdminUsageMetric,
+} from './loader-data.ts'
+
+export const adminInsightsSignupWeeks = 12
+export const adminInsightsUsageMonths = 12
+export const adminInsightsActivityDays = 28
+
+/**
+ * The dashboard is a platform-wide read model over many tables, so a short
+ * KV cache keeps repeated admin page loads off D1 (same policy as the admin
+ * usage rollup reads).
+ */
+const insightsCacheTtlMs = 5 * 60 * 1000
+
+const dayMs = 24 * 60 * 60 * 1000
+
+type CountRow = { n: number }
+type DayCountRow = { day: string; n: number }
+type UsageMonthRow = {
+	month: string
+	metric: string
+	events: number
+	errors: number
+}
+type EmailDayRow = { day: string; resource: string; n: number }
+type PlanRow = { plan: string; n: number }
+type AuthDayRow = { day: string; result: string; n: number }
+type AuthCategoryRow = { category: string; n: number }
+type HeatmapRow = { day: string; hour: string; n: number }
+type WorkflowStatusRow = { status: string | null; n: number }
+type JobStatsRow = {
+	total: number
+	enabled: number | null
+	success_runs: number | null
+	error_runs: number | null
+}
+
+export async function loadAdminInsightsData(
+	env: Env,
+	now: Date = new Date(),
+): Promise<AdminInsightsLoaderData> {
+	// Fall through to direct D1 queries when KV is unavailable (some tests
+	// construct a partial Env without the binding).
+	const cache = env.BUNDLE_ARTIFACTS_KV
+		? createKvCachifiedCache(env.BUNDLE_ARTIFACTS_KV)
+		: null
+	if (!cache) return await queryAdminInsights(env.APP_DB, now)
+	return await cachified({
+		key: 'admin-insights:v1',
+		cache,
+		ttl: insightsCacheTtlMs,
+		getFreshValue: () => queryAdminInsights(env.APP_DB, now),
+	})
+}
+
+async function queryAdminInsights(
+	db: D1Database,
+	now: Date,
+): Promise<AdminInsightsLoaderData> {
+	const signupCutoff =
+		listUtcWeekStarts(now, adminInsightsSignupWeeks)[0] ?? utcDayKey(now)
+	const monthCutoff = utcMonthKey(
+		new Date(
+			Date.UTC(
+				now.getUTCFullYear(),
+				now.getUTCMonth() - (adminInsightsUsageMonths - 1),
+				1,
+			),
+		),
+	)
+	const dayCutoff =
+		listUtcDayKeys(now, adminInsightsActivityDays)[0] ?? utcDayKey(now)
+
+	const [
+		totals,
+		jobStats,
+		signupRows,
+		usersBeforeWindow,
+		usageRows,
+		emailRows,
+		planRows,
+		authDayRows,
+		authCategoryRows,
+		heatmapRows,
+		workflowRows,
+	] = await Promise.all([
+		queryTotals(db),
+		db
+			.prepare(
+				`SELECT COUNT(*) AS total, SUM(enabled) AS enabled,
+					SUM(success_count) AS success_runs, SUM(error_count) AS error_runs
+				 FROM jobs`,
+			)
+			.first<JobStatsRow>(),
+		db
+			.prepare(
+				`SELECT substr(created_at, 1, 10) AS day, COUNT(*) AS n
+				 FROM users
+				 WHERE created_at >= ?
+				 GROUP BY day
+				 ORDER BY day ASC`,
+			)
+			.bind(signupCutoff)
+			.all<DayCountRow>(),
+		db
+			.prepare(`SELECT COUNT(*) AS n FROM users WHERE created_at < ?`)
+			.bind(signupCutoff)
+			.first<CountRow>(),
+		db
+			.prepare(
+				`SELECT month, metric, SUM(event_count) AS events, SUM(error_count) AS errors
+				 FROM usage_rollups
+				 WHERE month >= ?
+				 GROUP BY month, metric
+				 ORDER BY month ASC`,
+			)
+			.bind(monthCutoff)
+			.all<UsageMonthRow>(),
+		db
+			.prepare(
+				`SELECT day, resource, SUM(count) AS n
+				 FROM entitlement_daily_counters
+				 WHERE day >= ? AND resource IN ('email_sends_per_day', 'email_receives_per_day')
+				 GROUP BY day, resource`,
+			)
+			.bind(dayCutoff)
+			.all<EmailDayRow>(),
+		db
+			.prepare(
+				`SELECT COALESCE(plan, 'none') AS plan, COUNT(*) AS n
+				 FROM users
+				 GROUP BY COALESCE(plan, 'none')
+				 ORDER BY n DESC`,
+			)
+			.all<PlanRow>(),
+		db
+			.prepare(
+				`SELECT substr(timestamp, 1, 10) AS day, result, COUNT(*) AS n
+				 FROM audit_events
+				 WHERE timestamp >= ?
+				 GROUP BY day, result`,
+			)
+			.bind(dayCutoff)
+			.all<AuthDayRow>(),
+		db
+			.prepare(
+				`SELECT category, COUNT(*) AS n
+				 FROM audit_events
+				 WHERE timestamp >= ?
+				 GROUP BY category
+				 ORDER BY n DESC`,
+			)
+			.bind(dayCutoff)
+			.all<AuthCategoryRow>(),
+		db
+			.prepare(
+				`SELECT substr(timestamp, 1, 10) AS day, substr(timestamp, 12, 2) AS hour, COUNT(*) AS n
+				 FROM audit_events
+				 WHERE timestamp >= ?
+				 GROUP BY day, hour`,
+			)
+			.bind(dayCutoff)
+			.all<HeatmapRow>(),
+		db
+			.prepare(
+				`SELECT COALESCE(status, 'unknown') AS status, COUNT(*) AS n
+				 FROM workflow_runs
+				 GROUP BY COALESCE(status, 'unknown')
+				 ORDER BY n DESC`,
+			)
+			.all<WorkflowStatusRow>(),
+	])
+
+	const jobHealth: AdminInsightsJobHealth = {
+		totalJobs: Number(jobStats?.total ?? 0),
+		enabledJobs: Number(jobStats?.enabled ?? 0),
+		successRuns: Number(jobStats?.success_runs ?? 0),
+		errorRuns: Number(jobStats?.error_runs ?? 0),
+	}
+
+	return {
+		ok: true,
+		generatedAt: now.toISOString(),
+		totals: {
+			...totals,
+			scheduledJobs: jobHealth.totalJobs,
+			enabledJobs: jobHealth.enabledJobs,
+		},
+		signupsByWeek: buildSignupWeeks({
+			dayRows: signupRows.results ?? [],
+			usersBeforeWindow: Number(usersBeforeWindow?.n ?? 0),
+			now,
+			weeks: adminInsightsSignupWeeks,
+		}),
+		usageByMonth: buildUsageMonths(
+			usageRows.results ?? [],
+			now,
+			adminInsightsUsageMonths,
+		),
+		emailByDay: buildEmailDays(
+			emailRows.results ?? [],
+			now,
+			adminInsightsActivityDays,
+		),
+		plans: (planRows.results ?? []).map(
+			(row): AdminInsightsPlanSlice => ({
+				plan: row.plan,
+				count: Number(row.n),
+			}),
+		),
+		authByDay: buildAuthDays(
+			authDayRows.results ?? [],
+			now,
+			adminInsightsActivityDays,
+		),
+		authByCategory: (authCategoryRows.results ?? []).map(
+			(row): AdminInsightsAuthCategory => ({
+				category: row.category,
+				count: Number(row.n),
+			}),
+		),
+		authHeatmap: buildHeatmapCells(heatmapRows.results ?? []),
+		workflowStatuses: (workflowRows.results ?? []).map(
+			(row): AdminInsightsWorkflowStatus => ({
+				status: row.status ?? 'unknown',
+				count: Number(row.n),
+			}),
+		),
+		jobHealth,
+	}
+}
+
+async function queryTotals(
+	db: D1Database,
+): Promise<Omit<AdminInsightsTotals, 'scheduledJobs' | 'enabledJobs'>> {
+	const [
+		users,
+		verifiedUsers,
+		savedPackages,
+		workflowRuns,
+		activeMemories,
+		storedEmailMessages,
+		secrets,
+		activeCommunityListings,
+		passkeys,
+		oauthConnections,
+	] = await Promise.all([
+		countQuery(db, `SELECT COUNT(*) AS n FROM users`),
+		countQuery(
+			db,
+			`SELECT COUNT(*) AS n FROM users WHERE email_verified_at IS NOT NULL`,
+		),
+		countQuery(db, `SELECT COUNT(*) AS n FROM saved_packages`),
+		countQuery(db, `SELECT COUNT(*) AS n FROM workflow_runs`),
+		countQuery(
+			db,
+			`SELECT COUNT(*) AS n FROM mcp_memories WHERE status = 'active'`,
+		),
+		countQuery(db, `SELECT COUNT(*) AS n FROM email_messages`),
+		countQuery(db, `SELECT COUNT(*) AS n FROM secret_entries`),
+		countQuery(
+			db,
+			`SELECT COUNT(*) AS n FROM community_listings WHERE status = 'active'`,
+		),
+		countQuery(db, `SELECT COUNT(*) AS n FROM passkeys`),
+		countQuery(db, `SELECT COUNT(*) AS n FROM oauth_connections`),
+	])
+	return {
+		users,
+		verifiedUsers,
+		savedPackages,
+		workflowRuns,
+		activeMemories,
+		storedEmailMessages,
+		secrets,
+		activeCommunityListings,
+		passkeys,
+		oauthConnections,
+	}
+}
+
+async function countQuery(db: D1Database, query: string) {
+	const row = await db.prepare(query).first<CountRow>()
+	return Number(row?.n ?? 0)
+}
+
+/** UTC Monday day key of the week containing the given date. */
+export function utcWeekStart(date: Date) {
+	const daysSinceMonday = (date.getUTCDay() + 6) % 7
+	return utcDayKey(new Date(date.getTime() - daysSinceMonday * dayMs))
+}
+
+/** Oldest-first list of UTC Monday keys ending with the week containing now. */
+export function listUtcWeekStarts(now: Date, weeks: number) {
+	const currentWeekStart = new Date(`${utcWeekStart(now)}T00:00:00Z`)
+	const starts: Array<string> = []
+	for (let index = weeks - 1; index >= 0; index -= 1) {
+		starts.push(
+			utcDayKey(new Date(currentWeekStart.getTime() - index * 7 * dayMs)),
+		)
+	}
+	return starts
+}
+
+/** Oldest-first list of UTC day keys ending with today. */
+export function listUtcDayKeys(now: Date, days: number) {
+	const keys: Array<string> = []
+	for (let index = days - 1; index >= 0; index -= 1) {
+		keys.push(utcDayKey(new Date(now.getTime() - index * dayMs)))
+	}
+	return keys
+}
+
+/** Oldest-first list of UTC month keys ending with the current month. */
+export function listUtcMonthKeys(now: Date, months: number) {
+	const keys: Array<string> = []
+	for (let index = months - 1; index >= 0; index -= 1) {
+		keys.push(
+			utcMonthKey(
+				new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - index, 1)),
+			),
+		)
+	}
+	return keys
+}
+
+export function buildSignupWeeks(input: {
+	dayRows: Array<DayCountRow>
+	usersBeforeWindow: number
+	now: Date
+	weeks: number
+}): Array<AdminInsightsSignupWeek> {
+	const signupsByWeek = new Map<string, number>()
+	for (const row of input.dayRows) {
+		const week = utcWeekStart(new Date(`${row.day}T00:00:00Z`))
+		signupsByWeek.set(week, (signupsByWeek.get(week) ?? 0) + Number(row.n))
+	}
+	let cumulativeUsers = input.usersBeforeWindow
+	return listUtcWeekStarts(input.now, input.weeks).map((weekStart) => {
+		const signups = signupsByWeek.get(weekStart) ?? 0
+		cumulativeUsers += signups
+		return { weekStart, signups, cumulativeUsers }
+	})
+}
+
+export function buildUsageMonths(
+	rows: Array<UsageMonthRow>,
+	now: Date,
+	months: number,
+): Array<AdminInsightsUsageMonth> {
+	const byMonth = new Map<string, AdminInsightsUsageMonth>()
+	for (const month of listUtcMonthKeys(now, months)) {
+		byMonth.set(month, { month, events: emptyMetricEvents(), errorCount: 0 })
+	}
+	for (const row of rows) {
+		const entry = byMonth.get(row.month)
+		if (!entry || !isAdminUsageMetric(row.metric)) continue
+		entry.events[row.metric] += Number(row.events)
+		entry.errorCount += Number(row.errors)
+	}
+	return Array.from(byMonth.values())
+}
+
+export function buildEmailDays(
+	rows: Array<EmailDayRow>,
+	now: Date,
+	days: number,
+): Array<AdminInsightsEmailDay> {
+	const byDay = new Map<string, AdminInsightsEmailDay>()
+	for (const day of listUtcDayKeys(now, days)) {
+		byDay.set(day, { day, sends: 0, receives: 0 })
+	}
+	for (const row of rows) {
+		const entry = byDay.get(row.day)
+		if (!entry) continue
+		if (row.resource === 'email_sends_per_day') entry.sends += Number(row.n)
+		if (row.resource === 'email_receives_per_day') {
+			entry.receives += Number(row.n)
+		}
+	}
+	return Array.from(byDay.values())
+}
+
+export function buildAuthDays(
+	rows: Array<AuthDayRow>,
+	now: Date,
+	days: number,
+): Array<AdminInsightsAuthDay> {
+	const byDay = new Map<string, AdminInsightsAuthDay>()
+	for (const day of listUtcDayKeys(now, days)) {
+		byDay.set(day, { day, success: 0, failure: 0, rateLimited: 0 })
+	}
+	for (const row of rows) {
+		const entry = byDay.get(row.day)
+		if (!entry) continue
+		if (row.result === 'success') entry.success += Number(row.n)
+		if (row.result === 'failure') entry.failure += Number(row.n)
+		if (row.result === 'rate_limited') entry.rateLimited += Number(row.n)
+	}
+	return Array.from(byDay.values())
+}
+
+export function buildHeatmapCells(
+	rows: Array<HeatmapRow>,
+): Array<AdminInsightsHeatmapCell> {
+	const byCell = new Map<string, AdminInsightsHeatmapCell>()
+	for (const row of rows) {
+		const hour = Number(row.hour)
+		if (!Number.isInteger(hour) || hour < 0 || hour > 23) continue
+		const weekday = new Date(`${row.day}T00:00:00Z`).getUTCDay()
+		if (!Number.isInteger(weekday)) continue
+		const key = `${weekday}:${hour}`
+		const cell = byCell.get(key) ?? { weekday, hour, count: 0 }
+		cell.count += Number(row.n)
+		byCell.set(key, cell)
+	}
+	return Array.from(byCell.values()).sort(
+		(left, right) => left.weekday - right.weekday || left.hour - right.hour,
+	)
+}
+
+function emptyMetricEvents(): Record<AdminUsageMetric, number> {
+	const events = {} as Record<AdminUsageMetric, number>
+	for (const metric of adminUsageMetrics) {
+		events[metric] = 0
+	}
+	return events
+}
+
+function isAdminUsageMetric(metric: string): metric is AdminUsageMetric {
+	return (adminUsageMetrics as ReadonlyArray<string>).includes(metric)
+}

--- a/packages/worker/src/app/handlers/admin-insights.ts
+++ b/packages/worker/src/app/handlers/admin-insights.ts
@@ -1,0 +1,52 @@
+import { type Action } from 'remix/router'
+import { jsonResponse } from '#worker/json-response.ts'
+import { loadAdminInsightsData } from '#app/admin-insights-data.ts'
+import { readAuthSessionResult } from '#app/auth-session.ts'
+import { redirectToLogin } from '#app/auth-redirect.ts'
+import { requireUserWithRole } from '#app/permissions-server.ts'
+import { type routes } from '#app/routes.ts'
+import { renderAppPage } from '#app/ssr-render.tsx'
+
+export function createAdminInsightsHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			try {
+				await requireUserWithRole(request, env, 'admin')
+			} catch (error) {
+				if (error instanceof Response) return error
+				throw error
+			}
+
+			const { session } = await readAuthSessionResult(request)
+			if (!session) {
+				return redirectToLogin(request)
+			}
+
+			const adminInsights = await loadAdminInsightsData(env)
+
+			return renderAppPage({
+				request,
+				env,
+				title: 'Admin insights',
+				loaderData: { adminInsights },
+			})
+		},
+	} satisfies Action<typeof routes.adminInsights>
+}
+
+export function createAdminInsightsApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			try {
+				await requireUserWithRole(request, env, 'admin')
+				const payload = await loadAdminInsightsData(env)
+				return jsonResponse(payload)
+			} catch (error) {
+				if (error instanceof Response) return error
+				throw error
+			}
+		},
+	} satisfies Action<typeof routes.adminInsightsApi>
+}

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -184,6 +184,93 @@ export type AdminUsageLoaderData = {
 	today: string
 }
 
+export type AdminInsightsTotals = {
+	users: number
+	verifiedUsers: number
+	savedPackages: number
+	scheduledJobs: number
+	enabledJobs: number
+	workflowRuns: number
+	activeMemories: number
+	storedEmailMessages: number
+	secrets: number
+	activeCommunityListings: number
+	passkeys: number
+	oauthConnections: number
+}
+
+export type AdminInsightsSignupWeek = {
+	/** UTC Monday that starts the week, for example `2026-06-29`. */
+	weekStart: string
+	signups: number
+	/** Total registered users at the end of the week. */
+	cumulativeUsers: number
+}
+
+export type AdminInsightsUsageMonth = {
+	month: string
+	events: Record<AdminUsageMetric, number>
+	errorCount: number
+}
+
+export type AdminInsightsEmailDay = {
+	day: string
+	sends: number
+	receives: number
+}
+
+export type AdminInsightsAuthDay = {
+	day: string
+	success: number
+	failure: number
+	rateLimited: number
+}
+
+export type AdminInsightsAuthCategory = {
+	category: string
+	count: number
+}
+
+export type AdminInsightsHeatmapCell = {
+	/** 0 = Sunday through 6 = Saturday, matching `Date#getUTCDay`. */
+	weekday: number
+	/** UTC hour of day, 0-23. */
+	hour: number
+	count: number
+}
+
+export type AdminInsightsPlanSlice = {
+	plan: string
+	count: number
+}
+
+export type AdminInsightsWorkflowStatus = {
+	status: string
+	count: number
+}
+
+export type AdminInsightsJobHealth = {
+	totalJobs: number
+	enabledJobs: number
+	successRuns: number
+	errorRuns: number
+}
+
+export type AdminInsightsLoaderData = {
+	ok: true
+	generatedAt: string
+	totals: AdminInsightsTotals
+	signupsByWeek: Array<AdminInsightsSignupWeek>
+	usageByMonth: Array<AdminInsightsUsageMonth>
+	emailByDay: Array<AdminInsightsEmailDay>
+	plans: Array<AdminInsightsPlanSlice>
+	authByDay: Array<AdminInsightsAuthDay>
+	authByCategory: Array<AdminInsightsAuthCategory>
+	authHeatmap: Array<AdminInsightsHeatmapCell>
+	workflowStatuses: Array<AdminInsightsWorkflowStatus>
+	jobHealth: AdminInsightsJobHealth
+}
+
 export type AdminSystemEmailListItem = {
 	id: string
 	inbox_local_part: string
@@ -453,6 +540,7 @@ export type AppLoaderData = {
 	adminCommunityReports?: AdminCommunityReportsLoaderData
 	adminInvites?: AdminInvitesLoaderData
 	adminUsage?: AdminUsageLoaderData
+	adminInsights?: AdminInsightsLoaderData
 	adminSystemEmail?: AdminSystemEmailLoaderData
 	accountProfile?: AccountProfileLoaderData
 	onboarding?: OnboardingLoaderData

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -17,6 +17,10 @@ import {
 	createAdminRolesHandler,
 } from '#app/handlers/admin-roles.ts'
 import {
+	createAdminInsightsApiHandler,
+	createAdminInsightsHandler,
+} from '#app/handlers/admin-insights.ts'
+import {
 	createAdminUsageApiHandler,
 	createAdminUsageHandler,
 } from '#app/handlers/admin-usage.ts'
@@ -192,6 +196,8 @@ export function createAppRouter(env: Env) {
 			adminCommunityReportsApiPost: createAdminCommunityReportsApiHandler(env),
 			adminUsage: createAdminUsageHandler(env),
 			adminUsageApi: createAdminUsageApiHandler(env),
+			adminInsights: createAdminInsightsHandler(env),
+			adminInsightsApi: createAdminInsightsApiHandler(env),
 			adminSystemEmail: createAdminSystemEmailHandler(env),
 			adminSystemEmailApi: createAdminSystemEmailApiHandler(env),
 			community: createCommunityHandler(env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -55,6 +55,8 @@ export const routes = route({
 	adminCommunityReportsApiPost: post('/admin/community-reports.json'),
 	adminUsage: '/admin/usage',
 	adminUsageApi: '/admin/usage.json',
+	adminInsights: '/admin/insights',
+	adminInsightsApi: '/admin/insights.json',
 	adminSystemEmail: '/admin/system-email',
 	adminSystemEmailApi: '/admin/system-email.json',
 	community: '/community',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

A new **`/admin/insights`** page (plus `/admin/insights.json` API and an "Insights" tab in the admin subnav): a platform-wide analytics dashboard that is all charts, no data tables.

<a href="https://cursor.com/agents/bc-4a676c1d-87b0-4d40-9eb2-2291255894de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_insights_dashboard_demo.mp4"><img src="https://cursor.com/artifacts/c/art-699c8772-0f83-43ec-b938-e6d99317bd77" alt="admin_insights_dashboard_demo.mp4" /></a>

![Dashboard top: stat cards and user growth](https://cursor.com/artifacts/c/art-79febb78-2c3c-4533-b5c5-5fa5343be705)
![Platform activity stacked bars with native tooltip](https://cursor.com/artifacts/c/art-932de548-2c1a-4e7b-b41c-27dfacc6c852)
![Auth pulse, event categories, heatmap, workflow outcomes](https://cursor.com/artifacts/c/art-529f71c9-b3f2-4e5d-9f00-1fab3a75a712)

### What's on it

- **8 KPI stat cards** with accent gradients and sparklines (users + verified share, packages, jobs, workflow runs, memories, stored emails, secrets, sign-in methods)
- **User growth** — cumulative users over 12 weeks (smooth gradient area chart)
- **New signups** — per-week bars
- **Platform activity** — 12 months of `usage_rollups` events stacked by metric
- **Email traffic** — daily sends/receives over 28 days from the entitlement counters
- **Users by plan**, **Workflow outcomes**, **Event categories**, **Job run health**, **Email verification** — donuts with legends
- **Auth pulse** — audit events per day by result (success / failure / rate-limited)
- **When things happen** — weekday × hour (UTC) audit-event heatmap

### How

- **No chart library.** The UI runtime is Remix 3 `remix/ui` (not React), so the usual charting packages don't apply. Charts are a small hand-rolled SVG kit under `packages/worker/client/charts/` (area, stacked bar, donut, heatmap, sparkline, stat card, legend) with pure, unit-tested geometry helpers (`chart-geometry.ts`). Native `<title>` tooltips, dark-mode-safe palette, everything server-renderable.
- **Read-only aggregation.** `admin-insights-data.ts` runs `COUNT`/`GROUP BY` reads over existing tables (`users`, `usage_rollups`, `entitlement_daily_counters`, `audit_events`, `workflow_runs`, `jobs`, plus footprint counts). Aggregates only — no per-user drill-down, no emails, no content. The payload is KV-cached for 5 minutes like the admin usage rollups.
- **Same admin plumbing as existing pages**: `requireUserWithRole(request, env, 'admin')`, SSR loader data + SPA route loader, admin subnav entry.

### Testing

- Unit tests for the data-shaping helpers and full loader (mock D1), and for the chart geometry (`niceMax`, ticks, smooth paths, donut segments).
- `e2e/admin-rbac.spec.ts` extended: non-admin gets Forbidden on `/admin/insights`; admin sees the dashboard and the JSON payload leaks no secrets or emails.
- Manually tested with seeded demo data (video above): all charts render, tooltips work, SPA nav to/from the page works.
- `npm run validate` passes.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `47c9a24` · **Head:** `a6addd0a`

**Classification:** composes — a new admin-only read model and UI wired from existing primitives; no primitive contracts changed, no schema changes, no writes.

### Primitives touched

| Primitive            | Group   | Impact                                                                      |
| -------------------- | ------- | --------------------------------------------------------------------------- |
| `app-ui`             | surfaces | composes — new `/admin/insights` route, SVG chart components, subnav entry |
| `rbac`               | auth    | composes — `requireUserWithRole('admin')` gate on page + JSON API           |
| `d1-app-db`          | storage | composes — read-only `COUNT`/`GROUP BY` aggregations over existing tables   |
| `usage-metering`     | storage | composes — reads `usage_rollups` + `entitlement_daily_counters` aggregates  |
| `bundle-artifacts-kv`| storage | composes — 5-minute cachified cache of the dashboard payload                |

### System map

The admin browser app gains an insights route that reads aggregated metadata from D1 (via a short KV cache) behind the existing admin RBAC gate.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	rbac["rbac<br/>Role-based access control"]:::touched
	kv["bundle-artifacts-kv<br/>Bundle artifacts KV"]:::touched
	d1AppDb["d1-app-db<br/>D1 app database"]:::touched
	usageMetering["usage-metering<br/>Usage metering"]:::touched
	appUi -->|"GET /admin/insights(.json)"| rbac
	rbac -->|"admin role required"| kv
	kv -->|"5-min cachified read model"| d1AppDb
	d1AppDb -->|"usage_rollups, entitlement_daily_counters"| usageMetering
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- `per-user-isolation`: this is a deliberate cross-user **admin** surface, like `/admin/usage`. It exposes aggregated counts only — no usernames, emails, secrets, or user content appear in the payload (asserted in `e2e/admin-rbac.spec.ts`).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a676c1d-87b0-4d40-9eb2-2291255894de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a676c1d-87b0-4d40-9eb2-2291255894de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only Insights dashboard with user growth, usage, email, authentication, workflow, plan, job health, and activity visualizations.
  * Added interactive charts with legends, tooltips, accessibility labels, and empty-state handling.
  * Added Insights to the admin navigation.
  * Added secure data access for the dashboard and its supporting endpoint.

* **Bug Fixes**
  * Confirmed non-admin members cannot access Insights or its data.
  * Prevented private user information from appearing in dashboard responses.

* **Tests**
  * Expanded coverage for access control, dashboard rendering, data aggregation, chart behavior, and privacy protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->