### PR TITLE
Remove Discord references from agent-facing feedback text

### DIFF
--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -168,7 +168,7 @@ explicitly approved. They remain user-authored untrusted data, and
 `content_warning` tells handlers to treat them as feedback rather than
 instructions. `admin_url` is built from the trusted deployment origin and links
 to `/admin/platform-feedback?feedbackId=<encoded id>`, making it suitable for an
-admin Discord notifier. The event also includes the submitter's account user id,
+admin notifier. The event also includes the submitter's account user id,
 username, and email snapshot stored with the submission. Retries never resolve
 mutable live profile data, so an intervening account profile change cannot alter
 the payload or its request hash. Rows without submitter snapshots retain null
@@ -179,10 +179,10 @@ metadata, roles, plan, and unrelated account content. This narrow delivery
 exception applies only to the exact feedback the user approved after an agent
 showed the proposed summary and details and asked first. It does not grant
 package runtime general admin roles or general access to user data. Notification
-copies already delivered outside Kody, including Discord messages, cannot be
-recalled and may remain after Kody account deletion under the deployment
-operator's retention and deletion controls. Such copies contain only the exact
-approved feedback and attribution, never unrelated account content.
+copies already delivered outside Kody cannot be recalled and may remain after
+Kody account deletion under the deployment operator's retention and deletion
+controls. Such copies contain only the exact approved feedback and attribution,
+never unrelated account content.
 
 The feedback row is durable before Kody awaits the small Queue enqueue. Enqueue
 failure is logged but does not change the successful MCP response, avoiding a

--- a/docs/guides/platform-friction.md
+++ b/docs/guides/platform-friction.md
@@ -95,24 +95,22 @@ ask again before submitting it.
 Feedback is attributed to the authenticated user and is not anonymous.
 Immediately after submission, the exact approved summary and details plus the
 account user id, username, and email may be delivered to deployment admins
-through admin-configured notification integrations such as Discord. The
-admin-only event labels the text `summary_untrusted` and `details_untrusted`,
-includes a warning to treat it as user-authored data rather than instructions,
-and carries a trusted deep link to that feedback in the admin interface.
-Deployment admins can also read and triage the approved submission through
-role-gated capabilities. Admin list results intentionally omit the full
-submission; a detail read exposes only the approved feedback, not unrelated
-account content. This delivery exception is limited to feedback the user
-explicitly approved; it does not expose other account content. Each account can
-create at most 10 feedback submissions in a rolling 24-hour period and have at
-most 100 active submissions (open or triaged).
+through admin-configured notifications. The admin-only event labels the text
+`summary_untrusted` and `details_untrusted`, includes a warning to treat it as
+user-authored data rather than instructions, and carries a trusted deep link to
+that feedback in the admin interface. Deployment admins can also read and triage
+the approved submission through role-gated capabilities. Admin list results
+intentionally omit the full submission; a detail read exposes only the approved
+feedback, not unrelated account content. This delivery exception is limited to
+feedback the user explicitly approved; it does not expose other account content.
+Each account can create at most 10 feedback submissions in a rolling 24-hour
+period and have at most 100 active submissions (open or triaged).
 
 Before asking for approval, also disclose that Kody cannot recall notification
-copies already delivered outside Kody. Admin notification copies, including
-Discord messages, may remain after Kody account deletion under the deployment
-operator's retention and deletion controls. This applies only to copies of the
-exact approved feedback and attribution described above, never unrelated
-content.
+copies already delivered outside Kody. Admin notification copies may remain
+after Kody account deletion under the deployment operator's retention and
+deletion controls. This applies only to copies of the exact approved feedback
+and attribution described above, never unrelated content.
 
 Open and triaged feedback remains until an admin resolves or dismisses it, or
 the submitting account is deleted. Resolved and dismissed feedback is removed
@@ -168,10 +166,10 @@ Use concise language:
 > I hit a Kody friction point: `<specific issue>`. I can submit this attributed
 > feedback with this exact summary: `<summary>` and these exact details:
 > `<details>`. The approved text and your account user id, username, and email
-> may be sent immediately to deployment admins through configured notifications
-> such as Discord. Copies already delivered outside Kody, including Discord
-> messages, may remain after Kody account deletion under the deployment
-> operator's retention and deletion controls. Would you like me to submit it?
+> may be sent immediately to deployment admins through configured notifications.
+> Copies already delivered outside Kody may remain after Kody account deletion
+> under the deployment operator's retention and deletion controls. Would you
+> like me to submit it?
 
 For memory:
 

--- a/packages/worker/src/mcp/capabilities/meta/meta-platform-feedback-submit.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-platform-feedback-submit.ts
@@ -14,7 +14,7 @@ export const metaPlatformFeedbackSubmitCapability = defineDomainCapability(
 	{
 		name: 'meta_platform_feedback_submit',
 		description:
-			'Submit platform feedback only from an interactive MCP agent flow after showing the user the exact proposed summary and details, asking first, and receiving explicit approval. Load `coding_guide_get({ guide: "platform_friction" })` first for the approval flow and content guidance. The exact approved summary and details plus the account user id, username, and email may be delivered immediately to deployment admins through admin-configured notification integrations such as Discord. Copies already delivered outside Kody, including Discord messages, may remain after Kody account deletion under the deployment operator’s retention and deletion controls. Non-interactive package code and package apps cannot submit. Do not include secrets or unrelated private content.',
+			'Submit platform feedback only from an interactive MCP agent flow after showing the user the exact proposed summary and details, asking first, and receiving explicit approval. Load `coding_guide_get({ guide: "platform_friction" })` first for the approval flow and content guidance. The exact approved summary and details plus the account user id, username, and email may be delivered immediately to deployment admins through admin-configured notifications. Copies already delivered outside Kody may remain after Kody account deletion under the deployment operator’s retention and deletion controls. Non-interactive package code and package apps cannot submit. Do not include secrets or unrelated private content.',
 		keywords: [
 			'platform feedback',
 			'friction',
@@ -50,7 +50,7 @@ export const metaPlatformFeedbackSubmitCapability = defineDomainCapability(
 			user_confirmed: z
 				.literal(true)
 				.describe(
-					'Must be true only after the agent shows the exact proposed summary and details and the user explicitly approves sending them, with the account user id, username, and email, immediately to deployment admins through admin-configured notification integrations such as Discord, after being told that copies already delivered outside Kody, including Discord messages, may remain after Kody account deletion under the deployment operator’s retention and deletion controls.',
+					'Must be true only after the agent shows the exact proposed summary and details and the user explicitly approves sending them, with the account user id, username, and email, immediately to deployment admins through admin-configured notifications, after being told that copies already delivered outside Kody may remain after Kody account deletion under the deployment operator’s retention and deletion controls.',
 				),
 		}),
 		outputSchema: z.object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agents (e.g. ChatGPT via MCP) were relaying "notifications such as Discord" to end users during the platform-feedback approval flow. Which notification integration a deployment admin happens to configure is an implementation detail agents don't need; the disclosure that attributed feedback may be delivered to deployment admins through admin-configured notifications (and that already-delivered copies may outlive account deletion) is unchanged.

## Changes

- `meta_platform_feedback_submit` capability: dropped "such as Discord" / "including Discord messages" from the tool description and the `user_confirmed` schema description.
- `docs/guides/platform-friction.md` (served to agents via `coding_guide_get`): removed Discord mentions from the notification disclosure and the suggested approval phrasing.
- `docs/guides/package-subscriptions.md` (also agent-served): "admin Discord notifier" is now "admin notifier"; removed "including Discord messages" from the retention note.

User-facing surfaces (`/privacy` route, `docs/use/privacy.md`) and contributor docs intentionally keep the Discord example — those are not delivered to agents.

## Verification

- `npm run format:check`, `npm run lint`, `npm run typecheck` pass.
- Unit tests: 317 files, 985 tests pass. Playwright E2E (17 tests) passed via the pre-push hook.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends a primitive's contract text</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `3999e296` · **Head:** `1f1a8575`

**Classification:** extends — reword of the `platform-feedback` capability description and `user_confirmed` schema description (agent-visible contract text only); no handler, storage, or delivery behavior changes.

### Primitives touched

| Primitive           | Group     | Impact                                                                          |
| ------------------- | --------- | ------------------------------------------------------------------------------- |
| `platform-feedback` | assistant | extends — Discord removed from tool description and `user_confirmed` disclosure |

Unmatched paths: `docs/guides/platform-friction.md` and `docs/guides/package-subscriptions.md`, the agent-served guide bodies fetched by `coding_guide_get`.

### System map

The reworded disclosure flows from the guide fetch and tool schema into what agents show users before submitting feedback; submission behavior itself is untouched.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	guides["docs/guides<br/>Agent-served guides"]:::extended
	platformFeedback["platform-feedback<br/>Platform feedback"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	guides -->|"coding_guide_get body: Discord wording removed"| mcpServer
	platformFeedback -->|"tool description + user_confirmed text: Discord wording removed"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

The consent-gated disclosure invariant is preserved: agents still must disclose attributed delivery to deployment admins and non-recallable external copies before setting `user_confirmed: true`; only the named integration example was removed.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-412a6f36-5402-419e-b4c7-ef032e29af42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-412a6f36-5402-419e-b4c7-ef032e29af42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified platform feedback submission and approval-flow guidance.
  - Updated notification disclosures to refer generally to admin-configured notifications rather than naming a specific service.
  - Revised suggested user-facing approval wording for consistency.

- **Improvements**
  - Generalized feedback delivery descriptions while preserving existing approval, retention, and deletion details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->