### PR TITLE
Fix community OG overflow and steer short package descriptions

### DIFF
--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -154,8 +154,9 @@ mirroring app design tokens, satori layout + resvg rasterization, and the
 `publicOgPages` registry. Static public pages serve generated images from
 `/og/:page.png` (page ids such as `home`, `community`, `login`). Community
 listing cards use `og-image.ts` on that same pipeline and are served at
-`/community/:listingId/og.png` (package community icon, package name, “Use Kody
-to …” description, star rating, fork count).
+`/community/:listingId/og.png` (package identity as the visual hero — community
+icon, package name, and byline — with a truncated muted description as
+supporting text, then star rating and fork count).
 
 ## Admin moderation
 

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -15,7 +15,7 @@ Use `package.json` as the canonical source of truth for saved package metadata.
   `kody.id: "my-package"`)
 - `exports` — authoritative import/export map
 - `kody.id` — user-scoped Kody package id
-- `kody.description` — package description for search/detail
+- `kody.description` — short public tagline for search/detail (max 200)
 - `kody.tags` — search tags
 - `kody.dependencies` — direct static saved package dependencies imported via
   `kody:@...`

--- a/docs/guides/package-authoring.md
+++ b/docs/guides/package-authoring.md
@@ -54,6 +54,18 @@ This package exists to ...
 Keep the section concise. It should explain why the package exists and what
 success means for the user, not duplicate every implementation detail.
 
+## `kody.description` (short public tagline)
+
+`package.json#kody.description` is a **short public tagline**, not a feature
+dump. Aim for about **80–120 characters** (hard max **200**). Prefer outcome
+phrasing such as “Send transactional email via Resend” over inventory lists of
+exports, auth, or APIs.
+
+Put feature lists, API surface, auth notes, and longer guidance in `README.md`
+(including `## Intent`), `kody.searchText`, and export/JSDoc docs — not in
+`kody.description`. Community listings and Open Graph share cards reuse this
+field, so keep it concise.
+
 ## Package visibility (`private`)
 
 Default new saved packages to `"private": true` in `package.json` unless the

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -32,6 +32,9 @@ Requirements:
   **updating** an existing package.
 - A root **`README.md`** with a **`## Intent`** section (same guidance as
   [Packages](./packages.md#save-and-edit-packages)).
+- A short **`kody.description`** tagline (~80–120 characters ideal; max 200).
+  Community listings and Open Graph share cards use this field, so keep it
+  concise — not a feature dump.
 - A **published** saved package commit. Publishing creates a **pinned snapshot**
   of the files at that commit.
 

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -32,7 +32,11 @@ Important fields:
   public community listing
 - `exports` — authoritative import/export map
 - `kody.id` — user-scoped Kody package id
-- `kody.description` — package description for search/detail
+- `kody.description` — short public tagline for search, detail, community
+  listings, and share cards (~80–120 characters ideal; max 200). Prefer outcome
+  phrasing (“Send transactional email via Resend”) over feature lists; put API
+  surface, auth notes, and longer detail in README / Intent / `searchText` /
+  export docs
 - `kody.tags` — package tags
 - `kody.dependencies` — direct saved package names imported through static
   `kody:@...` imports

--- a/packages/worker/src/community/og-image.node.test.ts
+++ b/packages/worker/src/community/og-image.node.test.ts
@@ -41,3 +41,17 @@ test('renderCommunityOgImage returns valid PNG bytes with and without ratings', 
 	})
 	expectPngBytes(withoutRatings)
 })
+
+test('renderCommunityOgImage clamps a long description without overflowing', async () => {
+	const png = await renderCommunityOgImage({
+		name: '@kody/long-description-package',
+		description:
+			'this is an intentionally very long community package description that would previously overrun the OG card after the hard-coded Use Kody to prefix was prepended, including extra clauses about labels, assignees, digests, reminders, and weekly digests for multiple teams',
+		ownerUsername: 'kody',
+		averageStars: 3.5,
+		ratingCount: 4,
+		forkCount: 1,
+		iconDataUri: await sampleIconDataUri('@kody/long-description-package'),
+	})
+	expectPngBytes(png)
+})

--- a/packages/worker/src/community/og-image.ts
+++ b/packages/worker/src/community/og-image.ts
@@ -6,7 +6,14 @@ import {
 	type SatoriElement,
 } from '#worker/og/render.ts'
 
-const DESCRIPTION_MAX_LENGTH = 140
+/** Character clamp for the supporting description (~2 visual lines). */
+const DESCRIPTION_MAX_LENGTH = 95
+const DESCRIPTION_FONT_SIZE = 28
+const DESCRIPTION_LINE_HEIGHT = 1.4
+/** Hard visual clamp so long text cannot overrun ratings/forks. */
+const DESCRIPTION_MAX_HEIGHT = Math.round(
+	DESCRIPTION_FONT_SIZE * DESCRIPTION_LINE_HEIGHT * 2,
+)
 const PACKAGE_ICON_SIZE = 96
 /** Matches `--radius-lg` (0.75rem) at OG canvas scale (~1.5× UI). */
 const PACKAGE_ICON_RADIUS = 18
@@ -121,8 +128,9 @@ function createPackageIdentityRow(input: CommunityOgImageInput): SatoriElement {
 								type: 'div',
 								props: {
 									style: {
-										fontSize: 30,
+										fontSize: 48,
 										fontWeight: 600,
+										letterSpacing: '-0.02em',
 										color: ogPalette.primary,
 										marginBottom: 8,
 									},
@@ -148,31 +156,28 @@ function createPackageIdentityRow(input: CommunityOgImageInput): SatoriElement {
 }
 
 function createOgMarkup(input: CommunityOgImageInput): SatoriElement {
-	const headline = `Use Kody to ${truncateOgText(
-		input.description,
-		DESCRIPTION_MAX_LENGTH,
-	)}`
+	const description = truncateOgText(input.description, DESCRIPTION_MAX_LENGTH)
 	const starRow = createStarRow(input)
 	const ratingText = formatStarRating(input)
 
 	return createOgFrame({
 		label: 'Community package',
 		children: [
+			createPackageIdentityRow(input),
 			{
 				type: 'div',
 				props: {
 					style: {
-						fontSize: 42,
-						fontWeight: 600,
-						lineHeight: 1.2,
-						letterSpacing: '-0.02em',
+						fontSize: DESCRIPTION_FONT_SIZE,
+						lineHeight: DESCRIPTION_LINE_HEIGHT,
+						color: ogPalette.muted,
 						marginBottom: 28,
-						color: ogPalette.text,
+						maxHeight: DESCRIPTION_MAX_HEIGHT,
+						overflow: 'hidden',
 					},
-					children: headline,
+					children: description,
 				},
 			},
-			createPackageIdentityRow(input),
 			{
 				type: 'div',
 				props: {

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -18,6 +18,7 @@ import { deleteEntitySource } from '#worker/repo/entity-sources.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 import { assertPackageNotPrivateForCommunityPublish } from '#worker/package-registry/package-private.ts'
+import { assertKodyDescriptionLength } from '#worker/package-registry/types.ts'
 import { CommunityActionError } from './errors.ts'
 import {
 	countCommunityForksByListingIds,
@@ -325,6 +326,7 @@ export async function publishCommunityListing(input: {
 	if (!packageJsonContent) {
 		throw new Error('Saved packages require a root package.json file.')
 	}
+	assertKodyDescriptionLength(loadedSource.manifest.kody.description)
 	const license = parseRawPackageLicense(packageJsonContent)
 	assertPackageNotPrivateForCommunityPublish(packageJsonContent)
 

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -326,7 +326,8 @@ export async function publishCommunityListing(input: {
 	if (!packageJsonContent) {
 		throw new Error('Saved packages require a root package.json file.')
 	}
-	assertKodyDescriptionLength(loadedSource.manifest.kody.description)
+	const description = loadedSource.manifest.kody.description
+	assertKodyDescriptionLength(description)
 	const license = parseRawPackageLicense(packageJsonContent)
 	assertPackageNotPrivateForCommunityPublish(packageJsonContent)
 
@@ -387,7 +388,7 @@ export async function publishCommunityListing(input: {
 			sourceId: savedPackage.sourceId,
 			kodyId: savedPackage.kodyId,
 			name: savedPackage.name,
-			description: savedPackage.description,
+			description,
 			tagsJson,
 			searchText: savedPackage.searchText,
 			readmeContent: readme.content,
@@ -409,7 +410,7 @@ export async function publishCommunityListing(input: {
 			source_id: savedPackage.sourceId,
 			kody_id: savedPackage.kodyId,
 			name: savedPackage.name,
-			description: savedPackage.description,
+			description,
 			tags_json: tagsJson,
 			search_text: savedPackage.searchText,
 			readme_content: readme.content,

--- a/packages/worker/src/mcp/capabilities/packages/create-stub-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/create-stub-package.ts
@@ -4,7 +4,10 @@ import { buildSavedPackageEmbedText } from '#worker/package-registry/embed.ts'
 import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
 import { insertSavedPackage } from '#worker/package-registry/repo.ts'
 import { refreshSavedPackageProjection } from '#worker/package-registry/service.ts'
-import { kodyPackageIdPattern } from '#worker/package-registry/types.ts'
+import {
+	assertKodyDescriptionLength,
+	kodyPackageIdPattern,
+} from '#worker/package-registry/types.ts'
 import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
 import { upsertSavedPackageVector } from '#worker/package-registry/vectorize.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
@@ -71,6 +74,7 @@ export async function createStubSavedPackage(input: {
 	const scope = await getMcpUserPackageScope(input.env.APP_DB, input.user)
 	const name = `@${scope}/${kodyId}`
 	const description = input.description?.trim() || defaultStubPackageDescription
+	assertKodyDescriptionLength(description)
 	const files = buildStubPackageFiles({ name, kodyId, description })
 	const packageJsonContent = files['package.json']
 	if (!packageJsonContent) {

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -21,6 +21,7 @@ import {
 	insertSavedPackage,
 } from '#worker/package-registry/repo.ts'
 import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
+import { assertKodyDescriptionLength } from '#worker/package-registry/types.ts'
 import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
 import { buildSavedPackageEmbedText } from '#worker/package-registry/embed.ts'
 import { upsertSavedPackageVector } from '#worker/package-registry/vectorize.ts'
@@ -151,6 +152,7 @@ export const savePackageCapability = defineDomainCapability(
 				manifestPath: 'package.json',
 				expectedPackageScope,
 			})
+			assertKodyDescriptionLength(manifest.kody.description)
 			const packageId = existing?.id ?? args.package_id ?? crypto.randomUUID()
 			const canonicalExistingSource =
 				existing == null

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -75,6 +75,25 @@ test('parseAuthoredPackageJson validates scoped package names against kody.id', 
 	).toThrow(/must be a scoped package name/)
 })
 
+test('parseAuthoredPackageJson rejects kody.description longer than 200 characters', () => {
+	const tooLong = 'a'.repeat(201)
+	expect(() =>
+		parseAuthoredPackageJson({
+			content: JSON.stringify({
+				name: '@kentcdodds/long-description',
+				exports: {
+					'.': './index.ts',
+				},
+				kody: {
+					id: 'long-description',
+					description: tooLong,
+				},
+			}),
+			manifestPath: 'package.json',
+		}),
+	).toThrow(/kody\.description must be at most 200 characters/)
+})
+
 test('parseAuthoredPackageJson accepts services, subscriptions, emits, retrievers, and secret mounts', () => {
 	const manifest = parseAuthoredPackageJson({
 		content: JSON.stringify({

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -3,6 +3,10 @@ import {
 	buildPackageSearchProjection,
 	parseAuthoredPackageJson,
 } from './manifest.ts'
+import {
+	assertKodyDescriptionLength,
+	KODY_DESCRIPTION_MAX_LENGTH,
+} from './types.ts'
 
 test('parseAuthoredPackageJson validates scoped package names against kody.id', () => {
 	const manifest = parseAuthoredPackageJson({
@@ -75,23 +79,29 @@ test('parseAuthoredPackageJson validates scoped package names against kody.id', 
 	).toThrow(/must be a scoped package name/)
 })
 
-test('parseAuthoredPackageJson rejects kody.description longer than 200 characters', () => {
-	const tooLong = 'a'.repeat(201)
-	expect(() =>
-		parseAuthoredPackageJson({
-			content: JSON.stringify({
-				name: '@kentcdodds/long-description',
-				exports: {
-					'.': './index.ts',
-				},
-				kody: {
-					id: 'long-description',
-					description: tooLong,
-				},
-			}),
-			manifestPath: 'package.json',
+test('parseAuthoredPackageJson loads kody.description longer than the write-path max', () => {
+	const tooLongForWrite = 'a'.repeat(KODY_DESCRIPTION_MAX_LENGTH + 1)
+	const manifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/long-description',
+			exports: {
+				'.': './index.ts',
+			},
+			kody: {
+				id: 'long-description',
+				description: tooLongForWrite,
+			},
 		}),
-	).toThrow(/kody\.description must be at most 200 characters/)
+		manifestPath: 'package.json',
+	})
+	expect(manifest.kody.description).toBe(tooLongForWrite)
+})
+
+test('assertKodyDescriptionLength rejects descriptions longer than 200 characters', () => {
+	expect(() => assertKodyDescriptionLength('a'.repeat(200))).not.toThrow()
+	expect(() => assertKodyDescriptionLength('a'.repeat(201))).toThrow(
+		/kody\.description must be at most 200 characters \(short public tagline\)/,
+	)
 })
 
 test('parseAuthoredPackageJson accepts services, subscriptions, emits, retrievers, and secret mounts', () => {

--- a/packages/worker/src/package-registry/types.ts
+++ b/packages/worker/src/package-registry/types.ts
@@ -150,7 +150,13 @@ export type KodyPackageDependency = z.infer<typeof kodyPackageDependencySchema>
 
 export const authoredPackageKodySchema = z.object({
 	id: z.string().regex(kodyPackageIdPattern),
-	description: z.string().min(1),
+	description: z
+		.string()
+		.min(1)
+		.max(
+			200,
+			'kody.description must be at most 200 characters (short public tagline).',
+		),
 	tags: z.array(z.string().min(1)).optional(),
 	searchText: z.string().min(1).optional(),
 	dependencies: kodyPackageDependenciesSchema.optional(),

--- a/packages/worker/src/package-registry/types.ts
+++ b/packages/worker/src/package-registry/types.ts
@@ -148,15 +148,23 @@ const kodyPackageDependenciesSchema = z
 
 export type KodyPackageDependency = z.infer<typeof kodyPackageDependencySchema>
 
+/** Soft cap for new/updated `kody.description` taglines on write/publish only. */
+export const KODY_DESCRIPTION_MAX_LENGTH = 200
+
+export function assertKodyDescriptionLength(description: string) {
+	if (description.length > KODY_DESCRIPTION_MAX_LENGTH) {
+		throw new Error(
+			'kody.description must be at most 200 characters (short public tagline).',
+		)
+	}
+}
+
 export const authoredPackageKodySchema = z.object({
 	id: z.string().regex(kodyPackageIdPattern),
-	description: z
-		.string()
-		.min(1)
-		.max(
-			200,
-			'kody.description must be at most 200 characters (short public tagline).',
-		),
+	// No max here: this schema is shared by load/parse. Enforce
+	// KODY_DESCRIPTION_MAX_LENGTH only at write/publish boundaries via
+	// assertKodyDescriptionLength so existing longer descriptions still load.
+	description: z.string().min(1),
 	tags: z.array(z.string().min(1)).optional(),
 	searchText: z.string().min(1).optional(),
 	dependencies: kodyPackageDependenciesSchema.optional(),

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -7,7 +7,10 @@ import {
 	parseAuthoredPackageJson,
 	resolvePackageExportPath,
 } from '#worker/package-registry/manifest.ts'
-import { type AuthoredPackageJson } from '#worker/package-registry/types.ts'
+import {
+	assertKodyDescriptionLength,
+	type AuthoredPackageJson,
+} from '#worker/package-registry/types.ts'
 import {
 	buildKodyAppBundle,
 	buildKodyImportableModuleBundle,
@@ -882,6 +885,7 @@ export async function runRepoChecks(input: {
 		manifestPath: input.manifestPath,
 		expectedPackageScope: input.expectedPackageScope,
 	})
+	assertKodyDescriptionLength(manifest.kody.description)
 	const results: Array<RepoCheckResult> = [
 		{
 			kind: 'manifest',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Community package OG cards were overrun by long `kody.description` values, and the renderer hard-coded a `Use Kody to …` prefix that only made sense for verb-phrase blurbs (real packages are feature catalogs).

This PR:
- Drops the `Use Kody to` OG prefix
- Makes package identity the hero; description is muted and visually clamped (~2 lines)
- Steers agents toward short public taglines in authoring/use docs
- Enforces a **200-char max on write/publish only** (load/parse of older longer descriptions still works)
- `community_publish` persists the validated manifest description (not a possibly-stale saved-package projection)
- Separately shortened live `@kentcdodds/*` community listing descriptions via package republish (already on heykody.dev)

## Test plan

- [x] `vitest` community `og-image` node + workers tests
- [x] `vitest` package-registry manifest + stub create tests
- [x] `npm run typecheck` (earlier in branch)
- [ ] CI green
- [ ] Spot-check `/community/:id/og.png` after deploy (e.g. resend)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `54a493b1` · **Head:** `d6019e22`

**Classification:** extends — community OG presentation and package-description write contract; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — community listing OG image layout/copy |
| `saved-packages` | assistant | extends — write-path max length for `kody.description` |
| `mcp-server` | surfaces | extends — `package_save` / stub create enforce description max |
| `community-listings` | assistant | extends — `community_publish` rejects overlong descriptions and writes validated manifest description; OG share cards |

### System map

```mermaid
flowchart LR
  subgraph surfaces
    MCP[mcp-server]
    UI[app-ui /community OG]
  end
  subgraph assistant
    PKG[saved-packages]
    CL[community-listings]
  end
  MCP -->|package_save / publish| PKG
  PKG -->|community_publish| CL
  CL -->|og.png| UI
```

### Risk notes

- Description max is **write-only** so existing long manifests still load.
- OG clamp is presentation-only; listing DB text unchanged by this PR (live packages shortened separately).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6567cb02-f056-4e36-ab20-527b687d8674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6567cb02-f056-4e36-ab20-527b687d8674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `kody.description` is a concise public tagline (recommended 80–120 characters, max 200) and where it appears (search, package details, community listings, and share cards).
  * Added guidance to move longer feature/technical/API content to `README.md`, `## Intent`, `kody.searchText`, and export/JSDoc docs.

* **Improvements**
  * Enforced `kody.description` length validation during save, publish, and package creation.
  * Updated community share card/OG image rendering to show a compact, truncated muted description and adjusted visual layout.
  * Added tests to ensure overly long descriptions remain safe for generated OG images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->