### PR TITLE
Square onboarding starter cards with Choose your own adventure

### DIFF
--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -99,12 +99,14 @@ be effectively trusted before featuring; the effective `featured` flag
 (`featured_at IS NOT NULL AND trusted`) is computed in `repo.ts`, so an owner
 republish that drops trust also pulls the listing from onboarding while keeping
 the stored mark. `listFeaturedCommunityListings` feeds the onboarding page (slim
-`OnboardingFeaturedListing` shapes, capped at 6). Surfaces: the `Featured` badge
-on the detail page, the admin-only toggle
+`OnboardingFeaturedListing` shapes, capped at 12). Surfaces: the `Featured`
+badge on the detail page, the admin-only toggle
 (`POST /community/:listingId/feature.json`, audited), the admin-only
 `community_set_featured` capability, and the onboarding "Install a starter
-package" step (in-place Install on each starter card, then Copy prompt for agent
-setup). `community_get` exposes the effective `featured` flag.
+package" step (square-card grid with in-place Install, then Copy prompt for
+agent setup, plus a trailing Choose your own adventure card). `community_get`
+exposes the effective `featured` flag. Onboarding loads up to 12 featured
+listings.
 
 Reports survive listing deletion via denormalized listing name and owner on the
 report row.

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -119,12 +119,14 @@ Only after publish does the package become a live saved package in your account.
 ## One-click install
 
 Each listing detail page has an **Install** button for signed-in users. Featured
-starter packages on `/onboarding` also support one-click install without leaving
-the page: after install, **Copy prompt** gives your agent a short setup prompt.
-Install forks the listing into your account and, when the fork passes the same
-publish checks a repo session would run, publishes it immediately as a live
-saved package. **Publishing activates the package right away** — declared jobs
-are scheduled and `autoStart` services start.
+starter packages on `/onboarding` appear as a square-card grid with one-click
+install without leaving the page: after install, **Copy prompt** gives your
+agent a short setup prompt. A trailing **Choose your own adventure** card copies
+an open-ended setup prompt when you want to explore or build something custom
+instead. Install forks the listing into your account and, when the fork passes
+the same publish checks a repo session would run, publishes it immediately as a
+live saved package. **Publishing activates the package right away** — declared
+jobs are scheduled and `autoStart` services start.
 
 - **Untrusted listings** show a warning first: no admin has reviewed the code,
   and installing runs it in your account. You must explicitly confirm. Direct

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -45,11 +45,15 @@ and ChatGPT. For creating or editing packages, a coding agent (Cursor, Claude
 Code, Codex, VS Code, OpenCode, and similar) is usually smoother because those
 hosts can edit files and iterate on code more easily.
 
-## Ask your agent to help set up
+## Install a starter or build your own
 
-After the connection works, paste a short setup prompt into your agent (the Get
-started page has a copy button). Ask it to explain what Kody can do and help
-configure secrets, integrations, or packages you need.
+After the connection works, the Get started page offers admin-reviewed starter
+packages for one-click install. Each card can copy a short agent prompt for
+remaining setup. Prefer a starter when one is close to what you want.
+
+If nothing fits, use **Choose your own adventure** on that page to copy a prompt
+that asks your agent what Kody can do and helps you connect an integration and
+build something custom.
 
 ## Where to go next
 

--- a/e2e/community-featured.spec.ts
+++ b/e2e/community-featured.spec.ts
@@ -55,12 +55,12 @@ test('admins can feature trusted listings and members see them in onboarding', a
 	await expect(page.getByText('Fork with your agent')).toBeVisible()
 	await expect(page.getByTestId('community-admin-feature')).toHaveCount(0)
 
-	// Without any featured listings, onboarding falls back to the browse CTA.
+	// Without any featured listings, onboarding still shows the starter step
+	// with the Choose your own adventure card.
 	await page.goto('/onboarding')
-	await expect(
-		page.getByRole('heading', { name: 'Explore community packages' }),
-	).toBeVisible()
-	await expect(page.getByTestId('onboarding-starter-packages')).toHaveCount(0)
+	await expect(page.getByTestId('onboarding-starter-packages')).toBeVisible()
+	await expect(page.getByTestId('onboarding-diy-card')).toBeVisible()
+	await expect(page.getByTestId('onboarding-diy-copy')).toBeVisible()
 
 	// Admins can feature the trusted listing from the detail page.
 	await page.context().clearCookies()
@@ -121,6 +121,7 @@ test('admins can feature trusted listings and members see them in onboarding', a
 	const starterCard = page.getByTestId(`onboarding-starter-${trustedListingId}`)
 	await expect(starterCard).toBeVisible()
 	await expect(starterCard).toContainText(trustedListingName)
+	await expect(page.getByTestId('onboarding-diy-card')).toBeVisible()
 	await page
 		.getByTestId(`onboarding-starter-install-${trustedListingId}`)
 		.click()
@@ -136,7 +137,7 @@ test('admins can feature trusted listings and members see them in onboarding', a
 	await starterCard.getByRole('link', { name: trustedListingName }).click()
 	await expect(page).toHaveURL(new RegExp(`/community/${trustedListingId}$`))
 
-	// Removing the mark pulls the listing from onboarding again.
+	// Removing the mark pulls the listing from onboarding again; DIY remains.
 	await page.context().clearCookies()
 	await login({
 		email: adminUser.email,
@@ -152,8 +153,9 @@ test('admins can feature trusted listings and members see them in onboarding', a
 		0,
 	)
 	await page.goto('/onboarding')
+	await expect(page.getByTestId('onboarding-starter-packages')).toBeVisible()
 	await expect(
-		page.getByRole('heading', { name: 'Explore community packages' }),
-	).toBeVisible()
-	await expect(page.getByTestId('onboarding-starter-packages')).toHaveCount(0)
+		page.getByTestId(`onboarding-starter-${trustedListingId}`),
+	).toHaveCount(0)
+	await expect(page.getByTestId('onboarding-diy-card')).toBeVisible()
 })

--- a/packages/worker/client/routes/onboarding-diy-card.tsx
+++ b/packages/worker/client/routes/onboarding-diy-card.tsx
@@ -1,0 +1,178 @@
+import { type Handle, css } from 'remix/ui'
+import * as popover from 'remix/ui/popover'
+import { writeClipboardText } from '#client/clipboard.ts'
+import { on } from '#client/event-mixin.ts'
+import {
+	colors,
+	radius,
+	shadows,
+	spacing,
+	typography,
+} from '#client/styles/tokens.ts'
+import { getSecondaryButtonCss } from '#client/styles/style-primitives.ts'
+import {
+	starterCardCss,
+	starterCardItemCss,
+} from '#client/routes/onboarding-starter-card.tsx'
+
+type OnboardingDiyCardProps = {
+	setupPrompt: string
+}
+
+const copyPromptTooltip =
+	'Copies a prompt you can paste into your agent to explore what Kody can do and build something custom.'
+
+/**
+ * Trailing onboarding card: copy the open-ended setup prompt instead of
+ * installing a starter package ("choose your own adventure").
+ */
+export function OnboardingDiyCard(handle: Handle<OnboardingDiyCardProps>) {
+	let copyState: 'idle' | 'copied' | 'error' = 'idle'
+	let copyResetTimerId: ReturnType<typeof setTimeout> | null = null
+	let tooltipOpen = false
+
+	function openTooltip() {
+		tooltipOpen = true
+		handle.update()
+	}
+
+	function closeTooltip() {
+		tooltipOpen = false
+		handle.update()
+	}
+
+	async function copyPrompt() {
+		try {
+			await writeClipboardText(handle.props.setupPrompt)
+			copyState = 'copied'
+		} catch {
+			copyState = 'error'
+		}
+		handle.update()
+		if (copyResetTimerId != null) clearTimeout(copyResetTimerId)
+		copyResetTimerId = setTimeout(() => {
+			copyResetTimerId = null
+			if (handle.signal.aborted) return
+			copyState = 'idle'
+			handle.update()
+		}, 2000)
+	}
+
+	return () => (
+		<li mix={css(starterCardItemCss)}>
+			<div
+				mix={css({ ...starterCardCss, ...diyCardAccentCss })}
+				data-testid="onboarding-diy-card"
+			>
+				<div mix={css(diyBodyCss)}>
+					<span mix={css(diyEyebrowCss)}>Build it yourself</span>
+					<span mix={css(diyTitleCss)}>Choose your own adventure</span>
+					<span mix={css(diyDescriptionCss)}>
+						Skip the starters and ask your agent what Kody can do — connect an
+						integration, explore, and build something custom.
+					</span>
+				</div>
+				<div mix={css(diyActionsCss)}>
+					<popover.Context>
+						<button
+							type="button"
+							aria-describedby="onboarding-diy-prompt-tip"
+							disabled={!handle.props.setupPrompt}
+							mix={[
+								css(diyButtonCss),
+								popover.anchor({ placement: 'top' }),
+								popover.focusOnHide(),
+								on('click', () => void copyPrompt()),
+								on('pointerenter', openTooltip),
+								on('pointerleave', closeTooltip),
+								on('focus', openTooltip),
+								on('blur', closeTooltip),
+							]}
+							data-testid="onboarding-diy-copy"
+						>
+							{copyState === 'copied'
+								? 'Copied'
+								: copyState === 'error'
+									? 'Copy failed'
+									: 'Copy prompt'}
+						</button>
+						<div
+							id="onboarding-diy-prompt-tip"
+							role="tooltip"
+							mix={[
+								css(tooltipSurfaceCss),
+								popover.surface({
+									open: tooltipOpen,
+									closeOnAnchorClick: false,
+									onHide() {
+										closeTooltip()
+									},
+								}),
+							]}
+						>
+							{copyPromptTooltip}
+						</div>
+					</popover.Context>
+				</div>
+			</div>
+		</li>
+	)
+}
+
+const diyCardAccentCss = {
+	borderStyle: 'dashed' as const,
+	backgroundColor: colors.primarySoftest,
+}
+
+const diyBodyCss = {
+	display: 'flex',
+	flexDirection: 'column' as const,
+	alignItems: 'center',
+	gap: spacing.xs,
+	flex: 1,
+	textAlign: 'center' as const,
+}
+
+const diyEyebrowCss = {
+	fontSize: typography.fontSize.xs,
+	fontWeight: typography.fontWeight.medium,
+	color: colors.primary,
+	textTransform: 'uppercase' as const,
+	letterSpacing: '0.04em',
+}
+
+const diyTitleCss = {
+	fontWeight: typography.fontWeight.semibold,
+	color: colors.primaryText,
+	fontSize: typography.fontSize.sm,
+}
+
+const diyDescriptionCss = {
+	color: colors.textMuted,
+	fontSize: typography.fontSize.xs,
+	lineHeight: 1.4,
+}
+
+const diyActionsCss = {
+	marginTop: 'auto',
+	display: 'flex',
+	justifyContent: 'center',
+}
+
+const diyButtonCss = {
+	...getSecondaryButtonCss(),
+	width: '100%',
+	justifyContent: 'center',
+}
+
+const tooltipSurfaceCss = {
+	maxWidth: '16rem',
+	padding: `${spacing.xs} ${spacing.sm}`,
+	borderRadius: radius.md,
+	backgroundColor: colors.surface,
+	color: colors.text,
+	fontSize: typography.fontSize.sm,
+	lineHeight: 1.4,
+	boxShadow: shadows.md,
+	border: `1px solid ${colors.border}`,
+}

--- a/packages/worker/client/routes/onboarding-starter-card.tsx
+++ b/packages/worker/client/routes/onboarding-starter-card.tsx
@@ -8,6 +8,7 @@ import { on } from '#client/event-mixin.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
 	colors,
+	mq,
 	radius,
 	shadows,
 	spacing,
@@ -38,8 +39,8 @@ const copyPromptTooltip =
 	'Copies a short prompt you can paste into your agent to finish setup for this package.'
 
 /**
- * Featured onboarding starter: install in place, then copy the agent setup
- * prompt without leaving /onboarding.
+ * Featured onboarding starter: square card with in-place install, then copy
+ * the agent setup prompt without leaving /onboarding.
  */
 export function OnboardingStarterCard(
 	handle: Handle<OnboardingStarterCardProps>,
@@ -149,18 +150,18 @@ export function OnboardingStarterCard(
 		const detailHref = routes.communityDetail.href({ listingId: listing.id })
 
 		return (
-			<li>
+			<li mix={css(starterCardItemCss)}>
 				<div
 					mix={css(starterCardCss)}
 					data-testid={`onboarding-starter-${listing.id}`}
 				>
 					<a href={detailHref} mix={css(starterCardLinkCss)}>
-						<CommunityListingIcon listing={listing} size="card" />
-						<span mix={css(starterCardBodyCss)}>
-							<span mix={css(starterCardTitleCss)}>{listing.name}</span>
-							<span mix={css(starterCardDescriptionCss)}>
-								{listing.description}
-							</span>
+						<span mix={css(starterCardIconWrapCss)}>
+							<CommunityListingIcon listing={listing} size="card" />
+						</span>
+						<span mix={css(starterCardTitleCss)}>{listing.name}</span>
+						<span mix={css(starterCardDescriptionCss)}>
+							{listing.description}
 						</span>
 					</a>
 					<div mix={css(starterCardActionsCss)}>
@@ -170,7 +171,7 @@ export function OnboardingStarterCard(
 									type="button"
 									aria-describedby={`onboarding-starter-prompt-tip-${listing.id}`}
 									mix={[
-										css(getSecondaryButtonCss()),
+										css(actionButtonCss),
 										popover.anchor({ placement: 'top' }),
 										popover.focusOnHide(),
 										on('click', () => void copyPrompt()),
@@ -209,7 +210,7 @@ export function OnboardingStarterCard(
 								type="button"
 								disabled={phase === 'installing'}
 								mix={[
-									css(getPrimaryButtonCss()),
+									css(actionButtonPrimaryCss),
 									on('click', () => void submitInstall()),
 								]}
 								data-testid={`onboarding-starter-install-${listing.id}`}
@@ -242,59 +243,99 @@ export function OnboardingStarterCard(
 	}
 }
 
-const starterCardCss = {
+export const starterCardItemCss = {
+	display: 'flex',
+	flexDirection: 'column' as const,
+	minWidth: 0,
+}
+
+export const starterCardCss = {
 	...insetCardCss,
 	display: 'flex',
-	alignItems: 'center',
-	gap: '0.75rem',
+	flexDirection: 'column' as const,
+	alignItems: 'stretch',
+	gap: spacing.sm,
+	height: '100%',
+	minHeight: '14rem',
+	padding: spacing.md,
 	color: colors.text,
+	[mq.mobile]: {
+		minHeight: '12.5rem',
+	},
 }
 
 const starterCardLinkCss = {
 	display: 'flex',
+	flexDirection: 'column' as const,
 	alignItems: 'center',
-	gap: '0.75rem',
+	gap: spacing.xs,
 	flex: 1,
 	minWidth: 0,
+	textAlign: 'center' as const,
 	textDecoration: 'none',
 	color: 'inherit',
-	'&:hover span:first-of-type': {
+	'&:hover': {
 		color: colors.primary,
 	},
 }
 
-const starterCardBodyCss = {
+const starterCardIconWrapCss = {
 	display: 'flex',
-	flexDirection: 'column' as const,
-	gap: '0.25rem',
-	minWidth: 0,
+	justifyContent: 'center',
+	marginBottom: spacing.xs,
 }
 
 const starterCardTitleCss = {
 	fontWeight: typography.fontWeight.semibold,
 	color: colors.primaryText,
+	fontSize: typography.fontSize.sm,
 	overflowWrap: 'anywhere' as const,
+	display: '-webkit-box',
+	WebkitLineClamp: 2,
+	WebkitBoxOrient: 'vertical' as const,
+	overflow: 'hidden',
 }
 
 const starterCardDescriptionCss = {
 	color: colors.textMuted,
-	fontSize: typography.fontSize.sm,
+	fontSize: typography.fontSize.xs,
+	lineHeight: 1.4,
+	display: '-webkit-box',
+	WebkitLineClamp: 3,
+	WebkitBoxOrient: 'vertical' as const,
+	overflow: 'hidden',
 }
 
 const starterCardActionsCss = {
-	flexShrink: 0,
+	marginTop: 'auto',
+	display: 'flex',
+	justifyContent: 'center',
+}
+
+const actionButtonCss = {
+	...getSecondaryButtonCss(),
+	width: '100%',
+	justifyContent: 'center',
+}
+
+const actionButtonPrimaryCss = {
+	...getPrimaryButtonCss(),
+	width: '100%',
+	justifyContent: 'center',
 }
 
 const statusCss = {
 	margin: '0.35rem 0 0',
 	color: colors.textMuted,
-	fontSize: typography.fontSize.sm,
+	fontSize: typography.fontSize.xs,
+	textAlign: 'center' as const,
 }
 
 const errorCss = {
 	margin: '0.35rem 0 0',
 	color: colors.error,
-	fontSize: typography.fontSize.sm,
+	fontSize: typography.fontSize.xs,
+	textAlign: 'center' as const,
 }
 
 const tooltipSurfaceCss = {

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -21,18 +21,18 @@ import {
 } from '#client/routes/account-management-components.tsx'
 import { type OnboardingFeaturedListing } from '#app/community-public-types.ts'
 import { renderByokExplainer } from '#client/routes/byok-explainer.tsx'
+import { OnboardingDiyCard } from '#client/routes/onboarding-diy-card.tsx'
 import { OnboardingMcpClientTabs } from '#client/routes/onboarding-mcp-client-tabs.tsx'
 import { OnboardingStarterCard } from '#client/routes/onboarding-starter-card.tsx'
 import {
 	onboardingPath,
 	resolveOnboardingPendingVerificationPath,
 } from '#client/routes/onboarding-redirect.ts'
-import { colors, typography } from '#client/styles/tokens.ts'
+import { colors, mq, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
 	cardTitleCss,
 	descriptionCss,
-	getPrimaryButtonCss,
 	insetCardCss,
 	layoutMaxWidths,
 	mutedLinkCss,
@@ -248,65 +248,34 @@ export function OnboardingRoute(handle: Handle) {
 							<OnboardingMcpClientTabs mcpServerUrl={mcpServerUrl} />
 						</section>
 
-						<section mix={css(cardCss)}>
-							<h2 mix={css(cardTitleCss)}>2. Ask your agent to help set up</h2>
-							<p mix={css(descriptionCss)}>
-								After the connection succeeds, paste this prompt into your
-								agent. It asks the agent to explain what Kody can do and help
-								you configure the basics.
-							</p>
-							<pre mix={css(codeBlockCss)}>{setupPrompt}</pre>
-							<CopyTextButton
-								value={setupPrompt}
-								idleLabel="Copy prompt"
-								variant="secondary"
-							/>
-						</section>
-
 						{renderByokExplainer({ image: 'handoff' })}
 
-						{featuredListings.length > 0 ? (
-							<section
-								mix={css(cardCss)}
-								data-testid="onboarding-starter-packages"
-							>
-								<h2 mix={css(cardTitleCss)}>3. Install a starter package</h2>
-								<p mix={css(descriptionCss)}>
-									These packages were reviewed by an admin and support one-click
-									install here: they are copied into your account ready to run.
-									After install, use Copy prompt so your agent can finish any
-									remaining setup.
-								</p>
-								<ul mix={css(starterListCss)}>
-									{featuredListings.map((listing) => (
-										<OnboardingStarterCard
-											key={listing.id}
-											listing={listing}
-											loggedIn={loggedIn}
-										/>
-									))}
-								</ul>
-								<p mix={css({ margin: 0 })}>
-									<a href="/community" mix={css(primaryLinkCss)}>
-										Browse all community packages
-									</a>
-								</p>
-							</section>
-						) : (
-							<section mix={css(cardCss)}>
-								<h2 mix={css(cardTitleCss)}>3. Explore community packages</h2>
-								<p mix={css(descriptionCss)}>
-									See what other people have built with Kody — browse community
-									packages for ready-made automations you can fork into your own
-									account.
-								</p>
-								<div>
-									<a href="/community" mix={css(communityCtaCss)}>
-										Browse community packages
-									</a>
-								</div>
-							</section>
-						)}
+						<section
+							mix={css(cardCss)}
+							data-testid="onboarding-starter-packages"
+						>
+							<h2 mix={css(cardTitleCss)}>2. Install a starter package</h2>
+							<p mix={css(descriptionCss)}>
+								{featuredListings.length > 0
+									? 'These packages were reviewed by an admin and support one-click install here. After install, use Copy prompt so your agent can finish any remaining setup — or pick Choose your own adventure to explore with your agent instead.'
+									: 'No featured starters are available right now. Copy the Choose your own adventure prompt to explore with your agent, or browse community packages.'}
+							</p>
+							<ul mix={css(starterGridCss)}>
+								{featuredListings.map((listing) => (
+									<OnboardingStarterCard
+										key={listing.id}
+										listing={listing}
+										loggedIn={loggedIn}
+									/>
+								))}
+								<OnboardingDiyCard setupPrompt={setupPrompt} />
+							</ul>
+							<p mix={css({ margin: 0 })}>
+								<a href="/community" mix={css(primaryLinkCss)}>
+									Browse all community packages
+								</a>
+							</p>
+						</section>
 
 						<p mix={css({ margin: 0 })}>
 							{loggedIn ? (
@@ -352,17 +321,15 @@ const codeBlockCss = {
 	lineHeight: 1.6,
 }
 
-const communityCtaCss = {
-	...getPrimaryButtonCss(),
-	display: 'inline-flex',
-	textDecoration: 'none',
-}
-
-const starterListCss = {
-	display: 'flex',
-	flexDirection: 'column' as const,
-	gap: '0.75rem',
+const starterGridCss = {
+	display: 'grid',
+	gridTemplateColumns: 'repeat(auto-fill, minmax(10.5rem, 1fr))',
+	gap: spacing.md,
 	margin: 0,
 	padding: 0,
 	listStyle: 'none',
+	[mq.mobile]: {
+		gridTemplateColumns: 'repeat(auto-fill, minmax(9rem, 1fr))',
+		gap: spacing.sm,
+	},
 }

--- a/packages/worker/src/app/community-data.ts
+++ b/packages/worker/src/app/community-data.ts
@@ -27,7 +27,7 @@ import {
 import { getCommunityStar } from '#worker/community/social-repo.ts'
 
 const defaultCommunityListLimit = 50
-const onboardingFeaturedListingLimit = 6
+const onboardingFeaturedListingLimit = 12
 
 function isCommunityDataCacheEnabled(env: Env) {
 	const sentryEnv = (env as { SENTRY_ENVIRONMENT?: string }).SENTRY_ENVIRONMENT


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tightens the onboarding install step: denser square cards for featured packages, removes the separate setup-prompt step, and adds a trailing **Choose your own adventure** card that copies the open-ended agent prompt (what used to be step 2).

### Changes
- Starter packages render in a responsive square-card grid (Install → Installing → Copy prompt unchanged)
- Trailing DIY card copies `buildOnboardingSetupPrompt()` for custom exploration/build
- Featured listing cap raised from 6 → 12 so more starters fit
- Step numbering is now: 1) MCP connect, 2) Install a starter (or DIY)
- Docs + featured e2e updated (DIY always present)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `49680f32` · **Head:** `56345528`

**Classification:** composes — UI/layout and copy for onboarding starters; reuses existing install API and setup prompt.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — square starter grid + DIY copy-prompt card |

### System map

Onboarding step 2 focuses on starter install cards; DIY copies the former setup prompt.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	appUi -->|"featured grid + DIY card"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart TD
	mcp[1 Add MCP server]
	grid[2 Square starter card grid]
	install[Install featured package]
	diy[Choose your own adventure]
	prompt[Copy open-ended setup prompt]
	mcp --> grid
	grid --> install
	grid --> diy --> prompt
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd98354c-4759-423a-b37f-b2d95c193a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd98354c-4759-423a-b37f-b2d95c193a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a square-card grid for installing starter packages directly from onboarding.
  * Added “Copy prompt” actions for agent setup.
  * Added a “Choose your own adventure” card for custom integrations.
  * Increased the number of featured starter packages shown from 6 to 12.
* **Documentation**
  * Updated onboarding and agent connection guidance to reflect the new starter package and DIY setup experience.
* **Bug Fixes**
  * Improved onboarding behavior and layout across featured and non-featured package scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->