### PR TITLE
Add MCP client tabs to onboarding with copyable configs

### DIFF
--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -1,13 +1,17 @@
 # Connect your agent
 
-Kody is an MCP server. You use it from Cursor, Claude Desktop, or any other AI
-agent that supports MCP — not from a separate Kody chat app.
+Kody is an MCP server. You use it from Cursor, Claude Desktop, Claude Code,
+Codex / ChatGPT, OpenCode, VS Code, or any other AI agent that supports MCP —
+not from a separate Kody chat app.
+
+The in-app Get started page (`/onboarding`) has tabs with client-specific
+instructions and copyable config snippets for the host you are on.
 
 ## Add the MCP server
 
-1. In your agent host, add a remote MCP server.
-2. Use this deployment’s MCP URL: `https://<this-host>/mcp`. The in-app Get
-   started page (`/onboarding`) shows the exact URL for the host you are on.
+1. Open Get started (`/onboarding`) and choose your client tab, or follow the
+   short notes below.
+2. Use this deployment’s MCP URL: `https://<this-host>/mcp`.
 3. Complete the OAuth flow when the host opens it. Sign in to Kody if needed,
    then approve access.
 
@@ -17,6 +21,29 @@ the email link or `/pending-verification`), then continue. You do not need to
 restart the host connection. Unverified visits to Get started (`/onboarding`)
 redirect to `/pending-verification`; after verification, onboarding shows the
 MCP URL and setup prompt.
+
+### Client notes
+
+- **Cursor** — Add a remote MCP server from Customize, or merge a
+  `mcpServers.kody.url` entry into `~/.cursor/mcp.json` / `.cursor/mcp.json`.
+- **Claude Desktop** — Use Settings → Connectors (custom connector + MCP URL).
+  Remote servers are not configured through `claude_desktop_config.json`.
+- **Claude Code** — `claude mcp add --transport http -s user kody <url>`, or a
+  `.mcp.json` entry with `"type": "http"`.
+- **Codex / ChatGPT** — ChatGPT web uses Developer mode + a connector/app URL.
+  Codex (desktop, CLI, IDE) shares `~/.codex/config.toml` with an
+  `[mcp_servers.kody]` `url` entry.
+- **OpenCode** — Add a `mcp.kody` remote entry in `opencode.json`
+  (`"type": "remote"`).
+- **VS Code** — Use `.vscode/mcp.json` with root key `servers` (not
+  `mcpServers`) and `"type": "http"`.
+
+### Coding vs non-coding agents
+
+Using Kody packages works great with non-coding agents such as Claude Desktop
+and ChatGPT. For creating or editing packages, a coding agent (Cursor, Claude
+Code, Codex, VS Code, OpenCode, and similar) is usually smoother because those
+hosts can edit files and iterate on code more easily.
 
 ## Ask your agent to help set up
 

--- a/e2e/invite-signup-verification.spec.ts
+++ b/e2e/invite-signup-verification.spec.ts
@@ -143,7 +143,12 @@ test('admin invite signup and email verification happy path', async ({
 	await expect(
 		page.getByRole('heading', { name: 'Add Kody as an MCP server' }),
 	).toBeVisible()
-	await expect(page.getByText(/\/mcp/)).toBeVisible()
+	await expect(
+		page.getByRole('tablist', { name: 'MCP client setup instructions' }),
+	).toBeVisible()
+	await expect(
+		page.getByRole('button', { name: 'Copy MCP URL' }).first(),
+	).toBeVisible()
 
 	await page.goto('/account')
 	await expect(

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -1,0 +1,230 @@
+import { type Handle, css } from 'remix/ui'
+import { Tab, TabList, TabPanel, Tabs } from 'remix/ui/tabs'
+import { CopyTextButton } from '#client/copy-text-button.tsx'
+import {
+	buildClaudeCodeAddCommand,
+	buildClaudeCodeMcpJson,
+	buildCodexMcpToml,
+	buildCursorMcpJson,
+	buildOpenCodeMcpJson,
+	buildVsCodeMcpJson,
+	codingAgentPackageHint,
+	mcpClientTabs,
+	nonCodingAgentNote,
+} from '#client/routes/onboarding-mcp-clients.ts'
+import { colors, spacing, typography } from '#client/styles/tokens.ts'
+import {
+	descriptionCss,
+	insetCardCss,
+} from '#client/styles/style-primitives.ts'
+
+type OnboardingMcpClientTabsProps = {
+	mcpServerUrl: string
+}
+
+function ConfigSnippet(handle: Handle<{ value: string; idleLabel: string }>) {
+	return () => (
+		<div mix={css(snippetWrapCss)}>
+			<pre mix={css(codeBlockCss)}>{handle.props.value}</pre>
+			<CopyTextButton
+				value={handle.props.value}
+				idleLabel={handle.props.idleLabel}
+				variant="secondary"
+			/>
+		</div>
+	)
+}
+
+function ClientNote(handle: Handle<{ children: string }>) {
+	return () => (
+		<p mix={css(noteCss)} role="note">
+			{handle.props.children}
+		</p>
+	)
+}
+
+export function OnboardingMcpClientTabs(
+	handle: Handle<OnboardingMcpClientTabsProps>,
+) {
+	return () => {
+		const mcpServerUrl = handle.props.mcpServerUrl
+		const cursorJson = buildCursorMcpJson(mcpServerUrl)
+		const claudeCodeJson = buildClaudeCodeMcpJson(mcpServerUrl)
+		const claudeCodeCommand = buildClaudeCodeAddCommand(mcpServerUrl)
+		const vsCodeJson = buildVsCodeMcpJson(mcpServerUrl)
+		const openCodeJson = buildOpenCodeMcpJson(mcpServerUrl)
+		const codexToml = buildCodexMcpToml(mcpServerUrl)
+
+		return (
+			<Tabs defaultActiveTab="cursor">
+				<TabList aria-label="MCP client setup instructions">
+					{mcpClientTabs.map((tab) => (
+						<Tab name={tab.id}>{tab.label}</Tab>
+					))}
+				</TabList>
+
+				<TabPanel name="cursor">
+					<p mix={css(descriptionCss)}>
+						In Cursor, open <strong>Customize</strong> and add a remote MCP
+						server with this URL, or merge the JSON below into{' '}
+						<code>~/.cursor/mcp.json</code> (global) or{' '}
+						<code>.cursor/mcp.json</code> (project).
+					</p>
+					<pre mix={css(codeBlockCss)}>{mcpServerUrl}</pre>
+					<div mix={css(buttonRowCss)}>
+						<CopyTextButton
+							value={mcpServerUrl}
+							idleLabel="Copy MCP URL"
+							variant="primary"
+						/>
+					</div>
+					<p mix={css(descriptionCss)}>
+						JSON config (merge under your existing <code>mcpServers</code> if
+						you already have one):
+					</p>
+					<ConfigSnippet value={cursorJson} idleLabel="Copy JSON" />
+					<ClientNote>{codingAgentPackageHint}</ClientNote>
+				</TabPanel>
+
+				<TabPanel name="codex-chatgpt">
+					<p mix={css(descriptionCss)}>
+						<strong>ChatGPT (web)</strong>: turn on Developer mode under
+						Settings → Security and login, then create a developer-mode app /
+						connector pointed at the MCP URL below. Complete OAuth when
+						prompted.
+					</p>
+					<pre mix={css(codeBlockCss)}>{mcpServerUrl}</pre>
+					<div mix={css(buttonRowCss)}>
+						<CopyTextButton
+							value={mcpServerUrl}
+							idleLabel="Copy MCP URL"
+							variant="primary"
+						/>
+					</div>
+					<ClientNote>{nonCodingAgentNote}</ClientNote>
+					<p mix={css(descriptionCss)}>
+						<strong>Codex</strong> (ChatGPT desktop, Codex CLI, and the IDE
+						extension) share <code>~/.codex/config.toml</code>. Add this
+						streamable HTTP entry, then run <code>codex mcp login kody</code> if
+						OAuth does not start automatically:
+					</p>
+					<ConfigSnippet value={codexToml} idleLabel="Copy TOML" />
+				</TabPanel>
+
+				<TabPanel name="claude-desktop">
+					<p mix={css(descriptionCss)}>
+						In Claude Desktop, open <strong>Settings → Connectors</strong> (or
+						Customize → Connectors), add a custom connector, and paste this MCP
+						URL. Claude Desktop handles remote OAuth through that UI — do not
+						put the remote URL into <code>claude_desktop_config.json</code>.
+					</p>
+					<pre mix={css(codeBlockCss)}>{mcpServerUrl}</pre>
+					<div mix={css(buttonRowCss)}>
+						<CopyTextButton
+							value={mcpServerUrl}
+							idleLabel="Copy MCP URL"
+							variant="primary"
+						/>
+					</div>
+					<ClientNote>{nonCodingAgentNote}</ClientNote>
+				</TabPanel>
+
+				<TabPanel name="claude-code">
+					<p mix={css(descriptionCss)}>
+						Prefer the CLI (user scope, all projects):
+					</p>
+					<ConfigSnippet value={claudeCodeCommand} idleLabel="Copy command" />
+					<p mix={css(descriptionCss)}>
+						Or merge this into a project <code>.mcp.json</code> (or the
+						user-scoped <code>mcpServers</code> block). Claude Code requires{' '}
+						<code>type: &quot;http&quot;</code> for remote servers:
+					</p>
+					<ConfigSnippet value={claudeCodeJson} idleLabel="Copy JSON" />
+					<ClientNote>{codingAgentPackageHint}</ClientNote>
+				</TabPanel>
+
+				<TabPanel name="opencode">
+					<p mix={css(descriptionCss)}>
+						Add this to your OpenCode config (<code>opencode.json</code> in the
+						project, or your global OpenCode config). OpenCode uses{' '}
+						<code>type: &quot;remote&quot;</code> and will start OAuth when
+						needed:
+					</p>
+					<ConfigSnippet value={openCodeJson} idleLabel="Copy JSON" />
+					<p mix={css(descriptionCss)}>
+						You can also run <code>opencode mcp add</code> and paste the URL
+						interactively, then <code>opencode mcp auth kody</code> if prompted.
+					</p>
+					<ClientNote>{codingAgentPackageHint}</ClientNote>
+				</TabPanel>
+
+				<TabPanel name="vscode">
+					<p mix={css(descriptionCss)}>
+						Create or edit <code>.vscode/mcp.json</code> in your workspace (or
+						open user MCP config via the{' '}
+						<strong>MCP: Open User Configuration</strong> command). VS Code uses
+						the root key <code>servers</code>, not <code>mcpServers</code>:
+					</p>
+					<ConfigSnippet value={vsCodeJson} idleLabel="Copy JSON" />
+					<p mix={css(descriptionCss)}>
+						Use Agent mode in Copilot Chat so MCP tools are available, then
+						complete OAuth when VS Code opens it.
+					</p>
+					<ClientNote>{codingAgentPackageHint}</ClientNote>
+				</TabPanel>
+
+				<TabPanel name="other">
+					<p mix={css(descriptionCss)}>
+						Any MCP-capable host that supports remote / streamable HTTP servers
+						can connect to Kody. Add a remote MCP server pointed at this URL and
+						complete the OAuth flow when the host opens it:
+					</p>
+					<pre mix={css(codeBlockCss)}>{mcpServerUrl}</pre>
+					<div mix={css(buttonRowCss)}>
+						<CopyTextButton
+							value={mcpServerUrl}
+							idleLabel="Copy MCP URL"
+							variant="primary"
+						/>
+					</div>
+					<p mix={css(descriptionCss)}>
+						Config file shapes differ by host. If your client expects a JSON{' '}
+						<code>mcpServers</code> map with a <code>url</code> field, start
+						from the Cursor snippet; if it uses <code>servers</code> with{' '}
+						<code>type: &quot;http&quot;</code>, use the VS Code snippet.
+					</p>
+				</TabPanel>
+			</Tabs>
+		)
+	}
+}
+
+const codeBlockCss = {
+	...insetCardCss,
+	margin: 0,
+	whiteSpace: 'pre-wrap' as const,
+	wordBreak: 'break-word' as const,
+	fontFamily: typography.fontFamily,
+	fontSize: typography.fontSize.sm,
+	lineHeight: 1.6,
+}
+
+const snippetWrapCss = {
+	display: 'grid',
+	gap: spacing.sm,
+}
+
+const buttonRowCss = {
+	display: 'flex',
+	gap: spacing.sm,
+	flexWrap: 'wrap' as const,
+}
+
+const noteCss = {
+	...descriptionCss,
+	margin: 0,
+	padding: spacing.md,
+	borderRadius: 'var(--radius-md)',
+	border: `1px solid ${colors.border}`,
+	background: colors.primarySoftest,
+}

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from 'vitest'
+import {
+	buildClaudeCodeAddCommand,
+	buildClaudeCodeMcpJson,
+	buildCodexMcpToml,
+	buildCursorMcpJson,
+	buildOpenCodeMcpJson,
+	buildVsCodeMcpJson,
+	mcpClientTabs,
+	nonCodingAgentNote,
+} from './onboarding-mcp-clients.ts'
+
+const mcpServerUrl = 'https://heykody.dev/mcp'
+
+test('mcp client tabs cover the popular hosts from onboarding', () => {
+	expect(mcpClientTabs.map((tab) => tab.id)).toEqual([
+		'cursor',
+		'codex-chatgpt',
+		'claude-desktop',
+		'claude-code',
+		'opencode',
+		'vscode',
+		'other',
+	])
+	expect(
+		mcpClientTabs.filter((tab) => tab.isNonCodingAgent).map((tab) => tab.id),
+	).toEqual(['codex-chatgpt', 'claude-desktop'])
+	expect(nonCodingAgentNote).toMatch(/coding agent/i)
+})
+
+test('Cursor JSON uses mcpServers with a remote url', () => {
+	expect(JSON.parse(buildCursorMcpJson(mcpServerUrl))).toEqual({
+		mcpServers: {
+			kody: {
+				url: mcpServerUrl,
+			},
+		},
+	})
+})
+
+test('Claude Code JSON requires type http for remote servers', () => {
+	expect(JSON.parse(buildClaudeCodeMcpJson(mcpServerUrl))).toEqual({
+		mcpServers: {
+			kody: {
+				type: 'http',
+				url: mcpServerUrl,
+			},
+		},
+	})
+	expect(buildClaudeCodeAddCommand(mcpServerUrl)).toBe(
+		`claude mcp add --transport http -s user kody ${mcpServerUrl}`,
+	)
+})
+
+test('VS Code JSON uses servers root key with type http', () => {
+	expect(JSON.parse(buildVsCodeMcpJson(mcpServerUrl))).toEqual({
+		servers: {
+			kody: {
+				type: 'http',
+				url: mcpServerUrl,
+			},
+		},
+	})
+})
+
+test('OpenCode JSON uses mcp remote type', () => {
+	expect(JSON.parse(buildOpenCodeMcpJson(mcpServerUrl))).toEqual({
+		mcp: {
+			kody: {
+				type: 'remote',
+				url: mcpServerUrl,
+				enabled: true,
+			},
+		},
+	})
+})
+
+test('Codex TOML is a streamable HTTP mcp_servers entry', () => {
+	expect(buildCodexMcpToml(mcpServerUrl)).toBe(
+		['[mcp_servers.kody]', `url = "${mcpServerUrl}"`, ''].join('\n'),
+	)
+})

--- a/packages/worker/client/routes/onboarding-mcp-clients.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.ts
@@ -1,0 +1,101 @@
+/**
+ * Per-client MCP setup snippets and copy for the onboarding page.
+ * Keep this module free of Remix/UI so config builders stay unit-testable.
+ */
+
+export type McpClientKind =
+	| 'cursor'
+	| 'codex-chatgpt'
+	| 'claude-desktop'
+	| 'claude-code'
+	| 'opencode'
+	| 'vscode'
+	| 'other'
+
+export type McpClientTab = {
+	id: McpClientKind
+	label: string
+	/** True for hosts that are primarily chat/non-coding agents. */
+	isNonCodingAgent: boolean
+}
+
+export const mcpClientTabs = [
+	{ id: 'cursor', label: 'Cursor', isNonCodingAgent: false },
+	{ id: 'codex-chatgpt', label: 'Codex / ChatGPT', isNonCodingAgent: true },
+	{ id: 'claude-desktop', label: 'Claude Desktop', isNonCodingAgent: true },
+	{ id: 'claude-code', label: 'Claude Code', isNonCodingAgent: false },
+	{ id: 'opencode', label: 'OpenCode', isNonCodingAgent: false },
+	{ id: 'vscode', label: 'VS Code', isNonCodingAgent: false },
+	{ id: 'other', label: 'Other', isNonCodingAgent: false },
+] as const satisfies ReadonlyArray<McpClientTab>
+
+export const nonCodingAgentNote =
+	'Using Kody packages works great with non-coding agents. For creating or editing packages, a coding agent such as Cursor, Claude Code, Codex, VS Code, or OpenCode is usually smoother — those hosts can edit files and iterate on code more easily.'
+
+export const codingAgentPackageHint =
+	'Coding agents are the best fit when you want to create or edit Kody packages. Once a package exists, non-coding agents can use it just fine.'
+
+function prettyJson(value: unknown) {
+	return `${JSON.stringify(value, null, 2)}\n`
+}
+
+/** Cursor `~/.cursor/mcp.json` or `.cursor/mcp.json` remote server entry. */
+export function buildCursorMcpJson(mcpServerUrl: string) {
+	return prettyJson({
+		mcpServers: {
+			kody: {
+				url: mcpServerUrl,
+			},
+		},
+	})
+}
+
+/** Claude Code project `.mcp.json` or user-scoped `mcpServers` entry. */
+export function buildClaudeCodeMcpJson(mcpServerUrl: string) {
+	return prettyJson({
+		mcpServers: {
+			kody: {
+				type: 'http',
+				url: mcpServerUrl,
+			},
+		},
+	})
+}
+
+export function buildClaudeCodeAddCommand(mcpServerUrl: string) {
+	return `claude mcp add --transport http -s user kody ${mcpServerUrl}`
+}
+
+/** VS Code Copilot `.vscode/mcp.json` (root key is `servers`, not `mcpServers`). */
+export function buildVsCodeMcpJson(mcpServerUrl: string) {
+	return prettyJson({
+		servers: {
+			kody: {
+				type: 'http',
+				url: mcpServerUrl,
+			},
+		},
+	})
+}
+
+/** OpenCode `opencode.json` remote server entry. */
+export function buildOpenCodeMcpJson(mcpServerUrl: string) {
+	return prettyJson({
+		mcp: {
+			kody: {
+				type: 'remote',
+				url: mcpServerUrl,
+				enabled: true,
+			},
+		},
+	})
+}
+
+/** Codex / ChatGPT desktop shared `~/.codex/config.toml` streamable HTTP entry. */
+export function buildCodexMcpToml(mcpServerUrl: string) {
+	return [
+		'[mcp_servers.kody]',
+		`url = ${JSON.stringify(mcpServerUrl)}`,
+		'',
+	].join('\n')
+}

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -20,12 +20,13 @@ import {
 	AccountManagementShell,
 } from '#client/routes/account-management-components.tsx'
 import { renderByokExplainer } from '#client/routes/byok-explainer.tsx'
+import { OnboardingMcpClientTabs } from '#client/routes/onboarding-mcp-client-tabs.tsx'
 import {
 	onboardingPath,
 	resolveOnboardingLoginPath,
 	resolveOnboardingPendingVerificationPath,
 } from '#client/routes/onboarding-redirect.ts'
-import { colors, spacing, typography } from '#client/styles/tokens.ts'
+import { colors, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
 	cardTitleCss,
@@ -215,28 +216,12 @@ export function OnboardingRoute(handle: Handle) {
 						<section mix={css(cardCss)}>
 							<h2 mix={css(cardTitleCss)}>1. Add Kody as an MCP server</h2>
 							<p mix={css(descriptionCss)}>
-								In Cursor, Claude Desktop, or any other AI agent that supports
-								MCP, add a remote MCP server pointed at this URL:
+								Pick your MCP client below for host-specific setup. When the
+								agent connects, it starts an OAuth flow — sign in to Kody if
+								needed, approve the request, and the agent receives a token
+								scoped to your account.
 							</p>
-							<pre mix={css(codeBlockCss)}>{mcpServerUrl}</pre>
-							<div
-								mix={css({
-									display: 'flex',
-									gap: spacing.sm,
-									flexWrap: 'wrap',
-								})}
-							>
-								<CopyTextButton
-									value={mcpServerUrl}
-									idleLabel="Copy MCP URL"
-									variant="primary"
-								/>
-							</div>
-							<p mix={css(descriptionCss)}>
-								When your agent connects, it starts an OAuth flow. Sign in to
-								Kody if needed, approve the request, and the agent receives a
-								token scoped to your account.
-							</p>
+							<OnboardingMcpClientTabs mcpServerUrl={mcpServerUrl} />
 						</section>
 
 						<section mix={css(cardCss)}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replace the generic “paste this MCP URL” onboarding step with a Remix tabs UI covering Cursor, Codex/ChatGPT, Claude Desktop, Claude Code, OpenCode, VS Code, and Other.
- Clients that still need config edits get copyable JSON/TOML snippets (with copy buttons). Claude Desktop and ChatGPT web stay UI-first.
- Non-coding agent tabs note that using packages works fine there, while coding agents are recommended for creating/editing packages.
- Document the same guidance in `docs/use/connect-your-agent.md`.

## Test plan

- [x] Unit tests for per-client config builders
- [x] `npm run typecheck`
- [ ] CI green
- [ ] Manual: open `/onboarding`, switch tabs, copy JSON/TOML/URL

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/onboarding-mcp-client-tabs-a1b2`

**Classification:** composes — no primitives added or changed; this PR wires existing UI and onboarding surfaces together with client-specific copy and config snippets.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — onboarding route gains MCP client tabs + copyable configs |
| `mcp-server` | surfaces | composes — documents how hosts connect to `/mcp` (no server changes) |

### System map

```mermaid
flowchart LR
  Onboarding["/onboarding UI"] --> Tabs["Client tabs"]
  Tabs --> Cursor["Cursor JSON / UI"]
  Tabs --> Codex["Codex TOML / ChatGPT UI"]
  Tabs --> Claude["Claude Desktop UI / Claude Code"]
  Tabs --> Others["OpenCode / VS Code / Other"]
  Cursor --> MCP["/mcp OAuth"]
  Codex --> MCP
  Claude --> MCP
  Others --> MCP
```

### Risk notes

- Low risk UI/docs change only; no auth, storage, or MCP protocol changes.
- Config snippets are host-specific; wrong root keys (e.g. VS Code `servers` vs `mcpServers`) are called out explicitly.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6bbb-0a30-73ca-81ba-bd8073376d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6bbb-0a30-73ca-81ba-bd8073376d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-tab MCP onboarding UI with client-specific setup for Cursor, Claude Desktop, Claude Code, Codex/ChatGPT, OpenCode, VS Code, and other agents.
  * Included ready-to-copy MCP URL and generated configuration snippets/commands directly in the onboarding step.
  * Added clearer guidance for coding vs non-coding agents when using Kody packages.
* **Documentation**
  * Updated connection instructions to use MCP-capable agents and to follow the onboarding page’s client tabs and `https://<this-host>/mcp` URL.
* **Tests**
  * Updated onboarding verification to assert the MCP client setup UI, and added coverage for generated configuration outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->