### PR TITLE
Refresh session state after router form mutations so logout updates the nav

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -279,9 +279,17 @@ Related handlers:
 ### Client session refresh behavior
 
 The app shell (`packages/worker/client/app.tsx`) refreshes session state after
-initial load and on client-side navigation events. If an in-flight refresh is
-aborted, the client keeps the last known ready session instead of overwriting it
-with `null`. This prevents transient logged-out UI during concurrent re-renders.
+initial load and on client-side navigation events. Navigation-triggered
+refreshes are throttled (30s) to avoid a `/session` round trip on every SPA
+navigation, but the throttle never applies to refreshes that follow a mutation:
+the client router (`packages/worker/client/client-router.tsx`) emits a
+`mutation` event after every form POST it submits (exposed as
+`listenToRouterMutations`), and the shell marks its session state stale so the
+follow-up redirect navigation refreshes it regardless of the throttle —
+auth-changing POSTs like `/logout` update the top nav immediately. If an
+in-flight refresh is aborted, the client keeps the last known ready session
+instead of overwriting it with `null`. This prevents transient logged-out UI
+during concurrent re-renders.
 
 ## Password reset
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -38,7 +38,18 @@ test('smoke test covers shell, auth redirect, and login', async ({ page }) => {
 	).toBeVisible()
 	await expect(page.getByText('Failed to fetch')).not.toBeVisible()
 
-	await page.context().clearCookies()
+	// Log out through the top nav. The router intercepts the form POST and
+	// SPA-navigates to /login, so the shell must refresh its session state
+	// without a full document reload (regression: the throttled refresh kept
+	// the username and Log out button visible after logging out).
+	await page.getByRole('button', { name: 'Log out' }).click()
+	await expect(page).toHaveURL(/\/login$/)
+	await expect(page.getByRole('link', { name: 'Login' })).toBeVisible()
+	await expect(page.getByRole('button', { name: 'Log out' })).not.toBeVisible()
+	await expect(
+		page.getByRole('link', { name: primaryTestUser.username }),
+	).not.toBeVisible()
+
 	await page.goto('/privacy')
 	await expect(page.getByRole('heading', { name: 'Privacy' })).toBeVisible()
 	await expect(

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -1,6 +1,7 @@
 import { type Handle, css } from 'remix/ui'
 import { clientRouteLoaders, clientRoutes } from './routes/index.tsx'
 import {
+	listenToRouterMutations,
 	listenToRouterNavigation,
 	registerRouteLoaders,
 	Router,
@@ -42,12 +43,14 @@ export function App(handle: Handle<AppProps>) {
 	let sessionRefreshInFlight = false
 	let sessionRefreshQueued = false
 	let lastSessionRefreshAt = 0
+	let sessionMaybeStale = false
 	let currentPathname = readRouterPathname(handle)
 
 	// Navigation-triggered refreshes are throttled: auth rarely changes
 	// mid-session and every SPA navigation was previously a /session round
-	// trip (2 D1 queries). Explicit refreshes (login/logout/profile updates
-	// via setSessionRefreshHandler) always bypass the throttle.
+	// trip (2 D1 queries). Refreshes after mutations (router form POSTs such
+	// as logout) and explicit refreshes (profile updates via
+	// setSessionRefreshHandler) always bypass the throttle.
 	const sessionRefreshThrottleMs = 30_000
 
 	function queueSessionRefresh() {
@@ -80,11 +83,13 @@ export function App(handle: Handle<AppProps>) {
 
 	function queueThrottledSessionRefresh() {
 		if (
+			!sessionMaybeStale &&
 			sessionStatus === 'ready' &&
 			Date.now() - lastSessionRefreshAt < sessionRefreshThrottleMs
 		) {
 			return
 		}
+		sessionMaybeStale = false
 		queueSessionRefresh()
 	}
 
@@ -100,6 +105,14 @@ export function App(handle: Handle<AppProps>) {
 			currentPathname = readRouterPathname(handle)
 			queueThrottledSessionRefresh()
 			handle.update()
+		})
+		// Router form POSTs mutate server state, which may include auth (e.g.
+		// logout destroys the session cookie), so the next navigation must
+		// bypass the refresh throttle. The refresh cannot start here: the
+		// follow-up redirect navigation re-renders the shell, which aborts
+		// in-flight queued tasks and would silently drop the refresh.
+		listenToRouterMutations(handle, () => {
+			sessionMaybeStale = true
 		})
 	}
 

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -600,6 +600,11 @@ async function submitFormThroughRouter(details: FormSubmitDetails) {
 		}
 
 		const response = await fetch(details.action.toString(), init)
+		// The server processed the mutation no matter which navigation follows
+		// (even if a newer navigation aborted this one). Tell listeners that
+		// server-derived state they cache — like the shell's session info —
+		// may now be stale.
+		routerEvents.dispatchEvent(new Event('mutation'))
 		if (signal.aborted) return
 
 		if (response.redirected) {
@@ -702,6 +707,23 @@ export function listenToRouterNavigation(
 	ensureRouter()
 	addEventListeners(routerEvents, handle.signal, {
 		navigate: () => listener(),
+	})
+}
+
+/**
+ * Fires after the router submits a non-GET form (a mutation, e.g. logout).
+ * Listeners that cache or throttle server-derived state must revalidate:
+ * the follow-up redirect is a SPA navigation, so nothing else re-fetches
+ * state the mutation may have changed.
+ */
+export function listenToRouterMutations(
+	handle: Pick<Handle, 'signal' | 'update'>,
+	listener: () => void,
+) {
+	if (typeof document === 'undefined') return
+	ensureRouter()
+	addEventListeners(routerEvents, handle.signal, {
+		mutation: () => listener(),
 	})
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Logging out left the top nav showing the logged-in state (username, Admin link, Log out button) on the `/login` page.

## Root cause

Not the logout handler — the server destroys the cookie correctly. The gap is in the client router + shell session cache interaction:

1. The client router (`packages/worker/client/client-router.tsx`) intercepts every form POST (including the nav's `/logout` form), follows the redirect, and SPA-navigates to `/login` without a document reload.
2. The shell (`packages/worker/client/app.tsx`) renders the nav from an in-memory session refreshed on navigation events — but navigation-triggered refreshes were throttled to 30s (PR #605). The comment claimed logout bypassed the throttle via `setSessionRefreshHandler`, but nothing ever wired that up.
3. So any auth-changing form POST within 30s of the last `/session` fetch (which hydration always performs) SPA-navigated with the refresh skipped, leaving stale logged-in nav.

This was fundamental to the router, not specific to logout: the router had no concept of mutations, so listeners caching server-derived state could never know a form POST invalidated it.

## Fix

- The router now dispatches a `mutation` event on `routerEvents` after every form POST it submits, exposed as `listenToRouterMutations` alongside `listenToRouterNavigation`.
- The shell listens and marks its session state stale, so the follow-up redirect navigation refreshes `/session` regardless of the throttle. (The refresh must not start in the mutation listener itself: the redirect navigation re-renders the shell, which aborts in-flight `queueTask` work and would drop the refresh — this is why the first-cut "just call `queueSessionRefresh()`" approach failed in testing.)
- Extended the smoke E2E journey to log out through the nav and assert the nav flips to Login/Signup (reproduced the bug before the fix; passes after).
- Updated the stale comment in `app.tsx` and the client-session-refresh section of `docs/contributing/architecture/authentication.md`.

## Testing

- New smoke E2E logout assertions fail on `main` (stale nav reproduced) and pass with this fix.
- `npm run validate` green: format, lint, typecheck, 861 unit tests, 15 Playwright E2E, MCP E2E.
- Manual GUI test against `npm run dev` with the seeded admin account:

<a href="https://cursor.com/agents/bc-019f702b-68ae-7b38-ac20-62212c9334e9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogout_nav_updates_immediately.mp4"><img src="https://cursor.com/artifacts/c/art-e6adc07d-ee5f-46e1-9eb4-a56835866728" alt="logout_nav_updates_immediately.mp4" /></a>

| Before logout | After logout |
| --- | --- |
| ![Logged-in nav with Admin, kody, Log out](https://cursor.com/artifacts/c/art-bc769843-7a16-4a14-b82f-1e4df2ef50ea) | ![Logged-out nav with Login and Signup](https://cursor.com/artifacts/c/art-46d25415-45a0-4558-9429-2ee742235b49) |

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends a primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `82af4acd` · **Head:** `cursor/fix-stale-nav-after-logout-34e9`

**Classification:** extends — the browser app's client router gains a mutation event and the shell's session refresh contract changes; no primitives added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — client router emits `mutation` events; shell session refresh bypasses its throttle after mutations |
| `app-sessions` | auth | composes — `/logout` and `/session` handlers unchanged; the client now revalidates against them correctly |

### System map

Logout flows from the nav form through the client router's new mutation event into an unthrottled `/session` revalidation.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	appSessions["app-sessions<br/>Browser sessions"]:::touched
	appUi -->|"form POST /logout, then unthrottled GET /session after 'mutation' event"| appSessions
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Nav as Top nav (app.tsx)
	participant Router as client-router.tsx
	participant Server as Worker (/logout, /session)
	Nav->>Router: submit logout form (intercepted)
	Router->>Server: POST /logout (cookie destroyed)
	Router-->>Nav: dispatch "mutation" event → session marked stale
	Router->>Server: run /login route loader (SPA redirect)
	Router-->>Nav: dispatch "navigate" event
	Nav->>Server: GET /session (throttle bypassed: stale flag)
	Nav-->>Nav: render logged-out nav
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f702b-68ae-7b38-ac20-62212c9334e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f702b-68ae-7b38-ac20-62212c9334e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session handling after actions such as logout and form submissions, ensuring updated authentication state is reflected promptly.
  - Prevented interrupted session refreshes from incorrectly clearing the last known valid session.
  - Improved logout flow reliability so users are redirected to the login page and signed-in controls are removed immediately.

- **Tests**
  - Updated end-to-end coverage to verify logout behavior and session-related navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->