### PR TITLE
Explain unbound optional kody:runtime helper access in execute errors

### DIFF
--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -7,6 +7,7 @@ import {
 	createMissingSecretMessage,
 } from '#mcp/secrets/errors.ts'
 import { EntitlementLimitError } from '#worker/entitlements/errors.ts'
+import { createUnboundRuntimeHelperMessage } from '#worker/package-runtime/unbound-runtime-helpers.ts'
 import {
 	createKodyRemoteProxy,
 	createKodyProviderProxySource,
@@ -914,6 +915,60 @@ test('executor maps secret errors, formats guidance, extracts raw content, and t
 		getExecutionErrorDetails(new Error('myHelper is not defined')),
 	).toBeNull()
 
+	// A guard-less access to an imported-but-unbound optional kody:runtime
+	// helper must name the helper and the realistic remedies instead of
+	// leaving the bare TypeError.
+	const unboundStorageMessage = createUnboundRuntimeHelperMessage({
+		originalMessage: "Cannot read properties of undefined (reading 'sql')",
+		helperName: 'storage',
+		reference: 'storage.sql',
+	})
+	expect(
+		getExecutionErrorDetails(new Error(unboundStorageMessage)),
+	).toMatchObject({
+		kind: 'runtime_helper_unbound',
+		helperName: 'storage',
+		nextStep: expect.stringContaining('`storageId`'),
+		suggestedAction: { type: 'fix_code' },
+	})
+	expect(
+		getExecutionErrorDetails(new Error(unboundStorageMessage))?.nextStep,
+	).toContain('packages.invokeChecked')
+	// Wrapped transports prefix the message (for example package invocation
+	// responses); parsing stays prefix-tolerant.
+	expect(
+		getExecutionErrorDetails(
+			new Error(`[execution_failed] ${unboundStorageMessage}`),
+		),
+	).toMatchObject({
+		kind: 'runtime_helper_unbound',
+		helperName: 'storage',
+	})
+	// Helpers without a dedicated remedy get the generic guard guidance.
+	expect(
+		getExecutionErrorDetails(
+			new Error(
+				createUnboundRuntimeHelperMessage({
+					originalMessage:
+						"Cannot read properties of undefined (reading 'basic')",
+					helperName: 'secretHeaders',
+					reference: 'secretHeaders.basic',
+				}),
+			),
+		),
+	).toMatchObject({
+		kind: 'runtime_helper_unbound',
+		helperName: 'secretHeaders',
+		nextStep: expect.stringContaining('if (secretHeaders) { ... }'),
+	})
+	// The bare TypeError alone stays unhinted: without the rewrite marker the
+	// undefined value may be any user-code bug.
+	expect(
+		getExecutionErrorDetails(
+			new Error("Cannot read properties of undefined (reading 'sql')"),
+		),
+	).toBeNull()
+
 	// A disposed RPC stub in the sandbox means per-run state leaked into a
 	// cached dynamic worker; the structured hint explains how to escape the
 	// poisoned worker instead of suggesting a futile identical retry.
@@ -929,6 +984,7 @@ test('executor maps secret errors, formats guidance, extracts raw content, and t
 		capabilityError,
 		new Error(createMissingSecretMessage('missingToken')),
 		new Error('kody is not defined'),
+		new Error(unboundStorageMessage),
 	]
 	for (const error of errors) {
 		const output = formatExecutionOutput({ error } as const)

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -43,6 +43,7 @@ import {
 	assertGeneratedExecutorSourceIsBundleSafe,
 	kodyRemoteProxyFactorySource,
 } from '#mcp/kody-remote-proxy-source.ts'
+import { parseUnboundRuntimeHelperMessage } from '#worker/package-runtime/unbound-runtime-helpers.ts'
 
 type WorkerLoopbackExports = Exclude<typeof workerExports, undefined>
 
@@ -853,6 +854,15 @@ export type ExecutionErrorDetails =
 			}
 	  }
 	| {
+			kind: 'runtime_helper_unbound'
+			message: string
+			nextStep: string
+			helperName: string
+			suggestedAction: {
+				type: 'fix_code'
+			}
+	  }
+	| {
 			kind: 'entitlement_limit_exceeded'
 			message: string
 			nextStep: string
@@ -1017,6 +1027,19 @@ export function getExecutionErrorDetails(
 		}
 	}
 
+	const unboundRuntimeHelper = parseUnboundRuntimeHelperMessage(message)
+	if (unboundRuntimeHelper) {
+		return {
+			kind: 'runtime_helper_unbound',
+			message,
+			nextStep: buildUnboundRuntimeHelperNextStep(unboundRuntimeHelper),
+			helperName: unboundRuntimeHelper,
+			suggestedAction: {
+				type: 'fix_code',
+			},
+		}
+	}
+
 	const missingRuntimeExport = parseMissingRuntimeExportMessage(message)
 	if (missingRuntimeExport) {
 		return {
@@ -1035,7 +1058,7 @@ export function getExecutionErrorDetails(
 
 /**
  * Named exports of the virtual `kody:runtime` module (see
- * `buildRuntimeModuleSource` in `#worker/package-runtime/module-graph.ts`).
+ * `createRuntimeModuleSource` in `#worker/package-runtime/module-graph.ts`).
  * Referencing one without the import throws a bare `X is not defined`
  * ReferenceError that gives no hint about the required import.
  */
@@ -1055,6 +1078,35 @@ const kodyRuntimeExportNames = new Set([
 	'packages',
 	'events',
 ])
+
+/**
+ * Remedies for guard-less access to an optional `kody:runtime` export that
+ * the execution context intentionally left unbound (`undefined` / `null` so
+ * `if (storage) { ... }` guards stay falsy). The message itself is produced
+ * by `createUnboundRuntimeHelperMessage` in
+ * `#worker/package-runtime/unbound-runtime-helpers.ts`.
+ */
+const unboundRuntimeHelperNextSteps: Record<string, string> = {
+	storage:
+		"`storage` is only bound when the call provides durable storage: retry the execute call with a `storageId` to bind a storage bucket, or, if this code was imported from a saved package that owns its data, invoke that package's export dynamically (for example `packages.invokeChecked({ kodyId, exportName, params })`) so it runs in the package's own runtime context with the package's storage. Code that must also run without storage can guard with `if (storage) { ... }`.",
+	packages:
+		'`packages` is bound for authenticated ad hoc execute calls and saved-package runtime contexts; retry the call as an authenticated user, or guard with `if (packages) { ... }` where dynamic package invocation is optional.',
+	events:
+		"`events` is only bound in saved-package runtime contexts that can dispatch package events; invoke the owning package's export dynamically (for example `packages.invokeChecked`) so it runs in that context, or guard with `if (events) { ... }`.",
+	packageSecrets:
+		"`packageSecrets` is only bound in saved-package runtime contexts; invoke the owning package's export dynamically (for example `packages.invokeChecked`) so it runs with the package's mounted secrets, or guard with `if (packageSecrets) { ... }`.",
+	service:
+		'`service` is only bound in package service runs; guard with `if (service) { ... }` when the code can also run outside a service context.',
+	email:
+		'`email` is only bound for email-triggered runs; guard with `if (email) { ... }` when the code can also run outside an email context.',
+}
+
+function buildUnboundRuntimeHelperNextStep(helperName: string) {
+	return (
+		unboundRuntimeHelperNextSteps[helperName] ??
+		`The optional \`${helperName}\` export of 'kody:runtime' is not provided in this execution context; guard with a falsiness check (for example \`if (${helperName}) { ... }\`) or run the code in a context that binds it, such as invoking the owning saved package's export dynamically via \`packages.invokeChecked\`.`
+	)
+}
 
 /**
  * workerd throws this when an RPC stub outlives the execution context that

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -2431,6 +2431,48 @@ export default async function main() {
 			},
 		)
 		expect(boundResult.error).toBe(bareTypeError)
+
+		// Guard-less access inside a dynamically hydrated package module
+		// (literal dynamic `import("kody:@...")` target) must be matched too:
+		// the original bundle has no runtime import, only the hydrated module
+		// graph the sandbox actually executed does.
+		const hydrateSpy = vi
+			.spyOn(
+				await import('#worker/package-runtime/module-graph.ts'),
+				'hydrateKodyRuntimeModules',
+			)
+			.mockResolvedValue({
+				'entry.js': `export default async function main() {
+	const mod = await import('kody:@scope/skills/skill-list')
+	return await mod.default({})
+}`,
+				'.__kody_dynamic__/scope/skills/skill-list.js': `import { storage } from '../../.__kody_virtual__/runtime.js'
+export default async () => (await storage.sql('select 1')).rows`,
+			})
+		try {
+			const hydratedResult = await runBundledModuleWithRegistry(
+				env,
+				callerContext,
+				{
+					mainModule: 'entry.js',
+					modules: {
+						'entry.js': `export default async function main() {
+	const mod = await import('kody:@scope/skills/skill-list')
+	return await mod.default({})
+}`,
+					},
+				},
+				undefined,
+				{
+					skipCapabilityRegistry: true,
+				},
+			)
+			expect(hydratedResult.error).toContain(
+				'The optional kody:runtime export "storage" is not bound in this execution context',
+			)
+		} finally {
+			hydrateSpy.mockRestore()
+		}
 	} finally {
 		createExecuteExecutorSpy.mockRestore()
 	}

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -2352,6 +2352,90 @@ test('runBundledModuleWithRegistry injects OAuth helper prelude when execute hel
 	}
 })
 
+test('runBundledModuleWithRegistry rewrites guard-less unbound runtime helper errors with a bound-context hint', async () => {
+	silenceIncidentalRuntimeWarnings()
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: { userId: 'user-123' },
+	})
+	// Mirrors a saved-package export imported statically into an ad hoc
+	// execute call: the bundled module imports `storage` through the rewritten
+	// virtual runtime path and calls it without a falsiness guard.
+	const bundle = {
+		mainModule: 'entry.js',
+		modules: {
+			'entry.js': `import { storage } from './.__kody_virtual__/runtime.js'
+
+export default async function main() {
+	const result = await storage.sql('select count(*) as count from skills')
+	return result.rows
+}`,
+		},
+	}
+	const bareTypeError = "Cannot read properties of undefined (reading 'sql')"
+	const createExecuteExecutorSpy = vi
+		.spyOn(await import('#mcp/executor.ts'), 'createExecuteExecutor')
+		.mockReturnValue({
+			async execute() {
+				return {
+					result: undefined,
+					error: bareTypeError,
+					logs: [],
+				}
+			},
+		} as never)
+
+	try {
+		const unboundResult = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			bundle,
+			undefined,
+			{
+				skipCapabilityRegistry: true,
+			},
+		)
+		expect(unboundResult.error).toContain(bareTypeError)
+		expect(unboundResult.error).toContain(
+			'The optional kody:runtime export "storage" is not bound in this execution context',
+		)
+		expect(
+			mcpExecutor.getExecutionErrorDetails(unboundResult.error),
+		).toMatchObject({
+			kind: 'runtime_helper_unbound',
+			helperName: 'storage',
+			nextStep: expect.stringContaining('packages.invokeChecked'),
+		})
+
+		// With storage bound, the same TypeError is an ordinary user-code bug
+		// and keeps its bare message.
+		const boundEnv = {
+			STORAGE_RUNNER: {
+				idFromName: () => 'storage-runner-id',
+				get: () => ({}),
+			},
+		} as unknown as Env
+		const boundResult = await runBundledModuleWithRegistry(
+			boundEnv,
+			callerContext,
+			bundle,
+			undefined,
+			{
+				skipCapabilityRegistry: true,
+				storageTools: {
+					userId: 'user-123',
+					storageId: 'storage-1',
+					writable: false,
+				},
+			},
+		)
+		expect(boundResult.error).toBe(bareTypeError)
+	} finally {
+		createExecuteExecutorSpy.mockRestore()
+	}
+})
+
 test('runKodyWithRegistry expression path omits OAuth helper prelude without execute helper capabilities', async () => {
 	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -58,6 +58,10 @@ import {
 	hydrateKodyRuntimeModules,
 } from '#worker/package-runtime/module-graph.ts'
 import {
+	createUnboundRuntimeHelperMessage,
+	findUnboundRuntimeHelperAccess,
+} from '#worker/package-runtime/unbound-runtime-helpers.ts'
+import {
 	beginPackageRuntimeRun,
 	finishPackageRuntimeRun,
 	type PackageRuntimeDebugContext,
@@ -1278,6 +1282,26 @@ export async function runBundledModuleWithRegistry(
 		)
 			? createExecuteHelperPrelude()
 			: ''
+		// Mirrors the `__kodyRuntime` object below: a helper whose prelude is
+		// omitted reaches the sandbox as `undefined` / `null`, so guard-less
+		// access to it is what the unbound-helper error rewrite looks for.
+		const unboundOptionalRuntimeHelperNames = new Set<string>([
+			...(storageHelperPrelude ? [] : ['storage']),
+			...(executeHelperPrelude
+				? []
+				: [
+						'refreshAccessToken',
+						'createAuthenticatedFetch',
+						'secretHeaders',
+						'oauthClientCredentials',
+					]),
+			...(serviceHelperPrelude ? [] : ['service']),
+			...(packageSecretsHelperPrelude ? [] : ['packageSecrets']),
+			...(emailHelperPrelude ? [] : ['email']),
+			...(workflowsHelperPrelude ? [] : ['workflows']),
+			...(packagesHelperPrelude ? [] : ['packages']),
+			...(eventsHelperPrelude ? [] : ['events']),
+		])
 		const entrypointInputJson = JSON.stringify(params)
 		const entrypointInputSource =
 			entrypointInputJson === undefined ? 'undefined' : entrypointInputJson
@@ -1346,15 +1370,21 @@ ${eventsHelperPrelude ? `${eventsHelperPrelude}\n` : ''}
 				await recordPackageExportUsage('success')
 				return sanitizedResult
 			}
-			const batchMessage = await rewriteCapabilitySecretError({
-				error: result.error,
-				env,
-				callerContext,
-			})
-			const finalResult = batchMessage
+			const rewrittenMessage =
+				(await rewriteCapabilitySecretError({
+					error: result.error,
+					env,
+					callerContext,
+				})) ??
+				rewriteUnboundRuntimeHelperError({
+					error: result.error,
+					modules: bundle.modules,
+					unboundHelperNames: unboundOptionalRuntimeHelperNames,
+				})
+			const finalResult = rewrittenMessage
 				? {
 						...sanitizedResult,
-						error: secretRedactor.redactErrorMessage(batchMessage),
+						error: secretRedactor.redactErrorMessage(rewrittenMessage),
 					}
 				: sanitizedResult
 			await finishPackageRuntimeRunBestEffort({
@@ -1392,6 +1422,32 @@ ${eventsHelperPrelude ? `${eventsHelperPrelude}\n` : ''}
 		throw error
 	}
 }
+/**
+ * A guard-less access to an unbound optional `kody:runtime` helper (for
+ * example `storage.sql(...)` in an execute call without a bound `storageId`)
+ * throws a bare TypeError that gives the caller no path to self-correct.
+ * Enrich the message so `getExecutionErrorDetails` can attach a structured
+ * next step naming the unbound helper.
+ */
+function rewriteUnboundRuntimeHelperError(input: {
+	error: unknown
+	modules: WorkerLoaderModules
+	unboundHelperNames: ReadonlySet<string>
+}) {
+	const message = getErrorMessage(input.error)
+	const access = findUnboundRuntimeHelperAccess({
+		errorMessage: message,
+		modules: input.modules,
+		unboundHelperNames: input.unboundHelperNames,
+	})
+	if (!access) return null
+	return createUnboundRuntimeHelperMessage({
+		originalMessage: message,
+		helperName: access.helperName,
+		reference: access.reference,
+	})
+}
+
 async function rewriteCapabilitySecretError(input: {
 	error: unknown
 	env: Env

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -1207,6 +1207,15 @@ export async function runBundledModuleWithRegistry(
 		})
 	}
 	try {
+		// Hydration can install additional published-package sources (literal
+		// dynamic `import("kody:@...")` targets); keep a reference so error
+		// rewriting below scans the same module graph the sandbox executed.
+		const hydratedModules = await hydrateKodyRuntimeModules({
+			env,
+			baseUrl: callerContext.baseUrl,
+			userId: callerContext.user?.userId ?? '',
+			modules: bundle.modules,
+		})
 		const executor = createExecuteExecutor({
 			env,
 			exports: options?.executorExports ?? workerExports,
@@ -1216,12 +1225,7 @@ export async function runBundledModuleWithRegistry(
 				userId: callerContext.user?.userId ?? null,
 				storageContext: normalizedStorageContext,
 			},
-			modules: await hydrateKodyRuntimeModules({
-				env,
-				baseUrl: callerContext.baseUrl,
-				userId: callerContext.user?.userId ?? '',
-				modules: bundle.modules,
-			}),
+			modules: hydratedModules,
 			// Package-context runs are saved-package code; do not count their fetch hosts.
 			rawFetchHostSink: options?.packageContext
 				? undefined
@@ -1378,7 +1382,7 @@ ${eventsHelperPrelude ? `${eventsHelperPrelude}\n` : ''}
 				})) ??
 				rewriteUnboundRuntimeHelperError({
 					error: result.error,
-					modules: bundle.modules,
+					modules: hydratedModules,
 					unboundHelperNames: unboundOptionalRuntimeHelperNames,
 				})
 			const finalResult = rewrittenMessage

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -406,7 +406,7 @@ export default new Proxy(__kodyRuntimeNamedExports, {
 	return source
 }
 
-function isRuntimeModulePath(modulePath: string) {
+export function isKodyRuntimeModulePath(modulePath: string) {
 	return (
 		modulePath === runtimeModulePath ||
 		modulePath.endsWith(`/${runtimeModulePath}`)
@@ -423,14 +423,14 @@ function collectReferencedRuntimeModulePaths(
 		options?.includeDefaultRuntimePath === false ? [] : [runtimeModulePath],
 	)
 	for (const modulePath of Object.keys(modules)) {
-		if (isRuntimeModulePath(modulePath)) {
+		if (isKodyRuntimeModulePath(modulePath)) {
 			runtimePaths.add(modulePath)
 		}
 	}
 	for (const [modulePath, source] of iterateModuleSourceTexts(modules)) {
 		for (const node of collectLiteralImportNodes(source)) {
 			const resolvedPath = resolveRelativeModulePath(modulePath, node.specifier)
-			if (resolvedPath && isRuntimeModulePath(resolvedPath)) {
+			if (resolvedPath && isKodyRuntimeModulePath(resolvedPath)) {
 				runtimePaths.add(resolvedPath)
 			}
 		}
@@ -457,7 +457,7 @@ export function refreshKodyRuntimeModules(
 function stripKodyRuntimeModules(modules: WorkerLoaderModules) {
 	let stripped: WorkerLoaderModules | null = null
 	for (const modulePath of Object.keys(modules)) {
-		if (!isRuntimeModulePath(modulePath)) continue
+		if (!isKodyRuntimeModulePath(modulePath)) continue
 		stripped ??= { ...modules }
 		delete stripped[modulePath]
 	}

--- a/packages/worker/src/package-runtime/unbound-runtime-helpers.node.test.ts
+++ b/packages/worker/src/package-runtime/unbound-runtime-helpers.node.test.ts
@@ -1,0 +1,204 @@
+import { expect, test } from 'vitest'
+import {
+	createUnboundRuntimeHelperMessage,
+	findUnboundRuntimeHelperAccess,
+	parseUnboundRuntimeHelperMessage,
+} from './unbound-runtime-helpers.ts'
+
+const allOptionalHelperNames = new Set([
+	'storage',
+	'refreshAccessToken',
+	'createAuthenticatedFetch',
+	'secretHeaders',
+	'oauthClientCredentials',
+	'service',
+	'packageSecrets',
+	'email',
+	'workflows',
+	'packages',
+	'events',
+])
+
+test('findUnboundRuntimeHelperAccess matches guard-less property reads on unbound helpers', () => {
+	const modules = {
+		'entry.js': `import { storage } from 'kody:runtime'
+
+export default async function main() {
+	const result = await storage.sql('select 1')
+	return result.rows
+}`,
+	}
+
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage: "Cannot read properties of undefined (reading 'sql')",
+			modules,
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toEqual({
+		helperName: 'storage',
+		reference: 'storage.sql',
+	})
+
+	// Helpers with a `null` absent value fail the same way.
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage:
+				"TypeError: Cannot read properties of null (reading 'getMessage')",
+			modules: {
+				'entry.js': `import { email } from 'kody:runtime'
+export default async () => await email.getMessage('m-1')`,
+			},
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toEqual({
+		helperName: 'email',
+		reference: 'email.getMessage',
+	})
+})
+
+test('findUnboundRuntimeHelperAccess resolves rewritten runtime specifiers, aliases, and namespace imports', () => {
+	// Bundled saved-package modules import the virtual runtime module through
+	// a rewritten relative path and may alias the binding.
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage: "Cannot read properties of undefined (reading 'sql')",
+			modules: {
+				'entry.js': {
+					js: `import { storage as db } from '../.__kody_virtual__/runtime.js'
+export default async () => (await db.sql('select 1')).rows`,
+				},
+			},
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toEqual({
+		helperName: 'storage',
+		reference: 'storage.sql',
+	})
+
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage: "Cannot read properties of undefined (reading 'sql')",
+			modules: {
+				'entry.js': `import * as runtime from 'kody:runtime'
+export default async () => await runtime.storage.sql('select 1')`,
+			},
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toEqual({
+		helperName: 'storage',
+		reference: 'storage.sql',
+	})
+})
+
+test('findUnboundRuntimeHelperAccess matches calls to unbound function helpers', () => {
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage: 'TypeError: refreshAccessToken is not a function',
+			modules: {
+				'entry.js': `import { refreshAccessToken } from 'kody:runtime'
+export default async () => await refreshAccessToken('google-personal')`,
+			},
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toEqual({
+		helperName: 'refreshAccessToken',
+		reference: 'refreshAccessToken',
+	})
+
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage: 'runtime.oauthClientCredentials is not a function',
+			modules: {
+				'entry.js': `import * as runtime from 'kody:runtime'
+export default async () => await runtime.oauthClientCredentials({})`,
+			},
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toEqual({
+		helperName: 'oauthClientCredentials',
+		reference: 'oauthClientCredentials',
+	})
+})
+
+test('findUnboundRuntimeHelperAccess leaves unrelated errors and bound helpers unhinted', () => {
+	const modules = {
+		'entry.js': `import { storage } from 'kody:runtime'
+export default async () => (await storage.sql('select 1')).rows`,
+	}
+
+	// The helper is bound in this run, so the TypeError is a user-code bug.
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage: "Cannot read properties of undefined (reading 'sql')",
+			modules,
+			unboundHelperNames: new Set(['email']),
+		}),
+	).toBeNull()
+
+	// The failed property read does not appear on any runtime helper binding.
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage: "Cannot read properties of undefined (reading 'rows')",
+			modules,
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toBeNull()
+
+	// Optional chaining short-circuits instead of throwing, so guarded access
+	// must not be treated as the source of the TypeError.
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage: "Cannot read properties of undefined (reading 'sql')",
+			modules: {
+				'entry.js': `import { storage } from 'kody:runtime'
+export default async () => (await storage?.sql('select 1')) ?? null`,
+			},
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toBeNull()
+
+	// A same-named binding from another module is not a runtime helper.
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage: "Cannot read properties of undefined (reading 'sql')",
+			modules: {
+				'entry.js': `import { storage } from './my-storage.js'
+export default async () => (await storage.sql('select 1')).rows`,
+			},
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toBeNull()
+
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage: 'Execution timed out',
+			modules,
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toBeNull()
+})
+
+test('createUnboundRuntimeHelperMessage round-trips through parseUnboundRuntimeHelperMessage', () => {
+	const message = createUnboundRuntimeHelperMessage({
+		originalMessage: "Cannot read properties of undefined (reading 'sql')",
+		helperName: 'storage',
+		reference: 'storage.sql',
+	})
+	expect(message).toContain(
+		"Cannot read properties of undefined (reading 'sql')",
+	)
+	expect(parseUnboundRuntimeHelperMessage(message)).toBe('storage')
+
+	// Wrapped transports (for example package invocation responses) prefix
+	// the message; parsing must stay prefix-tolerant.
+	expect(
+		parseUnboundRuntimeHelperMessage(`[execution_failed] ${message}`),
+	).toBe('storage')
+
+	expect(
+		parseUnboundRuntimeHelperMessage(
+			"Cannot read properties of undefined (reading 'sql')",
+		),
+	).toBeNull()
+})

--- a/packages/worker/src/package-runtime/unbound-runtime-helpers.ts
+++ b/packages/worker/src/package-runtime/unbound-runtime-helpers.ts
@@ -37,10 +37,12 @@ export function createUnboundRuntimeHelperMessage(input: {
 	reference: string
 }) {
 	const separator = /[.!?]\s*$/.test(input.originalMessage) ? ' ' : '. '
+	// Attribution is a source-text heuristic (sandbox errors carry no stack),
+	// so name the matching access without asserting it is the thrower.
 	return (
 		`${input.originalMessage}${separator}` +
 		`The optional kody:runtime export "${input.helperName}" is not bound in this execution context, ` +
-		`so \`${input.reference}\` failed.`
+		`which likely caused \`${input.reference}\` to fail.`
 	)
 }
 

--- a/packages/worker/src/package-runtime/unbound-runtime-helpers.ts
+++ b/packages/worker/src/package-runtime/unbound-runtime-helpers.ts
@@ -1,0 +1,276 @@
+import { parseModuleSource } from '#worker/module-source.ts'
+import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
+import { isKodyRuntimeModulePath } from './module-graph.ts'
+
+/**
+ * Optional `kody:runtime` exports intentionally stay falsy (`undefined` /
+ * `null`) when the execution context does not bind them, so `if (storage)`
+ * guards keep working. The cost is that guard-less access throws a bare
+ * `Cannot read properties of undefined (reading 'sql')` / `X is not a
+ * function` TypeError with no hint that the helper simply was not bound to
+ * the call. This module matches such sandbox errors against the module
+ * graph's actual `kody:runtime` imports so the execute pipeline can attach a
+ * structured, actionable message (see `getExecutionErrorDetails` in
+ * `#mcp/executor.ts`).
+ */
+
+export type UnboundRuntimeHelperAccess = {
+	helperName: string
+	reference: string
+}
+
+type RuntimeImportBinding =
+	| { kind: 'named'; helperName: string; localName: string }
+	| { kind: 'namespace'; localName: string }
+
+const propertyReadErrorPattern =
+	/Cannot read properties of (?:undefined|null) \(reading '([^']+)'\)/
+const notAFunctionErrorPattern =
+	/(?<![\w$.])([\w$]+(?:\.[\w$]+)*) is not a function/
+
+const unboundRuntimeHelperMessagePattern =
+	/The optional kody:runtime export "([\w$]+)" is not bound in this execution context/
+
+export function createUnboundRuntimeHelperMessage(input: {
+	originalMessage: string
+	helperName: string
+	reference: string
+}) {
+	const separator = /[.!?]\s*$/.test(input.originalMessage) ? ' ' : '. '
+	return (
+		`${input.originalMessage}${separator}` +
+		`The optional kody:runtime export "${input.helperName}" is not bound in this execution context, ` +
+		`so \`${input.reference}\` failed.`
+	)
+}
+
+export function parseUnboundRuntimeHelperMessage(message: string) {
+	return unboundRuntimeHelperMessagePattern.exec(message)?.[1] ?? null
+}
+
+/**
+ * Matches a sandbox TypeError against the bundle's `kody:runtime` imports.
+ * Returns the unbound optional helper whose guard-less access most plausibly
+ * produced the error, or `null` when the error does not look like an
+ * unbound-helper access (an ordinary user-code bug keeps its bare message).
+ */
+export function findUnboundRuntimeHelperAccess(input: {
+	errorMessage: string
+	modules: WorkerLoaderModules
+	unboundHelperNames: ReadonlySet<string>
+}): UnboundRuntimeHelperAccess | null {
+	if (input.unboundHelperNames.size === 0) return null
+	const propertyName =
+		propertyReadErrorPattern.exec(input.errorMessage)?.[1] ?? null
+	const calledExpression = propertyName
+		? null
+		: (notAFunctionErrorPattern.exec(input.errorMessage)?.[1] ?? null)
+	if (propertyName == null && calledExpression == null) return null
+	for (const source of iterateModuleSourceTexts(input.modules)) {
+		const bindings = collectRuntimeImportBindings(source)
+		if (bindings.length === 0) continue
+		const match = propertyName
+			? findPropertyReadAccess({
+					source,
+					bindings,
+					propertyName,
+					unboundHelperNames: input.unboundHelperNames,
+				})
+			: findCalledHelperAccess({
+					calledExpression: calledExpression ?? '',
+					bindings,
+					unboundHelperNames: input.unboundHelperNames,
+				})
+		if (match) return match
+	}
+	return null
+}
+
+function findPropertyReadAccess(input: {
+	source: string
+	bindings: Array<RuntimeImportBinding>
+	propertyName: string
+	unboundHelperNames: ReadonlySet<string>
+}): UnboundRuntimeHelperAccess | null {
+	for (const binding of input.bindings) {
+		if (binding.kind === 'named') {
+			if (!input.unboundHelperNames.has(binding.helperName)) continue
+			if (
+				sourceContainsMemberAccess(input.source, [
+					binding.localName,
+					input.propertyName,
+				])
+			) {
+				return {
+					helperName: binding.helperName,
+					reference: `${binding.helperName}.${input.propertyName}`,
+				}
+			}
+			continue
+		}
+		for (const helperName of input.unboundHelperNames) {
+			if (
+				sourceContainsMemberAccess(input.source, [
+					binding.localName,
+					helperName,
+					input.propertyName,
+				])
+			) {
+				return {
+					helperName,
+					reference: `${helperName}.${input.propertyName}`,
+				}
+			}
+		}
+	}
+	return null
+}
+
+function findCalledHelperAccess(input: {
+	calledExpression: string
+	bindings: Array<RuntimeImportBinding>
+	unboundHelperNames: ReadonlySet<string>
+}): UnboundRuntimeHelperAccess | null {
+	const parts = input.calledExpression.split('.')
+	for (const binding of input.bindings) {
+		if (binding.kind === 'named') {
+			if (!input.unboundHelperNames.has(binding.helperName)) continue
+			if (parts.length === 1 && parts[0] === binding.localName) {
+				return {
+					helperName: binding.helperName,
+					reference: binding.helperName,
+				}
+			}
+			continue
+		}
+		if (parts.length !== 2 || parts[0] !== binding.localName) continue
+		const helperName = parts[1] ?? ''
+		if (input.unboundHelperNames.has(helperName)) {
+			return { helperName, reference: helperName }
+		}
+	}
+	return null
+}
+
+function sourceContainsMemberAccess(source: string, memberPath: Array<string>) {
+	// `?.` optional chaining short-circuits instead of throwing, so only a
+	// plain `.` access can have produced the TypeError being matched.
+	const pattern = new RegExp(
+		`(?<![\\w$.])${memberPath.map(escapeRegExp).join('\\s*\\.\\s*')}(?![\\w$])`,
+	)
+	return pattern.test(source)
+}
+
+function escapeRegExp(value: string) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function collectRuntimeImportBindings(
+	source: string,
+): Array<RuntimeImportBinding> {
+	if (!source.includes('kody:runtime') && !source.includes('runtime.js')) {
+		return []
+	}
+	let program: unknown
+	try {
+		program = parseModuleSource(source)
+	} catch {
+		return []
+	}
+	const bindings: Array<RuntimeImportBinding> = []
+	for (const node of readProgramBody(program)) {
+		if (readNodeType(node) !== 'ImportDeclaration') continue
+		if (readRecordValue(node, 'importKind') === 'type') continue
+		const specifier = readImportSourceValue(node)
+		if (specifier == null || !isRuntimeModuleSpecifier(specifier)) continue
+		for (const importSpecifier of readImportSpecifiers(node)) {
+			const localName = readIdentifierName(
+				readRecordValue(importSpecifier, 'local'),
+			)
+			if (!localName) continue
+			const specifierType = readNodeType(importSpecifier)
+			if (specifierType === 'ImportSpecifier') {
+				if (readRecordValue(importSpecifier, 'importKind') === 'type') continue
+				const importedName =
+					readIdentifierName(readRecordValue(importSpecifier, 'imported')) ??
+					readImportedStringName(readRecordValue(importSpecifier, 'imported'))
+				if (!importedName) continue
+				bindings.push({
+					kind: 'named',
+					helperName: importedName,
+					localName,
+				})
+				continue
+			}
+			if (
+				specifierType === 'ImportDefaultSpecifier' ||
+				specifierType === 'ImportNamespaceSpecifier'
+			) {
+				// The default export mirrors the named exports, so member access
+				// through either binding behaves like a namespace access.
+				bindings.push({ kind: 'namespace', localName })
+			}
+		}
+	}
+	return bindings
+}
+
+function isRuntimeModuleSpecifier(specifier: string) {
+	if (specifier === 'kody:runtime') return true
+	// Bundled module graphs rewrite `kody:runtime` to a relative path of the
+	// virtual runtime module (see `rewriteKodyImports` in `module-graph.ts`).
+	return isKodyRuntimeModulePath(specifier.replace(/^(\.\.?\/)+/, ''))
+}
+
+function* iterateModuleSourceTexts(
+	modules: WorkerLoaderModules,
+): Generator<string> {
+	for (const module of Object.values(modules)) {
+		if (typeof module === 'string') {
+			yield module
+			continue
+		}
+		if (typeof module.js === 'string') yield module.js
+		if (typeof module.cjs === 'string') yield module.cjs
+	}
+}
+
+function readProgramBody(program: unknown): Array<unknown> {
+	if (program == null || typeof program !== 'object') return []
+	const programNode = readRecordValue(program, 'program') ?? program
+	const body = readRecordValue(programNode, 'body')
+	return Array.isArray(body) ? body : []
+}
+
+function readNodeType(node: unknown) {
+	const type = readRecordValue(node, 'type')
+	return typeof type === 'string' ? type : null
+}
+
+function readRecordValue(node: unknown, key: string): unknown {
+	if (node == null || typeof node !== 'object') return undefined
+	return (node as Record<string, unknown>)[key]
+}
+
+function readImportSourceValue(node: unknown) {
+	const value = readRecordValue(readRecordValue(node, 'source'), 'value')
+	return typeof value === 'string' ? value : null
+}
+
+function readImportSpecifiers(node: unknown): Array<unknown> {
+	const specifiers = readRecordValue(node, 'specifiers')
+	return Array.isArray(specifiers) ? specifiers : []
+}
+
+function readIdentifierName(node: unknown) {
+	if (readNodeType(node) !== 'Identifier') return null
+	const name = readRecordValue(node, 'name')
+	return typeof name === 'string' ? name : null
+}
+
+function readImportedStringName(node: unknown) {
+	const nodeType = readNodeType(node)
+	if (nodeType !== 'StringLiteral' && nodeType !== 'Literal') return null
+	const value = readRecordValue(node, 'value')
+	return typeof value === 'string' ? value : null
+}


### PR DESCRIPTION
## Problem

When agent-authored code runs in the execute sandbox and touches an optional
`kody:runtime` helper that the current execution context did not bind, the
agent gets a bare, unactionable JavaScript error.

Concrete reproduction: an agent statically imports an export from a saved
package (`import skillList from 'kody:@kentcdodds/skills/skill-list'`) and calls
it in an ad hoc `execute` call **without** binding a `storageId`. The package
code does `import { storage } from 'kody:runtime'` and calls `storage.sql(...)`.
Because no storage was bound, `storage` is `undefined` (intentionally, so
`if (storage)` falsiness guards keep working), and the run fails with exactly:

    Error: [execution_failed] Cannot read properties of undefined (reading 'sql')

Nothing tells the agent that (a) storage was not bound to the call, (b) it could
pass `storageId` to execute, or (c) if the code came from a saved package that
owns its data, it should invoke the export dynamically (e.g.
`packages.invokeChecked`) so it runs in the package's own runtime context with
the package's bucket. An agent hitting this cold has no path to self-correct.

The sibling mistake — referencing `storage` without importing it at all —
already produces a structured, actionable `runtime_import_missing` hint via the
execution-error-details layer. The imported-but-unbound case got no such
treatment, and `storage` is not the only affected optional helper (`email`,
`workflows`, `packages`, `events`, `service`, `packageSecrets`, and the OAuth /
secret helpers fail the same way).

## Approach

The bare TypeError alone cannot identify the helper (its message only names the
property, e.g. `sql`), so the fix matches the error against the run's module
graph host-side — mirroring the existing `rewriteCapabilitySecretError` pattern
in `run-kody-registry.ts` — rather than changing anything in the sandbox
runtime (the falsiness-guard contract is untouched).

- **New `packages/worker/src/package-runtime/unbound-runtime-helpers.ts`** —
  `findUnboundRuntimeHelperAccess` parses each bundled module's actual
  `kody:runtime` imports (AST-based; handles the rewritten
  `.__kody_virtual__/runtime.js` specifiers, aliased named imports, and
  namespace/default imports) and matches `Cannot read properties of
  undefined/null (reading 'P')` against a plain `<binding>.P` member access, plus
  `X is not a function` for unbound function helpers such as
  `refreshAccessToken`. Optional-chained access (`storage?.sql`) is deliberately
  not matched, so guarded code that intentionally omits a helper is never
  flagged. Also exports `createUnboundRuntimeHelperMessage` /
  `parseUnboundRuntimeHelperMessage` for the message round trip.
- **`run-kody-registry.ts`** — `runBundledModuleWithRegistry` (ad hoc module
  execute *and* package invocations) computes which optional helpers are unbound
  for the run (mirroring the `__kodyRuntime` wrapper) and rewrites a matching
  sandbox error to append: `The optional kody:runtime export "storage" is not
  bound in this execution context, so `storage.sql` failed.`
- **`executor.ts`** — new `ExecutionErrorDetails` kind `runtime_helper_unbound`
  with per-helper `nextStep` remedies. For `storage` it names both realistic
  fixes: pass `storageId` to the execute call, or invoke the saved package's
  export dynamically via `packages.invokeChecked({ kodyId, exportName, params })`
  so it runs against the package's own storage — plus the `if (storage) { ... }`
  guard option. This flows through `formatExecutionOutput`, the execute tool's
  `structuredContent.errorDetails`, and package-invocation `[execution_failed]`
  responses (the parser is prefix-tolerant).
- **`module-graph.ts`** — exports the previously private runtime-path predicate
  as `isKodyRuntimeModulePath` (no behavior change).

## Tests

New/extended `*.node.test.ts` coverage, consistent with the neighboring
`runtime_import_missing` tests:

- `unbound-runtime-helpers.node.test.ts` — property-read and not-a-function
  matches, rewritten/aliased/namespace specifiers, and negative cases
  (bound helper, optional chaining, same-named non-runtime import, unrelated
  errors, message round trip).
- `executor.node.test.ts` — `getExecutionErrorDetails` returns
  `runtime_helper_unbound` with the `storageId` / `packages.invokeChecked`
  remedies, is prefix-tolerant, gives generic guard guidance for helpers without
  a dedicated remedy, and leaves the bare TypeError unhinted.
- `run-kody-registry.node.test.ts` — end-to-end: the repro's error gets the hint
  when storage is unbound, and stays a bare user-code error when storage *is*
  bound.

Local gate: `npm run typecheck`, `npm run lint` (0 errors),
`npm run format:check`, and `npm run test` (313 files / 980 tests) all pass,
re-verified after rebasing onto current `main` (`044a22bf`). The
Playwright/MCP E2E halves of `npm run validate` were not run locally (untouched
surfaces); CI covers them.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `044a22bf` · **Head:** `48d50093`

**Classification:** extends — enriches the execute error-details contract with a
new `runtime_helper_unbound` kind; no new primitive added.

### Primitives touched

| Primitive             | Group    | Impact                                                                          |
| --------------------- | -------- | ------------------------------------------------------------------------------- |
| `capabilities-execute`| runtime  | extends — rewrites unbound-helper sandbox errors before returning               |
| `package-runtime`     | runtime  | extends — new unbound-helper detector + exported `isKodyRuntimeModulePath`      |
| `mcp-server`          | surfaces | extends — new `runtime_helper_unbound` execution-error-details kind + next step |

### System map

An unbound optional `kody:runtime` helper access fails in the sandbox; the
execute runtime matches it against the bundled module graph and rewrites the
message so the MCP error-details layer can attach a structured next step.

**Legend:** green = composes · amber = extended by this PR · red = new primitive
· gray = context.

```mermaid
flowchart LR
	packageRuntime["package-runtime<br/>Package runtime"]:::extended
	capabilitiesExecute["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::extended
	packageRuntime -->|"findUnboundRuntimeHelperAccess over bundle modules"| capabilitiesExecute
	capabilitiesExecute -->|"rewritten error message"| mcpServer
	mcpServer -->|"runtime_helper_unbound next step in errorDetails"| capabilitiesExecute
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

Same failing execute call (`storage.sql(...)` with no bound `storageId`):

- **Before:** `Error: [execution_failed] Cannot read properties of undefined (reading 'sql')`
- **After:** same message plus `The optional kody:runtime export "storage" is not bound in this execution context, so `storage.sql` failed.`, and `errorDetails.kind = "runtime_helper_unbound"` with a `nextStep` naming the `storageId` bind and `packages.invokeChecked` remedies.

### Invariants

No per-user isolation or storage-scoping invariants touched: detection is a
pure host-side string/AST match over the run's own bundle; no cross-user data is
read or written.

</details>

<!-- system-recap:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Host-side error enrichment only; no sandbox binding contract changes, auth, or cross-user data access. Heuristic AST matching could occasionally mis-attribute an error, but false positives are constrained to unbound-helper sets and known TypeError shapes.
> 
> **Overview**
> When execute runs touch an optional **`kody:runtime`** helper that was not bound for the call (e.g. `storage.sql` without `storageId`), failures used to surface only a bare TypeError. This PR **detects those cases host-side** by matching the sandbox error against the hydrated module graph’s `kody:runtime` imports, then **rewrites the error** before it is returned.
> 
> **`unbound-runtime-helpers.ts`** adds AST-based matching for property-read and “not a function” errors (rewritten virtual runtime paths, aliases, namespace imports; optional chaining is excluded). **`runBundledModuleWithRegistry`** tracks which optional helpers are unbound for the run and applies the rewrite after capability-secret rewriting, including modules added by hydration.
> 
> **`getExecutionErrorDetails`** gains **`runtime_helper_unbound`** with per-helper **`nextStep`** text (notably `storageId` vs `packages.invokeChecked` for `storage`). Bare TypeErrors without the rewrite marker stay unhinted. **`isKodyRuntimeModulePath`** is exported from `module-graph.ts` for specifier detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b104b3738084e987de38d5d3f917a2f25e406f34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added structured, actionable execution error details for cases where optional `kody:runtime` helpers are unavailable in the current context.
  - Errors now identify the specific unbound helper (with `helperName`) and include a recommended next step to fix the code.
  - Diagnostics remain compatible with wrapped/prefixed execution error formats.

- **Bug Fixes**
  - Improved detection of unguarded access to unavailable runtime helpers and generation of accurate guidance only when applicable.
  - Preserved the underlying original error for easier troubleshooting when helpers are properly bound.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->