### PR TITLE
Skip no-op package job alarm synchronization

### DIFF
--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -16,8 +16,11 @@ import {
 	getJobInspection,
 	inspectJobsForUser,
 	runJobNow,
+	syncPackageJobsForPackage,
 	updateJob,
 } from './service.ts'
+import { listJobRowsByUserId } from './repo.ts'
+import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
 import {
 	type JobCreateInput,
 	type JobRecord,
@@ -1080,6 +1083,92 @@ function createBaseCallerContext(): PersistedJobCallerContext {
 		},
 	}) as PersistedJobCallerContext
 }
+
+test('package job sync reports scheduler changes for add, update, and remove only', async () => {
+	const env = {
+		APP_DB: createDatabase(),
+	} as Env
+	const input = {
+		env,
+		userId: 'user-1',
+		baseUrl: 'https://heykody.dev',
+		packageId: 'package-1',
+		sourceId: 'source-1',
+	}
+	const createManifest = (jobs: Record<string, unknown>) =>
+		parseAuthoredPackageJson({
+			content: JSON.stringify({
+				name: '@kentcdodds/cloudflare',
+				exports: {
+					'.': './index.ts',
+				},
+				kody: {
+					id: 'cloudflare',
+					description: 'Cloudflare package',
+					jobs,
+				},
+			}),
+		})
+
+	expect(
+		await syncPackageJobsForPackage({
+			...input,
+			manifest: createManifest({}),
+		}),
+	).toBe(false)
+
+	const intervalJob = {
+		'event-runner': {
+			entry: './src/jobs/event-runner.ts',
+			schedule: { type: 'interval', every: '1m' },
+			timezone: 'America/Denver',
+			enabled: true,
+		},
+	}
+	expect(
+		await syncPackageJobsForPackage({
+			...input,
+			manifest: createManifest(intervalJob),
+		}),
+	).toBe(true)
+	const rowsAfterAdd = await listJobRowsByUserId(env.APP_DB, input.userId)
+	expect(rowsAfterAdd).toHaveLength(1)
+	const nextRunAtAfterAdd = rowsAfterAdd[0]?.record.nextRunAt
+
+	expect(
+		await syncPackageJobsForPackage({
+			...input,
+			manifest: createManifest(intervalJob),
+		}),
+	).toBe(false)
+	const rowsAfterNoOp = await listJobRowsByUserId(env.APP_DB, input.userId)
+	expect(rowsAfterNoOp[0]?.record.nextRunAt).toBe(nextRunAtAfterAdd)
+
+	expect(
+		await syncPackageJobsForPackage({
+			...input,
+			manifest: createManifest({
+				'event-runner': {
+					...intervalJob['event-runner'],
+					schedule: { type: 'interval', every: '5m' },
+				},
+			}),
+		}),
+	).toBe(true)
+	const rowsAfterUpdate = await listJobRowsByUserId(env.APP_DB, input.userId)
+	expect(rowsAfterUpdate[0]?.record.schedule).toEqual({
+		type: 'interval',
+		every: '5m',
+	})
+
+	expect(
+		await syncPackageJobsForPackage({
+			...input,
+			manifest: createManifest({}),
+		}),
+	).toBe(true)
+	expect(await listJobRowsByUserId(env.APP_DB, input.userId)).toEqual([])
+})
 
 test('create, update, and delete jobs sync the job manager alarm', async () => {
 	const env = {

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -775,6 +775,7 @@ export async function syncPackageJobsForPackage(input: {
 	)
 	const desiredNames = new Set(Object.keys(desiredJobs))
 	const now = new Date().toISOString()
+	let schedulerStateChanged = false
 
 	for (const [jobName, definition] of Object.entries(desiredJobs)) {
 		const existing = existingByName.get(jobName)
@@ -782,6 +783,11 @@ export async function syncPackageJobsForPackage(input: {
 		const timezone = normalizeJobTimezone(definition.timezone)
 		const enabled = definition.enabled ?? true
 		if (existing) {
+			const schedulerStateMatches =
+				JSON.stringify(existing.record.schedule) === JSON.stringify(schedule) &&
+				existing.record.timezone === timezone &&
+				existing.record.enabled === enabled
+			if (schedulerStateMatches) continue
 			const updated: JobRecord = {
 				...existing.record,
 				name: jobName,
@@ -807,6 +813,7 @@ export async function syncPackageJobsForPackage(input: {
 					}),
 				),
 			})
+			schedulerStateChanged = true
 			continue
 		}
 
@@ -847,13 +854,16 @@ export async function syncPackageJobsForPackage(input: {
 				}),
 			),
 		})
+		schedulerStateChanged = true
 	}
 
 	for (const row of packageRows) {
 		if (desiredNames.has(row.name)) continue
 		await deleteJobRow(input.env.APP_DB, input.userId, row.id)
 		await deleteJobVector(input.env, row.id)
+		schedulerStateChanged = true
 	}
+	return schedulerStateChanged
 }
 
 export async function deletePackageJobsForSourceId(input: {

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -167,7 +167,7 @@ function setupDefaultMocks() {
 	mockModule.buildSavedPackageEmbedText.mockReturnValue('saved package embed')
 	mockModule.upsertSavedPackageVector.mockResolvedValue(undefined)
 	mockModule.buildPublishedPackageArtifacts.mockResolvedValue(undefined)
-	mockModule.syncPackageJobsForPackage.mockResolvedValue(undefined)
+	mockModule.syncPackageJobsForPackage.mockResolvedValue(false)
 	mockModule.syncJobManagerAlarm.mockResolvedValue(undefined)
 	mockModule.refreshPackageRetrieverManifestCache.mockResolvedValue(undefined)
 	mockModule.removePackageRetrieverManifestCacheEntries.mockResolvedValue(
@@ -195,6 +195,7 @@ function setupDefaultMocks() {
 
 test('refreshSavedPackageProjection resyncs the job manager after syncing package jobs', async () => {
 	setupDefaultMocks()
+	mockModule.syncPackageJobsForPackage.mockResolvedValue(true)
 	const env = createEnv()
 	const manifest = {
 		name: '@kentcdodds/shade-automation',
@@ -305,6 +306,31 @@ test('refreshSavedPackageProjection resyncs the job manager after syncing packag
 	)
 })
 
+test('refreshSavedPackageProjection skips job manager sync for a jobless first projection', async () => {
+	setupDefaultMocks()
+	const env = createEnv()
+	const manifest = {
+		name: '@kentcdodds/cloudflare',
+		kody: {
+			id: 'cloudflare',
+			description: 'Inert community fork',
+		},
+	}
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		manifest,
+		files: { 'package.json': '{}' },
+	})
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+	await refreshSavedPackageProjection({
+		env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		packageId: 'package-1',
+		sourceId: 'source-1',
+	})
+	expect(mockModule.syncJobManagerAlarm).not.toHaveBeenCalled()
+})
+
 test('refreshSavedPackageProjection omits files when artifact rebuild is skipped', async () => {
 	setupDefaultMocks()
 	const env = createEnv()
@@ -409,10 +435,7 @@ test('refreshSavedPackageProjection continues best-effort cleanup when dependent
 		sourceId: 'source-1',
 		manifest,
 	})
-	expect(mockModule.syncJobManagerAlarm).toHaveBeenCalledWith({
-		env: envAfterRetrieverFailure,
-		userId: 'user-1',
-	})
+	expect(mockModule.syncJobManagerAlarm).not.toHaveBeenCalled()
 	// The swallowed retriever-cache failure is still logged for operators.
 	expect(consoleError).toHaveBeenCalledTimes(1)
 
@@ -443,10 +466,7 @@ test('refreshSavedPackageProjection continues best-effort cleanup when dependent
 		packageId: 'package-1',
 		sourceId: 'source-1',
 	})
-	expect(mockModule.syncJobManagerAlarm).toHaveBeenCalledWith({
-		env: envAfterServiceFailure,
-		userId: 'user-1',
-	})
+	expect(mockModule.syncJobManagerAlarm).not.toHaveBeenCalled()
 })
 
 test('deleteSavedPackageProjection resyncs the job manager after removing package jobs', async () => {
@@ -580,10 +600,7 @@ test('deleteSavedPackageProjection continues best-effort cleanup when dependent 
 		env,
 		'package-1',
 	)
-	expect(mockModule.syncJobManagerAlarm).toHaveBeenCalledWith({
-		env,
-		userId: 'user-1',
-	})
+	expect(mockModule.syncJobManagerAlarm).not.toHaveBeenCalled()
 	// The swallowed entity source cleanup failure is still logged.
 	expect(consoleWarn).toHaveBeenCalledTimes(1)
 
@@ -606,10 +623,7 @@ test('deleteSavedPackageProjection continues best-effort cleanup when dependent 
 		env,
 		'package-1',
 	)
-	expect(mockModule.syncJobManagerAlarm).toHaveBeenCalledWith({
-		env,
-		userId: 'user-1',
-	})
+	expect(mockModule.syncJobManagerAlarm).not.toHaveBeenCalled()
 
 	setupDefaultMocks()
 	mockModule.getSavedPackageById.mockResolvedValue({

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -262,7 +262,7 @@ export async function refreshSavedPackageProjection(input: {
 		})
 	}
 	const { syncPackageJobsForPackage } = await import('#worker/jobs/service.ts')
-	await syncPackageJobsForPackage({
+	const schedulerStateChanged = await syncPackageJobsForPackage({
 		env: input.env,
 		userId: input.userId,
 		baseUrl: input.baseUrl,
@@ -289,10 +289,12 @@ export async function refreshSavedPackageProjection(input: {
 			// Auto-start failures should not block package job sync/alarm refresh.
 		}
 	}
-	await syncJobManagerAlarm({
-		env: input.env,
-		userId: input.userId,
-	})
+	if (schedulerStateChanged) {
+		await syncJobManagerAlarm({
+			env: input.env,
+			userId: input.userId,
+		})
+	}
 	return {
 		record: savedPackage,
 		manifest: loaded.manifest,
@@ -309,6 +311,7 @@ export async function deleteSavedPackageProjection(input: {
 		userId: input.userId,
 		packageId: input.packageId,
 	})
+	let packageJobsRemoved = false
 	if (savedPackage) {
 		const listedServices = await listSavedPackageServices({
 			env: input.env,
@@ -367,6 +370,7 @@ export async function deleteSavedPackageProjection(input: {
 		for (const row of packageRows) {
 			await deleteJobRow(input.env.APP_DB, input.userId, row.id)
 		}
+		packageJobsRemoved = packageRows.length > 0
 	}
 	await deleteAllPackageScopedSecrets({
 		env: input.env,
@@ -396,8 +400,10 @@ export async function deleteSavedPackageProjection(input: {
 		})
 	}
 	await deleteSavedPackageVector(input.env, input.packageId)
-	await syncJobManagerAlarm({
-		env: input.env,
-		userId: input.userId,
-	})
+	if (packageJobsRemoved) {
+		await syncJobManagerAlarm({
+			env: input.env,
+			userId: input.userId,
+		})
+	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Avoid contacting the JobManager when publishing or deleting a package does not change any scheduled jobs. This fixes jobless community-fork publication without legacy RPC error handling and preserves alarm synchronization for job additions, schedule changes, enablement changes, and removals.

## Testing

- `npx vitest run --project node-unit packages/worker/src/jobs/service.node.test.ts packages/worker/src/package-registry/service.node.test.ts`
- `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `8df899d` · **Head:** `f174078`

**Classification:** extends — package job projection now distinguishes scheduler-changing updates from no-op publishes and synchronizes the JobManager alarm only when needed.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — package projection reports whether job state changed |
| `jobs` | assistant | extends — unchanged jobs preserve their next run and skip alarm synchronization |
| `repo-sessions` | runtime | composes — jobless fork publication no longer crosses an unnecessary scheduler RPC boundary |
| `d1-app-db` | storage | composes — job rows remain user-scoped and mutate only for actual scheduler changes |

### System map

Package publication projects manifest jobs into D1 and contacts the JobManager only when that projection adds, changes, or removes scheduler state.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	repoSessions["repo-sessions<br/>Repo sessions"]:::touched
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	jobs["jobs<br/>Scheduled jobs"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::touched
	repoSessions -->|"publish package projection"| savedPackages
	savedPackages -->|"add/update/remove manifest jobs only"| jobs
	jobs -->|"user-scoped job row mutations"| d1AppDb
	savedPackages -->|"skip JobManager RPC when job projection is unchanged"| jobs
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

All package-job reads and writes remain scoped by `userId`; job additions, schedule/enablement changes, and removals still synchronize the per-user JobManager alarm.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6805-3258-731f-885e-c0d7367ea804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6805-3258-731f-885e-c0d7367ea804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package job synchronization to create, update, and remove scheduled jobs accurately.
  - Preserved job schedules when package definitions are unchanged.
  - Updated scheduler alarms only when package job state changes.
  - Avoided unnecessary alarm updates when packages contain no jobs or no job records were removed.
  - Improved cleanup behavior when related operations fail.

- **Tests**
  - Added coverage for job creation, schedule updates, removals, and no-op synchronization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->