### PR TITLE
Tag existing Kit subscribers on Kody signup

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -79,6 +79,14 @@ Waiting-list Kit integration:
   `first_name`
 - Rate-limited per client IP (5 requests / 15 minutes)
 
+Account signup Kit tagging (password and OAuth signup):
+
+- When `KIT_API_KEY` is set and the new account email already exists in Kit,
+  apply `signed_up::kody` (optional override `KIT_SIGNED_UP_TAG_ID`)
+- Does not create Kit subscribers for people who were never on the list
+- Leaves existing tags alone (including `waitlist::kody`)
+- Best-effort only: Kit errors or a missing key never fail account creation
+
 The `invites` table stores operator-created invite codes:
 
 - `code` is the primary key shown to the invited user

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -91,20 +91,22 @@ primitives:
       invite-gated with a Kit-backed public waiting list on /signup
       (non-production signup open), account email verification surfaced in
       session state and a dedicated `/pending-verification` experience after
-      password signup, MCP OAuth authorize gated until verified, social login
-      and invite-gated social signup (GitHub/Google/X OAuth connections in
-      oauth_connections, invite code carried in the signed OAuth state cookie,
-      mockable via MOCK_ client ids on non-production runtimes), and opt-in
-      second factors — TOTP two-factor (verifications table, pending kody_verify
-      cookie gates password/social login until /verify) and passkeys (WebAuthn
-      sign-in with required user verification; treated as MFA-complete, so TOTP
-      is skipped).
+      password signup, best-effort Kit `signed_up::kody` tagging when the
+      signup email already exists in Kit, MCP OAuth authorize gated until
+      verified, social login and invite-gated social signup (GitHub/Google/X
+      OAuth connections in oauth_connections, invite code carried in the signed
+      OAuth state cookie, mockable via MOCK_ client ids on non-production
+      runtimes), and opt-in second factors — TOTP two-factor (verifications
+      table, pending kody_verify cookie gates password/social login until
+      /verify) and passkeys (WebAuthn sign-in with required user verification;
+      treated as MFA-complete, so TOTP is skipped).
     code:
       - packages/worker/src/app/auth-session.ts
       - packages/worker/src/app/handlers/auth.ts
       - packages/worker/src/app/handlers/auth-provider.ts
       - packages/worker/src/app/handlers/waiting-list.ts
       - packages/worker/src/app/kit-waitlist.ts
+      - packages/worker/src/app/kit-signup.ts
       - packages/worker/src/app/handlers/account-connections.ts
       - packages/worker/src/app/oauth-providers.ts
       - packages/worker/src/app/oauth-login-state.ts

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -91,15 +91,15 @@ primitives:
       invite-gated with a Kit-backed public waiting list on /signup
       (non-production signup open), account email verification surfaced in
       session state and a dedicated `/pending-verification` experience after
-      password signup, best-effort Kit `signed_up::kody` tagging when the
-      signup email already exists in Kit, MCP OAuth authorize gated until
-      verified, social login and invite-gated social signup (GitHub/Google/X
-      OAuth connections in oauth_connections, invite code carried in the signed
-      OAuth state cookie, mockable via MOCK_ client ids on non-production
-      runtimes), and opt-in second factors — TOTP two-factor (verifications
-      table, pending kody_verify cookie gates password/social login until
-      /verify) and passkeys (WebAuthn sign-in with required user verification;
-      treated as MFA-complete, so TOTP is skipped).
+      password signup, best-effort Kit `signed_up::kody` tagging when the signup
+      email already exists in Kit, MCP OAuth authorize gated until verified,
+      social login and invite-gated social signup (GitHub/Google/X OAuth
+      connections in oauth_connections, invite code carried in the signed OAuth
+      state cookie, mockable via MOCK_ client ids on non-production runtimes),
+      and opt-in second factors — TOTP two-factor (verifications table, pending
+      kody_verify cookie gates password/social login until /verify) and passkeys
+      (WebAuthn sign-in with required user verification; treated as
+      MFA-complete, so TOTP is skipped).
     code:
       - packages/worker/src/app/auth-session.ts
       - packages/worker/src/app/handlers/auth.ts

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -98,6 +98,9 @@ Optional Worker secrets / vars for the public `/signup` waiting-list form
   `waitlist::kody` tag).
 - `KIT_WAITLIST_SEQUENCE_ID` — optional override for the welcome sequence id
   (defaults to "Kody Waitlist Welcome", from `hello@kentcdodds.com`).
+- `KIT_SIGNED_UP_TAG_ID` — optional override for the Kit tag applied on account
+  signup when the email already exists in Kit (defaults to `signed_up::kody`).
+  Signup never creates Kit subscribers and never fails when Kit is unset.
 
 See [`architecture/authentication.md`](./architecture/authentication.md).
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -147,10 +147,12 @@ Configure these GitHub Actions secrets and variables for workflows:
   Actions reserves the `GITHUB_*` secret namespace. See
   `docs/contributing/social-login.md` for provider app setup.)
 - `KIT_API_KEY` (optional GitHub / Worker secret; Kit / kit.com API key for
-  `/waiting-list` signup. Production deploy syncs it when set; without it,
-  production waiting-list joins return 503 while the rest of the app still
-  deploys. Preview deploys intentionally omit the key so preview/E2E joins do
-  not write to the production Kit audience. Create a Kit API key at
+  `/waiting-list` signup and best-effort `signed_up::kody` tagging on account
+  signup when the email already exists in Kit. Production deploy syncs it when
+  set; without it, production waiting-list joins return 503 while the rest of
+  the app still deploys (account signup simply skips Kit tagging). Preview
+  deploys intentionally omit the key so preview/E2E joins do not write to the
+  production Kit audience. Create a Kit API key at
   https://app.kit.com/account_settings/developer_settings and use the same value
   as the Kody user secret `kitApiKey` when convenient.)
 - `SENTRY_AUTH_TOKEN` (optional GitHub **secret**; Sentry auth token with

--- a/packages/worker/.env.example
+++ b/packages/worker/.env.example
@@ -68,9 +68,12 @@ X_CLIENT_SECRET=MOCK_X_CLIENT_SECRET
 # Kit (kit.com) waiting-list signup (optional Worker secret + tag/sequence ids).
 # Production /waiting-list posts create/upsert a subscriber, tag waitlist::kody,
 # and enroll them in the Kody Waitlist Welcome sequence (hello@kentcdodds.com).
+# Account signup best-effort tags existing Kit subscribers with signed_up::kody
+# (keeps waitlist::kody; never creates Kit subscribers; never fails signup).
 # Non-production skips Kit when KIT_API_KEY is unset.
 # KIT_API_KEY=
 # Optional overrides (defaults match the production Kit tag/sequence).
 # KIT_WAITLIST_TAG_ID=21081721
 # KIT_WAITLIST_SEQUENCE_ID=2823893
+# KIT_SIGNED_UP_TAG_ID=21252175
 

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -10,6 +10,7 @@ import {
 } from '#app/auth-session.ts'
 import { getUniqueConstraintField } from '#app/database-errors.ts'
 import { isNonProductionRuntime } from '#app/deployment-env.ts'
+import { maybeTagKitSubscriberOnSignup } from '#app/kit-signup.ts'
 import { getAvailableUsernameFromBase } from '#app/generated-username.ts'
 import {
 	consumeInviteCode,
@@ -541,6 +542,13 @@ export function createAuthProviderCallbackHandler(env: Env) {
 					)
 				}
 			}
+
+			// Best-effort: if this email is already in Kit (e.g. waitlist),
+			// add signed_up::kody without removing other tags.
+			await maybeTagKitSubscriberOnSignup({
+				env,
+				email,
+			})
 
 			void logAuditEvent({
 				category: 'auth',

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -34,6 +34,7 @@ import {
 } from '@kody-internal/shared/password-hash.ts'
 import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts'
 import { isNonProductionRuntime } from '#app/deployment-env.ts'
+import { maybeTagKitSubscriberOnSignup } from '#app/kit-signup.ts'
 
 const authModes = ['login', 'signup'] as const
 type AuthMode = (typeof authModes)[number]
@@ -396,6 +397,13 @@ export function createAuthHandler(env: Env) {
 						)
 					}
 				}
+
+				// Best-effort: if this email is already in Kit (e.g. waitlist),
+				// add signed_up::kody without removing other tags.
+				await maybeTagKitSubscriberOnSignup({
+					env,
+					email: normalizedEmail,
+				})
 
 				const cookie = await createAuthCookie(
 					{

--- a/packages/worker/src/app/kit-signup.node.test.ts
+++ b/packages/worker/src/app/kit-signup.node.test.ts
@@ -1,0 +1,127 @@
+import { expect, test, vi } from 'vitest'
+import {
+	type KitSignupError,
+	maybeTagKitSubscriberOnSignup,
+	resolveKitSignedUpTagId,
+	tagExistingKitSubscriberOnSignup,
+} from '#app/kit-signup.ts'
+
+test('resolveKitSignedUpTagId parses overrides and rejects junk', () => {
+	expect(resolveKitSignedUpTagId(undefined)).toBe(21252175)
+	expect(resolveKitSignedUpTagId(' 99 ')).toBe(99)
+	expect(resolveKitSignedUpTagId('nope')).toBeNull()
+})
+
+test('tagExistingKitSubscriberOnSignup tags existing subscribers only', async () => {
+	const calls: Array<{ url: string; method: string; body: unknown }> = []
+	const existingFetchImpl = async (
+		input: RequestInfo | URL,
+		init?: RequestInit,
+	) => {
+		const url = String(input)
+		const method = init?.method ?? 'GET'
+		const body = init?.body ? JSON.parse(String(init.body)) : null
+		calls.push({ url, method, body })
+		if (url.includes('/subscribers?email_address=')) {
+			return Response.json(
+				{
+					subscribers: [
+						{
+							id: 9,
+							email_address: 'ada@example.com',
+							first_name: 'Ada',
+						},
+					],
+				},
+				{ status: 200 },
+			)
+		}
+		if (url.includes('/tags/123/subscribers') && method === 'POST') {
+			return Response.json(
+				{ subscriber: { id: 9, email_address: 'ada@example.com' } },
+				{ status: 201 },
+			)
+		}
+		throw new Error(`Unexpected Kit call: ${method} ${url}`)
+	}
+
+	const tagged = await tagExistingKitSubscriberOnSignup({
+		apiKey: 'key',
+		email: 'ada@example.com',
+		tagId: 123,
+		fetchImpl: existingFetchImpl as typeof fetch,
+	})
+	expect(tagged).toEqual({ tagged: true, subscriberId: 9 })
+	expect(calls.map((call) => call.method)).toEqual(['GET', 'POST'])
+	expect(
+		calls.some(
+			(call) =>
+				call.method === 'POST' &&
+				call.url === 'https://api.kit.com/v4/subscribers',
+		),
+	).toBe(false)
+})
+
+test('tagExistingKitSubscriberOnSignup skips emails not in Kit', async () => {
+	const calls: Array<{ url: string; method: string }> = []
+	const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = String(input)
+		const method = init?.method ?? 'GET'
+		calls.push({ url, method })
+		if (url.includes('/subscribers?email_address=')) {
+			return Response.json({ subscribers: [] }, { status: 200 })
+		}
+		throw new Error(`Unexpected Kit call: ${method} ${url}`)
+	}
+
+	const result = await tagExistingKitSubscriberOnSignup({
+		apiKey: 'key',
+		email: 'new@example.com',
+		tagId: 123,
+		fetchImpl: fetchImpl as typeof fetch,
+	})
+	expect(result).toEqual({ tagged: false, reason: 'not_found' })
+	expect(calls).toHaveLength(1)
+})
+
+test('tagExistingKitSubscriberOnSignup classifies client failures', async () => {
+	const fetchImpl = vi.fn(async () =>
+		Response.json({ errors: ['invalid'] }, { status: 422 }),
+	)
+	await expect(
+		tagExistingKitSubscriberOnSignup({
+			apiKey: 'key',
+			email: 'ada@example.com',
+			fetchImpl: fetchImpl as typeof fetch,
+		}),
+	).rejects.toMatchObject({
+		name: 'KitSignupError',
+		kind: 'client',
+		status: 422,
+	} satisfies Partial<KitSignupError>)
+})
+
+test('maybeTagKitSubscriberOnSignup no-ops without an API key', async () => {
+	const fetchImpl = vi.fn()
+	await maybeTagKitSubscriberOnSignup({
+		env: {},
+		email: 'ada@example.com',
+		fetchImpl: fetchImpl as typeof fetch,
+	})
+	expect(fetchImpl).not.toHaveBeenCalled()
+})
+
+test('maybeTagKitSubscriberOnSignup swallows Kit failures', async () => {
+	const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	const fetchImpl = vi.fn(async () =>
+		Response.json({ errors: ['boom'] }, { status: 500 }),
+	)
+	await maybeTagKitSubscriberOnSignup({
+		env: { KIT_API_KEY: 'key' },
+		email: 'ada@example.com',
+		fetchImpl: fetchImpl as typeof fetch,
+	})
+	expect(fetchImpl).toHaveBeenCalled()
+	expect(warn).toHaveBeenCalled()
+	warn.mockRestore()
+})

--- a/packages/worker/src/app/kit-signup.ts
+++ b/packages/worker/src/app/kit-signup.ts
@@ -1,0 +1,237 @@
+/**
+ * Kit (kit.com) signup tagging helpers.
+ *
+ * When someone creates a Kody account and already exists as a Kit subscriber
+ * (for example from the public waitlist), tag them `signed_up::kody`. Existing
+ * tags such as `waitlist::kody` are left alone — Kit tags are additive.
+ *
+ * Auth uses the `X-Kit-Api-Key` header against `https://api.kit.com/v4`.
+ */
+
+import { KIT_API_BASE_URL } from '#app/kit-waitlist.ts'
+
+/** Kit tag `signed_up::kody` — override with `KIT_SIGNED_UP_TAG_ID` if needed. */
+export const DEFAULT_KIT_SIGNED_UP_TAG_ID = 21252175
+
+/** Bound Kit round-trips so a hung upstream cannot pin a Worker request. */
+export const KIT_SIGNUP_REQUEST_TIMEOUT_MS = 8_000
+
+export type TagExistingKitSubscriberOnSignupInput = {
+	apiKey: string
+	email: string
+	tagId?: number
+	fetchImpl?: typeof fetch
+	timeoutMs?: number
+}
+
+export type TagExistingKitSubscriberOnSignupResult =
+	| { tagged: true; subscriberId: number }
+	| { tagged: false; reason: 'not_found' }
+
+export class KitSignupError extends Error {
+	readonly status: number | null
+	readonly kind: 'client' | 'server' | 'network'
+
+	constructor(
+		message: string,
+		options: { status?: number | null; kind: KitSignupError['kind'] },
+	) {
+		super(message)
+		this.name = 'KitSignupError'
+		this.status = options.status ?? null
+		this.kind = options.kind
+	}
+}
+
+type KitSubscriber = {
+	id?: number
+	email_address?: string
+}
+
+type KitSubscriberPayload = {
+	subscriber?: KitSubscriber
+	subscribers?: Array<KitSubscriber>
+	errors?: Array<string>
+}
+
+function kitHeaders(apiKey: string): HeadersInit {
+	return {
+		Accept: 'application/json',
+		'Content-Type': 'application/json',
+		'X-Kit-Api-Key': apiKey,
+	}
+}
+
+async function readKitJson(
+	response: Response,
+): Promise<KitSubscriberPayload | null> {
+	try {
+		return (await response.json()) as KitSubscriberPayload
+	} catch {
+		return null
+	}
+}
+
+function kitErrorMessage(
+	payload: KitSubscriberPayload | null,
+	fallback: string,
+) {
+	const first = payload?.errors?.[0]
+	return typeof first === 'string' && first.trim() ? first : fallback
+}
+
+function classifyHttpKind(status: number): 'client' | 'server' {
+	return status >= 500 ? 'server' : 'client'
+}
+
+function isAbortError(error: unknown) {
+	return (
+		(error instanceof DOMException && error.name === 'TimeoutError') ||
+		(error instanceof Error && error.name === 'AbortError')
+	)
+}
+
+async function kitFetch(
+	fetchImpl: typeof fetch,
+	url: string,
+	init: RequestInit,
+	timeoutMs: number,
+): Promise<Response> {
+	try {
+		return await fetchImpl(url, {
+			...init,
+			signal: AbortSignal.timeout(timeoutMs),
+		})
+	} catch (error) {
+		if (isAbortError(error)) {
+			throw new KitSignupError('Kit request timed out.', {
+				status: null,
+				kind: 'network',
+			})
+		}
+		throw new KitSignupError('Kit request failed.', {
+			status: null,
+			kind: 'network',
+		})
+	}
+}
+
+/**
+ * If the email already exists in Kit, apply the signed-up tag. Does not create
+ * subscribers and does not remove other tags (including waitlist).
+ */
+export async function tagExistingKitSubscriberOnSignup(
+	input: TagExistingKitSubscriberOnSignupInput,
+): Promise<TagExistingKitSubscriberOnSignupResult> {
+	const fetchImpl = input.fetchImpl ?? fetch
+	const tagId = input.tagId ?? DEFAULT_KIT_SIGNED_UP_TAG_ID
+	const timeoutMs = input.timeoutMs ?? KIT_SIGNUP_REQUEST_TIMEOUT_MS
+	const headers = kitHeaders(input.apiKey)
+
+	const lookupUrl = `${KIT_API_BASE_URL}/subscribers?email_address=${encodeURIComponent(input.email)}`
+	const lookupResponse = await kitFetch(
+		fetchImpl,
+		lookupUrl,
+		{ method: 'GET', headers },
+		timeoutMs,
+	)
+	const lookupPayload = await readKitJson(lookupResponse)
+	if (!lookupResponse.ok) {
+		throw new KitSignupError(
+			kitErrorMessage(
+				lookupPayload,
+				`Kit subscriber lookup failed (${lookupResponse.status}).`,
+			),
+			{
+				status: lookupResponse.status,
+				kind: classifyHttpKind(lookupResponse.status),
+			},
+		)
+	}
+
+	const existing = lookupPayload?.subscribers?.find(
+		(subscriber) => typeof subscriber.id === 'number',
+	)
+	if (typeof existing?.id !== 'number') {
+		return { tagged: false, reason: 'not_found' }
+	}
+
+	const tagResponse = await kitFetch(
+		fetchImpl,
+		`${KIT_API_BASE_URL}/tags/${tagId}/subscribers`,
+		{
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				email_address: input.email,
+			}),
+		},
+		timeoutMs,
+	)
+	const tagPayload = await readKitJson(tagResponse)
+	if (!tagResponse.ok) {
+		throw new KitSignupError(
+			kitErrorMessage(
+				tagPayload,
+				`Kit signed-up tag failed (${tagResponse.status}).`,
+			),
+			{
+				status: tagResponse.status,
+				kind: classifyHttpKind(tagResponse.status),
+			},
+		)
+	}
+
+	return { tagged: true, subscriberId: existing.id }
+}
+
+function resolvePositiveIntId(
+	raw: string | undefined,
+	fallback: number,
+): number | null {
+	if (raw === undefined) return fallback
+	const trimmed = raw.trim()
+	if (!trimmed) return fallback
+	if (!/^\d+$/.test(trimmed)) return null
+	const parsed = Number.parseInt(trimmed, 10)
+	if (!Number.isSafeInteger(parsed) || parsed <= 0) return null
+	return parsed
+}
+
+export function resolveKitSignedUpTagId(
+	raw: string | undefined,
+): number | null {
+	return resolvePositiveIntId(raw, DEFAULT_KIT_SIGNED_UP_TAG_ID)
+}
+
+/**
+ * Best-effort signup side effect: when Kit is configured and the email already
+ * exists there, apply `signed_up::kody`. Failures are logged and never thrown.
+ */
+export async function maybeTagKitSubscriberOnSignup(input: {
+	env: Pick<Env, 'KIT_API_KEY' | 'KIT_SIGNED_UP_TAG_ID'>
+	email: string
+	fetchImpl?: typeof fetch
+}): Promise<void> {
+	const apiKey = input.env.KIT_API_KEY?.trim()
+	if (!apiKey) return
+
+	const tagId = resolveKitSignedUpTagId(input.env.KIT_SIGNED_UP_TAG_ID)
+	if (tagId === null) {
+		console.warn(
+			'Skipping Kit signed-up tagging: KIT_SIGNED_UP_TAG_ID is invalid.',
+		)
+		return
+	}
+
+	try {
+		await tagExistingKitSubscriberOnSignup({
+			apiKey,
+			email: input.email,
+			tagId,
+			fetchImpl: input.fetchImpl,
+		})
+	} catch (error) {
+		console.warn('Failed to tag Kit subscriber on signup:', error)
+	}
+}

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -198,9 +198,13 @@ export const EnvSchema = object({
 	JOB_REINDEX_SECRET: optionalNonEmptyStringSchema,
 	// Kit (kit.com) waitlist — optional; production waiting-list submits fail
 	// closed without KIT_API_KEY. Non-production skips Kit when unset.
+	// Account signup also uses KIT_API_KEY to best-effort tag existing Kit
+	// subscribers with signed_up::kody (never creates subscribers; never fails
+	// signup when Kit is unset or errors).
 	KIT_API_KEY: optionalNonEmptyStringSchema,
 	KIT_WAITLIST_TAG_ID: optionalNonEmptyStringSchema,
 	KIT_WAITLIST_SEQUENCE_ID: optionalNonEmptyStringSchema,
+	KIT_SIGNED_UP_TAG_ID: optionalNonEmptyStringSchema,
 })
 
 export type AppEnv = InferOutput<typeof EnvSchema>


### PR DESCRIPTION
## Summary
- On password and OAuth account signup, best-effort tag the email with Kit `signed_up::kody` when that subscriber already exists
- Leave existing tags alone (including `waitlist::kody`); never create Kit subscribers for new emails
- Optional `KIT_SIGNED_UP_TAG_ID` override; missing Kit config or API errors never fail signup

## Test plan
- [x] Unit tests for lookup/tag/skip/no-op paths (`kit-signup.node.test.ts`)
- [ ] Production: waitlist email signs up with invite → Kit has both `waitlist::kody` and `signed_up::kody`
- [ ] Production: brand-new email signs up → no Kit subscriber created
- [ ] Local/preview without `KIT_API_KEY` → signup still succeeds


Made with [Cursor](https://cursor.com)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `cae1752a` · **Head:** `05e2a9fb`

**Classification:** extends — account signup now best-effort tags existing Kit subscribers with `signed_up::kody` (additive; does not create Kit contacts).

### Primitives touched

| Primitive      | Group | Impact                                                                 |
| -------------- | ----- | ---------------------------------------------------------------------- |
| `app-sessions` | auth  | extends — password/OAuth signup call Kit tagging helper when key is set |

### System map

Password and OAuth signup paths call a best-effort Kit tag after account creation succeeds.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appSessions["app-sessions<br/>Browser sessions"]:::extended
	kitApi["Kit API<br/>api.kit.com"]:::untouched
	appSessions -->|"lookup email + POST signed_up::kody tag"| kitApi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant User
	participant Auth as auth / auth-provider
	participant Kit as api.kit.com
	User->>Auth: successful account create
	Auth->>Kit: GET subscriber by email
	alt already in Kit
		Auth->>Kit: POST tags/signed_up::kody/subscribers
	else not in Kit
		Auth-->>User: signup succeeds (no Kit write)
	end
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Waitlist join | tags `waitlist::kody` | unchanged |
| Account signup | no Kit call | if email exists in Kit, add `signed_up::kody` (keep waitlist) |
| Missing `KIT_API_KEY` | n/a | signup skips tagging; never fails |

</details>

<!-- system-recap:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Existing Kit subscribers are now tagged after password or OAuth signup.
  * Existing tags are preserved, and new Kit subscribers are not created during signup.
  * Added optional configuration to customize the signup tag.
  * Tagging is best-effort and won’t block account creation if Kit isn’t available or returns errors.

* **Documentation**
  * Updated contributing docs and environment/setup examples to describe the new signup tagging behavior and the override setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->