### PR TITLE
Add pre-setup discovery prompt for prospective users

### DIFF
--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -15,6 +15,8 @@ Read in order for a full tour, or jump to a topic.
 
 ## Guides
 
+- [What can Kody do?](./what-can-kody-do.md) — capability tour and discovery
+  prompt for people (and agents) deciding whether Kody fits, before any setup
 - [Connect your agent](./connect-your-agent.md) — add `{origin}/mcp`, complete
   OAuth, and use the setup prompt
 - [First steps — what to ask Kody to do](./first-steps.md)
@@ -30,6 +32,8 @@ Read in order for a full tour, or jump to a topic.
 - [Repo-backed editing sessions](./repo-sessions.md)
 - [Raw MCP content blocks](./raw-content-blocks.md)
 - [Secrets, values, and host approval](./secrets-and-values.md)
+- [Email primitives](./email-primitives.md) — the per-user inbox, notify-self
+  sends, and replies
 - [Mutating actions and confirmations](./mutating-actions.md)
 - [Privacy](./privacy.md) — what Kody stores and what deployment admins can see
 - [Troubleshooting](./troubleshooting.md)

--- a/docs/use/what-can-kody-do.md
+++ b/docs/use/what-can-kody-do.md
@@ -1,0 +1,101 @@
+# What can Kody do?
+
+This page is a capability tour for people deciding whether Kody is worth setting
+up — and for AI agents running a discovery conversation on someone's behalf.
+Everything here is readable without a Kody account, and every link resolves on
+GitHub, so an agent that can fetch URLs can follow the trail before any MCP
+connection exists.
+
+## What Kody is
+
+Kody is an open-source personal assistant platform. You do not chat with Kody
+directly: you connect the AI agent you already use (Claude, ChatGPT, Cursor,
+Codex, or any other MCP-capable host) to your Kody account, and that agent gains
+durable capabilities that outlive the conversation and keep running while your
+computer is off. Kody makes no inference calls of its own — your agent supplies
+the intelligence; Kody supplies memory, credentials, saved code, schedules, and
+execution.
+
+## The building blocks
+
+- **Integrations and secrets** — bring your own API keys and OAuth apps for the
+  services you already use. Credentials stay server-side and never enter your
+  agent's context. See
+  [Secrets, values, and host approval](./secrets-and-values.md).
+- **Ad hoc execution** — your agent runs sandboxed code against those
+  integrations immediately, no deploy step. See
+  [Execute and workflows](./execute.md).
+- **Scheduled jobs** — recurring or one-off automations that run in the cloud on
+  Cloudflare Workers, whether or not any of your devices are on. Jobs are
+  covered in [Execute and workflows](./execute.md) and
+  [First steps](./first-steps.md).
+- **Packages** — reusable saved code your agent writes and improves over time.
+  Packages can expose exports, own scheduled jobs, run long-lived services, and
+  even serve a small web app UI. See [Packages](./packages.md).
+- **Workflows** — durable multi-step runs that survive restarts and can wait on
+  external events. See [Workflows](./workflows.md).
+- **A personal email inbox** — every user gets an address; inbound mail can
+  trigger automations, and your assistant can send you notifications. See
+  [Email primitives](./email-primitives.md).
+- **Long-term memory** — durable memories that surface across conversations and
+  across every agent connected to the same account. See
+  [Memory and conversation context](./memory.md).
+- **Community packages** — browse automations other people published, and fork
+  them into your own account with one click. See
+  [Community packages](./community-packages.md).
+- **Extensibility** — connect your own remote MCP servers, OpenAPI providers, or
+  a local-network connector so your agent can reach devices at home through
+  Kody.
+
+## What people use it for
+
+Concrete examples that combine the blocks:
+
+- A morning digest job that gathers your calendar, weather, and feeds, then
+  emails you a summary before you wake up.
+- A watcher that polls a website, feed, or price and emails you only when
+  something actually changes.
+- Chore automation against services you already use — triaging GitHub
+  notifications, filing issues, cleaning up cloud resources — using your own API
+  keys.
+- A personal API: a package export you can hit from shortcuts or webhooks to log
+  a habit, save a link, or kick off a run.
+- Home automation routines through a local-network connector — scenes,
+  thermostats, speakers — driven by schedule or by asking your agent.
+- Forking a community package (say, a YouTube video manager or an RSS digest)
+  and having your agent adapt it to your needs.
+
+## Running a discovery conversation
+
+If you are an agent helping someone figure out whether Kody fits their life,
+work through these steps:
+
+1. Skim the building blocks and follow any links you need more detail on. The
+   [usage index](./index.md) lists every page.
+2. Interview the person: which services and tools do they use daily, which
+   recurring chores do they do by hand, what have they wished happened
+   automatically, and what should keep running when their computer is off?
+3. Propose three to five specific opportunities, ranked by payoff versus setup
+   effort. For each one, name the Kody pieces involved (an integration, a job, a
+   package, the inbox) and the first concrete step.
+4. Be clear about prerequisites: using Kody requires an account, an MCP-capable
+   agent, and for third-party services, the person's own API keys or OAuth apps
+   ([connection guide](./connect-your-agent.md)).
+
+Nothing in this discovery flow requires an account or an MCP connection.
+
+## Try it
+
+Paste this into an agent that can fetch URLs or search the web:
+
+> I'm deciding whether Kody (https://github.com/kentcdodds/kody) would be useful
+> for me. Read
+> https://github.com/kentcdodds/kody/blob/main/docs/use/what-can-kody-do.md and
+> follow its links for anything you need more detail on. Then interview me about
+> the tools I use, recurring chores I do by hand, and automations I've wished
+> for. Finish with 3–5 specific things Kody could do for me, ranked by payoff
+> versus setup effort, each with a concrete first step. Don't set anything up
+> yet — this works before I have an account.
+
+When some of the proposals sound useful, the Get started page (`/onboarding`) on
+the deployment walks through connecting your agent.

--- a/docs/use/what-can-kody-do.md
+++ b/docs/use/what-can-kody-do.md
@@ -88,8 +88,7 @@ Nothing in this discovery flow requires an account or an MCP connection.
 
 Paste this into an agent that can fetch URLs or search the web:
 
-> I'm deciding whether Kody (https://github.com/kentcdodds/kody) would be useful
-> for me. Read
+> I'm deciding whether Kody (https://heykody.dev) would be useful for me. Read
 > https://github.com/kentcdodds/kody/blob/main/docs/use/what-can-kody-do.md and
 > follow its links for anything you need more detail on. Then interview me about
 > the tools I use, recurring chores I do by hand, and automations I've wished

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -179,6 +179,13 @@ export function HomeRoute(handle: Handle) {
 							</a>
 						)}
 					</div>
+					<p mix={css(discoveryHintCss)}>
+						Not sure what you&apos;d use it for?{' '}
+						<a href={`${onboardingPath}#discovery`} mix={css(discoveryLinkCss)}>
+							Ask your agent with the discovery prompt
+						</a>
+						— no account needed.
+					</p>
 				</section>
 
 				<section mix={css(sectionCss)}>
@@ -347,6 +354,16 @@ const heroTaglineCss = {
 	margin: 0,
 	color: colors.textMuted,
 	fontSize: typography.fontSize.base,
+}
+
+const discoveryHintCss = {
+	margin: 0,
+	color: colors.textMuted,
+	fontSize: typography.fontSize.sm,
+}
+
+const discoveryLinkCss = {
+	color: colors.primaryText,
 }
 
 const heroCtaCss = {

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -44,6 +44,7 @@ export type OnboardingPayload = {
 	loggedIn: boolean
 	mcpServerUrl: string
 	setupPrompt: string
+	discoveryPrompt: string
 	hasMcpClient: boolean
 	emailVerified: boolean
 	needsOnboarding: boolean
@@ -102,6 +103,7 @@ export function OnboardingRoute(handle: Handle) {
 	let loggedIn = false
 	let mcpServerUrl = ''
 	let setupPrompt = ''
+	let discoveryPrompt = ''
 	let hasMcpClient = false
 	let featuredListings: Array<OnboardingFeaturedListing> = []
 	const loadLatch = createRouteLoadLatch()
@@ -110,6 +112,7 @@ export function OnboardingRoute(handle: Handle) {
 		loggedIn = payload.loggedIn
 		mcpServerUrl = payload.mcpServerUrl
 		setupPrompt = payload.setupPrompt
+		discoveryPrompt = payload.discoveryPrompt
 		hasMcpClient = payload.hasMcpClient
 		featuredListings = payload.featuredListings ?? []
 		status = 'ready'
@@ -211,6 +214,28 @@ export function OnboardingRoute(handle: Handle) {
 								</p>
 							</section>
 						) : null}
+
+						<section
+							id="discovery"
+							mix={css(cardCss)}
+							data-testid="onboarding-discovery"
+						>
+							<h2 mix={css(cardTitleCss)}>
+								Not sure what you&apos;d use Kody for?
+							</h2>
+							<p mix={css(descriptionCss)}>
+								Paste this into any AI agent that can fetch a URL or search the
+								web — ChatGPT, Claude, or whatever you already use. It has the
+								agent read Kody&apos;s docs, interview you, and suggest concrete
+								automations. No account or setup needed yet.
+							</p>
+							<pre mix={css(codeBlockCss)}>{discoveryPrompt}</pre>
+							<CopyTextButton
+								value={discoveryPrompt}
+								idleLabel="Copy discovery prompt"
+								variant="secondary"
+							/>
+						</section>
 
 						<section mix={css(cardCss)}>
 							<h2 mix={css(cardTitleCss)}>1. Add Kody as an MCP server</h2>

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -5,7 +5,10 @@ import {
 	createOnboardingApiHandler,
 	createOnboardingHandler,
 } from '#app/handlers/onboarding.ts'
-import { buildOnboardingSetupPrompt } from '#app/onboarding-data.ts'
+import {
+	buildDiscoveryPrompt,
+	buildOnboardingSetupPrompt,
+} from '#app/onboarding-data.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -35,6 +38,7 @@ test('onboarding serves public setup content to anonymous visitors', async () =>
 		loggedIn: false,
 		mcpServerUrl: 'https://example.com/mcp',
 		setupPrompt: buildOnboardingSetupPrompt(),
+		discoveryPrompt: buildDiscoveryPrompt(),
 		hasMcpClient: false,
 		emailVerified: false,
 		needsOnboarding: true,

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -38,7 +38,10 @@ test('onboarding serves public setup content to anonymous visitors', async () =>
 		loggedIn: false,
 		mcpServerUrl: 'https://example.com/mcp',
 		setupPrompt: buildOnboardingSetupPrompt(),
-		discoveryPrompt: buildDiscoveryPrompt(),
+		discoveryPrompt: buildDiscoveryPrompt({
+			env,
+			requestUrl: 'https://example.com/onboarding.json',
+		}),
 		hasMcpClient: false,
 		emailVerified: false,
 		needsOnboarding: true,

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -472,6 +472,8 @@ export type OnboardingLoaderData = {
 	loggedIn: boolean
 	mcpServerUrl: string
 	setupPrompt: string
+	/** Pre-connection "is Kody for me?" prompt; usable in any tool-calling agent. */
+	discoveryPrompt: string
 	hasMcpClient: boolean
 	emailVerified: boolean
 	needsOnboarding: boolean

--- a/packages/worker/src/app/onboarding-data.node.test.ts
+++ b/packages/worker/src/app/onboarding-data.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest'
 import {
+	buildDiscoveryPrompt,
 	buildMcpServerUrl,
 	buildOnboardingSetupPrompt,
 	loadOnboardingData,
@@ -24,6 +25,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		loggedIn: false,
 		mcpServerUrl: 'https://heykody.dev/mcp',
 		setupPrompt: buildOnboardingSetupPrompt(),
+		discoveryPrompt: buildDiscoveryPrompt(),
 		hasMcpClient: false,
 		emailVerified: false,
 		needsOnboarding: true,
@@ -45,6 +47,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		loggedIn: true,
 		mcpServerUrl: 'https://heykody.dev/mcp',
 		setupPrompt: buildOnboardingSetupPrompt(),
+		discoveryPrompt: buildDiscoveryPrompt(),
 		hasMcpClient: false,
 		emailVerified: true,
 		needsOnboarding: true,
@@ -88,6 +91,8 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		needsOnboarding: true,
 		mcpServerUrl: '',
 		setupPrompt: '',
+		// Discovery needs no verified email or MCP host, so it is never gated.
+		discoveryPrompt: buildDiscoveryPrompt(),
 	})
 
 	const whenProviderListingFails = await loadOnboardingData({

--- a/packages/worker/src/app/onboarding-data.node.test.ts
+++ b/packages/worker/src/app/onboarding-data.node.test.ts
@@ -16,6 +16,15 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 	).toBe('https://preview.example/mcp')
 
 	expect(
+		buildDiscoveryPrompt({
+			env: {},
+			requestUrl: 'https://heykody.dev/onboarding',
+		}),
+	).toContain(
+		"I'm deciding whether Kody (https://heykody.dev) would be useful for me.",
+	)
+
+	expect(
 		loadPublicOnboardingData({
 			env: { APP_BASE_URL: 'https://heykody.dev' },
 			requestUrl: 'https://heykody.dev/onboarding',
@@ -25,7 +34,10 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		loggedIn: false,
 		mcpServerUrl: 'https://heykody.dev/mcp',
 		setupPrompt: buildOnboardingSetupPrompt(),
-		discoveryPrompt: buildDiscoveryPrompt(),
+		discoveryPrompt: buildDiscoveryPrompt({
+			env: { APP_BASE_URL: 'https://heykody.dev' },
+			requestUrl: 'https://heykody.dev/onboarding',
+		}),
 		hasMcpClient: false,
 		emailVerified: false,
 		needsOnboarding: true,
@@ -47,7 +59,10 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		loggedIn: true,
 		mcpServerUrl: 'https://heykody.dev/mcp',
 		setupPrompt: buildOnboardingSetupPrompt(),
-		discoveryPrompt: buildDiscoveryPrompt(),
+		discoveryPrompt: buildDiscoveryPrompt({
+			env: {},
+			requestUrl: 'https://heykody.dev/onboarding',
+		}),
 		hasMcpClient: false,
 		emailVerified: true,
 		needsOnboarding: true,
@@ -92,7 +107,10 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		mcpServerUrl: '',
 		setupPrompt: '',
 		// Discovery needs no verified email or MCP host, so it is never gated.
-		discoveryPrompt: buildDiscoveryPrompt(),
+		discoveryPrompt: buildDiscoveryPrompt({
+			env: {},
+			requestUrl: 'https://heykody.dev/onboarding',
+		}),
 	})
 
 	const whenProviderListingFails = await loadOnboardingData({

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -37,10 +37,18 @@ export function buildOnboardingSetupPrompt() {
  * Discovery prompt for people who have not connected (or signed up) yet. It
  * only assumes the agent can fetch a URL or search the web, and points at the
  * GitHub usage docs, which resolve without any Kody account or MCP session.
+ * The parenthetical identifies this deployment (heykody.dev in production).
  */
-export function buildDiscoveryPrompt() {
+export function buildDiscoveryPrompt(input: {
+	env: Pick<OnboardingEnv, 'APP_BASE_URL'>
+	requestUrl: string | URL
+}) {
+	const origin = getAppBaseUrl({
+		env: input.env,
+		requestUrl: input.requestUrl,
+	})
 	return [
-		"I'm deciding whether Kody (https://github.com/kentcdodds/kody) would be useful for me.",
+		`I'm deciding whether Kody (${origin}) would be useful for me.`,
 		'Read https://github.com/kentcdodds/kody/blob/main/docs/use/what-can-kody-do.md and follow its links for anything you need more detail on.',
 		"Then interview me about the tools I use, recurring chores I do by hand, and automations I've wished for.",
 		'Finish with 3-5 specific things Kody could do for me, ranked by payoff versus setup effort, each with a concrete first step.',
@@ -79,7 +87,10 @@ export function loadPublicOnboardingData(input: {
 			requestUrl: input.requestUrl,
 		}),
 		setupPrompt: buildOnboardingSetupPrompt(),
-		discoveryPrompt: buildDiscoveryPrompt(),
+		discoveryPrompt: buildDiscoveryPrompt({
+			env: input.env,
+			requestUrl: input.requestUrl,
+		}),
 		hasMcpClient: false,
 		emailVerified: false,
 		needsOnboarding: true,
@@ -122,7 +133,10 @@ export async function loadOnboardingData(input: {
 		setupPrompt,
 		// The discovery prompt needs no MCP connection or verified email, so it
 		// stays available even while setup fields are gated.
-		discoveryPrompt: buildDiscoveryPrompt(),
+		discoveryPrompt: buildDiscoveryPrompt({
+			env: input.env,
+			requestUrl: input.requestUrl,
+		}),
 		hasMcpClient,
 		emailVerified: input.emailVerified,
 		needsOnboarding,

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -34,6 +34,21 @@ export function buildOnboardingSetupPrompt() {
 }
 
 /**
+ * Discovery prompt for people who have not connected (or signed up) yet. It
+ * only assumes the agent can fetch a URL or search the web, and points at the
+ * GitHub usage docs, which resolve without any Kody account or MCP session.
+ */
+export function buildDiscoveryPrompt() {
+	return [
+		"I'm deciding whether Kody (https://github.com/kentcdodds/kody) would be useful for me.",
+		'Read https://github.com/kentcdodds/kody/blob/main/docs/use/what-can-kody-do.md and follow its links for anything you need more detail on.',
+		"Then interview me about the tools I use, recurring chores I do by hand, and automations I've wished for.",
+		'Finish with 3-5 specific things Kody could do for me, ranked by payoff versus setup effort, each with a concrete first step.',
+		"Don't set anything up yet — this works before I have an account.",
+	].join(' ')
+}
+
+/**
  * True when the user has at least one inbound MCP OAuth grant (an AI host
  * authorized against this account). Listing failures treat the user as still
  * needing onboarding so the banner stays available.
@@ -64,6 +79,7 @@ export function loadPublicOnboardingData(input: {
 			requestUrl: input.requestUrl,
 		}),
 		setupPrompt: buildOnboardingSetupPrompt(),
+		discoveryPrompt: buildDiscoveryPrompt(),
 		hasMcpClient: false,
 		emailVerified: false,
 		needsOnboarding: true,
@@ -104,6 +120,9 @@ export async function loadOnboardingData(input: {
 		loggedIn: true,
 		mcpServerUrl,
 		setupPrompt,
+		// The discovery prompt needs no MCP connection or verified email, so it
+		// stays available even while setup fields are gated.
+		discoveryPrompt: buildDiscoveryPrompt(),
 		hasMcpClient,
 		emailVerified: input.emailVerified,
 		needsOnboarding,

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -285,6 +285,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		loggedIn: true,
 		mcpServerUrl: '',
 		setupPrompt: '',
+		discoveryPrompt: expect.stringContaining('what-can-kody-do'),
 		hasMcpClient: false,
 		emailVerified: false,
 		needsOnboarding: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

People invited to try Kody often can't tell whether they have a use case — they don't know what Kody is capable of, and the existing onboarding setup prompt assumes they already want to connect an integration. This adds a discovery path that works **before** any account or MCP setup, from any tool-calling agent (ChatGPT, Claude Desktop, a phone), as long as it can fetch a URL or search the web. The prompt stays simple; the linked doc carries the detail.

## What

- **`docs/use/what-can-kody-do.md`** — outcome-oriented capability tour written for both humans and agents: what Kody is, the building blocks (with links into existing usage docs), concrete example use cases, and a "running a discovery conversation" section that tells an agent how to interview the person and propose ranked opportunities. Everything resolves on GitHub with no account.
- **`buildDiscoveryPrompt()`** in `onboarding-data.ts` — a short copyable prompt identifying Kody by the deployment origin (`https://heykody.dev` in production, via `getAppBaseUrl`), pointing the agent at that doc, and asking it to interview the user and propose 3–5 concrete automations ranked by payoff versus setup effort.
- **`/onboarding`** — new "Not sure what you'd use Kody for?" card (before step 1) with the prompt and a copy button. Served to logged-out visitors and never gated by email verification, since discovery needs no credentials.
- **Homepage hero** — a muted "Ask your agent with the discovery prompt" link to `/onboarding#discovery`.
- **`docs/use/index.md`** — links the new page, and adds the previously missing `email-primitives.md` entry.

## Testing

- `npm run validate` — all seven checks green (format, lint, typecheck, unit, Playwright E2E, MCP E2E, primitives).
- Unit tests cover the new `discoveryPrompt` payload field in public, verified, and unverified-gated loader states, plus the exact production-origin prompt string.
- Manual GUI walkthrough on the local dev server (logged out): homepage hint link → onboarding discovery card → copy button "Copied" feedback → rest of onboarding intact.

<a href="https://cursor.com/agents/bc-5e2a0a40-08d4-4521-b5f3-00282cc90f5b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdiscovery_prompt_home_link_and_onboarding_card_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-7ec654da-8355-4e01-9737-00e8e6c604ea" alt="discovery_prompt_home_link_and_onboarding_card_walkthrough.mp4" /></a>

![Onboarding discovery card](https://cursor.com/artifacts/c/art-c78de6c8-f551-4a07-9dc6-9ff50a63ba80)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/discovery-prompt-0f5b` @ `bd818aa7`

**Classification:** extends — the onboarding loader payload gains a `discoveryPrompt` field rendered by the onboarding and home routes; no new primitives.

### Primitives touched

| Primitive      | Group    | Impact                                                         |
| -------------- | -------- | -------------------------------------------------------------- |
| `app-ui`       | surfaces | extends — onboarding/home routes render the discovery prompt   |
| `app-sessions` | auth     | composes — onboarding data loader adds an ungated static field |

### System map

The discovery prompt flows from the onboarding data loader through the loader payload into the onboarding and home routes, and points readers at a new GitHub usage doc.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appSessions["app-sessions<br/>Browser sessions"]:::touched
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	docsUse["docs/use<br/>GitHub usage docs"]:::extended
	appSessions -->|"discoveryPrompt in onboarding payload"| appUi
	appUi -->|"prompt links what-can-kody-do.md"| docsUse
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e2a0a40-08d4-4521-b5f3-00282cc90f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e2a0a40-08d4-4521-b5f3-00282cc90f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “What can Kody do?” guide with capabilities, use cases, and a ready-to-use discovery prompt.
  * Added a discovery hint to the home page.
  * Added a discovery section to onboarding, including a prompt that can be copied.

* **Documentation**
  * Expanded the Guides table of contents with links to the new discovery guide and email primitives guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->