### PR TITLE
Remove lazy capability registry proxies

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -39,10 +39,14 @@ Authoring flow:
 3. **`builtinDomains`** — in
    `packages/worker/src/mcp/capabilities/builtin-domains.ts`, list all domains
    you want in the default server. Order controls the flattening order of
-   `capabilityList` (capabilities from earlier domains come first).
-4. **`registry.ts`** — calls `buildCapabilityRegistry(builtinDomains)` and
-   re-exports `capabilityList`, `capabilityMap`, `capabilitySpecs`, handlers,
-   tool descriptors, and domain metadata for search/MCP instructions.
+   capabilities in the static registry (capabilities from earlier domains come
+   first).
+4. **`registry.ts`** — memoizes `buildCapabilityRegistry(builtinDomains)` via
+   **`getStaticRegistry()`** on first use per isolate, providing access to
+   builtin capabilities, handlers, tool descriptors, and domain metadata. At
+   request time, **`getCapabilityRegistryForContext()`** merges remote
+   connectors, MCP client servers, and OpenAPI bindings, then applies caller
+   role/permission/feature-flag filtering for search and execute.
 
 To merge extra domains later (e.g. plugins), the seam is:
 `buildCapabilityRegistry([...builtinDomains, ...extraDomains])` with real

--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -82,9 +82,11 @@ token and then attaches it to an outbound request.
 - MCP capability catalog: domain modules under
   `packages/worker/src/mcp/capabilities/*/domain.ts`, merged list in
   `packages/worker/src/mcp/capabilities/builtin-domains.ts`, built by
-  `packages/worker/src/mcp/capabilities/build-capability-registry.ts`,
-  re-exported from `packages/worker/src/mcp/capabilities/registry.ts` (see
-  [`../adding-kody.md`](../adding-kody.md)).
+  `packages/worker/src/mcp/capabilities/build-capability-registry.ts`, memoized
+  for builtins via `getStaticRegistry()` and resolved per request via
+  `getCapabilityRegistryForContext()` in
+  `packages/worker/src/mcp/capabilities/registry.ts` (see
+  [`../adding-capabilities.md`](../adding-capabilities.md)).
 - Workflow runtime hub:
   `packages/worker/src/package-runtime/package-workflows.ts` defines the shared
   `DynamicCallableWorkflow` Cloudflare Workflow used by every runtime context.

--- a/packages/worker/src/capability-maintenance.node.test.ts
+++ b/packages/worker/src/capability-maintenance.node.test.ts
@@ -8,11 +8,13 @@ const mockModule = vi.hoisted(() => ({
 }))
 
 vi.mock('./mcp/capabilities/registry.ts', () => ({
-	capabilitySpecs: {
-		example_capability: {
-			name: 'example_capability',
+	getStaticRegistry: () => ({
+		capabilitySpecs: {
+			example_capability: {
+				name: 'example_capability',
+			},
 		},
-	},
+	}),
 }))
 
 vi.mock('./mcp/capabilities/capability-reindex.ts', () => ({

--- a/packages/worker/src/capability-maintenance.ts
+++ b/packages/worker/src/capability-maintenance.ts
@@ -1,8 +1,8 @@
-import { capabilitySpecs } from './mcp/capabilities/registry.ts'
 import {
 	handleSecretMaintenanceRequest,
 	MaintenanceFailureError,
 } from './maintenance-handler.ts'
+import { getStaticRegistry } from './mcp/capabilities/registry.ts'
 import { reindexCapabilityVectors } from './mcp/capabilities/capability-reindex.ts'
 import { reindexJobVectors } from './jobs/job-reindex.ts'
 import { reindexMemoryVectors } from './mcp/memory/memory-reindex.ts'
@@ -46,7 +46,7 @@ async function reindexAllCapabilitySearchVectors(
 	input: { baseUrl: string },
 ) {
 	const capabilities = await runReindexStep(() =>
-		reindexCapabilityVectors(env, capabilitySpecs),
+		reindexCapabilityVectors(env, getStaticRegistry().capabilitySpecs),
 	)
 	const memories = await runReindexStep(() => reindexMemoryVectors(env))
 	const jobs = await runReindexStep(() => reindexJobVectors(env))

--- a/packages/worker/src/mcp/capabilities/registry.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/registry.node.test.ts
@@ -2,8 +2,6 @@ import { expect, test, vi } from 'vitest'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import {
 	clearCapabilityRegistryCacheForTests,
-	capabilityMap,
-	capabilitySpecs,
 	getCapabilityRegistryForContext,
 	getStaticRegistry,
 } from '#mcp/capabilities/registry.ts'
@@ -68,15 +66,13 @@ test('getCapabilityRegistryForContext bypasses connector caches when no connecto
 	expect(registry.capabilityMap).toBe(getStaticRegistry().capabilityMap)
 })
 
-test('getStaticRegistry memoizes and the lazy constant exports mirror it', () => {
-	expect(getStaticRegistry()).toBe(getStaticRegistry())
-	expect(capabilityMap.email_send).toBe(
-		getStaticRegistry().capabilityMap.email_send,
-	)
-	expect(Object.keys(capabilitySpecs)).toEqual(
-		Object.keys(getStaticRegistry().capabilitySpecs),
-	)
-	expect('email_send' in capabilityMap).toBe(true)
+test('getStaticRegistry memoizes the builtin registry', () => {
+	const first = getStaticRegistry()
+	const second = getStaticRegistry()
+	expect(first).toBe(second)
+	expect(first.capabilityMap.email_send).toBeTruthy()
+	expect(Object.keys(first.capabilitySpecs).length).toBeGreaterThan(0)
+	expect('email_send' in first.capabilityMap).toBe(true)
 })
 
 test('getCapabilityRegistryForContext filters admin capabilities by current caller roles', async () => {
@@ -123,6 +119,7 @@ test('the email domain no longer exposes self-service inbox or sender-identity c
 	// Inboxes are auto-provisioned at {username}@<platform domain> and the
 	// outbound from address is platform-assigned, so these capabilities were
 	// removed and must never come back silently.
+	const { capabilityMap } = getStaticRegistry()
 	expect(capabilityMap.email_inbox_create).toBeUndefined()
 	expect(capabilityMap.email_sender_identity_verify).toBeUndefined()
 	expect(capabilityMap.email_inbox_list).toBeTruthy()

--- a/packages/worker/src/mcp/capabilities/registry.ts
+++ b/packages/worker/src/mcp/capabilities/registry.ts
@@ -39,59 +39,6 @@ export function getStaticRegistry(): BuiltCapabilityRegistry {
 	return staticRegistryMemo
 }
 
-/**
- * Lazy view over one field of the static registry, so the legacy constant
- * exports below keep working without forcing the registry build at module
- * load. The proxy target only supplies the right base shape (array vs plain
- * object); every operation is forwarded to the real, memoized registry.
- */
-function lazyStaticRegistryField<Key extends keyof BuiltCapabilityRegistry>(
-	key: Key,
-	target: object,
-): BuiltCapabilityRegistry[Key] {
-	const resolve = () => getStaticRegistry()[key] as object
-	return new Proxy(target, {
-		get(_target, property) {
-			return Reflect.get(resolve(), property)
-		},
-		has(_target, property) {
-			return Reflect.has(resolve(), property)
-		},
-		ownKeys() {
-			return Reflect.ownKeys(resolve())
-		},
-		getOwnPropertyDescriptor(_target, property) {
-			return Object.getOwnPropertyDescriptor(resolve(), property)
-		},
-	}) as BuiltCapabilityRegistry[Key]
-}
-
-export const capabilityList = lazyStaticRegistryField('capabilityList', [])
-
-export const capabilityDomains = lazyStaticRegistryField(
-	'capabilityDomains',
-	[],
-)
-
-export const capabilityDomainDescriptionsByName = lazyStaticRegistryField(
-	'capabilityDomainDescriptionsByName',
-	{},
-)
-
-export const capabilityMap = lazyStaticRegistryField('capabilityMap', {})
-
-export const capabilitySpecs = lazyStaticRegistryField('capabilitySpecs', {})
-
-export const capabilityToolDescriptors = lazyStaticRegistryField(
-	'capabilityToolDescriptors',
-	{},
-)
-
-export const capabilityHandlers = lazyStaticRegistryField(
-	'capabilityHandlers',
-	{},
-)
-
 export const capabilityRegistryCacheTtlMs = 30_000
 export const capabilityRegistryCacheLimit = 50
 

--- a/packages/worker/src/mcp/observability.workers.test.ts
+++ b/packages/worker/src/mcp/observability.workers.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import { capabilityMap } from '#mcp/capabilities/registry.ts'
+import { getStaticRegistry } from '#mcp/capabilities/registry.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { errorFields, logMcpEvent } from '#mcp/observability.ts'
 import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
@@ -141,7 +141,7 @@ test('package_save logs parse failures, rejects invalid manifests, and logs succ
 		}
 	}) as typeof console.info
 	try {
-		const handler = capabilityMap['package_save'].handler
+		const handler = getStaticRegistry().capabilityMap['package_save'].handler
 		await expect(
 			handler(
 				{},
@@ -168,7 +168,7 @@ test('package_save logs parse failures, rejects invalid manifests, and logs succ
 	})
 
 	resetRepoPersistenceMocks()
-	const handler = capabilityMap['package_save'].handler
+	const handler = getStaticRegistry().capabilityMap['package_save'].handler
 	const signedInContext = {
 		env: {
 			APP_DB: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- migrate the final production and test consumers to `getStaticRegistry()`
- remove seven deprecated lazy registry proxy exports and their proxy helper
- update contributor docs to describe static and request-context registry APIs

## Validation
- `npm run validate` passed (format, lint, typecheck, unit, Playwright E2E, MCP E2E)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `02b7510c` · **Head:** `d573169a`

**Classification:** extends — narrows the capability-registry module API to explicit registry getters without changing registry contents or request filtering.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capability-registry` | assistant | extends — removes deprecated lazy field proxies in favor of `getStaticRegistry()` |
| `mcp-server` | surfaces | composes — tests obtain builtin handlers from the explicit static registry |

### System map

Maintenance and MCP test consumers now resolve builtin catalog fields through the memoized static registry getter.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	maintenance["maintenance<br/>Capability reindex"]:::untouched
	capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::touched
	maintenance -->|"getStaticRegistry().capabilitySpecs"| capabilityRegistry
	mcpServer -->|"getStaticRegistry().capabilityMap in tests"| capabilityRegistry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Per-request capability resolution and user/role/permission filtering remain on `getCapabilityRegistryForContext()` and are unchanged.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-467188c3-c3c4-4ed0-b27a-4878b81f582f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-467188c3-c3c4-4ed0-b27a-4878b81f582f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

