### PR TITLE
Derive community listing icons from the package's published commit

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -223,11 +223,14 @@ descriptor from `BUNDLE_ARTIFACTS_KV` and streams the referenced R2 object.
 Source files remain in the listing's pinned Artifacts commit; R2 stores only
 validated derived output or a generated fallback.
 
-- Keys use `community-icon:v1/{listingId}/{pinnedCommit}/asset`.
-- Descriptor keys include the same listing id and pinned commit, so re-publish
-  cannot serve an older icon.
-- Unpublish, admin hard delete, re-publish, and account deletion remove known
-  descriptor and object keys.
+- Keys use `community-icon:v1/{listingId}/{commit}/asset`, where the commit is
+  the listing's icon commit (the owner package's current published commit) or
+  its pinned snapshot commit.
+- Descriptor keys include the same listing id and commit, so package publish and
+  listing re-publish cannot serve an older icon.
+- Unpublish, admin hard delete, and re-publish prune all descriptor and object
+  keys under the listing prefix; package publish prunes superseded commits;
+  account deletion removes the pinned and icon commit keys derived from D1.
 - Bucket names are `kody-community-assets` in production and
   `{worker}-community-assets` for preview deployments.
 
@@ -585,9 +588,10 @@ or a deliberate retention note.
 
 App-owned R2 keys are:
 
-- `community-icon:v1/{listingId}/{pinnedCommit}/asset` — processed public
-  community icon bytes. The listing id is the public ownership boundary; account
-  deletion derives keys from the owner's listing rows.
+- `community-icon:v1/{listingId}/{commit}/asset` — processed public community
+  icon bytes at the listing's pinned or icon commit. The listing id is the
+  public ownership boundary; account deletion derives keys from the owner's
+  listing rows and their joined package source commits.
 
 - `email-raw:v1:{userId}/{messageId}` — raw email MIME for the message row that
   stores this key in `email_messages.raw_mime_key`. The `userId` prefix is part

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -202,7 +202,7 @@ primitives:
       Public pinned snapshots of published saved packages on the same
       deployment; inert forks, ratings, user reports, admin moderation at
       /admin/community-reports, /community routes, and lazily derived package
-      icons pinned to the published commit.
+      icons that track the owner package's current published commit.
     code:
       - packages/worker/src/community/
       - packages/worker/src/mcp/capabilities/community/
@@ -513,9 +513,11 @@ primitives:
     name: Community asset storage (R2)
     summary:
       COMMUNITY_ASSETS R2 bucket holding validated, lazily derived community
-      icon bytes under community-icon:v1/{listingId}/{pinnedCommit}/asset.
-      Cachified descriptors live in Bundle artifacts KV; public reads remain
-      gated by an active listing and account deletion removes owner assets.
+      icon bytes under community-icon:v1/{listingId}/{commit}/asset, keyed by
+      the listing's pinned or current icon commit. Cachified descriptors live in
+      Bundle artifacts KV; public reads remain gated by an active listing,
+      package publish prunes superseded commits, and account deletion removes
+      owner assets.
     code:
       - packages/worker/src/community/community-icon.ts
       - packages/worker/src/app/handlers/community-icon.ts

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -67,19 +67,30 @@ map; the path metadata lets the icon route retrieve bytes from Artifacts.
 
 ### Community icon cache
 
-Community listing icons are derived lazily from the pinned Artifacts commit.
-`@epic-web/cachified` stores a small descriptor in `BUNDLE_ARTIFACTS_KV` under
-`derived-cache:v1:community-icon:v1:{listingId}:{pinnedCommit}`. The processed
-bytes live in the private `COMMUNITY_ASSETS` R2 bucket under
-`community-icon:v1/{listingId}/{pinnedCommit}/asset`.
+Community listing icons are derived lazily from the listing's **icon commit**:
+the owner package's current `entity_sources.published_commit` (falling back to
+the listing's pinned commit when the source row is gone). Listing reads join the
+entity source, so a plain package publish moves the icon commit forward — and
+with it the icon URL — without a community republish. `@epic-web/cachified`
+stores a small descriptor in `BUNDLE_ARTIFACTS_KV` under
+`derived-cache:v1:community-icon:v1:{listingId}:{commit}`. The processed bytes
+live in the private `COMMUNITY_ASSETS` R2 bucket under
+`community-icon:v1/{listingId}/{commit}/asset`.
 
-On a descriptor cache miss, the icon service checks the pinned community
-snapshot for a standardized root `community-icon.*` path, reads that file as
-bytes from the Artifacts git repo at `pinnedCommit`, validates it, and writes
-the derived asset to R2 before returning the descriptor. A dangling descriptor
-is deleted and regenerated once. Packages without an icon receive a generated
-fallback. SVG input is rasterized to PNG; PNG, WebP, and JPEG input remains in
-its validated source format.
+On a descriptor cache miss, the icon service resolves the standardized root
+`community-icon.*` path (from the pinned snapshot when serving the pinned
+commit, otherwise by probing the Artifacts git repo at the icon commit), reads
+the bytes, validates them, and writes the derived asset to R2 before returning
+the descriptor. A dangling descriptor is deleted and regenerated once. Packages
+without an icon receive a generated fallback. SVG input is rasterized to PNG;
+PNG, WebP, and JPEG input remains in its validated source format.
+
+The icon route serves only the current icon commit and the pinned commit; stale
+commit URLs 404. Package publish (`finalizePublishedEntitySource`) calls
+`refreshCommunityIconForPackagePublish`, which prunes superseded KV/R2 icon
+entries by listing prefix and invalidates the public listing data cache.
+Community republish, unpublish, admin hard delete, and account deletion remove
+icon entries for the listing.
 
 ## Service layer
 
@@ -134,8 +145,9 @@ Client routes: `packages/worker/client/routes/community*`
 - `/community` — searchable index of active listings
 - `/community/:listingId` — metadata, ratings, README, fork prompt, report link
   (report requires login)
-- `/community/:listingId/icon/:pinnedCommit` — cached package icon or generated
-  fallback; stale commit URLs are rejected
+- `/community/:listingId/icon/:iconCommit` — cached package icon or generated
+  fallback; serves the current icon commit or the pinned snapshot commit, and
+  rejects stale commit URLs
 
 Shared OG rendering lives in `packages/worker/src/og/`: a light-mode palette
 mirroring app design tokens, satori layout + resvg rasterization, and the

--- a/docs/guides/package-authoring.md
+++ b/docs/guides/package-authoring.md
@@ -78,3 +78,8 @@ Public community packages may include one root `community-icon.svg`,
 `community-icon.jpeg`. Prefer a square visual with a simple silhouette that
 remains legible at 56 pixels. Keep it under 2 MiB and 16 megapixels. Kody
 generates a package-name fallback when the repository has no icon.
+
+Publishing the package refreshes the community listing icon automatically. The
+candidate paths win in the order listed above, so when replacing an icon with a
+different format (for example svg → png), delete the old file in the same commit
+or the old format keeps being served.

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -50,8 +50,12 @@ icons to PNG before serving them; PNG, WebP, and JPEG files are validated and
 served in their original format. Packages without an icon receive a generated
 visual based on the package name.
 
-Icon URLs are pinned to the same published commit as the listing. Re-publish the
-saved package and then re-run `community_publish` to update its icon.
+Icon URLs embed the package's **current published commit**, so publishing a new
+package version with an updated `community-icon.*` refreshes the listing icon
+without re-running `community_publish`. Remember the priority order above: an
+old `community-icon.svg` left at the package root keeps winning over a newly
+added `community-icon.png`, so delete superseded icon files when switching
+formats.
 
 Re-running `community_publish` updates the public listing to the package's
 current published commit. Private edits after publishing do not change the

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -50,10 +50,11 @@ icons to PNG before serving them; PNG, WebP, and JPEG files are validated and
 served in their original format. Packages without an icon receive a generated
 visual based on the package name.
 
-Icon URLs embed the package's **current published commit**, so publishing a new
-package version with an updated `community-icon.*` refreshes the listing icon
-without re-running `community_publish`. Remember the priority order above: an
-old `community-icon.svg` left at the package root keeps winning over a newly
+Icon URLs embed the package's **current published commit** (falling back to the
+listing's pinned commit if the package source no longer exists), so publishing a
+new package version with an updated `community-icon.*` refreshes the listing
+icon without re-running `community_publish`. Remember the priority order above:
+an old `community-icon.svg` left at the package root keeps winning over a newly
 added `community-icon.png`, so delete superseded icon files when switching
 formats.
 

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -162,15 +162,25 @@ function createTestDb(initial: RowMap): {
 								return { results: results as Array<T>, meta: { changes: 0 } }
 							}
 							if (
-								lower ===
-								'select id, pinned_commit from community_listings where owner_user_id = ?'
+								lower.startsWith(
+									'select community_listings.id, community_listings.pinned_commit',
+								)
 							) {
 								results = (rows.community_listings ?? [])
 									.filter((row) => row['owner_user_id'] === userId)
-									.map((row) => ({
-										id: row['id'],
-										pinned_commit: row['pinned_commit'],
-									}))
+									.map((row) => {
+										const source = (rows.entity_sources ?? []).find(
+											(sourceRow) =>
+												sourceRow['id'] === row['source_id'] &&
+												sourceRow['user_id'] === row['owner_user_id'],
+										)
+										return {
+											id: row['id'],
+											pinned_commit: row['pinned_commit'],
+											source_published_commit:
+												source?.['published_commit'] ?? null,
+										}
+									})
 								return { results: results as Array<T>, meta: { changes: 0 } }
 							}
 							const m = lower.match(/^select id from (\w+) where user_id = \?/)
@@ -591,7 +601,12 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 			{ user_id: userBbb, resource: 'email_sends_per_day', day: '2026-07-05' },
 		],
 		community_listings: [
-			{ id: 'listing-1', owner_user_id: userAaa, pinned_commit: 'commit-1' },
+			{
+				id: 'listing-1',
+				owner_user_id: userAaa,
+				pinned_commit: 'commit-1',
+				source_id: 'src-1',
+			},
 			{ id: 'listing-2', owner_user_id: userBbb, pinned_commit: 'commit-2' },
 		],
 		community_forks: [
@@ -844,6 +859,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(deletedKvKeys.sort()).toEqual([
 		'bundle-artifact:v1:src-1',
 		'community-snapshot:v1:listing-1',
+		'derived-cache:v1:community-icon:v1:listing-1:abc123',
 		'derived-cache:v1:community-icon:v1:listing-1:commit-1',
 		'package-retriever-index-entry:v1:user-aaa:context:pkg-1:notes',
 		'package-retriever-index-entry:v1:user-aaa:search:pkg-1:notes',
@@ -869,10 +885,13 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(result.updatedRowCounts.community_reports).toBe(1)
 	expect(result.deletedRowCounts.community_bans).toBe(1)
 	expect(result.updatedRowCounts.community_bans).toBe(1)
-	expect(result.deletedKvKeys).toBe(12)
-	expect(result.deletedCommunityAssets).toBe(1)
+	expect(result.deletedKvKeys).toBe(13)
+	expect(result.deletedCommunityAssets).toBe(2)
 	expect(result.deletedEmailBlobs).toBe(1)
-	expect(deletedCommunityAssetKeys).toEqual([
+	// Both the pinned snapshot revision and the current icon commit revision
+	// (the source's published commit) are removed.
+	expect(deletedCommunityAssetKeys.sort()).toEqual([
+		'community-icon:v1/listing-1/abc123/asset',
 		'community-icon:v1/listing-1/commit-1/asset',
 	])
 	expect(result.deletedVectors).toBe(5)

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -100,6 +100,7 @@ type UserPackageServiceSnapshot = {
 type UserCommunityListingSnapshot = {
 	id: string
 	pinnedCommit: string
+	iconCommit: string
 }
 
 type UserDeletionInventory = {
@@ -322,13 +323,26 @@ async function listUserEmailBlobKeys(env: Env, userId: string) {
 
 async function listUserCommunityListings(env: Env, userId: string) {
 	const rows = await env.APP_DB.prepare(
-		`SELECT id, pinned_commit FROM community_listings WHERE owner_user_id = ?`,
+		`SELECT community_listings.id, community_listings.pinned_commit,
+			entity_sources.published_commit AS source_published_commit
+		FROM community_listings
+		LEFT JOIN entity_sources
+			ON entity_sources.id = community_listings.source_id
+			AND entity_sources.user_id = community_listings.owner_user_id
+			AND entity_sources.entity_kind = 'package'
+			AND entity_sources.entity_id = community_listings.package_id
+		WHERE community_listings.owner_user_id = ?`,
 	)
 		.bind(userId)
-		.all<{ id: string; pinned_commit: string }>()
+		.all<{
+			id: string
+			pinned_commit: string
+			source_published_commit: string | null
+		}>()
 	return (rows.results ?? []).map((row) => ({
 		id: row.id,
 		pinnedCommit: row.pinned_commit,
+		iconCommit: row.source_published_commit ?? row.pinned_commit,
 	}))
 }
 
@@ -364,7 +378,12 @@ async function listUserBundleKvKeys(input: {
 			derivedCacheKeyPrefix +
 				buildCommunityIconCacheKey({
 					listingId: listing.id,
-					pinnedCommit: listing.pinnedCommit,
+					commit: listing.pinnedCommit,
+				}),
+			derivedCacheKeyPrefix +
+				buildCommunityIconCacheKey({
+					listingId: listing.id,
+					commit: listing.iconCommit,
 				}),
 		]),
 	])
@@ -1104,11 +1123,17 @@ export async function deleteUserAccount(input: {
 
 	result.deletedCommunityAssets = await deleteR2Objects({
 		blobs: input.env.COMMUNITY_ASSETS,
-		keys: inventory.communityListings.map((listing) =>
-			buildCommunityIconR2Key({
-				listingId: listing.id,
-				pinnedCommit: listing.pinnedCommit,
-			}),
+		keys: uniqueStrings(
+			inventory.communityListings.flatMap((listing) => [
+				buildCommunityIconR2Key({
+					listingId: listing.id,
+					commit: listing.pinnedCommit,
+				}),
+				buildCommunityIconR2Key({
+					listingId: listing.id,
+					commit: listing.iconCommit,
+				}),
+			]),
 		),
 		label: 'Community asset',
 		warnings,

--- a/packages/worker/src/app/community-public.ts
+++ b/packages/worker/src/app/community-public.ts
@@ -19,7 +19,7 @@ export function truncateCommunityText(text: string, maxLength: number) {
 
 export function buildCommunityIconUrl(input: {
 	listingId: string
-	pinnedCommit: string
+	iconCommit: string
 }) {
 	return routes.communityDetailIcon.href(input)
 }
@@ -34,7 +34,7 @@ export function toPublicCommunityListing(
 		description: listing.description,
 		iconUrl: buildCommunityIconUrl({
 			listingId: listing.id,
-			pinnedCommit: listing.pinnedCommit,
+			iconCommit: listing.iconCommit,
 		}),
 		tags: listing.tags,
 		readmeContent: listing.readmeContent,

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -33,6 +33,7 @@ const sampleListing = {
 	readmeContent: '# README',
 	license: 'MIT',
 	pinnedCommit: 'abc1234567890',
+	iconCommit: 'abc1234567890',
 	status: 'active',
 	createdAt: '2026-01-01T00:00:00.000Z',
 	updatedAt: '2026-01-01T00:00:00.000Z',

--- a/packages/worker/src/app/handlers/community-icon.node.test.ts
+++ b/packages/worker/src/app/handlers/community-icon.node.test.ts
@@ -38,26 +38,27 @@ const listing = {
 	readmeContent: null,
 	license: 'MIT',
 	pinnedCommit: 'abc123',
+	iconCommit: 'def456',
 	status: 'active',
 	createdAt: '2026-07-10T00:00:00.000Z',
 	updatedAt: '2026-07-10T00:00:00.000Z',
 	publishedAt: '2026-07-10T00:00:00.000Z',
 } satisfies CommunityListingRecord
 
-function callHandler(pinnedCommit = listing.pinnedCommit) {
+function callHandler(iconCommit = listing.iconCommit) {
 	const handler = createCommunityIconHandler({ APP_DB: {} } as Env)
 	return handler.handler({
 		request: new Request(
-			`https://example.com/community/${listing.id}/icon/${pinnedCommit}`,
+			`https://example.com/community/${listing.id}/icon/${iconCommit}`,
 		),
-		params: { listingId: listing.id, pinnedCommit },
+		params: { listingId: listing.id, iconCommit },
 		url: new URL(
-			`https://example.com/community/${listing.id}/icon/${pinnedCommit}`,
+			`https://example.com/community/${listing.id}/icon/${iconCommit}`,
 		),
 	} as never)
 }
 
-test('community icon handler serves cached R2 bytes for the pinned listing', async () => {
+test('community icon handler serves cached R2 bytes for the current icon commit', async () => {
 	const bytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47])
 	mocks.getCommunityListingById.mockResolvedValue(listing)
 	mocks.getCommunityIconObject.mockResolvedValue({
@@ -77,6 +78,30 @@ test('community icon handler serves cached R2 bytes for the pinned listing', asy
 	expect(response.headers.get('ETag')).toBe('"icon-etag"')
 	expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
 	expect(new Uint8Array(await response.arrayBuffer())).toEqual(bytes)
+	expect(mocks.getCommunityIconObject).toHaveBeenCalledWith(
+		expect.objectContaining({ iconCommit: listing.iconCommit }),
+	)
+})
+
+test('community icon handler keeps serving the pinned snapshot commit', async () => {
+	const bytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47])
+	mocks.getCommunityListingById.mockResolvedValue(listing)
+	mocks.getCommunityIconObject.mockResolvedValue({
+		descriptor: {
+			byteLength: bytes.byteLength,
+			contentType: 'image/png',
+		},
+		object: {
+			body: new Blob([bytes]).stream(),
+			httpEtag: '"icon-etag"',
+		},
+	})
+
+	const response = await callHandler(listing.pinnedCommit)
+	expect(response.status).toBe(200)
+	expect(mocks.getCommunityIconObject).toHaveBeenCalledWith(
+		expect.objectContaining({ iconCommit: listing.pinnedCommit }),
+	)
 })
 
 test('community icon handler rejects stale commit URLs and degrades to a safe fallback', async () => {

--- a/packages/worker/src/app/handlers/community-icon.ts
+++ b/packages/worker/src/app/handlers/community-icon.ts
@@ -17,7 +17,14 @@ export function createCommunityIconHandler(env: Env) {
 				listingId: params.listingId,
 				includeDelisted: false,
 			})
-			if (!listing || listing.pinnedCommit !== params.pinnedCommit) {
+			// The pinned snapshot commit stays servable alongside the current
+			// icon commit so pages cached just before a package publish do not
+			// break; anything else is a stale URL and is rejected.
+			if (
+				!listing ||
+				(params.iconCommit !== listing.iconCommit &&
+					params.iconCommit !== listing.pinnedCommit)
+			) {
 				return new Response('Not found', { status: 404 })
 			}
 
@@ -25,6 +32,7 @@ export function createCommunityIconHandler(env: Env) {
 				const { descriptor, object } = await getCommunityIconObject({
 					env,
 					listing,
+					iconCommit: params.iconCommit,
 				})
 				return new Response(object.body, {
 					headers: {

--- a/packages/worker/src/app/handlers/community.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community.frame.node.test.ts
@@ -27,6 +27,7 @@ const sampleListing = {
 	readmeContent: '# README',
 	license: 'MIT',
 	pinnedCommit: 'abc1234567890',
+	iconCommit: 'abc1234567890',
 	status: 'active',
 	createdAt: '2026-01-01T00:00:00.000Z',
 	updatedAt: '2026-01-01T00:00:00.000Z',

--- a/packages/worker/src/app/handlers/community.node.test.ts
+++ b/packages/worker/src/app/handlers/community.node.test.ts
@@ -27,6 +27,7 @@ const sampleListing = {
 	readmeContent: '# README',
 	license: 'MIT',
 	pinnedCommit: 'abc1234567890',
+	iconCommit: 'abc1234567890',
 	status: 'active',
 	createdAt: '2026-01-01T00:00:00.000Z',
 	updatedAt: '2026-01-01T00:00:00.000Z',

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -63,7 +63,7 @@ export const routes = route({
 	communityApi: '/community.json',
 	communityDetail: '/community/:listingId',
 	communityDetailApi: '/community/:listingId.json',
-	communityDetailIcon: '/community/:listingId/icon/:pinnedCommit',
+	communityDetailIcon: '/community/:listingId/icon/:iconCommit',
 	communityDetailOgImage: '/community/:listingId/og.png',
 	communityReportApiPost: post('/community/:listingId/report.json'),
 	health: '/health',

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -43,6 +43,7 @@ const sampleListing = {
 	readmeContent: '# README',
 	license: 'MIT',
 	pinnedCommit: 'abc1234567890',
+	iconCommit: 'abc1234567890',
 	status: 'active',
 	createdAt: '2026-01-01T00:00:00.000Z',
 	updatedAt: '2026-01-01T00:00:00.000Z',

--- a/packages/worker/src/community/community-icon.node.test.ts
+++ b/packages/worker/src/community/community-icon.node.test.ts
@@ -1,22 +1,29 @@
 import { expect, test, vi } from 'vitest'
 import {
+	getCommunityPublicCacheVersion,
+	resetDataCacheForTests,
+} from '#app/data-cache.ts'
+import {
+	deleteCommunityIconAssets,
 	findCommunityIconPath,
 	getCommunityIconObject,
 	processCommunityIcon,
+	refreshCommunityIconForPackagePublish,
 	renderCommunityIconFallbackPng,
 } from './community-icon.ts'
 import { type CommunityListingRecord } from './types.ts'
 
 const mocks = vi.hoisted(() => ({
-	readArtifactFileAtCommit: vi.fn(),
+	readFirstArtifactFileAtCommit: vi.fn(),
 	getEntitySourceById: vi.fn(),
 	getCommunityListingById: vi.fn(),
+	getCommunityListingByOwnerAndPackage: vi.fn(),
 	readCommunitySnapshot: vi.fn(),
 }))
 
 vi.mock('#worker/repo/artifact-file.ts', () => ({
-	readArtifactFileAtCommit: (...args: Array<unknown>) =>
-		mocks.readArtifactFileAtCommit(...args),
+	readFirstArtifactFileAtCommit: (...args: Array<unknown>) =>
+		mocks.readFirstArtifactFileAtCommit(...args),
 }))
 
 vi.mock('#worker/repo/entity-sources.ts', () => ({
@@ -27,6 +34,8 @@ vi.mock('#worker/repo/entity-sources.ts', () => ({
 vi.mock('./repo.ts', () => ({
 	getCommunityListingById: (...args: Array<unknown>) =>
 		mocks.getCommunityListingById(...args),
+	getCommunityListingByOwnerAndPackage: (...args: Array<unknown>) =>
+		mocks.getCommunityListingByOwnerAndPackage(...args),
 }))
 
 vi.mock('./snapshot.ts', () => ({
@@ -102,6 +111,14 @@ function createFakeKv() {
 			async delete(key: string) {
 				values.delete(key)
 			},
+			async list(options?: { prefix?: string }) {
+				return {
+					keys: Array.from(values.keys())
+						.filter((name) => name.startsWith(options?.prefix ?? ''))
+						.map((name) => ({ name })),
+					list_complete: true,
+				}
+			},
 		} as unknown as KVNamespace,
 	}
 }
@@ -124,6 +141,14 @@ function createFakeR2() {
 		async delete(key: string) {
 			values.delete(key)
 		},
+		async list(options?: { prefix?: string }) {
+			return {
+				objects: Array.from(values.keys())
+					.filter((key) => key.startsWith(options?.prefix ?? ''))
+					.map((key) => ({ key })),
+				truncated: false,
+			}
+		},
 	} as unknown as R2Bucket
 	return { bucket, values }
 }
@@ -141,11 +166,27 @@ const listing = {
 	readmeContent: null,
 	license: 'MIT',
 	pinnedCommit: 'abc123',
+	iconCommit: 'abc123',
 	status: 'active',
 	createdAt: '2026-07-10T00:00:00.000Z',
 	updatedAt: '2026-07-10T00:00:00.000Z',
 	publishedAt: '2026-07-10T00:00:00.000Z',
 } satisfies CommunityListingRecord
+
+const entitySourceRow = {
+	id: listing.sourceId,
+	user_id: listing.ownerUserId,
+	entity_kind: 'package',
+	entity_id: listing.packageId,
+	repo_id: 'package-package-1',
+	published_commit: listing.pinnedCommit,
+	indexed_commit: listing.pinnedCommit,
+	manifest_path: 'package.json',
+	source_root: '/',
+	last_external_check_at: null,
+	created_at: '2026-07-10T00:00:00.000Z',
+	updated_at: '2026-07-10T00:00:00.000Z',
+}
 
 test('community raster icon formats are validated and preserved', async () => {
 	const png = createPngHeader(256, 256)
@@ -222,7 +263,11 @@ test('community SVG icons load directly from the retained listing snapshot', asy
 	})
 	mocks.getCommunityListingById.mockResolvedValue(listing)
 
-	const result = await getCommunityIconObject({ env, listing })
+	const result = await getCommunityIconObject({
+		env,
+		listing,
+		iconCommit: listing.pinnedCommit,
+	})
 
 	expect(result.descriptor.sourcePath).toBe('community-icon.svg')
 	expect(result.descriptor.contentType).toBe('image/png')
@@ -234,7 +279,7 @@ test('community SVG icons load directly from the retained listing snapshot', asy
 		),
 	).toEqual([0x89, 0x50, 0x4e, 0x47])
 	expect(mocks.getEntitySourceById).not.toHaveBeenCalled()
-	expect(mocks.readArtifactFileAtCommit).not.toHaveBeenCalled()
+	expect(mocks.readFirstArtifactFileAtCommit).not.toHaveBeenCalled()
 })
 
 test('community icon descriptor caches the R2 reference and repairs a dangling reference', async () => {
@@ -254,33 +299,35 @@ test('community icon descriptor caches the R2 reference and repairs a dangling r
 		communityIconPath: 'community-icon.png',
 		createdAt: '2026-07-10T00:00:00.000Z',
 	})
-	mocks.getEntitySourceById.mockResolvedValue({
-		id: listing.sourceId,
-		user_id: listing.ownerUserId,
-		entity_kind: 'package',
-		entity_id: listing.packageId,
-		repo_id: 'package-package-1',
-		published_commit: listing.pinnedCommit,
-		indexed_commit: listing.pinnedCommit,
-		manifest_path: 'package.json',
-		source_root: '/',
-		last_external_check_at: null,
-		created_at: '2026-07-10T00:00:00.000Z',
-		updated_at: '2026-07-10T00:00:00.000Z',
-	})
+	mocks.getEntitySourceById.mockResolvedValue(entitySourceRow)
 	mocks.getCommunityListingById.mockResolvedValue(listing)
-	mocks.readArtifactFileAtCommit.mockResolvedValue(png)
+	mocks.readFirstArtifactFileAtCommit.mockResolvedValue({
+		path: 'community-icon.png',
+		bytes: png,
+	})
 
-	const first = await getCommunityIconObject({ env, listing })
-	const second = await getCommunityIconObject({ env, listing })
+	const first = await getCommunityIconObject({
+		env,
+		listing,
+		iconCommit: listing.pinnedCommit,
+	})
+	const second = await getCommunityIconObject({
+		env,
+		listing,
+		iconCommit: listing.pinnedCommit,
+	})
 	expect(first.descriptor.contentType).toBe('image/png')
 	expect(second.descriptor.r2Key).toBe(first.descriptor.r2Key)
-	expect(mocks.readArtifactFileAtCommit).toHaveBeenCalledTimes(1)
+	expect(mocks.readFirstArtifactFileAtCommit).toHaveBeenCalledTimes(1)
 
 	values.delete(first.descriptor.r2Key)
-	const repaired = await getCommunityIconObject({ env, listing })
+	const repaired = await getCommunityIconObject({
+		env,
+		listing,
+		iconCommit: listing.pinnedCommit,
+	})
 	expect(repaired.descriptor.r2Key).toBe(first.descriptor.r2Key)
-	expect(mocks.readArtifactFileAtCommit).toHaveBeenCalledTimes(2)
+	expect(mocks.readFirstArtifactFileAtCommit).toHaveBeenCalledTimes(2)
 
 	values.clear()
 	kvValues.clear()
@@ -288,8 +335,150 @@ test('community icon descriptor caches the R2 reference and repairs a dangling r
 	mocks.getCommunityListingById
 		.mockResolvedValueOnce(listing)
 		.mockResolvedValueOnce(null)
-	await getCommunityIconObject({ env, listing })
+	await getCommunityIconObject({
+		env,
+		listing,
+		iconCommit: listing.pinnedCommit,
+	})
 	expect(kvValues.size).toBe(0)
+})
+
+test('community icons ahead of the pinned snapshot load from the artifact repo at the icon commit', async () => {
+	const png = createPngHeader(128, 128)
+	const iconCommit = 'def456'
+	const publishedListing = { ...listing, iconCommit }
+	const { kv } = createFakeKv()
+	const { bucket } = createFakeR2()
+	const env = {
+		APP_DB: {} as D1Database,
+		BUNDLE_ARTIFACTS_KV: kv,
+		COMMUNITY_ASSETS: bucket,
+	} as Env
+	mocks.readCommunitySnapshot.mockResolvedValue(null)
+	mocks.getEntitySourceById.mockResolvedValue({
+		...entitySourceRow,
+		published_commit: iconCommit,
+	})
+	mocks.getCommunityListingById.mockResolvedValue(publishedListing)
+	mocks.readFirstArtifactFileAtCommit.mockResolvedValue({
+		path: 'community-icon.png',
+		bytes: png,
+	})
+
+	const result = await getCommunityIconObject({
+		env,
+		listing: publishedListing,
+		iconCommit,
+	})
+
+	expect(result.descriptor.iconCommit).toBe(iconCommit)
+	expect(result.descriptor.r2Key).toContain(`/${iconCommit}/`)
+	expect(result.descriptor.sourcePath).toBe('community-icon.png')
+	expect(mocks.readFirstArtifactFileAtCommit).toHaveBeenCalledWith(
+		expect.objectContaining({
+			commit: iconCommit,
+			filePaths: [
+				'community-icon.svg',
+				'community-icon.png',
+				'community-icon.webp',
+				'community-icon.jpg',
+				'community-icon.jpeg',
+			],
+		}),
+	)
+	// The pinned snapshot is never consulted for ahead-of-snapshot commits.
+	expect(mocks.readCommunitySnapshot).not.toHaveBeenCalled()
+})
+
+test('deleteCommunityIconAssets removes superseded revisions and keeps servable commits', async () => {
+	const { kv, values: kvValues } = createFakeKv()
+	const { bucket, values: r2Values } = createFakeR2()
+	const kvKey = (commit: string) =>
+		`derived-cache:v1:community-icon:v1:${listing.id}:${commit}`
+	const r2Key = (commit: string) =>
+		`community-icon:v1/${listing.id}/${commit}/asset`
+	for (const commit of ['commit-1', 'commit-2', 'commit-3']) {
+		kvValues.set(kvKey(commit), '{}')
+		r2Values.set(r2Key(commit), Uint8Array.from([1]))
+	}
+	kvValues.set(
+		'derived-cache:v1:community-icon:v1:other-listing:commit-1',
+		'{}',
+	)
+	r2Values.set(
+		'community-icon:v1/other-listing/commit-1/asset',
+		Uint8Array.from([1]),
+	)
+
+	await deleteCommunityIconAssets({
+		env: { BUNDLE_ARTIFACTS_KV: kv, COMMUNITY_ASSETS: bucket },
+		listingId: listing.id,
+		keepCommits: ['commit-2'],
+	})
+
+	expect(Array.from(kvValues.keys()).sort()).toEqual(
+		[
+			kvKey('commit-2'),
+			'derived-cache:v1:community-icon:v1:other-listing:commit-1',
+		].sort(),
+	)
+	expect(Array.from(r2Values.keys()).sort()).toEqual(
+		[
+			r2Key('commit-2'),
+			'community-icon:v1/other-listing/commit-1/asset',
+		].sort(),
+	)
+})
+
+test('refreshCommunityIconForPackagePublish drops superseded icon caches for active listings', async () => {
+	resetDataCacheForTests()
+	const { kv, values: kvValues } = createFakeKv()
+	const { bucket, values: r2Values } = createFakeR2()
+	const env = {
+		APP_DB: {} as D1Database,
+		BUNDLE_ARTIFACTS_KV: kv,
+		COMMUNITY_ASSETS: bucket,
+	} as Env
+	const kvKey = (commit: string) =>
+		`derived-cache:v1:community-icon:v1:${listing.id}:${commit}`
+	const r2Key = (commit: string) =>
+		`community-icon:v1/${listing.id}/${commit}/asset`
+	for (const commit of [listing.pinnedCommit, 'old-publish', 'new-publish']) {
+		kvValues.set(kvKey(commit), '{}')
+		r2Values.set(r2Key(commit), Uint8Array.from([1]))
+	}
+
+	mocks.getCommunityListingByOwnerAndPackage.mockResolvedValue({
+		...listing,
+		iconCommit: 'new-publish',
+	})
+	await refreshCommunityIconForPackagePublish({
+		env,
+		userId: listing.ownerUserId,
+		packageId: listing.packageId,
+		publishedCommit: 'new-publish',
+	})
+
+	expect(Array.from(kvValues.keys()).sort()).toEqual(
+		[kvKey(listing.pinnedCommit), kvKey('new-publish')].sort(),
+	)
+	expect(Array.from(r2Values.keys()).sort()).toEqual(
+		[r2Key(listing.pinnedCommit), r2Key('new-publish')].sort(),
+	)
+	expect(getCommunityPublicCacheVersion()).toBe(1)
+
+	// Without an active listing the hook must be a no-op.
+	mocks.getCommunityListingByOwnerAndPackage.mockResolvedValue(null)
+	r2Values.set(r2Key('old-publish'), Uint8Array.from([1]))
+	await refreshCommunityIconForPackagePublish({
+		env,
+		userId: listing.ownerUserId,
+		packageId: listing.packageId,
+		publishedCommit: 'newest-publish',
+	})
+	expect(r2Values.has(r2Key('old-publish'))).toBe(true)
+	expect(getCommunityPublicCacheVersion()).toBe(1)
+	resetDataCacheForTests()
 })
 
 test('community icon path selection is deterministic', () => {

--- a/packages/worker/src/community/community-icon.ts
+++ b/packages/worker/src/community/community-icon.ts
@@ -1,10 +1,18 @@
 import { cachified } from '@epic-web/cachified'
 import { Resvg } from '@resvg/resvg-wasm'
-import { createKvCachifiedCache } from '#worker/kv-cachified.ts'
+import { invalidateCommunityPublicCache } from '#app/data-cache.ts'
+import {
+	createKvCachifiedCache,
+	derivedCacheKeyPrefix,
+} from '#worker/kv-cachified.ts'
 import { ensureRenderPipelineReady } from '#worker/og/render.ts'
-import { readArtifactFileAtCommit } from '#worker/repo/artifact-file.ts'
+import { readFirstArtifactFileAtCommit } from '#worker/repo/artifact-file.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
-import { getCommunityListingById } from './repo.ts'
+import { type EntitySourceRow } from '#worker/repo/types.ts'
+import {
+	getCommunityListingById,
+	getCommunityListingByOwnerAndPackage,
+} from './repo.ts'
 import { readCommunitySnapshot } from './snapshot.ts'
 import { type CommunityListingRecord } from './types.ts'
 
@@ -29,7 +37,7 @@ type CommunityIconContentType = 'image/png' | 'image/webp' | 'image/jpeg'
 type CommunityIconDescriptor = {
 	version: typeof communityIconVersion
 	listingId: string
-	pinnedCommit: string
+	iconCommit: string
 	r2Key: string
 	contentType: CommunityIconContentType
 	sourcePath: (typeof communityIconPaths)[number] | null
@@ -43,16 +51,24 @@ type ProcessedCommunityIcon = {
 
 export function buildCommunityIconCacheKey(input: {
 	listingId: string
-	pinnedCommit: string
+	commit: string
 }) {
-	return `community-icon:v${communityIconVersion}:${input.listingId}:${input.pinnedCommit}`
+	return `community-icon:v${communityIconVersion}:${input.listingId}:${input.commit}`
+}
+
+function buildCommunityIconKvListingPrefix(listingId: string) {
+	return `${derivedCacheKeyPrefix}community-icon:v${communityIconVersion}:${listingId}:`
 }
 
 export function buildCommunityIconR2Key(input: {
 	listingId: string
-	pinnedCommit: string
+	commit: string
 }) {
-	return `community-icon:v${communityIconVersion}/${input.listingId}/${input.pinnedCommit}/asset`
+	return `community-icon:v${communityIconVersion}/${input.listingId}/${input.commit}/asset`
+}
+
+function buildCommunityIconR2ListingPrefix(listingId: string) {
+	return `community-icon:v${communityIconVersion}/${listingId}/`
 }
 
 export function findCommunityIconPath(
@@ -64,6 +80,7 @@ export function findCommunityIconPath(
 export async function getCommunityIconObject(input: {
 	env: Env
 	listing: CommunityListingRecord
+	iconCommit: string
 }): Promise<{
 	descriptor: CommunityIconDescriptor
 	object: R2ObjectBody
@@ -72,18 +89,18 @@ export async function getCommunityIconObject(input: {
 	const cache = {
 		...baseCache,
 		async set(key: string, entry: Parameters<typeof baseCache.set>[1]) {
-			if (await isCurrentActiveListing(input.env.APP_DB, input.listing)) {
+			if (await isServableIconCommit(input)) {
 				await baseCache.set(key, entry)
 			}
 		},
 	}
 	const key = buildCommunityIconCacheKey({
 		listingId: input.listing.id,
-		pinnedCommit: input.listing.pinnedCommit,
+		commit: input.iconCommit,
 	})
 	const expectedR2Key = buildCommunityIconR2Key({
 		listingId: input.listing.id,
-		pinnedCommit: input.listing.pinnedCommit,
+		commit: input.iconCommit,
 	})
 	const loadDescriptor = (forceFresh = false) =>
 		cachified({
@@ -94,7 +111,7 @@ export async function getCommunityIconObject(input: {
 			checkValue: (value) =>
 				isCommunityIconDescriptor(value) &&
 				value.listingId === input.listing.id &&
-				value.pinnedCommit === input.listing.pinnedCommit &&
+				value.iconCommit === input.iconCommit &&
 				value.r2Key === expectedR2Key,
 			getFreshValue: () => createCommunityIconDescriptor(input),
 		})
@@ -114,86 +131,189 @@ export async function getCommunityIconObject(input: {
 	return { descriptor, object }
 }
 
-export async function deleteCommunityIconAsset(input: {
+/**
+ * Deletes cached community icon descriptors (KV) and derived assets (R2) for
+ * a listing, keeping only entries for the provided commits. Publish paths
+ * pass the commits that remain servable; unpublish/delete paths pass none.
+ */
+export async function deleteCommunityIconAssets(input: {
 	env: Pick<Env, 'BUNDLE_ARTIFACTS_KV' | 'COMMUNITY_ASSETS'>
 	listingId: string
-	pinnedCommit: string
+	keepCommits?: ReadonlyArray<string>
 }) {
-	const cache = createKvCachifiedCache(input.env.BUNDLE_ARTIFACTS_KV)
-	await Promise.all([
-		cache.delete(buildCommunityIconCacheKey(input)),
-		input.env.COMMUNITY_ASSETS.delete(buildCommunityIconR2Key(input)),
-	])
+	const keptKvKeys = new Set(
+		(input.keepCommits ?? []).map(
+			(commit) =>
+				derivedCacheKeyPrefix +
+				buildCommunityIconCacheKey({ listingId: input.listingId, commit }),
+		),
+	)
+	const keptR2Keys = new Set(
+		(input.keepCommits ?? []).map((commit) =>
+			buildCommunityIconR2Key({ listingId: input.listingId, commit }),
+		),
+	)
+	let kvCursor: string | undefined
+	do {
+		const page = await input.env.BUNDLE_ARTIFACTS_KV.list({
+			prefix: buildCommunityIconKvListingPrefix(input.listingId),
+			cursor: kvCursor,
+		})
+		await Promise.all(
+			page.keys
+				.map((key) => key.name)
+				.filter((name) => !keptKvKeys.has(name))
+				.map((name) => input.env.BUNDLE_ARTIFACTS_KV.delete(name)),
+		)
+		kvCursor = page.list_complete ? undefined : page.cursor
+	} while (kvCursor)
+	let r2Cursor: string | undefined
+	do {
+		const page = await input.env.COMMUNITY_ASSETS.list({
+			prefix: buildCommunityIconR2ListingPrefix(input.listingId),
+			cursor: r2Cursor,
+		})
+		await Promise.all(
+			page.objects
+				.map((object) => object.key)
+				.filter((objectKey) => !keptR2Keys.has(objectKey))
+				.map((objectKey) => input.env.COMMUNITY_ASSETS.delete(objectKey)),
+		)
+		r2Cursor = page.truncated ? page.cursor : undefined
+	} while (r2Cursor)
+}
+
+/**
+ * Package-publish hook: when the owner republishes the package behind an
+ * active community listing, drop cached icon assets for superseded commits
+ * and bust the public listing data cache so pages emit the new icon URL
+ * (which embeds the new published commit) promptly.
+ */
+export async function refreshCommunityIconForPackagePublish(input: {
+	env: Env
+	userId: string
+	packageId: string
+	publishedCommit: string
+}) {
+	const listing = await getCommunityListingByOwnerAndPackage(input.env.APP_DB, {
+		ownerUserId: input.userId,
+		packageId: input.packageId,
+	})
+	if (!listing || listing.status !== 'active') return
+	await deleteCommunityIconAssets({
+		env: input.env,
+		listingId: listing.id,
+		keepCommits: [listing.pinnedCommit, input.publishedCommit],
+	})
+	invalidateCommunityPublicCache()
+}
+
+async function loadCommunityIconSource(input: {
+	env: Env
+	listing: CommunityListingRecord
+	iconCommit: string
+}): Promise<{
+	path: (typeof communityIconPaths)[number]
+	bytes: Uint8Array
+} | null> {
+	if (input.iconCommit === input.listing.pinnedCommit) {
+		const snapshot = await readCommunitySnapshot(
+			input.env.BUNDLE_ARTIFACTS_KV,
+			input.listing.id,
+		)
+		if (!snapshot || snapshot.pinnedCommit !== input.listing.pinnedCommit) {
+			throw new Error(
+				`Community listing snapshot for "${input.listing.id}" at "${input.listing.pinnedCommit}" was not found.`,
+			)
+		}
+		const sourcePath =
+			communityIconPaths.find((path) => path === snapshot.communityIconPath) ??
+			findCommunityIconPath(snapshot.files)
+		if (!sourcePath) return null
+		if (sourcePath === 'community-icon.svg') {
+			const source = snapshot.files[sourcePath]
+			if (source == null) {
+				throw new Error(
+					`Community icon "${sourcePath}" was not retained in the listing snapshot.`,
+				)
+			}
+			return {
+				path: sourcePath,
+				bytes: new TextEncoder().encode(source),
+			}
+		}
+		const source = await getValidatedListingPackageSource(input)
+		const found = await readFirstArtifactFileAtCommit({
+			env: input.env,
+			repoId: source.repo_id,
+			commit: input.iconCommit,
+			filePaths: [sourcePath],
+		})
+		if (!found) {
+			throw new Error(
+				`Community icon "${sourcePath}" was not found at pinned commit "${input.listing.pinnedCommit}".`,
+			)
+		}
+		return { path: sourcePath, bytes: found.bytes }
+	}
+
+	// Icon commits ahead of the pinned snapshot come straight from the owner
+	// package's Artifacts repo at the published commit.
+	const source = await getValidatedListingPackageSource(input)
+	const found = await readFirstArtifactFileAtCommit({
+		env: input.env,
+		repoId: source.repo_id,
+		commit: input.iconCommit,
+		filePaths: communityIconPaths,
+	})
+	if (!found) return null
+	const path = communityIconPaths.find((candidate) => candidate === found.path)
+	if (!path) return null
+	return { path, bytes: found.bytes }
+}
+
+async function getValidatedListingPackageSource(input: {
+	env: Env
+	listing: CommunityListingRecord
+}): Promise<EntitySourceRow> {
+	const source = await getEntitySourceById(
+		input.env.APP_DB,
+		input.listing.sourceId,
+	)
+	if (
+		!source ||
+		source.user_id !== input.listing.ownerUserId ||
+		source.entity_kind !== 'package' ||
+		source.entity_id !== input.listing.packageId
+	) {
+		throw new Error(
+			`Community listing "${input.listing.id}" has an invalid package source.`,
+		)
+	}
+	return source
 }
 
 async function createCommunityIconDescriptor(input: {
 	env: Env
 	listing: CommunityListingRecord
+	iconCommit: string
 }): Promise<CommunityIconDescriptor> {
-	const snapshot = await readCommunitySnapshot(
-		input.env.BUNDLE_ARTIFACTS_KV,
-		input.listing.id,
-	)
-	if (!snapshot || snapshot.pinnedCommit !== input.listing.pinnedCommit) {
-		throw new Error(
-			`Community listing snapshot for "${input.listing.id}" at "${input.listing.pinnedCommit}" was not found.`,
-		)
-	}
-
-	const sourcePath =
-		communityIconPaths.find((path) => path === snapshot.communityIconPath) ??
-		findCommunityIconPath(snapshot.files)
-	let processed: ProcessedCommunityIcon
-	if (sourcePath === 'community-icon.svg') {
-		const source = snapshot.files[sourcePath]
-		if (source == null) {
-			throw new Error(
-				`Community icon "${sourcePath}" was not retained in the listing snapshot.`,
-			)
-		}
-		processed = await processCommunityIcon({
-			path: sourcePath,
-			sourceBytes: new TextEncoder().encode(source),
-		})
-	} else if (sourcePath) {
-		const source = await getEntitySourceById(
-			input.env.APP_DB,
-			input.listing.sourceId,
-		)
-		if (
-			!source ||
-			source.user_id !== input.listing.ownerUserId ||
-			source.entity_kind !== 'package' ||
-			source.entity_id !== input.listing.packageId
-		) {
-			throw new Error(
-				`Community listing "${input.listing.id}" has an invalid package source.`,
-			)
-		}
-		const sourceBytes = await readArtifactFileAtCommit({
-			env: input.env,
-			repoId: source.repo_id,
-			commit: input.listing.pinnedCommit,
-			filePath: sourcePath,
-		})
-		if (!sourceBytes) {
-			throw new Error(
-				`Community icon "${sourcePath}" was not found at pinned commit "${input.listing.pinnedCommit}".`,
-			)
-		}
-		processed = await processCommunityIcon({ path: sourcePath, sourceBytes })
-	} else {
-		processed = {
-			bytes: await renderCommunitySvgIcon(
-				buildCommunityIconFallbackSvg(input.listing.name),
-			),
-			contentType: 'image/png',
-		}
-	}
+	const iconSource = await loadCommunityIconSource(input)
+	const processed: ProcessedCommunityIcon = iconSource
+		? await processCommunityIcon({
+				path: iconSource.path,
+				sourceBytes: iconSource.bytes,
+			})
+		: {
+				bytes: await renderCommunitySvgIcon(
+					buildCommunityIconFallbackSvg(input.listing.name),
+				),
+				contentType: 'image/png',
+			}
 
 	const r2Key = buildCommunityIconR2Key({
 		listingId: input.listing.id,
-		pinnedCommit: input.listing.pinnedCommit,
+		commit: input.iconCommit,
 	})
 	await input.env.COMMUNITY_ASSETS.put(r2Key, processed.bytes, {
 		httpMetadata: {
@@ -202,11 +322,11 @@ async function createCommunityIconDescriptor(input: {
 		},
 		customMetadata: {
 			listingId: input.listing.id,
-			pinnedCommit: input.listing.pinnedCommit,
-			sourcePath: sourcePath ?? '',
+			iconCommit: input.iconCommit,
+			sourcePath: iconSource?.path ?? '',
 		},
 	})
-	if (!(await isCurrentActiveListing(input.env.APP_DB, input.listing))) {
+	if (!(await isServableIconCommit(input))) {
 		await input.env.COMMUNITY_ASSETS.delete(r2Key)
 		throw new Error(
 			`Community listing "${input.listing.id}" was removed while its icon was generated.`,
@@ -215,27 +335,35 @@ async function createCommunityIconDescriptor(input: {
 	return {
 		version: communityIconVersion,
 		listingId: input.listing.id,
-		pinnedCommit: input.listing.pinnedCommit,
+		iconCommit: input.iconCommit,
 		r2Key,
 		contentType: processed.contentType,
-		sourcePath,
+		sourcePath: iconSource?.path ?? null,
 		byteLength: processed.bytes.byteLength,
 	}
 }
 
-async function isCurrentActiveListing(
-	db: D1Database,
-	listing: CommunityListingRecord,
-) {
-	const current = await getCommunityListingById(db, {
-		listingId: listing.id,
+/**
+ * A commit stays cacheable while the listing is still active with the same
+ * owner/package/source identity and the commit is either the pinned snapshot
+ * commit or the current icon commit. This keeps unpublish/delete cleanup
+ * race-free: assets are never re-persisted for removed or superseded state.
+ */
+async function isServableIconCommit(input: {
+	env: Pick<Env, 'APP_DB'>
+	listing: CommunityListingRecord
+	iconCommit: string
+}) {
+	const current = await getCommunityListingById(input.env.APP_DB, {
+		listingId: input.listing.id,
 		includeDelisted: false,
 	})
 	return (
-		current?.ownerUserId === listing.ownerUserId &&
-		current.packageId === listing.packageId &&
-		current.sourceId === listing.sourceId &&
-		current.pinnedCommit === listing.pinnedCommit
+		current?.ownerUserId === input.listing.ownerUserId &&
+		current.packageId === input.listing.packageId &&
+		current.sourceId === input.listing.sourceId &&
+		(current.pinnedCommit === input.iconCommit ||
+			current.iconCommit === input.iconCommit)
 	)
 }
 
@@ -504,7 +632,7 @@ function isCommunityIconDescriptor(
 	return (
 		descriptor.version === communityIconVersion &&
 		typeof descriptor.listingId === 'string' &&
-		typeof descriptor.pinnedCommit === 'string' &&
+		typeof descriptor.iconCommit === 'string' &&
 		typeof descriptor.r2Key === 'string' &&
 		['image/png', 'image/webp', 'image/jpeg'].includes(
 			descriptor.contentType ?? '',

--- a/packages/worker/src/community/community-icon.workers.test.ts
+++ b/packages/worker/src/community/community-icon.workers.test.ts
@@ -22,6 +22,7 @@ test('community icon resolves a cachified descriptor to R2 bytes', async () => {
 		readmeContent: null,
 		license: 'MIT',
 		pinnedCommit: 'abc123',
+		iconCommit: 'abc123',
 		status: 'active',
 		createdAt: '2026-07-10T00:00:00.000Z',
 		updatedAt: '2026-07-10T00:00:00.000Z',
@@ -30,13 +31,13 @@ test('community icon resolves a cachified descriptor to R2 bytes', async () => {
 	const bytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47])
 	const r2Key = buildCommunityIconR2Key({
 		listingId: listing.id,
-		pinnedCommit: listing.pinnedCommit,
+		commit: listing.iconCommit,
 	})
 	const cacheKey =
 		derivedCacheKeyPrefix +
 		buildCommunityIconCacheKey({
 			listingId: listing.id,
-			pinnedCommit: listing.pinnedCommit,
+			commit: listing.iconCommit,
 		})
 	await env.COMMUNITY_ASSETS.put(r2Key, bytes, {
 		httpMetadata: { contentType: 'image/png' },
@@ -51,7 +52,7 @@ test('community icon resolves a cachified descriptor to R2 bytes', async () => {
 			value: {
 				version: 1,
 				listingId: listing.id,
-				pinnedCommit: listing.pinnedCommit,
+				iconCommit: listing.iconCommit,
 				r2Key,
 				contentType: 'image/png',
 				sourcePath: 'community-icon.png',
@@ -63,6 +64,7 @@ test('community icon resolves a cachified descriptor to R2 bytes', async () => {
 	const result = await getCommunityIconObject({
 		env,
 		listing,
+		iconCommit: listing.iconCommit,
 	})
 
 	expect(result.descriptor.r2Key).toBe(r2Key)

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -133,9 +133,20 @@ const {
 
 const testBundleArtifactsKv = {
 	delete: vi.fn(async () => undefined),
+	list: vi.fn(async () => ({
+		keys: [{ name: 'derived-cache:v1:community-icon:v1:listing-1:commit-1' }],
+		list_complete: true,
+	})),
 } as unknown as KVNamespace
 const testCommunityAssets = {
 	delete: vi.fn(async () => undefined),
+	list: vi.fn(async () => ({
+		objects: [
+			{ key: 'community-icon:v1/listing-1/commit-1/asset' },
+			{ key: 'community-icon:v1/listing-1/commit-2/asset' },
+		],
+		truncated: false,
+	})),
 } as unknown as R2Bucket
 
 function createEnv() {
@@ -162,6 +173,7 @@ function sampleListing(
 		readmeContent: '# Discord Gateway\n\n## Intent\n\nBridge Discord events.',
 		license: 'MIT',
 		pinnedCommit: 'commit-1',
+		iconCommit: 'commit-1',
 		status: 'active',
 		createdAt: '2026-07-01T00:00:00.000Z',
 		updatedAt: '2026-07-01T00:00:00.000Z',
@@ -378,7 +390,6 @@ test('unpublishCommunityListing deletes active listings and cascades cleanup', a
 		'community-icon-delete-failed',
 		'unpublish',
 		'listing-1',
-		'commit-1',
 		expect.any(Error),
 	)
 	consoleError.mockRestore()

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -33,6 +33,10 @@ function mapCommunityListingRow(
 			row['readme_content'] == null ? null : String(row['readme_content']),
 		license: String(row['license']),
 		pinnedCommit: String(row['pinned_commit']),
+		iconCommit:
+			row['source_published_commit'] == null
+				? String(row['pinned_commit'])
+				: String(row['source_published_commit']),
 		status: String(row['status']) as CommunityListingStatus,
 		createdAt: String(row['created_at']),
 		updatedAt: String(row['updated_at']),
@@ -88,8 +92,28 @@ function mapCommunityBanRow(row: Record<string, unknown>): CommunityBanRecord {
 }
 
 function listingStatusFilter(includeDelisted: boolean) {
-	return includeDelisted ? '' : `WHERE status = 'active'`
+	return includeDelisted ? '' : `WHERE community_listings.status = 'active'`
 }
+
+/**
+ * Listing reads join the owner package's entity source so the icon commit
+ * (`source_published_commit`) tracks the latest package publish. The join is
+ * scoped to the listing owner + package so a foreign source row can never
+ * leak a commit into another user's listing.
+ */
+const communityListingSelectColumns = `community_listings.id, community_listings.owner_user_id,
+	community_listings.package_id, community_listings.source_id, community_listings.kody_id,
+	community_listings.name, community_listings.description, community_listings.tags_json,
+	community_listings.search_text, community_listings.readme_content, community_listings.license,
+	community_listings.pinned_commit, community_listings.status, community_listings.created_at,
+	community_listings.updated_at, community_listings.published_at,
+	entity_sources.published_commit AS source_published_commit`
+
+const communityListingSourceJoin = `LEFT JOIN entity_sources
+	ON entity_sources.id = community_listings.source_id
+	AND entity_sources.user_id = community_listings.owner_user_id
+	AND entity_sources.entity_kind = 'package'
+	AND entity_sources.entity_id = community_listings.package_id`
 
 // D1 caps bound parameters per statement, so IN (...) lookups over large id
 // sets are issued in chunks (90 leaves headroom for fixed bindings).
@@ -230,14 +254,15 @@ export async function getCommunityListingById(
 		includeDelisted: boolean
 	},
 ): Promise<CommunityListingRecord | null> {
-	const statusClause = input.includeDelisted ? '' : `AND status = 'active'`
+	const statusClause = input.includeDelisted
+		? ''
+		: `AND community_listings.status = 'active'`
 	const row = await db
 		.prepare(
-			`SELECT id, owner_user_id, package_id, source_id, kody_id, name, description,
-				tags_json, search_text, readme_content, license, pinned_commit, status,
-				created_at, updated_at, published_at
+			`SELECT ${communityListingSelectColumns}
 			FROM community_listings
-			WHERE id = ? ${statusClause}`,
+			${communityListingSourceJoin}
+			WHERE community_listings.id = ? ${statusClause}`,
 		)
 		.bind(input.listingId)
 		.first<Record<string, unknown>>()
@@ -253,11 +278,10 @@ export async function getCommunityListingByOwnerAndPackage(
 ): Promise<CommunityListingRecord | null> {
 	const row = await db
 		.prepare(
-			`SELECT id, owner_user_id, package_id, source_id, kody_id, name, description,
-				tags_json, search_text, readme_content, license, pinned_commit, status,
-				created_at, updated_at, published_at
+			`SELECT ${communityListingSelectColumns}
 			FROM community_listings
-			WHERE owner_user_id = ? AND package_id = ?`,
+			${communityListingSourceJoin}
+			WHERE community_listings.owner_user_id = ? AND community_listings.package_id = ?`,
 		)
 		.bind(input.ownerUserId, input.packageId)
 		.first<Record<string, unknown>>()
@@ -274,12 +298,11 @@ export async function listCommunityListings(
 ): Promise<Array<CommunityListingRecord>> {
 	const rows = await db
 		.prepare(
-			`SELECT id, owner_user_id, package_id, source_id, kody_id, name, description,
-				tags_json, search_text, readme_content, license, pinned_commit, status,
-				created_at, updated_at, published_at
+			`SELECT ${communityListingSelectColumns}
 			FROM community_listings
+			${communityListingSourceJoin}
 			${listingStatusFilter(input.includeDelisted)}
-			ORDER BY published_at DESC
+			ORDER BY community_listings.published_at DESC
 			LIMIT ? OFFSET ?`,
 		)
 		.bind(input.limit, input.offset)
@@ -304,7 +327,7 @@ export async function listCommunityListingCandidates(
 	const conditions: Array<string> = []
 	const bindings: Array<unknown> = []
 	if (!input.includeDelisted) {
-		conditions.push(`status = 'active'`)
+		conditions.push(`community_listings.status = 'active'`)
 	}
 	const tokens = extractCommunityListingLikeTokens(input.query ?? '')
 	if (tokens.length > 0) {
@@ -312,7 +335,7 @@ export async function listCommunityListingCandidates(
 			const pattern = `%${token}%`
 			const columnClauses = communityListingSearchTextColumns.map((column) => {
 				bindings.push(pattern)
-				return `${column} LIKE ?`
+				return `community_listings.${column} LIKE ?`
 			})
 			return `(${columnClauses.join(' OR ')})`
 		})
@@ -322,12 +345,11 @@ export async function listCommunityListingCandidates(
 		conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
 	const rows = await db
 		.prepare(
-			`SELECT id, owner_user_id, package_id, source_id, kody_id, name, description,
-				tags_json, search_text, readme_content, license, pinned_commit, status,
-				created_at, updated_at, published_at
+			`SELECT ${communityListingSelectColumns}
 			FROM community_listings
+			${communityListingSourceJoin}
 			${whereClause}
-			ORDER BY published_at DESC
+			ORDER BY community_listings.published_at DESC
 			LIMIT ?`,
 		)
 		.bind(...bindings, input.limit)

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -55,7 +55,7 @@ import {
 } from './snapshot.ts'
 import {
 	communityIconPaths,
-	deleteCommunityIconAsset,
+	deleteCommunityIconAssets,
 	findCommunityIconPath,
 } from './community-icon.ts'
 import {
@@ -84,20 +84,19 @@ export const COMMUNITY_SEARCH_VECTOR_MATCH_THRESHOLD = 0.12
 // a materialized score column if the catalog ever approaches this size.
 export const COMMUNITY_SEARCH_CANDIDATE_LIMIT = 500
 
-async function deleteCommunityIconAssetBestEffort(input: {
+async function deleteCommunityIconAssetsBestEffort(input: {
 	env: Env
 	listingId: string
-	pinnedCommit: string
+	keepCommits?: ReadonlyArray<string>
 	reason: 'republish' | 'unpublish' | 'hard-delete'
 }) {
 	try {
-		await deleteCommunityIconAsset(input)
+		await deleteCommunityIconAssets(input)
 	} catch (error) {
 		console.error(
 			'community-icon-delete-failed',
 			input.reason,
 			input.listingId,
-			input.pinnedCommit,
 			error,
 		)
 	}
@@ -453,17 +452,13 @@ export async function publishCommunityListing(input: {
 		throw snapshotError
 	}
 	if (existingListing) {
-		for (const pinnedCommit of new Set([
-			existingListing.pinnedCommit,
-			publishedCommit,
-		])) {
-			await deleteCommunityIconAssetBestEffort({
-				env: input.env,
-				listingId,
-				pinnedCommit,
-				reason: 'republish',
-			})
-		}
+		// Drop all cached icon revisions (including a reused commit id) so the
+		// republished listing regenerates its icon lazily from fresh state.
+		await deleteCommunityIconAssetsBestEffort({
+			env: input.env,
+			listingId,
+			reason: 'republish',
+		})
 	}
 
 	const listing = await getCommunityListingById(input.env.APP_DB, {
@@ -503,10 +498,9 @@ export async function unpublishCommunityListing(input: {
 		throw new Error(`Community listing "${input.listingId}" was not found.`)
 	}
 
-	await deleteCommunityIconAssetBestEffort({
+	await deleteCommunityIconAssetsBestEffort({
 		env: input.env,
 		listingId: listing.id,
-		pinnedCommit: listing.pinnedCommit,
 		reason: 'unpublish',
 	})
 	await deleteCommunityRatingsByListingId(input.env.APP_DB, input.listingId)
@@ -910,10 +904,9 @@ export async function resolveCommunityReport(input: {
 				)
 			} else {
 				if (listing) {
-					await deleteCommunityIconAssetBestEffort({
+					await deleteCommunityIconAssetsBestEffort({
 						env: input.env,
 						listingId: listing.id,
-						pinnedCommit: listing.pinnedCommit,
 						reason: 'hard-delete',
 					})
 				}

--- a/packages/worker/src/community/types.ts
+++ b/packages/worker/src/community/types.ts
@@ -34,6 +34,14 @@ export type CommunityListingRecord = {
 	readmeContent: string | null
 	license: string
 	pinnedCommit: string
+	/**
+	 * Commit the public listing icon is derived from: the owner package's
+	 * current published commit when the listing's package source still
+	 * exists, otherwise the pinned snapshot commit. Package publishes move
+	 * this forward without a community republish, so icon URLs and cache
+	 * keys bust as soon as a new `community-icon.*` is published.
+	 */
+	iconCommit: string
 	status: CommunityListingStatus
 	createdAt: string
 	updatedAt: string

--- a/packages/worker/src/repo/artifact-file.ts
+++ b/packages/worker/src/repo/artifact-file.ts
@@ -15,6 +15,26 @@ export async function readArtifactFileAtCommit(input: {
 	commit: string
 	filePath: string
 }): Promise<Uint8Array | null> {
+	const found = await readFirstArtifactFileAtCommit({
+		env: input.env,
+		repoId: input.repoId,
+		commit: input.commit,
+		filePaths: [input.filePath],
+	})
+	return found?.bytes ?? null
+}
+
+/**
+ * Reads the first candidate path that exists at the given commit using a
+ * single shallow fetch, so callers probing a small set of well-known paths
+ * (for example `community-icon.*`) do not pay one fetch per candidate.
+ */
+export async function readFirstArtifactFileAtCommit(input: {
+	env: Env
+	repoId: string
+	commit: string
+	filePaths: ReadonlyArray<string>
+}): Promise<{ path: string; bytes: Uint8Array } | null> {
 	const repo = await resolveExistingArtifactSourceRepo(input.env, input.repoId)
 	if (!repo) {
 		throw new Error(`Artifact repo "${input.repoId}" was not found.`)
@@ -30,8 +50,13 @@ export async function readArtifactFileAtCommit(input: {
 			repoId: input.repoId,
 			commit: input.commit,
 		})
-		const content = snapshot?.files[input.filePath]
-		return content == null ? null : new TextEncoder().encode(content)
+		for (const filePath of input.filePaths) {
+			const content = snapshot?.files[filePath]
+			if (content != null) {
+				return { path: filePath, bytes: new TextEncoder().encode(content) }
+			}
+		}
+		return null
 	}
 
 	const token = await repo.createToken('read', 300)
@@ -65,18 +90,20 @@ export async function readArtifactFileAtCommit(input: {
 		},
 	})
 
-	try {
-		const result = await git.readBlob({
-			fs: workspace.fs,
-			dir: workspace.dir,
-			oid: input.commit,
-			filepath: input.filePath,
-		})
-		return result.blob
-	} catch (error) {
-		if (isMissingArtifactFileError(error)) return null
-		throw error
+	for (const filePath of input.filePaths) {
+		try {
+			const result = await git.readBlob({
+				fs: workspace.fs,
+				dir: workspace.dir,
+				oid: input.commit,
+				filepath: filePath,
+			})
+			return { path: filePath, bytes: result.blob }
+		} catch (error) {
+			if (!isMissingArtifactFileError(error)) throw error
+		}
 	}
+	return null
 }
 
 function isMissingArtifactFileError(error: unknown) {

--- a/packages/worker/src/repo/external-publish.node.test.ts
+++ b/packages/worker/src/repo/external-publish.node.test.ts
@@ -8,6 +8,7 @@ const mockModule = vi.hoisted(() => ({
 	deletePublishedSourceSnapshot: vi.fn(async () => undefined),
 	loadPublishedSourceSnapshot: vi.fn(),
 	refreshSavedPackageProjection: vi.fn(),
+	refreshCommunityIconForPackagePublish: vi.fn(async () => undefined),
 	hasPublishedRuntimeArtifacts: vi.fn(() => false),
 }))
 
@@ -36,6 +37,11 @@ vi.mock('#worker/package-runtime/published-runtime-artifacts.ts', () => ({
 vi.mock('#worker/package-registry/service.ts', () => ({
 	refreshSavedPackageProjection: (...args: Array<unknown>) =>
 		mockModule.refreshSavedPackageProjection(...args),
+}))
+
+vi.mock('#worker/community/community-icon.ts', () => ({
+	refreshCommunityIconForPackagePublish: (...args: Array<unknown>) =>
+		mockModule.refreshCommunityIconForPackagePublish(...args),
 }))
 
 const { publishFromExternalRef } = await import('./external-publish.ts')
@@ -103,6 +109,16 @@ test('publishes an external fast-forward ref after checks pass', async () => {
 		expect.anything(),
 		expect.objectContaining({
 			id: 'source-1',
+			publishedCommit: 'commit-new',
+		}),
+	)
+	// A successful package publish refreshes the community listing icon so
+	// updated community-icon.* files become publicly visible without a
+	// community republish.
+	expect(mockModule.refreshCommunityIconForPackagePublish).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-1',
+			packageId: 'package-1',
 			publishedCommit: 'commit-new',
 		}),
 	)
@@ -365,6 +381,10 @@ test('publishFromExternalRef fails when projection refresh fails after commit', 
 			publishedCommit: 'commit-old',
 		}),
 	)
+	// Failed publishes must not invalidate community icon caches.
+	expect(
+		mockModule.refreshCommunityIconForPackagePublish,
+	).not.toHaveBeenCalled()
 
 	mockModule.getEntitySourceById.mockResolvedValue(source())
 	mockModule.hasPublishedRuntimeArtifacts.mockReturnValue(true)

--- a/packages/worker/src/repo/external-publish.ts
+++ b/packages/worker/src/repo/external-publish.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/cloudflare'
+import { refreshCommunityIconForPackagePublish } from '#worker/community/community-icon.ts'
 import { refreshSavedPackageProjection } from '#worker/package-registry/service.ts'
 import {
 	deletePublishedSourceSnapshot,
@@ -74,48 +75,64 @@ export async function finalizePublishedEntitySource(
 			throw snapshotError
 		}
 	}
-	if (input.source.entity_kind === 'package') {
+	if (input.source.entity_kind !== 'package') return
+	try {
+		await refreshSavedPackageProjection({
+			env: input.env,
+			baseUrl: input.baseUrl ?? input.source.source_root,
+			userId: input.source.user_id,
+			// No account email in this publish path; plan lookup fails open per entitlements.md.
+			packageId: input.source.entity_id,
+			sourceId: input.source.id,
+			rebuildArtifacts: input.rebuildPackageArtifacts ?? true,
+		})
+	} catch (projectionError) {
 		try {
-			await refreshSavedPackageProjection({
-				env: input.env,
-				baseUrl: input.baseUrl ?? input.source.source_root,
+			await updateEntitySource(input.env.APP_DB, {
+				id: input.source.id,
 				userId: input.source.user_id,
-				// No account email in this publish path; plan lookup fails open per entitlements.md.
-				packageId: input.source.entity_id,
-				sourceId: input.source.id,
-				rebuildArtifacts: input.rebuildPackageArtifacts ?? true,
+				publishedCommit: previousPublishedCommit,
+				manifestPath: input.source.manifest_path,
+				sourceRoot: input.source.source_root,
 			})
-		} catch (projectionError) {
-			try {
-				await updateEntitySource(input.env.APP_DB, {
-					id: input.source.id,
-					userId: input.source.user_id,
-					publishedCommit: previousPublishedCommit,
-					manifestPath: input.source.manifest_path,
-					sourceRoot: input.source.source_root,
-				})
-				if (wrotePublishedSnapshot) {
-					await deletePublishedSourceSnapshot({
-						env: input.env,
-						sourceId: input.source.id,
-						publishedCommit: input.publishedCommit,
-					})
-				}
-			} catch (revertError) {
-				Sentry.captureException(revertError, {
-					tags: {
-						scope:
-							'repo.publishFromExternalRef.revert-after-projection-failure',
-					},
-					extra: {
-						sourceId: input.source.id,
-						previousPublishedCommit,
-						attemptedPublishedCommit: input.publishedCommit,
-					},
+			if (wrotePublishedSnapshot) {
+				await deletePublishedSourceSnapshot({
+					env: input.env,
+					sourceId: input.source.id,
+					publishedCommit: input.publishedCommit,
 				})
 			}
-			throw projectionError
+		} catch (revertError) {
+			Sentry.captureException(revertError, {
+				tags: {
+					scope: 'repo.publishFromExternalRef.revert-after-projection-failure',
+				},
+				extra: {
+					sourceId: input.source.id,
+					previousPublishedCommit,
+					attemptedPublishedCommit: input.publishedCommit,
+				},
+			})
 		}
+		throw projectionError
+	}
+	// Best-effort: an active community listing derives its public icon from
+	// the package's published commit, so superseded cached icon revisions are
+	// dropped and the public listing cache is invalidated. Failures must not
+	// unwind an otherwise successful publish.
+	try {
+		await refreshCommunityIconForPackagePublish({
+			env: input.env,
+			userId: input.source.user_id,
+			packageId: input.source.entity_id,
+			publishedCommit: input.publishedCommit,
+		})
+	} catch (error) {
+		console.error(
+			'community-icon-publish-refresh-failed',
+			input.source.entity_id,
+			error,
+		)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Publishing updated `community-icon.*` files on a saved package (e.g. via `package_publish_external_push`) never became visible on the public community pages. Confirmed in production for `kit`, `hydrawise`, `transistor`, `venstar`, and `google`: the packages' Artifacts HEAD carried the new icons (published 2026-07-11 05:34 UTC), while `/community/:listingId` kept serving icons for the pinned commit from 2026-07-10.

Root cause: community icon URLs, KV descriptors (~30-day TTL), and R2 assets were all keyed by the listing's **pinned snapshot commit**, which only moves on an explicit `community_publish`. A package publish updated `entity_sources.published_commit` but nothing about the listing icon, so every cache layer kept the stale key alive indefinitely — shorter TTLs would not have fixed this, since the URL itself never changed.

## Fix

The listing icon now tracks an **icon commit**: the owner package's current published commit, falling back to the pinned commit when the package source row is gone.

- Community listing reads `LEFT JOIN entity_sources` (scoped to owner + package) and expose `iconCommit` on `CommunityListingRecord`.
- Icon URLs are `/community/:listingId/icon/:iconCommit`; KV descriptors and R2 assets are keyed by the same commit, so a package publish busts every cache layer by key change (content identity, not TTL).
- The icon route serves the current icon commit or the pinned snapshot commit and 404s stale commits, matching prior semantics.
- Descriptor generation reads `community-icon.*` from the Artifacts repo at the icon commit via a new `readFirstArtifactFileAtCommit` (one shallow fetch, candidate paths probed in priority order); pinned-commit requests keep the snapshot fast path for SVGs.
- `finalizePublishedEntitySource` (external push + repo-session publish lanes) calls a new best-effort `refreshCommunityIconForPackagePublish`: prunes superseded KV/R2 icon entries by listing prefix and invalidates the public listing data cache.
- Republish/unpublish/admin hard delete prune all icon entries by listing prefix; account deletion removes pinned + icon commit keys derived from D1.

Note for the affected packages: `kit`, `hydrawise`, and `transistor` added `community-icon.png` while leaving the old `community-icon.svg` in place — svg wins by documented priority, so those repos also need the stale svg deleted (handled as post-deploy verification, not in this PR). Docs now warn about this trap.

## Testing

- Unit tests updated + new coverage: icon generation at an ahead-of-snapshot commit, prefix pruning with keep-commits, the package-publish hook (active listing, no-op without one), publish-lane invocation, handler acceptance of icon/pinned commits and 404 for stale, and account-deletion key derivation via the join.
- `npm run validate` green locally (format, lint, typecheck, 809 unit tests, 13 Playwright E2E, MCP E2E), re-ran unit suite after rebasing onto `main`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `ff425827` · **Head:** `2b919149`

**Classification:** extends — the community listing read model and icon cache contract change shape (icon commit joins the package source); no new primitives.

### Primitives touched

| Primitive             | Group     | Impact                                                                       |
| --------------------- | --------- | ---------------------------------------------------------------------------- |
| `community-listings`  | assistant | extends — listing reads join `entity_sources`; icon route param is the icon commit |
| `community-assets-r2` | storage   | extends — keys move from pinned commit to pinned-or-icon commit; prefix pruning |
| `bundle-artifacts-kv` | storage   | composes — descriptor keys follow the icon commit; prefix pruning            |
| `artifacts-repos`     | storage   | composes — `readFirstArtifactFileAtCommit` probes icon paths in one fetch    |
| `repo-sessions`       | assistant | composes — publish lanes call the community icon refresh hook                |
| `account-export`      | assistant | composes — account deletion derives icon commit keys via the same join       |

### System map

A package publish flows through the publish finalizer into the community icon cache, and public listing reads now join the package source to build icon URLs.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	repoSessions["repo-sessions<br/>Repo-backed editing sessions"]:::touched
	communityListings["community-listings<br/>Community package listings"]:::extended
	communityAssetsR2["community-assets-r2<br/>Community asset storage (R2)"]:::extended
	bundleArtifactsKv["bundle-artifacts-kv<br/>Bundle artifacts KV"]:::touched
	artifactsRepos["artifacts-repos<br/>Artifacts source repos"]:::touched
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	repoSessions -->|"finalizePublishedEntitySource → refreshCommunityIconForPackagePublish"| communityListings
	communityListings -->|"LEFT JOIN entity_sources.published_commit AS iconCommit"| d1AppDb
	communityListings -->|"prune + write community-icon:v1/{listingId}/{commit}/asset"| communityAssetsR2
	communityListings -->|"descriptor derived-cache:v1:community-icon:v1:{listingId}:{commit}"| bundleArtifactsKv
	communityListings -->|"readFirstArtifactFileAtCommit(community-icon.*) @ iconCommit"| artifactsRepos
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
before: /community/:listingId/icon/:pinnedCommit   (moves only on community_publish)
after:  /community/:listingId/icon/:iconCommit     (moves on every package publish;
                                                    pinned commit stays servable)
```

### Invariants

Per-user isolation: the `entity_sources` join is constrained to the listing's `owner_user_id`, `entity_kind = 'package'`, and `package_id`, so a foreign source row can never contribute a commit (or icon bytes) to another user's listing. The icon read path keeps the existing owner/package/source validation before touching the Artifacts repo.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a016b4c-7a66-4f85-a574-d857d50cc9ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a016b4c-7a66-4f85-a574-d857d50cc9ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community listing icons now automatically refresh when a package is published.
  * Icon URLs now use the current package commit (with fallback to the pinned snapshot commit), supporting prioritized icon filename selection.
* **Bug Fixes**
  * Prevents stale or mismatched commit URLs from serving incorrect icons.
  * Account deletion, unpublish, and hard delete now remove community icon assets/caches for both pinned and icon commits.
* **Documentation**
  * Updated guidance covering icon derivation, storage keying, caching/pruning behavior, and endpoint/route parameter naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->