### PR TITLE
Add social proof quotes to home page

### DIFF
--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -63,6 +63,18 @@ const capabilityHighlights = [
 	},
 ] as const
 
+const socialProofQuotes = [
+	{
+		quote: 'Bro is building an ecosystem.',
+		name: 'Tejas Kumar',
+		detail: '@tejaskumar_',
+	},
+	{
+		quote: 'Pretty awesome.',
+		name: 'Josh Tomaino',
+	},
+] as const
+
 function isHomePath(href: string) {
 	return new URL(href, 'http://localhost').pathname === '/'
 }
@@ -181,6 +193,15 @@ export function HomeRoute(handle: Handle) {
 					</div>
 				</section>
 
+				<section aria-labelledby="social-proof-title" mix={css(sectionCss)}>
+					<h2 id="social-proof-title" mix={css(socialProofTitleCss)}>
+						From Kody users
+					</h2>
+					<div mix={css(socialProofGridCss)}>
+						{socialProofQuotes.map((quote) => renderSocialProofQuote(quote))}
+					</div>
+				</section>
+
 				<section mix={css(sectionCss)}>
 					<div mix={css(sectionHeaderCss)}>
 						<h2 mix={css(sectionTitleCss)}>How it works</h2>
@@ -224,6 +245,26 @@ function renderCommandPill(label: string) {
 		<div mix={css(commandPillCss)}>
 			<code>{label}</code>
 		</div>
+	)
+}
+
+function renderSocialProofQuote({
+	quote,
+	name,
+	detail,
+}: {
+	quote: string
+	name: string
+	detail?: string
+}) {
+	return (
+		<blockquote mix={css(socialProofQuoteCss)}>
+			<p mix={css(socialProofQuoteTextCss)}>&ldquo;{quote}&rdquo;</p>
+			<footer mix={css(socialProofAttributionCss)}>
+				<cite mix={css(socialProofNameCss)}>{name}</cite>
+				{detail ? <span>{detail}</span> : null}
+			</footer>
+		</blockquote>
 	)
 }
 
@@ -384,6 +425,63 @@ const sectionDescriptionCss = {
 	margin: 0,
 	color: colors.textMuted,
 	lineHeight: 1.6,
+}
+
+const socialProofTitleCss = {
+	margin: 0,
+	color: colors.textMuted,
+	fontSize: typography.fontSize.sm,
+	fontWeight: typography.fontWeight.semibold,
+	letterSpacing: '0.08em',
+	textTransform: 'uppercase' as const,
+}
+
+const socialProofGridCss = {
+	display: 'grid',
+	gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+	gap: spacing.xl,
+	width: '100%',
+	[mq.tablet]: {
+		gridTemplateColumns: '1fr',
+	},
+}
+
+const socialProofQuoteCss = {
+	display: 'grid',
+	gap: spacing.md,
+	alignContent: 'space-between',
+	margin: 0,
+	padding: `${spacing.lg} ${spacing.xl}`,
+	borderLeft: `3px solid ${colors.primary}`,
+	borderRadius: radius.md,
+	backgroundColor: colors.primarySoftest,
+	textAlign: 'left' as const,
+	[mq.mobile]: {
+		padding: spacing.lg,
+	},
+}
+
+const socialProofQuoteTextCss = {
+	margin: 0,
+	color: colors.text,
+	fontSize: typography.fontSize.lg,
+	fontWeight: typography.fontWeight.medium,
+	lineHeight: 1.5,
+}
+
+const socialProofAttributionCss = {
+	display: 'flex',
+	flexWrap: 'wrap' as const,
+	gap: spacing.xs,
+	margin: 0,
+	color: colors.textMuted,
+	fontSize: typography.fontSize.sm,
+}
+
+const socialProofNameCss = {
+	color: colors.text,
+	fontStyle: 'normal',
+	fontWeight: typography.fontWeight.semibold,
 }
 
 const stepGridCss = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a compact social-proof section below the home-page hero
- attribute the two recorded first-run quotes to Tejas Kumar and Josh Tomaino
- preserve the existing home-page positioning copy

## Testing
- full validation pending

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `07e85d84` · **Head:** `74405727`

**Classification:** extends — this PR changes the home-page presentation within the existing browser app; it adds no new system primitives or cross-system behavior.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — adds an attributed social-proof section to the public home route |

### Before / after

| Before | After |
| --- | --- |
| Home page moves directly from the hero to product explanation | Two compact, responsive user quotes provide social proof between the hero and product explanation |

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc352770-d4a1-4e7f-ad17-4d7e27fc37d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc352770-d4a1-4e7f-ad17-4d7e27fc37d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

