### PR TITLE
Add account packages route for browsing saved package metadata

### DIFF
--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -154,6 +154,7 @@ export function AccountManagementLinkNav(
 
 const accountNavItems = [
 	{ href: '/account', label: 'Overview' },
+	{ href: '/account/packages', label: 'Packages' },
 	{ href: '/account/secrets', label: 'Secrets' },
 	{ href: '/account/integrations', label: 'Integrations' },
 	{ href: '/account/package-invocation-tokens', label: 'Package tokens' },

--- a/packages/worker/client/routes/account-packages.tsx
+++ b/packages/worker/client/routes/account-packages.tsx
@@ -1,0 +1,676 @@
+import { formatTimestamp } from '#client/format-timestamp.ts'
+import { type Handle, css } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { replaceLocation } from '#client/replace-location.ts'
+import {
+	createInfiniteList,
+	type InfiniteListSnapshot,
+} from '#client/infinite-list.ts'
+import { infiniteScrollSentinel } from '#client/infinite-scroll.ts'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { readJson } from '#client/routes/account-approval-shared.ts'
+import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
+import {
+	cardCss,
+	fieldCss,
+	fieldLabelCss,
+	getSecondaryButtonCss,
+	inputCss,
+} from '#client/styles/style-primitives.ts'
+import {
+	AccountManagementLayout,
+	AccountManagementList,
+	AccountManagementListItemButton,
+	AccountManagementMessage,
+	AccountManagementSearchField,
+	AccountManagementShell,
+	AccountPageHeader,
+	AccountManagementSidebar,
+	MetadataGrid,
+} from './account-management-components.tsx'
+import {
+	type AccountPackageDetail,
+	type AccountPackageListItem,
+	type AccountPackagesAppFilter,
+	type AccountPackagesLoaderData,
+	type AccountPackagesSort,
+} from '#app/loader-data.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
+
+type PageStatus = 'loading' | 'ready' | 'error'
+
+const packagesBasePath = '/account/packages'
+const accountPackagesApiPath = '/account/packages.json'
+
+type PackageFilterState = {
+	search: string
+	app: AccountPackagesAppFilter
+	sort: AccountPackagesSort
+}
+
+function isAccountPackagesPath(href: string) {
+	const path = new URL(href, 'http://localhost').pathname
+	return path === packagesBasePath || path.startsWith(`${packagesBasePath}/`)
+}
+
+function getSelectedPackageId(href: string) {
+	const pathname = new URL(href, 'http://localhost').pathname
+	const detailPrefix = `${packagesBasePath}/`
+	if (!pathname.startsWith(detailPrefix)) return null
+	const packageId = decodeURIComponent(pathname.slice(detailPrefix.length))
+	return packageId || null
+}
+
+function readFilterState(href: string): PackageFilterState {
+	const url = new URL(href, 'http://localhost')
+	const rawApp = url.searchParams.get('app')?.trim()
+	const rawSort = url.searchParams.get('sort')?.trim()
+	return {
+		search: url.searchParams.get('q')?.trim() ?? '',
+		app: rawApp === 'with' || rawApp === 'without' ? rawApp : 'all',
+		sort: rawSort === 'created' || rawSort === 'name' ? rawSort : 'updated',
+	}
+}
+
+/**
+ * The list window only depends on the filters, not on which package is
+ * selected — selection-only navigations keep the loaded scroll window.
+ */
+function getListKey(href: string) {
+	const filters = readFilterState(href)
+	return `q=${filters.search}&app=${filters.app}&sort=${filters.sort}`
+}
+
+function getDataKey(href: string) {
+	const pathname = new URL(href, 'http://localhost').pathname
+	return `${pathname}?${getListKey(href)}`
+}
+
+function buildPackagesApiRequestUrl(
+	href: string,
+	options?: { page?: number; includeSelected?: boolean },
+) {
+	const filters = readFilterState(href)
+	const requestUrl = new URL(accountPackagesApiPath, 'http://localhost')
+	if (filters.search) requestUrl.searchParams.set('q', filters.search)
+	if (filters.app !== 'all') requestUrl.searchParams.set('app', filters.app)
+	if (filters.sort !== 'updated')
+		requestUrl.searchParams.set('sort', filters.sort)
+	if (options?.page != null)
+		requestUrl.searchParams.set('page', String(options.page))
+	const selectedPackageId = getSelectedPackageId(href)
+	if (selectedPackageId && options?.includeSelected !== false) {
+		requestUrl.searchParams.set('selected', selectedPackageId)
+	}
+	return `${requestUrl.pathname}${requestUrl.search}`
+}
+
+function buildPackageHref(packageId: string, search: string) {
+	return `${packagesBasePath}/${encodeURIComponent(packageId)}${search}`
+}
+
+export async function accountPackagesRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const href = `${url.pathname}${url.search}`
+	const response = await fetch(buildPackagesApiRequestUrl(href), {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		return routeLoaderRedirect('/login')
+	}
+	const payload = await readJson<AccountPackagesLoaderData>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load your packages.')
+	}
+	return { accountPackages: payload }
+}
+
+function formatUpdatedDate(updatedAt: string) {
+	return `Updated ${new Date(updatedAt).toLocaleDateString()}`
+}
+
+const truncatedTextCss = {
+	minWidth: 0,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+} as const
+
+const tagChipCss = {
+	display: 'inline-block',
+	padding: `0 ${spacing.sm}`,
+	borderRadius: radius.md,
+	border: `1px solid ${colors.border}`,
+	backgroundColor: colors.surface,
+	color: colors.textMuted,
+	fontSize: typography.fontSize.xs,
+	lineHeight: '1.5rem',
+} as const
+
+export function AccountPackagesRoute(handle: Handle) {
+	let status: PageStatus = 'loading'
+	let pageSize = 20
+	let loadedThroughPage = 1
+	const packageList = createInfiniteList<AccountPackageListItem>({
+		mergeDirection: 'append',
+		getKey: (pkg) => pkg.id,
+		onSnapshot: (snapshot) => {
+			packagesSnapshot = snapshot
+		},
+	})
+	let packagesSnapshot: InfiniteListSnapshot<AccountPackageListItem> =
+		packageList.getSnapshot()
+	let selectedPackage: AccountPackageDetail | null = null
+	let message: string | null = null
+	let loadRequestId = 0
+	let lastLoadedDataKey = ''
+	let lastLoadedListKey = ''
+	let loadingDataKey: string | null = null
+	let lastFailedDataKey: string | null = null
+
+	function getCurrentHref() {
+		return readCurrentRouterHref(handle)
+	}
+
+	function getCurrentSearch() {
+		return new URL(getCurrentHref(), 'http://localhost').search
+	}
+
+	function buildHrefWithUpdatedFilters(
+		nextFilters: Partial<PackageFilterState>,
+	) {
+		const url = new URL(getCurrentHref(), 'http://localhost')
+		const filters = { ...readFilterState(url.toString()), ...nextFilters }
+		if (filters.search) url.searchParams.set('q', filters.search)
+		else url.searchParams.delete('q')
+		if (filters.app !== 'all') url.searchParams.set('app', filters.app)
+		else url.searchParams.delete('app')
+		if (filters.sort !== 'updated') url.searchParams.set('sort', filters.sort)
+		else url.searchParams.delete('sort')
+		url.searchParams.delete('page')
+		return `${url.pathname}${url.search}`
+	}
+
+	function applyPayload(payload: AccountPackagesLoaderData, href: string) {
+		pageSize = payload.pageSize
+		const listKey = getListKey(href)
+		// Selection-only navigations deep in the scroll window keep the
+		// already-loaded pages; anything else reseeds from page one so
+		// filter changes and plain revisits always show fresh data.
+		if (listKey !== lastLoadedListKey || loadedThroughPage <= 1) {
+			loadedThroughPage = payload.page
+			// reset() invalidates any in-flight load-more so a stale page
+			// fetched for the previous filters can never append into the
+			// fresh window.
+			packageList.reset()
+			packageList.replaceWindow({
+				items: payload.packages,
+				hasMore: payload.page * payload.pageSize < payload.total,
+				totalCount: payload.total,
+			})
+			lastLoadedListKey = listKey
+		}
+		selectedPackage = payload.selectedPackage
+		message =
+			getSelectedPackageId(href) && !payload.selectedPackage
+				? 'Package not found.'
+				: null
+		status = 'ready'
+		lastLoadedDataKey = getDataKey(href)
+		lastFailedDataKey = null
+	}
+
+	async function loadAccountPackages() {
+		const href = getCurrentHref()
+		const dataKey = getDataKey(href)
+		loadingDataKey = dataKey
+		const requestId = ++loadRequestId
+		try {
+			const response = await fetch(buildPackagesApiRequestUrl(href), {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+			})
+			if (
+				requestId !== loadRequestId ||
+				getDataKey(getCurrentHref()) !== dataKey
+			)
+				return
+			if (response.status === 401) {
+				window.location.assign('/login')
+				return
+			}
+			const payload = await readJson<AccountPackagesLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load your packages.')
+			}
+			applyPayload(payload, href)
+			handle.update()
+		} catch (error) {
+			if (
+				requestId !== loadRequestId ||
+				getDataKey(getCurrentHref()) !== dataKey
+			)
+				return
+			status = 'error'
+			message =
+				error instanceof Error ? error.message : 'Unable to load your packages.'
+			lastFailedDataKey = dataKey
+			handle.update()
+		} finally {
+			if (requestId === loadRequestId && loadingDataKey === dataKey) {
+				loadingDataKey = null
+			}
+		}
+	}
+
+	async function loadMorePackages() {
+		if (status !== 'ready') return false
+		const nextPage = loadedThroughPage + 1
+		const loaded = await packageList.loadMore(async () => {
+			const requestUrl = buildPackagesApiRequestUrl(getCurrentHref(), {
+				page: nextPage,
+				includeSelected: false,
+			})
+			const response = await fetch(requestUrl, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+			})
+			if (response.status === 401) {
+				window.location.assign('/login')
+				throw new Error('Signed out.')
+			}
+			const payload = await readJson<AccountPackagesLoaderData>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load more packages.')
+			}
+			return {
+				items: payload.packages,
+				hasMore: payload.page * payload.pageSize < payload.total,
+				totalCount: payload.total,
+			}
+		})
+		if (loaded) {
+			loadedThroughPage = nextPage
+		}
+		handle.update()
+		return loaded
+	}
+
+	function applyRouteLoaderData(href: string) {
+		if (!isAccountPackagesPath(href)) return false
+		const routeData = tryConsumeRouteLoaderData(handle, 'accountPackages', href)
+		if (!routeData) return false
+		applyPayload(routeData, href)
+		return true
+	}
+
+	const secondaryButtonCss = getSecondaryButtonCss()
+	let lastSeenDataKey = ''
+
+	return () => {
+		const currentHref = getCurrentHref()
+		const currentDataKey = getDataKey(currentHref)
+		// The failure latch only guards retry loops for the location that
+		// failed; leaving it (or coming back) must allow a fresh attempt.
+		if (currentDataKey !== lastSeenDataKey) {
+			lastSeenDataKey = currentDataKey
+			lastFailedDataKey = null
+		}
+		// Consume route-loader data before deriving the list snapshot below;
+		// deriving first would render this pass from stale pre-navigation
+		// closure state.
+		const appliedRouteData = applyRouteLoaderData(currentHref)
+		// A same-path refresh whose loader failed leaves no preload and no
+		// data-key change; the stale marker forces the fallback refetch.
+		const needsStaleRefresh =
+			consumeStaleNavigationData(currentHref) && !appliedRouteData
+		const needsLoad =
+			(status === 'loading' ||
+				currentDataKey !== lastLoadedDataKey ||
+				needsStaleRefresh) &&
+			currentDataKey !== lastFailedDataKey &&
+			loadingDataKey !== currentDataKey
+		if (!appliedRouteData && needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
+			loadingDataKey = currentDataKey
+			handle.queueTask(loadAccountPackages)
+		}
+
+		const {
+			items: packages,
+			hasMore,
+			totalCount,
+			isLoadingMore,
+		} = packagesSnapshot
+		const filters = readFilterState(currentHref)
+		const hasActiveFilters = Boolean(filters.search || filters.app !== 'all')
+		const selectedPackageId = getSelectedPackageId(currentHref)
+		const activePackageId = selectedPackageId ?? selectedPackage?.id ?? null
+
+		return (
+			<AccountManagementShell>
+				<AccountPageHeader
+					title="Packages"
+					description="Browse your saved packages and review their metadata. Packages are created and edited through Kody's MCP tools."
+					currentHref={currentHref}
+				/>
+				{status === 'loading' ? (
+					<p mix={css({ color: colors.textMuted, margin: 0 })}>
+						Loading packages…
+					</p>
+				) : null}
+				{message ? (
+					<AccountManagementMessage
+						tone={status === 'error' ? 'error' : 'info'}
+					>
+						{message}
+					</AccountManagementMessage>
+				) : null}
+				<AccountManagementLayout
+					sidebar={
+						<AccountManagementSidebar
+							title="Saved packages"
+							description="Select a package to review its metadata."
+						>
+							<div mix={css({ display: 'grid', gap: spacing.sm })}>
+								<AccountManagementSearchField
+									label="Search"
+									placeholder="Search by name, id, description, or tag"
+									value={filters.search}
+									onInput={(value) => {
+										replaceLocation(
+											buildHrefWithUpdatedFilters({ search: value }),
+										)
+									}}
+								/>
+								<label mix={css(fieldCss)}>
+									<span mix={css(fieldLabelCss)}>App</span>
+									<select
+										value={filters.app}
+										aria-label="Filter packages by app"
+										mix={[
+											on('change', (event) => {
+												const nextApp = event.currentTarget
+													.value as AccountPackagesAppFilter
+												replaceLocation(
+													buildHrefWithUpdatedFilters({ app: nextApp }),
+												)
+											}),
+											css(inputCss),
+										]}
+									>
+										<option value="all">All packages</option>
+										<option value="with">With an app</option>
+										<option value="without">Without an app</option>
+									</select>
+								</label>
+								<label mix={css(fieldCss)}>
+									<span mix={css(fieldLabelCss)}>Sort</span>
+									<select
+										value={filters.sort}
+										aria-label="Sort packages"
+										mix={[
+											on('change', (event) => {
+												const nextSort = event.currentTarget
+													.value as AccountPackagesSort
+												replaceLocation(
+													buildHrefWithUpdatedFilters({ sort: nextSort }),
+												)
+											}),
+											css(inputCss),
+										]}
+									>
+										<option value="updated">Recently updated</option>
+										<option value="created">Recently created</option>
+										<option value="name">Name</option>
+									</select>
+								</label>
+							</div>
+							{status === 'ready' && packages.length === 0 ? (
+								<p mix={css({ margin: 0, color: colors.textMuted })}>
+									{hasActiveFilters
+										? 'No packages match the current filters.'
+										: 'No saved packages yet. Ask Kody to save one to get started.'}
+								</p>
+							) : (
+								<>
+									<AccountManagementList maxHeight="min(65vh, 48rem)">
+										{packages.map((pkg) => (
+											<li key={pkg.id} mix={css({ minWidth: 0 })}>
+												<AccountManagementListItemButton
+													active={activePackageId === pkg.id}
+													onClick={() => {
+														navigate(
+															buildPackageHref(pkg.id, getCurrentSearch()),
+														)
+													}}
+												>
+													<div
+														mix={css({
+															display: 'grid',
+															gridTemplateColumns: 'minmax(0, 1fr) auto',
+															gap: spacing.md,
+															alignItems: 'baseline',
+															minWidth: 0,
+														})}
+													>
+														<strong
+															mix={css({
+																...truncatedTextCss,
+																display: 'block',
+															})}
+														>
+															{pkg.name}
+														</strong>
+														<span
+															mix={css({
+																fontSize: typography.fontSize.xs,
+																color: colors.textMuted,
+															})}
+														>
+															{formatUpdatedDate(pkg.updatedAt)}
+														</span>
+													</div>
+													<span
+														mix={css({
+															...truncatedTextCss,
+															display: 'block',
+															fontSize: typography.fontSize.sm,
+															color: colors.textMuted,
+														})}
+													>
+														{pkg.kodyId}
+														{pkg.hasApp ? ' - has app' : ''}
+													</span>
+													{pkg.description ? (
+														<span
+															mix={css({
+																display: '-webkit-box',
+																fontSize: typography.fontSize.sm,
+																color: colors.textMuted,
+																overflow: 'hidden',
+																overflowWrap: 'anywhere',
+																textOverflow: 'ellipsis',
+																'-webkit-box-orient': 'vertical',
+																'-webkit-line-clamp': '2',
+															})}
+														>
+															{pkg.description}
+														</span>
+													) : null}
+												</AccountManagementListItemButton>
+											</li>
+										))}
+										{hasMore ? (
+											<li
+												key="load-more-sentinel"
+												mix={[
+													infiniteScrollSentinel(loadMorePackages),
+													css({ display: 'grid' }),
+												]}
+											>
+												<button
+													type="button"
+													disabled={isLoadingMore}
+													mix={[
+														on('click', () => void loadMorePackages()),
+														css(secondaryButtonCss),
+													]}
+												>
+													{isLoadingMore ? 'Loading more…' : 'Load more'}
+												</button>
+											</li>
+										) : null}
+									</AccountManagementList>
+									{packagesSnapshot.error ? (
+										<AccountManagementMessage tone="error">
+											{packagesSnapshot.error}
+										</AccountManagementMessage>
+									) : null}
+									{status === 'ready' ? (
+										<p
+											mix={css({
+												margin: 0,
+												marginTop: spacing.sm,
+												color: colors.textMuted,
+												fontSize: typography.fontSize.xs,
+											})}
+										>
+											Showing {packages.length} of {totalCount}{' '}
+											{totalCount === 1 ? 'package' : 'packages'}
+										</p>
+									) : null}
+								</>
+							)}
+						</AccountManagementSidebar>
+					}
+				>
+					<div mix={css({ ...cardCss, gap: spacing.lg })}>
+						{selectedPackage ? (
+							<>
+								<div mix={css({ display: 'grid', gap: spacing.xs })}>
+									<h2
+										mix={css({
+											margin: 0,
+											fontSize: typography.fontSize.lg,
+											fontWeight: typography.fontWeight.semibold,
+											color: colors.text,
+											overflowWrap: 'anywhere',
+										})}
+									>
+										{selectedPackage.name}
+									</h2>
+									{selectedPackage.description ? (
+										<p
+											mix={css({
+												margin: 0,
+												color: colors.textMuted,
+												overflowWrap: 'anywhere',
+											})}
+										>
+											{selectedPackage.description}
+										</p>
+									) : (
+										<p mix={css({ margin: 0, color: colors.textMuted })}>
+											This package has no description.
+										</p>
+									)}
+								</div>
+								{selectedPackage.tags.length > 0 ? (
+									<div
+										mix={css({
+											display: 'flex',
+											gap: spacing.xs,
+											flexWrap: 'wrap',
+										})}
+									>
+										{selectedPackage.tags.map((tag) => (
+											<span key={tag} mix={css(tagChipCss)}>
+												{tag}
+											</span>
+										))}
+									</div>
+								) : null}
+								<MetadataGrid
+									columns={3}
+									items={[
+										{ label: 'Kody id', value: selectedPackage.kodyId },
+										{
+											label: 'Package id',
+											value: (
+												<code mix={css({ overflowWrap: 'anywhere' })}>
+													{selectedPackage.id}
+												</code>
+											),
+										},
+										{
+											label: 'App',
+											value: selectedPackage.hasApp
+												? 'Declares a package app'
+												: 'No app',
+										},
+										{
+											label: 'Source id',
+											value: (
+												<code mix={css({ overflowWrap: 'anywhere' })}>
+													{selectedPackage.sourceId}
+												</code>
+											),
+										},
+										{
+											label: 'Created',
+											value: formatTimestamp(selectedPackage.createdAt),
+										},
+										{
+											label: 'Updated',
+											value: formatTimestamp(selectedPackage.updatedAt),
+										},
+									]}
+								/>
+								{selectedPackage.searchText ? (
+									<div mix={css({ display: 'grid', gap: spacing.xs })}>
+										<span mix={css(fieldLabelCss)}>Search text</span>
+										<p
+											mix={css({
+												margin: 0,
+												color: colors.textMuted,
+												overflowWrap: 'anywhere',
+											})}
+										>
+											{selectedPackage.searchText}
+										</p>
+									</div>
+								) : null}
+							</>
+						) : (
+							<div mix={css({ display: 'grid', gap: spacing.sm })}>
+								<h2
+									mix={css({
+										margin: 0,
+										fontSize: typography.fontSize.lg,
+										fontWeight: typography.fontWeight.semibold,
+										color: colors.text,
+									})}
+								>
+									Select a package
+								</h2>
+								<p mix={css({ margin: 0, color: colors.textMuted })}>
+									Pick a package from the list to review its metadata.
+								</p>
+							</div>
+						)}
+					</div>
+				</AccountManagementLayout>
+			</AccountManagementShell>
+		)
+	}
+}

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -13,6 +13,10 @@ import {
 	accountPackageInvocationTokensRouteLoader,
 } from './account-package-invocation-tokens.tsx'
 import {
+	AccountPackagesRoute,
+	accountPackagesRouteLoader,
+} from './account-packages.tsx'
+import {
 	AccountPasskeysRoute,
 	accountPasskeysRouteLoader,
 } from './account-passkeys.tsx'
@@ -77,6 +81,8 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		accountPackageInvocationTokensRouteLoader,
 	'/account/package-invocation-tokens/:tokenId':
 		accountPackageInvocationTokensRouteLoader,
+	'/account/packages': accountPackagesRouteLoader,
+	'/account/packages/:packageId': accountPackagesRouteLoader,
 	'/account/passkeys': accountPasskeysRouteLoader,
 	'/account/remote-connectors': accountRemoteConnectorsRouteLoader,
 	'/account/secrets': accountSecretsRouteLoader,
@@ -114,6 +120,8 @@ export const clientRoutes = {
 	'/account/package-invocation-tokens/:tokenId': (
 		<AccountPackageInvocationTokensRoute />
 	),
+	'/account/packages': <AccountPackagesRoute />,
+	'/account/packages/:packageId': <AccountPackagesRoute />,
 	'/account/passkeys': <AccountPasskeysRoute />,
 	'/account/remote-connectors': <AccountRemoteConnectorsRoute />,
 	'/account/secrets': <AccountSecretsRoute />,

--- a/packages/worker/src/app/account-packages-data.ts
+++ b/packages/worker/src/app/account-packages-data.ts
@@ -1,0 +1,135 @@
+import {
+	type AccountPackageDetail,
+	type AccountPackageListItem,
+	type AccountPackagesAppFilter,
+	type AccountPackagesLoaderData,
+	type AccountPackagesSort,
+} from '#app/loader-data.ts'
+import { type readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { readPagination } from '#app/query-params.ts'
+import {
+	getSavedPackageById,
+	searchSavedPackagesByUserId,
+} from '#worker/package-registry/repo.ts'
+import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+
+type AuthenticatedUser = NonNullable<
+	Awaited<ReturnType<typeof readAuthenticatedAppUser>>
+>
+
+const accountPackagesBasePath = '/account/packages'
+const defaultPageSize = 20
+const maxPageSize = 100
+
+export function readAccountPackagesSelectedPackageId(
+	requestUrl: string,
+	pathPackageId?: string,
+) {
+	if (pathPackageId?.trim()) return pathPackageId.trim()
+	const url = new URL(requestUrl, 'http://localhost')
+	const detailPrefix = `${accountPackagesBasePath}/`
+	if (url.pathname.startsWith(detailPrefix)) {
+		const packageId = decodeURIComponent(
+			url.pathname.slice(detailPrefix.length),
+		)
+		if (packageId) return packageId
+	}
+	const selected = url.searchParams.get('selected')?.trim()
+	return selected ? selected : null
+}
+
+function readAppFilter(url: URL): AccountPackagesAppFilter {
+	const raw = url.searchParams.get('app')?.trim()
+	return raw === 'with' || raw === 'without' ? raw : 'all'
+}
+
+function readSort(url: URL): AccountPackagesSort {
+	const raw = url.searchParams.get('sort')?.trim()
+	return raw === 'created' || raw === 'name' ? raw : 'updated'
+}
+
+function appFilterToHasApp(appFilter: AccountPackagesAppFilter) {
+	switch (appFilter) {
+		case 'all':
+			return null
+		case 'with':
+			return true
+		case 'without':
+			return false
+		default:
+			appFilter satisfies never
+			return null
+	}
+}
+
+function toListItem(record: SavedPackageRecord): AccountPackageListItem {
+	return {
+		id: record.id,
+		name: record.name,
+		kodyId: record.kodyId,
+		description: record.description,
+		tags: record.tags,
+		hasApp: record.hasApp,
+		sourceId: record.sourceId,
+		createdAt: record.createdAt,
+		updatedAt: record.updatedAt,
+	}
+}
+
+function toDetail(record: SavedPackageRecord): AccountPackageDetail {
+	return {
+		...toListItem(record),
+		searchText: record.searchText,
+	}
+}
+
+export async function loadAccountPackagesData(input: {
+	env: Env
+	request: Request
+	user: AuthenticatedUser
+	pathPackageId?: string
+}): Promise<AccountPackagesLoaderData> {
+	const userId = input.user.mcpUser.userId
+	const url = new URL(input.request.url, 'http://localhost')
+	const { page, pageSize, offset } = readPagination(url, {
+		defaultPageSize,
+		maxPageSize,
+	})
+	const query = url.searchParams.get('q')?.trim() ?? ''
+	const appFilter = readAppFilter(url)
+	const sort = readSort(url)
+	const selectedPackageId = readAccountPackagesSelectedPackageId(
+		input.request.url,
+		input.pathPackageId,
+	)
+
+	const [{ items, total }, selectedRecord] = await Promise.all([
+		searchSavedPackagesByUserId(input.env.APP_DB, {
+			userId,
+			query,
+			hasApp: appFilterToHasApp(appFilter),
+			sort,
+			limit: pageSize,
+			offset,
+		}),
+		selectedPackageId
+			? getSavedPackageById(input.env.APP_DB, {
+					userId,
+					packageId: selectedPackageId,
+				})
+			: Promise.resolve(null),
+	])
+
+	return {
+		ok: true,
+		email: input.user.email,
+		packages: items.map(toListItem),
+		selectedPackage: selectedRecord ? toDetail(selectedRecord) : null,
+		page,
+		pageSize,
+		total,
+		query,
+		appFilter,
+		sort,
+	}
+}

--- a/packages/worker/src/app/handlers/account-packages.node.test.ts
+++ b/packages/worker/src/app/handlers/account-packages.node.test.ts
@@ -1,0 +1,220 @@
+import { expect, test, vi } from 'vitest'
+
+const savedPackage = {
+	id: 'pkg-1',
+	userId: 'stable-user-1',
+	name: '@test/discord-gateway',
+	kodyId: 'discord-gateway',
+	description: 'Dispatch Discord gateway events.',
+	tags: ['discord', 'events'],
+	searchText: 'discord gateway websocket',
+	sourceId: 'source-1',
+	hasApp: true,
+	createdAt: new Date(0).toISOString(),
+	updatedAt: new Date(0).toISOString(),
+}
+
+const mockModule = vi.hoisted(() => ({
+	readAuthenticatedAppUser: vi.fn(async () => ({
+		sessionUserId: '42',
+		userId: 42,
+		username: 'test-user',
+		email: 'user@example.com',
+		displayName: 'user',
+		artifactOwnerIds: [],
+		mcpUser: {
+			userId: 'stable-user-1',
+			email: 'user@example.com',
+			username: 'test-user',
+			displayName: 'user',
+		},
+	})),
+	searchSavedPackagesByUserId: vi.fn(),
+	getSavedPackageById: vi.fn(),
+}))
+
+vi.mock('#app/authenticated-user.ts', () => ({
+	readAuthenticatedAppUser: (...args: Array<unknown>) =>
+		mockModule.readAuthenticatedAppUser(...args),
+}))
+
+vi.mock('#app/auth-session.ts', () => ({
+	readAuthSessionResult: async () => ({ session: null, setCookie: null }),
+}))
+
+vi.mock('#app/auth-redirect.ts', () => ({
+	redirectToLogin: () => new Response(null, { status: 302 }),
+	redirectToLoginWhenUnauthenticated: () => new Response(null, { status: 302 }),
+}))
+
+vi.mock('#app/ssr-render.tsx', () => ({
+	renderAppPage: async () => new Response('ok'),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	searchSavedPackagesByUserId: (...args: Array<unknown>) =>
+		mockModule.searchSavedPackagesByUserId(...args),
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+}))
+
+const { createAccountPackagesApiHandler } =
+	await import('./account-packages.ts')
+
+function createEnv() {
+	return {
+		APP_DB: {} as D1Database,
+		COOKIE_SECRET: 'secret',
+	} as Env
+}
+
+function resetMocks() {
+	mockModule.searchSavedPackagesByUserId.mockReset()
+	mockModule.getSavedPackageById.mockReset()
+	mockModule.searchSavedPackagesByUserId.mockResolvedValue({
+		items: [savedPackage],
+		total: 1,
+	})
+	mockModule.getSavedPackageById.mockResolvedValue(savedPackage)
+}
+
+test('packages API lists user packages with default filters and pagination', async () => {
+	resetMocks()
+	const env = createEnv()
+	const handler = createAccountPackagesApiHandler(env)
+
+	const response = await handler.handler({
+		request: new Request('https://example.com/account/packages.json'),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	expect(response.headers.get('Cache-Control')).toBe('no-store')
+	expect(mockModule.searchSavedPackagesByUserId).toHaveBeenCalledWith(
+		env.APP_DB,
+		{
+			userId: 'stable-user-1',
+			query: '',
+			hasApp: null,
+			sort: 'updated',
+			limit: 20,
+			offset: 0,
+		},
+	)
+	expect(mockModule.getSavedPackageById).not.toHaveBeenCalled()
+	await expect(response.json()).resolves.toEqual({
+		ok: true,
+		email: 'user@example.com',
+		packages: [
+			{
+				id: 'pkg-1',
+				name: '@test/discord-gateway',
+				kodyId: 'discord-gateway',
+				description: 'Dispatch Discord gateway events.',
+				tags: ['discord', 'events'],
+				hasApp: true,
+				sourceId: 'source-1',
+				createdAt: new Date(0).toISOString(),
+				updatedAt: new Date(0).toISOString(),
+			},
+		],
+		selectedPackage: null,
+		page: 1,
+		pageSize: 20,
+		total: 1,
+		query: '',
+		appFilter: 'all',
+		sort: 'updated',
+	})
+})
+
+test('packages API applies search, app filter, sort, pagination, and selection', async () => {
+	resetMocks()
+	const env = createEnv()
+	const handler = createAccountPackagesApiHandler(env)
+
+	const response = await handler.handler({
+		request: new Request(
+			'https://example.com/account/packages.json?q=discord&app=with&sort=name&page=3&pageSize=10&selected=pkg-1',
+		),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	expect(mockModule.searchSavedPackagesByUserId).toHaveBeenCalledWith(
+		env.APP_DB,
+		{
+			userId: 'stable-user-1',
+			query: 'discord',
+			hasApp: true,
+			sort: 'name',
+			limit: 10,
+			offset: 20,
+		},
+	)
+	expect(mockModule.getSavedPackageById).toHaveBeenCalledWith(env.APP_DB, {
+		userId: 'stable-user-1',
+		packageId: 'pkg-1',
+	})
+	await expect(response.json()).resolves.toMatchObject({
+		ok: true,
+		page: 3,
+		pageSize: 10,
+		query: 'discord',
+		appFilter: 'with',
+		sort: 'name',
+		selectedPackage: {
+			id: 'pkg-1',
+			searchText: 'discord gateway websocket',
+		},
+	})
+})
+
+test('packages API ignores invalid filter values and missing selections', async () => {
+	resetMocks()
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+	const env = createEnv()
+	const handler = createAccountPackagesApiHandler(env)
+
+	const response = await handler.handler({
+		request: new Request(
+			'https://example.com/account/packages.json?app=bogus&sort=bogus&selected=missing-package',
+		),
+		params: {},
+	} as never)
+
+	expect(response.status).toBe(200)
+	expect(mockModule.searchSavedPackagesByUserId).toHaveBeenCalledWith(
+		env.APP_DB,
+		expect.objectContaining({ hasApp: null, sort: 'updated' }),
+	)
+	await expect(response.json()).resolves.toMatchObject({
+		ok: true,
+		selectedPackage: null,
+		appFilter: 'all',
+		sort: 'updated',
+	})
+})
+
+test('packages API rejects non-GET methods and unauthenticated requests', async () => {
+	resetMocks()
+	const env = createEnv()
+	const handler = createAccountPackagesApiHandler(env)
+
+	const postResponse = await handler.handler({
+		request: new Request('https://example.com/account/packages.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ action: 'anything' }),
+		}),
+		params: {},
+	} as never)
+	expect(postResponse.status).toBe(405)
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValueOnce(null as never)
+	const unauthorizedResponse = await handler.handler({
+		request: new Request('https://example.com/account/packages.json'),
+		params: {},
+	} as never)
+	expect(unauthorizedResponse.status).toBe(401)
+})

--- a/packages/worker/src/app/handlers/account-packages.ts
+++ b/packages/worker/src/app/handlers/account-packages.ts
@@ -1,0 +1,67 @@
+import { jsonResponse } from '#worker/json-response.ts'
+import { type Action } from 'remix/router'
+import { loadAccountPackagesData } from '#app/account-packages-data.ts'
+import { readAuthSessionResult } from '#app/auth-session.ts'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import {
+	redirectToLogin,
+	redirectToLoginWhenUnauthenticated,
+} from '#app/auth-redirect.ts'
+import { renderAppPage } from '#app/ssr-render.tsx'
+import { type routes } from '#app/routes.ts'
+
+export function createAccountPackagesHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, params }) {
+			const { session } = await readAuthSessionResult(request)
+			if (!session) {
+				return redirectToLogin(request)
+			}
+
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return redirectToLoginWhenUnauthenticated(request, env)
+			}
+
+			const accountPackages = await loadAccountPackagesData({
+				env,
+				request,
+				user,
+				pathPackageId:
+					typeof params === 'object' &&
+					params !== null &&
+					'packageId' in params &&
+					typeof params.packageId === 'string'
+						? params.packageId
+						: undefined,
+			})
+			return renderAppPage({
+				request,
+				env,
+				title: 'Packages',
+				loaderData: { accountPackages },
+			})
+		},
+	} satisfies Action<
+		typeof routes.accountPackages | typeof routes.accountPackageDetail
+	>
+}
+
+export function createAccountPackagesApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+
+			if (request.method !== 'GET') {
+				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+			}
+
+			return jsonResponse(await loadAccountPackagesData({ env, request, user }))
+		},
+	} satisfies Action<typeof routes.accountPackagesApi>
+}

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -480,6 +480,39 @@ export type AccountPackageInvocationTokensLoaderData = {
 	selectedTokenId?: string
 }
 
+export type AccountPackageListItem = {
+	id: string
+	name: string
+	kodyId: string
+	description: string
+	tags: Array<string>
+	hasApp: boolean
+	sourceId: string
+	createdAt: string
+	updatedAt: string
+}
+
+export type AccountPackageDetail = AccountPackageListItem & {
+	searchText: string | null
+}
+
+export type AccountPackagesSort = 'updated' | 'created' | 'name'
+
+export type AccountPackagesAppFilter = 'all' | 'with' | 'without'
+
+export type AccountPackagesLoaderData = {
+	ok: true
+	email: string
+	packages: Array<AccountPackageListItem>
+	selectedPackage: AccountPackageDetail | null
+	page: number
+	pageSize: number
+	total: number
+	query: string
+	appFilter: AccountPackagesAppFilter
+	sort: AccountPackagesSort
+}
+
 export type AccountSecretListItem = {
 	id: string
 	name: string
@@ -563,6 +596,7 @@ export type AppLoaderData = {
 	accountMcpServers?: AccountMcpServersLoaderData
 	accountRemoteConnectors?: AccountRemoteConnectorsLoaderData
 	accountPackageInvocationTokens?: AccountPackageInvocationTokensLoaderData
+	accountPackages?: AccountPackagesLoaderData
 	accountSecrets?: AccountSecretsLoaderData
 	authProviders?: AuthProvidersLoaderData
 	emailVerification?: EmailVerificationLoaderData

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -43,6 +43,10 @@ import {
 	createAccountPackageInvocationTokensHandler,
 } from '#app/handlers/account-package-invocation-tokens.ts'
 import {
+	createAccountPackagesApiHandler,
+	createAccountPackagesHandler,
+} from '#app/handlers/account-packages.ts'
+import {
 	createAccountPasskeysApiHandler,
 	createAccountPasskeysHandler,
 } from '#app/handlers/account-passkeys.ts'
@@ -159,6 +163,9 @@ export function createAppRouter(env: Env) {
 				createAccountPackageInvocationTokensApiHandler(env),
 			accountPackageInvocationTokensApiPost:
 				createAccountPackageInvocationTokensApiHandler(env),
+			accountPackages: createAccountPackagesHandler(env),
+			accountPackageDetail: createAccountPackagesHandler(env),
+			accountPackagesApi: createAccountPackagesApiHandler(env),
 			accountConnectionsApi: createAccountConnectionsApiHandler(env),
 			accountConnectionsApiPost: createAccountConnectionsApiHandler(env),
 			accountPasskeys: createAccountPasskeysHandler(env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -17,6 +17,9 @@ export const routes = route({
 	accountPackageInvocationTokensApiPost: post(
 		'/account/package-invocation-tokens.json',
 	),
+	accountPackages: '/account/packages',
+	accountPackageDetail: '/account/packages/:packageId',
+	accountPackagesApi: '/account/packages.json',
 	accountRemoteConnectors: '/account/remote-connectors',
 	accountRemoteConnectorsApi: '/account/remote-connectors.json',
 	accountRemoteConnectorsApiPost: post('/account/remote-connectors.json'),

--- a/packages/worker/src/package-registry/repo-search.workers.test.ts
+++ b/packages/worker/src/package-registry/repo-search.workers.test.ts
@@ -1,0 +1,221 @@
+import { env } from 'cloudflare:workers'
+import { beforeAll, expect, test } from 'vitest'
+import { insertSavedPackage, searchSavedPackagesByUserId } from './repo.ts'
+
+const userId = 'search-user-1'
+const otherUserId = 'search-user-2'
+
+async function ensureSchema(db: D1Database) {
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS saved_packages (
+				id TEXT PRIMARY KEY NOT NULL,
+				user_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				kody_id TEXT NOT NULL,
+				description TEXT NOT NULL,
+				tags_json TEXT NOT NULL DEFAULT '[]',
+				search_text TEXT,
+				source_id TEXT NOT NULL,
+				has_app INTEGER NOT NULL DEFAULT 0 CHECK (has_app IN (0, 1)),
+				created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+				updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+			)`,
+		)
+		.run()
+	await db
+		.prepare(`DELETE FROM saved_packages WHERE user_id IN (?, ?)`)
+		.bind(userId, otherUserId)
+		.run()
+}
+
+function buildRow(input: {
+	id: string
+	userId?: string
+	name: string
+	kodyId: string
+	description?: string
+	tags?: Array<string>
+	searchText?: string | null
+	hasApp?: boolean
+	createdAt: string
+	updatedAt: string
+}) {
+	return {
+		id: input.id,
+		user_id: input.userId ?? userId,
+		name: input.name,
+		kody_id: input.kodyId,
+		description: input.description ?? '',
+		tags_json: JSON.stringify(input.tags ?? []),
+		search_text: input.searchText ?? null,
+		source_id: `source-${input.id}`,
+		has_app: input.hasApp ? 1 : 0,
+		created_at: input.createdAt,
+		updated_at: input.updatedAt,
+	}
+}
+
+beforeAll(async () => {
+	await ensureSchema(env.APP_DB)
+	await insertSavedPackage(
+		env.APP_DB,
+		buildRow({
+			id: 'search-pkg-a',
+			name: '@user/alpha-dashboard',
+			kodyId: 'alpha-dashboard',
+			description: 'Dashboard app for metrics',
+			tags: ['dashboard', 'metrics'],
+			hasApp: true,
+			createdAt: '2026-01-03T00:00:00.000Z',
+			updatedAt: '2026-01-05T00:00:00.000Z',
+		}),
+	)
+	await insertSavedPackage(
+		env.APP_DB,
+		buildRow({
+			id: 'search-pkg-b',
+			name: '@user/beta-notifier',
+			kodyId: 'beta-notifier',
+			description: 'Sends notification emails',
+			searchText: 'email digest 100% coverage',
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-06T00:00:00.000Z',
+		}),
+	)
+	await insertSavedPackage(
+		env.APP_DB,
+		buildRow({
+			id: 'search-pkg-c',
+			name: '@user/gamma-sync',
+			kodyId: 'gamma-sync',
+			description: 'Syncs calendars',
+			tags: ['calendar'],
+			createdAt: '2026-01-02T00:00:00.000Z',
+			updatedAt: '2026-01-04T00:00:00.000Z',
+		}),
+	)
+	await insertSavedPackage(
+		env.APP_DB,
+		buildRow({
+			id: 'search-pkg-other',
+			userId: otherUserId,
+			name: '@other/alpha-dashboard',
+			kodyId: 'alpha-dashboard',
+			description: 'Dashboard app for metrics',
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-07T00:00:00.000Z',
+		}),
+	)
+})
+
+test('lists only the requesting user packages sorted by most recently updated', async () => {
+	const { items, total } = await searchSavedPackagesByUserId(env.APP_DB, {
+		userId,
+		limit: 10,
+		offset: 0,
+	})
+	expect(total).toBe(3)
+	expect(items.map((item) => item.id)).toEqual([
+		'search-pkg-b',
+		'search-pkg-a',
+		'search-pkg-c',
+	])
+})
+
+test('supports created and name sorts', async () => {
+	const byCreated = await searchSavedPackagesByUserId(env.APP_DB, {
+		userId,
+		sort: 'created',
+		limit: 10,
+		offset: 0,
+	})
+	expect(byCreated.items.map((item) => item.id)).toEqual([
+		'search-pkg-a',
+		'search-pkg-c',
+		'search-pkg-b',
+	])
+
+	const byName = await searchSavedPackagesByUserId(env.APP_DB, {
+		userId,
+		sort: 'name',
+		limit: 10,
+		offset: 0,
+	})
+	expect(byName.items.map((item) => item.name)).toEqual([
+		'@user/alpha-dashboard',
+		'@user/beta-notifier',
+		'@user/gamma-sync',
+	])
+})
+
+test('matches queries case-insensitively across name, kody id, description, search text, and tags', async () => {
+	const byName = await searchSavedPackagesByUserId(env.APP_DB, {
+		userId,
+		query: 'ALPHA-DASH',
+		limit: 10,
+		offset: 0,
+	})
+	expect(byName.items.map((item) => item.id)).toEqual(['search-pkg-a'])
+
+	const bySearchText = await searchSavedPackagesByUserId(env.APP_DB, {
+		userId,
+		query: 'digest',
+		limit: 10,
+		offset: 0,
+	})
+	expect(bySearchText.items.map((item) => item.id)).toEqual(['search-pkg-b'])
+
+	const byTag = await searchSavedPackagesByUserId(env.APP_DB, {
+		userId,
+		query: 'calendar',
+		limit: 10,
+		offset: 0,
+	})
+	expect(byTag.items.map((item) => item.id)).toEqual(['search-pkg-c'])
+})
+
+test('escapes LIKE wildcards so queries match literally', async () => {
+	const literalPercent = await searchSavedPackagesByUserId(env.APP_DB, {
+		userId,
+		query: '100%',
+		limit: 10,
+		offset: 0,
+	})
+	expect(literalPercent.items.map((item) => item.id)).toEqual(['search-pkg-b'])
+
+	const wildcardOnly = await searchSavedPackagesByUserId(env.APP_DB, {
+		userId,
+		query: '%',
+		limit: 10,
+		offset: 0,
+	})
+	expect(wildcardOnly.total).toBe(1)
+})
+
+test('filters by app declaration and pages with a matching total', async () => {
+	const withApp = await searchSavedPackagesByUserId(env.APP_DB, {
+		userId,
+		hasApp: true,
+		limit: 10,
+		offset: 0,
+	})
+	expect(withApp.total).toBe(1)
+	expect(withApp.items.map((item) => item.id)).toEqual(['search-pkg-a'])
+
+	const withoutApp = await searchSavedPackagesByUserId(env.APP_DB, {
+		userId,
+		hasApp: false,
+		limit: 10,
+		offset: 0,
+	})
+	expect(withoutApp.total).toBe(2)
+
+	const pageTwo = await searchSavedPackagesByUserId(env.APP_DB, {
+		userId,
+		limit: 2,
+		offset: 2,
+	})
+	expect(pageTwo.total).toBe(3)
+	expect(pageTwo.items.map((item) => item.id)).toEqual(['search-pkg-c'])
+})

--- a/packages/worker/src/package-registry/repo.ts
+++ b/packages/worker/src/package-registry/repo.ts
@@ -202,6 +202,87 @@ export async function listSavedPackagesByUserId(
 	return (rows.results ?? []).map(mapSavedPackageRow)
 }
 
+export type SavedPackageSearchSort = 'updated' | 'created' | 'name'
+
+/** Escape LIKE wildcards so user queries match literally. */
+function escapeLikePattern(value: string) {
+	return value.replaceAll(/[\\%_]/g, (character) => `\\${character}`)
+}
+
+function savedPackageSearchOrderBy(sort: SavedPackageSearchSort) {
+	switch (sort) {
+		case 'updated':
+			return 'updated_at DESC, id ASC'
+		case 'created':
+			return 'created_at DESC, id ASC'
+		case 'name':
+			return 'name COLLATE NOCASE ASC, id ASC'
+		default:
+			sort satisfies never
+			throw new Error(`Unknown saved package sort: ${String(sort)}`)
+	}
+}
+
+/**
+ * Filtered, paged listing of one user's saved packages for browse UIs. The
+ * query and count share the same WHERE clause so the reported total always
+ * matches the filtered result set.
+ */
+export async function searchSavedPackagesByUserId(
+	db: D1Database,
+	input: {
+		userId: string
+		query?: string
+		hasApp?: boolean | null
+		sort?: SavedPackageSearchSort
+		limit: number
+		offset: number
+	},
+): Promise<{ items: Array<SavedPackageRecord>; total: number }> {
+	const conditions = ['user_id = ?']
+	const params: Array<unknown> = [input.userId]
+	const query = input.query?.trim() ?? ''
+	if (query) {
+		const pattern = `%${escapeLikePattern(query.toLowerCase())}%`
+		conditions.push(
+			`(LOWER(name) LIKE ? ESCAPE '\\'
+				OR LOWER(kody_id) LIKE ? ESCAPE '\\'
+				OR LOWER(description) LIKE ? ESCAPE '\\'
+				OR LOWER(COALESCE(search_text, '')) LIKE ? ESCAPE '\\'
+				OR LOWER(tags_json) LIKE ? ESCAPE '\\')`,
+		)
+		params.push(pattern, pattern, pattern, pattern, pattern)
+	}
+	if (input.hasApp != null) {
+		conditions.push('has_app = ?')
+		params.push(input.hasApp ? 1 : 0)
+	}
+	const whereClause = `WHERE ${conditions.join(' AND ')}`
+	const orderBy = savedPackageSearchOrderBy(input.sort ?? 'updated')
+
+	const [totalRow, rows] = await Promise.all([
+		db
+			.prepare(`SELECT COUNT(*) AS total FROM saved_packages ${whereClause}`)
+			.bind(...params)
+			.first<{ total: number }>(),
+		db
+			.prepare(
+				`SELECT id, user_id, name, kody_id, description, tags_json, search_text,
+					source_id, has_app, created_at, updated_at
+				FROM saved_packages
+				${whereClause}
+				ORDER BY ${orderBy}
+				LIMIT ? OFFSET ?`,
+			)
+			.bind(...params, input.limit, input.offset)
+			.all<Record<string, unknown>>(),
+	])
+	return {
+		items: (rows.results ?? []).map(mapSavedPackageRow),
+		total: totalRow?.total ?? 0,
+	}
+}
+
 // Keyset-paged listing across all users, used by maintenance reindex so a
 // single query never loads the whole table. Pass the last row id of the
 // previous page (or null for the first page).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds `/account/packages` — a read-only account section for browsing your saved packages and their metadata, following the same list/detail layout as `/account/secrets`, with server-backed search, filters, sort, and infinite scroll (same pattern as `/admin/users`).

<a href="https://cursor.com/agents/bc-48f211eb-941d-4657-8b9f-51485910db5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faccount_packages_list_detail_search_filter_infinite_scroll_demo.mp4"><img src="https://cursor.com/artifacts/c/art-940eb641-8b5a-41d8-b11d-613660ae585e" alt="account_packages_list_detail_search_filter_infinite_scroll_demo.mp4" /></a>

- **List**: sidebar list with text search (`q` matches name, kody id, description, search text, and tags), an app filter (all / with app / without app), and a sort select (recently updated — default, recently created, name). Server-paginated with an infinite-scroll sentinel plus a "Load more" fallback button and a "Showing X of Y" footer.
- **Detail**: path-based selection at `/account/packages/:packageId` showing name, description, tag chips, kody id, package id, app declaration, source id, created/updated timestamps, and search text.
- Selection-only navigations keep the loaded scroll window; filter changes re-anchor at page one.
- New `searchSavedPackagesByUserId` repo query (user-scoped, shared WHERE clause for page + total, LIKE-escaped search).
- New `Packages` entry in the account section nav.

![Package detail after infinite scroll](https://cursor.com/artifacts/c/art-85c6312c-89c9-45d0-a8ac-523b66500951)
![Search filtering to discord packages](https://cursor.com/artifacts/c/art-b08ecbd5-4b02-4fef-9eb9-d5ff0757dfac)

## How it works

- `routes.ts`: `accountPackages`, `accountPackageDetail`, `accountPackagesApi` (`/account/packages.json`, GET-only — this surface is read-only; packages are created/edited through MCP tools).
- `account-packages-data.ts` + `handlers/account-packages.ts` mirror the secrets/invocation-tokens handler pattern (session auth → load data → `renderAppPage` / JSON).
- `client/routes/account-packages.tsx` blends the secrets layout (path detail, URL-backed filters) with the admin-users infinite list (`createInfiniteList` + `infiniteScrollSentinel`).

## Testing

- `npm run validate` passes (format, lint, typecheck, unit tests, Playwright E2E, MCP E2E).
- `account-packages.node.test.ts`: API handler pagination/filter/sort/selection parsing, auth, and method guards.
- `repo-search.workers.test.ts`: real-D1 coverage of the search SQL — user scoping, sort orders, case-insensitive multi-column matching, LIKE wildcard escaping, app filter, and paging totals.
- Manual browser testing against the local dev server with 45 seeded packages: infinite scroll to 45/45, deep-scroll selection preserving the list window, search (`discord` → 3), app filter (→ 12), name sort, direct full-page detail loads, and the "Package not found." state (see video and screenshots above).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `18f67ce3` · **Head:** `f5f05073`

**Classification:** extends — adds a new account route to the browser app and a new user-scoped query to the saved-packages data layer. No new primitives, no schema changes.

### Primitives touched

| Primitive        | Group     | Impact                                                                                  |
| ---------------- | --------- | --------------------------------------------------------------------------------------- |
| `app-ui`         | surfaces  | extends — new `/account/packages(.json)` routes, handler, loader data, client route, nav |
| `saved-packages` | assistant | extends — new `searchSavedPackagesByUserId` filtered/paged query in the registry repo    |
| `d1-app-db`      | storage   | composes — read-only queries against the existing `saved_packages` table                 |

### System map

The packages account page flows from the browser app through the saved-packages registry repo into D1.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::touched
	appUi -->|"GET /account/packages.json (q, app, sort, page, selected)"| savedPackages
	savedPackages -->|"searchSavedPackagesByUserId + getSavedPackageById"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Per-user isolation: every query in `searchSavedPackagesByUserId` and the detail lookup is scoped by `user_id = ?` from the authenticated session; the count and page share one WHERE clause.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48f211eb-941d-4657-8b9f-51485910db5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48f211eb-941d-4657-8b9f-51485910db5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Packages section to account navigation.
  * Added an account Packages page with search, app filters, sorting, pagination, and infinite scrolling.
  * Added package detail views showing metadata, tags, timestamps, and search information.
  * Added authenticated package listing and detail routes.

* **Bug Fixes**
  * Added handling for unauthorized access, invalid requests, loading states, and data-fetching errors.

* **Tests**
  * Added coverage for package searching, filtering, sorting, pagination, authentication, and request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->