### PR TITLE
Include community package icon in listing OG images

### DIFF
--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -154,8 +154,8 @@ mirroring app design tokens, satori layout + resvg rasterization, and the
 `publicOgPages` registry. Static public pages serve generated images from
 `/og/:page.png` (page ids such as `home`, `community`, `login`). Community
 listing cards use `og-image.ts` on that same pipeline and are served at
-`/community/:listingId/og.png` (package name, “Use Kody to …” description, star
-rating, fork count).
+`/community/:listingId/og.png` (package community icon, package name, “Use Kody
+to …” description, star rating, fork count).
 
 ## Admin moderation
 

--- a/packages/worker/src/app/handlers/community-detail-og-image.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail-og-image.node.test.ts
@@ -1,0 +1,136 @@
+import { expect, test, vi } from 'vitest'
+import { type CommunityListingWithAggregates } from '#worker/community/types.ts'
+import { createCommunityDetailOgImageHandler } from './community-detail.tsx'
+
+const mocks = vi.hoisted(() => ({
+	getCommunityIconObject: vi.fn(),
+	getCommunityListingWithAggregates: vi.fn(),
+	renderCommunityIconFallbackPng: vi.fn(),
+	renderCommunityOgImage: vi.fn(),
+}))
+
+vi.mock('#worker/community/community-icon.ts', () => ({
+	getCommunityIconObject: (...args: Array<unknown>) =>
+		mocks.getCommunityIconObject(...args),
+	renderCommunityIconFallbackPng: (...args: Array<unknown>) =>
+		mocks.renderCommunityIconFallbackPng(...args),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	getCommunityListingWithAggregates: (...args: Array<unknown>) =>
+		mocks.getCommunityListingWithAggregates(...args),
+	reportCommunityListing: vi.fn(),
+}))
+
+vi.mock('#worker/community/og-image.ts', () => ({
+	renderCommunityOgImage: (...args: Array<unknown>) =>
+		mocks.renderCommunityOgImage(...args),
+}))
+
+const listing = {
+	id: 'listing-1',
+	ownerUserId: 'owner-1',
+	packageId: 'package-1',
+	sourceId: 'source-1',
+	kodyId: 'github-triage',
+	name: '@kody/github-triage',
+	description: 'triage GitHub issues',
+	tags: [],
+	searchText: null,
+	readmeContent: null,
+	license: 'MIT',
+	pinnedCommit: 'abc123',
+	iconCommit: 'def456',
+	status: 'active',
+	createdAt: '2026-07-10T00:00:00.000Z',
+	updatedAt: '2026-07-10T00:00:00.000Z',
+	publishedAt: '2026-07-10T00:00:00.000Z',
+	averageStars: 4.6,
+	ratingCount: 12,
+	averageAdaptationEffort: null,
+	forkCount: 37,
+} satisfies CommunityListingWithAggregates
+
+const tinyPng = Uint8Array.from([
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+	0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02,
+	0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44,
+	0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x03, 0x00,
+	0x01, 0x00, 0x05, 0xfe, 0xd4, 0xef, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e,
+	0x44, 0xae, 0x42, 0x60, 0x82,
+])
+
+test('community detail OG image embeds the package icon data URI', async () => {
+	mocks.getCommunityListingWithAggregates.mockResolvedValue(listing)
+	mocks.getCommunityIconObject.mockResolvedValue({
+		descriptor: {
+			version: 1,
+			listingId: listing.id,
+			iconCommit: listing.iconCommit,
+			r2Key: 'community-icon:v1/listing-1/def456/asset',
+			contentType: 'image/png',
+			sourcePath: 'community-icon.png',
+			byteLength: tinyPng.byteLength,
+		},
+		object: {
+			arrayBuffer: async () => tinyPng.buffer.slice(0),
+		},
+	})
+	mocks.renderCommunityOgImage.mockResolvedValue(tinyPng)
+
+	const response = await createCommunityDetailOgImageHandler({} as Env).handler(
+		{
+			request: new Request('https://example.com/community/listing-1/og.png'),
+			params: { listingId: listing.id },
+			url: new URL('https://example.com/community/listing-1/og.png'),
+		} as never,
+	)
+
+	expect(response.status).toBe(200)
+	expect(response.headers.get('Content-Type')).toBe('image/png')
+	expect(mocks.renderCommunityOgImage).toHaveBeenCalledWith(
+		expect.objectContaining({
+			name: listing.name,
+			iconDataUri: expect.stringMatching(/^data:image\/png;base64,/),
+		}),
+	)
+	expect(mocks.renderCommunityIconFallbackPng).not.toHaveBeenCalled()
+})
+
+test('community detail OG image falls back when the icon is WebP', async () => {
+	mocks.getCommunityListingWithAggregates.mockResolvedValue(listing)
+	mocks.getCommunityIconObject.mockResolvedValue({
+		descriptor: {
+			version: 1,
+			listingId: listing.id,
+			iconCommit: listing.iconCommit,
+			r2Key: 'community-icon:v1/listing-1/def456/asset',
+			contentType: 'image/webp',
+			sourcePath: 'community-icon.webp',
+			byteLength: 12,
+		},
+		object: {
+			arrayBuffer: async () => new ArrayBuffer(12),
+		},
+	})
+	mocks.renderCommunityIconFallbackPng.mockResolvedValue(tinyPng)
+	mocks.renderCommunityOgImage.mockResolvedValue(tinyPng)
+
+	const response = await createCommunityDetailOgImageHandler({} as Env).handler(
+		{
+			request: new Request('https://example.com/community/listing-1/og.png'),
+			params: { listingId: listing.id },
+			url: new URL('https://example.com/community/listing-1/og.png'),
+		} as never,
+	)
+
+	expect(response.status).toBe(200)
+	expect(mocks.renderCommunityIconFallbackPng).toHaveBeenCalledWith(
+		listing.name,
+	)
+	expect(mocks.renderCommunityOgImage).toHaveBeenCalledWith(
+		expect.objectContaining({
+			iconDataUri: expect.stringMatching(/^data:image\/png;base64,/),
+		}),
+	)
+})

--- a/packages/worker/src/app/handlers/community-detail.tsx
+++ b/packages/worker/src/app/handlers/community-detail.tsx
@@ -17,11 +17,17 @@ import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 import { getRequestDataCacheLookup } from '#app/request-cache.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { bytesToBase64 } from '@kody-internal/shared/base64.ts'
 import { CommunityActionError } from '#worker/community/errors.ts'
+import {
+	getCommunityIconObject,
+	renderCommunityIconFallbackPng,
+} from '#worker/community/community-icon.ts'
 import {
 	getCommunityListingWithAggregates,
 	reportCommunityListing,
 } from '#worker/community/service.ts'
+import { type CommunityListingRecord } from '#worker/community/types.ts'
 
 const reportReasonSchema = z
 	.string()
@@ -106,6 +112,36 @@ export function createCommunityDetailApiHandler(env: Env) {
 	} satisfies Action<typeof routes.communityDetailApi>
 }
 
+/**
+ * Resolve a satori-safe data URI for the package community icon. PNG and JPEG
+ * bytes embed directly; WebP (unsupported by satori) and load failures fall
+ * back to the same generated mark the public icon route uses.
+ */
+async function loadCommunityOgIconDataUri(input: {
+	env: Env
+	listing: CommunityListingRecord
+}): Promise<string> {
+	try {
+		const { descriptor, object } = await getCommunityIconObject({
+			env: input.env,
+			listing: input.listing,
+			iconCommit: input.listing.iconCommit,
+		})
+		if (
+			descriptor.contentType === 'image/png' ||
+			descriptor.contentType === 'image/jpeg'
+		) {
+			const bytes = new Uint8Array(await object.arrayBuffer())
+			return `data:${descriptor.contentType};base64,${bytesToBase64(bytes)}`
+		}
+	} catch (error) {
+		console.error('community-og-icon-load-failed', input.listing.id, error)
+	}
+
+	const fallback = await renderCommunityIconFallbackPng(input.listing.name)
+	return `data:image/png;base64,${bytesToBase64(fallback)}`
+}
+
 export function createCommunityDetailOgImageHandler(env: Env) {
 	return {
 		middleware: [],
@@ -121,6 +157,7 @@ export function createCommunityDetailOgImageHandler(env: Env) {
 			}
 
 			const publicListing = toPublicCommunityListing(listing)
+			const iconDataUri = await loadCommunityOgIconDataUri({ env, listing })
 			// Lazy import (sanctioned exception to the no-inline-imports rule):
 			// the OG renderer pulls in satori and @resvg/resvg-wasm plus two wasm
 			// binaries, which would otherwise bloat isolate cold starts for a
@@ -134,6 +171,7 @@ export function createCommunityDetailOgImageHandler(env: Env) {
 				averageStars: publicListing.averageStars,
 				ratingCount: publicListing.ratingCount,
 				forkCount: publicListing.forkCount,
+				iconDataUri,
 			})
 
 			return new Response(png, {

--- a/packages/worker/src/community/og-image.node.test.ts
+++ b/packages/worker/src/community/og-image.node.test.ts
@@ -1,4 +1,6 @@
+import { bytesToBase64 } from '@kody-internal/shared/base64.ts'
 import { expect, test } from 'vitest'
+import { renderCommunityIconFallbackPng } from './community-icon.ts'
 import { renderCommunityOgImage } from './og-image.ts'
 
 const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47] as const
@@ -10,6 +12,11 @@ function expectPngBytes(png: Uint8Array) {
 	}
 }
 
+async function sampleIconDataUri(name: string) {
+	const png = await renderCommunityIconFallbackPng(name)
+	return `data:image/png;base64,${bytesToBase64(png)}`
+}
+
 test('renderCommunityOgImage returns valid PNG bytes with and without ratings', async () => {
 	const withRatings = await renderCommunityOgImage({
 		name: '@kody/github-triage',
@@ -19,6 +26,7 @@ test('renderCommunityOgImage returns valid PNG bytes with and without ratings', 
 		averageStars: 4.6,
 		ratingCount: 12,
 		forkCount: 37,
+		iconDataUri: await sampleIconDataUri('@kody/github-triage'),
 	})
 	expectPngBytes(withRatings)
 
@@ -29,6 +37,7 @@ test('renderCommunityOgImage returns valid PNG bytes with and without ratings', 
 		averageStars: null,
 		ratingCount: 0,
 		forkCount: 2,
+		iconDataUri: await sampleIconDataUri('@kody/new-package'),
 	})
 	expectPngBytes(withoutRatings)
 })

--- a/packages/worker/src/community/og-image.ts
+++ b/packages/worker/src/community/og-image.ts
@@ -7,6 +7,9 @@ import {
 } from '#worker/og/render.ts'
 
 const DESCRIPTION_MAX_LENGTH = 140
+const PACKAGE_ICON_SIZE = 96
+/** Matches `--radius-lg` (0.75rem) at OG canvas scale (~1.5× UI). */
+const PACKAGE_ICON_RADIUS = 18
 
 /** Amber that reads well on the light surface for filled star icons. */
 const STAR_FILLED = '#d97706'
@@ -18,6 +21,8 @@ export type CommunityOgImageInput = {
 	averageStars: number | null
 	ratingCount: number
 	forkCount: number
+	/** Package community icon as a data URI (PNG or JPEG) for satori. */
+	iconDataUri: string
 }
 
 const STAR_PATH =
@@ -78,6 +83,70 @@ function createStarRow(input: CommunityOgImageInput): Array<SatoriElement> {
 	return stars
 }
 
+function createPackageIdentityRow(input: CommunityOgImageInput): SatoriElement {
+	return {
+		type: 'div',
+		props: {
+			style: {
+				display: 'flex',
+				alignItems: 'center',
+				marginBottom: 28,
+			},
+			children: [
+				{
+					type: 'img',
+					props: {
+						src: input.iconDataUri,
+						width: PACKAGE_ICON_SIZE,
+						height: PACKAGE_ICON_SIZE,
+						style: {
+							width: PACKAGE_ICON_SIZE,
+							height: PACKAGE_ICON_SIZE,
+							borderRadius: PACKAGE_ICON_RADIUS,
+							marginRight: 24,
+							objectFit: 'contain',
+						},
+					},
+				},
+				{
+					type: 'div',
+					props: {
+						style: {
+							display: 'flex',
+							flexDirection: 'column',
+							justifyContent: 'center',
+						},
+						children: [
+							{
+								type: 'div',
+								props: {
+									style: {
+										fontSize: 30,
+										fontWeight: 600,
+										color: ogPalette.primary,
+										marginBottom: 8,
+									},
+									children: input.name,
+								},
+							},
+							{
+								type: 'div',
+								props: {
+									style: {
+										fontSize: 24,
+										color: ogPalette.muted,
+									},
+									children: `by @${input.ownerUsername}`,
+								},
+							},
+						],
+					},
+				},
+			],
+		},
+	}
+}
+
 function createOgMarkup(input: CommunityOgImageInput): SatoriElement {
 	const headline = `Use Kody to ${truncateOgText(
 		input.description,
@@ -103,29 +172,7 @@ function createOgMarkup(input: CommunityOgImageInput): SatoriElement {
 					children: headline,
 				},
 			},
-			{
-				type: 'div',
-				props: {
-					style: {
-						fontSize: 30,
-						fontWeight: 600,
-						color: ogPalette.primary,
-						marginBottom: 20,
-					},
-					children: input.name,
-				},
-			},
-			{
-				type: 'div',
-				props: {
-					style: {
-						fontSize: 24,
-						color: ogPalette.muted,
-						marginBottom: 28,
-					},
-					children: `by @${input.ownerUsername}`,
-				},
-			},
+			createPackageIdentityRow(input),
 			{
 				type: 'div',
 				props: {

--- a/packages/worker/src/community/og-image.workers.test.ts
+++ b/packages/worker/src/community/og-image.workers.test.ts
@@ -1,9 +1,12 @@
+import { bytesToBase64 } from '@kody-internal/shared/base64.ts'
 import { expect, test } from 'vitest'
+import { renderCommunityIconFallbackPng } from './community-icon.ts'
 import { renderCommunityOgImage } from './og-image.ts'
 
 const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47] as const
 
 test('renderCommunityOgImage works in workerd', async () => {
+	const iconPng = await renderCommunityIconFallbackPng('@kody/github-triage')
 	const png = await renderCommunityOgImage({
 		name: '@kody/github-triage',
 		description: 'triage GitHub issues with labels and assignees',
@@ -11,6 +14,7 @@ test('renderCommunityOgImage works in workerd', async () => {
 		averageStars: 4.2,
 		ratingCount: 5,
 		forkCount: 9,
+		iconDataUri: `data:image/png;base64,${bytesToBase64(iconPng)}`,
 	})
 
 	expect(png.byteLength).toBeGreaterThan(10_000)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Community package detail Open Graph images (`/community/:listingId/og.png`) now include the package’s community icon beside the package name and owner, matching the detail page identity row.

- Load the listing icon in the OG handler and pass it to the renderer as a satori data URI
- Layout: icon + `@scope/name` / `by @owner` under the “Use Kody to …” headline
- PNG/JPEG embed directly; WebP (unsupported by satori) and load failures use the generated fallback mark
- Unit coverage for render + handler icon embedding / WebP fallback

### Preview (for approval)

![Community package OG image with vendor icon](https://cursor.com/artifacts/c/art-7664b02b-dc2d-43e6-a30b-d10cbdb10c78)

## Testing

- ✅ `npx vitest run --project node-unit` for OG render + handler tests
- ✅ `npm run typecheck`
- ✅ `npm run lint` (0 errors)
- ✅ Manual: rendered 1200×630 PNG with a sample community icon for visual review

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4bc85400` · **Head:** `77df4e9e`

**Classification:** extends — community listing OG cards gain the package icon; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | extends — `/community/:listingId/og.png` embeds the listing community icon |
| `app-ui` | surfaces | extends — shared OG frame content for community detail cards |

### System map

```mermaid
flowchart LR
	communityListings["community-listings<br/>Community package listings"]:::extended
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	communityAssets["community-assets-r2<br/>Community icon assets"]:::untouched
	communityListings -->|"OG handler loads icon bytes"| communityAssets
	communityListings -->|"renderCommunityOgImage with iconDataUri"| appUi
	classDef extended fill:#9a6700,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
Before: Community OG card showed headline, name, owner, stars, forks (no package icon)
After:  Same card plus the community/vendor icon beside package name and owner
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f3bf22e-e101-4dc5-9d33-c1da6f0f8c16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f3bf22e-e101-4dc5-9d33-c1da6f0f8c16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Community Open Graph images now display the package icon alongside the package name, description, star rating, and fork count.
  * Icons are rendered in supported formats, with a fallback image used when necessary.

* **Documentation**
  * Updated Open Graph image documentation to reflect the addition of package community icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->