### PR TITLE
Add Kit-backed waiting list to invite-gated signup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,6 +125,7 @@ jobs:
           GOOGLE_CLIENT_SECRET: ${{ secrets.OAUTH_GOOGLE_CLIENT_SECRET }}
           X_CLIENT_ID: ${{ secrets.OAUTH_X_CLIENT_ID }}
           X_CLIENT_SECRET: ${{ secrets.OAUTH_X_CLIENT_SECRET }}
+          KIT_API_KEY: ${{ secrets.KIT_API_KEY }}
         run: >
           node tools/ci/sync-worker-secrets.ts --env production --config
           "$WRANGLER_CONFIG" --set-from-env COOKIE_SECRET
@@ -135,7 +136,7 @@ jobs:
           --set-from-env-optional GITHUB_CLIENT_SECRET --set-from-env-optional
           GOOGLE_CLIENT_ID --set-from-env-optional GOOGLE_CLIENT_SECRET
           --set-from-env-optional X_CLIENT_ID --set-from-env-optional
-          X_CLIENT_SECRET
+          X_CLIENT_SECRET --set-from-env-optional KIT_API_KEY
 
       - name: 🗄️ Apply D1 Migrations
         env:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -264,6 +264,7 @@ jobs:
           PREVIEW_URL: ${{ steps.deploy_preview.outputs.url }}
           AI_GATEWAY_ID: ${{ secrets.AI_GATEWAY_ID_PREVIEW }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          KIT_API_KEY: ${{ secrets.KIT_API_KEY }}
         run: |
           set -euo pipefail
           ENV_FILE="packages/worker/.env.example"
@@ -281,7 +282,7 @@ jobs:
             extra_args+=(--set "APP_BASE_URL=$PREVIEW_URL")
           fi
 
-          node tools/ci/sync-worker-secrets.ts --env "" --name "$APP_WORKER_NAME" --config "$WRANGLER_CONFIG" --from-dotenv "$ENV_FILE" --from-dotenv "$OVERRIDES_FILE" --set-from-env-optional AI_GATEWAY_ID --set-from-env-optional SENTRY_DSN --generate-cookie-secret --include-empty "${extra_args[@]}"
+          node tools/ci/sync-worker-secrets.ts --env "" --name "$APP_WORKER_NAME" --config "$WRANGLER_CONFIG" --from-dotenv "$ENV_FILE" --from-dotenv "$OVERRIDES_FILE" --set-from-env-optional AI_GATEWAY_ID --set-from-env-optional SENTRY_DSN --set-from-env-optional KIT_API_KEY --generate-cookie-secret --include-empty "${extra_args[@]}"
 
       - name: 📤 Upload Worker source maps to Sentry
         env:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -264,7 +264,6 @@ jobs:
           PREVIEW_URL: ${{ steps.deploy_preview.outputs.url }}
           AI_GATEWAY_ID: ${{ secrets.AI_GATEWAY_ID_PREVIEW }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          KIT_API_KEY: ${{ secrets.KIT_API_KEY }}
         run: |
           set -euo pipefail
           ENV_FILE="packages/worker/.env.example"
@@ -282,7 +281,9 @@ jobs:
             extra_args+=(--set "APP_BASE_URL=$PREVIEW_URL")
           fi
 
-          node tools/ci/sync-worker-secrets.ts --env "" --name "$APP_WORKER_NAME" --config "$WRANGLER_CONFIG" --from-dotenv "$ENV_FILE" --from-dotenv "$OVERRIDES_FILE" --set-from-env-optional AI_GATEWAY_ID --set-from-env-optional SENTRY_DSN --set-from-env-optional KIT_API_KEY --generate-cookie-secret --include-empty "${extra_args[@]}"
+          # Intentionally omit KIT_API_KEY so preview/E2E waiting-list joins use
+          # the non-production no-op path instead of writing to production Kit.
+          node tools/ci/sync-worker-secrets.ts --env "" --name "$APP_WORKER_NAME" --config "$WRANGLER_CONFIG" --from-dotenv "$ENV_FILE" --from-dotenv "$OVERRIDES_FILE" --set-from-env-optional AI_GATEWAY_ID --set-from-env-optional SENTRY_DSN --generate-cookie-secret --include-empty "${extra_args[@]}"
 
       - name: 📤 Upload Worker source maps to Sentry
         env:

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -69,7 +69,10 @@ Waiting-list Kit integration:
 - Worker secret `KIT_API_KEY` (Kit v4 `X-Kit-Api-Key`)
 - Optional `KIT_WAITLIST_TAG_ID` (defaults to the `waitlist::kody` tag id)
 - Production fails closed with 503 when `KIT_API_KEY` is unset; non-production
-  accepts the join without calling Kit so local/preview UX stays usable
+  accepts the join without calling Kit so local/preview UX stays usable. Preview
+  deploys intentionally omit `KIT_API_KEY` so they never write to the production
+  Kit audience.
+- Existing Kit subscribers are tagged without overwriting their `first_name`
 - Rate-limited per client IP (5 requests / 15 minutes)
 
 The `invites` table stores operator-created invite codes:

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -59,6 +59,19 @@ whether an invite is required. Production wrangler env sets
 `'preview'` / `'test'`. The predicate fails closed: if the runtime cannot be
 positively identified as non-production, signup requires a valid invite code.
 
+The public `/signup` page defaults to a waiting-list form (first name + email)
+backed by `POST /waiting-list`, which upserts a Kit subscriber and tags them
+`waitlist::kody`. An "I have a code" control reveals the invite signup form.
+`?code`, `?invite`, or `?panel=invite` also opens the invite form directly.
+
+Waiting-list Kit integration:
+
+- Worker secret `KIT_API_KEY` (Kit v4 `X-Kit-Api-Key`)
+- Optional `KIT_WAITLIST_TAG_ID` (defaults to the `waitlist::kody` tag id)
+- Production fails closed with 503 when `KIT_API_KEY` is unset; non-production
+  accepts the join without calling Kit so local/preview UX stays usable
+- Rate-limited per client IP (5 requests / 15 minutes)
+
 The `invites` table stores operator-created invite codes:
 
 - `code` is the primary key shown to the invited user

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -88,9 +88,10 @@ primitives:
     name: Browser sessions
     summary:
       Signed kody_session cookie auth for browser users; production signup
-      invite-gated, non-production signup open, account email verification
-      surfaced in session state, social login (GitHub/Google/X OAuth connections
-      in oauth_connections, mockable via MOCK_ client ids on non-production
+      invite-gated with a Kit-backed public waiting list on /signup
+      (non-production signup open), account email verification surfaced in
+      session state, social login (GitHub/Google/X OAuth connections in
+      oauth_connections, mockable via MOCK_ client ids on non-production
       runtimes), and opt-in second factors — TOTP two-factor (verifications
       table, pending kody_verify cookie gates login until /verify) and passkeys
       (WebAuthn sign-in as an alternative first factor that still honors 2FA).
@@ -98,6 +99,8 @@ primitives:
       - packages/worker/src/app/auth-session.ts
       - packages/worker/src/app/handlers/auth.ts
       - packages/worker/src/app/handlers/auth-provider.ts
+      - packages/worker/src/app/handlers/waiting-list.ts
+      - packages/worker/src/app/kit-waitlist.ts
       - packages/worker/src/app/handlers/account-connections.ts
       - packages/worker/src/app/oauth-providers.ts
       - packages/worker/src/app/oauth-login-state.ts

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -91,7 +91,9 @@ Optional Worker secrets / vars for the public `/signup` waiting-list form
 (`POST /waiting-list`):
 
 - `KIT_API_KEY` — Kit v4 API key (`X-Kit-Api-Key`). Required for production
-  waiting-list joins; non-production skips Kit when unset.
+  waiting-list joins to succeed; when unset, production returns 503 for the
+  endpoint while the rest of the app stays up. Preview deploys omit the key so
+  joins no-op instead of writing to the production Kit audience.
 - `KIT_WAITLIST_TAG_ID` — optional override for the Kit tag id (defaults to the
   `waitlist::kody` tag).
 

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -85,6 +85,18 @@ non-production runtimes (used by local dev and E2E tests). In GitHub Actions the
 values live under `OAUTH_`-prefixed secret names because Actions reserves
 `GITHUB_*`; the deploy workflow maps them to the unprefixed Worker secrets.
 
+## Kit waiting list
+
+Optional Worker secrets / vars for the public `/signup` waiting-list form
+(`POST /waiting-list`):
+
+- `KIT_API_KEY` — Kit v4 API key (`X-Kit-Api-Key`). Required for production
+  waiting-list joins; non-production skips Kit when unset.
+- `KIT_WAITLIST_TAG_ID` — optional override for the Kit tag id (defaults to the
+  `waitlist::kody` tag).
+
+See [`architecture/authentication.md`](./architecture/authentication.md).
+
 ## Saved-secret encryption (`SECRET_STORE_KEY`)
 
 Required Worker secret used to derive the AES-GCM key for encrypting saved

--- a/docs/contributing/project-intent.md
+++ b/docs/contributing/project-intent.md
@@ -33,10 +33,11 @@ shared state between users.
 - Optimization target: a high-quality personal assistant for each individual
   signed-in user, with hard isolation between users
 - Onboarding: production signup is invite-gated by operator-created invite
-  codes. Local dev, preview, and test runtimes remain open so fixtures, seeds,
-  and manual development do not need an auth-bypass path. New signups must
-  verify their email address; unverified accounts can sign in but cannot send
-  outbound email. There is still no privileged "primary user" at runtime.
+  codes. People without a code can join a Kit-backed waiting list from
+  `/signup`. Local dev, preview, and test runtimes remain open so fixtures,
+  seeds, and manual development do not need an auth-bypass path. New signups
+  must verify their email address; unverified accounts can sign in but cannot
+  send outbound email. There is still no privileged "primary user" at runtime.
 - Tests and fixtures may seed deterministic local accounts, but seeded accounts
   are fixtures only and are not privileged at runtime
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -146,6 +146,11 @@ Configure these GitHub Actions secrets and variables for workflows:
   `GITHUB_CLIENT_ID`-style secrets — the `OAUTH_` prefix exists because GitHub
   Actions reserves the `GITHUB_*` secret namespace. See
   `docs/contributing/social-login.md` for provider app setup.)
+- `KIT_API_KEY` (optional; Kit / kit.com API key for `/waiting-list` signup.
+  Synced to the Worker as a secret. Production waiting-list joins fail closed
+  when unset; non-production skips Kit. Create a Kit API key at
+  https://app.kit.com/account_settings/developer_settings and use the same value
+  as the Kody user secret `kitApiKey` when convenient.)
 - `SENTRY_AUTH_TOKEN` (optional GitHub **secret**; Sentry auth token with
   `project:releases` / source map upload permissions — used only by CI to run
   `npm run sentry:upload-sourcemaps` after deploy)

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -146,9 +146,11 @@ Configure these GitHub Actions secrets and variables for workflows:
   `GITHUB_CLIENT_ID`-style secrets — the `OAUTH_` prefix exists because GitHub
   Actions reserves the `GITHUB_*` secret namespace. See
   `docs/contributing/social-login.md` for provider app setup.)
-- `KIT_API_KEY` (optional; Kit / kit.com API key for `/waiting-list` signup.
-  Synced to the Worker as a secret. Production waiting-list joins fail closed
-  when unset; non-production skips Kit. Create a Kit API key at
+- `KIT_API_KEY` (optional GitHub / Worker secret; Kit / kit.com API key for
+  `/waiting-list` signup. Production deploy syncs it when set; without it,
+  production waiting-list joins return 503 while the rest of the app still
+  deploys. Preview deploys intentionally omit the key so preview/E2E joins do
+  not write to the production Kit audience. Create a Kit API key at
   https://app.kit.com/account_settings/developer_settings and use the same value
   as the Kody user secret `kitApiKey` when convenient.)
 - `SENTRY_AUTH_TOKEN` (optional GitHub **secret**; Sentry auth token with

--- a/e2e/invite-signup-verification.spec.ts
+++ b/e2e/invite-signup-verification.spec.ts
@@ -87,6 +87,7 @@ test('admin invite signup and email verification happy path', async ({
 	await page.context().clearCookies()
 	await page.goto('/signup')
 	clearAuthRateLimitsInE2eDatabase()
+	await page.getByRole('button', { name: 'I have a code' }).click()
 	await page.getByLabel('Username').fill(invitedUsername)
 	await page.getByLabel('Email').fill(invitedEmail)
 	await page.getByLabel('Password').fill(invitedPassword)

--- a/e2e/waiting-list-signup.spec.ts
+++ b/e2e/waiting-list-signup.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test'
+
+test('signup waiting list form joins without an invite code', async ({
+	page,
+}) => {
+	await page.goto('/signup')
+	await expect(
+		page.getByRole('heading', { name: 'Join the waiting list' }),
+	).toBeVisible()
+	await page.getByLabel('First name').fill('Ada')
+	await page.getByLabel('Email').fill(`waitlist-${Date.now()}@example.com`)
+	await page.getByRole('button', { name: 'Join waiting list' }).click()
+	await expect(
+		page.getByText("You're on the list. We'll be in touch."),
+	).toBeVisible()
+
+	await page.getByRole('button', { name: 'I have a code' }).click()
+	await expect(
+		page.getByRole('heading', { name: 'Create your account' }),
+	).toBeVisible()
+	await expect(page.getByLabel('Invite code')).toBeVisible()
+	await page
+		.getByRole('button', { name: 'Join the waiting list instead' })
+		.click()
+	await expect(
+		page.getByRole('heading', { name: 'Join the waiting list' }),
+	).toBeVisible()
+})

--- a/packages/worker/.env.example
+++ b/packages/worker/.env.example
@@ -65,3 +65,10 @@ X_CLIENT_SECRET=MOCK_X_CLIENT_SECRET
 # deploy workflow.
 # CAPABILITY_REINDEX_SECRET=
 
+# Kit (kit.com) waiting-list signup (optional Worker secret + tag id).
+# Production /waiting-list posts create/upsert a subscriber and tag them with
+# waitlist::kody. Non-production skips Kit when KIT_API_KEY is unset.
+# KIT_API_KEY=
+# Optional override for the Kit tag id (defaults to waitlist::kody).
+# KIT_WAITLIST_TAG_ID=21081721
+

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -168,8 +168,9 @@ export function LoginRoute(handle: Handle) {
 	async function handleWaitingListSubmit(event: SubmitEvent) {
 		event.preventDefault()
 		if (!(event.currentTarget instanceof HTMLFormElement)) return
+		const form = event.currentTarget
 
-		const formData = new FormData(event.currentTarget)
+		const formData = new FormData(form)
 		const firstName = String(formData.get('firstName') ?? '').trim()
 		const email = String(formData.get('email') ?? '').trim()
 
@@ -202,8 +203,8 @@ export function LoginRoute(handle: Handle) {
 				typeof payload?.message === 'string'
 					? payload.message
 					: "You're on the list. We'll be in touch."
+			form.reset()
 			setState('success', successMessage)
-			event.currentTarget.reset()
 		} catch {
 			setState('error', 'Network error. Please try again.')
 		}

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -55,6 +55,18 @@ function shouldOpenInviteSignup(searchParams: URLSearchParams) {
 	return panel === 'invite' || panel === 'code'
 }
 
+function readPrefillInviteCode(searchParams: URLSearchParams) {
+	for (const key of ['code', 'invite'] as const) {
+		const value = searchParams.get(key)?.trim()
+		if (value) return value
+	}
+	return ''
+}
+
+function resolveSignupPanel(searchParams: URLSearchParams): SignupPanel {
+	return shouldOpenInviteSignup(searchParams) ? 'invite' : 'waiting-list'
+}
+
 function buildAuthPath(mode: AuthMode, redirectTo: string | null) {
 	const path = mode === 'signup' ? '/signup' : '/login'
 	return buildAuthLink(path, redirectTo)
@@ -109,9 +121,9 @@ export function LoginRoute(handle: Handle) {
 	let authProvidersReady = false
 	let activeMode = getCurrentAuthMode(handle)
 	let routePath: string | null = null
-	let signupPanel: SignupPanel = shouldOpenInviteSignup(getSearchParams(handle))
-		? 'invite'
-		: 'waiting-list'
+	let activeSignupSearch = readRouterSearch(handle)
+	let signupPanel: SignupPanel = resolveSignupPanel(getSearchParams(handle))
+	let prefillInviteCode = readPrefillInviteCode(getSearchParams(handle))
 
 	function setState(nextStatus: AuthStatus, nextMessage: string | null = null) {
 		status = nextStatus
@@ -122,6 +134,11 @@ export function LoginRoute(handle: Handle) {
 	function resetAuthState() {
 		status = 'idle'
 		message = null
+	}
+
+	function applySignupSearch(searchParams: URLSearchParams) {
+		signupPanel = resolveSignupPanel(searchParams)
+		prefillInviteCode = readPrefillInviteCode(searchParams)
 	}
 
 	function setSignupPanel(nextPanel: SignupPanel) {
@@ -369,15 +386,22 @@ export function LoginRoute(handle: Handle) {
 			handle.queueTask(loadSessionAndProviders)
 		}
 		const mode = getCurrentAuthMode(handle)
+		const currentSignupSearch = readRouterSearch(handle)
 		if (!routePath) {
 			routePath = getPathname(handle)
 		}
 		if (mode !== activeMode) {
 			activeMode = mode
 			resetAuthState()
-			signupPanel = shouldOpenInviteSignup(getSearchParams(handle))
-				? 'invite'
-				: 'waiting-list'
+			activeSignupSearch = currentSignupSearch
+			applySignupSearch(getSearchParams(handle))
+		} else if (
+			mode === 'signup' &&
+			currentSignupSearch !== activeSignupSearch
+		) {
+			activeSignupSearch = currentSignupSearch
+			applySignupSearch(getSearchParams(handle))
+			resetAuthState()
 		}
 		const redirectTo = getCurrentRedirectTo(handle)
 		const oauthErrorMessage =
@@ -516,7 +540,7 @@ export function LoginRoute(handle: Handle) {
 								<input
 									type="text"
 									name="inviteCode"
-									required
+									defaultValue={prefillInviteCode}
 									autoComplete="one-time-code"
 									placeholder="Required for production launch cohorts"
 									mix={css(inputCss)}

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -40,12 +40,19 @@ import {
 
 type AuthMode = 'login' | 'signup'
 type AuthStatus = 'idle' | 'submitting' | 'success' | 'error'
+type SignupPanel = 'waiting-list' | 'invite'
 
 function normalizeRedirectTo(value: string | null) {
 	if (!value) return null
 	if (!value.startsWith('/')) return null
 	if (value.startsWith('//')) return null
 	return value
+}
+
+function shouldOpenInviteSignup(searchParams: URLSearchParams) {
+	if (searchParams.has('code') || searchParams.has('invite')) return true
+	const panel = searchParams.get('panel')
+	return panel === 'invite' || panel === 'code'
 }
 
 function buildAuthPath(mode: AuthMode, redirectTo: string | null) {
@@ -102,6 +109,9 @@ export function LoginRoute(handle: Handle) {
 	let authProvidersReady = false
 	let activeMode = getCurrentAuthMode(handle)
 	let routePath: string | null = null
+	let signupPanel: SignupPanel = shouldOpenInviteSignup(getSearchParams(handle))
+		? 'invite'
+		: 'waiting-list'
 
 	function setState(nextStatus: AuthStatus, nextMessage: string | null = null) {
 		status = nextStatus
@@ -112,6 +122,12 @@ export function LoginRoute(handle: Handle) {
 	function resetAuthState() {
 		status = 'idle'
 		message = null
+	}
+
+	function setSignupPanel(nextPanel: SignupPanel) {
+		signupPanel = nextPanel
+		resetAuthState()
+		handle.update()
 	}
 
 	listenToRouterNavigation(handle, () => {
@@ -147,6 +163,50 @@ export function LoginRoute(handle: Handle) {
 			return
 		}
 		handle.update()
+	}
+
+	async function handleWaitingListSubmit(event: SubmitEvent) {
+		event.preventDefault()
+		if (!(event.currentTarget instanceof HTMLFormElement)) return
+
+		const formData = new FormData(event.currentTarget)
+		const firstName = String(formData.get('firstName') ?? '').trim()
+		const email = String(formData.get('email') ?? '').trim()
+
+		if (!firstName || !email) {
+			setState('error', 'First name and email are required.')
+			return
+		}
+
+		setState('submitting')
+
+		try {
+			const response = await fetch('/waiting-list', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				credentials: 'include',
+				body: JSON.stringify({ firstName, email }),
+			})
+			const payload = await response.json().catch(() => null)
+
+			if (!response.ok) {
+				const errorMessage =
+					typeof payload?.error === 'string'
+						? payload.error
+						: 'Unable to join the waiting list.'
+				setState('error', errorMessage)
+				return
+			}
+
+			const successMessage =
+				typeof payload?.message === 'string'
+					? payload.message
+					: "You're on the list. We'll be in touch."
+			setState('success', successMessage)
+			event.currentTarget.reset()
+		} catch {
+			setState('error', 'Network error. Please try again.')
+		}
 	}
 
 	async function handleSubmit(event: SubmitEvent) {
@@ -314,6 +374,9 @@ export function LoginRoute(handle: Handle) {
 		if (mode !== activeMode) {
 			activeMode = mode
 			resetAuthState()
+			signupPanel = shouldOpenInviteSignup(getSearchParams(handle))
+				? 'invite'
+				: 'waiting-list'
 		}
 		const redirectTo = getCurrentRedirectTo(handle)
 		const oauthErrorMessage =
@@ -321,11 +384,19 @@ export function LoginRoute(handle: Handle) {
 				? getOauthLoginErrorMessage(getSearchParams(handle).get('oauthError'))
 				: null
 		const isSignup = mode === 'signup'
+		const showWaitingList = isSignup && signupPanel === 'waiting-list'
+		const showInviteSignup = isSignup && signupPanel === 'invite'
 		const isSubmitting = status === 'submitting'
-		const title = isSignup ? 'Create your account' : 'Welcome back'
-		const description = isSignup
-			? 'Sign up to start using kody.'
-			: 'Log in to continue to kody.'
+		const title = showWaitingList
+			? 'Join the waiting list'
+			: isSignup
+				? 'Create your account'
+				: 'Welcome back'
+		const description = showWaitingList
+			? 'Kody is invite-only for now. Leave your name and email and we will let you know when a spot opens.'
+			: isSignup
+				? 'Sign up with your invite code to start using kody.'
+				: 'Log in to continue to kody.'
 		const submitLabel = isSignup ? 'Create account' : 'Sign in'
 		const toggleLabel = isSignup
 			? 'Already have an account?'
@@ -350,128 +421,197 @@ export function LoginRoute(handle: Handle) {
 						{oauthErrorMessage}
 					</p>
 				) : null}
-				<form mix={[css(cardCss), on('submit', handleSubmit)]}>
-					{isSignup ? (
+				{showWaitingList ? (
+					<form mix={[css(cardCss), on('submit', handleWaitingListSubmit)]}>
 						<label mix={css(fieldCss)}>
-							<span mix={css(fieldLabelCss)}>Username</span>
+							<span mix={css(fieldLabelCss)}>First name</span>
 							<input
 								type="text"
-								name="username"
+								name="firstName"
 								required
 								autoFocus
-								autoComplete="username"
-								pattern="[A-Za-z0-9][A-Za-z0-9_-]{1,30}[A-Za-z0-9]"
-								title="Use 3 to 32 letters, numbers, hyphens, or underscores. Start and end with a letter or number."
-								placeholder="kent"
+								autoComplete="given-name"
+								maxLength={80}
+								placeholder="Ada"
 								mix={css(inputCss)}
 							/>
 						</label>
-					) : null}
-					<label mix={css(fieldCss)}>
-						<span mix={css(fieldLabelCss)}>Email</span>
-						<input
-							type="email"
-							name="email"
-							required
-							autoFocus={!isSignup}
-							autoComplete="email"
-							placeholder="you@example.com"
-							mix={css(inputCss)}
-						/>
-					</label>
-					<label mix={css(fieldCss)}>
-						<span mix={css(fieldLabelCss)}>Password</span>
-						<input
-							type="password"
-							name="password"
-							required
-							autoComplete={isSignup ? 'new-password' : 'current-password'}
-							placeholder="At least 8 characters"
-							mix={css(inputCss)}
-						/>
-					</label>
-					{isSignup ? (
 						<label mix={css(fieldCss)}>
-							<span mix={css(fieldLabelCss)}>Invite code</span>
+							<span mix={css(fieldLabelCss)}>Email</span>
 							<input
-								type="text"
-								name="inviteCode"
-								autoComplete="one-time-code"
-								placeholder="Required for production launch cohorts"
+								type="email"
+								name="email"
+								required
+								autoComplete="email"
+								placeholder="you@example.com"
 								mix={css(inputCss)}
 							/>
 						</label>
-					) : null}
-					{!isSignup ? (
-						<label
-							mix={css({
-								display: 'flex',
-								gap: spacing.sm,
-								alignItems: 'flex-start',
-								color: colors.text,
-							})}
-						>
-							<input
-								type="checkbox"
-								name="rememberMe"
-								mix={[
-									checkbox(),
-									css({
-										marginTop: '0.15rem',
-									}),
-								]}
-							/>
-
-							<span mix={css({ display: 'grid', gap: spacing.xs })}>
-								<span
-									mix={css({
-										fontWeight: typography.fontWeight.medium,
-										fontSize: typography.fontSize.sm,
-									})}
-								>
-									Remember me
-								</span>
-								<span
-									mix={css({
-										color: colors.textMuted,
-										fontSize: typography.fontSize.sm,
-									})}
-								>
-									Stay signed in for 30 days. Active sessions renew after 14
-									days.
-								</span>
-							</span>
-						</label>
-					) : null}
-					<button
-						type="submit"
-						disabled={isSubmitting}
-						mix={css(primaryButtonCss)}
-					>
-						{isSubmitting ? 'Submitting...' : submitLabel}
-					</button>
-					{!isSignup ? (
 						<button
-							type="button"
-							disabled={isSubmitting}
-							mix={[css(secondaryButtonCss), on('click', handlePasskeySignIn)]}
+							type="submit"
+							disabled={isSubmitting || status === 'success'}
+							mix={css(primaryButtonCss)}
 						>
-							Sign in with a passkey
+							{isSubmitting ? 'Joining...' : 'Join waiting list'}
 						</button>
-					) : null}
-					{message ? (
-						<p
-							aria-live="polite"
-							mix={css({
-								color: status === 'error' ? colors.error : colors.text,
-								fontSize: typography.fontSize.sm,
-							})}
+						{message ? (
+							<p
+								aria-live="polite"
+								mix={css({
+									color: status === 'error' ? colors.error : colors.text,
+									fontSize: typography.fontSize.sm,
+								})}
+							>
+								{message}
+							</p>
+						) : null}
+					</form>
+				) : (
+					<form mix={[css(cardCss), on('submit', handleSubmit)]}>
+						{showInviteSignup ? (
+							<label mix={css(fieldCss)}>
+								<span mix={css(fieldLabelCss)}>Username</span>
+								<input
+									type="text"
+									name="username"
+									required
+									autoFocus
+									autoComplete="username"
+									pattern="[A-Za-z0-9][A-Za-z0-9_-]{1,30}[A-Za-z0-9]"
+									title="Use 3 to 32 letters, numbers, hyphens, or underscores. Start and end with a letter or number."
+									placeholder="kent"
+									mix={css(inputCss)}
+								/>
+							</label>
+						) : null}
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>Email</span>
+							<input
+								type="email"
+								name="email"
+								required
+								autoFocus={!showInviteSignup}
+								autoComplete="email"
+								placeholder="you@example.com"
+								mix={css(inputCss)}
+							/>
+						</label>
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>Password</span>
+							<input
+								type="password"
+								name="password"
+								required
+								autoComplete={
+									showInviteSignup ? 'new-password' : 'current-password'
+								}
+								placeholder="At least 8 characters"
+								mix={css(inputCss)}
+							/>
+						</label>
+						{showInviteSignup ? (
+							<label mix={css(fieldCss)}>
+								<span mix={css(fieldLabelCss)}>Invite code</span>
+								<input
+									type="text"
+									name="inviteCode"
+									required
+									autoComplete="one-time-code"
+									placeholder="Required for production launch cohorts"
+									mix={css(inputCss)}
+								/>
+							</label>
+						) : null}
+						{!isSignup ? (
+							<label
+								mix={css({
+									display: 'flex',
+									gap: spacing.sm,
+									alignItems: 'flex-start',
+									color: colors.text,
+								})}
+							>
+								<input
+									type="checkbox"
+									name="rememberMe"
+									mix={[
+										checkbox(),
+										css({
+											marginTop: '0.15rem',
+										}),
+									]}
+								/>
+
+								<span mix={css({ display: 'grid', gap: spacing.xs })}>
+									<span
+										mix={css({
+											fontWeight: typography.fontWeight.medium,
+											fontSize: typography.fontSize.sm,
+										})}
+									>
+										Remember me
+									</span>
+									<span
+										mix={css({
+											color: colors.textMuted,
+											fontSize: typography.fontSize.sm,
+										})}
+									>
+										Stay signed in for 30 days. Active sessions renew after 14
+										days.
+									</span>
+								</span>
+							</label>
+						) : null}
+						<button
+							type="submit"
+							disabled={isSubmitting}
+							mix={css(primaryButtonCss)}
 						>
-							{message}
-						</p>
-					) : null}
-				</form>
-				{authProviders.length > 0 ? (
+							{isSubmitting ? 'Submitting...' : submitLabel}
+						</button>
+						{!isSignup ? (
+							<button
+								type="button"
+								disabled={isSubmitting}
+								mix={[
+									css(secondaryButtonCss),
+									on('click', handlePasskeySignIn),
+								]}
+							>
+								Sign in with a passkey
+							</button>
+						) : null}
+						{message ? (
+							<p
+								aria-live="polite"
+								mix={css({
+									color: status === 'error' ? colors.error : colors.text,
+									fontSize: typography.fontSize.sm,
+								})}
+							>
+								{message}
+							</p>
+						) : null}
+					</form>
+				)}
+				{isSignup ? (
+					<button
+						type="button"
+						disabled={isSubmitting}
+						mix={[
+							css(secondaryButtonCss),
+							on('click', () =>
+								setSignupPanel(showWaitingList ? 'invite' : 'waiting-list'),
+							),
+						]}
+					>
+						{showWaitingList
+							? 'I have a code'
+							: 'Join the waiting list instead'}
+					</button>
+				) : null}
+				{!showWaitingList && authProviders.length > 0 ? (
 					<div mix={css({ display: 'grid', gap: spacing.sm })}>
 						<p
 							mix={css({

--- a/packages/worker/src/app/handlers/waiting-list.node.test.ts
+++ b/packages/worker/src/app/handlers/waiting-list.node.test.ts
@@ -138,7 +138,11 @@ test('joins the Kit waitlist with first name and email', async () => {
 	const fetchMock = vi.fn(
 		async (input: RequestInfo | URL, init?: RequestInit) => {
 			const url = String(input)
-			if (url.endsWith('/subscribers') && init?.method === 'POST') {
+			const method = init?.method ?? 'GET'
+			if (url.includes('/subscribers?email_address=')) {
+				return Response.json({ subscribers: [] }, { status: 200 })
+			}
+			if (url.endsWith('/subscribers') && method === 'POST') {
 				return Response.json(
 					{ subscriber: { id: 42, email_address: 'ada@example.com' } },
 					{ status: 201 },
@@ -168,8 +172,13 @@ test('joins the Kit waitlist with first name and email', async () => {
 		ok: true,
 		message: "You're on the list. We'll be in touch.",
 	})
-	expect(fetchMock).toHaveBeenCalledTimes(2)
-	const createCall = fetchMock.mock.calls[0]
+	expect(fetchMock).toHaveBeenCalledTimes(3)
+	const createCall = fetchMock.mock.calls.find(([url, init]) => {
+		return (
+			String(url).endsWith('/subscribers') &&
+			(init as RequestInit | undefined)?.method === 'POST'
+		)
+	})
 	expect(createCall?.[1]?.headers).toMatchObject({
 		'X-Kit-Api-Key': 'kit-test-key',
 	})
@@ -246,9 +255,17 @@ test('no-ops successfully in non-production without a Kit key', async () => {
 test('rate limits repeated waiting list submissions', async () => {
 	vi.stubGlobal(
 		'fetch',
-		vi.fn(async () =>
-			Response.json({ subscriber: { id: 1 } }, { status: 201 }),
-		),
+		vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = String(input)
+			const method = init?.method ?? 'GET'
+			if (url.includes('/subscribers?email_address=')) {
+				return Response.json({ subscribers: [] }, { status: 200 })
+			}
+			if (url.endsWith('/subscribers') && method === 'POST') {
+				return Response.json({ subscriber: { id: 1 } }, { status: 201 })
+			}
+			return Response.json({ subscriber: { id: 1 } }, { status: 201 })
+		}),
 	)
 	const { handler, rateLimitDb } = createHandler({
 		KIT_API_KEY: 'kit-test-key',
@@ -273,7 +290,7 @@ test('rate limits repeated waiting list submissions', async () => {
 	expect(rateLimitDb.attemptCount).toBe(waitingListRateLimitConfig.maxRequests)
 })
 
-test('refunds the rate-limit slot when Kit subscribe fails', async () => {
+test('refunds the rate-limit slot when Kit subscribe fails transiently', async () => {
 	consoleError.mockImplementation(() => {})
 	vi.stubGlobal(
 		'fetch',
@@ -288,5 +305,25 @@ test('refunds the rate-limit slot when Kit subscribe fails', async () => {
 	})
 	expect(response.status).toBe(502)
 	expect(rateLimitDb.attemptCount).toBe(0)
+	expect(consoleError).toHaveBeenCalled()
+})
+
+test('keeps the rate-limit slot when Kit rejects with a client error', async () => {
+	consoleError.mockImplementation(() => {})
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () =>
+			Response.json({ errors: ['invalid email'] }, { status: 422 }),
+		),
+	)
+	const { handler, rateLimitDb } = createHandler({
+		KIT_API_KEY: 'kit-test-key',
+	})
+	const response = await postWaitingList(handler, {
+		firstName: 'Ada',
+		email: 'ada@example.com',
+	})
+	expect(response.status).toBe(502)
+	expect(rateLimitDb.attemptCount).toBe(1)
 	expect(consoleError).toHaveBeenCalled()
 })

--- a/packages/worker/src/app/handlers/waiting-list.node.test.ts
+++ b/packages/worker/src/app/handlers/waiting-list.node.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { RequestContext } from 'remix/router'
+import {
+	createWaitingListHandler,
+	waitingListRateLimitConfig,
+} from '#app/handlers/waiting-list.ts'
+import { DEFAULT_KIT_WAITLIST_TAG_ID } from '#app/kit-waitlist.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
+import { consoleError } from '#worker/test-support/console-spies.ts'
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+	vi.restoreAllMocks()
+	logAuditEventSpy.mockClear()
+	consoleError.mockClear()
+})
+
+function createRateLimitDb() {
+	const rows: Array<{ id: number; key: string; ts: number }> = []
+	let nextId = 1
+
+	async function runStatement(statement: {
+		query?: string
+		binds?: unknown[]
+	}) {
+		const query = statement.query ?? ''
+		const binds = statement.binds ?? []
+
+		if (query.includes('CREATE TABLE') || query.includes('CREATE INDEX')) {
+			return { meta: { changes: 0, last_row_id: 0 } }
+		}
+		if (query.includes('DELETE FROM _rate_limits WHERE ts <=')) {
+			const windowStart = Number(binds[0])
+			const before = rows.length
+			for (let i = rows.length - 1; i >= 0; i--) {
+				if ((rows[i]?.ts ?? 0) <= windowStart) rows.splice(i, 1)
+			}
+			return { meta: { changes: before - rows.length, last_row_id: 0 } }
+		}
+		if (
+			query.includes('DELETE FROM _rate_limits') &&
+			query.includes('ORDER BY id DESC')
+		) {
+			const key = String(binds[0])
+			const index = [...rows].reverse().findIndex((row) => row.key === key)
+			if (index === -1) return { meta: { changes: 0, last_row_id: 0 } }
+			const actualIndex = rows.length - 1 - index
+			rows.splice(actualIndex, 1)
+			return { meta: { changes: 1, last_row_id: 0 } }
+		}
+		if (query.includes('INSERT INTO _rate_limits')) {
+			const key = String(binds[0])
+			const now = Number(binds[1])
+			const windowStart = Number(binds[3])
+			const maxRequests = Number(binds[4])
+			const count = rows.filter(
+				(row) => row.key === key && row.ts > windowStart,
+			).length
+			if (count >= maxRequests) {
+				return { meta: { changes: 0, last_row_id: 0 } }
+			}
+			const id = nextId++
+			rows.push({ id, key, ts: now })
+			return { meta: { changes: 1, last_row_id: id } }
+		}
+		return { meta: { changes: 0, last_row_id: 0 } }
+	}
+
+	const db = {
+		async batch(
+			statements: Array<{
+				query?: string
+				binds?: unknown[]
+				run?: () => Promise<unknown>
+			}>,
+		) {
+			const results = []
+			for (const statement of statements) {
+				results.push(await runStatement(statement))
+			}
+			return results
+		},
+		prepare(query: string) {
+			const statement = {
+				query,
+				binds: [] as unknown[],
+				bind(...binds: unknown[]) {
+					statement.binds = binds
+					return statement
+				},
+				async run() {
+					return runStatement(statement)
+				},
+			}
+			return statement
+		},
+	}
+
+	return {
+		db: db as unknown as D1Database,
+		get attemptCount() {
+			return rows.length
+		},
+	}
+}
+
+function createHandler(envOverrides: Record<string, unknown> = {}) {
+	const rateLimitDb = createRateLimitDb()
+	const handler = createWaitingListHandler({
+		APP_DB: rateLimitDb.db,
+		SENTRY_ENVIRONMENT: 'production',
+		...envOverrides,
+	} as unknown as Env)
+	return { handler, rateLimitDb }
+}
+
+async function postWaitingList(
+	handler: ReturnType<typeof createWaitingListHandler>,
+	body: unknown,
+	headers: HeadersInit = {},
+) {
+	const request = new Request('http://example.com/waiting-list', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...headers,
+		},
+		body: typeof body === 'string' ? body : JSON.stringify(body),
+	})
+	const context = new RequestContext(request)
+	return handler.handler(context)
+}
+
+test('joins the Kit waitlist with first name and email', async () => {
+	const fetchMock = vi.fn(
+		async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = String(input)
+			if (url.endsWith('/subscribers') && init?.method === 'POST') {
+				return Response.json(
+					{ subscriber: { id: 42, email_address: 'ada@example.com' } },
+					{ status: 201 },
+				)
+			}
+			if (url.includes(`/tags/${DEFAULT_KIT_WAITLIST_TAG_ID}/subscribers`)) {
+				return Response.json(
+					{ subscriber: { id: 42, email_address: 'ada@example.com' } },
+					{ status: 201 },
+				)
+			}
+			return Response.json({ errors: ['unexpected'] }, { status: 500 })
+		},
+	)
+	vi.stubGlobal('fetch', fetchMock)
+
+	const { handler } = createHandler({
+		KIT_API_KEY: 'kit-test-key',
+	})
+	const response = await postWaitingList(handler, {
+		firstName: '  Ada  Lovelace ',
+		email: 'Ada@Example.com',
+	})
+
+	expect(response.status).toBe(200)
+	expect(await response.json()).toEqual({
+		ok: true,
+		message: "You're on the list. We'll be in touch.",
+	})
+	expect(fetchMock).toHaveBeenCalledTimes(2)
+	const createCall = fetchMock.mock.calls[0]
+	expect(createCall?.[1]?.headers).toMatchObject({
+		'X-Kit-Api-Key': 'kit-test-key',
+	})
+	expect(JSON.parse(String(createCall?.[1]?.body))).toEqual({
+		email_address: 'ada@example.com',
+		first_name: 'Ada Lovelace',
+	})
+	expect(auditEventSummaries()).toEqual(['waiting_list_join:success'])
+})
+
+test('rejects missing first name and invalid email', async () => {
+	const { handler } = createHandler({ KIT_API_KEY: 'kit-test-key' })
+
+	const missingName = await postWaitingList(handler, {
+		firstName: '   ',
+		email: 'ada@example.com',
+	})
+	expect(missingName.status).toBe(400)
+	expect(await missingName.json()).toEqual({
+		ok: false,
+		error: 'First name is required.',
+	})
+
+	const badEmail = await postWaitingList(handler, {
+		firstName: 'Ada',
+		email: 'not-an-email',
+	})
+	expect(badEmail.status).toBe(400)
+	expect(await badEmail.json()).toEqual({
+		ok: false,
+		error: 'A valid email is required.',
+	})
+})
+
+test('fails closed in production when Kit is not configured', async () => {
+	const { handler } = createHandler({
+		SENTRY_ENVIRONMENT: 'production',
+	})
+	const response = await postWaitingList(handler, {
+		firstName: 'Ada',
+		email: 'ada@example.com',
+	})
+	expect(response.status).toBe(503)
+	expect(await response.json()).toEqual({
+		ok: false,
+		error:
+			'Waiting list signup is temporarily unavailable. Please try again later.',
+	})
+})
+
+test('no-ops successfully in non-production without a Kit key', async () => {
+	const fetchMock = vi.fn()
+	vi.stubGlobal('fetch', fetchMock)
+	const { handler } = createHandler({
+		SENTRY_ENVIRONMENT: 'test',
+	})
+	const response = await postWaitingList(handler, {
+		firstName: 'Ada',
+		email: 'ada@example.com',
+	})
+	expect(response.status).toBe(200)
+	expect(await response.json()).toMatchObject({ ok: true })
+	expect(fetchMock).not.toHaveBeenCalled()
+	expect(auditEventSummaries()).toEqual(['waiting_list_join:success'])
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			action: 'waiting_list_join',
+			result: 'success',
+			reason: 'kit_skipped_non_production',
+		}),
+	)
+})
+
+test('rate limits repeated waiting list submissions', async () => {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () =>
+			Response.json({ subscriber: { id: 1 } }, { status: 201 }),
+		),
+	)
+	const { handler, rateLimitDb } = createHandler({
+		KIT_API_KEY: 'kit-test-key',
+	})
+
+	for (let i = 0; i < waitingListRateLimitConfig.maxRequests; i++) {
+		const response = await postWaitingList(
+			handler,
+			{ firstName: 'Ada', email: `ada${i}@example.com` },
+			{ 'CF-Connecting-IP': '203.0.113.10' },
+		)
+		expect(response.status).toBe(200)
+	}
+
+	const limited = await postWaitingList(
+		handler,
+		{ firstName: 'Ada', email: 'ada-extra@example.com' },
+		{ 'CF-Connecting-IP': '203.0.113.10' },
+	)
+	expect(limited.status).toBe(429)
+	expect(limited.headers.get('Retry-After')).toBeTruthy()
+	expect(rateLimitDb.attemptCount).toBe(waitingListRateLimitConfig.maxRequests)
+})
+
+test('refunds the rate-limit slot when Kit subscribe fails', async () => {
+	consoleError.mockImplementation(() => {})
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () => Response.json({ errors: ['boom'] }, { status: 500 })),
+	)
+	const { handler, rateLimitDb } = createHandler({
+		KIT_API_KEY: 'kit-test-key',
+	})
+	const response = await postWaitingList(handler, {
+		firstName: 'Ada',
+		email: 'ada@example.com',
+	})
+	expect(response.status).toBe(502)
+	expect(rateLimitDb.attemptCount).toBe(0)
+	expect(consoleError).toHaveBeenCalled()
+})

--- a/packages/worker/src/app/handlers/waiting-list.ts
+++ b/packages/worker/src/app/handlers/waiting-list.ts
@@ -1,0 +1,195 @@
+import { object, parseSafe, string } from 'remix/data-schema'
+import { type Action } from 'remix/router'
+import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
+import { isNonProductionRuntime } from '#app/deployment-env.ts'
+import {
+	resolveKitWaitlistTagId,
+	subscribeToKitWaitlist,
+} from '#app/kit-waitlist.ts'
+import { normalizeEmail } from '#app/normalize-email.ts'
+import { checkRateLimit, releaseRateLimit } from '#app/rate-limit.ts'
+import { type routes } from '#app/routes.ts'
+import { jsonResponse } from '#worker/json-response.ts'
+
+export const waitingListRateLimitConfig = {
+	maxRequests: 5,
+	windowSeconds: 15 * 60,
+}
+
+const waitingListRequestSchema = object({
+	email: string(),
+	firstName: string(),
+})
+
+const MAX_FIRST_NAME_LENGTH = 80
+
+function normalizeFirstName(value: string) {
+	return value.trim().replace(/\s+/g, ' ')
+}
+
+function isPlausibleEmail(email: string) {
+	// Intentionally light — Kit validates further. Block empty / obvious junk.
+	return email.includes('@') && email.length <= 254
+}
+
+export function createWaitingListHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, url }) {
+			if (request.method !== 'POST') {
+				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+			}
+
+			let body: unknown
+			try {
+				body = await request.json()
+			} catch {
+				return jsonResponse({ ok: false, error: 'Invalid JSON payload.' }, 400)
+			}
+
+			const parsedBody = parseSafe(waitingListRequestSchema, body)
+			if (!parsedBody.success) {
+				return jsonResponse({ ok: false, error: 'Invalid request body.' }, 400)
+			}
+
+			const firstName = normalizeFirstName(parsedBody.value.firstName)
+			const email = normalizeEmail(parsedBody.value.email)
+			const requestIp = getRequestIp(request) ?? undefined
+
+			if (!firstName || firstName.length > MAX_FIRST_NAME_LENGTH) {
+				return jsonResponse(
+					{ ok: false, error: 'First name is required.' },
+					400,
+				)
+			}
+			if (!isPlausibleEmail(email)) {
+				return jsonResponse(
+					{ ok: false, error: 'A valid email is required.' },
+					400,
+				)
+			}
+
+			const tagId = resolveKitWaitlistTagId(env.KIT_WAITLIST_TAG_ID)
+			if (tagId === null) {
+				return jsonResponse(
+					{ ok: false, error: 'Waiting list is misconfigured.' },
+					500,
+				)
+			}
+
+			const rateLimitKey = `waiting-list:ip:${requestIp ?? 'unknown'}`
+			const rateLimit = await checkRateLimit(
+				env.APP_DB,
+				rateLimitKey,
+				waitingListRateLimitConfig,
+			)
+			if (!rateLimit.allowed) {
+				void logAuditEvent({
+					db: env.APP_DB,
+					category: 'auth',
+					action: 'waiting_list_join',
+					result: 'rate_limited',
+					email,
+					ip: requestIp,
+					path: url.pathname,
+				})
+				return jsonResponse(
+					{
+						ok: false,
+						error: 'Too many waiting list requests. Please try again later.',
+					},
+					{
+						status: 429,
+						headers: {
+							'Retry-After': String(rateLimit.retryAfterSeconds ?? 60),
+						},
+					},
+				)
+			}
+
+			const apiKey = env.KIT_API_KEY?.trim()
+			if (!apiKey) {
+				if (isNonProductionRuntime(env)) {
+					void logAuditEvent({
+						db: env.APP_DB,
+						category: 'auth',
+						action: 'waiting_list_join',
+						result: 'success',
+						email,
+						ip: requestIp,
+						path: url.pathname,
+						reason: 'kit_skipped_non_production',
+					})
+					return jsonResponse({
+						ok: true,
+						message: "You're on the list. We'll be in touch.",
+					})
+				}
+
+				await releaseRateLimit(env.APP_DB, rateLimitKey).catch(() => undefined)
+				void logAuditEvent({
+					db: env.APP_DB,
+					category: 'auth',
+					action: 'waiting_list_join',
+					result: 'failure',
+					email,
+					ip: requestIp,
+					path: url.pathname,
+					reason: 'kit_not_configured',
+				})
+				return jsonResponse(
+					{
+						ok: false,
+						error:
+							'Waiting list signup is temporarily unavailable. Please try again later.',
+					},
+					503,
+				)
+			}
+
+			try {
+				await subscribeToKitWaitlist({
+					apiKey,
+					email,
+					firstName,
+					tagId,
+				})
+			} catch (error) {
+				console.error('Failed to subscribe waiting list contact to Kit:', error)
+				await releaseRateLimit(env.APP_DB, rateLimitKey).catch(() => undefined)
+				void logAuditEvent({
+					db: env.APP_DB,
+					category: 'auth',
+					action: 'waiting_list_join',
+					result: 'failure',
+					email,
+					ip: requestIp,
+					path: url.pathname,
+					reason: 'kit_subscribe_failed',
+				})
+				return jsonResponse(
+					{
+						ok: false,
+						error:
+							'Unable to join the waiting list right now. Please try again later.',
+					},
+					502,
+				)
+			}
+
+			void logAuditEvent({
+				db: env.APP_DB,
+				category: 'auth',
+				action: 'waiting_list_join',
+				result: 'success',
+				email,
+				ip: requestIp,
+				path: url.pathname,
+			})
+			return jsonResponse({
+				ok: true,
+				message: "You're on the list. We'll be in touch.",
+			})
+		},
+	} satisfies Action<typeof routes.waitingList>
+}

--- a/packages/worker/src/app/handlers/waiting-list.ts
+++ b/packages/worker/src/app/handlers/waiting-list.ts
@@ -3,6 +3,7 @@ import { type Action } from 'remix/router'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
 import { isNonProductionRuntime } from '#app/deployment-env.ts'
 import {
+	KitWaitlistError,
 	resolveKitWaitlistTagId,
 	subscribeToKitWaitlist,
 } from '#app/kit-waitlist.ts'
@@ -156,7 +157,18 @@ export function createWaitingListHandler(env: Env) {
 				})
 			} catch (error) {
 				console.error('Failed to subscribe waiting list contact to Kit:', error)
-				await releaseRateLimit(env.APP_DB, rateLimitKey).catch(() => undefined)
+				const kitError = error instanceof KitWaitlistError ? error : null
+				// Refund only transient failures. Client 4xx (bad email, etc.)
+				// should still count against the IP budget.
+				const shouldRefund =
+					kitError === null ||
+					kitError.kind === 'network' ||
+					kitError.kind === 'server'
+				if (shouldRefund) {
+					await releaseRateLimit(env.APP_DB, rateLimitKey).catch(
+						() => undefined,
+					)
+				}
 				void logAuditEvent({
 					db: env.APP_DB,
 					category: 'auth',

--- a/packages/worker/src/app/kit-waitlist.node.test.ts
+++ b/packages/worker/src/app/kit-waitlist.node.test.ts
@@ -1,6 +1,7 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import {
 	DEFAULT_KIT_WAITLIST_TAG_ID,
+	type KitWaitlistError,
 	resolveKitWaitlistTagId,
 	subscribeToKitWaitlist,
 } from '#app/kit-waitlist.ts'
@@ -13,13 +14,17 @@ test('resolveKitWaitlistTagId defaults and validates overrides', () => {
 	expect(resolveKitWaitlistTagId('nope')).toBeNull()
 })
 
-test('subscribeToKitWaitlist creates then tags the subscriber', async () => {
-	const calls: Array<{ url: string; body: unknown }> = []
+test('subscribeToKitWaitlist creates new subscribers then tags them', async () => {
+	const calls: Array<{ url: string; method: string; body: unknown }> = []
 	const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
 		const url = String(input)
+		const method = init?.method ?? 'GET'
 		const body = init?.body ? JSON.parse(String(init.body)) : null
-		calls.push({ url, body })
-		if (url.endsWith('/subscribers')) {
+		calls.push({ url, method, body })
+		if (url.includes('/subscribers?email_address=')) {
+			return Response.json({ subscribers: [] }, { status: 200 })
+		}
+		if (url.endsWith('/subscribers') && method === 'POST') {
 			return Response.json(
 				{ subscriber: { id: 7, email_address: body.email_address } },
 				{ status: 201 },
@@ -39,15 +44,90 @@ test('subscribeToKitWaitlist creates then tags the subscriber', async () => {
 		fetchImpl: fetchImpl as typeof fetch,
 	})
 
-	expect(result).toEqual({ subscriberId: 7 })
+	expect(result).toEqual({ subscriberId: 7, created: true })
 	expect(calls).toEqual([
 		{
+			url: 'https://api.kit.com/v4/subscribers?email_address=ada%40example.com',
+			method: 'GET',
+			body: null,
+		},
+		{
 			url: 'https://api.kit.com/v4/subscribers',
+			method: 'POST',
 			body: { email_address: 'ada@example.com', first_name: 'Ada' },
 		},
 		{
 			url: 'https://api.kit.com/v4/tags/123/subscribers',
+			method: 'POST',
 			body: { email_address: 'ada@example.com' },
 		},
 	])
+})
+
+test('subscribeToKitWaitlist does not overwrite an existing first name', async () => {
+	const calls: Array<{ url: string; method: string; body: unknown }> = []
+	const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = String(input)
+		const method = init?.method ?? 'GET'
+		const body = init?.body ? JSON.parse(String(init.body)) : null
+		calls.push({ url, method, body })
+		if (url.includes('/subscribers?email_address=')) {
+			return Response.json(
+				{
+					subscribers: [
+						{
+							id: 9,
+							email_address: 'ada@example.com',
+							first_name: 'Existing',
+						},
+					],
+				},
+				{ status: 200 },
+			)
+		}
+		return Response.json(
+			{ subscriber: { id: 9, email_address: 'ada@example.com' } },
+			{ status: 201 },
+		)
+	}
+
+	const result = await subscribeToKitWaitlist({
+		apiKey: 'key',
+		email: 'ada@example.com',
+		firstName: 'Ada',
+		tagId: 123,
+		fetchImpl: fetchImpl as typeof fetch,
+	})
+
+	expect(result).toEqual({ subscriberId: 9, created: false })
+	expect(calls).toEqual([
+		{
+			url: 'https://api.kit.com/v4/subscribers?email_address=ada%40example.com',
+			method: 'GET',
+			body: null,
+		},
+		{
+			url: 'https://api.kit.com/v4/tags/123/subscribers',
+			method: 'POST',
+			body: { email_address: 'ada@example.com' },
+		},
+	])
+})
+
+test('subscribeToKitWaitlist classifies client failures', async () => {
+	const fetchImpl = vi.fn(async () =>
+		Response.json({ errors: ['invalid'] }, { status: 422 }),
+	)
+	await expect(
+		subscribeToKitWaitlist({
+			apiKey: 'key',
+			email: 'ada@example.com',
+			firstName: 'Ada',
+			fetchImpl: fetchImpl as typeof fetch,
+		}),
+	).rejects.toMatchObject({
+		name: 'KitWaitlistError',
+		kind: 'client',
+		status: 422,
+	} satisfies Partial<KitWaitlistError>)
 })

--- a/packages/worker/src/app/kit-waitlist.node.test.ts
+++ b/packages/worker/src/app/kit-waitlist.node.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from 'vitest'
+import {
+	DEFAULT_KIT_WAITLIST_TAG_ID,
+	resolveKitWaitlistTagId,
+	subscribeToKitWaitlist,
+} from '#app/kit-waitlist.ts'
+
+test('resolveKitWaitlistTagId defaults and validates overrides', () => {
+	expect(resolveKitWaitlistTagId(undefined)).toBe(DEFAULT_KIT_WAITLIST_TAG_ID)
+	expect(resolveKitWaitlistTagId('')).toBe(DEFAULT_KIT_WAITLIST_TAG_ID)
+	expect(resolveKitWaitlistTagId(' 99 ')).toBe(99)
+	expect(resolveKitWaitlistTagId('0')).toBeNull()
+	expect(resolveKitWaitlistTagId('nope')).toBeNull()
+})
+
+test('subscribeToKitWaitlist creates then tags the subscriber', async () => {
+	const calls: Array<{ url: string; body: unknown }> = []
+	const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = String(input)
+		const body = init?.body ? JSON.parse(String(init.body)) : null
+		calls.push({ url, body })
+		if (url.endsWith('/subscribers')) {
+			return Response.json(
+				{ subscriber: { id: 7, email_address: body.email_address } },
+				{ status: 201 },
+			)
+		}
+		return Response.json(
+			{ subscriber: { id: 7, email_address: body.email_address } },
+			{ status: 201 },
+		)
+	}
+
+	const result = await subscribeToKitWaitlist({
+		apiKey: 'key',
+		email: 'ada@example.com',
+		firstName: 'Ada',
+		tagId: 123,
+		fetchImpl: fetchImpl as typeof fetch,
+	})
+
+	expect(result).toEqual({ subscriberId: 7 })
+	expect(calls).toEqual([
+		{
+			url: 'https://api.kit.com/v4/subscribers',
+			body: { email_address: 'ada@example.com', first_name: 'Ada' },
+		},
+		{
+			url: 'https://api.kit.com/v4/tags/123/subscribers',
+			body: { email_address: 'ada@example.com' },
+		},
+	])
+})

--- a/packages/worker/src/app/kit-waitlist.ts
+++ b/packages/worker/src/app/kit-waitlist.ts
@@ -13,25 +13,48 @@ export const KIT_API_BASE_URL = 'https://api.kit.com/v4'
 /** Kit tag `waitlist::kody` — override with `KIT_WAITLIST_TAG_ID` if needed. */
 export const DEFAULT_KIT_WAITLIST_TAG_ID = 21081721
 
+/** Bound Kit round-trips so a hung upstream cannot pin a Worker request. */
+export const KIT_WAITLIST_REQUEST_TIMEOUT_MS = 8_000
+
 export type KitWaitlistSubscribeInput = {
 	apiKey: string
 	email: string
 	firstName: string
 	tagId?: number
 	fetchImpl?: typeof fetch
+	timeoutMs?: number
 }
 
 export type KitWaitlistSubscribeResult = {
 	subscriberId: number
+	created: boolean
+}
+
+type KitSubscriber = {
+	id?: number
+	email_address?: string
+	first_name?: string
 }
 
 type KitSubscriberPayload = {
-	subscriber?: {
-		id?: number
-		email_address?: string
-		first_name?: string
-	}
+	subscriber?: KitSubscriber
+	subscribers?: Array<KitSubscriber>
 	errors?: Array<string>
+}
+
+export class KitWaitlistError extends Error {
+	readonly status: number | null
+	readonly kind: 'client' | 'server' | 'network'
+
+	constructor(
+		message: string,
+		options: { status?: number | null; kind: KitWaitlistError['kind'] },
+	) {
+		super(message)
+		this.name = 'KitWaitlistError'
+		this.status = options.status ?? null
+		this.kind = options.kind
+	}
 }
 
 function kitHeaders(apiKey: string): HeadersInit {
@@ -60,41 +83,121 @@ function kitErrorMessage(
 	return typeof first === 'string' && first.trim() ? first : fallback
 }
 
+function classifyHttpKind(status: number): 'client' | 'server' {
+	return status >= 500 ? 'server' : 'client'
+}
+
+function isAbortError(error: unknown) {
+	return (
+		(error instanceof DOMException && error.name === 'TimeoutError') ||
+		(error instanceof Error && error.name === 'AbortError')
+	)
+}
+
+async function kitFetch(
+	fetchImpl: typeof fetch,
+	url: string,
+	init: RequestInit,
+	timeoutMs: number,
+): Promise<Response> {
+	try {
+		return await fetchImpl(url, {
+			...init,
+			signal: AbortSignal.timeout(timeoutMs),
+		})
+	} catch (error) {
+		if (isAbortError(error)) {
+			throw new KitWaitlistError('Kit request timed out.', {
+				status: null,
+				kind: 'network',
+			})
+		}
+		throw new KitWaitlistError('Kit request failed.', {
+			status: null,
+			kind: 'network',
+		})
+	}
+}
+
 /**
- * Upsert a Kit subscriber (email + first name) and tag them for the Kody
- * waitlist. Tagging is idempotent; create is an upsert by email.
+ * Find an existing Kit subscriber by email, tag them for the waitlist, and
+ * only create (with first_name) when they are new. Existing CRM names are
+ * never overwritten by a public waitlist submission.
  */
 export async function subscribeToKitWaitlist(
 	input: KitWaitlistSubscribeInput,
 ): Promise<KitWaitlistSubscribeResult> {
 	const fetchImpl = input.fetchImpl ?? fetch
 	const tagId = input.tagId ?? DEFAULT_KIT_WAITLIST_TAG_ID
+	const timeoutMs = input.timeoutMs ?? KIT_WAITLIST_REQUEST_TIMEOUT_MS
 	const headers = kitHeaders(input.apiKey)
 
-	const createResponse = await fetchImpl(`${KIT_API_BASE_URL}/subscribers`, {
-		method: 'POST',
-		headers,
-		body: JSON.stringify({
-			email_address: input.email,
-			first_name: input.firstName,
-		}),
-	})
-	const createPayload = await readKitJson(createResponse)
-	if (!createResponse.ok) {
-		throw new Error(
+	const lookupUrl = `${KIT_API_BASE_URL}/subscribers?email_address=${encodeURIComponent(input.email)}`
+	const lookupResponse = await kitFetch(
+		fetchImpl,
+		lookupUrl,
+		{ method: 'GET', headers },
+		timeoutMs,
+	)
+	const lookupPayload = await readKitJson(lookupResponse)
+	if (!lookupResponse.ok) {
+		throw new KitWaitlistError(
 			kitErrorMessage(
-				createPayload,
-				`Kit subscriber create failed (${createResponse.status}).`,
+				lookupPayload,
+				`Kit subscriber lookup failed (${lookupResponse.status}).`,
 			),
+			{
+				status: lookupResponse.status,
+				kind: classifyHttpKind(lookupResponse.status),
+			},
 		)
 	}
 
-	const subscriberId = createPayload?.subscriber?.id
+	const existing = lookupPayload?.subscribers?.find(
+		(subscriber) => typeof subscriber.id === 'number',
+	)
+	let subscriberId = existing?.id
+	let created = false
+
 	if (typeof subscriberId !== 'number') {
-		throw new Error('Kit subscriber create returned no subscriber id.')
+		const createResponse = await kitFetch(
+			fetchImpl,
+			`${KIT_API_BASE_URL}/subscribers`,
+			{
+				method: 'POST',
+				headers,
+				body: JSON.stringify({
+					email_address: input.email,
+					first_name: input.firstName,
+				}),
+			},
+			timeoutMs,
+		)
+		const createPayload = await readKitJson(createResponse)
+		if (!createResponse.ok) {
+			throw new KitWaitlistError(
+				kitErrorMessage(
+					createPayload,
+					`Kit subscriber create failed (${createResponse.status}).`,
+				),
+				{
+					status: createResponse.status,
+					kind: classifyHttpKind(createResponse.status),
+				},
+			)
+		}
+		subscriberId = createPayload?.subscriber?.id
+		created = true
+		if (typeof subscriberId !== 'number') {
+			throw new KitWaitlistError(
+				'Kit subscriber create returned no subscriber id.',
+				{ status: createResponse.status, kind: 'server' },
+			)
+		}
 	}
 
-	const tagResponse = await fetchImpl(
+	const tagResponse = await kitFetch(
+		fetchImpl,
 		`${KIT_API_BASE_URL}/tags/${tagId}/subscribers`,
 		{
 			method: 'POST',
@@ -103,18 +206,23 @@ export async function subscribeToKitWaitlist(
 				email_address: input.email,
 			}),
 		},
+		timeoutMs,
 	)
 	const tagPayload = await readKitJson(tagResponse)
 	if (!tagResponse.ok) {
-		throw new Error(
+		throw new KitWaitlistError(
 			kitErrorMessage(
 				tagPayload,
 				`Kit waitlist tag failed (${tagResponse.status}).`,
 			),
+			{
+				status: tagResponse.status,
+				kind: classifyHttpKind(tagResponse.status),
+			},
 		)
 	}
 
-	return { subscriberId }
+	return { subscriberId, created }
 }
 
 export function resolveKitWaitlistTagId(

--- a/packages/worker/src/app/kit-waitlist.ts
+++ b/packages/worker/src/app/kit-waitlist.ts
@@ -1,0 +1,130 @@
+/**
+ * Kit (kit.com) waitlist subscriber helpers.
+ *
+ * Auth uses the `X-Kit-Api-Key` header against `https://api.kit.com/v4`.
+ * Public signup captures join the `waitlist::kody` tag (created in Kit for
+ * this product). Forms cannot be created via the API, and Kent's existing
+ * waitlists use the `waitlist::…` tag convention, so tagging is the right
+ * integration surface.
+ */
+
+export const KIT_API_BASE_URL = 'https://api.kit.com/v4'
+
+/** Kit tag `waitlist::kody` — override with `KIT_WAITLIST_TAG_ID` if needed. */
+export const DEFAULT_KIT_WAITLIST_TAG_ID = 21081721
+
+export type KitWaitlistSubscribeInput = {
+	apiKey: string
+	email: string
+	firstName: string
+	tagId?: number
+	fetchImpl?: typeof fetch
+}
+
+export type KitWaitlistSubscribeResult = {
+	subscriberId: number
+}
+
+type KitSubscriberPayload = {
+	subscriber?: {
+		id?: number
+		email_address?: string
+		first_name?: string
+	}
+	errors?: Array<string>
+}
+
+function kitHeaders(apiKey: string): HeadersInit {
+	return {
+		Accept: 'application/json',
+		'Content-Type': 'application/json',
+		'X-Kit-Api-Key': apiKey,
+	}
+}
+
+async function readKitJson(
+	response: Response,
+): Promise<KitSubscriberPayload | null> {
+	try {
+		return (await response.json()) as KitSubscriberPayload
+	} catch {
+		return null
+	}
+}
+
+function kitErrorMessage(
+	payload: KitSubscriberPayload | null,
+	fallback: string,
+) {
+	const first = payload?.errors?.[0]
+	return typeof first === 'string' && first.trim() ? first : fallback
+}
+
+/**
+ * Upsert a Kit subscriber (email + first name) and tag them for the Kody
+ * waitlist. Tagging is idempotent; create is an upsert by email.
+ */
+export async function subscribeToKitWaitlist(
+	input: KitWaitlistSubscribeInput,
+): Promise<KitWaitlistSubscribeResult> {
+	const fetchImpl = input.fetchImpl ?? fetch
+	const tagId = input.tagId ?? DEFAULT_KIT_WAITLIST_TAG_ID
+	const headers = kitHeaders(input.apiKey)
+
+	const createResponse = await fetchImpl(`${KIT_API_BASE_URL}/subscribers`, {
+		method: 'POST',
+		headers,
+		body: JSON.stringify({
+			email_address: input.email,
+			first_name: input.firstName,
+		}),
+	})
+	const createPayload = await readKitJson(createResponse)
+	if (!createResponse.ok) {
+		throw new Error(
+			kitErrorMessage(
+				createPayload,
+				`Kit subscriber create failed (${createResponse.status}).`,
+			),
+		)
+	}
+
+	const subscriberId = createPayload?.subscriber?.id
+	if (typeof subscriberId !== 'number') {
+		throw new Error('Kit subscriber create returned no subscriber id.')
+	}
+
+	const tagResponse = await fetchImpl(
+		`${KIT_API_BASE_URL}/tags/${tagId}/subscribers`,
+		{
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				email_address: input.email,
+			}),
+		},
+	)
+	const tagPayload = await readKitJson(tagResponse)
+	if (!tagResponse.ok) {
+		throw new Error(
+			kitErrorMessage(
+				tagPayload,
+				`Kit waitlist tag failed (${tagResponse.status}).`,
+			),
+		)
+	}
+
+	return { subscriberId }
+}
+
+export function resolveKitWaitlistTagId(
+	raw: string | undefined,
+): number | null {
+	if (raw === undefined) return DEFAULT_KIT_WAITLIST_TAG_ID
+	const trimmed = raw.trim()
+	if (!trimmed) return DEFAULT_KIT_WAITLIST_TAG_ID
+	if (!/^\d+$/.test(trimmed)) return null
+	const parsed = Number.parseInt(trimmed, 10)
+	if (!Number.isSafeInteger(parsed) || parsed <= 0) return null
+	return parsed
+}

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -106,6 +106,7 @@ import {
 } from '#app/handlers/password-reset.ts'
 import { createSessionHandler } from '#app/handlers/session.ts'
 import { createSignupHandler } from '#app/handlers/signup.ts'
+import { createWaitingListHandler } from '#app/handlers/waiting-list.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { routes } from '#app/routes.ts'
 export function createAppRouter(env: Env) {
@@ -135,6 +136,7 @@ export function createAppRouter(env: Env) {
 			verifyEmail: createVerifyEmailHandler(env),
 			verifyEmailChange: createVerifyEmailChangeHandler(env),
 			signup: createSignupHandler(env),
+			waitingList: createWaitingListHandler(env),
 			account: createAccountHandler(env),
 			accountDelete: createAccountDeleteHandler(env),
 			accountExport: createAccountExportHandler(env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -77,6 +77,7 @@ export const routes = route({
 	verifyEmail: '/verify-email',
 	verifyEmailChange: '/verify-email-change',
 	signup: '/signup',
+	waitingList: post('/waiting-list'),
 	account: '/account',
 	accountDelete: post('/account/delete'),
 	auth: post('/auth'),

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -196,6 +196,10 @@ export const EnvSchema = object({
 	AI_GATEWAY_ID: optionalNonEmptyStringSchema,
 	CAPABILITY_REINDEX_SECRET: optionalNonEmptyStringSchema,
 	JOB_REINDEX_SECRET: optionalNonEmptyStringSchema,
+	// Kit (kit.com) waitlist — optional; production waiting-list submits fail
+	// closed without KIT_API_KEY. Non-production skips Kit when unset.
+	KIT_API_KEY: optionalNonEmptyStringSchema,
+	KIT_WAITLIST_TAG_ID: optionalNonEmptyStringSchema,
 })
 
 export type AppEnv = InferOutput<typeof EnvSchema>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Public `/signup` now defaults to a waiting-list form (first name + email). Submissions go to `POST /waiting-list`, which looks up/creates a Kit subscriber and tags them `waitlist::kody` without overwriting existing CRM names. An **I have a code** control reveals the existing invite signup form (`?code` / `?invite` / `?panel=invite` also open it directly).

Kit forms cannot be created via API; Kent’s existing waitlists use the `waitlist::…` tag convention, so tagging is the integration surface. Tag `waitlist::kody` (id `21081721`) was created in Kit for this.

### Production secret

Please add GitHub Actions secret **`KIT_API_KEY`** (same value as Kody `kitApiKey`). Production deploy syncs it when set; without it, waiting-list joins return 503 while the rest of the app still deploys. Preview deploys intentionally omit the key so preview/E2E joins do not write to the production Kit audience.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `300ae007` · **Head:** latest on `cursor/waiting-list-signup-e777`

**Classification:** extends — signup onboarding now includes a public Kit-backed waiting list while invite-gated account creation remains available.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-sessions` | auth | extends — `/signup` waiting list + `POST /waiting-list` Kit tag join; invite signup unchanged behind reveal |
| `app-ui` | surfaces | extends — signup route UI defaults to waiting list with “I have a code” reveal |
| `d1-app-db` | storage | composes — reuses existing D1 rate-limit table for IP throttling |

### System map

Signup waiting-list joins flow from the Remix signup UI through a new auth handler into Kit; invite signup still uses the existing auth/invite path.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>/signup"]:::extended
	appSessions["app-sessions<br/>waiting-list + invites"]:::extended
	d1AppDb["d1-app-db<br/>rate limits"]:::touched
	kit["Kit API<br/>waitlist::kody tag"]:::untouched
	appUi -->|"waiting list form"| appSessions
	appUi -->|"I have a code → POST /auth"| appSessions
	appSessions -->|"checkRateLimit"| d1AppDb
	appSessions -->|"lookup/create + tag"| kit
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant User
	participant Signup as /signup
	participant API as POST /waiting-list
	participant Kit as api.kit.com
	User->>Signup: first name + email
	Signup->>API: JSON submit
	API->>Kit: lookup subscriber by email
	alt new subscriber
		API->>Kit: create with first_name
	end
	API->>Kit: tag waitlist::kody
	API-->>Signup: ok
	Note over Signup: “I have a code” reveals invite signup
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| `/signup` | Always invite account form | Waiting list by default; invite form on demand |
| Kit | No waitlist integration | Tag `waitlist::kody` via `KIT_API_KEY` |

### Invariants

Per-user isolation unchanged — waiting-list joins are anonymous marketing contacts in Kit, not Kody user accounts.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5174-cc03-7aaf-8479-21d6c429e777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5174-cc03-7aaf-8479-21d6c429e777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public waiting-list signup flow on `/signup` for visitors without an invite code, including first name + email submission with validation and Kit-based joining.
  * Supports switching to invite-code signup from the same `/signup` experience, and enforces per-IP rate limiting with clear success/error messaging.
* **Bug Fixes**
  * Updated the invite-based signup flow to include the correct “I have a code” step before entering invite details.
* **Documentation**
  * Documented Kit waitlist configuration (`KIT_API_KEY`, `KIT_WAITLIST_TAG_ID`) and production vs preview behavior.
* **Tests**
  * Added/expanded end-to-end and handler tests for waiting-list signup, rate limiting, and Kit failure/no-op scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->