### PR TITLE
Update package scopes when username changes

### DIFF
--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -66,7 +66,10 @@ formats.
 
 Re-running `community_publish` updates the public listing to the package's
 current published commit. Private edits after publishing do not change the
-listing until you publish again and re-run `community_publish`.
+listing until you publish again and re-run `community_publish`. When you change
+your username on `/account`, Kody republishes any of your listings that were
+already pinned to the package's latest commit so the public `@{username}/…` name
+stays current.
 
 `community_unpublish` removes an active listing you own. If an admin **delists**
 a listing, the owner cannot unpublish or re-publish it; only an admin hard

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -50,7 +50,13 @@ Important fields:
 
 For predictable package resolution, saved packages must use a scoped
 `package.json.name`, and the leaf segment must match `kody.id`. For example,
-`@scope/my-package` must use `"kody": { "id": "my-package" }`.
+`@scope/my-package` must use `"kody": { "id": "my-package" }`. The scope is the
+account username. Changing your username on `/account` rewrites every saved
+package to the new `@{username}/…` name (including same-account `kody:@` imports
+and `kody.dependencies`), publishes an automatic update commit per package, and
+republishes any community listing that was already pinned to that package's
+latest commit. Third-party integrations and dynamic invocations that hard-code
+the old `@{username}` scope still need to be updated by their owners.
 
 ### npm dependencies
 

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -415,7 +415,13 @@ export function AccountRoute(handle: Handle) {
 				return
 			}
 			const payload = await readJson<
-				AccountProfileLoaderData & { error?: string }
+				AccountProfileLoaderData & {
+					error?: string
+					packagesUpdated?: number
+					communityListingsRepublished?: number
+					packageUpdateMessage?: string
+					communityUpdateWarning?: string
+				}
 			>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to save username.')
@@ -424,8 +430,18 @@ export function AccountRoute(handle: Handle) {
 			emailVerified = payload.emailVerified
 			username = payload.username
 			draftUsername = payload.username
-			message = 'Username saved.'
-			messageTone = 'info'
+			const packageMessage =
+				typeof payload.packageUpdateMessage === 'string'
+					? payload.packageUpdateMessage
+					: null
+			const communityWarning =
+				typeof payload.communityUpdateWarning === 'string'
+					? payload.communityUpdateWarning
+					: null
+			message = ['Username saved.', packageMessage, communityWarning]
+				.filter(Boolean)
+				.join(' ')
+			messageTone = communityWarning ? 'error' : 'info'
 			queueSessionRefresh()
 		} catch (error) {
 			message =
@@ -555,6 +571,16 @@ export function AccountRoute(handle: Handle) {
 								<p mix={css({ color: colors.textMuted, margin: 0 })}>
 									Email: {email} ({emailVerified ? 'verified' : 'unverified'})
 								</p>
+								{normalizedDraftUsername !== username ? (
+									<p mix={css({ color: colors.textMuted, margin: 0 })}>
+										Changing your username updates every saved package to the
+										new <code>@{normalizedDraftUsername}</code> scope with an
+										automatic commit. That can affect third-party integrations
+										and dynamic invocations that still reference{' '}
+										<code>@{username}</code>. Community listings already pinned
+										to the latest package commit are republished automatically.
+									</p>
+								) : null}
 								<div>
 									<button
 										type="submit"

--- a/packages/worker/src/app/handlers/account-profile.node.test.ts
+++ b/packages/worker/src/app/handlers/account-profile.node.test.ts
@@ -1,4 +1,17 @@
-import { beforeAll, expect, test, vi } from 'vitest'
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	updatePackagesForUsernameChange: vi.fn(),
+	republishCommunityListingsAfterUsernameChange: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/username-change-packages.ts', () => ({
+	updatePackagesForUsernameChange: (...args: Array<unknown>) =>
+		mocks.updatePackagesForUsernameChange(...args),
+	republishCommunityListingsAfterUsernameChange: (...args: Array<unknown>) =>
+		mocks.republishCommunityListingsAfterUsernameChange(...args),
+}))
+
 import {
 	createAuthCookie,
 	setAuthSessionSecret,
@@ -155,6 +168,7 @@ function createEnv(db: D1Database) {
 	return {
 		APP_DB: db,
 		COOKIE_SECRET: testCookieSecret,
+		APP_BASE_URL: 'http://example.com',
 	} as Env
 }
 
@@ -171,6 +185,19 @@ async function runHandler(
 
 beforeAll(() => {
 	setAuthSessionSecret(testCookieSecret)
+})
+
+beforeEach(() => {
+	mocks.updatePackagesForUsernameChange.mockReset()
+	mocks.republishCommunityListingsAfterUsernameChange.mockReset()
+	mocks.updatePackagesForUsernameChange.mockResolvedValue({
+		updatedPackages: [],
+		skippedPackages: [],
+	})
+	mocks.republishCommunityListingsAfterUsernameChange.mockResolvedValue({
+		republishedPackageIds: [],
+		warnings: [],
+	})
 })
 
 test('account profile API returns email and username for the signed-in user', async () => {
@@ -198,11 +225,30 @@ test('account profile API returns email and username for the signed-in user', as
 	})
 	// Reads are not audited.
 	expect(logAuditEventSpy).not.toHaveBeenCalled()
+	expect(mocks.updatePackagesForUsernameChange).not.toHaveBeenCalled()
 })
 
 test('account profile API updates username for the signed-in user', async () => {
 	const testDb = createProfileTestDb([createUser(1, 'current-user')])
 	const handler = createAccountProfileApiHandler(createEnv(testDb.db))
+	mocks.updatePackagesForUsernameChange.mockResolvedValueOnce({
+		updatedPackages: [
+			{
+				packageId: 'pkg-1',
+				kodyId: 'demo',
+				previousName: '@current-user/demo',
+				nextName: '@next_user/demo',
+				publishedCommit: 'abc',
+				changedPaths: ['package.json'],
+				shouldRepublishCommunityListing: true,
+			},
+		],
+		skippedPackages: [],
+	})
+	mocks.republishCommunityListingsAfterUsernameChange.mockResolvedValueOnce({
+		republishedPackageIds: ['pkg-1'],
+		warnings: [],
+	})
 
 	const response = await runHandler(
 		handler,
@@ -223,14 +269,67 @@ test('account profile API updates username for the signed-in user', async () => 
 		email: 'current-user@example.com',
 		username: 'next_user',
 		displayName: 'next_user',
+		packagesUpdated: 1,
+		communityListingsRepublished: 1,
+		packageUpdateMessage: 'Updated 1 package to the new @next_user scope.',
 	})
 	expect(testDb.users.get(1)?.username).toBe('next_user')
+	expect(mocks.updatePackagesForUsernameChange).toHaveBeenCalledWith(
+		expect.objectContaining({
+			previousUsername: 'current-user',
+			nextUsername: 'next_user',
+		}),
+	)
+	expect(
+		mocks.republishCommunityListingsAfterUsernameChange,
+	).toHaveBeenCalledWith(
+		expect.objectContaining({
+			packageIds: ['pkg-1'],
+		}),
+	)
 	expect(logAuditEventSpy).toHaveBeenCalledTimes(1)
 	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'account',
 			action: 'update_username',
 			result: 'success',
+		}),
+	)
+})
+
+test('account profile API rejects username changes when package updates fail', async () => {
+	const testDb = createProfileTestDb([createUser(1, 'current-user')])
+	const handler = createAccountProfileApiHandler(createEnv(testDb.db))
+	mocks.updatePackagesForUsernameChange.mockRejectedValueOnce(
+		new Error('sync failed'),
+	)
+
+	const response = await runHandler(
+		handler,
+		await createRequest({
+			session: {
+				id: '1',
+				email: 'current-user@example.com',
+				rememberMe: false,
+			},
+			method: 'POST',
+			body: { username: 'next_user' },
+		}),
+	)
+
+	expect(response.status).toBe(500)
+	expect(await response.json()).toEqual({
+		ok: false,
+		error:
+			'Username was not changed because package updates failed: sync failed',
+	})
+	expect(testDb.users.get(1)?.username).toBe('current-user')
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'account',
+			action: 'update_username',
+			result: 'failure',
+			reason: 'package_scope_update_failed',
 		}),
 	)
 })
@@ -285,6 +384,7 @@ test('account profile API rejects invalid or duplicate usernames', async () => {
 		error: 'Username already registered.',
 	})
 	expect(testDb.users.get(1)?.username).toBe('current-user')
+	expect(mocks.updatePackagesForUsernameChange).not.toHaveBeenCalled()
 	// Only the duplicate attempt is audited; validation rejections are not.
 	expect(logAuditEventSpy).toHaveBeenCalledTimes(1)
 	expect(logAuditEventSpy).toHaveBeenCalledWith(

--- a/packages/worker/src/app/handlers/account-profile.ts
+++ b/packages/worker/src/app/handlers/account-profile.ts
@@ -1,4 +1,5 @@
 import { utcSqliteTimestamp } from '@kody-internal/shared/date-keys.ts'
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
@@ -6,10 +7,15 @@ import {
 	buildAccountProfilePayload,
 	loadAccountProfileData,
 } from '#app/account-profile-data.ts'
+import { getAppBaseUrl } from '#app/app-base-url.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { getUniqueConstraintField } from '#app/database-errors.ts'
 import { type routes } from '#app/routes.ts'
 import { getUsernameValidationError, normalizeUsername } from '#app/username.ts'
+import {
+	republishCommunityListingsAfterUsernameChange,
+	updatePackagesForUsernameChange,
+} from '#worker/package-registry/username-change-packages.ts'
 import { createDb, usersTable } from '#worker/db.ts'
 
 type AuthenticatedUser = NonNullable<
@@ -49,6 +55,11 @@ export function createAccountProfileApiHandler(env: Env) {
 			}
 
 			const requestIp = getRequestIp(request) ?? undefined
+			const previousUsername = user.username
+			if (username === previousUsername) {
+				return jsonResponse(buildAccountProfilePayload(user))
+			}
+
 			const existingUsername = await db.findOne(usersTable, {
 				where: { username },
 			})
@@ -68,12 +79,62 @@ export function createAccountProfileApiHandler(env: Env) {
 				)
 			}
 
+			const baseUrl = getAppBaseUrl({ env, requestUrl: request.url })
+			const packageUserId = user.mcpUser.userId
+			let packageUpdate
+			try {
+				packageUpdate = await updatePackagesForUsernameChange({
+					env,
+					baseUrl,
+					userId: packageUserId,
+					previousUsername,
+					nextUsername: username,
+				})
+			} catch (error) {
+				void logAuditEvent({
+					category: 'account',
+					action: 'update_username',
+					result: 'failure',
+					email: user.email,
+					ip: requestIp,
+					path: url.pathname,
+					reason: 'package_scope_update_failed',
+				})
+				return jsonResponse(
+					{
+						ok: false,
+						error: `Username was not changed because package updates failed: ${getErrorMessage(error)}`,
+					},
+					500,
+				)
+			}
+
 			try {
 				await db.update(usersTable, user.userId, {
 					username,
 					updated_at: utcSqliteTimestamp(),
 				})
 			} catch (error) {
+				if (packageUpdate.updatedPackages.length > 0) {
+					try {
+						await updatePackagesForUsernameChange({
+							env,
+							baseUrl,
+							userId: packageUserId,
+							previousUsername: username,
+							nextUsername: previousUsername,
+						})
+					} catch (compensateError) {
+						console.error(
+							JSON.stringify({
+								message:
+									'username-change package compensation after username update failure failed',
+								userId: packageUserId,
+								error: getErrorMessage(compensateError),
+							}),
+						)
+					}
+				}
 				if (getUniqueConstraintField(error) === 'username') {
 					void logAuditEvent({
 						category: 'account',
@@ -92,6 +153,19 @@ export function createAccountProfileApiHandler(env: Env) {
 				throw error
 			}
 
+			const communityPackageIds = packageUpdate.updatedPackages
+				.filter((entry) => entry.shouldRepublishCommunityListing)
+				.map((entry) => entry.packageId)
+			const communityRepublish =
+				communityPackageIds.length > 0
+					? await republishCommunityListingsAfterUsernameChange({
+							env,
+							baseUrl,
+							userId: packageUserId,
+							packageIds: communityPackageIds,
+						})
+					: { republishedPackageIds: [], warnings: [] }
+
 			void logAuditEvent({
 				category: 'account',
 				action: 'update_username',
@@ -101,14 +175,31 @@ export function createAccountProfileApiHandler(env: Env) {
 				path: url.pathname,
 			})
 
-			return jsonResponse(
-				buildAccountProfilePayload({
+			const packageCount = packageUpdate.updatedPackages.length
+			const packageSummary =
+				packageCount === 0
+					? null
+					: `Updated ${packageCount} package${packageCount === 1 ? '' : 's'} to the new @${username} scope.`
+			const communityWarning =
+				communityRepublish.warnings.length > 0
+					? communityRepublish.warnings.join(' ')
+					: null
+
+			return jsonResponse({
+				...buildAccountProfilePayload({
 					...user,
 					username,
 					displayName: username,
 					mcpUser: { ...user.mcpUser, displayName: username },
 				} satisfies AuthenticatedUser),
-			)
+				packagesUpdated: packageCount,
+				communityListingsRepublished:
+					communityRepublish.republishedPackageIds.length,
+				...(packageSummary ? { packageUpdateMessage: packageSummary } : {}),
+				...(communityWarning
+					? { communityUpdateWarning: communityWarning }
+					: {}),
+			})
 		},
 	} satisfies Action<typeof routes.accountProfileApi>
 }

--- a/packages/worker/src/app/handlers/account-profile.ts
+++ b/packages/worker/src/app/handlers/account-profile.ts
@@ -81,60 +81,15 @@ export function createAccountProfileApiHandler(env: Env) {
 
 			const baseUrl = getAppBaseUrl({ env, requestUrl: request.url })
 			const packageUserId = user.mcpUser.userId
-			let packageUpdate
-			try {
-				packageUpdate = await updatePackagesForUsernameChange({
-					env,
-					baseUrl,
-					userId: packageUserId,
-					previousUsername,
-					nextUsername: username,
-				})
-			} catch (error) {
-				void logAuditEvent({
-					category: 'account',
-					action: 'update_username',
-					result: 'failure',
-					email: user.email,
-					ip: requestIp,
-					path: url.pathname,
-					reason: 'package_scope_update_failed',
-				})
-				return jsonResponse(
-					{
-						ok: false,
-						error: `Username was not changed because package updates failed: ${getErrorMessage(error)}`,
-					},
-					500,
-				)
-			}
 
+			// Claim the username first so concurrent renames lose on the unique
+			// constraint before any package publishes use the new scope.
 			try {
 				await db.update(usersTable, user.userId, {
 					username,
 					updated_at: utcSqliteTimestamp(),
 				})
 			} catch (error) {
-				if (packageUpdate.updatedPackages.length > 0) {
-					try {
-						await updatePackagesForUsernameChange({
-							env,
-							baseUrl,
-							userId: packageUserId,
-							previousUsername: username,
-							nextUsername: previousUsername,
-						})
-					} catch (compensateError) {
-						console.error(
-							JSON.stringify({
-								message:
-									'username-change package compensation after username update failure failed',
-								userId: packageUserId,
-								error: getErrorMessage(compensateError),
-							}),
-						)
-					}
-				}
 				if (getUniqueConstraintField(error) === 'username') {
 					void logAuditEvent({
 						category: 'account',
@@ -151,6 +106,48 @@ export function createAccountProfileApiHandler(env: Env) {
 					)
 				}
 				throw error
+			}
+
+			let packageUpdate
+			try {
+				packageUpdate = await updatePackagesForUsernameChange({
+					env,
+					baseUrl,
+					userId: packageUserId,
+					previousUsername,
+					nextUsername: username,
+				})
+			} catch (error) {
+				try {
+					await db.update(usersTable, user.userId, {
+						username: previousUsername,
+						updated_at: utcSqliteTimestamp(),
+					})
+				} catch (rollbackError) {
+					console.error(
+						JSON.stringify({
+							message: 'username-change rollback failed after package error',
+							userId: packageUserId,
+							error: getErrorMessage(rollbackError),
+						}),
+					)
+				}
+				void logAuditEvent({
+					category: 'account',
+					action: 'update_username',
+					result: 'failure',
+					email: user.email,
+					ip: requestIp,
+					path: url.pathname,
+					reason: 'package_scope_update_failed',
+				})
+				return jsonResponse(
+					{
+						ok: false,
+						error: `Username was not changed because package updates failed: ${getErrorMessage(error)}`,
+					},
+					500,
+				)
 			}
 
 			const communityPackageIds = packageUpdate.updatedPackages

--- a/packages/worker/src/package-registry/username-change-packages.node.test.ts
+++ b/packages/worker/src/package-registry/username-change-packages.node.test.ts
@@ -113,6 +113,7 @@ test('updatePackagesForUsernameChange rewrites packages and flags community repu
 				'Rename package scope after username change from @alice to @bob',
 			files: expect.objectContaining({
 				'package.json': expect.stringContaining('"name": "@bob/demo"'),
+				'index.ts': expect.stringContaining('kody:@bob/demo'),
 			}),
 		}),
 	)

--- a/packages/worker/src/package-registry/username-change-packages.node.test.ts
+++ b/packages/worker/src/package-registry/username-change-packages.node.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	listSavedPackagesByUserId: vi.fn(),
+	loadPackageSourceBySourceId: vi.fn(),
+	getCommunityListingByOwnerAndPackage: vi.fn(),
+	syncArtifactSourceSnapshot: vi.fn(),
+	refreshSavedPackageProjection: vi.fn(),
+	publishCommunityListing: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	listSavedPackagesByUserId: (...args: Array<unknown>) =>
+		mocks.listSavedPackagesByUserId(...args),
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
+		mocks.loadPackageSourceBySourceId(...args),
+}))
+
+vi.mock('#worker/community/repo.ts', () => ({
+	getCommunityListingByOwnerAndPackage: (...args: Array<unknown>) =>
+		mocks.getCommunityListingByOwnerAndPackage(...args),
+}))
+
+vi.mock('#worker/repo/source-sync.ts', () => ({
+	syncArtifactSourceSnapshot: (...args: Array<unknown>) =>
+		mocks.syncArtifactSourceSnapshot(...args),
+}))
+
+vi.mock('#worker/package-registry/service.ts', () => ({
+	refreshSavedPackageProjection: (...args: Array<unknown>) =>
+		mocks.refreshSavedPackageProjection(...args),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	publishCommunityListing: (...args: Array<unknown>) =>
+		mocks.publishCommunityListing(...args),
+}))
+
+import {
+	republishCommunityListingsAfterUsernameChange,
+	updatePackagesForUsernameChange,
+} from './username-change-packages.ts'
+
+const env = { APP_DB: {} } as Env
+
+beforeEach(() => {
+	mocks.listSavedPackagesByUserId.mockReset()
+	mocks.loadPackageSourceBySourceId.mockReset()
+	mocks.getCommunityListingByOwnerAndPackage.mockReset()
+	mocks.syncArtifactSourceSnapshot.mockReset()
+	mocks.refreshSavedPackageProjection.mockReset()
+	mocks.publishCommunityListing.mockReset()
+	mocks.syncArtifactSourceSnapshot.mockResolvedValue('commit-new')
+	mocks.refreshSavedPackageProjection.mockResolvedValue(undefined)
+	mocks.publishCommunityListing.mockResolvedValue({})
+})
+
+test('updatePackagesForUsernameChange rewrites packages and flags community republish', async () => {
+	mocks.listSavedPackagesByUserId.mockResolvedValueOnce([
+		{
+			id: 'pkg-1',
+			kodyId: 'demo',
+			sourceId: 'source-1',
+			name: '@alice/demo',
+		},
+	])
+	mocks.loadPackageSourceBySourceId.mockResolvedValueOnce({
+		source: { published_commit: 'commit-old' },
+		files: {
+			'package.json': `${JSON.stringify(
+				{
+					name: '@alice/demo',
+					exports: { '.': './index.ts' },
+					kody: { id: 'demo', description: 'Demo' },
+				},
+				null,
+				'\t',
+			)}\n`,
+			'index.ts': "import 'kody:@alice/demo'\n",
+		},
+	})
+	mocks.getCommunityListingByOwnerAndPackage.mockResolvedValueOnce({
+		status: 'active',
+		pinnedCommit: 'commit-old',
+	})
+
+	const result = await updatePackagesForUsernameChange({
+		env,
+		baseUrl: 'https://example.com',
+		userId: 'user-1',
+		previousUsername: 'alice',
+		nextUsername: 'bob',
+	})
+
+	expect(result.updatedPackages).toHaveLength(1)
+	expect(result.updatedPackages[0]).toMatchObject({
+		packageId: 'pkg-1',
+		kodyId: 'demo',
+		previousName: '@alice/demo',
+		nextName: '@bob/demo',
+		publishedCommit: 'commit-new',
+		shouldRepublishCommunityListing: true,
+	})
+	expect(mocks.syncArtifactSourceSnapshot).toHaveBeenCalledWith(
+		expect.objectContaining({
+			sourceId: 'source-1',
+			expectedPackageScope: 'bob',
+			destructiveOverwriteConfirmed: true,
+			commitMessage:
+				'Rename package scope after username change from @alice to @bob',
+			files: expect.objectContaining({
+				'package.json': expect.stringContaining('"name": "@bob/demo"'),
+			}),
+		}),
+	)
+	expect(mocks.refreshSavedPackageProjection).toHaveBeenCalledWith(
+		expect.objectContaining({
+			packageId: 'pkg-1',
+			sourceId: 'source-1',
+		}),
+	)
+})
+
+test('updatePackagesForUsernameChange compensates when a later package fails', async () => {
+	mocks.listSavedPackagesByUserId.mockResolvedValueOnce([
+		{
+			id: 'pkg-1',
+			kodyId: 'one',
+			sourceId: 'source-1',
+			name: '@alice/one',
+		},
+		{
+			id: 'pkg-2',
+			kodyId: 'two',
+			sourceId: 'source-2',
+			name: '@alice/two',
+		},
+	])
+	mocks.loadPackageSourceBySourceId.mockImplementation(
+		async (input: { sourceId: string }) => {
+			if (input.sourceId === 'source-2') {
+				throw new Error('missing source')
+			}
+			return {
+				source: { published_commit: 'commit-old' },
+				files: {
+					'package.json': `${JSON.stringify({
+						name: '@alice/one',
+						exports: { '.': './index.ts' },
+						kody: { id: 'one', description: 'One' },
+					})}\n`,
+				},
+			}
+		},
+	)
+	mocks.getCommunityListingByOwnerAndPackage.mockResolvedValue(null)
+
+	await expect(
+		updatePackagesForUsernameChange({
+			env,
+			baseUrl: 'https://example.com',
+			userId: 'user-1',
+			previousUsername: 'alice',
+			nextUsername: 'bob',
+		}),
+	).rejects.toThrow('missing source')
+
+	// First package published to bob, then compensated back to alice.
+	expect(mocks.syncArtifactSourceSnapshot).toHaveBeenCalledTimes(2)
+	expect(mocks.syncArtifactSourceSnapshot.mock.calls[0]?.[0]).toMatchObject({
+		expectedPackageScope: 'bob',
+	})
+	expect(mocks.syncArtifactSourceSnapshot.mock.calls[1]?.[0]).toMatchObject({
+		expectedPackageScope: 'alice',
+	})
+})
+
+test('republishCommunityListingsAfterUsernameChange collects warnings', async () => {
+	mocks.publishCommunityListing
+		.mockResolvedValueOnce({})
+		.mockRejectedValueOnce(new Error('delisted'))
+
+	const result = await republishCommunityListingsAfterUsernameChange({
+		env,
+		baseUrl: 'https://example.com',
+		userId: 'user-1',
+		packageIds: ['pkg-1', 'pkg-2'],
+	})
+
+	expect(result.republishedPackageIds).toEqual(['pkg-1'])
+	expect(result.warnings).toEqual([
+		'Community listing for package "pkg-2" was not republished: delisted',
+	])
+})

--- a/packages/worker/src/package-registry/username-change-packages.ts
+++ b/packages/worker/src/package-registry/username-change-packages.ts
@@ -1,0 +1,300 @@
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import { getCommunityListingByOwnerAndPackage } from '#worker/community/repo.ts'
+import { publishCommunityListing } from '#worker/community/service.ts'
+import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
+import { refreshSavedPackageProjection } from '#worker/package-registry/service.ts'
+import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
+import {
+	rewritePackageFilesForUsernameChange,
+	type UsernameScopeRewriteResult,
+} from '#worker/package-registry/username-scope-rewrite.ts'
+import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
+
+export type UsernameChangePackageUpdate = {
+	packageId: string
+	kodyId: string
+	previousName: string | null
+	nextName: string
+	publishedCommit: string | null
+	changedPaths: Array<string>
+	shouldRepublishCommunityListing: boolean
+}
+
+export type UsernameChangePackagesResult = {
+	updatedPackages: Array<UsernameChangePackageUpdate>
+	skippedPackages: Array<{ packageId: string; kodyId: string; reason: string }>
+}
+
+function buildUsernameRenameCommitMessage(input: {
+	previousScope: string
+	nextScope: string
+}) {
+	return `Rename package scope after username change from @${input.previousScope} to @${input.nextScope}`
+}
+
+function changedFilesOnly(
+	rewrite: UsernameScopeRewriteResult,
+): Record<string, string> {
+	const files: Record<string, string> = {}
+	for (const path of rewrite.changedPaths) {
+		const content = rewrite.files[path]
+		if (typeof content === 'string') {
+			files[path] = content
+		}
+	}
+	return files
+}
+
+async function rewriteAndPublishPackageScope(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	sourceId: string
+	files: Record<string, string>
+	previousScope: string
+	nextScope: string
+	kodyId: string
+	packageId: string
+}): Promise<UsernameChangePackageUpdate | null> {
+	const rewrite = rewritePackageFilesForUsernameChange({
+		files: input.files,
+		previousScope: input.previousScope,
+		nextScope: input.nextScope,
+		kodyId: input.kodyId,
+	})
+	if (!rewrite.changed) {
+		return null
+	}
+
+	const publishedCommit = await syncArtifactSourceSnapshot({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		sourceId: input.sourceId,
+		files: changedFilesOnly(rewrite),
+		expectedPackageScope: input.nextScope,
+		destructiveOverwriteConfirmed: true,
+		commitMessage: buildUsernameRenameCommitMessage({
+			previousScope: input.previousScope,
+			nextScope: input.nextScope,
+		}),
+	})
+
+	await refreshSavedPackageProjection({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		packageId: input.packageId,
+		sourceId: input.sourceId,
+	})
+
+	return {
+		packageId: input.packageId,
+		kodyId: input.kodyId,
+		previousName: rewrite.previousName,
+		nextName: rewrite.nextName,
+		publishedCommit,
+		changedPaths: rewrite.changedPaths,
+		shouldRepublishCommunityListing: false,
+	}
+}
+
+async function compensatePackageUpdates(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	previousScope: string
+	nextScope: string
+	applied: Array<{
+		packageId: string
+		sourceId: string
+		filesAtNewScope: Record<string, string>
+		kodyId: string
+	}>
+}) {
+	for (const applied of [...input.applied].reverse()) {
+		try {
+			await rewriteAndPublishPackageScope({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				sourceId: applied.sourceId,
+				files: applied.filesAtNewScope,
+				previousScope: input.nextScope,
+				nextScope: input.previousScope,
+				kodyId: applied.kodyId,
+				packageId: applied.packageId,
+			})
+		} catch (compensateError) {
+			console.error(
+				JSON.stringify({
+					message: 'username-change package compensation failed',
+					packageId: applied.packageId,
+					error: getErrorMessage(compensateError),
+				}),
+			)
+		}
+	}
+}
+
+/**
+ * Rewrite and republish every saved package whose scope still embeds the
+ * previous username. Call this **before** flipping `users.username` so a
+ * failure leaves the account on the old username. Package publish validates
+ * against `nextUsername` via `expectedPackageScope`.
+ *
+ * Returns which updated packages had an active community listing already
+ * pinned to the pre-rename published commit; the caller should republish
+ * those listings after the username row is updated.
+ */
+export async function updatePackagesForUsernameChange(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	previousUsername: string
+	nextUsername: string
+}): Promise<UsernameChangePackagesResult> {
+	const previousScope = input.previousUsername.trim().toLowerCase()
+	const nextScope = input.nextUsername.trim().toLowerCase()
+	if (!previousScope || previousScope === nextScope) {
+		return {
+			updatedPackages: [],
+			skippedPackages: [],
+		}
+	}
+
+	const savedPackages = await listSavedPackagesByUserId(input.env.APP_DB, {
+		userId: input.userId,
+	})
+	const updatedPackages: Array<UsernameChangePackageUpdate> = []
+	const skippedPackages: Array<{
+		packageId: string
+		kodyId: string
+		reason: string
+	}> = []
+	const applied: Array<{
+		packageId: string
+		sourceId: string
+		filesAtNewScope: Record<string, string>
+		kodyId: string
+	}> = []
+
+	try {
+		for (const savedPackage of savedPackages) {
+			const loaded = await loadPackageSourceBySourceId({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				sourceId: savedPackage.sourceId,
+			})
+
+			const listing = await getCommunityListingByOwnerAndPackage(
+				input.env.APP_DB,
+				{
+					ownerUserId: input.userId,
+					packageId: savedPackage.id,
+				},
+			)
+			const shouldRepublishCommunityListing =
+				listing != null &&
+				listing.status === 'active' &&
+				loaded.source.published_commit != null &&
+				listing.pinnedCommit === loaded.source.published_commit
+
+			const rewrite = rewritePackageFilesForUsernameChange({
+				files: loaded.files,
+				previousScope,
+				nextScope,
+				kodyId: savedPackage.kodyId,
+			})
+			if (!rewrite.changed) {
+				skippedPackages.push({
+					packageId: savedPackage.id,
+					kodyId: savedPackage.kodyId,
+					reason: 'already_new_scope',
+				})
+				continue
+			}
+
+			const update = await rewriteAndPublishPackageScope({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				sourceId: savedPackage.sourceId,
+				files: loaded.files,
+				previousScope,
+				nextScope,
+				kodyId: savedPackage.kodyId,
+				packageId: savedPackage.id,
+			})
+			if (!update) {
+				skippedPackages.push({
+					packageId: savedPackage.id,
+					kodyId: savedPackage.kodyId,
+					reason: 'already_new_scope',
+				})
+				continue
+			}
+
+			applied.push({
+				packageId: savedPackage.id,
+				sourceId: savedPackage.sourceId,
+				filesAtNewScope: rewrite.files,
+				kodyId: savedPackage.kodyId,
+			})
+			updatedPackages.push({
+				...update,
+				shouldRepublishCommunityListing,
+			})
+		}
+	} catch (error) {
+		await compensatePackageUpdates({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.userId,
+			previousScope,
+			nextScope,
+			applied,
+		})
+		throw error
+	}
+
+	return {
+		updatedPackages,
+		skippedPackages,
+	}
+}
+
+/**
+ * Republish community listings that were already on the package's latest
+ * commit before the username-rename package publishes. Safe to call after
+ * `users.username` has been updated.
+ */
+export async function republishCommunityListingsAfterUsernameChange(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	packageIds: Array<string>
+}): Promise<{
+	republishedPackageIds: Array<string>
+	warnings: Array<string>
+}> {
+	const republishedPackageIds: Array<string> = []
+	const warnings: Array<string> = []
+	for (const packageId of input.packageIds) {
+		try {
+			await publishCommunityListing({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				packageId,
+			})
+			republishedPackageIds.push(packageId)
+		} catch (error) {
+			warnings.push(
+				`Community listing for package "${packageId}" was not republished: ${getErrorMessage(error)}`,
+			)
+		}
+	}
+	return { republishedPackageIds, warnings }
+}

--- a/packages/worker/src/package-registry/username-change-packages.ts
+++ b/packages/worker/src/package-registry/username-change-packages.ts
@@ -4,10 +4,7 @@ import { publishCommunityListing } from '#worker/community/service.ts'
 import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { refreshSavedPackageProjection } from '#worker/package-registry/service.ts'
 import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
-import {
-	rewritePackageFilesForUsernameChange,
-	type UsernameScopeRewriteResult,
-} from '#worker/package-registry/username-scope-rewrite.ts'
+import { rewritePackageFilesForUsernameChange } from '#worker/package-registry/username-scope-rewrite.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 
 export type UsernameChangePackageUpdate = {
@@ -32,19 +29,6 @@ function buildUsernameRenameCommitMessage(input: {
 	return `Rename package scope after username change from @${input.previousScope} to @${input.nextScope}`
 }
 
-function changedFilesOnly(
-	rewrite: UsernameScopeRewriteResult,
-): Record<string, string> {
-	const files: Record<string, string> = {}
-	for (const path of rewrite.changedPaths) {
-		const content = rewrite.files[path]
-		if (typeof content === 'string') {
-			files[path] = content
-		}
-	}
-	return files
-}
-
 async function rewriteAndPublishPackageScope(input: {
 	env: Env
 	baseUrl: string
@@ -66,12 +50,15 @@ async function rewriteAndPublishPackageScope(input: {
 		return null
 	}
 
+	// Pass the full rewritten tree. Partial file maps are unsafe on the
+	// unpublished bootstrap path in syncArtifactSourceSnapshot, which replaces
+	// the whole repo with only the provided files.
 	const publishedCommit = await syncArtifactSourceSnapshot({
 		env: input.env,
 		baseUrl: input.baseUrl,
 		userId: input.userId,
 		sourceId: input.sourceId,
-		files: changedFilesOnly(rewrite),
+		files: rewrite.files,
 		expectedPackageScope: input.nextScope,
 		destructiveOverwriteConfirmed: true,
 		commitMessage: buildUsernameRenameCommitMessage({
@@ -80,13 +67,25 @@ async function rewriteAndPublishPackageScope(input: {
 		}),
 	})
 
-	await refreshSavedPackageProjection({
-		env: input.env,
-		baseUrl: input.baseUrl,
-		userId: input.userId,
-		packageId: input.packageId,
-		sourceId: input.sourceId,
-	})
+	try {
+		await refreshSavedPackageProjection({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.userId,
+			packageId: input.packageId,
+			sourceId: input.sourceId,
+		})
+	} catch (error) {
+		// Publish already succeeded; keep this package in the applied set so
+		// callers can compensate. Projection can be repaired on the next save.
+		console.error(
+			JSON.stringify({
+				message: 'username-change package projection refresh failed',
+				packageId: input.packageId,
+				error: getErrorMessage(error),
+			}),
+		)
+	}
 
 	return {
 		packageId: input.packageId,
@@ -139,13 +138,13 @@ async function compensatePackageUpdates(input: {
 
 /**
  * Rewrite and republish every saved package whose scope still embeds the
- * previous username. Call this **before** flipping `users.username` so a
- * failure leaves the account on the old username. Package publish validates
+ * previous username. Call this **after** claiming `users.username` so the
+ * new scope is reserved before package publishes. Package publish validates
  * against `nextUsername` via `expectedPackageScope`.
  *
  * Returns which updated packages had an active community listing already
  * pinned to the pre-rename published commit; the caller should republish
- * those listings after the username row is updated.
+ * those listings after this returns.
  */
 export async function updatePackagesForUsernameChange(input: {
 	env: Env

--- a/packages/worker/src/package-registry/username-scope-rewrite.node.test.ts
+++ b/packages/worker/src/package-registry/username-scope-rewrite.node.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from 'vitest'
+import {
+	buildPackageNameForScope,
+	rewritePackageFilesForUsernameChange,
+	rewriteScopedPackageReferences,
+} from './username-scope-rewrite.ts'
+
+test('rewriteScopedPackageReferences rewrites exact scopes only', () => {
+	expect(
+		rewriteScopedPackageReferences(
+			'import x from "kody:@alice/pkg"\nimport y from "kody:@alice-dev/other"',
+			{ previousScope: 'alice', nextScope: 'bob' },
+		),
+	).toBe('import x from "kody:@bob/pkg"\nimport y from "kody:@alice-dev/other"')
+})
+
+test('rewritePackageFilesForUsernameChange updates manifest and source references', () => {
+	const result = rewritePackageFilesForUsernameChange({
+		files: {
+			'package.json': `${JSON.stringify(
+				{
+					name: '@alice/demo',
+					exports: { '.': './src/index.ts' },
+					kody: {
+						id: 'demo',
+						description: 'Demo package',
+						dependencies: ['@alice/shared', '@other/lib'],
+						emits: {
+							'@alice/demo.ready': { description: 'Ready' },
+						},
+						subscriptions: {
+							'@alice/shared.event': { handler: './src/on-event.ts' },
+							'@other/topic': { handler: './src/on-other.ts' },
+						},
+					},
+				},
+				null,
+				'\t',
+			)}\n`,
+			'src/index.ts':
+				"import { helper } from 'kody:@alice/shared/helper'\nexport const other = 'kody:@other/lib'\n",
+			'README.md': '# @alice/demo\n',
+			'binary.bin': 'not-a-scope-reference',
+		},
+		previousScope: 'alice',
+		nextScope: 'bob',
+		kodyId: 'demo',
+	})
+
+	expect(result.changed).toBe(true)
+	expect(result.previousName).toBe('@alice/demo')
+	expect(result.nextName).toBe('@bob/demo')
+	expect(result.changedPaths).toEqual([
+		'package.json',
+		'README.md',
+		'src/index.ts',
+	])
+
+	const manifest = JSON.parse(result.files['package.json']!) as {
+		name: string
+		kody: {
+			dependencies: Array<string>
+			emits: Record<string, unknown>
+			subscriptions: Record<string, unknown>
+		}
+	}
+	expect(manifest.name).toBe('@bob/demo')
+	expect(manifest.kody.dependencies).toEqual(['@bob/shared', '@other/lib'])
+	expect(Object.keys(manifest.kody.emits)).toEqual(['@bob/demo.ready'])
+	expect(Object.keys(manifest.kody.subscriptions).sort()).toEqual([
+		'@bob/shared.event',
+		'@other/topic',
+	])
+	expect(result.files['src/index.ts']).toContain('kody:@bob/shared/helper')
+	expect(result.files['src/index.ts']).toContain('kody:@other/lib')
+	expect(result.files['README.md']).toBe('# @bob/demo\n')
+	expect(result.files['binary.bin']).toBe('not-a-scope-reference')
+})
+
+test('rewritePackageFilesForUsernameChange is a no-op when scopes match', () => {
+	const files = {
+		'package.json': '{"name":"@alice/demo"}\n',
+	}
+	const result = rewritePackageFilesForUsernameChange({
+		files,
+		previousScope: 'alice',
+		nextScope: 'Alice',
+		kodyId: 'demo',
+	})
+	expect(result.changed).toBe(false)
+	expect(result.changedPaths).toEqual([])
+	expect(buildPackageNameForScope({ scope: 'Alice', kodyId: 'demo' })).toBe(
+		'@alice/demo',
+	)
+})

--- a/packages/worker/src/package-registry/username-scope-rewrite.ts
+++ b/packages/worker/src/package-registry/username-scope-rewrite.ts
@@ -1,0 +1,109 @@
+/**
+ * Rewrite a saved package's scope when the owning user's username changes.
+ *
+ * Package names are `@{username}/{kodyId}`. Username changes must update
+ * `package.json#name` and any same-account references that embed that scope
+ * (`kody.dependencies`, `kody.emits` / `kody.subscriptions` topic keys, and
+ * `kody:@scope/...` imports in source files).
+ */
+
+function escapeRegExp(value: string) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function normalizePackageScope(scope: string) {
+	return scope.trim().replace(/^@/, '').toLowerCase()
+}
+
+/**
+ * Replace `@oldScope/` with `@newScope/` only when the old token is an exact
+ * scope segment (not a longer username that shares a prefix).
+ */
+export function rewriteScopedPackageReferences(
+	content: string,
+	input: { previousScope: string; nextScope: string },
+) {
+	const previousScope = normalizePackageScope(input.previousScope)
+	const nextScope = normalizePackageScope(input.nextScope)
+	if (!previousScope || previousScope === nextScope) {
+		return content
+	}
+	const pattern = new RegExp(`@${escapeRegExp(previousScope)}(?=/)`, 'g')
+	return content.replace(pattern, `@${nextScope}`)
+}
+
+export function buildPackageNameForScope(input: {
+	scope: string
+	kodyId: string
+}) {
+	return `@${normalizePackageScope(input.scope)}/${input.kodyId}`
+}
+
+export type UsernameScopeRewriteResult = {
+	files: Record<string, string>
+	changedPaths: Array<string>
+	previousName: string | null
+	nextName: string
+	changed: boolean
+}
+
+/**
+ * Rewrite package files from one username scope to another.
+ * Only paths whose content actually changes are listed in `changedPaths`.
+ */
+export function rewritePackageFilesForUsernameChange(input: {
+	files: Record<string, string>
+	previousScope: string
+	nextScope: string
+	kodyId: string
+}): UsernameScopeRewriteResult {
+	const previousScope = normalizePackageScope(input.previousScope)
+	const nextScope = normalizePackageScope(input.nextScope)
+	const nextName = buildPackageNameForScope({
+		scope: nextScope,
+		kodyId: input.kodyId,
+	})
+	const previousName = buildPackageNameForScope({
+		scope: previousScope,
+		kodyId: input.kodyId,
+	})
+
+	if (!previousScope || previousScope === nextScope) {
+		return {
+			files: { ...input.files },
+			changedPaths: [],
+			previousName,
+			nextName,
+			changed: false,
+		}
+	}
+
+	const files: Record<string, string> = {}
+	const changedPaths: Array<string> = []
+	const needle = `@${previousScope}/`
+
+	for (const [path, content] of Object.entries(input.files)) {
+		if (!content.includes(needle)) {
+			files[path] = content
+			continue
+		}
+		const nextContent = rewriteScopedPackageReferences(content, {
+			previousScope,
+			nextScope,
+		})
+		files[path] = nextContent
+		if (nextContent !== content) {
+			changedPaths.push(path)
+		}
+	}
+
+	changedPaths.sort((left, right) => left.localeCompare(right))
+
+	return {
+		files,
+		changedPaths,
+		previousName,
+		nextName,
+		changed: changedPaths.length > 0,
+	}
+}

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -1768,6 +1768,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		privateVisibilityChangeConfirmed?: boolean
 		rebuildPackageArtifacts?: boolean
 		expectedPackageScope?: string
+		commitMessage?: string
 	}): Promise<RepoSessionPublishResult> {
 		const { sessionRow, source, sessionAccess } = await this.getSessionState(
 			input.sessionId,
@@ -1830,8 +1831,10 @@ class RepoSessionBase extends DurableObject<Env> {
 			})
 		}
 		const sessionHeadCommit =
-			(await this.commitIfDirty(`Publish repo session ${input.sessionId}`)) ??
-			(await this.getHeadCommit())
+			(await this.commitIfDirty(
+				input.commitMessage?.trim() ||
+					`Publish repo session ${input.sessionId}`,
+			)) ?? (await this.getHeadCommit())
 		await this.readManifestFromWorkspace(
 			source.manifest_path,
 			source.entity_kind,

--- a/packages/worker/src/repo/source-sync.ts
+++ b/packages/worker/src/repo/source-sync.ts
@@ -23,6 +23,14 @@ type SyncArtifactSourceInput = {
 	bootstrapAccess?: ArtifactBootstrapAccess | null
 	destructiveOverwriteConfirmed?: boolean
 	privateVisibilityChangeConfirmed?: boolean
+	/**
+	 * When set, package publish validates `package.json#name` against this
+	 * scope instead of skipping scope checks. Used for username-rename
+	 * rewrites that publish the new scope before `users.username` flips.
+	 */
+	expectedPackageScope?: string
+	/** Optional git commit message used when publishing an existing source. */
+	commitMessage?: string
 }
 
 function validateEntitySourceManifest(input: {
@@ -190,6 +198,12 @@ export async function syncArtifactSourceSnapshot(
 				: {}),
 			...(input.privateVisibilityChangeConfirmed === true
 				? { privateVisibilityChangeConfirmed: true }
+				: {}),
+			...(input.expectedPackageScope !== undefined
+				? { expectedPackageScope: input.expectedPackageScope }
+				: {}),
+			...(input.commitMessage !== undefined
+				? { commitMessage: input.commitMessage }
 				: {}),
 		})
 		if (publishResult.status !== 'ok') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Username changes previously only updated `users.username`. Saved packages kept the old `@{username}/{kodyId}` name, so later saves/publishes failed scope checks and community “by @…” stayed stale.

This PR cascades username changes across packages:

- Claim the new username first (unique constraint wins races)
- Rewrite `package.json#name` and same-account `@old/` references (`kody.dependencies`, emits/subscriptions topic keys, `kody:@` imports)
- Publish an automatic update commit per package with the full rewritten tree
- Roll back the username (and compensate packages) if the cascade fails
- Warn on `/account` that package commits and third-party / dynamic invocations may be affected
- Auto-republish community listings that were already pinned to the package’s latest commit
- Document the behavior in usage docs

## Test plan

- [x] Unit tests for scope rewrite helpers
- [x] Unit tests for package cascade + community republish wiring
- [x] Account profile API tests for success, package-failure abort, and duplicate username
- [ ] Manual: change username on an account with packages + an up-to-date community listing; confirm package names, commit message, listing name, and invocation URLs

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6ed468bc` · **Head:** `215c34ca`

**Classification:** extends — username change now rewrites and republishes saved packages (and may republish community listings).

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — username rename rewrites scope and publishes update commits |
| `app-ui` | surfaces | extends — account profile warns and reports package/community outcomes |
| `repo-sessions` | runtime | extends — sync/publish accept expected scope + commit message for rename commits |
| `community-listings` | assistant | composes — republish listings already on latest commit after rename |

### System map

Username save claims `users.username` first, then rewrites package scopes and republishes eligible community listings.

```mermaid
flowchart TD
  A["Account /profile.json<br/>POST username"] --> B["Claim users.username"]
  B --> C["updatePackagesForUsernameChange"]
  C --> D["Rewrite @old → @new<br/>full file tree"]
  D --> E["syncArtifactSourceSnapshot<br/>force publish + commit"]
  E --> F["refreshSavedPackageProjection<br/>best-effort"]
  F --> G{"Listing was on<br/>latest commit?"}
  G -->|yes| H["publishCommunityListing"]
  G -->|no| I["Leave listing pin"]
  C -.->|failure| J["Roll back username<br/>compensate packages"]

  style B fill:#f4c27a,stroke:#8a5a00,color:#000
  style D fill:#f4c27a,stroke:#8a5a00,color:#000
  style E fill:#f4c27a,stroke:#8a5a00,color:#000
  style H fill:#9fd89f,stroke:#2f6b2f,color:#000
  style A fill:#9fd89f,stroke:#2f6b2f,color:#000
```

**Legend:** green = composes · amber = extended by this PR

### Invariants

- Per-user isolation preserved: only the signed-in user’s packages/listings are rewritten.
- Username is claimed before package publishes; cascade failure rolls username back and compensates packages best-effort.
- Third-party packages that hard-code the old `@{username}` scope are not rewritten (called out in UI + docs).

### Docs

- `docs/use/packages.md` — username scope cascade
- `docs/use/community-packages.md` — auto-republish when listing was on latest

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a45134c-dabd-4981-900f-96093c1c28f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a45134c-dabd-4981-900f-96093c1c28f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Username changes now rewrite saved package scopes and references, refresh saved package content, and keep pinned community listings current.
  * Profile success messaging now includes package/community update counts and warnings; the UI explains that scope updates and community republishing will happen automatically.
  * Username updates are handled safely: if package updates fail, changes are not applied and an error is shown.
* **Documentation**
  * Expanded guidance on community listings and scoped package names, including what changes after a username update and what to update for third-party integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->