### PR TITLE
Nudge repeated raw-fetch hosts toward OpenAPI bindings or packages

### DIFF
--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -11,6 +11,11 @@ import { sha256Base64Url } from '@kody-internal/shared/sha256.ts'
 import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { exports as workerExports } from 'cloudflare:workers'
 import { type FetchGatewayProps } from '#mcp/fetch-gateway.ts'
+import {
+	readBaseUrlHostname,
+	wrapOutboundFetcherRecordingHosts,
+	type RawFetchHostSink,
+} from '#mcp/raw-fetch-host-nudge.ts'
 import { extractMcpPassthrough } from '#mcp/downstream-mcp-result.ts'
 import { recordUsage, type UsageEnv } from '#worker/usage/record-usage.ts'
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
@@ -214,6 +219,12 @@ export function createExecuteExecutor(input: {
 	gatewayProps: FetchGatewayProps
 	modules?: WorkerLoaderModules
 	timeoutMs?: number | null
+	/**
+	 * Optional sink for literal hostnames observed on ad hoc execute raw
+	 * `fetch` traffic (before the fetch gateway). Package-context runs should
+	 * omit this so saved-package outbound requests are not counted.
+	 */
+	rawFetchHostSink?: RawFetchHostSink
 }) {
 	const loopbackExports = input.exports ?? workerExports
 	if (!loopbackExports?.KodyFetchGateway) {
@@ -225,12 +236,22 @@ export function createExecuteExecutor(input: {
 		input.timeoutMs === null
 			? maxSupportedExecutorTimeoutMs
 			: (input.timeoutMs ?? 90_000)
+	const gatewayOutbound = loopbackExports.KodyFetchGateway({
+		props: input.gatewayProps,
+	})
+	const globalOutbound = input.rawFetchHostSink
+		? wrapOutboundFetcherRecordingHosts(
+				gatewayOutbound,
+				input.rawFetchHostSink,
+				{
+					excludedHostname: readBaseUrlHostname(input.gatewayProps.baseUrl),
+				},
+			)
+		: gatewayOutbound
 	return createStableDynamicWorkerExecutor({
 		loader: input.env.LOADER,
 		timeout,
-		globalOutbound: loopbackExports.KodyFetchGateway({
-			props: input.gatewayProps,
-		}),
+		globalOutbound,
 		modules: input.modules,
 		gatewayProps: input.gatewayProps,
 		appCommitSha: input.env.APP_COMMIT_SHA ?? null,

--- a/packages/worker/src/mcp/index.ts
+++ b/packages/worker/src/mcp/index.ts
@@ -19,9 +19,11 @@ import { createRemoteConnectorMcpClient } from '#worker/remote-connector/client.
 import { remoteConnectorDomainId } from '#worker/remote-connector/remote-domain-id.ts'
 import { normalizeRemoteConnectorRefs } from '@kody-internal/shared/remote-connectors.ts'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { type RawFetchHostNudgeState } from '#mcp/raw-fetch-host-nudge.ts'
 
 export type State = {
 	searchConversationIdsWithPreamble?: Array<string>
+	rawFetchHostNudges?: RawFetchHostNudgeState
 }
 export type Props = McpServerProps
 
@@ -58,6 +60,10 @@ async function loadRemoteConnectorInstructionSummaries(input: {
 class MCPBase extends McpAgent<Env, State, Props> {
 	initialState: State = {
 		searchConversationIdsWithPreamble: [],
+		rawFetchHostNudges: {
+			conversationOrder: [],
+			byConversation: {},
+		},
 	}
 	declare server: McpServer
 	async init() {

--- a/packages/worker/src/mcp/raw-fetch-host-nudge.node.test.ts
+++ b/packages/worker/src/mcp/raw-fetch-host-nudge.node.test.ts
@@ -1,0 +1,156 @@
+import { expect, test, vi } from 'vitest'
+import {
+	applyRawFetchHostCounts,
+	createRawFetchHostSink,
+	formatRawFetchHostNudge,
+	listHostsApproachingRawFetchNudge,
+	maxRawFetchHostConversations,
+	maxRawFetchHostsPerConversation,
+	rawFetchHostNudgeThreshold,
+	readBaseUrlHostname,
+	readHostnameFromFetchInput,
+	readLiteralRequestHostname,
+	wrapOutboundFetcherRecordingHosts,
+} from '#mcp/raw-fetch-host-nudge.ts'
+
+test('raw-fetch host nudge counts hosts, tips at threshold once, excludes covered/own hosts, and evicts capped state', async () => {
+	expect(readLiteralRequestHostname('https://API.Notion.com/v1/pages')).toBe(
+		'api.notion.com',
+	)
+	expect(readLiteralRequestHostname('/relative')).toBe('')
+	expect(readLiteralRequestHostname('not a url')).toBe('')
+	expect(readBaseUrlHostname('https://heykody.dev/mcp')).toBe('heykody.dev')
+	expect(
+		readHostnameFromFetchInput(
+			new Request('https://api.kit.com/v4/subscribers'),
+		),
+	).toBe('api.kit.com')
+
+	const { sink, hostCounts } = createRawFetchHostSink()
+	const outboundFetch = vi.fn(async () => new Response('ok'))
+	const outbound = { fetch: outboundFetch } as unknown as Fetcher
+	const wrapped = wrapOutboundFetcherRecordingHosts(outbound, sink, {
+		excludedHostname: 'heykody.dev',
+	})
+
+	await wrapped.fetch('https://api.notion.com/v1/pages')
+	await wrapped.fetch(new URL('https://API.Notion.com/v1/users'))
+	await wrapped.fetch(new Request('https://heykody.dev/account'))
+	await wrapped.fetch('/local-path')
+	await wrapped.fetch('https://api.kit.com/v4/subscribers')
+
+	expect(outboundFetch).toHaveBeenCalledTimes(5)
+	expect(Object.fromEntries(hostCounts())).toEqual({
+		'api.notion.com': 2,
+		'api.kit.com': 1,
+	})
+
+	const belowThreshold = applyRawFetchHostCounts({
+		state: null,
+		conversationId: 'conv-a',
+		hostCounts: new Map([['api.notion.com', 2]]),
+	})
+	expect(belowThreshold.nudges).toEqual([])
+	expect(
+		belowThreshold.state.byConversation['conv-a']?.hosts['api.notion.com'],
+	).toEqual({ count: 2, nudged: false })
+	expect(
+		listHostsApproachingRawFetchNudge({
+			state: belowThreshold.state,
+			conversationId: 'conv-a',
+			hostCounts: new Map([['api.notion.com', 1]]),
+		}),
+	).toEqual(['api.notion.com'])
+
+	const tip = applyRawFetchHostCounts({
+		state: belowThreshold.state,
+		conversationId: 'conv-a',
+		hostCounts: { 'api.notion.com': 1 },
+	})
+	expect(tip.nudges).toEqual([
+		formatRawFetchHostNudge({
+			hostname: 'api.notion.com',
+			count: rawFetchHostNudgeThreshold,
+		}),
+	])
+	expect(tip.state.byConversation['conv-a']?.hosts['api.notion.com']).toEqual({
+		count: 3,
+		nudged: true,
+	})
+
+	const secondTipAttempt = applyRawFetchHostCounts({
+		state: tip.state,
+		conversationId: 'conv-a',
+		hostCounts: { 'api.notion.com': 5 },
+	})
+	expect(secondTipAttempt.nudges).toEqual([])
+	expect(
+		secondTipAttempt.state.byConversation['conv-a']?.hosts['api.notion.com']
+			?.count,
+	).toBe(8)
+
+	const covered = applyRawFetchHostCounts({
+		state: null,
+		conversationId: 'conv-b',
+		hostCounts: { 'api.transistor.fm': 3 },
+		coveredHosts: ['api.transistor.fm'],
+	})
+	expect(covered.nudges).toEqual([])
+	expect(
+		covered.state.byConversation['conv-b']?.hosts['api.transistor.fm'],
+	).toEqual({ count: 3, nudged: false })
+
+	let hostCapState = applyRawFetchHostCounts({
+		state: null,
+		conversationId: 'conv-hosts',
+		hostCounts: Object.fromEntries(
+			Array.from({ length: maxRawFetchHostsPerConversation }, (_, index) => [
+				`host-${index}.example`,
+				1,
+			]),
+		),
+	}).state
+	hostCapState = applyRawFetchHostCounts({
+		state: hostCapState,
+		conversationId: 'conv-hosts',
+		hostCounts: { 'host-overflow.example': 1 },
+	}).state
+	const cappedHosts = hostCapState.byConversation['conv-hosts']
+	expect(cappedHosts?.hostOrder).toHaveLength(maxRawFetchHostsPerConversation)
+	expect(cappedHosts?.hosts['host-0.example']).toBeUndefined()
+	expect(cappedHosts?.hosts['host-overflow.example']?.count).toBe(1)
+
+	let conversationCapState = null as
+		| ReturnType<typeof applyRawFetchHostCounts>['state']
+		| null
+	for (let index = 0; index < maxRawFetchHostConversations; index += 1) {
+		conversationCapState = applyRawFetchHostCounts({
+			state: conversationCapState,
+			conversationId: `conv-${index}`,
+			hostCounts: { 'api.example.com': 1 },
+		}).state
+	}
+	conversationCapState = applyRawFetchHostCounts({
+		state: conversationCapState,
+		conversationId: 'conv-overflow',
+		hostCounts: { 'api.example.com': 1 },
+	}).state
+	expect(conversationCapState.conversationOrder).toHaveLength(
+		maxRawFetchHostConversations,
+	)
+	expect(conversationCapState.byConversation['conv-0']).toBeUndefined()
+	expect(
+		conversationCapState.byConversation['conv-overflow']?.hosts[
+			'api.example.com'
+		]?.count,
+	).toBe(1)
+
+	const sameRunTip = applyRawFetchHostCounts({
+		state: null,
+		conversationId: 'conv-burst',
+		hostCounts: { 'api.notion.com': 3 },
+	})
+	expect(sameRunTip.nudges).toHaveLength(1)
+	expect(sameRunTip.nudges[0]).toContain('api.notion.com')
+	expect(sameRunTip.nudges[0]).toContain('3x')
+})

--- a/packages/worker/src/mcp/raw-fetch-host-nudge.ts
+++ b/packages/worker/src/mcp/raw-fetch-host-nudge.ts
@@ -1,0 +1,324 @@
+import { normalizeHost } from '#mcp/secrets/allowed-hosts.ts'
+
+/** Cumulative raw-fetch count that tips a one-line host nudge. */
+export const rawFetchHostNudgeThreshold = 3
+
+/** Cap tracked hostnames per conversation (FIFO eviction). */
+export const maxRawFetchHostsPerConversation = 20
+
+/** Cap tracked conversations in MCP agent DO state (FIFO eviction). */
+export const maxRawFetchHostConversations = 50
+
+export type RawFetchHostEntry = {
+	count: number
+	nudged: boolean
+}
+
+export type RawFetchHostConversationState = {
+	hostOrder: Array<string>
+	hosts: Record<string, RawFetchHostEntry>
+}
+
+export type RawFetchHostNudgeState = {
+	conversationOrder: Array<string>
+	byConversation: Record<string, RawFetchHostConversationState>
+}
+
+export type RawFetchHostSink = {
+	add: (hostname: string) => void
+}
+
+/**
+ * Read a hostname from a request URL string without ever consulting a
+ * secret-expanded URL. Placeholders contain `:`, which cannot appear in a
+ * parsed hostname, so a successfully parsed hostname is always literal.
+ */
+export function readLiteralRequestHostname(url: string) {
+	try {
+		return new URL(url).hostname
+	} catch {
+		return ''
+	}
+}
+
+export function createRawFetchHostSink() {
+	const counts = new Map<string, number>()
+	const sink: RawFetchHostSink = {
+		add(hostname) {
+			const normalized = normalizeHost(hostname)
+			if (!normalized) return
+			counts.set(normalized, (counts.get(normalized) ?? 0) + 1)
+		},
+	}
+	return {
+		sink,
+		snapshot(): Record<string, number> {
+			return Object.fromEntries(counts.entries())
+		},
+		hostCounts(): ReadonlyMap<string, number> {
+			return counts
+		},
+	}
+}
+
+export function readHostnameFromFetchInput(input: RequestInfo | URL) {
+	if (typeof input === 'string') {
+		return readLiteralRequestHostname(input)
+	}
+	if (input instanceof URL) {
+		return readLiteralRequestHostname(input.toString())
+	}
+	return readLiteralRequestHostname(input.url)
+}
+
+/**
+ * Wrap an outbound Fetcher so each ad hoc execute raw `fetch` records its
+ * literal hostname before the request reaches the fetch gateway.
+ */
+export function wrapOutboundFetcherRecordingHosts(
+	outbound: Fetcher,
+	sink: RawFetchHostSink,
+	options: { excludedHostname?: string | null } = {},
+): Fetcher {
+	const excluded = options.excludedHostname
+		? normalizeHost(options.excludedHostname)
+		: ''
+	return {
+		fetch(input: RequestInfo | URL, init?: RequestInit) {
+			const hostname = normalizeHost(readHostnameFromFetchInput(input))
+			if (hostname && hostname !== excluded) {
+				sink.add(hostname)
+			}
+			return outbound.fetch(input, init)
+		},
+	} as Fetcher
+}
+
+export function formatRawFetchHostNudge(input: {
+	hostname: string
+	count: number
+}) {
+	return `Raw-fetched ${input.hostname} ${input.count}x this conversation — consider openapi_binding_save or a saved package for this API (search for existing ones first).`
+}
+
+/**
+ * Hosts that would tip the nudge threshold after applying `hostCounts`, and
+ * have not already been nudged. Used to decide whether a binding-host lookup
+ * is worth doing on the execute hot path.
+ */
+export function listHostsApproachingRawFetchNudge(input: {
+	state: RawFetchHostNudgeState | null | undefined
+	conversationId: string
+	hostCounts: ReadonlyMap<string, number> | Record<string, number>
+}): Array<string> {
+	const conversationId = input.conversationId.trim()
+	if (!conversationId) return []
+	const state = normalizeRawFetchHostNudgeState(input.state)
+	const conversation = state.byConversation[conversationId]
+	const approaching: Array<string> = []
+	for (const [hostname, increment] of toHostCountEntries(input.hostCounts)) {
+		if (increment <= 0) continue
+		const existing = conversation?.hosts[hostname]
+		if (existing?.nudged) continue
+		const nextCount = (existing?.count ?? 0) + increment
+		if (nextCount >= rawFetchHostNudgeThreshold) {
+			approaching.push(hostname)
+		}
+	}
+	return approaching
+}
+
+export function applyRawFetchHostCounts(input: {
+	state: RawFetchHostNudgeState | null | undefined
+	conversationId: string
+	hostCounts: ReadonlyMap<string, number> | Record<string, number>
+	/** Hosts that already have a saved OpenAPI binding — never nudge these. */
+	coveredHosts?: ReadonlySet<string> | Iterable<string>
+}): {
+	state: RawFetchHostNudgeState
+	nudges: Array<string>
+} {
+	const conversationId = input.conversationId.trim()
+	if (!conversationId) {
+		return {
+			state: normalizeRawFetchHostNudgeState(input.state),
+			nudges: [],
+		}
+	}
+
+	const next = cloneRawFetchHostNudgeState(input.state)
+	const conversation = ensureConversationState(next, conversationId)
+	const covered = toNormalizedHostSet(input.coveredHosts)
+	const increments = toHostCountEntries(input.hostCounts)
+	const nudges: Array<string> = []
+
+	for (const [hostname, increment] of increments) {
+		if (increment <= 0) continue
+		const entry = ensureHostEntry(conversation, hostname)
+		entry.count += increment
+		touchHostOrder(conversation, hostname)
+
+		if (
+			entry.count >= rawFetchHostNudgeThreshold &&
+			!entry.nudged &&
+			!covered.has(hostname)
+		) {
+			entry.nudged = true
+			nudges.push(formatRawFetchHostNudge({ hostname, count: entry.count }))
+		}
+	}
+
+	trimConversationHosts(conversation)
+	trimConversations(next)
+	return { state: next, nudges }
+}
+
+export function normalizeRawFetchHostNudgeState(
+	state: RawFetchHostNudgeState | null | undefined,
+): RawFetchHostNudgeState {
+	return cloneRawFetchHostNudgeState(state)
+}
+
+export function readBaseUrlHostname(baseUrl: string) {
+	return normalizeHost(readLiteralRequestHostname(baseUrl.trim()))
+}
+
+function cloneRawFetchHostNudgeState(
+	state: RawFetchHostNudgeState | null | undefined,
+): RawFetchHostNudgeState {
+	const conversationOrder = Array.isArray(state?.conversationOrder)
+		? state.conversationOrder.filter(
+				(value): value is string =>
+					typeof value === 'string' && value.trim() !== '',
+			)
+		: []
+	const byConversation: Record<string, RawFetchHostConversationState> = {}
+	const source = state?.byConversation
+	if (source && typeof source === 'object') {
+		for (const conversationId of conversationOrder) {
+			const entry = source[conversationId]
+			if (!entry || typeof entry !== 'object') continue
+			const hostOrder = Array.isArray(entry.hostOrder)
+				? entry.hostOrder.filter(
+						(value): value is string =>
+							typeof value === 'string' && normalizeHost(value) !== '',
+					)
+				: []
+			const hosts: Record<string, RawFetchHostEntry> = {}
+			for (const hostname of hostOrder) {
+				const normalized = normalizeHost(hostname)
+				const hostEntry = entry.hosts?.[normalized] ?? entry.hosts?.[hostname]
+				const count =
+					typeof hostEntry?.count === 'number' &&
+					Number.isFinite(hostEntry.count) &&
+					hostEntry.count > 0
+						? Math.floor(hostEntry.count)
+						: 0
+				if (count <= 0) continue
+				hosts[normalized] = {
+					count,
+					nudged: hostEntry?.nudged === true,
+				}
+			}
+			byConversation[conversationId] = {
+				hostOrder: hostOrder
+					.map((hostname) => normalizeHost(hostname))
+					.filter((hostname, index, all) => {
+						return hostname !== '' && all.indexOf(hostname) === index
+					})
+					.filter((hostname) => hosts[hostname] != null),
+				hosts,
+			}
+		}
+	}
+	return { conversationOrder, byConversation }
+}
+
+function ensureConversationState(
+	state: RawFetchHostNudgeState,
+	conversationId: string,
+): RawFetchHostConversationState {
+	const existing = state.byConversation[conversationId]
+	if (existing) {
+		touchConversationOrder(state, conversationId)
+		return existing
+	}
+	const created: RawFetchHostConversationState = {
+		hostOrder: [],
+		hosts: {},
+	}
+	state.byConversation[conversationId] = created
+	touchConversationOrder(state, conversationId)
+	return created
+}
+
+function ensureHostEntry(
+	conversation: RawFetchHostConversationState,
+	hostname: string,
+): RawFetchHostEntry {
+	const existing = conversation.hosts[hostname]
+	if (existing) return existing
+	const created: RawFetchHostEntry = { count: 0, nudged: false }
+	conversation.hosts[hostname] = created
+	return created
+}
+
+function touchConversationOrder(
+	state: RawFetchHostNudgeState,
+	conversationId: string,
+) {
+	state.conversationOrder = [
+		...state.conversationOrder.filter((id) => id !== conversationId),
+		conversationId,
+	]
+}
+
+function touchHostOrder(
+	conversation: RawFetchHostConversationState,
+	hostname: string,
+) {
+	conversation.hostOrder = [
+		...conversation.hostOrder.filter((entry) => entry !== hostname),
+		hostname,
+	]
+}
+
+function trimConversationHosts(conversation: RawFetchHostConversationState) {
+	while (conversation.hostOrder.length > maxRawFetchHostsPerConversation) {
+		const evicted = conversation.hostOrder.shift()
+		if (!evicted) break
+		delete conversation.hosts[evicted]
+	}
+}
+
+function trimConversations(state: RawFetchHostNudgeState) {
+	while (state.conversationOrder.length > maxRawFetchHostConversations) {
+		const evicted = state.conversationOrder.shift()
+		if (!evicted) break
+		delete state.byConversation[evicted]
+	}
+}
+
+function toHostCountEntries(
+	hostCounts: ReadonlyMap<string, number> | Record<string, number>,
+) {
+	const entries =
+		hostCounts instanceof Map
+			? Array.from(hostCounts.entries())
+			: Object.entries(hostCounts)
+	return entries
+		.map(([hostname, count]) => [normalizeHost(hostname), count] as const)
+		.filter(([hostname, count]) => hostname !== '' && count > 0)
+}
+
+function toNormalizedHostSet(
+	hosts: ReadonlySet<string> | Iterable<string> | undefined,
+) {
+	const set = new Set<string>()
+	if (!hosts) return set
+	for (const host of hosts) {
+		const normalized = normalizeHost(host)
+		if (normalized) set.add(normalized)
+	}
+	return set
+}

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -11,6 +11,7 @@ import { exports as workerExports } from 'cloudflare:workers'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { normalizeRemoteConnectorRefs } from '@kody-internal/shared/remote-connectors.ts'
 import { createExecuteExecutor } from '#mcp/executor.ts'
+import { type RawFetchHostSink } from '#mcp/raw-fetch-host-nudge.ts'
 import {
 	getAdditionalPropertiesSchema,
 	getArrayItemSchema,
@@ -925,6 +926,7 @@ export async function runKodyWithRegistry(
 		packageInvokeTools?: PackageInvokeTools
 		packageEventTools?: PackageEventTools
 		capabilityRegistry?: BuiltCapabilityRegistry
+		rawFetchHostSink?: RawFetchHostSink
 	},
 ): Promise<ExecuteResult> {
 	const moduleSource = stripCodeFences(code.trim())
@@ -944,6 +946,7 @@ export async function runKodyWithRegistry(
 			packageEventTools: options?.packageEventTools,
 			executorTimeoutMs: options?.executorTimeoutMs,
 			capabilityRegistry: options?.capabilityRegistry,
+			rawFetchHostSink: options?.rawFetchHostSink,
 		})
 	}
 	const secretRedactor = createExecutionSecretRedactor()
@@ -960,6 +963,10 @@ export async function runKodyWithRegistry(
 			storageContext: normalizedStorageContext,
 		},
 		modules: options?.executorModules,
+		// Package-context runs are saved-package code; do not count their fetch hosts.
+		rawFetchHostSink: options?.packageContext
+			? undefined
+			: options?.rawFetchHostSink,
 	})
 	const workflowTools = createWorkflowTools({
 		env,
@@ -1079,6 +1086,7 @@ export async function runModuleWithRegistry(
 		packageInvokeTools?: PackageInvokeTools
 		packageEventTools?: PackageEventTools
 		capabilityRegistry?: BuiltCapabilityRegistry
+		rawFetchHostSink?: RawFetchHostSink
 	},
 ): Promise<ExecuteResult> {
 	const userId = callerContext.user?.userId ?? ''
@@ -1151,6 +1159,7 @@ export async function runBundledModuleWithRegistry(
 		executorTimeoutMs?: number | null
 		runtimeDebug?: PackageRuntimeDebugContext | null
 		capabilityRegistry?: BuiltCapabilityRegistry
+		rawFetchHostSink?: RawFetchHostSink
 	},
 ): Promise<ExecuteResult> {
 	const secretRedactor = createExecutionSecretRedactor()
@@ -1207,6 +1216,10 @@ export async function runBundledModuleWithRegistry(
 				userId: callerContext.user?.userId ?? '',
 				modules: bundle.modules,
 			}),
+			// Package-context runs are saved-package code; do not count their fetch hosts.
+			rawFetchHostSink: options?.packageContext
+				? undefined
+				: options?.rawFetchHostSink,
 		})
 		const workflowTools =
 			options?.workflowTools ??

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -14,6 +14,7 @@ const mockModule = vi.hoisted(() => ({
 			coding_guide_get: true,
 		},
 	})),
+	listOpenApiBindings: vi.fn(async () => []),
 }))
 
 vi.mock('#mcp/run-kody-registry.ts', () => ({
@@ -29,6 +30,11 @@ vi.mock('#mcp/capabilities/registry.ts', () => ({
 vi.mock('#worker/package-invocations/service.ts', () => ({
 	createExecutePackageInvokeTools: (...args: Array<unknown>) =>
 		mockModule.createExecutePackageInvokeTools(...args),
+}))
+
+vi.mock('#worker/openapi/binding-service.ts', () => ({
+	listOpenApiBindings: (...args: Array<unknown>) =>
+		mockModule.listOpenApiBindings(...args),
 }))
 
 const { registerExecuteTool } = await import('./execute.ts')
@@ -56,6 +62,10 @@ async function getExecuteHandler(
 		baseUrl: 'https://example.com',
 		user: null,
 	},
+	agentExtras: {
+		state?: Record<string, unknown>
+		setState?: (state: Record<string, unknown>) => void
+	} = {},
 ) {
 	vi.clearAllMocks()
 	const registerTool = vi.fn()
@@ -68,6 +78,7 @@ async function getExecuteHandler(
 		getCallerContext: vi.fn(() => callerContext),
 		requireDomain: vi.fn(),
 		getLoopbackExports: vi.fn(),
+		...agentExtras,
 	} as never)
 
 	expect(registerTool).toHaveBeenCalledTimes(1)
@@ -86,6 +97,7 @@ async function getExecuteHandler(
 			returnedBytes: number
 			truncated?: boolean
 			note?: string
+			warnings?: Array<string>
 			timing: {
 				startedAt: string
 				endedAt: string
@@ -532,4 +544,105 @@ test('execute passes through downstream MCP image content with structured data a
 	expect(tooManyBlocksResponse.structuredContent.error).toContain(
 		'too many MCP content blocks',
 	)
+})
+
+test('execute tool nudges repeated raw-fetch hosts once per conversation and skips OpenAPI-covered hosts', async () => {
+	const agentState: Record<string, unknown> = {}
+	const setState = vi.fn((next: Record<string, unknown>) => {
+		for (const key of Object.keys(agentState)) {
+			delete agentState[key]
+		}
+		Object.assign(agentState, next)
+	})
+	const handler = await getExecuteHandler(
+		{
+			baseUrl: 'https://example.com',
+			user: { userId: 'user-1', email: 'user@example.com' },
+		},
+		{
+			state: agentState,
+			setState,
+		},
+	)
+
+	mockModule.runModuleWithRegistry.mockImplementation(
+		async (
+			_env,
+			_ctx,
+			_code,
+			_params,
+			options: { rawFetchHostSink?: { add: (hostname: string) => void } },
+		) => {
+			options.rawFetchHostSink?.add('api.notion.com')
+			options.rawFetchHostSink?.add('api.notion.com')
+			return { result: { ok: true }, logs: [] }
+		},
+	)
+	mockPerformanceSequence(1, 2)
+	const below = await handler({
+		code: 'export default async () => ({ ok: true })',
+		conversationId: 'conv-nudge',
+	})
+	expect(below.structuredContent.warnings).toBeUndefined()
+	expect(
+		below.content.some(
+			(block) =>
+				block.type === 'text' &&
+				'text' in block &&
+				block.text.includes('Raw-fetched'),
+		),
+	).toBe(false)
+
+	mockPerformanceSequence(3, 4)
+	const tipped = await handler({
+		code: 'export default async () => ({ ok: true })',
+		conversationId: 'conv-nudge',
+	})
+	expect(tipped.structuredContent.warnings).toHaveLength(1)
+	expect(tipped.structuredContent.warnings?.[0]).toContain('api.notion.com')
+	expect(
+		tipped.content.some(
+			(block) =>
+				block.type === 'text' &&
+				'text' in block &&
+				typeof block.text === 'string' &&
+				block.text.includes('api.notion.com'),
+		),
+	).toBe(true)
+	expect(setState).toHaveBeenCalled()
+	expect(mockModule.listOpenApiBindings).toHaveBeenCalled()
+
+	mockPerformanceSequence(5, 6)
+	const again = await handler({
+		code: 'export default async () => ({ ok: true })',
+		conversationId: 'conv-nudge',
+	})
+	expect(again.structuredContent.warnings).toBeUndefined()
+
+	mockModule.listOpenApiBindings.mockResolvedValueOnce([
+		{
+			name: 'kit',
+			apiBaseUrl: 'https://api.kit.com/v4',
+		},
+	])
+	mockModule.runModuleWithRegistry.mockImplementationOnce(
+		async (
+			_env,
+			_ctx,
+			_code,
+			_params,
+			options: { rawFetchHostSink?: { add: (hostname: string) => void } },
+		) => {
+			options.rawFetchHostSink?.add('api.kit.com')
+			options.rawFetchHostSink?.add('api.kit.com')
+			options.rawFetchHostSink?.add('api.kit.com')
+			return { result: { ok: true }, logs: [] }
+		},
+	)
+	mockPerformanceSequence(7, 8)
+	const covered = await handler({
+		code: 'export default async () => ({ ok: true })',
+		conversationId: 'conv-covered',
+	})
+	expect(covered.structuredContent.warnings).toBeUndefined()
 })

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -39,6 +39,15 @@ import {
 import { repoRunCommandsExecuteSummary } from '#mcp/capabilities/repo/repo-run-commands-text.ts'
 import { finishToolTiming, startToolTiming } from './tool-timing.ts'
 import { prependToolMetadataContent } from './tool-response-content.ts'
+import {
+	applyRawFetchHostCounts,
+	createRawFetchHostSink,
+	listHostsApproachingRawFetchNudge,
+	readLiteralRequestHostname,
+	type RawFetchHostNudgeState,
+} from '#mcp/raw-fetch-host-nudge.ts'
+import { listOpenApiBindings } from '#worker/openapi/binding-service.ts'
+import { normalizeHost } from '#mcp/secrets/allowed-hosts.ts'
 
 const executeTool = {
 	name: 'execute',
@@ -237,6 +246,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 				const registeredCapabilityCount = Object.keys(
 					registry.capabilityHandlers,
 				).length
+				const rawFetchHosts = createRawFetchHostSink()
 				const result = await Sentry.startSpan(
 					{
 						name: 'mcp.tool.execute',
@@ -273,6 +283,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 											}
 										: undefined,
 									packageInvokeTools,
+									rawFetchHostSink: rawFetchHosts.sink,
 								},
 							)
 						} catch (cause) {
@@ -290,6 +301,13 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 				)
 				const timing = finishToolTiming(timingStart)
 				const durationMs = timing.durationMs
+				const rawFetchHostNudges = await resolveRawFetchHostNudges({
+					agent,
+					env,
+					callerContext,
+					conversationId: resolvedConversationId,
+					hostCounts: rawFetchHosts.hostCounts(),
+				})
 
 				if (result.error) {
 					const errorDetails = getExecutionErrorDetails(result.error)
@@ -314,6 +332,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 								type: 'text',
 								text: formatExecutionOutput(result),
 							},
+							...formatRawFetchHostNudgeContent(rawFetchHostNudges),
 							...formatSurfacedMemoriesMarkdown(surfacedMemories),
 						]),
 						structuredContent: {
@@ -324,6 +343,9 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							error: errorMessage,
 							errorDetails,
 							logs: result.logs ?? [],
+							...(rawFetchHostNudges.length > 0
+								? { warnings: rawFetchHostNudges }
+								: {}),
 							...buildMemoryStructuredContent(surfacedMemories),
 						},
 						isError: true,
@@ -422,6 +444,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					return {
 						content: prependToolMetadataContent(resolvedConversationId, [
 							...contentLimited.blocks,
+							...formatRawFetchHostNudgeContent(rawFetchHostNudges),
 							...formatSurfacedMemoriesMarkdown(surfacedMemories),
 						]),
 						structuredContent: {
@@ -441,6 +464,9 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 								? companionLimited.value
 								: (passthrough?.structuredResult ?? null),
 							logs: result.logs ?? [],
+							...(rawFetchHostNudges.length > 0
+								? { warnings: rawFetchHostNudges }
+								: {}),
 							...buildMemoryStructuredContent(surfacedMemories),
 						},
 						isError: passthrough?.isError ?? false,
@@ -474,6 +500,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 								displayText: structuredResultValue.displayText,
 							}),
 						},
+						...formatRawFetchHostNudgeContent(rawFetchHostNudges),
 						...formatSurfacedMemoriesMarkdown(surfacedMemories),
 					]),
 					structuredContent: {
@@ -489,6 +516,9 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							: {}),
 						result: structuredResultValue.value,
 						logs: result.logs ?? [],
+						...(rawFetchHostNudges.length > 0
+							? { warnings: rawFetchHostNudges }
+							: {}),
 						...buildMemoryStructuredContent(surfacedMemories),
 					},
 					isError: markerOnlyPassthrough?.isError ?? false,
@@ -496,4 +526,90 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 			}
 		},
 	)
+}
+
+function formatRawFetchHostNudgeContent(nudges: Array<string>) {
+	if (nudges.length === 0) return []
+	return [
+		{
+			type: 'text' as const,
+			text: nudges.join('\n'),
+		},
+	]
+}
+
+async function resolveRawFetchHostNudges(input: {
+	agent: McpRegistrationAgent
+	env: Env
+	callerContext: ReturnType<McpRegistrationAgent['getCallerContext']>
+	conversationId: string
+	hostCounts: ReadonlyMap<string, number>
+}): Promise<Array<string>> {
+	if (input.hostCounts.size === 0) return []
+
+	const statefulAgent = input.agent as McpRegistrationAgent & {
+		state?: {
+			rawFetchHostNudges?: RawFetchHostNudgeState
+		}
+		setState?: (state: {
+			rawFetchHostNudges?: RawFetchHostNudgeState
+			[key: string]: unknown
+		}) => void
+	}
+	const approaching = listHostsApproachingRawFetchNudge({
+		state: statefulAgent.state?.rawFetchHostNudges,
+		conversationId: input.conversationId,
+		hostCounts: input.hostCounts,
+	})
+	const coveredHosts =
+		approaching.length > 0
+			? await listOpenApiBindingHosts({
+					env: input.env,
+					callerContext: input.callerContext,
+				})
+			: new Set<string>()
+	const applied = applyRawFetchHostCounts({
+		state: statefulAgent.state?.rawFetchHostNudges,
+		conversationId: input.conversationId,
+		hostCounts: input.hostCounts,
+		coveredHosts,
+	})
+	if (typeof statefulAgent.setState === 'function') {
+		statefulAgent.setState({
+			...(statefulAgent.state ?? {}),
+			rawFetchHostNudges: applied.state,
+		})
+	}
+	return applied.nudges
+}
+
+async function listOpenApiBindingHosts(input: {
+	env: Env
+	callerContext: ReturnType<McpRegistrationAgent['getCallerContext']>
+}): Promise<Set<string>> {
+	const userId = input.callerContext.user?.userId
+	if (!userId) return new Set()
+	try {
+		const bindings = await listOpenApiBindings({
+			env: input.env,
+			userId,
+			storageContext: {
+				sessionId: input.callerContext.storageContext?.sessionId ?? null,
+				appId: input.callerContext.storageContext?.appId ?? null,
+				storageId: input.callerContext.storageContext?.storageId ?? null,
+			},
+		})
+		const hosts = new Set<string>()
+		for (const binding of bindings) {
+			const hostname = normalizeHost(
+				readLiteralRequestHostname(binding.apiBaseUrl),
+			)
+			if (hostname) hosts.add(hostname)
+		}
+		return hosts
+	} catch {
+		// Binding lookup is best-effort on this hot path; skip exclusion rather
+		// than failing the execute response.
+		return new Set()
+	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When MCP `execute` raw-fetches the same external host repeatedly within one conversation, append a one-line nudge suggesting `openapi_binding_save` or a saved package. This turns invisible fetch friction into self-correction without adding durable platform noise.

## Behavior

- **Counting:** During each ad hoc execute run, wrap the outbound Fetcher (before the fetch gateway) and count literal hostnames from request URLs. Path-only / unparseable URLs are ignored. Secret-expanded hosts are never consulted.
- **Trigger:** When a host’s cumulative count in the conversation reaches **3**, append one line to the execute response text `content` and mirror it in `structuredContent.warnings`.
- **Dedup:** Fire **at most once per host per conversation** (recorded in MCP agent DO state alongside the counts).
- **Exclusions from counting / nudging:**
  - The deployment’s own `baseUrl` host (never counted).
  - Hosts already covered by a saved OpenAPI binding’s `apiBaseUrl` (looked up only when a host is about to tip).
  - OpenAPI provider calls via `kody.openapi[...]` (dispatcher path, not sandbox `fetch`).
  - Saved-package runs that set `packageContext` (sink omitted). Nested `packages.invoke` uses a separate executor without the sink.
  - **Limitation:** Static `kody:@scope/...` imports bundled into an ad hoc execute module share the same outbound Fetcher, so those fetches are counted as ad hoc raw fetch.
- **State bounds:** ≤20 hosts per conversation, ≤50 conversations (FIFO eviction). Same DO state mechanism as `searchConversationIdsWithPreamble`.
- **Token cost:** One line, once per host per conversation.

## Test plan

- [x] Unit tests for counting, threshold=3, once-per-host dedup, own-host exclusion, OpenAPI-covered skip, host/conversation caps
- [x] Execute tool integration test for warnings content + DO state + covered-host skip
- [x] `typecheck`, `lint` (0 errors), `format:check` on touched files
- [x] Pre-push Playwright E2E (passed via husky)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `71930296` · **Head:** `443e9b48`

**Classification:** extends — MCP execute gains per-conversation raw-fetch host tracking and a one-line OpenAPI/package nudge; OpenAPI bindings are consulted only as an exclusion check.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — execute outbound fetch counting + DO state + response warnings |
| `openapi-bindings` | assistant | composes — cheap `apiBaseUrl` host lookup to suppress nudges |

### System map

Execute raw `fetch` is observed before the gateway; cumulative hosts live on the MCP agent DO; tipping hosts may consult OpenAPI bindings before a one-line warning is appended.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	openapiBindings["openapi-bindings<br/>OpenAPI provider bindings"]:::touched
	mcpServer -->|"listOpenApiBindings host exclusion"| openapiBindings
	mcpServer -->|"rawFetchHostNudges DO state"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Agent
	participant Execute as execute tool
	participant Outbound as outbound Fetcher wrap
	participant DO as MCP agent DO state
	participant OpenAPI as openapi bindings
	Agent->>Execute: execute(code, conversationId)
	Execute->>Outbound: sandbox fetch(url)
	Outbound->>Outbound: record literal hostname
	Execute->>DO: apply cumulative host counts
	alt host count reaches 3 and not nudged
		Execute->>OpenAPI: list binding apiBaseUrl hosts
		alt not covered
			Execute-->>Agent: result + one-line warning
		else covered
			Execute-->>Agent: result (no nudge)
		end
	else below threshold / already nudged
		Execute-->>Agent: result
	end
```

### Invariants

- Per-user isolation preserved: counts live on the per-user MCP agent DO and are keyed by `conversationId`; OpenAPI exclusion uses the signed-in user’s bindings only.
- No secret material in counted hosts or nudge text (literal request URLs only).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de1898aa-a403-4a98-945a-a1588a917146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de1898aa-a403-4a98-945a-a1588a917146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

