### PR TITLE
Encourage community packages to include an icon

### DIFF
--- a/docs/guides/package-authoring.md
+++ b/docs/guides/package-authoring.md
@@ -73,7 +73,7 @@ Account publishing still works so the owner can run the package privately.
 
 ## Community icon
 
-Public community packages may include one root `community-icon.svg`,
+Public community packages should include one root `community-icon.svg`,
 `community-icon.png`, `community-icon.webp`, `community-icon.jpg`, or
 `community-icon.jpeg`. Prefer a square visual with a simple silhouette that
 remains legible at 56 pixels. Keep it under 2 MiB and 16 megapixels. Kody

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -37,7 +37,7 @@ Requirements:
 
 ### Community icon
 
-Add one optional icon at the package root:
+Include an icon at the package root:
 
 - `community-icon.svg`
 - `community-icon.png`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Community package docs treated icons as optional (`may include` / `optional`). This updates that wording so authors are encouraged to include a `community-icon.*` file.

- `docs/use/community-packages.md`: “Add one optional icon” → “Include an icon”
- `docs/guides/package-authoring.md`: “may include” → “should include”

Fallback generation for packages without an icon is unchanged.

## Test plan

- [x] Docs-only wording change; no code or validation impact

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc87c222-502e-45c7-b8d4-f5b7c5a8cb9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc87c222-502e-45c7-b8d4-f5b7c5a8cb9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package authoring guidance to require a `community-icon.svg` for public community packages.
  * Clarified publishing instructions to include an icon at the package root.
  * Retained existing fallback icon format guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->