### PR TITLE
Clarify Kody's durable package lifecycle

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -9,6 +9,7 @@ style, tests, MCP kody, and runtime architecture.
 - [Optional Cloudflare offerings](./cloudflare-offerings.md)
 - [Setup](./setup.md), [code style](./code-style.md),
   [testing](./testing-principles.md)
+- [Package discovery routing evaluation](./package-discovery-evaluation.md)
 - [Cursor Cloud Agent notes](./cloud-agents.md)
 - [Remix skills](./remix.md), [frames](./frames.md)
 - [Packages and manifests](./packages-and-manifests.md)

--- a/docs/contributing/package-discovery-evaluation.md
+++ b/docs/contributing/package-discovery-evaluation.md
@@ -1,0 +1,71 @@
+# Package discovery routing evaluation
+
+The repository-owned evaluation set at
+[`tools/evals/package-discovery-routing.json`](../../tools/evals/package-discovery-routing.json)
+checks whether an agent chooses the right lifecycle route after capability and
+package discovery:
+
+- reuse an existing capability or package
+- prototype once with `execute`
+- author a durable package
+
+The cases cover recurring email drafting, a reusable writing style, a scheduled
+workflow, cross-host reuse, and promotion of a successful script. Discovery
+evidence is part of each case so every host and model receives the same
+inventory state.
+
+## Run the evaluation
+
+Connect Kody to the host as described in
+[Connect your agent](../use/connect-your-agent.md), then use the same procedure
+in Warp, Cursor, Claude, and ChatGPT:
+
+1. Record the host, model name/version, date, and evaluation `schemaVersion`.
+2. Start a fresh conversation. Do not expose the case's `expected` object to the
+   model.
+3. Paste the top-level `instruction`, `routes`, and `reasonCodes`.
+4. Paste `Discovery evidence:`, followed by the case's `discovery.summary`.
+5. Paste `User prompt:`, followed by the case's `prompt`.
+6. Save the returned JSON object and repeat in a fresh conversation for every
+   case.
+
+Use a fresh conversation for each case so earlier cases do not teach the model
+the route labels. Use identical case content and model settings when comparing
+hosts. The instruction prevents tool calls and mutations; this evaluation
+measures routing, not live package inventory.
+
+Agents can run the same protocol by reading the JSON, sending only
+`instruction`, `routes`, `reasonCodes`, `discovery.summary`, and `prompt` to an
+isolated host session, and recording the structured response. The set does not
+require a repository checkout on the machine running the host.
+
+## Score results
+
+A case passes when:
+
+1. the response is one JSON object;
+2. `route` exactly equals `expected.route`;
+3. `reasonCodes` contains every value in `expected.requiredReasonCodes`; and
+4. every returned reason code occurs in the top-level `reasonCodes` registry.
+
+Additional registered reason codes do not fail a case. Report both per-case
+results and the aggregate passed/total count for each host/model pair. This
+scores stable routing categories rather than matching explanatory prose.
+
+The offline schema and coverage check runs with:
+
+```sh
+npx vitest run --project node-unit \
+  tools/evals/package-discovery-routing.node.test.ts
+```
+
+It is also included in `npm run test` and therefore in `npm run validate`.
+
+## Scope and limitations
+
+This set isolates the post-discovery lifecycle decision. It does not measure
+search ranking, MCP transport behavior, live inventory differences, quality of
+generated package code, or whether a host honors a later mutation request. Those
+concerns require separate integration evaluations. Add a case when it introduces
+a distinct routing boundary; avoid adding paraphrases that exercise the same
+boundary.

--- a/docs/contributing/package-discovery-evaluation.md
+++ b/docs/contributing/package-discovery-evaluation.md
@@ -1,71 +1,171 @@
-# Package discovery routing evaluation
+# Package discovery lifecycle evaluation
 
-The repository-owned evaluation set at
 [`tools/evals/package-discovery-routing.json`](../../tools/evals/package-discovery-routing.json)
-checks whether an agent chooses the right lifecycle route after capability and
-package discovery:
+is a host/model evaluation for lifecycle behavior over a real Kody MCP
+connection. Evaluated sessions receive only a case's natural-language `prompt`.
+The inventory preconditions and `expected` actions remain with the evaluator.
 
-- reuse an existing capability or package
-- prototype once with `execute`
-- author a durable package
+The set has two cases for each scored route: reuse a discovered result, perform
+one ephemeral execution, create a direct ad hoc job, and author durable reusable
+source. It includes both one-time and simple recurring ad hoc schedules, plus a
+scheduled workflow whose reusable interface and cross-host use justify durable
+authoring.
 
-The cases cover recurring email drafting, a reusable writing style, a scheduled
-workflow, cross-host reuse, and promotion of a successful script. Discovery
-evidence is part of each case so every host and model receives the same
-inventory state.
+## Account setup
 
-## Run the evaluation
+Use the same disposable Kody account when comparing Warp, Cursor, Claude, and
+ChatGPT. Do not use a production account: schedule and authoring cases mutate
+state.
 
-Connect Kody to the host as described in
-[Connect your agent](../use/connect-your-agent.md), then use the same procedure
-in Warp, Cursor, Claude, and ChatGPT:
+In a separate operator session, create the only required controlled fixture by
+calling `value_set` through `execute` with:
 
-1. Record the host, model name/version, date, and evaluation `schemaVersion`.
-2. Start a fresh conversation. Do not expose the case's `expected` object to the
-   model.
-3. Paste the top-level `instruction`, `routes`, and `reasonCodes`.
-4. Paste `Discovery evidence:`, followed by the case's `discovery.summary`.
-5. Paste `User prompt:`, followed by the case's `prompt`.
-6. Save the returned JSON object and repeat in a fresh conversation for every
-   case.
+```json
+{
+	"name": "project-updates",
+	"value": "Checkout retry shipped; onboarding copy is in review; billing export is blocked on sample data.",
+	"description": "Deterministic lifecycle evaluation fixture.",
+	"scope": "user"
+}
+```
 
-Use a fresh conversation for each case so earlier cases do not teach the model
-the route labels. Use identical case content and model settings when comparing
-hosts. The instruction prevents tool calls and mutations; this evaluation
-measures routing, not live package inventory.
+Before each controlled-inventory case, use a separate operator session to:
 
-Agents can run the same protocol by reading the JSON, sending only
-`instruction`, `routes`, `reasonCodes`, `discovery.summary`, and `prompt` to an
-isolated host session, and recording the structured response. The set does not
-require a repository checkout on the machine running the host.
+1. search for the task described by the case;
+2. confirm there is no exact reusable result that already implements the whole
+   task; and
+3. remove jobs or saved source created by a prior run, or use a clean account.
 
-## Score results
+Apart from `project-updates`, the one-off listing cases require no seeded data.
+The `author-validated-cleanup-automation` prompt contains its validated source.
+Run authoring cases last because they intentionally add searchable inventory.
 
-A case passes when:
+The two `inventory-dependent` reuse cases are a separate cohort. Preflight them
+against each host's Kody account using the case's `eligibility` rule. Run a case
+only when exactly one eligible saved result exists; otherwise record
+`skipped-no-eligible-match`. Do not count a skip as a pass or compare its reuse
+rate across hosts. For deterministic reuse comparisons, provision all hosts with
+the same disposable Kody account and the same eligible saved result before
+running the case.
 
-1. the response is one JSON object;
-2. `route` exactly equals `expected.route`;
-3. `reasonCodes` contains every value in `expected.requiredReasonCodes`; and
-4. every returned reason code occurs in the top-level `reasonCodes` registry.
+## Run in each host
 
-Additional registered reason codes do not fail a case. Report both per-case
-results and the aggregate passed/total count for each host/model pair. This
-scores stable routing categories rather than matching explanatory prose.
+Connect Kody using [Connect your agent](../use/connect-your-agent.md). In Warp,
+Cursor, Claude, and ChatGPT:
 
-The offline schema and coverage check runs with:
+1. Start a fresh session with Kody enabled and record the host and exact model.
+2. Send only the case's `prompt`. Do not paste the case id, inventory metadata,
+   expected route, action names, or this page into the evaluated session.
+3. Allow the agent to use Kody and complete safe mutations requested by the
+   prompt.
+4. Export or copy the Kody `search` and `execute` call inputs and outputs before
+   starting the next case.
+5. Clean up created jobs or saved source from an operator session after its ids
+   have been recorded. Delete the `project-updates` fixture after the suite.
+
+This protocol evaluates MCP instructions and tool behavior. An answer with no
+Kody trace fails because every non-skipped case requires discovery followed by
+the appropriate action.
+
+## Normalize the trace
+
+Create one transcript event for every lifecycle action visible in a Kody tool
+call. Preserve the actual tool input and output in `input` and `output`; redact
+secrets, but do not replace tool names, entity ids, capability names, or source
+metadata.
+
+- A Kody `search` call is `search`. Record `exact-reusable` only when the result
+  implements the whole task; supporting primitives are `no-exact-reusable`.
+- Executing the exact discovered result is `invoke-existing`, with the same
+  entity id recorded as `targetEntityId`.
+- Ephemeral task code that does not persist source or a schedule is
+  `execute-one-off`.
+- An `execute` call to `job_schedule` or `job_schedule_once` is
+  `schedule-ad-hoc-job`.
+- Reading `coding_guide_get` or existing source before authoring is
+  `inspect-authoring-guidance`.
+- Creating or publishing reusable saved source is `author-package`.
+- Any other Kody `execute` call is `other-execute`, which no case allows.
+
+If one `execute` call performs multiple lifecycle actions, emit one event per
+action with the same `callId`, `input`, and `output`. This lets the scorer
+reject an otherwise hidden extra schedule, execution, or authoring action.
+Include failed tool attempts; the scorer fails traces containing them.
+
+A transcript has this machine-readable shape:
+
+```json
+{
+	"schemaVersion": 1,
+	"evalName": "package-discovery-routing",
+	"host": "cursor",
+	"model": "model-name-and-version",
+	"runAt": "2026-07-14T21:00:00.000Z",
+	"results": [
+		{
+			"caseId": "one-off-saved-automation-count",
+			"outcome": "completed",
+			"events": [
+				{
+					"callId": "host-call-1",
+					"action": "search",
+					"toolName": "search",
+					"status": "succeeded",
+					"input": {},
+					"output": {},
+					"match": { "kind": "no-exact-reusable" }
+				},
+				{
+					"callId": "host-call-2",
+					"action": "execute-one-off",
+					"toolName": "execute",
+					"status": "succeeded",
+					"input": {
+						"code": "Actual captured execute module"
+					},
+					"output": {}
+				}
+			]
+		}
+	]
+}
+```
+
+Inventory-dependent cases without an eligible result use:
+
+```json
+{
+	"caseId": "reuse-recurring-email-drafter",
+	"outcome": "skipped-no-eligible-match",
+	"note": "Preflight found no eligible saved result."
+}
+```
+
+## Score
+
+Run the executable scorer:
+
+```sh
+node tools/evals/package-discovery-routing.ts score path/to/transcript.json
+```
+
+It validates the transcript, requires search first, verifies reuse targets match
+discovery, checks `execute` source for the recorded lifecycle operations,
+rejects failed, wrong, hidden, or extraneous actions, and reports
+passed/failed/skipped totals per route. A controlled-inventory case cannot be
+skipped. The process exits nonzero for invalid schemas or failed cases.
+
+CI runs only the offline schema and scorer fixtures:
 
 ```sh
 npx vitest run --project node-unit \
   tools/evals/package-discovery-routing.node.test.ts
 ```
 
-It is also included in `npm run test` and therefore in `npm run validate`.
+CI does **not** connect to Warp, Cursor, Claude, ChatGPT, a model, or a live
+Kody account, and therefore does not run or claim to pass the host/model
+evaluation.
 
-## Scope and limitations
-
-This set isolates the post-discovery lifecycle decision. It does not measure
-search ranking, MCP transport behavior, live inventory differences, quality of
-generated package code, or whether a host honors a later mutation request. Those
-concerns require separate integration evaluations. Add a case when it introduces
-a distinct routing boundary; avoid adding paraphrases that exercise the same
-boundary.
+The scorer consumes this normalized format, not arbitrary host export formats.
+The evaluator remains responsible for faithfully copying every raw Kody call and
+splitting multi-action `execute` calls into events.

--- a/docs/contributing/package-discovery-evaluation.md
+++ b/docs/contributing/package-discovery-evaluation.md
@@ -84,7 +84,12 @@ metadata.
   `schedule-ad-hoc-job`.
 - Reading `coding_guide_get` or existing source before authoring is
   `inspect-authoring-guidance`.
-- Creating or publishing reusable saved source is `author-package`.
+- Initializing, editing, creating, or publishing reusable saved source is
+  `author-package`. The scorer derives the phase from actual `execute` code:
+  - `package_get_git_remote` is initialization;
+  - `repo_run_commands` is an intermediate edit;
+  - `package_save`, `package_publish_external_push`, and `repo_publish_session`
+    are terminal create/publish operations.
 - Any other Kody `execute` call is `other-execute`, which no case allows.
 
 If one `execute` call performs multiple lifecycle actions, emit one event per
@@ -92,10 +97,15 @@ action with the same `callId`, `input`, and `output`. This lets the scorer
 reject an otherwise hidden extra schedule, execution, or authoring action.
 Include failed tool attempts; the scorer fails traces containing them.
 
-Every case permits exactly one `search` action and exactly one terminal action.
-Any other allowed action, such as `inspect-authoring-guidance`, may occur at
-most once. Repeated successful invocations, executions, schedules, or authoring
-mutations fail; success status does not make a duplicate safe.
+Every case requires discovery first. Up to three read-only `search` or
+`inspect-authoring-guidance` actions are allowed so an agent can query, inspect
+an entity, and load authoring guidance. Reuse, one-off execution, and ad hoc job
+routes require exactly one terminal action.
+
+Authoring may contain up to five initialization, edit, and publication events,
+but the final event must contain the trace's only terminal create/publish
+operation. Repeated successful invocations, one-off executions, schedules, or
+terminal publications fail; success status does not make a duplicate safe.
 
 A transcript has this machine-readable shape:
 
@@ -156,10 +166,11 @@ node tools/evals/package-discovery-routing.ts score path/to/transcript.json
 
 It validates the transcript, requires search first, verifies reuse targets match
 discovery, checks `execute` source for the recorded lifecycle operations,
-enforces the evaluation's action cardinality, rejects failed, duplicate, wrong,
-hidden, or extraneous actions, and reports passed/failed/skipped totals per
-route. A controlled-inventory case cannot be skipped. The process exits nonzero
-for invalid schemas or failed cases.
+enforces route-aware action cardinality, rejects failed, duplicate, wrong,
+hidden, or extraneous mutations, and reports passed/failed/skipped totals per
+route. Read-only discovery may repeat within the bounded allowance. A
+controlled-inventory case cannot be skipped. The process exits nonzero for
+invalid schemas or failed cases.
 
 CI runs only the offline schema and scorer fixtures:
 

--- a/docs/contributing/package-discovery-evaluation.md
+++ b/docs/contributing/package-discovery-evaluation.md
@@ -88,8 +88,9 @@ metadata.
   `author-package`. The scorer derives the phase from actual `execute` code:
   - `package_get_git_remote` and `repo_open_session` initialize an authoring
     lane;
-  - `repo_write_file`, `repo_run_commands`, and `repo_run_checks` are edit/check
-    steps;
+  - `repo_write_file` and `repo_run_commands` are mutation-counted edit steps;
+  - `repo_run_checks` is a check-only step and does not satisfy the required
+    authoring mutation;
   - `package_save`, `package_publish_external_push`, and `repo_publish_session`
     create or publish source.
 - Any other Kody `execute` call is `other-execute`, which no case allows.

--- a/docs/contributing/package-discovery-evaluation.md
+++ b/docs/contributing/package-discovery-evaluation.md
@@ -88,7 +88,8 @@ metadata.
   `author-package`. The scorer derives the phase from actual `execute` code:
   - `package_get_git_remote` and `repo_open_session` initialize an authoring
     lane;
-  - `repo_write_file` and `repo_run_commands` are edit/check steps;
+  - `repo_write_file`, `repo_run_commands`, and `repo_run_checks` are edit/check
+    steps;
   - `package_save`, `package_publish_external_push`, and `repo_publish_session`
     create or publish source.
 - Any other Kody `execute` call is `other-execute`, which no case allows.

--- a/docs/contributing/package-discovery-evaluation.md
+++ b/docs/contributing/package-discovery-evaluation.md
@@ -86,10 +86,11 @@ metadata.
   `inspect-authoring-guidance`.
 - Initializing, editing, creating, or publishing reusable saved source is
   `author-package`. The scorer derives the phase from actual `execute` code:
-  - `package_get_git_remote` is initialization;
-  - `repo_run_commands` is an intermediate edit;
+  - `package_get_git_remote` and `repo_open_session` initialize an authoring
+    lane;
+  - `repo_write_file` and `repo_run_commands` are edit/check steps;
   - `package_save`, `package_publish_external_push`, and `repo_publish_session`
-    are terminal create/publish operations.
+    create or publish source.
 - Any other Kody `execute` call is `other-execute`, which no case allows.
 
 If one `execute` call performs multiple lifecycle actions, emit one event per
@@ -102,10 +103,15 @@ Every case requires discovery first. Up to three read-only `search` or
 an entity, and load authoring guidance. Reuse, one-off execution, and ad hoc job
 routes require exactly one terminal action.
 
-Authoring may contain up to five initialization, edit, and publication events,
-but the final event must contain the trace's only terminal create/publish
-operation. Repeated successful invocations, one-off executions, schedules, or
-terminal publications fail; success status does not make a duplicate safe.
+Authoring may contain up to eight initialization, edit, check, create, and
+publication events. It must include at least one mutation and end with an
+`author-package` event whose `execute` code contains a recognized authoring
+operation. Multiple publications are valid because safe rollout may publish a
+disabled schedule, test it, and publish it enabled. Publication safety and
+rollout correctness are outside this routing scorer's scope.
+
+Repeated successful reuse invocations, one-off executions, or ad hoc schedules
+still fail because those duplicate the terminal work selected by the route.
 
 A transcript has this machine-readable shape:
 
@@ -167,10 +173,10 @@ node tools/evals/package-discovery-routing.ts score path/to/transcript.json
 It validates the transcript, requires search first, verifies reuse targets match
 discovery, checks `execute` source for the recorded lifecycle operations,
 enforces route-aware action cardinality, rejects failed, duplicate, wrong,
-hidden, or extraneous mutations, and reports passed/failed/skipped totals per
-route. Read-only discovery may repeat within the bounded allowance. A
-controlled-inventory case cannot be skipped. The process exits nonzero for
-invalid schemas or failed cases.
+hidden, or extraneous non-authoring terminal work, and reports
+passed/failed/skipped totals per route. Read-only discovery and bounded
+multi-step authoring may repeat. A controlled-inventory case cannot be skipped.
+The process exits nonzero for invalid schemas or failed cases.
 
 CI runs only the offline schema and scorer fixtures:
 

--- a/docs/contributing/package-discovery-evaluation.md
+++ b/docs/contributing/package-discovery-evaluation.md
@@ -92,6 +92,11 @@ action with the same `callId`, `input`, and `output`. This lets the scorer
 reject an otherwise hidden extra schedule, execution, or authoring action.
 Include failed tool attempts; the scorer fails traces containing them.
 
+Every case permits exactly one `search` action and exactly one terminal action.
+Any other allowed action, such as `inspect-authoring-guidance`, may occur at
+most once. Repeated successful invocations, executions, schedules, or authoring
+mutations fail; success status does not make a duplicate safe.
+
 A transcript has this machine-readable shape:
 
 ```json
@@ -151,9 +156,10 @@ node tools/evals/package-discovery-routing.ts score path/to/transcript.json
 
 It validates the transcript, requires search first, verifies reuse targets match
 discovery, checks `execute` source for the recorded lifecycle operations,
-rejects failed, wrong, hidden, or extraneous actions, and reports
-passed/failed/skipped totals per route. A controlled-inventory case cannot be
-skipped. The process exits nonzero for invalid schemas or failed cases.
+enforces the evaluation's action cardinality, rejects failed, duplicate, wrong,
+hidden, or extraneous actions, and reports passed/failed/skipped totals per
+route. A controlled-inventory case cannot be skipped. The process exits nonzero
+for invalid schemas or failed cases.
 
 CI runs only the offline schema and scorer fixtures:
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -8,7 +8,7 @@ available `guide` ids).
 | File                                                                                     | Topic                                                                                                                       |
 | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | [package-authoring.md](./package-authoring.md)                                           | General package-authoring guidance, including the README Intent section                                                     |
-| [package-lifecycle.md](./package-lifecycle.md)                                           | Choose reuse, one-off execute, or a durable package; test package exports before enabling package-owned schedules           |
+| [package-lifecycle.md](./package-lifecycle.md)                                           | Choose reuse, one-off execute, or a durable package; test no-input job wrappers before enabling package-owned schedules     |
 | [integration-bootstrap.md](./integration-bootstrap.md)                                   | **Start here** for third-party integrations that must work before saving a dependent package or package app                 |
 | [openapi-integrations.md](./openapi-integrations.md)                                     | OpenAPI discover → summarize → scaffold or curated `openapi:<name>` binding                                                 |
 | [secret-backed-integration.md](./secret-backed-integration.md)                           | Default recipe for non-OAuth integrations that use one or more saved secrets                                                |

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -8,6 +8,7 @@ available `guide` ids).
 | File                                                                                     | Topic                                                                                                                       |
 | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | [package-authoring.md](./package-authoring.md)                                           | General package-authoring guidance, including the README Intent section                                                     |
+| [package-lifecycle.md](./package-lifecycle.md)                                           | Choose reuse, one-off execute, or a durable package; test package exports before enabling package-owned schedules           |
 | [integration-bootstrap.md](./integration-bootstrap.md)                                   | **Start here** for third-party integrations that must work before saving a dependent package or package app                 |
 | [openapi-integrations.md](./openapi-integrations.md)                                     | OpenAPI discover → summarize → scaffold or curated `openapi:<name>` binding                                                 |
 | [secret-backed-integration.md](./secret-backed-integration.md)                           | Default recipe for non-OAuth integrations that use one or more saved secrets                                                |

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -8,7 +8,7 @@ available `guide` ids).
 | File                                                                                     | Topic                                                                                                                       |
 | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | [package-authoring.md](./package-authoring.md)                                           | General package-authoring guidance, including the README Intent section                                                     |
-| [package-lifecycle.md](./package-lifecycle.md)                                           | Choose reuse, one-off execute, or a durable package; test no-input job wrappers before enabling package-owned schedules     |
+| [package-lifecycle.md](./package-lifecycle.md)                                           | Choose reuse, one-off execute, direct job schedules, or a durable package; test package-owned job wrappers safely           |
 | [integration-bootstrap.md](./integration-bootstrap.md)                                   | **Start here** for third-party integrations that must work before saving a dependent package or package app                 |
 | [openapi-integrations.md](./openapi-integrations.md)                                     | OpenAPI discover → summarize → scaffold or curated `openapi:<name>` binding                                                 |
 | [secret-backed-integration.md](./secret-backed-integration.md)                           | Default recipe for non-OAuth integrations that use one or more saved secrets                                                |

--- a/docs/guides/package-lifecycle.md
+++ b/docs/guides/package-lifecycle.md
@@ -86,21 +86,31 @@ If the work needs binary assets, broad refactors, or a substantial local
 build/test loop, explain that it fits a coding-capable agent and confirm before
 continuing in the tool-only lane.
 
-## Test an export before enabling its schedule
+## Test the scheduled wrapper before enabling its schedule
 
-Scheduled behavior should not be its first real execution. Make the package job
-entry callable through `package.json.exports`, and initially declare the
+Scheduled behavior should not be its first real execution. Package job manifests
+do not supply params to their entrypoints, so structure the package with:
+
+- a shared implementation that accepts explicit input
+- an optional callable export that passes representative input to that
+  implementation
+- a no-argument scheduled wrapper that loads its own current configuration and
+  calls the same implementation
+
+Make the no-argument scheduled wrapper callable through `package.json.exports`,
+point the package job entry at that wrapper, and initially declare the
 package-owned job with `"enabled": false`.
 
 After package checks and publishing succeed:
 
-1. Inspect the published package and export contract.
-2. Invoke the export from authenticated `execute` with
-   `packages.invokeChecked(...)`.
-3. Pass representative input: realistic field shapes, boundary values, and the
-   same configuration references the schedule will use. Never put plaintext
-   secrets in params.
-4. Validate the structured result and the intended durable or external effects.
+1. Inspect the published package and export contracts.
+2. Invoke the scheduled wrapper from authenticated `execute` with
+   `packages.invokeChecked(...)` and omit `params`. This verifies the same
+   no-input contract the scheduler uses.
+3. Optionally invoke the underlying callable export with representative input:
+   realistic field shapes, boundary values, and the same configuration
+   references the wrapper will load. Never put plaintext secrets in params.
+4. Validate the structured results and the intended durable or external effects.
    Exercise an expected failure path when the operation is risky.
 5. Only then change the job to `"enabled": true`, publish again, and verify the
    package/job detail reflects the enabled schedule.
@@ -113,11 +123,7 @@ import { packages } from 'kody:runtime'
 export default async function main() {
 	return await packages.invokeChecked({
 		kodyId: 'daily-report',
-		exportName: './run-report',
-		params: {
-			reportDate: '2026-07-14',
-			dryRun: true,
-		},
+		exportName: './scheduled-report',
 	})
 }
 ```
@@ -126,12 +132,17 @@ For exports that send messages, write remote records, charge accounts, or make
 other external mutations, prefer a package-specific `dryRun` input. Implement it
 so the export performs validation and returns a preview while skipping the
 mutation. `dryRun` is a package contract, not an automatic Kody runtime flag;
-test both the dry-run path and one deliberately confirmed live invocation before
-enabling recurring execution.
+test the dry-run path first.
+
+Immediately before any live external mutation, obtain explicit user confirmation
+that identifies the target and scope of the mutation. Do not infer confirmation
+from an earlier request, a successful dry run, or the agent's own assessment.
+After confirmation, perform only the confirmed call, then report the result.
+Require fresh confirmation if the target or scope changes.
 
 Keep the schedule disabled when representative testing is inconclusive,
 credentials or host approval are missing, the result is unexpected, or the live
-mutation has not been confirmed.
+mutation has not been explicitly confirmed by the user.
 
 ## Evolve the durable behavior
 

--- a/docs/guides/package-lifecycle.md
+++ b/docs/guides/package-lifecycle.md
@@ -29,14 +29,20 @@ required confirmation.
 
 Keep the module focused and return structured evidence. Do not treat the
 ephemeral module as the durable source for behavior that must be maintained,
-reused, or scheduled.
+reused, or evolved.
 
 ### Create a repo-backed package
 
-Create or extend a saved package when behavior is reusable, scheduled, or
-expected to evolve. The repo rooted at `package.json` is the durable source of
-truth. Package exports form the callable surface, while jobs, subscriptions,
-services, retrievers, and apps remain package-owned behavior.
+Create or extend a saved package when behavior is reusable, expected to evolve,
+or needs a named package-owned schedule that evolves with its implementation.
+The repo rooted at `package.json` is the durable source of truth. Package
+exports form the callable surface, while jobs, subscriptions, services,
+retrievers, and apps remain package-owned behavior.
+
+Scheduling alone does not require a package. Use `job_schedule` directly for a
+genuinely ad hoc or one-off job, or for a simple self-contained schedule that is
+not tied to reusable package behavior. `job_schedule_once` is the one-off
+convenience form.
 
 Use `guide: "package_authoring"` for package shape, README `## Intent`, and
 visibility guidance.
@@ -46,15 +52,17 @@ visibility guidance.
 Move the behavior into a package when one or more of these become true:
 
 - the user will run it again or other package code should reuse it
-- it needs a schedule, subscription, service, app, workflow entrypoint, or
-  package-owned storage
+- it needs a named package-owned schedule that should evolve with the
+  implementation, or another durable surface such as a subscription, service,
+  app, workflow entrypoint, or package-owned storage
 - the logic needs tests, multiple files, dependencies, review, or version
   history
 - inputs, output, error handling, or integration behavior will evolve
 - a one-off script has already been copied, repaired, or rerun
 
 Do not create a package merely to wrap one clear call to an existing capability
-or package export.
+or package export, or merely because a simple self-contained job needs a
+schedule.
 
 ## Choose an authoring lane
 

--- a/docs/guides/package-lifecycle.md
+++ b/docs/guides/package-lifecycle.md
@@ -1,0 +1,142 @@
+# Durable package lifecycle
+
+Use this guide to decide whether to reuse existing behavior, explore with
+`execute`, or create durable repo-backed package code. Use it before scheduling
+new package behavior.
+
+## Choose the smallest durable surface
+
+### Invoke an existing package or capability
+
+Search first. If a builtin capability or saved package already does the work,
+invoke it instead of creating another implementation.
+
+- Call discovered builtin capabilities through `kody` in `execute`.
+- For a saved package's current published export, use
+  `packages.invokeChecked({ kodyId, exportName, params })` from an authenticated
+  `execute` call or package runtime.
+- Use a static `kody:@scope/package/export` import only when a bundled,
+  published snapshot is the intended dependency behavior.
+
+This is the default for an established operation whose behavior should stay
+owned by its existing capability or package.
+
+### Use `execute` for temporary one-off exploration
+
+Use `execute` when the code is disposable: inspect an API response, test an
+assumption, transform a small result, or run a one-time operation after any
+required confirmation.
+
+Keep the module focused and return structured evidence. Do not treat the
+ephemeral module as the durable source for behavior that must be maintained,
+reused, or scheduled.
+
+### Create a repo-backed package
+
+Create or extend a saved package when behavior is reusable, scheduled, or
+expected to evolve. The repo rooted at `package.json` is the durable source of
+truth. Package exports form the callable surface, while jobs, subscriptions,
+services, retrievers, and apps remain package-owned behavior.
+
+Use `guide: "package_authoring"` for package shape, README `## Intent`, and
+visibility guidance.
+
+## Signals to escalate from `execute` to a package
+
+Move the behavior into a package when one or more of these become true:
+
+- the user will run it again or other package code should reuse it
+- it needs a schedule, subscription, service, app, workflow entrypoint, or
+  package-owned storage
+- the logic needs tests, multiple files, dependencies, review, or version
+  history
+- inputs, output, error handling, or integration behavior will evolve
+- a one-off script has already been copied, repaired, or rerun
+
+Do not create a package merely to wrap one clear call to an existing capability
+or package export.
+
+## Choose an authoring lane
+
+### Git lane for coding agents
+
+When a normal filesystem and git client are available:
+
+1. Call `package_get_git_remote`. For a new package, pass `create: true` and a
+   new `kody_id`; for an existing package, omit `create`.
+2. Run the returned setup commands and clone into a temporary directory.
+3. Edit and test through the normal local development loop.
+4. Commit and push the package repository.
+5. Publish the pushed head with `package_publish_external_push`.
+
+This lane supports binary assets, multi-file changes, local tests, and normal
+git review.
+
+### Tool-only lane
+
+Without local filesystem or git access:
+
+1. Create the complete UTF-8 text package with `package_save`, or inspect an
+   existing package with `package_get`.
+2. Use `repo_open_session`, `repo_write_file`, and `repo_run_commands` for
+   repo-backed edits and checks.
+3. Publish with `repo_publish_session`.
+
+If the work needs binary assets, broad refactors, or a substantial local
+build/test loop, explain that it fits a coding-capable agent and confirm before
+continuing in the tool-only lane.
+
+## Test an export before enabling its schedule
+
+Scheduled behavior should not be its first real execution. Make the package job
+entry callable through `package.json.exports`, and initially declare the
+package-owned job with `"enabled": false`.
+
+After package checks and publishing succeed:
+
+1. Inspect the published package and export contract.
+2. Invoke the export from authenticated `execute` with
+   `packages.invokeChecked(...)`.
+3. Pass representative input: realistic field shapes, boundary values, and the
+   same configuration references the schedule will use. Never put plaintext
+   secrets in params.
+4. Validate the structured result and the intended durable or external effects.
+   Exercise an expected failure path when the operation is risky.
+5. Only then change the job to `"enabled": true`, publish again, and verify the
+   package/job detail reflects the enabled schedule.
+
+Example test call:
+
+```ts
+import { packages } from 'kody:runtime'
+
+export default async function main() {
+	return await packages.invokeChecked({
+		kodyId: 'daily-report',
+		exportName: './run-report',
+		params: {
+			reportDate: '2026-07-14',
+			dryRun: true,
+		},
+	})
+}
+```
+
+For exports that send messages, write remote records, charge accounts, or make
+other external mutations, prefer a package-specific `dryRun` input. Implement it
+so the export performs validation and returns a preview while skipping the
+mutation. `dryRun` is a package contract, not an automatic Kody runtime flag;
+test both the dry-run path and one deliberately confirmed live invocation before
+enabling recurring execution.
+
+Keep the schedule disabled when representative testing is inconclusive,
+credentials or host approval are missing, the result is unexpected, or the live
+mutation has not been confirmed.
+
+## Evolve the durable behavior
+
+For later changes, inspect the current repo, preserve the package's intent,
+update tests and docs with the implementation, and repeat the disabled
+schedule/export test when the scheduled path or its inputs change. Publish only
+checked commits; do not patch generated runtime state as a substitute for
+changing the package source.

--- a/docs/guides/package-lifecycle.md
+++ b/docs/guides/package-lifecycle.md
@@ -8,10 +8,10 @@ new package behavior.
 
 ### Invoke an existing package or capability
 
-Search first. If a builtin capability or saved package already does the work,
+Search first. If a built-in capability or saved package already does the work,
 invoke it instead of creating another implementation.
 
-- Call discovered builtin capabilities through `kody` in `execute`.
+- Call discovered built-in capabilities through `kody` in `execute`.
 - For a saved package's current published export, use
   `packages.invokeChecked({ kodyId, exportName, params })` from an authenticated
   `execute` call or package runtime.

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.node.test.ts
@@ -15,7 +15,7 @@ const ctx = {
 }
 
 test('coding_guide_get fetches markdown and surfaces fetch failures', async () => {
-	const url = buildKodyOfficialGuideUrlForTest('platform_friction')
+	const url = buildKodyOfficialGuideUrlForTest('package_lifecycle')
 	{
 		using _server = createMswNodeServer([
 			http.get(url, () =>
@@ -25,9 +25,10 @@ test('coding_guide_get fetches markdown and surfaces fetch failures', async () =
 			),
 		])
 		const result = await kodyOfficialGuideCapability.handler(
-			{ guide: 'platform_friction' },
+			{ guide: 'package_lifecycle' },
 			ctx,
 		)
+		expect(result.title).toBe('Durable package lifecycle guide')
 		expect(result.body).toBe('# Hello\n\nbody')
 	}
 

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -23,6 +23,12 @@ export const kodyOfficialGuideCatalog = {
 		summary:
 			'START HERE when creating or materially changing a Kody package: package shape, README.md Intent section, and scope-update guidance without adding new primitives.',
 	},
+	package_lifecycle: {
+		file: 'package-lifecycle.md',
+		title: 'Durable package lifecycle guide',
+		summary:
+			'Choose between invoking existing behavior, temporary execute exploration, and a durable repo-backed package; test a representative package export before enabling package-owned schedules.',
+	},
 	integration_bootstrap: {
 		file: 'integration-bootstrap.md',
 		title: 'Integration bootstrap guide',
@@ -129,6 +135,7 @@ function buildCapabilityDescription(): string {
 		'Load an official Kody guide from the kody GitHub repository (markdown).',
 		'Prefer this capability plus `search` results over local repo spelunking when Kody auth or integration behavior is already documented.',
 		'Use `guide: "package_authoring"` for package creation or material package updates, and `guide: "integration_bootstrap"` before building integration-dependent packages, package apps, or workflows.',
+		'Use `guide: "package_lifecycle"` to choose reuse vs temporary execute vs a durable package, and before enabling package-owned schedules.',
 		'Integration bootstrap covers checking saved `integration` / `secret` entities and running a cheap authenticated smoke test before building.',
 		'Use `guide: "platform_friction"` when Kody itself creates avoidable friction and you can propose a docs, package, or memory follow-up.',
 		'',
@@ -142,6 +149,7 @@ const guideFieldSchema = z
 		[
 			'Which guide to load.',
 			'`package_authoring`: required package-authoring guidance for README.md Intent sections when creating or materially changing packages.',
+			'`package_lifecycle`: choose existing invocation, temporary execute, or a durable repo-backed package; test package exports before enabling package-owned schedules.',
 			'`integration_bootstrap`: required sequence before building packages/package apps that depend on a third-party integration.',
 			'`secret_backed_integration`: default non-OAuth recipe after bootstrap when the integration is driven by saved secrets.',
 			'`integration_backed_app`: default package-app construction pattern after the integration smoke test passes.',
@@ -172,6 +180,18 @@ const allKeywords = [
 		'oauth',
 		'integration bootstrap',
 		'package authoring',
+		'package lifecycle',
+		'durable package',
+		'repo-backed package',
+		'package escalation',
+		'temporary execute',
+		'one-off exploration',
+		'package export testing',
+		'representative input',
+		'dry run',
+		'dryRun',
+		'package-owned schedule',
+		'disabled schedule',
 		'package creation',
 		'package update',
 		'readme intent',

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -27,7 +27,7 @@ export const kodyOfficialGuideCatalog = {
 		file: 'package-lifecycle.md',
 		title: 'Durable package lifecycle guide',
 		summary:
-			'Choose between invoking existing behavior, temporary execute exploration, and a durable repo-backed package; test a representative package export before enabling package-owned schedules.',
+			'Choose between invoking existing behavior, temporary execute exploration, and a durable repo-backed package; test the no-input scheduled wrapper before enabling package-owned schedules.',
 	},
 	integration_bootstrap: {
 		file: 'integration-bootstrap.md',
@@ -149,7 +149,7 @@ const guideFieldSchema = z
 		[
 			'Which guide to load.',
 			'`package_authoring`: required package-authoring guidance for README.md Intent sections when creating or materially changing packages.',
-			'`package_lifecycle`: choose existing invocation, temporary execute, or a durable repo-backed package; test package exports before enabling package-owned schedules.',
+			'`package_lifecycle`: choose existing invocation, temporary execute, or a durable repo-backed package; test no-input job wrappers before enabling package-owned schedules.',
 			'`integration_bootstrap`: required sequence before building packages/package apps that depend on a third-party integration.',
 			'`secret_backed_integration`: default non-OAuth recipe after bootstrap when the integration is driven by saved secrets.',
 			'`integration_backed_app`: default package-app construction pattern after the integration smoke test passes.',
@@ -187,6 +187,8 @@ const allKeywords = [
 		'temporary execute',
 		'one-off exploration',
 		'package export testing',
+		'job wrapper testing',
+		'no-input entrypoint',
 		'representative input',
 		'dry run',
 		'dryRun',

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -27,7 +27,7 @@ export const kodyOfficialGuideCatalog = {
 		file: 'package-lifecycle.md',
 		title: 'Durable package lifecycle guide',
 		summary:
-			'Choose between invoking existing behavior, temporary execute exploration, and a durable repo-backed package; test the no-input scheduled wrapper before enabling package-owned schedules.',
+			'Choose between invoking existing behavior, temporary execute exploration, direct job schedules, and a durable repo-backed package; test package-owned job wrappers safely.',
 	},
 	integration_bootstrap: {
 		file: 'integration-bootstrap.md',
@@ -135,7 +135,7 @@ function buildCapabilityDescription(): string {
 		'Load an official Kody guide from the kody GitHub repository (markdown).',
 		'Prefer this capability plus `search` results over local repo spelunking when Kody auth or integration behavior is already documented.',
 		'Use `guide: "package_authoring"` for package creation or material package updates, and `guide: "integration_bootstrap"` before building integration-dependent packages, package apps, or workflows.',
-		'Use `guide: "package_lifecycle"` to choose reuse vs temporary execute vs a durable package, and before enabling package-owned schedules.',
+		'Use `guide: "package_lifecycle"` to choose reuse vs temporary execute vs direct job scheduling vs a durable package, and before enabling package-owned schedules.',
 		'Integration bootstrap covers checking saved `integration` / `secret` entities and running a cheap authenticated smoke test before building.',
 		'Use `guide: "platform_friction"` when Kody itself creates avoidable friction and you can propose a docs, package, or memory follow-up.',
 		'',
@@ -149,7 +149,7 @@ const guideFieldSchema = z
 		[
 			'Which guide to load.',
 			'`package_authoring`: required package-authoring guidance for README.md Intent sections when creating or materially changing packages.',
-			'`package_lifecycle`: choose existing invocation, temporary execute, or a durable repo-backed package; test no-input job wrappers before enabling package-owned schedules.',
+			'`package_lifecycle`: choose existing invocation, temporary execute, direct job scheduling, or a durable repo-backed package; test package-owned job wrappers safely.',
 			'`integration_bootstrap`: required sequence before building packages/package apps that depend on a third-party integration.',
 			'`secret_backed_integration`: default non-OAuth recipe after bootstrap when the integration is driven by saved secrets.',
 			'`integration_backed_app`: default package-app construction pattern after the integration smoke test passes.',
@@ -186,6 +186,10 @@ const allKeywords = [
 		'package escalation',
 		'temporary execute',
 		'one-off exploration',
+		'direct job scheduling',
+		'job_schedule',
+		'ad hoc job',
+		'self-contained schedule',
 		'package export testing',
 		'job wrapper testing',
 		'no-input entrypoint',

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -54,16 +54,28 @@ export function buildBaseMcpServerInstructions(
 End-user documentation (workflows, secrets, troubleshooting):
 https://github.com/kentcdodds/kody/tree/main/docs/use
 
-Two-step flow (unless you know exactly what to do):
-1. \`search\` — built-in kody, saved packages, persisted values, saved integrations, and secret references (metadata).
-2. \`execute\` — run one ephemeral module with imports/exports and runtime access through \`kody:runtime\`.
+Package lifecycle (use this as the primary mental model):
+1. Discover and invoke before building: use \`search\` to find an existing built-in capability, connected capability, or saved package. Inspect the entity detail for its exact call shape, then invoke it rather than reimplementing it.
+2. Explore temporarily: use \`execute\` for quick one-off work, capability composition, authenticated smoke tests, and experiments. Treat execute modules as ephemeral, not as the durable home for behavior.
+3. Create or evolve a repo-backed package: use a package when behavior should be reused, scheduled, maintained, tested, or exposed as an app or service. Search once more before creating one so you extend an existing package when that is the better fit.
+
+Signals to escalate from \`execute\` to a package:
+- The user wants to run the behavior again, put it on a schedule, or keep improving it.
+- The code is becoming a named workflow or needs multiple files, dependencies, tests, binary assets, version history, or review.
+- The behavior needs a durable surface such as package exports, package-owned jobs, an app, or a service.
+- You are repeating or incrementally editing substantially the same execute module. Stop accumulating ephemeral code and move it into a package.
+- Keep genuinely one-off exploration in \`execute\`; do not create a package merely because a task required code.
+
+Choose the package authoring lane before building:
+- Coding agents with local filesystem/git access should use the git lane: \`package_get_git_remote\` (pass \`create: true\` with a new \`kody_id\` to register a stub package and mint its remote in one call), clone into a temporary directory, edit and test normally (binary assets supported), push, then publish with \`package_publish_external_push\`.
+- Tool-only agents should use \`package_save\` and repo sessions. \`package_save\` creates or replaces a repo-backed package rooted at \`package.json\` from the complete UTF-8 text file set.
+- If package work needs binary assets, many-file changes, or local build/test loops and you lack local filesystem/git access, tell the user it fits a coding-capable agent better and confirm before proceeding tool-only.
+- Standard package exports define the package surface. \`package.json#kody\` contains Kody-specific metadata such as tags, optional app config, and package-owned jobs. When creating or materially changing a package, keep a root \`README.md\` \`## Intent\` section with the user's goal; ask the user if unclear and update it when scope expands.
 
 Conventions
 - ${conversationIdGuidance}
 - \`memoryContext\`: short and task-focused. Kody may use it to surface a few relevant long-term memories and suppress repeats within the same \`conversationId\`.
 - Credential setup uses the standard setup pages: \`/connect/oauth\` for OAuth integrations and reconnects, \`/account/secrets/new\` for API keys, PATs, and other user-provided secrets. Never ask users to paste secrets, tokens, API keys, passwords, or credentials into chat.
-- Package authoring lanes: coding agents with local filesystem/git access should prefer the git lane — \`package_get_git_remote\` (pass \`create: true\` with a new \`kody_id\` to register a stub package and mint its remote in one call), clone into a temporary directory, edit normally (binary assets supported), push, then publish with \`package_publish_external_push\`. Tool-only agents use \`package_save\` and repo sessions. When a request needs binary assets, many-file changes, or local build/test loops and you lack local filesystem/git access, tell the user the task fits a coding-capable agent better and confirm before proceeding tool-only.
-- \`package_save\`: create or replace a repo-backed saved package rooted at \`package.json\` by sending the complete UTF-8 text file set (tool-only lane). Standard package exports define the package surface. \`package.json#kody\` contains Kody-specific metadata such as tags, optional app config, and package-owned jobs. When creating or materially changing a package, keep a root \`README.md\` \`## Intent\` section with the user's goal; ask the user if unclear and update it when scope expands.
 - \`package_get\` / \`package_list\` / \`package_delete\`: inspect or manage saved packages for the signed-in user.
 - Integration-backed work: use \`search\` and official guides before local repo exploration. For packages, package apps, or workflows that depend on third-party auth, first call \`coding_guide_get\` with \`guide: "integration_bootstrap"\`, confirm the required \`integration\` or \`secret\` entity exists through \`search\`, run a cheap authenticated \`execute\` smoke test, then build. If setup is missing, load \`oauth\` for \`/connect/oauth\`, \`connect_secret\` for secret collection, and \`secret_backed_integration\` for the default non-OAuth recipe.
 - \`job_list\` / \`job_get\`: inspect the signed-in user's scheduled jobs, recent run outcomes, and current per-user alarm state when debugging scheduling issues. Pass \`includeCode: true\` to \`job_get\` when you need the stored repo-backed job source entrypoint and code.

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -57,14 +57,15 @@ https://github.com/kentcdodds/kody/tree/main/docs/use
 Package lifecycle (use this as the primary mental model):
 1. Discover and invoke before building: use \`search\` to find an existing built-in capability, connected capability, or saved package. Inspect the entity detail for its exact call shape, then invoke it rather than reimplementing it.
 2. Explore temporarily: use \`execute\` for quick one-off work, capability composition, authenticated smoke tests, and experiments. Treat execute modules as ephemeral, not as the durable home for behavior.
-3. Create or evolve a repo-backed package: use a package when behavior should be reused, scheduled, maintained, tested, or exposed as an app or service. Search once more before creating one so you extend an existing package when that is the better fit.
+3. Create or evolve a repo-backed package: use a package when behavior should be reused, maintained, tested, exposed as an app or service, or given a package-owned schedule as part of named or evolving behavior. Search once more before creating one so you extend an existing package when that is the better fit.
 
 Signals to escalate from \`execute\` to a package:
-- The user wants to run the behavior again, put it on a schedule, or keep improving it.
+- The user wants reusable named behavior, expects to keep improving it, or wants its schedule to evolve with the implementation.
 - The code is becoming a named workflow or needs multiple files, dependencies, tests, binary assets, version history, or review.
 - The behavior needs a durable surface such as package exports, package-owned jobs, an app, or a service.
 - You are repeating or incrementally editing substantially the same execute module. Stop accumulating ephemeral code and move it into a package.
 - Keep genuinely one-off exploration in \`execute\`; do not create a package merely because a task required code.
+- Scheduling alone does not require a package. Use a package-owned job when the schedule belongs to reusable, evolving, or named package behavior. Use \`job_schedule\` directly for a genuinely ad hoc or one-off job, or a simple self-contained schedule that is not tied to a reusable package.
 
 Choose the package authoring lane before building:
 - Coding agents with local filesystem/git access should use the git lane: \`package_get_git_remote\` (pass \`create: true\` with a new \`kody_id\` to register a stub package and mint its remote in one call), clone into a temporary directory, edit and test normally (binary assets supported), push, then publish with \`package_publish_external_push\`.
@@ -79,13 +80,13 @@ Conventions
 - \`package_get\` / \`package_list\` / \`package_delete\`: inspect or manage saved packages for the signed-in user.
 - Integration-backed work: use \`search\` and official guides before local repo exploration. For packages, package apps, or workflows that depend on third-party auth, first call \`coding_guide_get\` with \`guide: "integration_bootstrap"\`, confirm the required \`integration\` or \`secret\` entity exists through \`search\`, run a cheap authenticated \`execute\` smoke test, then build. If setup is missing, load \`oauth\` for \`/connect/oauth\`, \`connect_secret\` for secret collection, and \`secret_backed_integration\` for the default non-OAuth recipe.
 - \`job_list\` / \`job_get\`: inspect the signed-in user's scheduled jobs, recent run outcomes, and current per-user alarm state when debugging scheduling issues. Pass \`includeCode: true\` to \`job_get\` when you need the stored repo-backed job source entrypoint and code.
-- \`job_schedule\`: schedule a repo-backed job for the signed-in user without creating a saved package first. Supports one-off, interval, and cron schedules.
+- \`job_schedule\`: schedule a repo-backed job for the signed-in user without creating a saved package first. It is appropriate for genuinely ad hoc or one-off jobs and simple self-contained schedules not tied to a reusable package. Supports one-off, interval, and cron schedules.
 - \`job_schedule_once\`: compatibility wrapper for one-off repo-backed jobs when you only need a single run time.
 - \`job_update\`: update an existing scheduled job by id. Supports safe mutable fields such as name, code, params, schedule, timezone, enabled, and kill-switch state. Providing \`code\` publishes a new commit on the job's repo-backed source (the simplest way to change the job module for non-package jobs); the replacement must default export a function and read \`params\` from its first argument, not from \`kody:runtime\`.
 - \`job_delete\`: delete one of the signed-in user's scheduled jobs by id.
 - \`job_run_now\`: run an existing scheduled job immediately by id and return the updated job view plus execution result for debugging.
 - \`workflow_run_list\`: inspect recent Cloudflare Workflow runs created through \`kody:runtime\` \`workflows.create\`; use it after durable long-running work such as batch sweeps, migrations, and polling loops.
-- Package jobs are schedules owned by a package. For ad hoc work that is not tied to a package, use \`job_schedule\`. Package apps are optional UI surfaces declared by the package, and packages may also declare headless package services for long-lived background runtimes.
+- Package jobs are schedules owned by reusable, evolving, or named package behavior. For genuinely ad hoc or one-off jobs and simple self-contained schedules not tied to a reusable package, use \`job_schedule\`. Package apps are optional UI surfaces declared by the package, and packages may also declare headless package services for long-lived background runtimes.
 - Package apps can also use Kody-managed realtime websocket sessions through \`session_list\`, \`session_emit\`, and \`session_broadcast\`, and package jobs can emit to those sessions when running under the same package caller context.
 - Package services are inspected and controlled through \`service_list\`, \`service_get\`, \`service_start\`, and \`service_stop\`.
 - Memory writes are verify-first: always run \`meta_memory_verify\` before \`meta_memory_upsert\` or \`meta_memory_delete\`. Kody retrieves related memories; the consuming agent decides whether to upsert, delete, both, or do nothing. \`meta_memory_upsert\` creates a new memory when \`memory_id\` is omitted and updates an existing memory when \`memory_id\` is provided.

--- a/tools/evals/package-discovery-routing.json
+++ b/tools/evals/package-discovery-routing.json
@@ -4,7 +4,7 @@
 	"actionCardinality": {
 		"searchMinimum": 1,
 		"readOnlyMaximum": 3,
-		"authoringStepMaximum": 5
+		"authoringStepMaximum": 8
 	},
 	"cases": [
 		{

--- a/tools/evals/package-discovery-routing.json
+++ b/tools/evals/package-discovery-routing.json
@@ -1,0 +1,102 @@
+{
+	"schemaVersion": 1,
+	"name": "package-discovery-routing",
+	"instruction": "Evaluate the routing decision only. The case includes the result of capability and package discovery, so do not call tools or perform mutations. Return exactly one JSON object shaped as {\"route\":\"<route>\",\"reasonCodes\":[\"<reason-code>\"]}. route must be one value from routes. reasonCodes must be a non-empty array containing only values from reasonCodes.",
+	"routes": [
+		"existing-capability-or-package",
+		"execute-prototype",
+		"package-authoring"
+	],
+	"reasonCodes": [
+		"exact-match",
+		"no-match",
+		"one-off",
+		"unproven",
+		"recurring",
+		"scheduled",
+		"durable-reuse",
+		"cross-host",
+		"successful-prototype"
+	],
+	"cases": [
+		{
+			"id": "recurring-email-drafting-existing-package",
+			"theme": "recurring-email-drafting",
+			"discovery": {
+				"status": "exact-match",
+				"kind": "package",
+				"summary": "A saved package already drafts recurring customer follow-ups in the user's approved voice and exposes the required draft export."
+			},
+			"prompt": "Draft this week's customer follow-ups in my usual voice, and keep using the same approach each week.",
+			"expected": {
+				"route": "existing-capability-or-package",
+				"requiredReasonCodes": ["exact-match", "recurring"]
+			}
+		},
+		{
+			"id": "reusable-writing-style-first-trial",
+			"theme": "reusable-writing-style",
+			"discovery": {
+				"status": "no-match",
+				"kind": "none",
+				"summary": "Discovery found no capability or package that applies this writing style."
+			},
+			"prompt": "Try a warmer writing style on these two paragraphs. I have not decided whether I want to reuse it, so do not save anything yet.",
+			"expected": {
+				"route": "execute-prototype",
+				"requiredReasonCodes": ["no-match", "one-off", "unproven"]
+			}
+		},
+		{
+			"id": "scheduled-workflow-new-recurring-task",
+			"theme": "scheduled-workflow",
+			"discovery": {
+				"status": "no-match",
+				"kind": "none",
+				"summary": "Discovery found scheduling primitives but no existing package that implements this workflow."
+			},
+			"prompt": "Every Monday, gather my open project updates, turn them into a status brief, and keep the workflow available for later changes.",
+			"expected": {
+				"route": "package-authoring",
+				"requiredReasonCodes": [
+					"no-match",
+					"recurring",
+					"scheduled",
+					"durable-reuse"
+				]
+			}
+		},
+		{
+			"id": "cross-host-reuse-new-helper",
+			"theme": "cross-host-reuse",
+			"discovery": {
+				"status": "no-match",
+				"kind": "none",
+				"summary": "Discovery found no existing capability or package for the helper."
+			},
+			"prompt": "Create a release-note helper I can invoke with the same behavior from Warp, Cursor, Claude, and ChatGPT.",
+			"expected": {
+				"route": "package-authoring",
+				"requiredReasonCodes": ["no-match", "durable-reuse", "cross-host"]
+			}
+		},
+		{
+			"id": "promote-successful-script",
+			"theme": "promote-successful-script",
+			"discovery": {
+				"status": "no-match",
+				"kind": "none",
+				"summary": "Discovery found no existing capability or package, but the user has already validated an execute script through repeated successful runs."
+			},
+			"prompt": "That cleanup script has worked well for the last five runs. Save it as a maintained tool I can reuse instead of pasting the script again.",
+			"expected": {
+				"route": "package-authoring",
+				"requiredReasonCodes": [
+					"no-match",
+					"durable-reuse",
+					"successful-prototype"
+				]
+			}
+		}
+	]
+}

--- a/tools/evals/package-discovery-routing.json
+++ b/tools/evals/package-discovery-routing.json
@@ -1,6 +1,11 @@
 {
 	"schemaVersion": 2,
 	"name": "package-discovery-routing",
+	"actionCardinality": {
+		"search": 1,
+		"terminal": 1,
+		"otherAllowedMaximum": 1
+	},
 	"cases": [
 		{
 			"id": "reuse-recurring-email-drafter",

--- a/tools/evals/package-discovery-routing.json
+++ b/tools/evals/package-discovery-routing.json
@@ -2,9 +2,9 @@
 	"schemaVersion": 2,
 	"name": "package-discovery-routing",
 	"actionCardinality": {
-		"search": 1,
-		"terminal": 1,
-		"otherAllowedMaximum": 1
+		"searchMinimum": 1,
+		"readOnlyMaximum": 3,
+		"authoringStepMaximum": 5
 	},
 	"cases": [
 		{

--- a/tools/evals/package-discovery-routing.json
+++ b/tools/evals/package-discovery-routing.json
@@ -1,101 +1,125 @@
 {
-	"schemaVersion": 1,
+	"schemaVersion": 2,
 	"name": "package-discovery-routing",
-	"instruction": "Evaluate the routing decision only. The case includes the result of capability and package discovery, so do not call tools or perform mutations. Return exactly one JSON object shaped as {\"route\":\"<route>\",\"reasonCodes\":[\"<reason-code>\"]}. route must be one value from routes. reasonCodes must be a non-empty array containing only values from reasonCodes.",
-	"routes": [
-		"existing-capability-or-package",
-		"execute-prototype",
-		"package-authoring"
-	],
-	"reasonCodes": [
-		"exact-match",
-		"no-match",
-		"one-off",
-		"unproven",
-		"recurring",
-		"scheduled",
-		"durable-reuse",
-		"cross-host",
-		"successful-prototype"
-	],
 	"cases": [
 		{
-			"id": "recurring-email-drafting-existing-package",
-			"theme": "recurring-email-drafting",
-			"discovery": {
-				"status": "exact-match",
-				"kind": "package",
-				"summary": "A saved package already drafts recurring customer follow-ups in the user's approved voice and exposes the required draft export."
+			"id": "reuse-recurring-email-drafter",
+			"prompt": "Draft replies to these three customer messages in the voice I use for weekly follow-ups, and return the drafts for review.",
+			"inventory": {
+				"mode": "inventory-dependent",
+				"eligibility": "Run only when preflight search finds one saved result that explicitly supports recurring customer follow-up drafts in the user's established voice. Otherwise record skipped-no-eligible-match."
 			},
-			"prompt": "Draft this week's customer follow-ups in my usual voice, and keep using the same approach each week.",
 			"expected": {
-				"route": "existing-capability-or-package",
-				"requiredReasonCodes": ["exact-match", "recurring"]
+				"route": "existing",
+				"requiredActions": ["search", "invoke-existing"],
+				"allowedActions": ["search", "invoke-existing"],
+				"terminalAction": "invoke-existing"
 			}
 		},
 		{
-			"id": "reusable-writing-style-first-trial",
-			"theme": "reusable-writing-style",
-			"discovery": {
-				"status": "no-match",
-				"kind": "none",
-				"summary": "Discovery found no capability or package that applies this writing style."
+			"id": "reuse-release-note-helper",
+			"prompt": "Turn these merged pull request notes into our standard release update and return the final text.",
+			"inventory": {
+				"mode": "inventory-dependent",
+				"eligibility": "Run only when preflight search finds one saved result that explicitly implements the account's standard release-update format. Otherwise record skipped-no-eligible-match."
 			},
-			"prompt": "Try a warmer writing style on these two paragraphs. I have not decided whether I want to reuse it, so do not save anything yet.",
 			"expected": {
-				"route": "execute-prototype",
-				"requiredReasonCodes": ["no-match", "one-off", "unproven"]
+				"route": "existing",
+				"requiredActions": ["search", "invoke-existing"],
+				"allowedActions": ["search", "invoke-existing"],
+				"terminalAction": "invoke-existing"
 			}
 		},
 		{
-			"id": "scheduled-workflow-new-recurring-task",
-			"theme": "scheduled-workflow",
-			"discovery": {
-				"status": "no-match",
-				"kind": "none",
-				"summary": "Discovery found scheduling primitives but no existing package that implements this workflow."
+			"id": "one-off-saved-automation-count",
+			"prompt": "Give me a one-time count of my saved automations grouped by public or private visibility. I do not need this saved.",
+			"inventory": {
+				"mode": "controlled",
+				"precondition": "The evaluation account has no exact reusable result for this aggregation; an empty inventory is valid."
 			},
-			"prompt": "Every Monday, gather my open project updates, turn them into a status brief, and keep the workflow available for later changes.",
+			"expected": {
+				"route": "execute-one-off",
+				"requiredActions": ["search", "execute-one-off"],
+				"allowedActions": ["search", "execute-one-off"],
+				"terminalAction": "execute-one-off"
+			}
+		},
+		{
+			"id": "one-off-value-inventory",
+			"prompt": "Return a one-time alphabetical list of the names of my current non-secret saved settings. Do not save a helper.",
+			"inventory": {
+				"mode": "controlled",
+				"precondition": "The evaluation account has no exact reusable result for this listing; an empty value inventory is valid."
+			},
+			"expected": {
+				"route": "execute-one-off",
+				"requiredActions": ["search", "execute-one-off"],
+				"allowedActions": ["search", "execute-one-off"],
+				"terminalAction": "execute-one-off"
+			}
+		},
+		{
+			"id": "schedule-single-reminder",
+			"prompt": "At 4:00 PM tomorrow, remind me to review the launch checklist once.",
+			"inventory": {
+				"mode": "controlled",
+				"precondition": "The evaluation account has no exact reusable result for this reminder."
+			},
+			"expected": {
+				"route": "ad-hoc-job",
+				"requiredActions": ["search", "schedule-ad-hoc-job"],
+				"allowedActions": ["search", "schedule-ad-hoc-job"],
+				"terminalAction": "schedule-ad-hoc-job"
+			}
+		},
+		{
+			"id": "schedule-simple-recurring-reminder",
+			"prompt": "Every Friday at 3:00 PM, remind me to submit my timesheet. This is just a reminder with no shared logic or interface.",
+			"inventory": {
+				"mode": "controlled",
+				"precondition": "The evaluation account has no exact reusable result for this reminder."
+			},
+			"expected": {
+				"route": "ad-hoc-job",
+				"requiredActions": ["search", "schedule-ad-hoc-job"],
+				"allowedActions": ["search", "schedule-ad-hoc-job"],
+				"terminalAction": "schedule-ad-hoc-job"
+			}
+		},
+		{
+			"id": "author-reusable-scheduled-brief",
+			"prompt": "Every Monday, turn the current items in my project-updates setting into a status brief, and keep the logic together so I can adjust it and trigger it from any assistant I use.",
+			"inventory": {
+				"mode": "controlled",
+				"precondition": "The evaluation account has the documented user-scoped project-updates value fixture and no exact reusable result for this workflow."
+			},
 			"expected": {
 				"route": "package-authoring",
-				"requiredReasonCodes": [
-					"no-match",
-					"recurring",
-					"scheduled",
-					"durable-reuse"
-				]
+				"requiredActions": ["search", "author-package"],
+				"allowedActions": [
+					"search",
+					"inspect-authoring-guidance",
+					"author-package"
+				],
+				"terminalAction": "author-package"
 			}
 		},
 		{
-			"id": "cross-host-reuse-new-helper",
-			"theme": "cross-host-reuse",
-			"discovery": {
-				"status": "no-match",
-				"kind": "none",
-				"summary": "Discovery found no existing capability or package for the helper."
+			"id": "author-validated-cleanup-automation",
+			"prompt": "This cleanup code has completed successfully on five runs: `export default function main({ names = [] }) { return [...new Set(names.map((name) => name.trim()).filter(Boolean))].sort() }`. Make it a maintained reusable automation that I can call from any connected assistant without pasting the code again.",
+			"inventory": {
+				"mode": "controlled",
+				"precondition": "The evaluation account has no exact reusable result for this source."
 			},
-			"prompt": "Create a release-note helper I can invoke with the same behavior from Warp, Cursor, Claude, and ChatGPT.",
 			"expected": {
 				"route": "package-authoring",
-				"requiredReasonCodes": ["no-match", "durable-reuse", "cross-host"]
-			}
-		},
-		{
-			"id": "promote-successful-script",
-			"theme": "promote-successful-script",
-			"discovery": {
-				"status": "no-match",
-				"kind": "none",
-				"summary": "Discovery found no existing capability or package, but the user has already validated an execute script through repeated successful runs."
-			},
-			"prompt": "That cleanup script has worked well for the last five runs. Save it as a maintained tool I can reuse instead of pasting the script again.",
-			"expected": {
-				"route": "package-authoring",
-				"requiredReasonCodes": [
-					"no-match",
-					"durable-reuse",
-					"successful-prototype"
-				]
+				"requiredActions": ["search", "author-package"],
+				"allowedActions": [
+					"search",
+					"inspect-authoring-guidance",
+					"author-package"
+				],
+				"terminalAction": "author-package"
 			}
 		}
 	]

--- a/tools/evals/package-discovery-routing.node.test.ts
+++ b/tools/evals/package-discovery-routing.node.test.ts
@@ -61,10 +61,25 @@ const createPassingTranscript = (): unknown => {
 							},
 							output: { result: 'captured execution output' },
 						} as const)
+			const searchCalls =
+				evalCase.expected.route === 'existing'
+					? [
+							{
+								...searchCall,
+								callId: `${searchCall.callId}:query`,
+								match: { kind: 'no-exact-reusable' as const },
+							},
+							{
+								...searchCall,
+								callId: `${searchCall.callId}:entity`,
+								input: { entity: entityId },
+							},
+						]
+					: [searchCall]
 			return {
 				caseId: evalCase.id,
 				outcome: 'completed' as const,
-				events: [searchCall, terminalCall],
+				events: [...searchCalls, terminalCall],
 			}
 		}),
 	}
@@ -104,9 +119,9 @@ test('routing cases are natural, balanced, and have internally consistent hidden
 		'package-authoring': 2,
 	})
 	expect(evalSet.actionCardinality).toEqual({
-		search: 1,
-		terminal: 1,
-		otherAllowedMaximum: 1,
+		searchMinimum: 1,
+		readOnlyMaximum: 3,
+		authoringStepMaximum: 5,
 	})
 	expect(
 		evalSet.cases
@@ -158,7 +173,9 @@ test('scorer rejects wrong targets, extraneous actions, failed calls, and invali
 		throw new Error('Expected completed scorer fixtures.')
 	}
 
-	const invocation = existingResult.events[1]
+	const invocation = existingResult.events.find(
+		(event) => event.action === 'invoke-existing',
+	)
 	if (!invocation || invocation.action !== 'invoke-existing') {
 		throw new Error('Expected an existing-result invocation fixture.')
 	}
@@ -227,6 +244,110 @@ test('scorer rejects duplicate successful scheduling mutations', () => {
 		'expected exactly 1 schedule-ad-hoc-job action, received 2',
 	)
 	expect(report.byRoute['ad-hoc-job']).toEqual({
+		passed: 1,
+		failed: 1,
+		skipped: 0,
+		total: 2,
+	})
+})
+
+test('scorer accepts canonical git-lane authoring with repeated discovery and intermediate steps', () => {
+	const evalSet = loadPackageDiscoveryEval()
+	const transcript = structuredClone(
+		transcriptSchema.parse(createPassingTranscript()),
+	)
+	const authoringResult = transcript.results[6]
+	if (!authoringResult || authoringResult.outcome !== 'completed') {
+		throw new Error('Expected a completed authoring fixture.')
+	}
+	authoringResult.events = [
+		{
+			callId: 'author-search-query',
+			action: 'search',
+			toolName: 'search',
+			status: 'succeeded',
+			input: { query: 'status brief automation' },
+			output: { results: [] },
+			match: { kind: 'no-exact-reusable' },
+		},
+		{
+			callId: 'author-search-guide',
+			action: 'search',
+			toolName: 'search',
+			status: 'succeeded',
+			input: { entity: 'package-authoring-guide' },
+			output: { result: 'guide capability' },
+			match: { kind: 'no-exact-reusable' },
+		},
+		{
+			callId: 'author-inspect',
+			action: 'inspect-authoring-guidance',
+			toolName: 'execute',
+			status: 'succeeded',
+			input: { code: 'await kody.coding_guide_get({})' },
+			output: { guide: 'captured' },
+		},
+		{
+			callId: 'author-initialize',
+			action: 'author-package',
+			toolName: 'execute',
+			status: 'succeeded',
+			input: { code: 'await kody.package_get_git_remote({})' },
+			output: { remote: 'captured' },
+		},
+		{
+			callId: 'author-edit',
+			action: 'author-package',
+			toolName: 'execute',
+			status: 'succeeded',
+			input: { code: 'await kody.repo_run_commands({})' },
+			output: { edited: true },
+		},
+		{
+			callId: 'author-publish',
+			action: 'author-package',
+			toolName: 'execute',
+			status: 'succeeded',
+			input: { code: 'await kody.package_publish_external_push({})' },
+			output: { published: true },
+		},
+	]
+
+	const report = scorePackageDiscoveryTranscript(evalSet, transcript)
+	expect(report.ok).toBe(true)
+	expect(report.totals).toEqual({
+		passed: 8,
+		failed: 0,
+		skipped: 0,
+		total: 8,
+	})
+})
+
+test('scorer rejects duplicate successful package publications', () => {
+	const evalSet = loadPackageDiscoveryEval()
+	const transcript = structuredClone(
+		transcriptSchema.parse(createPassingTranscript()),
+	)
+	const authoringResult = transcript.results[6]
+	if (!authoringResult || authoringResult.outcome !== 'completed') {
+		throw new Error('Expected a completed authoring fixture.')
+	}
+	authoringResult.events.push({
+		callId: 'author-publish-duplicate',
+		action: 'author-package',
+		toolName: 'execute',
+		status: 'succeeded',
+		input: { code: 'await kody.package_publish_external_push({})' },
+		output: { published: true },
+	})
+
+	const report = scorePackageDiscoveryTranscript(evalSet, transcript)
+	expect(report.ok).toBe(false)
+	expect(report.totals.failed).toBe(1)
+	expect(report.cases[6]?.errors).toContain(
+		'expected exactly 1 terminal authoring operation, received 2',
+	)
+	expect(report.byRoute['package-authoring']).toEqual({
 		passed: 1,
 		failed: 1,
 		skipped: 0,

--- a/tools/evals/package-discovery-routing.node.test.ts
+++ b/tools/evals/package-discovery-routing.node.test.ts
@@ -121,7 +121,7 @@ test('routing cases are natural, balanced, and have internally consistent hidden
 	expect(evalSet.actionCardinality).toEqual({
 		searchMinimum: 1,
 		readOnlyMaximum: 3,
-		authoringStepMaximum: 5,
+		authoringStepMaximum: 8,
 	})
 	expect(
 		evalSet.cases
@@ -323,7 +323,7 @@ test('scorer accepts canonical git-lane authoring with repeated discovery and in
 	})
 })
 
-test('scorer rejects duplicate successful package publications', () => {
+test('scorer accepts a safe two-publish scheduled package rollout', () => {
 	const evalSet = loadPackageDiscoveryEval()
 	const transcript = structuredClone(
 		transcriptSchema.parse(createPassingTranscript()),
@@ -332,25 +332,95 @@ test('scorer rejects duplicate successful package publications', () => {
 	if (!authoringResult || authoringResult.outcome !== 'completed') {
 		throw new Error('Expected a completed authoring fixture.')
 	}
-	authoringResult.events.push({
-		callId: 'author-publish-duplicate',
-		action: 'author-package',
-		toolName: 'execute',
-		status: 'succeeded',
-		input: { code: 'await kody.package_publish_external_push({})' },
-		output: { published: true },
-	})
+	authoringResult.events = [
+		authoringResult.events[0]!,
+		{
+			callId: 'author-publish-disabled',
+			action: 'author-package',
+			toolName: 'execute',
+			status: 'succeeded',
+			input: { code: 'await kody.package_save({ enabled: false })' },
+			output: { published: true, enabled: false },
+		},
+		{
+			callId: 'author-test-disabled',
+			action: 'author-package',
+			toolName: 'execute',
+			status: 'succeeded',
+			input: { code: 'await kody.repo_run_commands({ commands: "test" })' },
+			output: { passed: true },
+		},
+		{
+			callId: 'author-publish-enabled',
+			action: 'author-package',
+			toolName: 'execute',
+			status: 'succeeded',
+			input: { code: 'await kody.package_save({ enabled: true })' },
+			output: { published: true, enabled: true },
+		},
+	]
 
 	const report = scorePackageDiscoveryTranscript(evalSet, transcript)
-	expect(report.ok).toBe(false)
-	expect(report.totals.failed).toBe(1)
-	expect(report.cases[6]?.errors).toContain(
-		'expected exactly 1 terminal authoring operation, received 2',
-	)
-	expect(report.byRoute['package-authoring']).toEqual({
-		passed: 1,
-		failed: 1,
+	expect(report.ok).toBe(true)
+	expect(report.totals).toEqual({
+		passed: 8,
+		failed: 0,
 		skipped: 0,
-		total: 2,
+		total: 8,
+	})
+})
+
+test('scorer accepts the full tool-only repo-session authoring flow', () => {
+	const evalSet = loadPackageDiscoveryEval()
+	const transcript = structuredClone(
+		transcriptSchema.parse(createPassingTranscript()),
+	)
+	const authoringResult = transcript.results[7]
+	if (!authoringResult || authoringResult.outcome !== 'completed') {
+		throw new Error('Expected a completed authoring fixture.')
+	}
+	authoringResult.events = [
+		authoringResult.events[0]!,
+		{
+			callId: 'tool-only-open',
+			action: 'author-package',
+			toolName: 'execute',
+			status: 'succeeded',
+			input: { code: 'await kody.repo_open_session({})' },
+			output: { sessionId: 'repo-session' },
+		},
+		{
+			callId: 'tool-only-write',
+			action: 'author-package',
+			toolName: 'execute',
+			status: 'succeeded',
+			input: { code: 'await kody.repo_write_file({})' },
+			output: { written: true },
+		},
+		{
+			callId: 'tool-only-commit',
+			action: 'author-package',
+			toolName: 'execute',
+			status: 'succeeded',
+			input: { code: 'await kody.repo_run_commands({})' },
+			output: { committed: true },
+		},
+		{
+			callId: 'tool-only-publish',
+			action: 'author-package',
+			toolName: 'execute',
+			status: 'succeeded',
+			input: { code: 'await kody.repo_publish_session({})' },
+			output: { published: true },
+		},
+	]
+
+	const report = scorePackageDiscoveryTranscript(evalSet, transcript)
+	expect(report.ok).toBe(true)
+	expect(report.totals).toEqual({
+		passed: 8,
+		failed: 0,
+		skipped: 0,
+		total: 8,
 	})
 })

--- a/tools/evals/package-discovery-routing.node.test.ts
+++ b/tools/evals/package-discovery-routing.node.test.ts
@@ -406,6 +406,14 @@ test('scorer accepts the full tool-only repo-session authoring flow', () => {
 			output: { committed: true },
 		},
 		{
+			callId: 'tool-only-check',
+			action: 'author-package',
+			toolName: 'execute',
+			status: 'succeeded',
+			input: { code: 'await kody.repo_run_checks({})' },
+			output: { passed: true },
+		},
+		{
 			callId: 'tool-only-publish',
 			action: 'author-package',
 			toolName: 'execute',

--- a/tools/evals/package-discovery-routing.node.test.ts
+++ b/tools/evals/package-discovery-routing.node.test.ts
@@ -85,6 +85,15 @@ const createPassingTranscript = (): unknown => {
 	}
 }
 
+function getByCaseId<T extends { caseId: string }>(
+	items: ReadonlyArray<T>,
+	caseId: string,
+): T {
+	const item = items.find((candidate) => candidate.caseId === caseId)
+	if (!item) throw new Error(`Expected fixture for ${caseId}.`)
+	return item
+}
+
 test('routing cases are natural, balanced, and have internally consistent hidden expectations', () => {
 	const evalSet = loadPackageDiscoveryEval()
 	const routeCounts = Object.fromEntries(
@@ -157,15 +166,23 @@ test('scorer rejects wrong targets, extraneous actions, failed calls, and invali
 	const transcript = structuredClone(
 		transcriptSchema.parse(createPassingTranscript()),
 	)
-	const existingResult = transcript.results[0]
-	const oneOffResult = transcript.results[2]
-	const controlledResult = transcript.results[4]
-	const noTraceResult = transcript.results[5]
+	const existingResult = getByCaseId(
+		transcript.results,
+		'reuse-recurring-email-drafter',
+	)
+	const oneOffResult = getByCaseId(
+		transcript.results,
+		'one-off-saved-automation-count',
+	)
+	const controlledResult = getByCaseId(
+		transcript.results,
+		'schedule-single-reminder',
+	)
+	const noTraceResult = getByCaseId(
+		transcript.results,
+		'schedule-simple-recurring-reminder',
+	)
 	if (
-		!existingResult ||
-		!oneOffResult ||
-		!controlledResult ||
-		!noTraceResult ||
 		existingResult.outcome !== 'completed' ||
 		oneOffResult.outcome !== 'completed' ||
 		noTraceResult.outcome !== 'completed'
@@ -188,29 +205,33 @@ test('scorer rejects wrong targets, extraneous actions, failed calls, and invali
 		input: { code: 'await kody.package_save({})' },
 		output: { error: 'failed' },
 	})
-	transcript.results[4] = {
+	transcript.results.splice(transcript.results.indexOf(controlledResult), 1, {
 		caseId: controlledResult.caseId,
 		outcome: 'skipped-no-eligible-match',
 		note: 'incorrect skip',
-	}
+	})
 	noTraceResult.events = []
 
 	const report = scorePackageDiscoveryTranscript(evalSet, transcript)
 	expect(report.ok).toBe(false)
 	expect(report.totals.failed).toBe(4)
-	expect(report.cases[0]?.errors).toContain(
-		'invocation target does not match the discovered entity',
-	)
-	expect(report.cases[2]?.errors).toEqual(
+	expect(
+		getByCaseId(report.cases, 'reuse-recurring-email-drafter').errors,
+	).toContain('invocation target does not match the discovered entity')
+	expect(
+		getByCaseId(report.cases, 'one-off-saved-automation-count').errors,
+	).toEqual(
 		expect.arrayContaining([
 			'extraneous action author-package',
 			'trace contains a failed tool call',
 		]),
 	)
-	expect(report.cases[4]?.errors).toContain(
-		'controlled-inventory case cannot be skipped',
-	)
-	expect(report.cases[5]?.errors).toEqual(
+	expect(
+		getByCaseId(report.cases, 'schedule-single-reminder').errors,
+	).toContain('controlled-inventory case cannot be skipped')
+	expect(
+		getByCaseId(report.cases, 'schedule-simple-recurring-reminder').errors,
+	).toEqual(
 		expect.arrayContaining([
 			'first action must be search',
 			'missing required action schedule-ad-hoc-job',
@@ -224,8 +245,11 @@ test('scorer rejects duplicate successful scheduling mutations', () => {
 	const transcript = structuredClone(
 		transcriptSchema.parse(createPassingTranscript()),
 	)
-	const scheduleResult = transcript.results[4]
-	if (!scheduleResult || scheduleResult.outcome !== 'completed') {
+	const scheduleResult = getByCaseId(
+		transcript.results,
+		'schedule-single-reminder',
+	)
+	if (scheduleResult.outcome !== 'completed') {
 		throw new Error('Expected a completed scheduling fixture.')
 	}
 	const scheduleEvent = scheduleResult.events[1]
@@ -240,9 +264,9 @@ test('scorer rejects duplicate successful scheduling mutations', () => {
 	const report = scorePackageDiscoveryTranscript(evalSet, transcript)
 	expect(report.ok).toBe(false)
 	expect(report.totals.failed).toBe(1)
-	expect(report.cases[4]?.errors).toContain(
-		'expected exactly 1 schedule-ad-hoc-job action, received 2',
-	)
+	expect(
+		getByCaseId(report.cases, 'schedule-single-reminder').errors,
+	).toContain('expected exactly 1 schedule-ad-hoc-job action, received 2')
 	expect(report.byRoute['ad-hoc-job']).toEqual({
 		passed: 1,
 		failed: 1,
@@ -251,13 +275,142 @@ test('scorer rejects duplicate successful scheduling mutations', () => {
 	})
 })
 
+test('scorer rejects different payloads recorded under one call id', () => {
+	const evalSet = loadPackageDiscoveryEval()
+	const transcript = structuredClone(
+		transcriptSchema.parse(createPassingTranscript()),
+	)
+	const authoringResult = getByCaseId(
+		transcript.results,
+		'author-reusable-scheduled-brief',
+	)
+	if (authoringResult.outcome !== 'completed') {
+		throw new Error('Expected a completed authoring fixture.')
+	}
+	const authoringEvent = authoringResult.events.at(-1)
+	if (!authoringEvent || authoringEvent.action !== 'author-package') {
+		throw new Error('Expected an authoring event fixture.')
+	}
+	authoringEvent.input = {
+		code: 'await kody.coding_guide_get({}); await kody.package_save({})',
+	}
+	authoringResult.events.splice(-1, 0, {
+		...authoringEvent,
+		action: 'inspect-authoring-guidance',
+	})
+	expect(scorePackageDiscoveryTranscript(evalSet, transcript).ok).toBe(true)
+
+	const inputMismatch = structuredClone(transcript)
+	const inputMismatchResult = getByCaseId(
+		inputMismatch.results,
+		'author-reusable-scheduled-brief',
+	)
+	if (inputMismatchResult.outcome !== 'completed') {
+		throw new Error('Expected a completed authoring fixture.')
+	}
+	inputMismatchResult.events.at(-1)!.input = {
+		code: 'await kody.package_save({})',
+	}
+
+	const outputMismatch = structuredClone(transcript)
+	const outputMismatchResult = getByCaseId(
+		outputMismatch.results,
+		'author-reusable-scheduled-brief',
+	)
+	if (outputMismatchResult.outcome !== 'completed') {
+		throw new Error('Expected a completed authoring fixture.')
+	}
+	outputMismatchResult.events.at(-1)!.output = { result: 'different output' }
+
+	for (const mismatchedTranscript of [inputMismatch, outputMismatch]) {
+		const report = scorePackageDiscoveryTranscript(
+			evalSet,
+			mismatchedTranscript,
+		)
+		expect(report.ok).toBe(false)
+		expect(
+			getByCaseId(report.cases, 'author-reusable-scheduled-brief').errors,
+		).toContain(
+			'execute:author-reusable-scheduled-brief has inconsistent input or output payloads',
+		)
+	}
+})
+
+test('scorer rejects read-only and authoring counts above their limits', () => {
+	const evalSet = loadPackageDiscoveryEval()
+	const readOnlyTranscript = structuredClone(
+		transcriptSchema.parse(createPassingTranscript()),
+	)
+	const readOnlyResult = getByCaseId(
+		readOnlyTranscript.results,
+		'author-reusable-scheduled-brief',
+	)
+	if (readOnlyResult.outcome !== 'completed') {
+		throw new Error('Expected a completed authoring fixture.')
+	}
+	readOnlyResult.events.splice(
+		-1,
+		0,
+		...Array.from({ length: 3 }, (_, index) => ({
+			callId: `author-inspect-${index}`,
+			action: 'inspect-authoring-guidance' as const,
+			toolName: 'execute' as const,
+			status: 'succeeded' as const,
+			input: { code: 'await kody.coding_guide_get({})' },
+			output: { guide: 'captured' },
+		})),
+	)
+	const readOnlyReport = scorePackageDiscoveryTranscript(
+		evalSet,
+		readOnlyTranscript,
+	)
+	expect(readOnlyReport.ok).toBe(false)
+	expect(
+		getByCaseId(readOnlyReport.cases, 'author-reusable-scheduled-brief').errors,
+	).toContain('read-only actions may appear at most 3 times, received 4')
+
+	const authoringTranscript = structuredClone(
+		transcriptSchema.parse(createPassingTranscript()),
+	)
+	const authoringResult = getByCaseId(
+		authoringTranscript.results,
+		'author-reusable-scheduled-brief',
+	)
+	if (authoringResult.outcome !== 'completed') {
+		throw new Error('Expected a completed authoring fixture.')
+	}
+	authoringResult.events = [
+		authoringResult.events[0]!,
+		...Array.from({ length: 9 }, (_, index) => ({
+			callId: `author-mutation-${index}`,
+			action: 'author-package' as const,
+			toolName: 'execute' as const,
+			status: 'succeeded' as const,
+			input: { code: 'await kody.package_save({})' },
+			output: { saved: true },
+		})),
+	]
+	const authoringReport = scorePackageDiscoveryTranscript(
+		evalSet,
+		authoringTranscript,
+	)
+	expect(authoringReport.ok).toBe(false)
+	expect(
+		getByCaseId(authoringReport.cases, 'author-reusable-scheduled-brief')
+			.errors,
+	).toContain('author-package action may appear at most 8 times, received 9')
+})
+
 test('scorer accepts canonical git-lane authoring with repeated discovery and intermediate steps', () => {
 	const evalSet = loadPackageDiscoveryEval()
 	const transcript = structuredClone(
 		transcriptSchema.parse(createPassingTranscript()),
 	)
-	const authoringResult = transcript.results[6]
-	if (!authoringResult || authoringResult.outcome !== 'completed') {
+	const authoringResult = getByCaseId(
+		transcript.results,
+		'author-reusable-scheduled-brief',
+	)
+	if (authoringResult.outcome !== 'completed') {
 		throw new Error('Expected a completed authoring fixture.')
 	}
 	authoringResult.events = [
@@ -328,8 +481,11 @@ test('scorer accepts a safe two-publish scheduled package rollout', () => {
 	const transcript = structuredClone(
 		transcriptSchema.parse(createPassingTranscript()),
 	)
-	const authoringResult = transcript.results[6]
-	if (!authoringResult || authoringResult.outcome !== 'completed') {
+	const authoringResult = getByCaseId(
+		transcript.results,
+		'author-reusable-scheduled-brief',
+	)
+	if (authoringResult.outcome !== 'completed') {
 		throw new Error('Expected a completed authoring fixture.')
 	}
 	authoringResult.events = [
@@ -375,8 +531,11 @@ test('scorer accepts the full tool-only repo-session authoring flow', () => {
 	const transcript = structuredClone(
 		transcriptSchema.parse(createPassingTranscript()),
 	)
-	const authoringResult = transcript.results[7]
-	if (!authoringResult || authoringResult.outcome !== 'completed') {
+	const authoringResult = getByCaseId(
+		transcript.results,
+		'author-validated-cleanup-automation',
+	)
+	if (authoringResult.outcome !== 'completed') {
 		throw new Error('Expected a completed authoring fixture.')
 	}
 	authoringResult.events = [

--- a/tools/evals/package-discovery-routing.node.test.ts
+++ b/tools/evals/package-discovery-routing.node.test.ts
@@ -103,6 +103,11 @@ test('routing cases are natural, balanced, and have internally consistent hidden
 		'ad-hoc-job': 2,
 		'package-authoring': 2,
 	})
+	expect(evalSet.actionCardinality).toEqual({
+		search: 1,
+		terminal: 1,
+		otherAllowedMaximum: 1,
+	})
 	expect(
 		evalSet.cases
 			.filter(({ expected }) => expected.route === 'existing')
@@ -195,4 +200,36 @@ test('scorer rejects wrong targets, extraneous actions, failed calls, and invali
 		]),
 	)
 	expect(actionSchema.safeParse('explain-only').success).toBe(false)
+})
+
+test('scorer rejects duplicate successful scheduling mutations', () => {
+	const evalSet = loadPackageDiscoveryEval()
+	const transcript = structuredClone(
+		transcriptSchema.parse(createPassingTranscript()),
+	)
+	const scheduleResult = transcript.results[4]
+	if (!scheduleResult || scheduleResult.outcome !== 'completed') {
+		throw new Error('Expected a completed scheduling fixture.')
+	}
+	const scheduleEvent = scheduleResult.events[1]
+	if (!scheduleEvent || scheduleEvent.action !== 'schedule-ad-hoc-job') {
+		throw new Error('Expected a scheduling event fixture.')
+	}
+	scheduleResult.events.push({
+		...scheduleEvent,
+		callId: `${scheduleEvent.callId}:duplicate`,
+	})
+
+	const report = scorePackageDiscoveryTranscript(evalSet, transcript)
+	expect(report.ok).toBe(false)
+	expect(report.totals.failed).toBe(1)
+	expect(report.cases[4]?.errors).toContain(
+		'expected exactly 1 schedule-ad-hoc-job action, received 2',
+	)
+	expect(report.byRoute['ad-hoc-job']).toEqual({
+		passed: 1,
+		failed: 1,
+		skipped: 0,
+		total: 2,
+	})
 })

--- a/tools/evals/package-discovery-routing.node.test.ts
+++ b/tools/evals/package-discovery-routing.node.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'node:fs'
+import { z } from 'zod'
+import { expect, test } from 'vitest'
+
+const routeSchema = z.enum([
+	'existing-capability-or-package',
+	'execute-prototype',
+	'package-authoring',
+])
+const reasonCodeSchema = z.enum([
+	'exact-match',
+	'no-match',
+	'one-off',
+	'unproven',
+	'recurring',
+	'scheduled',
+	'durable-reuse',
+	'cross-host',
+	'successful-prototype',
+])
+const themeSchema = z.enum([
+	'recurring-email-drafting',
+	'reusable-writing-style',
+	'scheduled-workflow',
+	'cross-host-reuse',
+	'promote-successful-script',
+])
+
+const evalSetSchema = z
+	.object({
+		schemaVersion: z.literal(1),
+		name: z.literal('package-discovery-routing'),
+		instruction: z.string().min(1),
+		routes: z.array(routeSchema).length(routeSchema.options.length),
+		reasonCodes: z
+			.array(reasonCodeSchema)
+			.length(reasonCodeSchema.options.length),
+		cases: z
+			.array(
+				z
+					.object({
+						id: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+						theme: themeSchema,
+						discovery: z.discriminatedUnion('status', [
+							z
+								.object({
+									status: z.literal('exact-match'),
+									kind: z.enum(['capability', 'package']),
+									summary: z.string().min(1),
+								})
+								.strict(),
+							z
+								.object({
+									status: z.literal('no-match'),
+									kind: z.literal('none'),
+									summary: z.string().min(1),
+								})
+								.strict(),
+						]),
+						prompt: z.string().min(1),
+						expected: z
+							.object({
+								route: routeSchema,
+								requiredReasonCodes: z.array(reasonCodeSchema).min(1),
+							})
+							.strict(),
+					})
+					.strict(),
+			)
+			.min(1),
+	})
+	.strict()
+
+test('package discovery routing eval has a valid schema and complete routing coverage', () => {
+	const rawEvalSet: unknown = JSON.parse(
+		readFileSync(
+			new URL('./package-discovery-routing.json', import.meta.url),
+			'utf8',
+		),
+	)
+	const evalSet = evalSetSchema.parse(rawEvalSet)
+
+	expect(new Set(evalSet.routes)).toEqual(new Set(routeSchema.options))
+	expect(new Set(evalSet.reasonCodes)).toEqual(
+		new Set(reasonCodeSchema.options),
+	)
+	expect(new Set(evalSet.cases.map(({ id }) => id)).size).toBe(
+		evalSet.cases.length,
+	)
+	expect(new Set(evalSet.cases.map(({ theme }) => theme))).toEqual(
+		new Set(themeSchema.options),
+	)
+	expect(new Set(evalSet.cases.map(({ expected }) => expected.route))).toEqual(
+		new Set(routeSchema.options),
+	)
+
+	for (const evalCase of evalSet.cases) {
+		expect(new Set(evalCase.expected.requiredReasonCodes).size).toBe(
+			evalCase.expected.requiredReasonCodes.length,
+		)
+		if (evalCase.discovery.status === 'exact-match') {
+			expect(evalCase.expected.route).toBe('existing-capability-or-package')
+			expect(evalCase.expected.requiredReasonCodes).toContain('exact-match')
+		} else {
+			expect(evalCase.expected.requiredReasonCodes).toContain('no-match')
+		}
+	}
+})

--- a/tools/evals/package-discovery-routing.node.test.ts
+++ b/tools/evals/package-discovery-routing.node.test.ts
@@ -1,108 +1,198 @@
-import { readFileSync } from 'node:fs'
-import { z } from 'zod'
 import { expect, test } from 'vitest'
+import {
+	actionSchema,
+	loadPackageDiscoveryEval,
+	routeSchema,
+	scorePackageDiscoveryTranscript,
+	transcriptSchema,
+} from './package-discovery-routing.ts'
 
-const routeSchema = z.enum([
-	'existing-capability-or-package',
-	'execute-prototype',
-	'package-authoring',
-])
-const reasonCodeSchema = z.enum([
-	'exact-match',
-	'no-match',
-	'one-off',
-	'unproven',
-	'recurring',
-	'scheduled',
-	'durable-reuse',
-	'cross-host',
-	'successful-prototype',
-])
-const themeSchema = z.enum([
-	'recurring-email-drafting',
-	'reusable-writing-style',
-	'scheduled-workflow',
-	'cross-host-reuse',
-	'promote-successful-script',
-])
+const createPassingTranscript = (): unknown => {
+	const evalSet = loadPackageDiscoveryEval()
+	return {
+		schemaVersion: 1 as const,
+		evalName: 'package-discovery-routing' as const,
+		host: 'cursor' as const,
+		model: 'test-model',
+		runAt: '2026-07-14T21:00:00.000Z',
+		results: evalSet.cases.map((evalCase) => {
+			const entityId = `fixture:${evalCase.id}`
+			const searchCall = {
+				callId: `search:${evalCase.id}`,
+				action: 'search' as const,
+				toolName: 'search' as const,
+				status: 'succeeded' as const,
+				input: { query: evalCase.prompt },
+				output: { result: 'captured search output' },
+				match:
+					evalCase.expected.route === 'existing'
+						? ({
+								kind: 'exact-reusable' as const,
+								entityId,
+							} as const)
+						: ({ kind: 'no-exact-reusable' as const } as const),
+			}
+			const terminalAction = evalCase.expected.terminalAction
+			const terminalCall =
+				terminalAction === 'invoke-existing'
+					? ({
+							callId: `execute:${evalCase.id}`,
+							action: terminalAction,
+							toolName: 'execute' as const,
+							status: 'succeeded' as const,
+							input: {
+								code: `import ${JSON.stringify(entityId)}`,
+							},
+							output: { result: 'captured invocation output' },
+							targetEntityId: entityId,
+						} as const)
+					: ({
+							callId: `execute:${evalCase.id}`,
+							action: terminalAction,
+							toolName: 'execute' as const,
+							status: 'succeeded' as const,
+							input: {
+								code:
+									terminalAction === 'schedule-ad-hoc-job'
+										? 'await kody.job_schedule_once({})'
+										: terminalAction === 'author-package'
+											? 'await kody.package_save({})'
+											: 'return await kody.value_list({})',
+							},
+							output: { result: 'captured execution output' },
+						} as const)
+			return {
+				caseId: evalCase.id,
+				outcome: 'completed' as const,
+				events: [searchCall, terminalCall],
+			}
+		}),
+	}
+}
 
-const evalSetSchema = z
-	.object({
-		schemaVersion: z.literal(1),
-		name: z.literal('package-discovery-routing'),
-		instruction: z.string().min(1),
-		routes: z.array(routeSchema).length(routeSchema.options.length),
-		reasonCodes: z
-			.array(reasonCodeSchema)
-			.length(reasonCodeSchema.options.length),
-		cases: z
-			.array(
-				z
-					.object({
-						id: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
-						theme: themeSchema,
-						discovery: z.discriminatedUnion('status', [
-							z
-								.object({
-									status: z.literal('exact-match'),
-									kind: z.enum(['capability', 'package']),
-									summary: z.string().min(1),
-								})
-								.strict(),
-							z
-								.object({
-									status: z.literal('no-match'),
-									kind: z.literal('none'),
-									summary: z.string().min(1),
-								})
-								.strict(),
-						]),
-						prompt: z.string().min(1),
-						expected: z
-							.object({
-								route: routeSchema,
-								requiredReasonCodes: z.array(reasonCodeSchema).min(1),
-							})
-							.strict(),
-					})
-					.strict(),
-			)
-			.min(1),
-	})
-	.strict()
-
-test('package discovery routing eval has a valid schema and complete routing coverage', () => {
-	const rawEvalSet: unknown = JSON.parse(
-		readFileSync(
-			new URL('./package-discovery-routing.json', import.meta.url),
-			'utf8',
-		),
+test('routing cases are natural, balanced, and have internally consistent hidden expectations', () => {
+	const evalSet = loadPackageDiscoveryEval()
+	const routeCounts = Object.fromEntries(
+		evalSet.cases.map(({ expected }) => [expected.route, 0]),
 	)
-	const evalSet = evalSetSchema.parse(rawEvalSet)
 
-	expect(new Set(evalSet.routes)).toEqual(new Set(routeSchema.options))
-	expect(new Set(evalSet.reasonCodes)).toEqual(
-		new Set(reasonCodeSchema.options),
-	)
 	expect(new Set(evalSet.cases.map(({ id }) => id)).size).toBe(
 		evalSet.cases.length,
 	)
-	expect(new Set(evalSet.cases.map(({ theme }) => theme))).toEqual(
-		new Set(themeSchema.options),
-	)
-	expect(new Set(evalSet.cases.map(({ expected }) => expected.route))).toEqual(
-		new Set(routeSchema.options),
-	)
-
 	for (const evalCase of evalSet.cases) {
-		expect(new Set(evalCase.expected.requiredReasonCodes).size).toBe(
-			evalCase.expected.requiredReasonCodes.length,
-		)
-		if (evalCase.discovery.status === 'exact-match') {
-			expect(evalCase.expected.route).toBe('existing-capability-or-package')
-			expect(evalCase.expected.requiredReasonCodes).toContain('exact-match')
-		} else {
-			expect(evalCase.expected.requiredReasonCodes).toContain('no-match')
+		expect(evalCase.prompt).not.toMatch(/\bpackage\b/i)
+		for (const hiddenLabel of [
+			...routeSchema.options,
+			...actionSchema.options,
+		]) {
+			expect(evalCase.prompt).not.toContain(hiddenLabel)
 		}
+		expect(
+			evalCase.expected.requiredActions.every((action) =>
+				evalCase.expected.allowedActions.includes(action),
+			),
+		).toBe(true)
+		expect(evalCase.expected.requiredActions).toContain(
+			evalCase.expected.terminalAction,
+		)
+		routeCounts[evalCase.expected.route] += 1
 	}
+	expect(routeCounts).toEqual({
+		existing: 2,
+		'execute-one-off': 2,
+		'ad-hoc-job': 2,
+		'package-authoring': 2,
+	})
+	expect(
+		evalSet.cases
+			.filter(({ expected }) => expected.route === 'existing')
+			.every(({ inventory }) => inventory.mode === 'inventory-dependent'),
+	).toBe(true)
+})
+
+test('scorer accepts exact traces and reports two passes per route', () => {
+	const evalSet = loadPackageDiscoveryEval()
+	const transcript = transcriptSchema.parse(createPassingTranscript())
+	const report = scorePackageDiscoveryTranscript(evalSet, transcript)
+
+	expect(report.ok).toBe(true)
+	expect(report.totals).toEqual({
+		passed: 8,
+		failed: 0,
+		skipped: 0,
+		total: 8,
+	})
+	for (const routeScore of Object.values(report.byRoute)) {
+		expect(routeScore).toEqual({
+			passed: 2,
+			failed: 0,
+			skipped: 0,
+			total: 2,
+		})
+	}
+})
+
+test('scorer rejects wrong targets, extraneous actions, failed calls, and invalid skips', () => {
+	const evalSet = loadPackageDiscoveryEval()
+	const transcript = structuredClone(
+		transcriptSchema.parse(createPassingTranscript()),
+	)
+	const existingResult = transcript.results[0]
+	const oneOffResult = transcript.results[2]
+	const controlledResult = transcript.results[4]
+	const noTraceResult = transcript.results[5]
+	if (
+		!existingResult ||
+		!oneOffResult ||
+		!controlledResult ||
+		!noTraceResult ||
+		existingResult.outcome !== 'completed' ||
+		oneOffResult.outcome !== 'completed' ||
+		noTraceResult.outcome !== 'completed'
+	) {
+		throw new Error('Expected completed scorer fixtures.')
+	}
+
+	const invocation = existingResult.events[1]
+	if (!invocation || invocation.action !== 'invoke-existing') {
+		throw new Error('Expected an existing-result invocation fixture.')
+	}
+	invocation.targetEntityId = 'fixture:wrong-target'
+	oneOffResult.events.splice(1, 0, {
+		callId: `execute:${oneOffResult.caseId}:wrong`,
+		action: 'author-package',
+		toolName: 'execute',
+		status: 'failed',
+		input: { code: 'await kody.package_save({})' },
+		output: { error: 'failed' },
+	})
+	transcript.results[4] = {
+		caseId: controlledResult.caseId,
+		outcome: 'skipped-no-eligible-match',
+		note: 'incorrect skip',
+	}
+	noTraceResult.events = []
+
+	const report = scorePackageDiscoveryTranscript(evalSet, transcript)
+	expect(report.ok).toBe(false)
+	expect(report.totals.failed).toBe(4)
+	expect(report.cases[0]?.errors).toContain(
+		'invocation target does not match the discovered entity',
+	)
+	expect(report.cases[2]?.errors).toEqual(
+		expect.arrayContaining([
+			'extraneous action author-package',
+			'trace contains a failed tool call',
+		]),
+	)
+	expect(report.cases[4]?.errors).toContain(
+		'controlled-inventory case cannot be skipped',
+	)
+	expect(report.cases[5]?.errors).toEqual(
+		expect.arrayContaining([
+			'first action must be search',
+			'missing required action schedule-ad-hoc-job',
+		]),
+	)
+	expect(actionSchema.safeParse('explain-only').success).toBe(false)
 })

--- a/tools/evals/package-discovery-routing.ts
+++ b/tools/evals/package-discovery-routing.ts
@@ -269,7 +269,7 @@ function scoreCompletedResult(
 		const hasScheduleOperation = /\bjob_schedule(?:_once)?\b/.test(code)
 		const authoringOperationCount = countMatches(
 			code,
-			/\b(?:package_save|package_get_git_remote|package_publish_external_push|repo_open_session|repo_write_file|repo_run_commands|repo_publish_session)\b/g,
+			/\b(?:package_save|package_get_git_remote|package_publish_external_push|repo_open_session|repo_write_file|repo_run_commands|repo_run_checks|repo_publish_session)\b/g,
 		)
 		const eventAuthoringMutationCount = countMatches(
 			code,

--- a/tools/evals/package-discovery-routing.ts
+++ b/tools/evals/package-discovery-routing.ts
@@ -40,9 +40,9 @@ export const evalSetSchema = z
 		name: z.literal('package-discovery-routing'),
 		actionCardinality: z
 			.object({
-				search: z.literal(1),
-				terminal: z.literal(1),
-				otherAllowedMaximum: z.literal(1),
+				searchMinimum: z.literal(1),
+				readOnlyMaximum: z.literal(3),
+				authoringStepMaximum: z.literal(5),
 			})
 			.strict(),
 		cases: z
@@ -193,6 +193,10 @@ export function loadPackageDiscoveryEval(): EvalSet {
 	return evalSetSchema.parse(raw)
 }
 
+function countMatches(value: string, pattern: RegExp): number {
+	return Array.from(value.matchAll(pattern)).length
+}
+
 function scoreCompletedResult(
 	evalCase: EvalSet['cases'][number],
 	result: z.infer<typeof completedResultSchema>,
@@ -210,18 +214,26 @@ function scoreCompletedResult(
 		errors.push('first action must be search')
 	}
 	const searchCount = actionCounts.get('search') ?? 0
-	if (searchCount !== actionCardinality.search) {
+	if (searchCount < actionCardinality.searchMinimum) {
 		errors.push(
-			`expected exactly ${actionCardinality.search} search action, received ${searchCount}`,
+			`expected at least ${actionCardinality.searchMinimum} search action, received ${searchCount}`,
 		)
 	}
 	if (actions.at(-1) !== evalCase.expected.terminalAction) {
 		errors.push(`terminal action must be ${evalCase.expected.terminalAction}`)
 	}
 	const terminalCount = actionCounts.get(evalCase.expected.terminalAction) ?? 0
-	if (terminalCount !== actionCardinality.terminal) {
+	if (evalCase.expected.route !== 'package-authoring' && terminalCount !== 1) {
 		errors.push(
-			`expected exactly ${actionCardinality.terminal} ${evalCase.expected.terminalAction} action, received ${terminalCount}`,
+			`expected exactly 1 ${evalCase.expected.terminalAction} action, received ${terminalCount}`,
+		)
+	}
+	if (
+		evalCase.expected.route === 'package-authoring' &&
+		terminalCount > actionCardinality.authoringStepMaximum
+	) {
+		errors.push(
+			`author-package action may appear at most ${actionCardinality.authoringStepMaximum} times, received ${terminalCount}`,
 		)
 	}
 	for (const requiredAction of evalCase.expected.requiredActions) {
@@ -234,21 +246,20 @@ function scoreCompletedResult(
 			errors.push(`extraneous action ${action}`)
 		}
 	}
-	for (const action of allowedActions) {
-		if (
-			action !== 'search' &&
-			action !== evalCase.expected.terminalAction &&
-			(actionCounts.get(action) ?? 0) > actionCardinality.otherAllowedMaximum
-		) {
-			errors.push(
-				`allowed action ${action} may appear at most ${actionCardinality.otherAllowedMaximum} time`,
-			)
-		}
+	const inspectionCount = actionCounts.get('inspect-authoring-guidance') ?? 0
+	const readOnlyCount = searchCount + inspectionCount
+	if (readOnlyCount > actionCardinality.readOnlyMaximum) {
+		errors.push(
+			`read-only actions may appear at most ${actionCardinality.readOnlyMaximum} times, received ${readOnlyCount}`,
+		)
 	}
 	if (result.events.some(({ status }) => status === 'failed')) {
 		errors.push('trace contains a failed tool call')
 	}
 
+	let authoringTerminalOperationCount = 0
+	let authoringTerminalCallId: string | null = null
+	const countedAuthoringCallIds = new Set<string>()
 	for (const event of result.events) {
 		if (event.toolName !== 'execute') continue
 		const code = event.input.code
@@ -257,10 +268,30 @@ function scoreCompletedResult(
 			continue
 		}
 		const hasScheduleOperation = /\bjob_schedule(?:_once)?\b/.test(code)
+		const authoringInitializationCount = countMatches(
+			code,
+			/\bpackage_get_git_remote\b/g,
+		)
+		const authoringIntermediateCount = countMatches(
+			code,
+			/\brepo_run_commands\b/g,
+		)
+		const eventAuthoringTerminalCount = countMatches(
+			code,
+			/\b(?:package_save|package_publish_external_push|repo_publish_session)\b/g,
+		)
 		const hasAuthorOperation =
-			/\b(?:package_save|package_get_git_remote|package_publish_external_push|repo_run_commands)\b/.test(
-				code,
-			)
+			authoringInitializationCount +
+				authoringIntermediateCount +
+				eventAuthoringTerminalCount >
+			0
+		if (!countedAuthoringCallIds.has(event.callId)) {
+			countedAuthoringCallIds.add(event.callId)
+			authoringTerminalOperationCount += eventAuthoringTerminalCount
+			if (eventAuthoringTerminalCount > 0) {
+				authoringTerminalCallId = event.callId
+			}
+		}
 		const sameCallActions = new Set(
 			result.events
 				.filter(({ callId }) => callId === event.callId)
@@ -299,6 +330,20 @@ function scoreCompletedResult(
 			!code.includes(event.targetEntityId)
 		) {
 			errors.push('invoke-existing evidence does not contain its target id')
+		}
+	}
+	if (evalCase.expected.route === 'package-authoring') {
+		if (authoringTerminalOperationCount !== 1) {
+			errors.push(
+				`expected exactly 1 terminal authoring operation, received ${authoringTerminalOperationCount}`,
+			)
+		}
+		if (
+			authoringTerminalOperationCount === 1 &&
+			(result.events.at(-1)?.action !== 'author-package' ||
+				result.events.at(-1)?.callId !== authoringTerminalCallId)
+		) {
+			errors.push('terminal authoring operation must be the final event')
 		}
 	}
 

--- a/tools/evals/package-discovery-routing.ts
+++ b/tools/evals/package-discovery-routing.ts
@@ -1,0 +1,416 @@
+import { readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { z } from 'zod'
+
+export const routeSchema = z.enum([
+	'existing',
+	'execute-one-off',
+	'ad-hoc-job',
+	'package-authoring',
+])
+
+export const actionSchema = z.enum([
+	'search',
+	'invoke-existing',
+	'execute-one-off',
+	'schedule-ad-hoc-job',
+	'inspect-authoring-guidance',
+	'author-package',
+	'other-execute',
+])
+
+const inventorySchema = z.discriminatedUnion('mode', [
+	z
+		.object({
+			mode: z.literal('controlled'),
+			precondition: z.string().min(1),
+		})
+		.strict(),
+	z
+		.object({
+			mode: z.literal('inventory-dependent'),
+			eligibility: z.string().min(1),
+		})
+		.strict(),
+])
+
+export const evalSetSchema = z
+	.object({
+		schemaVersion: z.literal(2),
+		name: z.literal('package-discovery-routing'),
+		cases: z
+			.array(
+				z
+					.object({
+						id: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+						prompt: z.string().min(1),
+						inventory: inventorySchema,
+						expected: z
+							.object({
+								route: routeSchema,
+								requiredActions: z.array(actionSchema).min(1),
+								allowedActions: z.array(actionSchema).min(1),
+								terminalAction: actionSchema,
+							})
+							.strict(),
+					})
+					.strict(),
+			)
+			.min(1),
+	})
+	.strict()
+
+const requiredOutputSchema = z.custom<unknown>(
+	(value) => value !== undefined,
+	'output is required',
+)
+const traceBaseSchema = z.object({
+	callId: z.string().min(1),
+	status: z.enum(['succeeded', 'failed']),
+	input: z.record(z.string(), z.unknown()),
+	output: requiredOutputSchema,
+})
+
+const searchCallSchema = traceBaseSchema
+	.extend({
+		action: z.literal('search'),
+		toolName: z.literal('search'),
+		match: z.discriminatedUnion('kind', [
+			z
+				.object({
+					kind: z.literal('exact-reusable'),
+					entityId: z.string().min(1),
+				})
+				.strict(),
+			z.object({ kind: z.literal('no-exact-reusable') }).strict(),
+		]),
+	})
+	.strict()
+
+const executeCallSchema = traceBaseSchema
+	.extend({
+		action: z.enum([
+			'execute-one-off',
+			'schedule-ad-hoc-job',
+			'inspect-authoring-guidance',
+			'author-package',
+			'other-execute',
+		]),
+		toolName: z.literal('execute'),
+	})
+	.strict()
+
+const invokeExistingCallSchema = traceBaseSchema
+	.extend({
+		action: z.literal('invoke-existing'),
+		toolName: z.literal('execute'),
+		targetEntityId: z.string().min(1),
+	})
+	.strict()
+
+export const traceCallSchema = z.discriminatedUnion('action', [
+	searchCallSchema,
+	invokeExistingCallSchema,
+	executeCallSchema,
+])
+
+const completedResultSchema = z
+	.object({
+		caseId: z.string().min(1),
+		outcome: z.literal('completed'),
+		events: z.array(traceCallSchema),
+	})
+	.strict()
+
+const skippedResultSchema = z
+	.object({
+		caseId: z.string().min(1),
+		outcome: z.literal('skipped-no-eligible-match'),
+		note: z.string().min(1),
+	})
+	.strict()
+
+export const transcriptSchema = z
+	.object({
+		schemaVersion: z.literal(1),
+		evalName: z.literal('package-discovery-routing'),
+		host: z.enum(['warp', 'cursor', 'claude', 'chatgpt']),
+		model: z.string().min(1),
+		runAt: z.string().datetime(),
+		results: z
+			.array(
+				z.discriminatedUnion('outcome', [
+					completedResultSchema,
+					skippedResultSchema,
+				]),
+			)
+			.min(1),
+	})
+	.strict()
+
+type EvalSet = z.infer<typeof evalSetSchema>
+type Transcript = z.infer<typeof transcriptSchema>
+
+type CaseScore = {
+	caseId: string
+	route: z.infer<typeof routeSchema>
+	status: 'passed' | 'failed' | 'skipped'
+	errors: Array<string>
+}
+
+export type ScoreReport = {
+	ok: boolean
+	host: Transcript['host']
+	model: string
+	totals: {
+		passed: number
+		failed: number
+		skipped: number
+		total: number
+	}
+	byRoute: Record<
+		z.infer<typeof routeSchema>,
+		{ passed: number; failed: number; skipped: number; total: number }
+	>
+	cases: Array<CaseScore>
+	errors: Array<string>
+}
+
+export function loadPackageDiscoveryEval(): EvalSet {
+	const raw: unknown = JSON.parse(
+		readFileSync(
+			new URL('./package-discovery-routing.json', import.meta.url),
+			'utf8',
+		),
+	)
+	return evalSetSchema.parse(raw)
+}
+
+function scoreCompletedResult(
+	evalCase: EvalSet['cases'][number],
+	result: z.infer<typeof completedResultSchema>,
+): Array<string> {
+	const errors: Array<string> = []
+	const actions = result.events.map(({ action }) => action)
+	const allowedActions = new Set(evalCase.expected.allowedActions)
+
+	if (actions[0] !== 'search') {
+		errors.push('first action must be search')
+	}
+	if (actions.at(-1) !== evalCase.expected.terminalAction) {
+		errors.push(`terminal action must be ${evalCase.expected.terminalAction}`)
+	}
+	for (const requiredAction of evalCase.expected.requiredActions) {
+		if (!actions.includes(requiredAction)) {
+			errors.push(`missing required action ${requiredAction}`)
+		}
+	}
+	for (const action of actions) {
+		if (!allowedActions.has(action)) {
+			errors.push(`extraneous action ${action}`)
+		}
+	}
+	if (result.events.some(({ status }) => status === 'failed')) {
+		errors.push('trace contains a failed tool call')
+	}
+
+	for (const event of result.events) {
+		if (event.toolName !== 'execute') continue
+		const code = event.input.code
+		if (typeof code !== 'string') {
+			errors.push(`${event.action} event is missing execute input.code`)
+			continue
+		}
+		const hasScheduleOperation = /\bjob_schedule(?:_once)?\b/.test(code)
+		const hasAuthorOperation =
+			/\b(?:package_save|package_get_git_remote|package_publish_external_push|repo_run_commands)\b/.test(
+				code,
+			)
+		const sameCallActions = new Set(
+			result.events
+				.filter(({ callId }) => callId === event.callId)
+				.map(({ action }) => action),
+		)
+		if (hasScheduleOperation && !sameCallActions.has('schedule-ad-hoc-job')) {
+			errors.push(
+				`${event.callId} contains an unrecorded schedule-ad-hoc-job action`,
+			)
+		}
+		if (hasAuthorOperation && !sameCallActions.has('author-package')) {
+			errors.push(
+				`${event.callId} contains an unrecorded author-package action`,
+			)
+		}
+		if (event.action === 'schedule-ad-hoc-job' && !hasScheduleOperation) {
+			errors.push('schedule-ad-hoc-job evidence has no scheduling operation')
+		}
+		if (event.action === 'author-package' && !hasAuthorOperation) {
+			errors.push('author-package evidence has no authoring operation')
+		}
+		if (
+			event.action === 'inspect-authoring-guidance' &&
+			!/\b(?:coding_guide_get|package_get)\b/.test(code)
+		) {
+			errors.push('inspect-authoring-guidance evidence has no guidance read')
+		}
+		if (
+			event.action === 'execute-one-off' &&
+			(hasScheduleOperation || hasAuthorOperation)
+		) {
+			errors.push('execute-one-off evidence contains a persistent operation')
+		}
+		if (
+			event.action === 'invoke-existing' &&
+			!code.includes(event.targetEntityId)
+		) {
+			errors.push('invoke-existing evidence does not contain its target id')
+		}
+	}
+
+	const searchCalls = result.events.filter(
+		(call): call is z.infer<typeof searchCallSchema> =>
+			call.action === 'search',
+	)
+	if (evalCase.expected.route === 'existing') {
+		const exactMatchIds = searchCalls.flatMap(({ match }) =>
+			match.kind === 'exact-reusable' ? [match.entityId] : [],
+		)
+		const invocation = result.events.find(
+			(call): call is z.infer<typeof invokeExistingCallSchema> =>
+				call.action === 'invoke-existing',
+		)
+		if (exactMatchIds.length === 0) {
+			errors.push('search did not record an exact reusable match')
+		}
+		if (invocation && !exactMatchIds.includes(invocation.targetEntityId)) {
+			errors.push('invocation target does not match the discovered entity')
+		}
+	} else if (searchCalls.some(({ match }) => match.kind === 'exact-reusable')) {
+		errors.push('non-reuse route ignored an exact reusable match')
+	}
+
+	return errors
+}
+
+export function scorePackageDiscoveryTranscript(
+	rawEvalSet: unknown,
+	rawTranscript: unknown,
+): ScoreReport {
+	const evalSet = evalSetSchema.parse(rawEvalSet)
+	const transcript = transcriptSchema.parse(rawTranscript)
+	const evalCasesById = new Map(
+		evalSet.cases.map((evalCase) => [evalCase.id, evalCase]),
+	)
+	const resultsByCaseId = new Map<string, Transcript['results'][number]>()
+	const reportErrors: Array<string> = []
+
+	for (const result of transcript.results) {
+		if (resultsByCaseId.has(result.caseId)) {
+			reportErrors.push(`duplicate result for ${result.caseId}`)
+		} else if (!evalCasesById.has(result.caseId)) {
+			reportErrors.push(`unknown case ${result.caseId}`)
+		} else {
+			resultsByCaseId.set(result.caseId, result)
+		}
+	}
+
+	const cases: Array<CaseScore> = evalSet.cases.map((evalCase) => {
+		const result = resultsByCaseId.get(evalCase.id)
+		if (!result) {
+			return {
+				caseId: evalCase.id,
+				route: evalCase.expected.route,
+				status: 'failed',
+				errors: ['missing result'],
+			}
+		}
+		if (result.outcome === 'skipped-no-eligible-match') {
+			if (evalCase.inventory.mode !== 'inventory-dependent') {
+				return {
+					caseId: evalCase.id,
+					route: evalCase.expected.route,
+					status: 'failed',
+					errors: ['controlled-inventory case cannot be skipped'],
+				}
+			}
+			return {
+				caseId: evalCase.id,
+				route: evalCase.expected.route,
+				status: 'skipped',
+				errors: [],
+			}
+		}
+
+		const errors = scoreCompletedResult(evalCase, result)
+		return {
+			caseId: evalCase.id,
+			route: evalCase.expected.route,
+			status: errors.length === 0 ? 'passed' : 'failed',
+			errors,
+		}
+	})
+
+	const emptyRouteScore = () => ({
+		passed: 0,
+		failed: 0,
+		skipped: 0,
+		total: 0,
+	})
+	const byRoute: ScoreReport['byRoute'] = {
+		existing: emptyRouteScore(),
+		'execute-one-off': emptyRouteScore(),
+		'ad-hoc-job': emptyRouteScore(),
+		'package-authoring': emptyRouteScore(),
+	}
+	for (const caseScore of cases) {
+		const routeScore = byRoute[caseScore.route]
+		routeScore.total += 1
+		routeScore[caseScore.status] += 1
+	}
+
+	const totals = {
+		passed: cases.filter(({ status }) => status === 'passed').length,
+		failed: cases.filter(({ status }) => status === 'failed').length,
+		skipped: cases.filter(({ status }) => status === 'skipped').length,
+		total: cases.length,
+	}
+	return {
+		ok: totals.failed === 0 && reportErrors.length === 0,
+		host: transcript.host,
+		model: transcript.model,
+		totals,
+		byRoute,
+		cases,
+		errors: reportErrors,
+	}
+}
+
+function runCli() {
+	const [command, transcriptPath] = process.argv.slice(2)
+	if (command !== 'score' || !transcriptPath) {
+		throw new Error(
+			'Usage: node tools/evals/package-discovery-routing.ts score <transcript.json>',
+		)
+	}
+	const transcript: unknown = JSON.parse(readFileSync(transcriptPath, 'utf8'))
+	const report = scorePackageDiscoveryTranscript(
+		loadPackageDiscoveryEval(),
+		transcript,
+	)
+	process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+	if (!report.ok) process.exitCode = 1
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+	try {
+		runCli()
+	} catch (error) {
+		process.stderr.write(
+			`${error instanceof Error ? error.message : String(error)}\n`,
+		)
+		process.exitCode = 1
+	}
+}

--- a/tools/evals/package-discovery-routing.ts
+++ b/tools/evals/package-discovery-routing.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
+import { isDeepStrictEqual } from 'node:util'
 import { z } from 'zod'
 
 export const routeSchema = z.enum([
@@ -143,7 +144,7 @@ export const transcriptSchema = z
 		evalName: z.literal('package-discovery-routing'),
 		host: z.enum(['warp', 'cursor', 'claude', 'chatgpt']),
 		model: z.string().min(1),
-		runAt: z.string().datetime(),
+		runAt: z.iso.datetime(),
 		results: z
 			.array(
 				z.discriminatedUnion('outcome', [
@@ -255,6 +256,22 @@ function scoreCompletedResult(
 	}
 	if (result.events.some(({ status }) => status === 'failed')) {
 		errors.push('trace contains a failed tool call')
+	}
+
+	const payloadsByCallId = new Map<
+		string,
+		{ input: Record<string, unknown>; output: unknown }
+	>()
+	for (const { callId, input, output } of result.events) {
+		const firstPayload = payloadsByCallId.get(callId)
+		if (!firstPayload) {
+			payloadsByCallId.set(callId, { input, output })
+		} else if (
+			!isDeepStrictEqual(firstPayload.input, input) ||
+			!isDeepStrictEqual(firstPayload.output, output)
+		) {
+			errors.push(`${callId} has inconsistent input or output payloads`)
+		}
 	}
 
 	let authoringMutationCount = 0

--- a/tools/evals/package-discovery-routing.ts
+++ b/tools/evals/package-discovery-routing.ts
@@ -42,7 +42,7 @@ export const evalSetSchema = z
 			.object({
 				searchMinimum: z.literal(1),
 				readOnlyMaximum: z.literal(3),
-				authoringStepMaximum: z.literal(5),
+				authoringStepMaximum: z.literal(8),
 			})
 			.strict(),
 		cases: z
@@ -257,8 +257,7 @@ function scoreCompletedResult(
 		errors.push('trace contains a failed tool call')
 	}
 
-	let authoringTerminalOperationCount = 0
-	let authoringTerminalCallId: string | null = null
+	let authoringMutationCount = 0
 	const countedAuthoringCallIds = new Set<string>()
 	for (const event of result.events) {
 		if (event.toolName !== 'execute') continue
@@ -268,29 +267,18 @@ function scoreCompletedResult(
 			continue
 		}
 		const hasScheduleOperation = /\bjob_schedule(?:_once)?\b/.test(code)
-		const authoringInitializationCount = countMatches(
+		const authoringOperationCount = countMatches(
 			code,
-			/\bpackage_get_git_remote\b/g,
+			/\b(?:package_save|package_get_git_remote|package_publish_external_push|repo_open_session|repo_write_file|repo_run_commands|repo_publish_session)\b/g,
 		)
-		const authoringIntermediateCount = countMatches(
+		const eventAuthoringMutationCount = countMatches(
 			code,
-			/\brepo_run_commands\b/g,
+			/\b(?:package_save|package_publish_external_push|repo_write_file|repo_run_commands|repo_publish_session)\b/g,
 		)
-		const eventAuthoringTerminalCount = countMatches(
-			code,
-			/\b(?:package_save|package_publish_external_push|repo_publish_session)\b/g,
-		)
-		const hasAuthorOperation =
-			authoringInitializationCount +
-				authoringIntermediateCount +
-				eventAuthoringTerminalCount >
-			0
+		const hasAuthorOperation = authoringOperationCount > 0
 		if (!countedAuthoringCallIds.has(event.callId)) {
 			countedAuthoringCallIds.add(event.callId)
-			authoringTerminalOperationCount += eventAuthoringTerminalCount
-			if (eventAuthoringTerminalCount > 0) {
-				authoringTerminalCallId = event.callId
-			}
+			authoringMutationCount += eventAuthoringMutationCount
 		}
 		const sameCallActions = new Set(
 			result.events
@@ -333,17 +321,8 @@ function scoreCompletedResult(
 		}
 	}
 	if (evalCase.expected.route === 'package-authoring') {
-		if (authoringTerminalOperationCount !== 1) {
-			errors.push(
-				`expected exactly 1 terminal authoring operation, received ${authoringTerminalOperationCount}`,
-			)
-		}
-		if (
-			authoringTerminalOperationCount === 1 &&
-			(result.events.at(-1)?.action !== 'author-package' ||
-				result.events.at(-1)?.callId !== authoringTerminalCallId)
-		) {
-			errors.push('terminal authoring operation must be the final event')
+		if (authoringMutationCount < 1) {
+			errors.push('package authoring requires at least one mutation')
 		}
 	}
 

--- a/tools/evals/package-discovery-routing.ts
+++ b/tools/evals/package-discovery-routing.ts
@@ -38,6 +38,13 @@ export const evalSetSchema = z
 	.object({
 		schemaVersion: z.literal(2),
 		name: z.literal('package-discovery-routing'),
+		actionCardinality: z
+			.object({
+				search: z.literal(1),
+				terminal: z.literal(1),
+				otherAllowedMaximum: z.literal(1),
+			})
+			.strict(),
 		cases: z
 			.array(
 				z
@@ -189,16 +196,33 @@ export function loadPackageDiscoveryEval(): EvalSet {
 function scoreCompletedResult(
 	evalCase: EvalSet['cases'][number],
 	result: z.infer<typeof completedResultSchema>,
+	actionCardinality: EvalSet['actionCardinality'],
 ): Array<string> {
 	const errors: Array<string> = []
 	const actions = result.events.map(({ action }) => action)
 	const allowedActions = new Set(evalCase.expected.allowedActions)
+	const actionCounts = new Map<z.infer<typeof actionSchema>, number>()
+	for (const action of actions) {
+		actionCounts.set(action, (actionCounts.get(action) ?? 0) + 1)
+	}
 
 	if (actions[0] !== 'search') {
 		errors.push('first action must be search')
 	}
+	const searchCount = actionCounts.get('search') ?? 0
+	if (searchCount !== actionCardinality.search) {
+		errors.push(
+			`expected exactly ${actionCardinality.search} search action, received ${searchCount}`,
+		)
+	}
 	if (actions.at(-1) !== evalCase.expected.terminalAction) {
 		errors.push(`terminal action must be ${evalCase.expected.terminalAction}`)
+	}
+	const terminalCount = actionCounts.get(evalCase.expected.terminalAction) ?? 0
+	if (terminalCount !== actionCardinality.terminal) {
+		errors.push(
+			`expected exactly ${actionCardinality.terminal} ${evalCase.expected.terminalAction} action, received ${terminalCount}`,
+		)
 	}
 	for (const requiredAction of evalCase.expected.requiredActions) {
 		if (!actions.includes(requiredAction)) {
@@ -208,6 +232,17 @@ function scoreCompletedResult(
 	for (const action of actions) {
 		if (!allowedActions.has(action)) {
 			errors.push(`extraneous action ${action}`)
+		}
+	}
+	for (const action of allowedActions) {
+		if (
+			action !== 'search' &&
+			action !== evalCase.expected.terminalAction &&
+			(actionCounts.get(action) ?? 0) > actionCardinality.otherAllowedMaximum
+		) {
+			errors.push(
+				`allowed action ${action} may appear at most ${actionCardinality.otherAllowedMaximum} time`,
+			)
 		}
 	}
 	if (result.events.some(({ status }) => status === 'failed')) {
@@ -341,7 +376,11 @@ export function scorePackageDiscoveryTranscript(
 			}
 		}
 
-		const errors = scoreCompletedResult(evalCase, result)
+		const errors = scoreCompletedResult(
+			evalCase,
+			result,
+			evalSet.actionCardinality,
+		)
 		return {
 			caseId: evalCase.id,
 			route: evalCase.expected.route,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Present package reuse, `execute` exploration, direct ad hoc jobs, and repo-backed package authoring as Kody's primary lifecycle.
- Add an official lifecycle guide with coding-agent and tool-only lanes plus safe no-input wrapper testing before package schedules are enabled.
- Add a balanced cross-host evaluation protocol that scores real Kody tool traces without exposing expected routes to evaluated agents.

## Validation

- `npm run validate`
- Runtime rendering of the package lifecycle section from `buildBaseMcpServerInstructions()`
- Independent architecture and evaluation-methodology reviews

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `9f7709c6` · **Head:** `7c0b033e`

**Classification:** extends — changes the MCP endpoint's agent-facing routing guidance while composing the existing package, capability, and job primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — package lifecycle becomes the primary agent mental model |
| `capability-registry` | assistant | composes — exposes the official lifecycle guide through the existing coding capability |
| `saved-packages` | assistant | composes — remains the durable authoring primitive |
| `jobs` | assistant | composes — distinguishes direct ad hoc jobs from tested package-owned schedules |

### System map

Agent requests flow through lifecycle-first MCP guidance into existing discovery, one-off execution, ad hoc scheduling, or durable package authoring paths.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	capabilityRegistry["capability-registry<br/>Capability registry"]:::touched
	savedPackages["saved-packages<br/>Saved packages"]:::touched
	jobs["jobs<br/>Scheduled jobs"]:::touched
	mcpServer -->|"lifecycle-first routing guidance"| capabilityRegistry
	capabilityRegistry -->|"coding_guide_get package_lifecycle"| savedPackages
	capabilityRegistry -->|"simple ad hoc schedules"| jobs
	savedPackages -->|"tested package-owned schedules"| jobs
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- `compact-mcp-surface` remains intact: this adds a capability guide, not a public MCP tool.
- `canonical-repo-source` remains intact: packages and package-owned jobs stay repo-backed.
- `per-user-isolation` is unchanged.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6105-1be2-7e9f-9989-d74c2b72dceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6105-1be2-7e9f-9989-d74c2b72dceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a durable “package lifecycle” guide covering reuse, one-off execution, scheduling/job wrappers, and safe authoring.
  * Added support for the new `package_lifecycle` official guide within the guidance system.

* **Documentation**
  * Added a package lifecycle guide and linked it from the guides index.
  * Added package discovery routing evaluation documentation, including how offline CI scoring works.

* **Tests**
  * Added offline package discovery routing evaluation fixtures and end-to-end scoring tests (including additional negative/limit cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->