### PR TITLE
Extend package git remote token default TTL to 4 hours

### DIFF
--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -492,7 +492,7 @@ called package was republished.
 Choose the narrowest token scope that fits the task. Use `read` for inspection
 or local diffing, and `write` only when the git client needs to push. Keep TTLs
 short for autonomous agents and CI-style helpers; the tool accepts 60 seconds to
-24 hours and defaults to 30 minutes.
+24 hours and defaults to 4 hours.
 
 ## Search and discovery
 

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
@@ -190,7 +190,7 @@ test('get_git_remote returns scoped artifact remotes and rejects invalid input',
 		{ kody_id: 'unleashed-wifi', scope: 'read' },
 		createContext(),
 	)
-	expect(readSetup.createToken).toHaveBeenCalledWith('read', 3600)
+	expect(readSetup.createToken).toHaveBeenCalledWith('read', 14_400)
 	expect(readResult.scope).toBe('read')
 
 	resetMocks()

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
@@ -33,7 +33,7 @@ const getGitRemoteInputSchema = z.object({
 			'Package description used when `create: true` registers a new stub package. Ignored for existing packages.',
 		),
 	scope: z.enum(['read', 'write']).default('write'),
-	ttl_seconds: z.number().int().min(60).max(86_400).default(3600),
+	ttl_seconds: z.number().int().min(60).max(86_400).default(14_400),
 })
 
 const outputSchema = markSecretInputFields(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Raise the default `ttl_seconds` for `package_get_git_remote` from 1 hour (`3600`) to 4 hours (`14_400`) so long-running coding agents are less likely to see clone/push credentials expire mid-session.
- Callers can still override within the existing range (60s–24h).
- Align end-user docs (previously said 30 minutes) with the new default.

## Test plan

- [x] Unit tests for `package_get_git_remote` (default TTL assertion updated)
- [ ] CI green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `044a22bf` · **Head:** `6dcbbf23`

**Classification:** extends — changes the default credential lifetime for the package git clone/push lane without adding primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — `package_get_git_remote` default `ttl_seconds` 1h → 4h |

### System map

Agents mint a short-lived Artifacts token via `package_get_git_remote`, then clone/push and publish; only the default TTL changes.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	artifacts["cloudflare-artifacts<br/>Artifacts git remotes"]:::untouched
	savedPackages -->|"createToken ttl default 14_400s"| artifacts
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Field | Before | After |
| --- | --- | --- |
| `package_get_git_remote` `ttl_seconds` default | `3600` (1 hour) | `14_400` (4 hours) |
| Allowed range | 60–86_400 | unchanged |
| Docs stated default | 30 minutes (stale) | 4 hours |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-546caf24-a742-4f3a-b60c-52e08b77ad1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-546caf24-a742-4f3a-b60c-52e08b77ad1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated saved package git remote creation to default to a 4-hour token lifetime, while still accepting TTL values from 60 seconds to 24 hours.
- **Documentation**
  - Updated usage guidance to reflect the new 4-hour default TTL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->