### PR TITLE
Enforce non-null stable user IDs

### DIFF
--- a/packages/worker/migrations/0075-stable-user-id-not-null.sql
+++ b/packages/worker/migrations/0075-stable-user-id-not-null.sql
@@ -1,0 +1,126 @@
+-- Enforce users.stable_user_id as NOT NULL after production backfill is complete.
+-- SQLite cannot ALTER a column nullability in place, so rebuild the table.
+--
+-- Cloudflare D1 wraps each migration in a transaction, so PRAGMA foreign_keys=OFF
+-- is a no-op there. With foreign keys still enforced, DROP TABLE users destroys or
+-- nulls inbound FK rows (CASCADE / SET NULL). Snapshot every table that references
+-- users, clear those rows, rebuild users, then restore the snapshots.
+-- Fail-closed: users_next.stable_user_id is NOT NULL with no default, so any
+-- remaining NULL stable ids abort the migration (and D1 rolls the transaction back).
+
+CREATE TABLE _mig0075_password_resets AS SELECT * FROM password_resets;
+CREATE TABLE _mig0075_email_verifications AS SELECT * FROM email_verifications;
+CREATE TABLE _mig0075_pending_email_changes AS SELECT * FROM pending_email_changes;
+CREATE TABLE _mig0075_passkeys AS SELECT * FROM passkeys;
+CREATE TABLE _mig0075_oauth_connections AS SELECT * FROM oauth_connections;
+CREATE TABLE _mig0075_user_roles AS SELECT * FROM user_roles;
+CREATE TABLE _mig0075_invites AS SELECT * FROM invites;
+CREATE TABLE _mig0075_feature_flags AS SELECT * FROM feature_flags;
+CREATE TABLE _mig0075_feature_flag_user_overrides AS
+SELECT * FROM feature_flag_user_overrides;
+
+DELETE FROM feature_flag_user_overrides;
+DELETE FROM feature_flags;
+DELETE FROM invites;
+DELETE FROM user_roles;
+DELETE FROM oauth_connections;
+DELETE FROM passkeys;
+DELETE FROM pending_email_changes;
+DELETE FROM email_verifications;
+DELETE FROM password_resets;
+
+CREATE TABLE users_next (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	username TEXT NOT NULL UNIQUE,
+	email TEXT NOT NULL UNIQUE,
+	password_hash TEXT NOT NULL,
+	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+	updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+	email_verified_at TEXT,
+	plan TEXT DEFAULT NULL,
+	stable_user_id TEXT NOT NULL,
+	stripe_customer_id TEXT,
+	stripe_plan TEXT,
+	stripe_plan_refreshed_at TEXT,
+	display_name TEXT,
+	bio TEXT,
+	profile_visibility TEXT NOT NULL DEFAULT 'public' CHECK (
+		profile_visibility IN ('public', 'private')
+	),
+	avatar_key TEXT,
+	account_type TEXT NOT NULL DEFAULT 'person' CHECK (
+		account_type IN ('person', 'platform')
+	)
+);
+
+INSERT INTO users_next (
+	id,
+	username,
+	email,
+	password_hash,
+	created_at,
+	updated_at,
+	email_verified_at,
+	plan,
+	stable_user_id,
+	stripe_customer_id,
+	stripe_plan,
+	stripe_plan_refreshed_at,
+	display_name,
+	bio,
+	profile_visibility,
+	avatar_key,
+	account_type
+)
+SELECT
+	id,
+	username,
+	email,
+	password_hash,
+	created_at,
+	updated_at,
+	email_verified_at,
+	plan,
+	stable_user_id,
+	stripe_customer_id,
+	stripe_plan,
+	stripe_plan_refreshed_at,
+	display_name,
+	bio,
+	profile_visibility,
+	avatar_key,
+	account_type
+FROM users;
+
+DROP TABLE users;
+
+ALTER TABLE users_next RENAME TO users;
+
+CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_stable_user_id
+	ON users(stable_user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_stripe_customer_id
+	ON users(stripe_customer_id)
+	WHERE stripe_customer_id IS NOT NULL;
+
+INSERT INTO password_resets SELECT * FROM _mig0075_password_resets;
+INSERT INTO email_verifications SELECT * FROM _mig0075_email_verifications;
+INSERT INTO pending_email_changes SELECT * FROM _mig0075_pending_email_changes;
+INSERT INTO passkeys SELECT * FROM _mig0075_passkeys;
+INSERT INTO oauth_connections SELECT * FROM _mig0075_oauth_connections;
+INSERT INTO user_roles SELECT * FROM _mig0075_user_roles;
+INSERT INTO invites SELECT * FROM _mig0075_invites;
+INSERT INTO feature_flags SELECT * FROM _mig0075_feature_flags;
+INSERT INTO feature_flag_user_overrides
+SELECT * FROM _mig0075_feature_flag_user_overrides;
+
+DROP TABLE _mig0075_password_resets;
+DROP TABLE _mig0075_email_verifications;
+DROP TABLE _mig0075_pending_email_changes;
+DROP TABLE _mig0075_passkeys;
+DROP TABLE _mig0075_oauth_connections;
+DROP TABLE _mig0075_user_roles;
+DROP TABLE _mig0075_invites;
+DROP TABLE _mig0075_feature_flags;
+DROP TABLE _mig0075_feature_flag_user_overrides;

--- a/packages/worker/src/app/account-export.node.test.ts
+++ b/packages/worker/src/app/account-export.node.test.ts
@@ -115,8 +115,14 @@ test('account export D1 coverage includes every live user-owned schema column', 
 test('account export documents and excludes operator-owned system email rows', async () => {
 	const { sqlite, db } = createMigratedDb()
 	sqlite.exec(`
-		INSERT INTO users (id, username, email, password_hash, created_at, updated_at, email_verified_at)
-		VALUES (1, 'user-a', 'a@example.com', 'password-hash-a', '2026-07-05', '2026-07-05', '2026-07-05');
+		INSERT INTO users (
+			id, username, email, password_hash, created_at, updated_at,
+			email_verified_at, stable_user_id
+		)
+		VALUES (
+			1, 'user-a', 'a@example.com', 'password-hash-a', '2026-07-05',
+			'2026-07-05', '2026-07-05', 'user-aaa'
+		);
 
 		INSERT INTO email_messages (
 			id, direction, user_id, from_address, subject, processing_status, created_at, updated_at
@@ -226,15 +232,16 @@ test('account export includes profile fields and social graph edges for either s
 	sqlite.exec(`
 		INSERT INTO users (
 			id, username, email, password_hash, created_at, updated_at,
-			email_verified_at, display_name, bio, profile_visibility
+			email_verified_at, stable_user_id, display_name, bio, profile_visibility
 		) VALUES
 			(
 				1, 'user-a', 'a@example.com', 'password-hash-a', '2026-07-05',
-				'2026-07-05', '2026-07-05', 'User A', 'Builds packages', 'public'
+				'2026-07-05', '2026-07-05', 'user-aaa', 'User A', 'Builds packages',
+				'public'
 			),
 			(
 				2, 'user-b', 'b@example.com', 'password-hash-b', '2026-07-05',
-				'2026-07-05', '2026-07-05', 'User B', NULL, 'private'
+				'2026-07-05', '2026-07-05', 'user-bbb', 'User B', NULL, 'private'
 			);
 
 		INSERT INTO community_listings (
@@ -355,10 +362,19 @@ test('account export includes profile fields and social graph edges for either s
 test('createAccountExport redacts secrets and credential-equivalent hashes', async () => {
 	const { sqlite, db } = createMigratedDb()
 	sqlite.exec(`
-		INSERT INTO users (id, username, email, password_hash, created_at, updated_at, email_verified_at)
+		INSERT INTO users (
+			id, username, email, password_hash, created_at, updated_at,
+			email_verified_at, stable_user_id
+		)
 		VALUES
-			(1, 'user-a', 'a@example.com', 'password-hash-a', '2026-07-05', '2026-07-05', '2026-07-05'),
-			(2, 'user-b', 'b@example.com', 'password-hash-b', '2026-07-05', '2026-07-05', '2026-07-05');
+			(
+				1, 'user-a', 'a@example.com', 'password-hash-a', '2026-07-05',
+				'2026-07-05', '2026-07-05', 'user-aaa'
+			),
+			(
+				2, 'user-b', 'b@example.com', 'password-hash-b', '2026-07-05',
+				'2026-07-05', '2026-07-05', 'user-bbb'
+			);
 
 		INSERT INTO secret_buckets (id, user_id, scope, binding_key, created_at, updated_at)
 		VALUES ('secret-bucket-a', 'user-aaa', 'user', 'global', '2026-07-05', '2026-07-05');
@@ -514,8 +530,14 @@ test('createAccountExport redacts secrets and credential-equivalent hashes', asy
 test('createAccountExport records partial-failure warnings and section pagination works', async () => {
 	const { sqlite, db } = createMigratedDb()
 	sqlite.exec(`
-		INSERT INTO users (id, username, email, password_hash, created_at, updated_at, email_verified_at)
-		VALUES (1, 'user-a', 'a@example.com', 'password-hash-a', '2026-07-05', '2026-07-05', '2026-07-05');
+		INSERT INTO users (
+			id, username, email, password_hash, created_at, updated_at,
+			email_verified_at, stable_user_id
+		)
+		VALUES (
+			1, 'user-a', 'a@example.com', 'password-hash-a', '2026-07-05',
+			'2026-07-05', '2026-07-05', 'user-aaa'
+		);
 		INSERT INTO archived_job_artifacts (
 			id,
 			job_id,
@@ -609,8 +631,14 @@ test('D1 export reads large tables in bounded keyset pages', async () => {
 		onQueryRows: (rowCount) => rowCounts.push(rowCount),
 	})
 	sqlite.exec(`
-		INSERT INTO users (id, username, email, password_hash, created_at, updated_at, email_verified_at)
-		VALUES (1, 'user-a', 'a@example.com', 'password-hash-a', '2026-07-05', '2026-07-05', '2026-07-05');
+		INSERT INTO users (
+			id, username, email, password_hash, created_at, updated_at,
+			email_verified_at, stable_user_id
+		)
+		VALUES (
+			1, 'user-a', 'a@example.com', 'password-hash-a', '2026-07-05',
+			'2026-07-05', '2026-07-05', 'user-aaa'
+		);
 	`)
 	const totalMessages = 1201
 	const insert = sqlite.prepare(

--- a/packages/worker/src/stable-user-id-not-null-migration.node.test.ts
+++ b/packages/worker/src/stable-user-id-not-null-migration.node.test.ts
@@ -1,0 +1,367 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+
+const migrationsDirectory = new URL('../migrations/', import.meta.url)
+
+const inboundUserFkTables = [
+	'password_resets',
+	'email_verifications',
+	'pending_email_changes',
+	'passkeys',
+	'oauth_connections',
+	'user_roles',
+	'invites',
+	'feature_flags',
+	'feature_flag_user_overrides',
+] as const
+
+type InboundUserFkTable = (typeof inboundUserFkTables)[number]
+type ChildRowSnapshot = Record<
+	InboundUserFkTable,
+	Array<Record<string, unknown>>
+>
+
+/** D1 wraps each migration file in a transaction; PRAGMA foreign_keys=OFF is a no-op. */
+function applyMigrationLikeD1(db: DatabaseSync, fileName: string) {
+	const sql = readFileSync(new URL(fileName, migrationsDirectory), 'utf8')
+	db.exec('BEGIN')
+	try {
+		db.exec(sql)
+		db.exec('COMMIT')
+	} catch (error) {
+		db.exec('ROLLBACK')
+		throw error
+	}
+}
+
+function applyMigrationsBeforeNotNull(db: DatabaseSync) {
+	db.exec('PRAGMA foreign_keys = ON')
+	for (const fileName of readdirSync(migrationsDirectory)
+		.filter(
+			(file) =>
+				file.endsWith('.sql') && file !== '0075-stable-user-id-not-null.sql',
+		)
+		.sort()) {
+		db.exec(readFileSync(new URL(fileName, migrationsDirectory), 'utf8'))
+	}
+}
+
+function listLiveTables(db: DatabaseSync) {
+	return (
+		db
+			.prepare(
+				`SELECT name FROM sqlite_master
+				 WHERE type = 'table'
+				   AND name NOT LIKE 'sqlite_%'
+				 ORDER BY name`,
+			)
+			.all() as Array<{ name: string }>
+	).map((row) => row.name)
+}
+
+function tablesWithForeignKeyToUsers(db: DatabaseSync) {
+	const referencingUsers: string[] = []
+	for (const tableName of listLiveTables(db)) {
+		const foreignKeys = db
+			.prepare(`PRAGMA foreign_key_list(${tableName})`)
+			.all() as Array<{ table: string }>
+		if (foreignKeys.some((foreignKey) => foreignKey.table === 'users')) {
+			referencingUsers.push(tableName)
+		}
+	}
+	return referencingUsers.sort()
+}
+
+function assertInboundUserFkInventoryMatches(db: DatabaseSync) {
+	expect(tablesWithForeignKeyToUsers(db)).toEqual(
+		[...inboundUserFkTables].sort(),
+	)
+}
+
+function selectAllRowsOrdered(db: DatabaseSync, tableName: string) {
+	const columns = (
+		db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{
+			name: string
+		}>
+	).map((column) => column.name)
+	const orderBy = columns.join(', ')
+	return db
+		.prepare(`SELECT * FROM ${tableName} ORDER BY ${orderBy}`)
+		.all() as Array<Record<string, unknown>>
+}
+
+function snapshotInboundUserFkRows(db: DatabaseSync): ChildRowSnapshot {
+	return Object.fromEntries(
+		inboundUserFkTables.map((tableName) => [
+			tableName,
+			selectAllRowsOrdered(db, tableName),
+		]),
+	) as ChildRowSnapshot
+}
+
+function expectInboundUserFkRowsPreserved(
+	db: DatabaseSync,
+	beforeRows: ChildRowSnapshot,
+) {
+	for (const tableName of inboundUserFkTables) {
+		expect(selectAllRowsOrdered(db, tableName)).toEqual(beforeRows[tableName])
+	}
+}
+
+function usersTableSql(db: DatabaseSync) {
+	const row = db
+		.prepare(
+			`SELECT sql FROM sqlite_master
+			 WHERE type = 'table' AND name = 'users'`,
+		)
+		.get() as { sql: string } | undefined
+	return row?.sql ?? ''
+}
+
+function stableUserIdIndexSql(db: DatabaseSync) {
+	const row = db
+		.prepare(
+			`SELECT sql FROM sqlite_master
+			 WHERE type = 'index' AND name = 'idx_users_stable_user_id'`,
+		)
+		.get() as { sql: string | null } | undefined
+	return row?.sql ?? ''
+}
+
+function seedInboundFkRows(db: DatabaseSync) {
+	db.exec(`
+		INSERT INTO users (
+			id, username, email, password_hash, email_verified_at, stable_user_id,
+			plan, stripe_customer_id, display_name, bio, profile_visibility,
+			avatar_key, account_type
+		) VALUES (
+			1, 'alice', 'alice@example.com', 'hash-a', '2026-07-01',
+			'custom-preserved-stable-id', 'pro', 'cus_alice', 'Alice', 'Builder',
+			'public', 'user-avatars/alice/a.png', 'person'
+		);
+		INSERT INTO users (
+			id, username, email, password_hash, stable_user_id, account_type
+		) VALUES (
+			2, 'platform', 'platform@example.com', 'hash-p', 'stable-platform',
+			'platform'
+		);
+
+		INSERT INTO password_resets (id, user_id, token_hash, expires_at)
+		VALUES (11, 1, 'reset-hash', 999999);
+		INSERT INTO email_verifications (id, user_id, token_hash, expires_at)
+		VALUES (21, 1, 'verify-hash', 999999);
+		INSERT INTO pending_email_changes (
+			id, user_id, new_email, token_hash, expires_at
+		) VALUES (31, 1, 'alice-new@example.com', 'email-change-hash', 999999);
+		INSERT INTO passkeys (
+			id, aaguid, public_key, user_id, webauthn_user_handle, counter,
+			device_type, backed_up, transports, name, last_used_at
+		) VALUES (
+			'passkey-1', 'aaguid', 'public-key', 1, 'handle-1', 3, 'platform', 1,
+			'internal', 'Laptop', '2026-07-02'
+		);
+		INSERT INTO oauth_connections (
+			id, user_id, provider_name, provider_id, provider_display_name,
+			created_at, updated_at
+		) VALUES (
+			41, 1, 'github', 'gh-1', 'alice-gh', '2026-07-01', '2026-07-01'
+		);
+		INSERT INTO user_roles (user_id, role_id, created_at)
+		SELECT 1, id, '2026-07-01' FROM roles WHERE name = 'user';
+		INSERT INTO invites (code, created_by, note, max_uses, use_count)
+		VALUES ('invite-alice', 1, 'friend', 2, 1);
+		INSERT INTO feature_flags (key, enabled, rollout_percent, note, updated_by)
+		VALUES ('beta', 1, 25, 'rollout', 1);
+		INSERT INTO feature_flag_user_overrides (
+			flag_key, user_id, enabled, updated_by, updated_at
+		) VALUES ('beta', 1, 0, 2, '2026-07-03');
+	`)
+}
+
+test('stable user id not-null migration rebuilds users and preserves inbound fks under a D1 transaction', () => {
+	const db = new DatabaseSync(':memory:')
+	applyMigrationsBeforeNotNull(db)
+	seedInboundFkRows(db)
+	assertInboundUserFkInventoryMatches(db)
+
+	const beforeChildRows = snapshotInboundUserFkRows(db)
+
+	expect(usersTableSql(db)).toContain('stable_user_id TEXT')
+	expect(usersTableSql(db)).not.toContain('stable_user_id TEXT NOT NULL')
+	expect(stableUserIdIndexSql(db)).toContain('WHERE stable_user_id IS NOT NULL')
+	expect(
+		db
+			.prepare(`SELECT sql FROM sqlite_master WHERE name LIKE '_mig0075_%'`)
+			.all(),
+	).toEqual([])
+
+	applyMigrationLikeD1(db, '0075-stable-user-id-not-null.sql')
+
+	const stableColumn = (
+		db.prepare(`PRAGMA table_info(users)`).all() as Array<{
+			name: string
+			notnull: number
+			type: string
+			dflt_value: string | null
+		}>
+	).find((column) => column.name === 'stable_user_id')
+	expect(stableColumn).toMatchObject({
+		name: 'stable_user_id',
+		type: 'TEXT',
+		notnull: 1,
+		dflt_value: null,
+	})
+	expect(usersTableSql(db)).toContain('stable_user_id TEXT NOT NULL')
+	expect(stableUserIdIndexSql(db)).toBe(
+		'CREATE UNIQUE INDEX idx_users_stable_user_id\n\tON users(stable_user_id)',
+	)
+	expect(
+		db
+			.prepare(
+				`SELECT name, sql FROM sqlite_master
+				 WHERE type = 'index' AND tbl_name = 'users' AND sql IS NOT NULL
+				 ORDER BY name`,
+			)
+			.all(),
+	).toEqual([
+		{
+			name: 'idx_users_email',
+			sql: 'CREATE INDEX idx_users_email ON users(email)',
+		},
+		{
+			name: 'idx_users_stable_user_id',
+			sql: 'CREATE UNIQUE INDEX idx_users_stable_user_id\n\tON users(stable_user_id)',
+		},
+		{
+			name: 'idx_users_stripe_customer_id',
+			sql: 'CREATE UNIQUE INDEX idx_users_stripe_customer_id\n\tON users(stripe_customer_id)\n\tWHERE stripe_customer_id IS NOT NULL',
+		},
+		{
+			name: 'idx_users_username',
+			sql: 'CREATE INDEX idx_users_username ON users(username)',
+		},
+	])
+	expect(
+		db
+			.prepare(`SELECT sql FROM sqlite_master WHERE name LIKE '_mig0075_%'`)
+			.all(),
+	).toEqual([])
+
+	expect(
+		db
+			.prepare(
+				`SELECT id, email, stable_user_id, plan, stripe_customer_id,
+					display_name, bio, profile_visibility, avatar_key, account_type
+				 FROM users
+				 ORDER BY id`,
+			)
+			.all(),
+	).toEqual([
+		{
+			id: 1,
+			email: 'alice@example.com',
+			stable_user_id: 'custom-preserved-stable-id',
+			plan: 'pro',
+			stripe_customer_id: 'cus_alice',
+			display_name: 'Alice',
+			bio: 'Builder',
+			profile_visibility: 'public',
+			avatar_key: 'user-avatars/alice/a.png',
+			account_type: 'person',
+		},
+		{
+			id: 2,
+			email: 'platform@example.com',
+			stable_user_id: 'stable-platform',
+			plan: null,
+			stripe_customer_id: null,
+			display_name: null,
+			bio: null,
+			profile_visibility: 'public',
+			avatar_key: null,
+			account_type: 'platform',
+		},
+	])
+
+	expectInboundUserFkRowsPreserved(db, beforeChildRows)
+
+	expect(db.prepare(`PRAGMA foreign_key_check`).all()).toEqual([])
+
+	expect(
+		db.prepare(`SELECT seq FROM sqlite_sequence WHERE name = 'users'`).get(),
+	).toEqual({ seq: 2 })
+
+	db.prepare(
+		`INSERT INTO users (username, email, password_hash, stable_user_id)
+		 VALUES ('carol', 'carol@example.com', 'hash-c', 'stable-carol')`,
+	).run()
+	expect(
+		db.prepare(`SELECT id FROM users WHERE username = 'carol'`).get(),
+	).toEqual({ id: 3 })
+
+	expect(() => {
+		db.prepare(
+			`INSERT INTO users (username, email, password_hash, stable_user_id)
+			 VALUES ('nope', 'nope@example.com', 'hash', NULL)`,
+		).run()
+	}).toThrow(/NOT NULL constraint failed: users\.stable_user_id/)
+
+	expect(() => {
+		db.prepare(
+			`INSERT INTO users (username, email, password_hash)
+			 VALUES ('nope2', 'nope2@example.com', 'hash')`,
+		).run()
+	}).toThrow(/NOT NULL constraint failed: users\.stable_user_id/)
+
+	db.exec('PRAGMA foreign_keys = ON')
+	db.prepare(`DELETE FROM users WHERE id = 1`).run()
+	expect(
+		db.prepare(`SELECT COUNT(*) AS count FROM pending_email_changes`).get(),
+	).toEqual({ count: 0 })
+	expect(
+		db.prepare(`SELECT COUNT(*) AS count FROM password_resets`).get(),
+	).toEqual({ count: 0 })
+	expect(
+		db.prepare(`SELECT COUNT(*) AS count FROM oauth_connections`).get(),
+	).toEqual({ count: 0 })
+	expect(
+		db
+			.prepare(`SELECT created_by FROM invites WHERE code = 'invite-alice'`)
+			.get(),
+	).toEqual({ created_by: null })
+})
+
+test('stable user id not-null migration fails closed when any NULL stable id remains', () => {
+	const db = new DatabaseSync(':memory:')
+	applyMigrationsBeforeNotNull(db)
+	seedInboundFkRows(db)
+	assertInboundUserFkInventoryMatches(db)
+	db.prepare(
+		`INSERT INTO users (username, email, password_hash, stable_user_id)
+		 VALUES (?, ?, ?, ?)`,
+	).run('legacy', 'legacy@example.com', 'hash', null)
+
+	const beforeChildRows = snapshotInboundUserFkRows(db)
+
+	expect(() =>
+		applyMigrationLikeD1(db, '0075-stable-user-id-not-null.sql'),
+	).toThrow(/NOT NULL constraint failed: users_next\.stable_user_id/)
+
+	expect(usersTableSql(db)).not.toContain('stable_user_id TEXT NOT NULL')
+	expect(stableUserIdIndexSql(db)).toContain('WHERE stable_user_id IS NOT NULL')
+	expect(
+		db.prepare(`SELECT username, stable_user_id FROM users ORDER BY id`).all(),
+	).toEqual([
+		{ username: 'alice', stable_user_id: 'custom-preserved-stable-id' },
+		{ username: 'platform', stable_user_id: 'stable-platform' },
+		{ username: 'legacy', stable_user_id: null },
+	])
+	expectInboundUserFkRowsPreserved(db, beforeChildRows)
+	expect(db.prepare(`PRAGMA foreign_key_check`).all()).toEqual([])
+	expect(
+		db
+			.prepare(`SELECT sql FROM sqlite_master WHERE name LIKE '_mig0075_%'`)
+			.all(),
+	).toEqual([])
+})

--- a/packages/worker/src/stable-user-id-not-null-migration.node.test.ts
+++ b/packages/worker/src/stable-user-id-not-null-migration.node.test.ts
@@ -4,6 +4,9 @@ import { expect, test } from 'vitest'
 
 const migrationsDirectory = new URL('../migrations/', import.meta.url)
 
+/** Upper bound (exclusive): only migrations before this file are applied as setup. */
+const stableUserIdNotNullMigration = '0075-stable-user-id-not-null.sql'
+
 const inboundUserFkTables = [
 	'password_resets',
 	'email_verifications',
@@ -39,8 +42,7 @@ function applyMigrationsBeforeNotNull(db: DatabaseSync) {
 	db.exec('PRAGMA foreign_keys = ON')
 	for (const fileName of readdirSync(migrationsDirectory)
 		.filter(
-			(file) =>
-				file.endsWith('.sql') && file !== '0075-stable-user-id-not-null.sql',
+			(file) => file.endsWith('.sql') && file < stableUserIdNotNullMigration,
 		)
 		.sort()) {
 		db.exec(readFileSync(new URL(fileName, migrationsDirectory), 'utf8'))
@@ -196,7 +198,7 @@ test('stable user id not-null migration rebuilds users and preserves inbound fks
 			.all(),
 	).toEqual([])
 
-	applyMigrationLikeD1(db, '0075-stable-user-id-not-null.sql')
+	applyMigrationLikeD1(db, stableUserIdNotNullMigration)
 
 	const stableColumn = (
 		db.prepare(`PRAGMA table_info(users)`).all() as Array<{
@@ -344,9 +346,9 @@ test('stable user id not-null migration fails closed when any NULL stable id rem
 
 	const beforeChildRows = snapshotInboundUserFkRows(db)
 
-	expect(() =>
-		applyMigrationLikeD1(db, '0075-stable-user-id-not-null.sql'),
-	).toThrow(/NOT NULL constraint failed: users_next\.stable_user_id/)
+	expect(() => applyMigrationLikeD1(db, stableUserIdNotNullMigration)).toThrow(
+		/NOT NULL constraint failed: users_next\.stable_user_id/,
+	)
 
 	expect(usersTableSql(db)).not.toContain('stable_user_id TEXT NOT NULL')
 	expect(stableUserIdIndexSql(db)).toContain('WHERE stable_user_id IS NOT NULL')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- enforce `users.stable_user_id` as `NOT NULL` after production backfill verification
- preserve all inbound foreign-key rows during the D1 transaction-safe table rebuild
- add migration coverage for exact child-row preservation, rollback, indexes, foreign keys, autoincrement, and historically bounded setup

## Production gate
Deploy run [29874947652](https://github.com/kentcdodds/kody/actions/runs/29874947652) reported `scanned: 26`, `backfilled: 0`, `failed: 0`. Thirty consecutive sampled deploys since the backfill gate landed reported zero backfills and zero failures.

## Validation
- `npm run validate`: passed on the final rebased head
- PR Validate: passed
- preview deployment, Bugbot, and CodeRabbit: passed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `142d7aba` · **Head:** `d5b0e695`

**Classification:** extends — strengthens the D1 user identity schema while preserving existing user and auth data.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `d1-app-db` | storage | extends — `users.stable_user_id` becomes non-null |
| `app-ui` | surfaces | composes — account-export fixtures follow the stronger schema |

### System map

The deploy applies a fail-closed D1 migration that preserves users and all integer-FK auth/account rows while strengthening stable identity storage.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::touched
	d1AppDb["d1-app-db<br/>D1 app database"]:::extended
	appUi -->|"account export fixtures satisfy stable_user_id constraint"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| `stable_user_id TEXT` + partial unique index | `stable_user_id TEXT NOT NULL` + full unique index |
| A naive D1 rebuild would cascade child rows | migration snapshots/restores every live inbound FK table inside D1's transaction |

### Invariants

- Stored stable IDs remain authoritative and unchanged.
- User-scoped data and auth/RBAC foreign-key rows are preserved exactly.
- Any residual NULL aborts and rolls back the whole migration.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e59f01b-ce4b-45f8-baaf-af79662c32a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e59f01b-ce4b-45f8-baaf-af79662c32a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Data Reliability**
  * Enforced that `stable_user_id` is now required for user records, improving consistency across the system.
  * Existing data and related relationships are maintained during the update.
* **Bug Fixes**
  * Requests that would result in missing/NULL `stable_user_id` are rejected, preventing partially-applied database changes.
* **Tests**
  * Added migration-focused test coverage for the schema update, including rollback behavior and foreign key integrity checks.
  * Updated account export test fixtures to include `stable_user_id` in seeded user rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->