### PR TITLE
Add outbound email delivery lifecycle events

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,11 +100,12 @@ jobs:
       - name: 📝 Prepare worker env
         run: cp packages/worker/.env.example packages/worker/.env
 
-      - name: 🧱 Ensure production resources (D1 + KV)
+      - name: 🧱 Ensure production resources
         id: resources
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           APP_BASE_URL: ${{ vars.APP_BASE_URL }}
+          USER_EMAIL_DOMAIN: ${{ vars.USER_EMAIL_DOMAIN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -524,8 +524,11 @@ on write unless a migration backfills existing rows.
   invocation routing and cached response projections.
 - `email_messages.*_addresses_json`, `email_messages.references_json`,
   `email_messages.headers_json`, and `email_delivery_events.detail_json`
-  (`0030-email-primitives.sql`, `0031-unified-email-receipt.sql`) store parsed
-  email metadata; `detail_json` is write-mostly audit detail.
+  (`0030-email-primitives.sql`, `0031-unified-email-receipt.sql`,
+  `0061-email-delivery-lifecycle.sql`) store parsed email metadata and provider
+  delivery details. Provider event ids are unique for idempotent Queue
+  ingestion; `email_messages.delivery_status` is the latest provider state,
+  separate from send-request `processing_status`.
 - `system_email_daily_counters` (`0051-system-email-daily-counters.sql`) stores
   fixed per-local daily receive counters for operator-owned system inboxes.
   These counters are not user entitlements and are pruned by the system-email

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -384,6 +384,18 @@ primitives:
     docs:
       - docs/contributing/architecture/data-storage.md
 
+  - id: email-delivery-queue
+    group: storage
+    name: Email delivery event queue
+    summary:
+      Cloudflare Queue ingestion for outbound Email Sending lifecycle events.
+    code:
+      - packages/worker/src/email/delivery-
+      - tools/ci/production-resources.ts
+    docs:
+      - docs/use/email-primitives.md
+      - docs/contributing/setup-manifest.md
+
   - id: community-assets-r2
     group: storage
     name: Community asset storage (R2)

--- a/docs/contributing/cloudflare-offerings.md
+++ b/docs/contributing/cloudflare-offerings.md
@@ -37,11 +37,12 @@ Cloudflare's API token UI changes over time, but the shape is stable:
 - You grant **Read**/**Edit** per product area
 - Wrangler deploys, creates resources, and sets secrets via the API token
 
-Recommended baseline permissions for this repo (deploy + existing D1/KV):
+Recommended baseline permissions for this repo:
 
 - `Workers Scripts:Edit` (deploy, update, delete preview Workers)
 - `Workers KV Storage:Edit` (OAuth/session KV)
 - `D1:Edit` (migrations, database operations)
+- `Workers Queues:Edit` (email delivery Queue, DLQ, and event subscription)
 
 Add these permissions when you add the corresponding offering:
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -19,6 +19,12 @@ This project uses the following resources:
 - Cloudflare Email Routing for inbound mail
   - Configure MX records and selected route aliases in the Cloudflare dashboard.
   - Route only aliases that should persist inbound mail to the Worker.
+- Cloudflare Queue for Email Sending delivery events
+  - Production CI ensures `kody-email-delivery` and `kody-email-delivery-dlq`,
+    then reconciles an `email.sending` event subscription for the configured
+    user email domain.
+  - The API token needs `Workers Queues:Edit`; the domain must already be
+    enabled for Cloudflare Email Sending.
 - Vectorize indexes for MCP capability search (`CAPABILITY_VECTOR_INDEX`)
   - Production: `kody-capabilities-prod`
   - Preview: `kody-capabilities-preview`
@@ -185,6 +191,9 @@ How to get/set each value:
     deploy, rather than syncing it as a Worker secret.
   - Request-scoped MCP/app URLs use the inbound request origin so OAuth resource
     metadata matches the host the client connected to.
+- `USER_EMAIL_DOMAIN` (optional GitHub Actions **variable**; overrides
+  `inbox.<APP_BASE_URL hostname>` for user inboxes, outbound senders, and the
+  Email Sending event subscription).
   - Do not also upload `APP_BASE_URL` through `wrangler secret bulk` or pass it
     as a deploy-time `--var`, because Wrangler treats that as a conflicting
     binding name.

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -191,12 +191,14 @@ How to get/set each value:
     deploy, rather than syncing it as a Worker secret.
   - Request-scoped MCP/app URLs use the inbound request origin so OAuth resource
     metadata matches the host the client connected to.
-- `USER_EMAIL_DOMAIN` (optional GitHub Actions **variable**; overrides
-  `inbox.<APP_BASE_URL hostname>` for user inboxes, outbound senders, and the
-  Email Sending event subscription).
   - Do not also upload `APP_BASE_URL` through `wrangler secret bulk` or pass it
     as a deploy-time `--var`, because Wrangler treats that as a conflicting
     binding name.
+- `USER_EMAIL_DOMAIN` (optional GitHub Actions **variable**; overrides
+  `inbox.<APP_BASE_URL hostname>` for user inboxes, outbound senders, and the
+  Email Sending event subscription).
+  - In GitHub: **Settings → Secrets and variables → Actions → Variables**, add
+    it only when the production user email domain differs from the default.
 - `AI_GATEWAY_ID`
   - Create a Cloudflare AI Gateway in the dashboard and copy its production
     gateway ID. The Worker uses this for Workers AI embedding calls when set;

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -101,6 +101,19 @@ bodies, parsed headers beyond the event metadata, or attachment bytes only when
 the handler needs them with `email_message_get`, `email_attachment_get`, or the
 package runtime `email` helper.
 
+## `email.message.delivery.updated`
+
+Outbound Email Sending lifecycle changes dispatch
+`email.message.delivery.updated`. The payload contains metadata for the owned
+Kody message plus the provider event id, delivery status, terminal flag,
+recipient, SMTP delivery fields, optional bounce/failure/rejection/complaint
+details, and provider event timestamp.
+
+Use this topic for delivery notifications and bounce or complaint workflows. Do
+not resend on `deferred`: Cloudflare still has provider retries pending.
+Provider event ids are stored idempotently, so duplicate Queue delivery does not
+dispatch duplicate package invocations.
+
 ## `email.system-message.received` (admins)
 
 Mail stored in the operator-owned system inbox (`kody@<apex>`, `support@<apex>`,

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -112,7 +112,8 @@ details, and provider event timestamp.
 Use this topic for delivery notifications and bounce or complaint workflows. Do
 not resend on `deferred`: Cloudflare still has provider retries pending.
 Provider event ids are stored idempotently, so duplicate Queue delivery does not
-dispatch duplicate package invocations.
+dispatch duplicate package invocations. Out-of-order events remain available in
+delivery history but do not dispatch after a newer status.
 
 ## `email.system-message.received` (admins)
 

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -246,7 +246,8 @@ type EmailMessageDeliveryUpdatedEvent = {
 
 `deferred` means Cloudflare still has delivery retries pending; handlers should
 not independently resend the message. Cloudflare automatically suppresses hard
-bounces and spam complaints.
+bounces and spam complaints. Out-of-order events remain in delivery history but
+do not dispatch after a newer delivery state has already been stored.
 
 ## `email.system-message.received` package subscription (admins)
 

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -55,10 +55,12 @@ Use the MCP `email` domain:
 - `email_message_list` lists stored inbound and outbound messages.
 - `email_message_search` searches stored messages by case-insensitive substring
   match against the subject, header `From`, and envelope sender. It accepts the
-  same `inbox_id` / `direction` / `processing_status` filters and limit caps as
-  `email_message_list`.
+  same `inbox_id` / `direction` / `processing_status` / `delivery_status`
+  filters and limit caps as `email_message_list`.
 - `email_message_get` returns parsed bodies, headers, thread metadata, and
   attachment metadata.
+- `email_delivery_event_list` lists stored delivery history, including final
+  Email Sending outcomes, SMTP responses, bounces, rejections, and complaints.
 - `email_usage_get` returns the signed-in user's email usage and limits: stored
   message count, today's send and receive counts, the applicable caps, and the
   plan name.
@@ -105,6 +107,10 @@ Inbound storage is quota-gated per user:
   recipients, and only recipients taken from stored inbound mail.
 - Outbound sends consume a per-day entitlement. Users without a plan are capped
   by a global daily backstop instead of sending unlimited mail.
+- A successful send request has `processing_status: "sent"`. Cloudflare delivery
+  events independently populate `delivery_status` with `delivered`, `deferred`,
+  `bounced`, `failed`, `rejected`, or `complained`; use
+  `email_delivery_event_list` for the event history and SMTP details.
 - System inbox mail is not gated by a user plan or account-verification state.
   It has fixed platform caps and retention: messages are pruned after 90 days
   and the stored system inbox is capped so arbitrary sender traffic cannot grow
@@ -185,6 +191,62 @@ when the handler needs them with `email_message_get`, `email_attachment_get`, or
 the package runtime `email` helper. Use `package_subscriptions_list` with
 `topic: "email.message.received"` to discover which saved packages subscribe for
 the signed-in user.
+
+## `email.message.delivery.updated` package subscription
+
+Cloudflare Email Sending lifecycle events dispatch
+`email.message.delivery.updated` after Kody correlates the provider message id,
+stores the event idempotently, and updates the outbound message's latest
+delivery status. Email Routing events are not part of this topic.
+
+The metadata-first payload contains the owned Kody message and the provider
+delivery event:
+
+```ts
+type EmailMessageDeliveryUpdatedEvent = {
+	event: 'email.message.delivery.updated'
+	message: {
+		id: string
+		inbox_id: string | null
+		thread_id: string | null
+		from_address: string | null
+		to_addresses: Array<string>
+		subject: string | null
+		processing_status: 'stored' | 'sent' | 'failed'
+		provider_message_id: string | null
+		delivery_status:
+			| 'delivered'
+			| 'deferred'
+			| 'bounced'
+			| 'failed'
+			| 'rejected'
+			| 'complained'
+			| null
+		delivery_status_at: string | null
+		sent_at: string | null
+		created_at: string
+	}
+	delivery: {
+		event_id: string
+		status: NonNullable<
+			EmailMessageDeliveryUpdatedEvent['message']['delivery_status']
+		>
+		terminal: boolean
+		sender: string
+		recipient: string
+		delivery: Record<string, unknown>
+		bounce: Record<string, unknown> | null
+		failure: Record<string, unknown> | null
+		rejection: Record<string, unknown> | null
+		complaint: Record<string, unknown> | null
+		occurred_at: string
+	}
+}
+```
+
+`deferred` means Cloudflare still has delivery retries pending; handlers should
+not independently resend the message. Cloudflare automatically suppresses hard
+bounces and spam complaints.
 
 ## `email.system-message.received` package subscription (admins)
 

--- a/packages/worker/migrations/0061-email-delivery-lifecycle.sql
+++ b/packages/worker/migrations/0061-email-delivery-lifecycle.sql
@@ -15,9 +15,28 @@ CHECK (
 ALTER TABLE email_messages
 ADD COLUMN delivery_status_at TEXT;
 
-CREATE INDEX IF NOT EXISTS idx_email_messages_provider_message_id
+UPDATE email_messages
+SET provider_message_id = NULL
+WHERE id IN (
+	SELECT id
+	FROM (
+		SELECT
+			id,
+			ROW_NUMBER() OVER (
+				PARTITION BY provider_message_id
+				ORDER BY created_at ASC, id ASC
+			) AS provider_id_ordinal
+		FROM email_messages
+		WHERE direction = 'outbound'
+			AND provider_message_id IS NOT NULL
+	)
+	WHERE provider_id_ordinal > 1
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_email_messages_provider_message_id
 ON email_messages(provider_message_id)
-WHERE provider_message_id IS NOT NULL;
+WHERE direction = 'outbound'
+	AND provider_message_id IS NOT NULL;
 
 CREATE TABLE email_delivery_events_next (
 	id TEXT PRIMARY KEY,

--- a/packages/worker/migrations/0061-email-delivery-lifecycle.sql
+++ b/packages/worker/migrations/0061-email-delivery-lifecycle.sql
@@ -1,0 +1,89 @@
+ALTER TABLE email_messages
+ADD COLUMN delivery_status TEXT
+CHECK (
+	delivery_status IS NULL
+	OR delivery_status IN (
+		'delivered',
+		'deferred',
+		'bounced',
+		'failed',
+		'rejected',
+		'complained'
+	)
+);
+
+ALTER TABLE email_messages
+ADD COLUMN delivery_status_at TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_email_messages_provider_message_id
+ON email_messages(provider_message_id)
+WHERE provider_message_id IS NOT NULL;
+
+CREATE TABLE email_delivery_events_next (
+	id TEXT PRIMARY KEY,
+	message_id TEXT,
+	user_id TEXT,
+	inbox_id TEXT,
+	event_type TEXT NOT NULL CHECK (
+		event_type IN (
+			'receive_started',
+			'received',
+			'rejected',
+			'send_requested',
+			'sent',
+			'failed',
+			'delivered',
+			'deferred',
+			'bounced',
+			'complained'
+		)
+	),
+	provider TEXT NOT NULL DEFAULT 'kody',
+	provider_message_id TEXT,
+	provider_event_id TEXT,
+	detail_json TEXT NOT NULL DEFAULT '{}',
+	created_at TEXT NOT NULL,
+	FOREIGN KEY (message_id) REFERENCES email_messages(id) ON DELETE SET NULL,
+	FOREIGN KEY (inbox_id) REFERENCES email_inboxes(id) ON DELETE SET NULL
+);
+
+INSERT INTO email_delivery_events_next (
+	id,
+	message_id,
+	user_id,
+	inbox_id,
+	event_type,
+	provider,
+	provider_message_id,
+	provider_event_id,
+	detail_json,
+	created_at
+)
+SELECT
+	id,
+	message_id,
+	user_id,
+	inbox_id,
+	event_type,
+	provider,
+	provider_message_id,
+	NULL,
+	detail_json,
+	created_at
+FROM email_delivery_events;
+
+DROP TABLE email_delivery_events;
+ALTER TABLE email_delivery_events_next RENAME TO email_delivery_events;
+
+CREATE INDEX IF NOT EXISTS idx_email_delivery_events_message_id
+ON email_delivery_events(message_id);
+
+CREATE INDEX IF NOT EXISTS idx_email_delivery_events_user_created_at
+ON email_delivery_events(user_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_email_delivery_events_created_at
+ON email_delivery_events(created_at);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_email_delivery_events_provider_event_id
+ON email_delivery_events(provider_event_id)
+WHERE provider_event_id IS NOT NULL;

--- a/packages/worker/src/email/delivery-events.ts
+++ b/packages/worker/src/email/delivery-events.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod'
+import { recordProviderEmailDeliveryEvent } from './repo.ts'
+import { emailDeliveryStatusValues, type EmailDeliveryStatus } from './types.ts'
+
+const cloudflareEmailDeliveryTypeValues = [
+	'cf.email.sending.message.delivered',
+	'cf.email.sending.message.deferred',
+	'cf.email.sending.message.bounced',
+	'cf.email.sending.message.failed',
+	'cf.email.sending.message.rejected',
+	'cf.email.sending.message.complained',
+] as const
+
+const optionalDetailSchema = z.record(z.string(), z.unknown()).optional()
+
+const cloudflareEmailDeliveryEventSchema = z.object({
+	type: z.enum(cloudflareEmailDeliveryTypeValues),
+	source: z.object({
+		type: z.literal('email.sending'),
+		zoneId: z.string().min(1),
+		domain: z.string().min(1),
+	}),
+	payload: z.object({
+		eventId: z.string().min(1),
+		messageId: z.string().min(1),
+		sender: z.string().min(1),
+		recipient: z.string().min(1),
+		subject: z.string().optional(),
+		terminal: z.boolean(),
+		delivery: z
+			.object({
+				status: z.enum(emailDeliveryStatusValues),
+				provider: z.string().optional(),
+				deliveryTimeMs: z.number().optional(),
+				smtpStatusCode: z.string().optional(),
+				smtpEnhancedStatusCode: z.string().optional(),
+				smtpResponse: z.string().optional(),
+			})
+			.passthrough(),
+		bounce: optionalDetailSchema,
+		failure: optionalDetailSchema,
+		rejection: optionalDetailSchema,
+		complaint: optionalDetailSchema,
+	}),
+	metadata: z.object({
+		accountId: z.string().min(1),
+		eventSubscriptionId: z.string().min(1),
+		eventSchemaVersion: z.number().int().positive(),
+		eventTimestamp: z.iso.datetime(),
+	}),
+})
+
+export type CloudflareEmailDeliveryEvent = z.infer<
+	typeof cloudflareEmailDeliveryEventSchema
+>
+
+function statusForEventType(
+	type: CloudflareEmailDeliveryEvent['type'],
+): EmailDeliveryStatus {
+	switch (type) {
+		case 'cf.email.sending.message.delivered':
+			return 'delivered'
+		case 'cf.email.sending.message.deferred':
+			return 'deferred'
+		case 'cf.email.sending.message.bounced':
+			return 'bounced'
+		case 'cf.email.sending.message.failed':
+			return 'failed'
+		case 'cf.email.sending.message.rejected':
+			return 'rejected'
+		case 'cf.email.sending.message.complained':
+			return 'complained'
+		default: {
+			const exhaustive: never = type
+			throw new Error(`Unsupported email delivery event type: ${exhaustive}`)
+		}
+	}
+}
+
+export function parseCloudflareEmailDeliveryEvent(input: unknown) {
+	const result = cloudflareEmailDeliveryEventSchema.safeParse(input)
+	if (!result.success) return null
+	if (
+		statusForEventType(result.data.type) !== result.data.payload.delivery.status
+	) {
+		return null
+	}
+	return result.data
+}
+
+export async function processCloudflareEmailDeliveryEvent(input: {
+	db: D1Database
+	body: unknown
+}) {
+	const event = parseCloudflareEmailDeliveryEvent(input.body)
+	if (!event) {
+		return { outcome: 'invalid' as const, event: null, message: null }
+	}
+	const result = await recordProviderEmailDeliveryEvent({
+		db: input.db,
+		providerMessageId: event.payload.messageId,
+		providerEventId: event.payload.eventId,
+		deliveryStatus: event.payload.delivery.status,
+		eventTimestamp: event.metadata.eventTimestamp,
+		detail: {
+			source: event.source,
+			sender: event.payload.sender,
+			recipient: event.payload.recipient,
+			subject: event.payload.subject ?? null,
+			terminal: event.payload.terminal,
+			delivery: event.payload.delivery,
+			bounce: event.payload.bounce ?? null,
+			failure: event.payload.failure ?? null,
+			rejection: event.payload.rejection ?? null,
+			complaint: event.payload.complaint ?? null,
+			metadata: event.metadata,
+		},
+	})
+	return { ...result, event }
+}

--- a/packages/worker/src/email/delivery-events.workers.test.ts
+++ b/packages/worker/src/email/delivery-events.workers.test.ts
@@ -1,0 +1,183 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import { processCloudflareEmailDeliveryEvent } from './delivery-events.ts'
+import {
+	getEmailMessageById,
+	insertEmailMessage,
+	listEmailDeliveryEvents,
+} from './repo.ts'
+import { ensureEmailTestSchema } from './test-schema.ts'
+
+function createDeliveryEvent(input: {
+	eventId: string
+	messageId: string
+	status:
+		| 'delivered'
+		| 'deferred'
+		| 'bounced'
+		| 'failed'
+		| 'rejected'
+		| 'complained'
+	eventTimestamp: string
+}) {
+	return {
+		type: `cf.email.sending.message.${input.status}`,
+		source: {
+			type: 'email.sending',
+			zoneId: 'zone-1',
+			domain: 'inbox.example.com',
+		},
+		payload: {
+			eventId: input.eventId,
+			messageId: input.messageId,
+			sender: 'user@inbox.example.com',
+			recipient: 'recipient@example.net',
+			subject: 'Delivery lifecycle',
+			terminal: input.status !== 'deferred',
+			delivery: {
+				status: input.status,
+				provider: 'external_smtp',
+				smtpStatusCode: input.status === 'delivered' ? '250' : '451',
+				smtpResponse:
+					input.status === 'delivered'
+						? '250 2.0.0 accepted'
+						: '451 4.2.0 temporary failure',
+			},
+			...(input.status === 'deferred'
+				? {
+						bounce: {
+							type: 'soft',
+							classification: 'temporary_failure',
+						},
+					}
+				: {}),
+		},
+		metadata: {
+			accountId: 'account-1',
+			eventSubscriptionId: 'subscription-1',
+			eventSchemaVersion: 1,
+			eventTimestamp: input.eventTimestamp,
+		},
+	}
+}
+
+test('provider delivery events are idempotent, ordered, and user scoped', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const userId = 'delivery-user-1'
+	const providerMessageId = `provider-${crypto.randomUUID()}`
+	const message = await insertEmailMessage({
+		db: env.APP_DB,
+		blobs: env.EMAIL_BLOBS,
+		message: {
+			direction: 'outbound',
+			userId,
+			fromAddress: 'user@inbox.example.com',
+			toAddresses: ['recipient@example.net'],
+			subject: 'Delivery lifecycle',
+			processingStatus: 'sent',
+			providerMessageId,
+			sentAt: '2026-07-17T20:00:00.000Z',
+		},
+	})
+
+	const delivered = createDeliveryEvent({
+		eventId: 'event-delivered',
+		messageId: providerMessageId,
+		status: 'delivered',
+		eventTimestamp: '2026-07-17T20:02:00.000Z',
+	})
+	const recorded = await processCloudflareEmailDeliveryEvent({
+		db: env.APP_DB,
+		body: delivered,
+	})
+	expect(recorded.outcome).toBe('recorded')
+	expect(recorded.message).toMatchObject({
+		id: message.id,
+		userId,
+		processingStatus: 'sent',
+		deliveryStatus: 'delivered',
+		deliveryStatusAt: '2026-07-17T20:02:00.000Z',
+	})
+
+	const duplicate = await processCloudflareEmailDeliveryEvent({
+		db: env.APP_DB,
+		body: delivered,
+	})
+	expect(duplicate.outcome).toBe('duplicate')
+
+	const olderDeferred = createDeliveryEvent({
+		eventId: 'event-deferred',
+		messageId: providerMessageId,
+		status: 'deferred',
+		eventTimestamp: '2026-07-17T20:01:00.000Z',
+	})
+	expect(
+		(
+			await processCloudflareEmailDeliveryEvent({
+				db: env.APP_DB,
+				body: olderDeferred,
+			})
+		).outcome,
+	).toBe('recorded')
+
+	const stored = await getEmailMessageById({
+		db: env.APP_DB,
+		userId,
+		messageId: message.id,
+	})
+	expect(stored).toMatchObject({
+		deliveryStatus: 'delivered',
+		deliveryStatusAt: '2026-07-17T20:02:00.000Z',
+	})
+
+	const events = await listEmailDeliveryEvents({
+		db: env.APP_DB,
+		userId,
+		messageId: message.id,
+		limit: 10,
+	})
+	expect(events).toHaveLength(2)
+	expect(events.map((event) => event.providerEventId).sort()).toEqual([
+		'event-deferred',
+		'event-delivered',
+	])
+	expect(JSON.parse(events[0]!.detailJson)).toEqual(
+		expect.objectContaining({
+			recipient: 'recipient@example.net',
+			delivery: expect.objectContaining({ status: 'delivered' }),
+		}),
+	)
+	expect(
+		await listEmailDeliveryEvents({
+			db: env.APP_DB,
+			userId: 'different-user',
+			limit: 10,
+		}),
+	).toEqual([])
+
+	expect(
+		(
+			await processCloudflareEmailDeliveryEvent({
+				db: env.APP_DB,
+				body: createDeliveryEvent({
+					eventId: 'event-unknown',
+					messageId: 'unknown-provider-message',
+					status: 'bounced',
+					eventTimestamp: '2026-07-17T20:03:00.000Z',
+				}),
+			})
+		).outcome,
+	).toBe('unmatched')
+
+	expect(
+		(
+			await processCloudflareEmailDeliveryEvent({
+				db: env.APP_DB,
+				body: {
+					...delivered,
+					type: 'cf.email.sending.message.bounced',
+				},
+			})
+		).outcome,
+	).toBe('invalid')
+})

--- a/packages/worker/src/email/delivery-events.workers.test.ts
+++ b/packages/worker/src/email/delivery-events.workers.test.ts
@@ -105,6 +105,35 @@ test('provider delivery events are idempotent, ordered, and user scoped', async 
 	})
 	expect(duplicate.outcome).toBe('duplicate')
 
+	const conflictingDuplicate = await processCloudflareEmailDeliveryEvent({
+		db: env.APP_DB,
+		body: createDeliveryEvent({
+			eventId: 'event-delivered',
+			messageId: providerMessageId,
+			status: 'bounced',
+			eventTimestamp: '2026-07-17T20:05:00.000Z',
+		}),
+	})
+	expect(conflictingDuplicate.outcome).toBe('duplicate')
+	expect(
+		await getEmailMessageById({
+			db: env.APP_DB,
+			userId,
+			messageId: message.id,
+		}),
+	).toMatchObject({
+		deliveryStatus: 'delivered',
+		deliveryStatusAt: '2026-07-17T20:02:00.000Z',
+	})
+	expect(
+		await listEmailDeliveryEvents({
+			db: env.APP_DB,
+			userId,
+			messageId: message.id,
+			limit: 10,
+		}),
+	).toHaveLength(1)
+
 	const olderDeferred = createDeliveryEvent({
 		eventId: 'event-deferred',
 		messageId: providerMessageId,

--- a/packages/worker/src/email/delivery-events.workers.test.ts
+++ b/packages/worker/src/email/delivery-events.workers.test.ts
@@ -114,7 +114,7 @@ test('provider delivery events are idempotent, ordered, and user scoped', async 
 			eventTimestamp: '2026-07-17T20:05:00.000Z',
 		}),
 	})
-	expect(conflictingDuplicate.outcome).toBe('duplicate')
+	expect(conflictingDuplicate.outcome).toBe('stale')
 	expect(
 		await getEmailMessageById({
 			db: env.APP_DB,
@@ -147,7 +147,7 @@ test('provider delivery events are idempotent, ordered, and user scoped', async 
 				body: olderDeferred,
 			})
 		).outcome,
-	).toBe('recorded')
+	).toBe('stale')
 
 	const stored = await getEmailMessageById({
 		db: env.APP_DB,

--- a/packages/worker/src/email/delivery-queue.node.test.ts
+++ b/packages/worker/src/email/delivery-queue.node.test.ts
@@ -38,6 +38,7 @@ test('email delivery Queue acknowledges permanent outcomes and retries unmatched
 	const recorded = createQueueMessage('queue-recorded', { kind: 'recorded' })
 	const duplicate = createQueueMessage('queue-duplicate', { kind: 'duplicate' })
 	const invalid = createQueueMessage('queue-invalid', { kind: 'invalid' })
+	const stale = createQueueMessage('queue-stale', { kind: 'stale' })
 	const unmatched = createQueueMessage('queue-unmatched', { kind: 'unmatched' })
 	const dispatchFailure = createQueueMessage('queue-dispatch-failure', {
 		kind: 'dispatch-failure',
@@ -61,6 +62,11 @@ test('email delivery Queue acknowledges permanent outcomes and retries unmatched
 			outcome: 'invalid',
 			event: null,
 			message: null,
+		})
+		.mockResolvedValueOnce({
+			outcome: 'stale',
+			event: providerEvent,
+			message: storedMessage,
 		})
 		.mockResolvedValueOnce({
 			outcome: 'unmatched',
@@ -87,7 +93,14 @@ test('email delivery Queue acknowledges permanent outcomes and retries unmatched
 	await handleEmailDeliveryQueue(
 		{
 			queue: 'kody-email-delivery',
-			messages: [recorded, duplicate, invalid, unmatched, dispatchFailure],
+			messages: [
+				recorded,
+				duplicate,
+				invalid,
+				stale,
+				unmatched,
+				dispatchFailure,
+			],
 			ackAll() {},
 			retryAll() {},
 		} as unknown as MessageBatch<unknown>,
@@ -99,6 +112,7 @@ test('email delivery Queue acknowledges permanent outcomes and retries unmatched
 	expect(recorded.ack).toHaveBeenCalledTimes(1)
 	expect(duplicate.ack).toHaveBeenCalledTimes(1)
 	expect(invalid.ack).toHaveBeenCalledTimes(1)
+	expect(stale.ack).toHaveBeenCalledTimes(1)
 	expect(unmatched.ack).not.toHaveBeenCalled()
 	expect(unmatched.retry).toHaveBeenCalledWith({ delaySeconds: 30 })
 	expect(dispatchFailure.ack).not.toHaveBeenCalled()

--- a/packages/worker/src/email/delivery-queue.node.test.ts
+++ b/packages/worker/src/email/delivery-queue.node.test.ts
@@ -1,5 +1,8 @@
 import { expect, test, vi } from 'vitest'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import {
+	consoleError,
+	consoleWarn,
+} from '#worker/test-support/console-spies.ts'
 
 const mocks = vi.hoisted(() => ({
 	processCloudflareEmailDeliveryEvent: vi.fn(),
@@ -31,10 +34,14 @@ function createQueueMessage(id: string, body: unknown) {
 
 test('email delivery Queue acknowledges permanent outcomes and retries unmatched messages', async () => {
 	consoleWarn.mockImplementation(() => {})
+	consoleError.mockImplementation(() => {})
 	const recorded = createQueueMessage('queue-recorded', { kind: 'recorded' })
 	const duplicate = createQueueMessage('queue-duplicate', { kind: 'duplicate' })
 	const invalid = createQueueMessage('queue-invalid', { kind: 'invalid' })
 	const unmatched = createQueueMessage('queue-unmatched', { kind: 'unmatched' })
+	const dispatchFailure = createQueueMessage('queue-dispatch-failure', {
+		kind: 'dispatch-failure',
+	})
 	const providerEvent = {
 		payload: { eventId: 'event-1', messageId: 'provider-1' },
 	}
@@ -60,6 +67,15 @@ test('email delivery Queue acknowledges permanent outcomes and retries unmatched
 			event: providerEvent,
 			message: null,
 		})
+		.mockResolvedValueOnce({
+			outcome: 'recorded',
+			event: providerEvent,
+			message: storedMessage,
+		})
+	mocks.dispatchEmailDeliverySubscriptionEvents
+		.mockResolvedValueOnce([])
+		.mockResolvedValueOnce([])
+		.mockRejectedValueOnce(new Error('dispatch failed'))
 	const waitUntilPromises: Array<Promise<unknown>> = []
 	const ctx = {
 		waitUntil(promise: Promise<unknown>) {
@@ -71,7 +87,7 @@ test('email delivery Queue acknowledges permanent outcomes and retries unmatched
 	await handleEmailDeliveryQueue(
 		{
 			queue: 'kody-email-delivery',
-			messages: [recorded, duplicate, invalid, unmatched],
+			messages: [recorded, duplicate, invalid, unmatched, dispatchFailure],
 			ackAll() {},
 			retryAll() {},
 		} as unknown as MessageBatch<unknown>,
@@ -85,13 +101,23 @@ test('email delivery Queue acknowledges permanent outcomes and retries unmatched
 	expect(invalid.ack).toHaveBeenCalledTimes(1)
 	expect(unmatched.ack).not.toHaveBeenCalled()
 	expect(unmatched.retry).toHaveBeenCalledWith({ delaySeconds: 30 })
-	expect(mocks.dispatchEmailDeliverySubscriptionEvents).toHaveBeenCalledWith({
-		env: expect.anything(),
-		message: storedMessage,
-		providerEvent,
-	})
+	expect(dispatchFailure.ack).not.toHaveBeenCalled()
+	expect(dispatchFailure.retry).toHaveBeenCalledWith({ delaySeconds: 30 })
+	expect(mocks.dispatchEmailDeliverySubscriptionEvents).toHaveBeenCalledTimes(3)
+	expect(mocks.dispatchEmailDeliverySubscriptionEvents).toHaveBeenNthCalledWith(
+		1,
+		{
+			env: expect.anything(),
+			message: storedMessage,
+			providerEvent,
+		},
+	)
 	expect(consoleWarn).toHaveBeenCalledWith('email-delivery-event-unmatched', {
 		queueMessageId: 'queue-unmatched',
 		providerMessageId: 'provider-1',
 	})
+	expect(consoleError).toHaveBeenCalledWith(
+		'email-delivery-event-processing-failed',
+		expect.objectContaining({ message: 'dispatch failed' }),
+	)
 })

--- a/packages/worker/src/email/delivery-queue.node.test.ts
+++ b/packages/worker/src/email/delivery-queue.node.test.ts
@@ -1,0 +1,97 @@
+import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
+
+const mocks = vi.hoisted(() => ({
+	processCloudflareEmailDeliveryEvent: vi.fn(),
+	dispatchEmailDeliverySubscriptionEvents: vi.fn(async () => []),
+}))
+
+vi.mock('./delivery-events.ts', () => ({
+	processCloudflareEmailDeliveryEvent:
+		mocks.processCloudflareEmailDeliveryEvent,
+}))
+
+vi.mock('./package-subscriptions.ts', () => ({
+	dispatchEmailDeliverySubscriptionEvents:
+		mocks.dispatchEmailDeliverySubscriptionEvents,
+}))
+
+const { handleEmailDeliveryQueue } = await import('./delivery-queue.ts')
+
+function createQueueMessage(id: string, body: unknown) {
+	return {
+		id,
+		timestamp: new Date('2026-07-17T20:00:00.000Z'),
+		body,
+		attempts: 1,
+		ack: vi.fn(),
+		retry: vi.fn(),
+	}
+}
+
+test('email delivery Queue acknowledges permanent outcomes and retries unmatched messages', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const recorded = createQueueMessage('queue-recorded', { kind: 'recorded' })
+	const duplicate = createQueueMessage('queue-duplicate', { kind: 'duplicate' })
+	const invalid = createQueueMessage('queue-invalid', { kind: 'invalid' })
+	const unmatched = createQueueMessage('queue-unmatched', { kind: 'unmatched' })
+	const providerEvent = {
+		payload: { eventId: 'event-1', messageId: 'provider-1' },
+	}
+	const storedMessage = { id: 'message-1', userId: 'user-1' }
+	mocks.processCloudflareEmailDeliveryEvent
+		.mockResolvedValueOnce({
+			outcome: 'recorded',
+			event: providerEvent,
+			message: storedMessage,
+		})
+		.mockResolvedValueOnce({
+			outcome: 'duplicate',
+			event: providerEvent,
+			message: storedMessage,
+		})
+		.mockResolvedValueOnce({
+			outcome: 'invalid',
+			event: null,
+			message: null,
+		})
+		.mockResolvedValueOnce({
+			outcome: 'unmatched',
+			event: providerEvent,
+			message: null,
+		})
+	const waitUntilPromises: Array<Promise<unknown>> = []
+	const ctx = {
+		waitUntil(promise: Promise<unknown>) {
+			waitUntilPromises.push(promise)
+		},
+		passThroughOnException() {},
+	} as ExecutionContext
+
+	await handleEmailDeliveryQueue(
+		{
+			queue: 'kody-email-delivery',
+			messages: [recorded, duplicate, invalid, unmatched],
+			ackAll() {},
+			retryAll() {},
+		} as unknown as MessageBatch<unknown>,
+		{ APP_DB: {} } as Env,
+		ctx,
+	)
+	await Promise.all(waitUntilPromises)
+
+	expect(recorded.ack).toHaveBeenCalledTimes(1)
+	expect(duplicate.ack).toHaveBeenCalledTimes(1)
+	expect(invalid.ack).toHaveBeenCalledTimes(1)
+	expect(unmatched.ack).not.toHaveBeenCalled()
+	expect(unmatched.retry).toHaveBeenCalledWith({ delaySeconds: 30 })
+	expect(mocks.dispatchEmailDeliverySubscriptionEvents).toHaveBeenCalledWith({
+		env: expect.anything(),
+		message: storedMessage,
+		providerEvent,
+	})
+	expect(consoleWarn).toHaveBeenCalledWith('email-delivery-event-unmatched', {
+		queueMessageId: 'queue-unmatched',
+		providerMessageId: 'provider-1',
+	})
+})

--- a/packages/worker/src/email/delivery-queue.ts
+++ b/packages/worker/src/email/delivery-queue.ts
@@ -6,7 +6,7 @@ const unmatchedRetryDelaySeconds = 30
 export async function handleEmailDeliveryQueue(
 	batch: MessageBatch<unknown>,
 	env: Env,
-	ctx: ExecutionContext,
+	_ctx: ExecutionContext,
 ) {
 	for (const queueMessage of batch.messages) {
 		try {
@@ -26,18 +26,13 @@ export async function handleEmailDeliveryQueue(
 					queueMessage.retry({ delaySeconds: unmatchedRetryDelaySeconds })
 					break
 				case 'duplicate':
-					queueMessage.ack()
-					break
 				case 'recorded': {
-					queueMessage.ack()
-					const dispatch = dispatchEmailDeliverySubscriptionEvents({
+					await dispatchEmailDeliverySubscriptionEvents({
 						env,
 						message: result.message,
 						providerEvent: result.event,
-					}).catch((error: unknown) => {
-						console.error('email-delivery-subscription-dispatch-failed', error)
 					})
-					ctx.waitUntil(dispatch)
+					queueMessage.ack()
 					break
 				}
 				default: {

--- a/packages/worker/src/email/delivery-queue.ts
+++ b/packages/worker/src/email/delivery-queue.ts
@@ -1,0 +1,55 @@
+import { processCloudflareEmailDeliveryEvent } from './delivery-events.ts'
+import { dispatchEmailDeliverySubscriptionEvents } from './package-subscriptions.ts'
+
+const unmatchedRetryDelaySeconds = 30
+
+export async function handleEmailDeliveryQueue(
+	batch: MessageBatch<unknown>,
+	env: Env,
+	ctx: ExecutionContext,
+) {
+	for (const queueMessage of batch.messages) {
+		try {
+			const result = await processCloudflareEmailDeliveryEvent({
+				db: env.APP_DB,
+				body: queueMessage.body,
+			})
+			switch (result.outcome) {
+				case 'invalid':
+					queueMessage.ack()
+					break
+				case 'unmatched':
+					console.warn('email-delivery-event-unmatched', {
+						queueMessageId: queueMessage.id,
+						providerMessageId: result.event?.payload.messageId ?? null,
+					})
+					queueMessage.retry({ delaySeconds: unmatchedRetryDelaySeconds })
+					break
+				case 'duplicate':
+					queueMessage.ack()
+					break
+				case 'recorded': {
+					queueMessage.ack()
+					const dispatch = dispatchEmailDeliverySubscriptionEvents({
+						env,
+						message: result.message,
+						providerEvent: result.event,
+					}).catch((error: unknown) => {
+						console.error('email-delivery-subscription-dispatch-failed', error)
+					})
+					ctx.waitUntil(dispatch)
+					break
+				}
+				default: {
+					const exhaustive: never = result
+					throw new Error(
+						`Unsupported email delivery queue outcome: ${JSON.stringify(exhaustive)}`,
+					)
+				}
+			}
+		} catch (error) {
+			console.error('email-delivery-event-processing-failed', error)
+			queueMessage.retry({ delaySeconds: unmatchedRetryDelaySeconds })
+		}
+	}
+}

--- a/packages/worker/src/email/delivery-queue.ts
+++ b/packages/worker/src/email/delivery-queue.ts
@@ -25,6 +25,9 @@ export async function handleEmailDeliveryQueue(
 					})
 					queueMessage.retry({ delaySeconds: unmatchedRetryDelaySeconds })
 					break
+				case 'stale':
+					queueMessage.ack()
+					break
 				case 'duplicate':
 				case 'recorded': {
 					await dispatchEmailDeliverySubscriptionEvents({

--- a/packages/worker/src/email/email-delivery-lifecycle-migration.node.test.ts
+++ b/packages/worker/src/email/email-delivery-lifecycle-migration.node.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+
+const migrationUrl = new URL(
+	'../../migrations/0061-email-delivery-lifecycle.sql',
+	import.meta.url,
+)
+
+test('email delivery migration deduplicates and uniquely indexes provider message ids', () => {
+	const db = new DatabaseSync(':memory:')
+	db.exec(`
+		CREATE TABLE email_inboxes (
+			id TEXT PRIMARY KEY
+		);
+		CREATE TABLE email_messages (
+			id TEXT PRIMARY KEY,
+			direction TEXT NOT NULL,
+			provider_message_id TEXT,
+			created_at TEXT NOT NULL
+		);
+		CREATE TABLE email_delivery_events (
+			id TEXT PRIMARY KEY,
+			message_id TEXT,
+			user_id TEXT,
+			inbox_id TEXT,
+			event_type TEXT NOT NULL,
+			provider TEXT NOT NULL DEFAULT 'kody',
+			provider_message_id TEXT,
+			detail_json TEXT NOT NULL DEFAULT '{}',
+			created_at TEXT NOT NULL
+		);
+		INSERT INTO email_messages (
+			id, direction, provider_message_id, created_at
+		) VALUES
+			('message-first', 'outbound', 'provider-1', '2026-07-17T20:00:00.000Z'),
+			('message-duplicate', 'outbound', 'provider-1', '2026-07-17T20:01:00.000Z');
+	`)
+
+	db.exec(readFileSync(migrationUrl, 'utf8'))
+
+	expect(
+		db
+			.prepare(
+				`SELECT id, provider_message_id
+				FROM email_messages
+				ORDER BY created_at ASC`,
+			)
+			.all(),
+	).toEqual([
+		{ id: 'message-first', provider_message_id: 'provider-1' },
+		{ id: 'message-duplicate', provider_message_id: null },
+	])
+	expect(() => {
+		db.prepare(
+			`UPDATE email_messages
+			 SET provider_message_id = 'provider-1'
+			 WHERE id = 'message-duplicate'`,
+		).run()
+	}).toThrow(/UNIQUE constraint failed/)
+})

--- a/packages/worker/src/email/package-subscriptions.node.test.ts
+++ b/packages/worker/src/email/package-subscriptions.node.test.ts
@@ -1,0 +1,122 @@
+import { expect, test, vi } from 'vitest'
+
+const emailDeliveryUpdatedTopic = 'email.message.delivery.updated'
+
+const mocks = vi.hoisted(() => ({
+	invokePackageSubscription: vi.fn(async () => ({ ok: true })),
+	listSavedPackagesByUserId: vi.fn(),
+	loadPackageManifestBySourceId: vi.fn(),
+}))
+
+vi.mock('#worker/package-invocations/service.ts', () => ({
+	invokePackageSubscription: mocks.invokePackageSubscription,
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	listSavedPackagesByUserId: mocks.listSavedPackagesByUserId,
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageManifestBySourceId: mocks.loadPackageManifestBySourceId,
+}))
+
+const { dispatchEmailDeliverySubscriptionEvents } =
+	await import('./package-subscriptions.ts')
+
+test('delivery updates fan out only through the stored message owner', async () => {
+	const savedPackage = {
+		id: 'package-1',
+		userId: 'user-1',
+		sourceId: 'source-1',
+		kodyId: 'delivery-notifier',
+		name: '@user/delivery-notifier',
+	}
+	mocks.listSavedPackagesByUserId.mockResolvedValueOnce([savedPackage])
+	mocks.loadPackageManifestBySourceId.mockResolvedValueOnce({
+		manifest: {
+			name: '@user/delivery-notifier',
+			kody: {
+				id: 'delivery-notifier',
+				description: 'Delivery notifier',
+				subscriptions: {
+					[emailDeliveryUpdatedTopic]: {
+						handler: './src/on-delivery.ts',
+					},
+				},
+			},
+		},
+	})
+	const message = {
+		id: 'message-1',
+		userId: 'user-1',
+		inboxId: 'inbox-1',
+		threadId: 'thread-1',
+		fromAddress: 'user@inbox.example.com',
+		toAddresses: ['recipient@example.net'],
+		subject: 'Hello',
+		processingStatus: 'sent',
+		providerMessageId: 'provider-1',
+		deliveryStatus: 'bounced',
+		deliveryStatusAt: '2026-07-17T20:00:00.000Z',
+		sentAt: '2026-07-17T19:59:00.000Z',
+		createdAt: '2026-07-17T19:59:00.000Z',
+	}
+	const providerEvent = {
+		type: 'cf.email.sending.message.bounced',
+		source: {
+			type: 'email.sending',
+			zoneId: 'zone-1',
+			domain: 'inbox.example.com',
+		},
+		payload: {
+			eventId: 'event-1',
+			messageId: 'provider-1',
+			sender: 'user@inbox.example.com',
+			recipient: 'recipient@example.net',
+			terminal: true,
+			delivery: { status: 'bounced' },
+			bounce: { type: 'hard' },
+		},
+		metadata: {
+			accountId: 'account-1',
+			eventSubscriptionId: 'subscription-1',
+			eventSchemaVersion: 1,
+			eventTimestamp: '2026-07-17T20:00:00.000Z',
+		},
+	}
+	const env = {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {},
+		APP_BASE_URL: 'https://example.com',
+	} as Env
+
+	await dispatchEmailDeliverySubscriptionEvents({
+		env,
+		message: message as never,
+		providerEvent: providerEvent as never,
+	})
+
+	expect(mocks.listSavedPackagesByUserId).toHaveBeenCalledWith(env.APP_DB, {
+		userId: 'user-1',
+	})
+	expect(mocks.invokePackageSubscription).toHaveBeenCalledWith(
+		expect.objectContaining({
+			savedPackage,
+			topic: emailDeliveryUpdatedTopic,
+			idempotencyKey: 'email-delivery:event-1:package-1',
+			source: 'email',
+			params: expect.objectContaining({
+				event: emailDeliveryUpdatedTopic,
+				message: expect.objectContaining({
+					id: 'message-1',
+					delivery_status: 'bounced',
+				}),
+				delivery: expect.objectContaining({
+					event_id: 'event-1',
+					status: 'bounced',
+					terminal: true,
+				}),
+			}),
+		}),
+	)
+})

--- a/packages/worker/src/email/package-subscriptions.ts
+++ b/packages/worker/src/email/package-subscriptions.ts
@@ -6,11 +6,13 @@ import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
 import { resolveUserStableId } from '#worker/user-id.ts'
+import { type CloudflareEmailDeliveryEvent } from './delivery-events.ts'
 import { listEmailAttachmentsForMessage } from './repo.ts'
 import { type EmailAttachmentRecord, type EmailMessageRecord } from './types.ts'
 
 const inboundEmailReceiptTopic = 'email.message.received'
 const systemInboundEmailReceiptTopic = 'email.system-message.received'
+export const emailDeliveryUpdatedTopic = 'email.message.delivery.updated'
 
 type EmailReceiptSubscriptionEnvelope = {
 	event: typeof inboundEmailReceiptTopic | typeof systemInboundEmailReceiptTopic
@@ -194,6 +196,64 @@ export async function dispatchInboundEmailSubscriptionEvents(input: {
 						packageId: savedPackage.id,
 						topic: inboundEmailReceiptTopic,
 					}),
+					source: 'email',
+				}),
+		),
+	)
+}
+
+export async function dispatchEmailDeliverySubscriptionEvents(input: {
+	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'APP_BASE_URL'>
+	message: EmailMessageRecord
+	providerEvent: CloudflareEmailDeliveryEvent
+}) {
+	const baseUrl = getAppBaseUrl({ env: input.env })
+	const subscriptions = await loadMatchingEmailSubscriptions({
+		env: input.env,
+		baseUrl,
+		userId: input.message.userId,
+		topic: emailDeliveryUpdatedTopic,
+	})
+	const payload = {
+		event: emailDeliveryUpdatedTopic,
+		message: {
+			id: input.message.id,
+			inbox_id: input.message.inboxId,
+			thread_id: input.message.threadId,
+			from_address: input.message.fromAddress,
+			to_addresses: stringArray(input.message.toAddresses),
+			subject: input.message.subject,
+			processing_status: input.message.processingStatus,
+			provider_message_id: input.message.providerMessageId,
+			delivery_status: input.message.deliveryStatus,
+			delivery_status_at: input.message.deliveryStatusAt,
+			sent_at: input.message.sentAt,
+			created_at: input.message.createdAt,
+		},
+		delivery: {
+			event_id: input.providerEvent.payload.eventId,
+			status: input.providerEvent.payload.delivery.status,
+			terminal: input.providerEvent.payload.terminal,
+			sender: input.providerEvent.payload.sender,
+			recipient: input.providerEvent.payload.recipient,
+			delivery: input.providerEvent.payload.delivery,
+			bounce: input.providerEvent.payload.bounce ?? null,
+			failure: input.providerEvent.payload.failure ?? null,
+			rejection: input.providerEvent.payload.rejection ?? null,
+			complaint: input.providerEvent.payload.complaint ?? null,
+			occurred_at: input.providerEvent.metadata.eventTimestamp,
+		},
+	}
+	return await Promise.all(
+		subscriptions.map(
+			async ({ savedPackage }) =>
+				await invokePackageSubscription({
+					env: input.env as Env,
+					baseUrl,
+					savedPackage,
+					topic: emailDeliveryUpdatedTopic,
+					params: payload,
+					idempotencyKey: `email-delivery:${input.providerEvent.payload.eventId}:${savedPackage.id}`,
 					source: 'email',
 				}),
 		),

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -3,8 +3,10 @@ import { isoTimestampDayKey } from '@kody-internal/shared/date-keys.ts'
 import PostalMime from 'postal-mime'
 import {
 	type EmailAttachmentRecord,
+	type EmailDeliveryEventRecord,
 	type EmailDirection,
 	type EmailDeliveryEventType,
+	type EmailDeliveryStatus,
 	type EmailInboxAddressRecord,
 	type EmailInboxRecord,
 	type EmailMessageRecord,
@@ -214,11 +216,42 @@ function mapMessageRow(row: Record<string, unknown>): EmailMessageRecord {
 			row['provider_message_id'] == null
 				? null
 				: String(row['provider_message_id']),
+		deliveryStatus:
+			row['delivery_status'] == null
+				? null
+				: (String(row['delivery_status']) as EmailDeliveryStatus),
+		deliveryStatusAt:
+			row['delivery_status_at'] == null
+				? null
+				: String(row['delivery_status_at']),
 		error: row['error'] == null ? null : String(row['error']),
 		receivedAt: row['received_at'] == null ? null : String(row['received_at']),
 		sentAt: row['sent_at'] == null ? null : String(row['sent_at']),
 		createdAt: String(row['created_at']),
 		updatedAt: String(row['updated_at']),
+	}
+}
+
+function mapDeliveryEventRow(
+	row: Record<string, unknown>,
+): EmailDeliveryEventRecord {
+	return {
+		id: String(row['id']),
+		messageId: row['message_id'] == null ? null : String(row['message_id']),
+		userId: row['user_id'] == null ? null : String(row['user_id']),
+		inboxId: row['inbox_id'] == null ? null : String(row['inbox_id']),
+		eventType: String(row['event_type']) as EmailDeliveryEventType,
+		provider: row['provider'] == null ? null : String(row['provider']),
+		providerMessageId:
+			row['provider_message_id'] == null
+				? null
+				: String(row['provider_message_id']),
+		providerEventId:
+			row['provider_event_id'] == null
+				? null
+				: String(row['provider_event_id']),
+		detailJson: String(row['detail_json'] ?? '{}'),
+		createdAt: String(row['created_at']),
 	}
 }
 
@@ -773,6 +806,29 @@ export async function getEmailMessageById(input: {
 	return row ? mapMessageRow(row) : null
 }
 
+export async function getOutboundEmailMessageByProviderMessageId(input: {
+	db: D1Database
+	providerMessageId: string
+}) {
+	const result = await input.db
+		.prepare(
+			`SELECT *
+			FROM email_messages
+			WHERE direction = 'outbound'
+				AND provider_message_id = ?
+			LIMIT 2`,
+		)
+		.bind(input.providerMessageId)
+		.all<Record<string, unknown>>()
+	const rows = result.results ?? []
+	if (rows.length > 1) {
+		throw new Error(
+			`Multiple outbound email messages share provider id: ${input.providerMessageId}`,
+		)
+	}
+	return rows[0] ? mapMessageRow(rows[0]) : null
+}
+
 export async function getEmailMessageWithAttachmentsById(input: {
 	db: D1Database
 	userId: string
@@ -814,6 +870,7 @@ export async function listEmailMessages(input: {
 	inboxId?: string | null
 	direction?: EmailDirection | null
 	processingStatus?: EmailProcessingStatus | null
+	deliveryStatus?: EmailDeliveryStatus | null
 	limit: number
 }) {
 	const result = await input.db
@@ -824,6 +881,7 @@ export async function listEmailMessages(input: {
 				AND (? IS NULL OR inbox_id = ?)
 				AND (? IS NULL OR direction = ?)
 				AND (? IS NULL OR processing_status = ?)
+				AND (? IS NULL OR delivery_status = ?)
 			ORDER BY created_at DESC, id DESC
 			LIMIT ?`,
 		)
@@ -835,10 +893,41 @@ export async function listEmailMessages(input: {
 			input.direction ?? null,
 			input.processingStatus ?? null,
 			input.processingStatus ?? null,
+			input.deliveryStatus ?? null,
+			input.deliveryStatus ?? null,
 			input.limit,
 		)
 		.all<Record<string, unknown>>()
 	return (result.results ?? []).map(mapMessageRow)
+}
+
+export async function listEmailDeliveryEvents(input: {
+	db: D1Database
+	userId: string
+	messageId?: string | null
+	eventType?: EmailDeliveryEventType | null
+	limit: number
+}) {
+	const result = await input.db
+		.prepare(
+			`SELECT *
+			FROM email_delivery_events
+			WHERE user_id = ?
+				AND (? IS NULL OR message_id = ?)
+				AND (? IS NULL OR event_type = ?)
+			ORDER BY created_at DESC, id DESC
+			LIMIT ?`,
+		)
+		.bind(
+			input.userId,
+			input.messageId ?? null,
+			input.messageId ?? null,
+			input.eventType ?? null,
+			input.eventType ?? null,
+			input.limit,
+		)
+		.all<Record<string, unknown>>()
+	return (result.results ?? []).map(mapDeliveryEventRow)
 }
 
 /** Escape LIKE wildcards so user queries match literally. */
@@ -862,6 +951,7 @@ export async function searchEmailMessages(input: {
 	inboxId?: string | null
 	direction?: EmailDirection | null
 	processingStatus?: EmailProcessingStatus | null
+	deliveryStatus?: EmailDeliveryStatus | null
 	limit: number
 }) {
 	const pattern = `%${escapeLikePattern(input.query.trim().toLowerCase())}%`
@@ -873,6 +963,7 @@ export async function searchEmailMessages(input: {
 				AND (? IS NULL OR inbox_id = ?)
 				AND (? IS NULL OR direction = ?)
 				AND (? IS NULL OR processing_status = ?)
+				AND (? IS NULL OR delivery_status = ?)
 				AND (
 					LOWER(subject) LIKE ? ESCAPE '\\'
 					OR LOWER(from_address) LIKE ? ESCAPE '\\'
@@ -889,6 +980,8 @@ export async function searchEmailMessages(input: {
 			input.direction ?? null,
 			input.processingStatus ?? null,
 			input.processingStatus ?? null,
+			input.deliveryStatus ?? null,
+			input.deliveryStatus ?? null,
 			pattern,
 			pattern,
 			pattern,
@@ -1214,14 +1307,16 @@ export async function insertEmailDeliveryEvent(input: {
 	eventType: EmailDeliveryEventType
 	provider?: string | null
 	providerMessageId?: string | null
+	providerEventId?: string | null
 	detail?: Record<string, unknown> | null
+	createdAt?: string
 }) {
 	await input.db
 		.prepare(
 			`INSERT INTO email_delivery_events (
 				id, message_id, user_id, inbox_id, event_type, provider,
-				provider_message_id, detail_json, created_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				provider_message_id, provider_event_id, detail_json, created_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		)
 		.bind(
 			crypto.randomUUID(),
@@ -1231,8 +1326,102 @@ export async function insertEmailDeliveryEvent(input: {
 			input.eventType,
 			input.provider ?? null,
 			input.providerMessageId ?? null,
+			input.providerEventId ?? null,
 			JSON.stringify(input.detail ?? {}),
-			nowIso(),
+			input.createdAt ?? nowIso(),
 		)
 		.run()
+}
+
+export async function recordProviderEmailDeliveryEvent(input: {
+	db: D1Database
+	providerMessageId: string
+	providerEventId: string
+	deliveryStatus: EmailDeliveryStatus
+	eventTimestamp: string
+	detail: Record<string, unknown>
+}) {
+	const message = await getOutboundEmailMessageByProviderMessageId({
+		db: input.db,
+		providerMessageId: input.providerMessageId,
+	})
+	if (!message) {
+		return { outcome: 'unmatched' as const, message: null }
+	}
+
+	const eventId = crypto.randomUUID()
+	const statements = await input.db.batch([
+		input.db
+			.prepare(
+				`INSERT OR IGNORE INTO email_delivery_events (
+					id, message_id, user_id, inbox_id, event_type, provider,
+					provider_message_id, provider_event_id, detail_json, created_at
+				) VALUES (?, ?, ?, ?, ?, 'cloudflare-email', ?, ?, ?, ?)`,
+			)
+			.bind(
+				eventId,
+				message.id,
+				message.userId,
+				message.inboxId,
+				input.deliveryStatus,
+				input.providerMessageId,
+				input.providerEventId,
+				JSON.stringify(input.detail),
+				input.eventTimestamp,
+			),
+		input.db
+			.prepare(
+				`UPDATE email_messages
+				SET delivery_status = ?,
+					delivery_status_at = ?,
+					updated_at = ?
+				WHERE id = ?
+					AND (delivery_status_at IS NULL OR delivery_status_at <= ?)
+					AND EXISTS (
+						SELECT 1
+						FROM email_delivery_events
+						WHERE provider_event_id = ?
+							AND message_id = ?
+					)`,
+			)
+			.bind(
+				input.deliveryStatus,
+				input.eventTimestamp,
+				nowIso(),
+				message.id,
+				input.eventTimestamp,
+				input.providerEventId,
+				message.id,
+			),
+	])
+	if (Number(statements[0]?.meta.changes ?? 0) === 0) {
+		return { outcome: 'duplicate' as const, message }
+	}
+
+	const updatedMessage = await getEmailMessageById({
+		db: input.db,
+		userId: message.userId,
+		messageId: message.id,
+	})
+	if (!updatedMessage) {
+		throw new Error(
+			`Email message disappeared after delivery event: ${message.id}`,
+		)
+	}
+	return {
+		outcome: 'recorded' as const,
+		message: updatedMessage,
+		event: {
+			id: eventId,
+			messageId: message.id,
+			userId: message.userId,
+			inboxId: message.inboxId,
+			eventType: input.deliveryStatus,
+			provider: 'cloudflare-email',
+			providerMessageId: input.providerMessageId,
+			providerEventId: input.providerEventId,
+			detailJson: JSON.stringify(input.detail),
+			createdAt: input.eventTimestamp,
+		} satisfies EmailDeliveryEventRecord,
+	}
 }

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -1380,7 +1380,7 @@ export async function recordProviderEmailDeliveryEvent(input: {
 					AND EXISTS (
 						SELECT 1
 						FROM email_delivery_events
-						WHERE provider_event_id = ?
+						WHERE id = ?
 							AND message_id = ?
 					)`,
 			)
@@ -1390,7 +1390,7 @@ export async function recordProviderEmailDeliveryEvent(input: {
 				nowIso(),
 				message.id,
 				input.eventTimestamp,
-				input.providerEventId,
+				eventId,
 				message.id,
 			),
 	])

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -1394,8 +1394,19 @@ export async function recordProviderEmailDeliveryEvent(input: {
 				message.id,
 			),
 	])
-	if (Number(statements[0]?.meta.changes ?? 0) === 0) {
-		return { outcome: 'duplicate' as const, message }
+	const inserted = Number(statements[0]?.meta.changes ?? 0) > 0
+	const updatedLatestStatus = Number(statements[1]?.meta.changes ?? 0) > 0
+	if (!inserted) {
+		const duplicateIsCurrent =
+			message.deliveryStatus === input.deliveryStatus &&
+			message.deliveryStatusAt === input.eventTimestamp
+		return {
+			outcome: duplicateIsCurrent ? ('duplicate' as const) : ('stale' as const),
+			message,
+		}
+	}
+	if (!updatedLatestStatus) {
+		return { outcome: 'stale' as const, message }
 	}
 
 	const updatedMessage = await getEmailMessageById({

--- a/packages/worker/src/email/test-schema.ts
+++ b/packages/worker/src/email/test-schema.ts
@@ -91,6 +91,12 @@ ON email_sender_identities(user_id, email);`,
 	raw_size INTEGER NOT NULL DEFAULT 0,
 	processing_status TEXT NOT NULL CHECK (processing_status IN ('stored', 'sent', 'failed')),
 	provider_message_id TEXT,
+	delivery_status TEXT CHECK (
+		delivery_status IS NULL OR delivery_status IN (
+			'delivered', 'deferred', 'bounced', 'failed', 'rejected', 'complained'
+		)
+	),
+	delivery_status_at TEXT,
 	error TEXT,
 	received_at TEXT,
 	sent_at TEXT,
@@ -116,12 +122,24 @@ ON email_sender_identities(user_id, email);`,
 	message_id TEXT,
 	user_id TEXT,
 	inbox_id TEXT,
-	event_type TEXT NOT NULL CHECK (event_type IN ('receive_started', 'received', 'rejected', 'send_requested', 'sent', 'failed')),
+	event_type TEXT NOT NULL CHECK (
+		event_type IN (
+			'receive_started', 'received', 'rejected', 'send_requested', 'sent',
+			'failed', 'delivered', 'deferred', 'bounced', 'complained'
+		)
+	),
 	provider TEXT NOT NULL DEFAULT 'kody',
 	provider_message_id TEXT,
+	provider_event_id TEXT,
 	detail_json TEXT NOT NULL DEFAULT '{}',
 	created_at TEXT NOT NULL
 );`,
+		`CREATE INDEX IF NOT EXISTS idx_email_messages_provider_message_id
+ON email_messages(provider_message_id)
+WHERE provider_message_id IS NOT NULL;`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_email_delivery_events_provider_event_id
+ON email_delivery_events(provider_event_id)
+WHERE provider_event_id IS NOT NULL;`,
 		`CREATE TABLE IF NOT EXISTS system_email_daily_counters (
 	local_part TEXT NOT NULL,
 	day TEXT NOT NULL,

--- a/packages/worker/src/email/test-schema.ts
+++ b/packages/worker/src/email/test-schema.ts
@@ -134,9 +134,10 @@ ON email_sender_identities(user_id, email);`,
 	detail_json TEXT NOT NULL DEFAULT '{}',
 	created_at TEXT NOT NULL
 );`,
-		`CREATE INDEX IF NOT EXISTS idx_email_messages_provider_message_id
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_email_messages_provider_message_id
 ON email_messages(provider_message_id)
-WHERE provider_message_id IS NOT NULL;`,
+WHERE direction = 'outbound'
+	AND provider_message_id IS NOT NULL;`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_email_delivery_events_provider_event_id
 ON email_delivery_events(provider_event_id)
 WHERE provider_event_id IS NOT NULL;`,

--- a/packages/worker/src/email/types.ts
+++ b/packages/worker/src/email/types.ts
@@ -4,6 +4,16 @@ export type EmailDirection = (typeof emailDirectionValues)[number]
 export const emailProcessingStatusValues = ['stored', 'sent', 'failed'] as const
 export type EmailProcessingStatus = (typeof emailProcessingStatusValues)[number]
 
+export const emailDeliveryStatusValues = [
+	'delivered',
+	'deferred',
+	'bounced',
+	'failed',
+	'rejected',
+	'complained',
+] as const
+export type EmailDeliveryStatus = (typeof emailDeliveryStatusValues)[number]
+
 export const emailDeliveryEventTypeValues = [
 	'receive_started',
 	'received',
@@ -11,6 +21,10 @@ export const emailDeliveryEventTypeValues = [
 	'send_requested',
 	'sent',
 	'failed',
+	'delivered',
+	'deferred',
+	'bounced',
+	'complained',
 ] as const
 export type EmailDeliveryEventType =
 	(typeof emailDeliveryEventTypeValues)[number]
@@ -121,6 +135,8 @@ export type EmailMessageRecord = {
 	rawSize: number | null
 	processingStatus: EmailProcessingStatus
 	providerMessageId: string | null
+	deliveryStatus: EmailDeliveryStatus | null
+	deliveryStatusAt: string | null
 	error: string | null
 	receivedAt: string | null
 	sentAt: string | null
@@ -149,6 +165,7 @@ export type EmailDeliveryEventRecord = {
 	eventType: EmailDeliveryEventType
 	provider: string | null
 	providerMessageId: string | null
+	providerEventId: string | null
 	detailJson: string
 	createdAt: string
 }

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -53,6 +53,7 @@ import {
 	isPackageAppRequestPath,
 } from '#app/handlers/package-app.ts'
 import { PackageAppRuntimeBridge } from '#worker/package-runtime/package-app.ts'
+import { handleEmailDeliveryQueue } from '#worker/email/delivery-queue.ts'
 import { handleInboundEmail } from '#worker/email/inbound.ts'
 import { pruneSystemEmailRetention } from '#worker/email/system-email.ts'
 import { findPublicUserIdentityByUsername } from '#app/user-lookup.ts'
@@ -497,6 +498,9 @@ const workerHandler = {
 		ctx: ExecutionContext,
 	) {
 		await handleInboundEmail(message, env, ctx)
+	},
+	async queue(batch: MessageBatch<unknown>, env: Env, ctx: ExecutionContext) {
+		await handleEmailDeliveryQueue(batch, env, ctx)
 	},
 	async scheduled(
 		controller: ScheduledController,

--- a/packages/worker/src/mcp/capabilities/email/domain.ts
+++ b/packages/worker/src/mcp/capabilities/email/domain.ts
@@ -2,6 +2,7 @@ import { defineDomain } from '#mcp/capabilities/define-domain.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { emailInboxListCapability } from './email-inbox-list.ts'
 import { emailAttachmentGetCapability } from './email-attachment-get.ts'
+import { emailDeliveryEventListCapability } from './email-delivery-event-list.ts'
 import { emailMessageGetCapability } from './email-message-get.ts'
 import { emailMessageListCapability } from './email-message-list.ts'
 import { emailMessageSearchCapability } from './email-message-search.ts'
@@ -17,6 +18,7 @@ export const emailDomain = defineDomain({
 	capabilities: [
 		emailInboxListCapability,
 		emailAttachmentGetCapability,
+		emailDeliveryEventListCapability,
 		emailMessageListCapability,
 		emailMessageSearchCapability,
 		emailMessageGetCapability,

--- a/packages/worker/src/mcp/capabilities/email/email-delivery-event-list.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-delivery-event-list.node.test.ts
@@ -1,0 +1,85 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mocks = vi.hoisted(() => ({
+	listEmailDeliveryEvents: vi.fn(),
+}))
+
+vi.mock('#worker/email/repo.ts', () => ({
+	listEmailDeliveryEvents: mocks.listEmailDeliveryEvents,
+}))
+
+const { emailDeliveryEventListCapability } =
+	await import('./email-delivery-event-list.ts')
+
+function createContext() {
+	return {
+		env: {
+			APP_DB: {
+				prepare: () => ({
+					bind: () => ({
+						first: async () => ({
+							email_verified_at: '2026-01-01T00:00:00.000Z',
+						}),
+					}),
+				}),
+			} as unknown as D1Database,
+		} as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'User Example',
+			},
+		}),
+	}
+}
+
+test('email_delivery_event_list returns parsed events scoped to the signed-in user', async () => {
+	mocks.listEmailDeliveryEvents.mockResolvedValueOnce([
+		{
+			id: 'event-1',
+			messageId: 'message-1',
+			userId: 'user-1',
+			inboxId: null,
+			eventType: 'bounced',
+			provider: 'cloudflare-email',
+			providerMessageId: 'provider-1',
+			providerEventId: 'provider-event-1',
+			detailJson: JSON.stringify({
+				delivery: { status: 'bounced', smtpStatusCode: '550' },
+			}),
+			createdAt: '2026-07-17T20:00:00.000Z',
+		},
+	])
+
+	const context = createContext()
+	const result = await emailDeliveryEventListCapability.handler(
+		{ message_id: 'message-1', event_type: 'bounced', limit: 10 },
+		context,
+	)
+
+	expect(mocks.listEmailDeliveryEvents).toHaveBeenCalledWith({
+		db: context.env.APP_DB,
+		userId: 'user-1',
+		messageId: 'message-1',
+		eventType: 'bounced',
+		limit: 10,
+	})
+	expect(result.events).toEqual([
+		{
+			id: 'event-1',
+			message_id: 'message-1',
+			inbox_id: null,
+			event_type: 'bounced',
+			provider: 'cloudflare-email',
+			provider_message_id: 'provider-1',
+			provider_event_id: 'provider-event-1',
+			detail: {
+				delivery: { status: 'bounced', smtpStatusCode: '550' },
+			},
+			created_at: '2026-07-17T20:00:00.000Z',
+		},
+	])
+})

--- a/packages/worker/src/mcp/capabilities/email/email-delivery-event-list.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-delivery-event-list.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { listEmailDeliveryEvents } from '#worker/email/repo.ts'
+import { emailDeliveryEventTypeValues } from '#worker/email/types.ts'
+import { requireVerifiedEmailAccountUser } from './require-verified-user.ts'
+
+const emailDeliveryEventSchema = z.object({
+	id: z.string(),
+	message_id: z.string().nullable(),
+	inbox_id: z.string().nullable(),
+	event_type: z.enum(emailDeliveryEventTypeValues),
+	provider: z.string().nullable(),
+	provider_message_id: z.string().nullable(),
+	provider_event_id: z.string().nullable(),
+	detail: z.record(z.string(), z.unknown()),
+	created_at: z.string(),
+})
+
+function parseDetail(value: string) {
+	try {
+		const parsed = JSON.parse(value) as unknown
+		if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+			return parsed as Record<string, unknown>
+		}
+	} catch {
+		// Corrupt historical detail must not fail the whole event list.
+	}
+	return {}
+}
+
+export const emailDeliveryEventListCapability = defineDomainCapability(
+	capabilityDomainNames.email,
+	{
+		name: 'email_delivery_event_list',
+		description:
+			'List stored email delivery events, including outbound provider lifecycle updates and SMTP details.',
+		keywords: [
+			'email',
+			'delivery',
+			'status',
+			'bounce',
+			'complaint',
+			'smtp',
+			'events',
+		],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: z.object({
+			message_id: z.string().min(1).optional(),
+			event_type: z.enum(emailDeliveryEventTypeValues).optional(),
+			limit: z.number().int().positive().max(100).default(25),
+		}),
+		outputSchema: z.object({
+			events: z.array(emailDeliveryEventSchema),
+		}),
+		async handler(args, ctx) {
+			const user = await requireVerifiedEmailAccountUser(ctx)
+			const events = await listEmailDeliveryEvents({
+				db: ctx.env.APP_DB,
+				userId: user.userId,
+				messageId: args.message_id ?? null,
+				eventType: args.event_type ?? null,
+				limit: args.limit,
+			})
+			return {
+				events: events.map((event) => ({
+					id: event.id,
+					message_id: event.messageId,
+					inbox_id: event.inboxId,
+					event_type: event.eventType,
+					provider: event.provider,
+					provider_message_id: event.providerMessageId,
+					provider_event_id: event.providerEventId,
+					detail: parseDetail(event.detailJson),
+					created_at: event.createdAt,
+				})),
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/email/email-message-list.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-message-list.ts
@@ -3,6 +3,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireVerifiedEmailAccountUser } from './require-verified-user.ts'
 import { listEmailMessages } from '#worker/email/repo.ts'
+import { emailDeliveryStatusValues } from '#worker/email/types.ts'
 import { emailMessageSummarySchema, toMessageSummary } from './shared.ts'
 
 export const emailMessageListCapability = defineDomainCapability(
@@ -19,6 +20,7 @@ export const emailMessageListCapability = defineDomainCapability(
 			inbox_id: z.string().min(1).optional(),
 			direction: z.enum(['inbound', 'outbound']).optional(),
 			processing_status: z.enum(['stored', 'sent', 'failed']).optional(),
+			delivery_status: z.enum(emailDeliveryStatusValues).optional(),
 			limit: z.number().int().positive().max(100).default(25),
 		}),
 		outputSchema: z.object({
@@ -32,6 +34,7 @@ export const emailMessageListCapability = defineDomainCapability(
 				inboxId: args.inbox_id ?? null,
 				direction: args.direction ?? null,
 				processingStatus: args.processing_status ?? null,
+				deliveryStatus: args.delivery_status ?? null,
 				limit: args.limit,
 			})
 			return { messages: messages.map(toMessageSummary) }

--- a/packages/worker/src/mcp/capabilities/email/email-message-search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-message-search.node.test.ts
@@ -107,6 +107,7 @@ test('email_message_search requires a signed-in, verified user and forwards the 
 		inboxId: 'inbox-1',
 		direction: 'inbound',
 		processingStatus: null,
+		deliveryStatus: null,
 		limit: 10,
 	})
 	expect(result.messages).toEqual([

--- a/packages/worker/src/mcp/capabilities/email/email-message-search.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-message-search.ts
@@ -3,6 +3,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { searchEmailMessages } from '#worker/email/repo.ts'
 import {
+	emailDeliveryStatusValues,
 	emailDirectionValues,
 	emailProcessingStatusValues,
 } from '#worker/email/types.ts'
@@ -31,6 +32,7 @@ export const emailMessageSearchCapability = defineDomainCapability(
 			inbox_id: z.string().min(1).optional(),
 			direction: z.enum(emailDirectionValues).optional(),
 			processing_status: z.enum(emailProcessingStatusValues).optional(),
+			delivery_status: z.enum(emailDeliveryStatusValues).optional(),
 			limit: z.number().int().positive().max(100).default(25),
 		}),
 		outputSchema: z.object({
@@ -45,6 +47,7 @@ export const emailMessageSearchCapability = defineDomainCapability(
 				inboxId: args.inbox_id ?? null,
 				direction: args.direction ?? null,
 				processingStatus: args.processing_status ?? null,
+				deliveryStatus: args.delivery_status ?? null,
 				limit: args.limit,
 			})
 			return { messages: messages.map(toMessageSummary) }

--- a/packages/worker/src/mcp/capabilities/email/shared.ts
+++ b/packages/worker/src/mcp/capabilities/email/shared.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import {
+	emailDeliveryStatusValues,
 	type EmailMessageRecord,
 	emailDirectionValues,
 	emailProcessingStatusValues,
@@ -38,6 +39,8 @@ export const emailMessageSummarySchema = z.object({
 	message_id_header: z.string().nullable(),
 	processing_status: z.enum(emailProcessingStatusValues),
 	provider_message_id: z.string().nullable(),
+	delivery_status: z.enum(emailDeliveryStatusValues).nullable(),
+	delivery_status_at: z.string().nullable(),
 	error: z.string().nullable(),
 	received_at: z.string().nullable(),
 	sent_at: z.string().nullable(),
@@ -88,6 +91,8 @@ export function toMessageSummary(message: EmailMessageRecord) {
 		message_id_header: message.messageIdHeader,
 		processing_status: message.processingStatus,
 		provider_message_id: message.providerMessageId,
+		delivery_status: message.deliveryStatus ?? null,
+		delivery_status_at: message.deliveryStatusAt ?? null,
 		error: message.error,
 		received_at: message.receivedAt,
 		sent_at: message.sentAt,

--- a/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
@@ -20,7 +20,7 @@ export const listPackageSubscriptionsCapability = defineDomainCapability(
 	{
 		name: 'package_subscriptions_list',
 		description:
-			'List package.json#kody.subscriptions entries for the signed-in user, optionally filtered by exact event topic. Use this to discover package event handlers such as email.message.received subscribers before debugging dispatch or building fan-out.',
+			'List package.json#kody.subscriptions entries for the signed-in user, optionally filtered by exact event topic. Use this to discover package event handlers such as email receipt or delivery-update subscribers before debugging dispatch or building fan-out.',
 		keywords: [
 			'package',
 			'package.json#kody.subscriptions',
@@ -31,6 +31,8 @@ export const listPackageSubscriptionsCapability = defineDomainCapability(
 			'handler',
 			'email.message.received',
 			'email message received',
+			'email.message.delivery.updated',
+			'email delivery updated',
 			'email.system-message.received',
 			'system email',
 			'inbound email',
@@ -47,7 +49,7 @@ export const listPackageSubscriptionsCapability = defineDomainCapability(
 				.min(1)
 				.optional()
 				.describe(
-					'Optional exact event topic filter such as "email.message.received".',
+					'Optional exact event topic filter such as "email.message.received" or "email.message.delivery.updated".',
 				),
 		}),
 		outputSchema: z.object({

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -1136,6 +1136,8 @@ async function invokeSavedPackageModule(input: {
 							raw_size: loaded.message.rawSize,
 							processing_status: loaded.message.processingStatus,
 							provider_message_id: loaded.message.providerMessageId,
+							delivery_status: loaded.message.deliveryStatus,
+							delivery_status_at: loaded.message.deliveryStatusAt,
 							error: loaded.message.error,
 							received_at: loaded.message.receivedAt,
 							sent_at: loaded.message.sentAt,

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -160,6 +160,17 @@
 					"name": "EMAIL",
 				},
 			],
+			"queues": {
+				"consumers": [
+					{
+						"queue": "kody-email-delivery",
+						"max_batch_size": 10,
+						"max_batch_timeout": 5,
+						"max_retries": 3,
+						"dead_letter_queue": "kody-email-delivery-dlq",
+					},
+				],
+			},
 			"kv_namespaces": [
 				{
 					"binding": "OAUTH_KV",

--- a/tools/ci/production-resources.ts
+++ b/tools/ci/production-resources.ts
@@ -1,5 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import {
+	ensureCloudflareQueue,
+	ensureEmailSendingEventSubscription,
 	ensureR2Bucket,
 	fail,
 	listD1Databases,
@@ -30,6 +32,8 @@ type ResolvedProductionBindings = {
 	bundleArtifactsKvConfiguredId: string
 	communityAssetsBucketName: string
 	emailBlobsBucketName: string
+	emailDeliveryQueueName: string
+	emailDeliveryDeadLetterQueueName: string
 }
 
 function parseArgs(argv: Array<string>): {
@@ -104,6 +108,21 @@ function defaultOauthKvTitle(workerName: string) {
 
 function defaultBundleArtifactsKvTitle(workerName: string) {
 	return truncateWithSuffix(workerName, '-bundle-artifacts', 63)
+}
+
+function resolveEmailSendingDomain(dryRun: boolean) {
+	const configured = process.env.USER_EMAIL_DOMAIN?.trim()
+		.toLowerCase()
+		.replace(/\.$/, '')
+	if (configured) return configured
+	const appBaseUrl = process.env.APP_BASE_URL?.trim()
+	if (!appBaseUrl) {
+		if (dryRun) return 'inbox.example.com'
+		fail(
+			'Missing APP_BASE_URL or USER_EMAIL_DOMAIN; cannot configure Email Sending event subscription.',
+		)
+	}
+	return `inbox.${new URL(appBaseUrl).hostname.toLowerCase()}`
 }
 
 function ensureD1Database({
@@ -354,6 +373,32 @@ async function resolveProductionBindings({
 		)
 	}
 
+	const queues = (productionEnv as Record<string, unknown>).queues
+	if (!queues || typeof queues !== 'object' || Array.isArray(queues)) {
+		fail(
+			`wrangler config "${wranglerConfigPath}" is missing "env.production.queues".`,
+		)
+	}
+	const consumers = (queues as Record<string, unknown>).consumers
+	if (!Array.isArray(consumers) || consumers.length !== 1) {
+		fail(
+			`wrangler config "${wranglerConfigPath}" must define one production Queue consumer.`,
+		)
+	}
+	const consumer = consumers[0] as Record<string, unknown>
+	const emailDeliveryQueueName = consumer.queue
+	const emailDeliveryDeadLetterQueueName = consumer.dead_letter_queue
+	if (
+		typeof emailDeliveryQueueName !== 'string' ||
+		!emailDeliveryQueueName ||
+		typeof emailDeliveryDeadLetterQueueName !== 'string' ||
+		!emailDeliveryDeadLetterQueueName
+	) {
+		fail(
+			`wrangler config "${wranglerConfigPath}" has invalid production email Queue names.`,
+		)
+	}
+
 	const resolved: ResolvedProductionBindings = {
 		workerName,
 		d1DatabaseName,
@@ -364,6 +409,8 @@ async function resolveProductionBindings({
 		bundleArtifactsKvConfiguredId,
 		communityAssetsBucketName,
 		emailBlobsBucketName,
+		emailDeliveryQueueName,
+		emailDeliveryDeadLetterQueueName,
 	}
 
 	return resolved
@@ -402,6 +449,34 @@ async function ensureProductionResources(options: CliOptions) {
 		name: bindings.communityAssetsBucketName,
 		dryRun: options.dryRun,
 	})
+	const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim()
+	const apiToken = process.env.CLOUDFLARE_API_TOKEN?.trim()
+	if ((!accountId || !apiToken) && !options.dryRun) {
+		fail(
+			'Missing CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_API_TOKEN for Queue provisioning.',
+		)
+	}
+	const emailDeliveryQueue = await ensureCloudflareQueue({
+		accountId: accountId ?? 'dry-run-account',
+		apiToken: apiToken ?? 'dry-run-token',
+		name: bindings.emailDeliveryQueueName,
+		dryRun: options.dryRun,
+	})
+	await ensureCloudflareQueue({
+		accountId: accountId ?? 'dry-run-account',
+		apiToken: apiToken ?? 'dry-run-token',
+		name: bindings.emailDeliveryDeadLetterQueueName,
+		dryRun: options.dryRun,
+	})
+	const emailSendingDomain = resolveEmailSendingDomain(options.dryRun)
+	const emailEventSubscription = await ensureEmailSendingEventSubscription({
+		accountId: accountId ?? 'dry-run-account',
+		apiToken: apiToken ?? 'dry-run-token',
+		name: truncateWithSuffix(bindings.workerName, '-email-delivery-events', 63),
+		queueId: emailDeliveryQueue.id,
+		domain: emailSendingDomain,
+		dryRun: options.dryRun,
+	})
 
 	const generatedConfigPath = await writeGeneratedWranglerConfig({
 		baseConfigPath: options.wranglerConfigPath,
@@ -417,6 +492,7 @@ async function ensureProductionResources(options: CliOptions) {
 		workerVars: {
 			APP_BASE_URL: process.env.APP_BASE_URL,
 			CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID,
+			USER_EMAIL_DOMAIN: process.env.USER_EMAIL_DOMAIN,
 		},
 	})
 
@@ -430,6 +506,8 @@ async function ensureProductionResources(options: CliOptions) {
 	console.log(`bundle_artifacts_kv_id=${bundleArtifactsKv.id}`)
 	console.log(`community_assets_bucket_name=${communityAssets.name}`)
 	console.log(`email_blobs_bucket_name=${emailBlobs.name}`)
+	console.log(`email_delivery_queue_name=${emailDeliveryQueue.name}`)
+	console.log(`email_event_subscription_id=${emailEventSubscription.id}`)
 }
 
 async function main() {

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -6,6 +6,9 @@ import { expect, test, vi } from 'vitest'
 import { consoleError } from '#worker/test-support/console-spies.ts'
 
 import {
+	emailSendingEventTypes,
+	ensureCloudflareQueue,
+	ensureEmailSendingEventSubscription,
 	isWranglerNotFoundOutput,
 	parseJsonc,
 	parseR2BucketListOutput,
@@ -144,6 +147,124 @@ test('parseR2BucketListOutput reads bucket names from labelled wrangler output',
 		'kody-pr-42-email-blobs',
 	])
 	expect(parseR2BucketListOutput('')).toEqual([])
+})
+
+test('Queue and Email Sending subscription ensure creates and reconciles Cloudflare resources', async () => {
+	consoleError.mockImplementation(() => {})
+	const queueFetch = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [],
+				result_info: { total_pages: 1 },
+			}),
+		)
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: {
+					queue_id: 'queue-1',
+					queue_name: 'kody-email-delivery',
+				},
+			}),
+		)
+	const queue = await ensureCloudflareQueue({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		name: 'kody-email-delivery',
+		dryRun: false,
+		fetcher: queueFetch,
+	})
+	expect(queue).toEqual({ id: 'queue-1', name: 'kody-email-delivery' })
+	expect(queueFetch).toHaveBeenNthCalledWith(
+		2,
+		'https://api.cloudflare.com/client/v4/accounts/account-1/queues',
+		expect.objectContaining({
+			method: 'POST',
+			body: JSON.stringify({ queue_name: 'kody-email-delivery' }),
+		}),
+	)
+
+	const subscriptionFetch = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [
+					{
+						id: 'subscription-old',
+						name: 'kody-email-delivery-events',
+						enabled: true,
+						events: ['message.delivered'],
+						source: {
+							type: 'email.sending',
+							domain: 'inbox.example.com',
+						},
+						destination: {
+							type: 'queues.queue',
+							queue_id: 'queue-old',
+						},
+					},
+				],
+				result_info: { total_pages: 1 },
+			}),
+		)
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: {
+					id: 'subscription-old',
+					name: 'kody-email-delivery-events',
+				},
+			}),
+		)
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: {
+					id: 'subscription-new',
+					name: 'kody-email-delivery-events',
+				},
+			}),
+		)
+	const subscription = await ensureEmailSendingEventSubscription({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		name: 'kody-email-delivery-events',
+		queueId: queue.id,
+		domain: 'inbox.example.com',
+		dryRun: false,
+		fetcher: subscriptionFetch,
+	})
+	expect(subscription).toEqual({
+		id: 'subscription-new',
+		name: 'kody-email-delivery-events',
+	})
+	expect(subscriptionFetch).toHaveBeenNthCalledWith(
+		2,
+		'https://api.cloudflare.com/client/v4/accounts/account-1/event_subscriptions/subscriptions/subscription-old',
+		expect.objectContaining({ method: 'DELETE' }),
+	)
+	const createCall = subscriptionFetch.mock.calls[2]
+	expect(createCall?.[0]).toBe(
+		'https://api.cloudflare.com/client/v4/accounts/account-1/event_subscriptions/subscriptions',
+	)
+	const createBody = JSON.parse(
+		String((createCall?.[1] as RequestInit | undefined)?.body),
+	) as Record<string, unknown>
+	expect(createBody).toMatchObject({
+		name: 'kody-email-delivery-events',
+		source: {
+			type: 'email.sending',
+			domain: 'inbox.example.com',
+		},
+		destination: {
+			type: 'queues.queue',
+			queue_id: 'queue-1',
+		},
+		events: [...emailSendingEventTypes],
+	})
 })
 
 test('writeGeneratedWranglerConfig rejects invalid environment asset config', async () => {

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -219,15 +219,6 @@ test('Queue and Email Sending subscription ensure creates and reconciles Cloudfl
 				},
 			}),
 		)
-		.mockResolvedValueOnce(
-			Response.json({
-				success: true,
-				result: {
-					id: 'subscription-new',
-					name: 'kody-email-delivery-events',
-				},
-			}),
-		)
 	const subscription = await ensureEmailSendingEventSubscription({
 		accountId: 'account-1',
 		apiToken: 'token-1',
@@ -238,15 +229,60 @@ test('Queue and Email Sending subscription ensure creates and reconciles Cloudfl
 		fetcher: subscriptionFetch,
 	})
 	expect(subscription).toEqual({
-		id: 'subscription-new',
+		id: 'subscription-old',
 		name: 'kody-email-delivery-events',
 	})
 	expect(subscriptionFetch).toHaveBeenNthCalledWith(
 		2,
 		'https://api.cloudflare.com/client/v4/accounts/account-1/event_subscriptions/subscriptions/subscription-old',
-		expect.objectContaining({ method: 'DELETE' }),
+		expect.objectContaining({
+			method: 'PATCH',
+			signal: expect.any(AbortSignal),
+		}),
 	)
-	const createCall = subscriptionFetch.mock.calls[2]
+	const updateBody = JSON.parse(
+		String(
+			(subscriptionFetch.mock.calls[1]?.[1] as RequestInit | undefined)?.body,
+		),
+	) as Record<string, unknown>
+	expect(updateBody).toMatchObject({
+		name: 'kody-email-delivery-events',
+		destination: {
+			type: 'queues.queue',
+			queue_id: 'queue-1',
+		},
+		events: [...emailSendingEventTypes],
+	})
+	expect(updateBody).not.toHaveProperty('source')
+
+	const createSubscriptionFetch = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [],
+				result_info: { total_pages: 1 },
+			}),
+		)
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: {
+					id: 'subscription-new',
+					name: 'kody-email-delivery-events',
+				},
+			}),
+		)
+	await ensureEmailSendingEventSubscription({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		name: 'kody-email-delivery-events',
+		queueId: queue.id,
+		domain: 'inbox.example.com',
+		dryRun: false,
+		fetcher: createSubscriptionFetch,
+	})
+	const createCall = createSubscriptionFetch.mock.calls[1]
 	expect(createCall?.[0]).toBe(
 		'https://api.cloudflare.com/client/v4/accounts/account-1/event_subscriptions/subscriptions',
 	)

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -283,22 +283,30 @@ async function cloudflareApiRequest<T>(input: {
 	accountId: string
 	apiToken: string
 	pathname: string
-	method?: 'GET' | 'POST' | 'DELETE'
+	method?: 'GET' | 'POST' | 'PATCH' | 'DELETE'
 	body?: Record<string, unknown>
 	apiBaseUrl?: string
 	fetcher?: typeof fetch
 }) {
 	const baseUrl = input.apiBaseUrl ?? 'https://api.cloudflare.com/client/v4'
 	const url = `${baseUrl.replace(/\/$/, '')}/accounts/${encodeURIComponent(input.accountId)}${input.pathname}`
-	const response = await (input.fetcher ?? fetch)(url, {
-		method: input.method ?? 'GET',
-		headers: {
-			Authorization: `Bearer ${input.apiToken}`,
-			Accept: 'application/json',
-			...(input.body ? { 'Content-Type': 'application/json' } : {}),
-		},
-		...(input.body ? { body: JSON.stringify(input.body) } : {}),
-	})
+	const abortController = new AbortController()
+	const timeout = setTimeout(() => abortController.abort(), 30_000)
+	let response: Response
+	try {
+		response = await (input.fetcher ?? fetch)(url, {
+			method: input.method ?? 'GET',
+			headers: {
+				Authorization: `Bearer ${input.apiToken}`,
+				Accept: 'application/json',
+				...(input.body ? { 'Content-Type': 'application/json' } : {}),
+			},
+			...(input.body ? { body: JSON.stringify(input.body) } : {}),
+			signal: abortController.signal,
+		})
+	} finally {
+		clearTimeout(timeout)
+	}
 	const payload = (await response.json()) as CloudflareApiEnvelope<T>
 	if (
 		!response.ok ||
@@ -423,24 +431,50 @@ export async function ensureEmailSendingEventSubscription(input: {
 		(subscription) => subscription.name === input.name,
 	)
 	const events = [...emailSendingEventTypes]
+	const sourceIsCurrent =
+		existing?.source['type'] === 'email.sending' &&
+		existing.source['domain'] === input.domain
 	const isCurrent =
 		existing?.enabled === true &&
 		existing.destination.type === 'queues.queue' &&
 		existing.destination.queue_id === input.queueId &&
-		existing.source['type'] === 'email.sending' &&
-		existing.source['domain'] === input.domain &&
+		sourceIsCurrent &&
 		sameStringSet(existing.events, events)
 	if (existing && isCurrent) {
 		console.error(`Email event subscription exists: ${existing.name}`)
 		return { id: existing.id, name: existing.name }
 	}
 	if (existing) {
+		const pathname = `/event_subscriptions/subscriptions/${encodeURIComponent(existing.id)}`
+		if (sourceIsCurrent) {
+			const payload = await cloudflareApiRequest<CloudflareEventSubscription>({
+				...input,
+				pathname,
+				method: 'PATCH',
+				body: {
+					name: input.name,
+					enabled: true,
+					destination: {
+						type: 'queues.queue',
+						queue_id: input.queueId,
+					},
+					events,
+				},
+			})
+			console.error(`Updated Email event subscription: ${existing.name}`)
+			return {
+				id: payload.result?.id ?? existing.id,
+				name: payload.result?.name ?? existing.name,
+			}
+		}
 		await cloudflareApiRequest<CloudflareEventSubscription>({
 			...input,
-			pathname: `/event_subscriptions/subscriptions/${encodeURIComponent(existing.id)}`,
+			pathname,
 			method: 'DELETE',
 		})
-		console.error(`Deleted stale Email event subscription: ${existing.name}`)
+		console.error(
+			`Deleted Email event subscription with stale source: ${existing.name}`,
+		)
 	}
 	const payload = await cloudflareApiRequest<CloudflareEventSubscription>({
 		...input,

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -25,6 +25,39 @@ type KvNamespaceListEntry = {
 	title: string
 }
 
+type CloudflareApiEnvelope<T> = {
+	success?: boolean
+	result?: T
+	errors?: Array<{ code?: number | string; message?: string }>
+	result_info?: { total_pages?: number }
+}
+
+type CloudflareQueue = {
+	queue_id: string
+	queue_name: string
+}
+
+type CloudflareEventSubscription = {
+	id: string
+	name: string
+	enabled: boolean
+	events: Array<string>
+	source: Record<string, unknown>
+	destination: {
+		type: string
+		queue_id: string
+	}
+}
+
+export const emailSendingEventTypes = [
+	'message.delivered',
+	'message.deferred',
+	'message.bounced',
+	'message.failed',
+	'message.rejected',
+	'message.complained',
+] as const
+
 export function fail(message: string): never {
 	console.error(message)
 	process.exit(1)
@@ -244,6 +277,196 @@ export function deleteR2Bucket({
 		return
 	}
 	console.error(`Deleted R2 bucket: ${name}`)
+}
+
+async function cloudflareApiRequest<T>(input: {
+	accountId: string
+	apiToken: string
+	pathname: string
+	method?: 'GET' | 'POST' | 'DELETE'
+	body?: Record<string, unknown>
+	apiBaseUrl?: string
+	fetcher?: typeof fetch
+}) {
+	const baseUrl = input.apiBaseUrl ?? 'https://api.cloudflare.com/client/v4'
+	const url = `${baseUrl.replace(/\/$/, '')}/accounts/${encodeURIComponent(input.accountId)}${input.pathname}`
+	const response = await (input.fetcher ?? fetch)(url, {
+		method: input.method ?? 'GET',
+		headers: {
+			Authorization: `Bearer ${input.apiToken}`,
+			Accept: 'application/json',
+			...(input.body ? { 'Content-Type': 'application/json' } : {}),
+		},
+		...(input.body ? { body: JSON.stringify(input.body) } : {}),
+	})
+	const payload = (await response.json()) as CloudflareApiEnvelope<T>
+	if (
+		!response.ok ||
+		payload.success !== true ||
+		payload.result === undefined
+	) {
+		const error = payload.errors?.[0]
+		throw new Error(
+			`Cloudflare API request failed (${response.status}): ${error?.message ?? error?.code ?? input.pathname}`,
+		)
+	}
+	return payload
+}
+
+async function listCloudflareQueues(input: {
+	accountId: string
+	apiToken: string
+	apiBaseUrl?: string
+	fetcher?: typeof fetch
+}) {
+	const queues: Array<CloudflareQueue> = []
+	let page = 1
+	let totalPages = 1
+	do {
+		const payload = await cloudflareApiRequest<Array<CloudflareQueue>>({
+			...input,
+			pathname: `/queues?page=${page}&per_page=100`,
+		})
+		queues.push(...(payload.result ?? []))
+		totalPages = Math.max(1, payload.result_info?.total_pages ?? 1)
+		page += 1
+	} while (page <= totalPages)
+	return queues
+}
+
+export async function ensureCloudflareQueue(input: {
+	accountId: string
+	apiToken: string
+	name: string
+	dryRun: boolean
+	apiBaseUrl?: string
+	fetcher?: typeof fetch
+}) {
+	if (input.dryRun) {
+		console.error(`[dry-run] ensure Queue: ${input.name}`)
+		return { id: `dry-run-${input.name}`, name: input.name }
+	}
+	const existing = (await listCloudflareQueues(input)).find(
+		(queue) => queue.queue_name === input.name,
+	)
+	if (existing) {
+		console.error(`Queue exists: ${existing.queue_name} (${existing.queue_id})`)
+		return { id: existing.queue_id, name: existing.queue_name }
+	}
+	const payload = await cloudflareApiRequest<CloudflareQueue>({
+		...input,
+		pathname: '/queues',
+		method: 'POST',
+		body: { queue_name: input.name },
+	})
+	if (!payload.result?.queue_id || !payload.result.queue_name) {
+		throw new Error(`Cloudflare created Queue without an id: ${input.name}`)
+	}
+	console.error(
+		`Created Queue: ${payload.result.queue_name} (${payload.result.queue_id})`,
+	)
+	return { id: payload.result.queue_id, name: payload.result.queue_name }
+}
+
+async function listCloudflareEventSubscriptions(input: {
+	accountId: string
+	apiToken: string
+	apiBaseUrl?: string
+	fetcher?: typeof fetch
+}) {
+	const subscriptions: Array<CloudflareEventSubscription> = []
+	let page = 1
+	let totalPages = 1
+	do {
+		const payload = await cloudflareApiRequest<
+			Array<CloudflareEventSubscription>
+		>({
+			...input,
+			pathname: `/event_subscriptions/subscriptions?page=${page}&per_page=100`,
+		})
+		subscriptions.push(...(payload.result ?? []))
+		totalPages = Math.max(1, payload.result_info?.total_pages ?? 1)
+		page += 1
+	} while (page <= totalPages)
+	return subscriptions
+}
+
+function sameStringSet(
+	left: ReadonlyArray<string>,
+	right: ReadonlyArray<string>,
+) {
+	return (
+		left.length === right.length &&
+		new Set(left).size === new Set(right).size &&
+		left.every((value) => right.includes(value))
+	)
+}
+
+export async function ensureEmailSendingEventSubscription(input: {
+	accountId: string
+	apiToken: string
+	name: string
+	queueId: string
+	domain: string
+	dryRun: boolean
+	apiBaseUrl?: string
+	fetcher?: typeof fetch
+}) {
+	if (input.dryRun) {
+		console.error(
+			`[dry-run] ensure Email Sending event subscription: ${input.name} (${input.domain})`,
+		)
+		return { id: `dry-run-${input.name}`, name: input.name }
+	}
+	const subscriptions = await listCloudflareEventSubscriptions(input)
+	const existing = subscriptions.find(
+		(subscription) => subscription.name === input.name,
+	)
+	const events = [...emailSendingEventTypes]
+	const isCurrent =
+		existing?.enabled === true &&
+		existing.destination.type === 'queues.queue' &&
+		existing.destination.queue_id === input.queueId &&
+		existing.source['type'] === 'email.sending' &&
+		existing.source['domain'] === input.domain &&
+		sameStringSet(existing.events, events)
+	if (existing && isCurrent) {
+		console.error(`Email event subscription exists: ${existing.name}`)
+		return { id: existing.id, name: existing.name }
+	}
+	if (existing) {
+		await cloudflareApiRequest<CloudflareEventSubscription>({
+			...input,
+			pathname: `/event_subscriptions/subscriptions/${encodeURIComponent(existing.id)}`,
+			method: 'DELETE',
+		})
+		console.error(`Deleted stale Email event subscription: ${existing.name}`)
+	}
+	const payload = await cloudflareApiRequest<CloudflareEventSubscription>({
+		...input,
+		pathname: '/event_subscriptions/subscriptions',
+		method: 'POST',
+		body: {
+			name: input.name,
+			enabled: true,
+			source: {
+				type: 'email.sending',
+				domain: input.domain,
+			},
+			destination: {
+				type: 'queues.queue',
+				queue_id: input.queueId,
+			},
+			events,
+		},
+	})
+	if (!payload.result?.id || !payload.result.name) {
+		throw new Error(
+			`Cloudflare created Email event subscription without an id: ${input.name}`,
+		)
+	}
+	console.error(`Created Email event subscription: ${payload.result.name}`)
+	return { id: payload.result.id, name: payload.result.name }
 }
 
 function stripJsonc(source: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- ingest Cloudflare Email Sending lifecycle events through a production Queue and DLQ
- persist idempotent delivery history and expose latest delivery state through email capabilities
- dispatch `email.message.delivery.updated` package subscriptions
- provision the Queue and domain-scoped event subscription during production deploys

## Validation
- `npm run validate` — passed: formatting, lint, typecheck, 271 test files / 877 tests, Playwright E2E, MCP E2E, and primitive taxonomy
- focused review-fix tests — passed: Queue dispatch retry, conflicting/stale events, subscription reconciliation, provider-ID migration
- fresh local migration through `0061` — passed
- production resource provisioning dry-run — passed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>adds an email delivery event primitive</b> (high risk)</summary>

**Mode:** recap · **Base:** `main` @ `182a1903` · **Head:** `79e22c0f`

**Classification:** adds — introduces the Cloudflare Queue-backed `email-delivery-queue` primitive and extends email/D1 contracts.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `email-delivery-queue` | storage | adds — Queue/DLQ ingestion and provisioning |
| `email` | assistant | extends — delivery state, history capability, package topic |
| `d1-app-db` | storage | extends — lifecycle columns, event idempotency, indexes |
| `saved-packages` | assistant | extends — delivery-update subscription discovery |
| `email-blobs-r2` | storage | composes — shared email repository only; blob behavior unchanged |
| `scheduled-cron` | surfaces | composes — shared Worker entrypoint only; cron behavior unchanged |

### System map

Cloudflare publishes outbound lifecycle events to a Queue; Kody correlates them to its stored outbound message before exposing state or dispatching the owning user's packages.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	queue["email-delivery-queue<br/>Email delivery event queue"]:::added
	email["email<br/>Email"]:::extended
	db["d1-app-db<br/>D1 app database"]:::extended
	packages["saved-packages<br/>Saved packages"]:::extended
	queue -->|"provider message id lookup"| db
	db -->|"owned message + delivery history"| email
	email -->|"email.message.delivery.updated"| packages
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant CF as Cloudflare Email Sending
	participant Q as Delivery Queue
	participant DB as Kody D1
	participant P as User package
	CF->>Q: lifecycle event + provider message id
	Q->>DB: correlate outbound message
	DB->>DB: insert event idempotently + update latest state
	alt current provider state
		Q->>P: idempotent email.message.delivery.updated
		P-->>Q: success before Queue acknowledgement
	else stale provider state
		Q->>Q: acknowledge without automation
	end
```

### Invariants

- `userId` is recovered from the stored outbound message; provider payload fields never select a user.
- Cloudflare `eventId` and outbound provider message ids are unique; conflicting duplicates cannot mutate state.
- Package dispatch succeeds before Queue acknowledgement; failures retry safely through invocation idempotency.
- Out-of-order events remain in history but cannot replace or dispatch after newer state.
- Unknown provider message ids retry into the DLQ instead of crossing an ownership boundary.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e42c840b-8980-4090-93ee-ef132d1604d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e42c840b-8980-4090-93ee-ef132d1604d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email delivery status tracking, including delivered, deferred, bounced, failed, rejected, and complained outcomes.
  * Added delivery history access through the `email_delivery_event_list` capability, including provider details and SMTP information.
  * Added delivery-status filters to email listing and search.
  * Added `email.message.delivery.updated` subscription events for delivery notifications and bounce or complaint workflows.

* **Documentation**
  * Documented delivery statuses, event history, subscriptions, and required email delivery configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->