### PR TITLE
Render community READMEs as safely-parsed markdown

### DIFF
--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -39,6 +39,15 @@ package-app surfaces:
 7. **Every data path is `userId`-scoped.** New D1 queries, Durable Object names,
    and Vectorize filters must include `userId`. Prefer parameterized SQL
    (`.prepare(...).bind(...)`); never interpolate user input into SQL.
+8. **Untrusted markdown renders through the safe renderer only.** Community
+   READMEs (and any future third-party-authored markdown shown on first-party
+   pages) must go through `packages/worker/client/markdown-view.tsx`, which
+   builds JSX from an allowlist of `marked` lexer tokens: raw HTML renders as
+   escaped text, no resource-loading elements are ever emitted (images become
+   links), and links are restricted to absolute `http:`/`https:`/`mailto:` URLs
+   with `/@...` user-scope paths refused so a README can never point viewers at
+   hosted package endpoints. Never render third-party markdown via an HTML
+   string, `innerHTML`, or a markdown-to-HTML renderer.
 
 ## First-party HTTP security headers
 

--- a/e2e/ssr-hydration.spec.ts
+++ b/e2e/ssr-hydration.spec.ts
@@ -82,6 +82,11 @@ test('SSR community HTML hydrates SPA navigation and client search', async ({
 		new RegExp(`/community/${alphaListing.listingId}$`),
 	)
 	await expect(page.getByText(alphaListing.description)).toBeVisible()
+	// The README renders as markdown (its `#` title becomes a heading
+	// element via the safe renderer), not as a raw markdown string.
+	await expect(
+		page.getByRole('heading', { name: 'Scroll restoration fixture' }),
+	).toBeVisible()
 	await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
 	expect(
 		await page.evaluate(

--- a/package-lock.json
+++ b/package-lock.json
@@ -10926,6 +10926,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.6.tgz",
+      "integrity": "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "license": "MIT",
@@ -15213,6 +15225,7 @@
         "croner": "^10.0.1",
         "diff": "^9.0.0",
         "isomorphic-git": "^1.37.6",
+        "marked": "^18.0.6",
         "postal-mime": "^2.7.4",
         "qrcode": "^1.5.4",
         "remix": "^3.0.0-beta.5",

--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -141,4 +141,30 @@ test('getSafeMarkdownLinkHref allowlists protocols and blocks user-scope paths',
 	expect(getSafeMarkdownLinkHref('https://other.example/@user/anything')).toBe(
 		null,
 	)
+	// Repeated slashes collapse in worker routing (`split('/').filter(Boolean)`),
+	// so `//@user` must be refused too.
+	expect(
+		getSafeMarkdownLinkHref('https://heykody.dev//@user/packages/app'),
+	).toBe(null)
+	expect(
+		getSafeMarkdownLinkHref('https://heykody.dev///@user/packages/app'),
+	).toBe(null)
+	// Percent-encoded (and nested-encoded) user scopes must be refused:
+	// URL.pathname does not decode, but the server does.
+	expect(
+		getSafeMarkdownLinkHref('https://heykody.dev/%40user/packages/app'),
+	).toBe(null)
+	expect(
+		getSafeMarkdownLinkHref('https://heykody.dev/%2540user/packages/app'),
+	).toBe(null)
+	expect(
+		getSafeMarkdownLinkHref('https://heykody.dev/%25252540user/packages/app'),
+	).toBe(null)
+	expect(getSafeMarkdownLinkHref('https://heykody.dev/%2F@user/x')).toBe(null)
+	// Undecodable paths fail closed.
+	expect(getSafeMarkdownLinkHref('https://heykody.dev/%E0%A4%A')).toBe(null)
+	// Benign encoded paths that decode to non-user-scope stay allowed.
+	expect(getSafeMarkdownLinkHref('https://example.com/a%20b')).toBe(
+		'https://example.com/a%20b',
+	)
 })

--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -1,0 +1,144 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import {
+	MarkdownView,
+	getSafeMarkdownLinkHref,
+} from '#client/markdown-view.tsx'
+
+async function renderMarkdown(markdown: string) {
+	return renderToString(jsx(MarkdownView, { markdown }))
+}
+
+test('renders common markdown constructs as HTML elements', async () => {
+	const html = await renderMarkdown(
+		[
+			'# Title',
+			'',
+			'#### Deep heading',
+			'',
+			'Some **bold** and *italic* and ~~gone~~ and `inline code` text.',
+			'',
+			'> a quote',
+			'',
+			'- first',
+			'- [x] done task',
+			'',
+			'5. five',
+			'6. six',
+			'',
+			'| Name | Count |',
+			'| :--- | ----: |',
+			'| a    | 1     |',
+			'',
+			'```js',
+			'const x = 1',
+			'```',
+			'',
+			'---',
+			'',
+			'Entities: &amp; &#65; stay characters.',
+		].join('\n'),
+	)
+
+	// Headings are demoted below the page-owned h1/h2 and clamped at h6.
+	expect(html).toContain('<h3>Title</h3>')
+	expect(html).toContain('<h6>Deep heading</h6>')
+	expect(html).toContain('<strong>bold</strong>')
+	expect(html).toContain('<em>italic</em>')
+	expect(html).toContain('<del>gone</del>')
+	expect(html).toContain('<code>inline code</code>')
+	expect(html).toContain('<blockquote>')
+	expect(html).toContain('<li><span>first</span></li>')
+	expect(html).toContain('<input type="checkbox" disabled checked />')
+	expect(html).toContain('start="5"')
+	expect(html).toContain('>Name</th>')
+	expect(html).toContain('>a</td>')
+	expect(html).toContain('<pre><code>const x = 1</code></pre>')
+	expect(html).toContain('<hr')
+	// Character references decode to text, then re-escape safely on output.
+	expect(html).toContain('Entities: &amp; A stay characters.')
+})
+
+test('raw HTML is shown as escaped text, never as markup', async () => {
+	const html = await renderMarkdown(
+		[
+			'<script>alert(1)</script>',
+			'',
+			'inline <img src="https://evil.example/x.png" onerror="alert(1)"> html',
+			'',
+			'<iframe src="https://evil.example"></iframe>',
+		].join('\n'),
+	)
+
+	expect(html).not.toContain('<script')
+	expect(html).not.toContain('<img')
+	expect(html).not.toContain('<iframe')
+	expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+	expect(html).toContain('&lt;img src=')
+})
+
+test('markdown images never emit <img> and render as links instead', async () => {
+	const html = await renderMarkdown(
+		'![badge](https://img.example/badge.svg) and ![local](/logo.png)',
+	)
+
+	expect(html).not.toContain('<img')
+	expect(html).toContain(
+		'<a href="https://img.example/badge.svg" target="_blank" rel="noopener noreferrer nofollow ugc">badge</a>',
+	)
+	// Relative image URL is unsafe, so only its alt text remains.
+	expect(html).toContain('<span>local</span>')
+	expect(html).not.toContain('/logo.png')
+})
+
+test('unsafe link targets render as plain text without an anchor', async () => {
+	const html = await renderMarkdown(
+		[
+			'[bad-proto](javascript:alert(1))',
+			'',
+			'[data-proto](data:text/html,hi)',
+			'',
+			'[relative](/account/secrets)',
+			'',
+			'[package-endpoint](https://heykody.dev/@mallory/packages/tracker/app)',
+			'',
+			'[good](https://example.com/docs) and <https://example.com/auto>',
+		].join('\n'),
+	)
+
+	expect(html).not.toContain('javascript:')
+	expect(html).not.toContain('data:text/html')
+	expect(html).not.toContain('/account/secrets')
+	expect(html).not.toContain('@mallory')
+	expect(html).toContain('<span>bad-proto</span>')
+	expect(html).toContain('<span>package-endpoint</span>')
+	expect(html).toContain(
+		'<a href="https://example.com/docs" target="_blank" rel="noopener noreferrer nofollow ugc">good</a>',
+	)
+	expect(html).toContain('https://example.com/auto</a>')
+})
+
+test('getSafeMarkdownLinkHref allowlists protocols and blocks user-scope paths', () => {
+	expect(getSafeMarkdownLinkHref('https://example.com/a')).toBe(
+		'https://example.com/a',
+	)
+	expect(getSafeMarkdownLinkHref('http://example.com')).toBe(
+		'http://example.com/',
+	)
+	expect(getSafeMarkdownLinkHref('mailto:kody@example.com')).toBe(
+		'mailto:kody@example.com',
+	)
+	expect(getSafeMarkdownLinkHref('javascript:alert(1)')).toBe(null)
+	expect(getSafeMarkdownLinkHref('vbscript:x')).toBe(null)
+	expect(getSafeMarkdownLinkHref('data:text/html,hi')).toBe(null)
+	expect(getSafeMarkdownLinkHref('/relative/path')).toBe(null)
+	expect(getSafeMarkdownLinkHref('relative/path')).toBe(null)
+	expect(getSafeMarkdownLinkHref('//protocol-relative.example')).toBe(null)
+	expect(
+		getSafeMarkdownLinkHref('https://heykody.dev/@user/packages/app'),
+	).toBe(null)
+	expect(getSafeMarkdownLinkHref('https://other.example/@user/anything')).toBe(
+		null,
+	)
+})

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -1,0 +1,313 @@
+/**
+ * Safe markdown rendering for untrusted, third-party authored content
+ * (community package READMEs).
+ *
+ * Safety model (do not regress):
+ * - Markdown is parsed with `marked`'s lexer only; its HTML renderer is never
+ *   used. Output is built exclusively from JSX text and an allowlist of token
+ *   types, so every string goes through the framework's escaping.
+ * - Raw HTML tokens (block and inline) are rendered as escaped literal text,
+ *   never as markup.
+ * - No resource-loading elements are emitted (`<img>`, `<iframe>`, media,
+ *   etc.), so a README can never make a viewer's browser issue requests —
+ *   including to hosted package endpoints (`/@username/packages/*`), which
+ *   execute author-controlled code. Images render as plain links instead.
+ * - Links must be absolute `http:`/`https:`/`mailto:` URLs. Relative URLs
+ *   (which would resolve against this origin) and URLs whose path points at a
+ *   user scope (`/@...`) render as plain text. Allowed links open in a new
+ *   tab with `rel="noopener noreferrer nofollow ugc"`.
+ *
+ * The first-party CSP (`security-headers.ts`) blocks off-site scripts,
+ * images, and connections as defense in depth; this module must stay safe
+ * without relying on it.
+ */
+import { lexer, type Token, type Tokens } from 'marked'
+import { type Handle, type RemixNode, css } from 'remix/ui'
+import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
+
+const allowedLinkProtocols = new Set(['http:', 'https:', 'mailto:'])
+
+/**
+ * Returns a normalized href when the link is safe to emit, otherwise null.
+ * Only absolute http(s)/mailto URLs pass, and any URL whose path enters a
+ * user scope (`/@...`, where hosted package apps live) is refused on every
+ * host so READMEs cannot funnel viewers into author-controlled endpoints.
+ */
+export function getSafeMarkdownLinkHref(href: string): string | null {
+	let url: URL
+	try {
+		url = new URL(href)
+	} catch {
+		return null
+	}
+	if (!allowedLinkProtocols.has(url.protocol)) return null
+	if (url.pathname.startsWith('/@')) return null
+	return url.href
+}
+
+const namedEntities: Record<string, string> = {
+	amp: '&',
+	lt: '<',
+	gt: '>',
+	quot: '"',
+	apos: "'",
+	nbsp: '\u00a0',
+}
+
+/**
+ * Markdown text tokens keep character references (`&amp;`, `&#65;`) verbatim
+ * because marked expects HTML passthrough. We render as JSX text (which
+ * re-escapes), so decode them first to display what the author meant.
+ */
+function decodeCharacterReferences(value: string): string {
+	if (!value.includes('&')) return value
+	return value.replace(
+		/&(#x[0-9a-f]+|#[0-9]+|[a-z]+);/gi,
+		(match, entity: string) => {
+			if (entity.startsWith('#')) {
+				const codePoint =
+					entity[1]?.toLowerCase() === 'x'
+						? Number.parseInt(entity.slice(2), 16)
+						: Number.parseInt(entity.slice(1), 10)
+				if (!Number.isInteger(codePoint) || codePoint <= 0) return match
+				try {
+					return String.fromCodePoint(codePoint)
+				} catch {
+					return match
+				}
+			}
+			return namedEntities[entity.toLowerCase()] ?? match
+		},
+	)
+}
+
+function renderLink(key: number, href: string, children: RemixNode): RemixNode {
+	const safeHref = getSafeMarkdownLinkHref(href)
+	if (!safeHref) return <span key={key}>{children}</span>
+	return (
+		<a
+			key={key}
+			href={safeHref}
+			target="_blank"
+			rel="noopener noreferrer nofollow ugc"
+		>
+			{children}
+		</a>
+	)
+}
+
+function renderTableCell(
+	cell: Tokens.TableCell,
+	key: number,
+	tag: 'th' | 'td',
+): RemixNode {
+	const Tag = tag
+	return (
+		<Tag
+			key={key}
+			mix={cell.align ? css({ textAlign: cell.align }) : undefined}
+		>
+			{renderTokens(cell.tokens)}
+		</Tag>
+	)
+}
+
+function renderToken(token: Token, key: number): RemixNode {
+	switch (token.type) {
+		case 'space':
+		case 'def':
+			return null
+		case 'heading': {
+			// The listing page owns h1/h2, so README headings start at h3.
+			const headingTags = ['h3', 'h4', 'h5', 'h6'] as const
+			const Tag = headingTags[Math.min(token.depth - 1, 3)] ?? 'h6'
+			return <Tag key={key}>{renderTokens(token.tokens)}</Tag>
+		}
+		case 'paragraph':
+			return <p key={key}>{renderTokens(token.tokens)}</p>
+		case 'blockquote':
+			return <blockquote key={key}>{renderTokens(token.tokens)}</blockquote>
+		case 'hr':
+			return <hr key={key} />
+		case 'code':
+			return (
+				<pre key={key}>
+					<code>{token.text}</code>
+				</pre>
+			)
+		case 'list': {
+			// marked's Token union includes a generic catch-all, so `type`
+			// narrowing alone leaves these fields untyped (same for `table`).
+			const listToken = token as Tokens.List
+			const items = listToken.items.map((item, index) =>
+				renderToken(item, index),
+			)
+			if (!listToken.ordered) return <ul key={key}>{items}</ul>
+			const start =
+				typeof listToken.start === 'number' && listToken.start !== 1
+					? listToken.start
+					: undefined
+			return (
+				<ol key={key} start={start}>
+					{items}
+				</ol>
+			)
+		}
+		case 'list_item':
+			return <li key={key}>{renderTokens(token.tokens)}</li>
+		case 'checkbox':
+			return (
+				<input key={key} type="checkbox" disabled checked={token.checked} />
+			)
+		case 'table': {
+			const tableToken = token as Tokens.Table
+			return (
+				<table key={key}>
+					<thead>
+						<tr>
+							{tableToken.header.map((cell, index) =>
+								renderTableCell(cell, index, 'th'),
+							)}
+						</tr>
+					</thead>
+					<tbody>
+						{tableToken.rows.map((row, rowIndex) => (
+							<tr key={rowIndex}>
+								{row.map((cell, cellIndex) =>
+									renderTableCell(cell, cellIndex, 'td'),
+								)}
+							</tr>
+						))}
+					</tbody>
+				</table>
+			)
+		}
+		case 'strong':
+			return <strong key={key}>{renderTokens(token.tokens)}</strong>
+		case 'em':
+			return <em key={key}>{renderTokens(token.tokens)}</em>
+		case 'del':
+			return <del key={key}>{renderTokens(token.tokens)}</del>
+		case 'codespan':
+			return <code key={key}>{token.text}</code>
+		case 'br':
+			return <br key={key} />
+		case 'escape':
+			return token.text
+		case 'link':
+			return renderLink(key, token.href, renderTokens(token.tokens))
+		case 'image':
+			// Never emit <img>: auto-loading author-chosen URLs is exactly what
+			// this renderer exists to prevent. Offer the image as a link instead.
+			return renderLink(key, token.href, token.text || token.href)
+		case 'html':
+			// Escaped literal text, so authors see their markup but it never
+			// becomes part of the document.
+			return token.raw
+		case 'text': {
+			const textToken = token as Tokens.Text
+			if (textToken.tokens?.length) {
+				return <span key={key}>{renderTokens(textToken.tokens)}</span>
+			}
+			return decodeCharacterReferences(textToken.text)
+		}
+		default:
+			// marked's token union is open (extensions add types), so exhaustive
+			// `never` checking is impossible; fall back to escaped raw text.
+			return typeof token.raw === 'string' ? token.raw : null
+	}
+}
+
+function renderTokens(tokens: Array<Token> | undefined): Array<RemixNode> {
+	if (!tokens) return []
+	return tokens.map((token, index) => renderToken(token, index))
+}
+
+/** Parses untrusted markdown and returns safe JSX (see module docs). */
+export function renderMarkdownNodes(markdown: string): Array<RemixNode> {
+	return renderTokens(lexer(markdown))
+}
+
+export type MarkdownViewProps = { markdown: string }
+
+export function MarkdownView(handle: Handle<MarkdownViewProps>) {
+	let renderedForMarkdown: string | null = null
+	let rendered: Array<RemixNode> = []
+
+	return () => {
+		if (handle.props.markdown !== renderedForMarkdown) {
+			renderedForMarkdown = handle.props.markdown
+			rendered = renderMarkdownNodes(handle.props.markdown)
+		}
+		return <div mix={css(markdownCss)}>{rendered}</div>
+	}
+}
+
+const markdownCss = {
+	fontSize: typography.fontSize.sm,
+	lineHeight: 1.6,
+	color: colors.text,
+	overflowWrap: 'break-word' as const,
+	'& > :first-child': {
+		marginTop: 0,
+	},
+	'& > :last-child': {
+		marginBottom: 0,
+	},
+	'& h3, & h4, & h5, & h6': {
+		margin: `${spacing.lg} 0 ${spacing.xs}`,
+		lineHeight: 1.3,
+	},
+	'& h3': {
+		fontSize: typography.fontSize.lg,
+	},
+	'& h4': {
+		fontSize: typography.fontSize.base,
+	},
+	'& p, & blockquote, & pre, & table, & ul, & ol': {
+		margin: `${spacing.sm} 0`,
+	},
+	'& ul, & ol': {
+		paddingLeft: spacing.lg,
+	},
+	'& li': {
+		margin: `${spacing.xs} 0`,
+	},
+	'& blockquote': {
+		borderLeft: `3px solid ${colors.border}`,
+		paddingLeft: spacing.md,
+		color: colors.textMuted,
+	},
+	'& pre': {
+		padding: spacing.md,
+		borderRadius: radius.md,
+		border: `1px solid ${colors.border}`,
+		backgroundColor: colors.background,
+		overflowX: 'auto' as const,
+	},
+	'& code': {
+		fontSize: typography.fontSize.sm,
+	},
+	'& table': {
+		borderCollapse: 'collapse' as const,
+		display: 'block',
+		overflowX: 'auto' as const,
+	},
+	'& th, & td': {
+		border: `1px solid ${colors.border}`,
+		padding: `${spacing.xs} ${spacing.sm}`,
+		textAlign: 'left' as const,
+	},
+	'& th': {
+		fontWeight: typography.fontWeight.semibold,
+	},
+	'& a': {
+		color: colors.primaryText,
+		textDecoration: 'underline',
+	},
+	'& hr': {
+		border: 'none',
+		borderTop: `1px solid ${colors.border}`,
+		margin: `${spacing.lg} 0`,
+	},
+}

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -28,10 +28,36 @@ import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
 const allowedLinkProtocols = new Set(['http:', 'https:', 'mailto:'])
 
 /**
+ * True when the URL's path could reach a user scope (`/@...`, where hosted
+ * package apps live). Deliberately over-matches: repeated leading slashes
+ * collapse (the worker routes with `split('/').filter(Boolean)`, so
+ * `//@user` still reaches package apps) and percent-encoding is decoded
+ * repeatedly (`/%40user`, `/%2540user`) before checking. Undecodable paths
+ * are treated as user-scope so ambiguity always fails closed.
+ */
+function hasUserScopePath(url: URL): boolean {
+	let pathname = url.pathname
+	for (let pass = 0; ; pass++) {
+		let decoded: string
+		try {
+			decoded = decodeURIComponent(pathname)
+		} catch {
+			return true
+		}
+		if (decoded === pathname) break
+		// Still decodable after several passes: pathologically nested
+		// encoding, so fail closed rather than guessing.
+		if (pass >= 4) return true
+		pathname = decoded
+	}
+	return pathname.replace(/^\/+/, '').startsWith('@')
+}
+
+/**
  * Returns a normalized href when the link is safe to emit, otherwise null.
  * Only absolute http(s)/mailto URLs pass, and any URL whose path enters a
- * user scope (`/@...`, where hosted package apps live) is refused on every
- * host so READMEs cannot funnel viewers into author-controlled endpoints.
+ * user scope is refused on every host so READMEs cannot funnel viewers into
+ * author-controlled endpoints.
  */
 export function getSafeMarkdownLinkHref(href: string): string | null {
 	let url: URL
@@ -41,7 +67,7 @@ export function getSafeMarkdownLinkHref(href: string): string | null {
 		return null
 	}
 	if (!allowedLinkProtocols.has(url.protocol)) return null
-	if (url.pathname.startsWith('/@')) return null
+	if (hasUserScopePath(url)) return null
 	return url.href
 }
 

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -12,6 +12,7 @@ import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { readRouterPathname } from '#client/router-location.tsx'
 import { on } from '#client/event-mixin.ts'
+import { MarkdownView } from '#client/markdown-view.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, typography } from '#client/styles/tokens.ts'
 import {
@@ -345,7 +346,9 @@ export function CommunityDetailRoute(handle: Handle) {
 						{readmeContent ? (
 							<section mix={css(cardCss)}>
 								<h2 mix={css(cardTitleCss)}>README</h2>
-								<pre mix={css(readmeBlockCss)}>{readmeContent}</pre>
+								<div data-testid="community-readme" mix={css(readmeBlockCss)}>
+									<MarkdownView markdown={readmeContent} />
+								</div>
 							</section>
 						) : null}
 
@@ -434,7 +437,7 @@ const promptBlockCss = {
 }
 
 const readmeBlockCss = {
-	...promptBlockCss,
+	...insetCardCss,
 	maxHeight: '32rem',
 	overflow: 'auto',
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -27,6 +27,7 @@
     "croner": "^10.0.1",
     "diff": "^9.0.0",
     "isomorphic-git": "^1.37.6",
+    "marked": "^18.0.6",
     "postal-mime": "^2.7.4",
     "qrcode": "^1.5.4",
     "remix": "^3.0.0-beta.5",


### PR DESCRIPTION
## Summary

- Community package detail pages (`/community/:listingId`) now render the README as formatted markdown instead of dumping the raw string into a `<pre>`.
- Adds `packages/worker/client/markdown-view.tsx`, a purpose-built safe renderer: it parses with `marked`'s lexer only and builds output as JSX from an allowlist of token types, so every string passes through framework escaping. No HTML-string rendering, no `innerHTML`.
- Safety properties for this untrusted, third-party-authored content:
  - Raw HTML in a README renders as escaped literal text, never as markup.
  - No resource-loading elements are ever emitted — markdown images become plain links — so a README can never make a viewer's browser issue requests, including to hosted package endpoints (`/@username/packages/*`).
  - Links are restricted to absolute `http:`/`https:`/`mailto:` URLs; relative URLs and `/@...` user-scope paths render as plain text. Allowed links open with `target="_blank" rel="noopener noreferrer nofollow ugc"`.
- The strict first-party CSP (`script-src 'self'`, `img-src 'self' data: blob:`, `connect-src 'self'`) already applies to these pages and remains unchanged as defense in depth; the renderer is safe without relying on it.
- Records the new invariant in `docs/contributing/security.md` (invariant #8).

## Test plan

- [x] New node-unit tests in `packages/worker/client/markdown-view.node.test.ts`: common construct rendering, raw-HTML escaping (no `<script>`/`<img>`/`<iframe>` in output), images-as-links, unsafe-link neutralization, and the href allowlist function.
- [x] `e2e/ssr-hydration.spec.ts` now asserts the seeded README's `#` title renders as a real heading.
- [x] `npm run typecheck`, `oxlint`, `oxfmt --check` clean; full unit + Playwright e2e suite passed via the pre-push hook.

Made with [Cursor](https://cursor.com)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends a primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4bc85400` · **Head:** `8f0daa97`

**Classification:** extends — the community detail page changes how it presents
README content (raw `<pre>` text → safely rendered markdown). No primitives
added; `primitives.yaml` unchanged.

### Primitives touched

| Primitive            | Group     | Impact                                                                        |
| -------------------- | --------- | ----------------------------------------------------------------------------- |
| `community-listings` | assistant | extends — detail route renders READMEs via a new safe markdown renderer       |
| `app-ui`             | surfaces  | composes — new shared client module `client/markdown-view.tsx` (marked lexer → allowlisted JSX) |

### System map

Untrusted README content flows from the community detail shell through the new
safe markdown renderer into the browser DOM, with the existing first-party CSP
unchanged as defense in depth.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red =
new primitive · gray = context (unchanged, included only when an edge crosses
it).

```mermaid
flowchart LR
	communityListings["community-listings<br/>Community package listings"]:::extended
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	communityListings -->|"readmeContent → MarkdownView (marked lexer, allowlisted JSX)"| appUi
	appUi -->|"CSP script-src 'self' unchanged (defense in depth)"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Aspect          | Before                          | After                                                                 |
| --------------- | ------------------------------- | --------------------------------------------------------------------- |
| README display  | Raw markdown string in `<pre>`  | Rendered headings/lists/tables/code via allowlisted token → JSX       |
| Raw HTML in README | Shown as text (JSX-escaped)  | Still shown as escaped text — never parsed as markup                  |
| Images          | Shown as literal `![...]` text  | Rendered as plain links; `<img>` is never emitted (no auto-requests)  |
| Links           | Shown as literal `[...](...)`   | Absolute `http`/`https`/`mailto` only; relative and `/@...` user-scope paths degrade to text |

### Invariants

No `primitives.yaml` invariant is touched. This PR adds security invariant #8
to `docs/contributing/security.md`: third-party markdown on first-party pages
must render through `client/markdown-view.tsx` (no HTML-string rendering, no
resource-loading elements, restricted link protocols), keeping READMEs unable
to reach hosted package endpoints (`/@username/packages/*`).

</details>

<!-- system-recap:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Community README content now renders as safe formatted Markdown (headings, emphasis, lists, tables, task lists, and code blocks).
  - External links are supported with safety protections; unsafe links/images are rendered as plain text (no clickable targets or embedded media).
- **Bug Fixes**
  - Prevented untrusted Markdown from executing HTML or loading unintended resources.
  - Strengthened SSR hydration/navigation checks for README-rendered headings.
- **Documentation**
  - Added security guidance outlining safe third-party Markdown rendering requirements.
- **Tests**
  - Added coverage for Markdown rendering behavior and link safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
