### PR TITLE
Make passkeys distinguishable with labels and rename

### DIFF
--- a/e2e/passkeys.spec.ts
+++ b/e2e/passkeys.spec.ts
@@ -51,6 +51,18 @@ test('passkey lifecycle: register, sign in, delete', async ({
 	await expect(
 		page.getByRole('heading', { name: 'Registered passkeys' }),
 	).toBeVisible()
+	const passkeyList = page.getByRole('list').filter({
+		has: page.getByRole('button', { name: 'Rename' }),
+	})
+	await expect(passkeyList.getByText(/Created /)).toBeVisible()
+	await expect(passkeyList.getByText('Last used Never')).toBeVisible()
+
+	// Rename so multiple passkeys stay distinguishable.
+	await page.getByRole('button', { name: 'Rename' }).click()
+	await page.getByLabel('Passkey nickname').fill('Josh phone')
+	await page.getByRole('button', { name: 'Save' }).click()
+	await expect(page.getByText('Passkey renamed.')).toBeVisible()
+	await expect(passkeyList.getByText('Josh phone')).toBeVisible()
 
 	// Sign in with the passkey instead of the password.
 	await page.context().clearCookies()
@@ -62,6 +74,9 @@ test('passkey lifecycle: register, sign in, delete', async ({
 
 	// Delete the passkey.
 	await page.goto(localhostUrl(baseURL, '/account/passkeys'))
+	await expect(passkeyList.getByText('Josh phone')).toBeVisible()
+	await expect(passkeyList.getByText(/Last used /)).toBeVisible()
+	await expect(passkeyList.getByText('Last used Never')).toHaveCount(0)
 	await page.getByRole('button', { name: 'Delete' }).click()
 	await expect(page.getByText('Passkey deleted.')).toBeVisible()
 	await expect(

--- a/packages/worker/client/routes/account-passkeys.tsx
+++ b/packages/worker/client/routes/account-passkeys.tsx
@@ -1,4 +1,7 @@
-import { formatTimestamp } from '#client/format-timestamp.ts'
+import {
+	formatNullableTimestamp,
+	formatTimestamp,
+} from '#client/format-timestamp.ts'
 import { startRegistration } from '@simplewebauthn/browser'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
@@ -26,15 +29,19 @@ import {
 	descriptionCss,
 	getDangerButtonCss,
 	getPrimaryButtonCss,
+	getSecondaryButtonCss,
+	inputCss,
 	layoutMaxWidths,
 	primaryLinkCss,
 } from '#client/styles/style-primitives.ts'
 
 type PasskeyListItem = {
 	id: string
+	name: string
 	deviceType: string
 	backedUp: boolean
 	createdAt: string
+	lastUsedAt: string | null
 }
 
 type AccountPasskeysPayload = {
@@ -81,6 +88,8 @@ export function AccountPasskeysRoute(handle: Handle) {
 	let passkeys: Array<PasskeyListItem> = []
 	let message: string | null = null
 	let messageTone: 'error' | 'info' = 'info'
+	let renamingPasskeyId: string | null = null
+	let renameDraft = ''
 	const loadLatch = createRouteLoadLatch()
 
 	async function loadPasskeys(signal: AbortSignal) {
@@ -201,6 +210,63 @@ export function AccountPasskeysRoute(handle: Handle) {
 		}
 	}
 
+	function beginRename(passkey: PasskeyListItem) {
+		renamingPasskeyId = passkey.id
+		renameDraft = passkey.name
+		message = null
+		handle.update()
+	}
+
+	function cancelRename() {
+		renamingPasskeyId = null
+		renameDraft = ''
+		handle.update()
+	}
+
+	async function handleRenamePasskey(passkeyId: string) {
+		actionStatus = 'busy'
+		message = null
+		handle.update()
+
+		try {
+			const response = await fetch(passkeysApiPath, {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				credentials: 'include',
+				body: JSON.stringify({
+					intent: 'rename',
+					passkeyId,
+					name: renameDraft,
+				}),
+			})
+			if (response.status === 401) {
+				window.location.assign('/login')
+				return
+			}
+			const payload = await readJson<
+				AccountPasskeysPayload & { error?: string }
+			>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error(payload?.error || 'Unable to rename the passkey.')
+			}
+			passkeys = payload.passkeys
+			renamingPasskeyId = null
+			renameDraft = ''
+			message = 'Passkey renamed.'
+			messageTone = 'info'
+		} catch (error) {
+			message =
+				error instanceof Error ? error.message : 'Unable to rename the passkey.'
+			messageTone = 'error'
+		} finally {
+			actionStatus = 'idle'
+			handle.update()
+		}
+	}
+
 	async function handleDeletePasskey(passkeyId: string) {
 		actionStatus = 'busy'
 		message = null
@@ -227,6 +293,10 @@ export function AccountPasskeysRoute(handle: Handle) {
 				throw new Error(payload?.error || 'Unable to delete the passkey.')
 			}
 			passkeys = payload.passkeys
+			if (renamingPasskeyId === passkeyId) {
+				renamingPasskeyId = null
+				renameDraft = ''
+			}
 			message = 'Passkey deleted.'
 			messageTone = 'info'
 		} catch (error) {
@@ -329,49 +399,160 @@ export function AccountPasskeysRoute(handle: Handle) {
 										gap: spacing.md,
 									})}
 								>
-									{passkeys.map((passkey) => (
-										<li
-											key={passkey.id}
-											mix={css({
-												display: 'flex',
-												justifyContent: 'space-between',
-												alignItems: 'center',
-												gap: spacing.md,
-												flexWrap: 'wrap',
-												paddingBottom: spacing.md,
-												borderBottom: `1px solid ${colors.border}`,
-											})}
-										>
-											<div mix={css({ display: 'grid', gap: spacing.xs })}>
-												<span
-													mix={css({
-														fontWeight: typography.fontWeight.medium,
-														color: colors.text,
-													})}
-												>
-													{describeDeviceType(passkey.deviceType)}
-												</span>
-												<span
-													mix={css({
-														color: colors.textMuted,
-														fontSize: typography.fontSize.sm,
-													})}
-												>
-													Registered {formatTimestamp(passkey.createdAt)}
-												</span>
-											</div>
-											<button
-												type="button"
-												disabled={isBusy}
-												mix={[
-													css(dangerButtonCss),
-													on('click', () => handleDeletePasskey(passkey.id)),
-												]}
+									{passkeys.map((passkey) => {
+										const isRenaming = renamingPasskeyId === passkey.id
+										return (
+											<li
+												key={passkey.id}
+												mix={css({
+													display: 'flex',
+													justifyContent: 'space-between',
+													alignItems: 'flex-start',
+													gap: spacing.md,
+													flexWrap: 'wrap',
+													paddingBottom: spacing.md,
+													borderBottom: `1px solid ${colors.border}`,
+												})}
 											>
-												Delete
-											</button>
-										</li>
-									))}
+												<div
+													mix={css({
+														display: 'grid',
+														gap: spacing.xs,
+														flex: '1 1 16rem',
+														minWidth: 0,
+													})}
+												>
+													{isRenaming ? (
+														<label
+															mix={css({
+																display: 'grid',
+																gap: spacing.xs,
+															})}
+														>
+															<span
+																mix={css({
+																	fontSize: typography.fontSize.sm,
+																	color: colors.textMuted,
+																})}
+															>
+																Nickname
+															</span>
+															<input
+																type="text"
+																value={renameDraft}
+																maxLength={80}
+																disabled={isBusy}
+																aria-label="Passkey nickname"
+																mix={[
+																	css(inputCss),
+																	on('input', (event) => {
+																		renameDraft = (
+																			event.currentTarget as HTMLInputElement
+																		).value
+																		handle.update()
+																	}),
+																]}
+															/>
+														</label>
+													) : (
+														<span
+															mix={css({
+																fontWeight: typography.fontWeight.medium,
+																color: colors.text,
+															})}
+														>
+															{passkey.name}
+														</span>
+													)}
+													<span
+														mix={css({
+															color: colors.textMuted,
+															fontSize: typography.fontSize.sm,
+														})}
+													>
+														{describeDeviceType(passkey.deviceType)}
+													</span>
+													<span
+														mix={css({
+															color: colors.textMuted,
+															fontSize: typography.fontSize.sm,
+														})}
+													>
+														Created {formatTimestamp(passkey.createdAt)}
+													</span>
+													<span
+														mix={css({
+															color: colors.textMuted,
+															fontSize: typography.fontSize.sm,
+														})}
+													>
+														Last used{' '}
+														{formatNullableTimestamp(
+															passkey.lastUsedAt,
+															'Never',
+														)}
+													</span>
+												</div>
+												<div
+													mix={css({
+														display: 'flex',
+														gap: spacing.sm,
+														flexWrap: 'wrap',
+													})}
+												>
+													{isRenaming ? (
+														<>
+															<button
+																type="button"
+																disabled={isBusy}
+																mix={[
+																	css(primaryButtonCss),
+																	on('click', () =>
+																		handleRenamePasskey(passkey.id),
+																	),
+																]}
+															>
+																Save
+															</button>
+															<button
+																type="button"
+																disabled={isBusy}
+																mix={[
+																	css(secondaryButtonCss),
+																	on('click', cancelRename),
+																]}
+															>
+																Cancel
+															</button>
+														</>
+													) : (
+														<button
+															type="button"
+															disabled={isBusy}
+															mix={[
+																css(secondaryButtonCss),
+																on('click', () => beginRename(passkey)),
+															]}
+														>
+															Rename
+														</button>
+													)}
+													<button
+														type="button"
+														disabled={isBusy}
+														mix={[
+															css(dangerButtonCss),
+															on('click', () =>
+																handleDeletePasskey(passkey.id),
+															),
+														]}
+													>
+														Delete
+													</button>
+												</div>
+											</li>
+										)
+									})}
 								</ul>
 							</section>
 						)}
@@ -389,4 +570,5 @@ export function AccountPasskeysRoute(handle: Handle) {
 }
 
 const primaryButtonCss = getPrimaryButtonCss()
+const secondaryButtonCss = getSecondaryButtonCss()
 const dangerButtonCss = getDangerButtonCss()

--- a/packages/worker/migrations/0071-passkey-labels.sql
+++ b/packages/worker/migrations/0071-passkey-labels.sql
@@ -1,0 +1,3 @@
+-- Editable nickname plus last-used timestamp so users can tell passkeys apart.
+ALTER TABLE passkeys ADD COLUMN name TEXT NOT NULL DEFAULT '';
+ALTER TABLE passkeys ADD COLUMN last_used_at TEXT;

--- a/packages/worker/src/app/handlers/account-passkeys.ts
+++ b/packages/worker/src/app/handlers/account-passkeys.ts
@@ -1,6 +1,6 @@
 import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
-import { object, parseSafe, string } from 'remix/data-schema'
+import { enum_, object, optional, parseSafe, string } from 'remix/data-schema'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
 import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
@@ -8,7 +8,16 @@ import {
 	redirectToLogin,
 	redirectToLoginWhenUnauthenticated,
 } from '#app/auth-redirect.ts'
-import { deletePasskeyForUser, listPasskeysForUser } from '#app/passkeys.ts'
+import {
+	buildDefaultPasskeyName,
+	validatePasskeyName,
+} from '#app/passkey-label.ts'
+import {
+	deletePasskeyForUser,
+	listPasskeysForUser,
+	renamePasskeyForUser,
+	type PasskeyRow,
+} from '#app/passkeys.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 
@@ -35,9 +44,10 @@ export function createAccountPasskeysHandler(env: Env) {
 	} satisfies Action<typeof routes.accountPasskeys>
 }
 
-const deletePasskeySchema = object({
-	intent: string(),
+const passkeyActionSchema = object({
+	intent: enum_(['delete', 'rename'] as const),
 	passkeyId: string(),
+	name: optional(string()),
 })
 
 export function createAccountPasskeysApiHandler(env: Env) {
@@ -58,32 +68,85 @@ export function createAccountPasskeysApiHandler(env: Env) {
 			}
 
 			const body = await request.json().catch(() => null)
-			const parsed = parseSafe(deletePasskeySchema, body)
-			if (!parsed.success || parsed.value.intent !== 'delete') {
+			const parsed = parseSafe(passkeyActionSchema, body)
+			if (!parsed.success) {
 				return jsonResponse({ ok: false, error: 'Invalid request body.' }, 400)
 			}
 
 			const requestIp = getRequestIp(request) ?? undefined
-			const deleted = await deletePasskeyForUser(
-				env.APP_DB,
-				parsed.value.passkeyId,
-				user.userId,
-			)
-			if (!deleted) {
-				return jsonResponse({ ok: false, error: 'Passkey not found.' }, 404)
-			}
+			const intent = parsed.value.intent
 
-			void logAuditEvent({
-				category: 'account',
-				action: 'passkey_delete',
-				result: 'success',
-				email: user.email,
-				ip: requestIp,
-				path: url.pathname,
-			})
-			return jsonResponse(await loadPasskeysPayload(env.APP_DB, user.userId))
+			switch (intent) {
+				case 'delete': {
+					const deleted = await deletePasskeyForUser(
+						env.APP_DB,
+						parsed.value.passkeyId,
+						user.userId,
+					)
+					if (!deleted) {
+						return jsonResponse({ ok: false, error: 'Passkey not found.' }, 404)
+					}
+
+					void logAuditEvent({
+						category: 'account',
+						action: 'passkey_delete',
+						result: 'success',
+						email: user.email,
+						ip: requestIp,
+						path: url.pathname,
+					})
+					return jsonResponse(
+						await loadPasskeysPayload(env.APP_DB, user.userId),
+					)
+				}
+				case 'rename': {
+					const validated = validatePasskeyName(parsed.value.name)
+					if (!validated.ok) {
+						return jsonResponse({ ok: false, error: validated.error }, 400)
+					}
+
+					const renamed = await renamePasskeyForUser(
+						env.APP_DB,
+						parsed.value.passkeyId,
+						user.userId,
+						validated.name,
+					)
+					if (!renamed) {
+						return jsonResponse({ ok: false, error: 'Passkey not found.' }, 404)
+					}
+
+					void logAuditEvent({
+						category: 'account',
+						action: 'passkey_rename',
+						result: 'success',
+						email: user.email,
+						ip: requestIp,
+						path: url.pathname,
+					})
+					return jsonResponse(
+						await loadPasskeysPayload(env.APP_DB, user.userId),
+					)
+				}
+				default: {
+					const _exhaustive: never = intent
+					void _exhaustive
+					return jsonResponse(
+						{ ok: false, error: 'Invalid request body.' },
+						400,
+					)
+				}
+			}
 		},
 	} satisfies Action<typeof routes.accountPasskeysApi>
+}
+
+function displayPasskeyName(passkey: PasskeyRow) {
+	const stored = passkey.name.trim()
+	if (stored) return stored
+	return buildDefaultPasskeyName({
+		aaguid: passkey.aaguid,
+		deviceType: passkey.device_type,
+	})
 }
 
 async function loadPasskeysPayload(db: D1Database, userId: number) {
@@ -92,9 +155,11 @@ async function loadPasskeysPayload(db: D1Database, userId: number) {
 		ok: true,
 		passkeys: passkeys.map((passkey) => ({
 			id: passkey.id,
+			name: displayPasskeyName(passkey),
 			deviceType: passkey.device_type,
 			backedUp: passkey.backed_up === 1,
 			createdAt: passkey.created_at,
+			lastUsedAt: passkey.last_used_at,
 		})),
 	}
 }

--- a/packages/worker/src/app/handlers/passkeys.node.test.ts
+++ b/packages/worker/src/app/handlers/passkeys.node.test.ts
@@ -143,22 +143,38 @@ async function seedUser(
 
 function seedPasskey(
 	sqlite: DatabaseSync,
-	input: { id: string; userId: number },
+	input: {
+		id: string
+		userId: number
+		name?: string
+		aaguid?: string
+		lastUsedAt?: string | null
+	},
 ) {
+	const name = input.name ?? ''
+	const aaguid = input.aaguid ?? '00000000-0000-0000-0000-000000000000'
+	const lastUsedAt =
+		input.lastUsedAt === undefined
+			? 'NULL'
+			: input.lastUsedAt === null
+				? 'NULL'
+				: quoteSqlString(input.lastUsedAt)
 	sqlite.exec(`
 		INSERT INTO passkeys (
 			id, aaguid, public_key, user_id, webauthn_user_handle, counter,
-			device_type, backed_up, transports
+			device_type, backed_up, transports, name, last_used_at
 		) VALUES (
 			${quoteSqlString(input.id)},
-			'00000000-0000-0000-0000-000000000000',
+			${quoteSqlString(aaguid)},
 			'cHVibGljLWtleQ',
 			${input.userId},
 			'd2ViYXV0aG4tdXNlcg',
 			0,
 			'multiDevice',
 			1,
-			'internal'
+			'internal',
+			${quoteSqlString(name)},
+			${lastUsedAt}
 		);
 	`)
 }
@@ -197,13 +213,23 @@ const userOneSession: AuthSession = {
 	rememberMe: false,
 }
 
-test('account passkeys API lists owned keys and deletes them while ignoring other users', async () => {
+test('account passkeys API lists labels/dates, renames owned keys, and deletes while ignoring other users', async () => {
 	initTestSecrets()
 	const { sqlite, db } = createMigratedDb()
 	await seedUser(sqlite, { id: 1, email: 'one@example.com', username: 'one' })
 	await seedUser(sqlite, { id: 2, email: 'two@example.com', username: 'two' })
-	seedPasskey(sqlite, { id: 'passkey-user-1', userId: 1 })
-	seedPasskey(sqlite, { id: 'passkey-user-2', userId: 2 })
+	seedPasskey(sqlite, {
+		id: 'passkey-user-1',
+		userId: 1,
+		aaguid: 'ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4',
+		lastUsedAt: '2026-07-01 12:00:00',
+	})
+	seedPasskey(sqlite, {
+		id: 'passkey-user-1b',
+		userId: 1,
+		name: 'Work laptop',
+	})
+	seedPasskey(sqlite, { id: 'passkey-user-2', userId: 2, name: 'Other user' })
 
 	const handler = createAccountPasskeysApiHandler(createAppEnv(db))
 	const listResponse = await runHandler(
@@ -215,12 +241,97 @@ test('account passkeys API lists owned keys and deletes them while ignoring othe
 	expect(listResponse.status).toBe(200)
 	const listPayload = (await listResponse.json()) as {
 		ok: boolean
-		passkeys: Array<{ id: string }>
+		passkeys: Array<{
+			id: string
+			name: string
+			createdAt: string
+			lastUsedAt: string | null
+		}>
 	}
 	expect(listPayload.ok).toBe(true)
 	expect(listPayload.passkeys.map((passkey) => passkey.id)).toEqual([
+		'passkey-user-1b',
 		'passkey-user-1',
 	])
+	expect(listPayload.passkeys).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				id: 'passkey-user-1',
+				name: 'Google Password Manager',
+				lastUsedAt: '2026-07-01 12:00:00',
+			}),
+			expect.objectContaining({
+				id: 'passkey-user-1b',
+				name: 'Work laptop',
+				lastUsedAt: null,
+			}),
+		]),
+	)
+
+	const crossUserRename = await runHandler(
+		handler,
+		new Request('http://example.com/account/passkeys.json', {
+			method: 'POST',
+			headers: {
+				Cookie: await createAuthCookie(userOneSession, false),
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				intent: 'rename',
+				passkeyId: 'passkey-user-2',
+				name: 'Stolen name',
+			}),
+		}),
+	)
+	expect(crossUserRename.status).toBe(404)
+	expect(
+		sqlite
+			.prepare(`SELECT name FROM passkeys WHERE id = 'passkey-user-2'`)
+			.get(),
+	).toEqual({ name: 'Other user' })
+
+	const ownRename = await runHandler(
+		handler,
+		new Request('http://example.com/account/passkeys.json', {
+			method: 'POST',
+			headers: {
+				Cookie: await createAuthCookie(userOneSession, false),
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				intent: 'rename',
+				passkeyId: 'passkey-user-1',
+				name: '  Phone · Google  ',
+			}),
+		}),
+	)
+	expect(ownRename.status).toBe(200)
+	const renamePayload = (await ownRename.json()) as {
+		ok: boolean
+		passkeys: Array<{ id: string; name: string }>
+	}
+	expect(renamePayload.ok).toBe(true)
+	expect(
+		renamePayload.passkeys.find((passkey) => passkey.id === 'passkey-user-1')
+			?.name,
+	).toBe('Phone · Google')
+
+	const invalidRename = await runHandler(
+		handler,
+		new Request('http://example.com/account/passkeys.json', {
+			method: 'POST',
+			headers: {
+				Cookie: await createAuthCookie(userOneSession, false),
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				intent: 'rename',
+				passkeyId: 'passkey-user-1',
+				name: '   ',
+			}),
+		}),
+	)
+	expect(invalidRename.status).toBe(400)
 
 	const crossUserDelete = await runHandler(
 		handler,
@@ -236,7 +347,7 @@ test('account passkeys API lists owned keys and deletes them while ignoring othe
 	expect(crossUserDelete.status).toBe(404)
 	expect(
 		sqlite.prepare(`SELECT COUNT(*) AS count FROM passkeys`).get(),
-	).toEqual({ count: 2 })
+	).toEqual({ count: 3 })
 
 	const ownDelete = await runHandler(
 		handler,
@@ -250,7 +361,14 @@ test('account passkeys API lists owned keys and deletes them while ignoring othe
 		}),
 	)
 	expect(ownDelete.status).toBe(200)
-	expect(await ownDelete.json()).toEqual({ ok: true, passkeys: [] })
+	const deletePayload = (await ownDelete.json()) as {
+		ok: boolean
+		passkeys: Array<{ id: string }>
+	}
+	expect(deletePayload.ok).toBe(true)
+	expect(deletePayload.passkeys.map((passkey) => passkey.id)).toEqual([
+		'passkey-user-1b',
+	])
 })
 
 test('registration options require authentication and exclude existing credentials', async () => {

--- a/packages/worker/src/app/handlers/webauthn.ts
+++ b/packages/worker/src/app/handlers/webauthn.ts
@@ -16,6 +16,7 @@ import {
 	setAuthSessionSecret,
 } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { buildDefaultPasskeyName } from '#app/passkey-label.ts'
 import {
 	createPasskey,
 	findPasskeyById,
@@ -173,6 +174,11 @@ export function createWebauthnRegistrationHandler(env: Env) {
 				deviceType: credentialDeviceType,
 				backedUp: credentialBackedUp,
 				transports: credential.transports?.join(',') ?? null,
+				name: buildDefaultPasskeyName({
+					aaguid,
+					deviceType: credentialDeviceType,
+					userAgent: request.headers.get('user-agent'),
+				}),
 			})
 
 			void logAuditEvent({

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -464,9 +464,11 @@ export type AccountTwoFactorLoaderData = {
 
 export type AccountPasskeyListItem = {
 	id: string
+	name: string
 	deviceType: string
 	backedUp: boolean
 	createdAt: string
+	lastUsedAt: string | null
 }
 
 export type AccountPasskeysLoaderData = {

--- a/packages/worker/src/app/passkey-label.node.test.ts
+++ b/packages/worker/src/app/passkey-label.node.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from 'vitest'
+import {
+	buildDefaultPasskeyName,
+	getAuthenticatorName,
+	describeUserAgentPlatform,
+	validatePasskeyName,
+	passkeyNameMaxLength,
+} from './passkey-label.ts'
+
+test('getAuthenticatorName maps common providers and ignores anonymous AAGUIDs', () => {
+	expect(getAuthenticatorName('ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4')).toBe(
+		'Google Password Manager',
+	)
+	expect(getAuthenticatorName('BADA5566-A7AA-401F-BD96-45619A55120D')).toBe(
+		'1Password',
+	)
+	expect(getAuthenticatorName('fbfc3007-154e-4ecc-8c0b-6e020557d7bd')).toBe(
+		'Apple Passwords',
+	)
+	expect(getAuthenticatorName('2fc0579f-8113-47ea-b116-bb5a8db9202a')).toBe(
+		'YubiKey 5 NFC',
+	)
+	expect(getAuthenticatorName('00000000-0000-0000-0000-000000000000')).toBe(
+		undefined,
+	)
+	expect(getAuthenticatorName('not-a-real-aaguid')).toBe(undefined)
+	expect(getAuthenticatorName('toString')).toBe(undefined)
+})
+
+test('describeUserAgentPlatform extracts common platforms', () => {
+	expect(
+		describeUserAgentPlatform(
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+		),
+	).toBe('macOS')
+	expect(
+		describeUserAgentPlatform(
+			'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+		),
+	).toBe('iPhone')
+	expect(
+		describeUserAgentPlatform(
+			'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+		),
+	).toBe('Windows')
+	expect(
+		describeUserAgentPlatform(
+			'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
+		),
+	).toBe('Linux')
+	expect(describeUserAgentPlatform(null)).toBe(undefined)
+})
+
+test('buildDefaultPasskeyName prefers provider and includes platform when useful', () => {
+	expect(
+		buildDefaultPasskeyName({
+			aaguid: 'ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4',
+			deviceType: 'multiDevice',
+			userAgent:
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+		}),
+	).toBe('Google Password Manager · macOS')
+
+	expect(
+		buildDefaultPasskeyName({
+			aaguid: '00000000-0000-0000-0000-000000000000',
+			deviceType: 'multiDevice',
+			userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
+		}),
+	).toBe('Synced passkey · Linux')
+
+	expect(
+		buildDefaultPasskeyName({
+			aaguid: '00000000-0000-0000-0000-000000000000',
+			deviceType: 'singleDevice',
+			userAgent: null,
+		}),
+	).toBe('Device-bound passkey')
+})
+
+test('validatePasskeyName trims and enforces length', () => {
+	expect(validatePasskeyName('  Work laptop  ')).toEqual({
+		ok: true,
+		name: 'Work laptop',
+	})
+	expect(validatePasskeyName('')).toEqual({
+		ok: false,
+		error: 'Name is required.',
+	})
+	expect(validatePasskeyName('   ')).toEqual({
+		ok: false,
+		error: 'Name is required.',
+	})
+	expect(validatePasskeyName('x'.repeat(passkeyNameMaxLength + 1))).toEqual({
+		ok: false,
+		error: `Name must be ${passkeyNameMaxLength} characters or fewer.`,
+	})
+})

--- a/packages/worker/src/app/passkey-label.ts
+++ b/packages/worker/src/app/passkey-label.ts
@@ -1,0 +1,112 @@
+/**
+ * Best-effort map of common authenticator AAGUIDs to provider names for
+ * passkey management labels. Names mirror the community-maintained registry:
+ * https://github.com/passkeydeveloper/passkey-authenticator-aaguids
+ *
+ * Privacy-preserving platforms often report the all-zero AAGUID, so callers
+ * should fall back to user-agent platform info when lookup fails.
+ */
+const commonAuthenticatorNames: Record<string, string> = {
+	'ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4': 'Google Password Manager',
+	'adce0002-35bc-c60a-648b-0b25f1f05503': 'Chrome on Mac',
+	'fbfc3007-154e-4ecc-8c0b-6e020557d7bd': 'Apple Passwords',
+	'dd4ec289-e01d-41c9-bb89-70fa845d4bf2': 'iCloud Keychain (Managed)',
+	'08987058-cadc-4b81-b6e1-30de50dcbe96': 'Windows Hello',
+	'9ddd1817-af5a-4672-a2b9-3e3dd95000a9': 'Windows Hello',
+	'6028b017-b1d4-4c02-b4b3-afcdafc96bb2': 'Windows Hello',
+	'bada5566-a7aa-401f-bd96-45619a55120d': '1Password',
+	'd548826e-79b4-db40-a3d8-11116f7e8349': 'Bitwarden',
+	'531126d6-e717-415c-9320-3d9aa6981239': 'Dashlane',
+	'b78a0a55-6ef8-d246-a042-ba0f6d55050c': 'LastPass',
+	'b84e4048-15dc-4dd0-8640-f4f60813c8af': 'NordPass',
+	'50726f74-6f6e-5061-7373-50726f746f6e': 'Proton Pass',
+	'0ea242b4-43c4-4a1b-8b17-dd6d0b6baec6': 'Keeper',
+	'53414d53-554e-4700-0000-000000000000': 'Samsung Pass',
+	// Common YubiKey models from FIDO MDS / community lists.
+	'2fc0579f-8113-47ea-b116-bb5a8db9202a': 'YubiKey 5 NFC',
+	'ee882879-721c-4913-9775-3dfcce97072a': 'YubiKey 5 Series',
+	'fa2b99dc-9e39-4257-8f92-4a30d23c4118': 'YubiKey 5 NFC FIPS',
+	'cb69481e-8ff7-4039-93ec-0a2729a154a8': 'YubiKey 5C',
+	'c5ef55ff-ad9a-4b9f-b580-adebafe026d0': 'YubiKey 5 Series with Lightning',
+	'a02167b9-ae71-4d63-a93a-9f135338449c': 'YubiKey 5Ci',
+	'dd86a2da-86a0-4cbe-b462-4bd31f57bc6f': 'YubiKey Bio Series',
+	'73bb0cd4-e502-49b8-9c6f-b59445bf720b': 'YubiKey 5 FIPS Series',
+	'85203421-48f9-4355-9bc8-8a53846e54f2': 'YubiKey 5C NFC FIPS',
+	'c1f9a0bc-1dd2-404a-b27f-8e2907723133': 'YubiKey 5 NFC FIPS',
+}
+
+const anonymousAaguid = '00000000-0000-0000-0000-000000000000'
+
+export const passkeyNameMaxLength = 80
+
+export function getAuthenticatorName(
+	aaguid: string | null | undefined,
+): string | undefined {
+	const normalized = aaguid?.trim().toLowerCase()
+	if (!normalized || normalized === anonymousAaguid) return undefined
+	const name = Object.hasOwn(commonAuthenticatorNames, normalized)
+		? commonAuthenticatorNames[normalized]
+		: undefined
+	return typeof name === 'string' ? name : undefined
+}
+
+export function describeUserAgentPlatform(
+	userAgent: string | null | undefined,
+): string | undefined {
+	if (!userAgent) return undefined
+	const ua = userAgent
+	if (/iPhone/i.test(ua)) return 'iPhone'
+	if (/iPad/i.test(ua)) return 'iPad'
+	if (/Android/i.test(ua)) return 'Android'
+	if (/CrOS/i.test(ua)) return 'ChromeOS'
+	if (/Macintosh|Mac OS X/i.test(ua)) return 'macOS'
+	if (/Windows/i.test(ua)) return 'Windows'
+	if (/Linux/i.test(ua)) return 'Linux'
+	return undefined
+}
+
+function genericPasskeyLabel(deviceType: string | null | undefined) {
+	return deviceType === 'multiDevice'
+		? 'Synced passkey'
+		: 'Device-bound passkey'
+}
+
+/**
+ * Build a default nickname at registration time from authenticator AAGUID
+ * and/or the registering browser's platform.
+ */
+export function buildDefaultPasskeyName(input: {
+	aaguid: string | null | undefined
+	deviceType: string | null | undefined
+	userAgent?: string | null | undefined
+}): string {
+	const provider = getAuthenticatorName(input.aaguid)
+	const platform = describeUserAgentPlatform(input.userAgent)
+	if (provider && platform) return `${provider} · ${platform}`
+	if (provider) return provider
+	if (platform) return `${genericPasskeyLabel(input.deviceType)} · ${platform}`
+	return genericPasskeyLabel(input.deviceType)
+}
+
+export function normalizePasskeyName(value: string) {
+	return value.trim().replace(/\s+/g, ' ')
+}
+
+export function validatePasskeyName(
+	value: unknown,
+): { ok: true; name: string } | { ok: false; error: string } {
+	if (typeof value !== 'string') {
+		return { ok: false, error: 'Name is required.' }
+	}
+	const name = normalizePasskeyName(value)
+	if (name.length === 0) {
+		return { ok: false, error: 'Name is required.' }
+	}
+	if (name.length > passkeyNameMaxLength) {
+		return {
+			ok: false,
+			error: `Name must be ${passkeyNameMaxLength} characters or fewer.`,
+		}
+	}
+	return { ok: true, name }
+}

--- a/packages/worker/src/app/passkeys.ts
+++ b/packages/worker/src/app/passkeys.ts
@@ -8,14 +8,18 @@ export type PasskeyRow = {
 	device_type: string
 	backed_up: number
 	transports: string | null
+	name: string
 	created_at: string
+	last_used_at: string | null
 }
+
+const passkeySelectColumns = `id, aaguid, public_key, user_id, webauthn_user_handle, counter,
+				device_type, backed_up, transports, name, created_at, last_used_at`
 
 export async function listPasskeysForUser(db: D1Database, userId: number) {
 	const result = await db
 		.prepare(
-			`SELECT id, aaguid, public_key, user_id, webauthn_user_handle, counter,
-				device_type, backed_up, transports, created_at
+			`SELECT ${passkeySelectColumns}
 			 FROM passkeys
 			 WHERE user_id = ?
 			 ORDER BY created_at DESC, id DESC`,
@@ -28,8 +32,7 @@ export async function listPasskeysForUser(db: D1Database, userId: number) {
 export async function findPasskeyById(db: D1Database, id: string) {
 	return db
 		.prepare(
-			`SELECT id, aaguid, public_key, user_id, webauthn_user_handle, counter,
-				device_type, backed_up, transports, created_at
+			`SELECT ${passkeySelectColumns}
 			 FROM passkeys
 			 WHERE id = ?`,
 		)
@@ -49,14 +52,15 @@ export async function createPasskey(
 		deviceType: string
 		backedUp: boolean
 		transports: string | null
+		name: string
 	},
 ) {
 	await db
 		.prepare(
 			`INSERT INTO passkeys (
 				id, aaguid, public_key, user_id, webauthn_user_handle, counter,
-				device_type, backed_up, transports
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				device_type, backed_up, transports, name
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		)
 		.bind(
 			input.id,
@@ -68,6 +72,7 @@ export async function createPasskey(
 			input.deviceType,
 			input.backedUp ? 1 : 0,
 			input.transports,
+			input.name,
 		)
 		.run()
 }
@@ -79,10 +84,30 @@ export async function updatePasskeyCounter(
 ) {
 	await db
 		.prepare(
-			`UPDATE passkeys SET counter = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+			`UPDATE passkeys
+			 SET counter = ?, last_used_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+			 WHERE id = ?`,
 		)
 		.bind(counter, id)
 		.run()
+}
+
+/** Ownership is enforced in the WHERE clause: cross-user renames are no-ops. */
+export async function renamePasskeyForUser(
+	db: D1Database,
+	id: string,
+	userId: number,
+	name: string,
+) {
+	const result = await db
+		.prepare(
+			`UPDATE passkeys
+			 SET name = ?, updated_at = CURRENT_TIMESTAMP
+			 WHERE id = ? AND user_id = ?`,
+		)
+		.bind(name, id, userId)
+		.run()
+	return (result.meta?.changes ?? 0) > 0
 }
 
 /** Ownership is enforced in the WHERE clause: cross-user deletes are no-ops. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses user-testing feedback (Josh Tomaino): passkey labels were indistinguishable when multiple were registered. Registration now derives a helpful default nickname from authenticator AAGUID (common providers like Google Password Manager, Apple Passwords / iCloud Keychain, 1Password, YubiKey, etc.) and/or the registering browser platform, users can rename passkeys, and the list shows created + last-used dates.

## Changes

- Migration `0071-passkey-labels.sql`: `passkeys.name` and `passkeys.last_used_at`
- Default label at WebAuthn registration via AAGUID map + User-Agent platform
- `last_used_at` updated on successful passkey sign-in
- Account passkeys API `rename` intent (user-scoped) + management UI rename flow
- Unit + E2E coverage for labels, rename, and last-used

## Test plan

- [x] Unit: `passkey-label.node.test.ts`, expanded `passkeys.node.test.ts`
- [x] E2E: register → rename → sign in → last-used updates → delete
- [x] `npm run validate`
- [x] Squash-merged and production deploy succeeded

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/kody-passkey-labels-c200`

**Classification:** extends — passkey storage/API/UI contracts grow (`name`, `last_used_at`, rename) while keeping per-user ownership checks.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `d1-app-db` | storage | extends — `passkeys.name`, `passkeys.last_used_at` |
| `app-sessions` | auth | extends — registration labels, last-used on auth, rename API |
| `app-ui` | surfaces | extends — passkey list nickname + dates + rename |

### System map

Registration and management flow through WebAuthn handlers into D1, then the account passkeys UI.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	appSessions["app-sessions<br/>Browser sessions"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::extended
	appUi -->|"register / rename / list"| appSessions
	appSessions -->|"passkeys.name + last_used_at"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant UI as Account passkeys UI
	participant Reg as webauthn registration
	participant Auth as webauthn authentication
	participant API as passkeys.json
	participant DB as passkeys table
	UI->>Reg: register ceremony
	Reg->>DB: INSERT name from AAGUID/UA
	UI->>API: rename intent
	API->>DB: UPDATE name WHERE user_id
	UI->>Auth: sign in with passkey
	Auth->>DB: UPDATE last_used_at
	UI->>API: GET list
	API->>DB: SELECT name, created_at, last_used_at
```

### Before / after

| Area | Before | After |
| --- | --- | --- |
| List label | Generic synced/device-bound type | Provider/platform nickname (editable) |
| Dates | Created only | Created + last used |
| Rename | None | `intent: "rename"` + UI |

### Invariants

- Rename and delete remain scoped by `user_id` (cross-user ops stay no-ops / 404).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cef9c8ef-137c-4fd7-b40e-c124bcefcf06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cef9c8ef-137c-4fd7-b40e-c124bcefcf06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passkey nicknames with inline rename, save, and cancel controls.
  * Automatically assigns helpful default names when passkeys are registered.
  * Displays passkey creation dates and last-used information.
  * Records passkey usage and validates nickname formatting.

* **Bug Fixes**
  * Improved passkey management responses and ownership validation for rename and delete actions.

* **Tests**
  * Expanded coverage for passkey listing, renaming, deletion, labeling, and lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->