### PR TITLE
Fix repo-search workers test for saved_packages hidden column

### DIFF
--- a/packages/worker/src/package-registry/repo-search.workers.test.ts
+++ b/packages/worker/src/package-registry/repo-search.workers.test.ts
@@ -18,6 +18,7 @@ async function ensureSchema(db: D1Database) {
 				search_text TEXT,
 				source_id TEXT NOT NULL,
 				has_app INTEGER NOT NULL DEFAULT 0 CHECK (has_app IN (0, 1)),
+				hidden INTEGER NOT NULL DEFAULT 0 CHECK (hidden IN (0, 1)),
 				created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
 				updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
 			)`,
@@ -50,7 +51,8 @@ function buildRow(input: {
 		tags_json: JSON.stringify(input.tags ?? []),
 		search_text: input.searchText ?? null,
 		source_id: `source-${input.id}`,
-		has_app: input.hasApp ? 1 : 0,
+		has_app: input.hasApp ? (1 as const) : (0 as const),
+		hidden: 0 as const,
 		created_at: input.createdAt,
 		updated_at: input.updatedAt,
 	}

--- a/packages/worker/src/package-registry/repo.ts
+++ b/packages/worker/src/package-registry/repo.ts
@@ -275,7 +275,7 @@ export async function searchSavedPackagesByUserId(
 		db
 			.prepare(
 				`SELECT id, user_id, name, kody_id, description, tags_json, search_text,
-					source_id, has_app, created_at, updated_at
+					source_id, has_app, hidden, created_at, updated_at
 				FROM saved_packages
 				${whereClause}
 				ORDER BY ${orderBy}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Fixes the `main` CI failure from the semantic merge conflict between #745 and #746: `repo-search.workers.test.ts` (added in #745) created its own `saved_packages` test schema without the `hidden` column that #746's migration added, so `insertSavedPackage` failed with `table saved_packages has no column named hidden` once both landed.

- Adds the `hidden` column to the test schema and seed rows (mirroring `community-flow-test-schema.ts`).
- Includes `hidden` in the `searchSavedPackagesByUserId` SELECT so returned records carry the real visibility flag instead of always mapping to `false`.

## Testing

- `npm run test` (node + workers unit suites) passes on latest `main` plus this fix, including the previously failing `repo-search.workers.test.ts`.
- `npm run typecheck`, `npm run lint`, `npm run format:check` pass.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `d857526a` · **Head:** `c83ff92b`

**Classification:** composes — test-schema fix plus one added column in an existing read query; no contracts change.

### Primitives touched

| Primitive        | Group     | Impact                                                                       |
| ---------------- | --------- | ----------------------------------------------------------------------------- |
| `saved-packages` | assistant | composes — `searchSavedPackagesByUserId` SELECT now includes `hidden`; workers test schema matches migration 0058 |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48f211eb-941d-4657-8b9f-51485910db5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48f211eb-941d-4657-8b9f-51485910db5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

