### PR TITLE
Handle legacy repo artifact RPC during publish

### DIFF
--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -1,6 +1,17 @@
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtime/package-artifact-targets.ts'
-import { formatErrorCauseChain } from '@kody-internal/shared/error-message.ts'
+import {
+	errorCauseChainIncludes,
+	formatErrorCauseChain,
+} from '@kody-internal/shared/error-message.ts'
+
+function isUnavailableLegacyArtifactRpc(error: unknown) {
+	return errorCauseChainIncludes(
+		error,
+		(message) =>
+			message === "Cannot read properties of undefined (reading 'bind')",
+	)
+}
 
 function describePackageArtifactTarget(
 	target: PublishedPackageArtifactBuildTarget,
@@ -43,6 +54,12 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 			userId: input.userId,
 		})
 	} catch (error) {
+		// Both artifact RPC methods and the `rebuildPackageArtifacts: false`
+		// publish option were introduced together. A pre-upgrade Durable Object
+		// therefore already rebuilt artifacts inside its successful publish call.
+		// Cloudflare reports a call to its missing follow-up method with this
+		// generic `.bind` TypeError.
+		if (isUnavailableLegacyArtifactRpc(error)) return
 		throw new Error(
 			buildRebuildFailureMessage({
 				sourceId: input.sourceId,

--- a/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
@@ -554,7 +554,7 @@ test('repo open → run commands → publish session workflow', async () => {
 	expect(publishRpc.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(2)
 })
 
-test('repo_publish_session covers base_moved repair, artifact rebuild, and rebuild failures', async () => {
+test('repo_publish_session covers base_moved repair, artifact rebuild, legacy RPC compatibility, and rebuild failures', async () => {
 	resetMocks()
 	const baseMovedRpc = createRepoRpc()
 	baseMovedRpc.getSessionInfo.mockResolvedValueOnce({
@@ -665,6 +665,49 @@ test('repo_publish_session covers base_moved repair, artifact rebuild, and rebui
 		},
 		baseUrl: 'https://heykody.dev',
 	})
+
+	resetMocks()
+	const legacyRpc = createRepoRpc()
+	legacyRpc.getSessionInfo.mockResolvedValueOnce({
+		id: 'session-1',
+		source_id: 'source-package-1',
+		source_root: '/',
+		base_commit: 'commit-old',
+		session_branch: 'sessions/session-1',
+		source_branch: 'main',
+		conversation_id: null,
+		last_checkpoint_commit: 'commit-old',
+		last_check_run_id: 'check-1',
+		last_check_tree_hash: 'tree-1',
+		expires_at: null,
+		created_at: '2026-04-18T00:01:00.000Z',
+		updated_at: '2026-04-18T00:02:00.000Z',
+		published_commit: 'commit-old',
+		manifest_path: 'package.json',
+		entity_type: 'package',
+	})
+	legacyRpc.publishSession.mockResolvedValueOnce({
+		status: 'ok',
+		sessionId: 'session-1',
+		publishedCommit: 'commit-new',
+		message: 'Published session.',
+	})
+	legacyRpc.listPublishedPackageArtifactTargets.mockRejectedValueOnce(
+		new TypeError("Cannot read properties of undefined (reading 'bind')"),
+	)
+	mockModule.repoSessionRpc.mockReturnValue(legacyRpc)
+
+	await expect(
+		repoPublishSessionCapability.handler(
+			{ session_id: 'session-1' },
+			createCapabilityContext(),
+		),
+	).resolves.toMatchObject({
+		status: 'ok',
+		session_id: 'session-1',
+		published_commit: 'commit-new',
+	})
+	expect(legacyRpc.rebuildPublishedPackageArtifact).not.toHaveBeenCalled()
 
 	resetMocks()
 	const rebuildFailureRpc = createRepoRpc()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fix `repo_publish_session` and `repo_run_commands(..., publish: true)` when a pre-upgrade RepoSession Durable Object has already completed artifact rebuilding but lacks the newer follow-up artifact RPC methods.

## Testing

- `npx vitest run --config vitest.node.config.ts packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts`
- `npm run validate`
- `git diff --check`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `b4d5ce8` · **Head:** `2f37bca`

**Classification:** extends — repo publishing now tolerates the exact legacy Durable Object missing-method error after a successful publish while preserving other rebuild failures.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — publish capabilities recognize the legacy RPC compatibility condition |
| `repo-sessions` | runtime | extends — successful pre-upgrade publish transactions no longer fail during the newer follow-up RPC step |
| `bundle-artifacts-kv` | storage | composes — legacy sessions retain their in-transaction artifact rebuild; current sessions keep the split rebuild flow |

### System map

Package publishing crosses the MCP capability into the RepoSession Durable Object, then follows either the legacy in-transaction rebuild or the current follow-up artifact RPC path.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	bundleArtifactsKv["bundle-artifacts-kv<br/>Bundle artifacts KV"]:::touched
	mcpServer -->|"repo publish + legacy missing-method compatibility"| repoSessions
	repoSessions -->|"legacy in-transaction or current follow-up artifact rebuild"| bundleArtifactsKv
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

The canonical repo source remains unchanged: compatibility handling only applies after `publishSession` returns success, when the legacy Durable Object has already finalized source and artifacts.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6805-3258-731f-885e-c0d7367ea804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6805-3258-731f-885e-c0d7367ea804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

