### PR TITLE
Add platform accounts and package scope grants

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -205,6 +205,10 @@ Current admin capabilities:
 - `admin_user_get`
 - `admin_user_create`
 - `admin_user_update`
+- `admin_platform_account_create`
+- `admin_package_scope_grant_create`
+- `admin_package_scope_grant_revoke`
+- `admin_package_scope_grant_list`
 - `admin_audit_log_query`
 - `admin_user_usage`
 - `admin_feature_flag_list`

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -202,8 +202,7 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   migration 0072) distinguishes normal signups from operator-provisioned
   platform accounts that own official package scopes (see
   [Platform accounts](./platform-accounts.md)). Inbound email routing does not
-  reverse-resolve
-  stable ids at all — it uses the indexed username lookup
+  reverse-resolve stable ids at all — it uses the indexed username lookup
   (`findPublicUserIdentityByUsername`). The remaining contextless paths resolve
   stable ids with one indexed point read (`findUserRowByStableUserId` /
   `findUserAccountByStableUserId`); legacy rows with a NULL `stable_user_id`

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -198,7 +198,11 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   `userId` (`stable_user_id`, SHA-256 of the normalized email, unique partial
   index from migration 0052; written at signup). Optional community profile
   fields (`display_name`, `bio`, `profile_visibility` with default `public`)
-  come from migration 0065. Inbound email routing does not reverse-resolve
+  come from migration 0065. `account_type` (`'person'` default or `'platform'`,
+  migration 0072) distinguishes normal signups from operator-provisioned
+  platform accounts that own official package scopes (see
+  [Platform accounts](./platform-accounts.md)). Inbound email routing does not
+  reverse-resolve
   stable ids at all — it uses the indexed username lookup
   (`findPublicUserIdentityByUsername`). The remaining contextless paths resolve
   stable ids with one indexed point read (`findUserRowByStableUserId` /
@@ -212,6 +216,10 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   they are resolved, dismissed, or the submitting account is deleted. Resolved
   and dismissed rows are pruned 365 days after `updated_at`; submitter deletion
   removes any remaining rows.
+- `package_scope_grants`: explicit rows granting a person account permission to
+  act inside a platform account's package scope (`scope_owner_user_id`,
+  `grantee_user_id`, `created_by_user_id`, `created_at`; migration 0072). Grants
+  are only representable when the scope owner is a platform account.
 - `password_resets`: hashed reset tokens with expiry and foreign key to users
 - `jobs`: persisted job metadata, caller context, schedule state, repo source
   pointers, and run observability counters/history

--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -15,6 +15,9 @@ to become.
   Worker.
 - [Authentication](./authentication.md): app session auth and OAuth-protected
   MCP auth.
+- [Platform accounts](./platform-accounts.md): operator-provisioned platform
+  accounts, package scope grants, and actor/owner delegation for official
+  package scopes.
 - [Authorization](./authorization.md): role-based access control (RBAC), admin
   routes, and the `any`-access exception to per-user isolation.
 - [Entitlements](./entitlements.md): per-user plans (`users.plan`), per-plan

--- a/docs/contributing/architecture/platform-accounts.md
+++ b/docs/contributing/architecture/platform-accounts.md
@@ -1,0 +1,127 @@
+# Platform accounts and package scope grants
+
+Kody distinguishes **person accounts** (normal signups) from **platform
+accounts** (operator-provisioned owners of official package scopes such as
+`@kody`). Platform accounts never log in and have no usable password. Person
+users continue to own their personal package scope by default; an explicit
+**package scope grant** lets a person act inside a platform account's scope
+while storage remains scoped to exactly one owner `userId`.
+
+See [Data storage](./data-storage.md) for table inventory and
+[Authorization](./authorization.md) for admin capability guards.
+
+## Data model
+
+Migration `packages/worker/migrations/0072-package-scope-grants.sql`:
+
+- **`users.account_type`** — `'person'` (default) or `'platform'`. Platform
+  accounts are created by operators, not through signup.
+- **`package_scope_grants`** — `(scope_owner_user_id, grantee_user_id,
+created_by_user_id, created_at)`. Primary key
+  `(scope_owner_user_id, grantee_user_id)`. A row means the grantee person may
+  act inside the scope owner's package namespace.
+
+Platform account usernames must come from the reserved-username denylist in
+`packages/worker/src/app/reserved-usernames.ts` (for example `kody`,
+`support`, `admin`). That list blocks end-user signup from claiming those
+names, so platform scopes never collide with real accounts.
+
+Platform accounts use a sentinel password hash that never verifies, the same
+pattern as admin-created person accounts awaiting password setup.
+
+## Actor / owner resolution
+
+Package and community capabilities accept an optional `package_scope` input (for
+example `"kody"`, without `@`). When omitted, or when it matches the caller's
+own username, behavior is unchanged: the caller is both actor and owner.
+
+When a foreign scope is requested, `resolvePackageOwnerContext` in
+`packages/worker/src/package-registry/package-owner.ts` returns:
+
+| Field         | Role                                                      |
+| ------------- | --------------------------------------------------------- |
+| `ownerUserId` | Stable MCP id used for **all storage** (`saved_packages`, |
+|               | `entity_sources`, Vectorize, community listing ownership, |
+|               | entitlements)                                             |
+| `ownerScope`  | Platform username (package name prefix)                   |
+| `ownerEmail`  | Platform account email                                    |
+| `actorUserId` | Signed-in caller (always the person)                      |
+| `delegated`   | `true` when acting under a grant                          |
+
+Storage paths use **only** `ownerUserId`. The actor is never written into
+ownership columns; it appears in audit events instead.
+
+Capabilities that accept `package_scope` include package save/get/list/delete/
+update, git-lane publish (`package_get_git_remote`,
+`package_publish_external_push`), and community publish/unpublish.
+
+## Security invariant
+
+**Package scope grants exist only on platform accounts.** This is structural,
+not policy:
+
+- `insertPackageScopeGrant` in `scope-grants.ts` rejects person accounts as
+  scope owners.
+- `getPlatformAccountByUsername` returns null unless
+  `users.account_type = 'platform'`.
+- The resolver never treats another person account as a delegatable scope.
+
+Admins can act **as** a platform account (for example `@kody`); acting **as**
+(or reading data of) another person user is deliberately unrepresentable in the
+API.
+
+## Audit
+
+Each delegated resolution logs `package_scope_delegated_access` in the audit log
+(`category: account`, `result: success`) with the acting person's email and
+`reason: scope=@<username>`.
+
+## Admin capabilities
+
+The `admin` MCP domain exposes:
+
+- `admin_platform_account_create` — provision a platform account (reserved
+  username, no login).
+- `admin_package_scope_grant_create` — grant a person access to a platform
+  scope.
+- `admin_package_scope_grant_revoke` — remove a grant.
+- `admin_package_scope_grant_list` — list grants (optionally filtered by scope
+  owner).
+
+## Operator workflow
+
+Typical path for official packages and onboarding starters:
+
+1. Operator creates the `kody` platform account (if missing).
+2. Operator receives a package scope grant on `@kody`.
+3. From their own MCP session, the operator passes `package_scope: "kody"` to
+   the git lane: `package_get_git_remote` → clone/edit/push →
+   `package_publish_external_push`.
+4. Community listings are published with `community_publish` and the same
+   `package_scope`, so featured starters display as `@kody/...`.
+
+## Intentionally not built
+
+This release seeds delegation mechanics only. It does **not** include:
+
+- org/team roles or membership tiers beyond a single grant bit
+- invitations or self-service grant requests
+- org management UI (grants are admin MCP capabilities today)
+- `repo_*` capability delegation — repo sessions remain personal-scope only;
+  community forks and installs always land in the caller's personal account
+
+## Future orgs
+
+The actor/owner split and `package_scope_grants` table are the deliberate seed
+of a future org/teams feature: scope maps to an owning account, grant maps to
+membership. Orgs would extend these tables (roles, management UI), not replace
+the mechanism.
+
+## Source of truth in code
+
+- `packages/worker/src/package-registry/scope-grants.ts` — grant CRUD and
+  platform account lookup
+- `packages/worker/src/package-registry/package-owner.ts` — scope resolution and
+  audit
+- `packages/worker/migrations/0072-package-scope-grants.sql` — schema
+- `packages/worker/src/app/reserved-usernames.ts` — username denylist

--- a/docs/contributing/architecture/platform-accounts.md
+++ b/docs/contributing/architecture/platform-accounts.md
@@ -16,15 +16,15 @@ Migration `packages/worker/migrations/0072-package-scope-grants.sql`:
 
 - **`users.account_type`** — `'person'` (default) or `'platform'`. Platform
   accounts are created by operators, not through signup.
-- **`package_scope_grants`** — `(scope_owner_user_id, grantee_user_id,
-created_by_user_id, created_at)`. Primary key
-  `(scope_owner_user_id, grantee_user_id)`. A row means the grantee person may
-  act inside the scope owner's package namespace.
+- **`package_scope_grants`** —
+  `(scope_owner_user_id, grantee_user_id, created_by_user_id, created_at)`.
+  Primary key `(scope_owner_user_id, grantee_user_id)`. A row means the grantee
+  person may act inside the scope owner's package namespace.
 
 Platform account usernames must come from the reserved-username denylist in
-`packages/worker/src/app/reserved-usernames.ts` (for example `kody`,
-`support`, `admin`). That list blocks end-user signup from claiming those
-names, so platform scopes never collide with real accounts.
+`packages/worker/src/app/reserved-usernames.ts` (for example `kody`, `support`,
+`admin`). That list blocks end-user signup from claiming those names, so
+platform scopes never collide with real accounts.
 
 Platform accounts use a sentinel password hash that never verifies, the same
 pattern as admin-created person accounts awaiting password setup.

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -94,12 +94,12 @@ expose the effective `trusted` flag.
 
 Admin **featured** marks live in `featured_at` (migration
 `0060-community-featured-listings.sql`) and highlight onboarding starter
-packages. Operators publish official starters under a platform scope (for example
-`@kody`) by passing `package_scope` to `community_publish` while holding a
-package scope grant; see
-[Platform accounts](./architecture/platform-accounts.md). `setCommunityListingFeatured`
-in `service.ts` requires the listing to be effectively trusted before
-featuring; the effective `featured` flag
+packages. Operators publish official starters under a platform scope (for
+example `@kody`) by passing `package_scope` to `community_publish` while holding
+a package scope grant; see
+[Platform accounts](./architecture/platform-accounts.md).
+`setCommunityListingFeatured` in `service.ts` requires the listing to be
+effectively trusted before featuring; the effective `featured` flag
 (`featured_at IS NOT NULL AND trusted`) is computed in `repo.ts`, so an owner
 republish that drops trust also pulls the listing from onboarding while keeping
 the stored mark. `listFeaturedCommunityListings` feeds the onboarding page (slim

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -94,8 +94,12 @@ expose the effective `trusted` flag.
 
 Admin **featured** marks live in `featured_at` (migration
 `0060-community-featured-listings.sql`) and highlight onboarding starter
-packages. `setCommunityListingFeatured` in `service.ts` requires the listing to
-be effectively trusted before featuring; the effective `featured` flag
+packages. Operators publish official starters under a platform scope (for example
+`@kody`) by passing `package_scope` to `community_publish` while holding a
+package scope grant; see
+[Platform accounts](./architecture/platform-accounts.md). `setCommunityListingFeatured`
+in `service.ts` requires the listing to be effectively trusted before
+featuring; the effective `featured` flag
 (`featured_at IS NOT NULL AND trusted`) is computed in `repo.ts`, so an owner
 republish that drops trust also pulls the listing from onboarding while keeping
 the stored mark. `listFeaturedCommunityListings` feeds the onboarding page (slim

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -167,8 +167,11 @@ Admins toggle trust from the listing detail page or with the
 
 Admins can additionally mark trusted listings as **featured**. Featured listings
 appear on the onboarding page (`/onboarding`) as starter packages new users can
-one-click install. Only trusted listings can be featured, and a listing is only
-_shown_ in onboarding while it remains effectively trusted: when the owner
+one-click install. Official starter packages are published under platform scopes
+such as `@kody` by operators who hold a package scope grant on that account —
+they show up like any other community listing, owned by `@kody/...` rather than
+a personal username. Only trusted listings can be featured, and a listing is
+only _shown_ in onboarding while it remains effectively trusted: when the owner
 republishes, it silently drops out of onboarding until an admin re-trusts the
 new version (the featured mark itself is kept, so re-trusting restores it).
 

--- a/packages/worker/migrations/0072-package-scope-grants.sql
+++ b/packages/worker/migrations/0072-package-scope-grants.sql
@@ -1,0 +1,13 @@
+ALTER TABLE users ADD COLUMN account_type TEXT NOT NULL DEFAULT 'person' CHECK (account_type IN ('person', 'platform'));
+
+CREATE TABLE package_scope_grants (
+	scope_owner_user_id INTEGER NOT NULL,
+	grantee_user_id INTEGER NOT NULL,
+	created_by_user_id INTEGER NOT NULL,
+	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+	PRIMARY KEY (scope_owner_user_id, grantee_user_id),
+	CHECK (scope_owner_user_id != grantee_user_id)
+);
+
+CREATE INDEX idx_package_scope_grants_grantee_user_id
+ON package_scope_grants(grantee_user_id);

--- a/packages/worker/migrations/0072-package-scope-grants.sql
+++ b/packages/worker/migrations/0072-package-scope-grants.sql
@@ -1,9 +1,12 @@
 ALTER TABLE users ADD COLUMN account_type TEXT NOT NULL DEFAULT 'person' CHECK (account_type IN ('person', 'platform'));
 
+-- User id columns hold stable MCP user ids (users.stable_user_id), matching
+-- saved_packages/community_* ownership columns and the account deletion and
+-- export machinery.
 CREATE TABLE package_scope_grants (
-	scope_owner_user_id INTEGER NOT NULL,
-	grantee_user_id INTEGER NOT NULL,
-	created_by_user_id INTEGER NOT NULL,
+	scope_owner_user_id TEXT NOT NULL,
+	grantee_user_id TEXT NOT NULL,
+	created_by_user_id TEXT NOT NULL,
 	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
 	PRIMARY KEY (scope_owner_user_id, grantee_user_id),
 	CHECK (scope_owner_user_id != grantee_user_id)

--- a/packages/worker/src/app/account-data-targets.ts
+++ b/packages/worker/src/app/account-data-targets.ts
@@ -1,37 +1,37 @@
 export type UserScopedDataTarget =
-  | { kind: "user_id"; table: string }
-  | { kind: "db_user_id"; table: string }
-  // Rows keyed by a `target` column holding the stringified database user id
-  // (Epic Stack-style verifications: 2fa secrets etc).
-  | { kind: "db_user_target"; table: string }
-  | { kind: "user_columns"; table: string; columns: ReadonlyArray<string> }
-  | {
-      kind: "null_user_column";
-      table: string;
-      matchColumn: string;
-      nullColumns: ReadonlyArray<string>;
-      includeInExport?: boolean;
-    }
-  | {
-      kind: "replace_user_column";
-      table: string;
-      matchColumn: string;
-      setColumn: string;
-      value: string;
-    }
-  | { kind: "bucket_parent"; table: string; parentTable: string }
-  | { kind: "attachment_parent"; table: string }
-  | { kind: "community_listing_child"; table: string; listingColumn: string }
-  | { kind: "mcp_memory_suppression" };
+	| { kind: 'user_id'; table: string }
+	| { kind: 'db_user_id'; table: string }
+	// Rows keyed by a `target` column holding the stringified database user id
+	// (Epic Stack-style verifications: 2fa secrets etc).
+	| { kind: 'db_user_target'; table: string }
+	| { kind: 'user_columns'; table: string; columns: ReadonlyArray<string> }
+	| {
+			kind: 'null_user_column'
+			table: string
+			matchColumn: string
+			nullColumns: ReadonlyArray<string>
+			includeInExport?: boolean
+	  }
+	| {
+			kind: 'replace_user_column'
+			table: string
+			matchColumn: string
+			setColumn: string
+			value: string
+	  }
+	| { kind: 'bucket_parent'; table: string; parentTable: string }
+	| { kind: 'attachment_parent'; table: string }
+	| { kind: 'community_listing_child'; table: string; listingColumn: string }
+	| { kind: 'mcp_memory_suppression' }
 
 export const accountUserDataExcludedOwnerIds = [
-  {
-    ownerId: "system:email",
-    surface: "system_email_inboxes",
-    reason:
-      "Operator-owned inbound mail for reserved platform locals is stored under the reserved system:email owner id. It is not a user account, must not be attributed to any user, and is excluded from per-user account deletion/export while system retention pruning bounds growth.",
-  },
-] as const;
+	{
+		ownerId: 'system:email',
+		surface: 'system_email_inboxes',
+		reason:
+			'Operator-owned inbound mail for reserved platform locals is stored under the reserved system:email owner id. It is not a user account, must not be attributed to any user, and is excluded from per-user account deletion/export while system retention pruning bounds growth.',
+	},
+] as const
 
 /**
  * Tables that are scoped by `user_id` (directly or transitively) and should
@@ -50,215 +50,215 @@ export const accountUserDataExcludedOwnerIds = [
  * tables) are not represented.
  */
 export const accountUserDataTargets: ReadonlyArray<UserScopedDataTarget> = [
-  { kind: "user_id", table: "package_invocations" },
-  { kind: "user_id", table: "package_invocation_tokens" },
-  { kind: "user_id", table: "workflow_runs" },
-  { kind: "user_id", table: "package_runtime_logs" },
-  { kind: "user_id", table: "package_runtime_runs" },
-  { kind: "user_id", table: "usage_rollups" },
-  { kind: "mcp_memory_suppression" },
-  { kind: "user_id", table: "mcp_memories" },
-  { kind: "user_id", table: "mcp_user_server_instructions" },
-  {
-    kind: "bucket_parent",
-    table: "value_entries",
-    parentTable: "value_buckets",
-  },
-  { kind: "user_id", table: "value_buckets" },
-  {
-    kind: "bucket_parent",
-    table: "secret_entries",
-    parentTable: "secret_buckets",
-  },
-  { kind: "user_id", table: "secret_buckets" },
-  { kind: "user_id", table: "remote_connector_settings" },
-  { kind: "user_id", table: "mcp_server_settings" },
-  { kind: "user_id", table: "archived_job_artifacts" },
-  { kind: "user_id", table: "published_bundle_artifacts" },
-  { kind: "user_id", table: "jobs" },
-  { kind: "user_id", table: "repo_sessions" },
-  { kind: "user_id", table: "saved_packages" },
-  { kind: "user_id", table: "entity_sources" },
-  { kind: "user_id", table: "email_delivery_events" },
-  { kind: "attachment_parent", table: "email_attachments" },
-  { kind: "user_id", table: "email_messages" },
-  { kind: "user_id", table: "email_threads" },
-  { kind: "user_id", table: "email_inbox_addresses" },
-  { kind: "user_id", table: "email_inboxes" },
-  { kind: "user_id", table: "email_sender_identities" },
-  { kind: "user_id", table: "entitlement_daily_counters" },
-  {
-    kind: "user_columns",
-    table: "platform_feedback",
-    columns: ["submitter_user_id"],
-  },
-  // Feedback is owned by its submitter. A reviewer relationship is cleanup
-  // metadata only: deleting that reviewer anonymizes the surviving review,
-  // but account export must not expose another user's feedback to the reviewer.
-  {
-    kind: "null_user_column",
-    table: "platform_feedback",
-    matchColumn: "reviewed_by_user_id",
-    nullColumns: ["reviewed_by_user_id", "reviewed_at", "admin_note"],
-    includeInExport: false,
-  },
-  {
-    kind: "community_listing_child",
-    table: "community_ratings",
-    listingColumn: "listing_id",
-  },
-  { kind: "user_id", table: "community_ratings" },
-  {
-    kind: "community_listing_child",
-    table: "community_stars",
-    listingColumn: "listing_id",
-  },
-  { kind: "user_id", table: "community_stars" },
-  {
-    kind: "community_listing_child",
-    table: "community_activity_events",
-    listingColumn: "listing_id",
-  },
-  {
-    kind: "user_columns",
-    table: "community_activity_events",
-    columns: ["actor_user_id"],
-  },
-  {
-    kind: "user_columns",
-    table: "user_follows",
-    columns: ["follower_user_id", "followee_user_id"],
-  },
-  {
-    kind: "community_listing_child",
-    table: "community_forks",
-    listingColumn: "listing_id",
-  },
-  {
-    kind: "user_columns",
-    table: "community_forks",
-    columns: ["forker_user_id"],
-  },
-  {
-    kind: "community_listing_child",
-    table: "community_reports",
-    listingColumn: "listing_id",
-  },
-  {
-    kind: "user_columns",
-    table: "community_reports",
-    columns: ["listing_owner_user_id", "reporter_user_id"],
-  },
-  {
-    kind: "null_user_column",
-    table: "community_reports",
-    matchColumn: "resolved_by_user_id",
-    nullColumns: ["resolved_by_user_id", "resolved_at", "resolution_note"],
-  },
-  // A grant dies with its scope owner or grantee, but survives deletion of
-  // the admin who created it (the grant remains valid; only attribution is
-  // anonymized, matching community_bans).
-  {
-    kind: "user_columns",
-    table: "package_scope_grants",
-    columns: ["scope_owner_user_id", "grantee_user_id"],
-  },
-  {
-    kind: "replace_user_column",
-    table: "package_scope_grants",
-    matchColumn: "created_by_user_id",
-    setColumn: "created_by_user_id",
-    value: "deleted-user",
-  },
-  {
-    kind: "user_columns",
-    table: "community_bans",
-    columns: ["user_id"],
-  },
-  {
-    kind: "replace_user_column",
-    table: "community_bans",
-    matchColumn: "banned_by_user_id",
-    setColumn: "banned_by_user_id",
-    value: "deleted-user",
-  },
-  // Trust marks record which admin reviewed a listing. When that admin's
-  // account is deleted the mark itself stays valid (the review happened);
-  // only the attribution is anonymized, matching community_bans.
-  {
-    kind: "replace_user_column",
-    table: "community_listings",
-    matchColumn: "trusted_by_user_id",
-    setColumn: "trusted_by_user_id",
-    value: "deleted-user",
-  },
-  {
-    kind: "user_columns",
-    table: "community_listings",
-    columns: ["owner_user_id"],
-  },
-  // password_resets.user_id is an INTEGER FK to users.id (predates the
-  // stable mcp string user id), so it must be handled with the database
-  // integer id rather than the mcp user id.
-  { kind: "db_user_id", table: "email_verifications" },
-  { kind: "db_user_id", table: "pending_email_changes" },
-  { kind: "db_user_id", table: "password_resets" },
-  { kind: "db_user_id", table: "user_roles" },
-  { kind: "db_user_id", table: "passkeys" },
-  { kind: "db_user_id", table: "oauth_connections" },
-  // Feature-flag overrides use the integer users.id FK (with ON DELETE
-  // CASCADE), but account deletion still issues an explicit DELETE so the
-  // cascade stays self-contained when FK enforcement is disabled.
-  { kind: "db_user_id", table: "feature_flag_user_overrides" },
-  // Two-factor verification rows are keyed by `target` = stringified db user
-  // id rather than a user_id column, so they need the dedicated kind.
-  { kind: "db_user_target", table: "verifications" },
-];
+	{ kind: 'user_id', table: 'package_invocations' },
+	{ kind: 'user_id', table: 'package_invocation_tokens' },
+	{ kind: 'user_id', table: 'workflow_runs' },
+	{ kind: 'user_id', table: 'package_runtime_logs' },
+	{ kind: 'user_id', table: 'package_runtime_runs' },
+	{ kind: 'user_id', table: 'usage_rollups' },
+	{ kind: 'mcp_memory_suppression' },
+	{ kind: 'user_id', table: 'mcp_memories' },
+	{ kind: 'user_id', table: 'mcp_user_server_instructions' },
+	{
+		kind: 'bucket_parent',
+		table: 'value_entries',
+		parentTable: 'value_buckets',
+	},
+	{ kind: 'user_id', table: 'value_buckets' },
+	{
+		kind: 'bucket_parent',
+		table: 'secret_entries',
+		parentTable: 'secret_buckets',
+	},
+	{ kind: 'user_id', table: 'secret_buckets' },
+	{ kind: 'user_id', table: 'remote_connector_settings' },
+	{ kind: 'user_id', table: 'mcp_server_settings' },
+	{ kind: 'user_id', table: 'archived_job_artifacts' },
+	{ kind: 'user_id', table: 'published_bundle_artifacts' },
+	{ kind: 'user_id', table: 'jobs' },
+	{ kind: 'user_id', table: 'repo_sessions' },
+	{ kind: 'user_id', table: 'saved_packages' },
+	{ kind: 'user_id', table: 'entity_sources' },
+	{ kind: 'user_id', table: 'email_delivery_events' },
+	{ kind: 'attachment_parent', table: 'email_attachments' },
+	{ kind: 'user_id', table: 'email_messages' },
+	{ kind: 'user_id', table: 'email_threads' },
+	{ kind: 'user_id', table: 'email_inbox_addresses' },
+	{ kind: 'user_id', table: 'email_inboxes' },
+	{ kind: 'user_id', table: 'email_sender_identities' },
+	{ kind: 'user_id', table: 'entitlement_daily_counters' },
+	{
+		kind: 'user_columns',
+		table: 'platform_feedback',
+		columns: ['submitter_user_id'],
+	},
+	// Feedback is owned by its submitter. A reviewer relationship is cleanup
+	// metadata only: deleting that reviewer anonymizes the surviving review,
+	// but account export must not expose another user's feedback to the reviewer.
+	{
+		kind: 'null_user_column',
+		table: 'platform_feedback',
+		matchColumn: 'reviewed_by_user_id',
+		nullColumns: ['reviewed_by_user_id', 'reviewed_at', 'admin_note'],
+		includeInExport: false,
+	},
+	{
+		kind: 'community_listing_child',
+		table: 'community_ratings',
+		listingColumn: 'listing_id',
+	},
+	{ kind: 'user_id', table: 'community_ratings' },
+	{
+		kind: 'community_listing_child',
+		table: 'community_stars',
+		listingColumn: 'listing_id',
+	},
+	{ kind: 'user_id', table: 'community_stars' },
+	{
+		kind: 'community_listing_child',
+		table: 'community_activity_events',
+		listingColumn: 'listing_id',
+	},
+	{
+		kind: 'user_columns',
+		table: 'community_activity_events',
+		columns: ['actor_user_id'],
+	},
+	{
+		kind: 'user_columns',
+		table: 'user_follows',
+		columns: ['follower_user_id', 'followee_user_id'],
+	},
+	{
+		kind: 'community_listing_child',
+		table: 'community_forks',
+		listingColumn: 'listing_id',
+	},
+	{
+		kind: 'user_columns',
+		table: 'community_forks',
+		columns: ['forker_user_id'],
+	},
+	{
+		kind: 'community_listing_child',
+		table: 'community_reports',
+		listingColumn: 'listing_id',
+	},
+	{
+		kind: 'user_columns',
+		table: 'community_reports',
+		columns: ['listing_owner_user_id', 'reporter_user_id'],
+	},
+	{
+		kind: 'null_user_column',
+		table: 'community_reports',
+		matchColumn: 'resolved_by_user_id',
+		nullColumns: ['resolved_by_user_id', 'resolved_at', 'resolution_note'],
+	},
+	// A grant dies with its scope owner or grantee, but survives deletion of
+	// the admin who created it (the grant remains valid; only attribution is
+	// anonymized, matching community_bans).
+	{
+		kind: 'user_columns',
+		table: 'package_scope_grants',
+		columns: ['scope_owner_user_id', 'grantee_user_id'],
+	},
+	{
+		kind: 'replace_user_column',
+		table: 'package_scope_grants',
+		matchColumn: 'created_by_user_id',
+		setColumn: 'created_by_user_id',
+		value: 'deleted-user',
+	},
+	{
+		kind: 'user_columns',
+		table: 'community_bans',
+		columns: ['user_id'],
+	},
+	{
+		kind: 'replace_user_column',
+		table: 'community_bans',
+		matchColumn: 'banned_by_user_id',
+		setColumn: 'banned_by_user_id',
+		value: 'deleted-user',
+	},
+	// Trust marks record which admin reviewed a listing. When that admin's
+	// account is deleted the mark itself stays valid (the review happened);
+	// only the attribution is anonymized, matching community_bans.
+	{
+		kind: 'replace_user_column',
+		table: 'community_listings',
+		matchColumn: 'trusted_by_user_id',
+		setColumn: 'trusted_by_user_id',
+		value: 'deleted-user',
+	},
+	{
+		kind: 'user_columns',
+		table: 'community_listings',
+		columns: ['owner_user_id'],
+	},
+	// password_resets.user_id is an INTEGER FK to users.id (predates the
+	// stable mcp string user id), so it must be handled with the database
+	// integer id rather than the mcp user id.
+	{ kind: 'db_user_id', table: 'email_verifications' },
+	{ kind: 'db_user_id', table: 'pending_email_changes' },
+	{ kind: 'db_user_id', table: 'password_resets' },
+	{ kind: 'db_user_id', table: 'user_roles' },
+	{ kind: 'db_user_id', table: 'passkeys' },
+	{ kind: 'db_user_id', table: 'oauth_connections' },
+	// Feature-flag overrides use the integer users.id FK (with ON DELETE
+	// CASCADE), but account deletion still issues an explicit DELETE so the
+	// cascade stays self-contained when FK enforcement is disabled.
+	{ kind: 'db_user_id', table: 'feature_flag_user_overrides' },
+	// Two-factor verification rows are keyed by `target` = stringified db user
+	// id rather than a user_id column, so they need the dedicated kind.
+	{ kind: 'db_user_target', table: 'verifications' },
+]
 
 export function getAccountD1UserColumnCoverage() {
-  const covered = new Set<string>();
-  covered.add("users.stable_user_id");
-  for (const target of accountUserDataTargets) {
-    switch (target.kind) {
-      case "user_id":
-      case "db_user_id":
-      case "mcp_memory_suppression": {
-        const table =
-          target.kind === "mcp_memory_suppression"
-            ? "mcp_memory_conversation_suppressions"
-            : target.table;
-        covered.add(`${table}.user_id`);
-        break;
-      }
-      case "user_columns": {
-        for (const column of target.columns) {
-          covered.add(`${target.table}.${column}`);
-        }
-        break;
-      }
-      case "null_user_column": {
-        covered.add(`${target.table}.${target.matchColumn}`);
-        break;
-      }
-      case "replace_user_column": {
-        covered.add(`${target.table}.${target.matchColumn}`);
-        break;
-      }
-      case "bucket_parent":
-      case "attachment_parent":
-      case "community_listing_child":
-      // db_user_target tables key rows by `target`, not a *_user_id
-      // column, so there is no schema column for the guard to cover.
-      case "db_user_target": {
-        break;
-      }
-      default: {
-        const exhaustive: never = target;
-        throw new Error(
-          `Unhandled account data coverage target: ${JSON.stringify(exhaustive)}`,
-        );
-      }
-    }
-  }
-  return covered;
+	const covered = new Set<string>()
+	covered.add('users.stable_user_id')
+	for (const target of accountUserDataTargets) {
+		switch (target.kind) {
+			case 'user_id':
+			case 'db_user_id':
+			case 'mcp_memory_suppression': {
+				const table =
+					target.kind === 'mcp_memory_suppression'
+						? 'mcp_memory_conversation_suppressions'
+						: target.table
+				covered.add(`${table}.user_id`)
+				break
+			}
+			case 'user_columns': {
+				for (const column of target.columns) {
+					covered.add(`${target.table}.${column}`)
+				}
+				break
+			}
+			case 'null_user_column': {
+				covered.add(`${target.table}.${target.matchColumn}`)
+				break
+			}
+			case 'replace_user_column': {
+				covered.add(`${target.table}.${target.matchColumn}`)
+				break
+			}
+			case 'bucket_parent':
+			case 'attachment_parent':
+			case 'community_listing_child':
+			// db_user_target tables key rows by `target`, not a *_user_id
+			// column, so there is no schema column for the guard to cover.
+			case 'db_user_target': {
+				break
+			}
+			default: {
+				const exhaustive: never = target
+				throw new Error(
+					`Unhandled account data coverage target: ${JSON.stringify(exhaustive)}`,
+				)
+			}
+		}
+	}
+	return covered
 }

--- a/packages/worker/src/app/account-data-targets.ts
+++ b/packages/worker/src/app/account-data-targets.ts
@@ -1,37 +1,37 @@
 export type UserScopedDataTarget =
-	| { kind: 'user_id'; table: string }
-	| { kind: 'db_user_id'; table: string }
-	// Rows keyed by a `target` column holding the stringified database user id
-	// (Epic Stack-style verifications: 2fa secrets etc).
-	| { kind: 'db_user_target'; table: string }
-	| { kind: 'user_columns'; table: string; columns: ReadonlyArray<string> }
-	| {
-			kind: 'null_user_column'
-			table: string
-			matchColumn: string
-			nullColumns: ReadonlyArray<string>
-			includeInExport?: boolean
-	  }
-	| {
-			kind: 'replace_user_column'
-			table: string
-			matchColumn: string
-			setColumn: string
-			value: string
-	  }
-	| { kind: 'bucket_parent'; table: string; parentTable: string }
-	| { kind: 'attachment_parent'; table: string }
-	| { kind: 'community_listing_child'; table: string; listingColumn: string }
-	| { kind: 'mcp_memory_suppression' }
+  | { kind: "user_id"; table: string }
+  | { kind: "db_user_id"; table: string }
+  // Rows keyed by a `target` column holding the stringified database user id
+  // (Epic Stack-style verifications: 2fa secrets etc).
+  | { kind: "db_user_target"; table: string }
+  | { kind: "user_columns"; table: string; columns: ReadonlyArray<string> }
+  | {
+      kind: "null_user_column";
+      table: string;
+      matchColumn: string;
+      nullColumns: ReadonlyArray<string>;
+      includeInExport?: boolean;
+    }
+  | {
+      kind: "replace_user_column";
+      table: string;
+      matchColumn: string;
+      setColumn: string;
+      value: string;
+    }
+  | { kind: "bucket_parent"; table: string; parentTable: string }
+  | { kind: "attachment_parent"; table: string }
+  | { kind: "community_listing_child"; table: string; listingColumn: string }
+  | { kind: "mcp_memory_suppression" };
 
 export const accountUserDataExcludedOwnerIds = [
-	{
-		ownerId: 'system:email',
-		surface: 'system_email_inboxes',
-		reason:
-			'Operator-owned inbound mail for reserved platform locals is stored under the reserved system:email owner id. It is not a user account, must not be attributed to any user, and is excluded from per-user account deletion/export while system retention pruning bounds growth.',
-	},
-] as const
+  {
+    ownerId: "system:email",
+    surface: "system_email_inboxes",
+    reason:
+      "Operator-owned inbound mail for reserved platform locals is stored under the reserved system:email owner id. It is not a user account, must not be attributed to any user, and is excluded from per-user account deletion/export while system retention pruning bounds growth.",
+  },
+] as const;
 
 /**
  * Tables that are scoped by `user_id` (directly or transitively) and should
@@ -50,200 +50,215 @@ export const accountUserDataExcludedOwnerIds = [
  * tables) are not represented.
  */
 export const accountUserDataTargets: ReadonlyArray<UserScopedDataTarget> = [
-	{ kind: 'user_id', table: 'package_invocations' },
-	{ kind: 'user_id', table: 'package_invocation_tokens' },
-	{ kind: 'user_id', table: 'workflow_runs' },
-	{ kind: 'user_id', table: 'package_runtime_logs' },
-	{ kind: 'user_id', table: 'package_runtime_runs' },
-	{ kind: 'user_id', table: 'usage_rollups' },
-	{ kind: 'mcp_memory_suppression' },
-	{ kind: 'user_id', table: 'mcp_memories' },
-	{ kind: 'user_id', table: 'mcp_user_server_instructions' },
-	{
-		kind: 'bucket_parent',
-		table: 'value_entries',
-		parentTable: 'value_buckets',
-	},
-	{ kind: 'user_id', table: 'value_buckets' },
-	{
-		kind: 'bucket_parent',
-		table: 'secret_entries',
-		parentTable: 'secret_buckets',
-	},
-	{ kind: 'user_id', table: 'secret_buckets' },
-	{ kind: 'user_id', table: 'remote_connector_settings' },
-	{ kind: 'user_id', table: 'mcp_server_settings' },
-	{ kind: 'user_id', table: 'archived_job_artifacts' },
-	{ kind: 'user_id', table: 'published_bundle_artifacts' },
-	{ kind: 'user_id', table: 'jobs' },
-	{ kind: 'user_id', table: 'repo_sessions' },
-	{ kind: 'user_id', table: 'saved_packages' },
-	{ kind: 'user_id', table: 'entity_sources' },
-	{ kind: 'user_id', table: 'email_delivery_events' },
-	{ kind: 'attachment_parent', table: 'email_attachments' },
-	{ kind: 'user_id', table: 'email_messages' },
-	{ kind: 'user_id', table: 'email_threads' },
-	{ kind: 'user_id', table: 'email_inbox_addresses' },
-	{ kind: 'user_id', table: 'email_inboxes' },
-	{ kind: 'user_id', table: 'email_sender_identities' },
-	{ kind: 'user_id', table: 'entitlement_daily_counters' },
-	{
-		kind: 'user_columns',
-		table: 'platform_feedback',
-		columns: ['submitter_user_id'],
-	},
-	// Feedback is owned by its submitter. A reviewer relationship is cleanup
-	// metadata only: deleting that reviewer anonymizes the surviving review,
-	// but account export must not expose another user's feedback to the reviewer.
-	{
-		kind: 'null_user_column',
-		table: 'platform_feedback',
-		matchColumn: 'reviewed_by_user_id',
-		nullColumns: ['reviewed_by_user_id', 'reviewed_at', 'admin_note'],
-		includeInExport: false,
-	},
-	{
-		kind: 'community_listing_child',
-		table: 'community_ratings',
-		listingColumn: 'listing_id',
-	},
-	{ kind: 'user_id', table: 'community_ratings' },
-	{
-		kind: 'community_listing_child',
-		table: 'community_stars',
-		listingColumn: 'listing_id',
-	},
-	{ kind: 'user_id', table: 'community_stars' },
-	{
-		kind: 'community_listing_child',
-		table: 'community_activity_events',
-		listingColumn: 'listing_id',
-	},
-	{
-		kind: 'user_columns',
-		table: 'community_activity_events',
-		columns: ['actor_user_id'],
-	},
-	{
-		kind: 'user_columns',
-		table: 'user_follows',
-		columns: ['follower_user_id', 'followee_user_id'],
-	},
-	{
-		kind: 'community_listing_child',
-		table: 'community_forks',
-		listingColumn: 'listing_id',
-	},
-	{
-		kind: 'user_columns',
-		table: 'community_forks',
-		columns: ['forker_user_id'],
-	},
-	{
-		kind: 'community_listing_child',
-		table: 'community_reports',
-		listingColumn: 'listing_id',
-	},
-	{
-		kind: 'user_columns',
-		table: 'community_reports',
-		columns: ['listing_owner_user_id', 'reporter_user_id'],
-	},
-	{
-		kind: 'null_user_column',
-		table: 'community_reports',
-		matchColumn: 'resolved_by_user_id',
-		nullColumns: ['resolved_by_user_id', 'resolved_at', 'resolution_note'],
-	},
-	{
-		kind: 'user_columns',
-		table: 'community_bans',
-		columns: ['user_id'],
-	},
-	{
-		kind: 'replace_user_column',
-		table: 'community_bans',
-		matchColumn: 'banned_by_user_id',
-		setColumn: 'banned_by_user_id',
-		value: 'deleted-user',
-	},
-	// Trust marks record which admin reviewed a listing. When that admin's
-	// account is deleted the mark itself stays valid (the review happened);
-	// only the attribution is anonymized, matching community_bans.
-	{
-		kind: 'replace_user_column',
-		table: 'community_listings',
-		matchColumn: 'trusted_by_user_id',
-		setColumn: 'trusted_by_user_id',
-		value: 'deleted-user',
-	},
-	{
-		kind: 'user_columns',
-		table: 'community_listings',
-		columns: ['owner_user_id'],
-	},
-	// password_resets.user_id is an INTEGER FK to users.id (predates the
-	// stable mcp string user id), so it must be handled with the database
-	// integer id rather than the mcp user id.
-	{ kind: 'db_user_id', table: 'email_verifications' },
-	{ kind: 'db_user_id', table: 'pending_email_changes' },
-	{ kind: 'db_user_id', table: 'password_resets' },
-	{ kind: 'db_user_id', table: 'user_roles' },
-	{ kind: 'db_user_id', table: 'passkeys' },
-	{ kind: 'db_user_id', table: 'oauth_connections' },
-	// Feature-flag overrides use the integer users.id FK (with ON DELETE
-	// CASCADE), but account deletion still issues an explicit DELETE so the
-	// cascade stays self-contained when FK enforcement is disabled.
-	{ kind: 'db_user_id', table: 'feature_flag_user_overrides' },
-	// Two-factor verification rows are keyed by `target` = stringified db user
-	// id rather than a user_id column, so they need the dedicated kind.
-	{ kind: 'db_user_target', table: 'verifications' },
-]
+  { kind: "user_id", table: "package_invocations" },
+  { kind: "user_id", table: "package_invocation_tokens" },
+  { kind: "user_id", table: "workflow_runs" },
+  { kind: "user_id", table: "package_runtime_logs" },
+  { kind: "user_id", table: "package_runtime_runs" },
+  { kind: "user_id", table: "usage_rollups" },
+  { kind: "mcp_memory_suppression" },
+  { kind: "user_id", table: "mcp_memories" },
+  { kind: "user_id", table: "mcp_user_server_instructions" },
+  {
+    kind: "bucket_parent",
+    table: "value_entries",
+    parentTable: "value_buckets",
+  },
+  { kind: "user_id", table: "value_buckets" },
+  {
+    kind: "bucket_parent",
+    table: "secret_entries",
+    parentTable: "secret_buckets",
+  },
+  { kind: "user_id", table: "secret_buckets" },
+  { kind: "user_id", table: "remote_connector_settings" },
+  { kind: "user_id", table: "mcp_server_settings" },
+  { kind: "user_id", table: "archived_job_artifacts" },
+  { kind: "user_id", table: "published_bundle_artifacts" },
+  { kind: "user_id", table: "jobs" },
+  { kind: "user_id", table: "repo_sessions" },
+  { kind: "user_id", table: "saved_packages" },
+  { kind: "user_id", table: "entity_sources" },
+  { kind: "user_id", table: "email_delivery_events" },
+  { kind: "attachment_parent", table: "email_attachments" },
+  { kind: "user_id", table: "email_messages" },
+  { kind: "user_id", table: "email_threads" },
+  { kind: "user_id", table: "email_inbox_addresses" },
+  { kind: "user_id", table: "email_inboxes" },
+  { kind: "user_id", table: "email_sender_identities" },
+  { kind: "user_id", table: "entitlement_daily_counters" },
+  {
+    kind: "user_columns",
+    table: "platform_feedback",
+    columns: ["submitter_user_id"],
+  },
+  // Feedback is owned by its submitter. A reviewer relationship is cleanup
+  // metadata only: deleting that reviewer anonymizes the surviving review,
+  // but account export must not expose another user's feedback to the reviewer.
+  {
+    kind: "null_user_column",
+    table: "platform_feedback",
+    matchColumn: "reviewed_by_user_id",
+    nullColumns: ["reviewed_by_user_id", "reviewed_at", "admin_note"],
+    includeInExport: false,
+  },
+  {
+    kind: "community_listing_child",
+    table: "community_ratings",
+    listingColumn: "listing_id",
+  },
+  { kind: "user_id", table: "community_ratings" },
+  {
+    kind: "community_listing_child",
+    table: "community_stars",
+    listingColumn: "listing_id",
+  },
+  { kind: "user_id", table: "community_stars" },
+  {
+    kind: "community_listing_child",
+    table: "community_activity_events",
+    listingColumn: "listing_id",
+  },
+  {
+    kind: "user_columns",
+    table: "community_activity_events",
+    columns: ["actor_user_id"],
+  },
+  {
+    kind: "user_columns",
+    table: "user_follows",
+    columns: ["follower_user_id", "followee_user_id"],
+  },
+  {
+    kind: "community_listing_child",
+    table: "community_forks",
+    listingColumn: "listing_id",
+  },
+  {
+    kind: "user_columns",
+    table: "community_forks",
+    columns: ["forker_user_id"],
+  },
+  {
+    kind: "community_listing_child",
+    table: "community_reports",
+    listingColumn: "listing_id",
+  },
+  {
+    kind: "user_columns",
+    table: "community_reports",
+    columns: ["listing_owner_user_id", "reporter_user_id"],
+  },
+  {
+    kind: "null_user_column",
+    table: "community_reports",
+    matchColumn: "resolved_by_user_id",
+    nullColumns: ["resolved_by_user_id", "resolved_at", "resolution_note"],
+  },
+  // A grant dies with its scope owner or grantee, but survives deletion of
+  // the admin who created it (the grant remains valid; only attribution is
+  // anonymized, matching community_bans).
+  {
+    kind: "user_columns",
+    table: "package_scope_grants",
+    columns: ["scope_owner_user_id", "grantee_user_id"],
+  },
+  {
+    kind: "replace_user_column",
+    table: "package_scope_grants",
+    matchColumn: "created_by_user_id",
+    setColumn: "created_by_user_id",
+    value: "deleted-user",
+  },
+  {
+    kind: "user_columns",
+    table: "community_bans",
+    columns: ["user_id"],
+  },
+  {
+    kind: "replace_user_column",
+    table: "community_bans",
+    matchColumn: "banned_by_user_id",
+    setColumn: "banned_by_user_id",
+    value: "deleted-user",
+  },
+  // Trust marks record which admin reviewed a listing. When that admin's
+  // account is deleted the mark itself stays valid (the review happened);
+  // only the attribution is anonymized, matching community_bans.
+  {
+    kind: "replace_user_column",
+    table: "community_listings",
+    matchColumn: "trusted_by_user_id",
+    setColumn: "trusted_by_user_id",
+    value: "deleted-user",
+  },
+  {
+    kind: "user_columns",
+    table: "community_listings",
+    columns: ["owner_user_id"],
+  },
+  // password_resets.user_id is an INTEGER FK to users.id (predates the
+  // stable mcp string user id), so it must be handled with the database
+  // integer id rather than the mcp user id.
+  { kind: "db_user_id", table: "email_verifications" },
+  { kind: "db_user_id", table: "pending_email_changes" },
+  { kind: "db_user_id", table: "password_resets" },
+  { kind: "db_user_id", table: "user_roles" },
+  { kind: "db_user_id", table: "passkeys" },
+  { kind: "db_user_id", table: "oauth_connections" },
+  // Feature-flag overrides use the integer users.id FK (with ON DELETE
+  // CASCADE), but account deletion still issues an explicit DELETE so the
+  // cascade stays self-contained when FK enforcement is disabled.
+  { kind: "db_user_id", table: "feature_flag_user_overrides" },
+  // Two-factor verification rows are keyed by `target` = stringified db user
+  // id rather than a user_id column, so they need the dedicated kind.
+  { kind: "db_user_target", table: "verifications" },
+];
 
 export function getAccountD1UserColumnCoverage() {
-	const covered = new Set<string>()
-	covered.add('users.stable_user_id')
-	for (const target of accountUserDataTargets) {
-		switch (target.kind) {
-			case 'user_id':
-			case 'db_user_id':
-			case 'mcp_memory_suppression': {
-				const table =
-					target.kind === 'mcp_memory_suppression'
-						? 'mcp_memory_conversation_suppressions'
-						: target.table
-				covered.add(`${table}.user_id`)
-				break
-			}
-			case 'user_columns': {
-				for (const column of target.columns) {
-					covered.add(`${target.table}.${column}`)
-				}
-				break
-			}
-			case 'null_user_column': {
-				covered.add(`${target.table}.${target.matchColumn}`)
-				break
-			}
-			case 'replace_user_column': {
-				covered.add(`${target.table}.${target.matchColumn}`)
-				break
-			}
-			case 'bucket_parent':
-			case 'attachment_parent':
-			case 'community_listing_child':
-			// db_user_target tables key rows by `target`, not a *_user_id
-			// column, so there is no schema column for the guard to cover.
-			case 'db_user_target': {
-				break
-			}
-			default: {
-				const exhaustive: never = target
-				throw new Error(
-					`Unhandled account data coverage target: ${JSON.stringify(exhaustive)}`,
-				)
-			}
-		}
-	}
-	return covered
+  const covered = new Set<string>();
+  covered.add("users.stable_user_id");
+  for (const target of accountUserDataTargets) {
+    switch (target.kind) {
+      case "user_id":
+      case "db_user_id":
+      case "mcp_memory_suppression": {
+        const table =
+          target.kind === "mcp_memory_suppression"
+            ? "mcp_memory_conversation_suppressions"
+            : target.table;
+        covered.add(`${table}.user_id`);
+        break;
+      }
+      case "user_columns": {
+        for (const column of target.columns) {
+          covered.add(`${target.table}.${column}`);
+        }
+        break;
+      }
+      case "null_user_column": {
+        covered.add(`${target.table}.${target.matchColumn}`);
+        break;
+      }
+      case "replace_user_column": {
+        covered.add(`${target.table}.${target.matchColumn}`);
+        break;
+      }
+      case "bucket_parent":
+      case "attachment_parent":
+      case "community_listing_child":
+      // db_user_target tables key rows by `target`, not a *_user_id
+      // column, so there is no schema column for the guard to cover.
+      case "db_user_target": {
+        break;
+      }
+      default: {
+        const exhaustive: never = target;
+        throw new Error(
+          `Unhandled account data coverage target: ${JSON.stringify(exhaustive)}`,
+        );
+      }
+    }
+  }
+  return covered;
 }

--- a/packages/worker/src/app/account-export.ts
+++ b/packages/worker/src/app/account-export.ts
@@ -1,477 +1,477 @@
-import { getErrorMessage } from "@kody-internal/shared/error-message.ts";
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import {
-  accountUserDataTargets,
-  accountUserDataExcludedOwnerIds,
-  type UserScopedDataTarget,
-  getAccountD1UserColumnCoverage,
-} from "#app/account-data-targets.ts";
-import { exportJobManagerForUser } from "#worker/jobs/manager-client.ts";
+	accountUserDataTargets,
+	accountUserDataExcludedOwnerIds,
+	type UserScopedDataTarget,
+	getAccountD1UserColumnCoverage,
+} from '#app/account-data-targets.ts'
+import { exportJobManagerForUser } from '#worker/jobs/manager-client.ts'
 import {
-  buildPackageServiceStorageId,
-  packageServiceRpc,
-} from "#worker/package-runtime/package-service.ts";
+	buildPackageServiceStorageId,
+	packageServiceRpc,
+} from '#worker/package-runtime/package-service.ts'
 import {
-  buildPublishedSourceManifestSnapshotKvKey,
-  buildPublishedSourceSnapshotKvKey,
-} from "#worker/package-runtime/published-runtime-artifacts.ts";
-import { buildCommunitySnapshotKvKey } from "#worker/community/snapshot.ts";
-import { storageRunnerRpc } from "#worker/storage-runner.ts";
-import { userScopedConnectorSessionKey } from "#worker/remote-connector/connector-session-key.ts";
-import { type RemoteConnectorSessionExport } from "#worker/remote-connector/types.ts";
-import { resolveUserStableId } from "#worker/user-id.ts";
+	buildPublishedSourceManifestSnapshotKvKey,
+	buildPublishedSourceSnapshotKvKey,
+} from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { buildCommunitySnapshotKvKey } from '#worker/community/snapshot.ts'
+import { storageRunnerRpc } from '#worker/storage-runner.ts'
+import { userScopedConnectorSessionKey } from '#worker/remote-connector/connector-session-key.ts'
+import { type RemoteConnectorSessionExport } from '#worker/remote-connector/types.ts'
+import { resolveUserStableId } from '#worker/user-id.ts'
 
-const accountExportSchemaVersion = 1;
-const defaultExportPageSize = 100;
-const maxExportPageSize = 500;
+const accountExportSchemaVersion = 1
+const defaultExportPageSize = 100
+const maxExportPageSize = 500
 // Full exports stream each D1 table in keyset-paged batches of this size so
 // memory stays bounded per query even for very large tables (e.g. mailboxes).
-const d1ExportPageSize = 500;
+const d1ExportPageSize = 500
 // Internal alias for the SQLite rowid used as the keyset cursor. Stripped from
 // exported rows so the export document schema is unchanged.
-const exportRowidColumn = "__account_export_rowid";
+const exportRowidColumn = '__account_export_rowid'
 
 // Secret values and credential-equivalent hashes must never leave Kody through
 // account export. Secret entries are metadata-only; encrypted payloads stay
 // server-side and token/password hashes are omitted for the same reason.
 const redactedColumnsByTable: Readonly<Record<string, ReadonlyArray<string>>> =
-  {
-    email_inbox_addresses: ["reply_token_hash"],
-    email_verifications: ["token_hash"],
-    package_invocation_tokens: ["token_hash"],
-    password_resets: ["token_hash"],
-    pending_email_changes: ["token_hash"],
-    platform_feedback: ["reviewed_by_user_id", "reviewed_at", "admin_note"],
-    remote_connector_settings: ["encrypted_shared_secret"],
-    secret_entries: ["encrypted_value", "lookup_hash"],
-    users: ["password_hash"],
-    verifications: ["secret"],
-  };
+	{
+		email_inbox_addresses: ['reply_token_hash'],
+		email_verifications: ['token_hash'],
+		package_invocation_tokens: ['token_hash'],
+		password_resets: ['token_hash'],
+		pending_email_changes: ['token_hash'],
+		platform_feedback: ['reviewed_by_user_id', 'reviewed_at', 'admin_note'],
+		remote_connector_settings: ['encrypted_shared_secret'],
+		secret_entries: ['encrypted_value', 'lookup_hash'],
+		users: ['password_hash'],
+		verifications: ['secret'],
+	}
 
 // Social-graph export rows can include another user's stable id. Keep the
 // exporter's own id; replace every other value in these columns.
 const foreignUserIdColumnsByTable: Readonly<
-  Record<string, ReadonlyArray<string>>
+	Record<string, ReadonlyArray<string>>
 > = {
-  user_follows: ["follower_user_id", "followee_user_id"],
-  community_stars: ["user_id"],
-  community_activity_events: ["actor_user_id"],
-  package_scope_grants: [
-    "scope_owner_user_id",
-    "grantee_user_id",
-    "created_by_user_id",
-  ],
-};
+	user_follows: ['follower_user_id', 'followee_user_id'],
+	community_stars: ['user_id'],
+	community_activity_events: ['actor_user_id'],
+	package_scope_grants: [
+		'scope_owner_user_id',
+		'grantee_user_id',
+		'created_by_user_id',
+	],
+}
 
-const redactedForeignUserId = "[redacted]";
+const redactedForeignUserId = '[redacted]'
 
 export const accountExportSectionNames = [
-  "d1_table",
-  "storage_runner",
-  "oauth_grants",
-  "artifact_repos",
-  "kv_keys",
-  "durable_object_summaries",
-] as const;
+	'd1_table',
+	'storage_runner',
+	'oauth_grants',
+	'artifact_repos',
+	'kv_keys',
+	'durable_object_summaries',
+] as const
 
 export type AccountExportSectionName =
-  (typeof accountExportSectionNames)[number];
+	(typeof accountExportSectionNames)[number]
 
 type OAuthGrantPage = {
-  items: Array<{ id: string; clientId: string }>;
-  cursor: string | undefined;
-};
+	items: Array<{ id: string; clientId: string }>
+	cursor: string | undefined
+}
 
 type OAuthHelpersShape = {
-  listUserGrants(
-    userId: string,
-    options: { cursor: string | undefined },
-  ): Promise<OAuthGrantPage>;
-};
+	listUserGrants(
+		userId: string,
+		options: { cursor: string | undefined },
+	): Promise<OAuthGrantPage>
+}
 
 type AccountExportEnv = Env & {
-  OAUTH_PROVIDER?: OAuthHelpersShape;
-};
+	OAUTH_PROVIDER?: OAuthHelpersShape
+}
 
 type UserSourceSnapshot = {
-  sourceId: string;
-  publishedCommit: string | null;
-  repoId: string;
-  entityKind: string;
-  entityId: string;
-  manifestPath: string;
-  sourceRoot: string;
-};
+	sourceId: string
+	publishedCommit: string | null
+	repoId: string
+	entityKind: string
+	entityId: string
+	manifestPath: string
+	sourceRoot: string
+}
 
 type UserSavedPackageSnapshot = {
-  id: string;
-  kodyId: string;
-  sourceId: string;
-  hasApp: boolean;
-};
+	id: string
+	kodyId: string
+	sourceId: string
+	hasApp: boolean
+}
 
 type UserRemoteConnectorSnapshot = {
-  instanceId: string;
-};
+	instanceId: string
+}
 
 type UserPackageServiceSnapshot = {
-  packageId: string;
-  kodyId: string;
-  sourceId: string;
-  serviceName: string;
-};
+	packageId: string
+	kodyId: string
+	sourceId: string
+	serviceName: string
+}
 
 type UserExportInventory = {
-  storageIds: Array<string>;
-  sourceSnapshots: Array<UserSourceSnapshot>;
-  savedPackages: Array<UserSavedPackageSnapshot>;
-  remoteConnectors: Array<UserRemoteConnectorSnapshot>;
-  packageServices: Array<UserPackageServiceSnapshot>;
-  communityListingIds: Array<string>;
-  bundleKvKeys: Array<string>;
-  artifactRepos: Array<AccountExportArtifactRepo>;
-};
+	storageIds: Array<string>
+	sourceSnapshots: Array<UserSourceSnapshot>
+	savedPackages: Array<UserSavedPackageSnapshot>
+	remoteConnectors: Array<UserRemoteConnectorSnapshot>
+	packageServices: Array<UserPackageServiceSnapshot>
+	communityListingIds: Array<string>
+	bundleKvKeys: Array<string>
+	artifactRepos: Array<AccountExportArtifactRepo>
+}
 
 export type AccountExportManifestSection = {
-  count: number;
-  warnings: Array<string>;
-  redactedColumns?: Array<string>;
-};
+	count: number
+	warnings: Array<string>
+	redactedColumns?: Array<string>
+}
 
 export type AccountExportManifest = {
-  schemaVersion: number;
-  generatedAt: string;
-  user: {
-    dbUserId: number;
-    userId: string;
-  };
-  security: {
-    secretValuesExported: false;
-    note: string;
-  };
-  sections: Record<string, AccountExportManifestSection>;
-  warnings: Array<string>;
-  chunking: {
-    sections: Array<AccountExportSectionName>;
-    defaultPageSize: number;
-    maxPageSize: number;
-  };
-  artifacts: {
-    canonicalPackageSource: string;
-  };
-  derivedData: {
-    vectorize: string;
-  };
-  excludedDurableObjects: Array<{
-    name: string;
-    reason: string;
-  }>;
-  excludedD1Surfaces: Array<{
-    name: string;
-    reason: string;
-  }>;
-};
+	schemaVersion: number
+	generatedAt: string
+	user: {
+		dbUserId: number
+		userId: string
+	}
+	security: {
+		secretValuesExported: false
+		note: string
+	}
+	sections: Record<string, AccountExportManifestSection>
+	warnings: Array<string>
+	chunking: {
+		sections: Array<AccountExportSectionName>
+		defaultPageSize: number
+		maxPageSize: number
+	}
+	artifacts: {
+		canonicalPackageSource: string
+	}
+	derivedData: {
+		vectorize: string
+	}
+	excludedDurableObjects: Array<{
+		name: string
+		reason: string
+	}>
+	excludedD1Surfaces: Array<{
+		name: string
+		reason: string
+	}>
+}
 
 export type AccountExportD1Table = {
-  table: string;
-  rows: Array<Record<string, unknown>>;
-  redactedColumns: Array<string>;
-  warnings: Array<string>;
-};
+	table: string
+	rows: Array<Record<string, unknown>>
+	redactedColumns: Array<string>
+	warnings: Array<string>
+}
 
 export type AccountExportArtifactRepo = {
-  sourceId: string;
-  entityKind: string;
-  entityId: string;
-  repoId: string;
-  publishedCommit: string | null;
-  manifestPath: string;
-  sourceRoot: string;
-};
+	sourceId: string
+	entityKind: string
+	entityId: string
+	repoId: string
+	publishedCommit: string | null
+	manifestPath: string
+	sourceRoot: string
+}
 
 type AccountExportDurableObjects = {
-  jobManager: unknown | null;
-  remoteConnectorSessions: Array<{
-    instanceId: string;
-    export: RemoteConnectorSessionExport | null;
-  }>;
-  packageServices: Array<{
-    packageId: string;
-    serviceName: string;
-    status: unknown | null;
-  }>;
-  storageRunners: Array<{
-    storageId: string;
-    export: Awaited<
-      ReturnType<ReturnType<typeof storageRunnerRpc>["exportStorage"]>
-    >;
-  }>;
-};
+	jobManager: unknown | null
+	remoteConnectorSessions: Array<{
+		instanceId: string
+		export: RemoteConnectorSessionExport | null
+	}>
+	packageServices: Array<{
+		packageId: string
+		serviceName: string
+		status: unknown | null
+	}>
+	storageRunners: Array<{
+		storageId: string
+		export: Awaited<
+			ReturnType<ReturnType<typeof storageRunnerRpc>['exportStorage']>
+		>
+	}>
+}
 
 export type AccountExportFile = {
-  manifest: AccountExportManifest;
-  d1: Record<string, AccountExportD1Table>;
-  durableObjects: AccountExportDurableObjects;
-  oauthGrants: Array<{ id: string; clientId: string }>;
-  artifactRepos: Array<AccountExportArtifactRepo>;
-  kvKeys: Array<string>;
-};
+	manifest: AccountExportManifest
+	d1: Record<string, AccountExportD1Table>
+	durableObjects: AccountExportDurableObjects
+	oauthGrants: Array<{ id: string; clientId: string }>
+	artifactRepos: Array<AccountExportArtifactRepo>
+	kvKeys: Array<string>
+}
 
 export type AccountExportSectionResult = {
-  section: AccountExportSectionName;
-  items: Array<unknown>;
-  truncated: boolean;
-  nextStartAfter: string | null;
-  pageSize: number;
-  warnings: Array<string>;
-};
+	section: AccountExportSectionName
+	items: Array<unknown>
+	truncated: boolean
+	nextStartAfter: string | null
+	pageSize: number
+	warnings: Array<string>
+}
 
 function normalizePageSize(pageSize: number | undefined) {
-  const requested =
-    typeof pageSize === "number" && Number.isFinite(pageSize)
-      ? Math.trunc(pageSize)
-      : defaultExportPageSize;
-  return Math.min(Math.max(requested, 1), maxExportPageSize);
+	const requested =
+		typeof pageSize === 'number' && Number.isFinite(pageSize)
+			? Math.trunc(pageSize)
+			: defaultExportPageSize
+	return Math.min(Math.max(requested, 1), maxExportPageSize)
 }
 
 function paginateItems<T>(input: {
-  items: ReadonlyArray<T>;
-  pageSize: number | undefined;
-  startAfter: string | undefined;
+	items: ReadonlyArray<T>
+	pageSize: number | undefined
+	startAfter: string | undefined
 }) {
-  const pageSize = normalizePageSize(input.pageSize);
-  const startIndex = input.startAfter
-    ? Number.parseInt(input.startAfter, 10)
-    : 0;
-  const safeStart =
-    Number.isFinite(startIndex) && startIndex > 0 ? startIndex : 0;
-  const page = input.items.slice(safeStart, safeStart + pageSize);
-  const nextIndex = safeStart + page.length;
-  const truncated = nextIndex < input.items.length;
-  return {
-    items: page,
-    truncated,
-    nextStartAfter: truncated ? String(nextIndex) : null,
-    pageSize,
-  };
+	const pageSize = normalizePageSize(input.pageSize)
+	const startIndex = input.startAfter
+		? Number.parseInt(input.startAfter, 10)
+		: 0
+	const safeStart =
+		Number.isFinite(startIndex) && startIndex > 0 ? startIndex : 0
+	const page = input.items.slice(safeStart, safeStart + pageSize)
+	const nextIndex = safeStart + page.length
+	const truncated = nextIndex < input.items.length
+	return {
+		items: page,
+		truncated,
+		nextStartAfter: truncated ? String(nextIndex) : null,
+		pageSize,
+	}
 }
 
 function uniqueStrings(values: Iterable<string | null | undefined>) {
-  return Array.from(
-    new Set(
-      Array.from(values)
-        .map((value) => value?.trim() ?? "")
-        .filter((value) => value.length > 0),
-    ),
-  );
+	return Array.from(
+		new Set(
+			Array.from(values)
+				.map((value) => value?.trim() ?? '')
+				.filter((value) => value.length > 0),
+		),
+	)
 }
 
 function normalizeBoolean(value: unknown) {
-  return value === 1 || value === "1" || value === true;
+	return value === 1 || value === '1' || value === true
 }
 
 type D1TableCondition = {
-  condition: string;
-  params: Array<unknown>;
-};
+	condition: string
+	params: Array<unknown>
+}
 
 function buildConditionForTarget(input: {
-  target: UserScopedDataTarget;
-  mcpUserId: string;
-  dbUserId: number;
+	target: UserScopedDataTarget
+	mcpUserId: string
+	dbUserId: number
 }): { table: string; condition: D1TableCondition } {
-  const { target } = input;
-  switch (target.kind) {
-    case "user_id": {
-      return {
-        table: target.table,
-        condition: {
-          condition: `${target.table}.user_id = ?`,
-          params: [input.mcpUserId],
-        },
-      };
-    }
-    case "db_user_id": {
-      return {
-        table: target.table,
-        condition: {
-          condition: `${target.table}.user_id = ?`,
-          params: [input.dbUserId],
-        },
-      };
-    }
-    case "db_user_target": {
-      return {
-        table: target.table,
-        condition: {
-          condition: `${target.table}.target = ?`,
-          params: [String(input.dbUserId)],
-        },
-      };
-    }
-    case "user_columns": {
-      return {
-        table: target.table,
-        condition: {
-          condition: target.columns
-            .map((column) => `${target.table}.${column} = ?`)
-            .join(" OR "),
-          params: target.columns.map(() => input.mcpUserId),
-        },
-      };
-    }
-    case "null_user_column": {
-      return {
-        table: target.table,
-        condition: {
-          condition: `${target.table}.${target.matchColumn} = ?`,
-          params: [input.mcpUserId],
-        },
-      };
-    }
-    case "replace_user_column": {
-      return {
-        table: target.table,
-        condition: {
-          condition: `${target.table}.${target.matchColumn} = ?`,
-          params: [input.mcpUserId],
-        },
-      };
-    }
-    case "bucket_parent": {
-      return {
-        table: target.table,
-        condition: {
-          condition: `${target.table}.bucket_id IN (
+	const { target } = input
+	switch (target.kind) {
+		case 'user_id': {
+			return {
+				table: target.table,
+				condition: {
+					condition: `${target.table}.user_id = ?`,
+					params: [input.mcpUserId],
+				},
+			}
+		}
+		case 'db_user_id': {
+			return {
+				table: target.table,
+				condition: {
+					condition: `${target.table}.user_id = ?`,
+					params: [input.dbUserId],
+				},
+			}
+		}
+		case 'db_user_target': {
+			return {
+				table: target.table,
+				condition: {
+					condition: `${target.table}.target = ?`,
+					params: [String(input.dbUserId)],
+				},
+			}
+		}
+		case 'user_columns': {
+			return {
+				table: target.table,
+				condition: {
+					condition: target.columns
+						.map((column) => `${target.table}.${column} = ?`)
+						.join(' OR '),
+					params: target.columns.map(() => input.mcpUserId),
+				},
+			}
+		}
+		case 'null_user_column': {
+			return {
+				table: target.table,
+				condition: {
+					condition: `${target.table}.${target.matchColumn} = ?`,
+					params: [input.mcpUserId],
+				},
+			}
+		}
+		case 'replace_user_column': {
+			return {
+				table: target.table,
+				condition: {
+					condition: `${target.table}.${target.matchColumn} = ?`,
+					params: [input.mcpUserId],
+				},
+			}
+		}
+		case 'bucket_parent': {
+			return {
+				table: target.table,
+				condition: {
+					condition: `${target.table}.bucket_id IN (
 						SELECT id FROM ${target.parentTable} WHERE user_id = ?
 					)`,
-          params: [input.mcpUserId],
-        },
-      };
-    }
-    case "attachment_parent": {
-      return {
-        table: "email_attachments",
-        condition: {
-          condition: `email_attachments.message_id IN (
+					params: [input.mcpUserId],
+				},
+			}
+		}
+		case 'attachment_parent': {
+			return {
+				table: 'email_attachments',
+				condition: {
+					condition: `email_attachments.message_id IN (
 						SELECT id FROM email_messages WHERE user_id = ?
 					)`,
-          params: [input.mcpUserId],
-        },
-      };
-    }
-    case "community_listing_child": {
-      return {
-        table: target.table,
-        condition: {
-          condition: `${target.table}.${target.listingColumn} IN (
+					params: [input.mcpUserId],
+				},
+			}
+		}
+		case 'community_listing_child': {
+			return {
+				table: target.table,
+				condition: {
+					condition: `${target.table}.${target.listingColumn} IN (
 						SELECT id FROM community_listings WHERE owner_user_id = ?
 					)`,
-          params: [input.mcpUserId],
-        },
-      };
-    }
-    case "mcp_memory_suppression": {
-      return {
-        table: "mcp_memory_conversation_suppressions",
-        condition: {
-          condition: `mcp_memory_conversation_suppressions.user_id = ?`,
-          params: [input.mcpUserId],
-        },
-      };
-    }
-    default: {
-      const exhaustive: never = target;
-      throw new Error(
-        `Unhandled account export target: ${JSON.stringify(exhaustive)}`,
-      );
-    }
-  }
+					params: [input.mcpUserId],
+				},
+			}
+		}
+		case 'mcp_memory_suppression': {
+			return {
+				table: 'mcp_memory_conversation_suppressions',
+				condition: {
+					condition: `mcp_memory_conversation_suppressions.user_id = ?`,
+					params: [input.mcpUserId],
+				},
+			}
+		}
+		default: {
+			const exhaustive: never = target
+			throw new Error(
+				`Unhandled account export target: ${JSON.stringify(exhaustive)}`,
+			)
+		}
+	}
 }
 
 function buildD1TableConditions(input: {
-  mcpUserId: string;
-  dbUserId: number;
+	mcpUserId: string
+	dbUserId: number
 }) {
-  const conditionsByTable = new Map<string, Array<D1TableCondition>>();
-  function add(table: string, condition: D1TableCondition) {
-    const existing = conditionsByTable.get(table);
-    if (existing) {
-      existing.push(condition);
-      return;
-    }
-    conditionsByTable.set(table, [condition]);
-  }
-  add("users", { condition: `users.id = ?`, params: [input.dbUserId] });
-  for (const target of accountUserDataTargets) {
-    if (
-      target.kind === "null_user_column" &&
-      target.includeInExport === false
-    ) {
-      continue;
-    }
-    const built = buildConditionForTarget({
-      target,
-      mcpUserId: input.mcpUserId,
-      dbUserId: input.dbUserId,
-    });
-    add(built.table, built.condition);
-  }
-  return conditionsByTable;
+	const conditionsByTable = new Map<string, Array<D1TableCondition>>()
+	function add(table: string, condition: D1TableCondition) {
+		const existing = conditionsByTable.get(table)
+		if (existing) {
+			existing.push(condition)
+			return
+		}
+		conditionsByTable.set(table, [condition])
+	}
+	add('users', { condition: `users.id = ?`, params: [input.dbUserId] })
+	for (const target of accountUserDataTargets) {
+		if (
+			target.kind === 'null_user_column' &&
+			target.includeInExport === false
+		) {
+			continue
+		}
+		const built = buildConditionForTarget({
+			target,
+			mcpUserId: input.mcpUserId,
+			dbUserId: input.dbUserId,
+		})
+		add(built.table, built.condition)
+	}
+	return conditionsByTable
 }
 
 function sanitizeRow(
-  table: string,
-  row: Record<string, unknown>,
-  mcpUserId: string,
+	table: string,
+	row: Record<string, unknown>,
+	mcpUserId: string,
 ) {
-  const redactedColumns = redactedColumnsByTable[table] ?? [];
-  const foreignUserIdColumns = foreignUserIdColumnsByTable[table] ?? [];
-  const sanitized: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(row)) {
-    if (redactedColumns.includes(key)) continue;
-    if (
-      foreignUserIdColumns.includes(key) &&
-      typeof value === "string" &&
-      value !== mcpUserId
-    ) {
-      sanitized[key] = redactedForeignUserId;
-      continue;
-    }
-    sanitized[key] = value;
-  }
-  return {
-    row: sanitized,
-    redactedColumns: redactedColumns.filter((column) => column in row),
-  };
+	const redactedColumns = redactedColumnsByTable[table] ?? []
+	const foreignUserIdColumns = foreignUserIdColumnsByTable[table] ?? []
+	const sanitized: Record<string, unknown> = {}
+	for (const [key, value] of Object.entries(row)) {
+		if (redactedColumns.includes(key)) continue
+		if (
+			foreignUserIdColumns.includes(key) &&
+			typeof value === 'string' &&
+			value !== mcpUserId
+		) {
+			sanitized[key] = redactedForeignUserId
+			continue
+		}
+		sanitized[key] = value
+	}
+	return {
+		row: sanitized,
+		redactedColumns: redactedColumns.filter((column) => column in row),
+	}
 }
 
 function rowDedupeKey(row: Record<string, unknown>) {
-  if ("id" in row && row.id !== null && row.id !== undefined)
-    return String(row.id);
-  if ("bucket_id" in row && "name" in row) {
-    return `${String(row.bucket_id)}:${String(row.name)}`;
-  }
-  if ("user_id" in row && "role_id" in row) {
-    return `${String(row.user_id)}:${String(row.role_id)}`;
-  }
-  return JSON.stringify(row);
+	if ('id' in row && row.id !== null && row.id !== undefined)
+		return String(row.id)
+	if ('bucket_id' in row && 'name' in row) {
+		return `${String(row.bucket_id)}:${String(row.name)}`
+	}
+	if ('user_id' in row && 'role_id' in row) {
+		return `${String(row.user_id)}:${String(row.role_id)}`
+	}
+	return JSON.stringify(row)
 }
 
 function sortRowsByDedupeKey(rows: Array<Record<string, unknown>>) {
-  return rows.sort((left, right) =>
-    rowDedupeKey(left).localeCompare(rowDedupeKey(right)),
-  );
+	return rows.sort((left, right) =>
+		rowDedupeKey(left).localeCompare(rowDedupeKey(right)),
+	)
 }
 
 async function selectRows<T extends Record<string, unknown>>(
-  env: Env,
-  sql: string,
-  params: ReadonlyArray<unknown>,
+	env: Env,
+	sql: string,
+	params: ReadonlyArray<unknown>,
 ) {
-  const result = await env.APP_DB.prepare(sql)
-    .bind(...params)
-    .all<T>();
-  return result.results ?? [];
+	const result = await env.APP_DB.prepare(sql)
+		.bind(...params)
+		.all<T>()
+	return result.results ?? []
 }
 
 // Reads one keyset page of a table: rows are selected by ascending rowid
@@ -480,193 +480,193 @@ async function selectRows<T extends Record<string, unknown>>(
 // target of the table are OR-combined into one query, which also removes the
 // need for cross-target row deduplication.
 async function selectD1TablePage(input: {
-  env: AccountExportEnv;
-  table: string;
-  conditions: ReadonlyArray<D1TableCondition>;
-  mcpUserId: string;
-  afterRowid: number;
-  limit: number;
+	env: AccountExportEnv
+	table: string
+	conditions: ReadonlyArray<D1TableCondition>
+	mcpUserId: string
+	afterRowid: number
+	limit: number
 }) {
-  const where = input.conditions
-    .map((condition) => `(${condition.condition})`)
-    .join(" OR ");
-  const sql = `SELECT ${input.table}.rowid AS ${exportRowidColumn}, ${input.table}.*
+	const where = input.conditions
+		.map((condition) => `(${condition.condition})`)
+		.join(' OR ')
+	const sql = `SELECT ${input.table}.rowid AS ${exportRowidColumn}, ${input.table}.*
 		FROM ${input.table}
 		WHERE (${where}) AND ${input.table}.rowid > ?
 		ORDER BY ${input.table}.rowid
-		LIMIT ?`;
-  const params = [
-    ...input.conditions.flatMap((condition) => condition.params),
-    input.afterRowid,
-    input.limit + 1,
-  ];
-  const rawRows = await selectRows(input.env, sql, params);
-  const truncated = rawRows.length > input.limit;
-  const pageRows = truncated ? rawRows.slice(0, input.limit) : rawRows;
-  let lastRowid = input.afterRowid;
-  const rows: Array<ReturnType<typeof sanitizeRow>> = [];
-  for (const rawRow of pageRows) {
-    const { [exportRowidColumn]: rowid, ...columns } = rawRow;
-    lastRowid = Number(rowid);
-    rows.push(sanitizeRow(input.table, columns, input.mcpUserId));
-  }
-  return { rows, lastRowid, truncated };
+		LIMIT ?`
+	const params = [
+		...input.conditions.flatMap((condition) => condition.params),
+		input.afterRowid,
+		input.limit + 1,
+	]
+	const rawRows = await selectRows(input.env, sql, params)
+	const truncated = rawRows.length > input.limit
+	const pageRows = truncated ? rawRows.slice(0, input.limit) : rawRows
+	let lastRowid = input.afterRowid
+	const rows: Array<ReturnType<typeof sanitizeRow>> = []
+	for (const rawRow of pageRows) {
+		const { [exportRowidColumn]: rowid, ...columns } = rawRow
+		lastRowid = Number(rowid)
+		rows.push(sanitizeRow(input.table, columns, input.mcpUserId))
+	}
+	return { rows, lastRowid, truncated }
 }
 
 async function collectD1TableRows(input: {
-  env: AccountExportEnv;
-  table: string;
-  conditions: ReadonlyArray<D1TableCondition>;
-  mcpUserId: string;
-  warnings: Array<string>;
+	env: AccountExportEnv
+	table: string
+	conditions: ReadonlyArray<D1TableCondition>
+	mcpUserId: string
+	warnings: Array<string>
 }): Promise<AccountExportD1Table> {
-  const section: AccountExportD1Table = {
-    table: input.table,
-    rows: [],
-    redactedColumns: [],
-    warnings: [],
-  };
-  const redacted = new Set<string>();
-  let afterRowid = 0;
-  try {
-    while (true) {
-      const page = await selectD1TablePage({
-        env: input.env,
-        table: input.table,
-        conditions: input.conditions,
-        mcpUserId: input.mcpUserId,
-        afterRowid,
-        limit: d1ExportPageSize,
-      });
-      for (const entry of page.rows) {
-        for (const column of entry.redactedColumns) redacted.add(column);
-        section.rows.push(entry.row);
-      }
-      if (!page.truncated) break;
-      afterRowid = page.lastRowid;
-    }
-  } catch (error) {
-    const warning = `D1 export failed for ${input.table}: ${getErrorMessage(error)}`;
-    section.warnings.push(warning);
-    input.warnings.push(warning);
-  }
-  section.rows = sortRowsByDedupeKey(section.rows);
-  section.redactedColumns = Array.from(redacted).sort();
-  return section;
+	const section: AccountExportD1Table = {
+		table: input.table,
+		rows: [],
+		redactedColumns: [],
+		warnings: [],
+	}
+	const redacted = new Set<string>()
+	let afterRowid = 0
+	try {
+		while (true) {
+			const page = await selectD1TablePage({
+				env: input.env,
+				table: input.table,
+				conditions: input.conditions,
+				mcpUserId: input.mcpUserId,
+				afterRowid,
+				limit: d1ExportPageSize,
+			})
+			for (const entry of page.rows) {
+				for (const column of entry.redactedColumns) redacted.add(column)
+				section.rows.push(entry.row)
+			}
+			if (!page.truncated) break
+			afterRowid = page.lastRowid
+		}
+	} catch (error) {
+		const warning = `D1 export failed for ${input.table}: ${getErrorMessage(error)}`
+		section.warnings.push(warning)
+		input.warnings.push(warning)
+	}
+	section.rows = sortRowsByDedupeKey(section.rows)
+	section.redactedColumns = Array.from(redacted).sort()
+	return section
 }
 
 async function listUserStorageIds(env: Env, userId: string) {
-  const [jobRows, archivedRows, runtimeRows, packageRows, serviceRows] =
-    await Promise.all([
-      selectRows<{ storage_id: string }>(
-        env,
-        `SELECT storage_id FROM jobs WHERE user_id = ? AND storage_id IS NOT NULL`,
-        [userId],
-      ),
-      selectRows<{ storage_id: string }>(
-        env,
-        `SELECT storage_id FROM archived_job_artifacts WHERE user_id = ? AND storage_id IS NOT NULL`,
-        [userId],
-      ),
-      selectRows<{ storage_id: string }>(
-        env,
-        `SELECT storage_id FROM package_runtime_runs WHERE user_id = ? AND storage_id IS NOT NULL`,
-        [userId],
-      ),
-      selectRows<{ id: string }>(
-        env,
-        `SELECT id FROM saved_packages WHERE user_id = ? AND has_app = 1`,
-        [userId],
-      ),
-      selectRows<{ package_id: string; name: string }>(
-        env,
-        `SELECT DISTINCT package_id, name
+	const [jobRows, archivedRows, runtimeRows, packageRows, serviceRows] =
+		await Promise.all([
+			selectRows<{ storage_id: string }>(
+				env,
+				`SELECT storage_id FROM jobs WHERE user_id = ? AND storage_id IS NOT NULL`,
+				[userId],
+			),
+			selectRows<{ storage_id: string }>(
+				env,
+				`SELECT storage_id FROM archived_job_artifacts WHERE user_id = ? AND storage_id IS NOT NULL`,
+				[userId],
+			),
+			selectRows<{ storage_id: string }>(
+				env,
+				`SELECT storage_id FROM package_runtime_runs WHERE user_id = ? AND storage_id IS NOT NULL`,
+				[userId],
+			),
+			selectRows<{ id: string }>(
+				env,
+				`SELECT id FROM saved_packages WHERE user_id = ? AND has_app = 1`,
+				[userId],
+			),
+			selectRows<{ package_id: string; name: string }>(
+				env,
+				`SELECT DISTINCT package_id, name
 				FROM package_runtime_runs
 				WHERE user_id = ? AND surface = 'service' AND name IS NOT NULL`,
-        [userId],
-      ),
-    ]);
-  return uniqueStrings([
-    ...jobRows.map((row) => row.storage_id),
-    ...archivedRows.map((row) => row.storage_id),
-    ...runtimeRows.map((row) => row.storage_id),
-    ...packageRows.map((row) => row.id),
-    ...serviceRows.map((row) =>
-      buildPackageServiceStorageId(row.package_id, row.name),
-    ),
-  ]);
+				[userId],
+			),
+		])
+	return uniqueStrings([
+		...jobRows.map((row) => row.storage_id),
+		...archivedRows.map((row) => row.storage_id),
+		...runtimeRows.map((row) => row.storage_id),
+		...packageRows.map((row) => row.id),
+		...serviceRows.map((row) =>
+			buildPackageServiceStorageId(row.package_id, row.name),
+		),
+	])
 }
 
 async function listUserSourceSnapshots(env: Env, userId: string) {
-  const rows = await selectRows<{
-    id: string;
-    published_commit: string | null;
-    repo_id: string;
-    entity_kind: string;
-    entity_id: string;
-    manifest_path: string;
-    source_root: string;
-  }>(
-    env,
-    `SELECT id, published_commit, repo_id, entity_kind, entity_id, manifest_path, source_root
+	const rows = await selectRows<{
+		id: string
+		published_commit: string | null
+		repo_id: string
+		entity_kind: string
+		entity_id: string
+		manifest_path: string
+		source_root: string
+	}>(
+		env,
+		`SELECT id, published_commit, repo_id, entity_kind, entity_id, manifest_path, source_root
 		FROM entity_sources
 		WHERE user_id = ?`,
-    [userId],
-  );
-  return rows.map((row) => ({
-    sourceId: row.id,
-    publishedCommit: row.published_commit,
-    repoId: row.repo_id,
-    entityKind: row.entity_kind,
-    entityId: row.entity_id,
-    manifestPath: row.manifest_path,
-    sourceRoot: row.source_root,
-  }));
+		[userId],
+	)
+	return rows.map((row) => ({
+		sourceId: row.id,
+		publishedCommit: row.published_commit,
+		repoId: row.repo_id,
+		entityKind: row.entity_kind,
+		entityId: row.entity_id,
+		manifestPath: row.manifest_path,
+		sourceRoot: row.source_root,
+	}))
 }
 
 async function listUserSavedPackages(env: Env, userId: string) {
-  const rows = await selectRows<{
-    id: string;
-    kody_id: string;
-    source_id: string;
-    has_app: number | string | boolean;
-  }>(
-    env,
-    `SELECT id, kody_id, source_id, has_app
+	const rows = await selectRows<{
+		id: string
+		kody_id: string
+		source_id: string
+		has_app: number | string | boolean
+	}>(
+		env,
+		`SELECT id, kody_id, source_id, has_app
 		FROM saved_packages
 		WHERE user_id = ?`,
-    [userId],
-  );
-  return rows.map((row) => ({
-    id: row.id,
-    kodyId: row.kody_id,
-    sourceId: row.source_id,
-    hasApp: normalizeBoolean(row.has_app),
-  }));
+		[userId],
+	)
+	return rows.map((row) => ({
+		id: row.id,
+		kodyId: row.kody_id,
+		sourceId: row.source_id,
+		hasApp: normalizeBoolean(row.has_app),
+	}))
 }
 
 async function listUserRemoteConnectors(env: Env, userId: string) {
-  const rows = await selectRows<{ instance_id: string }>(
-    env,
-    `SELECT instance_id
+	const rows = await selectRows<{ instance_id: string }>(
+		env,
+		`SELECT instance_id
 		FROM remote_connector_settings
 		WHERE user_id = ?`,
-    [userId],
-  );
-  return rows.map((row) => ({
-    instanceId: row.instance_id,
-  }));
+		[userId],
+	)
+	return rows.map((row) => ({
+		instanceId: row.instance_id,
+	}))
 }
 
 async function listUserPackageServices(env: Env, userId: string) {
-  const rows = await selectRows<{
-    package_id: string;
-    kody_id: string;
-    source_id: string | null;
-    name: string;
-  }>(
-    env,
-    `SELECT DISTINCT
+	const rows = await selectRows<{
+		package_id: string
+		kody_id: string
+		source_id: string | null
+		name: string
+	}>(
+		env,
+		`SELECT DISTINCT
 			r.package_id,
 			COALESCE(p.kody_id, r.package_kody_id) AS kody_id,
 			COALESCE(p.source_id, r.source_id) AS source_id,
@@ -677,766 +677,764 @@ async function listUserPackageServices(env: Env, userId: string) {
 		WHERE r.user_id = ?
 			AND r.surface = 'service'
 			AND r.name IS NOT NULL`,
-    [userId],
-  );
-  return rows.map((row) => ({
-    packageId: row.package_id,
-    kodyId: row.kody_id,
-    sourceId: row.source_id ?? "",
-    serviceName: row.name,
-  }));
+		[userId],
+	)
+	return rows.map((row) => ({
+		packageId: row.package_id,
+		kodyId: row.kody_id,
+		sourceId: row.source_id ?? '',
+		serviceName: row.name,
+	}))
 }
 
 async function listUserCommunityListingIds(env: Env, userId: string) {
-  const rows = await selectRows<{ id: string }>(
-    env,
-    `SELECT id FROM community_listings WHERE owner_user_id = ?`,
-    [userId],
-  );
-  return uniqueStrings(rows.map((row) => row.id));
+	const rows = await selectRows<{ id: string }>(
+		env,
+		`SELECT id FROM community_listings WHERE owner_user_id = ?`,
+		[userId],
+	)
+	return uniqueStrings(rows.map((row) => row.id))
 }
 
 async function listUserBundleKvKeys(input: {
-  env: Env;
-  userId: string;
-  sourceSnapshots: ReadonlyArray<UserSourceSnapshot>;
-  communityListingIds: ReadonlyArray<string>;
-  warnings: Array<string>;
+	env: Env
+	userId: string
+	sourceSnapshots: ReadonlyArray<UserSourceSnapshot>
+	communityListingIds: ReadonlyArray<string>
+	warnings: Array<string>
 }) {
-  const published = await selectRows<{ kv_key: string }>(
-    input.env,
-    `SELECT kv_key FROM published_bundle_artifacts WHERE user_id = ?`,
-    [input.userId],
-  );
-  const keys = new Set(
-    uniqueStrings([
-      ...published.map((row) => row.kv_key),
-      ...input.sourceSnapshots.flatMap((source) =>
-        source.publishedCommit
-          ? [
-              buildPublishedSourceSnapshotKvKey({
-                sourceId: source.sourceId,
-                publishedCommit: source.publishedCommit,
-              }),
-              buildPublishedSourceManifestSnapshotKvKey({
-                sourceId: source.sourceId,
-                publishedCommit: source.publishedCommit,
-              }),
-            ]
-          : [],
-      ),
-      ...input.communityListingIds.map(buildCommunitySnapshotKvKey),
-    ]),
-  );
-  if (!input.env.BUNDLE_ARTIFACTS_KV?.list) return Array.from(keys);
-  const prefixes = input.sourceSnapshots.flatMap((source) => [
-    `source-snapshot:v1:${source.sourceId}:`,
-    `source-manifest-snapshot:v1:${source.sourceId}:`,
-  ]);
-  for (const prefix of prefixes) {
-    let cursor: string | undefined;
-    do {
-      try {
-        const result = await input.env.BUNDLE_ARTIFACTS_KV.list({
-          prefix,
-          cursor,
-        });
-        for (const key of result.keys) {
-          keys.add(key.name);
-        }
-        cursor = result.list_complete ? undefined : result.cursor;
-      } catch (error) {
-        input.warnings.push(
-          `KV prefix listing failed for ${prefix}: ${getErrorMessage(error)}`,
-        );
-        cursor = undefined;
-      }
-    } while (cursor);
-  }
-  return Array.from(keys).sort();
+	const published = await selectRows<{ kv_key: string }>(
+		input.env,
+		`SELECT kv_key FROM published_bundle_artifacts WHERE user_id = ?`,
+		[input.userId],
+	)
+	const keys = new Set(
+		uniqueStrings([
+			...published.map((row) => row.kv_key),
+			...input.sourceSnapshots.flatMap((source) =>
+				source.publishedCommit
+					? [
+							buildPublishedSourceSnapshotKvKey({
+								sourceId: source.sourceId,
+								publishedCommit: source.publishedCommit,
+							}),
+							buildPublishedSourceManifestSnapshotKvKey({
+								sourceId: source.sourceId,
+								publishedCommit: source.publishedCommit,
+							}),
+						]
+					: [],
+			),
+			...input.communityListingIds.map(buildCommunitySnapshotKvKey),
+		]),
+	)
+	if (!input.env.BUNDLE_ARTIFACTS_KV?.list) return Array.from(keys)
+	const prefixes = input.sourceSnapshots.flatMap((source) => [
+		`source-snapshot:v1:${source.sourceId}:`,
+		`source-manifest-snapshot:v1:${source.sourceId}:`,
+	])
+	for (const prefix of prefixes) {
+		let cursor: string | undefined
+		do {
+			try {
+				const result = await input.env.BUNDLE_ARTIFACTS_KV.list({
+					prefix,
+					cursor,
+				})
+				for (const key of result.keys) {
+					keys.add(key.name)
+				}
+				cursor = result.list_complete ? undefined : result.cursor
+			} catch (error) {
+				input.warnings.push(
+					`KV prefix listing failed for ${prefix}: ${getErrorMessage(error)}`,
+				)
+				cursor = undefined
+			}
+		} while (cursor)
+	}
+	return Array.from(keys).sort()
 }
 
 async function collectInventory(input: {
-  env: AccountExportEnv;
-  userId: string;
-  warnings: Array<string>;
+	env: AccountExportEnv
+	userId: string
+	warnings: Array<string>
 }): Promise<UserExportInventory> {
-  const [
-    storageIds,
-    sourceSnapshots,
-    savedPackages,
-    remoteConnectors,
-    packageServices,
-    communityListingIds,
-  ] = await Promise.all([
-    listUserStorageIds(input.env, input.userId).catch((error) => {
-      input.warnings.push(
-        `Failed to enumerate storage ids: ${getErrorMessage(error)}`,
-      );
-      return [] as Array<string>;
-    }),
-    listUserSourceSnapshots(input.env, input.userId).catch((error) => {
-      input.warnings.push(
-        `Failed to enumerate entity sources: ${getErrorMessage(error)}`,
-      );
-      return [] as Array<UserSourceSnapshot>;
-    }),
-    listUserSavedPackages(input.env, input.userId).catch((error) => {
-      input.warnings.push(
-        `Failed to enumerate saved packages: ${getErrorMessage(error)}`,
-      );
-      return [] as Array<UserSavedPackageSnapshot>;
-    }),
-    listUserRemoteConnectors(input.env, input.userId).catch((error) => {
-      input.warnings.push(
-        `Failed to enumerate remote connectors: ${getErrorMessage(error)}`,
-      );
-      return [] as Array<UserRemoteConnectorSnapshot>;
-    }),
-    listUserPackageServices(input.env, input.userId).catch((error) => {
-      input.warnings.push(
-        `Failed to enumerate package services: ${getErrorMessage(error)}`,
-      );
-      return [] as Array<UserPackageServiceSnapshot>;
-    }),
-    listUserCommunityListingIds(input.env, input.userId).catch((error) => {
-      input.warnings.push(
-        `Failed to enumerate community listings: ${getErrorMessage(error)}`,
-      );
-      return [] as Array<string>;
-    }),
-  ]);
-  const bundleKvKeys = await listUserBundleKvKeys({
-    env: input.env,
-    userId: input.userId,
-    sourceSnapshots,
-    communityListingIds,
-    warnings: input.warnings,
-  }).catch((error) => {
-    input.warnings.push(
-      `Failed to enumerate bundle KV keys: ${getErrorMessage(error)}`,
-    );
-    return [] as Array<string>;
-  });
-  const artifactRepos = sourceSnapshots.map((source) => ({
-    sourceId: source.sourceId,
-    entityKind: source.entityKind,
-    entityId: source.entityId,
-    repoId: source.repoId,
-    publishedCommit: source.publishedCommit,
-    manifestPath: source.manifestPath,
-    sourceRoot: source.sourceRoot,
-  }));
-  return {
-    storageIds,
-    sourceSnapshots,
-    savedPackages,
-    remoteConnectors,
-    packageServices,
-    communityListingIds,
-    bundleKvKeys,
-    artifactRepos,
-  };
+	const [
+		storageIds,
+		sourceSnapshots,
+		savedPackages,
+		remoteConnectors,
+		packageServices,
+		communityListingIds,
+	] = await Promise.all([
+		listUserStorageIds(input.env, input.userId).catch((error) => {
+			input.warnings.push(
+				`Failed to enumerate storage ids: ${getErrorMessage(error)}`,
+			)
+			return [] as Array<string>
+		}),
+		listUserSourceSnapshots(input.env, input.userId).catch((error) => {
+			input.warnings.push(
+				`Failed to enumerate entity sources: ${getErrorMessage(error)}`,
+			)
+			return [] as Array<UserSourceSnapshot>
+		}),
+		listUserSavedPackages(input.env, input.userId).catch((error) => {
+			input.warnings.push(
+				`Failed to enumerate saved packages: ${getErrorMessage(error)}`,
+			)
+			return [] as Array<UserSavedPackageSnapshot>
+		}),
+		listUserRemoteConnectors(input.env, input.userId).catch((error) => {
+			input.warnings.push(
+				`Failed to enumerate remote connectors: ${getErrorMessage(error)}`,
+			)
+			return [] as Array<UserRemoteConnectorSnapshot>
+		}),
+		listUserPackageServices(input.env, input.userId).catch((error) => {
+			input.warnings.push(
+				`Failed to enumerate package services: ${getErrorMessage(error)}`,
+			)
+			return [] as Array<UserPackageServiceSnapshot>
+		}),
+		listUserCommunityListingIds(input.env, input.userId).catch((error) => {
+			input.warnings.push(
+				`Failed to enumerate community listings: ${getErrorMessage(error)}`,
+			)
+			return [] as Array<string>
+		}),
+	])
+	const bundleKvKeys = await listUserBundleKvKeys({
+		env: input.env,
+		userId: input.userId,
+		sourceSnapshots,
+		communityListingIds,
+		warnings: input.warnings,
+	}).catch((error) => {
+		input.warnings.push(
+			`Failed to enumerate bundle KV keys: ${getErrorMessage(error)}`,
+		)
+		return [] as Array<string>
+	})
+	const artifactRepos = sourceSnapshots.map((source) => ({
+		sourceId: source.sourceId,
+		entityKind: source.entityKind,
+		entityId: source.entityId,
+		repoId: source.repoId,
+		publishedCommit: source.publishedCommit,
+		manifestPath: source.manifestPath,
+		sourceRoot: source.sourceRoot,
+	}))
+	return {
+		storageIds,
+		sourceSnapshots,
+		savedPackages,
+		remoteConnectors,
+		packageServices,
+		communityListingIds,
+		bundleKvKeys,
+		artifactRepos,
+	}
 }
 
 async function collectD1Tables(input: {
-  env: AccountExportEnv;
-  dbUserId: number;
-  mcpUserId: string;
-  warnings: Array<string>;
+	env: AccountExportEnv
+	dbUserId: number
+	mcpUserId: string
+	warnings: Array<string>
 }) {
-  const conditionsByTable = buildD1TableConditions({
-    mcpUserId: input.mcpUserId,
-    dbUserId: input.dbUserId,
-  });
-  const tables: Array<[string, AccountExportD1Table]> = [];
-  for (const [table, conditions] of conditionsByTable) {
-    tables.push([
-      table,
-      await collectD1TableRows({
-        env: input.env,
-        table,
-        conditions,
-        mcpUserId: input.mcpUserId,
-        warnings: input.warnings,
-      }),
-    ]);
-  }
-  return Object.fromEntries(
-    tables.sort(([left], [right]) => left.localeCompare(right)),
-  );
+	const conditionsByTable = buildD1TableConditions({
+		mcpUserId: input.mcpUserId,
+		dbUserId: input.dbUserId,
+	})
+	const tables: Array<[string, AccountExportD1Table]> = []
+	for (const [table, conditions] of conditionsByTable) {
+		tables.push([
+			table,
+			await collectD1TableRows({
+				env: input.env,
+				table,
+				conditions,
+				mcpUserId: input.mcpUserId,
+				warnings: input.warnings,
+			}),
+		])
+	}
+	return Object.fromEntries(
+		tables.sort(([left], [right]) => left.localeCompare(right)),
+	)
 }
 
 function parseRowidCursor(startAfter: string | undefined) {
-  if (!startAfter) return 0;
-  const parsed = Number.parseInt(startAfter, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+	if (!startAfter) return 0
+	const parsed = Number.parseInt(startAfter, 10)
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
 }
 
 async function readD1TableSectionPage(input: {
-  env: AccountExportEnv;
-  dbUserId: number;
-  mcpUserId: string;
-  table: string;
-  pageSize: number | undefined;
-  startAfter: string | undefined;
-  warnings: Array<string>;
+	env: AccountExportEnv
+	dbUserId: number
+	mcpUserId: string
+	table: string
+	pageSize: number | undefined
+	startAfter: string | undefined
+	warnings: Array<string>
 }) {
-  const conditions = buildD1TableConditions({
-    mcpUserId: input.mcpUserId,
-    dbUserId: input.dbUserId,
-  }).get(input.table);
-  if (!conditions) return null;
-  const pageSize = normalizePageSize(input.pageSize);
-  try {
-    const page = await selectD1TablePage({
-      env: input.env,
-      table: input.table,
-      conditions,
-      mcpUserId: input.mcpUserId,
-      afterRowid: parseRowidCursor(input.startAfter),
-      limit: pageSize,
-    });
-    return {
-      items: page.rows.map((entry) => entry.row),
-      truncated: page.truncated,
-      nextStartAfter: page.truncated ? String(page.lastRowid) : null,
-      pageSize,
-    };
-  } catch (error) {
-    input.warnings.push(
-      `D1 export failed for ${input.table}: ${getErrorMessage(error)}`,
-    );
-    return {
-      items: [] as Array<Record<string, unknown>>,
-      truncated: false,
-      nextStartAfter: null,
-      pageSize,
-    };
-  }
+	const conditions = buildD1TableConditions({
+		mcpUserId: input.mcpUserId,
+		dbUserId: input.dbUserId,
+	}).get(input.table)
+	if (!conditions) return null
+	const pageSize = normalizePageSize(input.pageSize)
+	try {
+		const page = await selectD1TablePage({
+			env: input.env,
+			table: input.table,
+			conditions,
+			mcpUserId: input.mcpUserId,
+			afterRowid: parseRowidCursor(input.startAfter),
+			limit: pageSize,
+		})
+		return {
+			items: page.rows.map((entry) => entry.row),
+			truncated: page.truncated,
+			nextStartAfter: page.truncated ? String(page.lastRowid) : null,
+			pageSize,
+		}
+	} catch (error) {
+		input.warnings.push(
+			`D1 export failed for ${input.table}: ${getErrorMessage(error)}`,
+		)
+		return {
+			items: [] as Array<Record<string, unknown>>,
+			truncated: false,
+			nextStartAfter: null,
+			pageSize,
+		}
+	}
 }
 
 async function listOAuthGrants(input: {
-  env: AccountExportEnv;
-  userId: string;
-  warnings: Array<string>;
+	env: AccountExportEnv
+	userId: string
+	warnings: Array<string>
 }) {
-  const helpers = input.env.OAUTH_PROVIDER;
-  if (!helpers) {
-    input.warnings.push(
-      "OAuth provider binding was unavailable; OAuth grant metadata was not exported.",
-    );
-    return [] as Array<{ id: string; clientId: string }>;
-  }
-  const grants: Array<{ id: string; clientId: string }> = [];
-  let cursor: string | undefined;
-  while (true) {
-    let page: OAuthGrantPage;
-    try {
-      page = await helpers.listUserGrants(input.userId, { cursor });
-    } catch (error) {
-      input.warnings.push(
-        `OAuth grant listing failed after ${grants.length} grant(s): ${getErrorMessage(error)}`,
-      );
-      return grants;
-    }
-    grants.push(...page.items.map((grant) => ({ ...grant })));
-    if (!page.cursor) return grants;
-    cursor = page.cursor;
-  }
+	const helpers = input.env.OAUTH_PROVIDER
+	if (!helpers) {
+		input.warnings.push(
+			'OAuth provider binding was unavailable; OAuth grant metadata was not exported.',
+		)
+		return [] as Array<{ id: string; clientId: string }>
+	}
+	const grants: Array<{ id: string; clientId: string }> = []
+	let cursor: string | undefined
+	while (true) {
+		let page: OAuthGrantPage
+		try {
+			page = await helpers.listUserGrants(input.userId, { cursor })
+		} catch (error) {
+			input.warnings.push(
+				`OAuth grant listing failed after ${grants.length} grant(s): ${getErrorMessage(error)}`,
+			)
+			return grants
+		}
+		grants.push(...page.items.map((grant) => ({ ...grant })))
+		if (!page.cursor) return grants
+		cursor = page.cursor
+	}
 }
 
 async function exportStorageRunners(input: {
-  env: AccountExportEnv;
-  userId: string;
-  storageIds: ReadonlyArray<string>;
-  warnings: Array<string>;
+	env: AccountExportEnv
+	userId: string
+	storageIds: ReadonlyArray<string>
+	warnings: Array<string>
 }) {
-  const storageRunners: AccountExportDurableObjects["storageRunners"] = [];
-  for (const storageId of input.storageIds) {
-    try {
-      const runnerExport = await storageRunnerRpc({
-        env: input.env,
-        userId: input.userId,
-        storageId,
-      }).exportStorage({ pageSize: maxExportPageSize });
-      storageRunners.push({ storageId, export: runnerExport });
-      if (runnerExport.truncated) {
-        input.warnings.push(
-          `Storage runner ${storageId} was truncated in the full export; use account_export_section with section "storage_runner" and storage_id "${storageId}" to retrieve additional pages.`,
-        );
-      }
-    } catch (error) {
-      input.warnings.push(
-        `Storage runner export failed for ${storageId}: ${getErrorMessage(error)}`,
-      );
-    }
-  }
-  return storageRunners;
+	const storageRunners: AccountExportDurableObjects['storageRunners'] = []
+	for (const storageId of input.storageIds) {
+		try {
+			const runnerExport = await storageRunnerRpc({
+				env: input.env,
+				userId: input.userId,
+				storageId,
+			}).exportStorage({ pageSize: maxExportPageSize })
+			storageRunners.push({ storageId, export: runnerExport })
+			if (runnerExport.truncated) {
+				input.warnings.push(
+					`Storage runner ${storageId} was truncated in the full export; use account_export_section with section "storage_runner" and storage_id "${storageId}" to retrieve additional pages.`,
+				)
+			}
+		} catch (error) {
+			input.warnings.push(
+				`Storage runner export failed for ${storageId}: ${getErrorMessage(error)}`,
+			)
+		}
+	}
+	return storageRunners
 }
 
 async function exportRemoteConnectorSessions(input: {
-  env: AccountExportEnv;
-  userId: string;
-  connectors: ReadonlyArray<UserRemoteConnectorSnapshot>;
-  warnings: Array<string>;
+	env: AccountExportEnv
+	userId: string
+	connectors: ReadonlyArray<UserRemoteConnectorSnapshot>
+	warnings: Array<string>
 }) {
-  const namespace = input.env.REMOTE_CONNECTOR_SESSION;
-  if (!namespace) {
-    if (input.connectors.length > 0) {
-      input.warnings.push(
-        `REMOTE_CONNECTOR_SESSION binding was unavailable; ${input.connectors.length} connector session export(s) were skipped.`,
-      );
-    }
-    return [] as AccountExportDurableObjects["remoteConnectorSessions"];
-  }
-  const sessions: AccountExportDurableObjects["remoteConnectorSessions"] = [];
-  for (const connector of input.connectors) {
-    const sessionKey = userScopedConnectorSessionKey({
-      userId: input.userId,
-      instanceId: connector.instanceId,
-    });
-    try {
-      const stub = namespace.get(
-        namespace.idFromName(sessionKey),
-      ) as unknown as {
-        rpcExportUserSession: (payload: {
-          userId: string;
-          instanceId: string;
-        }) => Promise<RemoteConnectorSessionExport>;
-      };
-      sessions.push({
-        instanceId: connector.instanceId,
-        export: await stub.rpcExportUserSession({
-          userId: input.userId,
-          instanceId: connector.instanceId,
-        }),
-      });
-    } catch (error) {
-      input.warnings.push(
-        `Remote connector session export failed for ${connector.instanceId}: ${getErrorMessage(error)}`,
-      );
-      sessions.push({
-        instanceId: connector.instanceId,
-        export: null,
-      });
-    }
-  }
-  return sessions;
+	const namespace = input.env.REMOTE_CONNECTOR_SESSION
+	if (!namespace) {
+		if (input.connectors.length > 0) {
+			input.warnings.push(
+				`REMOTE_CONNECTOR_SESSION binding was unavailable; ${input.connectors.length} connector session export(s) were skipped.`,
+			)
+		}
+		return [] as AccountExportDurableObjects['remoteConnectorSessions']
+	}
+	const sessions: AccountExportDurableObjects['remoteConnectorSessions'] = []
+	for (const connector of input.connectors) {
+		const sessionKey = userScopedConnectorSessionKey({
+			userId: input.userId,
+			instanceId: connector.instanceId,
+		})
+		try {
+			const stub = namespace.get(
+				namespace.idFromName(sessionKey),
+			) as unknown as {
+				rpcExportUserSession: (payload: {
+					userId: string
+					instanceId: string
+				}) => Promise<RemoteConnectorSessionExport>
+			}
+			sessions.push({
+				instanceId: connector.instanceId,
+				export: await stub.rpcExportUserSession({
+					userId: input.userId,
+					instanceId: connector.instanceId,
+				}),
+			})
+		} catch (error) {
+			input.warnings.push(
+				`Remote connector session export failed for ${connector.instanceId}: ${getErrorMessage(error)}`,
+			)
+			sessions.push({
+				instanceId: connector.instanceId,
+				export: null,
+			})
+		}
+	}
+	return sessions
 }
 
 async function exportPackageServices(input: {
-  env: AccountExportEnv;
-  userId: string;
-  services: ReadonlyArray<UserPackageServiceSnapshot>;
-  warnings: Array<string>;
+	env: AccountExportEnv
+	userId: string
+	services: ReadonlyArray<UserPackageServiceSnapshot>
+	warnings: Array<string>
 }) {
-  const statuses: AccountExportDurableObjects["packageServices"] = [];
-  for (const service of input.services) {
-    try {
-      statuses.push({
-        packageId: service.packageId,
-        serviceName: service.serviceName,
-        status: await packageServiceRpc({
-          env: input.env,
-          userId: input.userId,
-          packageId: service.packageId,
-          kodyId: service.kodyId,
-          sourceId: service.sourceId,
-          baseUrl: "https://account-export.invalid",
-          serviceName: service.serviceName,
-        }).status(),
-      });
-    } catch (error) {
-      input.warnings.push(
-        `Package service status export failed for ${service.packageId}/${service.serviceName}: ${getErrorMessage(error)}`,
-      );
-      statuses.push({
-        packageId: service.packageId,
-        serviceName: service.serviceName,
-        status: null,
-      });
-    }
-  }
-  return statuses;
+	const statuses: AccountExportDurableObjects['packageServices'] = []
+	for (const service of input.services) {
+		try {
+			statuses.push({
+				packageId: service.packageId,
+				serviceName: service.serviceName,
+				status: await packageServiceRpc({
+					env: input.env,
+					userId: input.userId,
+					packageId: service.packageId,
+					kodyId: service.kodyId,
+					sourceId: service.sourceId,
+					baseUrl: 'https://account-export.invalid',
+					serviceName: service.serviceName,
+				}).status(),
+			})
+		} catch (error) {
+			input.warnings.push(
+				`Package service status export failed for ${service.packageId}/${service.serviceName}: ${getErrorMessage(error)}`,
+			)
+			statuses.push({
+				packageId: service.packageId,
+				serviceName: service.serviceName,
+				status: null,
+			})
+		}
+	}
+	return statuses
 }
 
 async function exportDurableObjects(input: {
-  env: AccountExportEnv;
-  userId: string;
-  inventory: UserExportInventory;
-  warnings: Array<string>;
+	env: AccountExportEnv
+	userId: string
+	inventory: UserExportInventory
+	warnings: Array<string>
 }): Promise<AccountExportDurableObjects> {
-  const [storageRunners, remoteConnectorSessions, packageServices] =
-    await Promise.all([
-      exportStorageRunners({
-        env: input.env,
-        userId: input.userId,
-        storageIds: input.inventory.storageIds,
-        warnings: input.warnings,
-      }),
-      exportRemoteConnectorSessions({
-        env: input.env,
-        userId: input.userId,
-        connectors: input.inventory.remoteConnectors,
-        warnings: input.warnings,
-      }),
-      exportPackageServices({
-        env: input.env,
-        userId: input.userId,
-        services: input.inventory.packageServices,
-        warnings: input.warnings,
-      }),
-    ]);
-  let jobManager: unknown | null = null;
-  try {
-    jobManager = await exportJobManagerForUser({
-      env: input.env,
-      userId: input.userId,
-    });
-  } catch (error) {
-    input.warnings.push(`Job manager export failed: ${getErrorMessage(error)}`);
-  }
-  return {
-    jobManager,
-    remoteConnectorSessions,
-    packageServices,
-    storageRunners,
-  };
+	const [storageRunners, remoteConnectorSessions, packageServices] =
+		await Promise.all([
+			exportStorageRunners({
+				env: input.env,
+				userId: input.userId,
+				storageIds: input.inventory.storageIds,
+				warnings: input.warnings,
+			}),
+			exportRemoteConnectorSessions({
+				env: input.env,
+				userId: input.userId,
+				connectors: input.inventory.remoteConnectors,
+				warnings: input.warnings,
+			}),
+			exportPackageServices({
+				env: input.env,
+				userId: input.userId,
+				services: input.inventory.packageServices,
+				warnings: input.warnings,
+			}),
+		])
+	let jobManager: unknown | null = null
+	try {
+		jobManager = await exportJobManagerForUser({
+			env: input.env,
+			userId: input.userId,
+		})
+	} catch (error) {
+		input.warnings.push(`Job manager export failed: ${getErrorMessage(error)}`)
+	}
+	return {
+		jobManager,
+		remoteConnectorSessions,
+		packageServices,
+		storageRunners,
+	}
 }
 
 function buildManifest(input: {
-  generatedAt: string;
-  dbUserId: number;
-  mcpUserId: string;
-  d1: Record<string, AccountExportD1Table>;
-  durableObjects?: AccountExportDurableObjects | null;
-  oauthGrants?: ReadonlyArray<{ id: string; clientId: string }>;
-  inventory: UserExportInventory;
-  warnings: Array<string>;
+	generatedAt: string
+	dbUserId: number
+	mcpUserId: string
+	d1: Record<string, AccountExportD1Table>
+	durableObjects?: AccountExportDurableObjects | null
+	oauthGrants?: ReadonlyArray<{ id: string; clientId: string }>
+	inventory: UserExportInventory
+	warnings: Array<string>
 }) {
-  const sections: Record<string, AccountExportManifestSection> = {};
-  for (const [table, exportTable] of Object.entries(input.d1)) {
-    sections[`d1.${table}`] = {
-      count: exportTable.rows.length,
-      warnings: exportTable.warnings,
-      ...(exportTable.redactedColumns.length > 0
-        ? { redactedColumns: exportTable.redactedColumns }
-        : {}),
-    };
-  }
-  sections.storage_runners = {
-    count: input.inventory.storageIds.length,
-    warnings: input.warnings.filter((warning) =>
-      warning.startsWith("Storage runner "),
-    ),
-  };
-  sections.remote_connector_sessions = {
-    count: input.inventory.remoteConnectors.length,
-    warnings: input.warnings.filter((warning) =>
-      warning.startsWith("Remote connector session "),
-    ),
-  };
-  sections.package_services = {
-    count: input.inventory.packageServices.length,
-    warnings: input.warnings.filter((warning) =>
-      warning.startsWith("Package service "),
-    ),
-  };
-  sections.oauth_grants = {
-    count: input.oauthGrants?.length ?? 0,
-    warnings: input.warnings.filter((warning) =>
-      warning.startsWith("OAuth grant "),
-    ),
-  };
-  sections.artifact_repos = {
-    count: input.inventory.artifactRepos.length,
-    warnings: [],
-  };
-  sections.kv_keys = {
-    count: input.inventory.bundleKvKeys.length,
-    warnings: input.warnings.filter((warning) => warning.startsWith("KV ")),
-  };
-  return {
-    schemaVersion: accountExportSchemaVersion,
-    generatedAt: input.generatedAt,
-    user: {
-      dbUserId: input.dbUserId,
-      userId: input.mcpUserId,
-    },
-    security: {
-      secretValuesExported: false as const,
-      note: "Secret values, encrypted secret payloads, password hashes, token hashes, and credential-equivalent hashes are never exported. Secret entries contain metadata only.",
-    },
-    sections,
-    warnings: input.warnings,
-    chunking: {
-      sections: [...accountExportSectionNames],
-      defaultPageSize: defaultExportPageSize,
-      maxPageSize: maxExportPageSize,
-    },
-    artifacts: {
-      canonicalPackageSource:
-        "Package/job source code is stored in Cloudflare Artifacts repos referenced by entity_sources.repo_id. This export lists repo pointers and published commits; fetch or clone those repos separately with Artifacts access rather than relying on D1 projections.",
-    },
-    derivedData: {
-      vectorize:
-        "Vectorize entries for memories, jobs, and packages are derived from exported D1 rows and are intentionally excluded; rebuild them by reindexing after import.",
-    },
-    excludedDurableObjects: [
-      {
-        name: "MCP",
-        reason:
-          "Session-keyed by the MCP SDK and not globally enumerable; durable user data is carried by D1 and user-scoped stores instead.",
-      },
-      {
-        name: "RepoSession",
-        reason:
-          "Ephemeral editing workspace. Canonical repo-backed source is exported as Artifacts repo pointers via entity_sources and repo_sessions metadata.",
-      },
-      {
-        name: "PackageRealtimeSession",
-        reason:
-          "Ephemeral live websocket/session state. Durable app storage is exported through StorageRunner buckets.",
-      },
-    ],
-    excludedD1Surfaces: accountUserDataExcludedOwnerIds.map((exclusion) => ({
-      name: exclusion.surface,
-      reason: exclusion.reason,
-    })),
-  } satisfies AccountExportManifest;
+	const sections: Record<string, AccountExportManifestSection> = {}
+	for (const [table, exportTable] of Object.entries(input.d1)) {
+		sections[`d1.${table}`] = {
+			count: exportTable.rows.length,
+			warnings: exportTable.warnings,
+			...(exportTable.redactedColumns.length > 0
+				? { redactedColumns: exportTable.redactedColumns }
+				: {}),
+		}
+	}
+	sections.storage_runners = {
+		count: input.inventory.storageIds.length,
+		warnings: input.warnings.filter((warning) =>
+			warning.startsWith('Storage runner '),
+		),
+	}
+	sections.remote_connector_sessions = {
+		count: input.inventory.remoteConnectors.length,
+		warnings: input.warnings.filter((warning) =>
+			warning.startsWith('Remote connector session '),
+		),
+	}
+	sections.package_services = {
+		count: input.inventory.packageServices.length,
+		warnings: input.warnings.filter((warning) =>
+			warning.startsWith('Package service '),
+		),
+	}
+	sections.oauth_grants = {
+		count: input.oauthGrants?.length ?? 0,
+		warnings: input.warnings.filter((warning) =>
+			warning.startsWith('OAuth grant '),
+		),
+	}
+	sections.artifact_repos = {
+		count: input.inventory.artifactRepos.length,
+		warnings: [],
+	}
+	sections.kv_keys = {
+		count: input.inventory.bundleKvKeys.length,
+		warnings: input.warnings.filter((warning) => warning.startsWith('KV ')),
+	}
+	return {
+		schemaVersion: accountExportSchemaVersion,
+		generatedAt: input.generatedAt,
+		user: {
+			dbUserId: input.dbUserId,
+			userId: input.mcpUserId,
+		},
+		security: {
+			secretValuesExported: false as const,
+			note: 'Secret values, encrypted secret payloads, password hashes, token hashes, and credential-equivalent hashes are never exported. Secret entries contain metadata only.',
+		},
+		sections,
+		warnings: input.warnings,
+		chunking: {
+			sections: [...accountExportSectionNames],
+			defaultPageSize: defaultExportPageSize,
+			maxPageSize: maxExportPageSize,
+		},
+		artifacts: {
+			canonicalPackageSource:
+				'Package/job source code is stored in Cloudflare Artifacts repos referenced by entity_sources.repo_id. This export lists repo pointers and published commits; fetch or clone those repos separately with Artifacts access rather than relying on D1 projections.',
+		},
+		derivedData: {
+			vectorize:
+				'Vectorize entries for memories, jobs, and packages are derived from exported D1 rows and are intentionally excluded; rebuild them by reindexing after import.',
+		},
+		excludedDurableObjects: [
+			{
+				name: 'MCP',
+				reason:
+					'Session-keyed by the MCP SDK and not globally enumerable; durable user data is carried by D1 and user-scoped stores instead.',
+			},
+			{
+				name: 'RepoSession',
+				reason:
+					'Ephemeral editing workspace. Canonical repo-backed source is exported as Artifacts repo pointers via entity_sources and repo_sessions metadata.',
+			},
+			{
+				name: 'PackageRealtimeSession',
+				reason:
+					'Ephemeral live websocket/session state. Durable app storage is exported through StorageRunner buckets.',
+			},
+		],
+		excludedD1Surfaces: accountUserDataExcludedOwnerIds.map((exclusion) => ({
+			name: exclusion.surface,
+			reason: exclusion.reason,
+		})),
+	} satisfies AccountExportManifest
 }
 
 export function getAccountExportD1UserColumnCoverage() {
-  return getAccountD1UserColumnCoverage();
+	return getAccountD1UserColumnCoverage()
 }
 
 export async function resolveAccountExportDbUserId(input: {
-  env: AccountExportEnv;
-  mcpUserId: string;
-  email?: string | null;
+	env: AccountExportEnv
+	mcpUserId: string
+	email?: string | null
 }) {
-  const email = input.email?.trim().toLowerCase();
-  if (!email) {
-    throw new Error("Account export requires an authenticated user email.");
-  }
-  const row = await input.env.APP_DB.prepare(
-    `SELECT id, email, stable_user_id FROM users WHERE email = ?`,
-  )
-    .bind(email)
-    .first<{ id: number; email: string; stable_user_id: string | null }>();
-  if (!row) {
-    throw new Error("Authenticated account was not found.");
-  }
-  if ((await resolveUserStableId(row)) !== input.mcpUserId) {
-    throw new Error(
-      "Authenticated user identity did not match the account email.",
-    );
-  }
-  return row.id;
+	const email = input.email?.trim().toLowerCase()
+	if (!email) {
+		throw new Error('Account export requires an authenticated user email.')
+	}
+	const row = await input.env.APP_DB.prepare(
+		`SELECT id, email, stable_user_id FROM users WHERE email = ?`,
+	)
+		.bind(email)
+		.first<{ id: number; email: string; stable_user_id: string | null }>()
+	if (!row) {
+		throw new Error('Authenticated account was not found.')
+	}
+	if ((await resolveUserStableId(row)) !== input.mcpUserId) {
+		throw new Error(
+			'Authenticated user identity did not match the account email.',
+		)
+	}
+	return row.id
 }
 
 export async function createAccountExportManifest(input: {
-  env: AccountExportEnv;
-  dbUserId: number;
-  mcpUserId: string;
-  generatedAt?: string;
+	env: AccountExportEnv
+	dbUserId: number
+	mcpUserId: string
+	generatedAt?: string
 }): Promise<AccountExportManifest> {
-  const warnings: Array<string> = [];
-  const generatedAt = input.generatedAt ?? new Date().toISOString();
-  const [d1, inventory, oauthGrants] = await Promise.all([
-    collectD1Tables({
-      env: input.env,
-      dbUserId: input.dbUserId,
-      mcpUserId: input.mcpUserId,
-      warnings,
-    }),
-    collectInventory({
-      env: input.env,
-      userId: input.mcpUserId,
-      warnings,
-    }),
-    listOAuthGrants({
-      env: input.env,
-      userId: input.mcpUserId,
-      warnings,
-    }),
-  ]);
-  return buildManifest({
-    generatedAt,
-    dbUserId: input.dbUserId,
-    mcpUserId: input.mcpUserId,
-    d1,
-    inventory,
-    oauthGrants,
-    warnings,
-  });
+	const warnings: Array<string> = []
+	const generatedAt = input.generatedAt ?? new Date().toISOString()
+	const [d1, inventory, oauthGrants] = await Promise.all([
+		collectD1Tables({
+			env: input.env,
+			dbUserId: input.dbUserId,
+			mcpUserId: input.mcpUserId,
+			warnings,
+		}),
+		collectInventory({
+			env: input.env,
+			userId: input.mcpUserId,
+			warnings,
+		}),
+		listOAuthGrants({
+			env: input.env,
+			userId: input.mcpUserId,
+			warnings,
+		}),
+	])
+	return buildManifest({
+		generatedAt,
+		dbUserId: input.dbUserId,
+		mcpUserId: input.mcpUserId,
+		d1,
+		inventory,
+		oauthGrants,
+		warnings,
+	})
 }
 
 export async function createAccountExport(input: {
-  env: AccountExportEnv;
-  dbUserId: number;
-  mcpUserId: string;
-  generatedAt?: string;
+	env: AccountExportEnv
+	dbUserId: number
+	mcpUserId: string
+	generatedAt?: string
 }): Promise<AccountExportFile> {
-  const warnings: Array<string> = [];
-  const generatedAt = input.generatedAt ?? new Date().toISOString();
-  const [d1, inventory, oauthGrants] = await Promise.all([
-    collectD1Tables({
-      env: input.env,
-      dbUserId: input.dbUserId,
-      mcpUserId: input.mcpUserId,
-      warnings,
-    }),
-    collectInventory({
-      env: input.env,
-      userId: input.mcpUserId,
-      warnings,
-    }),
-    listOAuthGrants({
-      env: input.env,
-      userId: input.mcpUserId,
-      warnings,
-    }),
-  ]);
-  const durableObjects = await exportDurableObjects({
-    env: input.env,
-    userId: input.mcpUserId,
-    inventory,
-    warnings,
-  });
-  return {
-    manifest: buildManifest({
-      generatedAt,
-      dbUserId: input.dbUserId,
-      mcpUserId: input.mcpUserId,
-      d1,
-      durableObjects,
-      oauthGrants,
-      inventory,
-      warnings,
-    }),
-    d1,
-    durableObjects,
-    oauthGrants,
-    artifactRepos: inventory.artifactRepos,
-    kvKeys: inventory.bundleKvKeys,
-  };
+	const warnings: Array<string> = []
+	const generatedAt = input.generatedAt ?? new Date().toISOString()
+	const [d1, inventory, oauthGrants] = await Promise.all([
+		collectD1Tables({
+			env: input.env,
+			dbUserId: input.dbUserId,
+			mcpUserId: input.mcpUserId,
+			warnings,
+		}),
+		collectInventory({
+			env: input.env,
+			userId: input.mcpUserId,
+			warnings,
+		}),
+		listOAuthGrants({
+			env: input.env,
+			userId: input.mcpUserId,
+			warnings,
+		}),
+	])
+	const durableObjects = await exportDurableObjects({
+		env: input.env,
+		userId: input.mcpUserId,
+		inventory,
+		warnings,
+	})
+	return {
+		manifest: buildManifest({
+			generatedAt,
+			dbUserId: input.dbUserId,
+			mcpUserId: input.mcpUserId,
+			d1,
+			durableObjects,
+			oauthGrants,
+			inventory,
+			warnings,
+		}),
+		d1,
+		durableObjects,
+		oauthGrants,
+		artifactRepos: inventory.artifactRepos,
+		kvKeys: inventory.bundleKvKeys,
+	}
 }
 
 export async function readAccountExportSection(input: {
-  env: AccountExportEnv;
-  dbUserId: number;
-  mcpUserId: string;
-  section: AccountExportSectionName;
-  table?: string;
-  storageId?: string;
-  pageSize?: number;
-  startAfter?: string;
+	env: AccountExportEnv
+	dbUserId: number
+	mcpUserId: string
+	section: AccountExportSectionName
+	table?: string
+	storageId?: string
+	pageSize?: number
+	startAfter?: string
 }): Promise<AccountExportSectionResult> {
-  const warnings: Array<string> = [];
-  if (input.section === "storage_runner") {
-    if (!input.storageId) {
-      throw new Error("storage_id is required when section is storage_runner.");
-    }
-    const pageSize = normalizePageSize(input.pageSize);
-    const runnerExport = await storageRunnerRpc({
-      env: input.env,
-      userId: input.mcpUserId,
-      storageId: input.storageId,
-    }).exportStorage({
-      pageSize,
-      startAfter: input.startAfter,
-    });
-    return {
-      section: input.section,
-      items: runnerExport.entries,
-      truncated: runnerExport.truncated,
-      nextStartAfter: runnerExport.nextStartAfter,
-      pageSize: runnerExport.pageSize,
-      warnings,
-    };
-  }
-  let items: Array<unknown>;
-  switch (input.section) {
-    case "d1_table": {
-      if (!input.table) {
-        throw new Error("table is required when section is d1_table.");
-      }
-      const page = await readD1TableSectionPage({
-        env: input.env,
-        dbUserId: input.dbUserId,
-        mcpUserId: input.mcpUserId,
-        table: input.table,
-        pageSize: input.pageSize,
-        startAfter: input.startAfter,
-        warnings,
-      });
-      if (!page) {
-        throw new Error(
-          `Table "${input.table}" is not part of account export.`,
-        );
-      }
-      return {
-        section: input.section,
-        ...page,
-        warnings,
-      };
-    }
-    case "oauth_grants": {
-      const oauthGrants = await listOAuthGrants({
-        env: input.env,
-        userId: input.mcpUserId,
-        warnings,
-      });
-      items = [...oauthGrants];
-      break;
-    }
-    case "artifact_repos": {
-      const inventory = await collectInventory({
-        env: input.env,
-        userId: input.mcpUserId,
-        warnings,
-      });
-      items = inventory.artifactRepos;
-      break;
-    }
-    case "kv_keys": {
-      const inventory = await collectInventory({
-        env: input.env,
-        userId: input.mcpUserId,
-        warnings,
-      });
-      items = inventory.bundleKvKeys;
-      break;
-    }
-    case "durable_object_summaries": {
-      const inventory = await collectInventory({
-        env: input.env,
-        userId: input.mcpUserId,
-        warnings,
-      });
-      items = [
-        { kind: "storage_runner", ids: inventory.storageIds },
-        { kind: "remote_connector_session", refs: inventory.remoteConnectors },
-        { kind: "package_service", refs: inventory.packageServices },
-        { kind: "job_manager", userId: input.mcpUserId },
-      ];
-      break;
-    }
-    default: {
-      const exhaustive: never = input.section;
-      throw new Error(`Unhandled account export section: ${exhaustive}`);
-    }
-  }
-  const page = paginateItems({
-    items,
-    pageSize: input.pageSize,
-    startAfter: input.startAfter,
-  });
-  return {
-    section: input.section,
-    ...page,
-    warnings,
-  };
+	const warnings: Array<string> = []
+	if (input.section === 'storage_runner') {
+		if (!input.storageId) {
+			throw new Error('storage_id is required when section is storage_runner.')
+		}
+		const pageSize = normalizePageSize(input.pageSize)
+		const runnerExport = await storageRunnerRpc({
+			env: input.env,
+			userId: input.mcpUserId,
+			storageId: input.storageId,
+		}).exportStorage({
+			pageSize,
+			startAfter: input.startAfter,
+		})
+		return {
+			section: input.section,
+			items: runnerExport.entries,
+			truncated: runnerExport.truncated,
+			nextStartAfter: runnerExport.nextStartAfter,
+			pageSize: runnerExport.pageSize,
+			warnings,
+		}
+	}
+	let items: Array<unknown>
+	switch (input.section) {
+		case 'd1_table': {
+			if (!input.table) {
+				throw new Error('table is required when section is d1_table.')
+			}
+			const page = await readD1TableSectionPage({
+				env: input.env,
+				dbUserId: input.dbUserId,
+				mcpUserId: input.mcpUserId,
+				table: input.table,
+				pageSize: input.pageSize,
+				startAfter: input.startAfter,
+				warnings,
+			})
+			if (!page) {
+				throw new Error(`Table "${input.table}" is not part of account export.`)
+			}
+			return {
+				section: input.section,
+				...page,
+				warnings,
+			}
+		}
+		case 'oauth_grants': {
+			const oauthGrants = await listOAuthGrants({
+				env: input.env,
+				userId: input.mcpUserId,
+				warnings,
+			})
+			items = [...oauthGrants]
+			break
+		}
+		case 'artifact_repos': {
+			const inventory = await collectInventory({
+				env: input.env,
+				userId: input.mcpUserId,
+				warnings,
+			})
+			items = inventory.artifactRepos
+			break
+		}
+		case 'kv_keys': {
+			const inventory = await collectInventory({
+				env: input.env,
+				userId: input.mcpUserId,
+				warnings,
+			})
+			items = inventory.bundleKvKeys
+			break
+		}
+		case 'durable_object_summaries': {
+			const inventory = await collectInventory({
+				env: input.env,
+				userId: input.mcpUserId,
+				warnings,
+			})
+			items = [
+				{ kind: 'storage_runner', ids: inventory.storageIds },
+				{ kind: 'remote_connector_session', refs: inventory.remoteConnectors },
+				{ kind: 'package_service', refs: inventory.packageServices },
+				{ kind: 'job_manager', userId: input.mcpUserId },
+			]
+			break
+		}
+		default: {
+			const exhaustive: never = input.section
+			throw new Error(`Unhandled account export section: ${exhaustive}`)
+		}
+	}
+	const page = paginateItems({
+		items,
+		pageSize: input.pageSize,
+		startAfter: input.startAfter,
+	})
+	return {
+		section: input.section,
+		...page,
+		warnings,
+	}
 }

--- a/packages/worker/src/app/account-export.ts
+++ b/packages/worker/src/app/account-export.ts
@@ -1,472 +1,477 @@
-import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import { getErrorMessage } from "@kody-internal/shared/error-message.ts";
 import {
-	accountUserDataTargets,
-	accountUserDataExcludedOwnerIds,
-	type UserScopedDataTarget,
-	getAccountD1UserColumnCoverage,
-} from '#app/account-data-targets.ts'
-import { exportJobManagerForUser } from '#worker/jobs/manager-client.ts'
+  accountUserDataTargets,
+  accountUserDataExcludedOwnerIds,
+  type UserScopedDataTarget,
+  getAccountD1UserColumnCoverage,
+} from "#app/account-data-targets.ts";
+import { exportJobManagerForUser } from "#worker/jobs/manager-client.ts";
 import {
-	buildPackageServiceStorageId,
-	packageServiceRpc,
-} from '#worker/package-runtime/package-service.ts'
+  buildPackageServiceStorageId,
+  packageServiceRpc,
+} from "#worker/package-runtime/package-service.ts";
 import {
-	buildPublishedSourceManifestSnapshotKvKey,
-	buildPublishedSourceSnapshotKvKey,
-} from '#worker/package-runtime/published-runtime-artifacts.ts'
-import { buildCommunitySnapshotKvKey } from '#worker/community/snapshot.ts'
-import { storageRunnerRpc } from '#worker/storage-runner.ts'
-import { userScopedConnectorSessionKey } from '#worker/remote-connector/connector-session-key.ts'
-import { type RemoteConnectorSessionExport } from '#worker/remote-connector/types.ts'
-import { resolveUserStableId } from '#worker/user-id.ts'
+  buildPublishedSourceManifestSnapshotKvKey,
+  buildPublishedSourceSnapshotKvKey,
+} from "#worker/package-runtime/published-runtime-artifacts.ts";
+import { buildCommunitySnapshotKvKey } from "#worker/community/snapshot.ts";
+import { storageRunnerRpc } from "#worker/storage-runner.ts";
+import { userScopedConnectorSessionKey } from "#worker/remote-connector/connector-session-key.ts";
+import { type RemoteConnectorSessionExport } from "#worker/remote-connector/types.ts";
+import { resolveUserStableId } from "#worker/user-id.ts";
 
-const accountExportSchemaVersion = 1
-const defaultExportPageSize = 100
-const maxExportPageSize = 500
+const accountExportSchemaVersion = 1;
+const defaultExportPageSize = 100;
+const maxExportPageSize = 500;
 // Full exports stream each D1 table in keyset-paged batches of this size so
 // memory stays bounded per query even for very large tables (e.g. mailboxes).
-const d1ExportPageSize = 500
+const d1ExportPageSize = 500;
 // Internal alias for the SQLite rowid used as the keyset cursor. Stripped from
 // exported rows so the export document schema is unchanged.
-const exportRowidColumn = '__account_export_rowid'
+const exportRowidColumn = "__account_export_rowid";
 
 // Secret values and credential-equivalent hashes must never leave Kody through
 // account export. Secret entries are metadata-only; encrypted payloads stay
 // server-side and token/password hashes are omitted for the same reason.
 const redactedColumnsByTable: Readonly<Record<string, ReadonlyArray<string>>> =
-	{
-		email_inbox_addresses: ['reply_token_hash'],
-		email_verifications: ['token_hash'],
-		package_invocation_tokens: ['token_hash'],
-		password_resets: ['token_hash'],
-		pending_email_changes: ['token_hash'],
-		platform_feedback: ['reviewed_by_user_id', 'reviewed_at', 'admin_note'],
-		remote_connector_settings: ['encrypted_shared_secret'],
-		secret_entries: ['encrypted_value', 'lookup_hash'],
-		users: ['password_hash'],
-		verifications: ['secret'],
-	}
+  {
+    email_inbox_addresses: ["reply_token_hash"],
+    email_verifications: ["token_hash"],
+    package_invocation_tokens: ["token_hash"],
+    password_resets: ["token_hash"],
+    pending_email_changes: ["token_hash"],
+    platform_feedback: ["reviewed_by_user_id", "reviewed_at", "admin_note"],
+    remote_connector_settings: ["encrypted_shared_secret"],
+    secret_entries: ["encrypted_value", "lookup_hash"],
+    users: ["password_hash"],
+    verifications: ["secret"],
+  };
 
 // Social-graph export rows can include another user's stable id. Keep the
 // exporter's own id; replace every other value in these columns.
 const foreignUserIdColumnsByTable: Readonly<
-	Record<string, ReadonlyArray<string>>
+  Record<string, ReadonlyArray<string>>
 > = {
-	user_follows: ['follower_user_id', 'followee_user_id'],
-	community_stars: ['user_id'],
-	community_activity_events: ['actor_user_id'],
-}
+  user_follows: ["follower_user_id", "followee_user_id"],
+  community_stars: ["user_id"],
+  community_activity_events: ["actor_user_id"],
+  package_scope_grants: [
+    "scope_owner_user_id",
+    "grantee_user_id",
+    "created_by_user_id",
+  ],
+};
 
-const redactedForeignUserId = '[redacted]'
+const redactedForeignUserId = "[redacted]";
 
 export const accountExportSectionNames = [
-	'd1_table',
-	'storage_runner',
-	'oauth_grants',
-	'artifact_repos',
-	'kv_keys',
-	'durable_object_summaries',
-] as const
+  "d1_table",
+  "storage_runner",
+  "oauth_grants",
+  "artifact_repos",
+  "kv_keys",
+  "durable_object_summaries",
+] as const;
 
 export type AccountExportSectionName =
-	(typeof accountExportSectionNames)[number]
+  (typeof accountExportSectionNames)[number];
 
 type OAuthGrantPage = {
-	items: Array<{ id: string; clientId: string }>
-	cursor: string | undefined
-}
+  items: Array<{ id: string; clientId: string }>;
+  cursor: string | undefined;
+};
 
 type OAuthHelpersShape = {
-	listUserGrants(
-		userId: string,
-		options: { cursor: string | undefined },
-	): Promise<OAuthGrantPage>
-}
+  listUserGrants(
+    userId: string,
+    options: { cursor: string | undefined },
+  ): Promise<OAuthGrantPage>;
+};
 
 type AccountExportEnv = Env & {
-	OAUTH_PROVIDER?: OAuthHelpersShape
-}
+  OAUTH_PROVIDER?: OAuthHelpersShape;
+};
 
 type UserSourceSnapshot = {
-	sourceId: string
-	publishedCommit: string | null
-	repoId: string
-	entityKind: string
-	entityId: string
-	manifestPath: string
-	sourceRoot: string
-}
+  sourceId: string;
+  publishedCommit: string | null;
+  repoId: string;
+  entityKind: string;
+  entityId: string;
+  manifestPath: string;
+  sourceRoot: string;
+};
 
 type UserSavedPackageSnapshot = {
-	id: string
-	kodyId: string
-	sourceId: string
-	hasApp: boolean
-}
+  id: string;
+  kodyId: string;
+  sourceId: string;
+  hasApp: boolean;
+};
 
 type UserRemoteConnectorSnapshot = {
-	instanceId: string
-}
+  instanceId: string;
+};
 
 type UserPackageServiceSnapshot = {
-	packageId: string
-	kodyId: string
-	sourceId: string
-	serviceName: string
-}
+  packageId: string;
+  kodyId: string;
+  sourceId: string;
+  serviceName: string;
+};
 
 type UserExportInventory = {
-	storageIds: Array<string>
-	sourceSnapshots: Array<UserSourceSnapshot>
-	savedPackages: Array<UserSavedPackageSnapshot>
-	remoteConnectors: Array<UserRemoteConnectorSnapshot>
-	packageServices: Array<UserPackageServiceSnapshot>
-	communityListingIds: Array<string>
-	bundleKvKeys: Array<string>
-	artifactRepos: Array<AccountExportArtifactRepo>
-}
+  storageIds: Array<string>;
+  sourceSnapshots: Array<UserSourceSnapshot>;
+  savedPackages: Array<UserSavedPackageSnapshot>;
+  remoteConnectors: Array<UserRemoteConnectorSnapshot>;
+  packageServices: Array<UserPackageServiceSnapshot>;
+  communityListingIds: Array<string>;
+  bundleKvKeys: Array<string>;
+  artifactRepos: Array<AccountExportArtifactRepo>;
+};
 
 export type AccountExportManifestSection = {
-	count: number
-	warnings: Array<string>
-	redactedColumns?: Array<string>
-}
+  count: number;
+  warnings: Array<string>;
+  redactedColumns?: Array<string>;
+};
 
 export type AccountExportManifest = {
-	schemaVersion: number
-	generatedAt: string
-	user: {
-		dbUserId: number
-		userId: string
-	}
-	security: {
-		secretValuesExported: false
-		note: string
-	}
-	sections: Record<string, AccountExportManifestSection>
-	warnings: Array<string>
-	chunking: {
-		sections: Array<AccountExportSectionName>
-		defaultPageSize: number
-		maxPageSize: number
-	}
-	artifacts: {
-		canonicalPackageSource: string
-	}
-	derivedData: {
-		vectorize: string
-	}
-	excludedDurableObjects: Array<{
-		name: string
-		reason: string
-	}>
-	excludedD1Surfaces: Array<{
-		name: string
-		reason: string
-	}>
-}
+  schemaVersion: number;
+  generatedAt: string;
+  user: {
+    dbUserId: number;
+    userId: string;
+  };
+  security: {
+    secretValuesExported: false;
+    note: string;
+  };
+  sections: Record<string, AccountExportManifestSection>;
+  warnings: Array<string>;
+  chunking: {
+    sections: Array<AccountExportSectionName>;
+    defaultPageSize: number;
+    maxPageSize: number;
+  };
+  artifacts: {
+    canonicalPackageSource: string;
+  };
+  derivedData: {
+    vectorize: string;
+  };
+  excludedDurableObjects: Array<{
+    name: string;
+    reason: string;
+  }>;
+  excludedD1Surfaces: Array<{
+    name: string;
+    reason: string;
+  }>;
+};
 
 export type AccountExportD1Table = {
-	table: string
-	rows: Array<Record<string, unknown>>
-	redactedColumns: Array<string>
-	warnings: Array<string>
-}
+  table: string;
+  rows: Array<Record<string, unknown>>;
+  redactedColumns: Array<string>;
+  warnings: Array<string>;
+};
 
 export type AccountExportArtifactRepo = {
-	sourceId: string
-	entityKind: string
-	entityId: string
-	repoId: string
-	publishedCommit: string | null
-	manifestPath: string
-	sourceRoot: string
-}
+  sourceId: string;
+  entityKind: string;
+  entityId: string;
+  repoId: string;
+  publishedCommit: string | null;
+  manifestPath: string;
+  sourceRoot: string;
+};
 
 type AccountExportDurableObjects = {
-	jobManager: unknown | null
-	remoteConnectorSessions: Array<{
-		instanceId: string
-		export: RemoteConnectorSessionExport | null
-	}>
-	packageServices: Array<{
-		packageId: string
-		serviceName: string
-		status: unknown | null
-	}>
-	storageRunners: Array<{
-		storageId: string
-		export: Awaited<
-			ReturnType<ReturnType<typeof storageRunnerRpc>['exportStorage']>
-		>
-	}>
-}
+  jobManager: unknown | null;
+  remoteConnectorSessions: Array<{
+    instanceId: string;
+    export: RemoteConnectorSessionExport | null;
+  }>;
+  packageServices: Array<{
+    packageId: string;
+    serviceName: string;
+    status: unknown | null;
+  }>;
+  storageRunners: Array<{
+    storageId: string;
+    export: Awaited<
+      ReturnType<ReturnType<typeof storageRunnerRpc>["exportStorage"]>
+    >;
+  }>;
+};
 
 export type AccountExportFile = {
-	manifest: AccountExportManifest
-	d1: Record<string, AccountExportD1Table>
-	durableObjects: AccountExportDurableObjects
-	oauthGrants: Array<{ id: string; clientId: string }>
-	artifactRepos: Array<AccountExportArtifactRepo>
-	kvKeys: Array<string>
-}
+  manifest: AccountExportManifest;
+  d1: Record<string, AccountExportD1Table>;
+  durableObjects: AccountExportDurableObjects;
+  oauthGrants: Array<{ id: string; clientId: string }>;
+  artifactRepos: Array<AccountExportArtifactRepo>;
+  kvKeys: Array<string>;
+};
 
 export type AccountExportSectionResult = {
-	section: AccountExportSectionName
-	items: Array<unknown>
-	truncated: boolean
-	nextStartAfter: string | null
-	pageSize: number
-	warnings: Array<string>
-}
+  section: AccountExportSectionName;
+  items: Array<unknown>;
+  truncated: boolean;
+  nextStartAfter: string | null;
+  pageSize: number;
+  warnings: Array<string>;
+};
 
 function normalizePageSize(pageSize: number | undefined) {
-	const requested =
-		typeof pageSize === 'number' && Number.isFinite(pageSize)
-			? Math.trunc(pageSize)
-			: defaultExportPageSize
-	return Math.min(Math.max(requested, 1), maxExportPageSize)
+  const requested =
+    typeof pageSize === "number" && Number.isFinite(pageSize)
+      ? Math.trunc(pageSize)
+      : defaultExportPageSize;
+  return Math.min(Math.max(requested, 1), maxExportPageSize);
 }
 
 function paginateItems<T>(input: {
-	items: ReadonlyArray<T>
-	pageSize: number | undefined
-	startAfter: string | undefined
+  items: ReadonlyArray<T>;
+  pageSize: number | undefined;
+  startAfter: string | undefined;
 }) {
-	const pageSize = normalizePageSize(input.pageSize)
-	const startIndex = input.startAfter
-		? Number.parseInt(input.startAfter, 10)
-		: 0
-	const safeStart =
-		Number.isFinite(startIndex) && startIndex > 0 ? startIndex : 0
-	const page = input.items.slice(safeStart, safeStart + pageSize)
-	const nextIndex = safeStart + page.length
-	const truncated = nextIndex < input.items.length
-	return {
-		items: page,
-		truncated,
-		nextStartAfter: truncated ? String(nextIndex) : null,
-		pageSize,
-	}
+  const pageSize = normalizePageSize(input.pageSize);
+  const startIndex = input.startAfter
+    ? Number.parseInt(input.startAfter, 10)
+    : 0;
+  const safeStart =
+    Number.isFinite(startIndex) && startIndex > 0 ? startIndex : 0;
+  const page = input.items.slice(safeStart, safeStart + pageSize);
+  const nextIndex = safeStart + page.length;
+  const truncated = nextIndex < input.items.length;
+  return {
+    items: page,
+    truncated,
+    nextStartAfter: truncated ? String(nextIndex) : null,
+    pageSize,
+  };
 }
 
 function uniqueStrings(values: Iterable<string | null | undefined>) {
-	return Array.from(
-		new Set(
-			Array.from(values)
-				.map((value) => value?.trim() ?? '')
-				.filter((value) => value.length > 0),
-		),
-	)
+  return Array.from(
+    new Set(
+      Array.from(values)
+        .map((value) => value?.trim() ?? "")
+        .filter((value) => value.length > 0),
+    ),
+  );
 }
 
 function normalizeBoolean(value: unknown) {
-	return value === 1 || value === '1' || value === true
+  return value === 1 || value === "1" || value === true;
 }
 
 type D1TableCondition = {
-	condition: string
-	params: Array<unknown>
-}
+  condition: string;
+  params: Array<unknown>;
+};
 
 function buildConditionForTarget(input: {
-	target: UserScopedDataTarget
-	mcpUserId: string
-	dbUserId: number
+  target: UserScopedDataTarget;
+  mcpUserId: string;
+  dbUserId: number;
 }): { table: string; condition: D1TableCondition } {
-	const { target } = input
-	switch (target.kind) {
-		case 'user_id': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.user_id = ?`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		case 'db_user_id': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.user_id = ?`,
-					params: [input.dbUserId],
-				},
-			}
-		}
-		case 'db_user_target': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.target = ?`,
-					params: [String(input.dbUserId)],
-				},
-			}
-		}
-		case 'user_columns': {
-			return {
-				table: target.table,
-				condition: {
-					condition: target.columns
-						.map((column) => `${target.table}.${column} = ?`)
-						.join(' OR '),
-					params: target.columns.map(() => input.mcpUserId),
-				},
-			}
-		}
-		case 'null_user_column': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.${target.matchColumn} = ?`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		case 'replace_user_column': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.${target.matchColumn} = ?`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		case 'bucket_parent': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.bucket_id IN (
+  const { target } = input;
+  switch (target.kind) {
+    case "user_id": {
+      return {
+        table: target.table,
+        condition: {
+          condition: `${target.table}.user_id = ?`,
+          params: [input.mcpUserId],
+        },
+      };
+    }
+    case "db_user_id": {
+      return {
+        table: target.table,
+        condition: {
+          condition: `${target.table}.user_id = ?`,
+          params: [input.dbUserId],
+        },
+      };
+    }
+    case "db_user_target": {
+      return {
+        table: target.table,
+        condition: {
+          condition: `${target.table}.target = ?`,
+          params: [String(input.dbUserId)],
+        },
+      };
+    }
+    case "user_columns": {
+      return {
+        table: target.table,
+        condition: {
+          condition: target.columns
+            .map((column) => `${target.table}.${column} = ?`)
+            .join(" OR "),
+          params: target.columns.map(() => input.mcpUserId),
+        },
+      };
+    }
+    case "null_user_column": {
+      return {
+        table: target.table,
+        condition: {
+          condition: `${target.table}.${target.matchColumn} = ?`,
+          params: [input.mcpUserId],
+        },
+      };
+    }
+    case "replace_user_column": {
+      return {
+        table: target.table,
+        condition: {
+          condition: `${target.table}.${target.matchColumn} = ?`,
+          params: [input.mcpUserId],
+        },
+      };
+    }
+    case "bucket_parent": {
+      return {
+        table: target.table,
+        condition: {
+          condition: `${target.table}.bucket_id IN (
 						SELECT id FROM ${target.parentTable} WHERE user_id = ?
 					)`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		case 'attachment_parent': {
-			return {
-				table: 'email_attachments',
-				condition: {
-					condition: `email_attachments.message_id IN (
+          params: [input.mcpUserId],
+        },
+      };
+    }
+    case "attachment_parent": {
+      return {
+        table: "email_attachments",
+        condition: {
+          condition: `email_attachments.message_id IN (
 						SELECT id FROM email_messages WHERE user_id = ?
 					)`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		case 'community_listing_child': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.${target.listingColumn} IN (
+          params: [input.mcpUserId],
+        },
+      };
+    }
+    case "community_listing_child": {
+      return {
+        table: target.table,
+        condition: {
+          condition: `${target.table}.${target.listingColumn} IN (
 						SELECT id FROM community_listings WHERE owner_user_id = ?
 					)`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		case 'mcp_memory_suppression': {
-			return {
-				table: 'mcp_memory_conversation_suppressions',
-				condition: {
-					condition: `mcp_memory_conversation_suppressions.user_id = ?`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		default: {
-			const exhaustive: never = target
-			throw new Error(
-				`Unhandled account export target: ${JSON.stringify(exhaustive)}`,
-			)
-		}
-	}
+          params: [input.mcpUserId],
+        },
+      };
+    }
+    case "mcp_memory_suppression": {
+      return {
+        table: "mcp_memory_conversation_suppressions",
+        condition: {
+          condition: `mcp_memory_conversation_suppressions.user_id = ?`,
+          params: [input.mcpUserId],
+        },
+      };
+    }
+    default: {
+      const exhaustive: never = target;
+      throw new Error(
+        `Unhandled account export target: ${JSON.stringify(exhaustive)}`,
+      );
+    }
+  }
 }
 
 function buildD1TableConditions(input: {
-	mcpUserId: string
-	dbUserId: number
+  mcpUserId: string;
+  dbUserId: number;
 }) {
-	const conditionsByTable = new Map<string, Array<D1TableCondition>>()
-	function add(table: string, condition: D1TableCondition) {
-		const existing = conditionsByTable.get(table)
-		if (existing) {
-			existing.push(condition)
-			return
-		}
-		conditionsByTable.set(table, [condition])
-	}
-	add('users', { condition: `users.id = ?`, params: [input.dbUserId] })
-	for (const target of accountUserDataTargets) {
-		if (
-			target.kind === 'null_user_column' &&
-			target.includeInExport === false
-		) {
-			continue
-		}
-		const built = buildConditionForTarget({
-			target,
-			mcpUserId: input.mcpUserId,
-			dbUserId: input.dbUserId,
-		})
-		add(built.table, built.condition)
-	}
-	return conditionsByTable
+  const conditionsByTable = new Map<string, Array<D1TableCondition>>();
+  function add(table: string, condition: D1TableCondition) {
+    const existing = conditionsByTable.get(table);
+    if (existing) {
+      existing.push(condition);
+      return;
+    }
+    conditionsByTable.set(table, [condition]);
+  }
+  add("users", { condition: `users.id = ?`, params: [input.dbUserId] });
+  for (const target of accountUserDataTargets) {
+    if (
+      target.kind === "null_user_column" &&
+      target.includeInExport === false
+    ) {
+      continue;
+    }
+    const built = buildConditionForTarget({
+      target,
+      mcpUserId: input.mcpUserId,
+      dbUserId: input.dbUserId,
+    });
+    add(built.table, built.condition);
+  }
+  return conditionsByTable;
 }
 
 function sanitizeRow(
-	table: string,
-	row: Record<string, unknown>,
-	mcpUserId: string,
+  table: string,
+  row: Record<string, unknown>,
+  mcpUserId: string,
 ) {
-	const redactedColumns = redactedColumnsByTable[table] ?? []
-	const foreignUserIdColumns = foreignUserIdColumnsByTable[table] ?? []
-	const sanitized: Record<string, unknown> = {}
-	for (const [key, value] of Object.entries(row)) {
-		if (redactedColumns.includes(key)) continue
-		if (
-			foreignUserIdColumns.includes(key) &&
-			typeof value === 'string' &&
-			value !== mcpUserId
-		) {
-			sanitized[key] = redactedForeignUserId
-			continue
-		}
-		sanitized[key] = value
-	}
-	return {
-		row: sanitized,
-		redactedColumns: redactedColumns.filter((column) => column in row),
-	}
+  const redactedColumns = redactedColumnsByTable[table] ?? [];
+  const foreignUserIdColumns = foreignUserIdColumnsByTable[table] ?? [];
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(row)) {
+    if (redactedColumns.includes(key)) continue;
+    if (
+      foreignUserIdColumns.includes(key) &&
+      typeof value === "string" &&
+      value !== mcpUserId
+    ) {
+      sanitized[key] = redactedForeignUserId;
+      continue;
+    }
+    sanitized[key] = value;
+  }
+  return {
+    row: sanitized,
+    redactedColumns: redactedColumns.filter((column) => column in row),
+  };
 }
 
 function rowDedupeKey(row: Record<string, unknown>) {
-	if ('id' in row && row.id !== null && row.id !== undefined)
-		return String(row.id)
-	if ('bucket_id' in row && 'name' in row) {
-		return `${String(row.bucket_id)}:${String(row.name)}`
-	}
-	if ('user_id' in row && 'role_id' in row) {
-		return `${String(row.user_id)}:${String(row.role_id)}`
-	}
-	return JSON.stringify(row)
+  if ("id" in row && row.id !== null && row.id !== undefined)
+    return String(row.id);
+  if ("bucket_id" in row && "name" in row) {
+    return `${String(row.bucket_id)}:${String(row.name)}`;
+  }
+  if ("user_id" in row && "role_id" in row) {
+    return `${String(row.user_id)}:${String(row.role_id)}`;
+  }
+  return JSON.stringify(row);
 }
 
 function sortRowsByDedupeKey(rows: Array<Record<string, unknown>>) {
-	return rows.sort((left, right) =>
-		rowDedupeKey(left).localeCompare(rowDedupeKey(right)),
-	)
+  return rows.sort((left, right) =>
+    rowDedupeKey(left).localeCompare(rowDedupeKey(right)),
+  );
 }
 
 async function selectRows<T extends Record<string, unknown>>(
-	env: Env,
-	sql: string,
-	params: ReadonlyArray<unknown>,
+  env: Env,
+  sql: string,
+  params: ReadonlyArray<unknown>,
 ) {
-	const result = await env.APP_DB.prepare(sql)
-		.bind(...params)
-		.all<T>()
-	return result.results ?? []
+  const result = await env.APP_DB.prepare(sql)
+    .bind(...params)
+    .all<T>();
+  return result.results ?? [];
 }
 
 // Reads one keyset page of a table: rows are selected by ascending rowid
@@ -475,193 +480,193 @@ async function selectRows<T extends Record<string, unknown>>(
 // target of the table are OR-combined into one query, which also removes the
 // need for cross-target row deduplication.
 async function selectD1TablePage(input: {
-	env: AccountExportEnv
-	table: string
-	conditions: ReadonlyArray<D1TableCondition>
-	mcpUserId: string
-	afterRowid: number
-	limit: number
+  env: AccountExportEnv;
+  table: string;
+  conditions: ReadonlyArray<D1TableCondition>;
+  mcpUserId: string;
+  afterRowid: number;
+  limit: number;
 }) {
-	const where = input.conditions
-		.map((condition) => `(${condition.condition})`)
-		.join(' OR ')
-	const sql = `SELECT ${input.table}.rowid AS ${exportRowidColumn}, ${input.table}.*
+  const where = input.conditions
+    .map((condition) => `(${condition.condition})`)
+    .join(" OR ");
+  const sql = `SELECT ${input.table}.rowid AS ${exportRowidColumn}, ${input.table}.*
 		FROM ${input.table}
 		WHERE (${where}) AND ${input.table}.rowid > ?
 		ORDER BY ${input.table}.rowid
-		LIMIT ?`
-	const params = [
-		...input.conditions.flatMap((condition) => condition.params),
-		input.afterRowid,
-		input.limit + 1,
-	]
-	const rawRows = await selectRows(input.env, sql, params)
-	const truncated = rawRows.length > input.limit
-	const pageRows = truncated ? rawRows.slice(0, input.limit) : rawRows
-	let lastRowid = input.afterRowid
-	const rows: Array<ReturnType<typeof sanitizeRow>> = []
-	for (const rawRow of pageRows) {
-		const { [exportRowidColumn]: rowid, ...columns } = rawRow
-		lastRowid = Number(rowid)
-		rows.push(sanitizeRow(input.table, columns, input.mcpUserId))
-	}
-	return { rows, lastRowid, truncated }
+		LIMIT ?`;
+  const params = [
+    ...input.conditions.flatMap((condition) => condition.params),
+    input.afterRowid,
+    input.limit + 1,
+  ];
+  const rawRows = await selectRows(input.env, sql, params);
+  const truncated = rawRows.length > input.limit;
+  const pageRows = truncated ? rawRows.slice(0, input.limit) : rawRows;
+  let lastRowid = input.afterRowid;
+  const rows: Array<ReturnType<typeof sanitizeRow>> = [];
+  for (const rawRow of pageRows) {
+    const { [exportRowidColumn]: rowid, ...columns } = rawRow;
+    lastRowid = Number(rowid);
+    rows.push(sanitizeRow(input.table, columns, input.mcpUserId));
+  }
+  return { rows, lastRowid, truncated };
 }
 
 async function collectD1TableRows(input: {
-	env: AccountExportEnv
-	table: string
-	conditions: ReadonlyArray<D1TableCondition>
-	mcpUserId: string
-	warnings: Array<string>
+  env: AccountExportEnv;
+  table: string;
+  conditions: ReadonlyArray<D1TableCondition>;
+  mcpUserId: string;
+  warnings: Array<string>;
 }): Promise<AccountExportD1Table> {
-	const section: AccountExportD1Table = {
-		table: input.table,
-		rows: [],
-		redactedColumns: [],
-		warnings: [],
-	}
-	const redacted = new Set<string>()
-	let afterRowid = 0
-	try {
-		while (true) {
-			const page = await selectD1TablePage({
-				env: input.env,
-				table: input.table,
-				conditions: input.conditions,
-				mcpUserId: input.mcpUserId,
-				afterRowid,
-				limit: d1ExportPageSize,
-			})
-			for (const entry of page.rows) {
-				for (const column of entry.redactedColumns) redacted.add(column)
-				section.rows.push(entry.row)
-			}
-			if (!page.truncated) break
-			afterRowid = page.lastRowid
-		}
-	} catch (error) {
-		const warning = `D1 export failed for ${input.table}: ${getErrorMessage(error)}`
-		section.warnings.push(warning)
-		input.warnings.push(warning)
-	}
-	section.rows = sortRowsByDedupeKey(section.rows)
-	section.redactedColumns = Array.from(redacted).sort()
-	return section
+  const section: AccountExportD1Table = {
+    table: input.table,
+    rows: [],
+    redactedColumns: [],
+    warnings: [],
+  };
+  const redacted = new Set<string>();
+  let afterRowid = 0;
+  try {
+    while (true) {
+      const page = await selectD1TablePage({
+        env: input.env,
+        table: input.table,
+        conditions: input.conditions,
+        mcpUserId: input.mcpUserId,
+        afterRowid,
+        limit: d1ExportPageSize,
+      });
+      for (const entry of page.rows) {
+        for (const column of entry.redactedColumns) redacted.add(column);
+        section.rows.push(entry.row);
+      }
+      if (!page.truncated) break;
+      afterRowid = page.lastRowid;
+    }
+  } catch (error) {
+    const warning = `D1 export failed for ${input.table}: ${getErrorMessage(error)}`;
+    section.warnings.push(warning);
+    input.warnings.push(warning);
+  }
+  section.rows = sortRowsByDedupeKey(section.rows);
+  section.redactedColumns = Array.from(redacted).sort();
+  return section;
 }
 
 async function listUserStorageIds(env: Env, userId: string) {
-	const [jobRows, archivedRows, runtimeRows, packageRows, serviceRows] =
-		await Promise.all([
-			selectRows<{ storage_id: string }>(
-				env,
-				`SELECT storage_id FROM jobs WHERE user_id = ? AND storage_id IS NOT NULL`,
-				[userId],
-			),
-			selectRows<{ storage_id: string }>(
-				env,
-				`SELECT storage_id FROM archived_job_artifacts WHERE user_id = ? AND storage_id IS NOT NULL`,
-				[userId],
-			),
-			selectRows<{ storage_id: string }>(
-				env,
-				`SELECT storage_id FROM package_runtime_runs WHERE user_id = ? AND storage_id IS NOT NULL`,
-				[userId],
-			),
-			selectRows<{ id: string }>(
-				env,
-				`SELECT id FROM saved_packages WHERE user_id = ? AND has_app = 1`,
-				[userId],
-			),
-			selectRows<{ package_id: string; name: string }>(
-				env,
-				`SELECT DISTINCT package_id, name
+  const [jobRows, archivedRows, runtimeRows, packageRows, serviceRows] =
+    await Promise.all([
+      selectRows<{ storage_id: string }>(
+        env,
+        `SELECT storage_id FROM jobs WHERE user_id = ? AND storage_id IS NOT NULL`,
+        [userId],
+      ),
+      selectRows<{ storage_id: string }>(
+        env,
+        `SELECT storage_id FROM archived_job_artifacts WHERE user_id = ? AND storage_id IS NOT NULL`,
+        [userId],
+      ),
+      selectRows<{ storage_id: string }>(
+        env,
+        `SELECT storage_id FROM package_runtime_runs WHERE user_id = ? AND storage_id IS NOT NULL`,
+        [userId],
+      ),
+      selectRows<{ id: string }>(
+        env,
+        `SELECT id FROM saved_packages WHERE user_id = ? AND has_app = 1`,
+        [userId],
+      ),
+      selectRows<{ package_id: string; name: string }>(
+        env,
+        `SELECT DISTINCT package_id, name
 				FROM package_runtime_runs
 				WHERE user_id = ? AND surface = 'service' AND name IS NOT NULL`,
-				[userId],
-			),
-		])
-	return uniqueStrings([
-		...jobRows.map((row) => row.storage_id),
-		...archivedRows.map((row) => row.storage_id),
-		...runtimeRows.map((row) => row.storage_id),
-		...packageRows.map((row) => row.id),
-		...serviceRows.map((row) =>
-			buildPackageServiceStorageId(row.package_id, row.name),
-		),
-	])
+        [userId],
+      ),
+    ]);
+  return uniqueStrings([
+    ...jobRows.map((row) => row.storage_id),
+    ...archivedRows.map((row) => row.storage_id),
+    ...runtimeRows.map((row) => row.storage_id),
+    ...packageRows.map((row) => row.id),
+    ...serviceRows.map((row) =>
+      buildPackageServiceStorageId(row.package_id, row.name),
+    ),
+  ]);
 }
 
 async function listUserSourceSnapshots(env: Env, userId: string) {
-	const rows = await selectRows<{
-		id: string
-		published_commit: string | null
-		repo_id: string
-		entity_kind: string
-		entity_id: string
-		manifest_path: string
-		source_root: string
-	}>(
-		env,
-		`SELECT id, published_commit, repo_id, entity_kind, entity_id, manifest_path, source_root
+  const rows = await selectRows<{
+    id: string;
+    published_commit: string | null;
+    repo_id: string;
+    entity_kind: string;
+    entity_id: string;
+    manifest_path: string;
+    source_root: string;
+  }>(
+    env,
+    `SELECT id, published_commit, repo_id, entity_kind, entity_id, manifest_path, source_root
 		FROM entity_sources
 		WHERE user_id = ?`,
-		[userId],
-	)
-	return rows.map((row) => ({
-		sourceId: row.id,
-		publishedCommit: row.published_commit,
-		repoId: row.repo_id,
-		entityKind: row.entity_kind,
-		entityId: row.entity_id,
-		manifestPath: row.manifest_path,
-		sourceRoot: row.source_root,
-	}))
+    [userId],
+  );
+  return rows.map((row) => ({
+    sourceId: row.id,
+    publishedCommit: row.published_commit,
+    repoId: row.repo_id,
+    entityKind: row.entity_kind,
+    entityId: row.entity_id,
+    manifestPath: row.manifest_path,
+    sourceRoot: row.source_root,
+  }));
 }
 
 async function listUserSavedPackages(env: Env, userId: string) {
-	const rows = await selectRows<{
-		id: string
-		kody_id: string
-		source_id: string
-		has_app: number | string | boolean
-	}>(
-		env,
-		`SELECT id, kody_id, source_id, has_app
+  const rows = await selectRows<{
+    id: string;
+    kody_id: string;
+    source_id: string;
+    has_app: number | string | boolean;
+  }>(
+    env,
+    `SELECT id, kody_id, source_id, has_app
 		FROM saved_packages
 		WHERE user_id = ?`,
-		[userId],
-	)
-	return rows.map((row) => ({
-		id: row.id,
-		kodyId: row.kody_id,
-		sourceId: row.source_id,
-		hasApp: normalizeBoolean(row.has_app),
-	}))
+    [userId],
+  );
+  return rows.map((row) => ({
+    id: row.id,
+    kodyId: row.kody_id,
+    sourceId: row.source_id,
+    hasApp: normalizeBoolean(row.has_app),
+  }));
 }
 
 async function listUserRemoteConnectors(env: Env, userId: string) {
-	const rows = await selectRows<{ instance_id: string }>(
-		env,
-		`SELECT instance_id
+  const rows = await selectRows<{ instance_id: string }>(
+    env,
+    `SELECT instance_id
 		FROM remote_connector_settings
 		WHERE user_id = ?`,
-		[userId],
-	)
-	return rows.map((row) => ({
-		instanceId: row.instance_id,
-	}))
+    [userId],
+  );
+  return rows.map((row) => ({
+    instanceId: row.instance_id,
+  }));
 }
 
 async function listUserPackageServices(env: Env, userId: string) {
-	const rows = await selectRows<{
-		package_id: string
-		kody_id: string
-		source_id: string | null
-		name: string
-	}>(
-		env,
-		`SELECT DISTINCT
+  const rows = await selectRows<{
+    package_id: string;
+    kody_id: string;
+    source_id: string | null;
+    name: string;
+  }>(
+    env,
+    `SELECT DISTINCT
 			r.package_id,
 			COALESCE(p.kody_id, r.package_kody_id) AS kody_id,
 			COALESCE(p.source_id, r.source_id) AS source_id,
@@ -672,764 +677,766 @@ async function listUserPackageServices(env: Env, userId: string) {
 		WHERE r.user_id = ?
 			AND r.surface = 'service'
 			AND r.name IS NOT NULL`,
-		[userId],
-	)
-	return rows.map((row) => ({
-		packageId: row.package_id,
-		kodyId: row.kody_id,
-		sourceId: row.source_id ?? '',
-		serviceName: row.name,
-	}))
+    [userId],
+  );
+  return rows.map((row) => ({
+    packageId: row.package_id,
+    kodyId: row.kody_id,
+    sourceId: row.source_id ?? "",
+    serviceName: row.name,
+  }));
 }
 
 async function listUserCommunityListingIds(env: Env, userId: string) {
-	const rows = await selectRows<{ id: string }>(
-		env,
-		`SELECT id FROM community_listings WHERE owner_user_id = ?`,
-		[userId],
-	)
-	return uniqueStrings(rows.map((row) => row.id))
+  const rows = await selectRows<{ id: string }>(
+    env,
+    `SELECT id FROM community_listings WHERE owner_user_id = ?`,
+    [userId],
+  );
+  return uniqueStrings(rows.map((row) => row.id));
 }
 
 async function listUserBundleKvKeys(input: {
-	env: Env
-	userId: string
-	sourceSnapshots: ReadonlyArray<UserSourceSnapshot>
-	communityListingIds: ReadonlyArray<string>
-	warnings: Array<string>
+  env: Env;
+  userId: string;
+  sourceSnapshots: ReadonlyArray<UserSourceSnapshot>;
+  communityListingIds: ReadonlyArray<string>;
+  warnings: Array<string>;
 }) {
-	const published = await selectRows<{ kv_key: string }>(
-		input.env,
-		`SELECT kv_key FROM published_bundle_artifacts WHERE user_id = ?`,
-		[input.userId],
-	)
-	const keys = new Set(
-		uniqueStrings([
-			...published.map((row) => row.kv_key),
-			...input.sourceSnapshots.flatMap((source) =>
-				source.publishedCommit
-					? [
-							buildPublishedSourceSnapshotKvKey({
-								sourceId: source.sourceId,
-								publishedCommit: source.publishedCommit,
-							}),
-							buildPublishedSourceManifestSnapshotKvKey({
-								sourceId: source.sourceId,
-								publishedCommit: source.publishedCommit,
-							}),
-						]
-					: [],
-			),
-			...input.communityListingIds.map(buildCommunitySnapshotKvKey),
-		]),
-	)
-	if (!input.env.BUNDLE_ARTIFACTS_KV?.list) return Array.from(keys)
-	const prefixes = input.sourceSnapshots.flatMap((source) => [
-		`source-snapshot:v1:${source.sourceId}:`,
-		`source-manifest-snapshot:v1:${source.sourceId}:`,
-	])
-	for (const prefix of prefixes) {
-		let cursor: string | undefined
-		do {
-			try {
-				const result = await input.env.BUNDLE_ARTIFACTS_KV.list({
-					prefix,
-					cursor,
-				})
-				for (const key of result.keys) {
-					keys.add(key.name)
-				}
-				cursor = result.list_complete ? undefined : result.cursor
-			} catch (error) {
-				input.warnings.push(
-					`KV prefix listing failed for ${prefix}: ${getErrorMessage(error)}`,
-				)
-				cursor = undefined
-			}
-		} while (cursor)
-	}
-	return Array.from(keys).sort()
+  const published = await selectRows<{ kv_key: string }>(
+    input.env,
+    `SELECT kv_key FROM published_bundle_artifacts WHERE user_id = ?`,
+    [input.userId],
+  );
+  const keys = new Set(
+    uniqueStrings([
+      ...published.map((row) => row.kv_key),
+      ...input.sourceSnapshots.flatMap((source) =>
+        source.publishedCommit
+          ? [
+              buildPublishedSourceSnapshotKvKey({
+                sourceId: source.sourceId,
+                publishedCommit: source.publishedCommit,
+              }),
+              buildPublishedSourceManifestSnapshotKvKey({
+                sourceId: source.sourceId,
+                publishedCommit: source.publishedCommit,
+              }),
+            ]
+          : [],
+      ),
+      ...input.communityListingIds.map(buildCommunitySnapshotKvKey),
+    ]),
+  );
+  if (!input.env.BUNDLE_ARTIFACTS_KV?.list) return Array.from(keys);
+  const prefixes = input.sourceSnapshots.flatMap((source) => [
+    `source-snapshot:v1:${source.sourceId}:`,
+    `source-manifest-snapshot:v1:${source.sourceId}:`,
+  ]);
+  for (const prefix of prefixes) {
+    let cursor: string | undefined;
+    do {
+      try {
+        const result = await input.env.BUNDLE_ARTIFACTS_KV.list({
+          prefix,
+          cursor,
+        });
+        for (const key of result.keys) {
+          keys.add(key.name);
+        }
+        cursor = result.list_complete ? undefined : result.cursor;
+      } catch (error) {
+        input.warnings.push(
+          `KV prefix listing failed for ${prefix}: ${getErrorMessage(error)}`,
+        );
+        cursor = undefined;
+      }
+    } while (cursor);
+  }
+  return Array.from(keys).sort();
 }
 
 async function collectInventory(input: {
-	env: AccountExportEnv
-	userId: string
-	warnings: Array<string>
+  env: AccountExportEnv;
+  userId: string;
+  warnings: Array<string>;
 }): Promise<UserExportInventory> {
-	const [
-		storageIds,
-		sourceSnapshots,
-		savedPackages,
-		remoteConnectors,
-		packageServices,
-		communityListingIds,
-	] = await Promise.all([
-		listUserStorageIds(input.env, input.userId).catch((error) => {
-			input.warnings.push(
-				`Failed to enumerate storage ids: ${getErrorMessage(error)}`,
-			)
-			return [] as Array<string>
-		}),
-		listUserSourceSnapshots(input.env, input.userId).catch((error) => {
-			input.warnings.push(
-				`Failed to enumerate entity sources: ${getErrorMessage(error)}`,
-			)
-			return [] as Array<UserSourceSnapshot>
-		}),
-		listUserSavedPackages(input.env, input.userId).catch((error) => {
-			input.warnings.push(
-				`Failed to enumerate saved packages: ${getErrorMessage(error)}`,
-			)
-			return [] as Array<UserSavedPackageSnapshot>
-		}),
-		listUserRemoteConnectors(input.env, input.userId).catch((error) => {
-			input.warnings.push(
-				`Failed to enumerate remote connectors: ${getErrorMessage(error)}`,
-			)
-			return [] as Array<UserRemoteConnectorSnapshot>
-		}),
-		listUserPackageServices(input.env, input.userId).catch((error) => {
-			input.warnings.push(
-				`Failed to enumerate package services: ${getErrorMessage(error)}`,
-			)
-			return [] as Array<UserPackageServiceSnapshot>
-		}),
-		listUserCommunityListingIds(input.env, input.userId).catch((error) => {
-			input.warnings.push(
-				`Failed to enumerate community listings: ${getErrorMessage(error)}`,
-			)
-			return [] as Array<string>
-		}),
-	])
-	const bundleKvKeys = await listUserBundleKvKeys({
-		env: input.env,
-		userId: input.userId,
-		sourceSnapshots,
-		communityListingIds,
-		warnings: input.warnings,
-	}).catch((error) => {
-		input.warnings.push(
-			`Failed to enumerate bundle KV keys: ${getErrorMessage(error)}`,
-		)
-		return [] as Array<string>
-	})
-	const artifactRepos = sourceSnapshots.map((source) => ({
-		sourceId: source.sourceId,
-		entityKind: source.entityKind,
-		entityId: source.entityId,
-		repoId: source.repoId,
-		publishedCommit: source.publishedCommit,
-		manifestPath: source.manifestPath,
-		sourceRoot: source.sourceRoot,
-	}))
-	return {
-		storageIds,
-		sourceSnapshots,
-		savedPackages,
-		remoteConnectors,
-		packageServices,
-		communityListingIds,
-		bundleKvKeys,
-		artifactRepos,
-	}
+  const [
+    storageIds,
+    sourceSnapshots,
+    savedPackages,
+    remoteConnectors,
+    packageServices,
+    communityListingIds,
+  ] = await Promise.all([
+    listUserStorageIds(input.env, input.userId).catch((error) => {
+      input.warnings.push(
+        `Failed to enumerate storage ids: ${getErrorMessage(error)}`,
+      );
+      return [] as Array<string>;
+    }),
+    listUserSourceSnapshots(input.env, input.userId).catch((error) => {
+      input.warnings.push(
+        `Failed to enumerate entity sources: ${getErrorMessage(error)}`,
+      );
+      return [] as Array<UserSourceSnapshot>;
+    }),
+    listUserSavedPackages(input.env, input.userId).catch((error) => {
+      input.warnings.push(
+        `Failed to enumerate saved packages: ${getErrorMessage(error)}`,
+      );
+      return [] as Array<UserSavedPackageSnapshot>;
+    }),
+    listUserRemoteConnectors(input.env, input.userId).catch((error) => {
+      input.warnings.push(
+        `Failed to enumerate remote connectors: ${getErrorMessage(error)}`,
+      );
+      return [] as Array<UserRemoteConnectorSnapshot>;
+    }),
+    listUserPackageServices(input.env, input.userId).catch((error) => {
+      input.warnings.push(
+        `Failed to enumerate package services: ${getErrorMessage(error)}`,
+      );
+      return [] as Array<UserPackageServiceSnapshot>;
+    }),
+    listUserCommunityListingIds(input.env, input.userId).catch((error) => {
+      input.warnings.push(
+        `Failed to enumerate community listings: ${getErrorMessage(error)}`,
+      );
+      return [] as Array<string>;
+    }),
+  ]);
+  const bundleKvKeys = await listUserBundleKvKeys({
+    env: input.env,
+    userId: input.userId,
+    sourceSnapshots,
+    communityListingIds,
+    warnings: input.warnings,
+  }).catch((error) => {
+    input.warnings.push(
+      `Failed to enumerate bundle KV keys: ${getErrorMessage(error)}`,
+    );
+    return [] as Array<string>;
+  });
+  const artifactRepos = sourceSnapshots.map((source) => ({
+    sourceId: source.sourceId,
+    entityKind: source.entityKind,
+    entityId: source.entityId,
+    repoId: source.repoId,
+    publishedCommit: source.publishedCommit,
+    manifestPath: source.manifestPath,
+    sourceRoot: source.sourceRoot,
+  }));
+  return {
+    storageIds,
+    sourceSnapshots,
+    savedPackages,
+    remoteConnectors,
+    packageServices,
+    communityListingIds,
+    bundleKvKeys,
+    artifactRepos,
+  };
 }
 
 async function collectD1Tables(input: {
-	env: AccountExportEnv
-	dbUserId: number
-	mcpUserId: string
-	warnings: Array<string>
+  env: AccountExportEnv;
+  dbUserId: number;
+  mcpUserId: string;
+  warnings: Array<string>;
 }) {
-	const conditionsByTable = buildD1TableConditions({
-		mcpUserId: input.mcpUserId,
-		dbUserId: input.dbUserId,
-	})
-	const tables: Array<[string, AccountExportD1Table]> = []
-	for (const [table, conditions] of conditionsByTable) {
-		tables.push([
-			table,
-			await collectD1TableRows({
-				env: input.env,
-				table,
-				conditions,
-				mcpUserId: input.mcpUserId,
-				warnings: input.warnings,
-			}),
-		])
-	}
-	return Object.fromEntries(
-		tables.sort(([left], [right]) => left.localeCompare(right)),
-	)
+  const conditionsByTable = buildD1TableConditions({
+    mcpUserId: input.mcpUserId,
+    dbUserId: input.dbUserId,
+  });
+  const tables: Array<[string, AccountExportD1Table]> = [];
+  for (const [table, conditions] of conditionsByTable) {
+    tables.push([
+      table,
+      await collectD1TableRows({
+        env: input.env,
+        table,
+        conditions,
+        mcpUserId: input.mcpUserId,
+        warnings: input.warnings,
+      }),
+    ]);
+  }
+  return Object.fromEntries(
+    tables.sort(([left], [right]) => left.localeCompare(right)),
+  );
 }
 
 function parseRowidCursor(startAfter: string | undefined) {
-	if (!startAfter) return 0
-	const parsed = Number.parseInt(startAfter, 10)
-	return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+  if (!startAfter) return 0;
+  const parsed = Number.parseInt(startAfter, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 }
 
 async function readD1TableSectionPage(input: {
-	env: AccountExportEnv
-	dbUserId: number
-	mcpUserId: string
-	table: string
-	pageSize: number | undefined
-	startAfter: string | undefined
-	warnings: Array<string>
+  env: AccountExportEnv;
+  dbUserId: number;
+  mcpUserId: string;
+  table: string;
+  pageSize: number | undefined;
+  startAfter: string | undefined;
+  warnings: Array<string>;
 }) {
-	const conditions = buildD1TableConditions({
-		mcpUserId: input.mcpUserId,
-		dbUserId: input.dbUserId,
-	}).get(input.table)
-	if (!conditions) return null
-	const pageSize = normalizePageSize(input.pageSize)
-	try {
-		const page = await selectD1TablePage({
-			env: input.env,
-			table: input.table,
-			conditions,
-			mcpUserId: input.mcpUserId,
-			afterRowid: parseRowidCursor(input.startAfter),
-			limit: pageSize,
-		})
-		return {
-			items: page.rows.map((entry) => entry.row),
-			truncated: page.truncated,
-			nextStartAfter: page.truncated ? String(page.lastRowid) : null,
-			pageSize,
-		}
-	} catch (error) {
-		input.warnings.push(
-			`D1 export failed for ${input.table}: ${getErrorMessage(error)}`,
-		)
-		return {
-			items: [] as Array<Record<string, unknown>>,
-			truncated: false,
-			nextStartAfter: null,
-			pageSize,
-		}
-	}
+  const conditions = buildD1TableConditions({
+    mcpUserId: input.mcpUserId,
+    dbUserId: input.dbUserId,
+  }).get(input.table);
+  if (!conditions) return null;
+  const pageSize = normalizePageSize(input.pageSize);
+  try {
+    const page = await selectD1TablePage({
+      env: input.env,
+      table: input.table,
+      conditions,
+      mcpUserId: input.mcpUserId,
+      afterRowid: parseRowidCursor(input.startAfter),
+      limit: pageSize,
+    });
+    return {
+      items: page.rows.map((entry) => entry.row),
+      truncated: page.truncated,
+      nextStartAfter: page.truncated ? String(page.lastRowid) : null,
+      pageSize,
+    };
+  } catch (error) {
+    input.warnings.push(
+      `D1 export failed for ${input.table}: ${getErrorMessage(error)}`,
+    );
+    return {
+      items: [] as Array<Record<string, unknown>>,
+      truncated: false,
+      nextStartAfter: null,
+      pageSize,
+    };
+  }
 }
 
 async function listOAuthGrants(input: {
-	env: AccountExportEnv
-	userId: string
-	warnings: Array<string>
+  env: AccountExportEnv;
+  userId: string;
+  warnings: Array<string>;
 }) {
-	const helpers = input.env.OAUTH_PROVIDER
-	if (!helpers) {
-		input.warnings.push(
-			'OAuth provider binding was unavailable; OAuth grant metadata was not exported.',
-		)
-		return [] as Array<{ id: string; clientId: string }>
-	}
-	const grants: Array<{ id: string; clientId: string }> = []
-	let cursor: string | undefined
-	while (true) {
-		let page: OAuthGrantPage
-		try {
-			page = await helpers.listUserGrants(input.userId, { cursor })
-		} catch (error) {
-			input.warnings.push(
-				`OAuth grant listing failed after ${grants.length} grant(s): ${getErrorMessage(error)}`,
-			)
-			return grants
-		}
-		grants.push(...page.items.map((grant) => ({ ...grant })))
-		if (!page.cursor) return grants
-		cursor = page.cursor
-	}
+  const helpers = input.env.OAUTH_PROVIDER;
+  if (!helpers) {
+    input.warnings.push(
+      "OAuth provider binding was unavailable; OAuth grant metadata was not exported.",
+    );
+    return [] as Array<{ id: string; clientId: string }>;
+  }
+  const grants: Array<{ id: string; clientId: string }> = [];
+  let cursor: string | undefined;
+  while (true) {
+    let page: OAuthGrantPage;
+    try {
+      page = await helpers.listUserGrants(input.userId, { cursor });
+    } catch (error) {
+      input.warnings.push(
+        `OAuth grant listing failed after ${grants.length} grant(s): ${getErrorMessage(error)}`,
+      );
+      return grants;
+    }
+    grants.push(...page.items.map((grant) => ({ ...grant })));
+    if (!page.cursor) return grants;
+    cursor = page.cursor;
+  }
 }
 
 async function exportStorageRunners(input: {
-	env: AccountExportEnv
-	userId: string
-	storageIds: ReadonlyArray<string>
-	warnings: Array<string>
+  env: AccountExportEnv;
+  userId: string;
+  storageIds: ReadonlyArray<string>;
+  warnings: Array<string>;
 }) {
-	const storageRunners: AccountExportDurableObjects['storageRunners'] = []
-	for (const storageId of input.storageIds) {
-		try {
-			const runnerExport = await storageRunnerRpc({
-				env: input.env,
-				userId: input.userId,
-				storageId,
-			}).exportStorage({ pageSize: maxExportPageSize })
-			storageRunners.push({ storageId, export: runnerExport })
-			if (runnerExport.truncated) {
-				input.warnings.push(
-					`Storage runner ${storageId} was truncated in the full export; use account_export_section with section "storage_runner" and storage_id "${storageId}" to retrieve additional pages.`,
-				)
-			}
-		} catch (error) {
-			input.warnings.push(
-				`Storage runner export failed for ${storageId}: ${getErrorMessage(error)}`,
-			)
-		}
-	}
-	return storageRunners
+  const storageRunners: AccountExportDurableObjects["storageRunners"] = [];
+  for (const storageId of input.storageIds) {
+    try {
+      const runnerExport = await storageRunnerRpc({
+        env: input.env,
+        userId: input.userId,
+        storageId,
+      }).exportStorage({ pageSize: maxExportPageSize });
+      storageRunners.push({ storageId, export: runnerExport });
+      if (runnerExport.truncated) {
+        input.warnings.push(
+          `Storage runner ${storageId} was truncated in the full export; use account_export_section with section "storage_runner" and storage_id "${storageId}" to retrieve additional pages.`,
+        );
+      }
+    } catch (error) {
+      input.warnings.push(
+        `Storage runner export failed for ${storageId}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+  return storageRunners;
 }
 
 async function exportRemoteConnectorSessions(input: {
-	env: AccountExportEnv
-	userId: string
-	connectors: ReadonlyArray<UserRemoteConnectorSnapshot>
-	warnings: Array<string>
+  env: AccountExportEnv;
+  userId: string;
+  connectors: ReadonlyArray<UserRemoteConnectorSnapshot>;
+  warnings: Array<string>;
 }) {
-	const namespace = input.env.REMOTE_CONNECTOR_SESSION
-	if (!namespace) {
-		if (input.connectors.length > 0) {
-			input.warnings.push(
-				`REMOTE_CONNECTOR_SESSION binding was unavailable; ${input.connectors.length} connector session export(s) were skipped.`,
-			)
-		}
-		return [] as AccountExportDurableObjects['remoteConnectorSessions']
-	}
-	const sessions: AccountExportDurableObjects['remoteConnectorSessions'] = []
-	for (const connector of input.connectors) {
-		const sessionKey = userScopedConnectorSessionKey({
-			userId: input.userId,
-			instanceId: connector.instanceId,
-		})
-		try {
-			const stub = namespace.get(
-				namespace.idFromName(sessionKey),
-			) as unknown as {
-				rpcExportUserSession: (payload: {
-					userId: string
-					instanceId: string
-				}) => Promise<RemoteConnectorSessionExport>
-			}
-			sessions.push({
-				instanceId: connector.instanceId,
-				export: await stub.rpcExportUserSession({
-					userId: input.userId,
-					instanceId: connector.instanceId,
-				}),
-			})
-		} catch (error) {
-			input.warnings.push(
-				`Remote connector session export failed for ${connector.instanceId}: ${getErrorMessage(error)}`,
-			)
-			sessions.push({
-				instanceId: connector.instanceId,
-				export: null,
-			})
-		}
-	}
-	return sessions
+  const namespace = input.env.REMOTE_CONNECTOR_SESSION;
+  if (!namespace) {
+    if (input.connectors.length > 0) {
+      input.warnings.push(
+        `REMOTE_CONNECTOR_SESSION binding was unavailable; ${input.connectors.length} connector session export(s) were skipped.`,
+      );
+    }
+    return [] as AccountExportDurableObjects["remoteConnectorSessions"];
+  }
+  const sessions: AccountExportDurableObjects["remoteConnectorSessions"] = [];
+  for (const connector of input.connectors) {
+    const sessionKey = userScopedConnectorSessionKey({
+      userId: input.userId,
+      instanceId: connector.instanceId,
+    });
+    try {
+      const stub = namespace.get(
+        namespace.idFromName(sessionKey),
+      ) as unknown as {
+        rpcExportUserSession: (payload: {
+          userId: string;
+          instanceId: string;
+        }) => Promise<RemoteConnectorSessionExport>;
+      };
+      sessions.push({
+        instanceId: connector.instanceId,
+        export: await stub.rpcExportUserSession({
+          userId: input.userId,
+          instanceId: connector.instanceId,
+        }),
+      });
+    } catch (error) {
+      input.warnings.push(
+        `Remote connector session export failed for ${connector.instanceId}: ${getErrorMessage(error)}`,
+      );
+      sessions.push({
+        instanceId: connector.instanceId,
+        export: null,
+      });
+    }
+  }
+  return sessions;
 }
 
 async function exportPackageServices(input: {
-	env: AccountExportEnv
-	userId: string
-	services: ReadonlyArray<UserPackageServiceSnapshot>
-	warnings: Array<string>
+  env: AccountExportEnv;
+  userId: string;
+  services: ReadonlyArray<UserPackageServiceSnapshot>;
+  warnings: Array<string>;
 }) {
-	const statuses: AccountExportDurableObjects['packageServices'] = []
-	for (const service of input.services) {
-		try {
-			statuses.push({
-				packageId: service.packageId,
-				serviceName: service.serviceName,
-				status: await packageServiceRpc({
-					env: input.env,
-					userId: input.userId,
-					packageId: service.packageId,
-					kodyId: service.kodyId,
-					sourceId: service.sourceId,
-					baseUrl: 'https://account-export.invalid',
-					serviceName: service.serviceName,
-				}).status(),
-			})
-		} catch (error) {
-			input.warnings.push(
-				`Package service status export failed for ${service.packageId}/${service.serviceName}: ${getErrorMessage(error)}`,
-			)
-			statuses.push({
-				packageId: service.packageId,
-				serviceName: service.serviceName,
-				status: null,
-			})
-		}
-	}
-	return statuses
+  const statuses: AccountExportDurableObjects["packageServices"] = [];
+  for (const service of input.services) {
+    try {
+      statuses.push({
+        packageId: service.packageId,
+        serviceName: service.serviceName,
+        status: await packageServiceRpc({
+          env: input.env,
+          userId: input.userId,
+          packageId: service.packageId,
+          kodyId: service.kodyId,
+          sourceId: service.sourceId,
+          baseUrl: "https://account-export.invalid",
+          serviceName: service.serviceName,
+        }).status(),
+      });
+    } catch (error) {
+      input.warnings.push(
+        `Package service status export failed for ${service.packageId}/${service.serviceName}: ${getErrorMessage(error)}`,
+      );
+      statuses.push({
+        packageId: service.packageId,
+        serviceName: service.serviceName,
+        status: null,
+      });
+    }
+  }
+  return statuses;
 }
 
 async function exportDurableObjects(input: {
-	env: AccountExportEnv
-	userId: string
-	inventory: UserExportInventory
-	warnings: Array<string>
+  env: AccountExportEnv;
+  userId: string;
+  inventory: UserExportInventory;
+  warnings: Array<string>;
 }): Promise<AccountExportDurableObjects> {
-	const [storageRunners, remoteConnectorSessions, packageServices] =
-		await Promise.all([
-			exportStorageRunners({
-				env: input.env,
-				userId: input.userId,
-				storageIds: input.inventory.storageIds,
-				warnings: input.warnings,
-			}),
-			exportRemoteConnectorSessions({
-				env: input.env,
-				userId: input.userId,
-				connectors: input.inventory.remoteConnectors,
-				warnings: input.warnings,
-			}),
-			exportPackageServices({
-				env: input.env,
-				userId: input.userId,
-				services: input.inventory.packageServices,
-				warnings: input.warnings,
-			}),
-		])
-	let jobManager: unknown | null = null
-	try {
-		jobManager = await exportJobManagerForUser({
-			env: input.env,
-			userId: input.userId,
-		})
-	} catch (error) {
-		input.warnings.push(`Job manager export failed: ${getErrorMessage(error)}`)
-	}
-	return {
-		jobManager,
-		remoteConnectorSessions,
-		packageServices,
-		storageRunners,
-	}
+  const [storageRunners, remoteConnectorSessions, packageServices] =
+    await Promise.all([
+      exportStorageRunners({
+        env: input.env,
+        userId: input.userId,
+        storageIds: input.inventory.storageIds,
+        warnings: input.warnings,
+      }),
+      exportRemoteConnectorSessions({
+        env: input.env,
+        userId: input.userId,
+        connectors: input.inventory.remoteConnectors,
+        warnings: input.warnings,
+      }),
+      exportPackageServices({
+        env: input.env,
+        userId: input.userId,
+        services: input.inventory.packageServices,
+        warnings: input.warnings,
+      }),
+    ]);
+  let jobManager: unknown | null = null;
+  try {
+    jobManager = await exportJobManagerForUser({
+      env: input.env,
+      userId: input.userId,
+    });
+  } catch (error) {
+    input.warnings.push(`Job manager export failed: ${getErrorMessage(error)}`);
+  }
+  return {
+    jobManager,
+    remoteConnectorSessions,
+    packageServices,
+    storageRunners,
+  };
 }
 
 function buildManifest(input: {
-	generatedAt: string
-	dbUserId: number
-	mcpUserId: string
-	d1: Record<string, AccountExportD1Table>
-	durableObjects?: AccountExportDurableObjects | null
-	oauthGrants?: ReadonlyArray<{ id: string; clientId: string }>
-	inventory: UserExportInventory
-	warnings: Array<string>
+  generatedAt: string;
+  dbUserId: number;
+  mcpUserId: string;
+  d1: Record<string, AccountExportD1Table>;
+  durableObjects?: AccountExportDurableObjects | null;
+  oauthGrants?: ReadonlyArray<{ id: string; clientId: string }>;
+  inventory: UserExportInventory;
+  warnings: Array<string>;
 }) {
-	const sections: Record<string, AccountExportManifestSection> = {}
-	for (const [table, exportTable] of Object.entries(input.d1)) {
-		sections[`d1.${table}`] = {
-			count: exportTable.rows.length,
-			warnings: exportTable.warnings,
-			...(exportTable.redactedColumns.length > 0
-				? { redactedColumns: exportTable.redactedColumns }
-				: {}),
-		}
-	}
-	sections.storage_runners = {
-		count: input.inventory.storageIds.length,
-		warnings: input.warnings.filter((warning) =>
-			warning.startsWith('Storage runner '),
-		),
-	}
-	sections.remote_connector_sessions = {
-		count: input.inventory.remoteConnectors.length,
-		warnings: input.warnings.filter((warning) =>
-			warning.startsWith('Remote connector session '),
-		),
-	}
-	sections.package_services = {
-		count: input.inventory.packageServices.length,
-		warnings: input.warnings.filter((warning) =>
-			warning.startsWith('Package service '),
-		),
-	}
-	sections.oauth_grants = {
-		count: input.oauthGrants?.length ?? 0,
-		warnings: input.warnings.filter((warning) =>
-			warning.startsWith('OAuth grant '),
-		),
-	}
-	sections.artifact_repos = {
-		count: input.inventory.artifactRepos.length,
-		warnings: [],
-	}
-	sections.kv_keys = {
-		count: input.inventory.bundleKvKeys.length,
-		warnings: input.warnings.filter((warning) => warning.startsWith('KV ')),
-	}
-	return {
-		schemaVersion: accountExportSchemaVersion,
-		generatedAt: input.generatedAt,
-		user: {
-			dbUserId: input.dbUserId,
-			userId: input.mcpUserId,
-		},
-		security: {
-			secretValuesExported: false as const,
-			note: 'Secret values, encrypted secret payloads, password hashes, token hashes, and credential-equivalent hashes are never exported. Secret entries contain metadata only.',
-		},
-		sections,
-		warnings: input.warnings,
-		chunking: {
-			sections: [...accountExportSectionNames],
-			defaultPageSize: defaultExportPageSize,
-			maxPageSize: maxExportPageSize,
-		},
-		artifacts: {
-			canonicalPackageSource:
-				'Package/job source code is stored in Cloudflare Artifacts repos referenced by entity_sources.repo_id. This export lists repo pointers and published commits; fetch or clone those repos separately with Artifacts access rather than relying on D1 projections.',
-		},
-		derivedData: {
-			vectorize:
-				'Vectorize entries for memories, jobs, and packages are derived from exported D1 rows and are intentionally excluded; rebuild them by reindexing after import.',
-		},
-		excludedDurableObjects: [
-			{
-				name: 'MCP',
-				reason:
-					'Session-keyed by the MCP SDK and not globally enumerable; durable user data is carried by D1 and user-scoped stores instead.',
-			},
-			{
-				name: 'RepoSession',
-				reason:
-					'Ephemeral editing workspace. Canonical repo-backed source is exported as Artifacts repo pointers via entity_sources and repo_sessions metadata.',
-			},
-			{
-				name: 'PackageRealtimeSession',
-				reason:
-					'Ephemeral live websocket/session state. Durable app storage is exported through StorageRunner buckets.',
-			},
-		],
-		excludedD1Surfaces: accountUserDataExcludedOwnerIds.map((exclusion) => ({
-			name: exclusion.surface,
-			reason: exclusion.reason,
-		})),
-	} satisfies AccountExportManifest
+  const sections: Record<string, AccountExportManifestSection> = {};
+  for (const [table, exportTable] of Object.entries(input.d1)) {
+    sections[`d1.${table}`] = {
+      count: exportTable.rows.length,
+      warnings: exportTable.warnings,
+      ...(exportTable.redactedColumns.length > 0
+        ? { redactedColumns: exportTable.redactedColumns }
+        : {}),
+    };
+  }
+  sections.storage_runners = {
+    count: input.inventory.storageIds.length,
+    warnings: input.warnings.filter((warning) =>
+      warning.startsWith("Storage runner "),
+    ),
+  };
+  sections.remote_connector_sessions = {
+    count: input.inventory.remoteConnectors.length,
+    warnings: input.warnings.filter((warning) =>
+      warning.startsWith("Remote connector session "),
+    ),
+  };
+  sections.package_services = {
+    count: input.inventory.packageServices.length,
+    warnings: input.warnings.filter((warning) =>
+      warning.startsWith("Package service "),
+    ),
+  };
+  sections.oauth_grants = {
+    count: input.oauthGrants?.length ?? 0,
+    warnings: input.warnings.filter((warning) =>
+      warning.startsWith("OAuth grant "),
+    ),
+  };
+  sections.artifact_repos = {
+    count: input.inventory.artifactRepos.length,
+    warnings: [],
+  };
+  sections.kv_keys = {
+    count: input.inventory.bundleKvKeys.length,
+    warnings: input.warnings.filter((warning) => warning.startsWith("KV ")),
+  };
+  return {
+    schemaVersion: accountExportSchemaVersion,
+    generatedAt: input.generatedAt,
+    user: {
+      dbUserId: input.dbUserId,
+      userId: input.mcpUserId,
+    },
+    security: {
+      secretValuesExported: false as const,
+      note: "Secret values, encrypted secret payloads, password hashes, token hashes, and credential-equivalent hashes are never exported. Secret entries contain metadata only.",
+    },
+    sections,
+    warnings: input.warnings,
+    chunking: {
+      sections: [...accountExportSectionNames],
+      defaultPageSize: defaultExportPageSize,
+      maxPageSize: maxExportPageSize,
+    },
+    artifacts: {
+      canonicalPackageSource:
+        "Package/job source code is stored in Cloudflare Artifacts repos referenced by entity_sources.repo_id. This export lists repo pointers and published commits; fetch or clone those repos separately with Artifacts access rather than relying on D1 projections.",
+    },
+    derivedData: {
+      vectorize:
+        "Vectorize entries for memories, jobs, and packages are derived from exported D1 rows and are intentionally excluded; rebuild them by reindexing after import.",
+    },
+    excludedDurableObjects: [
+      {
+        name: "MCP",
+        reason:
+          "Session-keyed by the MCP SDK and not globally enumerable; durable user data is carried by D1 and user-scoped stores instead.",
+      },
+      {
+        name: "RepoSession",
+        reason:
+          "Ephemeral editing workspace. Canonical repo-backed source is exported as Artifacts repo pointers via entity_sources and repo_sessions metadata.",
+      },
+      {
+        name: "PackageRealtimeSession",
+        reason:
+          "Ephemeral live websocket/session state. Durable app storage is exported through StorageRunner buckets.",
+      },
+    ],
+    excludedD1Surfaces: accountUserDataExcludedOwnerIds.map((exclusion) => ({
+      name: exclusion.surface,
+      reason: exclusion.reason,
+    })),
+  } satisfies AccountExportManifest;
 }
 
 export function getAccountExportD1UserColumnCoverage() {
-	return getAccountD1UserColumnCoverage()
+  return getAccountD1UserColumnCoverage();
 }
 
 export async function resolveAccountExportDbUserId(input: {
-	env: AccountExportEnv
-	mcpUserId: string
-	email?: string | null
+  env: AccountExportEnv;
+  mcpUserId: string;
+  email?: string | null;
 }) {
-	const email = input.email?.trim().toLowerCase()
-	if (!email) {
-		throw new Error('Account export requires an authenticated user email.')
-	}
-	const row = await input.env.APP_DB.prepare(
-		`SELECT id, email, stable_user_id FROM users WHERE email = ?`,
-	)
-		.bind(email)
-		.first<{ id: number; email: string; stable_user_id: string | null }>()
-	if (!row) {
-		throw new Error('Authenticated account was not found.')
-	}
-	if ((await resolveUserStableId(row)) !== input.mcpUserId) {
-		throw new Error(
-			'Authenticated user identity did not match the account email.',
-		)
-	}
-	return row.id
+  const email = input.email?.trim().toLowerCase();
+  if (!email) {
+    throw new Error("Account export requires an authenticated user email.");
+  }
+  const row = await input.env.APP_DB.prepare(
+    `SELECT id, email, stable_user_id FROM users WHERE email = ?`,
+  )
+    .bind(email)
+    .first<{ id: number; email: string; stable_user_id: string | null }>();
+  if (!row) {
+    throw new Error("Authenticated account was not found.");
+  }
+  if ((await resolveUserStableId(row)) !== input.mcpUserId) {
+    throw new Error(
+      "Authenticated user identity did not match the account email.",
+    );
+  }
+  return row.id;
 }
 
 export async function createAccountExportManifest(input: {
-	env: AccountExportEnv
-	dbUserId: number
-	mcpUserId: string
-	generatedAt?: string
+  env: AccountExportEnv;
+  dbUserId: number;
+  mcpUserId: string;
+  generatedAt?: string;
 }): Promise<AccountExportManifest> {
-	const warnings: Array<string> = []
-	const generatedAt = input.generatedAt ?? new Date().toISOString()
-	const [d1, inventory, oauthGrants] = await Promise.all([
-		collectD1Tables({
-			env: input.env,
-			dbUserId: input.dbUserId,
-			mcpUserId: input.mcpUserId,
-			warnings,
-		}),
-		collectInventory({
-			env: input.env,
-			userId: input.mcpUserId,
-			warnings,
-		}),
-		listOAuthGrants({
-			env: input.env,
-			userId: input.mcpUserId,
-			warnings,
-		}),
-	])
-	return buildManifest({
-		generatedAt,
-		dbUserId: input.dbUserId,
-		mcpUserId: input.mcpUserId,
-		d1,
-		inventory,
-		oauthGrants,
-		warnings,
-	})
+  const warnings: Array<string> = [];
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+  const [d1, inventory, oauthGrants] = await Promise.all([
+    collectD1Tables({
+      env: input.env,
+      dbUserId: input.dbUserId,
+      mcpUserId: input.mcpUserId,
+      warnings,
+    }),
+    collectInventory({
+      env: input.env,
+      userId: input.mcpUserId,
+      warnings,
+    }),
+    listOAuthGrants({
+      env: input.env,
+      userId: input.mcpUserId,
+      warnings,
+    }),
+  ]);
+  return buildManifest({
+    generatedAt,
+    dbUserId: input.dbUserId,
+    mcpUserId: input.mcpUserId,
+    d1,
+    inventory,
+    oauthGrants,
+    warnings,
+  });
 }
 
 export async function createAccountExport(input: {
-	env: AccountExportEnv
-	dbUserId: number
-	mcpUserId: string
-	generatedAt?: string
+  env: AccountExportEnv;
+  dbUserId: number;
+  mcpUserId: string;
+  generatedAt?: string;
 }): Promise<AccountExportFile> {
-	const warnings: Array<string> = []
-	const generatedAt = input.generatedAt ?? new Date().toISOString()
-	const [d1, inventory, oauthGrants] = await Promise.all([
-		collectD1Tables({
-			env: input.env,
-			dbUserId: input.dbUserId,
-			mcpUserId: input.mcpUserId,
-			warnings,
-		}),
-		collectInventory({
-			env: input.env,
-			userId: input.mcpUserId,
-			warnings,
-		}),
-		listOAuthGrants({
-			env: input.env,
-			userId: input.mcpUserId,
-			warnings,
-		}),
-	])
-	const durableObjects = await exportDurableObjects({
-		env: input.env,
-		userId: input.mcpUserId,
-		inventory,
-		warnings,
-	})
-	return {
-		manifest: buildManifest({
-			generatedAt,
-			dbUserId: input.dbUserId,
-			mcpUserId: input.mcpUserId,
-			d1,
-			durableObjects,
-			oauthGrants,
-			inventory,
-			warnings,
-		}),
-		d1,
-		durableObjects,
-		oauthGrants,
-		artifactRepos: inventory.artifactRepos,
-		kvKeys: inventory.bundleKvKeys,
-	}
+  const warnings: Array<string> = [];
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+  const [d1, inventory, oauthGrants] = await Promise.all([
+    collectD1Tables({
+      env: input.env,
+      dbUserId: input.dbUserId,
+      mcpUserId: input.mcpUserId,
+      warnings,
+    }),
+    collectInventory({
+      env: input.env,
+      userId: input.mcpUserId,
+      warnings,
+    }),
+    listOAuthGrants({
+      env: input.env,
+      userId: input.mcpUserId,
+      warnings,
+    }),
+  ]);
+  const durableObjects = await exportDurableObjects({
+    env: input.env,
+    userId: input.mcpUserId,
+    inventory,
+    warnings,
+  });
+  return {
+    manifest: buildManifest({
+      generatedAt,
+      dbUserId: input.dbUserId,
+      mcpUserId: input.mcpUserId,
+      d1,
+      durableObjects,
+      oauthGrants,
+      inventory,
+      warnings,
+    }),
+    d1,
+    durableObjects,
+    oauthGrants,
+    artifactRepos: inventory.artifactRepos,
+    kvKeys: inventory.bundleKvKeys,
+  };
 }
 
 export async function readAccountExportSection(input: {
-	env: AccountExportEnv
-	dbUserId: number
-	mcpUserId: string
-	section: AccountExportSectionName
-	table?: string
-	storageId?: string
-	pageSize?: number
-	startAfter?: string
+  env: AccountExportEnv;
+  dbUserId: number;
+  mcpUserId: string;
+  section: AccountExportSectionName;
+  table?: string;
+  storageId?: string;
+  pageSize?: number;
+  startAfter?: string;
 }): Promise<AccountExportSectionResult> {
-	const warnings: Array<string> = []
-	if (input.section === 'storage_runner') {
-		if (!input.storageId) {
-			throw new Error('storage_id is required when section is storage_runner.')
-		}
-		const pageSize = normalizePageSize(input.pageSize)
-		const runnerExport = await storageRunnerRpc({
-			env: input.env,
-			userId: input.mcpUserId,
-			storageId: input.storageId,
-		}).exportStorage({
-			pageSize,
-			startAfter: input.startAfter,
-		})
-		return {
-			section: input.section,
-			items: runnerExport.entries,
-			truncated: runnerExport.truncated,
-			nextStartAfter: runnerExport.nextStartAfter,
-			pageSize: runnerExport.pageSize,
-			warnings,
-		}
-	}
-	let items: Array<unknown>
-	switch (input.section) {
-		case 'd1_table': {
-			if (!input.table) {
-				throw new Error('table is required when section is d1_table.')
-			}
-			const page = await readD1TableSectionPage({
-				env: input.env,
-				dbUserId: input.dbUserId,
-				mcpUserId: input.mcpUserId,
-				table: input.table,
-				pageSize: input.pageSize,
-				startAfter: input.startAfter,
-				warnings,
-			})
-			if (!page) {
-				throw new Error(`Table "${input.table}" is not part of account export.`)
-			}
-			return {
-				section: input.section,
-				...page,
-				warnings,
-			}
-		}
-		case 'oauth_grants': {
-			const oauthGrants = await listOAuthGrants({
-				env: input.env,
-				userId: input.mcpUserId,
-				warnings,
-			})
-			items = [...oauthGrants]
-			break
-		}
-		case 'artifact_repos': {
-			const inventory = await collectInventory({
-				env: input.env,
-				userId: input.mcpUserId,
-				warnings,
-			})
-			items = inventory.artifactRepos
-			break
-		}
-		case 'kv_keys': {
-			const inventory = await collectInventory({
-				env: input.env,
-				userId: input.mcpUserId,
-				warnings,
-			})
-			items = inventory.bundleKvKeys
-			break
-		}
-		case 'durable_object_summaries': {
-			const inventory = await collectInventory({
-				env: input.env,
-				userId: input.mcpUserId,
-				warnings,
-			})
-			items = [
-				{ kind: 'storage_runner', ids: inventory.storageIds },
-				{ kind: 'remote_connector_session', refs: inventory.remoteConnectors },
-				{ kind: 'package_service', refs: inventory.packageServices },
-				{ kind: 'job_manager', userId: input.mcpUserId },
-			]
-			break
-		}
-		default: {
-			const exhaustive: never = input.section
-			throw new Error(`Unhandled account export section: ${exhaustive}`)
-		}
-	}
-	const page = paginateItems({
-		items,
-		pageSize: input.pageSize,
-		startAfter: input.startAfter,
-	})
-	return {
-		section: input.section,
-		...page,
-		warnings,
-	}
+  const warnings: Array<string> = [];
+  if (input.section === "storage_runner") {
+    if (!input.storageId) {
+      throw new Error("storage_id is required when section is storage_runner.");
+    }
+    const pageSize = normalizePageSize(input.pageSize);
+    const runnerExport = await storageRunnerRpc({
+      env: input.env,
+      userId: input.mcpUserId,
+      storageId: input.storageId,
+    }).exportStorage({
+      pageSize,
+      startAfter: input.startAfter,
+    });
+    return {
+      section: input.section,
+      items: runnerExport.entries,
+      truncated: runnerExport.truncated,
+      nextStartAfter: runnerExport.nextStartAfter,
+      pageSize: runnerExport.pageSize,
+      warnings,
+    };
+  }
+  let items: Array<unknown>;
+  switch (input.section) {
+    case "d1_table": {
+      if (!input.table) {
+        throw new Error("table is required when section is d1_table.");
+      }
+      const page = await readD1TableSectionPage({
+        env: input.env,
+        dbUserId: input.dbUserId,
+        mcpUserId: input.mcpUserId,
+        table: input.table,
+        pageSize: input.pageSize,
+        startAfter: input.startAfter,
+        warnings,
+      });
+      if (!page) {
+        throw new Error(
+          `Table "${input.table}" is not part of account export.`,
+        );
+      }
+      return {
+        section: input.section,
+        ...page,
+        warnings,
+      };
+    }
+    case "oauth_grants": {
+      const oauthGrants = await listOAuthGrants({
+        env: input.env,
+        userId: input.mcpUserId,
+        warnings,
+      });
+      items = [...oauthGrants];
+      break;
+    }
+    case "artifact_repos": {
+      const inventory = await collectInventory({
+        env: input.env,
+        userId: input.mcpUserId,
+        warnings,
+      });
+      items = inventory.artifactRepos;
+      break;
+    }
+    case "kv_keys": {
+      const inventory = await collectInventory({
+        env: input.env,
+        userId: input.mcpUserId,
+        warnings,
+      });
+      items = inventory.bundleKvKeys;
+      break;
+    }
+    case "durable_object_summaries": {
+      const inventory = await collectInventory({
+        env: input.env,
+        userId: input.mcpUserId,
+        warnings,
+      });
+      items = [
+        { kind: "storage_runner", ids: inventory.storageIds },
+        { kind: "remote_connector_session", refs: inventory.remoteConnectors },
+        { kind: "package_service", refs: inventory.packageServices },
+        { kind: "job_manager", userId: input.mcpUserId },
+      ];
+      break;
+    }
+    default: {
+      const exhaustive: never = input.section;
+      throw new Error(`Unhandled account export section: ${exhaustive}`);
+    }
+  }
+  const page = paginateItems({
+    items,
+    pageSize: input.pageSize,
+    startAfter: input.startAfter,
+  });
+  return {
+    section: input.section,
+    ...page,
+    warnings,
+  };
 }

--- a/packages/worker/src/app/platform-account-creation.ts
+++ b/packages/worker/src/app/platform-account-creation.ts
@@ -1,0 +1,133 @@
+import { getUniqueConstraintField } from '#app/database-errors.ts'
+import { userExistsByUsername } from '#app/generated-username.ts'
+import { normalizeEmail } from '#app/normalize-email.ts'
+import { isReservedUsername } from '#app/reserved-usernames.ts'
+import {
+	getUsernameFormatValidationError,
+	normalizeUsername,
+} from '#app/username.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+
+const platformAccountNoUsablePasswordHash =
+	'platform_account_no_usable_password'
+
+export type PlatformAccountCreateErrorCode =
+	| 'invalid_email'
+	| 'invalid_username'
+	| 'email_exists'
+	| 'username_exists'
+	| 'create_failed'
+
+export class PlatformAccountCreateError extends Error {
+	readonly code: PlatformAccountCreateErrorCode
+
+	constructor(code: PlatformAccountCreateErrorCode, message: string) {
+		super(message)
+		this.name = 'PlatformAccountCreateError'
+		this.code = code
+	}
+}
+
+export type CreatedPlatformAccount = {
+	userId: number
+	email: string
+	username: string
+	stableUserId: string
+}
+
+/**
+ * Create a platform account that owns official packages.
+ *
+ * Platform accounts may only claim usernames from the reserved denylist, so
+ * they never collide with a signable-up username and person users can never
+ * squat a platform scope.
+ */
+export async function createPlatformAccount(input: {
+	db: D1Database
+	email: string
+	username: string
+	now?: Date
+}) {
+	const email = normalizeEmail(input.email)
+	if (!email) {
+		throw new PlatformAccountCreateError('invalid_email', 'Email is required.')
+	}
+
+	const username = normalizeUsername(input.username)
+	const formatError = getUsernameFormatValidationError(username)
+	if (formatError) {
+		throw new PlatformAccountCreateError('invalid_username', formatError)
+	}
+	if (!isReservedUsername(username)) {
+		throw new PlatformAccountCreateError(
+			'invalid_username',
+			'Platform accounts may only claim reserved usernames.',
+		)
+	}
+
+	const existingUser = await input.db
+		.prepare(`SELECT id FROM users WHERE email = ?`)
+		.bind(email)
+		.first<{ id: number }>()
+	if (existingUser) {
+		throw new PlatformAccountCreateError(
+			'email_exists',
+			'Email already registered.',
+		)
+	}
+	if (await userExistsByUsername(input.db, username)) {
+		throw new PlatformAccountCreateError(
+			'username_exists',
+			'Username already registered.',
+		)
+	}
+
+	const now = input.now ?? new Date()
+	const nowIso = now.toISOString()
+	const stableUserId = await createStableUserIdFromEmail(email)
+
+	try {
+		const result = await input.db
+			.prepare(
+				`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id, account_type)
+				 VALUES (?, ?, ?, ?, ?, 'platform')`,
+			)
+			.bind(
+				username,
+				email,
+				platformAccountNoUsablePasswordHash,
+				nowIso,
+				stableUserId,
+			)
+			.run()
+		const lastRowId = result.meta.last_row_id
+		if (!Number.isSafeInteger(lastRowId) || lastRowId < 1) {
+			throw new PlatformAccountCreateError(
+				'create_failed',
+				'Unable to create platform account.',
+			)
+		}
+		return {
+			userId: lastRowId,
+			email,
+			username,
+			stableUserId,
+		} satisfies CreatedPlatformAccount
+	} catch (error) {
+		if (error instanceof PlatformAccountCreateError) throw error
+		const uniqueField = getUniqueConstraintField(error)
+		if (uniqueField === 'email') {
+			throw new PlatformAccountCreateError(
+				'email_exists',
+				'Email already registered.',
+			)
+		}
+		if (uniqueField === 'username') {
+			throw new PlatformAccountCreateError(
+				'username_exists',
+				'Username already registered.',
+			)
+		}
+		throw error
+	}
+}

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -236,6 +236,29 @@ test('community operations reject banned users', async () => {
 			listingId: 'listing-1',
 		}),
 	).rejects.toThrow(/banned from community participation/)
+
+	// Delegated publishes bind bans to the acting person too: the platform
+	// owner is not banned, but the banned actor must still be rejected.
+	mockModule.getCommunityBan.mockImplementation(
+		async (_db: unknown, userId: unknown) =>
+			userId === 'user-1'
+				? {
+						userId: 'user-1',
+						bannedByUserId: 'admin-1',
+						reason: 'spam',
+						createdAt: '2026-07-01T00:00:00.000Z',
+					}
+				: null,
+	)
+	await expect(
+		publishCommunityListing({
+			env: createEnv(),
+			baseUrl: 'https://heykody.dev',
+			userId: 'platform-owner-1',
+			actorUserId: 'user-1',
+			packageId: 'package-1',
+		}),
+	).rejects.toThrow(/banned from community participation/)
 })
 
 function validPublishSource() {

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -259,6 +259,15 @@ test('community operations reject banned users', async () => {
 			packageId: 'package-1',
 		}),
 	).rejects.toThrow(/banned from community participation/)
+
+	await expect(
+		unpublishCommunityListing({
+			env: createEnv(),
+			userId: 'platform-owner-1',
+			actorUserId: 'user-1',
+			listingId: 'listing-1',
+		}),
+	).rejects.toThrow(/banned from community participation/)
 })
 
 function validPublishSource() {

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -531,7 +531,7 @@ export async function publishCommunityListing(input: {
 	try {
 		await insertCommunityActivityEvent(input.env.APP_DB, {
 			id: crypto.randomUUID(),
-			actorUserId: input.userId,
+			actorUserId: input.actorUserId ?? input.userId,
 			eventType: existingListing ? 'listing_updated' : 'listing_published',
 			listingId,
 		})
@@ -548,8 +548,17 @@ export async function publishCommunityListing(input: {
 export async function unpublishCommunityListing(input: {
 	env: Env
 	userId: string
+	/**
+	 * Acting user on delegated (package scope grant) unpublishes. Community
+	 * bans must bind to the person acting, not just the owning platform
+	 * account.
+	 */
+	actorUserId?: string
 	listingId: string
 }): Promise<void> {
+	if (input.actorUserId && input.actorUserId !== input.userId) {
+		await assertNotCommunityBanned(input.env.APP_DB, input.actorUserId)
+	}
 	const listing = await getCommunityListingById(input.env.APP_DB, {
 		listingId: input.listingId,
 		includeDelisted: true,

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -346,9 +346,17 @@ export async function publishCommunityListing(input: {
 	env: Env
 	baseUrl: string
 	userId: string
+	/**
+	 * Acting user on delegated (package scope grant) publishes. Community bans
+	 * must bind to the person acting, not just the owning platform account.
+	 */
+	actorUserId?: string
 	packageId: string
 }): Promise<CommunityListingRecord> {
 	await assertNotCommunityBanned(input.env.APP_DB, input.userId)
+	if (input.actorUserId && input.actorUserId !== input.userId) {
+		await assertNotCommunityBanned(input.env.APP_DB, input.actorUserId)
+	}
 
 	const savedPackage = await getSavedPackageById(input.env.APP_DB, {
 		userId: input.userId,

--- a/packages/worker/src/db.ts
+++ b/packages/worker/src/db.ts
@@ -8,6 +8,7 @@ export const usersTable = table({
 		username: c.text(),
 		email: c.text(),
 		stable_user_id: c.text(),
+		account_type: c.text(),
 		display_name: c.text(),
 		bio: c.text(),
 		profile_visibility: c.text(),

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-create.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-create.ts
@@ -1,106 +1,106 @@
-import { z } from "zod";
-import { normalizeUsername } from "#app/username.ts";
-import { defineDomainCapability } from "#mcp/capabilities/define-domain-capability.ts";
-import { capabilityDomainNames } from "#mcp/capabilities/domain-metadata.ts";
-import { requireMcpUser } from "#mcp/capabilities/meta/require-user.ts";
+import { z } from 'zod'
+import { normalizeUsername } from '#app/username.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import {
-  getPlatformAccountByUsername,
-  insertPackageScopeGrant,
-} from "#worker/package-registry/scope-grants.ts";
-import { resolveUserStableId } from "#worker/user-id.ts";
+	getPlatformAccountByUsername,
+	insertPackageScopeGrant,
+} from '#worker/package-registry/scope-grants.ts'
+import { resolveUserStableId } from '#worker/user-id.ts'
 import {
-  adminMutationCapabilityAccess,
-  auditAdminCapabilityInvocation,
-} from "./admin-shared.ts";
+	adminMutationCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
 
 const inputSchema = z.object({
-  scope: z
-    .string()
-    .min(1)
-    .describe(
-      'Platform account username that owns the package scope (without "@"), for example "kody".',
-    ),
-  username: z
-    .string()
-    .min(1)
-    .describe("Person account username to grant access to the package scope."),
-});
+	scope: z
+		.string()
+		.min(1)
+		.describe(
+			'Platform account username that owns the package scope (without "@"), for example "kody".',
+		),
+	username: z
+		.string()
+		.min(1)
+		.describe('Person account username to grant access to the package scope.'),
+})
 
 const outputSchema = z.object({
-  created: z.boolean(),
-  scope: z.string(),
-  username: z.string(),
-});
+	created: z.boolean(),
+	scope: z.string(),
+	username: z.string(),
+})
 
 export const adminPackageScopeGrantCreateCapability = defineDomainCapability(
-  capabilityDomainNames.admin,
-  {
-    ...adminMutationCapabilityAccess,
-    name: "admin_package_scope_grant_create",
-    description:
-      "Grant a person account permission to act inside a platform account package scope. Grants are only possible on platform accounts. Admin-only; does not expose package contents.",
-    keywords: [
-      "admin",
-      "package scope",
-      "grant",
-      "platform account",
-      "delegate",
-      "packages",
-    ],
-    inputSchema,
-    outputSchema,
-    async handler(args, ctx) {
-      const scope = normalizeUsername(args.scope).replace(/^@/, "");
-      const username = normalizeUsername(args.username);
-      return auditAdminCapabilityInvocation(
-        ctx,
-        "admin_package_scope_grant_create",
-        async () => {
-          const platformAccount = await getPlatformAccountByUsername(
-            ctx.env.APP_DB,
-            scope,
-          );
-          if (!platformAccount) {
-            throw new Error(
-              `Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
-            );
-          }
-          const grantee = await ctx.env.APP_DB.prepare(
-            `SELECT username, email, account_type, stable_user_id
+	capabilityDomainNames.admin,
+	{
+		...adminMutationCapabilityAccess,
+		name: 'admin_package_scope_grant_create',
+		description:
+			'Grant a person account permission to act inside a platform account package scope. Grants are only possible on platform accounts. Admin-only; does not expose package contents.',
+		keywords: [
+			'admin',
+			'package scope',
+			'grant',
+			'platform account',
+			'delegate',
+			'packages',
+		],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			const scope = normalizeUsername(args.scope).replace(/^@/, '')
+			const username = normalizeUsername(args.username)
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_package_scope_grant_create',
+				async () => {
+					const platformAccount = await getPlatformAccountByUsername(
+						ctx.env.APP_DB,
+						scope,
+					)
+					if (!platformAccount) {
+						throw new Error(
+							`Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
+						)
+					}
+					const grantee = await ctx.env.APP_DB.prepare(
+						`SELECT username, email, account_type, stable_user_id
 						FROM users
 						WHERE username = ?`,
-          )
-            .bind(username)
-            .first<{
-              username: string;
-              email: string;
-              account_type: string;
-              stable_user_id: string | null;
-            }>();
-          if (!grantee) {
-            throw new Error(`User "${username}" was not found.`);
-          }
-          if (grantee.account_type !== "person") {
-            throw new Error(
-              `User "${username}" is not a person account and cannot receive a package scope grant.`,
-            );
-          }
-          const admin = requireMcpUser(ctx.callerContext);
-          const { created } = await insertPackageScopeGrant(ctx.env.APP_DB, {
-            scopeOwnerUserId: platformAccount.stableUserId,
-            granteeUserId: await resolveUserStableId(grantee),
-            createdByUserId: admin.userId,
-          });
-          return {
-            created,
-            scope: platformAccount.username,
-            username: grantee.username,
-          };
-        },
-        {
-          successReason: () => `scope=@${scope};grantee=${username}`,
-        },
-      );
-    },
-  },
-);
+					)
+						.bind(username)
+						.first<{
+							username: string
+							email: string
+							account_type: string
+							stable_user_id: string | null
+						}>()
+					if (!grantee) {
+						throw new Error(`User "${username}" was not found.`)
+					}
+					if (grantee.account_type !== 'person') {
+						throw new Error(
+							`User "${username}" is not a person account and cannot receive a package scope grant.`,
+						)
+					}
+					const admin = requireMcpUser(ctx.callerContext)
+					const { created } = await insertPackageScopeGrant(ctx.env.APP_DB, {
+						scopeOwnerUserId: platformAccount.stableUserId,
+						granteeUserId: await resolveUserStableId(grantee),
+						createdByUserId: admin.userId,
+					})
+					return {
+						created,
+						scope: platformAccount.username,
+						username: grantee.username,
+					}
+				},
+				{
+					successReason: () => `scope=@${scope};grantee=${username}`,
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-create.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-create.ts
@@ -1,117 +1,106 @@
-import { z } from 'zod'
-import { normalizeUsername } from '#app/username.ts'
-import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
-import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { z } from "zod";
+import { normalizeUsername } from "#app/username.ts";
+import { defineDomainCapability } from "#mcp/capabilities/define-domain-capability.ts";
+import { capabilityDomainNames } from "#mcp/capabilities/domain-metadata.ts";
+import { requireMcpUser } from "#mcp/capabilities/meta/require-user.ts";
 import {
-	getPlatformAccountByUsername,
-	insertPackageScopeGrant,
-} from '#worker/package-registry/scope-grants.ts'
-import { findUserRowByStableUserId } from '#worker/user-id.ts'
+  getPlatformAccountByUsername,
+  insertPackageScopeGrant,
+} from "#worker/package-registry/scope-grants.ts";
+import { resolveUserStableId } from "#worker/user-id.ts";
 import {
-	adminMutationCapabilityAccess,
-	auditAdminCapabilityInvocation,
-} from './admin-shared.ts'
+  adminMutationCapabilityAccess,
+  auditAdminCapabilityInvocation,
+} from "./admin-shared.ts";
 
 const inputSchema = z.object({
-	scope: z
-		.string()
-		.min(1)
-		.describe(
-			'Platform account username that owns the package scope (without "@"), for example "kody".',
-		),
-	username: z
-		.string()
-		.min(1)
-		.describe('Person account username to grant access to the package scope.'),
-})
+  scope: z
+    .string()
+    .min(1)
+    .describe(
+      'Platform account username that owns the package scope (without "@"), for example "kody".',
+    ),
+  username: z
+    .string()
+    .min(1)
+    .describe("Person account username to grant access to the package scope."),
+});
 
 const outputSchema = z.object({
-	created: z.boolean(),
-	scope: z.string(),
-	username: z.string(),
-})
+  created: z.boolean(),
+  scope: z.string(),
+  username: z.string(),
+});
 
 export const adminPackageScopeGrantCreateCapability = defineDomainCapability(
-	capabilityDomainNames.admin,
-	{
-		...adminMutationCapabilityAccess,
-		name: 'admin_package_scope_grant_create',
-		description:
-			'Grant a person account permission to act inside a platform account package scope. Grants are only possible on platform accounts. Admin-only; does not expose package contents.',
-		keywords: [
-			'admin',
-			'package scope',
-			'grant',
-			'platform account',
-			'delegate',
-			'packages',
-		],
-		inputSchema,
-		outputSchema,
-		async handler(args, ctx) {
-			const scope = normalizeUsername(args.scope).replace(/^@/, '')
-			const username = normalizeUsername(args.username)
-			return auditAdminCapabilityInvocation(
-				ctx,
-				'admin_package_scope_grant_create',
-				async () => {
-					const platformAccount = await getPlatformAccountByUsername(
-						ctx.env.APP_DB,
-						scope,
-					)
-					if (!platformAccount) {
-						throw new Error(
-							`Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
-						)
-					}
-					const grantee = await ctx.env.APP_DB.prepare(
-						`SELECT id, username, account_type FROM users WHERE username = ?`,
-					)
-						.bind(username)
-						.first<{
-							id: number
-							username: string
-							account_type: string
-						}>()
-					if (!grantee) {
-						throw new Error(`User "${username}" was not found.`)
-					}
-					if (grantee.account_type !== 'person') {
-						throw new Error(
-							`User "${username}" is not a person account and cannot receive a package scope grant.`,
-						)
-					}
-					const admin = requireMcpUser(ctx.callerContext)
-					const adminRow = await findUserRowByStableUserId<{
-						id: number
-						email: string
-						stable_user_id: string | null
-					}>({
-						db: ctx.env.APP_DB,
-						stableUserId: admin.userId,
-						select: 'SELECT id, email, stable_user_id FROM users',
-					})
-					if (!adminRow) {
-						throw new Error(
-							'Cannot create package scope grant because the acting admin user record was not found.',
-						)
-					}
-					const { created } = await insertPackageScopeGrant(ctx.env.APP_DB, {
-						scopeOwnerUserId: platformAccount.id,
-						granteeUserId: grantee.id,
-						createdByUserId: adminRow.id,
-					})
-					return {
-						created,
-						scope: platformAccount.username,
-						username: grantee.username,
-					}
-				},
-				{
-					successReason: () => `scope=@${scope};grantee=${username}`,
-				},
-			)
-		},
-	},
-)
+  capabilityDomainNames.admin,
+  {
+    ...adminMutationCapabilityAccess,
+    name: "admin_package_scope_grant_create",
+    description:
+      "Grant a person account permission to act inside a platform account package scope. Grants are only possible on platform accounts. Admin-only; does not expose package contents.",
+    keywords: [
+      "admin",
+      "package scope",
+      "grant",
+      "platform account",
+      "delegate",
+      "packages",
+    ],
+    inputSchema,
+    outputSchema,
+    async handler(args, ctx) {
+      const scope = normalizeUsername(args.scope).replace(/^@/, "");
+      const username = normalizeUsername(args.username);
+      return auditAdminCapabilityInvocation(
+        ctx,
+        "admin_package_scope_grant_create",
+        async () => {
+          const platformAccount = await getPlatformAccountByUsername(
+            ctx.env.APP_DB,
+            scope,
+          );
+          if (!platformAccount) {
+            throw new Error(
+              `Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
+            );
+          }
+          const grantee = await ctx.env.APP_DB.prepare(
+            `SELECT username, email, account_type, stable_user_id
+						FROM users
+						WHERE username = ?`,
+          )
+            .bind(username)
+            .first<{
+              username: string;
+              email: string;
+              account_type: string;
+              stable_user_id: string | null;
+            }>();
+          if (!grantee) {
+            throw new Error(`User "${username}" was not found.`);
+          }
+          if (grantee.account_type !== "person") {
+            throw new Error(
+              `User "${username}" is not a person account and cannot receive a package scope grant.`,
+            );
+          }
+          const admin = requireMcpUser(ctx.callerContext);
+          const { created } = await insertPackageScopeGrant(ctx.env.APP_DB, {
+            scopeOwnerUserId: platformAccount.stableUserId,
+            granteeUserId: await resolveUserStableId(grantee),
+            createdByUserId: admin.userId,
+          });
+          return {
+            created,
+            scope: platformAccount.username,
+            username: grantee.username,
+          };
+        },
+        {
+          successReason: () => `scope=@${scope};grantee=${username}`,
+        },
+      );
+    },
+  },
+);

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-create.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-create.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod'
+import { normalizeUsername } from '#app/username.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import {
+	getPlatformAccountByUsername,
+	insertPackageScopeGrant,
+} from '#worker/package-registry/scope-grants.ts'
+import { findUserRowByStableUserId } from '#worker/user-id.ts'
+import {
+	adminMutationCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
+
+const inputSchema = z.object({
+	scope: z
+		.string()
+		.min(1)
+		.describe(
+			'Platform account username that owns the package scope (without "@"), for example "kody".',
+		),
+	username: z
+		.string()
+		.min(1)
+		.describe('Person account username to grant access to the package scope.'),
+})
+
+const outputSchema = z.object({
+	created: z.boolean(),
+	scope: z.string(),
+	username: z.string(),
+})
+
+export const adminPackageScopeGrantCreateCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminMutationCapabilityAccess,
+		name: 'admin_package_scope_grant_create',
+		description:
+			'Grant a person account permission to act inside a platform account package scope. Grants are only possible on platform accounts. Admin-only; does not expose package contents.',
+		keywords: [
+			'admin',
+			'package scope',
+			'grant',
+			'platform account',
+			'delegate',
+			'packages',
+		],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			const scope = normalizeUsername(args.scope).replace(/^@/, '')
+			const username = normalizeUsername(args.username)
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_package_scope_grant_create',
+				async () => {
+					const platformAccount = await getPlatformAccountByUsername(
+						ctx.env.APP_DB,
+						scope,
+					)
+					if (!platformAccount) {
+						throw new Error(
+							`Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
+						)
+					}
+					const grantee = await ctx.env.APP_DB.prepare(
+						`SELECT id, username, account_type FROM users WHERE username = ?`,
+					)
+						.bind(username)
+						.first<{
+							id: number
+							username: string
+							account_type: string
+						}>()
+					if (!grantee) {
+						throw new Error(`User "${username}" was not found.`)
+					}
+					if (grantee.account_type !== 'person') {
+						throw new Error(
+							`User "${username}" is not a person account and cannot receive a package scope grant.`,
+						)
+					}
+					const admin = requireMcpUser(ctx.callerContext)
+					const adminRow = await findUserRowByStableUserId<{
+						id: number
+						email: string
+						stable_user_id: string | null
+					}>({
+						db: ctx.env.APP_DB,
+						stableUserId: admin.userId,
+						select: 'SELECT id, email, stable_user_id FROM users',
+					})
+					if (!adminRow) {
+						throw new Error(
+							'Cannot create package scope grant because the acting admin user record was not found.',
+						)
+					}
+					const { created } = await insertPackageScopeGrant(ctx.env.APP_DB, {
+						scopeOwnerUserId: platformAccount.id,
+						granteeUserId: grantee.id,
+						createdByUserId: adminRow.id,
+					})
+					return {
+						created,
+						scope: platformAccount.username,
+						username: grantee.username,
+					}
+				},
+				{
+					successReason: () => `scope=@${scope};grantee=${username}`,
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-list.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-list.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod'
+import { normalizeUsername } from '#app/username.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	getPlatformAccountByUsername,
+	listPackageScopeGrants,
+} from '#worker/package-registry/scope-grants.ts'
+import {
+	adminCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
+
+const inputSchema = z.object({
+	scope: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			'Optional platform account username (without "@") to filter grants. When omitted, returns all package scope grants.',
+		),
+})
+
+const outputSchema = z.object({
+	grants: z.array(
+		z.object({
+			scope: z.string(),
+			username: z.string(),
+			created_by_user_id: z.number().int().positive(),
+			created_at: z.string(),
+		}),
+	),
+})
+
+export const adminPackageScopeGrantListCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminCapabilityAccess,
+		name: 'admin_package_scope_grant_list',
+		description:
+			'List package scope grants that let person accounts act inside platform account scopes. Optionally filter by platform account username. Admin-only; does not expose package contents.',
+		keywords: [
+			'admin',
+			'package scope',
+			'grant',
+			'list',
+			'platform account',
+			'packages',
+		],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_package_scope_grant_list',
+				async () => {
+					let scopeOwnerUserId: number | undefined
+					if (args.scope !== undefined) {
+						const scope = normalizeUsername(args.scope).replace(/^@/, '')
+						const platformAccount = await getPlatformAccountByUsername(
+							ctx.env.APP_DB,
+							scope,
+						)
+						if (!platformAccount) {
+							throw new Error(
+								`Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
+							)
+						}
+						scopeOwnerUserId = platformAccount.id
+					}
+					const rows = await listPackageScopeGrants(ctx.env.APP_DB, {
+						scopeOwnerUserId,
+					})
+					return {
+						grants: rows.map((row) => ({
+							scope: row.scope_username,
+							username: row.grantee_username,
+							created_by_user_id: row.created_by_user_id,
+							created_at: row.created_at,
+						})),
+					}
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-list.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-list.ts
@@ -1,86 +1,86 @@
-import { z } from 'zod'
-import { normalizeUsername } from '#app/username.ts'
-import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
-import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { z } from "zod";
+import { normalizeUsername } from "#app/username.ts";
+import { defineDomainCapability } from "#mcp/capabilities/define-domain-capability.ts";
+import { capabilityDomainNames } from "#mcp/capabilities/domain-metadata.ts";
 import {
-	getPlatformAccountByUsername,
-	listPackageScopeGrants,
-} from '#worker/package-registry/scope-grants.ts'
+  getPlatformAccountByUsername,
+  listPackageScopeGrants,
+} from "#worker/package-registry/scope-grants.ts";
 import {
-	adminCapabilityAccess,
-	auditAdminCapabilityInvocation,
-} from './admin-shared.ts'
+  adminCapabilityAccess,
+  auditAdminCapabilityInvocation,
+} from "./admin-shared.ts";
 
 const inputSchema = z.object({
-	scope: z
-		.string()
-		.min(1)
-		.optional()
-		.describe(
-			'Optional platform account username (without "@") to filter grants. When omitted, returns all package scope grants.',
-		),
-})
+  scope: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Optional platform account username (without "@") to filter grants. When omitted, returns all package scope grants.',
+    ),
+});
 
 const outputSchema = z.object({
-	grants: z.array(
-		z.object({
-			scope: z.string(),
-			username: z.string(),
-			created_by_user_id: z.number().int().positive(),
-			created_at: z.string(),
-		}),
-	),
-})
+  grants: z.array(
+    z.object({
+      scope: z.string(),
+      username: z.string(),
+      created_by_user_id: z.string(),
+      created_at: z.string(),
+    }),
+  ),
+});
 
 export const adminPackageScopeGrantListCapability = defineDomainCapability(
-	capabilityDomainNames.admin,
-	{
-		...adminCapabilityAccess,
-		name: 'admin_package_scope_grant_list',
-		description:
-			'List package scope grants that let person accounts act inside platform account scopes. Optionally filter by platform account username. Admin-only; does not expose package contents.',
-		keywords: [
-			'admin',
-			'package scope',
-			'grant',
-			'list',
-			'platform account',
-			'packages',
-		],
-		inputSchema,
-		outputSchema,
-		async handler(args, ctx) {
-			return auditAdminCapabilityInvocation(
-				ctx,
-				'admin_package_scope_grant_list',
-				async () => {
-					let scopeOwnerUserId: number | undefined
-					if (args.scope !== undefined) {
-						const scope = normalizeUsername(args.scope).replace(/^@/, '')
-						const platformAccount = await getPlatformAccountByUsername(
-							ctx.env.APP_DB,
-							scope,
-						)
-						if (!platformAccount) {
-							throw new Error(
-								`Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
-							)
-						}
-						scopeOwnerUserId = platformAccount.id
-					}
-					const rows = await listPackageScopeGrants(ctx.env.APP_DB, {
-						scopeOwnerUserId,
-					})
-					return {
-						grants: rows.map((row) => ({
-							scope: row.scope_username,
-							username: row.grantee_username,
-							created_by_user_id: row.created_by_user_id,
-							created_at: row.created_at,
-						})),
-					}
-				},
-			)
-		},
-	},
-)
+  capabilityDomainNames.admin,
+  {
+    ...adminCapabilityAccess,
+    name: "admin_package_scope_grant_list",
+    description:
+      "List package scope grants that let person accounts act inside platform account scopes. Optionally filter by platform account username. Admin-only; does not expose package contents.",
+    keywords: [
+      "admin",
+      "package scope",
+      "grant",
+      "list",
+      "platform account",
+      "packages",
+    ],
+    inputSchema,
+    outputSchema,
+    async handler(args, ctx) {
+      return auditAdminCapabilityInvocation(
+        ctx,
+        "admin_package_scope_grant_list",
+        async () => {
+          let scopeOwnerUserId: string | undefined;
+          if (args.scope !== undefined) {
+            const scope = normalizeUsername(args.scope).replace(/^@/, "");
+            const platformAccount = await getPlatformAccountByUsername(
+              ctx.env.APP_DB,
+              scope,
+            );
+            if (!platformAccount) {
+              throw new Error(
+                `Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
+              );
+            }
+            scopeOwnerUserId = platformAccount.stableUserId;
+          }
+          const rows = await listPackageScopeGrants(ctx.env.APP_DB, {
+            scopeOwnerUserId,
+          });
+          return {
+            grants: rows.map((row) => ({
+              scope: row.scope_username,
+              username: row.grantee_username,
+              created_by_user_id: row.created_by_user_id,
+              created_at: row.created_at,
+            })),
+          };
+        },
+      );
+    },
+  },
+);

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-list.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-list.ts
@@ -1,86 +1,86 @@
-import { z } from "zod";
-import { normalizeUsername } from "#app/username.ts";
-import { defineDomainCapability } from "#mcp/capabilities/define-domain-capability.ts";
-import { capabilityDomainNames } from "#mcp/capabilities/domain-metadata.ts";
+import { z } from 'zod'
+import { normalizeUsername } from '#app/username.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
-  getPlatformAccountByUsername,
-  listPackageScopeGrants,
-} from "#worker/package-registry/scope-grants.ts";
+	getPlatformAccountByUsername,
+	listPackageScopeGrants,
+} from '#worker/package-registry/scope-grants.ts'
 import {
-  adminCapabilityAccess,
-  auditAdminCapabilityInvocation,
-} from "./admin-shared.ts";
+	adminCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
 
 const inputSchema = z.object({
-  scope: z
-    .string()
-    .min(1)
-    .optional()
-    .describe(
-      'Optional platform account username (without "@") to filter grants. When omitted, returns all package scope grants.',
-    ),
-});
+	scope: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			'Optional platform account username (without "@") to filter grants. When omitted, returns all package scope grants.',
+		),
+})
 
 const outputSchema = z.object({
-  grants: z.array(
-    z.object({
-      scope: z.string(),
-      username: z.string(),
-      created_by_user_id: z.string(),
-      created_at: z.string(),
-    }),
-  ),
-});
+	grants: z.array(
+		z.object({
+			scope: z.string(),
+			username: z.string(),
+			created_by_user_id: z.string(),
+			created_at: z.string(),
+		}),
+	),
+})
 
 export const adminPackageScopeGrantListCapability = defineDomainCapability(
-  capabilityDomainNames.admin,
-  {
-    ...adminCapabilityAccess,
-    name: "admin_package_scope_grant_list",
-    description:
-      "List package scope grants that let person accounts act inside platform account scopes. Optionally filter by platform account username. Admin-only; does not expose package contents.",
-    keywords: [
-      "admin",
-      "package scope",
-      "grant",
-      "list",
-      "platform account",
-      "packages",
-    ],
-    inputSchema,
-    outputSchema,
-    async handler(args, ctx) {
-      return auditAdminCapabilityInvocation(
-        ctx,
-        "admin_package_scope_grant_list",
-        async () => {
-          let scopeOwnerUserId: string | undefined;
-          if (args.scope !== undefined) {
-            const scope = normalizeUsername(args.scope).replace(/^@/, "");
-            const platformAccount = await getPlatformAccountByUsername(
-              ctx.env.APP_DB,
-              scope,
-            );
-            if (!platformAccount) {
-              throw new Error(
-                `Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
-              );
-            }
-            scopeOwnerUserId = platformAccount.stableUserId;
-          }
-          const rows = await listPackageScopeGrants(ctx.env.APP_DB, {
-            scopeOwnerUserId,
-          });
-          return {
-            grants: rows.map((row) => ({
-              scope: row.scope_username,
-              username: row.grantee_username,
-              created_by_user_id: row.created_by_user_id,
-              created_at: row.created_at,
-            })),
-          };
-        },
-      );
-    },
-  },
-);
+	capabilityDomainNames.admin,
+	{
+		...adminCapabilityAccess,
+		name: 'admin_package_scope_grant_list',
+		description:
+			'List package scope grants that let person accounts act inside platform account scopes. Optionally filter by platform account username. Admin-only; does not expose package contents.',
+		keywords: [
+			'admin',
+			'package scope',
+			'grant',
+			'list',
+			'platform account',
+			'packages',
+		],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_package_scope_grant_list',
+				async () => {
+					let scopeOwnerUserId: string | undefined
+					if (args.scope !== undefined) {
+						const scope = normalizeUsername(args.scope).replace(/^@/, '')
+						const platformAccount = await getPlatformAccountByUsername(
+							ctx.env.APP_DB,
+							scope,
+						)
+						if (!platformAccount) {
+							throw new Error(
+								`Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
+							)
+						}
+						scopeOwnerUserId = platformAccount.stableUserId
+					}
+					const rows = await listPackageScopeGrants(ctx.env.APP_DB, {
+						scopeOwnerUserId,
+					})
+					return {
+						grants: rows.map((row) => ({
+							scope: row.scope_username,
+							username: row.grantee_username,
+							created_by_user_id: row.created_by_user_id,
+							created_at: row.created_at,
+						})),
+					}
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-revoke.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-revoke.ts
@@ -1,103 +1,103 @@
-import { z } from "zod";
-import { normalizeUsername } from "#app/username.ts";
-import { defineDomainCapability } from "#mcp/capabilities/define-domain-capability.ts";
-import { capabilityDomainNames } from "#mcp/capabilities/domain-metadata.ts";
+import { z } from 'zod'
+import { normalizeUsername } from '#app/username.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
-  deletePackageScopeGrant,
-  getPlatformAccountByUsername,
-} from "#worker/package-registry/scope-grants.ts";
-import { resolveUserStableId } from "#worker/user-id.ts";
+	deletePackageScopeGrant,
+	getPlatformAccountByUsername,
+} from '#worker/package-registry/scope-grants.ts'
+import { resolveUserStableId } from '#worker/user-id.ts'
 import {
-  adminMutationCapabilityAccess,
-  auditAdminCapabilityInvocation,
-} from "./admin-shared.ts";
+	adminMutationCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
 
 const inputSchema = z.object({
-  scope: z
-    .string()
-    .min(1)
-    .describe(
-      'Platform account username that owns the package scope (without "@"), for example "kody".',
-    ),
-  username: z
-    .string()
-    .min(1)
-    .describe("Person account username whose package scope grant to revoke."),
-});
+	scope: z
+		.string()
+		.min(1)
+		.describe(
+			'Platform account username that owns the package scope (without "@"), for example "kody".',
+		),
+	username: z
+		.string()
+		.min(1)
+		.describe('Person account username whose package scope grant to revoke.'),
+})
 
 const outputSchema = z.object({
-  deleted: z.boolean(),
-  scope: z.string(),
-  username: z.string(),
-});
+	deleted: z.boolean(),
+	scope: z.string(),
+	username: z.string(),
+})
 
 export const adminPackageScopeGrantRevokeCapability = defineDomainCapability(
-  capabilityDomainNames.admin,
-  {
-    ...adminMutationCapabilityAccess,
-    name: "admin_package_scope_grant_revoke",
-    description:
-      "Revoke a person account grant to act inside a platform account package scope. Grants are only possible on platform accounts. Admin-only; does not expose package contents.",
-    keywords: [
-      "admin",
-      "package scope",
-      "grant",
-      "revoke",
-      "platform account",
-      "packages",
-    ],
-    inputSchema,
-    outputSchema,
-    async handler(args, ctx) {
-      const scope = normalizeUsername(args.scope).replace(/^@/, "");
-      const username = normalizeUsername(args.username);
-      return auditAdminCapabilityInvocation(
-        ctx,
-        "admin_package_scope_grant_revoke",
-        async () => {
-          const platformAccount = await getPlatformAccountByUsername(
-            ctx.env.APP_DB,
-            scope,
-          );
-          if (!platformAccount) {
-            throw new Error(
-              `Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
-            );
-          }
-          const grantee = await ctx.env.APP_DB.prepare(
-            `SELECT username, email, account_type, stable_user_id
+	capabilityDomainNames.admin,
+	{
+		...adminMutationCapabilityAccess,
+		name: 'admin_package_scope_grant_revoke',
+		description:
+			'Revoke a person account grant to act inside a platform account package scope. Grants are only possible on platform accounts. Admin-only; does not expose package contents.',
+		keywords: [
+			'admin',
+			'package scope',
+			'grant',
+			'revoke',
+			'platform account',
+			'packages',
+		],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			const scope = normalizeUsername(args.scope).replace(/^@/, '')
+			const username = normalizeUsername(args.username)
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_package_scope_grant_revoke',
+				async () => {
+					const platformAccount = await getPlatformAccountByUsername(
+						ctx.env.APP_DB,
+						scope,
+					)
+					if (!platformAccount) {
+						throw new Error(
+							`Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
+						)
+					}
+					const grantee = await ctx.env.APP_DB.prepare(
+						`SELECT username, email, account_type, stable_user_id
 						FROM users
 						WHERE username = ?`,
-          )
-            .bind(username)
-            .first<{
-              username: string;
-              email: string;
-              account_type: string;
-              stable_user_id: string | null;
-            }>();
-          if (!grantee) {
-            throw new Error(`User "${username}" was not found.`);
-          }
-          if (grantee.account_type !== "person") {
-            throw new Error(
-              `User "${username}" is not a person account and cannot hold a package scope grant.`,
-            );
-          }
-          const { deleted } = await deletePackageScopeGrant(ctx.env.APP_DB, {
-            scopeOwnerUserId: platformAccount.stableUserId,
-            granteeUserId: await resolveUserStableId(grantee),
-          });
-          return {
-            deleted,
-            scope: platformAccount.username,
-            username: grantee.username,
-          };
-        },
-        {
-          successReason: () => `scope=@${scope};grantee=${username}`,
-        },
-      );
-    },
-  },
-);
+					)
+						.bind(username)
+						.first<{
+							username: string
+							email: string
+							account_type: string
+							stable_user_id: string | null
+						}>()
+					if (!grantee) {
+						throw new Error(`User "${username}" was not found.`)
+					}
+					if (grantee.account_type !== 'person') {
+						throw new Error(
+							`User "${username}" is not a person account and cannot hold a package scope grant.`,
+						)
+					}
+					const { deleted } = await deletePackageScopeGrant(ctx.env.APP_DB, {
+						scopeOwnerUserId: platformAccount.stableUserId,
+						granteeUserId: await resolveUserStableId(grantee),
+					})
+					return {
+						deleted,
+						scope: platformAccount.username,
+						username: grantee.username,
+					}
+				},
+				{
+					successReason: () => `scope=@${scope};grantee=${username}`,
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-revoke.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-revoke.ts
@@ -1,99 +1,103 @@
-import { z } from 'zod'
-import { normalizeUsername } from '#app/username.ts'
-import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
-import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { z } from "zod";
+import { normalizeUsername } from "#app/username.ts";
+import { defineDomainCapability } from "#mcp/capabilities/define-domain-capability.ts";
+import { capabilityDomainNames } from "#mcp/capabilities/domain-metadata.ts";
 import {
-	deletePackageScopeGrant,
-	getPlatformAccountByUsername,
-} from '#worker/package-registry/scope-grants.ts'
+  deletePackageScopeGrant,
+  getPlatformAccountByUsername,
+} from "#worker/package-registry/scope-grants.ts";
+import { resolveUserStableId } from "#worker/user-id.ts";
 import {
-	adminMutationCapabilityAccess,
-	auditAdminCapabilityInvocation,
-} from './admin-shared.ts'
+  adminMutationCapabilityAccess,
+  auditAdminCapabilityInvocation,
+} from "./admin-shared.ts";
 
 const inputSchema = z.object({
-	scope: z
-		.string()
-		.min(1)
-		.describe(
-			'Platform account username that owns the package scope (without "@"), for example "kody".',
-		),
-	username: z
-		.string()
-		.min(1)
-		.describe('Person account username whose package scope grant to revoke.'),
-})
+  scope: z
+    .string()
+    .min(1)
+    .describe(
+      'Platform account username that owns the package scope (without "@"), for example "kody".',
+    ),
+  username: z
+    .string()
+    .min(1)
+    .describe("Person account username whose package scope grant to revoke."),
+});
 
 const outputSchema = z.object({
-	deleted: z.boolean(),
-	scope: z.string(),
-	username: z.string(),
-})
+  deleted: z.boolean(),
+  scope: z.string(),
+  username: z.string(),
+});
 
 export const adminPackageScopeGrantRevokeCapability = defineDomainCapability(
-	capabilityDomainNames.admin,
-	{
-		...adminMutationCapabilityAccess,
-		name: 'admin_package_scope_grant_revoke',
-		description:
-			'Revoke a person account grant to act inside a platform account package scope. Grants are only possible on platform accounts. Admin-only; does not expose package contents.',
-		keywords: [
-			'admin',
-			'package scope',
-			'grant',
-			'revoke',
-			'platform account',
-			'packages',
-		],
-		inputSchema,
-		outputSchema,
-		async handler(args, ctx) {
-			const scope = normalizeUsername(args.scope).replace(/^@/, '')
-			const username = normalizeUsername(args.username)
-			return auditAdminCapabilityInvocation(
-				ctx,
-				'admin_package_scope_grant_revoke',
-				async () => {
-					const platformAccount = await getPlatformAccountByUsername(
-						ctx.env.APP_DB,
-						scope,
-					)
-					if (!platformAccount) {
-						throw new Error(
-							`Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
-						)
-					}
-					const grantee = await ctx.env.APP_DB.prepare(
-						`SELECT id, username, account_type FROM users WHERE username = ?`,
-					)
-						.bind(username)
-						.first<{
-							id: number
-							username: string
-							account_type: string
-						}>()
-					if (!grantee) {
-						throw new Error(`User "${username}" was not found.`)
-					}
-					if (grantee.account_type !== 'person') {
-						throw new Error(
-							`User "${username}" is not a person account and cannot hold a package scope grant.`,
-						)
-					}
-					const { deleted } = await deletePackageScopeGrant(ctx.env.APP_DB, {
-						scopeOwnerUserId: platformAccount.id,
-						granteeUserId: grantee.id,
-					})
-					return {
-						deleted,
-						scope: platformAccount.username,
-						username: grantee.username,
-					}
-				},
-				{
-					successReason: () => `scope=@${scope};grantee=${username}`,
-				},
-			)
-		},
-	},
-)
+  capabilityDomainNames.admin,
+  {
+    ...adminMutationCapabilityAccess,
+    name: "admin_package_scope_grant_revoke",
+    description:
+      "Revoke a person account grant to act inside a platform account package scope. Grants are only possible on platform accounts. Admin-only; does not expose package contents.",
+    keywords: [
+      "admin",
+      "package scope",
+      "grant",
+      "revoke",
+      "platform account",
+      "packages",
+    ],
+    inputSchema,
+    outputSchema,
+    async handler(args, ctx) {
+      const scope = normalizeUsername(args.scope).replace(/^@/, "");
+      const username = normalizeUsername(args.username);
+      return auditAdminCapabilityInvocation(
+        ctx,
+        "admin_package_scope_grant_revoke",
+        async () => {
+          const platformAccount = await getPlatformAccountByUsername(
+            ctx.env.APP_DB,
+            scope,
+          );
+          if (!platformAccount) {
+            throw new Error(
+              `Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
+            );
+          }
+          const grantee = await ctx.env.APP_DB.prepare(
+            `SELECT username, email, account_type, stable_user_id
+						FROM users
+						WHERE username = ?`,
+          )
+            .bind(username)
+            .first<{
+              username: string;
+              email: string;
+              account_type: string;
+              stable_user_id: string | null;
+            }>();
+          if (!grantee) {
+            throw new Error(`User "${username}" was not found.`);
+          }
+          if (grantee.account_type !== "person") {
+            throw new Error(
+              `User "${username}" is not a person account and cannot hold a package scope grant.`,
+            );
+          }
+          const { deleted } = await deletePackageScopeGrant(ctx.env.APP_DB, {
+            scopeOwnerUserId: platformAccount.stableUserId,
+            granteeUserId: await resolveUserStableId(grantee),
+          });
+          return {
+            deleted,
+            scope: platformAccount.username,
+            username: grantee.username,
+          };
+        },
+        {
+          successReason: () => `scope=@${scope};grantee=${username}`,
+        },
+      );
+    },
+  },
+);

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-revoke.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-scope-grant-revoke.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod'
+import { normalizeUsername } from '#app/username.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	deletePackageScopeGrant,
+	getPlatformAccountByUsername,
+} from '#worker/package-registry/scope-grants.ts'
+import {
+	adminMutationCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
+
+const inputSchema = z.object({
+	scope: z
+		.string()
+		.min(1)
+		.describe(
+			'Platform account username that owns the package scope (without "@"), for example "kody".',
+		),
+	username: z
+		.string()
+		.min(1)
+		.describe('Person account username whose package scope grant to revoke.'),
+})
+
+const outputSchema = z.object({
+	deleted: z.boolean(),
+	scope: z.string(),
+	username: z.string(),
+})
+
+export const adminPackageScopeGrantRevokeCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminMutationCapabilityAccess,
+		name: 'admin_package_scope_grant_revoke',
+		description:
+			'Revoke a person account grant to act inside a platform account package scope. Grants are only possible on platform accounts. Admin-only; does not expose package contents.',
+		keywords: [
+			'admin',
+			'package scope',
+			'grant',
+			'revoke',
+			'platform account',
+			'packages',
+		],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			const scope = normalizeUsername(args.scope).replace(/^@/, '')
+			const username = normalizeUsername(args.username)
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_package_scope_grant_revoke',
+				async () => {
+					const platformAccount = await getPlatformAccountByUsername(
+						ctx.env.APP_DB,
+						scope,
+					)
+					if (!platformAccount) {
+						throw new Error(
+							`Package scope "@${scope}" is not a platform account. Grants are only possible on platform accounts.`,
+						)
+					}
+					const grantee = await ctx.env.APP_DB.prepare(
+						`SELECT id, username, account_type FROM users WHERE username = ?`,
+					)
+						.bind(username)
+						.first<{
+							id: number
+							username: string
+							account_type: string
+						}>()
+					if (!grantee) {
+						throw new Error(`User "${username}" was not found.`)
+					}
+					if (grantee.account_type !== 'person') {
+						throw new Error(
+							`User "${username}" is not a person account and cannot hold a package scope grant.`,
+						)
+					}
+					const { deleted } = await deletePackageScopeGrant(ctx.env.APP_DB, {
+						scopeOwnerUserId: platformAccount.id,
+						granteeUserId: grantee.id,
+					})
+					return {
+						deleted,
+						scope: platformAccount.username,
+						username: grantee.username,
+					}
+				},
+				{
+					successReason: () => `scope=@${scope};grantee=${username}`,
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/admin-platform-account-create.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-platform-account-create.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod'
+import { createPlatformAccount } from '#app/platform-account-creation.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	adminMutationCapabilityAccess,
+	auditAdminCapabilityInvocation,
+	buildCreatedUserAuditReason,
+} from './admin-shared.ts'
+
+const inputSchema = z.object({
+	email: z.email().describe('Email address for the platform account.'),
+	username: z
+		.string()
+		.min(1)
+		.describe(
+			'Reserved username for the platform account (without "@"), for example "kody".',
+		),
+})
+
+const outputSchema = z.object({
+	platformAccount: z.object({
+		userId: z.number().int().positive(),
+		email: z.string(),
+		username: z.string(),
+	}),
+})
+
+export const adminPlatformAccountCreateCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminMutationCapabilityAccess,
+		name: 'admin_platform_account_create',
+		description:
+			'Create a platform account that holds official/platform-owned packages. Platform accounts can only claim reserved usernames and never log in. Admin-only; does not expose user content.',
+		keywords: [
+			'admin',
+			'platform',
+			'account',
+			'create',
+			'package scope',
+			'reserved username',
+			'official packages',
+		],
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_platform_account_create',
+				async () => {
+					const created = await createPlatformAccount({
+						db: ctx.env.APP_DB,
+						email: args.email,
+						username: args.username,
+					})
+					return {
+						platformAccount: {
+							userId: created.userId,
+							email: created.email,
+							username: created.username,
+						},
+					}
+				},
+				{
+					successReason: ({ platformAccount }) =>
+						buildCreatedUserAuditReason({
+							userId: platformAccount.userId,
+							email: platformAccount.email,
+						}),
+				},
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/domain.ts
+++ b/packages/worker/src/mcp/capabilities/admin/domain.ts
@@ -5,6 +5,10 @@ import { adminCommunityActivityListCapability } from './admin-community-activity
 import { adminFeatureFlagListCapability } from './admin-feature-flag-list.ts'
 import { adminFeatureFlagOverrideCapability } from './admin-feature-flag-override.ts'
 import { adminFeatureFlagSetCapability } from './admin-feature-flag-set.ts'
+import { adminPackageScopeGrantCreateCapability } from './admin-package-scope-grant-create.ts'
+import { adminPackageScopeGrantListCapability } from './admin-package-scope-grant-list.ts'
+import { adminPackageScopeGrantRevokeCapability } from './admin-package-scope-grant-revoke.ts'
+import { adminPlatformAccountCreateCapability } from './admin-platform-account-create.ts'
 import { adminPlatformFeedbackGetCapability } from './admin-platform-feedback-get.ts'
 import { adminPlatformFeedbackListCapability } from './admin-platform-feedback-list.ts'
 import { adminPlatformFeedbackUpdateCapability } from './admin-platform-feedback-update.ts'
@@ -19,7 +23,7 @@ import { adminUserUpdateCapability } from './admin-user-update.ts'
 export const adminDomain = defineDomain({
 	name: capabilityDomainNames.admin,
 	description:
-		'Admin-only operator capabilities for account metadata, feature flags, operator-owned system email, attributed platform feedback users explicitly submit for admin review, and metadata about activity on public community listings; never exposes private package source or unrelated user content such as secrets, memories, jobs, or user inbox email.',
+		'Admin-only operator capabilities for account metadata, platform accounts, package scope grants, feature flags, operator-owned system email, attributed platform feedback users explicitly submit for admin review, and metadata about activity on public community listings; never exposes private package source or unrelated user content such as secrets, memories, jobs, or user inbox email.',
 	keywords: [
 		'admin',
 		'rbac',
@@ -32,12 +36,18 @@ export const adminDomain = defineDomain({
 		'system email',
 		'platform feedback',
 		'community activity',
+		'platform accounts',
+		'package scope grants',
 	],
 	capabilities: [
 		adminUserListCapability,
 		adminUserGetCapability,
 		adminUserCreateCapability,
 		adminUserUpdateCapability,
+		adminPlatformAccountCreateCapability,
+		adminPackageScopeGrantCreateCapability,
+		adminPackageScopeGrantRevokeCapability,
+		adminPackageScopeGrantListCapability,
 		adminAuditLogQueryCapability,
 		adminUserUsageCapability,
 		adminFeatureFlagListCapability,

--- a/packages/worker/src/mcp/capabilities/community/publish.ts
+++ b/packages/worker/src/mcp/capabilities/community/publish.ts
@@ -4,6 +4,10 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import {
+	packageScopeInputDescription,
+	resolvePackageOwnerContext,
+} from '#worker/package-registry/package-owner.ts'
+import {
 	buildCommunityPublicUrl,
 	communityListingSummarySchema,
 } from './shared.ts'
@@ -30,14 +34,24 @@ export const communityPublishCapability = defineDomainCapability(
 				.string()
 				.min(1)
 				.describe('Saved package id to publish as a community listing.'),
+			package_scope: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(packageScopeInputDescription),
 		}),
 		outputSchema: communityListingSummarySchema,
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
+			const owner = await resolvePackageOwnerContext(
+				ctx.env.APP_DB,
+				user,
+				args.package_scope,
+			)
 			const listing = await publishCommunityListing({
 				env: ctx.env,
 				baseUrl: ctx.callerContext.baseUrl,
-				userId: user.userId,
+				userId: owner.ownerUserId,
 				packageId: args.package_id,
 			})
 			return {

--- a/packages/worker/src/mcp/capabilities/community/publish.ts
+++ b/packages/worker/src/mcp/capabilities/community/publish.ts
@@ -52,6 +52,7 @@ export const communityPublishCapability = defineDomainCapability(
 				env: ctx.env,
 				baseUrl: ctx.callerContext.baseUrl,
 				userId: owner.ownerUserId,
+				actorUserId: owner.actorUserId,
 				packageId: args.package_id,
 			})
 			return {

--- a/packages/worker/src/mcp/capabilities/community/unpublish.ts
+++ b/packages/worker/src/mcp/capabilities/community/unpublish.ts
@@ -43,6 +43,7 @@ export const communityUnpublishCapability = defineDomainCapability(
 			await unpublishCommunityListing({
 				env: ctx.env,
 				userId: owner.ownerUserId,
+				actorUserId: owner.actorUserId,
 				listingId: args.listing_id,
 			})
 			return {

--- a/packages/worker/src/mcp/capabilities/community/unpublish.ts
+++ b/packages/worker/src/mcp/capabilities/community/unpublish.ts
@@ -3,6 +3,10 @@ import { unpublishCommunityListing } from '#worker/community/service.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import {
+	packageScopeInputDescription,
+	resolvePackageOwnerContext,
+} from '#worker/package-registry/package-owner.ts'
 
 export const communityUnpublishCapability = defineDomainCapability(
 	capabilityDomainNames.community,
@@ -19,6 +23,11 @@ export const communityUnpublishCapability = defineDomainCapability(
 				.string()
 				.min(1)
 				.describe('Community listing id to unpublish.'),
+			package_scope: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(packageScopeInputDescription),
 		}),
 		outputSchema: z.object({
 			listing_id: z.string(),
@@ -26,9 +35,14 @@ export const communityUnpublishCapability = defineDomainCapability(
 		}),
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
+			const owner = await resolvePackageOwnerContext(
+				ctx.env.APP_DB,
+				user,
+				args.package_scope,
+			)
 			await unpublishCommunityListing({
 				env: ctx.env,
-				userId: user.userId,
+				userId: owner.ownerUserId,
 				listingId: args.listing_id,
 			})
 			return {

--- a/packages/worker/src/mcp/capabilities/packages/create-stub-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/create-stub-package.node.test.ts
@@ -1,8 +1,8 @@
 import { expect, test, vi } from 'vitest'
+import { type PackageOwnerContext } from '#worker/package-registry/package-owner.ts'
 
 const mockModule = vi.hoisted(() => ({
 	assertWithinEntitlement: vi.fn(),
-	getMcpUserPackageScope: vi.fn(),
 	ensureEntitySource: vi.fn(),
 	syncArtifactSourceSnapshot: vi.fn(),
 	insertSavedPackage: vi.fn(),
@@ -13,11 +13,6 @@ const mockModule = vi.hoisted(() => ({
 vi.mock('#worker/entitlements/service.ts', () => ({
 	assertWithinEntitlement: (...args: Array<unknown>) =>
 		mockModule.assertWithinEntitlement(...args),
-}))
-
-vi.mock('#worker/package-registry/user-scope.ts', () => ({
-	getMcpUserPackageScope: (...args: Array<unknown>) =>
-		mockModule.getMcpUserPackageScope(...args),
 }))
 
 vi.mock('#worker/repo/source-service.ts', () => ({
@@ -52,7 +47,6 @@ function resetMocks() {
 		fn.mockReset()
 	}
 	mockModule.assertWithinEntitlement.mockResolvedValue(undefined)
-	mockModule.getMcpUserPackageScope.mockResolvedValue('kentcdodds')
 	mockModule.ensureEntitySource.mockResolvedValue({
 		id: 'source-new',
 		bootstrapAccess: null,
@@ -63,10 +57,12 @@ function resetMocks() {
 	mockModule.refreshSavedPackageProjection.mockResolvedValue({ record: {} })
 }
 
-const user = {
-	userId: 'user-1',
-	email: 'user-1@example.com',
-	displayName: 'User One',
+const owner: PackageOwnerContext = {
+	ownerUserId: 'user-1',
+	ownerScope: 'kentcdodds',
+	ownerEmail: 'user-1@example.com',
+	actorUserId: 'user-1',
+	delegated: false,
 }
 
 test('createStubSavedPackage rejects invalid kody ids and registers valid stubs through the pipeline', async () => {
@@ -75,7 +71,7 @@ test('createStubSavedPackage rejects invalid kody ids and registers valid stubs 
 		createStubSavedPackage({
 			env: { APP_DB: {} } as Env,
 			baseUrl: 'https://heykody.dev',
-			user,
+			owner,
 			kodyId: 'Not_A_Valid_Id',
 		}),
 	).rejects.toThrow(/lower-kebab-case/)
@@ -86,7 +82,7 @@ test('createStubSavedPackage rejects invalid kody ids and registers valid stubs 
 	const result = await createStubSavedPackage({
 		env: { APP_DB: {} } as Env,
 		baseUrl: 'https://heykody.dev',
-		user,
+		owner,
 		kodyId: 'my-package',
 		description: 'Does the thing.',
 	})
@@ -95,7 +91,11 @@ test('createStubSavedPackage rejects invalid kody ids and registers valid stubs 
 		name: '@kentcdodds/my-package',
 	})
 	expect(mockModule.assertWithinEntitlement).toHaveBeenCalledWith(
-		expect.objectContaining({ resource: 'saved_packages' }),
+		expect.objectContaining({
+			resource: 'saved_packages',
+			userId: 'user-1',
+			email: 'user-1@example.com',
+		}),
 	)
 	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalledWith(
 		expect.objectContaining({
@@ -110,6 +110,7 @@ test('createStubSavedPackage rejects invalid kody ids and registers valid stubs 
 	expect(mockModule.insertSavedPackage).toHaveBeenCalledWith(
 		expect.anything(),
 		expect.objectContaining({
+			user_id: 'user-1',
 			name: '@kentcdodds/my-package',
 			kody_id: 'my-package',
 			description: 'Does the thing.',
@@ -120,4 +121,44 @@ test('createStubSavedPackage rejects invalid kody ids and registers valid stubs 
 	)
 	expect(mockModule.upsertSavedPackageVector).toHaveBeenCalled()
 	expect(mockModule.refreshSavedPackageProjection).toHaveBeenCalled()
+})
+
+test('createStubSavedPackage stores under the owner account when acting under a grant', async () => {
+	resetMocks()
+	const delegatedOwner: PackageOwnerContext = {
+		ownerUserId: 'platform-owner',
+		ownerScope: 'kody',
+		ownerEmail: 'kody@example.com',
+		actorUserId: 'actor-1',
+		delegated: true,
+	}
+	await createStubSavedPackage({
+		env: { APP_DB: {} } as Env,
+		baseUrl: 'https://heykody.dev',
+		owner: delegatedOwner,
+		kodyId: 'official-tool',
+	})
+	expect(mockModule.assertWithinEntitlement).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'platform-owner',
+			email: 'kody@example.com',
+		}),
+	)
+	expect(mockModule.ensureEntitySource).toHaveBeenCalledWith(
+		expect.objectContaining({ userId: 'platform-owner' }),
+	)
+	expect(mockModule.insertSavedPackage).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({
+			user_id: 'platform-owner',
+			name: '@kody/official-tool',
+		}),
+	)
+	expect(mockModule.upsertSavedPackageVector).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({ userId: 'platform-owner' }),
+	)
+	expect(mockModule.refreshSavedPackageProjection).toHaveBeenCalledWith(
+		expect.objectContaining({ userId: 'platform-owner' }),
+	)
 })

--- a/packages/worker/src/mcp/capabilities/packages/create-stub-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/create-stub-package.ts
@@ -1,14 +1,13 @@
-import { type McpUserContext } from '@kody-internal/shared/chat.ts'
 import { assertWithinEntitlement } from '#worker/entitlements/service.ts'
 import { buildSavedPackageEmbedText } from '#worker/package-registry/embed.ts'
 import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
+import { type PackageOwnerContext } from '#worker/package-registry/package-owner.ts'
 import { insertSavedPackage } from '#worker/package-registry/repo.ts'
 import { refreshSavedPackageProjection } from '#worker/package-registry/service.ts'
 import {
 	assertKodyDescriptionLength,
 	kodyPackageIdPattern,
 } from '#worker/package-registry/types.ts'
-import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
 import { upsertSavedPackageVector } from '#worker/package-registry/vectorize.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
@@ -55,7 +54,7 @@ export function buildStubPackageFiles(input: {
 export async function createStubSavedPackage(input: {
 	env: Env
 	baseUrl: string
-	user: McpUserContext
+	owner: PackageOwnerContext
 	kodyId: string
 	description?: string
 }) {
@@ -67,12 +66,11 @@ export async function createStubSavedPackage(input: {
 	}
 	await assertWithinEntitlement({
 		db: input.env.APP_DB,
-		userId: input.user.userId,
-		email: input.user.email,
+		userId: input.owner.ownerUserId,
+		email: input.owner.ownerEmail,
 		resource: 'saved_packages',
 	})
-	const scope = await getMcpUserPackageScope(input.env.APP_DB, input.user)
-	const name = `@${scope}/${kodyId}`
+	const name = `@${input.owner.ownerScope}/${kodyId}`
 	const description = input.description?.trim() || defaultStubPackageDescription
 	assertKodyDescriptionLength(description)
 	const files = buildStubPackageFiles({ name, kodyId, description })
@@ -83,13 +81,13 @@ export async function createStubSavedPackage(input: {
 	const manifest = parseAuthoredPackageJson({
 		content: packageJsonContent,
 		manifestPath: 'package.json',
-		expectedPackageScope: scope,
+		expectedPackageScope: input.owner.ownerScope,
 	})
 	const packageId = crypto.randomUUID()
 	const ensuredSource = await ensureEntitySource({
 		db: input.env.APP_DB,
 		env: input.env,
-		userId: input.user.userId,
+		userId: input.owner.ownerUserId,
 		entityKind: 'package',
 		entityId: packageId,
 		sourceRoot: '/',
@@ -98,7 +96,7 @@ export async function createStubSavedPackage(input: {
 	})
 	await syncArtifactSourceSnapshot({
 		env: input.env,
-		userId: input.user.userId,
+		userId: input.owner.ownerUserId,
 		baseUrl: input.baseUrl,
 		sourceId: ensuredSource.id,
 		bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
@@ -107,7 +105,7 @@ export async function createStubSavedPackage(input: {
 	const now = new Date().toISOString()
 	await insertSavedPackage(input.env.APP_DB, {
 		id: packageId,
-		user_id: input.user.userId,
+		user_id: input.owner.ownerUserId,
 		name: manifest.name,
 		kody_id: manifest.kody.id,
 		description: manifest.kody.description,
@@ -122,13 +120,13 @@ export async function createStubSavedPackage(input: {
 	})
 	await upsertSavedPackageVector(input.env, {
 		packageId,
-		userId: input.user.userId,
+		userId: input.owner.ownerUserId,
 		embedText: buildSavedPackageEmbedText(manifest),
 	})
 	await refreshSavedPackageProjection({
 		env: input.env,
 		baseUrl: input.baseUrl,
-		userId: input.user.userId,
+		userId: input.owner.ownerUserId,
 		packageId,
 		sourceId: ensuredSource.id,
 	})

--- a/packages/worker/src/mcp/capabilities/packages/delete-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/delete-package.ts
@@ -2,6 +2,10 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import {
+	packageScopeInputDescription,
+	resolvePackageOwnerContext,
+} from '#worker/package-registry/package-owner.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { deleteSavedPackageProjection } from '#worker/package-registry/service.ts'
 
@@ -17,6 +21,11 @@ export const deletePackageCapability = defineDomainCapability(
 		destructive: true,
 		inputSchema: z.object({
 			package_id: z.string().min(1).describe('Saved package id to delete.'),
+			package_scope: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(packageScopeInputDescription),
 		}),
 		outputSchema: z.object({
 			ok: z.literal(true),
@@ -24,8 +33,13 @@ export const deletePackageCapability = defineDomainCapability(
 		}),
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
+			const owner = await resolvePackageOwnerContext(
+				ctx.env.APP_DB,
+				user,
+				args.package_scope,
+			)
 			const existing = await getSavedPackageById(ctx.env.APP_DB, {
-				userId: user.userId,
+				userId: owner.ownerUserId,
 				packageId: args.package_id,
 			})
 			if (!existing) {
@@ -33,7 +47,7 @@ export const deletePackageCapability = defineDomainCapability(
 			}
 			await deleteSavedPackageProjection({
 				env: ctx.env,
-				userId: user.userId,
+				userId: owner.ownerUserId,
 				packageId: args.package_id,
 			})
 			return {

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
@@ -7,6 +7,7 @@ const mockModule = vi.hoisted(() => ({
 	resolveArtifactDefaultBranchHead: vi.fn(),
 	resolveExistingArtifactSourceRepo: vi.fn(),
 	createStubSavedPackage: vi.fn(),
+	resolvePackageOwnerContext: vi.fn(),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -14,6 +15,12 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 		mockModule.getSavedPackageById(...args),
 	getSavedPackageByKodyId: (...args: Array<unknown>) =>
 		mockModule.getSavedPackageByKodyId(...args),
+}))
+
+vi.mock('#worker/package-registry/package-owner.ts', () => ({
+	packageScopeInputDescription: 'package scope',
+	resolvePackageOwnerContext: (...args: Array<unknown>) =>
+		mockModule.resolvePackageOwnerContext(...args),
 }))
 
 vi.mock('#worker/repo/entity-sources.ts', () => ({
@@ -39,10 +46,21 @@ vi.mock('./create-stub-package.ts', () => ({
 
 const { getGitRemoteCapability } = await import('./get-git-remote.ts')
 
+function personalOwner(userId = 'user-1') {
+	return {
+		ownerUserId: userId,
+		ownerScope: 'kentcdodds',
+		ownerEmail: `${userId}@example.com`,
+		actorUserId: userId,
+		delegated: false,
+	}
+}
+
 function resetMocks() {
 	for (const fn of Object.values(mockModule)) {
 		fn.mockReset()
 	}
+	mockModule.resolvePackageOwnerContext.mockResolvedValue(personalOwner())
 }
 
 function createContext(userId = 'user-1') {
@@ -245,6 +263,7 @@ test('get_git_remote create mode registers a stub package when missing', async (
 			kodyId: 'unleashed-wifi',
 			description: 'WiFi controls',
 			baseUrl: 'https://heykody.dev',
+			owner: personalOwner(),
 		}),
 	)
 	expect(createdResult.created).toBe(true)
@@ -286,4 +305,62 @@ test('get_git_remote create mode registers a stub package when missing', async (
 	)
 	expect(trimmedResult.created).toBe(true)
 	expect(trimmedResult.kody_id).toBe('unleashed-wifi')
+})
+
+test('get_git_remote uses the delegated package owner for storage lookups', async () => {
+	resetMocks()
+	const delegatedOwner = {
+		ownerUserId: 'platform-owner',
+		ownerScope: 'kody',
+		ownerEmail: 'kody@example.com',
+		actorUserId: 'user-1',
+		delegated: true,
+	}
+	mockModule.resolvePackageOwnerContext.mockResolvedValue(delegatedOwner)
+	mockModule.getSavedPackageByKodyId.mockResolvedValueOnce(null)
+	mockModule.createStubSavedPackage.mockImplementation(async () => {
+		mockPackageSource('platform-owner')
+		return {
+			packageId: 'package-1',
+			kodyId: 'unleashed-wifi',
+			name: '@kody/unleashed-wifi',
+		}
+	})
+	const result = await getGitRemoteCapability.handler(
+		{
+			kody_id: 'unleashed-wifi',
+			create: true,
+			package_scope: 'kody',
+		},
+		createContext('user-1'),
+	)
+	expect(mockModule.resolvePackageOwnerContext).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({ userId: 'user-1' }),
+		'kody',
+	)
+	expect(mockModule.getSavedPackageByKodyId).toHaveBeenNthCalledWith(
+		1,
+		expect.anything(),
+		expect.objectContaining({
+			userId: 'platform-owner',
+			kodyId: 'unleashed-wifi',
+		}),
+	)
+	expect(mockModule.createStubSavedPackage).toHaveBeenCalledWith(
+		expect.objectContaining({
+			owner: delegatedOwner,
+			kodyId: 'unleashed-wifi',
+		}),
+	)
+	expect(mockModule.getSavedPackageByKodyId).toHaveBeenNthCalledWith(
+		2,
+		expect.anything(),
+		expect.objectContaining({
+			userId: 'platform-owner',
+			kodyId: 'unleashed-wifi',
+		}),
+	)
+	expect(result.created).toBe(true)
+	expect(result.package_id).toBe('package-1')
 })

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
@@ -3,6 +3,10 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import {
+	packageScopeInputDescription,
+	resolvePackageOwnerContext,
+} from '#worker/package-registry/package-owner.ts'
 import { getSavedPackageByKodyId } from '#worker/package-registry/repo.ts'
 import {
 	buildAuthenticatedArtifactsRemote,
@@ -18,6 +22,11 @@ import { resolveOwnedPackageSource } from './resolve-package-source.ts'
 const getGitRemoteInputSchema = z.object({
 	package_id: z.string().min(1).optional(),
 	kody_id: z.string().min(1).optional(),
+	package_scope: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(packageScopeInputDescription),
 	create: z
 		.boolean()
 		.optional()
@@ -87,6 +96,11 @@ export const getGitRemoteCapability = defineDomainCapability(
 		outputSchema,
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
+			const owner = await resolvePackageOwnerContext(
+				ctx.env.APP_DB,
+				user,
+				args.package_scope,
+			)
 			const requestedKodyId = args.kody_id?.trim() || undefined
 			let created = false
 			if (args.create) {
@@ -96,14 +110,14 @@ export const getGitRemoteCapability = defineDomainCapability(
 					)
 				}
 				const existing = await getSavedPackageByKodyId(ctx.env.APP_DB, {
-					userId: user.userId,
+					userId: owner.ownerUserId,
 					kodyId: requestedKodyId,
 				})
 				if (!existing) {
 					await createStubSavedPackage({
 						env: ctx.env,
 						baseUrl: ctx.callerContext.baseUrl,
-						user,
+						owner,
 						kodyId: requestedKodyId,
 						description: args.description,
 					})
@@ -112,7 +126,7 @@ export const getGitRemoteCapability = defineDomainCapability(
 			}
 			const { source, packageId, kodyId } = await resolveOwnedPackageSource({
 				db: ctx.env.APP_DB,
-				userId: user.userId,
+				userId: owner.ownerUserId,
 				args: {
 					package_id: args.package_id,
 					kody_id: requestedKodyId,
@@ -121,7 +135,7 @@ export const getGitRemoteCapability = defineDomainCapability(
 			if (args.scope === 'write') {
 				await assertRestorablePackageSourceSnapshot({
 					env: ctx.env,
-					userId: user.userId,
+					userId: owner.ownerUserId,
 					source,
 					operation: 'package_get_git_remote write access',
 				})

--- a/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
@@ -3,6 +3,7 @@ import { expect, test, vi } from 'vitest'
 const mockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
 	loadPackageManifestBySourceId: vi.fn(),
+	resolvePackageOwnerContext: vi.fn(),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -15,22 +16,31 @@ vi.mock('#worker/package-registry/source.ts', () => ({
 		mockModule.loadPackageManifestBySourceId(...args),
 }))
 
+vi.mock('#worker/package-registry/package-owner.ts', () => ({
+	packageScopeInputDescription: 'package scope',
+	resolvePackageOwnerContext: (...args: Array<unknown>) =>
+		mockModule.resolvePackageOwnerContext(...args),
+}))
+
 const { getPackageCapability } = await import('./get-package.ts')
 
 function createCallerContext(input?: {
-	includeUsername?: boolean
 	username?: string | null
+	ownerUserId?: string
+	ownerScope?: string
+	ownerEmail?: string
+	delegated?: boolean
 }) {
-	const appDb = {
-		prepare: () => ({
-			bind: () => ({
-				first: async () => {
-					if (input?.includeUsername === false) return null
-					return { username: input?.username ?? 'kody' }
-				},
-			}),
-		}),
-	} as unknown as D1Database
+	const userId = 'user-1'
+	const ownerUserId = input?.ownerUserId ?? userId
+	const ownerScope = input?.ownerScope ?? input?.username ?? 'kody'
+	mockModule.resolvePackageOwnerContext.mockResolvedValue({
+		ownerUserId,
+		ownerScope,
+		ownerEmail: input?.ownerEmail ?? 'kody@example.com',
+		actorUserId: userId,
+		delegated: input?.delegated ?? false,
+	})
 
 	const user: {
 		userId: string
@@ -38,16 +48,16 @@ function createCallerContext(input?: {
 		displayName: string
 		username?: string
 	} = {
-		userId: 'user-1',
+		userId,
 		email: 'kody@example.com',
 		displayName: 'Kody',
 	}
-	if (input?.includeUsername !== false) {
+	if (input?.username !== null) {
 		user.username = input?.username ?? 'kody'
 	}
 
 	return {
-		env: { APP_DB: appDb } as Env,
+		env: { APP_DB: {} } as Env,
 		callerContext: {
 			baseUrl: 'https://heykody.dev',
 			user,
@@ -58,7 +68,7 @@ function createCallerContext(input?: {
 	}
 }
 
-test('getPackageCapability returns export metadata and omits external invocation without a public username', async () => {
+test('getPackageCapability returns export metadata and owner-scoped invocation URLs', async () => {
 	mockModule.getSavedPackageById.mockReset()
 	mockModule.loadPackageManifestBySourceId.mockReset()
 	mockModule.getSavedPackageById.mockResolvedValue({
@@ -151,19 +161,25 @@ test('getPackageCapability returns export metadata and omits external invocation
 			},
 		],
 	})
+	expect(mockModule.getSavedPackageById).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({ userId: 'user-1', packageId: 'package-1' }),
+	)
 	expect(mockModule.loadPackageManifestBySourceId).toHaveBeenCalledWith({
 		env: expect.objectContaining({ APP_DB: expect.anything() }),
 		baseUrl: 'https://heykody.dev',
 		userId: 'user-1',
 		sourceId: 'source-1',
 	})
+})
 
+test('getPackageCapability loads packages under a delegated package_scope owner', async () => {
 	mockModule.getSavedPackageById.mockReset()
 	mockModule.loadPackageManifestBySourceId.mockReset()
 	mockModule.getSavedPackageById.mockResolvedValue({
 		id: 'package-1',
-		userId: 'user-1',
-		name: '@kentcdodds/discord-gateway',
+		userId: 'platform-owner',
+		name: '@kody/discord-gateway',
 		kodyId: 'discord-gateway',
 		description: 'Discord helpers',
 		tags: ['discord'],
@@ -178,7 +194,7 @@ test('getPackageCapability returns export metadata and omits external invocation
 	mockModule.loadPackageManifestBySourceId.mockResolvedValue({
 		source: { id: 'source-1' },
 		manifest: {
-			name: '@kentcdodds/discord-gateway',
+			name: '@kody/discord-gateway',
 			exports: {
 				'./post-message': './src/post-message.ts',
 			},
@@ -189,15 +205,33 @@ test('getPackageCapability returns export metadata and omits external invocation
 		},
 	})
 
-	const withoutUsername = await getPackageCapability.handler(
-		{ package_id: 'package-1' },
-		createCallerContext({ includeUsername: false }),
+	const result = await getPackageCapability.handler(
+		{ package_id: 'package-1', package_scope: 'kody' },
+		createCallerContext({
+			ownerUserId: 'platform-owner',
+			ownerScope: 'kody',
+			ownerEmail: 'platform@example.com',
+			delegated: true,
+		}),
 	)
 
-	expect(withoutUsername.exports).toEqual([
+	expect(mockModule.resolvePackageOwnerContext).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({ userId: 'user-1' }),
+		'kody',
+	)
+	expect(mockModule.getSavedPackageById).toHaveBeenCalledWith(
+		expect.anything(),
 		expect.objectContaining({
-			subpath: './post-message',
-			external_invocation: null,
+			userId: 'platform-owner',
+			packageId: 'package-1',
 		}),
-	])
+	)
+	expect(mockModule.loadPackageManifestBySourceId).toHaveBeenCalledWith(
+		expect.objectContaining({ userId: 'platform-owner' }),
+	)
+	expect(result.exports[0]?.external_invocation).toMatchObject({
+		owner_username: 'kody',
+		url: 'https://heykody.dev/@kody/api/package-invocations/discord-gateway/post-message',
+	})
 })

--- a/packages/worker/src/mcp/capabilities/packages/get-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.ts
@@ -6,6 +6,10 @@ import { resolvePublicUsername } from '#app/user-lookup.ts'
 import { buildExternalPackageInvocationDescriptor } from '#worker/package-invocations/public-url.ts'
 import { buildPackageSearchProjection } from '#worker/package-registry/manifest.ts'
 import { buildPackageImportSpecifier } from '#worker/package-registry/package-import-specifier.ts'
+import {
+	packageScopeInputDescription,
+	resolvePackageOwnerContext,
+} from '#worker/package-registry/package-owner.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
 import { packageDetailSchema } from './shared.ts'
@@ -31,12 +35,22 @@ export const getPackageCapability = defineDomainCapability(
 		destructive: false,
 		inputSchema: z.object({
 			package_id: z.string().min(1),
+			package_scope: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(packageScopeInputDescription),
 		}),
 		outputSchema: packageDetailSchema,
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
+			const owner = await resolvePackageOwnerContext(
+				ctx.env.APP_DB,
+				user,
+				args.package_scope,
+			)
 			const saved = await getSavedPackageById(ctx.env.APP_DB, {
-				userId: user.userId,
+				userId: owner.ownerUserId,
 				packageId: args.package_id,
 			})
 			if (!saved) {
@@ -44,13 +58,13 @@ export const getPackageCapability = defineDomainCapability(
 			}
 			const username = await resolvePublicUsername({
 				db: ctx.env.APP_DB,
-				username: user.username ?? null,
-				email: user.email ?? null,
+				username: owner.ownerScope,
+				email: owner.ownerEmail,
 			})
 			const loaded = await loadPackageManifestBySourceId({
 				env: ctx.env,
 				baseUrl: ctx.callerContext.baseUrl,
-				userId: user.userId,
+				userId: owner.ownerUserId,
 				sourceId: saved.sourceId,
 			})
 			const projection = buildPackageSearchProjection(loaded.manifest)

--- a/packages/worker/src/mcp/capabilities/packages/list-packages.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-packages.ts
@@ -2,7 +2,10 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
-import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
+import {
+	packageScopeInputDescription,
+	resolvePackageOwnerContext,
+} from '#worker/package-registry/package-owner.ts'
 import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { packageSummarySchema, toPackageSummary } from './shared.ts'
 
@@ -16,14 +19,25 @@ export const listPackagesCapability = defineDomainCapability(
 		readOnly: true,
 		idempotent: true,
 		destructive: false,
-		inputSchema: emptyCapabilityInputSchema,
+		inputSchema: z.object({
+			package_scope: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(packageScopeInputDescription),
+		}),
 		outputSchema: z.object({
 			packages: z.array(packageSummarySchema),
 		}),
-		async handler(_args, ctx) {
+		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
+			const owner = await resolvePackageOwnerContext(
+				ctx.env.APP_DB,
+				user,
+				args.package_scope,
+			)
 			const packages = await listSavedPackagesByUserId(ctx.env.APP_DB, {
-				userId: user.userId,
+				userId: owner.ownerUserId,
 			})
 			return {
 				packages: packages.map(toPackageSummary),

--- a/packages/worker/src/mcp/capabilities/packages/package-update.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-update.node.test.ts
@@ -3,6 +3,7 @@ import { expect, test, vi } from 'vitest'
 const mockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
 	updateSavedPackage: vi.fn(),
+	resolvePackageOwnerContext: vi.fn(),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -12,9 +13,22 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 		mockModule.updateSavedPackage(...args),
 }))
 
+vi.mock('#worker/package-registry/package-owner.ts', () => ({
+	packageScopeInputDescription: 'package scope',
+	resolvePackageOwnerContext: (...args: Array<unknown>) =>
+		mockModule.resolvePackageOwnerContext(...args),
+}))
+
 const { packageUpdateCapability } = await import('./package-update.ts')
 
 function createCtx(userId = 'user-1') {
+	mockModule.resolvePackageOwnerContext.mockResolvedValue({
+		ownerUserId: userId,
+		ownerScope: 'user',
+		ownerEmail: 'user@example.com',
+		actorUserId: userId,
+		delegated: false,
+	})
 	return {
 		env: { APP_DB: {} } as Env,
 		callerContext: {

--- a/packages/worker/src/mcp/capabilities/packages/package-update.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-update.ts
@@ -3,6 +3,10 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import {
+	packageScopeInputDescription,
+	resolvePackageOwnerContext,
+} from '#worker/package-registry/package-owner.ts'
+import {
 	getSavedPackageById,
 	updateSavedPackage,
 } from '#worker/package-registry/repo.ts'
@@ -33,6 +37,11 @@ export const packageUpdateCapability = defineDomainCapability(
 		destructive: false,
 		inputSchema: z.strictObject({
 			package_id: z.string().min(1).describe('Saved package id.'),
+			package_scope: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(packageScopeInputDescription),
 			changes: packageUpdateChangesSchema,
 		}),
 		outputSchema: z.object({
@@ -41,8 +50,13 @@ export const packageUpdateCapability = defineDomainCapability(
 		}),
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
+			const owner = await resolvePackageOwnerContext(
+				ctx.env.APP_DB,
+				user,
+				args.package_scope,
+			)
 			const changed = await updateSavedPackage(ctx.env.APP_DB, {
-				userId: user.userId,
+				userId: owner.ownerUserId,
 				packageId: args.package_id,
 				hidden: args.changes.hidden,
 			})
@@ -50,7 +64,7 @@ export const packageUpdateCapability = defineDomainCapability(
 				throw new Error('Saved package not found for this user.')
 			}
 			const savedPackage = await getSavedPackageById(ctx.env.APP_DB, {
-				userId: user.userId,
+				userId: owner.ownerUserId,
 				packageId: args.package_id,
 			})
 			if (!savedPackage) {

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -11,7 +11,10 @@ import {
 	getStaticPackageDependentsSummary,
 	type StaticPackageDependentsSummary,
 } from '#worker/package-runtime/static-package-dependents.ts'
-import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
+import {
+	packageScopeInputDescription,
+	resolvePackageOwnerContext,
+} from '#worker/package-registry/package-owner.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { resolveArtifactSourceHead } from '#worker/repo/artifacts.ts'
 import { rebuildPublishedPackageArtifactsViaRepoSession } from '#mcp/capabilities/repo/package-artifact-rebuild.ts'
@@ -21,6 +24,11 @@ import { resolveOwnedPackageSource } from './resolve-package-source.ts'
 const inputSchema = z.object({
 	package_id: z.string().min(1).optional(),
 	kody_id: z.string().min(1).optional(),
+	package_scope: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(packageScopeInputDescription),
 	allow_force: z.boolean().optional().default(false),
 	confirm_destructive_overwrite: z
 		.boolean()
@@ -251,10 +259,12 @@ export const publishExternalPushCapability = defineDomainCapability(
 		outputSchema,
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
-			const expectedPackageScope = await getMcpUserPackageScope(
+			const owner = await resolvePackageOwnerContext(
 				ctx.env.APP_DB,
 				user,
+				args.package_scope,
 			)
+			const expectedPackageScope = owner.ownerScope
 			const maxAttempts = externalPublishRetryDelaysMs.length + 1
 			let lastTransientError: unknown = null
 			for (
@@ -265,7 +275,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 				const attempt = attemptIndex + 1
 				const { packageId, source } = await resolveOwnedPackageSource({
 					db: ctx.env.APP_DB,
-					userId: user.userId,
+					userId: owner.ownerUserId,
 					args: {
 						package_id: args.package_id,
 						kody_id: args.kody_id,
@@ -289,7 +299,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 					).publishFromExternalRef({
 						sessionId,
 						sourceId: source.id,
-						userId: user.userId,
+						userId: owner.ownerUserId,
 						newCommit,
 						expectedHead: newCommit,
 						allowForce: args.allow_force,
@@ -308,7 +318,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 							env: ctx.env,
 							rpcSessionId: sessionId,
 							sourceId: source.id,
-							userId: user.userId,
+							userId: owner.ownerUserId,
 							publishedCommit: result.published_commit,
 							baseUrl: ctx.callerContext.baseUrl,
 						})
@@ -316,7 +326,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 							...result,
 							static_dependents: await getPublishStaticDependents({
 								db: ctx.env.APP_DB,
-								userId: user.userId,
+								userId: owner.ownerUserId,
 								sourceId: source.id,
 								publishedCommit: result.published_commit,
 							}),
@@ -329,7 +339,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 						env: ctx.env,
 						rpcSessionId: sessionId,
 						sourceId: source.id,
-						userId: user.userId,
+						userId: owner.ownerUserId,
 						publishedCommit: result.published_commit,
 						baseUrl: ctx.callerContext.baseUrl,
 					})
@@ -337,7 +347,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 						...result,
 						static_dependents: await getPublishStaticDependents({
 							db: ctx.env.APP_DB,
-							userId: user.userId,
+							userId: owner.ownerUserId,
 							sourceId: source.id,
 							publishedCommit: result.published_commit,
 						}),

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -22,7 +22,10 @@ import {
 } from '#worker/package-registry/repo.ts'
 import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
 import { assertKodyDescriptionLength } from '#worker/package-registry/types.ts'
-import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
+import {
+	packageScopeInputDescription,
+	resolvePackageOwnerContext,
+} from '#worker/package-registry/package-owner.ts'
 import { buildSavedPackageEmbedText } from '#worker/package-registry/embed.ts'
 import { upsertSavedPackageVector } from '#worker/package-registry/vectorize.ts'
 import { refreshSavedPackageProjection } from '#worker/package-registry/service.ts'
@@ -38,6 +41,11 @@ const inputSchema = z
 			.describe(
 				'Optional saved package id to update in place. Omit to create a new saved package.',
 			),
+		package_scope: z
+			.string()
+			.min(1)
+			.optional()
+			.describe(packageScopeInputDescription),
 		files: z
 			.array(packageFileSchema)
 			.min(1)
@@ -114,23 +122,25 @@ export const savePackageCapability = defineDomainCapability(
 		}),
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
+			const owner = await resolvePackageOwnerContext(
+				ctx.env.APP_DB,
+				user,
+				args.package_scope,
+			)
 			let files = normalizeFiles(args.files)
 			let packageJsonContent = files['package.json']
 			if (!packageJsonContent) {
 				throw new Error('Saved packages require a root package.json file.')
 			}
-			const expectedPackageScope = await getMcpUserPackageScope(
-				ctx.env.APP_DB,
-				user,
-			)
+			const expectedPackageScope = owner.ownerScope
 			const existing =
 				args.package_id !== undefined
 					? await getSavedPackageById(ctx.env.APP_DB, {
-							userId: user.userId,
+							userId: owner.ownerUserId,
 							packageId: args.package_id,
 						})
 					: await getSavedPackageByKodyId(ctx.env.APP_DB, {
-							userId: user.userId,
+							userId: owner.ownerUserId,
 							kodyId: parseAuthoredPackageJson({
 								content: packageJsonContent,
 								manifestPath: 'package.json',
@@ -140,8 +150,8 @@ export const savePackageCapability = defineDomainCapability(
 			if (!existing) {
 				await assertWithinEntitlement({
 					db: ctx.env.APP_DB,
-					userId: user.userId,
-					email: user.email,
+					userId: owner.ownerUserId,
+					email: owner.ownerEmail,
 					resource: 'saved_packages',
 				})
 				packageJsonContent = injectDefaultPrivateField(packageJsonContent)
@@ -158,14 +168,14 @@ export const savePackageCapability = defineDomainCapability(
 				existing == null
 					? null
 					: await getEntitySourceByEntity(ctx.env.APP_DB, {
-							userId: user.userId,
+							userId: owner.ownerUserId,
 							entityKind: 'package',
 							entityId: packageId,
 						})
 			const ensuredSource = await ensureEntitySource({
 				db: ctx.env.APP_DB,
 				env: ctx.env,
-				userId: user.userId,
+				userId: owner.ownerUserId,
 				entityKind: 'package',
 				entityId: packageId,
 				sourceRoot: '/',
@@ -177,7 +187,7 @@ export const savePackageCapability = defineDomainCapability(
 					? null
 					: await loadPriorPackageManifestContent({
 							env: ctx.env,
-							userId: user.userId,
+							userId: owner.ownerUserId,
 							source:
 								canonicalExistingSource?.id === ensuredSource.id
 									? canonicalExistingSource
@@ -193,7 +203,7 @@ export const savePackageCapability = defineDomainCapability(
 			if (existing) {
 				await assertPackageSourceOverwriteAllowed({
 					env: ctx.env,
-					userId: user.userId,
+					userId: owner.ownerUserId,
 					source:
 						canonicalExistingSource?.id === ensuredSource.id
 							? canonicalExistingSource
@@ -204,7 +214,7 @@ export const savePackageCapability = defineDomainCapability(
 			}
 			await syncArtifactSourceSnapshot({
 				env: ctx.env,
-				userId: user.userId,
+				userId: owner.ownerUserId,
 				baseUrl: ctx.callerContext.baseUrl,
 				sourceId: ensuredSource.id,
 				bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
@@ -217,7 +227,7 @@ export const savePackageCapability = defineDomainCapability(
 				const now = new Date().toISOString()
 				await insertSavedPackage(ctx.env.APP_DB, {
 					id: packageId,
-					user_id: user.userId,
+					user_id: owner.ownerUserId,
 					name: manifest.name,
 					kody_id: manifest.kody.id,
 					description: manifest.kody.description,
@@ -232,14 +242,14 @@ export const savePackageCapability = defineDomainCapability(
 				})
 				await upsertSavedPackageVector(ctx.env, {
 					packageId,
-					userId: user.userId,
+					userId: owner.ownerUserId,
 					embedText: buildSavedPackageEmbedText(manifest),
 				})
 			}
 			const refreshed = await refreshSavedPackageProjection({
 				env: ctx.env,
 				baseUrl: ctx.callerContext.baseUrl,
-				userId: user.userId,
+				userId: owner.ownerUserId,
 				packageId,
 				sourceId: ensuredSource.id,
 			})

--- a/packages/worker/src/package-registry/package-owner.ts
+++ b/packages/worker/src/package-registry/package-owner.ts
@@ -1,15 +1,11 @@
-import { type McpUserContext } from '@kody-internal/shared/chat.ts'
-import { logAuditEvent } from '#app/audit-log.ts'
-import { getUsernameFormatValidationError } from '#app/username.ts'
+import { type McpUserContext } from "@kody-internal/shared/chat.ts";
+import { logAuditEvent } from "#app/audit-log.ts";
+import { getUsernameFormatValidationError } from "#app/username.ts";
 import {
-	findUserRowByStableUserId,
-	resolveUserStableId,
-} from '#worker/user-id.ts'
-import {
-	getPlatformAccountByUsername,
-	hasPackageScopeGrant,
-} from './scope-grants.ts'
-import { getMcpUserPackageScope } from './user-scope.ts'
+  getPlatformAccountByUsername,
+  hasPackageScopeGrant,
+} from "./scope-grants.ts";
+import { getMcpUserPackageScope } from "./user-scope.ts";
 
 /**
  * The acting-user / owning-account pair for a package operation.
@@ -22,19 +18,19 @@ import { getMcpUserPackageScope } from './user-scope.ts'
  * differ only when acting under a package scope grant on a platform account.
  */
 export type PackageOwnerContext = {
-	ownerUserId: string
-	ownerScope: string
-	ownerEmail: string
-	actorUserId: string
-	delegated: boolean
-}
+  ownerUserId: string;
+  ownerScope: string;
+  ownerEmail: string;
+  actorUserId: string;
+  delegated: boolean;
+};
 
 export const packageScopeInputDescription =
-	'Optional package scope (without "@") to act in, for example "kody". Requires an explicit package scope grant on that platform account. Omit to act in your own personal scope.'
+  'Optional package scope (without "@") to act in, for example "kody". Requires an explicit package scope grant on that platform account. Omit to act in your own personal scope.';
 
 function normalizeRequestedScope(scope: string | undefined) {
-	const normalized = scope?.trim().toLowerCase().replace(/^@/, '') ?? ''
-	return normalized || null
+  const normalized = scope?.trim().toLowerCase().replace(/^@/, "") ?? "";
+  return normalized || null;
 }
 
 /**
@@ -51,70 +47,53 @@ function normalizeRequestedScope(scope: string | undefined) {
  * caller's email so scope use stays attributable to a person.
  */
 export async function resolvePackageOwnerContext(
-	db: D1Database,
-	user: McpUserContext,
-	requestedScope?: string,
+  db: D1Database,
+  user: McpUserContext,
+  requestedScope?: string,
 ): Promise<PackageOwnerContext> {
-	const ownScope = await getMcpUserPackageScope(db, user)
-	const scope = normalizeRequestedScope(requestedScope)
-	if (!scope || scope === ownScope) {
-		return {
-			ownerUserId: user.userId,
-			ownerScope: ownScope,
-			ownerEmail: user.email,
-			actorUserId: user.userId,
-			delegated: false,
-		}
-	}
+  const ownScope = await getMcpUserPackageScope(db, user);
+  const scope = normalizeRequestedScope(requestedScope);
+  if (!scope || scope === ownScope) {
+    return {
+      ownerUserId: user.userId,
+      ownerScope: ownScope,
+      ownerEmail: user.email,
+      actorUserId: user.userId,
+      delegated: false,
+    };
+  }
 
-	const formatError = getUsernameFormatValidationError(scope)
-	if (formatError) {
-		throw new Error(`Invalid package scope "@${scope}": ${formatError}`)
-	}
-	const platformAccount = await getPlatformAccountByUsername(db, scope)
-	if (!platformAccount) {
-		throw new Error(
-			`Package scope "@${scope}" is not a platform account scope you can act in.`,
-		)
-	}
-	const callerRow = await findUserRowByStableUserId<{
-		id: number
-		email: string
-		stable_user_id: string | null
-	}>({
-		db,
-		stableUserId: user.userId,
-		select: 'SELECT id, email, stable_user_id FROM users',
-	})
-	if (!callerRow) {
-		throw new Error(
-			'Cannot resolve package scope because the signed-in user record was not found.',
-		)
-	}
-	const granted = await hasPackageScopeGrant(db, {
-		scopeOwnerUserId: platformAccount.id,
-		granteeUserId: callerRow.id,
-	})
-	if (!granted) {
-		throw new Error(`You do not have a package scope grant for "@${scope}".`)
-	}
-	await logAuditEvent({
-		db,
-		category: 'account',
-		action: 'package_scope_delegated_access',
-		result: 'success',
-		email: user.email,
-		path: '/mcp',
-		reason: `scope=@${platformAccount.username}`,
-	})
-	return {
-		ownerUserId: await resolveUserStableId({
-			email: platformAccount.email,
-			stable_user_id: platformAccount.stable_user_id,
-		}),
-		ownerScope: platformAccount.username,
-		ownerEmail: platformAccount.email,
-		actorUserId: user.userId,
-		delegated: true,
-	}
+  const formatError = getUsernameFormatValidationError(scope);
+  if (formatError) {
+    throw new Error(`Invalid package scope "@${scope}": ${formatError}`);
+  }
+  const platformAccount = await getPlatformAccountByUsername(db, scope);
+  if (!platformAccount) {
+    throw new Error(
+      `Package scope "@${scope}" is not a platform account scope you can act in.`,
+    );
+  }
+  const granted = await hasPackageScopeGrant(db, {
+    scopeOwnerUserId: platformAccount.stableUserId,
+    granteeUserId: user.userId,
+  });
+  if (!granted) {
+    throw new Error(`You do not have a package scope grant for "@${scope}".`);
+  }
+  await logAuditEvent({
+    db,
+    category: "account",
+    action: "package_scope_delegated_access",
+    result: "success",
+    email: user.email,
+    path: "/mcp",
+    reason: `scope=@${platformAccount.username}`,
+  });
+  return {
+    ownerUserId: platformAccount.stableUserId,
+    ownerScope: platformAccount.username,
+    ownerEmail: platformAccount.email,
+    actorUserId: user.userId,
+    delegated: true,
+  };
 }

--- a/packages/worker/src/package-registry/package-owner.ts
+++ b/packages/worker/src/package-registry/package-owner.ts
@@ -1,0 +1,120 @@
+import { type McpUserContext } from '@kody-internal/shared/chat.ts'
+import { logAuditEvent } from '#app/audit-log.ts'
+import { getUsernameFormatValidationError } from '#app/username.ts'
+import {
+	findUserRowByStableUserId,
+	resolveUserStableId,
+} from '#worker/user-id.ts'
+import {
+	getPlatformAccountByUsername,
+	hasPackageScopeGrant,
+} from './scope-grants.ts'
+import { getMcpUserPackageScope } from './user-scope.ts'
+
+/**
+ * The acting-user / owning-account pair for a package operation.
+ *
+ * `ownerUserId` (a stable MCP user id) is the only id that may be used for
+ * storage: `saved_packages.user_id`, `entity_sources.user_id`, Vectorize
+ * metadata, repo-session RPC ownership, entitlements, and community listing
+ * ownership. `actorUserId` is the signed-in caller and is used for audit and
+ * attribution only. The two are equal for personal-scope operations and
+ * differ only when acting under a package scope grant on a platform account.
+ */
+export type PackageOwnerContext = {
+	ownerUserId: string
+	ownerScope: string
+	ownerEmail: string
+	actorUserId: string
+	delegated: boolean
+}
+
+export const packageScopeInputDescription =
+	'Optional package scope (without "@") to act in, for example "kody". Requires an explicit package scope grant on that platform account. Omit to act in your own personal scope.'
+
+function normalizeRequestedScope(scope: string | undefined) {
+	const normalized = scope?.trim().toLowerCase().replace(/^@/, '') ?? ''
+	return normalized || null
+}
+
+/**
+ * Resolve the effective package owner for a capability call.
+ *
+ * Without `requestedScope` (or when it matches the caller's own username)
+ * this preserves existing behavior: the caller is the owner. With a foreign
+ * `requestedScope`, the scope must belong to a platform account
+ * (`users.account_type = 'platform'`) and the caller must hold an explicit
+ * grant row. Person accounts are never resolvable as a foreign scope, so
+ * acting as another user is unrepresentable here by construction.
+ *
+ * Delegated resolutions are recorded in the audit log with the acting
+ * caller's email so scope use stays attributable to a person.
+ */
+export async function resolvePackageOwnerContext(
+	db: D1Database,
+	user: McpUserContext,
+	requestedScope?: string,
+): Promise<PackageOwnerContext> {
+	const ownScope = await getMcpUserPackageScope(db, user)
+	const scope = normalizeRequestedScope(requestedScope)
+	if (!scope || scope === ownScope) {
+		return {
+			ownerUserId: user.userId,
+			ownerScope: ownScope,
+			ownerEmail: user.email,
+			actorUserId: user.userId,
+			delegated: false,
+		}
+	}
+
+	const formatError = getUsernameFormatValidationError(scope)
+	if (formatError) {
+		throw new Error(`Invalid package scope "@${scope}": ${formatError}`)
+	}
+	const platformAccount = await getPlatformAccountByUsername(db, scope)
+	if (!platformAccount) {
+		throw new Error(
+			`Package scope "@${scope}" is not a platform account scope you can act in.`,
+		)
+	}
+	const callerRow = await findUserRowByStableUserId<{
+		id: number
+		email: string
+		stable_user_id: string | null
+	}>({
+		db,
+		stableUserId: user.userId,
+		select: 'SELECT id, email, stable_user_id FROM users',
+	})
+	if (!callerRow) {
+		throw new Error(
+			'Cannot resolve package scope because the signed-in user record was not found.',
+		)
+	}
+	const granted = await hasPackageScopeGrant(db, {
+		scopeOwnerUserId: platformAccount.id,
+		granteeUserId: callerRow.id,
+	})
+	if (!granted) {
+		throw new Error(`You do not have a package scope grant for "@${scope}".`)
+	}
+	await logAuditEvent({
+		db,
+		category: 'account',
+		action: 'package_scope_delegated_access',
+		result: 'success',
+		email: user.email,
+		path: '/mcp',
+		reason: `scope=@${platformAccount.username}`,
+	})
+	return {
+		ownerUserId: await resolveUserStableId({
+			email: platformAccount.email,
+			stable_user_id: platformAccount.stable_user_id,
+		}),
+		ownerScope: platformAccount.username,
+		ownerEmail: platformAccount.email,
+		actorUserId: user.userId,
+		delegated: true,
+	}
+}

--- a/packages/worker/src/package-registry/package-owner.ts
+++ b/packages/worker/src/package-registry/package-owner.ts
@@ -1,11 +1,11 @@
-import { type McpUserContext } from "@kody-internal/shared/chat.ts";
-import { logAuditEvent } from "#app/audit-log.ts";
-import { getUsernameFormatValidationError } from "#app/username.ts";
+import { type McpUserContext } from '@kody-internal/shared/chat.ts'
+import { logAuditEvent } from '#app/audit-log.ts'
+import { getUsernameFormatValidationError } from '#app/username.ts'
 import {
-  getPlatformAccountByUsername,
-  hasPackageScopeGrant,
-} from "./scope-grants.ts";
-import { getMcpUserPackageScope } from "./user-scope.ts";
+	getPlatformAccountByUsername,
+	hasPackageScopeGrant,
+} from './scope-grants.ts'
+import { getMcpUserPackageScope } from './user-scope.ts'
 
 /**
  * The acting-user / owning-account pair for a package operation.
@@ -18,19 +18,19 @@ import { getMcpUserPackageScope } from "./user-scope.ts";
  * differ only when acting under a package scope grant on a platform account.
  */
 export type PackageOwnerContext = {
-  ownerUserId: string;
-  ownerScope: string;
-  ownerEmail: string;
-  actorUserId: string;
-  delegated: boolean;
-};
+	ownerUserId: string
+	ownerScope: string
+	ownerEmail: string
+	actorUserId: string
+	delegated: boolean
+}
 
 export const packageScopeInputDescription =
-  'Optional package scope (without "@") to act in, for example "kody". Requires an explicit package scope grant on that platform account. Omit to act in your own personal scope.';
+	'Optional package scope (without "@") to act in, for example "kody". Requires an explicit package scope grant on that platform account. Omit to act in your own personal scope.'
 
 function normalizeRequestedScope(scope: string | undefined) {
-  const normalized = scope?.trim().toLowerCase().replace(/^@/, "") ?? "";
-  return normalized || null;
+	const normalized = scope?.trim().toLowerCase().replace(/^@/, '') ?? ''
+	return normalized || null
 }
 
 /**
@@ -47,53 +47,53 @@ function normalizeRequestedScope(scope: string | undefined) {
  * caller's email so scope use stays attributable to a person.
  */
 export async function resolvePackageOwnerContext(
-  db: D1Database,
-  user: McpUserContext,
-  requestedScope?: string,
+	db: D1Database,
+	user: McpUserContext,
+	requestedScope?: string,
 ): Promise<PackageOwnerContext> {
-  const ownScope = await getMcpUserPackageScope(db, user);
-  const scope = normalizeRequestedScope(requestedScope);
-  if (!scope || scope === ownScope) {
-    return {
-      ownerUserId: user.userId,
-      ownerScope: ownScope,
-      ownerEmail: user.email,
-      actorUserId: user.userId,
-      delegated: false,
-    };
-  }
+	const ownScope = await getMcpUserPackageScope(db, user)
+	const scope = normalizeRequestedScope(requestedScope)
+	if (!scope || scope === ownScope) {
+		return {
+			ownerUserId: user.userId,
+			ownerScope: ownScope,
+			ownerEmail: user.email,
+			actorUserId: user.userId,
+			delegated: false,
+		}
+	}
 
-  const formatError = getUsernameFormatValidationError(scope);
-  if (formatError) {
-    throw new Error(`Invalid package scope "@${scope}": ${formatError}`);
-  }
-  const platformAccount = await getPlatformAccountByUsername(db, scope);
-  if (!platformAccount) {
-    throw new Error(
-      `Package scope "@${scope}" is not a platform account scope you can act in.`,
-    );
-  }
-  const granted = await hasPackageScopeGrant(db, {
-    scopeOwnerUserId: platformAccount.stableUserId,
-    granteeUserId: user.userId,
-  });
-  if (!granted) {
-    throw new Error(`You do not have a package scope grant for "@${scope}".`);
-  }
-  await logAuditEvent({
-    db,
-    category: "account",
-    action: "package_scope_delegated_access",
-    result: "success",
-    email: user.email,
-    path: "/mcp",
-    reason: `scope=@${platformAccount.username}`,
-  });
-  return {
-    ownerUserId: platformAccount.stableUserId,
-    ownerScope: platformAccount.username,
-    ownerEmail: platformAccount.email,
-    actorUserId: user.userId,
-    delegated: true,
-  };
+	const formatError = getUsernameFormatValidationError(scope)
+	if (formatError) {
+		throw new Error(`Invalid package scope "@${scope}": ${formatError}`)
+	}
+	const platformAccount = await getPlatformAccountByUsername(db, scope)
+	if (!platformAccount) {
+		throw new Error(
+			`Package scope "@${scope}" is not a platform account scope you can act in.`,
+		)
+	}
+	const granted = await hasPackageScopeGrant(db, {
+		scopeOwnerUserId: platformAccount.stableUserId,
+		granteeUserId: user.userId,
+	})
+	if (!granted) {
+		throw new Error(`You do not have a package scope grant for "@${scope}".`)
+	}
+	await logAuditEvent({
+		db,
+		category: 'account',
+		action: 'package_scope_delegated_access',
+		result: 'success',
+		email: user.email,
+		path: '/mcp',
+		reason: `scope=@${platformAccount.username}`,
+	})
+	return {
+		ownerUserId: platformAccount.stableUserId,
+		ownerScope: platformAccount.username,
+		ownerEmail: platformAccount.email,
+		actorUserId: user.userId,
+		delegated: true,
+	}
 }

--- a/packages/worker/src/package-registry/package-owner.workers.test.ts
+++ b/packages/worker/src/package-registry/package-owner.workers.test.ts
@@ -67,9 +67,9 @@ test('resolvePackageOwnerContext returns platform owner when a grant exists', as
 		username: reservedPlatformUsername(),
 	})
 	await insertPackageScopeGrant(env.APP_DB, {
-		scopeOwnerUserId: platform.userId,
-		granteeUserId: person.id,
-		createdByUserId: person.id,
+		scopeOwnerUserId: platform.stableUserId,
+		granteeUserId: person.stableUserId,
+		createdByUserId: person.stableUserId,
 	})
 
 	const context = await resolvePackageOwnerContext(

--- a/packages/worker/src/package-registry/package-owner.workers.test.ts
+++ b/packages/worker/src/package-registry/package-owner.workers.test.ts
@@ -1,0 +1,125 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import { createPlatformAccount } from '#app/platform-account-creation.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { resolvePackageOwnerContext } from './package-owner.ts'
+import { insertPackageScopeGrant } from './scope-grants.ts'
+import { ensurePackageScopeGrantsTestSchema } from './test-schema.ts'
+
+function reservedPlatformUsername() {
+	return `kody-r-${crypto.randomUUID().replaceAll('-', '').slice(0, 8)}`
+}
+
+function personUsername() {
+	return `person-${crypto.randomUUID().replaceAll('-', '').slice(0, 8)}`
+}
+
+async function seedPersonUser(input: {
+	username: string
+	email: string
+}) {
+	const stableUserId = await createStableUserIdFromEmail(input.email)
+	const result = await env.APP_DB.prepare(
+		`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id, account_type)
+		 VALUES (?, ?, 'test-password-hash', ?, ?, 'person')`,
+	)
+		.bind(input.username, input.email, new Date().toISOString(), stableUserId)
+		.run()
+	return {
+		id: result.meta.last_row_id as number,
+		username: input.username,
+		email: input.email,
+		stableUserId,
+	}
+}
+
+test('resolvePackageOwnerContext returns caller as owner when no scope is requested', async () => {
+	await ensurePackageScopeGrantsTestSchema(env.APP_DB)
+	const person = await seedPersonUser({
+		username: personUsername(),
+		email: `owner-${crypto.randomUUID()}@example.com`,
+	})
+	const user = {
+		userId: person.stableUserId,
+		email: person.email,
+		displayName: person.username,
+	}
+
+	const context = await resolvePackageOwnerContext(env.APP_DB, user)
+	expect(context).toEqual({
+		ownerUserId: person.stableUserId,
+		ownerScope: person.username,
+		ownerEmail: person.email,
+		actorUserId: person.stableUserId,
+		delegated: false,
+	})
+})
+
+test('resolvePackageOwnerContext returns platform owner when a grant exists', async () => {
+	await ensurePackageScopeGrantsTestSchema(env.APP_DB)
+	const person = await seedPersonUser({
+		username: personUsername(),
+		email: `grantee-${crypto.randomUUID()}@example.com`,
+	})
+	const platform = await createPlatformAccount({
+		db: env.APP_DB,
+		email: `platform-${crypto.randomUUID()}@example.com`,
+		username: reservedPlatformUsername(),
+	})
+	await insertPackageScopeGrant(env.APP_DB, {
+		scopeOwnerUserId: platform.userId,
+		granteeUserId: person.id,
+		createdByUserId: person.id,
+	})
+
+	const context = await resolvePackageOwnerContext(
+		env.APP_DB,
+		{
+			userId: person.stableUserId,
+			email: person.email,
+			displayName: person.username,
+		},
+		platform.username,
+	)
+	expect(context).toEqual({
+		ownerUserId: platform.stableUserId,
+		ownerScope: platform.username,
+		ownerEmail: platform.email,
+		actorUserId: person.stableUserId,
+		delegated: true,
+	})
+})
+
+test('resolvePackageOwnerContext rejects person scopes, missing grants, and unknown scopes', async () => {
+	await ensurePackageScopeGrantsTestSchema(env.APP_DB)
+	const actor = await seedPersonUser({
+		username: personUsername(),
+		email: `actor-${crypto.randomUUID()}@example.com`,
+	})
+	const otherPerson = await seedPersonUser({
+		username: personUsername(),
+		email: `other-${crypto.randomUUID()}@example.com`,
+	})
+	const platform = await createPlatformAccount({
+		db: env.APP_DB,
+		email: `platform-${crypto.randomUUID()}@example.com`,
+		username: reservedPlatformUsername(),
+	})
+	const user = {
+		userId: actor.stableUserId,
+		email: actor.email,
+		displayName: actor.username,
+	}
+
+	await expect(
+		resolvePackageOwnerContext(env.APP_DB, user, otherPerson.username),
+	).rejects.toThrow(/not a platform account scope/)
+
+	await expect(
+		resolvePackageOwnerContext(env.APP_DB, user, platform.username),
+	).rejects.toThrow(/do not have a package scope grant/)
+
+	await expect(
+		resolvePackageOwnerContext(env.APP_DB, user, 'missing-scope-xyz'),
+	).rejects.toThrow(/not a platform account scope/)
+})

--- a/packages/worker/src/package-registry/package-owner.workers.test.ts
+++ b/packages/worker/src/package-registry/package-owner.workers.test.ts
@@ -14,10 +14,7 @@ function personUsername() {
 	return `person-${crypto.randomUUID().replaceAll('-', '').slice(0, 8)}`
 }
 
-async function seedPersonUser(input: {
-	username: string
-	email: string
-}) {
+async function seedPersonUser(input: { username: string; email: string }) {
 	const stableUserId = await createStableUserIdFromEmail(input.email)
 	const result = await env.APP_DB.prepare(
 		`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id, account_type)

--- a/packages/worker/src/package-registry/scope-grants.ts
+++ b/packages/worker/src/package-registry/scope-grants.ts
@@ -1,3 +1,5 @@
+import { resolveUserStableId } from "#worker/user-id.ts";
+
 /**
  * Package scope grants: explicit rows that let a person account act inside a
  * platform account's package scope (for example `@kody/*`).
@@ -7,115 +9,139 @@
  * "act as another user" is structurally unrepresentable — enforced in
  * `insertPackageScopeGrant` and re-checked at resolution time in
  * `package-owner.ts`.
+ *
+ * All user id columns hold stable MCP user ids (`users.stable_user_id`),
+ * matching the other ownership tables and the account deletion/export
+ * machinery.
  */
 
 export type PackageScopeGrantRow = {
-	scope_owner_user_id: number
-	grantee_user_id: number
-	created_by_user_id: number
-	created_at: string
-	scope_username: string
-	grantee_username: string
-}
+  scope_owner_user_id: string;
+  grantee_user_id: string;
+  created_by_user_id: string;
+  created_at: string;
+  scope_username: string;
+  grantee_username: string;
+};
 
-type UserAccountRow = {
-	id: number
-	username: string
-	email: string
-	account_type: string
-	stable_user_id: string | null
-}
-
-const userAccountSelect = `SELECT id, username, email, account_type, stable_user_id FROM users`
+export type PlatformAccountRow = {
+  id: number;
+  username: string;
+  email: string;
+  stableUserId: string;
+};
 
 export async function getPlatformAccountByUsername(
-	db: D1Database,
-	username: string,
-): Promise<UserAccountRow | null> {
-	const row = await db
-		.prepare(`${userAccountSelect} WHERE username = ? LIMIT 1`)
-		.bind(username)
-		.first<UserAccountRow>()
-	if (!row || row.account_type !== 'platform') return null
-	return row
+  db: D1Database,
+  username: string,
+): Promise<PlatformAccountRow | null> {
+  const row = await db
+    .prepare(
+      `SELECT id, username, email, account_type, stable_user_id
+			FROM users
+			WHERE username = ?
+			LIMIT 1`,
+    )
+    .bind(username)
+    .first<{
+      id: number;
+      username: string;
+      email: string;
+      account_type: string;
+      stable_user_id: string | null;
+    }>();
+  if (!row || row.account_type !== "platform") return null;
+  return {
+    id: row.id,
+    username: row.username,
+    email: row.email,
+    stableUserId: await resolveUserStableId(row),
+  };
+}
+
+async function isPlatformAccountStableUserId(
+  db: D1Database,
+  stableUserId: string,
+) {
+  const row = await db
+    .prepare(`SELECT account_type FROM users WHERE stable_user_id = ? LIMIT 1`)
+    .bind(stableUserId)
+    .first<{ account_type: string }>();
+  return row?.account_type === "platform";
 }
 
 export async function hasPackageScopeGrant(
-	db: D1Database,
-	input: {
-		scopeOwnerUserId: number
-		granteeUserId: number
-	},
+  db: D1Database,
+  input: {
+    scopeOwnerUserId: string;
+    granteeUserId: string;
+  },
 ): Promise<boolean> {
-	const row = await db
-		.prepare(
-			`SELECT 1 AS granted FROM package_scope_grants
+  const row = await db
+    .prepare(
+      `SELECT 1 AS granted FROM package_scope_grants
 			WHERE scope_owner_user_id = ? AND grantee_user_id = ?
 			LIMIT 1`,
-		)
-		.bind(input.scopeOwnerUserId, input.granteeUserId)
-		.first<{ granted: number }>()
-	return Boolean(row)
+    )
+    .bind(input.scopeOwnerUserId, input.granteeUserId)
+    .first<{ granted: number }>();
+  return Boolean(row);
 }
 
 export async function insertPackageScopeGrant(
-	db: D1Database,
-	input: {
-		scopeOwnerUserId: number
-		granteeUserId: number
-		createdByUserId: number
-	},
+  db: D1Database,
+  input: {
+    scopeOwnerUserId: string;
+    granteeUserId: string;
+    createdByUserId: string;
+  },
 ): Promise<{ created: boolean }> {
-	const scopeOwner = await db
-		.prepare(`SELECT account_type FROM users WHERE id = ? LIMIT 1`)
-		.bind(input.scopeOwnerUserId)
-		.first<{ account_type: string }>()
-	if (scopeOwner?.account_type !== 'platform') {
-		throw new Error(
-			'Package scope grants can only be created on platform accounts.',
-		)
-	}
-	const result = await db
-		.prepare(
-			`INSERT INTO package_scope_grants
+  if (!(await isPlatformAccountStableUserId(db, input.scopeOwnerUserId))) {
+    throw new Error(
+      "Package scope grants can only be created on platform accounts.",
+    );
+  }
+  const result = await db
+    .prepare(
+      `INSERT INTO package_scope_grants
 			(scope_owner_user_id, grantee_user_id, created_by_user_id)
 			VALUES (?, ?, ?)
 			ON CONFLICT(scope_owner_user_id, grantee_user_id) DO NOTHING`,
-		)
-		.bind(input.scopeOwnerUserId, input.granteeUserId, input.createdByUserId)
-		.run()
-	return { created: (result.meta.changes ?? 0) > 0 }
+    )
+    .bind(input.scopeOwnerUserId, input.granteeUserId, input.createdByUserId)
+    .run();
+  return { created: (result.meta.changes ?? 0) > 0 };
 }
 
 export async function deletePackageScopeGrant(
-	db: D1Database,
-	input: {
-		scopeOwnerUserId: number
-		granteeUserId: number
-	},
+  db: D1Database,
+  input: {
+    scopeOwnerUserId: string;
+    granteeUserId: string;
+  },
 ): Promise<{ deleted: boolean }> {
-	const result = await db
-		.prepare(
-			`DELETE FROM package_scope_grants
+  const result = await db
+    .prepare(
+      `DELETE FROM package_scope_grants
 			WHERE scope_owner_user_id = ? AND grantee_user_id = ?`,
-		)
-		.bind(input.scopeOwnerUserId, input.granteeUserId)
-		.run()
-	return { deleted: (result.meta.changes ?? 0) > 0 }
+    )
+    .bind(input.scopeOwnerUserId, input.granteeUserId)
+    .run();
+  return { deleted: (result.meta.changes ?? 0) > 0 };
 }
 
 export async function listPackageScopeGrants(
-	db: D1Database,
-	input: {
-		scopeOwnerUserId?: number
-	} = {},
+  db: D1Database,
+  input: {
+    scopeOwnerUserId?: string;
+  } = {},
 ): Promise<Array<PackageScopeGrantRow>> {
-	const where =
-		input.scopeOwnerUserId === undefined
-			? ''
-			: 'WHERE grants.scope_owner_user_id = ?'
-	const statement = db.prepare(
-		`SELECT
+  const where =
+    input.scopeOwnerUserId === undefined
+      ? ""
+      : "WHERE grants.scope_owner_user_id = ?";
+  const statement = db.prepare(
+    `SELECT
 			grants.scope_owner_user_id,
 			grants.grantee_user_id,
 			grants.created_by_user_id,
@@ -123,14 +149,18 @@ export async function listPackageScopeGrants(
 			scope_users.username AS scope_username,
 			grantee_users.username AS grantee_username
 		FROM package_scope_grants AS grants
-		INNER JOIN users AS scope_users ON scope_users.id = grants.scope_owner_user_id
-		INNER JOIN users AS grantee_users ON grantee_users.id = grants.grantee_user_id
+		INNER JOIN users AS scope_users
+			ON scope_users.stable_user_id = grants.scope_owner_user_id
+		INNER JOIN users AS grantee_users
+			ON grantee_users.stable_user_id = grants.grantee_user_id
 		${where}
 		ORDER BY grants.created_at ASC`,
-	)
-	const rows =
-		input.scopeOwnerUserId === undefined
-			? await statement.all<PackageScopeGrantRow>()
-			: await statement.bind(input.scopeOwnerUserId).all<PackageScopeGrantRow>()
-	return rows.results ?? []
+  );
+  const rows =
+    input.scopeOwnerUserId === undefined
+      ? await statement.all<PackageScopeGrantRow>()
+      : await statement
+          .bind(input.scopeOwnerUserId)
+          .all<PackageScopeGrantRow>();
+  return rows.results ?? [];
 }

--- a/packages/worker/src/package-registry/scope-grants.ts
+++ b/packages/worker/src/package-registry/scope-grants.ts
@@ -1,0 +1,136 @@
+/**
+ * Package scope grants: explicit rows that let a person account act inside a
+ * platform account's package scope (for example `@kody/*`).
+ *
+ * Grants are only representable on platform accounts (`users.account_type =
+ * 'platform'`). Person accounts can never be the target of a grant, so
+ * "act as another user" is structurally unrepresentable — enforced in
+ * `insertPackageScopeGrant` and re-checked at resolution time in
+ * `package-owner.ts`.
+ */
+
+export type PackageScopeGrantRow = {
+	scope_owner_user_id: number
+	grantee_user_id: number
+	created_by_user_id: number
+	created_at: string
+	scope_username: string
+	grantee_username: string
+}
+
+type UserAccountRow = {
+	id: number
+	username: string
+	email: string
+	account_type: string
+	stable_user_id: string | null
+}
+
+const userAccountSelect = `SELECT id, username, email, account_type, stable_user_id FROM users`
+
+export async function getPlatformAccountByUsername(
+	db: D1Database,
+	username: string,
+): Promise<UserAccountRow | null> {
+	const row = await db
+		.prepare(`${userAccountSelect} WHERE username = ? LIMIT 1`)
+		.bind(username)
+		.first<UserAccountRow>()
+	if (!row || row.account_type !== 'platform') return null
+	return row
+}
+
+export async function hasPackageScopeGrant(
+	db: D1Database,
+	input: {
+		scopeOwnerUserId: number
+		granteeUserId: number
+	},
+): Promise<boolean> {
+	const row = await db
+		.prepare(
+			`SELECT 1 AS granted FROM package_scope_grants
+			WHERE scope_owner_user_id = ? AND grantee_user_id = ?
+			LIMIT 1`,
+		)
+		.bind(input.scopeOwnerUserId, input.granteeUserId)
+		.first<{ granted: number }>()
+	return Boolean(row)
+}
+
+export async function insertPackageScopeGrant(
+	db: D1Database,
+	input: {
+		scopeOwnerUserId: number
+		granteeUserId: number
+		createdByUserId: number
+	},
+): Promise<{ created: boolean }> {
+	const scopeOwner = await db
+		.prepare(`SELECT account_type FROM users WHERE id = ? LIMIT 1`)
+		.bind(input.scopeOwnerUserId)
+		.first<{ account_type: string }>()
+	if (scopeOwner?.account_type !== 'platform') {
+		throw new Error(
+			'Package scope grants can only be created on platform accounts.',
+		)
+	}
+	const result = await db
+		.prepare(
+			`INSERT INTO package_scope_grants
+			(scope_owner_user_id, grantee_user_id, created_by_user_id)
+			VALUES (?, ?, ?)
+			ON CONFLICT(scope_owner_user_id, grantee_user_id) DO NOTHING`,
+		)
+		.bind(input.scopeOwnerUserId, input.granteeUserId, input.createdByUserId)
+		.run()
+	return { created: (result.meta.changes ?? 0) > 0 }
+}
+
+export async function deletePackageScopeGrant(
+	db: D1Database,
+	input: {
+		scopeOwnerUserId: number
+		granteeUserId: number
+	},
+): Promise<{ deleted: boolean }> {
+	const result = await db
+		.prepare(
+			`DELETE FROM package_scope_grants
+			WHERE scope_owner_user_id = ? AND grantee_user_id = ?`,
+		)
+		.bind(input.scopeOwnerUserId, input.granteeUserId)
+		.run()
+	return { deleted: (result.meta.changes ?? 0) > 0 }
+}
+
+export async function listPackageScopeGrants(
+	db: D1Database,
+	input: {
+		scopeOwnerUserId?: number
+	} = {},
+): Promise<Array<PackageScopeGrantRow>> {
+	const where =
+		input.scopeOwnerUserId === undefined
+			? ''
+			: 'WHERE grants.scope_owner_user_id = ?'
+	const statement = db.prepare(
+		`SELECT
+			grants.scope_owner_user_id,
+			grants.grantee_user_id,
+			grants.created_by_user_id,
+			grants.created_at,
+			scope_users.username AS scope_username,
+			grantee_users.username AS grantee_username
+		FROM package_scope_grants AS grants
+		INNER JOIN users AS scope_users ON scope_users.id = grants.scope_owner_user_id
+		INNER JOIN users AS grantee_users ON grantee_users.id = grants.grantee_user_id
+		${where}
+		ORDER BY grants.created_at ASC`,
+	)
+	const rows =
+		input.scopeOwnerUserId === undefined
+			? await statement.all<PackageScopeGrantRow>()
+			: await statement.bind(input.scopeOwnerUserId).all<PackageScopeGrantRow>()
+	return rows.results ?? []
+}

--- a/packages/worker/src/package-registry/scope-grants.ts
+++ b/packages/worker/src/package-registry/scope-grants.ts
@@ -1,4 +1,4 @@
-import { resolveUserStableId } from "#worker/user-id.ts";
+import { resolveUserStableId } from '#worker/user-id.ts'
 
 /**
  * Package scope grants: explicit rows that let a person account act inside a
@@ -16,132 +16,132 @@ import { resolveUserStableId } from "#worker/user-id.ts";
  */
 
 export type PackageScopeGrantRow = {
-  scope_owner_user_id: string;
-  grantee_user_id: string;
-  created_by_user_id: string;
-  created_at: string;
-  scope_username: string;
-  grantee_username: string;
-};
+	scope_owner_user_id: string
+	grantee_user_id: string
+	created_by_user_id: string
+	created_at: string
+	scope_username: string
+	grantee_username: string
+}
 
 export type PlatformAccountRow = {
-  id: number;
-  username: string;
-  email: string;
-  stableUserId: string;
-};
+	id: number
+	username: string
+	email: string
+	stableUserId: string
+}
 
 export async function getPlatformAccountByUsername(
-  db: D1Database,
-  username: string,
+	db: D1Database,
+	username: string,
 ): Promise<PlatformAccountRow | null> {
-  const row = await db
-    .prepare(
-      `SELECT id, username, email, account_type, stable_user_id
+	const row = await db
+		.prepare(
+			`SELECT id, username, email, account_type, stable_user_id
 			FROM users
 			WHERE username = ?
 			LIMIT 1`,
-    )
-    .bind(username)
-    .first<{
-      id: number;
-      username: string;
-      email: string;
-      account_type: string;
-      stable_user_id: string | null;
-    }>();
-  if (!row || row.account_type !== "platform") return null;
-  return {
-    id: row.id,
-    username: row.username,
-    email: row.email,
-    stableUserId: await resolveUserStableId(row),
-  };
+		)
+		.bind(username)
+		.first<{
+			id: number
+			username: string
+			email: string
+			account_type: string
+			stable_user_id: string | null
+		}>()
+	if (!row || row.account_type !== 'platform') return null
+	return {
+		id: row.id,
+		username: row.username,
+		email: row.email,
+		stableUserId: await resolveUserStableId(row),
+	}
 }
 
 async function isPlatformAccountStableUserId(
-  db: D1Database,
-  stableUserId: string,
+	db: D1Database,
+	stableUserId: string,
 ) {
-  const row = await db
-    .prepare(`SELECT account_type FROM users WHERE stable_user_id = ? LIMIT 1`)
-    .bind(stableUserId)
-    .first<{ account_type: string }>();
-  return row?.account_type === "platform";
+	const row = await db
+		.prepare(`SELECT account_type FROM users WHERE stable_user_id = ? LIMIT 1`)
+		.bind(stableUserId)
+		.first<{ account_type: string }>()
+	return row?.account_type === 'platform'
 }
 
 export async function hasPackageScopeGrant(
-  db: D1Database,
-  input: {
-    scopeOwnerUserId: string;
-    granteeUserId: string;
-  },
+	db: D1Database,
+	input: {
+		scopeOwnerUserId: string
+		granteeUserId: string
+	},
 ): Promise<boolean> {
-  const row = await db
-    .prepare(
-      `SELECT 1 AS granted FROM package_scope_grants
+	const row = await db
+		.prepare(
+			`SELECT 1 AS granted FROM package_scope_grants
 			WHERE scope_owner_user_id = ? AND grantee_user_id = ?
 			LIMIT 1`,
-    )
-    .bind(input.scopeOwnerUserId, input.granteeUserId)
-    .first<{ granted: number }>();
-  return Boolean(row);
+		)
+		.bind(input.scopeOwnerUserId, input.granteeUserId)
+		.first<{ granted: number }>()
+	return Boolean(row)
 }
 
 export async function insertPackageScopeGrant(
-  db: D1Database,
-  input: {
-    scopeOwnerUserId: string;
-    granteeUserId: string;
-    createdByUserId: string;
-  },
+	db: D1Database,
+	input: {
+		scopeOwnerUserId: string
+		granteeUserId: string
+		createdByUserId: string
+	},
 ): Promise<{ created: boolean }> {
-  if (!(await isPlatformAccountStableUserId(db, input.scopeOwnerUserId))) {
-    throw new Error(
-      "Package scope grants can only be created on platform accounts.",
-    );
-  }
-  const result = await db
-    .prepare(
-      `INSERT INTO package_scope_grants
+	if (!(await isPlatformAccountStableUserId(db, input.scopeOwnerUserId))) {
+		throw new Error(
+			'Package scope grants can only be created on platform accounts.',
+		)
+	}
+	const result = await db
+		.prepare(
+			`INSERT INTO package_scope_grants
 			(scope_owner_user_id, grantee_user_id, created_by_user_id)
 			VALUES (?, ?, ?)
 			ON CONFLICT(scope_owner_user_id, grantee_user_id) DO NOTHING`,
-    )
-    .bind(input.scopeOwnerUserId, input.granteeUserId, input.createdByUserId)
-    .run();
-  return { created: (result.meta.changes ?? 0) > 0 };
+		)
+		.bind(input.scopeOwnerUserId, input.granteeUserId, input.createdByUserId)
+		.run()
+	return { created: (result.meta.changes ?? 0) > 0 }
 }
 
 export async function deletePackageScopeGrant(
-  db: D1Database,
-  input: {
-    scopeOwnerUserId: string;
-    granteeUserId: string;
-  },
+	db: D1Database,
+	input: {
+		scopeOwnerUserId: string
+		granteeUserId: string
+	},
 ): Promise<{ deleted: boolean }> {
-  const result = await db
-    .prepare(
-      `DELETE FROM package_scope_grants
+	const result = await db
+		.prepare(
+			`DELETE FROM package_scope_grants
 			WHERE scope_owner_user_id = ? AND grantee_user_id = ?`,
-    )
-    .bind(input.scopeOwnerUserId, input.granteeUserId)
-    .run();
-  return { deleted: (result.meta.changes ?? 0) > 0 };
+		)
+		.bind(input.scopeOwnerUserId, input.granteeUserId)
+		.run()
+	return { deleted: (result.meta.changes ?? 0) > 0 }
 }
 
 export async function listPackageScopeGrants(
-  db: D1Database,
-  input: {
-    scopeOwnerUserId?: string;
-  } = {},
+	db: D1Database,
+	input: {
+		scopeOwnerUserId?: string
+	} = {},
 ): Promise<Array<PackageScopeGrantRow>> {
-  const where =
-    input.scopeOwnerUserId === undefined
-      ? ""
-      : "WHERE grants.scope_owner_user_id = ?";
-  const statement = db.prepare(
-    `SELECT
+	const where =
+		input.scopeOwnerUserId === undefined
+			? ''
+			: 'WHERE grants.scope_owner_user_id = ?'
+	const statement = db.prepare(
+		`SELECT
 			grants.scope_owner_user_id,
 			grants.grantee_user_id,
 			grants.created_by_user_id,
@@ -155,12 +155,10 @@ export async function listPackageScopeGrants(
 			ON grantee_users.stable_user_id = grants.grantee_user_id
 		${where}
 		ORDER BY grants.created_at ASC`,
-  );
-  const rows =
-    input.scopeOwnerUserId === undefined
-      ? await statement.all<PackageScopeGrantRow>()
-      : await statement
-          .bind(input.scopeOwnerUserId)
-          .all<PackageScopeGrantRow>();
-  return rows.results ?? [];
+	)
+	const rows =
+		input.scopeOwnerUserId === undefined
+			? await statement.all<PackageScopeGrantRow>()
+			: await statement.bind(input.scopeOwnerUserId).all<PackageScopeGrantRow>()
+	return rows.results ?? []
 }

--- a/packages/worker/src/package-registry/scope-grants.ts
+++ b/packages/worker/src/package-registry/scope-grants.ts
@@ -1,4 +1,7 @@
-import { resolveUserStableId } from '#worker/user-id.ts'
+import {
+	findUserRowByStableUserId,
+	resolveUserStableId,
+} from '#worker/user-id.ts'
 
 /**
  * Package scope grants: explicit rows that let a person account act inside a
@@ -63,10 +66,18 @@ async function isPlatformAccountStableUserId(
 	db: D1Database,
 	stableUserId: string,
 ) {
-	const row = await db
-		.prepare(`SELECT account_type FROM users WHERE stable_user_id = ? LIMIT 1`)
-		.bind(stableUserId)
-		.first<{ account_type: string }>()
+	// Self-healing lookup: matches legacy rows whose stable_user_id column is
+	// still NULL by deriving the id from email, then backfilling.
+	const row = await findUserRowByStableUserId<{
+		id: number
+		email: string
+		stable_user_id: string | null
+		account_type: string
+	}>({
+		db,
+		stableUserId,
+		select: 'SELECT id, email, stable_user_id, account_type FROM users',
+	})
 	return row?.account_type === 'platform'
 }
 

--- a/packages/worker/src/package-registry/scope-grants.workers.test.ts
+++ b/packages/worker/src/package-registry/scope-grants.workers.test.ts
@@ -2,7 +2,7 @@ import { env } from 'cloudflare:workers'
 import { expect, test } from 'vitest'
 import {
 	createPlatformAccount,
-	PlatformAccountCreateError,
+	type PlatformAccountCreateError,
 } from '#app/platform-account-creation.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { adminPackageScopeGrantCreateCapability } from '#mcp/capabilities/admin/admin-package-scope-grant-create.ts'

--- a/packages/worker/src/package-registry/scope-grants.workers.test.ts
+++ b/packages/worker/src/package-registry/scope-grants.workers.test.ts
@@ -1,0 +1,232 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import {
+	createPlatformAccount,
+	PlatformAccountCreateError,
+} from '#app/platform-account-creation.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { adminPackageScopeGrantCreateCapability } from '#mcp/capabilities/admin/admin-package-scope-grant-create.ts'
+import { adminPackageScopeGrantListCapability } from '#mcp/capabilities/admin/admin-package-scope-grant-list.ts'
+import { adminPackageScopeGrantRevokeCapability } from '#mcp/capabilities/admin/admin-package-scope-grant-revoke.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { insertPackageScopeGrant } from './scope-grants.ts'
+import { ensurePackageScopeGrantsTestSchema } from './test-schema.ts'
+
+function reservedPlatformUsername() {
+	return `kody-r-${crypto.randomUUID().replaceAll('-', '').slice(0, 8)}`
+}
+
+function personUsername() {
+	return `person-${crypto.randomUUID().replaceAll('-', '').slice(0, 8)}`
+}
+
+async function seedPersonUser(input: {
+	username: string
+	email: string
+	stableUserId?: string
+}) {
+	const stableUserId =
+		input.stableUserId ?? (await createStableUserIdFromEmail(input.email))
+	const result = await env.APP_DB.prepare(
+		`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id, account_type)
+		 VALUES (?, ?, 'test-password-hash', ?, ?, 'person')`,
+	)
+		.bind(input.username, input.email, new Date().toISOString(), stableUserId)
+		.run()
+	return {
+		id: result.meta.last_row_id as number,
+		username: input.username,
+		email: input.email,
+		stableUserId,
+	}
+}
+
+function createAdminCapabilityContext(input: {
+	userId: string
+	email: string
+}) {
+	return {
+		env: { APP_DB: env.APP_DB } as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId: input.userId,
+				email: input.email,
+				displayName: 'admin',
+				roles: ['admin'],
+			},
+		}),
+	}
+}
+
+test('createPlatformAccount rejects non-reserved usernames and duplicates; creates platform rows', async () => {
+	await ensurePackageScopeGrantsTestSchema(env.APP_DB)
+	const email = `platform-${crypto.randomUUID()}@example.com`
+	const username = reservedPlatformUsername()
+
+	await expect(
+		createPlatformAccount({
+			db: env.APP_DB,
+			email,
+			username: 'not-reserved-user',
+		}),
+	).rejects.toMatchObject({
+		code: 'invalid_username',
+		message: 'Platform accounts may only claim reserved usernames.',
+	} satisfies Partial<PlatformAccountCreateError>)
+
+	const created = await createPlatformAccount({
+		db: env.APP_DB,
+		email,
+		username,
+	})
+	expect(created).toMatchObject({
+		email,
+		username,
+		userId: expect.any(Number),
+		stableUserId: expect.any(String),
+	})
+
+	const row = await env.APP_DB.prepare(
+		`SELECT account_type, password_hash, username, email FROM users WHERE id = ?`,
+	)
+		.bind(created.userId)
+		.first<{
+			account_type: string
+			password_hash: string
+			username: string
+			email: string
+		}>()
+	expect(row).toEqual({
+		account_type: 'platform',
+		password_hash: 'platform_account_no_usable_password',
+		username,
+		email,
+	})
+
+	await expect(
+		createPlatformAccount({
+			db: env.APP_DB,
+			email,
+			username: reservedPlatformUsername(),
+		}),
+	).rejects.toMatchObject({ code: 'email_exists' })
+
+	await expect(
+		createPlatformAccount({
+			db: env.APP_DB,
+			email: `other-${crypto.randomUUID()}@example.com`,
+			username,
+		}),
+	).rejects.toMatchObject({ code: 'username_exists' })
+})
+
+test('insertPackageScopeGrant rejects person-account scope owners', async () => {
+	await ensurePackageScopeGrantsTestSchema(env.APP_DB)
+	const person = await seedPersonUser({
+		username: personUsername(),
+		email: `person-${crypto.randomUUID()}@example.com`,
+	})
+	const grantee = await seedPersonUser({
+		username: personUsername(),
+		email: `grantee-${crypto.randomUUID()}@example.com`,
+	})
+	const admin = await seedPersonUser({
+		username: personUsername(),
+		email: `admin-${crypto.randomUUID()}@example.com`,
+	})
+
+	await expect(
+		insertPackageScopeGrant(env.APP_DB, {
+			scopeOwnerUserId: person.id,
+			granteeUserId: grantee.id,
+			createdByUserId: admin.id,
+		}),
+	).rejects.toThrow(
+		'Package scope grants can only be created on platform accounts.',
+	)
+})
+
+test('admin package scope grant create, list, and revoke handlers', async () => {
+	await ensurePackageScopeGrantsTestSchema(env.APP_DB)
+	const adminEmail = `admin-${crypto.randomUUID()}@example.com`
+	const admin = await seedPersonUser({
+		username: personUsername(),
+		email: adminEmail,
+	})
+	const platform = await createPlatformAccount({
+		db: env.APP_DB,
+		email: `platform-${crypto.randomUUID()}@example.com`,
+		username: reservedPlatformUsername(),
+	})
+	const grantee = await seedPersonUser({
+		username: personUsername(),
+		email: `grantee-${crypto.randomUUID()}@example.com`,
+	})
+	const otherPerson = await seedPersonUser({
+		username: personUsername(),
+		email: `other-${crypto.randomUUID()}@example.com`,
+	})
+	const ctx = createAdminCapabilityContext({
+		userId: admin.stableUserId,
+		email: adminEmail,
+	})
+
+	const created = await adminPackageScopeGrantCreateCapability.handler(
+		{ scope: platform.username, username: grantee.username },
+		ctx,
+	)
+	expect(created).toEqual({
+		created: true,
+		scope: platform.username,
+		username: grantee.username,
+	})
+
+	const createdAgain = await adminPackageScopeGrantCreateCapability.handler(
+		{ scope: platform.username, username: grantee.username },
+		ctx,
+	)
+	expect(createdAgain.created).toBe(false)
+
+	await expect(
+		adminPackageScopeGrantCreateCapability.handler(
+			{ scope: otherPerson.username, username: grantee.username },
+			ctx,
+		),
+	).rejects.toThrow(/only possible on platform accounts/)
+
+	const listed = await adminPackageScopeGrantListCapability.handler(
+		{ scope: platform.username },
+		ctx,
+	)
+	expect(listed.grants).toEqual([
+		expect.objectContaining({
+			scope: platform.username,
+			username: grantee.username,
+			created_by_user_id: admin.id,
+			created_at: expect.any(String),
+		}),
+	])
+
+	const revoked = await adminPackageScopeGrantRevokeCapability.handler(
+		{ scope: platform.username, username: grantee.username },
+		ctx,
+	)
+	expect(revoked).toEqual({
+		deleted: true,
+		scope: platform.username,
+		username: grantee.username,
+	})
+
+	const revokedAgain = await adminPackageScopeGrantRevokeCapability.handler(
+		{ scope: platform.username, username: grantee.username },
+		ctx,
+	)
+	expect(revokedAgain.deleted).toBe(false)
+
+	const listedAfter = await adminPackageScopeGrantListCapability.handler(
+		{ scope: platform.username },
+		ctx,
+	)
+	expect(listedAfter.grants).toEqual([])
+})

--- a/packages/worker/src/package-registry/scope-grants.workers.test.ts
+++ b/packages/worker/src/package-registry/scope-grants.workers.test.ts
@@ -138,9 +138,9 @@ test('insertPackageScopeGrant rejects person-account scope owners', async () => 
 
 	await expect(
 		insertPackageScopeGrant(env.APP_DB, {
-			scopeOwnerUserId: person.id,
-			granteeUserId: grantee.id,
-			createdByUserId: admin.id,
+			scopeOwnerUserId: person.stableUserId,
+			granteeUserId: grantee.stableUserId,
+			createdByUserId: admin.stableUserId,
 		}),
 	).rejects.toThrow(
 		'Package scope grants can only be created on platform accounts.',
@@ -203,7 +203,7 @@ test('admin package scope grant create, list, and revoke handlers', async () => 
 		expect.objectContaining({
 			scope: platform.username,
 			username: grantee.username,
-			created_by_user_id: admin.id,
+			created_by_user_id: admin.stableUserId,
 			created_at: expect.any(String),
 		}),
 	])

--- a/packages/worker/src/package-registry/test-schema.ts
+++ b/packages/worker/src/package-registry/test-schema.ts
@@ -5,9 +5,9 @@
  * 0072 (account_type, package_scope_grants).
  */
 export async function ensurePackageScopeGrantsTestSchema(db: D1Database) {
-  await db
-    .prepare(
-      `CREATE TABLE IF NOT EXISTS users (
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS users (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 	username TEXT NOT NULL UNIQUE,
 	email TEXT NOT NULL UNIQUE,
@@ -18,23 +18,23 @@ export async function ensurePackageScopeGrantsTestSchema(db: D1Database) {
 	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
 	updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
 )`,
-    )
-    .run();
-  for (const column of [
-    "email_verified_at TEXT",
-    "stable_user_id TEXT",
-    `account_type TEXT NOT NULL DEFAULT 'person'`,
-  ]) {
-    try {
-      await db.prepare(`ALTER TABLE users ADD COLUMN ${column}`).run();
-    } catch {
-      // Column already exists (fresh CREATE above or prior suite setup).
-    }
-  }
-  await db.prepare(`DROP TABLE IF EXISTS package_scope_grants`).run();
-  await db
-    .prepare(
-      `CREATE TABLE package_scope_grants (
+		)
+		.run()
+	for (const column of [
+		'email_verified_at TEXT',
+		'stable_user_id TEXT',
+		`account_type TEXT NOT NULL DEFAULT 'person'`,
+	]) {
+		try {
+			await db.prepare(`ALTER TABLE users ADD COLUMN ${column}`).run()
+		} catch {
+			// Column already exists (fresh CREATE above or prior suite setup).
+		}
+	}
+	await db.prepare(`DROP TABLE IF EXISTS package_scope_grants`).run()
+	await db
+		.prepare(
+			`CREATE TABLE package_scope_grants (
 	scope_owner_user_id TEXT NOT NULL,
 	grantee_user_id TEXT NOT NULL,
 	created_by_user_id TEXT NOT NULL,
@@ -42,18 +42,18 @@ export async function ensurePackageScopeGrantsTestSchema(db: D1Database) {
 	PRIMARY KEY (scope_owner_user_id, grantee_user_id),
 	CHECK (scope_owner_user_id != grantee_user_id)
 )`,
-    )
-    .run();
-  await db
-    .prepare(
-      `CREATE INDEX idx_package_scope_grants_grantee_user_id
+		)
+		.run()
+	await db
+		.prepare(
+			`CREATE INDEX idx_package_scope_grants_grantee_user_id
 ON package_scope_grants(grantee_user_id)`,
-    )
-    .run();
-  // Delegated scope resolution and admin grant mutations write audit rows.
-  await db
-    .prepare(
-      `CREATE TABLE IF NOT EXISTS audit_events (
+		)
+		.run()
+	// Delegated scope resolution and admin grant mutations write audit rows.
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS audit_events (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 	category TEXT NOT NULL CHECK (category IN ('account', 'admin', 'auth', 'oauth')),
 	action TEXT NOT NULL,
@@ -65,6 +65,6 @@ ON package_scope_grants(grantee_user_id)`,
 	reason TEXT,
 	timestamp TEXT NOT NULL
 )`,
-    )
-    .run();
+		)
+		.run()
 }

--- a/packages/worker/src/package-registry/test-schema.ts
+++ b/packages/worker/src/package-registry/test-schema.ts
@@ -1,0 +1,70 @@
+/**
+ * Schema for package scope grant / platform account workers-unit tests.
+ * Local D1 does not apply migrations, so suites provision the tables they need.
+ * Mirrors users columns from early migrations plus 0052 (stable_user_id) and
+ * 0072 (account_type, package_scope_grants).
+ */
+export async function ensurePackageScopeGrantsTestSchema(db: D1Database) {
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS users (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	username TEXT NOT NULL UNIQUE,
+	email TEXT NOT NULL UNIQUE,
+	password_hash TEXT NOT NULL,
+	email_verified_at TEXT,
+	stable_user_id TEXT,
+	account_type TEXT NOT NULL DEFAULT 'person' CHECK (account_type IN ('person', 'platform')),
+	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+	updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+)`,
+		)
+		.run()
+	for (const column of [
+		'email_verified_at TEXT',
+		'stable_user_id TEXT',
+		`account_type TEXT NOT NULL DEFAULT 'person'`,
+	]) {
+		try {
+			await db.prepare(`ALTER TABLE users ADD COLUMN ${column}`).run()
+		} catch {
+			// Column already exists (fresh CREATE above or prior suite setup).
+		}
+	}
+	await db.prepare(`DROP TABLE IF EXISTS package_scope_grants`).run()
+	await db
+		.prepare(
+			`CREATE TABLE package_scope_grants (
+	scope_owner_user_id INTEGER NOT NULL,
+	grantee_user_id INTEGER NOT NULL,
+	created_by_user_id INTEGER NOT NULL,
+	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+	PRIMARY KEY (scope_owner_user_id, grantee_user_id),
+	CHECK (scope_owner_user_id != grantee_user_id)
+)`,
+		)
+		.run()
+	await db
+		.prepare(
+			`CREATE INDEX idx_package_scope_grants_grantee_user_id
+ON package_scope_grants(grantee_user_id)`,
+		)
+		.run()
+	// Delegated scope resolution and admin grant mutations write audit rows.
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS audit_events (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	category TEXT NOT NULL CHECK (category IN ('account', 'admin', 'auth', 'oauth')),
+	action TEXT NOT NULL,
+	result TEXT NOT NULL CHECK (result IN ('success', 'failure', 'rate_limited')),
+	email_hash TEXT,
+	ip_hash TEXT,
+	client_id TEXT,
+	path TEXT,
+	reason TEXT,
+	timestamp TEXT NOT NULL
+)`,
+		)
+		.run()
+}

--- a/packages/worker/src/package-registry/test-schema.ts
+++ b/packages/worker/src/package-registry/test-schema.ts
@@ -5,9 +5,9 @@
  * 0072 (account_type, package_scope_grants).
  */
 export async function ensurePackageScopeGrantsTestSchema(db: D1Database) {
-	await db
-		.prepare(
-			`CREATE TABLE IF NOT EXISTS users (
+  await db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS users (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 	username TEXT NOT NULL UNIQUE,
 	email TEXT NOT NULL UNIQUE,
@@ -18,42 +18,42 @@ export async function ensurePackageScopeGrantsTestSchema(db: D1Database) {
 	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
 	updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
 )`,
-		)
-		.run()
-	for (const column of [
-		'email_verified_at TEXT',
-		'stable_user_id TEXT',
-		`account_type TEXT NOT NULL DEFAULT 'person'`,
-	]) {
-		try {
-			await db.prepare(`ALTER TABLE users ADD COLUMN ${column}`).run()
-		} catch {
-			// Column already exists (fresh CREATE above or prior suite setup).
-		}
-	}
-	await db.prepare(`DROP TABLE IF EXISTS package_scope_grants`).run()
-	await db
-		.prepare(
-			`CREATE TABLE package_scope_grants (
-	scope_owner_user_id INTEGER NOT NULL,
-	grantee_user_id INTEGER NOT NULL,
-	created_by_user_id INTEGER NOT NULL,
+    )
+    .run();
+  for (const column of [
+    "email_verified_at TEXT",
+    "stable_user_id TEXT",
+    `account_type TEXT NOT NULL DEFAULT 'person'`,
+  ]) {
+    try {
+      await db.prepare(`ALTER TABLE users ADD COLUMN ${column}`).run();
+    } catch {
+      // Column already exists (fresh CREATE above or prior suite setup).
+    }
+  }
+  await db.prepare(`DROP TABLE IF EXISTS package_scope_grants`).run();
+  await db
+    .prepare(
+      `CREATE TABLE package_scope_grants (
+	scope_owner_user_id TEXT NOT NULL,
+	grantee_user_id TEXT NOT NULL,
+	created_by_user_id TEXT NOT NULL,
 	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
 	PRIMARY KEY (scope_owner_user_id, grantee_user_id),
 	CHECK (scope_owner_user_id != grantee_user_id)
 )`,
-		)
-		.run()
-	await db
-		.prepare(
-			`CREATE INDEX idx_package_scope_grants_grantee_user_id
+    )
+    .run();
+  await db
+    .prepare(
+      `CREATE INDEX idx_package_scope_grants_grantee_user_id
 ON package_scope_grants(grantee_user_id)`,
-		)
-		.run()
-	// Delegated scope resolution and admin grant mutations write audit rows.
-	await db
-		.prepare(
-			`CREATE TABLE IF NOT EXISTS audit_events (
+    )
+    .run();
+  // Delegated scope resolution and admin grant mutations write audit rows.
+  await db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS audit_events (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 	category TEXT NOT NULL CHECK (category IN ('account', 'admin', 'auth', 'oauth')),
 	action TEXT NOT NULL,
@@ -65,6 +65,6 @@ ON package_scope_grants(grantee_user_id)`,
 	reason TEXT,
 	timestamp TEXT NOT NULL
 )`,
-		)
-		.run()
+    )
+    .run();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Official/starter packages currently live under the operator's personal scope (`@kentcdodds/...`), which is what the onboarding page displays. This PR introduces **platform accounts** and **package scope grants** so official packages can live under `@kody` while the operator keeps authoring from their own session.

## What's in here

- **Migration `0072-package-scope-grants.sql`**: `users.account_type` (`'person'` default, `'platform'`) and a `package_scope_grants` table keyed by stable MCP user ids (`scope_owner_user_id`, `grantee_user_id`, `created_by_user_id`, PK on the owner/grantee pair, CHECK owner ≠ grantee).
- **Platform accounts** (`platform-account-creation.ts`): operator-provisioned accounts that never log in (sentinel password hash, no role). They may only claim usernames from the reserved denylist, so they can never collide with a signable-up username and users can never squat a platform scope.
- **Actor/owner resolution** (`package-registry/package-owner.ts`): `resolvePackageOwnerContext(db, user, package_scope?)` returns an explicit `{ actorUserId, ownerUserId, ownerScope, ownerEmail, delegated }` pair. Storage keys off the owner; audit keys off the actor. Delegated resolutions log `package_scope_delegated_access` audit events with the acting person's email.
- **`package_scope` input** on `package_save`, `package_get_git_remote`, `package_publish_external_push`, `package_get`, `package_list`, `package_delete`, `package_update`, `community_publish`, `community_unpublish`. Omitted → behavior identical to today.
- **Admin capabilities**: `admin_platform_account_create`, `admin_package_scope_grant_create` / `_revoke` / `_list` (all `requiredRole: 'admin'`, audit-logged).
- **Account deletion/export coverage**: `package_scope_grants` registered in `account-data-targets.ts` (grant dies with scope owner or grantee; creator attribution anonymized like `community_bans`) and in export with foreign-id redaction.
- **Docs**: new `docs/contributing/architecture/platform-accounts.md`, plus data-storage / community-packages / adding-capabilities updates.

## Security invariant (structural, not policy)

Grants are only representable on **platform** accounts: `insertPackageScopeGrant` rejects person accounts, and the resolver only resolves foreign scopes to `account_type = 'platform'` rows. Admins can act as the platform account only; acting as (or reading data of) another person user is unrepresentable in the API. Per-user isolation holds: every storage path still scopes to exactly one `userId` (the owner's).

## Deliberately not built

Org/team roles, invitations, management UI, and `repo_*` session delegation. Forks and community installs still land in the caller's personal account. The actor/owner split and grants table are the intentional seed of a future orgs feature.

## Testing

- `npm run validate` green locally (format, lint, typecheck, unit, Playwright E2E, MCP E2E, primitives).
- New workers-unit suites: `scope-grants.workers.test.ts`, `package-owner.workers.test.ts` (real D1: reserved-username enforcement, person-scope rejection, grant lifecycle, delegated resolution).
- Manual E2E against a local dev server + Cloudflare mock with real MCP OAuth clients: provisioned the `kody` platform account, verified grant-gated access (admin without grant rejected; regular user rejected), saved `@kody/demo-starter` from the operator session, confirmed isolation (absent from personal `package_list`, present with `package_scope: "kody"`), published + trusted + featured the listing, and confirmed `/onboarding.json` serves `@kody/demo-starter`.

## Operator workflow this enables

1. `admin_platform_account_create` → `kody` platform account.
2. `admin_package_scope_grant_create` → grant yourself `@kody`.
3. Author via the git lane with `package_scope: "kody"`, publish listings with `community_publish` + `package_scope`, feature them — onboarding shows `@kody/...`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `24f871c6` · **Head:** `fb99c106`

**Classification:** extends — new D1 table + `account_type` column, new admin capabilities, and an optional `package_scope` contract addition on package/community capabilities. No new primitive ids.

### Primitives touched

| Primitive            | Group     | Impact                                                                     |
| -------------------- | --------- | -------------------------------------------------------------------------- |
| `d1-app-db`          | storage   | extends — `users.account_type`, new `package_scope_grants` table           |
| `saved-packages`     | assistant | extends — optional `package_scope` input; storage keys off resolved owner  |
| `community-listings` | assistant | extends — publish/unpublish accept `package_scope`                         |
| `rbac`               | auth      | extends — 4 new admin capabilities for platform accounts and grants        |
| `account-export`     | storage   | extends — `package_scope_grants` in deletion/export targets                |

### System map

An admin provisions a platform account and grants; package capabilities resolve an actor/owner pair through the grants table and write storage under the platform owner.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	rbac["rbac<br/>Role-based access control"]:::extended
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	communityListings["community-listings<br/>Community listings"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::extended
	accountExport["account-export<br/>Account data export"]:::extended
	auditLog["audit-log<br/>Audit log"]:::untouched
	rbac -->|"admin_platform_account_create / grant create+revoke+list"| d1AppDb
	savedPackages -->|"package_scope → resolvePackageOwnerContext grant check"| d1AppDb
	savedPackages -->|"storage keyed by ownerUserId (platform account)"| d1AppDb
	communityListings -->|"community_publish package_scope → listing owned by @kody"| d1AppDb
	savedPackages -->|"package_scope_delegated_access (actor email)"| auditLog
	accountExport -->|"package_scope_grants deletion/export targets"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
before: package/community capability → userId = caller; scope = caller username
after:  package/community capability → { actorUserId, ownerUserId, ownerScope }
        package_scope omitted        → owner == actor (unchanged behavior)
        package_scope: "kody"        → owner = platform account (grant required)
```

### Invariants

- `per-user-isolation`: preserved by construction — delegation swaps which single `userId` owns the write (platform account), never fans out across users. Grants are unrepresentable on person accounts, so cross-user access cannot be expressed.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-996edb1e-8fae-4d61-99c3-a30012d7bc11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-996edb1e-8fae-4d61-99c3-a30012d7bc11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform accounts and package-scope grants to enable delegated package ownership.
  * Introduced admin capabilities to create platform accounts and manage package-scope grants (create, list, revoke).
  * Added optional package-scope support to package and community workflows for owner-scoped publishing and management.
* **Documentation**
  * Expanded architecture and contribution docs covering platform accounts, delegated access, and official starters under platform scopes.
* **Bug Fixes**
  * Improved delegated publishing safety by applying ban checks to the acting (delegated) identity and recording activity under the correct actor.
* **Tests**
  * Added end-to-end coverage for package-scope resolution, admin grant flows, and delegated access behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->