### PR TITLE
Filter stale package rows out of last-N popularity ranking

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -126,10 +126,11 @@ conversations** in which a signed-in user’s agents used a saved package via MC
   (cardinality only; not reversible to the raw id).
 - Read path: take the user’s last **N** distinct agent conversations
   (default 40) with `last_used_at` within a hard max age (default 180 days),
-  count how many of those conversations used each package, join `saved_packages`
-  for `kody_id` + description, top 8 for `buildMcpServerInstructions`. Cold
-  start (no rows) omits the section. List failures (missing table, transient D1
-  errors) return `[]` so MCP init stays up during migration rollout.
+  count how many of those conversations used each package (package rows must
+  also be within max age), join `saved_packages` for `kody_id` + description,
+  top 8 for `buildMcpServerInstructions`. Cold start (no rows) omits the
+  section. List failures (missing table, transient D1 errors) return `[]` so MCP
+  init stays up during migration rollout.
 - Writes are best-effort and never throw into the invoke path (same spirit as
   `recordUsage`). Do **not** widen `usage_rollups` for conversation cardinality.
 

--- a/packages/worker/src/usage/agent-package-conversation-uses.node.test.ts
+++ b/packages/worker/src/usage/agent-package-conversation-uses.node.test.ts
@@ -291,6 +291,52 @@ test('listPopularAgentPackagesForUser ignores conversations older than max age',
 	expect(ranked.map((row) => row.kodyId)).toEqual(['alpha'])
 })
 
+test('listPopularAgentPackagesForUser ignores stale package rows inside recent conversations', async () => {
+	const { sqlite, db } = createTestDb()
+	seedPackage(sqlite, {
+		id: 'pkg-a',
+		userId: 'user-a',
+		kodyId: 'alpha',
+		description: 'Alpha pack',
+	})
+	seedPackage(sqlite, {
+		id: 'pkg-old',
+		userId: 'user-a',
+		kodyId: 'stale',
+		description: 'Stale pack',
+	})
+
+	const now = new Date('2026-07-21T12:00:00.000Z')
+	// Same conversation: recent alpha use pulls the conversation into last-N,
+	// but a much older stale-package row must not count.
+	await recordAgentPackageConversationUse(
+		{ APP_DB: db },
+		{
+			userId: 'user-a',
+			packageId: 'pkg-old',
+			conversationId: 'shared',
+			usedAt: '2025-01-01T00:00:00.000Z',
+		},
+	)
+	await recordAgentPackageConversationUse(
+		{ APP_DB: db },
+		{
+			userId: 'user-a',
+			packageId: 'pkg-a',
+			conversationId: 'shared',
+			usedAt: '2026-07-10T00:00:00.000Z',
+		},
+	)
+
+	const ranked = await listPopularAgentPackagesForUser(db, {
+		userId: 'user-a',
+		now,
+		conversationLimit: 40,
+		maxAgeDays: 180,
+	})
+	expect(ranked.map((row) => row.kodyId)).toEqual(['alpha'])
+})
+
 test('recordAgentPackageConversationUse never throws when DB is missing', async () => {
 	await expect(
 		recordAgentPackageConversationUse(

--- a/packages/worker/src/usage/agent-package-conversation-uses.ts
+++ b/packages/worker/src/usage/agent-package-conversation-uses.ts
@@ -162,6 +162,7 @@ INNER JOIN recent_conversations rc
 INNER JOIN saved_packages p
 	ON p.id = u.package_id AND p.user_id = u.user_id
 WHERE u.user_id = ?1
+	AND u.last_used_at >= ?2
 GROUP BY u.package_id, p.kody_id, p.description
 ORDER BY conversation_count DESC, p.kody_id ASC
 LIMIT ?4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #826 / Bugbot: when ranking packages in the user’s last N agent conversations, require each package row’s `last_used_at` to be within the max-age bound. Prevents an abandoned package in a recently revived conversation from inflating the MCP “Often used from agents” hint.

## Test plan

- [x] Unit test for stale row in a recent conversation
- [ ] CI validate

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/agent-package-popularity-max-age-filter-0387`

**Classification:** extends — tightens the `usage-metering` popularity read query.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `usage-metering` | storage | extends — max-age filter on package rows in last-N ranking |

### System map

Last-N conversation selection still drives the candidate set; package counts now also require row-level freshness.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	usageMetering["usage-metering<br/>Usage metering"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	usageMetering -->|"last N CTE + row max-age filter"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e25cee0d-8474-4d5a-9d92-d51289970387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e25cee0d-8474-4d5a-9d92-d51289970387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popular package rankings by excluding stale usage records from recent conversation counts.
  * Ensured outdated package activity no longer affects popularity results.

* **Tests**
  * Added coverage verifying stale package records are excluded when calculating recent popularity.

* **Documentation**
  * Reformatted usage metering guidance for improved readability without changing its meaning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->