### PR TITLE
Fix execute raw-fetch host counting to keep a real Fetcher

### DIFF
--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -293,8 +293,12 @@ test('generated kody provider source avoids bundle-scoped __name helpers', () =>
 		],
 		shadowGlobalThis: false,
 		timeoutMs: 1_000,
+		excludedHostname: 'heykody.dev',
 	})
 	assertGeneratedExecutorSourceIsBundleSafe(moduleSource)
+	expect(moduleSource).toContain('rawFetchHosts: __kodyRawFetchHosts')
+	expect(moduleSource).toContain('heykody.dev')
+	expect(moduleSource).toContain('__kodyNativeFetch')
 })
 
 test('generated kody provider source wires remote proxy dispatch', async () => {

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -13,7 +13,6 @@ import { exports as workerExports } from 'cloudflare:workers'
 import { type FetchGatewayProps } from '#mcp/fetch-gateway.ts'
 import {
 	readBaseUrlHostname,
-	wrapOutboundFetcherRecordingHosts,
 	type RawFetchHostSink,
 } from '#mcp/raw-fetch-host-nudge.ts'
 import { extractMcpPassthrough } from '#mcp/downstream-mcp-result.ts'
@@ -53,7 +52,7 @@ const dynamicWorkerCompatibilityDate = '2025-06-01'
 const dynamicWorkerCompatibilityFlags = ['nodejs_compat'] as const
 const dynamicWorkerMainModule = 'executor.js'
 const dynamicWorkerIdPrefix = 'kody-'
-const dynamicWorkerCacheKeyVersion = 2
+const dynamicWorkerCacheKeyVersion = 3
 const reservedProviderNames = new Set(['__dispatchers', '__logs'])
 const validProviderNamePattern = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
 const javascriptReservedWords = new Set([
@@ -116,6 +115,7 @@ type DynamicWorkerExecutorInput = {
 	gatewayProps: FetchGatewayProps
 	appCommitSha?: string | null
 	usageEnv: UsageEnv
+	rawFetchHostSink?: RawFetchHostSink
 }
 
 type DynamicWorkerExecutorOptions = {
@@ -131,6 +131,7 @@ type DynamicWorkerEntrypoint = {
 		result: unknown
 		error?: string
 		logs?: Array<string>
+		rawFetchHosts?: Array<string>
 	}>
 }
 
@@ -221,8 +222,9 @@ export function createExecuteExecutor(input: {
 	timeoutMs?: number | null
 	/**
 	 * Optional sink for literal hostnames observed on ad hoc execute raw
-	 * `fetch` traffic (before the fetch gateway). Package-context runs should
-	 * omit this so saved-package outbound requests are not counted.
+	 * `fetch` traffic. Counting happens inside the sandbox (so LOADER keeps a
+	 * real Fetcher for globalOutbound). Package-context runs should omit this
+	 * so saved-package outbound requests are not counted.
 	 */
 	rawFetchHostSink?: RawFetchHostSink
 }) {
@@ -236,26 +238,17 @@ export function createExecuteExecutor(input: {
 		input.timeoutMs === null
 			? maxSupportedExecutorTimeoutMs
 			: (input.timeoutMs ?? 90_000)
-	const gatewayOutbound = loopbackExports.KodyFetchGateway({
-		props: input.gatewayProps,
-	})
-	const globalOutbound = input.rawFetchHostSink
-		? wrapOutboundFetcherRecordingHosts(
-				gatewayOutbound,
-				input.rawFetchHostSink,
-				{
-					excludedHostname: readBaseUrlHostname(input.gatewayProps.baseUrl),
-				},
-			)
-		: gatewayOutbound
 	return createStableDynamicWorkerExecutor({
 		loader: input.env.LOADER,
 		timeout,
-		globalOutbound,
+		globalOutbound: loopbackExports.KodyFetchGateway({
+			props: input.gatewayProps,
+		}),
 		modules: input.modules,
 		gatewayProps: input.gatewayProps,
 		appCommitSha: input.env.APP_COMMIT_SHA ?? null,
 		usageEnv: input.env,
+		rawFetchHostSink: input.rawFetchHostSink,
 	})
 }
 
@@ -273,11 +266,13 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 					error: validationError,
 				}
 			}
+			const excludedHostname = readBaseUrlHostname(input.gatewayProps.baseUrl)
 			const executorModule = createExecutorModule({
 				code,
 				providers,
 				shadowGlobalThis: Object.keys(modules).length === 0,
 				timeoutMs: input.timeout,
+				excludedHostname,
 			})
 			const workerOptions = {
 				compatibilityDate: dynamicWorkerCompatibilityDate,
@@ -304,6 +299,11 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 					.get(workerId, () => workerOptions)
 					.getEntrypoint() as unknown as DynamicWorkerEntrypoint
 				const response = await entrypoint.evaluate(dispatchers)
+				if (input.rawFetchHostSink) {
+					for (const hostname of response.rawFetchHosts ?? []) {
+						input.rawFetchHostSink.add(hostname)
+					}
+				}
 				if (response.error) {
 					outcome = 'error'
 					return {
@@ -359,8 +359,10 @@ function createExecutorModule(input: {
 	providers: Array<ResolvedProvider>
 	shadowGlobalThis: boolean
 	timeoutMs: number
+	excludedHostname?: string
 }) {
 	const normalized = normalizeCode(input.code)
+	const excludedHostname = JSON.stringify(input.excludedHostname ?? '')
 	const sandboxGlobalLines = input.shadowGlobalThis
 		? [
 				'    const __kodySandboxGlobalValues = Object.create(null);',
@@ -391,6 +393,24 @@ function createExecutorModule(input: {
 		'export default class CodeExecutor extends WorkerEntrypoint {',
 		'  async evaluate(__dispatchers = {}) {',
 		'    const __logs = [];',
+		'    const __kodyRawFetchHosts = [];',
+		`    const __kodyExcludedFetchHost = ${excludedHostname};`,
+		'    const __kodyNativeFetch = globalThis.fetch.bind(globalThis);',
+		'    globalThis.fetch = (input, init) => {',
+		'      try {',
+		'        let url = "";',
+		'        if (typeof input === "string") url = input;',
+		'        else if (input instanceof URL) url = input.toString();',
+		'        else if (input && typeof input.url === "string") url = input.url;',
+		'        const hostname = new URL(url).hostname.trim().toLowerCase();',
+		'        if (hostname && hostname !== __kodyExcludedFetchHost) {',
+		'          __kodyRawFetchHosts.push(hostname);',
+		'        }',
+		'      } catch {',
+		'        // Ignore unparseable / relative URLs; only literal hosts count.',
+		'      }',
+		'      return __kodyNativeFetch(input, init);',
+		'    };',
 		'    const console = {',
 		'      log: (...a) => { __logs.push(a.map(String).join(" ")); },',
 		'      warn: (...a) => { __logs.push("[warn] " + a.map(String).join(" ")); },',
@@ -411,9 +431,9 @@ function createExecutorModule(input: {
 		...userCodeInvocation,
 		'        __timeoutPromise',
 		'      ]);',
-		'      return { result, logs: __logs };',
+		'      return { result, logs: __logs, rawFetchHosts: __kodyRawFetchHosts };',
 		'    } catch (err) {',
-		'      return { result: undefined, error: err.message, logs: __logs };',
+		'      return { result: undefined, error: err.message, logs: __logs, rawFetchHosts: __kodyRawFetchHosts };',
 		'    } finally {',
 		'      clearTimeout(__timeoutId);',
 		'    }',
@@ -427,6 +447,7 @@ export function createExecutorModuleSource(input: {
 	providers: Array<ResolvedProvider>
 	shadowGlobalThis: boolean
 	timeoutMs: number
+	excludedHostname?: string
 }) {
 	return createExecutorModule(input)
 }

--- a/packages/worker/src/mcp/raw-fetch-host-nudge.ts
+++ b/packages/worker/src/mcp/raw-fetch-host-nudge.ts
@@ -72,8 +72,10 @@ export function readHostnameFromFetchInput(input: RequestInfo | URL) {
 }
 
 /**
- * Wrap an outbound Fetcher so each ad hoc execute raw `fetch` records its
- * literal hostname before the request reaches the fetch gateway.
+ * Test/helper wrapper that records literal hostnames from fetch inputs.
+ * Do not pass the result to WorkerLoader `globalOutbound` — LOADER requires a
+ * real Fetcher binding. Production counting wraps `globalThis.fetch` inside
+ * the execute sandbox instead (see `#mcp/executor.ts`).
  */
 export function wrapOutboundFetcherRecordingHosts(
 	outbound: Fetcher,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hotfix for a production break introduced by #770: wrapping `KodyFetchGateway` in a plain `{ fetch }` object made WorkerLoader reject `globalOutbound` (`Incorrect type for the 'globalOutbound' field ... not of type 'Fetcher'`), which broke MCP `execute`.

## Fix

- Keep `globalOutbound` as the real `KodyFetchGateway` Fetcher.
- Record literal fetch hostnames inside the sandbox by wrapping `globalThis.fetch`, return them from `evaluate`, and feed the optional sink afterward.
- Bump dynamic worker cache key version.

## Test plan

- [x] Existing executor / nudge / execute unit tests
- [x] Assert generated executor module includes `rawFetchHosts` recording
- [x] typecheck + pre-push e2e

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `06fa1f2b` · **Head:** `8d7d9142`

**Classification:** extends — corrects how MCP execute observes raw-fetch hosts without changing the LOADER Fetcher contract.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — sandbox-side raw-fetch host recording instead of invalid Fetcher wrap |

### System map

Execute sandbox wraps `fetch` locally; LOADER still receives a real gateway Fetcher.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	mcpServer -->|"sandbox fetch wrap records hosts"| mcpServer
	mcpServer -->|"globalOutbound remains KodyFetchGateway"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- No secret-expanded hostnames are recorded (literal request URLs only).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de1898aa-a403-4a98-945a-a1588a917146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de1898aa-a403-4a98-945a-a1588a917146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tracking of outbound request hostnames made during sandboxed execution.
  - Excludes the configured service hostname and ignores invalid or relative request URLs.
  - Preserves native fetch behavior while collecting hostname data for downstream handling.
- **Tests**
  - Expanded coverage to verify generated execution code includes hostname tracking and native fetch references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->