### PR TITLE
Fix flaky Cloudflare mock startup

### DIFF
--- a/packages/worker/src/app/email/cloudflare-email.node.test.ts
+++ b/packages/worker/src/app/email/cloudflare-email.node.test.ts
@@ -178,4 +178,4 @@ test('sendCloudflareEmail delivers through the mock API and handles configuratio
 	// consoleWarn must not have picked up anything new.
 	expect(consoleWarn).toHaveBeenCalledTimes(1)
 	expect(consoleInfo).toHaveBeenCalledTimes(1)
-})
+}, 75_000)

--- a/packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts
+++ b/packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts
@@ -63,4 +63,4 @@ test('Cloudflare mock implements the Artifacts REST workflow used in local dev',
 		artifactRepoCount?: number
 	}
 	expect(meta.artifactRepoCount).toBe(1)
-}, 40_000)
+}, 75_000)

--- a/packages/worker/src/test-support/cloudflare-mock-server.ts
+++ b/packages/worker/src/test-support/cloudflare-mock-server.ts
@@ -1,4 +1,5 @@
 import { setTimeout as delay } from 'node:timers/promises'
+import { stripVTControlCharacters } from 'node:util'
 import {
 	captureOutput,
 	spawnProcess,
@@ -22,7 +23,9 @@ async function waitForCloudflareMock(
 	)
 	while (Date.now() < deadline) {
 		const output = `${readStdout()}\n${readStderr()}`
-		const readyMatch = output.match(/\bReady on (http:\/\/127\.0\.0\.1:\d+)\b/)
+		const readyMatch = stripVTControlCharacters(output).match(
+			/\bReady on (http:\/\/127\.0\.0\.1:\d+)\b/,
+		)
 		const origin = readyMatch?.[1]
 		if (origin) {
 			try {

--- a/packages/worker/src/test-support/cloudflare-mock-server.ts
+++ b/packages/worker/src/test-support/cloudflare-mock-server.ts
@@ -28,14 +28,19 @@ async function waitForCloudflareMock(
 		)
 		const origin = readyMatch?.[1]
 		if (origin) {
+			let response: Response | undefined
 			try {
-				const response = await fetch(`${origin}/__mocks/meta`)
+				const remainingTime = Math.max(1, deadline - Date.now())
+				response = await fetch(`${origin}/__mocks/meta`, {
+					signal: AbortSignal.timeout(Math.min(1_000, remainingTime)),
+				})
 				if (response.ok) {
-					await response.body?.cancel()
 					return origin
 				}
 			} catch {
 				/* retry */
+			} finally {
+				await response?.body?.cancel()
 			}
 		}
 

--- a/packages/worker/src/test-support/cloudflare-mock-server.ts
+++ b/packages/worker/src/test-support/cloudflare-mock-server.ts
@@ -1,4 +1,3 @@
-import getPort from 'get-port'
 import { setTimeout as delay } from 'node:timers/promises'
 import {
 	captureOutput,
@@ -9,28 +8,52 @@ import {
 
 const workerConfig = 'packages/mock-servers/cloudflare/wrangler.jsonc'
 const projectRoot = process.cwd()
+const startupTimeout = 60_000
 
-async function waitForCloudflareMock(origin: string) {
-	const deadline = Date.now() + 25_000
+async function waitForCloudflareMock(
+	proc: ReturnType<typeof spawnProcess>,
+	readStdout: () => string,
+	readStderr: () => string,
+) {
+	const deadline = Date.now() + startupTimeout
+	const exited = proc.exited.then(
+		(code) => ({ status: 'exited' as const, code }),
+		(error: unknown) => ({ status: 'error' as const, error }),
+	)
 	while (Date.now() < deadline) {
-		try {
-			const response = await fetch(`${origin}/__mocks/meta`)
-			if (response.ok) {
-				await response.body?.cancel()
-				return
+		const output = `${readStdout()}\n${readStderr()}`
+		const readyMatch = output.match(/\bReady on (http:\/\/127\.0\.0\.1:\d+)\b/)
+		const origin = readyMatch?.[1]
+		if (origin) {
+			try {
+				const response = await fetch(`${origin}/__mocks/meta`)
+				if (response.ok) {
+					await response.body?.cancel()
+					return origin
+				}
+			} catch {
+				/* retry */
 			}
-		} catch {
-			/* retry */
 		}
-		await delay(200)
+
+		const exitResult = await Promise.race([exited, delay(200).then(() => null)])
+		if (exitResult?.status === 'error') {
+			throw new Error('mock cloudflare failed to start', {
+				cause: exitResult.error,
+			})
+		}
+		if (exitResult?.status === 'exited') {
+			throw new Error(
+				`mock cloudflare exited before becoming ready (code ${String(exitResult.code)})\n${output}`,
+			)
+		}
 	}
-	throw new Error('mock cloudflare timeout')
+	throw new Error(
+		`mock cloudflare did not become ready within ${startupTimeout}ms\n${readStdout()}\n${readStderr()}`,
+	)
 }
 
 export async function startCloudflareMock(token: string) {
-	const port = await getPort({ host: '127.0.0.1' })
-	const origin = `http://127.0.0.1:${port}`
-	const inspectorPort = await getPort({ host: '127.0.0.1' })
 	const proc = spawnProcess({
 		cmd: [
 			wranglerBin,
@@ -41,29 +64,28 @@ export async function startCloudflareMock(token: string) {
 			'--var',
 			`MOCK_API_TOKEN:${token}`,
 			'--port',
-			String(port),
+			'0',
 			'--inspector-port',
-			String(inspectorPort),
+			'0',
 			'--ip',
 			'127.0.0.1',
 			'--show-interactive-dev-session=false',
 			'--log-level',
-			'error',
+			'info',
 		],
 		cwd: projectRoot,
 	})
-	captureOutput(proc.stdout)
-	captureOutput(proc.stderr)
-	const mock = {
-		origin,
-		token,
-		async [Symbol.asyncDispose]() {
-			await stopProcess(proc)
-		},
-	}
+	const readStdout = captureOutput(proc.stdout)
+	const readStderr = captureOutput(proc.stderr)
 	try {
-		await waitForCloudflareMock(origin)
-		return mock
+		const origin = await waitForCloudflareMock(proc, readStdout, readStderr)
+		return {
+			origin,
+			token,
+			async [Symbol.asyncDispose]() {
+				await stopProcess(proc)
+			},
+		}
 	} catch (error) {
 		await stopProcess(proc)
 		throw error


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- let Wrangler atomically allocate both the mock server and inspector ports instead of probing and releasing ports before startup
- discover Wrangler's assigned public origin from ANSI-normalized readiness output, then verify the mock metadata endpoint with bounded probes
- fail immediately with captured Wrangler diagnostics when the child exits, and allow 60 seconds for startup under loaded CI runners
- align both integration-test timeouts with the helper's startup budget

## Root cause
`get-port` only proved a port was free and then released it. During `npm run validate`, unit, Playwright, and MCP suites run concurrently and can start competing Wrangler processes, so another process could bind either selected port before this helper's Wrangler did. The helper then discarded Wrangler's output and polled the dead origin for 25 seconds, producing only `mock cloudflare timeout`.

Wrangler now binds port `0` atomically and reports the assigned origin. Its CI output includes ANSI control sequences inside the URL, so the helper strips those sequences before parsing the readiness line. Each metadata probe is bounded to one second (or the remaining startup budget) so a half-open response cannot bypass the overall deadline.

## Test evidence
- targeted Cloudflare mock tests: 2/2 passed
- ANSI/CI reproduction (`FORCE_COLOR=3`): 2/2 passed after reproducing the pre-fix timeout
- cross-process ANSI startup stress: 12/12 artifacts workflow runs passed with 6 concurrent Vitest processes
- `npm run validate`: passed (263 unit files / 864 unit tests, 18 Playwright tests, MCP suite, typecheck, lint, and formatting)
- PR checks: Validate, preview resources, Cursor Bugbot, and CodeRabbit passed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `75cd1b6c` · **Head:** `2eda3994`

**Classification:** composes — this PR changes only the local test harness and test time budgets; no production primitive behavior or contract changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `artifacts-repos` | storage | composes — stabilizes the local mock used to verify the existing Artifacts REST workflow |

### System map

The focused integration test continues to exercise the existing Artifacts repository contract through a more reliable Wrangler mock startup path.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	artifactsRepos["artifacts-repos<br/>Artifacts repos"]:::touched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8576da9-a25b-4fe9-b7d1-57acaa5ab65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8576da9-a25b-4fe9-b7d1-57acaa5ab65d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cloudflare mock startup detection with more reliable readiness checks and clearer errors for early process exit or startup timeout.
  * Updated the local Cloudflare dev server launch behavior to use dynamic ports and enhanced logging for better stability.
  * Increased Vitest timeouts for email-sending and Cloudflare artifacts workflow tests to reduce intermittent failures in slower environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->