### PR TITLE
Provide zone ID for email event subscriptions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,7 @@ jobs:
           APP_BASE_URL: ${{ vars.APP_BASE_URL }}
           USER_EMAIL_DOMAIN: ${{ vars.USER_EMAIL_DOMAIN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
         run: |
           set -euo pipefail
           node tools/ci/production-resources.ts ensure --out-config packages/worker/wrangler-production.generated.json | tee -a "$GITHUB_OUTPUT"

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -130,6 +130,11 @@ Configure these GitHub Actions secrets and variables for workflows:
 - `CLOUDFLARE_API_TOKEN` (Workers deploy + D1 edit access on the correct
   account; also reused for remote AI and Cloudflare API workflows that run with
   account secrets + package workflows)
+- `CLOUDFLARE_ACCOUNT_ID` (required GitHub Actions **variable** for Cloudflare
+  resource provisioning and Email Service)
+- `CLOUDFLARE_ZONE_ID` (required GitHub Actions **variable** for the zone that
+  owns the user email sending domain; Email Sending event subscriptions require
+  both this zone id and the domain)
 - `COOKIE_SECRET` (same format as local)
 - `SECRET_STORE_KEY` (same format as local; required for deploys)
 - `APP_BASE_URL` (optional GitHub Actions **variable**, used by the production
@@ -194,6 +199,11 @@ How to get/set each value:
   - Do not also upload `APP_BASE_URL` through `wrangler secret bulk` or pass it
     as a deploy-time `--var`, because Wrangler treats that as a conflicting
     binding name.
+- `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_ZONE_ID`
+  - Copy both identifiers from the Cloudflare dashboard overview for the
+    production zone.
+  - In GitHub: **Settings → Secrets and variables → Actions → Variables**, add
+    each under its exact name.
 - `USER_EMAIL_DOMAIN` (optional GitHub Actions **variable**; overrides
   `inbox.<APP_BASE_URL hostname>` for user inboxes, outbound senders, and the
   Email Sending event subscription).

--- a/tools/ci/production-resources.ts
+++ b/tools/ci/production-resources.ts
@@ -451,9 +451,10 @@ async function ensureProductionResources(options: CliOptions) {
 	})
 	const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim()
 	const apiToken = process.env.CLOUDFLARE_API_TOKEN?.trim()
-	if ((!accountId || !apiToken) && !options.dryRun) {
+	const zoneId = process.env.CLOUDFLARE_ZONE_ID?.trim()
+	if ((!accountId || !apiToken || !zoneId) && !options.dryRun) {
 		fail(
-			'Missing CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_API_TOKEN for Queue provisioning.',
+			'Missing CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_ZONE_ID, or CLOUDFLARE_API_TOKEN for Queue provisioning.',
 		)
 	}
 	const emailDeliveryQueue = await ensureCloudflareQueue({
@@ -475,6 +476,7 @@ async function ensureProductionResources(options: CliOptions) {
 		name: truncateWithSuffix(bindings.workerName, '-email-delivery-events', 63),
 		queueId: emailDeliveryQueue.id,
 		domain: emailSendingDomain,
+		zoneId: zoneId ?? 'dry-run-zone',
 		dryRun: options.dryRun,
 	})
 

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -200,6 +200,7 @@ test('Queue and Email Sending subscription ensure creates and reconciles Cloudfl
 						source: {
 							type: 'email.sending',
 							domain: 'inbox.example.com',
+							zone_id: 'zone-1',
 						},
 						destination: {
 							type: 'queues.queue',
@@ -225,6 +226,7 @@ test('Queue and Email Sending subscription ensure creates and reconciles Cloudfl
 		name: 'kody-email-delivery-events',
 		queueId: queue.id,
 		domain: 'inbox.example.com',
+		zoneId: 'zone-1',
 		dryRun: false,
 		fetcher: subscriptionFetch,
 	})
@@ -279,6 +281,7 @@ test('Queue and Email Sending subscription ensure creates and reconciles Cloudfl
 		name: 'kody-email-delivery-events',
 		queueId: queue.id,
 		domain: 'inbox.example.com',
+		zoneId: 'zone-1',
 		dryRun: false,
 		fetcher: createSubscriptionFetch,
 	})
@@ -294,6 +297,7 @@ test('Queue and Email Sending subscription ensure creates and reconciles Cloudfl
 		source: {
 			type: 'email.sending',
 			domain: 'inbox.example.com',
+			zone_id: 'zone-1',
 		},
 		destination: {
 			type: 'queues.queue',

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -416,6 +416,7 @@ export async function ensureEmailSendingEventSubscription(input: {
 	name: string
 	queueId: string
 	domain: string
+	zoneId: string
 	dryRun: boolean
 	apiBaseUrl?: string
 	fetcher?: typeof fetch
@@ -433,7 +434,8 @@ export async function ensureEmailSendingEventSubscription(input: {
 	const events = [...emailSendingEventTypes]
 	const sourceIsCurrent =
 		existing?.source['type'] === 'email.sending' &&
-		existing.source['domain'] === input.domain
+		existing.source['domain'] === input.domain &&
+		existing.source['zone_id'] === input.zoneId
 	const isCurrent =
 		existing?.enabled === true &&
 		existing.destination.type === 'queues.queue' &&
@@ -486,6 +488,7 @@ export async function ensureEmailSendingEventSubscription(input: {
 			source: {
 				type: 'email.sending',
 				domain: input.domain,
+				zone_id: input.zoneId,
 			},
 			destination: {
 				type: 'queues.queue',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- pass the production zone ID to Cloudflare Email Sending event subscription provisioning
- include `source.zone_id` in subscription identity and create payloads
- document and configure the required `CLOUDFLARE_ZONE_ID` repository variable

## Context
Production deploy for #780 stopped during resource provisioning with `400 Required at "source.zone_id"`; no migration or Worker upload ran.

## Validation
- `npm run validate` — passed: formatting, lint, typecheck, 271 test files / 878 tests, Playwright E2E, MCP E2E, and primitive taxonomy
- zone-aware production provisioning dry-run — passed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1cd48c15` · **Head:** `bd29f47f`

**Classification:** extends — supplies Cloudflare's required zone identity to the existing email delivery Queue provisioning path.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `email-delivery-queue` | storage | extends — subscription source includes zone and domain |

### System map

Production configuration now identifies the Cloudflare zone and sending domain when reconciling the Queue event subscription.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	workflow["deploy workflow<br/>GitHub Actions"]:::untouched
	queue["email-delivery-queue<br/>Email delivery event queue"]:::extended
	cloudflare["Cloudflare API<br/>Event subscriptions"]:::untouched
	workflow -->|"CLOUDFLARE_ZONE_ID variable"| queue
	queue -->|"source.zone_id + source.domain"| cloudflare
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- The configured zone owns the sending domain; both remain part of subscription reconciliation identity.
- The deployment API token does not require a new zone-read permission because CI receives the non-secret zone ID as configuration.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e42c840b-8980-4090-93ee-ef132d1604d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e42c840b-8980-4090-93ee-ef132d1604d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production setup now configures email-sending event subscriptions for the correct Cloudflare DNS zone.
  * Email-sending resources are reconciled more accurately when zone settings change.

* **Documentation**
  * Added guidance for finding and configuring the required Cloudflare account and zone identifiers in GitHub Actions.

* **Bug Fixes**
  * Improved production resource validation to prevent incomplete Cloudflare configurations from proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->