### PR TITLE
Add compact top waitlist banner for signed-out visitors

### DIFF
--- a/e2e/waiting-list-banner.spec.ts
+++ b/e2e/waiting-list-banner.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test'
+
+test('top waitlist banner joins from the home page', async ({ page }) => {
+	await page.goto('/')
+	const banner = page.getByRole('region', { name: 'Join the waiting list' })
+	await expect(banner).toBeVisible()
+	await banner.getByPlaceholder('First name').fill('Ada')
+	await banner
+		.getByPlaceholder('Email')
+		.fill(`waitlist-banner-${Date.now()}@example.com`)
+	await banner.getByRole('button', { name: 'Join' }).click()
+	await expect(
+		banner.getByText("You're on the list. We'll be in touch."),
+	).toBeVisible()
+})
+
+test('top waitlist banner is hidden on signup', async ({ page }) => {
+	await page.goto('/signup')
+	await expect(
+		page.getByRole('region', { name: 'Join the waiting list' }),
+	).toHaveCount(0)
+	await expect(
+		page.getByRole('heading', { name: 'Join the waiting list' }),
+	).toBeVisible()
+})

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -25,6 +25,7 @@ import { type AppLoaderData } from '#app/loader-data.ts'
 import { userHasRole } from '#app/permissions.ts'
 import { buildAuthLink } from './auth-links.ts'
 import { colors, mq, spacing, typography } from './styles/tokens.ts'
+import { WaitlistBanner } from './waitlist-banner.tsx'
 
 registerRouteLoaders(clientRouteLoaders)
 
@@ -151,6 +152,12 @@ export function App(handle: Handle<AppProps>) {
 				: null
 		const loginHref = buildAuthLink('/login', oauthRedirectTo)
 		const signupHref = buildAuthLink('/signup', oauthRedirectTo)
+		const hideWaitlistBanner =
+			!showAuthLinks ||
+			currentPathname === '/signup' ||
+			currentPathname === '/login' ||
+			currentPathname === '/oauth/authorize' ||
+			currentPathname === '/connect/oauth'
 
 		return (
 			<AppLoaderDataProvider loaderData={handle.props.loaderData}>
@@ -160,104 +167,116 @@ export function App(handle: Handle<AppProps>) {
 					mix={css({
 						width: '100%',
 						minHeight: '100vh',
-						padding: `${spacing.lg} ${spacing.xl} ${spacing.sm}`,
 						fontFamily: typography.fontFamily,
 						boxSizing: 'border-box',
-						[mq.tablet]: {
-							padding: `${spacing.sm} ${spacing.sm} 0`,
-						},
-						[mq.mobile]: {
-							padding: `${spacing.md} ${spacing.md} ${spacing.sm}`,
-						},
 					})}
 				>
-					<nav
+					{hideWaitlistBanner ? null : <WaitlistBanner />}
+					<div
 						mix={css({
-							maxWidth: layoutMaxWidths.wide,
 							width: '100%',
-							margin: `0 auto ${spacing.xl}`,
+							padding: `${spacing.lg} ${spacing.xl} ${spacing.sm}`,
 							boxSizing: 'border-box',
-							display: 'flex',
-							alignItems: 'center',
-							justifyContent: 'space-between',
-							gap: spacing.md,
-							flexWrap: 'wrap',
-							[mq.tablet]: compactNavCss,
-							[mq.mobile]: compactNavCss,
+							[mq.tablet]: {
+								padding: `${spacing.sm} ${spacing.sm} 0`,
+							},
+							[mq.mobile]: {
+								padding: `${spacing.md} ${spacing.md} ${spacing.sm}`,
+							},
 						})}
 					>
-						<div mix={css(navGroupCss)}>
-							<a href="/" aria-label="Home" mix={css(navHomeLinkCss)}>
-								<img
-									src="/logo.png"
-									alt=""
-									width={112}
-									height={28}
-									mix={css({
-										display: 'block',
-										height: '1.35em',
-										width: 'auto',
-									})}
-								/>
-							</a>
-							<a href="/community" mix={css(primaryLinkCss)}>
-								Community
-							</a>
-						</div>
-						<div mix={css(navGroupCss)}>
-							{showAuthLinks ? (
-								<>
-									<a href={loginHref} mix={css(primaryLinkCss)}>
-										Login
-									</a>
-									<a href={signupHref} mix={css(primaryLinkCss)}>
-										Signup
-									</a>
-								</>
-							) : null}
-							{isLoggedIn ? (
-								<>
-									{showAdminLink ? (
-										<a href="/admin/users" mix={css(primaryLinkCss)}>
-											Admin
-										</a>
-									) : null}
-									<a href="/account" mix={css(primaryLinkCss)}>
-										{sessionDisplayName}
-									</a>
-									<form method="post" action="/logout" mix={css({ margin: 0 })}>
-										<button type="submit" mix={css(logOutButtonCss)}>
-											Log out
-										</button>
-									</form>
-								</>
-							) : null}
-						</div>
-					</nav>
-					<main mix={css({ width: '100%', boxSizing: 'border-box' })}>
-						<Router
-							routes={clientRoutes}
-							loaderData={handle.props.loaderData}
-							notFound={handle.props.notFound}
-							fallback={
-								<section>
-									<h2
+						<nav
+							mix={css({
+								maxWidth: layoutMaxWidths.wide,
+								width: '100%',
+								margin: `0 auto ${spacing.xl}`,
+								boxSizing: 'border-box',
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'space-between',
+								gap: spacing.md,
+								flexWrap: 'wrap',
+								[mq.tablet]: compactNavCss,
+								[mq.mobile]: compactNavCss,
+							})}
+						>
+							<div mix={css(navGroupCss)}>
+								<a href="/" aria-label="Home" mix={css(navHomeLinkCss)}>
+									<img
+										src="/logo.png"
+										alt=""
+										width={112}
+										height={28}
 										mix={css({
-											fontSize: typography.fontSize.lg,
-											fontWeight: typography.fontWeight.semibold,
-											marginBottom: spacing.sm,
-											color: colors.text,
+											display: 'block',
+											height: '1.35em',
+											width: 'auto',
 										})}
-									>
-										Not Found
-									</h2>
-									<p mix={css({ color: colors.textMuted })}>
-										We could not find that page.
-									</p>
-								</section>
-							}
-						/>
-					</main>
+									/>
+								</a>
+								<a href="/community" mix={css(primaryLinkCss)}>
+									Community
+								</a>
+							</div>
+							<div mix={css(navGroupCss)}>
+								{showAuthLinks ? (
+									<>
+										<a href={loginHref} mix={css(primaryLinkCss)}>
+											Login
+										</a>
+										<a href={signupHref} mix={css(primaryLinkCss)}>
+											Signup
+										</a>
+									</>
+								) : null}
+								{isLoggedIn ? (
+									<>
+										{showAdminLink ? (
+											<a href="/admin/users" mix={css(primaryLinkCss)}>
+												Admin
+											</a>
+										) : null}
+										<a href="/account" mix={css(primaryLinkCss)}>
+											{sessionDisplayName}
+										</a>
+										<form
+											method="post"
+											action="/logout"
+											mix={css({ margin: 0 })}
+										>
+											<button type="submit" mix={css(logOutButtonCss)}>
+												Log out
+											</button>
+										</form>
+									</>
+								) : null}
+							</div>
+						</nav>
+						<main mix={css({ width: '100%', boxSizing: 'border-box' })}>
+							<Router
+								routes={clientRoutes}
+								loaderData={handle.props.loaderData}
+								notFound={handle.props.notFound}
+								fallback={
+									<section>
+										<h2
+											mix={css({
+												fontSize: typography.fontSize.lg,
+												fontWeight: typography.fontWeight.semibold,
+												marginBottom: spacing.sm,
+												color: colors.text,
+											})}
+										>
+											Not Found
+										</h2>
+										<p mix={css({ color: colors.textMuted })}>
+											We could not find that page.
+										</p>
+									</section>
+								}
+							/>
+						</main>
+					</div>
 				</div>
 			</AppLoaderDataProvider>
 		)

--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -1,0 +1,239 @@
+import { type Handle, css } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import {
+	compactInputCss,
+	getPrimaryButtonCss,
+	layoutMaxWidths,
+} from '#client/styles/style-primitives.ts'
+import {
+	colors,
+	mq,
+	radius,
+	spacing,
+	typography,
+} from '#client/styles/tokens.ts'
+
+type WaitlistStatus = 'idle' | 'submitting' | 'success' | 'error'
+
+/**
+ * Compact site-wide waitlist strip for signed-out visitors. Posts to the same
+ * `/waiting-list` endpoint as the signup page.
+ */
+export function WaitlistBanner(handle: Handle) {
+	let status: WaitlistStatus = 'idle'
+	let message: string | null = null
+
+	function setState(
+		nextStatus: WaitlistStatus,
+		nextMessage: string | null = null,
+	) {
+		status = nextStatus
+		message = nextMessage
+		handle.update()
+	}
+
+	async function handleSubmit(event: SubmitEvent) {
+		event.preventDefault()
+		if (!(event.currentTarget instanceof HTMLFormElement)) return
+		const form = event.currentTarget
+
+		const formData = new FormData(form)
+		const firstName = String(formData.get('firstName') ?? '').trim()
+		const email = String(formData.get('email') ?? '').trim()
+
+		if (!firstName || !email) {
+			setState('error', 'First name and email are required.')
+			return
+		}
+
+		setState('submitting')
+
+		try {
+			const response = await fetch('/waiting-list', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				credentials: 'include',
+				body: JSON.stringify({ firstName, email }),
+			})
+			const payload = await response.json().catch(() => null)
+
+			if (!response.ok) {
+				const errorMessage =
+					typeof payload?.error === 'string'
+						? payload.error
+						: 'Unable to join the waiting list.'
+				setState('error', errorMessage)
+				return
+			}
+
+			const successMessage =
+				typeof payload?.message === 'string'
+					? payload.message
+					: "You're on the list. We'll be in touch."
+			form.reset()
+			setState('success', successMessage)
+		} catch {
+			setState('error', 'Network error. Please try again.')
+		}
+	}
+
+	return () => {
+		const isSubmitting = status === 'submitting'
+		const isSuccess = status === 'success'
+
+		return (
+			<section aria-label="Join the waiting list" mix={css(bannerCss)}>
+				<div mix={css(bannerInnerCss)}>
+					{isSuccess ? (
+						<p
+							aria-live="polite"
+							mix={css({
+								margin: 0,
+								color: colors.text,
+								fontSize: typography.fontSize.sm,
+								fontWeight: typography.fontWeight.medium,
+							})}
+						>
+							{message}
+						</p>
+					) : (
+						<>
+							<p mix={css(promptCss)}>
+								Kody is invite-only — join the waiting list
+							</p>
+							<form mix={[css(formCss), on('submit', handleSubmit)]}>
+								<label mix={css(fieldCss)}>
+									<span mix={css(visuallyHiddenCss)}>First name</span>
+									<input
+										type="text"
+										name="firstName"
+										required
+										autoComplete="given-name"
+										maxLength={80}
+										placeholder="First name"
+										mix={css(bannerInputCss)}
+									/>
+								</label>
+								<label mix={css(fieldCss)}>
+									<span mix={css(visuallyHiddenCss)}>Email</span>
+									<input
+										type="email"
+										name="email"
+										required
+										autoComplete="email"
+										placeholder="Email"
+										mix={css(bannerInputCss)}
+									/>
+								</label>
+								<button
+									type="submit"
+									disabled={isSubmitting}
+									mix={css(submitCss)}
+								>
+									{isSubmitting ? 'Joining…' : 'Join'}
+								</button>
+							</form>
+							{message ? (
+								<p
+									aria-live="polite"
+									mix={css({
+										margin: 0,
+										color: colors.error,
+										fontSize: typography.fontSize.xs,
+									})}
+								>
+									{message}
+								</p>
+							) : null}
+						</>
+					)}
+				</div>
+			</section>
+		)
+	}
+}
+
+const bannerCss = {
+	width: '100%',
+	margin: 0,
+	padding: `${spacing.xs} ${spacing.xl}`,
+	borderBottom: `1px solid ${colors.border}`,
+	backgroundColor: colors.primarySoftest,
+	boxSizing: 'border-box' as const,
+	[mq.tablet]: {
+		padding: `${spacing.xs} ${spacing.sm}`,
+	},
+	[mq.mobile]: {
+		padding: `${spacing.xs} ${spacing.md}`,
+	},
+}
+
+const bannerInnerCss = {
+	maxWidth: layoutMaxWidths.wide,
+	width: '100%',
+	margin: '0 auto',
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	gap: spacing.sm,
+	flexWrap: 'wrap' as const,
+	boxSizing: 'border-box' as const,
+}
+
+const promptCss = {
+	margin: 0,
+	color: colors.textMuted,
+	fontSize: typography.fontSize.sm,
+	whiteSpace: 'nowrap' as const,
+	[mq.mobile]: {
+		whiteSpace: 'normal' as const,
+		textAlign: 'center' as const,
+		width: '100%',
+	},
+}
+
+const formCss = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: spacing.xs,
+	flexWrap: 'wrap' as const,
+	[mq.mobile]: {
+		width: '100%',
+	},
+}
+
+const fieldCss = {
+	display: 'grid',
+	margin: 0,
+	flex: '1 1 8rem',
+	minWidth: '7rem',
+	[mq.mobile]: {
+		flex: '1 1 calc(50% - 0.25rem)',
+	},
+}
+
+const bannerInputCss = {
+	...compactInputCss,
+	backgroundColor: colors.surface,
+	borderRadius: radius.sm,
+}
+
+const submitCss = {
+	...getPrimaryButtonCss({ size: 'md' }),
+	padding: `${spacing.xs} ${spacing.md}`,
+	fontSize: typography.fontSize.sm,
+	borderRadius: radius.sm,
+	flex: '0 0 auto',
+}
+
+const visuallyHiddenCss = {
+	position: 'absolute' as const,
+	width: '1px',
+	height: '1px',
+	padding: 0,
+	margin: '-1px',
+	overflow: 'hidden' as const,
+	clip: 'rect(0, 0, 0, 0)',
+	whiteSpace: 'nowrap' as const,
+	border: 0,
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a compact full-width waitlist banner at the top of the app for signed-out visitors: short prompt + horizontal first-name/email form posting to the existing `/waiting-list` endpoint (Kit tag + welcome email).

Hidden for signed-in users and on `/signup`, `/login`, and OAuth pages so it doesn’t compete with the full waitlist/signup forms.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/waitlist-top-banner-e777`

**Classification:** extends — app UI shell now surfaces waitlist capture site-wide for signed-out visitors.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — top waitlist banner in app shell |
| `app-sessions` | auth | composes — reuses `/waiting-list` join path |

### System map

Signed-out visitors can join from any page via the top banner; the banner posts to the existing waitlist handler.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>WaitlistBanner"]:::extended
	waitingList["POST /waiting-list"]:::touched
	appUi -->|"first name + email"| waitingList
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5174-cc03-7aaf-8479-21d6c429e777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5174-cc03-7aaf-8479-21d6c429e777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a waiting-list banner for signed-out visitors.
  * Visitors can submit their first name and email directly from the banner.
  * Added success and error feedback after submission.
  * The banner is hidden on signup, login, and authorization pages.

* **Tests**
  * Added end-to-end coverage for successful signups and banner visibility rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->