### PR TITLE
Match inlined runtime helper declarations in unbound-helper detection

### DIFF
--- a/packages/worker/src/mcp/unbound-runtime-helpers-bundle.workers.test.ts
+++ b/packages/worker/src/mcp/unbound-runtime-helpers-bundle.workers.test.ts
@@ -1,0 +1,59 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
+import { buildKodyModuleBundle } from '#worker/package-runtime/module-graph.ts'
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
+
+/**
+ * Regression coverage for the unbound-helper hint against a REAL
+ * `buildKodyModuleBundle` bundle rather than hand-written modules: the
+ * bundler inlines the virtual `kody:runtime` module into the entry module,
+ * so no `kody:runtime` import statements survive and helpers appear as
+ * `var storage = __kodyOptionalRuntimeObjectExport("storage", void 0)`
+ * declarations. The detector must match that inlined shape, or the hint
+ * only ever fires in synthetic tests (as shipped in the first iteration).
+ */
+test(
+	'guard-less unbound storage access in a real bundle gets the bound-context hint',
+	{ timeout: 60_000 },
+	async () => {
+		silenceIncidentalRuntimeWarnings()
+		const callerContext = createMcpCallerContext({
+			baseUrl: 'https://kody.dev',
+			user: {
+				userId: 'user-unbound-repro',
+				email: 'repro@example.com',
+				displayName: 'Repro',
+			},
+		})
+		const bundle = await buildKodyModuleBundle({
+			env,
+			baseUrl: 'https://kody.dev',
+			userId: 'user-unbound-repro',
+			sourceFiles: {
+				'entry.ts': [
+					"import { storage } from 'kody:runtime'",
+					'export default async function main() {',
+					"\tconst result = await storage.sql('select 1')",
+					'\treturn result.rows',
+					'}',
+				].join('\n'),
+			},
+			entryPoint: 'entry.ts',
+		})
+		const result = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			bundle,
+			undefined,
+			{ skipCapabilityRegistry: true },
+		)
+		expect(result.error).toContain(
+			"Cannot read properties of undefined (reading 'sql')",
+		)
+		expect(result.error).toContain(
+			'The optional kody:runtime export "storage" is not bound in this execution context',
+		)
+	},
+)

--- a/packages/worker/src/package-runtime/unbound-runtime-helpers.node.test.ts
+++ b/packages/worker/src/package-runtime/unbound-runtime-helpers.node.test.ts
@@ -91,6 +91,51 @@ export default async () => await runtime.storage.sql('select 1')`,
 	})
 })
 
+test('findUnboundRuntimeHelperAccess matches inlined runtime helper declarations', () => {
+	// Real bundles inline the virtual runtime module into the entry module,
+	// so helpers are top-level declarations rather than import bindings.
+	const inlinedSource = `var storage = __kodyOptionalRuntimeObjectExport("storage", void 0);
+var refreshAccessToken = __kodyOptionalRuntimeFunctionExport("refreshAccessToken");
+async function main() {
+	const result = await storage.sql("select 1");
+	return result.rows;
+}`
+
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage: "Cannot read properties of undefined (reading 'sql')",
+			modules: { 'bundle.js': inlinedSource },
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toEqual({
+		helperName: 'storage',
+		reference: 'storage.sql',
+	})
+
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage: 'refreshAccessToken is not a function',
+			modules: { 'bundle.js': inlinedSource },
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toEqual({
+		helperName: 'refreshAccessToken',
+		reference: 'refreshAccessToken',
+	})
+
+	// A declaration initialized by an unrelated factory is not a helper.
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage: "Cannot read properties of undefined (reading 'sql')",
+			modules: {
+				'bundle.js': `var storage = createMyStorage("storage");
+async function main() { return (await storage.sql("select 1")).rows }`,
+			},
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toBeNull()
+})
+
 test('findUnboundRuntimeHelperAccess matches calls to unbound function helpers', () => {
 	expect(
 		findUnboundRuntimeHelperAccess({

--- a/packages/worker/src/package-runtime/unbound-runtime-helpers.ts
+++ b/packages/worker/src/package-runtime/unbound-runtime-helpers.ts
@@ -170,7 +170,11 @@ function escapeRegExp(value: string) {
 function collectRuntimeImportBindings(
 	source: string,
 ): Array<RuntimeImportBinding> {
-	if (!source.includes('kody:runtime') && !source.includes('runtime.js')) {
+	if (
+		!source.includes('kody:runtime') &&
+		!source.includes('runtime.js') &&
+		!source.includes('__kodyOptionalRuntime')
+	) {
 		return []
 	}
 	let program: unknown
@@ -181,6 +185,7 @@ function collectRuntimeImportBindings(
 	}
 	const bindings: Array<RuntimeImportBinding> = []
 	for (const node of readProgramBody(program)) {
+		collectInlinedRuntimeBindings(node, bindings)
 		if (readNodeType(node) !== 'ImportDeclaration') continue
 		if (readRecordValue(node, 'importKind') === 'type') continue
 		const specifier = readImportSourceValue(node)
@@ -215,6 +220,43 @@ function collectRuntimeImportBindings(
 		}
 	}
 	return bindings
+}
+
+const inlinedRuntimeExportFactoryNames = new Set([
+	'__kodyOptionalRuntimeObjectExport',
+	'__kodyOptionalRuntimeFunctionExport',
+])
+
+/**
+ * Bundlers can inline the virtual runtime module into the entry module, so
+ * helpers appear as plain top-level declarations instead of imports:
+ * `var storage = __kodyOptionalRuntimeObjectExport("storage", void 0);`.
+ * Collect those as named bindings so inlined bundles match too.
+ */
+function collectInlinedRuntimeBindings(
+	node: unknown,
+	bindings: Array<RuntimeImportBinding>,
+) {
+	if (readNodeType(node) !== 'VariableDeclaration') return
+	const declarations = readRecordValue(node, 'declarations')
+	if (!Array.isArray(declarations)) return
+	for (const declaration of declarations) {
+		if (readNodeType(declaration) !== 'VariableDeclarator') continue
+		const localName = readIdentifierName(readRecordValue(declaration, 'id'))
+		if (!localName) continue
+		const init = readRecordValue(declaration, 'init')
+		if (readNodeType(init) !== 'CallExpression') continue
+		const calleeName = readIdentifierName(readRecordValue(init, 'callee'))
+		if (!calleeName || !inlinedRuntimeExportFactoryNames.has(calleeName)) {
+			continue
+		}
+		const callArguments = readRecordValue(init, 'arguments')
+		const helperName = Array.isArray(callArguments)
+			? readImportedStringName(callArguments[0])
+			: null
+		if (!helperName) continue
+		bindings.push({ kind: 'named', helperName, localName })
+	}
 }
 
 function isRuntimeModuleSpecifier(specifier: string) {


### PR DESCRIPTION
## Problem

The unbound-helper error hint shipped in #812 never fired in production. Re-running the original repro (a static `kody:@kentcdodds/skills/skill-list` import calling `storage.sql(...)` in an execute call with no bound `storageId`) after the deploy still returned the bare:

    Error: Cannot read properties of undefined (reading 'sql')

Root cause: `findUnboundRuntimeHelperAccess` only matched `kody:runtime` **import statements** (including rewritten virtual-module specifiers), but real `buildKodyModuleBundle` output inlines the virtual runtime module into the single bundled entry module. No import statements survive; helpers appear as top-level declarations:

```js
var storage = __kodyOptionalRuntimeObjectExport("storage", void 0);
```

The #812 tests all used hand-written module maps with intact import statements, so the gap was invisible to them.

## Fix

- `collectRuntimeImportBindings` now also collects top-level `var <local> = __kodyOptionalRuntimeObjectExport("<helper>", ...)` / `__kodyOptionalRuntimeFunctionExport("<helper>")` declarations as named bindings (AST-based, unrelated factory names are ignored), and the cheap pre-scan includes the `__kodyOptionalRuntime` marker.
- New `unbound-runtime-helpers-bundle.workers.test.ts` runs the original repro through a **real** `buildKodyModuleBundle` bundle end-to-end and asserts the hint appears, so synthetic module shapes can no longer mask this class of gap.
- New node-unit cases cover the inlined declaration shape (property read, not-a-function, and a negative case for unrelated factories).

## Tests

- `npm run typecheck` — pass
- Touched suites (`unbound-runtime-helpers.node.test.ts`, `unbound-runtime-helpers-bundle.workers.test.ts`, `run-kody-registry.node.test.ts`, `executor.node.test.ts`) — 4 files / 37 tests pass
- Full pre-push gate (unit + e2e) ran on push — pass

Made with [Cursor](https://cursor.com)