### PR TITLE
Frame public messaging for builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="./packages/worker/public/logo.png" alt="kody logo" width="400" />
 
   <p>
-    <strong>An open-source personal assistant platform built on Cloudflare Workers and MCP</strong>
+    <strong>An open-source personal assistant platform for builders, powered by Cloudflare Workers and MCP</strong>
   </p>
 
   <p>

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -4,6 +4,9 @@ Kody users on the same deployment can share **saved packages** with everyone
 through **community listings**. A listing is a pinned public snapshot of a
 published package — not a live link to the owner's private copy.
 
+A successful one-click install creates and publishes a fork you own. Open it,
+change it, schedule it, or publish your own version back to the community.
+
 Community listings are **public**: `/community` (searchable index) and
 `/community/:listingId` (detail) work without a Kody account. Forking, rating,
 and reporting require a signed-in MCP user.

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -1,5 +1,8 @@
 # Using Kody
 
+Kody is the personal assistant platform for builders who would rather own their
+automations than rent them.
+
 Kody gives your AI assistant secure, reusable access to your services and lets
 it run durable Worker-native automations while your computer is offline.
 

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -52,9 +52,9 @@ const capabilityHighlights = [
 			'Connect Kody to Claude, ChatGPT, Cursor, or Codex through MCP. Kody makes zero inference calls, so there is no second agent or model bill.',
 	},
 	{
-		title: 'Durable jobs, not agent sessions',
+		title: 'The fastest way to start',
 		description:
-			'Jobs run explicit code and API calls. They are not persistent agent sessions, local processes, or general-purpose containers.',
+			'Install a community package in one click. Every install is a fork you own—open it, change it, schedule it, or publish your version back.',
 	},
 	{
 		title: 'Self-service means ownership',
@@ -149,7 +149,8 @@ export function HomeRoute(handle: Handle) {
 					<img src="/logo.png" alt="kody logo" mix={css(heroLogoCss)} />
 					<div mix={css(heroTextCss)}>
 						<h1 mix={css(heroTitleCss)}>
-							Meet <span mix={css({ color: colors.primaryText })}>kody</span>
+							Kody{' '}
+							<span mix={css({ color: colors.primaryText })}>for builders</span>
 						</h1>
 						<p mix={css(heroSubtitleCss)}>
 							Kody gives your AI assistant secure, reusable access to your

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -429,10 +429,10 @@ export function LoginRoute(handle: Handle) {
 				? 'Create your account'
 				: 'Welcome back'
 		const description = showWaitingList
-			? 'Kody is invite-only while we polish onboarding. Join the waitlist to get an invite.'
+			? 'Kody is built for people who want to own their automations. Join the waitlist for an invite.'
 			: isSignup
-				? 'Use your invite code to create an account with a password or social login.'
-				: 'Log in to continue to kody.'
+				? 'Use your invite code to create an account and start building automations you own.'
+				: 'Log in to keep building automations you own.'
 		const submitLabel = isSignup ? 'Create account' : 'Sign in'
 		const toggleLabel = isSignup
 			? 'Already have an account?'

--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -99,8 +99,8 @@ export function WaitlistBanner(handle: Handle) {
 					) : (
 						<>
 							<p mix={css(promptCss)}>
-								Invite-only while we polish onboarding — join the waitlist to
-								get an invite
+								Built for people who want to own their automations. Join the
+								waitlist for an invite.
 							</p>
 							<form mix={[css(formCss), on('submit', handleSubmit)]}>
 								<label mix={css(nameFieldCss)}>

--- a/packages/worker/src/og/pages.ts
+++ b/packages/worker/src/og/pages.ts
@@ -21,12 +21,12 @@ export type PublicOgPage = {
 
 export const publicOgPages = {
 	home: {
-		imageTitle: 'Meet kody',
+		imageTitle: 'Kody for builders',
 		imageSubtitle:
-			'Your personal assistant, built to work from any AI agent host that supports MCP.',
-		ogTitle: 'kody — your personal assistant',
+			'Own the packages and automations behind the AI assistant you already use.',
+		ogTitle: 'Kody — the personal assistant platform for builders',
 		ogDescription:
-			'Your personal assistant, built to work from any AI agent host that supports MCP.',
+			'Own the packages and automations behind the AI assistant you already use.',
 		path: '/',
 	},
 	community: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Frames Kody as the self-service personal assistant platform for builders who want to own their automations.
- Makes the fastest on-ramp explicit: install a community package in one click, then evolve the fork you own.
- Aligns landing, waitlist/auth, README, usage docs, and home share metadata without changing behavior or layout.

## Audience decision
Kody is for developers who prefer to own their keys, OAuth apps, packages, and automations. Self-service ownership is a product feature, not a limitation, and Kody enhances the AI assistant they already use through MCP.

> Ownership ladder: one-click install → fork you own → open, change, or schedule it → publish your own version.

## Validation
- `npm run validate` passed: format, lint, typecheck, 912 unit tests, 17 Playwright E2E tests, 2 MCP E2E tests, and primitive-map validation.
- Manual desktop and mobile checks confirmed the changed copy remains readable without clipping or horizontal overflow.

<a href="https://cursor.com/agents/bc-2d3e0bba-7457-4119-bd10-7c66f314ed37/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuilder_messaging_complete_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-a2d84978-96ac-41d4-9fd5-b8d7692dfe56" alt="builder_messaging_complete_walkthrough.mp4" /></a>

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `4f84d184` · **Head:** `27f5f916`

**Classification:** composes — no primitives are added or changed; this PR edits copy on existing public surfaces.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — landing and auth copy only |

### System map

Public-facing messaging changes within the existing browser app; usage docs and Open Graph metadata mirror the same framing without changing runtime boundaries.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d3e0bba-7457-4119-bd10-7c66f314ed37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d3e0bba-7457-4119-bd10-7c66f314ed37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer guidance about one-click community package installs, including ownership and the ability to modify, schedule, or republish installed packages.
  * Added introductory documentation describing Kody as a platform for owning automations.

* **Style**
  * Refreshed homepage, login, waitlist, and social sharing copy with builder-focused messaging.
  * Updated hero branding and supporting descriptions across the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->