### PR TITLE
Make onboarding a public route

### DIFF
--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -76,12 +76,14 @@ export async function homeRouteLoader(
 export function HomeRoute(handle: Handle) {
 	let needsOnboarding = false
 	let emailVerified = false
+	let loggedIn = false
 	let onboardingStatus: 'idle' | 'loading' | 'ready' = 'idle'
 	const loadLatch = createRouteLoadLatch()
 
 	function applyOnboardingPayload(payload: OnboardingPayload | null) {
 		needsOnboarding = payload?.needsOnboarding === true
 		emailVerified = payload?.emailVerified === true
+		loggedIn = payload?.loggedIn === true
 		onboardingStatus = 'ready'
 	}
 
@@ -160,6 +162,7 @@ export function HomeRoute(handle: Handle) {
 					<div>
 						{onboardingStatus === 'ready' &&
 						needsOnboarding &&
+						loggedIn &&
 						!emailVerified ? (
 							<a href={pendingVerificationPath} mix={css(heroCtaCss)}>
 								Verify your email

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -25,7 +25,6 @@ import { renderByokExplainer } from '#client/routes/byok-explainer.tsx'
 import { OnboardingMcpClientTabs } from '#client/routes/onboarding-mcp-client-tabs.tsx'
 import {
 	onboardingPath,
-	resolveOnboardingLoginPath,
 	resolveOnboardingPendingVerificationPath,
 } from '#client/routes/onboarding-redirect.ts'
 import { colors, typography } from '#client/styles/tokens.ts'
@@ -42,6 +41,7 @@ import {
 
 export type OnboardingPayload = {
 	ok: true
+	loggedIn: boolean
 	mcpServerUrl: string
 	setupPrompt: string
 	hasMcpClient: boolean
@@ -73,14 +73,11 @@ export async function onboardingRouteLoader(
 		credentials: 'include',
 		signal,
 	})
-	if (response.status === 401) {
-		return routeLoaderRedirect(resolveOnboardingLoginPath(redirectTo))
-	}
 	const payload = await readJson<OnboardingPayload>(response)
 	if (!response.ok || !payload?.ok) {
 		throw new Error('Unable to load onboarding.')
 	}
-	if (!payload.emailVerified) {
+	if (payload.loggedIn && !payload.emailVerified) {
 		return routeLoaderRedirect(
 			resolveOnboardingPendingVerificationPath(redirectTo),
 		)
@@ -94,7 +91,6 @@ export async function fetchOnboardingPayload(signal?: AbortSignal) {
 		credentials: 'include',
 		signal,
 	})
-	if (response.status === 401) return null
 	const payload = await readJson<OnboardingPayload>(response)
 	if (!response.ok || !payload?.ok) return null
 	return payload
@@ -103,6 +99,7 @@ export async function fetchOnboardingPayload(signal?: AbortSignal) {
 export function OnboardingRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
 	let message: string | null = null
+	let loggedIn = false
 	let mcpServerUrl = ''
 	let setupPrompt = ''
 	let hasMcpClient = false
@@ -110,6 +107,7 @@ export function OnboardingRoute(handle: Handle) {
 	const loadLatch = createRouteLoadLatch()
 
 	function applyPayload(payload: OnboardingPayload) {
+		loggedIn = payload.loggedIn
 		mcpServerUrl = payload.mcpServerUrl
 		setupPrompt = payload.setupPrompt
 		hasMcpClient = payload.hasMcpClient
@@ -128,15 +126,11 @@ export function OnboardingRoute(handle: Handle) {
 				signal,
 			})
 			if (signal.aborted) return
-			if (response.status === 401) {
-				window.location.assign(resolveOnboardingLoginPath(redirectTo))
-				return
-			}
 			const payload = await readJson<OnboardingPayload>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load onboarding.')
 			}
-			if (!payload.emailVerified) {
+			if (payload.loggedIn && !payload.emailVerified) {
 				window.location.assign(
 					resolveOnboardingPendingVerificationPath(redirectTo),
 				)
@@ -159,7 +153,7 @@ export function OnboardingRoute(handle: Handle) {
 		if (!isOnboardingPath(href)) return false
 		const routeData = tryConsumeRouteLoaderData(handle, 'onboarding', href)
 		if (!routeData) return false
-		if (!routeData.emailVerified) {
+		if (routeData.loggedIn && !routeData.emailVerified) {
 			window.location.assign(
 				resolveOnboardingPendingVerificationPath(
 					readOnboardingRedirectTo(handle),
@@ -301,17 +295,31 @@ export function OnboardingRoute(handle: Handle) {
 						)}
 
 						<p mix={css({ margin: 0 })}>
-							<a href="/account" mix={css(mutedLinkCss)}>
-								Back to account
-							</a>
-							{' · '}
-							<a href="/account/secrets" mix={css(primaryLinkCss)}>
-								Secrets
-							</a>
-							{' · '}
-							<a href="/account/integrations" mix={css(primaryLinkCss)}>
-								Integrations
-							</a>
+							{loggedIn ? (
+								<>
+									<a href="/account" mix={css(mutedLinkCss)}>
+										Back to account
+									</a>
+									{' · '}
+									<a href="/account/secrets" mix={css(primaryLinkCss)}>
+										Secrets
+									</a>
+									{' · '}
+									<a href="/account/integrations" mix={css(primaryLinkCss)}>
+										Integrations
+									</a>
+								</>
+							) : (
+								<>
+									<a href="/signup" mix={css(primaryLinkCss)}>
+										Sign up
+									</a>
+									{' · '}
+									<a href="/login" mix={css(mutedLinkCss)}>
+										Log in
+									</a>
+								</>
+							)}
 						</p>
 					</>
 				) : null}

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -1,101 +1,39 @@
 import { expect, test, vi } from 'vitest'
 import { RequestContext } from 'remix/router'
-import {
-	createAuthCookie,
-	setAuthSessionSecret,
-	type AuthSession,
-} from '#app/auth-session.ts'
+import { setAuthSessionSecret } from '#app/auth-session.ts'
 import {
 	createOnboardingApiHandler,
 	createOnboardingHandler,
 } from '#app/handlers/onboarding.ts'
+import { buildOnboardingSetupPrompt } from '#app/onboarding-data.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
-
-vi.mock('#app/onboarding-data.ts', () => ({
-	loadOnboardingData: vi.fn(async () => ({
-		ok: true,
-		mcpServerUrl: 'https://example.com/mcp',
-		setupPrompt: 'Help me get started with Kody.',
-		hasMcpClient: false,
-		emailVerified: true,
-		needsOnboarding: true,
-	})),
-}))
 
 vi.mock('#app/ssr-render.tsx', () => ({
 	renderAppPage: vi.fn(async () => new Response('ok')),
 }))
 
-function createStaleSessionTestEnv() {
-	return {
-		COOKIE_SECRET: testCookieSecret,
-		APP_DB: {
-			prepare(query: string) {
-				const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
-				return {
-					bind() {
-						return {
-							async all() {
-								if (
-									normalizedQuery.startsWith('select') &&
-									normalizedQuery.includes('from "users"')
-								) {
-									return { results: [], meta: { changes: 0 } }
-								}
-								if (normalizedQuery.includes('from user_roles ur')) {
-									return { results: [], meta: { changes: 0 } }
-								}
-								return { results: [], meta: { changes: 0 } }
-							},
-							async first() {
-								return null
-							},
-							async run() {
-								return { meta: { changes: 0 } }
-							},
-						}
-					},
-				}
-			},
-			async exec() {
-				return
-			},
-		} as unknown as D1Database,
-	} as Env
-}
-
-test('onboarding routes require a live session and reject anonymous API access', async () => {
+test('onboarding serves public setup content to anonymous visitors', async () => {
 	setAuthSessionSecret(testCookieSecret)
-	const env = createStaleSessionTestEnv()
-	const session: AuthSession = {
-		id: '99',
-		email: 'missing@example.com',
-		rememberMe: false,
-	}
-	const cookie = await createAuthCookie(session, false)
+	const env = { COOKIE_SECRET: testCookieSecret } as Env
 
-	const staleSessionResponse = await createOnboardingHandler(env).handler(
-		new RequestContext(
-			new Request('https://example.com/onboarding', {
-				headers: { Cookie: cookie },
-			}),
-		),
+	const anonymousPageResponse = await createOnboardingHandler(env).handler(
+		new RequestContext(new Request('https://example.com/onboarding')),
 	)
-	expect(staleSessionResponse.status).toBe(302)
-	expect(staleSessionResponse.headers.get('Location')).toBe(
-		'https://example.com/login?redirectTo=%2Fonboarding',
-	)
-	const setCookie = staleSessionResponse.headers.get('Set-Cookie') ?? ''
-	expect(setCookie).toContain('kody_session=')
-	expect(setCookie).toContain('Max-Age=0')
+	expect(anonymousPageResponse.status).toBe(200)
 
 	const anonymousApiResponse = await createOnboardingApiHandler(env).handler(
 		new RequestContext(new Request('https://example.com/onboarding.json')),
 	)
-	expect(anonymousApiResponse.status).toBe(401)
+	expect(anonymousApiResponse.status).toBe(200)
 	await expect(anonymousApiResponse.json()).resolves.toEqual({
-		ok: false,
-		error: 'Unauthorized.',
+		ok: true,
+		loggedIn: false,
+		mcpServerUrl: 'https://example.com/mcp',
+		setupPrompt: buildOnboardingSetupPrompt(),
+		hasMcpClient: false,
+		emailVerified: false,
+		needsOnboarding: true,
+		featuredListings: [],
 	})
 })

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -13,6 +13,10 @@ vi.mock('#app/ssr-render.tsx', () => ({
 	renderAppPage: vi.fn(async () => new Response('ok')),
 }))
 
+vi.mock('#worker/community/service.ts', () => ({
+	listFeaturedCommunityListingsWithAggregates: vi.fn(async () => []),
+}))
+
 test('onboarding serves public setup content to anonymous visitors', async () => {
 	setAuthSessionSecret(testCookieSecret)
 	const env = { COOKIE_SECRET: testCookieSecret } as Env

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -1,15 +1,13 @@
 import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
-import {
-	normalizeRedirectTo,
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
+import { normalizeRedirectTo } from '#app/auth-redirect.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { loadOnboardingFeaturedListings } from '#app/community-data.ts'
-import { loadOnboardingData } from '#app/onboarding-data.ts'
+import {
+	loadOnboardingData,
+	loadPublicOnboardingData,
+} from '#app/onboarding-data.ts'
 import { createPageOgHeadNode } from '#app/ssr-document.tsx'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
@@ -30,14 +28,26 @@ export function createOnboardingHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
 			const user = await readAuthenticatedAppUser(request, env)
 			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+				const onboarding = {
+					...loadPublicOnboardingData({
+						env,
+						requestUrl: request.url,
+					}),
+					featuredListings: await loadOnboardingFeaturedListings(
+						env,
+						request,
+					),
+				}
+				const origin = getAppBaseUrl({ env, requestUrl: request.url })
+				return renderAppPage({
+					request,
+					env,
+					title: 'Get started',
+					extraHead: createPageOgHeadNode({ origin, pageId: 'onboarding' }),
+					loaderData: { onboarding },
+				})
 			}
 
 			if (!user.emailVerified) {
@@ -67,13 +77,22 @@ export function createOnboardingApiHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
-			}
-
 			if (request.method !== 'GET') {
 				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+			}
+
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return jsonResponse({
+					...loadPublicOnboardingData({
+						env,
+						requestUrl: request.url,
+					}),
+					featuredListings: await loadOnboardingFeaturedListings(
+						env,
+						request,
+					),
+				})
 			}
 
 			// Unverified callers still get a payload so clients can detect the

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -35,10 +35,7 @@ export function createOnboardingHandler(env: Env) {
 						env,
 						requestUrl: request.url,
 					}),
-					featuredListings: await loadOnboardingFeaturedListings(
-						env,
-						request,
-					),
+					featuredListings: await loadOnboardingFeaturedListings(env, request),
 				}
 				const origin = getAppBaseUrl({ env, requestUrl: request.url })
 				return renderAppPage({
@@ -88,10 +85,7 @@ export function createOnboardingApiHandler(env: Env) {
 						env,
 						requestUrl: request.url,
 					}),
-					featuredListings: await loadOnboardingFeaturedListings(
-						env,
-						request,
-					),
+					featuredListings: await loadOnboardingFeaturedListings(env, request),
 				})
 			}
 

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -348,6 +348,7 @@ export type AccountConnectionsLoaderData = {
 
 export type OnboardingLoaderData = {
 	ok: true
+	loggedIn: boolean
 	mcpServerUrl: string
 	setupPrompt: string
 	hasMcpClient: boolean

--- a/packages/worker/src/app/onboarding-data.node.test.ts
+++ b/packages/worker/src/app/onboarding-data.node.test.ts
@@ -3,6 +3,7 @@ import {
 	buildMcpServerUrl,
 	buildOnboardingSetupPrompt,
 	loadOnboardingData,
+	loadPublicOnboardingData,
 } from '#app/onboarding-data.ts'
 
 test('onboarding data builds the MCP URL and derives incomplete setup from verification plus grants', async () => {
@@ -25,6 +26,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 	})
 	expect(withoutClient).toEqual({
 		ok: true,
+		loggedIn: true,
 		mcpServerUrl: 'https://heykody.dev/mcp',
 		setupPrompt: buildOnboardingSetupPrompt(),
 		hasMcpClient: false,
@@ -86,4 +88,22 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 	})
 	expect(whenProviderListingFails.hasMcpClient).toBe(false)
 	expect(whenProviderListingFails.needsOnboarding).toBe(true)
+})
+
+test('public onboarding data exposes setup content without an authenticated user', () => {
+	expect(
+		loadPublicOnboardingData({
+			env: { APP_BASE_URL: 'https://heykody.dev' },
+			requestUrl: 'https://heykody.dev/onboarding',
+		}),
+	).toEqual({
+		ok: true,
+		loggedIn: false,
+		mcpServerUrl: 'https://heykody.dev/mcp',
+		setupPrompt: buildOnboardingSetupPrompt(),
+		hasMcpClient: false,
+		emailVerified: false,
+		needsOnboarding: true,
+		featuredListings: [],
+	})
 })

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -52,6 +52,25 @@ export async function userHasMcpOAuthGrants(
 	}
 }
 
+export function loadPublicOnboardingData(input: {
+	env: Pick<OnboardingEnv, 'APP_BASE_URL'>
+	requestUrl: string | URL
+}): OnboardingLoaderData {
+	return {
+		ok: true,
+		loggedIn: false,
+		mcpServerUrl: buildMcpServerUrl({
+			env: input.env,
+			requestUrl: input.requestUrl,
+		}),
+		setupPrompt: buildOnboardingSetupPrompt(),
+		hasMcpClient: false,
+		emailVerified: false,
+		needsOnboarding: true,
+		featuredListings: [],
+	}
+}
+
 export async function loadOnboardingData(input: {
 	env: OnboardingEnv
 	requestUrl: string | URL
@@ -82,6 +101,7 @@ export async function loadOnboardingData(input: {
 	const setupPrompt = input.emailVerified ? buildOnboardingSetupPrompt() : ''
 	return {
 		ok: true,
+		loggedIn: true,
 		mcpServerUrl,
 		setupPrompt,
 		hasMcpClient,

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -260,6 +260,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	})
 	expect(accountProps.loaderData?.onboarding).toEqual({
 		ok: true,
+		loggedIn: true,
 		mcpServerUrl: '',
 		setupPrompt: '',
 		hasMcpClient: false,
@@ -311,10 +312,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		createOnboardingHandler(env),
 		new Request('https://example.com/onboarding'),
 	)
-	expect(anonymousOnboardingResponse.status).toBe(302)
-	expect(anonymousOnboardingResponse.headers.get('Location')).toBe(
-		'https://example.com/login?redirectTo=%2Fonboarding',
-	)
+	expect(anonymousOnboardingResponse.status).toBe(200)
 
 	const anonymousAccountResponse = await runHtmlHandler(
 		createAccountHandler(env),

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -27,6 +27,7 @@ vi.mock('#worker/community/service.ts', () => ({
 		communityMockModule.searchCommunityListings(...args),
 	getCommunityListingWithAggregates: vi.fn(),
 	reportCommunityListing: vi.fn(),
+	listFeaturedCommunityListingsWithAggregates: vi.fn(async () => []),
 }))
 
 const sampleListing = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Onboarding (`/onboarding` and `/onboarding.json`) is now reachable without signing in. Anonymous visitors see the MCP setup guide, client tabs, and starter prompt. Logged-in but unverified users still redirect to pending verification.

## Changes

- Add `loadPublicOnboardingData` for anonymous onboarding payloads (includes MCP URL and setup prompt).
- Serve public onboarding from the page and JSON handlers instead of redirecting to login.
- Add `loggedIn` to onboarding loader data so clients only gate verified-account flows for signed-in users.
- Home hero CTA shows "Verify your email" only for logged-in unverified users, not anonymous visitors.
- Onboarding footer shows Sign up / Log in links for anonymous visitors instead of account links.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `f66d471d`

**Classification:** extends — adjusts onboarding route auth behavior and loader payload shape without adding new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `remix-app` | surfaces | extends — `/onboarding` and `/onboarding.json` are now public; payload adds `loggedIn` |

### What changed

- Anonymous visitors get full MCP setup content instead of a login redirect.
- Verified-account gating (pending verification redirect) remains for signed-in unverified users.
- Home and onboarding client routes use `loggedIn` to distinguish anonymous vs authenticated state.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d42474a0-6061-4e6f-998e-882b1558a100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d42474a0-6061-4e6f-998e-882b1558a100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding is now accessible without signing in, allowing visitors to view the public “Get started” experience.
  * Logged-in users with unverified email addresses are directed to email verification.
  * Onboarding navigation now displays account links for signed-in users and sign-up or login links for visitors.

* **Bug Fixes**
  * Improved onboarding CTA behavior so verification prompts appear only for logged-in users.
  * Preserved destination links when redirecting users to email verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->