### PR TITLE
Require email verification before MCP setup and preserve media results

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -135,7 +135,8 @@ instead.
 Signed-in users with an unverified email can request a fresh link with
 `POST /account/resend-verification.json`
 (`packages/worker/src/app/handlers/account-resend-verification.ts`), surfaced as
-a "Resend verification email" button on `/account`. The endpoint reuses
+a "Resend verification email" button on `/pending-verification`, `/account`,
+`/onboarding`, and `/oauth/authorize`. The endpoint reuses
 `createEmailVerification` (invalidating older tokens) and is rate-limited per
 user (3 requests per 15 minutes).
 
@@ -145,12 +146,29 @@ null until `GET /verify-email?token=...` succeeds. Seeded and test fixture
 accounts are created verified. Unverified accounts can sign in and see their
 status on `/account`.
 
-Unverified accounts can still use browser sessions and complete OAuth flows
-(authorize + token exchange keep working so clients can finish login), but
-assistant features are blocked until the email is verified:
+Unverified accounts can still use browser sessions (sign in, manage account,
+resend verification), but they must verify before MCP OAuth authorization or
+assistant features:
 
-- **MCP**: `handleMcpRequest` in `packages/worker/src/mcp-auth.ts` is the single
-  chokepoint for `/mcp`. After token validation it checks
+- **Signup**: password signup keeps the authenticated session and lands on
+  `/pending-verification` (preserving a safe `redirectTo` such as an OAuth
+  authorize URL). Users can resend the verification email and continue once the
+  link succeeds; continue returns to `redirectTo` when present, otherwise
+  `/onboarding`.
+- **Onboarding** (`/onboarding`): verified users only. Unverified HTML requests
+  redirect to `/pending-verification`. Loader/API data still exposes
+  `emailVerified` and withholds MCP URL/setup until verified as defense in
+  depth. `needsOnboarding` means incomplete overall setup (`!emailVerified` or
+  no MCP grant). Account keeps an inline verification card for resend/status;
+  home and account banners do not show the connect-agent callout while
+  unverified.
+- **MCP OAuth authorize**: `/oauth/authorize` rejects approval before creating a
+  grant/token when the account email is unverified
+  (`403 email_verification_required`). The authorize UI keeps inline
+  verification/resend controls and the original OAuth query so verification in
+  another tab can resume without restarting the host connection.
+- **MCP requests**: `handleMcpRequest` in `packages/worker/src/mcp-auth.ts` is
+  the single chokepoint for `/mcp`. After token validation it checks
   `users.email_verified_at` (via `isAccountEmailVerified`) and rejects
   unverified — or unidentifiable — accounts with a
   `403 email_verification_required` JSON response pointing at `/account`. The
@@ -345,7 +363,12 @@ routed from `packages/worker/src/index.ts`.
 - Supported scopes: `profile`, `email`
 - On `/oauth/authorize`, unauthenticated users can log in inline or via top-nav
   auth links; those links preserve the full authorize URL in `redirectTo` so
-  successful login/signup returns to the original OAuth request
+  successful login returns to the original OAuth request. Password signup lands
+  on `/pending-verification` with that safe `redirectTo` preserved for
+  continue-after-verify. The authorize tab itself should stay open when the
+  email link is opened elsewhere, so the original OAuth query remains resumable.
+- Approval is rejected before `completeAuthorization` when the account email is
+  unverified, so no grant/token is created until verification succeeds.
 
 `/mcp` is protected by `packages/worker/src/mcp-auth.ts`:
 

--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -61,7 +61,13 @@ callback replay finds no matching state.
   `kody.mcp["<server-name>"].<tool>(input)` and are never exposed as flat
   `kody.*` functions. Search capability detail returns the exact accessor.
 - Tool calls flow worker → hub DO `callTool` → `MCPClientManager.callTool` →
-  remote server. Structured content is returned directly when present.
+  remote server. At the synthesized capability boundary, results are wrapped
+  with explicit `__mcpContent` / companion markers when protocol content must
+  reach the upstream client (especially non-text blocks such as images).
+  Structured content remains available for code; `isError` is preserved. See
+  [Raw MCP content blocks](../../use/raw-content-blocks.md).
+- Malformed third-party content blocks are rejected with a source-specific
+  error. Image/audio URL-only payloads are not fetched.
 
 ## Management surfaces
 

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -90,11 +90,13 @@ primitives:
       Signed kody_session cookie auth for browser users; production signup
       invite-gated with a Kit-backed public waiting list on /signup
       (non-production signup open), account email verification surfaced in
-      session state, social login (GitHub/Google/X OAuth connections in
-      oauth_connections, mockable via MOCK_ client ids on non-production
-      runtimes), and opt-in second factors — TOTP two-factor (verifications
-      table, pending kody_verify cookie gates login until /verify) and passkeys
-      (WebAuthn sign-in as an alternative first factor that still honors 2FA).
+      session state and a dedicated `/pending-verification` experience after
+      password signup, MCP OAuth authorize gated until verified, social login
+      (GitHub/Google/X OAuth connections in oauth_connections, mockable via
+      MOCK_ client ids on non-production runtimes), and opt-in second factors —
+      TOTP two-factor (verifications table, pending kody_verify cookie gates
+      login until /verify) and passkeys (WebAuthn sign-in as an alternative
+      first factor that still honors 2FA).
     code:
       - packages/worker/src/app/auth-session.ts
       - packages/worker/src/app/handlers/auth.ts
@@ -107,9 +109,12 @@ primitives:
       - packages/worker/src/app/oauth-login-errors.ts
       - packages/worker/migrations/0056-oauth-connections.sql
       - packages/worker/src/app/handlers/verify-email.ts
+      - packages/worker/src/app/handlers/pending-verification.ts
       - packages/worker/src/app/handlers/admin-invites.ts
       - packages/worker/src/app/invites.ts
       - packages/worker/src/app/email-verification.ts
+      - packages/worker/src/app/onboarding-data.ts
+      - packages/worker/src/oauth-handlers.ts
       - packages/worker/src/app/two-factor.ts
       - packages/worker/src/app/verify-session.ts
       - packages/worker/src/app/passkeys.ts

--- a/docs/contributing/architecture/remote-connectors.md
+++ b/docs/contributing/architecture/remote-connectors.md
@@ -59,7 +59,10 @@ The Worker sends MCP-style requests over the WebSocket wrapped in
 
 - **`tools/call`** — Params: `{ name: string, arguments?: object }`. Return a
   normal MCP **`CallToolResult`**-compatible payload (content, structured
-  content, `isError`, etc.).
+  content, `isError`, etc.). When execute returns that capability result
+  directly, protocol-valid non-text content blocks (images, audio, resources)
+  pass through to the upstream MCP client; see
+  [Raw MCP content blocks](../../use/raw-content-blocks.md).
 
 If the Worker forwards **`notifications/tools/list_changed`**, the connector
 should re-list tools when it supports dynamic registration.

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -11,8 +11,12 @@ agent that supports MCP — not from a separate Kody chat app.
 3. Complete the OAuth flow when the host opens it. Sign in to Kody if needed,
    then approve access.
 
-MCP stays unavailable until your account email is verified. If authorize fails
-for that reason, verify from your account page and try again.
+Your account email must be verified before authorize can finish or MCP can run.
+If authorize asks you to verify, keep that tab open, finish verification (from
+the email link or `/pending-verification`), then continue. You do not need to
+restart the host connection. Unverified visits to Get started (`/onboarding`)
+redirect to `/pending-verification`; after verification, onboarding shows the
+MCP URL and setup prompt.
 
 ## Ask your agent to help set up
 

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -343,3 +343,11 @@ Readable non-secret configuration uses **`kody.value_get`** and
 By default, **`execute`** returns text output. To return non-text MCP content
 blocks such as images, return an object with a **`__mcpContent`** array instead;
 see [Raw MCP content blocks](./raw-content-blocks.md).
+
+The same passthrough applies when execute returns a result from a user-added MCP
+server or remote connector that already includes protocol image (or other
+non-text) content blocks.
+
+**`responseLimit`** caps ordinary JSON/text output (~100 KB by default).
+Protocol `__mcpContent` blocks use a separate ~512 KB content cap so valid
+images larger than 100 KB are not collapsed into truncated JSON.

--- a/docs/use/raw-content-blocks.md
+++ b/docs/use/raw-content-blocks.md
@@ -23,3 +23,33 @@ base64 string inside text.
 
 Use this only when the return value is genuinely a non-text content block. For
 normal structured data, return plain values and let `execute` serialize them.
+
+## Size limits
+
+`execute` has two separate caps:
+
+- **`responseLimit`** (~100 KB by default) applies to ordinary JSON/text return
+  values (and to structured companion data alongside protocol content).
+- **Protocol content** from `__mcpContent` (and from downstream MCP / remote
+  connector tools that pass through images, audio, or resources) uses a separate
+  ~512 KB serialized-content cap. Base64 expands binary by about 4/3, so a ~133
+  KB WebP is roughly ~177 KB of JSON and fits; oversized protocol content fails
+  explicitly instead of being truncated into unusable JSON text.
+
+## Downstream MCP servers and remote connectors
+
+When execute code calls a user-added MCP server (`kody.mcp[...]`) or remote
+connector (`kody.remote[...]`) and returns that capability result directly, Kody
+preserves protocol-valid MCP content blocks from the downstream tool — including
+`image`, `audio`, `resource`, and `resource_link` — and passes them through to
+the upstream MCP client.
+
+If the downstream tool returns both `structuredContent` and non-text `content`,
+structured data stays available for code (and in execute’s
+`structuredContent.result`) while the content blocks still pass through.
+
+Image and audio blocks must already be protocol-valid
+`{ type: 'image' | 'audio', data, mimeType }` with base64 `data`. Kody does not
+fetch image URLs from third-party payloads (SSRF / host-approval risk).
+Malformed blocks fail with a source-specific error naming the MCP server,
+connector tool, or execute `__mcpContent` return.

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -2,10 +2,11 @@
 
 ## MCP requests fail with `email_verification_required`
 
-Kody requires a verified account email before any MCP access. Open the
-verification link sent to the account email at signup, or sign in to the app and
-use **Resend verification email** on the `/account` page, then reconnect the MCP
-client.
+Kody requires a verified account email before any MCP access, including OAuth
+authorization. Open the verification link sent at signup, or sign in and use
+**Resend verification email** on `/pending-verification`, `/account`, or the
+authorize page. Keep an open `/oauth/authorize` tab so you can continue the same
+OAuth request after verifying in another tab, then reconnect or approve again.
 
 ## Search returns no good matches
 

--- a/e2e/invite-signup-verification.spec.ts
+++ b/e2e/invite-signup-verification.spec.ts
@@ -105,8 +105,12 @@ test('admin invite signup and email verification happy path', async ({
 	).toHaveCount(0)
 	await expect(page.getByText(/\/mcp/)).toHaveCount(0)
 
-	await page.goto('/onboarding')
-	await expect(page).toHaveURL(/\/pending-verification$/)
+	await page.goto(
+		`/onboarding?redirectTo=${encodeURIComponent('/oauth/authorize?client_id=e2e-onboarding')}`,
+	)
+	await expect(page).toHaveURL(
+		/\/pending-verification\?redirectTo=%2Foauth%2Fauthorize%3Fclient_id%3De2e-onboarding$/,
+	)
 	await expect(
 		page.getByRole('heading', { name: 'Add Kody as an MCP server' }),
 	).toHaveCount(0)

--- a/e2e/invite-signup-verification.spec.ts
+++ b/e2e/invite-signup-verification.spec.ts
@@ -93,10 +93,23 @@ test('admin invite signup and email verification happy path', async ({
 	await page.getByLabel('Password').fill(invitedPassword)
 	await page.getByLabel('Invite code').fill(inviteCode)
 	await page.getByRole('button', { name: 'Create account' }).click()
-	await expect(page).toHaveURL(/\/account$/)
+	await expect(page).toHaveURL(/\/pending-verification$/)
+	await expect(
+		page.getByRole('heading', { name: 'Check your email' }),
+	).toBeVisible()
 	await expect(
 		page.getByRole('heading', { name: 'Verify your email' }),
 	).toBeVisible()
+	await expect(
+		page.getByRole('heading', { name: 'Add Kody as an MCP server' }),
+	).toHaveCount(0)
+	await expect(page.getByText(/\/mcp/)).toHaveCount(0)
+
+	await page.goto('/onboarding')
+	await expect(page).toHaveURL(/\/pending-verification$/)
+	await expect(
+		page.getByRole('heading', { name: 'Add Kody as an MCP server' }),
+	).toHaveCount(0)
 
 	await page.getByRole('button', { name: 'Resend verification email' }).click()
 	await expect(async () => {
@@ -111,6 +124,14 @@ test('admin invite signup and email verification happy path', async ({
 			page.getByRole('heading', { name: 'Email verified' }),
 		).toBeVisible({ timeout: 1_000 })
 	}).toPass({ timeout: 15_000 })
+
+	await expect(page.getByText(/MCP access is now available/i)).toBeVisible()
+	await page.getByRole('link', { name: 'Continue to onboarding' }).click()
+	await expect(page).toHaveURL(/\/onboarding$/)
+	await expect(
+		page.getByRole('heading', { name: 'Add Kody as an MCP server' }),
+	).toBeVisible()
+	await expect(page.getByText(/\/mcp/)).toBeVisible()
 
 	await page.goto('/account')
 	await expect(

--- a/e2e/invite-signup-verification.spec.ts
+++ b/e2e/invite-signup-verification.spec.ts
@@ -112,13 +112,14 @@ test('admin invite signup and email verification happy path', async ({
 	).toHaveCount(0)
 
 	await page.getByRole('button', { name: 'Resend verification email' }).click()
+	const oauthResume = '/oauth/authorize?client_id=e2e-demo&response_type=code'
 	await expect(async () => {
 		await setEmailVerificationTokenInE2eDatabase({
 			email: invitedEmail,
 			token: verificationToken,
 		})
 		await page.goto(
-			`/verify-email?token=${encodeURIComponent(verificationToken)}`,
+			`/verify-email?token=${encodeURIComponent(verificationToken)}&redirectTo=${encodeURIComponent(oauthResume)}`,
 		)
 		await expect(
 			page.getByRole('heading', { name: 'Email verified' }),
@@ -126,7 +127,14 @@ test('admin invite signup and email verification happy path', async ({
 	}).toPass({ timeout: 15_000 })
 
 	await expect(page.getByText(/MCP access is now available/i)).toBeVisible()
-	await page.getByRole('link', { name: 'Continue to onboarding' }).click()
+	const continueAuthorization = page.getByRole('link', {
+		name: 'Continue authorization',
+	})
+	await expect(continueAuthorization).toHaveAttribute('href', oauthResume)
+	await continueAuthorization.click()
+	await expect(page).toHaveURL(/\/oauth\/authorize/)
+
+	await page.goto('/onboarding')
 	await expect(page).toHaveURL(/\/onboarding$/)
 	await expect(
 		page.getByRole('heading', { name: 'Add Kody as an MCP server' }),

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -13,7 +13,6 @@ import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import {
-	cardTitleCss,
 	descriptionCss,
 	fieldCss,
 	fieldLabelCss,
@@ -35,9 +34,12 @@ import {
 	AccountManagementPanel,
 	AccountManagementShell,
 	AccountPageHeader,
-	noticeCardCss,
 } from '#client/routes/account-management-components.tsx'
 import { renderOnboardingBanner } from '#client/routes/onboarding-banner.tsx'
+import {
+	renderEmailVerificationPrompt,
+	requestResendVerification,
+} from '#client/routes/email-verification-prompt.tsx'
 import {
 	fetchOnboardingPayload,
 	type OnboardingPayload,
@@ -69,7 +71,6 @@ type AccountConnectionsPayload = {
 	availableProviders: Array<AuthProviderInfo>
 }
 
-const resendVerificationApiPath = '/account/resend-verification.json'
 const emailChangeApiPath = '/account/email-change.json'
 const connectionsApiPath = '/account/connections.json'
 
@@ -312,34 +313,16 @@ export function AccountRoute(handle: Handle) {
 		handle.update()
 
 		try {
-			const response = await fetch(resendVerificationApiPath, {
-				method: 'POST',
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-			})
-			if (response.status === 401) {
+			const result = await requestResendVerification()
+			if (!result.ok && result.unauthorized) {
 				window.location.assign('/login')
 				return
 			}
-			const payload = await readJson<{
-				ok?: boolean
-				message?: string
-				error?: string
-			}>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error(
-					payload?.error || 'Unable to send the verification email.',
-				)
-			}
-			resendMessage =
-				payload.message ?? 'Verification email sent. Check your inbox.'
-			resendTone = 'info'
-		} catch (error) {
-			resendMessage =
-				error instanceof Error
-					? error.message
-					: 'Unable to send the verification email.'
+			resendTone = result.ok ? 'info' : 'error'
+			resendMessage = result.message
+		} catch {
 			resendTone = 'error'
+			resendMessage = 'Unable to send the verification email.'
 		} finally {
 			resendStatus = 'idle'
 			handle.update()
@@ -559,46 +542,21 @@ export function AccountRoute(handle: Handle) {
 
 				{status === 'ready' ? (
 					<>
-						{needsOnboarding ? renderOnboardingBanner() : null}
-						{!emailVerified ? (
-							<section
-								aria-label="Email verification status"
-								mix={css(noticeCardCss)}
-							>
-								<h2 mix={css(cardTitleCss)}>Verify your email</h2>
-								<p mix={css(descriptionCss)}>
-									Check your inbox for the verification link. MCP access and
-									email features stay disabled until this account email is
-									verified.
-								</p>
-								<div>
-									<button
-										type="button"
-										disabled={resendStatus === 'sending'}
-										mix={[
-											css(primaryButtonCss),
-											on('click', handleResendVerification),
-										]}
-									>
-										{resendStatus === 'sending'
-											? 'Sending...'
-											: 'Resend verification email'}
-									</button>
-								</div>
-								{resendMessage ? (
-									<p
-										role="status"
-										mix={css({
-											color:
-												resendTone === 'error' ? colors.error : colors.text,
-											margin: 0,
-										})}
-									>
-										{resendMessage}
-									</p>
-								) : null}
-							</section>
-						) : null}
+						{!emailVerified
+							? renderEmailVerificationPrompt({
+									description:
+										'Check your inbox for the verification link. MCP access and email features stay locked until this account email is verified.',
+									resendStatus,
+									resendMessage,
+									resendTone,
+									onResend: () => {
+										void handleResendVerification()
+									},
+									secondaryHref: '/pending-verification',
+									secondaryLabel: 'Verification page',
+								})
+							: null}
+						{emailVerified && needsOnboarding ? renderOnboardingBanner() : null}
 						<AccountManagementPanel
 							title="Profile"
 							description="Your username is unique and visible anywhere Kody needs a display name. Your email stays on the account for login."

--- a/packages/worker/client/routes/email-verification-prompt.tsx
+++ b/packages/worker/client/routes/email-verification-prompt.tsx
@@ -1,0 +1,151 @@
+import { css } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import { colors, spacing } from '#client/styles/tokens.ts'
+import {
+	cardCss,
+	cardTitleCss,
+	descriptionCss,
+	getPrimaryButtonCss,
+	getSecondaryButtonCss,
+	mutedLinkCss,
+} from '#client/styles/style-primitives.ts'
+
+export {
+	buildPendingVerificationPath,
+	pendingVerificationPath,
+} from '#client/routes/pending-verification-path.ts'
+
+export const resendVerificationApiPath = '/account/resend-verification.json'
+
+export type ResendVerificationResult =
+	| { ok: true; message: string }
+	| { ok: false; message: string; unauthorized?: boolean }
+
+export async function requestResendVerification(): Promise<ResendVerificationResult> {
+	const response = await fetch(resendVerificationApiPath, {
+		method: 'POST',
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+	})
+	if (response.status === 401) {
+		return {
+			ok: false,
+			message: 'Sign in again to resend the verification email.',
+			unauthorized: true,
+		}
+	}
+	const payload = (await response.json().catch(() => null)) as {
+		ok?: boolean
+		message?: string
+		error?: string
+	} | null
+	if (!response.ok || !payload?.ok) {
+		return {
+			ok: false,
+			message:
+				typeof payload?.error === 'string'
+					? payload.error
+					: 'Unable to resend the verification email.',
+		}
+	}
+	return {
+		ok: true,
+		message:
+			typeof payload.message === 'string'
+				? payload.message
+				: 'Verification email sent. Check your inbox.',
+	}
+}
+
+type EmailVerificationPromptOptions = {
+	email?: string | null
+	title?: string
+	description: string
+	resendStatus: 'idle' | 'sending'
+	resendMessage: string | null
+	resendTone?: 'error' | 'info'
+	onResend: () => void
+	continueLabel?: string | null
+	onContinue?: (() => void) | null
+	secondaryHref?: string | null
+	secondaryLabel?: string | null
+}
+
+/**
+ * Shared verify-email callout used by pending signup, account, and the MCP
+ * authorize gate. Keeps resend/continue actions consistent.
+ */
+export function renderEmailVerificationPrompt(
+	options: EmailVerificationPromptOptions,
+) {
+	const title = options.title ?? 'Verify your email'
+	const primaryButtonCss = getPrimaryButtonCss({
+		size: 'md',
+		weight: 'semibold',
+	})
+	const secondaryButtonCss = getSecondaryButtonCss({
+		size: 'md',
+		weight: 'semibold',
+	})
+
+	return (
+		<section
+			aria-label="Email verification status"
+			mix={css({
+				...cardCss,
+				borderColor: colors.primary,
+				backgroundColor: colors.primarySoftest,
+			})}
+		>
+			<h2 mix={css(cardTitleCss)}>{title}</h2>
+			<p mix={css(descriptionCss)}>{options.description}</p>
+			{options.email ? (
+				<p mix={css({ ...descriptionCss, margin: 0 })}>
+					Sent to <strong>{options.email}</strong>
+				</p>
+			) : null}
+			<div
+				mix={css({
+					display: 'flex',
+					gap: spacing.sm,
+					flexWrap: 'wrap',
+					alignItems: 'center',
+				})}
+			>
+				<button
+					type="button"
+					disabled={options.resendStatus === 'sending'}
+					mix={[css(primaryButtonCss), on('click', options.onResend)]}
+				>
+					{options.resendStatus === 'sending'
+						? 'Sending...'
+						: 'Resend verification email'}
+				</button>
+				{options.continueLabel && options.onContinue ? (
+					<button
+						type="button"
+						mix={[css(secondaryButtonCss), on('click', options.onContinue)]}
+					>
+						{options.continueLabel}
+					</button>
+				) : null}
+				{options.secondaryHref && options.secondaryLabel ? (
+					<a href={options.secondaryHref} mix={css(mutedLinkCss)}>
+						{options.secondaryLabel}
+					</a>
+				) : null}
+			</div>
+			{options.resendMessage ? (
+				<p
+					role="status"
+					mix={css({
+						color: options.resendTone === 'error' ? colors.error : colors.text,
+						margin: 0,
+					})}
+				>
+					{options.resendMessage}
+				</p>
+			) : null}
+		</section>
+	)
+}

--- a/packages/worker/client/routes/email-verification-prompt.tsx
+++ b/packages/worker/client/routes/email-verification-prompt.tsx
@@ -1,4 +1,5 @@
 import { css } from 'remix/ui'
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
 import { on } from '#client/event-mixin.ts'
 import { colors, spacing } from '#client/styles/tokens.ts'
 import {
@@ -21,11 +22,18 @@ export type ResendVerificationResult =
 	| { ok: true; message: string }
 	| { ok: false; message: string; unauthorized?: boolean }
 
-export async function requestResendVerification(): Promise<ResendVerificationResult> {
+export async function requestResendVerification(
+	redirectTo?: string | null,
+): Promise<ResendVerificationResult> {
+	const safeRedirectTo = normalizeRedirectTo(redirectTo)
 	const response = await fetch(resendVerificationApiPath, {
 		method: 'POST',
-		headers: { Accept: 'application/json' },
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+		},
 		credentials: 'include',
+		body: JSON.stringify(safeRedirectTo ? { redirectTo: safeRedirectTo } : {}),
 	})
 	if (response.status === 401) {
 		return {

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -9,6 +9,7 @@ import {
 	onboardingPath,
 	type OnboardingPayload,
 } from '#client/routes/onboarding.tsx'
+import { pendingVerificationPath } from '#client/routes/pending-verification-path.ts'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import {
 	colors,
@@ -74,11 +75,13 @@ export async function homeRouteLoader(
 
 export function HomeRoute(handle: Handle) {
 	let needsOnboarding = false
+	let emailVerified = false
 	let onboardingStatus: 'idle' | 'loading' | 'ready' = 'idle'
 	const loadLatch = createRouteLoadLatch()
 
 	function applyOnboardingPayload(payload: OnboardingPayload | null) {
 		needsOnboarding = payload?.needsOnboarding === true
+		emailVerified = payload?.emailVerified === true
 		onboardingStatus = 'ready'
 	}
 
@@ -126,7 +129,7 @@ export function HomeRoute(handle: Handle) {
 
 		return (
 			<section mix={css(pageCss)}>
-				{needsOnboarding ? (
+				{needsOnboarding && emailVerified ? (
 					<div
 						mix={css({
 							width: '100%',
@@ -155,9 +158,17 @@ export function HomeRoute(handle: Handle) {
 						Two tools. A vast capability graph behind them.
 					</p>
 					<div>
-						<a href={onboardingPath} mix={css(heroCtaCss)}>
-							Connect your agent
-						</a>
+						{onboardingStatus === 'ready' &&
+						needsOnboarding &&
+						!emailVerified ? (
+							<a href={pendingVerificationPath} mix={css(heroCtaCss)}>
+								Verify your email
+							</a>
+						) : (
+							<a href={onboardingPath} mix={css(heroCtaCss)}>
+								Connect your agent
+							</a>
+						)}
 					</div>
 				</section>
 

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -52,6 +52,10 @@ import { ConnectOauthRoute } from './connect-oauth.tsx'
 import { HomeRoute, homeRouteLoader } from './home.tsx'
 import { LoginRoute, authProvidersRouteLoader } from './login.tsx'
 import { OnboardingRoute, onboardingRouteLoader } from './onboarding.tsx'
+import {
+	PendingVerificationRoute,
+	pendingVerificationRouteLoader,
+} from './pending-verification.tsx'
 import { PrivacyRoute } from './privacy.tsx'
 import {
 	OAuthAuthorizeRoute,
@@ -95,6 +99,7 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 	'/signup': authProvidersRouteLoader,
 	'/oauth/authorize': oauthAuthorizeRouteLoader,
 	'/onboarding': onboardingRouteLoader,
+	'/pending-verification': pendingVerificationRouteLoader,
 }
 
 export const clientRoutes = {
@@ -129,6 +134,7 @@ export const clientRoutes = {
 	'/community/:listingId': <CommunityDetailRoute />,
 	'/login': <LoginRoute />,
 	'/onboarding': <OnboardingRoute />,
+	'/pending-verification': <PendingVerificationRoute />,
 	'/privacy': <PrivacyRoute />,
 	'/signup': <LoginRoute />,
 	'/reset-password': <ResetPasswordRoute />,

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -251,7 +251,13 @@ export function LoginRoute(handle: Handle) {
 					password,
 					mode,
 					rememberMe,
-					...(mode === 'signup' ? { username, inviteCode } : {}),
+					...(mode === 'signup'
+						? {
+								username,
+								inviteCode,
+								redirectTo: getCurrentRedirectTo(handle),
+							}
+						: {}),
 				}),
 			})
 			const payload = await response.json().catch(() => null)
@@ -351,19 +357,10 @@ export function LoginRoute(handle: Handle) {
 				return
 			}
 
-			if (verificationPayload.requiresTwoFactor === true) {
-				window.location.assign(
-					resolvePasswordAuthRedirect({
-						mode: 'login',
-						requiresTwoFactor: true,
-						redirectTo: getCurrentRedirectTo(handle),
-					}),
-				)
-				return
-			}
 			window.location.assign(
 				resolvePasswordAuthRedirect({
 					mode: 'login',
+					requiresTwoFactor: verificationPayload.requiresTwoFactor === true,
 					redirectTo: getCurrentRedirectTo(handle),
 				}),
 			)

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -3,6 +3,7 @@ import { type Handle, css } from 'remix/ui'
 import checkbox from 'remix/ui/checkbox'
 import { on } from '#client/event-mixin.ts'
 import { buildAuthLink } from '#client/auth-links.ts'
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
 import {
 	getPathname,
 	listenToRouterNavigation,
@@ -23,6 +24,7 @@ import {
 	type AuthProviderInfo,
 } from '#client/social-sign-in.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
+import { resolvePasswordAuthRedirect } from '#client/routes/resolve-password-auth-redirect.ts'
 import {
 	cardCss,
 	fieldCss,
@@ -41,13 +43,6 @@ import {
 type AuthMode = 'login' | 'signup'
 type AuthStatus = 'idle' | 'submitting' | 'success' | 'error'
 type SignupPanel = 'waiting-list' | 'invite'
-
-function normalizeRedirectTo(value: string | null) {
-	if (!value) return null
-	if (!value.startsWith('/')) return null
-	if (value.startsWith('//')) return null
-	return value
-}
 
 function shouldOpenInviteSignup(searchParams: URLSearchParams) {
 	if (searchParams.has('code') || searchParams.has('invite')) return true
@@ -70,12 +65,6 @@ function resolveSignupPanel(searchParams: URLSearchParams): SignupPanel {
 function buildAuthPath(mode: AuthMode, redirectTo: string | null) {
 	const path = mode === 'signup' ? '/signup' : '/login'
 	return buildAuthLink(path, redirectTo)
-}
-
-function buildVerifyPath(redirectTo: string | null) {
-	return redirectTo
-		? `/verify?redirectTo=${encodeURIComponent(redirectTo)}`
-		: '/verify'
 }
 
 function getAuthModeFromPathname(pathname: string): AuthMode {
@@ -277,11 +266,15 @@ export function LoginRoute(handle: Handle) {
 			}
 
 			if (typeof window !== 'undefined') {
-				if (payload?.requiresTwoFactor === true) {
-					window.location.assign(buildVerifyPath(getCurrentRedirectTo(handle)))
-					return
-				}
-				window.location.assign(getCurrentRedirectTo(handle) ?? '/account')
+				window.location.assign(
+					resolvePasswordAuthRedirect({
+						mode,
+						requiresTwoFactor: payload?.requiresTwoFactor === true,
+						emailVerificationRequired:
+							payload?.emailVerificationRequired === true,
+						redirectTo: getCurrentRedirectTo(handle),
+					}),
+				)
 			}
 		} catch {
 			setState('error', 'Network error. Please try again.')
@@ -359,10 +352,21 @@ export function LoginRoute(handle: Handle) {
 			}
 
 			if (verificationPayload.requiresTwoFactor === true) {
-				window.location.assign(buildVerifyPath(getCurrentRedirectTo(handle)))
+				window.location.assign(
+					resolvePasswordAuthRedirect({
+						mode: 'login',
+						requiresTwoFactor: true,
+						redirectTo: getCurrentRedirectTo(handle),
+					}),
+				)
 				return
 			}
-			window.location.assign(getCurrentRedirectTo(handle) ?? '/account')
+			window.location.assign(
+				resolvePasswordAuthRedirect({
+					mode: 'login',
+					redirectTo: getCurrentRedirectTo(handle),
+				}),
+			)
 		} catch {
 			setState('error', 'Network error. Please try again.')
 		}

--- a/packages/worker/client/routes/oauth-authorize-email-verified.node.test.ts
+++ b/packages/worker/client/routes/oauth-authorize-email-verified.node.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest'
+import { resolveAuthorizeEmailVerified } from '#client/routes/oauth-authorize-email-verified.ts'
+
+test('authorize emailVerified prefers a ready session over stale authorize-info', () => {
+	expect(
+		resolveAuthorizeEmailVerified({
+			isSessionReady: true,
+			sessionEmailVerified: false,
+			infoEmailVerified: true,
+		}),
+	).toBe(false)
+	expect(
+		resolveAuthorizeEmailVerified({
+			isSessionReady: true,
+			sessionEmailVerified: true,
+			infoEmailVerified: false,
+		}),
+	).toBe(true)
+	expect(
+		resolveAuthorizeEmailVerified({
+			isSessionReady: false,
+			sessionEmailVerified: false,
+			infoEmailVerified: true,
+		}),
+	).toBe(true)
+	expect(
+		resolveAuthorizeEmailVerified({
+			isSessionReady: false,
+			sessionEmailVerified: true,
+			infoEmailVerified: false,
+		}),
+	).toBe(false)
+})

--- a/packages/worker/client/routes/oauth-authorize-email-verified.ts
+++ b/packages/worker/client/routes/oauth-authorize-email-verified.ts
@@ -1,0 +1,15 @@
+/**
+ * Once the live session has loaded, it is authoritative for the authorize
+ * gate. Stale authorize-info metadata must not keep approval available after
+ * the server reports email_verification_required.
+ */
+export function resolveAuthorizeEmailVerified(input: {
+	isSessionReady: boolean
+	sessionEmailVerified?: boolean | null
+	infoEmailVerified?: boolean | null
+}) {
+	if (input.isSessionReady) {
+		return input.sessionEmailVerified === true
+	}
+	return input.infoEmailVerified === true
+}

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -6,6 +6,10 @@ import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readRouterSearch } from '#client/router-location.tsx'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import {
+	renderEmailVerificationPrompt,
+	requestResendVerification,
+} from '#client/routes/email-verification-prompt.tsx'
+import {
 	fetchSessionInfo,
 	getSessionDisplayName,
 	type SessionInfo,
@@ -35,6 +39,7 @@ import {
 type OAuthAuthorizeInfo = {
 	client: { id: string; name: string }
 	scopes: Array<string>
+	emailVerified: boolean | null
 }
 
 type OAuthAuthorizeStatus = 'idle' | 'loading' | 'ready' | 'error'
@@ -69,6 +74,7 @@ export async function oauthAuthorizeRouteLoader(
 				ok: false,
 				error: errorText,
 				allowClientReset: payload?.allowClientReset === true,
+				code: typeof payload?.code === 'string' ? payload.code : undefined,
 			},
 		}
 	}
@@ -77,6 +83,10 @@ export async function oauthAuthorizeRouteLoader(
 			ok: true,
 			client: payload.client,
 			scopes: payload.scopes,
+			emailVerified:
+				typeof payload.emailVerified === 'boolean'
+					? payload.emailVerified
+					: null,
 		},
 	}
 }
@@ -92,6 +102,9 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 	let resetCompleted = false
 	let allowClientReset = false
 	let activeInfoRequestId = 0
+	let resendStatus: 'idle' | 'sending' = 'idle'
+	let resendMessage: string | null = null
+	let resendTone: 'error' | 'info' = 'info'
 
 	function setMessage(next: OAuthAuthorizeMessage | null) {
 		message = next
@@ -130,6 +143,10 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 			info = {
 				client: payload.client,
 				scopes: payload.scopes,
+				emailVerified:
+					typeof payload.emailVerified === 'boolean'
+						? payload.emailVerified
+						: null,
 			}
 			status = 'ready'
 			allowClientReset = false
@@ -174,6 +191,10 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 			info = {
 				client: routeData.client,
 				scopes: routeData.scopes,
+				emailVerified:
+					typeof routeData.emailVerified === 'boolean'
+						? routeData.emailVerified
+						: null,
 			}
 			status = 'ready'
 			allowClientReset = false
@@ -185,6 +206,41 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 			message = { type: 'error', text: routeData.error }
 		}
 		return true
+	}
+
+	async function handleResendVerification() {
+		resendStatus = 'sending'
+		resendMessage = null
+		resendTone = 'info'
+		handle.update()
+		try {
+			const result = await requestResendVerification()
+			resendTone = result.ok ? 'info' : 'error'
+			resendMessage = result.message
+		} catch {
+			resendTone = 'error'
+			resendMessage = 'Unable to resend the verification email.'
+		} finally {
+			resendStatus = 'idle'
+			handle.update()
+		}
+	}
+
+	async function handleContinueAfterVerify() {
+		session = await fetchSessionInfo()
+		sessionStatus = 'ready'
+		activeInfoRequestId += 1
+		const requestId = activeInfoRequestId
+		await loadInfo(requestId)
+		if (session?.emailVerified) {
+			resendTone = 'info'
+			resendMessage = 'Email verified. You can approve the connection now.'
+		} else {
+			resendTone = 'info'
+			resendMessage =
+				'Still waiting on verification. Keep this page open, finish verification in another tab, then continue.'
+		}
+		handle.update()
 	}
 
 	async function submitDecision(
@@ -230,6 +286,10 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 						? payload.error
 						: 'Unable to complete authorization.'
 				setMessage({ type: 'error', text: errorText })
+				if (payload?.code === 'email_verification_required') {
+					session = await fetchSessionInfo()
+					sessionStatus = 'ready'
+				}
 				submittingDecision = null
 				handle.update()
 				return
@@ -310,10 +370,16 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		const isSessionLoading =
 			sessionStatus === 'loading' || sessionStatus === 'idle'
 		const isLoggedIn = isSessionReady && Boolean(sessionEmail)
+		const emailVerified =
+			session?.emailVerified === true || info?.emailVerified === true
+		const needsEmailVerification = isLoggedIn && !emailVerified
 		const showResetClientCard = allowClientReset && !resetCompleted
-		const showAuthorizeForm = !resetCompleted
+		const showAuthorizeForm = !resetCompleted && !needsEmailVerification
 		const actionsDisabled =
-			status !== 'ready' || Boolean(submittingDecision) || isSessionLoading
+			status !== 'ready' ||
+			Boolean(submittingDecision) ||
+			isSessionLoading ||
+			needsEmailVerification
 		const resetClientDisabled =
 			Boolean(submittingDecision) || isSessionLoading || !isLoggedIn
 		const formReady = status === 'ready' && !isSessionLoading
@@ -357,9 +423,42 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 						<p mix={css(descriptionCss)}>
 							{resetCompleted
 								? 'Start the connection again from your client to continue with this account.'
-								: 'Approve to continue with this account.'}
+								: needsEmailVerification
+									? 'Verify your email before approving MCP access. Keep this page open so the original OAuth request is preserved.'
+									: 'Approve to continue with this account.'}
 						</p>
 					</section>
+				) : null}
+				{needsEmailVerification
+					? renderEmailVerificationPrompt({
+							email: sessionEmail,
+							description:
+								'MCP authorization cannot finish until this account email is verified. Resend the link here if needed. Keep this page open, verify in another tab, then continue without restarting the host connection.',
+							resendStatus,
+							resendMessage,
+							resendTone,
+							onResend: () => {
+								void handleResendVerification()
+							},
+							continueLabel: "I've verified - continue",
+							onContinue: () => {
+								void handleContinueAfterVerify()
+							},
+						})
+					: null}
+				{needsEmailVerification && !resetCompleted ? (
+					<div mix={css({ marginBottom: spacing.md })}>
+						<button
+							type="button"
+							disabled={Boolean(submittingDecision) || isSessionLoading}
+							mix={[
+								on('click', () => submitDecision('deny')),
+								css(secondaryButtonCss),
+							]}
+						>
+							Deny
+						</button>
+					</div>
 				) : null}
 				{status === 'loading' ? (
 					<p mix={css(descriptionCss)}>Loading authorization details...</p>

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -1,4 +1,5 @@
 import { type Handle, css } from 'remix/ui'
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { on } from '#client/event-mixin.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
@@ -9,6 +10,7 @@ import {
 	renderEmailVerificationPrompt,
 	requestResendVerification,
 } from '#client/routes/email-verification-prompt.tsx'
+import { resolveAuthorizeEmailVerified } from '#client/routes/oauth-authorize-email-verified.ts'
 import {
 	fetchSessionInfo,
 	getSessionDisplayName,
@@ -208,13 +210,21 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		return true
 	}
 
+	function readOAuthResumeTarget() {
+		const currentUrl = new URL(
+			readCurrentRouterHref(handle),
+			'http://localhost',
+		)
+		return normalizeRedirectTo(`${currentUrl.pathname}${currentUrl.search}`)
+	}
+
 	async function handleResendVerification() {
 		resendStatus = 'sending'
 		resendMessage = null
 		resendTone = 'info'
 		handle.update()
 		try {
-			const result = await requestResendVerification()
+			const result = await requestResendVerification(readOAuthResumeTarget())
 			resendTone = result.ok ? 'info' : 'error'
 			resendMessage = result.message
 		} catch {
@@ -370,8 +380,11 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		const isSessionLoading =
 			sessionStatus === 'loading' || sessionStatus === 'idle'
 		const isLoggedIn = isSessionReady && Boolean(sessionEmail)
-		const emailVerified =
-			session?.emailVerified === true || info?.emailVerified === true
+		const emailVerified = resolveAuthorizeEmailVerified({
+			isSessionReady,
+			sessionEmailVerified: session?.emailVerified,
+			infoEmailVerified: info?.emailVerified,
+		})
 		const needsEmailVerification = isLoggedIn && !emailVerified
 		const showResetClientCard = allowClientReset && !resetCompleted
 		const showAuthorizeForm = !resetCompleted && !needsEmailVerification

--- a/packages/worker/client/routes/onboarding-banner.tsx
+++ b/packages/worker/client/routes/onboarding-banner.tsx
@@ -9,7 +9,7 @@ import {
 import { onboardingPath } from '#client/routes/onboarding.tsx'
 
 /**
- * Callout shown when the signed-in user has never authorized an MCP host.
+ * Callout shown when the signed-in verified user still needs MCP host setup.
  */
 export function renderOnboardingBanner() {
 	return (

--- a/packages/worker/client/routes/onboarding-redirect.node.test.ts
+++ b/packages/worker/client/routes/onboarding-redirect.node.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from 'vitest'
+import {
+	buildOnboardingPath,
+	onboardingPath,
+	resolveOnboardingLoginPath,
+	resolveOnboardingPendingVerificationPath,
+} from '#client/routes/onboarding-redirect.ts'
+
+test('onboarding redirect helpers preserve safe redirectTo and reject open redirects', () => {
+	const oauthResume = '/oauth/authorize?client_id=demo&state=abc'
+
+	expect(buildOnboardingPath(null)).toBe(onboardingPath)
+	expect(buildOnboardingPath(oauthResume)).toBe(
+		`/onboarding?redirectTo=${encodeURIComponent(oauthResume)}`,
+	)
+	expect(buildOnboardingPath('https://evil.example')).toBe(onboardingPath)
+	expect(buildOnboardingPath('/\\evil.example')).toBe(onboardingPath)
+
+	expect(resolveOnboardingPendingVerificationPath(null)).toBe(
+		'/pending-verification',
+	)
+	expect(resolveOnboardingPendingVerificationPath(oauthResume)).toBe(
+		`/pending-verification?redirectTo=${encodeURIComponent(oauthResume)}`,
+	)
+	expect(resolveOnboardingPendingVerificationPath('https://evil.example')).toBe(
+		'/pending-verification',
+	)
+	expect(resolveOnboardingPendingVerificationPath('/\\evil.example')).toBe(
+		'/pending-verification',
+	)
+
+	expect(resolveOnboardingLoginPath(null)).toBe(
+		'/login?redirectTo=%2Fonboarding',
+	)
+	expect(resolveOnboardingLoginPath(oauthResume)).toBe(
+		`/login?redirectTo=${encodeURIComponent(buildOnboardingPath(oauthResume))}`,
+	)
+	expect(resolveOnboardingLoginPath('https://evil.example')).toBe(
+		'/login?redirectTo=%2Fonboarding',
+	)
+})

--- a/packages/worker/client/routes/onboarding-redirect.ts
+++ b/packages/worker/client/routes/onboarding-redirect.ts
@@ -1,0 +1,34 @@
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
+import { buildAuthLink } from '#client/auth-links.ts'
+import { buildPendingVerificationPath } from '#client/routes/pending-verification-path.ts'
+
+export const onboardingPath = '/onboarding'
+
+/**
+ * Onboarding URL, optionally carrying a safe nested resume target (for example
+ * an OAuth authorize path) through verification or login.
+ */
+export function buildOnboardingPath(redirectTo?: string | null) {
+	const safeRedirectTo = normalizeRedirectTo(redirectTo)
+	if (!safeRedirectTo) return onboardingPath
+	const params = new URLSearchParams({ redirectTo: safeRedirectTo })
+	return `${onboardingPath}?${params.toString()}`
+}
+
+/**
+ * Destination for unverified onboarding visitors. Preserves only a normalized
+ * same-origin redirectTo so SPA behavior matches the server handler.
+ */
+export function resolveOnboardingPendingVerificationPath(
+	redirectTo?: string | null,
+) {
+	return buildPendingVerificationPath(redirectTo)
+}
+
+/**
+ * Login return path that keeps the user on onboarding and, when present, the
+ * nested safe redirectTo after they authenticate again.
+ */
+export function resolveOnboardingLoginPath(redirectTo?: string | null) {
+	return buildAuthLink('/login', buildOnboardingPath(redirectTo))
+}

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -1,9 +1,11 @@
 import { type Handle, css } from 'remix/ui'
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { readRouterSearch } from '#client/router-location.tsx'
 import {
 	type AccountStatus,
 	readJson,
@@ -18,7 +20,11 @@ import {
 	AccountManagementShell,
 } from '#client/routes/account-management-components.tsx'
 import { renderByokExplainer } from '#client/routes/byok-explainer.tsx'
-import { pendingVerificationPath } from '#client/routes/pending-verification-path.ts'
+import {
+	onboardingPath,
+	resolveOnboardingLoginPath,
+	resolveOnboardingPendingVerificationPath,
+} from '#client/routes/onboarding-redirect.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
@@ -29,7 +35,6 @@ import {
 	mutedLinkCss,
 	primaryLinkCss,
 } from '#client/styles/style-primitives.ts'
-import { buildAuthLink } from '#client/auth-links.ts'
 
 export type OnboardingPayload = {
 	ok: true
@@ -41,34 +46,39 @@ export type OnboardingPayload = {
 }
 
 export const onboardingApiPath = '/onboarding.json'
-export const onboardingPath = '/onboarding'
+export { onboardingPath }
 
 function isOnboardingPath(href: string) {
 	return new URL(href, 'http://localhost').pathname === onboardingPath
 }
 
-function redirectUnverifiedOnboarding() {
-	return routeLoaderRedirect(pendingVerificationPath)
+function readOnboardingRedirectTo(handle: Handle) {
+	return normalizeRedirectTo(
+		new URLSearchParams(readRouterSearch(handle)).get('redirectTo'),
+	)
 }
 
 export async function onboardingRouteLoader(
-	_url: URL,
+	url: URL,
 	signal: AbortSignal,
 ): Promise<RouteLoaderResult> {
+	const redirectTo = normalizeRedirectTo(url.searchParams.get('redirectTo'))
 	const response = await fetch(onboardingApiPath, {
 		headers: { Accept: 'application/json' },
 		credentials: 'include',
 		signal,
 	})
 	if (response.status === 401) {
-		return routeLoaderRedirect(buildAuthLink('/login', onboardingPath))
+		return routeLoaderRedirect(resolveOnboardingLoginPath(redirectTo))
 	}
 	const payload = await readJson<OnboardingPayload>(response)
 	if (!response.ok || !payload?.ok) {
 		throw new Error('Unable to load onboarding.')
 	}
 	if (!payload.emailVerified) {
-		return redirectUnverifiedOnboarding()
+		return routeLoaderRedirect(
+			resolveOnboardingPendingVerificationPath(redirectTo),
+		)
 	}
 	return { onboarding: payload }
 }
@@ -103,6 +113,7 @@ export function OnboardingRoute(handle: Handle) {
 
 	async function loadOnboarding(signal: AbortSignal) {
 		const href = readCurrentRouterHref(handle)
+		const redirectTo = readOnboardingRedirectTo(handle)
 		try {
 			const response = await fetch(onboardingApiPath, {
 				headers: { Accept: 'application/json' },
@@ -111,7 +122,7 @@ export function OnboardingRoute(handle: Handle) {
 			})
 			if (signal.aborted) return
 			if (response.status === 401) {
-				window.location.assign(buildAuthLink('/login', onboardingPath))
+				window.location.assign(resolveOnboardingLoginPath(redirectTo))
 				return
 			}
 			const payload = await readJson<OnboardingPayload>(response)
@@ -119,7 +130,9 @@ export function OnboardingRoute(handle: Handle) {
 				throw new Error('Unable to load onboarding.')
 			}
 			if (!payload.emailVerified) {
-				window.location.assign(pendingVerificationPath)
+				window.location.assign(
+					resolveOnboardingPendingVerificationPath(redirectTo),
+				)
 				return
 			}
 			applyPayload(payload)
@@ -140,7 +153,11 @@ export function OnboardingRoute(handle: Handle) {
 		const routeData = tryConsumeRouteLoaderData(handle, 'onboarding', href)
 		if (!routeData) return false
 		if (!routeData.emailVerified) {
-			window.location.assign(pendingVerificationPath)
+			window.location.assign(
+				resolveOnboardingPendingVerificationPath(
+					readOnboardingRedirectTo(handle),
+				),
+			)
 			return true
 		}
 		applyPayload(routeData)

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -18,6 +18,7 @@ import {
 	AccountManagementShell,
 } from '#client/routes/account-management-components.tsx'
 import { renderByokExplainer } from '#client/routes/byok-explainer.tsx'
+import { pendingVerificationPath } from '#client/routes/pending-verification-path.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
@@ -28,12 +29,14 @@ import {
 	mutedLinkCss,
 	primaryLinkCss,
 } from '#client/styles/style-primitives.ts'
+import { buildAuthLink } from '#client/auth-links.ts'
 
 export type OnboardingPayload = {
 	ok: true
 	mcpServerUrl: string
 	setupPrompt: string
 	hasMcpClient: boolean
+	emailVerified: boolean
 	needsOnboarding: boolean
 }
 
@@ -42,6 +45,10 @@ export const onboardingPath = '/onboarding'
 
 function isOnboardingPath(href: string) {
 	return new URL(href, 'http://localhost').pathname === onboardingPath
+}
+
+function redirectUnverifiedOnboarding() {
+	return routeLoaderRedirect(pendingVerificationPath)
 }
 
 export async function onboardingRouteLoader(
@@ -54,11 +61,14 @@ export async function onboardingRouteLoader(
 		signal,
 	})
 	if (response.status === 401) {
-		return routeLoaderRedirect('/login')
+		return routeLoaderRedirect(buildAuthLink('/login', onboardingPath))
 	}
 	const payload = await readJson<OnboardingPayload>(response)
 	if (!response.ok || !payload?.ok) {
 		throw new Error('Unable to load onboarding.')
+	}
+	if (!payload.emailVerified) {
+		return redirectUnverifiedOnboarding()
 	}
 	return { onboarding: payload }
 }
@@ -101,12 +111,16 @@ export function OnboardingRoute(handle: Handle) {
 			})
 			if (signal.aborted) return
 			if (response.status === 401) {
-				window.location.assign('/login?redirectTo=%2Fonboarding')
+				window.location.assign(buildAuthLink('/login', onboardingPath))
 				return
 			}
 			const payload = await readJson<OnboardingPayload>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load onboarding.')
+			}
+			if (!payload.emailVerified) {
+				window.location.assign(pendingVerificationPath)
+				return
 			}
 			applyPayload(payload)
 			loadLatch.markLoaded(href)
@@ -125,6 +139,10 @@ export function OnboardingRoute(handle: Handle) {
 		if (!isOnboardingPath(href)) return false
 		const routeData = tryConsumeRouteLoaderData(handle, 'onboarding', href)
 		if (!routeData) return false
+		if (!routeData.emailVerified) {
+			window.location.assign(pendingVerificationPath)
+			return true
+		}
 		applyPayload(routeData)
 		loadLatch.markLoaded(href)
 		return true
@@ -200,10 +218,6 @@ export function OnboardingRoute(handle: Handle) {
 								When your agent connects, it starts an OAuth flow. Sign in to
 								Kody if needed, approve the request, and the agent receives a
 								token scoped to your account.
-							</p>
-							<p mix={css(descriptionCss)}>
-								Verify your account email first if you have not already — MCP
-								access stays disabled until the email is verified.
 							</p>
 						</section>
 

--- a/packages/worker/client/routes/pending-verification-continue.node.test.ts
+++ b/packages/worker/client/routes/pending-verification-continue.node.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'vitest'
+import { resolveContinueVerificationFeedback } from '#client/routes/pending-verification-continue.ts'
+
+test('continue-after-verify treats missing session as an actionable error', () => {
+	expect(resolveContinueVerificationFeedback({ emailVerified: true })).toEqual({
+		status: 'verified',
+		tone: 'info',
+		message: null,
+	})
+	expect(resolveContinueVerificationFeedback({ emailVerified: false })).toEqual(
+		{
+			status: 'pending',
+			tone: 'info',
+			message:
+				'Still waiting on verification. Open the link from your email, then try again.',
+		},
+	)
+	expect(resolveContinueVerificationFeedback(null)).toEqual({
+		status: 'error',
+		tone: 'error',
+		message: 'Unable to check verification status. Try again.',
+	})
+})

--- a/packages/worker/client/routes/pending-verification-continue.ts
+++ b/packages/worker/client/routes/pending-verification-continue.ts
@@ -1,0 +1,29 @@
+/**
+ * Maps a session probe on the pending-verification continue control to UI
+ * feedback. A missing session is treated as a check failure (network or
+ * signed-out), not as "still waiting".
+ */
+export function resolveContinueVerificationFeedback(
+	session: { emailVerified: boolean } | null,
+) {
+	if (session?.emailVerified) {
+		return {
+			status: 'verified' as const,
+			tone: 'info' as const,
+			message: null,
+		}
+	}
+	if (!session) {
+		return {
+			status: 'error' as const,
+			tone: 'error' as const,
+			message: 'Unable to check verification status. Try again.',
+		}
+	}
+	return {
+		status: 'pending' as const,
+		tone: 'info' as const,
+		message:
+			'Still waiting on verification. Open the link from your email, then try again.',
+	}
+}

--- a/packages/worker/client/routes/pending-verification-path.node.test.ts
+++ b/packages/worker/client/routes/pending-verification-path.node.test.ts
@@ -3,21 +3,41 @@ import {
 	buildPendingVerificationPath,
 	resolvePostVerificationRedirect,
 } from '#client/routes/pending-verification-path.ts'
-import { normalizeRedirectTo } from '#app/safe-redirect.ts'
+import {
+	normalizeRedirectTo,
+	resolveVerifyEmailSuccessCta,
+} from '#app/safe-redirect.ts'
 
 test('safe redirect helpers reject open redirects and preserve same-origin paths', () => {
 	expect(normalizeRedirectTo('/oauth/authorize?client_id=1')).toBe(
 		'/oauth/authorize?client_id=1',
 	)
+	expect(normalizeRedirectTo('/account#security')).toBe('/account#security')
+	expect(normalizeRedirectTo('/path%20with%20spaces')).toBe(
+		'/path%20with%20spaces',
+	)
 	expect(normalizeRedirectTo('https://evil.example')).toBeNull()
 	expect(normalizeRedirectTo('//evil.example')).toBeNull()
+	expect(normalizeRedirectTo('/\\evil.example')).toBeNull()
+	expect(normalizeRedirectTo('/\\\\evil.example')).toBeNull()
+	expect(normalizeRedirectTo('/%5cevil.example')).toBeNull()
+	expect(normalizeRedirectTo('/%5Cevil.example')).toBeNull()
+	expect(normalizeRedirectTo('/\tevil.example')).toBeNull()
+	expect(normalizeRedirectTo('/evil\n.example')).toBeNull()
+	expect(normalizeRedirectTo('/%00evil')).toBeNull()
+	expect(normalizeRedirectTo('/%0aevil')).toBeNull()
+	expect(normalizeRedirectTo('/%2f%2fevil.example')).toBe('/%2f%2fevil.example')
 	expect(normalizeRedirectTo(null)).toBeNull()
+	expect(normalizeRedirectTo('')).toBeNull()
 
 	expect(buildPendingVerificationPath(null)).toBe('/pending-verification')
 	expect(buildPendingVerificationPath('/onboarding')).toBe(
 		'/pending-verification?redirectTo=%2Fonboarding',
 	)
 	expect(buildPendingVerificationPath('https://evil.example')).toBe(
+		'/pending-verification',
+	)
+	expect(buildPendingVerificationPath('/\\evil.example')).toBe(
 		'/pending-verification',
 	)
 
@@ -28,4 +48,17 @@ test('safe redirect helpers reject open redirects and preserve same-origin paths
 	expect(resolvePostVerificationRedirect('https://evil.example')).toBe(
 		'/onboarding',
 	)
+
+	expect(resolveVerifyEmailSuccessCta('/oauth/authorize?client_id=1')).toEqual({
+		href: '/oauth/authorize?client_id=1',
+		label: 'Continue authorization',
+		message:
+			'Your email address has been verified. MCP access is now available. Continue authorization to finish connecting your AI agent.',
+	})
+	expect(resolveVerifyEmailSuccessCta('https://evil.example')).toEqual({
+		href: '/onboarding',
+		label: 'Continue to onboarding',
+		message:
+			'Your email address has been verified. MCP access is now available. Continue onboarding to connect your AI agent.',
+	})
 })

--- a/packages/worker/client/routes/pending-verification-path.node.test.ts
+++ b/packages/worker/client/routes/pending-verification-path.node.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'vitest'
+import {
+	buildPendingVerificationPath,
+	resolvePostVerificationRedirect,
+} from '#client/routes/pending-verification-path.ts'
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
+
+test('safe redirect helpers reject open redirects and preserve same-origin paths', () => {
+	expect(normalizeRedirectTo('/oauth/authorize?client_id=1')).toBe(
+		'/oauth/authorize?client_id=1',
+	)
+	expect(normalizeRedirectTo('https://evil.example')).toBeNull()
+	expect(normalizeRedirectTo('//evil.example')).toBeNull()
+	expect(normalizeRedirectTo(null)).toBeNull()
+
+	expect(buildPendingVerificationPath(null)).toBe('/pending-verification')
+	expect(buildPendingVerificationPath('/onboarding')).toBe(
+		'/pending-verification?redirectTo=%2Fonboarding',
+	)
+	expect(buildPendingVerificationPath('https://evil.example')).toBe(
+		'/pending-verification',
+	)
+
+	expect(resolvePostVerificationRedirect(null)).toBe('/onboarding')
+	expect(resolvePostVerificationRedirect('/oauth/authorize?x=1')).toBe(
+		'/oauth/authorize?x=1',
+	)
+	expect(resolvePostVerificationRedirect('https://evil.example')).toBe(
+		'/onboarding',
+	)
+})

--- a/packages/worker/client/routes/pending-verification-path.ts
+++ b/packages/worker/client/routes/pending-verification-path.ts
@@ -1,4 +1,9 @@
-import { normalizeRedirectTo } from '#app/safe-redirect.ts'
+import {
+	normalizeRedirectTo,
+	resolvePostVerificationRedirect,
+} from '#app/safe-redirect.ts'
+
+export { resolvePostVerificationRedirect }
 
 export const pendingVerificationPath = '/pending-verification'
 
@@ -11,9 +16,4 @@ export function buildPendingVerificationPath(redirectTo?: string | null) {
 	if (!safeRedirectTo) return pendingVerificationPath
 	const params = new URLSearchParams({ redirectTo: safeRedirectTo })
 	return `${pendingVerificationPath}?${params.toString()}`
-}
-
-/** Destination after email verification succeeds from the pending page. */
-export function resolvePostVerificationRedirect(redirectTo?: string | null) {
-	return normalizeRedirectTo(redirectTo) ?? '/onboarding'
 }

--- a/packages/worker/client/routes/pending-verification-path.ts
+++ b/packages/worker/client/routes/pending-verification-path.ts
@@ -1,0 +1,19 @@
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
+
+export const pendingVerificationPath = '/pending-verification'
+
+/**
+ * Pending-verification URL, optionally carrying a safe post-verify redirect
+ * (for example an OAuth authorize path with its original query).
+ */
+export function buildPendingVerificationPath(redirectTo?: string | null) {
+	const safeRedirectTo = normalizeRedirectTo(redirectTo)
+	if (!safeRedirectTo) return pendingVerificationPath
+	const params = new URLSearchParams({ redirectTo: safeRedirectTo })
+	return `${pendingVerificationPath}?${params.toString()}`
+}
+
+/** Destination after email verification succeeds from the pending page. */
+export function resolvePostVerificationRedirect(redirectTo?: string | null) {
+	return normalizeRedirectTo(redirectTo) ?? '/onboarding'
+}

--- a/packages/worker/client/routes/pending-verification.tsx
+++ b/packages/worker/client/routes/pending-verification.tsx
@@ -15,6 +15,7 @@ import {
 	renderEmailVerificationPrompt,
 	requestResendVerification,
 } from '#client/routes/email-verification-prompt.tsx'
+import { resolveContinueVerificationFeedback } from '#client/routes/pending-verification-continue.ts'
 import {
 	pendingVerificationPath,
 	resolvePostVerificationRedirect,
@@ -119,7 +120,9 @@ export function PendingVerificationRoute(handle: Handle) {
 		resendTone = 'info'
 		handle.update()
 		try {
-			const result = await requestResendVerification()
+			const result = await requestResendVerification(
+				readPendingRedirectTo(handle),
+			)
 			if (!result.ok && result.unauthorized) {
 				window.location.assign(buildLoginRedirectForPending(handle))
 				return
@@ -136,16 +139,21 @@ export function PendingVerificationRoute(handle: Handle) {
 	}
 
 	async function handleContinue() {
-		const session = await fetchSessionInfo()
-		if (session?.emailVerified) {
-			window.location.assign(
-				resolvePostVerificationRedirect(readPendingRedirectTo(handle)),
-			)
-			return
+		try {
+			const session = await fetchSessionInfo()
+			const feedback = resolveContinueVerificationFeedback(session)
+			if (feedback.status === 'verified') {
+				window.location.assign(
+					resolvePostVerificationRedirect(readPendingRedirectTo(handle)),
+				)
+				return
+			}
+			resendTone = feedback.tone
+			resendMessage = feedback.message
+		} catch {
+			resendTone = 'error'
+			resendMessage = 'Unable to check verification status. Try again.'
 		}
-		resendTone = 'info'
-		resendMessage =
-			'Still waiting on verification. Open the link from your email, then try again.'
 		handle.update()
 	}
 

--- a/packages/worker/client/routes/pending-verification.tsx
+++ b/packages/worker/client/routes/pending-verification.tsx
@@ -1,0 +1,220 @@
+import { type Handle, css } from 'remix/ui'
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { createRouteLoadLatch } from '#client/route-load-latch.ts'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { type AccountStatus } from '#client/routes/account-approval-shared.ts'
+import {
+	AccountManagementHeader,
+	AccountManagementMessage,
+	AccountManagementShell,
+} from '#client/routes/account-management-components.tsx'
+import {
+	buildPendingVerificationPath,
+	renderEmailVerificationPrompt,
+	requestResendVerification,
+} from '#client/routes/email-verification-prompt.tsx'
+import {
+	pendingVerificationPath,
+	resolvePostVerificationRedirect,
+} from '#client/routes/pending-verification-path.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
+import { fetchSessionInfo } from '#client/session.ts'
+import { colors } from '#client/styles/tokens.ts'
+import { layoutMaxWidths } from '#client/styles/style-primitives.ts'
+import { readRouterSearch } from '#client/router-location.tsx'
+import { type PendingVerificationLoaderData } from '#app/loader-data.ts'
+import { buildAuthLink } from '#client/auth-links.ts'
+
+function isPendingVerificationPath(href: string) {
+	return new URL(href, 'http://localhost').pathname === pendingVerificationPath
+}
+
+function readPendingRedirectTo(handle: Handle) {
+	return normalizeRedirectTo(
+		new URLSearchParams(readRouterSearch(handle)).get('redirectTo'),
+	)
+}
+
+function buildLoginRedirectForPending(handle: Handle) {
+	const pendingHref = buildPendingVerificationPath(
+		readPendingRedirectTo(handle),
+	)
+	return buildAuthLink('/login', pendingHref)
+}
+
+export async function pendingVerificationRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const session = await fetchSessionInfo(signal)
+	if (!session) {
+		const pendingHref = buildPendingVerificationPath(
+			normalizeRedirectTo(url.searchParams.get('redirectTo')),
+		)
+		return routeLoaderRedirect(buildAuthLink('/login', pendingHref))
+	}
+	if (session.emailVerified) {
+		return routeLoaderRedirect(
+			resolvePostVerificationRedirect(url.searchParams.get('redirectTo')),
+		)
+	}
+	return {
+		pendingVerification: { ok: true, email: session.email },
+	}
+}
+
+export function PendingVerificationRoute(handle: Handle) {
+	let status: AccountStatus = 'loading'
+	let email = ''
+	let message: string | null = null
+	let resendStatus: 'idle' | 'sending' = 'idle'
+	let resendMessage: string | null = null
+	let resendTone: 'error' | 'info' = 'info'
+	const loadLatch = createRouteLoadLatch()
+
+	function applyPayload(payload: PendingVerificationLoaderData) {
+		email = payload.email
+		status = 'ready'
+		message = null
+	}
+
+	async function loadPending(signal: AbortSignal) {
+		const href = readCurrentRouterHref(handle)
+		try {
+			const session = await fetchSessionInfo(signal)
+			if (signal.aborted) return
+			if (!session) {
+				window.location.assign(buildLoginRedirectForPending(handle))
+				return
+			}
+			if (session.emailVerified) {
+				window.location.assign(
+					resolvePostVerificationRedirect(readPendingRedirectTo(handle)),
+				)
+				return
+			}
+			applyPayload({ ok: true, email: session.email })
+			loadLatch.markLoaded(href)
+			handle.update()
+		} catch (error) {
+			if (signal.aborted) return
+			status = 'error'
+			message =
+				error instanceof Error
+					? error.message
+					: 'Unable to load verification status.'
+			loadLatch.markFailed(href)
+			handle.update()
+		}
+	}
+
+	async function handleResend() {
+		resendStatus = 'sending'
+		resendMessage = null
+		resendTone = 'info'
+		handle.update()
+		try {
+			const result = await requestResendVerification()
+			if (!result.ok && result.unauthorized) {
+				window.location.assign(buildLoginRedirectForPending(handle))
+				return
+			}
+			resendTone = result.ok ? 'info' : 'error'
+			resendMessage = result.message
+		} catch {
+			resendTone = 'error'
+			resendMessage = 'Unable to resend the verification email.'
+		} finally {
+			resendStatus = 'idle'
+			handle.update()
+		}
+	}
+
+	async function handleContinue() {
+		const session = await fetchSessionInfo()
+		if (session?.emailVerified) {
+			window.location.assign(
+				resolvePostVerificationRedirect(readPendingRedirectTo(handle)),
+			)
+			return
+		}
+		resendTone = 'info'
+		resendMessage =
+			'Still waiting on verification. Open the link from your email, then try again.'
+		handle.update()
+	}
+
+	function applyRouteLoaderData(href: string) {
+		if (!isPendingVerificationPath(href)) return false
+		const routeData = tryConsumeRouteLoaderData(
+			handle,
+			'pendingVerification',
+			href,
+		)
+		if (!routeData) return false
+		applyPayload(routeData)
+		loadLatch.markLoaded(href)
+		return true
+	}
+
+	return () => {
+		const currentHref = readCurrentRouterHref(handle)
+		const appliedRouteData = applyRouteLoaderData(currentHref)
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
+		const needsLoad = loadLatch.needsLoad({
+			currentHref,
+			isLoading: status === 'loading',
+			appliedRouteData,
+			needsStaleRefresh,
+		})
+		if (needsLoad && typeof document !== 'undefined') {
+			handle.queueTask(loadPending)
+		}
+
+		return (
+			<AccountManagementShell maxWidth={layoutMaxWidths.content}>
+				<AccountManagementHeader
+					title="Check your email"
+					description="Your Kody account is ready. Verify your email before connecting an AI agent or using MCP."
+				/>
+
+				{status === 'loading' ? (
+					<p mix={css({ color: colors.textMuted, margin: 0 })}>
+						Loading verification…
+					</p>
+				) : null}
+				{message ? (
+					<AccountManagementMessage tone="error">
+						{message}
+					</AccountManagementMessage>
+				) : null}
+
+				{status === 'ready'
+					? renderEmailVerificationPrompt({
+							email,
+							description:
+								'We sent a verification link to your inbox. MCP access stays locked until you verify. Keep this browser signed in so you can resend the email or continue once the link works.',
+							resendStatus,
+							resendMessage,
+							resendTone,
+							onResend: () => {
+								void handleResend()
+							},
+							continueLabel: "I've verified - continue",
+							onContinue: () => {
+								void handleContinue()
+							},
+							secondaryHref: '/account',
+							secondaryLabel: 'Account settings',
+						})
+					: null}
+			</AccountManagementShell>
+		)
+	}
+}

--- a/packages/worker/client/routes/resolve-password-auth-redirect.node.test.ts
+++ b/packages/worker/client/routes/resolve-password-auth-redirect.node.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from 'vitest'
+import { resolvePasswordAuthRedirect } from '#client/routes/resolve-password-auth-redirect.ts'
+
+test('password auth redirect prefers 2FA, then signup verification with preserved redirectTo, then account', () => {
+	expect(
+		resolvePasswordAuthRedirect({
+			mode: 'signup',
+			requiresTwoFactor: true,
+			emailVerificationRequired: true,
+			redirectTo: '/onboarding',
+		}),
+	).toBe('/verify?redirectTo=%2Fonboarding')
+
+	expect(
+		resolvePasswordAuthRedirect({
+			mode: 'signup',
+			emailVerificationRequired: true,
+			redirectTo: '/account',
+		}),
+	).toBe('/pending-verification?redirectTo=%2Faccount')
+
+	expect(
+		resolvePasswordAuthRedirect({
+			mode: 'signup',
+			emailVerificationRequired: true,
+			redirectTo:
+				'/oauth/authorize?response_type=code&client_id=demo&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&scope=profile&state=abc',
+		}),
+	).toBe(
+		'/pending-verification?redirectTo=%2Foauth%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Ddemo%26redirect_uri%3Dhttps%253A%252F%252Fexample.com%252Fcallback%26scope%3Dprofile%26state%3Dabc',
+	)
+
+	expect(
+		resolvePasswordAuthRedirect({
+			mode: 'signup',
+			emailVerificationRequired: true,
+			redirectTo: 'https://evil.example/phish',
+		}),
+	).toBe('/pending-verification')
+
+	expect(
+		resolvePasswordAuthRedirect({
+			mode: 'login',
+			emailVerificationRequired: true,
+			redirectTo: '/onboarding',
+		}),
+	).toBe('/onboarding')
+
+	expect(
+		resolvePasswordAuthRedirect({
+			mode: 'login',
+		}),
+	).toBe('/account')
+
+	expect(
+		resolvePasswordAuthRedirect({
+			mode: 'signup',
+			emailVerificationRequired: false,
+			redirectTo: '/secrets',
+		}),
+	).toBe('/secrets')
+})

--- a/packages/worker/client/routes/resolve-password-auth-redirect.ts
+++ b/packages/worker/client/routes/resolve-password-auth-redirect.ts
@@ -1,0 +1,26 @@
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
+import { buildPendingVerificationPath } from '#client/routes/pending-verification-path.ts'
+
+/**
+ * Chooses where password login/signup should land after a successful /auth
+ * response. Signup that still needs email verification goes to the dedicated
+ * pending page so users are not dropped into MCP connect flow. A safe
+ * redirectTo (such as an OAuth authorize URL) is preserved for continue-after-verify.
+ */
+export function resolvePasswordAuthRedirect(input: {
+	mode: 'login' | 'signup'
+	requiresTwoFactor?: boolean
+	emailVerificationRequired?: boolean
+	redirectTo?: string | null
+}) {
+	const redirectTo = normalizeRedirectTo(input.redirectTo)
+	if (input.requiresTwoFactor) {
+		return redirectTo
+			? `/verify?redirectTo=${encodeURIComponent(redirectTo)}`
+			: '/verify'
+	}
+	if (input.mode === 'signup' && input.emailVerificationRequired) {
+		return buildPendingVerificationPath(redirectTo)
+	}
+	return redirectTo ?? '/account'
+}

--- a/packages/worker/client/routes/verify-email.tsx
+++ b/packages/worker/client/routes/verify-email.tsx
@@ -6,6 +6,7 @@ import {
 	pageDescriptionCss,
 	pageHeaderCss,
 	pageTitleCss,
+	primaryLinkCss,
 	stackedPageCss,
 } from '#client/styles/style-primitives.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
@@ -27,6 +28,18 @@ export function VerifyEmailRoute(handle: Handle) {
 				? 'Email changed'
 				: 'Email verified'
 			: 'Email verification'
+		const ctaHref =
+			data.ok && data.ctaHref
+				? data.ctaHref
+				: isEmailChange
+					? '/account'
+					: '/onboarding'
+		const ctaLabel =
+			data.ok && data.ctaLabel
+				? data.ctaLabel
+				: isEmailChange
+					? 'Go to account'
+					: 'Continue to onboarding'
 
 		return (
 			<section mix={css(pageCss)}>
@@ -36,7 +49,7 @@ export function VerifyEmailRoute(handle: Handle) {
 						{data.ok
 							? isEmailChange
 								? 'Your Kody account uses this email address.'
-								: 'Your Kody account can send outbound email.'
+								: 'Your Kody account can use MCP and send outbound email.'
 							: 'We could not verify your email address.'}
 					</p>
 				</header>
@@ -51,9 +64,21 @@ export function VerifyEmailRoute(handle: Handle) {
 					>
 						{data.ok ? data.message : data.error}
 					</p>
-					<a href="/account" mix={css(mutedLinkCss)}>
-						Go to account
-					</a>
+					{data.ok ? (
+						<p mix={css({ margin: 0 })}>
+							<a href={ctaHref} mix={css(primaryLinkCss)}>
+								{ctaLabel}
+							</a>
+							{' · '}
+							<a href="/account" mix={css(mutedLinkCss)}>
+								Account
+							</a>
+						</p>
+					) : (
+						<a href="/account" mix={css(mutedLinkCss)}>
+							Go to account
+						</a>
+					)}
 				</div>
 			</section>
 		)

--- a/packages/worker/src/app/auth-redirect.ts
+++ b/packages/worker/src/app/auth-redirect.ts
@@ -1,16 +1,11 @@
 import { loadResolvedRequestAuth } from '#app/request-auth-cache.ts'
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
+
+export { normalizeRedirectTo }
 
 type RedirectToLoginOptions = {
 	redirectTo?: string
 	setCookie?: string
-}
-
-/** Allow only same-origin absolute paths as post-auth redirect targets. */
-export function normalizeRedirectTo(value: string | null) {
-	if (!value) return null
-	if (!value.startsWith('/')) return null
-	if (value.startsWith('//')) return null
-	return value
 }
 
 export function redirectToLogin(

--- a/packages/worker/src/app/email-verification.node.test.ts
+++ b/packages/worker/src/app/email-verification.node.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from 'vitest'
+import { buildEmailVerificationUrl } from '#app/email-verification.ts'
+import {
+	normalizeRedirectTo,
+	resolvePostVerificationRedirect,
+	resolveVerifyEmailSuccessCta,
+} from '#app/safe-redirect.ts'
+
+test('email verification links preserve safe resume targets and reject open redirects', () => {
+	const oauthResume = '/oauth/authorize?client_id=demo&state=abc'
+	const withResume = buildEmailVerificationUrl({
+		appBaseUrl: 'https://kody.example',
+		token: 'verify-token',
+		redirectTo: oauthResume,
+	})
+	expect(withResume.pathname).toBe('/verify-email')
+	expect(withResume.searchParams.get('token')).toBe('verify-token')
+	expect(withResume.searchParams.get('redirectTo')).toBe(oauthResume)
+
+	const withoutResume = buildEmailVerificationUrl({
+		appBaseUrl: 'https://kody.example',
+		token: 'verify-token',
+		redirectTo: 'https://evil.example',
+	})
+	expect(withoutResume.searchParams.get('token')).toBe('verify-token')
+	expect(withoutResume.searchParams.has('redirectTo')).toBe(false)
+
+	expect(normalizeRedirectTo('//evil.example')).toBeNull()
+	expect(normalizeRedirectTo('/\\evil.example')).toBeNull()
+	expect(normalizeRedirectTo('/%5cevil.example')).toBeNull()
+	expect(resolvePostVerificationRedirect('https://evil.example')).toBe(
+		'/onboarding',
+	)
+	expect(resolveVerifyEmailSuccessCta(null)).toEqual({
+		href: '/onboarding',
+		label: 'Continue to onboarding',
+		message:
+			'Your email address has been verified. MCP access is now available. Continue onboarding to connect your AI agent.',
+	})
+	expect(resolveVerifyEmailSuccessCta(oauthResume)).toEqual({
+		href: oauthResume,
+		label: 'Continue authorization',
+		message:
+			'Your email address has been verified. MCP access is now available. Continue authorization to finish connecting your AI agent.',
+	})
+	expect(resolveVerifyEmailSuccessCta('/account')).toEqual({
+		href: '/account',
+		label: 'Continue',
+		message:
+			'Your email address has been verified. MCP access is now available.',
+	})
+	expect(resolveVerifyEmailSuccessCta('https://evil.example')).toEqual({
+		href: '/onboarding',
+		label: 'Continue to onboarding',
+		message:
+			'Your email address has been verified. MCP access is now available. Continue onboarding to connect your AI agent.',
+	})
+})

--- a/packages/worker/src/app/email-verification.ts
+++ b/packages/worker/src/app/email-verification.ts
@@ -225,7 +225,7 @@ export async function isAccountEmailVerified(input: {
 }
 
 export const emailVerificationRequiredMessage =
-	'Account email is not verified. Open the verification link sent to your account email, or resend it from the /account page.'
+	'Account email is not verified. Open the verification link sent to your account email, or resend it from /pending-verification or /account.'
 
 export async function assertAccountEmailVerified(input: {
 	db: D1Database

--- a/packages/worker/src/app/email-verification.ts
+++ b/packages/worker/src/app/email-verification.ts
@@ -1,6 +1,7 @@
 import { isNonProductionRuntime } from '#app/deployment-env.ts'
 import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
 import { normalizeEmail } from '#app/normalize-email.ts'
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
 import { createDb, emailVerificationsTable } from '#worker/db.ts'
 import { findUserRowByStableUserId } from '#worker/user-id.ts'
 import { toHex } from '@kody-internal/shared/hex.ts'
@@ -53,11 +54,27 @@ function buildVerificationEmail(verificationUrl: string) {
 	}
 }
 
+/** Builds `/verify-email` with token and an optional safe post-verify resume target. */
+export function buildEmailVerificationUrl(input: {
+	appBaseUrl: string
+	token: string
+	redirectTo?: string | null
+}) {
+	const verificationUrl = new URL('/verify-email', input.appBaseUrl)
+	verificationUrl.searchParams.set('token', input.token)
+	const safeRedirectTo = normalizeRedirectTo(input.redirectTo)
+	if (safeRedirectTo) {
+		verificationUrl.searchParams.set('redirectTo', safeRedirectTo)
+	}
+	return verificationUrl
+}
+
 export async function createEmailVerification(input: {
 	env: Env
 	userId: number
 	email: string
 	requestUrl: string | URL
+	redirectTo?: string | null
 }) {
 	const db = createDb(input.env.APP_DB)
 	const token = generateVerificationToken()
@@ -86,8 +103,11 @@ export async function createEmailVerification(input: {
 		env: input.env,
 		requestUrl: input.requestUrl,
 	})
-	const verificationUrl = new URL('/verify-email', emailConfig.appBaseUrl)
-	verificationUrl.searchParams.set('token', token)
+	const verificationUrl = buildEmailVerificationUrl({
+		appBaseUrl: emailConfig.appBaseUrl,
+		token,
+		redirectTo: input.redirectTo,
+	})
 	const email = buildVerificationEmail(verificationUrl.toString())
 
 	let sendResult: Awaited<ReturnType<typeof sendCloudflareEmail>>

--- a/packages/worker/src/app/handlers/account-resend-verification.ts
+++ b/packages/worker/src/app/handlers/account-resend-verification.ts
@@ -4,11 +4,25 @@ import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { createEmailVerification } from '#app/email-verification.ts'
 import { checkRateLimit, releaseRateLimit } from '#app/rate-limit.ts'
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
 import { type routes } from '#app/routes.ts'
 
 export const resendVerificationRateLimitConfig = {
 	maxRequests: 3,
 	windowSeconds: 15 * 60,
+}
+
+async function readResendRedirectTo(request: Request) {
+	const contentType = request.headers.get('content-type') ?? ''
+	if (!contentType.includes('application/json')) {
+		return normalizeRedirectTo(
+			new URL(request.url).searchParams.get('redirectTo'),
+		)
+	}
+	const body = await request.json().catch(() => null)
+	if (!body || typeof body !== 'object') return null
+	const redirectTo = (body as Record<string, unknown>).redirectTo
+	return typeof redirectTo === 'string' ? normalizeRedirectTo(redirectTo) : null
 }
 
 export function createAccountResendVerificationHandler(env: Env) {
@@ -27,6 +41,8 @@ export function createAccountResendVerificationHandler(env: Env) {
 					400,
 				)
 			}
+
+			const redirectTo = await readResendRedirectTo(request)
 
 			const rateLimitKey = `verification-resend:user:${user.userId}`
 			const rateLimit = await checkRateLimit(
@@ -64,6 +80,7 @@ export function createAccountResendVerificationHandler(env: Env) {
 					userId: user.userId,
 					email: user.email,
 					requestUrl: url,
+					redirectTo,
 				})
 			} catch (error) {
 				console.error('Failed to resend verification email:', error)

--- a/packages/worker/src/app/handlers/account.ts
+++ b/packages/worker/src/app/handlers/account.ts
@@ -31,6 +31,7 @@ export function createAccountHandler(env: Env) {
 					env,
 					requestUrl: request.url,
 					stableUserId: user.mcpUser.userId,
+					emailVerified: user.emailVerified,
 				}),
 			])
 			return renderAppPage({

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -20,6 +20,7 @@ import {
 	releaseInviteUse,
 } from '#app/invites.ts'
 import { normalizeEmail } from '#app/normalize-email.ts'
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
 import { assignUserRole } from '#app/permissions-db.ts'
 import { type routes } from '#app/routes.ts'
 import { getUsernameValidationError, normalizeUsername } from '#app/username.ts'
@@ -91,6 +92,15 @@ export function createAuthHandler(env: Env) {
 				typeof body === 'object' && body !== null
 					? (body as Record<string, unknown>).rememberMe
 					: undefined
+			const signupRedirectTo =
+				normalizedMode === 'signup' &&
+				typeof body === 'object' &&
+				body !== null &&
+				typeof (body as Record<string, unknown>).redirectTo === 'string'
+					? normalizeRedirectTo(
+							(body as Record<string, unknown>).redirectTo as string,
+						)
+					: null
 			const requestIp = getRequestIp(request) ?? undefined
 			if (
 				rememberMeValue !== undefined &&
@@ -334,6 +344,7 @@ export function createAuthHandler(env: Env) {
 						userId: record.id,
 						email: normalizedEmail,
 						requestUrl: url,
+						redirectTo: signupRedirectTo,
 					})
 				} catch (error) {
 					console.error('Failed to create email verification at signup:', error)

--- a/packages/worker/src/app/handlers/home.ts
+++ b/packages/worker/src/app/handlers/home.ts
@@ -21,6 +21,7 @@ export function createHomeHandler(env: Env) {
 				env,
 				requestUrl: request.url,
 				stableUserId: user.mcpUser.userId,
+				emailVerified: user.emailVerified,
 			})
 			return renderAppPage({
 				request,

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -18,6 +18,7 @@ vi.mock('#app/onboarding-data.ts', () => ({
 		mcpServerUrl: 'https://example.com/mcp',
 		setupPrompt: 'Help me get started with Kody.',
 		hasMcpClient: false,
+		emailVerified: true,
 		needsOnboarding: true,
 	})),
 }))

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -2,6 +2,7 @@ import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
 import {
+	normalizeRedirectTo,
 	redirectToLogin,
 	redirectToLoginWhenUnauthenticated,
 } from '#app/auth-redirect.ts'
@@ -11,6 +12,18 @@ import { loadOnboardingData } from '#app/onboarding-data.ts'
 import { createPageOgHeadNode } from '#app/ssr-document.tsx'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
+
+function redirectUnverifiedToPending(request: Request) {
+	const requestUrl = new URL(request.url)
+	const redirectTo = normalizeRedirectTo(
+		requestUrl.searchParams.get('redirectTo'),
+	)
+	const pendingUrl = new URL('/pending-verification', requestUrl)
+	if (redirectTo) {
+		pendingUrl.searchParams.set('redirectTo', redirectTo)
+	}
+	return Response.redirect(pendingUrl, 302)
+}
 
 export function createOnboardingHandler(env: Env) {
 	return {
@@ -26,10 +39,15 @@ export function createOnboardingHandler(env: Env) {
 				return redirectToLoginWhenUnauthenticated(request, env)
 			}
 
+			if (!user.emailVerified) {
+				return redirectUnverifiedToPending(request)
+			}
+
 			const onboarding = await loadOnboardingData({
 				env,
 				requestUrl: request.url,
 				stableUserId: user.mcpUser.userId,
+				emailVerified: user.emailVerified,
 			})
 			const origin = getAppBaseUrl({ env, requestUrl: request.url })
 			return renderAppPage({
@@ -56,11 +74,14 @@ export function createOnboardingApiHandler(env: Env) {
 				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
 			}
 
+			// Unverified callers still get a payload so clients can detect the
+			// gate; MCP URL/setup fields stay empty until verification succeeds.
 			return jsonResponse(
 				await loadOnboardingData({
 					env,
 					requestUrl: request.url,
 					stableUserId: user.mcpUser.userId,
+					emailVerified: user.emailVerified,
 				}),
 			)
 		},

--- a/packages/worker/src/app/handlers/pending-verification.node.test.ts
+++ b/packages/worker/src/app/handlers/pending-verification.node.test.ts
@@ -1,0 +1,160 @@
+import { expect, test, vi } from 'vitest'
+import { RequestContext } from 'remix/router'
+import {
+	createAuthCookie,
+	setAuthSessionSecret,
+	type AuthSession,
+} from '#app/auth-session.ts'
+import { createPendingVerificationHandler } from '#app/handlers/pending-verification.ts'
+
+const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
+
+vi.mock('#app/ssr-render.tsx', () => ({
+	renderAppPage: vi.fn(async ({ loaderData }) =>
+		Response.json({ ok: true, loaderData }),
+	),
+}))
+
+function createUserEnv(options: {
+	emailVerifiedAt?: string | null
+	missingUser?: boolean
+}) {
+	const user = options.missingUser
+		? null
+		: {
+				id: 1,
+				email: 'pending@example.com',
+				username: 'pending-user',
+				password_hash: 'unused',
+				email_verified_at: options.emailVerifiedAt ?? null,
+				created_at: new Date(0).toISOString(),
+				updated_at: new Date(0).toISOString(),
+			}
+	return {
+		COOKIE_SECRET: testCookieSecret,
+		APP_DB: {
+			prepare(query: string) {
+				const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
+				return {
+					bind() {
+						return {
+							async all() {
+								if (
+									normalizedQuery.startsWith('select') &&
+									normalizedQuery.includes('from "users"')
+								) {
+									return {
+										results: user ? [user] : [],
+										meta: { changes: 0 },
+									}
+								}
+								if (normalizedQuery.includes('from user_roles ur')) {
+									return { results: [], meta: { changes: 0 } }
+								}
+								return { results: [], meta: { changes: 0 } }
+							},
+							async first() {
+								if (normalizedQuery.includes('email_verified_at')) {
+									return user
+										? { email_verified_at: user.email_verified_at }
+										: null
+								}
+								return user
+							},
+							async run() {
+								return { meta: { changes: 0 } }
+							},
+						}
+					},
+				}
+			},
+			async exec() {
+				return
+			},
+		} as unknown as D1Database,
+	} as Env
+}
+
+test('pending verification requires a live session, preserves redirectTo after verify, and renders when unverified', async () => {
+	setAuthSessionSecret(testCookieSecret)
+	const session: AuthSession = {
+		id: '1',
+		email: 'pending@example.com',
+		rememberMe: false,
+	}
+	const cookie = await createAuthCookie(session, false)
+
+	const anonymousResponse = await createPendingVerificationHandler(
+		createUserEnv({}),
+	).handler(
+		new RequestContext(new Request('https://example.com/pending-verification')),
+	)
+	expect(anonymousResponse.status).toBe(302)
+	expect(anonymousResponse.headers.get('Location')).toBe(
+		'https://example.com/login?redirectTo=%2Fpending-verification',
+	)
+
+	const pendingResponse = await createPendingVerificationHandler(
+		createUserEnv({ emailVerifiedAt: null }),
+	).handler(
+		new RequestContext(
+			new Request('https://example.com/pending-verification', {
+				headers: { Cookie: cookie },
+			}),
+		),
+	)
+	expect(pendingResponse.status).toBe(200)
+	await expect(pendingResponse.json()).resolves.toEqual({
+		ok: true,
+		loaderData: {
+			pendingVerification: {
+				ok: true,
+				email: 'pending@example.com',
+			},
+		},
+	})
+
+	const verifiedResponse = await createPendingVerificationHandler(
+		createUserEnv({ emailVerifiedAt: new Date(0).toISOString() }),
+	).handler(
+		new RequestContext(
+			new Request('https://example.com/pending-verification', {
+				headers: { Cookie: cookie },
+			}),
+		),
+	)
+	expect(verifiedResponse.status).toBe(302)
+	expect(verifiedResponse.headers.get('Location')).toBe(
+		'https://example.com/onboarding',
+	)
+
+	const verifiedWithRedirect = await createPendingVerificationHandler(
+		createUserEnv({ emailVerifiedAt: new Date(0).toISOString() }),
+	).handler(
+		new RequestContext(
+			new Request(
+				'https://example.com/pending-verification?redirectTo=%2Foauth%2Fauthorize%3Fclient_id%3Ddemo',
+				{ headers: { Cookie: cookie } },
+			),
+		),
+	)
+	expect(verifiedWithRedirect.status).toBe(302)
+	expect(verifiedWithRedirect.headers.get('Location')).toBe(
+		'https://example.com/oauth/authorize?client_id=demo',
+	)
+
+	const verifiedRejectsOpenRedirect = await createPendingVerificationHandler(
+		createUserEnv({ emailVerifiedAt: new Date(0).toISOString() }),
+	).handler(
+		new RequestContext(
+			new Request(
+				'https://example.com/pending-verification?redirectTo=https%3A%2F%2Fevil.example',
+				{ headers: { Cookie: cookie } },
+			),
+		),
+	)
+	expect(verifiedRejectsOpenRedirect.status).toBe(302)
+	expect(verifiedRejectsOpenRedirect.headers.get('Location')).toBe(
+		'https://example.com/onboarding',
+	)
+})

--- a/packages/worker/src/app/handlers/pending-verification.ts
+++ b/packages/worker/src/app/handlers/pending-verification.ts
@@ -1,0 +1,50 @@
+import { type Action } from 'remix/router'
+import {
+	normalizeRedirectTo,
+	redirectToLogin,
+	redirectToLoginWhenUnauthenticated,
+} from '#app/auth-redirect.ts'
+import { readAuthSessionResult } from '#app/auth-session.ts'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { renderAppPage } from '#app/ssr-render.tsx'
+import { type routes } from '#app/routes.ts'
+
+function resolvePostVerificationRedirect(request: Request) {
+	const redirectTo = normalizeRedirectTo(
+		new URL(request.url).searchParams.get('redirectTo'),
+	)
+	return new URL(redirectTo ?? '/onboarding', request.url)
+}
+
+export function createPendingVerificationHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const { session } = await readAuthSessionResult(request)
+			if (!session) {
+				return redirectToLogin(request)
+			}
+
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return redirectToLoginWhenUnauthenticated(request, env)
+			}
+
+			if (user.emailVerified) {
+				return Response.redirect(resolvePostVerificationRedirect(request), 302)
+			}
+
+			return renderAppPage({
+				request,
+				env,
+				title: 'Verify your email',
+				loaderData: {
+					pendingVerification: {
+						ok: true,
+						email: user.email,
+					},
+				},
+			})
+		},
+	} satisfies Action<typeof routes.pendingVerification>
+}

--- a/packages/worker/src/app/handlers/verify-email.node.test.ts
+++ b/packages/worker/src/app/handlers/verify-email.node.test.ts
@@ -1,0 +1,97 @@
+import { expect, test, vi } from 'vitest'
+import { createVerifyEmailHandler } from '#app/handlers/verify-email.ts'
+import { verifyEmailToken } from '#app/email-verification.ts'
+import { renderAppPage } from '#app/ssr-render.tsx'
+
+vi.mock('#app/email-verification.ts', () => ({
+	verifyEmailToken: vi.fn(),
+}))
+
+vi.mock('#app/ssr-render.tsx', () => ({
+	renderAppPage: vi.fn(async ({ loaderData }) =>
+		Response.json({ ok: true, loaderData }),
+	),
+}))
+
+test('verify-email success CTA resumes a safe OAuth target and rejects open redirects', async () => {
+	vi.mocked(verifyEmailToken).mockResolvedValue({
+		ok: true,
+		userId: 1,
+		email: 'verified@example.com',
+	})
+	const handler = createVerifyEmailHandler({
+		APP_DB: {} as D1Database,
+	} as Env)
+
+	const oauthResume = '/oauth/authorize?client_id=demo'
+	const oauthResponse = await handler.handler({
+		request: new Request(
+			`https://example.com/verify-email?token=ok&redirectTo=${encodeURIComponent(oauthResume)}`,
+		),
+		url: new URL(
+			`https://example.com/verify-email?token=ok&redirectTo=${encodeURIComponent(oauthResume)}`,
+		),
+		params: {},
+	} as never)
+	expect(await oauthResponse.json()).toEqual({
+		ok: true,
+		loaderData: {
+			emailVerification: {
+				ok: true,
+				kind: 'email_verify',
+				message:
+					'Your email address has been verified. MCP access is now available. Continue authorization to finish connecting your AI agent.',
+				ctaHref: oauthResume,
+				ctaLabel: 'Continue authorization',
+			},
+		},
+	})
+
+	const maliciousResponse = await handler.handler({
+		request: new Request(
+			'https://example.com/verify-email?token=ok&redirectTo=https%3A%2F%2Fevil.example',
+		),
+		url: new URL(
+			'https://example.com/verify-email?token=ok&redirectTo=https%3A%2F%2Fevil.example',
+		),
+		params: {},
+	} as never)
+	expect(await maliciousResponse.json()).toEqual({
+		ok: true,
+		loaderData: {
+			emailVerification: {
+				ok: true,
+				kind: 'email_verify',
+				message:
+					'Your email address has been verified. MCP access is now available. Continue onboarding to connect your AI agent.',
+				ctaHref: '/onboarding',
+				ctaLabel: 'Continue to onboarding',
+			},
+		},
+	})
+
+	const backslashResponse = await handler.handler({
+		request: new Request(
+			'https://example.com/verify-email?token=ok&redirectTo=%2F%5Cevil.example',
+		),
+		url: new URL(
+			'https://example.com/verify-email?token=ok&redirectTo=%2F%5Cevil.example',
+		),
+		params: {},
+	} as never)
+	expect(await backslashResponse.json()).toEqual({
+		ok: true,
+		loaderData: {
+			emailVerification: {
+				ok: true,
+				kind: 'email_verify',
+				message:
+					'Your email address has been verified. MCP access is now available. Continue onboarding to connect your AI agent.',
+				ctaHref: '/onboarding',
+				ctaLabel: 'Continue to onboarding',
+			},
+		},
+	})
+
+	expect(renderAppPage).toHaveBeenCalled()
+})

--- a/packages/worker/src/app/handlers/verify-email.ts
+++ b/packages/worker/src/app/handlers/verify-email.ts
@@ -1,6 +1,7 @@
 import { type Action } from 'remix/router'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
 import { verifyEmailToken } from '#app/email-verification.ts'
+import { resolveVerifyEmailSuccessCta } from '#app/safe-redirect.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 
@@ -62,6 +63,9 @@ export function createVerifyEmailHandler(env: Env) {
 				ip: requestIp,
 				path: url.pathname,
 			})
+			const cta = resolveVerifyEmailSuccessCta(
+				url.searchParams.get('redirectTo'),
+			)
 			return renderAppPage({
 				request,
 				env,
@@ -70,10 +74,9 @@ export function createVerifyEmailHandler(env: Env) {
 					emailVerification: {
 						ok: true,
 						kind: 'email_verify',
-						message:
-							'Your email address has been verified. MCP access is now available. Continue onboarding to connect your AI agent.',
-						ctaHref: '/onboarding',
-						ctaLabel: 'Continue to onboarding',
+						message: cta.message,
+						ctaHref: cta.href,
+						ctaLabel: cta.label,
 					},
 				},
 			})

--- a/packages/worker/src/app/handlers/verify-email.ts
+++ b/packages/worker/src/app/handlers/verify-email.ts
@@ -70,7 +70,10 @@ export function createVerifyEmailHandler(env: Env) {
 					emailVerification: {
 						ok: true,
 						kind: 'email_verify',
-						message: 'Your email address has been verified.',
+						message:
+							'Your email address has been verified. MCP access is now available. Continue onboarding to connect your AI agent.',
+						ctaHref: '/onboarding',
+						ctaLabel: 'Continue to onboarding',
 					},
 				},
 			})

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -321,6 +321,7 @@ export type OnboardingLoaderData = {
 	mcpServerUrl: string
 	setupPrompt: string
 	hasMcpClient: boolean
+	emailVerified: boolean
 	needsOnboarding: boolean
 }
 
@@ -341,11 +342,18 @@ export type AccountPasskeysLoaderData = {
 	passkeys: Array<AccountPasskeyListItem>
 }
 
+export type PendingVerificationLoaderData = {
+	ok: true
+	email: string
+}
+
 export type EmailVerificationLoaderData =
 	| {
 			ok: true
 			kind: 'email_verify' | 'email_change'
 			message: string
+			ctaHref?: string
+			ctaLabel?: string
 	  }
 	| {
 			ok: false
@@ -505,11 +513,13 @@ export type OAuthAuthorizeLoaderData =
 			ok: true
 			client: { id: string; name: string }
 			scopes: Array<string>
+			emailVerified: boolean | null
 	  }
 	| {
 			ok: false
 			error: string
 			allowClientReset: boolean
+			code?: 'email_verification_required'
 	  }
 
 export type AppLoaderData = {
@@ -522,6 +532,7 @@ export type AppLoaderData = {
 	adminSystemEmail?: AdminSystemEmailLoaderData
 	accountProfile?: AccountProfileLoaderData
 	onboarding?: OnboardingLoaderData
+	pendingVerification?: PendingVerificationLoaderData
 	accountTwoFactor?: AccountTwoFactorLoaderData
 	accountPasskeys?: AccountPasskeysLoaderData
 	accountIntegrations?: AccountIntegrationsLoaderData

--- a/packages/worker/src/app/onboarding-data.node.test.ts
+++ b/packages/worker/src/app/onboarding-data.node.test.ts
@@ -5,7 +5,7 @@ import {
 	loadOnboardingData,
 } from '#app/onboarding-data.ts'
 
-test('onboarding data builds the MCP URL and derives MCP-client status from OAuth grants', async () => {
+test('onboarding data builds the MCP URL and derives incomplete setup from verification plus grants', async () => {
 	expect(
 		buildMcpServerUrl({
 			env: { APP_BASE_URL: 'https://configured.example' },
@@ -21,12 +21,14 @@ test('onboarding data builds the MCP URL and derives MCP-client status from OAut
 		},
 		requestUrl: 'https://heykody.dev/onboarding',
 		stableUserId: 'user-1',
+		emailVerified: true,
 	})
 	expect(withoutClient).toEqual({
 		ok: true,
 		mcpServerUrl: 'https://heykody.dev/mcp',
 		setupPrompt: buildOnboardingSetupPrompt(),
 		hasMcpClient: false,
+		emailVerified: true,
 		needsOnboarding: true,
 	})
 
@@ -40,11 +42,33 @@ test('onboarding data builds the MCP URL and derives MCP-client status from OAut
 		},
 		requestUrl: 'http://localhost:3742/onboarding',
 		stableUserId: 'user-1',
+		emailVerified: true,
 	})
 	expect(withClient).toMatchObject({
 		hasMcpClient: true,
+		emailVerified: true,
 		needsOnboarding: false,
 		mcpServerUrl: 'http://localhost:3742/mcp',
+	})
+
+	const unverifiedWithGrant = await loadOnboardingData({
+		env: {
+			OAUTH_PROVIDER: {
+				listUserGrants: vi.fn(async () => ({
+					items: [{ id: 'grant-1' }],
+				})),
+			},
+		},
+		requestUrl: 'https://heykody.dev/onboarding',
+		stableUserId: 'user-1',
+		emailVerified: false,
+	})
+	expect(unverifiedWithGrant).toMatchObject({
+		hasMcpClient: true,
+		emailVerified: false,
+		needsOnboarding: true,
+		mcpServerUrl: '',
+		setupPrompt: '',
 	})
 
 	const whenProviderListingFails = await loadOnboardingData({
@@ -57,6 +81,7 @@ test('onboarding data builds the MCP URL and derives MCP-client status from OAut
 		},
 		requestUrl: 'https://heykody.dev/onboarding',
 		stableUserId: 'user-1',
+		emailVerified: true,
 	})
 	expect(whenProviderListingFails.hasMcpClient).toBe(false)
 	expect(whenProviderListingFails.needsOnboarding).toBe(true)

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -55,20 +55,31 @@ export async function loadOnboardingData(input: {
 	env: OnboardingEnv
 	requestUrl: string | URL
 	stableUserId: string
+	emailVerified: boolean
 }): Promise<OnboardingLoaderData> {
-	const mcpServerUrl = buildMcpServerUrl({
-		env: input.env,
-		requestUrl: input.requestUrl,
-	})
 	const hasMcpClient = await userHasMcpOAuthGrants(
 		input.env,
 		input.stableUserId,
 	)
+	// Incomplete setup means either the account email is still unverified or no
+	// MCP host has authorized yet. An unverified account with a leftover grant
+	// still needs onboarding until verification is finished.
+	const needsOnboarding = !input.emailVerified || !hasMcpClient
+	// Keep MCP URL/setup out of unverified responses so SSR and JSON clients
+	// cannot push users into the authorize → 403 loop before verification.
+	const mcpServerUrl = input.emailVerified
+		? buildMcpServerUrl({
+				env: input.env,
+				requestUrl: input.requestUrl,
+			})
+		: ''
+	const setupPrompt = input.emailVerified ? buildOnboardingSetupPrompt() : ''
 	return {
 		ok: true,
 		mcpServerUrl,
-		setupPrompt: buildOnboardingSetupPrompt(),
+		setupPrompt,
 		hasMcpClient,
-		needsOnboarding: !hasMcpClient,
+		emailVerified: input.emailVerified,
+		needsOnboarding,
 	}
 }

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -53,6 +53,7 @@ import {
 	createAccountTwoFactorHandler,
 } from '#app/handlers/account-two-factor.ts'
 import { createAccountResendVerificationHandler } from '#app/handlers/account-resend-verification.ts'
+import { createPendingVerificationHandler } from '#app/handlers/pending-verification.ts'
 import {
 	createAccountRemoteConnectorsApiHandler,
 	createAccountRemoteConnectorsHandler,
@@ -135,6 +136,7 @@ export function createAppRouter(env: Env) {
 			resetPassword: createResetPasswordHandler(env),
 			verifyEmail: createVerifyEmailHandler(env),
 			verifyEmailChange: createVerifyEmailChangeHandler(env),
+			pendingVerification: createPendingVerificationHandler(env),
 			signup: createSignupHandler(env),
 			waitingList: createWaitingListHandler(env),
 			account: createAccountHandler(env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -76,6 +76,7 @@ export const routes = route({
 	verifyTwoFactorApi: post('/verify/2fa.json'),
 	verifyEmail: '/verify-email',
 	verifyEmailChange: '/verify-email-change',
+	pendingVerification: '/pending-verification',
 	signup: '/signup',
 	waitingList: post('/waiting-list'),
 	account: '/account',

--- a/packages/worker/src/app/safe-redirect.ts
+++ b/packages/worker/src/app/safe-redirect.ts
@@ -1,0 +1,7 @@
+/** Allow only same-origin absolute paths as post-auth redirect targets. */
+export function normalizeRedirectTo(value: string | null | undefined) {
+	if (!value) return null
+	if (!value.startsWith('/')) return null
+	if (value.startsWith('//')) return null
+	return value
+}

--- a/packages/worker/src/app/safe-redirect.ts
+++ b/packages/worker/src/app/safe-redirect.ts
@@ -1,7 +1,66 @@
-/** Allow only same-origin absolute paths as post-auth redirect targets. */
+/**
+ * Allow only same-origin absolute paths (with optional query/hash) as
+ * post-auth redirect targets. Rejects protocol-relative URLs, backslash
+ * network-path tricks browsers normalize to `//host`, control characters,
+ * and other host-hijacking forms.
+ */
 export function normalizeRedirectTo(value: string | null | undefined) {
-	if (!value) return null
+	if (typeof value !== 'string' || value.length === 0) return null
 	if (!value.startsWith('/')) return null
+	// Browsers treat `\` as `/`, so `/\evil` becomes a network-path `//evil`.
+	if (value.includes('\\') || /%5c/i.test(value)) return null
+	// Protocol-relative / network-path references.
 	if (value.startsWith('//')) return null
+	// Raw controls/whitespace confuse Location parsers and URL normalizers.
+	for (let index = 0; index < value.length; index += 1) {
+		const code = value.charCodeAt(index)
+		if (code <= 0x1f || code === 0x7f || code === 0x20) return null
+	}
+	// Percent-encoded C0 controls and DEL (encoded spaces in paths stay valid).
+	if (/%(?:[01][\da-f]|7f)/i.test(value)) return null
+	try {
+		const url = new URL(value, 'https://kody.invalid')
+		if (url.origin !== 'https://kody.invalid') return null
+		if (!url.pathname.startsWith('/') || url.pathname.startsWith('//')) {
+			return null
+		}
+	} catch {
+		return null
+	}
 	return value
+}
+
+/** Destination after email verification succeeds when no safer target exists. */
+export const defaultPostVerificationRedirect = '/onboarding'
+
+/** Destination after email verification succeeds from pending/verify flows. */
+export function resolvePostVerificationRedirect(redirectTo?: string | null) {
+	return normalizeRedirectTo(redirectTo) ?? defaultPostVerificationRedirect
+}
+
+/** Success CTA for `/verify-email`, preserving a safe OAuth (or other) resume target. */
+export function resolveVerifyEmailSuccessCta(redirectTo?: string | null) {
+	const href = resolvePostVerificationRedirect(redirectTo)
+	if (href === defaultPostVerificationRedirect) {
+		return {
+			href,
+			label: 'Continue to onboarding',
+			message:
+				'Your email address has been verified. MCP access is now available. Continue onboarding to connect your AI agent.',
+		}
+	}
+	if (href.startsWith('/oauth/authorize')) {
+		return {
+			href,
+			label: 'Continue authorization',
+			message:
+				'Your email address has been verified. MCP access is now available. Continue authorization to finish connecting your AI agent.',
+		}
+	}
+	return {
+		href,
+		label: 'Continue',
+		message:
+			'Your email address has been verified. MCP access is now available.',
+	}
 }

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -10,7 +10,6 @@ import { createAccountHandler } from '#app/handlers/account.ts'
 import { createCommunityHandler } from '#app/handlers/community.tsx'
 import { createOnboardingHandler } from '#app/handlers/onboarding.ts'
 import { createResetPasswordHandler } from '#app/handlers/reset-password.ts'
-import { buildOnboardingSetupPrompt } from '#app/onboarding-data.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { resetDataCacheForTests } from '#app/data-cache.ts'
 
@@ -252,13 +251,15 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	})
 	expect(accountProps.loaderData?.onboarding).toEqual({
 		ok: true,
-		mcpServerUrl: 'https://example.com/mcp',
-		setupPrompt: buildOnboardingSetupPrompt(),
+		mcpServerUrl: '',
+		setupPrompt: '',
 		hasMcpClient: false,
+		emailVerified: false,
 		needsOnboarding: true,
 	})
-	expect(accountHtml).toContain('Connect your AI agent')
-	expect(accountHtml).toContain('/onboarding')
+	expect(accountHtml).toContain('Verify your email')
+	expect(accountHtml).not.toContain('Connect your AI agent')
+	expect(accountHtml).toContain('/pending-verification')
 
 	const onboardingResponse = await runHtmlHandler(
 		createOnboardingHandler(env),
@@ -266,19 +267,22 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 			headers: { Cookie: accountCookie },
 		}),
 	)
-	expect(onboardingResponse.status).toBe(200)
-	const onboardingHtml = await readResponseText(onboardingResponse)
-	expect(onboardingHtml).toContain('Get started with Kody')
-	expect(onboardingHtml).toContain('https://example.com/mcp')
-	expect(onboardingHtml).toContain(buildOnboardingSetupPrompt())
-	const onboardingProps = readAppRootProps(onboardingHtml)
-	expect(onboardingProps.loaderData?.onboarding).toEqual({
-		ok: true,
-		mcpServerUrl: 'https://example.com/mcp',
-		setupPrompt: buildOnboardingSetupPrompt(),
-		hasMcpClient: false,
-		needsOnboarding: true,
-	})
+	expect(onboardingResponse.status).toBe(302)
+	expect(onboardingResponse.headers.get('Location')).toBe(
+		'https://example.com/pending-verification',
+	)
+
+	const onboardingPreservesRedirect = await runHtmlHandler(
+		createOnboardingHandler(env),
+		new Request(
+			'https://example.com/onboarding?redirectTo=%2Foauth%2Fauthorize%3Fclient_id%3Ddemo',
+			{ headers: { Cookie: accountCookie } },
+		),
+	)
+	expect(onboardingPreservesRedirect.status).toBe(302)
+	expect(onboardingPreservesRedirect.headers.get('Location')).toBe(
+		'https://example.com/pending-verification?redirectTo=%2Foauth%2Fauthorize%3Fclient_id%3Ddemo',
+	)
 
 	const anonymousOnboardingResponse = await runHtmlHandler(
 		createOnboardingHandler(env),

--- a/packages/worker/src/mcp/capabilities/mcp-server/index.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-server/index.ts
@@ -18,6 +18,7 @@ import {
 	type McpServerSnapshot,
 	type McpServerToolDescriptor,
 } from '#worker/mcp-client/types.ts'
+import { wrapDownstreamMcpToolResult } from '#mcp/downstream-mcp-result.ts'
 
 type McpServerToolCapabilityBinding = {
 	capabilityName: string
@@ -142,16 +143,10 @@ function createCapabilityFromTool(input: {
 					`MCP server capability "${ref.name}:${tool.name}" failed: ${message}`,
 				)
 			}
-			if (
-				result.structuredContent &&
-				typeof result.structuredContent === 'object'
-			) {
-				return result.structuredContent as Record<string, unknown>
-			}
-			return {
-				content: result.content,
-				isError: result.isError ?? false,
-			}
+			return wrapDownstreamMcpToolResult(result, {
+				kind: 'mcp-server',
+				label: `${ref.name}:${tool.name}`,
+			})
 		},
 	})
 

--- a/packages/worker/src/mcp/capabilities/remote-connector/index.ts
+++ b/packages/worker/src/mcp/capabilities/remote-connector/index.ts
@@ -15,6 +15,7 @@ import {
 } from '#worker/remote-connector/remote-domain-id.ts'
 import { type Capability, type DomainSpec } from '#mcp/capabilities/types.ts'
 import { type RemoteConnectorSnapshot } from '#worker/remote-connector/types.ts'
+import { wrapDownstreamMcpToolResult } from '#mcp/downstream-mcp-result.ts'
 
 type RemoteToolCapabilityBinding = {
 	capabilityName: string
@@ -139,16 +140,10 @@ function createCapabilityFromTool(input: {
 					`Remote capability "${binding.instanceId}:${tool.name}" failed: ${message}`,
 				)
 			}
-			if (
-				result.structuredContent &&
-				typeof result.structuredContent === 'object'
-			) {
-				return result.structuredContent as Record<string, unknown>
-			}
-			return {
-				content: result.content,
-				isError: result.isError ?? false,
-			}
+			return wrapDownstreamMcpToolResult(result, {
+				kind: 'remote-connector',
+				label: `${binding.instanceId}:${tool.name}`,
+			})
 		},
 	})
 

--- a/packages/worker/src/mcp/downstream-mcp-result.node.test.ts
+++ b/packages/worker/src/mcp/downstream-mcp-result.node.test.ts
@@ -1,0 +1,400 @@
+import { expect, test, vi } from 'vitest'
+import {
+	boundRawContentForPersistence,
+	defaultMcpContentLimitBytes,
+	estimateUntrustedMcpContentPayloadBytes,
+	extractMcpPassthrough,
+	limitMcpContentBlocks,
+	maxMcpContentBlockCount,
+	measureMcpContentBytes,
+	mcpContentMarker,
+	mcpIsErrorMarker,
+	mcpStructuredContentMarker,
+	persistableExecutionArtifacts,
+	reservedStructuredFieldCollisionKey,
+	sanitizeStructuredContentRecord,
+	validateDownstreamMcpContentBlocks,
+	wrapDownstreamMcpToolResult,
+} from '#mcp/downstream-mcp-result.ts'
+
+/** Minimal valid 1×1 WebP (lossy) as base64. */
+const minimalWebpBase64 =
+	'UklGRiQAAABXRUJQVlA4IBgAAAAwAQCdASoBAAEAAwA0JaQAA3AA/vuUAAA='
+
+function oversizedBase64(byteLength: number) {
+	// 'A' is valid base64 alphabet; length must be multiple of 4 for atob.
+	const rawLength = Math.ceil(byteLength / 4) * 4
+	return 'A'.repeat(rawLength)
+}
+
+test('downstream MCP wrap preserves WebP images, structured+content, oversized bounds, malformed errors, resources, and isError', () => {
+	const webpBlock = {
+		type: 'image' as const,
+		data: minimalWebpBase64,
+		mimeType: 'image/webp',
+	}
+	const resourceBlock = {
+		type: 'resource' as const,
+		resource: {
+			uri: 'mcp://example/doc',
+			mimeType: 'text/plain',
+			text: 'hello resource',
+		},
+	}
+	const resourceLinkBlock = {
+		type: 'resource_link' as const,
+		uri: 'https://example.com/doc',
+		name: 'Example doc',
+	}
+	const audioBlock = {
+		type: 'audio' as const,
+		data: 'AAAA',
+		mimeType: 'audio/wav',
+	}
+
+	const webpWrapped = wrapDownstreamMcpToolResult(
+		{
+			content: [webpBlock, { type: 'text', text: 'chart' }],
+			isError: false,
+		},
+		{ kind: 'mcp-server', label: 'charts:render' },
+	)
+	expect(webpWrapped).toMatchObject({
+		[mcpContentMarker]: [webpBlock, { type: 'text', text: 'chart' }],
+	})
+	expect(extractMcpPassthrough(webpWrapped)?.content).toEqual([
+		webpBlock,
+		{ type: 'text', text: 'chart' },
+	])
+
+	const structuredAndImage = wrapDownstreamMcpToolResult(
+		{
+			content: [webpBlock],
+			structuredContent: { chartId: 'c1', width: 640 },
+			isError: false,
+		},
+		{ kind: 'remote-connector', label: 'home:screenshot' },
+	)
+	expect(structuredAndImage).toMatchObject({
+		chartId: 'c1',
+		width: 640,
+		[mcpContentMarker]: [webpBlock],
+		[mcpStructuredContentMarker]: { chartId: 'c1', width: 640 },
+	})
+	expect(extractMcpPassthrough(structuredAndImage)).toEqual({
+		content: [webpBlock],
+		structuredResult: { chartId: 'c1', width: 640 },
+		isError: false,
+	})
+
+	// ~133KB binary WebP ≈ ~177KB base64 must fit under the media cap.
+	const reportedWebpBinaryBytes = 132_550
+	const reportedWebpBase64 = oversizedBase64(
+		Math.ceil(reportedWebpBinaryBytes / 3) * 4,
+	)
+	expect(reportedWebpBase64.length).toBeGreaterThan(170_000)
+	expect(reportedWebpBase64.length).toBeLessThan(defaultMcpContentLimitBytes)
+	const reportedWebpBlocks = [
+		{
+			type: 'image' as const,
+			data: reportedWebpBase64,
+			mimeType: 'image/webp',
+		},
+	]
+	expect(measureMcpContentBytes(reportedWebpBlocks)).toBeLessThan(
+		defaultMcpContentLimitBytes,
+	)
+	expect(
+		limitMcpContentBlocks(reportedWebpBlocks, defaultMcpContentLimitBytes),
+	).toMatchObject({ ok: true, blocks: reportedWebpBlocks })
+	expect(
+		validateDownstreamMcpContentBlocks(reportedWebpBlocks, {
+			kind: 'mcp-server',
+			label: 'vision:shot',
+		}),
+	).toEqual(reportedWebpBlocks)
+
+	const largeData = oversizedBase64(110_000)
+	const largeBlocks = [
+		{
+			type: 'image' as const,
+			data: largeData,
+			mimeType: 'image/webp',
+		},
+	]
+	expect(measureMcpContentBytes(largeBlocks)).toBeGreaterThan(102_400)
+	expect(limitMcpContentBlocks(largeBlocks, 102_400)).toMatchObject({
+		ok: false,
+	})
+	expect(
+		limitMcpContentBlocks(largeBlocks, defaultMcpContentLimitBytes),
+	).toMatchObject({
+		ok: true,
+		blocks: largeBlocks,
+	})
+
+	const tooLarge = [
+		{
+			type: 'image' as const,
+			data: oversizedBase64(defaultMcpContentLimitBytes + 50_000),
+			mimeType: 'image/png',
+		},
+	]
+	const overContentLimit = limitMcpContentBlocks(
+		tooLarge,
+		defaultMcpContentLimitBytes,
+	)
+	expect(overContentLimit.ok).toBe(false)
+	if (!overContentLimit.ok) {
+		expect(overContentLimit.note).toContain('exceeding content limit')
+	}
+
+	expect(() =>
+		validateDownstreamMcpContentBlocks(
+			[{ type: 'image', url: 'https://evil.example/x.png' }],
+			{ kind: 'mcp-server', label: 'evil:img' },
+		),
+	).toThrow(/evil:img[\s\S]*does not fetch image\/audio URLs/)
+
+	expect(() =>
+		wrapDownstreamMcpToolResult(
+			{
+				content: [{ type: 'image', data: '!!!', mimeType: 'image/png' }],
+			},
+			{ kind: 'remote-connector', label: 'cam:snap' },
+		),
+	).toThrow(/cam:snap[\s\S]*malformed MCP content/)
+
+	// Arbitrary application { content: [] } is not treated as protocol content.
+	expect(extractMcpPassthrough({ content: [webpBlock], ok: true })).toBeNull()
+
+	const withResources = wrapDownstreamMcpToolResult(
+		{
+			content: [resourceBlock, resourceLinkBlock, audioBlock],
+			structuredContent: { ok: true },
+		},
+		{ kind: 'mcp-server', label: 'docs:get' },
+	)
+	expect(extractMcpPassthrough(withResources)?.content).toEqual([
+		resourceBlock,
+		resourceLinkBlock,
+		audioBlock,
+	])
+
+	const errorWithStructured = wrapDownstreamMcpToolResult(
+		{
+			content: [{ type: 'text', text: 'permission denied' }],
+			structuredContent: { code: 'forbidden' },
+			isError: true,
+		},
+		{ kind: 'mcp-server', label: 'linear:create_issue' },
+	)
+	expect(extractMcpPassthrough(errorWithStructured)).toEqual({
+		content: [{ type: 'text', text: 'permission denied' }],
+		structuredResult: { code: 'forbidden' },
+		isError: true,
+	})
+	expect(errorWithStructured).toMatchObject({
+		code: 'forbidden',
+		[mcpIsErrorMarker]: true,
+	})
+
+	// Structured-only success stays a plain object (no unsafe content heuristic).
+	expect(
+		wrapDownstreamMcpToolResult(
+			{
+				content: [{ type: 'text', text: 'ignored when structured present' }],
+				structuredContent: { id: 1 },
+			},
+			{ kind: 'mcp-server', label: 'linear:get' },
+		),
+	).toEqual({ id: 1 })
+})
+
+test('reserved structuredContent marker names are isolated on every wrap path', () => {
+	const collidingStructured = {
+		id: 1,
+		[mcpContentMarker]: [
+			{
+				type: 'image',
+				data: minimalWebpBase64,
+				mimeType: 'image/webp',
+			},
+		],
+		[mcpIsErrorMarker]: true,
+		[mcpStructuredContentMarker]: { injected: true },
+	}
+
+	// Success: text + structured (plain structured return, no trusted markers).
+	const textAndStructured = wrapDownstreamMcpToolResult(
+		{
+			content: [{ type: 'text', text: 'ok' }],
+			structuredContent: collidingStructured,
+		},
+		{ kind: 'mcp-server', label: 'collision:text' },
+	)
+	expect(textAndStructured).toEqual({
+		id: 1,
+		[reservedStructuredFieldCollisionKey]: {
+			[mcpContentMarker]: collidingStructured[mcpContentMarker],
+			[mcpIsErrorMarker]: true,
+			[mcpStructuredContentMarker]: { injected: true },
+		},
+	})
+	expect(extractMcpPassthrough(textAndStructured)).toBeNull()
+
+	// Structured-only success.
+	const structuredOnly = wrapDownstreamMcpToolResult(
+		{ structuredContent: collidingStructured },
+		{ kind: 'remote-connector', label: 'collision:structured' },
+	)
+	expect(structuredOnly).toEqual(textAndStructured)
+	expect(extractMcpPassthrough(structuredOnly)).toBeNull()
+
+	// Error path: real isError marker wins; collisions stay isolated.
+	const errorWrapped = wrapDownstreamMcpToolResult(
+		{
+			content: [{ type: 'text', text: 'denied' }],
+			structuredContent: {
+				code: 'forbidden',
+				[mcpIsErrorMarker]: false,
+				[mcpContentMarker]: [{ type: 'text', text: 'spoofed' }],
+			},
+			isError: true,
+		},
+		{ kind: 'mcp-server', label: 'collision:error' },
+	)
+	expect(errorWrapped[mcpIsErrorMarker]).toBe(true)
+	expect(errorWrapped[mcpContentMarker]).toEqual([
+		{ type: 'text', text: 'denied' },
+	])
+	expect(errorWrapped[mcpStructuredContentMarker]).toEqual({
+		code: 'forbidden',
+		[reservedStructuredFieldCollisionKey]: {
+			[mcpIsErrorMarker]: false,
+			[mcpContentMarker]: [{ type: 'text', text: 'spoofed' }],
+		},
+	})
+	expect(extractMcpPassthrough(errorWrapped)).toEqual({
+		content: [{ type: 'text', text: 'denied' }],
+		structuredResult: {
+			code: 'forbidden',
+			[reservedStructuredFieldCollisionKey]: {
+				[mcpIsErrorMarker]: false,
+				[mcpContentMarker]: [{ type: 'text', text: 'spoofed' }],
+			},
+		},
+		isError: true,
+	})
+
+	expect(
+		sanitizeStructuredContentRecord({
+			ok: true,
+			[mcpContentMarker]: [],
+		}),
+	).toEqual({
+		ok: true,
+		[reservedStructuredFieldCollisionKey]: {
+			[mcpContentMarker]: [],
+		},
+	})
+})
+
+test('untrusted content is bounded by block count and payload size before schema atob', () => {
+	const atobSpy = vi.spyOn(globalThis, 'atob')
+
+	const tooManyBlocks = Array.from(
+		{ length: maxMcpContentBlockCount + 1 },
+		() => ({
+			type: 'text' as const,
+			text: 'x',
+		}),
+	)
+	expect(() =>
+		validateDownstreamMcpContentBlocks(tooManyBlocks, {
+			kind: 'mcp-server',
+			label: 'flood:blocks',
+		}),
+	).toThrow(/flood:blocks[\s\S]*too many MCP content blocks/)
+	expect(atobSpy).not.toHaveBeenCalled()
+
+	const hugePayload = [
+		{
+			type: 'image',
+			data: oversizedBase64(defaultMcpContentLimitBytes + 80_000),
+			mimeType: 'image/webp',
+		},
+	]
+	expect(estimateUntrustedMcpContentPayloadBytes(hugePayload)).toBeGreaterThan(
+		defaultMcpContentLimitBytes,
+	)
+	expect(() =>
+		validateDownstreamMcpContentBlocks(hugePayload, {
+			kind: 'remote-connector',
+			label: 'flood:bytes',
+		}),
+	).toThrow(/flood:bytes[\s\S]*exceeding content limit/)
+	expect(atobSpy).not.toHaveBeenCalled()
+
+	atobSpy.mockRestore()
+
+	const withinCount = Array.from({ length: maxMcpContentBlockCount }, () => ({
+		type: 'text' as const,
+		text: 'ok',
+	}))
+	expect(
+		validateDownstreamMcpContentBlocks(withinCount, {
+			kind: 'execute',
+			label: 'default export (__mcpContent)',
+		}),
+	).toHaveLength(maxMcpContentBlockCount)
+})
+
+test('persistence bounds or omits rawContent and strips markers from stored result', () => {
+	const webpBlock = {
+		type: 'image' as const,
+		data: minimalWebpBase64,
+		mimeType: 'image/webp',
+	}
+	const wrapped = wrapDownstreamMcpToolResult(
+		{
+			content: [webpBlock],
+			structuredContent: { shotId: 's1' },
+		},
+		{ kind: 'mcp-server', label: 'vision:shot' },
+	)
+	const persisted = persistableExecutionArtifacts(wrapped)
+	expect(persisted.result).toEqual({ shotId: 's1' })
+	expect(persisted.rawContent).toEqual([webpBlock])
+	expect(persisted.rawContentOmitted).toBeNull()
+
+	const huge = [
+		{
+			type: 'image' as const,
+			data: oversizedBase64(defaultMcpContentLimitBytes + 40_000),
+			mimeType: 'image/png',
+		},
+	]
+	const omitted = boundRawContentForPersistence(huge)
+	expect(omitted.rawContent).toBeNull()
+	expect(omitted.rawContentOmitted).toMatchObject({
+		blockCount: 1,
+		note: expect.stringContaining('exceeding content limit'),
+	})
+
+	const oversizeArtifacts = persistableExecutionArtifacts({
+		[mcpContentMarker]: huge,
+		shotId: 'drop-me-from-markers-path',
+	})
+	expect(oversizeArtifacts.result).toEqual({
+		shotId: 'drop-me-from-markers-path',
+	})
+	expect(oversizeArtifacts.rawContent).toBeNull()
+	expect(oversizeArtifacts.rawContentOmitted?.blockCount).toBe(1)
+
+	expect(persistableExecutionArtifacts({ ok: true })).toEqual({
+		result: { ok: true },
+		rawContent: null,
+		rawContentOmitted: null,
+	})
+})

--- a/packages/worker/src/mcp/downstream-mcp-result.ts
+++ b/packages/worker/src/mcp/downstream-mcp-result.ts
@@ -1,0 +1,433 @@
+import {
+	ContentBlockSchema,
+	type ContentBlock,
+} from '@modelcontextprotocol/sdk/types.js'
+
+/**
+ * Explicit markers used at the synthesized MCP-server / remote-connector
+ * capability boundary (and understood by execute) so protocol content is never
+ * inferred from arbitrary application `{ content: [] }` objects.
+ */
+export const mcpContentMarker = '__mcpContent' as const
+export const mcpIsErrorMarker = '__mcpIsError' as const
+export const mcpStructuredContentMarker = '__mcpStructuredContent' as const
+
+/**
+ * When downstream `structuredContent` uses reserved marker names, those fields
+ * are moved here so they cannot become trusted control markers.
+ */
+export const reservedStructuredFieldCollisionKey =
+	'_kodyMcpReservedFieldCollisions' as const
+
+/**
+ * Soft cap for protocol content blocks (images/audio/resources) returned through
+ * execute / persistence. Higher than the default JSON `responseLimit` (102_400)
+ * so valid images survive, but still bounded.
+ *
+ * Rationale: MCP image/audio `data` is base64 (~4/3 expansion). A ~132,550-byte
+ * WebP is ~177 KiB of base64 JSON — comfortably under 512 KiB — while multi-MiB
+ * dumps are rejected before `ContentBlockSchema` runs `atob`.
+ */
+export const defaultMcpContentLimitBytes = 524_288
+
+/** Max content blocks accepted from untrusted downstream / execute payloads. */
+export const maxMcpContentBlockCount = 32
+
+export type DownstreamMcpResultSource = {
+	kind: 'mcp-server' | 'remote-connector' | 'execute'
+	/** Human-readable label for errors, e.g. `linear:screenshot`. */
+	label: string
+}
+
+export type DownstreamMcpToolResult = {
+	content?: unknown
+	structuredContent?: unknown
+	isError?: boolean
+}
+
+export type McpPassthroughExtraction = {
+	content: Array<ContentBlock> | null
+	/** Structured data for execute `structuredContent.result` / code use. */
+	structuredResult: unknown | null
+	isError: boolean
+}
+
+export type PersistedRawContentBound = {
+	rawContent: Array<ContentBlock> | null
+	rawContentOmitted: null | {
+		note: string
+		returnedBytes: number
+		blockCount: number
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isReservedMarkerKey(key: string) {
+	return (
+		key === mcpContentMarker ||
+		key === mcpIsErrorMarker ||
+		key === mcpStructuredContentMarker
+	)
+}
+
+function sourcePrefix(source: DownstreamMcpResultSource) {
+	switch (source.kind) {
+		case 'mcp-server':
+			return `MCP server "${source.label}"`
+		case 'remote-connector':
+			return `Remote connector "${source.label}"`
+		case 'execute':
+			return `Execute ${source.label}`
+		default: {
+			const _exhaustive: never = source.kind
+			return _exhaustive
+		}
+	}
+}
+
+/**
+ * Move reserved marker keys out of structured content so they cannot become
+ * trusted control markers when the object is returned or re-extracted.
+ */
+export function sanitizeStructuredContentRecord(
+	structured: Record<string, unknown>,
+): Record<string, unknown> {
+	const clean: Record<string, unknown> = {}
+	const collisions: Record<string, unknown> = {}
+
+	for (const [key, value] of Object.entries(structured)) {
+		if (isReservedMarkerKey(key)) {
+			collisions[key] = value
+		} else {
+			clean[key] = value
+		}
+	}
+
+	if (Object.keys(collisions).length === 0) {
+		return clean
+	}
+
+	if (reservedStructuredFieldCollisionKey in clean) {
+		collisions[reservedStructuredFieldCollisionKey] =
+			clean[reservedStructuredFieldCollisionKey]
+		delete clean[reservedStructuredFieldCollisionKey]
+	}
+	clean[reservedStructuredFieldCollisionKey] = collisions
+	return clean
+}
+
+function formatContentBlockIssue(block: unknown, index: number) {
+	if (!isRecord(block)) {
+		return `content[${index}] is not an object`
+	}
+	const type = typeof block.type === 'string' ? block.type : 'unknown'
+	if (
+		(type === 'image' || type === 'audio') &&
+		'url' in block &&
+		typeof block.data !== 'string'
+	) {
+		return `content[${index}] type=${type} uses a URL without base64 "data"; Kody does not fetch image/audio URLs. Return protocol-valid { type: '${type}', data, mimeType }.`
+	}
+	if (type === 'image' || type === 'audio') {
+		return `content[${index}] type=${type} is not protocol-valid (need base64 "data" and "mimeType")`
+	}
+	return `content[${index}] type=${type} is not a protocol-valid MCP content block`
+}
+
+export function getUtf8ByteLength(value: string) {
+	return new TextEncoder().encode(value).byteLength
+}
+
+/**
+ * Estimate untrusted content payload size without decoding base64 (`atob`).
+ * Used to reject oversized payloads before `ContentBlockSchema.safeParse`.
+ */
+export function estimateUntrustedMcpContentPayloadBytes(
+	content: ReadonlyArray<unknown>,
+): number {
+	let total = 2 // []
+	for (let index = 0; index < content.length; index++) {
+		if (index > 0) total += 1 // comma
+		const entry = content[index]
+		if (!isRecord(entry)) {
+			total += getUtf8ByteLength(JSON.stringify(entry) ?? 'null')
+			continue
+		}
+		total += 2 // {}
+		let fieldIndex = 0
+		for (const [key, value] of Object.entries(entry)) {
+			if (fieldIndex > 0) total += 1
+			total += getUtf8ByteLength(JSON.stringify(key) ?? '""') + 1
+			if (typeof value === 'string') {
+				// Avoid allocating a second copy of huge base64 strings. ASCII
+				// media payloads need no JSON escapes, so length+2 is exact;
+				// remaining cases are bounded by the same order of magnitude.
+				total += value.length + 2
+			} else {
+				total += getUtf8ByteLength(JSON.stringify(value) ?? 'null')
+			}
+			fieldIndex += 1
+		}
+	}
+	return total
+}
+
+/**
+ * Validate MCP content blocks from a downstream tool result or execute return.
+ * Bounds block count and payload size before schema parse (avoids unbounded
+ * `atob`); does not fetch URLs or rewrite shapes.
+ */
+export function validateDownstreamMcpContentBlocks(
+	content: unknown,
+	source: DownstreamMcpResultSource,
+	options?: {
+		maxBlockCount?: number
+		maxPayloadBytes?: number
+	},
+): Array<ContentBlock> {
+	const maxBlockCount = options?.maxBlockCount ?? maxMcpContentBlockCount
+	const maxPayloadBytes =
+		options?.maxPayloadBytes ?? defaultMcpContentLimitBytes
+
+	if (!Array.isArray(content)) {
+		throw new Error(
+			`${sourcePrefix(source)} returned invalid MCP content (expected an array of content blocks).`,
+		)
+	}
+
+	if (content.length > maxBlockCount) {
+		throw new Error(
+			`${sourcePrefix(source)} returned too many MCP content blocks (${content.length.toLocaleString()} > limit ${maxBlockCount.toLocaleString()}).`,
+		)
+	}
+
+	const estimatedBytes = estimateUntrustedMcpContentPayloadBytes(content)
+	if (estimatedBytes > maxPayloadBytes) {
+		throw new Error(
+			`${sourcePrefix(source)} returned MCP content estimated at ${estimatedBytes.toLocaleString()} bytes, exceeding content limit ${maxPayloadBytes.toLocaleString()} bytes before validation. Reduce image/audio payload size or split the response.`,
+		)
+	}
+
+	const blocks: Array<ContentBlock> = []
+	for (let index = 0; index < content.length; index++) {
+		const entry = content[index]
+		const parsed = ContentBlockSchema.safeParse(entry)
+		if (!parsed.success) {
+			throw new Error(
+				`${sourcePrefix(source)} returned malformed MCP content: ${formatContentBlockIssue(entry, index)}.`,
+			)
+		}
+		blocks.push(parsed.data)
+	}
+	return blocks
+}
+
+function hasNonTextContent(blocks: Array<ContentBlock>) {
+	return blocks.some((block) => block.type !== 'text')
+}
+
+/**
+ * Convert a downstream MCP CallToolResult into a capability return value.
+ * Non-text content and isError are preserved via explicit markers; structured
+ * content remains available for code (spread + companion marker). Reserved
+ * marker keys inside structuredContent are isolated, never trusted as control.
+ */
+export function wrapDownstreamMcpToolResult(
+	result: DownstreamMcpToolResult,
+	source: DownstreamMcpResultSource,
+): Record<string, unknown> {
+	const hasStructured =
+		result.structuredContent !== undefined &&
+		result.structuredContent !== null &&
+		typeof result.structuredContent === 'object' &&
+		!Array.isArray(result.structuredContent)
+
+	const structuredRecord = hasStructured
+		? sanitizeStructuredContentRecord(
+				result.structuredContent as Record<string, unknown>,
+			)
+		: null
+
+	const contentBlocks =
+		result.content === undefined
+			? null
+			: validateDownstreamMcpContentBlocks(result.content, source)
+
+	const isError = result.isError === true
+	const needsContentPassthrough =
+		contentBlocks !== null &&
+		(hasNonTextContent(contentBlocks) || !hasStructured || isError)
+
+	if (needsContentPassthrough) {
+		return {
+			...(structuredRecord ?? {}),
+			[mcpContentMarker]: contentBlocks,
+			...(structuredRecord
+				? { [mcpStructuredContentMarker]: structuredRecord }
+				: {}),
+			...(isError ? { [mcpIsErrorMarker]: true } : {}),
+		}
+	}
+
+	if (isError && hasStructured && structuredRecord) {
+		return {
+			...structuredRecord,
+			[mcpStructuredContentMarker]: structuredRecord,
+			[mcpIsErrorMarker]: true,
+		}
+	}
+
+	if (isError) {
+		return {
+			[mcpContentMarker]: contentBlocks ?? [
+				{ type: 'text', text: 'Tool reported an error.' },
+			],
+			[mcpIsErrorMarker]: true,
+		}
+	}
+
+	if (hasStructured && structuredRecord) {
+		return structuredRecord
+	}
+
+	return {
+		content: contentBlocks ?? [],
+		isError: false,
+	}
+}
+
+function stripPassthroughMarkers(
+	value: Record<string, unknown>,
+): Record<string, unknown> | null {
+	const next: Record<string, unknown> = {}
+	for (const [key, entry] of Object.entries(value)) {
+		if (isReservedMarkerKey(key)) {
+			continue
+		}
+		next[key] = entry
+	}
+	return Object.keys(next).length > 0 ? next : null
+}
+
+/**
+ * Extract explicit MCP passthrough markers from an execute return value.
+ * Only recognizes `__mcpContent` / companion markers — never arbitrary
+ * `{ content: [] }` application objects. Content is not schema-validated here;
+ * callers at trust boundaries (execute egress) must revalidate.
+ */
+export function extractMcpPassthrough(
+	value: unknown,
+): McpPassthroughExtraction | null {
+	if (!isRecord(value)) return null
+
+	const hasContentMarker =
+		mcpContentMarker in value && Array.isArray(value[mcpContentMarker])
+	const hasIsErrorMarker = value[mcpIsErrorMarker] === true
+	const hasStructuredMarker =
+		mcpStructuredContentMarker in value &&
+		isRecord(value[mcpStructuredContentMarker])
+
+	if (!hasContentMarker && !hasIsErrorMarker && !hasStructuredMarker) {
+		return null
+	}
+
+	const content = hasContentMarker
+		? (value[mcpContentMarker] as Array<ContentBlock>)
+		: null
+
+	const structuredResult = hasStructuredMarker
+		? sanitizeStructuredContentRecord(
+				value[mcpStructuredContentMarker] as Record<string, unknown>,
+			)
+		: hasContentMarker || hasIsErrorMarker
+			? stripPassthroughMarkers(value)
+			: null
+
+	return {
+		content,
+		structuredResult,
+		isError: hasIsErrorMarker,
+	}
+}
+
+export function measureMcpContentBytes(blocks: Array<ContentBlock>) {
+	return getUtf8ByteLength(JSON.stringify(blocks) ?? '[]')
+}
+
+export function limitMcpContentBlocks(
+	blocks: Array<ContentBlock>,
+	limitBytes: number,
+):
+	| {
+			ok: true
+			blocks: Array<ContentBlock>
+			returnedBytes: number
+	  }
+	| {
+			ok: false
+			returnedBytes: number
+			note: string
+	  } {
+	const returnedBytes = measureMcpContentBytes(blocks)
+	if (returnedBytes <= limitBytes) {
+		return { ok: true, blocks, returnedBytes }
+	}
+	return {
+		ok: false,
+		returnedBytes,
+		note: `MCP content was ${returnedBytes.toLocaleString()} bytes, exceeding content limit ${limitBytes.toLocaleString()} bytes; content was not returned. Reduce image/audio payload size or split the response.`,
+	}
+}
+
+/**
+ * Bound protocol content before durable package-invocation persistence.
+ * Oversized media is omitted with safe metadata (never stored unbounded).
+ */
+export function boundRawContentForPersistence(
+	content: Array<ContentBlock> | null,
+	limitBytes: number = defaultMcpContentLimitBytes,
+): PersistedRawContentBound {
+	if (!content || content.length === 0) {
+		return { rawContent: null, rawContentOmitted: null }
+	}
+	const limited = limitMcpContentBlocks(content, limitBytes)
+	if (!limited.ok) {
+		return {
+			rawContent: null,
+			rawContentOmitted: {
+				note: limited.note,
+				returnedBytes: limited.returnedBytes,
+				blockCount: content.length,
+			},
+		}
+	}
+	return { rawContent: limited.blocks, rawContentOmitted: null }
+}
+
+/**
+ * Shape package-invocation storage so control markers and unbounded base64 are
+ * not written into the durable `result` blob. Media lives in `rawContent` only
+ * when within the content cap.
+ */
+export function persistableExecutionArtifacts(value: unknown): {
+	result: unknown
+	rawContent: Array<ContentBlock> | null
+	rawContentOmitted: PersistedRawContentBound['rawContentOmitted']
+} {
+	const passthrough = extractMcpPassthrough(value)
+	if (!passthrough) {
+		return { result: value, rawContent: null, rawContentOmitted: null }
+	}
+
+	const result =
+		passthrough.structuredResult !== null ? passthrough.structuredResult : null
+	const bounded = boundRawContentForPersistence(passthrough.content)
+	return {
+		result,
+		rawContent: bounded.rawContent,
+		rawContentOmitted: bounded.rawContentOmitted,
+	}
+}

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -954,6 +954,17 @@ test('executor maps secret errors, formats guidance, extracts raw content, and t
 		}),
 	).toEqual(content)
 	expect(extractRawContent({ result: 'not raw content' })).toBeNull()
+	expect(
+		extractRawContent({
+			content: [
+				{
+					type: 'image',
+					data: 'AAAA',
+					mimeType: 'image/png',
+				},
+			],
+		}),
+	).toBeNull()
 
 	const oneByteLimit = limitExecutionResultValue('éabc', 1)
 	expect(oneByteLimit).toMatchObject({

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -11,6 +11,7 @@ import { sha256Base64Url } from '@kody-internal/shared/sha256.ts'
 import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { exports as workerExports } from 'cloudflare:workers'
 import { type FetchGatewayProps } from '#mcp/fetch-gateway.ts'
+import { extractMcpPassthrough } from '#mcp/downstream-mcp-result.ts'
 import { recordUsage, type UsageEnv } from '#worker/usage/record-usage.ts'
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
 import {
@@ -1059,15 +1060,7 @@ export function formatExecutionOutput(result: ExecuteResult) {
 }
 
 export function extractRawContent(value: unknown): Array<ContentBlock> | null {
-	if (
-		typeof value === 'object' &&
-		value !== null &&
-		'__mcpContent' in value &&
-		Array.isArray((value as { __mcpContent: unknown }).__mcpContent)
-	) {
-		return (value as { __mcpContent: Array<ContentBlock> }).__mcpContent
-	}
-	return null
+	return extractMcpPassthrough(value)?.content ?? null
 }
 
 function extractFirstUrl(message: string) {

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -1,5 +1,10 @@
 import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { expect, test, vi } from 'vitest'
+import {
+	defaultMcpContentLimitBytes,
+	maxMcpContentBlockCount,
+	wrapDownstreamMcpToolResult,
+} from '#mcp/downstream-mcp-result.ts'
 
 const mockModule = vi.hoisted(() => ({
 	runModuleWithRegistry: vi.fn(),
@@ -115,7 +120,7 @@ test('execute tool serializes successes and errors, binds storage, passes packag
 		logs: [{ level: 'info', message: 'captured screenshot' }],
 	})
 	const returnedBytes = new TextEncoder().encode(
-		JSON.stringify({ __mcpContent: rawContent }),
+		JSON.stringify(rawContent),
 	).byteLength
 
 	const mcpContentResponse = await handler({
@@ -371,5 +376,160 @@ test('execute tool serializes successes and errors, binds storage, passes packag
 			returnedBytes: 0,
 			logs: [{ level: 'error', message: 'failed' }],
 		}),
+	)
+})
+
+test('execute passes through downstream MCP image content with structured data and rejects oversize content explicitly', async () => {
+	const handler = await getExecuteHandler()
+	const webpBlock = {
+		type: 'image' as const,
+		data: 'UklGRiQAAABXRUJQVlA4IBgAAAAwAQCdASoBAAEAAwA0JaQAA3AA/vuUAAA=',
+		mimeType: 'image/webp',
+	}
+
+	mockPerformanceSequence(1, 2)
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		result: wrapDownstreamMcpToolResult(
+			{
+				content: [webpBlock],
+				structuredContent: { shotId: 's1' },
+			},
+			{ kind: 'mcp-server', label: 'vision:screenshot' },
+		),
+		logs: [],
+	})
+
+	const passthroughResponse = await handler({
+		code: 'async () => downstream',
+		conversationId: 'conv-passthrough',
+	})
+
+	expect(passthroughResponse.isError).toBe(false)
+	expect(passthroughResponse.content).toEqual([
+		{ type: 'text', text: 'conversationId: conv-passthrough' },
+		webpBlock,
+	])
+	expect(passthroughResponse.structuredContent.result).toEqual({
+		shotId: 's1',
+	})
+
+	const largeData = 'A'.repeat(Math.ceil(110_000 / 4) * 4)
+	const largeBlock = {
+		type: 'image' as const,
+		data: largeData,
+		mimeType: 'image/webp',
+	}
+	mockPerformanceSequence(3, 4)
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		result: {
+			__mcpContent: [largeBlock],
+		},
+		logs: [],
+	})
+
+	const largeResponse = await handler({
+		code: 'async () => large',
+		conversationId: 'conv-large-image',
+		responseLimit: 102_400,
+	})
+
+	expect(largeResponse.isError).toBe(false)
+	expect(largeResponse.content).toEqual([
+		{ type: 'text', text: 'conversationId: conv-large-image' },
+		largeBlock,
+	])
+
+	const tooLargeData = 'A'.repeat(
+		Math.ceil((defaultMcpContentLimitBytes + 50_000) / 4) * 4,
+	)
+	mockPerformanceSequence(5, 6)
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		result: {
+			__mcpContent: [
+				{
+					type: 'image',
+					data: tooLargeData,
+					mimeType: 'image/png',
+				},
+			],
+		},
+		logs: [],
+	})
+
+	const oversizeResponse = await handler({
+		code: 'async () => oversize',
+		conversationId: 'conv-oversize',
+	})
+
+	expect(oversizeResponse.isError).toBe(true)
+	expect(oversizeResponse.structuredContent.error).toContain(
+		'exceeding content limit',
+	)
+	expect(oversizeResponse.content[1]).toMatchObject({
+		type: 'text',
+		text: expect.stringContaining('exceeding content limit'),
+	})
+
+	// Ordinary application objects with a `content` array stay JSON text.
+	mockPerformanceSequence(7, 8)
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		result: {
+			content: [webpBlock],
+			ok: true,
+		},
+		logs: [],
+	})
+	const arbitraryContentResponse = await handler({
+		code: 'async () => ({ content: [...] })',
+		conversationId: 'conv-arbitrary-content',
+	})
+	expect(arbitraryContentResponse.isError).toBe(false)
+	expect(arbitraryContentResponse.content).toEqual([
+		{ type: 'text', text: 'conversationId: conv-arbitrary-content' },
+		{
+			type: 'text',
+			text: JSON.stringify({ content: [webpBlock], ok: true }, null, 2),
+		},
+	])
+	expect(arbitraryContentResponse.content.some((b) => b.type === 'image')).toBe(
+		false,
+	)
+
+	// Malformed user-authored __mcpContent becomes an isError result (no throw).
+	mockPerformanceSequence(9, 10)
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		result: {
+			__mcpContent: [{ type: 'image', data: '!!!', mimeType: 'image/png' }],
+		},
+		logs: [],
+	})
+	const malformedResponse = await handler({
+		code: 'async () => bad',
+		conversationId: 'conv-malformed',
+	})
+	expect(malformedResponse.isError).toBe(true)
+	expect(malformedResponse.structuredContent.error).toMatch(
+		/default export \(__mcpContent\)[\s\S]*malformed MCP content/,
+	)
+	expect(malformedResponse.content.some((b) => b.type === 'image')).toBe(false)
+
+	// Too many content blocks fail before expensive validation work.
+	mockPerformanceSequence(11, 12)
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		result: {
+			__mcpContent: Array.from({ length: maxMcpContentBlockCount + 1 }, () => ({
+				type: 'text',
+				text: 'x',
+			})),
+		},
+		logs: [],
+	})
+	const tooManyBlocksResponse = await handler({
+		code: 'async () => many',
+		conversationId: 'conv-too-many-blocks',
+	})
+	expect(tooManyBlocksResponse.isError).toBe(true)
+	expect(tooManyBlocksResponse.structuredContent.error).toContain(
+		'too many MCP content blocks',
 	)
 })

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -1,15 +1,23 @@
 import * as Sentry from '@sentry/cloudflare'
-import { type ToolAnnotations } from '@modelcontextprotocol/sdk/types.js'
+import {
+	type ContentBlock,
+	type ToolAnnotations,
+} from '@modelcontextprotocol/sdk/types.js'
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { z } from 'zod'
 import {
 	defaultExecutionResponseLimitBytes,
-	extractRawContent,
 	formatLimitedExecutionOutput,
 	limitExecutionResultValue,
 	formatExecutionOutput,
 	getExecutionErrorDetails,
 } from '#mcp/executor.ts'
+import {
+	defaultMcpContentLimitBytes,
+	extractMcpPassthrough,
+	limitMcpContentBlocks,
+	validateDownstreamMcpContentBlocks,
+} from '#mcp/downstream-mcp-result.ts'
 import { runModuleWithRegistry } from '#mcp/run-kody-registry.ts'
 import { type McpRegistrationAgent } from '#mcp/mcp-registration-agent.ts'
 import {
@@ -131,7 +139,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					.min(1)
 					.optional()
 					.describe(
-						`Soft cap on the size of the value returned from your default export. Defaults to ~100 KB. Returns over the cap are truncated and the response includes a note. You write the code -- if you only need a few fields, project before returning. Examples:
+						`Soft cap on the JSON/text value returned from your default export (structured result / serialized output). Defaults to ~100 KB (${defaultExecutionResponseLimitBytes.toLocaleString()} bytes). Oversized JSON is truncated with a note. Protocol content blocks from __mcpContent (images/audio/resources) use a separate ~512 KB content cap and are not truncated into JSON text — oversized protocol content fails explicitly. Project large API payloads before returning. Examples:
 // bad: messages.list().then(j => j) -- returns full Gmail payloads
 // good: messages.list().then(j => j.messages.map(m => ({id: m.id, snippet: m.snippet})))
 // good: aggregate().then(rows => ({count: rows.length, sample: rows.slice(0, 3)}))`,
@@ -334,44 +342,156 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					sandboxError: false,
 					context: activeStorageId ? { storageId: activeStorageId } : undefined,
 				})
+				const responseLimitBytes =
+					responseLimit ?? defaultExecutionResponseLimitBytes
+				const passthrough = extractMcpPassthrough(result.result)
+				const rawContent = passthrough?.content ?? null
+
+				if (rawContent) {
+					let validatedContent: Array<ContentBlock>
+					try {
+						validatedContent = validateDownstreamMcpContentBlocks(rawContent, {
+							kind: 'execute',
+							label: 'default export (__mcpContent)',
+						})
+					} catch (error) {
+						const message = getErrorMessage(error)
+						return {
+							content: prependToolMetadataContent(resolvedConversationId, [
+								{
+									type: 'text',
+									text: `Error: ${message}`,
+								},
+								...formatSurfacedMemoriesMarkdown(surfacedMemories),
+							]),
+							structuredContent: {
+								conversationId: resolvedConversationId,
+								timing,
+								...(activeStorageId
+									? { storage: { id: activeStorageId } }
+									: {}),
+								returnedBytes: 0,
+								error: message,
+								result: passthrough?.structuredResult ?? null,
+								logs: result.logs ?? [],
+								...buildMemoryStructuredContent(surfacedMemories),
+							},
+							isError: true,
+						}
+					}
+
+					const contentLimited = limitMcpContentBlocks(
+						validatedContent,
+						defaultMcpContentLimitBytes,
+					)
+					if (!contentLimited.ok) {
+						return {
+							content: prependToolMetadataContent(resolvedConversationId, [
+								{
+									type: 'text',
+									text: `Error: ${contentLimited.note}`,
+								},
+								...formatSurfacedMemoriesMarkdown(surfacedMemories),
+							]),
+							structuredContent: {
+								conversationId: resolvedConversationId,
+								timing,
+								...(activeStorageId
+									? { storage: { id: activeStorageId } }
+									: {}),
+								returnedBytes: contentLimited.returnedBytes,
+								truncated: true,
+								note: contentLimited.note,
+								result: passthrough?.structuredResult ?? null,
+								logs: result.logs ?? [],
+								...buildMemoryStructuredContent(surfacedMemories),
+							},
+							isError: true,
+						}
+					}
+
+					const companionLimited =
+						passthrough?.structuredResult === undefined ||
+						passthrough.structuredResult === null
+							? null
+							: limitExecutionResultValue(
+									passthrough.structuredResult,
+									responseLimitBytes,
+								)
+
+					return {
+						content: prependToolMetadataContent(resolvedConversationId, [
+							...contentLimited.blocks,
+							...formatSurfacedMemoriesMarkdown(surfacedMemories),
+						]),
+						structuredContent: {
+							conversationId: resolvedConversationId,
+							timing,
+							...(activeStorageId ? { storage: { id: activeStorageId } } : {}),
+							returnedBytes:
+								contentLimited.returnedBytes +
+								(companionLimited?.returnedBytes ?? 0),
+							...(companionLimited?.truncated
+								? {
+										truncated: true,
+										note: companionLimited.note,
+									}
+								: {}),
+							result: companionLimited
+								? companionLimited.value
+								: (passthrough?.structuredResult ?? null),
+							logs: result.logs ?? [],
+							...buildMemoryStructuredContent(surfacedMemories),
+						},
+						isError: passthrough?.isError ?? false,
+					}
+				}
+
 				const limitedResult = limitExecutionResultValue(
 					result.result,
-					responseLimit ?? defaultExecutionResponseLimitBytes,
+					responseLimitBytes,
 				)
-				const rawContent = limitedResult.truncated
-					? null
-					: extractRawContent(limitedResult.value)
+				const markerOnlyPassthrough =
+					passthrough &&
+					(passthrough.isError || passthrough.structuredResult !== null)
+						? passthrough
+						: null
+				const structuredResultValue = markerOnlyPassthrough
+					? limitExecutionResultValue(
+							markerOnlyPassthrough.structuredResult ?? {},
+							responseLimitBytes,
+						)
+					: limitedResult
+
 				return {
 					content: prependToolMetadataContent(resolvedConversationId, [
-						...(rawContent ?? [
-							{
-								type: 'text',
-								text: formatLimitedExecutionOutput({
-									value: limitedResult.value,
-									truncated: limitedResult.truncated,
-									note: limitedResult.note,
-									displayText: limitedResult.displayText,
-								}),
-							},
-						]),
+						{
+							type: 'text',
+							text: formatLimitedExecutionOutput({
+								value: structuredResultValue.value,
+								truncated: structuredResultValue.truncated,
+								note: structuredResultValue.note,
+								displayText: structuredResultValue.displayText,
+							}),
+						},
 						...formatSurfacedMemoriesMarkdown(surfacedMemories),
 					]),
 					structuredContent: {
 						conversationId: resolvedConversationId,
 						timing,
 						...(activeStorageId ? { storage: { id: activeStorageId } } : {}),
-						returnedBytes: limitedResult.returnedBytes,
-						...(limitedResult.truncated
+						returnedBytes: structuredResultValue.returnedBytes,
+						...(structuredResultValue.truncated
 							? {
 									truncated: true,
-									note: limitedResult.note,
+									note: structuredResultValue.note,
 								}
 							: {}),
-						result: rawContent ? null : limitedResult.value,
+						result: structuredResultValue.value,
 						logs: result.logs ?? [],
 						...buildMemoryStructuredContent(surfacedMemories),
 					},
-					isError: false,
+					isError: markerOnlyPassthrough?.isError ?? false,
 				}
 			}
 		},

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -12,6 +12,7 @@ import {
 	readAuthSessionResult,
 	setAuthSessionSecret,
 } from '#app/auth-session.ts'
+import { isAccountEmailVerified } from '#app/email-verification.ts'
 import { getEnv } from '#app/env.ts'
 import { type OAuthAuthorizeLoaderData } from '#app/loader-data.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
@@ -40,6 +41,8 @@ export const oauthPaths = {
 export const oauthScopes: Array<string> = ['profile', 'email']
 const invalidOAuthClientRegistrationMessage =
 	'Invalid OAuth client registration.'
+export const oauthEmailVerificationRequiredMessage =
+	'Verify your account email before authorizing MCP access. Keep this page open, resend or open the verification link from Account in another tab, then continue.'
 
 type OAuthProps = {
 	userId: string
@@ -626,6 +629,16 @@ export async function loadOAuthAuthorizeData(
 		}
 	}
 
+	const { email: sessionEmail, setCookie: sessionSetCookie } =
+		await resolveSessionEmail(request, env)
+	let emailVerified: boolean | null = null
+	if (sessionEmail) {
+		emailVerified = await isAccountEmailVerified({
+			db: env.APP_DB,
+			email: sessionEmail,
+		})
+	}
+
 	return {
 		data: {
 			ok: true,
@@ -634,8 +647,9 @@ export async function loadOAuthAuthorizeData(
 				name: client.clientName ?? client.clientId,
 			},
 			scopes: resolvedScopes,
+			emailVerified,
 		},
-		setCookie: clearResetVerificationCookie,
+		setCookie: clearResetVerificationCookie ?? sessionSetCookie,
 	}
 }
 
@@ -659,6 +673,7 @@ export async function handleAuthorizeInfo(
 			ok: true,
 			client: data.client,
 			scopes: data.scopes,
+			emailVerified: data.emailVerified,
 		},
 		{
 			headers: createSetCookieHeaders([setCookie]),
@@ -892,6 +907,30 @@ export async function handleAuthorizeRequest(
 				isSecureRequest(request),
 			)
 		}
+	}
+
+	const emailVerified = await isAccountEmailVerified({
+		db: env.APP_DB,
+		email: approvedEmail,
+		stableUserId: approvedUserId,
+	})
+	if (!emailVerified) {
+		void logAuditEvent({
+			category: 'oauth',
+			action: 'authorize',
+			result: 'failure',
+			email: approvedEmail,
+			ip: requestIp,
+			clientId: authRequest.clientId,
+			reason: 'email_verification_required',
+		})
+		return respondAuthorizeError(
+			request,
+			oauthEmailVerificationRequiredMessage,
+			403,
+			'email_verification_required',
+			createSetCookieHeaders([setCookie]),
+		)
 	}
 
 	const resolvedScopes = resolveScopes(authRequest.scope)

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -18,6 +18,7 @@ import { invalidClientIdMismatchMessage } from '@kody-internal/shared/oauth-mess
 import {
 	handleAuthorizeInfo,
 	handleAuthorizeRequest,
+	oauthEmailVerificationRequiredMessage,
 	oauthScopes,
 } from './oauth-handlers.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
@@ -76,13 +77,21 @@ function createHelpers(overrides: Partial<OAuthHelpers> = {}): OAuthHelpers {
 	}
 }
 
-async function createDatabase(password: string) {
+async function createDatabase(
+	password: string,
+	options: { emailVerifiedAt?: string | null } = {},
+) {
 	const passwordHash = await createPasswordHash(password)
+	const emailVerifiedAt =
+		options.emailVerifiedAt === undefined
+			? new Date(0).toISOString()
+			: options.emailVerifiedAt
 	return {
 		prepare(query: string) {
 			// The 2FA gate queries verifications during inline OAuth login; the
 			// mocked user has no verification rows, so those queries are empty.
 			const isVerificationsQuery = query.includes('FROM verifications')
+			const isEmailVerifiedQuery = query.includes('email_verified_at')
 			return {
 				bind() {
 					return {
@@ -96,6 +105,7 @@ async function createDatabase(password: string) {
 												username: 'test-user',
 												email: 'user@example.com',
 												password_hash: passwordHash,
+												email_verified_at: emailVerifiedAt,
 											},
 										],
 								meta: { changes: 0, last_row_id: 0 },
@@ -103,11 +113,15 @@ async function createDatabase(password: string) {
 						},
 						async first() {
 							if (isVerificationsQuery) return null
+							if (isEmailVerifiedQuery) {
+								return { email_verified_at: emailVerifiedAt }
+							}
 							return {
 								id: 1,
 								username: 'test-user',
 								email: 'user@example.com',
 								password_hash: passwordHash,
+								email_verified_at: emailVerifiedAt,
 							}
 						},
 						async run() {
@@ -193,7 +207,11 @@ async function createSha256Hex(value: string) {
 		.join('')
 }
 
-async function seedWorkerUser(email: string, password: string) {
+async function seedWorkerUser(
+	email: string,
+	password: string,
+	options: { emailVerifiedAt?: string | null } = {},
+) {
 	const passwordHash = await createPasswordHash(password)
 	await env.APP_DB.prepare(
 		`CREATE TABLE IF NOT EXISTS users (
@@ -201,6 +219,7 @@ async function seedWorkerUser(email: string, password: string) {
 			username TEXT NOT NULL UNIQUE,
 			email TEXT NOT NULL UNIQUE,
 			password_hash TEXT NOT NULL,
+			email_verified_at TEXT,
 			created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
 			updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
 		)`,
@@ -222,12 +241,23 @@ async function seedWorkerUser(email: string, password: string) {
 			UNIQUE (target, type)
 		)`,
 	).run()
+	const emailVerifiedAt =
+		options.emailVerifiedAt === undefined
+			? new Date(0).toISOString()
+			: options.emailVerifiedAt
 	const result = await env.APP_DB.prepare(
-		`INSERT INTO users (username, email, password_hash)
-			VALUES (?, ?, ?)
-			ON CONFLICT(email) DO UPDATE SET password_hash = excluded.password_hash`,
+		`INSERT INTO users (username, email, password_hash, email_verified_at)
+			VALUES (?, ?, ?, ?)
+			ON CONFLICT(email) DO UPDATE SET
+				password_hash = excluded.password_hash,
+				email_verified_at = excluded.email_verified_at`,
 	)
-		.bind(`user-${crypto.randomUUID().slice(0, 8)}`, email, passwordHash)
+		.bind(
+			`user-${crypto.randomUUID().slice(0, 8)}`,
+			email,
+			passwordHash,
+			emailVerifiedAt,
+		)
 		.run()
 	return Number(result.meta.last_row_id)
 }
@@ -263,6 +293,7 @@ test('authorize info, denial, approval, and default scopes follow the OAuth work
 		ok: true,
 		client: { id: baseClient.clientId, name: baseClient.clientName },
 		scopes: baseAuthRequest.scope,
+		emailVerified: null,
 	})
 
 	const authorizeHtmlResponse = await handleAuthorizeRequest(
@@ -499,6 +530,97 @@ test('session approval uses database user id when cookie email is stale', async 
 	).resolves.toMatchObject({
 		session: { id: String(userId), email: currentEmail },
 	})
+})
+
+test('authorize rejects unverified accounts before creating a grant', async () => {
+	const completeAuthorization = vi.fn(async () => ({
+		redirectTo: 'https://example.com/callback?code=should-not-happen',
+	}))
+	const helpers = createHelpers({ completeAuthorization })
+	const unverifiedResponse = await handleAuthorizeRequest(
+		createFormRequest(
+			{
+				decision: 'approve',
+				email: 'user@example.com',
+				password: 'password123',
+			},
+			{ Accept: 'application/json' },
+		),
+		createEnv(
+			helpers,
+			await createDatabase('password123', { emailVerifiedAt: null }),
+		),
+	)
+
+	expect(unverifiedResponse.status).toBe(403)
+	await expect(unverifiedResponse.json()).resolves.toEqual({
+		ok: false,
+		error: oauthEmailVerificationRequiredMessage,
+		code: 'email_verification_required',
+	})
+	expect(completeAuthorization).not.toHaveBeenCalled()
+
+	setAuthSessionSecret(cookieSecret)
+	const cookie = await createAuthCookie(
+		{ id: 'session-id', email: 'user@example.com', rememberMe: false },
+		false,
+	)
+	const sessionUnverifiedResponse = await handleAuthorizeRequest(
+		createFormRequest(
+			{ decision: 'approve' },
+			{ Accept: 'application/json', Cookie: cookie },
+		),
+		createEnv(
+			helpers,
+			await createDatabase('password123', { emailVerifiedAt: null }),
+		),
+	)
+	expect(sessionUnverifiedResponse.status).toBe(403)
+	await expect(sessionUnverifiedResponse.json()).resolves.toMatchObject({
+		ok: false,
+		code: 'email_verification_required',
+	})
+	expect(completeAuthorization).not.toHaveBeenCalled()
+
+	const authorizeInfo = await handleAuthorizeInfo(
+		new Request(
+			'https://example.com/oauth/authorize-info?response_type=code&client_id=client-123&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&scope=profile&state=demo',
+			{
+				headers: { Accept: 'application/json', Cookie: cookie },
+			},
+		),
+		createEnv(
+			helpers,
+			await createDatabase('password123', { emailVerifiedAt: null }),
+		),
+	)
+	expect(authorizeInfo.status).toBe(200)
+	await expect(authorizeInfo.json()).resolves.toMatchObject({
+		ok: true,
+		emailVerified: false,
+	})
+
+	completeAuthorization.mockClear()
+	completeAuthorization.mockImplementation(async () => ({
+		redirectTo: 'https://example.com/callback?code=verified-ok',
+	}))
+	const verifiedResponse = await handleAuthorizeRequest(
+		createFormRequest(
+			{
+				decision: 'approve',
+				email: 'user@example.com',
+				password: 'password123',
+			},
+			{ Accept: 'application/json' },
+		),
+		createEnv(helpers, await createDatabase('password123')),
+	)
+	expect(verifiedResponse.status).toBe(200)
+	await expect(verifiedResponse.json()).resolves.toEqual({
+		ok: true,
+		redirectTo: 'https://example.com/callback?code=verified-ok',
+	})
+	expect(completeAuthorization).toHaveBeenCalledTimes(1)
 })
 
 test('worker entrypoint handles Claude-shaped authorize GET requests', async () => {

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -2,7 +2,8 @@ import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { normalizePackageInvocationExportName } from '@kody-internal/shared/public-urls.ts'
 import { toHex } from '@kody-internal/shared/hex.ts'
 import { type RemoteConnectorRef } from '@kody-internal/shared/remote-connectors.ts'
-import { extractRawContent, getExecutionErrorDetails } from '#mcp/executor.ts'
+import { getExecutionErrorDetails } from '#mcp/executor.ts'
+import { persistableExecutionArtifacts } from '#mcp/downstream-mcp-result.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { canonicalJsonStringify } from '@kody-internal/shared/canonical-json.ts'
 import { toJsonSafeValue } from '@kody-internal/shared/json-safe-value.ts'
@@ -687,6 +688,11 @@ function buildExecutionSuccessResponse(input: {
 	result: unknown
 	logs: Array<string>
 	rawContent: Array<ContentBlock> | null
+	rawContentOmitted: null | {
+		note: string
+		returnedBytes: number
+		blockCount: number
+	}
 }): PackageInvocationStoredResponse {
 	return {
 		status: 200,
@@ -707,6 +713,9 @@ function buildExecutionSuccessResponse(input: {
 			logs: input.logs,
 			...(input.rawContent
 				? { rawContent: toJsonSafeValue(input.rawContent) }
+				: {}),
+			...(input.rawContentOmitted
+				? { rawContentOmitted: input.rawContentOmitted }
 				: {}),
 		},
 	}
@@ -1205,26 +1214,33 @@ async function invokeSavedPackageModule(input: {
 				}),
 			},
 		)
-		const response = executionResult.error
-			? buildExecutionErrorResponse({
-					savedPackage: input.savedPackage,
-					invocationName: input.invocationName,
-					idempotencyKey: input.idempotencyKey,
-					source: input.source,
-					topic: input.topic,
-					error: executionResult.error,
-					logs: executionResult.logs ?? [],
-				})
-			: buildExecutionSuccessResponse({
-					savedPackage: input.savedPackage,
-					invocationName: input.invocationName,
-					idempotencyKey: input.idempotencyKey,
-					source: input.source,
-					topic: input.topic,
-					result: executionResult.result,
-					logs: executionResult.logs ?? [],
-					rawContent: extractRawContent(executionResult.result),
-				})
+		let response: PackageInvocationStoredResponse
+		if (executionResult.error) {
+			response = buildExecutionErrorResponse({
+				savedPackage: input.savedPackage,
+				invocationName: input.invocationName,
+				idempotencyKey: input.idempotencyKey,
+				source: input.source,
+				topic: input.topic,
+				error: executionResult.error,
+				logs: executionResult.logs ?? [],
+			})
+		} else {
+			const persistedArtifacts = persistableExecutionArtifacts(
+				executionResult.result,
+			)
+			response = buildExecutionSuccessResponse({
+				savedPackage: input.savedPackage,
+				invocationName: input.invocationName,
+				idempotencyKey: input.idempotencyKey,
+				source: input.source,
+				topic: input.topic,
+				result: persistedArtifacts.result,
+				rawContent: persistedArtifacts.rawContent,
+				rawContentOmitted: persistedArtifacts.rawContentOmitted,
+				logs: executionResult.logs ?? [],
+			})
+		}
 		await updatePackageInvocationResult({
 			db: input.env.APP_DB,
 			id: invocationId,

--- a/packages/worker/tsconfig-client.json
+++ b/packages/worker/tsconfig-client.json
@@ -24,7 +24,8 @@
 		"./src/app/frame-constants.ts",
 		"./src/app/community-frame-constants.ts",
 		"./src/app/community-public-types.ts",
-		"./src/app/loader-data.ts"
+		"./src/app/loader-data.ts",
+		"./src/app/safe-redirect.ts"
 	],
 	"exclude": ["./client/**/*.test.ts", "./client/**/*.spec.ts"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add a verification-first signup and onboarding experience that blocks MCP OAuth grants until the account email is verified.
- Preserve safe OAuth resume targets consistently across signup, resend, verification, server redirects, and SPA navigation.
- Pass protocol-valid downstream MCP image, audio, and resource blocks through `execute` with bounded media-specific limits.
- Harden stale verification state, open redirects, marker collisions, malformed payload handling, and durable invocation persistence.

## Validation

- `npm run validate` passes: format, lint, typecheck, 825 unit/worker tests, 14 Playwright tests, and 2 MCP E2E tests.
- CI Validate, preview deployment, CodeRabbit, and Cursor Bugbot checks pass on `602eb2af`.
- All substantive automated review findings are addressed; one optional test-encoding nit remains intentionally unchanged because it does not affect production behavior.
- Manual browser walkthrough confirms unverified onboarding is blocked, no MCP URL is exposed, resend/continue controls work, and `/onboarding` redirects to verification.

<a href="https://cursor.com/agents/bc-019f5764-0d98-74b4-a272-fc054f52f304/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverification-first-onboarding.mp4"><img src="https://cursor.com/artifacts/c/art-ea2f7442-41bf-4d18-a56a-ab751f6b1f08" alt="verification-first-onboarding.mp4" /></a>

![Verification-first pending page](https://cursor.com/artifacts/c/art-9ca24a43-be85-464b-8b03-8609c3af9a8a)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `025ea00a` · **Head:** `602eb2af`

**Classification:** extends — changes email-verification gates, MCP OAuth authorization, and downstream MCP result transport without adding a primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — adds pending-verification and redirect-safe onboarding states |
| `app-sessions` | auth | extends — preserves safe post-verification redirect state |
| `mcp-oauth` | auth | extends — rejects grant approval until email verification |
| `mcp-server` | surfaces | extends — emits bounded non-text protocol content through execute |
| `capability-registry` | assistant | extends — synthesized downstream tools retain MCP content blocks |
| `mcp-client-servers` | assistant | extends — validates and wraps downstream tool content |
| `remote-connectors` | assistant | extends — validates and wraps connector tool content |
| `package-runtime` | runtime | extends — bounds persisted raw invocation content |

### System map

Email verification gates onboarding and OAuth grants while downstream media flows through trusted markers into MCP responses and bounded persistence.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	appSessions["app-sessions<br/>Browser sessions"]:::extended
	mcpOauth["mcp-oauth<br/>MCP OAuth"]:::extended
	mcpClients["mcp-client-servers<br/>MCP client servers"]:::extended
	remoteConnectors["remote-connectors<br/>Remote connectors"]:::extended
	capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	packageRuntime["package-runtime<br/>Package runtime"]:::extended
	appUi -->|"pending-verification + safe redirectTo"| appSessions
	appSessions -->|"verified-email guard before grant"| mcpOauth
	mcpClients -->|"validated CallToolResult content"| capabilityRegistry
	remoteConnectors -->|"validated tool content"| capabilityRegistry
	capabilityRegistry -->|"trusted bounded content markers"| mcpServer
	mcpServer -->|"bounded raw invocation artifacts"| packageRuntime
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Every verification, grant, connector, and persisted invocation path remains scoped to the authenticated `userId`.
- Unverified accounts retain browser sessions for resend and recovery, but cannot receive MCP OAuth grants.
- Verification resume targets remain same-origin across server and client navigation.
- Kody does not fetch downstream image URLs or normalize malformed content blocks.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5764-0d98-74b4-a272-fc054f52f304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5764-0d98-74b4-a272-fc054f52f304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **pending email verification** experience with **Resend** and **Continue** actions, including redirect preservation.
  * Email verification now gates onboarding, OAuth approval, and MCP availability.
  * Enhanced MCP tool/execute handling for **non-text** (images/audio/resources) and **structured** content, with clearer output sizing.
* **Bug Fixes**
  * Improved protection against unsafe redirects and malformed/oversized MCP payloads.
* **Documentation**
  * Updated auth and MCP content protocol docs for verification gating and passthrough behavior.
* **Tests**
  * Expanded unit and end-to-end coverage for verification redirects, OAuth gating, and MCP passthrough validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->