### PR TITLE
Polish waitlist banner text contrast and Join attachment

### DIFF
--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -102,7 +102,7 @@ export function WaitlistBanner(handle: Handle) {
 								Kody is invite-only — join the waiting list
 							</p>
 							<form mix={[css(formCss), on('submit', handleSubmit)]}>
-								<label mix={css(fieldCss)}>
+								<label mix={css(nameFieldCss)}>
 									<span mix={css(visuallyHiddenCss)}>First name</span>
 									<input
 										type="text"
@@ -114,24 +114,26 @@ export function WaitlistBanner(handle: Handle) {
 										mix={css(bannerInputCss)}
 									/>
 								</label>
-								<label mix={css(fieldCss)}>
-									<span mix={css(visuallyHiddenCss)}>Email</span>
-									<input
-										type="email"
-										name="email"
-										required
-										autoComplete="email"
-										placeholder="Email"
-										mix={css(bannerInputCss)}
-									/>
-								</label>
-								<button
-									type="submit"
-									disabled={isSubmitting}
-									mix={css(submitCss)}
-								>
-									{isSubmitting ? 'Joining…' : 'Join'}
-								</button>
+								<div mix={css(emailGroupCss)}>
+									<label mix={css(emailFieldCss)}>
+										<span mix={css(visuallyHiddenCss)}>Email</span>
+										<input
+											type="email"
+											name="email"
+											required
+											autoComplete="email"
+											placeholder="Email"
+											mix={css(emailInputCss)}
+										/>
+									</label>
+									<button
+										type="submit"
+										disabled={isSubmitting}
+										mix={css(submitCss)}
+									>
+										{isSubmitting ? 'Joining…' : 'Join'}
+									</button>
+								</div>
 							</form>
 							{message ? (
 								<p
@@ -140,6 +142,8 @@ export function WaitlistBanner(handle: Handle) {
 										margin: 0,
 										color: colors.error,
 										fontSize: typography.fontSize.xs,
+										width: '100%',
+										textAlign: 'center' as const,
 									})}
 								>
 									{message}
@@ -182,8 +186,9 @@ const bannerInnerCss = {
 
 const promptCss = {
 	margin: 0,
-	color: colors.textMuted,
+	color: colors.text,
 	fontSize: typography.fontSize.sm,
+	fontWeight: typography.fontWeight.medium,
 	whiteSpace: 'nowrap' as const,
 	[mq.mobile]: {
 		whiteSpace: 'normal' as const,
@@ -194,7 +199,7 @@ const promptCss = {
 
 const formCss = {
 	display: 'flex',
-	alignItems: 'center',
+	alignItems: 'stretch',
 	gap: spacing.xs,
 	flexWrap: 'wrap' as const,
 	[mq.mobile]: {
@@ -202,28 +207,78 @@ const formCss = {
 	},
 }
 
-const fieldCss = {
+const nameFieldCss = {
 	display: 'grid',
 	margin: 0,
-	flex: '1 1 8rem',
+	flex: '0 1 9rem',
 	minWidth: '7rem',
 	[mq.mobile]: {
-		flex: '1 1 calc(50% - 0.25rem)',
+		flex: '1 1 6rem',
+		minWidth: '5.5rem',
 	},
+}
+
+const emailGroupCss = {
+	display: 'flex',
+	alignItems: 'stretch',
+	flex: '1 1 14rem',
+	minWidth: '12rem',
+	border: `1px solid ${colors.border}`,
+	borderRadius: radius.sm,
+	overflow: 'hidden',
+	backgroundColor: colors.surface,
+	'&:focus-within': {
+		borderColor: colors.primary,
+	},
+	[mq.mobile]: {
+		flex: '1 1 11rem',
+		minWidth: '10rem',
+	},
+}
+
+const emailFieldCss = {
+	display: 'grid',
+	margin: 0,
+	flex: '1 1 auto',
+	minWidth: 0,
 }
 
 const bannerInputCss = {
 	...compactInputCss,
+	height: '100%',
 	backgroundColor: colors.surface,
 	borderRadius: radius.sm,
+}
+
+const emailInputCss = {
+	...bannerInputCss,
+	border: 'none',
+	borderRadius: 0,
+	boxShadow: 'none',
+	outline: 'none',
+	'&:focus': {
+		outline: 'none',
+		boxShadow: 'none',
+		borderColor: 'transparent',
+	},
 }
 
 const submitCss = {
 	...getPrimaryButtonCss({ size: 'md' }),
 	padding: `${spacing.xs} ${spacing.md}`,
 	fontSize: typography.fontSize.sm,
-	borderRadius: radius.sm,
+	borderRadius: 0,
 	flex: '0 0 auto',
+	alignSelf: 'stretch',
+	transform: 'none',
+	'&:not(:disabled):hover': {
+		backgroundColor: colors.primaryHover,
+		transform: 'none',
+	},
+	'&:not(:disabled):active': {
+		backgroundColor: colors.primaryActive,
+		transform: 'none',
+	},
 }
 
 const visuallyHiddenCss = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tweaks the signed-out waitlist banner layout after the initial ship:

- Prompt text uses `colors.text` (medium weight) instead of muted grey so it reads correctly on the soft blue strip.
- Email + **Join** are one bordered control group (`overflow: hidden`, shared radius, focus-within border) so Join stays attached to the right of the email field when the form wraps on narrow screens.
- First name stays a separate field; only email|Join moves as a unit.

## Screenshots

![Desktop waitlist banner](https://cursor.com/artifacts/c/art-3d0824d3-8df4-46cb-aac6-6f2206112681)
![Mobile waitlist banner](https://cursor.com/artifacts/c/art-787a42be-aded-4722-8d69-e648c36f629e)

## Test plan

- [x] `npm run typecheck`
- [x] pre-push unit + Playwright E2E (including `waiting-list-banner`)
- [x] Manual layout check at 1280 / 768 / 390 / 360 — Join flush with email (`gap: 0`)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `269b4478` · **Head:** `5e4002e6`

**Classification:** composes — CSS/layout-only change to the existing waitlist banner in the browser app UI; no new primitives or contracts.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — waitlist banner prompt color + email/Join attached control |

### System map

Signed-out visitors see the compact waitlist strip; this PR only adjusts presentation of that strip.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context.

```mermaid
flowchart LR
	visitor["Signed-out visitor"]:::untouched
	appUi["app-ui<br/>WaitlistBanner"]:::touched
	waitingList["POST /waiting-list"]:::untouched
	visitor --> appUi
	appUi -->|"unchanged submit"| waitingList
	classDef touched fill:#1a7f37,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

1. Prompt uses primary text color + medium weight.
2. Email input and Join share one bordered flex group so wrapping keeps them together.
3. Submit path unchanged.

### Risk and invariants

- Low risk: client CSS/layout only; form fields and `/waiting-list` POST unchanged.
- No per-user isolation impact (banner remains signed-out only).

### Docs

No docs changes.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5174-cc03-7aaf-8479-21d6c429e777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5174-cc03-7aaf-8479-21d6c429e777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the waitlist signup form layout for improved clarity and responsiveness.
  * Updated input and button sizing, spacing, colors, and interactive states.
  * Improved the appearance and alignment of success and error messages.
  * Enhanced prompt text styling for better visual emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->