### PR TITLE
Rank agent package popularity by last N conversations

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -124,11 +124,12 @@ conversations** in which a signed-in user’s agents used a saved package via MC
   the same package in the same conversation counts once. Stored
   `conversation_id` values are SHA-256 hex digests of the MCP conversation id
   (cardinality only; not reversible to the raw id).
-- Read path: count conversations with `last_used_at` in the last 30 days, join
-  `saved_packages` for `kody_id` + description, top 8 for
-  `buildMcpServerInstructions`. Cold start (no rows) omits the section. List
-  failures (missing table, transient D1 errors) return `[]` so MCP init stays up
-  during migration rollout.
+- Read path: take the user’s last **N** distinct agent conversations
+  (default 40) with `last_used_at` within a hard max age (default 180 days),
+  count how many of those conversations used each package, join `saved_packages`
+  for `kody_id` + description, top 8 for `buildMcpServerInstructions`. Cold
+  start (no rows) omits the section. List failures (missing table, transient D1
+  errors) return `[]` so MCP init stays up during migration rollout.
 - Writes are best-effort and never throw into the invoke path (same spirit as
   `recordUsage`). Do **not** widen `usage_rollups` for conversation cardinality.
 

--- a/packages/worker/src/usage/agent-package-conversation-uses.node.test.ts
+++ b/packages/worker/src/usage/agent-package-conversation-uses.node.test.ts
@@ -157,7 +157,7 @@ test('listPopularAgentPackagesForUser returns [] when the table is missing', asy
 	)
 })
 
-test('listPopularAgentPackagesForUser ranks by distinct conversations and skips missing packages', async () => {
+test('listPopularAgentPackagesForUser ranks within last N conversations and skips missing packages', async () => {
 	const { sqlite, db } = createTestDb()
 	seedPackage(sqlite, {
 		id: 'pkg-a',
@@ -179,29 +179,39 @@ test('listPopularAgentPackagesForUser ranks by distinct conversations and skips 
 	})
 
 	const now = new Date('2026-07-21T12:00:00.000Z')
-	const recent = '2026-07-10T00:00:00.000Z'
-	const older = '2026-06-01T00:00:00.000Z'
-
-	// alpha: 3 conversations
-	for (const conversationId of ['c1', 'c2', 'c3']) {
+	// Five conversations; ranking uses only the newest 4.
+	// c1–c3: alpha; c1+c4: bravo; c0 (oldest): charlie only
+	await recordAgentPackageConversationUse(
+		{ APP_DB: db },
+		{
+			userId: 'user-a',
+			packageId: 'pkg-c',
+			conversationId: 'c0',
+			usedAt: '2026-07-01T00:00:00.000Z',
+		},
+	)
+	for (const [conversationId, usedAt] of [
+		['c1', '2026-07-10T00:00:00.000Z'],
+		['c2', '2026-07-11T00:00:00.000Z'],
+		['c3', '2026-07-12T00:00:00.000Z'],
+	] as const) {
 		await recordAgentPackageConversationUse(
 			{ APP_DB: db },
 			{
 				userId: 'user-a',
 				packageId: 'pkg-a',
 				conversationId,
-				usedAt: recent,
+				usedAt,
 			},
 		)
 	}
-	// bravo: 2 conversations (one duplicate upsert)
 	await recordAgentPackageConversationUses(
 		{ APP_DB: db },
 		{
 			userId: 'user-a',
 			packageIds: ['pkg-b', 'pkg-b'],
 			conversationId: 'c1',
-			usedAt: recent,
+			usedAt: '2026-07-10T00:00:00.000Z',
 		},
 	)
 	await recordAgentPackageConversationUse(
@@ -210,17 +220,7 @@ test('listPopularAgentPackagesForUser ranks by distinct conversations and skips 
 			userId: 'user-a',
 			packageId: 'pkg-b',
 			conversationId: 'c4',
-			usedAt: recent,
-		},
-	)
-	// charlie: only outside the window
-	await recordAgentPackageConversationUse(
-		{ APP_DB: db },
-		{
-			userId: 'user-a',
-			packageId: 'pkg-c',
-			conversationId: 'c-old',
-			usedAt: older,
+			usedAt: '2026-07-13T00:00:00.000Z',
 		},
 	)
 	// deleted package row still in uses — skip via join
@@ -230,18 +230,65 @@ test('listPopularAgentPackagesForUser ranks by distinct conversations and skips 
 			userId: 'user-a',
 			packageId: 'pkg-gone',
 			conversationId: 'c5',
-			usedAt: recent,
+			usedAt: '2026-07-14T00:00:00.000Z',
 		},
 	)
 
 	const ranked = await listPopularAgentPackagesForUser(db, {
 		userId: 'user-a',
 		now,
+		conversationLimit: 4,
 		limit: 8,
 	})
+	// Last 4 conversations by recency: c5 (gone), c4 (bravo), c3/c2/c1 (alpha),
+	// but limit 4 means c5,c4,c3,c2 — charlie's c0 is excluded.
 	expect(ranked.map((row) => row.kodyId)).toEqual(['alpha', 'bravo'])
-	expect(ranked[0]?.conversationCount).toBe(3)
-	expect(ranked[1]?.conversationCount).toBe(2)
+	expect(ranked[0]?.conversationCount).toBe(2) // c2, c3
+	expect(ranked[1]?.conversationCount).toBe(1) // c4
+})
+
+test('listPopularAgentPackagesForUser ignores conversations older than max age', async () => {
+	const { sqlite, db } = createTestDb()
+	seedPackage(sqlite, {
+		id: 'pkg-a',
+		userId: 'user-a',
+		kodyId: 'alpha',
+		description: 'Alpha pack',
+	})
+	seedPackage(sqlite, {
+		id: 'pkg-old',
+		userId: 'user-a',
+		kodyId: 'stale',
+		description: 'Stale pack',
+	})
+
+	const now = new Date('2026-07-21T12:00:00.000Z')
+	await recordAgentPackageConversationUse(
+		{ APP_DB: db },
+		{
+			userId: 'user-a',
+			packageId: 'pkg-old',
+			conversationId: 'ancient',
+			usedAt: '2025-01-01T00:00:00.000Z',
+		},
+	)
+	await recordAgentPackageConversationUse(
+		{ APP_DB: db },
+		{
+			userId: 'user-a',
+			packageId: 'pkg-a',
+			conversationId: 'recent',
+			usedAt: '2026-07-10T00:00:00.000Z',
+		},
+	)
+
+	const ranked = await listPopularAgentPackagesForUser(db, {
+		userId: 'user-a',
+		now,
+		conversationLimit: 40,
+		maxAgeDays: 180,
+	})
+	expect(ranked.map((row) => row.kodyId)).toEqual(['alpha'])
 })
 
 test('recordAgentPackageConversationUse never throws when DB is missing', async () => {

--- a/packages/worker/src/usage/agent-package-conversation-uses.ts
+++ b/packages/worker/src/usage/agent-package-conversation-uses.ts
@@ -4,9 +4,10 @@ import { toHex } from '@kody-internal/shared/hex.ts'
  * Agent-facing package popularity for MCP server instructions.
  *
  * Tracks distinct (user, package, conversation) uses from MCP `execute`
- * package paths. Ranking uses unique conversation counts over a rolling
- * window — not raw invoke spam. Writes are best-effort and never throw into
- * the invoke path (same spirit as `recordUsage`).
+ * package paths. Ranking uses unique conversation counts among the user's
+ * most recent agent conversations — not a fixed calendar window, and not raw
+ * invoke spam. Writes are best-effort and never throw into the invoke path
+ * (same spirit as `recordUsage`).
  *
  * Stored `conversation_id` values are SHA-256 hex digests of the MCP
  * conversation id (not the raw id), so the table only needs cardinality, not
@@ -15,7 +16,10 @@ import { toHex } from '@kody-internal/shared/hex.ts'
  * See `docs/contributing/architecture/usage-metering.md`.
  */
 
-export const agentPackagePopularityWindowDays = 30
+/** How many recent distinct agent conversations to consider for ranking. */
+export const agentPackagePopularityConversationLimit = 40
+/** Hard outer bound so abandoned packages do not linger forever. */
+export const agentPackagePopularityMaxAgeDays = 180
 export const agentPackagePopularityTopLimit = 8
 
 export type AgentPackageConversationUseEnv = {
@@ -107,15 +111,17 @@ export async function recordAgentPackageConversationUses(
 }
 
 /**
- * Rank packages by distinct conversation count in the rolling window, join
- * saved-package metadata, skip packages the user no longer has.
+ * Rank packages by how many of the user's last N agent conversations used
+ * them. Skips packages the user no longer has. Conversations older than the
+ * max-age bound are ignored even if they would otherwise fall in the last N.
  */
 export async function listPopularAgentPackagesForUser(
 	db: D1Database,
 	input: {
 		userId: string
 		limit?: number
-		windowDays?: number
+		conversationLimit?: number
+		maxAgeDays?: number
 		now?: Date
 	},
 ): Promise<Array<PopularAgentPackageSummary>> {
@@ -123,31 +129,45 @@ export async function listPopularAgentPackagesForUser(
 		const userId = input.userId.trim()
 		if (!userId) return []
 		const limit = input.limit ?? agentPackagePopularityTopLimit
-		const windowDays = input.windowDays ?? agentPackagePopularityWindowDays
+		const conversationLimit =
+			input.conversationLimit ?? agentPackagePopularityConversationLimit
+		const maxAgeDays = input.maxAgeDays ?? agentPackagePopularityMaxAgeDays
 		const now = input.now ?? new Date()
 		const since = new Date(
-			now.getTime() - windowDays * 24 * 60 * 60 * 1000,
+			now.getTime() - maxAgeDays * 24 * 60 * 60 * 1000,
 		).toISOString()
 
 		const rows = await db
 			.prepare(
 				`
+WITH recent_conversations AS (
+	SELECT
+		conversation_id,
+		MAX(last_used_at) AS conversation_last_used_at
+	FROM agent_package_conversation_uses
+	WHERE user_id = ?1
+		AND last_used_at >= ?2
+	GROUP BY conversation_id
+	ORDER BY conversation_last_used_at DESC
+	LIMIT ?3
+)
 SELECT
 	u.package_id AS package_id,
 	p.kody_id AS kody_id,
 	p.description AS description,
 	COUNT(*) AS conversation_count
 FROM agent_package_conversation_uses u
+INNER JOIN recent_conversations rc
+	ON rc.conversation_id = u.conversation_id
 INNER JOIN saved_packages p
 	ON p.id = u.package_id AND p.user_id = u.user_id
 WHERE u.user_id = ?1
-	AND u.last_used_at >= ?2
 GROUP BY u.package_id, p.kody_id, p.description
 ORDER BY conversation_count DESC, p.kody_id ASC
-LIMIT ?3
+LIMIT ?4
 				`.trim(),
 			)
-			.bind(userId, since, limit)
+			.bind(userId, since, conversationLimit, limit)
 			.all<{
 				package_id: string
 				kody_id: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #823: ranking for the MCP “Often used from agents” hint now uses the user’s **last N agent conversations** (default 40) instead of a fixed 30-day calendar window, so infrequent users still get a useful packages-first signal. A 180-day max-age bound keeps abandoned packages from lingering forever.

## Test plan

- [x] Unit tests for last-N ranking and max-age exclusion
- [ ] CI `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/agent-package-popularity-last-n-0387`

**Classification:** extends — changes how `usage-metering` ranks agent package popularity for MCP instructions.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `usage-metering` | storage | extends — last-N conversation ranking (+ max age) |

### System map

Popularity read path samples the user’s recent agent conversations, then ranks packages by participation in that set.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	usageMetering["usage-metering<br/>Usage metering"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	mcpServer -->|"listPopularAgentPackagesForUser"| usageMetering
	usageMetering -->|"last N conversations CTE"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

- Before: count package conversations with `last_used_at` in last **30 days**
- After: take last **40** distinct conversations (within **180** days), then count package participation in that set; top 8 unchanged

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e25cee0d-8474-4d5a-9d92-d51289970387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e25cee0d-8474-4d5a-9d92-d51289970387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved agent package popularity rankings by considering the latest 40 distinct conversations by default.
  * Excludes conversations older than 180 days from popularity results.
  * Package usage is now ranked by the number of recent conversations using each package.
  * Missing or deleted packages continue to be excluded from displayed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->