### PR TITLE
Preload account third-party connections like other route data

### DIFF
--- a/e2e/social-login.spec.ts
+++ b/e2e/social-login.spec.ts
@@ -57,7 +57,9 @@ test('social login signs in via mock GitHub and manages connections', async ({
 		.getByRole('listitem')
 		.filter({ hasText: 'Google' })
 	await expect(googleRow).toBeVisible()
-	await expect(googleRow.getByText('Connected as mock-google-user')).toBeVisible()
+	await expect(
+		googleRow.getByText('Connected as Mock Google User'),
+	).toBeVisible()
 
 	// With two connections, disconnecting one is allowed again.
 	await googleRow.getByRole('button', { name: 'Disconnect' }).click()

--- a/e2e/social-login.spec.ts
+++ b/e2e/social-login.spec.ts
@@ -53,19 +53,16 @@ test('social login signs in via mock GitHub and manages connections', async ({
 	await connectionsCard.getByRole('button', { name: 'Connect Google' }).click()
 	await expect(page).toHaveURL(/\/account\?oauthLinked=google$/)
 	await expect(page.getByText('Google connected.')).toBeVisible()
-	await expect(
-		connectionsCard.getByText('Google', { exact: true }),
-	).toBeVisible()
-
-	// With two connections, disconnecting one is allowed again.
 	const googleRow = connectionsCard
 		.getByRole('listitem')
 		.filter({ hasText: 'Google' })
+	await expect(googleRow).toBeVisible()
+	await expect(googleRow.getByText('Connected as mock-google-user')).toBeVisible()
+
+	// With two connections, disconnecting one is allowed again.
 	await googleRow.getByRole('button', { name: 'Disconnect' }).click()
 	await expect(page.getByText('Google disconnected.')).toBeVisible()
-	await expect(
-		connectionsCard.getByText('Google', { exact: true }),
-	).not.toBeVisible()
+	await expect(googleRow).not.toBeVisible()
 	await expect(
 		connectionsCard.getByRole('button', { name: 'Connect Google' }),
 	).toBeVisible()

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -480,7 +480,10 @@ export function AccountRoute(handle: Handle) {
 		if (needsLoad && typeof document !== 'undefined') {
 			handle.queueTask(loadAccountProfile)
 		}
-		if (typeof document !== 'undefined' && !consumedCallbackMessage) {
+		// Apply the OAuth flash on both SSR and client from the URL so the
+		// first client render matches the server HTML. A client-only message
+		// mismatched SSR and duplicated the connections list during hydration.
+		if (!consumedCallbackMessage) {
 			consumedCallbackMessage = true
 			connectionsMessage =
 				readConnectionCallbackMessage(currentHref) ?? connectionsMessage

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -4,13 +4,15 @@ import { on } from '#client/event-mixin.ts'
 import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { ProviderIcon } from '#client/provider-icons.tsx'
-import {
-	startSocialSignIn,
-	type AuthProviderInfo,
-} from '#client/social-sign-in.ts'
+import { startSocialSignIn } from '#client/social-sign-in.ts'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import {
+	type AccountConnectionListItem,
+	type AccountConnectionsLoaderData,
+	type AccountProfileLoaderData,
+} from '#app/loader-data.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	descriptionCss,
@@ -49,28 +51,6 @@ import {
 	type RouteLoaderResult,
 } from '#client/route-loader.ts'
 
-type AccountProfilePayload = {
-	ok: true
-	email: string
-	emailVerified: boolean
-	username: string
-	displayName: string
-}
-
-type AccountConnection = {
-	provider: string
-	label: string
-	displayName: string | null
-	createdAt: string
-}
-
-type AccountConnectionsPayload = {
-	ok: true
-	connections: Array<AccountConnection>
-	canDisconnect: boolean
-	availableProviders: Array<AuthProviderInfo>
-}
-
 const emailChangeApiPath = '/account/email-change.json'
 const connectionsApiPath = '/account/connections.json'
 
@@ -105,23 +85,35 @@ export async function accountRouteLoader(
 	url: URL,
 	signal: AbortSignal,
 ): Promise<RouteLoaderResult> {
-	const [profileResponse, onboarding] = await Promise.all([
+	const [profileResponse, connectionsResponse, onboarding] = await Promise.all([
 		fetch(`${accountProfileApiPath}${url.search}`, {
+			headers: { Accept: 'application/json' },
+			credentials: 'include',
+			signal,
+		}),
+		fetch(connectionsApiPath, {
 			headers: { Accept: 'application/json' },
 			credentials: 'include',
 			signal,
 		}),
 		fetchOnboardingPayload(signal),
 	])
-	if (profileResponse.status === 401) {
+	if (profileResponse.status === 401 || connectionsResponse.status === 401) {
 		return routeLoaderRedirect('/login')
 	}
-	const payload = await readJson<AccountProfilePayload>(profileResponse)
+	const [payload, connectionsPayload] = await Promise.all([
+		readJson<AccountProfileLoaderData>(profileResponse),
+		readJson<AccountConnectionsLoaderData>(connectionsResponse),
+	])
 	if (!profileResponse.ok || !payload?.ok) {
 		throw new Error('Unable to load your account.')
 	}
+	if (!connectionsResponse.ok || !connectionsPayload?.ok) {
+		throw new Error('Unable to load connected accounts.')
+	}
 	return {
 		accountProfile: payload,
+		accountConnections: connectionsPayload,
 		...(onboarding ? { onboarding } : {}),
 	}
 }
@@ -143,55 +135,19 @@ export function AccountRoute(handle: Handle) {
 	let messageTone: 'error' | 'info' = 'info'
 	let emailChangeMessage: string | null = null
 	let emailChangeTone: 'error' | 'info' = 'info'
-	let connectionsStatus: 'idle' | 'loading' | 'ready' | 'error' = 'idle'
 	let connectionsBusy = false
-	let connections: Array<AccountConnection> = []
+	let connections: Array<AccountConnectionListItem> = []
 	let canDisconnect = true
-	let availableProviders: Array<AuthProviderInfo> = []
+	let availableProviders: Array<{ id: string; label: string }> = []
 	let connectionsMessage: { text: string; tone: 'error' | 'info' } | null = null
 	let consumedCallbackMessage = false
 	let needsOnboarding = false
 	const loadLatch = createRouteLoadLatch()
 
-	function applyConnectionsPayload(payload: AccountConnectionsPayload) {
+	function applyConnectionsPayload(payload: AccountConnectionsLoaderData) {
 		connections = payload.connections
 		canDisconnect = payload.canDisconnect
 		availableProviders = payload.availableProviders
-	}
-
-	async function loadConnections(signal: AbortSignal) {
-		try {
-			const response = await fetch(connectionsApiPath, {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-				signal,
-			})
-			if (signal.aborted) {
-				connectionsStatus = 'idle'
-				return
-			}
-			const payload = await readJson<AccountConnectionsPayload>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error('Unable to load connected accounts.')
-			}
-			applyConnectionsPayload(payload)
-			connectionsStatus = 'ready'
-			handle.update()
-		} catch (error) {
-			if (signal.aborted) {
-				connectionsStatus = 'idle'
-				return
-			}
-			connectionsStatus = 'error'
-			connectionsMessage = {
-				text:
-					error instanceof Error
-						? error.message
-						: 'Unable to load connected accounts.',
-				tone: 'error',
-			}
-			handle.update()
-		}
 	}
 
 	async function handleConnectProvider(providerId: string) {
@@ -235,7 +191,7 @@ export function AccountRoute(handle: Handle) {
 				return
 			}
 			const payload = await readJson<
-				AccountConnectionsPayload & { error?: string }
+				AccountConnectionsLoaderData & { error?: string }
 			>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to disconnect the account.')
@@ -267,8 +223,13 @@ export function AccountRoute(handle: Handle) {
 		const href = readCurrentRouterHref(handle)
 		try {
 			const search = new URL(href, 'http://localhost').search
-			const [response, onboarding] = await Promise.all([
+			const [response, connectionsResponse, onboarding] = await Promise.all([
 				fetch(`${accountProfileApiPath}${search}`, {
+					headers: { Accept: 'application/json' },
+					credentials: 'include',
+					signal,
+				}),
+				fetch(connectionsApiPath, {
 					headers: { Accept: 'application/json' },
 					credentials: 'include',
 					signal,
@@ -276,15 +237,22 @@ export function AccountRoute(handle: Handle) {
 				fetchOnboardingPayload(signal),
 			])
 			if (signal.aborted) return
-			if (response.status === 401) {
+			if (response.status === 401 || connectionsResponse.status === 401) {
 				window.location.assign('/login')
 				return
 			}
-			const payload = await readJson<AccountProfilePayload>(response)
+			const [payload, connectionsPayload] = await Promise.all([
+				readJson<AccountProfileLoaderData>(response),
+				readJson<AccountConnectionsLoaderData>(connectionsResponse),
+			])
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load your account.')
 			}
+			if (!connectionsResponse.ok || !connectionsPayload?.ok) {
+				throw new Error('Unable to load connected accounts.')
+			}
 			applyOnboardingPayload(onboarding)
+			applyConnectionsPayload(connectionsPayload)
 			email = payload.email
 			emailVerified = payload.emailVerified
 			username = payload.username
@@ -447,7 +415,7 @@ export function AccountRoute(handle: Handle) {
 				return
 			}
 			const payload = await readJson<
-				AccountProfilePayload & { error?: string }
+				AccountProfileLoaderData & { error?: string }
 			>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to save username.')
@@ -473,11 +441,18 @@ export function AccountRoute(handle: Handle) {
 		if (!isAccountPath(href)) return false
 		const routeData = tryConsumeRouteLoaderData(handle, 'accountProfile', href)
 		if (!routeData) return false
+		const connectionsData = tryConsumeRouteLoaderData(
+			handle,
+			'accountConnections',
+			href,
+		)
+		if (!connectionsData) return false
 		email = routeData.email
 		emailVerified = routeData.emailVerified
 		username = routeData.username
 		draftUsername = routeData.username
 		draftEmail = routeData.email
+		applyConnectionsPayload(connectionsData)
 		const onboardingData = tryConsumeRouteLoaderData(handle, 'onboarding', href)
 		if (onboardingData) {
 			applyOnboardingPayload(onboardingData)
@@ -505,16 +480,10 @@ export function AccountRoute(handle: Handle) {
 		if (needsLoad && typeof document !== 'undefined') {
 			handle.queueTask(loadAccountProfile)
 		}
-		if (typeof document !== 'undefined') {
-			if (!consumedCallbackMessage) {
-				consumedCallbackMessage = true
-				connectionsMessage =
-					readConnectionCallbackMessage(currentHref) ?? connectionsMessage
-			}
-			if (connectionsStatus === 'idle') {
-				connectionsStatus = 'loading'
-				handle.queueTask(loadConnections)
-			}
+		if (typeof document !== 'undefined' && !consumedCallbackMessage) {
+			consumedCallbackMessage = true
+			connectionsMessage =
+				readConnectionCallbackMessage(currentHref) ?? connectionsMessage
 		}
 		const isSaving = saveStatus === 'saving'
 		const isSendingEmailChange = emailChangeStatus === 'sending'
@@ -709,110 +678,104 @@ export function AccountRoute(handle: Handle) {
 									{connectionsMessage.text}
 								</p>
 							) : null}
-							{connectionsStatus === 'loading' ? (
-								<p mix={css({ color: colors.textMuted, margin: 0 })}>
-									Loading connected accounts…
-								</p>
-							) : null}
-							{connectionsStatus === 'ready' ? (
-								<div mix={css({ display: 'grid', gap: spacing.md })}>
-									{connections.length > 0 ? (
-										<ul
-											mix={css({
-												listStyle: 'none',
-												padding: 0,
-												margin: 0,
-												display: 'grid',
-												gap: spacing.md,
-											})}
-										>
-											{connections.map((connection) => (
-												<li
-													key={connection.provider}
-													mix={css({
-														display: 'flex',
-														justifyContent: 'space-between',
-														alignItems: 'center',
-														gap: spacing.md,
-														flexWrap: 'wrap',
-													})}
-												>
-													<span mix={css({ display: 'grid', gap: spacing.xs })}>
-														<span
-															mix={css({
-																display: 'inline-flex',
-																alignItems: 'center',
-																gap: spacing.sm,
-																fontWeight: typography.fontWeight.medium,
-																color: colors.text,
-															})}
-														>
-															<ProviderIcon providerId={connection.provider} />
-															{connection.label}
-														</span>
-														<span
-															mix={css({
-																color: colors.textMuted,
-																fontSize: typography.fontSize.sm,
-															})}
-														>
-															{connection.displayName
-																? `Connected as ${connection.displayName}`
-																: 'Connected'}
-														</span>
-													</span>
-													<button
-														type="button"
-														disabled={connectionsBusy || !canDisconnect}
-														title={
-															canDisconnect
-																? undefined
-																: 'This connection is your only way to sign in. Set a password or register a passkey first.'
-														}
-														mix={[
-															css(dangerButtonCss),
-															on('click', () =>
-																handleDisconnectProvider(connection.provider),
-															),
-														]}
+							<div mix={css({ display: 'grid', gap: spacing.md })}>
+								{connections.length > 0 ? (
+									<ul
+										mix={css({
+											listStyle: 'none',
+											padding: 0,
+											margin: 0,
+											display: 'grid',
+											gap: spacing.md,
+										})}
+									>
+										{connections.map((connection) => (
+											<li
+												key={connection.provider}
+												mix={css({
+													display: 'flex',
+													justifyContent: 'space-between',
+													alignItems: 'center',
+													gap: spacing.md,
+													flexWrap: 'wrap',
+												})}
+											>
+												<span mix={css({ display: 'grid', gap: spacing.xs })}>
+													<span
+														mix={css({
+															display: 'inline-flex',
+															alignItems: 'center',
+															gap: spacing.sm,
+															fontWeight: typography.fontWeight.medium,
+															color: colors.text,
+														})}
 													>
-														Disconnect
-													</button>
-												</li>
-											))}
-										</ul>
-									) : (
-										<p mix={css({ color: colors.textMuted, margin: 0 })}>
-											No accounts connected yet.
-										</p>
-									)}
-									{availableProviders.length > 0 ? (
-										<div
-											mix={css({
-												display: 'flex',
-												gap: spacing.md,
-												flexWrap: 'wrap',
-											})}
-										>
-											{availableProviders.map((provider) => (
+														<ProviderIcon providerId={connection.provider} />
+														{connection.label}
+													</span>
+													<span
+														mix={css({
+															color: colors.textMuted,
+															fontSize: typography.fontSize.sm,
+														})}
+													>
+														{connection.displayName
+															? `Connected as ${connection.displayName}`
+															: 'Connected'}
+													</span>
+												</span>
 												<button
 													type="button"
-													disabled={connectionsBusy}
+													disabled={connectionsBusy || !canDisconnect}
+													title={
+														canDisconnect
+															? undefined
+															: 'This connection is your only way to sign in. Set a password or register a passkey first.'
+													}
 													mix={[
-														css(providerConnectButtonCss),
+														css(dangerButtonCss),
 														on('click', () =>
-															handleConnectProvider(provider.id),
+															handleDisconnectProvider(connection.provider),
 														),
 													]}
 												>
-													<ProviderIcon providerId={provider.id} />
-													Connect {provider.label}
+													Disconnect
 												</button>
-											))}
-										</div>
-									) : null}
-								</div>
-							) : null}
+											</li>
+										))}
+									</ul>
+								) : (
+									<p mix={css({ color: colors.textMuted, margin: 0 })}>
+										No accounts connected yet.
+									</p>
+								)}
+								{availableProviders.length > 0 ? (
+									<div
+										mix={css({
+											display: 'flex',
+											gap: spacing.md,
+											flexWrap: 'wrap',
+										})}
+									>
+										{availableProviders.map((provider) => (
+											<button
+												key={provider.id}
+												type="button"
+												disabled={connectionsBusy}
+												mix={[
+													css(providerConnectButtonCss),
+													on('click', () =>
+														handleConnectProvider(provider.id),
+													),
+												]}
+											>
+												<ProviderIcon providerId={provider.id} />
+												Connect {provider.label}
+											</button>
+										))}
+									</div>
+								) : null}
+							</div>
 						</AccountManagementPanel>
 						<AccountManagementPanel
 							title="Your data"

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -767,9 +767,7 @@ export function AccountRoute(handle: Handle) {
 												disabled={connectionsBusy}
 												mix={[
 													css(providerConnectButtonCss),
-													on('click', () =>
-														handleConnectProvider(provider.id),
-													),
+													on('click', () => handleConnectProvider(provider.id)),
 												]}
 											>
 												<ProviderIcon providerId={provider.id} />

--- a/packages/worker/src/app/account-connections-data.ts
+++ b/packages/worker/src/app/account-connections-data.ts
@@ -1,0 +1,74 @@
+import { type AccountConnectionsLoaderData } from '#app/loader-data.ts'
+import {
+	getEnabledOauthProviders,
+	isOauthProviderId,
+	oauthProviderDefinitions,
+} from '#app/oauth-providers.ts'
+import { listPasskeysForUser } from '#app/passkeys.ts'
+
+type ConnectionRow = {
+	id: number
+	provider_name: string
+	provider_display_name: string | null
+	created_at: string
+}
+
+async function listConnections(db: D1Database, userId: number) {
+	const result = await db
+		.prepare(
+			`SELECT id, provider_name, provider_display_name, created_at
+			 FROM oauth_connections
+			 WHERE user_id = ?
+			 ORDER BY created_at, id`,
+		)
+		.bind(userId)
+		.all<ConnectionRow>()
+	return result.results ?? []
+}
+
+async function hasUsablePassword(db: D1Database, userId: number) {
+	const row = await db
+		.prepare(`SELECT password_hash FROM users WHERE id = ?`)
+		.bind(userId)
+		.first<{ password_hash: string }>()
+	// Sentinel hashes (admin-created / OAuth-created accounts) never verify,
+	// so only a real PBKDF2 hash counts as a usable password.
+	return row?.password_hash.startsWith('pbkdf2_sha256$') === true
+}
+
+export async function loadAccountConnectionsData(input: {
+	env: Env
+	userId: number
+}): Promise<AccountConnectionsLoaderData> {
+	const { env, userId } = input
+	const [connections, usablePassword, passkeys] = await Promise.all([
+		listConnections(env.APP_DB, userId),
+		hasUsablePassword(env.APP_DB, userId),
+		listPasskeysForUser(env.APP_DB, userId),
+	])
+	// Disconnecting the last connection is only safe when another first
+	// factor (password or passkey) can still sign the account in.
+	const canDisconnect =
+		usablePassword || passkeys.length > 0 || connections.length > 1
+	const connectedProviders = new Set(
+		connections.map((connection) => connection.provider_name),
+	)
+	return {
+		ok: true,
+		connections: connections.map((connection) => ({
+			provider: connection.provider_name,
+			label: isOauthProviderId(connection.provider_name)
+				? oauthProviderDefinitions[connection.provider_name].label
+				: connection.provider_name,
+			displayName: connection.provider_display_name,
+			createdAt: connection.created_at,
+		})),
+		canDisconnect,
+		availableProviders: getEnabledOauthProviders(env)
+			.filter((provider) => !connectedProviders.has(provider))
+			.map((provider) => ({
+				id: provider,
+				label: oauthProviderDefinitions[provider].label,
+			})),
+	}
+}

--- a/packages/worker/src/app/handlers/account-connections.ts
+++ b/packages/worker/src/app/handlers/account-connections.ts
@@ -1,84 +1,16 @@
 import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { object, parseSafe, string } from 'remix/data-schema'
+import { loadAccountConnectionsData } from '#app/account-connections-data.ts'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import {
-	getEnabledOauthProviders,
-	isOauthProviderId,
-	oauthProviderDefinitions,
-} from '#app/oauth-providers.ts'
-import { listPasskeysForUser } from '#app/passkeys.ts'
+import { isOauthProviderId } from '#app/oauth-providers.ts'
 import { type routes } from '#app/routes.ts'
 
 const disconnectSchema = object({
 	intent: string(),
 	provider: string(),
 })
-
-type ConnectionRow = {
-	id: number
-	provider_name: string
-	provider_display_name: string | null
-	created_at: string
-}
-
-async function listConnections(db: D1Database, userId: number) {
-	const result = await db
-		.prepare(
-			`SELECT id, provider_name, provider_display_name, created_at
-			 FROM oauth_connections
-			 WHERE user_id = ?
-			 ORDER BY created_at, id`,
-		)
-		.bind(userId)
-		.all<ConnectionRow>()
-	return result.results ?? []
-}
-
-async function hasUsablePassword(db: D1Database, userId: number) {
-	const row = await db
-		.prepare(`SELECT password_hash FROM users WHERE id = ?`)
-		.bind(userId)
-		.first<{ password_hash: string }>()
-	// Sentinel hashes (admin-created / OAuth-created accounts) never verify,
-	// so only a real PBKDF2 hash counts as a usable password.
-	return row?.password_hash.startsWith('pbkdf2_sha256$') === true
-}
-
-async function loadConnectionsPayload(input: { env: Env; userId: number }) {
-	const { env, userId } = input
-	const [connections, usablePassword, passkeys] = await Promise.all([
-		listConnections(env.APP_DB, userId),
-		hasUsablePassword(env.APP_DB, userId),
-		listPasskeysForUser(env.APP_DB, userId),
-	])
-	// Disconnecting the last connection is only safe when another first
-	// factor (password or passkey) can still sign the account in.
-	const canDisconnect =
-		usablePassword || passkeys.length > 0 || connections.length > 1
-	const connectedProviders = new Set(
-		connections.map((connection) => connection.provider_name),
-	)
-	return {
-		ok: true,
-		connections: connections.map((connection) => ({
-			provider: connection.provider_name,
-			label: isOauthProviderId(connection.provider_name)
-				? oauthProviderDefinitions[connection.provider_name].label
-				: connection.provider_name,
-			displayName: connection.provider_display_name,
-			createdAt: connection.created_at,
-		})),
-		canDisconnect,
-		availableProviders: getEnabledOauthProviders(env)
-			.filter((provider) => !connectedProviders.has(provider))
-			.map((provider) => ({
-				id: provider,
-				label: oauthProviderDefinitions[provider].label,
-			})),
-	}
-}
 
 export function createAccountConnectionsApiHandler(env: Env) {
 	return {
@@ -91,7 +23,7 @@ export function createAccountConnectionsApiHandler(env: Env) {
 
 			if (request.method === 'GET') {
 				return jsonResponse(
-					await loadConnectionsPayload({ env, userId: user.userId }),
+					await loadAccountConnectionsData({ env, userId: user.userId }),
 				)
 			}
 
@@ -161,7 +93,7 @@ export function createAccountConnectionsApiHandler(env: Env) {
 				reason: `provider=${provider}`,
 			})
 			return jsonResponse(
-				await loadConnectionsPayload({ env, userId: user.userId }),
+				await loadAccountConnectionsData({ env, userId: user.userId }),
 			)
 		},
 	} satisfies Action<typeof routes.accountConnectionsApi>

--- a/packages/worker/src/app/handlers/account.ts
+++ b/packages/worker/src/app/handlers/account.ts
@@ -1,4 +1,5 @@
 import { type Action } from 'remix/router'
+import { loadAccountConnectionsData } from '#app/account-connections-data.ts'
 import { loadAccountProfileData } from '#app/account-profile-data.ts'
 import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
@@ -25,20 +26,22 @@ export function createAccountHandler(env: Env) {
 				return redirectToLoginWhenUnauthenticated(request, env)
 			}
 
-			const [accountProfile, onboarding] = await Promise.all([
-				loadAccountProfileData(user),
-				loadOnboardingData({
-					env,
-					requestUrl: request.url,
-					stableUserId: user.mcpUser.userId,
-					emailVerified: user.emailVerified,
-				}),
-			])
+			const [accountProfile, accountConnections, onboarding] =
+				await Promise.all([
+					loadAccountProfileData(user),
+					loadAccountConnectionsData({ env, userId: user.userId }),
+					loadOnboardingData({
+						env,
+						requestUrl: request.url,
+						stableUserId: user.mcpUser.userId,
+						emailVerified: user.emailVerified,
+					}),
+				])
 			return renderAppPage({
 				request,
 				env,
 				title: 'Account',
-				loaderData: { accountProfile, onboarding },
+				loaderData: { accountProfile, accountConnections, onboarding },
 			})
 		},
 	} satisfies Action<typeof routes.account>

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -325,6 +325,20 @@ export type AccountProfileLoaderData = {
 	displayName: string
 }
 
+export type AccountConnectionListItem = {
+	provider: string
+	label: string
+	displayName: string | null
+	createdAt: string
+}
+
+export type AccountConnectionsLoaderData = {
+	ok: true
+	connections: Array<AccountConnectionListItem>
+	canDisconnect: boolean
+	availableProviders: Array<{ id: string; label: string }>
+}
+
 export type OnboardingLoaderData = {
 	ok: true
 	mcpServerUrl: string
@@ -540,6 +554,7 @@ export type AppLoaderData = {
 	adminInsights?: AdminInsightsLoaderData
 	adminSystemEmail?: AdminSystemEmailLoaderData
 	accountProfile?: AccountProfileLoaderData
+	accountConnections?: AccountConnectionsLoaderData
 	onboarding?: OnboardingLoaderData
 	pendingVerification?: PendingVerificationLoaderData
 	accountTwoFactor?: AccountTwoFactorLoaderData

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -249,6 +249,12 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		username: 'account-user',
 		displayName: 'account-user',
 	})
+	expect(accountProps.loaderData?.accountConnections).toEqual({
+		ok: true,
+		connections: [],
+		canDisconnect: false,
+		availableProviders: [],
+	})
 	expect(accountProps.loaderData?.onboarding).toEqual({
 		ok: true,
 		mcpServerUrl: '',
@@ -258,6 +264,8 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		needsOnboarding: true,
 	})
 	expect(accountHtml).toContain('Verify your email')
+	expect(accountHtml).toContain('No accounts connected yet.')
+	expect(accountHtml).not.toContain('Loading connected accounts')
 	expect(accountHtml).not.toContain('Connect your AI agent')
 	expect(accountHtml).toContain('/pending-verification')
 

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -269,6 +269,17 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	expect(accountHtml).not.toContain('Connect your AI agent')
 	expect(accountHtml).toContain('/pending-verification')
 
+	const accountLinkedResponse = await runHtmlHandler(
+		createAccountHandler(env),
+		new Request('https://example.com/account?oauthLinked=google', {
+			headers: { Cookie: accountCookie },
+		}),
+	)
+	expect(accountLinkedResponse.status).toBe(200)
+	const accountLinkedHtml = await readResponseText(accountLinkedResponse)
+	expect(accountLinkedHtml).toContain('Google connected.')
+	expect(accountLinkedHtml).toContain('No accounts connected yet.')
+
 	const onboardingResponse = await runHtmlHandler(
 		createOnboardingHandler(env),
 		new Request('https://example.com/onboarding', {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Load third-party connections in the account route loader and SSR payload (same preload-then-commit pattern as the rest of account settings).
- Consume `accountConnections` on first render instead of fetching after the route commits.
- Removes the stuck/flashing "Loading connected accounts…" state on SPA navigation to `/account`.

## Test plan
- [ ] Full page load of `/account` shows connected accounts (or "No accounts connected yet") without a loading flash
- [ ] Client-side navigate to `/account` from another account section (e.g. Integrations) and confirm connections render immediately
- [ ] Connect/disconnect still update the list from the POST response

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-818cc7af-6324-45b2-a2af-52cf272a7238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-818cc7af-6324-45b2-a2af-52cf272a7238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account pages now load account profile, onboarding, and connected-account data together, enabling the “Connected accounts” section to render immediately from loader data.
  * Connect/disconnect UI now reflects refreshed provider availability and updated per-connection messaging.
  * Requests that return unauthorized now redirect to the login page.
* **Bug Fixes**
  * Removed the client-side connected-accounts loading state machine; the panel is now fully loader-driven.
  * OAuth callback “flash” messaging is applied only once.
* **Tests**
  * Expanded SSR and social-login e2e assertions to validate the new connected-accounts rendering and disconnect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->