### PR TITLE
Remove duplicate account section links already in the nav

### DIFF
--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -1130,30 +1130,19 @@ export function AccountSecretsRoute(handle: Handle) {
 					description="Create, update, and delete user secrets and package-owned secrets."
 					currentHref={currentHref}
 					actions={
-						<>
-							<a
-								href="/account/remote-connectors"
-								mix={css({
-									...secondaryButtonCss,
-									textDecoration: 'none',
-								})}
-							>
-								Remote connectors
-							</a>
-							<button
-								type="button"
-								disabled={isMutating}
-								mix={[
-									on('click', () => {
-										if (isMutating) return
-										navigate(buildNewSecretHref(getCurrentSearch()))
-									}),
-									css(primaryButtonCss),
-								]}
-							>
-								New secret
-							</button>
-						</>
+						<button
+							type="button"
+							disabled={isMutating}
+							mix={[
+								on('click', () => {
+									if (isMutating) return
+									navigate(buildNewSecretHref(getCurrentSearch()))
+								}),
+								css(primaryButtonCss),
+							]}
+						>
+							New secret
+						</button>
 					}
 				/>
 

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -525,7 +525,7 @@ export function AccountRoute(handle: Handle) {
 			<AccountManagementShell>
 				<AccountPageHeader
 					title="Account"
-					description="Manage your profile, integrations, approval requests, stored secrets, and package invocation tokens."
+					description="Manage your profile, security settings, connected accounts, and data export."
 					currentHref={currentHref}
 				/>
 
@@ -815,16 +815,6 @@ export function AccountRoute(handle: Handle) {
 							) : null}
 						</AccountManagementPanel>
 						<AccountManagementPanel
-							title="Secret management"
-							description="Create, edit, and delete secrets from the dedicated management page."
-						>
-							<div>
-								<a href="/account/secrets" mix={css(primaryLinkCss)}>
-									Manage secrets
-								</a>
-							</div>
-						</AccountManagementPanel>
-						<AccountManagementPanel
 							title="Your data"
 							description="Download a portable JSON export of your Kody account data for backup or migration. Secret values are never included; secret entries export metadata such as names, hosts, and allowlists only."
 						>
@@ -835,49 +825,6 @@ export function AccountRoute(handle: Handle) {
 									mix={css(primaryLinkCss)}
 								>
 									Download account export
-								</a>
-							</div>
-						</AccountManagementPanel>
-						<AccountManagementPanel
-							title="Integrations"
-							description="Review saved OAuth provider configurations and reconnect integrations when tokens need to be refreshed."
-						>
-							<div>
-								<a href="/account/integrations" mix={css(primaryLinkCss)}>
-									Manage integrations
-								</a>
-							</div>
-						</AccountManagementPanel>
-						<AccountManagementPanel
-							title="Package invocation tokens"
-							description="Create and revoke bearer tokens for trusted personal clients that call saved package exports."
-						>
-							<div>
-								<a
-									href="/account/package-invocation-tokens"
-									mix={css(primaryLinkCss)}
-								>
-									Manage package tokens
-								</a>
-							</div>
-						</AccountManagementPanel>
-						<AccountManagementPanel
-							title="MCP servers"
-							description="Connect remote MCP servers so their tools become Kody capabilities, including OAuth-protected servers."
-						>
-							<div>
-								<a href="/account/mcp-servers" mix={css(primaryLinkCss)}>
-									Manage MCP servers
-								</a>
-							</div>
-						</AccountManagementPanel>
-						<AccountManagementPanel
-							title="Remote connectors"
-							description="Attach generic remote connector refs to normal Kody sessions and manage their connector hello shared secrets."
-						>
-							<div>
-								<a href="/account/remote-connectors" mix={css(primaryLinkCss)}>
-									Manage remote connectors
 								</a>
 							</div>
 						</AccountManagementPanel>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The account overview page had shortcut panels linking to Secrets, Integrations, Package tokens, MCP servers, and Remote connectors — destinations already reachable from the account sections nav. The secrets page header also had a stray Remote connectors button. This PR removes those duplicates so each destination lives in one place.

## Changes

- Drop the nav-duplicate panels from `/account` (keep Profile, Security, Connected accounts, and Your data)
- Update the account page description to match what remains
- Remove the Remote connectors action from the secrets page header (keep New secret)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `d3034257` · **Head:** `0f0d3f5d`

**Classification:** composes — no primitives added or changed; this PR only trims duplicate account UI links that already appear in the account sections nav.

### Primitives touched

| Primitive | Group    | Impact |
| --------- | -------- | ------ |
| `app-ui`  | surfaces | composes — remove duplicate `/account` and secrets-page header links |

### System map

Account UI stops repeating destinations that the account sections nav already exposes.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>App UI / Remix routes"]:::touched
	accountNav["Account sections nav"]:::untouched
	appUi -->|"drop duplicate panels + secrets header link"| accountNav
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface | Before | After |
| ------- | ------ | ----- |
| `/account` | Profile + Security + Connected accounts + Your data + 5 nav-duplicate panels | Profile + Security + Connected accounts + Your data |
| Secrets header actions | Remote connectors + New secret | New secret |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7415662-f356-45ec-b158-336441ab5ae2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7415662-f356-45ec-b158-336441ab5ae2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prominent “New secret” button to the account secrets page.

* **Changes**
  * Simplified the Account page by removing the Secret management, Integrations, Package invocation tokens, MCP servers, and Remote connectors panels.
  * Updated the Account page header description.
  * Removed the Remote connectors link from the account secrets page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->