### PR TITLE
Steer agents toward actionable platform feedback content

### DIFF
--- a/docs/guides/platform-friction.md
+++ b/docs/guides/platform-friction.md
@@ -130,6 +130,37 @@ category fits, while keeping the same approval and privacy rules.
 If the user declines or does not answer, continue the main task without
 submitting feedback.
 
+## Write feedback admins can act on
+
+Submit one issue per call. Unrelated problems get separate submissions. Each
+account already has the 10-per-24h and 100-active limits above, so prioritize
+the most useful reports.
+
+Write a summary that names the affected area and the specific symptom or need so
+an admin can triage from the list view alone (list results intentionally show
+only the summary). Good:
+`package_save rejects README-only updates with a misleading validation error`.
+Vague: `packages are broken`.
+
+In details, capture the firsthand context you uniquely have while it is still in
+the conversation:
+
+- what the user was trying to accomplish
+- exact capability, package, or guide names and non-secret inputs involved
+- minimal reproduction steps
+- expected vs actual behavior
+- verbatim error text quoted as text
+- frequency (always / intermittent, plus conditions)
+- impact (blocked vs degraded, and any workaround plus its cost)
+
+For `suggestion` feedback, lead with the underlying problem and the cost of the
+current workaround; present a proposed change as one possible approach rather
+than the requirement. Separate observed facts from diagnosis: label suspected
+root causes as suspicion.
+
+Keep omitting secrets and unrelated private content. Quote the relevant excerpt
+rather than pasting long transcripts or logs.
+
 ## Suggested phrasing
 
 Use concise language:

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -81,7 +81,7 @@ export const kodyOfficialGuideCatalog = {
 		file: 'platform-friction.md',
 		title: 'Kody platform friction guide',
 		summary:
-			'Use for meaningful Kody friction, bugs, poor experiences, or suggestions: show the exact proposal and account-identity notification disclosure before asking for explicit approval.',
+			'Use for meaningful Kody friction, bugs, poor experiences, or suggestions: show the exact proposal and account-identity notification disclosure before asking for explicit approval, and write one actionable issue per submission (repro steps, expected vs actual, impact).',
 	},
 } as const
 
@@ -158,7 +158,7 @@ const guideFieldSchema = z
 			'`package_invocation_token_setup`: /account/package-invocation-tokens/new setup URL shape, owner-scoped /@:username/api/package-invocations invocation route shape, query params, and bearer-token safety policy for external package invocation clients.',
 			'`package_service_pattern`: package-native long-lived service architecture built on package services and package app realtime.',
 			'`package_subscriptions`: package-owned event subscriptions, package_subscriptions_list discovery, metadata-first email payloads, and consent-gated admin-only platform.feedback.submitted notifications with untrusted text, submitter identity, and an admin deep link.',
-			'`platform_friction`: choose an inline fix, an approved memory workflow, or attributed platform feedback after showing the exact proposal and notification disclosure and receiving explicit user approval.',
+			'`platform_friction`: choose an inline fix, an approved memory workflow, or attributed platform feedback after showing the exact proposal and notification disclosure and receiving explicit user approval, writing one actionable issue per submission.',
 		].join(' '),
 	)
 

--- a/packages/worker/src/mcp/capabilities/meta/meta-platform-feedback-submit.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-platform-feedback-submit.ts
@@ -14,7 +14,7 @@ export const metaPlatformFeedbackSubmitCapability = defineDomainCapability(
 	{
 		name: 'meta_platform_feedback_submit',
 		description:
-			'Submit platform feedback only from an interactive MCP agent flow after showing the user the exact proposed summary and details, asking first, and receiving explicit approval. The exact approved summary and details plus the account user id, username, and email may be delivered immediately to deployment admins through admin-configured notification integrations such as Discord. Copies already delivered outside Kody, including Discord messages, may remain after Kody account deletion under the deployment operator’s retention and deletion controls. Non-interactive package code and package apps cannot submit. Do not include secrets or unrelated private content.',
+			'Submit platform feedback only from an interactive MCP agent flow after showing the user the exact proposed summary and details, asking first, and receiving explicit approval. Load `coding_guide_get({ guide: "platform_friction" })` first for the approval flow and content guidance. The exact approved summary and details plus the account user id, username, and email may be delivered immediately to deployment admins through admin-configured notification integrations such as Discord. Copies already delivered outside Kody, including Discord messages, may remain after Kody account deletion under the deployment operator’s retention and deletion controls. Non-interactive package code and package apps cannot submit. Do not include secrets or unrelated private content.',
 		keywords: [
 			'platform feedback',
 			'friction',

--- a/packages/worker/src/mcp/capabilities/meta/meta-platform-feedback-submit.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-platform-feedback-submit.ts
@@ -28,20 +28,24 @@ export const metaPlatformFeedbackSubmitCapability = defineDomainCapability(
 		inputSchema: z.strictObject({
 			category: z
 				.enum(platformFeedbackCategories)
-				.describe('Stable feedback category.'),
+				.describe(
+					'Stable feedback category: "bug" for reproducible defects, "friction" for capability/guide/package text that caused a wrong turn, "experience" for a poor overall experience, "suggestion" for a problem-first improvement idea, "other" when nothing fits.',
+				),
 			summary: z
 				.string()
 				.trim()
 				.min(1)
 				.max(200)
-				.describe('Concise feedback summary (1–200 characters).'),
+				.describe(
+					'Specific, scannable summary naming the affected area and symptom or need (1–200 characters); admins triage from this line alone, so avoid vague summaries like "search is broken".',
+				),
 			details: z
 				.string()
 				.trim()
 				.min(1)
 				.max(8000)
 				.describe(
-					'Feedback details (1–8000 characters). Do not include secrets or unrelated private content.',
+					'Feedback details (1–8000 characters), one issue per submission: goal context, exact capability or package names, minimal reproduction steps, expected vs actual behavior, verbatim error text, frequency, impact, and any workaround. Do not include secrets or unrelated private content.',
 				),
 			user_confirmed: z
 				.literal(true)

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -70,7 +70,7 @@ Conventions:
 - Jobs, workflows, sessions, services, values, storage, and the other capability groups below are individual capabilities: discover them with \`search\`, whose entity detail includes each capability's exact call shape.
 - Memory writes are verify-first: run \`meta_memory_verify\` before \`meta_memory_upsert\` or \`meta_memory_delete\`.
 - User-specific MCP instructions: \`meta_get_mcp_server_instructions\` / \`meta_set_mcp_server_instructions\` (signed-in users). Updates apply to **new** MCP sessions.
-- For meaningful or recurring Kody friction, bugs, poor experiences, or suggestions, load \`coding_guide_get({ guide: "platform_friction" })\`. Show the exact proposed feedback and explain the attributed admin-notification disclosure before asking; call \`meta_platform_feedback_submit\` with \`user_confirmed: true\` only after explicit approval of that exact text.
+- For meaningful or recurring Kody friction, bugs, poor experiences, or suggestions, load \`coding_guide_get({ guide: "platform_friction" })\`. Show the exact proposed feedback and explain the attributed admin-notification disclosure before asking; call \`meta_platform_feedback_submit\` with \`user_confirmed: true\` only after explicit approval of that exact text. Write one actionable issue per submission: specific summary, repro steps, expected vs actual, impact.
 
 Kody repository (for contributors): https://github.com/kentcdodds/kody
 

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -70,7 +70,6 @@ Conventions:
 - Jobs, workflows, sessions, services, values, storage, and the other capability groups below are individual capabilities: discover them with \`search\`, whose entity detail includes each capability's exact call shape.
 - Memory writes are verify-first: run \`meta_memory_verify\` before \`meta_memory_upsert\` or \`meta_memory_delete\`.
 - User-specific MCP instructions: \`meta_get_mcp_server_instructions\` / \`meta_set_mcp_server_instructions\` (signed-in users). Updates apply to **new** MCP sessions.
-- For meaningful or recurring Kody friction, bugs, poor experiences, or suggestions, load \`coding_guide_get({ guide: "platform_friction" })\`. Show the exact proposed feedback and explain the attributed admin-notification disclosure before asking; call \`meta_platform_feedback_submit\` with \`user_confirmed: true\` only after explicit approval of that exact text. Write one actionable issue per submission: specific summary, repro steps, expected vs actual, impact.
 
 Kody repository (for contributors): https://github.com/kentcdodds/kody
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The platform-feedback steering (the `platform_friction` guide, `meta_platform_feedback_submit` schema descriptions, and MCP server instructions) thoroughly covers consent, attribution, and privacy, but says nothing about what makes the feedback content itself useful to triage. Research on high-quality product feedback (Mozilla bug-writing guidelines, OpenTelemetry good-issues guide, Atlassian product-discovery guidance, NN/g task-context research) converges on: one issue per submission, a specific scannable summary, goal context, minimal repro steps, expected vs actual, verbatim errors, frequency, impact/workaround cost, and problem-first framing for suggestions. Agents are uniquely positioned to capture that firsthand context while it is still in the conversation — but nothing told them to.

## What changed

- `docs/guides/platform-friction.md`: new `## Write feedback admins can act on` section covering one issue per submission, summary quality (with a good-vs-vague example, noting admins triage from the summary-only list view), a details checklist (goal context, exact capability names, repro steps, expected vs actual, verbatim errors, frequency, impact/workaround), problem-first framing for `suggestion` feedback, fact-vs-suspicion labeling, and excerpt-over-transcript quoting.
- `meta-platform-feedback-submit.ts`: the `category`, `summary`, and `details` field descriptions now steer content quality (when to pick each category; specific scannable summary; per-issue details checklist), and the capability description points at `coding_guide_get({ guide: "platform_friction" })` for the approval flow and content guidance. No handler or shape changes.
- `kody-official-guide.ts`: the `platform_friction` catalog summary and `guide` enum description now also advertise the one-actionable-issue content bar.
- `server-instructions.ts`: the platform-feedback bullet is removed from the base server instructions. Server instructions hold a high bar (workflows and cross-tool conventions, per `docs/contributing/mcp-server-patterns.md`); feedback discovery now lives on the capability surfaces themselves — the `meta` domain description, the submit capability's description/keywords, and the `coding_guide_get` guide catalog — which agents hit through `search` and tool listings.

No runtime behavior, schema shape, validation, or storage changes — text-only steering.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk, prompt-surface text only)</summary>

**Mode:** recap · **Base:** `main` @ `84952ee3` · **Head:** `8dbc4962`

**Classification:** extends — the change edits agent-facing contract text (schema descriptions, guide body) on existing primitives and removes one bullet from the base server instructions. No runtime behavior, schema shape, or storage changes.

### Primitives touched

| Primitive             | Group     | Impact                                                                            |
| --------------------- | --------- | --------------------------------------------------------------------------------- |
| `platform-feedback`   | assistant | extends — capability description + `category`/`summary`/`details` describe() text |
| `capability-registry` | assistant | extends — `coding_guide_get` platform_friction summary/describe text               |
| `mcp-server`          | surfaces  | extends — platform-feedback bullet removed from base server instructions           |

### System map

An agent discovers the feedback flow from the submit capability and guide catalog descriptions (no longer from server instructions), loads the guide body from `docs/guides/platform-friction.md` on main, and then calls the unchanged submit handler.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::extended
	capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
	platformFeedback["platform-feedback<br/>Platform feedback"]:::extended
	guideDoc["docs/guides/platform-friction.md<br/>guide body (fetched from main)"]:::extended
	mcpServer -->|"platform-feedback bullet removed from instructions"| capabilityRegistry
	capabilityRegistry -->|"coding_guide_get platform_friction summary"| guideDoc
	guideDoc -->|"new: Write feedback admins can act on section"| platformFeedback
	capabilityRegistry -->|"submit description + category/summary/details describe() text"| platformFeedback
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

## Testing

- `npm run validate` (format:check, lint, typecheck, unit tests, Playwright E2E, MCP E2E) locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07c48613-dc4f-4511-a2dd-c586b66c85c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07c48613-dc4f-4511-a2dd-c586b66c85c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for writing clear, actionable platform feedback.
  * Feedback instructions now emphasize one issue per submission, concise summaries, reproducible details, expected versus actual behavior, and relevant error messages.
  * Clarified privacy expectations, including excluding secrets and unrelated private content.
* **Improvements**
  * Updated feedback submission guidance to require showing the exact proposal and account-identity disclosure before requesting approval.
  * Clarified how approved feedback may be shared with deployment administrators and retained after account deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->