### PR TITLE
Tighten document-head managed tag contract

### DIFF
--- a/packages/worker/client/document-head.ts
+++ b/packages/worker/client/document-head.ts
@@ -54,7 +54,7 @@ function applyResolvedDocumentHead(resolved: ResolvedDocumentHead) {
 	// stale OG/canonical/RSS nodes that no longer apply.
 	removeManagedHeadNodes(head)
 
-	if (resolved.og && resolved.canonicalUrl) {
+	if (resolved.og) {
 		appendMeta(head, 'og:title', {
 			property: 'og:title',
 			content: resolved.og.title,
@@ -71,10 +71,12 @@ function applyResolvedDocumentHead(resolved: ResolvedDocumentHead) {
 			property: 'og:type',
 			content: 'website',
 		})
-		appendMeta(head, 'og:url', {
-			property: 'og:url',
-			content: resolved.canonicalUrl,
-		})
+		if (resolved.canonicalUrl) {
+			appendMeta(head, 'og:url', {
+				property: 'og:url',
+				content: resolved.canonicalUrl,
+			})
+		}
 		appendMeta(head, 'twitter:card', {
 			name: 'twitter:card',
 			content: 'summary_large_image',
@@ -91,6 +93,9 @@ function applyResolvedDocumentHead(resolved: ResolvedDocumentHead) {
 			name: 'twitter:image',
 			content: resolved.og.imageUrl,
 		})
+	}
+
+	if (resolved.canonicalUrl) {
 		appendLink(head, 'canonical', {
 			rel: 'canonical',
 			href: resolved.canonicalUrl,

--- a/packages/worker/src/app/ssr-document.tsx
+++ b/packages/worker/src/app/ssr-document.tsx
@@ -6,7 +6,10 @@ import {
 	buildClientEntryHref,
 	buildStylesheetHref,
 } from '#app/client-build-id.ts'
-import { type ResolvedDocumentHead } from '#app/document-head.ts'
+import {
+	DOCUMENT_HEAD_ATTR,
+	type ResolvedDocumentHead,
+} from '#app/document-head.ts'
 import { publicOgPages, type PublicOgPageId } from '#worker/og/pages.ts'
 
 export const CLIENT_ENTRY_HREF = '/client-entry.js'
@@ -20,6 +23,10 @@ export type SsrDocumentProps = AppRootProps & {
 	stylesheetHref?: string
 }
 
+function managedHeadAttr(value: string) {
+	return { [DOCUMENT_HEAD_ATTR]: value }
+}
+
 /**
  * Managed OG / Twitter / canonical tags. Marked with `data-kody-head` so the
  * client router can upsert or remove them on SPA navigations.
@@ -31,59 +38,63 @@ export function ManagedDocumentHead(
 		const { head } = handle.props
 		return (
 			<>
-				{head.og && head.canonicalUrl ? (
+				{head.og ? (
 					<>
 						<meta
 							property="og:title"
 							content={head.og.title}
-							data-kody-head="og:title"
+							{...managedHeadAttr('og:title')}
 						/>
 						<meta
 							property="og:description"
 							content={head.og.description}
-							data-kody-head="og:description"
+							{...managedHeadAttr('og:description')}
 						/>
 						<meta
 							property="og:image"
 							content={head.og.imageUrl}
-							data-kody-head="og:image"
+							{...managedHeadAttr('og:image')}
 						/>
 						<meta
 							property="og:type"
 							content="website"
-							data-kody-head="og:type"
+							{...managedHeadAttr('og:type')}
 						/>
-						<meta
-							property="og:url"
-							content={head.canonicalUrl}
-							data-kody-head="og:url"
-						/>
+						{head.canonicalUrl ? (
+							<meta
+								property="og:url"
+								content={head.canonicalUrl}
+								{...managedHeadAttr('og:url')}
+							/>
+						) : null}
 						<meta
 							name="twitter:card"
 							content="summary_large_image"
-							data-kody-head="twitter:card"
+							{...managedHeadAttr('twitter:card')}
 						/>
 						<meta
 							name="twitter:title"
 							content={head.og.title}
-							data-kody-head="twitter:title"
+							{...managedHeadAttr('twitter:title')}
 						/>
 						<meta
 							name="twitter:description"
 							content={head.og.description}
-							data-kody-head="twitter:description"
+							{...managedHeadAttr('twitter:description')}
 						/>
 						<meta
 							name="twitter:image"
 							content={head.og.imageUrl}
-							data-kody-head="twitter:image"
-						/>
-						<link
-							rel="canonical"
-							href={head.canonicalUrl}
-							data-kody-head="canonical"
+							{...managedHeadAttr('twitter:image')}
 						/>
 					</>
+				) : null}
+				{head.canonicalUrl ? (
+					<link
+						rel="canonical"
+						href={head.canonicalUrl}
+						{...managedHeadAttr('canonical')}
+					/>
 				) : null}
 				{(head.links ?? []).map((link, index) => (
 					<link
@@ -92,7 +103,7 @@ export function ManagedDocumentHead(
 						href={link.href}
 						type={link.type}
 						title={link.title}
-						data-kody-head={`link:${index}`}
+						{...managedHeadAttr(`link:${index}`)}
 					/>
 				))}
 			</>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #807 addressing CodeRabbit feedback:

- SSR managed tags use the shared `DOCUMENT_HEAD_ATTR` constant instead of a duplicated literal
- OG/Twitter tags and canonical links are applied independently on SSR and SPA paths

## Test plan

- [x] Pre-push hooks (typecheck/lint/e2e)
- [ ] CI validate

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `HEAD`

**Classification:** extends — small contract cleanup on the document-head apply path introduced in #807.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — managed head marker/constant + independent OG/canonical apply |

### System map

Keeps SSR and SPA document-head markers on one shared constant.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	appUi -->|"DOCUMENT_HEAD_ATTR shared marker"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b41fec6-8262-4bf6-a65c-53ba633b0612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b41fec6-8262-4bf6-a65c-53ba633b0612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Open Graph and Twitter metadata now renders even when no canonical URL is configured.
  - Canonical links are handled independently and appear whenever a canonical URL is available.
  - Improved consistency for managing generated document metadata and link tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->