### PR TITLE
Add search/filtering and infinite scroll to the admin users page

### DIFF
--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -116,18 +116,15 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	await expect(page.getByRole('heading', { name: 'Admin users' })).toBeVisible()
 	await expect(page.getByText(/Showing ([2-9]|\d{2,}) of \d+/)).toBeVisible()
 
-	const initialUsersApiResponse = await page.request.get(
-		'/admin/users.json?pageSize=100',
-	)
-	expect(initialUsersApiResponse.ok()).toBe(true)
-	const initialUsersPayload = await initialUsersApiResponse.json()
-	expect(initialUsersPayload.ok).toBe(true)
-	const lastUsersPage = Math.max(
-		1,
-		Math.ceil(Number(initialUsersPayload.total) / 100),
-	)
+	// Deep links with `?page=N` must not anchor the list past unreachable
+	// earlier pages: the initial window always seeds from page one.
+	await page.goto('/admin/users?pageSize=1&page=99999')
+	await expect(page.getByRole('heading', { name: 'Admin users' })).toBeVisible()
+	await expect(page.getByText(/Showing \d+ of \d+/)).toBeVisible()
 
-	await page.goto(`/admin/users?pageSize=100&page=${lastUsersPage}`)
+	// Both rbac users share the `rbac-${runId}` username suffix, so search
+	// pins the list to exactly the accounts this test seeded.
+	await page.goto(`/admin/users?q=rbac-${runId}`)
 	await expect(page.getByRole('heading', { name: 'Admin users' })).toBeVisible()
 	// The first user is auto-selected, so the email can render in both the
 	// list and the detail panel — assert on the list entry specifically.
@@ -139,7 +136,7 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	await expect(page.getByText('super-secret-value')).toHaveCount(0)
 
 	const usersApiResponse = await page.request.get(
-		`/admin/users.json?pageSize=100&page=${lastUsersPage}`,
+		`/admin/users.json?q=rbac-${runId}`,
 	)
 	expect(usersApiResponse.ok()).toBe(true)
 	const usersPayload = await usersApiResponse.json()
@@ -154,7 +151,7 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 
 	// The usage drill-down lives on the users page and loads for the
 	// selected account only.
-	await page.goto(`/admin/users?pageSize=100&page=${lastUsersPage}`)
+	await page.goto(`/admin/users?q=rbac-${runId}`)
 	await page.getByRole('button', { name: memberUser.username }).click()
 	await expect(page.getByText('Usage & quotas')).toBeVisible()
 	await expect(
@@ -194,7 +191,7 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	expect(JSON.stringify(insightsPayload)).not.toContain('super-secret-value')
 	expect(JSON.stringify(insightsPayload)).not.toContain(memberUser.email)
 
-	await page.goto(`/admin/users?pageSize=100&page=${lastUsersPage}`)
+	await page.goto(`/admin/users?q=rbac-${runId}`)
 	await page.getByRole('button', { name: memberUser.username }).click()
 	await expect(page.getByText('Account metadata only')).toBeVisible()
 
@@ -204,7 +201,7 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	await page.getByRole('button', { name: 'Save plan' }).click()
 	await expect(planSelect).toHaveValue('pro')
 	const planApiResponse = await page.request.get(
-		`/admin/users.json?pageSize=100&page=${lastUsersPage}`,
+		`/admin/users.json?q=rbac-${runId}`,
 	)
 	expect(planApiResponse.ok()).toBe(true)
 	const planPayload = await planApiResponse.json()
@@ -213,6 +210,21 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	)
 	expect(memberAfterPlan.plan).toBe('pro')
 
+	// Mutations under an active role filter: removing the filtered role must
+	// drop the row from the list and shrink the filtered total in place.
+	await page.goto(`/admin/users?q=rbac-${runId}&role=user`)
+	await expect(page.getByText('Showing 2 of 2 accounts')).toBeVisible()
+	await page.getByRole('button', { name: memberUser.username }).click()
+	const filteredRoleSelect = page.getByLabel('Role', { exact: true })
+	await filteredRoleSelect.selectOption('user')
+	await page.getByRole('button', { name: 'Remove', exact: true }).click()
+	await expect(
+		page.getByRole('button', { name: memberUser.username }),
+	).toHaveCount(0)
+	await expect(page.getByText('Showing 1 of 1 account')).toBeVisible()
+
+	await page.goto(`/admin/users?q=rbac-${runId}`)
+	await page.getByRole('button', { name: memberUser.username }).click()
 	const roleSelect = page.getByLabel('Role', { exact: true })
 	await roleSelect.selectOption('admin')
 	await page.getByRole('button', { name: 'Assign', exact: true }).click()

--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -86,6 +86,36 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 		),
 	).toBe(true)
 
+	// Server-side search: typing in the accounts search filters the list,
+	// writes `q` to the URL, and the reported total shrinks to match.
+	const usersSearchInput = page.getByLabel('Search', { exact: true })
+	await usersSearchInput.fill(memberUser.username)
+	await expect(page).toHaveURL(new RegExp(`q=${memberUser.username}`))
+	await expect(
+		page.getByRole('button', { name: memberUser.username }),
+	).toBeVisible()
+	await expect(
+		page.getByRole('button', { name: adminUser.username }),
+	).toHaveCount(0)
+	const searchApiResponse = await page.request.get(
+		`/admin/users.json?q=${memberUser.username}`,
+	)
+	expect(searchApiResponse.ok()).toBe(true)
+	const searchPayload = await searchApiResponse.json()
+	expect(searchPayload.total).toBe(1)
+	expect(searchPayload.users[0].email).toBe(memberUser.email)
+
+	await usersSearchInput.fill(`no-user-matches-${runId}`)
+	await expect(
+		page.getByText('No users match the current filters.'),
+	).toBeVisible()
+
+	// Infinite scroll: with a one-user page size the sentinel is visible in
+	// the under-filled list and auto-loads following pages.
+	await page.goto('/admin/users?pageSize=1')
+	await expect(page.getByRole('heading', { name: 'Admin users' })).toBeVisible()
+	await expect(page.getByText(/Showing ([2-9]|\d{2,}) of \d+/)).toBeVisible()
+
 	const initialUsersApiResponse = await page.request.get(
 		'/admin/users.json?pageSize=100',
 	)
@@ -183,7 +213,7 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	)
 	expect(memberAfterPlan.plan).toBe('pro')
 
-	const roleSelect = page.getByLabel('Role')
+	const roleSelect = page.getByLabel('Role', { exact: true })
 	await roleSelect.selectOption('admin')
 	await page.getByRole('button', { name: 'Assign', exact: true }).click()
 	await page.context().clearCookies()

--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -120,7 +120,7 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	// earlier pages: the initial window always seeds from page one.
 	await page.goto('/admin/users?pageSize=1&page=99999')
 	await expect(page.getByRole('heading', { name: 'Admin users' })).toBeVisible()
-	await expect(page.getByText(/Showing \d+ of \d+/)).toBeVisible()
+	await expect(page.getByText(/Showing [1-9]\d* of \d+/)).toBeVisible()
 
 	// Both rbac users share the `rbac-${runId}` username suffix, so search
 	// pins the list to exactly the accounts this test seeded.

--- a/packages/worker/client/infinite-list.node.test.ts
+++ b/packages/worker/client/infinite-list.node.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from 'vitest'
+import {
+	createInfiniteList,
+	type InfiniteListSnapshot,
+} from './infinite-list.ts'
+
+type Item = { id: number }
+
+function createList() {
+	let snapshot: InfiniteListSnapshot<Item> | null = null
+	const list = createInfiniteList<Item>({
+		mergeDirection: 'append',
+		getKey: (item) => String(item.id),
+		onSnapshot: (nextSnapshot) => {
+			snapshot = nextSnapshot
+		},
+	})
+	return { list, getSnapshot: () => snapshot ?? list.getSnapshot() }
+}
+
+test('loadMore appends, dedupes overlap, and tracks hasMore', async () => {
+	const { list, getSnapshot } = createList()
+
+	await list.loadInitial(async () => ({
+		items: [{ id: 1 }, { id: 2 }],
+		hasMore: true,
+		totalCount: 3,
+	}))
+	expect(getSnapshot().items.map((item) => item.id)).toEqual([1, 2])
+	expect(getSnapshot().hasMore).toBe(true)
+
+	// Overlapping windows (an item created while scrolling shifts offsets)
+	// must not produce duplicate rows.
+	const loaded = await list.loadMore(async () => ({
+		items: [{ id: 2 }, { id: 3 }],
+		hasMore: false,
+		totalCount: 3,
+	}))
+	expect(loaded).toBe(true)
+	expect(getSnapshot().items.map((item) => item.id)).toEqual([1, 2, 3])
+	expect(getSnapshot().hasMore).toBe(false)
+
+	// Nothing more to load: loadMore is a no-op that reports false.
+	expect(
+		await list.loadMore(async () => ({
+			items: [{ id: 4 }],
+			hasMore: false,
+			totalCount: 4,
+		})),
+	).toBe(false)
+	expect(getSnapshot().items.map((item) => item.id)).toEqual([1, 2, 3])
+})
+
+test('reset invalidates an in-flight loadMore so a stale page never lands', async () => {
+	const { list, getSnapshot } = createList()
+	await list.loadInitial(async () => ({
+		items: [{ id: 1 }],
+		hasMore: true,
+		totalCount: 10,
+	}))
+
+	let releaseStaleLoad = () => {}
+	const staleGate = new Promise<void>((resolve) => {
+		releaseStaleLoad = resolve
+	})
+	const staleLoadMore = list.loadMore(async () => {
+		await staleGate
+		return { items: [{ id: 2 }], hasMore: true, totalCount: 10 }
+	})
+
+	// Filters changed: the window is re-seeded while the old page is in
+	// flight (this is what the admin users page does on every filter edit).
+	list.reset()
+	list.replaceWindow({
+		items: [{ id: 7 }],
+		hasMore: true,
+		totalCount: 2,
+	})
+	releaseStaleLoad()
+
+	expect(await staleLoadMore).toBe(false)
+	expect(getSnapshot().items.map((item) => item.id)).toEqual([7])
+	expect(getSnapshot().totalCount).toBe(2)
+})
+
+test('loadMore failures surface an error without dropping loaded items', async () => {
+	const { list, getSnapshot } = createList()
+	await list.loadInitial(async () => ({
+		items: [{ id: 1 }],
+		hasMore: true,
+		totalCount: 2,
+	}))
+
+	const loaded = await list.loadMore(async () => {
+		throw new Error('Unable to load more users.')
+	})
+	expect(loaded).toBe(false)
+	expect(getSnapshot().error).toBe('Unable to load more users.')
+	expect(getSnapshot().items.map((item) => item.id)).toEqual([1])
+	expect(getSnapshot().isLoadingMore).toBe(false)
+})

--- a/packages/worker/client/infinite-scroll.ts
+++ b/packages/worker/client/infinite-scroll.ts
@@ -1,0 +1,39 @@
+import { ref } from 'remix/ui'
+
+/**
+ * Mixin for an infinite-scroll sentinel element rendered at the end of a
+ * list. When the sentinel scrolls into view (or near it), `loadMore` runs.
+ * `loadMore` must resolve to whether more items were actually loaded —
+ * `createInfiniteList().loadMore` already returns exactly that — so an
+ * under-filled viewport keeps loading until the sentinel leaves view or
+ * there is nothing left, without looping forever once the list is done.
+ */
+export function infiniteScrollSentinel(
+	loadMore: () => Promise<boolean> | boolean,
+) {
+	return ref((node: Element, signal: AbortSignal) => {
+		let running = false
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (!entries.some((entry) => entry.isIntersecting)) return
+				if (running) return
+				running = true
+				void (async () => {
+					try {
+						const loadedMore = await loadMore()
+						if (signal.aborted || !loadedMore) return
+						// Re-observing delivers a fresh initial notification, so a
+						// still-visible sentinel triggers the next page load.
+						observer.unobserve(node)
+						observer.observe(node)
+					} finally {
+						running = false
+					}
+				})()
+			},
+			{ rootMargin: '200px' },
+		)
+		observer.observe(node)
+		signal.addEventListener('abort', () => observer.disconnect())
+	})
+}

--- a/packages/worker/client/replace-location.ts
+++ b/packages/worker/client/replace-location.ts
@@ -1,0 +1,17 @@
+import { routerEvents } from '#client/client-router.tsx'
+
+/**
+ * Replace the current URL without adding a history entry and notify the
+ * router so route components re-render against the new location. Use this
+ * for URL-backed filter state (search fields, filter selects) where every
+ * keystroke would otherwise pollute history or restart scroll positions.
+ */
+export function replaceLocation(to: string) {
+	if (typeof window === 'undefined') return
+	const destination = new URL(to, window.location.href)
+	const nextPath = `${destination.pathname}${destination.search}${destination.hash}`
+	const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`
+	if (nextPath === currentPath) return
+	window.history.replaceState({}, '', nextPath)
+	routerEvents.dispatchEvent(new Event('navigate'))
+}

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -11,8 +11,10 @@ import {
 	cardCss,
 	cardTitleCss,
 	descriptionCss,
+	fieldCss,
 	fieldLabelCss,
 	getSecondaryButtonCss,
+	inputCss,
 	layoutMaxWidths,
 } from '#client/styles/style-primitives.ts'
 
@@ -336,6 +338,45 @@ export function AccountManagementList(
 				{handle.props.children}
 			</ul>
 		</div>
+	)
+}
+
+type AccountManagementSearchFieldProps = {
+	label: string
+	placeholder: string
+	value: string
+	onInput: (value: string) => void
+}
+
+/**
+ * URL-backed search input for sidebar lists (secrets, admin users, ...).
+ * Callers own the URL update — typically `replaceLocation(...)` with the
+ * value written to a `q` query param.
+ */
+export function AccountManagementSearchField(
+	handle: Handle<AccountManagementSearchFieldProps>,
+) {
+	return () => (
+		<label mix={css(fieldCss)}>
+			<span mix={css(fieldLabelCss)}>{handle.props.label}</span>
+			<input
+				type="search"
+				value={handle.props.value}
+				placeholder={handle.props.placeholder}
+				aria-label={handle.props.label}
+				mix={[
+					on('input', (event) =>
+						handle.props.onInput(
+							(event.currentTarget as HTMLInputElement).value,
+						),
+					),
+					css({
+						...inputCss,
+						paddingRight: spacing.xl,
+					}),
+				]}
+			/>
+		</label>
 	)
 }
 

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -7,11 +7,8 @@ import {
 	buildAccountSecretPath,
 	parseAccountSecretPath,
 } from '@kody-internal/shared/account-secret-route.ts'
-import {
-	navigate,
-	routerEvents,
-	readCurrentRouterHref,
-} from '#client/client-router.tsx'
+import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { replaceLocation } from '#client/replace-location.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import {
@@ -57,6 +54,7 @@ import {
 	AccountManagementList,
 	AccountManagementListItemButton,
 	AccountManagementMessage,
+	AccountManagementSearchField,
 	AccountManagementShell,
 	AccountManagementSidebar,
 	AccountPageHeader,
@@ -444,16 +442,6 @@ function buildNewSecretHref(search = '') {
 
 function buildBaseSecretsHref(search = '') {
 	return buildSecretsHref(secretsBasePath, search)
-}
-
-function replaceSecretsLocation(to: string) {
-	if (typeof window === 'undefined') return
-	const destination = new URL(to, window.location.href)
-	const nextPath = `${destination.pathname}${destination.search}${destination.hash}`
-	const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`
-	if (nextPath === currentPath) return
-	window.history.replaceState({}, '', nextPath)
-	routerEvents.dispatchEvent(new Event('navigate'))
 }
 
 function getDataRefreshKey(href: string) {
@@ -1312,33 +1300,16 @@ export function AccountSecretsRoute(handle: Handle) {
 									gap: spacing.sm,
 								})}
 							>
-								<label mix={css(fieldCss)}>
-									<span mix={css(fieldLabelCss)}>Search</span>
-									<input
-										type="search"
-										value={filters.search}
-										placeholder="Search secrets"
-										aria-label="Search secrets"
-										mix={[
-											on(
-												'input',
-
-												(event) => {
-													replaceSecretsLocation(
-														buildHrefWithUpdatedFilters({
-															search: event.currentTarget.value,
-														}),
-													)
-												},
-											),
-
-											css({
-												...inputCss,
-												paddingRight: spacing.xl,
-											}),
-										]}
-									/>
-								</label>
+								<AccountManagementSearchField
+									label="Search"
+									placeholder="Search secrets"
+									value={filters.search}
+									onInput={(value) => {
+										replaceLocation(
+											buildHrefWithUpdatedFilters({ search: value }),
+										)
+									}}
+								/>
 								<label mix={css(fieldCss)}>
 									<span mix={css(fieldLabelCss)}>Scope</span>
 									<select
@@ -1351,7 +1322,7 @@ export function AccountSecretsRoute(handle: Handle) {
 												(event) => {
 													const nextScope = event.currentTarget
 														.value as SecretFilterScope
-													replaceSecretsLocation(
+													replaceLocation(
 														buildHrefWithUpdatedFilters({
 															scope: nextScope,
 															packageId:
@@ -1378,7 +1349,7 @@ export function AccountSecretsRoute(handle: Handle) {
 											disabled: filters.scope === 'user',
 											options: filterPackageOptions,
 											onChange: (packageId) => {
-												replaceSecretsLocation(
+												replaceLocation(
 													buildHrefWithUpdatedFilters({
 														packageId,
 													}),

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -91,15 +91,30 @@ function readFilterState(href: string): AdminUserFilterState {
 	}
 }
 
+/**
+ * Initial loads must anchor the window at page 1 — seeding from a stale
+ * `?page=N` link would leave every earlier page unreachable because
+ * infinite scroll only appends later pages.
+ */
+function stripPageParam(search: string) {
+	const params = new URLSearchParams(search)
+	params.delete('page')
+	const next = params.toString()
+	return next ? `?${next}` : ''
+}
+
 export async function adminUsersRouteLoader(
 	url: URL,
 	signal: AbortSignal,
 ): Promise<RouteLoaderResult> {
-	const response = await fetch(`${adminUsersApiPath}${url.search}`, {
-		headers: { Accept: 'application/json' },
-		credentials: 'include',
-		signal,
-	})
+	const response = await fetch(
+		`${adminUsersApiPath}${stripPageParam(url.search)}`,
+		{
+			headers: { Accept: 'application/json' },
+			credentials: 'include',
+			signal,
+		},
+	)
 	if (response.status === 401) {
 		return routeLoaderRedirect('/login')
 	}
@@ -257,7 +272,7 @@ export function AdminUsersRoute(handle: Handle) {
 		const requestId = ++loadRequestId
 		try {
 			const response = await fetch(
-				`${adminUsersApiPath}${readRouterSearch(handle)}`,
+				`${adminUsersApiPath}${stripPageParam(readRouterSearch(handle))}`,
 				{ headers: { Accept: 'application/json' }, credentials: 'include' },
 			)
 			if (requestId !== loadRequestId) return
@@ -328,18 +343,34 @@ export function AdminUsersRoute(handle: Handle) {
 	/**
 	 * Mutation responses carry the refreshed target user; patch it in place
 	 * so a list the admin has scrolled deep into keeps its loaded window and
-	 * selection instead of resetting to the first page.
+	 * selection instead of resetting to the first page. A role change can
+	 * knock the target out of the active role filter, so drop rows that no
+	 * longer match and take the refreshed filtered total from the server.
 	 */
 	function applyMutationPayload(payload: AdminUsersMutationData) {
 		availableRoles = payload.availableRoles
 		availablePlans = payload.availablePlans
 		const updatedUser = payload.updatedUser
-		if (updatedUser) {
-			userList.updateItems((items) =>
-				items.map((item) => (item.id === updatedUser.id ? updatedUser : item)),
-			)
-		}
+		const { role } = readFilterState(readCurrentRouterHref(handle))
+		const matchesRoleFilter =
+			!updatedUser ||
+			!role ||
+			(updatedUser.roles as Array<string>).includes(role)
+		const currentItems = usersSnapshot.items
+		const nextItems = updatedUser
+			? matchesRoleFilter
+				? currentItems.map((item) =>
+						item.id === updatedUser.id ? updatedUser : item,
+					)
+				: currentItems.filter((item) => item.id !== updatedUser.id)
+			: currentItems
+		userList.replaceWindow({
+			items: nextItems,
+			hasMore: nextItems.length < payload.total,
+			totalCount: payload.total,
+		})
 		resetPlanDraft()
+		ensureSelection()
 	}
 
 	async function submitRoleAction(action: 'assign_role' | 'remove_role') {

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -1,8 +1,14 @@
 import { formatTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
-import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { readRouterSearch } from '#client/router-location.tsx'
+import { replaceLocation } from '#client/replace-location.ts'
+import {
+	createInfiniteList,
+	type InfiniteListSnapshot,
+} from '#client/infinite-list.ts'
+import { infiniteScrollSentinel } from '#client/infinite-scroll.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
@@ -21,6 +27,7 @@ import {
 	AccountManagementListItemButton,
 	AccountManagementMessage,
 	AccountManagementPanel,
+	AccountManagementSearchField,
 	AccountManagementShell,
 	AccountManagementSidebar,
 	AdminPageHeader,
@@ -42,6 +49,7 @@ import {
 	type AdminPlanName,
 	type AdminUserListItem,
 	type AdminUsersLoaderData,
+	type AdminUsersMutationData,
 	type AdminUserUsageLoaderData,
 } from '#app/loader-data.ts'
 import {
@@ -69,11 +77,18 @@ function isAdminUsersPath(href: string) {
 	return path === '/admin/users' || path === '/admin'
 }
 
-function buildUsersHref(handle: Handle, page: number) {
-	const url = new URL(readCurrentRouterHref(handle), 'http://localhost')
-	if (page <= 1) url.searchParams.delete('page')
-	else url.searchParams.set('page', String(page))
-	return `${url.pathname}${url.search}`
+type AdminUserFilterState = {
+	search: string
+	role: string
+}
+
+/** Read the `q`/`role` filter params the server applies to the list. */
+function readFilterState(href: string): AdminUserFilterState {
+	const url = new URL(href, 'http://localhost')
+	return {
+		search: url.searchParams.get('q')?.trim() ?? '',
+		role: url.searchParams.get('role')?.trim() ?? '',
+	}
 }
 
 export async function adminUsersRouteLoader(
@@ -100,12 +115,19 @@ export async function adminUsersRouteLoader(
 
 export function AdminUsersRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
-	let users: Array<AdminUserListItem> = []
 	let availableRoles: Array<RoleName> = []
 	let availablePlans: Array<AdminPlanName> = []
-	let page = 1
 	let pageSize = 20
-	let total = 0
+	let loadedThroughPage = 1
+	const userList = createInfiniteList<AdminUserListItem>({
+		mergeDirection: 'append',
+		getKey: (user) => String(user.id),
+		onSnapshot: (snapshot) => {
+			usersSnapshot = snapshot
+		},
+	})
+	let usersSnapshot: InfiniteListSnapshot<AdminUserListItem> =
+		userList.getSnapshot()
 	let selectedUserId: number | null = null
 	let message: string | null = null
 	let actionState: 'idle' | 'assigning' | 'removing' | 'saving-plan' = 'idle'
@@ -127,7 +149,53 @@ export function AdminUsersRoute(handle: Handle) {
 	let usageFailedForUserId: number | null = null
 
 	function getSelectedUser() {
-		return users.find((user) => user.id === selectedUserId) ?? null
+		return (
+			usersSnapshot.items.find((user) => user.id === selectedUserId) ?? null
+		)
+	}
+
+	function ensureSelection() {
+		const users = usersSnapshot.items
+		if (
+			selectedUserId != null &&
+			!users.some((user) => user.id === selectedUserId)
+		) {
+			selectedUserId = users[0]?.id ?? null
+		}
+		if (selectedUserId == null && users.length > 0) {
+			selectedUserId = users[0]?.id ?? null
+		}
+	}
+
+	function seedUsersFromPayload(payload: AdminUsersLoaderData) {
+		availableRoles = payload.availableRoles
+		availablePlans = payload.availablePlans
+		pageSize = payload.pageSize
+		loadedThroughPage = payload.page
+		// reset() invalidates any in-flight load-more so a stale page fetched
+		// for the previous filters can never append into the fresh window.
+		userList.reset()
+		userList.replaceWindow({
+			items: payload.users,
+			hasMore: payload.page * payload.pageSize < payload.total,
+			totalCount: payload.total,
+		})
+		resetPlanDraft()
+		ensureSelection()
+	}
+
+	function buildHrefWithUpdatedFilters(
+		nextFilters: Partial<AdminUserFilterState>,
+	) {
+		const url = new URL(readCurrentRouterHref(handle), 'http://localhost')
+		const filters = { ...readFilterState(url.toString()), ...nextFilters }
+		if (filters.search) url.searchParams.set('q', filters.search)
+		else url.searchParams.delete('q')
+		if (filters.role) url.searchParams.set('role', filters.role)
+		else url.searchParams.delete('role')
+		// Filter changes re-anchor the list at the first page.
+		url.searchParams.delete('page')
+		return `${url.pathname}${url.search}`
 	}
 
 	async function loadUserUsage(userId: number) {
@@ -208,23 +276,8 @@ export function AdminUsersRoute(handle: Handle) {
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load admin users.')
 			}
-			users = payload.users
-			availableRoles = payload.availableRoles
-			availablePlans = payload.availablePlans
-			page = payload.page
-			pageSize = payload.pageSize
-			total = payload.total
-			resetPlanDraft()
+			seedUsersFromPayload(payload)
 			lastLoadedHref = href
-			if (
-				selectedUserId != null &&
-				!users.some((user) => user.id === selectedUserId)
-			) {
-				selectedUserId = users[0]?.id ?? null
-			}
-			if (selectedUserId == null && users.length > 0) {
-				selectedUserId = users[0]?.id ?? null
-			}
 			status = 'ready'
 			message = null
 			lastFailedHref = null
@@ -239,6 +292,54 @@ export function AdminUsersRoute(handle: Handle) {
 		} finally {
 			if (requestId === loadRequestId) loadingForHref = null
 		}
+	}
+
+	async function loadMoreUsers() {
+		if (status !== 'ready') return false
+		const nextPage = loadedThroughPage + 1
+		const loaded = await userList.loadMore(async () => {
+			const url = new URL(readCurrentRouterHref(handle), 'http://localhost')
+			url.searchParams.set('page', String(nextPage))
+			const response = await fetch(`${adminUsersApiPath}${url.search}`, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+			})
+			if (response.status === 401) {
+				window.location.assign('/login')
+				throw new Error('Signed out.')
+			}
+			const payload = await readJson<AdminUsersLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load more users.')
+			}
+			return {
+				items: payload.users,
+				hasMore: payload.page * payload.pageSize < payload.total,
+				totalCount: payload.total,
+			}
+		})
+		if (loaded) {
+			loadedThroughPage = nextPage
+		}
+		handle.update()
+		return loaded
+	}
+
+	/**
+	 * Mutation responses carry the refreshed target user; patch it in place
+	 * so a list the admin has scrolled deep into keeps its loaded window and
+	 * selection instead of resetting to the first page.
+	 */
+	function applyMutationPayload(payload: AdminUsersMutationData) {
+		availableRoles = payload.availableRoles
+		availablePlans = payload.availablePlans
+		const updatedUser = payload.updatedUser
+		if (updatedUser) {
+			userList.updateItems((items) =>
+				items.map((item) => (item.id === updatedUser.id ? updatedUser : item)),
+			)
+		}
+		resetPlanDraft()
 	}
 
 	async function submitRoleAction(action: 'assign_role' | 'remove_role') {
@@ -270,18 +371,12 @@ export function AdminUsersRoute(handle: Handle) {
 				return
 			}
 			const payload = await readJson<
-				AdminUsersLoaderData & { ok?: boolean; error?: string }
+				AdminUsersMutationData & { ok?: boolean; error?: string }
 			>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to update user roles.')
 			}
-			users = payload.users
-			availableRoles = payload.availableRoles
-			availablePlans = payload.availablePlans
-			page = payload.page
-			pageSize = payload.pageSize
-			total = payload.total
-			resetPlanDraft()
+			applyMutationPayload(payload)
 			selectedUserId = selectedUser.id
 			lastLoadedHref = readCurrentRouterHref(handle)
 			message =
@@ -329,18 +424,12 @@ export function AdminUsersRoute(handle: Handle) {
 				return
 			}
 			const payload = await readJson<
-				AdminUsersLoaderData & { ok?: boolean; error?: string }
+				AdminUsersMutationData & { ok?: boolean; error?: string }
 			>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to update user plan.')
 			}
-			users = payload.users
-			availableRoles = payload.availableRoles
-			availablePlans = payload.availablePlans
-			page = payload.page
-			pageSize = payload.pageSize
-			total = payload.total
-			resetPlanDraft()
+			applyMutationPayload(payload)
 			invalidateUsage()
 			selectedUserId = selectedUser.id
 			lastLoadedHref = readCurrentRouterHref(handle)
@@ -363,23 +452,8 @@ export function AdminUsersRoute(handle: Handle) {
 		if (!isAdminUsersPath(href)) return false
 		const routeData = tryConsumeRouteLoaderData(handle, 'adminUsers', href)
 		if (!routeData) return false
-		users = routeData.users
-		availableRoles = routeData.availableRoles
-		availablePlans = routeData.availablePlans
-		page = routeData.page
-		pageSize = routeData.pageSize
-		total = routeData.total
-		resetPlanDraft()
+		seedUsersFromPayload(routeData)
 		lastLoadedHref = href
-		if (
-			selectedUserId != null &&
-			!users.some((user) => user.id === selectedUserId)
-		) {
-			selectedUserId = users[0]?.id ?? null
-		}
-		if (selectedUserId == null && users.length > 0) {
-			selectedUserId = users[0]?.id ?? null
-		}
 		status = 'ready'
 		message = null
 		lastFailedHref = null
@@ -396,7 +470,7 @@ export function AdminUsersRoute(handle: Handle) {
 			lastSeenHref = currentHref
 			lastFailedHref = null
 		}
-		// Consume route-loader data before deriving `totalPages` and
+		// Consume route-loader data before deriving the list snapshot and
 		// `selectedUser`; deriving first would render this pass from the
 		// stale pre-navigation closure state.
 		const appliedRouteData = applyRouteLoaderData(currentHref)
@@ -416,7 +490,9 @@ export function AdminUsersRoute(handle: Handle) {
 			handle.queueTask(loadAdminUsers)
 		}
 
-		const totalPages = Math.max(1, Math.ceil(total / pageSize))
+		const { items: users, hasMore, totalCount, isLoadingMore } = usersSnapshot
+		const filters = readFilterState(currentHref)
+		const hasActiveFilters = Boolean(filters.search || filters.role)
 		const selectedUser = getSelectedUser()
 		const isMutating = actionState !== 'idle'
 
@@ -474,89 +550,130 @@ export function AdminUsersRoute(handle: Handle) {
 							title="Accounts"
 							description="Select a user to review metadata and roles."
 						>
+							<div mix={css({ display: 'grid', gap: spacing.sm })}>
+								<AccountManagementSearchField
+									label="Search"
+									placeholder="Search by username or email"
+									value={filters.search}
+									onInput={(value) => {
+										replaceLocation(
+											buildHrefWithUpdatedFilters({ search: value }),
+										)
+									}}
+								/>
+								<label mix={css(fieldCss)}>
+									<span mix={css(fieldLabelCss)}>Role</span>
+									<select
+										value={filters.role}
+										aria-label="Filter users by role"
+										mix={[
+											on('change', (event) => {
+												replaceLocation(
+													buildHrefWithUpdatedFilters({
+														role: event.currentTarget.value,
+													}),
+												)
+											}),
+											css(inputCss),
+										]}
+									>
+										<option value="">All roles</option>
+										{availableRoles.map((role) => (
+											<option key={role} value={role}>
+												{role}
+											</option>
+										))}
+									</select>
+								</label>
+							</div>
 							{status === 'ready' && users.length === 0 ? (
 								<p mix={css({ margin: 0, color: colors.textMuted })}>
-									No users found.
+									{hasActiveFilters
+										? 'No users match the current filters.'
+										: 'No users found.'}
 								</p>
 							) : (
-								<AccountManagementList maxHeight="min(65vh, 48rem)">
-									{users.map((user) => (
-										<li key={user.id} mix={css({ minWidth: 0 })}>
-											<AccountManagementListItemButton
-												active={selectedUserId === user.id}
-												disabled={isMutating}
-												onClick={() => {
-													if (isMutating) return
-													selectedUserId = user.id
-													message = null
-													handle.update()
-												}}
+								<>
+									<AccountManagementList maxHeight="min(65vh, 48rem)">
+										{users.map((user) => (
+											<li key={user.id} mix={css({ minWidth: 0 })}>
+												<AccountManagementListItemButton
+													active={selectedUserId === user.id}
+													disabled={isMutating}
+													onClick={() => {
+														if (isMutating) return
+														selectedUserId = user.id
+														message = null
+														handle.update()
+													}}
+												>
+													<strong mix={css({ display: 'block' })}>
+														{user.username}
+													</strong>
+													<span
+														mix={css({
+															display: 'block',
+															fontSize: typography.fontSize.sm,
+															color: colors.textMuted,
+														})}
+													>
+														{user.email}
+													</span>
+													<span
+														mix={css({
+															display: 'block',
+															fontSize: typography.fontSize.xs,
+															color: colors.textMuted,
+														})}
+													>
+														{user.roles.length > 0
+															? user.roles.join(', ')
+															: 'No roles'}
+													</span>
+												</AccountManagementListItemButton>
+											</li>
+										))}
+										{hasMore ? (
+											<li
+												key="load-more-sentinel"
+												mix={[
+													infiniteScrollSentinel(loadMoreUsers),
+													css({ display: 'grid' }),
+												]}
 											>
-												<strong mix={css({ display: 'block' })}>
-													{user.username}
-												</strong>
-												<span
-													mix={css({
-														display: 'block',
-														fontSize: typography.fontSize.sm,
-														color: colors.textMuted,
-													})}
+												<button
+													type="button"
+													disabled={isLoadingMore}
+													mix={[
+														on('click', () => void loadMoreUsers()),
+														css(secondaryButtonCss),
+													]}
 												>
-													{user.email}
-												</span>
-												<span
-													mix={css({
-														display: 'block',
-														fontSize: typography.fontSize.xs,
-														color: colors.textMuted,
-													})}
-												>
-													{user.roles.length > 0
-														? user.roles.join(', ')
-														: 'No roles'}
-												</span>
-											</AccountManagementListItemButton>
-										</li>
-									))}
-								</AccountManagementList>
+													{isLoadingMore ? 'Loading more…' : 'Load more'}
+												</button>
+											</li>
+										) : null}
+									</AccountManagementList>
+									{usersSnapshot.error ? (
+										<AccountManagementMessage tone="error">
+											{usersSnapshot.error}
+										</AccountManagementMessage>
+									) : null}
+									{status === 'ready' ? (
+										<p
+											mix={css({
+												margin: 0,
+												marginTop: spacing.sm,
+												color: colors.textMuted,
+												fontSize: typography.fontSize.xs,
+											})}
+										>
+											Showing {users.length} of {totalCount}{' '}
+											{totalCount === 1 ? 'account' : 'accounts'}
+										</p>
+									) : null}
+								</>
 							)}
-							{totalPages > 1 ? (
-								<div
-									mix={css({
-										display: 'flex',
-										gap: spacing.sm,
-										marginTop: spacing.md,
-									})}
-								>
-									<button
-										type="button"
-										disabled={page <= 1 || isMutating}
-										mix={[
-											on('click', () =>
-												navigate(buildUsersHref(handle, page - 1)),
-											),
-											css(secondaryButtonCss),
-										]}
-									>
-										Previous
-									</button>
-									<span mix={css({ color: colors.textMuted })}>
-										Page {page} of {totalPages}
-									</span>
-									<button
-										type="button"
-										disabled={page >= totalPages || isMutating}
-										mix={[
-											on('click', () =>
-												navigate(buildUsersHref(handle, page + 1)),
-											),
-											css(secondaryButtonCss),
-										]}
-									>
-										Next
-									</button>
-								</div>
-							) : null}
 						</AccountManagementSidebar>
 					}
 				>

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -352,10 +352,16 @@ export function AdminUsersRoute(handle: Handle) {
 		availablePlans = payload.availablePlans
 		const updatedUser = payload.updatedUser
 		const { role } = readFilterState(readCurrentRouterHref(handle))
+		// The server ignores unknown role values, so only a known role counts
+		// as an active filter — otherwise every mutation would wrongly remove
+		// its target from the list.
+		const activeRoleFilter = (availableRoles as Array<string>).includes(role)
+			? role
+			: ''
 		const matchesRoleFilter =
 			!updatedUser ||
-			!role ||
-			(updatedUser.roles as Array<string>).includes(role)
+			!activeRoleFilter ||
+			(updatedUser.roles as Array<string>).includes(activeRoleFilter)
 		const currentItems = usersSnapshot.items
 		const nextItems = updatedUser
 			? matchesRoleFilter
@@ -364,6 +370,9 @@ export function AdminUsersRoute(handle: Handle) {
 					)
 				: currentItems.filter((item) => item.id !== updatedUser.id)
 			: currentItems
+		// reset() invalidates any in-flight load-more so a page fetched before
+		// the mutation cannot merge stale rows or counts back in afterward.
+		userList.reset()
 		userList.replaceWindow({
 			items: nextItems,
 			hasMore: nextItems.length < payload.total,

--- a/packages/worker/src/app/admin-users-data.ts
+++ b/packages/worker/src/app/admin-users-data.ts
@@ -42,6 +42,49 @@ export type AdminUserListItem = Record<AdminUserListItemFieldName, unknown> & {
 const defaultPageSize = 20
 const maxPageSize = 100
 
+type AdminUserListFilters = {
+	query: string
+	role: RoleName | null
+}
+
+/** Read the `q` and `role` filter query params shared by the page and API. */
+function readAdminUserListFilters(url: URL): AdminUserListFilters {
+	const rawRole = url.searchParams.get('role')?.trim() ?? ''
+	return {
+		query: url.searchParams.get('q')?.trim() ?? '',
+		role: isRoleName(rawRole) ? rawRole : null,
+	}
+}
+
+function escapeLikePattern(value: string) {
+	return value.replace(/[\\%_]/g, (char) => `\\${char}`)
+}
+
+/**
+ * Build the WHERE clause shared by the page query and its COUNT so the
+ * reported total always matches the filtered result set.
+ */
+function buildAdminUserListWhereClause(filters: AdminUserListFilters) {
+	const conditions: Array<string> = []
+	const params: Array<string> = []
+	if (filters.query) {
+		const pattern = `%${escapeLikePattern(filters.query)}%`
+		conditions.push(`(username LIKE ? ESCAPE '\\' OR email LIKE ? ESCAPE '\\')`)
+		params.push(pattern, pattern)
+	}
+	if (filters.role) {
+		conditions.push(
+			`id IN (SELECT ur.user_id FROM user_roles ur INNER JOIN roles r ON r.id = ur.role_id WHERE r.name = ?)`,
+		)
+		params.push(filters.role)
+	}
+	return {
+		whereClause:
+			conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '',
+		params,
+	}
+}
+
 export async function loadAdminUsersData(
 	env: Env,
 	requestUrl: string,
@@ -51,18 +94,21 @@ export async function loadAdminUsersData(
 		defaultPageSize,
 		maxPageSize,
 	})
+	const filters = readAdminUserListFilters(url)
+	const { whereClause, params } = buildAdminUserListWhereClause(filters)
 
 	const [totalResult, userRows] = await Promise.all([
-		env.APP_DB.prepare(`SELECT COUNT(*) AS total FROM users`).first<{
-			total: number
-		}>(),
+		env.APP_DB.prepare(`SELECT COUNT(*) AS total FROM users ${whereClause}`)
+			.bind(...params)
+			.first<{ total: number }>(),
 		env.APP_DB.prepare(
 			`SELECT id, username, email, email_verified_at, plan, created_at, updated_at
 			 FROM users
+			 ${whereClause}
 			 ORDER BY id ASC
 			 LIMIT ? OFFSET ?`,
 		)
-			.bind(pageSize, offset)
+			.bind(...params, pageSize, offset)
 			.all<AdminUserRow>(),
 	])
 	const total = totalResult?.total ?? 0

--- a/packages/worker/src/app/handlers/admin-users.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-users.node.test.ts
@@ -70,6 +70,37 @@ function createAdminTestEnv(input: {
 		APP_DB: {
 			prepare(query: string) {
 				const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
+				// Mirrors buildAdminUserListWhereClause: an optional
+				// username/email LIKE pair followed by an optional role
+				// membership param, shared by the page query and its COUNT.
+				function applyListFilters(params: Array<unknown>) {
+					let rows = Array.from(users.values()).sort((a, b) => a.id - b.id)
+					let paramIndex = 0
+					if (normalizedQuery.includes('username like ?')) {
+						const pattern = String(params[paramIndex])
+						paramIndex += 2
+						const needle = pattern
+							.slice(1, -1)
+							.replace(/\\(.)/g, '$1')
+							.toLowerCase()
+						rows = rows.filter(
+							(row) =>
+								row.username.toLowerCase().includes(needle) ||
+								row.email.toLowerCase().includes(needle),
+						)
+					}
+					if (normalizedQuery.includes('where r.name = ?')) {
+						const roleName = String(params[paramIndex])
+						paramIndex += 1
+						rows = rows.filter((row) =>
+							userRoles.some(
+								(role) =>
+									role.user_id === row.id && role.role_name === roleName,
+							),
+						)
+					}
+					return { rows, paramIndex }
+				}
 				const execute = {
 					async all<T>() {
 						if (
@@ -100,11 +131,10 @@ function createAdminTestEnv(input: {
 						return {
 							async all<T>() {
 								if (normalizedQuery.startsWith('select id, username, email')) {
-									const pageSize = Number(params[0])
-									const offset = Number(params[1])
-									const results = Array.from(users.values())
-										.sort((a, b) => a.id - b.id)
-										.slice(offset, offset + pageSize)
+									const { rows, paramIndex } = applyListFilters(params)
+									const pageSize = Number(params[paramIndex])
+									const offset = Number(params[paramIndex + 1])
+									const results = rows.slice(offset, offset + pageSize)
 									return { results: results as Array<T>, meta: { changes: 0 } }
 								}
 								if (normalizedQuery.includes('where ur.user_id in')) {
@@ -124,6 +154,27 @@ function createAdminTestEnv(input: {
 							async first<T>() {
 								if (
 									normalizedQuery.includes(
+										'count(distinct ur.user_id) as count',
+									)
+								) {
+									const roleName = String(params[0])
+									const count = new Set(
+										userRoles
+											.filter((row) => row.role_name === roleName)
+											.map((row) => row.user_id),
+									).size
+									return { count } as T
+								}
+								if (
+									normalizedQuery.startsWith(
+										'select count(*) as total from users',
+									)
+								) {
+									const { rows } = applyListFilters(params)
+									return { total: rows.length } as T
+								}
+								if (
+									normalizedQuery.includes(
 										'select id, email from users where id =',
 									)
 								) {
@@ -137,19 +188,6 @@ function createAdminTestEnv(input: {
 								) {
 									const user = users.get(Number(params[0]))
 									return user ? ({ ...user } as T) : null
-								}
-								if (
-									normalizedQuery.includes(
-										'count(distinct ur.user_id) as count',
-									)
-								) {
-									const roleName = String(params[0])
-									const count = new Set(
-										userRoles
-											.filter((row) => row.role_name === roleName)
-											.map((row) => row.user_id),
-									).size
-									return { count } as T
 								}
 								return null
 							},
@@ -299,6 +337,78 @@ test('admin users list payload exposes only account metadata fields', async () =
 	])
 })
 
+test('admin users list applies q and role filters to the slice and total', async () => {
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(
+		createAdminActor(['admin']),
+	)
+	const env = createAdminTestEnv({
+		users: [
+			{
+				id: 1,
+				username: 'admin-user',
+				email: 'admin@example.com',
+				created_at: '2026-01-01 00:00:00',
+				updated_at: '2026-01-02 00:00:00',
+			},
+			{
+				id: 2,
+				username: 'searchable-member',
+				email: 'member@example.com',
+				created_at: '2026-01-03 00:00:00',
+				updated_at: '2026-01-04 00:00:00',
+			},
+			{
+				id: 3,
+				username: 'another-member',
+				email: 'searchable@example.com',
+				created_at: '2026-01-05 00:00:00',
+				updated_at: '2026-01-06 00:00:00',
+			},
+		],
+		userRoles: [
+			{ user_id: 1, role_name: 'admin' },
+			{ user_id: 2, role_name: 'user' },
+			{ user_id: 3, role_name: 'user' },
+		],
+	})
+	const handler = createAdminUsersApiHandler(env as unknown as Env)
+	const listUsers = async (search: string) => {
+		const response = await handler.handler({
+			request: new Request(`https://example.com/admin/users.json${search}`, {
+				headers: { Accept: 'application/json' },
+			}),
+			params: {},
+			url: new URL(`https://example.com/admin/users.json${search}`),
+		} as never)
+		expect(response.status).toBe(200)
+		return response.json()
+	}
+
+	// q matches username or email; total reflects the filtered set.
+	const searchPayload = await listUsers('?q=searchable')
+	expect(searchPayload.total).toBe(2)
+	expect(searchPayload.users.map((user: { id: number }) => user.id)).toEqual([
+		2, 3,
+	])
+
+	const rolePayload = await listUsers('?role=admin')
+	expect(rolePayload.total).toBe(1)
+	expect(rolePayload.users.map((user: { id: number }) => user.id)).toEqual([1])
+
+	const combinedPayload = await listUsers('?q=searchable&role=admin')
+	expect(combinedPayload.total).toBe(0)
+	expect(combinedPayload.users).toEqual([])
+
+	// Unknown role values are ignored rather than filtering everything out.
+	const unknownRolePayload = await listUsers('?role=not-a-role')
+	expect(unknownRolePayload.total).toBe(3)
+
+	// Filters and pagination compose.
+	const pagedPayload = await listUsers('?q=searchable&pageSize=1&page=2')
+	expect(pagedPayload.total).toBe(2)
+	expect(pagedPayload.users.map((user: { id: number }) => user.id)).toEqual([3])
+})
+
 test('assign role action updates user roles and logs audit event', async () => {
 	logAuditEventSpy.mockClear()
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(
@@ -338,6 +448,14 @@ test('assign role action updates user roles and logs audit event', async () => {
 	expect(response.status).toBe(200)
 	const payload = await response.json()
 	expect(payload.users[0].roles).toContain('admin')
+	// Mutations return the updated target so the client can patch it into
+	// an infinite-scroll window without resetting to the first page.
+	expect(payload.updatedUser).toEqual(
+		expect.objectContaining({
+			id: 2,
+			roles: expect.arrayContaining(['admin', 'user']),
+		}),
+	)
 	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({ category: 'admin', action: 'assign_role' }),
 	)

--- a/packages/worker/src/app/handlers/admin-users.ts
+++ b/packages/worker/src/app/handlers/admin-users.ts
@@ -58,7 +58,12 @@ export function createAdminUsersHandler(env: Env) {
 				return redirectToLogin(request)
 			}
 
-			const adminUsers = await loadAdminUsersData(env, request.url)
+			// The HTML page always seeds the first window; infinite scroll owns
+			// later pages through the JSON API, so a stale `?page=N` link must
+			// not anchor the list past the rows it can never load.
+			const pageUrl = new URL(request.url)
+			pageUrl.searchParams.delete('page')
+			const adminUsers = await loadAdminUsersData(env, pageUrl.toString())
 
 			return renderAppPage({
 				request,

--- a/packages/worker/src/app/handlers/admin-users.ts
+++ b/packages/worker/src/app/handlers/admin-users.ts
@@ -4,6 +4,7 @@ import { type Action } from 'remix/router'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
 import { loadAdminUserUsageData } from '#app/admin-user-usage-data.ts'
 import {
+	loadAdminUserByIdOrEmail,
 	loadAdminUsersData,
 	loadRolesByUserIds,
 	adminUserListItemFieldNames,
@@ -208,8 +209,24 @@ async function handleAssignRoleAction(input: {
 		reason: `target_user_id=${targetUserId};role=${roleName}`,
 	})
 
-	const payload = await loadAdminUsersData(input.env, input.request.url)
-	return jsonResponse(payload)
+	return buildMutationResponse(input.env, input.request.url, targetUserId)
+}
+
+/**
+ * Mutation responses carry the refreshed page slice plus the updated target
+ * user, because with infinite scroll the target may live outside the first
+ * page and the client patches it in place instead of resetting the list.
+ */
+async function buildMutationResponse(
+	env: Env,
+	requestUrl: string,
+	targetUserId: number,
+) {
+	const [payload, updatedUser] = await Promise.all([
+		loadAdminUsersData(env, requestUrl),
+		loadAdminUserByIdOrEmail(env.APP_DB, { id: targetUserId }),
+	])
+	return jsonResponse({ ...payload, updatedUser })
 }
 
 async function handleRemoveRoleAction(input: {
@@ -294,8 +311,7 @@ async function handleRemoveRoleAction(input: {
 		reason: `target_user_id=${targetUserId};role=${roleName}`,
 	})
 
-	const payload = await loadAdminUsersData(input.env, input.request.url)
-	return jsonResponse(payload)
+	return buildMutationResponse(input.env, input.request.url, targetUserId)
 }
 
 async function handleUpdatePlanAction(input: {
@@ -340,8 +356,7 @@ async function handleUpdatePlanAction(input: {
 		reason: `target_user_id=${targetUserId};plan=${planUpdate.plan ?? 'null'}`,
 	})
 
-	const payload = await loadAdminUsersData(input.env, input.request.url)
-	return jsonResponse(payload)
+	return buildMutationResponse(input.env, input.request.url, targetUserId)
 }
 
 /**

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -50,6 +50,15 @@ export type AdminUsersLoaderData = {
 	availablePlans: Array<AdminPlanName>
 }
 
+/**
+ * POST (mutation) responses also carry the updated target user so the
+ * client can patch it into an infinite-scroll list that may have scrolled
+ * past the first page.
+ */
+export type AdminUsersMutationData = AdminUsersLoaderData & {
+	updatedUser: AdminUserListItem | null
+}
+
 export type AdminRoleListItem = {
 	name: string
 	description: string

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-list.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-list.ts
@@ -22,6 +22,14 @@ const inputSchema = z.object({
 		.max(100)
 		.optional()
 		.describe('Users per page. Defaults to 20 and maxes at 100.'),
+	query: z
+		.string()
+		.optional()
+		.describe('Case-insensitive substring match on username or email.'),
+	role: z
+		.string()
+		.optional()
+		.describe('Only return users holding this role (for example "admin").'),
 })
 
 const outputSchema = z.object({
@@ -51,6 +59,8 @@ export const adminUserListCapability = defineDomainCapability(
 					if (args.pageSize) {
 						url.searchParams.set('pageSize', String(args.pageSize))
 					}
+					if (args.query) url.searchParams.set('q', args.query)
+					if (args.role) url.searchParams.set('role', args.role)
 					const data = await loadAdminUsersData(ctx.env, url.toString())
 					return {
 						total: data.total,

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-list.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-list.ts
@@ -6,6 +6,7 @@ import {
 	adminCapabilityAccess,
 	adminUserMetadataSchema,
 	auditAdminCapabilityInvocation,
+	roleNameSchema,
 } from './admin-shared.ts'
 
 const inputSchema = z.object({
@@ -26,8 +27,7 @@ const inputSchema = z.object({
 		.string()
 		.optional()
 		.describe('Case-insensitive substring match on username or email.'),
-	role: z
-		.string()
+	role: roleNameSchema
 		.optional()
 		.describe('Only return users holding this role (for example "admin").'),
 })


### PR DESCRIPTION
## Summary

- Adds server-side search (`q`, matching username or email) and a role filter (`role`) to the admin users page, mirroring the secrets page's URL-backed filter UX. Filters apply in SQL with a WHERE clause shared by the page slice and its `COUNT(*)`, so the reported total always matches the filtered set.
- Replaces Previous/Next pagination with infinite scroll: an IntersectionObserver sentinel (rendered as an accessible "Load more" button fallback) appends pages via the existing-but-unused `createInfiniteList`, with stale in-flight pages invalidated whenever filters change.
- Shares only what has real reuse ([AHA](https://kcd.im/aha)): `replace-location.ts` (extracted from the secrets page), `AccountManagementSearchField` (now used by secrets and admin users, ready for the other sidebar list pages), and `infinite-scroll.ts`.
- Role/plan mutation responses now include the updated target user (`updatedUser`) so the client patches it into a deeply-scrolled list instead of resetting to page one.
- The `admin_user_list` MCP capability gains matching `query`/`role` inputs.

## Test plan

- [x] Handler tests: `q`/`role`/pagination composition, unknown-role tolerance, `updatedUser` mutation contract (`admin-users.node.test.ts`)
- [x] New unit tests for `createInfiniteList`: append/dedupe, stale-page invalidation on reset, error handling
- [x] E2E (`admin-rbac.spec.ts`): typing in search filters the list and syncs the URL, filtered API totals, no-matches empty state, sentinel auto-load with `?pageSize=1`
- [x] `npm run validate` green locally

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `d3034257` · **Head:** `4d0d5242`

**Classification:** extends — the admin users JSON API contract gains `q`/`role` query params and an `updatedUser` field on mutation responses; the `admin_user_list` MCP capability input schema gains `query`/`role`. No primitives added; `primitives.yaml` unchanged.

### Primitives touched

| Primitive   | Group    | Impact                                                                                  |
| ----------- | -------- | --------------------------------------------------------------------------------------- |
| `app-ui`    | surfaces | extends — `/admin/users(.json)` filter params, infinite scroll, shared client utilities |
| `rbac`      | auth     | extends — `admin_user_list` capability accepts `query`/`role`; guards unchanged         |
| `d1-app-db` | storage  | composes — new WHERE clauses on existing `users`/`user_roles` tables; no schema change  |

### System map

Search and scroll flow from the admin users UI through the RBAC-guarded JSON API into filtered D1 queries.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	rbac["rbac<br/>Role-based access control"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::untouched
	appUi -->|"GET /admin/users.json?q=&role=&page="| rbac
	rbac -->|"filtered LIKE + role-membership WHERE on users/user_roles"| d1AppDb
	rbac -->|"POST mutations return updatedUser for in-place patch"| appUi
	mcpServer -->|"admin_user_list query/role inputs"| rbac
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Contract                     | Before                          | After                                                    |
| ---------------------------- | ------------------------------- | -------------------------------------------------------- |
| `GET /admin/users.json`      | `page`, `pageSize`              | + `q` (username/email substring), `role` (known role name) |
| `POST /admin/users.json`     | full first-page payload         | + `updatedUser` (refreshed target for in-place patching) |
| `admin_user_list` capability | `page`, `pageSize`              | + `query`, `role` (validated against `roleNameSchema`)   |
| Users page pagination        | Previous/Next buttons honoring `?page=N` | infinite scroll; initial loads ignore `?page` so stale deep links seed from page 1 |

### Invariants

Admin routes still expose account metadata only (`adminUserListItemFieldNames` unchanged; e2e privacy assertions still pass); all queries remain guarded by `read:user:any` / `update:user:any`.

### Plan vs actual

- Shipped as planned: server-side `q`/`role` filters, infinite scroll via `createInfiniteList`, shared `replace-location.ts` / `AccountManagementSearchField` / `infinite-scroll.ts`, `updatedUser` mutation patching.
- Review-driven drift: mutations now reconcile against the active role filter (drop non-matching rows, refresh total), and initial loads strip `?page=N` so stale deep links cannot orphan earlier rows.

</details>

<!-- system-recap:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the admin users JSON API and in-place role/plan mutation handling on RBAC-guarded routes; behavior is well tested but touches entitlement and role assignment flows.
> 
> **Overview**
> Adds **server-side search** (`q` on username/email) and a **role filter** to the admin users list, with URL-backed controls via `replaceLocation` and a shared `AccountManagementSearchField` (secrets page refactored to use the same helpers).
> 
> **Replaces Previous/Next pagination** with infinite scroll: `createInfiniteList`, an intersection-observer sentinel (`infinite-scroll.ts`), and initial loads that **strip `?page`** so deep links always seed from page one. Filter changes reset the list and invalidate in-flight `loadMore` requests.
> 
> **Role/plan POST responses** now include `updatedUser` so the client can patch a scrolled list in place; rows drop when a mutation removes the active role filter. D1 list queries share one filtered `WHERE` for rows and `COUNT(*)`.
> 
> The **`admin_user_list` MCP capability** accepts matching `query`/`role` inputs. E2E and handler/unit tests cover search, scroll, mutations, and privacy boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d0d5242b3012b5a358d038932feee0d90a7d86c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin users can be searched (username/email) and filtered by role, now backed by an infinite-scroll list.
  * Admin users integrations now support query and role filters, and mutation updates refresh the list plus the updated user.
  * Account secrets filters/search now update the URL smoothly (no new history entries).
* **Bug Fixes**
  * Filtered totals and results are now consistent end-to-end, including correct deep-linking and prevention of stale page anchoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->