### PR TITLE
Allow invite-gated social signup in production

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -335,12 +335,12 @@ sign-in. Provider identities live in the `oauth_connections` table; handlers
 live in `packages/worker/src/app/handlers/auth-provider.ts` with the provider
 definitions in `packages/worker/src/app/oauth-providers.ts`.
 
-- `POST /auth/:provider` starts the flow (CSRF state + PKCE verifier in the
-  signed `kody_oauth_login` cookie); `GET /auth/:provider/callback` completes it
-  and issues the normal `kody_session` cookie. The first-party UI fetches the
-  start endpoint with `Accept: application/json` and navigates to the returned
-  authorize URL itself, because the CSP locks `form-action` and `connect-src` to
-  `'self'`
+- `POST /auth/:provider` starts the flow (CSRF state + PKCE verifier + optional
+  invite code in the signed `kody_oauth_login` cookie);
+  `GET /auth/:provider/callback` completes it and issues the normal
+  `kody_session` cookie. The first-party UI fetches the start endpoint with
+  `Accept: application/json` and navigates to the returned authorize URL itself,
+  because the CSP locks `form-action` and `connect-src` to `'self'`
 - Existing connections sign in directly; the two-factor gate applies exactly as
   for password logins (passkey sign-in skips TOTP)
 - A signed-in user hitting the callback links the provider identity to their
@@ -348,7 +348,8 @@ definitions in `packages/worker/src/app/oauth-providers.ts`.
   `/account/connections.json` (disconnect is refused when the connection is the
   only sign-in method); a provider-verified email matching an existing account
   auto-links and signs in; otherwise account creation follows the signup posture
-  (production stays invite-gated, so OAuth signup is non-production only)
+  (production requires a valid invite code carried from the invite signup panel;
+  non-production remains open without one)
 - Buttons only render for providers whose client id/secret env vars are set;
   `MOCK_`-prefixed client ids activate an in-worker mock flow on non-production
   runtimes for dev and E2E tests

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -92,11 +92,13 @@ primitives:
       (non-production signup open), account email verification surfaced in
       session state and a dedicated `/pending-verification` experience after
       password signup, MCP OAuth authorize gated until verified, social login
-      (GitHub/Google/X OAuth connections in oauth_connections, mockable via
-      MOCK_ client ids on non-production runtimes), and opt-in second factors —
-      TOTP two-factor (verifications table, pending kody_verify cookie gates
-      password/social login until /verify) and passkeys (WebAuthn sign-in with
-      required user verification; treated as MFA-complete, so TOTP is skipped).
+      and invite-gated social signup (GitHub/Google/X OAuth connections in
+      oauth_connections, invite code carried in the signed OAuth state cookie,
+      mockable via MOCK_ client ids on non-production runtimes), and opt-in
+      second factors — TOTP two-factor (verifications table, pending kody_verify
+      cookie gates password/social login until /verify) and passkeys (WebAuthn
+      sign-in with required user verification; treated as MFA-complete, so TOTP
+      is skipped).
     code:
       - packages/worker/src/app/auth-session.ts
       - packages/worker/src/app/handlers/auth.ts

--- a/docs/contributing/social-login.md
+++ b/docs/contributing/social-login.md
@@ -18,8 +18,9 @@ Routes (see `packages/worker/src/app/handlers/auth-provider.ts` and
 - `GET /auth/providers.json` — enabled providers (drives the login buttons; a
   provider only appears when both its client id and secret env vars are set)
 - `POST /auth/:provider` — starts the flow (signed `kody_oauth_login` state
-  cookie with CSRF state + PKCE verifier). With `Accept: application/json` it
-  returns `{ authorizeUrl }` for client-side navigation; otherwise it 302s.
+  cookie with CSRF state + PKCE verifier + optional `inviteCode` query for
+  production social signup). With `Accept: application/json` it returns
+  `{ authorizeUrl }` for client-side navigation; otherwise it 302s.
 - `GET /auth/:provider/callback` — completes the flow
 - `GET/POST /account/connections.json` — signed-in connection management (list,
   disconnect)
@@ -42,10 +43,12 @@ Callback resolution order:
 3. A **provider-verified** email matching an existing account links the identity
    and signs that account in (this also marks the account email verified, since
    the provider asserted ownership of the same address).
-4. Otherwise a new account is created — but only on non-production runtimes.
-   Production signups are invite-gated and the provider redirect cannot carry an
-   invite code, so new production users must sign up with their invite first and
-   then sign in with the provider using the same email.
+4. Otherwise a new account is created. Production requires a valid invite code
+   carried in the signed OAuth state cookie (the invite signup panel passes
+   `inviteCode` into `POST /auth/:provider`). Non-production stays open without
+   an invite, but still consumes and validates a code when one is supplied —
+   same posture as password signup. Missing or invalid invites redirect to
+   `/login?oauthError=invite-*`.
 
 X frequently does not share an email (it requires the "Request email from users"
 app permission and a confirmed email), in which case only paths 1 and 2 work:
@@ -98,7 +101,7 @@ endpoint; `email_verified` gates account matching).
 3. Set the **Callback URI** to `https://<your-domain>/auth/x/callback` and the
    **Website URL** to your app origin.
 4. Enable **Request email from users** so `confirmed_email` is returned (this
-   makes email-based matching and non-production signup work for X).
+   makes email-based matching and invite-gated signup work for X).
 5. Save the OAuth 2.0 client id and secret as `X_CLIENT_ID` / `X_CLIENT_SECRET`.
 
 Scopes requested: `tweet.read users.read users.email` (PKCE S256 is mandatory;

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -290,9 +290,19 @@ export function LoginRoute(handle: Handle) {
 	async function handleProviderSignIn(providerId: string) {
 		setState('submitting')
 		try {
+			// Carry the invite code from the invite signup panel so production
+			// social signup can consume it on the OAuth callback.
+			let inviteCode: string | null = null
+			if (getCurrentAuthMode(handle) === 'signup') {
+				const inviteInput = document.querySelector('input[name="inviteCode"]')
+				if (inviteInput instanceof HTMLInputElement) {
+					inviteCode = inviteInput.value.trim() || null
+				}
+			}
 			const errorMessage = await startSocialSignIn(
 				providerId,
 				getCurrentRedirectTo(handle),
+				inviteCode,
 			)
 			if (errorMessage) {
 				setState('error', errorMessage)
@@ -421,7 +431,7 @@ export function LoginRoute(handle: Handle) {
 		const description = showWaitingList
 			? 'Kody is invite-only. Leave your name and email and we will let you know when a spot opens.'
 			: isSignup
-				? 'Sign up with your invite code to start using kody.'
+				? 'Sign up with your invite code (password or social) to start using kody.'
 				: 'Log in to continue to kody.'
 		const submitLabel = isSignup ? 'Create account' : 'Sign in'
 		const toggleLabel = isSignup

--- a/packages/worker/client/social-sign-in.node.test.ts
+++ b/packages/worker/client/social-sign-in.node.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+import { buildProviderStartPath } from './social-sign-in.ts'
+
+test('buildProviderStartPath includes redirect and invite query params', () => {
+	expect(buildProviderStartPath('github', null)).toBe('/auth/github')
+	expect(buildProviderStartPath('github', '/community')).toBe(
+		'/auth/github?redirectTo=%2Fcommunity',
+	)
+	expect(buildProviderStartPath('google', null, '  launch-one  ')).toBe(
+		'/auth/google?inviteCode=launch-one',
+	)
+	expect(buildProviderStartPath('github', '/account', 'SOCIAL-INVITE')).toBe(
+		'/auth/github?redirectTo=%2Faccount&inviteCode=SOCIAL-INVITE',
+	)
+	expect(buildProviderStartPath('github', null, '   ')).toBe('/auth/github')
+})

--- a/packages/worker/client/social-sign-in.ts
+++ b/packages/worker/client/social-sign-in.ts
@@ -3,10 +3,14 @@ export type AuthProviderInfo = { id: string; label: string }
 export function buildProviderStartPath(
 	providerId: string,
 	redirectTo: string | null,
+	inviteCode: string | null = null,
 ) {
-	return redirectTo
-		? `/auth/${providerId}?redirectTo=${encodeURIComponent(redirectTo)}`
-		: `/auth/${providerId}`
+	const params = new URLSearchParams()
+	if (redirectTo) params.set('redirectTo', redirectTo)
+	const trimmedInvite = inviteCode?.trim()
+	if (trimmedInvite) params.set('inviteCode', trimmedInvite)
+	const query = params.toString()
+	return query ? `/auth/${providerId}?${query}` : `/auth/${providerId}`
 }
 
 /**
@@ -42,16 +46,23 @@ export async function fetchEnabledAuthProviders(
  * `form-action` and `connect-src` to 'self', so neither a form-POST redirect
  * nor a fetch-followed redirect may leave the origin — a top-level JS
  * navigation may. Returns an error message, or null when navigation started.
+ *
+ * Pass `inviteCode` when starting from the invite signup panel so production
+ * can create the account on callback.
  */
 export async function startSocialSignIn(
 	providerId: string,
 	redirectTo: string | null,
+	inviteCode: string | null = null,
 ): Promise<string | null> {
-	const response = await fetch(buildProviderStartPath(providerId, redirectTo), {
-		method: 'POST',
-		headers: { Accept: 'application/json' },
-		credentials: 'include',
-	})
+	const response = await fetch(
+		buildProviderStartPath(providerId, redirectTo, inviteCode),
+		{
+			method: 'POST',
+			headers: { Accept: 'application/json' },
+			credentials: 'include',
+		},
+	)
 	const payload = await response.json().catch(() => null)
 	if (
 		!response.ok ||

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -756,3 +756,170 @@ test('MOCK_ client ids run the whole flow in-worker without network access', asy
 	expect(user).toBeTruthy()
 	expect(user.username).toBe('mock-github-user')
 })
+
+function seedInvite(sqlite: DatabaseSync, code: string, maxUses = 1) {
+	sqlite.exec(`
+		INSERT INTO invites (code, created_by, note, max_uses, use_count)
+		VALUES (${quoteSqlString(code)}, NULL, '', ${maxUses}, 0);
+	`)
+}
+
+function mockGithubProfileExchange(email = 'octo@example.com') {
+	msw.use(
+		http.post('https://github.com/login/oauth/access_token', async () =>
+			HttpResponse.json({ access_token: 'github-access-token' }),
+		),
+		http.get('https://api.github.com/user', () =>
+			HttpResponse.json({
+				id: 99001,
+				login: 'octo-cat',
+				name: 'Octo Cat',
+				email: null,
+			}),
+		),
+		http.get('https://api.github.com/user/emails', () =>
+			HttpResponse.json([{ email, primary: true, verified: true }]),
+		),
+	)
+}
+
+test('production OAuth signup requires an invite code', async () => {
+	const { sqlite, db } = createMigratedDb()
+	const env = createAppEnv(db, { SENTRY_ENVIRONMENT: 'production' })
+	mockGithubProfileExchange()
+
+	const start = await startProviderFlow(
+		env,
+		'github',
+		'http://example.com/auth/github',
+	)
+	const callbackResponse = await runHandler(
+		createAuthProviderCallbackHandler(env),
+		new Request(
+			`http://example.com/auth/github/callback?code=github-auth-code&state=${start.state}`,
+			{ headers: { Cookie: start.stateCookie } },
+		),
+		{ provider: 'github' },
+	)
+	expect(callbackResponse.status).toBe(302)
+	expect(callbackResponse.headers.get('Location')).toBe(
+		'/login?oauthError=invite-required',
+	)
+	expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM users`).get()).toEqual({
+		count: 0,
+	})
+})
+
+test('production OAuth signup succeeds with a valid invite code', async () => {
+	const { sqlite, db } = createMigratedDb()
+	const env = createAppEnv(db, { SENTRY_ENVIRONMENT: 'production' })
+	seedInvite(sqlite, 'SOCIAL-INVITE')
+	mockGithubProfileExchange('social-invited@example.com')
+
+	const start = await startProviderFlow(
+		env,
+		'github',
+		'http://example.com/auth/github?inviteCode=social-invite',
+	)
+	const callbackResponse = await runHandler(
+		createAuthProviderCallbackHandler(env),
+		new Request(
+			`http://example.com/auth/github/callback?code=github-auth-code&state=${start.state}`,
+			{ headers: { Cookie: start.stateCookie } },
+		),
+		{ provider: 'github' },
+	)
+	expect(callbackResponse.status).toBe(302)
+	expect(callbackResponse.headers.get('Location')).toBe('/account')
+	const user = sqlite
+		.prepare(`SELECT * FROM users WHERE email = ?`)
+		.get('social-invited@example.com') as Record<string, unknown>
+	expect(user).toBeTruthy()
+	expect(user.email_verified_at).toBeTruthy()
+	expect(
+		sqlite
+			.prepare(`SELECT use_count FROM invites WHERE code = ?`)
+			.get('SOCIAL-INVITE'),
+	).toEqual({ use_count: 1 })
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'oauth_signup',
+			result: 'success',
+		}),
+	)
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'invite_use',
+			result: 'success',
+			reason: expect.stringContaining('invite_code=SOCIAL-INVITE'),
+		}),
+	)
+})
+
+test('production OAuth signup rejects an invalid invite code', async () => {
+	const { sqlite, db } = createMigratedDb()
+	const env = createAppEnv(db, { SENTRY_ENVIRONMENT: 'production' })
+	mockGithubProfileExchange()
+
+	const start = await startProviderFlow(
+		env,
+		'github',
+		'http://example.com/auth/github?inviteCode=not-a-real-invite',
+	)
+	const callbackResponse = await runHandler(
+		createAuthProviderCallbackHandler(env),
+		new Request(
+			`http://example.com/auth/github/callback?code=github-auth-code&state=${start.state}`,
+			{ headers: { Cookie: start.stateCookie } },
+		),
+		{ provider: 'github' },
+	)
+	expect(callbackResponse.status).toBe(302)
+	expect(callbackResponse.headers.get('Location')).toBe(
+		'/login?oauthError=invite-invalid',
+	)
+	expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM users`).get()).toEqual({
+		count: 0,
+	})
+})
+
+test('production OAuth login still works without an invite for existing connections', async () => {
+	const { sqlite, db } = createMigratedDb()
+	const env = createAppEnv(db, { SENTRY_ENVIRONMENT: 'production' })
+	await seedUser(sqlite, {
+		id: 11,
+		email: 'existing-oauth@example.com',
+		username: 'existing-oauth',
+	})
+	sqlite.exec(`
+		INSERT INTO oauth_connections (provider_name, provider_id, user_id, provider_display_name)
+		VALUES ('github', '99001', 11, 'existing-oauth');
+	`)
+	mockGithubProfileExchange('existing-oauth@example.com')
+
+	const start = await startProviderFlow(
+		env,
+		'github',
+		'http://example.com/auth/github',
+	)
+	const callbackResponse = await runHandler(
+		createAuthProviderCallbackHandler(env),
+		new Request(
+			`http://example.com/auth/github/callback?code=github-auth-code&state=${start.state}`,
+			{ headers: { Cookie: start.stateCookie } },
+		),
+		{ provider: 'github' },
+	)
+	expect(callbackResponse.status).toBe(302)
+	expect(callbackResponse.headers.get('Location')).toBe('/account')
+	expect(
+		callbackResponse.headers
+			.getSetCookie()
+			.some((cookie) => cookie.startsWith('kody_session=')),
+	).toBe(true)
+	expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM users`).get()).toEqual({
+		count: 1,
+	})
+})

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -11,6 +11,12 @@ import {
 import { getUniqueConstraintField } from '#app/database-errors.ts'
 import { isNonProductionRuntime } from '#app/deployment-env.ts'
 import { getAvailableUsernameFromBase } from '#app/generated-username.ts'
+import {
+	consumeInviteCode,
+	type InviteConsumeFailureReason,
+	normalizeInviteCode,
+	releaseInviteUse,
+} from '#app/invites.ts'
 import { normalizeEmail } from '#app/normalize-email.ts'
 import {
 	oauthLoginErrorMessages,
@@ -94,6 +100,31 @@ function prefersJsonResponse(request: Request) {
 	)
 }
 
+function isInviteRequiredForSignup(env: Env) {
+	return !isNonProductionRuntime(env)
+}
+
+function inviteFailureToOauthError(
+	reason: InviteConsumeFailureReason,
+): OauthLoginErrorCode {
+	switch (reason) {
+		case 'missing':
+			return 'invite-required'
+		case 'not_found':
+			return 'invite-invalid'
+		case 'revoked':
+			return 'invite-revoked'
+		case 'expired':
+			return 'invite-expired'
+		case 'exhausted':
+			return 'invite-exhausted'
+		default: {
+			const unreachable: never = reason
+			return unreachable
+		}
+	}
+}
+
 export function createAuthProvidersApiHandler(env: Env) {
 	return {
 		middleware: [],
@@ -115,6 +146,7 @@ export function createAuthProviderStartHandler(env: Env) {
 		async handler({ request, url, params }) {
 			const wantsJson = prefersJsonResponse(request)
 			const redirectTo = normalizeRedirectTo(url.searchParams.get('redirectTo'))
+			const inviteCode = normalizeInviteCode(url.searchParams.get('inviteCode'))
 
 			function startError(code: OauthLoginErrorCode) {
 				if (wantsJson) {
@@ -145,7 +177,13 @@ export function createAuthProviderStartHandler(env: Env) {
 				redirectUri: getCallbackRedirectUri(env, url, providerParam),
 			})
 			const stateCookie = await createOauthLoginStateCookie(
-				{ provider: providerParam, state, codeVerifier, redirectTo },
+				{
+					provider: providerParam,
+					state,
+					codeVerifier,
+					redirectTo,
+					inviteCode,
+				},
 				isSecureRequest(request),
 			)
 			// JSON mode: the CSP (`form-action`/`connect-src` locked to 'self')
@@ -389,11 +427,34 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				return issueLogin(existingUser)
 			}
 
-			// 4. New account. Production signups require an invite code, which
-			// the provider redirect cannot carry, so OAuth signup stays limited
-			// to non-production runtimes (mirrors password signup gating).
-			if (!isNonProductionRuntime(env)) {
-				return fail('invite-required', 'invite_required')
+			// 4. New account. Production requires a valid invite carried in the
+			// signed OAuth state cookie (started from the invite signup panel).
+			// Non-production stays open without an invite, but still consumes
+			// one when supplied — same posture as password signup.
+			let consumedInviteCode: string | null = null
+			async function releaseConsumedInvite() {
+				if (!consumedInviteCode) return
+				await releaseInviteUse({
+					db: env.APP_DB,
+					code: consumedInviteCode,
+				})
+				consumedInviteCode = null
+			}
+
+			const inviteRequired = isInviteRequiredForSignup(env)
+			const inviteCodeFromState = loginState.inviteCode
+			if (inviteRequired || normalizeInviteCode(inviteCodeFromState)) {
+				const inviteResult = await consumeInviteCode({
+					db: env.APP_DB,
+					code: inviteCodeFromState,
+				})
+				if (!inviteResult.ok) {
+					return fail(
+						inviteFailureToOauthError(inviteResult.reason),
+						`invite_${inviteResult.reason}`,
+					)
+				}
+				consumedInviteCode = inviteResult.invite.code
 			}
 
 			const username = await getAvailableUsernameFromBase(
@@ -416,6 +477,7 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				)
 				newUser = { id: createdUser.id }
 			} catch (error) {
+				await releaseConsumedInvite()
 				if (getUniqueConstraintField(error)) {
 					return fail('account-error', 'user_create_conflict')
 				}
@@ -430,6 +492,7 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				} catch (error) {
 					console.error('Failed to roll back OAuth-created user row:', error)
 				}
+				await releaseConsumedInvite()
 			}
 
 			let assigned = false
@@ -484,6 +547,17 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				path: url.pathname,
 				reason: `provider=${provider}`,
 			})
+			if (consumedInviteCode) {
+				void logAuditEvent({
+					category: 'auth',
+					action: 'invite_use',
+					result: 'success',
+					email,
+					ip: requestIp,
+					path: url.pathname,
+					reason: `invite_code=${consumedInviteCode};user_id=${newUser.id};provider=${provider}`,
+				})
+			}
 			return issueLogin({ id: newUser.id, email })
 		},
 	} satisfies Action<typeof routes.authProviderCallback>

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -457,13 +457,17 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				consumedInviteCode = inviteResult.invite.code
 			}
 
-			const username = await getAvailableUsernameFromBase(
-				env.APP_DB,
-				profile.username ?? usernameFromEmail(email),
-			)
-			const stableUserId = await createStableUserIdFromEmail(email)
+			// Username / stable-id lookup must share the create try/catch so a
+			// transient failure after consumeInviteCode still releases the invite.
+			let username: string
+			let stableUserId: string
 			let newUser: { id: number } | null = null
 			try {
+				username = await getAvailableUsernameFromBase(
+					env.APP_DB,
+					profile.username ?? usernameFromEmail(email),
+				)
+				stableUserId = await createStableUserIdFromEmail(email)
 				const createdUser = await db.create(
 					usersTable,
 					{

--- a/packages/worker/src/app/oauth-login-errors.ts
+++ b/packages/worker/src/app/oauth-login-errors.ts
@@ -14,7 +14,11 @@ export const oauthLoginErrorMessages = {
 	'no-verified-email':
 		'The provider did not share a verified email for your account. Sign in another way first, then connect the provider from this screen while signed in.',
 	'invite-required':
-		'New accounts need an invite code. Sign up with your invite first, then sign in with this provider using the same email.',
+		'New accounts need an invite code. Open Sign up, enter your invite, then continue with this provider.',
+	'invite-invalid': 'That invite code is invalid.',
+	'invite-revoked': 'That invite code has been revoked.',
+	'invite-expired': 'That invite code has expired.',
+	'invite-exhausted': 'That invite code has already been used.',
 	'connection-conflict':
 		'That provider account is already connected to a different user.',
 	'account-error': 'We could not create your account. Please try again.',

--- a/packages/worker/src/app/oauth-login-state.ts
+++ b/packages/worker/src/app/oauth-login-state.ts
@@ -6,8 +6,9 @@ import {
 
 /**
  * Short-lived signed cookie that carries the social-login round-trip state:
- * the CSRF `state` value, the PKCE code verifier, and the post-login
- * redirect target. Written when the flow starts and cleared by the callback.
+ * the CSRF `state` value, the PKCE code verifier, the post-login redirect
+ * target, and an optional invite code for production social signup. Written
+ * when the flow starts and cleared by the callback.
  */
 const oauthLoginStateMaxAgeSeconds = 60 * 10
 
@@ -16,6 +17,7 @@ export type OauthLoginState = {
 	state: string
 	codeVerifier: string
 	redirectTo: string | null
+	inviteCode: string | null
 }
 
 let stateCookie: ReturnType<typeof createCookie> | null = null
@@ -53,6 +55,10 @@ function getStateCookie() {
 function isOauthLoginState(value: unknown): value is OauthLoginState {
 	if (!value || typeof value !== 'object') return false
 	const record = value as Record<string, unknown>
+	const inviteCodeOk =
+		record.inviteCode === undefined ||
+		record.inviteCode === null ||
+		typeof record.inviteCode === 'string'
 	return (
 		typeof record.provider === 'string' &&
 		isOauthProviderId(record.provider) &&
@@ -60,15 +66,29 @@ function isOauthLoginState(value: unknown): value is OauthLoginState {
 		record.state.length > 0 &&
 		typeof record.codeVerifier === 'string' &&
 		record.codeVerifier.length > 0 &&
-		(record.redirectTo === null || typeof record.redirectTo === 'string')
+		(record.redirectTo === null || typeof record.redirectTo === 'string') &&
+		inviteCodeOk
 	)
+}
+
+function normalizeOauthLoginState(value: OauthLoginState): OauthLoginState {
+	return {
+		...value,
+		inviteCode:
+			typeof value.inviteCode === 'string' && value.inviteCode.length > 0
+				? value.inviteCode
+				: null,
+	}
 }
 
 export async function createOauthLoginStateCookie(
 	state: OauthLoginState,
 	secure: boolean,
 ) {
-	return getStateCookie().serialize(JSON.stringify(state), { secure })
+	return getStateCookie().serialize(
+		JSON.stringify(normalizeOauthLoginState(state)),
+		{ secure },
+	)
 }
 
 export async function destroyOauthLoginStateCookie(secure: boolean) {
@@ -91,7 +111,7 @@ export async function readOauthLoginState(
 	try {
 		const parsed = JSON.parse(stored)
 		if (isOauthLoginState(parsed)) {
-			return parsed
+			return normalizeOauthLoginState(parsed)
 		}
 	} catch {
 		return null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production blocked OAuth account creation even when the user had a valid invite. Social signup now works the same way as password signup: the invite signup panel carries the code into the signed OAuth state cookie, and the callback consumes it before creating the account.

- Carry optional `inviteCode` in `kody_oauth_login` state from `POST /auth/:provider`
- Production new-account path consumes the invite (missing/invalid → `oauthError=invite-*`); non-production stays open without one
- Invite signup UI passes the code into social “Continue with …” buttons
- Rollback releases a consumed invite if account creation fails mid-flight (including username/stable-id generation)

## Test plan

- [x] Unit: production OAuth signup blocked without invite
- [x] Unit: production OAuth signup succeeds with valid invite (consumes + audits)
- [x] Unit: invalid invite → `invite-invalid`; existing connection login still works without invite
- [x] Unit: `buildProviderStartPath` includes invite query param
- [ ] Manual: `/signup` → “I have a code” → enter invite → Continue with GitHub/Google

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `a58fa1d0` · **Head:** `e8dae200`

**Classification:** extends — OAuth signup callback now invite-consumes like password signup; signed OAuth state and login UI carry the invite code.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-sessions` | auth | extends — production social signup consumes invite from OAuth state; new `invite-*` oauth error codes |
| `app-ui` | surfaces | composes — invite signup panel passes `inviteCode` into social start |
| `d1-app-db` | storage | composes — same `invites` consume/release path as password signup |

### System map

Invite-gated social signup flows from the signup UI through OAuth state into invite consumption and account creation in D1.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::touched
	appSessions["app-sessions<br/>Browser sessions"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::touched
	appUi -->|"inviteCode on POST /auth/:provider"| appSessions
	appSessions -->|"consumeInviteCode on new OAuth account"| d1AppDb
	appSessions -->|"oauth_connections + users insert"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant UI as Signup UI
	participant Start as POST /auth/:provider
	participant Provider as GitHub/Google/X
	participant Callback as GET /auth/:provider/callback
	participant Invites as invites table
	UI->>Start: inviteCode + redirectTo
	Start-->>UI: authorizeUrl + kody_oauth_login cookie
	UI->>Provider: top-level navigate
	Provider->>Callback: code + state
	Callback->>Invites: consume when new account
	Callback-->>UI: kody_session (or oauthError=invite-*)
```

### Before / after

| Path | Before | After |
| --- | --- | --- |
| Production OAuth new account | Always `invite-required` | Succeeds when signed state has a valid invite |
| Non-production OAuth new account | Open | Unchanged (still open; consumes invite if provided) |
| Existing connection / email match | Sign in / link | Unchanged (no invite needed) |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6ea3-a635-7bae-bf98-cb8a552122c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6ea3-a635-7bae-bf98-cb8a552122c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added invite-code support to social sign-up for GitHub, Google, and X, including trimming/forwarding invite codes through the OAuth flow.
  - Production social sign-up is now invite-gated; existing social logins for connected accounts still work without an invite.
  - Enhanced invite-related OAuth errors with clearer `oauthError` outcomes (e.g., invite-required/invalid/revoked/expired/exhausted).
- **Documentation**
  - Updated architecture and social-login docs to explain invite-code gating and how it’s carried during the provider callback.
- **Tests**
  - Added unit and end-to-end coverage for invite-gated social signup and new error handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->