### PR TITLE
Hint popular agent packages in MCP server instructions

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -22,15 +22,15 @@ One schema covers every chokepoint. It is defined in
 
 ```ts
 type UsageEvent = {
-  userId: string; // required; owning user
-  eventType: UsageEventType; // see the metric table below
-  entityId?: string | null; // metered entity id when one exists
-  durationMs?: number | null; // wall-clock duration of the metered unit
-  cpuMs?: number | null; // CPU time, only when the platform exposes it
-  bytes?: number | null; // bytes moved/stored when meaningful
-  outcome: "success" | "error";
-  timestamp?: string; // ISO 8601; defaults to time of recording
-};
+	userId: string // required; owning user
+	eventType: UsageEventType // see the metric table below
+	entityId?: string | null // metered entity id when one exists
+	durationMs?: number | null // wall-clock duration of the metered unit
+	cpuMs?: number | null // CPU time, only when the platform exposes it
+	bytes?: number | null // bytes moved/stored when meaningful
+	outcome: 'success' | 'error'
+	timestamp?: string // ISO 8601; defaults to time of recording
+}
 ```
 
 `eventType` is a closed union. Add new members to `UsageEventType` in
@@ -127,8 +127,8 @@ conversations** in which a signed-in user’s agents used a saved package via MC
 - Read path: count conversations with `last_used_at` in the last 30 days, join
   `saved_packages` for `kody_id` + description, top 8 for
   `buildMcpServerInstructions`. Cold start (no rows) omits the section. List
-  failures (missing table, transient D1 errors) return `[]` so MCP init stays
-  up during migration rollout.
+  failures (missing table, transient D1 errors) return `[]` so MCP init stays up
+  during migration rollout.
 - Writes are best-effort and never throw into the invoke path (same spirit as
   `recordUsage`). Do **not** widen `usage_rollups` for conversation cardinality.
 
@@ -137,15 +137,15 @@ Helpers live in `packages/worker/src/usage/agent-package-conversation-uses.ts`.
 ## Helper contract
 
 ```ts
-import { recordUsage } from "#worker/usage/record-usage.ts";
+import { recordUsage } from '#worker/usage/record-usage.ts'
 
 await recordUsage(env, {
-  userId,
-  eventType: "job_run",
-  entityId: job.id,
-  durationMs,
-  outcome: execution.ok ? "success" : "error",
-});
+	userId,
+	eventType: 'job_run',
+	entityId: job.id,
+	durationMs,
+	outcome: execution.ok ? 'success' : 'error',
+})
 ```
 
 Guarantees and rules:
@@ -179,23 +179,23 @@ Guarantees and rules:
    id, the start time, and the outcome. Wrap it:
 
    ```ts
-   const startedAtMs = Date.now();
-   let outcome: "success" | "error" = "success";
+   const startedAtMs = Date.now()
+   let outcome: 'success' | 'error' = 'success'
    try {
-     // existing work
+   	// existing work
    } catch (error) {
-     outcome = "error";
-     throw error;
+   	outcome = 'error'
+   	throw error
    } finally {
-     if (userId) {
-       await recordUsage(env, {
-         userId,
-         eventType: "my_metric",
-         entityId,
-         durationMs: Date.now() - startedAtMs,
-         outcome,
-       });
-     }
+   	if (userId) {
+   		await recordUsage(env, {
+   			userId,
+   			eventType: 'my_metric',
+   			entityId,
+   			durationMs: Date.now() - startedAtMs,
+   			outcome,
+   		})
+   	}
    }
    ```
 
@@ -210,10 +210,10 @@ Guarantees and rules:
 6. **Test it.** In `*.node.test.ts`, spy on the helper:
 
    ```ts
-   const usageModule = await import("#worker/usage/record-usage.ts");
+   const usageModule = await import('#worker/usage/record-usage.ts')
    const recordUsageSpy = vi
-     .spyOn(usageModule, "recordUsage")
-     .mockResolvedValue(undefined);
+   	.spyOn(usageModule, 'recordUsage')
+   	.mockResolvedValue(undefined)
    ```
 
    Assert one call per metered unit with the expected `userId`, `eventType`,

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -121,10 +121,14 @@ conversations** in which a signed-in user’s agents used a saved package via MC
 `kody:@…` deps attributed to that execute call’s `conversationId`).
 
 - Key: `(user_id, package_id, conversation_id)` — upsert updates `last_used_at`;
-  the same package in the same conversation counts once.
+  the same package in the same conversation counts once. Stored
+  `conversation_id` values are SHA-256 hex digests of the MCP conversation id
+  (cardinality only; not reversible to the raw id).
 - Read path: count conversations with `last_used_at` in the last 30 days, join
   `saved_packages` for `kody_id` + description, top 8 for
-  `buildMcpServerInstructions`. Cold start (no rows) omits the section.
+  `buildMcpServerInstructions`. Cold start (no rows) omits the section. List
+  failures (missing table, transient D1 errors) return `[]` so MCP init stays
+  up during migration rollout.
 - Writes are best-effort and never throw into the invoke path (same spirit as
   `recordUsage`). Do **not** widen `usage_rollups` for conversation cardinality.
 

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -22,15 +22,15 @@ One schema covers every chokepoint. It is defined in
 
 ```ts
 type UsageEvent = {
-	userId: string // required; owning user
-	eventType: UsageEventType // see the metric table below
-	entityId?: string | null // metered entity id when one exists
-	durationMs?: number | null // wall-clock duration of the metered unit
-	cpuMs?: number | null // CPU time, only when the platform exposes it
-	bytes?: number | null // bytes moved/stored when meaningful
-	outcome: 'success' | 'error'
-	timestamp?: string // ISO 8601; defaults to time of recording
-}
+  userId: string; // required; owning user
+  eventType: UsageEventType; // see the metric table below
+  entityId?: string | null; // metered entity id when one exists
+  durationMs?: number | null; // wall-clock duration of the metered unit
+  cpuMs?: number | null; // CPU time, only when the platform exposes it
+  bytes?: number | null; // bytes moved/stored when meaningful
+  outcome: "success" | "error";
+  timestamp?: string; // ISO 8601; defaults to time of recording
+};
 ```
 
 `eventType` is a closed union. Add new members to `UsageEventType` in
@@ -137,15 +137,15 @@ Helpers live in `packages/worker/src/usage/agent-package-conversation-uses.ts`.
 ## Helper contract
 
 ```ts
-import { recordUsage } from '#worker/usage/record-usage.ts'
+import { recordUsage } from "#worker/usage/record-usage.ts";
 
 await recordUsage(env, {
-	userId,
-	eventType: 'job_run',
-	entityId: job.id,
-	durationMs,
-	outcome: execution.ok ? 'success' : 'error',
-})
+  userId,
+  eventType: "job_run",
+  entityId: job.id,
+  durationMs,
+  outcome: execution.ok ? "success" : "error",
+});
 ```
 
 Guarantees and rules:
@@ -179,23 +179,23 @@ Guarantees and rules:
    id, the start time, and the outcome. Wrap it:
 
    ```ts
-   const startedAtMs = Date.now()
-   let outcome: 'success' | 'error' = 'success'
+   const startedAtMs = Date.now();
+   let outcome: "success" | "error" = "success";
    try {
-   	// existing work
+     // existing work
    } catch (error) {
-   	outcome = 'error'
-   	throw error
+     outcome = "error";
+     throw error;
    } finally {
-   	if (userId) {
-   		await recordUsage(env, {
-   			userId,
-   			eventType: 'my_metric',
-   			entityId,
-   			durationMs: Date.now() - startedAtMs,
-   			outcome,
-   		})
-   	}
+     if (userId) {
+       await recordUsage(env, {
+         userId,
+         eventType: "my_metric",
+         entityId,
+         durationMs: Date.now() - startedAtMs,
+         outcome,
+       });
+     }
    }
    ```
 
@@ -210,10 +210,10 @@ Guarantees and rules:
 6. **Test it.** In `*.node.test.ts`, spy on the helper:
 
    ```ts
-   const usageModule = await import('#worker/usage/record-usage.ts')
+   const usageModule = await import("#worker/usage/record-usage.ts");
    const recordUsageSpy = vi
-   	.spyOn(usageModule, 'recordUsage')
-   	.mockResolvedValue(undefined)
+     .spyOn(usageModule, "recordUsage")
+     .mockResolvedValue(undefined);
    ```
 
    Assert one call per metered unit with the expected `userId`, `eventType`,

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -112,6 +112,24 @@ each chokepoint records exactly one event per metered unit, so sums are safe.
    The rollup is the cheap read path a future quota/entitlements layer will
    consume: one point lookup per user, metric, and month.
 
+## Agent package popularity (MCP instructions hint)
+
+Separate from `usage_rollups`, D1 table `agent_package_conversation_uses`
+(migration `0073-agent-package-conversation-uses.sql`) tracks **distinct
+conversations** in which a signed-in user’s agents used a saved package via MCP
+`execute` (`packages.invoke*` with execute provenance, plus static/dynamic
+`kody:@…` deps attributed to that execute call’s `conversationId`).
+
+- Key: `(user_id, package_id, conversation_id)` — upsert updates `last_used_at`;
+  the same package in the same conversation counts once.
+- Read path: count conversations with `last_used_at` in the last 30 days, join
+  `saved_packages` for `kody_id` + description, top 8 for
+  `buildMcpServerInstructions`. Cold start (no rows) omits the section.
+- Writes are best-effort and never throw into the invoke path (same spirit as
+  `recordUsage`). Do **not** widen `usage_rollups` for conversation cardinality.
+
+Helpers live in `packages/worker/src/usage/agent-package-conversation-uses.ts`.
+
 ## Helper contract
 
 ```ts

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -246,8 +246,12 @@ Users can read or replace their own MCP server instruction overlay with
 **`meta_set_mcp_server_instructions`**.
 
 This overlay is appended to Kody's built-in server instructions for that user.
-Pass an empty string to clear it. Changes apply to new MCP sessions, so
-reconnect the MCP client if the host caches server instructions.
+Use it for preferences and workflow notes only — not for maintaining a package
+inventory. When agents have used saved packages via MCP `execute`, Kody may
+include a short “often used from agents” hint of those packages automatically;
+discover others with **`search`**. Pass an empty string to clear the overlay.
+Changes apply to new MCP sessions, so reconnect the MCP client if the host
+caches server instructions.
 
 ## Network and OAuth helpers
 

--- a/packages/worker/migrations/0073-agent-package-conversation-uses.sql
+++ b/packages/worker/migrations/0073-agent-package-conversation-uses.sql
@@ -1,0 +1,15 @@
+-- Distinct agent-facing (MCP execute) package uses per conversation.
+-- Source of truth for the packages-first popularity hint in MCP server
+-- instructions. Ranked by unique conversation_id count over a rolling window;
+-- not a hot usage_rollups widen.
+CREATE TABLE agent_package_conversation_uses (
+	user_id TEXT NOT NULL,
+	package_id TEXT NOT NULL,
+	conversation_id TEXT NOT NULL,
+	first_used_at TEXT NOT NULL,
+	last_used_at TEXT NOT NULL,
+	PRIMARY KEY (user_id, package_id, conversation_id)
+);
+
+CREATE INDEX idx_agent_package_conversation_uses_user_last_used
+ON agent_package_conversation_uses(user_id, last_used_at);

--- a/packages/worker/migrations/0073-agent-package-conversation-uses.sql
+++ b/packages/worker/migrations/0073-agent-package-conversation-uses.sql
@@ -2,6 +2,8 @@
 -- Source of truth for the packages-first popularity hint in MCP server
 -- instructions. Ranked by unique conversation_id count over a rolling window;
 -- not a hot usage_rollups widen.
+-- conversation_id stores SHA-256 hex of the MCP conversation id (cardinality
+-- only; not reversible to the raw id).
 CREATE TABLE agent_package_conversation_uses (
 	user_id TEXT NOT NULL,
 	package_id TEXT NOT NULL,

--- a/packages/worker/src/app/account-data-targets.ts
+++ b/packages/worker/src/app/account-data-targets.ts
@@ -56,6 +56,7 @@ export const accountUserDataTargets: ReadonlyArray<UserScopedDataTarget> = [
 	{ kind: 'user_id', table: 'package_runtime_logs' },
 	{ kind: 'user_id', table: 'package_runtime_runs' },
 	{ kind: 'user_id', table: 'usage_rollups' },
+	{ kind: 'user_id', table: 'agent_package_conversation_uses' },
 	{ kind: 'mcp_memory_suppression' },
 	{ kind: 'user_id', table: 'mcp_memories' },
 	{ kind: 'user_id', table: 'mcp_user_server_instructions' },

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -586,6 +586,13 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		mcp_user_server_instructions: [{ user_id: userAaa }],
 		package_invocation_tokens: [{ id: 'pit-1', user_id: userAaa }],
 		package_invocations: [{ id: 'pi-1', user_id: userAaa }],
+		agent_package_conversation_uses: [
+			{
+				user_id: userAaa,
+				package_id: 'pkg-1',
+				conversation_id: 'conv-1',
+			},
+		],
 		workflow_runs: [{ id: 'wr-1', user_id: userAaa }],
 		mcp_memory_conversation_suppressions: [
 			{ user_id: userAaa, conversation_id: 'c1', memory_id: 'mem-1' },

--- a/packages/worker/src/mcp/capabilities/meta/meta-set-mcp-server-instructions.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-set-mcp-server-instructions.ts
@@ -21,7 +21,7 @@ export const metaSetMcpServerInstructionsCapability = defineDomainCapability(
 	{
 		name: 'meta_set_mcp_server_instructions',
 		description:
-			'Replace or clear the signed-in user’s custom MCP server instructions overlay (appended to built-in server instructions for new MCP connections). Pass an empty string to clear. Changes apply to new MCP sessions—reconnect the client if the host caches server instructions.',
+			'Replace or clear the signed-in user’s custom MCP server instructions overlay (appended to built-in server instructions for new MCP connections). Use for preferences and workflow notes only—not for maintaining a package inventory (popular packages are hinted automatically when available). Pass an empty string to clear. Changes apply to new MCP sessions—reconnect the client if the host caches server instructions.',
 		keywords: [
 			'instructions',
 			'server',

--- a/packages/worker/src/mcp/index.ts
+++ b/packages/worker/src/mcp/index.ts
@@ -19,6 +19,7 @@ import { remoteConnectorDomainId } from '#worker/remote-connector/remote-domain-
 import { normalizeRemoteConnectorRefs } from '@kody-internal/shared/remote-connectors.ts'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { type RawFetchHostNudgeState } from '#mcp/raw-fetch-host-nudge.ts'
+import { listPopularAgentPackagesForUser } from '#worker/usage/agent-package-conversation-uses.ts'
 
 export type State = {
 	searchConversationIdsWithPreamble?: Array<string>
@@ -66,24 +67,29 @@ class MCPBase extends McpAgent<Env, State, Props> {
 	async init() {
 		const caller = this.getCallerContext()
 		const userId = caller.user?.userId ?? null
-		const [overlay, remoteConnectors, registry] = await Promise.all([
-			userId !== null
-				? getMcpUserServerInstructions(this.env.APP_DB, userId)
-				: Promise.resolve(null),
-			loadRemoteConnectorInstructionSummaries({
-				env: this.env,
-				caller,
-			}),
-			getCapabilityRegistryForContext({
-				env: this.env,
-				callerContext: caller,
-			}),
-		])
+		const [overlay, remoteConnectors, registry, popularPackages] =
+			await Promise.all([
+				userId !== null
+					? getMcpUserServerInstructions(this.env.APP_DB, userId)
+					: Promise.resolve(null),
+				loadRemoteConnectorInstructionSummaries({
+					env: this.env,
+					caller,
+				}),
+				getCapabilityRegistryForContext({
+					env: this.env,
+					callerContext: caller,
+				}),
+				userId !== null
+					? listPopularAgentPackagesForUser(this.env.APP_DB, { userId })
+					: Promise.resolve([]),
+			])
 		this.server = createKodyMcpServer({
 			instructions: buildMcpServerInstructions({
 				userOverlay: overlay,
 				domains: registry.capabilityDomains,
 				remoteConnectors,
+				popularPackages,
 			}),
 			jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
 		})

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -78,6 +78,7 @@ import {
 } from '#worker/storage-runner.ts'
 import { type BundleArtifactDependency } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { recordUsage } from '#worker/usage/record-usage.ts'
+import { recordAgentPackageConversationUses } from '#worker/usage/agent-package-conversation-uses.ts'
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
 import {
 	formatRemoteConnectorUnavailableMessage,
@@ -1122,6 +1123,11 @@ export async function runModuleWithRegistry(
 		packageEventTools?: PackageEventTools
 		capabilityRegistry?: BuiltCapabilityRegistry
 		rawFetchHostSink?: RawFetchHostSink
+		/**
+		 * When set (MCP public `execute` tool), static/dynamic `kody:@…`
+		 * package deps are credited toward agent-facing package popularity.
+		 */
+		conversationId?: string | null
 	},
 ): Promise<ExecuteResult> {
 	const userId = callerContext.user?.userId ?? ''
@@ -1135,6 +1141,19 @@ export async function runModuleWithRegistry(
 		entryPoint: 'entry.ts',
 		reuseCachedBundle: true,
 	})
+	const conversationId = options?.conversationId?.trim()
+	if (conversationId && userId) {
+		const packageIds = bundled.dependencies
+			.map((dependency) => dependency.packageId)
+			.filter((packageId): packageId is string => Boolean(packageId))
+		if (packageIds.length > 0) {
+			void recordAgentPackageConversationUses(env, {
+				userId,
+				packageIds,
+				conversationId,
+			})
+		}
+	}
 	return runBundledModuleWithRegistry(
 		env,
 		callerContext,
@@ -1156,6 +1175,7 @@ export async function runModuleWithRegistry(
 				}),
 			packageInvokeTools: options?.packageInvokeTools,
 			packageEventTools: options?.packageEventTools,
+			conversationId: options?.conversationId ?? null,
 		},
 	)
 }
@@ -1231,6 +1251,7 @@ export async function runBundledModuleWithRegistry(
 		runtimeDebug?: PackageRuntimeDebugContext | null
 		capabilityRegistry?: BuiltCapabilityRegistry
 		rawFetchHostSink?: RawFetchHostSink
+		conversationId?: string | null
 	},
 ): Promise<ExecuteResult> {
 	const secretRedactor = createExecutionSecretRedactor()
@@ -1282,6 +1303,19 @@ export async function runBundledModuleWithRegistry(
 				userId: callerContext.user?.userId ?? '',
 				modules: bundle.modules,
 			})
+		const agentConversationId = options?.conversationId?.trim()
+		const agentUserId = callerContext.user?.userId
+		if (
+			agentConversationId &&
+			agentUserId &&
+			dynamicDependencyPackageIds.length > 0
+		) {
+			void recordAgentPackageConversationUses(env, {
+				userId: agentUserId,
+				packageIds: dynamicDependencyPackageIds,
+				conversationId: agentConversationId,
+			})
+		}
 		const grantedPackageStorageIds = collectPackageStorageGrantIds({
 			packageContext: options?.packageContext ?? null,
 			dependencies: bundle.dependencies ?? [],

--- a/packages/worker/src/mcp/server-instructions.node.test.ts
+++ b/packages/worker/src/mcp/server-instructions.node.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from 'vitest'
+import {
+	buildBaseMcpServerInstructions,
+	buildMcpServerInstructions,
+	formatPopularPackagesInstructions,
+	popularPackagesInstructionCharBudget,
+} from './server-instructions.ts'
+
+test('formatPopularPackagesInstructions omits cold-start empty lists', () => {
+	expect(formatPopularPackagesInstructions(undefined)).toBe('')
+	expect(formatPopularPackagesInstructions([])).toBe('')
+})
+
+test('formatPopularPackagesInstructions uses hint language and kody ids', () => {
+	const section = formatPopularPackagesInstructions([
+		{ kodyId: 'email-helper', description: 'Send and read mail' },
+		{ kodyId: 'calendar-sync', description: '' },
+	])
+	expect(section).toContain('Often used from agents:')
+	expect(section).toContain('discover others with `search`')
+	expect(section).toContain('`email-helper`')
+	expect(section).toContain('`calendar-sync`')
+	expect(section).toContain('Send and read mail')
+	expect(section.toLowerCase()).not.toContain('whitelist')
+	expect(section.toLowerCase()).not.toContain('only these')
+})
+
+test('formatPopularPackagesInstructions caps entries and respects char budget', () => {
+	const many = Array.from({ length: 12 }, (_, index) => ({
+		kodyId: `pkg-${String(index + 1).padStart(2, '0')}`,
+		description: 'A reasonably long one-line description for packing',
+	}))
+	const section = formatPopularPackagesInstructions(many)
+	const listed = [...section.matchAll(/`pkg-\d+`/g)].map((match) => match[0])
+	expect(listed.length).toBeLessThanOrEqual(8)
+	expect(listed.length).toBeGreaterThan(0)
+	expect(section.trim().length).toBeLessThanOrEqual(
+		popularPackagesInstructionCharBudget + 10,
+	)
+
+	const tight = formatPopularPackagesInstructions(many, { charBudget: 80 })
+	expect(tight).toContain('Often used from agents:')
+	expect(tight).toContain('discover others with `search`')
+	expect([...tight.matchAll(/`pkg-\d+`/g)].length).toBeLessThanOrEqual(2)
+})
+
+test('formatPopularPackagesInstructions truncates long descriptions', () => {
+	const section = formatPopularPackagesInstructions([
+		{
+			kodyId: 'big-desc',
+			description:
+				'This description is intentionally very long so the formatter must truncate it for the instruction budget',
+		},
+	])
+	expect(section).toContain('`big-desc`')
+	expect(section).toContain('...')
+	expect(section).not.toContain('instruction budget')
+})
+
+test('buildMcpServerInstructions includes popular packages and keeps overlay for prefs', () => {
+	const instructions = buildMcpServerInstructions({
+		popularPackages: [{ kodyId: 'notes', description: 'Scratch notes' }],
+		userOverlay: 'Prefer concise replies.',
+		domains: [],
+	})
+	expect(instructions).toContain('Often used from agents:')
+	expect(instructions).toContain('`notes`')
+	expect(instructions).toContain('not for maintaining a package inventory')
+	expect(instructions).toContain('User-provided MCP instructions')
+	expect(instructions).toContain('Prefer concise replies.')
+})
+
+test('buildBaseMcpServerInstructions omits popular section when empty', () => {
+	const base = buildBaseMcpServerInstructions({ popularPackages: [] })
+	expect(base).not.toContain('Often used from agents:')
+})

--- a/packages/worker/src/mcp/server-instructions.ts
+++ b/packages/worker/src/mcp/server-instructions.ts
@@ -10,9 +10,18 @@ function formatDomainInstructions(
 
 const maxRemoteConnectorDescriptionChars = 240
 
+/** Soft budget for the popular-packages hint section (names + short blurbs). */
+export const popularPackagesInstructionCharBudget = 550
+const maxPopularPackageDescriptionChars = 48
+
 export type RemoteConnectorInstructionSummary = {
 	name: string
 	domain: string
+	description?: string | null
+}
+
+export type PopularPackageInstructionSummary = {
+	kodyId: string
 	description?: string | null
 }
 
@@ -21,6 +30,15 @@ function truncateRemoteConnectorDescription(description: string) {
 		return description
 	}
 	return `${description.slice(0, maxRemoteConnectorDescriptionChars - 3).trimEnd()}...`
+}
+
+function truncatePopularPackageDescription(description: string) {
+	const trimmed = description.trim().replace(/\s+/g, ' ')
+	if (!trimmed) return ''
+	if (trimmed.length <= maxPopularPackageDescriptionChars) {
+		return trimmed
+	}
+	return `${trimmed.slice(0, maxPopularPackageDescriptionChars - 3).trimEnd()}...`
 }
 
 function formatRemoteConnectorInstructions(
@@ -40,10 +58,57 @@ ${lines.join('\n')}
 `
 }
 
+/**
+ * Compact packages-first popularity hint. Omits entirely when empty (cold
+ * start). Frames as a hint, not a whitelist; stays under a soft char budget.
+ */
+export function formatPopularPackagesInstructions(
+	packages: ReadonlyArray<PopularPackageInstructionSummary> | undefined,
+	options: { charBudget?: number } = {},
+): string {
+	if (!packages?.length) return ''
+	const charBudget = options.charBudget ?? popularPackagesInstructionCharBudget
+	const prefix = 'Often used from agents: '
+	const suffix = ' — discover others with `search`'
+	const parts: Array<string> = []
+	let used = prefix.length + suffix.length
+
+	for (const pkg of packages) {
+		const kodyId = pkg.kodyId.trim()
+		if (!kodyId) continue
+		const description = truncatePopularPackageDescription(pkg.description ?? '')
+		const part = description
+			? `\`${kodyId}\` — ${description}`
+			: `\`${kodyId}\``
+		const separatorCost = parts.length > 0 ? 2 : 0 // "; "
+		if (used + separatorCost + part.length > charBudget) {
+			if (parts.length === 0) {
+				// Always include at least the first kody id, truncated if needed.
+				const available = Math.max(8, charBudget - used)
+				parts.push(
+					part.length <= available
+						? part
+						: `${part.slice(0, available - 3)}...`,
+				)
+			}
+			break
+		}
+		used += separatorCost + part.length
+		parts.push(part)
+	}
+
+	if (parts.length === 0) return ''
+	return `
+
+${prefix}${parts.join('; ')}${suffix}
+`
+}
+
 export function buildBaseMcpServerInstructions(
 	input: {
 		domains?: ReadonlyArray<CapabilityDomainMetadata>
 		remoteConnectors?: ReadonlyArray<RemoteConnectorInstructionSummary>
+		popularPackages?: ReadonlyArray<PopularPackageInstructionSummary>
 	} = {},
 ): string {
 	const domainInstructions = formatDomainInstructions(input.domains ?? [])
@@ -70,8 +135,8 @@ Conventions:
 - Integration-backed work: before building packages, package apps, or workflows that depend on third-party auth, call \`coding_guide_get({ guide: "integration_bootstrap" })\`, confirm the required \`integration\` or \`secret\` entity exists through \`search\`, run a cheap authenticated \`execute\` smoke test, then check \`community_search\` for a trusted close package before creating one. Do not present auth-dependent work as complete until that smoke test succeeds.
 - Jobs, workflows, sessions, services, values, storage, and the other capability groups below are individual capabilities: discover them with \`search\`, whose entity detail includes each capability's exact call shape.
 - Memory writes are verify-first: run \`meta_memory_verify\` before \`meta_memory_upsert\` or \`meta_memory_delete\`.
-- User-specific MCP instructions: \`meta_get_mcp_server_instructions\` / \`meta_set_mcp_server_instructions\` (signed-in users). Updates apply to **new** MCP sessions.
-
+- User-specific MCP instructions: \`meta_get_mcp_server_instructions\` / \`meta_set_mcp_server_instructions\` (signed-in users) are for preferences and workflow notes only — not for maintaining a package inventory (popular packages are hinted automatically when available). Updates apply to **new** MCP sessions.
+${formatPopularPackagesInstructions(input.popularPackages)}
 Kody repository (for contributors): https://github.com/kentcdodds/kody
 
 Domains (builtin capability groups)
@@ -89,6 +154,7 @@ export function buildMcpServerInstructions(
 				userOverlay?: string | null | undefined
 				domains?: ReadonlyArray<CapabilityDomainMetadata>
 				remoteConnectors?: ReadonlyArray<RemoteConnectorInstructionSummary>
+				popularPackages?: ReadonlyArray<PopularPackageInstructionSummary>
 		  },
 ): string {
 	const normalizedInput =
@@ -96,6 +162,7 @@ export function buildMcpServerInstructions(
 	const base = buildBaseMcpServerInstructions({
 		domains: normalizedInput.domains,
 		remoteConnectors: normalizedInput.remoteConnectors,
+		popularPackages: normalizedInput.popularPackages,
 	})
 	const userOverlay = normalizedInput.userOverlay
 	const trimmed = userOverlay?.trim()

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -286,6 +286,7 @@ test('execute tool serializes successes and errors, binds storage, passes packag
 		env: {},
 		baseUrl: 'https://example.com',
 		callerContext: expect.objectContaining(callerContext),
+		conversationId: 'conv-packages',
 	})
 	expect(mockModule.runModuleWithRegistry).toHaveBeenLastCalledWith(
 		expect.anything(),
@@ -294,6 +295,7 @@ test('execute tool serializes successes and errors, binds storage, passes packag
 		undefined,
 		expect.objectContaining({
 			packageInvokeTools,
+			conversationId: 'conv-packages',
 		}),
 	)
 

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -254,6 +254,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 											env,
 											baseUrl: callerContext.baseUrl,
 											callerContext,
+											conversationId: resolvedConversationId,
 										}),
 								)
 							: undefined
@@ -275,6 +276,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 										: undefined,
 									packageInvokeTools,
 									rawFetchHostSink: rawFetchHosts.sink,
+									conversationId: resolvedConversationId,
 								},
 							)
 						} catch (cause) {

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -20,6 +20,7 @@ const repoMockModule = vi.hoisted(() => ({
 	persistPublishedBundleArtifact: vi.fn(),
 	typecheckPackageEntrypointsFromSourceFiles: vi.fn(),
 	runBundledModuleWithRegistry: vi.fn(),
+	recordAgentPackageConversationUse: vi.fn(),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -58,6 +59,11 @@ vi.mock('#worker/repo/checks.ts', () => ({
 vi.mock('#mcp/run-kody-registry.ts', () => ({
 	runBundledModuleWithRegistry: (...args: Array<unknown>) =>
 		repoMockModule.runBundledModuleWithRegistry(...args),
+}))
+
+vi.mock('#worker/usage/agent-package-conversation-uses.ts', () => ({
+	recordAgentPackageConversationUse: (...args: Array<unknown>) =>
+		repoMockModule.recordAgentPackageConversationUse(...args),
 }))
 
 function createDatabase(options: { failInsert?: boolean } = {}) {
@@ -1011,6 +1017,8 @@ test('execute runtime invokeChecked invokes target package with execute provenan
 		result: { handled: true, eventId: 'message-1' },
 		logs: [],
 	})
+	repoMockModule.recordAgentPackageConversationUse.mockClear()
+	repoMockModule.recordAgentPackageConversationUse.mockResolvedValue(undefined)
 	const callerContext = createMcpCallerContext({
 		baseUrl: 'https://kody.dev',
 		user: {
@@ -1023,6 +1031,7 @@ test('execute runtime invokeChecked invokes target package with execute provenan
 		env: createEnv(db),
 		baseUrl: 'https://kody.dev',
 		callerContext,
+		conversationId: 'conv-execute-1',
 	})
 
 	const result = await tools.invokeChecked({
@@ -1066,6 +1075,14 @@ test('execute runtime invokeChecked invokes target package with execute provenan
 		(runCall?.[4] as { packageInvokeTools?: unknown } | undefined)
 			?.packageInvokeTools,
 	).toBeDefined()
+	expect(repoMockModule.recordAgentPackageConversationUse).toHaveBeenCalledWith(
+		expect.anything(),
+		{
+			userId: 'user-123',
+			packageId: 'pkg-subscriber',
+			conversationId: 'conv-execute-1',
+		},
+	)
 })
 
 test('package runtime check reads target package metadata changes without republishing caller', async () => {

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -47,6 +47,7 @@ import {
 } from '#worker/package-runtime/published-bundle-artifacts.ts'
 import { packageWorkflowInvocationSource } from '#worker/package-runtime/package-invocation-sources.ts'
 import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from '#worker/package-runtime/published-source-dependencies.ts'
+import { recordAgentPackageConversationUse } from '#worker/usage/agent-package-conversation-uses.ts'
 import {
 	buildPackageSubscriptionArtifactName,
 	normalizePackageSubscriptionTopic,
@@ -1529,11 +1530,14 @@ export function createExecutePackageInvokeTools(input: {
 	callerContext: ReturnType<typeof createMcpCallerContext>
 	parentRuntimeDebug?: PackageRuntimeDebugContext | null
 	packageInvokeDepth?: number
+	/** MCP execute conversation id for agent-facing popularity recording. */
+	conversationId?: string | null
 }): PackageInvokeTools {
 	return createPackageInvokeTools({
 		...input,
 		packageContext: null,
 		callerKind: 'execute',
+		conversationId: input.conversationId ?? null,
 	})
 }
 
@@ -1545,6 +1549,7 @@ function createPackageInvokeTools(input: {
 	parentRuntimeDebug?: PackageRuntimeDebugContext | null
 	packageInvokeDepth?: number
 	callerKind: 'package' | 'execute'
+	conversationId?: string | null
 }): PackageInvokeTools {
 	let autoIdempotencySequence = 0
 	const requireRuntimeCaller = (operationName: string) => {
@@ -1613,6 +1618,7 @@ function createPackageInvokeTools(input: {
 						topic: request.topic,
 					},
 					runtimeInvokeDepth: packageInvokeDepth + 1,
+					conversationId: input.conversationId ?? null,
 				})
 		if (response.status >= 200 && response.status < 400) {
 			return response.body['result']
@@ -1680,6 +1686,7 @@ async function invokePackageExportForExecuteRuntime(input: {
 	}
 	request: PackageInvocationRequest
 	runtimeInvokeDepth?: number
+	conversationId?: string | null
 }): Promise<PackageInvocationResponse> {
 	const packageIdOrKodyId = input.request.packageIdOrKodyId.trim()
 	if (!packageIdOrKodyId) {
@@ -1709,6 +1716,15 @@ async function invokePackageExportForExecuteRuntime(input: {
 			code: 'package_not_found',
 			message: `Saved package "${packageIdOrKodyId}" was not found for this user.`,
 			idempotencyKey,
+		})
+	}
+	const conversationId = input.conversationId?.trim()
+	if (conversationId) {
+		// Best-effort; must not affect invoke. Conversation-unique upsert.
+		void recordAgentPackageConversationUse(input.env, {
+			userId: input.caller.userId,
+			packageId: savedPackage.id,
+			conversationId,
 		})
 	}
 	return await invokeSavedPackageModule({

--- a/packages/worker/src/usage/agent-package-conversation-uses.node.test.ts
+++ b/packages/worker/src/usage/agent-package-conversation-uses.node.test.ts
@@ -1,0 +1,242 @@
+import { readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import {
+	listPopularAgentPackagesForUser,
+	recordAgentPackageConversationUse,
+	recordAgentPackageConversationUses,
+} from './agent-package-conversation-uses.ts'
+
+type TestD1Statement = {
+	bind(...params: Array<unknown>): TestD1Statement
+	all<T>(): Promise<{ results: Array<T>; meta: { changes: number } }>
+	first<T>(): Promise<T | null>
+	run(): Promise<{ meta: { changes: number } }>
+}
+
+function createD1FromSqlite(sqlite: DatabaseSync) {
+	function createStatement(
+		query: string,
+		params: Array<unknown> = [],
+	): TestD1Statement {
+		return {
+			bind(...boundParams: Array<unknown>) {
+				return createStatement(query, boundParams)
+			},
+			async all<T>() {
+				return {
+					results: sqlite.prepare(query).all(...params) as Array<T>,
+					meta: { changes: 0 },
+				}
+			},
+			async first<T>() {
+				return (sqlite.prepare(query).get(...params) ?? null) as T | null
+			},
+			async run() {
+				const result = sqlite.prepare(query).run(...params)
+				return { meta: { changes: result.changes } }
+			},
+		}
+	}
+	return {
+		prepare(query: string) {
+			return createStatement(query)
+		},
+	} as unknown as D1Database
+}
+
+function createTestDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	sqlite.exec(
+		readFileSync(
+			new URL('../../migrations/0027-saved-packages.sql', import.meta.url),
+			'utf8',
+		),
+	)
+	sqlite.exec(
+		readFileSync(
+			new URL(
+				'../../migrations/0073-agent-package-conversation-uses.sql',
+				import.meta.url,
+			),
+			'utf8',
+		),
+	)
+	return { sqlite, db: createD1FromSqlite(sqlite) }
+}
+
+function seedPackage(
+	sqlite: DatabaseSync,
+	input: {
+		id: string
+		userId: string
+		kodyId: string
+		description: string
+		name?: string
+	},
+) {
+	sqlite
+		.prepare(
+			`INSERT INTO saved_packages (
+				id, user_id, name, kody_id, description, source_id
+			) VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			input.id,
+			input.userId,
+			input.name ?? input.kodyId,
+			input.kodyId,
+			input.description,
+			`source-${input.id}`,
+		)
+}
+
+test('recordAgentPackageConversationUse upserts idempotently per conversation', async () => {
+	const { sqlite, db } = createTestDb()
+	seedPackage(sqlite, {
+		id: 'pkg-1',
+		userId: 'user-a',
+		kodyId: 'mail',
+		description: 'Mail helper',
+	})
+
+	await recordAgentPackageConversationUse(
+		{ APP_DB: db },
+		{
+			userId: 'user-a',
+			packageId: 'pkg-1',
+			conversationId: 'conv-1',
+			usedAt: '2026-07-01T10:00:00.000Z',
+		},
+	)
+	await recordAgentPackageConversationUse(
+		{ APP_DB: db },
+		{
+			userId: 'user-a',
+			packageId: 'pkg-1',
+			conversationId: 'conv-1',
+			usedAt: '2026-07-01T12:00:00.000Z',
+		},
+	)
+
+	const rows = sqlite
+		.prepare(
+			`SELECT user_id, package_id, conversation_id, first_used_at, last_used_at
+			FROM agent_package_conversation_uses`,
+		)
+		.all() as Array<{
+		user_id: string
+		package_id: string
+		conversation_id: string
+		first_used_at: string
+		last_used_at: string
+	}>
+	expect(rows).toHaveLength(1)
+	expect(rows[0]).toMatchObject({
+		user_id: 'user-a',
+		package_id: 'pkg-1',
+		conversation_id: 'conv-1',
+		first_used_at: '2026-07-01T10:00:00.000Z',
+		last_used_at: '2026-07-01T12:00:00.000Z',
+	})
+})
+
+test('listPopularAgentPackagesForUser ranks by distinct conversations and skips missing packages', async () => {
+	const { sqlite, db } = createTestDb()
+	seedPackage(sqlite, {
+		id: 'pkg-a',
+		userId: 'user-a',
+		kodyId: 'alpha',
+		description: 'Alpha pack',
+	})
+	seedPackage(sqlite, {
+		id: 'pkg-b',
+		userId: 'user-a',
+		kodyId: 'bravo',
+		description: 'Bravo pack',
+	})
+	seedPackage(sqlite, {
+		id: 'pkg-c',
+		userId: 'user-a',
+		kodyId: 'charlie',
+		description: 'Charlie pack',
+	})
+
+	const now = new Date('2026-07-21T12:00:00.000Z')
+	const recent = '2026-07-10T00:00:00.000Z'
+	const older = '2026-06-01T00:00:00.000Z'
+
+	// alpha: 3 conversations
+	for (const conversationId of ['c1', 'c2', 'c3']) {
+		await recordAgentPackageConversationUse(
+			{ APP_DB: db },
+			{
+				userId: 'user-a',
+				packageId: 'pkg-a',
+				conversationId,
+				usedAt: recent,
+			},
+		)
+	}
+	// bravo: 2 conversations (one duplicate upsert)
+	await recordAgentPackageConversationUses(
+		{ APP_DB: db },
+		{
+			userId: 'user-a',
+			packageIds: ['pkg-b', 'pkg-b'],
+			conversationId: 'c1',
+			usedAt: recent,
+		},
+	)
+	await recordAgentPackageConversationUse(
+		{ APP_DB: db },
+		{
+			userId: 'user-a',
+			packageId: 'pkg-b',
+			conversationId: 'c4',
+			usedAt: recent,
+		},
+	)
+	// charlie: only outside the window
+	await recordAgentPackageConversationUse(
+		{ APP_DB: db },
+		{
+			userId: 'user-a',
+			packageId: 'pkg-c',
+			conversationId: 'c-old',
+			usedAt: older,
+		},
+	)
+	// deleted package row still in uses — skip via join
+	await recordAgentPackageConversationUse(
+		{ APP_DB: db },
+		{
+			userId: 'user-a',
+			packageId: 'pkg-gone',
+			conversationId: 'c5',
+			usedAt: recent,
+		},
+	)
+
+	const ranked = await listPopularAgentPackagesForUser(db, {
+		userId: 'user-a',
+		now,
+		limit: 8,
+	})
+	expect(ranked.map((row) => row.kodyId)).toEqual(['alpha', 'bravo'])
+	expect(ranked[0]?.conversationCount).toBe(3)
+	expect(ranked[1]?.conversationCount).toBe(2)
+})
+
+test('recordAgentPackageConversationUse never throws when DB is missing', async () => {
+	await expect(
+		recordAgentPackageConversationUse(
+			{},
+			{
+				userId: 'user-a',
+				packageId: 'pkg-1',
+				conversationId: 'conv-1',
+			},
+		),
+	).resolves.toBeUndefined()
+})

--- a/packages/worker/src/usage/agent-package-conversation-uses.node.test.ts
+++ b/packages/worker/src/usage/agent-package-conversation-uses.node.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import {
 	listPopularAgentPackagesForUser,
 	recordAgentPackageConversationUse,
@@ -135,10 +136,25 @@ test('recordAgentPackageConversationUse upserts idempotently per conversation', 
 	expect(rows[0]).toMatchObject({
 		user_id: 'user-a',
 		package_id: 'pkg-1',
-		conversation_id: 'conv-1',
 		first_used_at: '2026-07-01T10:00:00.000Z',
 		last_used_at: '2026-07-01T12:00:00.000Z',
 	})
+	// Stored value is a SHA-256 hex digest, not the raw conversation id.
+	expect(rows[0]?.conversation_id).toMatch(/^[0-9a-f]{64}$/)
+	expect(rows[0]?.conversation_id).not.toBe('conv-1')
+})
+
+test('listPopularAgentPackagesForUser returns [] when the table is missing', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const sqlite = new DatabaseSync(':memory:')
+	const db = createD1FromSqlite(sqlite)
+	await expect(
+		listPopularAgentPackagesForUser(db, { userId: 'user-a' }),
+	).resolves.toEqual([])
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'agent-package-conversation-use-list-failed',
+		expect.anything(),
+	)
 })
 
 test('listPopularAgentPackagesForUser ranks by distinct conversations and skips missing packages', async () => {

--- a/packages/worker/src/usage/agent-package-conversation-uses.ts
+++ b/packages/worker/src/usage/agent-package-conversation-uses.ts
@@ -1,3 +1,5 @@
+import { toHex } from '@kody-internal/shared/hex.ts'
+
 /**
  * Agent-facing package popularity for MCP server instructions.
  *
@@ -5,6 +7,10 @@
  * package paths. Ranking uses unique conversation counts over a rolling
  * window — not raw invoke spam. Writes are best-effort and never throw into
  * the invoke path (same spirit as `recordUsage`).
+ *
+ * Stored `conversation_id` values are SHA-256 hex digests of the MCP
+ * conversation id (not the raw id), so the table only needs cardinality, not
+ * reversible conversation identifiers.
  *
  * See `docs/contributing/architecture/usage-metering.md`.
  */
@@ -30,6 +36,12 @@ INSERT INTO agent_package_conversation_uses (
 ON CONFLICT (user_id, package_id, conversation_id) DO UPDATE SET
 	last_used_at = excluded.last_used_at
 `.trim()
+
+async function hashConversationId(conversationId: string): Promise<string> {
+	const data = new TextEncoder().encode(conversationId)
+	const digest = await crypto.subtle.digest('SHA-256', data)
+	return toHex(new Uint8Array(digest))
+}
 
 /**
  * Upsert one conversation-scoped agent package use. Idempotent for the same
@@ -57,9 +69,10 @@ export async function recordAgentPackageConversationUse(
 			return
 		}
 		const usedAt = input.usedAt ?? new Date().toISOString()
+		const conversationKey = await hashConversationId(conversationId)
 		await db
 			.prepare(upsertStatement)
-			.bind(userId, packageId, conversationId, usedAt)
+			.bind(userId, packageId, conversationKey, usedAt)
 			.run()
 	} catch (error) {
 		console.warn('agent-package-conversation-use-record-failed', error)
@@ -106,18 +119,19 @@ export async function listPopularAgentPackagesForUser(
 		now?: Date
 	},
 ): Promise<Array<PopularAgentPackageSummary>> {
-	const userId = input.userId.trim()
-	if (!userId) return []
-	const limit = input.limit ?? agentPackagePopularityTopLimit
-	const windowDays = input.windowDays ?? agentPackagePopularityWindowDays
-	const now = input.now ?? new Date()
-	const since = new Date(
-		now.getTime() - windowDays * 24 * 60 * 60 * 1000,
-	).toISOString()
+	try {
+		const userId = input.userId.trim()
+		if (!userId) return []
+		const limit = input.limit ?? agentPackagePopularityTopLimit
+		const windowDays = input.windowDays ?? agentPackagePopularityWindowDays
+		const now = input.now ?? new Date()
+		const since = new Date(
+			now.getTime() - windowDays * 24 * 60 * 60 * 1000,
+		).toISOString()
 
-	const rows = await db
-		.prepare(
-			`
+		const rows = await db
+			.prepare(
+				`
 SELECT
 	u.package_id AS package_id,
 	p.kody_id AS kody_id,
@@ -131,20 +145,25 @@ WHERE u.user_id = ?1
 GROUP BY u.package_id, p.kody_id, p.description
 ORDER BY conversation_count DESC, p.kody_id ASC
 LIMIT ?3
-			`.trim(),
-		)
-		.bind(userId, since, limit)
-		.all<{
-			package_id: string
-			kody_id: string
-			description: string
-			conversation_count: number
-		}>()
+				`.trim(),
+			)
+			.bind(userId, since, limit)
+			.all<{
+				package_id: string
+				kody_id: string
+				description: string
+				conversation_count: number
+			}>()
 
-	return (rows.results ?? []).map((row) => ({
-		packageId: row.package_id,
-		kodyId: row.kody_id,
-		description: row.description ?? '',
-		conversationCount: Number(row.conversation_count) || 0,
-	}))
+		return (rows.results ?? []).map((row) => ({
+			packageId: row.package_id,
+			kodyId: row.kody_id,
+			description: row.description ?? '',
+			conversationCount: Number(row.conversation_count) || 0,
+		}))
+	} catch (error) {
+		// MCP init must stay up during migration rollout / transient D1 errors.
+		console.warn('agent-package-conversation-use-list-failed', error)
+		return []
+	}
 }

--- a/packages/worker/src/usage/agent-package-conversation-uses.ts
+++ b/packages/worker/src/usage/agent-package-conversation-uses.ts
@@ -1,0 +1,150 @@
+/**
+ * Agent-facing package popularity for MCP server instructions.
+ *
+ * Tracks distinct (user, package, conversation) uses from MCP `execute`
+ * package paths. Ranking uses unique conversation counts over a rolling
+ * window — not raw invoke spam. Writes are best-effort and never throw into
+ * the invoke path (same spirit as `recordUsage`).
+ *
+ * See `docs/contributing/architecture/usage-metering.md`.
+ */
+
+export const agentPackagePopularityWindowDays = 30
+export const agentPackagePopularityTopLimit = 8
+
+export type AgentPackageConversationUseEnv = {
+	APP_DB?: D1Database
+}
+
+export type PopularAgentPackageSummary = {
+	packageId: string
+	kodyId: string
+	description: string
+	conversationCount: number
+}
+
+const upsertStatement = `
+INSERT INTO agent_package_conversation_uses (
+	user_id, package_id, conversation_id, first_used_at, last_used_at
+) VALUES (?1, ?2, ?3, ?4, ?4)
+ON CONFLICT (user_id, package_id, conversation_id) DO UPDATE SET
+	last_used_at = excluded.last_used_at
+`.trim()
+
+/**
+ * Upsert one conversation-scoped agent package use. Idempotent for the same
+ * (userId, packageId, conversationId). Never throws.
+ */
+export async function recordAgentPackageConversationUse(
+	env: AgentPackageConversationUseEnv,
+	input: {
+		userId: string
+		packageId: string
+		conversationId: string
+		usedAt?: string
+	},
+): Promise<void> {
+	try {
+		const userId = input.userId.trim()
+		const packageId = input.packageId.trim()
+		const conversationId = input.conversationId.trim()
+		if (!userId || !packageId || !conversationId) {
+			return
+		}
+		const db = env.APP_DB
+		if (!db) {
+			console.debug('agent-package-conversation-use-skipped', 'missing APP_DB')
+			return
+		}
+		const usedAt = input.usedAt ?? new Date().toISOString()
+		await db
+			.prepare(upsertStatement)
+			.bind(userId, packageId, conversationId, usedAt)
+			.run()
+	} catch (error) {
+		console.warn('agent-package-conversation-use-record-failed', error)
+	}
+}
+
+/**
+ * Record conversation uses for many packages (e.g. static/dynamic execute
+ * deps). Dedupes package ids; never throws.
+ */
+export async function recordAgentPackageConversationUses(
+	env: AgentPackageConversationUseEnv,
+	input: {
+		userId: string
+		packageIds: ReadonlyArray<string>
+		conversationId: string
+		usedAt?: string
+	},
+): Promise<void> {
+	const seen = new Set<string>()
+	for (const packageId of input.packageIds) {
+		const trimmed = packageId.trim()
+		if (!trimmed || seen.has(trimmed)) continue
+		seen.add(trimmed)
+		await recordAgentPackageConversationUse(env, {
+			userId: input.userId,
+			packageId: trimmed,
+			conversationId: input.conversationId,
+			usedAt: input.usedAt,
+		})
+	}
+}
+
+/**
+ * Rank packages by distinct conversation count in the rolling window, join
+ * saved-package metadata, skip packages the user no longer has.
+ */
+export async function listPopularAgentPackagesForUser(
+	db: D1Database,
+	input: {
+		userId: string
+		limit?: number
+		windowDays?: number
+		now?: Date
+	},
+): Promise<Array<PopularAgentPackageSummary>> {
+	const userId = input.userId.trim()
+	if (!userId) return []
+	const limit = input.limit ?? agentPackagePopularityTopLimit
+	const windowDays = input.windowDays ?? agentPackagePopularityWindowDays
+	const now = input.now ?? new Date()
+	const since = new Date(
+		now.getTime() - windowDays * 24 * 60 * 60 * 1000,
+	).toISOString()
+
+	const rows = await db
+		.prepare(
+			`
+SELECT
+	u.package_id AS package_id,
+	p.kody_id AS kody_id,
+	p.description AS description,
+	COUNT(*) AS conversation_count
+FROM agent_package_conversation_uses u
+INNER JOIN saved_packages p
+	ON p.id = u.package_id AND p.user_id = u.user_id
+WHERE u.user_id = ?1
+	AND u.last_used_at >= ?2
+GROUP BY u.package_id, p.kody_id, p.description
+ORDER BY conversation_count DESC, p.kody_id ASC
+LIMIT ?3
+			`.trim(),
+		)
+		.bind(userId, since, limit)
+		.all<{
+			package_id: string
+			kody_id: string
+			description: string
+			conversation_count: number
+		}>()
+
+	return (rows.results ?? []).map((row) => ({
+		packageId: row.package_id,
+		kodyId: row.kody_id,
+		description: row.description ?? '',
+		conversationCount: Number(row.conversation_count) || 0,
+	}))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses platform feedback that agents miss Kody for email/calendar-style work because early MCP discovery doesn’t advertise what packages this account actually uses.

MCP server instructions now include a capped, packages-first **“Often used from agents”** hint ranked by **distinct conversation counts** over 30 days (not raw invoke spam). Tracking is automatic from agent-facing `execute` package uses; the user instruction overlay stays for preferences only.

## Approach

- New D1 table `agent_package_conversation_uses` (PK user/package/conversation; conversation ids stored as SHA-256 digests)
- Record on execute `packages.invoke*` and static/dynamic `kody:@…` deps when `conversationId` is present (best-effort, never breaks invoke)
- Soft-fail popularity reads so MCP init survives migration rollout
- Format top 8 into server instructions as a hint; omit section on cold start

## Test plan

- [x] Unit tests for upsert idempotency, ranking, hashing, soft-fail list, instruction formatting
- [x] Execute / package-invocation plumbing tests
- [ ] CI `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/agent-package-popularity-0387`

**Classification:** extends — new D1 table + usage helpers for agent package popularity; MCP instructions and execute plumbing consume them.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `usage-metering` | storage | extends — agent package conversation-use tracking |
| `d1-app-db` | storage | extends — migration `0073-agent-package-conversation-uses` |
| `mcp-server` | surfaces | extends — popular-packages hint in server instructions |
| `capabilities-execute` | runtime | extends — thread `conversationId`; record package deps |
| `app-ui` | surfaces | composes — account deletion target for new table |
| `memories` | assistant | composes — clarify overlay is prefs-only |

### System map

Execute package uses write conversation-scoped popularity rows; MCP init reads the top packages into server instructions.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	capabilitiesExecute["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	usageMetering["usage-metering<br/>Usage metering"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::extended
	mcpServer -->|"execute + conversationId"| capabilitiesExecute
	capabilitiesExecute -->|"record agent package conversation use"| usageMetering
	usageMetering -->|"agent_package_conversation_uses upsert/read"| d1AppDb
	mcpServer -->|"listPopularAgentPackagesForUser on init"| usageMetering
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Agent
	participant MCP as mcp-server
	participant Exec as execute runtime
	participant D1 as agent_package_conversation_uses
	Agent->>MCP: execute(code, conversationId)
	MCP->>Exec: run with conversationId
	Exec->>D1: upsert hashed (user, package, conversation)
	Note over MCP,D1: Later MCP session init
	MCP->>D1: top packages by distinct conversations (30d)
	MCP-->>Agent: server instructions include popularity hint
```

### Before / after

**Server instructions**

- Before: domains + remote connectors + user overlay; no package popularity
- After: optional `Often used from agents: … — discover others with search` (top 8 / ~char budget; omitted when empty)

### Invariants

- Per-user isolation: all rows keyed by `user_id`; reads join `saved_packages` on matching `user_id`
- Account deletion includes `agent_package_conversation_uses`

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e25cee0d-8474-4d5a-9d92-d51289970387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e25cee0d-8474-4d5a-9d92-d51289970387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP sessions can now highlight saved packages frequently used by agents via a “popular packages” hint.
  * Package popularity is computed from recent, distinct conversation usage and surfaces up to eight relevant packages.
  * Agent executions now record “package used in conversation” for usage metering.
* **Documentation**
  * Updated guidance for MCP server instruction overlays, including how popular-package hints are applied and cleared.
* **Bug Fixes**
  * Account deletion now correctly cascades agent package conversation usage data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->