### PR TITLE
Make onboarding responsive to MCP connection state

### DIFF
--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -209,52 +209,57 @@ export function OnboardingRoute(handle: Handle) {
 								<h2 mix={css(cardTitleCss)}>You are connected</h2>
 								<p mix={css(descriptionCss)}>
 									At least one AI agent has already authorized access to this
-									account. You can still use the steps below to connect another
-									host or re-run setup with your agent.
+									account, so the first steps below are collapsed. Open them any
+									time to connect another host or re-run setup with your agent.
 								</p>
 							</section>
 						) : null}
 
-						<section
-							id="discovery"
-							mix={css(cardCss)}
-							data-testid="onboarding-discovery"
-						>
-							<h2 mix={css(cardTitleCss)}>
-								Not sure what you&apos;d use Kody for?
-							</h2>
-							<p mix={css(descriptionCss)}>
-								Paste this into any AI agent that can fetch a URL or search the
-								web — ChatGPT, Claude, or whatever you already use. It has the
-								agent read Kody&apos;s docs, interview you, and suggest concrete
-								automations. No account or setup needed yet.
-							</p>
-							<pre mix={css(codeBlockCss)}>{discoveryPrompt}</pre>
-							<CopyTextButton
-								value={discoveryPrompt}
-								idleLabel="Copy discovery prompt"
-								variant="secondary"
-							/>
-						</section>
+						{renderOnboardingStep({
+							title: '1. Not sure what you\u2019d use Kody for?',
+							collapsed: hasMcpClient,
+							id: 'discovery',
+							testId: 'onboarding-discovery',
+							children: (
+								<>
+									<p mix={css(descriptionCss)}>
+										Paste this into any AI agent that can fetch a URL or search
+										the web — ChatGPT, Claude, or whatever you already use. It
+										has the agent read Kody&apos;s docs, interview you, and
+										suggest concrete automations. No account or setup needed
+										yet.
+									</p>
+									<pre mix={css(codeBlockCss)}>{discoveryPrompt}</pre>
+									<CopyTextButton
+										value={discoveryPrompt}
+										idleLabel="Copy discovery prompt"
+										variant="secondary"
+									/>
+								</>
+							),
+						})}
 
-						<section mix={css(cardCss)}>
-							<h2 mix={css(cardTitleCss)}>1. Add Kody as an MCP server</h2>
-							<p mix={css(descriptionCss)}>
-								Pick your MCP client below for host-specific setup. When the
-								agent connects, it starts an OAuth flow — sign in to Kody if
-								needed, approve the request, and the agent receives a token
-								scoped to your account.
-							</p>
-							<OnboardingMcpClientTabs mcpServerUrl={mcpServerUrl} />
-						</section>
-
-						{renderByokExplainer({ image: 'handoff' })}
+						{renderOnboardingStep({
+							title: '2. Add Kody as an MCP server',
+							collapsed: hasMcpClient,
+							children: (
+								<>
+									<p mix={css(descriptionCss)}>
+										Pick your MCP client below for host-specific setup. When the
+										agent connects, it starts an OAuth flow — sign in to Kody if
+										needed, approve the request, and the agent receives a token
+										scoped to your account.
+									</p>
+									<OnboardingMcpClientTabs mcpServerUrl={mcpServerUrl} />
+								</>
+							),
+						})}
 
 						<section
 							mix={css(cardCss)}
 							data-testid="onboarding-starter-packages"
 						>
-							<h2 mix={css(cardTitleCss)}>2. Install a starter package</h2>
+							<h2 mix={css(cardTitleCss)}>3. Install a starter package</h2>
 							<p mix={css(descriptionCss)}>
 								{featuredListings.length > 0
 									? 'These packages were reviewed by an admin and support one-click install here. After install, use Copy prompt so your agent can finish any remaining setup — or pick Choose your own adventure to explore with your agent instead.'
@@ -277,38 +282,75 @@ export function OnboardingRoute(handle: Handle) {
 							</p>
 						</section>
 
-						<p mix={css({ margin: 0 })}>
-							{loggedIn ? (
-								<>
-									<a href="/account" mix={css(mutedLinkCss)}>
-										Back to account
-									</a>
-									{' · '}
-									<a href="/account/secrets" mix={css(primaryLinkCss)}>
-										Secrets
-									</a>
-									{' · '}
-									<a href="/account/integrations" mix={css(primaryLinkCss)}>
-										Integrations
-									</a>
-								</>
-							) : (
-								<>
-									<a href="/signup" mix={css(primaryLinkCss)}>
-										Sign up
-									</a>
-									{' · '}
-									<a href="/login" mix={css(mutedLinkCss)}>
-										Log in
-									</a>
-								</>
-							)}
-						</p>
+						{renderByokExplainer({ image: 'handoff' })}
+
+						{loggedIn ? null : (
+							<p mix={css({ margin: 0 })}>
+								<a href="/signup" mix={css(primaryLinkCss)}>
+									Sign up
+								</a>
+								{' · '}
+								<a href="/login" mix={css(mutedLinkCss)}>
+									Log in
+								</a>
+							</p>
+						)}
 					</>
 				) : null}
 			</AccountManagementShell>
 		)
 	}
+}
+
+type OnboardingStepSlot = any
+
+/**
+ * Renders an onboarding step as an open card, or — once an MCP client is
+ * already connected — as a collapsed `<details>` card the user can reopen to
+ * redo the step (e.g. connect another host).
+ */
+function renderOnboardingStep(input: {
+	title: string
+	collapsed: boolean
+	id?: string
+	testId?: string
+	children: OnboardingStepSlot
+}) {
+	if (!input.collapsed) {
+		return (
+			<section id={input.id} mix={css(cardCss)} data-testid={input.testId}>
+				<h2 mix={css(cardTitleCss)}>{input.title}</h2>
+				{input.children}
+			</section>
+		)
+	}
+	return (
+		<details id={input.id} mix={css(cardCss)} data-testid={input.testId}>
+			<summary mix={css(collapsedStepSummaryCss)}>
+				<h2 mix={css(collapsedStepTitleCss)}>{input.title}</h2>
+				<span mix={css(collapsedStepHintCss)}>Done — open to revisit</span>
+			</summary>
+			{input.children}
+		</details>
+	)
+}
+
+const collapsedStepSummaryCss = {
+	cursor: 'pointer',
+	'&::marker': {
+		color: colors.textMuted,
+	},
+}
+
+const collapsedStepTitleCss = {
+	...cardTitleCss,
+	display: 'inline' as const,
+}
+
+const collapsedStepHintCss = {
+	marginLeft: spacing.sm,
+	color: colors.textMuted,
+	fontSize: typography.fontSize.sm,
 }
 
 const codeBlockCss = {

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -155,10 +155,18 @@ export function OnboardingRoute(handle: Handle) {
 	// Users typically keep this page open while their MCP client runs the
 	// OAuth flow, so poll the same JSON endpoint until a grant shows up and
 	// collapse the completed steps without requiring a manual refresh.
+	let pollIntervalId: ReturnType<typeof setInterval> | undefined
+	let pollInFlight = false
+
 	async function pollForMcpConnection() {
-		if (status !== 'ready' || !loggedIn || hasMcpClient) return
+		if (hasMcpClient) {
+			clearInterval(pollIntervalId)
+			return
+		}
+		if (pollInFlight || status !== 'ready' || !loggedIn) return
 		if (document.hidden) return
 		if (!isOnboardingPath(readCurrentRouterHref(handle))) return
+		pollInFlight = true
 		try {
 			const payload = await fetchOnboardingPayload(handle.signal)
 			if (handle.signal.aborted || !payload?.hasMcpClient) return
@@ -166,11 +174,13 @@ export function OnboardingRoute(handle: Handle) {
 			handle.update()
 		} catch {
 			// Transient poll failures are fine; the next tick retries.
+		} finally {
+			pollInFlight = false
 		}
 	}
 
 	if (typeof document !== 'undefined') {
-		const pollIntervalId = setInterval(pollForMcpConnection, 5000)
+		pollIntervalId = setInterval(pollForMcpConnection, 5000)
 		handle.signal.addEventListener('abort', () => clearInterval(pollIntervalId))
 	}
 

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -152,6 +152,28 @@ export function OnboardingRoute(handle: Handle) {
 		}
 	}
 
+	// Users typically keep this page open while their MCP client runs the
+	// OAuth flow, so poll the same JSON endpoint until a grant shows up and
+	// collapse the completed steps without requiring a manual refresh.
+	async function pollForMcpConnection() {
+		if (status !== 'ready' || !loggedIn || hasMcpClient) return
+		if (document.hidden) return
+		if (!isOnboardingPath(readCurrentRouterHref(handle))) return
+		try {
+			const payload = await fetchOnboardingPayload(handle.signal)
+			if (handle.signal.aborted || !payload?.hasMcpClient) return
+			applyPayload(payload)
+			handle.update()
+		} catch {
+			// Transient poll failures are fine; the next tick retries.
+		}
+	}
+
+	if (typeof document !== 'undefined') {
+		const pollIntervalId = setInterval(pollForMcpConnection, 5000)
+		handle.signal.addEventListener('abort', () => clearInterval(pollIntervalId))
+	}
+
 	function applyRouteLoaderData(href: string) {
 		if (!isOnboardingPath(href)) return false
 		const routeData = tryConsumeRouteLoaderData(handle, 'onboarding', href)


### PR DESCRIPTION
## Summary

- Reorder onboarding into three numbered steps with the discovery prompt first: 1. discovery, 2. add Kody as an MCP server, 3. install a starter package.
- Once an MCP client is connected, steps 1 and 2 collapse into native `<details>` cards ("Done — open to revisit") so only the starter packages remain expanded; while the page is open, it polls `/onboarding.json` every 5s (visible tab, logged in, not yet connected) so the UI reacts without a refresh.
- Move the bring-your-own-keys explainer below the starter packages.
- Remove the "Back to account · Secrets · Integrations" footer links (sign up / log in links remain for logged-out visitors).

## Test plan

- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`
- [x] Playwright: `e2e/community-featured.spec.ts`, `e2e/invite-signup-verification.spec.ts`
- [ ] CI green

Made with [Cursor](https://cursor.com)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `24f871c6` · **Head:** `6361f328`

**Classification:** composes — no primitives added or changed; this PR rearranges the onboarding UI and polls an existing JSON endpoint.

### Primitives touched

| Primitive | Group    | Impact                                                              |
| --------- | -------- | ------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — onboarding route layout + client-side polling, one file |

### System map

The onboarding page in the browser app polls the existing onboarding JSON endpoint to detect a new MCP OAuth grant and collapses completed steps in place.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	oauthGrants["mcp-oauth<br/>Inbound MCP OAuth"]:::untouched
	appUi -->|"GET /onboarding.json every 5s until hasMcpClient"| oauthGrants
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Onboarding section order (before)      | After                                             |
| -------------------------------------- | ------------------------------------------------- |
| Discovery prompt (unnumbered)          | 1. Discovery prompt (collapses once connected)    |
| 1. Add Kody as an MCP server           | 2. Add Kody as an MCP server (collapses too)      |
| BYOK explainer                         | 3. Install a starter package                      |
| 2. Install a starter package           | BYOK explainer                                    |
| Back to account · Secrets · Integrations | (removed; sign up / log in kept for logged out) |

</details>

<!-- system-recap:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding now automatically checks for authorization updates and updates the UI as soon as an MCP client becomes available.
  * Onboarding steps 1–2 can collapse after connection (with an easy “Done — open to revisit” summary), with improved step ordering and content.
  * Bottom onboarding links now show sign up / log in only when not signed in.
* **Bug Fixes**
  * Prevented unnecessary background polling when the page is hidden, the user is not logged in, navigating away, another poll is already running, or the component is no longer ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
