### PR TITLE
Split ChatGPT and Codex onboarding; fix ChatGPT setup path

### DIFF
--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -1,8 +1,8 @@
 # Connect your agent
 
-Kody is an MCP server. You use it from Cursor, Claude Desktop, Claude Code,
-Codex / ChatGPT, OpenCode, VS Code, or any other AI agent that supports MCP —
-not from a separate Kody chat app.
+Kody is an MCP server. You use it from Cursor, ChatGPT, Codex, Claude Desktop,
+Claude Code, OpenCode, VS Code, or any other AI agent that supports MCP — not
+from a separate Kody chat app.
 
 The in-app Get started page (`/onboarding`) has tabs with client-specific
 instructions and copyable config snippets for the host you are on.
@@ -30,9 +30,12 @@ MCP URL and setup prompt.
   Remote servers are not configured through `claude_desktop_config.json`.
 - **Claude Code** — `claude mcp add --transport http -s user kody <url>`, or a
   `.mcp.json` entry with `"type": "http"`.
-- **Codex / ChatGPT** — ChatGPT web uses Developer mode + a connector/app URL.
-  Codex (desktop, CLI, IDE) shares `~/.codex/config.toml` with an
-  `[mcp_servers.kody]` `url` entry.
+- **ChatGPT** — Turn on Developer mode (Settings → Security and login), then
+  create an app under Settings → Plugins → Browse plugins → Create app with the
+  MCP URL. Use the site favicon (`/apple-touch-icon.png`) for the app icon;
+  ChatGPT does not let you change the icon later.
+- **Codex** — Codex (ChatGPT desktop, CLI, IDE) shares `~/.codex/config.toml`
+  with an `[mcp_servers.kody]` `url` entry.
 - **OpenCode** — Add a `mcp.kody` remote entry in `opencode.json`
   (`"type": "remote"`).
 - **VS Code** — Use `.vscode/mcp.json` with root key `servers` (not

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -30,10 +30,14 @@ MCP URL and setup prompt.
   Remote servers are not configured through `claude_desktop_config.json`.
 - **Claude Code** — `claude mcp add --transport http -s user kody <url>`, or a
   `.mcp.json` entry with `"type": "http"`.
-- **ChatGPT** — Turn on Developer mode (Settings → Security and login), then
-  create an app under Settings → Plugins → Browse plugins → Create app with the
-  MCP URL. Use the site favicon (`/apple-touch-icon.png`) for the app icon;
-  ChatGPT does not let you change the icon later.
+- **ChatGPT** — On an
+  [eligible paid plan (Plus, Pro, Business, Enterprise, or Education)](https://developers.openai.com/api/docs/guides/developer-mode),
+  turn on Developer mode on the web (Settings → Security and login), then create
+  an app under Settings → Plugins → Browse plugins → Create app with the MCP
+  URL. In a managed workspace, ask an admin to enable access if the setting or
+  Plugins UI is missing. You can use the site favicon (`/apple-touch-icon.png`)
+  for the app icon; the owner can edit a developer-mode app's name and logo
+  later from Manage in Apps settings.
 - **Codex** — Codex (ChatGPT desktop, CLI, IDE) shares `~/.codex/config.toml`
   with an `[mcp_servers.kody]` `url` entry.
 - **OpenCode** — Add a `mcp.kody` remote entry in `opencode.json`

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -9,6 +9,7 @@ import {
 	buildKodyAppIconUrl,
 	buildOpenCodeMcpJson,
 	buildVsCodeMcpJson,
+	chatGptDeveloperModeGuideUrl,
 	codingAgentPackageHint,
 	type McpClientKind,
 	mcpClientTabs,
@@ -114,12 +115,23 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 				<>
 					<p mix={css(descriptionCss)}>
 						In ChatGPT, turn on <strong>Developer mode</strong> under Settings →
-						Security and login (reload ChatGPT if the Plugins UI does not appear
-						yet). Then open{' '}
+						Security and login. Developer mode is available on the web for{' '}
+						<a
+							href={chatGptDeveloperModeGuideUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							eligible paid plans (Plus, Pro, Business, Enterprise, and
+							Education)
+						</a>
+						. In a managed workspace, ask an admin to enable access if the
+						setting or Plugins UI is missing. Then open{' '}
 						<strong>Settings → Plugins → Browse plugins → Create app</strong>.
 						Paste the MCP URL below as the server URL. For the app icon,
-						download Kody&apos;s favicon from the link below — ChatGPT does not
-						let you change the icon later. Complete OAuth when prompted.
+						download Kody&apos;s favicon from the link below. Owners can edit a
+						developer-mode app&apos;s name and logo later from its{' '}
+						<strong>Manage</strong> menu in Apps settings. Complete OAuth when
+						prompted.
 					</p>
 					<CopyCard
 						label="MCP URL"

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -6,6 +6,7 @@ import {
 	buildClaudeCodeMcpJson,
 	buildCodexMcpToml,
 	buildCursorMcpJson,
+	buildKodyAppIconUrl,
 	buildOpenCodeMcpJson,
 	buildVsCodeMcpJson,
 	codingAgentPackageHint,
@@ -107,15 +108,18 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 				</>
 			)
 		}
-		case 'codex-chatgpt': {
-			const codexToml = buildCodexMcpToml(mcpServerUrl)
+		case 'chatgpt': {
+			const appIconUrl = buildKodyAppIconUrl(mcpServerUrl)
 			return (
 				<>
 					<p mix={css(descriptionCss)}>
-						<strong>ChatGPT (web)</strong>: turn on Developer mode under
-						Settings → Security and login, then create a developer-mode app /
-						connector pointed at the MCP URL below. Complete OAuth when
-						prompted.
+						In ChatGPT, turn on <strong>Developer mode</strong> under Settings →
+						Security and login (reload ChatGPT if the Plugins UI does not appear
+						yet). Then open{' '}
+						<strong>Settings → Plugins → Browse plugins → Create app</strong>.
+						Paste the MCP URL below as the server URL. For the app icon,
+						download Kody&apos;s favicon from the link below — ChatGPT does not
+						let you change the icon later. Complete OAuth when prompted.
 					</p>
 					<CopyCard
 						label="MCP URL"
@@ -123,18 +127,31 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						copyLabel="Copy MCP URL"
 						variant="primary"
 					/>
+					<CopyCard
+						label="App icon (favicon)"
+						value={appIconUrl}
+						copyLabel="Copy icon URL"
+					/>
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
+				</>
+			)
+		}
+		case 'codex': {
+			const codexToml = buildCodexMcpToml(mcpServerUrl)
+			return (
+				<>
 					<p mix={css(descriptionCss)}>
-						<strong>Codex</strong> (ChatGPT desktop, Codex CLI, and the IDE
-						extension) share <code>~/.codex/config.toml</code>. Add this
-						streamable HTTP entry, then run <code>codex mcp login kody</code> if
-						OAuth does not start automatically:
+						Codex (ChatGPT desktop, Codex CLI, and the IDE extension) shares{' '}
+						<code>~/.codex/config.toml</code>. Add this streamable HTTP entry,
+						then run <code>codex mcp login kody</code> if OAuth does not start
+						automatically:
 					</p>
 					<CopyCard
 						label="config.toml"
 						value={codexToml}
 						copyLabel="Copy TOML"
 					/>
+					<ClientNote>{codingAgentPackageHint}</ClientNote>
 				</>
 			)
 		}

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -4,6 +4,7 @@ import {
 	buildClaudeCodeMcpJson,
 	buildCodexMcpToml,
 	buildCursorMcpJson,
+	buildKodyAppIconUrl,
 	buildOpenCodeMcpJson,
 	buildVsCodeMcpJson,
 	mcpClientTabs,
@@ -14,7 +15,8 @@ const mcpServerUrl = 'https://heykody.dev/mcp'
 test('onboarding MCP client builders emit the structured configs each host expects', () => {
 	expect(mcpClientTabs.map((tab) => tab.id)).toEqual([
 		'cursor',
-		'codex-chatgpt',
+		'chatgpt',
+		'codex',
 		'claude-desktop',
 		'claude-code',
 		'opencode',
@@ -23,7 +25,7 @@ test('onboarding MCP client builders emit the structured configs each host expec
 	])
 	expect(
 		mcpClientTabs.filter((tab) => tab.isNonCodingAgent).map((tab) => tab.id),
-	).toEqual(['codex-chatgpt', 'claude-desktop'])
+	).toEqual(['chatgpt', 'claude-desktop'])
 
 	expect(JSON.parse(buildCursorMcpJson(mcpServerUrl))).toEqual({
 		mcpServers: {
@@ -62,5 +64,8 @@ test('onboarding MCP client builders emit the structured configs each host expec
 	})
 	expect(buildCodexMcpToml(mcpServerUrl)).toBe(
 		['[mcp_servers.kody]', `url = "${mcpServerUrl}"`, ''].join('\n'),
+	)
+	expect(buildKodyAppIconUrl(mcpServerUrl)).toBe(
+		'https://heykody.dev/apple-touch-icon.png',
 	)
 })

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -7,6 +7,7 @@ import {
 	buildKodyAppIconUrl,
 	buildOpenCodeMcpJson,
 	buildVsCodeMcpJson,
+	chatGptDeveloperModeGuideUrl,
 	mcpClientTabs,
 } from './onboarding-mcp-clients.ts'
 
@@ -67,5 +68,8 @@ test('onboarding MCP client builders emit the structured configs each host expec
 	)
 	expect(buildKodyAppIconUrl(mcpServerUrl)).toBe(
 		'https://heykody.dev/apple-touch-icon.png',
+	)
+	expect(chatGptDeveloperModeGuideUrl).toBe(
+		'https://developers.openai.com/api/docs/guides/developer-mode',
 	)
 })

--- a/packages/worker/client/routes/onboarding-mcp-clients.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.ts
@@ -31,6 +31,9 @@ export const mcpClientTabs = [
 	{ id: 'other', label: 'Other', isNonCodingAgent: false },
 ] as const satisfies ReadonlyArray<McpClientTab>
 
+export const chatGptDeveloperModeGuideUrl =
+	'https://developers.openai.com/api/docs/guides/developer-mode'
+
 /** Square favicon suitable for ChatGPT plugin / connector app icons. */
 export function buildKodyAppIconUrl(mcpServerUrl: string) {
 	return new URL('/apple-touch-icon.png', mcpServerUrl).href

--- a/packages/worker/client/routes/onboarding-mcp-clients.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.ts
@@ -5,7 +5,8 @@
 
 export type McpClientKind =
 	| 'cursor'
-	| 'codex-chatgpt'
+	| 'chatgpt'
+	| 'codex'
 	| 'claude-desktop'
 	| 'claude-code'
 	| 'opencode'
@@ -21,13 +22,19 @@ export type McpClientTab = {
 
 export const mcpClientTabs = [
 	{ id: 'cursor', label: 'Cursor', isNonCodingAgent: false },
-	{ id: 'codex-chatgpt', label: 'Codex / ChatGPT', isNonCodingAgent: true },
+	{ id: 'chatgpt', label: 'ChatGPT', isNonCodingAgent: true },
+	{ id: 'codex', label: 'Codex', isNonCodingAgent: false },
 	{ id: 'claude-desktop', label: 'Claude Desktop', isNonCodingAgent: true },
 	{ id: 'claude-code', label: 'Claude Code', isNonCodingAgent: false },
 	{ id: 'opencode', label: 'OpenCode', isNonCodingAgent: false },
 	{ id: 'vscode', label: 'VS Code', isNonCodingAgent: false },
 	{ id: 'other', label: 'Other', isNonCodingAgent: false },
 ] as const satisfies ReadonlyArray<McpClientTab>
+
+/** Square favicon suitable for ChatGPT plugin / connector app icons. */
+export function buildKodyAppIconUrl(mcpServerUrl: string) {
+	return new URL('/apple-touch-icon.png', mcpServerUrl).href
+}
 
 export const nonCodingAgentNote =
 	'Using Kody packages works great with non-coding agents. For creating or editing packages, a coding agent such as Cursor, Claude Code, Codex, VS Code, or OpenCode is usually smoother — those hosts can edit files and iterate on code more easily.'
@@ -91,7 +98,7 @@ export function buildOpenCodeMcpJson(mcpServerUrl: string) {
 	})
 }
 
-/** Codex / ChatGPT desktop shared `~/.codex/config.toml` streamable HTTP entry. */
+/** Codex shared `~/.codex/config.toml` streamable HTTP entry. */
 export function buildCodexMcpToml(mcpServerUrl: string) {
 	return [
 		'[mcp_servers.kody]',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

From Daniel Leal’s onboarding recording: ChatGPT setup instructions pointed people at the wrong create-app path and mixed Codex `config.toml` into the same tab. This splits **ChatGPT** and **Codex** into separate Get started tabs, updates ChatGPT to Settings → Plugins → Browse plugins → Create app, and adds a copyable site favicon URL (`/apple-touch-icon.png`).

The ChatGPT guidance now links OpenAI’s official developer-mode setup, identifies eligible paid plans and managed-workspace admin enablement, and explains that owners can edit a developer-mode app’s name and logo later from Manage in Apps settings. `docs/use/connect-your-agent.md` matches the route copy.

## Test plan

- [x] Focused onboarding client unit test
- [x] `npm run validate`
- [x] Local `/onboarding` spot-check: corrected ChatGPT copy/link/cards and separate Codex TOML tab
- [x] CI Validate, Cursor Bugbot, and CodeRabbit checks

## Walkthrough

![Corrected ChatGPT onboarding guidance](https://cursor.com/artifacts/c/art-c459fa15-e690-42f9-accf-3042e2cbd55c)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `218e7684` · **Head:** `8d12791a`

**Classification:** composes — onboarding copy, client-tab wiring, and documentation only; no primitive behavior or storage/API contracts change.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — separate ChatGPT/Codex setup and accurate developer-mode guidance |

### System map

The onboarding browser surface directs users to the appropriate ChatGPT or Codex configuration path without changing MCP authentication or runtime behavior.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
  openAi["OpenAI developer-mode guide"]:::untouched
  mcp["Kody /mcp endpoint"]:::untouched
  appUi -->|"eligibility and admin troubleshooting link"| openAi
  appUi -->|"ChatGPT app URL or Codex TOML"| mcp
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| ChatGPT and Codex shared one tab | Each client has its own setup tab |
| Missing Plugins UI suggested a reload | Copy identifies eligible plans and managed-workspace admin enablement |
| Icon warning said it could never be changed | Copy accurately says owners can edit developer-mode app name/logo from Manage |

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a48520b6-756a-4ad7-994d-bfef51667897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a48520b6-756a-4ad7-994d-bfef51667897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated onboarding to split the combined ChatGPT/Codex experience into separate “ChatGPT” and “Codex” tabs with tailored setup steps.
  * ChatGPT setup now includes the MCP server URL, a generated app icon link, and a developer-mode guide.
  * Codex setup now shows only the dedicated `config.toml` snippet entry.
* **Documentation**
  * Refreshed “Connect your agent” wording to describe ChatGPT and Codex separately with clearer client notes.
* **Tests**
  * Updated onboarding tests to validate the new tab list and the app icon/developer-mode URL outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->