### PR TITLE
Send Kit welcome email on waiting-list signup

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -68,11 +68,15 @@ Waiting-list Kit integration:
 
 - Worker secret `KIT_API_KEY` (Kit v4 `X-Kit-Api-Key`)
 - Optional `KIT_WAITLIST_TAG_ID` (defaults to the `waitlist::kody` tag id)
+- Optional `KIT_WAITLIST_SEQUENCE_ID` (defaults to the "Kody Waitlist Welcome"
+  sequence, which sends an immediate thank-you from `hello@kentcdodds.com`
+  asking what they hope to use Kody for)
 - Production fails closed with 503 when `KIT_API_KEY` is unset; non-production
   accepts the join without calling Kit so local/preview UX stays usable. Preview
   deploys intentionally omit `KIT_API_KEY` so they never write to the production
   Kit audience.
-- Existing Kit subscribers are tagged without overwriting their `first_name`
+- Existing Kit subscribers are tagged/enrolled without overwriting their
+  `first_name`
 - Rate-limited per client IP (5 requests / 15 minutes)
 
 The `invites` table stores operator-created invite codes:

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -96,6 +96,8 @@ Optional Worker secrets / vars for the public `/signup` waiting-list form
   joins no-op instead of writing to the production Kit audience.
 - `KIT_WAITLIST_TAG_ID` — optional override for the Kit tag id (defaults to the
   `waitlist::kody` tag).
+- `KIT_WAITLIST_SEQUENCE_ID` — optional override for the welcome sequence id
+  (defaults to "Kody Waitlist Welcome", from `hello@kentcdodds.com`).
 
 See [`architecture/authentication.md`](./architecture/authentication.md).
 

--- a/packages/worker/.env.example
+++ b/packages/worker/.env.example
@@ -65,10 +65,12 @@ X_CLIENT_SECRET=MOCK_X_CLIENT_SECRET
 # deploy workflow.
 # CAPABILITY_REINDEX_SECRET=
 
-# Kit (kit.com) waiting-list signup (optional Worker secret + tag id).
-# Production /waiting-list posts create/upsert a subscriber and tag them with
-# waitlist::kody. Non-production skips Kit when KIT_API_KEY is unset.
+# Kit (kit.com) waiting-list signup (optional Worker secret + tag/sequence ids).
+# Production /waiting-list posts create/upsert a subscriber, tag waitlist::kody,
+# and enroll them in the Kody Waitlist Welcome sequence (hello@kentcdodds.com).
+# Non-production skips Kit when KIT_API_KEY is unset.
 # KIT_API_KEY=
-# Optional override for the Kit tag id (defaults to waitlist::kody).
+# Optional overrides (defaults match the production Kit tag/sequence).
 # KIT_WAITLIST_TAG_ID=21081721
+# KIT_WAITLIST_SEQUENCE_ID=2823893
 

--- a/packages/worker/src/app/handlers/waiting-list.node.test.ts
+++ b/packages/worker/src/app/handlers/waiting-list.node.test.ts
@@ -154,6 +154,12 @@ test('joins the Kit waitlist with first name and email', async () => {
 					{ status: 201 },
 				)
 			}
+			if (url.includes('/sequences/') && url.endsWith('/subscribers')) {
+				return Response.json(
+					{ subscriber: { id: 42, email_address: 'ada@example.com' } },
+					{ status: 201 },
+				)
+			}
 			return Response.json({ errors: ['unexpected'] }, { status: 500 })
 		},
 	)
@@ -172,7 +178,7 @@ test('joins the Kit waitlist with first name and email', async () => {
 		ok: true,
 		message: "You're on the list. We'll be in touch.",
 	})
-	expect(fetchMock).toHaveBeenCalledTimes(3)
+	expect(fetchMock).toHaveBeenCalledTimes(4)
 	const createCall = fetchMock.mock.calls.find(([url, init]) => {
 		return (
 			String(url).endsWith('/subscribers') &&

--- a/packages/worker/src/app/handlers/waiting-list.ts
+++ b/packages/worker/src/app/handlers/waiting-list.ts
@@ -4,6 +4,7 @@ import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
 import { isNonProductionRuntime } from '#app/deployment-env.ts'
 import {
 	KitWaitlistError,
+	resolveKitWaitlistSequenceId,
 	resolveKitWaitlistTagId,
 	subscribeToKitWaitlist,
 } from '#app/kit-waitlist.ts'
@@ -71,7 +72,10 @@ export function createWaitingListHandler(env: Env) {
 			}
 
 			const tagId = resolveKitWaitlistTagId(env.KIT_WAITLIST_TAG_ID)
-			if (tagId === null) {
+			const sequenceId = resolveKitWaitlistSequenceId(
+				env.KIT_WAITLIST_SEQUENCE_ID,
+			)
+			if (tagId === null || sequenceId === null) {
 				return jsonResponse(
 					{ ok: false, error: 'Waiting list is misconfigured.' },
 					500,
@@ -154,6 +158,7 @@ export function createWaitingListHandler(env: Env) {
 					email,
 					firstName,
 					tagId,
+					sequenceId,
 				})
 			} catch (error) {
 				console.error('Failed to subscribe waiting list contact to Kit:', error)

--- a/packages/worker/src/app/kit-waitlist.node.test.ts
+++ b/packages/worker/src/app/kit-waitlist.node.test.ts
@@ -1,20 +1,27 @@
 import { expect, test, vi } from 'vitest'
 import {
+	DEFAULT_KIT_WAITLIST_SEQUENCE_ID,
 	DEFAULT_KIT_WAITLIST_TAG_ID,
 	type KitWaitlistError,
+	resolveKitWaitlistSequenceId,
 	resolveKitWaitlistTagId,
 	subscribeToKitWaitlist,
 } from '#app/kit-waitlist.ts'
 
-test('resolveKitWaitlistTagId defaults and validates overrides', () => {
+test('resolveKitWaitlist ids default and validate overrides', () => {
 	expect(resolveKitWaitlistTagId(undefined)).toBe(DEFAULT_KIT_WAITLIST_TAG_ID)
 	expect(resolveKitWaitlistTagId('')).toBe(DEFAULT_KIT_WAITLIST_TAG_ID)
 	expect(resolveKitWaitlistTagId(' 99 ')).toBe(99)
 	expect(resolveKitWaitlistTagId('0')).toBeNull()
 	expect(resolveKitWaitlistTagId('nope')).toBeNull()
+	expect(resolveKitWaitlistSequenceId(undefined)).toBe(
+		DEFAULT_KIT_WAITLIST_SEQUENCE_ID,
+	)
+	expect(resolveKitWaitlistSequenceId('2823893')).toBe(2823893)
+	expect(resolveKitWaitlistSequenceId('nope')).toBeNull()
 })
 
-test('subscribeToKitWaitlist creates new subscribers then tags them', async () => {
+test('subscribeToKitWaitlist creates, tags, and enrolls new subscribers', async () => {
 	const calls: Array<{ url: string; method: string; body: unknown }> = []
 	const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
 		const url = String(input)
@@ -41,6 +48,7 @@ test('subscribeToKitWaitlist creates new subscribers then tags them', async () =
 		email: 'ada@example.com',
 		firstName: 'Ada',
 		tagId: 123,
+		sequenceId: 456,
 		fetchImpl: fetchImpl as typeof fetch,
 	})
 
@@ -58,6 +66,11 @@ test('subscribeToKitWaitlist creates new subscribers then tags them', async () =
 		},
 		{
 			url: 'https://api.kit.com/v4/tags/123/subscribers',
+			method: 'POST',
+			body: { email_address: 'ada@example.com' },
+		},
+		{
+			url: 'https://api.kit.com/v4/sequences/456/subscribers',
 			method: 'POST',
 			body: { email_address: 'ada@example.com' },
 		},
@@ -96,6 +109,7 @@ test('subscribeToKitWaitlist does not overwrite an existing first name', async (
 		email: 'ada@example.com',
 		firstName: 'Ada',
 		tagId: 123,
+		sequenceId: 456,
 		fetchImpl: fetchImpl as typeof fetch,
 	})
 
@@ -108,6 +122,11 @@ test('subscribeToKitWaitlist does not overwrite an existing first name', async (
 		},
 		{
 			url: 'https://api.kit.com/v4/tags/123/subscribers',
+			method: 'POST',
+			body: { email_address: 'ada@example.com' },
+		},
+		{
+			url: 'https://api.kit.com/v4/sequences/456/subscribers',
 			method: 'POST',
 			body: { email_address: 'ada@example.com' },
 		},

--- a/packages/worker/src/app/kit-waitlist.ts
+++ b/packages/worker/src/app/kit-waitlist.ts
@@ -3,15 +3,20 @@
  *
  * Auth uses the `X-Kit-Api-Key` header against `https://api.kit.com/v4`.
  * Public signup captures join the `waitlist::kody` tag (created in Kit for
- * this product). Forms cannot be created via the API, and Kent's existing
- * waitlists use the `waitlist::…` tag convention, so tagging is the right
- * integration surface.
+ * this product) and enrolls them in the "Kody Waitlist Welcome" sequence,
+ * which sends an immediate thank-you from hello@kentcdodds.com.
  */
 
 export const KIT_API_BASE_URL = 'https://api.kit.com/v4'
 
 /** Kit tag `waitlist::kody` — override with `KIT_WAITLIST_TAG_ID` if needed. */
 export const DEFAULT_KIT_WAITLIST_TAG_ID = 21081721
+
+/**
+ * Kit sequence "Kody Waitlist Welcome" (from hello@kentcdodds.com).
+ * Override with `KIT_WAITLIST_SEQUENCE_ID` if needed.
+ */
+export const DEFAULT_KIT_WAITLIST_SEQUENCE_ID = 2823893
 
 /** Bound Kit round-trips so a hung upstream cannot pin a Worker request. */
 export const KIT_WAITLIST_REQUEST_TIMEOUT_MS = 8_000
@@ -21,6 +26,7 @@ export type KitWaitlistSubscribeInput = {
 	email: string
 	firstName: string
 	tagId?: number
+	sequenceId?: number
 	fetchImpl?: typeof fetch
 	timeoutMs?: number
 }
@@ -120,15 +126,17 @@ async function kitFetch(
 }
 
 /**
- * Find an existing Kit subscriber by email, tag them for the waitlist, and
- * only create (with first_name) when they are new. Existing CRM names are
- * never overwritten by a public waitlist submission.
+ * Find an existing Kit subscriber by email, tag them for the waitlist, enroll
+ * them in the welcome sequence, and only create (with first_name) when they
+ * are new. Existing CRM names are never overwritten by a public waitlist
+ * submission.
  */
 export async function subscribeToKitWaitlist(
 	input: KitWaitlistSubscribeInput,
 ): Promise<KitWaitlistSubscribeResult> {
 	const fetchImpl = input.fetchImpl ?? fetch
 	const tagId = input.tagId ?? DEFAULT_KIT_WAITLIST_TAG_ID
+	const sequenceId = input.sequenceId ?? DEFAULT_KIT_WAITLIST_SEQUENCE_ID
 	const timeoutMs = input.timeoutMs ?? KIT_WAITLIST_REQUEST_TIMEOUT_MS
 	const headers = kitHeaders(input.apiKey)
 
@@ -222,17 +230,56 @@ export async function subscribeToKitWaitlist(
 		)
 	}
 
+	const sequenceResponse = await kitFetch(
+		fetchImpl,
+		`${KIT_API_BASE_URL}/sequences/${sequenceId}/subscribers`,
+		{
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				email_address: input.email,
+			}),
+		},
+		timeoutMs,
+	)
+	const sequencePayload = await readKitJson(sequenceResponse)
+	if (!sequenceResponse.ok) {
+		throw new KitWaitlistError(
+			kitErrorMessage(
+				sequencePayload,
+				`Kit waitlist sequence enroll failed (${sequenceResponse.status}).`,
+			),
+			{
+				status: sequenceResponse.status,
+				kind: classifyHttpKind(sequenceResponse.status),
+			},
+		)
+	}
+
 	return { subscriberId, created }
+}
+
+function resolvePositiveIntId(
+	raw: string | undefined,
+	fallback: number,
+): number | null {
+	if (raw === undefined) return fallback
+	const trimmed = raw.trim()
+	if (!trimmed) return fallback
+	if (!/^\d+$/.test(trimmed)) return null
+	const parsed = Number.parseInt(trimmed, 10)
+	if (!Number.isSafeInteger(parsed) || parsed <= 0) return null
+	return parsed
 }
 
 export function resolveKitWaitlistTagId(
 	raw: string | undefined,
 ): number | null {
-	if (raw === undefined) return DEFAULT_KIT_WAITLIST_TAG_ID
-	const trimmed = raw.trim()
-	if (!trimmed) return DEFAULT_KIT_WAITLIST_TAG_ID
-	if (!/^\d+$/.test(trimmed)) return null
-	const parsed = Number.parseInt(trimmed, 10)
-	if (!Number.isSafeInteger(parsed) || parsed <= 0) return null
-	return parsed
+	return resolvePositiveIntId(raw, DEFAULT_KIT_WAITLIST_TAG_ID)
+}
+
+export function resolveKitWaitlistSequenceId(
+	raw: string | undefined,
+): number | null {
+	return resolvePositiveIntId(raw, DEFAULT_KIT_WAITLIST_SEQUENCE_ID)
 }

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -200,6 +200,7 @@ export const EnvSchema = object({
 	// closed without KIT_API_KEY. Non-production skips Kit when unset.
 	KIT_API_KEY: optionalNonEmptyStringSchema,
 	KIT_WAITLIST_TAG_ID: optionalNonEmptyStringSchema,
+	KIT_WAITLIST_SEQUENCE_ID: optionalNonEmptyStringSchema,
 })
 
 export type AppEnv = InferOutput<typeof EnvSchema>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Waiting-list joins now enroll in Kit’s **Kody Waitlist Welcome** sequence (id `2823893`), which immediately sends a thank-you from `hello@kentcdodds.com` and asks what they’re hoping to use Kody for.

Copy (Sonnet):

> **Subject:** You're on the Kody waitlist
>
> Thanks for signing up — you're on the list… One quick thing: I'm genuinely curious what you'd want to use Kody for…

The sequence and published email were created in Kit for this change. App wiring adds sequence enrollment alongside the existing `waitlist::kody` tag.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/waitlist-welcome-email-e777`

**Classification:** extends — waiting-list Kit join now also enrolls the welcome sequence.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-sessions` | auth | extends — `/waiting-list` also enrolls Kit welcome sequence |

### System map

Waitlist joins still tag `waitlist::kody`, then enroll the welcome sequence so Kit sends from `hello@kentcdodds.com`.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	waitingList["POST /waiting-list"]:::extended
	kitTag["Kit tag waitlist::kody"]:::untouched
	kitSeq["Kit sequence welcome email"]:::untouched
	waitingList -->|"tag subscriber"| kitTag
	waitingList -->|"enroll sequence"| kitSeq
	kitSeq -->|"immediate send"| hello["hello@kentcdodds.com"]:::untouched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5174-cc03-7aaf-8479-21d6c429e777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5174-cc03-7aaf-8479-21d6c429e777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New waitlist signups are now automatically enrolled in a welcome sequence.
  * Existing subscribers retain their first name while receiving the waitlist tag and welcome sequence.
  * Welcome sequence configuration can be customized.

* **Documentation**
  * Updated authentication and environment configuration guidance for waitlist sequence settings.

* **Bug Fixes**
  * Improved validation for missing or invalid waitlist configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->