### PR TITLE
Set waitlist banner form margin-bottom to 0

### DIFF
--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -202,6 +202,7 @@ const formCss = {
 	alignItems: 'stretch',
 	gap: spacing.xs,
 	flexWrap: 'wrap' as const,
+	marginBottom: 0,
 	[mq.mobile]: {
 		width: '100%',
 	},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes extra spacing below the "Join the waiting list" banner form on narrow layouts where the flex-wrapped fields stack.

## Change

- Add `marginBottom: 0` to `formCss` in `waitlist-banner.tsx`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/waitlist-banner-form-margin-b5e2`

**Classification:** composes — styling-only change to the existing waitlist banner UI; no primitives added or changed.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `auth` | surfaces | composes — waitlist banner form spacing |

### What changed

- Set `marginBottom: 0` on the waitlist banner `<form>` to eliminate unwanted gap when fields wrap on mobile.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca828deb-6e51-480a-9bd1-17b6c68eb5e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca828deb-6e51-480a-9bd1-17b6c68eb5e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted waitlist banner form spacing to remove extra bottom margin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->