### PR TITLE
Add featured community listings surfaced as onboarding starter packages

### DIFF
--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -211,14 +211,16 @@ primitives:
       deployment; inert forks, one-click install (UI-only fork + publish checks
       + immediate activation, with an acknowledgement gate for untrusted
       listings), ratings, user reports, admin moderation at
-      /admin/community-reports, commit-pinned admin trust marks, /community
-      routes, and lazily derived package icons that track the owner package's
-      current published commit.
+      /admin/community-reports, commit-pinned admin trust marks, admin featured
+      marks that surface trusted listings as onboarding starter packages,
+      /community routes, and lazily derived package icons that track the owner
+      package's current published commit.
     code:
       - packages/worker/src/community/
       - packages/worker/src/mcp/capabilities/community/
       - packages/worker/migrations/0045-community-listings.sql
       - packages/worker/migrations/0059-community-trusted-listings.sql
+      - packages/worker/migrations/0060-community-featured-listings.sql
       - packages/worker/src/app/handlers/community*
       - packages/worker/src/app/handlers/admin-community-reports*
       - packages/worker/client/routes/community*

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -61,6 +61,19 @@ mark; delisted listings cannot be trusted. Surfaces: the `Trusted` badge on
 `community_set_trusted` capability. `community_search` and `community_get`
 expose the effective `trusted` flag.
 
+Admin **featured** marks live in `featured_at` (migration
+`0060-community-featured-listings.sql`) and highlight onboarding starter
+packages. `setCommunityListingFeatured` in `service.ts` requires the listing to
+be effectively trusted before featuring; the effective `featured` flag
+(`featured_at IS NOT NULL AND trusted`) is computed in `repo.ts`, so an owner
+republish that drops trust also pulls the listing from onboarding while keeping
+the stored mark. `listFeaturedCommunityListings` feeds the onboarding page (slim
+`OnboardingFeaturedListing` shapes, capped at 6). Surfaces: the `Featured` badge
+on the detail page, the admin-only toggle
+(`POST /community/:listingId/feature.json`, audited), the admin-only
+`community_set_featured` capability, and the onboarding "Install a starter
+package" step. `community_get` exposes the effective `featured` flag.
+
 Reports survive listing deletion via denormalized listing name and owner on the
 report row.
 
@@ -155,6 +168,7 @@ Capabilities:
 - `community_rate`
 - `community_report`
 - `community_set_trusted` (admin-only via `requiredRole`)
+- `community_set_featured` (admin-only via `requiredRole`)
 
 Register the domain in `builtinDomains` and `capabilityDomainNames` like other
 builtin domains (see [Adding capabilities](./adding-kody.md)). Do not surface

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -151,6 +151,19 @@ publishing it into your account.
 Admins toggle trust from the listing detail page or with the
 `community_set_trusted` capability.
 
+## Featured listings
+
+Admins can additionally mark trusted listings as **featured**. Featured listings
+appear on the onboarding page (`/onboarding`) as starter packages new users can
+one-click install. Only trusted listings can be featured, and a listing is only
+_shown_ in onboarding while it remains effectively trusted: when the owner
+republishes, it silently drops out of onboarding until an admin re-trusts the
+new version (the featured mark itself is kept, so re-trusting restores it).
+
+Featured listings show a **Featured** badge on their detail page. Admins toggle
+featuring from the listing detail page or with the `community_set_featured`
+capability.
+
 ## Ratings
 
 After forking, your agent can call `community_rate` with:
@@ -191,6 +204,8 @@ Use the MCP `community` domain:
 - `community_report` — report a listing (requires login)
 - `community_set_trusted` — admin-only: mark or unmark a listing as trusted at
   its current pinned commit
+- `community_set_featured` — admin-only: feature or unfeature a trusted listing
+  as an onboarding starter package
 
 ## Privacy and isolation
 

--- a/e2e/community-featured.spec.ts
+++ b/e2e/community-featured.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test } from './playwright-utils.ts'
+import { seedCommunityListingInE2eDatabase } from './d1-utils.ts'
+
+test('admins can feature trusted listings and members see them in onboarding', async ({
+	page,
+	seedE2eUser,
+	login,
+}) => {
+	const runId = Date.now()
+	const trustedListingId = `e2e-featured-listing-${runId}`
+	const trustedListingName = `@kody/featured-package-${runId}`
+	const untrustedListingId = `e2e-unfeaturable-listing-${runId}`
+	const adminUser = await seedE2eUser({
+		email: `featured-admin-${runId}@example.com`,
+		username: `featured-admin-${runId}`,
+		password: 'featured-admin-password',
+		admin: true,
+	})
+	const memberUser = await seedE2eUser({
+		email: `featured-member-${runId}@example.com`,
+		username: `featured-member-${runId}`,
+		password: 'featured-member-password',
+	})
+	await seedCommunityListingInE2eDatabase({
+		listingId: trustedListingId,
+		ownerEmail: memberUser.email,
+		name: trustedListingName,
+		description: 'Trusted listing seeded for the featured e2e test.',
+		tags: ['featured'],
+		trusted: true,
+	})
+	await seedCommunityListingInE2eDatabase({
+		listingId: untrustedListingId,
+		ownerEmail: memberUser.email,
+		name: `@kody/unfeaturable-package-${runId}`,
+		description: 'Untrusted listing seeded for the featured e2e test.',
+		tags: ['featured'],
+	})
+
+	// Non-admin members never see the featuring controls and cannot hit the
+	// API.
+	await login({
+		email: memberUser.email,
+		password: memberUser.password,
+		mode: 'login',
+	})
+	await page.goto(`/community/${trustedListingId}`)
+	await expect(page.getByText('Fork with your agent')).toBeVisible()
+	await expect(page.getByTestId('community-admin-feature')).toHaveCount(0)
+	const memberFeatureResponse = await page.request.post(
+		`/community/${trustedListingId}/feature.json`,
+		{
+			data: { featured: true },
+			headers: { 'Content-Type': 'application/json' },
+		},
+	)
+	expect(memberFeatureResponse.status()).toBe(403)
+
+	// Without any featured listings, onboarding falls back to the browse CTA.
+	await page.goto('/onboarding')
+	await expect(
+		page.getByRole('heading', { name: 'Explore community packages' }),
+	).toBeVisible()
+	await expect(page.getByTestId('onboarding-starter-packages')).toHaveCount(0)
+
+	// Admins can feature the trusted listing from the detail page.
+	await page.context().clearCookies()
+	await login({
+		email: adminUser.email,
+		password: adminUser.password,
+		mode: 'login',
+	})
+	await page.goto(`/community/${trustedListingId}`)
+	await expect(page.getByTestId('community-admin-feature')).toBeVisible()
+	await page.getByRole('button', { name: 'Feature in onboarding' }).click()
+	await expect(
+		page.getByRole('button', { name: 'Remove from onboarding' }),
+	).toBeVisible()
+	await expect(
+		page.getByTestId('community-detail-featured-badge'),
+	).toBeVisible()
+
+	// Untrusted listings cannot be featured: the button stays disabled.
+	await page.goto(`/community/${untrustedListingId}`)
+	await expect(
+		page.getByRole('button', { name: 'Feature in onboarding' }),
+	).toBeDisabled()
+	await expect(
+		page.getByText('Only trusted listings can be featured in onboarding.'),
+	).toBeVisible()
+
+	// Members now see the featured listing as an onboarding starter package.
+	await page.context().clearCookies()
+	await login({
+		email: memberUser.email,
+		password: memberUser.password,
+		mode: 'login',
+	})
+	await page.goto('/onboarding')
+	await expect(page.getByTestId('onboarding-starter-packages')).toBeVisible()
+	const starterLink = page.getByTestId(`onboarding-starter-${trustedListingId}`)
+	await expect(starterLink).toBeVisible()
+	await expect(starterLink).toContainText(trustedListingName)
+	await starterLink.click()
+	await expect(page).toHaveURL(new RegExp(`/community/${trustedListingId}$`))
+	await expect(
+		page.getByRole('button', { name: 'Install', exact: true }),
+	).toBeVisible()
+
+	// Removing the mark pulls the listing from onboarding again.
+	await page.context().clearCookies()
+	await login({
+		email: adminUser.email,
+		password: adminUser.password,
+		mode: 'login',
+	})
+	await page.goto(`/community/${trustedListingId}`)
+	await page.getByRole('button', { name: 'Remove from onboarding' }).click()
+	await expect(
+		page.getByRole('button', { name: 'Feature in onboarding' }),
+	).toBeVisible()
+	await expect(page.getByTestId('community-detail-featured-badge')).toHaveCount(
+		0,
+	)
+	await page.goto('/onboarding')
+	await expect(
+		page.getByRole('heading', { name: 'Explore community packages' }),
+	).toBeVisible()
+	await expect(page.getByTestId('onboarding-starter-packages')).toHaveCount(0)
+})

--- a/e2e/d1-utils.ts
+++ b/e2e/d1-utils.ts
@@ -120,6 +120,9 @@ export async function seedCommunityListingInE2eDatabase(input: {
 	readmeContent?: string | null
 	sourceId?: string
 	trusted?: boolean
+	/** Implies nothing about trust: pass `trusted: true` too for an
+	 * effectively featured (onboarding-visible) listing. */
+	featured?: boolean
 }) {
 	const ownerUserId = await createStableUserIdFromEmail(input.ownerEmail)
 	const tagsJson = JSON.stringify(input.tags ?? [])
@@ -134,6 +137,7 @@ export async function seedCommunityListingInE2eDatabase(input: {
 		? quoteSqlString('e2e-seeded-admin')
 		: 'NULL'
 	const trustedAt = input.trusted ? 'CURRENT_TIMESTAMP' : 'NULL'
+	const featuredAt = input.featured ? 'CURRENT_TIMESTAMP' : 'NULL'
 	const sql = `
 INSERT INTO community_listings (
 	id,
@@ -150,7 +154,8 @@ INSERT INTO community_listings (
 	status,
 	trusted_commit,
 	trusted_by_user_id,
-	trusted_at
+	trusted_at,
+	featured_at
 ) VALUES (
 	${quoteSqlString(input.listingId)},
 	${quoteSqlString(ownerUserId)},
@@ -166,7 +171,8 @@ INSERT INTO community_listings (
 	'active',
 	${trustedCommit},
 	${trustedByUserId},
-	${trustedAt}
+	${trustedAt},
+	${featuredAt}
 )
 ON CONFLICT(id) DO UPDATE SET
 	owner_user_id = excluded.owner_user_id,
@@ -178,6 +184,7 @@ ON CONFLICT(id) DO UPDATE SET
 	trusted_commit = excluded.trusted_commit,
 	trusted_by_user_id = excluded.trusted_by_user_id,
 	trusted_at = excluded.trusted_at,
+	featured_at = excluded.featured_at,
 	updated_at = CURRENT_TIMESTAMP;`.trim()
 	executeE2eD1Command(sql)
 	// Icon requests resolve through the listing's KV snapshot; without one the

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -109,6 +109,7 @@ export async function communityDetailRouteLoader(
 			loggedIn: payload.loggedIn,
 			viewerIsAdmin: payload.viewerIsAdmin,
 			trusted: payload.listing.trusted,
+			featured: payload.listing.featured,
 			readmeContent: payload.listing.readmeContent,
 		},
 	}
@@ -125,6 +126,9 @@ export function CommunityDetailRoute(handle: Handle) {
 	let trusted = false
 	let trustState: 'idle' | 'submitting' | 'error' = 'idle'
 	let trustMessage: string | null = null
+	let featured = false
+	let featureState: 'idle' | 'submitting' | 'error' = 'idle'
+	let featureMessage: string | null = null
 	let installState: 'idle' | 'confirming' | 'submitting' | 'error' = 'idle'
 	let installMessage: string | null = null
 	let installOutcome: CommunityInstallOutcome | null = null
@@ -178,6 +182,9 @@ export function CommunityDetailRoute(handle: Handle) {
 			trusted = payload.listing.trusted
 			trustState = 'idle'
 			trustMessage = null
+			featured = payload.listing.featured
+			featureState = 'idle'
+			featureMessage = null
 			installState = 'idle'
 			installMessage = null
 			installOutcome = null
@@ -266,6 +273,9 @@ export function CommunityDetailRoute(handle: Handle) {
 			}
 			trusted = payload.trusted ?? nextTrusted
 			trustState = 'idle'
+			// Featuring is only effective while the listing is trusted, so
+			// revoking trust also pulls it from onboarding immediately.
+			if (!trusted) featured = false
 			handle.update()
 			// The trusted badge renders inside the server frame; reload it so
 			// the header reflects the new state immediately.
@@ -275,6 +285,50 @@ export function CommunityDetailRoute(handle: Handle) {
 			trustState = 'error'
 			trustMessage =
 				error instanceof Error ? error.message : 'Unable to update trust.'
+			handle.update()
+		}
+	}
+
+	async function submitFeature(nextFeatured: boolean) {
+		const listingId = getCurrentListingId(handle)
+		if (!listingId || featureState === 'submitting') return
+
+		featureState = 'submitting'
+		featureMessage = null
+		handle.update()
+
+		try {
+			const response = await fetch(
+				routes.communityFeatureApiPost.href({ listingId }),
+				{
+					method: 'POST',
+					headers: {
+						Accept: 'application/json',
+						'Content-Type': 'application/json',
+					},
+					credentials: 'include',
+					body: JSON.stringify({ featured: nextFeatured }),
+				},
+			)
+			const payload = await readJson<{
+				ok: boolean
+				featured?: boolean
+				error?: string
+			}>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error(payload?.error ?? 'Unable to update featuring.')
+			}
+			featured = payload.featured ?? nextFeatured
+			featureState = 'idle'
+			handle.update()
+			// The featured badge renders inside the server frame; reload it so
+			// the header reflects the new state immediately.
+			const frame = handle.frames.get(COMMUNITY_DETAIL_TARGET)
+			if (frame) void frame.reload()
+		} catch (error) {
+			featureState = 'error'
+			featureMessage =
+				error instanceof Error ? error.message : 'Unable to update featuring.'
 			handle.update()
 		}
 	}
@@ -421,6 +475,9 @@ export function CommunityDetailRoute(handle: Handle) {
 		trusted = routeData.trusted
 		trustState = 'idle'
 		trustMessage = null
+		featured = routeData.featured
+		featureState = 'idle'
+		featureMessage = null
 		installState = 'idle'
 		installMessage = null
 		installOutcome = null
@@ -699,6 +756,39 @@ export function CommunityDetailRoute(handle: Handle) {
 								{trustMessage ? (
 									<p mix={css({ margin: 0, color: colors.error })} role="alert">
 										{trustMessage}
+									</p>
+								) : null}
+							</section>
+						) : null}
+
+						{viewerIsAdmin ? (
+							<section mix={css(cardCss)} data-testid="community-admin-feature">
+								<h2 mix={css(cardTitleCss)}>Admin: onboarding</h2>
+								<p mix={css(descriptionCss)}>
+									{featured
+										? 'This listing is featured as an onboarding starter package. Removing it hides it from onboarding immediately.'
+										: trusted
+											? 'Featuring offers this listing for one-click install during onboarding. A republish by the owner drops it from onboarding until the new version is re-trusted.'
+											: 'Only trusted listings can be featured in onboarding. Mark the listing trusted first.'}
+								</p>
+								<button
+									disabled={
+										featureState === 'submitting' || (!featured && !trusted)
+									}
+									mix={[
+										on('click', () => void submitFeature(!featured)),
+										css(secondaryButtonCss),
+									]}
+								>
+									{featureState === 'submitting'
+										? 'Saving…'
+										: featured
+											? 'Remove from onboarding'
+											: 'Feature in onboarding'}
+								</button>
+								{featureMessage ? (
+									<p mix={css({ margin: 0, color: colors.error })} role="alert">
+										{featureMessage}
 									</p>
 								) : null}
 							</section>

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -266,6 +266,7 @@ export function CommunityDetailRoute(handle: Handle) {
 			const payload = await readJson<{
 				ok: boolean
 				trusted?: boolean
+				featured?: boolean
 				error?: string
 			}>(response)
 			if (!response.ok || !payload?.ok) {
@@ -273,9 +274,10 @@ export function CommunityDetailRoute(handle: Handle) {
 			}
 			trusted = payload.trusted ?? nextTrusted
 			trustState = 'idle'
-			// Featuring is only effective while the listing is trusted, so
-			// revoking trust also pulls it from onboarding immediately.
-			if (!trusted) featured = false
+			// Featuring is only effective while the listing is trusted: revoking
+			// trust pulls it from onboarding, and re-trusting a listing whose
+			// featured mark survived restores it. Sync from the server response.
+			featured = payload.featured ?? (trusted ? featured : false)
 			handle.update()
 			// The trusted badge renders inside the server frame; reload it so
 			// the header reflects the new state immediately.

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -19,6 +19,8 @@ import {
 	AccountManagementMessage,
 	AccountManagementShell,
 } from '#client/routes/account-management-components.tsx'
+import { type OnboardingFeaturedListing } from '#app/community-public-types.ts'
+import { CommunityListingIcon } from '#app/community-listing-icon.tsx'
 import { renderByokExplainer } from '#client/routes/byok-explainer.tsx'
 import { OnboardingMcpClientTabs } from '#client/routes/onboarding-mcp-client-tabs.tsx'
 import {
@@ -45,6 +47,7 @@ export type OnboardingPayload = {
 	hasMcpClient: boolean
 	emailVerified: boolean
 	needsOnboarding: boolean
+	featuredListings: Array<OnboardingFeaturedListing>
 }
 
 export const onboardingApiPath = '/onboarding.json'
@@ -103,12 +106,14 @@ export function OnboardingRoute(handle: Handle) {
 	let mcpServerUrl = ''
 	let setupPrompt = ''
 	let hasMcpClient = false
+	let featuredListings: Array<OnboardingFeaturedListing> = []
 	const loadLatch = createRouteLoadLatch()
 
 	function applyPayload(payload: OnboardingPayload) {
 		mcpServerUrl = payload.mcpServerUrl
 		setupPrompt = payload.setupPrompt
 		hasMcpClient = payload.hasMcpClient
+		featuredListings = payload.featuredListings ?? []
 		status = 'ready'
 		message = null
 	}
@@ -241,19 +246,59 @@ export function OnboardingRoute(handle: Handle) {
 
 						{renderByokExplainer({ image: 'handoff' })}
 
-						<section mix={css(cardCss)}>
-							<h2 mix={css(cardTitleCss)}>3. Explore community packages</h2>
-							<p mix={css(descriptionCss)}>
-								See what other people have built with Kody — browse community
-								packages for ready-made automations you can fork into your own
-								account.
-							</p>
-							<div>
-								<a href="/community" mix={css(communityCtaCss)}>
-									Browse community packages
-								</a>
-							</div>
-						</section>
+						{featuredListings.length > 0 ? (
+							<section
+								mix={css(cardCss)}
+								data-testid="onboarding-starter-packages"
+							>
+								<h2 mix={css(cardTitleCss)}>3. Install a starter package</h2>
+								<p mix={css(descriptionCss)}>
+									These packages were reviewed by an admin and support one-click
+									install: they are copied into your account ready to run, and
+									your agent helps with any remaining setup.
+								</p>
+								<ul mix={css(starterListCss)}>
+									{featuredListings.map((listing) => (
+										<li key={listing.id}>
+											<a
+												href={`/community/${listing.id}`}
+												mix={css(starterCardCss)}
+												data-testid={`onboarding-starter-${listing.id}`}
+											>
+												<CommunityListingIcon listing={listing} size="card" />
+												<span mix={css(starterCardBodyCss)}>
+													<span mix={css(starterCardTitleCss)}>
+														{listing.name}
+													</span>
+													<span mix={css(starterCardDescriptionCss)}>
+														{listing.description}
+													</span>
+												</span>
+											</a>
+										</li>
+									))}
+								</ul>
+								<p mix={css({ margin: 0 })}>
+									<a href="/community" mix={css(primaryLinkCss)}>
+										Browse all community packages
+									</a>
+								</p>
+							</section>
+						) : (
+							<section mix={css(cardCss)}>
+								<h2 mix={css(cardTitleCss)}>3. Explore community packages</h2>
+								<p mix={css(descriptionCss)}>
+									See what other people have built with Kody — browse community
+									packages for ready-made automations you can fork into your own
+									account.
+								</p>
+								<div>
+									<a href="/community" mix={css(communityCtaCss)}>
+										Browse community packages
+									</a>
+								</div>
+							</section>
+						)}
 
 						<p mix={css({ margin: 0 })}>
 							<a href="/account" mix={css(mutedLinkCss)}>
@@ -289,4 +334,43 @@ const communityCtaCss = {
 	...getPrimaryButtonCss(),
 	display: 'inline-flex',
 	textDecoration: 'none',
+}
+
+const starterListCss = {
+	display: 'flex',
+	flexDirection: 'column' as const,
+	gap: '0.75rem',
+	margin: 0,
+	padding: 0,
+	listStyle: 'none',
+}
+
+const starterCardCss = {
+	...insetCardCss,
+	display: 'flex',
+	alignItems: 'center',
+	gap: '0.75rem',
+	textDecoration: 'none',
+	color: colors.text,
+	'&:hover': {
+		borderColor: colors.primary,
+	},
+}
+
+const starterCardBodyCss = {
+	display: 'flex',
+	flexDirection: 'column' as const,
+	gap: '0.25rem',
+	minWidth: 0,
+}
+
+const starterCardTitleCss = {
+	fontWeight: typography.fontWeight.semibold,
+	color: colors.primaryText,
+	overflowWrap: 'anywhere' as const,
+}
+
+const starterCardDescriptionCss = {
+	color: colors.textMuted,
+	fontSize: typography.fontSize.sm,
 }

--- a/packages/worker/migrations/0060-community-featured-listings.sql
+++ b/packages/worker/migrations/0060-community-featured-listings.sql
@@ -1,0 +1,6 @@
+-- Admin-curated featured marks for community listings. Featured listings are
+-- highlighted during onboarding as one-click-install starter packages. A
+-- listing is only effectively featured while it is also effectively trusted
+-- (trusted_commit matches pinned_commit), so an owner republish silently
+-- pulls it from onboarding until an admin re-reviews and re-trusts it.
+ALTER TABLE community_listings ADD COLUMN featured_at TEXT;

--- a/packages/worker/src/app/community-data.ts
+++ b/packages/worker/src/app/community-data.ts
@@ -1,11 +1,14 @@
 import { readPositiveInt } from '#app/query-params.ts'
 import {
 	buildForkPrompt,
+	toOnboardingFeaturedListing,
 	toPublicCommunityListing,
+	type OnboardingFeaturedListing,
 	type PublicCommunityListing,
 } from '#app/community-public.ts'
 import {
 	buildCommunityDetailListingCacheKey,
+	buildCommunityFeaturedCacheKey,
 	buildCommunityIndexCacheKey,
 	getOrSetDataCache,
 } from '#app/data-cache.ts'
@@ -17,11 +20,13 @@ import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { setRequestDataCacheLookup } from '#app/request-cache.ts'
 import {
 	listCommunityListingsWithAggregates,
+	listFeaturedCommunityListingsWithAggregates,
 	searchCommunityListings,
 	getCommunityListingWithAggregates,
 } from '#worker/community/service.ts'
 
 const defaultCommunityListLimit = 50
+const onboardingFeaturedListingLimit = 6
 
 function isCommunityDataCacheEnabled(env: Env) {
 	const sentryEnv = (env as { SENTRY_ENVIRONMENT?: string }).SENTRY_ENVIRONMENT
@@ -82,6 +87,31 @@ export async function loadCommunityIndexData(
 		ok: true,
 		listings,
 		query: query || null,
+	}
+}
+
+/**
+ * Featured starter packages for the onboarding page. Fails open to an empty
+ * list: onboarding must render even if the community tables are unavailable.
+ */
+export async function loadOnboardingFeaturedListings(
+	env: Env,
+	request: Request,
+): Promise<Array<OnboardingFeaturedListing>> {
+	const cacheKey = buildCommunityFeaturedCacheKey(
+		onboardingFeaturedListingLimit,
+	)
+	try {
+		return await loadWithCommunityCache(env, request, cacheKey, async () => {
+			const rows = await listFeaturedCommunityListingsWithAggregates({
+				env,
+				limit: onboardingFeaturedListingLimit,
+			})
+			return rows.map(toOnboardingFeaturedListing)
+		})
+	} catch (error) {
+		console.error('Failed to load onboarding featured listings:', error)
+		return []
 	}
 }
 

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -52,6 +52,15 @@ export function CommunityDetailContent(
 							Trusted
 						</span>
 					) : null}
+					{listing.featured ? (
+						<span
+							data-testid="community-detail-featured-badge"
+							title="An admin featured this package as an onboarding starter install."
+							mix={css(trustedBadgeCss)}
+						>
+							Featured
+						</span>
+					) : null}
 				</div>
 			</header>
 

--- a/packages/worker/src/app/community-public-types.ts
+++ b/packages/worker/src/app/community-public-types.ts
@@ -17,8 +17,23 @@ export type PublicCommunityListing = {
 	ownerUsername: string
 	/** True when an admin marked the current pinned commit as reviewed. */
 	trusted: boolean
+	/** True when an admin featured this trusted listing in onboarding. */
+	featured: boolean
 	averageStars: number | null
 	ratingCount: number
 	averageAdaptationEffort: number | null
 	forkCount: number
+}
+
+/**
+ * Slim listing shape embedded in the onboarding payload for the starter
+ * package step. Kept minimal (no README) so onboarding stays light.
+ */
+export type OnboardingFeaturedListing = {
+	id: string
+	kodyId: string
+	name: string
+	description: string
+	iconUrl: string
+	tags: Array<string>
 }

--- a/packages/worker/src/app/community-public.ts
+++ b/packages/worker/src/app/community-public.ts
@@ -1,8 +1,14 @@
-import { type PublicCommunityListing } from '#app/community-public-types.ts'
+import {
+	type OnboardingFeaturedListing,
+	type PublicCommunityListing,
+} from '#app/community-public-types.ts'
 import { routes } from '#app/routes.ts'
 import { type CommunityListingWithAggregates } from '#worker/community/types.ts'
 
-export { type PublicCommunityListing } from '#app/community-public-types.ts'
+export {
+	type OnboardingFeaturedListing,
+	type PublicCommunityListing,
+} from '#app/community-public-types.ts'
 
 const scopedPackageNamePattern = /^@([a-z0-9][a-z0-9._-]*)\//
 
@@ -43,10 +49,27 @@ export function toPublicCommunityListing(
 		publishedAt: listing.publishedAt,
 		ownerUsername: getOwnerUsernameFromListingName(listing.name),
 		trusted: listing.trusted,
+		featured: listing.featured,
 		averageStars: listing.averageStars,
 		ratingCount: listing.ratingCount,
 		averageAdaptationEffort: listing.averageAdaptationEffort,
 		forkCount: listing.forkCount,
+	}
+}
+
+export function toOnboardingFeaturedListing(
+	listing: CommunityListingWithAggregates,
+): OnboardingFeaturedListing {
+	return {
+		id: listing.id,
+		kodyId: listing.kodyId,
+		name: listing.name,
+		description: listing.description,
+		iconUrl: buildCommunityIconUrl({
+			listingId: listing.id,
+			iconCommit: listing.iconCommit,
+		}),
+		tags: listing.tags,
 	}
 }
 

--- a/packages/worker/src/app/data-cache.ts
+++ b/packages/worker/src/app/data-cache.ts
@@ -42,6 +42,10 @@ export function buildCommunityDetailListingCacheKey(listingId: string) {
 	return `community-detail-listing:v${communityPublicCacheVersion}:id=${listingId}`
 }
 
+export function buildCommunityFeaturedCacheKey(limit: number) {
+	return `community-featured:v${communityPublicCacheVersion}:limit=${limit}`
+}
+
 function sweepExpiredEntries(now = Date.now()) {
 	for (const [key, entry] of store) {
 		if (entry.expiresAt <= now) {

--- a/packages/worker/src/app/handlers/community-detail.tsx
+++ b/packages/worker/src/app/handlers/community-detail.tsx
@@ -87,6 +87,7 @@ export function createCommunityDetailHandler(env: Env) {
 						loggedIn: detail.loggedIn,
 						viewerIsAdmin: detail.viewerIsAdmin,
 						trusted: detail.listing.trusted,
+						featured: detail.listing.featured,
 						readmeContent: detail.listing.readmeContent,
 					},
 				},

--- a/packages/worker/src/app/handlers/community-feature.node.test.ts
+++ b/packages/worker/src/app/handlers/community-feature.node.test.ts
@@ -1,0 +1,120 @@
+import { expect, test, vi } from 'vitest'
+import { CommunityActionError } from '#worker/community/errors.ts'
+import { createCommunityFeatureApiPostHandler } from './community-feature.ts'
+
+const mockModule = vi.hoisted(() => ({
+	requireUserWithRole: vi.fn(),
+	setCommunityListingFeatured: vi.fn(),
+	logAuditEvent: vi.fn(),
+}))
+
+vi.mock('#app/permissions-server.ts', () => ({
+	requireUserWithRole: (...args: Array<unknown>) =>
+		mockModule.requireUserWithRole(...args),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	setCommunityListingFeatured: (...args: Array<unknown>) =>
+		mockModule.setCommunityListingFeatured(...args),
+}))
+
+vi.mock('#app/audit-log.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
+	return {
+		...actual,
+		logAuditEvent: (...args: Array<unknown>) =>
+			mockModule.logAuditEvent(...args),
+	}
+})
+
+const env = { APP_DB: {} as D1Database } as Env
+
+function buildFeatureRequest(body: unknown) {
+	return {
+		request: new Request(
+			'https://example.com/community/listing-1/feature.json',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body),
+			},
+		),
+		params: { listingId: 'listing-1' },
+		url: new URL('https://example.com/community/listing-1/feature.json'),
+	} as never
+}
+
+test('community feature POST enforces admin role, validation, and error mapping', async () => {
+	const handler = createCommunityFeatureApiPostHandler(env)
+
+	mockModule.requireUserWithRole.mockRejectedValue(
+		new Response('Forbidden', { status: 403 }),
+	)
+	const forbidden = await handler.handler(
+		buildFeatureRequest({ featured: true }),
+	)
+	expect(forbidden.status).toBe(403)
+	expect(mockModule.setCommunityListingFeatured).not.toHaveBeenCalled()
+
+	mockModule.requireUserWithRole.mockResolvedValue({
+		email: 'admin@example.com',
+		mcpUser: { userId: 'stable-admin-id' },
+	})
+
+	const invalidBody = await handler.handler(
+		buildFeatureRequest({ featured: 'yes' }),
+	)
+	expect(invalidBody.status).toBe(400)
+	expect(mockModule.setCommunityListingFeatured).not.toHaveBeenCalled()
+
+	mockModule.setCommunityListingFeatured.mockResolvedValue({
+		id: 'listing-1',
+		featured: true,
+	})
+	const success = await handler.handler(buildFeatureRequest({ featured: true }))
+	expect(success.status).toBe(200)
+	expect(await success.json()).toEqual({ ok: true, featured: true })
+	expect(mockModule.setCommunityListingFeatured).toHaveBeenCalledWith({
+		env,
+		listingId: 'listing-1',
+		featured: true,
+	})
+	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'admin',
+			action: 'community_listing_feature',
+			result: 'success',
+			reason: 'listing_id=listing-1;featured=true',
+		}),
+	)
+
+	mockModule.setCommunityListingFeatured.mockRejectedValue(
+		new CommunityActionError(
+			'Only trusted community listings can be featured in onboarding. Mark the listing trusted first.',
+		),
+	)
+	const userFacingError = await handler.handler(
+		buildFeatureRequest({ featured: true }),
+	)
+	expect(userFacingError.status).toBe(400)
+	expect(await userFacingError.json()).toEqual({
+		ok: false,
+		error:
+			'Only trusted community listings can be featured in onboarding. Mark the listing trusted first.',
+	})
+
+	const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+	mockModule.setCommunityListingFeatured.mockRejectedValue(
+		new Error('db timeout'),
+	)
+	const serverError = await handler.handler(
+		buildFeatureRequest({ featured: false }),
+	)
+	expect(serverError.status).toBe(500)
+	expect(await serverError.json()).toEqual({
+		ok: false,
+		error: 'Unable to update featuring for this listing.',
+	})
+	expect(consoleError).toHaveBeenCalled()
+	consoleError.mockRestore()
+})

--- a/packages/worker/src/app/handlers/community-feature.ts
+++ b/packages/worker/src/app/handlers/community-feature.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod'
+import { type Action } from 'remix/router'
+import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
+import { requireUserWithRole } from '#app/permissions-server.ts'
+import { type routes } from '#app/routes.ts'
+import { CommunityActionError } from '#worker/community/errors.ts'
+import { setCommunityListingFeatured } from '#worker/community/service.ts'
+import { jsonResponse } from '#worker/json-response.ts'
+
+const communityFeaturePostSchema = z.object({
+	featured: z.boolean(),
+})
+
+export function createCommunityFeatureApiPostHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, params }) {
+			if (request.method !== 'POST') {
+				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+			}
+
+			let actor
+			try {
+				actor = await requireUserWithRole(request, env, 'admin')
+			} catch (error) {
+				if (error instanceof Response) return error
+				throw error
+			}
+
+			const body = await request.json().catch(() => null)
+			const parsed = communityFeaturePostSchema.safeParse(body)
+			if (!parsed.success) {
+				return jsonResponse({ ok: false, error: 'Invalid request body.' }, 400)
+			}
+
+			try {
+				const listing = await setCommunityListingFeatured({
+					env,
+					listingId: params.listingId,
+					featured: parsed.data.featured,
+				})
+				void logAuditEvent({
+					db: env.APP_DB,
+					category: 'admin',
+					action: 'community_listing_feature',
+					result: 'success',
+					email: actor.email,
+					ip: getRequestIp(request) ?? undefined,
+					path: new URL(request.url).pathname,
+					reason: `listing_id=${listing.id};featured=${parsed.data.featured}`,
+				})
+				return jsonResponse({ ok: true, featured: listing.featured })
+			} catch (error) {
+				if (error instanceof CommunityActionError) {
+					return jsonResponse({ ok: false, error: error.message }, 400)
+				}
+				console.error('Community feature update failed:', error)
+				return jsonResponse(
+					{ ok: false, error: 'Unable to update featuring for this listing.' },
+					500,
+				)
+			}
+		},
+	} satisfies Action<typeof routes.communityFeatureApiPost>
+}

--- a/packages/worker/src/app/handlers/community-trust.node.test.ts
+++ b/packages/worker/src/app/handlers/community-trust.node.test.ts
@@ -65,10 +65,17 @@ test('community trust POST enforces admin role, validation, and error mapping', 
 	mockModule.setCommunityListingTrusted.mockResolvedValue({
 		id: 'listing-1',
 		trusted: true,
+		featured: true,
 	})
 	const success = await handler.handler(buildTrustRequest({ trusted: true }))
 	expect(success.status).toBe(200)
-	expect(await success.json()).toEqual({ ok: true, trusted: true })
+	// featured is derived from trust, so the recomputed flag rides along for
+	// client-side state sync.
+	expect(await success.json()).toEqual({
+		ok: true,
+		trusted: true,
+		featured: true,
+	})
 	expect(mockModule.setCommunityListingTrusted).toHaveBeenCalledWith({
 		env,
 		adminUserId: 'stable-admin-id',

--- a/packages/worker/src/app/handlers/community-trust.ts
+++ b/packages/worker/src/app/handlers/community-trust.ts
@@ -50,7 +50,13 @@ export function createCommunityTrustApiPostHandler(env: Env) {
 					path: new URL(request.url).pathname,
 					reason: `listing_id=${listing.id};trusted=${parsed.data.trusted}`,
 				})
-				return jsonResponse({ ok: true, trusted: listing.trusted })
+				// Featured is derived from trust (featured_at survives revocation),
+				// so the client needs the recomputed flag to stay in sync.
+				return jsonResponse({
+					ok: true,
+					trusted: listing.trusted,
+					featured: listing.featured,
+				})
 			} catch (error) {
 				if (error instanceof CommunityActionError) {
 					return jsonResponse({ ok: false, error: error.message }, 400)

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -8,6 +8,7 @@ import {
 } from '#app/auth-redirect.ts'
 import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { loadOnboardingFeaturedListings } from '#app/community-data.ts'
 import { loadOnboardingData } from '#app/onboarding-data.ts'
 import { createPageOgHeadNode } from '#app/ssr-document.tsx'
 import { renderAppPage } from '#app/ssr-render.tsx'
@@ -48,6 +49,7 @@ export function createOnboardingHandler(env: Env) {
 				requestUrl: request.url,
 				stableUserId: user.mcpUser.userId,
 				emailVerified: user.emailVerified,
+				featuredListings: await loadOnboardingFeaturedListings(env, request),
 			})
 			const origin = getAppBaseUrl({ env, requestUrl: request.url })
 			return renderAppPage({
@@ -75,13 +77,17 @@ export function createOnboardingApiHandler(env: Env) {
 			}
 
 			// Unverified callers still get a payload so clients can detect the
-			// gate; MCP URL/setup fields stay empty until verification succeeds.
+			// gate; MCP URL/setup and featured fields stay empty until
+			// verification succeeds.
 			return jsonResponse(
 				await loadOnboardingData({
 					env,
 					requestUrl: request.url,
 					stableUserId: user.mcpUser.userId,
 					emailVerified: user.emailVerified,
+					featuredListings: user.emailVerified
+						? await loadOnboardingFeaturedListings(env, request)
+						: [],
 				}),
 			)
 		},

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -1,4 +1,7 @@
-import { type PublicCommunityListing } from '#app/community-public-types.ts'
+import {
+	type OnboardingFeaturedListing,
+	type PublicCommunityListing,
+} from '#app/community-public-types.ts'
 import { type PermissionString, type RoleName } from '#app/permissions.ts'
 
 export type CommunityIndexLoaderData = {
@@ -23,6 +26,7 @@ export type CommunityDetailShellLoaderData = {
 	loggedIn: boolean
 	viewerIsAdmin: boolean
 	trusted: boolean
+	featured: boolean
 	readmeContent: string | null
 }
 
@@ -349,6 +353,8 @@ export type OnboardingLoaderData = {
 	hasMcpClient: boolean
 	emailVerified: boolean
 	needsOnboarding: boolean
+	/** Admin-featured trusted listings offered as one-click starter installs. */
+	featuredListings: Array<OnboardingFeaturedListing>
 }
 
 export type AccountTwoFactorLoaderData = {

--- a/packages/worker/src/app/onboarding-data.node.test.ts
+++ b/packages/worker/src/app/onboarding-data.node.test.ts
@@ -30,6 +30,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		hasMcpClient: false,
 		emailVerified: true,
 		needsOnboarding: true,
+		featuredListings: [],
 	})
 
 	const withClient = await loadOnboardingData({

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -1,4 +1,5 @@
 import { getAppBaseUrl } from '#app/app-base-url.ts'
+import { type OnboardingFeaturedListing } from '#app/community-public-types.ts'
 import { type OnboardingLoaderData } from '#app/loader-data.ts'
 
 const mcpServerPath = '/mcp'
@@ -56,6 +57,11 @@ export async function loadOnboardingData(input: {
 	requestUrl: string | URL
 	stableUserId: string
 	emailVerified: boolean
+	/**
+	 * Featured starter packages loaded by the handler (which has the full
+	 * worker Env); this module stays narrow so it is trivially testable.
+	 */
+	featuredListings?: Array<OnboardingFeaturedListing>
 }): Promise<OnboardingLoaderData> {
 	const hasMcpClient = await userHasMcpOAuthGrants(
 		input.env,
@@ -81,5 +87,6 @@ export async function loadOnboardingData(input: {
 		hasMcpClient,
 		emailVerified: input.emailVerified,
 		needsOnboarding,
+		featuredListings: input.emailVerified ? (input.featuredListings ?? []) : [],
 	}
 }

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -83,6 +83,7 @@ import {
 	createCommunityDetailOgImageHandler,
 	createCommunityReportApiPostHandler,
 } from '#app/handlers/community-detail.tsx'
+import { createCommunityFeatureApiPostHandler } from '#app/handlers/community-feature.ts'
 import { createCommunityIconHandler } from '#app/handlers/community-icon.ts'
 import { createCommunityInstallApiPostHandler } from '#app/handlers/community-install.ts'
 import { createCommunityTrustApiPostHandler } from '#app/handlers/community-trust.ts'
@@ -217,6 +218,7 @@ export function createAppRouter(env: Env) {
 			communityDetailOgImage: createCommunityDetailOgImageHandler(env),
 			communityReportApiPost: createCommunityReportApiPostHandler(env),
 			communityTrustApiPost: createCommunityTrustApiPostHandler(env),
+			communityFeatureApiPost: createCommunityFeatureApiPostHandler(env),
 			communityInstallApiPost: createCommunityInstallApiPostHandler(env),
 			connectOauth: createConnectOauthHandler(env),
 			auth: createAuthHandler(env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -69,6 +69,7 @@ export const routes = route({
 	communityDetailOgImage: '/community/:listingId/og.png',
 	communityReportApiPost: post('/community/:listingId/report.json'),
 	communityTrustApiPost: post('/community/:listingId/trust.json'),
+	communityFeatureApiPost: post('/community/:listingId/feature.json'),
 	communityInstallApiPost: post('/community/:listingId/install.json'),
 	health: '/health',
 	login: '/login',

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -265,6 +265,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		hasMcpClient: false,
 		emailVerified: false,
 		needsOnboarding: true,
+		featuredListings: [],
 	})
 	expect(accountHtml).toContain('Verify your email')
 	expect(accountHtml).toContain('No accounts connected yet.')

--- a/packages/worker/src/community/community-flow-test-schema.ts
+++ b/packages/worker/src/community/community-flow-test-schema.ts
@@ -64,6 +64,7 @@ export async function ensureCommunityFlowSchema(db: D1Database) {
 			trusted_commit TEXT,
 			trusted_by_user_id TEXT,
 			trusted_at TEXT,
+			featured_at TEXT,
 			created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
 			updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
 			published_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)

--- a/packages/worker/src/community/community-flow.workers.test.ts
+++ b/packages/worker/src/community/community-flow.workers.test.ts
@@ -7,12 +7,15 @@ import { communityPublishCapability } from '#mcp/capabilities/community/publish.
 import { communityRateCapability } from '#mcp/capabilities/community/rate.ts'
 import { communityReportCapability } from '#mcp/capabilities/community/report.ts'
 import { communitySearchCapability } from '#mcp/capabilities/community/search.ts'
+import { communitySetFeaturedCapability } from '#mcp/capabilities/community/set-featured.ts'
 import { communitySetTrustedCapability } from '#mcp/capabilities/community/set-trusted.ts'
 import { communityContentWarning } from '#mcp/capabilities/community/shared.ts'
 import { callerCanAccessCapability } from '#mcp/capabilities/access-control.ts'
 import {
 	banCommunityUser,
+	listFeaturedCommunityListingsWithAggregates,
 	resolveCommunityReport,
+	setCommunityListingFeatured,
 	setCommunityListingTrusted,
 } from '#worker/community/service.ts'
 import { installCommunityListing } from '#worker/community/install.ts'
@@ -306,6 +309,15 @@ test('community package flow works end-to-end through capability handlers', asyn
 	// Admin curation: trust pins to the reviewed commit and the effective
 	// mark drops as soon as the owner republishes new content.
 	expect(ratedListing.trusted).toBe(false)
+	// Featuring requires trust, so it is rejected while the listing is
+	// untrusted.
+	await expect(
+		setCommunityListingFeatured({
+			env: testEnv,
+			listingId,
+			featured: true,
+		}),
+	).rejects.toThrow('Only trusted community listings can be featured')
 	const trustedListing = await setCommunityListingTrusted({
 		env: testEnv,
 		adminUserId: admin.userId,
@@ -319,6 +331,26 @@ test('community package flow works end-to-end through capability handlers', asyn
 		forkerCtx,
 	)
 	expect(trustedGet.trusted).toBe(true)
+
+	// Once trusted, featuring works and the listing shows up in the
+	// onboarding starter list.
+	const featuredListing = await setCommunityListingFeatured({
+		env: testEnv,
+		listingId,
+		featured: true,
+	})
+	expect(featuredListing.featured).toBe(true)
+	expect(featuredListing.featuredAt).toBeTruthy()
+	const featuredRows = await listFeaturedCommunityListingsWithAggregates({
+		env: testEnv,
+		limit: 10,
+	})
+	expect(featuredRows.some((row) => row.id === listingId)).toBe(true)
+	const featuredGet = await communityGetCapability.handler(
+		{ listing_id: listingId },
+		forkerCtx,
+	)
+	expect(featuredGet.featured).toBe(true)
 
 	const republishedCommit = `commit-republished-${unique}`
 	await writePublishedSourceSnapshot({
@@ -341,12 +373,47 @@ test('community package flow works end-to-end through capability handlers', asyn
 		forkerCtx,
 	)
 	expect(afterRepublish.trusted).toBe(false)
+	// The republish also pulls the listing from onboarding: the featured mark
+	// stays stored but is no longer effective without trust.
+	expect(afterRepublish.featured).toBe(false)
+	const featuredAfterRepublish =
+		await listFeaturedCommunityListingsWithAggregates({
+			env: testEnv,
+			limit: 10,
+		})
+	expect(featuredAfterRepublish.some((row) => row.id === listingId)).toBe(false)
+	// Re-trusting the republished commit restores the stored featured mark.
+	await setCommunityListingTrusted({
+		env: testEnv,
+		adminUserId: admin.userId,
+		listingId,
+		trusted: true,
+	})
+	const afterRetrust = await communityGetCapability.handler(
+		{ listing_id: listingId },
+		forkerCtx,
+	)
+	expect(afterRetrust.featured).toBe(true)
+	// Removing the mark takes the listing out of onboarding while trusted.
+	const unfeatured = await setCommunityListingFeatured({
+		env: testEnv,
+		listingId,
+		featured: false,
+	})
+	expect(unfeatured.featured).toBe(false)
+	expect(unfeatured.featuredAt).toBeNull()
 
-	// Access control: only admins may reach community_set_trusted.
+	// Access control: only admins may reach the curation capabilities.
 	expect(
 		callerCanAccessCapability(
 			forkerCtx.callerContext,
 			communitySetTrustedCapability,
+		),
+	).toBe(false)
+	expect(
+		callerCanAccessCapability(
+			forkerCtx.callerContext,
+			communitySetFeaturedCapability,
 		),
 	).toBe(false)
 
@@ -383,6 +450,14 @@ test('community package flow works end-to-end through capability handlers', asyn
 			trusted: true,
 		}),
 	).rejects.toThrow('Delisted community listings cannot be marked trusted.')
+
+	await expect(
+		setCommunityListingFeatured({
+			env: testEnv,
+			listingId,
+			featured: true,
+		}),
+	).rejects.toThrow('Delisted community listings cannot be featured.')
 
 	await banCommunityUser({
 		env: testEnv,

--- a/packages/worker/src/community/community-flow.workers.test.ts
+++ b/packages/worker/src/community/community-flow.workers.test.ts
@@ -341,6 +341,14 @@ test('community package flow works end-to-end through capability handlers', asyn
 	})
 	expect(featuredListing.featured).toBe(true)
 	expect(featuredListing.featuredAt).toBeTruthy()
+	// Re-featuring is idempotent: the original featured_at is preserved so
+	// retries never reshuffle the onboarding order.
+	const refeatured = await setCommunityListingFeatured({
+		env: testEnv,
+		listingId,
+		featured: true,
+	})
+	expect(refeatured.featuredAt).toBe(featuredListing.featuredAt)
 	const featuredRows = await listFeaturedCommunityListingsWithAggregates({
 		env: testEnv,
 		limit: 10,

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -21,6 +21,9 @@ function mapCommunityListingRow(
 	const pinnedCommit = String(row['pinned_commit'])
 	const trustedCommit =
 		row['trusted_commit'] == null ? null : String(row['trusted_commit'])
+	const trusted = trustedCommit != null && trustedCommit === pinnedCommit
+	const featuredAt =
+		row['featured_at'] == null ? null : String(row['featured_at'])
 	return {
 		id: String(row['id']),
 		ownerUserId: String(row['owner_user_id']),
@@ -43,7 +46,12 @@ function mapCommunityListingRow(
 		status: String(row['status']) as CommunityListingStatus,
 		trustedCommit,
 		trustedAt: row['trusted_at'] == null ? null : String(row['trusted_at']),
-		trusted: trustedCommit != null && trustedCommit === pinnedCommit,
+		trusted,
+		featuredAt,
+		// Featured is an onboarding placement, so it never outlives trust: a
+		// republish (or trust revocation) pulls the listing from onboarding
+		// even though featured_at stays set.
+		featured: featuredAt != null && trusted,
 		createdAt: String(row['created_at']),
 		updatedAt: String(row['updated_at']),
 		publishedAt: String(row['published_at']),
@@ -114,7 +122,7 @@ const communityListingSelectColumns = `community_listings.id, community_listings
 	community_listings.pinned_commit, community_listings.status, community_listings.created_at,
 	community_listings.updated_at, community_listings.published_at,
 	community_listings.trusted_commit, community_listings.trusted_by_user_id,
-	community_listings.trusted_at,
+	community_listings.trusted_at, community_listings.featured_at,
 	entity_sources.published_commit AS source_published_commit`
 
 const communityListingSourceJoin = `LEFT JOIN entity_sources
@@ -150,8 +158,9 @@ export function extractCommunityListingLikeTokens(
 
 export async function insertCommunityListing(
 	db: D1Database,
-	// New listings are never trusted; the trust columns start NULL and are
-	// only set through setCommunityListingTrustedCommit.
+	// New listings are never trusted or featured; those columns start NULL
+	// and are only set through setCommunityListingTrustedCommit /
+	// setCommunityListingFeaturedAt.
 	row: Omit<
 		CommunityListingRow,
 		| 'created_at'
@@ -160,6 +169,7 @@ export async function insertCommunityListing(
 		| 'trusted_commit'
 		| 'trusted_by_user_id'
 		| 'trusted_at'
+		| 'featured_at'
 	> & {
 		created_at?: string
 		updated_at?: string
@@ -415,6 +425,53 @@ export async function setCommunityListingTrustedCommit(
 		)
 		.run()
 	return (result.meta.changes ?? 0) > 0
+}
+
+export async function setCommunityListingFeaturedAt(
+	db: D1Database,
+	input: {
+		listingId: string
+		featured: boolean
+	},
+): Promise<boolean> {
+	const now = new Date().toISOString()
+	const result = await db
+		.prepare(
+			`UPDATE community_listings
+			SET featured_at = ?, updated_at = ?
+			WHERE id = ?`,
+		)
+		.bind(input.featured ? now : null, now, input.listingId)
+		.run()
+	return (result.meta.changes ?? 0) > 0
+}
+
+/**
+ * Listings that should be offered as onboarding starter packages: featured
+ * by an admin AND still effectively trusted (the trusted commit matches the
+ * pinned commit). Ordered by when they were featured so the curated order
+ * stays stable as new packages are added.
+ */
+export async function listFeaturedCommunityListings(
+	db: D1Database,
+	input: {
+		limit: number
+	},
+): Promise<Array<CommunityListingRecord>> {
+	const rows = await db
+		.prepare(
+			`SELECT ${communityListingSelectColumns}
+			FROM community_listings
+			${communityListingSourceJoin}
+			WHERE community_listings.status = 'active'
+				AND community_listings.featured_at IS NOT NULL
+				AND community_listings.trusted_commit = community_listings.pinned_commit
+			ORDER BY community_listings.featured_at ASC
+			LIMIT ?`,
+		)
+		.bind(input.limit)
+		.all<Record<string, unknown>>()
+	return (rows.results ?? []).map(mapCommunityListingRow)
 }
 
 export async function setCommunityListingStatus(

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -435,13 +435,16 @@ export async function setCommunityListingFeaturedAt(
 	},
 ): Promise<boolean> {
 	const now = new Date().toISOString()
+	// Re-featuring keeps the original timestamp (COALESCE) so idempotent
+	// retries never reshuffle the featured_at-ordered onboarding list.
 	const result = await db
 		.prepare(
 			`UPDATE community_listings
-			SET featured_at = ?, updated_at = ?
+			SET featured_at = CASE WHEN ? THEN COALESCE(featured_at, ?) ELSE NULL END,
+				updated_at = ?
 			WHERE id = ?`,
 		)
-		.bind(input.featured ? now : null, now, input.listingId)
+		.bind(input.featured ? 1 : 0, now, now, input.listingId)
 		.run()
 	return (result.meta.changes ?? 0) > 0
 }

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -39,7 +39,9 @@ import {
 	extractCommunityListingLikeTokens,
 	listCommunityListingCandidates,
 	listCommunityReports as listCommunityReportsFromDb,
+	listFeaturedCommunityListings as listFeaturedCommunityListingsFromDb,
 	resolveCommunityReportRow,
+	setCommunityListingFeaturedAt,
 	setCommunityListingStatus,
 	setCommunityListingTrustedCommit,
 	updateCommunityListing,
@@ -554,6 +556,68 @@ export async function setCommunityListingTrusted(input: {
 		)
 	}
 	return updated
+}
+
+/**
+ * Admin curation: mark a listing as an onboarding starter package, or remove
+ * the mark. Featuring requires the listing to be effectively trusted at its
+ * current commit, because onboarding presents featured listings for one-click
+ * install. The mark itself survives republishes; the effective `featured`
+ * flag drops with trust and returns when the same commit is re-trusted.
+ */
+export async function setCommunityListingFeatured(input: {
+	env: Env
+	listingId: string
+	featured: boolean
+}): Promise<CommunityListingRecord> {
+	const listing = await getCommunityListingById(input.env.APP_DB, {
+		listingId: input.listingId,
+		includeDelisted: true,
+	})
+	if (!listing) {
+		throw new CommunityActionError(
+			`Community listing "${input.listingId}" was not found.`,
+		)
+	}
+	if (input.featured && listing.status !== 'active') {
+		throw new CommunityActionError(
+			'Delisted community listings cannot be featured.',
+		)
+	}
+	if (input.featured && !listing.trusted) {
+		throw new CommunityActionError(
+			'Only trusted community listings can be featured in onboarding. Mark the listing trusted first.',
+		)
+	}
+	await setCommunityListingFeaturedAt(input.env.APP_DB, {
+		listingId: input.listingId,
+		featured: input.featured,
+	})
+	invalidateCommunityPublicCache()
+	const updated = await getCommunityListingById(input.env.APP_DB, {
+		listingId: input.listingId,
+		includeDelisted: true,
+	})
+	if (!updated) {
+		throw new Error(
+			`Community listing "${input.listingId}" could not be loaded.`,
+		)
+	}
+	return updated
+}
+
+/**
+ * Onboarding starter packages: featured listings that are still effectively
+ * trusted, with rating/fork aggregates attached for public display.
+ */
+export async function listFeaturedCommunityListingsWithAggregates(input: {
+	env: Env
+	limit: number
+}): Promise<Array<CommunityListingWithAggregates>> {
+	const listings = await listFeaturedCommunityListingsFromDb(input.env.APP_DB, {
+		limit: input.limit,
+	})
+	return await attachListingAggregatesBatch(input.env.APP_DB, listings)
 }
 
 export async function getCommunityListingWithAggregates(input: {

--- a/packages/worker/src/community/types.ts
+++ b/packages/worker/src/community/types.ts
@@ -19,6 +19,7 @@ export type CommunityListingRow = {
 	trusted_commit: string | null
 	trusted_by_user_id: string | null
 	trusted_at: string | null
+	featured_at: string | null
 	created_at: string
 	updated_at: string
 	published_at: string
@@ -55,6 +56,15 @@ export type CommunityListingRecord = {
 	trustedCommit: string | null
 	trustedAt: string | null
 	trusted: boolean
+	/**
+	 * When an admin marked this listing as an onboarding starter package, or
+	 * null when never featured (or the mark was removed). The mark survives
+	 * republishes, but the listing is only *effectively* featured while it is
+	 * also effectively trusted, so `featured` drops with `trusted` and comes
+	 * back if the same commit is re-trusted.
+	 */
+	featuredAt: string | null
+	featured: boolean
 	createdAt: string
 	updatedAt: string
 	publishedAt: string

--- a/packages/worker/src/mcp/capabilities/community/domain.ts
+++ b/packages/worker/src/mcp/capabilities/community/domain.ts
@@ -6,6 +6,7 @@ import { communityPublishCapability } from './publish.ts'
 import { communityRateCapability } from './rate.ts'
 import { communityReportCapability } from './report.ts'
 import { communitySearchCapability } from './search.ts'
+import { communitySetFeaturedCapability } from './set-featured.ts'
 import { communitySetTrustedCapability } from './set-trusted.ts'
 import { communityUnpublishCapability } from './unpublish.ts'
 
@@ -33,5 +34,6 @@ export const communityDomain = defineDomain({
 		communityRateCapability,
 		communityReportCapability,
 		communitySetTrustedCapability,
+		communitySetFeaturedCapability,
 	],
 })

--- a/packages/worker/src/mcp/capabilities/community/get.ts
+++ b/packages/worker/src/mcp/capabilities/community/get.ts
@@ -6,6 +6,7 @@ import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import {
 	buildCommunityPublicUrl,
 	communityContentWarning,
+	communityFeaturedFieldSchema,
 	communityGetForkInstructions,
 	communityListingAggregatesSchema,
 	communityListingStatusSchema,
@@ -35,6 +36,7 @@ export const communityGetCapability = defineDomainCapability(
 			pinned_commit: z.string(),
 			status: communityListingStatusSchema,
 			trusted: communityTrustedFieldSchema,
+			featured: communityFeaturedFieldSchema,
 			public_url: z.string(),
 			published_at: z.string(),
 			readme_untrusted: z.string().nullable(),
@@ -61,6 +63,7 @@ export const communityGetCapability = defineDomainCapability(
 				pinned_commit: listing.pinnedCommit,
 				status: listing.status,
 				trusted: listing.trusted,
+				featured: listing.featured,
 				public_url: buildCommunityPublicUrl(
 					ctx.callerContext.baseUrl,
 					listing.id,

--- a/packages/worker/src/mcp/capabilities/community/set-featured.ts
+++ b/packages/worker/src/mcp/capabilities/community/set-featured.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod'
+import { setCommunityListingFeatured } from '#worker/community/service.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { auditAdminCapabilityInvocation } from '#mcp/capabilities/admin/admin-shared.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { communityListingStatusSchema } from './shared.ts'
+
+export const communitySetFeaturedCapability = defineDomainCapability(
+	capabilityDomainNames.community,
+	{
+		name: 'community_set_featured',
+		description:
+			'Admin-only curation: mark a trusted community listing as an onboarding starter package, or remove the mark. Featured listings are offered for one-click install during onboarding, so featuring requires the listing to be trusted at its current commit; an owner republish drops the listing from onboarding until an admin re-trusts it.',
+		keywords: [
+			'community',
+			'featured',
+			'onboarding',
+			'starter',
+			'curate',
+			'admin',
+			'listing',
+		],
+		readOnly: false,
+		idempotent: true,
+		destructive: false,
+		requiredRole: 'admin',
+		inputSchema: z.object({
+			listing_id: z
+				.string()
+				.min(1)
+				.describe('Community listing id to mark or unmark as featured.'),
+			featured: z
+				.boolean()
+				.describe(
+					'True to feature this trusted listing in onboarding; false to remove it.',
+				),
+		}),
+		outputSchema: z.object({
+			listing_id: z.string(),
+			name: z.string(),
+			status: communityListingStatusSchema,
+			trusted: z.boolean(),
+			featured: z.boolean(),
+			featured_at: z.string().nullable(),
+		}),
+		async handler(args, ctx) {
+			requireMcpUser(ctx.callerContext)
+			return await auditAdminCapabilityInvocation(
+				ctx,
+				'community_set_featured',
+				async () => {
+					const listing = await setCommunityListingFeatured({
+						env: ctx.env,
+						listingId: args.listing_id,
+						featured: args.featured,
+					})
+					return {
+						listing_id: listing.id,
+						name: listing.name,
+						status: listing.status,
+						trusted: listing.trusted,
+						featured: listing.featured,
+						featured_at: listing.featuredAt,
+					}
+				},
+				{
+					successReason: (result) =>
+						`listing_id=${result.listing_id};featured=${result.featured}`,
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/community/shared.ts
+++ b/packages/worker/src/mcp/capabilities/community/shared.ts
@@ -43,6 +43,12 @@ export const communityTrustedFieldSchema = z
 		'True when an admin reviewed and trusted the exact pinned commit of this listing.',
 	)
 
+export const communityFeaturedFieldSchema = z
+	.boolean()
+	.describe(
+		'True when an admin featured this trusted listing as an onboarding starter package.',
+	)
+
 export const communitySearchMatchSchema =
 	communityListingAggregatesSchema.extend({
 		listing_id: z.string(),

--- a/packages/worker/tsconfig-client.json
+++ b/packages/worker/tsconfig-client.json
@@ -23,6 +23,7 @@
 		"./src/app/routes.ts",
 		"./src/app/frame-constants.ts",
 		"./src/app/community-frame-constants.ts",
+		"./src/app/community-listing-icon.tsx",
 		"./src/app/community-public-types.ts",
 		"./src/app/loader-data.ts",
 		"./src/app/safe-redirect.ts"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Third and final PR in the trusted/one-click-install/onboarding series (after #760 and #763). Admins can now mark **trusted** community listings as **featured**, and featured listings appear on `/onboarding` as one-click-installable starter packages for new users.

- New `featured_at` column on `community_listings` (migration `0060`). A listing is *effectively* featured only while `featured_at IS NOT NULL` **and** it is effectively trusted (`trusted_commit = pinned_commit`), so an owner republish silently pulls it from onboarding until an admin re-trusts the new version; the stored mark survives and re-trusting restores it.
- `setCommunityListingFeatured` service (rejects untrusted/delisted listings) + `listFeaturedCommunityListings` (active + featured + trusted, capped at 6 for onboarding).
- Admin-only `community_set_featured` MCP capability (`requiredRole: 'admin'`, invisible to non-admins, audited) and admin-only `POST /community/:listingId/feature.json` handler (audited).
- Detail page: **Featured** badge next to **Trusted**, and an "Admin: onboarding" panel with a feature/unfeature toggle (disabled with an explanation while the listing is untrusted). Revoking trust in the UI also clears the local featured state.
- Onboarding: new "3. Install a starter package" step listing featured packages (slim `OnboardingFeaturedListing` payload — no README) linking to their detail pages where the one-click Install button (from #763) lives. Falls back to the existing "Explore community packages" CTA when nothing is featured. Featured data is omitted for unverified users and fails open to an empty list.
- `community_get` exposes the effective `featured` flag.
- Docs: usage + contributing community-packages docs, `primitives.yaml`.

## Demo

<a href="https://cursor.com/agents/bc-019f6b52-408c-7980-912f-990f1eead4a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_features_trusted_listing_in_onboarding.mp4"><img src="https://cursor.com/artifacts/c/art-ab4d6dc4-1bcb-4e28-ae09-016db0b9970d" alt="admin_features_trusted_listing_in_onboarding.mp4" /></a>

Admin features the trusted `@jane/notes-digest` listing; the Featured badge appears, and the untrusted listing shows the disabled explanation instead.

<a href="https://cursor.com/agents/bc-019f6b52-408c-7980-912f-990f1eead4a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnew_user_onboarding_starter_package_one_click_install.mp4"><img src="https://cursor.com/artifacts/c/art-05165350-15b4-40df-9dab-c4dcb9427b24" alt="new_user_onboarding_starter_package_one_click_install.mp4" /></a>

A fresh user sees the starter package on `/onboarding` and one-click installs it.

![Onboarding starter package step](https://cursor.com/artifacts/c/art-57f88a52-1f04-4796-8746-37c3a7b90e5d)
![Featured badge next to Trusted badge](https://cursor.com/artifacts/c/art-c5e5b935-c51f-4653-bb35-68952416ecc0)

## Testing

- ✅ `npm run validate` (format, lint, typecheck, unit, Playwright E2E, MCP E2E — all green)
- ✅ New node tests: `community-feature.node.test.ts` (RBAC, validation, error mapping)
- ✅ Workers integration: featuring requires trust, onboarding list membership, republish drops effective featured, re-trust restores it, delisted rejection, non-admin capability access denied
- ✅ New Playwright E2E: `e2e/community-featured.spec.ts` (member 403 + no admin panel, admin toggle, disabled button on untrusted, onboarding starter section appears/disappears)
- ✅ Manual dev-server demo (videos above)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends community listings</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `236554c4` · **Head:** `7ad88523`

**Classification:** extends — no new primitives; `community-listings` gains an admin featured mark and the onboarding page gains a starter-package step built on it.

### Primitives touched

| Primitive             | Group     | Impact                                                                                                   |
| --------------------- | --------- | -------------------------------------------------------------------------------------------------------- |
| `community-listings`  | assistant | extends — `featured_at` column, `setCommunityListingFeatured` / `listFeaturedCommunityListings`, badge   |
| `app-ui`              | surfaces  | composes — feature toggle on the detail page, "Install a starter package" step on `/onboarding`          |
| `mcp-server`          | surfaces  | composes — new admin-only `community_set_featured` capability in the existing community domain           |
| `rbac`                | auth      | composes — `requiredRole: 'admin'` on the capability; `requireUserWithRole` on `feature.json`            |
| `d1-app-db`           | storage   | extends — migration `0060-community-featured-listings.sql` adds `community_listings.featured_at`         |

### System map

Admin featuring flows from the detail-page toggle through RBAC into the community service and D1; onboarding reads the effectively featured listings back out as starter packages.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::touched
	rbac["rbac<br/>Role-based access control"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint"]:::touched
	communityListings["community-listings<br/>Community package listings"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::extended
	appUi -->|"POST /community/:id/feature.json (admin toggle)"| rbac
	mcpServer -->|"community_set_featured (requiredRole: admin)"| rbac
	rbac -->|"setCommunityListingFeatured (requires trusted)"| communityListings
	communityListings -->|"featured_at column (migration 0060)"| d1AppDb
	appUi -->|"/onboarding starter step ← listFeaturedCommunityListings (featured ∧ trusted ∧ active, cap 6)"| communityListings
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
before: community_listings(trusted_commit, trusted_by_user_id, trusted_at)
after:  community_listings(... , featured_at)
        effective featured = featured_at IS NOT NULL AND trusted_commit = pinned_commit
```

```text
before: OnboardingLoaderData { mcpServerUrl, setupPrompt, hasMcpClient, emailVerified, needsOnboarding }
after:  OnboardingLoaderData { ..., featuredListings: OnboardingFeaturedListing[] }  // slim: no README
```

### Invariants

- `community-listing-isolation`: unchanged — featuring only affects which public listings onboarding highlights; installs still go through the #763 fork + publish-check path and the featured flag never bypasses the untrusted acknowledgement (featuring *requires* effective trust).
- Featured marks never outlive trust: the effective flag is computed as `featured_at IS NOT NULL AND trusted`, so an owner republish drops the listing from onboarding without an explicit revoke.
- `primitives.yaml` updated in this PR (`community-listings` summary + migration path).

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6b52-408c-7980-912f-990f1eead4a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6b52-408c-7980-912f-990f1eead4a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can mark effectively trusted community listings as **featured**, making them appear as **onboarding starter packages**.
  * Adds an admin-only **“Feature in onboarding”** control and Featured badge; featuring is cleared when trust is revoked and handled correctly across republish flows.
  * Onboarding falls back to **exploring community packages** when no featured listings exist.
* **Documentation**
  * Updated contributing and usage docs for featured listings and onboarding behavior, including the new admin MCP capability.
* **Tests**
  * Added end-to-end coverage for permissions, validation, UI/API behavior, and onboarding visibility/state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->