### PR TITLE
Revert legacy repo artifact RPC fallback

### DIFF
--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -1,17 +1,6 @@
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtime/package-artifact-targets.ts'
-import {
-	errorCauseChainIncludes,
-	formatErrorCauseChain,
-} from '@kody-internal/shared/error-message.ts'
-
-function isUnavailableLegacyArtifactRpc(error: unknown) {
-	return errorCauseChainIncludes(
-		error,
-		(message) =>
-			message === "Cannot read properties of undefined (reading 'bind')",
-	)
-}
+import { formatErrorCauseChain } from '@kody-internal/shared/error-message.ts'
 
 function describePackageArtifactTarget(
 	target: PublishedPackageArtifactBuildTarget,
@@ -54,12 +43,6 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 			userId: input.userId,
 		})
 	} catch (error) {
-		// Both artifact RPC methods and the `rebuildPackageArtifacts: false`
-		// publish option were introduced together. A pre-upgrade Durable Object
-		// therefore already rebuilt artifacts inside its successful publish call.
-		// Cloudflare reports a call to its missing follow-up method with this
-		// generic `.bind` TypeError.
-		if (isUnavailableLegacyArtifactRpc(error)) return
 		throw new Error(
 			buildRebuildFailureMessage({
 				sourceId: input.sourceId,

--- a/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
@@ -554,7 +554,7 @@ test('repo open → run commands → publish session workflow', async () => {
 	expect(publishRpc.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(2)
 })
 
-test('repo_publish_session covers base_moved repair, artifact rebuild, legacy RPC compatibility, and rebuild failures', async () => {
+test('repo_publish_session covers base_moved repair, artifact rebuild, and rebuild failures', async () => {
 	resetMocks()
 	const baseMovedRpc = createRepoRpc()
 	baseMovedRpc.getSessionInfo.mockResolvedValueOnce({
@@ -665,49 +665,6 @@ test('repo_publish_session covers base_moved repair, artifact rebuild, legacy RP
 		},
 		baseUrl: 'https://heykody.dev',
 	})
-
-	resetMocks()
-	const legacyRpc = createRepoRpc()
-	legacyRpc.getSessionInfo.mockResolvedValueOnce({
-		id: 'session-1',
-		source_id: 'source-package-1',
-		source_root: '/',
-		base_commit: 'commit-old',
-		session_branch: 'sessions/session-1',
-		source_branch: 'main',
-		conversation_id: null,
-		last_checkpoint_commit: 'commit-old',
-		last_check_run_id: 'check-1',
-		last_check_tree_hash: 'tree-1',
-		expires_at: null,
-		created_at: '2026-04-18T00:01:00.000Z',
-		updated_at: '2026-04-18T00:02:00.000Z',
-		published_commit: 'commit-old',
-		manifest_path: 'package.json',
-		entity_type: 'package',
-	})
-	legacyRpc.publishSession.mockResolvedValueOnce({
-		status: 'ok',
-		sessionId: 'session-1',
-		publishedCommit: 'commit-new',
-		message: 'Published session.',
-	})
-	legacyRpc.listPublishedPackageArtifactTargets.mockRejectedValueOnce(
-		new TypeError("Cannot read properties of undefined (reading 'bind')"),
-	)
-	mockModule.repoSessionRpc.mockReturnValue(legacyRpc)
-
-	await expect(
-		repoPublishSessionCapability.handler(
-			{ session_id: 'session-1' },
-			createCapabilityContext(),
-		),
-	).resolves.toMatchObject({
-		status: 'ok',
-		session_id: 'session-1',
-		published_commit: 'commit-new',
-	})
-	expect(legacyRpc.rebuildPublishedPackageArtifact).not.toHaveBeenCalled()
 
 	resetMocks()
 	const rebuildFailureRpc = createRepoRpc()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Revert #755. The legacy compatibility fallback is not desired, and the reported source state does not conclusively support the post-success RPC version-skew diagnosis.

## Testing

- `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `aac1e7e` · **Head:** `c8c88a7`

**Classification:** extends — restores the prior repo publish error behavior by removing the legacy Durable Object compatibility exception.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — removes legacy missing-method special handling |
| `repo-sessions` | runtime | extends — restores strict artifact follow-up RPC failures |

### System map

Repo publish again requires all current RepoSession artifact RPC calls to succeed.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	mcpServer -->|"strict repo publish artifact RPC flow"| repoSessions
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6805-3258-731f-885e-c0d7367ea804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6805-3258-731f-885e-c0d7367ea804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved published package artifact rebuild error handling.
  * Removed outdated compatibility behavior for a legacy artifact service failure.
  * Updated publish workflow handling and validation for artifact rebuild failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->