### PR TITLE
Optimize MCP search discovery

### DIFF
--- a/packages/worker/src/mcp/capabilities/capability-search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.node.test.ts
@@ -1,0 +1,128 @@
+import { expect, test } from 'vitest'
+import {
+	CAPABILITY_EMBEDDING_DIMENSIONS,
+	CAPABILITY_VECTOR_KIND,
+	buildCapabilityVectorMetadataFilter,
+	deterministicEmbedding,
+	searchCapabilities,
+} from './capability-search.ts'
+import { type CapabilitySpec } from './types.ts'
+
+function spec(name: string, description: string): CapabilitySpec {
+	return {
+		name,
+		domain: 'meta',
+		description,
+		keywords: name.split('_'),
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		source: 'builtin',
+		inputFields: [],
+		requiredInputFields: [],
+		outputFields: [],
+		inputSchema: { type: 'object', properties: {} },
+		inputTypeDefinition: `type ${name}Input = Record<string, never>`,
+	}
+}
+
+function onlineEnv(matches: Array<{ id: string; score: number }>) {
+	const embeddedTexts: Array<string> = []
+	const capturedFilters: Array<Record<string, unknown> | undefined> = []
+	const env = {
+		SENTRY_ENVIRONMENT: 'production',
+		AI: {
+			async run(...args: Array<unknown>) {
+				const input = args[1] as { text?: unknown }
+				const texts = Array.isArray(input.text)
+					? input.text.map(String)
+					: [String(input.text ?? '')]
+				embeddedTexts.push(...texts)
+				return {
+					data: texts.map((text) => deterministicEmbedding(text)),
+					shape: [texts.length, CAPABILITY_EMBEDDING_DIMENSIONS],
+				}
+			},
+		},
+		CAPABILITY_VECTOR_INDEX: {
+			async query(
+				_values: Array<number>,
+				options: { filter?: Record<string, unknown> },
+			) {
+				capturedFilters.push(options.filter)
+				return { matches }
+			},
+		},
+	} as unknown as Env
+	return { env, embeddedTexts, capturedFilters }
+}
+
+test('capability Vectorize stays builtin-scoped, query-embed-only, and lexical-only for misses', async () => {
+	expect(buildCapabilityVectorMetadataFilter()).toEqual({
+		kind: { $eq: CAPABILITY_VECTOR_KIND },
+	})
+	expect(
+		buildCapabilityVectorMetadataFilter({
+			domain: { $eq: 'meta' },
+			kind: { $eq: 'package' },
+		}),
+	).toEqual({
+		domain: { $eq: 'meta' },
+		kind: { $eq: CAPABILITY_VECTOR_KIND },
+	})
+
+	const query = 'oauth redirect uri provider registration'
+	const specs = {
+		capability_noise_a: spec('capability_noise_a', 'Unrelated helper'),
+		oauth_redirect_helper: spec(
+			'oauth_redirect_helper',
+			'oauth redirect uri provider registration guide for configuring providers.',
+		),
+	}
+	const { env, embeddedTexts, capturedFilters } = onlineEnv([
+		{ id: 'package_pkg-1', score: 0.99 },
+		{ id: 'capability_noise_a', score: 0.41 },
+	])
+	const result = await searchCapabilities({
+		env,
+		query,
+		limit: 3,
+		detail: false,
+		specs,
+		vectorMetadataFilter: { domain: { $eq: 'meta' } },
+	})
+	expect(embeddedTexts).toEqual([query])
+	expect(capturedFilters).toEqual([
+		{ domain: { $eq: 'meta' }, kind: { $eq: CAPABILITY_VECTOR_KIND } },
+	])
+	expect(result.matches.map((match) => match.name)).toContain(
+		'oauth_redirect_helper',
+	)
+	expect(result.matches.map((match) => match.name)).not.toContain(
+		'package_pkg-1',
+	)
+
+	const lexical = await searchCapabilities({
+		env: onlineEnv([{ id: 'weak_vector_hit', score: 0.22 }]).env,
+		query: 'check whether sonos speakers are playing status',
+		limit: 2,
+		detail: false,
+		specs: {
+			weak_vector_hit: spec('weak_vector_hit', 'barely related helper'),
+			strong_lexical_only: spec(
+				'strong_lexical_only',
+				'sonos player status playing speakers check whether live playback state',
+			),
+		},
+	})
+	const lexicalOnly = lexical.matches.find(
+		(match) => match.name === 'strong_lexical_only',
+	)
+	const vectorHit = lexical.matches.find(
+		(match) => match.name === 'weak_vector_hit',
+	)
+	expect(lexicalOnly?.vectorRank).toBeUndefined()
+	expect(lexicalOnly?.vectorScore).toBe(0)
+	expect(lexicalOnly!.lexicalScore).toBeGreaterThan(vectorHit!.lexicalScore)
+	expect(vectorHit?.vectorRank).toBe(1)
+})

--- a/packages/worker/src/mcp/capabilities/capability-search.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.ts
@@ -27,6 +27,30 @@ export const CAPABILITY_EMBEDDING_MAX_INPUT_CHARS = 2_000
 
 export const CAPABILITY_SEARCH_RRF_K = 60
 
+/**
+ * Indexed metadata `kind` for builtin capability vectors in the shared
+ * CAPABILITY_VECTOR_INDEX (see capability-reindex.ts). Distinct from package /
+ * memory / job kinds in the same index.
+ */
+export const CAPABILITY_VECTOR_KIND = 'builtin'
+
+/**
+ * Always scope capability Vectorize queries to builtin capability vectors.
+ * Caller-supplied RBAC/provider filters are merged with implicit AND; `kind` is
+ * forced to builtin so callers cannot widen into packages or other corpora.
+ */
+export function buildCapabilityVectorMetadataFilter(
+	callerFilter?: VectorizeVectorMetadataFilter,
+): VectorizeVectorMetadataFilter {
+	if (!callerFilter || Object.keys(callerFilter).length === 0) {
+		return { kind: { $eq: CAPABILITY_VECTOR_KIND } }
+	}
+	return {
+		...callerFilter,
+		kind: { $eq: CAPABILITY_VECTOR_KIND },
+	}
+}
+
 function truncateEmbeddingInput(text: string) {
 	if (text.length <= CAPABILITY_EMBEDDING_MAX_INPUT_CHARS) return text
 	return text.slice(0, CAPABILITY_EMBEDDING_MAX_INPUT_CHARS)
@@ -338,8 +362,17 @@ export async function searchCapabilities(input: {
 	limit: number
 	detail: boolean
 	specs: Record<string, CapabilitySpec>
-	/** When set (online only), Vectorize query uses this metadata filter first; falls back to unfiltered if no spec ids match. */
+	/**
+	 * Optional online-only metadata filter combined with the builtin capability
+	 * kind filter (RBAC/provider scoping). Never widens into other index kinds.
+	 */
 	vectorMetadataFilter?: VectorizeVectorMetadataFilter
+	/**
+	 * Optional precomputed query embedding. Callers that also rank packages
+	 * (or other Vectorize-backed corpora) against the same query should embed
+	 * once and pass the vector here to avoid a second Workers AI round-trip.
+	 */
+	queryVector?: ReadonlyArray<number>
 }): Promise<{ matches: Array<CapabilitySearchHit>; offline: boolean }> {
 	const q = input.query.trim()
 	const specs = input.specs
@@ -355,11 +388,16 @@ export async function searchCapabilities(input: {
 
 	let vectorOrder: Array<string>
 	let vectorScoreById: Record<string, number>
+	let vectorHitIds: Set<string>
 
 	const offline = isCapabilitySearchOffline(input.env)
 
 	if (offline) {
-		const qVec = deterministicEmbedding(q)
+		const qVec =
+			input.queryVector &&
+			input.queryVector.length === CAPABILITY_EMBEDDING_DIMENSIONS
+				? [...input.queryVector]
+				: deterministicEmbedding(q)
 		vectorScoreById = Object.fromEntries(
 			ids.map((id) => {
 				const cVec = deterministicEmbedding(docsById[id]!)
@@ -367,6 +405,7 @@ export async function searchCapabilities(input: {
 			}),
 		)
 		vectorOrder = sortIdsByScore(ids, (id) => vectorScoreById[id]!)
+		vectorHitIds = new Set(ids)
 	} else {
 		const index = getCapabilityVectorIndex(input.env)
 		if (!index) {
@@ -375,55 +414,43 @@ export async function searchCapabilities(input: {
 			)
 		}
 		const vectorIndex = index
-		const qVec = await embedTextForVectorize(input.env, q)
+		// Clone at the Vectorize boundary — Workers may mutate the query array.
+		const qVec = [
+			...(input.queryVector ?? (await embedTextForVectorize(input.env, q))),
+		]
 		const topK = Math.min(Math.max(ids.length, input.limit * 5), 100)
 		const vectorScoreMap = new Map<string, number>()
+		const filter = buildCapabilityVectorMetadataFilter(
+			input.vectorMetadataFilter,
+		)
 
-		async function queryVectorize(filter?: VectorizeVectorMetadataFilter) {
-			return vectorIndex.query(qVec, {
-				topK,
-				returnMetadata: 'none',
-				...(filter ? { filter } : {}),
-			})
-		}
-
-		let vecMatches = await queryVectorize(input.vectorMetadataFilter)
-		const collectFromMatches = (
-			raw: typeof vecMatches.matches,
-		): { fromIndex: Array<string>; seen: Set<string> } => {
-			const seen = new Set<string>()
-			const fromIndex: Array<string> = []
-			for (const m of raw) {
-				if (typeof m.id !== 'string' || !specs[m.id] || seen.has(m.id)) continue
-				seen.add(m.id)
-				fromIndex.push(m.id)
-				vectorScoreMap.set(m.id, m.score)
-			}
-			return { fromIndex, seen }
-		}
-
-		let { fromIndex, seen } = collectFromMatches(vecMatches.matches)
-		if (fromIndex.length === 0 && input.vectorMetadataFilter) {
-			vecMatches = await queryVectorize(undefined)
-			;({ fromIndex, seen } = collectFromMatches(vecMatches.matches))
-		}
-		const missingIds = ids.filter((id) => !seen.has(id))
-		if (missingIds.length > 0) {
-			const missingVectors = await embedTextsForVectorize(
-				input.env,
-				missingIds.map((id) => docsById[id]!),
+		const vecMatches = await vectorIndex.query(qVec, {
+			topK,
+			returnMetadata: 'none',
+			filter,
+		})
+		const fromIndex: Array<string> = []
+		const seen = new Set<string>()
+		for (const match of vecMatches.matches) {
+			if (
+				typeof match.id !== 'string' ||
+				!specs[match.id] ||
+				seen.has(match.id)
 			)
-			for (let index_ = 0; index_ < missingIds.length; index_ += 1) {
-				vectorScoreMap.set(
-					missingIds[index_]!,
-					cosineSimilarity(qVec, missingVectors[index_]!),
-				)
-			}
+				continue
+			seen.add(match.id)
+			fromIndex.push(match.id)
+			vectorScoreMap.set(match.id, match.score)
 		}
+		// Do not re-embed documents missing from Vectorize topK on the query path,
+		// and do not fall back to an unfiltered cross-kind query. Lexical ranking
+		// recalls non-vector hits; reindexing owns document embeddings.
+		vectorHitIds = seen
 		vectorScoreById = Object.fromEntries(
 			ids.map((id) => [id, vectorScoreMap.get(id) ?? Number.NEGATIVE_INFINITY]),
 		)
-		vectorOrder = sortIdsByScore(ids, (id) => vectorScoreById[id]!)
+		// Only real Vectorize hits participate in vectorOrder / RRF.
+		vectorOrder = fromIndex
 	}
 
 	const lexicalRankById = new Map<string, number>()
@@ -443,8 +470,13 @@ export async function searchCapabilities(input: {
 		.sort((a, b) => {
 			const fusedDiff = (fused.get(b) ?? 0) - (fused.get(a) ?? 0)
 			if (fusedDiff !== 0) return fusedDiff
-			const vectorDiff = vectorScoreById[b]! - vectorScoreById[a]!
-			if (vectorDiff !== 0) return vectorDiff
+			const aHasVector = vectorHitIds.has(a)
+			const bHasVector = vectorHitIds.has(b)
+			if (aHasVector !== bHasVector) return aHasVector ? -1 : 1
+			if (aHasVector && bHasVector) {
+				const vectorDiff = vectorScoreById[b]! - vectorScoreById[a]!
+				if (vectorDiff !== 0) return vectorDiff
+			}
 			return lexicalScoreById[b]! - lexicalScoreById[a]!
 		})
 		.slice(0, Math.max(1, Math.min(input.limit, ids.length)))
@@ -452,19 +484,23 @@ export async function searchCapabilities(input: {
 	const matches: Array<CapabilitySearchHit> = ordered.map((id) => {
 		const spec = specs[id]!
 		const base = input.detail ? toDetail(spec) : toSummary(spec)
+		const hasVectorHit = vectorHitIds.has(id)
 		const rawVectorScore = vectorScoreById[id]
 		const vectorScore =
-			rawVectorScore !== undefined && Number.isFinite(rawVectorScore)
+			hasVectorHit &&
+			rawVectorScore !== undefined &&
+			Number.isFinite(rawVectorScore)
 				? rawVectorScore
 				: 0
 		return {
 			...base,
 			fusedScore: fused.get(id) ?? 0,
 			lexicalRank: lexicalRankById.get(id),
-			vectorRank: vectorRankById.get(id),
+			// Omit vectorRank when there was no Vectorize hit so callers can
+			// treat the candidate as lexical-only (not vectorScore === 0).
+			...(hasVectorHit ? { vectorRank: vectorRankById.get(id) } : {}),
 			lexicalScore: lexicalScoreById[id] ?? 0,
-			// Keep non-finite scores internal to ranking and expose a stable numeric
-			// value on the public hit shape.
+			// Keep a stable numeric public field; ranking uses vectorRank presence.
 			vectorScore,
 		}
 	})

--- a/packages/worker/src/mcp/capabilities/meta/search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/search.node.test.ts
@@ -25,6 +25,24 @@ const mockModule = vi.hoisted(() => ({
 	listValues: vi.fn(async () => []),
 	loadRelevantMemoriesForTool: vi.fn(async () => null),
 	acknowledgeToolMemories: vi.fn(async () => undefined),
+	buildMemoryRetrievalQuery: vi.fn(
+		(
+			input?: {
+				task?: string
+				query?: string
+				entities?: Array<string>
+				constraints?: Array<string>
+			} | null,
+		) =>
+			[
+				input?.task,
+				input?.query,
+				...(input?.entities ?? []),
+				...(input?.constraints ?? []),
+			]
+				.filter(Boolean)
+				.join('\n'),
+	),
 	runPackageRetrievers: vi.fn(async () => ({ results: [], warnings: [] })),
 }))
 
@@ -56,6 +74,8 @@ vi.mock('#mcp/tools/memory-tool-context.ts', () => ({
 		mockModule.loadRelevantMemoriesForTool(...args),
 	acknowledgeToolMemories: (...args: Array<unknown>) =>
 		mockModule.acknowledgeToolMemories(...args),
+	buildMemoryRetrievalQuery: (...args: Array<unknown>) =>
+		mockModule.buildMemoryRetrievalQuery(...args),
 }))
 
 vi.mock('#worker/package-retrievers/service.ts', () => ({

--- a/packages/worker/src/mcp/capabilities/meta/search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/search.node.test.ts
@@ -24,6 +24,7 @@ const mockModule = vi.hoisted(() => ({
 	listUserSecretsForSearch: vi.fn(async () => []),
 	listValues: vi.fn(async () => []),
 	loadRelevantMemoriesForTool: vi.fn(async () => null),
+	acknowledgeToolMemories: vi.fn(async () => undefined),
 	runPackageRetrievers: vi.fn(async () => ({ results: [], warnings: [] })),
 }))
 
@@ -53,6 +54,8 @@ vi.mock('#mcp/values/service.ts', () => ({
 vi.mock('#mcp/tools/memory-tool-context.ts', () => ({
 	loadRelevantMemoriesForTool: (...args: Array<unknown>) =>
 		mockModule.loadRelevantMemoriesForTool(...args),
+	acknowledgeToolMemories: (...args: Array<unknown>) =>
+		mockModule.acknowledgeToolMemories(...args),
 }))
 
 vi.mock('#worker/package-retrievers/service.ts', () => ({

--- a/packages/worker/src/mcp/capabilities/meta/search.ts
+++ b/packages/worker/src/mcp/capabilities/meta/search.ts
@@ -15,7 +15,6 @@ import {
 	memoryContextInputField,
 	resolveConversationId,
 } from '#mcp/tools/tool-call-context.ts'
-import { loadRelevantMemoriesForTool } from '#mcp/tools/memory-tool-context.ts'
 
 const defaultSearchLimit = 15
 const maxSearchLimit = 100
@@ -168,10 +167,11 @@ export const searchCapability = defineDomainCapability(
 				includeHiddenPackages,
 			})
 			const {
+				launchSearchMemoryEnrichment,
 				loadDownRemoteConnectorStatuses,
-				resolveSearchMemoryContext,
 				searchUnified,
 				serializeRemoteConnectorStatus,
+				settleSearchMemoryEnrichment,
 			} = await import('#mcp/tools/search.ts')
 			let warnings: Array<string>
 			let result: {
@@ -179,6 +179,16 @@ export const searchCapability = defineDomainCapability(
 				offline: boolean
 				guidance?: string
 			}
+			const memoryLaunch = launchSearchMemoryEnrichment({
+				env: ctx.env,
+				callerContext: ctx.callerContext,
+				conversationId,
+				query,
+				memoryContext: args.memoryContext,
+			})
+			const memoryEnrichmentPromise =
+				memoryLaunch?.promise ?? Promise.resolve(null)
+			const memoryEnrichmentLaunchedAtMs = memoryLaunch?.launchedAtMs
 			if (identityResolution.recognized) {
 				warnings = []
 				result = {
@@ -205,6 +215,7 @@ export const searchCapability = defineDomainCapability(
 					env: ctx.env,
 					query,
 					limit: normalizeLimit(args.limit),
+					userId: userId ?? undefined,
 					registry: searchRows.registry,
 					optionalRows: searchRows,
 					retrieverResults: retrieverRun.results,
@@ -215,34 +226,27 @@ export const searchCapability = defineDomainCapability(
 				env: ctx.env,
 				callerContext: ctx.callerContext,
 			})
-			const memoryToolContext = await loadRelevantMemoriesForTool({
+			const memorySettlement = await settleSearchMemoryEnrichment({
 				env: ctx.env,
 				callerContext: ctx.callerContext,
 				conversationId,
-				memoryContext: resolveSearchMemoryContext({
-					query,
-					memoryContext: args.memoryContext,
-				}),
+				promise: memoryEnrichmentPromise,
+				launchedAtMs: memoryEnrichmentLaunchedAtMs,
 			})
-			warnings.push(...(memoryToolContext?.retrieverWarnings ?? []))
+			warnings.push(...memorySettlement.warnings)
 			return {
 				conversationId,
 				matches: toSlimStructuredMatches({
 					matches: result.matches,
 					baseUrl: ctx.callerContext.baseUrl,
+					username,
 				}) as Array<SlimSearchMatch>,
 				offline: result.offline,
 				warnings,
 				...(result.guidance ? { guidance: result.guidance } : {}),
-				...(memoryToolContext
+				...(memorySettlement.memories
 					? {
-							memories: {
-								surfaced: memoryToolContext.memories,
-								suppressedCount: memoryToolContext.suppressedCount,
-								retrievalQuery: memoryToolContext.retrievalQuery,
-								retrieverResults: memoryToolContext.retrieverResults,
-								retrieverWarnings: memoryToolContext.retrieverWarnings,
-							},
+							memories: memorySettlement.memories,
 						}
 					: {}),
 				...(remoteConnectorStatuses.length > 0

--- a/packages/worker/src/mcp/memory/memory-search.node.test.ts
+++ b/packages/worker/src/mcp/memory/memory-search.node.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { searchMemories } from './memory-search.ts'
+import { type McpMemoryRow } from './types.ts'
+
+function row(
+	id: string,
+	userId: string,
+	subject: string,
+	summary: string,
+): McpMemoryRow {
+	return {
+		id,
+		user_id: userId,
+		category: 'preference',
+		status: 'active',
+		subject,
+		summary,
+		details: '',
+		tags_json: '[]',
+		source_uris_json: '[]',
+		dedupe_key: null,
+		created_at: '2026-04-20T00:00:00.000Z',
+		updated_at: '2026-04-20T00:00:00.000Z',
+		last_accessed_at: null,
+		deleted_at: null,
+	}
+}
+
+test('searchMemories fail-closes on foreign rows and keeps Vectorize misses lexical-only', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const owned = [
+		row('mem-weak', 'user-1', 'helper', 'barely related ranking noise'),
+		row(
+			'mem-lexical',
+			'user-1',
+			'inbox triage',
+			'summarize inbox threads for triage',
+		),
+	]
+	const ranked = await searchMemories({
+		env: {} as Env,
+		query: 'summarize inbox threads for triage',
+		limit: 5,
+		userId: 'user-1',
+		statuses: ['active', 'archived'],
+		rows: owned,
+		vectorRankedIds: ['mem-weak'],
+	})
+	const lexicalOnly = ranked.matches.find((match) => match.id === 'mem-lexical')
+	expect(lexicalOnly).toMatchObject({ id: 'mem-lexical' })
+	expect(lexicalOnly).not.toHaveProperty('vectorRank')
+	expect(ranked.matches.find((match) => match.id === 'mem-weak')).toMatchObject(
+		{
+			vectorRank: 1,
+		},
+	)
+
+	const foreign = await searchMemories({
+		env: {} as Env,
+		query: 'summarize inbox threads for triage',
+		limit: 5,
+		userId: 'user-1',
+		statuses: ['active'],
+		rows: [...owned, row('mem-foreign', 'user-2', 'x', 'summarize inbox')],
+		vectorRankedIds: ['mem-weak'],
+	})
+	expect(foreign.matches).toEqual([])
+})

--- a/packages/worker/src/mcp/memory/memory-search.ts
+++ b/packages/worker/src/mcp/memory/memory-search.ts
@@ -14,10 +14,23 @@ import { parseJsonStringArray } from './json-string-array.ts'
 import { buildMemoryEmbedTextFromRow } from './memory-embed.ts'
 import { type McpMemoryRow, type MemorySearchMatch } from './types.ts'
 
+function buildMemoryVectorFilter(input: {
+	userId: string
+	statuses: ReadonlyArray<McpMemoryRow['status']>
+	category?: string | null
+}): VectorizeVectorMetadataFilter {
+	return {
+		kind: { $eq: 'memory' },
+		userId: { $eq: input.userId },
+		status: { $in: [...input.statuses] },
+		...(input.category ? { category: { $eq: input.category } } : {}),
+	}
+}
+
 /**
- * Queries Vectorize for the user's memory vectors (metadata filter on kind,
- * userId, status, and optional category) and returns memory ids ordered by
- * similarity. Returns an empty list when the vector index is unavailable.
+ * Queries Vectorize for the user's memory vectors (strict metadata filter on
+ * kind, userId, status, and optional category) and returns memory ids ordered
+ * by similarity. Returns an empty list when the vector index is unavailable.
  */
 export async function queryMemoryVectorIds(input: {
 	env: Env
@@ -28,17 +41,12 @@ export async function queryMemoryVectorIds(input: {
 	topK: number
 }): Promise<Array<string>> {
 	const index = getCapabilityVectorIndex(input.env)
-	if (!index) return []
+	if (!index || !input.userId) return []
 	const queryVector = await embedTextForVectorize(input.env, input.query)
 	const vectorMatches = await index.query(queryVector, {
 		topK: input.topK,
 		returnMetadata: 'none',
-		filter: {
-			kind: { $eq: 'memory' },
-			userId: { $eq: input.userId },
-			status: { $in: [...input.statuses] },
-			...(input.category ? { category: { $eq: input.category } } : {}),
-		},
+		filter: buildMemoryVectorFilter(input),
 	})
 	const memoryIds: Array<string> = []
 	const seen = new Set<string>()
@@ -59,22 +67,29 @@ export async function searchMemories(input: {
 	env: Env
 	query: string
 	limit: number
+	userId: string
+	statuses: ReadonlyArray<McpMemoryRow['status']>
+	category?: string | null
 	rows: Array<McpMemoryRow>
-	/**
-	 * Vector-ranked memory ids already fetched from Vectorize (online path).
-	 * When provided, no additional Vectorize query is issued here.
-	 */
 	vectorRankedIds?: ReadonlyArray<string>
 }): Promise<{ matches: Array<MemorySearchMatch>; offline: boolean }> {
 	const query = input.query.trim()
-	const rowsById = new Map(input.rows.map((row) => [row.id, row] as const))
-	const ids = [...rowsById.keys()]
 	const offline = isCapabilitySearchOffline(input.env)
-
-	if (!query || ids.length === 0) {
+	if (!query || !input.userId || input.rows.length === 0) {
+		return { matches: [], offline }
+	}
+	if (input.rows.some((row) => row.user_id !== input.userId)) {
+		console.warn(
+			JSON.stringify({
+				message: 'memory search skipped: row userId mismatch',
+				expectedUserId: input.userId,
+			}),
+		)
 		return { matches: [], offline }
 	}
 
+	const rowsById = new Map(input.rows.map((row) => [row.id, row] as const))
+	const ids = [...rowsById.keys()]
 	const docsById = Object.fromEntries(
 		input.rows.map(
 			(row) => [row.id, buildMemoryEmbedTextFromRow(row)] as const,
@@ -86,9 +101,7 @@ export async function searchMemories(input: {
 
 	let vectorOrder: Array<string>
 	if (input.vectorRankedIds) {
-		const fromIndex = input.vectorRankedIds.filter((id) => rowsById.has(id))
-		const fromIndexSet = new Set(fromIndex)
-		vectorOrder = [...fromIndex, ...ids.filter((id) => !fromIndexSet.has(id))]
+		vectorOrder = input.vectorRankedIds.filter((id) => rowsById.has(id))
 	} else if (offline) {
 		const queryVector = deterministicEmbedding(query)
 		const similarityById = Object.fromEntries(
@@ -102,20 +115,14 @@ export async function searchMemories(input: {
 		const index = getCapabilityVectorIndex(input.env)!
 		const queryVector = await embedTextForVectorize(input.env, query)
 		const topK = Math.min(Math.max(ids.length, input.limit * 5), 100)
-		const userIds = Array.from(
-			new Set(input.rows.map((row) => row.user_id).filter(Boolean)),
-		)
 		const vectorMatches = await index.query(queryVector, {
 			topK,
 			returnMetadata: 'none',
-			filter: {
-				kind: { $eq: 'memory' },
-				...(userIds.length === 1
-					? {
-							userId: { $eq: userIds[0] },
-						}
-					: {}),
-			},
+			filter: buildMemoryVectorFilter({
+				userId: input.userId,
+				statuses: input.statuses,
+				category: input.category,
+			}),
 		})
 		const seen = new Set<string>()
 		const fromIndex: Array<string> = []
@@ -125,12 +132,11 @@ export async function searchMemories(input: {
 				prefix: 'memory',
 				vectorId: match.id,
 			})
-			if (!memoryId) continue
-			if (!rowsById.has(memoryId)) continue
+			if (!memoryId || !rowsById.has(memoryId)) continue
 			seen.add(match.id)
 			fromIndex.push(memoryId)
 		}
-		vectorOrder = [...fromIndex, ...ids.filter((id) => !fromIndex.includes(id))]
+		vectorOrder = fromIndex
 	}
 
 	const lexicalRankById = new Map<string, number>()
@@ -154,6 +160,7 @@ export async function searchMemories(input: {
 	return {
 		matches: ordered.map((id) => {
 			const row = rowsById.get(id)!
+			const vectorRank = vectorRankById.get(id)
 			return {
 				id: row.id,
 				category: row.category,
@@ -170,7 +177,7 @@ export async function searchMemories(input: {
 				deletedAt: row.deleted_at,
 				score: fused.get(id) ?? 0,
 				lexicalRank: lexicalRankById.get(id),
-				vectorRank: vectorRankById.get(id),
+				...(vectorRank != null ? { vectorRank } : {}),
 			}
 		}),
 		offline,

--- a/packages/worker/src/mcp/memory/repo.ts
+++ b/packages/worker/src/mcp/memory/repo.ts
@@ -247,6 +247,22 @@ export async function listMemoriesPage(input: {
 	return (results ?? []).map(mapMemoryRow)
 }
 
+function touchMemoryAccessedAtStatement(
+	db: D1Database,
+	userId: string,
+	memoryIds: Array<string>,
+	timestamp: string,
+) {
+	const placeholders = memoryIds.map(() => '?').join(', ')
+	return db
+		.prepare(
+			`UPDATE mcp_memories
+			SET last_accessed_at = ?, updated_at = updated_at
+			WHERE user_id = ? AND id IN (${placeholders})`,
+		)
+		.bind(timestamp, userId, ...memoryIds)
+}
+
 export async function touchMemoryAccessedAt(
 	db: D1Database,
 	userId: string,
@@ -255,15 +271,7 @@ export async function touchMemoryAccessedAt(
 ) {
 	if (memoryIds.length === 0) return
 	const touchedAt = timestamp ?? new Date().toISOString()
-	const placeholders = memoryIds.map(() => '?').join(', ')
-	await db
-		.prepare(
-			`UPDATE mcp_memories
-			SET last_accessed_at = ?, updated_at = updated_at
-			WHERE user_id = ? AND id IN (${placeholders})`,
-		)
-		.bind(touchedAt, userId, ...memoryIds)
-		.run()
+	await touchMemoryAccessedAtStatement(db, userId, memoryIds, touchedAt).run()
 }
 
 export async function getConversationSuppressions(input: {
@@ -284,6 +292,36 @@ export async function getConversationSuppressions(input: {
 	return (results ?? []).map(mapSuppressionRow)
 }
 
+const conversationSuppressionUpsertSql = `INSERT INTO mcp_memory_conversation_suppressions (
+					user_id, conversation_id, memory_id, created_at, last_seen_at, expires_at
+				) VALUES (?, ?, ?, ?, ?, ?)
+				ON CONFLICT(user_id, conversation_id, memory_id)
+				DO UPDATE SET
+					last_seen_at = excluded.last_seen_at,
+					expires_at = excluded.expires_at`
+
+function conversationSuppressionUpsertStatements(input: {
+	db: D1Database
+	userId: string
+	conversationId: string
+	memoryIds: Array<string>
+	expiresAt: string
+	now: string
+}) {
+	return input.memoryIds.map((memoryId) =>
+		input.db
+			.prepare(conversationSuppressionUpsertSql)
+			.bind(
+				input.userId,
+				input.conversationId,
+				memoryId,
+				input.now,
+				input.now,
+				input.expiresAt,
+			),
+	)
+}
+
 export async function upsertConversationSuppressions(input: {
 	db: D1Database
 	userId: string
@@ -294,27 +332,48 @@ export async function upsertConversationSuppressions(input: {
 }) {
 	if (input.memoryIds.length === 0) return
 	const now = input.now ?? new Date().toISOString()
-	for (const memoryId of input.memoryIds) {
-		await input.db
-			.prepare(
-				`INSERT INTO mcp_memory_conversation_suppressions (
-					user_id, conversation_id, memory_id, created_at, last_seen_at, expires_at
-				) VALUES (?, ?, ?, ?, ?, ?)
-				ON CONFLICT(user_id, conversation_id, memory_id)
-				DO UPDATE SET
-					last_seen_at = excluded.last_seen_at,
-					expires_at = excluded.expires_at`,
-			)
-			.bind(
-				input.userId,
-				input.conversationId,
-				memoryId,
-				now,
-				now,
-				input.expiresAt,
-			)
-			.run()
-	}
+	await input.db.batch(
+		conversationSuppressionUpsertStatements({
+			db: input.db,
+			userId: input.userId,
+			conversationId: input.conversationId,
+			memoryIds: input.memoryIds,
+			expiresAt: input.expiresAt,
+			now,
+		}),
+	)
+}
+
+/**
+ * Atomically upsert conversation suppressions and touch last_accessed_at in one
+ * D1 batch so acknowledgement cannot partially suppress.
+ */
+export async function acknowledgeSurfacedMemoryWrites(input: {
+	db: D1Database
+	userId: string
+	conversationId: string
+	memoryIds: Array<string>
+	expiresAt: string
+	now?: string
+}) {
+	if (input.memoryIds.length === 0) return
+	const now = input.now ?? new Date().toISOString()
+	await input.db.batch([
+		...conversationSuppressionUpsertStatements({
+			db: input.db,
+			userId: input.userId,
+			conversationId: input.conversationId,
+			memoryIds: input.memoryIds,
+			expiresAt: input.expiresAt,
+			now,
+		}),
+		touchMemoryAccessedAtStatement(
+			input.db,
+			input.userId,
+			input.memoryIds,
+			now,
+		),
+	])
 }
 
 export async function pruneExpiredConversationSuppressions(

--- a/packages/worker/src/mcp/memory/service.node.test.ts
+++ b/packages/worker/src/mcp/memory/service.node.test.ts
@@ -4,6 +4,7 @@ import {
 	deterministicEmbedding,
 } from '#mcp/capabilities/capability-search.ts'
 import {
+	acknowledgeSurfacedMemories,
 	deleteMemory,
 	getMemory,
 	searchMemoryRecords,
@@ -19,6 +20,7 @@ import {
 function createMemoryTestDb() {
 	const memories = new Map<string, McpMemoryRow>()
 	const suppressions = new Map<string, McpMemoryConversationSuppressionRow>()
+	const batches: Array<Array<unknown>> = []
 
 	function suppressionKey(
 		userId: string,
@@ -29,6 +31,14 @@ function createMemoryTestDb() {
 	}
 
 	const db = {
+		async batch(statements: Array<{ run: () => Promise<unknown> }>) {
+			batches.push(statements)
+			const results = []
+			for (const statement of statements) {
+				results.push(await statement.run())
+			}
+			return results
+		},
 		prepare(query: string) {
 			const normalizedQuery = query.replace(/\s+/g, ' ').trim().toLowerCase()
 			return {
@@ -259,7 +269,7 @@ function createMemoryTestDb() {
 		},
 	} as unknown as D1Database
 
-	return { db, memories, suppressions }
+	return { db, memories, suppressions, batches }
 }
 
 const env = (db: D1Database) =>
@@ -481,6 +491,39 @@ test('memory surfacing suppresses repeated memories per conversation', async () 
 
 	expect(search.matches).toHaveLength(0)
 	expect(search.suppressedCount).toBeGreaterThanOrEqual(1)
+})
+
+test('acknowledgeSurfacedMemories writes suppressions and last_accessed in one batch', async () => {
+	const testDb = createMemoryTestDb()
+	const runtimeEnv = env(testDb.db)
+	const created = await upsertMemory({
+		env: runtimeEnv,
+		userId: 'user-123',
+		subject: 'Ack batch',
+		summary: 'Atomic acknowledgement coverage.',
+		category: 'workflow',
+		verificationReference: 'verify-ack-batch',
+	})
+	testDb.batches.length = 0
+
+	await acknowledgeSurfacedMemories({
+		env: runtimeEnv,
+		userId: 'user-123',
+		conversationId: 'conv-ack-batch',
+		memoryIds: [created.memory.id],
+	})
+
+	expect(testDb.batches).toHaveLength(1)
+	expect(testDb.batches[0]).toHaveLength(2)
+	expect(
+		testDb.suppressions.get(`user-123:conv-ack-batch:${created.memory.id}`),
+	).toMatchObject({
+		memory_id: created.memory.id,
+		conversation_id: 'conv-ack-batch',
+	})
+	expect(testDb.memories.get(created.memory.id)?.last_accessed_at).toEqual(
+		expect.any(String),
+	)
 })
 
 test('memory service rejects invalid source uris and tolerates missing stored values', async () => {

--- a/packages/worker/src/mcp/memory/service.ts
+++ b/packages/worker/src/mcp/memory/service.ts
@@ -2,6 +2,7 @@ import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { type StorageContext } from '#mcp/storage.ts'
 import { isCapabilitySearchOffline } from '#mcp/capabilities/capability-search.ts'
 import {
+	acknowledgeSurfacedMemoryWrites,
 	deleteMemory as deleteMemoryRow,
 	getConversationSuppressions,
 	getMemoryById,
@@ -9,9 +10,7 @@ import {
 	listMemoriesByIds,
 	listMemoriesByUserId,
 	pruneExpiredConversationSuppressions,
-	touchMemoryAccessedAt,
 	updateMemory,
-	upsertConversationSuppressions,
 } from './repo.ts'
 import { parseJsonStringArray } from './json-string-array.ts'
 import { buildMemoryEmbedText } from './memory-embed.ts'
@@ -130,6 +129,30 @@ type SurfaceRelevantMemoriesInput = MemoryOwnerContext & {
 	query: string
 	conversationId: string
 	limit?: number
+	acknowledgeSurfaced?: boolean
+}
+
+/**
+ * Marks memories as surfaced for a conversation so later enrichment does not repeat them.
+ */
+export async function acknowledgeSurfacedMemories(input: {
+	env: MemoryEnv
+	userId: string
+	conversationId: string
+	memoryIds: Array<string>
+}) {
+	const memoryIds = Array.from(
+		new Set(input.memoryIds.filter((id) => id.trim().length > 0)),
+	)
+	if (memoryIds.length === 0) return
+	const expiresAt = new Date(Date.now() + defaultSuppressionTtlMs).toISOString()
+	await acknowledgeSurfacedMemoryWrites({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		conversationId: input.conversationId,
+		memoryIds,
+		expiresAt,
+	})
 }
 
 export async function upsertMemory(input: MemoryUpsertInput): Promise<{
@@ -436,6 +459,9 @@ export async function searchMemoryRecords(input: MemorySearchInput): Promise<{
 		env: input.env as Env,
 		query,
 		limit: rankedLimit,
+		userId: input.userId,
+		statuses,
+		category,
 		rows: filteredRows,
 		...(vectorRankedIds ? { vectorRankedIds } : {}),
 	})
@@ -523,20 +549,15 @@ export async function surfaceRelevantMemories(
 	}
 
 	const memories = result.matches.map(mapSearchMatchToMemoryRecord)
-
+	const acknowledgeSurfaced = input.acknowledgeSurfaced !== false
 	const memoryIds = memories.map((memory) => memory.id)
-	if (memoryIds.length > 0) {
-		const expiresAt = new Date(
-			Date.now() + defaultSuppressionTtlMs,
-		).toISOString()
-		await upsertConversationSuppressions({
-			db: input.env.APP_DB,
+	if (acknowledgeSurfaced && memoryIds.length > 0) {
+		await acknowledgeSurfacedMemories({
+			env: input.env,
 			userId: input.userId,
 			conversationId: input.conversationId,
 			memoryIds,
-			expiresAt,
 		})
-		await touchMemoryAccessedAt(input.env.APP_DB, input.userId, memoryIds)
 	}
 
 	return {

--- a/packages/worker/src/mcp/tools/memory-tool-context.ts
+++ b/packages/worker/src/mcp/tools/memory-tool-context.ts
@@ -1,6 +1,9 @@
 import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
-import { surfaceRelevantMemories } from '#mcp/memory/service.ts'
+import {
+	acknowledgeSurfacedMemories,
+	surfaceRelevantMemories,
+} from '#mcp/memory/service.ts'
 import { type MemoryRecord } from '#mcp/memory/types.ts'
 import { type PackageRetrieverSurfaceResult } from '#worker/package-retrievers/types.ts'
 import {
@@ -64,6 +67,7 @@ export async function loadRelevantMemoriesForTool(input: {
 		constraints?: Array<string>
 	} | null
 	limit?: number
+	acknowledgeSurfaced?: boolean
 }): Promise<MemoryToolSummary | null> {
 	const userId = input.callerContext.user?.userId ?? null
 	if (!userId) return null
@@ -80,6 +84,7 @@ export async function loadRelevantMemoriesForTool(input: {
 			query: retrievalQuery,
 			conversationId: input.conversationId,
 			limit: input.limit,
+			acknowledgeSurfaced: input.acknowledgeSurfaced,
 		}),
 		runContextPackageRetrievers({
 			env: input.env as Env,
@@ -106,6 +111,22 @@ export async function loadRelevantMemoriesForTool(input: {
 		suppressedCount: result.suppressedCount,
 		retrievalQuery: result.retrievalQuery,
 	}
+}
+
+export async function acknowledgeToolMemories(input: {
+	env: Pick<Env, 'APP_DB'> & Partial<Pick<Env, 'CAPABILITY_VECTOR_INDEX'>>
+	callerContext: McpCallerContext
+	conversationId: string
+	memoryIds: Array<string>
+}) {
+	const userId = input.callerContext.user?.userId ?? null
+	if (!userId || input.memoryIds.length === 0) return
+	await acknowledgeSurfacedMemories({
+		env: input.env,
+		userId,
+		conversationId: input.conversationId,
+		memoryIds: input.memoryIds,
+	})
 }
 
 export async function surfaceToolMemories(input: {

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -89,6 +89,7 @@ export type SearchResultStructuredContent = {
 		memoryEnrichmentTimedOut?: boolean
 		memoryAcknowledgementTimedOut?: boolean
 		memoryEnrichmentFailed?: boolean
+		memoryAcknowledgementFailed?: boolean
 	}
 	memories?: {
 		surfaced: Array<{

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -77,6 +77,18 @@ export type SearchResultStructuredContent = {
 		candidateGenerationMs: number
 		rerankingMs: number
 		formattingMs?: number
+		rowAndRegistryLoadMs?: number
+		retrieversMs?: number
+		queryEmbeddingMs?: number
+		capabilityCandidatesMs?: number
+		packageCandidatesMs?: number
+		remoteConnectorStatusMs?: number
+		memoryEnrichmentMs?: number
+		memoryEnrichmentWaitMs?: number
+		memoryAcknowledgementMs?: number
+		memoryEnrichmentTimedOut?: boolean
+		memoryAcknowledgementTimedOut?: boolean
+		memoryEnrichmentFailed?: boolean
 	}
 	memories?: {
 		surfaced: Array<{

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -791,7 +791,8 @@ test('search tool memory enrichment: timeout, rejection, and ack failure stay of
 	expect(ackResult.warnings).toContain(memoryAcknowledgementWarning)
 	expect(ackResult.phaseTimings).toEqual(
 		expect.objectContaining({
-			memoryEnrichmentFailed: true,
+			memoryEnrichmentFailed: false,
+			memoryAcknowledgementFailed: true,
 			memoryAcknowledgementMs: expect.any(Number),
 		}),
 	)

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -688,6 +688,34 @@ test('search tool memory enrichment: timeout, rejection, and ack failure stay of
 		results: [],
 		warnings: [],
 	})
+	mockModule.loadRelevantMemoriesForTool.mockResolvedValueOnce(memorySummary)
+	const { handler: structuredContextHandler } = await getSearchRegistration({
+		user,
+	})
+	const structuredContextResult = await structuredContextHandler({
+		query: ' ',
+		conversationId: 'conv-structured-memory',
+		memoryContext: { task: 'search docs' },
+	})
+	expect(mockModule.loadRelevantMemoriesForTool).toHaveBeenCalledWith(
+		expect.objectContaining({
+			memoryContext: { task: 'search docs' },
+			acknowledgeSurfaced: false,
+		}),
+	)
+	expect(
+		(
+			structuredContextResult.structuredContent.result as {
+				memories?: { surfaced: Array<{ id: string }> }
+			}
+		).memories?.surfaced,
+	).toEqual([expect.objectContaining({ id: 'memory-1' })])
+
+	vi.clearAllMocks()
+	mockModule.runPackageRetrievers.mockResolvedValue({
+		results: [],
+		warnings: [],
+	})
 	mockModule.loadRelevantMemoriesForTool.mockImplementation(
 		() =>
 			new Promise((resolve) => {

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -26,6 +26,7 @@ const mockModule = vi.hoisted(() => ({
 	listValues: vi.fn(async () => []),
 	loadPackageSourceBySourceId: vi.fn(),
 	loadRelevantMemoriesForTool: vi.fn(async () => null),
+	acknowledgeToolMemories: vi.fn(async () => undefined),
 	runPackageRetrievers: vi.fn(async () => ({
 		results: [],
 		warnings: [],
@@ -76,6 +77,8 @@ vi.mock('./memory-tool-context.ts', async () => {
 		...actual,
 		loadRelevantMemoriesForTool: (...args: Array<unknown>) =>
 			mockModule.loadRelevantMemoriesForTool(...args),
+		acknowledgeToolMemories: (...args: Array<unknown>) =>
+			mockModule.acknowledgeToolMemories(...args),
 	}
 })
 
@@ -89,7 +92,13 @@ vi.mock('#worker/remote-connector/status.ts', () => ({
 		mockModule.getRemoteConnectorStatus(...args),
 }))
 
-const { registerSearchTool } = await import('./search.ts')
+const {
+	registerSearchTool,
+	SEARCH_MEMORY_ACKNOWLEDGEMENT_BUDGET_MS,
+	SEARCH_MEMORY_ENRICHMENT_BUDGET_MS,
+	memoryAcknowledgementWarning,
+	memoryEnrichmentSkippedWarning,
+} = await import('./search.ts')
 
 const mockPerformanceNow = vi.spyOn(performance, 'now')
 
@@ -229,7 +238,14 @@ test('search tool returns compact query markdown while preserving structured aux
 			'Second memory retriever warning should remain structured.',
 		],
 	})
-	const handler = await getSearchHandler()
+	const { handler } = await getSearchRegistration({
+		user: {
+			userId: 'user-1',
+			email: 'user@example.com',
+			displayName: 'User',
+			username: 'user',
+		},
+	})
 
 	mockPerformanceNow.mockReturnValueOnce(100).mockReturnValueOnce(112)
 	const successResponse = await handler({
@@ -255,6 +271,10 @@ test('search tool returns compact query markdown while preserving structured aux
 		warnings: Array<string>
 		guidance?: string
 		memories?: { surfaced: Array<{ id: string }> }
+		phaseTimings?: {
+			memoryEnrichmentMs?: number
+			memoryEnrichmentTimedOut?: boolean
+		}
 		matches: Array<{ type: string; entityRef?: string }>
 	}
 	expect(result.warnings).toHaveLength(2)
@@ -267,6 +287,19 @@ test('search tool returns compact query markdown while preserving structured aux
 	expect(result.memories?.surfaced).toEqual([
 		expect.objectContaining({ id: 'memory-1' }),
 	])
+	expect(result.phaseTimings).toEqual(
+		expect.objectContaining({
+			memoryEnrichmentTimedOut: false,
+			memoryEnrichmentMs: expect.any(Number),
+			memoryAcknowledgementMs: expect.any(Number),
+		}),
+	)
+	expect(mockModule.acknowledgeToolMemories).toHaveBeenCalledWith(
+		expect.objectContaining({
+			conversationId: 'conv-compact-search',
+			memoryIds: ['memory-1'],
+		}),
+	)
 
 	mockPerformanceNow.mockReturnValueOnce(5).mockReturnValueOnce(9)
 	const validationErrorResponse = await handler({
@@ -296,7 +329,6 @@ test('search tool returns compact query markdown while preserving structured aux
 		'Registry unavailable',
 	)
 })
-
 test('search tool excludes hidden packages by default and includes them with includeHiddenPackages', async () => {
 	vi.clearAllMocks()
 	consoleWarn.mockImplementation(() => {})
@@ -624,3 +656,181 @@ test('search tool batches entity detail with per-ref isolation and preserves sin
 		}),
 	])
 })
+
+test('search tool memory enrichment: timeout, rejection, and ack failure stay off the critical path', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const user = {
+		userId: 'user-1',
+		email: 'user@example.com',
+		displayName: 'User',
+		username: 'user',
+	}
+	const memorySummary = {
+		memories: [
+			{
+				id: 'memory-1',
+				category: 'preference',
+				status: 'active',
+				subject: 'Search preference',
+				summary: 'Prefers compact search results',
+				details: '',
+				tags: ['search'],
+				updatedAt: '2026-04-20T00:00:00.000Z',
+			},
+		],
+		suppressedCount: 0,
+		retrievalQuery: 'search docs',
+		retrieverResults: [],
+		retrieverWarnings: [],
+	}
+
+	vi.clearAllMocks()
+	mockModule.runPackageRetrievers.mockResolvedValue({
+		results: [],
+		warnings: [],
+	})
+	mockModule.loadRelevantMemoriesForTool.mockImplementation(
+		() =>
+			new Promise((resolve) => {
+				setTimeout(
+					() => resolve(memorySummary),
+					SEARCH_MEMORY_ENRICHMENT_BUDGET_MS + 250,
+				)
+			}),
+	)
+	const { handler: timeoutHandler } = await getSearchRegistration({ user })
+	const timedOut = await timeoutHandler({
+		query: 'search docs',
+		conversationId: 'conv-memory-budget',
+	})
+	const timedOutResult = timedOut.structuredContent.result as {
+		matches: Array<{ type: string }>
+		memories?: unknown
+		warnings: Array<string>
+		phaseTimings?: Record<string, unknown>
+	}
+	expect(timedOutResult.matches.length).toBeGreaterThan(0)
+	expect(timedOutResult.memories).toBeUndefined()
+	expect(timedOutResult.warnings).toContain(memoryEnrichmentSkippedWarning)
+	expect(timedOutResult.phaseTimings).toEqual(
+		expect.objectContaining({
+			memoryEnrichmentTimedOut: true,
+			memoryEnrichmentFailed: false,
+			memoryEnrichmentMs: expect.any(Number),
+			memoryEnrichmentWaitMs: expect.any(Number),
+		}),
+	)
+	expect(mockModule.loadRelevantMemoriesForTool).toHaveBeenCalledWith(
+		expect.objectContaining({ acknowledgeSurfaced: false }),
+	)
+
+	vi.clearAllMocks()
+	consoleWarn.mockImplementation(() => {})
+	const unhandled: Array<unknown> = []
+	const onUnhandled = (reason: unknown) => {
+		unhandled.push(reason)
+	}
+	process.on('unhandledRejection', onUnhandled)
+	try {
+		mockModule.runPackageRetrievers.mockResolvedValue({
+			results: [],
+			warnings: [],
+		})
+		mockModule.loadRelevantMemoriesForTool.mockRejectedValueOnce(
+			new Error('memory store unavailable'),
+		)
+		const { handler } = await getSearchRegistration({ user })
+		const rejected = await handler({
+			query: 'search docs',
+			conversationId: 'conv-memory-reject',
+		})
+		const rejectedResult = rejected.structuredContent.result as {
+			memories?: unknown
+			warnings: Array<string>
+			phaseTimings?: Record<string, unknown>
+		}
+		expect(rejectedResult.memories).toBeUndefined()
+		expect(rejectedResult.warnings).toContain(memoryEnrichmentSkippedWarning)
+		expect(rejectedResult.phaseTimings).toEqual(
+			expect.objectContaining({
+				memoryEnrichmentFailed: true,
+				memoryEnrichmentTimedOut: false,
+			}),
+		)
+		await Promise.resolve()
+		await Promise.resolve()
+		expect(unhandled).toEqual([])
+	} finally {
+		process.off('unhandledRejection', onUnhandled)
+	}
+
+	vi.clearAllMocks()
+	consoleWarn.mockImplementation(() => {})
+	mockModule.runPackageRetrievers.mockResolvedValue({
+		results: [],
+		warnings: [],
+	})
+	mockModule.loadRelevantMemoriesForTool.mockResolvedValueOnce(memorySummary)
+	mockModule.acknowledgeToolMemories.mockRejectedValueOnce(
+		new Error('ack store unavailable'),
+	)
+	const { handler: ackHandler } = await getSearchRegistration({ user })
+	const ackFailed = await ackHandler({
+		query: 'search docs',
+		conversationId: 'conv-memory-ack-fail',
+	})
+	const ackResult = ackFailed.structuredContent.result as {
+		matches: Array<{ type: string }>
+		memories?: { surfaced: Array<{ id: string }> }
+		warnings: Array<string>
+		phaseTimings?: Record<string, unknown>
+	}
+	expect(ackResult.matches.length).toBeGreaterThan(0)
+	expect(ackResult.memories?.surfaced).toEqual([
+		expect.objectContaining({ id: 'memory-1' }),
+	])
+	expect(ackResult.warnings).toContain(memoryAcknowledgementWarning)
+	expect(ackResult.phaseTimings).toEqual(
+		expect.objectContaining({
+			memoryEnrichmentFailed: true,
+			memoryAcknowledgementMs: expect.any(Number),
+		}),
+	)
+
+	vi.clearAllMocks()
+	consoleWarn.mockImplementation(() => {})
+	mockModule.runPackageRetrievers.mockResolvedValue({
+		results: [],
+		warnings: [],
+	})
+	mockModule.loadRelevantMemoriesForTool.mockResolvedValueOnce(memorySummary)
+	mockModule.acknowledgeToolMemories.mockImplementation(
+		() => new Promise(() => {}),
+	)
+	const { handler: neverSettlingHandler } = await getSearchRegistration({
+		user,
+	})
+	const neverSettling = await neverSettlingHandler({
+		query: 'search docs',
+		conversationId: 'conv-memory-ack-hang',
+	})
+	const hangResult = neverSettling.structuredContent.result as {
+		memories?: { surfaced: Array<{ id: string }> }
+		warnings: Array<string>
+		phaseTimings?: Record<string, unknown>
+	}
+	expect(hangResult.memories?.surfaced).toEqual([
+		expect.objectContaining({ id: 'memory-1' }),
+	])
+	expect(hangResult.warnings).toContain(memoryAcknowledgementWarning)
+	expect(hangResult.phaseTimings).toEqual(
+		expect.objectContaining({
+			memoryAcknowledgementTimedOut: true,
+			memoryEnrichmentFailed: false,
+			memoryAcknowledgementMs: expect.any(Number),
+		}),
+	)
+	expect(
+		hangResult.phaseTimings?.memoryAcknowledgementMs,
+	).toBeGreaterThanOrEqual(SEARCH_MEMORY_ACKNOWLEDGEMENT_BUDGET_MS)
+}, 10_000)

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -94,7 +94,6 @@ vi.mock('#worker/remote-connector/status.ts', () => ({
 
 const {
 	registerSearchTool,
-	SEARCH_MEMORY_ACKNOWLEDGEMENT_BUDGET_MS,
 	SEARCH_MEMORY_ENRICHMENT_BUDGET_MS,
 	memoryAcknowledgementWarning,
 	memoryEnrichmentSkippedWarning,
@@ -830,7 +829,4 @@ test('search tool memory enrichment: timeout, rejection, and ack failure stay of
 			memoryAcknowledgementMs: expect.any(Number),
 		}),
 	)
-	expect(
-		hangResult.phaseTimings?.memoryAcknowledgementMs,
-	).toBeGreaterThanOrEqual(SEARCH_MEMORY_ACKNOWLEDGEMENT_BUDGET_MS)
 }, 10_000)

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -16,6 +16,7 @@ import {
 	loadDownRemoteConnectorStatuses,
 	loadOptionalSearchRows,
 	searchUnified,
+	settleWithBudget,
 	type OptionalSearchRowsResult,
 	type PackageSearchRow,
 } from './search.ts'
@@ -82,6 +83,92 @@ function createDeterministicAiBinding(): Ai {
 			}
 		},
 	} as unknown as Ai
+}
+
+function leanPackage(
+	id: string,
+	userId: string,
+	name: string,
+	description: string,
+): PackageSearchRow {
+	return {
+		record: {
+			id,
+			userId,
+			name,
+			kodyId: name,
+			description,
+			tags: [],
+			searchText: null,
+			sourceId: `source-${id}`,
+			hasApp: false,
+			hidden: false,
+			isPrivate: false,
+			createdAt: '2026-04-20T00:00:00.000Z',
+			updatedAt: '2026-04-20T00:00:00.000Z',
+		},
+		projection: {
+			name,
+			kodyId: name,
+			description,
+			tags: [],
+			searchText: null,
+			hasApp: false,
+			hidden: false,
+			isPrivate: false,
+			appEntry: null,
+			exports: [],
+			jobs: [],
+			services: [],
+			subscriptions: [],
+			retrievers: [],
+		},
+		readmeSnippet: null,
+	}
+}
+
+function homeCapability(
+	name: string,
+	description: string,
+	keywords: Array<string>,
+) {
+	return {
+		name,
+		domain: 'home' as const,
+		description,
+		keywords,
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: { type: 'object' as const, properties: {} },
+		handler: async () => null,
+	}
+}
+
+function leanPackageRow(
+	id: string,
+	userId: string,
+	overrides: Partial<PackageSearchRow['record']> = {},
+): PackageSearchRow {
+	const row = leanPackage(
+		id,
+		userId,
+		overrides.name ?? id,
+		overrides.description ?? '',
+	)
+	return {
+		...row,
+		record: { ...row.record, ...overrides },
+		projection: {
+			...row.projection,
+			name: overrides.name ?? row.projection.name,
+			kodyId: overrides.kodyId ?? row.projection.kodyId,
+			description: overrides.description ?? row.projection.description,
+			tags: overrides.tags ?? row.projection.tags,
+			searchText: overrides.searchText ?? row.projection.searchText,
+			hasApp: overrides.hasApp ?? row.projection.hasApp,
+		},
+	}
 }
 
 function createPackageExportProjection(
@@ -151,40 +238,14 @@ test('searchUnified ranks mixed search rows through one shared pipeline', async 
 			],
 		},
 	])
-	const packageRows: Array<PackageSearchRow> = [
-		{
-			record: {
-				id: 'pkg-1',
-				userId: 'user-1',
-				name: 'alpha',
-				kodyId: 'beta',
-				description: 'gamma',
-				tags: ['delta'],
-				searchText: 'epsilon',
-				sourceId: 'source-1',
-				hasApp: false,
-				hidden: false,
-				isPrivate: false,
-				createdAt: '2026-04-20T00:00:00.000Z',
-				updatedAt: '2026-04-20T00:00:00.000Z',
-			},
-			projection: {
-				name: 'alpha',
-				kodyId: 'beta',
-				description: 'gamma',
-				tags: ['delta'],
-				searchText: 'epsilon',
-				hasApp: false,
-				hidden: false,
-				isPrivate: false,
-				appEntry: null,
-				exports: [],
-				jobs: [],
-				services: [],
-				subscriptions: [],
-				retrievers: [],
-			},
-		},
+	const packageRows = [
+		leanPackageRow('pkg-1', 'user-1', {
+			name: 'alpha',
+			kodyId: 'beta',
+			description: 'gamma',
+			tags: ['delta'],
+			searchText: 'epsilon',
+		}),
 	]
 	const optionalRows = {
 		packageRows,
@@ -235,6 +296,7 @@ test('searchUnified ranks mixed search rows through one shared pipeline', async 
 		env: {} as Env,
 		query: 'alpha\nbeta\ngamma\ndelta\nepsilon',
 		limit: 5,
+		userId: 'user-1',
 		registry,
 		optionalRows,
 	})
@@ -421,11 +483,7 @@ test('searchUnified ranks package retriever results alongside capabilities', asy
 		query: 'target lookup note',
 		limit: 5,
 		registry: buildCapabilityRegistry([]),
-		optionalRows: {
-			packageRows: [],
-			userSecretRows: [],
-			userValueRows: [],
-		},
+		optionalRows: emptyOptionalSearchRows,
 		retrieverResults,
 	})
 	expect(directMatch.matches).toEqual([
@@ -443,11 +501,7 @@ test('searchUnified ranks package retriever results alongside capabilities', asy
 		query: 'target lookup',
 		limit: 2,
 		registry,
-		optionalRows: {
-			packageRows: [],
-			userSecretRows: [],
-			userValueRows: [],
-		},
+		optionalRows: emptyOptionalSearchRows,
 		retrieverResults: [
 			{
 				...retrieverResults[0]!,
@@ -613,6 +667,7 @@ test('searchUnified annotates high-confidence package action matches', async () 
 	const result = await searchUnified({
 		env: {} as Env,
 		query: 'module-a run task',
+		userId: 'user-1',
 		limit: 5,
 		registry,
 		optionalRows: {
@@ -642,6 +697,7 @@ test('searchUnified annotates high-confidence package action matches', async () 
 	const broadQuery = await searchUnified({
 		env: {} as Env,
 		query: 'alpha helpers overview',
+		userId: 'user-1',
 		limit: 5,
 		registry,
 		optionalRows: {
@@ -732,7 +788,6 @@ export declare function traceProcessorFailure(messageId: string): Promise<void>
 		],
 	})
 
-	// Building rows only projects cheap D1 fields; no source snapshots load.
 	expect(rows.warnings).toEqual([])
 	expect(sourceMocks.loadPackageSourceBySourceId).not.toHaveBeenCalled()
 	expect(rows.rows[0]).toMatchObject({
@@ -747,6 +802,7 @@ export declare function traceProcessorFailure(messageId: string): Promise<void>
 		env: {} as Env,
 		query: 'trace package',
 		limit: 3,
+		userId: 'user-123',
 		registry: buildCapabilityRegistry([]),
 		optionalRows: {
 			packageRows: rows.rows,
@@ -755,7 +811,6 @@ export declare function traceProcessorFailure(messageId: string): Promise<void>
 		},
 	})
 
-	// The returned top match is hydrated with README and export metadata.
 	const packageMatch = result.matches.find((match) => match.type === 'package')
 	expect(packageMatch).toMatchObject({
 		type: 'package',
@@ -780,7 +835,6 @@ export declare function traceProcessorFailure(messageId: string): Promise<void>
 	)
 	expect(sourceMocks.loadPackageSourceBySourceId).toHaveBeenCalledTimes(1)
 
-	// Hydration failures degrade to the lean match instead of failing search.
 	consoleWarn.mockImplementation(() => {})
 	sourceMocks.loadPackageSourceBySourceId.mockRejectedValueOnce(
 		new Error('missing-source'),
@@ -811,6 +865,7 @@ export declare function traceProcessorFailure(messageId: string): Promise<void>
 		env: {} as Env,
 		query: 'observed package',
 		limit: 3,
+		userId: 'user-123',
 		registry: buildCapabilityRegistry([]),
 		optionalRows: {
 			packageRows: failedHydration.rows,
@@ -827,101 +882,9 @@ export declare function traceProcessorFailure(messageId: string): Promise<void>
 			}),
 		]),
 	)
-	// The degraded path leaves a hydration-failure trail for the package.
 	expect(consoleWarn).toHaveBeenCalledWith(
 		expect.stringContaining('package-123'),
 	)
-})
-
-test('searchUnified ranks packages via user-filtered package vectors when Vectorize is online', async () => {
-	const capturedFilters: Array<Record<string, unknown> | undefined> = []
-	const env = {
-		SENTRY_ENVIRONMENT: 'production',
-		AI: createDeterministicAiBinding(),
-		CAPABILITY_VECTOR_INDEX: {
-			async query(
-				_values: Array<number>,
-				options: { filter?: Record<string, unknown> },
-			) {
-				capturedFilters.push(options.filter)
-				const kind = (options.filter as { kind?: { $eq?: string } } | undefined)
-					?.kind?.$eq
-				if (kind === 'package') {
-					return { matches: [{ id: 'package_pkg-vector', score: 0.91 }] }
-				}
-				return { matches: [] }
-			},
-		},
-	} as unknown as Env
-	function leanPackageRow(id: string, name: string): PackageSearchRow {
-		return {
-			record: {
-				id,
-				userId: 'user-1',
-				name,
-				kodyId: name,
-				description: 'automation helpers',
-				tags: [],
-				searchText: null,
-				sourceId: `source-${id}`,
-				hasApp: false,
-				hidden: false,
-				isPrivate: false,
-				createdAt: '2026-04-20T00:00:00.000Z',
-				updatedAt: '2026-04-20T00:00:00.000Z',
-			},
-			projection: {
-				name,
-				kodyId: name,
-				description: 'automation helpers',
-				tags: [],
-				searchText: null,
-				hasApp: false,
-				hidden: false,
-				isPrivate: false,
-				appEntry: null,
-				exports: [],
-				jobs: [],
-				services: [],
-				subscriptions: [],
-				retrievers: [],
-			},
-			readmeSnippet: null,
-		}
-	}
-
-	const result = await searchUnified({
-		env,
-		query: 'summarize inbox threads',
-		limit: 5,
-		registry: buildCapabilityRegistry([]),
-		optionalRows: {
-			packageRows: [
-				leanPackageRow('pkg-vector', 'semantic-match'),
-				leanPackageRow('pkg-other', 'unrelated-package'),
-			],
-			userSecretRows: [],
-			userValueRows: [],
-		},
-	})
-
-	expect(result.offline).toBe(false)
-	expect(capturedFilters).toContainEqual(
-		expect.objectContaining({
-			kind: { $eq: 'package' },
-			userId: { $eq: 'user-1' },
-		}),
-	)
-	expect(
-		result.matches.some(
-			(match) => match.type === 'package' && match.packageId === 'pkg-vector',
-		),
-	).toBe(true)
-	expect(
-		result.matches.some(
-			(match) => match.type === 'package' && match.packageId === 'pkg-other',
-		),
-	).toBe(false)
 })
 
 test('searchUnified degrades to lexical package ranking when the vector query throws', async () => {
@@ -945,48 +908,22 @@ test('searchUnified degrades to lexical package ranking when the vector query th
 			},
 		},
 	} as unknown as Env
-	const packageRow: PackageSearchRow = {
-		record: {
-			id: 'pkg-inbox',
-			userId: 'user-1',
-			name: 'inbox-summarizer',
-			kodyId: 'inbox-summarizer',
-			description: 'summarize inbox threads',
-			tags: [],
-			searchText: null,
-			sourceId: 'source-pkg-inbox',
-			hasApp: false,
-			hidden: false,
-			isPrivate: false,
-			createdAt: '2026-04-20T00:00:00.000Z',
-			updatedAt: '2026-04-20T00:00:00.000Z',
-		},
-		projection: {
-			name: 'inbox-summarizer',
-			kodyId: 'inbox-summarizer',
-			description: 'summarize inbox threads',
-			tags: [],
-			searchText: null,
-			hasApp: false,
-			hidden: false,
-			isPrivate: false,
-			appEntry: null,
-			exports: [],
-			jobs: [],
-			services: [],
-			subscriptions: [],
-			retrievers: [],
-		},
-		readmeSnippet: null,
-	}
 
 	const result = await searchUnified({
 		env,
 		query: 'summarize inbox threads',
 		limit: 5,
+		userId: 'user-1',
 		registry: buildCapabilityRegistry([]),
 		optionalRows: {
-			packageRows: [packageRow],
+			packageRows: [
+				leanPackage(
+					'pkg-inbox',
+					'user-1',
+					'inbox-summarizer',
+					'summarize inbox threads',
+				),
+			],
 			userSecretRows: [],
 			userValueRows: [],
 		},
@@ -999,7 +936,6 @@ test('searchUnified degrades to lexical package ranking when the vector query th
 			(match) => match.type === 'package' && match.packageId === 'pkg-inbox',
 		),
 	).toBe(true)
-	// The degradation leaves a warn trail carrying the vector failure.
 	expect(consoleWarn).toHaveBeenCalledWith(
 		expect.stringContaining('vectorize unavailable'),
 	)
@@ -1230,4 +1166,304 @@ test('searchUnified inlines call shapes for the top three capability matches onl
 		inputTypeDefinition: 'type ListWidgetsInput = Record<string, never>',
 	})
 	expect(listTop).not.toHaveProperty('inputTypeDefinitionTruncated')
+})
+
+test('settleWithBudget uses an absolute launch deadline and degrades safely', async () => {
+	await expect(
+		settleWithBudget(Promise.resolve('ready'), 25),
+	).resolves.toMatchObject({
+		ok: true,
+		value: 'ready',
+		timedOut: false,
+		failed: false,
+	})
+	await expect(
+		settleWithBudget(Promise.reject(new Error('memory down')), 100),
+	).resolves.toMatchObject({ ok: false, timedOut: false, failed: true })
+
+	vi.useFakeTimers()
+	try {
+		const latePromise = new Promise<string>(() => {})
+		const settlement = settleWithBudget(latePromise, 40)
+		await vi.advanceTimersByTimeAsync(40)
+		await expect(settlement).resolves.toMatchObject({
+			ok: false,
+			timedOut: true,
+		})
+
+		const overdue = settleWithBudget(
+			new Promise(() => {}),
+			1_000,
+			performance.now() - 2_000,
+		)
+		await vi.advanceTimersByTimeAsync(0)
+		await expect(overdue).resolves.toMatchObject({ ok: false, timedOut: true })
+	} finally {
+		vi.useRealTimers()
+	}
+})
+
+test('searchUnified shares query embedding, fail-closes package isolation, and keeps lexical-only Vectorize misses', async () => {
+	consoleWarn.mockImplementation(() => {})
+	let aiRunCount = 0
+	let inFlightQueries = 0
+	let maxInFlightQueries = 0
+	let packageQueryCount = 0
+	const capturedFilters: Array<Record<string, unknown> | undefined> = []
+	const registry = buildCapabilityRegistry([
+		{
+			name: 'meta',
+			description: 'Meta',
+			capabilities: [
+				{
+					name: 'inbox_summarize',
+					domain: 'meta',
+					description: 'summarize inbox threads',
+					keywords: ['inbox', 'summarize'],
+					readOnly: true,
+					idempotent: true,
+					destructive: false,
+					inputSchema: { type: 'object', properties: {} },
+					handler: async () => null,
+				},
+			],
+		},
+	])
+	const env = {
+		SENTRY_ENVIRONMENT: 'production',
+		AI: {
+			async run(...args: Array<unknown>) {
+				aiRunCount += 1
+				return createDeterministicAiBinding().run(...args)
+			},
+		},
+		CAPABILITY_VECTOR_INDEX: {
+			async query(
+				_values: Array<number>,
+				options: { filter?: Record<string, unknown> },
+			) {
+				capturedFilters.push(options.filter)
+				inFlightQueries += 1
+				maxInFlightQueries = Math.max(maxInFlightQueries, inFlightQueries)
+				await new Promise((resolve) => setTimeout(resolve, 15))
+				inFlightQueries -= 1
+				const kind = (options.filter as { kind?: { $eq?: string } } | undefined)
+					?.kind?.$eq
+				if (kind === 'package') {
+					packageQueryCount += 1
+					return { matches: [{ id: 'package_pkg-weak', score: 0.99 }] }
+				}
+				return { matches: [{ id: 'inbox_summarize', score: 0.93 }] }
+			},
+		},
+	} as unknown as Env
+	const packageRows = [
+		leanPackage('pkg-weak', 'user-1', 'noise-helper', 'barely related helper'),
+		leanPackage(
+			'pkg-lexical',
+			'user-1',
+			'inbox-triage',
+			'summarize inbox threads for triage',
+		),
+	]
+
+	const overlapped = await searchUnified({
+		env,
+		query: 'summarize inbox threads for triage',
+		limit: 5,
+		userId: 'user-1',
+		registry,
+		optionalRows: { packageRows, userSecretRows: [], userValueRows: [] },
+	})
+	expect(aiRunCount).toBe(1)
+	expect(maxInFlightQueries).toBeGreaterThanOrEqual(2)
+	expect(packageQueryCount).toBe(1)
+	expect(capturedFilters).toContainEqual(
+		expect.objectContaining({
+			kind: { $eq: 'package' },
+			userId: { $eq: 'user-1' },
+		}),
+	)
+	expect(overlapped.matches[0]).toMatchObject({
+		type: 'package',
+		packageId: 'pkg-lexical',
+	})
+
+	packageQueryCount = 0
+	const noUserOnline = await searchUnified({
+		env,
+		query: 'summarize inbox threads for triage',
+		limit: 5,
+		registry: buildCapabilityRegistry([]),
+		optionalRows: {
+			packageRows: [packageRows[0]!],
+			userSecretRows: [],
+			userValueRows: [],
+		},
+	})
+	expect(packageQueryCount).toBe(0)
+	expect(
+		noUserOnline.matches.filter((match) => match.type === 'package'),
+	).toEqual([])
+	expect(
+		(
+			await searchUnified({
+				env: {} as Env,
+				query: 'summarize inbox threads for triage',
+				limit: 5,
+				registry: buildCapabilityRegistry([]),
+				optionalRows: {
+					packageRows: [packageRows[0]!],
+					userSecretRows: [],
+					userValueRows: [],
+				},
+			})
+		).matches.filter((match) => match.type === 'package'),
+	).toEqual([])
+
+	packageQueryCount = 0
+	const mismatched = await searchUnified({
+		env,
+		query: 'summarize inbox threads for triage',
+		limit: 5,
+		userId: 'user-1',
+		registry: buildCapabilityRegistry([]),
+		optionalRows: {
+			packageRows: [
+				packageRows[0]!,
+				leanPackage(
+					'pkg-foreign',
+					'user-2',
+					'foreign',
+					'summarize inbox threads',
+				),
+			],
+			userSecretRows: [],
+			userValueRows: [],
+		},
+	})
+	expect(packageQueryCount).toBe(0)
+	expect(
+		mismatched.matches.filter((match) => match.type === 'package'),
+	).toEqual([])
+})
+
+test('searchUnified inspect affinity: live-status, package-oriented, and generic value counterexample', async () => {
+	const statusCaps = [
+		homeCapability(
+			'sonos_list_players',
+			'List known Sonos players with room names and group membership.',
+			['sonos', 'speakers', 'list', 'players'],
+		),
+		homeCapability(
+			'sonos_get_player_status',
+			'Get transport, track, queue, volume, and playback status for a Sonos player.',
+			['sonos', 'status', 'playing', 'speakers'],
+		),
+		{
+			...homeCapability('sonos_play', 'Start playback on a Sonos player.', [
+				'sonos',
+				'play',
+				'speakers',
+				'start',
+			]),
+			readOnly: false,
+			idempotent: false,
+		},
+		homeCapability(
+			'webhook_list_status',
+			'List webhook delivery status and connection state.',
+			['webhook', 'status', 'list', 'connection'],
+		),
+	]
+	const registry = buildCapabilityRegistry([
+		{ name: 'home', description: 'Home', capabilities: statusCaps },
+	])
+	const notesPackage = leanPackageRow('pkg-sonos-notes', 'user-1', {
+		name: 'sonos-setup-notes',
+		description: 'Notes about configuring Sonos speakers around the home.',
+		tags: ['sonos', 'notes', 'setup'],
+		searchText: 'sonos speakers setup notes',
+	})
+	const opsPackage = leanPackageRow('pkg-home-ops', 'user-1', {
+		name: 'home-ops-manager',
+		description:
+			'Home automation package management wrappers and workflow helpers.',
+		tags: ['home', 'workflow', 'wrapper', 'package'],
+		hasApp: true,
+	})
+	opsPackage.projection.appEntry = './app.tsx'
+
+	const live = await searchUnified({
+		env: {} as Env,
+		query: 'check whether any Sonos speakers are playing',
+		limit: 8,
+		userId: 'user-1',
+		registry,
+		optionalRows: {
+			packageRows: [opsPackage, notesPackage],
+			userSecretRows: [],
+			userValueRows: [],
+		},
+	})
+	expect(live.intent.task.name).toBe('inspect')
+	const liveNames = live.matches.map((match) =>
+		match.type === 'capability'
+			? match.name
+			: match.type === 'package'
+				? match.kodyId
+				: match.type,
+	)
+	expect(liveNames[0]).toBe('sonos_get_player_status')
+	expect(liveNames.slice(0, 3)).toContain('sonos_list_players')
+	expect(liveNames.slice(0, 4)).not.toContain('home-ops-manager')
+	expect(liveNames.indexOf('sonos_get_player_status')).toBeLessThan(
+		liveNames.indexOf('sonos_play'),
+	)
+
+	const packageOriented = await searchUnified({
+		env: {} as Env,
+		query: 'show my Sonos setup notes',
+		limit: 5,
+		userId: 'user-1',
+		registry,
+		optionalRows: {
+			packageRows: [notesPackage],
+			userSecretRows: [],
+			userValueRows: [],
+		},
+	})
+	expect(packageOriented.matches[0]).toMatchObject({
+		type: 'package',
+		kodyId: 'sonos-setup-notes',
+	})
+
+	const genericValue = await searchUnified({
+		env: {} as Env,
+		query: 'show my webhook api key value',
+		limit: 5,
+		userId: 'user-1',
+		registry,
+		optionalRows: {
+			packageRows: [],
+			userSecretRows: [],
+			userValueRows: [
+				{
+					name: 'webhook_api_key',
+					scope: 'user',
+					value: 'secret-value',
+					description: 'Webhook API key value for outbound hooks',
+					appId: null,
+					createdAt: '2026-04-20T00:00:00.000Z',
+					updatedAt: '2026-04-20T00:00:00.000Z',
+					ttlMs: null,
+				},
+			],
+		},
+	})
+	expect(genericValue.intent.task.name).toBe('inspect')
+	expect(genericValue.matches[0]).toMatchObject({
+		type: 'value',
+		name: 'webhook_api_key',
+	})
 })

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -25,6 +25,7 @@ import { type SecretSearchRow } from '#mcp/secrets/types.ts'
 import { type McpRegistrationAgent } from '#mcp/mcp-registration-agent.ts'
 import {
 	acknowledgeToolMemories,
+	buildMemoryRetrievalQuery,
 	loadRelevantMemoriesForTool,
 	type MemoryToolSummary,
 } from '#mcp/tools/memory-tool-context.ts'
@@ -1919,18 +1920,18 @@ export function launchSearchMemoryEnrichment(input: {
 	promise: Promise<MemoryToolSummary | null>
 	launchedAtMs: number
 } | null {
-	const query = input.query?.trim() ?? ''
 	const userId = input.callerContext.user?.userId ?? null
-	if (!query || !userId) return null
+	const memoryContext = resolveSearchMemoryContext({
+		query: input.query,
+		memoryContext: input.memoryContext,
+	})
+	if (!userId || !buildMemoryRetrievalQuery(memoryContext)) return null
 	const launchedAtMs = performance.now()
 	const promise = loadRelevantMemoriesForTool({
 		env: input.env,
 		callerContext: input.callerContext,
 		conversationId: input.conversationId,
-		memoryContext: resolveSearchMemoryContext({
-			query: input.query,
-			memoryContext: input.memoryContext,
-		}),
+		memoryContext,
 		acknowledgeSurfaced: false,
 	})
 	void promise.catch(() => {})

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -23,7 +23,11 @@ import {
 import { listUserSecretsForSearch } from '#mcp/secrets/service.ts'
 import { type SecretSearchRow } from '#mcp/secrets/types.ts'
 import { type McpRegistrationAgent } from '#mcp/mcp-registration-agent.ts'
-import { loadRelevantMemoriesForTool } from '#mcp/tools/memory-tool-context.ts'
+import {
+	acknowledgeToolMemories,
+	loadRelevantMemoriesForTool,
+	type MemoryToolSummary,
+} from '#mcp/tools/memory-tool-context.ts'
 import {
 	buildValueEntityId,
 	describeValue,
@@ -106,18 +110,19 @@ const defaultMaxResponseSize = 4_000
 const topCapabilityInlineCallShapeCount = 3
 const maxRelatedCapabilityOperations = 20
 const maxBatchEntityRefs = 10
-/** Upper bound on package candidates kept after lexical/vector rank fusion. */
 const maxFusedPackageCandidates = 100
+export const SEARCH_MEMORY_ENRICHMENT_BUDGET_MS = 1_000
+/** Bound wait for post-retrieval D1 acknowledgement; does not cover retrieval. */
+export const SEARCH_MEMORY_ACKNOWLEDGEMENT_BUDGET_MS = 250
+export const memoryEnrichmentSkippedWarning =
+	'Memory enrichment was skipped; returning core results without memory context.'
+export const memoryAcknowledgementWarning =
+	'Memory acknowledgement did not complete; surfaced memories may repeat in this conversation.'
 
 export type PackageSearchRow = {
 	record: Awaited<ReturnType<typeof listSavedPackagesByUserId>>[number]
 	projection: PackageSearchProjection
 	readmeSnippet?: PackageReadmeSnippet | null
-	/**
-	 * Lazily loads full package source detail (export metadata + README).
-	 * Only invoked for the bounded set of top-ranked package matches so broad
-	 * searches never load every package's published source.
-	 */
 	hydrate?: () => Promise<{
 		projection: PackageSearchProjection
 		readmeSnippet: PackageReadmeSnippet | null
@@ -181,6 +186,90 @@ type SearchPhaseTimings = {
 	candidateGenerationMs: number
 	rerankingMs: number
 	formattingMs?: number
+	rowAndRegistryLoadMs?: number
+	retrieversMs?: number
+	queryEmbeddingMs?: number
+	capabilityCandidatesMs?: number
+	packageCandidatesMs?: number
+	remoteConnectorStatusMs?: number
+	memoryEnrichmentMs?: number
+	memoryEnrichmentWaitMs?: number
+	memoryAcknowledgementMs?: number
+	memoryEnrichmentTimedOut?: boolean
+	memoryAcknowledgementTimedOut?: boolean
+	memoryEnrichmentFailed?: boolean
+}
+
+function elapsedMs(startedAt: number): number {
+	return Math.max(0, Math.round(performance.now() - startedAt))
+}
+
+export async function settleWithBudget<T>(
+	promise: Promise<T>,
+	budgetMs: number,
+	launchedAtMs: number = performance.now(),
+): Promise<
+	| { ok: true; value: T; durationMs: number; timedOut: false; failed: false }
+	| {
+			ok: false
+			value: null
+			durationMs: number
+			timedOut: true
+			failed: false
+	  }
+	| {
+			ok: false
+			value: null
+			durationMs: number
+			timedOut: false
+			failed: true
+			error: unknown
+	  }
+> {
+	const remainingMs = Math.max(0, budgetMs - (performance.now() - launchedAtMs))
+	let timeoutId: ReturnType<typeof setTimeout> | undefined
+	try {
+		const raced = await Promise.race([
+			promise.then(
+				(value) => ({ status: 'fulfilled' as const, value }) as const,
+				(error: unknown) => ({ status: 'rejected' as const, error }) as const,
+			),
+			new Promise<{ status: 'timeout' }>((resolve) => {
+				timeoutId = setTimeout(() => {
+					resolve({ status: 'timeout' })
+				}, remainingMs)
+			}),
+		])
+		const durationMs = elapsedMs(launchedAtMs)
+		if (raced.status === 'timeout') {
+			return {
+				ok: false,
+				value: null,
+				durationMs,
+				timedOut: true,
+				failed: false,
+			}
+		}
+		if (raced.status === 'rejected') {
+			return {
+				ok: false,
+				value: null,
+				durationMs,
+				timedOut: false,
+				failed: true,
+				error: raced.error,
+			}
+		}
+		return {
+			ok: true,
+			value: raced.value,
+			durationMs,
+			timedOut: false,
+			failed: false,
+		}
+	} finally {
+		if (timeoutId !== undefined) clearTimeout(timeoutId)
+	}
 }
 
 type SearchGuidanceContext = {
@@ -212,10 +301,7 @@ function buildExactPackageSearchResult(input: {
 		query: input.query,
 		entities: [],
 	})
-	const queryUnderstandingMs = Math.max(
-		0,
-		Math.round(performance.now() - queryUnderstandingStart),
-	)
+	const queryUnderstandingMs = elapsedMs(queryUnderstandingStart)
 	const matches = input.match ? [input.match] : []
 	const candidates: Array<SearchCandidate> = input.match
 		? [
@@ -271,16 +357,6 @@ export type BuildSavedPackageSearchRowsResult = {
 	warnings: Array<string>
 }
 
-/**
- * Cheap projection built entirely from the `saved_packages` D1 row. Heavier
- * fields (exports, jobs, README) stay empty until a row is hydrated for a
- * top-ranked match.
- */
-// Ranking works on this lean D1 projection so broad searches never load
-// full package source per package. Export/job/action recall is preserved
-// online by the package vectors (built from the full document at publish)
-// and by hydrating the top matches; the offline lexical path ranks on
-// name/description/tags/searchText only.
 function buildLeanPackageSearchProjection(
 	record: Awaited<ReturnType<typeof listSavedPackagesByUserId>>[number],
 ): PackageSearchProjection {
@@ -814,9 +890,11 @@ function scorePackageWrapperWorkflowBoost(
 	const taskWeight =
 		intent.task.name === 'learn'
 			? 0.25
-			: intent.task.name === 'unknown'
-				? 0.75
-				: 1
+			: intent.task.name === 'inspect' && isLiveStatusInspect(intent)
+				? 0.15
+				: intent.task.name === 'unknown'
+					? 0.75
+					: 1
 	const confidenceWeight = Math.min(
 		1,
 		Math.max(0.35, intent.confidence, intent.task.confidence),
@@ -829,6 +907,46 @@ function scorePackageWrapperWorkflowBoost(
 	boost += Math.min(0.1, queryCoverage * 0.16)
 	boost += Math.min(0.08, actionCoverage * 0.1)
 	return Math.min(0.42, boost) * confidenceWeight * taskWeight
+}
+
+function isPackageOrientedInspect(intent: SearchIntent): boolean {
+	return intent.meaningfulTokens.some((token) =>
+		[
+			'note',
+			'notes',
+			'package',
+			'packages',
+			'setup',
+			'readme',
+			'doc',
+			'docs',
+		].includes(token),
+	)
+}
+
+/** Inspect queries about live device/playback state, not package notes. */
+function isLiveStatusInspect(intent: SearchIntent): boolean {
+	if (intent.task.name !== 'inspect') return false
+	if (isPackageOrientedInspect(intent)) return false
+	return (
+		intent.constraints.some((constraint) => constraint.kind === 'state') ||
+		intent.actions.some(
+			(action) =>
+				action.name === 'inspect' &&
+				action.matchedTerms.some((term) =>
+					[
+						'check',
+						'whether',
+						'playing',
+						'status',
+						'running',
+						'paused',
+						'connected',
+						'disconnected',
+					].includes(term),
+				),
+		)
+	)
 }
 
 function scoreTaskAffinity(
@@ -875,12 +993,46 @@ function scoreTaskAffinity(
 			if (candidate.type === 'value') taskAffinity += 0.06
 			if (candidate.type === 'capability') taskAffinity += 0.05
 			break
-		case 'inspect':
-			if (candidate.type === 'value' || candidate.type === 'integration') {
-				taskAffinity += 0.12
+		case 'inspect': {
+			const packageOrientedInspect = isPackageOrientedInspect(intent)
+			const liveStatusInspect = isLiveStatusInspect(intent)
+			if (packageOrientedInspect) {
+				if (candidate.type === 'capability') taskAffinity += 0.04
+				if (candidate.type === 'value' || candidate.type === 'integration') {
+					taskAffinity += 0.06
+				}
+				if (candidate.type === 'package') taskAffinity += 0.16
+			} else if (liveStatusInspect) {
+				const inspectionTerms = [
+					'status',
+					'list',
+					'state',
+					'current',
+					'playing',
+					'show',
+					'check',
+				] as const
+				const inspectionKeyHits = inspectionTerms.filter(
+					(term) => scoreMatchedTerms(candidate.searchFields, [term]) > 0,
+				).length
+				if (candidate.type === 'capability') {
+					taskAffinity += 0.16 + Math.min(0.16, inspectionKeyHits * 0.08)
+				}
+				if (candidate.type === 'value' || candidate.type === 'integration') {
+					taskAffinity += 0.06
+				}
+				if (candidate.type === 'package') {
+					taskAffinity -= 0.12
+					if (inspectionKeyHits === 0) taskAffinity -= 0.1
+				}
+			} else {
+				if (candidate.type === 'value' || candidate.type === 'integration') {
+					taskAffinity += 0.12
+				}
+				if (candidate.type === 'package') taskAffinity += 0.05
 			}
-			if (candidate.type === 'package') taskAffinity += 0.05
 			break
+		}
 		case 'learn':
 			if (candidate.type === 'capability') taskAffinity += 0.16
 			if (candidate.type === 'package') taskAffinity -= 0.02
@@ -967,6 +1119,7 @@ async function buildCapabilityCandidates(input: {
 	query: string
 	env: Env
 	registry: Awaited<ReturnType<typeof getCapabilityRegistryForContext>>
+	queryVector?: ReadonlyArray<number>
 }): Promise<Array<SearchCandidate>> {
 	const capabilitySearch = await searchCapabilities({
 		env: input.env,
@@ -974,6 +1127,7 @@ async function buildCapabilityCandidates(input: {
 		limit: Math.max(1, Object.keys(input.registry.capabilitySpecs).length),
 		detail: false,
 		specs: input.registry.capabilitySpecs,
+		...(input.queryVector ? { queryVector: input.queryVector } : {}),
 	})
 
 	return capabilitySearch.matches
@@ -990,35 +1144,35 @@ async function buildCapabilityCandidates(input: {
 }
 
 /**
- * Queries Vectorize for this user's `package_{id}` vectors (written at publish
- * time) and returns similarity scores keyed by saved package record id.
- * Returns null when the vector index is unavailable so callers fall back to
- * deterministic offline scoring.
+ * Queries Vectorize for this user's `package_{id}` vectors with
+ * `{ kind: 'package', userId }`. Returns null when unavailable.
  */
 async function queryPackageVectorScores(input: {
 	env: Env
 	query: string
 	rows: Array<PackageSearchRow>
+	userId: string
 	limit: number
+	queryVector?: ReadonlyArray<number>
 }): Promise<Map<string, number> | null> {
 	const index = getCapabilityVectorIndex(input.env)
-	if (!index) return null
-	const userIds = Array.from(
-		new Set(input.rows.map((row) => row.record.userId).filter(Boolean)),
-	)
+	if (!index || !input.userId) return null
 	const recordIdByVectorId = new Map(
 		input.rows.map(
 			(row) => [savedPackageVectorId(row.record.id), row.record.id] as const,
 		),
 	)
-	const queryVector = await embedTextForVectorize(input.env, input.query)
+	const queryVector = [
+		...(input.queryVector ??
+			(await embedTextForVectorize(input.env, input.query))),
+	]
 	const topK = Math.min(Math.max(input.rows.length, input.limit * 5), 100)
 	const vectorMatches = await index.query(queryVector, {
 		topK,
 		returnMetadata: 'none',
 		filter: {
 			kind: { $eq: 'package' },
-			...(userIds.length === 1 ? { userId: { $eq: userIds[0] } } : {}),
+			userId: { $eq: input.userId },
 		},
 	})
 	const scores = new Map<string, number>()
@@ -1038,21 +1192,34 @@ async function buildPackageCandidates(input: {
 	queryEmbedding: ReadonlyArray<number>
 	limit: number
 	offline: boolean
+	userId?: string
+	queryVector?: ReadonlyArray<number>
 }): Promise<Array<SearchCandidate>> {
 	if (input.rows.length === 0) return []
+	// Fail closed in every mode: no userId or foreign rows never enter ranking.
+	if (!input.userId) return []
+	if (input.rows.some((row) => row.record.userId !== input.userId)) {
+		console.warn(
+			JSON.stringify({
+				message: 'package candidates skipped: row userId mismatch',
+				expectedUserId: input.userId,
+			}),
+		)
+		return []
+	}
 	const meaningfulTokens = extractMeaningfulSearchTokens(input.query)
 	let vectorScoresByRecordId: Map<string, number> | null = null
-	if (!input.offline) {
+	if (!input.offline && input.userId) {
 		try {
 			vectorScoresByRecordId = await queryPackageVectorScores({
 				env: input.env,
 				query: input.query,
 				rows: input.rows,
+				userId: input.userId,
 				limit: input.limit,
+				...(input.queryVector ? { queryVector: input.queryVector } : {}),
 			})
 		} catch (error) {
-			// Degrade to lexical/deterministic ranking rather than failing the
-			// whole search when the vector index is unreachable.
 			console.warn(
 				JSON.stringify({
 					message: 'package vector query failed, using lexical ranking',
@@ -1090,15 +1257,24 @@ async function buildPackageCandidates(input: {
 			]
 				.filter((value) => value.trim().length > 0)
 				.join('\n')
-			const lexical = lexicalScore(input.query, document)
-			// Online, Vectorize similarity replaces the per-package deterministic
-			// embedding so broad searches never embed every package document.
-			const vector = vectorScoresByRecordId
-				? (vectorScoresByRecordId.get(entry.record.id) ?? 0)
-				: cosineSimilarity(
-						input.queryEmbedding,
-						deterministicEmbedding(document),
-					)
+			const lexical = Math.max(
+				lexicalScore(input.query, document),
+				(actionMatches[0]?.score ?? 0) * 0.8,
+			)
+			const vectorHit = vectorScoresByRecordId?.get(entry.record.id)
+			const scoreComponents =
+				vectorScoresByRecordId != null
+					? buildCandidateBaseScore({
+							lexical,
+							...(vectorHit !== undefined ? { vector: vectorHit } : {}),
+						})
+					: buildCandidateBaseScore({
+							lexical,
+							vector: cosineSimilarity(
+								input.queryEmbedding,
+								deterministicEmbedding(document),
+							),
+						})
 			return {
 				match: {
 					type: 'package' as const,
@@ -1152,18 +1328,14 @@ async function buildPackageCandidates(input: {
 					readmeSnippet,
 					...(entry.record.hasApp ? ['app', 'ui', 'remote'] : []),
 				],
-				scoreComponents: buildCandidateBaseScore({
-					lexical: Math.max(lexical, (actionMatches[0]?.score ?? 0) * 0.8),
-					vector,
-				}),
+				scoreComponents,
 			}
 		})
 		.filter((candidate) => candidate.scoreComponents.base > 0)
 	if (!vectorScoresByRecordId) {
 		return candidates
 	}
-	// Online: fuse lexical and vector rankings (RRF, mirroring
-	// capability-search) to bound the package candidate set.
+	// Fuse lexical and vector rankings to bound the online candidate set.
 	const candidateIds = candidates.map((candidate) => candidate.match.packageId)
 	const lexicalById = new Map(
 		candidates.map(
@@ -1175,8 +1347,11 @@ async function buildPackageCandidates(input: {
 		candidateIds,
 		(id) => lexicalById.get(id) ?? 0,
 	)
+	const vectorHitIds = candidateIds.filter((id) =>
+		vectorScoresByRecordId.has(id),
+	)
 	const vectorOrder = sortIdsByScore(
-		candidateIds,
+		vectorHitIds,
 		(id) => vectorScoresByRecordId.get(id) ?? 0,
 	)
 	const fused = reciprocalRankFusion(
@@ -1400,16 +1575,11 @@ function capabilityMatchToCandidate(
 		],
 		scoreComponents: buildCandidateBaseScore({
 			lexical: match.lexicalScore,
-			vector: match.vectorScore,
+			...(match.vectorRank != null ? { vector: match.vectorScore } : {}),
 		}),
 	}
 }
 
-/**
- * Attaches a compact call shape (accessor + collapsed input type) to the top
- * capability matches only, so query responses stay lean while still letting
- * agents call without an immediate entity round trip.
- */
 function attachTopCapabilityCallShapes(input: {
 	matches: Array<SearchMatch>
 	registry: Awaited<ReturnType<typeof getCapabilityRegistryForContext>>
@@ -1491,11 +1661,6 @@ function collectRelatedCapabilityOperations(input: {
 		}))
 }
 
-/**
- * Loads README snippets and export metadata for the bounded set of package
- * matches actually being returned (at most `limit` rows), instead of loading
- * every saved package's full source up front.
- */
 async function hydrateTopPackageMatches(input: {
 	query: string
 	matches: Array<SearchMatch>
@@ -1538,6 +1703,8 @@ export async function searchUnified(input: {
 	env: Env
 	query: string
 	limit: number
+	/** Authenticated user; required for fail-closed package Vectorize isolation. */
+	userId?: string
 	registry: Awaited<ReturnType<typeof getCapabilityRegistryForContext>>
 	optionalRows: Pick<
 		OptionalSearchRowsResult,
@@ -1553,10 +1720,7 @@ export async function searchUnified(input: {
 			query,
 			entities: [],
 		})
-		const queryUnderstandingMs = Math.max(
-			0,
-			Math.round(performance.now() - queryUnderstandingStart),
-		)
+		const queryUnderstandingMs = elapsedMs(queryUnderstandingStart)
 		return {
 			matches: [],
 			offline,
@@ -1584,26 +1748,44 @@ export async function searchUnified(input: {
 		query,
 		entities: entityDescriptors,
 	})
-	const queryUnderstandingMs = Math.max(
-		0,
-		Math.round(performance.now() - queryUnderstandingStart),
-	)
+	const queryUnderstandingMs = elapsedMs(queryUnderstandingStart)
 	const candidateGenerationStart = performance.now()
+	const queryEmbeddingStart = performance.now()
 	const queryEmbedding = deterministicEmbedding(intent.normalizedQuery)
-	const candidates = [
-		...(await buildCapabilityCandidates({
+	const sharedQueryVector = offline
+		? queryEmbedding
+		: await embedTextForVectorize(input.env, intent.normalizedQuery)
+	const queryEmbeddingMs = elapsedMs(queryEmbeddingStart)
+
+	const capabilityCandidatesStart = performance.now()
+	const packageCandidatesStart = performance.now()
+	const [capabilityCandidates, packageCandidates] = await Promise.all([
+		buildCapabilityCandidates({
 			query: intent.normalizedQuery,
 			env: input.env,
 			registry: input.registry,
+			queryVector: sharedQueryVector,
+		}).then((candidates) => ({
+			candidates,
+			durationMs: elapsedMs(capabilityCandidatesStart),
 		})),
-		...(await buildPackageCandidates({
+		buildPackageCandidates({
 			env: input.env,
 			query: intent.normalizedQuery,
 			rows: input.optionalRows.packageRows,
 			queryEmbedding,
 			limit,
 			offline,
+			userId: input.userId,
+			queryVector: offline ? undefined : sharedQueryVector,
+		}).then((candidates) => ({
+			candidates,
+			durationMs: elapsedMs(packageCandidatesStart),
 		})),
+	])
+	const candidates = [
+		...capabilityCandidates.candidates,
+		...packageCandidates.candidates,
 		...buildValueCandidates({
 			query: intent.normalizedQuery,
 			rows: input.optionalRows.userValueRows,
@@ -1622,10 +1804,7 @@ export async function searchUnified(input: {
 			results: input.retrieverResults ?? [],
 		}),
 	]
-	const candidateGenerationMs = Math.max(
-		0,
-		Math.round(performance.now() - candidateGenerationStart),
-	)
+	const candidateGenerationMs = elapsedMs(candidateGenerationStart)
 	const rerankingStart = performance.now()
 	const reranked = rerankCandidates({
 		candidates,
@@ -1642,10 +1821,7 @@ export async function searchUnified(input: {
 		matches,
 		rows: input.optionalRows.packageRows,
 	})
-	const rerankingMs = Math.max(
-		0,
-		Math.round(performance.now() - rerankingStart),
-	)
+	const rerankingMs = elapsedMs(rerankingStart)
 
 	return {
 		matches,
@@ -1660,6 +1836,9 @@ export async function searchUnified(input: {
 			queryUnderstandingMs,
 			candidateGenerationMs,
 			rerankingMs,
+			queryEmbeddingMs,
+			capabilityCandidatesMs: capabilityCandidates.durationMs,
+			packageCandidatesMs: packageCandidates.durationMs,
 		},
 		guidance: buildRecommendedNextStep({
 			query,
@@ -1674,12 +1853,14 @@ export async function searchPackages(input: {
 	baseUrl: string
 	query: string
 	limit: number
+	userId?: string
 	rows: Array<PackageSearchRow>
 }): Promise<{ matches: Array<SearchMatch>; offline: boolean }> {
 	const result = await searchUnified({
 		env: input.env,
 		query: input.query,
 		limit: input.limit,
+		userId: input.userId,
 		registry: {
 			capabilitySpecs: {},
 		} as Awaited<ReturnType<typeof getCapabilityRegistryForContext>>,
@@ -1705,6 +1886,215 @@ export function resolveSearchMemoryContext(input: {
 
 	const query = input.query?.trim() ?? ''
 	return query.length > 0 ? { query } : undefined
+}
+
+export type SearchMemoryEnrichmentSettlement = {
+	memories?: {
+		surfaced: MemoryToolSummary['memories']
+		suppressedCount: number
+		retrievalQuery: string
+		retrieverResults: MemoryToolSummary['retrieverResults']
+	}
+	warnings: Array<string>
+	phaseTimings: Pick<
+		SearchPhaseTimings,
+		| 'memoryEnrichmentMs'
+		| 'memoryEnrichmentWaitMs'
+		| 'memoryAcknowledgementMs'
+		| 'memoryEnrichmentTimedOut'
+		| 'memoryAcknowledgementTimedOut'
+		| 'memoryEnrichmentFailed'
+	>
+}
+
+export function launchSearchMemoryEnrichment(input: {
+	env: Env
+	callerContext: McpCallerContext
+	conversationId: string
+	query?: string
+	memoryContext?: z.infer<typeof memoryContextInputField>
+}): {
+	promise: Promise<MemoryToolSummary | null>
+	launchedAtMs: number
+} | null {
+	const query = input.query?.trim() ?? ''
+	const userId = input.callerContext.user?.userId ?? null
+	if (!query || !userId) return null
+	const launchedAtMs = performance.now()
+	const promise = loadRelevantMemoriesForTool({
+		env: input.env,
+		callerContext: input.callerContext,
+		conversationId: input.conversationId,
+		memoryContext: resolveSearchMemoryContext({
+			query: input.query,
+			memoryContext: input.memoryContext,
+		}),
+		acknowledgeSurfaced: false,
+	})
+	void promise.catch(() => {})
+	return { promise, launchedAtMs }
+}
+
+export async function settleSearchMemoryEnrichment(input: {
+	env: Env
+	callerContext: McpCallerContext
+	conversationId: string
+	promise: Promise<MemoryToolSummary | null>
+	launchedAtMs?: number
+	budgetMs?: number
+	acknowledgementBudgetMs?: number
+}): Promise<SearchMemoryEnrichmentSettlement> {
+	const waitStartedAt = performance.now()
+	const launchedAtMs = input.launchedAtMs ?? waitStartedAt
+	const budgetMs = input.budgetMs ?? SEARCH_MEMORY_ENRICHMENT_BUDGET_MS
+	const settlement = await settleWithBudget(
+		input.promise,
+		budgetMs,
+		launchedAtMs,
+	)
+	const memoryEnrichmentWaitMs = elapsedMs(waitStartedAt)
+	const memoryEnrichmentMs = settlement.durationMs
+
+	if (!settlement.ok) {
+		console.warn(
+			JSON.stringify({
+				message: 'search memory enrichment skipped',
+				reason: settlement.timedOut ? 'timeout' : 'failure',
+				budgetMs,
+				waitedMs: memoryEnrichmentWaitMs,
+				launchToSettleMs: memoryEnrichmentMs,
+				...(settlement.failed
+					? {
+							error:
+								settlement.error instanceof Error
+									? settlement.error.message
+									: String(settlement.error),
+						}
+					: {}),
+			}),
+		)
+		return {
+			warnings: [memoryEnrichmentSkippedWarning],
+			phaseTimings: {
+				memoryEnrichmentMs,
+				memoryEnrichmentWaitMs,
+				memoryEnrichmentTimedOut: settlement.timedOut,
+				memoryEnrichmentFailed: settlement.failed,
+			},
+		}
+	}
+
+	const memoryToolContext = settlement.value
+	const warnings = [...(memoryToolContext?.retrieverWarnings ?? [])]
+	if (!memoryToolContext || memoryToolContext.memories.length === 0) {
+		return {
+			...(memoryToolContext
+				? {
+						memories: {
+							surfaced: memoryToolContext.memories,
+							suppressedCount: memoryToolContext.suppressedCount,
+							retrievalQuery: memoryToolContext.retrievalQuery,
+							retrieverResults: memoryToolContext.retrieverResults,
+						},
+					}
+				: {}),
+			warnings,
+			phaseTimings: {
+				memoryEnrichmentMs,
+				memoryEnrichmentWaitMs,
+				memoryEnrichmentTimedOut: false,
+				memoryEnrichmentFailed: false,
+			},
+		}
+	}
+
+	const memories = {
+		surfaced: memoryToolContext.memories,
+		suppressedCount: memoryToolContext.suppressedCount,
+		retrievalQuery: memoryToolContext.retrievalQuery,
+		retrieverResults: memoryToolContext.retrieverResults,
+	}
+	const acknowledgementBudgetMs =
+		input.acknowledgementBudgetMs ?? SEARCH_MEMORY_ACKNOWLEDGEMENT_BUDGET_MS
+	const acknowledgementStartedAt = performance.now()
+	const acknowledgementPromise = acknowledgeToolMemories({
+		env: input.env,
+		callerContext: input.callerContext,
+		conversationId: input.conversationId,
+		memoryIds: memoryToolContext.memories.map((memory) => memory.id),
+	})
+	const acknowledgement = await settleWithBudget(
+		acknowledgementPromise,
+		acknowledgementBudgetMs,
+		acknowledgementStartedAt,
+	)
+	const memoryAcknowledgementMs = elapsedMs(acknowledgementStartedAt)
+
+	if (acknowledgement.ok) {
+		return {
+			memories,
+			warnings,
+			phaseTimings: {
+				memoryEnrichmentMs,
+				memoryEnrichmentWaitMs,
+				memoryAcknowledgementMs,
+				memoryEnrichmentTimedOut: false,
+				memoryEnrichmentFailed: false,
+			},
+		}
+	}
+
+	if (acknowledgement.timedOut) {
+		void acknowledgementPromise.catch((error) => {
+			console.warn(
+				JSON.stringify({
+					message: 'search memory acknowledgement failed after timeout',
+					error: error instanceof Error ? error.message : String(error),
+				}),
+			)
+		})
+		console.warn(
+			JSON.stringify({
+				message: 'search memory acknowledgement timed out',
+				budgetMs: acknowledgementBudgetMs,
+				acknowledgementMs: memoryAcknowledgementMs,
+			}),
+		)
+		return {
+			memories,
+			warnings: [...warnings, memoryAcknowledgementWarning],
+			phaseTimings: {
+				memoryEnrichmentMs,
+				memoryEnrichmentWaitMs,
+				memoryAcknowledgementMs,
+				memoryEnrichmentTimedOut: false,
+				memoryAcknowledgementTimedOut: true,
+				memoryEnrichmentFailed: false,
+			},
+		}
+	}
+
+	console.warn(
+		JSON.stringify({
+			message: 'search memory acknowledgement failed',
+			error:
+				acknowledgement.error instanceof Error
+					? acknowledgement.error.message
+					: String(acknowledgement.error),
+			acknowledgementMs: memoryAcknowledgementMs,
+		}),
+	)
+	return {
+		memories,
+		warnings: [...warnings, memoryAcknowledgementWarning],
+		phaseTimings: {
+			memoryEnrichmentMs,
+			memoryEnrichmentWaitMs,
+			memoryAcknowledgementMs,
+			memoryEnrichmentTimedOut: false,
+			memoryEnrichmentFailed: true,
+		},
+	}
 }
 
 function truncateSearchText(text: string): string {
@@ -2011,9 +2401,6 @@ async function resolveEntityDetail(input: {
 
 	if (ref.type === 'value') {
 		const valueRef = parseValueEntityId(ref.id)
-		// The search snapshot only covers buckets visible to the caller's
-		// storage context; fetch directly so entity detail works for values in
-		// scopes the snapshot missed (matching the package path).
 		const row =
 			input.searchRows.userValueRows.find(
 				(value) =>
@@ -2178,6 +2565,10 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 			let warnings: Array<string> = []
 			let remoteConnectorDownStatuses: Array<RemoteConnectorStatus> = []
 			let username: string | null = null
+			const endToEndPhaseTimings: Partial<SearchPhaseTimings> = {}
+			let memoryEnrichmentPromise: Promise<MemoryToolSummary | null> =
+				Promise.resolve(null)
+			let memoryEnrichmentLaunchedAtMs: number | undefined
 
 			const searchSpan = async () => {
 				const query = args.query?.trim() ?? ''
@@ -2186,6 +2577,19 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					username: callerContext.user?.username ?? null,
 					email: callerContext.user?.email ?? null,
 				})
+				if (!args.entity) {
+					const launched = launchSearchMemoryEnrichment({
+						env: agent.getEnv(),
+						callerContext,
+						conversationId,
+						query: args.query,
+						memoryContext: args.memoryContext,
+					})
+					if (launched) {
+						memoryEnrichmentLaunchedAtMs = launched.launchedAtMs
+						memoryEnrichmentPromise = launched.promise
+					}
+				}
 				if (!args.entity && query) {
 					const identityResolution = await resolvePackageIdentitySearch({
 						db: agent.getEnv().APP_DB,
@@ -2196,11 +2600,15 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 						includeHiddenPackages,
 					})
 					if (identityResolution.recognized) {
+						const remoteConnectorStatusStart = performance.now()
 						remoteConnectorDownStatuses = await loadDownRemoteConnectorStatuses(
 							{
 								env: agent.getEnv(),
 								callerContext,
 							},
+						)
+						endToEndPhaseTimings.remoteConnectorStatusMs = elapsedMs(
+							remoteConnectorStatusStart,
 						)
 						return {
 							mode: 'list' as const,
@@ -2212,6 +2620,19 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 						}
 					}
 				}
+				const rowAndRegistryLoadStart = performance.now()
+				const rowsPromise = loadSearchRowsAndRegistry({
+					env: agent.getEnv(),
+					callerContext,
+					userId,
+					includeHiddenPackages,
+				}).then((rows) => {
+					endToEndPhaseTimings.rowAndRegistryLoadMs = elapsedMs(
+						rowAndRegistryLoadStart,
+					)
+					return rows
+				})
+				const retrieversStart = performance.now()
 				const retrieverRunPromise =
 					!args.entity && userId && query
 						? (async () => {
@@ -2230,21 +2651,28 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 									}),
 									conversationId,
 								})
-							})()
-						: Promise.resolve({ results: [], warnings: [] })
+							})().then((retrieverRun) => {
+								endToEndPhaseTimings.retrieversMs = elapsedMs(retrieversStart)
+								return retrieverRun
+							})
+						: Promise.resolve({ results: [], warnings: [] }).then(
+								(retrieverRun) => {
+									endToEndPhaseTimings.retrieversMs = elapsedMs(retrieversStart)
+									return retrieverRun
+								},
+							)
 				const [searchRows] = await Promise.all([
-					loadSearchRowsAndRegistry({
-						env: agent.getEnv(),
-						callerContext,
-						userId,
-						includeHiddenPackages,
-					}),
+					rowsPromise,
 					retrieverRunPromise,
 				])
+				const remoteConnectorStatusStart = performance.now()
 				remoteConnectorDownStatuses = await loadDownRemoteConnectorStatuses({
 					env: agent.getEnv(),
 					callerContext,
 				})
+				endToEndPhaseTimings.remoteConnectorStatusMs = elapsedMs(
+					remoteConnectorStatusStart,
+				)
 				warnings = searchRows.warnings
 
 				if (args.entity) {
@@ -2300,6 +2728,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					env: agent.getEnv(),
 					query,
 					limit,
+					userId: userId ?? undefined,
 					registry: searchRows.registry,
 					optionalRows: searchRows,
 					retrieverResults: retrieverRun.results,
@@ -2456,26 +2885,16 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					remoteConnectorDownStatuses.length > 0
 						? remoteConnectorDownStatuses.map(serializeRemoteConnectorStatus)
 						: undefined
-				const memoryToolContext = await loadRelevantMemoriesForTool({
+				const memorySettlement = await settleSearchMemoryEnrichment({
 					env: agent.getEnv(),
 					callerContext,
 					conversationId,
-					memoryContext: resolveSearchMemoryContext({
-						query: args.query,
-						memoryContext: args.memoryContext,
-					}),
+					promise: memoryEnrichmentPromise,
+					launchedAtMs: memoryEnrichmentLaunchedAtMs,
 				})
-				const searchMemories = memoryToolContext
-					? {
-							surfaced: memoryToolContext.memories,
-							suppressedCount: memoryToolContext.suppressedCount,
-							retrievalQuery: memoryToolContext.retrievalQuery,
-							retrieverResults: memoryToolContext.retrieverResults,
-						}
-					: undefined
-				if (memoryToolContext) {
-					warnings.push(...memoryToolContext.retrieverWarnings)
-				}
+				Object.assign(endToEndPhaseTimings, memorySettlement.phaseTimings)
+				warnings.push(...memorySettlement.warnings)
+				const searchMemories = memorySettlement.memories
 				const structuredWarnings = [...warnings]
 
 				const payload: {
@@ -2541,10 +2960,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					0,
 					outcome.result.matches.length - trimmedPayload.matches.length,
 				)
-				const formattingMs = Math.max(
-					0,
-					Math.round(performance.now() - formattingStartMs),
-				)
+				const formattingMs = elapsedMs(formattingStartMs)
 				const result: SearchResultStructuredContent = {
 					offline: trimmedPayload.offline,
 					warnings: structuredWarnings,
@@ -2563,6 +2979,7 @@ export async function registerSearchTool(agent: McpRegistrationAgent) {
 					},
 					phaseTimings: {
 						...outcome.result.phaseTimings,
+						...endToEndPhaseTimings,
 						formattingMs,
 					},
 					...(searchMemories

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -198,6 +198,7 @@ type SearchPhaseTimings = {
 	memoryEnrichmentTimedOut?: boolean
 	memoryAcknowledgementTimedOut?: boolean
 	memoryEnrichmentFailed?: boolean
+	memoryAcknowledgementFailed?: boolean
 }
 
 function elapsedMs(startedAt: number): number {
@@ -1904,6 +1905,7 @@ export type SearchMemoryEnrichmentSettlement = {
 		| 'memoryEnrichmentTimedOut'
 		| 'memoryAcknowledgementTimedOut'
 		| 'memoryEnrichmentFailed'
+		| 'memoryAcknowledgementFailed'
 	>
 }
 
@@ -2092,7 +2094,8 @@ export async function settleSearchMemoryEnrichment(input: {
 			memoryEnrichmentWaitMs,
 			memoryAcknowledgementMs,
 			memoryEnrichmentTimedOut: false,
-			memoryEnrichmentFailed: true,
+			memoryEnrichmentFailed: false,
+			memoryAcknowledgementFailed: true,
 		},
 	}
 }

--- a/packages/worker/src/mcp/tools/understand-search-query.ts
+++ b/packages/worker/src/mcp/tools/understand-search-query.ts
@@ -71,6 +71,14 @@ const taskLexicon = {
 		'current',
 		'latest',
 		'summary',
+		'check',
+		'checking',
+		'whether',
+		'playing',
+		'running',
+		'paused',
+		'connected',
+		'disconnected',
 	],
 	learn: [
 		'what',
@@ -331,11 +339,33 @@ function inferTaskSignals(
 			confidence: Math.min(1, result.score),
 		}))
 
+	// Prefer inspect over setup for package/note lookups.
+	const inspectAction = actions.find((action) => action.name === 'inspect')
+	const setupAction = actions.find((action) => action.name === 'setup')
+	const packageOrientedTokens = meaningfulTokens.some((token) =>
+		['note', 'notes', 'package', 'packages', 'readme', 'doc', 'docs'].includes(
+			token,
+		),
+	)
+	const prefersInspectOverSetup =
+		packageOrientedTokens &&
+		inspectAction != null &&
+		setupAction != null &&
+		inspectAction.matchedTerms.some((term) =>
+			['show', 'list', 'view', 'inspect'].includes(term),
+		)
+	const task = prefersInspectOverSetup
+		? {
+				name: 'inspect' as const,
+				confidence: Math.min(1, inspectAction.confidence),
+			}
+		: {
+				name: strongest.task,
+				confidence: Math.min(1, strongest.score),
+			}
+
 	return {
-		task: {
-			name: strongest.task,
-			confidence: Math.min(1, strongest.score),
-		},
+		task,
 		actions,
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- reuse one query embedding and remove query-time capability document embedding sweeps
- isolate capability, package, and memory Vectorize ranking and improve live-status discovery
- overlap and bound optional memory enrichment with atomic acknowledgement
- expose end-to-end phase timings for production diagnosis

## Validation
- `npm run validate`
- unit/worker tests: 991 passed
- Playwright E2E: 17 passed
- MCP E2E: 2 passed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `3999e296` · **Head:** `d81431a7`

**Classification:** extends — search ranking, Vectorize access, and optional memory enrichment behavior change without adding a primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — bounded search orchestration and phase telemetry |
| `capability-registry` | assistant | extends — shared query vectors and focused inspect ranking |
| `memories` | assistant | extends — side-effect-free retrieval with atomic acknowledgement |
| `vectorize-search` | storage | extends — strict kind/user filters and hits-only RRF |

### System map

Search flows through scoped capability/package Vectorize ranking, then returns optional acknowledged memory context within bounded waits.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::extended
  capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
  vectorizeSearch["vectorize-search<br/>Vectorize search"]:::extended
  memories["memories<br/>Memories"]:::extended
  mcpServer -->|"search query + phase timings"| capabilityRegistry
  capabilityRegistry -->|"one query vector; strict kind/user filters"| vectorizeSearch
  mcpServer -->|"bounded retrieval + atomic acknowledgement"| memories
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

### Invariants

- `per-user-isolation`: package and memory rows fail closed and every user-owned Vectorize query filters by `userId`.
- `compact-mcp-surface`: no new public tool; `search` behavior and additive telemetry improve in place.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a632009-939e-4c25-8e4f-7279c0f95f24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a632009-939e-4c25-8e4f-7279c0f95f24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now provide more accurate capability, package, and memory matches.
  * Search can reuse shared query processing for faster, more consistent results.
  * Memory enrichment and acknowledgement are handled without blocking the main search.
  * Search responses include expanded timing and status details for major processing stages.

* **Bug Fixes**
  * Improved user isolation prevents unrelated package or memory results from appearing.
  * Lexical matches are retained when vector search does not return a match.
  * Search now handles timeouts and enrichment failures gracefully with warnings.
  * Inspect-style queries better distinguish package-focused and live-status requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->